### PR TITLE
Remove potentialCollisions from RigidBodyTree

### DIFF
--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -129,30 +129,6 @@ class BulletModel : public Model {
                         Eigen::VectorXd& distances,
                         Eigen::Matrix3Xd& normals) override;
 
-  /** Computes the set of potential collision points for all
-  eligible pairs of collision geometries in this model. This includes
-  the points of closest approach, but may also include additional points
-  that are "close" to being in contact. This can be useful when
-  simulating scenarios in which two collision elements have more than
-  one point of contact.
-
-  This implementation uses Bullet's random perturbation approach to
-  generate the additional contact points. Bullet performs discrete
-  collision detection multiple times with small perturbations to the
-  pose of each collision geometry. The potential collision points are
-  the union of the closest points found in each of these perturbed runs.
-
-  @param use_margins flag indicating whether or not to use the version
-  of this model with collision margins.
-
-  @returns a vector of PointPair objects containing the potential
-  collision points.
-
-  @throws An std::runtime_error if calls to this method are mixed with other
-  dispatching methods such as BulletModel::collisionPointsAllToAll since mixing
-  dispatch methods causes undefined behavior. **/
-  std::vector<PointPair> potentialCollisionPoints(bool use_margins) override;
-
   bool collidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
@@ -165,8 +141,7 @@ class BulletModel : public Model {
   enum DispatchMethod {
     kNotYetDecided,
     kClosestPointsAllToAll,
-    kCollisionPointsAllToAll,
-    kPotentialCollisionPoints
+    kCollisionPointsAllToAll
   };
 
   static constexpr double kSmallMargin = 1e-9;

--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -62,12 +62,6 @@ bool FCLModel::collisionRaycast(const Eigen::Matrix3Xd& origins,
   return false;
 }
 
-std::vector<PointPair> FCLModel::potentialCollisionPoints(bool use_margins) {
-  drake::unused(use_margins);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return std::vector<PointPair>();
-}
-
 bool FCLModel::collidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>& input_points,
     double collision_threshold) {

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -35,7 +35,6 @@ class FCLModel : public Model {
                         Eigen::Matrix3Xd& normals) override;
   bool ComputeMaximumDepthCollisionPoints(
       bool use_margins, std::vector<PointPair>& points) override;
-  std::vector<PointPair> potentialCollisionPoints(bool use_margins) override;
   std::vector<size_t> collidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -169,23 +169,6 @@ class Model {
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
       std::vector<PointPair>& closest_points) = 0;
 
-  // TODO(SeanCurtis-TRI): In the documentation below, clarify the definitions
-  // of "eligible", "additional", and "potential". Definitely do this before
-  // moving this functionality into GeometryWorld.
-  //
-  /** Computes the set of potential collision points for all eligible pairs of
-   collision geometries in this model. This includes the points of closest
-   approach, but may also include additional points that are "close" to being
-   in contact. This can be useful when simulating scenarios in which two
-   collision elements have more than one contact point.
-
-   @param use_margins A flag indicating whether or not to use the version of
-   this model with collision margins.
-
-   @return A vector of PointPair objects containing the potential collision
-   points. **/
-  virtual std::vector<PointPair> potentialCollisionPoints(bool use_margins) = 0;
-
   // TODO(SeanCurtis-TRI): Add a C++ version of "collidingPointsTest.m". Once
   // such a test exists, update the @see reference to it below.
   //

--- a/drake/multibody/collision/unusable_model.cc
+++ b/drake/multibody/collision/unusable_model.cc
@@ -61,12 +61,6 @@ bool UnusableModel::collisionRaycast(const Eigen::Matrix3Xd&,
   return false;
 }
 
-std::vector<PointPair> UnusableModel::potentialCollisionPoints(bool) {
-  DRAKE_ABORT_MSG(
-      "Compile Drake with a collision library backend for collision support!");
-  return std::vector<PointPair>();
-}
-
 bool UnusableModel::collidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>&, double) {
   DRAKE_ABORT_MSG(

--- a/drake/multibody/collision/unusable_model.h
+++ b/drake/multibody/collision/unusable_model.h
@@ -45,8 +45,6 @@ class UnusableModel : public Model {
                         Eigen::VectorXd& distances,
                         Eigen::Matrix3Xd& normals) override;
 
-  std::vector<PointPair> potentialCollisionPoints(bool use_margins) override;
-
   bool collidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -978,44 +978,6 @@ bool RigidBodyTree<T>::collisionDetect(
 }
 
 template <typename T>
-void RigidBodyTree<T>::potentialCollisions(
-    const KinematicsCache<double>& cache,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    VectorXd& phi, Matrix3Xd& normal,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    Matrix3Xd& xA, Matrix3Xd& xB,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    vector<int>& bodyA_idx,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    vector<int>& bodyB_idx,
-    bool use_margins) {
-  updateDynamicCollisionElements(cache);
-  vector<DrakeCollision::PointPair> potential_collisions;
-  potential_collisions =
-      collision_model_->potentialCollisionPoints(use_margins);
-  size_t num_potential_collisions = potential_collisions.size();
-
-  phi = VectorXd::Zero(num_potential_collisions);
-  normal = MatrixXd::Zero(3, num_potential_collisions);
-  xA = Matrix3Xd(3, num_potential_collisions);
-  xB = Matrix3Xd(3, num_potential_collisions);
-
-  bodyA_idx.clear();
-  bodyB_idx.clear();
-
-  for (size_t i = 0; i < num_potential_collisions; ++i) {
-    const DrakeCollision::Element* elementA = potential_collisions[i].elementA;
-    const DrakeCollision::Element* elementB = potential_collisions[i].elementB;
-    xA.col(i) = potential_collisions[i].ptA;
-    xB.col(i) = potential_collisions[i].ptB;
-    normal.col(i) = potential_collisions[i].normal;
-    phi[i] = potential_collisions[i].distance;
-    bodyA_idx.push_back(elementA->get_body()->get_body_index());
-    bodyB_idx.push_back(elementB->get_body()->get_body_index());
-  }
-}
-
-template <typename T>
 std::vector<DrakeCollision::PointPair>
 RigidBodyTree<T>::ComputeMaximumDepthCollisionPoints(
     const KinematicsCache<double>& cache, bool use_margins) {

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -1093,22 +1093,6 @@ class RigidBodyTree {
       Eigen::Matrix3Xd& ptsB,
       bool use_margins = true);
 
-  void potentialCollisions(
-      const KinematicsCache<double>& cache,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::VectorXd& phi,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::Matrix3Xd& normal,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::Matrix3Xd& xA,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::Matrix3Xd& xB,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<int>& bodyA_idx,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<int>& bodyB_idx,
-      bool use_margins = true);
-
   /** Computes the point of closest approach between bodies in the
    RigidBodyTree that are in contact.
 


### PR DESCRIPTION
Also removes the corresponding member function
(potentialCollisionPoints) from the collision model classes. These
functions are currently unused in Drake and Spartan, and are based on a
suspect approach to generating multiple contact points.

I'm removing unused portions of our collision model API so as to avoid unnecessary effort when implementing the FCL-based collision model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6542)
<!-- Reviewable:end -->
