### PR TITLE
Simplify divide-by-constant cases in Expression::Expand()

### DIFF
--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -232,10 +232,12 @@ class Expression {
   double Evaluate(const Environment& env = Environment{}) const;
 
   /** Expands out products and positive integer powers in expression. For
-   * example, <tt>(x + 1) * (x - 1)</tt> is expanded to <tt>x^2 - 1</tt> and
-   * <tt>(x + y)^2</tt> is expanded to <tt>x^2 + 2xy + y^2</tt>. Note that
-   * Expand applies recursively to sub-expressions. For instance, <tt>sin(2 * (x
-   * + y))</tt> is expanded to <tt>sin(2x + 2y)</tt>.
+   * example, `(x + 1) * (x - 1)` is expanded to `x^2 - 1` and `(x + y)^2` is
+   * expanded to `x^2 + 2xy + y^2`. Note that Expand applies recursively to
+   * sub-expressions. For instance, `sin(2 * (x + y))` is expanded to `sin(2x +
+   * 2y)`. It also simplifies "division by constant" cases. See
+   * "drake/common/test/symbolic_expansion_test.cc" to find the examples.
+   *
    * @throws std::runtime_error if NaN is detected during expansion.
    */
   Expression Expand() const;


### PR DESCRIPTION
```
 Case Addition      : e =  (c₀ + ∑ᵢ (cᵢ * eᵢ)) / n
                        => c₀/n + ∑ᵢ (cᵢ / n * eᵢ)

 Case Multiplication: e =  (c₀ * ∏ᵢ (bᵢ * eᵢ)) / n
                        => c₀ / n * ∏ᵢ (bᵢ * eᵢ)

 Case Division      : e =  (e₁ / m) / n
                        => Recursively simplify e₁ / (n * m)

                      e =  (e₁ / e₂) / n
                        =  (e₁ / n) / e₂
                        => Recursively simplify (e₁ / n) and divide it by e₂
```

This is a part of the commits that we're migrating from the SOS (sum-of-squares) sprint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6454)
<!-- Reviewable:end -->
