### PR TITLE
Make the automotive demo depend on pydrake.

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -30,8 +30,8 @@ sh_binary(
         "//conditions:default": ["drake_visualizer_linux.sh"],
     }),
     data = [
+        "//drake/bindings:pydrake",
         "@director",
-        "//drake/bindings:pydrake"
     ],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -29,7 +29,10 @@ sh_binary(
         "//tools:apple": ["drake_visualizer_apple.sh"],
         "//conditions:default": ["drake_visualizer_linux.sh"],
     }),
-    data = ["@director"],
+    data = [
+        "@director",
+        "//drake/bindings:pydrake"
+    ],
 )
 
 sh_binary(

--- a/tools/drake_visualizer_apple.sh
+++ b/tools/drake_visualizer_apple.sh
@@ -16,6 +16,6 @@ fi
 
 export DYLD_LIBRARY_PATH="external/director/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 # TODO(jamiesnape): Do not hard code absolute path to vtk@8.0.
-export PYTHONPATH="external/director/lib/python2.7/dist-packages:/usr/local/opt/vtk@8.0/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:external/director/lib/python2.7/dist-packages:/usr/local/opt/vtk@8.0/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/director/bin/drake-visualizer" "$@"

--- a/tools/drake_visualizer_linux.sh
+++ b/tools/drake_visualizer_linux.sh
@@ -15,6 +15,6 @@ if ! [ -d "external/director" ]; then
 fi
 
 export LD_LIBRARY_PATH="external/director/lib:external/vtk/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export PYTHONPATH="external/director/lib/python2.7/dist-packages:external/vtk/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:external/director/lib/python2.7/dist-packages:external/vtk/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/director/bin/drake-visualizer" "$@"


### PR DESCRIPTION
This avoids a python backtrace and lets the visualizer find
the prius.dae file.

@jamiesnape correctly points out that this isn't fixing the problem at quite the right level.  We should really have this dependency down in tools/BUILD:drake_visualizer, or in the [shell script](https://github.com/RobotLocomotion/drake/blob/master/tools/drake_visualizer_linux.sh) that launches drake_visualizer.  We can't do the former, because in bazel a shell script cannot have a python dependency.  I couldn't make the latter work, which suggests to me that there is something more than just PYTHONPATH being modified, but I couldn't figure out what.  If we want a short-term fix, we can take this, otherwise I'll have to bang my head against bazel some more to figure out what is going on.

Fixes #6333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6616)
<!-- Reviewable:end -->
