### PR TITLE
Ensure that body_idx is resized appropriately.

### DIFF
--- a/drake/multibody/rigid_body_tree.cc
+++ b/drake/multibody/rigid_body_tree.cc
@@ -810,6 +810,7 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
   body_x.resize(3, closest_points.size());
   normal.resize(3, closest_points.size());
   phi.resize(closest_points.size());
+  body_idx.resize(closest_points.size());
 
   for (size_t i = 0; i < closest_points.size(); ++i) {
     x.col(i) = closest_points[i].ptB;
@@ -821,9 +822,9 @@ void RigidBodyTree<T>::collisionDetectFromPoints(
     // In the case that no closest point was found, elementB will come back
     // as a null pointer which we should not attempt to access.
     if (elementB) {
-      body_idx.push_back(elementB->get_body()->get_body_index());
+      body_idx[i] = elementB->get_body()->get_body_index();
     } else {
-      body_idx.push_back(-1);
+      body_idx[i] = -1;
     }
   }
 }


### PR DESCRIPTION
This is a minor fix which ensures that `body_idx` is appropriately sized (rather than directly appending).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6641)
<!-- Reviewable:end -->
