### PR TITLE
Make multibody/collision/model.h conform to our C++ standards

### DIFF
--- a/drake/examples/double_pendulum/sdf_helpers.cc
+++ b/drake/examples/double_pendulum/sdf_helpers.cc
@@ -106,7 +106,8 @@ void ParseVisual(sdf::ElementPtr sdf_visual_element, RigidBody<double>* body) {
 }
 
 // Parses a collision geometry from the given SDF element and adds a
-// DrakeCollision::Element instance to the given body through the given tree.
+// drake::multibody::collision::Element instance to the given body through the
+// given tree.
 void ParseCollision(sdf::ElementPtr sdf_collision_element,
                     RigidBody<double>* body,
                     RigidBodyTree<double>* tree) {
@@ -124,7 +125,7 @@ void ParseCollision(sdf::ElementPtr sdf_collision_element,
     X_BE = ParsePose(sdf_pose_element);
   }
 
-  DrakeCollision::Element element(X_BE, body);
+  drake::multibody::collision::Element element(X_BE, body);
   sdf::ElementPtr sdf_geometry_element =
       sdf_collision_element->GetElement("geometry");
   ParseGeometry(sdf_geometry_element, &element);

--- a/drake/examples/double_pendulum/test/rigid_body_types_compare.cc
+++ b/drake/examples/double_pendulum/test/rigid_body_types_compare.cc
@@ -136,8 +136,8 @@ namespace test {
             it2 = non_const_body2.collision_elements_begin(),
             ed1 = non_const_body1.collision_elements_end();
        it1 != ed1 ; ++it1, ++it2) {
-    const DrakeCollision::Element* body1_collision = *it1;
-    const DrakeCollision::Element* body2_collision = *it2;
+    const drake::multibody::collision::Element* body1_collision = *it1;
+    const drake::multibody::collision::Element* body2_collision = *it2;
     ::testing::AssertionResult result =
         AreElementsEquivalent(*body1_collision, *body2_collision);
     if (!result) {

--- a/drake/examples/double_pendulum/test/sdf_helpers_test.cc
+++ b/drake/examples/double_pendulum/test/sdf_helpers_test.cc
@@ -36,7 +36,8 @@ GTEST_TEST(SDFHelpersTest, ParsingTest) {
   const Isometry3<double> body_element_transform =
       body_element_translation * body_element_rotation;
   DrakeShapes::Box body_geometry(Vector3<double>(0.2, 0.2, 1.8));
-  DrakeCollision::Element body_collision(body_geometry, body_element_transform);
+  drake::multibody::collision::Element body_collision(body_geometry,
+                                                      body_element_transform);
   body_ref.AddCollisionElement("", &body_collision);
   DrakeShapes::VisualElement body_visual(body_element_transform);
   body_visual.setGeometry(body_geometry);
@@ -60,7 +61,8 @@ GTEST_TEST(SDFHelpersTest, ParsingTest) {
       arm_element_translation * arm_element_rotation;
 
   DrakeShapes::Cylinder arm_geometry(0.05, 0.4);
-  DrakeCollision::Element arm_collision(arm_geometry, arm_element_transform);
+  drake::multibody::collision::Element arm_collision(arm_geometry,
+                                                     arm_element_transform);
   arm_ref.AddCollisionElement("", &arm_collision);
   DrakeShapes::VisualElement arm_visual(arm_element_transform);
   arm_visual.setGeometry(arm_geometry);

--- a/drake/multibody/collision/bullet_model.cc
+++ b/drake/multibody/collision/bullet_model.cc
@@ -389,7 +389,7 @@ void BulletModel::DoAddElement(const Element& element) {
   }
 }
 
-bool BulletModel::collidingPointsCheckOnly(
+bool BulletModel::CollidingPointsCheckOnly(
     const std::vector<Vector3d>& input_points, double collision_threshold) {
   // Create sphere geometry
   btSphereShape bt_shape(collision_threshold);
@@ -421,7 +421,7 @@ bool BulletModel::collidingPointsCheckOnly(
   return false;
 }
 
-std::vector<size_t> BulletModel::collidingPoints(
+std::vector<size_t> BulletModel::CollidingPoints(
     const std::vector<Vector3d>& input_points, double collision_threshold) {
   // Create sphere geometry
   btSphereShape bt_shape(collision_threshold);
@@ -454,10 +454,10 @@ std::vector<size_t> BulletModel::collidingPoints(
   return in_collision_indices;
 }
 
-bool BulletModel::updateElementWorldTransform(
+bool BulletModel::UpdateElementWorldTransform(
     ElementId id, const Isometry3d& T_local_to_world) {
   const bool element_exists(
-      Model::updateElementWorldTransform(id, T_local_to_world));
+      Model::UpdateElementWorldTransform(id, T_local_to_world));
   if (element_exists) {
     btTransform btT = convert(elements[id]->getWorldTransform());
 
@@ -477,7 +477,7 @@ bool BulletModel::updateElementWorldTransform(
   return element_exists;
 }
 
-void BulletModel::updateModel() {
+void BulletModel::UpdateModel() {
   bullet_world_.bt_collision_world->updateAabbs();
   bullet_world_no_margin_.bt_collision_world->updateAabbs();
 }
@@ -598,7 +598,7 @@ PointPair BulletModel::findClosestPointsBetweenElements(
   }
 }
 
-void BulletModel::collisionDetectFromPoints(
+void BulletModel::CollisionDetectFromPoints(
     const Matrix3Xd& points, bool use_margins,
     std::vector<PointPair>& closest_points) {
   closest_points.resize(points.cols());
@@ -681,7 +681,7 @@ void BulletModel::collisionDetectFromPoints(
   }
 }
 
-bool BulletModel::collisionRaycast(const Matrix3Xd& origins,
+bool BulletModel::CollisionRaycast(const Matrix3Xd& origins,
                                    const Matrix3Xd& ray_endpoints,
                                    bool use_margins, VectorXd& distances,
                                    Matrix3Xd& normals) {
@@ -762,7 +762,7 @@ bool BulletModel::collisionRaycast(const Matrix3Xd& origins,
   return true;
 }
 
-bool BulletModel::closestPointsAllToAll(
+bool BulletModel::ClosestPointsAllToAll(
     const std::vector<ElementId>& ids_to_check, bool use_margins,
     std::vector<PointPair>& closest_points) {
   if (dispatch_method_in_use_ == kNotYetDecided)
@@ -782,10 +782,10 @@ bool BulletModel::closestPointsAllToAll(
       }
     }
   }
-  return closestPointsPairwise(id_pairs, use_margins, closest_points);
+  return ClosestPointsPairwise(id_pairs, use_margins, closest_points);
 }
 
-bool BulletModel::closestPointsPairwise(
+bool BulletModel::ClosestPointsPairwise(
     const std::vector<ElementIdPair>& id_pairs, bool use_margins,
     std::vector<PointPair>& closest_points) {
   closest_points.clear();

--- a/drake/multibody/collision/bullet_model.cc
+++ b/drake/multibody/collision/bullet_model.cc
@@ -600,8 +600,9 @@ PointPair BulletModel::findClosestPointsBetweenElements(
 
 void BulletModel::CollisionDetectFromPoints(
     const Matrix3Xd& points, bool use_margins,
-    std::vector<PointPair>& closest_points) {
-  closest_points.resize(points.cols());
+    std::vector<PointPair>* closest_points) {
+  DRAKE_DEMAND(closest_points != nullptr);
+  closest_points->resize(points.cols());
   VectorXd phi(points.cols());
 
   btSphereShape shapeA(0.0);
@@ -656,7 +657,7 @@ void BulletModel::CollisionDetectFromPoints(
           got_one = true;
           Element *collision_element =
               static_cast<Element *>(bt_objB->getUserPointer());
-          closest_points[i] =
+          closest_points->at(i) =
               PointPair(collision_element, collision_element,
                         toVector3d(pointOnElemB), toVector3d(pointOnBinWorld),
                         toVector3d(gjkOutput.m_normalOnBInWorld), distance);
@@ -672,21 +673,23 @@ void BulletModel::CollisionDetectFromPoints(
       // In case there are no other objects found, we report a null object
       // infinitely far away.
       phi[i] = inf;
-      closest_points[i] = PointPair();
-      closest_points[i].distance = inf;
-      closest_points[i].normal = default_norm;
-      closest_points[i].ptA = inf_vector;
-      closest_points[i].ptB = inf_vector;
+      closest_points->at(i) = PointPair();
+      closest_points->at(i).distance = inf;
+      closest_points->at(i).normal = default_norm;
+      closest_points->at(i).ptA = inf_vector;
+      closest_points->at(i).ptB = inf_vector;
     }
   }
 }
 
 bool BulletModel::CollisionRaycast(const Matrix3Xd& origins,
                                    const Matrix3Xd& ray_endpoints,
-                                   bool use_margins, VectorXd& distances,
-                                   Matrix3Xd& normals) {
-  distances.resize(ray_endpoints.cols());
-  normals.resize(3, ray_endpoints.cols());
+                                   bool use_margins, VectorXd* distances,
+                                   Matrix3Xd* normals) {
+  DRAKE_DEMAND(distances != nullptr);
+  DRAKE_DEMAND(normals != nullptr);
+  distances->resize(ray_endpoints.cols());
+  normals->resize(3, ray_endpoints.cols());
 
   BulletCollisionWorldWrapper& bt_world = getBulletWorld(use_margins);
 
@@ -745,17 +748,17 @@ bool BulletModel::CollisionRaycast(const Matrix3Xd& origins,
 
       Vector3d end_eigen(end.getX(), end.getY(), end.getZ());
 
-      distances(i) = (end_eigen - origins.col(origin_col)).norm();
+      (*distances)(i) = (end_eigen - origins.col(origin_col)).norm();
 
       btVector3 normal = ray_callback.m_hitNormalWorld;
-      normals(0, i) = normal.getX();
-      normals(1, i) = normal.getY();
-      normals(2, i) = normal.getZ();
+      (*normals)(0, i) = normal.getX();
+      (*normals)(1, i) = normal.getY();
+      (*normals)(2, i) = normal.getZ();
     } else {
-      distances(i) = -1.;
-      normals(0, i) = 0.;
-      normals(1, i) = 0.;
-      normals(2, i) = 0.;
+      (*distances)(i) = -1.;
+      (*normals)(0, i) = 0.;
+      (*normals)(1, i) = 0.;
+      (*normals)(2, i) = 0.;
     }
   }
 
@@ -764,7 +767,8 @@ bool BulletModel::CollisionRaycast(const Matrix3Xd& origins,
 
 bool BulletModel::ClosestPointsAllToAll(
     const std::vector<ElementId>& ids_to_check, bool use_margins,
-    std::vector<PointPair>& closest_points) {
+    std::vector<PointPair>* closest_points) {
+  DRAKE_DEMAND(closest_points != nullptr);
   if (dispatch_method_in_use_ == kNotYetDecided)
     dispatch_method_in_use_ = kClosestPointsAllToAll;
 
@@ -787,25 +791,27 @@ bool BulletModel::ClosestPointsAllToAll(
 
 bool BulletModel::ClosestPointsPairwise(
     const std::vector<ElementIdPair>& id_pairs, bool use_margins,
-    std::vector<PointPair>& closest_points) {
-  closest_points.clear();
+    std::vector<PointPair>* closest_points) {
+  DRAKE_DEMAND(closest_points != nullptr);
+  closest_points->clear();
   for (const ElementIdPair& pair : id_pairs) {
     try {
-      closest_points.push_back(findClosestPointsBetweenElements(
+      closest_points->push_back(findClosestPointsBetweenElements(
           pair.first, pair.second, use_margins));
     } catch (std::logic_error& e) {
       drake::log()->warn(e.what());
     }
   }
-  return closest_points.size() > 0;
+  return closest_points->size() > 0;
 }
 
 bool BulletModel::ComputeMaximumDepthCollisionPoints(
-    bool use_margins, std::vector<PointPair> &collision_points) {
+    bool use_margins, std::vector<PointPair>* collision_points) {
+  DRAKE_DEMAND(collision_points != nullptr);
   if (dispatch_method_in_use_ == kNotYetDecided)
     dispatch_method_in_use_ = kCollisionPointsAllToAll;
 
-  collision_points.clear();
+  collision_points->clear();
   MatrixXd normals;
   std::vector<double> distance;
   BulletCollisionWorldWrapper& bt_world = getBulletWorld(use_margins);
@@ -848,14 +854,14 @@ bool BulletModel::ComputeMaximumDepthCollisionPoints(
         const btVector3& ptA = pt.getPositionWorldOnA() + normalOnB * marginA;
         const btVector3& ptB = pt.getPositionWorldOnB() - normalOnB * marginB;
 
-        collision_points.emplace_back(
+        collision_points->emplace_back(
             elementA, elementB,
             toVector3d(ptA), toVector3d(ptB), toVector3d(normalOnB),
             static_cast<double>(pt.getDistance() + marginA + marginB));
       }
     }
   }
-  return collision_points.size() > 0;
+  return collision_points->size() > 0;
 }
 
 void BulletModel::ClearCachedResults(bool use_margins) {

--- a/drake/multibody/collision/bullet_model.cc
+++ b/drake/multibody/collision/bullet_model.cc
@@ -19,7 +19,9 @@ using Eigen::VectorXd;
 using Eigen::Vector3i;
 using Eigen::Matrix3Xi;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 // Helper method to convert a btVector3 to an Eigen vector representation.
 // Using Eigen::Map avoids unnecessary (expensive) copies.
@@ -899,4 +901,6 @@ const char* UnknownShapeException::what() const throw() {
       .c_str();
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -14,7 +14,9 @@
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/model.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 class BulletModel;  // forward declaration
 
@@ -183,4 +185,6 @@ class BulletModel : public Model {
   DispatchMethod dispatch_method_in_use_{kNotYetDecided};
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -59,11 +59,11 @@ class BulletModel : public Model {
 
   virtual ~BulletModel() {}
 
-  void updateModel() override;
+  void UpdateModel() override;
 
   void DoAddElement(const Element& element) override;
 
-  bool updateElementWorldTransform(
+  bool UpdateElementWorldTransform(
       ElementId, const Eigen::Isometry3d& T_local_to_world) override;
 
   /**
@@ -72,7 +72,7 @@ class BulletModel : public Model {
    *
    * \return true if any points are found.
    */
-  bool closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
+  bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
 
@@ -85,7 +85,7 @@ class BulletModel : public Model {
    *
    * \return true if any points are found.
    */
-  bool closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
+  bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
 
@@ -118,22 +118,22 @@ class BulletModel : public Model {
    * @param[out] closest_points     The vector for which all the closest point
    *                                data will be returned.
    */
-  void collisionDetectFromPoints(
+  void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>& closest_points) override;
 
   void ClearCachedResults(bool use_margins) override;
 
-  bool collisionRaycast(const Eigen::Matrix3Xd& origins,
+  bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
                         Eigen::VectorXd& distances,
                         Eigen::Matrix3Xd& normals) override;
 
-  bool collidingPointsCheckOnly(
+  bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
 
-  std::vector<size_t> collidingPoints(
+  std::vector<size_t> CollidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
 

--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -74,10 +74,10 @@ class BulletModel : public Model {
    */
   bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
 
   bool ComputeMaximumDepthCollisionPoints(
-      bool use_margins, std::vector<PointPair>& points) override;
+      bool use_margins, std::vector<PointPair>* points) override;
 
   /**
    * Finds the points where each pair of elements in id_pairs are
@@ -87,7 +87,7 @@ class BulletModel : public Model {
    */
   bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
 
   /**
    * Computes the closest point in the collision world to each of a set of
@@ -120,14 +120,14 @@ class BulletModel : public Model {
    */
   void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
-      std::vector<PointPair>& closest_points) override;
+      std::vector<PointPair>* closest_points) override;
 
   void ClearCachedResults(bool use_margins) override;
 
   bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
-                        Eigen::VectorXd& distances,
-                        Eigen::Matrix3Xd& normals) override;
+                        Eigen::VectorXd* distances,
+                        Eigen::Matrix3Xd* normals) override;
 
   bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,

--- a/drake/multibody/collision/collision_filter.cc
+++ b/drake/multibody/collision/collision_filter.cc
@@ -7,7 +7,9 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/text_logging.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 using drake::AutoDiffXd;
 
@@ -149,4 +151,6 @@ template class CollisionFilterGroup<AutoDiffXd>;
 template class CollisionFilterGroupManager<double>;
 template class CollisionFilterGroupManager<AutoDiffXd>;
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/collision_filter.h
+++ b/drake/multibody/collision/collision_filter.h
@@ -12,7 +12,9 @@
 template <typename U>
 class RigidBody;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 /** The maximum width of the collision filter group bitmasks. */
 constexpr int kMaxNumCollisionFilterGroups = 128;
 
@@ -253,7 +255,8 @@ class CollisionFilterGroupManager {
   int next_id_{1};
 
   // Map between group names and its collision filter group specification.
-  std::unordered_map<std::string, DrakeCollision::CollisionFilterGroup<T>>
+  std::unordered_map<std::string,
+                     drake::multibody::collision::CollisionFilterGroup<T>>
       collision_filter_groups_{};
 
   // Mappings between a RigidBody and the bitmasks that define its group
@@ -262,4 +265,6 @@ class CollisionFilterGroupManager {
   std::unordered_map<const RigidBody<T>*, std::pair<bitmask, bitmask>>
       body_groups_;
 };
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/collision_filter_doxygen.h
+++ b/drake/multibody/collision/collision_filter_doxygen.h
@@ -216,10 +216,10 @@ pair is filtered.  The cost of the comparison is constant, but related to the
 bitmask width.
 
 The width is defined at compile time and is defined by
-DrakeCollision::kMaxNumCollisionFilterGroups. The fixed width is a performance
-optimization but it means that there is a finite number of collision filter
-groups available in the system. Each RigidBodyTree instance has its _own_
-space of collision filter group identifiers.
+drake::multibody::collision::kMaxNumCollisionFilterGroups. The fixed width is a
+performance optimization but it means that there is a finite number of
+collision filter groups available in the system. Each RigidBodyTree instance
+has its _own_ space of collision filter group identifiers.
 <!-- TODO(SeanCurtis-TRI): This will have to be handled carefully in Geometry
  World. Each source of collision elements will get its own space of filters.
  Sources will need to be differentiated. -->

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -10,7 +10,9 @@
 
 using std::unique_ptr;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 unique_ptr<Model> newModel() {
 #ifdef BULLET_COLLISION
@@ -20,4 +22,6 @@ unique_ptr<Model> newModel() {
 #endif
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/drake_collision.h
+++ b/drake/multibody/collision/drake_collision.h
@@ -4,6 +4,10 @@
 
 #include "drake/multibody/collision/model.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 std::unique_ptr<Model> newModel();
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/element.cc
+++ b/drake/multibody/collision/element.cc
@@ -8,7 +8,9 @@ using Eigen::Isometry3d;
 using drake::SortedVectorsHaveIntersection;
 using std::ostream;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 Element::Element()
     : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr) {
@@ -81,14 +83,15 @@ const std::vector<int>& Element::collision_cliques() const {
   return collision_cliques_;
 }
 
-void Element::set_collision_filter(const DrakeCollision::bitmask &group,
-                                   const DrakeCollision::bitmask &ignores) {
+void Element::set_collision_filter(
+    const drake::multibody::collision::bitmask& group,
+    const drake::multibody::collision::bitmask& ignores) {
   collision_filter_group_ = group;
   collision_filter_ignores_ = ignores;
 }
 
 ostream& operator<<(ostream& out, const Element& ee) {
-  out << "DrakeCollision::Element:\n"
+  out << "drake::multibody::collision::Element:\n"
       << "  - id = " << ee.getId() << "\n"
       << "  - T_element_to_world =\n"
       << ee.T_element_to_world.matrix() << "\n"
@@ -98,4 +101,6 @@ ostream& operator<<(ostream& out, const Element& ee) {
   return out;
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/element.h
+++ b/drake/multibody/collision/element.h
@@ -20,7 +20,9 @@
 template <typename T>
 class RigidBody;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 typedef uintptr_t ElementId;
 
 /**
@@ -183,15 +185,17 @@ class Element : public DrakeShapes::Element {
   // A bitmask that determines the collision groups that this element is part
   // of. If the i-th bit is set this rigid body belongs to the i-th collision
   // group. An element can belong to multiple collision groups.
-  DrakeCollision::bitmask collision_filter_group_{kDefaultGroup};
+  drake::multibody::collision::bitmask collision_filter_group_{kDefaultGroup};
 
   // A bitmask that determines which collision groups this element can *not*
   // collide with. Thus, if the i-th bit is set this element is not checked
   // for collisions with elements in the i-th group.
-  DrakeCollision::bitmask collision_filter_ignores_{kNoneMask};
+  drake::multibody::collision::bitmask collision_filter_ignores_{kNoneMask};
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -20,14 +20,14 @@ void FclModel::UpdateModel() {
 
 bool FclModel::ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                                      bool use_margins,
-                                     std::vector<PointPair>& closest_points) {
+                                     std::vector<PointPair>* closest_points) {
   drake::unused(ids_to_check, use_margins, closest_points);
   DRAKE_ABORT_MSG("Not implemented.");
   return false;
 }
 
 bool FclModel::ComputeMaximumDepthCollisionPoints(
-    bool use_margins, std::vector<PointPair>& points) {
+    bool use_margins, std::vector<PointPair>* points) {
   drake::unused(use_margins, points);
   DRAKE_ABORT_MSG("Not implemented.");
   return false;
@@ -35,7 +35,7 @@ bool FclModel::ComputeMaximumDepthCollisionPoints(
 
 bool FclModel::ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                                      bool use_margins,
-                                     std::vector<PointPair>& closest_points) {
+                                     std::vector<PointPair>* closest_points) {
   drake::unused(id_pairs, use_margins, closest_points);
   DRAKE_ABORT_MSG("Not implemented.");
   return false;
@@ -43,7 +43,7 @@ bool FclModel::ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
 
 void FclModel::CollisionDetectFromPoints(
     const Eigen::Matrix3Xd& points, bool use_margins,
-    std::vector<PointPair>& closest_points) {
+    std::vector<PointPair>* closest_points) {
   drake::unused(points, use_margins, closest_points);
   DRAKE_ABORT_MSG("Not implemented.");
 }
@@ -55,8 +55,8 @@ void FclModel::ClearCachedResults(bool use_margins) {
 
 bool FclModel::CollisionRaycast(const Eigen::Matrix3Xd& origins,
                                 const Eigen::Matrix3Xd& ray_endpoints,
-                                bool use_margins, Eigen::VectorXd& distances,
-                                Eigen::Matrix3Xd& normals) {
+                                bool use_margins, Eigen::VectorXd* distances,
+                                Eigen::Matrix3Xd* normals) {
   drake::unused(origins, ray_endpoints, use_margins, distances, normals);
   DRAKE_ABORT_MSG("Not implemented.");
   return false;

--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -9,16 +9,16 @@ namespace DrakeCollision {
 
 // TODO(jamiesnape): Implement the model.
 
-void FCLModel::DoAddElement(const Element& element) {
+void FclModel::DoAddElement(const Element& element) {
   drake::unused(element);
   DRAKE_ABORT_MSG("Not implemented.");
 }
 
-void FCLModel::updateModel() {
+void FclModel::UpdateModel() {
   DRAKE_ABORT_MSG("Not implemented.");
 }
 
-bool FCLModel::closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
+bool FclModel::ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                                      bool use_margins,
                                      std::vector<PointPair>& closest_points) {
   drake::unused(ids_to_check, use_margins, closest_points);
@@ -26,14 +26,14 @@ bool FCLModel::closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
   return false;
 }
 
-bool FCLModel::ComputeMaximumDepthCollisionPoints(
+bool FclModel::ComputeMaximumDepthCollisionPoints(
     bool use_margins, std::vector<PointPair>& points) {
   drake::unused(use_margins, points);
   DRAKE_ABORT_MSG("Not implemented.");
   return false;
 }
 
-bool FCLModel::closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
+bool FclModel::ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                                      bool use_margins,
                                      std::vector<PointPair>& closest_points) {
   drake::unused(id_pairs, use_margins, closest_points);
@@ -41,19 +41,19 @@ bool FCLModel::closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
   return false;
 }
 
-void FCLModel::collisionDetectFromPoints(
+void FclModel::CollisionDetectFromPoints(
     const Eigen::Matrix3Xd& points, bool use_margins,
     std::vector<PointPair>& closest_points) {
   drake::unused(points, use_margins, closest_points);
   DRAKE_ABORT_MSG("Not implemented.");
 }
 
-void FCLModel::ClearCachedResults(bool use_margins) {
+void FclModel::ClearCachedResults(bool use_margins) {
   drake::unused(use_margins);
   DRAKE_ABORT_MSG("Not implemented.");
 }
 
-bool FCLModel::collisionRaycast(const Eigen::Matrix3Xd& origins,
+bool FclModel::CollisionRaycast(const Eigen::Matrix3Xd& origins,
                                 const Eigen::Matrix3Xd& ray_endpoints,
                                 bool use_margins, Eigen::VectorXd& distances,
                                 Eigen::Matrix3Xd& normals) {
@@ -62,7 +62,7 @@ bool FCLModel::collisionRaycast(const Eigen::Matrix3Xd& origins,
   return false;
 }
 
-bool FCLModel::collidingPointsCheckOnly(
+bool FclModel::CollidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>& input_points,
     double collision_threshold) {
   drake::unused(input_points, collision_threshold);
@@ -70,7 +70,7 @@ bool FCLModel::collidingPointsCheckOnly(
   return false;
 }
 
-std::vector<size_t> FCLModel::collidingPoints(
+std::vector<size_t> FclModel::CollidingPoints(
     const std::vector<Eigen::Vector3d>& input_points,
     double collision_threshold) {
   drake::unused(input_points, collision_threshold);

--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -5,7 +5,9 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 // TODO(jamiesnape): Implement the model.
 
@@ -78,4 +80,6 @@ std::vector<size_t> FclModel::CollidingPoints(
   return std::vector<size_t>();
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -9,7 +9,9 @@
 #include "drake/multibody/collision/model.h"
 #include "drake/multibody/collision/point_pair.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 class FclModel : public Model {
  public:
@@ -44,4 +46,6 @@ class FclModel : public Model {
   void UpdateModel() override;
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -21,26 +21,26 @@ class FclModel : public Model {
   void DoAddElement(const Element& element) override;
   bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
   bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
   bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
   bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
-                        Eigen::VectorXd& distances,
-                        Eigen::Matrix3Xd& normals) override;
+                        Eigen::VectorXd* distances,
+                        Eigen::Matrix3Xd* normals) override;
   bool ComputeMaximumDepthCollisionPoints(
-      bool use_margins, std::vector<PointPair>& points) override;
+      bool use_margins, std::vector<PointPair>* points) override;
   std::vector<size_t> CollidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
   void ClearCachedResults(bool use_margins) override;
   void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
-      std::vector<PointPair>& closest_points) override;
+      std::vector<PointPair>* closest_points) override;
   void UpdateModel() override;
 };
 

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -11,38 +11,37 @@
 
 namespace DrakeCollision {
 
-// TODO(jwnimmer-tri) This should be named FclModel per cppguide.
-class FCLModel : public Model {
+class FclModel : public Model {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FCLModel)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FclModel)
 
-  FCLModel() {}
-  virtual ~FCLModel() {}
+  FclModel() {}
+  virtual ~FclModel() {}
 
   void DoAddElement(const Element& element) override;
-  bool closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
+  bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
-  bool closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
+  bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
-  bool collidingPointsCheckOnly(
+  bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
-  bool collisionRaycast(const Eigen::Matrix3Xd& origins,
+  bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
                         Eigen::VectorXd& distances,
                         Eigen::Matrix3Xd& normals) override;
   bool ComputeMaximumDepthCollisionPoints(
       bool use_margins, std::vector<PointPair>& points) override;
-  std::vector<size_t> collidingPoints(
+  std::vector<size_t> CollidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
   void ClearCachedResults(bool use_margins) override;
-  void collisionDetectFromPoints(
+  void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>& closest_points) override;
-  void updateModel() override;
+  void UpdateModel() override;
 };
 
 }  // namespace DrakeCollision

--- a/drake/multibody/collision/model.cc
+++ b/drake/multibody/collision/model.cc
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include "drake/common/drake_assert.h"
+
 using Eigen::Isometry3d;
 using std::move;
 using std::unique_ptr;
@@ -47,12 +49,13 @@ Element* Model::FindMutableElement(ElementId id) {
 }
 
 void Model::GetTerrainContactPoints(ElementId id0,
-                                    Eigen::Matrix3Xd& terrain_points) {
+                                    Eigen::Matrix3Xd* terrain_points) {
+  DRAKE_DEMAND(terrain_points != nullptr);
   auto element_iter = elements.find(id0);
   if (element_iter != elements.end()) {
-    element_iter->second->getTerrainContactPoints(terrain_points);
+    element_iter->second->getTerrainContactPoints(*terrain_points);
   } else {
-    terrain_points = Eigen::Matrix3Xd();
+    *terrain_points = Eigen::Matrix3Xd();
   }
 }
 

--- a/drake/multibody/collision/model.cc
+++ b/drake/multibody/collision/model.cc
@@ -9,7 +9,9 @@ using std::move;
 using std::unique_ptr;
 using std::vector;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 Element* Model::AddElement(std::unique_ptr<Element> element) {
   ElementId id = element->getId();
@@ -71,7 +73,7 @@ bool Model::UpdateElementWorldTransform(ElementId id,
 }
 
 bool Model::TransformCollisionFrame(
-    const DrakeCollision::ElementId& eid,
+    const drake::multibody::collision::ElementId& eid,
     const Eigen::Isometry3d& transform_body_to_joint) {
   auto element = elements.find(eid);
   if (element != elements.end()) {
@@ -104,4 +106,6 @@ std::ostream& operator<<(std::ostream& os, const Model& model) {
   return os;
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/model.cc
+++ b/drake/multibody/collision/model.cc
@@ -24,7 +24,7 @@ Element* Model::AddElement(std::unique_ptr<Element> element) {
       std::to_string(id));
 }
 
-bool Model::removeElement(ElementId id) {
+bool Model::RemoveElement(ElementId id) {
   return elements.erase(id) > 0;
 }
 
@@ -46,7 +46,7 @@ Element* Model::FindMutableElement(ElementId id) {
   }
 }
 
-void Model::getTerrainContactPoints(ElementId id0,
+void Model::GetTerrainContactPoints(ElementId id0,
                                     Eigen::Matrix3Xd& terrain_points) {
   auto element_iter = elements.find(id0);
   if (element_iter != elements.end()) {
@@ -56,7 +56,7 @@ void Model::getTerrainContactPoints(ElementId id0,
   }
 }
 
-bool Model::updateElementWorldTransform(ElementId id,
+bool Model::UpdateElementWorldTransform(ElementId id,
                                         const Isometry3d& X_WL) {
   auto elem_itr = elements.find(id);
   if (elem_itr != elements.end()) {
@@ -67,7 +67,7 @@ bool Model::updateElementWorldTransform(ElementId id,
   }
 }
 
-bool Model::transformCollisionFrame(
+bool Model::TransformCollisionFrame(
     const DrakeCollision::ElementId& eid,
     const Eigen::Isometry3d& transform_body_to_joint) {
   auto element = elements.find(eid);

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -61,10 +61,7 @@ class Model {
    model. **/
   virtual Element* FindMutableElement(ElementId id);
 
-  void GetTerrainContactPoints(
-      ElementId id0,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::Matrix3Xd& terrain_points);
+  void GetTerrainContactPoints(ElementId id0, Eigen::Matrix3Xd* terrain_points);
 
   /** Updates the collision model. This method is typically called after changes
    are made to its collision elements. **/
@@ -97,10 +94,9 @@ class Model {
    contains the closest point information after this method is called
 
    @return Whether this method successfully ran. **/
-  virtual bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
-                                     bool use_margins,
-                                     std::vector<PointPair>&
-                                     closest_points) = 0;
+  virtual bool ClosestPointsAllToAll(
+      const std::vector<ElementId>& ids_to_check, bool use_margins,
+      std::vector<PointPair>* closest_points) = 0;
 
   /** Computes the point of closest approach between collision elements that
    are in contact.
@@ -113,9 +109,7 @@ class Model {
 
    @returns Whether this method successfully ran. **/
   virtual bool ComputeMaximumDepthCollisionPoints(
-      bool use_margins,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<PointPair>& closest_points) = 0;
+      bool use_margins, std::vector<PointPair>* closest_points) = 0;
 
   /** Computes the points of closest approach between specified pairs of
    collision elements.
@@ -131,10 +125,9 @@ class Model {
    called
 
    @return Whether this method successfully ran. **/
-  virtual bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
-                                     bool use_margins,
-                                     std::vector<PointPair>&
-                                     closest_points) = 0;
+  virtual bool ClosestPointsPairwise(
+      const std::vector<ElementIdPair>& id_pairs, bool use_margins,
+      std::vector<PointPair>* closest_points) = 0;
 
   /** Clears possibly cached results so that a fresh computation can be
   performed.
@@ -165,8 +158,7 @@ class Model {
    i'th instance reports the query result for the i'th input point. **/
   virtual void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<PointPair>& closest_points) = 0;
+      std::vector<PointPair>* closest_points) = 0;
 
   // TODO(SeanCurtis-TRI): Add a C++ version of "collidingPointsTest.m". Once
   // such a test exists, update the @see reference to it below.
@@ -231,14 +223,10 @@ class Model {
    collision occurs.
 
    @return Whether this method successfully ran. **/
-  virtual bool CollisionRaycast(
-      const Eigen::Matrix3Xd& origin,
-      const Eigen::Matrix3Xd& ray_endpoint,
-      bool use_margins,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::VectorXd& distances,
-      // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      Eigen::Matrix3Xd& normals) = 0;
+  virtual bool CollisionRaycast(const Eigen::Matrix3Xd& origin,
+                                const Eigen::Matrix3Xd& ray_endpoint,
+                                bool use_margins, Eigen::VectorXd* distances,
+                                Eigen::Matrix3Xd* normals) = 0;
 
   /** Modifies a collision element's local transform to be relative to a joint's
    frame rather than a link's frame. This is necessary because Drake requires

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -11,7 +11,9 @@
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/point_pair.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 typedef std::pair<ElementId, ElementId> ElementIdPair;
 
 /** Model is an abstract base class of a collision model. Child classes of Model
@@ -28,9 +30,10 @@ class Model {
 
    This operation is frequently referred to as "registering" the collision
    element.  This is the process by which a fully-realized Drake collision
-   element is fed to a specific DrakeCollision::Model implementation.  Prior
-   to this *registration*, the collision model knows nothing about the collision
-   element.  After registration, it owns the collision element.
+   element is fed to a specific drake::multibody::collision::Model
+   implementation.  Prior to this *registration*, the collision model knows
+   nothing about the collision element.  After registration, it owns the
+   collision element.
 
    @param element The element to add.
 
@@ -239,7 +242,7 @@ class Model {
 
    @return Whether the collision element was successfully updated. **/
   virtual bool TransformCollisionFrame(
-      const DrakeCollision::ElementId& eid,
+      const drake::multibody::collision::ElementId& eid,
       const Eigen::Isometry3d& transform_body_to_joint);
 
   /** A toString method for this class. */
@@ -260,4 +263,6 @@ class Model {
   std::unordered_map<ElementId, std::unique_ptr<Element>> elements;
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -40,7 +40,7 @@ class Model {
    error configuring collision  model, etc.) **/
   Element* AddElement(std::unique_ptr<Element> element);
 
-  bool removeElement(ElementId id);
+  bool RemoveElement(ElementId id);
 
   /** Gets a read-only pointer to a collision element in this model.
 
@@ -61,15 +61,14 @@ class Model {
    model. **/
   virtual Element* FindMutableElement(ElementId id);
 
-  // TODO(SeanCurtis-TRI): Why is this virtual?
-  virtual void getTerrainContactPoints(
+  void GetTerrainContactPoints(
       ElementId id0,
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
       Eigen::Matrix3Xd& terrain_points);
 
   /** Updates the collision model. This method is typically called after changes
    are made to its collision elements. **/
-  virtual void updateModel() = 0;
+  virtual void UpdateModel() = 0;
 
   /** Updates the stored transformation from a collision element's canonical
   space to world space (`X_WE`), where `X_WE = X_WL * X_LE`. `X_LE` is the
@@ -82,7 +81,7 @@ class Model {
    current world pose of the parent body in a given context.
 
    @return Whether the update was successful. **/
-  virtual bool updateElementWorldTransform(
+  virtual bool UpdateElementWorldTransform(
       ElementId id, const Eigen::Isometry3d& X_WL);
 
   /** Computes the points of closest approach between all eligible pairs of
@@ -98,7 +97,7 @@ class Model {
    contains the closest point information after this method is called
 
    @return Whether this method successfully ran. **/
-  virtual bool closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
+  virtual bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                                      bool use_margins,
                                      std::vector<PointPair>&
                                      closest_points) = 0;
@@ -132,7 +131,7 @@ class Model {
    called
 
    @return Whether this method successfully ran. **/
-  virtual bool closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
+  virtual bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                                      bool use_margins,
                                      std::vector<PointPair>&
                                      closest_points) = 0;
@@ -164,7 +163,7 @@ class Model {
 
    @param[out] closest_points A vector of `N` PointPair instances such that the
    i'th instance reports the query result for the i'th input point. **/
-  virtual void collisionDetectFromPoints(
+  virtual void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
       std::vector<PointPair>& closest_points) = 0;
@@ -191,7 +190,7 @@ class Model {
 
   @see drake/matlab/systems/plants/test/collidingPointsTest.m for a MATLAB
   %test. **/
-  virtual std::vector<size_t> collidingPoints(
+  virtual std::vector<size_t> CollidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) = 0;
 
@@ -212,7 +211,7 @@ class Model {
   used to check for collisions with the model.
 
   @return Whether any of the points positively checks for collision. **/
-  virtual bool collidingPointsCheckOnly(
+  virtual bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) = 0;
 
@@ -232,7 +231,7 @@ class Model {
    collision occurs.
 
    @return Whether this method successfully ran. **/
-  virtual bool collisionRaycast(
+  virtual bool CollisionRaycast(
       const Eigen::Matrix3Xd& origin,
       const Eigen::Matrix3Xd& ray_endpoint,
       bool use_margins,
@@ -251,7 +250,7 @@ class Model {
    link's frame to the joint's coordinate frame.
 
    @return Whether the collision element was successfully updated. **/
-  virtual bool transformCollisionFrame(
+  virtual bool TransformCollisionFrame(
       const DrakeCollision::ElementId& eid,
       const Eigen::Isometry3d& transform_body_to_joint);
 

--- a/drake/multibody/collision/point_pair.h
+++ b/drake/multibody/collision/point_pair.h
@@ -4,7 +4,9 @@
 
 #include "drake/multibody/collision/element.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 /** Structure containing the results of a collision query. **/
 struct PointPair {
@@ -45,4 +47,6 @@ struct PointPair {
   double distance{};
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -25,7 +25,9 @@
 //    Value: 0b10011
 //    Group:   43210,
 // where groups are enumerated from *right* to *left*.
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 namespace test {
 namespace {
 
@@ -317,12 +319,13 @@ GTEST_TEST(CollisionFilterGroupCompile, ClearFlushesData) {
 
 //---------------------------------------------------------------------------
 
-// This tests the functionality of the DrakeCollision::Element::CanCollideWith
-// method.  Assuming the bit masks have been set properly, this confirms they
-// are interpreted properly.
+// This tests the functionality of the
+// drake::multibody::collision::Element::CanCollideWith method.  Assuming the
+// bit masks have been set properly, this confirms they are interpreted
+// properly.
 GTEST_TEST(CollisionFilterGroupElement, ElementCanCollideWithTest) {
-  DrakeCollision::Element e1;
-  DrakeCollision::Element e2;
+  drake::multibody::collision::Element e1;
+  drake::multibody::collision::Element e2;
 
   // Case 1: By default, elements belong to no group and ignore nothing.
   EXPECT_EQ(e1.get_collision_filter_group(), kDefaultGroup);
@@ -498,4 +501,6 @@ GTEST_TEST(CollisionFilterGroupURDF, ParseMultiIgnoreTest) {
 }
 }  // namespace
 }  // namespace test
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/test/fcl_model_test.cc
+++ b/drake/multibody/collision/test/fcl_model_test.cc
@@ -3,7 +3,9 @@
 #include <fcl/fcl.h>
 #include <gtest/gtest.h>
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 namespace {
 
 // TODO(jamiesnape): Test the model.
@@ -38,4 +40,6 @@ GTEST_TEST(FCLModelTest, SphereSphereDistance) {
 }
 
 }  // namespace
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/test/model_test.cc
+++ b/drake/multibody/collision/test/model_test.cc
@@ -56,7 +56,7 @@ typedef std::unordered_map<const DrakeCollision::Element*, SurfacePoint>
 // A series of canonical tests are performed. These are Box_vs_Sphere,
 // SmallBoxSittingOnLargeBox and NonAlignedBoxes.
 // These tests are performed using the following algorithms:
-// - closestPointsAllToAll: O(N^2) checking all pairs of collision elements.
+// - ClosestPointsAllToAll: O(N^2) checking all pairs of collision elements.
 //   Results are in bodies' frames.
 // - ComputeMaximumDepthCollisionPoints: Uses collision library dispatching.
 //   Results are in world frame.
@@ -89,7 +89,7 @@ typedef std::unordered_map<const DrakeCollision::Element*, SurfacePoint>
  *          |                    |
  *
  */
-GTEST_TEST(ModelTest, closestPointsAllToAll) {
+GTEST_TEST(ModelTest, ClosestPointsAllToAll) {
   // Set up the geometry.
   Isometry3d T_body1_to_world, T_body2_to_world, T_body3_to_world,
       T_elem2_to_body;
@@ -122,14 +122,14 @@ GTEST_TEST(ModelTest, closestPointsAllToAll) {
   ElementId id1 = element_1->getId();
   ElementId id2 = element_2->getId();
   ElementId id3 = element_3->getId();
-  model->updateElementWorldTransform(id1, T_body1_to_world);
-  model->updateElementWorldTransform(id2, T_body2_to_world);
-  model->updateElementWorldTransform(id3, T_body3_to_world);
+  model->UpdateElementWorldTransform(id1, T_body1_to_world);
+  model->UpdateElementWorldTransform(id2, T_body2_to_world);
+  model->UpdateElementWorldTransform(id3, T_body3_to_world);
 
   // Compute the closest points.
   const std::vector<ElementId> ids_to_check = {id1, id2, id3};
   std::vector<PointPair> points;
-  model->closestPointsAllToAll(ids_to_check, true, points);
+  model->ClosestPointsAllToAll(ids_to_check, true, points);
   ASSERT_EQ(3u, points.size());
 
   // Check the closest point between object 1 and object 2.
@@ -264,13 +264,13 @@ class BoxVsSphereTest : public ::testing::Test {
     Isometry3d box_pose;
     box_pose.setIdentity();
     box_pose.translation() = Vector3d(0.0, 0.5, 0.0);
-    model_->updateElementWorldTransform(box_->getId(), box_pose);
+    model_->UpdateElementWorldTransform(box_->getId(), box_pose);
 
     // Body 2 pose
     Isometry3d sphere_pose;
     sphere_pose.setIdentity();
     sphere_pose.translation() = Vector3d(0.0, 1.25, 0.0);
-    model_->updateElementWorldTransform(sphere_->getId(), sphere_pose);
+    model_->UpdateElementWorldTransform(sphere_->getId(), sphere_pose);
   }
 
  protected:
@@ -289,9 +289,9 @@ TEST_F(BoxVsSphereTest, SingleContact) {
   // List of collision points.
   std::vector<PointPair> points;
 
-  // Collision test performed with Model::closestPointsAllToAll.
+  // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {box_->getId(), sphere_->getId()};
-  model_->closestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.25, points[0].distance, tolerance_);
   // Points are in the bodies' frame on the surface of the corresponding body.
@@ -311,7 +311,7 @@ TEST_F(BoxVsSphereTest, SingleContact) {
   // That is why ptA is generally different from ptB, unless there is
   // an exact non-penetrating collision.
   // WARNING:
-  // This convention is different from the one used by closestPointsAllToAll
+  // This convention is different from the one used by ClosestPointsAllToAll
   // which computes points in the local frame of the body.
   // TODO(amcastro-tri): make these two conventions match? does this interfere
   // with any Matlab functionality?
@@ -331,7 +331,7 @@ TEST_F(BoxVsSphereTest, SingleContact) {
   // That is why ptA is generally different from ptB, unless there is
   // an exact non-penetrating collision.
   // WARNING:
-  // This convention is different from the one used by closestPointsAllToAll
+  // This convention is different from the one used by ClosestPointsAllToAll
   // which computes points in the local frame of the body.
   // TODO(amcastro-tri): make these two conventions match? does this interfere
   // with any Matlab functionality?
@@ -377,13 +377,13 @@ class SmallBoxSittingOnLargeBox: public ::testing::Test {
     Isometry3d large_box_pose;
     large_box_pose.setIdentity();
     large_box_pose.translation() = Vector3d(0.0, 2.5, 0.0);
-    model_->updateElementWorldTransform(large_box_->getId(), large_box_pose);
+    model_->UpdateElementWorldTransform(large_box_->getId(), large_box_pose);
 
     // Small body pose
     Isometry3d small_box_pose;
     small_box_pose.setIdentity();
     small_box_pose.translation() = Vector3d(0.0, 5.4, 0.0);
-    model_->updateElementWorldTransform(small_box_->getId(), small_box_pose);
+    model_->UpdateElementWorldTransform(small_box_->getId(), small_box_pose);
   }
 
  protected:
@@ -412,10 +412,10 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   // 2. The vertical position of the collision point (since for any of the four
   //    corners of the small box is the same.
 
-  // Collision test performed with Model::closestPointsAllToAll.
+  // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {large_box_->getId(),
                                                small_box_->getId()};
-  model_->closestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   EXPECT_TRUE(points[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
@@ -491,7 +491,7 @@ class NonAlignedBoxes: public ::testing::Test {
     Isometry3d box1_pose;
     box1_pose.setIdentity();
     box1_pose.translation() = Vector3d(0.0, 0.5, 0.0);
-    model_->updateElementWorldTransform(box1_->getId(), box1_pose);
+    model_->UpdateElementWorldTransform(box1_->getId(), box1_pose);
 
     // Box 2 pose.
     // Rotate box 2 45 degrees around the y axis so that it does not alight with
@@ -501,7 +501,7 @@ class NonAlignedBoxes: public ::testing::Test {
     box2_pose.translation() = Vector3d(0.0, 1.4, 0.0);
     box2_pose.linear() =
         AngleAxisd(M_PI_4, Vector3d::UnitY()).toRotationMatrix();
-    model_->updateElementWorldTransform(box2_->getId(), box2_pose);
+    model_->UpdateElementWorldTransform(box2_->getId(), box2_pose);
   }
 
  protected:
@@ -529,9 +529,9 @@ TEST_F(NonAlignedBoxes, SingleContact) {
   // 1. The penetration depth.
   // 2. The vertical position of the collision point (since for any of the four
   //    corners of the small box is the same.
-  // Collision test performed with Model::closestPointsAllToAll.
+  // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {box1_->getId(), box2_->getId()};
-  model_->closestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   EXPECT_TRUE(points[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
@@ -573,13 +573,13 @@ TEST_F(SmallBoxSittingOnLargeBox, ClearCachedResults) {
   Isometry3d large_box_pose;
   large_box_pose.setIdentity();
   large_box_pose.translation() = Vector3d(0.0, 2.5, 0.0);
-  model_->updateElementWorldTransform(large_box_->getId(), large_box_pose);
+  model_->UpdateElementWorldTransform(large_box_->getId(), large_box_pose);
 
   // Small body pose
   Isometry3d small_box_pose;
   small_box_pose.setIdentity();
   small_box_pose.translation() = Vector3d(0.0, 5.4, 0.0);
-  model_->updateElementWorldTransform(small_box_->getId(), small_box_pose);
+  model_->UpdateElementWorldTransform(small_box_->getId(), small_box_pose);
 
   // List of collision points.
   std::vector<PointPair> points;
@@ -592,7 +592,7 @@ TEST_F(SmallBoxSittingOnLargeBox, ClearCachedResults) {
     if (i == 1) small_box_pose.translation() = Vector3d(1.0e-3, 5.4,    0.0);
     if (i == 2) small_box_pose.translation() = Vector3d(   0.0, 5.4, 1.0e-3);
     if (i == 3) small_box_pose.translation() = Vector3d(1.0e-3, 5.4, 1.0e-3);
-    model_->updateElementWorldTransform(small_box_->getId(), small_box_pose);
+    model_->UpdateElementWorldTransform(small_box_->getId(), small_box_pose);
 
     // Notice that the results vector is cleared every time so that results
     // do not accumulate.
@@ -726,10 +726,10 @@ GTEST_TEST(ModelTest, AnchoredMeshes) {
 
   // Sets the collision elements' pose.
   pose.translation() = Vector3d(0.0, 0.0, 0.59);
-  model->updateElementWorldTransform(sphere->getId(), pose);
+  model->UpdateElementWorldTransform(sphere->getId(), pose);
 
   pose.translation() = Vector3d(0.0, 0.0, 0.0);
-  model->updateElementWorldTransform(cap->getId(), pose);
+  model->UpdateElementWorldTransform(cap->getId(), pose);
 
   // List of collision points.
   std::vector<PointPair> points;
@@ -780,7 +780,7 @@ GTEST_TEST(ModelTest, PointDistanceToNonConvex) {
   points << cx, cy, cz;
 
   std::vector<PointPair> results;
-  model->collisionDetectFromPoints(points, false, results);
+  model->CollisionDetectFromPoints(points, false, results);
 
   ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
@@ -811,7 +811,7 @@ GTEST_TEST(ModelTest, PointDistanceToEmptyWorld) {
   points << cx, cy, cz;
 
   std::vector<PointPair> results;
-  model->collisionDetectFromPoints(points, false, results);
+  model->CollisionDetectFromPoints(points, false, results);
 
   ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
@@ -851,15 +851,15 @@ GTEST_TEST(ModelTest, DistanceToNonConvex) {
 
   // Sets the collision elements' pose.
   pose.translation() = Vector3d(0.0, 0.0, 0.7);
-  model->updateElementWorldTransform(sphere->getId(), pose);
+  model->UpdateElementWorldTransform(sphere->getId(), pose);
 
   pose.translation() = Vector3d(0.0, 0.0, 0.0);
-  model->updateElementWorldTransform(cap->getId(), pose);
+  model->UpdateElementWorldTransform(cap->getId(), pose);
 
   std::vector<PointPair> results;
   std::vector<ElementIdPair> pairs;
   pairs.emplace_back(sphere->getId(), cap->getId());
-  model->closestPointsPairwise(pairs, true, results);
+  model->ClosestPointsPairwise(pairs, true, results);
   EXPECT_EQ(results.size(), 0u);
 }
 

--- a/drake/multibody/collision/test/model_test.cc
+++ b/drake/multibody/collision/test/model_test.cc
@@ -129,7 +129,7 @@ GTEST_TEST(ModelTest, ClosestPointsAllToAll) {
   // Compute the closest points.
   const std::vector<ElementId> ids_to_check = {id1, id2, id3};
   std::vector<PointPair> points;
-  model->ClosestPointsAllToAll(ids_to_check, true, points);
+  model->ClosestPointsAllToAll(ids_to_check, true, &points);
   ASSERT_EQ(3u, points.size());
 
   // Check the closest point between object 1 and object 2.
@@ -291,7 +291,7 @@ TEST_F(BoxVsSphereTest, SingleContact) {
 
   // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {box_->getId(), sphere_->getId()};
-  model_->ClosestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, &points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.25, points[0].distance, tolerance_);
   // Points are in the bodies' frame on the surface of the corresponding body.
@@ -304,7 +304,7 @@ TEST_F(BoxVsSphereTest, SingleContact) {
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   // Not using margins.
   points.clear();
-  model_->ComputeMaximumDepthCollisionPoints(false, points);
+  model_->ComputeMaximumDepthCollisionPoints(false, &points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.25, points[0].distance, tolerance_);
   // Points are in the world frame on the surface of the corresponding body.
@@ -324,7 +324,7 @@ TEST_F(BoxVsSphereTest, SingleContact) {
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   // Using margins.
   points.clear();
-  model_->ComputeMaximumDepthCollisionPoints(true, points);
+  model_->ComputeMaximumDepthCollisionPoints(true, &points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.25, points[0].distance, tolerance_);
   // Points are in the world frame on the surface of the corresponding body.
@@ -415,7 +415,7 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {large_box_->getId(),
                                                small_box_->getId()};
-  model_->ClosestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, &points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   EXPECT_TRUE(points[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
@@ -429,7 +429,7 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   // Not using margins.
   points.clear();
-  model_->ComputeMaximumDepthCollisionPoints(false, points);
+  model_->ComputeMaximumDepthCollisionPoints(false, &points);
 
   // Unfortunately DrakeCollision::Model's manifold has one point for this case.
   // Best for physics simulations would be DrakeCollision::Model to return at
@@ -447,7 +447,7 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   // Using margins.
   points.clear();
-  model_->ComputeMaximumDepthCollisionPoints(true, points);
+  model_->ComputeMaximumDepthCollisionPoints(true, &points);
 
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
@@ -531,7 +531,7 @@ TEST_F(NonAlignedBoxes, SingleContact) {
   //    corners of the small box is the same.
   // Collision test performed with Model::ClosestPointsAllToAll.
   const std::vector<ElementId> ids_to_check = {box1_->getId(), box2_->getId()};
-  model_->ClosestPointsAllToAll(ids_to_check, true, points);
+  model_->ClosestPointsAllToAll(ids_to_check, true, &points);
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   EXPECT_TRUE(points[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
@@ -544,7 +544,7 @@ TEST_F(NonAlignedBoxes, SingleContact) {
 
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   points.clear();
-  model_->ComputeMaximumDepthCollisionPoints(false, points);
+  model_->ComputeMaximumDepthCollisionPoints(false, &points);
   // Unfortunately DrakeCollision::Model's manifold has one point for this case.
   // Best for physics simulations would be DrakeCollision::Model to return at
   // least the four corners of the smaller box. However it randomly picks one
@@ -598,7 +598,7 @@ TEST_F(SmallBoxSittingOnLargeBox, ClearCachedResults) {
     // do not accumulate.
     points.clear();
 
-    model_->ComputeMaximumDepthCollisionPoints(false, points);
+    model_->ComputeMaximumDepthCollisionPoints(false, &points);
   }
 
   // Check that the model is not caching results even after four queries.
@@ -666,7 +666,7 @@ GTEST_TEST(ModelTest, AnchoredElements) {
   std::vector<PointPair> points;
 
   // Compute all points of contact.
-  model->ComputeMaximumDepthCollisionPoints(false, points);
+  model->ComputeMaximumDepthCollisionPoints(false, &points);
 
   // Only three points are expected (instead of four) since ball1 and ball4 are
   // flagged as anchored.
@@ -735,7 +735,7 @@ GTEST_TEST(ModelTest, AnchoredMeshes) {
   std::vector<PointPair> points;
 
   // Computes all points of contact.
-  model->ComputeMaximumDepthCollisionPoints(false, points);
+  model->ComputeMaximumDepthCollisionPoints(false, &points);
 
   // Expects one collision point for this test.
   ASSERT_EQ(1u, points.size());
@@ -780,7 +780,7 @@ GTEST_TEST(ModelTest, PointDistanceToNonConvex) {
   points << cx, cy, cz;
 
   std::vector<PointPair> results;
-  model->CollisionDetectFromPoints(points, false, results);
+  model->CollisionDetectFromPoints(points, false, &results);
 
   ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
@@ -811,7 +811,7 @@ GTEST_TEST(ModelTest, PointDistanceToEmptyWorld) {
   points << cx, cy, cz;
 
   std::vector<PointPair> results;
-  model->CollisionDetectFromPoints(points, false, results);
+  model->CollisionDetectFromPoints(points, false, &results);
 
   ASSERT_EQ(results.size(), 4u);
   const double inf = std::numeric_limits<double>::infinity();
@@ -859,7 +859,7 @@ GTEST_TEST(ModelTest, DistanceToNonConvex) {
   std::vector<PointPair> results;
   std::vector<ElementIdPair> pairs;
   pairs.emplace_back(sphere->getId(), cap->getId());
-  model->ClosestPointsPairwise(pairs, true, results);
+  model->ClosestPointsPairwise(pairs, true, &results);
   EXPECT_EQ(results.size(), 0u);
 }
 

--- a/drake/multibody/collision/test/model_test.cc
+++ b/drake/multibody/collision/test/model_test.cc
@@ -19,7 +19,9 @@ using std::make_unique;
 using std::move;
 using std::unique_ptr;
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 namespace {
 
 // Structure used to hold the analytical solution of the tests.
@@ -34,8 +36,9 @@ struct SurfacePoint {
 };
 
 // Solutions are accessed by collision element id using an std::unordered_set.
-// DrakeCollision::Model returns the collision detection results as a vector of
-// DrakeCollision::PointPair entries. Each entry holds a reference to the pair
+// drake::multibody::collision::Model returns the collision detection results
+// as a vector of drake::multibody::collision::PointPair entries. Each entry
+// holds a reference to the pair
 // of collision elements taking part in the collision. Collision elements are
 // referenced by their id.
 // The order in which the pair of elements is stored in a PointPair cannot
@@ -49,7 +52,8 @@ struct SurfacePoint {
 // contact point on a specific element here we use an `std::unordered_set` to
 // map id's to a `SurfacePoint` structure holding the analytical solution on
 // both body and world frames.
-typedef std::unordered_map<const DrakeCollision::Element*, SurfacePoint>
+typedef std::unordered_map<const drake::multibody::collision::Element*,
+                           SurfacePoint>
     ElementToSurfacePointMap;
 
 // GENERAL REMARKS ON THE TESTS PERFORMED
@@ -342,17 +346,17 @@ TEST_F(BoxVsSphereTest, SingleContact) {
       points[0].ptB.isApprox(solution_[points[0].elementB].world_frame));
 }
 
-// This test seeks to find out whether DrakeCollision::Model can report
-// collision manifolds. To this end, a small cube with unit length sides is
-// placed on top of a large cube with sides of length 5.0. The smaller cube is
-// placed such that it intersects the large box. Therefore the intersection
+// This test seeks to find out whether drake::multibody::collision::Model can
+// report collision manifolds. To this end, a small cube with unit length sides
+// is placed on top of a large cube with sides of length 5.0. The smaller cube
+// is placed such that it intersects the large box. Therefore the intersection
 // between the two boxes is not just a single point but the (squared) perimeter
 // all around the smaller box (the manifold).
 //
-// Unfortunately these tests show that DrakeCollision::Model only reports a
-// single (randomly chosen) point at one of the smaller box corners. In previous
-// runs this was the corner at (0.5, 0.5, z) where z = 5.0 for the top of the
-// large box and z = 4.9 for the bottom of the smaller box.
+// Unfortunately these tests show that drake::multibody::collision::Model only
+// reports a single (randomly chosen) point at one of the smaller box corners.
+// In previous runs this was the corner at (0.5, 0.5, z) where z = 5.0 for the
+// top of the large box and z = 4.9 for the bottom of the smaller box.
 class SmallBoxSittingOnLargeBox: public ::testing::Test {
  public:
   void SetUp() override {
@@ -402,9 +406,9 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   // List of collision points.
   std::vector<PointPair> points;
 
-  // Unfortunately DrakeCollision::Model is randomly selecting one of the small
-  // box's corners instead of reporting a manifold describing the perimeter of
-  // the square where both boxes intersect.
+  // Unfortunately drake::multibody::collision::Model is randomly selecting one
+  // of the small box's corners instead of reporting a manifold describing the
+  // perimeter of the square where both boxes intersect.
   // Therefore it is impossible to assert if that choice would change with
   // future releases (say just because tolerances changed).
   // What we can test for sure is:
@@ -431,10 +435,10 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
   points.clear();
   model_->ComputeMaximumDepthCollisionPoints(false, &points);
 
-  // Unfortunately DrakeCollision::Model's manifold has one point for this case.
-  // Best for physics simulations would be DrakeCollision::Model to return at
-  // least the four corners of the smaller box. However it randomly picks one
-  // corner.
+  // Unfortunately drake::multibody::collision::Model's manifold has one point
+  // for this case.  Best for physics simulations would be
+  // drake::multibody::collision::Model to return at least the four corners of
+  // the smaller box. However it randomly picks one corner.
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   // Collision points are reported in the world's frame.
@@ -459,14 +463,15 @@ TEST_F(SmallBoxSittingOnLargeBox, SingleContact) {
               solution_[points[0].elementB].world_frame.y(), tolerance_);
 }
 
-// This test seeks to find out whether DrakeCollision::Model can report
-// collision manifolds. To this end two unit length boxes are placed on top of
-// one another. The box sitting on top is rotated by 45 degrees so that the
-// contact area would consist of an octagon. If DrakeCollision::Model can report
-// manifolds, the manifold would consist of the perimeter of this octagon.
+// This test seeks to find out whether drake::multibody::collision::Model can
+// report collision manifolds. To this end two unit length boxes are placed on
+// top of one another. The box sitting on top is rotated by 45 degrees so that
+// the contact area would consist of an octagon. If
+// drake::multibody::collision::Model can report manifolds, the manifold would
+// consist of the perimeter of this octagon.
 
-// Unfortunately these tests show that DrakeCollision::Model only reports a
-// single (randomly chosen) point within this octagonal contact area.
+// Unfortunately these tests show that drake::multibody::collision::Model only
+// reports a single (randomly chosen) point within this octagonal contact area.
 class NonAlignedBoxes: public ::testing::Test {
  public:
   void SetUp() override {
@@ -520,9 +525,9 @@ TEST_F(NonAlignedBoxes, SingleContact) {
   // List of collision points.
   std::vector<PointPair> points;
 
-  // Unfortunately DrakeCollision::Model is randomly selecting one of the small
-  // box's corners instead of reporting a manifold describing the perimeter of
-  // the square where both boxes intersect.
+  // Unfortunately drake::multibody::collision::Model is randomly selecting one
+  // of the small box's corners instead of reporting a manifold describing the
+  // perimeter of the square where both boxes intersect.
   // Therefore it is impossible to assert if that choice would change with
   // future releases (say just because tolerances changed).
   // What we can test for sure is:
@@ -545,10 +550,10 @@ TEST_F(NonAlignedBoxes, SingleContact) {
   // Collision test performed with Model::ComputeMaximumDepthCollisionPoints.
   points.clear();
   model_->ComputeMaximumDepthCollisionPoints(false, &points);
-  // Unfortunately DrakeCollision::Model's manifold has one point for this case.
-  // Best for physics simulations would be DrakeCollision::Model to return at
-  // least the four corners of the smaller box. However it randomly picks one
-  // corner.
+  // Unfortunately drake::multibody::collision::Model's manifold has one point
+  // for this case.  Best for physics simulations would be
+  // drake::multibody::collision::Model to return at least the four corners of
+  // the smaller box. However it randomly picks one corner.
   ASSERT_EQ(1u, points.size());
   EXPECT_NEAR(-0.1, points[0].distance, tolerance_);
   EXPECT_TRUE(points[0].normal.isApprox(Vector3d(0.0, -1.0, 0.0)));
@@ -864,4 +869,6 @@ GTEST_TEST(ModelTest, DistanceToNonConvex) {
 }
 
 }  // namespace
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/unusable_model.cc
+++ b/drake/multibody/collision/unusable_model.cc
@@ -2,7 +2,9 @@
 
 #include "drake/common/drake_assert.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 void UnusableModel::UpdateModel() {
   DRAKE_ABORT_MSG(
@@ -75,4 +77,6 @@ std::vector<size_t> UnusableModel::CollidingPoints(
   return std::vector<size_t>();
 }
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/collision/unusable_model.cc
+++ b/drake/multibody/collision/unusable_model.cc
@@ -4,20 +4,20 @@
 
 namespace DrakeCollision {
 
-void UnusableModel::updateModel() {
+void UnusableModel::UpdateModel() {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return;
 }
 
-bool UnusableModel::updateElementWorldTransform(
+bool UnusableModel::UpdateElementWorldTransform(
     ElementId, const Eigen::Isometry3d&) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
-bool UnusableModel::closestPointsAllToAll(
+bool UnusableModel::ClosestPointsAllToAll(
     const std::vector<ElementId>&, bool, std::vector<PointPair>&) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
@@ -31,14 +31,14 @@ bool UnusableModel::ComputeMaximumDepthCollisionPoints(
   return false;
 }
 
-bool UnusableModel::closestPointsPairwise(
+bool UnusableModel::ClosestPointsPairwise(
     const std::vector<ElementIdPair>&, bool, std::vector<PointPair>&) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
-void UnusableModel::collisionDetectFromPoints(
+void UnusableModel::CollisionDetectFromPoints(
     const Eigen::Matrix3Xd&, bool, std::vector<PointPair>&) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
@@ -51,7 +51,7 @@ void UnusableModel::ClearCachedResults(bool) {
   return;
 }
 
-bool UnusableModel::collisionRaycast(const Eigen::Matrix3Xd&,
+bool UnusableModel::CollisionRaycast(const Eigen::Matrix3Xd&,
                                      const Eigen::Matrix3Xd&,
                                      bool,
                                      Eigen::VectorXd&,
@@ -61,14 +61,14 @@ bool UnusableModel::collisionRaycast(const Eigen::Matrix3Xd&,
   return false;
 }
 
-bool UnusableModel::collidingPointsCheckOnly(
+bool UnusableModel::CollidingPointsCheckOnly(
     const std::vector<Eigen::Vector3d>&, double) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
-std::vector<size_t> UnusableModel::collidingPoints(
+std::vector<size_t> UnusableModel::CollidingPoints(
     const std::vector<Eigen::Vector3d>&, double) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");

--- a/drake/multibody/collision/unusable_model.cc
+++ b/drake/multibody/collision/unusable_model.cc
@@ -17,29 +17,29 @@ bool UnusableModel::UpdateElementWorldTransform(
   return false;
 }
 
-bool UnusableModel::ClosestPointsAllToAll(
-    const std::vector<ElementId>&, bool, std::vector<PointPair>&) {
+bool UnusableModel::ClosestPointsAllToAll(const std::vector<ElementId>&, bool,
+                                          std::vector<PointPair>*) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::ComputeMaximumDepthCollisionPoints(
-    bool, std::vector<PointPair>&) {
+    bool, std::vector<PointPair>*) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 bool UnusableModel::ClosestPointsPairwise(
-    const std::vector<ElementIdPair>&, bool, std::vector<PointPair>&) {
+    const std::vector<ElementIdPair>&, bool, std::vector<PointPair>*) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;
 }
 
 void UnusableModel::CollisionDetectFromPoints(
-    const Eigen::Matrix3Xd&, bool, std::vector<PointPair>&) {
+    const Eigen::Matrix3Xd&, bool, std::vector<PointPair>*) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return;
@@ -54,8 +54,8 @@ void UnusableModel::ClearCachedResults(bool) {
 bool UnusableModel::CollisionRaycast(const Eigen::Matrix3Xd&,
                                      const Eigen::Matrix3Xd&,
                                      bool,
-                                     Eigen::VectorXd&,
-                                     Eigen::Matrix3Xd&) {
+                                     Eigen::VectorXd*,
+                                     Eigen::Matrix3Xd*) {
   DRAKE_ABORT_MSG(
       "Compile Drake with a collision library backend for collision support!");
   return false;

--- a/drake/multibody/collision/unusable_model.h
+++ b/drake/multibody/collision/unusable_model.h
@@ -25,25 +25,25 @@ class UnusableModel : public Model {
 
   bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
 
   bool ComputeMaximumDepthCollisionPoints(
-      bool use_margins, std::vector<PointPair>& points) override;
+      bool use_margins, std::vector<PointPair>* points) override;
 
   bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
-                             std::vector<PointPair>& closest_points) override;
+                             std::vector<PointPair>* closest_points) override;
 
   void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
-      std::vector<PointPair>& closest_points) override;
+      std::vector<PointPair>* closest_points) override;
 
   void ClearCachedResults(bool use_margins) override;
 
   bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
-                        Eigen::VectorXd& distances,
-                        Eigen::Matrix3Xd& normals) override;
+                        Eigen::VectorXd* distances,
+                        Eigen::Matrix3Xd* normals) override;
 
   bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,

--- a/drake/multibody/collision/unusable_model.h
+++ b/drake/multibody/collision/unusable_model.h
@@ -18,38 +18,38 @@ class UnusableModel : public Model {
 
   virtual ~UnusableModel() {}
 
-  void updateModel() override;
+  void UpdateModel() override;
 
-  bool updateElementWorldTransform(
+  bool UpdateElementWorldTransform(
       ElementId, const Eigen::Isometry3d& T_local_to_world) override;
 
-  bool closestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
+  bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
 
   bool ComputeMaximumDepthCollisionPoints(
       bool use_margins, std::vector<PointPair>& points) override;
 
-  bool closestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
+  bool ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,
                              bool use_margins,
                              std::vector<PointPair>& closest_points) override;
 
-  void collisionDetectFromPoints(
+  void CollisionDetectFromPoints(
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>& closest_points) override;
 
   void ClearCachedResults(bool use_margins) override;
 
-  bool collisionRaycast(const Eigen::Matrix3Xd& origins,
+  bool CollisionRaycast(const Eigen::Matrix3Xd& origins,
                         const Eigen::Matrix3Xd& ray_endpoints, bool use_margins,
                         Eigen::VectorXd& distances,
                         Eigen::Matrix3Xd& normals) override;
 
-  bool collidingPointsCheckOnly(
+  bool CollidingPointsCheckOnly(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
 
-  std::vector<size_t> collidingPoints(
+  std::vector<size_t> CollidingPoints(
       const std::vector<Eigen::Vector3d>& input_points,
       double collision_threshold) override;
 };

--- a/drake/multibody/collision/unusable_model.h
+++ b/drake/multibody/collision/unusable_model.h
@@ -7,7 +7,9 @@
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/collision/model.h"
 
-namespace DrakeCollision {
+namespace drake {
+namespace multibody {
+namespace collision {
 
 /// An unusable model, used when no collision detection backend is available.
 class UnusableModel : public Model {
@@ -54,4 +56,6 @@ class UnusableModel : public Model {
       double collision_threshold) override;
 };
 
-}  // namespace DrakeCollision
+}  // namespace collision
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/parsers/sdf_parser.cc
+++ b/drake/multibody/parsers/sdf_parser.cc
@@ -266,7 +266,7 @@ void ParseSdfCollision(RigidBody<double>* body, XMLElement* node,
                         " has a collision element without a geometry.");
   }
 
-  DrakeCollision::Element element(
+  drake::multibody::collision::Element element(
       transform_parent_to_model.inverse() * transform_to_model, body);
 
   if (!ParseSdfGeometry(geometry_node, package_map, root_dir, element)) {

--- a/drake/multibody/parsers/urdf_parser.cc
+++ b/drake/multibody/parsers/urdf_parser.cc
@@ -467,7 +467,7 @@ void ParseCollision(RigidBody<double>* body, XMLElement* node,
         body->get_name() + " has a collision element without geometry");
   }
 
-  DrakeCollision::Element element(T_element_to_link, body);
+  drake::multibody::collision::Element element(T_element_to_link, body);
   if (!ParseGeometry(geometry_node, package_map, root_dir, element)) {
     throw runtime_error(string(__FILE__) + ": " + __func__ + ": ERROR: Failed "
         "to parse collision element in link " + body->get_name() + ".");

--- a/drake/multibody/rigid_body.cc
+++ b/drake/multibody/rigid_body.cc
@@ -129,35 +129,37 @@ const DrakeShapes::VectorOfVisualElements& RigidBody<T>::get_visual_elements()
 }
 
 template <typename T>
-void RigidBody<T>::AddCollisionElement(const std::string& group_name,
-                                    DrakeCollision::Element* element) {
-  DrakeCollision::ElementId id = element->getId();
+void RigidBody<T>::AddCollisionElement(
+    const std::string& group_name,
+    drake::multibody::collision::Element* element) {
+  drake::multibody::collision::ElementId id = element->getId();
   collision_element_ids_.push_back(id);
   collision_element_groups_[group_name].push_back(id);
   collision_elements_.push_back(element);
 }
 
 template <typename T>
-const std::vector<DrakeCollision::ElementId>&
-    RigidBody<T>::get_collision_element_ids() const {
+const std::vector<drake::multibody::collision::ElementId>&
+RigidBody<T>::get_collision_element_ids() const {
   return collision_element_ids_;
 }
 
 template <typename T>
-std::vector<DrakeCollision::ElementId>&
-    RigidBody<T>::get_mutable_collision_element_ids() {
+std::vector<drake::multibody::collision::ElementId>&
+RigidBody<T>::get_mutable_collision_element_ids() {
   return collision_element_ids_;
 }
 
 template <typename T>
-const std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-    RigidBody<T>::get_group_to_collision_ids_map() const {
+const std::map<std::string,
+               std::vector<drake::multibody::collision::ElementId>>&
+RigidBody<T>::get_group_to_collision_ids_map() const {
   return collision_element_groups_;
 }
 
 template <typename T>
-std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-    RigidBody<T>::get_mutable_group_to_collision_ids_map() {
+std::map<std::string, std::vector<drake::multibody::collision::ElementId>>&
+RigidBody<T>::get_mutable_group_to_collision_ids_map() {
   return collision_element_groups_;
 }
 
@@ -217,8 +219,9 @@ bool RigidBody<T>::CanCollideWith(const RigidBody& other) const {
 
 template <typename T>
 bool RigidBody<T>::appendCollisionElementIdsFromThisBody(
+    const string& group_name,
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    const string& group_name, vector<DrakeCollision::ElementId>& ids) const {
+    vector<drake::multibody::collision::ElementId>& ids) const {
   auto group_ids_iter = collision_element_groups_.find(group_name);
   if (group_ids_iter != collision_element_groups_.end()) {
     ids.reserve(ids.size() + distance(group_ids_iter->second.begin(),
@@ -234,7 +237,7 @@ bool RigidBody<T>::appendCollisionElementIdsFromThisBody(
 template <typename T>
 bool RigidBody<T>::appendCollisionElementIdsFromThisBody(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    vector<DrakeCollision::ElementId>& ids) const {
+    vector<drake::multibody::collision::ElementId>& ids) const {
   ids.reserve(ids.size() + collision_element_ids_.size());
   ids.insert(ids.end(), collision_element_ids_.begin(),
              collision_element_ids_.end());

--- a/drake/multibody/rigid_body.h
+++ b/drake/multibody/rigid_body.h
@@ -222,36 +222,38 @@ class RigidBody {
    * @param[in] element The element to associate with the rigid body.
    */
   void AddCollisionElement(const std::string& group_name,
-                           DrakeCollision::Element* element);
+                           drake::multibody::collision::Element* element);
 
   /**
    * @returns A reference to an `std::vector` of collision elements that
    * represent the collision geometry of this rigid body.
    */
-  const std::vector<DrakeCollision::ElementId>& get_collision_element_ids()
-      const;
+  const std::vector<drake::multibody::collision::ElementId>&
+  get_collision_element_ids() const;
 
   /**
    * Returns a reference to an `std::vector` of collision elements that
    * represent the collision geometry of this rigid body.
    */
-  std::vector<DrakeCollision::ElementId>& get_mutable_collision_element_ids();
+  std::vector<drake::multibody::collision::ElementId>&
+  get_mutable_collision_element_ids();
 
   /**
    * Returns a map of collision element group names to vectors of collision
    * element IDs. These are the collision element groups created through calls
    * to RigidBody::AddCollisionElementToGroup().
    */
-  const std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-      get_group_to_collision_ids_map() const;
+  const std::map<std::string,
+                 std::vector<drake::multibody::collision::ElementId>>&
+  get_group_to_collision_ids_map() const;
 
   /**
    * Returns a map of collision element group names to vectors of collision
    * element IDs. These are the collision element groups created through calls
    * to RigidBody::AddCollisionElementToGroup().
    */
-  std::map<std::string, std::vector<DrakeCollision::ElementId>>&
-    get_mutable_group_to_collision_ids_map();
+  std::map<std::string, std::vector<drake::multibody::collision::ElementId>>&
+  get_mutable_group_to_collision_ids_map();
 
   /**
    * Reports if there is a path in this tree from this body to the world where
@@ -323,11 +325,11 @@ class RigidBody {
   bool appendCollisionElementIdsFromThisBody(
       const std::string& group_name,
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<DrakeCollision::ElementId>& ids) const;
+      std::vector<drake::multibody::collision::ElementId>& ids) const;
 
   bool appendCollisionElementIdsFromThisBody(
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      std::vector<DrakeCollision::ElementId>& ids) const;
+      std::vector<drake::multibody::collision::ElementId>& ids) const;
 
   /**
    * Returns the points on this rigid body that should be checked for collision
@@ -397,7 +399,8 @@ class RigidBody {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  typedef std::vector<DrakeCollision::Element*> CollisionElementsVector;
+  typedef std::vector<drake::multibody::collision::Element*>
+      CollisionElementsVector;
   typedef typename CollisionElementsVector::iterator CollisionElementsIterator;
 
   CollisionElementsIterator collision_elements_begin() {
@@ -455,12 +458,12 @@ class RigidBody {
 
   // A list of collision element IDs of collision elements that represent the
   // geometry of this rigid body.
-  std::vector<DrakeCollision::ElementId> collision_element_ids_;
+  std::vector<drake::multibody::collision::ElementId> collision_element_ids_;
 
   // A map of groups of collision element IDs. This is just for conveniently
   // accessing particular groups of collision elements. The groups do not imply
   // anything in terms of how the collision elements relate to each other.
-  std::map<std::string, std::vector<DrakeCollision::ElementId>>
+  std::map<std::string, std::vector<drake::multibody::collision::ElementId>>
       collision_element_groups_;
 
   // The contact points this rigid body has with its environment.

--- a/drake/multibody/rigid_body_plant/compliant_contact_model.cc
+++ b/drake/multibody/rigid_body_plant/compliant_contact_model.cc
@@ -63,7 +63,7 @@ VectorX<T> CompliantContactModel<T>::ComputeContactForce(
   // when updating the collision element poses.
   // TODO(naveenoid) : This method call limits the template instanziation of
   // this class currently to T = double only.
-  std::vector<DrakeCollision::PointPair> pairs =
+  std::vector<drake::multibody::collision::PointPair> pairs =
       const_cast<RigidBodyTree<T>*>(&tree)->ComputeMaximumDepthCollisionPoints(
           kinsol, true);
 

--- a/drake/multibody/rigid_body_plant/contact_info.cc
+++ b/drake/multibody/rigid_body_plant/contact_info.cc
@@ -6,8 +6,8 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-ContactInfo<T>::ContactInfo(DrakeCollision::ElementId element1,
-                            DrakeCollision::ElementId element2)
+ContactInfo<T>::ContactInfo(drake::multibody::collision::ElementId element1,
+                            drake::multibody::collision::ElementId element2)
     : element1_(element1),
       element2_(element2),
       resultant_force_(),

--- a/drake/multibody/rigid_body_plant/contact_info.h
+++ b/drake/multibody/rigid_body_plant/contact_info.h
@@ -53,11 +53,15 @@ class ContactInfo {
    @param element1      The identifier for the first collision element.
    @param element2      The identifier for the second collision element.
    */
-  ContactInfo(DrakeCollision::ElementId element1,
-              DrakeCollision::ElementId element2);
+  ContactInfo(drake::multibody::collision::ElementId element1,
+              drake::multibody::collision::ElementId element2);
 
-  DrakeCollision::ElementId get_element_id_1() const { return element1_; }
-  DrakeCollision::ElementId get_element_id_2() const { return element2_; }
+  drake::multibody::collision::ElementId get_element_id_1() const {
+    return element1_;
+  }
+  drake::multibody::collision::ElementId get_element_id_2() const {
+    return element2_;
+  }
 
   void set_resultant_force(const ContactForce<T> force) {
     resultant_force_ = force;
@@ -87,8 +91,8 @@ class ContactInfo {
   }
 
  private:
-  DrakeCollision::ElementId element1_{};
-  DrakeCollision::ElementId element2_{};
+  drake::multibody::collision::ElementId element1_{};
+  drake::multibody::collision::ElementId element2_{};
   ContactForce<T> resultant_force_;
   std::vector<copyable_unique_ptr<ContactDetail<T>>> contact_details_;
 };

--- a/drake/multibody/rigid_body_plant/contact_model_doxygen.h
+++ b/drake/multibody/rigid_body_plant/contact_model_doxygen.h
@@ -26,8 +26,9 @@
  First, contact _conceptually_ occurs between two _surfaces_, one on each of
  two independently moving _bodies_. The contact produces _forces_ on those two
  surfaces, which can then affect the motion of the bodies. In practice, surfaces
- are represented by one or more DrakeCollision::Element objects -- geometric
- shapes rigidly affixed to a body, whose surfaces can engage in contact.
+ are represented by one or more drake::multibody::collision::Element objects --
+ geometric shapes rigidly affixed to a body, whose surfaces can engage in
+ contact.
 
  This document discusses a _compliant_ contact model. In compliant models, the
  bodies are considered deformable. The
@@ -47,8 +48,8 @@
  Contacts are defined in terms of these collision Element instances and _not_
  RigidBody instances. For Drake's purposes, a "contact":
 
- - describes a relationship between two DrakeCollision::Element instances,
-   denoted elements `A` and `B`,
+ - describes a relationship between two drake::multibody::collision::Element
+   instances, denoted elements `A` and `B`,
  - only exists if the Element instances overlap,
  - quantifies the degree that the two Element instances are overlapping,
  - is characterized by a single contact point and a normal direction that are

--- a/drake/multibody/rigid_body_plant/contact_results.cc
+++ b/drake/multibody/rigid_body_plant/contact_results.cc
@@ -26,8 +26,8 @@ void ContactResults<T>::Clear() {
 
 template <typename T>
 ContactInfo<T>& ContactResults<T>::AddContact(
-    DrakeCollision::ElementId element_a,
-    DrakeCollision::ElementId element_b) {
+    drake::multibody::collision::ElementId element_a,
+    drake::multibody::collision::ElementId element_b) {
   contacts_.emplace_back(element_a, element_b);
   return contacts_.back();
 }

--- a/drake/multibody/rigid_body_plant/contact_results.h
+++ b/drake/multibody/rigid_body_plant/contact_results.h
@@ -44,8 +44,8 @@ class ContactResults {
 
   // Reports a contact between two elements and prepares a ContactInfo. The
   // caller should populate the ContactInfo with the appropriate details.
-  ContactInfo<T>& AddContact(DrakeCollision::ElementId element_a,
-                             DrakeCollision::ElementId element_b);
+  ContactInfo<T>& AddContact(drake::multibody::collision::ElementId element_a,
+                             drake::multibody::collision::ElementId element_b);
 
  private:
   std::vector<ContactInfo<T>> contacts_;

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -19,7 +19,7 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
-using DrakeCollision::ElementId;
+using drake::multibody::collision::ElementId;
 
 namespace drake {
 namespace systems {

--- a/drake/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
@@ -99,8 +99,8 @@ TEST_F(CompliantContactModelTest, ModelSingleCollision) {
   const auto info = contact_results.get_contact_info(0);
 
   // Confirms that the proper bodies are in contact.
-  DrakeCollision::ElementId e1 = info.get_element_id_1();
-  DrakeCollision::ElementId e2 = info.get_element_id_2();
+  drake::multibody::collision::ElementId e1 = info.get_element_id_1();
+  drake::multibody::collision::ElementId e2 = info.get_element_id_2();
   const RigidBody<double>* b1 = unique_tree_->FindBody(e1);
   const RigidBody<double>* b2 = unique_tree_->FindBody(e2);
   ASSERT_NE(e1, e2);

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -95,8 +95,8 @@ TEST_F(ContactResultTest, SingleCollision) {
   const auto info = contact_results.get_contact_info(0);
 
   // Confirms that the proper bodies are in contact.
-  DrakeCollision::ElementId e1 = info.get_element_id_1();
-  DrakeCollision::ElementId e2 = info.get_element_id_2();
+  drake::multibody::collision::ElementId e1 = info.get_element_id_1();
+  drake::multibody::collision::ElementId e2 = info.get_element_id_2();
   const RigidBody<double>* b1 = GetTree().FindBody(e1);
   const RigidBody<double>* b2 = GetTree().FindBody(e2);
   ASSERT_NE(e1, e2);

--- a/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -118,7 +118,7 @@ class ContactFormulaTest : public ::testing::Test {
     body->add_joint(&tree_->world(),
                     make_unique<QuaternionFloatingJoint>("base", pose));
     DrakeShapes::Sphere sphere(kRadius);
-    DrakeCollision::Element collision_element(sphere);
+    drake::multibody::collision::Element collision_element(sphere);
     collision_element.set_body(body);
     tree_->addCollisionElement(collision_element, *body, "group1");
     return body;

--- a/drake/multibody/rigid_body_plant/test/contact_info_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_info_test.cc
@@ -63,8 +63,8 @@ void AssertValidCopy(const ContactInfo<T>& test_value,
 // through the copy constructor as well as the assignment operator.
 GTEST_TEST(ContactInfoTests, CloneDetails) {
   // First, construct a ContactInfo reference.
-  DrakeCollision::ElementId element_a = 10;
-  DrakeCollision::ElementId element_b = 20;
+  drake::multibody::collision::ElementId element_a = 10;
+  drake::multibody::collision::ElementId element_b = 20;
   ContactInfo<double> contact_info(element_a, element_b);
   std::vector<unique_ptr<ContactDetail<double>>> details;
 
@@ -87,8 +87,8 @@ GTEST_TEST(ContactInfoTests, CloneDetails) {
 template <template <class> class Pointer>
 void TestSetDetails() {
   // Set up initial conditions.
-  DrakeCollision::ElementId element_a = 10;
-  DrakeCollision::ElementId element_b = 20;
+  drake::multibody::collision::ElementId element_a = 10;
+  drake::multibody::collision::ElementId element_b = 20;
   ContactInfo<double> contact_info(element_a, element_b);
 
   std::vector<Pointer<ContactDetail<double>>> details;

--- a/drake/multibody/rigid_body_plant/test/contact_result_test_common.h
+++ b/drake/multibody/rigid_body_plant/test/contact_result_test_common.h
@@ -75,7 +75,7 @@ class ContactResultTestCommon : public ::testing::Test {
     body->add_joint(&tree->world(),
                     std::make_unique<QuaternionFloatingJoint>("base", pose));
     DrakeShapes::Sphere sphere(kRadius);
-    DrakeCollision::Element collision_element(sphere);
+    drake::multibody::collision::Element collision_element(sphere);
     collision_element.set_body(body);
     tree->addCollisionElement(collision_element, *body, "group1");
     return body;

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -237,7 +237,7 @@ bool RigidBodyTree<T>::transformCollisionFrame(
   for (auto body_itr = body->collision_elements_begin();
        body_itr != body->collision_elements_end(); ++body_itr) {
     DrakeCollision::Element* element = *body_itr;
-    if (!collision_model_->transformCollisionFrame(element->getId(),
+    if (!collision_model_->TransformCollisionFrame(element->getId(),
                                                    displace_transform)) {
       return false;
     }
@@ -726,7 +726,7 @@ void RigidBodyTree<T>::updateCollisionElements(
     const Eigen::Transform<double, 3, Eigen::Isometry>& transform_to_world) {
   for (auto id_iter = body.get_collision_element_ids().begin();
        id_iter != body.get_collision_element_ids().end(); ++id_iter) {
-    collision_model_->updateElementWorldTransform(*id_iter, transform_to_world);
+    collision_model_->UpdateElementWorldTransform(*id_iter, transform_to_world);
   }
 }
 
@@ -743,7 +743,7 @@ void RigidBodyTree<T>::updateDynamicCollisionElements(
           body, cache.get_element(body.get_body_index()).transform_to_world);
     }
   }
-  collision_model_->updateModel();
+  collision_model_->UpdateModel();
 }
 
 template <typename T>
@@ -784,7 +784,7 @@ void RigidBodyTree<T>::getTerrainContactPoints(
   for (auto id_iter = element_ids.begin();
        id_iter != element_ids.end(); ++id_iter) {
     Matrix3Xd element_points;
-    collision_model_->getTerrainContactPoints(*id_iter, element_points);
+    collision_model_->GetTerrainContactPoints(*id_iter, element_points);
     terrain_points->conservativeResize(
         Eigen::NoChange, terrain_points->cols() + element_points.cols());
     terrain_points->block(0, num_points, terrain_points->rows(),
@@ -804,7 +804,7 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
 
   vector<DrakeCollision::PointPair> closest_points;
 
-  collision_model_->collisionDetectFromPoints(points, use_margins,
+  collision_model_->CollisionDetectFromPoints(points, use_margins,
                                               closest_points);
   x.resize(3, closest_points.size());
   body_x.resize(3, closest_points.size());
@@ -836,7 +836,7 @@ bool RigidBodyTree<T>::collisionRaycast(
     VectorXd& distances, bool use_margins) {
   Matrix3Xd normals;
   updateDynamicCollisionElements(cache);
-  return collision_model_->collisionRaycast(origins, ray_endpoints, use_margins,
+  return collision_model_->CollisionRaycast(origins, ray_endpoints, use_margins,
                                             distances, normals);
 }
 
@@ -849,7 +849,7 @@ bool RigidBodyTree<T>::collisionRaycast(
     VectorXd& distances, Matrix3Xd& normals,
     bool use_margins) {
   updateDynamicCollisionElements(cache);
-  return collision_model_->collisionRaycast(origins, ray_endpoints, use_margins,
+  return collision_model_->CollisionRaycast(origins, ray_endpoints, use_margins,
                                             distances, normals);
 }
 
@@ -866,7 +866,7 @@ bool RigidBodyTree<T>::collisionDetect(
 
   vector<DrakeCollision::PointPair> points;
   bool points_found =
-      collision_model_->closestPointsAllToAll(ids_to_check, use_margins,
+      collision_model_->ClosestPointsAllToAll(ids_to_check, use_margins,
                                               points);
 
   xA = MatrixXd::Zero(3, points.size());
@@ -1014,7 +1014,7 @@ bool RigidBodyTree<T>::collidingPointsCheckOnly(
     const KinematicsCache<double>& cache, const vector<Vector3d>& points,
     double collision_threshold) {
   updateDynamicCollisionElements(cache);
-  return collision_model_->collidingPointsCheckOnly(points,
+  return collision_model_->CollidingPointsCheckOnly(points,
                                                     collision_threshold);
 }
 
@@ -1023,7 +1023,7 @@ vector<size_t> RigidBodyTree<T>::collidingPoints(
     const KinematicsCache<double>& cache, const vector<Vector3d>& points,
     double collision_threshold) {
   updateDynamicCollisionElements(cache);
-  return collision_model_->collidingPoints(points, collision_threshold);
+  return collision_model_->CollidingPoints(points, collision_threshold);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -784,7 +784,7 @@ void RigidBodyTree<T>::getTerrainContactPoints(
   for (auto id_iter = element_ids.begin();
        id_iter != element_ids.end(); ++id_iter) {
     Matrix3Xd element_points;
-    collision_model_->GetTerrainContactPoints(*id_iter, element_points);
+    collision_model_->GetTerrainContactPoints(*id_iter, &element_points);
     terrain_points->conservativeResize(
         Eigen::NoChange, terrain_points->cols() + element_points.cols());
     terrain_points->block(0, num_points, terrain_points->rows(),
@@ -805,7 +805,7 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
   vector<DrakeCollision::PointPair> closest_points;
 
   collision_model_->CollisionDetectFromPoints(points, use_margins,
-                                              closest_points);
+                                              &closest_points);
   x.resize(3, closest_points.size());
   body_x.resize(3, closest_points.size());
   normal.resize(3, closest_points.size());
@@ -837,7 +837,7 @@ bool RigidBodyTree<T>::collisionRaycast(
   Matrix3Xd normals;
   updateDynamicCollisionElements(cache);
   return collision_model_->CollisionRaycast(origins, ray_endpoints, use_margins,
-                                            distances, normals);
+                                            &distances, &normals);
 }
 
 template <typename T>
@@ -850,7 +850,7 @@ bool RigidBodyTree<T>::collisionRaycast(
     bool use_margins) {
   updateDynamicCollisionElements(cache);
   return collision_model_->CollisionRaycast(origins, ray_endpoints, use_margins,
-                                            distances, normals);
+                                            &distances, &normals);
 }
 
 template <typename T>
@@ -867,7 +867,7 @@ bool RigidBodyTree<T>::collisionDetect(
   vector<DrakeCollision::PointPair> points;
   bool points_found =
       collision_model_->ClosestPointsAllToAll(ids_to_check, use_margins,
-                                              points);
+                                              &points);
 
   xA = MatrixXd::Zero(3, points.size());
   xB = MatrixXd::Zero(3, points.size());
@@ -984,7 +984,7 @@ RigidBodyTree<T>::ComputeMaximumDepthCollisionPoints(
   updateDynamicCollisionElements(cache);
   vector<DrakeCollision::PointPair> contact_points;
   collision_model_->ComputeMaximumDepthCollisionPoints(use_margins,
-                                                       contact_points);
+                                                       &contact_points);
   // For each contact pair, map contact point from world frame to each body's
   // frame.
   for (size_t i = 0; i < contact_points.size(); ++i) {
@@ -1040,8 +1040,8 @@ bool RigidBodyTree<T>::allCollisions(
   updateDynamicCollisionElements(cache);
 
   vector<DrakeCollision::PointPair> points;
-  bool points_found =
-      collision_model_->ComputeMaximumDepthCollisionPoints(use_margins, points);
+  bool points_found = collision_model_->ComputeMaximumDepthCollisionPoints(
+      use_margins, &points);
 
   xA_in_world = Matrix3Xd::Zero(3, points.size());
   xB_in_world = Matrix3Xd::Zero(3, points.size());

--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -61,7 +61,7 @@ using drake::math::gradientMatrixToAutoDiff;
 using drake::math::Gradient;
 using drake::multibody::joints::FloatingBaseType;
 
-using DrakeCollision::CollisionFilterGroup;
+using drake::multibody::collision::CollisionFilterGroup;
 
 using std::allocator;
 using std::cerr;
@@ -107,7 +107,7 @@ std::ostream& operator<<(std::ostream& os, const RigidBodyTree<double>& tree) {
 
 template <typename T>
 RigidBodyTree<T>::RigidBodyTree()
-    : collision_model_(DrakeCollision::newModel()) {
+    : collision_model_(drake::multibody::collision::newModel()) {
   // Sets the gravity vector.
   a_grav << 0, 0, 0, 0, 0, -9.81;
 
@@ -236,7 +236,7 @@ bool RigidBodyTree<T>::transformCollisionFrame(
   // to be officially decided.
   for (auto body_itr = body->collision_elements_begin();
        body_itr != body->collision_elements_end(); ++body_itr) {
-    DrakeCollision::Element* element = *body_itr;
+    drake::multibody::collision::Element* element = *body_itr;
     if (!collision_model_->TransformCollisionFrame(element->getId(),
                                                    displace_transform)) {
       return false;
@@ -322,8 +322,8 @@ void RigidBodyTree<T>::AddCollisionFilterIgnoreTarget(
 
 template <typename T>
 void RigidBodyTree<T>::SetBodyCollisionFilters(
-    const RigidBody<T>& body, const DrakeCollision::bitmask& group,
-    const DrakeCollision::bitmask& ignores) {
+    const RigidBody<T>& body, const drake::multibody::collision::bitmask& group,
+    const drake::multibody::collision::bitmask& ignores) {
   collision_group_manager_.SetBodyCollisionFilters(body, group, ignores);
 }
 
@@ -453,9 +453,9 @@ void RigidBodyTree<T>::CompileCollisionState() {
   // an exception.
   for (auto& pair : body_collision_map_) {
     RigidBody<T>* body = pair.first;
-    DrakeCollision::bitmask group =
+    drake::multibody::collision::bitmask group =
         collision_group_manager_.get_group_mask(*body);
-    DrakeCollision::bitmask ignore =
+    drake::multibody::collision::bitmask ignore =
         collision_group_manager_.get_ignore_mask(*body);
     BodyCollisions& elements = pair.second;
     for (const auto& collision_item : elements) {
@@ -696,7 +696,7 @@ map<string, int> RigidBodyTree<T>::computePositionNameToIndexMap() const {
 template <typename T>
 void RigidBodyTree<T>::addCollisionElement(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    const DrakeCollision::Element& element, RigidBody<T>& body,
+    const drake::multibody::collision::Element& element, RigidBody<T>& body,
     const string& group_name) {
   auto itr = body_collision_map_.find(&body);
   if (itr == body_collision_map_.end()) {
@@ -716,7 +716,7 @@ void RigidBodyTree<T>::addCollisionElement(
   BodyCollisions& body_collisions = itr->second;
   size_t id = element_order_.size();
   element_order_.emplace_back(
-      std::unique_ptr<DrakeCollision::Element>(element.clone()));
+      std::unique_ptr<drake::multibody::collision::Element>(element.clone()));
   body_collisions.emplace_back(group_name, id);
 }
 
@@ -758,7 +758,7 @@ void RigidBodyTree<T>::getTerrainContactPoints(
   size_t num_points = 0;
   terrain_points->resize(Eigen::NoChange, 0);
 
-  vector<DrakeCollision::ElementId> element_ids;
+  vector<drake::multibody::collision::ElementId> element_ids;
 
   // If a group name was given, use it to look up the subset of collision
   // elements that belong to that group.  Otherwise, use the full set of
@@ -802,7 +802,7 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     vector<int>& body_idx, bool use_margins) {
   updateDynamicCollisionElements(cache);
 
-  vector<DrakeCollision::PointPair> closest_points;
+  vector<drake::multibody::collision::PointPair> closest_points;
 
   collision_model_->CollisionDetectFromPoints(points, use_margins,
                                               &closest_points);
@@ -816,7 +816,8 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     body_x.col(i) = closest_points[i].ptA;
     normal.col(i) = closest_points[i].normal;
     phi[i] = closest_points[i].distance;
-    const DrakeCollision::Element* elementB = closest_points[i].elementB;
+    const drake::multibody::collision::Element* elementB =
+        closest_points[i].elementB;
     // In the case that no closest point was found, elementB will come back
     // as a null pointer which we should not attempt to access.
     if (elementB) {
@@ -861,10 +862,11 @@ bool RigidBodyTree<T>::collisionDetect(
     Matrix3Xd& xA, Matrix3Xd& xB, vector<int>& bodyA_idx,
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     vector<int>& bodyB_idx,
-    const vector<DrakeCollision::ElementId>& ids_to_check, bool use_margins) {
+    const vector<drake::multibody::collision::ElementId>& ids_to_check,
+    bool use_margins) {
   updateDynamicCollisionElements(cache);
 
-  vector<DrakeCollision::PointPair> points;
+  vector<drake::multibody::collision::PointPair> points;
   bool points_found =
       collision_model_->ClosestPointsAllToAll(ids_to_check, use_margins,
                                               &points);
@@ -879,9 +881,9 @@ bool RigidBodyTree<T>::collisionDetect(
     xB.col(i) = points[i].ptB;
     normal.col(i) = points[i].normal;
     phi[i] = points[i].distance;
-    const DrakeCollision::Element* elementA = points[i].elementA;
+    const drake::multibody::collision::Element* elementA = points[i].elementA;
     bodyA_idx.push_back(elementA->get_body()->get_body_index());
-    const DrakeCollision::Element* elementB = points[i].elementB;
+    const drake::multibody::collision::Element* elementB = points[i].elementB;
     bodyB_idx.push_back(elementB->get_body()->get_body_index());
   }
   return points_found;
@@ -897,7 +899,7 @@ bool RigidBodyTree<T>::collisionDetect(
     vector<int>& bodyB_idx, const vector<int>& bodies_idx,
     const set<string>& active_element_groups, bool use_margins) {
   CheckCacheValidity(cache);
-  vector<DrakeCollision::ElementId> ids_to_check;
+  vector<drake::multibody::collision::ElementId> ids_to_check;
   for (const int& body_idx : bodies_idx) {
     if (body_idx >= 0 && body_idx < static_cast<int>(bodies.size())) {
       for (const string& group : active_element_groups) {
@@ -919,7 +921,7 @@ bool RigidBodyTree<T>::collisionDetect(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     vector<int>& bodyB_idx, const vector<int>& bodies_idx, bool use_margins) {
   CheckCacheValidity(cache);
-  vector<DrakeCollision::ElementId> ids_to_check;
+  vector<drake::multibody::collision::ElementId> ids_to_check;
   for (const int& body_idx : bodies_idx) {
     if (body_idx >= 0 && body_idx < static_cast<int>(bodies.size())) {
       bodies[body_idx]->appendCollisionElementIdsFromThisBody(ids_to_check);
@@ -943,7 +945,7 @@ bool RigidBodyTree<T>::collisionDetect(
     const set<string>& active_element_groups,
     bool use_margins) {
   CheckCacheValidity(cache);
-  vector<DrakeCollision::ElementId> ids_to_check;
+  vector<drake::multibody::collision::ElementId> ids_to_check;
   for (auto body_iter = bodies.begin(); body_iter != bodies.end();
        ++body_iter) {
     for (auto group_iter = active_element_groups.begin();
@@ -968,7 +970,7 @@ bool RigidBodyTree<T>::collisionDetect(
     // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
     vector<int>& bodyB_idx, bool use_margins) {
   CheckCacheValidity(cache);
-  vector<DrakeCollision::ElementId> ids_to_check;
+  vector<drake::multibody::collision::ElementId> ids_to_check;
   for (auto body_iter = bodies.begin(); body_iter != bodies.end();
        ++body_iter) {
     (*body_iter)->appendCollisionElementIdsFromThisBody(ids_to_check);
@@ -978,11 +980,11 @@ bool RigidBodyTree<T>::collisionDetect(
 }
 
 template <typename T>
-std::vector<DrakeCollision::PointPair>
+std::vector<drake::multibody::collision::PointPair>
 RigidBodyTree<T>::ComputeMaximumDepthCollisionPoints(
     const KinematicsCache<double>& cache, bool use_margins) {
   updateDynamicCollisionElements(cache);
-  vector<DrakeCollision::PointPair> contact_points;
+  vector<drake::multibody::collision::PointPair> contact_points;
   collision_model_->ComputeMaximumDepthCollisionPoints(use_margins,
                                                        &contact_points);
   // For each contact pair, map contact point from world frame to each body's
@@ -1039,7 +1041,7 @@ bool RigidBodyTree<T>::allCollisions(
     Matrix3Xd& xB_in_world, bool use_margins) {
   updateDynamicCollisionElements(cache);
 
-  vector<DrakeCollision::PointPair> points;
+  vector<drake::multibody::collision::PointPair> points;
   bool points_found = collision_model_->ComputeMaximumDepthCollisionPoints(
       use_margins, &points);
 
@@ -1050,9 +1052,9 @@ bool RigidBodyTree<T>::allCollisions(
     xA_in_world.col(i) = points[i].ptA;
     xB_in_world.col(i) = points[i].ptB;
 
-    const DrakeCollision::Element* elementA = points[i].elementA;
+    const drake::multibody::collision::Element* elementA = points[i].elementA;
     bodyA_idx.push_back(elementA->get_body()->get_body_index());
-    const DrakeCollision::Element* elementB = points[i].elementB;
+    const drake::multibody::collision::Element* elementB = points[i].elementB;
     bodyB_idx.push_back(elementB->get_body()->get_body_index());
   }
   return points_found;
@@ -2614,7 +2616,7 @@ RigidBody<T>* RigidBodyTree<T>::FindBody(const std::string& body_name,
 
 template <typename T>
 const RigidBody<double>* RigidBodyTree<T>::FindBody(
-    DrakeCollision::ElementId element_id) const {
+    drake::multibody::collision::ElementId element_id) const {
   auto element = collision_model_->FindElement(element_id);
   if (element != nullptr) {
     return element->get_body();

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -912,7 +912,7 @@ class RigidBodyTree {
           auto& ids = body_ptr->get_mutable_collision_element_ids();
           for (const auto& id : group.second) {
             ids.erase(std::find(ids.begin(), ids.end(), id));
-            collision_model_->removeElement(id);
+            collision_model_->RemoveElement(id);
           }
           names_of_groups_to_delete.push_back(group_name);
         }

--- a/drake/multibody/rigid_body_tree.h
+++ b/drake/multibody/rigid_body_tree.h
@@ -888,17 +888,16 @@ class RigidBodyTree {
    * @param group_name a group name to tag the associated element with.
    */
   void addCollisionElement(
-      const DrakeCollision::Element& element,
+      const drake::multibody::collision::Element& element,
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-      RigidBody<T>& body,
-      const std::string& group_name);
+      RigidBody<T>& body, const std::string& group_name);
 
   /// Retrieve a `const` pointer to an element of the collision model.
   /// Note: The use of Find (instead of get) and the use of CamelCase both
   /// imply a potential runtime cost are carried over from the collision model
   /// accessor method.
-  const DrakeCollision::Element* FindCollisionElement(
-      const DrakeCollision::ElementId& id) const {
+  const drake::multibody::collision::Element* FindCollisionElement(
+      const drake::multibody::collision::ElementId& id) const {
     return collision_model_->FindElement(id);
   }
 
@@ -1010,7 +1009,7 @@ class RigidBodyTree {
       std::vector<int>& bodyA_idx,
       // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
       std::vector<int>& bodyB_idx,
-      const std::vector<DrakeCollision::ElementId>& ids_to_check,
+      const std::vector<drake::multibody::collision::ElementId>& ids_to_check,
       bool use_margins);
 
   bool collisionDetect(
@@ -1107,8 +1106,9 @@ class RigidBodyTree {
    @param use_margins[in] If `true` the model uses the representation with
    margins. If `false`, the representation without margins is used instead.
    **/
-  std::vector<DrakeCollision::PointPair> ComputeMaximumDepthCollisionPoints(
-      const KinematicsCache<double>& cache, bool use_margins = true);
+  std::vector<drake::multibody::collision::PointPair>
+  ComputeMaximumDepthCollisionPoints(const KinematicsCache<double>& cache,
+                                     bool use_margins = true);
 
   virtual bool collidingPointsCheckOnly(
       const KinematicsCache<double>& cache,
@@ -1143,7 +1143,8 @@ class RigidBodyTree {
    * @return A pointer to the owning RigidBody.
    * @throws std::logic_error if no body can be mapped to the element id.
    */
-  const RigidBody<double>* FindBody(DrakeCollision::ElementId element_id) const;
+  const RigidBody<double>* FindBody(
+      drake::multibody::collision::ElementId element_id) const;
 
   /**
    * Returns a vector of pointers to all rigid bodies in this tree that belong
@@ -1447,9 +1448,10 @@ class RigidBodyTree {
    mapped ids directly the manager for when the tree gets compiled.  It relies
    on correct encoding of groups into bitmasks.
    */
-  void SetBodyCollisionFilters(const RigidBody<T>& body,
-                               const DrakeCollision::bitmask& group,
-                               const DrakeCollision::bitmask& ignores);
+  void SetBodyCollisionFilters(
+      const RigidBody<T>& body,
+      const drake::multibody::collision::bitmask& group,
+      const drake::multibody::collision::bitmask& ignores);
 
   /**
    * @brief Returns a mutable reference to the RigidBody associated with the
@@ -1564,7 +1566,8 @@ class RigidBodyTree {
   // RigidBodyTree to become finalized.
   void CompileCollisionState();
 
-  // Defines a number of collision cliques to be used by DrakeCollision::Model.
+  // Defines a number of collision cliques to be used by
+  // drake::multibody::collision::Model.
   // Collision cliques are defined so that:
   // - There is one clique per RigidBody: and so CollisionElement's attached to
   // a RigidBody do not collide.
@@ -1586,7 +1589,7 @@ class RigidBodyTree {
   // RBM for use in collision detection of different kinds. Small margins are
   // applied to all collision geometry when that geometry is added, to improve
   // the numerical stability of contact gradients taken using the model.
-  std::unique_ptr<DrakeCollision::Model> collision_model_;
+  std::unique_ptr<drake::multibody::collision::Model> collision_model_;
 
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -1629,10 +1632,12 @@ class RigidBodyTree {
   //
   // For more information, see:
   //     https://github.com/bulletphysics/bullet3/issues/888
-  std::vector< std::unique_ptr<DrakeCollision::Element>> element_order_;
+  std::vector<std::unique_ptr<drake::multibody::collision::Element>>
+      element_order_;
 
   // A manager for instantiating and managing collision filter groups.
-  DrakeCollision::CollisionFilterGroupManager<T> collision_group_manager_{};
+  drake::multibody::collision::CollisionFilterGroupManager<T>
+      collision_group_manager_{};
 };
 
 typedef RigidBodyTree<double> RigidBodyTreed;

--- a/drake/multibody/rigid_body_tree_construction.cc
+++ b/drake/multibody/rigid_body_tree_construction.cc
@@ -18,8 +18,8 @@ void AddFlatTerrainToWorld(RigidBodyTreed* tree, double box_size,
   world.AddVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   tree->addCollisionElement(
-      DrakeCollision::Element(geom, T_element_to_link, &world), world,
-      "terrain");
+      drake::multibody::collision::Element(geom, T_element_to_link, &world),
+      world, "terrain");
   tree->compile();
 }
 

--- a/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
+++ b/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
@@ -160,7 +160,8 @@ GTEST_TEST(ByHandAnchoredGeometry, WorldCollisionElementIsAnchored) {
   RigidBodyTree<double> tree;
   RigidBody<double>& world = tree.world();
   DrakeShapes::Box geom(Vector3d(1.0, 1.0, 1.0));
-  DrakeCollision::Element element(geom, Isometry3d::Identity(), &world);
+  drake::multibody::collision::Element element(geom, Isometry3d::Identity(),
+                                               &world);
   tree.addCollisionElement(element, world, "rigid_body");
   tree.compile();
 

--- a/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -33,9 +33,10 @@ struct SurfacePoint {
 };
 
 // Solutions are accessed by rigid body pointer using an std::unordered_map.
-// DrakeCollision::Model returns the collision detection results as a vector of
-// DrakeCollision::PointPair entries. Each entry holds a reference to the pair
-// of collision elements taking part in the collision.
+// drake::multibody::collision::Model returns the collision detection results
+// as a vector of drake::multibody::collision::PointPair entries. Each entry
+// holds a reference to the pair of collision elements taking part in the
+// collision.
 // To provide a simple access to the appropriate solution for the collision
 // point on each body, a map is used to allow referencing the corresponding
 // solution by body pointer.
@@ -93,9 +94,8 @@ TEST_F(RBTCollisionTest, FindAndComputeContactPoints) {
 
   KinematicsCache<double> kinsol = tree_.doKinematics(q, v);
 
-  std::vector<DrakeCollision::PointPair> collision_pairs =
-      tree_.ComputeMaximumDepthCollisionPoints(
-      kinsol, false);
+  std::vector<drake::multibody::collision::PointPair> collision_pairs =
+      tree_.ComputeMaximumDepthCollisionPoints(kinsol, false);
 
   // RigidBodyTree::ComputeMaximumDepthCollisionPoints returns only one point,
   // the maximum depth collision point.
@@ -186,9 +186,8 @@ TEST_F(RBTCollisionCliqueTest, ComputeContactPointsWithCliques) {
 
   KinematicsCache<double> kinsol = tree_.doKinematics(q, v);
 
-  std::vector<DrakeCollision::PointPair> collision_pairs =
-      tree_.ComputeMaximumDepthCollisionPoints(
-          kinsol, false);
+  std::vector<drake::multibody::collision::PointPair> collision_pairs =
+      tree_.ComputeMaximumDepthCollisionPoints(kinsol, false);
 
   // RigidBodyTree::ComputeMaximumDepthCollisionPoints returns only one point,
   // the maximum depth collision point. The overlapping spheres should be

--- a/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_collision_clique_test.cc
@@ -15,7 +15,7 @@ namespace systems {
 namespace plants {
 namespace {
 
-using DrakeCollision::Element;
+using drake::multibody::collision::Element;
 using Eigen::Isometry3d;
 using Eigen::Matrix3d;
 using std::make_unique;
@@ -38,8 +38,8 @@ class RigidBodyTreeCollisionCliqueTest : public ::testing::Test {
     I.block(3, 3, 3, 3) << Matrix3d::Identity();
 
     // This element is cloned each time it is added to the tree.
-    DrakeCollision::Element element(DrakeShapes::Sphere(1.0),
-                                    Eigen::Isometry3d::Identity());
+    drake::multibody::collision::Element element(DrakeShapes::Sphere(1.0),
+                                                 Eigen::Isometry3d::Identity());
 
     // This body requires a self-collision clique
     body1_ = tree_->add_rigid_body(make_unique<RigidBody<double>>());

--- a/drake/systems/estimators/dev/pose_estimation_test.cc
+++ b/drake/systems/estimators/dev/pose_estimation_test.cc
@@ -30,7 +30,7 @@ Eigen::Isometry3d PoseEstimation(const RigidBodyTree<double>& tree,
   const auto& collision_element_ids =
       tree.get_body(1).get_collision_element_ids();
   DRAKE_DEMAND(collision_element_ids.size() == 1);
-  const DrakeCollision::Element* collision_element =
+  const drake::multibody::collision::Element* collision_element =
       tree.FindCollisionElement(collision_element_ids[0]);
   DRAKE_DEMAND(collision_element->getShape() == DrakeShapes::BOX);
 

--- a/drake/systems/sensors/test/depth_sensor_test.cc
+++ b/drake/systems/sensors/test/depth_sensor_test.cc
@@ -154,8 +154,8 @@ std::pair<VectorX<double>, Matrix3Xd> DoBoxOcclusionTest(
   world.AddVisualElement(
       DrakeShapes::VisualElement(geom, T_element_to_link, color));
   tree.addCollisionElement(
-      DrakeCollision::Element(geom, T_element_to_link, &world), world,
-      "terrain");
+      drake::multibody::collision::Element(geom, T_element_to_link, &world),
+      world, "terrain");
   tree.compile();
 
   auto frame = std::allocate_shared<RigidBodyFrame<double>>(


### PR DESCRIPTION
This is Spiral 0 as described in #6571. The goal is to make the collision model API comply with our C++ standards prior to adding an FCL implementation. I have updated other classes only insomuchI as was necessary to keep things working.

`bazel test //...` runs without failures for each intermediate commit, but I'm open to squashing them if that's preferable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6628)
<!-- Reviewable:end -->
