### PR TITLE
RNDF Utility functions to work with Bezier, Splines and PChip curves.

### DIFF
--- a/drake/automotive/maliput/rndf/BUILD
+++ b/drake/automotive/maliput/rndf/BUILD
@@ -34,6 +34,7 @@ drake_cc_library(
     deps = [
         "//drake/automotive/maliput/api",
         "//drake/common",
+        "//drake/common/trajectories:piecewise_polynomial",
         "//drake/math:geometric_transform",
         "//drake/math:saturate",
         "@ignition_math",

--- a/drake/automotive/maliput/rndf/spline_helpers.cc
+++ b/drake/automotive/maliput/rndf/spline_helpers.cc
@@ -4,8 +4,13 @@
 #include <limits>
 #include <utility>
 
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Vector4.hh>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
 
 namespace drake {
 namespace maliput {
@@ -20,6 +25,20 @@ namespace rndf {
 // and / or kFunctionPartitionTreeMaxDepth.
 static const int kFunctionPartitionTreeDegree = 10;
 static const int kFunctionPartitionTreeMaxDepth = 10;
+
+// A Cubic Bezier coefficient matrix.
+static constexpr double kBezierMatrix[16] = {
+    1.0, 0.0, 0.0, 0.0,
+    -3.0, 3.0, 0.0, 0.0,
+    3.0, -6.0, 3.0, 0.0,
+    -1.0, 3.0, -3.0, 1.0};
+
+// A Hermite Spline coefficient matrix.
+static constexpr double kHermiteMatrix[16] = {
+    1.0, 0.0, 0.0, 0.0,
+    0.0, 1.0, 0.0, 0.0,
+    -3.0, -2.0, 3.0, -1.0,
+    2.0, 1.0, -2.0, 1.0};
 
 InverseFunctionInterpolator::InverseFunctionInterpolator(
     std::function<double(double)> function, double xmin, double xmax,
@@ -198,6 +217,206 @@ double ArcLengthParameterizedSpline::FindClosestPointTo(
   }
 
   return closest_s;
+}
+
+namespace {
+
+// @returns An ignition::math::Matrix4d object with kBezierMatrix coefficients.
+ignition::math::Matrix4d BezierBasis() {
+  return ignition::math::Matrix4d(
+      kBezierMatrix[0], kBezierMatrix[1], kBezierMatrix[2], kBezierMatrix[3],
+      kBezierMatrix[4], kBezierMatrix[5], kBezierMatrix[6], kBezierMatrix[7],
+      kBezierMatrix[8], kBezierMatrix[9], kBezierMatrix[10], kBezierMatrix[11],
+      kBezierMatrix[12], kBezierMatrix[13], kBezierMatrix[14],
+      kBezierMatrix[15]);
+}
+
+// @returns An ignition::math::Matrix4d object with kHermiteMatrix coefficients.
+ignition::math::Matrix4d HermiteBasis() {
+  return ignition::math::Matrix4d(
+      kHermiteMatrix[0], kHermiteMatrix[1], kHermiteMatrix[2],
+      kHermiteMatrix[3], kHermiteMatrix[4], kHermiteMatrix[5],
+      kHermiteMatrix[6], kHermiteMatrix[7], kHermiteMatrix[8],
+      kHermiteMatrix[9], kHermiteMatrix[10], kHermiteMatrix[11],
+      kHermiteMatrix[12], kHermiteMatrix[13], kHermiteMatrix[14],
+      kHermiteMatrix[15]);
+}
+
+}  // namespace
+
+std::vector<ignition::math::Vector3d> SplineToBezier(
+    const ignition::math::Vector3d& p0, const ignition::math::Vector3d& t0,
+    const ignition::math::Vector3d& p1, const ignition::math::Vector3d& t1) {
+  // These are the control points arranged by coordinate.
+  const ignition::math::Matrix4d hermite_points(
+      p0.X(), p0.Y(), p0.Z(), 0.0, t0.X(), t0.Y(), t0.Z(), 0.0, p1.X(), p1.Y(),
+      p1.Z(), 0.0, t1.X(), t1.Y(), t1.Z(), 0.0);
+  // Given a function F_B(t): ℝ --> ℝ^3 that represents a cubic Bezier curve,
+  // and F_H(t) : ℝ --> ℝ^3 that represents a cubic Hermite Spline curve, we can
+  // define them like:
+  // F_B(t) = [1 t t^2 t^3] * [kBezierMatrix] * [bezier_points]
+  // F_H(t) = [1 t t^2 t^3] * [kHermiteMatrix] * [hermite_points]
+  // If both functions have the same image: F_B(t) = F_H(t), we can say:
+  // [bezier_points] =
+  //     [kBezierMatrix]^(-1) * [kHermiteMatrix] * [hermite_points]
+  // [hermite_points] =
+  //     [kHermiteMatrix]^(-1) * [kBezierMatrix] * [bezier_points]
+  const ignition::math::Matrix4d bezier_points =
+      BezierBasis().Inverse() * HermiteBasis() * hermite_points;
+  std::vector<ignition::math::Vector3d> result;
+  result.push_back(ignition::math::Vector3d(
+      bezier_points(0, 0), bezier_points(0, 1), bezier_points(0, 2)));
+  result.push_back(ignition::math::Vector3d(
+      bezier_points(1, 0), bezier_points(1, 1), bezier_points(1, 2)));
+  result.push_back(ignition::math::Vector3d(
+      bezier_points(2, 0), bezier_points(2, 1), bezier_points(2, 2)));
+  result.push_back(ignition::math::Vector3d(
+      bezier_points(3, 0), bezier_points(3, 1), bezier_points(3, 2)));
+  return result;
+}
+
+std::vector<ignition::math::Vector3d> BezierToSpline(
+    const ignition::math::Vector3d& p0, const ignition::math::Vector3d& p1,
+    const ignition::math::Vector3d& p2, const ignition::math::Vector3d& p3) {
+  // These are the control points arranged by coordinate.
+  const ignition::math::Matrix4d bezier_points(
+      p0.X(), p0.Y(), p0.Z(), 0.0, p1.X(), p1.Y(), p1.Z(), 0.0, p2.X(), p2.Y(),
+      p2.Z(), 0.0, p3.X(), p3.Y(), p3.Z(), 0.0);
+  // Given a function F_B(t): ℝ --> ℝ^3 that represents a cubic Bezier curve,
+  // and F_H(t) : ℝ --> ℝ^3 that represents a cubic Hermite Spline curve, we can
+  // define them like:
+  // F_B(t) = [1 t t^2 t^3] * [kBezierMatrix] * [bezier_points]
+  // F_H(t) = [1 t t^2 t^3] * [kHermiteMatrix] * [hermite_points]
+  // If both functions have the same image: F_B(t) = F_H(t), we can say:
+  // [bezier_points] =
+  //     [kBezierMatrix]^(-1) * [kHermiteMatrix] * [hermite_points]
+  // [hermite_points] =
+  //     [kHermiteMatrix]^(-1) * [kBezierMatrix] * [bezier_points]
+  const ignition::math::Matrix4d hermite_points =
+      HermiteBasis().Inverse() * BezierBasis() * bezier_points;
+  std::vector<ignition::math::Vector3d> result;
+  result.push_back(ignition::math::Vector3d(
+      hermite_points(0, 0), hermite_points(0, 1), hermite_points(0, 2)));
+  result.push_back(ignition::math::Vector3d(
+      hermite_points(1, 0), hermite_points(1, 1), hermite_points(1, 2)));
+  result.push_back(ignition::math::Vector3d(
+      hermite_points(2, 0), hermite_points(2, 1), hermite_points(2, 2)));
+  result.push_back(ignition::math::Vector3d(
+      hermite_points(3, 0), hermite_points(3, 1), hermite_points(3, 2)));
+  return result;
+}
+
+std::vector<ignition::math::Vector3d> MakeBezierCurveMonotonic(
+    const std::vector<ignition::math::Vector3d>& control_points,
+    double scale = 1.0) {
+  DRAKE_THROW_UNLESS(control_points.size() == 4);
+  DRAKE_THROW_UNLESS(scale <= 1.0);
+  DRAKE_THROW_UNLESS(scale >= 0.0);
+  // Sets a constant to compare cross product results near zero.
+  const double kAlmostZero = 1e-3;
+  // References to control points for better code readability.
+  const ignition::math::Vector3d& p0 = control_points[0];
+  const ignition::math::Vector3d& p1 = control_points[1];
+  const ignition::math::Vector3d& p2 = control_points[2];
+  const ignition::math::Vector3d& p3 = control_points[3];
+
+  // Computes normalized tangents at the beginning and the ending.
+  const ignition::math::Vector3d norm_t0 = (p1 - p0).Normalize();
+  const ignition::math::Vector3d norm_t3 = (p3 - p2).Normalize();
+  // Computes a vector that joins curve's endings.
+  const ignition::math::Vector3d r = p3 - p0;
+  // Computes cross products to determine if the lines will intersect or not.
+  const ignition::math::Vector3d norm_t3_x_r = norm_t3.Cross(r);
+  const ignition::math::Vector3d norm_t3_x_norm_t0 = norm_t3.Cross(norm_t0);
+
+  std::vector<ignition::math::Vector3d> result;
+  if (norm_t3_x_r.Length() < kAlmostZero ||
+      norm_t3_x_norm_t0.Length() < kAlmostZero) {
+    // Lines are not coplanar or are parallel so they will not intersect. As
+    // RNDF does not support any other z coordinate different from 0.0, it is
+    // assumed that lines are coplanar and parallel. Consequently, control
+    // points for the resulting Bezier curve are adjusted to match a smooth
+    // S-shaped transition.
+    const double r_dot_norm_t0 = norm_t0.Dot(r);
+    result.push_back(p0);
+    result.push_back(p0 + (0.5 * r_dot_norm_t0) * norm_t0);
+    result.push_back(p3 + (-0.5 * r_dot_norm_t0) * norm_t3);
+    result.push_back(p3);
+    return result;
+  }
+  // Computes the vector to move from p0 towards the control point.
+  const ignition::math::Vector3d l =
+      (norm_t3_x_r.Length() / norm_t3_x_norm_t0.Length()) * norm_t0;
+  // Checks the addition or subtraction of l to get the critical point.
+  double projection = norm_t3_x_r.Dot(norm_t3_x_norm_t0);
+  ignition::math::Vector3d critical_point;
+  if (projection >= kAlmostZero) {
+    critical_point = p0 + l;
+  } else {
+    critical_point = p0 - l;
+  }
+
+  // Computes if the resulting Bezier curve will preserve convexity.
+  const ignition::math::Vector3d diff_to_p0 = (critical_point - p0);
+  const ignition::math::Vector3d diff_to_p3 = (p3 - critical_point);
+  // In case the curve should not preserve convexity (first two conditions),
+  // intermediate control points will be set to produce the desired geometry.
+  if (diff_to_p3.Normalized().Dot(norm_t3) < kAlmostZero) {
+    result.push_back(p0);
+    result.push_back(p0 + scale * (critical_point - p0));
+    result.push_back(p3 + (-scale) * (critical_point - p3));
+    result.push_back(p3);
+  } else if (diff_to_p0.Normalized().Dot(norm_t0) < kAlmostZero) {
+    result.push_back(p0);
+    result.push_back(p0 + (-scale) * (critical_point - p0));
+    result.push_back(p3 + scale * (critical_point - p3));
+    result.push_back(p3);
+  } else {
+    result.push_back(p0);
+    result.push_back(p0 + scale * (critical_point - p0));
+    result.push_back(p3 + scale * (critical_point - p3));
+    result.push_back(p3);
+  }
+  return result;
+}
+
+std::unique_ptr<ignition::math::Spline> CreatePChipBasedSpline(
+    const std::vector<ignition::math::Vector3d>& positions) {
+  // Checks if the size of the vector is OK.
+  DRAKE_THROW_UNLESS(positions.size() > 2);
+  // Adds the knots and breaks.
+  std::vector<double> breaks;
+  std::vector<MatrixX<double>> knots(positions.size(),
+                                     MatrixX<double>::Zero(3, 1));
+  for (int i = 0; i < static_cast<int>(positions.size()); i++) {
+    knots[i] << positions[i].X(), positions[i].Y(), 0.0;
+    if (i == 0) {
+      breaks.push_back(0.0);
+    } else {
+      const double length = (positions[i] - positions[i - 1]).Length();
+      // TODO(@agalabachicar) We don't support yet duplicate waypoints in the
+      // same lane which are continuous and share the same location.
+      // See issue https://bitbucket.org/ekumen/terminus-simulation/issues/171.
+      DRAKE_THROW_UNLESS(length > 0.0);
+      breaks.push_back(length + breaks.back());
+    }
+  }
+  // Creates the PChip curve and its first derivative so interpolation of
+  // tangents at the knots is possible.
+  const PiecewisePolynomial<double> polynomial =
+      PiecewisePolynomial<double>::Pchip(breaks, knots, false);
+  const PiecewisePolynomial<double> derivated_polynomial =
+      polynomial.derivative(1);
+  // Creates a spline and adds PChip's tangents.
+  std::unique_ptr<ignition::math::Spline> spline =
+      std::make_unique<ignition::math::Spline>();
+  spline->AutoCalculate(true);
+  for (int i = 0; i < static_cast<int>(positions.size()); i++) {
+    const Vector3<double> tangent = derivated_polynomial.value(breaks[i]);
+    spline->AddPoint(positions[i],
+                     ignition::math::Vector3d(tangent.x(), tangent.y(), 0.0));
+  }
+  return spline;
 }
 
 }  // namespace rndf

--- a/drake/automotive/maliput/rndf/spline_helpers.h
+++ b/drake/automotive/maliput/rndf/spline_helpers.h
@@ -109,7 +109,8 @@ class ArcLengthParameterizedSpline {
   /// interpolation is done, any derivative order greater than 3 will be zero.
   /// @param[in] s path length to interpolate at, constrained
   /// by the curve dimensions [0, path_length].
-  /// @return the @p derivative_order derivative @f$ Q^{(derivative_order)}(s) .
+  /// @return the @p derivative_order derivative
+  ///         @f$ Q^{(derivative_order)}(s) @f$.
   /// @throws std::runtime_error If @p derivative_order is a negative integer.
   ignition::math::Vector3d InterpolateMthDerivative(int derivative_order,
                                                     double s);
@@ -140,6 +141,87 @@ class ArcLengthParameterizedSpline {
   std::unique_ptr<InverseFunctionInterpolator>
       F_ts_;  //< Inverse path length function t(s).
 };
+
+/// Provides the equivalent set of points in cubic Bezier base from two pairs
+/// of points and tangents at the extents of a spline.
+/// @param p0 A vector that describes the starting position of the curve.
+/// @param t0 A vector that describes the tangent at @p p0.
+/// @param p1 A vector that describes the ending position of the curve.
+/// @param t1 A vector that describes the tangent at @p p1.
+/// @return A vector containing four Bezier control points. The first and last
+/// points are the extent points of the Bezier curve and the other two are the
+/// tangent controlling waypoints.
+std::vector<ignition::math::Vector3d> SplineToBezier(
+    const ignition::math::Vector3d& p0, const ignition::math::Vector3d& t0,
+    const ignition::math::Vector3d& p1, const ignition::math::Vector3d& t1);
+
+/// Provides the equivalent set of points in cubic spline base from four cubic
+/// Bezier control points.
+/// @param p0 A vector that describes the starting position of the curve.
+/// @param p1 A vector that describes the first control point of the curve.
+/// @param p2 A vector that describes the second control point of the curve.
+/// @param p3 A vector that describes the last control point of the curve.
+/// @return A vector containing four spline control points. The points are
+/// returned in the following order:
+/// 1. index 0 --> curve position at the beginning.
+/// 2. index 1 --> curve tangent at the beginning.
+/// 3. index 2 --> curve position at the ending.
+/// 4. index 3 --> curve tangent at the ending.
+std::vector<ignition::math::Vector3d> BezierToSpline(
+    const ignition::math::Vector3d& p0, const ignition::math::Vector3d& p1,
+    const ignition::math::Vector3d& p2, const ignition::math::Vector3d& p3);
+
+/// Provides a conditionally convex and monotonic Bezier curve given a vector of
+/// control points @p control_points.
+/// First it computes the intersection of the lines represented by point and
+/// tangent at the beginning and at the end of the curve. From here we have a
+/// a first branch in the behavior, if there is no intersection, we assume that
+/// all these curves are 2-D curves over the z = 0.0 api::GeoPosition frame.
+/// Then, we create two intermediate control points for them that will provide a
+/// S shape to match the curve. The change in convexity is set to be in the mid
+/// point of the extents of the curve. In case there is an intersection between
+/// the two lines, we find it and this will be the critical point. From this
+/// step, there are two types of geometries we can generate but for both, the
+/// control points at the extents remain the same. For those control points in
+/// between we use the following equations to compute them:
+///
+/// @p control_points[1] = @p control_points[0] +
+///                        (±1.0) * @p scale * (critical_point -
+///                                             control_points[0])
+/// @p control_points[2] = @p control_points[3] +
+///                        (∓1.0) * @p scale * (critical_point -
+///                                             control_points[3])
+///
+/// When the curve preserves convexity, @p scale is multiplied by (+1.0) in both
+/// cases. However, when it is not, opposite signs are used.
+/// @param control_points A vector containing four Bezier control points. The
+/// first and last points are the extent points of the Bezier curve and the
+/// other two are the tangent controlling waypoints.
+/// @param scale A scale factor with a range value between 0.0 and 1.0.
+/// @return A vector containing four Bezier control points. The first and last
+/// points are the extent points of the Bezier curve and the other two are the
+/// tangent controlling waypoints.
+/// @throws std::runtime_error When the size of @p control_points is different
+/// from 4.
+/// @throws std::runtime_error When @p scale is bigger than 1.0.
+/// @throws std::runtime_error When @p scale is smaller than 0.0.
+std::vector<ignition::math::Vector3d> MakeBezierCurveMonotonic(
+    const std::vector<ignition::math::Vector3d>& control_points, double scale);
+
+/// Creates a ignition::math::Spline from a set of @p positions. These positions
+/// are the control points where the curve must go through. The final curve is
+/// based from a PChip algorithm, which makes the interpolation safe in terms of
+/// piecewise convexity and monotonicity.
+/// @param positions A vector of position where the spline should go through. It
+/// should have more than two points. In addition, two consecutive points that
+/// have a length of zero will throw an exception since it's not yet supported.
+/// @return A ignition's Spline containing as knots the positions vector and as
+/// tangent's the PChip's interpolated value.
+/// @throws std::runtime_error When positions' size is less than three.
+/// @throws std::runtime_error When two consecutive @p positions' items have a
+/// distance of zero.
+std::unique_ptr<ignition::math::Spline> CreatePChipBasedSpline(
+    const std::vector<ignition::math::Vector3d>& positions);
 
 }  // namespace rndf
 }  // namespace maliput


### PR DESCRIPTION
Since piecewise splines do not provide guarantee monotonicity nor convexity at each piece, this pull request provides some utility functions that adjust splines geometries to that end for the purpose of creating smooth roads.

Cubic splines can be converted to cubic Bezier curves whose control points can be easily adjusted to prevent undesired shapes while preserving headings at the ends. This becomes useful when deriving the geometry that connects two Maliput's `BranchPoints` (`exits` and `entries` in RNDF spec). 

In addition, since [PChip](https://github.com/RobotLocomotion/drake/blob/master/drake/common/trajectories/piecewise_polynomial.h#L100-L139) guarantees monotonicity and convexity at each piece, creating an spline from PChip's knots provides the desired geometry with Maliput's required characteristics. This is convenient when creating a curve from a set of RNDF waypoints.

This code will be consumed by the RNDF builder in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6569)
<!-- Reviewable:end -->
