### PR TITLE
Update supported Bazel version to 0.5.2

### DIFF
--- a/drake/doc/developers.rst
+++ b/drake/doc/developers.rst
@@ -89,8 +89,8 @@ Bazel, and there are no plans to add support.
 +------------------------------+------------------+--------------------+-------------------+---------+
 | Operating System             | Build Systems    | Compilers          | Superbuild Deps   | Build   |
 +==============================+==================+====================+===================+=========+
-| Ubuntu 14.04 LTS ("Trusty")  | | CMake 3.5      | | GCC 4.9          | Minimal           | Debug   |
-|                              | | Bazel 0.4.5    | | Java 1.8         |                   +---------+
+| Ubuntu 14.04 LTS ("Trusty")  | | CMake 3.5.2    | | GCC 4.9          | Minimal           | Debug   |
+|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
 |                              |                  |                    |                   | Release |
 |                              |                  |                    +-------------------+---------+
 |                              |                  |                    | Default           | Debug   |
@@ -100,19 +100,19 @@ Bazel, and there are no plans to add support.
 |                              |                  |                    | Default + MATLAB  | Release |
 |                              |                  +--------------------+-------------------+---------+
 |                              |                  | | Clang 3.9        | Default           | Debug   |
-|                              |                  | | Java 1.7         |                   +---------+
+|                              |                  | | Java 1.8         |                   +---------+
 |                              |                  |                    |                   | Release |
 +------------------------------+------------------+--------------------+-------------------+---------+
-| Ubuntu 16.04 LTS ("Xenial")  | | CMake 3.5      | | GCC 5.4          | Default           | Debug   |
-|                              | | Bazel 0.4.5    | | Java 1.8         |                   +---------+
+| Ubuntu 16.04 LTS ("Xenial")  | | CMake 3.5.1    | | GCC 5.4          | Default           | Debug   |
+|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
 |                              |                  |                    |                   | Release |
 |                              |                  +--------------------+-------------------+---------+
 |                              |                  | | Clang 3.9        | Default           | Debug   |
 |                              |                  | | Java 1.8         |                   +---------+
 |                              |                  |                    |                   | Release |
 +------------------------------+------------------+--------------------+-------------------+---------+
-| OS X 10.10                   | | CMake 3.5      | | Apple Clang 7.0  | Minimal           | Debug   |
-|                              | | Bazel 0.4.5    | | Java 1.8         |                   +---------+
+| OS X 10.11 ("El Capitan")    | | CMake 3.5.2    | | Apple Clang 7.0  | Minimal           | Debug   |
+|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
 |                              |                  |                    |                   | Release |
 |                              |                  |                    +-------------------+---------+
 |                              |                  |                    | Default           | Debug   |

--- a/drake/doc/mac.rst
+++ b/drake/doc/mac.rst
@@ -6,7 +6,7 @@ We assume that you have already installed:
 
 * `Xcode 7.3.1 or above <https://developer.apple.com/xcode/download/>`_ and the Command Line Tools (``xcode-select --install``)
 * `XQuartz 2.7.8 or above <https://www.xquartz.org/releases/>`_
-* `Java SE Development Kit 7 or above <http://www.oracle.com/technetwork/java/javase/downloads/>`_
+* `Java SE Development Kit 8 or above <http://www.oracle.com/technetwork/java/javase/downloads/>`_
 
 Using the Bazel Build System
 ============================

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -36,11 +36,11 @@ Clang 3.9::
 CMake
 -----
 
-CMake 3.5 or higher is required. Visit the `CMake Download Page`_ to obtain
-the CMake 3.5 pre-compiled binaries.  Extract the archive and add its ``bin``
+CMake 3.5.2 or higher is required. Visit the `CMake Download Page`_ to obtain
+the CMake 3.5.2 pre-compiled binaries.  Extract the archive and add its ``bin``
 directory to the ``PATH`` environment variable. For example, below is a
-suggested sequence of commands that installs CMake 3.5 into `~/tools/` and then
-modifies `~/.bashrc` with the new ``PATH`` environment variable::
+suggested sequence of commands that installs CMake 3.5.2 into `~/tools/` and
+then modifies `~/.bashrc` with the new ``PATH`` environment variable::
 
     mkdir -p ~/tools
     cd ~/tools
@@ -70,9 +70,9 @@ Be sure to install a version that is consistent with Drake's
 
 Here's a short recipe that summarizes the instructions on that page::
 
-    wget https://github.com/bazelbuild/bazel/releases/download/0.4.3/bazel_0.4.3-linux-x86_64.deb
-    echo "0cd6592ac2c5548d566fa9f874a386737e76029f5aabe1f04f8320173a05280d  bazel_0.4.3-linux-x86_64.deb" > bazel_0.4.3-linux-x86_64.deb.sha256
-    sha256sum --check bazel_0.4.3-linux-x86_64.deb.sha256 && sudo dpkg -i bazel_0.4.3-linux-x86_64.deb
+    wget https://github.com/bazelbuild/bazel/releases/download/0.5.2/bazel_0.5.2-linux-x86_64.deb
+    echo "b14c8773dab078d3422fe4082f3ab4d9e14f02313c3b3eb4b5b40c44ce29ed59  bazel_0.5.2-linux-x86_64.deb" > bazel_0.5.2-linux-x86_64.deb.sha256
+    sha256sum --check bazel_0.5.2-linux-x86_64.deb.sha256 && sudo dpkg -i bazel_0.5.2-linux-x86_64.deb
 
 
 Other Prerequisites
@@ -82,21 +82,19 @@ Other prerequisites may be installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
-      autoconf automake bison doxygen freeglut3-dev git graphviz \
-      libboost-dev libboost-system-dev libgtk2.0-dev libhtml-form-perl \
-      libjpeg-dev libmpfr-dev libpng-dev libterm-readkey-perl libtinyxml-dev \
-      libtool libvtk5-dev libwww-perl make ninja-build \
-      patchutils perl pkg-config \
-      python-bs4 python-dev python-gtk2 python-html5lib python-numpy \
-      python-pip python-sphinx python-yaml unzip valgrind
+      autoconf automake bison doxygen freeglut3-dev git graphviz libboost-dev \
+      libboost-system-dev libgtk2.0-dev libjpeg-dev libmpfr-dev libpng-dev \
+      libtinyxml-dev libtool libvtk5-dev make ninja-build patchutils perl \
+      pkg-config python-bs4 python-dev python-gtk2 python-html5lib \
+      python-numpy python-pip python-sphinx python-yaml unzip valgrind
 
 If you will be building/using Director, some additional prerequisites may be
 installed as follows::
 
     sudo apt-get update
     sudo apt-get install --no-install-recommends \
-      libqt4-dev libqt4-opengl-dev libqwt-dev \
-      libvtk-java libvtk5-qt4-dev python-lxml python-scipy python-vtk
+      libqt4-dev libqt4-opengl-dev libqwt-dev libvtk-java libvtk5-qt4-dev \
+      python-lxml python-scipy python-vtk
 
 Note that the above installs an old version of VTK that is required by Drake. If
 a different version needs to be installed, Drake's build system can be

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+#
 # Prerequisite set-up script for Drake on Ubuntu 16.04.
-# 16.04 support is in beta. It is not tested in CI or officially supported.
 
 set -eu
 
@@ -39,19 +39,18 @@ while true; do
 done
 
 # The CI scripts require a newer version of CMake than apt installs.
-# Only install CMake if it's not installed or older than 3.5.
+# Only install CMake if it's not installed or older than 3.5.1.
 install_cmake=true
 if command -v cmake &>/dev/null; then
   cmake_version=$(cmake --version) &>/dev/null
-  cmake_version=${cmake_version:14:3}
-  if dpkg --compare-versions $cmake_version ge 3.5; then
+  cmake_version=${cmake_version:14:5}
+  if dpkg --compare-versions $cmake_version ge 3.5.1; then
     echo "CMake is already installed ($cmake_version)"
     install_cmake=false
   fi
 fi
 if $install_cmake; then
-  apt install --no-install-recommends cmake
-  apt install --no-install-recommends cmake-curses-gui
+  apt install --no-install-recommends cmake cmake-curses-gui
 fi
 
 # Install the APT dependencies.
@@ -65,7 +64,6 @@ automake
 bash-completion
 bison
 clang-format
-default-jdk
 doxygen
 fakeroot
 flex
@@ -82,7 +80,6 @@ graphviz
 libboost-dev
 libboost-system-dev
 libgtk2.0-dev
-libhtml-form-perl
 libmpfr-dev
 libpng12-dev
 libqt4-dev
@@ -99,6 +96,7 @@ libvtk5-qt4-dev
 libxmu-dev
 make
 ninja-build
+openjdk-8-jdk
 patchutils
 perl
 pkg-config
@@ -122,15 +120,15 @@ EOF
     )
 
 # Install Bazel.
-wget -O /tmp/bazel_0.4.5-linux-x86_64.deb https://github.com/bazelbuild/bazel/releases/download/0.4.5/bazel_0.4.5-linux-x86_64.deb
-if echo "b494d0a413e4703b6cd5312403bea4d92246d6425b3be68c9bfbeb8cc4db8a55 /tmp/bazel_0.4.5-linux-x86_64.deb" | sha256sum -c -; then
-  dpkg -i /tmp/bazel_0.4.5-linux-x86_64.deb
+wget -O /tmp/bazel_0.5.2-linux-x86_64.deb https://github.com/bazelbuild/bazel/releases/download/0.5.2/bazel_0.5.2-linux-x86_64.deb
+if echo "b14c8773dab078d3422fe4082f3ab4d9e14f02313c3b3eb4b5b40c44ce29ed59 /tmp/bazel_0.5.2-linux-x86_64.deb" | sha256sum -c -; then
+  dpkg -i /tmp/bazel_0.5.2-linux-x86_64.deb
 else
   echo "The Bazel deb does not have the expected SHA256.  Not installing Bazel."
   exit 1
 fi
 
-rm /tmp/bazel_0.4.5-linux-x86_64.deb
+rm /tmp/bazel_0.5.2-linux-x86_64.deb
 
 # Repair a bad Bazel/ccache interaction.
 # See https://github.com/RobotLocomotion/drake/issues/4464.


### PR DESCRIPTION
Also fixed some inconsistencies related to the supported Java version, an incorrect supported Mac version, and removed some leftover dependencies from the days of the [long since removed](https://github.com/RobotLocomotion/gurobi/pull/12) interactive Gurobi downloader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6532)
<!-- Reviewable:end -->
