### PR TITLE
Refactor monomial.{h,cc}

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -256,8 +256,14 @@ drake_cc_library(
 
 drake_cc_library(
     name = "monomial",
-    srcs = ["monomial.cc"],
-    hdrs = ["monomial.h"],
+    srcs = [
+        "monomial.cc",
+        "monomial_util.cc",
+    ],
+    hdrs = [
+        "monomial.h",
+        "monomial_util.h",
+    ],
     deps = [
         ":common",
         ":symbolic",

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -20,6 +20,7 @@ set(sources
   find_resource.cc
   functional_form.cc
   monomial.cc
+  monomial_util.cc
   nice_type_name.cc
   polynomial.cc
   symbolic_environment.cc
@@ -64,6 +65,7 @@ set(installed_headers
   is_approx_equal_abstol.h
   is_cloneable.h
   monomial.h
+  monomial_util.h
   never_destroyed.h
   nice_type_name.h
   number_traits.h

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -42,6 +42,9 @@ class Monomial {
    */
   explicit Monomial(const Expression& e);
 
+  /** Constructs a Monomial from @p var. */
+  explicit Monomial(const Variable& var);
+
   /** Constructs a Monomial from @p var and @exponent. */
   Monomial(const Variable& var, int exponent);
 
@@ -50,6 +53,9 @@ class Monomial {
 
   /** Returns hash value. */
   size_t GetHash() const;
+
+  /** Returns the set of variables in this monomial. */
+  Variables GetVariables() const;
 
   /** Returns the internal representation of Monomial, the map from a base
    * (Variable) to its exponent (int).*/
@@ -111,159 +117,7 @@ Monomial operator*(Monomial m1, const Monomial& m2);
 /** Returns @p m1 raised to @p p.
  * @throws std::runtime_error if @p p is negative.
  */
-
 Monomial pow(Monomial m, int p);
-
-/** Implements Graded reverse lexicographic order.
- *
- * @tparam VariableOrder VariableOrder{}(v1, v2) is true if v1 < v2.
- *
- * We first compare the total degree of the monomial; if there is a tie, then we
- * use the lexicographical order as the tie breaker, but a monomial with higher
- * order in lexicographical order is considered lower order in graded reverse
- * lexicographical order.
- *
- * Take the example MonomialBasis({x, y, z}, 2) as an example, with the order x
- * > y > z. To get the graded reverse lexicographical order, we take the
- * following steps:
- *
- * First find all the monomials using the total degree. The monomials with
- * degree 2 are {x^2, y^2, z^2, xy, xz, yz}. The monomials with degree 1 are {x,
- * y, z}, and the monomials with degree 0 is {1}. To break the tie between
- * monomials with the same total degree, first sort them in the reverse
- * lexicographical order, namely x < y < z in the reverse lexicographical
- * order. The lexicographical order compares two monomial by first comparing the
- * exponent of the largest variable, if there is a tie then go forth to the
- * second largest variable. Thus z^2 > zy >zx > y^2 > yx > x^2. Finally reverse
- * the order as x^2 > xy > y^2 > xz > yz > z^2.
- *
- * There is an introduction to monomial order in
- * https://en.wikipedia.org/wiki/Monomial_order, and an introduction to graded
- * reverse lexicographical order in
- * https://en.wikipedia.org/wiki/Monomial_order#Graded_reverse_lexicographic_order
- */
-template <typename VariableOrder>
-struct GradedReverseLexOrder {
-  /** Returns true if m1 > m2 under the Graded reverse lexicographic order. */
-  bool operator()(const Monomial& m1, const Monomial& m2) {
-    const int d1{m1.total_degree()};
-    const int d2{m2.total_degree()};
-    if (d1 > d2) {
-      return true;
-    }
-    if (d2 > d1) {
-      return false;
-    }
-    // d1 == d2
-    if (d1 == 0) {
-      // Because both of them are 1.
-      return false;
-    }
-    const std::map<Variable, int>& powers1{m1.get_powers()};
-    const std::map<Variable, int>& powers2{m2.get_powers()};
-    std::map<Variable, int>::const_iterator it1{powers1.cbegin()};
-    std::map<Variable, int>::const_iterator it2{powers2.cbegin()};
-    while (it1 != powers1.cend() && it2 != powers2.cend()) {
-      const Variable& var1{it1->first};
-      const Variable& var2{it2->first};
-      const int exponent1{it1->second};
-      const int exponent2{it2->second};
-      if (variable_order_(var2, var1)) {
-        return true;
-      } else if (variable_order_(var1, var2)) {
-        return false;
-      } else {
-        // var1 == var2
-        if (exponent1 == exponent2) {
-          ++it1;
-          ++it2;
-        } else {
-          return exponent2 > exponent1;
-        }
-      }
-    }
-    // When m1 and m2 are identical.
-    return false;
-  }
-
- private:
-  VariableOrder variable_order_;
-};
-
-/** Generates [b * m for m in MonomialBasis(vars, degree)] and push them to
- * bin. Used as a helper function to implement MonomialBasis.
- *
- * @tparam MonomialOrder provides a monomial ordering.
- */
-template <typename MonomialOrder>
-void AddMonomialsOfDegreeN(const Variables& vars, int degree, const Monomial& b,
-                           std::set<Monomial, MonomialOrder>* const bin) {
-  DRAKE_ASSERT(vars.size() > 0);
-  if (degree == 0) {
-    bin->insert(b);
-    return;
-  }
-  const Variable& var{*vars.cbegin()};
-  bin->insert(b * Monomial{var, degree});
-  if (vars.size() == 1) {
-    return;
-  }
-  for (int i{degree - 1}; i >= 0; --i) {
-    AddMonomialsOfDegreeN(vars - var, degree - i, b * Monomial{var, i}, bin);
-  }
-  return;
-}
-
-/** Returns all monomials up to a given degree under the graded reverse
- * lexicographic order. This is called by MonomialBasis functions defined below
- * outside of internal namespace.
- *
- * @tparam rows Number of rows or Dynamic
- * TODO(soonho-tri): Change its return type to Eigen::Matrix<Monomial, rows, 1>.
- */
-template <int rows>
-Eigen::Matrix<Expression, rows, 1> ComputeMonomialBasis(const Variables& vars,
-                                                        int degree) {
-  DRAKE_DEMAND(vars.size() > 0);
-  DRAKE_DEMAND(degree >= 0);
-  // 1. Collect monomials.
-  std::set<Monomial, GradedReverseLexOrder<std::less<Variable>>> monomials;
-  for (int i{degree}; i >= 0; --i) {
-    AddMonomialsOfDegreeN(vars, i, Monomial{}, &monomials);
-  }
-  // 2. Prepare the return value, basis.
-  DRAKE_DEMAND((rows == Eigen::Dynamic) ||
-               (static_cast<size_t>(rows) == monomials.size()));
-  Eigen::Matrix<Expression, rows, 1> basis(monomials.size());
-  size_t i{0};
-  for (const auto& m : monomials) {
-    basis[i] = m.ToExpression();
-    i++;
-  }
-  return basis;
-}
-
-/**
- * Returns the total degrees of the polynomial @p e w.r.t the variables in @p
- * vars. For example, the total degree of e = x^2*y + 2 * x*y*z^3 + x * z^2
- *  - w.r.t (x, y) is 3 (from x^2 * y)
- *  - w.r.t (x, z) is 4 (from x*y*z^3)
- *  - w.r.t (z)    is 3 (from x*y*z^3)
- * Throws a runtime error if e.is_polynomial() is false.
- * @param vars A set of variables.
- * @return The total degree.
- */
-int Degree(const Expression& e, const Variables& vars);
-
-/**
- * Returns the total degress of all the variables in the polynomial @p e.
- * For example, the total degree of
- * x^2*y + 2*x*y*z^3 + x*z^2
- * is 5, from x*y*z^3
- * Throws a runtime error is e.is_polynomial() is false.
- * @return The total degree.
- */
-int Degree(const Expression& e);
 
 /** Returns a monomial of the form x^2*y^3, it does not have the constant
  * factor. To generate a monomial x^2*y^3, @p map_var_to_exponent contains the
@@ -274,44 +128,6 @@ int Degree(const Expression& e);
 Expression GetMonomial(
     const std::unordered_map<Variable, int, hash_value<Variable>>&
         map_var_to_exponent);
-
-/** Returns all monomials up to a given degree under the graded reverse
- * lexicographic order. Note that graded reverse lexicographic order uses the
- * total order among Variable which is based on a variable's unique ID. For
- * example, for a given variable ordering x > y > z, <tt>MonomialBasis({x, y,
- * z}, 2)</tt> returns a column vector <tt>[x^2, xy, y^2, xz, yz, z^2, x, y, z,
- * 1]</tt>.
- *
- * @pre @p vars is a non-empty set.
- * @pre @p degree is a non-negative integer.
- */
-Eigen::Matrix<Expression, Eigen::Dynamic, 1> MonomialBasis(
-    const Variables& vars, int degree);
-
-// Computes "n choose k", the number of ways, disregarding order, that k objects
-// can be chosen from among n objects. It is used in the following MonomialBasis
-// function.
-constexpr int NChooseK(int n, int k) {
-  return (k == 0) ? 1 : (n * NChooseK(n - 1, k - 1)) / k;
-}
-
-/** Returns all monomials up to a given degree under the graded reverse
- * lexicographic order.
- *
- * @tparam n      number of variables
- * @tparam degree maximum total degree of monomials to compute
- *
- * @pre @p vars is a non-empty set.
- * @pre vars.size() == @p n.
- */
-template <int n, int degree>
-Eigen::Matrix<Expression, NChooseK(n + degree, degree), 1> MonomialBasis(
-    const Variables& vars) {
-  static_assert(n > 0, "n should be a positive integer.");
-  static_assert(degree >= 0, "degree should be a non-negative integer.");
-  DRAKE_ASSERT(vars.size() == n);
-  return ComputeMonomialBasis<NChooseK(n + degree, degree)>(vars, degree);
-}
 
 typedef std::unordered_map<Expression, Expression, hash_value<Expression>>
     MonomialAsExpressionToCoefficientMap;
@@ -396,3 +212,15 @@ MonomialToCoefficientMap DecomposePolynomialIntoMonomial(const Expression& e,
 
 }  // namespace symbolic
 }  // namespace drake
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+namespace Eigen {
+// Eigen scalar type traits for Matrix<drake::symbolic::Monomial>.
+template <>
+struct NumTraits<drake::symbolic::Monomial>
+    : GenericNumTraits<drake::symbolic::Monomial> {
+  static inline int digits10() { return 0; }
+};
+
+}  // namespace Eigen
+#endif  // !defined(DRAKE_DOXYGEN_CXX)

--- a/drake/common/monomial_util.cc
+++ b/drake/common/monomial_util.cc
@@ -1,0 +1,93 @@
+#include "drake/common/monomial_util.h"
+
+#include <algorithm>
+#include <map>
+#include <numeric>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_expression_cell.h"
+#include "drake/common/symbolic_expression_visitor.h"
+#include "drake/common/symbolic_variable.h"
+#include "drake/common/symbolic_variables.h"
+
+namespace drake {
+namespace symbolic {
+
+using std::accumulate;
+using std::map;
+using std::max;
+using std::move;
+using std::pair;
+using std::runtime_error;
+using std::unordered_map;
+
+class DegreeVisitor {
+ public:
+  int Visit(const Expression& e, const Variables& vars) const {
+    return VisitPolynomial<int>(this, e, vars);
+  }
+
+ private:
+  int VisitVariable(const Expression& e, const Variables& vars) const {
+    return vars.include(get_variable(e)) ? 1 : 0;
+  }
+
+  int VisitConstant(const Expression&, const Variables&) const { return 0; }
+
+  int VisitAddition(const Expression& e, const Variables& vars) const {
+    int degree = 0;
+    for (const auto& p : get_expr_to_coeff_map_in_addition(e)) {
+      degree = max(degree, Visit(p.first, vars));
+    }
+    return degree;
+  }
+
+  int VisitMultiplication(const Expression& e, const Variables& vars) const {
+    const auto& base_to_exponent_map =
+        get_base_to_exponent_map_in_multiplication(e);
+    return accumulate(
+        base_to_exponent_map.begin(), base_to_exponent_map.end(), 0,
+        [this, &vars](const int& degree,
+                      const pair<Expression, Expression>& p) {
+          const Expression& base{p.first};
+          const Expression& exponent{p.second};
+          return degree + Visit(base, vars) *
+                              static_cast<int>(get_constant_value(exponent));
+        });
+  }
+
+  int VisitDivision(const Expression& e, const Variables& vars) const {
+    return Visit(get_first_argument(e), vars) -
+           Visit(get_second_argument(e), vars);
+  }
+
+  int VisitPow(const Expression& e, const Variables& vars) const {
+    const int exponent{
+        static_cast<int>(get_constant_value(get_second_argument(e)))};
+    return Visit(get_first_argument(e), vars) * exponent;
+  }
+
+  // Makes VisitPolynomial a friend of this class so that it can use private
+  // methods.
+  friend int drake::symbolic::VisitPolynomial<int>(const DegreeVisitor*,
+                                                   const Expression&,
+                                                   const Variables&);
+};
+
+int Degree(const Expression& e, const Variables& vars) {
+  return DegreeVisitor().Visit(e, vars);
+}
+
+int Degree(const Expression& e) { return Degree(e, e.GetVariables()); }
+
+Eigen::Matrix<Monomial, Eigen::Dynamic, 1> MonomialBasis(const Variables& vars,
+                                                         const int degree) {
+  return internal::ComputeMonomialBasis<Eigen::Dynamic>(vars, degree);
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/monomial_util.h
+++ b/drake/common/monomial_util.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <set>
+#include <unordered_map>
+
+#include <Eigen/Core>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/hash.h"
+#include "drake/common/monomial.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_variable.h"
+#include "drake/common/symbolic_variables.h"
+
+namespace drake {
+namespace symbolic {
+
+/** Implements Graded reverse lexicographic order.
+ *
+ * @tparam VariableOrder VariableOrder{}(v1, v2) is true if v1 < v2.
+ *
+ * We first compare the total degree of the monomial; if there is a tie, then we
+ * use the lexicographical order as the tie breaker, but a monomial with higher
+ * order in lexicographical order is considered lower order in graded reverse
+ * lexicographical order.
+ *
+ * Take MonomialBasis({x, y, z}, 2) as an example, with the order x > y > z. To
+ * get the graded reverse lexicographical order, we take the following steps:
+ *
+ * First find all the monomials using the total degree. The monomials with
+ * degree 2 are {x^2, y^2, z^2, xy, xz, yz}. The monomials with degree 1 are {x,
+ * y, z}, and the monomials with degree 0 is {1}. To break the tie between
+ * monomials with the same total degree, first sort them in the reverse
+ * lexicographical order, namely x < y < z in the reverse lexicographical
+ * order. The lexicographical order compares two monomial by first comparing the
+ * exponent of the largest variable, if there is a tie then go forth to the
+ * second largest variable. Thus z^2 > zy >zx > y^2 > yx > x^2. Finally reverse
+ * the order as x^2 > xy > y^2 > xz > yz > z^2.
+ *
+ * There is an introduction to monomial order in
+ * https://en.wikipedia.org/wiki/Monomial_order, and an introduction to graded
+ * reverse lexicographical order in
+ * https://en.wikipedia.org/wiki/Monomial_order#Graded_reverse_lexicographic_order
+ */
+template <typename VariableOrder>
+struct GradedReverseLexOrder {
+  /** Returns true if m1 > m2 under the Graded reverse lexicographic order. */
+  bool operator()(const Monomial& m1, const Monomial& m2) {
+    const int d1{m1.total_degree()};
+    const int d2{m2.total_degree()};
+    if (d1 > d2) {
+      return true;
+    }
+    if (d2 > d1) {
+      return false;
+    }
+    // d1 == d2
+    if (d1 == 0) {
+      // Because both of them are 1.
+      return false;
+    }
+    const std::map<Variable, int>& powers1{m1.get_powers()};
+    const std::map<Variable, int>& powers2{m2.get_powers()};
+    std::map<Variable, int>::const_iterator it1{powers1.cbegin()};
+    std::map<Variable, int>::const_iterator it2{powers2.cbegin()};
+    while (it1 != powers1.cend() && it2 != powers2.cend()) {
+      const Variable& var1{it1->first};
+      const Variable& var2{it2->first};
+      const int exponent1{it1->second};
+      const int exponent2{it2->second};
+      if (variable_order_(var2, var1)) {
+        return true;
+      } else if (variable_order_(var1, var2)) {
+        return false;
+      } else {
+        // var1 == var2
+        if (exponent1 == exponent2) {
+          ++it1;
+          ++it2;
+        } else {
+          return exponent2 > exponent1;
+        }
+      }
+    }
+    // When m1 and m2 are identical.
+    return false;
+  }
+
+ private:
+  VariableOrder variable_order_;
+};
+
+namespace internal {
+/** Generates [b * m for m in MonomialBasis(vars, degree)] and push them to
+ * bin. Used as a helper function to implement MonomialBasis.
+ *
+ * @tparam MonomialOrder provides a monomial ordering.
+ */
+template <typename MonomialOrder>
+void AddMonomialsOfDegreeN(const Variables& vars, int degree, const Monomial& b,
+                           std::set<Monomial, MonomialOrder>* const bin) {
+  DRAKE_ASSERT(vars.size() > 0);
+  if (degree == 0) {
+    bin->insert(b);
+    return;
+  }
+  const Variable& var{*vars.cbegin()};
+  bin->insert(b * Monomial{var, degree});
+  if (vars.size() == 1) {
+    return;
+  }
+  for (int i{degree - 1}; i >= 0; --i) {
+    AddMonomialsOfDegreeN(vars - var, degree - i, b * Monomial{var, i}, bin);
+  }
+  return;
+}
+
+/** Returns all monomials up to a given degree under the graded reverse
+ * lexicographic order. This is called by MonomialBasis functions defined below.
+ *
+ * @tparam rows Number of rows or Dynamic
+ */
+template <int rows>
+Eigen::Matrix<Monomial, rows, 1> ComputeMonomialBasis(const Variables& vars,
+                                                      int degree) {
+  DRAKE_DEMAND(vars.size() > 0);
+  DRAKE_DEMAND(degree >= 0);
+  // 1. Collect monomials.
+  std::set<Monomial, GradedReverseLexOrder<std::less<Variable>>> monomials;
+  for (int i{degree}; i >= 0; --i) {
+    AddMonomialsOfDegreeN(vars, i, Monomial{}, &monomials);
+  }
+  // 2. Prepare the return value, basis.
+  DRAKE_DEMAND((rows == Eigen::Dynamic) ||
+               (static_cast<size_t>(rows) == monomials.size()));
+  Eigen::Matrix<Monomial, rows, 1> basis(monomials.size());
+  size_t i{0};
+  for (const auto& m : monomials) {
+    basis[i] = m;
+    i++;
+  }
+  return basis;
+}
+}  // namespace internal
+
+/**
+ * Returns the total degrees of the polynomial @p e w.r.t the variables in @p
+ * vars. For example, the total degree of e = x^2*y + 2 * x*y*z^3 + x * z^2
+ *  - w.r.t (x, y) is 3 (from x^2 * y)
+ *  - w.r.t (x, z) is 4 (from x*y*z^3)
+ *  - w.r.t (z)    is 3 (from x*y*z^3)
+ * Throws a runtime error if e.is_polynomial() is false.
+ * @param vars A set of variables.
+ * @return The total degree.
+ */
+int Degree(const Expression& e, const Variables& vars);
+
+/**
+ * Returns the total degress of all the variables in the polynomial @p e.
+ * For example, the total degree of
+ * x^2*y + 2*x*y*z^3 + x*z^2
+ * is 5, from x*y*z^3
+ * Throws a runtime error is e.is_polynomial() is false.
+ * @return The total degree.
+ */
+int Degree(const Expression& e);
+
+/** Returns all monomials up to a given degree under the graded reverse
+ * lexicographic order. Note that graded reverse lexicographic order uses the
+ * total order among Variable which is based on a variable's unique ID. For
+ * example, for a given variable ordering x > y > z, `MonomialBasis({x, y, z},
+ * 2)` returns a column vector `[x^2, xy, y^2, xz, yz, z^2, x, y, z, 1]`.
+ *
+ * @pre @p vars is a non-empty set.
+ * @pre @p degree is a non-negative integer.
+ */
+Eigen::Matrix<Monomial, Eigen::Dynamic, 1> MonomialBasis(const Variables& vars,
+                                                         int degree);
+
+// Computes "n choose k", the number of ways, disregarding order, that k objects
+// can be chosen from among n objects. It is used in the following MonomialBasis
+// function.
+constexpr int NChooseK(int n, int k) {
+  return (k == 0) ? 1 : (n * NChooseK(n - 1, k - 1)) / k;
+}
+
+/** Returns all monomials up to a given degree under the graded reverse
+ * lexicographic order.
+ *
+ * @tparam n      number of variables.
+ * @tparam degree maximum total degree of monomials to compute.
+ *
+ * @pre @p vars is a non-empty set.
+ * @pre vars.size() == @p n.
+ */
+template <int n, int degree>
+Eigen::Matrix<Monomial, NChooseK(n + degree, degree), 1> MonomialBasis(
+    const Variables& vars) {
+  static_assert(n > 0, "n should be a positive integer.");
+  static_assert(degree >= 0, "degree should be a non-negative integer.");
+  DRAKE_ASSERT(vars.size() == n);
+  return internal::ComputeMonomialBasis<NChooseK(n + degree, degree)>(vars,
+                                                                      degree);
+}
+
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/monomial.h"
 
+#include <sstream>
 #include <stdexcept>
 #include <unordered_map>
 #include <utility>
@@ -9,16 +10,19 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
+#include "drake/common/monomial_util.h"
 #include "drake/common/symbolic_environment.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/common/symbolic_variable.h"
 #include "drake/common/test/symbolic_test_util.h"
 
+using std::map;
+using std::ostringstream;
 using std::out_of_range;
 using std::pair;
+using std::runtime_error;
 using std::unordered_map;
 using std::vector;
-using std::runtime_error;
 
 namespace drake {
 namespace symbolic {
@@ -121,6 +125,47 @@ class MonomialTest : public ::testing::Test {
   }
 };
 
+TEST_F(MonomialTest, ConstructFromVariable) {
+  const Monomial m1{var_x_};
+  const std::map<Variable, int> powers{m1.get_powers()};
+
+  // Checks that powers = {x ↦ 1}.
+  ASSERT_EQ(powers.size(), 1u);
+  EXPECT_EQ(powers.begin()->first, var_x_);
+  EXPECT_EQ(powers.begin()->second, 1);
+}
+
+TEST_F(MonomialTest, GetVariables) {
+  const Monomial m0{};
+  EXPECT_EQ(m0.GetVariables(), Variables{});
+
+  const Monomial m1{var_z_, 4};
+  EXPECT_EQ(m1.GetVariables(), Variables({var_z_}));
+
+  const Monomial m2{{{var_x_, 1}, {var_y_, 2}}};
+  EXPECT_EQ(m2.GetVariables(), Variables({var_x_, var_y_}));
+
+  const Monomial m3{{{var_x_, 1}, {var_y_, 2}, {var_z_, 3}}};
+  EXPECT_EQ(m3.GetVariables(), Variables({var_x_, var_y_, var_z_}));
+}
+
+// Checks we can have an Eigen matrix of Monomials without compilation
+// errors. No assertions in the test.
+TEST_F(MonomialTest, EigenMatrixOfMonomials) {
+  Eigen::Matrix<Monomial, 2, 2> M;
+  // M = | 1   x    |
+  //     | y²  x²z³ |
+  // clang-format off
+  M << Monomial{}, Monomial{var_x_},
+       Monomial{{{var_y_, 2}}}, Monomial{{{var_x_, 2}, {var_z_, 3}}};
+  // clang-format on
+
+  // The following fails if we do not provide
+  // `Eigen::NumTraits<drake::symbolic::Monomial>`.
+  ostringstream oss;
+  oss << M;
+}
+
 TEST_F(MonomialTest, MonomialOne) {
   // Compares monomials all equal to 1, but with different variables.
   Monomial m1{};
@@ -142,84 +187,59 @@ TEST_F(MonomialTest, MonomialWithZeroExponent) {
   EXPECT_EQ(m2.get_powers(), power_expected);
 }
 
-TEST_F(MonomialTest, Monomial) {
-  // clang-format off
-  EXPECT_PRED2(
-      ExprEqual,
-      GetMonomial(unordered_map<Variable, int, hash_value<Variable>>{}),
-      Expression{1.0});
-
-  EXPECT_PRED2(ExprEqual, GetMonomial({{var_x_, 1}}),
-               x_);
-
-  EXPECT_PRED2(ExprEqual, GetMonomial({{var_y_, 1}}),
-               y_);
-
-  EXPECT_PRED2(ExprEqual, GetMonomial({{var_x_, 1}, {var_y_, 1}}),
-               x_ * y_);
-
-  EXPECT_PRED2(ExprEqual, GetMonomial({{var_x_, 2}, {var_y_, 3}}),
-               x_ * x_ * y_ * y_ * y_);
-
-  EXPECT_PRED2(ExprEqual, GetMonomial({{var_x_, 1}, {var_y_, 2}, {var_z_, 3}}),
-               pow(x_, 1) * pow(y_, 2) * pow(z_, 3));
-  // clang-format on
-}
-
 TEST_F(MonomialTest, MonomialBasis_x_0) {
-  const drake::Vector1<Expression> basis1{MonomialBasis({var_x_}, 0)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_}, 0)};
   const auto basis2 = MonomialBasis<1, 0>({var_x_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 1);
-  drake::Vector1<Expression> expected;
+  drake::Vector1<Monomial> expected;
 
-  // MonomialBasis({x}, 0)
-  expected << Expression{1.0};
+  // MonomialBasis({x}, 0) = {x⁰} = {1}.
+  expected << Monomial{};
 
   EXPECT_EQ(basis1, expected);
   EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_2) {
-  const drake::Vector3<Expression> basis1{MonomialBasis({var_x_}, 2)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_}, 2)};
   const auto basis2 = MonomialBasis<1, 2>({var_x_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 3);
-  drake::Vector3<Expression> expected;
+  drake::Vector3<Monomial> expected;
 
-  // MonomialBasis({x}, 2)
+  // MonomialBasis({x}, 2) = {x², x, 1}.
   // clang-format off
-  expected << x_ * x_,
-              x_,
-              1.0;
+  expected << Monomial{var_x_, 2},
+              Monomial{var_x_},
+              Monomial{};
   // clang-format on
-
   EXPECT_EQ(basis1, expected);
   EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_0) {
-  const drake::VectorX<Expression> basis1{MonomialBasis({var_x_, var_y_}, 0)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 0)};
   const auto basis2 = MonomialBasis<2, 0>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 1);
-  drake::Vector1<Expression> expected;
+  drake::Vector1<Monomial> expected;
 
-  // MonomialBasis({x, y}, 0)
-  expected << Expression{1.0};
+  // MonomialBasis({x, y}, 0) = {1}.
+  expected << Monomial{{{var_x_, 0}, {var_y_, 0}}};  // = {1}.
 
   EXPECT_EQ(basis1, expected);
   EXPECT_EQ(basis2, expected);
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_1) {
-  const drake::VectorX<Expression> basis1{MonomialBasis({var_x_, var_y_}, 1)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 1)};
   const auto basis2 = MonomialBasis<2, 1>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 3);
-  drake::Vector3<Expression> expected;
+  drake::Vector3<Monomial> expected;
 
-  // MonomialBasis({x, y}, 1)
+  // MonomialBasis({x, y}, 1) = {x, y, 1}.
   // clang-format off
-  expected << x_,
-              y_,
-              1.0;
+  expected << Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);
@@ -227,19 +247,19 @@ TEST_F(MonomialTest, MonomialBasis_x_y_1) {
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_2) {
-  const drake::VectorX<Expression> basis1{MonomialBasis({var_x_, var_y_}, 2)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 2)};
   const auto basis2 = MonomialBasis<2, 2>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 6);
-  drake::Vector6<Expression> expected;
+  drake::Vector6<Monomial> expected;
 
-  // MonomialBasis({x, y}, 2)
+  // MonomialBasis({x, y}, 2) = {x², xy, y², x, y, 1}.
   // clang-format off
-  expected << x_ * x_,
-              x_ * y_,
-              y_ * y_,
-              x_,
-              y_,
-              1.0;
+  expected << Monomial{var_x_, 2},
+              Monomial{{{var_x_, 1}, {var_y_, 1}}},
+              Monomial{var_y_, 2},
+              Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);
@@ -247,23 +267,23 @@ TEST_F(MonomialTest, MonomialBasis_x_y_2) {
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_3) {
-  const drake::VectorX<Expression> basis1{MonomialBasis({var_x_, var_y_}, 3)};
+  const drake::VectorX<Monomial> basis1{MonomialBasis({var_x_, var_y_}, 3)};
   const auto basis2 = MonomialBasis<2, 3>({var_x_, var_y_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 10);
-  Eigen::Matrix<Expression, 10, 1> expected;
+  Eigen::Matrix<Monomial, 10, 1> expected;
 
-  // MonomialBasis({x, y}, 3)
+  // MonomialBasis({x, y}, 3) = {x³, x²y, xy², y³, x², xy, y², x, y, 1}.
   // clang-format off
-  expected << pow(x_, 3),
-              (pow(x_, 2) * y_),
-              (x_ * pow(y_, 2)),
-              pow(y_, 3),
-              pow(x_, 2),
-              (x_ * y_),
-              pow(y_, 2),
-              x_,
-              y_,
-              1;
+  expected << Monomial{var_x_, 3},
+              Monomial{{{var_x_, 2}, {var_y_, 1}}},
+              Monomial{{{var_x_, 1}, {var_y_, 2}}},
+              Monomial{var_y_, 3},
+              Monomial{var_x_, 2},
+              Monomial{{{var_x_, 1}, {var_y_, 1}}},
+              Monomial{var_y_, 2},
+              Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);
@@ -271,25 +291,25 @@ TEST_F(MonomialTest, MonomialBasis_x_y_3) {
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
-  const drake::VectorX<Expression> basis1{
+  const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_}, 2)};
   const auto basis2 = MonomialBasis<3, 2>({var_x_, var_y_, var_z_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 10);
 
-  Eigen::Matrix<Expression, 10, 1> expected;
+  Eigen::Matrix<Monomial, 10, 1> expected;
 
   // MonomialBasis({x, y, z}, 2)
   // clang-format off
-  expected << pow(x_, 2),
-              (x_ * y_),
-              pow(y_, 2),
-              (x_ * z_),
-              (y_ * z_),
-              pow(z_, 2),
-              x_,
-              y_,
-              z_,
-              1;
+  expected << Monomial{var_x_, 2},
+              Monomial{{{var_x_, 1}, {var_y_, 1}}},
+              Monomial{var_y_, 2},
+              Monomial{{{var_x_, 1}, {var_z_, 1}}},
+              Monomial{{{var_y_, 1}, {var_z_, 1}}},
+              Monomial{var_z_, 2},
+              Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{var_z_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);
@@ -297,34 +317,36 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_2) {
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
-  const drake::VectorX<Expression> basis1{
+  const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_}, 3)};
   const auto basis2 = MonomialBasis<3, 3>({var_x_, var_y_, var_z_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 20);
-  Eigen::Matrix<Expression, 20, 1> expected;
+  Eigen::Matrix<Monomial, 20, 1> expected;
 
   // MonomialBasis({x, y, z}, 3)
+  // = {x³, x²y, xy², y³, x²z, xyz, y²z, xz², yz²,
+  //    z³, x², xy, y², xz, yz, z², x, y, z, 1}
   // clang-format off
-  expected << pow(x_, 3),
-              (pow(x_, 2) * y_),
-              (x_ * pow(y_, 2)),
-              pow(y_, 3),
-              (pow(x_, 2) * z_),
-              (y_ * x_ * z_),
-              (pow(y_, 2) * z_),
-              (x_ * pow(z_, 2)),
-              (y_ * pow(z_, 2)),
-              pow(z_, 3),
-              pow(x_, 2),
-              (x_ * y_),
-              pow(y_, 2),
-              (x_ * z_),
-              (y_ * z_),
-              pow(z_, 2),
-              x_,
-              y_,
-              z_,
-              1;
+  expected << Monomial{var_x_, 3},
+              Monomial{{{var_x_, 2}, {var_y_, 1}}},
+              Monomial{{{var_x_, 1}, {var_y_, 2}}},
+              Monomial{var_y_, 3},
+              Monomial{{{var_x_, 2}, {var_z_, 1}}},
+              Monomial{{{var_x_, 1}, {var_y_, 1}, {var_z_, 1}}},
+              Monomial{{{var_y_, 2}, {var_z_, 1}}},
+              Monomial{{{var_x_, 1}, {var_z_, 2}}},
+              Monomial{{{var_y_, 1}, {var_z_, 2}}},
+              Monomial{var_z_, 3},
+              Monomial{var_x_, 2},
+              Monomial{{{var_x_, 1}, {var_y_, 1}}},
+              Monomial{var_y_, 2},
+              Monomial{{{var_x_, 1}, {var_z_, 1}}},
+              Monomial{{{var_y_, 1}, {var_z_, 1}}},
+              Monomial{var_z_, 2},
+              Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{var_z_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);
@@ -332,49 +354,49 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_3) {
 }
 
 TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
-  const drake::VectorX<Expression> basis1{
+  const drake::VectorX<Monomial> basis1{
       MonomialBasis({var_x_, var_y_, var_z_, var_w_}, 3)};
   const auto basis2 = MonomialBasis<4, 3>({var_x_, var_y_, var_z_, var_w_});
   EXPECT_EQ(decltype(basis2)::RowsAtCompileTime, 35);
-  Eigen::Matrix<Expression, 35, 1> expected;
+  Eigen::Matrix<Monomial, 35, 1> expected;
 
   // MonomialBasis({x, y, z, w}, 3)
   // clang-format off
-  expected << pow(x_, 3),
-              (pow(x_, 2) * y_),
-              (x_ * pow(y_, 2)),
-              pow(y_, 3),
-              (pow(x_, 2) * z_),
-              (x_ * y_ * z_),
-              (pow(y_, 2) * z_),
-              (x_ * pow(z_, 2)),
-              (y_ * pow(z_, 2)),
-              pow(z_, 3),
-              (pow(x_, 2) * w_),
-              (y_ * x_ * w_),
-              (pow(y_, 2) * w_),
-              (z_ * x_ * w_),
-              (z_ * y_ * w_),
-              (pow(z_, 2) * w_),
-              (x_ * pow(w_, 2)),
-              (y_ * pow(w_, 2)),
-              (z_ * pow(w_, 2)),
-              pow(w_, 3),
-              pow(x_, 2),
-              (x_ * y_),
-              pow(y_, 2),
-              (x_ * z_),
-              (y_ * z_),
-              pow(z_, 2),
-              (x_ * w_),
-              (y_ * w_),
-              (z_ * w_),
-              pow(w_, 2),
-              x_,
-              y_,
-              z_,
-              w_,
-              1;
+  expected << Monomial{var_x_, 3},
+              Monomial{{{var_x_, 2}, {var_y_, 1}}},
+              Monomial{{{var_x_, 1}, {var_y_, 2}}},
+              Monomial{var_y_, 3},
+              Monomial{{{var_x_, 2}, {var_z_, 1}}},
+              Monomial{{{var_x_, 1}, {var_y_, 1}, {var_z_, 1}}},
+              Monomial{{{var_y_, 2}, {var_z_, 1}}},
+              Monomial{{{var_x_, 1}, {var_z_, 2}}},
+              Monomial{{{var_y_, 1}, {var_z_, 2}}},
+              Monomial{var_z_, 3},
+              Monomial{{{var_x_, 2}, {var_w_, 1}}},
+              Monomial{{{var_y_, 1}, {var_x_, 1}, {var_w_, 1}}},
+              Monomial{{{var_y_, 2}, {var_w_, 1}}},
+              Monomial{{{var_z_, 1}, {var_x_, 1}, {var_w_, 1}}},
+              Monomial{{{var_z_, 1}, {var_y_, 1}, {var_w_, 1}}},
+              Monomial{{{var_z_, 2}, {var_w_, 1}}},
+              Monomial{{{var_x_, 1}, {var_w_, 2}}},
+              Monomial{{{var_y_, 1}, {var_w_, 2}}},
+              Monomial{{{var_z_, 1}, {var_w_, 2}}},
+              Monomial{var_w_, 3},
+              Monomial{var_x_, 2},
+              Monomial{{{var_x_, 1}, {var_y_, 1}}},
+              Monomial{var_y_, 2},
+              Monomial{{{var_x_, 1}, {var_z_, 1}}},
+              Monomial{{{var_y_, 1}, {var_z_, 1}}},
+              Monomial{var_z_, 2},
+              Monomial{{{var_x_, 1}, {var_w_, 1}}},
+              Monomial{{{var_y_, 1}, {var_w_, 1}}},
+              Monomial{{{var_z_, 1}, {var_w_, 1}}},
+              Monomial{var_w_, 2},
+              Monomial{var_x_},
+              Monomial{var_y_},
+              Monomial{var_z_},
+              Monomial{var_w_},
+              Monomial{};
   // clang-format on
 
   EXPECT_EQ(basis1, expected);


### PR DESCRIPTION
 - Move monomial-basis code to `monomial_util.{h,cc}`.
 - Make Monomial class compatible with Eigen.

`monomial.h` will include only `Monomial` class. The others will be
removed in the next PRs. Symbolic::Polynomial will substitute them.

This is a part of the commits that we're migrating from the SOS (sum-of-squares) sprint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6459)
<!-- Reviewable:end -->
