### PR TITLE
Implements SpatialVelocity::ComposeWithMovingFrameVelocity()

### DIFF
--- a/drake/multibody/multibody_tree/body_node.h
+++ b/drake/multibody/multibody_tree/body_node.h
@@ -314,7 +314,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // =========================================================================
     // Update velocity V_WB of this node's body B in the world frame. Using the
     // recursive Eq. (1). See summary at the top of this method.
-    get_mutable_V_WB(vc) = V_WP.Shift(p_PB_W) + V_PB_W;
+    get_mutable_V_WB(vc) = V_WP.ComposeWithMovingFrameVelocity(p_PB_W, V_PB_W);
   }
 
   /// Returns the topology information for this body node.

--- a/drake/multibody/multibody_tree/math/spatial_vector.h
+++ b/drake/multibody/multibody_tree/math/spatial_vector.h
@@ -149,8 +149,9 @@ class SpatialVector {
 
   /// Sets both rotational and translational components of `this`
   /// %SpatialVector to zero.
-  void SetZero() {
+  SpatialQuantity& SetZero() {
     V_.setZero();
+    return get_mutable_derived();
   }
 
   /// Returns a reference to the underlying storage.
@@ -185,7 +186,19 @@ class SpatialVector {
     return SpatialQuantity(R_FE * V_E.rotational(), R_FE * V_E.translational());
   }
 
+  /// Factory to create a _zero_ %SpatialVector, i.e. rotational and
+  /// translational components are both zero.
+  static SpatialQuantity Zero() {
+    return SpatialQuantity{}.SetZero();
+  }
+
  private:
+  // Helper method to return a mutable reference to the derived spatial
+  // quantity.
+  SpatialQuantity& get_mutable_derived() {
+    // Static cast is safe since types are resolved at compile time by CRTP.
+    return *static_cast<SpatialQuantity*>(this);
+  }
   CoeffsEigenType V_;
 };
 

--- a/drake/multibody/multibody_tree/math/spatial_velocity.h
+++ b/drake/multibody/multibody_tree/math/spatial_velocity.h
@@ -139,6 +139,48 @@ class SpatialVelocity : public SpatialVector<SpatialVelocity, T> {
     return SpatialVelocity<T>(*this).ShiftInPlace(p_BpBq_E);
   }
 
+  /// This method composes `this` spatial velocity `V_WP` of a frame P measured
+  /// in a frame W, with that of a third frame B moving in P with spatial
+  /// velocity `V_PB`. The result is the spatial velocity `V_WB` of frame B
+  /// measured in W. At the instant in which the velocities are composed, frame
+  /// B is located with its origin `Bo` at `p_PoBo` from P's origin Po.
+  ///
+  /// The composition cannot be performed directly since frames P and B do not
+  /// have the same origins. To perform the composition `V_WB`, the velocity of
+  /// P needs to be shifted to point `Bo`: <pre>
+  ///   V_WB_E = V_WPb_E + V_PB_E = V_WP_E.Shift(p_PoBo_E) + V_PB_E
+  /// </pre>
+  /// where p_PoBo is the position vector from P's origin to B's origin and
+  /// `V_WPb` is the spatial velocity of a new frame `Pb` which is an offset
+  /// frame rigidly aligned with P, but with its origin shifted to B's origin.
+  /// The key is that in the expression above, the two spatial velocities being
+  /// added must be for frames with the same origin point, in this case Bo.
+  ///
+  /// For computation, all quantities above must be expressed in a common
+  /// frame E; we add an `_E` suffix to each symbol to indicate that.
+  ///
+  /// @note If frame B moves rigidly together with frame P, as in a rigid body,
+  /// `V_PB = 0` and the result of this method equals that of the Shift()
+  /// operation.
+  ///
+  /// @param[in] p_PoBo_E
+  ///   Shift vector from P's origin to B's origin, expressed in frame E.
+  ///   The "from" point `Po` must be the point whose velocity is currently
+  ///   represented in `this` spatial velocity, and E must be the same
+  ///   expressed-in frame as for `this` spatial velocity.
+  /// @param[in] V_PB_E
+  ///   The spatial velocity of a third frame B in motion with respect to P,
+  ///   expressed in the same frame E as `this` spatial velocity.
+  /// @retval V_WB_E
+  ///   The spatial velocity of frame B in W resulting from the composition of
+  ///   `this` spatial velocity `V_WP` and B's velocity in P, `V_PB`. The result
+  ///   is expressed in the same frame E as `this` spatial velocity.
+  SpatialVelocity<T> ComposeWithMovingFrameVelocity(
+      const Vector3<T>& p_PoBo_E, const SpatialVelocity<T>& V_PB_E) const {
+    // V_WB_E = V_WPb_E + V_PB_E = V_WP_E.Shift(p_PoBo_E) + V_PB_E
+    return this->Shift(p_PoBo_E) + V_PB_E;
+  }
+
   /// Given `this` spatial velocity `V_IBp_E` of point P of body B,
   /// measured in an inertial frame I and expressed in a frame E,
   /// this method computes the 6-dimensional dot product with the spatial

--- a/drake/multibody/multibody_tree/math/test/spatial_algebra_tests.cc
+++ b/drake/multibody/multibody_tree/math/test/spatial_algebra_tests.cc
@@ -63,6 +63,15 @@ TYPED_TEST(SpatialQuantityTest, SizeAtCompileTime) {
   EXPECT_EQ(V.size(), 6);
 }
 
+// Construction of a "zero" spatial vector.
+TYPED_TEST(SpatialQuantityTest, ZeroFactory) {
+  typedef typename TestFixture::SpatialQuantityType SpatialQuantity;
+  typedef typename TestFixture::ScalarType T;
+  SpatialQuantity V = SpatialQuantity::Zero();
+  EXPECT_TRUE(V.rotational() == Vector3<T>::Zero());
+  EXPECT_TRUE(V.translational() == Vector3<T>::Zero());
+}
+
 // Tests:
 // - Construction from a Eigen expressions.
 // - SetZero() method.
@@ -260,8 +269,11 @@ class SpatialVelocityTest : public ::testing::Test {
 };
 TYPED_TEST_CASE(SpatialVelocityTest, ScalarTypes);
 
-// Tests the shifting of a spatial velocity between two moving frames rigidly
-// attached to each other.
+// Unit tests for the composition of spatial velocities:
+// - Shift(): shift of a spatial velocity between two moving frames rigidly
+//            attached to each other.
+// - ComposeWithMovingFrameVelocity(): compose the velocity V_XY of a frame Y
+//   in X with that of a third frame Z moving in Y with velocity V_YZ.
 TYPED_TEST(SpatialVelocityTest, ShiftOperation) {
   typedef typename TestFixture::ScalarType T;
   const SpatialVelocity<T>& V_XY_A = this->V_XY_A_;
@@ -274,10 +286,25 @@ TYPED_TEST(SpatialVelocityTest, ShiftOperation) {
   // Consider now shifting the spatial velocity of a frame Y measured in frame
   // X to the spatial velocity of frame Z measured in frame X knowing that
   // frames Y and Z are rigidly attached to each other.
-  SpatialVelocity<T> V_XZ_A = V_XY_A.Shift(p_YZ_A);
+  SpatialVelocity<T> V_XYz_A = V_XY_A.Shift(p_YZ_A);
 
   // Verify the result.
-  SpatialVelocity<T> expected_V_XZ_A(w_XY_A, Vector3<T>(7, 8, 0));
+  SpatialVelocity<T> expected_V_XYz_A(w_XY_A, Vector3<T>(7, 8, 0));
+  EXPECT_TRUE(V_XYz_A.IsApprox(expected_V_XYz_A));
+
+  // ComposeWithMovingFrameVelocity() should yield the same result.
+  EXPECT_TRUE(V_XY_A.ComposeWithMovingFrameVelocity(
+      p_YZ_A, SpatialVelocity<T>::Zero()).IsApprox(V_XYz_A));
+
+  // Unit test with the composition of the spatial velocity of a moving frame Z
+  // in frame Y.
+  const SpatialVelocity<T> V_YZ_A(Vector3<T>(1.0, 2.0, 3.0),
+                                  Vector3<T>(4.0, 5.0, 6.0));
+  const SpatialVelocity<T> V_XZ_A =
+      V_XY_A.ComposeWithMovingFrameVelocity(p_YZ_A, V_YZ_A);
+
+  // Verify the result: V_XZ = V_XYz + V_YZ = V_XY.Shift(p_YZ) + V_YZ
+  SpatialVelocity<T> expected_V_XZ_A = expected_V_XYz_A + V_YZ_A;
   EXPECT_TRUE(V_XZ_A.IsApprox(expected_V_XZ_A));
 }
 


### PR DESCRIPTION
This PR will help define and API to be used in #6429 and also to make that one PR smaller.
Essentially we found having `operator+()` to be a bad idea and especially bad for spatial accelerations.
Here I do not remove `operator+()` for spatial velocities yet though probably I should. 
The idea is that if we want to compose two spatial velocities we should just call the right method to do so. 

Composition of spatial accelerations will be submitted in #6429 and will avoid having the dangerous `operator+()` lying around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6470)
<!-- Reviewable:end -->
