### PR TITLE
Removing double_pendulum_demo_test

### DIFF
--- a/drake/examples/double_pendulum/BUILD
+++ b/drake/examples/double_pendulum/BUILD
@@ -38,12 +38,10 @@ drake_cc_binary(
     srcs = [
         "double_pendulum_demo.cc",
     ],
-    add_test_rule = 1,
     data = [
         ":models",
         "//tools:drake_visualizer",
     ],
-    test_rule_args = [" --simulation_time=0.01"],
     deps = [
         ":sdf_helpers",
         "//drake/common",


### PR DESCRIPTION
We don't want to revert the commit https://github.com/RobotLocomotion/drake/commit/46b4b829560d1a1ddc493d3a5d9a1f0b63e5c90d
because the author thinks that the PR doesn't introduce an error but reveals an existing one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6632)
<!-- Reviewable:end -->
