### PR TITLE
Allow construction of FclModel instances with drake::multibody::collision::newModel

### DIFF
--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -40,9 +40,7 @@ drake_cc_library(
     srcs = [
         "bullet_model.cc",
         "bullet_model.h",
-        "drake_collision.cc",
     ],
-    defines = ["BULLET_COLLISION"],
     deps = [
         ":collision_api",
         "//drake/common:unused",
@@ -56,7 +54,6 @@ drake_cc_library(
 drake_cc_library(
     name = "unusable_collision",
     srcs = [
-        "drake_collision.cc",
         "unusable_model.cc",
         "unusable_model.h",
     ],
@@ -83,9 +80,18 @@ drake_cc_library(
 
 # By default, supply a bullet-only model.  As we gain more collision library
 # choices, we may want to be more subtle here.
-alias(
+drake_cc_library(
     name = "collision",
-    actual = ":bullet_collision",
+    srcs = [
+        "drake_collision.cc",
+    ],
+    defines = ["BULLET_COLLISION"],
+    deps = [
+        ":collision_api",
+        ":bullet_collision",
+        ":fcl_collision",
+        ":unusable_collision",
+    ],
 )
 
 drake_cc_googletest(

--- a/drake/multibody/collision/CMakeLists.txt
+++ b/drake/multibody/collision/CMakeLists.txt
@@ -23,6 +23,8 @@ if(Bullet_FOUND)
   set(bullet_dependent_requires bullet)
 endif()
 
+target_compile_definitions(drakeCollision PUBLIC DRAKE_DISABLE_FCL)
+
 target_link_libraries(drakeCollision
   drakeCommon
   drakeShapes

--- a/drake/multibody/collision/drake_collision.cc
+++ b/drake/multibody/collision/drake_collision.cc
@@ -1,12 +1,14 @@
 #include "drake/multibody/collision/drake_collision.h"
 
-#include "drake/multibody/collision/collision_filter.h"
-
+#include "drake/common/drake_assert.h"
 #ifdef BULLET_COLLISION
 #include "drake/multibody/collision/bullet_model.h"
-#else
-#include "drake/multibody/collision/unusable_model.h"
 #endif
+#include "drake/multibody/collision/collision_filter.h"
+#ifndef DRAKE_DISABLE_FCL
+#include "drake/multibody/collision/fcl_model.h"
+#endif
+#include "drake/multibody/collision/unusable_model.h"
 
 using std::unique_ptr;
 
@@ -14,12 +16,24 @@ namespace drake {
 namespace multibody {
 namespace collision {
 
-unique_ptr<Model> newModel() {
-#ifdef BULLET_COLLISION
-  return unique_ptr<Model>(new BulletModel());
-#else
-  return unique_ptr<Model>(new UnusableModel());
+unique_ptr<Model> newModel(ModelType type) {
+  switch (type) {
+    case (ModelType::kUnusable): {
+      return unique_ptr<Model>(new UnusableModel());
+    }
+#ifndef DRAKE_DISABLE_FCL
+    case (ModelType::kFcl): {
+      return unique_ptr<Model>(new FclModel());
+    }
 #endif
+#ifdef BULLET_COLLISION
+    case (ModelType::kBullet): {
+      return unique_ptr<Model>(new BulletModel());
+    }
+#endif
+    default:
+      DRAKE_ABORT_MSG("Unexpected collision model type.");
+  }
 }
 
 }  // namespace collision

--- a/drake/multibody/collision/drake_collision.h
+++ b/drake/multibody/collision/drake_collision.h
@@ -7,7 +7,25 @@
 namespace drake {
 namespace multibody {
 namespace collision {
-std::unique_ptr<Model> newModel();
+
+enum class ModelType {
+  kUnusable = 0,
+#ifndef DRAKE_DISABLE_FCL
+  kFcl = 1,
+#endif
+#ifdef BULLET_COLLISION
+  kBullet = 2
+#endif
+};
+
+/// Returns a unique pointer to a Model that uses the collision backend
+/// specified by @p type.
+#ifdef BULLET_COLLISION
+std::unique_ptr<Model> newModel(ModelType type = ModelType::kBullet);
+#else
+std::unique_ptr<Model> newModel(ModelType type = ModelType::kUnusable);
+#endif
+
 }  // namespace collision
 }  // namespace multibody
 }  // namespace drake


### PR DESCRIPTION
This is Spiral 1 as described in #6571. This PR adds an argument to `drake::multibody::collision::newModel` that allows specification of the collision backend. The default is to use Bullet, so all existing call sites will retain their current behavior. The PR also adds unit tests to lock down the current behavior of `FclModel` (always abort with a "Not implemented" message).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6646)
<!-- Reviewable:end -->
