### PR TITLE
Add -Werror=shadow to bazel + clang build.

### DIFF
--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -5,6 +5,7 @@
 CLANG_FLAGS = [
     "-Werror=all",
     "-Werror=inconsistent-missing-override",
+    "-Werror=shadow",
     "-Werror=sign-compare",
     "-Werror=non-virtual-dtor",
     "-Werror=return-stack-address",
@@ -12,6 +13,8 @@ CLANG_FLAGS = [
 
 # The GCC_FLAGS will be enabled for all C++ rules in the project when
 # building with gcc.
+# TODO(#2852) Turn on shadow checking for g++ once we use a version that fixes
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
 GCC_FLAGS = [
     "-Werror=all",
     "-Werror=extra",


### PR DESCRIPTION
@m-chaturvedi pointed out that the errors from #6540 do not occur in Bazel (and did not appear to happen at all in Experimental CI).

This addresses this for `bazel` + `clang`.

There is still a TODO (regarding #2852) in CMake.
However, if our minimum-supported version of GCC correctly supports `-Werror=shadow`, then I can re-enable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6543)
<!-- Reviewable:end -->
