### PR TITLE
Add symbolic polynomial

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -250,6 +250,21 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "symbolic_polynomial",
+    srcs = [
+        "symbolic_polynomial.cc",
+    ],
+    hdrs = [
+        "symbolic_polynomial.h",
+    ],
+    deps = [
+        ":common",
+        ":monomial",
+        ":symbolic",
+    ],
+)
+
+drake_cc_library(
     name = "nice_type_name",
     srcs = ["nice_type_name.cc"],
     hdrs = ["nice_type_name.h"],
@@ -691,6 +706,14 @@ drake_cc_googletest(
     deps = [
         ":common",
         ":symbolic",
+    ],
+)
+
+drake_cc_googletest(
+    name = "symbolic_polynomial_test",
+    deps = [
+        ":symbolic_polynomial",
+        ":symbolic_test_util",
     ],
 )
 

--- a/drake/common/CMakeLists.txt
+++ b/drake/common/CMakeLists.txt
@@ -27,6 +27,7 @@ set(sources
   symbolic_formula.cc
   symbolic_formula_cell.cc
   symbolic_formula_cell.h
+  symbolic_polynomial.cc
   symbolic_variable.cc
   symbolic_variables.cc
   text_logging.cc
@@ -73,6 +74,7 @@ set(installed_headers
   symbolic_expression_visitor.h
   symbolic_formula.h
   symbolic_formula_visitor.h
+  symbolic_polynomial.h
   symbolic_variable.h
   symbolic_variables.h
   text_logging.h

--- a/drake/common/monomial.cc
+++ b/drake/common/monomial.cc
@@ -111,6 +111,15 @@ Monomial::Monomial(const map<Variable, int>& powers)
 Monomial::Monomial(const Expression& e)
     : Monomial(ToMonomialPower(e.Expand())) {}
 
+int Monomial::degree(const Variable& v) const {
+  const auto it = powers_.find(v);
+  if (it == powers_.end()) {
+    return 0;
+  } else {
+    return it->second;
+  }
+}
+
 size_t Monomial::GetHash() const {
   // To get a hash value for a Monomial, we re-use the hash value for
   // powers_. This is suitable because powers_ is the only independent

--- a/drake/common/monomial.h
+++ b/drake/common/monomial.h
@@ -48,6 +48,9 @@ class Monomial {
   /** Constructs a Monomial from @p var and @exponent. */
   Monomial(const Variable& var, int exponent);
 
+  /** Returns the degree of this Monomial in a variable @p v. */
+  int degree(const Variable& v) const;
+
   /** Returns the total degree of this Monomial. */
   int total_degree() const { return total_degree_; }
 

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -173,7 +173,7 @@ Expression ExpandPow(const Expression& base, const Expression& exponent) {
     //   pow(c * ∏ᵢ pow(e₁ᵢ, e₂ᵢ), exponent)
     // = pow(c, exponent) * ∏ᵢ pow(e₁ᵢ, e₂ᵢ * exponent)
     const double c{get_constant_in_multiplication(base)};
-    auto map{get_base_to_exponent_map_in_multiplication(base)};
+    auto map = get_base_to_exponent_map_in_multiplication(base);
     for (pair<const Expression, Expression>& p : map) {
       p.second = p.second * exponent;
     }

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -976,20 +976,21 @@ namespace {
 // `e` and a constant `n`, it pushes the division in `e / n` inside for the
 // following cases:
 //
-// Case Addition      : e =  (c₀ + ∑ᵢ (cᵢ * eᵢ)) / n
+// Case Addition      :      (c₀ + ∑ᵢ (cᵢ * eᵢ)) / n
 //                        => c₀/n + ∑ᵢ (cᵢ / n * eᵢ)
 //
-// Case Multiplication: e =  (c₀ * ∏ᵢ (bᵢ * eᵢ)) / n
+// Case Multiplication:      (c₀ * ∏ᵢ (bᵢ * eᵢ)) / n
 //                        => c₀ / n * ∏ᵢ (bᵢ * eᵢ)
 //
-// Case Division      : e =  (e₁ / m) / n
+// Case Division      :      (e₁ / m) / n
 //                        => Recursively simplify e₁ / (n * m)
 //
-//                      e =  (e₁ / e₂) / n
+//                           (e₁ / e₂) / n
 //                        =  (e₁ / n) / e₂
 //                        => Recursively simplify (e₁ / n) and divide it by e₂
 //
-// For other cases, it does not perform any simplifications.
+// Other cases        :      e / n
+//                        => (1/n) * e
 //
 // Note that we use VisitExpression instead of VisitPolynomial because we want
 // to handle cases such as `(6xy / z) / 3` where (6xy / z) is not a polynomial
@@ -1034,68 +1035,68 @@ class DivExpandVisitor {
     }
   }
   Expression VisitVariable(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitConstant(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitLog(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitPow(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitAbs(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitExp(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitSqrt(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitSin(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitCos(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitTan(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitAsin(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitAcos(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitAtan(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitAtan2(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitSinh(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitCosh(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitTanh(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitMin(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitMax(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitIfThenElse(const Expression& e, const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
   Expression VisitUninterpretedFunction(const Expression& e,
                                         const double n) const {
-    return e / n;
+    return (1.0 / n) * e;
   }
 
   // Makes VisitExpression a friend of this class so that VisitExpression can

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -169,6 +169,17 @@ Expression ExpandPow(const Expression& base, const Expression& exponent) {
   // Precondition: base and exponent are already expanded.
   DRAKE_ASSERT(base.EqualTo(base.Expand()));
   DRAKE_ASSERT(exponent.EqualTo(exponent.Expand()));
+  if (is_multiplication(base)) {
+    //   pow(c * ∏ᵢ pow(e₁ᵢ, e₂ᵢ), exponent)
+    // = pow(c, exponent) * ∏ᵢ pow(e₁ᵢ, e₂ᵢ * exponent)
+    const double c{get_constant_in_multiplication(base)};
+    auto map{get_base_to_exponent_map_in_multiplication(base)};
+    for (pair<const Expression, Expression>& p : map) {
+      p.second = p.second * exponent;
+    }
+    return pow(c, exponent) * ExpressionMulFactory{1.0, map}.GetExpression();
+  }
+
   // Expand if
   //     1) base is an addition expression and
   //     2) exponent is a positive integer.

--- a/drake/common/symbolic_polynomial.cc
+++ b/drake/common/symbolic_polynomial.cc
@@ -1,0 +1,422 @@
+#include "drake/common/symbolic_polynomial.h"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#include "drake/common/symbolic_expression_visitor.h"
+
+using std::ostream;
+using std::ostringstream;
+using std::pair;
+using std::runtime_error;
+
+namespace drake {
+namespace symbolic {
+
+namespace {
+// Helper function to add coeff * m to map (Monomial → Expression).
+// Used in DecomposePolynomialVisitor::VisitAddition and Polynomial::Add.
+void DoAdd(const Expression& coeff, const Monomial& m,
+           Polynomial::MapType* const map) {
+  auto it = map->find(m);
+  if (it != map->end()) {
+    // m ∈ dom(map)
+    Expression& existing_coeff{it->second};
+    // Note that `.Expand()` is needed in the following line. For example,
+    // consider the following case:
+    //     c1 := (a + b)²
+    //     c2 := - (a² + 2ab + b²)
+    // Without expanding the terms, we have `is_zero(c1 + c2) = false` while
+    // it's clear that c1 + c2 is a zero polynomial. Using `Expand()` help us
+    // identify those cases.
+    if (is_zero(existing_coeff.Expand() + coeff.Expand())) {
+      map->erase(it);
+    } else {
+      existing_coeff += coeff;
+    }
+  } else {
+    // m ∉ dom(map)
+    map->emplace_hint(it, m, coeff);
+  }
+}
+// Visitor class to implement `Polynomial(const Expression& e, const
+// Variables& indeterminates)` constructor which decomposes an expression e
+// w.r.t. indeterminates.
+class DecomposePolynomialVisitor {
+ public:
+  Polynomial::MapType Decompose(const Expression& e,
+                                const Variables& vars) const {
+    // Note that it calls `Expression::Expand()` here.
+    return Visit(e.Expand(), vars);
+  }
+
+ private:
+  Polynomial::MapType Visit(const Expression& e, const Variables& vars) const {
+    return VisitPolynomial<Polynomial::MapType>(this, e, vars);
+  }
+
+  Polynomial::MapType VisitVariable(const Expression& e,
+                                    const Variables& vars) const {
+    const Variable& var{get_variable(e)};
+    if (vars.include(var)) {
+      // Monomial : var, coefficient : 1
+      return Polynomial::MapType{{{Monomial{var}, 1}}};
+    } else {
+      // Monomial : 1, coefficient : var
+      return Polynomial::MapType{{{Monomial{}, var}}};
+    }
+  }
+
+  Polynomial::MapType VisitConstant(const Expression& e,
+                                    const Variables&) const {
+    const double v{get_constant_value(e)};
+    if (v != 0) {
+      return Polynomial::MapType{{{Monomial(), v}}};  // = v.
+    }
+    return Polynomial::MapType{};  // = 0.
+  }
+
+  Polynomial::MapType VisitAddition(const Expression& e,
+                                    const Variables& vars) const {
+    // e = c₀ + ∑ᵢ (cᵢ * eᵢ)
+    Polynomial::MapType new_map;
+    const double c_0{get_constant_in_addition(e)};
+    if (c_0 != 0) {
+      new_map.emplace(Monomial{}, c_0);
+    }
+    for (const pair<Expression, double>& p :
+         get_expr_to_coeff_map_in_addition(e)) {
+      const Expression& e_i{p.first};
+      const double c_i{p.second};
+      // e = c₀ + ∑ᵢ (cᵢ * eᵢ) = c₀ + ∑ᵢ (cᵢ * (∑ⱼ mⱼ * cⱼ))
+      //                                   ~~~~~~~~~~~
+      //                                  Monomial of eᵢ
+      //                     = c₀ + ∑ᵢ ∑ⱼ ((cᵢ * cⱼ) * mⱼ)
+      // Note that we have cᵢ ≠ 0 ∧ cⱼ ≠ 0 → (cᵢ * cⱼ) ≠ 0.
+      const Polynomial::MapType map_i = Visit(e_i, vars);
+      for (const pair<Monomial, Expression>& term : map_i) {
+        const Monomial& m_j{term.first};
+        const Expression& c_j{term.second};
+        // Add (cᵢ * cⱼ) * mⱼ.
+        DoAdd(c_i * c_j, m_j, &new_map);
+      }
+    }
+    return new_map;
+  }
+
+  Polynomial::MapType VisitMultiplication(const Expression& e,
+                                          const Variables& vars) const {
+    // e = c * ∏ᵢ pow(baseᵢ, exponentᵢ).
+    const double c = get_constant_in_multiplication(e);
+    Expression coeff{c};
+    Monomial m{};
+    for (const pair<Expression, Expression>& p :
+         get_base_to_exponent_map_in_multiplication(e)) {
+      const Expression& base_i{p.first};
+      const Expression& exponent_i{p.second};
+      const Polynomial::MapType map_i{Visit(pow(base_i, exponent_i), vars)};
+      DRAKE_DEMAND(map_i.size() == 1);
+      const Monomial& m_i{map_i.begin()->first};
+      const Expression& coeff_i{map_i.begin()->second};
+      m *= m_i;
+      coeff *= coeff_i;
+    }
+    return Polynomial::MapType{{m, coeff}};
+  }
+
+  Polynomial::MapType VisitPow(const Expression& e,
+                               const Variables& vars) const {
+    // e = pow(base, exponent)
+    //   = pow(∏ᵢ varᵢ, n)          where n is of integer.
+    // It holds because e is an expanded polynomial.
+    const Expression& base{get_first_argument(e)};
+    const Expression& exponent{get_second_argument(e)};
+    DRAKE_DEMAND(is_constant(exponent));
+    // The following static_cast<int> does not lose information because of the
+    // preconditions.
+    const int n{static_cast<int>(get_constant_value(exponent))};
+    Expression coeff{1.0};
+    Monomial m{};
+    DRAKE_DEMAND(is_variable(base) || is_multiplication(base));
+    for (const Variable& var : base.GetVariables()) {
+      if (vars.include(var)) {
+        m *= Monomial{var, n};
+      } else {
+        coeff *= pow(Expression{var}, exponent);
+      }
+    }
+    return Polynomial::MapType{{m, coeff}};
+  }
+
+  Polynomial::MapType VisitDivision(const Expression&, const Variables&) const {
+    // Because e.is_polynomial() is true. We have e = e₁ / c. Since e is already
+    // expanded, e₁ is expanded as well. With those preconditions, the following
+    // case analysis concludes that this method is not called in run-time.
+    //
+    //  - e = c₁ / c
+    //    (This case should've been constant-folded so e₁ is not a constant.)
+    //
+    //  - e = (c₀ + ∑ᵢ(cᵢ * eᵢ)) / c
+    //      = c₀/c + ∑ᵢ(cᵢ/c * eᵢ)     // By Expand()
+    //    (As a result, e is not a division at the top level.)
+    //
+    //  - e = (c₀ * ∏ᵢ(pow(e₁ᵢ, e₂ᵢ)) / c
+    //      = c₀/c * ∏ᵢ(pow(e₁ᵢ, e₂ᵢ)  // By Expand()
+    //    (As a result, e is not a division at the top level.)
+    //
+    //  - e = (e' / c') / c
+    //      = e' / (c' * c)      // Simplified in construction.
+    //      = (1 / c' * c) * e'  // Expand()
+    //    (As a result, e is not a division at the top level.)
+    //
+    //  - e = v / c
+    //      = (1 / c) * v  // By Expand()
+    //    (As a result, e is not a division at the top level.)
+    //
+    //  - e = pow(base, exponent) / c
+    //      = (1 / c) * pow(base, exponent)  // By Expand()
+    //    (As a result, e is not a division at the top level.)
+    //
+    throw runtime_error(
+        "This should not be reachable because of preconditions.");
+  }
+
+  // Makes VisitPolynomial a friend of this class so that it can use private
+  // methods.
+  friend Polynomial::MapType
+  drake::symbolic::VisitPolynomial<Polynomial::MapType>(
+      const DecomposePolynomialVisitor*, const Expression&, const Variables&);
+};
+}  // namespace
+
+Polynomial::Polynomial(MapType init)
+    : monomial_to_coefficient_map_{move(init)} {
+  CheckInvariant();
+};
+
+Polynomial::Polynomial(const Monomial& m)
+    : monomial_to_coefficient_map_{{m, 1}} {
+  // No need to call CheckInvariant() because the following should hold.
+  DRAKE_ASSERT(decision_variables().empty());
+}
+
+Polynomial::Polynomial(const Expression& e) : Polynomial{e, e.GetVariables()} {
+  // No need to call CheckInvariant() because the following should hold.
+  DRAKE_ASSERT(decision_variables().empty());
+}
+
+Polynomial::Polynomial(const Expression& e, const Variables& indeterminates)
+    : monomial_to_coefficient_map_{
+          DecomposePolynomialVisitor{}.Decompose(e, indeterminates)} {
+  // No need to call CheckInvariant() because DecomposePolynomialVisitor is
+  // supposed to make sure the invariant holds as a post-condition.
+}
+
+Variables Polynomial::indeterminates() const {
+  Variables vars;
+  for (const pair<Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    const Monomial& m_i{p.first};
+    vars += m_i.GetVariables();
+  }
+  return vars;
+}
+
+Variables Polynomial::decision_variables() const {
+  Variables vars;
+  for (const pair<Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    const Expression& e_i{p.second};
+    vars += e_i.GetVariables();
+  }
+  return vars;
+}
+
+int Polynomial::Degree(const Variable& v) const {
+  int degree{0};
+  for (const pair<Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    const Monomial& m{p.first};
+    degree = std::max(degree, m.degree(v));
+  }
+  return degree;
+}
+
+int Polynomial::TotalDegree() const {
+  int degree{0};
+  for (const pair<Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    const Monomial& m{p.first};
+    degree = std::max(degree, m.total_degree());
+  }
+  return degree;
+}
+
+const Polynomial::MapType& Polynomial::monomial_to_coefficient_map() const {
+  return monomial_to_coefficient_map_;
+}
+
+Expression Polynomial::ToExpression() const {
+  // Returns ∑ᵢ (cᵢ * mᵢ).
+  return accumulate(
+      monomial_to_coefficient_map_.begin(), monomial_to_coefficient_map_.end(),
+      Expression{0.0},
+      [](const Expression& init, const pair<Monomial, Expression>& p) {
+        const Monomial& m{p.first};
+        const Expression& coeff{p.second};
+        return init + (coeff * m.ToExpression());
+      });
+}
+
+Polynomial& Polynomial::operator+=(const Polynomial& p) {
+  for (const pair<Monomial, Expression>& item :
+       p.monomial_to_coefficient_map_) {
+    const Monomial& m{item.first};
+    const Expression& coeff{item.second};
+    DoAdd(coeff, m, &monomial_to_coefficient_map_);
+  }
+  CheckInvariant();
+  return *this;
+}
+
+Polynomial& Polynomial::operator+=(const Monomial& m) {
+  // No need to call CheckInvariant() since it's called inside of Add.
+  return Add(1.0, m);
+}
+
+Polynomial& Polynomial::operator+=(const double c) {
+  // No need to call CheckInvariant() since it's called inside of Add.
+  return Add(c, Monomial{});
+}
+
+Polynomial& Polynomial::operator-=(const Polynomial& p) {
+  // No need to call CheckInvariant() since it's called inside of operator+=.
+  return *this += -p;
+}
+
+Polynomial& Polynomial::operator-=(const Monomial& m) {
+  // No need to call CheckInvariant() since it's called inside of Add.
+  return Add(-1.0, m);
+}
+
+Polynomial& Polynomial::operator-=(const double c) {
+  // No need to call CheckInvariant() since it's called inside of Add.
+  return Add(-c, Monomial{});
+}
+
+Polynomial& Polynomial::operator*=(const Polynomial& p) {
+  // (c₁₁ * m₁₁ + ... + c₁ₙ * m₁ₙ) * (c₂₁ * m₂₁ + ... + c₂ₘ * m₂ₘ)
+  // = (c₁₁ * m₁₁ + ... + c₁ₙ * m₁ₙ) * c₂₁ * m₂₁ + ... +
+  //   (c₁₁ * m₁₁ + ... + c₁ₙ * m₁ₙ) * c₂ₘ * m₂ₘ
+  MapType new_map{};
+  for (const auto& p1 : monomial_to_coefficient_map_) {
+    for (const auto& p2 : p.monomial_to_coefficient_map()) {
+      const Monomial new_monomial{p1.first * p2.first};
+      const Expression new_coeff{p1.second * p2.second};
+      DoAdd(new_coeff, new_monomial, &new_map);
+    }
+  }
+  monomial_to_coefficient_map_ = std::move(new_map);
+  CheckInvariant();
+  return *this;
+}
+
+Polynomial& Polynomial::operator*=(const Monomial& m) {
+  MapType new_map;
+  for (const pair<Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    const Monomial& m_i{p.first};
+    const Expression& coeff_i{p.second};
+    new_map.emplace(m * m_i, coeff_i);
+  }
+  monomial_to_coefficient_map_ = std::move(new_map);
+  CheckInvariant();
+  return *this;
+}
+
+Polynomial& Polynomial::operator*=(const double c) {
+  for (pair<const Monomial, Expression>& p : monomial_to_coefficient_map_) {
+    Expression& coeff{p.second};
+    coeff *= c;
+  }  // No need to call CheckInvariant() since `c` doesn't include a variable.
+  return *this;
+}
+
+bool Polynomial::EqualTo(const Polynomial& p) const {
+  return monomial_to_coefficient_map_ == p.monomial_to_coefficient_map();
+}
+
+Formula Polynomial::operator==(Polynomial p) const {
+  // 1) Update p' = p - (this polynomial).
+  // 2) Extract the condition where p' is zero.
+  //    That is, all coefficients should be zero.
+  p -= *this;
+  Formula ret{Formula::True()};
+  for (const pair<Monomial, Expression>& item :
+       p.monomial_to_coefficient_map_) {
+    const Expression& coeff{item.second};
+    ret = ret && (coeff == 0.0);
+  }
+  return ret;
+}
+
+Polynomial& Polynomial::Add(const Expression& coeff, const Monomial& m) {
+  DoAdd(coeff, m, &monomial_to_coefficient_map_);
+  CheckInvariant();
+  return *this;
+}
+
+void Polynomial::CheckInvariant() const {
+  Variables vars{intersect(decision_variables(), indeterminates())};
+  if (!vars.empty()) {
+    ostringstream oss;
+    oss << "Polynomial " << *this
+        << " does not satisfy the invariant because the following variable(s) "
+           "are used as decision variables and indeterminates at the same "
+           "time:\n"
+        << vars << ".";
+    throw runtime_error(oss.str());
+  }
+}
+
+Polynomial operator-(Polynomial p) { return -1 * p; }
+Polynomial operator+(Polynomial p1, const Polynomial& p2) { return p1 += p2; }
+Polynomial operator+(Polynomial p, const Monomial& m) { return p += m; }
+Polynomial operator+(const Monomial& m, Polynomial p) { return p += m; }
+Polynomial operator+(const Monomial& m1, const Monomial& m2) {
+  return Polynomial(m1) + m2;
+}
+Polynomial operator+(Polynomial p, const double c) { return p += c; }
+Polynomial operator+(const double c, Polynomial p) { return p += c; }
+Polynomial operator-(Polynomial p1, const Polynomial& p2) { return p1 -= p2; }
+Polynomial operator-(Polynomial p, const Monomial& m) { return p -= m; }
+Polynomial operator-(const Monomial& m, Polynomial p) {
+  return p = -1 * p + m;  // p' = m - p = -1 * p + m.
+}
+Polynomial operator-(const Monomial& m1, const Monomial& m2) {
+  return Polynomial(m1) - m2;
+}
+Polynomial operator-(Polynomial p, const double c) { return p -= c; }
+Polynomial operator-(const double c, Polynomial p) { return p = -p + c; }
+Polynomial operator*(Polynomial p1, const Polynomial& p2) { return p1 *= p2; }
+Polynomial operator*(Polynomial p, const Monomial& m) { return p *= m; }
+Polynomial operator*(const Monomial& m, Polynomial p) { return p *= m; }
+Polynomial operator*(const double c, Polynomial p) { return p *= c; }
+Polynomial operator*(Polynomial p, const double c) { return p *= c; }
+
+Polynomial pow(const Polynomial& p, int n) {
+  // TODO(soonho-tri): Optimize this by not relying on ToExpression() method.
+  return Polynomial{pow(p.ToExpression(), n), p.indeterminates()};
+}
+
+ostream& operator<<(ostream& os, const Polynomial& p) {
+  const Polynomial::MapType& map{p.monomial_to_coefficient_map()};
+  if (map.empty()) {
+    return os << 0;
+  }
+  auto it = map.begin();
+  os << it->second << "*" << it->first;
+  for (++it; it != map.end(); ++it) {
+    os << " + " << it->second << "*" << it->first;
+  }
+  return os;
+}
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/symbolic_polynomial.h
+++ b/drake/common/symbolic_polynomial.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <ostream>
+#include <unordered_map>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
+#include "drake/common/monomial.h"
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_formula.h"
+#include "drake/common/symbolic_variables.h"
+
+namespace drake {
+namespace symbolic {
+/// Represents symbolic polynomials. A symbolic polynomial keeps a mapping from
+/// a monomial of indeterminates to its coefficient in a symbolic expression.
+///
+/// A polynomial `p` has to satisfy an invariant such that
+/// `p.decision_variables() ∩ p.indeterminates() = ∅`. We have CheckInvariant()
+/// method to check the invariant.
+///
+/// Note that arithmetic operations (+,-,*) between a Polynomial and a Variable
+/// are not provided. The problem is that Variable class has no intrinsic
+/// information if a variable is a decision variable or an indeterminate while
+/// we need this information to perform arithmetic operations over Polynomials.
+class Polynomial {
+ public:
+  using MapType =
+      std::unordered_map<Monomial, Expression, hash_value<Monomial>>;
+
+  /// Constructs a zero polynomial.
+  Polynomial() = default;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Polynomial)
+
+  /// Constructs a polynomial from a map, Monomial → Expression.
+  explicit Polynomial(MapType init);
+
+  /// Constructs a polynomial from a monomial @p m. Note that all variables
+  /// in `m` are considered as indeterminates.
+  explicit Polynomial(const Monomial& m);
+
+  /// Constructs a polynomial from an expression @p e. Note that all variables
+  /// in `e` are considered as indeterminates.
+  explicit Polynomial(const Expression& e);
+
+  /// Constructs a polynomial from an expression @p e by decomposing it with
+  /// respect to @p indeterminates.
+  Polynomial(const Expression& e, const Variables& indeterminates);
+
+  /// Returns the indeterminates of this polynomial.
+  Variables indeterminates() const;
+
+  /// Returns the decision variables of this polynomial.
+  Variables decision_variables() const;
+
+  /// Returns the highest degree of this polynomial in a variable @p v.
+  int Degree(const Variable& v) const;
+
+  /// Returns the total degree of this polynomial.
+  int TotalDegree() const;
+
+  /// Returns the mapping from a Monomial to its corresponding coefficient of
+  /// this polynomial.
+  const MapType& monomial_to_coefficient_map() const;
+
+  /// Returns an equivalent symbolic expression of this polynomial.
+  Expression ToExpression() const;
+
+  Polynomial& operator+=(const Polynomial& p);
+  Polynomial& operator+=(const Monomial& m);
+  Polynomial& operator+=(double c);
+
+  Polynomial& operator-=(const Polynomial& p);
+  Polynomial& operator-=(const Monomial& m);
+  Polynomial& operator-=(double c);
+
+  Polynomial& operator*=(const Polynomial& p);
+  Polynomial& operator*=(const Monomial& m);
+  Polynomial& operator*=(double c);
+
+  /// Returns true if this polynomial and @p p are structurally equal.
+  bool EqualTo(const Polynomial& p) const;
+
+  /// Returns a symbolic formula representing the condition where this
+  /// polynomial and @p p are the same.
+  Formula operator==(Polynomial p) const;
+
+ private:
+  // Adds (coeff * m) to this polynomial.
+  Polynomial& Add(const Expression& coeff, const Monomial& m);
+  // Throws std::runtime_error if there is a variable appeared in both of
+  // decision_variables() and indeterminates().
+  void CheckInvariant() const;
+  MapType monomial_to_coefficient_map_;
+};
+
+/// Unary minus operation for polynomial.
+Polynomial operator-(Polynomial p);
+Polynomial operator+(Polynomial p1, const Polynomial& p2);
+Polynomial operator+(Polynomial p, const Monomial& m);
+Polynomial operator+(const Monomial& m, Polynomial p);
+Polynomial operator+(const Monomial& m1, const Monomial& m2);
+Polynomial operator+(Polynomial p, double c);
+Polynomial operator+(double c, Polynomial p);
+Polynomial operator-(Polynomial p1, const Polynomial& p2);
+Polynomial operator-(Polynomial p, const Monomial& m);
+Polynomial operator-(const Monomial& m, Polynomial p);
+Polynomial operator-(const Monomial& m1, const Monomial& m2);
+Polynomial operator-(Polynomial p, double c);
+Polynomial operator-(double c, Polynomial p);
+Polynomial operator*(Polynomial p1, const Polynomial& p2);
+Polynomial operator*(Polynomial p, const Monomial& m);
+Polynomial operator*(const Monomial& m, Polynomial p);
+Polynomial operator*(double c, Polynomial p);
+Polynomial operator*(Polynomial p, double c);
+
+/// Returns polynomial @p rasied to @p n.
+Polynomial pow(const Polynomial& p, int n);
+
+std::ostream& operator<<(std::ostream& os, const Polynomial& p);
+}  // namespace symbolic
+}  // namespace drake

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -111,6 +111,9 @@ target_link_libraries(symbolic_variable_test drakeCommon)
 drake_add_cc_test(symbolic_variable_overloading_test)
 target_link_libraries(symbolic_variable_overloading_test drakeCommon)
 
+drake_add_cc_test(symbolic_polynomial_test)
+target_link_libraries(symbolic_polynomial_test drakeCommon)
+
 drake_add_cc_test(symbolic_variables_test)
 target_link_libraries(symbolic_variables_test drakeCommon)
 

--- a/drake/common/test/monomial_test.cc
+++ b/drake/common/test/monomial_test.cc
@@ -707,6 +707,28 @@ TEST_F(MonomialTest, Substitute) {
   }
 }
 
+TEST_F(MonomialTest, DegreeVariable) {
+  EXPECT_EQ(Monomial().degree(var_x_), 0);
+  EXPECT_EQ(Monomial().degree(var_y_), 0);
+
+  EXPECT_EQ(Monomial(var_x_).degree(var_x_), 1);
+  EXPECT_EQ(Monomial(var_x_).degree(var_y_), 0);
+
+  EXPECT_EQ(Monomial(var_x_, 4).degree(var_x_), 4);
+  EXPECT_EQ(Monomial(var_x_, 4).degree(var_y_), 0);
+
+  EXPECT_EQ(Monomial({{var_x_, 1}, {var_y_, 2}}).degree(var_x_), 1);
+  EXPECT_EQ(Monomial({{var_x_, 1}, {var_y_, 2}}).degree(var_y_), 2);
+}
+
+TEST_F(MonomialTest, TotalDegree) {
+  EXPECT_EQ(Monomial().total_degree(), 0);
+  EXPECT_EQ(Monomial(var_x_).total_degree(), 1);
+  EXPECT_EQ(Monomial(var_x_, 1).total_degree(), 1);
+  EXPECT_EQ(Monomial(var_x_, 4).total_degree(), 4);
+  EXPECT_EQ(Monomial({{var_x_, 1}, {var_y_, 2}}).total_degree(), 3);
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake

--- a/drake/common/test/symbolic_expansion_test.cc
+++ b/drake/common/test/symbolic_expansion_test.cc
@@ -239,14 +239,14 @@ TEST_F(SymbolicExpansionTest, UninterpretedFunction) {
 }
 
 TEST_F(SymbolicExpansionTest, DivideByConstant) {
-  // (x) / 2 => x / 2  (no simplification)
-  EXPECT_PRED2(ExprEqual, (x_ / 2).Expand(), x_ / 2);
+  // (x) / 2 => 0.5 * x
+  EXPECT_PRED2(ExprEqual, (x_ / 2).Expand(), 0.5 * x_);
 
   // 3 / 2 => 3 / 2  (no simplification)
   EXPECT_PRED2(ExprEqual, (Expression(3.0) / 2).Expand(), 3.0 / 2);
 
-  // pow(x, y) / 2 => pow(x, y) / 2  (no simplification)
-  EXPECT_PRED2(ExprEqual, (pow(x_, y_) / 2).Expand(), pow(x_, y_) / 2);
+  // pow(x, y) / 2 => 0.5 * pow(x, y)
+  EXPECT_PRED2(ExprEqual, (pow(x_, y_) / 2).Expand(), 0.5 * pow(x_, y_));
 
   // (2x) / 2 => x
   EXPECT_PRED2(ExprEqual, ((2 * x_) / 2).Expand(), x_);

--- a/drake/common/test/symbolic_expansion_test.cc
+++ b/drake/common/test/symbolic_expansion_test.cc
@@ -105,6 +105,10 @@ TEST_F(SymbolicExpansionTest, ExpressionExpansion) {
 
   vector<pair<Expression, Expression>> test_exprs;
 
+  // (2xy²)² = 4x²y⁴
+  test_exprs.emplace_back(pow(2 * x_ * y_ * y_, 2),
+                          4 * pow(x_, 2) * pow(y_, 4));
+
   //   5 * (3 + 2y) + 30 * (7 + x_)
   // = 15 + 10y + 210 + 30x
   // = 225 + 30x + 10y

--- a/drake/common/test/symbolic_polynomial_test.cc
+++ b/drake/common/test/symbolic_polynomial_test.cc
@@ -1,0 +1,404 @@
+#include "drake/common/symbolic_polynomial.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/monomial.h"
+#include "drake/common/monomial_util.h"
+#include "drake/common/test/symbolic_test_util.h"
+
+namespace drake {
+namespace symbolic {
+namespace {
+using std::vector;
+using std::runtime_error;
+using std::to_string;
+
+using test::ExprEqual;
+
+class SymbolicPolynomialTest : public ::testing::Test {
+ protected:
+  const Variable var_x_{"x"};
+  const Variable var_y_{"y"};
+  const Variable var_z_{"z"};
+  const Variable var_a_{"a"};
+  const Variable var_b_{"b"};
+  const Variable var_c_{"c"};
+
+  const Variables var_xy_{var_x_, var_y_};
+  const Variables var_xyz_{var_x_, var_y_, var_z_};
+  const Variables var_abc_{var_a_, var_b_, var_c_};
+
+  const drake::VectorX<symbolic::Monomial> monomials_{
+      MonomialBasis(var_xyz_, 3)};
+
+  const vector<double> doubles{-9999.0, -5.0, -1.0, 0.0, 1.0, 5.0, 9999.0};
+
+  const Expression x_{var_x_};
+  const Expression y_{var_y_};
+  const Expression z_{var_z_};
+  const Expression a_{var_a_};
+  const Expression b_{var_b_};
+  const Expression c_{var_c_};
+  const Expression xy_{var_x_ + var_y_};
+  const Expression xyz_{var_x_ + var_y_ + var_z_};
+
+  const vector<Expression> exprs_{
+      0,
+      -1,
+      3,
+      x_,
+      5 * x_,
+      -3 * x_,
+      y_,
+      x_* y_,
+      2 * x_* x_,
+      2 * x_* x_,
+      6 * x_* y_,
+      3 * x_* x_* y_ + 4 * pow(y_, 3) * z_ + 2,
+      y_*(3 * x_ * x_ + 4 * y_ * y_ * z_) + 2,
+      6 * pow(x_, 3) * pow(y_, 2),
+      2 * pow(x_, 3) * 3 * pow(y_, 2),
+      pow(x_, 3) - 4 * x_* y_* y_ + 2 * x_* x_* y_ - 8 * pow(y_, 3),
+      pow(x_ + 2 * y_, 2) * (x_ - 2 * y_),
+      (x_ + 2 * y_) * (x_ * x_ - 4 * y_ * y_),
+      (x_ * x_ + 4 * x_ * y_ + 4 * y_ * y_) * (x_ - 2 * y_),
+      pow(x_ + y_ + 1, 4),
+      pow(x_ + y_ + 1, 3),
+      1 + x_* x_ + 2 * (y_ - 0.5 * x_ * x_ - 0.5),
+      Expression(5.0) / 2.0,     // constant / constant
+      x_ / 3.0,                  // var / constant
+      pow(x_, 2) / 2,            // pow / constant
+      pow(x_* y_ / 3.0, 2) / 2,  // pow / constant
+      (x_ + y_) / 2.0,           // sum / constant
+      (x_* y_* z_ * 3) / 2.0,    // product / constant
+      (x_* y_ / -5.0) / 2.0,     // div / constant
+  };
+};
+
+TEST_F(SymbolicPolynomialTest, DefaultConstructor) {
+  const Polynomial p{};
+  EXPECT_TRUE(p.monomial_to_coefficient_map().empty());
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromMapType1) {
+  Polynomial::MapType map;
+  map.emplace(Monomial{var_x_}, -2.0 * a_);          // x ↦ -2a
+  map.emplace(Monomial{{{var_y_, 3.0}}}, 4.0 * b_);  // y³ ↦ 4b
+  const Polynomial p{map};                           // p = -2ax + 4by³
+  EXPECT_EQ(p.monomial_to_coefficient_map(), map);
+  EXPECT_EQ(p.ToExpression(), -2 * a_ * x_ + 4 * b_ * pow(y_, 3));
+  EXPECT_EQ(p.decision_variables(), Variables({var_a_, var_b_}));
+  EXPECT_EQ(p.indeterminates(), Variables({var_x_, var_y_}));
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromMapType2) {
+  Polynomial::MapType p_map;
+  for (int i = 0; i < monomials_.size(); ++i) {
+    p_map.emplace(monomials_[i], 1);
+  }
+  EXPECT_EQ(Polynomial{p_map}.monomial_to_coefficient_map(), p_map);
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromMapType3) {
+  Polynomial::MapType map;
+  map.emplace(Monomial{var_x_}, -2.0 * a_);          // x ↦ -2a
+  map.emplace(Monomial{{{var_a_, 2.0}}}, 4.0 * b_);  // a² ↦ 4b
+  // We cannot construct a polynomial from the `map` because variable a is used
+  // as a decision variable (x ↦ -2a) and an indeterminate (a² ↦ 4b) at the same
+  // time.
+  EXPECT_THROW(Polynomial{map}, runtime_error);
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromMonomial) {
+  for (int i = 0; i < monomials_.size(); ++i) {
+    const Polynomial p{monomials_[i]};
+    for (const std::pair<Monomial, Expression>& map :
+         p.monomial_to_coefficient_map()) {
+      EXPECT_EQ(map.first, monomials_[i]);
+      EXPECT_EQ(map.second, 1);
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructFromExpression) {
+  // Expression -------------------> Polynomial
+  //     | .Expand()                     | .ToExpression()
+  //    \/                              \/
+  // Expanded Expression     ==      Expression
+  for (const Expression& e : exprs_) {
+    const Expression expanded_expr{e.Expand()};
+    const Expression expr_from_polynomial{Polynomial{e}.ToExpression()};
+    EXPECT_PRED2(ExprEqual, expanded_expr, expr_from_polynomial);
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, ConstructorFromExpressionAndIndeterminates) {
+  const Polynomial p1{1.0, var_xyz_};  // p₁ = 1.0,
+  EXPECT_EQ(p1.monomial_to_coefficient_map(),
+            Polynomial::MapType({{Monomial{}, Expression(1.0)}}));
+  // p₂ = ax + by + cz + 10
+  const Polynomial p2{a_ * x_ + b_ * y_ + c_ * z_ + 10, var_xyz_};
+  EXPECT_EQ(p2.monomial_to_coefficient_map(),
+            Polynomial::MapType({{Monomial{var_x_}, a_},
+                                 {Monomial{var_y_}, b_},
+                                 {Monomial{var_z_}, c_},
+                                 {Monomial{}, 10}}));
+  // p₃ = 3ab²*x²y -bc*z³
+  const Polynomial p3{
+      3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(z_, 3), var_xyz_};
+  EXPECT_EQ(p3.monomial_to_coefficient_map(),
+            Polynomial::MapType(
+                // x²y ↦ 3ab²
+                {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
+                 // z³ ↦ -bc
+                 {Monomial{{{var_z_, 3}}}, -b_ * c_}}));
+
+  // p₄ = 3ab²*x²y - bc*x³
+  const Polynomial p4{
+      3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(x_, 3), var_xyz_};
+  EXPECT_EQ(p4.monomial_to_coefficient_map(),
+            Polynomial::MapType(
+                {{Monomial{{{var_x_, 2}, {var_y_, 1}}}, 3 * a_ * pow(b_, 2)},
+                 {Monomial{{{var_x_, 3}}}, -b_ * c_}}));
+}
+
+TEST_F(SymbolicPolynomialTest, IndeterminatesAndDecisionVariables) {
+  // p = 3ab²*x²y -bc*z³
+  const Polynomial p{
+      3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(z_, 3), var_xyz_};
+  EXPECT_EQ(p.indeterminates(), var_xyz_);
+  EXPECT_EQ(p.decision_variables(), var_abc_);
+}
+
+TEST_F(SymbolicPolynomialTest, DegreeAndTotalDegree) {
+  // p = 3ab²*x²y -bc*z³
+  const Polynomial p{
+      3 * a_ * pow(b_, 2) * pow(x_, 2) * y_ - b_ * c_ * pow(z_, 3), var_xyz_};
+  EXPECT_EQ(p.Degree(var_x_), 2);
+  EXPECT_EQ(p.Degree(var_y_), 1);
+  EXPECT_EQ(p.Degree(var_z_), 3);
+  EXPECT_EQ(p.TotalDegree(), 3);
+}
+
+TEST_F(SymbolicPolynomialTest, AdditionPolynomialPolynomial) {
+  // (Polynomial(e₁) + Polynomial(e₂)).ToExpression() = (e₁ + e₂).Expand()
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      EXPECT_PRED2(ExprEqual, (Polynomial{e1} + Polynomial{e2}).ToExpression(),
+                   (e1 + e2).Expand());
+    }
+  }
+  // Test Polynomial& operator+=(Polynomial& c);
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      Polynomial p{e1};
+      p += Polynomial{e2};
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), (e1 + e2).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, AdditionPolynomialMonomial) {
+  // (Polynomial(e) + m).ToExpression() = (e + m.ToExpression()).Expand()
+  // (m + Polynomial(e)).ToExpression() = (m.ToExpression() + e).Expand()
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) + m).ToExpression(),
+                   (e + m.ToExpression()).Expand());
+      EXPECT_PRED2(ExprEqual, (m + Polynomial(e)).ToExpression(),
+                   (m.ToExpression() + e).Expand());
+    }
+  }
+  // Test Polynomial& operator+=(const Monomial& m);
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      Polynomial p{e};
+      p += m;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(),
+                   (e + m.ToExpression()).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, AdditionPolynomialDouble) {
+  //   (Polynomial(e) + c).ToExpression() = (e + c).Expand()
+  //   (c + Polynomial(e)).ToExpression() = (c + e).Expand()
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) + c).ToExpression(),
+                   (e + c).Expand());
+      EXPECT_PRED2(ExprEqual, (c + Polynomial(e)).ToExpression(),
+                   (c + e).Expand());
+    }
+  }
+  // Test Polynomial& operator+=(double c).
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      Polynomial p{e};
+      p += c;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), (e + c).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, SubtractionPolynomialPolynomial) {
+  // (Polynomial(e₁) - Polynomial(e₂)).ToExpression() = (e₁ - e₂).Expand()
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      EXPECT_PRED2(ExprEqual, (Polynomial{e1} - Polynomial{e2}).ToExpression(),
+                   (e1 - e2).Expand());
+    }
+  }
+  // Test Polynomial& operator-=(Polynomial& c);
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      Polynomial p{e1};
+      p -= Polynomial{e2};
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), (e1 - e2).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, SubtractionPolynomialMonomial) {
+  // (Polynomial(e) - m).ToExpression() = (e - m.ToExpression()).Expand()
+  // (m - Polynomial(e)).ToExpression() = (m.ToExpression() - e).Expand()
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) - m).ToExpression(),
+                   (e - m.ToExpression()).Expand());
+      EXPECT_PRED2(ExprEqual, (m - Polynomial(e)).ToExpression(),
+                   (m.ToExpression() - e).Expand());
+    }
+  }
+  // Test Polynomial& operator-=(const Monomial& m);
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      Polynomial p{e};
+      p -= m;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(),
+                   (e - m.ToExpression()).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, SubtractionPolynomialDouble) {
+  // (Polynomial(e) - c).ToExpression() = (e - c).Expand()
+  // (c - Polynomial(e)).ToExpression() = (c - e).Expand()
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) - c).ToExpression(),
+                   (e - c).Expand());
+      EXPECT_PRED2(ExprEqual, (c - Polynomial(e)).ToExpression(),
+                   (c - e).Expand());
+    }
+  }
+  // Test Polynomial& operator-=(double c).
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      Polynomial p{e};
+      p -= c;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), (e - c).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, UnaryMinus) {
+  // (-Polynomial(e)).ToExpression() = -(e.Expand())
+  for (const Expression& e : exprs_) {
+    EXPECT_PRED2(ExprEqual, (-Polynomial(e)).ToExpression(), -(e.Expand()));
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialPolynomial1) {
+  // (Polynomial(e₁) * Polynomial(e₂)).ToExpression() = (e₁ * e₂).Expand()
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      EXPECT_PRED2(ExprEqual, (Polynomial{e1} * Polynomial{e2}).ToExpression(),
+                   (e1.Expand() * e2.Expand()).Expand());
+    }
+  }
+  // Test Polynomial& operator*=(Polynomial& c);
+  for (const Expression& e1 : exprs_) {
+    for (const Expression& e2 : exprs_) {
+      Polynomial p{e1};
+      p *= Polynomial{e2};
+      EXPECT_PRED2(ExprEqual, p.ToExpression(),
+                   (e1.Expand() * e2.Expand()).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialMonomial) {
+  // (Polynomial(e) * m).ToExpression() = (e * m.ToExpression()).Expand()
+  // (m * Polynomial(e)).ToExpression() = (m.ToExpression() * e).Expand()
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) * m).ToExpression(),
+                   (e * m.ToExpression()).Expand());
+      EXPECT_PRED2(ExprEqual, (m * Polynomial(e)).ToExpression(),
+                   (m.ToExpression() * e).Expand());
+    }
+  }
+  // Test Polynomial& operator*=(const Monomial& m);
+  for (const Expression& e : exprs_) {
+    for (int i = 0; i < monomials_.size(); ++i) {
+      const Monomial& m{monomials_[i]};
+      Polynomial p{e};
+      p *= m;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(),
+                   (e * m.ToExpression()).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialDouble) {
+  // (Polynomial(e) * c).ToExpression() = (e * c).Expand()
+  // (c * Polynomial(e)).ToExpression() = (c * e).Expand()
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      EXPECT_PRED2(ExprEqual, (Polynomial(e) * c).ToExpression(),
+                   (e * c).Expand());
+      EXPECT_PRED2(ExprEqual, (c * Polynomial(e)).ToExpression(),
+                   (c * e).Expand());
+    }
+  }
+  // Test Polynomial& operator*=(double c).
+  for (const Expression& e : exprs_) {
+    for (const double c : doubles) {
+      Polynomial p{e};
+      p *= c;
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), (e * c).Expand());
+    }
+  }
+}
+
+TEST_F(SymbolicPolynomialTest, MultiplicationPolynomialPolynomial2) {
+  // Evaluates (1 + x) * (1 - x) to confirm that the cross term 0 * x is
+  // erased from the product.
+  const Polynomial p1(1 + x_);
+  const Polynomial p2(1 - x_);
+  Polynomial::MapType product_map_expected{};
+  product_map_expected.emplace(Monomial(), 1);
+  product_map_expected.emplace(Monomial(var_x_, 2), -1);
+  EXPECT_EQ(product_map_expected, (p1 * p2).monomial_to_coefficient_map());
+}
+
+TEST_F(SymbolicPolynomialTest, Pow) {
+  for (int n = 2; n <= 5; ++n) {
+    for (const Expression& e : exprs_) {
+      Polynomial p{pow(Polynomial{e}, n)};  // p = pow(e, n)
+      EXPECT_PRED2(ExprEqual, p.ToExpression(), pow(e, n).Expand());
+    }
+  }
+}
+}  // namespace
+}  // namespace symbolic
+}  // namespace drake


### PR DESCRIPTION
This is a part of the commits that we're migrating from the SOS (sum-of-squares) sprint.

To reduce the size of this PR, I removed Eigen-related code from this PR. There will be another PR enabling `Eigen::Matrix<symbolic::Polynomial>`.

When SOS PRs are all landed in `master`, I'll work on unifying the existing `drake::Polynomial<T>` and this `drake::symbolic::Polynomial`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6545)
<!-- Reviewable:end -->
