### PR TITLE
Introducing GeometrySystem - Registration API

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -11,10 +11,64 @@ load(
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "geometry_frame",
+    srcs = [],
+    hdrs = ["geometry_frame.h"],
+    deps = ["//drake/common"],
+)
+
+drake_cc_library(
+    name = "geometry_ids",
+    srcs = [],
+    hdrs = ["geometry_ids.h"],
+    deps = [":identifier"],
+)
+
+drake_cc_library(
+    name = "geometry_instance",
+    srcs = ["geometry_instance.cc"],
+    hdrs = ["geometry_instance.h"],
+    deps = [
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
+    name = "geometry_system",
+    srcs = ["geometry_system.cc"],
+    hdrs = [
+        "geometry_system.h",
+    ],
+    deps = [
+        ":geometry_frame",
+        ":geometry_ids",
+        ":geometry_instance",
+        "//drake/common",
+        "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
     name = "identifier",
     srcs = [],
     hdrs = ["identifier.h"],
     deps = ["//drake/common"],
+)
+
+# -----------------------------------------------------
+
+drake_cc_library(
+    name = "expect_error_message",
+    srcs = [],
+    hdrs = ["test/expect_error_message.h"],
+)
+
+drake_cc_googletest(
+    name = "geometry_system_test",
+    deps = [
+        ":expect_error_message",
+        ":geometry_system",
+    ],
 )
 
 drake_cc_googletest(

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -7,7 +7,7 @@
 namespace drake {
 namespace geometry {
 
-/** This simple struct carries the definition of a frame used by GeometryWorld.
+/** This simple class carries the definition of a frame used by GeometryWorld.
  To register moving frames with GeometryWorld (see
  GeometryWorld::RegisterFrame), a geometry source (see
  GeometryWorld::RegisterNewSource) instantiates a frame and passes ownership

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace geometry {
+
+/** This simple struct carries the definition of a frame used by GeometryWorld.
+ To register moving frames with GeometryWorld (see
+ GeometryWorld::RegisterFrame), a geometry source (see
+ GeometryWorld::RegisterNewSource) instantiates a frame and passes ownership
+ over to GeometryWorld.
+
+ A frame is defined by three pieces of information:
+    - the name, which must be unique within a single geometry source,
+    - the "frame group", an integer identifier that can be used to group frames
+      together within a geometry source, and
+    - the initial pose of the frame (measured and expressed in its parent
+      frame). The parent is defined at registration. This is only the _initial_
+      pose; registered frames are expected to move with time.
+
+ @internal The "frame group" is intended as a generic synonym for the model
+ instance id defined by the RigidBodyTree and used again in automotive to
+ serve as unique car identifiers.
+
+ @see GeometryWorld
+
+ @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
+template <typename T>
+class GeometryFrame {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryFrame)
+
+  GeometryFrame() = default;
+};
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_ids.h
+++ b/drake/geometry/geometry_ids.h
@@ -5,7 +5,7 @@
 namespace drake {
 namespace geometry {
 
-/** Type used to identify geometry sources n GeometryWorld. */
+/** Type used to identify geometry sources in GeometryWorld. */
 using SourceId = Identifier<class SourceTag>;
 
 /** Type used to identify geometry frames in GeometryWorld .*/

--- a/drake/geometry/geometry_ids.h
+++ b/drake/geometry/geometry_ids.h
@@ -5,14 +5,13 @@
 namespace drake {
 namespace geometry {
 
-/// Type used to identify geometry sources by index in GeometryWorld.
+/** Type used to identify geometry sources n GeometryWorld. */
 using SourceId = Identifier<class SourceTag>;
 
-/// Type used to identify a frame kinematics instance by index in
-/// GeometryWorld
+/** Type used to identify geometry frames in GeometryWorld .*/
 using FrameId = Identifier<class FrameTag>;
 
-/// Type used to identify a geometry instance by index in GeometryWorld.
+/** Type used to identify geometry instances in GeometryWorld. */
 using GeometryId = Identifier<class GeometryTag>;
 
 }  // namespace geometry

--- a/drake/geometry/geometry_ids.h
+++ b/drake/geometry/geometry_ids.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "drake/geometry/identifier.h"
+
+namespace drake {
+namespace geometry {
+
+/// Type used to identify geometry sources by index in GeometryWorld.
+using SourceId = Identifier<class SourceTag>;
+
+/// Type used to identify a frame kinematics instance by index in
+/// GeometryWorld
+using FrameId = Identifier<class FrameTag>;
+
+/// Type used to identify a geometry instance by index in GeometryWorld.
+using GeometryId = Identifier<class GeometryTag>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_instance.cc
+++ b/drake/geometry/geometry_instance.cc
@@ -1,0 +1,10 @@
+#include "drake/geometry/geometry_instance.h"
+
+namespace drake {
+namespace geometry {
+
+// Explicitly instantiates on the most common scalar types.
+template class GeometryInstance<double>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace geometry {
+
+/**
+ A geometry instance combines a geometry definition (i.e., a shape of some
+ sort), a pose (relative to a parent frame), material information, and an
+ opaque collection of metadata.
+
+ @tparam T  The underlying scalar type. Must be a valid Eigen scalar.
+            Only double is supported. */
+// TODO(SeanCurtis-TRI): Add support for AutoDiffXd.
+template <typename T>
+class GeometryInstance {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryInstance)
+
+  GeometryInstance() = default;
+};
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -11,7 +11,12 @@ namespace geometry {
  opaque collection of metadata.
 
  @tparam T  The underlying scalar type. Must be a valid Eigen scalar.
-            Only double is supported. */
+
+ Instantiated templates for the following kinds of T's are provided:
+    - double
+
+ They are already available to link against in the containing library.
+ No other values for T are currently supported. */
 // TODO(SeanCurtis-TRI): Add support for AutoDiffXd.
 template <typename T>
 class GeometryInstance {

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -1,0 +1,129 @@
+#include "drake/geometry/geometry_system.h"
+
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/unused.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+namespace geometry {
+
+using systems::Context;
+using systems::LeafContext;
+using systems::LeafSystem;
+using systems::SparsityMatrix;
+using systems::SystemOutput;
+using std::vector;
+
+template <typename T>
+GeometrySystem<T>::~GeometrySystem() {}
+
+template <typename T>
+SourceId GeometrySystem<T>::RegisterSource(const std::string &name) {
+  unused(name);
+  if (!context_allocated_) {
+    // TODO(SeanCurtis-TRI): Replace dummy source id with actual id.
+    return SourceId::get_new_id();
+  } else {
+    throw std::logic_error(
+        "A context has been created for this system. Adding new geometry "
+        "sources is no longer possible.");
+  }
+}
+
+template <typename T>
+FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id,
+                                         const GeometryFrame<T>& frame) {
+  // TODO(SeanCurtis-TRI): Replace dummy frame id with actual registration and
+  // use all parameters.
+  unused(source_id, frame);
+  ThrowIfContextAllocated();
+  return FrameId::get_new_id();
+}
+
+template <typename T>
+FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
+                                         const GeometryFrame<T>& frame) {
+  // TODO(SeanCurtis-TRI): Replace dummy frame id with actual registration and
+  // use all parameters.
+  unused(source_id, parent_id, frame);
+  ThrowIfContextAllocated();
+  return FrameId::get_new_id();
+}
+
+template <typename T>
+GeometryId GeometrySystem<T>::RegisterGeometry(
+    SourceId source_id, FrameId frame_id,
+    std::unique_ptr<GeometryInstance<T>> geometry) {
+  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
+  // and use all parameters.
+  unused(source_id, frame_id, geometry);
+  ThrowIfContextAllocated();
+  return GeometryId::get_new_id();
+}
+
+template <typename T>
+GeometryId GeometrySystem<T>::RegisterGeometry(
+    SourceId source_id, GeometryId geometry_id,
+    std::unique_ptr<GeometryInstance<T>> geometry) {
+  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
+  // and use all parameters.
+  unused(source_id, geometry_id, geometry);
+  ThrowIfContextAllocated();
+  return GeometryId::get_new_id();
+}
+
+template <typename T>
+GeometryId GeometrySystem<T>::RegisterAnchoredGeometry(
+    SourceId source_id,
+    std::unique_ptr<GeometryInstance<T>> geometry) {
+  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
+  // and use all parameters.
+  unused(source_id, geometry);
+  ThrowIfContextAllocated();
+  return GeometryId::get_new_id();
+}
+
+template <typename T>
+void GeometrySystem<T>::ClearSource(SourceId source_id) {
+  // TODO(SeanCurtis-TRI): Actually do the work.
+  unused(source_id);
+  ThrowIfContextAllocated();
+}
+
+template <typename T>
+void GeometrySystem<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
+  // TODO(SeanCurtis-TRI): Actually do the work
+  unused(source_id, frame_id);
+  ThrowIfContextAllocated();
+}
+
+template <typename T>
+void GeometrySystem<T>::RemoveGeometry(SourceId source_id,
+                                       GeometryId geometry_id) {
+  // TODO(SeanCurtis-TRI): Actually do the work.
+  unused(source_id, geometry_id);
+  ThrowIfContextAllocated();
+}
+
+template <typename T>
+std::unique_ptr<LeafContext<T>> GeometrySystem<T>::DoMakeContext() const {
+  // Disallow further geometry source additions.
+  context_allocated_ = true;
+  return std::make_unique<LeafContext<T>>();
+}
+
+template <typename T>
+void GeometrySystem<T>::ThrowIfContextAllocated() const {
+  if (context_allocated_)
+    throw std::logic_error("Operation invalid; a context has already been "
+                           "allocated.");
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class GeometrySystem<double>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/geometry_system.h"
 
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -17,20 +18,17 @@ using systems::SparsityMatrix;
 using systems::SystemOutput;
 using std::vector;
 
+#define THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
+
 template <typename T>
 GeometrySystem<T>::~GeometrySystem() {}
 
 template <typename T>
 SourceId GeometrySystem<T>::RegisterSource(const std::string &name) {
   unused(name);
-  if (!context_allocated_) {
-    // TODO(SeanCurtis-TRI): Replace dummy source id with actual id.
-    return SourceId::get_new_id();
-  } else {
-    throw std::logic_error(
-        "A context has been created for this system. Adding new geometry "
-        "sources is no longer possible.");
-  }
+  ThrowIfContextAllocated(__FUNCTION__);
+  // TODO(SeanCurtis-TRI): Replace dummy source id with actual id.
+  return SourceId::get_new_id();
 }
 
 template <typename T>
@@ -39,7 +37,7 @@ FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id,
   // TODO(SeanCurtis-TRI): Replace dummy frame id with actual registration and
   // use all parameters.
   unused(source_id, frame);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
   return FrameId::get_new_id();
 }
 
@@ -49,7 +47,7 @@ FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
   // TODO(SeanCurtis-TRI): Replace dummy frame id with actual registration and
   // use all parameters.
   unused(source_id, parent_id, frame);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
   return FrameId::get_new_id();
 }
 
@@ -60,7 +58,7 @@ GeometryId GeometrySystem<T>::RegisterGeometry(
   // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
   // and use all parameters.
   unused(source_id, frame_id, geometry);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
   return GeometryId::get_new_id();
 }
 
@@ -71,7 +69,7 @@ GeometryId GeometrySystem<T>::RegisterGeometry(
   // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
   // and use all parameters.
   unused(source_id, geometry_id, geometry);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
   return GeometryId::get_new_id();
 }
 
@@ -82,7 +80,7 @@ GeometryId GeometrySystem<T>::RegisterAnchoredGeometry(
   // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
   // and use all parameters.
   unused(source_id, geometry);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
   return GeometryId::get_new_id();
 }
 
@@ -90,14 +88,14 @@ template <typename T>
 void GeometrySystem<T>::ClearSource(SourceId source_id) {
   // TODO(SeanCurtis-TRI): Actually do the work.
   unused(source_id);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
 }
 
 template <typename T>
 void GeometrySystem<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
   // TODO(SeanCurtis-TRI): Actually do the work
   unused(source_id, frame_id);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
 }
 
 template <typename T>
@@ -105,7 +103,7 @@ void GeometrySystem<T>::RemoveGeometry(SourceId source_id,
                                        GeometryId geometry_id) {
   // TODO(SeanCurtis-TRI): Actually do the work.
   unused(source_id, geometry_id);
-  ThrowIfContextAllocated();
+  THROW_IF_CONTEXT_ALLOCATED
 }
 
 template <typename T>
@@ -116,10 +114,12 @@ std::unique_ptr<LeafContext<T>> GeometrySystem<T>::DoMakeContext() const {
 }
 
 template <typename T>
-void GeometrySystem<T>::ThrowIfContextAllocated() const {
+void GeometrySystem<T>::ThrowIfContextAllocated(
+    const char* source_method) const {
   if (context_allocated_)
-    throw std::logic_error("Operation invalid; a context has already been "
-                           "allocated.");
+    throw std::logic_error(
+        "The call to " + std::string(source_method) + " is invalid; a "
+        "context has already been allocated.");
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -26,7 +26,7 @@ GeometrySystem<T>::~GeometrySystem() {}
 template <typename T>
 SourceId GeometrySystem<T>::RegisterSource(const std::string &name) {
   unused(name);
-  ThrowIfContextAllocated(__FUNCTION__);
+  THROW_IF_CONTEXT_ALLOCATED
   // TODO(SeanCurtis-TRI): Replace dummy source id with actual id.
   return SourceId::get_new_id();
 }

--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -1,0 +1,280 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T> class GeometryFrame;
+template <typename T> class GeometryInstance;
+
+// TODO(SeanCurtis-TRI): Introducing the API has been decomposed into two PRs.
+// There is functiaonlity alluded to in these comments (e.g., updating state
+// and performing queries that will come in the follow-up PR.
+
+/** GeometrySystem serves as a system-level wrapper for GeometryWorld. It serves
+ as the nexus for all geometry (and geometry-based operations) in the system.
+ Through GeometrySystem, other systems that introduce geometry can _register_
+ that geometry as part of a common global domain, including it in geometric
+ queries (e.g., cars controlled by one LeafSystem can be observed by a different
+ sensor system). GeometrySystem provides the interface for registering the
+ geometry.
+
+ Only registered "geometry sources" can introduce geometry into %GeometrySystem.
+ Geometry sources will typically be other leaf systems, but, in the case of
+ _anchored_ (i.e., stationary) geometry, it could also be some other block of
+ code (e.g., adding a common ground plane with which all systems' geometries
+ interact). For dynamic geometry (geometry whose pose depends on a Context), the
+ geometry source must also provide pose values for all of the geometries the
+ source owns, via a port connection on %GeometrySystem.
+
+ The basic workflow for registering geometry with %GeometrySystem is:
+   - Register as a geometry source, acquiring a unique SourceId.
+   - Register geometry (anchored and dynamic) with the system.
+   - @todo Document i/o connections when that API is introduced.
+
+ @section geom_sys_workflow Working with GeometrySystem
+
+ LeafSystem instances can relate to GeometrySystem in one of two ways: as a
+ consumer that _performs_ queries, or as a producer that introduces geometry
+ into the shared world and defines its context-dependent kinematics values.
+ It is reasonable for systems to perform either role singly, or both.
+
+ __Consumer__
+
+ @todo Document this when API is introduced.
+
+ __Producer__
+
+ All producers introduce geometry into the shared geometric world. This is
+ called _registering_ geometry. Depending on what exactly has been registered,
+ a producer may also have to _update kinematics_. Producers themselves must be
+ registered with %GeometrySystem as producers (a.k.a. _geometry sources_). They
+ do this by acquiring a SourceId (via GeometrySystem::RegisterSource()). The
+ SourceId serves as a unique handle through which the producer's identity is
+ validated and its ownership of its registered geometry is maintained.
+
+ _Registering Geometry_
+
+ %GeometrySystem cannot know what belongs in the shared world. It must
+ be informed of what the world contains by other systems. Defining the geometry
+ in the world and informing the %GeometrySystem is called _registering_ the
+ geometry. Geometry can be registered as _anchored_ or _dynamic_. The
+ source that registers the geometry _owns_ the geometry; operations that change
+ the geometry, or its frames, requires the SourceId used to register it.
+
+ Dynamic geometry can move; more specifically, its kinematics (e.g., pose)
+ depends on a system's Context. Particularly, dynamic geometry is
+ _fixed_ to a _frame_ whose kinematics values depend on a context. As the frame
+ moves, the geometries fixed to it move with it. Therefore, to register dynamic
+ geometry a frame must be registered first. These registered frames serve as the
+ basis for repositioning geometry in the shared world. The geometry source is
+ responsible for providing up-to-date kinematics values for those registered
+ frames upon request (via an appropriate output port on the source LeafSystem
+ connecting to the appropriate input port on %GeometrySystem). The work flow is
+ as follows:
+   1. Source LeafSystem acquires a SourceId (GeometrySource::RegisterSource()).
+   2. Source registers a frame (GeometrySource::RegisterFrame()).
+     - A frame always has a "parent" frame. It can implicitly be the world
+     frame, _or_ another frame registered by the source.
+   3. Register one or more geometries to a frame
+   (GeometrySource::RegisterGeometry()).
+     - The registered geometry is posed relative to the frame to which it is
+     fixed.
+     - The geometry can also be posed relative to another registered geometry.
+     It will be affixed to _that_ geometry's frame.
+
+ Anchored geometry is _independent_ of the context (i.e., it doesn't move).
+ Anchored geometries are always affixed to the immobile world frame. As such,
+ registering a frame is _not_ required for registering anchored geometry
+ (see GeometrySource::RegisterAnchoredGeometry()). However, the source still
+ owns the anchored geometry.
+
+ _Updating Kinematics_
+
+ @todo Document this when the API has been introduced.
+
+ @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+ */
+template <typename T>
+class GeometrySystem : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GeometrySystem)
+
+  GeometrySystem() = default;
+  ~GeometrySystem() override;
+
+  /** Registers a new source to the geometry system (see GeometryWorld for the
+   discussion of "geometry source"). The caller must save the returned SourceId;
+   it is the token by which all other operations on the geometry world are
+   conducted.
+
+   This source id can be used to register arbitrary _anchored_ geometry. But if
+   dynamic geometry is registered (via RegisterGeometry/RegisterFrame), then
+   the context-dependent pose values must be provided on an input port.
+   See get_source_frame_id_port() and get_source_pose_port().
+   @param name          The optional name of the source. If none is provided
+                        (or the empty string) a unique name will be defined by
+                        GeometrySystem's logic.
+   @throws  std::logic_error if a context has already been allocated for this
+                             %GeometrySystem.
+   @see GeometryState::RegisterNewSource() */
+  SourceId RegisterSource(const std::string &name = "");
+
+  /** @name             Topology Manipulation
+   Topology manipulation consists of changing the data contained in
+   GeometryWorld. This includes registering a new geometry source, adding or
+   removing frames, and adding or removing geometries.
+
+   Currently, the topology can only be manipulated at initialization.
+   Eventually, the API will expand to include modifications of the topology
+   during discrete updates.
+
+   The initialization phase begins with the instantiation of a %GeometrySystem
+   and ends when a context is allocated by the %GeometrySystem instance. This is
+   the only phase when geometry sources can be registered with GeometryWorld.
+   Once a source is registered, it can register frames and geometries. Any
+   frames and geometries registered during this phase become part of the
+   _default_ context state for %GeometrySystem and calls to
+   CreateDefaultContext() will produce identical contexts.
+
+   Every geometry must be associated with a frame. It is rigidly affixed to the
+   frame. As the frame moves, so does the geometry. Colloquially, this is
+   referred to as "hanging" a geometry on a frame.
+   */
+  //@{
+
+  /** Registers a new frame F on for this source. The frame hangs on the world
+   frame (W). Its pose is defined relative to the world frame (i.e, `X_WF`).
+   Returns the corresponding unique frame id.
+   @param source_id     The id for the source registering the frame.
+   @param frame         The definition of the frame to add.
+   @returns  A newly allocated frame id.
+   @throws std::logic_error  If the `source_id` does _not_ map to an active
+                             source or if a context has been allocated. */
+  FrameId RegisterFrame(SourceId source_id, const GeometryFrame<T>& frame);
+
+  /** Registers a new frame F for this source. The frame hangs on another
+   previously registered frame P (indicated by `parent_id`). The pose of the new
+   frame is defined relative to the parent frame (i.e., `X_PF`).  Returns the
+   corresponding unique frame id.
+   @param source_id    The id for the source registering the frame.
+   @param parent_id    The id of the parent frame P.
+   @param frame        The frame to register.
+   @returns  A newly allocated frame id.
+   @throws std::logic_error  1. If the `source_id` does _not_ map to an active
+                             source,
+                             2. If the `parent_id` does _not_ map to a known
+                             frame or does not belong to the source, or
+                             3. a context has been allocated. */
+  FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
+                        const GeometryFrame<T>& frame);
+
+  /** Registers a new geometry G for this source. The geometry hangs on a
+   previously registered frame F (indicated by `frame_id`). The pose of the
+   geometry is defined in a fixed position relative to F (i.e., `X_FG`).
+   Returns the corresponding unique geometry id.
+   @param source_id   The id for the source registering the geometry.
+   @param frame_id    The id for the frame F to hang the geometry on.
+   @param geometry    The geometry G to affix to frame F.
+   @return A unique identifier for the added geometry.
+   @throws std::logic_error  1. the `source_id` does _not_ map to an active
+                             source,
+                             2. the `frame_id` doesn't belong to the source,
+                             3. the `geometry` is equal to `nullptr`,
+                             4. a context has been allocated. */
+  GeometryId RegisterGeometry(SourceId source_id,
+                              FrameId frame_id,
+                              std::unique_ptr<GeometryInstance<T>> geometry);
+
+  /** Registers a new geometry G for this source. The pose of the geometry is
+   defined in a fixed position relative to another, previously registered
+   geometry P (indicated by `geometry_id`). The pose of the new geometry is
+   defined in a fixed position relative to P (i.e., `X_PG`). By induction, this
+   geometry is rigidly affixed to the frame that P is affixed to. Returns the
+   corresponding unique geometry id.
+
+   @param source_id    The id for the source registering the geometry.
+   @param geometry_id  The id for the parent geometry P.
+   @param geometry     The geometry G to add.
+   @return A unique identifier for the added geometry.
+   @throws std::logic_error 1. the `source_id` does _not_ map to an active
+                            source,
+                            2. the `geometry_id` doesn't belong to the source,
+                            3. the `geometry` is equal to `nullptr`, or
+                            4. a context has been allocated. */
+  GeometryId RegisterGeometry(SourceId source_id,
+                              GeometryId geometry_id,
+                              std::unique_ptr<GeometryInstance<T>> geometry);
+
+  /** Registers a new _anchored_ geometry G for this source. The geometry hangs
+   from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
+   Returns the corresponding unique geometry id.
+   @param source_id     The id for the source registering the frame.
+   @param geometry      The anchored geometry G to add to the world.
+   @returns The index for the added geometry.
+   @throws std::logic_error  If the `source_id` does _not_ map to an active
+                             source or a context has been allocated. */
+  GeometryId RegisterAnchoredGeometry(
+      SourceId source_id,
+      std::unique_ptr<GeometryInstance<T>> geometry);
+
+  /** Clears of all the registered frames and geometries from this source, but
+   the source is still registered, allowing future registration of frames
+   and geometries.
+   @param source_id   The id of the source whose regisetered elements will be
+                      cleared.
+   @throws std::logic_error  If the `source_id` does _not_ map to an active
+                             source or if a context has been allocated. */
+  void ClearSource(SourceId source_id);
+
+  /** Removes the given frame F (indicated by `frame_id`) from the the given
+   source's registered frames. All registered geometries connected to this frame
+   will also be removed.
+   @param source_id   The id for the owner geometry source.
+   @param frame_id    The id of the frame to remove.
+   @throws std::logic_error If:
+                            1. The `source_id` is not an active source,
+                            2. the `frame_id` doesn't belong to the source, or
+                            3. a context has been allocated. */
+  void RemoveFrame(SourceId source_id, FrameId frame_id);
+
+  /** Removes the given geometry G (indicated by `geometry_id`) from the the
+   given source's registered geometries. All registered geometries hanging from
+   this geometry will also be removed.
+   @param source_id   The identifier for the owner geometry source.
+   @param geometry_id The identifier of the geometry to remove.
+   @throws std::logic_error If:
+                            1. The `source_id` is not an active source,
+                            2. the `geometry_id` doesn't belong to the source,
+                               or
+                            3. a context has been allocated. */
+  void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
+
+  //@}
+
+ private:
+  // Friend class to facilitate testing.
+  friend class GeometrySystemTester;
+
+  // Override of construction to account for
+  //    - instantiating a GeometryContext instance (as opposed to LeafContext),
+  //    - modifying the state to prevent additional sources being added. */
+  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+
+  // Helper method for throwing an exception if a context has *ever* been
+  // allocated by this system.
+  void ThrowIfContextAllocated() const;
+
+  mutable bool context_allocated_{false};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -125,8 +125,8 @@ class GeometrySystem : public systems::LeafSystem<T> {
    @param name          The optional name of the source. If none is provided
                         (or the empty string) a unique name will be defined by
                         GeometrySystem's logic.
-   @throws  std::logic_error if a context has already been allocated for this
-                             %GeometrySystem.
+   @throws std::logic_error if a context has already been allocated for this
+                            %GeometrySystem.
    @see GeometryState::RegisterNewSource() */
   SourceId RegisterSource(const std::string &name = "");
 

--- a/drake/geometry/test/expect_error_message.h
+++ b/drake/geometry/test/expect_error_message.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <regex>
+
+// Helper macro for "expecting" an exception but *also* testing the error
+// message against the provided regular expression.
+#define EXPECT_ERROR_MESSAGE(expression, exception, reg_exp) \
+try { \
+  expression; \
+  GTEST_NONFATAL_FAILURE_("\t" #expression " failed to throw " #exception); \
+} catch (const exception& err) { \
+  auto matcher = [](const char* s, const char* re) { \
+    return std::regex_match(s, std::regex(re)); }; \
+  EXPECT_PRED2(matcher, err.what(), reg_exp); \
+}
+
+// Helper macro for "asserting" an exception but *also* testing the error
+// message against the provided regular expression.
+#define ASSERT_ERROR_MESSAGE(expression, exception, reg_exp) \
+try { \
+  expression; \
+  GTEST_FATAL_FAILURE_("\t" #expression " failed to throw " #exception); \
+} catch (const exception& err) { \
+  auto matcher = [](const char* s, const char* re) { \
+    return std::regex_match(s, std::regex(re)); }; \
+  ASSERT_PRED2(matcher, err.what(), reg_exp); \
+}
+
+// Helper macros for which mirror the above macros, except they depend on
+// whether assert is armed or not. If *not* armed, they become EXPECT_NO_THROW.
+#ifdef DRAKE_ASSERT_IS_DISARMED
+
+#define EXPECT_ERROR_MESSAGE_IF_ARMED(expression, exception, regexp) \
+do {\
+  EXPECT_NO_THROW(expression); \
+} while (0)
+
+#define ASSERT_ERROR_MESSAGE_IF_ARMED(expression, exception, regexp) \
+do {\
+  EXPECT_NO_THROW(expression); \
+} while (0)
+
+#else
+
+#define EXPECT_ERROR_MESSAGE_IF_ARMED(expression, exception, regexp) \
+EXPECT_ERROR_MESSAGE(expression, exception, regexp)
+
+#define ASSERT_ERROR_MESSAGE_IF_ARMED(expression, exception, regexp) \
+ASSERT_ERROR_MESSAGE(expression, exception, regexp)
+
+#endif

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -23,7 +23,6 @@ namespace drake {
 namespace geometry {
 
 using systems::Context;
-using GSystem = GeometrySystem<double>;
 using std::make_unique;
 using std::unique_ptr;
 
@@ -55,7 +54,7 @@ class GeometrySystemTest : public ::testing::Test {
     return make_unique<GeometryInstance<double>>();
   }
 
-  GSystem system_;
+  GeometrySystem<double> system_;
   // Ownership of context.
   unique_ptr<Context<double>> context_;
 };

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -85,8 +85,8 @@ TEST_F(GeometrySystemTest, PoseContextSourceRegistration) {
   EXPECT_ERROR_MESSAGE(
       system_.RegisterSource(),
       std::logic_error,
-      "A context has been created for this system. Adding new geometry "
-      "sources is no longer possible.");
+      "The call to RegisterSource is invalid; a context has already been "
+      "allocated.");
 }
 
 // Test topology changes (registration, removal, clearing, etc.)
@@ -105,7 +105,8 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
       system_.RegisterFrame(
           id, GeometryFrame<double>()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RegisterFrame is invalid; a context has already been "
+      "allocated.");
 
   // Attach frame to another frame.
   EXPECT_ERROR_MESSAGE(
@@ -113,45 +114,52 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
           id, FrameId::get_new_id(),
           GeometryFrame<double>()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RegisterFrame is invalid; a context has already been "
+      "allocated.");
 
   // Attach geometry to frame.
   EXPECT_ERROR_MESSAGE(
       system_.RegisterGeometry(
           id, FrameId::get_new_id(), make_sphere_instance()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RegisterGeometry is invalid; a context has already been "
+      "allocated.");
 
   // Attach geometry to another geometry.
   EXPECT_ERROR_MESSAGE(
       system_.RegisterGeometry(
           id, GeometryId::get_new_id(), make_sphere_instance()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RegisterGeometry is invalid; a context has already been "
+          "allocated.");
 
   // Attach anchored geometry to world.
   EXPECT_ERROR_MESSAGE(
       system_.RegisterAnchoredGeometry(id, make_sphere_instance()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RegisterAnchoredGeometry is invalid; a context has already "
+      "been allocated.");
 
   // Clearing a source.
   EXPECT_ERROR_MESSAGE(
       system_.ClearSource(id),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to ClearSource is invalid; a context has already been "
+      "allocated.");
 
   // Removing a frame.
   EXPECT_ERROR_MESSAGE(
       system_.RemoveFrame(id, FrameId::get_new_id()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RemoveFrame is invalid; a context has already been "
+      "allocated.");
 
   // Removing a geometry.
   EXPECT_ERROR_MESSAGE(
       system_.RemoveGeometry(id, GeometryId::get_new_id()),
       std::logic_error,
-      "Operation invalid; a context has already been allocated.");
+      "The call to RemoveGeometry is invalid; a context has already been "
+      "allocated.");
 }
 
 }  // namespace

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -1,0 +1,159 @@
+#include "drake/geometry/geometry_system.h"
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/test/expect_error_message.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/leaf_system.h"
+
+// Test of the unique GeometrySystem operations. GeometrySystem is mostly a thin
+// wrapper around GeometryWorld. It's purpose is to connect GeometryWorld to the
+// Drake ecosystem. As such, there will be no tests on functional logic but just
+// on that wrapping. For examples, queries simply extract a context from the
+// QueryHandle and pass it to the GeometryWorld method. As such, there is
+// nothing to test.
+
+namespace drake {
+namespace geometry {
+
+using systems::Context;
+using GSystem = GeometrySystem<double>;
+using std::make_unique;
+using std::unique_ptr;
+
+// Friend class for accessing GeometrySystem protected/private functionality.
+class GeometrySystemTester {
+ public:
+  static bool HasDirectFeedthrough(const GeometrySystem<double>& system,
+                                   int input_port, int output_port) {
+    return system.DoHasDirectFeedthrough(nullptr, input_port, output_port);
+  }
+};
+
+namespace {
+
+// Testing harness to facilitate working with/testing the GeometrySystem. Before
+// performing *any* queries in tests, `AllocateContext` must be explicitly
+// invoked in the test.
+
+class GeometrySystemTest : public ::testing::Test {
+ protected:
+  void AllocateContext() {
+    // TODO(SeanCurtis-TRI): This will probably have to be moved into an
+    // explicit call so it can be run *after* topology has been set.
+    context_ = system_.AllocateContext();
+  }
+
+  static std::unique_ptr<GeometryInstance<double>> make_sphere_instance(
+      double radius = 1.0) {
+    return make_unique<GeometryInstance<double>>();
+  }
+
+  GSystem system_;
+  // Ownership of context.
+  unique_ptr<Context<double>> context_;
+};
+
+// Test sources.
+
+// Tests registration using a default source name. Confirms that the source
+// registered and that a name is available.
+TEST_F(GeometrySystemTest, RegisterSourceDefaultName) {
+  SourceId id;
+  EXPECT_NO_THROW(id = system_.RegisterSource());
+  EXPECT_TRUE(id.is_valid());
+}
+
+// Tests registration using a specified source name. Confirms that the source
+// registered and that the name is available.
+TEST_F(GeometrySystemTest, RegisterSourceSpecifiedName) {
+  std::string name = "some_unique_name";
+  SourceId id;
+  EXPECT_NO_THROW(id = system_.RegisterSource(name));
+  EXPECT_TRUE(id.is_valid());
+}
+
+// Tests that sources cannot be registered after context allocation.
+TEST_F(GeometrySystemTest, PoseContextSourceRegistration) {
+  AllocateContext();
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterSource(),
+      std::logic_error,
+      "A context has been created for this system. Adding new geometry "
+      "sources is no longer possible.");
+}
+
+// Test topology changes (registration, removal, clearing, etc.)
+
+// Tests that topology operations (registration, removal, clearing, etc.) after
+// allocation is not allowed -- and an exception with an intelligible message is
+// thrown. The underlying handling of the *values* of the parameters is handled
+// in the GeometryState unit tests. GeometrySystem merely confirms the context
+// hasn't been allocated.
+TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
+  SourceId id = system_.RegisterSource();
+  AllocateContext();
+
+  // Attach frame to world.
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterFrame(
+          id, GeometryFrame<double>()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Attach frame to another frame.
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterFrame(
+          id, FrameId::get_new_id(),
+          GeometryFrame<double>()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Attach geometry to frame.
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterGeometry(
+          id, FrameId::get_new_id(), make_sphere_instance()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Attach geometry to another geometry.
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterGeometry(
+          id, GeometryId::get_new_id(), make_sphere_instance()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Attach anchored geometry to world.
+  EXPECT_ERROR_MESSAGE(
+      system_.RegisterAnchoredGeometry(id, make_sphere_instance()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Clearing a source.
+  EXPECT_ERROR_MESSAGE(
+      system_.ClearSource(id),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Removing a frame.
+  EXPECT_ERROR_MESSAGE(
+      system_.RemoveFrame(id, FrameId::get_new_id()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+
+  // Removing a geometry.
+  EXPECT_ERROR_MESSAGE(
+      system_.RemoveGeometry(id, GeometryId::get_new_id()),
+      std::logic_error,
+      "Operation invalid; a context has already been allocated.");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This is the first of a sequence of PRs which will introduce GeometrySystem (and GeometryWorld) into Drake. The approach is a top-down approach. Stubbed interfaces which will get gradually filled in (that we can work from the public API inward -- no point PRing the details if they support an insufferable API).

The public API is too large to fit into a PR. So, the public API is going to be broken into several parts (see issue #6578 for details).  This is the first -- the `GeometrySystem` and the API responsible for registering geometry.

NOTE: Although github is reporting 764 changes, here's the actual breakdown. 364 lines of code and 279 lines of comment. It's probably not worth trying to whittle this down any further.
```
| file                    | blank | comment | code | cloc total |
|-------------------------+-------+---------+------+------------|
| BUILD                   |       |         |   54 |         54 |
| geometry_frame.h        |     9 |      17 |   13 |         39 |
| geometry_ids.h          |     6 |       4 |    9 |         19 |
| geometry_isntance.cc    |     3 |       1 |    6 |         10 |
| geometry_instance.h     |     5 |       7 |   12 |         24 |
| geometry_system.cc      |    18 |      16 |   94 |        128 |
| geometry_system.h       |    43 |     195 |   42 |        280 |
| expect_error_message.h  |    10 |       6 |   35 |         51 |
| geometry_system_test.cc |    27 |      33 |   99 |        159 |
|-------------------------+-------+---------+------+------------|
| TOTAL                   |   121 |     279 |  364 |        764 |
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6579)
<!-- Reviewable:end -->
