### PR TITLE
Initializing coulomb_window To Epsilon

### DIFF
--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -535,7 +535,8 @@ template <typename JointType>
 void SetDynamics(XMLElement* node, FixedAxisOneDoFJoint<JointType>* fjoint) {
   XMLElement* dynamics_node = node->FirstChildElement("dynamics");
   if (fjoint != nullptr && dynamics_node) {
-    double damping = 0.0, coulomb_friction = 0.0, coulomb_window = 0.0;
+    double damping = 0.0, coulomb_friction = 0.0;
+    double coulomb_window = std::numeric_limits<double>::epsilon();
     parseScalarAttribute(dynamics_node, "damping", damping);
     parseScalarAttribute(dynamics_node, "friction", coulomb_friction);
     parseScalarAttribute(dynamics_node, "coulomb_window", coulomb_window);


### PR DESCRIPTION
The variable `coulomb_window_` causes a divide by zero error here:
https://github.com/RobotLocomotion/drake/blob/master/drake/multibody/joints/fixed_axis_one_dof_joint.h#L117

This variable is being set in `urdf_parser.cc` via the `setDynamics` function.  We attempt to make it an epsilon, similar to the MATLAB code as pointed out by @RussTedrake: 
https://github.com/RobotLocomotion/drake/blob/last_sha_with_original_matlab/drake/matlab/systems/plants/RigidBody.m#L29

The divide by zero error: https://drake-cdash.csail.mit.edu/viewDynamicAnalysisFile.php?id=140757

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6539)
<!-- Reviewable:end -->
