### PR TITLE
Add both static and dynamic sized variables

### DIFF
--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -133,38 +133,6 @@ VectorXDecisionVariable MathematicalProgram::NewVariables(
   return NewVariables(type, rows, 1, false, names);
 }
 
-VectorXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    int rows, const vector<string>& names) {
-  return NewVariables(VarType::CONTINUOUS, rows, names);
-}
-
-MatrixXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    int rows, int cols, const vector<string>& names) {
-  return NewVariables(VarType::CONTINUOUS, rows, cols, false, names);
-}
-
-VectorXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    int rows, const string& name) {
-  vector<string> names(rows);
-  for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + "(" + to_string(i) + ")";
-  }
-  return NewContinuousVariables(rows, names);
-}
-
-MatrixXDecisionVariable MathematicalProgram::NewContinuousVariables(
-    int rows, int cols, const string& name) {
-  vector<string> names(rows * cols);
-  int count = 0;
-  for (int j = 0; j < static_cast<int>(cols); ++j) {
-    for (int i = 0; i < static_cast<int>(rows); ++i) {
-      names[count] = name + "(" + to_string(i) + "," + to_string(j) + ")";
-      ++count;
-    }
-  }
-  return NewContinuousVariables(rows, cols, names);
-}
-
 MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
     int rows, int cols, const vector<string>& names) {
   return NewVariables(VarType::BINARY, rows, cols, false, names);

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -128,34 +128,6 @@ MatrixXDecisionVariable MathematicalProgram::NewVariables(
   return decision_variable_matrix;
 }
 
-VectorXDecisionVariable MathematicalProgram::NewVariables(
-    VarType type, int rows, const vector<string>& names) {
-  return NewVariables(type, rows, 1, false, names);
-}
-
-MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    int rows, int cols, const vector<string>& names) {
-  return NewVariables(VarType::BINARY, rows, cols, false, names);
-}
-
-MatrixXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    int rows, int cols, const string& name) {
-  vector<string> names(rows * cols);
-  int count = 0;
-  for (int j = 0; j < static_cast<int>(cols); ++j) {
-    for (int i = 0; i < static_cast<int>(rows); ++i) {
-      names[count] = name + "(" + to_string(i) + "," + to_string(j) + ")";
-      ++count;
-    }
-  }
-  return NewBinaryVariables(rows, cols, names);
-}
-
-MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
-    int rows, const vector<string>& names) {
-  return NewVariables(VarType::CONTINUOUS, rows, rows, true, names);
-}
-
 MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
     int rows, const string& name) {
   vector<string> names(rows * (rows + 1) / 2);
@@ -167,15 +139,6 @@ MatrixXDecisionVariable MathematicalProgram::NewSymmetricContinuousVariables(
     }
   }
   return NewVariables(VarType::CONTINUOUS, rows, rows, true, names);
-}
-
-VectorXDecisionVariable MathematicalProgram::NewBinaryVariables(
-    int rows, const string& name) {
-  vector<string> names(rows);
-  for (int i = 0; i < static_cast<int>(rows); ++i) {
-    names[i] = name + "(" + to_string(i) + ")";
-  }
-  return NewVariables(VarType::BINARY, rows, names);
 }
 
 MatrixXIndeterminate MathematicalProgram::NewIndeterminates(

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -219,6 +219,9 @@ struct NewSymmetricVariableNames
                                                      : Rows*(Rows + 1) / 2> {};
 
 namespace internal {
+/**
+ * Return un-initialized new variable names.
+ */
 template <int Size>
 typename std::enable_if< Size >= 0, typename NewVariableNames<Size>::type>::type
 CreateNewVariableNames(int) {
@@ -226,6 +229,9 @@ CreateNewVariableNames(int) {
   return names;
 }
 
+/**
+ * Return un-initialized new variable names.
+ */
 template <int Size>
 typename std::enable_if<Size == Eigen::Dynamic,
                         typename NewVariableNames<Size>::type>::type

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -265,7 +265,7 @@ class MathematicalProgram {
    * and/or constraints to have any effect during optimization.
    * Callers can also set the initial guess of the decision variables through
    * SetInitialGuess() or SetInitialGuessForAllVariables().
-   * @tparam Rows  The number of rows in the new variables.
+   * @param rows  The number of rows in the new variables.
    * @param name The name of the newly added variables
    * @return The VectorDecisionVariable of size rows x 1, containing the new
    * vars (not all the vars stored).
@@ -273,24 +273,13 @@ class MathematicalProgram {
    * Example:
    * @code{.cc}
    * MathematicalProgram prog;
-   * auto x = prog.NewContinuousVariables<2>("x");
+   * auto x = prog.NewContinuousVariables(2, "x");
    * @endcode
    * This adds a 2 x 1 vector containing decision variables into the program.
    * The names of the variables are "x(0)" and "x(1)".
    *
    * The name of the variable is only used for the user in order to ease
    * readability.
-   */
-  template <int Rows>
-  VectorDecisionVariable<Rows> NewContinuousVariables(
-      const std::string& name = "x") {
-    return NewContinuousVariables<Rows, 1>(Rows, 1, name);
-  }
-
-  /**
-   * Adds continuous variables to this MathematicalProgram.
-   * @see NewContinuousVariables(int rows, int cols, const
-   * std::vector<std::string>& names);
    */
   VectorXDecisionVariable NewContinuousVariables(
       int rows, const std::string& name = "x") {
@@ -348,7 +337,7 @@ class MathematicalProgram {
    * Callers can also set the initial guess of the decision variables through
    * SetInitialGuess() or SetInitialGuessForAllVariables().
    * @tparam Rows  The number of rows in the new variables.
-   * @tparam Cols  The number of columns in the new variables.
+   * @tparam Cols  The number of columns in the new variables. The default is 1.
    * @param name All variables will share the same name, but different index.
    * @return The MatrixDecisionVariable of size rows x cols, containing the new
    * vars (not all the vars stored).
@@ -363,7 +352,7 @@ class MathematicalProgram {
    * The name of the variable is only used for the user in order to ease
    * readability.
    */
-  template <int Rows, int Cols>
+  template <int Rows, int Cols = 1>
   MatrixDecisionVariable<Rows, Cols> NewContinuousVariables(
       const std::string& name = "X") {
     return NewContinuousVariables<Rows, Cols>(Rows, Cols, name);
@@ -402,35 +391,22 @@ class MathematicalProgram {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names = internal::CreateNewVariableNames<MultiplyEigenSizes<Rows, Cols>::value>(rows * cols);
-    internal::SetVariableNames(name, Rows, Cols, &names);
+    internal::SetVariableNames(name, rows, cols, &names);
     return NewVariables<Rows, Cols>(VarType::BINARY, names, rows, cols);
   }
 
   /**
    * Adds a matrix of binary variables into the optimization program.
-   * @tparam rows The number of rows in the newly added binary variables.
-   * @tparam cols  The number of columns in the new variables.
+   * @tparam Rows The number of rows in the newly added binary variables.
+   * @tparam Cols  The number of columns in the new variables. The default is 1.
    * @param name Each newly added binary variable will share the same name. The
    * default name is "b".
    * @return A matrix containing the newly added variables.
    */
-  template <int rows, int cols>
-  MatrixDecisionVariable<rows, cols> NewBinaryVariables(
+  template <int Rows, int Cols = 1>
+  MatrixDecisionVariable<Rows, Cols> NewBinaryVariables(
       const std::string& name = "b") {
-    return NewBinaryVariables<rows, cols>(rows, cols, name);
-  }
-
-  /**
-   * Adds vector of binary variables into the optimization program.
-   * @tparam rows The number of rows in the newly added binary variables.
-   * @param name Each newly added binary variable will share the same name. The
-   * default name is "b".
-   * @return A vector containing the newly added variables.
-   */
-  template <int rows>
-  VectorDecisionVariable<rows> NewBinaryVariables(
-      const std::string& name = "b") {
-    return NewBinaryVariables<rows, 1>(rows, 1, name);
+    return NewBinaryVariables<Rows, Cols>(Rows, Cols, name);
   }
 
   /**
@@ -2337,10 +2313,8 @@ class MathematicalProgram {
    */
   template <int Rows, int Cols>
   MatrixDecisionVariable<Rows, Cols> NewVariables(
-      VarType type,
-      const typename NewVariableName<Rows == Eigen::Dynamic ||
-                                         Cols == Eigen::Dynamic ? Eigen::Dynamic
-                                             : Rows * Cols>::type& names,
+      VarType type, const typename NewVariableName<
+                        MultiplyEigenSizes<Rows, Cols>::value>::type& names,
       int rows, int cols) {
     DRAKE_DEMAND(rows >= 0 && cols >= 0);
     MatrixDecisionVariable<Rows, Cols> decision_variable_matrix;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -207,13 +207,6 @@ struct NewVariableNameType<Eigen::Dynamic> {
   typedef std::vector<std::string> type;
 };
 
-constexpr int VariableSize(int rows, int cols) {
-  if (rows == Eigen::Dynamic || cols == Eigen::Dynamic) {
-    return Eigen::Dynamic;
-  }
-  return rows * cols;
-}
-
 class MathematicalProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MathematicalProgram)

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -207,7 +207,7 @@ struct NewVariableNameType<Eigen::Dynamic> {
   typedef std::vector<std::string> type;
 };
 
-namespace {
+namespace internal {
 /**
  * Set the names of the newly added variables.
  * @param name The common name of all new variables.
@@ -230,7 +230,7 @@ void SetVariableNames(const std::string& name, int rows, int cols,
     }
   }
 }
-}  // anonymous namespace
+}  // namespace internal
 
 class MathematicalProgram {
  public:
@@ -296,7 +296,7 @@ class MathematicalProgram {
                           MatrixDecisionVariable<Rows, Cols>>::type
   NewContinuousVariables(int, int, const std::string& name) {
     std::array<std::string, Rows * Cols> names;
-    SetVariableNames(name, Rows, Cols, &names);
+    internal::SetVariableNames(name, Rows, Cols, &names);
     return NewVariables<Rows, Cols>(VarType::CONTINUOUS, names, Rows, Cols);
   }
 
@@ -333,7 +333,7 @@ class MathematicalProgram {
   NewContinuousVariables(int rows, int cols, const std::string& name = "X") {
     DRAKE_DEMAND(rows >= 0 && cols >= 0);
     std::vector<std::string> names(rows * cols);
-    SetVariableNames(name, rows, cols, &names);
+    internal::SetVariableNames(name, rows, cols, &names);
     return NewVariables<Rows, Cols>(VarType::CONTINUOUS, names, rows, cols);
   }
 
@@ -381,7 +381,7 @@ class MathematicalProgram {
                           MatrixDecisionVariable<Rows, Cols>>::type
   NewBinaryVariables(int, int, const std::string& name) {
     std::array<std::string, Rows * Cols> names;
-    SetVariableNames(name, Rows, Cols, &names);
+    internal::SetVariableNames(name, Rows, Cols, &names);
     return NewVariables<Rows, Cols>(VarType::BINARY, names, Rows, Cols);
   }
 
@@ -417,7 +417,7 @@ class MathematicalProgram {
                           MatrixDecisionVariable<Rows, Cols>>::type
   NewBinaryVariables(int rows, int cols, const std::string& name) {
     std::vector<std::string> names(rows * cols);
-    SetVariableNames(name, rows, cols, &names);
+    internal::SetVariableNames(name, rows, cols, &names);
     return NewVariables<Rows, Cols>(VarType::BINARY, names, rows, cols);
   }
 

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -224,6 +224,55 @@ GTEST_TEST(testAddVariable, testAddContinuousVariable4) {
                      MathematicalProgram::VarType::CONTINUOUS);
 }
 
+GTEST_TEST(testAddVariable, testAddContinuousVariable5) {
+  // Adds a static-sized matrix of continuous variables.
+  MathematicalProgram prog;
+  auto X = prog.NewContinuousVariables<2, 3>(2, 3, "X");
+  static_assert(is_same<decltype(X), MatrixDecisionVariable<2, 3>>::value,
+                "should be a static sized matrix");
+  CheckAddedVariable(prog, X, "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n",
+                     false, MathematicalProgram::VarType::CONTINUOUS);
+}
+
+GTEST_TEST(testAddVariable, testAddContinuousVariables6) {
+  // Adds a dynamic-sized matrix of continuous variables.
+  MathematicalProgram prog;
+  auto X =
+      prog.NewContinuousVariables<Eigen::Dynamic, Eigen::Dynamic>(2, 3, "X");
+  static_assert(is_same<decltype(X), MatrixXDecisionVariable>::value,
+                "should be a dynamic sized matrix");
+  EXPECT_EQ(X.rows(), 2);
+  EXPECT_EQ(X.cols(), 3);
+  CheckAddedVariable(prog, X, "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n",
+                     false, MathematicalProgram::VarType::CONTINUOUS);
+}
+
+GTEST_TEST(testAddVariable, testAddContinuousVariables7) {
+  // Adds a dynamic-sized matrix of continuous variables.
+  MathematicalProgram prog;
+  auto X = prog.NewContinuousVariables<2, Eigen::Dynamic>(2, 3, "X");
+  static_assert(
+      is_same<decltype(X), MatrixDecisionVariable<2, Eigen::Dynamic>>::value,
+      "should be a dynamic sized matrix");
+  EXPECT_EQ(X.rows(), 2);
+  EXPECT_EQ(X.cols(), 3);
+  CheckAddedVariable(prog, X, "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n",
+                     false, MathematicalProgram::VarType::CONTINUOUS);
+}
+
+GTEST_TEST(testAddVariable, testAddContinuousVariables8) {
+  // Adds a dynamic-sized matrix of continuous variables.
+  MathematicalProgram prog;
+  auto X = prog.NewContinuousVariables<Eigen::Dynamic, 3>(2, 3, "X");
+  static_assert(
+      is_same<decltype(X), MatrixDecisionVariable<Eigen::Dynamic, 3>>::value,
+      "should be a dynamic sized matrix");
+  EXPECT_EQ(X.rows(), 2);
+  EXPECT_EQ(X.cols(), 3);
+  CheckAddedVariable(prog, X, "X(0,0) X(0,1) X(0,2)\nX(1,0) X(1,1) X(1,2)\n",
+                     false, MathematicalProgram::VarType::CONTINUOUS);
+}
+
 GTEST_TEST(testAddVariable, testAddSymmetricVariable1) {
   // Adds a static-sized symmetric matrix of continuous variables.
   MathematicalProgram prog;
@@ -262,6 +311,18 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable1) {
                      false, MathematicalProgram::VarType::BINARY);
 }
 
+GTEST_TEST(testAddVariable, testAddBinaryVariable2) {
+  // Adds a dynamic-sized matrix of binary variables.
+  MathematicalProgram prog;
+  auto X = prog.NewBinaryVariables<Eigen::Dynamic, Eigen::Dynamic>(2, 3, "B");
+  static_assert(is_same<decltype(X), MatrixXDecisionVariable>::value,
+                "wrong type");
+  EXPECT_EQ(X.rows(), 2);
+  EXPECT_EQ(X.cols(), 3);
+  CheckAddedVariable(prog, X, "B(0,0) B(0,1) B(0,2)\nB(1,0) B(1,1) B(1,2)\n",
+                     false, MathematicalProgram::VarType::BINARY);
+}
+
 GTEST_TEST(testAddVariable, testAddBinaryVariable3) {
   // Adds dynamic-sized vector of binary variables.
   MathematicalProgram prog;
@@ -281,6 +342,50 @@ GTEST_TEST(testAddVariable, testAddBinaryVariable4) {
                 "wrong type");
   CheckAddedVariable(prog, X, "B(0)\nB(1)\nB(2)\nB(3)\n", false,
                      MathematicalProgram::VarType::BINARY);
+}
+
+GTEST_TEST(testAddVariable, testAddBinaryVariable5) {
+  // Adds a static-sized matrix of binary variables.
+  MathematicalProgram prog;
+  auto X = prog.NewBinaryVariables<2, 3>("B");
+  static_assert(is_same<decltype(X), MatrixDecisionVariable<2, 3>>::value,
+                "wrong type");
+  CheckAddedVariable(prog, X, "B(0,0) B(0,1) B(0,2)\nB(1,0) B(1,1) B(1,2)\n",
+                     false, MathematicalProgram::VarType::BINARY);
+}
+
+GTEST_TEST(testAddVariable, testAddBinaryVariable6) {
+  // Adds a static-sized matrix of binary variables.
+  MathematicalProgram prog;
+  auto X = prog.NewBinaryVariables<2, 3>(2, 3, "B");
+  static_assert(is_same<decltype(X), MatrixDecisionVariable<2, 3>>::value,
+                "wrong type");
+  CheckAddedVariable(prog, X, "B(0,0) B(0,1) B(0,2)\nB(1,0) B(1,1) B(1,2)\n",
+                     false, MathematicalProgram::VarType::BINARY);
+}
+
+GTEST_TEST(testAddVariable, testAddBinaryVariable7) {
+  // Adds a dynamic-sized matrix of binary variables.
+  MathematicalProgram prog;
+  auto X = prog.NewBinaryVariables<2, Eigen::Dynamic>(2, 3, "B");
+  static_assert(
+      is_same<decltype(X), MatrixDecisionVariable<2, Eigen::Dynamic>>::value,
+      "wrong type");
+  EXPECT_EQ(X.cols(), 3);
+  CheckAddedVariable(prog, X, "B(0,0) B(0,1) B(0,2)\nB(1,0) B(1,1) B(1,2)\n",
+                     false, MathematicalProgram::VarType::BINARY);
+}
+
+GTEST_TEST(testAddVariable, testAddBinaryVariable8) {
+  // Adds a dynamic-sized matrix of binary variables.
+  MathematicalProgram prog;
+  auto X = prog.NewBinaryVariables<Eigen::Dynamic, 3>(2, 3, "B");
+  static_assert(
+      is_same<decltype(X), MatrixDecisionVariable<Eigen::Dynamic, 3>>::value,
+      "wrong type");
+  EXPECT_EQ(X.rows(), 2);
+  CheckAddedVariable(prog, X, "B(0,0) B(0,1) B(0,2)\nB(1,0) B(1,1) B(1,2)\n",
+                     false, MathematicalProgram::VarType::BINARY);
 }
 
 GTEST_TEST(testAddIndeterminates, testAddIndeterminates1) {


### PR DESCRIPTION
Previously we have separate APIs to add static and dynamic sized variables. This causes issue if we have a function that adds new variables whose size depends on the input argument, that we cannot use a unified API to handle both cases. For example
```C++
template<Derived>
void foo(const Derived& x) {
  MathematicalProgram prog;
  auto y_static = prog.NewContinuousVariables<Derived::RowsAtCompileTime>(); // If Derived has a static size at compile time.
  auto y_dynamic = prog.NewContinuousVariables(x.rows()); // If Derived has a dynamic size at compile time.
}
```
Namely I cannot use one single API to handle both cases for static and dynamic size.
Now with the newly introduced API, we can do
```C++
template<typename Derived>
void foo(const Derived& x) {
  MathematicalProgram prog;
  auto y = prog.NewContinuousVariables<Derived::RowsAtCompileTime, Derived::ColsAtCompileTime>(x.rows(), x.cols()); // This works for both static-sized x and dynamic-sized x
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6516)
<!-- Reviewable:end -->
