### PR TITLE
Create hpp aggregate headers and strip include suffix

### DIFF
--- a/tools/lcmtypes_bot2_core.BUILD
+++ b/tools/lcmtypes_bot2_core.BUILD
@@ -34,6 +34,7 @@ lcm_c_library(
 
 lcm_cc_library(
     name = "lcmtypes_bot2_core",
+    aggregate_hdr = "lcmtypes/bot_core.hpp",
     includes = ["lcmtypes"],
     lcm_package = "bot_core",
     lcm_srcs = LCM_SRCS,

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -163,6 +163,7 @@ BOT2_PARAM_LCM_STRUCTS = [
 lcm_c_library(
     name = "lcmtypes_bot2_param_c",
     aggregate_hdr = "bot2-param/lcmtypes/bot2_param.h",
+    aggregate_hdr_strip_prefix = ["bot2-param"],
     includes = ["bot2-param"],
     lcm_package = "bot_param",
     lcm_srcs = BOT2_PARAM_LCM_SRCS,
@@ -171,6 +172,8 @@ lcm_c_library(
 
 lcm_cc_library(
     name = "lcmtypes_bot2_param",
+    aggregate_hdr = "lcmtypes/bot2_param.hpp",
+    aggregate_hdr_strip_prefix = ["bot2-param"],
     includes = ["bot2-param"],
     lcm_package = "bot_param",
     lcm_srcs = BOT2_PARAM_LCM_SRCS,
@@ -277,6 +280,7 @@ BOT2_FRAMES_LCM_STRUCTS = [
 lcm_c_library(
     name = "lcmtypes_bot2_frames_c",
     aggregate_hdr = "bot2-frames/lcmtypes/bot2_frames.h",
+    aggregate_hdr_strip_prefix = ["bot2-frames"],
     includes = ["bot2-frames"],
     lcm_package = "bot_frames",
     lcm_srcs = BOT2_FRAMES_LCM_SRCS,
@@ -285,6 +289,8 @@ lcm_c_library(
 
 lcm_cc_library(
     name = "lcmtypes_bot2_frames",
+    aggregate_hdr = "lcmtypes/bot2_frames.hpp",
+    aggregate_hdr_strip_prefix = ["bot2-frames"],
     includes = ["bot2-frames"],
     lcm_package = "bot_frames",
     lcm_srcs = BOT2_FRAMES_LCM_SRCS,
@@ -339,6 +345,7 @@ BOT2_LCMGL_LCM_STRUCTS = [
 lcm_c_library(
     name = "lcmtypes_bot2_lcmgl_c",
     aggregate_hdr = "bot2-lcmgl/lcmtypes/bot2_lcmgl.h",
+    aggregate_hdr_strip_prefix = ["bot2-lcmgl"],
     includes = ["bot2-lcmgl"],
     lcm_package = "bot_lcmgl",
     lcm_srcs = BOT2_LCMGL_LCM_SRCS,
@@ -347,6 +354,8 @@ lcm_c_library(
 
 lcm_cc_library(
     name = "lcmtypes_bot2_lcmgl",
+    aggregate_hdr = "lcmtypes/bot2_lcmgl.hpp",
+    aggregate_hdr_strip_prefix = ["bot2-lcmgl"],
     includes = ["bot2-lcmgl"],
     lcm_package = "bot_lcmgl",
     lcm_srcs = BOT2_LCMGL_LCM_SRCS,


### PR DESCRIPTION
* Macro lcm_cc_library creates aggregate header if value changed from `None`
to either `AUTO` or a list of header files.
* Option `hdr_strip_prefix` added to `lcm_cc_library` and `lcm_c_library` to
strip include header prefix in aggregate header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6442)
<!-- Reviewable:end -->
