### PR TITLE
make kuka_plan_runner to ignore all plan msg that has fewer than 2 knots.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -115,6 +115,9 @@ class RobotPlanRunner {
       std::cout << "Discarding plan, no status message received yet"
                 << std::endl;
       return;
+    } else if (plan->num_states < 2) {
+      std::cout << "Discarding plan, Not enough knot points." << std::endl;
+      return;
     }
 
     std::vector<Eigen::MatrixXd> knots(plan->num_states,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6497)
<!-- Reviewable:end -->
