### PR TITLE
Getting Rid of a GCC Warning

### DIFF
--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -386,7 +386,12 @@ bool ImplicitEulerIntegrator<T>::CalcMatrices(const T& tf, const T& dt,
 // Helper method to keep UBSan happy when a division by zero is not
 // unexpected.
 template <typename T>
+#ifdef __clang__
 __attribute__((no_sanitize("float-divide-by-zero")))
+#elif defined(__GNUC__)
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78204
+__attribute__((no_sanitize_undefined))
+#endif
 T divide_allowing_by_zero(const T& n, const T& d) {
   DRAKE_ASSERT(!(d == T{0.0} && n == T{0.0}));
   return n / d;


### PR DESCRIPTION
The warning:

`/home/ubuntu/workspace/linux-xenial-gcc-ninja-experimental-open-source-debug/drake/../drake/systems/analysis/implicit_euler_integrator-inl.h:390:49: warning: ‘no_sanitize’ attribute directive ignored [-Wattributes]`
due to https://github.com/RobotLocomotion/drake/pull/6561

Before: https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-linux-xenial-gcc-experimental-open-source-release-5278&field2=buildstarttime&compare2=84&value2=now

After: https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-linux-xenial-gcc-experimental-open-source-release-5300&field2=buildstarttime&compare2=84&value2=now

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6583)
<!-- Reviewable:end -->
