### PR TITLE
Transition RgbdCamera update to a discrete (unrestricted) update. Add auto_init capability.

### DIFF
--- a/drake/systems/sensors/rgbd_camera.h
+++ b/drake/systems/sensors/rgbd_camera.h
@@ -132,14 +132,22 @@ class RgbdCamera : public LeafSystem<double> {
   ///
   /// @param fov_y The RgbdCamera's vertical field of view.
   ///
+  /// @param period_sec Update interval of the RgbdCamera in seconds.
+  ///
   /// @param show_window A flag for showing a visible window.  If this is false,
   /// offscreen rendering is executed. This is useful for debugging purposes.
+  ///
+  /// @param auto_init Automatically initialize the camera scene by evaluating
+  /// the upstream block's output such that the camera has a valid frame at
+  /// t = 0.
   RgbdCamera(const std::string& name,
              const RigidBodyTree<double>& tree,
              const Eigen::Vector3d& position,
              const Eigen::Vector3d& orientation,
              double fov_y,
-             bool show_window);
+             double period_sec,
+             bool show_window,
+             bool auto_init = false);
 
   /// A constructor for %RgbdCamera that defines `B` using a RigidBodyFrame.
   /// The pose of %RgbdCamera is fixed to a user-defined frame and will be
@@ -158,13 +166,21 @@ class RgbdCamera : public LeafSystem<double> {
   ///
   /// @param fov_y The RgbdCamera's vertical field of view.
   ///
+  /// @param period_sec Update interval of the RgbdCamera in seconds.
+  ///
   /// @param show_window A flag for showing a visible window.  If this is false,
   /// offscreen rendering is executed. This is useful for debugging purposes.
+  ///
+  /// @param auto_init Automatically initialize the camera scene by evaluating
+  /// the upstream block's output such that the camera has a valid frame at
+  /// t = 0.
   RgbdCamera(const std::string& name,
              const RigidBodyTree<double>& tree,
              const RigidBodyFrame<double>& frame,
              double fov_y,
-             bool show_window);
+             double period_sec,
+             bool show_window,
+             bool auto_init = false);
 
   ~RgbdCamera();
 
@@ -217,6 +233,15 @@ class RgbdCamera : public LeafSystem<double> {
                         ImageLabel16I* label_image) const;
   void OutputPoseVector(const Context<double>& context,
                         rendering::PoseVector<double>* pose_vector) const;
+
+  void DoCalcUnrestrictedUpdate(const Context<double>& context,
+                                State<double>* state) const override;
+
+  void SetDefaultState(const Context<double>& context,
+                       State<double>* state) const override;
+
+  std::unique_ptr<DiscreteValues<double>>
+  AllocateDiscreteState() const override;
 
   const OutputPort<double>* color_image_port_{};
   const OutputPort<double>* depth_image_port_{};

--- a/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -71,7 +71,8 @@ int main() {
       builder.template AddSystem<RgbdCamera>(
           "rgbd_camera", plant->get_rigid_body_tree(),
           Eigen::Vector3d(-1., 0., 1.),
-          Eigen::Vector3d(0., M_PI_4, 0.), M_PI_4, true);
+          Eigen::Vector3d(0., M_PI_4, 0.), M_PI_4,
+          kImageArrayPublishPeriod, true);
 
   auto image_to_lcm_image_array =
       builder.template AddSystem<ImageToLcmImageArrayT>(


### PR DESCRIPTION
This transitions `RgbdCamera`s update logic to be a discrete update, rather than a direct feedthrough.
To handle initial conditions, this PR also adds `auto_init` functionality.

I will be creating a separate issue on whether or not it would make sense to split out the core functionality of `RgbdCamera` to a non-`System` framework, so that the direct functionality (rendering) can be separated from the state-based semantics (such as the `auto_init` stuff, which could be split via component-based testing).

\cc @kunimatsu-tri @SeanCurtis-TRI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6458)
<!-- Reviewable:end -->
