### PR TITLE
Disable IPOPT in automotive trajectory optimization unit test

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -640,6 +640,9 @@ drake_cc_googletest(
     name = "trajectory_optimization_test",
     # Test size increased to not timeout when run with Valgrind.
     size = "medium",
+    # Disable IPOPT for this example due to test timeouts on Mac-Clang-Bazel
+    # builds (see #6223).
+    tags = ["snopt"],
     deps = [
         ":simple_car",
         "//drake/common:call_matlab",

--- a/drake/automotive/test/trajectory_optimization_test.cc
+++ b/drake/automotive/test/trajectory_optimization_test.cc
@@ -32,7 +32,7 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
   xf.set_heading(0.0);
   xf.set_velocity(x0.velocity());
 
-  const int kNumTimeSamples = 10;
+  const int kNumTimeSamples = 20;
 
   // The solved trajectory may deviate from the initial guess at a reasonable
   // duration.
@@ -76,14 +76,7 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
   int solver_result;
   prog.GetSolverResult(&solver, &solver_result);
 
-  if (solver == solvers::SolverType::kIpopt) {
-    EXPECT_EQ(result,
-              solvers::SolutionResult::kIterationLimit);  // TODO(russt): Tune
-                                                          // Ipopt for this
-                                                          // example.
-  } else {
-    EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound);
-  }
+  EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound);
 
   // Plot the solution.
   // Note: see lcm_call_matlab.h for instructions on viewing the plot.


### PR DESCRIPTION
Towards #6223, where IPOPT-induced timeouts were observed after tuning the solver's `max_iter` so that it returns the optimal trajectory (`SolutionResult::kSolutionFound`, rather than `solvers::SolutionResult::kIterationLimit`).

Since the SNOPT solver runs fast on this problem, the number of time intervals were also increased slightly to improve the granularity of the result.

\cc @RussTedrake, @jefesaurus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6440)
<!-- Reviewable:end -->
