### PR TITLE
Rigid contact solver

### DIFF
--- a/drake/examples/rod2d/rod2d.h
+++ b/drake/examples/rod2d/rod2d.h
@@ -406,6 +406,21 @@ T CalcNormalAccelWithoutContactForces(const systems::Context<T>& context) const;
     return *pose_output_port_;
   }
 
+  // Utility method for determining the World frame location of one of three
+  // points on the rod whose origin is Ro. Let r be the half-length of the rod.
+  // Define point P = Ro+k*r where k = { -1, 0, 1 }. This returns p_WP.
+  static Vector2<T> CalcRodEndpoint(const T& x, const T& y, const int k,
+                                    const T& ctheta, const T& stheta,
+                                    const double half_rod_len);
+
+  // Given a location p_WC of a point C in the World frame, define the point Rc
+  // of the rod that is coincident with C, and report Rc's World frame velocity
+  // v_WRc. We're given p_WRo=(x,y) and V_WRo=(v_WRo,w_WR)=(xdot,ydot,thetadot).
+  static Vector2<T> CalcCoincidentRodPointVelocity(
+      const Vector2<T>& p_WRo, const Vector2<T>& v_WRo,
+      const T& w_WR,  // aka thetadot
+      const Vector2<T>& p_WC);
+
  private:
   int get_k(const systems::Context<T>& context) const;
   std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
@@ -460,21 +475,6 @@ T CalcNormalAccelWithoutContactForces(const systems::Context<T>& context) const;
                         systems::VectorBase<T>* const f) const;
   Vector2<T> CalcStickingContactForces(
       const systems::Context<T>& context) const;
-
-  // Utility method for determining the World frame location of one of three
-  // points on the rod whose origin is Ro. Let r be the half-length of the rod.
-  // Define point P = Ro+k*r where k = { -1, 0, 1 }. This returns p_WP.
-  static Vector2<T> CalcRodEndpoint(const T& x, const T& y, const int k,
-                                    const T& ctheta, const T& stheta,
-                                    const double half_rod_len);
-
-  // Given a location p_WC of a point C in the World frame, define the point Rc
-  // of the rod that is coincident with C, and report Rc's World frame velocity
-  // v_WRc. We're given p_WRo=(x,y) and V_WRo=(v_WRo,w_WR)=(xdot,ydot,thetadot).
-  static Vector2<T> CalcCoincidentRodPointVelocity(
-      const Vector2<T>& p_WRo, const Vector2<T>& v_WRo,
-      const T& w_WR,  // aka thetadot
-      const Vector2<T>& p_WC);
 
   // 2D cross product returns a scalar. This is the z component of the 3D
   // cross product [ax ay 0] × [bx by 0]; the x,y components are zero.

--- a/drake/multibody/rigid_contact/BUILD
+++ b/drake/multibody/rigid_contact/BUILD
@@ -1,0 +1,37 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "rigid-contact",
+    srcs = ["rigid_contact_solver.cc"],
+    hdrs = [
+        "rigid_contact_problem_data.h",
+        "rigid_contact_solver.h",
+    ],
+    deps = [
+        "//drake/common",
+        "//drake/solvers:mathematical_program",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "rigid_contact_solver_test",
+    deps = [
+        ":rigid-contact",
+        "//drake/examples/rod2d",
+    ],
+)
+
+cpplint()

--- a/drake/multibody/rigid_contact/CMakeLists.txt
+++ b/drake/multibody/rigid_contact/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(drakeRigidContact_SRC_FILES
+    rigid_contact_solver.cc
+    )
+
+add_library_with_exports(LIB_NAME drakeRigidContact SOURCE_FILES ${drakeRigidContact_SRC_FILES})
+
+target_link_libraries(drakeRigidContact
+  drakeCommon
+  drakeSystemFramework
+  drakeOptimization
+  Eigen3::Eigen)
+
+drake_install_libraries(drakeRigidContact)
+drake_install_headers(rigid_contact.h
+    rigid_contact_problem_data.h 
+    rigid_contact_solver.h 
+    )
+drake_install_pkg_config_file(drake-rigid-contact
+  TARGET drakeRigidContact
+  LIBS -ldrakeRigidContact
+  REQUIRES
+    drake-common
+    drake-optimization
+    drake-system-framework
+    eigen3
+    )
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/drake/multibody/rigid_contact/rigid_contact_problem_data.h
+++ b/drake/multibody/rigid_contact/rigid_contact_problem_data.h
@@ -12,21 +12,14 @@ namespace rigid_contact {
 /// problems at the acceleration-level.
 template <class T>
 struct RigidContactAccelProblemData {
-  /// Flag that indicates whether one or more points of contact is transitioning
-  /// from not-sliding to sliding, indicating whether LCP solver must be used.
-  bool transitioning_contacts{false};
-
   /// The indices of the sliding contacts (those contacts at which there is
   /// non-zero relative velocity between bodies in the plane tangent to the
-  /// point of contact) in the vector of possible contacts.
+  /// point of contact), taken from the indices of all contacts.
   std::vector<int> sliding_contacts;
 
   /// The indices of the non-sliding contacts (those contacts at which there
   /// is zero relative velocity between bodies in the plane tangent to the
-  /// point of contact) in the vector of possible contacts. This group also
-  /// includes those contacts which have a sliding mode but for which the
-  /// tangential velocity is momentarily below the floating point tolerance for
-  /// zero.
+  /// point of contact), taken from the indices of all contacts.
   std::vector<int> non_sliding_contacts;
 
   /// The number of spanning vectors in the contact tangents (used to linearize

--- a/drake/multibody/rigid_contact/rigid_contact_problem_data.h
+++ b/drake/multibody/rigid_contact/rigid_contact_problem_data.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <Eigen/Core>
 
 #include "drake/common/eigen_types.h"
@@ -14,12 +16,12 @@ template <class T>
 struct RigidContactAccelProblemData {
   /// The indices of the sliding contacts (those contacts at which there is
   /// non-zero relative velocity between bodies in the plane tangent to the
-  /// point of contact), taken from the indices of all contacts.
+  /// point of contact), out of the set of all contact indices (0...n-1).
   std::vector<int> sliding_contacts;
 
   /// The indices of the non-sliding contacts (those contacts at which there
   /// is zero relative velocity between bodies in the plane tangent to the
-  /// point of contact), taken from the indices of all contacts.
+  /// point of contact), out of the set of all contact indices (0...n-1).
   std::vector<int> non_sliding_contacts;
 
   /// The number of spanning vectors in the contact tangents (used to linearize
@@ -30,10 +32,12 @@ struct RigidContactAccelProblemData {
   /// to k/2 in [Anitescu 2003].
   std::vector<int> r;
 
-  /// Coefficients of friction for the sliding contacts.
+  /// Coefficients of friction for the sliding contacts. The size of this vector
+  /// should be equal to `sliding_contacts.size()`.
   VectorX<T> mu_sliding;
 
-  /// Coefficients of friction for the non-sliding contacts.
+  /// Coefficients of friction for the non-sliding contacts. The size of this
+  /// vector should be equal to `non_sliding_contacts.size()`.
   VectorX<T> mu_non_sliding;
 
   /// The ℝⁿˣᵐ Jacobian matrix that transforms generalized velocities (m is the
@@ -41,9 +45,9 @@ struct RigidContactAccelProblemData {
   /// contact normals at the n contact points.
   MatrixX<T> N;
 
-  /// The time derivative of the matrix N (defined above) times the generalized
-  /// velocity of the rigid body system.
-  MatrixX<T> Ndot_x_v;
+  /// This ℝⁿ vector is the time derivative of the matrix N (defined above)
+  /// times the generalized velocity (∈ ℝᵐ) of the rigid body system.
+  VectorX<T> Ndot_x_v;
 
   /// The ℝⁿʳˣᵐ Jacobian matrix that transforms generalized velocities (m is the
   /// dimension of generalized velocity) into velocities projected along the
@@ -55,8 +59,8 @@ struct RigidContactAccelProblemData {
   /// such requirement.
   MatrixX<T> F;
 
-  /// The time derivative of the matrix F (defined above) times the generalized
-  /// velocity of the rigid body system.
+  /// This ℝⁿʳ vector is the time derivative of the matrix F (defined above)
+  /// times the generalized velocity (∈ ℝᵐ) of the rigid body system.
   VectorX<T> Fdot_x_v;
 
   /// The ℝⁿˣᵐ matrix (N - μQ) that transforms generalized velocities (m is the
@@ -80,6 +84,6 @@ struct RigidContactAccelProblemData {
 };
 
 
-}  // namespace rod2d
-}  // namespace examples
+}  // namespace rigid_contact
+}  // namespace multibody
 }  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_problem_data.h
+++ b/drake/multibody/rigid_contact/rigid_contact_problem_data.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+
+/// Structure for holding rigid contact data for computing rigid contact
+/// problems at the acceleration-level.
+template <class T>
+struct RigidContactAccelProblemData {
+  /// Flag that indicates whether one or more points of contact is transitioning
+  /// from not-sliding to sliding, indicating whether LCP solver must be used.
+  bool transitioning_contacts{false};
+
+  /// The indices of the sliding contacts (those contacts at which there is
+  /// non-zero relative velocity between bodies in the plane tangent to the
+  /// point of contact) in the vector of possible contacts.
+  std::vector<int> sliding_contacts;
+
+  /// The indices of the non-sliding contacts (those contacts at which there
+  /// is zero relative velocity between bodies in the plane tangent to the
+  /// point of contact) in the vector of possible contacts. This group also
+  /// includes those contacts which have a sliding mode but for which the
+  /// tangential velocity is momentarily below the floating point tolerance for
+  /// zero.
+  std::vector<int> non_sliding_contacts;
+
+  /// The number of spanning vectors in the contact tangents (used to linearize
+  /// the friction cone) at the n *non-sliding* contact points. For contact
+  /// problems in two dimensions, each element of r will be one. For contact
+  /// problems in three dimensions, a friction pyramid (for example), for a
+  /// contact point i will have rᵢ = 2. The definition of r here corresponds
+  /// to k/2 in [Anitescu 2003].
+  std::vector<int> r;
+
+  /// Coefficients of friction for the sliding contacts.
+  VectorX<T> mu_sliding;
+
+  /// Coefficients of friction for the non-sliding contacts.
+  VectorX<T> mu_non_sliding;
+
+  /// The ℝⁿˣᵐ Jacobian matrix that transforms generalized velocities (m is the
+  /// dimension of generalized velocity) into velocities projected along the
+  /// contact normals at the n contact points.
+  MatrixX<T> N;
+
+  /// The time derivative of the matrix N (defined above) times the generalized
+  /// velocity of the rigid body system.
+  MatrixX<T> Ndot_x_v;
+
+  /// The ℝⁿʳˣᵐ Jacobian matrix that transforms generalized velocities (m is the
+  /// dimension of generalized velocity) into velocities projected along the
+  /// k vector that span the contact tangents (used to linearize the friction
+  /// cone) at the n *non-sliding* contact points. For contact problems in two
+  /// dimensions, r will be one. For a friction pyramid in three dimensions, r
+  /// would be two. While the definition of the dimension of the Jacobian matrix
+  /// above indicates that every contact uses the same "r", the code imposes no
+  /// such requirement.
+  MatrixX<T> F;
+
+  /// The time derivative of the matrix F (defined above) times the generalized
+  /// velocity of the rigid body system.
+  VectorX<T> Fdot_x_v;
+
+  /// The ℝⁿˣᵐ matrix (N - μQ) that transforms generalized velocities (m is the
+  /// dimension of generalized velocity) into velocities projected along the
+  /// contact normals at the n contact points, where Q ∈ ℝⁿˣᵐ is the Jacobian
+  /// matrix that transforms generalized velocities (m is the dimension of
+  /// generalized velocity) into velocities projected along the directions of
+  /// sliding at the n *sliding* contact points. The μQ factor indicates that
+  /// any normal forces applied using this Jacobian will yield frictional
+  /// effects for sliding contacts.
+  MatrixX<T> N_minus_mu_Q;
+
+  /// The ℝᵐ vector f, the generalized external force vector that
+  /// comprises gravitational, centrifugal, Coriolis, actuator, etc. forces.
+  VectorX<T> f;
+
+  /// A function for solving the equation MX = B for matrix X, given input
+  /// matrix B, where M is the generalized inertia matrix for the rigid body
+  /// system.
+  std::function<MatrixX<T>(const MatrixX<T>&)> solve_inertia;
+};
+
+
+}  // namespace rod2d
+}  // namespace examples
+}  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_solver.cc
+++ b/drake/multibody/rigid_contact/rigid_contact_solver.cc
@@ -1,0 +1,11 @@
+#include "drake/multibody/rigid_contact/rigid_contact_solver.h"
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+
+template class RigidContactSolver<double>;
+
+}  // namespace rigid_contact
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_solver.h
+++ b/drake/multibody/rigid_contact/rigid_contact_solver.h
@@ -1,0 +1,279 @@
+#pragma once
+
+#include <memory>
+#include <numeric>
+#include <utility>
+
+#include "drake/multibody/rigid_contact/rigid_contact_problem_data.h"
+#include "drake/solvers/moby_lcp_solver.h"
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+
+/**
+ * Rigid contact problem solver.
+ */
+template <typename T>
+class RigidContactSolver {
+ public:
+  void SolveContactProblem(double cfm,
+      const RigidContactAccelProblemData<T>& problem_data,
+      VectorX<T>* cf) const;
+
+ private:
+  void FormSustainedContactLinearSystem(
+      const RigidContactAccelProblemData<T>& problem_data,
+      MatrixX<T>* MM, VectorX<T>* qq) const;
+  void FormSustainedContactLCP(
+      const RigidContactAccelProblemData<T>& problem_data,
+      MatrixX<T>* MM,
+      Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const;
+
+  drake::solvers::MobyLCPSolver<T> lcp_;
+  mutable Eigen::CompleteOrthogonalDecomposition<MatrixX<T>> QR_;
+};
+
+/// Solves the appropriate contact problem at the acceleration level.
+/// @param cfm The regularization factor to apply to the contact problem,
+///            also known as the "constraint force mixing" parameter.
+/// @param problem_data The data used to compute the contact forces.
+/// @param cf The computed contact forces, on return. Aborts if @p cf is null.
+/// @pre Contact data has been computed.
+/// @throws a std::runtime_error if the contact forces cannot be computed
+///         (due to, e.g., an inconsistent configuration).
+template <typename T>
+void RigidContactSolver<T>::SolveContactProblem(double cfm,
+    const RigidContactAccelProblemData<T>& problem_data,
+    VectorX<T>* cf) const {
+  using std::max;
+  using std::abs;
+  DRAKE_DEMAND(cf);
+
+  // Alias problem data.
+  const std::vector<int>& sliding_contacts = problem_data.sliding_contacts;
+  const std::vector<int>& non_sliding_contacts =
+      problem_data.non_sliding_contacts;
+
+  // Get numbers of friction directions and types of contacts.
+  const int num_sliding = sliding_contacts.size();
+  const int num_non_sliding = non_sliding_contacts.size();
+  const int nc = num_sliding + num_non_sliding;
+  const int nr = std::accumulate(problem_data.r.begin(),
+                                 problem_data.r.end(), 0);
+
+  // Look for fast exit.
+  if (nc == 0) {
+    cf->resize(0);
+    return;
+  }
+    
+  // Initialize contact force vector.
+  cf->resize(nc + nr);
+
+  // Formulate and solve the linear equation 0 = MM⋅zz + qq for zz *unless*
+  // there are contacts transitioning from not sliding to sliding.
+  MatrixX<T> MM;
+  VectorX<T> qq;
+  if (problem_data.transitioning_contacts) {
+    // Transitioning contacts requires formulating and solving an LCP.
+    FormSustainedContactLCP(problem_data, &MM, &qq);
+
+    // Regularize the LCP matrix as necessary.
+    const int nvars = qq.size();
+    MM += MatrixX<T>::Identity(nvars, nvars) * cfm;
+
+    // Get the zero tolerance for solving the LCP.
+    const T zero_tol = max(cfm, lcp_.ComputeZeroTolerance(MM));
+
+    // Solve the LCP and compute the values of the slack variables.
+    VectorX<T> zz;
+    bool success = lcp_.SolveLcpLemke(MM, qq, &zz, -1, zero_tol);
+    VectorX<T> ww = MM * zz + qq;
+
+    // NOTE: This LCP might not be solvable due to inconsistent configurations.
+    // Check the answer and throw a runtime error if it's no good.
+    if (!success || (zz.size() > 0 && (zz.minCoeff() < -10*zero_tol ||
+        ww.minCoeff() < -10*zero_tol ||
+        abs(zz.dot(ww)) > nvars * 100 * zero_tol))) {
+      throw std::runtime_error("Unable to solve LCP- it may be unsolvable.");
+    }
+
+    // Get the contact forces in the contact frame.
+    cf->segment(0, nc) = zz.segment(0, nc);
+    cf->segment(nc, nr) = zz.segment(nc, nr) -
+    zz.segment(nc + nr, nr);
+  } else {
+    // No contacts transitioning means that an easier problem can be solved.
+    FormSustainedContactLinearSystem(problem_data, &MM, &qq);
+
+    // Solve the linear system. The LCP used in the active set method computed
+    // an (invertible) basis to attain its solution, which means that MM
+    // should be invertible. However, the LCP matrix was regularized (which
+    // may have allowed an otherwise unsolvable LCP to be unsolvable in
+    // addition to its other function, that of minimizing the effect of
+    // pivoting error on the ability of the solver to find a solution on known
+    // solvable problems). For this reason, we will also employ regularization
+    // here.
+    const int nvars = qq.size();
+    MM += MatrixX<T>::Identity(nvars, nvars) * cfm;
+    QR_.compute(MM);
+    *cf = QR_.solve(-qq);
+  }
+}
+
+// Forms the system of linear equations used to compute the accelerations during
+// ODE evaluations. Specifically, this method forms the matrix @p MM and vector
+// @p qq used to describe the linear complementarity problem MM*z + qq = w,
+// where:
+// (1) z ≥ 0
+// (2) w ≥ 0
+// (3) z ⋅ w = 0
+// If the active set is correctly determined, the contact mode variables will
+// provide the solution w = 0, implying that z = MM⁻¹⋅qq. This function only
+// forms MM and qq. It does not attempt to solve the linear system (or, by
+// extension, determine whether said solution for z results in a solution to
+// the linear complementarity problem).
+template <class T>
+void RigidContactSolver<T>::FormSustainedContactLinearSystem(
+    const RigidContactAccelProblemData<T>& problem_data,
+    MatrixX<T>* MM, VectorX<T>* qq) const {
+  using std::fabs;
+
+  DRAKE_DEMAND(MM);
+  DRAKE_DEMAND(qq);
+
+  // Get numbers of types of contacts.
+  const int num_sliding = problem_data.sliding_contacts.size();
+  const int num_non_sliding = problem_data.non_sliding_contacts.size();
+  const int nc = num_sliding + num_non_sliding;
+  const int nr = std::accumulate(problem_data.r.begin(),
+                                 problem_data.r.end(), 0);
+
+  // Problem matrices and vectors are mildly adapted from:
+  // M. Anitescu and F. Potra. Formulating Dynamic Multi-Rigid Body Contact
+  // Problems as Solvable Linear Complementarity Problems. Nonlinear Dynamics,
+  // 14, 1997.
+
+  // Alias matrices / vectors to make accessing them more wieldy.
+  const MatrixX<T>& N = problem_data.N;
+  const MatrixX<T>& F = problem_data.F;
+  const VectorX<T>& Ndot_x_v = problem_data.Ndot_x_v;
+  const VectorX<T>& Fdot_x_v = problem_data.Fdot_x_v;
+
+  // Construct the matrix:
+  // N⋅M⁻¹⋅(Nᵀ - μQᵀ)  N⋅M⁻¹⋅Fᵀ
+  // F⋅M⁻¹⋅Nᵀ          F⋅M⁻¹⋅Dᵀ
+  const int nvars = nc + nr;
+  const MatrixX<T> M_inv_x_FT = problem_data.solve_inertia(F.transpose());
+  MM->resize(nvars, nvars);
+  MM->block(0, 0, nc, nc) = N *
+      problem_data.solve_inertia(problem_data.N_minus_mu_Q.transpose());
+  MM->block(0, nc, nc, nr) = N * M_inv_x_FT;
+
+  // Now construct the tangent contact direction rows for non-sliding contacts.
+  MM->block(nc, 0, nr, nc) = MM->block(0, nc, nc, nr).transpose();
+  MM->block(nc, nc, nr, nr) = F * M_inv_x_FT;
+
+  // Construct the vector:
+  // N⋅M⁻¹⋅fext + dN/dt⋅v
+  // F⋅M⁻¹⋅fext + dF/dt⋅v
+  const VectorX<T> M_inv_x_f = problem_data.solve_inertia(problem_data.f);
+  qq->resize(nvars, 1);
+  qq->segment(0, nc) = N * M_inv_x_f + Ndot_x_v;
+  qq->segment(nc, nr) = F * M_inv_x_f + Fdot_x_v;
+}
+
+// Forms the LCP matrix and vector, which is used to determine the active
+// set of constraints at the acceleration-level.
+template <class T>
+void RigidContactSolver<T>::FormSustainedContactLCP(
+    const RigidContactAccelProblemData<T>& problem_data,
+    MatrixX<T>* MM,
+    Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const {
+  using std::fabs;
+
+  DRAKE_DEMAND(MM);
+  DRAKE_DEMAND(qq);
+
+  // Get numbers of types of contacts.
+  const int num_sliding = problem_data.sliding_contacts.size();
+  const int num_non_sliding = problem_data.non_sliding_contacts.size();
+  const int nc = num_sliding + num_non_sliding;
+  const int nr = std::accumulate(problem_data.r.begin(),
+                                 problem_data.r.end(), 0);
+  const int nk = nr * 2;
+
+  // Problem matrices and vectors are mildly adapted from:
+  // M. Anitescu and F. Potra. Formulating Dynamic Multi-Rigid Body Contact
+  // Problems as Solvable Linear Complementarity Problems. Nonlinear Dynamics,
+  // 14, 1997.
+
+  // Alias matrices / vectors to make accessing them less clunky.
+  const MatrixX<T>& N = problem_data.N;
+  const MatrixX<T>& F = problem_data.F;
+  const VectorX<T>& Ndot_x_v = problem_data.Ndot_x_v;
+  const VectorX<T>& Fdot_x_v = problem_data.Fdot_x_v;
+  const VectorX<T>& mu_non_sliding = problem_data.mu_non_sliding;
+
+  // Construct a matrix similar to E in Anitscu and Potra 1997. This matrix
+  // will be used to specify the constraints 0 ≤ μ⋅fN - E⋅fF ⊥ λ ≥ 0 and
+  // 0 ≤ e⋅λ + F⋅dv/dt ⊥ fF ≥ 0.
+  MatrixX<T> E = MatrixX<T>::Zero(nk, num_non_sliding);
+  for (int i = 0, j = 0; i < num_non_sliding; ++i) {
+    const int num_tangent_dirs = problem_data.r[i];
+    E.col(i).segment(j, num_tangent_dirs).setOnes();
+    j += num_tangent_dirs;
+  }
+
+  // Construct the LCP matrix. First do the "normal contact direction" rows:
+  // N⋅M⁻¹⋅(Nᵀ - μQᵀ)  N⋅M⁻¹⋅Dᵀ  0
+  // D⋅M⁻¹⋅Nᵀ          D⋅M⁻¹⋅Dᵀ  E
+  // μ                 -Eᵀ       0
+  // where D = [F -F]
+  const int nvars = nc + nk + num_non_sliding;
+  MatrixX<T> M_inv_x_FT = problem_data.solve_inertia(F.transpose());
+  MM->resize(nvars, nvars);
+  MM->block(0, 0, nc, nc) = N *
+      problem_data.solve_inertia(problem_data.N_minus_mu_Q.transpose());
+  MM->block(0, nc, nc, nr) = N * M_inv_x_FT;
+  MM->block(0, nc + nr, nc, nr) = -MM->block(0, nc, nc, nr);
+  MM->block(0, nc + nk, num_non_sliding, num_non_sliding).setZero();
+
+  // Now construct the un-negated tangent contact direction rows (everything
+  // but last block column).
+  MM->block(nc, 0, nr, nc) = MM->block(0, nc, nc, nr).transpose();
+  MM->block(nc, nc, nr, nr) = F * M_inv_x_FT;
+  MM->block(nc, nc + nr, nr, nr) = -MM->block(nc, nc, nr, nr);
+
+  // Now construct the negated tangent contact direction rows (everything but
+  // last block column). These negated tangent contact directions allow the
+  // LCP to compute forces applied along the negative x-axis.
+  MM->block(nc + nr, 0, nr, nc + nk) = -MM->block(nc, 0, nr, nc + nk);
+
+  // Construct the last block column for the last set of rows (see Anitescu and
+  // Potra, 1997).
+  MM->block(nc, nc + nk, nk, num_non_sliding) = E;
+
+  // Construct the last two rows, which provide the friction "cone" constraint.
+  MM->block(nc + nk, 0, num_non_sliding, num_non_sliding) =
+      Eigen::DiagonalMatrix<T, Eigen::Dynamic>(mu_non_sliding);
+  MM->block(nc + nk, nc, num_non_sliding, nk) = -E.transpose();
+  MM->block(nc + nk, nc + nk, num_non_sliding, num_non_sliding).setZero();
+
+  // Construct the LCP vector:
+  // N⋅M⁻¹⋅fext + dN/dt⋅v
+  // D⋅M⁻¹⋅fext + dD/dt⋅v
+  // 0
+  // where, as above, D is defined as [F -F]
+  VectorX<T> M_inv_x_f = problem_data.solve_inertia(problem_data.f);
+  qq->resize(nvars, 1);
+  qq->segment(0, nc) = N * M_inv_x_f + Ndot_x_v;
+  qq->segment(nc, nr) = F * M_inv_x_f + Fdot_x_v;
+  qq->segment(nc + nr, nr) = -qq->segment(nc, nr);
+  qq->segment(nc + nk, num_non_sliding).setZero();
+}
+
+}  // namespace rigid_contact
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_solver.h
+++ b/drake/multibody/rigid_contact/rigid_contact_solver.h
@@ -22,7 +22,6 @@ namespace rigid_contact {
 template <typename T>
 class RigidContactSolver {
  public:
-
   /// Solves the appropriate contact problem at the acceleration level.
   /// @param cfm The regularization factor to apply to the contact problem,
   ///            also known as the "constraint force mixing" parameter.

--- a/drake/multibody/rigid_contact/rigid_contact_solver.h
+++ b/drake/multibody/rigid_contact/rigid_contact_solver.h
@@ -12,7 +12,7 @@ namespace multibody {
 namespace rigid_contact {
 
 /**
- * Rigid contact problem solver.
+ * Solves rigid contact problems for contact forces.
  */
 template <typename T>
 class RigidContactSolver {
@@ -27,18 +27,23 @@ class RigidContactSolver {
       MatrixX<T>* MM, VectorX<T>* qq) const;
   void FormSustainedContactLCP(
       const RigidContactAccelProblemData<T>& problem_data,
-      MatrixX<T>* MM,
-      Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const;
+      MatrixX<T>* MM, Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const;
 
   drake::solvers::MobyLCPSolver<T> lcp_;
-  mutable Eigen::CompleteOrthogonalDecomposition<MatrixX<T>> QR_;
 };
 
 /// Solves the appropriate contact problem at the acceleration level.
 /// @param cfm The regularization factor to apply to the contact problem,
 ///            also known as the "constraint force mixing" parameter.
 /// @param problem_data The data used to compute the contact forces.
-/// @param cf The computed contact forces, on return. Aborts if @p cf is null.
+/// @param cf The computed contact forces, on return, in a packed storage
+///           format. The first `nc` elements of @p cf correspond to the
+///           magnitudes of the contact forces applied along the normals of the
+///           `nc` contact points. The remaining elements of @p cf correspond
+///           to the frictional forces along the `r` spanning directions at each
+///           non-sliding point of contact. The first `r` values correspond to
+///           the first non-sliding contact, the next `r` values correspond to
+///           the second non-sliding contct, etc.
 /// @pre Contact data has been computed.
 /// @throws a std::runtime_error if the contact forces cannot be computed
 ///         (due to, e.g., an inconsistent configuration).
@@ -71,126 +76,43 @@ void RigidContactSolver<T>::SolveContactProblem(double cfm,
   // Initialize contact force vector.
   cf->resize(nc + nr);
 
-  // Formulate and solve the linear equation 0 = MM⋅zz + qq for zz *unless*
-  // there are contacts transitioning from not sliding to sliding.
+  // Set up the linear complementarity problem.
   MatrixX<T> MM;
   VectorX<T> qq;
-  if (problem_data.transitioning_contacts) {
-    // Transitioning contacts requires formulating and solving an LCP.
-    FormSustainedContactLCP(problem_data, &MM, &qq);
+  FormSustainedContactLCP(problem_data, &MM, &qq);
 
-    // Regularize the LCP matrix as necessary.
-    const int nvars = qq.size();
-    MM += MatrixX<T>::Identity(nvars, nvars) * cfm;
+  // Regularize the LCP matrix as necessary.
+  const int nvars = qq.size();
+  MM += MatrixX<T>::Identity(nvars, nvars) * cfm;
 
-    // Get the zero tolerance for solving the LCP.
-    const T zero_tol = max(cfm, lcp_.ComputeZeroTolerance(MM));
+  // Get the zero tolerance for solving the LCP.
+  const T zero_tol = max(cfm, lcp_.ComputeZeroTolerance(MM));
 
-    // Solve the LCP and compute the values of the slack variables.
-    VectorX<T> zz;
-    bool success = lcp_.SolveLcpLemke(MM, qq, &zz, -1, zero_tol);
-    VectorX<T> ww = MM * zz + qq;
+  // Solve the LCP and compute the values of the slack variables.
+  VectorX<T> zz;
+  bool success = lcp_.SolveLcpLemke(MM, qq, &zz, -1, zero_tol);
+  VectorX<T> ww = MM * zz + qq;
 
-    // NOTE: This LCP might not be solvable due to inconsistent configurations.
-    // Check the answer and throw a runtime error if it's no good.
-    if (!success || (zz.size() > 0 && (zz.minCoeff() < -10*zero_tol ||
-        ww.minCoeff() < -10*zero_tol ||
-        abs(zz.dot(ww)) > nvars * 100 * zero_tol))) {
-      throw std::runtime_error("Unable to solve LCP- it may be unsolvable.");
-    }
-
-    // Get the contact forces in the contact frame.
-    cf->segment(0, nc) = zz.segment(0, nc);
-    cf->segment(nc, nr) = zz.segment(nc, nr) -
-    zz.segment(nc + nr, nr);
-  } else {
-    // No contacts transitioning means that an easier problem can be solved.
-    FormSustainedContactLinearSystem(problem_data, &MM, &qq);
-
-    // Solve the linear system. The LCP used in the active set method computed
-    // an (invertible) basis to attain its solution, which means that MM
-    // should be invertible. However, the LCP matrix was regularized (which
-    // may have allowed an otherwise unsolvable LCP to be unsolvable in
-    // addition to its other function, that of minimizing the effect of
-    // pivoting error on the ability of the solver to find a solution on known
-    // solvable problems). For this reason, we will also employ regularization
-    // here.
-    const int nvars = qq.size();
-    MM += MatrixX<T>::Identity(nvars, nvars) * cfm;
-    QR_.compute(MM);
-    *cf = QR_.solve(-qq);
+  // NOTE: This LCP might not be solvable due to inconsistent configurations.
+  // Check the answer and throw a runtime error if it's no good.
+  if (!success || (zz.size() > 0 && (zz.minCoeff() < -10*zero_tol ||
+      ww.minCoeff() < -10*zero_tol ||
+      abs(zz.dot(ww)) > nvars * 100 * zero_tol))) {
+    throw std::runtime_error("Unable to solve LCP- it may be unsolvable.");
   }
+
+  // Get the contact forces in the contact frame.
+  cf->segment(0, nc) = zz.segment(0, nc);
+  cf->segment(nc, nr) = zz.segment(nc, nr) - zz.segment(nc + nr, nr);
 }
 
-// Forms the system of linear equations used to compute the accelerations during
-// ODE evaluations. Specifically, this method forms the matrix @p MM and vector
-// @p qq used to describe the linear complementarity problem MM*z + qq = w,
-// where:
-// (1) z ≥ 0
-// (2) w ≥ 0
-// (3) z ⋅ w = 0
-// If the active set is correctly determined, the contact mode variables will
-// provide the solution w = 0, implying that z = MM⁻¹⋅qq. This function only
-// forms MM and qq. It does not attempt to solve the linear system (or, by
-// extension, determine whether said solution for z results in a solution to
-// the linear complementarity problem).
-template <class T>
-void RigidContactSolver<T>::FormSustainedContactLinearSystem(
-    const RigidContactAccelProblemData<T>& problem_data,
-    MatrixX<T>* MM, VectorX<T>* qq) const {
-  using std::fabs;
-
-  DRAKE_DEMAND(MM);
-  DRAKE_DEMAND(qq);
-
-  // Get numbers of types of contacts.
-  const int num_sliding = problem_data.sliding_contacts.size();
-  const int num_non_sliding = problem_data.non_sliding_contacts.size();
-  const int nc = num_sliding + num_non_sliding;
-  const int nr = std::accumulate(problem_data.r.begin(),
-                                 problem_data.r.end(), 0);
-
-  // Problem matrices and vectors are mildly adapted from:
-  // M. Anitescu and F. Potra. Formulating Dynamic Multi-Rigid Body Contact
-  // Problems as Solvable Linear Complementarity Problems. Nonlinear Dynamics,
-  // 14, 1997.
-
-  // Alias matrices / vectors to make accessing them more wieldy.
-  const MatrixX<T>& N = problem_data.N;
-  const MatrixX<T>& F = problem_data.F;
-  const VectorX<T>& Ndot_x_v = problem_data.Ndot_x_v;
-  const VectorX<T>& Fdot_x_v = problem_data.Fdot_x_v;
-
-  // Construct the matrix:
-  // N⋅M⁻¹⋅(Nᵀ - μQᵀ)  N⋅M⁻¹⋅Fᵀ
-  // F⋅M⁻¹⋅Nᵀ          F⋅M⁻¹⋅Dᵀ
-  const int nvars = nc + nr;
-  const MatrixX<T> M_inv_x_FT = problem_data.solve_inertia(F.transpose());
-  MM->resize(nvars, nvars);
-  MM->block(0, 0, nc, nc) = N *
-      problem_data.solve_inertia(problem_data.N_minus_mu_Q.transpose());
-  MM->block(0, nc, nc, nr) = N * M_inv_x_FT;
-
-  // Now construct the tangent contact direction rows for non-sliding contacts.
-  MM->block(nc, 0, nr, nc) = MM->block(0, nc, nc, nr).transpose();
-  MM->block(nc, nc, nr, nr) = F * M_inv_x_FT;
-
-  // Construct the vector:
-  // N⋅M⁻¹⋅fext + dN/dt⋅v
-  // F⋅M⁻¹⋅fext + dF/dt⋅v
-  const VectorX<T> M_inv_x_f = problem_data.solve_inertia(problem_data.f);
-  qq->resize(nvars, 1);
-  qq->segment(0, nc) = N * M_inv_x_f + Ndot_x_v;
-  qq->segment(nc, nr) = F * M_inv_x_f + Fdot_x_v;
-}
-
-// Forms the LCP matrix and vector, which is used to determine the active
-// set of constraints at the acceleration-level.
+// Forms the LCP matrix and vector, which is used to determine the contact
+// forces (and can also be used to determine the active set of constraints at
+// the acceleration-level).
 template <class T>
 void RigidContactSolver<T>::FormSustainedContactLCP(
     const RigidContactAccelProblemData<T>& problem_data,
-    MatrixX<T>* MM,
-    Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const {
+    MatrixX<T>* MM, Eigen::Matrix<T, Eigen::Dynamic, 1>* qq) const {
   using std::fabs;
 
   DRAKE_DEMAND(MM);

--- a/drake/multibody/rigid_contact/test/rigid_contact_solver_test.cc
+++ b/drake/multibody/rigid_contact/test/rigid_contact_solver_test.cc
@@ -1,0 +1,353 @@
+#include "drake/multibody/rigid_contact/rigid_contact_solver.h"
+#include "drake/examples/rod2d/rod2d.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+
+using drake::systems::VectorBase;
+using drake::systems::BasicVector;
+using drake::systems::ContinuousState;
+using drake::systems::Context;
+using drake::examples::rod2d::Rod2D;
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+namespace {
+
+class RigidContact2DSolverTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    rod_ = std::make_unique<Rod2D<double>>(
+        Rod2D<double>::SimulationType::kPiecewiseDAE, 0);
+    context_ = rod_->CreateDefaultContext();
+  }
+
+  // Construct the inertia solve function.
+  std::function<MatrixX<double>(const MatrixX<double>&)> get_inertia_solve() {
+    return [this](const MatrixX<double>& B) {
+      return this->solve_inertia(*this->rod_, B);
+    };
+  }
+
+  // Solves MX = B for X, where M is the generalized inertia matrix.
+  MatrixX<double> solve_inertia(const Rod2D<double>& rod,
+                                const MatrixX<double>& B) {
+    const double inv_mass = 1.0 / rod.get_rod_mass();
+    const double inv_J = 1.0 / rod.get_rod_moment_of_inertia();
+    Matrix3<double> iM;
+    iM << inv_mass, 0,        0,
+           0,       inv_mass, 0,
+           0,       0,        inv_J;
+    return iM * B;
+  }
+
+  // Sets the rod to a horizontal, resting configuration.
+  void SetRestingHorizontal() {
+    ContinuousState<double>& xc = *context_->
+        get_mutable_continuous_state();
+    for (int i = 0; i < xc.size(); ++i)
+      xc[i] = 0.0;
+  }
+
+  // Gets the gravitational force on the rod.
+  MatrixX<double> GetRodGravitationalForce() const {
+    const double mg = rod_->get_rod_mass() *
+        rod_->get_gravitational_acceleration();
+    MatrixX<double> f(3,1);
+    f << 0, mg, 0;
+    return f;
+  }
+
+  // Initializes the contact data for the rod *based purely upon its current
+  // continuous state*.
+  void SetProblemData(RigidContactAccelProblemData<double>* data, double mu) {
+    const int ngc = 3;
+
+    // Set the inertia solver.
+    data->solve_inertia = get_inertia_solve();
+
+    // There is always one normal and one tangent direction.
+    const Vector2<double> contact_normal(0.0, 1.0);
+    const Vector2<double> contact_tan(1.0, 0.0);
+
+    // Get the set of contact points.
+    const std::vector<Vector2<double>> points = GetContacts();
+    const int nc = points.size();
+
+    // Get the set of tangent velocities.
+    const double sliding_vel_tol = 100 * std::numeric_limits<double>::epsilon();
+    const std::vector<double> vels = GetContactPointsTangentVelocities(points);
+
+    // Set sliding and non-sliding contacts.
+    for (int i = 0; i < nc; ++i) {
+      if (std::fabs(vels[i]) < sliding_vel_tol) {
+        data->non_sliding_contacts.push_back(i);
+      } else {
+        data->sliding_contacts.push_back(i);
+      }
+    }
+
+    // Designate sliding and non-sliding contacts.
+    const int num_sliding = data->sliding_contacts.size();
+    const int num_non_sliding = data->non_sliding_contacts.size();
+    EXPECT_EQ(num_sliding + num_non_sliding, nc);
+
+    // Set sliding and non-sliding friction coefficients.
+    data->mu_sliding.setOnes(num_sliding) *= mu;
+    data->mu_non_sliding.setOnes(num_non_sliding) *= mu;
+
+    // Set r.
+    data->r.resize(num_non_sliding);
+    for (int i = 0; i < num_non_sliding; ++i)
+      data->r[i] = 1;
+
+    // Form N.
+    data->N.resize(nc, ngc);
+    for (int i = 0; i < nc; ++i)
+      data->N.row(i) =  GetJacobianRow(points[i], contact_normal);
+
+    // Form Ndot.
+    MatrixX<double> Ndot(nc, ngc);
+    for (int i = 0; i < nc; ++i)
+      Ndot.row(i) =  GetJacobianDotRow(points[i], contact_normal);
+
+    // Compute Ndot * v;
+    const VectorX<double> v = context_->get_state().get_continuous_state()->
+        get_generalized_velocity().CopyToVector();
+    EXPECT_EQ(v.size(), ngc);
+    data->Ndot_x_v = Ndot * v;
+
+    // Form F and Fdot.
+    const int nr = std::accumulate(data->r.begin(), data->r.end(), 0);
+    EXPECT_EQ(nr, num_non_sliding);
+    data->F.resize(nr, ngc);
+    MatrixX<double> Fdot(nr, ngc);
+    for (int i = 0, j = 0; i < nc; ++i) {
+      if (std::binary_search(data->sliding_contacts.begin(),
+                             data->sliding_contacts.end(), i))
+        continue;
+      data->F.row(j) = GetJacobianRow(points[i], contact_tan);
+      Fdot.row(j) = GetJacobianDotRow(points[i], contact_tan);
+      ++j;
+    }
+
+    // Compute Fdot * v.
+    data->Fdot_x_v = Fdot * v;
+
+    // Form N - mu*Q
+    data->N_minus_mu_Q = data->N;
+    VectorX<double> Qrow;
+    for (int i = 0, j = 0; i < nc; ++i) {
+      if (std::binary_search(data->non_sliding_contacts.begin(),
+                             data->non_sliding_contacts.end(), i))
+        continue;
+      if (vels[i] > 0) {
+        Qrow = GetJacobianRow(points[i], contact_tan);
+      } else {
+        Qrow = GetJacobianRow(points[i], -contact_tan);
+      }
+      data->N.row(i) -= data->mu_sliding[j] * Qrow;
+      ++j;
+    }
+
+    // Set f.
+    data->f = GetRodGravitationalForce();
+  }
+
+  double cfm_{1e-8};
+  RigidContactSolver<double> solver_;
+  std::unique_ptr<Rod2D<double>> rod_;
+  std::unique_ptr<Context<double>> context_;
+
+ private:
+
+  // Gets the point(s) of contact for the 2D rod.
+  std::vector<Vector2<double>> GetContacts() {
+    std::vector<Vector2<double>> points;
+
+    // Get the rod configuration.
+    const VectorX<double> q = context_->get_state().get_continuous_state()->
+        get_generalized_position().CopyToVector();
+    const double x = q[0];
+    const double y = q[1];
+    const double cth = std::cos(q[2]);
+    const double sth = std::sin(q[2]);
+
+    // Get the two rod endpoint locations.
+    const double half_len = rod_->get_rod_half_length();
+    Vector2<double> pa = rod_->CalcRodEndpoint(x, y, -1, cth, sth, half_len);
+    Vector2<double> pb = rod_->CalcRodEndpoint(x, y, +1, cth, sth, half_len);
+
+    if (pa[1] <= 0)
+      points.push_back(pa);
+    if (pb[1] <= 0)
+      points.push_back(pb);
+
+    return points;
+  }
+
+  // Gets the tangent velocities for all contact points.
+  std::vector<double> GetContactPointsTangentVelocities(
+      const std::vector<Vector2<double>>& points) {
+    const VectorX<double> q = context_->get_state().get_continuous_state()->
+        get_generalized_position().CopyToVector();
+    const VectorX<double> v = context_->get_state().get_continuous_state()->
+        get_generalized_velocity().CopyToVector();
+
+    // Get necessary quantities.
+    const Vector2<double> p_WRo = q.segment(0, 2);
+    const Vector2<double> v_WRo = v.segment(0, 2);
+    const double w_WR = q[2];
+
+    std::vector<double> vels(points.size());
+    for (size_t i = 0; i < points.size(); ++i) {
+      vels[i] = rod_->CalcCoincidentRodPointVelocity(p_WRo, v_WRo, w_WR,
+                                                     points[i])[0];
+    }
+
+    return vels;
+  }
+
+  Matrix2<double> GetRotationMatrixDerivative(double theta) const {
+    const double cth = std::cos(theta);
+    const double sth = std::sin(theta);
+    Matrix2<double> Rdot;
+    Rdot << -sth, -cth, cth, -sth;
+    return Rdot;
+  }
+
+  Vector3<double> GetJacobianRow(const Vector2<double>& p,
+                                 const Vector2<double>& dir) const {
+    // Get rod configuration variables.
+    const VectorX<double> q = context_->get_state().get_continuous_state()->
+        get_generalized_position().CopyToVector();
+
+    // Compute cross product of the point and the direction.
+    const Vector3<double> p3(p[0] - q[0], p[1] - q[1], 0);
+    const Vector3<double> dir3(dir[0], dir[1], 0);
+    const Vector3<double> result = p3.cross(dir3);
+    return Vector3<double>(dir[0], dir[1], result[2]);
+  }
+
+  Vector3<double> GetJacobianDotRow(const Vector2<double>& p,
+                                    const Vector2<double>& dir) const {
+    // Get rod state variables.
+    const VectorX<double> q = context_->get_state().get_continuous_state()->
+        get_generalized_position().CopyToVector();
+    const VectorX<double> v = context_->get_state().get_continuous_state()->
+        get_generalized_velocity().CopyToVector();
+
+    // Get the transformation of vectors from the rod frame to the
+    // world frame and its time derivative.
+    const double& theta = q[2];
+    Eigen::Rotation2D<double> R(theta);
+
+    // Get the vector from the rod center-of-mass to the contact point,
+    // expressed in the rod frame.
+    const Vector2<double> x = q.segment(0,2);
+    const Vector2<double> u = R.inverse() * (p - x);
+
+    // Compute the translational velocity of the contact point.
+    const Vector2<double> xdot = v.segment(0,2);
+    const Matrix2<double> Rdot = GetRotationMatrixDerivative(theta);
+    const double& thetadot = v[2];
+    const Vector2<double> pdot = xdot + Rdot * u * thetadot;
+
+    // Compute cross product of the point and the direction.
+    const Vector3<double> p3dot(pdot[0] - v[0], pdot[1] - v[1], 0);
+    const Vector3<double> dir3(dir[0], dir[1], 0);
+    const Vector3<double> result = p3dot.cross(dir3);
+    return Vector3<double>(0, 0, result[2]);
+  }
+};
+
+// Tests the rod in a ballistic configuration (non-contacting) configuration.
+TEST_F(RigidContact2DSolverTest, NonContacting) {
+  // Set the state of the rod to reseting on its side with no velocity.
+  SetRestingHorizontal();
+
+  // Set the vertical position to strictly positive.
+  ContinuousState<double>& xc = *context_->
+      get_mutable_continuous_state();
+  xc[1] = 1.0;
+
+  // Compute the rigid contact data.
+  RigidContactAccelProblemData<double> data;
+  SetProblemData(&data, 1.0 /* Coulomb friction coefficient */);
+
+  // Verify there are no contacts.
+  EXPECT_TRUE(data.sliding_contacts.empty());
+  EXPECT_TRUE(data.non_sliding_contacts.empty());
+
+  // Compute the contact forces.
+  VectorX<double> cf;
+  solver_.SolveContactProblem(cfm_, data, &cf);
+
+  // Verify that the contact forces are zero.
+  EXPECT_LT(cf.norm(), cfm_);
+}
+
+// Tests the rod in a two-point non-sliding configuration.
+TEST_F(RigidContact2DSolverTest, TwoPointNonSliding) {
+  // Set the state of the rod to reseting on its side with no velocity.
+  SetRestingHorizontal();
+
+  // Compute the rigid contact data.
+  RigidContactAccelProblemData<double> data;
+  SetProblemData(&data, 1.0 /* Coulomb friction coefficient */);
+
+  // Compute the contact forces.
+  VectorX<double> cf;
+  solver_.SolveContactProblem(cfm_, data, &cf);
+
+  // Verify that there are no frictional forces.
+  EXPECT_TRUE(data.sliding_contacts.empty());
+  const int nc = data.non_sliding_contacts.size();
+  EXPECT_LT(cf.segment(nc, cf.size() - nc).norm(), 10 * cfm_);
+
+  // Verify that the normal contact forces exactly oppose gravity (there should
+  // be no frictional forces).
+  const double mg = GetRodGravitationalForce().norm();
+  EXPECT_NEAR(cf.segment(0,nc).lpNorm<1>(), mg, 10 * cfm_);
+}
+
+// Tests the rod in a two-point sliding configuration.
+TEST_F(RigidContact2DSolverTest, TwoPointSliding) {
+  // Set the state of the rod to reseting on its side with horizontal velocity.
+  SetRestingHorizontal();
+  ContinuousState<double>& xc = *context_->
+      get_mutable_continuous_state();
+  xc[3] = 1.0;
+
+  // Compute the rigid contact data.
+  RigidContactAccelProblemData<double> data;
+  SetProblemData(&data, 0.0 /* frictionless contact */);
+
+  // Compute the contact forces.
+  VectorX<double> cf;
+  solver_.SolveContactProblem(cfm_, data, &cf);
+
+  // Verify that there are no frictional forces.
+  EXPECT_TRUE(data.non_sliding_contacts.empty());
+  const int nc = data.sliding_contacts.size();
+  EXPECT_LT(cf.segment(nc, cf.size() - nc).norm(), 10 * cfm_);
+
+  // Verify that the normal contact forces exactly oppose gravity (there should
+  // be no frictional forces).
+  const double mg = GetRodGravitationalForce().norm();
+  EXPECT_NEAR(cf.segment(0,nc).lpNorm<1>(), mg, 10 * cfm_);
+}
+
+}  // namespace
+}  // namespace rigid_contact
+}  // namespace multibody
+}  // namespace drake

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -223,10 +223,8 @@ bool MobyLCPSolver<T>::SolveLcpFast(const MatrixX<T>& M,
 
   // set zero tolerance if necessary
   T mod_zero_tol = zero_tol;
-  if (mod_zero_tol < 0) {
-    mod_zero_tol = M.rows() * M.template lpNorm<Eigen::Infinity>() *
-        std::numeric_limits<double>::epsilon();
-  }
+  if (mod_zero_tol < 0)
+    mod_zero_tol = ComputeZeroTolerance(M);
 
   // prepare to setup basic and nonbasic variable indices for z
   nonbas_.clear();
@@ -406,9 +404,7 @@ bool MobyLCPSolver<T>::SolveLcpFastRegularized(const MatrixX<T>& M,
   // not discernible at this time.
 
   // Assign value for zero tolerance, if necessary.
-  const T naive_tol = q.size() * M.template lpNorm<Eigen::Infinity>() *
-      kSqrtEps;
-  const T mod_zero_tol = (zero_tol > 0) ? zero_tol : naive_tol;
+  const T mod_zero_tol = (zero_tol > 0) ? zero_tol : ComputeZeroTolerance(M);
 
   Log() << " zero tolerance: " << mod_zero_tol << std::endl;
 
@@ -604,11 +600,8 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
 
   // come up with a sensible value for zero tolerance if none is given
   T mod_zero_tol = zero_tol;
-  if (mod_zero_tol <= 0) {
-    mod_zero_tol =
-        M.template lpNorm<Eigen::Infinity>() *
-            std::numeric_limits<double>::epsilon();
-  }
+  if (mod_zero_tol <= 0)
+    mod_zero_tol = ComputeZeroTolerance(M);
 
   if (CheckLemkeTrivial(n, mod_zero_tol, q, z)) {
     Log() << " -- trivial solution found" << std::endl;
@@ -905,8 +898,7 @@ bool MobyLCPSolver<T>::SolveLcpLemkeRegularized(const MatrixX<T>& M,
   // Assign value for zero tolerance, if necessary. See discussion in
   // SolveLcpFastRegularized() to see why this tolerance is computed here once,
   // rather than for each regularized version of M.
-  T naive_tol = q.size() * M.template lpNorm<Eigen::Infinity>() * kSqrtEps;
-  const T mod_zero_tol = (zero_tol > 0) ? zero_tol : naive_tol;
+  const T mod_zero_tol = (zero_tol > 0) ? zero_tol : ComputeZeroTolerance(M);
 
   Log() << " zero tolerance: " << mod_zero_tol << std::endl;
 
@@ -1057,8 +1049,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   // come up with a sensible value for zero tolerance if none is given
   if (zero_tol <= static_cast<double>(0.0)) {
     Eigen::MatrixXd dense_M = M;
-    zero_tol = dense_M.lpNorm<Eigen::Infinity>() *
-        std::numeric_limits<double>::epsilon() * n;
+    zero_tol = ComputeZeroTolerance(dense_M);
   }
 
   if (CheckLemkeTrivial(n, zero_tol, q, z)) {

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -64,6 +64,14 @@ class MobyLCPSolver : public MathematicalProgramSolverInterface {
 
   void SetLoggingEnabled(bool enabled);
 
+  /// Calculates the zero tolerance that the solver would compute if the user
+  /// does not specify a tolerance.
+  template <class U>
+  static U ComputeZeroTolerance(const MatrixX<U>& M) {
+    return M.rows() * M.template lpNorm<Eigen::Infinity>() *
+        std::numeric_limits<double>::epsilon();
+  }
+
   /// Fast pivoting algorithm for LCPs of the form M = PAPᵀ, q = Pb, where
   /// b ∈ ℝᵐ, P ∈ ℝⁿˣᵐ, and A ∈ ℝᵐˣᵐ (where A is positive definite). Therefore,
   /// q is in the range of P and M is positive semi-definite. An LCP of this

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -69,7 +69,7 @@ class MobyLCPSolver : public MathematicalProgramSolverInterface {
   template <class U>
   static U ComputeZeroTolerance(const MatrixX<U>& M) {
     return M.rows() * M.template lpNorm<Eigen::Infinity>() *
-        std::numeric_limits<double>::epsilon();
+        (10 * std::numeric_limits<double>::epsilon());
   }
 
   /// Fast pivoting algorithm for LCPs of the form M = PAPᵀ, q = Pb, where


### PR DESCRIPTION
This PR introduces a minimal rigid contact solver at the acceleration level. Given "problem data"- namely, Jacobian matrices, external forces, designation of sliding or non-sliding for each contact- the rigid contact solver computes contact forces according to the rigid contact model with Coulomb friction and stiction.

This PR is as stripped down as possible, but is still relatively large, due primarily to the unit tests, which must compute all of the necessary problem data manually. Future PRs will add more unit tests (contact scenarios with multiple modes, 3D contact scenarios), rigid body impact, ability to use an "active contact set" to speed computation, and witness functions for determining changing contact modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6437)
<!-- Reviewable:end -->
