### PR TITLE
AcrobotPlant retains parameters during transmogrification

### DIFF
--- a/drake/examples/Acrobot/acrobot_plant.cc
+++ b/drake/examples/Acrobot/acrobot_plant.cc
@@ -146,15 +146,36 @@ T AcrobotPlant<T>::DoCalcPotentialEnergy(
   return -m1_ * g_ * lc1_ * c1 - m2_ * g_ * (l1_ * c1 + lc2_ * c12);
 }
 
-// AcrobotPlant has no constructor arguments, so there's no work to do here.
 template <typename T>
 AcrobotPlant<AutoDiffXd>* AcrobotPlant<T>::DoToAutoDiffXd() const {
-  return new AcrobotPlant<AutoDiffXd>();
+  return new AcrobotPlant<AutoDiffXd>(
+      m1_,
+      m2_,
+      l1_,
+      l2_,
+      lc1_,
+      lc2_,
+      Ic1_,
+      Ic2_,
+      b1_,
+      b2_,
+      g_);
 }
 
 template <typename T>
 AcrobotPlant<symbolic::Expression>* AcrobotPlant<T>::DoToSymbolic() const {
-  return new AcrobotPlant<symbolic::Expression>();
+  return new AcrobotPlant<symbolic::Expression>(
+      m1_,
+      m2_,
+      l1_,
+      l2_,
+      lc1_,
+      lc2_,
+      Ic1_,
+      Ic2_,
+      b1_,
+      b2_,
+      g_);
 }
 
 template class AcrobotPlant<double>;

--- a/drake/examples/Acrobot/acrobot_plant.h
+++ b/drake/examples/Acrobot/acrobot_plant.h
@@ -108,11 +108,12 @@ class AcrobotPlant : public systems::LeafSystem<T> {
   AcrobotPlant<symbolic::Expression>* DoToSymbolic() const override;
 
   // TODO(russt): Declare these as parameters in the context.
-
   const double m1_, m2_, l1_, l2_, lc1_, lc2_, Ic1_, Ic2_, b1_, b2_, g_;
+
+  // Quantities that occur often.
   const double I1_ = Ic1_ + m1_ * lc1_ * lc1_;
   const double I2_ = Ic2_ + m2_ * lc2_ * lc2_;
-  const double m2l1lc2_ = m2_ * l1_ * lc2_;  // Quantities that occur often.
+  const double m2l1lc2_ = m2_ * l1_ * lc2_;
 };
 
 /// Constructs the Acrobot with (only) encoder outputs.


### PR DESCRIPTION
When MIT parameters were added in #5093, they were not correctly carried through transmogrification, so any, e.g., optimization or control using AutoDiff would have been wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6599)
<!-- Reviewable:end -->
