### PR TITLE
Fix license check in case of "dummy" installs

### DIFF
--- a/tools/check_licenses.bzl
+++ b/tools/check_licenses.bzl
@@ -30,22 +30,32 @@ def _is_license_file(filename):
 
 #------------------------------------------------------------------------------
 def _check_licenses_for_label(label):
+    # Don't check empty installs (can happen if an install is a dummy due to
+    # some platforms relying on a package already being installed).
+    if not label.install_actions:
+        return []
+
+    # Look for file(s) that appear to be license(s) in the install actions.
     has_license = False
     for a in label.install_actions:
         if _is_license_file(a.src.basename):
             has_license = True
 
+    # If no license found, return the failing label.
     if not has_license:
         return [label.label]
 
+    # Otherwise return nothing; caller collects failing labels to report.
     return []
 
 #------------------------------------------------------------------------------
 def _check_licenses_impl(ctx):
+    # Iterate over labels, collecting ones that are missing licenses.
     labels_missing_licenses = []
     for l in ctx.attr.install_labels:
         labels_missing_licenses += _check_licenses_for_label(l)
 
+    # Report collected failures.
     if labels_missing_licenses:
         fail("Missing license files for install label(s) %s" %
              labels_missing_licenses)


### PR DESCRIPTION
Tweak license check to first verify if an install label actually does anything, and to implicitly accept empty install labels. (An install label that doesn't actually install anything is presumably okay not installing a license, since there is nothing to be licensed.)

In particular, this affects VTK, as on macOS, we rely on VTK being installed via homebrew, and the install label does not actually do anything (it is merely present so that other code referring to it does not need to be made conditional).

Also, add some comments around this logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6487)
<!-- Reviewable:end -->
