### PR TITLE
Raise the bar for vtk on kinetic

### DIFF
--- a/drake/doc/from_source_ros_kinetic.rst
+++ b/drake/doc/from_source_ros_kinetic.rst
@@ -70,23 +70,7 @@ Step 4: Install Drake's Dependencies
 ====================================
 
 Drake includes a convenient Ubuntu 16.04 shell script that installs all of
-its dependencies. This script is located in
-``~/dev/drake_catkin_workspace/src/drake/setup/ubuntu/16.04/install_prereqs.sh``.
-
-There is currently a conflict between Drake's need for ``libvtk5-dev`` and
-ROS Kinetic's need for ``libvtk6-dev``. To resolve this issue, we do the
-following:
-
-Open
-``~/dev/drake_catkin_workspace/src/drake/setup/ubuntu/16.04/install_prereqs.sh``
-and delete the following lines::
-
-    libvtk-java
-    libvtk5-dev
-    libvtk5-qt4-dev
-    python-vtk
-
-Then execute the script::
+its dependencies::
 
     cd ~/dev/drake_catkin_workspace/src/drake/setup/ubuntu/16.04
     sudo ./install_prereqs.sh

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -89,9 +89,9 @@ libqt5x11extras5
 libqwt-dev
 libtinyxml-dev
 libtool
-libvtk-java
-libvtk5-dev
-libvtk5-qt4-dev
+libvtk6-java
+libvtk6-dev
+libvtk6-qt4-dev
 libxmu-dev
 make
 ninja-build


### PR DESCRIPTION
This is only for the cmake superbuild and in that, only for director. Director
as it happens, has already raised the bar to a system 6.2 or pre-compiled (> 7.0).

The relevant director commit is [here](https://github.com/RobotLocomotion/director/commit/329d6d6d030cc3ceb1e15f45e597c921eb9d3a5c).

Note that these should disappear once the CMake superbuild disappears since we're now using pre-compiled VTK8 binaries (there is no system default, non-broken binary available on Xenial).

This should also inadvertantly stop ros users accidentally having their ROS systems deleted because ros-kinetic-opencv3 depends on the system vtk (libvtk6).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6622)
<!-- Reviewable:end -->
