### PR TITLE
Contact point tracking

### DIFF
--- a/drake/multibody/rigid_contact/BUILD
+++ b/drake/multibody/rigid_contact/BUILD
@@ -22,6 +22,18 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "rigid_contact_point",
+    hdrs = [
+        "rigid_contact_point.h",
+    ],
+    srcs = ["rigid_contact_point.cc"],
+    deps = [
+        "//drake/common",
+        "//drake/common:autodiff",
+    ],
+)
+
+drake_cc_library(
     name = "rigid_contact_solver",
     srcs = ["rigid_contact_solver.cc"],
     hdrs = [

--- a/drake/multibody/rigid_contact/BUILD
+++ b/drake/multibody/rigid_contact/BUILD
@@ -30,6 +30,7 @@ drake_cc_library(
     deps = [
         "//drake/common",
         "//drake/common:autodiff",
+        "//drake/systems/framework:value",
     ],
 )
 

--- a/drake/multibody/rigid_contact/rigid_contact_point.cc
+++ b/drake/multibody/rigid_contact/rigid_contact_point.cc
@@ -1,0 +1,16 @@
+#include "drake/multibody/rigid_contact/rigid_contact_point.h"
+
+#include <unsupported/Eigen/AutoDiff>
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+
+template struct RigidContactPoint<double>;
+template struct RigidContactPoint<AutoDiffXd>;
+
+}  // namespace rigid_contact
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_point.h
+++ b/drake/multibody/rigid_contact/rigid_contact_point.h
@@ -17,6 +17,7 @@ namespace rigid_contact {
 /// state- sliding or not sliding) into a System's abstract state and using
 /// ancillary information (e.g., zero Lagrange Multipliers) allows avoiding
 /// these floating point issues.
+template <class T>
 struct RigidContactPoint {
   enum class ContactSlidingState {
     /// The bodies are to be considered as sliding at this point of contact.
@@ -32,7 +33,7 @@ struct RigidContactPoint {
   /// Abstract data sufficient (in combination with other continuous and/or
   /// discrete state variables) to uniquely determine a point of contact between
   /// two rigid bodies.
-  AbstractValue contact_point_key;
+  systems::Value<T> contact_point_key;
 };
 
 }  // namespace rigid_contact

--- a/drake/multibody/rigid_contact/rigid_contact_point.h
+++ b/drake/multibody/rigid_contact/rigid_contact_point.h
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/systems/framework/value.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -17,7 +18,6 @@ namespace rigid_contact {
 /// use ancillary information (e.g., are Lagrange Multipliers zero?) and
 /// store the contact state (sliding, not sliding) to compose necessary
 /// constraint equations.
-template <class T>
 struct RigidContactPoint {
   enum class ContactSlidingState {
     /// The bodies are to be considered as sliding at this point of contact.
@@ -30,9 +30,9 @@ struct RigidContactPoint {
   /// Whether the contact is to be treated as sliding or not sliding.
   ContactSlidingState sliding_state;
 
-  /// The vector from the center-of-mass of the rigid body to the point of
-  /// contact, expressed in the body frame of one of the rigid bodies.
-  Vector3<T> u;
+  /// Abstract data sufficient to uniquely determine a point of contact between
+  /// two rigid bodies.
+  AbstractValue contact_point_key;
 };
 
 }  // namespace rigid_contact

--- a/drake/multibody/rigid_contact/rigid_contact_point.h
+++ b/drake/multibody/rigid_contact/rigid_contact_point.h
@@ -14,10 +14,11 @@ namespace rigid_contact {
 /// the distance from it to the second rigid body were zero; floating point
 /// truncation and rounding errors imply that such distances are unlikely to
 /// ever actually be zero. Instead, we track the point of contact over time and
-/// use ancillary information (e.g., are Lagrangle Multipliers zero?) and
+/// use ancillary information (e.g., are Lagrange Multipliers zero?) and
 /// store the contact state (sliding, not sliding) to compose necessary
 /// constraint equations.
-struct RigidContactContact {
+template <class T>
+struct RigidContactPoint {
   enum class ContactSlidingState {
     /// The bodies are to be considered as sliding at this point of contact.
     kSliding,
@@ -31,7 +32,7 @@ struct RigidContactContact {
 
   /// The vector from the center-of-mass of the rigid body to the point of
   /// contact, expressed in the body frame of one of the rigid bodies.
-  Eigen::Vector3d u;
+  Vector3<T> u;
 };
 
 }  // namespace rigid_contact

--- a/drake/multibody/rigid_contact/rigid_contact_point.h
+++ b/drake/multibody/rigid_contact/rigid_contact_point.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace multibody {
+namespace rigid_contact {
+
+/// A tracked point of contact between two rigid bodies that use polytopical
+/// geometries. The point is defined with respect to exactly one of the two
+/// rigid bodies. This point would ideally be used to define constraints only if
+/// the distance from it to the second rigid body were zero; floating point
+/// truncation and rounding errors imply that such distances are unlikely to
+/// ever actually be zero. Instead, we track the point of contact over time and
+/// use ancillary information (e.g., are Lagrangle Multipliers zero?) and
+/// store the contact state (sliding, not sliding) to compose necessary
+/// constraint equations.
+struct RigidContactContact {
+  enum class ContactSlidingState {
+    /// The bodies are to be considered as sliding at this point of contact.
+    kSliding,
+
+    /// The bodies are to be considered as not sliding at this point of contact.
+    kNotSliding,
+  };
+
+  /// Whether the contact is to be treated as sliding or not sliding.
+  ContactSlidingState sliding_state;
+
+  /// The vector from the center-of-mass of the rigid body to the point of
+  /// contact, expressed in the body frame of one of the rigid bodies.
+  Eigen::Vector3d u;
+};
+
+}  // namespace rigid_contact
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/rigid_contact/rigid_contact_point.h
+++ b/drake/multibody/rigid_contact/rigid_contact_point.h
@@ -9,15 +9,14 @@ namespace drake {
 namespace multibody {
 namespace rigid_contact {
 
-/// A tracked point of contact between two rigid bodies that use polytopical
-/// geometries. The point is defined with respect to exactly one of the two
-/// rigid bodies. This point would ideally be used to define constraints only if
-/// the distance from it to the second rigid body were zero; floating point
-/// truncation and rounding errors imply that such distances are unlikely to
-/// ever actually be zero. Instead, we track the point of contact over time and
-/// use ancillary information (e.g., are Lagrange Multipliers zero?) and
-/// store the contact state (sliding, not sliding) to compose necessary
-/// constraint equations.
+/// A tracked point of contact between two rigid bodies. This point, p, would
+/// ideally be used to define constraints at time t if and only if the distance
+/// between the rigid bodies at p(t) were zero; floating point truncation and
+/// rounding errors mean that such distances are unlikely to ever actually be
+/// zero. Incorporating tracked points of contact (as well as the sliding
+/// state- sliding or not sliding) into a System's abstract state and using
+/// ancillary information (e.g., zero Lagrange Multipliers) allows avoiding
+/// these floating point issues.
 struct RigidContactPoint {
   enum class ContactSlidingState {
     /// The bodies are to be considered as sliding at this point of contact.
@@ -30,7 +29,8 @@ struct RigidContactPoint {
   /// Whether the contact is to be treated as sliding or not sliding.
   ContactSlidingState sliding_state;
 
-  /// Abstract data sufficient to uniquely determine a point of contact between
+  /// Abstract data sufficient (in combination with other continuous and/or
+  /// discrete state variables) to uniquely determine a point of contact between
   /// two rigid bodies.
   AbstractValue contact_point_key;
 };


### PR DESCRIPTION
This data structure is to be used for augmenting abstract state variables for rigid contact between bodies with polytopic geometries for use with the "active set method" (no relation to constrained optimization or mathematical programming).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6618)
<!-- Reviewable:end -->
