### PR TITLE
Improve buildifier

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -261,8 +261,10 @@ new_go_repository(
 github_archive(
     name = "com_github_bazelbuild_buildtools",
     repository = "bazelbuild/buildtools",
-    commit = "0.4.5",
-    sha256 = "7a732ea12d88ddbf9adc99ff5b5c39bfda53b6286ecc79c3bc082d5f53f46f44",
+    # TODO(mwoehlke-kitware): Bump this commit to a release tag once it is
+    # incorporated in a released version.
+    commit = "7ce605fb1585076ed681e37d82d0ef529244b23a",
+    sha256 = "c6210992d328212a7752a2c888a15f5c597dbf31f03ac0d59457ceff2928a30b",
 )
 
 github_archive(

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -317,8 +317,8 @@ cc_binary(
 # (i.e. in Drake itself; not externals).
 install(
     name = "install",
-    guess_hdrs = "WORKSPACE",
-    hdr_dest = "include/drake",
     targets = ["libdrake.so"],
+    hdr_dest = "include/drake",
+    guess_hdrs = "WORKSPACE",
     deps = ["//drake/bindings:install"],
 )

--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -209,12 +209,12 @@ py_library(
 
 install(
     name = "install",
-    library_dest = "lib/python2.7/site-packages",
-    library_strip_prefix = ["python"],
-    py_strip_prefix = ["python"],
     targets = [
         ":pydrake",
     ] + PYDRAKE_SO_DATA,
+    library_dest = "lib/python2.7/site-packages",
+    library_strip_prefix = ["python"],
+    py_strip_prefix = ["python"],
     visibility = ["//visibility:public"],
 )
 

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -367,15 +367,15 @@ drake_cc_binary(
 
 install(
     name = "install",
-    allowed_externals = [DRAKE_RESOURCE_SENTINEL],
-    data_dest = "share/drake",
-    guess_data = "WORKSPACE",
+    targets = [":resource_tool"],
     # TODO(jwnimmer-tri) The install rule should offer more specific options
     # for putting programs into libexec and including the workspace and/or
     # package name in the installed path.  For now, we'll just specify it
     # manually.
     runtime_dest = "libexec/drake/drake/common",
-    targets = [":resource_tool"],
+    data_dest = "share/drake",
+    guess_data = "WORKSPACE",
+    allowed_externals = [DRAKE_RESOURCE_SENTINEL],
 )
 
 # === test/ ===

--- a/tools/bazel_lint.bzl
+++ b/tools/bazel_lint.bzl
@@ -24,7 +24,10 @@ def _bazel_lint(name, files, ignore):
             name = name + "_buildifier",
             size = "small",
             srcs = ["@drake//tools:buildifier-test.sh"],
-            data = files + ["@drake//tools:buildifier"],
+            data = files + [
+                "@drake//tools:buildifier",
+                "@drake//tools:buildifier-tables.json",
+            ],
             args = ["$(location %s)" % f for f in files],
             tags = ["buildifier", "lint"],
         )

--- a/tools/buildifier-tables.json
+++ b/tools/buildifier-tables.json
@@ -1,0 +1,51 @@
+{
+  "IsLabelArg": {
+  },
+  "LabelBlacklist": {
+  },
+  "IsSortableListArg": {
+    "allowed_externals": true
+  },
+  "SortableWhitelist": {
+    "install.data": true,
+    "install.docs": true,
+    "install.hdrs": true,
+    "install.targets": true,
+    "install_files.files": true
+  },
+  "NamePriority": {
+    "install.targets": 400,
+    "install.archive_dest": 401,
+    "install.archive_strip_prefix": 401,
+    "install.library_dest": 401,
+    "install.library_strip_prefix": 401,
+    "install.runtime_dest": 401,
+    "install.runtime_strip_prefix": 401,
+    "install.java_dest": 402,
+    "install.java_strip_prefix": 402,
+    "install.py_dest": 402,
+    "install.py_strip_prefix": 402,
+    "install.hdrs": 410,
+    "install.hdr_dest": 411,
+    "install.hdr_strip_prefix": 411,
+    "install.guess_hdrs": 415,
+    "install.guess_hdrs_exclude": 416,
+    "install.data": 420,
+    "install.data_dest": 421,
+    "install.guess_data": 425,
+    "install.guess_data_exclude": 426,
+    "install.docs": 440,
+    "install.doc_dest": 441,
+    "install.doc_strip_prefix": 441,
+    "install.rename": 460,
+    "install_files.files": 400,
+    "install_files.strip_prefix": 401,
+    "install_files.rename": 460,
+    "install.allowed_externals": 465,
+    "install_files.allowed_externals": 465,
+    "install.visibility": 490,
+    "install_files.visibility": 490,
+    "install.deps": 499,
+    "install_files.deps": 499
+  }
+}

--- a/tools/buildifier-test.sh
+++ b/tools/buildifier-test.sh
@@ -4,8 +4,9 @@
 # to be reformatted.
 
 buildifier="$PWD/external/com_github_bazelbuild_buildtools/buildifier/buildifier"
+tables="$PWD/tools/buildifier-tables.json"
 
-out=$("$buildifier" -mode=check "$@")
+out=$("$buildifier" -mode=check -add_tables="$tables" "$@")
 [[ -z "$out" ]] && exit 0
 
 echo "$out"

--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -75,6 +75,7 @@ fi
 echo "Refreshing buildifier binary ..."
 bazel build --show_result=0 //tools:buildifier
 buildifier="$workspace"/bazel-bin/external/com_github_bazelbuild_buildtools/buildifier/buildifier
+tables="$workspace"/tools/buildifier-tables.json
 if [[ ! -x $buildifier ]]; then
   echo "Failed to build buildifier at $buildifier"
   exit 1
@@ -92,7 +93,7 @@ else
           -name BUILD.bazel -o \
           -name '*.BUILD' -o \
           -name '*.bzl' \) -print |
-      xargs -t "$buildifier" -mode=fix
+      xargs -t "$buildifier" -mode=fix -add_tables="$tables"
 fi
 
 echo "... done"

--- a/tools/bullet.BUILD
+++ b/tools/bullet.BUILD
@@ -75,18 +75,18 @@ install_cmake_config(package = "Bullet")
 
 install(
     name = "install",
-    docs = [
-        "AUTHORS.txt",
-        "LICENSE.txt",
-    ],
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/bullet",
-    hdr_strip_prefix = BULLET_INCLUDES,
     targets = [
         ":BulletCollision",
         ":BulletDynamics",
         ":BulletSoftBody",
         ":LinearMath",
+    ],
+    hdr_dest = "include/bullet",
+    hdr_strip_prefix = BULLET_INCLUDES,
+    guess_hdrs = "PACKAGE",
+    docs = [
+        "AUTHORS.txt",
+        "LICENSE.txt",
     ],
     deps = [":install_cmake_config"],
 )

--- a/tools/ccd.BUILD
+++ b/tools/ccd.BUILD
@@ -58,10 +58,10 @@ install_cmake_config(package = "ccd")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
+    targets = [":ccd"],
     hdrs = CCD_PUBLIC_HEADERS,
-    docs = ["BSD-LICENSE"],
     hdr_dest = "include/ccd",
     hdr_strip_prefix = ["**/"],
-    targets = [":ccd"],
+    docs = ["BSD-LICENSE"],
     deps = [":install_cmake_config"],
 )

--- a/tools/eigen.BUILD
+++ b/tools/eigen.BUILD
@@ -37,11 +37,11 @@ install_cmake_config(package = "Eigen3")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    doc_dest = "share/doc/eigen3",
-    docs = glob(["COPYING.*"]),
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/eigen3",
     targets = [":eigen"],
+    hdr_dest = "include/eigen3",
+    guess_hdrs = "PACKAGE",
+    docs = glob(["COPYING.*"]),
+    doc_dest = "share/doc/eigen3",
     deps = [":install_cmake_config"],
 )
 

--- a/tools/fcl.BUILD
+++ b/tools/fcl.BUILD
@@ -69,10 +69,10 @@ install_cmake_config(package = "fcl")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    docs = ["LICENSE"],
-    guess_hdrs = "PACKAGE",
+    targets = [":fcl"],
     hdr_dest = "include/fcl",
     hdr_strip_prefix = ["include/fcl"],
-    targets = [":fcl"],
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE"],
     deps = [":install_cmake_config"],
 )

--- a/tools/fmt.BUILD
+++ b/tools/fmt.BUILD
@@ -28,10 +28,10 @@ install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    docs = ["LICENSE.rst"],
-    guess_hdrs = "PACKAGE",
+    targets = [":fmt"],
     hdr_dest = "include/fmt",
     hdr_strip_prefix = ["fmt"],
-    targets = [":fmt"],
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE.rst"],
     deps = [":install_cmake_config"],
 )

--- a/tools/ignition_math.BUILD
+++ b/tools/ignition_math.BUILD
@@ -138,16 +138,16 @@ install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
+    workspace = CMAKE_PACKAGE,
+    targets = [":ignition_math"],
     hdrs = public_headers + [
         ":config",
         ":mathhh_genrule",
     ],
-    docs = [
-        "LICENSE",
-        "COPYING",
-    ],
     hdr_strip_prefix = ["include"],
-    targets = [":ignition_math"],
-    workspace = CMAKE_PACKAGE,
+    docs = [
+        "COPYING",
+        "LICENSE",
+    ],
     deps = [":install_cmake_config"],
 )

--- a/tools/ignition_rndf.BUILD
+++ b/tools/ignition_rndf.BUILD
@@ -74,16 +74,16 @@ install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
+    workspace = CMAKE_PACKAGE,
+    targets = [":ignition_rndf"],
     hdrs = public_headers + [
         ":config",
         ":rndfhh_genrule",
     ],
-    docs = [
-        "LICENSE",
-        "COPYING",
-    ],
     hdr_strip_prefix = ["include"],
-    targets = [":ignition_rndf"],
-    workspace = CMAKE_PACKAGE,
+    docs = [
+        "COPYING",
+        "LICENSE",
+    ],
     deps = [":install_cmake_config"],
 )

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -278,6 +278,7 @@ def _install_impl(ctx):
 # TODO(mwoehlke-kitware) default guess_data to PACKAGE when we have better
 # default destinations.
 install = rule(
+    # Update buildifier-tables.json when this changes.
     attrs = {
         "deps": attr.label_list(providers = ["install_actions"]),
         "docs": attr.label_list(allow_files = True),
@@ -414,6 +415,7 @@ def _install_files_impl(ctx):
     return InstallInfo(install_actions = actions)
 
 install_files = rule(
+    # Update buildifier-tables.json when this changes.
     attrs = {
         "dest": attr.string(mandatory = True),
         "files": attr.label_list(allow_files = True),

--- a/tools/install/gflags/BUILD
+++ b/tools/install/gflags/BUILD
@@ -13,18 +13,18 @@ install_cmake_config(package = "gflags")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    allowed_externals = ["@com_github_gflags_gflags//:gflags"],
-    doc_dest = "share/doc/gflags",
-    docs = ["@com_github_gflags_gflags//:COPYING.txt"],
+    targets = ["@com_github_gflags_gflags//:gflags"],
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
     guess_hdrs = "PACKAGE",
     guess_hdrs_exclude = [
         "config.h",
         "src/mutex.h",
         "src/util.h",
     ],
-    hdr_dest = "include",
-    hdr_strip_prefix = ["include"],
-    targets = ["@com_github_gflags_gflags//:gflags"],
+    docs = ["@com_github_gflags_gflags//:COPYING.txt"],
+    doc_dest = "share/doc/gflags",
+    allowed_externals = ["@com_github_gflags_gflags//:gflags"],
     visibility = ["//:__pkg__"],
     deps = [":install_cmake_config"],
 )

--- a/tools/install/jchart2d/BUILD
+++ b/tools/install/jchart2d/BUILD
@@ -24,12 +24,12 @@ JCHART_TARGETS = [
 
 install(
     name = "install",
-    allowed_externals = JCHART_LICENSE_DOCS + JCHART_TARGETS,
-    doc_strip_prefix = ["**/"],
-    docs = JCHART_LICENSE_DOCS,
-    java_strip_prefix = ["**/"],
-    targets = JCHART_TARGETS,
-    visibility = ["//:__pkg__"],
     workspace = CMAKE_PACKAGE,
+    targets = JCHART_TARGETS,
+    java_strip_prefix = ["**/"],
+    docs = JCHART_LICENSE_DOCS,
+    doc_strip_prefix = ["**/"],
+    allowed_externals = JCHART_LICENSE_DOCS + JCHART_TARGETS,
+    visibility = ["//:__pkg__"],
     deps = [":install_cmake_config"],
 )

--- a/tools/install/optitrack_driver/BUILD
+++ b/tools/install/optitrack_driver/BUILD
@@ -27,19 +27,19 @@ OPTITRACK_TARGETS = [
 
 install(
     name = "install",
-    allowed_externals = OPTITRACK_LICENSE_DOCS + OPTITRACK_TARGETS,
-    doc_strip_prefix = ["**/"],
-    docs = OPTITRACK_LICENSE_DOCS,
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/lcmtypes",
+    workspace = CMAKE_PACKAGE,
+    targets = OPTITRACK_TARGETS,
     java_strip_prefix = ["**/"],
     py_dest = "lib/python2.7/site-packages/optitrack",
     py_strip_prefix = ["**/"],
+    hdr_dest = "include/lcmtypes",
+    guess_hdrs = "PACKAGE",
+    docs = OPTITRACK_LICENSE_DOCS,
+    doc_strip_prefix = ["**/"],
     rename = {
         "share/java/liblcmtypes_optitrack.jar": "lcmtypes_optitrack.jar",
     },
-    targets = OPTITRACK_TARGETS,
+    allowed_externals = OPTITRACK_LICENSE_DOCS + OPTITRACK_TARGETS,
     visibility = ["//:__pkg__"],
-    workspace = CMAKE_PACKAGE,
     deps = [":install_cmake_config"],
 )

--- a/tools/install/protobuf/BUILD
+++ b/tools/install/protobuf/BUILD
@@ -155,18 +155,18 @@ excluded_headers = [
 
 install(
     name = "install",
-    hdrs = ["@protobuf//:well_known_protos"],
-    allowed_externals = ["@protobuf//:protobuf"],
-    doc_dest = "share/doc/protobuf",
-    docs = ["@protobuf//:LICENSE"],
-    guess_hdrs = "PACKAGE",
-    guess_hdrs_exclude = excluded_headers,
-    hdr_strip_prefix = ["src"],
     targets = [
         "@protobuf//:protobuf",
         "@protobuf//:protobuf_lite",
         "@protobuf//:protoc_lib",
         "@protobuf//:protoc",
     ],
+    hdrs = ["@protobuf//:well_known_protos"],
+    hdr_strip_prefix = ["src"],
+    guess_hdrs = "PACKAGE",
+    guess_hdrs_exclude = excluded_headers,
+    docs = ["@protobuf//:LICENSE"],
+    doc_dest = "share/doc/protobuf",
+    allowed_externals = ["@protobuf//:protobuf"],
     deps = [":install_cmake_config"],
 )

--- a/tools/ipopt.BUILD
+++ b/tools/ipopt.BUILD
@@ -148,11 +148,11 @@ install_cmake_config(package = "IPOPT")  # Creates rule :install_cmake_config.
 # TODO(jamiesnape): At the moment libipopt.a has gone AWOL.
 install(
     name = "install",
-    docs = glob(["**/LICENSE"]),
-    guess_hdrs = "PACKAGE",
+    targets = [":ipopt"],
     hdr_dest = "include/ipopt",
     hdr_strip_prefix = ["include/coin"],
-    targets = [":ipopt"],
+    guess_hdrs = "PACKAGE",
+    docs = glob(["**/LICENSE"]),
     deps = [":install_cmake_config"],
 )
 

--- a/tools/lcm.BUILD
+++ b/tools/lcm.BUILD
@@ -220,26 +220,16 @@ install_files(
 
 install(
     name = "install_python",
-    library_dest = "lib/python2.7/site-packages/lcm",
-    py_strip_prefix = ["lcm-python"],
     targets = [
         ":_lcm.so",
         ":lcm-python-upstream",
     ],
+    library_dest = "lib/python2.7/site-packages/lcm",
+    py_strip_prefix = ["lcm-python"],
 )
 
 install(
     name = "install",
-    hdrs = LCM_PUBLIC_HEADERS,
-    docs = [
-        "AUTHORS",
-        "COPYING",
-        "NEWS",
-    ],
-    py_strip_prefix = ["lcm-python"],
-    rename = {
-        "share/java/liblcm-java.jar": "lcm.jar",
-    },
     targets = [
         ":lcm",
         ":lcm-gen",
@@ -248,6 +238,16 @@ install(
         ":lcm-logplayer",
         ":lcm-spy",
     ],
+    py_strip_prefix = ["lcm-python"],
+    hdrs = LCM_PUBLIC_HEADERS,
+    docs = [
+        "AUTHORS",
+        "COPYING",
+        "NEWS",
+    ],
+    rename = {
+        "share/java/liblcm-java.jar": "lcm.jar",
+    },
     deps = [
         ":install_cmake_config",
         ":install_extra_cmake",

--- a/tools/lcmtypes_bot2_core.BUILD
+++ b/tools/lcmtypes_bot2_core.BUILD
@@ -69,18 +69,18 @@ install_cmake_config(
 # and https://github.com/openhumanoids/bot_core_lcmtypes/issues/33.
 install(
     name = "install",
-    docs = ["@lcmtypes_robotlocomotion//:LICENSE.txt"],
-    guess_hdrs = "PACKAGE",
-    py_strip_prefix = ["lcmtypes"],
-    rename = {
-        "share/java/liblcmtypes_bot2_core_java.jar": "lcmtypes_bot2_core.jar",
-    },
+    workspace = CMAKE_PACKAGE,
     targets = [
         ":lcmtypes_bot2_core",
         ":lcmtypes_bot2_core_c",
         ":lcmtypes_bot2_core_java",
         ":lcmtypes_bot2_core_py",
     ],
-    workspace = CMAKE_PACKAGE,
+    py_strip_prefix = ["lcmtypes"],
+    guess_hdrs = "PACKAGE",
+    docs = ["@lcmtypes_robotlocomotion//:LICENSE.txt"],
+    rename = {
+        "share/java/liblcmtypes_bot2_core_java.jar": "lcmtypes_bot2_core.jar",
+    },
     deps = [":install_cmake_config"],
 )

--- a/tools/lcmtypes_robotlocomotion.BUILD
+++ b/tools/lcmtypes_robotlocomotion.BUILD
@@ -60,19 +60,19 @@ install_cmake_config(
 
 install(
     name = "install",
-    docs = ["LICENSE.txt"],
-    guess_hdrs = "PACKAGE",
-    py_strip_prefix = ["lcmtypes"],
-    rename = {
-        "share/java/liblcmtypes_robotlocomotion_java.jar": "lcmtypes_robotlocomotion.jar",  # noqa
-    },
+    workspace = CMAKE_PACKAGE,
     targets = [
         ":lcmtypes_robotlocomotion",
         ":lcmtypes_robotlocomotion_c",
         ":lcmtypes_robotlocomotion_java",
         ":lcmtypes_robotlocomotion_py",
     ],
-    workspace = CMAKE_PACKAGE,
+    py_strip_prefix = ["lcmtypes"],
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE.txt"],
+    rename = {
+        "share/java/liblcmtypes_robotlocomotion_java.jar": "lcmtypes_robotlocomotion.jar",  # noqa
+    },
     deps = [":install_cmake_config"],
 )
 

--- a/tools/libbot.BUILD
+++ b/tools/libbot.BUILD
@@ -437,22 +437,6 @@ install_cmake_config(
 
 install(
     name = "install_lcmtypes",
-    guess_hdrs = "PACKAGE",
-    hdr_strip_prefix = [
-        "bot2-frames",
-        "bot2-lcmgl",
-        "bot2-param",
-    ],
-    py_strip_prefix = [
-        "bot2-frames/lcmtypes",
-        "bot2-lcmgl/lcmtypes",
-        "bot2-param/lcmtypes",
-    ],
-    rename = {
-        "share/java/liblcmtypes_bot2_frames_java.jar": "lcmtypes_bot2_frames.jar",  # noqa
-        "share/java/liblcmtypes_bot2_lcmgl_java.jar": "lcmtypes_bot2_lcmgl.jar",  # noqa
-        "share/java/liblcmtypes_bot2_param_java.jar": "lcmtypes_bot2_param.jar",  # noqa
-    },
     targets = [
         ":lcmtypes_bot2_frames_c",
         ":lcmtypes_bot2_frames_java",
@@ -467,28 +451,43 @@ install(
         ":lcmtypes_bot2_param_py",
         ":lcmtypes_bot2_param",
     ],
+    py_strip_prefix = [
+        "bot2-frames/lcmtypes",
+        "bot2-lcmgl/lcmtypes",
+        "bot2-param/lcmtypes",
+    ],
+    hdr_strip_prefix = [
+        "bot2-frames",
+        "bot2-lcmgl",
+        "bot2-param",
+    ],
+    guess_hdrs = "PACKAGE",
+    rename = {
+        "share/java/liblcmtypes_bot2_frames_java.jar": "lcmtypes_bot2_frames.jar",  # noqa
+        "share/java/liblcmtypes_bot2_lcmgl_java.jar": "lcmtypes_bot2_lcmgl.jar",  # noqa
+        "share/java/liblcmtypes_bot2_param_java.jar": "lcmtypes_bot2_param.jar",  # noqa
+    },
 )
 
 HDR_DEST = "include/" + CMAKE_PACKAGE
 
 install(
     name = "install_bot2_core",
+    targets = [
+        ":bot-spy",
+        ":bot2_core",
+        ":lcmspy_plugins_bot2",
+    ],
     hdrs = BOT2_CORE_PUBLIC_HDRS,
     hdr_dest = HDR_DEST,
     hdr_strip_prefix = ["bot2-core/src"],
     rename = {
         "share/java/liblcmspy_plugins_bot2.jar": "lcmspy_plugins_bot2.jar",
     },
-    targets = [
-        ":bot-spy",
-        ":bot2_core",
-        ":lcmspy_plugins_bot2",
-    ],
 )
 
 install(
     name = "install_bot2_lcm_utils",
-    py_strip_prefix = ["bot2-lcm-utils/python/src"],
     targets = [
         ":bot_log2mat",
         ":bot-lcm-logfilter",
@@ -496,43 +495,44 @@ install(
         ":bot-lcm-tunnel",
         ":bot-lcm-who",
     ],
+    py_strip_prefix = ["bot2-lcm-utils/python/src"],
 )
 
 install(
     name = "install_bot2_param",
-    hdrs = BOT2_PARAM_PUBLIC_HDRS,
-    hdr_dest = HDR_DEST + "/" + BOT2_PARAM_INCLUDE_PREFIX,
-    hdr_strip_prefix = ["bot2-param/src/param_client"],
     targets = [
         ":bot-param-dump",
         ":bot-param-server",
         ":bot-param-tool",
         ":bot2_param_client",
     ],
+    hdrs = BOT2_PARAM_PUBLIC_HDRS,
+    hdr_dest = HDR_DEST + "/" + BOT2_PARAM_INCLUDE_PREFIX,
+    hdr_strip_prefix = ["bot2-param/src/param_client"],
 )
 
 install(
     name = "install_bot2_frames",
+    targets = [":bot2_frames"],
     hdrs = BOT2_FRAMES_PUBLIC_HDRS,
     hdr_dest = HDR_DEST + "/" + BOT2_FRAMES_INCLUDE_PREFIX,
     hdr_strip_prefix = ["bot2-frames/src"],
-    targets = [":bot2_frames"],
 )
 
 install(
     name = "install_bot2_lcmgl",
-    hdrs = BOT2_LCMGL_PUBLIC_HDRS,
-    hdr_dest = HDR_DEST,
-    hdr_strip_prefix = ["bot2-lcmgl/src"],
-    rename = {
-        "share/java/libbot2_lcmgl_java.jar": "bot2_lcmgl.jar",
-    },
     targets = [
         ":bot2_lcmgl_client",
         ":bot2_lcmgl_java",
         ":bot2_lcmgl_py",
         ":bot2_lcmgl_render",
     ],
+    hdrs = BOT2_LCMGL_PUBLIC_HDRS,
+    hdr_dest = HDR_DEST,
+    hdr_strip_prefix = ["bot2-lcmgl/src"],
+    rename = {
+        "share/java/libbot2_lcmgl_java.jar": "bot2_lcmgl.jar",
+    },
 )
 
 install(

--- a/tools/nlopt.BUILD
+++ b/tools/nlopt.BUILD
@@ -188,6 +188,9 @@ install_cmake_config(package = "NLopt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
+    targets = [":nlopt"],
+    hdr_dest = "include/nlopt",
+    guess_hdrs = "PACKAGE",
     docs = [
         "AUTHORS",
         "NEWS",
@@ -195,9 +198,6 @@ install(
         "**/COPYING",
         "**/COPYRIGHT",
     ]),
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/nlopt",
-    targets = [":nlopt"],
     deps = [":install_cmake_config"],
 )
 

--- a/tools/octomap.BUILD
+++ b/tools/octomap.BUILD
@@ -63,14 +63,14 @@ install_cmake_config(package = "octomap")
 
 install(
     name = "install",
-    doc_dest = "share/doc",
-    docs = ["octomap/LICENSE.txt"],
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include",
-    hdr_strip_prefix = ["octomap/include"],
     targets = [
         ":octomap",
         ":octomath",
     ],
+    hdr_dest = "include",
+    hdr_strip_prefix = ["octomap/include"],
+    guess_hdrs = "PACKAGE",
+    docs = ["octomap/LICENSE.txt"],
+    doc_dest = "share/doc",
     deps = [":install_cmake_config"],
 )

--- a/tools/pybind11.BUILD
+++ b/tools/pybind11.BUILD
@@ -62,10 +62,10 @@ install_files(
 
 install(
     name = "install",
-    docs = ["LICENSE"],
-    guess_hdrs = "PACKAGE",
-    hdr_strip_prefix = ["include"],
     targets = [":pybind11"],
+    hdr_strip_prefix = ["include"],
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE"],
     deps = [
         ":install_cmake_config",
         ":install_extra_cmake",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -142,15 +142,15 @@ install_cmake_config(package = "SDFormat")
 
 install(
     name = "install",
+    targets = [":sdformat"],
     hdrs = public_headers + [
         ":sdfhh_genrule",
         ":config",
     ],
-    docs = [
-        "LICENSE",
-        "COPYING",
-    ],
     hdr_strip_prefix = ["include"],
-    targets = [":sdformat"],
+    docs = [
+        "COPYING",
+        "LICENSE",
+    ],
     deps = [":install_cmake_config"],
 )

--- a/tools/spdlog.BUILD
+++ b/tools/spdlog.BUILD
@@ -38,10 +38,10 @@ install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    docs = ["LICENSE"],
-    guess_hdrs = "PACKAGE",
+    targets = [":spdlog"],
     hdr_dest = "include/spdlog",
     hdr_strip_prefix = ["include/spdlog"],
-    targets = [":spdlog"],
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE"],
     deps = [":install_cmake_config"],
 )

--- a/tools/tinyobjloader.BUILD
+++ b/tools/tinyobjloader.BUILD
@@ -34,9 +34,9 @@ install_cmake_config(package = "tinyobjloader")
 
 install(
     name = "install",
-    docs = ["LICENSE"],
-    guess_hdrs = "PACKAGE",
-    hdr_dest = "include/tinyobjloader",
     targets = [":tinyobjloader"],
+    hdr_dest = "include/tinyobjloader",
+    guess_hdrs = "PACKAGE",
+    docs = ["LICENSE"],
     deps = [":install_cmake_config"],
 )

--- a/tools/yaml_cpp.BUILD
+++ b/tools/yaml_cpp.BUILD
@@ -36,11 +36,11 @@ install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
+    workspace = CMAKE_PACKAGE,
+    targets = [":yaml_cpp"],
     hdrs = public_headers,
-    docs = ["LICENSE"],
     hdr_dest = "include",
     hdr_strip_prefix = ["include"],
-    targets = [":yaml_cpp"],
-    workspace = CMAKE_PACKAGE,
+    docs = ["LICENSE"],
     deps = [":install_cmake_config"],
 )


### PR DESCRIPTION
Update to a version of buildifier that allows overriding `NamePriority` per rule. Add custom tables for ordering the install framework rules, and use these when running buildifier. Apply the changes that these trigger.

This is split into two commits. The first commit has the "interesting" changes and results in the `bazel_lint` tests being broken as of that commit. The second applies the results of running `buildifier.sh` after the changes, and consists entirely of changes made by the same.

See also bazelbuild/buildtools#113.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6482)
<!-- Reviewable:end -->
