### PR TITLE
Adjust pydrake unit tests for when IPOPT is disabled

### DIFF
--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -174,6 +174,10 @@ py_test(
     srcs = ["python/pydrake/test/test_ipopt_solver.py"],
     main = "python/pydrake/test/test_ipopt_solver.py",
     deps = [":pydrake"],
+    args = select({
+        "//tools:no_ipopt": ["TestIpoptSolver.unavailable"],
+        "//conditions:default": []
+    }),
 )
 
 py_test(

--- a/drake/bindings/python/pydrake/test/test_ipopt_solver.py
+++ b/drake/bindings/python/pydrake/test/test_ipopt_solver.py
@@ -6,7 +6,7 @@ from pydrake.solvers import mathematicalprogram as mp
 from pydrake.solvers.ipopt import IpoptSolver
 
 
-class TestMathematicalProgram(unittest.TestCase):
+class TestIpoptSolver(unittest.TestCase):
     def test_ipopt_solver(self):
         prog = mp.MathematicalProgram()
         x = prog.NewContinuousVariables(2, "x")
@@ -22,6 +22,11 @@ class TestMathematicalProgram(unittest.TestCase):
         self.assertEqual(result, mp.SolutionResult.kSolutionFound)
         x_expected = np.array([1, 1])
         self.assertTrue(np.allclose(prog.GetSolution(x), x_expected))
+
+    def unavailable(self):
+        """Per the BUILD file, this test is only run when IPOPT is disabled."""
+        solver = IpoptSolver()
+        self.assertFalse(solver.available())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #6500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6512)
<!-- Reviewable:end -->
