### PR TITLE
Increasing Sizes of a Couple of Tests

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -701,6 +701,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "symbolic_polynomial_test",
+    size = "medium",
     deps = [
         ":symbolic_polynomial",
         ":symbolic_test_util",

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -788,7 +788,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "rotation_constraint_test",
-    size = "medium",
+    size = "large",
     # Excluding because an assertion fails in LLVM code. Issue #6179.
     tags = gurobi_test_tags() + mosek_test_tags() + ["no_tsan"],
     deps = [


### PR DESCRIPTION
`rotation_constraint_test`: Due to recent timeouts on CI  : https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-everything-debug/888/

And `symbolic_polynomial_test` due to the timeouts with Valgrind:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/62/consoleText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6553)
<!-- Reviewable:end -->
