### PR TITLE
Remove spurious "too small step" messages from implicit integrator.

### DIFF
--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -308,8 +308,6 @@ VectorX<AutoDiffXd> ImplicitEulerIntegrator<AutoDiffXd>::Solve(
 // refactorized.
 template <class T>
 bool ImplicitEulerIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
-  using std::isnan;
-
   return !J.allFinite();
 }
 

--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -304,6 +304,15 @@ VectorX<AutoDiffXd> ImplicitEulerIntegrator<AutoDiffXd>::Solve(
   return QR_.solve(b);
 }
 
+// Checks to see whether a Jacobian matrix has "become bad" and needs to be
+// refactorized.
+template <class T>
+bool ImplicitEulerIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
+  using std::isnan;
+
+  return (isnan(J.norm()));
+}
+
 // Computes any necessary matrices for the Newton-Raphson iteration in
 // StepAbstract(). Parameters are identical to those for StepAbstract;
 // @see StepAbstract() for their documentation.
@@ -316,7 +325,7 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
                                               int trial) {
   // Compute the initial Jacobian and negated iteration matrices (see
   // rationale for the negation below) and factor them, if necessary.
-  if (!reuse_ || J_.rows() == 0) {
+  if (!reuse_ || J_.rows() == 0 || IsBadJacobian(J_)) {
     J_ = CalcJacobian(tf, xtplus);
     const int n = xtplus.size();
     neg_iteration_matrix_ = J_ * (dt / scale) - MatrixX<T>::Identity(n, n);
@@ -409,8 +418,8 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
   // Get the initial state.
   VectorX<T> xt0 = context->get_continuous_state_vector().CopyToVector();
 
-  SPDLOG_DEBUG(drake::log(), "StepAbstract() entered for t={}, h={}",
-               context->get_time(), dt);
+  SPDLOG_DEBUG(drake::log(), "StepAbstract() entered for t={}, h={}, trial={}",
+               context->get_time(), dt, trial);
 
   // Advance the context time; this means that all derivatives will be computed
   // at t+dt.
@@ -475,20 +484,23 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     // [Hairer, 1996] notes that this convergence strategy should only be
     // applied after *at least* two iterations (p. 121).
     if (i >= 1) {
-      // [Hairer, 1996] determined values of kappa in [0.01, 0.1] work most
-      // efficiently on a number of test problems with *RADAU5* (a fifth order
-      // implicit integrator), p. 121. We select a value halfway in-between.
-      const double kappa = 0.05;
       const T theta = dx_norm / last_dx_norm;
       const T eta = theta / (1 - theta);
       SPDLOG_DEBUG(drake::log(), "Newton-Raphson loop {} theta: {}, eta: {}",
                    i, theta, eta);
 
       // Look for divergence.
-      if (theta > 1)
+      if (theta > 1) {
+        SPDLOG_DEBUG(drake::log(), "Newton-Raphson divergence detected for "
+            "h={}", dt);
         break;
+      }
 
       // Look for convergence using Equation 8.10 from [Hairer, 1996].
+      // [Hairer, 1996] determined values of kappa in [0.01, 0.1] work most
+      // efficiently on a number of test problems with *RADAU5* (a fifth order
+      // implicit integrator), p. 121. We select a value halfway in-between.
+      const double kappa = 0.05;
       const double k_dot_tol = kappa * this->get_accuracy_in_use();
       if (eta * dx_norm < k_dot_tol) {
         SPDLOG_DEBUG(drake::log(), "Newton-Raphson converged; η = {}, h = {}",
@@ -845,8 +857,7 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Reset the error estimate.
   err_est_vec_.setZero(context->get_continuous_state()->size());
 
-  // Compute and update the error estimate. We assume that the error estimates
-  // can be summed.
+  // Compute and update the error estimate.
   err_est_vec_ += xtplus_ie - xtplus_itr;
 
   // Update the caller-accessible error estimate.

--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -310,7 +310,7 @@ template <class T>
 bool ImplicitEulerIntegrator<T>::IsBadJacobian(const MatrixX<T>& J) const {
   using std::isnan;
 
-  return (isnan(J.norm()));
+  return !J.allFinite();
 }
 
 // Computes any necessary matrices for the Newton-Raphson iteration in

--- a/drake/systems/analysis/implicit_euler_integrator.h
+++ b/drake/systems/analysis/implicit_euler_integrator.h
@@ -248,6 +248,7 @@ class ImplicitEulerIntegrator final : public IntegratorBase<T> {
   /// @}
 
  private:
+  bool IsBadJacobian(const MatrixX<T>& J) const;
   void DoInitialize() override;
   void DoResetStatistics() override;
   void Factor(const MatrixX<T>& A);


### PR DESCRIPTION
If the continuous state advanced by the turbo integrator veered into NaN territory (due to overflow from expected occasional divergence in the Newton-Raphson process), reusing the Jacobian matrix (which, naturally, would become NaN as well) would cause any step size to fail. This PR fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6448)
<!-- Reviewable:end -->
