### PR TITLE
Add a simple 1D bouncing ball scenario

### DIFF
--- a/drake/examples/geometry_world/BUILD
+++ b/drake/examples/geometry_world/BUILD
@@ -2,7 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library", "drake_cc_binary")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 drake_cc_library(
     name = "bouncing_ball_vector",
@@ -19,7 +24,7 @@ drake_cc_library(
     hdrs = ["bouncing_ball_plant.h"],
     deps = [
         ":bouncing_ball_vector",
-        "//drake/systems/framework",
+        "//drake/systems/framework:leaf_system",
     ],
 )
 

--- a/drake/examples/geometry_world/BUILD
+++ b/drake/examples/geometry_world/BUILD
@@ -1,0 +1,41 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:cpplint.bzl", "cpplint")
+load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library", "drake_cc_binary")
+
+drake_cc_library(
+    name = "bouncing_ball_vector",
+    srcs = ["gen/bouncing_ball_vector.cc"],
+    hdrs = ["gen/bouncing_ball_vector.h"],
+    deps = [
+        "//drake/systems/framework:vector",
+    ],
+)
+
+drake_cc_library(
+    name = "bouncing_ball_plant",
+    srcs = ["bouncing_ball_plant.cc"],
+    hdrs = ["bouncing_ball_plant.h"],
+    deps = [
+        ":bouncing_ball_vector",
+        "//drake/systems/framework",
+    ],
+)
+
+drake_cc_binary(
+    name = "bouncing_ball_run_dynamics",
+    testonly = 1,
+    srcs = ["bouncing_ball_run_dynamics.cc"],
+    add_test_rule = 1,
+    deps = [
+        ":bouncing_ball_plant",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/lcm",
+        "//drake/systems/primitives:constant_vector_source",
+        "//drake/systems/primitives:signal_logger",
+    ],
+)
+
+cpplint()

--- a/drake/examples/geometry_world/bouncing_ball_gen.sh
+++ b/drake/examples/geometry_world/bouncing_ball_gen.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Generates the source files for the BouncingBallStateVector.
+
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+mydir=$(dirname "$me")
+examples=$(dirname "$mydir")
+drake=$(dirname "$examples")
+
+namespace="drake::examples::bouncing_ball"
+
+source $drake/tools/lcm_vector_gen.sh
+
+gen_vector "bouncing ball vector" z zdot

--- a/drake/examples/geometry_world/bouncing_ball_plant.cc
+++ b/drake/examples/geometry_world/bouncing_ball_plant.cc
@@ -1,0 +1,68 @@
+#include "drake/examples/geometry_world/bouncing_ball_plant.h"
+
+#include <algorithm>
+
+namespace drake {
+namespace examples {
+namespace bouncing_ball {
+
+using systems::Context;
+using systems::Value;
+using std::make_unique;
+
+template <typename T>
+BouncingBallPlant<T>::BouncingBallPlant(const Vector2<T>& init_position)
+    : init_position_(init_position) {
+  state_port_ =
+      this->DeclareVectorOutputPort(BouncingBallVector<T>(),
+                                    &BouncingBallPlant::CopyStateToOutput)
+          .get_index();
+
+    this->DeclareContinuousState(
+      BouncingBallVector<T>(),
+      1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
+  static_assert(BouncingBallVectorIndices::kNumCoordinates == 1 + 1, "");
+}
+
+template <typename T>
+BouncingBallPlant<T>::~BouncingBallPlant() {}
+
+template <typename T>
+const systems::OutputPort<T>&
+BouncingBallPlant<T>::get_state_output_port() const {
+  return systems::System<T>::get_output_port(state_port_);
+}
+
+// Updates the state output port.
+template <typename T>
+void BouncingBallPlant<T>::CopyStateToOutput(
+    const Context<T>& context,
+    BouncingBallVector<T>* state_output_vector) const {
+  state_output_vector->set_value(get_state(context).get_value());
+}
+
+// Compute the actual physics.
+template <typename T>
+void BouncingBallPlant<T>::DoCalcTimeDerivatives(
+    const systems::Context<T>& context,
+    systems::ContinuousState<T>* derivatives) const {
+  using std::max;
+
+  const BouncingBallVector<T>& state = get_state(context);
+  BouncingBallVector<T>* derivative_vector = get_mutable_state(derivatives);
+
+  derivative_vector->set_z(state.zdot());
+
+  const T& x = -state.z();  // Penetration depth, > 0 at penetration.
+  const T& xdot = -state.zdot();  // Penetration rate, > 0 during penetration.
+
+  const T fN = max(0.0, k_ * x * (1.0 - d_ * xdot));
+
+  derivative_vector->set_zdot((- m_ * g_ + fN));
+}
+
+template class BouncingBallPlant<double>;
+
+}  // namespace bouncing_ball
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/geometry_world/bouncing_ball_plant.cc
+++ b/drake/examples/geometry_world/bouncing_ball_plant.cc
@@ -53,12 +53,13 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
 
   derivative_vector->set_z(state.zdot());
 
-  const T& x = -state.z();  // Penetration depth, > 0 at penetration.
-  const T& xdot = -state.zdot();  // Penetration rate, > 0 during penetration.
+  const T& x = -state.z();        // Penetration depth, > 0 at penetration.
+  const T& xdot = -state.zdot();  // Penetration rate, > 0 implies increasing
+                                  // penetration.
 
   const T fN = max(0.0, k_ * x * (1.0 - d_ * xdot));
 
-  derivative_vector->set_zdot((- m_ * g_ + fN));
+  derivative_vector->set_zdot((- m_ * g_ + fN) / m_);
 }
 
 template class BouncingBallPlant<double>;

--- a/drake/examples/geometry_world/bouncing_ball_plant.h
+++ b/drake/examples/geometry_world/bouncing_ball_plant.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/examples/geometry_world/gen/bouncing_ball_vector.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace bouncing_ball {
+
+/** A model of a bouncing ball with Hunt-Crossley compliant contact model.
+
+ @tparam T The vector element type, which must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double */
+template <typename T>
+class BouncingBallPlant : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BouncingBallPlant)
+
+  explicit BouncingBallPlant(const Vector2<T>& init_position);
+  ~BouncingBallPlant() override;
+
+  using MyContext = systems::Context<T>;
+  using MyContinuousState = systems::ContinuousState<T>;
+  using MyOutput = systems::SystemOutput<T>;
+
+  /** Returns the port to output state. */
+  const systems::OutputPort<T>& get_state_output_port() const;
+
+  void set_z(MyContext* context, const T& z) const {
+    get_mutable_state(context)->set_z(z);
+  }
+
+  void set_zdot(MyContext* context, const T& zdot) const {
+    get_mutable_state(context)->set_zdot(zdot);
+  }
+
+  /** Mass in kg. */
+  T m() const { return m_; }
+
+  /** Stiffness constant. */
+  T k() const {return k_; }
+
+  /** Hunt-Crossley's dissipation factor. */
+  T d() const {return d_; }
+
+  /** Gravity in m/s^2. */
+  T g() const { return g_; }
+
+ private:
+  // Callback for writing the state vector to an output.
+  void CopyStateToOutput(const MyContext& context,
+                         BouncingBallVector<T>* state_output_vector) const;
+
+  void DoCalcTimeDerivatives(const MyContext& context,
+                             MyContinuousState* derivatives) const override;
+
+  static const BouncingBallVector<T>& get_state(
+      const MyContinuousState& cstate) {
+    return dynamic_cast<const BouncingBallVector<T>&>(cstate.get_vector());
+  }
+
+  static BouncingBallVector<T>* get_mutable_state(
+      MyContinuousState* cstate) {
+    return dynamic_cast<BouncingBallVector<T>*>(cstate->get_mutable_vector());
+  }
+
+  BouncingBallVector<T>* get_mutable_state_output(MyOutput *output) const {
+    return dynamic_cast<BouncingBallVector<T>*>(
+        output->GetMutableVectorData(state_port_));
+  }
+
+  static const BouncingBallVector<T>& get_state(const MyContext& context) {
+    return get_state(*context.get_continuous_state());
+  }
+
+  static BouncingBallVector<T>* get_mutable_state(MyContext* context) {
+    return get_mutable_state(context->get_mutable_continuous_state());
+  }
+
+  const Vector2<T> init_position_;
+
+  int state_port_;
+
+  const double diameter_{0.1};  // Ball diameter, just for visualization.
+  const double m_{0.1};   // kg
+  const double g_{9.81};  // m/s^2
+  // Stiffness constant [N/m]. Calculated so that under its own weight the ball
+  // penetrates the plane by 1 mm when the contact force and gravitational
+  // force are in equilibrium.
+  const double k_{m_* g_ / 0.001};
+  // Hunt-Crossley's dissipation factor.
+  const double d_{0.0};  // [s/m]
+};
+
+}  // namespace bouncing_ball
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/drake/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -1,0 +1,45 @@
+#include "drake/examples/geometry_world/bouncing_ball_plant.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace bouncing_ball {
+namespace {
+
+using systems::InputPortDescriptor;
+
+int do_main() {
+  systems::DiagramBuilder<double> builder;
+  auto bouncing_ball = builder.AddSystem<BouncingBallPlant>(
+      Vector2<double>(0.25, 0.25));
+  bouncing_ball->set_name("BouncingBall1");
+
+  auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+  auto init_ball = [&](BouncingBallPlant<double>* system,
+                             double z, double zdot) {
+    systems::Context<double>& ball_context =
+        diagram->GetMutableSubsystemContext(*system,
+            simulator.get_mutable_context());
+    system->set_z(&ball_context, z);
+    system->set_zdot(&ball_context, zdot);
+  };
+  init_ball(bouncing_ball, 0.3, 0.);
+
+  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.Initialize();
+  simulator.StepTo(10);
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace bouncing_ball
+}  // namespace examples
+}  // namespace drake
+
+int main() {
+  return drake::examples::bouncing_ball::do_main();
+}

--- a/drake/examples/geometry_world/gen/bouncing_ball_vector.cc
+++ b/drake/examples/geometry_world/gen/bouncing_ball_vector.cc
@@ -1,0 +1,25 @@
+#include "drake/examples/geometry_world/gen/bouncing_ball_vector.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace drake {
+namespace examples {
+namespace bouncing_ball {
+
+const int BouncingBallVectorIndices::kNumCoordinates;
+const int BouncingBallVectorIndices::kZ;
+const int BouncingBallVectorIndices::kZdot;
+
+const std::vector<std::string>&
+BouncingBallVectorIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "z", "zdot",
+      });
+  return coordinates.access();
+}
+
+}  // namespace bouncing_ball
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/geometry_world/gen/bouncing_ball_vector.h
+++ b/drake/examples/geometry_world/gen/bouncing_ball_vector.h
@@ -1,0 +1,83 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "drake/common/never_destroyed.h"
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace examples {
+namespace bouncing_ball {
+
+/// Describes the row indices of a BouncingBallVector.
+struct BouncingBallVectorIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 2;
+
+  // The index of each individual coordinate.
+static const int kZ = 0;
+static const int kZdot = 1;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BouncingBallVectorIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class BouncingBallVector : public systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef BouncingBallVectorIndices K;
+
+  /// Default constructor.  Sets all rows to zero.
+  BouncingBallVector() : systems::BasicVector<T>(K::kNumCoordinates) {
+    this->SetFromVector(VectorX<T>::Zero(K::kNumCoordinates));
+  }
+
+  BouncingBallVector<T>* DoClone() const override {
+    return new BouncingBallVector;
+  }
+
+  /// @name Getters and Setters
+  //@{
+  /// z
+  const T& z() const { return this->GetAtIndex(K::kZ); }
+  void set_z(const T& z) {
+    this->SetAtIndex(K::kZ, z);
+  }
+  /// zdot
+  const T& zdot() const { return this->GetAtIndex(K::kZdot); }
+  void set_zdot(const T& zdot) {
+    this->SetAtIndex(K::kZdot, zdot);
+  }
+  //@}
+
+  /// See BouncingBallVectorIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BouncingBallVectorIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(z());
+    result = result && !isnan(zdot());
+    return result;
+  }
+};
+
+}  // namespace bouncing_ball
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
This will serve as the initial example of using `GeometrySystem` in a Drake diagram. Currently, it does not *depend* on `GeometrySystem`. As that class's implementation increases in master, this example will expand to incorporate that functionality.

The scenario is that of a ball with a single degree of freedom (z-position). It interacts with an implicitly defined half space (`z = 0`). It bounces on that half plane based on a complaint contact model. Currently, 
there is no visualization or other feedback. This will come into place as the various `GeometrySystem` features come online.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6582)
<!-- Reviewable:end -->
