### PR TITLE
Add AutoDiff support when making Maliput Geo->Lane-space conversions

### DIFF
--- a/drake/automotive/maliput/api/BUILD.bazel
+++ b/drake/automotive/maliput/api/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_library(
     name = "api",
     srcs = [
+        "lane.cc",
         "lane_data.cc",
         "road_geometry.cc",
     ],
@@ -22,6 +23,7 @@ drake_cc_library(
         "type_specific_identifier.h",
     ],
     deps = [
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/math:geometric_transform",
     ],

--- a/drake/automotive/maliput/api/lane.cc
+++ b/drake/automotive/maliput/api/lane.cc
@@ -1,0 +1,50 @@
+#include "drake/automotive/maliput/api/lane.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+// These instantiations must match the API documentation in lane.h.
+template<>
+LanePositionT<double> Lane::ToLanePositionT<double>(
+    const GeoPositionT<double>& geo_pos,
+    GeoPositionT<double>* nearest_point,
+    double* distance) const {
+  return DoToLanePosition(geo_pos, nearest_point, distance);
+}
+
+template<>
+LanePositionT<AutoDiffXd> Lane::ToLanePositionT<AutoDiffXd>(
+    const GeoPositionT<AutoDiffXd>& geo_pos,
+    GeoPositionT<AutoDiffXd>* nearest_point,
+    AutoDiffXd* distance) const {
+  // Fail fast if geo_pos contains derivatives of inconsistent sizes.
+  const Eigen::VectorXd deriv = geo_pos.x().derivatives();
+  DRAKE_THROW_UNLESS(deriv.size() == geo_pos.y().derivatives().size());
+  DRAKE_THROW_UNLESS(deriv.size() == geo_pos.z().derivatives().size());
+
+  LanePositionT<AutoDiffXd> result =
+      DoToLanePositionAutoDiff(geo_pos, nearest_point, distance);
+
+  // If the partial derivatives of result, nearest_point and distance are not of
+  // the same dimension as those in geo_pos, pad them with zeros of the same
+  // dismension as those in geo_pos.
+  Eigen::internal::make_coherent(result.s().derivatives(), deriv);
+  Eigen::internal::make_coherent(result.r().derivatives(), deriv);
+  Eigen::internal::make_coherent(result.h().derivatives(), deriv);
+  if (nearest_point != nullptr) {
+    const Vector3<AutoDiffXd>& xyz = nearest_point->xyz();
+    Eigen::internal::make_coherent(xyz.x().derivatives(), deriv);
+    Eigen::internal::make_coherent(xyz.y().derivatives(), deriv);
+    Eigen::internal::make_coherent(xyz.z().derivatives(), deriv);
+    nearest_point->set_xyz(xyz);
+  }
+  if (distance != nullptr) {
+    Eigen::internal::make_coherent(distance->derivatives(), deriv);
+  }
+  return result;
+}
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -5,6 +5,7 @@
 
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
+#include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
 
 namespace drake {
@@ -72,6 +73,7 @@ class Lane {
   /// "staying in the lane".
   RBounds lane_bounds(double s) const { return do_lane_bounds(s); }
 
+
   /// Returns the driveable lateral (r) bounds of the lane as a function of s.
   ///
   /// These are the lateral bounds for a position that is considered to be
@@ -91,27 +93,61 @@ class Lane {
   /// @pre The s component of @p lane_pos must be in domain [0, Lane::length()].
   /// @pre The r component of @p lane_pos must be in domain [Rmin, Rmax]
   ///      derived from Lane::driveable_bounds().
+  //
+  // TODO(jadecastro): Generalize `Lane::ToGeoPosition` (and possibly others)
+  // with another member function `Lane::ToGeoPositionT<T>()`.
   GeoPosition ToGeoPosition(const LanePosition& lane_pos) const {
     return DoToGeoPosition(lane_pos);
   }
 
-  /// Determines the LanePosition corresponding to GeoPosition @p geo_position.
+  /// Determines the LanePosition corresponding to GeoPosition @p geo_pos.
   ///
   /// The return value is the LanePosition of the point within the Lane's
-  /// driveable-bounds which is closest to @p geo_position (as measured by
-  /// the Cartesian metric in the world frame).  If @p nearest_point is
-  /// non-null, then it will be populated with the GeoPosition of that
-  /// nearest point.  If @p distance is non-null, then it will be populated
-  /// with the Cartesian distance from @p geo_position to that nearest point.
+  /// driveable-bounds which is closest to @p geo_pos (as measured by the
+  /// Cartesian metric in the world frame).  If @p nearest_point is non-null,
+  /// then it will be populated with the GeoPosition of that nearest point.  If
+  /// @p distance is non-null, then it will be populated with the Cartesian
+  /// distance from @p geo_pos to that nearest point.
   ///
   /// This method guarantees that its result satisfies the condition that
   /// `ToGeoPosition(result)` is within `linear_tolerance()` of
   /// `*nearest_position`.
-  LanePosition ToLanePosition(const GeoPosition& geo_position,
+  LanePosition ToLanePosition(const GeoPosition& geo_pos,
                               GeoPosition* nearest_point,
                               double* distance) const {
-    return DoToLanePosition(geo_position, nearest_point, distance);
+    return DoToLanePosition(geo_pos, nearest_point, distance);
   }
+
+  /// Generalization of ToLanePosition to arbitrary scalar types, where the
+  /// structures `LanePositionT<T>` and `GeoPositionT<T>` are used in place of
+  /// `LanePosition` and `GeoPosition`, respectively.
+  ///
+  /// When the arguments are of type AutoDiffXd, the return value is a
+  /// LanePositionT<AutoDiffXd> containing the same partial derivatives as those
+  /// appearing in geo_pos.  The provided geo_pos must contain x, y, and z
+  /// values whose derivative must be of the same size.  If either @p
+  /// nearest_point or @p distance are non-null, they will also contain @p
+  /// geo_pos's partial derivatives.
+  ///
+  /// Instantiated templates for the following kinds of T's are provided:
+  /// - double
+  /// - drake::AutoDiffXd
+  ///
+  /// They are already available to link against in the containing library.
+  ///
+  /// Note: This is an experimental API that is not necessarily implemented in
+  /// all back-end implementations.
+  //
+  // TODO(jadecastro): Consider having the client enforce the geo_pos AutoDiffXd
+  // coherency contract rather than api::Lane.  Reevaluate this once an AutoDiff
+  // consumer for api::ToLanePositionT() exists.
+  //
+  // TODO(jadecastro): Apply this implementation in all the subclasses of
+  // `api::Lane`.
+  template <typename T>
+  LanePositionT<T> ToLanePositionT(const GeoPositionT<T>& geo_pos,
+                                   GeoPositionT<T>* nearest_point,
+                                   T* distance) const;
 
   // TODO(maddog@tri.global) Method to convert LanePosition to that of
   //                         another Lane.  (Should assert that both
@@ -200,9 +236,10 @@ class Lane {
 
   virtual GeoPosition DoToGeoPosition(const LanePosition& lane_pos) const = 0;
 
-  virtual LanePosition DoToLanePosition(const GeoPosition& geo_position,
-                                        GeoPosition* nearest_point,
-                                        double* distance) const = 0;
+  virtual LanePosition DoToLanePosition(
+      const GeoPosition& geo_pos,
+      GeoPosition* nearest_point,
+      double* distance) const = 0;
 
   virtual Rotation DoGetOrientation(const LanePosition& lane_pos) const = 0;
 
@@ -220,6 +257,19 @@ class Lane {
 
   virtual std::unique_ptr<LaneEnd> DoGetDefaultBranch(
       const LaneEnd::Which which_end) const = 0;
+
+  // AutoDiffXd overload of DoToLanePosition().
+  virtual LanePositionT<AutoDiffXd> DoToLanePositionAutoDiff(
+      const GeoPositionT<AutoDiffXd>&,
+      GeoPositionT<AutoDiffXd>*,
+      AutoDiffXd*) const {
+    throw std::runtime_error(
+        "DoToLanePosition has been instantiated with AutoDiffXd arguments, "
+        "but a Lane back-end has not overrided its AutoDiffXd specialization.");
+  }
+
+  // TODO(jadecastro): Template the entire `api::Lane` class to prevent explicit
+  // virtual functions for each member function.
   ///@}
 };
 

--- a/drake/automotive/maliput/api/lane_data.cc
+++ b/drake/automotive/maliput/api/lane_data.cc
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace maliput {
 namespace api {
@@ -21,14 +23,6 @@ std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position) {
       << ", z = " << geo_position.z() << ")";
 }
 
-bool operator==(const GeoPosition& lhs, const GeoPosition& rhs) {
-  return (lhs.xyz() == rhs.xyz());
-}
-
-bool operator!=(const GeoPosition& lhs, const GeoPosition& rhs) {
-  return (lhs.xyz() != rhs.xyz());
-}
-
 std::ostream& operator<<(std::ostream& out, const LanePosition& lane_position) {
   return out << "(s = " << lane_position.s() << ", r = " << lane_position.r()
       << ", h = " << lane_position.h() << ")";
@@ -37,3 +31,9 @@ std::ostream& operator<<(std::ostream& out, const LanePosition& lane_position) {
 }  // namespace api
 }  // namespace maliput
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::maliput::api::GeoPositionT)
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::maliput::api::LanePositionT)

--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -15,9 +15,7 @@ namespace drake {
 namespace maliput {
 namespace api {
 
-
 class Lane;
-
 
 /// A specific endpoint of a specific Lane.
 struct LaneEnd {
@@ -124,51 +122,60 @@ class Rotation {
 /// text-logging. It is not intended for serialization.
 std::ostream& operator<<(std::ostream& out, const Rotation& rotation);
 
-/// A position in 3-dimensional geographical Cartesian space, i.e.,
-/// in the world frame, consisting of three components x, y, and z.
-class GeoPosition {
+
+/// A position in 3-dimensional geographical Cartesian space, i.e., in the world
+/// frame, consisting of three components x, y, and z.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - drake::AutoDiffXd
+///
+/// They are already available to link against in the containing library.
+template <typename T>
+class GeoPositionT {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeoPosition)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeoPositionT)
 
   /// Default constructor, initializing all components to zero.
-  GeoPosition() : xyz_(0., 0., 0.) {}
+  GeoPositionT() : xyz_(T(0.), T(0.), T(0.)) {}
 
   /// Fully parameterized constructor.
-  GeoPosition(double x, double y, double z) : xyz_(x, y, z) {}
+  GeoPositionT(const T& x, const T& y, const T& z) : xyz_(x, y, z) {}
 
-  /// Fully parameterized constructor from a 3-vector @p xyz of the form
-  /// `[x, y, z]`.
-  explicit GeoPosition(const Vector3<double>& xyz) : xyz_(xyz) {}
-
-  /// Constructs a GeoPosition from a 3-vector @p xyz of the form `[x, y, z]`.
-  static GeoPosition FromXyz(const Vector3<double>& xyz) {
-    return GeoPosition(xyz);
+  /// Constructs a GeoPositionT from a 3-vector @p xyz of the form `[x, y, z]`.
+  static GeoPositionT<T> FromXyz(const Vector3<T>& xyz) {
+    return GeoPositionT<T>(xyz);
   }
 
   /// Returns all components as 3-vector `[x, y, z]`.
-  const Vector3<double>& xyz() const { return xyz_; }
+  const Vector3<T>& xyz() const { return xyz_; }
   /// Sets all components from 3-vector `[x, y, z]`.
-  void set_xyz(const Vector3<double>& xyz) { xyz_ = xyz; }
+  void set_xyz(const Vector3<T>& xyz) { xyz_ = xyz; }
 
   /// @name Getters and Setters
   //@{
   /// Gets `x` value.
-  double x() const { return xyz_.x(); }
+  T x() const { return xyz_.x(); }
   /// Sets `x` value.
-  void set_x(double x) { xyz_.x() = x; }
+  void set_x(const T& x) { xyz_.x() = x; }
   /// Gets `y` value.
-  double y() const { return xyz_.y(); }
+  T y() const { return xyz_.y(); }
   /// Sets `y` value.
-  void set_y(double y) { xyz_.y() = y; }
-  /// Gets `z` vaue.
-  double z() const { return xyz_.z(); }
+  void set_y(const T& y) { xyz_.y() = y; }
+  /// Gets `z` value.
+  T z() const { return xyz_.z(); }
   /// Sets `z` value.
-  void set_z(double z) { xyz_.z() = z; }
+  void set_z(const T& z) { xyz_.z() = z; }
   //@}
 
  private:
-  Vector3<double> xyz_;
+  explicit GeoPositionT(const Vector3<T>& xyz) : xyz_(xyz) {}
+
+  Vector3<T> xyz_;
 };
+
+// Alias for the double scalar type.
+using GeoPosition = GeoPositionT<double>;
 
 /// Streams a string representation of @p geo_position into @p out. Returns
 /// @p out. This method is provided for the purposes of debugging or
@@ -176,56 +183,72 @@ class GeoPosition {
 std::ostream& operator<<(std::ostream& out, const GeoPosition& geo_position);
 
 /// GeoPosition overload for the equality operator.
-bool operator==(const GeoPosition& lhs, const GeoPosition& rhs);
+template <typename T>
+bool operator==(const GeoPositionT<T>& lhs, const GeoPositionT<T>& rhs) {
+    return (lhs.xyz() == rhs.xyz());
+}
 
 /// GeoPosition overload for the inequality operator.
-bool operator!=(const GeoPosition& lhs, const GeoPosition& rhs);
+template <typename T>
+bool operator!=(const GeoPositionT<T>& lhs, const GeoPositionT<T>& rhs) {
+    return !(lhs.xyz() == rhs.xyz());
+}
 
 /// A 3-dimensional position in a `Lane`-frame, consisting of three components:
 ///  * s is longitudinal position, as arc-length along a Lane's reference line.
 ///  * r is lateral position, perpendicular to the reference line at s.
 ///  * h is height above the road surface.
-class LanePosition {
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - drake::AutoDiffXd
+///
+/// They are already available to link against in the containing library.
+template <typename T>
+class LanePositionT {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LanePosition)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LanePositionT)
 
   /// Default constructor, initializing all components to zero.
-  LanePosition() : srh_(0., 0., 0.) {}
+  LanePositionT() : srh_(T(0.), T(0.), T(0.)) {}
 
   /// Fully parameterized constructor.
-  LanePosition(double s, double r, double h) : srh_(s, r, h) {}
+  LanePositionT(const T& s, const T& r, const T& h) : srh_(s, r, h) {}
 
   /// Constructs a LanePosition from a 3-vector @p srh of the form `[s, r, h]`.
-  static LanePosition FromSrh(const Vector3<double>& srh) {
-    return LanePosition(srh);
+  static LanePositionT<T> FromSrh(const Vector3<T>& srh) {
+    return LanePositionT<T>(srh);
   }
 
   /// Returns all components as 3-vector `[s, r, h]`.
-  const Vector3<double>& srh() const { return srh_; }
+  const Vector3<T>& srh() const { return srh_; }
   /// Sets all components from 3-vector `[s, r, h]`.
-  void set_srh(const Vector3<double>& srh) { srh_ = srh; }
+  void set_srh(const Vector3<T>& srh) { srh_ = srh; }
 
   /// @name Getters and Setters
   //@{
   /// Gets `s` value.
-  double s() const { return srh_.x(); }
+  T s() const { return srh_.x(); }
   /// Sets `s` value.
-  void set_s(double s) { srh_.x() = s; }
+  void set_s(const T& s) { srh_.x() = s; }
   /// Gets `r` value.
-  double r() const { return srh_.y(); }
+  T r() const { return srh_.y(); }
   /// Sets `r` value.
-  void set_r(double r) { srh_.y() = r; }
+  void set_r(const T& r) { srh_.y() = r; }
   /// Gets `h` value.
-  double h() const { return srh_.z(); }
+  T h() const { return srh_.z(); }
   /// Sets `h` value.
-  void set_h(double h) { srh_.z() = h; }
+  void set_h(const T& h) { srh_.z() = h; }
   //@}
 
  private:
-  Vector3<double> srh_;
+  explicit LanePositionT(const Vector3<T>& srh) : srh_(srh) {}
 
-  explicit LanePosition(const Vector3<double>& srh) : srh_(srh) {}
+  Vector3<T> srh_;
 };
+
+// Alias for the double scalar type.
+using LanePosition = LanePositionT<double>;
 
 /// Streams a string representation of @p lane_position into @p out. Returns
 /// @p out. This method is provided for the purposes of debugging or

--- a/drake/automotive/maliput/api/test/lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/lane_data_test.cc
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_types.h"
+#include "drake/common/autodiff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
@@ -10,134 +10,184 @@ namespace maliput {
 namespace api {
 namespace {
 
-#define CHECK_ALL_LANE_POSITION_ACCESSORS(dut, _s, _r, _h)       \
-  do {                                                           \
-    EXPECT_EQ(dut.s(), _s);                                      \
-    EXPECT_EQ(dut.r(), _r);                                      \
-    EXPECT_EQ(dut.h(), _h);                                      \
-    EXPECT_TRUE(CompareMatrices(dut.srh(), Vector3<double>(_s, _r, _h))); \
+static constexpr double kX0 = 23.;
+static constexpr double kX1 = 75.;
+static constexpr double kX2 = 0.567;
+
+// TODO(jadecastro) Use CompareMatrices() to implement the
+// LanePositionT<T>::srh() accessor checks once AutoDiff supported.
+#define CHECK_ALL_LANE_POSITION_ACCESSORS(dut, _s, _r, _h)              \
+  do {                                                                  \
+    EXPECT_EQ(dut.s(), _s);                                             \
+    EXPECT_EQ(dut.r(), _r);                                             \
+    EXPECT_EQ(dut.h(), _h);                                             \
+    EXPECT_EQ(dut.srh().rows(), 3);                                     \
+    EXPECT_EQ(dut.srh().cols(), 1);                                     \
+    EXPECT_EQ(dut.srh().x(), _s);                                       \
+    EXPECT_EQ(dut.srh().y(), _r);                                       \
+    EXPECT_EQ(dut.srh().z(), _h);                                       \
   } while (0)
 
+// Class for defining identical tests in LanePositionTest across different
+// scalar types, T.
+template <typename T>
+class LanePositionTest : public ::testing::Test {};
 
-GTEST_TEST(LanePositionTest, DefaultConstructor) {
+typedef ::testing::Types<double, AutoDiffXd> Implementations;
+TYPED_TEST_CASE(LanePositionTest, Implementations);
+
+
+TYPED_TEST(LanePositionTest, DefaultConstructor) {
   // Check that default constructor obeys its contract.
-  LanePosition dut;
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 0., 0., 0.);
+  using T = TypeParam;
+  const LanePositionT<T> dut;
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(0.), T(0.), T(0.));
 }
 
 
-GTEST_TEST(LanePositionTest, ParameterizedConstructor) {
+TYPED_TEST(LanePositionTest, ParameterizedConstructor) {
   // Check the fully-parameterized constructor.
-  LanePosition dut(23., 75., 0.567);
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+  using T = TypeParam;
+  const LanePositionT<T> dut(kX0, kX1, kX2);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(kX0), T(kX1), T(kX2));
 }
 
 
-GTEST_TEST(LanePositionTest, ConstructionFromVector) {
+TYPED_TEST(LanePositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
-  LanePosition dut = LanePosition::FromSrh(Vector3<double>(23., 75., 0.567));
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+  using T = TypeParam;
+  const LanePositionT<T> dut =
+      LanePositionT<T>::FromSrh(Vector3<T>(kX0, kX1, kX2));
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(kX0), T(kX1), T(kX2));
 }
 
 
-GTEST_TEST(LanePositionTest, VectorSetter) {
+TYPED_TEST(LanePositionTest, VectorSetter) {
   // Check the vector-based setter.
-  LanePosition dut(23., 75., 0.567);
-  dut.set_srh(Vector3<double>(9., 7., 8.));
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 9., 7., 8.);
+  using T = TypeParam;
+  LanePositionT<T> dut(kX0, kX1, kX2);
+  const Vector3<T> srh(T(9.), T(7.), T(8.));
+  dut.set_srh(srh);
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(srh.x()), T(srh.y()), T(srh.z()));
 }
 
 
-GTEST_TEST(LanePositionTest, ComponentSetters) {
+TYPED_TEST(LanePositionTest, ComponentSetters) {
   // Check the individual component setters.
-  LanePosition dut(0.1, 0.2, 0.3);
+  using T = TypeParam;
+  LanePositionT<T> dut(T(0.1), T(0.2), T(0.3));
 
-  dut.set_s(99.);
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 0.2, 0.3);
+  dut.set_s(T(99.));
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(99.), T(0.2), T(0.3));
 
-  dut.set_r(2.3);
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 2.3, 0.3);
+  dut.set_r(T(2.3));
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(99.), T(2.3), T(0.3));
 
-  dut.set_h(42.);
-  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, 99., 2.3, 42.);
+  dut.set_h(T(42.));
+  CHECK_ALL_LANE_POSITION_ACCESSORS(dut, T(99.), T(2.3), T(42.));
 }
 
 #undef CHECK_ALL_LANE_POSITION_ACCESSORS
 
-
+// TODO(jadecastro) Use CompareMatrices() to implement the
+// GeoPositionT<T>::xyz() accessor checks once AutoDiff supported.
 #define CHECK_ALL_GEO_POSITION_ACCESSORS(dut, _x, _y, _z)               \
   do {                                                                  \
     EXPECT_EQ(dut.x(), _x);                                             \
     EXPECT_EQ(dut.y(), _y);                                             \
     EXPECT_EQ(dut.z(), _z);                                             \
-    EXPECT_TRUE(CompareMatrices(dut.xyz(), Vector3<double>(_x, _y, _z))); \
+    EXPECT_EQ(dut.xyz().rows(), 3);                                     \
+    EXPECT_EQ(dut.xyz().cols(), 1);                                     \
+    EXPECT_EQ(dut.xyz().x(), _x);                                       \
+    EXPECT_EQ(dut.xyz().y(), _y);                                       \
+    EXPECT_EQ(dut.xyz().z(), _z);                                       \
   } while (0)
 
+// Class for defining identical tests in GeoPositionTest across different scalar
+// types, T.
+template <typename T>
+class GeoPositionTest : public ::testing::Test {};
 
-GTEST_TEST(GeoPositionTest, DefaultConstructor) {
+typedef ::testing::Types<double, AutoDiffXd> Implementations;
+TYPED_TEST_CASE(GeoPositionTest, Implementations);
+
+TYPED_TEST(GeoPositionTest, DefaultConstructor) {
   // Check that default constructor obeys its contract.
-  GeoPosition dut;
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 0., 0., 0.);
+  using T = TypeParam;
+  const GeoPositionT<T> dut;
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(0.), T(0.), T(0.));
 }
 
 
-GTEST_TEST(GeoPositionTest, ParameterizedConstructor) {
+TYPED_TEST(GeoPositionTest, ParameterizedConstructor) {
   // Check the fully-parameterized constructor.
-  GeoPosition dut(23., 75., 0.567);
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+  using T = TypeParam;
+  const GeoPositionT<T> dut(kX0, kX1, kX2);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(kX0), T(kX1), T(kX2));
 }
 
 
-GTEST_TEST(GeoPositionTest, ConstructionFromVector) {
+TYPED_TEST(GeoPositionTest, ConstructionFromVector) {
   // Check the conversion-construction from a 3-vector.
-  GeoPosition dut = GeoPosition::FromXyz(Vector3<double>(23., 75., 0.567));
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 23., 75., 0.567);
+  using T = TypeParam;
+  const GeoPositionT<T> dut =
+      GeoPositionT<T>::FromXyz(Vector3<T>(T(kX0), T(kX1), T(kX2)));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(kX0), T(kX1), T(kX2));
 }
 
 
-GTEST_TEST(GeoPositionTest, VectorSetter) {
+TYPED_TEST(GeoPositionTest, VectorSetter) {
   // Check the vector-based setter.
-  GeoPosition dut(23., 75., 0.567);
-  dut.set_xyz(Vector3<double>(9., 7., 8.));
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 9., 7., 8.);
+  using T = TypeParam;
+  GeoPositionT<T> dut(kX0, kX1, kX2);
+  const Vector3<T> xyz(T(9.), T(7.), T(8.));
+  dut.set_xyz(xyz);
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(xyz.x()), T(xyz.y()), T(xyz.z()));
 }
 
 
-GTEST_TEST(GeoPositionTest, ComponentSetters) {
+TYPED_TEST(GeoPositionTest, ComponentSetters) {
   // Check the individual component setters.
-  GeoPosition dut(0.1, 0.2, 0.3);
+  using T = TypeParam;
+  GeoPositionT<T> dut(0.1, 0.2, 0.3);
 
-  dut.set_x(99.);
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 0.2, 0.3);
+  dut.set_x(T(99.));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(99.), T(0.2), T(0.3));
 
-  dut.set_y(2.3);
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 2.3, 0.3);
+  dut.set_y(T(2.3));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(99.), T(2.3), T(0.3));
 
-  dut.set_z(42.);
-  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, 99., 2.3, 42.);
+  dut.set_z(T(42.));
+  CHECK_ALL_GEO_POSITION_ACCESSORS(dut, T(99.), T(2.3), T(42.));
 }
 
-GTEST_TEST(GeoPositionTest, EqualityInequalityOperators) {
+#undef CHECK_ALL_GEO_POSITION_ACCESSORS
+
+TYPED_TEST(GeoPositionTest, EqualityInequalityOperators) {
   // Checks that equality is true iff the constituent components are all equal,
   // and that inequality is true otherwise.
-  GeoPosition gp1(0.1, 0.2, 0.3);
-  GeoPosition gp2(0.1, 0.2, 0.3);
+  using T = TypeParam;
+  GeoPositionT<T> gp1(0.1, 0.2, 0.3);
+  GeoPositionT<T> gp2(0.1, 0.2, 0.3);
 
   EXPECT_TRUE(gp1 == gp2);
   EXPECT_FALSE(gp1 != gp2);
 
-  GeoPosition gp_xerror(gp2.x() + 1e-6, gp2.y(), gp2.z());
+  GeoPositionT<T> gp_xerror(gp2.x() + T(1e-6), gp2.y(), gp2.z());
   EXPECT_FALSE(gp1 == gp_xerror);
   EXPECT_TRUE(gp1 != gp_xerror);
-  GeoPosition gp_yerror(gp2.x(), gp2.y() + 1e-6, gp2.z());
+  GeoPositionT<T> gp_yerror(gp2.x(), gp2.y() + T(1e-6), gp2.z());
   EXPECT_FALSE(gp1 == gp_yerror);
   EXPECT_TRUE(gp1 != gp_xerror);
-  GeoPosition gp_zerror(gp2.x(), gp2.y(), gp2.z() + 1e-6);
+  GeoPositionT<T> gp_zerror(gp2.x(), gp2.y(), gp2.z() + T(1e-6));
   EXPECT_FALSE(gp1 == gp_zerror);
   EXPECT_TRUE(gp1 != gp_xerror);
-}
 
-#undef CHECK_ALL_GEO_POSITION_ACCESSORS
+  GeoPositionT<T> gp_nan1(NAN, NAN, NAN);
+  GeoPositionT<T> gp_nan2(NAN, NAN, NAN);
+  EXPECT_TRUE(gp_nan1 != gp_nan2);
+  EXPECT_FALSE(gp_nan1 == gp_nan2);
+}
 
 // An arbitrary very small number (that passes the tests).
 const double kRotationTolerance = 1e-15;

--- a/drake/automotive/maliput/dragway/BUILD.bazel
+++ b/drake/automotive/maliput/dragway/BUILD.bazel
@@ -58,6 +58,7 @@ drake_cc_googletest(
     deps = [
         ":dragway",
         "//drake/automotive/maliput/api/test_utilities",
+        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -1,6 +1,8 @@
 #include "drake/automotive/maliput/dragway/lane.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -102,29 +104,74 @@ api::LanePosition Lane::DoToLanePosition(
     const api::GeoPosition& geo_pos,
     api::GeoPosition* nearest_point,
     double* distance) const {
+  return ImplDoToLanePositionT<double>(geo_pos, nearest_point, distance);
+}
 
-  const double min_x = 0;
-  const double max_x = length_;
-  const double min_y = driveable_bounds_.min() + y_offset_;
-  const double max_y = driveable_bounds_.max() + y_offset_;
-  const double min_z = elevation_bounds_.min();
-  const double max_z = elevation_bounds_.max();
+api::LanePositionT<AutoDiffXd> Lane::DoToLanePositionAutoDiff(
+    const api::GeoPositionT<AutoDiffXd>& geo_pos,
+    api::GeoPositionT<AutoDiffXd>* nearest_point,
+    AutoDiffXd* distance) const {
+  return ImplDoToLanePositionT<AutoDiffXd>(geo_pos, nearest_point, distance);
+}
 
-  const api::GeoPosition closest_point{
-    math::saturate(geo_pos.x(), min_x, max_x),
-    math::saturate(geo_pos.y(), min_y, max_y),
-    math::saturate(geo_pos.z(), min_z, max_z)};
+template <typename T>
+api::LanePositionT<T> Lane::ImplDoToLanePositionT(
+    const api::GeoPositionT<T>& geo_pos,
+    api::GeoPositionT<T>* nearest_point,
+    T* distance) const {
+  using math::saturate;
+
+  const T min_x{0.};
+  const T max_x{length_};
+  const T min_y{driveable_bounds_.min() + y_offset_};
+  const T max_y{driveable_bounds_.max() + y_offset_};
+  const T min_z{elevation_bounds_.min()};
+  const T max_z{elevation_bounds_.max()};
+
+  const T x = geo_pos.x();
+  const T y = geo_pos.y();
+  const T z = geo_pos.z();
+
+  api::GeoPositionT<T> closest_point{
+    saturate(x, min_x, max_x),
+    saturate(y, min_y, max_y),
+    saturate(z, min_z, max_z)};
   if (nearest_point != nullptr) {
     *nearest_point = closest_point;
   }
 
   if (distance != nullptr) {
-    *distance = (geo_pos.xyz() - closest_point.xyz()).norm();
+    const T distance_unsat = (geo_pos.xyz() - closest_point.xyz()).norm();
+
+    // N.B. Under AutoDiff, the partial derivative of the distance with respect
+    // to position is undefined (i.e. NaN) when distance.value() = 0.  This
+    // implementation replaces those NaN values with numbers that are consistent
+    // with the geometry such that the following hold:
+    //
+    // Let v be any coordinate x, y, or z.
+    //
+    // 1) Within the interior of the lane volume, ∂/∂v(distance) = 0, since
+    // distance is invariant to perturbations in v.
+    //
+    // 2) On the exterior of the lane, ∂/∂v(distance) is identical to
+    // ∂/∂v(distance_unsat).
+    //
+    // 3) On the boundary, ∂/∂v(distance) has two solutions: zero or
+    // ∂/∂v(distance_unsat), depending on whether the derivative at the boundary
+    // is evaluated when approached from the exterior or interior.  This
+    // implementation chooses the derivatives taken from within the interior
+    // (zero) in order to remain consistent with the derivatives of
+    // nearest_point and the returned LanePositionT.
+    if (distance_unsat > T(0.)) {
+      *distance = distance_unsat;
+    } else {  // ∂/∂x(distance) = 0 when distance = 0.
+      *distance = T(0.);
+    }
   }
 
-  return api::LanePosition(closest_point.x()              /* s */,
-                           closest_point.y() - y_offset_  /* r */,
-                           closest_point.z()              /* h */);
+  return {closest_point.x(),
+          closest_point.y() - T(y_offset_),
+          closest_point.z()};
 }
 
 }  // namespace dragway

--- a/drake/automotive/maliput/dragway/lane.h
+++ b/drake/automotive/maliput/dragway/lane.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
+#include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
 namespace maliput {
@@ -66,9 +67,9 @@ class Segment;
   the surface itself. The origin of the lane's frame is defined by the `o` along
   the above-shown `s = 0` line.
 
-  Note: Each dagway lane has a teleportation feature at both ends: the (default)
-  ongoing lane for LaneEnd::kFinish is LaneEnd::kStart of the same lane, and
-  vice versa.
+  Note: Each dragway lane has a teleportation feature at both ends: the
+  (default) ongoing lane for LaneEnd::kFinish is LaneEnd::kStart of the same
+  lane, and vice versa.
 **/
 class Lane final : public api::Lane {
  public:
@@ -99,7 +100,7 @@ class Lane final : public api::Lane {
   ///        the entire reference path.
   ///
   Lane(const Segment* segment, const api::LaneId& id,  int index, double length,
-      double y_offset, const api::RBounds& lane_bounds,
+       double y_offset, const api::RBounds& lane_bounds,
        const api::RBounds& driveable_bounds,
        const api::HBounds& elevation_bounds);
 
@@ -163,6 +164,17 @@ class Lane final : public api::Lane {
                                      api::GeoPosition* nearest_point,
                                      double* distance) const final;
 
+  api::LanePositionT<AutoDiffXd> DoToLanePositionAutoDiff(
+      const api::GeoPositionT<AutoDiffXd>& geo_pos,
+      api::GeoPositionT<AutoDiffXd>* nearest_point,
+      AutoDiffXd* distance) const final;
+
+  template <typename T>
+  api::LanePositionT<T> ImplDoToLanePositionT(
+      const api::GeoPositionT<T>& geo_pos,
+      api::GeoPositionT<T>* nearest_point,
+      T* distance) const;
+
   const Segment* segment_{};  // The segment to which this lane belongs.
   const api::LaneId id_;
   const int index_{};  // The index of this lane within a Segment.
@@ -178,7 +190,6 @@ class Lane final : public api::Lane {
   const api::Lane* lane_to_left_{};
   const api::Lane* lane_to_right_{};
 };
-
 
 }  // namespace dragway
 }  // namespace maliput

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/dragway/junction.h"
 #include "drake/automotive/maliput/dragway/lane.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace maliput {
@@ -22,8 +23,13 @@ class MaliputDragwayLaneTest : public ::testing::Test {
       : length_(100.0),
         lane_width_(6.0),
         shoulder_width_(0.5),
-        maximum_height_(5.0) {
-  }
+        maximum_height_(5.0),
+        min_x_(0.),
+        max_x_(length_),
+        min_y_(-lane_width_ / 2 - shoulder_width_),
+        max_y_(lane_width_ / 2 + shoulder_width_),
+        min_z_(0.),
+        max_z_(maximum_height_) {}
 
   // Contains expected driveable r_min, driveable r_max, and y_offset parameters
   // of a Dragway Lane.
@@ -35,8 +41,26 @@ class MaliputDragwayLaneTest : public ::testing::Test {
     double elevation_max{};
   };
 
-  ExpectedLaneParameters GetExpectedLaneParameters(
-      int num_lanes, int lane_index) const {
+  void MakeDragway(int num_lanes) {
+    const api::RoadGeometryId road_geometry_id(std::to_string(num_lanes) +
+                                               "LaneDragwayRoadGeometry");
+    road_geometry_.reset(new RoadGeometry(
+        road_geometry_id, num_lanes, length_, lane_width_, shoulder_width_,
+        maximum_height_, kLinearTolerance, kAngularTolerance));
+
+    const api::Junction* junction = road_geometry_->junction(0);
+    ASSERT_NE(junction, nullptr);
+    segment_ = junction->segment(0);
+    ASSERT_NE(segment_, nullptr);
+    lane_ = dynamic_cast<const Lane*>(segment_->lane(0));
+    ASSERT_NE(lane_, nullptr);
+
+    EXPECT_EQ(lane_->length(), length_);
+    EXPECT_EQ(segment_->num_lanes(), num_lanes);
+  }
+
+  ExpectedLaneParameters GetExpectedLaneParameters(int num_lanes,
+                                                   int lane_index) const {
     ExpectedLaneParameters result{};
     if (num_lanes == 1) {
       result.y_offset = 0.0;
@@ -222,10 +246,82 @@ class MaliputDragwayLaneTest : public ::testing::Test {
     }
   }
 
+  void PopulateGeoPositionTestCases() {
+    /*
+      A figure of the one-lane dragway is shown below. The minimum and maximum
+      values of the dragway's driveable region are demarcated.
+
+      X
+      Y = max_y ^  Y = min_y
+      :
+      |     :     |
+      |     :     |
+      --------+-----+-----+---------  X = max_x
+      | .   :   . |
+      | .   :   . |
+      | .   :   . |
+      | .  The  . |
+      | .Dragway. |
+      | .   :   . |
+      | .   :   . |
+      | .   :   . |
+      Y <----------+-----o-----+---------  X = min_x
+      |     :     |
+      :
+      ->|-|<- : ->|-|<-  shoulder_width
+      :
+      |<--:-->|      lane_width
+      V
+    */
+
+    // Defines the test case values for x and y. Points both far away and close
+    // to the driveable area are evaluated, with a focus on edge cases.
+    std::vector<double> x_values{min_x_ - 10., min_x_ - 1e-10, min_x_,
+          min_x_ + 1e-10, (max_x_ + min_x_) / 2., max_x_ - 1e-10, max_x_,
+          max_x_ + 1e-10, max_x_ + 10.};
+    std::vector<double> y_values{min_y_ - 10., min_y_ - 1e-10, min_y_,
+          min_y_ + 1e-10, (max_y_ + min_y_) / 2., max_y_ - 1e-10, max_y_,
+          max_y_ + 1e-10, max_y_ + 10.};
+    std::vector<double> z_values{min_z_ - 10., min_z_ - 1e-10, min_z_,
+          min_z_ + 1e-10, (max_z_ + min_z_) / 2., max_z_ - 1e-10,  max_z_,
+          max_z_ + 1e-10, max_z_ + 10.};
+    x_test_cases_ = x_values;
+    y_test_cases_ = y_values;
+    z_test_cases_ = z_values;
+  }
+
+  std::vector<int> GetTransgressedBoundaries(
+      const api::GeoPositionT<AutoDiffXd>& geo_position) {
+    const int kXIndex = 0;
+    const int kYIndex = 1;
+    const int kZIndex = 2;
+
+    std::vector<int> result{};
+    const double x = geo_position.x().value();
+    if (x < min_x_ || x > max_x_) result.push_back(kXIndex);
+    const double y = geo_position.y().value();
+    if (y < min_y_ || y > max_y_) result.push_back(kYIndex);
+    const double z = geo_position.z().value();
+    if (z < min_z_ || z > max_z_) result.push_back(kZIndex);
+
+    return result;
+  }
+
+  std::unique_ptr<RoadGeometry> road_geometry_;
+  const api::Segment* segment_{nullptr};
+  const Lane* lane_{nullptr};
+
   const double length_{};
   const double lane_width_{};
   const double shoulder_width_{};
   const double maximum_height_{};
+
+  const double min_x_{};
+  const double max_x_{};
+  const double min_y_{};
+  const double max_y_{};
+  const double min_z_{};
+  const double max_z_{};
 
   // The following linear tolerance was empirically derived on a 64-bit Ubuntu
   // system. It is necessary due to inaccuracies in floating point calculations
@@ -233,6 +329,11 @@ class MaliputDragwayLaneTest : public ::testing::Test {
   const double kLinearTolerance = 1e-15;
 
   const double kAngularTolerance = std::numeric_limits<double>::epsilon();
+
+  // For tests involving ToLanePosition().
+  std::vector<double> x_test_cases_{};
+  std::vector<double> y_test_cases_{};
+  std::vector<double> z_test_cases_{};
 };
 
 /*
@@ -253,30 +354,15 @@ class MaliputDragwayLaneTest : public ::testing::Test {
                V
  */
 TEST_F(MaliputDragwayLaneTest, SingleLane) {
-  const api::RoadGeometryId road_geometry_id("OneLaneDragwayRoadGeometry");
   const int kNumLanes = 1;
+  MakeDragway(kNumLanes);
 
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_, lane_width_,
-                             shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
+  EXPECT_EQ(segment_->id(), api::SegmentId("Dragway_Segment_ID"));
+  EXPECT_EQ(lane_->segment(), segment_);
 
-  const api::Junction* junction = road_geometry.junction(0);
-  ASSERT_NE(junction, nullptr);
-  const api::Segment* segment = junction->segment(0);
-  ASSERT_NE(segment, nullptr);
-  EXPECT_EQ(segment->lane(0)->length(), length_);
-  EXPECT_EQ(segment->num_lanes(), 1);
-  EXPECT_EQ(segment->id(), api::SegmentId("Dragway_Segment_ID"));
-
-  const int kLaneIndex = 0;
-  const api::Lane* lane = segment->lane(kLaneIndex);
-  ASSERT_NE(lane, nullptr);
-  EXPECT_EQ(lane->segment(), segment);
-
-  VerifyLaneCorrectness(lane, kNumLanes);
-  VerifyBranches(lane, &road_geometry);
+  VerifyLaneCorrectness(lane_, kNumLanes);
+  VerifyBranches(lane_, road_geometry_.get());
 }
-
 
 /*
  Tests a dragway containing two lanes. The two lanes are arranged as shown below
@@ -298,28 +384,16 @@ TEST_F(MaliputDragwayLaneTest, SingleLane) {
                               V
  */
 TEST_F(MaliputDragwayLaneTest, TwoLaneDragway) {
-  const api::RoadGeometryId road_geometry_id("TwoLaneDragwayRoadGeometry");
   const int kNumLanes = 2;
+  MakeDragway(kNumLanes);
 
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_,
-                             lane_width_, shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
-
-  const api::Junction* junction = road_geometry.junction(0);
-  ASSERT_NE(junction, nullptr);
-  const api::Segment* segment = junction->segment(0);
-  ASSERT_NE(segment, nullptr);
-  const api::Lane* lane_zero = segment->lane(0);
-  ASSERT_NE(lane_zero, nullptr);
-  EXPECT_EQ(lane_zero->length(), length_);
-  EXPECT_EQ(segment->num_lanes(), kNumLanes);
-  EXPECT_EQ(segment->id(), api::SegmentId("Dragway_Segment_ID"));
+  EXPECT_EQ(segment_->id(), api::SegmentId("Dragway_Segment_ID"));
 
   for (int i = 0; i < kNumLanes; ++i) {
-    const api::Lane* lane = segment->lane(i);
+    const api::Lane* lane = segment_->lane(i);
     ASSERT_NE(lane, nullptr);
     VerifyLaneCorrectness(lane, kNumLanes);
-    VerifyBranches(lane, &road_geometry);
+    VerifyBranches(lane, road_geometry_.get());
   }
 }
 
@@ -329,12 +403,7 @@ TEST_F(MaliputDragwayLaneTest, TwoLaneDragway) {
 // dragway::RoadGeometry::IsGeoPositionOnDragway() does not incorrectly return
 // false.
 TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
-  const api::RoadGeometryId road_geometry_id("TwoLaneDragwayRoadGeometry");
-  const int kNumLanes = 2;
-
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_,
-                             lane_width_, shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
+  MakeDragway(2 /* num lanes */);
 
   // Spot checks geographic positions on lane 0 and the right shoulder with a
   // focus on edge cases.
@@ -344,11 +413,11 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
       for (double z = 0; z <= maximum_height_; z += maximum_height_ / 2.) {
         api::GeoPosition nearest_position;
         double distance;
-        const api::RoadPosition road_position = road_geometry.ToRoadPosition(
+        const api::RoadPosition road_position = road_geometry_->ToRoadPosition(
             api::GeoPosition(x, y, z), nullptr /* hint */, &nearest_position,
             &distance);
         const api::Lane* expected_lane =
-            road_geometry.junction(0)->segment(0)->lane(0);
+            road_geometry_->junction(0)->segment(0)->lane(0);
         EXPECT_TRUE(api::test::IsGeoPositionClose(
             nearest_position, api::GeoPosition(x, y, z),
             kLinearTolerance));
@@ -369,12 +438,12 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
       for (double z = 0; z <= maximum_height_; z += maximum_height_ / 2.) {
         api::GeoPosition nearest_position;
         double distance;
-        const api::RoadPosition road_position = road_geometry.ToRoadPosition(
+        const api::RoadPosition road_position = road_geometry_->ToRoadPosition(
             api::GeoPosition(x, y, z), nullptr /* hint */, &nearest_position,
             &distance);
         const int lane_index = (y == 0 ? 0 : 1);
         const api::Lane* expected_lane =
-            road_geometry.junction(0)->segment(0)->lane(lane_index);
+            road_geometry_->junction(0)->segment(0)->lane(lane_index);
         EXPECT_TRUE(api::test::IsGeoPositionClose(
             nearest_position, api::GeoPosition(x, y, z),
             kLinearTolerance));
@@ -402,12 +471,7 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOnRoad) {
 // dragway::RoadGeometry::IsGeoPositionOnDragway() does not incorrectly return
 // false.
 TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
-  const api::RoadGeometryId road_geometry_id("TwoLaneDragwayRoadGeometry");
-  const int kNumLanes = 2;
-
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_,
-                             lane_width_, shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
+  MakeDragway(2 /* num lanes */);
 
   // Computes the bounds of the road's driveable region.
   const double x_max = length_;
@@ -442,7 +506,7 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
       for (const auto z : z_test_cases) {
         api::GeoPosition nearest_position;
         double distance;
-        const api::RoadPosition road_position = road_geometry.ToRoadPosition(
+        const api::RoadPosition road_position = road_geometry_->ToRoadPosition(
             api::GeoPosition(x, y, z), nullptr /* hint */, &nearest_position,
             &distance);
         EXPECT_LE(nearest_position.x(), x_max);
@@ -481,7 +545,7 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
         EXPECT_LT(0, distance);
         const int expected_lane_index = (y > 0 ? 1 : 0);
         const Lane* expected_lane = dynamic_cast<const Lane*>(
-            road_geometry.junction(0)->segment(0)->lane(expected_lane_index));
+            road_geometry_->junction(0)->segment(0)->lane(expected_lane_index));
         EXPECT_EQ(road_position.lane, expected_lane);
         EXPECT_TRUE(api::test::IsLanePositionClose(
             road_position.pos,
@@ -498,22 +562,17 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionOffRoad) {
 // Tests that dragway::RoadGeometry::ToRoadPosition() can be called with
 // parameters `nearest_position` and `distance` set to `nullptr`.
 TEST_F(MaliputDragwayLaneTest, TestToRoadPositionNullptr) {
-  const api::RoadGeometryId road_geometry_id("TwoLaneDragwayRoadGeometry");
-  const int kNumLanes = 2;
-
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_,
-                             lane_width_, shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
+  MakeDragway(2 /* num lanes */);
 
   // Case 1: The provided geo_pos is in the driveable region.
-  EXPECT_NO_THROW(road_geometry.ToRoadPosition(
+  EXPECT_NO_THROW(road_geometry_->ToRoadPosition(
             api::GeoPosition(length_ / 2 /* x */, 0 /* y */, 0 /* z */),
             nullptr /* hint */,
             nullptr /* nearest_position */,
             nullptr /* distance */));
 
   // Case 2: The provided geo_pos is beyond the driveable region.
-  EXPECT_NO_THROW(road_geometry.ToRoadPosition(
+  EXPECT_NO_THROW(road_geometry_->ToRoadPosition(
             api::GeoPosition(length_ + 1e-10 /* x */, 0 /* y */, 0 /* z */),
             nullptr /* hint */,
             nullptr /* nearest_position */,
@@ -523,91 +582,36 @@ TEST_F(MaliputDragwayLaneTest, TestToRoadPositionNullptr) {
 // Tests dragway::Lane::ToLanePosition() using geographic positions whose
 // projections onto the XY plane reside within the lane's driveable region.
 TEST_F(MaliputDragwayLaneTest, TestToLanePosition) {
-  const api::RoadGeometryId road_geometry_id("OneLaneDragwayRoadGeometry");
-  const int kNumLanes = 1;
+  MakeDragway(1 /* num lanes */);
+  PopulateGeoPositionTestCases();
 
-  RoadGeometry road_geometry(road_geometry_id, kNumLanes, length_,
-                             lane_width_, shoulder_width_, maximum_height_,
-                             kLinearTolerance, kAngularTolerance);
-
-  const api::Junction* junction = road_geometry.junction(0);
-  ASSERT_NE(junction, nullptr);
-  const api::Segment* segment = junction->segment(0);
-  ASSERT_NE(segment, nullptr);
-  const Lane* lane = dynamic_cast<const Lane*>(segment->lane(0));
-  ASSERT_NE(lane, nullptr);
-  EXPECT_EQ(lane->length(), length_);
-
-  /*
-    A figure of the one-lane dragway is shown below. The minimum and maximum
-    values of the dragway's driveable region are demarcated.
- 
-                        X
-              Y = max_y ^  Y = min_y
-                        :
-                  |     :     |
-                  |     :     |
-          --------+-----+-----+---------  X = max_x
-                  | .   :   . |
-                  | .   :   . |
-                  | .   :   . |
-                  | .  The  . |
-                  | .Dragway. |
-                  | .   :   . |
-                  | .   :   . |
-                  | .   :   . |
-     Y <----------+-----o-----+---------  X = min_x
-                  |     :     |
-                        :
-                ->|-|<- : ->|-|<-  shoulder_width
-                        :
-                    |<--:-->|      lane_width
-                        V
-  */
-  const double min_x = 0;
-  const double max_x = length_;
-  const double min_y = -lane_width_ / 2 - shoulder_width_;
-  const double max_y = lane_width_ / 2 + shoulder_width_;
-  const double min_z = 0.;
-  const double max_z = maximum_height_;
-
-  // Defines the test case values for x and y. Points both far away and close to
-  // the driveable area are evaluated.
-  const std::vector<double> x_test_cases{
-    min_x - 10, min_x - 1e-10, min_x, max_x, max_x + 1e-10, max_x + 10};
-  const std::vector<double> y_test_cases{
-    min_y - 10, min_y - 1e-10, min_y, max_y, max_y + 1e-10, max_y + 10};
-  const std::vector<double> z_test_cases{
-    min_z - 10, min_z - 1e-10, min_z, max_z, max_z + 1e-10, max_z + 10};
-
-  // Spot checks geographic positions on and beyond the lane's driveable region
-  // with a focus on edge cases.
-  for (const auto x : x_test_cases) {
-    for (const auto y : y_test_cases) {
-      for (const double z : z_test_cases) {
+  for (const double x : x_test_cases_) {
+    for (const double y : y_test_cases_) {
+      for (const double z : z_test_cases_) {
         api::GeoPosition nearest_position;
         double distance;
-        const api::LanePosition lane_position = lane->ToLanePosition(
+        const api::LanePosition lane_position = lane_->ToLanePosition(
             api::GeoPosition(x, y, z), &nearest_position, &distance);
         api::GeoPosition expected_nearest_position(x, y, z);
-        if (x < min_x) {
-          expected_nearest_position.set_x(min_x);
+        if (x < min_x_) {
+          expected_nearest_position.set_x(min_x_);
         }
-        if (x > max_x) {
-          expected_nearest_position.set_x(max_x);
+        if (x > max_x_) {
+          expected_nearest_position.set_x(max_x_);
         }
-        if (y < min_y) {
-          expected_nearest_position.set_y(min_y);
+        if (y < min_y_) {
+          expected_nearest_position.set_y(min_y_);
         }
-        if (y > max_y) {
-          expected_nearest_position.set_y(max_y);
+        if (y > max_y_) {
+          expected_nearest_position.set_y(max_y_);
         }
-        if (z < min_z) {
-          expected_nearest_position.set_z(min_z);
+        if (z < min_z_) {
+          expected_nearest_position.set_z(min_z_);
         }
-        if (z > max_z) {
-          expected_nearest_position.set_z(max_z);
+        if (z > max_z_) {
+          expected_nearest_position.set_z(max_z_);
         }
+
         EXPECT_TRUE(api::test::IsGeoPositionClose(
             nearest_position, expected_nearest_position,
             kLinearTolerance));
@@ -615,13 +619,165 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePosition) {
         EXPECT_GE(distance, 0);
         EXPECT_TRUE(api::test::IsLanePositionClose(
             lane_position,
-            api::LanePosition(expected_nearest_position.x(),
-                              expected_nearest_position.y() - lane->y_offset(),
-                              expected_nearest_position.z()),
+            api::LanePosition(
+                expected_nearest_position.x(),
+                expected_nearest_position.y() - lane_->y_offset(),
+                expected_nearest_position.z()),
             kLinearTolerance));
       }
     }
   }
+}
+
+// Tests that AutoDiffXd returns values whose sizes and values match what is
+// expected, and preserving any partial derivatives given to it.
+TEST_F(MaliputDragwayLaneTest, TestToLanePositionAutoDiff) {
+  MakeDragway(1 /* num lanes */);
+  PopulateGeoPositionTestCases();
+
+  for (const double x : x_test_cases_) {
+    for (const double y : y_test_cases_) {
+      for (const double z : z_test_cases_) {
+        AutoDiffXd distance(0.);
+        api::GeoPositionT<AutoDiffXd> nearest_position;
+
+        // Define the partial derivatives with respect to geo_position's
+        // x-axis.  That is, seed geo_position with the partial derivatives
+        // ∂x/∂x = 1, ∂y/∂x = 0., ∂z/∂x = 0, etc.
+        AutoDiffXd x_autodiff{x, Vector3<double>(1., 0., 0.)};
+        AutoDiffXd y_autodiff{y, Vector3<double>(0., 1., 0.)};
+        AutoDiffXd z_autodiff{z, Vector3<double>(0., 0., 1.)};
+
+        api::GeoPositionT<AutoDiffXd> geo_position{
+          x_autodiff, y_autodiff, z_autodiff};
+
+        const api::LanePositionT<AutoDiffXd> lane_position =
+            lane_->ToLanePositionT<AutoDiffXd>(geo_position,
+                                               &nearest_position, &distance);
+
+        std::vector<Vector3<double>> positional_derivatives{
+          Vector3<double>::Zero(),   // s
+          Vector3<double>::Zero(),   // r
+          Vector3<double>::Zero()};  // h
+        for (int i{0}; i < 3; ++i) positional_derivatives[i](i) = 1.;
+
+        if (distance == 0.) {
+          // `geo_position` is within the interior or on the boundary.
+          //
+          // For the x-coordinate, expect the following derivatives for
+          // lane_position within the interior: ∂s/∂x = 1, ∂r/∂x = 0., ∂h/∂x
+          // = 0 (Dragway's s-r-h axis has the same orientation as the x-y-z
+          // axis).  Verify that the derivatives of nearest position are the
+          // same as for geo_position.
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      lane_position.s().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      nearest_position.x().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[1],
+                                      lane_position.r().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[1],
+                                      nearest_position.y().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[2],
+                                      lane_position.h().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[2],
+                                      nearest_position.z().derivatives()));
+
+          // Expect ∂/∂x(distance) = 0., as distance remains unchanged when
+          // on the boundary or within the interior of the lane.
+          EXPECT_TRUE(CompareMatrices(Vector3<double>::Zero(),
+                                      distance.derivatives()));
+        } else {
+          // `geo_position` is outside of the lane.  In this case, the
+          // derivatives for distance and position depend on the region in
+          // which `geo_position` resides.
+          //
+          // For instance, take some (x, y, z) such that min_x ≮ x ≮ max_x,
+          // but min_y < y < max_y and min_z < z< max_z, then `geo_position`
+          // lies closest to the s-facet.  We expect ∂(distance)/∂x = 1 when x
+          // > max_x and -1 when x < min_x, but expect distance to be
+          // invariant to y and z (i.e. ∂(distance)/∂y = ∂(distance)/∂z = 0).
+          //
+          // We further expect
+          // ∂/∂x(lane_position.s()) = ∂/∂x(nearest_position.x()) = 0, but
+          // ∂/∂y(lane_position.r()) = ∂/∂y(nearest_position.y()) = 1 and
+          // ∂/∂z(lane_position.h()) = ∂/∂z(nearest_position.z()) = 1.
+          //
+          // The following diagram summarizes, slightly more generally, the
+          // expected behavior with respect to x and y when z = 0.  Note that
+          // we are depicting only the 2D subproblem for ease of
+          // visualization.
+          //
+          //  y                                      (+)  (+)  (#)
+          //  ^
+          //  |          y = max_y  -----------------(o)--(o)  (-)
+          //  |                     |                      |
+          //  +----> x              |     Dragway    (o)  (o)  (-)
+          //                        |                      |
+          //                        ------------------------
+          //                                               x = max_x
+          //
+          // Consider the points labeled above and let D = distance, LP =
+          // lane_position, NP = nearest_position.  The following should hold:
+          //
+          // (+):  ∂/∂x(D) = 0, ∂/∂y(D) = 1
+          //       ∂/∂x(LP.s()) = ∂/∂x(NP.x()) = 1
+          //       ∂/∂y(LP.r()) = ∂/∂y(NP.y()) = 0
+          // (-):  ∂/∂x(D) = 1, ∂/∂y(D) = 0
+          //       ∂/∂x(LP.s()) = ∂/∂x(NP.x()) = 0
+          //       ∂/∂y(LP.r()) = ∂/∂y(NP.y()) = 1
+          // (#):  ∂/∂x(D) = √2/2, ∂/∂y(D) = √2/2  (assuming # is equilateral)
+          //       ∂/∂x(LP.s()) = ∂/∂x(NP.x()) = 0
+          //       ∂/∂y(LP.r()) = ∂/∂y(NP.y()) = 0
+          // (o):  ∂/∂x(D) = 0, ∂/∂y(D) = 0
+          //       ∂/∂x(LP.s()) = ∂/∂x(NP.x()) = 1
+          //       ∂/∂y(LP.r()) = ∂/∂y(NP.y()) = 1
+          //       (Note these are the distance = 0 cases)
+          //
+          // The cross-derivatives ∂/∂y(LP.s()), ∂/∂y(NP.s()), ∂/∂x(LP.r()),
+          // ∂/∂x(NP.r()) should always be zero.  Similar principles apply
+          // in cases where z ≠ 0.
+          const Vector3<double> derivative_candidates(
+              (x < min_x_) ?
+              (x - min_x_) / distance.value() :
+              (x - max_x_) / distance.value(),
+              (y < min_y_) ?
+              (y - min_y_) / distance.value() :
+              (y - max_y_) / distance.value(),
+              (z < min_z_) ?
+              (z - min_z_) / distance.value() :
+              (z - max_z_) / distance.value());
+          Vector3<double> distance_derivatives = Vector3<double>::Zero();
+
+          for (int index : GetTransgressedBoundaries(geo_position)) {
+            distance_derivatives(index) = derivative_candidates(index);
+            positional_derivatives[index](index) = 0.;  // (entry was = 1).
+          }
+          EXPECT_TRUE(CompareMatrices(
+              distance_derivatives, distance.derivatives(),
+              1e-15 /* account for small numerical errors */));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      lane_position.s().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      nearest_position.x().derivatives()));
+        }
+      }
+    }
+  }
+}
+
+TEST_F(MaliputDragwayLaneTest, ThrowIfUsingMismatchedDerivatives) {
+  MakeDragway(1 /* num lanes */);
+
+  // Expect the function to throw when given a triple whose derivatives have
+  // mismatched sizes.
+  AutoDiffXd x{1., Vector3<double>(1., 2., 3.)};
+  AutoDiffXd y{5., Vector2<double>(1., 2.)};
+  AutoDiffXd z{7., Vector1<double>(1.)};
+  api::GeoPositionT<AutoDiffXd> geo_position(x, y, z);
+
+  EXPECT_THROW(
+      lane_->ToLanePositionT<AutoDiffXd>(geo_position, nullptr, nullptr),
+      std::runtime_error);
 }
 
 }  // namespace

--- a/drake/automotive/maliput/multilane/test/multilane_lanes_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_lanes_test.cc
@@ -123,7 +123,9 @@ TEST_P(MultilaneLanesParamTest, FlatLineLane) {
   // At the very end of the lane.
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l1->ToGeoPosition({l1->length(), 0., 0.}),
-      api::GeoPosition(Vector3<double>(200., -25., 0.) + r_offset_vector),
+      api::GeoPosition(200. + r_offset_vector.x(),
+                       -25. + r_offset_vector.y(),
+                       0. + r_offset_vector.z()),
       kLinearTolerance));
   // Case 1: Tests LineLane::ToLanePosition() with a closest point that lies
   // within the lane bounds.

--- a/drake/automotive/mobil_planner.cc
+++ b/drake/automotive/mobil_planner.cc
@@ -131,8 +131,9 @@ void MobilPlanner<T>::ImplCalcLaneDirection(
   DRAKE_DEMAND(mobil_params.IsValid());
 
   const RoadPosition ego_position =
-      road_.ToRoadPosition(GeoPosition(ego_pose.get_isometry().translation()),
-                           nullptr, nullptr, nullptr);
+      road_.ToRoadPosition(
+          GeoPosition::FromXyz(ego_pose.get_isometry().translation()),
+          nullptr, nullptr, nullptr);
   // Prepare a list of (possibly nullptr) Lanes to evaluate.
   std::pair<const Lane*, const Lane*> lanes = std::make_pair(
       ego_position.lane->to_left(), ego_position.lane->to_right());
@@ -167,8 +168,9 @@ const std::pair<T, T> MobilPlanner<T>::ComputeIncentives(
   std::pair<T, T> incentives(-kDefaultLargeAccel, -kDefaultLargeAccel);
 
   const RoadPosition ego_position =
-      road_.ToRoadPosition(GeoPosition(ego_pose.get_isometry().translation()),
-                           nullptr, nullptr, nullptr);
+      road_.ToRoadPosition(
+          GeoPosition::FromXyz(ego_pose.get_isometry().translation()),
+          nullptr, nullptr, nullptr);
   DRAKE_DEMAND(ego_position.lane != nullptr);
   const ClosestPoses current_closest_poses = PoseSelector<T>::FindClosestPair(
       ego_position.lane, ego_pose, traffic_poses,

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -41,7 +41,8 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
 
   DRAKE_DEMAND(lane != nullptr);
 
-  const GeoPosition ego_geo_position(ego_pose.get_isometry().translation());
+  const GeoPosition ego_geo_position =
+      GeoPosition::FromXyz(ego_pose.get_isometry().translation());
   const LanePosition ego_lane_position =
       lane->ToLanePosition(ego_geo_position, nullptr, nullptr);
   LaneDirection lane_direction = CalcLaneDirection(
@@ -65,7 +66,8 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
     T distance_increment{0.};
     for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
       const Isometry3<T> traffic_isometry = traffic_poses.get_pose(i);
-      const GeoPosition traffic_geo_position(traffic_isometry.translation());
+      const GeoPosition traffic_geo_position =
+          GeoPosition::FromXyz(traffic_isometry.translation());
 
       if (ego_geo_position == traffic_geo_position) continue;
       if (!IsWithinLane(traffic_geo_position, lane_direction.lane)) continue;

--- a/drake/automotive/pure_pursuit.cc
+++ b/drake/automotive/pure_pursuit.cc
@@ -53,10 +53,9 @@ const GeoPosition PurePursuit<T>::ComputeGoalPoint(
   const Lane* const lane = lane_direction.lane;
   const bool with_s = lane_direction.with_s;
   const LanePosition position =
-      lane->ToLanePosition({pose.get_isometry().translation().x(),
-                            pose.get_isometry().translation().y(),
-                            pose.get_isometry().translation().z()},
-                           nullptr, nullptr);
+      lane->ToLanePosition(
+          GeoPosition::FromXyz(pose.get_isometry().translation()),
+          nullptr, nullptr);
   const T s_new =
       cond(with_s, position.s() + s_lookahead, position.s() - s_lookahead);
   const T s_goal = math::saturate(s_new, 0., lane->length());
@@ -66,6 +65,7 @@ const GeoPosition PurePursuit<T>::ComputeGoalPoint(
 
 // These instantiations must match the API documentation in pure_pursuit.h.
 // The only scalar type supported is double.
+// TODO(jadecastro): Enable AutoDiffXd support.
 template class PurePursuit<double>;
 
 }  // namespace automotive


### PR DESCRIPTION
Implement the AutoDiff-supported coordinate transformation within Dragway::Lane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6614)
<!-- Reviewable:end -->
