### PR TITLE
Stop passing SNOPT details through RigidBody IK

### DIFF
--- a/drake/automotive/test/trajectory_optimization_test.cc
+++ b/drake/automotive/test/trajectory_optimization_test.cc
@@ -72,10 +72,6 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
       prog.SolveTraj(initial_duration, PiecewisePolynomial<double>(),
                      initial_state_trajectory);
 
-  solvers::SolverType solver;
-  int solver_result;
-  prog.GetSolverResult(&solver, &solver_result);
-
   EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound);
 
   // Plot the solution.

--- a/drake/multibody/inverse_kinematics_backend.cc
+++ b/drake/multibody/inverse_kinematics_backend.cc
@@ -41,18 +41,9 @@ namespace drake {
 namespace systems {
 namespace plants {
 
-int GetIKSolverInfo(const MathematicalProgram& prog, SolutionResult result) {
-  solvers::SolverType solver_type;
-  int solver_result = 0;
-  prog.GetSolverResult(&solver_type, &solver_result);
-
-  if (solver_type ==
-      solvers::SolverType::kSnopt) {
-    // We can return SNOPT results directly.
-    return solver_result;
-  }
-
+int GetIKSolverInfo(SolutionResult result) {
   // Make a SNOPT-like return code out of the generic result.
+  // Magic constants are per rigid_body_ik.h.
   switch (result) {
     case SolutionResult::kSolutionFound: {
       return 1;
@@ -60,9 +51,7 @@ int GetIKSolverInfo(const MathematicalProgram& prog, SolutionResult result) {
     case SolutionResult::kInvalidInput: {
       return 91;
     }
-    case SolutionResult::kInfeasibleConstraints: {
-      return 13;
-    }
+    case SolutionResult::kInfeasibleConstraints:
     case SolutionResult::kInfeasible_Or_Unbounded: {
       return 13;
     }
@@ -301,7 +290,7 @@ void inverseKinBackend(RigidBodyTree<double>* model, const int nT,
     SolutionResult result = prog.Solve();
     const VectorXd& vars_value = prog.GetSolution(vars);
     q_sol->col(t_index) = vars_value;
-    info[t_index] = GetIKSolverInfo(prog, result);
+    info[t_index] = GetIKSolverInfo(result);
   }
 }
 

--- a/drake/multibody/inverse_kinematics_backend.h
+++ b/drake/multibody/inverse_kinematics_backend.h
@@ -64,8 +64,7 @@ void inverseKinTrajBackend(
 
 /// Translate a solver result into something expected for the info
 /// output parameter.
-int GetIKSolverInfo(const drake::solvers::MathematicalProgram& prog,
-                    drake::solvers::SolutionResult result);
+int GetIKSolverInfo(drake::solvers::SolutionResult result);
 
 /// Set solver options based on IK options.
 void SetIKSolverOptions(const IKoptions& ikoptions,

--- a/drake/multibody/inverse_kinematics_trajectory_backend.cc
+++ b/drake/multibody/inverse_kinematics_trajectory_backend.cc
@@ -531,7 +531,7 @@ void inverseKinTrajBackend(RigidBodyTree<double>* model, const int nT,
   }
 
   const SolutionResult result = prog.Solve();
-  *info = GetIKSolverInfo(prog, result);
+  *info = GetIKSolverInfo(result);
 
   // Populate the output arguments.
   const auto q_value = prog.GetSolution(q);


### PR DESCRIPTION
This removes a use of the (soon to be deprecated) `GetSolverResult` and will make SNOPT answers look more like IPOPT and the rest.

Also remove a separate dead-code use of `GetSolverResult`.

Relates #6159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6478)
<!-- Reviewable:end -->
