### PR TITLE
Move PoseBundle::ToAutoDiffXd to testonly; add symbolic

### DIFF
--- a/drake/systems/rendering/BUILD
+++ b/drake/systems/rendering/BUILD
@@ -72,6 +72,7 @@ drake_cc_library(
         ":frame_velocity",
         "//drake/common",
         "//drake/common:autodiff",
+        "//drake/common:symbolic",
     ],
 )
 

--- a/drake/systems/rendering/pose_bundle.cc
+++ b/drake/systems/rendering/pose_bundle.cc
@@ -4,7 +4,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic_formula.h"
 
 namespace drake {
 namespace systems {
@@ -73,29 +73,9 @@ void PoseBundle<T>::set_model_instance_id(int index, int id) {
   ids_[index] = id;
 }
 
-template <typename T>
-std::unique_ptr<PoseBundle<AutoDiffXd>> PoseBundle<T>::ToAutoDiffXd() const {
-  // TODO(sherm1): Consider changing this to overload a default implementation
-  // in AbstractValue, as discussed in
-  // https://github.com/RobotLocomotion/drake/issues/5454
-
-  auto bundle = std::make_unique<PoseBundle<AutoDiffXd>>(get_num_poses());
-  for (int pose_index = 0; pose_index < get_num_poses(); pose_index++) {
-    Isometry3<AutoDiffXd> pose(get_pose(pose_index));
-    bundle->set_pose(pose_index, pose);
-    FrameVelocity<AutoDiffXd> velocity;
-    velocity.set_velocity(multibody::SpatialVelocity<AutoDiffXd>(
-        get_velocity(pose_index).get_velocity().get_coeffs()));
-    bundle->set_velocity(pose_index, velocity);
-    bundle->set_name(pose_index, get_name(pose_index));
-    bundle->set_model_instance_id(pose_index,
-                                  get_model_instance_id(pose_index));
-  }
-  return bundle;
-}
-
 template class PoseBundle<double>;
 template class PoseBundle<AutoDiffXd>;
+template class PoseBundle<symbolic::Expression>;
 
 }  // namespace rendering
 }  // namespace systems

--- a/drake/systems/rendering/pose_bundle.h
+++ b/drake/systems/rendering/pose_bundle.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic_expression.h"
 #include "drake/systems/rendering/frame_velocity.h"
 
 namespace drake {
@@ -31,12 +32,15 @@ namespace rendering {
 /// other scalar types are supported.
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///           Only double and AutoDiffXd are supported.
 template <typename T>
 class PoseBundle {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseBundle)
+
   explicit PoseBundle(int num_poses);
   ~PoseBundle();
 
@@ -52,10 +56,6 @@ class PoseBundle {
 
   int get_model_instance_id(int index) const;
   void set_model_instance_id(int index, int id);
-
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PoseBundle)
-
-  std::unique_ptr<PoseBundle<AutoDiffXd>> ToAutoDiffXd() const;
 
  private:
   std::vector<Isometry3<T>> poses_;


### PR DESCRIPTION
This method was added in #5852 and is only used in the unit test as some convenience sugar.

It makes sense to transmogrify systems -- we need to change the memory layout of the `Context` storage, the signature of port types, etc.

I'm not really sure it ever makes sense to transmogrify values, at least not without `AbstractValue` providing a way that is generically usable (ala #5454).

But I am fairly sure that demanding that `PoseBundle<symbolic::Expression>` be able to transmogrify into a `PoseBundle<AutoDiffXd>` is nothing we ever want to support, so at a minimum the existing method signature was wrong.

If we decide we need this for some reason, we can move it back out of the unit test code into some free function or other phrasing, once we better understand what the purpose is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6549)
<!-- Reviewable:end -->
