### PR TITLE
Remove flaky tests from CMake build

### DIFF
--- a/drake/systems/lcm/test/CMakeLists.txt
+++ b/drake/systems/lcm/test/CMakeLists.txt
@@ -12,11 +12,6 @@ if(lcm_FOUND)
   target_link_libraries(lcm_translator_dictionary_test
       drakeLcmSystem)
 
-  drake_add_cc_test(lcm_driven_loop_test)
-  target_link_libraries(lcm_driven_loop_test
-      drakeLcmDrivenLoop
-      drakeSystemPrimitives)
-
   drake_add_cc_test(serializer_test)
   target_link_libraries(serializer_test drakeLcmSystem)
 

--- a/drake/systems/trajectory_optimization/test/CMakeLists.txt
+++ b/drake/systems/trajectory_optimization/test/CMakeLists.txt
@@ -1,7 +1,2 @@
-if(ipopt_FOUND OR NLopt_FOUND)
-  drake_add_cc_test(NAME trajectory_optimization_test SIZE medium)
-  target_link_libraries(trajectory_optimization_test drakeTrajectoryOptimization drakeSystemPrimitives)
-endif()
-
 drake_add_cc_test(direct_collocation_constraint_test)
 target_link_libraries(direct_collocation_constraint_test drakeTrajectoryOptimization)


### PR DESCRIPTION
These are failing on ASan and LSan builds and would have been removed from the CMake build within a week in any case (per #3129).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6485)
<!-- Reviewable:end -->
