### PR TITLE
Replace bilinear product in an expression

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -202,6 +202,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "bilinear_product_util",
+    srcs = ["bilinear_product_util.cc"],
+    hdrs = ["bilinear_product_util.h"],
+    deps = [
+        ":decision_variable",
+        "//drake/common:symbolic",
+        "//drake/common:symbolic_polynomial",
+    ],
+)
+
+drake_cc_library(
     name = "system_identification",
     srcs = ["system_identification.cc"],
     hdrs = ["system_identification.h"],
@@ -578,6 +589,14 @@ drake_cc_library(
 )
 
 # === test/ ===
+drake_cc_googletest(
+    name = "bilinear_product_util_test",
+    deps = [
+        ":bilinear_product_util",
+        "//drake/common:symbolic_test_util",
+    ],
+)
+
 drake_cc_googletest(
     name = "binding_test",
     srcs = [

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -117,10 +117,9 @@ drake_install_headers(
 
 add_library_with_exports(LIB_NAME drakeBilinearProductUtil SOURCE_FILES bilinear_product_util.cc)
 target_link_libraries(drakeBilinearProductUtil
-        drakeMath
-        drakeOptimization)
+        drakeCommon)
 drake_install_headers(
-        bilinear_product_util.cc.h
+        bilinear_product_util.h
 )
 
 add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -115,6 +115,14 @@ drake_install_headers(
         mixed_integer_optimization_util.h
 )
 
+add_library_with_exports(LIB_NAME drakeBilinearProductUtil SOURCE_FILES bilinear_product_util.cc)
+target_link_libraries(drakeBilinearProductUtil
+        drakeMath
+        drakeOptimization)
+drake_install_headers(
+        bilinear_product_util.cc.h
+)
+
 add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)
 target_link_libraries(drakeRotationConstraint
         drakeOptimization)

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -1,0 +1,118 @@
+#include "drake/solvers/bilinear_product_util.h"
+
+#include <ostream>
+#include <sstream>
+namespace drake {
+namespace solvers {
+std::unordered_map<symbolic::Variable::Id, int> ConstructVarToIndexMap(const Eigen::Ref<const VectorXDecisionVariable>& x) {
+  std::unordered_map<symbolic::Variable::Id, int> map;
+  map.reserve(x.rows());
+  for (int i = 0; i < x.rows(); ++i) {
+    auto it = map.find(x(i).get_id());
+    if (it != map.end()) {
+      throw std::runtime_error("Input vector contains duplicate variable " + x(i).get_name());
+    }
+    map.emplace_hint(it, x(i).get_id(), i);
+  }
+  return map;
+};
+
+symbolic::Expression ReplaceBilinearTerms(
+    const symbolic::Expression& e,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
+    const Eigen::Ref<const MatrixXDecisionVariable>& W) {
+  DRAKE_ASSERT(W.rows() == x.rows() && W.cols() == y.rows());
+  const std::unordered_map<symbolic::Variable::Id, int> x_to_index_map = ConstructVarToIndexMap(x);
+  const std::unordered_map<symbolic::Variable::Id, int> y_to_index_map = ConstructVarToIndexMap(y);
+
+  symbolic::Variables vars{};
+  for (int i = 0; i < x.rows(); ++i) {
+    vars.insert(x(i));
+  }
+  for (int i = 0; i < y.rows(); ++i) {
+    vars.insert(y(i));
+  }
+  symbolic::Polynomial p_bilinear(e, vars);
+
+  auto map_bilinear = p_bilinear.monomial_to_coefficient_map();
+  symbolic::Polynomial::MapType map_replaced;
+  map_replaced.reserve(map_bilinear.size());
+  for (const auto& p : map_bilinear) {
+    std::map<symbolic::Variable, int> monomial_replace_map;
+    // For each monomial, we decompose it into two parts, the part that contains
+    // variables in `x` or `y`, and the part that does not. We call the first
+    // part as "dependent monomial", the second part as "independent monomial".
+    std::map<symbolic::Variable, int> dependent_monomial_map;
+    std::map<symbolic::Variable, int> independent_monomial_map;
+    int xy_total_degree{0};
+    for (const auto& var_power : p.first.get_powers()) {
+      const symbolic::Variable& var{var_power.first};
+      if (x_to_index_map.find(var.get_id()) != x_to_index_map.end() || y_to_index_map.find(var.get_id()) != y_to_index_map.end()) {
+        dependent_monomial_map.emplace(var_power.first, var_power.second);
+        xy_total_degree += var_power.second;
+      } else {
+        independent_monomial_map.emplace(var_power.first, var_power.second);
+      }
+    }
+    if (xy_total_degree > 2) {
+      std::ostringstream oss;
+      oss << "The term " << p.first << " has degree larger than 2 on the variables";
+      throw std::runtime_error(oss.str());
+    } else if (xy_total_degree < 2) {
+      // Only linear or constant terms, do not need to replace the variables.
+      auto it = map_replaced.find(p.first);
+      if (it != map_replaced.end()) {
+        it->second += p.second;
+      } else {
+        map_replaced.emplace_hint(it, p.first, p.second);
+      }
+    } else {
+      // This monomial contains bilinear term in x and y.
+      std::unordered_map<symbolic::Variable::Id, int>::const_iterator it_x_idx;
+      std::unordered_map<symbolic::Variable::Id, int>::const_iterator it_y_idx;
+      if (dependent_monomial_map.size() == 2) {
+        // The dependent monomial is in the form of x * y, namely two different
+        // variables multiplying together.
+        auto dependent_monomial_map_it = dependent_monomial_map.begin();
+        const symbolic::Variable &var1{dependent_monomial_map_it->first};
+        ++dependent_monomial_map_it;
+        const symbolic::Variable &var2{dependent_monomial_map_it->first};
+        it_x_idx = x_to_index_map.find(var1.get_id());
+        if (it_x_idx != x_to_index_map.end()) {
+          it_y_idx = y_to_index_map.find(var2.get_id());
+        } else {
+          it_x_idx = x_to_index_map.find(var2.get_id());
+          it_y_idx = y_to_index_map.find(var1.get_id());
+        }
+      } else {
+        // The dependent monomial is in the form of x * x, the square of a variable.
+        const symbolic::Variable& squared_var{dependent_monomial_map.begin()->first};
+        it_x_idx = x_to_index_map.find(squared_var.get_id());
+        it_y_idx = y_to_index_map.find(squared_var.get_id());
+      }
+      if (it_x_idx == x_to_index_map.end() || it_y_idx == y_to_index_map.end()) {
+        std::ostringstream oss;
+        oss << "Term " << p.first << " is bilinear, but x and y does not have the corresponding variables.";
+        throw std::runtime_error(oss.str());
+      }
+      // w_xy is the symbolic variable representing the bilinear term x * y.
+      const symbolic::Variable& w_xy{W(it_x_idx->second, it_y_idx->second)};
+      // Multiply w_xy with the independent monomial
+      auto it_w_in_independent_monomial = independent_monomial_map.find(w_xy);
+      if (it_w_in_independent_monomial != independent_monomial_map.end()) {
+        ++(it_w_in_independent_monomial->second);
+      } else {
+        independent_monomial_map.emplace_hint(it_w_in_independent_monomial, w_xy, 1);
+      }
+      map_replaced.emplace(symbolic::Monomial{independent_monomial_map}, p.second);
+    }
+  }
+  symbolic::Expression poly_replaced{0};
+  for (const auto& p_replaced : map_replaced) {
+    poly_replaced += p_replaced.first.ToExpression() * p_replaced.second;
+  }
+  return poly_replaced;
+}
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -50,17 +50,16 @@ symbolic::Expression ReplaceBilinearTerms(
   map_replaced.reserve(map_bilinear.size());
   for (const auto& p : map_bilinear) {
     std::unordered_map<int, int> monomial_map;
-    int xy_total_degree{0};
+    int monomial_degree = p.first.total_degree();
     for (const auto& var_power : p.first.get_powers()) {
       monomial_map.emplace(var_power.first.get_id(), var_power.second);
-      xy_total_degree += var_power.second;
     }
-    if (xy_total_degree > 2) {
+    if (monomial_degree > 2) {
       std::ostringstream oss;
       oss << "The term " << p.first
           << " has degree larger than 2 on the variables";
       throw std::runtime_error(oss.str());
-    } else if (xy_total_degree < 2) {
+    } else if (monomial_degree < 2) {
       // Only linear or constant terms, do not need to replace the variables.
       auto it = map_replaced.find(p.first);
       if (it != map_replaced.end()) {

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -108,8 +108,11 @@ symbolic::Expression ReplaceBilinearTerms(
                            p.second);
     }
   }
-  symbolic::Polynomial poly_replaced{map_replaced};
-  return poly_replaced.ToExpression();
+  symbolic::Expression e_replaced{0};
+  for (const auto& p_replaced : map_replaced) {
+    e_replaced += p_replaced.first.ToExpression() * p_replaced.second;
+  }
+  return e_replaced;
 }
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -2,20 +2,27 @@
 
 #include <ostream>
 #include <sstream>
+#include <unordered_map>
+
 namespace drake {
 namespace solvers {
-std::unordered_map<symbolic::Variable::Id, int> ConstructVarToIndexMap(const Eigen::Ref<const VectorXDecisionVariable>& x) {
+/*
+ * Returns the map that maps x(i).get_id() to i.
+ */
+std::unordered_map<symbolic::Variable::Id, int> ConstructVarToIndexMap(
+    const Eigen::Ref<const VectorXDecisionVariable>& x) {
   std::unordered_map<symbolic::Variable::Id, int> map;
   map.reserve(x.rows());
   for (int i = 0; i < x.rows(); ++i) {
     auto it = map.find(x(i).get_id());
     if (it != map.end()) {
-      throw std::runtime_error("Input vector contains duplicate variable " + x(i).get_name());
+      throw std::runtime_error("Input vector contains duplicate variable " +
+                               x(i).get_name());
     }
     map.emplace_hint(it, x(i).get_id(), i);
   }
   return map;
-};
+}
 
 symbolic::Expression ReplaceBilinearTerms(
     const symbolic::Expression& e,
@@ -23,9 +30,12 @@ symbolic::Expression ReplaceBilinearTerms(
     const Eigen::Ref<const VectorXDecisionVariable>& y,
     const Eigen::Ref<const MatrixXDecisionVariable>& W) {
   DRAKE_ASSERT(W.rows() == x.rows() && W.cols() == y.rows());
-  const std::unordered_map<symbolic::Variable::Id, int> x_to_index_map = ConstructVarToIndexMap(x);
-  const std::unordered_map<symbolic::Variable::Id, int> y_to_index_map = ConstructVarToIndexMap(y);
+  const std::unordered_map<symbolic::Variable::Id, int> x_to_index_map =
+      ConstructVarToIndexMap(x);
+  const std::unordered_map<symbolic::Variable::Id, int> y_to_index_map =
+      ConstructVarToIndexMap(y);
 
+  // vars contains all the variables in x and y.
   symbolic::Variables vars{};
   for (int i = 0; i < x.rows(); ++i) {
     vars.insert(x(i));
@@ -39,25 +49,16 @@ symbolic::Expression ReplaceBilinearTerms(
   symbolic::Polynomial::MapType map_replaced;
   map_replaced.reserve(map_bilinear.size());
   for (const auto& p : map_bilinear) {
-    std::map<symbolic::Variable, int> monomial_replace_map;
-    // For each monomial, we decompose it into two parts, the part that contains
-    // variables in `x` or `y`, and the part that does not. We call the first
-    // part as "dependent monomial", the second part as "independent monomial".
-    std::map<symbolic::Variable, int> dependent_monomial_map;
-    std::map<symbolic::Variable, int> independent_monomial_map;
+    std::unordered_map<symbolic::Variable, int, hash_value<symbolic::Variable>> monomial_map;
     int xy_total_degree{0};
     for (const auto& var_power : p.first.get_powers()) {
-      const symbolic::Variable& var{var_power.first};
-      if (x_to_index_map.find(var.get_id()) != x_to_index_map.end() || y_to_index_map.find(var.get_id()) != y_to_index_map.end()) {
-        dependent_monomial_map.emplace(var_power.first, var_power.second);
-        xy_total_degree += var_power.second;
-      } else {
-        independent_monomial_map.emplace(var_power.first, var_power.second);
-      }
+      monomial_map.emplace(var_power.first, var_power.second);
+      xy_total_degree += var_power.second;
     }
     if (xy_total_degree > 2) {
       std::ostringstream oss;
-      oss << "The term " << p.first << " has degree larger than 2 on the variables";
+      oss << "The term " << p.first
+          << " has degree larger than 2 on the variables";
       throw std::runtime_error(oss.str());
     } else if (xy_total_degree < 2) {
       // Only linear or constant terms, do not need to replace the variables.
@@ -71,48 +72,46 @@ symbolic::Expression ReplaceBilinearTerms(
       // This monomial contains bilinear term in x and y.
       std::unordered_map<symbolic::Variable::Id, int>::const_iterator it_x_idx;
       std::unordered_map<symbolic::Variable::Id, int>::const_iterator it_y_idx;
-      if (dependent_monomial_map.size() == 2) {
-        // The dependent monomial is in the form of x * y, namely two different
+      if (monomial_map.size() == 2) {
+        // The monomial is in the form of x * y, namely two different
         // variables multiplying together.
-        auto dependent_monomial_map_it = dependent_monomial_map.begin();
-        const symbolic::Variable &var1{dependent_monomial_map_it->first};
-        ++dependent_monomial_map_it;
-        const symbolic::Variable &var2{dependent_monomial_map_it->first};
+        auto monomial_map_it = monomial_map.begin();
+        const symbolic::Variable &var1{monomial_map_it->first};
+        ++monomial_map_it;
+        const symbolic::Variable &var2{monomial_map_it->first};
         it_x_idx = x_to_index_map.find(var1.get_id());
         if (it_x_idx != x_to_index_map.end()) {
+          // var1 is in x.
           it_y_idx = y_to_index_map.find(var2.get_id());
         } else {
+          // var1 is in y.
           it_x_idx = x_to_index_map.find(var2.get_id());
           it_y_idx = y_to_index_map.find(var1.get_id());
         }
       } else {
-        // The dependent monomial is in the form of x * x, the square of a variable.
-        const symbolic::Variable& squared_var{dependent_monomial_map.begin()->first};
+        // The monomial is in the form of x * x, the square of a variable.
+        const symbolic::Variable& squared_var{
+            monomial_map.begin()->first};
         it_x_idx = x_to_index_map.find(squared_var.get_id());
         it_y_idx = y_to_index_map.find(squared_var.get_id());
       }
-      if (it_x_idx == x_to_index_map.end() || it_y_idx == y_to_index_map.end()) {
+      if (it_x_idx == x_to_index_map.end() ||
+          it_y_idx == y_to_index_map.end()) {
+        // This error would happen, if we ask
+        // ReplaceBilinearTerms(x(i) * x(j), x, y, W).
         std::ostringstream oss;
-        oss << "Term " << p.first << " is bilinear, but x and y does not have the corresponding variables.";
+        oss << "Term " << p.first << " is bilinear, but x and y does not have "
+                                     "the corresponding variables.";
         throw std::runtime_error(oss.str());
       }
       // w_xy is the symbolic variable representing the bilinear term x * y.
       const symbolic::Variable& w_xy{W(it_x_idx->second, it_y_idx->second)};
-      // Multiply w_xy with the independent monomial
-      auto it_w_in_independent_monomial = independent_monomial_map.find(w_xy);
-      if (it_w_in_independent_monomial != independent_monomial_map.end()) {
-        ++(it_w_in_independent_monomial->second);
-      } else {
-        independent_monomial_map.emplace_hint(it_w_in_independent_monomial, w_xy, 1);
-      }
-      map_replaced.emplace(symbolic::Monomial{independent_monomial_map}, p.second);
+      map_replaced.emplace(symbolic::Monomial{w_xy},
+                           p.second);
     }
   }
-  symbolic::Expression poly_replaced{0};
-  for (const auto& p_replaced : map_replaced) {
-    poly_replaced += p_replaced.first.ToExpression() * p_replaced.second;
-  }
-  return poly_replaced;
+  symbolic::Polynomial poly_replaced{map_replaced};
+  return poly_replaced.ToExpression();
 }
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -49,10 +49,10 @@ symbolic::Expression ReplaceBilinearTerms(
   symbolic::Polynomial::MapType map_replaced;
   map_replaced.reserve(map_bilinear.size());
   for (const auto& p : map_bilinear) {
-    std::unordered_map<symbolic::Variable, int, hash_value<symbolic::Variable>> monomial_map;
+    std::unordered_map<int, int> monomial_map;
     int xy_total_degree{0};
     for (const auto& var_power : p.first.get_powers()) {
-      monomial_map.emplace(var_power.first, var_power.second);
+      monomial_map.emplace(var_power.first.get_id(), var_power.second);
       xy_total_degree += var_power.second;
     }
     if (xy_total_degree > 2) {
@@ -76,24 +76,23 @@ symbolic::Expression ReplaceBilinearTerms(
         // The monomial is in the form of x * y, namely two different
         // variables multiplying together.
         auto monomial_map_it = monomial_map.begin();
-        const symbolic::Variable &var1{monomial_map_it->first};
+        int var1_id{monomial_map_it->first};
         ++monomial_map_it;
-        const symbolic::Variable &var2{monomial_map_it->first};
-        it_x_idx = x_to_index_map.find(var1.get_id());
+        int var2_id{monomial_map_it->first};
+        it_x_idx = x_to_index_map.find(var1_id);
         if (it_x_idx != x_to_index_map.end()) {
           // var1 is in x.
-          it_y_idx = y_to_index_map.find(var2.get_id());
+          it_y_idx = y_to_index_map.find(var2_id);
         } else {
           // var1 is in y.
-          it_x_idx = x_to_index_map.find(var2.get_id());
-          it_y_idx = y_to_index_map.find(var1.get_id());
+          it_x_idx = x_to_index_map.find(var2_id);
+          it_y_idx = y_to_index_map.find(var1_id);
         }
       } else {
         // The monomial is in the form of x * x, the square of a variable.
-        const symbolic::Variable& squared_var{
-            monomial_map.begin()->first};
-        it_x_idx = x_to_index_map.find(squared_var.get_id());
-        it_y_idx = y_to_index_map.find(squared_var.get_id());
+        int squared_var_id{monomial_map.begin()->first};
+        it_x_idx = x_to_index_map.find(squared_var_id);
+        it_y_idx = y_to_index_map.find(squared_var_id);
       }
       if (it_x_idx == x_to_index_map.end() ||
           it_y_idx == y_to_index_map.end()) {

--- a/drake/solvers/bilinear_product_util.cc
+++ b/drake/solvers/bilinear_product_util.cc
@@ -7,10 +7,6 @@
 
 namespace drake {
 namespace solvers {
-/*
- * Returns the map that maps x(i).get_id() to i.
- */
-
 using std::ostringstream;
 using std::runtime_error;
 using std::unordered_map;
@@ -22,6 +18,9 @@ using symbolic::Variables;
 
 using MapVarToIndex = unordered_map<Variable::Id, int>;
 
+/*
+ * Returns the map that maps x(i).get_id() to i.
+ */
 MapVarToIndex ConstructVarToIndexMap(
     const Eigen::Ref<const VectorXDecisionVariable>& x) {
   MapVarToIndex map;
@@ -79,9 +78,9 @@ Expression ReplaceBilinearTerms(
         // The monomial is in the form of x * y, namely two different
         // variables multiplying together.
         auto monomial_map_it = monomial_map.begin();
-        const auto var1_id{monomial_map_it->first};
+        const Variable::Id var1_id{monomial_map_it->first};
         ++monomial_map_it;
-        const auto var2_id{monomial_map_it->first};
+        const Variable::Id var2_id{monomial_map_it->first};
         it_x_idx = x_to_index_map.find(var1_id);
         if (it_x_idx != x_to_index_map.end()) {
           // var1 is in x.
@@ -93,7 +92,7 @@ Expression ReplaceBilinearTerms(
         }
       } else {
         // The monomial is in the form of x * x, the square of a variable.
-        const auto squared_var_id{monomial_map.begin()->first};
+        const Variable::Id squared_var_id{monomial_map.begin()->first};
         it_x_idx = x_to_index_map.find(squared_var_id);
         it_y_idx = y_to_index_map.find(squared_var_id);
       }

--- a/drake/solvers/bilinear_product_util.h
+++ b/drake/solvers/bilinear_product_util.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "drake/common/symbolic_expression.h"
+#include "drake/common/symbolic_polynomial.h"
+#include "drake/solvers/decision_variable.h"
+
+namespace drake {
+namespace solvers {
+symbolic::Expression ReplaceBilinearTerms(
+    const symbolic::Expression& e,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+const Eigen::Ref<const VectorXDecisionVariable>& y,
+const Eigen::Ref<const MatrixXDecisionVariable>& W);
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/bilinear_product_util.h
+++ b/drake/solvers/bilinear_product_util.h
@@ -6,6 +6,25 @@
 
 namespace drake {
 namespace solvers {
+/**
+ * Replace all the bilinear product terms in the expression `e`, with the
+ * corresponding term in `W`, where `W` represents the matrix x * yᵀ, such that
+ * after replacement, `e` does not have bilinear terms involving `x` and `y`.
+ * For example, if e = x(0)*y(0) + 2 * x(0)*y(1) + x(1) * y(1) + 3 * x(1),
+ * `e` has bilinear terms x(0)*y(0), x(0) * y(1) and x(2) * y(1), if we call
+ * ReplaceBilinearTerms(e, x, y, W)
+ * where W(i, j) represent the term x(i) * y(j), then this function returns
+ * W(0, 0) + 2 * W(0, 1) + W(1, 1) + 3 * x(1).
+ * @param e A expression potentially contains bilinear product between x and y.
+ * @param x The bilinear product between `x` and `y` will be replaced by the
+ * corresponding term in `W. Throws a runtime error if `x` contains duplicate
+ * entries.
+ * @param y The bilinear product between `x` and `y` will be replaced by the
+ * corresponding term in `W.Throws a runtime error if `y` contains duplicate
+ * entries.
+ * @param W Bilinear product term x(i) * y(j) will be replaced by W(i, j).
+ * @return The symbolic expression after replacing x(i) * y(j) with W(i, j).
+ */
 symbolic::Expression ReplaceBilinearTerms(
     const symbolic::Expression& e,
     const Eigen::Ref<const VectorXDecisionVariable>& x,

--- a/drake/solvers/bilinear_product_util.h
+++ b/drake/solvers/bilinear_product_util.h
@@ -7,15 +7,15 @@
 namespace drake {
 namespace solvers {
 /**
- * Replace all the bilinear product terms in the expression `e`, with the
- * corresponding term in `W`, where `W` represents the matrix x * yᵀ, such that
+  * Replaces all the bilinear product terms in the expression `e`, with the
+ * corresponding terms in `W`, where `W` represents the matrix x * yᵀ, such that
  * after replacement, `e` does not have bilinear terms involving `x` and `y`.
- * For example, if e = x(0)*y(0) + 2 * x(0)*y(1) + x(1) * y(1) + 3 * x(1),
- * `e` has bilinear terms x(0)*y(0), x(0) * y(1) and x(2) * y(1), if we call
- * ReplaceBilinearTerms(e, x, y, W)
- * where W(i, j) represent the term x(i) * y(j), then this function returns
- * W(0, 0) + 2 * W(0, 1) + W(1, 1) + 3 * x(1).
- * @param e A expression potentially contains bilinear product between x and y.
+ * For example, if e = x(0)*y(0) + 2 * x(0)*y(1) + x(1) * y(1) + 3 * x(1), `e`
+ * has bilinear terms x(0)*y(0), x(0) * y(1) and x(2) * y(1), if we call
+ * ReplaceBilinearTerms(e, x, y, W) where W(i, j) represent the term x(i) *
+ * y(j), then this function returns W(0, 0) + 2 * W(0, 1) + W(1, 1) + 3 * x(1).
+ * @param e An expression potentially contains bilinear products between x and
+ * y.
  * @param x The bilinear product between `x` and `y` will be replaced by the
  * corresponding term in `W. Throws a runtime error if `x` contains duplicate
  * entries.
@@ -28,7 +28,7 @@ namespace solvers {
 symbolic::Expression ReplaceBilinearTerms(
     const symbolic::Expression& e,
     const Eigen::Ref<const VectorXDecisionVariable>& x,
-const Eigen::Ref<const VectorXDecisionVariable>& y,
-const Eigen::Ref<const MatrixXDecisionVariable>& W);
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
+    const Eigen::Ref<const MatrixXDecisionVariable>& W);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -22,6 +22,9 @@ target_link_libraries(constraint_test drakeOptimization drakeCommon)
 drake_add_cc_test(cost_test)
 target_link_libraries(cost_test drakeOptimization drakeCommon)
 
+drake_add_cc_test(bilinear_product_util_test)
+target_link_libraries(bilinear_product_util_test drakeBilinearProductUtil)
+
 set(drakeOptimizationTestSources
         add_solver_util.cc
         optimization_examples.cc

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -1,0 +1,149 @@
+#include "drake/solvers/bilinear_product_util.h"
+
+#include <gtest/gtest.h>
+#include "drake/common/test/symbolic_test_util.h"
+
+using drake::symbolic::Variable;
+using drake::symbolic::test::ExprEqual;
+
+namespace drake {
+namespace solvers {
+namespace {
+class BilinearProductTest : public ::testing::Test {
+ public:
+  BilinearProductTest()
+      : x_{Variable{"x0"}, Variable{"x1"}, Variable{"x2"}},
+        y_{Variable{"y0"}, Variable{"y1"}, Variable{"y2"}, Variable{"y3"}},
+        z_{Variable{"z0"}, Variable{"z1"}} {
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        xy_(i, j) = symbolic::Variable("xy(" + std::to_string(i) + "," + std::to_string(j) + ")");
+      }
+    }
+
+    for (int i = 0; i < 3; ++i) {
+      for (int j = i; j < 3; ++j) {
+        xx_(i, j) = symbolic::Variable("xx(" + std::to_string(i) + "," + std::to_string(j) + ")");
+      }
+    }
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < i; ++j) {
+        xx_(i, j) = xx_(j, i);
+      }
+    }
+  }
+ protected:
+  VectorDecisionVariable<3> x_;
+  VectorDecisionVariable<4> y_;
+  VectorDecisionVariable<2> z_;
+  MatrixDecisionVariable<3, 4> xy_;
+  MatrixDecisionVariable<3, 3> xx_;
+};
+
+TEST_F(BilinearProductTest, ConstantTerm) {
+  std::vector<symbolic::Expression> e;
+  e.emplace_back(0);
+  e.emplace_back(1);
+  e.emplace_back(z_(0) + z_(1));
+  e.emplace_back(pow(z_(0), 3) + z_(0) * z_(1));
+  for (const auto& ei : e) {
+    EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, y_, xy_));
+    EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, x_, xx_));
+  }
+}
+
+TEST_F(BilinearProductTest, LinearTerm) {
+  std::vector<symbolic::Expression> e;
+  e.emplace_back(x_(0));
+  e.emplace_back(y_(0));
+  e.emplace_back(x_(0) + y_(1) + z_(0) + 2);
+  e.emplace_back(2 * x_(0) + 3 * y_(1) * z_(1) + 3);
+  e.emplace_back(2 * x_(0) + 3 * y_(1) * z_(0) + pow(z_(1), 3));
+  for (const auto& ei : e) {
+    EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, y_, xy_));
+    EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, x_, xx_));
+  }
+}
+
+TEST_F(BilinearProductTest, QuadraticTerm0) {
+  symbolic::Expression e{x_(0) * x_(0)};
+  symbolic::Expression e_expected{xx_(0, 0)};
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = x_(0) * x_(0) + 2 * x_(1) * x_(1);
+  e_expected = xx_(0, 0) + 2 * xx_(1, 1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * x_(0) * x_(0) * y_(0) * y_(1);
+  e_expected = 2 * xx_(0, 0) * y_(0) * y_(1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * x_(2) * x_(2) * y_(0) * y_(1) + 3 * y_(1) * x_(2) + 2;
+  e_expected = 2 * xx_(2, 2) * y_(0) * y_(1) + 3 * y_(1) * x_(2) + 2;
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = (2 + y_(0) + y_(0) * y_(1)) * x_(0) * x_(0);
+  e_expected = (2 + y_(0) + y_(0) * y_(1)) * xx_(0, 0);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+}
+
+TEST_F(BilinearProductTest, QuadraticTerm1) {
+  symbolic::Expression e{x_(0) * x_(1)};
+  symbolic::Expression e_expected{xx_(0, 1)};
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * x_(0) * x_(1);
+  e_expected = 2 * xx_(0, 1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * y_(0) * y_(1) * x_(1) * x_(2);
+  e_expected = 2 * y_(0) * y_(1) * xx_(1, 2);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * pow(y_(0), 3) * x_(1) * x_(2) + y_(1) * x_(1) * x_(1) + 2 * x_(0) + 3 + 3 * x_(1);
+  e_expected = 2 * pow(y_(0), 3) * xx_(1, 2) + y_(1) * xx_(1, 1) + 2 * x_(0) + 3 + 3 * x_(1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = (2 + y_(0) + y_(0) * y_(1)) * x_(0) * x_(1);
+  e_expected = (2 + y_(0) + y_(0) * y_(1)) * xx_(0, 1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+}
+
+TEST_F(BilinearProductTest, QuadraticTerm2) {
+  symbolic::Expression e{x_(0) * y_(0)};
+  symbolic::Expression e_expected{xy_(0, 0)};
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, y_, xy_));
+
+  e = 4 * x_(0) * y_(1);
+  e_expected = 4 * xy_(0, 1);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, y_, xy_));
+
+  e = 2 * z_(0) * z_(1) * z_(1) * x_(0) * y_(2);
+  e_expected = 2 * z_(0) * z_(1) * z_(1) * xy_(0, 2);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, y_, xy_));
+
+  e = 2 * pow(z_(1), 3) * x_(0) * y_(2) + z_(0) * x_(1) * y_(1) + (4 * z_(0) + z_(1)) * x_(2) * y_(3) + 3 * x_(2) + 4;
+  e_expected = 2 * pow(z_(1), 3) * xy_(0, 2) + z_(0) * xy_(1, 1) + (4 * z_(0) + z_(1)) * xy_(2, 3) + 3 * x_(2) + 4;
+  EXPECT_PRED2(ExprEqual, e_expected.Expand(), ReplaceBilinearTerms(e, x_, y_, xy_).Expand());
+}
+
+TEST_F(BilinearProductTest, HigherOrderTest) {
+  EXPECT_THROW(ReplaceBilinearTerms(pow(x_(0), 3), x_, x_, xx_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0) * x_(1), x_, x_, xx_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(2), x_, x_, xx_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0), x_, y_, xy_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1), x_, y_, xy_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(1), x_, y_, xy_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(1) * y_(2), x_, y_, xy_), std::runtime_error);
+
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(2) * y_(2), x_, y_, xy_), std::runtime_error);
+}
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -17,13 +17,15 @@ class BilinearProductTest : public ::testing::Test {
         z_{Variable{"z0"}, Variable{"z1"}} {
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 4; ++j) {
-        xy_(i, j) = symbolic::Variable("xy(" + std::to_string(i) + "," + std::to_string(j) + ")");
+        xy_(i, j) = symbolic::Variable("xy(" + std::to_string(i) + "," +
+                                       std::to_string(j) + ")");
       }
     }
 
     for (int i = 0; i < 3; ++i) {
       for (int j = i; j < 3; ++j) {
-        xx_(i, j) = symbolic::Variable("xx(" + std::to_string(i) + "," + std::to_string(j) + ")");
+        xx_(i, j) = symbolic::Variable("xx(" + std::to_string(i) + "," +
+                                       std::to_string(j) + ")");
       }
     }
     for (int i = 0; i < 3; ++i) {
@@ -32,6 +34,7 @@ class BilinearProductTest : public ::testing::Test {
       }
     }
   }
+
  protected:
   VectorDecisionVariable<3> x_;
   VectorDecisionVariable<4> y_;
@@ -100,8 +103,10 @@ TEST_F(BilinearProductTest, QuadraticTerm1) {
   e_expected = 2 * y_(0) * y_(1) * xx_(1, 2);
   EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
 
-  e = 2 * pow(y_(0), 3) * x_(1) * x_(2) + y_(1) * x_(1) * x_(1) + 2 * x_(0) + 3 + 3 * x_(1);
-  e_expected = 2 * pow(y_(0), 3) * xx_(1, 2) + y_(1) * xx_(1, 1) + 2 * x_(0) + 3 + 3 * x_(1);
+  e = 2 * pow(y_(0), 3) * x_(1) * x_(2) + y_(1) * x_(1) * x_(1) + 2 * x_(0) +
+      3 + 3 * x_(1);
+  e_expected = 2 * pow(y_(0), 3) * xx_(1, 2) + y_(1) * xx_(1, 1) + 2 * x_(0) +
+               3 + 3 * x_(1);
   EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
 
   e = (2 + y_(0) + y_(0) * y_(1)) * x_(0) * x_(1);
@@ -122,27 +127,38 @@ TEST_F(BilinearProductTest, QuadraticTerm2) {
   e_expected = 2 * z_(0) * z_(1) * z_(1) * xy_(0, 2);
   EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, y_, xy_));
 
-  e = 2 * pow(z_(1), 3) * x_(0) * y_(2) + z_(0) * x_(1) * y_(1) + (4 * z_(0) + z_(1)) * x_(2) * y_(3) + 3 * x_(2) + 4;
-  e_expected = 2 * pow(z_(1), 3) * xy_(0, 2) + z_(0) * xy_(1, 1) + (4 * z_(0) + z_(1)) * xy_(2, 3) + 3 * x_(2) + 4;
-  EXPECT_PRED2(ExprEqual, e_expected.Expand(), ReplaceBilinearTerms(e, x_, y_, xy_).Expand());
+  e = 2 * pow(z_(1), 3) * x_(0) * y_(2) + z_(0) * x_(1) * y_(1) +
+      (4 * z_(0) + z_(1)) * x_(2) * y_(3) + 3 * x_(2) + 4;
+  e_expected = 2 * pow(z_(1), 3) * xy_(0, 2) + z_(0) * xy_(1, 1) +
+               (4 * z_(0) + z_(1)) * xy_(2, 3) + 3 * x_(2) + 4;
+  EXPECT_PRED2(ExprEqual, e_expected.Expand(),
+               ReplaceBilinearTerms(e, x_, y_, xy_).Expand());
 }
 
 TEST_F(BilinearProductTest, HigherOrderTest) {
-  EXPECT_THROW(ReplaceBilinearTerms(pow(x_(0), 3), x_, x_, xx_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(pow(x_(0), 3), x_, x_, xx_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0) * x_(1), x_, x_, xx_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0) * x_(1), x_, x_, xx_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(2), x_, x_, xx_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(2), x_, x_, xx_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0), x_, y_, xy_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0), x_, y_, xy_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1), x_, y_, xy_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1), x_, y_, xy_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(1), x_, y_, xy_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(1) * x_(1), x_, y_, xy_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(1) * y_(2), x_, y_, xy_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(1) * y_(2), x_, y_, xy_),
+               std::runtime_error);
 
-  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(2) * y_(2), x_, y_, xy_), std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(2) * y_(2), x_, y_, xy_),
+               std::runtime_error);
 }
 }  // namespace
 }  // namespace solvers

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -164,9 +164,9 @@ TEST_F(BilinearProductTest, HigherOrderTest) {
 TEST_F(BilinearProductTest, DuplicateEntry) {
   // x_duplicate contains duplicate entries.
   VectorDecisionVariable<2> x_duplicate(x_(0), x_(0));
-  EXPECT_THROW(
-      ReplaceBilinearTerms(x_(0) * x_(0), x_duplicate, x_duplicate, xx_),
-      std::runtime_error);
+  EXPECT_THROW(ReplaceBilinearTerms(x_(0) * x_(0), x_duplicate, x_duplicate,
+                                    xx_.block<2, 2>(0, 0)),
+               std::runtime_error);
 }
 }  // namespace
 }  // namespace solvers

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -44,12 +44,9 @@ class BilinearProductTest : public ::testing::Test {
 };
 
 TEST_F(BilinearProductTest, ConstantTerm) {
-  std::vector<symbolic::Expression> e;
-  e.emplace_back(0);
-  e.emplace_back(1);
-  e.emplace_back(z_(0) + z_(1));
-  e.emplace_back(pow(z_(0), 3) + z_(0) * z_(1));
-  for (const auto& ei : e) {
+  const std::vector<symbolic::Expression> expressions{
+      0, 1, z_(0) + z_(1), pow(z_(0), 3) + z_(0) * z_(1)};
+  for (const auto& ei : expressions) {
     EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, y_, xy_));
     EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, x_, xx_));
   }

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -112,6 +112,14 @@ TEST_F(BilinearProductTest, QuadraticTerm1) {
   e = (2 + y_(0) + y_(0) * y_(1)) * x_(0) * x_(1);
   e_expected = (2 + y_(0) + y_(0) * y_(1)) * xx_(0, 1);
   EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = 2 * x_(0) * x_(0) + xx_(0, 0);
+  e_expected = 3 * xx_(0, 0);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
+
+  e = xx_(0, 0) * x_(0) * x_(0);
+  e_expected = xx_(0, 0) * xx_(0, 0);
+  EXPECT_PRED2(ExprEqual, e_expected, ReplaceBilinearTerms(e, x_, x_, xx_));
 }
 
 TEST_F(BilinearProductTest, QuadraticTerm2) {

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -160,6 +160,14 @@ TEST_F(BilinearProductTest, HigherOrderTest) {
   EXPECT_THROW(ReplaceBilinearTerms(x_(0) * y_(2) * y_(2), x_, y_, xy_),
                std::runtime_error);
 }
+
+TEST_F(BilinearProductTest, DuplicateEntry) {
+  // x_duplicate contains duplicate entries.
+  VectorDecisionVariable<2> x_duplicate(x_(0), x_(0));
+  EXPECT_THROW(
+      ReplaceBilinearTerms(x_(0) * x_(0), x_duplicate, x_duplicate, xx_),
+      std::runtime_error);
+}
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/bilinear_product_util_test.cc
+++ b/drake/solvers/test/bilinear_product_util_test.cc
@@ -53,13 +53,11 @@ TEST_F(BilinearProductTest, ConstantTerm) {
 }
 
 TEST_F(BilinearProductTest, LinearTerm) {
-  std::vector<symbolic::Expression> e;
-  e.emplace_back(x_(0));
-  e.emplace_back(y_(0));
-  e.emplace_back(x_(0) + y_(1) + z_(0) + 2);
-  e.emplace_back(2 * x_(0) + 3 * y_(1) * z_(1) + 3);
-  e.emplace_back(2 * x_(0) + 3 * y_(1) * z_(0) + pow(z_(1), 3));
-  for (const auto& ei : e) {
+  const std::vector<symbolic::Expression> expressions{
+      x_(0), y_(0), x_(0) + y_(1) + z_(0) + 2,
+      2 * x_(0) + 3 * y_(1) * z_(1) + 3,
+      2 * x_(0) + 3 * y_(1) * z_(0) + pow(z_(1), 3)};
+  for (const auto& ei : expressions) {
     EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, y_, xy_));
     EXPECT_PRED2(ExprEqual, ei, ReplaceBilinearTerms(ei, x_, x_, xx_));
   }


### PR DESCRIPTION
This is useful for solving a non-convex quadratically constrained quadratic problem, by first replacing the quadratic/bilinear terms with another variables, and then impose constraint on this new variable to approximate the quadratic/bilinear term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6548)
<!-- Reviewable:end -->
