### PR TITLE
Algebraic loop detection on ports instead of systems

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -245,12 +245,12 @@ class Diagram : public System<T>,
     return result;
   }
 
-  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const final {
-    std::vector<std::pair<int, int>> pairs;
+  std::multimap<int, int> GetDirectFeedthroughs() const final {
+    std::multimap<int, int> pairs;
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
         if (this->HasDirectFeedthrough(u, v)) {
-          pairs.emplace_back(std::make_pair(u, v));
+          pairs.emplace(std::make_pair(u, v));
         }
       }
     }

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -249,89 +249,13 @@ class Diagram : public System<T>,
     std::multimap<int, int> pairs;
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
-        if (this->HasDirectFeedthrough(u, v)) {
+        if (DoHasDirectFeedthrough(u, v)) {
           pairs.emplace(std::make_pair(u, v));
         }
       }
     }
     return pairs;
   };
-
-  /// Returns true if any output of the Diagram might have direct-feedthrough
-  /// from any input of the Diagram. The implementation is quite conservative:
-  /// it will return true if there is any path on the directed acyclic graph
-  /// of subsystems that begins at any input port to the Diagram, and ends at
-  /// any System producing an output port of the Diagram, such that every System
-  /// in that path HasAnyDirectFeedthrough.
-  bool HasAnyDirectFeedthrough() const final {
-    for (int i = 0; i < this->get_num_output_ports(); i++) {
-      if (HasDirectFeedthrough(i)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /// Returns true if the given @p output_port of the Diagram might have
-  /// direct-feedthrough from any input of the Diagram. The implementation is
-  /// quite conservative: it will return true if there is any path on the
-  /// directed acyclic graph of subsystems that begins at any input port to
-  /// the Diagram, and ends at the system producing the given @p output_port,
-  /// such that every System in that path HasAnyDirectFeedthrough.
-  bool HasDirectFeedthrough(int output_port) const final {
-    DRAKE_ASSERT(output_port >= 0);
-    DRAKE_ASSERT(output_port < this->get_num_output_ports());
-    for (int i = 0; i < this->get_num_input_ports(); i++) {
-      if (HasDirectFeedthrough(i, output_port)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /// Returns true if there might be direct feedthrough from the given
-  /// @p input_port of the Diagram to the given @p output_port of the Diagram.
-  bool HasDirectFeedthrough(int input_port, int output_port) const final {
-    DRAKE_ASSERT(input_port >= 0);
-    DRAKE_ASSERT(input_port < this->get_num_input_ports());
-    DRAKE_ASSERT(output_port >= 0);
-    DRAKE_ASSERT(output_port < this->get_num_output_ports());
-
-    const PortIdentifier& target_id = input_port_ids_[input_port];
-
-    // Search the graph for a direct-feedthrough connection from the output_port
-    // back to the input_port. Maintain a set of the output port identifiers
-    // that are known to have a direct-feedthrough path to the output_port.
-    std::set<PortIdentifier> active_set;
-    active_set.insert(output_port_ids_[output_port]);
-    while (!active_set.empty()) {
-      const PortIdentifier current_id = *active_set.begin();
-      active_set.erase(current_id);
-      const System<T>* sys = current_id.first;
-      for (int i = 0; i < sys->get_num_input_ports(); ++i) {
-        if (sys->HasDirectFeedthrough(i, current_id.second)) {
-          if (sys == target_id.first) {
-            // We've found a direct-feedthrough path to the input_port.
-            return true;
-          } else {
-            // We've found an intermediate input port has a direct-feedthrough
-            // path to the output_port. Add the upstream output port (if there
-            // is one) to the active set.
-            const PortIdentifier pos(sys, i);
-            auto it = dependency_graph_.find(pos);
-            if (it != dependency_graph_.end()) {
-              const PortIdentifier& upstream_output = it->second;
-              active_set.insert(upstream_output);
-            }
-          }
-        }
-      }
-    }
-    // If there are no intermediate output ports with a direct-feedthrough path
-    // to the output_port, there is no direct feedthrough to it from the
-    // input_port.
-    return false;
-  }
 
   /// Allocates a DiagramEventCollection for this Diagram.
   /// @sa System::AllocateCompositeEventCollection().
@@ -1026,6 +950,50 @@ class Diagram : public System<T>,
   }
 
  private:
+  /// Returns true if there might be direct feedthrough from the given
+  /// @p input_port of the Diagram to the given @p output_port of the Diagram.
+  bool DoHasDirectFeedthrough(int input_port, int output_port) const {
+    DRAKE_ASSERT(input_port >= 0);
+    DRAKE_ASSERT(input_port < this->get_num_input_ports());
+    DRAKE_ASSERT(output_port >= 0);
+    DRAKE_ASSERT(output_port < this->get_num_output_ports());
+
+    const PortIdentifier& target_id = input_port_ids_[input_port];
+
+    // Search the graph for a direct-feedthrough connection from the output_port
+    // back to the input_port. Maintain a set of the output port identifiers
+    // that are known to have a direct-feedthrough path to the output_port.
+    std::set<PortIdentifier> active_set;
+    active_set.insert(output_port_ids_[output_port]);
+    while (!active_set.empty()) {
+      const PortIdentifier current_id = *active_set.begin();
+      active_set.erase(current_id);
+      const System<T>* sys = current_id.first;
+      for (int i = 0; i < sys->get_num_input_ports(); ++i) {
+        if (sys->HasDirectFeedthrough(i, current_id.second)) {
+          if (sys == target_id.first) {
+            // We've found a direct-feedthrough path to the input_port.
+            return true;
+          } else {
+            // We've found an intermediate input port has a direct-feedthrough
+            // path to the output_port. Add the upstream output port (if there
+            // is one) to the active set.
+            const PortIdentifier pos(sys, i);
+            auto it = dependency_graph_.find(pos);
+            if (it != dependency_graph_.end()) {
+              const PortIdentifier& upstream_output = it->second;
+              active_set.insert(upstream_output);
+            }
+          }
+        }
+      }
+    }
+    // If there are no intermediate output ports with a direct-feedthrough path
+    // to the output_port, there is no direct feedthrough to it from the
+    // input_port.
+    return false;
+  }
+
   template <typename EventType>
   std::unique_ptr<EventCollection<EventType>> AllocateForcedEventCollection(
       std::function<

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -250,7 +250,7 @@ class Diagram : public System<T>,
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
         if (DoHasDirectFeedthrough(u, v)) {
-          pairs.emplace(std::make_pair(u, v));
+          pairs.emplace(u, v);
         }
       }
     }

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -972,7 +972,7 @@ class Diagram : public System<T>,
       const System<T>* sys = current_id.first;
       for (int i = 0; i < sys->get_num_input_ports(); ++i) {
         if (sys->HasDirectFeedthrough(i, current_id.second)) {
-          if (sys == target_id.first) {
+          if (sys == target_id.first && i == target_id.second) {
             // We've found a direct-feedthrough path to the input_port.
             return true;
           } else {

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -16,8 +16,7 @@
 namespace drake {
 namespace systems {
 
-/// DiagramBuilder is a factory class for Diagram. It collects the dependency
-/// graph of constituent systems, and topologically sorts them. It is single
+/// DiagramBuilder is a factory class for Diagram. It is single
 /// use: after calling Build or BuildInto, DiagramBuilder gives up ownership
 /// of the constituent systems, and should therefore be discarded.
 ///
@@ -340,8 +339,8 @@ class DiagramBuilder {
   // the systems on which they depend.
   std::map<PortIdentifier, PortIdentifier> dependency_graph_;
 
-  // The unsorted set of Systems in this DiagramBuilder. Used for fast
-  // membership queries.
+  // A mirror on the systems in the diagram. Should have the same values as
+  // registered_systems_. Used for fast membership queries.
   std::set<const System<T>*> systems_;
   // The Systems in this DiagramBuilder, in the order they were registered.
   std::vector<std::unique_ptr<System<T>>> registered_systems_;

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <set>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -341,7 +342,7 @@ class DiagramBuilder {
 
   // A mirror on the systems in the diagram. Should have the same values as
   // registered_systems_. Used for fast membership queries.
-  std::set<const System<T>*> systems_;
+  std::unordered_set<const System<T>*> systems_;
   // The Systems in this DiagramBuilder, in the order they were registered.
   std::vector<std::unique_ptr<System<T>>> registered_systems_;
 };

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -317,7 +317,7 @@ class DiagramBuilder {
     blueprint.output_port_ids = output_port_ids_;
     blueprint.dependency_graph = dependency_graph_;
     for (const auto& system : registered_systems_) {
-      blueprint.sorted_systems.push_back(system.get());
+      blueprint.systems.push_back(system.get());
     }
     return blueprint;
   }

--- a/drake/systems/framework/diagram_continuous_state.h
+++ b/drake/systems/framework/diagram_continuous_state.h
@@ -22,7 +22,7 @@ class DiagramContinuousState : public ContinuousState<T> {
   /// which are not owned by this object and must outlive it.
   ///
   /// The DiagramContinuousState vector xc = [q v z] will have the same
-  /// ordering as the @p substates parameter, which should be the sort order of
+  /// ordering as the @p substates parameter, which should be the order of
   /// the Diagram itself. This fact is an implementation detail that should
   /// only be of interest to framework authors. Everyone else can just use
   /// Diagram<T>::GetMutableSubsystemState.

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -196,13 +196,13 @@ class LeafSystem : public System<T> {
     return AllocateDiscreteState();
   }
 
-  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const final {
-    std::vector<std::pair<int, int>> pairs;
+  std::multimap<int, int> GetDirectFeedthroughs() const final {
+    std::multimap<int, int> pairs;
     auto sparsity = MakeSparsityMatrix();
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
         if (DoHasDirectFeedthrough(sparsity.get(), u, v)) {
-          pairs.emplace_back(std::make_pair(u, v));
+          pairs.emplace(std::make_pair(u, v));
         }
       }
     }

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -196,6 +196,24 @@ class LeafSystem : public System<T> {
     return AllocateDiscreteState();
   }
 
+  /// Reports all direct feedthroughs from input ports to output ports. For
+  /// a system with m input ports, i₀, i₁, ..., iₘ₋₁, and n input ports,
+  /// o₀, o₁, ..., oₙ₋₁, the output will contain all pairs (u, v) such that
+  /// 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough from input iᵤ
+  /// to output oᵥ.
+  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const final {
+    std::vector<std::pair<int, int>> pairs;
+    auto sparsity = MakeSparsityMatrix();
+    for (int u = 0; u < this->get_num_input_ports(); ++u) {
+      for (int v = 0; v < this->get_num_output_ports(); ++v) {
+        if (DoHasDirectFeedthrough(sparsity.get(), u, v)) {
+          pairs.emplace_back(std::make_pair(u, v));
+        }
+      }
+    }
+    return pairs;
+  };
+
   /// Returns `true` if any of the inputs to the system is directly
   /// fed through to any of its outputs and `false` otherwise.
   bool HasAnyDirectFeedthrough() const final {

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -203,7 +203,7 @@ class LeafSystem : public System<T> {
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
         if (DoHasDirectFeedthrough(sparsity.get(), u, v)) {
-          pairs.emplace(std::make_pair(u, v));
+          pairs.emplace(u, v);
         }
       }
     }

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <map>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -197,8 +198,8 @@ class LeafSystem : public System<T> {
   }
 
   std::multimap<int, int> GetDirectFeedthroughs() const final {
-    std::multimap<int, int> pairs;
     auto sparsity = MakeSparsityMatrix();
+    std::multimap<int, int> pairs;
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
         if (DoHasDirectFeedthrough(sparsity.get(), u, v)) {
@@ -208,39 +209,6 @@ class LeafSystem : public System<T> {
     }
     return pairs;
   };
-
-  /// Returns `true` if any of the inputs to the system is directly
-  /// fed through to any of its outputs and `false` otherwise.
-  bool HasAnyDirectFeedthrough() const final {
-    auto sparsity = MakeSparsityMatrix();
-    for (int i = 0; i < this->get_num_input_ports(); ++i) {
-      for (int j = 0; j < this->get_num_output_ports(); ++j) {
-        if (DoHasDirectFeedthrough(sparsity.get(), i, j)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /// Returns true if there is direct-feedthrough from any input port to the
-  /// given @p output_port, and false otherwise.
-  bool HasDirectFeedthrough(int output_port) const final {
-    auto sparsity = MakeSparsityMatrix();
-    for (int i = 0; i < this->get_num_input_ports(); ++i) {
-      if (DoHasDirectFeedthrough(sparsity.get(), i, output_port)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /// Returns true if there is direct-feedthrough from the given @p input_port
-  /// to the given @p output_port, and false otherwise.
-  bool HasDirectFeedthrough(int input_port, int output_port) const final {
-    auto sparsity = MakeSparsityMatrix();
-    return DoHasDirectFeedthrough(sparsity.get(), input_port, output_port);
-  }
 
  protected:
   LeafSystem() {

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -196,11 +196,6 @@ class LeafSystem : public System<T> {
     return AllocateDiscreteState();
   }
 
-  /// Reports all direct feedthroughs from input ports to output ports. For
-  /// a system with m input ports, i₀, i₁, ..., iₘ₋₁, and n input ports,
-  /// o₀, o₁, ..., oₙ₋₁, the output will contain all pairs (u, v) such that
-  /// 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough from input iᵤ
-  /// to output oᵥ.
   std::vector<std::pair<int, int>> GetDirectFeedthroughs() const final {
     std::vector<std::pair<int, int>> pairs;
     auto sparsity = MakeSparsityMatrix();

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -170,21 +170,36 @@ class System {
   ///
   /// This method is virtual for framework purposes only. User code should not
   /// override it.
-  virtual bool HasAnyDirectFeedthrough() const = 0;
+  bool HasAnyDirectFeedthrough() const {
+    return GetDirectFeedthroughs().size() > 0;
+  }
 
   /// Returns true if there might be direct-feedthrough from any input port to
   /// the given @p output_port, and false otherwise.
   ///
   /// This method is virtual for framework purposes only. User code should not
   /// override it.
-  virtual bool HasDirectFeedthrough(int output_port) const = 0;
+  bool HasDirectFeedthrough(int output_port) const {
+    std::multimap<int, int> pairs = GetDirectFeedthroughs();
+    for (const auto& pair : pairs) {
+      if (pair.second == output_port) return true;
+    }
+    return false;
+  }
 
   /// Returns true if there might be direct-feedthrough from the given
   /// @p input_port to the given @p output_port, and false otherwise.
   ///
   /// This method is virtual for framework purposes only. User code should not
   /// override it.
-  virtual bool HasDirectFeedthrough(int input_port, int output_port) const = 0;
+  bool HasDirectFeedthrough(int input_port, int output_port) const {
+    std::multimap<int, int> pairs = GetDirectFeedthroughs();
+    auto range = pairs.equal_range(input_port);
+    for (auto i = range.first; i != range.second; ++i) {
+      if (i->second == output_port) return true;
+    }
+    return false;
+  }
 
   //@}
 

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -160,25 +160,22 @@ class System {
 
   /// Reports all direct feedthroughs from input ports to output ports. For
   /// a system with m input ports: `I = i₀, i₁, ..., iₘ₋₁`, and n output ports,
-  /// `O = o₀, o₁, ..., oₙ₋₁`, the return map will contain all pairs
-  /// (u, v) such that 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough
-  /// from input iᵤ to each output oᵥ.
+  /// `O = o₀, o₁, ..., oₙ₋₁`, the return map will contain pairs (u, v) such
+  /// that
+  ///     - 0 ≤ u < m,
+  ///     - 0 ≤ v < n,
+  ///     - and there _might_ be a direct feedthrough from input iᵤ to each
+  ///       output oᵥ.
   virtual std::multimap<int, int> GetDirectFeedthroughs() const = 0;
 
   /// Returns `true` if any of the inputs to the system might be directly
   /// fed through to any of its outputs and `false` otherwise.
-  ///
-  /// This method is virtual for framework purposes only. User code should not
-  /// override it.
   bool HasAnyDirectFeedthrough() const {
     return GetDirectFeedthroughs().size() > 0;
   }
 
   /// Returns true if there might be direct-feedthrough from any input port to
   /// the given @p output_port, and false otherwise.
-  ///
-  /// This method is virtual for framework purposes only. User code should not
-  /// override it.
   bool HasDirectFeedthrough(int output_port) const {
     std::multimap<int, int> pairs = GetDirectFeedthroughs();
     for (const auto& pair : pairs) {
@@ -189,9 +186,6 @@ class System {
 
   /// Returns true if there might be direct-feedthrough from the given
   /// @p input_port to the given @p output_port, and false otherwise.
-  ///
-  /// This method is virtual for framework purposes only. User code should not
-  /// override it.
   bool HasDirectFeedthrough(int input_port, int output_port) const {
     std::multimap<int, int> pairs = GetDirectFeedthroughs();
     auto range = pairs.equal_range(input_port);

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -157,6 +157,13 @@ class System {
     }
   }
 
+  /// Reports all direct feedthroughs from input ports to output ports. For
+  /// a system with m input ports, i₀, i₁, ..., iₘ₋₁, and n input ports,
+  /// o₀, o₁, ..., oₙ₋₁, the output will contain all pairs (u, v) such that
+  /// 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough from input iᵤ
+  /// to output oᵥ.
+  virtual std::vector<std::pair<int, int>> GetDirectFeedthroughs() const = 0;
+
   /// Returns `true` if any of the inputs to the system might be directly
   /// fed through to any of its outputs and `false` otherwise.
   ///

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <limits>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -158,11 +159,11 @@ class System {
   }
 
   /// Reports all direct feedthroughs from input ports to output ports. For
-  /// a system with m input ports, i₀, i₁, ..., iₘ₋₁, and n input ports,
-  /// o₀, o₁, ..., oₙ₋₁, the output will contain all pairs (u, v) such that
-  /// 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough from input iᵤ
-  /// to output oᵥ.
-  virtual std::vector<std::pair<int, int>> GetDirectFeedthroughs() const = 0;
+  /// a system with m input ports: `I = i₀, i₁, ..., iₘ₋₁`, and n output ports,
+  /// `O = o₀, o₁, ..., oₙ₋₁`, the return map will contain all pairs
+  /// (u, v) such that 0 ≤ u < m, 0 ≤ v < n, and there is a direct feedthrough
+  /// from input iᵤ to each output oᵥ.
+  virtual std::multimap<int, int> GetDirectFeedthroughs() const = 0;
 
   /// Returns `true` if any of the inputs to the system might be directly
   /// fed through to any of its outputs and `false` otherwise.

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -75,8 +75,8 @@ GTEST_TEST(DiagramBuilderTest, AlgebraicLoop) {
 }
 
 // Tests that a cycle which is not an algebraic loop is recognized as valid.
-// Both systems have direct feedthrough; but they are not actually wired into an
-// algebraic loop at the port level.
+// The system has direct feedthrough; but, at the port level, it is wired
+// without an algebraic loop at the port level.
 GTEST_TEST(DiagramBuilderTest, CycleButNoLoopPortLevel) {
   DiagramBuilder<double> builder;
 

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -95,7 +95,7 @@ GTEST_TEST(DiagramBuilderTest, CycleButNoLoopPortLevel) {
 
 // Contrasts with CycleButNoLoopPortLevel. In this case, the cycle *does*
 // represent an algebraic loop.
-GTEST_TEST(DiagramBuilderTest, CycleAndLoopPortLevel) {
+GTEST_TEST(DiagramBuilderTest, CycleAtLoopPortLevel) {
   DiagramBuilder<double> builder;
 
   //    +----------+
@@ -137,8 +137,6 @@ GTEST_TEST(DiagramBuilderTest, CycleButNoAlgebraicLoopSystemLevel) {
   integrator->set_name("integrator");
 
   builder.Connect(integrator->get_output_port(), adder->get_input_port(1));
-  builder.ExportInput(adder->get_input_port(0));
-  builder.ExportOutput(integrator->get_output_port());
 
   // There is no algebraic loop, so we should not throw.
   EXPECT_NO_THROW(builder.Build());
@@ -156,8 +154,6 @@ GTEST_TEST(DiagramBuilderTest, CascadedNonDirectFeedthrough) {
 
   builder.Connect(integrator1->get_output_port(),
                   integrator2->get_input_port());
-  builder.ExportInput(integrator1->get_input_port());
-  builder.ExportOutput(integrator2->get_output_port());
 
   // There is no algebraic loop, so we should not throw.
   EXPECT_NO_THROW(builder.Build());

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -24,24 +24,21 @@ class ConstAndEcho : public LeafSystem<T> {
  public:
   ConstAndEcho() {
     this->DeclareInputPort(kVectorValued, 1);
-    echo_port_ = this->DeclareVectorOutputPort(BasicVector<T>(1),
-                                               &ConstAndEcho::CalcEcho)
-                     .get_index();
-    const_port_ = this->DeclareVectorOutputPort(BasicVector<T>(1),
-                                                &ConstAndEcho::CalcConstant)
-        .get_index();
+    this->DeclareVectorOutputPort(BasicVector<T>(1), &ConstAndEcho::CalcEcho);
+    this->DeclareVectorOutputPort(BasicVector<T>(1),
+                                  &ConstAndEcho::CalcConstant);
   }
 
   const systems::InputPortDescriptor<T>& get_vec_input_port() {
     return this->get_input_port(0);
   }
 
-  const systems::OutputPort<T>& get_const_output_port() const {
-    return systems::System<T>::get_output_port(const_port_);
+  const systems::OutputPort<T>& get_echo_output_port() const {
+    return systems::System<T>::get_output_port(0);
   }
 
-  const systems::OutputPort<T>& get_echo_output_port() const {
-    return systems::System<T>::get_output_port(echo_port_);
+  const systems::OutputPort<T>& get_const_output_port() const {
+    return systems::System<T>::get_output_port(1);
   }
 
   void CalcConstant(const Context<T>& context,
@@ -57,10 +54,6 @@ class ConstAndEcho : public LeafSystem<T> {
   ConstAndEcho<symbolic::Expression>* DoToSymbolic() const override {
     return new ConstAndEcho<symbolic::Expression>();
   }
-
- private:
-  int const_port_{-1};
-  int echo_port_{-1};
 };
 
 // Tests that an exception is thrown if the diagram contains an algebraic loop.

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -98,7 +98,7 @@ GTEST_TEST(DiagramBuilderTest, CycleButNoLoopPortLevel) {
   auto echo = builder.AddSystem<ConstAndEcho>();
   echo->set_name("echo");
   builder.Connect(echo->get_const_output_port(), echo->get_vec_input_port());
-  EXPECT_THROW(builder.Build(), std::logic_error);
+  EXPECT_NO_THROW(builder.Build());
 }
 
 // Tests that a cycle which is not an algebraic loop is recognized as valid.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -712,6 +712,110 @@ GTEST_TEST(FeedbackDiagramTest, DeletionIsMemoryClean) {
   EXPECT_NO_THROW(context.reset());
 }
 
+// A simple class that consumes *two* inputs and passes one input through. The
+// sink input (S) is consumed, the feed through input (F) is passed through to
+// the output (O). This system has direct feedthrough, but only with respect to
+// one input. Support class for the PortDependentFeedthroughTest.
+//      +-----------+
+//      +--+        |
+//      +S |        |
+//      +--+     +--+
+//      |     +->+O |
+//      +--+  |  +--+
+//      |F +--+     |
+//      +--+        |
+//      +-----------+
+class Reduce : public LeafSystem<double> {
+ public:
+  Reduce() {
+    feedthrough_input_ = this->DeclareInputPort(kVectorValued, 1).get_index();
+    sink_input_ = this->DeclareInputPort(kVectorValued, 1).get_index();
+    this->DeclareVectorOutputPort(BasicVector<double>(1),
+                                  &Reduce::CalcFeedthrough);
+  }
+
+  const systems::InputPortDescriptor<double>& get_sink_input() {
+    return this->get_input_port(sink_input_);
+  }
+
+  const systems::InputPortDescriptor<double>& get_feedthrough_input() {
+    return this->get_input_port(feedthrough_input_);
+  }
+
+  void CalcFeedthrough(const Context<double>& context,
+                       BasicVector<double>* output) const {
+    const BasicVector<double>* input_vector =
+        this->EvalVectorInput(context, feedthrough_input_);
+    output->get_mutable_value() = input_vector->get_value();
+  }
+
+  bool DoHasDirectFeedthrough(const SparsityMatrix* sparsity,
+                              int input_port, int output_port) const override {
+    return input_port == feedthrough_input_;
+  }
+
+ private:
+  int feedthrough_input_{-1};
+  int sink_input_{-1};
+};
+
+// Diagram inputs and outputs are connected by systems that have direct
+// feedthrough, but the input and output are not connected by such a path.
+GTEST_TEST(PortDependentFeedthroughTest, DetectNoFeedthrough) {
+// This is a diagram that wraps a Reduce Leaf system, exporting the output
+// and the *sink* input. There should be *no* direct feedthrough on the diagram.
+//        +-----------------+
+//        |                 |
+//        |  +-----------+  |
+//        |  +--+        |  |
+//   I +---->+S |        |  |
+//        |  +--+     +--+  |
+//        |  |     +->+O +------> O
+//        |  +--+  |  +--+  |
+//        |  |F +--+     |  |
+//        |  +--+        |  |
+//        |  +-----------+  |
+//        |                 |
+//        +-----------------+
+  DiagramBuilder<double> builder;
+  auto reduce = builder.AddSystem<Reduce>();
+  builder.ExportInput(reduce->get_sink_input());
+  builder.ExportOutput(reduce->get_output_port(0));
+  auto diagram = builder.Build();
+  EXPECT_FALSE(diagram->HasAnyDirectFeedthrough());
+  EXPECT_FALSE(diagram->HasDirectFeedthrough(0));
+  EXPECT_FALSE(diagram->HasDirectFeedthrough(0, 0));
+}
+
+// Diagram inputs and outputs are connected by systems that have direct
+// feedthrough, and the input and output *are* connected by such a path.
+GTEST_TEST(PortDependentFeedthroughTest, DetectFeedthrough) {
+// This is a diagram that wraps a Reduce Leaf system, exporting the output
+// and the *feedthrough* input. There should be direct feedthrough on the
+// diagram.
+//        +-----------------+
+//        |                 |
+//        |  +-----------+  |
+//        |  +--+        |  |
+//        |  |S |        |  |
+//        |  +--+     +--+  |
+//        |  |     +->+O +------> O
+//        |  +--+  |  +--+  |
+//   I +---->|F +--+     |  |
+//        |  +--+        |  |
+//        |  +-----------+  |
+//        |                 |
+//        +-----------------+
+  DiagramBuilder<double> builder;
+  auto reduce = builder.AddSystem<Reduce>();
+  builder.ExportInput(reduce->get_feedthrough_input());
+  builder.ExportOutput(reduce->get_output_port(0));
+  auto diagram = builder.Build();
+  EXPECT_TRUE(diagram->HasAnyDirectFeedthrough());
+  EXPECT_TRUE(diagram->HasDirectFeedthrough(0));
+  EXPECT_TRUE(diagram->HasDirectFeedthrough(0, 0));
+}
+
 // A vector with a scalar configuration and scalar velocity.
 class SecondOrderStateVector : public BasicVector<double> {
  public:

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -811,16 +811,16 @@ GTEST_TEST(SecondOrderStateTest, MapVelocityToQDot) {
   // The order of these derivatives is arbitrary, so this test is brittle.
   // TODO(david-german-tri): Use UnorderedElementsAre once gmock is available
   // in the superbuild. https://github.com/RobotLocomotion/drake/issues/3133
-  EXPECT_EQ(qdot.GetAtIndex(0), 34);
-  EXPECT_EQ(qdot.GetAtIndex(1), 26);
+  EXPECT_EQ(qdot.GetAtIndex(0), 26);
+  EXPECT_EQ(qdot.GetAtIndex(1), 34);
 
   // Now map the configuration derivatives back to v.
   // TODO(david-german-tri): Address the issue broached immediately above
   // here too.
   BasicVector<double> vmutable(v.size());
   diagram.MapQDotToVelocity(*context, qdot, &vmutable);
-  EXPECT_EQ(vmutable.GetAtIndex(0), 17);
-  EXPECT_EQ(vmutable.GetAtIndex(1), 13);
+  EXPECT_EQ(vmutable.GetAtIndex(0), 13);
+  EXPECT_EQ(vmutable.GetAtIndex(1), 17);
 }
 
 // Test for GetSystems.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -759,8 +759,9 @@ class Reduce : public LeafSystem<double> {
   int sink_input_{-1};
 };
 
-// Diagram inputs and outputs are connected by systems that have direct
-// feedthrough, but the input and output are not connected by such a path.
+// Diagram input and output are connected by a system that has direct
+// feedthrough, but the path between diagram input and output doesn't follow
+// this path.
 GTEST_TEST(PortDependentFeedthroughTest, DetectNoFeedthrough) {
 // This is a diagram that wraps a Reduce Leaf system, exporting the output
 // and the *sink* input. There should be *no* direct feedthrough on the diagram.
@@ -787,8 +788,8 @@ GTEST_TEST(PortDependentFeedthroughTest, DetectNoFeedthrough) {
   EXPECT_FALSE(diagram->HasDirectFeedthrough(0, 0));
 }
 
-// Diagram inputs and outputs are connected by systems that have direct
-// feedthrough, and the input and output *are* connected by such a path.
+// Diagram input and output are connected by a system that has direct
+// feedthrough, and the input and output *are* connected by that path.
 GTEST_TEST(PortDependentFeedthroughTest, DetectFeedthrough) {
 // This is a diagram that wraps a Reduce Leaf system, exporting the output
 // and the *feedthrough* input. There should be direct feedthrough on the

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -808,15 +808,12 @@ GTEST_TEST(SecondOrderStateTest, MapVelocityToQDot) {
       context->get_continuous_state()->get_generalized_velocity();
   diagram.MapVelocityToQDot(*context, v, &qdot);
 
-  // The order of these derivatives is arbitrary, so this test is brittle.
-  // TODO(david-german-tri): Use UnorderedElementsAre once gmock is available
-  // in the superbuild. https://github.com/RobotLocomotion/drake/issues/3133
+  // The order of these derivatives is defined to be the same as the order
+  // subsystems are added.
   EXPECT_EQ(qdot.GetAtIndex(0), 26);
   EXPECT_EQ(qdot.GetAtIndex(1), 34);
 
   // Now map the configuration derivatives back to v.
-  // TODO(david-german-tri): Address the issue broached immediately above
-  // here too.
   BasicVector<double> vmutable(v.size());
   diagram.MapQDotToVelocity(*context, qdot, &vmutable);
   EXPECT_EQ(vmutable.GetAtIndex(0), 13);

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -916,7 +916,7 @@ GTEST_TEST(FeedthroughTest, DefaultWithBothInputsAndOutputs) {
   EXPECT_TRUE(system.HasDirectFeedthrough(0, 0));
   // Confirm all pairs are returned.
   std::multimap<int, int> expected;
-  expected.emplace(std::make_pair(0, 0));
+  expected.emplace(0, 0);
   EXPECT_EQ(system.GetDirectFeedthroughs(), expected);
 }
 
@@ -950,7 +950,7 @@ GTEST_TEST(FeedthroughTest, DefaultWithMultipleIoPorts) {
     system.AddAbstractInputPort();
     for (int o = 0; o < output_count; ++o) {
       if (i == 0) system.AddAbstractOutputPort();
-      expected.emplace(std::make_pair(i, o));
+      expected.emplace(i, o);
     }
   }
   EXPECT_TRUE(system.HasAnyDirectFeedthrough());
@@ -1002,8 +1002,8 @@ GTEST_TEST(FeedthroughTest, ManualSparsity) {
   EXPECT_FALSE(system.HasDirectFeedthrough(1, 1));
   // Confirm all pairs are returned.
   std::multimap<int, int> expected;
-  expected.emplace(std::make_pair(1, 0));
-  expected.emplace(std::make_pair(0, 1));
+  expected.emplace(1, 0);
+  expected.emplace(0, 1);
   auto feedthrough_pairs = system.GetDirectFeedthroughs();
   EXPECT_EQ(feedthrough_pairs, expected);
 }
@@ -1057,8 +1057,8 @@ GTEST_TEST(FeedthroughTest, SymbolicSparsity) {
   EXPECT_FALSE(system.HasDirectFeedthrough(1, 1));
   // Confirm all pairs are returned.
   std::multimap<int, int> expected;
-  expected.emplace(std::make_pair(1, 0));
-  expected.emplace(std::make_pair(0, 1));
+  expected.emplace(1, 0);
+  expected.emplace(0, 1);
   auto feedthrough_pairs = system.GetDirectFeedthroughs();
   EXPECT_EQ(feedthrough_pairs, expected);
 }

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -74,24 +74,16 @@ class TestSystem : public System<double> {
     return *port_ptr;
   }
 
-  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
-    std::vector<std::pair<int, int>> pairs;
+  std::multimap<int, int> GetDirectFeedthroughs() const override {
+    std::multimap<int, int> pairs;
     // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
     // ports.
     for (int i = 0; i < get_num_input_ports(); ++i) {
       for (int o = 0; o < get_num_output_ports(); ++o) {
-        pairs.emplace_back(i, o);
+        pairs.emplace(i, o);
       }
     }
     return pairs;
-  }
-
-  bool HasAnyDirectFeedthrough() const override { return true; }
-
-  bool HasDirectFeedthrough(int output_port) const override { return true; }
-
-  bool HasDirectFeedthrough(int input_port, int output_port) const override {
-    return true;
   }
 
   int get_publish_count() const { return publish_count_; }
@@ -423,24 +415,16 @@ class ValueIOTestSystem : public System<T> {
 
   void SetDefaults(Context<T>* context) const override {}
 
-  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
-    std::vector<std::pair<int, int>> pairs;
+  std::multimap<int, int> GetDirectFeedthroughs() const override {
+    std::multimap<int, int> pairs;
     // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
     // ports.
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
       for (int o = 0; o < this->get_num_output_ports(); ++o) {
-        pairs.emplace_back(i, o);
+        pairs.emplace(i, o);
       }
     }
     return pairs;
-  }
-
-  bool HasAnyDirectFeedthrough() const override { return true; }
-
-  bool HasDirectFeedthrough(int output_port) const override { return true; }
-
-  bool HasDirectFeedthrough(int input_port, int output_port) const override {
-    return true;
   }
 
   // Appends "output" to input(0) for output(0).

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -76,8 +76,7 @@ class TestSystem : public System<double> {
 
   std::multimap<int, int> GetDirectFeedthroughs() const override {
     std::multimap<int, int> pairs;
-    // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
-    // ports.
+    // Report *everything* as having direct feedthrough.
     for (int i = 0; i < get_num_input_ports(); ++i) {
       for (int o = 0; o < get_num_output_ports(); ++o) {
         pairs.emplace(i, o);
@@ -417,8 +416,7 @@ class ValueIOTestSystem : public System<T> {
 
   std::multimap<int, int> GetDirectFeedthroughs() const override {
     std::multimap<int, int> pairs;
-    // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
-    // ports.
+    // Report *everything* as having direct feedthrough.
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
       for (int o = 0; o < this->get_num_output_ports(); ++o) {
         pairs.emplace(i, o);

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -74,6 +74,13 @@ class TestSystem : public System<double> {
     return *port_ptr;
   }
 
+  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
+    std::vector<std::pair<int, int>> pairs;
+    // Single input port feeds through to first output port.
+    pairs.emplace_back(0, 0);
+    return pairs;
+  }
+
   bool HasAnyDirectFeedthrough() const override { return true; }
 
   bool HasDirectFeedthrough(int output_port) const override { return true; }
@@ -410,6 +417,13 @@ class ValueIOTestSystem : public System<T> {
                        State<T>* state) const override {}
 
   void SetDefaults(Context<T>* context) const override {}
+
+  std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
+    std::vector<std::pair<int, int>> pairs;
+    // Single input port feeds through to second output port.
+    pairs.emplace_back(0, 1);
+    return pairs;
+  }
 
   bool HasAnyDirectFeedthrough() const override { return true; }
 

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -76,8 +76,13 @@ class TestSystem : public System<double> {
 
   std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
     std::vector<std::pair<int, int>> pairs;
-    // Single input port feeds through to first output port.
-    pairs.emplace_back(0, 0);
+    // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
+    // ports.
+    for (int i = 0; i < get_num_input_ports(); ++i) {
+      for (int o = 0; o < get_num_output_ports(); ++o) {
+        pairs.emplace_back(i, o);
+      }
+    }
     return pairs;
   }
 
@@ -420,8 +425,13 @@ class ValueIOTestSystem : public System<T> {
 
   std::vector<std::pair<int, int>> GetDirectFeedthroughs() const override {
     std::vector<std::pair<int, int>> pairs;
-    // Single input port feeds through to second output port.
-    pairs.emplace_back(0, 1);
+    // Support `HasDirectFeedthrough(int, int)`'s behavior: returns true for all
+    // ports.
+    for (int i = 0; i < this->get_num_input_ports(); ++i) {
+      for (int o = 0; o < this->get_num_output_ports(); ++o) {
+        pairs.emplace_back(i, o);
+      }
+    }
     return pairs;
   }
 


### PR DESCRIPTION
Resolves #6461.

`DiagramBuilder` conservatively detected algebraic loops by examining *systems* and considering the possibility of an algebraic loop if the system had *any* direct feedthrough.

This changes the analysis to actually follow *port* dependencies. So, it's possible to have a system consisting of systems that all have direct feedtrhough, but because the ports aren't connected in a way that depends on that feedthrough, there are no algebraic loops. 

Also, `Diagram` and `DiagramBuilder` had a relic of "sorting" the systems that has not been valid for a while. This also removes the (now impossible) sorting algorithm, expectation, and code artifacts.

The changes are as follows:

1. Add unit test that for the case where the *old* code would detect a loop, but the new code does not: `diagram_builder_test.cc`
2. Update loop algorithm:
  - `diagram_builder.h` - the actual algorithm
  - `system.h`, `diagram.h`, `leaf_system.h` (and their tests) - provide *new* API so that all pairs of input-output ports on a single system with a direct-feedthrough connection can be reported efficiently. Necessary to implement the port-level loop detection.
3. Removal or sorting artifacts. This includes modifying initialization of `Diagram` from `DiagramBuilder`. Affects: `diagram.h` and `diagram_builder.h`

NOTE: If there is confusion between these two related pieces of work, it can be broken into two PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6480)
<!-- Reviewable:end -->
