### PR TITLE
Uses rules_boost and pkg_config_package to find boost and tinyxml

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -373,6 +373,22 @@ bitbucket_archive(
     build_file = "tools/ignition_rndf.BUILD",
 )
 
+github_archive(
+    name = "com_github_nelhage_boost",
+    repository = "nelhage/rules_boost",
+    commit = "0838fdac246ef9362b80009b9dd2018b5378a5ed",
+    sha256 = "3604bfef01cb50d1b6ef3410bf3dda87875fa0ed1e8d9bbd585e09677c159bd9",  # noqa
+)
+
+load("@com_github_nelhage_boost//:boost/boost.bzl", "boost_deps")
+
+boost_deps()
+
+pkg_config_package(
+    name = "tinyxml",
+    modname = "tinyxml",
+)
+
 bitbucket_archive(
     name = "sdformat",
     repository = "osrf/sdformat",

--- a/tools/sdformat.BUILD
+++ b/tools/sdformat.BUILD
@@ -117,16 +117,13 @@ cc_library(
     # cc_library rule, or by using a true external version of URDF.
     copts = ["-I external/sdformat/src/urdf"],
     data = glob(["sdf/1.6/*.sdf"]),
-    includes = [
-        "include",
-    ],
-    linkopts = [
-        "-lboost_system",
-        "-ltinyxml",
-    ],
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
+        "@boost//:system",
+        "@boost//:variant",
         "@ignition_math",
+        "@tinyxml",
     ],
 )
 


### PR DESCRIPTION
Bazel builds via `ExternalProject_Add` on Mac are failing due to not being able to resolve `-ltinyxml` and `-lboost_system`. This should be more robust.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6547)
<!-- Reviewable:end -->
