### PR TITLE
Rotation constraint bilinear

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -229,7 +229,9 @@ drake_cc_library(
         "rotation_constraint_internal.h",
     ],
     deps = [
+        ":bilinear_product_util",
         ":mathematical_program",
+        ":mixed_integer_optimization_util",
         "//drake/math:gradient",
     ],
 )
@@ -284,8 +286,8 @@ drake_cc_library(
     srcs = ["test/mathematical_program_test_util.cc"],
     hdrs = ["test/mathematical_program_test_util.h"],
     deps = [
-        ":mathematical_program",
         "@gtest//:without_main",
+        ":mathematical_program",
     ],
 )
 
@@ -295,11 +297,11 @@ drake_cc_library(
     srcs = ["test/optimization_examples.cc"],
     hdrs = ["test/optimization_examples.h"],
     deps = [
+        "@gtest//:without_main",
         ":mathematical_program",
         ":mathematical_program_test_util",
         ":solver_type_converter",
         "//drake/common:eigen_matrix_compare",
-        "@gtest//:without_main",
     ],
 )
 

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -286,8 +286,8 @@ drake_cc_library(
     srcs = ["test/mathematical_program_test_util.cc"],
     hdrs = ["test/mathematical_program_test_util.h"],
     deps = [
-        "@gtest//:without_main",
         ":mathematical_program",
+        "@gtest//:without_main",
     ],
 )
 
@@ -297,11 +297,11 @@ drake_cc_library(
     srcs = ["test/optimization_examples.cc"],
     hdrs = ["test/optimization_examples.h"],
     deps = [
-        "@gtest//:without_main",
         ":mathematical_program",
         ":mathematical_program_test_util",
         ":solver_type_converter",
         "//drake/common:eigen_matrix_compare",
+        "@gtest//:without_main",
     ],
 )
 

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -124,7 +124,9 @@ drake_install_headers(
 
 add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)
 target_link_libraries(drakeRotationConstraint
-        drakeOptimization)
+        drakeOptimization
+        drakeMixedIntegerOptimizationUtil
+        drakeBilinearProductUtil)
 drake_install_headers(
         rotation_constraint.h
 )

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -133,7 +133,8 @@ drake_install_pkg_config_file(drake-bilinear-product-util
         TARGET drakeBilinearProductUtil
         LIBS -ldrakeBilinearProductUtil
         REQUIRES
-        drake-common)
+        drake-common
+        drake-optimization)
 
 add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)
 target_link_libraries(drakeRotationConstraint

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -114,6 +114,12 @@ target_link_libraries(drakeMixedIntegerOptimizationUtil
 drake_install_headers(
         mixed_integer_optimization_util.h
 )
+drake_install_pkg_config_file(drake-mixed-integer-optimization-util
+        TARGET drakeMixedIntegerOptimizationUtil
+        LIBS -ldrakeMixedIntegerOptimizationUtil
+        REQUIRES
+        drake-math
+        drake-optimization)
 
 add_library_with_exports(LIB_NAME drakeBilinearProductUtil SOURCE_FILES bilinear_product_util.cc)
 target_link_libraries(drakeBilinearProductUtil
@@ -121,6 +127,11 @@ target_link_libraries(drakeBilinearProductUtil
 drake_install_headers(
         bilinear_product_util.h
 )
+drake_install_pkg_config_file(drake-bilinear-product-util
+        TARGET drakeBilinearProductUtil
+        LIBS -ldrakeBilinearProductUtil
+        REQUIRES
+        drake-common)
 
 add_library_with_exports(LIB_NAME drakeRotationConstraint SOURCE_FILES rotation_constraint.cc)
 target_link_libraries(drakeRotationConstraint
@@ -134,7 +145,9 @@ drake_install_pkg_config_file(drake-rotation-constraint
         TARGET drakeRotationConstraint
         LIBS -ldrakeRotationConstraint
         REQUIRES
+        drake-bilinear-product-util
         drake-common
+        drake-mixed-integer-optimization-util
         drake-optimization)
 
 drake_install_libraries(drakeRotationConstraint)

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library_with_exports(LIB_NAME drakeMixedIntegerOptimizationUtil SOURCE_FILES
 target_link_libraries(drakeMixedIntegerOptimizationUtil
         drakeMath
         drakeOptimization)
+drake_install_libraries(drakeMixedIntegerOptimizationUtil)
 drake_install_headers(
         mixed_integer_optimization_util.h
 )
@@ -124,6 +125,7 @@ drake_install_pkg_config_file(drake-mixed-integer-optimization-util
 add_library_with_exports(LIB_NAME drakeBilinearProductUtil SOURCE_FILES bilinear_product_util.cc)
 target_link_libraries(drakeBilinearProductUtil
         drakeCommon)
+drake_install_libraries(drakeBilinearProductUtil)
 drake_install_headers(
         bilinear_product_util.h
 )

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -10,7 +10,6 @@
 
 #include "drake/math/cross_product.h"
 #include "drake/solvers/bilinear_product_util.h"
-#include "drake/solvers/mixed_integer_optimization_util.h"
 
 using std::numeric_limits;
 using drake::symbolic::Expression;
@@ -1234,6 +1233,12 @@ template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
 AddRotationMatrixBilinearMcCormickMilpConstraints<3>(
     MathematicalProgram *prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
+    int num_intervlas_per_half_axis);
+
+template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<4>::type
+AddRotationMatrixBilinearMcCormickMilpConstraints<4>(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
     int num_intervlas_per_half_axis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -10,6 +10,7 @@
 
 #include "drake/math/cross_product.h"
 #include "drake/solvers/bilinear_product_util.h"
+#include "drake/solvers/mixed_integer_optimization_util.h"
 
 using std::numeric_limits;
 using drake::symbolic::Expression;

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -920,7 +920,10 @@ void AddUnitLengthConstraintWithLogarithmicSos2(
       const symbolic::Expression x1_square_lb{2 * phi(phi1_idx) * x1 - pow(phi(phi1_idx), 2)};
       for (int phi2_idx = 0; phi2_idx < num_phi; phi2_idx++) {
         const symbolic::Expression x2_square_lb{2 * phi(phi2_idx) * x2 - pow(phi(phi2_idx), 2)};
-        prog->AddLinearConstraint(x0_square_lb + x1_square_lb + x2_square_lb <= 1);
+        symbolic::Expression x_sum_of_squares_lb{x0_square_lb + x1_square_lb + x2_square_lb};
+        if (!is_constant(x_sum_of_squares_lb)) {
+          prog->AddLinearConstraint(x_sum_of_squares_lb <= 1);
+        }
       }
     }
   }

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include "drake/math/cross_product.h"
+#include "drake/solvers/bilinear_product_util.h"
 
 using std::numeric_limits;
 using drake::symbolic::Expression;
@@ -888,6 +889,106 @@ void AddNotInSameOrOppositeOrthantConstraint(
     }
   }
 }
+
+// Relax the unit length constraint x₀² + x₁² + x₂² = 1, to a set of linear
+// constraints. We do this with the auxiliary variables λ, such that λ satisfies
+// SOS2 constraint, and xᵢ = φᵀ * λᵢ.
+// We know that due to the convexity of the curve w = x², we get
+//     x² ≥ 2φⱼ*x-φⱼ²
+// where the right hand-side of the inequality is the tangent of the curve
+// w = x² at φⱼ. Thus we have 1 ≥ sum_j sum_i 2φⱼ*xᵢ-φⱼ²
+// Moreover, also due to the convexity of the curve w = x², we know
+//   x² ≤ sum_j φ(j)² * λ(j)
+// So we have the constraint
+// 1 ≤ sum_i sum_j φ(j)² * λᵢ(j)
+void AddUnitLengthConstraintWithLogarithmicSos2(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const Eigen::VectorXd>& phi,
+    const Eigen::Ref<const VectorXDecisionVariable>& lambda0,
+    const Eigen::Ref<const VectorXDecisionVariable>& lambda1,
+    const Eigen::Ref<const VectorXDecisionVariable>& lambda2) {
+  const int num_phi = phi.rows();
+  DRAKE_ASSERT(num_phi == lambda0.rows());
+  DRAKE_ASSERT(num_phi == lambda1.rows());
+  DRAKE_ASSERT(num_phi == lambda2.rows());
+  const symbolic::Expression x0{phi.dot(lambda0.cast<symbolic::Expression>())};
+  const symbolic::Expression x1{phi.dot(lambda1.cast<symbolic::Expression>())};
+  const symbolic::Expression x2{phi.dot(lambda2.cast<symbolic::Expression>())};
+  for (int phi0_idx = 0; phi0_idx < num_phi; phi0_idx++) {
+    const symbolic::Expression x0_square_lb{2 * phi(phi0_idx) * x0 - pow(phi(phi0_idx), 2)};
+    for (int phi1_idx = 0; phi1_idx < num_phi; phi1_idx++) {
+      const symbolic::Expression x1_square_lb{2 * phi(phi1_idx) * x1 - pow(phi(phi1_idx), 2)};
+      for (int phi2_idx = 0; phi2_idx < num_phi; phi2_idx++) {
+        const symbolic::Expression x2_square_lb{2 * phi(phi2_idx) * x2 - pow(phi(phi2_idx), 2)};
+        prog->AddLinearConstraint(x0_square_lb + x1_square_lb + x2_square_lb <= 1);
+      }
+    }
+  }
+  symbolic::Expression x_square_ub{0};
+  for (int i = 0; i < num_phi; ++i) {
+    x_square_ub += phi(i) * phi(i) * (lambda0(i) + lambda1(i) + lambda2(i));
+  }
+  prog->AddLinearConstraint(x_square_ub >= 1);
+}
+
+std::pair<int, int> Index2Subscripts(int index, int num_rows, int num_cols) {
+  int col_idx = index  / num_rows;
+  int row_idx = index - col_idx * num_rows;
+  return std::make_pair(row_idx, col_idx);
+};
+
+// Relax the orthogonal constraint
+// R.col(i)ᵀ * R.col(j) = 0
+// R.row(i)ᵀ * R.row(j) = 0.
+// and the cross product constraint
+// R.col(i) x R.col(j) = R.col(k)
+// R.row(i) x R.row(j) = R.row(k)
+// To handle this non-convex bilinear product, we relax any bilinear product
+// in the form x * y, we relax (x, y, w) to be in the convex hull of the
+// curve w = x * y, and replace all the bilinear term x * y with w. For more
+// details, @see AddBilinearProductMcCormickEnvelopeSos2.
+template<int NumIntervalsPerHalfAxis>
+void AddOrthogonalAndCrossProductConstraintRelaxationWithMcCormickEnvelopeOnBilinearProduct(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    const typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::PhiType& phi,
+    const typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::BinaryVarType& B,
+    const std::array<std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 2 * NumIntervalsPerHalfAxis + 1>, 3>, 3>& lambda) {
+  VectorDecisionVariable<9> R_flat;
+  R_flat << R.col(0), R.col(1), R.col(2);
+  MatrixDecisionVariable<9, 9> W;
+  for (int i = 0; i < 9; ++i) {
+    int Ri_row, Ri_col;
+    std::tie(Ri_row, Ri_col) = Index2Subscripts(i, 3, 3);
+    for (int j = i + 1; j < 9; ++j) {
+      int Rj_row, Rj_col;
+      std::tie(Rj_row, Rj_col) = Index2Subscripts(j, 3, 3);
+      std::string W_ij_name = "R(" + std::to_string(Ri_row) + "," + std::to_string(Ri_col) + ")*R(" + std::to_string(Rj_row) + "," + std::to_string(Rj_col) + ")";
+      W(i, j) = prog->NewContinuousVariables<1>(W_ij_name)(0);
+      auto lambda_bilinear = AddBilinearProductMcCormickEnvelopeSos2(prog, R(Ri_row, Ri_col), R(Rj_row, Rj_col), W(i, j), phi, phi, B[Ri_row][Ri_col], B[Rj_row][Rj_col]);
+      prog->AddLinearConstraint(lambda_bilinear.template cast<symbolic::Expression>().rowwise().sum() == lambda[Ri_row][Ri_col]);
+      prog->AddLinearConstraint(lambda_bilinear.template cast<symbolic::Expression>().colwise().sum().transpose() == lambda[Rj_row][Rj_col]);
+      W(j, i) = W(i, j);
+    }
+  }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = i + 1; j < 3; ++j) {
+      prog->AddLinearConstraint(ReplaceBilinearTerms(R.col(i).dot(R.col(j).cast<symbolic::Expression>()), R_flat, R_flat, W) == 0);
+      prog->AddLinearConstraint(ReplaceBilinearTerms(R.row(i).transpose().dot(R.row(j).cast<symbolic::Expression>().transpose()), R_flat, R_flat, W) == 0);
+    }
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    int j = (i + 1) % 3;
+    int k = (i + 2) % 3;
+    Vector3<symbolic::Expression> cross_product1 = R.col(i).cross(R.col(j).cast<symbolic::Expression>());
+    Vector3<symbolic::Expression> cross_product2 = R.row(i).transpose().cross(R.row(j).transpose().cast<symbolic::Expression>());
+    for (int row = 0; row < 3; ++row) {
+      prog->AddLinearConstraint(ReplaceBilinearTerms(cross_product1(row), R_flat, R_flat, W) == R(row, k));
+      prog->AddLinearConstraint(ReplaceBilinearTerms(cross_product2(row), R_flat, R_flat, W) == R(k, row));
+    }
+  }
+}
 }  // namespace
 
 AddRotationMatrixMcCormickEnvelopeReturnType
@@ -1010,33 +1111,60 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   return make_tuple(CRpos, CRneg, BRpos, BRneg);
 }
 
-template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
+template<int NumIntervalsPerHalfAxis>
 typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
-                        AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>>::type
+                        typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::type>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
     int num_intervlas_per_half_axis) {
+  typedef typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::BinaryVarType Btype;
+  typedef typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::PhiType PhiType;
   DRAKE_DEMAND(num_intervlas_per_half_axis >= 1);
-  const auto phi = typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::PhiType::LinSpaced(2 * num_intervlas_per_half_axis + 1, -1, 1);
+  constexpr int kLambdaRows = NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 2 * NumIntervalsPerHalfAxis + 1;
+  //Eigen::Matrix<double, kLambdaRows, 1> phi = typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::PhiType::LinSpaced(2 * num_intervlas_per_half_axis + 1, -1, 1);
+  PhiType phi = Eigen::VectorXd::LinSpaced(2 * num_intervlas_per_half_axis + 1, -1, 1);
+  phi(num_intervlas_per_half_axis) = 0;
 
   // Add the binary variables to determine in which interval R(i, j) lies.
   // B[i][j] is a vector of binary variables. If these binary variables
   // represent integer M in the reflected Gray code, then R(i, j) is within the
   // interval [φ(M), φ(M + 1)]. Refer to AddLogarithmicSos2Constraint for more
-  // details. 
+  // details.
+  // λ[i][j] is a vector of continuous variables. λ[i][j] satisfies SOS2
+  // constraint, and R(i, j) = φᵀ * λ[i][j]
+  const int lambda_rows = 2 * num_intervlas_per_half_axis + 1;
+  std::array<std::array<VectorDecisionVariable<kLambdaRows>, 3>, 3> lambda;
+  Btype B{};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      lambda[i][j] = prog->NewContinuousVariables<kLambdaRows, 1>(lambda_rows, 1, "lambda");
+      B[i][j] = AddLogarithmicSos2Constraint(prog, lambda[i][j].template cast<symbolic::Expression>());
+      // R(i, j) = φᵀ * λ[i][j]
+      prog->AddLinearConstraint(R(i, j) - phi.dot(lambda[i][j].template cast<symbolic::Expression>()) == 0);
+    }
+  }
+  for (int row = 0; row < 3; ++row) {
+    AddUnitLengthConstraintWithLogarithmicSos2(prog, phi, lambda[row][0], lambda[row][1], lambda[row][2]);
+  }
+  for (int col = 0; col < 3; ++col) {
+    AddUnitLengthConstraintWithLogarithmicSos2(prog, phi, lambda[0][col], lambda[1][col], lambda[2][col]);
+  }
+  AddOrthogonalAndCrossProductConstraintRelaxationWithMcCormickEnvelopeOnBilinearProduct<NumIntervalsPerHalfAxis>(prog, R, phi, B, lambda);
+
+  return std::make_pair(B, phi);
 };
 
-template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<Eigen::Dynamic>
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<Eigen::Dynamic>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<Eigen::Dynamic>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
 
-template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<1>
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<1>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<1>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
 
-template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<2>
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<2>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<2>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
 
-template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<3>
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<3>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<3>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1010,5 +1010,33 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   return make_tuple(CRpos, CRneg, BRpos, BRneg);
 }
 
+template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
+typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
+                        AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>>::type
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervlas_per_half_axis) {
+  DRAKE_DEMAND(num_intervlas_per_half_axis >= 1);
+  const auto phi = typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::PhiType::LinSpaced(2 * num_intervlas_per_half_axis + 1, -1, 1);
+
+  // Add the binary variables to determine in which interval R(i, j) lies.
+  // B[i][j] is a vector of binary variables. If these binary variables
+  // represent integer M in the reflected Gray code, then R(i, j) is within the
+  // interval [φ(M), φ(M + 1)]. Refer to AddLogarithmicSos2Constraint for more
+  // details. 
+};
+
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<Eigen::Dynamic>
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<Eigen::Dynamic>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
+
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<1>
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<1>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
+
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<2>
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<2>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
+
+template AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<3>
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints<3>(MathematicalProgram* prog, const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R, int num_intervlas_per_half_axis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -961,12 +961,12 @@ void AddOrthogonalAndCrossProductConstraintRelaxationReplacingBilinearProduct(
         NumIntervalsPerHalfAxis>::PhiType& phi,
     const typename AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
         NumIntervalsPerHalfAxis>::BinaryVarType& B,
-    const std::array<std::array<VectorDecisionVariable<
-                                    NumIntervalsPerHalfAxis == Eigen::Dynamic
-                                        ? Eigen::Dynamic
-                                        : 2 * NumIntervalsPerHalfAxis + 1>,
-                                3>,
-                     3>& lambda) {
+    const std::array<
+        std::array<VectorDecisionVariable<
+                       AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
+                           NumIntervalsPerHalfAxis>::PhiRows>,
+                   3>,
+        3>& lambda) {
   VectorDecisionVariable<9> R_flat;
   R_flat << R.col(0), R.col(1), R.col(2);
   MatrixDecisionVariable<9, 9> W;

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -9,7 +9,6 @@
 #include "drake/common/symbolic.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
-#include "drake/solvers/mixed_integer_optimization_util.h"
 
 /// @file Functions for reasoning about 3D rotations in a @MathematicalProgram.
 ///

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -158,6 +158,31 @@ struct AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn {
   typedef std::pair<BinaryVarType, PhiType> type;
 };
 
+/**
+ * Relax the SO(3) constraint on a rotation matrix R = [R₀ R₁ R₂]
+ * <pre>
+ * Rᵢᵀ * Rᵢ = 1
+ * Rᵢᵀ * Rⱼ = 0
+ * Rᵢ x Rⱼ = Rₖ
+ * </pre>
+ * to a set of mixed-integer linear constraints. This is achieved by replacing
+ * the bilinear product terms in the SO(3) constraint, with a new auxiliary
+ * variable in the McCormick envelope of bilinear product. For more details,
+ * please refer to
+ * Global Inverse Kinematics via Mixed-Integer Convex Optimization
+ * by Hongkai Dai, Gregory Izatt and Russ Tedrake, 2017.
+ * @tparam NumIntervalsPerHalfAxis We cut the interval [-1, 1] evenly into
+ * NumIntervalsPerHalfAxis * 2 intervals. Then depending on in which interval
+ * R(i, j) is, we impose corresponding linear constraints.
+ * @param prog The optimization program to which the SO(3) relaxation is added.
+ * @param R The rotation matrix.
+ * @param num_intervlas_per_half_axis Same as NumIntervalsPerHalfAxis, use this
+ * variable when NumIntervalsPerHalfAxis is dynamic.
+ * @return pair. pair = (B, φ). B[i][j] is a column vector. If B[i][j]
+ * represents integer M in the reflected Gray code, then R(i, j) is in the
+ * interval [φ(M), φ(M+1)]. φ contains the end points of the all the intervals,
+ * namely φ(i) = -1 + 1 / num_intervals_per_half_axis * i.
+ */
 template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
 typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
                         typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::type>::type

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -9,6 +9,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mixed_integer_optimization_util.h"
 
 /// @file Functions for reasoning about 3D rotations in a @MathematicalProgram.
 ///
@@ -151,12 +152,13 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
 
 template <int NumIntervalsPerHalfAxis>
 struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
-  typedef std::array<
-      std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis>, 3>, 3>
-      BinaryVarType;
   static constexpr int PhiRows = NumIntervalsPerHalfAxis == Eigen::Dynamic
                                      ? Eigen::Dynamic
                                      : 1 + 2 * NumIntervalsPerHalfAxis;
+  static constexpr int NumBinaryVars =
+      PhiRows == Eigen::Dynamic ? Eigen::Dynamic : CeilLog2(PhiRows - 1);
+  typedef std::array<std::array<VectorDecisionVariable<NumBinaryVars>, 3>, 3>
+      BinaryVarType;
   typedef Eigen::Matrix<double, PhiRows, 1> PhiType;
   typedef std::pair<BinaryVarType, PhiType> type;
 };

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -150,10 +150,14 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     int num_binary_vars_per_half_axis = 2,
     RollPitchYawLimits limits = kNoLimits);
 
-template<int NumIntervalsPerHalfAxis>
-struct AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn {
-  typedef std::array<std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis>, 3>, 3> BinaryVarType;
-  static constexpr int PhiRows = NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 1 + 2 * NumIntervalsPerHalfAxis;
+template <int NumIntervalsPerHalfAxis>
+struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
+  typedef std::array<
+      std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis>, 3>, 3>
+      BinaryVarType;
+  static constexpr int PhiRows = NumIntervalsPerHalfAxis == Eigen::Dynamic
+                                     ? Eigen::Dynamic
+                                     : 1 + 2 * NumIntervalsPerHalfAxis;
   typedef Eigen::Matrix<double, PhiRows, 1> PhiType;
   typedef std::pair<BinaryVarType, PhiType> type;
 };
@@ -183,12 +187,14 @@ struct AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn {
  * interval [φ(M), φ(M+1)]. φ contains the end points of the all the intervals,
  * namely φ(i) = -1 + 1 / num_intervals_per_half_axis * i.
  */
-template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
-typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
-                        typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::type>::type
-AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
-    MathematicalProgram* prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+template <int NumIntervalsPerHalfAxis = Eigen::Dynamic>
+typename std::enable_if<
+    NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
+    typename AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
+        NumIntervalsPerHalfAxis>::type>::type
+AddRotationMatrixBilinearMcCormickMilpConstraints(
+    MathematicalProgram *prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
     int num_intervlas_per_half_axis = NumIntervalsPerHalfAxis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -153,13 +153,14 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
 template<int NumIntervalsPerHalfAxis>
 struct AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn {
   typedef std::array<std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis>, 3>, 3> BinaryVarType;
-  typedef Eigen::Matrix<double, NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 1 + CeilLog2(NumIntervalsPerHalfAxis), 1> PhiType;
+  static constexpr int PhiRows = NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 1 + 2 * NumIntervalsPerHalfAxis;
+  typedef Eigen::Matrix<double, PhiRows, 1> PhiType;
   typedef std::pair<BinaryVarType, PhiType> type;
 };
 
 template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
 typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
-                        AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>>::type
+                        typename AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>::type>::type
 AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -181,7 +181,7 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * R(i, j) is, we impose corresponding linear constraints.
  * @param prog The optimization program to which the SO(3) relaxation is added.
  * @param R The rotation matrix.
- * @param num_intervlas_per_half_axis Same as NumIntervalsPerHalfAxis, use this
+ * @param num_intervals_per_half_axis Same as NumIntervalsPerHalfAxis, use this
  * variable when NumIntervalsPerHalfAxis is dynamic.
  * @return pair. pair = (B, φ). B[i][j] is a column vector. If B[i][j]
  * represents integer M in the reflected Gray code, then R(i, j) is in the
@@ -196,6 +196,6 @@ typename std::enable_if<
 AddRotationMatrixBilinearMcCormickMilpConstraints(
     MathematicalProgram *prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
-    int num_intervlas_per_half_axis = NumIntervalsPerHalfAxis);
+    int num_intervals_per_half_axis = NumIntervalsPerHalfAxis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/rotation_constraint.h
+++ b/drake/solvers/rotation_constraint.h
@@ -9,6 +9,7 @@
 #include "drake/common/symbolic.h"
 #include "drake/solvers/decision_variable.h"
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mixed_integer_optimization_util.h"
 
 /// @file Functions for reasoning about 3D rotations in a @MathematicalProgram.
 ///
@@ -149,5 +150,19 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     int num_binary_vars_per_half_axis = 2,
     RollPitchYawLimits limits = kNoLimits);
 
+template<int NumIntervalsPerHalfAxis>
+struct AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn {
+  typedef std::array<std::array<VectorDecisionVariable<NumIntervalsPerHalfAxis>, 3>, 3> BinaryVarType;
+  typedef Eigen::Matrix<double, NumIntervalsPerHalfAxis == Eigen::Dynamic ? Eigen::Dynamic : 1 + CeilLog2(NumIntervalsPerHalfAxis), 1> PhiType;
+  typedef std::pair<BinaryVarType, PhiType> type;
+};
+
+template<int NumIntervalsPerHalfAxis = Eigen::Dynamic>
+typename std::enable_if<NumIntervalsPerHalfAxis == Eigen::Dynamic || NumIntervalsPerHalfAxis >= 1,
+                        AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraintsReturn<NumIntervalsPerHalfAxis>>::type
+AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervlas_per_half_axis = NumIntervalsPerHalfAxis);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -189,6 +189,42 @@ bool IsFeasibleCheck(
   return (prog->Solve() == kSolutionFound);
 }
 
+GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
+  MathematicalProgram prog;
+  auto R = NewRotationMatrixVars(&prog);
+  auto ret1 = AddRotationMatrixBilinearMcCormickMilpConstraints<1>(&prog, R);
+  static_assert(
+      std::is_same<
+          decltype(ret1),
+          std::pair<std::array<std::array<VectorDecisionVariable<1>, 3>, 3>,
+                    Eigen::Matrix<double, 3, 1>>>::value,
+      "Incorrect type.");
+
+  auto ret2 = AddRotationMatrixBilinearMcCormickMilpConstraints<2>(&prog, R);
+  static_assert(
+      std::is_same<
+          decltype(ret2),
+          std::pair<std::array<std::array<VectorDecisionVariable<2>, 3>, 3>,
+                    Eigen::Matrix<double, 5, 1>>>::value,
+      "Incorrect type.");
+
+  auto ret3 = AddRotationMatrixBilinearMcCormickMilpConstraints<3>(&prog, R);
+  static_assert(
+      std::is_same<
+          decltype(ret3),
+          std::pair<std::array<std::array<VectorDecisionVariable<3>, 3>, 3>,
+                    Eigen::Matrix<double, 7, 1>>>::value,
+      "Incorrect type.");
+
+  auto ret4 = AddRotationMatrixBilinearMcCormickMilpConstraints<4>(&prog, R);
+  static_assert(
+      std::is_same<
+          decltype(ret4),
+          std::pair<std::array<std::array<VectorDecisionVariable<3>, 3>, 3>,
+                    Eigen::Matrix<double, 9, 1>>>::value,
+      "Incorrect type.");
+}
+
 class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMcCormick)

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -264,7 +264,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
 };
 
 TEST_P(TestMcCormick, TestExactRotationMatrix) {
-  // Test if R is exactly on SO(3), whether it also satisfies our relaxation.
+  // If R is exactly on SO(3), test whether it also satisfies our relaxation.
   std::mt19937 generator(41);
   std::normal_distribution<double> randn;
   std::uniform_int_distribution<> rand(0, 1 << 6);

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -203,7 +203,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
       Eigen::Matrix<double, 9, 1>::Zero(),
       {R_.col(0), R_.col(1), R_.col(2)}).constraint()} {
     if (replace_bilinear_product_) {
-      AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
+      AddRotationMatrixBilinearMcCormickMilpConstraints(
           &prog_, R_, num_intervals_per_half_axis_);
     } else {
       AddRotationMatrixMcCormickEnvelopeMilpConstraints(
@@ -220,10 +220,9 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
   MathematicalProgram prog_;
   MatrixDecisionVariable<3, 3> R_;
-  bool replace_bilinear_product_; // If true, replace the bilinear product with
-                                  // another varaible in the McCormick envelope.
-                                  // Otherwise, relax the surface of the unit
-                                  // sphere to its convex hull.
+  bool replace_bilinear_product_;  // If true, replace the bilinear product with
+  // another varaible in the McCormick envelope. Otherwise, relax the surface of
+  // the unit sphere to its convex hull.
   int num_intervals_per_half_axis_;
   std::shared_ptr<LinearEqualityConstraint> feasibility_constraint_;
 };

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -203,9 +203,11 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
       Eigen::Matrix<double, 9, 1>::Zero(),
       {R_.col(0), R_.col(1), R_.col(2)}).constraint()} {
     if (replace_bilinear_product_) {
-      AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(&prog_, R_, num_intervals_per_half_axis_);
+      AddRotationMatrixBilinearTermMcCormickEnvelopeMilpConstraints(
+          &prog_, R_, num_intervals_per_half_axis_);
     } else {
-      AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog_, R_, num_intervals_per_half_axis_);
+      AddRotationMatrixMcCormickEnvelopeMilpConstraints(
+          &prog_, R_, num_intervals_per_half_axis_);
     }
   }
 
@@ -218,12 +220,16 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
   MathematicalProgram prog_;
   MatrixDecisionVariable<3, 3> R_;
-  bool replace_bilinear_product_;
+  bool replace_bilinear_product_; // If true, replace the bilinear product with
+                                  // another varaible in the McCormick envelope.
+                                  // Otherwise, relax the surface of the unit
+                                  // sphere to its convex hull.
   int num_intervals_per_half_axis_;
   std::shared_ptr<LinearEqualityConstraint> feasibility_constraint_;
 };
 
-TEST_P(TestMcCormick, TestFeasibleRotation) {
+TEST_P(TestMcCormick, TestExactRotationMatrix) {
+  // Test if R is exactly on SO(3), whether it also satisfies our relaxation.
   std::mt19937 generator(41);
   std::normal_distribution<double> randn;
   std::uniform_int_distribution<> rand(0, 1 << 6);
@@ -262,114 +268,58 @@ TEST_P(TestMcCormick, TestFeasibleRotation) {
   }
 }
 
+TEST_P(TestMcCormick, TestInexactRotationMatrix) {
+  // If R is not exactly on SO(3), test whether it is infeasible for our SO(3)
+  // relaxation.
+
+  // Checks the dot product constraints.
+  Eigen::Matrix3d R_test =
+      Matrix3d::Constant(1.0 / sqrt(3.0));  // All rows and columns are
+  // on the unit sphere.
+  EXPECT_FALSE(IsFeasible(R_test));
+  // All in different octants, all unit length, but not orthogonal.
+  // R.col(0).dot(R.col(1)) = 1/3;
+  R_test(0, 1) *= -1.0;
+  R_test(2, 1) *= -1.0;
+  R_test(0, 2) *= -1.0;
+  R_test(1, 2) *= -1.0;
+  // Requires 2 intervals per half axis to catch.
+  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+    EXPECT_TRUE(IsFeasible(R_test));
+  else
+    EXPECT_FALSE(IsFeasible(R_test));
+
+  // Checks the det(R)=-1 case.
+  // (only ruled out by the cross-product constraint).
+  R_test = Matrix3d::Identity();
+  R_test(2, 2) = -1;
+  EXPECT_FALSE(IsFeasible(R_test));
+
+  R_test = math::ZRotation(M_PI_4) * R_test;
+  EXPECT_FALSE(IsFeasible(R_test));
+
+  R_test = math::YRotation(M_PI_4) * R_test;
+  EXPECT_FALSE(IsFeasible(R_test));
+
+  // Checks a few cases just outside the L1 ball. If we use the formulation that
+  // replaces the bilinear term with another variable in the McCormick envelope,
+  // then it should always be infeasible. Otherwise should be feasible for
+  // num_intervals_per_half_axis_=1, but infeasible for
+  // num_intervals_per_half_axis_>1.
+  R_test = math::YRotation(M_PI_4);
+  R_test(2, 0) -= 0.1;
+  EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
+  EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);
+  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+    EXPECT_TRUE(IsFeasible(R_test));
+  else
+    EXPECT_FALSE(IsFeasible(R_test));
+}
+
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
     ::testing::Combine(::testing::ValuesIn<std::vector<bool>>({false, true}),
                        ::testing::ValuesIn<std::vector<int>>({1, 2})));
-/*
-// Tests that a number of feasible rotation matrices are indeed feasible for
-// McCormick envelopes with 1 or 2 bins per axis.  Also checks that some
-// specific matrices that should be ruled out by the orthogonality and cross-
-// product constraints are indeed infeasible.  Finally, checks a few points
-// that we expect to be reported as feasible for the loose envelope, but are
-// then correctly reported as infeasible given the tighter envelope.
-GTEST_TEST(RotationTest, TestMcCormick) {
-  std::mt19937 generator(41);
-  std::normal_distribution<double> randn;
-  std::uniform_int_distribution<> rand(0, 1 << 6);
-
-  for (int num_bins = 1; num_bins < 3; num_bins++) {
-    MathematicalProgram prog;
-    MatrixDecisionVariable<3, 3> R = NewRotationMatrixVars(&prog);
-
-    AddRotationMatrixMcCormickEnvelopeMilpConstraints(&prog, R, num_bins);
-
-    // Feasibility constraint
-    std::shared_ptr<LinearEqualityConstraint> feasibility_constraint =
-        prog.AddLinearEqualityConstraint(
-            Eigen::Matrix<double, 9, 9>::Identity(),
-            Eigen::Matrix<double, 9, 1>::Zero(),
-            {R.col(0), R.col(1), R.col(2)}).constraint();
-
-    // Use a simple lambda to make the tests more readable below.
-    auto IsFeasible = [&](Matrix3d R_to_check) -> bool {
-      return IsFeasibleCheck(&prog, feasibility_constraint, R_to_check);
-    };
-
-    // Test a few valid rotation matrices.
-    Matrix3d R_test = Matrix3d::Identity();
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::ZRotation(M_PI_4) * R_test;
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::YRotation(M_PI_4) * R_test;
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::ZRotation(M_PI_2);
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::ZRotation(-M_PI_2);
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::YRotation(M_PI_2);
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    R_test = math::YRotation(-M_PI_2);
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    // This one caught a bug (in the loop finding the most conservative linear
-    // constraint for a given region) during random testing.
-    R_test << 0.17082017792981191, 0.65144498431260445, -0.73921573253413542,
-        -0.82327804434149443, -0.31781600529013027, -0.47032568342231595,
-        -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
-    EXPECT_TRUE(IsFeasible(R_test));
-
-    for (int i = 0; i < 40; i++) {
-      R_test = math::UniformlyRandomRotmat(generator);
-      EXPECT_TRUE(IsFeasible(R_test));
-    }
-
-    // Checks the dot product constraints.
-    R_test = Matrix3d::Constant(1.0 / sqrt(3.0));  // All rows and columns are
-    // on the unit sphere.
-    EXPECT_FALSE(IsFeasible(R_test));
-    // All in different octants, all unit length, but not orthogonal.
-    // R.col(0).dot(R.col(1)) = 1/3;
-    R_test(0, 1) *= -1.0;
-    R_test(2, 1) *= -1.0;
-    R_test(0, 2) *= -1.0;
-    R_test(1, 2) *= -1.0;
-    // Requires 2 bins to catch.
-    if (num_bins == 1)
-      EXPECT_TRUE(IsFeasible(R_test));
-    else
-      EXPECT_FALSE(IsFeasible(R_test));
-
-    // Checks the det(R)=-1 case.
-    // (only ruled out by the cross-product constraint).
-    R_test = Matrix3d::Identity();
-    R_test(2, 2) = -1;
-    EXPECT_FALSE(IsFeasible(R_test));
-
-    R_test = math::ZRotation(M_PI_4) * R_test;
-    EXPECT_FALSE(IsFeasible(R_test));
-
-    R_test = math::YRotation(M_PI_4) * R_test;
-    EXPECT_FALSE(IsFeasible(R_test));
-
-    // Checks a few cases just outside the L1 ball.  Should be feasible for
-    // num_bins=1, but infeasible for num_bins>1.
-    R_test = math::YRotation(M_PI_4);
-    R_test(2, 0) -= 0.1;
-    EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
-    EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);
-    if (num_bins == 1)
-      EXPECT_TRUE(IsFeasible(R_test));
-    else
-      EXPECT_FALSE(IsFeasible(R_test));
-  }
-}*/
 
 // Test some corner cases of McCormick envelope.
 // The corner cases happens when either the innermost or the outermost corner

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -256,18 +256,16 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
   MathematicalProgram prog_;
   MatrixDecisionVariable<3, 3> R_;
-  bool replace_bilinear_product_;  // If true, replace the bilinear product with
-  // another varaible in the McCormick envelope. Otherwise, relax the surface of
-  // the unit sphere to its convex hull.
-  int num_intervals_per_half_axis_;
+  bool replace_bilinear_product_{};  // If true, replace the bilinear product
+  // with another varaible in the McCormick envelope. Otherwise, relax the
+  // surface ofthe unit sphere to its convex hull.
+  int num_intervals_per_half_axis_{};
   std::shared_ptr<LinearEqualityConstraint> feasibility_constraint_;
 };
 
 TEST_P(TestMcCormick, TestExactRotationMatrix) {
   // If R is exactly on SO(3), test whether it also satisfies our relaxation.
-  std::mt19937 generator(41);
-  std::normal_distribution<double> randn;
-  std::uniform_int_distribution<> rand(0, 1 << 6);
+
   // Test a few valid rotation matrices.
   Matrix3d R_test = Matrix3d::Identity();
   EXPECT_TRUE(IsFeasible(R_test));
@@ -297,6 +295,7 @@ TEST_P(TestMcCormick, TestExactRotationMatrix) {
       -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
   EXPECT_TRUE(IsFeasible(R_test));
 
+  std::mt19937 generator(41);
   for (int i = 0; i < 40; i++) {
     R_test = math::UniformlyRandomRotmat(generator);
     EXPECT_TRUE(IsFeasible(R_test));


### PR DESCRIPTION
This introduces a different mixed-integer convex relaxation on the SO(3) rotation constraint. The idea is to replace the bilinear product in the SO(3) constraint, with an auxiliary variable lies in the convex hull of the curve w = x * y. We test this new relaxation, and found it being much tighter than the one that was in the master, if we use 1 interval per half axis, and slightly tighter with 2 intervals per half axis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6635)
<!-- Reviewable:end -->
