### PR TITLE
cast() methods for inertia classes.

### DIFF
--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -204,6 +204,7 @@ drake_cc_googletest(
     name = "unit_inertia_test",
     deps = [
         ":unit_inertia",
+        "//drake/math:gradient",
     ],
 )
 

--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -130,7 +130,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "rotational_inertia",
-    srcs = [],
+    srcs = ["rotational_inertia.cc"],
     hdrs = ["rotational_inertia.h"],
     deps = [
         "//drake/common",
@@ -141,7 +141,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "spatial_inertia",
-    srcs = [],
+    srcs = ["spatial_inertia.cc"],
     hdrs = ["spatial_inertia.h"],
     deps = [
         ":unit_inertia",
@@ -152,7 +152,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "unit_inertia",
-    srcs = [],
+    srcs = ["unit_inertia.cc"],
     hdrs = ["unit_inertia.h"],
     deps = [
         ":rotational_inertia",
@@ -189,6 +189,7 @@ drake_cc_googletest(
     deps = [
         ":rotational_inertia",
         "//drake/common:autodiff",
+        "//drake/math:gradient",
     ],
 )
 

--- a/drake/multibody/multibody_tree/rotational_inertia.cc
+++ b/drake/multibody/multibody_tree/rotational_inertia.cc
@@ -1,0 +1,13 @@
+#include "drake/multibody/multibody_tree/rotational_inertia.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace multibody {
+
+// Explicitly instantiates on the most common scalar types.
+template class RotationalInertia<double>;
+template class RotationalInertia<AutoDiffXd>;
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/rotational_inertia.h
+++ b/drake/multibody/multibody_tree/rotational_inertia.h
@@ -395,10 +395,12 @@ class RotationalInertia {
   /// @tparam Scalar The scalar type on which the new rotational inertia will
   /// be templated.
   ///
-  /// @note The cast is only valid when `Scalar` has a valid constructor from
-  /// the scalar type `T` on which `this` object is templated.
-  /// For instance, RotationalInertia<double>::cast<AutoDiffXd>() is valid.
-  /// However, RotationalInertia<AutoDiffXd>::cast<double>() is not.
+  /// @note `RotationalInertia<From>::cast<To>()` creates a new
+  /// `RotationalInertia<To>` from a `RotationalInertia<From>` but only if
+  /// type `To` is constructible from type `From`. As an example of this,
+  /// `RotationalInertia<double>::cast<AutoDiffXd>()` is valid since
+  /// `AutoDiffXd a(1.0)` is valid. However,
+  /// `RotationalInertia<AutoDiffXd>::cast<double>()` is not.
   template <typename Scalar>
   RotationalInertia<Scalar> cast() const {
     return RotationalInertia<Scalar>(I_SP_E_.template cast<Scalar>());
@@ -741,15 +743,15 @@ class RotationalInertia {
 
   // Constructor from an Eigen expression that represents a matrix in ℝ³ˣ³ with
   // entries corresponding to inertia moments and products as described in this
-  // class' documentation. This constructor will assert that I is a 3x3 matrix.
+  // class's documentation. This constructor will assert that I is a 3x3 matrix.
   // For internal use only.
   template <typename I_Type>
   explicit RotationalInertia(const Eigen::MatrixBase<I_Type>& I) {
     EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Eigen::MatrixBase<I_Type>, 3, 3);
     // Input matrix must be templated on the same scalar type as this inertia.
     static_assert(std::is_same<typename I_Type::Scalar, T>::value,
-                  "I must be templated on the same scalar type as this"
-                  "rotational inertia");
+                  "Input argument I must be templated on the same scalar type "
+                  "as this rotational inertia");
     I_SP_E_ = I;
     DRAKE_ASSERT_VOID(ThrowIfNotPhysicallyValid());
   }

--- a/drake/multibody/multibody_tree/spatial_inertia.cc
+++ b/drake/multibody/multibody_tree/spatial_inertia.cc
@@ -1,0 +1,13 @@
+#include "drake/multibody/multibody_tree/spatial_inertia.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace multibody {
+
+// Explicitly instantiates on the most common scalar types.
+template class SpatialInertia<double>;
+template class SpatialInertia<AutoDiffXd>;
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/spatial_inertia.h
+++ b/drake/multibody/multibody_tree/spatial_inertia.h
@@ -77,6 +77,12 @@ namespace multibody {
 ///                algorithms. Springer Science & Business Media.
 ///
 /// @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// They are already available to link against in the containing library.
 template <typename T>
 class SpatialInertia {
  public:
@@ -108,6 +114,24 @@ class SpatialInertia {
       const T& mass, const Vector3<T>& p_PScm_E, const UnitInertia<T>& G_SP_E) :
       mass_(mass), p_PScm_E_(p_PScm_E), G_SP_E_(G_SP_E) {
     CheckInvariants();
+  }
+
+  /// Returns a new %SpatialInertia object templated on `Scalar` initialized
+  /// from the value of `this` spatial inertia.
+  ///
+  /// @tparam Scalar The scalar type on which the new spatial inertia will
+  /// be templated.
+  ///
+  /// @note The cast is only valid when `Scalar` has a valid constructor from
+  /// the scalar type `T` on which `this` object is templated.
+  /// For instance, SpatialInertia<double>::cast<AutoDiffXd>() is valid.
+  /// However, SpatialInertia<AutoDiffXd>::cast<double>() is not.
+  template <typename Scalar>
+  SpatialInertia<Scalar> cast() const {
+    return SpatialInertia<Scalar>(
+        get_mass(),
+        get_com().template cast<Scalar>(),
+        get_unit_inertia().template cast<Scalar>());
   }
 
   /// Get a constant reference to the mass of this spatial inertia.

--- a/drake/multibody/multibody_tree/spatial_inertia.h
+++ b/drake/multibody/multibody_tree/spatial_inertia.h
@@ -318,28 +318,6 @@ class SpatialInertia {
     return SpatialInertia(*this).ShiftInPlace(p_PQ_E);
   }
 
-  /// Multiplies `this` spatial inertia `M_Bo_E` of a body B about it's frame
-  /// origin `Bo` by the spatial acceleration of the body frame B in a frame W.
-  /// Mathematically: <pre>
-  ///   F_Bo_E = M_Bo_E * A_WB_E
-  /// </pre>
-  /// or, in terms of its rotational and translational components: <pre>
-  ///   t_Bo = I_Bo * alpha_WB + m * p_BoBcm x a_WBo
-  ///   f_Bo = -m * p_BoBcm x alpha_WB + m * a_WBo
-  /// </pre>
-  /// where `alpha_WB` and `a_WBo` are the rotational and translational
-  /// components of the spatial acceleration `A_WB`, respectively.
-  SpatialForce<T> operator*(const SpatialAcceleration<T>& A_WB_E) const {
-    const Vector3<T>& alpha_WB_E = A_WB_E.rotational();
-    const Vector3<T>& a_WBo_E = A_WB_E.translational();
-    const Vector3<T>& mp_BoBcm_E = CalcComMoment();
-    return SpatialForce<T>(
-        /* rotational */
-        CalcRotationalInertia() * alpha_WB_E + mp_BoBcm_E.cross(a_WBo_E),
-        /* translational */
-        alpha_WB_E.cross(mp_BoBcm_E) + get_mass() * a_WBo_E);
-  }
-
  private:
   // Helper method for NaN initialization.
   static constexpr T nan() {

--- a/drake/multibody/multibody_tree/test/rotational_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/rotational_inertia_test.cc
@@ -519,12 +519,14 @@ GTEST_TEST(RotationalInertia, ShiftOperator) {
   EXPECT_EQ(expected_string, stream.str());
 }
 
-// Tests that we can cast a RotationalInertia<double> to a RotationalInertia
-// templated on an AutoDiffScalar type.
+// Tests that we can correctly cast a RotationalInertia<double> to a
+// RotationalInertia templated on an AutoDiffScalar type.
+// The cast from a RotationalInertia<double>, a constant, results in a
+// rotational inertia with zero gradients.
 GTEST_TEST(RotationalInertia, CastToAutoDiff) {
-  typedef Eigen::AutoDiffScalar<Vector1<double>> ADScalar;
+  typedef Eigen::AutoDiffScalar<Vector1<double>> AutoDiff1d;
   const RotationalInertia<double> I_double(1, 2.718, 3.14);
-  const RotationalInertia<ADScalar> I_autodiff(1, 2.718, 3.14);
+  const RotationalInertia<AutoDiff1d> I_autodiff(1, 2.718, 3.14);
 
   // Verify derivatives are zero.
   const auto& m_gradients =
@@ -535,10 +537,10 @@ GTEST_TEST(RotationalInertia, CastToAutoDiff) {
   EXPECT_TRUE(p_gradients.isZero(kEpsilon));
 
   // Cast from double to AutoDiffScalar.
-  const RotationalInertia<ADScalar> I_cast = I_double.cast<ADScalar>();
+  const RotationalInertia<AutoDiff1d> I_cast = I_double.cast<AutoDiff1d>();
   EXPECT_TRUE(I_autodiff.IsNearlyEqualTo(I_cast, kEpsilon));
 
-  const Matrix3<ADScalar> I_autodiff_matrix = I_cast.CopyToFullMatrix3();
+  const Matrix3<AutoDiff1d> I_autodiff_matrix = I_cast.CopyToFullMatrix3();
   auto I_value = drake::math::autoDiffToValueMatrix(I_autodiff_matrix);
   I_value.resize(3, 3);
   EXPECT_TRUE(I_value.isApprox(I_double.CopyToFullMatrix3(), kEpsilon));
@@ -565,12 +567,12 @@ GTEST_TEST(RotationalInertia, CastToAutoDiff) {
 // We then re-express the inertia of B in the world frame and verify the value
 // of its time derivative with the expected result.
 GTEST_TEST(RotationalInertia, AutoDiff) {
-  typedef Eigen::AutoDiffScalar<Vector1<double>> ADScalar;
+  typedef Eigen::AutoDiffScalar<Vector1<double>> AutoDiff1d;
 
   // Helper lambda to extract from a matrix of auto-diff scalar's the matrix of
   // values and the matrix of derivatives.
   auto extract_derivatives = [](
-      const Matrix3<ADScalar>& M, Matrix3d& Mvalue, Matrix3d& Mdot) {
+      const Matrix3<AutoDiff1d>& M, Matrix3d& Mvalue, Matrix3d& Mdot) {
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
         Mvalue(i, j) = M(i, j).value();
@@ -581,17 +583,17 @@ GTEST_TEST(RotationalInertia, AutoDiff) {
 
   // Construct a rotational inertia in the frame of a body B.
   const double Ix(1.0), Iy(2.0), Iz(3.0);
-  RotationalInertia<ADScalar> I_B(Ix, Iy, Iz);
+  RotationalInertia<AutoDiff1d> I_B(Ix, Iy, Iz);
 
   // Assume B has a pose rotated +20 degrees about z with respect to the
   // world frame W. The body rotates with angular velocity wz in the z-axis.
   const double angle_value = 20 * M_PI / 180.0;
   const double wz = 1.0;  // Angular velocity in the z-axis.
 
-  ADScalar angle = angle_value;
+  AutoDiff1d angle = angle_value;
   angle.derivatives()[0] = wz;
-  const Matrix3<ADScalar> R_WB =
-      (AngleAxis<ADScalar>(angle, Vector3d::UnitZ())).toRotationMatrix();
+  const Matrix3<AutoDiff1d> R_WB =
+      (AngleAxis<AutoDiff1d>(angle, Vector3d::UnitZ())).toRotationMatrix();
 
   // Split the rotational inertia into two Matrix3d; one with the values and
   // another one with the time derivatives.
@@ -609,7 +611,7 @@ GTEST_TEST(RotationalInertia, AutoDiff) {
   EXPECT_TRUE(wcross.isApprox(wcross_expected, kEpsilon));
 
   // Re-express inertia into another frame.
-  const RotationalInertia<ADScalar> I_W = I_B.ReExpress(R_WB);
+  const RotationalInertia<AutoDiff1d> I_W = I_B.ReExpress(R_WB);
 
   // Extract value and derivatives of I_W into two separate matrices.
   Matrix3d Ivalue_W, Idot_W;
@@ -637,9 +639,9 @@ GTEST_TEST(RotationalInertia, AutoDiff) {
 
   // Test method that compares to inertia matrices using the original rotational
   // inertia and then the rotated/semi-unrotated rotational inertia.
-  const Matrix3<ADScalar> R_BW =
-      (AngleAxis<ADScalar>(-angle, Vector3d::UnitZ())).toRotationMatrix();
-  const RotationalInertia<ADScalar> expectedI_B = I_W.ReExpress(R_BW);
+  const Matrix3<AutoDiff1d> R_BW =
+      (AngleAxis<AutoDiff1d>(-angle, Vector3d::UnitZ())).toRotationMatrix();
+  const RotationalInertia<AutoDiff1d> expectedI_B = I_W.ReExpress(R_BW);
   EXPECT_TRUE(expectedI_B.IsNearlyEqualTo(I_B, kEpsilon));
 }
 

--- a/drake/multibody/multibody_tree/test/spatial_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/spatial_inertia_test.cc
@@ -68,8 +68,11 @@ GTEST_TEST(SpatialInertia, ConstructionFromMasComAndUnitInertia) {
   EXPECT_TRUE(M.IsNaN());
 }
 
-// Tests that we can cast a SpatialInertia<double> to a SpatialInertia
-// templated on an AutoDiffScalar type.
+// Tests that we can correctly cast a SpatialInertia<double> to a
+// SpatialInertia<AutoDiffXd>.
+// The cast from a SpatialInertia<double>, a constant, results in a spatial
+// inertia with zero gradients. Since we are using a dynamic size
+// AutoDiffScalar type, this results in gradient vectors with zero size.
 GTEST_TEST(SpatialInertia, CastToAutoDiff) {
   const double mass_double = 2.5;
   const Vector3d com_double(0.1, -0.2, 0.3);

--- a/drake/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -241,8 +241,10 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
   EXPECT_TRUE(G3.CouldBePhysicallyValid());
 }
 
-// Tests that we can cast a RotationalInertia<double> to a RotationalInertia
+// Tests that we can correctly cast a UnitInertia<double> to a UnitInertia
 // templated on an AutoDiffScalar type.
+// The cast from a UnitInertia<double>, a constant, results in a unit inertia
+// with zero gradients.
 GTEST_TEST(UnitInertia, CastToAutoDiff) {
   typedef Eigen::AutoDiffScalar<Vector1<double>> ADScalar;
   const UnitInertia<double> I_double(1, 2.718, 3.14);

--- a/drake/multibody/multibody_tree/unit_inertia.cc
+++ b/drake/multibody/multibody_tree/unit_inertia.cc
@@ -1,0 +1,13 @@
+#include "drake/multibody/multibody_tree/unit_inertia.h"
+
+#include "drake/common/eigen_autodiff_types.h"
+
+namespace drake {
+namespace multibody {
+
+// Explicitly instantiates on the most common scalar types.
+template class UnitInertia<double>;
+template class UnitInertia<AutoDiffXd>;
+
+}  // namespace multibody
+}  // namespace drake

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -31,6 +31,12 @@ namespace multibody {
 /// of _some_ body, perhaps with scaled geometry from the user's intention.
 ///
 /// @tparam T The underlying scalar type. Must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// They are already available to link against in the containing library.
 template <typename T>
 class UnitInertia : public RotationalInertia<T> {
  public:
@@ -63,6 +69,21 @@ class UnitInertia : public RotationalInertia<T> {
   /// It is the responsibility of the user to pass a valid unit inertia.
   explicit UnitInertia(const RotationalInertia<T>& I)
       : RotationalInertia<T>(I) {}
+
+  /// Returns a new %UnitInertia object templated on `Scalar` initialized
+  /// from the value of `this` unit inertia.
+  ///
+  /// @tparam Scalar The scalar type on which the new unit inertia will
+  /// be templated.
+  ///
+  /// @note The cast is only valid when `Scalar` has a valid constructor from
+  /// the scalar type `T` on which `this` object is templated.
+  /// For instance, UnitInertia<double>::cast<AutoDiffXd>() is valid.
+  /// However, UnitInertia<AutoDiffXd>::cast<double>() is not.
+  template <typename Scalar>
+  UnitInertia<Scalar> cast() const {
+    return UnitInertia<Scalar>(RotationalInertia<T>::template cast<Scalar>());
+  }
 
   /// Sets `this` unit inertia from a generally non-unit inertia I corresponding
   /// to a body with a given `mass`.

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -76,10 +76,12 @@ class UnitInertia : public RotationalInertia<T> {
   /// @tparam Scalar The scalar type on which the new unit inertia will
   /// be templated.
   ///
-  /// @note The cast is only valid when `Scalar` has a valid constructor from
-  /// the scalar type `T` on which `this` object is templated.
-  /// For instance, UnitInertia<double>::cast<AutoDiffXd>() is valid.
-  /// However, UnitInertia<AutoDiffXd>::cast<double>() is not.
+  /// @note `UnitInertia<From>::cast<To>()` creates a new
+  /// `UnitInertia<To>` from a `UnitInertia<From>` but only if
+  /// type `To` is constructible from type `From`. As an example of this,
+  /// `UnitInertia<double>::cast<AutoDiffXd>()` is valid since
+  /// `AutoDiffXd a(1.0)` is valid. However,
+  /// `UnitInertia<AutoDiffXd>::cast<double>()` is not.
   template <typename Scalar>
   UnitInertia<Scalar> cast() const {
     return UnitInertia<Scalar>(RotationalInertia<T>::template cast<Scalar>());


### PR DESCRIPTION
Similarly to Eigen classes having a `cast()` method, this PR introduces `cast()` methods for `RotationalInertia`, `UnitInertia` and `SpatialInertia`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6656)
<!-- Reviewable:end -->
