### PR TITLE
Switch pydrake to use libdrake.so

### DIFF
--- a/drake/BUILD
+++ b/drake/BUILD
@@ -4,6 +4,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:install.bzl", "install")
+load("//tools:transitive_hdrs.bzl", "transitive_hdrs_library")
 
 # Should include everything any consumer of Drake would ever need.
 # When adding new components to the package, please also add the licenses for
@@ -321,4 +322,68 @@ install(
     hdr_dest = "include/drake",
     targets = ["libdrake.so"],
     deps = ["//drake/bindings:install"],
+)
+
+# Gather all of libdrake.so's dependent headers.
+transitive_hdrs_library(
+    name = "libdrake_headers",
+    deps = _LIBDRAKE_COMPONENTS,
+    visibility = [],
+)
+
+# Depend on Gurobi's shared library iff Gurobi is enabled.
+cc_library(
+    name = "gurobi_deps",
+    deps = select({
+        "//tools:with_gurobi": ["@gurobi"],
+        "//conditions:default": [],
+    }),
+    visibility = [],
+)
+
+# Depend on Mosek's shared library iff Mosek is enabled.
+cc_library(
+    name = "mosek_deps",
+    deps = select({
+        "//tools:with_mosek": ["@mosek"],
+        "//conditions:default": [],
+    }),
+    visibility = [],
+)
+
+# Depend on the subset of VTK's shared libraries that Drake uses.
+cc_library(
+    name = "vtk_deps",
+    deps = [
+        # TODO(jwnimmer-tri) This duplicates the list of VTK libraries needed
+        # by //drake/sensors.  We should find a way for ":drake_shared_library"
+        # to be declared without having to repeat this list here.
+        "@vtk//:vtkCommonCore",
+        "@vtk//:vtkCommonDataModel",
+        "@vtk//:vtkCommonTransforms",
+        "@vtk//:vtkFiltersGeneral",
+        "@vtk//:vtkFiltersSources",
+        "@vtk//:vtkIOGeometry",
+        "@vtk//:vtkIOImage",
+        "@vtk//:vtkRenderingCore",
+        "@vtk//:vtkRenderingOpenGL2",
+    ],
+    visibility = [],
+)
+
+# Provide a cc_library target that provides libdrake.so, its headers, and its
+# required *.so's that are WORKSPACE downloads (such as VTK, Gurobi, etc).
+#
+# TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
+# *.so files (Gurobi, Mosek, VTK) for us, without us having to know up-front
+# here which dependencies are coming from the WORKSPACE in the form of *.so.
+cc_library(
+    name = "drake_shared_library",
+    deps = [
+        ":gurobi_deps",
+        ":libdrake_headers",
+        ":mosek_deps",
+        ":vtk_deps",
+    ],
+    visibility = ["//drake/bindings:__pkg__"],
 )

--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -2,169 +2,85 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_binary")
 load("//tools:gurobi.bzl", "gurobi_test_tags")
 load("//tools:install.bzl", "install")
 load("//tools:mosek.bzl", "mosek_test_tags")
 load("//tools:python_lint.bzl", "python_lint")
+load(":pybind.bzl", "drake_pybind_cc_binary")
 
 package(default_visibility = ["//visibility:private"])
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/_pydrake_common.so",
     srcs = [
         "pybind11/pydrake_common.cc",
     ],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/common",
-        "@pybind11",
-    ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/_pydrake_autodiffutils.so",
     srcs = [
         "pybind11/pydrake_autodiff_types.h",
         "pybind11/pydrake_autodiffutils.cc",
     ],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "@eigen",
-        "@pybind11",
-    ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/_pydrake_rbtree.so",
     srcs = [
         "pybind11/pydrake_autodiff_types.h",
         "pybind11/pydrake_rbtree.cc",
     ],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
-        "@eigen",
-        "@pybind11",
-    ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/parsers.so",
-    srcs = ["pybind11/pydrake_parsers.cc"],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/multibody/parsers",
-        "@pybind11",
+    srcs = [
+        "pybind11/pydrake_parsers.cc",
     ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/solvers/_pydrake_ik.so",
-    srcs = ["pybind11/pydrake_ik.cc"],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/multibody:inverse_kinematics",
-        "//drake/multibody:rigid_body_tree",
-        "@pybind11",
+    srcs = [
+        "pybind11/pydrake_ik.cc",
     ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/solvers/_pydrake_mathematicalprogram.so",
     srcs = [
         "pybind11/pydrake_mathematicalprogram.cc",
         "pybind11/pydrake_symbolic_types.h",
     ],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/common:symbolic",
-        "//drake/solvers:mathematical_program",
-        "@pybind11",
-    ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/solvers/gurobi.so",
-    srcs = ["pybind11/pydrake_gurobi.cc"],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/solvers:mathematical_program",
-        "@pybind11",
+    srcs = [
+        "pybind11/pydrake_gurobi.cc",
     ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/solvers/ipopt.so",
-    srcs = ["pybind11/pydrake_ipopt.cc"],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/solvers:ipopt_solver",
-        "@pybind11",
+    srcs = [
+        "pybind11/pydrake_ipopt.cc",
     ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/solvers/mosek.so",
-    srcs = ["pybind11/pydrake_mosek.cc"],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/solvers:mathematical_program",
-        "@pybind11",
+    srcs = [
+        "pybind11/pydrake_mosek.cc",
     ],
 )
 
-drake_cc_binary(
+drake_pybind_cc_binary(
     name = "python/pydrake/_pydrake_symbolic.so",
     srcs = [
         "pybind11/pydrake_symbolic.cc",
         "pybind11/pydrake_symbolic_types.h",
-    ],
-    copts = [
-        "-Wno-#warnings",
-        "-Wno-cpp",
-        "-Wno-unknown-warning-option",
-    ],
-    linkshared = 1,
-    linkstatic = 1,
-    deps = [
-        "//drake/common:symbolic",
-        "@pybind11",
     ],
 )
 

--- a/drake/bindings/pybind.bzl
+++ b/drake/bindings/pybind.bzl
@@ -1,0 +1,48 @@
+# -*- python -*-
+
+load("//tools:drake.bzl", "drake_cc_binary")
+
+def drake_pybind_cc_binary(name, srcs=[], copts=[], **kwargs):
+    """Declare a pybind11 shared library with the given name and srcs.  The
+    libdrake.so library and its headers are already automatically depended-on
+    by this rule.
+
+    The deps, linkshared, and linkstatic parameters cannot be set by the
+    caller; this rule must fully control their values.
+    """
+
+    # Disallow `linkshared` and `linkstatic` because Bazel requires them to be
+    # set to 1 when making a ".so" library.
+    #
+    # Disallow `deps` because we _must not_ deps on any given object code more
+    # than once or else we risk linking in multiple copies of it into different
+    # _pybind_foo.so files, which breaks C++ global variables.  All object code
+    # must come in through libdrake.so.  (Conceivably a header-only library
+    # could be allowed in deps, but we can fix that when we need it.)
+    for key in ["deps", "linkshared", "linkstatic"]:
+        if key in kwargs:
+            fail("%s cannot be set by the caller" % key)
+
+    drake_cc_binary(
+        name = name,
+        # This is how you tell Bazel to link in a shared library.
+        srcs = srcs + ["//drake:libdrake.so"],
+        # These copts are per pybind11 deficiencies.
+        copts = [
+            "-Wno-#warnings",
+            "-Wno-cpp",
+            "-Wno-unknown-warning-option",
+        ] + copts,
+        # This is how you tell Bazel to create a shared library.
+        linkshared = 1,
+        linkstatic = 1,
+        # For all pydrake_foo.so, always link to Drake and pybind11.
+        deps = [
+            # Even though "libdrake.so" appears in srcs above, we have to list
+            # :drake_shared_library here in order to get its headers onto the
+            # include path, and its prerequisite *.so's onto LD_LIBRARY_PATH.
+            "//drake:drake_shared_library",
+            "@pybind11",
+        ],
+        **kwargs
+    )

--- a/tools/transitive_hdrs.bzl
+++ b/tools/transitive_hdrs.bzl
@@ -1,0 +1,39 @@
+# -*- python -*-
+
+# Collects the transitive closure of header files from ctx.attr.deps.
+# This has headers from all (depended-on) externals, but not system headers.
+def _transitive_hdrs_impl(ctx):
+    headers = depset()
+    for dep in ctx.attr.deps:
+        headers += dep.cc.transitive_headers
+    return struct(files = headers)
+
+_transitive_hdrs = rule(
+    attrs = {
+        "deps": attr.label_list(
+            allow_files = False,
+            providers = ["cc"],
+        ),
+    },
+    implementation = _transitive_hdrs_impl,
+)
+
+def transitive_hdrs_library(name, deps = [], **kwargs):
+    """Declare a drake_cc_library that provides only hdrs (no srcs), where the
+    hdrs are the hdrs for all cc_library targets named by "deps", transitively
+    for all deps-of-deps, etc.
+
+    All other kwargs are passed through to drake_cc_library.
+
+    """
+
+    _transitive_hdrs(
+        name = name + "_gather",
+        deps = deps,
+        visibility = []
+    )
+    native.cc_library(
+        name = name,
+        hdrs = [":" + name + "_gather"],
+        **kwargs
+    )


### PR DESCRIPTION
Prior to this patch, in Bazel builds each `_pydrake_foo.so` had its own copy of e.g. `drake/common/symbolic_variable.o` object code.  That means that global data was being duplicated / instantiated multiple times, but Drake assumes that each global variable is a process-wide singleton, e.g. for assigning each `symbolic::Variable` an ID.

This patch switches all of the `_pydrake_foo.so` to depend on the `libdrake.so` rollup library, which will then be loaded just the once into the Python interpreter.

In order do this, we need a header-only Bazel `cc_library` that provides the headers for `libdrake.so`; we do that by resurrecting some code removed in 31f79b63f79289de736218f067b7c1f5b27668d9 to transitively read out the headers based on the cc artifact.

Because the correct way to write a `_pydrake_foo.so` binary is now very finicky, we factor their declarations into a helper macro.

Relates #6159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6465)
<!-- Reviewable:end -->
