### PR TITLE
Avoiding accessing a null pointer in RBT::collisionDetectFromPoints

### DIFF
--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -817,7 +817,10 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     normal.col(i) = closest_points[i].normal;
     phi[i] = closest_points[i].distance;
     const DrakeCollision::Element* elementB = closest_points[i].elementB;
-    body_idx.push_back(elementB->get_body()->get_body_index());
+    if (elementB)
+      body_idx.push_back(elementB->get_body()->get_body_index());
+    else
+      body_idx.push_back(-1);
   }
 }
 

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -817,7 +817,7 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     normal.col(i) = closest_points[i].normal;
     phi[i] = closest_points[i].distance;
     const DrakeCollision::Element* elementB = closest_points[i].elementB;
-    // In the case of not closest points, elementB can come back
+    // In the case that no closest point was found, elementB will come back
     // as a null pointer which we should not attempt to access.
     if (elementB) {
       body_idx.push_back(elementB->get_body()->get_body_index());

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -817,10 +817,13 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     normal.col(i) = closest_points[i].normal;
     phi[i] = closest_points[i].distance;
     const DrakeCollision::Element* elementB = closest_points[i].elementB;
-    if (elementB)
+    // In the case of not closest points, elementB can come back
+    // as a null pointer which we should not attempt to access.
+    if (elementB) {
       body_idx.push_back(elementB->get_body()->get_body_index());
-    else
+    } else {
       body_idx.push_back(-1);
+    }
   }
 }
 

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -962,6 +962,29 @@ class RigidBodyTree {
   /**
    * Computes the *signed* distance from the given points to the nearest body in
    * the RigidBodyTree.
+   *
+   * @param cache[in] a KinematicsCache constructed by RigidBodyTree::doKinematics
+   * given `q` and `v`.
+   *
+   * @param[in] points A 3xN matrix of points, in world frame, to which signed
+   * distance will be computed.
+   *
+   * @param[out] phi Resized to N elements and filled with the computed signed
+   * distances, or inf if no closest point was found. If no closest point
+   * was found, all other output parameters are undefined.
+   * @param[out] normal Resized to 3xN elements and filled with mesh normals,
+   * in world frame, at the closest point on the mesh to each point in
+   * `points`.
+   * @param[out] x Resized to 3xN elements and filled with the closest points
+   * in world frame on the mesh to each point in `points`.
+   * @param[out] body_x Resized to 3xN elements and filled with the closest
+   * points in body frame of the closest body, to each point in `points`.
+   * @param[out] body_idx Resized to N elements and filled with the body idx
+   * of the closest body to each point in `points`. Beware: will be set to -1
+   * if no closest body was found.
+   * @param[in] use_margins Whether to pad each collision body with a narrow
+   * (see bullet_model) margin to improve stability of normal estimation at
+   * the  cost of the accuracy of closest points calculations.
    */
   void collisionDetectFromPoints(
       const KinematicsCache<double>& cache,

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -960,31 +960,31 @@ class RigidBodyTree {
                         bool use_margins = false);
 
   /**
-   * Computes the *signed* distance from the given points to the nearest body in
-   * the RigidBodyTree.
+   * Computes the *signed* distance from the given points to the nearest body
+   * in the RigidBodyTree.
    *
-   * @param cache[in] a KinematicsCache constructed by RigidBodyTree::doKinematics
-   * given `q` and `v`.
-   *
+   * @param[in] cache a KinematicsCache constructed by
+   * RigidBodyTree::doKinematics given `q` and `v`.
    * @param[in] points A 3xN matrix of points, in world frame, to which signed
    * distance will be computed.
-   *
    * @param[out] phi Resized to N elements and filled with the computed signed
-   * distances, or inf if no closest point was found. If no closest point
-   * was found, all other output parameters are undefined.
-   * @param[out] normal Resized to 3xN elements and filled with mesh normals,
-   * in world frame, at the closest point on the mesh to each point in
-   * `points`.
+   * distances, or inf if no closest point was found.
+   * @param[out] normal Resized to 3xN elements and filled with collision
+   * element normals in world frame, at the closest point on the collision
+   * geometry to each point in `points`. Undefined where no closest point was
+   * found.
    * @param[out] x Resized to 3xN elements and filled with the closest points
-   * in world frame on the mesh to each point in `points`.
+   * on the collision geometry to each point in `points`, in world frame.
+   * Undefined where no closest point was found.
    * @param[out] body_x Resized to 3xN elements and filled with the closest
-   * points in body frame of the closest body, to each point in `points`.
+   * points on the collision geometry to each point in `points`, in the body
+   * frame of the closest body. Undefined where no closest point was found.
    * @param[out] body_idx Resized to N elements and filled with the body idx
-   * of the closest body to each point in `points`. Beware: will be set to -1
-   * if no closest body was found.
+   * of the closest body to each point in `points`, or -1 where no closest
+   * body was found.
    * @param[in] use_margins Whether to pad each collision body with a narrow
    * (see bullet_model) margin to improve stability of normal estimation at
-   * the  cost of the accuracy of closest points calculations.
+   * the cost of the accuracy of closest points calculations.
    */
   void collisionDetectFromPoints(
       const KinematicsCache<double>& cache,


### PR DESCRIPTION
I ran into this case during development a while back; it required some special circumstances to cause it to happen (the collision engine needs to find no other objects to check distance against), but it seemed worth guarding anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6522)
<!-- Reviewable:end -->
