### PR TITLE
Add a script for drake_visualizer to draw frames sent through lcm.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -167,6 +167,7 @@ drake_cc_binary(
         "//drake/examples/kuka_iiwa_arm/iiwa_world:world_sim_tree_builder",
         "//drake/lcm",
         "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:frame_visualizer",
         "//drake/systems/analysis:simulator",
         "//drake/systems/controllers:inverse_dynamics_controller",
         "//drake/systems/primitives:constant_vector_source",

--- a/drake/multibody/rigid_body_plant/BUILD
+++ b/drake/multibody/rigid_body_plant/BUILD
@@ -116,6 +116,17 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "frame_visualizer",
+    srcs = ["frame_visualizer.cc"],
+    hdrs = ["frame_visualizer.h"],
+    deps = [
+        "//drake/lcmtypes:viewer",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/systems/lcm",
+    ],
+)
+
 drake_cc_googletest(
     name = "contact_detail_test",
     deps = [
@@ -189,6 +200,19 @@ drake_cc_googletest(
         "//drake/common:find_resource",
         "//drake/lcm:mock",
         "//drake/systems/analysis",
+    ],
+)
+
+drake_cc_googletest(
+    name = "frame_visualizer_test",
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        ":frame_visualizer",
+        "//drake/common:find_resource",
+        "//drake/lcm:mock",
+        "//drake/multibody/parsers",
     ],
 )
 

--- a/drake/multibody/rigid_body_plant/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/CMakeLists.txt
@@ -18,6 +18,7 @@ if (lcm_FOUND)
     contact_results_to_lcm.h
     create_load_robot_message.h
     drake_visualizer.h
+    frame_visualizer.h
     rigid_body_plant_that_publishes_xdot.h
     viewer_draw_translator.h)
 endif ()
@@ -28,6 +29,7 @@ if (lcm_FOUND)
     contact_results_to_lcm.cc
     create_load_robot_message.cc
     drake_visualizer.cc
+    frame_visualizer.cc
     rigid_body_plant_that_publishes_xdot.cc
     viewer_draw_translator.cc)
 endif ()

--- a/drake/multibody/rigid_body_plant/frame_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/frame_visualizer.cc
@@ -1,0 +1,61 @@
+#include "drake/multibody/rigid_body_plant/frame_visualizer.h"
+
+namespace drake {
+namespace systems {
+
+FrameVisualizer::FrameVisualizer(
+    const RigidBodyTree<double>* tree,
+    const std::vector<RigidBodyFrame<double>>& local_transforms,
+    drake::lcm::DrakeLcmInterface* lcm)
+    : tree_(*tree), lcm_(lcm), local_transforms_(local_transforms) {
+  DeclareInputPort(kVectorValued,
+                   tree_.get_num_positions() + tree_.get_num_velocities());
+  set_name("frame_visualzier");
+
+  default_msg_.num_links = static_cast<int>(local_transforms_.size());
+  default_msg_.link_name.resize(default_msg_.num_links);
+  // The robot num is not relevant here.
+  default_msg_.robot_num.resize(default_msg_.num_links, 0);
+  std::vector<float> pos = {0, 0, 0};
+  std::vector<float> quaternion = {1, 0, 0, 0};
+  default_msg_.position.resize(default_msg_.num_links, pos);
+  default_msg_.quaternion.resize(default_msg_.num_links, quaternion);
+  for (size_t i = 0; i < local_transforms_.size(); ++i) {
+    default_msg_.link_name[i] = local_transforms_[i].get_name();
+  }
+}
+
+void FrameVisualizer::DoPublish(
+    const systems::Context<double>& context,
+    const std::vector<const PublishEvent<double>*>&) const {
+  KinematicsCache<double> cache = tree_.CreateKinematicsCache();
+
+  auto state = EvalEigenVectorInput(context, 0);
+  cache.initialize(state.head(tree_.get_num_positions()),
+                   state.tail(tree_.get_num_velocities()));
+  tree_.doKinematics(cache);
+
+  drake::lcmt_viewer_draw msg = default_msg_;
+  msg.timestamp = static_cast<int64_t>(context.get_time() * 1e3);
+
+  Isometry3<double> X_WF;
+  for (size_t i = 0; i < local_transforms_.size(); ++i) {
+    X_WF = tree_.CalcFramePoseInWorldFrame(cache, local_transforms_[i]);
+
+    for (int j = 0; j < 3; j++)
+      msg.position[i][j] = static_cast<float>(X_WF.translation()[j]);
+    Quaternion<double> quat(X_WF.linear());
+    msg.quaternion[i][0] = static_cast<float>(quat.w());
+    msg.quaternion[i][1] = static_cast<float>(quat.x());
+    msg.quaternion[i][2] = static_cast<float>(quat.y());
+    msg.quaternion[i][3] = static_cast<float>(quat.z());
+  }
+
+  const int length = msg.getEncodedSize();
+  std::vector<uint8_t> msgbytes(length);
+  msg.encode(msgbytes.data(), 0, length);
+  lcm_->Publish("DRAKE_DRAW_FRAMES", msgbytes.data(), msgbytes.size());
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/frame_visualizer.h
+++ b/drake/multibody/rigid_body_plant/frame_visualizer.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcm/drake_lcm_interface.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+
+/**
+ * This is a Drake System block that takes in a state vector, and outputs a
+ * drake::lcmt_viewer_draw message that contains information about the frames
+ * for visualization.
+ *
+ * @ingroup rigid_body_systems
+ */
+class FrameVisualizer : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FrameVisualizer)
+
+  /**
+   * Constructor.
+   * @param tree A const pointer to the RigidBodyTree used for doing kinematics.
+   *        Its life span must be longer than this.
+   * @param local_transforms A vector of frames to be visualized.
+   * @param lcm A pointer to the object through which LCM messages can be
+   *        published. This pointer must remain valid for the duration of this
+   *        object.
+   */
+  FrameVisualizer(const RigidBodyTree<double>* tree,
+                  const std::vector<RigidBodyFrame<double>>& local_transforms,
+                  drake::lcm::DrakeLcmInterface* lcm);
+
+  /**
+   * Sets the publishing period of this system. See
+   * LeafSystem::DeclarePublishPeriodSec() for details about the semantics of
+   * parameter `period`.
+   */
+  void set_publish_period(double period) {
+    this->DeclarePeriodicPublish(period);
+  }
+
+ private:
+  void DoPublish(
+      const systems::Context<double>& context,
+      const std::vector<const PublishEvent<double>*>&) const override;
+
+  const RigidBodyTree<double>& tree_;
+  drake::lcm::DrakeLcmInterface* const lcm_;
+  const std::vector<RigidBodyFrame<double>> local_transforms_;
+
+  drake::lcmt_viewer_draw default_msg_{};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/test/CMakeLists.txt
+++ b/drake/multibody/rigid_body_plant/test/CMakeLists.txt
@@ -57,6 +57,13 @@ if(Bullet_FOUND)
   endif()
 endif()
 
+if (lcm_FOUND)
+  drake_add_cc_test(frame_visualizer_test)
+  target_link_libraries(frame_visualizer_test
+      drakeMultibodyParsers
+      drakeRigidBodyPlant)
+endif()
+
 drake_add_cc_test(contact_force_test)
 target_link_libraries(contact_force_test drakeRigidBodyPlant)
 

--- a/drake/multibody/rigid_body_plant/test/frame_visualizer_test.cc
+++ b/drake/multibody/rigid_body_plant/test/frame_visualizer_test.cc
@@ -1,0 +1,90 @@
+#include "drake/multibody/rigid_body_plant/frame_visualizer.h"
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/lcm/drake_mock_lcm.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+GTEST_TEST(FrameVisualizerTests, TestMessageGeneration) {
+  RigidBodyTree<double> tree;
+
+  const char* kModelPath =
+      "drake/manipulation/models/iiwa_description/"
+      "urdf/iiwa14_polytope_collision.urdf";
+  const std::string urdf = FindResourceOrThrow(kModelPath);
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+      urdf, multibody::joints::kFixed, &tree);
+
+  // Visualizes the 7th body's frame.
+  std::vector<RigidBodyFrame<double>> local_transforms;
+  Isometry3<double> X_BF = Isometry3<double>::Identity();
+  X_BF.linear() =
+      AngleAxis<double>(0.3, Vector3<double>::UnitZ()).toRotationMatrix();
+  X_BF.translation() = Vector3<double>(1, 2, 3);
+  local_transforms.push_back(
+      RigidBodyFrame<double>("iiwa_link_ee",
+          tree.FindBody("iiwa_link_ee"), X_BF));
+
+  drake::lcm::DrakeMockLcm lcm;
+  systems::FrameVisualizer dut(&tree, local_transforms, &lcm);
+
+  auto context = dut.CreateDefaultContext();
+  EXPECT_EQ(1, context->get_num_input_ports());
+
+  // Initializes the system's input vector to contain all zeros.
+  const int vector_size = tree.get_num_positions() + tree.get_num_velocities();
+  auto input_data = std::make_unique<systems::BasicVector<double>>(vector_size);
+  VectorX<double> x(vector_size);
+  auto q = x.head(tree.get_num_positions());
+  auto v = x.head(tree.get_num_velocities());
+  input_data->set_value(x);
+  context->SetInputPortValue(
+      0, std::make_unique<systems::FreestandingInputPortValue>(
+             std::move(input_data)));
+  dut.Publish(*context);
+
+  KinematicsCache<double> cache = tree.CreateKinematicsCache();
+  cache.initialize(q, v);
+  tree.doKinematics(cache);
+  const Isometry3<double> X_WF = tree.CalcFramePoseInWorldFrame(
+      cache, local_transforms[0]);
+  const Quaternion<double> quat_tmp(X_WF.linear());
+  // Casts to float, because the message is in float.
+  const Quaternion<float> q_WF = quat_tmp.cast<float>();
+  const Vector3<float> p_WF = X_WF.translation().cast<float>();
+
+  drake::lcmt_viewer_draw expected_message{};
+  expected_message.timestamp = context->get_time();
+  expected_message.num_links = 1;
+  expected_message.link_name.push_back("iiwa_link_ee");
+  expected_message.robot_num.push_back(0);
+  expected_message.position.push_back({p_WF[0], p_WF[1], p_WF[2]});
+  expected_message.quaternion.push_back(
+      {q_WF.w(), q_WF.x(), q_WF.y(), q_WF.z()});
+
+  // Ensures both messages have the same length.
+  const std::vector<uint8_t>& message_bytes =
+      lcm.get_last_published_message("DRAKE_DRAW_FRAMES");
+  const int byte_count = expected_message.getEncodedSize();
+  EXPECT_EQ(byte_count, static_cast<int>(message_bytes.size()));
+
+  // Serializes the expected message.
+  std::vector<uint8_t> expected_message_bytes(byte_count);
+  expected_message.encode(expected_message_bytes.data(), 0, byte_count);
+
+  // Verifies that the messages are equal.
+  EXPECT_EQ(expected_message_bytes, message_bytes);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/rigid_body_plant/visualization/show_frames.py
+++ b/drake/multibody/rigid_body_plant/visualization/show_frames.py
@@ -1,0 +1,69 @@
+# Note that this script runs in the main context of drake-visulizer,
+# where many modules and variables already exist in the global scope.
+from sets import Set
+from director import lcmUtils
+from director import applogic
+from director import objectmodel as om
+from director import visualization as vis
+import robotlocomotion as lcmrobotlocomotion
+
+class FramesVisualizer(object):
+    def __init__(self):
+        self._folder_name = 'Frames'
+        self._name = "Frame Visualizer"
+        self._subscriber = None
+        self.set_enabled(True)
+
+    def _add_subscriber(self):
+        if (self._subscriber is not None):
+            return
+
+        self._subscriber = lcmUtils.addSubscriber(
+            'DRAKE_DRAW_FRAMES',
+            messageClass = lcmrobotlocomotion.viewer_draw_t,
+            callback = self._handle_message)
+
+    def _remove_subscriber(self):
+        if (self._subscriber is None):
+            return
+
+        lcmUtils.removeSubscriber(self._subscriber)
+        om.removeFromObjectModel(om.findObjectByName(self._folder_name))
+        self._subscriber = None
+
+    def is_enabled(self):
+        return self._subscriber is not None
+
+    def set_enabled(self, enable):
+        if enable:
+            self._add_subscriber()
+        else:
+            self._remove_subscriber()
+
+    def _handle_message(self, msg):
+        # Removes the folder completely. This is the clearest and easiest way
+        # of doing update. Otherwise we need to store the FrameItem returned
+        # by vis.showFrame, and update its transform. Also need to handle
+        # enable / disable.
+        om.removeFromObjectModel(om.findObjectByName(self._folder_name))
+
+        # Recreates folder.
+        folder = om.getOrCreateContainer(self._folder_name)
+
+        for i in range(0, msg.num_links):
+            name = msg.link_name[i]
+            transform = transformUtils.transformFromPose(
+                msg.position[i], msg.quaternion[i])
+            vis.showFrame(transform, name, parent=folder, scale=0.1);
+
+def init_visualizer():
+    frame_viz = FramesVisualizer()
+
+    # Adds to the "Tools" menu.
+    applogic.MenuActionToggleHelper(
+        'Tools', frame_viz._name,
+        frame_viz.is_enabled, frame_viz.set_enabled)
+    return frame_viz
+
+# Creates the visualizer when this script is executed.
+frame_viz = init_visualizer()


### PR DESCRIPTION
Added a python script to draw the frame sent through lcm.
Added a system block that generates the lcm message given a list of frames defined respect to some rigid bodies. 
Added a test, and an example usage to kuka_simulation.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6633)
<!-- Reviewable:end -->
