### PR TITLE
Global ik add joint limits

### DIFF
--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -19,6 +19,7 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
+        "@gtest//:main",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
         "//drake/multibody:global_inverse_kinematics",
@@ -66,6 +67,18 @@ drake_cc_googletest(
     ],
     # Excluding because an assertion fails in LLVM code. Issue #6179.
     tags = gurobi_test_tags() + ["no_tsan"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "global_inverse_kinematics_feasible_posture_test",
+    srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = ["gurobi"],
     deps = [
         ":global_inverse_kinematics_test_util",
     ],

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -72,16 +72,17 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
-    name = "global_inverse_kinematics_feasible_posture_test",
-    srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
-    data = [
-        "//drake/manipulation/models/iiwa_description:models",
-    ],
-    tags = ["gurobi"],
-    deps = [
-        ":global_inverse_kinematics_test_util",
-    ],
-)
+#drake_cc_googletest(
+#    name = "global_inverse_kinematics_feasible_posture_test",
+#    size = "medium",
+#    srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
+#    data = [
+#        "//drake/manipulation/models/iiwa_description:models",
+#    ],
+#    tags = ["gurobi"],
+#    deps = [
+#        ":global_inverse_kinematics_test_util",
+#    ],
+#)
 
 cpplint()

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -19,14 +19,13 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
-        "@gtest//:main",
+        "@gtest//:without_main",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
         "//drake/multibody:global_inverse_kinematics",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
-        "@gtest//:without_main",
     ],
 )
 
@@ -72,17 +71,17 @@ drake_cc_googletest(
     ],
 )
 
-#drake_cc_googletest(
-#    name = "global_inverse_kinematics_feasible_posture_test",
-#    size = "medium",
-#    srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
-#    data = [
-#        "//drake/manipulation/models/iiwa_description:models",
-#    ],
-#    tags = ["gurobi"],
-#    deps = [
-#        ":global_inverse_kinematics_test_util",
-#    ],
-#)
+drake_cc_googletest(
+    name = "global_inverse_kinematics_feasible_posture_test",
+    size = "medium",
+    srcs = ["test/global_inverse_kinematics_feasible_posture_test.cc"],
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    tags = gurobi_test_tags() + ["no_tsan"],
+    deps = [
+        ":global_inverse_kinematics_test_util",
+    ],
+)
 
 cpplint()

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -19,13 +19,13 @@ drake_cc_library(
         "test/global_inverse_kinematics_test_util.h",
     ],
     deps = [
-        "@gtest//:without_main",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
         "//drake/multibody:global_inverse_kinematics",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
+        "@gtest//:without_main",
     ],
 )
 

--- a/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -1,0 +1,64 @@
+#include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
+
+#include <cmath>
+
+namespace drake {
+namespace multibody {
+TEST_F(KukaTest, FeasiblePostureTest) {
+  // For feasible postures, check if global IK also thinks it is a feasible
+  // solution. For each posture q, we compute the forward kinematics, and
+  // constraint the body pose in global IK, to the pose from the forward
+  // kinematics. global IK should always think the problem is feasible.
+
+  // First sample some postures, within the joint limits.
+  const int kNumSamplePerJoint = 2;
+  Eigen::Matrix<double, 7, kNumSamplePerJoint> q_grid;
+  for (int i = 0; i < 7; ++i) {
+    q_grid(i, 0) = rigid_body_tree_->joint_limit_min(i) * 0.95 + rigid_body_tree_->joint_limit_max(i) * 0.05;
+    q_grid(i, 1) = rigid_body_tree_->joint_limit_min(i) * 0.5 + rigid_body_tree_->joint_limit_max(i) * 0.5;
+  }
+  KinematicsCache<double> cache = rigid_body_tree_->CreateKinematicsCache();
+
+  std::array<solvers::Binding<solvers::BoundingBoxConstraint>, 11> body_position_constraint;
+  std::array<solvers::Binding<solvers::BoundingBoxConstraint>, 11> body_orientation_constraint;
+  for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
+    body_position_constraint[body - 1] = global_ik_.AddBoundingBoxConstraint(0, 0, global_ik_.body_position(body));
+    const auto& body_rotmat = global_ik_.body_rotation_matrix(body);
+    Eigen::Matrix<symbolic::Variable, 9, 1> body_rotmat_flat;
+    body_rotmat_flat << body_rotmat.col(0), body_rotmat.col(1), body_rotmat.col(2);
+    body_orientation_constraint[body - 1] = global_ik_.AddBoundingBoxConstraint(0, 0, body_rotmat_flat);
+  }
+
+  // Now generate the feasible posture q
+  for (int i = 0; i < static_cast<int>(std::pow<int>(kNumSamplePerJoint, 7)); ++i) {
+    Eigen::Matrix<double, 7, 1> q;
+    for (int joint = 0; joint < 7; ++joint) {
+      q(joint) = (1 << joint) && i ? q_grid(joint, 0) : q_grid(joint, 1);
+    }
+    cache.initialize(q);
+    rigid_body_tree_->doKinematics(cache);
+    for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
+      const Eigen::Isometry3d body_pose = rigid_body_tree_->CalcBodyPoseInWorldFrame(cache, rigid_body_tree_->get_body(body));
+      const Eigen::Vector3d pos_lb = body_pose.translation() - 0.01 * Eigen::Vector3d::Ones();
+      const Eigen::Vector3d pos_ub = body_pose.translation() + 0.01 * Eigen::Vector3d::Ones();
+      body_position_constraint[body - 1].constraint()->UpdateLowerBound(pos_lb);
+      body_position_constraint[body - 1].constraint()->UpdateUpperBound(pos_ub);
+      Eigen::Matrix<double, 9, 1> rotmat_lb_flat;
+      Eigen::Matrix<double, 9, 1> rotmat_ub_flat;
+      rotmat_lb_flat << body_pose.linear().col(0) - 0.01 * Eigen::Vector3d::Ones(),
+      body_pose.linear().col(1) - 0.01 * Eigen::Vector3d::Ones(),
+      body_pose.linear().col(2) - 0.01 * Eigen::Vector3d::Ones();
+      rotmat_ub_flat << body_pose.linear().col(0) + 0.01 * Eigen::Vector3d::Ones(),
+          body_pose.linear().col(1) + 0.01 * Eigen::Vector3d::Ones(),
+          body_pose.linear().col(2) + 0.01 * Eigen::Vector3d::Ones();
+    }
+  }
+}
+class KukaFeasiblePostureTest : public KukaTest {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KukaFeasiblePostureTest)
+
+  KukaFeasiblePostureTest
+};
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -1,4 +1,5 @@
 #include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
+#include "drake/solvers/gurobi_solver.h"
 
 #include <cmath>
 
@@ -14,23 +15,33 @@ TEST_F(KukaTest, FeasiblePostureTest) {
   const int kNumSamplePerJoint = 2;
   Eigen::Matrix<double, 7, kNumSamplePerJoint> q_grid;
   for (int i = 0; i < 7; ++i) {
-    q_grid(i, 0) = rigid_body_tree_->joint_limit_min(i) * 0.95 + rigid_body_tree_->joint_limit_max(i) * 0.05;
-    q_grid(i, 1) = rigid_body_tree_->joint_limit_min(i) * 0.5 + rigid_body_tree_->joint_limit_max(i) * 0.5;
+    q_grid(i, 0) = rigid_body_tree_->joint_limit_min(i) * 0.95
+        + rigid_body_tree_->joint_limit_max(i) * 0.05;
+    q_grid(i, 1) = rigid_body_tree_->joint_limit_min(i) * 0.5
+        + rigid_body_tree_->joint_limit_max(i) * 0.5;
   }
   KinematicsCache<double> cache = rigid_body_tree_->CreateKinematicsCache();
 
-  std::array<solvers::Binding<solvers::BoundingBoxConstraint>, 11> body_position_constraint;
-  std::array<solvers::Binding<solvers::BoundingBoxConstraint>, 11> body_orientation_constraint;
+  std::vector<solvers::Binding<solvers::BoundingBoxConstraint>>
+      body_position_constraint;
+  std::vector<solvers::Binding<solvers::BoundingBoxConstraint>>
+      body_orientation_constraint;
   for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
-    body_position_constraint[body - 1] = global_ik_.AddBoundingBoxConstraint(0, 0, global_ik_.body_position(body));
-    const auto& body_rotmat = global_ik_.body_rotation_matrix(body);
+    body_position_constraint.push_back(global_ik_.AddBoundingBoxConstraint(0,
+                                                                             0,
+                                                                             global_ik_.body_position(
+                                                                                 body)));
+    const auto &body_rotmat = global_ik_.body_rotation_matrix(body);
     Eigen::Matrix<symbolic::Variable, 9, 1> body_rotmat_flat;
-    body_rotmat_flat << body_rotmat.col(0), body_rotmat.col(1), body_rotmat.col(2);
-    body_orientation_constraint[body - 1] = global_ik_.AddBoundingBoxConstraint(0, 0, body_rotmat_flat);
+    body_rotmat_flat << body_rotmat.col(0), body_rotmat.col(1), body_rotmat.col(
+        2);
+    body_orientation_constraint.push_back(
+        global_ik_.AddBoundingBoxConstraint(0, 0, body_rotmat_flat));
   }
 
   // Now generate the feasible posture q
-  for (int i = 0; i < static_cast<int>(std::pow<int>(kNumSamplePerJoint, 7)); ++i) {
+  for (int i = 0; i < static_cast<int>(std::pow<int>(kNumSamplePerJoint, 7));
+       ++i) {
     Eigen::Matrix<double, 7, 1> q;
     for (int joint = 0; joint < 7; ++joint) {
       q(joint) = (1 << joint) && i ? q_grid(joint, 0) : q_grid(joint, 1);
@@ -38,27 +49,37 @@ TEST_F(KukaTest, FeasiblePostureTest) {
     cache.initialize(q);
     rigid_body_tree_->doKinematics(cache);
     for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
-      const Eigen::Isometry3d body_pose = rigid_body_tree_->CalcBodyPoseInWorldFrame(cache, rigid_body_tree_->get_body(body));
-      const Eigen::Vector3d pos_lb = body_pose.translation() - 0.01 * Eigen::Vector3d::Ones();
-      const Eigen::Vector3d pos_ub = body_pose.translation() + 0.01 * Eigen::Vector3d::Ones();
+      const Eigen::Isometry3d body_pose =
+          rigid_body_tree_->CalcBodyPoseInWorldFrame(cache,
+                                                     rigid_body_tree_->get_body(
+                                                         body));
+      const Eigen::Vector3d
+          pos_lb = body_pose.translation() - 0.01 * Eigen::Vector3d::Ones();
+      const Eigen::Vector3d
+          pos_ub = body_pose.translation() + 0.01 * Eigen::Vector3d::Ones();
       body_position_constraint[body - 1].constraint()->UpdateLowerBound(pos_lb);
       body_position_constraint[body - 1].constraint()->UpdateUpperBound(pos_ub);
       Eigen::Matrix<double, 9, 1> rotmat_lb_flat;
       Eigen::Matrix<double, 9, 1> rotmat_ub_flat;
-      rotmat_lb_flat << body_pose.linear().col(0) - 0.01 * Eigen::Vector3d::Ones(),
-      body_pose.linear().col(1) - 0.01 * Eigen::Vector3d::Ones(),
-      body_pose.linear().col(2) - 0.01 * Eigen::Vector3d::Ones();
-      rotmat_ub_flat << body_pose.linear().col(0) + 0.01 * Eigen::Vector3d::Ones(),
+      rotmat_lb_flat
+          << body_pose.linear().col(0) - 0.01 * Eigen::Vector3d::Ones(),
+          body_pose.linear().col(1) - 0.01 * Eigen::Vector3d::Ones(),
+          body_pose.linear().col(2) - 0.01 * Eigen::Vector3d::Ones();
+      rotmat_ub_flat
+          << body_pose.linear().col(0) + 0.01 * Eigen::Vector3d::Ones(),
           body_pose.linear().col(1) + 0.01 * Eigen::Vector3d::Ones(),
           body_pose.linear().col(2) + 0.01 * Eigen::Vector3d::Ones();
+      body_orientation_constraint[body - 1].constraint()->UpdateLowerBound(
+          rotmat_lb_flat);
+      body_orientation_constraint[body - 1].constraint()->UpdateUpperBound(
+          rotmat_ub_flat);
+
+      solvers::GurobiSolver gurobi_solver;
+      const solvers::SolutionResult
+          sol_result = gurobi_solver.Solve(global_ik_);
+      EXPECT_EQ(sol_result, solvers::SolutionResult::kSolutionFound);
     }
   }
 }
-class KukaFeasiblePostureTest : public KukaTest {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(KukaFeasiblePostureTest)
-
-  KukaFeasiblePostureTest
-};
 }  // namespace multibody
 }  // namespace drake

--- a/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -12,13 +12,15 @@ TEST_F(KukaTest, FeasiblePostureTest) {
   // kinematics. global IK should always think the problem is feasible.
 
   // First sample some postures, within the joint limits.
-  const int kNumSamplePerJoint = 2;
+  const int kNumSamplePerJoint = 3;
   Eigen::Matrix<double, 7, kNumSamplePerJoint> q_grid;
   for (int i = 0; i < 7; ++i) {
     q_grid(i, 0) = rigid_body_tree_->joint_limit_min(i) * 0.95
         + rigid_body_tree_->joint_limit_max(i) * 0.05;
     q_grid(i, 1) = rigid_body_tree_->joint_limit_min(i) * 0.5
         + rigid_body_tree_->joint_limit_max(i) * 0.5;
+    q_grid(i, 2) = rigid_body_tree_->joint_limit_min(i) * 0.05
+        + rigid_body_tree_->joint_limit_max(i) * 0.95;
   }
   KinematicsCache<double> cache = rigid_body_tree_->CreateKinematicsCache();
 
@@ -40,12 +42,30 @@ TEST_F(KukaTest, FeasiblePostureTest) {
   }
 
   // Now generate the feasible posture q
-  for (int i = 0; i < static_cast<int>(std::pow<int>(kNumSamplePerJoint, 7));
-       ++i) {
+  // q(i) = q_grid(i, joint_grid_idx(i));
+  Eigen::Matrix<int, 7, 1> joint_grid_idx;
+  joint_grid_idx.setZero();
+  int num_q = std::pow<int>(kNumSamplePerJoint, 7);
+  int q_count = 0;
+  while (q_count < num_q) {
     Eigen::Matrix<double, 7, 1> q;
     for (int joint = 0; joint < 7; ++joint) {
-      q(joint) = (1 << joint) && i ? q_grid(joint, 0) : q_grid(joint, 1);
+      q(joint) = q_grid(joint, joint_grid_idx(joint));
     }
+    // Now increment joint_grid_idx;
+    for (int joint = 0; joint < 7; ++joint) {
+      ++joint_grid_idx(joint);
+      if (joint_grid_idx(joint) >= kNumSamplePerJoint) {
+        joint_grid_idx(joint) -= kNumSamplePerJoint;
+        if (joint < 6) {
+          ++joint_grid_idx(joint + 1);
+        }
+      }
+    }
+    ++q_count;
+
+    // Now compute the forward kinematics for posture q, and then fix the body
+    // position and orientation of the global IK to the body pose of q.
     cache.initialize(q);
     rigid_body_tree_->doKinematics(cache);
     for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
@@ -54,21 +74,21 @@ TEST_F(KukaTest, FeasiblePostureTest) {
                                                      rigid_body_tree_->get_body(
                                                          body));
       const Eigen::Vector3d
-          pos_lb = body_pose.translation() - 0.01 * Eigen::Vector3d::Ones();
+          pos_lb = body_pose.translation();
       const Eigen::Vector3d
-          pos_ub = body_pose.translation() + 0.01 * Eigen::Vector3d::Ones();
+          pos_ub = body_pose.translation();
       body_position_constraint[body - 1].constraint()->UpdateLowerBound(pos_lb);
       body_position_constraint[body - 1].constraint()->UpdateUpperBound(pos_ub);
       Eigen::Matrix<double, 9, 1> rotmat_lb_flat;
       Eigen::Matrix<double, 9, 1> rotmat_ub_flat;
       rotmat_lb_flat
-          << body_pose.linear().col(0) - 0.01 * Eigen::Vector3d::Ones(),
-          body_pose.linear().col(1) - 0.01 * Eigen::Vector3d::Ones(),
-          body_pose.linear().col(2) - 0.01 * Eigen::Vector3d::Ones();
+          << body_pose.linear().col(0),
+          body_pose.linear().col(1),
+          body_pose.linear().col(2);
       rotmat_ub_flat
-          << body_pose.linear().col(0) + 0.01 * Eigen::Vector3d::Ones(),
-          body_pose.linear().col(1) + 0.01 * Eigen::Vector3d::Ones(),
-          body_pose.linear().col(2) + 0.01 * Eigen::Vector3d::Ones();
+          << body_pose.linear().col(0),
+          body_pose.linear().col(1),
+          body_pose.linear().col(2);
       body_orientation_constraint[body - 1].constraint()->UpdateLowerBound(
           rotmat_lb_flat);
       body_orientation_constraint[body - 1].constraint()->UpdateUpperBound(

--- a/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -73,12 +73,11 @@ TEST_F(KukaTest, FeasiblePostureTest) {
           rotmat_lb_flat);
       body_orientation_constraint[body - 1].constraint()->UpdateUpperBound(
           rotmat_ub_flat);
-
-      solvers::GurobiSolver gurobi_solver;
-      const solvers::SolutionResult
-          sol_result = gurobi_solver.Solve(global_ik_);
-      EXPECT_EQ(sol_result, solvers::SolutionResult::kSolutionFound);
     }
+    solvers::GurobiSolver gurobi_solver;
+    const solvers::SolutionResult
+        sol_result = gurobi_solver.Solve(global_ik_);
+    EXPECT_EQ(sol_result, solvers::SolutionResult::kSolutionFound);
   }
 }
 }  // namespace multibody

--- a/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_feasible_posture_test.cc
@@ -1,8 +1,6 @@
 #include "drake/multibody/dev/test/global_inverse_kinematics_test_util.h"
 #include "drake/solvers/gurobi_solver.h"
 
-#include <cmath>
-
 namespace drake {
 namespace multibody {
 TEST_F(KukaTest, FeasiblePostureTest) {
@@ -29,10 +27,8 @@ TEST_F(KukaTest, FeasiblePostureTest) {
   std::vector<solvers::Binding<solvers::BoundingBoxConstraint>>
       body_orientation_constraint;
   for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
-    body_position_constraint.push_back(global_ik_.AddBoundingBoxConstraint(0,
-                                                                             0,
-                                                                             global_ik_.body_position(
-                                                                                 body)));
+    body_position_constraint.push_back(global_ik_.AddBoundingBoxConstraint(
+        0, 0, global_ik_.body_position(body)));
     const auto &body_rotmat = global_ik_.body_rotation_matrix(body);
     Eigen::Matrix<symbolic::Variable, 9, 1> body_rotmat_flat;
     body_rotmat_flat << body_rotmat.col(0), body_rotmat.col(1), body_rotmat.col(
@@ -70,9 +66,8 @@ TEST_F(KukaTest, FeasiblePostureTest) {
     rigid_body_tree_->doKinematics(cache);
     for (int body = 1; body < rigid_body_tree_->get_num_bodies(); ++body) {
       const Eigen::Isometry3d body_pose =
-          rigid_body_tree_->CalcBodyPoseInWorldFrame(cache,
-                                                     rigid_body_tree_->get_body(
-                                                         body));
+          rigid_body_tree_->CalcBodyPoseInWorldFrame(
+              cache, rigid_body_tree_->get_body(body));
       const Eigen::Vector3d
           pos_lb = body_pose.translation();
       const Eigen::Vector3d

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -93,12 +93,6 @@ TEST_F(KukaTest, ReachableWithCost) {
 
     EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
-    // The position tolerance and the orientation tolerance is chosen
-    // according to the Gurobi solver tolerance.
-    double position_error = 1E-5;
-    double orientation_error = 2E-5;
-    CheckGlobalIKSolution(position_error, orientation_error);
-
     const Eigen::VectorXd q_w_cost =
         global_ik_.ReconstructGeneralizedPositionSolution();
     // There is extra error introduced from gurobi optimality condition and SVD,

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -93,6 +93,12 @@ TEST_F(KukaTest, ReachableWithCost) {
 
     EXPECT_EQ(sol_result, SolutionResult::kSolutionFound);
 
+    // The position tolerance and the orientation tolerance is chosen
+    // according to the Gurobi solver tolerance.
+    double position_error = 1E-5;
+    double orientation_error = 2E-5;
+    CheckGlobalIKSolution(position_error, orientation_error);
+    
     const Eigen::VectorXd q_w_cost =
         global_ik_.ReconstructGeneralizedPositionSolution();
     // There is extra error introduced from gurobi optimality condition and SVD,

--- a/drake/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -98,7 +98,7 @@ TEST_F(KukaTest, ReachableWithCost) {
     double position_error = 1E-5;
     double orientation_error = 2E-5;
     CheckGlobalIKSolution(position_error, orientation_error);
-    
+
     const Eigen::VectorXd q_w_cost =
         global_ik_.ReconstructGeneralizedPositionSolution();
     // There is extra error introduced from gurobi optimality condition and SVD,

--- a/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
+++ b/drake/multibody/dev/test/global_inverse_kinematics_test_util.cc
@@ -31,8 +31,6 @@ std::unique_ptr<RigidBodyTree<double>> ConstructKuka() {
       rigid_body_tree.get());
 
   AddFlatTerrainToWorld(rigid_body_tree.get());
-  // Manually change the joint limits.
-  rigid_body_tree->joint_limit_min(6) = -2.1 * M_PI;
   return rigid_body_tree;
 }
 

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -181,19 +181,19 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 const Matrix3d rotmat_joint_offset =
                     Eigen::AngleAxisd((joint_lb + joint_ub) / 2, axis_F)
                         .toRotationMatrix();
-                if (!robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
-                  // joint_limit_expr is going to be within the Lorentz cone.
-                  Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
-                  joint_limit_expr(0) = 2 * sin(joint_bound / 2);
-                  for (int j = 0; j < static_cast<int>(v.size()); ++j) {
-                    // joint_limit_expr.tail<3> is
-                    // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
-                    joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
-                        R_WB_[parent_idx] * X_PF.linear() *
-                            rotmat_joint_offset * v[j];
-                    AddLorentzConeConstraint(joint_limit_expr);
-                  }
-                } else {
+
+                // joint_limit_expr is going to be within the Lorentz cone.
+                Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
+                joint_limit_expr(0) = 2 * sin(joint_bound / 2);
+                for (int j = 0; j < static_cast<int>(v.size()); ++j) {
+                  // joint_limit_expr.tail<3> is
+                  // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
+                  joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
+                      R_WB_[parent_idx] * X_PF.linear() *
+                          rotmat_joint_offset * v[j];
+                  AddLorentzConeConstraint(joint_limit_expr);
+                }
+                if(robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
                   // If the parent body is rigidly fixed to the world. Then we
                   // can impose a tighter linear constraint. Based on the
                   // derivation above, we have

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -182,12 +182,17 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                     Eigen::AngleAxisd((joint_lb + joint_ub) / 2, axis_F)
                         .toRotationMatrix();
 
-                // joint_limit_expr.tail<3> is
-                // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
-                joint_limit_expr.tail<3>() = R_WB_[body_idx] * v_C -
-                                             R_WB_[parent_idx] * X_PF.linear() *
-                                                 rotmat_joint_offset * v_C;
-                AddLorentzConeConstraint(joint_limit_expr);
+                std::array<Eigen::Vector3d, 2> v = {{v_C, axis_F.cross(v_C)}};
+                v[1] /= v[1].norm();
+                for (int j = 0; j < static_cast<int>(v.size()); ++j) {
+                  // joint_limit_expr.tail<3> is
+                  // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
+                  joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
+                      R_WB_[parent_idx] * X_PF.linear() *
+                          rotmat_joint_offset * v[j];
+                  AddLorentzConeConstraint(joint_limit_expr);
+                }
+
               }
             } else {
               // TODO(hongkai.dai): Add prismatic and helical joint.

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -137,9 +137,9 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 // If the rotation angle θ satisfies
                 // a <= θ <= b
                 // This is equivalent to
-                // -(b-a)/2 <= θ - (a+b)/2 <= (b-a)/2
-                // where (a+b)/2 is the joint offset, such that the bounds on
-                // θ - (a+b)/2 are symmetric.
+                // -α <= θ - (a+b)/2 <= α
+                // where α = (b-a) / 2, (a+b) / 2 is the joint offset, such that
+                // the bounds on β = θ - (a+b)/2 are symmetric.
                 // We use the following notation:
                 // R_WP     The rotation matrix of parent frame `P` to world
                 //          frame `W`.
@@ -147,18 +147,18 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 //          frame `W`.
                 // R_PF     The rotation matrix of joint frame `F` to parent
                 //          frame `P`.
-                // R(k, θ)  The rotation matrix along joint axis k by angle θ.
+                // R(k, β)  The rotation matrix along joint axis k by angle β.
                 // The kinematics constraint is
                 // R_WP * R_PJ * R(k, θ) = R_WC.
                 // This is equivalent to
-                // R_WP * R_PF * R(k, (a+b)/2) * R(k, θ-(a+b)/2)) = R_WC.
-                // So to constrain that -(b-a)/2 <= θ - (a+b)/2 <= (b-a)/2,
+                // R_WP * R_PF * R(k, (a+b)/2) * R(k, β)) = R_WC.
+                // So to constrain that -α <= β <= α,
                 // we can constrain the angle between the two vectors
                 // R_WC * v and R_WP * R_PF * R(k,(a+b)/2) * v is no larger than
-                // (b-a)/2, where v is a unit length vector perpendicular to
+                // α, where v is a unit length vector perpendicular to
                 // the rotation axis k, in the joint frame.
                 // Thus we can constrain that
-                // |R_WC*v - R_WP * R_PF * R(k,(a+b)/2)*v | <= 2*sin ((b-a) / 4)
+                // |R_WC*v - R_WP * R_PF * R(k,(a+b)/2)*v | <= 2*sin (α / 2)
                 // as we explained above.
 
                 // First generate a vector v_C that is perpendicular to rotation
@@ -178,9 +178,11 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 // length vector `v`, perpendicular to the joint axis, in the
                 // joint frame. Here to balance between the size of the
                 // optimization problem, and the tightness of the convex
-                // relaxation, we just use two vectors in `v`.
-                std::array<Eigen::Vector3d, 2> v = {{v_C, axis_F.cross(v_C)}};
-                v[1] /= v[1].norm();
+                // relaxation, we just use two vectors in `v`. Notice that
+                // v_basis contains the orthonormal basis of the null space
+                // null(axis_F).
+                std::array<Eigen::Vector3d, 2> v_basis = {{v_C, axis_F.cross(v_C)}};
+                v_basis[1] /= v_basis[1].norm();
 
                 // rotmat_joint_offset is R(k, (a+b)/2) explained above.
                 const Matrix3d rotmat_joint_offset =
@@ -190,37 +192,51 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 // joint_limit_expr is going to be within the Lorentz cone.
                 Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
                 joint_limit_expr(0) = 2 * sin(joint_bound / 2);
-                for (int j = 0; j < static_cast<int>(v.size()); ++j) {
+                for (const auto& v : v_basis) {
                   // joint_limit_expr.tail<3> is
                   // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
-                  joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
+                  joint_limit_expr.tail<3>() = R_WB_[body_idx] * v -
                       R_WB_[parent_idx] * X_PF.linear() *
-                          rotmat_joint_offset * v[j];
+                          rotmat_joint_offset * v;
                   AddLorentzConeConstraint(joint_limit_expr);
                 }
                 if (robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
                   // If the parent body is rigidly fixed to the world. Then we
-                  // can impose a tighter linear constraint. Based on the
-                  // derivation above, we have
-                  // R(k, θ-(a+b)/2)) = [R_WP * R_PF * R(k, (a+b)/2)]ᵀ * R_WC
+                  // can impose a tighter constraint. Based on the derivation
+                  // above, we have
+                  // R(k, β) = [R_WP * R_PF * R(k, (a+b)/2)]ᵀ * R_WC
                   // as a linear expression of the decision variable R_WC
                   // (notice that R_WP is constant, since the parent body is
                   // rigidly fixed to the world.
-                  // For a unit length vector `v` perpendicular to the rotation
-                  // axis, in the joint frame, we know
-                  //   vᵀ * R(k, θ-(a+b)/2)) * v = cos(θ - (a+b)/2)
-                  //                            >= cos((b-a)/2)
+                  // Any unit length vector `v` that is perpendicular to
+                  // joint axis `axis_F` in the joint Frame, can be written as
+                  //   v = V * u, uᵀ * u = 1
+                  // where V = [v_basis[0] v_basis[1]] containing the basis
+                  // vectors for the linear space Null(axis_F).
+                  // On the other hand, we know
+                  //   vᵀ * R(k, β) * v = cos(β) >= cos(α)
+                  // due to the joint limits constraint
+                  //   -α <= β <= α.
+                  // So we have the condition that
+                  // uᵀ * u = 1
+                  //    => uᵀ * Vᵀ * R(k, β) * V * u >= cos(α)
+                  // Using S-lemma, we know this implication is equivalent to
+                  // Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I is p.s.d
+                  // We let a 2 x 2 matrix
+                  //   M = Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I
+                  // A 2 x 2 matrix M being positive semidefinite (p.s.d) is
+                  // equivalent to the condition that
+                  // [M(0, 0), M(1, 1), M(1, 0)] is in the rotated Lorentz cone.
                   const Isometry3d X_WP =
                       robot_->get_body(parent_idx).ComputeWorldFixedPose();
-                  // R_joint_angle is R(k, θ-(a+b)/2)) in the documentation.
-                  Eigen::Matrix<symbolic::Expression, 3, 3> R_joint_angle =
+                  // R_joint_beta is R(k, β) in the documentation.
+                  Eigen::Matrix<symbolic::Expression, 3, 3> R_joint_beta =
                       (X_WP.linear() * X_PF.linear() * rotmat_joint_offset)
-                          .transpose() *
-                      R_WB_[body_idx];
-                  for (int j = 0; j < static_cast<int>(v.size()); ++j) {
-                    AddLinearConstraint(v[j].dot(R_joint_angle * v[j]),
-                                        std::cos(joint_bound), 1.0);
-                  }
+                          .transpose() * R_WB_[body_idx];
+                  Eigen::Matrix<double, 3, 2> V;
+                  V << v_basis[0], v_basis[1];
+                  const Eigen::Matrix<symbolic::Expression, 2, 2> M = V.transpose() * (R_joint_beta  + R_joint_beta.transpose()) / 2 * V - std::cos(joint_bound) * Eigen::Matrix2d::Identity();
+                  AddRotatedLorentzConeConstraint(Vector3<symbolic::Expression>(M(0, 0), M(1, 1), M(1, 0)));
                 }
               }
             } else {

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -174,25 +174,49 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 // Normalizes the revolute vector.
                 v_C /= v_C_norm;
 
-                // joint_limit_expr is going to be within the Lorentz cone.
-                Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
-                joint_limit_expr(0) = 2 * sin(joint_bound / 2);
-                // rotmat_joint_offset is R(k, (a+b)/2) explained above.
-                Matrix3d rotmat_joint_offset =
-                    Eigen::AngleAxisd((joint_lb + joint_ub) / 2, axis_F)
-                        .toRotationMatrix();
-
                 std::array<Eigen::Vector3d, 2> v = {{v_C, axis_F.cross(v_C)}};
                 v[1] /= v[1].norm();
-                for (int j = 0; j < static_cast<int>(v.size()); ++j) {
-                  // joint_limit_expr.tail<3> is
-                  // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
-                  joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
-                      R_WB_[parent_idx] * X_PF.linear() *
-                          rotmat_joint_offset * v[j];
-                  AddLorentzConeConstraint(joint_limit_expr);
-                }
 
+                // rotmat_joint_offset is R(k, (a+b)/2) explained above.
+                const Matrix3d rotmat_joint_offset =
+                    Eigen::AngleAxisd((joint_lb + joint_ub) / 2, axis_F)
+                        .toRotationMatrix();
+                if (!robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
+                  // joint_limit_expr is going to be within the Lorentz cone.
+                  Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
+                  joint_limit_expr(0) = 2 * sin(joint_bound / 2);
+                  for (int j = 0; j < static_cast<int>(v.size()); ++j) {
+                    // joint_limit_expr.tail<3> is
+                    // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
+                    joint_limit_expr.tail<3>() = R_WB_[body_idx] * v[j] -
+                        R_WB_[parent_idx] * X_PF.linear() *
+                            rotmat_joint_offset * v[j];
+                    AddLorentzConeConstraint(joint_limit_expr);
+                  }
+                } else {
+                  // If the parent body is rigidly fixed to the world. Then we
+                  // can impose a tighter linear constraint. Based on the
+                  // derivation above, we have
+                  // R(k, θ-(a+b)/2)) = [R_WP * R_PF * R(k, (a+b)/2)]ᵀ * R_WC
+                  // as a linear expression of the decision variable R_WC
+                  // (notice that R_WP is constant, since the parent body is
+                  // rigidly fixed to the world.
+                  // For a unit length vector `v` perpendicular to the rotation
+                  // axis, in the joint frame, we know
+                  //   vᵀ * R(k, θ-(a+b)/2)) * v = cos(θ - (a+b)/2)
+                  //                            >= cos((b-a)/2)
+                  const Isometry3d X_WP =
+                      robot_->get_body(parent_idx).ComputeWorldFixedPose();
+                  // R_joint_angle is R(k, θ-(a+b)/2)) in the documentation.
+                  Eigen::Matrix<symbolic::Expression, 3, 3> R_joint_angle =
+                      (X_WP.linear() * X_PF.linear() * rotmat_joint_offset)
+                          .transpose() *
+                      R_WB_[body_idx];
+                  for (int j = 0; j < static_cast<int>(v.size()); ++j) {
+                    AddLinearConstraint(v[j].dot(R_joint_angle * v[j]),
+                                        std::cos(joint_bound), 1.0);
+                  }
+                }
               }
             } else {
               // TODO(hongkai.dai): Add prismatic and helical joint.

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -174,6 +174,11 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                 // Normalizes the revolute vector.
                 v_C /= v_C_norm;
 
+                // The constraint would be tighter, if we choose many unit
+                // length vector `v`, perpendicular to the joint axis, in the
+                // joint frame. Here to balance between the size of the
+                // optimization problem, and the tightness of the convex
+                // relaxation, we just use two vectors in `v`.
                 std::array<Eigen::Vector3d, 2> v = {{v_C, axis_F.cross(v_C)}};
                 v[1] /= v[1].norm();
 
@@ -193,7 +198,7 @@ GlobalInverseKinematics::GlobalInverseKinematics(
                           rotmat_joint_offset * v[j];
                   AddLorentzConeConstraint(joint_limit_expr);
                 }
-                if(robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
+                if (robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
                   // If the parent body is rigidly fixed to the world. Then we
                   // can impose a tighter linear constraint. Based on the
                   // derivation above, we have

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -424,10 +424,10 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
   }
   const RigidBody<double> &body = robot_->get_body(body_index);
   if (body.has_parent_body()) {
-    const RigidBody<double> *parent_body = body.get_parent();
+    const RigidBody<double>* parent_body = body.get_parent();
     const int parent_idx = parent_body->get_body_index();
-    const DrakeJoint *joint = &(body.getJoint());
-    const auto &X_PF = joint->get_transform_to_parent_body();
+    const DrakeJoint* joint = &(body.getJoint());
+    const auto& X_PF = joint->get_transform_to_parent_body();
     switch (joint->get_num_velocities()) {
       case 0 : {
         // Fixed to the parent body.

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -605,8 +605,8 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
       default: throw std::runtime_error("Unsupported joint type.");
     }
   } else {
-    throw std::runtime_error("The body" + body.get_name() +
-                             "does not have a joint.");
+    throw std::runtime_error("The body " + body.get_name() +
+                             " does not have a joint.");
   }
 }
 }  // namespace multibody

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/global_inverse_kinematics.h"
 
+#include <limits>
 #include <stack>
 #include <string>
 
@@ -20,7 +21,13 @@ namespace drake {
 namespace multibody {
 GlobalInverseKinematics::GlobalInverseKinematics(
     const RigidBodyTreed& robot, int num_binary_vars_per_half_axis)
-    : robot_(&robot) {
+    : robot_(&robot),
+      joint_lower_bounds_{
+          Eigen::VectorXd::Constant(robot_->get_num_positions(),
+                                    -std::numeric_limits<double>::infinity())},
+      joint_upper_bounds_{
+          Eigen::VectorXd::Constant(robot_->get_num_positions(),
+                                    std::numeric_limits<double>::infinity())} {
   const int num_bodies = robot_->get_num_bodies();
   R_WB_.resize(num_bodies);
   p_WBo_.resize(num_bodies);
@@ -197,8 +204,9 @@ void GlobalInverseKinematics::ReconstructGeneralizedPositionSolutionForBody(
       }
       reconstruct_R_WB->at(body_idx) = normalized_rotmat;
     } else if (num_positions == 1) {
-      const double joint_lb = joint->getJointLimitMin()(0);
-      const double joint_ub = joint->getJointLimitMax()(0);
+      int joint_idx = body.get_position_start_index();
+      const double joint_lb = joint_lower_bounds_(joint_idx);
+      const double joint_ub = joint_upper_bounds_(joint_idx);
       // Should NOT do this evil dynamic cast here, but currently we do
       // not have a method to tell if a joint is revolute or not.
       if (dynamic_cast<const RevoluteJoint *>(joint) != nullptr) {
@@ -429,147 +437,165 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
             "Cannot impose joint limits for a fixed joint.");
       }
       case 1 : {
-        // Should NOT do this evil dynamic cast here, but currently we do
-        // not have a method to tell if a joint is revolute or not.
-        if (dynamic_cast<const RevoluteJoint *>(joint) != nullptr) {
-          // Adding McCormick Envelope will add binary variables into
-          // the program.
-          const RevoluteJoint
-              *revolute_joint = dynamic_cast<const RevoluteJoint *>(joint);
-          // axis_F is the vector of the rotation axis in the joint
-          // inboard/outboard frame.
-          const Vector3d axis_F =
-              revolute_joint->joint_axis().head<3>();
+        // If the new bound [joint_lower_bound joint_upper_bound] is not tighter
+        // than the existing bound, then we ignore it, without adding new
+        // constraints.
+        bool is_limits_tightened = false;
+        int joint_idx = body.get_position_start_index();
+        if (joint_lower_bound > joint_lower_bounds_(joint_idx)) {
+          joint_lower_bounds_(joint_idx) = joint_lower_bound;
+          is_limits_tightened = true;
+        }
+        if (joint_upper_bound < joint_upper_bounds_(joint_idx)) {
+          joint_upper_bounds_(joint_idx) = joint_upper_bound;
+          is_limits_tightened = true;
+        }
+        if (is_limits_tightened) {
+          // Should NOT do this evil dynamic cast here, but currently we do
+          // not have a method to tell if a joint is revolute or not.
+          if (dynamic_cast<const RevoluteJoint *>(joint) != nullptr) {
+            const RevoluteJoint
+                *revolute_joint = dynamic_cast<const RevoluteJoint *>(joint);
+            // axis_F is the vector of the rotation axis in the joint
+            // inboard/outboard frame.
+            const Vector3d axis_F =
+                revolute_joint->joint_axis().head<3>();
 
-          // Now we process the joint limits constraint.
-          double joint_bound = (joint_upper_bound - joint_lower_bound) / 2;
+            // Now we process the joint limits constraint.
+            double joint_bound = (joint_upper_bounds_[joint_idx]
+                - joint_lower_bounds_[joint_idx]) / 2;
 
-          if (joint_bound < M_PI) {
-            // We use the fact that if the angle between two unit length
-            // vectors u and v is smaller than α, it is equivalent to
-            // |u - v| <= 2*sin(α/2)
-            // which is a second order cone constraint.
+            if (joint_bound < M_PI) {
+              // We use the fact that if the angle between two unit length
+              // vectors u and v is smaller than α, it is equivalent to
+              // |u - v| <= 2*sin(α/2)
+              // which is a second order cone constraint.
 
-            // If the rotation angle θ satisfies
-            // a <= θ <= b
-            // This is equivalent to
-            // -α <= θ - (a+b)/2 <= α
-            // where α = (b-a) / 2, (a+b) / 2 is the joint offset, such that
-            // the bounds on β = θ - (a+b)/2 are symmetric.
-            // We use the following notation:
-            // R_WP     The rotation matrix of parent frame `P` to world
-            //          frame `W`.
-            // R_WC     The rotation matrix of child frame `C` to world
-            //          frame `W`.
-            // R_PF     The rotation matrix of joint frame `F` to parent
-            //          frame `P`.
-            // R(k, β)  The rotation matrix along joint axis k by angle β.
-            // The kinematics constraint is
-            // R_WP * R_PJ * R(k, θ) = R_WC.
-            // This is equivalent to
-            // R_WP * R_PF * R(k, (a+b)/2) * R(k, β)) = R_WC.
-            // So to constrain that -α <= β <= α,
-            // we can constrain the angle between the two vectors
-            // R_WC * v and R_WP * R_PF * R(k,(a+b)/2) * v is no larger than
-            // α, where v is a unit length vector perpendicular to
-            // the rotation axis k, in the joint frame.
-            // Thus we can constrain that
-            // |R_WC*v - R_WP * R_PF * R(k,(a+b)/2)*v | <= 2*sin (α / 2)
-            // as we explained above.
+              // If the rotation angle θ satisfies
+              // a <= θ <= b
+              // This is equivalent to
+              // -α <= θ - (a+b)/2 <= α
+              // where α = (b-a) / 2, (a+b) / 2 is the joint offset, such that
+              // the bounds on β = θ - (a+b)/2 are symmetric.
+              // We use the following notation:
+              // R_WP     The rotation matrix of parent frame `P` to world
+              //          frame `W`.
+              // R_WC     The rotation matrix of child frame `C` to world
+              //          frame `W`.
+              // R_PF     The rotation matrix of joint frame `F` to parent
+              //          frame `P`.
+              // R(k, β)  The rotation matrix along joint axis k by angle β.
+              // The kinematics constraint is
+              // R_WP * R_PF * R(k, θ) = R_WC.
+              // This is equivalent to
+              // R_WP * R_PF * R(k, (a+b)/2) * R(k, β)) = R_WC.
+              // So to constrain that -α <= β <= α,
+              // we can constrain the angle between the two vectors
+              // R_WC * v and R_WP * R_PF * R(k,(a+b)/2) * v is no larger than
+              // α, where v is a unit length vector perpendicular to
+              // the rotation axis k, in the joint frame.
+              // Thus we can constrain that
+              // |R_WC*v - R_WP * R_PF * R(k,(a+b)/2)*v | <= 2*sin (α / 2)
+              // as we explained above.
 
-            // First generate a vector v_C that is perpendicular to rotation
-            // axis, in child frame.
-            Vector3d v_C = axis_F.cross(Vector3d(1, 0, 0));
-            double v_C_norm = v_C.norm();
-            if (v_C_norm < sqrt(2) / 2) {
-              // axis_F is almost parallel to [1; 0; 0]. Try another axis
-              // [0, 1, 0]
-              v_C = axis_F.cross(Vector3d(0, 1, 0));
-              v_C_norm = v_C.norm();
+              // First generate a vector v_C that is perpendicular to rotation
+              // axis, in child frame.
+              Vector3d v_C = axis_F.cross(Vector3d(1, 0, 0));
+              double v_C_norm = v_C.norm();
+              if (v_C_norm < sqrt(2) / 2) {
+                // axis_F is almost parallel to [1; 0; 0]. Try another axis
+                // [0, 1, 0]
+                v_C = axis_F.cross(Vector3d(0, 1, 0));
+                v_C_norm = v_C.norm();
+              }
+              // Normalizes the revolute vector.
+              v_C /= v_C_norm;
+
+              // The constraint would be tighter, if we choose many unit
+              // length vector `v`, perpendicular to the joint axis, in the
+              // joint frame. Here to balance between the size of the
+              // optimization problem, and the tightness of the convex
+              // relaxation, we just use four vectors in `v`. Notice that
+              // v_basis contains the orthonormal basis of the null space
+              // null(axis_F).
+              std::array<Eigen::Vector3d, 2>
+                  v_basis = {{v_C, axis_F.cross(v_C)}};
+              v_basis[1] /= v_basis[1].norm();
+
+              std::array<Eigen::Vector3d, 4> v_samples;
+              v_samples[0] = v_basis[0];
+              v_samples[1] = v_basis[1];
+              v_samples[2] = v_basis[0] + v_basis[1];
+              v_samples[2] /= v_samples[2].norm();
+              v_samples[3] = v_basis[0] - v_basis[1];
+              v_samples[3] /= v_samples[3].norm();
+
+              // rotmat_joint_offset is R(k, (a+b)/2) explained above.
+              const Matrix3d rotmat_joint_offset =
+                  Eigen::AngleAxisd((joint_lower_bounds_[joint_idx]
+                                        + joint_upper_bounds_[joint_idx]) / 2,
+                                    axis_F)
+                      .toRotationMatrix();
+
+              // joint_limit_expr is going to be within the Lorentz cone.
+              Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
+              joint_limit_expr(0) = 2 * sin(joint_bound / 2);
+              for (const auto &v : v_samples) {
+                // joint_limit_expr.tail<3> is
+                // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
+                joint_limit_expr.tail<3>() = R_WB_[body_index] * v -
+                    R_WB_[parent_idx] * X_PF.linear() *
+                        rotmat_joint_offset * v;
+                AddLorentzConeConstraint(joint_limit_expr);
+              }
+              if (robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
+                // If the parent body is rigidly fixed to the world. Then we
+                // can impose a tighter constraint. Based on the derivation
+                // above, we have
+                // R(k, β) = [R_WP * R_PF * R(k, (a+b)/2)]ᵀ * R_WC
+                // as a linear expression of the decision variable R_WC
+                // (notice that R_WP is constant, since the parent body is
+                // rigidly fixed to the world.
+                // Any unit length vector `v` that is perpendicular to
+                // joint axis `axis_F` in the joint Frame, can be written as
+                //   v = V * u, uᵀ * u = 1
+                // where V = [v_basis[0] v_basis[1]] containing the basis
+                // vectors for the linear space Null(axis_F).
+                // On the other hand, we know
+                //   vᵀ * R(k, β) * v = cos(β) >= cos(α)
+                // due to the joint limits constraint
+                //   -α <= β <= α.
+                // So we have the condition that
+                // uᵀ * u = 1
+                //    => uᵀ * Vᵀ * R(k, β) * V * u >= cos(α)
+                // Using S-lemma, we know this implication is equivalent to
+                // Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I is p.s.d
+                // We let a 2 x 2 matrix
+                //   M = Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I
+                // A 2 x 2 matrix M being positive semidefinite (p.s.d) is
+                // equivalent to the condition that
+                // [M(0, 0), M(1, 1), M(1, 0)] is in the rotated Lorentz cone.
+                const Isometry3d X_WP =
+                    robot_->get_body(parent_idx).ComputeWorldFixedPose();
+                // R_joint_beta is R(k, β) in the documentation.
+                Eigen::Matrix<symbolic::Expression, 3, 3> R_joint_beta =
+                    (X_WP.linear() * X_PF.linear() * rotmat_joint_offset)
+                        .transpose() * R_WB_[body_index];
+                Eigen::Matrix<double, 3, 2> V;
+                V << v_basis[0], v_basis[1];
+                const Eigen::Matrix<symbolic::Expression, 2, 2> M =
+                    V.transpose() * (R_joint_beta + R_joint_beta.transpose())
+                        / 2
+                        * V
+                        - std::cos(joint_bound) * Eigen::Matrix2d::Identity();
+                AddRotatedLorentzConeConstraint(
+                    Vector3<symbolic::Expression>(M(0, 0), M(1, 1), M(1, 0)));
+              }
             }
-            // Normalizes the revolute vector.
-            v_C /= v_C_norm;
-
-            // The constraint would be tighter, if we choose many unit
-            // length vector `v`, perpendicular to the joint axis, in the
-            // joint frame. Here to balance between the size of the
-            // optimization problem, and the tightness of the convex
-            // relaxation, we just use four vectors in `v`. Notice that
-            // v_basis contains the orthonormal basis of the null space
-            // null(axis_F).
-            std::array<Eigen::Vector3d, 2> v_basis = {{v_C, axis_F.cross(v_C)}};
-            v_basis[1] /= v_basis[1].norm();
-
-            std::array<Eigen::Vector3d, 4> v_samples;
-            v_samples[0] = v_basis[0];
-            v_samples[1] = v_basis[1];
-            v_samples[2] = v_basis[0] + v_basis[1];
-            v_samples[2] /= v_samples[2].norm();
-            v_samples[3] = v_basis[0] - v_basis[1];
-            v_samples[3] /= v_samples[3].norm();
-
-            // rotmat_joint_offset is R(k, (a+b)/2) explained above.
-            const Matrix3d rotmat_joint_offset =
-                Eigen::AngleAxisd((joint_lower_bound + joint_upper_bound) / 2,
-                                  axis_F)
-                    .toRotationMatrix();
-
-            // joint_limit_expr is going to be within the Lorentz cone.
-            Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
-            joint_limit_expr(0) = 2 * sin(joint_bound / 2);
-            for (const auto &v : v_samples) {
-              // joint_limit_expr.tail<3> is
-              // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
-              joint_limit_expr.tail<3>() = R_WB_[body_index] * v -
-                  R_WB_[parent_idx] * X_PF.linear() *
-                      rotmat_joint_offset * v;
-              AddLorentzConeConstraint(joint_limit_expr);
-            }
-            if (robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
-              // If the parent body is rigidly fixed to the world. Then we
-              // can impose a tighter constraint. Based on the derivation
-              // above, we have
-              // R(k, β) = [R_WP * R_PF * R(k, (a+b)/2)]ᵀ * R_WC
-              // as a linear expression of the decision variable R_WC
-              // (notice that R_WP is constant, since the parent body is
-              // rigidly fixed to the world.
-              // Any unit length vector `v` that is perpendicular to
-              // joint axis `axis_F` in the joint Frame, can be written as
-              //   v = V * u, uᵀ * u = 1
-              // where V = [v_basis[0] v_basis[1]] containing the basis
-              // vectors for the linear space Null(axis_F).
-              // On the other hand, we know
-              //   vᵀ * R(k, β) * v = cos(β) >= cos(α)
-              // due to the joint limits constraint
-              //   -α <= β <= α.
-              // So we have the condition that
-              // uᵀ * u = 1
-              //    => uᵀ * Vᵀ * R(k, β) * V * u >= cos(α)
-              // Using S-lemma, we know this implication is equivalent to
-              // Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I is p.s.d
-              // We let a 2 x 2 matrix
-              //   M = Vᵀ * [R(k, β) + R(k, β)ᵀ]/2 * V - cos(α) * I
-              // A 2 x 2 matrix M being positive semidefinite (p.s.d) is
-              // equivalent to the condition that
-              // [M(0, 0), M(1, 1), M(1, 0)] is in the rotated Lorentz cone.
-              const Isometry3d X_WP =
-                  robot_->get_body(parent_idx).ComputeWorldFixedPose();
-              // R_joint_beta is R(k, β) in the documentation.
-              Eigen::Matrix<symbolic::Expression, 3, 3> R_joint_beta =
-                  (X_WP.linear() * X_PF.linear() * rotmat_joint_offset)
-                      .transpose() * R_WB_[body_index];
-              Eigen::Matrix<double, 3, 2> V;
-              V << v_basis[0], v_basis[1];
-              const Eigen::Matrix<symbolic::Expression, 2, 2> M =
-                  V.transpose() * (R_joint_beta + R_joint_beta.transpose()) / 2
-                      * V - std::cos(joint_bound) * Eigen::Matrix2d::Identity();
-              AddRotatedLorentzConeConstraint(
-                  Vector3<symbolic::Expression>(M(0, 0), M(1, 1), M(1, 0)));
-            }
+          } else {
+            // TODO(hongkai.dai): add prismatic and helical joint.
+            throw std::runtime_error("Unsupported joint type.");
           }
-        } else {
-          // TODO(hongkai.dai): add prismatic and helical joint.
-          throw std::runtime_error("Unsupported joint type.");
         }
         break;
       }

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -410,7 +410,8 @@ GlobalInverseKinematics::BodyPointInOneOfRegions(
   return z;
 }
 
-void GlobalInverseKinematics::AddJointLimitConstraint(int body_index, double joint_lower_bound, double joint_upper_bound) {
+void GlobalInverseKinematics::AddJointLimitConstraint(
+    int body_index, double joint_lower_bound, double joint_upper_bound) {
   if (joint_lower_bound > joint_upper_bound) {
     throw std::runtime_error(
         "The joint lower bound should be no larger than the upper bound.");
@@ -424,7 +425,8 @@ void GlobalInverseKinematics::AddJointLimitConstraint(int body_index, double joi
     switch (joint->get_num_velocities()) {
       case 0 : {
         // Fixed to the parent body.
-        throw std::runtime_error("Cannot impose joint limits for a fixed joint.");
+        throw std::runtime_error(
+            "Cannot impose joint limits for a fixed joint.");
       }
       case 1 : {
         // Should NOT do this evil dynamic cast here, but currently we do
@@ -508,7 +510,8 @@ void GlobalInverseKinematics::AddJointLimitConstraint(int body_index, double joi
 
             // rotmat_joint_offset is R(k, (a+b)/2) explained above.
             const Matrix3d rotmat_joint_offset =
-                Eigen::AngleAxisd((joint_lower_bound + joint_upper_bound) / 2, axis_F)
+                Eigen::AngleAxisd((joint_lower_bound + joint_upper_bound) / 2,
+                                  axis_F)
                     .toRotationMatrix();
 
             // joint_limit_expr is going to be within the Lorentz cone.

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -604,6 +604,9 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
       }
       default: throw std::runtime_error("Unsupported joint type.");
     }
+  } else {
+    throw std::runtime_error("The body" + body.get_name() +
+                             "does not have a joint.");
   }
 }
 }  // namespace multibody

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -258,8 +258,8 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
   // robot_->get_num_positions() x 1.
   // joint_lower_bounds_(i) is the lower bound of the i'th joint.
   // joint_upper_bounds_(i) is the upper bound of the i'th joint.
-  // These joint bounds included those specified in the robot (like in the URDF
-  // file), and the bounds imposed by the user, through AddJointLimitConstraint
+  // These joint bounds include those specified in the robot (like in the URDF
+  // file), and the bounds imposed by the user, through AddJointLimitConstraint.
   Eigen::VectorXd joint_lower_bounds_;
   Eigen::VectorXd joint_upper_bounds_;
 

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -234,12 +234,12 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       const std::vector<Eigen::Matrix3Xd>& region_vertices);
 
   /**
- * Adds joint limits on a specified joint.
- * @param body_index The joint connecting the parent link to this body will be
- * constrained.
- * @param joint_lower_bound The lower bound for the joint.
- * @param joint_upper_bound The upper bound for the joint.
- */
+   * Adds joint limits on a specified joint.
+   * @param body_index The joint connecting the parent link to this body will be
+   * constrained.
+   * @param joint_lower_bound The lower bound for the joint.
+   * @param joint_upper_bound The upper bound for the joint.
+   */
   void AddJointLimitConstraint(int body_index, double joint_lower_bound,
                                double joint_upper_bound);
 
@@ -253,6 +253,15 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       std::vector<Eigen::Matrix3d>* reconstruct_R_WB) const;
 
   const RigidBodyTree<double>* robot_;
+
+  // joint_lower_bounds_ and joint_upper_bounds_ are column vectors of size
+  // robot_->get_num_positions() x 1.
+  // joint_lower_bounds_(i) is the lower bound of the i'th joint.
+  // joint_upper_bounds_(i) is the upper bound of the i'th joint.
+  // These joint bounds included those specified in the robot (like in the URDF
+  // file), and the bounds imposed by the user, through AddJointLimitConstraint
+  Eigen::VectorXd joint_lower_bounds_;
+  Eigen::VectorXd joint_upper_bounds_;
 
   // R_WB_[i] is the orientation of body i in the world reference frame,
   // it is expressed in the world frame.

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -233,6 +233,16 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
       int body_index, const Eigen::Ref<const Eigen::Vector3d>& p_BQ,
       const std::vector<Eigen::Matrix3Xd>& region_vertices);
 
+  /**
+ * Adds joint limits on a specified joint.
+ * @param body_index The joint connecting the parent link to this body will be
+ * constrained.
+ * @param joint_lower_bound The lower bound for the joint.
+ * @param joint_upper_bound The upper bound for the joint.
+ */
+  void AddJointLimitConstraint(int body_index, double joint_lower_bound,
+                               double joint_upper_bound);
+
  private:
   // This is an utility function for `ReconstructGeneralizedPositionSolution`.
   // This function computes the joint generalized position on the body with


### PR DESCRIPTION
This PR does two things

1. Move the code block that adds a joint limits in global IK, to a separate function.
2. Impose tighter joint limits, when the parent link of the joint is fixed to the world.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6585)
<!-- Reviewable:end -->
