### PR TITLE
Bilinear product tetrahedron

### DIFF
--- a/drake/solvers/mixed_integer_optimization_util.cc
+++ b/drake/solvers/mixed_integer_optimization_util.cc
@@ -116,8 +116,11 @@ void AddBilinearProductMcCormickEnvelopeSOS2(
   prog->AddLinearConstraint(y == y_convex_combination);
   prog->AddLinearConstraint(w == w_convex_combination);
 
-  AddLogarithmicSOS2Constraint(prog, lambda.cast<symbolic::Expression>().rowwise().sum(), Bx);
-  AddLogarithmicSOS2Constraint(prog, lambda.cast<symbolic::Expression>().colwise().sum().transpose(), By);
+  AddLogarithmicSOS2Constraint(
+      prog, lambda.cast<symbolic::Expression>().rowwise().sum(), Bx);
+  AddLogarithmicSOS2Constraint(
+      prog, lambda.cast<symbolic::Expression>().colwise().sum().transpose(),
+      By);
 }
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/mixed_integer_optimization_util.cc
+++ b/drake/solvers/mixed_integer_optimization_util.cc
@@ -85,5 +85,39 @@ void AddLogarithmicSOS1Constraint(
     prog->AddLinearConstraint(lambda_sum2 <= 1 - y(j));
   }
 }
+
+void AddBilinearProductMcCormickEnvelopeSOS2(
+    MathematicalProgram* prog,
+    const symbolic::Variable& x,
+    const symbolic::Variable& y,
+    const symbolic::Expression& w,
+    const Eigen::Ref<const Eigen::VectorXd>& phi_x,
+    const Eigen::Ref<const Eigen::VectorXd>& phi_y,
+    const Eigen::Ref<const VectorXDecisionVariable>& Bx,
+    const Eigen::Ref<const VectorXDecisionVariable>& By) {
+  DRAKE_ASSERT(Bx.rows() == CeilLog2(phi_x.rows() - 1));
+  DRAKE_ASSERT(By.rows() == CeilLog2(phi_y.rows() - 1));
+  const int num_phi_x = phi_x.rows();
+  const int num_phi_y = phi_y.rows();
+  auto lambda = prog->NewContinuousVariables(num_phi_x, num_phi_y, "lambda");
+  prog->AddBoundingBoxConstraint(0, 1, lambda);
+
+  symbolic::Expression x_convex_combination{0};
+  symbolic::Expression y_convex_combination{0};
+  symbolic::Expression w_convex_combination{0};
+  for (int i = 0; i < num_phi_x; ++i) {
+    for (int j = 0; j < num_phi_y; ++j) {
+      x_convex_combination += lambda(i, j) * phi_x(i);
+      y_convex_combination += lambda(i, j) * phi_y(j);
+      w_convex_combination += lambda(i, j) * phi_x(i) * phi_y(j);
+    }
+  }
+  prog->AddLinearConstraint(x == x_convex_combination);
+  prog->AddLinearConstraint(y == y_convex_combination);
+  prog->AddLinearConstraint(w == w_convex_combination);
+
+  AddLogarithmicSOS2Constraint(prog, lambda.cast<symbolic::Expression>().rowwise().sum(), Bx);
+  AddLogarithmicSOS2Constraint(prog, lambda.cast<symbolic::Expression>().colwise().sum().transpose(), By);
+}
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/mixed_integer_optimization_util.h
+++ b/drake/solvers/mixed_integer_optimization_util.h
@@ -81,5 +81,36 @@ void AddLogarithmicSOS1Constraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& lambda,
     const Eigen::Ref<const VectorXDecisionVariable>& y,
     const Eigen::Ref<const Eigen::MatrixXi>& codes);
+
+/**
+ * Constrain `w` to approximate the bilinear product x * y. We know
+ * that x is in one of the intervals [φx(i), φx(i+1)], y is in one of the
+ * intervals [φy(j), φy(j+1)]. The variable `w` is constrained to be in the
+ * convex hull of x * y for x in [φx(i), φx(i+1)], y in [φy(j), φy(j+1)], namely
+ * (x, y, w) is in the tetrahedron, with vertices [φx(i), φy(j), φx(i)*φy(j)],
+ * [φx(i+1), φy(j), φx(i+1)*φy(j)], [φx(i), φy(j+1), φx(i)*φy(j+1)] and
+ * [φx(i+1), φy(j+1), φx(i+1)*φy(j+1)]
+ * @param prog The program to which the bilinear product constraint is added
+ * @param x The decision variable.
+ * @param y The decision variable.
+ * @param w The expression to approximate x * y
+ * @param phi_x The end points of the intervals for `x`.
+ * @param phi_y The end points of the intervals for `y`.
+ * @param Bx The binary variable, to determine in which interval `x` stays.
+ * If Bx represents integer M in Gray code, then `x` is in the interval
+ * [φx(M), φx(M+1)].
+ * @param By The binary variable, to determine in which interval `y` stays.
+ * If Bx represents integer M in Gray code, then `y` is in the interval
+ * [φy(M), φy(M+1)].
+ */
+void AddBilinearProductMcCormickEnvelopeSOS2(
+    MathematicalProgram* prog,
+    const symbolic::Variable& x,
+    const symbolic::Variable& y,
+    const symbolic::Expression& w,
+    const Eigen::Ref<const Eigen::VectorXd>& phi_x,
+    const Eigen::Ref<const Eigen::VectorXd>& phi_y,
+    const Eigen::Ref<const VectorXDecisionVariable>& Bx,
+    const Eigen::Ref<const VectorXDecisionVariable>& By);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -202,7 +202,8 @@ TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
   Eigen::MatrixXi gray_codes_x = math::CalculateReflectedGrayCodes(Bx_.rows());
   Eigen::MatrixXi gray_codes_y = math::CalculateReflectedGrayCodes(By_.rows());
   // We will assign the binary variables Bx_ and By to a value in the gray code,
-  // representing integer i and j
+  // representing integer i and j, such that x is constrained in
+  // [φx(i), φx(i+1)], y is constrained in [φy(j), φy(j+1)].
   auto x_gray_code_cnstr =
       prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(Bx_.rows()),
                                      Eigen::VectorXd::Zero(Bx_.rows()), Bx_);

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -161,20 +161,81 @@ GTEST_TEST(TestLogarithmicSOS1, Test5Lambda) {
   LogarithmicSOS1Test(5, codes.topRows<5>());
 }
 
-class BilinearProductMcCormickEnvelopeSOS2Test : public ::testing::TestWithParam<int> {
+class BilinearProductMcCormickEnvelopeSOS2Test : public ::testing::TestWithParam<std::tuple<int, int>> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BilinearProductMcCormickEnvelopeSOS2Test)
 
   BilinearProductMcCormickEnvelopeSOS2Test()
-      :
- private:
+      : prog_{},
+        num_interval_x_{std::get<0>(GetParam())},
+        num_interval_y_{std::get<1>(GetParam())},
+        w_{prog_.NewContinuousVariables<1>()(0)},
+        x_{prog_.NewContinuousVariables<1>()(0)},
+        y_{prog_.NewContinuousVariables<1>()(0)},
+        phi_x_{Eigen::VectorXd::LinSpaced(num_interval_x_ + 1, 0, 1)},
+        phi_y_{Eigen::VectorXd::LinSpaced(num_interval_y_ + 1, 0, 1)},
+        Bx_{prog_.NewBinaryVariables(CeilLog2(num_interval_x_))},
+        By_{prog_.NewBinaryVariables(CeilLog2(num_interval_y_))} {
+    AddBilinearProductMcCormickEnvelopeSOS2(&prog_, x_, y_, w_, phi_x_, phi_y_, Bx_, By_);
+  }
+
+ protected:
   MathematicalProgram prog_;
   int num_interval_x_;
   int num_interval_y_;
   symbolic::Variable w_;
   symbolic::Variable x_;
   symbolic::Variable y_;
+  Eigen::VectorXd phi_x_;
+  Eigen::VectorXd phi_y_;
+  VectorXDecisionVariable Bx_;
+  VectorXDecisionVariable By_;
 };
+
+TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
+  // Solve the program min aᵀ * [x;y;w]
+  // s.t (x, y, w) is in the convex hull of the (x, y, x*y).
+  // We fix x and y to each intervals.
+  Eigen::MatrixXi gray_codes_x = math::CalculateReflectedGrayCodes(Bx_.rows());
+  Eigen::MatrixXi gray_codes_y = math::CalculateReflectedGrayCodes(By_.rows());
+  auto x_gray_code_cnstr = prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(Bx_.rows()), Eigen::VectorXd::Zero(Bx_.rows()), Bx_);
+  auto y_gray_code_cnstr = prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(By_.rows()), Eigen::VectorXd::Zero(By_.rows()), By_);
+  VectorDecisionVariable<3> xyw{x_, y_, w_};
+  auto cost = prog_.AddLinearCost(Eigen::Vector3d::Zero(), xyw);
+  Eigen::Matrix<double, 3, 4> a;
+  a << 1, 0, 1, -1,
+       -1, 1, 2, 1,
+       2, -1, -2, 3;
+  for (int i = 0; i < num_interval_x_; ++i) {
+    Eigen::VectorXd x_gray_code = gray_codes_x.cast<double>().row(i).transpose();
+    x_gray_code_cnstr.constraint()->UpdateLowerBound(x_gray_code);
+    x_gray_code_cnstr.constraint()->UpdateUpperBound(x_gray_code);
+    for (int j = 0; j < num_interval_y_; ++j) {
+      Eigen::VectorXd y_gray_code = gray_codes_y.cast<double>().row(j).transpose();
+      y_gray_code_cnstr.constraint()->UpdateLowerBound(y_gray_code);
+      y_gray_code_cnstr.constraint()->UpdateUpperBound(y_gray_code);
+      Eigen::Matrix<double, 3, 4> vertices;
+      vertices << phi_x_(i), phi_x_(i), phi_x_(i+1), phi_x_(i+1),
+                  phi_y_(j), phi_y_(j+1), phi_y_(j+1), phi_y_(j),
+                  phi_x_(i) * phi_y_(j), phi_x_(i) * phi_y_(j+1), phi_x_(i+1) * phi_y_(j+1), phi_x_(i+1) * phi_y_(j);
+      for (int k = 0; k < a.cols(); ++k) {
+        cost.constraint()->UpdateCoefficients(a.col(k));
+        GurobiSolver gurobi_solver;
+        if (gurobi_solver.available()) {
+          auto result = gurobi_solver.Solve(prog_);
+          EXPECT_EQ(result, SolutionResult::kSolutionFound);
+          Eigen::Matrix<double, 1, 4> cost_at_vertices = a.col(k).transpose() * vertices;
+          EXPECT_NEAR(prog_.GetOptimalCost(), cost_at_vertices.minCoeff(), 1E-4);
+        }
+      }
+    }
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    TestMixedIntegerUtil, BilinearProductMcCormickEnvelopeSOS2Test,
+    ::testing::Combine(::testing::ValuesIn(std::vector<int>{2, 3}),
+                       ::testing::ValuesIn(std::vector<int>{2, 3})));
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -201,6 +201,8 @@ TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
   // We expect the optimum obtained at one of the vertices of the tetrahedron.
   Eigen::MatrixXi gray_codes_x = math::CalculateReflectedGrayCodes(Bx_.rows());
   Eigen::MatrixXi gray_codes_y = math::CalculateReflectedGrayCodes(By_.rows());
+  // We will assign the binary variables Bx_ and By to a value in the gray code,
+  // representing integer i and j
   auto x_gray_code_cnstr =
       prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(Bx_.rows()),
                                      Eigen::VectorXd::Zero(Bx_.rows()), Bx_);
@@ -225,6 +227,8 @@ TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
           gray_codes_y.cast<double>().row(j).transpose();
       y_gray_code_cnstr.constraint()->UpdateLowerBound(y_gray_code);
       y_gray_code_cnstr.constraint()->UpdateUpperBound(y_gray_code);
+
+      // vertices.col(l) is the l'th vertex of the tetrahedron.
       Eigen::Matrix<double, 3, 4> vertices;
       vertices << phi_x_(i), phi_x_(i), phi_x_(i + 1), phi_x_(i + 1), phi_y_(j),
           phi_y_(j + 1), phi_y_(j + 1), phi_y_(j), phi_x_(i) * phi_y_(j),

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -160,6 +160,21 @@ GTEST_TEST(TestLogarithmicSOS1, Test5Lambda) {
   auto codes = math::CalculateReflectedGrayCodes<3>();
   LogarithmicSOS1Test(5, codes.topRows<5>());
 }
+
+class BilinearProductMcCormickEnvelopeSOS2Test : public ::testing::TestWithParam<int> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BilinearProductMcCormickEnvelopeSOS2Test)
+
+  BilinearProductMcCormickEnvelopeSOS2Test()
+      :
+ private:
+  MathematicalProgram prog_;
+  int num_interval_x_;
+  int num_interval_y_;
+  symbolic::Variable w_;
+  symbolic::Variable x_;
+  symbolic::Variable y_;
+};
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -216,7 +216,7 @@ TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
   // clang-format off
   a << 1, 1, 1, 1, -1, -1, -1, -1,
        1, 1, -1, -1, 1, 1, -1, -1,
-       1, -1, 1, -1, 1, -1, 1 -1;
+       1, -1, 1, -1, 1, -1, 1, -1;
   // clang-format on
   for (int i = 0; i < num_interval_x_; ++i) {
     Eigen::VectorXd x_gray_code =

--- a/drake/solvers/test/mixed_integer_optimization_util_test.cc
+++ b/drake/solvers/test/mixed_integer_optimization_util_test.cc
@@ -161,7 +161,8 @@ GTEST_TEST(TestLogarithmicSOS1, Test5Lambda) {
   LogarithmicSOS1Test(5, codes.topRows<5>());
 }
 
-class BilinearProductMcCormickEnvelopeSOS2Test : public ::testing::TestWithParam<std::tuple<int, int>> {
+class BilinearProductMcCormickEnvelopeSOS2Test
+    : public ::testing::TestWithParam<std::tuple<int, int>> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BilinearProductMcCormickEnvelopeSOS2Test)
 
@@ -176,7 +177,8 @@ class BilinearProductMcCormickEnvelopeSOS2Test : public ::testing::TestWithParam
         phi_y_{Eigen::VectorXd::LinSpaced(num_interval_y_ + 1, 0, 1)},
         Bx_{prog_.NewBinaryVariables(CeilLog2(num_interval_x_))},
         By_{prog_.NewBinaryVariables(CeilLog2(num_interval_y_))} {
-    AddBilinearProductMcCormickEnvelopeSOS2(&prog_, x_, y_, w_, phi_x_, phi_y_, Bx_, By_);
+    AddBilinearProductMcCormickEnvelopeSOS2(&prog_, x_, y_, w_, phi_x_, phi_y_,
+                                            Bx_, By_);
   }
 
  protected:
@@ -196,36 +198,48 @@ TEST_P(BilinearProductMcCormickEnvelopeSOS2Test, LinearObjectiveTest) {
   // Solve the program min aᵀ * [x;y;w]
   // s.t (x, y, w) is in the convex hull of the (x, y, x*y).
   // We fix x and y to each intervals.
+  // We expect the optimum obtained at one of the vertices of the tetrahedron.
   Eigen::MatrixXi gray_codes_x = math::CalculateReflectedGrayCodes(Bx_.rows());
   Eigen::MatrixXi gray_codes_y = math::CalculateReflectedGrayCodes(By_.rows());
-  auto x_gray_code_cnstr = prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(Bx_.rows()), Eigen::VectorXd::Zero(Bx_.rows()), Bx_);
-  auto y_gray_code_cnstr = prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(By_.rows()), Eigen::VectorXd::Zero(By_.rows()), By_);
+  auto x_gray_code_cnstr =
+      prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(Bx_.rows()),
+                                     Eigen::VectorXd::Zero(Bx_.rows()), Bx_);
+  auto y_gray_code_cnstr =
+      prog_.AddBoundingBoxConstraint(Eigen::VectorXd::Zero(By_.rows()),
+                                     Eigen::VectorXd::Zero(By_.rows()), By_);
   VectorDecisionVariable<3> xyw{x_, y_, w_};
   auto cost = prog_.AddLinearCost(Eigen::Vector3d::Zero(), xyw);
   Eigen::Matrix<double, 3, 4> a;
+  // clang-format off
   a << 1, 0, 1, -1,
-       -1, 1, 2, 1,
-       2, -1, -2, 3;
+      -1, 1, 2, 1,
+      2, -1, -2, 3;
+  // clang-format on
   for (int i = 0; i < num_interval_x_; ++i) {
-    Eigen::VectorXd x_gray_code = gray_codes_x.cast<double>().row(i).transpose();
+    Eigen::VectorXd x_gray_code =
+        gray_codes_x.cast<double>().row(i).transpose();
     x_gray_code_cnstr.constraint()->UpdateLowerBound(x_gray_code);
     x_gray_code_cnstr.constraint()->UpdateUpperBound(x_gray_code);
     for (int j = 0; j < num_interval_y_; ++j) {
-      Eigen::VectorXd y_gray_code = gray_codes_y.cast<double>().row(j).transpose();
+      Eigen::VectorXd y_gray_code =
+          gray_codes_y.cast<double>().row(j).transpose();
       y_gray_code_cnstr.constraint()->UpdateLowerBound(y_gray_code);
       y_gray_code_cnstr.constraint()->UpdateUpperBound(y_gray_code);
       Eigen::Matrix<double, 3, 4> vertices;
-      vertices << phi_x_(i), phi_x_(i), phi_x_(i+1), phi_x_(i+1),
-                  phi_y_(j), phi_y_(j+1), phi_y_(j+1), phi_y_(j),
-                  phi_x_(i) * phi_y_(j), phi_x_(i) * phi_y_(j+1), phi_x_(i+1) * phi_y_(j+1), phi_x_(i+1) * phi_y_(j);
+      vertices << phi_x_(i), phi_x_(i), phi_x_(i + 1), phi_x_(i + 1), phi_y_(j),
+          phi_y_(j + 1), phi_y_(j + 1), phi_y_(j), phi_x_(i) * phi_y_(j),
+          phi_x_(i) * phi_y_(j + 1), phi_x_(i + 1) * phi_y_(j + 1),
+          phi_x_(i + 1) * phi_y_(j);
       for (int k = 0; k < a.cols(); ++k) {
         cost.constraint()->UpdateCoefficients(a.col(k));
         GurobiSolver gurobi_solver;
         if (gurobi_solver.available()) {
           auto result = gurobi_solver.Solve(prog_);
           EXPECT_EQ(result, SolutionResult::kSolutionFound);
-          Eigen::Matrix<double, 1, 4> cost_at_vertices = a.col(k).transpose() * vertices;
-          EXPECT_NEAR(prog_.GetOptimalCost(), cost_at_vertices.minCoeff(), 1E-4);
+          Eigen::Matrix<double, 1, 4> cost_at_vertices =
+              a.col(k).transpose() * vertices;
+          EXPECT_NEAR(prog_.GetOptimalCost(), cost_at_vertices.minCoeff(),
+                      1E-4);
         }
       }
     }


### PR DESCRIPTION
Relax the bilinear product `w = x*y` to mixed-integer linear constraints. Divide the range of `x` and `y` to small intervals, and constrain the point `(x, y, w)` to be within one of the convex hulls of `w = x*y` in each interval. The convex hull is a tetrahedron.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6504)
<!-- Reviewable:end -->
