### PR TITLE
Use Curve2d not Curve2<T> in TrajectoryCar

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -348,6 +348,7 @@ drake_cc_library(
         ":curve2",
         ":generated_vectors",
         "//drake/common:autodiff",
+        "//drake/common:extract_double",
         "//drake/systems/rendering:frame_velocity",
         "//drake/systems/rendering:pose_vector",
     ],

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -14,6 +14,7 @@
 #include "drake/automotive/gen/trajectory_car_params.h"
 #include "drake/automotive/gen/trajectory_car_state.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/extract_double.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/vector_base.h"
 #include "drake/systems/rendering/frame_velocity.h"
@@ -61,13 +62,14 @@ namespace automotive {
 template <typename T>
 class TrajectoryCar : public systems::LeafSystem<T> {
  public:
-  typedef typename Curve2<T>::Point2 Point2;
+  typedef typename Curve2<double>::Point2 Point2d;
 
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryCar)
 
   /// Constructs a TrajectoryCar system that traces a given two-dimensional @p
   /// curve.  Throws an error if the curve is empty (has a zero @p path_length).
-  explicit TrajectoryCar(const Curve2<T>& curve) : curve_(std::move(curve)) {
+  explicit TrajectoryCar(Curve2<double> curve)
+      : curve_(std::move(curve)) {
     if (curve_.path_length() == 0.0) {
       throw std::invalid_argument{"empty curve"};
     }
@@ -99,8 +101,8 @@ class TrajectoryCar : public systems::LeafSystem<T> {
  protected:
   /// Data structure returned by CalcRawPose containing raw pose information.
   struct PositionHeading {
-    Point2 position = Point2(Point2::Zero());
-    T heading{0.};
+    Point2d position = Point2d(Point2d::Zero());
+    double heading{0.};
   };
 
   void CalcStateOutput(const systems::Context<T>& context,
@@ -240,8 +242,8 @@ class TrajectoryCar : public systems::LeafSystem<T> {
     PositionHeading result;
 
     // Compute the curve at the current longitudinal (along-curve) position.
-    const typename Curve2<T>::PositionResult pose =
-        curve_.GetPosition(state.position());
+    const typename Curve2<double>::PositionResult pose =
+        curve_.GetPosition(ExtractDoubleOrThrow(state.position()));
     // TODO(jadecastro): Now that the curve is a function of position rather
     // than time, we are not acting on a `trajectory` anymore.  Rename this
     // System to PathFollowingCar or something similar.
@@ -253,18 +255,10 @@ class TrajectoryCar : public systems::LeafSystem<T> {
   }
 
   TrajectoryCar<AutoDiffXd>* DoToAutoDiffXd() const override {
-    const std::vector<typename Curve2<T>::Point2>& waypoints =
-        curve_.waypoints();
-    std::vector<Curve2<AutoDiffXd>::Point2> autodiff_waypoints{};
-    for (const auto& point : waypoints) {
-      autodiff_waypoints.emplace_back(point);
-    }
-    const Curve2<AutoDiffXd> curve(autodiff_waypoints);
-    return new TrajectoryCar<AutoDiffXd>(
-        Curve2<AutoDiffXd>(autodiff_waypoints));
+    return new TrajectoryCar<AutoDiffXd>(curve_);
   }
 
-  const Curve2<T> curve_;
+  const Curve2<double> curve_;
 };
 
 }  // namespace automotive


### PR DESCRIPTION
Passing a `Curve2<T>` to the constructor does not help optimization frameworks at all and is needless hassle for transmogrification.

In #6119 we changed `TrajectoryCar(const Curve2<double>& curve)` to `TrajectoryCar(const Curve2<T>& curve)`. In general, passing T type or T-based types to constructor cannot work, because it does not allow the optimization framework to establish the symbolic variables, nor set up the autodiff derivatives, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6600)
<!-- Reviewable:end -->
