### PR TITLE
Add manip plan eval block for humanoids. 

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/config/valkyrie.id_controller_config
+++ b/drake/examples/QPInverseDynamicsForHumanoids/config/valkyrie.id_controller_config
@@ -19,21 +19,21 @@ centroidal_momentum {
     kp: 0
     kp: 40
     kp: 40
-    kp: 40
+    kp: 0
 
     kd: 4
     kd: 4
     kd: 4
     kd: 12
     kd: 12
-    kd: 12
+    kd: 0
 
     weight: 0
     weight: 0
     weight: 0
     weight: 10
     weight: 10
-    weight: 10
+    weight: 0
 }
 
 default_body_motion {
@@ -57,21 +57,21 @@ body_motion {
     kp: 20
     kp: 0
     kp: 0
-    kp: 0
+    kp: 20
 
     kd: 8
     kd: 8
     kd: 8
     kd: 0
     kd: 0
-    kd: 0
+    kd: 8
 
     weight: 1
     weight: 1
     weight: 1
     weight: 0
     weight: 0
-    weight: 0
+    weight: 10
 }
 
 body_motion {

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
@@ -31,6 +31,7 @@ drake_cc_library(
         "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
         "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
         "//drake/manipulation/util:trajectory_utils",
+        "//drake/systems/framework:value",
     ],
 )
 
@@ -64,6 +65,44 @@ drake_cc_googletest(
         "//drake/common:find_resource",
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody/parsers",
+    ],
+)
+
+drake_cc_library(
+    name = "humanoid_manipulation_plan",
+    srcs = [
+        "dev/humanoid_manipulation_plan.cc",
+    ],
+    hdrs = [
+        "dev/humanoid_manipulation_plan.h",
+    ],
+    deps = [
+        ":generic_plan",
+        "//drake/examples/QPInverseDynamicsForHumanoids:lcm_utils",
+        "//drake/manipulation/util:robot_state_msg_translator",
+        "//drake/systems/controllers:zmp_planner",
+        "//drake/util:util",
+        "@lcmtypes_bot2_core",
+        "@lcmtypes_robotlocomotion",
+    ],
+)
+
+drake_cc_binary(
+    name = "humanoid_manipulation_demo",
+    srcs = [
+        "dev/humanoid_manipulation_demo.cc",
+    ],
+    data = [
+        "//drake/examples/Valkyrie:models",
+    ],
+    deps = [
+        "//drake/common:find_resource",
+        "//drake/examples/Valkyrie:valkyrie_constants",
+        "//drake/manipulation/util:robot_state_msg_translator",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/parsers",
+        "@lcmtypes_bot2_core",
+        "@lcmtypes_robotlocomotion",
     ],
 )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_demo.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_demo.cc
@@ -1,0 +1,73 @@
+/**
+ * @brief This is a demo program that sends a full body manipulation plan
+ * encoded as a robotlocomotion::robot_plan_t to ValkyrieController. Upon
+ * receiving the plan, the Valkyrie robot should return to the nominal
+ * configuration except the right shoulder pitch joint.
+ */
+#include "drake/examples/Valkyrie/valkyrie_constants.h"
+#include "drake/manipulation/util/robot_state_msg_translator.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+#include "lcm/lcm-cpp.hpp"
+#include "robotlocomotion/robot_plan_t.hpp"
+
+using std::default_random_engine;
+
+namespace drake {
+namespace {
+
+void send_manip_message() {
+  RigidBodyTree<double> robot;
+  drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+      "drake/examples/Valkyrie/urdf/urdf/"
+      "valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf",
+      multibody::joints::kRollPitchYaw, &robot);
+
+  DRAKE_DEMAND(examples::valkyrie::kRPYValkyrieDof ==
+               robot.get_num_positions());
+  VectorX<double> q = examples::valkyrie::RPYValkyrieFixedPointState().head(
+      examples::valkyrie::kRPYValkyrieDof);
+  VectorX<double> v = VectorX<double>::Zero(robot.get_num_velocities());
+
+  const manipulation::RobotStateLcmMessageTranslator translator(robot);
+
+  // There needs to be at least 1 knot point, the controller will insert its
+  // current desired q to the beginning to make the desired trajectories.
+  //
+  // Some notes about the message:
+  // 1. The first timestamp needs to be bigger than 0.
+  // 2. msg.utime needs to be different for different messages. The controller
+  // ignores messages with the same utime.
+  // 3. Assumes the message is packaged with a RPY floating joint.
+  // 4. Assumes that the given knot points are stable given the current actual
+  // contact points.
+  // 5. Pelvis z and orientation + torso orientation are tracked in Cartesian
+  // mode (These can be changed by the gains in the configuration file). CoM
+  // in controlled by a LQR like controller, where the desired is given by the
+  // knot points specified here.
+  robotlocomotion::robot_plan_t msg{};
+  msg.utime = time(NULL);
+  msg.num_states = 1;
+  msg.plan.resize(msg.num_states);
+  msg.plan_info.resize(msg.num_states, 1);
+
+  q[10] -= 0.5;  // right shoulder pitch
+  translator.InitializeMessage(&(msg.plan[0]));
+  translator.EncodeMessageKinematics(q, v, &(msg.plan[0]));
+  msg.plan[0].utime = 1e6;
+
+  lcm::LCM lcm;
+  lcm.publish("VALKYRIE_MANIP_PLAN", &msg);
+
+  sleep(1);
+}
+
+}  // namespace
+}  // namespace drake
+
+int main() {
+  drake::send_manip_message();
+  return 0;
+}

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
@@ -1,0 +1,221 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "robotlocomotion/robot_plan_t.hpp"
+#include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
+#include "drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+template <typename T>
+void HumanoidManipulationPlan<T>::InitializeGenericPlanDerived(
+    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) {
+  unused(paramset);
+
+  // Knots are constant, the second time doesn't matter as long as it's larger.
+  const std::vector<T> times = {robot_status.time(), robot_status.time() + 1};
+
+  // Current com q and v.
+  Vector4<double> xcom;
+  xcom << robot_status.com().head<2>(), robot_status.comd().head<2>();
+  // Set desired com q to current.
+  MatrixX<double> com_d = robot_status.com().head<2>();
+  PiecewisePolynomial<T> zmp_d =
+      PiecewisePolynomial<T>::ZeroOrderHold(times, {com_d, com_d});
+  // Makes a zmp planner that stays still.
+  zmp_planner_.Plan(zmp_d, xcom, zmp_height_);
+
+  // Assumes double support with both feet.
+  ContactState double_support;
+  double_support.insert(alias_groups.get_body("left_foot"));
+  double_support.insert(alias_groups.get_body("right_foot"));
+  this->UpdateContactState(double_support);
+
+  // Sets body tracking trajectories for pelvis and torso.
+  const std::vector<std::string> tracked_body_names = {"pelvis", "torso"};
+  MatrixX<T> position;
+  for (const auto& name : tracked_body_names) {
+    const RigidBody<T>* body = alias_groups.get_body(name);
+    Isometry3<T> body_pose = robot_status.robot().CalcBodyPoseInWorldFrame(
+        robot_status.cache(), *body);
+    position = body_pose.translation();
+    PiecewisePolynomial<T> pos_traj =
+        PiecewisePolynomial<T>::ZeroOrderHold(times, {position, position});
+    PiecewiseQuaternionSlerp<T> rot_traj(
+        times, {body_pose.linear(), body_pose.linear()});
+
+    manipulation::PiecewiseCartesianTrajectory<T> body_traj(pos_traj, rot_traj);
+    this->set_body_trajectory(body, body_traj);
+  }
+}
+
+template <typename T>
+void HumanoidManipulationPlan<T>::UpdateQpInputGenericPlanDerived(
+    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+    QpInput* qp_input) const {
+  unused(paramset, alias_groups);
+
+  // Generates CoM acceleration.
+  Vector4<T> xcom;
+  xcom << robot_status.com().head<2>(), robot_status.comd().head<2>();
+  Vector2<T> comdd_d =
+      zmp_planner_.ComputeOptimalCoMdd(robot_status.time(), xcom);
+
+  // Zeros linear and angular momentum change.
+  qp_input->mutable_desired_centroidal_momentum_dot()
+      .mutable_values()
+      .setZero();
+  // Only sets the xy dimensions of the linear momentum change.
+  qp_input->mutable_desired_centroidal_momentum_dot()
+      .mutable_values()
+      .segment<2>(3) = robot_status.robot().getMass() * comdd_d;
+}
+
+template <typename T>
+void HumanoidManipulationPlan<T>::HandlePlanGenericPlanDerived(
+    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+    const systems::AbstractValue& plan) {
+  unused(paramset);
+
+  const auto& msg = plan.GetValueOrThrow<robotlocomotion::robot_plan_t>();
+
+  if (msg.utime == last_handle_plan_time_) return;
+
+  // Saves the time stamp.
+  last_handle_plan_time_ = msg.utime;
+
+  // knots for setting up the splines.
+  int length = static_cast<int>(msg.plan.size());
+  if (length < 1) {
+    drake::log()->warn(
+        "HumanoidManipulationPlan::HandlePlanGenericPlanDerived: "
+        "received plan has less than 1 knots.");
+    return;
+  }
+
+  const RigidBodyTree<T>& robot = robot_status.robot();
+  KinematicsCache<T> cache = robot.CreateKinematicsCache();
+
+  const double time_now = robot_status.time();
+  VectorX<T> q = this->get_dof_trajectory().get_position(time_now);
+  VectorX<T> v = VectorX<T>::Zero(robot.get_num_velocities());
+
+  // Set the first knot points to the current desired values.
+  std::vector<T> times(1, time_now);
+  std::vector<MatrixX<T>> dof_knots(1, q);
+  std::unordered_map<const RigidBody<T>*, std::vector<Isometry3<T>>> body_knots;
+  std::vector<const RigidBody<T>*> tracked_bodies = {
+      alias_groups.get_body("pelvis"), alias_groups.get_body("torso")};
+  for (const RigidBody<T>* body : tracked_bodies) {
+    body_knots[body] = std::vector<Isometry3<T>>(
+        1, this->get_body_trajectory(body).get_pose(time_now));
+  }
+  std::vector<T> com_times(1, time_now);
+  std::vector<MatrixX<T>> com_knots(1, zmp_planner_.get_nominal_com(time_now));
+
+  const manipulation::RobotStateLcmMessageTranslator translator(
+      robot_status.robot());
+
+  for (const bot_core::robot_state_t& keyframe : msg.plan) {
+    translator.DecodeMessageKinematics(keyframe, q, v);
+    const double time = static_cast<double>(keyframe.utime) / 1e6;
+
+    cache.initialize(q);
+    robot.doKinematics(cache, false);
+
+    times.push_back(time_now + time);
+    com_times.push_back(time_now + time);
+    dof_knots.push_back(q);
+
+    for (auto& body_knots_pair : body_knots) {
+      const RigidBody<T>* body = body_knots_pair.first;
+      std::vector<Isometry3<T>>& body_knots = body_knots_pair.second;
+      body_knots.push_back(robot.CalcBodyPoseInWorldFrame(cache, *body));
+    }
+
+    // Computes com.
+    com_knots.push_back(robot.centerOfMass(cache).template head<2>());
+  }
+
+  // Generates the zmp trajectory.
+  {
+    // CoM has 1 more knot point to ensure the trajectory ends at zero velocity.
+    // TODO(siyuan): have the zmp planner deal with this.
+    // Repeats the last desired CoM position to ensure CoM trajector ends in
+    // zero velocity.
+    com_times.push_back(com_times.back() + 0.1);
+    com_knots.push_back(com_knots.back());
+    PiecewisePolynomial<T> zmp_poly =
+        PiecewisePolynomial<T>::Pchip(com_times, com_knots, true);
+    Vector4<T> x_com0;
+    x_com0 << robot_status.com().head<2>(), robot_status.comd().head<2>();
+    zmp_planner_.Plan(zmp_poly, x_com0, zmp_height_);
+  }
+
+  // Generates dof trajectories.
+  {
+    MatrixX<T> zeros = MatrixX<T>::Zero(robot.get_num_positions(), 1);
+    this->set_dof_trajectory(manipulation::PiecewiseCubicTrajectory<T>(
+        PiecewisePolynomial<T>::Cubic(times, dof_knots, zeros, zeros)));
+  }
+
+  // Generates body trajectories.
+  {
+    for (const auto& body_knots_pair : body_knots) {
+      const RigidBody<T>* body = body_knots_pair.first;
+      const std::vector<Isometry3<T>>& body_knots = body_knots_pair.second;
+
+      manipulation::PiecewiseCartesianTrajectory<T> body_traj =
+          manipulation::PiecewiseCartesianTrajectory<
+              T>::MakeCubicLinearWithEndLinearVelocity(times, body_knots,
+                                                       Vector3<T>::Zero(),
+                                                       Vector3<T>::Zero());
+
+      this->set_body_trajectory(body, body_traj);
+    }
+  }
+}
+
+template <typename T>
+bool HumanoidManipulationPlan<T>::IsRigidBodyTreeCompatible(
+    const RigidBodyTree<T>& robot) const {
+  if (robot.get_num_bodies() < 2) return false;
+
+  const RigidBody<T>& root_body = robot.get_body(1);
+  const DrakeJoint& root_joint = root_body.getJoint();
+  if (!root_joint.is_floating()) return false;
+
+  if (root_joint.get_num_positions() != root_joint.get_num_velocities())
+    return false;
+
+  if (robot.get_num_positions() != robot.get_num_velocities()) return false;
+
+  return true;
+}
+
+template <typename T>
+bool HumanoidManipulationPlan<T>::IsRigidBodyTreeAliasGroupsCompatible(
+    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) const {
+  if (VerifyRigidBodyTreeAliasGroups(alias_groups, "pelvis") &&
+      VerifyRigidBodyTreeAliasGroups(alias_groups, "torso") &&
+      VerifyRigidBodyTreeAliasGroups(alias_groups, "left_foot") &&
+      VerifyRigidBodyTreeAliasGroups(alias_groups, "right_foot")) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template class HumanoidManipulationPlan<double>;
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h
@@ -1,0 +1,161 @@
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.h"
+
+#include <string>
+
+#include "drake/manipulation/util/robot_state_msg_translator.h"
+#include "drake/systems/controllers/zmp_planner.h"
+
+namespace drake {
+namespace examples {
+namespace qp_inverse_dynamics {
+
+/**
+ * A baseline manipulation plan interpretor for a humanoid robot. The plan
+ * essentially consists of a sequence of time and generalized positions,
+ * which are used to generate splines, which are then used as desired
+ * trajectories to populate QpInput for the QPController.
+ *
+ * @see HandlePlanGenericPlanDerived for more details about the behavior.
+ */
+// TODO(siyuan): make quaternion floating joint work.
+template <typename T>
+class HumanoidManipulationPlan : public GenericPlan<T> {
+ protected:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HumanoidManipulationPlan)
+
+ public:
+  HumanoidManipulationPlan() {}
+
+  /**
+   * Returns the center of mass height used in the ZMP planner.
+   * @see ZMPPlanner::Plan for more details.
+   */
+  double get_zmp_height() const { return zmp_height_; }
+
+  /**
+   * Sets the center of mass height used in the ZMP planner to @p z.
+   * @see ZMPPlanner::Plan for more details.
+   */
+  void set_zmp_height(double z) { zmp_height_ = z; }
+
+  /**
+   * Returns true if @p robot has at least 2 rigid bodies; the first rigid body
+   * has a RPY parametrized floating joint, and it has the same number of
+   * generalized positions and velocities.
+   */
+  bool IsRigidBodyTreeCompatible(const RigidBodyTree<T>& robot) const override;
+
+  /**
+   * Returns true if @p alias_groups has singleton body groups: "pelvis",
+   * "torso", "left_foot" and "right_foot".
+   */
+  bool IsRigidBodyTreeAliasGroupsCompatible(
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups)
+      const override;
+
+  // TODO(siyuan): override IsParamSetCompatible as well.
+
+ protected:
+  /**
+   * Assuming both feet are in contact, initializes a plan that holds the
+   * current configuration in @p robot_status.
+   */
+  void InitializeGenericPlanDerived(
+      const HumanoidStatus& robot_status,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) override;
+
+  /**
+   * This function generates various trajectories from the given plan in
+   * @p plan. Let `T_plan` be the timing information and `Q_plan` be the
+   * generalized positions contained in @p plan, and `t` and `q` be the current
+   * time and estimated generalized position represented by @p robot_status,
+   * we define `Ts = {t, T_plan + t}` and `Qs = {q, Q_plan}`.
+   * Given timing `Ts` and knot points for the generalized positions `Qs`, the
+   * following trajectories are generated:
+   * <pre>
+   * 1. Cubic splines for all degrees of freedom. The splines are generated from
+   *    `Ts` and `Qs` assuming zero end point velocities and continuous
+   * position,
+   *    velocity and acceleration at all intermediate knot points.
+   * 2. Cartesian trajectories are made for the pelvis and torso link. The knot
+   *    poses are computed by forward kinematics at each `Qs`. The linear part
+   * of
+   *    the Cartesian trajectory is constructed similarly as above, and the
+   *    rotation part is based on Slerp (linear interpolation between
+   * quaternion).
+   *    Timing is given by `Ts`.
+   * 3. A desired ZMP trajectory is generated using Pchip from the center of
+   * mass
+   *    XY positions computed by forward kinematics at each `Qs` and timing
+   * given
+   *    by `Ts`. A nominal center of mass trajectory and its associated optimal
+   *    linear policy is then planned using systems::ZMPPlanner.
+   * </pre>
+   * Note that these trajectories are arbitrarily designed, without considering
+   * position, velocity or acceleration consistency. The QpController will trade
+   * off tracking errors based on weights specified in the parameters.
+   *
+   * This function also assumes that both feet are in contact with the ground,
+   * and every configuration in `Q_plan` is statically stable given the support
+   * region defined by the current foot poses. `T_plan` has to be strictly
+   * increasing, and `T_plan[0]` is bigger than 0. The current implementation
+   * assumes that the message is encoded with a RPY parametrized floating base
+   * model as opposed to a quaternion floating joint.
+   *
+   * This function returns without changing the current trajectories if the
+   * time stamp in @p plan has not changed from when the current trajectories
+   * were last generated or the number of knots in @p plan is smaller than 1.
+   *
+   * Aborts if assumptions about `T_plan` is not valid.
+   *
+   * @throws if @p plan is not of type robotlocomotion::robot_plan_t
+   */
+  void HandlePlanGenericPlanDerived(
+      const HumanoidStatus& robot_status,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+      const systems::AbstractValue& plan) override;
+
+  /**
+   * Updates the X and Y dimension of the desired linear momentum change in
+   * @p qp_input based on the center of mass acceleration computed using the
+   * ZMP planner's policy. Sets the other dimensions of desired centroidal
+   * momentum change to zero.
+   */
+  void UpdateQpInputGenericPlanDerived(
+      const HumanoidStatus& robot_status,
+      const param_parsers::ParamSet& paramset,
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+      QpInput* qp_input) const override;
+
+ private:
+  // Returns true if @p alias_groups has a singleton body group whose name is
+  // @p body_alias_name.
+  bool VerifyRigidBodyTreeAliasGroups(
+      const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
+      const std::string& body_alias_name) const {
+    if (alias_groups.has_body_group(body_alias_name) &&
+        alias_groups.get_body_group(body_alias_name).size() == 1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  GenericPlan<T>* CloneGenericPlanDerived() const override {
+    return new HumanoidManipulationPlan<T>(*this);
+  }
+
+  void ModifyPlanGenericPlanDerived(
+      const HumanoidStatus&, const param_parsers::ParamSet&,
+      const param_parsers::RigidBodyTreeAliasGroups<T>&) override {}
+
+  systems::ZMPPlanner zmp_planner_;
+  double zmp_height_{1.0};
+  int64_t last_handle_plan_time_{-1};
+};
+
+}  // namespace qp_inverse_dynamics
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.cc
@@ -17,6 +17,9 @@ template <typename T>
 void GenericPlan<T>::Initialize(
     const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
     const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) {
+  // Checks parameters and throw if they are incompatible.
+  CheckCompatibilityAndThrow(robot_status.robot(), paramset, alias_groups);
+
   // Sets contact states sequence to empty from t = 0 to forever.
   ContactState empty;
   UpdateContactState(empty);
@@ -37,28 +40,13 @@ void GenericPlan<T>::Initialize(
 }
 
 template <typename T>
-void GenericPlan<T>::HandlePlanMessage(
-    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
-    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
-    const void* message_bytes, int message_length) {
-  // Calls custom handler.
-  HandlePlanMessageGenericPlanDerived(robot_status, paramset, alias_groups,
-                                      message_bytes, message_length);
-}
-
-template <typename T>
-void GenericPlan<T>::ModifyPlan(
-    const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
-    const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) {
-  // Runs derived class' plan.
-  ModifyPlanGenericPlanDerived(robot_status, paramset, alias_groups);
-}
-
-template <typename T>
 void GenericPlan<T>::UpdateQpInput(
     const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
     const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
     QpInput* qp_input) const {
+  // Checks parameters and throw if they are incompatible.
+  CheckCompatibilityAndThrow(robot_status.robot(), paramset, alias_groups);
+
   // Gets all bodies that are in contact.
   const ContactState& contact_state = get_planned_contact_state();
   const std::vector<const RigidBody<T>*> contact_bodies(contact_state.begin(),

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.cc
@@ -32,18 +32,16 @@ void ManipulatorMoveEndEffectorPlan<T>::InitializeGenericPlanDerived(
 }
 
 template <typename T>
-void ManipulatorMoveEndEffectorPlan<T>::HandlePlanMessageGenericPlanDerived(
+void ManipulatorMoveEndEffectorPlan<T>::HandlePlanGenericPlanDerived(
     const HumanoidStatus& robot_status, const param_parsers::ParamSet& paramset,
     const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
-    const void* message_bytes, int message_length) {
+    const systems::AbstractValue& plan) {
   unused(paramset);  // TODO(jwnimmer-tri) This seems bad.
 
-  // Tries to decode as a lcmt_manipulator_plan_move_end_effector message.
-  lcmt_manipulator_plan_move_end_effector msg;
-  int consumed = msg.decode(message_bytes, 0, message_length);
-  DRAKE_DEMAND(consumed == message_length);
+  const auto& msg =
+      plan.GetValueOrThrow<lcmt_manipulator_plan_move_end_effector>();
 
-  // TODO(siyuan): should do better error handling wrt bad plan message.
+  // TODO(siyuan): should do better error handling wrt bad plan plan.
   DRAKE_DEMAND(static_cast<size_t>(msg.num_steps) == msg.utimes.size() &&
                static_cast<size_t>(msg.num_steps) == msg.poses.size());
   DRAKE_DEMAND(msg.num_steps >= 0);

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/manipulator_move_end_effector_plan.h
@@ -36,11 +36,11 @@ class ManipulatorMoveEndEffectorPlan : public GenericPlan<T> {
       const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups) override;
 
   /**
-   * This function assumes that the bytes in @p message_bytes encodes a valid
-   * lcmt_manipulator_plan_move_end_effector message, from which the desired
+   * This function assumes that the bytes in @p plan encodes a valid
+   * lcmt_manipulator_plan_move_end_effector plan, from which the desired
    * poses (x_i) for the end effector and timing (t_i) are extracted and used
    * to construct a Cartesian spline. Let t_now be the time in @p robot_stauts.
-   * If t_0 = 0 (first time stamp in @p message_bytes is zero), the spline is
+   * If t_0 = 0 (first time stamp in @p plan is zero), the spline is
    * constructed with
    * MakeCubicLinearWithEndLinearVelocity(t_i + t_now, x_i, 0, 0), which starts
    * immediately from x_0 regardless of what's the current planned desired
@@ -52,12 +52,15 @@ class ManipulatorMoveEndEffectorPlan : public GenericPlan<T> {
    * {x_d_now, x_i}, xd_d_now, 0),
    * where x_d_now and xd_d_now are the current desired pose and velocity of
    * the end effector. This results in a smoother transition to the new plan.
+   *
+   * @throws std::bad_cast if @p plan is not of type
+   * lcmt_manipulator_plan_move_end_effector;
    */
-  void HandlePlanMessageGenericPlanDerived(
+  void HandlePlanGenericPlanDerived(
       const HumanoidStatus& robot_stauts,
       const param_parsers::ParamSet& paramset,
       const param_parsers::RigidBodyTreeAliasGroups<T>& alias_groups,
-      const void* message_bytes, int message_length) override;
+      const systems::AbstractValue& plan) override;
 
  private:
   GenericPlan<T>* CloneGenericPlanDerived() const override;

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -63,6 +63,7 @@ drake_cc_library(
     hdrs = ["humanoid_plan_eval_system.h"],
     deps = [
         ":plan_eval_base_system",
+        "//drake/examples/QPInverseDynamicsForHumanoids/plan_eval:humanoid_manipulation_plan",
     ],
 )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
@@ -5,23 +5,12 @@
 #include <utility>
 #include <vector>
 
-#include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
-#include "drake/examples/QPInverseDynamicsForHumanoids/humanoid_status.h"
+#include "robotlocomotion/robot_plan_t.hpp"
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h"
 
 namespace drake {
 namespace examples {
 namespace qp_inverse_dynamics {
-
-// Example struct of a "Plan" object containing internal state such as desired
-// trajectories or setpoints.
-struct SimpleStandingPlan {
-  VectorSetpoint<double> joint_servo;
-  CartesianSetpoint<double> pelvis_servo;
-  CartesianSetpoint<double> torso_servo;
-  VectorSetpoint<double> com_servo;
-
-  Vector3<double> initial_com;
-};
 
 HumanoidPlanEvalSystem::HumanoidPlanEvalSystem(
     const RigidBodyTree<double>& robot,
@@ -29,97 +18,56 @@ HumanoidPlanEvalSystem::HumanoidPlanEvalSystem(
     const std::string& param_file_name, double dt)
     : PlanEvalBaseSystem(robot, alias_groups_file_name, param_file_name, dt) {
   set_name("HumanoidPlanEval");
-  abs_state_index_plan_ = DeclareAbstractState(
-      systems::AbstractValue::Make<SimpleStandingPlan>(SimpleStandingPlan()));
+
+  input_port_index_manip_plan_msg_ = DeclareAbstractInputPort().get_index();
+
+  auto plan_as_value = systems::AbstractValue::Make<GenericPlan<double>>(
+      HumanoidManipulationPlan<double>());
+  abs_state_index_plan_ = DeclareAbstractState(std::move(plan_as_value));
 }
 
 void HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     systems::State<double>* state) const {
   // Gets the plan from abstract state.
-  SimpleStandingPlan& plan = get_mutable_abstract_value<SimpleStandingPlan>(
+  GenericPlan<double>& plan = get_mutable_abstract_value<GenericPlan<double>>(
       state, abs_state_index_plan_);
 
   // Gets the robot state from input.
   const HumanoidStatus* robot_status = EvalInputValue<HumanoidStatus>(
       context, get_input_port_humanoid_status().get_index());
 
-  // Mutates the plan given the current state.
-  // This can be much more complicated like replanning trajectories, etc.
-  // Moves desired com height in a sine wave.
-  plan.com_servo.mutable_desired_position()[2] =
-      plan.initial_com[2] + 0.1 * std::sin(context.get_time() * 2 * M_PI);
+  // Gets the plan message fron input.
+  const systems::AbstractValue* msg_as_value =
+      EvalAbstractInput(context, input_port_index_manip_plan_msg_);
+  DRAKE_DEMAND(msg_as_value != nullptr);
 
-  // Generates a QpInput and stores it in AbstractState.
+  // Handles the plan.
+  plan.HandlePlan(*robot_status, get_paramset(), get_alias_groups(),
+                  *msg_as_value);
+
+  // Runs the controller.
+  plan.ModifyPlan(*robot_status, get_paramset(), get_alias_groups());
+
+  // Updates the QpInput in AbstractState.
   QpInput& qp_input = get_mutable_qp_input(state);
-
-  // Does acceleration feedback based on the plan.
-  qp_input.mutable_desired_centroidal_momentum_dot()
-      .mutable_values()
-      .tail<3>() = get_robot().getMass() *
-                   plan.com_servo.ComputeTargetAcceleration(
-                       robot_status->com(), robot_status->comd());
-
-  qp_input.mutable_desired_dof_motions().mutable_values() =
-      plan.joint_servo.ComputeTargetAcceleration(robot_status->position(),
-                                                 robot_status->velocity());
-
-  const std::string& pelvis_body_name =
-      get_alias_groups().get_body("pelvis")->get_name();
-  const std::string& torso_body_name =
-      get_alias_groups().get_body("torso")->get_name();
-
-  qp_input.mutable_desired_body_motions()
-      .at(pelvis_body_name)
-      .mutable_values() = plan.pelvis_servo.ComputeTargetAcceleration(
-      robot_status->pelvis().pose(), robot_status->pelvis().velocity());
-
-  qp_input.mutable_desired_body_motions().at(torso_body_name).mutable_values() =
-      plan.torso_servo.ComputeTargetAcceleration(
-          robot_status->torso().pose(), robot_status->torso().velocity());
+  plan.UpdateQpInput(*robot_status, get_paramset(), get_alias_groups(),
+                     &qp_input);
 }
 
-void HumanoidPlanEvalSystem::Initialize(const VectorX<double>& q_d,
-                                        systems::State<double>* state) {
-  // Gets the plan.
-  SimpleStandingPlan& plan = get_mutable_abstract_value<SimpleStandingPlan>(
+void HumanoidPlanEvalSystem::Initialize(const HumanoidStatus& current_status,
+                                        systems::State<double>* state) const {
+  // Initializes the plan.
+  GenericPlan<double>& plan = get_mutable_abstract_value<GenericPlan<double>>(
       state, abs_state_index_plan_);
+  plan.Initialize(current_status, get_paramset(), get_alias_groups());
 
-  KinematicsCache<double> cache = get_robot().doKinematics(q_d);
-
-  plan.initial_com = get_robot().centerOfMass(cache);
-  plan.pelvis_servo.mutable_desired_pose() = get_robot().relativeTransform(
-      cache, 0, get_alias_groups().get_body("pelvis")->get_body_index());
-  plan.torso_servo.mutable_desired_pose() = get_robot().relativeTransform(
-      cache, 0, get_alias_groups().get_body("torso")->get_body_index());
-
-  plan.com_servo = VectorSetpoint<double>(3);
-  plan.com_servo.mutable_desired_position() = plan.initial_com;
-
-  int dim = get_robot().get_num_velocities();
-  plan.joint_servo = VectorSetpoint<double>(dim);
-  plan.joint_servo.mutable_desired_position() = q_d;
-
-  // Sets the gains.
-  get_paramset().LookupDesiredBodyMotionGains(
-      *get_alias_groups().get_body("pelvis"), &(plan.pelvis_servo.mutable_Kp()),
-      &(plan.pelvis_servo.mutable_Kd()));
-  get_paramset().LookupDesiredBodyMotionGains(
-      *get_alias_groups().get_body("torso"), &(plan.torso_servo.mutable_Kp()),
-      &(plan.torso_servo.mutable_Kd()));
-  get_paramset().LookupDesiredDofMotionGains(&(plan.joint_servo.mutable_Kp()),
-                                             &(plan.joint_servo.mutable_Kd()));
-  Vector6<double> Kp, Kd;
-  get_paramset().LookupDesiredCentroidalMomentumDotGains(&Kp, &Kd);
-  plan.com_servo.mutable_Kp() = Kp.tail<3>();
-  plan.com_servo.mutable_Kd() = Kd.tail<3>();
-
-  // Initializes qp input.
+  // Uses the plan to initialize the first QpInput. This is important because
+  // on the first tick, CalcOutput will be called before unrestricted update,
+  // where outputs are "really" computed. So we need to compute it here first.
   QpInput& qp_input = get_mutable_qp_input(state);
-  qp_input =
-      get_paramset().MakeQpInput({"feet"},            /* contacts */
-                                 {"pelvis", "torso"}, /* tracked bodies */
-                                 get_alias_groups());
+  plan.UpdateQpInput(current_status, get_paramset(), get_alias_groups(),
+                     &qp_input);
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
@@ -12,6 +12,7 @@
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_value_source.h"
+#include "robotlocomotion/robot_plan_t.hpp"
 
 namespace drake {
 namespace examples {
@@ -69,12 +70,20 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     auto state_source = builder.AddSystem<systems::ConstantValueSource<double>>(
         systems::AbstractValue::Make<HumanoidStatus>(robot_status));
 
+    // Adds a dummy plan message.
+    robotlocomotion::robot_plan_t msg{};
+    auto plan_source = builder.AddSystem<systems::ConstantValueSource<double>>(
+        systems::AbstractValue::Make<robotlocomotion::robot_plan_t>(msg));
+
     // State -> qp inverse dynamics.
     builder.Connect(state_source->get_output_port(0),
                     controller->get_input_port_humanoid_status());
     // State -> plan eval.
     builder.Connect(state_source->get_output_port(0),
                     plan_eval->get_input_port_humanoid_status());
+    // Plan source -> plan eval.
+    builder.Connect(plan_source->get_output_port(0),
+                    plan_eval->get_input_port_manip_plan_msg());
     // plan eval -> qp inverse dynamics.
     builder.Connect(plan_eval->get_output_port_qp_input(),
                     controller->get_input_port_qp_input());
@@ -94,7 +103,7 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     // Initializes.
     auto& plan_eval_context =
         diagram_->GetMutableSubsystemContext(*plan_eval, context_.get());
-    plan_eval->Initialize(q, plan_eval_context.get_mutable_state());
+    plan_eval->Initialize(robot_status, plan_eval_context.get_mutable_state());
 
     // Computes results.
     auto events = diagram_->AllocateCompositeEventCollection();
@@ -149,7 +158,7 @@ TEST_F(HumanoidPlanEvalAndQpInverseDynamicsTest, DofAcceleration) {
 
       case ConstraintType::Soft:
         EXPECT_NEAR(qp_input.desired_dof_motions().value(i), qp_output.vd()[i],
-                    5e-4);
+                    1e-2);
         break;
 
       default:
@@ -165,7 +174,7 @@ TEST_F(HumanoidPlanEvalAndQpInverseDynamicsTest, ContactAcceleration) {
 
   for (const auto& contact_pair : qp_output.resolved_contacts()) {
     EXPECT_TRUE(drake::CompareMatrices(contact_pair.second.body_acceleration(),
-                                       Vector6<double>::Zero(), 1e-8,
+                                       Vector6<double>::Zero(), 1e-7,
                                        drake::MatrixCompareType::absolute));
   }
 }
@@ -181,7 +190,7 @@ TEST_F(HumanoidPlanEvalAndQpInverseDynamicsTest, BodyAcceleration) {
     EXPECT_TRUE(drake::CompareMatrices(
         body_motion_pair.second.accelerations(),
         qp_input.desired_body_motions().at(body_motion_pair.first).values(),
-        5e-4, drake::MatrixCompareType::absolute));
+        1e-3, drake::MatrixCompareType::absolute));
   }
 }
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
@@ -18,6 +18,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
+#include "robotlocomotion/robot_plan_t.hpp"
 
 namespace drake {
 namespace examples {
@@ -26,7 +27,8 @@ namespace qp_inverse_dynamics {
 /**
  * A controller for humanoid balancing built on top of HumanoidPlanEvalSystem
  * and QpControllerSystem. This diagram does not have any input or output ports.
- * The state inputs and control outputs are sent through LCM messages directly.
+ * The state and plan inputs and control outputs are sent through LCM messages
+ * directly.
  */
 class ValkyrieController : public systems::Diagram<double> {
  public:
@@ -61,6 +63,11 @@ class ValkyrieController : public systems::Diagram<double> {
             "EST_ROBOT_STATE", lcm));
     robot_state_subscriber_->set_name("robot_state_subscriber");
 
+    auto plan_subscriber = builder.AddSystem(
+        systems::lcm::LcmSubscriberSystem::Make<robotlocomotion::robot_plan_t>(
+            "VALKYRIE_MANIP_PLAN", lcm));
+    plan_subscriber->set_name("plan_subscriber");
+
     auto atlas_command_publisher = builder.AddSystem(
         systems::lcm::LcmPublisherSystem::Make<bot_core::atlas_command_t>(
             "ROBOT_COMMAND", lcm));
@@ -69,9 +76,11 @@ class ValkyrieController : public systems::Diagram<double> {
     // lcm -> rs
     builder.Connect(robot_state_subscriber_->get_output_port(0),
                     msg_to_humanoid_status->get_input_port_robot_state_msg());
-    // rs -> qp_input
+    // rs + plan -> qp_input
     builder.Connect(msg_to_humanoid_status->get_output_port_humanoid_status(),
                     plan_eval_->get_input_port_humanoid_status());
+    builder.Connect(plan_subscriber->get_output_port(0),
+                    plan_eval_->get_input_port_manip_plan_msg());
     // rs + qp_input -> qp_output
     builder.Connect(msg_to_humanoid_status->get_output_port_humanoid_status(),
                     qp_con->get_input_port_humanoid_status());

--- a/drake/examples/QPInverseDynamicsForHumanoids/test/valkyrie_balancing_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/test/valkyrie_balancing_test.cc
@@ -160,7 +160,7 @@ GTEST_TEST(testQPInverseDynamicsController, testBalancingStanding) {
   // generalized position and velocity.
   EXPECT_TRUE(robot_status.foot(Side::LEFT).velocity().norm() < 1e-6);
   EXPECT_TRUE(robot_status.foot(Side::RIGHT).velocity().norm() < 1e-6);
-  EXPECT_TRUE(drake::CompareMatrices(q, q_ini, 1e-4,
+  EXPECT_TRUE(drake::CompareMatrices(q, q_ini, 1e-3,
                                      drake::MatrixCompareType::absolute));
   EXPECT_TRUE(drake::CompareMatrices(
       v, VectorX<double>::Zero(robot->get_num_velocities()), 1e-4,

--- a/drake/systems/controllers/zmp_planner.h
+++ b/drake/systems/controllers/zmp_planner.h
@@ -68,7 +68,7 @@ namespace systems {
  */
 class ZMPPlanner {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ZMPPlanner)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ZMPPlanner)
 
   ZMPPlanner() {}
 
@@ -282,7 +282,7 @@ class ZMPPlanner {
   // Used to test whether the last point of the desired ZMP trajectory is
   // stationary or not in CheckStationaryEndPoint. This number is currently
   // arbitrarily chosen.
-  double kStationaryThreshold = 1e-8;
+  static constexpr double kStationaryThreshold = 1e-8;
 
   // Symbols:
   // x: [com; comd]


### PR DESCRIPTION
1. Replaced the old "moving pelvis up and down" plan eval block with a new one that listens to a lcm message of robotlocomotion::robot_plan_t. 
2. I put the new plan eval block in dev. 
3. Switched the param file from tracking COM height to tracking pelvis height. Had to tweak some tolerance settings in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6607)
<!-- Reviewable:end -->
