### PR TITLE
Use clang-format-3.9 or newer

### DIFF
--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -45,22 +45,13 @@ Clang-Format
 Installation
 ^^^^^^^^^^^^
 
-On Ubuntu, first determine which versions are available::
+Follow the
+:ref:`Mandatory platform specific instructions <platform_specific_setup>`.
 
-    apt-cache search clang-format
+On Ubuntu, you may also wish to create an alias (assuming ``$HOME/bin`` is
+already on your ``$PATH``)::
 
-Then install the version you prefer::
-
-    sudo apt-get install clang-format-[version]
-
-Once installed, create a symbolic link so you don't need to type the version
-number every time you execute it::
-
-    sudo ln -s /usr/bin/clang-format-[version] /usr/local/bin/clang-format
-
-On OSX::
-
-    brew install clang-format
+    ln -s /usr/bin/clang-format-3.9 $HOME/bin/clang-format
 
 You can check whether you've installed it correctly by executing::
 

--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -29,7 +29,7 @@ Clang 3.9::
     sudo add-apt-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
     sudo apt-get update
     sudo apt-get upgrade
-    sudo apt-get install clang-3.9 gfortran
+    sudo apt-get install clang-3.9 clang-format-3.9 gfortran
 
 .. _cmake:
 

--- a/drake/tools/formatter.py
+++ b/drake/tools/formatter.py
@@ -166,6 +166,12 @@ class FormatterBase(object):
     def get_non_format_ranges(self):
         return self.indices_to_ranges(self.get_non_format_indices())
 
+    def _get_clang_format_path(self):
+        preferred = "/usr/bin/clang-format-3.9"
+        if os.path.isfile(preferred):
+            return preferred
+        return "clang-format"
+
     def clang_format(self):
         """Reformat the working list using clang-format, passing -lines=...
         groups for only the lines that pass the should_format() predicate.
@@ -178,7 +184,7 @@ class FormatterBase(object):
 
         # Run clang-format.
         command = [
-            "clang-format",
+            self._get_clang_format_path(),
             "-style=file",
             "-assume-filename=%s" % self._filename] + \
             lines_args

--- a/drake/tools/lcm_vector_gen.sh
+++ b/drake/tools/lcm_vector_gen.sh
@@ -23,7 +23,12 @@ workspace=$(dirname "$drake")
 mkdir -p $drake/lcmtypes
 mkdir -p $mydir/gen
 
-CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
+if [ -z "$CLANG_FORMAT" ]; then
+    CLANG_FORMAT="/usr/bin/clang-format-3.9"  # Preferred choice.
+    if [ ! -x "$CLANG_FORMAT" ]; then
+        CLANG_FORMAT=clang-format
+    fi
+fi
 if ! type -p $CLANG_FORMAT > /dev/null ; then
     cat <<EOF
 Cannot find $CLANG_FORMAT ; see installation instructions at:

--- a/drake/tools/test/lcm_vector_gen_test.sh
+++ b/drake/tools/test/lcm_vector_gen_test.sh
@@ -6,6 +6,21 @@ set -ex
 # Dump some debugging output.
 find .
 
+# TODO(jwnimmer-tri) De-duplicate this with lcm_vector_gen.sh.
+if [ -z "$CLANG_FORMAT" ]; then
+    CLANG_FORMAT="/usr/bin/clang-format-3.9"  # Preferred choice.
+    if [ ! -x "$CLANG_FORMAT" ]; then
+        CLANG_FORMAT=clang-format
+    fi
+fi
+if ! type -p $CLANG_FORMAT > /dev/null ; then
+    cat <<EOF
+Cannot find $CLANG_FORMAT ; see installation instructions at:
+http://drake.mit.edu/code_style_tools.html
+EOF
+    exit 1
+fi
+
 # Move the originals (which are symlinks) out of the way.
 tool_outputs="lcmt_sample_t.lcm sample.cc sample.h sample_translator.cc sample_translator.h"
 for item in $tool_outputs; do
@@ -26,9 +41,8 @@ done
 find drake/tools/test/gen
 
 # Re-format the code.
-# TODO(jwnimmer-tri) De-duplicate this with lcm_vector_gen.sh.
 for item in $tool_outputs; do
-    clang-format --style=file -i drake/tools/test/gen/"$item"
+    $CLANG_FORMAT --style=file -i drake/tools/test/gen/"$item"
 done
 
 # Insist that the generated output matches the current copy in git.

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -30,7 +30,7 @@ while true; do
       wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
       add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main"
       apt-get update
-      apt install --no-install-recommends clang-3.9 lldb-3.9
+      apt install --no-install-recommends clang-3.9 lldb-3.9 clang-format-3.9
       break
       ;;
     [Nn]*) break ;;
@@ -63,7 +63,6 @@ autoconf
 automake
 bash-completion
 bison
-clang-format
 doxygen
 fakeroot
 flex


### PR DESCRIPTION
It turns out that Xenial's default clang-format (3.8) meaningfully differs from 3.9 with respect to the "related header" include statements.  Since we want to have the build system enforce clang-format-includes, we need to have consistency, so settle on 3.9 which is the same on Trusty and OS X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6652)
<!-- Reviewable:end -->
