### PR TITLE
Add callback support to Gurobi interface

### DIFF
--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -26,13 +26,16 @@ namespace drake {
 namespace solvers {
 namespace {
 
-// see http://www.gurobi.com/documentation/7.0/examples.pdf
-// First C callbacks example
-
+// Information to be passed through a Gurobi C callback to
+// grant it information about its problem (the host
+// MathematicalProgram prog, and which decision variables
+// are not represented in prog), and what user functions
+// are present for handling the callback.
 // TODO(gizatt) This struct can be replaced with a ptr to
-// the GurobiSolver class (or the callback can shell to a 
+// the GurobiSolver class (or the callback can shell to a
 // method on that class) once the above TODO(hongkai.dai) is
-// dealt with
+// completed. It might be able to be further reduced if
+// GurobiSolver subclasses GRBCallback in the Gurobi C++ API.
 struct GurobiCallbackInformation {
   MathematicalProgram * prog;
   std::vector<bool> is_new_variable;
@@ -44,22 +47,24 @@ struct GurobiCallbackInformation {
 
 static int
 gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
-  GurobiCallbackInformation * callbackInfo = (GurobiCallbackInformation *) usrdata;
+  GurobiCallbackInformation * callbackInfo =
+    reinterpret_cast<GurobiCallbackInformation *>(usrdata);
 
-  if (where == GRB_CB_POLLING){
-    ;
-  } else if (where == GRB_CB_PRESOLVE) { 
-    ;
-  } else if (where == GRB_CB_SIMPLEX) { 
-    ;
-  } else if (where == GRB_CB_MIP) { 
-    ;
+  if (where == GRB_CB_POLLING) {
+  } else if (where == GRB_CB_PRESOLVE) {
+  } else if (where == GRB_CB_SIMPLEX) {
+  } else if (where == GRB_CB_MIP) {
   } else if (where == GRB_CB_MIPSOL) {
+    // Extract variable values from Gurobi, and set the current
+    // solution of the MathematicalProgram to these values.
     int num_total_variables = callbackInfo->is_new_variable.size();
     std::vector<double> solver_sol_vector(num_total_variables);
-    auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL, solver_sol_vector.data());
-    if (error){
-      printf("GRB error %d in cbget mipsol rel: %s\n", error, GRBgeterrormsg(GRBgetenv(model)));
+    auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
+      solver_sol_vector.data());
+    if (error) {
+      printf("GRB error %d in MIPSol callback cbget: %s\n", error,
+        GRBgeterrormsg(GRBgetenv(model)));
+      return 0;
     }
     // TODO(gizatt): If I use the entries from is_new_variable,
     // I wind up out of alignment. Why? Where are the new vars
@@ -69,33 +74,44 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
       prog_sol_vector(i) = solver_sol_vector[i];
     }
     callbackInfo->prog->SetDecisionVariableValues(prog_sol_vector);
-  
+
+    // Extract current solve information to pass to user callback.
     GurobiSolver::SolveStatusInfo solve_status;
-    GRBcbget(cbdata, where, GRB_CB_RUNTIME, &(solve_status.reported_runtime));
-    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJ, &(solve_status.current_objective));
-    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJBST, &(solve_status.best_objective));
-    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJBND, &(solve_status.best_bound));
-    GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOLCNT, &(solve_status.feasible_solutions_count));
-    // This expects a double, so...
+    GRBcbget(cbdata, where, GRB_CB_RUNTIME,
+      &(solve_status.reported_runtime));
+    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJ,
+      &(solve_status.current_objective));
+    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJBST,
+      &(solve_status.best_objective));
+    GRBcbget(cbdata, where, GRB_CB_MIPSOL_OBJBND,
+      &(solve_status.best_bound));
+    GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOLCNT,
+      &(solve_status.feasible_solutions_count));
     double explored_node_count_dbl;
-    GRBcbget(cbdata, where, GRB_CB_MIPSOL_NODCNT, &explored_node_count_dbl); 
+    GRBcbget(cbdata, where, GRB_CB_MIPSOL_NODCNT, &explored_node_count_dbl);
     solve_status.explored_node_count = explored_node_count_dbl;
 
-    callbackInfo->mip_sol_callback(*(callbackInfo->prog), solve_status, callbackInfo->mip_node_callback_usrdata);
+    callbackInfo->mip_sol_callback(*(callbackInfo->prog), solve_status,
+      callbackInfo->mip_node_callback_usrdata);
 
   } else if (where == GRB_CB_MIPNODE) {
     int sol_status;
     auto error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_STATUS, &sol_status);
-    if (error){
-      printf("GRB error %d in cbget mipnode status: %s\n", error, GRBgeterrormsg(GRBgetenv(model)));
-    }
-    
-    if (sol_status == GRB_OPTIMAL){
+    if (error) {
+      printf("GRB error %d in MIPNode callback getting sol status: %s\n",
+        error, GRBgeterrormsg(GRBgetenv(model)));
+      return 0;
+    } else if (sol_status == GRB_OPTIMAL) {
+      // Extract variable values from Gurobi, and set the current
+      // solution of the MathematicalProgram to these values.
       int num_total_variables = callbackInfo->is_new_variable.size();
       std::vector<double> solver_sol_vector(num_total_variables);
-      error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_REL, solver_sol_vector.data());
-      if (error){
-        printf("GRB error %d in cbget mipnode rel: %s\n", error, GRBgeterrormsg(GRBgetenv(model)));
+      auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
+        solver_sol_vector.data());
+      if (error) {
+        printf("GRB error %d in MIPSol callback cbget: %s\n", error,
+          GRBgeterrormsg(GRBgetenv(model)));
+        return 0;
       }
       // TODO(gizatt): If I use the entries from is_new_variable,
       // I wind up out of alignment. Why? Where are the new vars
@@ -104,46 +120,49 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
       for (int i = 0; i < num_total_variables; ++i) {
         prog_sol_vector(i) = solver_sol_vector[i];
       }
-
       callbackInfo->prog->SetDecisionVariableValues(prog_sol_vector);
-      
-      Eigen::VectorXd vals; 
-      VectorXDecisionVariable vars;
-      
+
       GurobiSolver::SolveStatusInfo solve_status;
-      GRBcbget(cbdata, where, GRB_CB_RUNTIME, &(solve_status.reported_runtime));
+      GRBcbget(cbdata, where, GRB_CB_RUNTIME,
+        &(solve_status.reported_runtime));
       solve_status.current_objective = -1.0;
-      GRBcbget(cbdata, where, GRB_CB_MIPNODE_OBJBST, &(solve_status.best_objective));
-      GRBcbget(cbdata, where, GRB_CB_MIPNODE_OBJBND, &(solve_status.best_bound));
-      GRBcbget(cbdata, where, GRB_CB_MIPNODE_SOLCNT, &(solve_status.feasible_solutions_count));
-      // This expects a double, so...
+      GRBcbget(cbdata, where, GRB_CB_MIPNODE_OBJBST,
+        &(solve_status.best_objective));
+      GRBcbget(cbdata, where, GRB_CB_MIPNODE_OBJBND,
+        &(solve_status.best_bound));
+      GRBcbget(cbdata, where, GRB_CB_MIPNODE_SOLCNT,
+        &(solve_status.feasible_solutions_count));
       double explored_node_count_dbl;
-      GRBcbget(cbdata, where, GRB_CB_MIPNODE_NODCNT, &explored_node_count_dbl); 
+      GRBcbget(cbdata, where, GRB_CB_MIPNODE_NODCNT, &explored_node_count_dbl);
       solve_status.explored_node_count = explored_node_count_dbl;
 
-      callbackInfo->mip_node_callback(*(callbackInfo->prog), solve_status, callbackInfo->mip_node_callback_usrdata, vals, vars);
+      Eigen::VectorXd vals;
+      VectorXDecisionVariable vars;
+      callbackInfo->mip_node_callback(*(callbackInfo->prog), solve_status,
+        callbackInfo->mip_node_callback_usrdata, vals, vars);
 
-      // The callback may return an assignment of some number of variables as a new
-      // heuristic solution seed. If so, feed those back to Gurobi.
-      if (vals.size() > 0){
-        std::vector<double> new_sol(callbackInfo->prog->num_vars(), GRB_UNDEFINED);
-        for (int i = 0; i < vals.size(); i++){
+      // The callback may return an assignment of some number of variables
+      // as a new heuristic solution seed. If so, feed those back to Gurobi.
+      if (vals.size() > 0) {
+        std::vector<double> new_sol(callbackInfo->prog->num_vars(),
+          GRB_UNDEFINED);
+        for (int i = 0; i < vals.size(); i++) {
           double val = vals[i];
           int k = callbackInfo->prog->FindDecisionVariableIndex(vars[i]);
           new_sol[k] = val;
         }
         double err;
         error = GRBcbsolution(cbdata, new_sol.data(), &err);
-        printf("Injected new sol with error %d, specified %ld vals\n", error, vals.size());
-        if (error){
-          printf("GRB error %d in injection: %s\n", error, GRBgeterrormsg(GRBgetenv(model)));
+        printf("Injected new sol with error %d, specified %ld vals\n", error,
+          vals.size());
+        if (error) {
+          printf("GRB error %d in injection: %s\n", error,
+            GRBgeterrormsg(GRBgetenv(model)));
         }
       }
     }
-  } else if (where == GRB_CB_BARRIER) { 
-    ;
+  } else if (where == GRB_CB_BARRIER) {
   } else if (where == GRB_CB_MESSAGE) {
-    ;
   }
   return 0;
 }
@@ -717,8 +736,10 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   }
 
   GRBupdatemodel(model);
-  
-  if (mip_node_callback_){
+
+  // If we have been supplied a callback,
+  // register it with Gurobi.
+  if (mip_node_callback_ || mip_sol_callback_) {
     GurobiCallbackInformation callbackInfo;
     callbackInfo.prog = &prog;
     callbackInfo.is_new_variable = is_new_variable;
@@ -726,7 +747,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     callbackInfo.mip_sol_callback = mip_sol_callback_;
     callbackInfo.mip_node_callback_usrdata = mip_node_callback_usrdata_;
     callbackInfo.mip_sol_callback_usrdata = mip_sol_callback_usrdata_;
-    GRBsetcallbackfunc(model, &gurobi_callback, &callbackInfo); 
+    GRBsetcallbackfunc(model, &gurobi_callback, &callbackInfo);
   }
 
   error = GRBoptimize(model);

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -17,6 +17,7 @@
 #include "gurobi_c++.h"
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/text_logging.h"
 #include "drake/math/eigen_sparse_triplet.h"
 #include "drake/solvers/mathematical_program.h"
 
@@ -100,8 +101,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
     auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
                           callback_info->solver_sol_vector.data());
     if (error) {
-      printf("GRB error %d in MIPSol callback cbget: %s\n", error,
-             GRBgeterrormsg(GRBgetenv(model)));
+      drake::log()->error("GRB error %d in MIPSol callback cbget: %s\n", error,
+                          GRBgeterrormsg(GRBgetenv(model)));
       return 0;
     }
     SetProgramSolutionVector(
@@ -117,8 +118,9 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
     int sol_status;
     auto error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_STATUS, &sol_status);
     if (error) {
-      printf("GRB error %d in MIPNode callback getting sol status: %s\n", error,
-             GRBgeterrormsg(GRBgetenv(model)));
+      drake::log()->error(
+          "GRB error %d in MIPNode callback getting sol status: %s\n", error,
+          GRBgeterrormsg(GRBgetenv(model)));
       return 0;
     } else if (sol_status == GRB_OPTIMAL) {
       // Extract variable values from Gurobi, and set the current
@@ -126,8 +128,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
       auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
                             callback_info->solver_sol_vector.data());
       if (error) {
-        printf("GRB error %d in MIPSol callback cbget: %s\n", error,
-               GRBgeterrormsg(GRBgetenv(model)));
+        drake::log()->error("GRB error %d in MIPSol callback cbget: %s\n",
+                            error, GRBgeterrormsg(GRBgetenv(model)));
         return 0;
       }
       SetProgramSolutionVector(
@@ -154,8 +156,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
         double objective_solution;
         error = GRBcbsolution(cbdata, new_sol.data(), &objective_solution);
         if (error) {
-          printf("GRB error %d in injection: %s\n", error,
-                 GRBgeterrormsg(GRBgetenv(model)));
+          drake::log()->error("GRB error %d in injection: %s\n", error,
+                              GRBgeterrormsg(GRBgetenv(model)));
         }
       }
     }
@@ -811,8 +813,8 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       double lower_bound;
       auto error = GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
       if (error) {
-        printf("GRB error %d getting lower bound: %s\n", error,
-               GRBgeterrormsg(GRBgetenv(model)));
+        drake::log()->error("GRB error %d getting lower bound: %s\n", error,
+                            GRBgeterrormsg(GRBgetenv(model)));
       } else {
         prog.SetLowerBoundCost(lower_bound);
       }

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -39,8 +39,8 @@ namespace {
 struct GurobiCallbackInformation {
   MathematicalProgram * prog;
   std::vector<bool> is_new_variable;
-  GurobiSolver::mipNodeCallbackFunction mip_node_callback;
-  GurobiSolver::mipSolCallbackFunction mip_sol_callback;
+  GurobiSolver::MipNodeCallbackFunction mip_node_callback;
+  GurobiSolver::MipSolCallbackFunction mip_sol_callback;
   void * mip_sol_callback_usrdata;
   void * mip_node_callback_usrdata;
 };

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -55,7 +55,7 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
   } else if (where == GRB_CB_SIMPLEX) {
   } else if (where == GRB_CB_MIP) {
   } else if (where == GRB_CB_MIPSOL &&
-   callbackInfo->mip_sol_callback != NULL) {
+      callbackInfo->mip_sol_callback != NULL) {
     // Extract variable values from Gurobi, and set the current
     // solution of the MathematicalProgram to these values.
     int num_total_variables = callbackInfo->is_new_variable.size();

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -139,7 +139,7 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
       Eigen::VectorXd vals;
       VectorXDecisionVariable vars;
       callbackInfo->mip_node_callback(*(callbackInfo->prog), solve_status,
-        callbackInfo->mip_node_callback_usrdata, vals, vars);
+        callbackInfo->mip_node_callback_usrdata, &vals, &vars);
 
       // The callback may return an assignment of some number of variables
       // as a new heuristic solution seed. If so, feed those back to Gurobi.

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -157,8 +157,8 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
           int k = callbackInfo->prog->FindDecisionVariableIndex(vars[i]);
           new_sol[k] = val;
         }
-        double err;
-        error = GRBcbsolution(cbdata, new_sol.data(), &err);
+        double objective_solution;
+        error = GRBcbsolution(cbdata, new_sol.data(), &objective_solution);
         if (error) {
           printf("GRB error %d in injection: %s\n", error,
             GRBgeterrormsg(GRBgetenv(model)));

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -816,7 +816,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       // Provide Gurobi's lower bound.
       double lower_bound = std::numeric_limits<double>::quiet_NaN();
       GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
-      prog.SetLowerBound(lower_bound);
+      prog.SetLowerBoundCost(lower_bound);
     }
   }
 

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -156,8 +156,6 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
         }
         double err;
         error = GRBcbsolution(cbdata, new_sol.data(), &err);
-        printf("Injected new sol with error %d, specified %ld vals\n", error,
-          vals.size());
         if (error) {
           printf("GRB error %d in injection: %s\n", error,
             GRBgeterrormsg(GRBgetenv(model)));
@@ -624,7 +622,6 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   // variables to Gurobi model.
   // The invariant is
   // EXPECT_TRUE(HasCorrectNumberOfVariables(model, is_new_variables.size()))
-  printf("Setup gurobi problem starting with %d vars\n", num_prog_vars);
   std::vector<bool> is_new_variable(num_prog_vars, false);
 
   // Bound constraints.

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -132,7 +132,8 @@ gurobi_callback(GRBmodel *model, void *cbdata, int where, void *usrdata) {
           int k = callbackInfo->prog->FindDecisionVariableIndex(vars[i]);
           new_sol[k] = val;
         }
-        error = GRBcbsolution(cbdata, new_sol.data());
+        double err;
+        error = GRBcbsolution(cbdata, new_sol.data(), &err);
         printf("Injected new sol with error %d, specified %ld vals\n", error, vals.size());
         if (error){
           printf("GRB error %d in injection: %s\n", error, GRBgeterrormsg(GRBgetenv(model)));

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -41,8 +41,8 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   // See Gurobi reference manual for more detail on callbacks:
   // https://www.gurobi.com/documentation/7.0/refman/refman.html.
   typedef void (*mipNodeCallbackFunction)(const MathematicalProgram&,
-    const SolveStatusInfo& callback_info, void *, Eigen::VectorXd&,
-    VectorXDecisionVariable&);
+    const SolveStatusInfo& callback_info, void *, Eigen::VectorXd*,
+    VectorXDecisionVariable*);
   void addMIPNodeCallback(mipNodeCallbackFunction fnc, void * usrdata) {
     mip_node_callback_ = fnc;
     mip_node_callback_usrdata_ = usrdata;

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -19,12 +19,28 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   // Gurobi was available during compilation.
   bool available() const override;
 
+  // This passes the model and model environment to a
+  // an external 
+  typedef std::pair<
+    const Eigen::Ref<const Eigen::VectorXd>&,
+    const Eigen::Ref<const VectorXDecisionVariable>&
+  > mipSolCallbackReturn;
+  typedef mipSolCallbackReturn (*mipSolCallbackFunction)(const MathematicalProgram&, void *);
+  void addMIPSolCallback(mipSolCallbackFunction fnc, void * usrdata){
+  	mip_sol_callback_ = fnc;
+  	mip_sol_callback_usrdata_ = usrdata;
+  }
+
   SolutionResult Solve(MathematicalProgram& prog) const override;
 
   SolverId solver_id() const override;
 
   /// @return same as MathematicalProgramSolverInterface::solver_id()
   static SolverId id();
+
+ private:
+  mipSolCallbackFunction mip_sol_callback_ = NULL;
+  void * mip_sol_callback_usrdata_ = NULL;
 };
 
 }  // end namespace solvers

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -21,10 +21,15 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
 
   // This passes the model and model environment to a
   // an external 
-  typedef void (*mipSolCallbackFunction)(const MathematicalProgram&, void *, Eigen::VectorXd&, VectorXDecisionVariable&);
-  void addMIPNodeCallback(mipSolCallbackFunction fnc, void * usrdata){
+  typedef void (*mipNodeCallbackFunction)(const MathematicalProgram&, void *, Eigen::VectorXd&, VectorXDecisionVariable&);
+  void addMIPNodeCallback(mipNodeCallbackFunction fnc, void * usrdata){
   	mip_node_callback_ = fnc;
   	mip_node_callback_usrdata_ = usrdata;
+  }
+  typedef void (*mipSolCallbackFunction)(const MathematicalProgram&, void *);
+  void addMIPSolCallback(mipSolCallbackFunction fnc, void * usrdata){
+  	mip_sol_callback_ = fnc;
+  	mip_sol_callback_usrdata_ = usrdata;
   }
 
   SolutionResult Solve(MathematicalProgram& prog) const override;
@@ -35,8 +40,10 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   static SolverId id();
 
  private:
-  mipSolCallbackFunction mip_node_callback_ = NULL;
+  mipNodeCallbackFunction mip_node_callback_ = NULL;
+  mipSolCallbackFunction mip_sol_callback_ = NULL;
   void * mip_node_callback_usrdata_ = NULL;
+  void * mip_sol_callback_usrdata_ = NULL;
 };
 
 }  // end namespace solvers

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -21,11 +21,7 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
 
   // This passes the model and model environment to a
   // an external 
-  typedef std::pair<
-    const Eigen::Ref<const Eigen::VectorXd>&,
-    const Eigen::Ref<const VectorXDecisionVariable>&
-  > mipSolCallbackReturn;
-  typedef mipSolCallbackReturn (*mipSolCallbackFunction)(const MathematicalProgram&, void *);
+  typedef void (*mipSolCallbackFunction)(const MathematicalProgram&, void *, Eigen::VectorXd&, VectorXDecisionVariable&);
   void addMIPSolCallback(mipSolCallbackFunction fnc, void * usrdata){
   	mip_sol_callback_ = fnc;
   	mip_sol_callback_usrdata_ = usrdata;

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -22,9 +22,9 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   // This passes the model and model environment to a
   // an external 
   typedef void (*mipSolCallbackFunction)(const MathematicalProgram&, void *, Eigen::VectorXd&, VectorXDecisionVariable&);
-  void addMIPSolCallback(mipSolCallbackFunction fnc, void * usrdata){
-  	mip_sol_callback_ = fnc;
-  	mip_sol_callback_usrdata_ = usrdata;
+  void addMIPNodeCallback(mipSolCallbackFunction fnc, void * usrdata){
+  	mip_node_callback_ = fnc;
+  	mip_node_callback_usrdata_ = usrdata;
   }
 
   SolutionResult Solve(MathematicalProgram& prog) const override;
@@ -35,8 +35,8 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   static SolverId id();
 
  private:
-  mipSolCallbackFunction mip_sol_callback_ = NULL;
-  void * mip_sol_callback_usrdata_ = NULL;
+  mipSolCallbackFunction mip_node_callback_ = NULL;
+  void * mip_node_callback_usrdata_ = NULL;
 };
 
 }  // end namespace solvers

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -44,7 +44,7 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   /// Users can supply a callback to be called when the Gurobi solver
   /// finds an intermediate solution node, which may not be feasible.
   /// See Gurobi reference manual for more detail on callbacks:
-  /// https://www.gurobi.com/documentation/7.0/refman/refman.html.
+  /// https://www.gurobi.com/documentation/7.0/refman/callback_codes.html.
   /// The user may supply a partial solution in the VectorXd and
   /// VectorXDecisionVariable arguments that will be passed to Gurobi
   /// as a candidate feasible solution.
@@ -78,7 +78,7 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   /// Users can supply a callback to be called when the Gurobi solver
   /// finds a feasible solution.
   /// See Gurobi reference manual for more detail on callbacks:
-  /// https://www.gurobi.com/documentation/7.0/refman/refman.html.
+  /// https://www.gurobi.com/documentation/7.0/refman/callback_codes.html.
   /// See gurobi_solver_test.cc for an example of using std::bind
   /// to create a callback of this signature, while allowing
   /// additional data to be passed through.

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -21,37 +21,78 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   // Gurobi was available during compilation.
   bool available() const override;
 
+  /// Contains info returned to a user function that handles
+  /// a Node or Solution callback.
+  /// @see MipNodeCallbackFunction
+  /// @see MipSolCallbackFunction
   struct SolveStatusInfo {
+      /// Runtime as of this callback.
       double reported_runtime;
+      /// Objective of current solution.
       double current_objective;
+      /// Objective of best solution yet.
       double best_objective;
+      /// Best known objective lower bound.
       double best_bound;
+      /// Number of nodes explored so far.
       int explored_node_count;
+      /// Number of feasible sols found so far.
       int feasible_solutions_count;
   };
 
-  // Users can supply a callback to be called when the Gurobi solver
-  // finds an intermediate solution node, which may not be feasible.
-  // The user may supply a partial solution in the VectorXd and
-  // VectorXDecisionVariable arguments that will be passed to Gurobi
-  // as a candidate feasible solution. In that case, the user function
-  // should assign the VectorXd& to be the values of the variable
-  // assignments, and the VectorXDecisionVariable& to be the decision
-  // variables being assigned.
-  // See Gurobi reference manual for more detail on callbacks:
-  // https://www.gurobi.com/documentation/7.0/refman/refman.html.
-  typedef void (*mipNodeCallbackFunction)(const MathematicalProgram&,
+  /// Users can supply a callback to be called when the Gurobi solver
+  /// finds an intermediate solution node, which may not be feasible.
+  /// See Gurobi reference manual for more detail on callbacks:
+  /// https://www.gurobi.com/documentation/7.0/refman/refman.html.
+  /// The user may supply a partial solution in the VectorXd and
+  /// VectorXDecisionVariable arguments that will be passed to Gurobi
+  /// as a candidate feasible solution.
+  /// @param MathematicalProgram& The optimization wrapper, whose
+  /// current variable values (accessible via
+  /// MathematicalProgram::GetSolution) will be set to the intermediate
+  /// solution values.
+  /// @param SolveStatusInfo& Intermediate solution status information values
+  /// queried from Gurobi.
+  /// @param void* Arbitrary data supplied during callback registration.
+  /// @param VectorXd* User may assign this to be the values of the variable
+  /// assignments.
+  /// @param VectorXDecisionVariable* User may assign this to be the decision
+  /// variables being assigned. Must have the same number of elements as
+  /// the VectorXd assignment.
+  typedef void (*MipNodeCallbackFunction)(const MathematicalProgram&,
     const SolveStatusInfo& callback_info, void *, Eigen::VectorXd*,
     VectorXDecisionVariable*);
-  void addMIPNodeCallback(mipNodeCallbackFunction fnc, void * usrdata) {
-    mip_node_callback_ = fnc;
-    mip_node_callback_usrdata_ = usrdata;
+
+  /// Registers a callback to be called at intermediate solutions
+  /// during the solve.
+  /// @param callback User callback function.
+  /// @param user_data Arbitrary data that will be passed to the user
+  /// callback function.
+  void AddMipNodeCallback(MipNodeCallbackFunction callback, void * user_data) {
+    mip_node_callback_ = callback;
+    mip_node_callback_usrdata_ = user_data;
   }
-  // Users can supply a callback to be called when the Gurobi solver
-  // finds a feasible solution.
-  typedef void (*mipSolCallbackFunction)(const MathematicalProgram&,
+
+  /// Users can supply a callback to be called when the Gurobi solver
+  /// finds a feasible solution.
+  /// See Gurobi reference manual for more detail on callbacks:
+  /// https://www.gurobi.com/documentation/7.0/refman/refman.html.
+  /// @param MathematicalProgram& The optimization wrapper, whose
+  /// current variable values (accessible via
+  /// MathematicalProgram::GetSolution) will be set to the intermediate
+  /// solution values.
+  /// @param SolveStatusInfo& Intermediate solution status information values
+  /// queried from Gurobi.
+  /// @param void* Arbitrary data supplied during callback registration.
+  typedef void (*MipSolCallbackFunction)(const MathematicalProgram&,
     const SolveStatusInfo& callback_info, void *);
-  void addMIPSolCallback(mipSolCallbackFunction fnc, void * usrdata) {
+
+  /// Registers a callback to be called at feasible solutions
+  /// during the solve.
+  /// @param fnc User callback function.
+  /// @param usrdata Arbitrary data that will be passed to the user
+  /// callback function.
+  void AddMipSolCallback(MipSolCallbackFunction fnc, void * usrdata) {
     mip_sol_callback_ = fnc;
     mip_sol_callback_usrdata_ = usrdata;
   }
@@ -66,10 +107,10 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
  private:
   // Callbacks and generic user data to pass through,
   // or NULL if no callback has been supplied.
-  mipNodeCallbackFunction mip_node_callback_ = NULL;
-  mipSolCallbackFunction mip_sol_callback_ = NULL;
-  void * mip_node_callback_usrdata_ = NULL;
-  void * mip_sol_callback_usrdata_ = NULL;
+  MipNodeCallbackFunction mip_node_callback_ = nullptr;
+  MipSolCallbackFunction mip_sol_callback_ = nullptr;
+  void * mip_node_callback_usrdata_ = nullptr;
+  void * mip_sol_callback_usrdata_ = nullptr;
 };
 
 }  // end namespace solvers

--- a/drake/solvers/gurobi_solver.h
+++ b/drake/solvers/gurobi_solver.h
@@ -27,18 +27,18 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   /// @see MipNodeCallbackFunction
   /// @see MipSolCallbackFunction
   struct SolveStatusInfo {
-      /// Runtime as of this callback.
-      double reported_runtime;
-      /// Objective of current solution.
-      double current_objective;
-      /// Objective of best solution yet.
-      double best_objective;
-      /// Best known objective lower bound.
-      double best_bound;
-      /// Number of nodes explored so far.
-      int explored_node_count;
-      /// Number of feasible sols found so far.
-      int feasible_solutions_count;
+    /// Runtime as of this callback.
+    double reported_runtime{};
+    /// Objective of current solution.
+    double current_objective{};
+    /// Objective of best solution yet.
+    double best_objective{};
+    /// Best known objective lower bound.
+    double best_bound{};
+    /// Number of nodes explored so far.
+    int explored_node_count{};
+    /// Number of feasible sols found so far.
+    int feasible_solutions_count{};
   };
 
   /// Users can supply a callback to be called when the Gurobi solver
@@ -63,8 +63,9 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   /// variables being assigned. Must have the same number of elements as
   /// the VectorXd assignment.
   typedef std::function<void(const MathematicalProgram&,
-    const SolveStatusInfo& callback_info, Eigen::VectorXd*,
-    VectorXDecisionVariable*)> MipNodeCallbackFunction;
+                             const SolveStatusInfo& callback_info,
+                             Eigen::VectorXd*, VectorXDecisionVariable*)>
+      MipNodeCallbackFunction;
 
   /// Registers a callback to be called at intermediate solutions
   /// during the solve.
@@ -90,15 +91,16 @@ class GurobiSolver : public MathematicalProgramSolverInterface {
   /// queried from Gurobi.
   /// @param void* Arbitrary data supplied during callback registration.
   typedef std::function<void(const MathematicalProgram&,
-    const SolveStatusInfo& callback_info)> MipSolCallbackFunction;
+                             const SolveStatusInfo& callback_info)>
+      MipSolCallbackFunction;
 
   /// Registers a callback to be called at feasible solutions
   /// during the solve.
-  /// @param fnc User callback function.
+  /// @param callback User callback function.
   /// @param usrdata Arbitrary data that will be passed to the user
   /// callback function.
-  void AddMipSolCallback(const MipSolCallbackFunction& fnc) {
-    mip_sol_callback_ = fnc;
+  void AddMipSolCallback(const MipSolCallbackFunction& callback) {
+    mip_sol_callback_ = callback;
   }
 
   SolutionResult Solve(MathematicalProgram& prog) const override;

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -108,6 +108,7 @@ MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(
           static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
       optimal_cost_(numeric_limits<double>::quiet_NaN()),
+      lower_bound_(-numeric_limits<double>::infinity()),
       required_capabilities_(kNoCapabilities),
       ipopt_solver_(new IpoptSolver()),
       nlopt_solver_(new NloptSolver()),

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -108,7 +108,7 @@ MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(
           static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
       optimal_cost_(numeric_limits<double>::quiet_NaN()),
-      lower_bound_(-numeric_limits<double>::infinity()),
+      lower_bound_cost_(-numeric_limits<double>::infinity()),
       required_capabilities_(kNoCapabilities),
       ipopt_solver_(new IpoptSolver()),
       nlopt_solver_(new NloptSolver()),

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2046,6 +2046,13 @@ class MathematicalProgram {
   void SetOptimalCost(double optimal_cost) { optimal_cost_ = optimal_cost; }
 
   /**
+   * Getter and setter for lower bound on optical cost. Will return NaN
+   * if this has not been discovered.
+   */
+  double GetLowerBound() const { return lower_bound_; }
+  void SetLowerBound(double lower_bound) { lower_bound_ = lower_bound; }
+
+  /**
    * Getter for all generic costs.
    */
   const std::vector<Binding<Cost>>& generic_costs() const {
@@ -2307,6 +2314,7 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   optional<SolverId> solver_id_;
   double optimal_cost_{};
+  double lower_bound_{};
   std::map<SolverId, std::map<std::string, double>> solver_options_double_;
   std::map<SolverId, std::map<std::string, int>> solver_options_int_;
   std::map<SolverId, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2049,11 +2049,13 @@ class MathematicalProgram {
    * Getter for lower bound on optimal cost. Defaults to -Infinity
    * if a lower bound has not been found.
    */
-  double GetLowerBound() const { return lower_bound_; }
+  double GetLowerBoundCost() const { return lower_bound_cost_; }
   /**
    * Setter for lower bound on optimal cost.
    */
-  void SetLowerBound(double lower_bound) { lower_bound_ = lower_bound; }
+  void SetLowerBoundCost(double lower_bound_cost) {
+    lower_bound_cost_ = lower_bound_cost;
+  }
 
   /**
    * Getter for all generic costs.
@@ -2317,7 +2319,7 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   optional<SolverId> solver_id_;
   double optimal_cost_{};
-  double lower_bound_{};
+  double lower_bound_cost_{};
   std::map<SolverId, std::map<std::string, double>> solver_options_double_;
   std::map<SolverId, std::map<std::string, int>> solver_options_int_;
   std::map<SolverId, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2046,10 +2046,13 @@ class MathematicalProgram {
   void SetOptimalCost(double optimal_cost) { optimal_cost_ = optimal_cost; }
 
   /**
-   * Getter and setter for lower bound on optical cost. Will return NaN
-   * if this has not been discovered.
+   * Getter for lower bound on optimal cost. Defaults to -Infinity
+   * if a lower bound has not been found.
    */
   double GetLowerBound() const { return lower_bound_; }
+  /**
+   * Setter for lower bound on optimal cost.
+   */
   void SetLowerBound(double lower_bound) { lower_bound_ = lower_bound; }
 
   /**

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -138,9 +138,9 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
     // Constraint such that x_0 and x_1 can't both be
     // 1, but leave a feasible vertex at (0.75, 0.75)
     // that is optimal in the continuous relaxation.
-    prog.AddLinearConstraint(x[2] <= 1. - 0.5*x[3]);
-    prog.AddLinearConstraint(x[3] <= 1. - 0.5*x[2]);
-    prog.AddLinearCost(-x[2] - x[3]);
+    prog.AddLinearConstraint(x[0] <= 1. - 0.5*x[1]);
+    prog.AddLinearConstraint(x[1] <= 1. - 0.5*x[0]);
+    prog.AddLinearCost(-x[0] - x[1]);
 
     // Each of these options would short-circuit the solver
     // from entering a full solve and generating both

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -102,6 +102,89 @@ GTEST_TEST(GurobiTest, TestInitialGuess) {
     }
   }
 }
+
+namespace TestCallbacks {
+
+struct TestCallbackInfo {
+  Eigen::VectorXd x_vals;
+  VectorXDecisionVariable x_vars;
+  bool mipSolCallbackCalled = false;
+  bool mipNodeCallbackCalled = false;
+};
+
+void mipSolCallbackFunction(const MathematicalProgram& prog,
+  const drake::solvers::GurobiSolver::SolveStatusInfo& solve_info,
+  void * usrdata){
+  TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
+  cb_info->mipSolCallbackCalled = true;
+}
+void mipNodeCallbackFunction(const MathematicalProgram& prog,
+  const GurobiSolver::SolveStatusInfo& solve_info,
+  void * usrdata, Eigen::VectorXd& vals, VectorXDecisionVariable& vars){
+  TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
+  cb_info->mipNodeCallbackCalled = true;
+  vals = cb_info->x_vals;
+  vars = cb_info->x_vars;
+}
+
+GTEST_TEST(GurobiTest, TestCallbacks) {
+  GurobiSolver solver;
+  if (solver.available()) {
+    // Formulate a problem with multiple feasible
+    // solutions and multiple clear optimal solutions.
+    MathematicalProgram prog;
+    auto x = prog.NewBinaryVariables<4>("x");
+
+    // Constraint such that x_0 and x_1 can't both be
+    // 1, but leave a feasible vertex at (0.75, 0.75)
+    // that is optimal in the continuous relaxation.
+    prog.AddLinearConstraint( x[1] <= 1. - 0.5*x[0] );
+    prog.AddLinearConstraint( x[0] <= 1. - 0.5*x[1] );
+    prog.AddLinearCost( -x[0] - x[1]);
+
+    // Each of these options would short-circuit the solver
+    // from entering a full solve and generating both
+    // feasible solution callbacks (mipSol) and intermediate
+    // node callbacks (mipNode).
+    // Prevents the problem from being simplified, making the
+    // solution potentially trivial:
+    prog.SetSolverOption(GurobiSolver::id(), "Presolve", 0);
+    // Prevents the optimal solution from being generated without
+    // doing a full solve:
+    prog.SetSolverOption(GurobiSolver::id(), "Heuristics", 0.0);
+    // Similarly, prevents trivialization of the problem via
+    // clever new cuts:
+    prog.SetSolverOption(GurobiSolver::id(), "Cuts", 0);
+    // Prevents the root node from finding the optimal feasible
+    // solution via simplex, by switching to a barrier method:
+    prog.SetSolverOption(GurobiSolver::id(), "NodeMethod", 2);
+
+    // Force us to start at a known-suboptimal sol.
+    Eigen::VectorXd x_init(4);
+    x_init << 0.0, 0.0, 0.0, 0.0;
+    prog.SetInitialGuess(x, x_init);
+
+    // Expect, and inject, a different sol that we know is
+    // one of the (several) optimal sols.
+    Eigen::VectorXd x_expected(4);
+    x_expected << 1.0, 0.0, 0.0, 1.0;
+    TestCallbackInfo cb_info;
+    cb_info.x_vals = x_expected;
+    cb_info.x_vars = x;
+    solver.addMIPNodeCallback(mipNodeCallbackFunction, &cb_info);
+    solver.addMIPSolCallback(mipSolCallbackFunction, &cb_info);
+
+    SolutionResult result = solver.Solve(prog);
+    EXPECT_EQ(result, SolutionResult::kSolutionFound);
+    const auto& x_value = prog.GetSolution(x);
+    EXPECT_TRUE(CompareMatrices(x_value, x_expected, 1E-6,
+                                MatrixCompareType::absolute));
+    ExpectSolutionCostAccurate(prog, 1E-6);
+    EXPECT_TRUE(cb_info.mipSolCallbackCalled);
+    EXPECT_TRUE(cb_info.mipNodeCallbackCalled);
+  }
+}
+}  // namespace TestCallbacks
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -112,13 +112,13 @@ struct TestCallbackInfo {
   bool mipNodeCallbackCalled = false;
 };
 
-void mipSolCallbackFunction(const MathematicalProgram& prog,
+void MipSolCallbackFunction(const MathematicalProgram& prog,
   const drake::solvers::GurobiSolver::SolveStatusInfo& solve_info,
   void * usrdata) {
   TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
   cb_info->mipSolCallbackCalled = true;
 }
-void mipNodeCallbackFunction(const MathematicalProgram& prog,
+void MipNodeCallbackFunction(const MathematicalProgram& prog,
   const GurobiSolver::SolveStatusInfo& solve_info,
   void * usrdata, Eigen::VectorXd * vals, VectorXDecisionVariable * vars) {
   TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
@@ -171,8 +171,8 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
     TestCallbackInfo cb_info;
     cb_info.x_vals = x_expected;
     cb_info.x_vars = x;
-    solver.addMIPNodeCallback(mipNodeCallbackFunction, &cb_info);
-    solver.addMIPSolCallback(mipSolCallbackFunction, &cb_info);
+    solver.AddMipNodeCallback(MipNodeCallbackFunction, &cb_info);
+    solver.AddMipSolCallback(MipSolCallbackFunction, &cb_info);
 
     SolutionResult result = solver.Solve(prog);
     EXPECT_EQ(result, SolutionResult::kSolutionFound);

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -114,17 +114,17 @@ struct TestCallbackInfo {
 
 void mipSolCallbackFunction(const MathematicalProgram& prog,
   const drake::solvers::GurobiSolver::SolveStatusInfo& solve_info,
-  void * usrdata){
+  void * usrdata) {
   TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
   cb_info->mipSolCallbackCalled = true;
 }
 void mipNodeCallbackFunction(const MathematicalProgram& prog,
   const GurobiSolver::SolveStatusInfo& solve_info,
-  void * usrdata, Eigen::VectorXd& vals, VectorXDecisionVariable& vars){
+  void * usrdata, Eigen::VectorXd * vals, VectorXDecisionVariable * vars) {
   TestCallbackInfo * cb_info = reinterpret_cast<TestCallbackInfo *>(usrdata);
   cb_info->mipNodeCallbackCalled = true;
-  vals = cb_info->x_vals;
-  vars = cb_info->x_vars;
+  *vals = cb_info->x_vals;
+  *vars = cb_info->x_vars;
 }
 
 GTEST_TEST(GurobiTest, TestCallbacks) {
@@ -138,9 +138,9 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
     // Constraint such that x_0 and x_1 can't both be
     // 1, but leave a feasible vertex at (0.75, 0.75)
     // that is optimal in the continuous relaxation.
-    prog.AddLinearConstraint( x[1] <= 1. - 0.5*x[0] );
-    prog.AddLinearConstraint( x[0] <= 1. - 0.5*x[1] );
-    prog.AddLinearCost( -x[0] - x[1]);
+    prog.AddLinearConstraint(x[1] <= 1. - 0.5*x[0]);
+    prog.AddLinearConstraint(x[0] <= 1. - 0.5*x[1]);
+    prog.AddLinearCost(-x[0] - x[1]);
 
     // Each of these options would short-circuit the solver
     // from entering a full solve and generating both

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -137,7 +137,7 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
     auto x = prog.NewBinaryVariables<4>("x");
 
     // Constraint such that x_0 and x_1 can't both be
-    // 1, but leave a feasible vertex at (0.75, 0.75)
+    // 1, but leave a feasible vertex at (2/3, 2/3)
     // that is optimal in the continuous relaxation.
     prog.AddLinearConstraint(x[0] <= 1. - 0.5*x[1]);
     prog.AddLinearConstraint(x[1] <= 1. - 0.5*x[0]);

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -138,9 +138,9 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
     // Constraint such that x_0 and x_1 can't both be
     // 1, but leave a feasible vertex at (0.75, 0.75)
     // that is optimal in the continuous relaxation.
-    prog.AddLinearConstraint(x[1] <= 1. - 0.5*x[0]);
-    prog.AddLinearConstraint(x[0] <= 1. - 0.5*x[1]);
-    prog.AddLinearCost(-x[0] - x[1]);
+    prog.AddLinearConstraint(x[2] <= 1. - 0.5*x[3]);
+    prog.AddLinearConstraint(x[3] <= 1. - 0.5*x[2]);
+    prog.AddLinearCost(-x[2] - x[3]);
 
     // Each of these options would short-circuit the solver
     // from entering a full solve and generating both

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -105,8 +105,6 @@ GTEST_TEST(GurobiTest, TestInitialGuess) {
 
 namespace TestCallbacks {
 
-using namespace std::placeholders;
-
 struct TestCallbackInfo {
   Eigen::VectorXd x_vals;
   VectorXDecisionVariable x_vars;
@@ -179,9 +177,17 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
       cb_info.x_vals = x_expected;
       cb_info.x_vars = x;
       GurobiSolver::MipNodeCallbackFunction MipNodeCallbackFunctionWrapper =
-        std::bind(MipNodeCallbackFunctionTest, _1, _2, _3, _4, &cb_info);
+        std::bind(MipNodeCallbackFunctionTest,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          std::placeholders::_3,
+          std::placeholders::_4,
+          &cb_info);
       GurobiSolver::MipSolCallbackFunction MipSolCallbackFunctionWrapper =
-        std::bind(MipSolCallbackFunctionTest, _1, _2, &cb_info);
+        std::bind(MipSolCallbackFunctionTest,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          &cb_info);
       solver.AddMipNodeCallback(MipNodeCallbackFunctionWrapper);
       solver.AddMipSolCallback(MipSolCallbackFunctionWrapper);
 


### PR DESCRIPTION
Adds ability to register callbacks with the Gurobi interface to allow users to get intermediate info about MIP solves. Supports MIPNode (intermediate solutions, possibly infeasible) and MIPSol (new incumbent) callbacks; see [Gurobi Callback codes](https://www.gurobi.com/documentation/7.0/refman/callback_codes.html#sec:CallbackCodes). The callback uses the MathematicalProgram that is doing the solve to store the intermediate solution being considered by Gurobi.

+@hongkai-dai for feature review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6555)
<!-- Reviewable:end -->
