### PR TITLE
Remove spurious "too small step" messages from implicit integrator.

### DIFF
--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -491,7 +491,8 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
 
       // Look for divergence.
       if (theta > 1) {
-        SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected for h={}", dt);
+        SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected for "
+            "h={}", dt);
         break;
       }
 

--- a/drake/systems/analysis/implicit_euler_integrator.h
+++ b/drake/systems/analysis/implicit_euler_integrator.h
@@ -248,6 +248,7 @@ class ImplicitEulerIntegrator final : public IntegratorBase<T> {
   /// @}
 
  private:
+  bool IsBadJacobian(const MatrixX<T>& J) const;
   void DoInitialize() override;
   void DoResetStatistics() override;
   void Factor(const MatrixX<T>& A);


### PR DESCRIPTION
If the continuous state advanced by the turbo integrator veered into NaN territory (due to overflow from expected occasional divergence in the Newton-Raphson process), reusing the Jacobian matrix (which, naturally, would become NaN as well) would cause any step size to fail. This PR fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6444)
<!-- Reviewable:end -->
