### PR TITLE
Add SystemScalarConverter

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -307,6 +307,22 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "system_scalar_converter",
+    srcs = [
+        "system_scalar_converter.cc",
+    ],
+    hdrs = [
+        "scalar_conversion_traits.h",
+        "system_scalar_converter.h",
+        "system_type_tag.h",
+    ],
+    deps = [
+        ":system",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
     name = "leaf_system",
     srcs = ["leaf_system.cc"],
     hdrs = ["leaf_system.h"],
@@ -617,6 +633,14 @@ drake_cc_googletest(
     name = "vector_system_test",
     deps = [
         ":vector_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "system_scalar_converter_test",
+    deps = [
+        ":leaf_system",
+        ":system_scalar_converter",
     ],
 )
 

--- a/drake/systems/framework/CMakeLists.txt
+++ b/drake/systems/framework/CMakeLists.txt
@@ -29,6 +29,7 @@ set(sources
   subvector.cc
   supervector.cc
   system.cc
+  system_scalar_converter.cc
   value.cc
   vector_base.cc
   witness_function.cc
@@ -67,17 +68,20 @@ set(installed_headers
   output_port_listener_interface.h
   output_port_value.h
   parameters.h
+  scalar_conversion_traits.h
   single_output_vector_source.h
-  vector_system.h
   sparsity_matrix.h
   state.h
   subvector.h
   supervector.h
   system.h
   system_common.h
+  system_scalar_converter.h
+  system_type_tag.h
   value.h
   value_checker.h
   vector_base.h
+  vector_system.h
   witness_function.h
   )
 

--- a/drake/systems/framework/scalar_conversion_traits.h
+++ b/drake/systems/framework/scalar_conversion_traits.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <type_traits>
+
+#include "drake/common/drake_compat.h"
+
+namespace drake {
+namespace systems {
+namespace scalar_conversion {
+
+/// A templated traits class for whether an S<T> can be converted into an S<U>;
+/// the default value is true for all values of S, T, and U.  Particular
+/// scalar-dependent classes may specialize this template to indicate whether
+/// the framework should support conversion for a combination of S, T, and U.
+///
+/// In supported cases, the "scalar-converting copy constructor" for those
+/// types will be used.  That constructor takes the form of, e.g.:
+///
+/// @code
+/// template <typename T>
+/// class Foo {
+///   template <typename U>
+///   explicit Foo(const Foo<U>& other);
+/// };
+/// @endcode
+///
+/// In unsupported cases, the constructor will not even be mentioned by the
+/// framework, so that S need not even compile for certain values of T and U.
+///
+/// @tparam S is the scalar-templated type to copy
+template <template <typename> class S>
+struct Traits {
+  /// @tparam T is the resulting scalar type (to convert into)
+  /// @tparam U is the donor scalar type (to convert from)
+  template <typename T, typename U>
+  using supported = std::true_type;
+};
+
+/// A concrete traits class providing sugar to disable support for symbolic
+/// evaluation (i.e., the symbolic::Expression scalar type).
+///
+/// For example, if MySystem does not support the symbolic expression scalar
+/// type, it could specialize Traits as follows:
+///
+/// @code
+/// namespace drake {
+/// namespace systems {
+/// namespace scalar_conversion {
+/// template <> struct Traits<MySystem> : public NonSymbolicTraits {};
+/// }  // namespace scalar_conversion
+/// }  // namespace systems
+/// }  // namespace drake
+/// @endcode
+struct NonSymbolicTraits {
+  template <typename T, typename U>
+  using supported = typename std::conditional<
+    !std::is_same<T, symbolic::Expression>::value &&
+    !std::is_same<U, symbolic::Expression>::value,
+    std::true_type, std::false_type>::type;
+};
+
+/// A concrete traits class providing sugar to support for converting only from
+/// the `double` scalar type.  For example, if a MySystem<symbolic::Expression>
+/// cannot be converted into a MySystem<double>, it could specialize Traits as
+/// follows:
+///
+/// @code
+/// namespace drake {
+/// namespace systems {
+/// namespace scalar_conversion {
+/// template <> struct Traits<MySystem> : public FromDoubleTraits {};
+/// }  // namespace scalar_conversion
+/// }  // namespace systems
+/// }  // namespace drake
+/// @endcode
+struct FromDoubleTraits {
+  template <typename T, typename U>
+  using supported = typename std::conditional<
+    std::is_same<U, double>::value,
+    std::true_type, std::false_type>::type;
+};
+
+}  // namespace scalar_conversion
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_scalar_converter.cc
+++ b/drake/systems/framework/system_scalar_converter.cc
@@ -1,0 +1,33 @@
+#include "drake/systems/framework/system_scalar_converter.h"
+
+namespace drake {
+namespace systems {
+
+namespace {
+std::pair<std::type_index, std::type_index> make_key(
+    const std::type_info& t_info, const std::type_info& u_info) {
+  return std::make_pair(std::type_index(t_info), std::type_index(u_info));
+}
+}  // namespace
+
+void SystemScalarConverter::Insert(
+    const std::type_info& t_info, const std::type_info& u_info,
+    const ErasedConverterFunc& converter) {
+  const auto& key = make_key(t_info, u_info);
+  const auto& insert_result = funcs_.insert({key, converter});
+  DRAKE_ASSERT(insert_result.second);
+}
+
+const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
+    const std::type_info& t_info, const std::type_info& u_info) const {
+  const auto& key = make_key(t_info, u_info);
+  auto iter = funcs_.find(key);
+  if (iter != funcs_.end()) {
+    return &(iter->second);
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <typeindex>
+#include <utility>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic.h"
+#include "drake/systems/framework/scalar_conversion_traits.h"
+#include "drake/systems/framework/system.h"
+#include "drake/systems/framework/system_type_tag.h"
+
+namespace drake {
+namespace systems {
+
+/// Helper class to convert a System<U> into a System<T>, intended for internal
+/// use by the System framework, not directly by users.
+///
+/// Because it is not templated on a System subclass, this class can be used by
+/// LeafSystem without any direct knowledge of the subtypes being converted.
+/// In other words, it enables a runtime flavor of the CRTP.
+class SystemScalarConverter {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemScalarConverter);
+
+  /// Creates an object that returns nullptr for all Convert() requests.  The
+  /// single-argument constructor below is the typical way to create a useful
+  /// instance of this type.
+  SystemScalarConverter() = default;
+
+  /// Creates an object that uses S's scalar-type converting copy constructor.
+  /// That constructor takes the form of, e.g.:
+  ///
+  /// @code
+  /// template <typename T>
+  /// class Foo {
+  ///   template <typename U>
+  ///   explicit Foo(const Foo<U>& other);
+  /// };
+  /// @endcode
+  ///
+  /// This constructor only creates a converter between a limited set of types,
+  /// specifically:
+  ///
+  /// - double
+  /// - AutoDiffXd
+  /// - symbolic::Expression
+  ///
+  /// By default, all non-identity pairs (pairs where T and U differ) drawn
+  /// from the above list can be used for T and U.  Systems may specialize
+  /// scalar_conversion::Traits to disable support for some or all of these
+  /// conversions, or after construction may call Add<T, U>() on the returned
+  /// object to enable support for additional custom types.
+  ///
+  /// @tparam S is the System type to convert
+  template <template <typename> class S>
+  explicit SystemScalarConverter(SystemTypeTag<S>) : SystemScalarConverter() {
+    using Expression = symbolic::Expression;
+    // From double to all other types.
+    AddIfSupported<S, AutoDiffXd, double>();
+    AddIfSupported<S, Expression, double>();
+    // From AutoDiffXd to all other types.
+    AddIfSupported<S, double,     AutoDiffXd>();
+    AddIfSupported<S, Expression, AutoDiffXd>();
+    // From Expression to all other types.
+    AddIfSupported<S, double,     Expression>();
+    AddIfSupported<S, AutoDiffXd, Expression>();
+  }
+
+  /// A std::function used to convert a System<U> into a System<T>.
+  template <typename T, typename U>
+  using ConverterFunction =
+      std::function<std::unique_ptr<System<T>>(const System<U>&)>;
+
+  /// Registers the std::function to be used to convert a System<U> into a
+  /// System<T>.  A pair of types can be registered (added) at most once.
+  template <typename T, typename U>
+  void Add(const ConverterFunction<T, U>&);
+
+  /// Adds converter for an S<U> into an S<T>, iff scalar_conversion::Traits
+  /// says its supported.  The converter uses S's scalar-type converting copy
+  /// constructor.
+  template <template <typename> class S, typename T, typename U>
+  void AddIfSupported();
+
+  /// Returns true iff this object can convert a System<U> into a System<T>,
+  /// i.e., whether Convert() will return non-null.
+  ///
+  /// @tparam U the donor scalar type (to convert from)
+  /// @tparam T the resulting scalar type (to convert into)
+  template <typename T, typename U>
+  bool IsConvertible() const;
+
+  /// Converts a System<U> into a System<T>.  This is the API that LeafSystem
+  /// uses to provide a default implementation of DoToAutoDiffXd, etc.
+  ///
+  /// @tparam U the donor scalar type (to convert from)
+  /// @tparam T the resulting scalar type (to convert into)
+  template <typename T, typename U>
+  std::unique_ptr<System<T>> Convert(const System<U>& other) const;
+
+ private:
+  // Like ConverterFunc, but with the args and return value decayed into void*.
+  using ErasedConverterFunc = std::function<void*(const void*)>;
+
+  // Given typeid(T), typeid(U), returns a converter.  If no converter has been
+  // added yet, returns nullptr.
+  const ErasedConverterFunc* Find(
+      const std::type_info&, const std::type_info&) const;
+
+  // Given typeid(T), typeid(U), adds a converter.
+  void Insert(
+      const std::type_info&, const std::type_info&,
+      const ErasedConverterFunc&);
+
+  // Maps from {T, U} to the function that converts from U into T.
+  std::map<std::pair<std::type_index, std::type_index>, ErasedConverterFunc>
+      funcs_;
+};
+
+#if !defined(DRAKE_DOXYGEN_CXX)
+
+template <typename T, typename U>
+void SystemScalarConverter::Add(const ConverterFunction<T, U>& func) {
+  // Make sure func contains a target (i.e., is not null-ish).
+  DRAKE_ASSERT(static_cast<bool>(func));
+  // Copy `func` into a lambda that ends up stored into `funcs_`.  The lambda
+  // is typed as `void* => void*` in order to have a non-templated signature
+  // and thus fit into a homogeneously-typed std::map.
+  Insert(typeid(T), typeid(U), [func](const void* const bare_u) {
+    DRAKE_ASSERT(bare_u);
+    const System<U>& other = *static_cast<const System<U>*>(bare_u);
+    return func(other).release();
+  });
+}
+
+template <typename T, typename U>
+bool SystemScalarConverter::IsConvertible() const {
+  const ErasedConverterFunc* converter = Find(typeid(T), typeid(U));
+  return (converter != nullptr);
+}
+
+template <typename T, typename U>
+std::unique_ptr<System<T>> SystemScalarConverter::Convert(
+    const System<U>& other) const {
+  // Lookup the lambda that Add() stored and call it.
+  System<T>* result = nullptr;
+  const ErasedConverterFunc* converter = Find(typeid(T), typeid(U));
+  if (converter) {
+    result = static_cast<System<T>*>((*converter)(&other));
+  }
+  return std::unique_ptr<System<T>>(result);
+}
+
+namespace system_scalar_converter_detail {
+// When Traits says that conversion is supported.
+template <template <typename> class S, typename T, typename U>
+static std::unique_ptr<System<T>> Make(
+    const System<U>& other, std::true_type) {
+  const auto& my_other = dynamic_cast<const S<U>&>(other);
+  return std::make_unique<S<T>>(my_other);
+}
+// When Traits says not to convert.
+template <template <typename> class S, typename T, typename U>
+static std::unique_ptr<System<T>> Make(
+    const System<U>&, std::false_type) {
+  // AddIfSupported is guaranteed not to call us, but we *will* be compiled,
+  // so we have to have some kind of function body.
+  DRAKE_ABORT();
+}
+}  // namespace system_scalar_converter_detail
+
+template <template <typename> class S, typename T, typename U>
+void SystemScalarConverter::AddIfSupported() {
+  using supported =
+      typename scalar_conversion::Traits<S>::template supported<T, U>;
+  if (supported::value) {
+    const ConverterFunction<T, U> func = [](const System<U>& other) {
+      // Dispatch to an overload based on whether S<U> ==> S<T> is supported.
+      // (At runtime, this block is only executed for supported conversions,
+      // but at compile time, Make will be instantiated unconditionally.)
+      return system_scalar_converter_detail::Make<S, T, U>(other, supported{});
+    };
+    Add(func);
+  }
+}
+
+#endif  // DRAKE_DOXYGEN_CXX
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/system_type_tag.h
+++ b/drake/systems/framework/system_type_tag.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "drake/systems/framework/system.h"
+
+namespace drake {
+namespace systems {
+
+/// A tag object that denotes a System subclass `S` in function signatures.
+///
+/// For example, `SystemTypeTag<MySystem>{}` will create a dummy object that
+/// can be used to call functions that look like:
+///
+/// @code
+/// template <template <typename> class S>
+/// const char* get_foo(SystemTypeTag<S>) { return S<double>::get_foo(); }
+///
+/// int main() {
+///    std::cout << get_foo(SystemTypeTag<MySystem>{});
+/// }
+/// @endcode
+///
+/// In this case, we could directly call get_foo<MySystem>() by specifying the
+/// template argument, but that is not always possible.  In particular, tag
+/// objects are acutely useful when calling templated constructors, because
+/// there is no other mechanism for the caller to specify the template type.
+template <template <typename> class S>
+struct SystemTypeTag {
+  SystemTypeTag() {
+    static_assert(std::is_base_of<System<double>, S<double>>::value,
+                  "The type argument to SystemTypeTag must be a System");
+  }
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/framework/test/system_scalar_converter_test.cc
+++ b/drake/systems/framework/test/system_scalar_converter_test.cc
@@ -1,0 +1,241 @@
+#include "drake/systems/framework/system_scalar_converter.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using symbolic::Expression;
+
+// A system that has non-trivial non-T-typed member data.
+// This system can convert between all scalar types.
+template <typename T>
+class AnyToAnySystem : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(AnyToAnySystem);
+
+  // User constructor.
+  explicit AnyToAnySystem(int magic) : magic_(magic) {}
+
+  // Copy constructor that converts to a different scalar type.
+  template <typename U>
+  explicit AnyToAnySystem(const AnyToAnySystem<U>& other)
+      : AnyToAnySystem(other.magic()) {}
+
+  int magic() const { return magic_; }
+
+ private:
+  int magic_{};
+};
+
+// A system that has non-trivial non-T-typed member data.
+// This system does not support symbolic form.
+template <typename T>
+class NonSymbolicSystem : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NonSymbolicSystem);
+
+  // User constructor.
+  explicit NonSymbolicSystem(int magic)
+      : magic_(magic) {
+    // Declare input-output relation of `y[0] = copysign(magic, u[0])`.
+    this->DeclareVectorInputPort(BasicVector<T>(1));
+    this->DeclareVectorOutputPort(
+        BasicVector<T>(1),
+        [this](const Context<T>& context, BasicVector<T>* output) {
+          const BasicVector<T>& input = *(this->EvalVectorInput(context, 0));
+          (*output)[0] = magic_copysign(this->magic(), input[0]);
+        });
+  }
+
+  // Copy constructor that converts to a different scalar type.
+  template <typename U>
+  explicit NonSymbolicSystem(const NonSymbolicSystem<U>& other)
+      : NonSymbolicSystem(other.magic()) {}
+
+  int magic() const { return magic_; }
+
+ private:
+  // A non-symbolic-compatible helper function.  If the SystemScalarConverter
+  // implementation fails to avoid instantiating S<symbolic::Expression> when
+  // told not to, then we would see compile errors that this function does not
+  // compile with T = symbolic::Expression.
+  static T magic_copysign(int magic, const T& value) {
+    if ((magic < 0) == (value < 0)) {
+      return value;
+    } else {
+      return -value;
+    }
+  }
+
+  int magic_{};
+};
+
+// A system that has non-trivial non-T-typed member data.
+// This system can only convert from a scalar type of double.
+template <typename T>
+class FromDoubleSystem : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FromDoubleSystem);
+
+  // User constructor.
+  explicit FromDoubleSystem(int magic) : magic_(magic) {}
+
+  // Copy constructor that converts to a different scalar type.  Note that we
+  // are not templated on U, since FromDoubleSystem can only come from double.
+  // Note that we need a dummy argument in order to avoid conflicting with our
+  // copy constructor.
+  explicit FromDoubleSystem(
+      const FromDoubleSystem<double>& other, int dummy = 0)
+      : FromDoubleSystem(other.magic()) {}
+
+  int magic() const { return magic_; }
+
+ private:
+  int magic_{};
+};
+
+}  // namespace
+
+namespace scalar_conversion {
+template <> struct Traits<NonSymbolicSystem> : public NonSymbolicTraits {};
+template <> struct Traits<FromDoubleSystem> : public FromDoubleTraits {};
+}  // namespace scalar_conversion
+
+namespace {
+
+template <template <typename> class S, typename T, typename U, int kMagic>
+void TestConversionPass() {
+  // The device under test.
+  const SystemScalarConverter dut(SystemTypeTag<S>{});
+
+  // Do the conversion.
+  EXPECT_TRUE((dut.IsConvertible<T, U>()));
+  const S<U> original{kMagic};
+  const std::unique_ptr<System<T>> converted = dut.Convert<T, U>(original);
+  EXPECT_TRUE(converted != nullptr);
+
+  // Confirm that the correct type came out.
+  const auto* const downcast = dynamic_cast<const S<T>*>(converted.get());
+  EXPECT_TRUE(downcast != nullptr);
+
+  // Confirm that the magic was preserved.
+  EXPECT_EQ(downcast ? downcast->magic() : 0, kMagic);
+}
+
+template <template <typename> class S, typename T, typename U>
+void TestConversionFail() {
+  const SystemScalarConverter dut(SystemTypeTag<S>{});
+
+  // Do the conversion.
+  EXPECT_FALSE((dut.IsConvertible<T, U>()));
+  const S<U> original{0};
+  const std::unique_ptr<System<T>> converted = dut.Convert<T, U>(original);
+
+  // Confirm that nothing came out.
+  EXPECT_TRUE(converted == nullptr);
+}
+
+GTEST_TEST(SystemScalarConverterTest, DefaualtConstructor) {
+  // With the default ctor, nothing is convertible ...
+  const SystemScalarConverter dut;
+  EXPECT_FALSE((dut.IsConvertible<double,     double>()));
+  EXPECT_FALSE((dut.IsConvertible<double,     AutoDiffXd>()));
+  EXPECT_FALSE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, double>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, AutoDiffXd>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, double>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, Expression>()));
+
+  // ... including non-standard scalar types.
+  using AD2 = Eigen::AutoDiffScalar<Eigen::Vector2d>;
+  EXPECT_FALSE((dut.IsConvertible<AD2, double>()));
+  EXPECT_FALSE((dut.IsConvertible<double, AD2>()));
+}
+
+GTEST_TEST(SystemScalarConverterTest, TestAnyToAnySystem) {
+  // We don't support T => T conversion -- that's the copy constructor, which
+  // is usually disabled.
+  TestConversionFail<AnyToAnySystem, double,     double>();
+  TestConversionFail<AnyToAnySystem, AutoDiffXd, AutoDiffXd>();
+  TestConversionFail<AnyToAnySystem, Expression, Expression>();
+
+  // We support all remaining combinations of standard types.
+  TestConversionPass<AnyToAnySystem, double,     AutoDiffXd, 1>();
+  TestConversionPass<AnyToAnySystem, double,     Expression, 2>();
+  TestConversionPass<AnyToAnySystem, AutoDiffXd, double,     3>();
+  TestConversionPass<AnyToAnySystem, AutoDiffXd, Expression, 4>();
+  TestConversionPass<AnyToAnySystem, Expression, double,     5>();
+  TestConversionPass<AnyToAnySystem, Expression, AutoDiffXd, 6>();
+}
+
+GTEST_TEST(SystemScalarConverterTest, TestNonSymbolicSystem) {
+  // The always-disabled cases.
+  TestConversionFail<NonSymbolicSystem, double,     double>();
+  TestConversionFail<NonSymbolicSystem, AutoDiffXd, AutoDiffXd>();
+
+  // All Expression conversions are disabled.
+  //
+  // We cannot test TestConversionFail<foo, Expression>, because in order to
+  // call Convert, we need a reference to the come-from type (Expression), and
+  // instantiating a NonSymbolicSystem<Expression> does not even compile.
+  // Instead, we just confirm that the converter claims to not support it.
+  TestConversionFail<NonSymbolicSystem, Expression, double>();
+  TestConversionFail<NonSymbolicSystem, Expression, AutoDiffXd>();
+  const SystemScalarConverter dut(SystemTypeTag<NonSymbolicSystem>{});
+  EXPECT_FALSE((dut.IsConvertible<double, Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
+
+  // We support all remaining combinations of standard types.
+  TestConversionPass<NonSymbolicSystem, double,     AutoDiffXd, 1>();
+  TestConversionPass<NonSymbolicSystem, AutoDiffXd, double,     2>();
+}
+
+GTEST_TEST(SystemScalarConverterTest, TestFromDoubleSystem) {
+  // The always-disabled cases.
+  TestConversionFail<FromDoubleSystem, double,     double>();
+  TestConversionFail<FromDoubleSystem, AutoDiffXd, AutoDiffXd>();
+  TestConversionFail<FromDoubleSystem, Expression, Expression>();
+
+  // The from-non-double conversions are disabled.
+  TestConversionFail<FromDoubleSystem, double,     Expression>();
+  TestConversionFail<FromDoubleSystem, AutoDiffXd, Expression>();
+  TestConversionFail<FromDoubleSystem, Expression, AutoDiffXd>();
+  TestConversionFail<FromDoubleSystem, double,     AutoDiffXd>();
+
+  // We support all remaining combinations of standard types.
+  TestConversionPass<FromDoubleSystem, Expression, double, 1>();
+  TestConversionPass<FromDoubleSystem, AutoDiffXd, double, 2>();
+}
+
+GTEST_TEST(SystemScalarConverterTest, TestUserTypes) {
+  // The device under test.
+  SystemScalarConverter dut(SystemTypeTag<AnyToAnySystem>{});
+
+  // We don't (by default) support non-standard types.
+  using AD2 = Eigen::AutoDiffScalar<Eigen::Vector2d>;
+  TestConversionFail<AnyToAnySystem, AD2, double>();
+
+  // The user can opt-in to non-standard types.
+  dut.AddIfSupported<AnyToAnySystem, AD2, double>();
+
+  // Do the conversion.
+  const AnyToAnySystem<double> original{0};
+  const std::unique_ptr<System<AD2>> converted =
+      dut.Convert<AD2, double>(original);
+  EXPECT_TRUE(converted != nullptr);
+
+  // Confirm that the correct type came out.
+  const auto* const downcast =
+      dynamic_cast<const AnyToAnySystem<AD2>*>(converted.get());
+  EXPECT_TRUE(downcast != nullptr);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This PR introduces the concept of a "transmogrification copy constructor", to replace the prior design of an "override one NVI virtual method for each supported target ScalarType".  The constructor can support converting from any (supported) scalar type to any other (supported) scalar type, and a Traits class allows specialization to disable unsupported conversions at compile-time (e.g., we can allow AutoDiff -> Symbolic but disallow the opposite direction).

This design scores higher on the "Don't Repeat Yourself" metric, and should be more robust in the face of (1) API changes to how transmogrification works and (2) evolution in the supported set of AutoDiff layouts, such as adding support for (possibly several) fixed-size AutoDiff variants for the ScalarType.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6589)
<!-- Reviewable:end -->
