### PR TITLE
Add some clang-format guards

### DIFF
--- a/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/automotive/maliput/monolane/builder.h"
 /* clang-format on */
 

--- a/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -1,6 +1,8 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/automotive/maliput/monolane/arc_lane.h"
 #include "drake/automotive/maliput/monolane/lane.h"
 #include "drake/automotive/maliput/monolane/line_lane.h"
+/* clang-format on */
 
 #include <cmath>
 

--- a/drake/automotive/maliput/monolane/test/monolane_road_geometry_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_road_geometry_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/automotive/maliput/monolane/road_geometry.h"
+/* clang-format on */
 
 #include <cmath>
 

--- a/drake/common/drake_assert_and_throw.cc
+++ b/drake/common/drake_assert_and_throw.cc
@@ -1,8 +1,8 @@
 // This file contains the implementation of both drake_assert and drake_throw.
-// clang-format off
+/* clang-format off to disable clang-format-includes */
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_throw.h"
-// clang-format on
+/* clang-format on */
 
 #include <atomic>
 #include <cstdlib>

--- a/drake/common/drake_path_bazel.cc
+++ b/drake/common/drake_path_bazel.cc
@@ -1,5 +1,7 @@
 // This file is the Bazel build's implementation of drake_path.h.
+/* clang-format off to disable clang-format-includes */
 #include "drake/common/drake_path.h"
+/* clang-format on */
 
 #include <spruce.hh>
 

--- a/drake/common/drake_path_cmake.cc
+++ b/drake/common/drake_path_cmake.cc
@@ -1,5 +1,7 @@
 // This file is the CMake build's implementation of drake_path.h.
+/* clang-format off to disable clang-format-includes */
 #include "drake/common/drake_path.h"
+/* clang-format on */
 
 #include "drake/common/cmake_project_source_dir.h"
 

--- a/drake/common/test/drake_assert_test_compile.cc
+++ b/drake/common/test/drake_assert_test_compile.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/common/drake_assert.h"
+/* clang-format on */
 
 #include "drake/common/unused.h"
 

--- a/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
+++ b/drake/common/trajectories/test/piecewise_polynomial_generation_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/common/trajectories/piecewise_polynomial.h"
+/* clang-format on */
 
 #include <iostream>
 #include <random>

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_demo.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_demo.cc
@@ -4,14 +4,14 @@
  * receiving the plan, the Valkyrie robot should return to the nominal
  * configuration except the right shoulder pitch joint.
  */
+#include "lcm/lcm-cpp.hpp"
+#include "robotlocomotion/robot_plan_t.hpp"
+
 #include "drake/examples/valkyrie/valkyrie_constants.h"
 #include "drake/manipulation/util/robot_state_msg_translator.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"
-
-#include "lcm/lcm-cpp.hpp"
-#include "robotlocomotion/robot_plan_t.hpp"
 
 using std::default_random_engine;
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "robotlocomotion/robot_plan_t.hpp"
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/control_utils.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/lcm_utils.h"
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h
@@ -1,7 +1,6 @@
-#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.h"
-
 #include <string>
 
+#include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/generic_plan.h"
 #include "drake/manipulation/util/robot_state_msg_translator.h"
 #include "drake/systems/controllers/zmp_planner.h"
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "robotlocomotion/robot_plan_t.hpp"
+
 #include "drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.h"
 
 namespace drake {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/test/humanoid_plan_eval_system_test.cc
@@ -1,6 +1,7 @@
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.h"
 
 #include <gtest/gtest.h>
+#include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/find_resource.h"
@@ -12,7 +13,6 @@
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/constant_value_source.h"
-#include "robotlocomotion/robot_plan_t.hpp"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
@@ -6,6 +6,7 @@
 
 #include "bot_core/atlas_command_t.hpp"
 #include "bot_core/robot_state_t.hpp"
+#include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/atlas_joint_level_controller_system.h"
 #include "drake/examples/QPInverseDynamicsForHumanoids/system/humanoid_plan_eval_system.h"
@@ -18,7 +19,6 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
-#include "robotlocomotion/robot_plan_t.hpp"
 
 namespace drake {
 namespace examples {

--- a/drake/examples/acrobot/acrobot_plant_w_lcm.cc
+++ b/drake/examples/acrobot/acrobot_plant_w_lcm.cc
@@ -9,14 +9,13 @@
  * LcmPublisherSystem
  *
  */
-#include "drake/examples/acrobot/acrobot_plant.h"
-
 #include <memory>
 
 #include <gflags/gflags.h>
 
 #include "drake/common/find_resource.h"
 #include "drake/examples/acrobot/acrobot_lcm.h"
+#include "drake/examples/acrobot/acrobot_plant.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_acrobot_u.hpp"
 #include "drake/lcmt_acrobot_x.hpp"

--- a/drake/examples/acrobot/acrobot_spong_controller_w_lcm.cc
+++ b/drake/examples/acrobot/acrobot_spong_controller_w_lcm.cc
@@ -9,11 +9,10 @@
  * LcmPublisherSystem
  *
  */
-#include "drake/examples/acrobot/acrobot_spong_controller.h"
-
 #include <memory>
 
 #include "drake/examples/acrobot/acrobot_lcm.h"
+#include "drake/examples/acrobot/acrobot_spong_controller.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_acrobot_u.hpp"
 #include "drake/lcmt_acrobot_x.hpp"

--- a/drake/examples/rod2d/rod2d_sim.cc
+++ b/drake/examples/rod2d/rod2d_sim.cc
@@ -1,5 +1,3 @@
-#include "drake/examples/rod2d/rod2d.h"
-
 #include <cmath>
 #include <iomanip>
 #include <limits>
@@ -9,6 +7,7 @@
 
 #include "drake/common/text_logging.h"
 #include "drake/common/text_logging_gflags.h"
+#include "drake/examples/rod2d/rod2d.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcmtypes/drake/lcmt_viewer_load_robot.hpp"

--- a/drake/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/drake/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/examples/valkyrie/robot_state_encoder.h"
 #include "drake/examples/valkyrie/robot_state_decoder.h"
 /* clang-format on */

--- a/drake/examples/valkyrie/test/valkyrie_simulation_test.cc
+++ b/drake/examples/valkyrie/test/valkyrie_simulation_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/examples/valkyrie/valkyrie_simulator.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/manipulation/util/simple_tree_visualizer_demo.cc
+++ b/drake/manipulation/util/simple_tree_visualizer_demo.cc
@@ -1,8 +1,6 @@
 /**
  * @file test demo to visualize a given tree in a random set of configurations.
  */
-#include "drake/manipulation/util/simple_tree_visualizer.h"
-
 #include <chrono>
 #include <thread>
 
@@ -11,6 +9,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/manipulation/util/simple_tree_visualizer.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"
 

--- a/drake/multibody/collision/test/collision_filter_group_test.cc
+++ b/drake/multibody/collision/test/collision_filter_group_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/collision/collision_filter.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/multibody_tree/test/frames_test.cc
+++ b/drake/multibody/multibody_tree/test/frames_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+/* clang-format on */
 
 #include <memory>
 #include <set>

--- a/drake/multibody/multibody_tree/test/multibody_tree_creation_test.cc
+++ b/drake/multibody/multibody_tree/test/multibody_tree_creation_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+/* clang-format on */
 
 #include <memory>
 #include <set>

--- a/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/drake/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 /* clang-format on */
 

--- a/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 /* clang-format on */
 

--- a/drake/multibody/rigid_body_plant/test/contact_resultant_force_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_resultant_force_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_plant/contact_force.h"
 #include "drake/multibody/rigid_body_plant/contact_resultant_force_calculator.h"
 /* clang-format on */

--- a/drake/multibody/rigid_body_tree_contact.cc
+++ b/drake/multibody/rigid_body_tree_contact.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <iostream>

--- a/drake/multibody/shapes/test/face_query_test.cc
+++ b/drake/multibody/shapes/test/face_query_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/shapes/geometry.h"
 /* clang-format on */
 

--- a/drake/multibody/shapes/test/mesh_scaling_test.cc
+++ b/drake/multibody/shapes/test/mesh_scaling_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/shapes/geometry.h"
 /* clang-format on */
 

--- a/drake/multibody/shapes/test/mesh_triangulate_test.cc
+++ b/drake/multibody/shapes/test/mesh_triangulate_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/shapes/geometry.h"
 /* clang-format on */
 

--- a/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
+++ b/drake/multibody/test/rigid_body_tree/anchored_geometry_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
 /* clang-format on */
 

--- a/drake/multibody/test/rigid_body_tree/contact_points_generation_test.cc
+++ b/drake/multibody/test/rigid_body_tree/contact_points_generation_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
 /* clang-format on */
 

--- a/drake/multibody/test/rigid_body_tree/point_collision_detection_test.cc
+++ b/drake/multibody/test/rigid_body_tree/point_collision_detection_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
 /* clang-format on */
 

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <cmath>
 #include <iostream>

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_creation_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_creation_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <iostream>
 

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_face_extraction_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_face_extraction_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <memory>
 

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_kinematics_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_kinematics_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/multibody/test/test_kinematics_cache_checks.cc
+++ b/drake/multibody/test/test_kinematics_cache_checks.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/rigid_body_tree.h"
 /* clang-format on */
 

--- a/drake/solvers/dreal_solver_common.cc
+++ b/drake/solvers/dreal_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/dreal_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/gurobi_solver_common.cc
+++ b/drake/solvers/gurobi_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/gurobi_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/ipopt_solver_common.cc
+++ b/drake/solvers/ipopt_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/ipopt_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/mathematical_program_api.cc
+++ b/drake/solvers/mathematical_program_api.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/mathematical_program.h"
+/* clang-format on */
 
 #include <sstream>
 #include <stdexcept>

--- a/drake/solvers/mosek_solver_common.cc
+++ b/drake/solvers/mosek_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/mosek_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/nlopt_solver_common.cc
+++ b/drake/solvers/nlopt_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/nlopt_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/no_dreal.cc
+++ b/drake/solvers/no_dreal.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/dreal_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/no_gurobi.cc
+++ b/drake/solvers/no_gurobi.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/gurobi_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/no_ipopt.cc
+++ b/drake/solvers/no_ipopt.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/ipopt_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/no_mosek.cc
+++ b/drake/solvers/no_mosek.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/mosek_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/no_nlopt.cc
+++ b/drake/solvers/no_nlopt.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/nlopt_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/no_snopt.cc
+++ b/drake/solvers/no_snopt.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/snopt_solver.h"
 /* clang-format on */
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/rotation_constraint.h"
 #include "drake/solvers/rotation_constraint_internal.h"
 /* clang-format on */

--- a/drake/solvers/snopt_solver_common.cc
+++ b/drake/solvers/snopt_solver_common.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/snopt_solver.h"
+/* clang-format on */
 
 #include "drake/common/never_destroyed.h"
 

--- a/drake/solvers/test/linear_complementary_problem_test.cc
+++ b/drake/solvers/test/linear_complementary_problem_test.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/mathematical_program.h"
 /* clang-format on */
 

--- a/drake/solvers/test/plot_rotation_mccormick_envelope.cc
+++ b/drake/solvers/test/plot_rotation_mccormick_envelope.cc
@@ -1,4 +1,4 @@
-/* clang-format off */
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/test/rotation_constraint_visualization.h"
 /* clang-format on */
 

--- a/drake/solvers/test/rotation_constraint_internal_test.cc
+++ b/drake/solvers/test/rotation_constraint_internal_test.cc
@@ -1,5 +1,7 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/rotation_constraint.h"
 #include "drake/solvers/rotation_constraint_internal.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/solvers/test/rotation_constraint_limit_test.cc
+++ b/drake/solvers/test/rotation_constraint_limit_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/rotation_constraint.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -1,6 +1,4 @@
-/* clang-format off */
 #include "drake/solvers/rotation_constraint.h"
-/* clang-format on */
 
 #include <random>
 

--- a/drake/solvers/test/sos_constraint_test.cc
+++ b/drake/solvers/test/sos_constraint_test.cc
@@ -1,4 +1,6 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/solvers/mathematical_program.h"
+/* clang-format on */
 
 #include <gtest/gtest.h>
 

--- a/drake/systems/framework/test/output_port_test.cc
+++ b/drake/systems/framework/test/output_port_test.cc
@@ -1,6 +1,8 @@
+/* clang-format off to disable clang-format-includes */
 #include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/leaf_output_port.h"
+/* clang-format on */
 
 #include <memory>
 #include <stdexcept>

--- a/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -1,5 +1,3 @@
-#include "drake/systems/sensors/image_to_lcm_image_array_t.h"
-
 #include <string>
 
 #include <gflags/gflags.h>
@@ -15,6 +13,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
 #include "drake/systems/rendering/pose_stamped_t_pose_vector_translator.h"
+#include "drake/systems/sensors/image_to_lcm_image_array_t.h"
 #include "drake/systems/sensors/rgbd_camera.h"
 
 using std::cout;

--- a/drake/tools/formatter.py
+++ b/drake/tools/formatter.py
@@ -123,13 +123,13 @@ class FormatterBase(object):
             if '// clang-format off' in line:
                 clang_format_on = False
                 continue
-            if '/* clang-format off */' in line:
+            if '/* clang-format off' in line:
                 clang_format_on = False
                 continue
             elif '// clang-format on' in line:
                 clang_format_on = True
                 continue
-            elif '/* clang-format on */' in line:
+            elif '/* clang-format on' in line:
                 clang_format_on = True
                 continue
             if self.should_format(clang_format_on, index, line):

--- a/drake/tools/test/formatter_test.py
+++ b/drake/tools/test/formatter_test.py
@@ -240,10 +240,22 @@ namespace { }
     def test_internal_related_header(self):
         # Two related headers, guarded by "clang-format off".
         original = """
-/* clang-format off */
+/* clang-format off (with explanatory comment) */
 #include "drake/dummy/dut.h"
 #include "drake/dummy/dut_internal.h"
-/* clang-format on */
+/* clang-format on  (with explanatory comment) */
+
+#include <vector>
+#include <string>
+
+#include "drake/dummy/drake_assert.h"
+#include "drake/dummy/drake_deprecated.h"
+"""
+        expected = """
+/* clang-format off (with explanatory comment) */
+#include "drake/dummy/dut.h"
+#include "drake/dummy/dut_internal.h"
+/* clang-format on  (with explanatory comment) */
 
 #include <string>
 #include <vector>
@@ -251,7 +263,7 @@ namespace { }
 #include "drake/dummy/drake_assert.h"
 #include "drake/dummy/drake_deprecated.h"
 """
-        self._check("dut.cc", original, original)
+        self._check("dut.cc", original, expected)
 
     def test_resort_solo_groups(self):
         # Groups of one, but sorted uncorrectly.


### PR DESCRIPTION
Also run clang-format-includes to catch a few other recent strays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6651)
<!-- Reviewable:end -->
