### PR TITLE
Adding a Few UBSan Suppressions

### DIFF
--- a/tools/ubsan.supp
+++ b/tools/ubsan.supp
@@ -1,1 +1,10 @@
+# overflow in bullet's gethash function, issue filed:
+# https://github.com/bulletphysics/bullet3/issues/1228
+signed-integer-overflow:BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
+shift-base:BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
 
+# undefined behaviour in bits/stl_tree.h
+# https://bugs.chromium.org/p/chromium/issues/detail?id=532101
+# http://llvm.org/viewvc/llvm-project/llvm/trunk/utils/sanitizers/ubsan_blacklist.txt?view=markup&pathrev=291918
+alignment:bits/stl_tree.h
+alignment:bits/stl_pair.h


### PR DESCRIPTION
[inverse_dynamics_test](https://drake-cdash.csail.mit.edu/viewDynamicAnalysisFile.php?id=140897) contains errors due to stl_tree, stl_pair and bullet.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6562)
<!-- Reviewable:end -->
