### PR TITLE
Deprecate GetDrakePath

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -186,9 +186,6 @@ drake_cc_library(
 
 drake_cc_library(
     name = "drake_path",
-    # TODO(david-german-tri): Set testonly = 1 once the non-test uses of
-    # drake_path are removed.
-    # testonly = 1,
     srcs = ["drake_path_bazel.cc"],
     hdrs = ["drake_path.h"],
     data = [
@@ -199,6 +196,7 @@ drake_cc_library(
         ":find_resource",
         "//drake/thirdParty:spruce",
     ],
+    visibility = ["//drake:__pkg__"],
 )
 
 # TODO(jwnimmer-tri) Move this header file into test/ subdirectory (and this

--- a/drake/common/drake_path.h
+++ b/drake/common/drake_path.h
@@ -2,15 +2,13 @@
 
 #include <string>
 
-#include "drake/common/drake_compat.h"
+#include "drake/common/drake_deprecated.h"
 
 namespace drake {
 
 /// Returns the fully-qualified path to the root of the `drake` source tree.
 /// N.B: <em>not</em> the `drake-distro` source tree.
-///
-/// This method will eventually become deprecated.
-/// Please use drake::FindResource() instead.
+DRAKE_DEPRECATED("Please use drake::FindResource() instead.")
 std::string GetDrakePath();
 
 }  // namespace drake


### PR DESCRIPTION
Deprecate `GetDrakePath` and restrict its use to `libdrake.so` only.

Closes #5893.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6534)
<!-- Reviewable:end -->
