### PR TITLE
Increasing --num-callers For Valgrind And Adding A Suppression

### DIFF
--- a/tools/valgrind-cmake.supp
+++ b/tools/valgrind-cmake.supp
@@ -207,3 +207,14 @@
     fun:GRBoptimize
 }
 
+# Started happening when Gurobi got updated to 7.0.2.
+{
+    <gurobi-2>
+    Memcheck:Leak
+    match-leak-kinds: possible
+    fun:malloc
+    fun:mkl_serv_thread_free_buffers
+    fun:PRIVATE*
+    ...
+    fun:start_thread
+}

--- a/tools/valgrind.sh
+++ b/tools/valgrind.sh
@@ -10,4 +10,5 @@ valgrind \
     --trace-children=yes \
     --track-origins=yes \
     --show-leak-kinds=definite,possible \
+    --num-callers=16 \
     "$@"

--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -88,3 +88,15 @@
     ...
     fun:GRBoptimize
 }
+
+# Started happening when Gurobi got updated to 7.0.2.
+{
+    <gurobi-2>
+    Memcheck:Leak
+    match-leak-kinds: possible
+    fun:malloc
+    fun:mkl_serv_thread_free_buffers
+    fun:PRIVATE*
+    ...
+    fun:start_thread
+}


### PR DESCRIPTION
We have a failure which is covered by the suppression in PR 6393 but the stack is not sufficiently big to be suppressed by it. As noted in #6393, the leak started happening after we updated Gurobi to 7.0.2.

https://drake-jenkins.csail.mit.edu/view/Nightly/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/49/consoleText

We checked that the stack is indeed covered by this suppression by using --num-callers=20 in valgrind.sh. The default number of callers in 12 in valgrind. The failing test is //drake/solvers:mixed_integer_optimization_util_test

The output after increasing the number of callers is:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-experimental-memcheck-valgrind-everything/15/consoleText

We have another failure which has been confirmed to have started after the update of Gurobi.   We add a suppression for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6472)
<!-- Reviewable:end -->
