### PR TITLE
Remove SolverId default ctor; Add MathematicalProgram::GetSolverId

### DIFF
--- a/drake/bindings/python/pydrake/test/testMathematicalProgram.py
+++ b/drake/bindings/python/pydrake/test/testMathematicalProgram.py
@@ -45,8 +45,10 @@ class TestMathematicalProgram(unittest.TestCase):
         a = np.array([1.0, 2.0, 3.0])
         prog.AddLinearConstraint(a.dot(x) <= 4)
         prog.AddLinearConstraint(x[0] + x[1], 1, np.inf)
+        self.assertIsNone(prog.GetSolverId())
         result = prog.Solve()
         self.assertEqual(result, mp.SolutionResult.kSolutionFound)
+        self.assertIsNotNone(prog.GetSolverId().name())
 
         # Test that we got the right solution for all x
         x_expected = np.array([1.0, 0.0, 1.0])

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -192,6 +192,7 @@ drake_cc_library(
         ":snopt_solver",
         ":solver_id",
         ":solver_type",
+        ":solver_type_converter",
         ":symbolic_extraction",
         "//drake/common",
         "//drake/common:autodiff",

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -25,6 +25,7 @@
 #include "drake/solvers/mosek_solver.h"
 #include "drake/solvers/nlopt_solver.h"
 #include "drake/solvers/snopt_solver.h"
+#include "drake/solvers/solver_type_converter.h"
 #include "drake/solvers/symbolic_extraction.h"
 
 // Note that the file mathematical_program_api.cc also contains some of the
@@ -680,6 +681,14 @@ SolutionResult MathematicalProgram::Solve() {
         "MathematicalProgram::Solve: "
         "No solver available for the given optimization problem!");
   }
+}
+
+optional<SolverId> MathematicalProgram::GetSolverId() const {
+  if (!solver_type_) {
+    return nullopt;
+  }
+  // TODO(jwnimmer-tri) We should eventually store SolverId directly.
+  return SolverTypeConverter::TypeToId(*solver_type_);
 }
 
 }  // namespace solvers

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -19,6 +19,8 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/polynomial.h"
@@ -2017,15 +2019,9 @@ class MathematicalProgram {
     return solver_options_str_[solver_type];
   }
 
-  /**
-   * Get the name and result code of the particular solver which was
-   * used to solve this MathematicalProgram.  The solver names and
-   * results are not documented here as this function is only intended
-   * for debugging, testing, and support of certain legacy
-   * APIs.
-   */
+  DRAKE_DEPRECATED("Use GetSolverId() instead")
   void GetSolverResult(SolverType* solver_type, int* solver_result) const {
-    *solver_type = solver_type_;
+    *solver_type = *solver_type_;
     *solver_result = solver_result_;
   }
 
@@ -2033,6 +2029,12 @@ class MathematicalProgram {
     solver_type_ = solver_type;
     solver_result_ = solver_result;
   }
+
+  /**
+   * Returns the ID of the solver that was used to solve this program.
+   * Returns empty if Solve() has not been called.
+   */
+  optional<SolverId> GetSolverId() const;
 
   /**
    * Getter for optimal cost at the solution. Will return NaN if there has
@@ -2302,9 +2304,9 @@ class MathematicalProgram {
   Eigen::VectorXd x_initial_guess_;
   std::vector<double> x_values_;
   std::shared_ptr<SolverData> solver_data_;
-  SolverType solver_type_;
-  int solver_result_;
-  double optimal_cost_;
+  optional<SolverType> solver_type_;
+  int solver_result_{};
+  double optimal_cost_{};
   std::map<SolverType, std::map<std::string, double>> solver_options_double_;
   std::map<SolverType, std::map<std::string, int>> solver_options_int_;
   std::map<SolverType, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/solver_id.cc
+++ b/drake/solvers/solver_id.cc
@@ -10,16 +10,13 @@ namespace solvers {
 namespace {
 
 int get_next_id() {
-  // Note that id 0 is reserved for the SolverId that is created by the default
-  // constructor. As a result, we have an invariant "get_next_id() > 0".
+  // Note that id 0 is reserved for the moved-from SolverId.  As a result, we
+  // have an invariant "get_next_id() > 0".
   static never_destroyed<std::atomic<int>> next_id{1};
   return next_id.access()++;
 }
 
 }  // namespace
-
-SolverId::SolverId()
-    : id_{0}, name_{"unknown"} {}
 
 SolverId::SolverId(std::string name)
     : id_{get_next_id()}, name_{std::move(name)} {}

--- a/drake/solvers/solver_id.h
+++ b/drake/solvers/solver_id.h
@@ -11,16 +11,12 @@ namespace solvers {
 
 /// Identifies a MathematicalProgramSolverInterface implementation.
 ///
-/// A moved-from instance is guaranteed to be identical to a
-/// default-constructed instance.
+/// A moved-from instance is guaranteed to be empty and will not compare equal
+/// to any non-empty ID.
 class SolverId {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SolverId)
   ~SolverId() = default;
-
-  /// Constructs a default "unknown" solver type.  All unknown instances are
-  /// considered equal.
-  SolverId();
 
   /// Constructs a specific, known solver type.  Internally, a hidden
   /// identifier is allocated and assigned to this instance; all instances that

--- a/drake/solvers/test/convex_optimization_test.cc
+++ b/drake/solvers/test/convex_optimization_test.cc
@@ -390,13 +390,11 @@ void FindSpringEquilibrium(const Eigen::VectorXd& weight,
 
   RunSolver(&prog, solver);
 
-  SolverType solver_type;
-  int solver_result;
-  prog.GetSolverResult(&solver_type, &solver_result);
+  const optional<SolverId> solver_id = prog.GetSolverId();
+  ASSERT_TRUE(solver_id);
   double precision = 1e-3;
-  // The precision of Gurobi solver is not as good as Mosek, in
-  // this problem.
-  if (solver_type == SolverType::kGurobi) {
+  // The precision of Gurobi solver is not as good as Mosek, in this problem.
+  if (*solver_id == GurobiSolver::id()) {
     precision = 2e-2;
   }
   for (int i = 0; i < num_nodes - 1; ++i) {

--- a/drake/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/drake/solvers/test/equality_constrained_qp_solver_test.cc
@@ -43,9 +43,9 @@ GTEST_TEST(testMathematicalProgram, testUnconstrainedQPDispatch) {
                               MatrixCompareType::absolute));
   EXPECT_NEAR(0.0, prog.GetOptimalCost(), 1e-10);
 
-// There are no inequality constraints, and only quadratic costs,
-// so this should hold:
-  CheckSolver(prog, SolverType::kEqualityConstrainedQP);
+  // There are no inequality constraints, and only quadratic costs,
+  // so this should hold:
+  CheckSolver(prog, EqualityConstrainedQPSolver::id());
 
   // Add one more variable and constrain a view into them.
   auto y = prog.NewContinuousVariables<1>("y");
@@ -71,7 +71,7 @@ GTEST_TEST(testMathematicalProgram, testUnconstrainedQPDispatch) {
   EXPECT_NEAR(0.0, prog.GetOptimalCost(), 1e-10);
 
   // Problem still has only quadratic costs, so solver should be the same.
-  CheckSolver(prog, SolverType::kEqualityConstrainedQP);
+  CheckSolver(prog, EqualityConstrainedQPSolver::id());
 }
 
 // Test how an equality-constrained QP is dispatched
@@ -109,8 +109,7 @@ GTEST_TEST(testMathematicalProgram, testLinearlyConstrainedQPDispatch) {
 
   // This problem is now an Equality Constrained QP and should
   // use this solver:
-  CheckSolver(
-      prog, SolverType::kEqualityConstrainedQP);
+  CheckSolver(prog, EqualityConstrainedQPSolver::id());
 
   // Add one more variable and constrain it in a different way
   auto y = prog.NewContinuousVariables(1);

--- a/drake/solvers/test/linear_system_solver_test.cc
+++ b/drake/solvers/test/linear_system_solver_test.cc
@@ -13,7 +13,7 @@ namespace test {
 namespace {
 void TestLinearSystemExample(LinearSystemExample1* example) {
   example->prog()->Solve();
-  CheckSolver(*(example->prog()), SolverType::kLinearSystem);
+  CheckSolver(*(example->prog()), LinearSystemSolver::id());
   example->CheckSolution();
 }
 }  // namespace
@@ -32,7 +32,7 @@ GTEST_TEST(testLinearSystemSolver, trivialExample) {
 GTEST_TEST(testLinearSystemSolver, linearMatrixEqualityExample) {
   LinearMatrixEqualityExample example{};
   example.prog()->Solve();
-  CheckSolver(*(example.prog()), SolverType::kLinearSystem);
+  CheckSolver(*(example.prog()), LinearSystemSolver::id());
   example.CheckSolution();
 }
 }  // namespace test

--- a/drake/solvers/test/mathematical_program_test_util.cc
+++ b/drake/solvers/test/mathematical_program_test_util.cc
@@ -5,12 +5,12 @@
 namespace drake {
 namespace solvers {
 namespace test {
-void CheckSolver(const MathematicalProgram& prog,
-                 SolverType desired_solver_type) {
-  SolverType solver_type;
-  int solver_result;
-  prog.GetSolverResult(&solver_type, &solver_result);
-  EXPECT_EQ(solver_type, desired_solver_type);
+void CheckSolver(const MathematicalProgram& prog, SolverId desired_solver_id) {
+  const optional<SolverId> solver_id = prog.GetSolverId();
+  EXPECT_TRUE(solver_id);
+  if (!solver_id) { return; }
+
+  EXPECT_EQ(*solver_id, desired_solver_id);
 }
 
 void RunSolver(MathematicalProgram* prog,

--- a/drake/solvers/test/mathematical_program_test_util.cc
+++ b/drake/solvers/test/mathematical_program_test_util.cc
@@ -13,9 +13,6 @@ void CheckSolver(const MathematicalProgram& prog,
   EXPECT_EQ(solver_type, desired_solver_type);
 }
 
-// If the solver is absent or does not find a solution, stop immediately.
-// (Were we to continue, testing statements that examine the results would be
-// likely to fail with confusing messages, so best to avoid them entirely.)
 void RunSolver(MathematicalProgram* prog,
                const MathematicalProgramSolverInterface& solver) {
   if (!solver.available()) {

--- a/drake/solvers/test/mathematical_program_test_util.h
+++ b/drake/solvers/test/mathematical_program_test_util.h
@@ -9,8 +9,8 @@
 namespace drake {
 namespace solvers {
 namespace test {
-void CheckSolver(const MathematicalProgram& prog,
-                 SolverType desired_solver_type);
+/// Test that @p prog was solved by @p desired_solver_id.
+void CheckSolver(const MathematicalProgram& prog, SolverId desired_solver_id);
 
 /// Run solver.Solve() on the given @p prog.  If the solver is absent or does
 /// not find a solution, stop immediately via an exception.  (Were we to

--- a/drake/solvers/test/mathematical_program_test_util.h
+++ b/drake/solvers/test/mathematical_program_test_util.h
@@ -12,6 +12,10 @@ namespace test {
 void CheckSolver(const MathematicalProgram& prog,
                  SolverType desired_solver_type);
 
+/// Run solver.Solve() on the given @p prog.  If the solver is absent or does
+/// not find a solution, stop immediately via an exception.  (Were we to
+/// continue, testing statements that examine the results would be likely to
+/// fail with confusing messages, so best to avoid them entirely.)
 void RunSolver(MathematicalProgram* prog,
                const MathematicalProgramSolverInterface& solver);
 }  // namespace test

--- a/drake/solvers/test/optimization_examples.cc
+++ b/drake/solvers/test/optimization_examples.cc
@@ -61,6 +61,7 @@ OptimizationProgram::OptimizationProgram(CostForm cost_form,
 void OptimizationProgram::RunProblem(
     MathematicalProgramSolverInterface* solver) {
   if (solver->available()) {
+    EXPECT_FALSE(prog_->GetSolverId());
     RunSolver(prog_.get(), *solver);
     const optional<SolverType> solver_type =
         SolverTypeConverter::IdToType(solver->solver_id());

--- a/drake/solvers/test/solver_id_test.cc
+++ b/drake/solvers/test/solver_id_test.cc
@@ -7,10 +7,11 @@ namespace solvers {
 namespace {
 
 GTEST_TEST(SolverId, Equality) {
-  // Default-constructed objects are always equal.
+  // An ID is equal to itself.
   // Use the EQ/NE form here to make sure gtest error reporting compiles okay.
-  EXPECT_EQ(SolverId{}, SolverId{});
-  EXPECT_NE(SolverId{}, SolverId{""});
+  SolverId foo{"foo"};
+  EXPECT_EQ(foo, foo);
+  EXPECT_NE(foo, SolverId{"bar"});
 
   // Named objects are equal per their assigned IDs; same name is not enough.
   // Use the op==/op!= form here to be clear which operators are being tested.
@@ -36,8 +37,7 @@ GTEST_TEST(SolverId, Move) {
   SolverId new_bar{std::move(old_bar)};
   EXPECT_EQ(old_bar.name(), "");
   EXPECT_EQ(new_bar.name(), "bar");
-  EXPECT_TRUE(old_bar == SolverId{});
-  EXPECT_FALSE(old_bar != SolverId{});
+  EXPECT_NE(new_bar, old_bar);
 }
 
 }  // namespace

--- a/drake/systems/estimators/dev/pose_estimation_test.cc
+++ b/drake/systems/estimators/dev/pose_estimation_test.cc
@@ -184,12 +184,8 @@ Eigen::Isometry3d PoseEstimation(const RigidBodyTree<double>& tree,
 
   prog.PrintSolution();
 
-  drake::solvers::SolverType solver_type{};
-  int solver_result{};
-  prog.GetSolverResult(&solver_type, &solver_result);
-  std::cout << "Solver type " << static_cast<int>(solver_type)
-            << " solution result " << static_cast<int>(solution_result)
-            << " solver result " << solver_result
+  std::cout << "Solver " << prog.GetSolverId()->name()
+            << " result " << static_cast<int>(solution_result)
             << std::endl;
   Eigen::Isometry3d T;
   T.translation() = prog.GetSolution(t);


### PR DESCRIPTION
Deprecate `MathematicalProgram::GetSolverResult`, which was only used to ask the for the `SolverType` anyway.

The goal here is to stop using `SolverType` so that the set of solvers can become open-ended.

Relates #6159.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6479)
<!-- Reviewable:end -->
