### PR TITLE
Fixes issue with integrators limiting simulator time advancement even when no continuous state is present.

### DIFF
--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -1643,6 +1643,14 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::IntegrateAtMost(
     dt = boundary_dt;
   }
 
+  // If there is no continuous state, there will be no need to limit the
+  // integration step size.
+  if (get_context().get_continuous_state()->size() == 0) {
+    Context<T>* context = get_mutable_context();
+    context->set_time(context->get_time() + dt);
+    return candidate_result;
+  }
+
   // If all events are farther into the future than the maximum step
   // size times a stretch factor of 1.01, the maximum step size becomes the
   // candidate dt. Put another way, if the maximum step occurs right before

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -97,15 +97,13 @@ GTEST_TEST(SimulatorTest, NoContinuousStateYieldsSingleStep) {
      final_time + 1, /* publish time *after* final time */
      WitnessFunctionDirection::kCrossesZero);
 
-  // Construct the simulation without any publishing and using the RK2
-  // (fixed step) integrator with a small time step.
+  // Construct the simulation using the RK2 (fixed step) integrator with a small
+  // time step.
   const double dt = 1e-3;
   Simulator<double> simulator(system);
-  simulator.set_publish_at_initialization(false);
   Context<double>* context = simulator.get_mutable_context();
   simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
       context);
-  simulator.set_publish_every_time_step(false);
   simulator.StepTo(final_time);
 
   EXPECT_EQ(simulator.get_num_steps_taken(), 1);

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -88,6 +88,29 @@ class ExampleDiagram : public Diagram<double> {
   StatelessDiagram* stateless_diag_ = nullptr;
 };
 
+// Tests that simulation only takes a single step when there is no continuous
+// state, regardless of the integrator maximum step size (and no discrete state
+// or events).
+GTEST_TEST(SimulatorTest, NoContinuousStateYieldsSingleStep) {
+  const double final_time = 1.0;
+  StatelessSystem system(
+     final_time + 1, /* publish time *after* final time */
+     WitnessFunctionDirection::kCrossesZero);
+
+  // Construct the simulation without any publishing and using the RK2
+  // (fixed step) integrator with a small time step.
+  const double dt = 1e-3;
+  Simulator<double> simulator(system);
+  simulator.set_publish_at_initialization(false);
+  Context<double>* context = simulator.get_mutable_context();
+  simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
+      context);
+  simulator.set_publish_every_time_step(false);
+  simulator.StepTo(final_time);
+
+  EXPECT_EQ(simulator.get_num_steps_taken(), 1);
+}
+
 // Tests ability of simulation to identify the proper number of witness function
 // triggerings going from negative to non-negative witness function evaluation
 // using a Diagram. This particular example uses an empty system and a clock as
@@ -1169,7 +1192,11 @@ GTEST_TEST(SimulatorTest, AutodiffBasic) {
 GTEST_TEST(SimulatorTest, PerStepAction) {
   class PerStepActionTestSystem : public LeafSystem<double> {
    public:
-    PerStepActionTestSystem() {}
+    PerStepActionTestSystem() {
+      // We need some continuous state (which will be unused) so that the
+      // continuous state integration will not be bypassed.
+      this->DeclareContinuousState(1);
+    }
 
     void AddPerStepPublishEvent() {
       PublishEvent<double> event(Event<double>::TriggerType::kPerStep);
@@ -1200,6 +1227,13 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
     }
 
    private:
+    void DoCalcTimeDerivatives(
+        const Context<double>& context,
+        ContinuousState<double>* derivatives) const override {
+      // Derivative will always be zero, making the system stationary.
+      derivatives->get_mutable_vector()->SetAtIndex(0, 0.0);
+    }
+
     void DoCalcDiscreteVariableUpdates(
         const Context<double>& context,
         const std::vector<const DiscreteUpdateEvent<double>*>& events,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6593)
<!-- Reviewable:end -->
