### PR TITLE
Convert `maliput::api::RBounds` into a class (from struct)

### DIFF
--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -271,18 +271,34 @@ struct RoadPosition {
 /// Bounds in the lateral dimension (r component) of a `Lane`-frame, consisting
 /// of a pair of minimum and maximum r value.  The bounds must straddle r = 0,
 /// i.e., the minimum must be <= 0 and the maximum must be >= 0.
-struct RBounds {
+class RBounds {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RBounds)
+
   /// Default constructor.
   RBounds() = default;
 
   /// Fully parameterized constructor.
-  RBounds(double rmin, double rmax) : r_min(rmin), r_max(rmax) {
-    DRAKE_DEMAND(r_min <= 0.);
-    DRAKE_DEMAND(r_max >= 0.);
+  RBounds(double min, double max) : min_(min), max_(max) {
+    DRAKE_DEMAND(min <= 0.);
+    DRAKE_DEMAND(max >= 0.);
   }
 
-  double r_min{};
-  double r_max{};
+  /// @name Getters and Setters
+  //@{
+  /// Gets minimum bound.
+  double min() const { return min_; }
+  /// Sets minimum bound.
+  void set_min(double min) { min_ = min; }
+  /// Gets maximum bound.
+  double max() const { return max_; }
+  /// Sets maximum bound.
+  void set_max(double max) { max_ = max; }
+  //@}
+
+ private:
+  double min_{};
+  double max_{};
 };
 
 

--- a/drake/automotive/maliput/api/test/maliput_types_compare.cc
+++ b/drake/automotive/maliput/api/test/maliput_types_compare.cc
@@ -149,23 +149,23 @@ namespace test {
                                           double tolerance) {
   bool fails = false;
   std::string error_message;
-  double delta = std::abs(rbounds1.r_min - rbounds2.r_min);
+  double delta = std::abs(rbounds1.min() - rbounds2.min());
   if (delta > tolerance) {
     fails = true;
     error_message = error_message
                     + "RBounds are different at r_min. "
-                    + "rbounds1.r_min: " + std::to_string(rbounds1.r_min)
-                    + " vs. rbounds2.r_min: " + std::to_string(rbounds2.r_min)
+                    + "rbounds1.r_min: " + std::to_string(rbounds1.min())
+                    + " vs. rbounds2.r_min: " + std::to_string(rbounds2.min())
                     + ", diff = " + std::to_string(delta) + ", tolerance = "
                     + std::to_string(tolerance) + "\n";
   }
-  delta = std::abs(rbounds1.r_max - rbounds2.r_max);
+  delta = std::abs(rbounds1.max() - rbounds2.max());
   if (delta > tolerance) {
     fails = true;
     error_message = error_message
                     + "RBounds are different at r_max. "
-                    + "rbounds1.r_max: " + std::to_string(rbounds1.r_max)
-                    + " vs. rbounds2.r_max: " + std::to_string(rbounds2.r_max)
+                    + "rbounds1.r_max: " + std::to_string(rbounds1.max())
+                    + " vs. rbounds2.r_max: " + std::to_string(rbounds2.max())
                     + ", diff = " + std::to_string(delta) + ", tolerance = "
                     + std::to_string(tolerance) + "\n";
   }
@@ -174,10 +174,10 @@ namespace test {
   }
   return ::testing::AssertionSuccess()
          << "rbounds1 =\n"
-         << "(" << rbounds1.r_min << ", " << rbounds1.r_max << ")"
+         << "(" << rbounds1.min() << ", " << rbounds1.max() << ")"
          << "\nis approximately equal to "
          << " rbounds2 =\n"
-         << "(" << rbounds2.r_min << ", " << rbounds2.r_max << ")"
+         << "(" << rbounds2.min() << ", " << rbounds2.max() << ")"
          << ", tolerance = " << tolerance;
 }
 

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -28,8 +28,8 @@ Lane::Lane(const Segment* segment, const api::LaneId& id,  int index,
       driveable_bounds_(driveable_bounds),
       elevation_bounds_(elevation_bounds) {
   DRAKE_DEMAND(segment != nullptr);
-  DRAKE_DEMAND(lane_bounds_.r_min >= driveable_bounds_.r_min);
-  DRAKE_DEMAND(lane_bounds_.r_max <= driveable_bounds_.r_max);
+  DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
+  DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
   // TODO(liang.fok) Consider initializing this variable in the constructor's
   // initializer list so branch_point_ can be declared `const`.
   branch_point_ = make_unique<BranchPoint>(
@@ -104,8 +104,8 @@ api::LanePosition Lane::DoToLanePosition(
 
   const double min_x = 0;
   const double max_x = length_;
-  const double min_y = driveable_bounds_.r_min + y_offset_;
-  const double max_y = driveable_bounds_.r_max + y_offset_;
+  const double min_y = driveable_bounds_.min() + y_offset_;
+  const double max_y = driveable_bounds_.max() + y_offset_;
   const double min_z = elevation_bounds_.min();
   const double max_z = elevation_bounds_.max();
 

--- a/drake/automotive/maliput/dragway/road_geometry.cc
+++ b/drake/automotive/maliput/dragway/road_geometry.cc
@@ -61,8 +61,8 @@ bool RoadGeometry::IsGeoPositionOnDragway(const api::GeoPosition& geo_pos)
   DRAKE_ASSERT(lane != nullptr);
   const double length = lane->length();
   const api::RBounds lane_driveable_bounds = lane->driveable_bounds(0 /* s */);
-  const double min_y = lane->y_offset() + lane_driveable_bounds.r_min;
-  const double max_y = lane->y_offset() + lane_driveable_bounds.r_max;
+  const double min_y = lane->y_offset() + lane_driveable_bounds.min();
+  const double max_y = lane->y_offset() + lane_driveable_bounds.max();
 
   if (geo_pos.x() < 0 || geo_pos.x() > length ||
       geo_pos.y() > max_y || geo_pos.y() < min_y) {
@@ -83,7 +83,7 @@ int RoadGeometry::GetLaneIndex(const api::GeoPosition& geo_pos) const {
   for (int i = 0; !lane_found && i < junction_.segment(0)->num_lanes(); ++i) {
     const Lane* lane = dynamic_cast<const Lane*>(junction_.segment(0)->lane(i));
     DRAKE_ASSERT(lane != nullptr);
-    if (geo_pos.y() <= lane->y_offset() + lane->lane_bounds(0).r_max) {
+    if (geo_pos.y() <= lane->y_offset() + lane->lane_bounds(0).max()) {
       result = i;
       lane_found = true;
     }
@@ -91,8 +91,8 @@ int RoadGeometry::GetLaneIndex(const api::GeoPosition& geo_pos) const {
     // Checks whether `geo_pos` is on the right shoulder. If it is, save the
     // index of the right-most lane in `result`.
     if (lane->to_right() == nullptr) {
-      if (geo_pos.y() <= lane->y_offset() + lane->lane_bounds(0).r_min &&
-          geo_pos.y() >= lane->y_offset() + lane->driveable_bounds(0).r_min) {
+      if (geo_pos.y() <= lane->y_offset() + lane->lane_bounds(0).min() &&
+          geo_pos.y() >= lane->y_offset() + lane->driveable_bounds(0).min()) {
         result = i;
         lane_found = true;
       }
@@ -101,8 +101,8 @@ int RoadGeometry::GetLaneIndex(const api::GeoPosition& geo_pos) const {
     // Checks whether `geo_pos` is on the left shoulder. If it is, save the
     // index of the left-most lane in `result`.
     if (lane->to_left() == nullptr) {
-      if (geo_pos.y() >= lane->y_offset() + lane->lane_bounds(0).r_max &&
-          geo_pos.y() <= lane->y_offset() + lane->driveable_bounds(0).r_max) {
+      if (geo_pos.y() >= lane->y_offset() + lane->lane_bounds(0).max() &&
+          geo_pos.y() <= lane->y_offset() + lane->driveable_bounds(0).max()) {
         result = i;
         lane_found = true;
       }
@@ -132,8 +132,8 @@ api::RoadPosition RoadGeometry::DoToRoadPosition(
   DRAKE_ASSERT(lane != nullptr);
   const double length = lane->length();
   const api::RBounds lane_driveable_bounds = lane->driveable_bounds(0 /* s */);
-  const double min_y = lane->y_offset() + lane_driveable_bounds.r_min;
-  const double max_y = lane->y_offset() + lane_driveable_bounds.r_max;
+  const double min_y = lane->y_offset() + lane_driveable_bounds.min();
+  const double max_y = lane->y_offset() + lane_driveable_bounds.max();
   const double min_x = 0;
   const double max_x = length;
   const double min_z = lane->elevation_bounds(0, 0).min();

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -86,9 +86,9 @@ class MaliputDragwayLaneTest : public ::testing::Test {
     for (double s = 0 ; s < length_; s += length_ / 10) {
       const api::RBounds driveable_bounds = lane->driveable_bounds(s);
       const api::HBounds elevation_bounds0 =
-          lane->elevation_bounds(s, driveable_bounds.r_min);
+          lane->elevation_bounds(s, driveable_bounds.min());
       const api::HBounds elevation_bounds1 =
-          lane->elevation_bounds(s, driveable_bounds.r_max);
+          lane->elevation_bounds(s, driveable_bounds.max());
       EXPECT_TRUE(api::test::IsHBoundsClose(
           elevation_bounds0,
           api::HBounds(expected.elevation_min, expected.elevation_max),

--- a/drake/automotive/maliput/monolane/arc_lane.cc
+++ b/drake/automotive/maliput/monolane/arc_lane.cc
@@ -139,9 +139,9 @@ ArcLane::ArcLane(const api::LaneId& id, const api::Segment* segment,
   // TODO(maddog@tri.global)  When you have nothing better to do, handle the
   //                          improbable case of superelevation >= 90 deg, too.
   if (d_theta > 0.) {
-    DRAKE_DEMAND((driveable_bounds.r_max * max_cos_theta) < r_);
+    DRAKE_DEMAND((driveable_bounds.max() * max_cos_theta) < r_);
   } else {
-    DRAKE_DEMAND((driveable_bounds.r_min * max_cos_theta) > -r_);
+    DRAKE_DEMAND((driveable_bounds.min() * max_cos_theta) > -r_);
   }
 }
 
@@ -218,8 +218,8 @@ api::LanePosition ArcLane::DoToLanePosition(
   // Compute r (its direction depends on the direction of the +s-coordinate)
   const double r_unsaturated = (d_theta_ >= 0.) ? r_ - v.norm() : v.norm() - r_;
   // Saturate r within drivable bounds.
-  const double r = math::saturate(r_unsaturated, driveable_bounds(s).r_min,
-                                  driveable_bounds(s).r_max);
+  const double r = math::saturate(r_unsaturated, driveable_bounds(s).min(),
+                                  driveable_bounds(s).max());
 
   // Calculate the (uniform) road elevation.
   const double p_scale = r_ * d_theta_;

--- a/drake/automotive/maliput/monolane/builder.cc
+++ b/drake/automotive/maliput/monolane/builder.cc
@@ -24,8 +24,8 @@ Builder::Builder(const api::RBounds& lane_bounds,
       elevation_bounds_(elevation_bounds),
       linear_tolerance_(linear_tolerance),
       angular_tolerance_(angular_tolerance) {
-  DRAKE_DEMAND(lane_bounds_.r_min >= driveable_bounds_.r_min);
-  DRAKE_DEMAND(lane_bounds_.r_max <= driveable_bounds_.r_max);
+  DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
+  DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
 }
 
 

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -191,8 +191,8 @@ class Lane : public api::Lane {
         p_scale_(p_scale),
         elevation_(elevation),
         superelevation_(superelevation) {
-    DRAKE_DEMAND(lane_bounds_.r_min >= driveable_bounds_.r_min);
-    DRAKE_DEMAND(lane_bounds_.r_max <= driveable_bounds_.r_max);
+    DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
+    DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
   }
 
   // TODO(maddog@tri.global)  Allow superelevation to have a center-of-rotation

--- a/drake/automotive/maliput/monolane/line_lane.cc
+++ b/drake/automotive/maliput/monolane/line_lane.cc
@@ -37,8 +37,8 @@ api::LanePosition LineLane::DoToLanePosition(
   const double s_unsaturated = lane_origin_to_p.dot(s_unit_vector);
   const double s = math::saturate(s_unsaturated, 0., length);
   const double r_unsaturated = lane_origin_to_p.dot(r_unit_vector);
-  const double r = math::saturate(r_unsaturated, driveable_bounds(s).r_min,
-                                  driveable_bounds(s).r_max);
+  const double r = math::saturate(r_unsaturated, driveable_bounds(s).min(),
+                                  driveable_bounds(s).max());
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
   const double h_unsaturated = geo_position.z() - elevation().a() * length;

--- a/drake/automotive/maliput/rndf/spline_lane.cc
+++ b/drake/automotive/maliput/rndf/spline_lane.cc
@@ -45,8 +45,8 @@ api::GeoPosition SplineLane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
   const double s = drake::math::saturate(lane_pos.s(), 0., do_length());
   const api::RBounds driveable_bounds = do_driveable_bounds(s);
-  const double r = drake::math::saturate(lane_pos.r(), driveable_bounds.r_min,
-                                         driveable_bounds.r_max);
+  const double r = drake::math::saturate(lane_pos.r(), driveable_bounds.min(),
+                                         driveable_bounds.max());
   // Calculate x,y of (s,0,0).
   const Vector2<double> xy = xy_of_s(s);
   // Calculate orientation of (s,r,h) basis at (s,0,0).
@@ -136,10 +136,10 @@ api::RBounds SplineLane::do_driveable_bounds(double s) const {
       GetPositionToLane(s, segment()->num_lanes() - 1);
   const double r_min = -std::abs(
       (position_first_lane - spline_->InterpolateMthDerivative(0, s)).Length() +
-      segment()->lane(0)->lane_bounds(0.).r_max);
+      segment()->lane(0)->lane_bounds(0.).max());
   const double r_max = std::abs(
       (position_last_lane - spline_->InterpolateMthDerivative(0, s)).Length() +
-      segment()->lane(segment()->num_lanes() - 1)->lane_bounds(0.).r_max);
+      segment()->lane(segment()->num_lanes() - 1)->lane_bounds(0.).max());
   return api::RBounds(r_min, r_max);
 }
 

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -313,9 +313,9 @@ void CoverLaneWithQuads(
     {
       double r00 = 0.;
       double r10 = 0.;
-      while ((r00 < rb0.r_max) && (r10 < rb1.r_max)) {
-        const double r01 = std::min(r00 + grid_unit, rb0.r_max);
-        const double r11 = std::min(r10 + grid_unit, rb1.r_max);
+      while ((r00 < rb0.max()) && (r10 < rb1.max())) {
+        const double r01 = std::min(r00 + grid_unit, rb0.max());
+        const double r11 = std::min(r10 + grid_unit, rb1.max());
         //
         // (s1,r11) o <-- o (s1,r10)       ^ +s
         //          |     ^                |
@@ -337,9 +337,9 @@ void CoverLaneWithQuads(
     {
       double r00 = 0.;
       double r10 = 0.;
-      while ((r00 > rb0.r_min) && (r10 > rb1.r_min)) {
-        const double r01 = std::max(r00 - grid_unit, rb0.r_min);
-        const double r11 = std::max(r10 - grid_unit, rb1.r_min);
+      while ((r00 > rb0.min()) && (r10 > rb1.min())) {
+        const double r01 = std::max(r00 - grid_unit, rb0.min());
+        const double r11 = std::max(r10 - grid_unit, rb1.min());
         //
         // (s1,r10) o <-- o (s1,r11)  ^ +s
         //          |     ^           |
@@ -385,19 +385,19 @@ void StripeLaneBounds(GeoMesh* mesh, const api::Lane* lane,
     // Left side of lane.
     {
       SrhFace srh_face({
-          {s0, rb0.r_max - half_stripe, h_offset},
-          {s1, rb1.r_max - half_stripe, h_offset},
-          {s1, rb1.r_max + half_stripe, h_offset},
-          {s0, rb0.r_max + half_stripe, h_offset}}, {0., 0., 1.});
+          {s0, rb0.max() - half_stripe, h_offset},
+          {s1, rb1.max() - half_stripe, h_offset},
+          {s1, rb1.max() + half_stripe, h_offset},
+          {s0, rb0.max() + half_stripe, h_offset}}, {0., 0., 1.});
       mesh->PushFace(srh_face.ToGeoFace(lane));
     }
     // Right side of lane.
     {
       SrhFace srh_face({
-          {s0, rb0.r_min - half_stripe, h_offset},
-          {s1, rb1.r_min - half_stripe, h_offset},
-          {s1, rb1.r_min + half_stripe, h_offset},
-          {s0, rb0.r_min + half_stripe, h_offset}}, {0., 0., 1.});
+          {s0, rb0.min() - half_stripe, h_offset},
+          {s1, rb1.min() - half_stripe, h_offset},
+          {s1, rb1.min() + half_stripe, h_offset},
+          {s0, rb0.min() + half_stripe, h_offset}}, {0., 0., 1.});
       mesh->PushFace(srh_face.ToGeoFace(lane));
     }
   }
@@ -425,8 +425,8 @@ void DrawLaneArrow(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
 
   const int max_num_s_units = static_cast<int>(std::ceil(s_size / grid_unit));
 
-  const double rl_size = rb0.r_max * kRelativeWidth;
-  const double rr_size = -rb0.r_min * kRelativeWidth;
+  const double rl_size = rb0.max() * kRelativeWidth;
+  const double rr_size = -rb0.min() * kRelativeWidth;
   const int max_num_rl_units = static_cast<int>(std::ceil(rl_size / grid_unit));
   const int max_num_rr_units = static_cast<int>(std::ceil(rr_size / grid_unit));
 
@@ -534,11 +534,11 @@ void MarkLaneEnds(GeoMesh* mesh, const api::Lane* lane, double grid_unit,
   // Arrows are sized relative to their respective ends.
   const api::RBounds start_rb = lane->lane_bounds(0.);
   const double start_s_size = std::min(max_length,
-                                       (start_rb.r_max - start_rb.r_min));
+                                       (start_rb.max() - start_rb.min()));
 
   const api::RBounds finish_rb = lane->lane_bounds(lane->length());
   const double finish_s_size = std::min(max_length,
-                                        (finish_rb.r_max - finish_rb.r_min));
+                                        (finish_rb.max() - finish_rb.min()));
 
   DrawLaneArrow(mesh, lane, grid_unit,
                 0. + nudge, start_s_size, h_offset);
@@ -554,8 +554,8 @@ double PickGridUnit(const api::Lane* lane,
   double result = max_size;
   const api::RBounds rb0 = lane->lane_bounds(0.);
   const api::RBounds rb1 = lane->lane_bounds(lane->length());
-  result = std::min(result, (rb0.r_max - rb0.r_min) / min_resolution);
-  result = std::min(result, (rb1.r_max - rb1.r_min) / min_resolution);
+  result = std::min(result, (rb0.max() - rb0.min()) / min_resolution);
+  result = std::min(result, (rb1.max() - rb1.min()) / min_resolution);
   result = std::min(result, lane->length() / min_resolution);
   return result;
 }
@@ -593,7 +593,7 @@ void RenderBranchPoint(
       reference_end.lane->length();
   const api::RBounds reference_bounds =
       reference_end.lane->lane_bounds(reference_end_s);
-  const double sr_margin = reference_bounds.r_max - reference_bounds.r_min;
+  const double sr_margin = reference_bounds.max() - reference_bounds.min();
   const double h_margin = height;
 
   // Choose an elevation that keeps this BranchPoint out of the way
@@ -652,10 +652,10 @@ void RenderBranchPoint(
     const api::RBounds r_bounds = lane_end.lane->lane_bounds(end_s);
 
     const double half_width =
-      (r_bounds.r_max - r_bounds.r_min) * kWidthFactor * 0.5;
+      (r_bounds.max() - r_bounds.min()) * kWidthFactor * 0.5;
     const double length =
       std::min(kMaxLengthFraction * lane_end.lane->length(),
-               kLengthFactor * (r_bounds.r_max - r_bounds.r_min)) *
+               kLengthFactor * (r_bounds.max() - r_bounds.min())) *
       ((lane_end.end == api::LaneEnd::kStart) ? 1. : -1);
 
     const double left_r =

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -137,8 +137,8 @@ bool PoseSelector<T>::IsWithinDriveable(const LanePosition& lane_position,
   }
   const maliput::api::RBounds r_bounds =
       lane->driveable_bounds(lane_position.s());
-  if (lane_position.r() < r_bounds.r_min ||
-      lane_position.r() > r_bounds.r_max) {
+  if (lane_position.r() < r_bounds.min() ||
+      lane_position.r() > r_bounds.max()) {
     return false;
   }
   const maliput::api::HBounds h_bounds =
@@ -154,8 +154,8 @@ bool PoseSelector<T>::IsWithinLane(const GeoPosition& geo_position,
   const LanePosition pos =
       lane->ToLanePosition(geo_position, nullptr, &distance);
   const maliput::api::RBounds r_bounds = lane->lane_bounds(pos.s());
-  return (distance == 0. && pos.r() >= r_bounds.r_min &&
-          pos.r() <= r_bounds.r_max);
+  return (distance == 0. && pos.r() >= r_bounds.min() &&
+          pos.r() <= r_bounds.max());
 }
 
 template <typename T>
@@ -163,8 +163,8 @@ bool PoseSelector<T>::IsWithinLane(const LanePosition& lane_position,
                                    const Lane* lane) {
   if (IsWithinDriveable(lane_position, lane)) {
     const maliput::api::RBounds r_bounds = lane->lane_bounds(lane_position.s());
-    if (lane_position.r() >= r_bounds.r_min ||
-        lane_position.r() <= r_bounds.r_max) {
+    if (lane_position.r() >= r_bounds.min() ||
+        lane_position.r() <= r_bounds.max()) {
       return true;
     }
   }

--- a/drake/automotive/test/monolane_onramp_merge_test.cc
+++ b/drake/automotive/test/monolane_onramp_merge_test.cc
@@ -32,11 +32,11 @@ GTEST_TEST(MonolaneOnrampMergeTest, TestDefaultAndNonDefaultAttributes) {
 
   // Check the correctness of the default parameters.
   EXPECT_EQ(
-      RoadCharacteristics{}.lane_bounds.r_max,
-      rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition).r_max);
+      RoadCharacteristics{}.lane_bounds.max(),
+      rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition).max());
   EXPECT_EQ(
-      RoadCharacteristics{}.driveable_bounds.r_max,
-      rg->junction(0)->segment(0)->lane(0)->driveable_bounds(kSPosition).r_max);
+      RoadCharacteristics{}.driveable_bounds.max(),
+      rg->junction(0)->segment(0)->lane(0)->driveable_bounds(kSPosition).max());
 
   EXPECT_EQ(rg->id().id, "monolane-merge-example");
   EXPECT_EQ(rg->num_junctions(), 9);
@@ -87,12 +87,11 @@ GTEST_TEST(MonolaneOnrampMergeTest, TestDefaultAndNonDefaultAttributes) {
   // Check the correctness of the non-default parameters.
   EXPECT_EQ(
       kLaneWidth / 2.,
-      new_rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition).r_max);
+      new_rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition).max());
   EXPECT_EQ(kDriveableWidth / 2., new_rg->junction(0)
                                       ->segment(0)
                                       ->lane(0)
-                                      ->driveable_bounds(kSPosition)
-                                      .r_max);
+                                      ->driveable_bounds(kSPosition).max());
 
   EXPECT_EQ(new_rg->id().id, "monolane-merge-example");
   EXPECT_EQ(new_rg->num_junctions(), 9);


### PR DESCRIPTION
Convert `maliput::api::RBounds` into a class (from struct),
mirroring the API of other entities in `lane_data.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6573)
<!-- Reviewable:end -->
