### PR TITLE
Adding A TSan Suppression For Gurobi

### DIFF
--- a/tools/tsan.supp
+++ b/tools/tsan.supp
@@ -25,3 +25,6 @@ thread:__kmp_create_monitor
 
 # data race (libglib-2.0.*) in g_static_rec_mutex_lock
 race:g_static_rec_mutex_lock
+
+# data race in libgurobi70.so.  Gurobi has not been instrumented with TSan.
+called_from_lib:libgurobi.so


### PR DESCRIPTION
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-experimental-memcheck-tsan-everything/5/consoleText

@hongkai-dai confirmed that this race wasn't there when Gurobi 6.x.x was being used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6528)
<!-- Reviewable:end -->
