### PR TITLE
Replace C*Pos intermediate variables with expressions

### DIFF
--- a/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_reachable_test.cc
@@ -32,7 +32,7 @@ TEST_F(KukaTest, ReachableTest) {
     EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
     double pos_tol = 0.06;
-    double orient_tol = 0.2;
+    double orient_tol = 0.22;
     CheckGlobalIKSolution(pos_tol, orient_tol);
     // Now call nonlinear IK with the solution from global IK as the initial
     // seed. If the global IK provides a good initial seed, then the nonlinear

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/symbolic_expression.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
@@ -92,8 +93,8 @@ void AddRotationMatrixOrthonormalSocpConstraint(
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R);
 
 using AddRotationMatrixMcCormickEnvelopeReturnType =
-std::tuple<std::vector<Eigen::Matrix<drake::symbolic::Expression, 3, 3>>,
-           std::vector<Eigen::Matrix<drake::symbolic::Expression, 3, 3>>,
+std::tuple<std::vector<Matrix3<symbolic::Expression>>,
+           std::vector<Matrix3<symbolic::Expression>>,
            std::vector<MatrixDecisionVariable<3, 3>>,
            std::vector<MatrixDecisionVariable<3, 3>>>;
 /**

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/symbolic_expression.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -91,8 +92,8 @@ void AddRotationMatrixOrthonormalSocpConstraint(
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R);
 
 using AddRotationMatrixMcCormickEnvelopeReturnType =
-std::tuple<std::vector<MatrixDecisionVariable<3, 3>>,
-           std::vector<MatrixDecisionVariable<3, 3>>,
+std::tuple<std::vector<Eigen::Matrix<drake::symbolic::Expression, 3, 3>>,
+           std::vector<Eigen::Matrix<drake::symbolic::Expression, 3, 3>>,
            std::vector<MatrixDecisionVariable<3, 3>>,
            std::vector<MatrixDecisionVariable<3, 3>>>;
 /**


### PR DESCRIPTION
This replaces some continuous variables that were carried around to make writing the rotation constraints easier. Instead, they are now formed as expressions, simplifying the optimization.

This has been deployed on my stuff for a while, but the timing differences it makes on tests relying on the rotations show that it does increase setup time, but makes longer-running solves more efficient:

All times reported below are found by running `time <the test binary>` and taking the user time (which I interpret as total CPU time spent for the process running non-syscall code). I tested each case 3 times, and numbers didn't change more than a few percent. The first two cases have lots of short-running solves, and last two cases have much longer-running solves.

| Test | Total CPU core time without change   | Total CPU core time with change |
| -------------- | ------------- | ------------- |
| rotation_constraint_test (all) | 1m 7s  | 1m 24s  |
| TestMcCormick | 0m 1.4s  | 0m 2.0s  |
| rotation_constraint_limit_test (all) | 37m 0s | 29-33m 0s |
| global_inverse_kinematics_collision_avoidance_test | 10m 40s | 4m 10s |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6533)
<!-- Reviewable:end -->
