### PR TITLE
Teach ZeroOrderHold to handle AbstractValue's.

### DIFF
--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -44,6 +44,9 @@ class PassThrough : public SisoVectorSystem<T> {
   /// @param size number of elements in the signal to be processed.
   explicit PassThrough(int size);
 
+  // TODO(eric.cousineau): Ensure that this system can also handle
+  // AbstractValue's akin to ZeroOrderHold (#6491).
+
  protected:
   /// Sets the output port to equal the input port.
   void DoCalcVectorOutput(

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -5,6 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+#include <memory>
+#include <vector>
+
 #include "drake/common/unused.h"
 #include "drake/systems/primitives/zero_order_hold.h"
 
@@ -13,37 +16,105 @@ namespace systems {
 
 template <typename T>
 ZeroOrderHold<T>::ZeroOrderHold(double period_sec, int size)
-    : SisoVectorSystem<T>(size, size), period_sec_(period_sec) {
+    : period_sec_(period_sec) {
   // TODO(david-german-tri): remove the size parameter from the constructor
   // once #3109 supporting automatic sizes is resolved.
+  BasicVector<T> dummy_value(size);
+  this->DeclareVectorInputPort(dummy_value);
+  this->DeclareVectorOutputPort(
+      dummy_value, &ZeroOrderHold::DoCalcVectorOutput);
   this->DeclareDiscreteState(size);
   this->DeclarePeriodicDiscreteUpdate(period_sec);
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcVectorOutput(
-      const Context<T>&,
-      const Eigen::VectorBlock<const VectorX<T>>& input,
-      const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const {
-  unused(input);
-  *output = state;
+ZeroOrderHold<T>::ZeroOrderHold(double period_sec,
+                                const AbstractValue& model_value)
+    : period_sec_(period_sec), abstract_model_value_(model_value.Clone()) {
+  // TODO(eric.cousineau): Remove value parameter from the constructor once
+  // the equivalent of #3109 for abstract values is also resolved.
+  this->DeclareAbstractInputPort(model_value);
+  // Use the std::function<> overloads to work with `AbstractValue` type
+  // directly and maintain type erasure.
+  namespace sp = std::placeholders;
+  this->DeclareAbstractOutputPort(
+      std::bind(&ZeroOrderHold::AllocateAbstractValue, this, sp::_1),
+      std::bind(&ZeroOrderHold::DoCalcAbstractOutput, this, sp::_1, sp::_2));
+  this->DeclareAbstractState(model_value.Clone());
+  this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0.);
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcVectorDiscreteVariableUpdates(
-    const Context<T>&,
-    const Eigen::VectorBlock<const VectorX<T>>& input,
-    const Eigen::VectorBlock<const VectorX<T>>& state,
-    Eigen::VectorBlock<VectorX<T>>* discrete_updates) const {
-  unused(state);
-  *discrete_updates = input;
+void ZeroOrderHold<T>::DoCalcVectorOutput(
+      const Context<T>& context,
+      BasicVector<T>* output) const {
+  DRAKE_ASSERT(!is_abstract());
+  const BasicVector<T>& state_value = *context.get_discrete_state(0);
+  output->SetFrom(state_value);
+}
+
+template <typename T>
+void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
+    const Context<T>& context,
+    const std::vector<const DiscreteUpdateEvent<T>*>&,
+    DiscreteValues<T>* discrete_state) const {
+  DRAKE_ASSERT(!is_abstract());
+  const BasicVector<T>& input_value = *this->EvalVectorInput(context, 0);
+  BasicVector<T>& state_value = *discrete_state->get_mutable_vector(0);
+  state_value.SetFrom(input_value);
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue>
+ZeroOrderHold<T>::AllocateAbstractValue(const Context<T>&) const {
+  return abstract_model_value_->Clone();
+}
+
+template <typename T>
+void ZeroOrderHold<T>::DoCalcAbstractOutput(const Context<T>& context,
+                                            AbstractValue* output) const {
+  DRAKE_ASSERT(is_abstract());
+  // Do not use `get_abstract_state<AbstractValue>` since it would cast
+  // the value to `Value<AbstractValue>`, which is an invalid type by design.
+  const AbstractValue& state_value =
+      context.template get_abstract_state()->get_value(0);
+  output->SetFrom(state_value);
+}
+
+template <typename T>
+void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
+    const Context<T>& context,
+    const std::vector<const UnrestrictedUpdateEvent<T>*>&,
+    State<T> *state) const {
+  DRAKE_ASSERT(is_abstract());
+  const AbstractValue& input_value = *this->EvalAbstractInput(context, 0);
+  // See `DoCalcAbstractOutput` for rationale regarding non-templated value
+  // accessor.
+  AbstractValue& state_value =
+      state->get_mutable_abstract_state()->get_mutable_value(0);
+  state_value.SetFrom(input_value);
+}
+
+template <typename T>
+bool ZeroOrderHold<T>::DoHasDirectFeedthrough(
+    const SparsityMatrix*, int input_port, int output_port) const {
+  DRAKE_DEMAND(input_port == 0);
+  DRAKE_DEMAND(output_port == 0);
+  // By definition, a zero-order hold will not have direct feedthrough, as the
+  // output only depends on the state, not the input.
+  return false;
 }
 
 template <typename T>
 ZeroOrderHold<symbolic::Expression>* ZeroOrderHold<T>::DoToSymbolic() const {
-  return new ZeroOrderHold<symbolic::Expression>(period_sec_,
-                                                 this->get_input_port().size());
+  if (!is_abstract()) {
+    return new ZeroOrderHold<symbolic::Expression>(
+        period_sec_, this->get_input_port().size());
+  } else {
+    // Return `nullptr` to enable control to reach `DoHasDirectFeedthrough`.
+    // See Doxygen comments regarding transmogrification.
+    return nullptr;
+  }
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/zero_order_hold.h
+++ b/drake/systems/primitives/zero_order_hold.h
@@ -1,50 +1,100 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/systems/framework/context.h"
-#include "drake/systems/framework/siso_vector_system.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {
 
-/// A ZeroOrderHold block with input `u`, which may be discrete or continuous,
-/// and discrete output `y`, where the y is sampled from u with a fixed period.
+/// A ZeroOrderHold block with input `u`, which may be vector-valued (discrete
+/// or continuous) or abstract, and discrete output `y`, where the y is sampled
+/// from u with a fixed period.
+/// @note For an abstract-valued ZeroOrderHold, transmografication is not
+/// supported since AbstractValue does not support it.
 /// @ingroup primitive_systems
 template <typename T>
-class ZeroOrderHold : public SisoVectorSystem<T> {
+class ZeroOrderHold : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ZeroOrderHold)
 
   /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
-  /// vector-valued input of size @p size.
+  /// vector-valued input of size @p size. The default initial value for this
+  /// system will be zero.
   ZeroOrderHold(double period_sec, int size);
 
+  /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
+  /// abstract-valued input @p model_value. The default initial value for this
+  /// system will be @p model_value.
+  ZeroOrderHold(double period_sec, const AbstractValue& model_value);
+
+  ~ZeroOrderHold() override {}
+
+  // TODO(eric.cousineau): Create a SisoSystem that is type-agnostic, and
+  // have both this and SisoVectorSystem inherit from it (#6490).
+
+  /// Returns the sole input port.
+  const InputPortDescriptor<T>& get_input_port() const {
+    return LeafSystem<T>::get_input_port(0);
+  }
+
+  // Don't use the indexed get_input_port when calling this system directly.
+  void get_input_port(int) = delete;
+
+  /// Returns the sole output port.
+  const OutputPort<T>& get_output_port() const {
+    return LeafSystem<T>::get_output_port(0);
+  }
+
+  // Don't use the indexed get_output_port when calling this system directly.
+  void get_output_port(int) = delete;
+
+
  protected:
+  // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
+  bool DoHasDirectFeedthrough(const SparsityMatrix* sparsity,
+                              int input_port, int output_port) const override;
+
   // System<T> override.  Returns a ZeroOrderHold<symbolic::Expression> with
   // the same dimensions as this ZeroOrderHold.
   ZeroOrderHold<symbolic::Expression>* DoToSymbolic() const override;
 
-  /// Sets the output port value to the value that is currently latched in the
-  /// zero-order hold.
+  /// Sets the output port value to the vector value that is currently
+  /// latched in the zero-order hold.
   void DoCalcVectorOutput(
       const Context<T>& context,
-      const Eigen::VectorBlock<const VectorX<T>>& input,
-      const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      BasicVector<T>* output) const;
 
-  /// Latches the input port into the discrete state.
-  void DoCalcVectorDiscreteVariableUpdates(
+  /// Latches the input port into the discrete vector-valued state.
+  void DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
-      const Eigen::VectorBlock<const VectorX<T>>& input,
-      const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* discrete_updates) const override;
+      const std::vector<const DiscreteUpdateEvent<T>*>& events,
+      DiscreteValues<T>* discrete_state) const override;
+
+  // Return a cloned copy of the initial abstract value.
+  std::unique_ptr<AbstractValue> AllocateAbstractValue(const Context<T>&) const;
+
+  // Same as `DoCalcVectorOutput`, but for abstract values.
+  void DoCalcAbstractOutput(
+      const Context<T>& context,
+      AbstractValue* output) const;
+
+  // Same as `DoCalcDiscreteVariablesUpdate`, but for abstract values.
+  void DoCalcUnrestrictedUpdate(
+      const Context<T>& context,
+      const std::vector<const UnrestrictedUpdateEvent<T>*>& events,
+      State<T>* state) const override;
 
  private:
+  bool is_abstract() const { return abstract_model_value_ != nullptr; }
+
   const double period_sec_{};
+  const std::unique_ptr<const AbstractValue> abstract_model_value_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
This resolves the main intent of #6460 by permitting `ZeroOrderHold` to handle abstract values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6488)
<!-- Reviewable:end -->
