### PR TITLE
Parameterize ConstantVectorSource

### DIFF
--- a/drake/systems/primitives/constant_vector_source.cc
+++ b/drake/systems/primitives/constant_vector_source.cc
@@ -11,14 +11,14 @@ namespace systems {
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(
     const Eigen::Ref<const VectorX<T>>& source_value)
-    : SingleOutputVectorSource<T>(source_value.rows()),
-      source_value_(source_value) {}
+    : ConstantVectorSource(BasicVector<T>(source_value)) {}
 
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(
     const BasicVector<T>& source_value)
-    : SingleOutputVectorSource<T>(source_value),
-      source_value_(source_value.get_value()) {}
+    : SingleOutputVectorSource<T>(source_value) {
+  source_value_index_ = this->DeclareNumericParameter(source_value);
+}
 
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(const T& source_value)
@@ -29,8 +29,20 @@ ConstantVectorSource<T>::~ConstantVectorSource() = default;
 
 template <typename T>
 void ConstantVectorSource<T>::DoCalcVectorOutput(
-    const Context<T>&, Eigen::VectorBlock<VectorX<T>>* output) const {
-  *output = source_value_;
+    const Context<T>& context, Eigen::VectorBlock<VectorX<T>>* output) const {
+  *output = get_source_value(context).get_value();
+}
+
+template <typename T>
+const BasicVector<T>& ConstantVectorSource<T>::get_source_value(
+    const Context<T>& context) const {
+  return this->GetNumericParameter(context, source_value_index_);
+}
+
+template <typename T>
+BasicVector<T>* ConstantVectorSource<T>::get_mutable_source_value(
+    Context<T>* context) {
+  return this->GetMutableNumericParameter(context, source_value_index_);
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -9,7 +9,8 @@
 namespace drake {
 namespace systems {
 
-/// A source block with a constant output port at all times.
+/// A source block with a constant output port at all times. The value of the
+/// output port is a parameter of the system (see Parameters).
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 /// @ingroup primitive_systems
 ///
@@ -44,14 +45,21 @@ class ConstantVectorSource : public SingleOutputVectorSource<T> {
 
   ~ConstantVectorSource() override;
 
+  /// Return a read-only reference to the source value of this block in the
+  /// given @p context.
+  const BasicVector<T>& get_source_value(const Context<T>& context) const;
+
+  /// Return a mutable pointer to the source value of this block in the given
+  /// @p context.
+  BasicVector<T>* get_mutable_source_value(Context<T>* context);
+
  private:
   // Outputs a signal with a fixed value as specified by the user.
   void DoCalcVectorOutput(
       const Context<T>& context,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
 
-  // TODO(amcastro-tri): move source_value_ to the system's parameters.
-  const VectorX<T> source_value_;
+  int source_value_index_{};
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/primitives/test/constant_vector_source_test.cc
@@ -51,6 +51,19 @@ TEST_F(ConstantVectorSourceTest, EigenModel) {
   const auto& output_basic = output_->GetValueOrThrow<BasicVector<double>>();
   EXPECT_TRUE(kConstantVectorSource.isApprox(
       output_basic.get_value(), Eigen::NumTraits<double>::epsilon()));
+
+  // Tests that the output reflects changes to the parameter value in the
+  // context.
+  BasicVector<double>* source_value =
+      static_cast<ConstantVectorSource<double>*>(source_.get())
+          ->get_mutable_source_value(context_.get());
+  source_value->SetFromVector(2.0 * source_value->get_value());
+
+  source_->get_output_port(0).Calc(*context_, output_.get());
+
+  const auto& output_basic_2 = output_->GetValueOrThrow<BasicVector<double>>();
+  EXPECT_TRUE(kConstantVectorSource.isApprox(
+      0.5 * output_basic_2.get_value(), Eigen::NumTraits<double>::epsilon()));
 }
 
 // Tests that the output of the ConstantVectorSource is correct with a
@@ -63,10 +76,24 @@ TEST_F(ConstantVectorSourceTest, BasicVectorModel) {
   source_->get_output_port(0).Calc(*context_, output_.get());
   const auto& output_basic = output_->GetValueOrThrow<BasicVector<double>>();
 
-  auto output_vector =
-      dynamic_cast<const MyVector<3, double>*>(&output_basic);
+  auto output_vector = dynamic_cast<const MyVector<3, double>*>(&output_basic);
   ASSERT_NE(nullptr, output_vector);
   EXPECT_EQ(43.0, output_vector->GetAtIndex(1));
+
+  // Tests that the output reflects changes to the parameter value in the
+  // context.
+  BasicVector<double>* source_value =
+      static_cast<ConstantVectorSource<double>*>(source_.get())
+          ->get_mutable_source_value(context_.get());
+  source_value->SetFromVector(2.0 * source_value->get_value());
+
+  source_->get_output_port(0).Calc(*context_, output_.get());
+
+  const auto& output_basic_2 = output_->GetValueOrThrow<BasicVector<double>>();
+  auto output_vector_2 =
+      dynamic_cast<const MyVector<3, double>*>(&output_basic_2);
+  ASSERT_NE(nullptr, output_vector_2);
+  EXPECT_EQ(43.0, 0.5 * output_vector_2->GetAtIndex(1));
 }
 
 // Tests that ConstantVectorSource allocates no state variables in its context.


### PR DESCRIPTION
This PR replaces the `source_value_` member variable in `ConstantVectorSource` with a numeric parameter. This allows one diagram to represent a family of models that differ only in the value of the source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6660)
<!-- Reviewable:end -->
