### PR TITLE
adds gramBasis

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -122,6 +122,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "sos_util",
+    srcs = ["sos_util.cc"],
+    hdrs = ["sos_util.h"],
+    deps = [
+        "//drake/common",
+        "//drake/common:symbolic",
+    ],
+)
+
+drake_cc_library(
     name = "indeterminate",
     srcs = ["indeterminate.cc"],
     hdrs = ["indeterminate.h"],
@@ -188,6 +198,7 @@ drake_cc_library(
         ":nlopt_solver",
         ":snopt_solver",
         ":solver_id",
+        ":sos_util",
         ":symbolic_extraction",
         "//drake/common",
         "//drake/common:autodiff",
@@ -643,6 +654,13 @@ drake_cc_googletest(
         ":symbolic_extraction",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:symbolic_test_util",
+    ],
+)
+
+drake_cc_googletest(
+    name = "sos_util_test",
+    deps = [
+        ":sos_util",
     ],
 )
 

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND optimization_files
   snopt_solver_common.cc
   solver_id.cc
   solver_type_converter.cc
+  sos_util.cc
   symbolic_extraction.cc
   system_identification.cc
   )
@@ -70,6 +71,7 @@ drake_install_headers(
   mathematical_program_solver_interface.h
   decision_variable.h
   indeterminate.h
+  sos_util.h
   symbolic_extraction.h
   system_identification.h
   )

--- a/drake/solvers/sos_util.cc
+++ b/drake/solvers/sos_util.cc
@@ -1,0 +1,303 @@
+#include "drake/solvers/sos_util.h"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <random>
+#include <set>
+#include <string>
+#include <utility>
+
+#include <Eigen/Core>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/hash.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace solvers {
+
+using std::map;
+using std::set;
+using Eigen::MatrixXi;
+using Eigen::VectorXi;
+using symbolic::Monomial;
+using symbolic::Variable;
+using symbolic::Variables;
+
+VectorX<Monomial> ConstructGramBasis(const symbolic::Polynomial& p) {
+  if (p.TotalDegree() % 2 == 1) {  // catches off polynomials
+    // TODO(FischerGundlach) Catch all obvious non-SOS polynomial, i.e.
+    // x_0^3*x_1^5 is clearly not SOS.
+    throw std::runtime_error("Polynomial is odd and thus can't be SOS.");
+  } else if (p.indeterminates().empty()) {  // catches constant polynomials
+    // TODO(FischerGundlach) According to Eigen documentation, this should take
+    // a reference, i,e. Matrix (const Scalar &x). Why does it take the rvalue
+    // reference?
+    return Vector1<Monomial>(Monomial());
+  } else {
+    std::pair<MatrixXi, map<Variable, int>> pair{
+        build_gram_basis::PolynomialToSupport(p)};
+    const MatrixXi pow{pair.first};
+    MatrixXi mpow{build_gram_basis::GenerateExponentBoundPolytope(pow)};
+
+    mpow = build_gram_basis::RandomlyPruneSupport(pow, mpow);
+    mpow = build_gram_basis::CheckDiagonalConsistency(pow, mpow);
+
+    return build_gram_basis::SupportToGramBasis(mpow, pair.second);
+  }
+}
+
+namespace build_gram_basis {
+
+MatrixXi GenerateCrossTerms(const MatrixXi& mpow) {
+  MatrixXi crossterms(symbolic::NChooseK(mpow.rows(), 2), mpow.cols());
+  int crossindex{0};
+  for (int i = 0; i < mpow.rows() - 1; ++i) {
+    for (int j = i + 1; j < mpow.rows(); ++j) {
+      crossterms.row(crossindex) = mpow.row(i) + mpow.row(j);
+      crossindex++;
+    }
+  }
+
+  return UniqueRows(crossterms);
+}
+
+MatrixXi CheckDiagonalConsistency(const MatrixXi& pow, MatrixXi mpow) {
+  // pow.cols() == mpow.cols(), otherwise they are not in the same amount of
+  // indeterminates
+  // mpow.rows() != 0 otherwise there are no monomials/ points in the support
+  // mpow.cols() != 0 otherwise, the monomials are in 0 indeterminates, i.e.
+  // the polynomial needs to be constant or of degree 1.
+  // These cases should be caught in ConstructGramBasis already.
+  DRAKE_ASSERT(pow.cols() == mpow.cols() && mpow.cols() != 0 &&
+               mpow.rows() != 0);
+
+  MatrixXi mpow_sqr{RowIntersect(2 * mpow, pow) / 2};
+
+  auto N = mpow.rows();
+  while (1) {
+    MatrixXi crossterms = GenerateCrossTerms(mpow);
+
+    if (crossterms.rows() != 0) {
+      // TODO(FischerGndlach) The following rows can be squashed + do I need
+      // temp?
+      MatrixXi intersect_terms = RowIntersect(2 * mpow, crossterms);
+      intersect_terms = intersect_terms / 2;
+      MatrixXi temp(mpow_sqr.rows() + intersect_terms.rows(), mpow.cols());
+
+      temp << mpow_sqr, intersect_terms;
+
+      mpow = UniqueRows(temp);
+    } else {
+      mpow = mpow_sqr;
+    }
+    // If the last iteration did not change the size, then break.
+    if (mpow.rows() == N) {
+      break;
+    } else {
+      N = mpow.rows();
+    }
+  }
+
+  return mpow;
+}
+
+MatrixXi GenerateExponentBoundPolytope(const MatrixXi& pow) {
+  // TODO(FischerGundlach) Implement quicker combinatorial creation (dont rely
+  // on the slow creation of monomialBasis).
+
+  // pow.rows() != 0 otherwise there are no monomials/ points in the support
+  // pow.cols() != 0 otherwise, the monomials are in 0 indeterminates, i.e.
+  // the polynomial must NOT be constant.
+  DRAKE_ASSERT(pow.cols() != 0 && pow.rows() != 0);
+
+  Variables indeterminates;
+  for (int i = 0; i < pow.cols(); ++i) {
+    indeterminates.insert(Variable(std::to_string(i)));
+  }
+  const int maximum_degree_in_pow{
+      (pow.rowwise().sum()).colwise().maxCoeff()[0]};
+  const int maximum_degree_in_m_pow{
+      static_cast<int>(std::floor(maximum_degree_in_pow / 2))};
+
+  // maximum_degree_in_m_pow >= 1 otherwise pow is constant or clearly not SOS.
+  DRAKE_ASSERT(maximum_degree_in_m_pow >= 1);
+
+  const VectorX<Monomial> m{
+      drake::symbolic::MonomialBasis(indeterminates, maximum_degree_in_m_pow)};
+  symbolic::Polynomial::MapType p_map;
+  for (int i = 0; i < m.size(); ++i) {
+    p_map.emplace(m(i), 1);
+  }
+
+  return PolynomialToSupport(symbolic::Polynomial(p_map)).first;
+}
+
+std::pair<MatrixXi, map<Variable, int>> PolynomialToSupport(
+    const symbolic::Polynomial& p) {
+  Variables indeterminates{p.indeterminates()};
+  map<Variable, int> variable_to_position_map;
+
+  int column{0};
+  for (Variables::iterator it = indeterminates.begin();
+       it != indeterminates.end(); ++it) {
+    variable_to_position_map.insert(std::pair<Variable, int>(*it, column));
+    ++column;
+  }
+
+  set<Monomial, symbolic::GradedReverseLexOrder<std::less<Variable>>>
+      monomials_in_poly;
+  for (auto& m : p.monomial_to_coefficient_map()) {
+    monomials_in_poly.insert(m.first);
+  }
+
+  MatrixXi support(monomials_in_poly.size(), indeterminates.size());
+  support *= 0;
+  int row{0};
+  for (auto& mono : monomials_in_poly) {
+    map<Variable, int> powers{mono.get_powers()};
+    for (auto variable_2_power : powers) {
+      support(row, variable_to_position_map[variable_2_power.first]) =
+          variable_2_power.second;
+    }
+    ++row;
+  }
+
+  return std::make_pair(support, variable_to_position_map);
+}
+
+MatrixXi RandomlyPruneSupport(const MatrixXi& pow, MatrixXi mpow,
+                              const int num_hyper_planes, const int seed) {
+  // pow.cols() == mpow.cols(), otherwise they are not in the same amount of
+  // indeterminates
+  // mpow.rows() != 0 otherwise there are no monomials/ points in the support
+  // mpow.cols() != 0 otherwise, the monomials are in 0 indeterminates, i.e.
+  // the polynomial needs to be constant or of degree 1.
+  // These cases should be caught in ConstructGramBasis already.
+  DRAKE_ASSERT(pow.cols() == mpow.cols() && mpow.cols() != 0 &&
+               mpow.rows() != 0);
+
+  VectorXi w{mpow.cols()};
+  VectorXi y{mpow.rows()};
+
+  MatrixXi new_mpow(mpow.rows(), mpow.cols());
+
+  double lower_bound, upper_bound;
+
+  // Seed and range [0,99] are chosen arbitrarily.
+  std::mt19937 mt(seed);
+  std::uniform_int_distribution<int> dist(0, 99);
+  for (int i = 0; i < num_hyper_planes; ++i) {
+    for (int j = 0; j < w.rows(); ++j) {
+      w(j) = dist(mt);
+    }
+    lower_bound = (pow * w).minCoeff();
+    upper_bound = (pow * w).maxCoeff();
+
+    y = 2 * (mpow * w);
+
+    // TODO(FischerGundlach) Rewrite this block to use remove row! (But maybe
+    // this implementation is quicker!)
+    // reduce rows so that if an entry of y is between the bounds, then keep
+    // that row. Otherwise, remove that row.
+    int exterior_rows = 0;
+    for (int k = 0; k < y.rows(); ++k) {
+      if (y(k) >= lower_bound && y(k) <= upper_bound) {
+        new_mpow.row(k - exterior_rows) = mpow.row(k);
+      } else {
+        exterior_rows++;
+      }
+    }
+    new_mpow.conservativeResize(y.rows() - exterior_rows, new_mpow.cols());
+
+    mpow = new_mpow;
+    if (mpow.rows() < 100) {
+      return mpow;
+    }
+  }
+  return mpow;
+}
+
+VectorX<Monomial> SupportToGramBasis(
+    const MatrixXi& mpow, const map<Variable, int>& variable_to_position_map) {
+  VectorX<Monomial> gram_basis(mpow.rows());
+
+  for (int i = 0; i < static_cast<int>(mpow.rows()); ++i) {
+    map<Variable, int> powers;
+    for (auto& m : variable_to_position_map) {
+      powers.insert(std::make_pair(m.first, mpow(i, m.second)));
+    }
+    gram_basis(i) = Monomial(powers);
+  }
+
+  return gram_basis;
+}
+
+// From here on definition of helper functions.
+
+MatrixXi RemoveRows(const MatrixXi& mat, const set<int>& rows_to_remove) {
+  MatrixXi reduced_matrix(mat.rows() - rows_to_remove.size(), mat.cols());
+  // now rows to remove is sorted, so populating reduced_matrix is easy
+  int removed_rows{0};
+  for (int i = 0; i < mat.rows(); i++) {
+    if (rows_to_remove.find(i) == (rows_to_remove.end())) {
+      reduced_matrix.row(i - removed_rows) = mat.row(i);
+    } else {
+      removed_rows++;
+    }
+  }
+
+  return reduced_matrix;
+}
+
+MatrixXi RowIntersect(const MatrixXi& mat1, const MatrixXi& mat2) {
+  if (mat1.cols() != mat2.cols()) {
+    return MatrixXi();
+  }
+
+  MatrixXi ret_mat(mat1.rows(), mat2.cols());
+  int num_match{0};
+  for (int i = 0; i < mat1.rows(); ++i) {
+    for (int j = 0; j < mat2.rows(); ++j) {
+      if (mat1.row(i) == mat2.row(j)) {
+        ret_mat.row(num_match) = mat1.row(i);
+        num_match++;
+      }
+    }
+  }
+
+  ret_mat.conservativeResize(num_match, ret_mat.cols());
+  return ret_mat;
+}
+
+MatrixXi UniqueRows(const MatrixXi& mat) {
+  set<int> row_duplicates;
+  bool no_row_duplicate{true};
+
+  // TODO(FischerGundlach) Look for faster ways to cull the duplicate rows, i.e.
+  // would it be better to remove the row immediately?
+  for (int i = 0; i < mat.rows() - 1; i++) {
+    for (int j = i + 1; j < mat.rows(); j++) {
+      if (mat.row(i) == mat.row(j)) {
+        row_duplicates.insert(j);
+        no_row_duplicate = false;
+      }
+    }
+  }
+
+  if (no_row_duplicate == true) {
+    return mat;
+  } else {
+    return RemoveRows(mat, row_duplicates);
+  }
+}
+
+}  // namespace build_gram_basis
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/sos_util.h
+++ b/drake/solvers/sos_util.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <map>
+#include <set>
+#include <utility>
+
+#include <Eigen/Core>
+
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace solvers {
+
+/** Returns a ConstructGramBasis for the polynomial @p. This gram basis is
+ preprocessed. @see
+ RandomlyPruneSupport and @see CheckDiagConsistency. */
+VectorX<symbolic::Monomial> ConstructGramBasis(const symbolic::Polynomial& p);
+
+namespace build_gram_basis {
+
+/** Returns 'crossterms' of the rows in @p mpow, i.e. returns row_i+row_j for
+ all i
+ != j.
+ The size of @param mpow is dictated as following:
+ the number of rows (length of colums) is equal to number of monomials and
+ the number of coloms (length of rows) are equal to number of variables.
+ Therefore, every row represents a monomial/point in the support. */
+Eigen::MatrixXi GenerateCrossTerms(const Eigen::MatrixXi& mpow);
+
+/** Checks diagonal consistency as in Lofberg, Johan. "Pre-and post-processing
+ sum-of-squares programs in practice." IEEE Transactions on Automatic Control
+ 54.5 (2009): 1007-1011.
+ This implementation is based on the MATLAB version
+ https://github.com/frankpermenter/spotless/blob/master/util/spot_build_gram_basis.m
+ The size of @param pow and @param mpow are dictated as following:
+ the number of rows (length of colums) is equal to number of monomials and
+ the number of coloms (length of rows) are equal to number of variables.
+ Therefore, every row represents a monomial/point in the support. */
+Eigen::MatrixXi CheckDiagonalConsistency(const Eigen::MatrixXi& pow,
+                                         Eigen::MatrixXi mpow);
+
+/** Returns a rough outer approximation of the needed monomial basis to
+ represent
+ the polynomial(pow) as SOS.
+ This implementation is based on the MATLAB version
+ https://github.com/spot-toolbox/spotless/blob/master/util/spot_exponent_bound_polytope.m
+ The size of @param pow is dictated as following:
+ the number of rows (length of columns) is equal to number of monomials and
+ the number of columns (length of rows) are equal to number of variables.
+ Therefore, every row represents a monomial/point in the support. */
+Eigen::MatrixXi GenerateExponentBoundPolytope(const Eigen::MatrixXi& pow);
+
+/** Returns a pair of the support of a polynomial( see: Lofberg, Johan. "Pre-and
+ post-processing sum-of-squares programs in practice." IEEE Transactions on
+ Automatic Control 54.5 (2009): 1007-1011.) and a mapping from variables to
+ column in support.
+ The size of the return Eigen::MatrixXi is dictated as following:
+ the number of rows (length of colums) is equal to number of monomials and
+ the number of coloms (length of rows) are equal to number of variables.
+ Therefore, every row represents a monomial in @param p/ point in the support.
+ */
+
+std::pair<Eigen::MatrixXi, std::map<symbolic::Variable, int>>
+PolynomialToSupport(const symbolic::Polynomial& p);
+
+/** Phase 1 in "Kojima, Masakazu, Sunyoung Kim, and Hayato Waki. "Sparsity in
+ sums of squares of polynomials." Mathematical Programming 103.1 (2005):
+ 45-62."
+
+ pow is the support of the polynomial p. @see PolynomialToSupport
+ mpow is an outer approximation of pow. @see GenerateExponentBoundPolytope
+ The size of @param pow and @param mpow are dictated as following:
+ the number of rows (length of colums) is equal to number of monomials and
+ the number of coloms (length of rows) are equal to number of variables.
+ Therefore, every row represents a monomial/point in the support.
+ @param num_hyper_planes The amount of planes drawn to seperate @param pow and
+ points in the support given by @param mpow.
+ Default number of hyperplanes is copied from spotless.
+ */
+Eigen::MatrixXi RandomlyPruneSupport(const Eigen::MatrixXi& pow,
+                                     Eigen::MatrixXi mpow,
+                                     int num_hyper_planes = 2000,
+                                     int seed = 9390);
+
+/** Returns a vector filled with monomials which represent rows of support. This
+ function reverses @see PolynomialToSupport*/
+drake::VectorX<symbolic::Monomial> SupportToGramBasis(
+    const Eigen::MatrixXi& mpow,
+    const std::map<symbolic::Variable, int>& variable_to_position_map);
+
+// From here in declaration of helper functions.
+
+/** Removes rows of matrix_to_change, which are given by the entries of
+ rows_to_remove.*/
+Eigen::MatrixXi RemoveRows(const Eigen::MatrixXi& mat,
+                           const std::set<int>& rows_to_remove);
+
+/** Returns rows of mat1 which intersect rows of mat2*/
+Eigen::MatrixXi RowIntersect(const Eigen::MatrixXi& mat1,
+                             const Eigen::MatrixXi& mat2);
+
+/** Returns the unique Rows of mat*/
+Eigen::MatrixXi UniqueRows(const Eigen::MatrixXi& mat);
+
+}  // namespace build_gram_basis
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -99,6 +99,9 @@ target_link_libraries(solver_id_test drakeOptimization)
 drake_add_cc_test(solver_type_converter_test)
 target_link_libraries(solver_type_converter_test drakeOptimization)
 
+drake_add_cc_test(sos_util_test)
+target_link_libraries(sos_util_test drakeCommon drakeOptimization)
+
 if (lcm_FOUND)
   add_executable(plot_feasible_rotation_matrices plot_feasible_rotation_matrices.cc)
   target_link_libraries(plot_feasible_rotation_matrices

--- a/drake/solvers/test/sos_constraint_test.cc
+++ b/drake/solvers/test/sos_constraint_test.cc
@@ -82,90 +82,91 @@ class SosConstraintTest : public ::testing::Test {
 };
 
 TEST_F(SosConstraintTest, NewFreePolynomialUnivariateDegree1) {
-  const auto& x = x_(0);
-  const Variables indeterminates{x};
-  const int degree{1};
-  const symbolic::Polynomial poly{
-      prog_.NewFreePolynomial(indeterminates, degree)};
-  CheckNewFreePolynomial(poly, indeterminates, degree);
+const auto& x = x_(0);
+const Variables indeterminates{x};
+const int degree{1};
+const symbolic::Polynomial poly{
+    prog_.NewFreePolynomial(indeterminates, degree)};
+CheckNewFreePolynomial(poly, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewFreePolynomialUnivariateDegree2) {
-  const auto& x = x_(0);
-  const Variables indeterminates{x};
-  const int degree{2};
-  const symbolic::Polynomial poly{
-      prog_.NewFreePolynomial(indeterminates, degree)};
-  CheckNewFreePolynomial(poly, indeterminates, degree);
+const auto& x = x_(0);
+const Variables indeterminates{x};
+const int degree{2};
+const symbolic::Polynomial poly{
+    prog_.NewFreePolynomial(indeterminates, degree)};
+CheckNewFreePolynomial(poly, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewFreePolynomialMultivariateDegree1) {
-  const auto& x0 = x_(0);
-  const auto& x1 = x_(1);
-  const Variables indeterminates{x0, x1};
-  const int degree{1};
-  const symbolic::Polynomial poly{
-      prog_.NewFreePolynomial(indeterminates, degree)};
-  CheckNewFreePolynomial(poly, indeterminates, degree);
+const auto& x0 = x_(0);
+const auto& x1 = x_(1);
+const Variables indeterminates{x0, x1};
+const int degree{1};
+const symbolic::Polynomial poly{
+    prog_.NewFreePolynomial(indeterminates, degree)};
+CheckNewFreePolynomial(poly, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewFreePolynomialMultivariateDegree2) {
-  const auto& x0 = x_(0);
-  const auto& x1 = x_(1);
-  const Variables indeterminates{x0, x1};
-  const int degree{2};
-  const symbolic::Polynomial poly{
-      prog_.NewFreePolynomial(indeterminates, degree)};
-  CheckNewFreePolynomial(poly, indeterminates, degree);
+const auto& x0 = x_(0);
+const auto& x1 = x_(1);
+const Variables indeterminates{x0, x1};
+const int degree{2};
+const symbolic::Polynomial poly{
+    prog_.NewFreePolynomial(indeterminates, degree)};
+CheckNewFreePolynomial(poly, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialUnivariate1) {
-  const auto& x = x_(0);
-  const Variables indeterminates{x};
-  const int degree{2};
-  const auto p = prog_.NewSosPolynomial(indeterminates, degree);
-  const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+const auto& x = x_(0);
+const Variables indeterminates{x};
+const int degree{2};
+const auto p = prog_.NewSosPolynomial(indeterminates, degree);
+const symbolic::Polynomial& poly{p.first};
+const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
+CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialUnivariate2) {
-  const auto& x = x_(0);
-  const Variables indeterminates{x};
-  const int degree{4};
-  const auto p = prog_.NewSosPolynomial(indeterminates, degree);
-  const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+const auto& x = x_(0);
+const Variables indeterminates{x};
+const int degree{4};
+const auto p = prog_.NewSosPolynomial(indeterminates, degree);
+const symbolic::Polynomial& poly{p.first};
+const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
+CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialMultivariate1) {
-  const auto& x0 = x_(0);
-  const auto& x1 = x_(1);
-  const Variables indeterminates{x0, x1};
-  const int degree{2};
-  const auto p = prog_.NewSosPolynomial(indeterminates, degree);
-  const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+const auto& x0 = x_(0);
+const auto& x1 = x_(1);
+const Variables indeterminates{x0, x1};
+const int degree{2};
+const auto p = prog_.NewSosPolynomial(indeterminates, degree);
+const symbolic::Polynomial& poly{p.first};
+const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
+CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
 }
 
 TEST_F(SosConstraintTest, NewSosPolynomialMultivariate2) {
-  const auto& x0 = x_(0);
-  const auto& x1 = x_(1);
-  const auto& x2 = x_(2);
-  const Variables indeterminates{x0, x1, x2};
-  const int degree{4};
-  const auto p = prog_.NewSosPolynomial(indeterminates, degree);
-  const symbolic::Polynomial& poly{p.first};
-  const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
-  CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
+const auto& x0 = x_(0);
+const auto& x1 = x_(1);
+const auto& x2 = x_(2);
+const Variables indeterminates{x0, x1, x2};
+const int degree{4};
+const auto p = prog_.NewSosPolynomial(indeterminates, degree);
+const symbolic::Polynomial& poly{p.first};
+const Binding<PositiveSemidefiniteConstraint>& psd_binding{p.second};
+CheckNewSosPolynomial(poly, psd_binding, indeterminates, degree);
 }
 
 // Shows that f(x) = x² + 2x + 1 is SOS.
 TEST_F(SosConstraintTest, AddSosConstraintUnivariate1) {
   const auto& x = x_(0);
-  const auto binding_pair = prog_.AddSosConstraint(2 * pow(x, 2) + 2 * x + 1);
+  const symbolic::Polynomial p{2 * pow(x, 2) + 2 * x + 1};
+  const auto binding_pair = prog_.AddSosConstraint(p);
   const auto result = prog_.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
   CheckPsdBinding(binding_pair.first);
@@ -176,11 +177,14 @@ TEST_F(SosConstraintTest, AddSosConstraintUnivariate1) {
 // http://www.mit.edu/~parrilo/cdc03_workshop/08_sum_of_squares_2003_12_07_07_screen.pdf.
 TEST_F(SosConstraintTest, AddSosConstraintUnivariate2) {
   const auto& x = x_(0);
+  const symbolic::Variables indets_{x_(0)};
   const auto& c = c_(0);
+  const symbolic::Polynomial p{pow(x, 6) - 10 * pow(x, 5) + 51 * pow(x, 4) -
+                                   166 * pow(x, 3) + 342 * pow(x, 2) - 400 * x +
+                                   200 - c,
+                               indets_};
   prog_.AddCost(-c);
-  const auto binding_pair = prog_.AddSosConstraint(
-      pow(x, 6) - 10 * pow(x, 5) + 51 * pow(x, 4) - 166 * pow(x, 3) +
-      342 * pow(x, 2) - 400 * x + 200 - c);
+  const auto binding_pair = prog_.AddSosConstraint(p);
   const auto result = prog_.Solve();
   ASSERT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_LE(prog_.GetSolution(c), 1E-4);
@@ -191,9 +195,9 @@ TEST_F(SosConstraintTest, AddSosConstraintUnivariate2) {
 TEST_F(SosConstraintTest, AddSosConstraintMultivariate1) {
   const auto& x0 = x_(0);
   const auto& x1 = x_(1);
-  const auto binding_pair =
-      prog_.AddSosConstraint(2 * pow(x0, 4) + 2 * pow(x0, 3) * x1 -
-                             pow(x0, 2) * pow(x1, 2) + 5 * pow(x1, 4));
+  const symbolic::Polynomial p{2 * pow(x0, 4) + 2 * pow(x0, 3) * x1 -
+                               pow(x0, 2) * pow(x1, 2) + 5 * pow(x1, 4)};
+  const auto binding_pair = prog_.AddSosConstraint(p);
   const auto result = prog_.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
   CheckPsdBinding(binding_pair.first);
@@ -207,12 +211,14 @@ TEST_F(SosConstraintTest, AddSosConstraintMultivariate1) {
 TEST_F(SosConstraintTest, AddSosConstraintMultivariate2) {
   const auto& x0 = x_(0);
   const auto& x1 = x_(1);
+  const symbolic::Variables indets_{x_(0), x_(1)};
   const auto& c = c_(0);
+  const symbolic::Polynomial p{4 * pow(x0, 2) - 2.1 * pow(x0, 4) +
+                                   1.0 / 3.0 * pow(x0, 6) + x0 * x1 -
+                                   4 * x1 * x1 + 4 * pow(x1, 4) - c,
+                               indets_};
   prog_.AddCost(-c);
-  const auto binding_pair = prog_.AddSosConstraint(
-      4 * pow(x0, 2) - 2.1 * pow(x0, 4) + 1.0 / 3.0 * pow(x0, 6) + x0 * x1 -
-      4 * x1 * x1 + 4 * pow(x1, 4) - c);
-
+  const auto binding_pair = prog_.AddSosConstraint(p);
   const auto result = prog_.Solve();
   ASSERT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_NEAR(prog_.GetSolution(c), -1.0316, 1E-4);

--- a/drake/solvers/test/sos_util_test.cc
+++ b/drake/solvers/test/sos_util_test.cc
@@ -1,0 +1,317 @@
+#include "drake/solvers/sos_util.h"
+
+#include <array>
+#include <iostream>
+#include <map>
+#include <set>
+#include <vector>
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/symbolic.h"
+
+namespace drake {
+namespace solvers {
+namespace build_gram_basis {
+
+using std::array;
+using std::set;
+using std::vector;
+using std::make_pair;
+using drake::symbolic::Expression;
+using drake::symbolic::Monomial;
+using drake::symbolic::Polynomial;
+using drake::symbolic::Variable;
+
+typedef std::map<Variable, int> map;
+
+class SosUtilTest : public ::testing::Test {
+ public:
+  SosUtilTest()
+      : exprs_({2, x_, 5 * x_, y_, x_ * y_, 2 * x_ * x_, 6 * x_ * y_,
+                x_ * x_ + x_ * y_, 3 * x_ * x_ * y_ + 4 * pow(y_, 3) * z_ + 2,
+                pow(x_, 4) * pow(y_, 2) + pow(y_, 4) * pow(x_, 2) + 1}),
+        polys_(exprs_.begin(), exprs_.end()),
+        supports_{support_0, support_1, support_2, support_3, support_4,
+                  support_5, support_6, support_7, support_8, support_9},
+        polytopes_{polytope_0, polytope_1, polytope_2, polytope_3, polytope_4,
+                   polytope_5, polytope_6, polytope_7, polytope_8, polytope_9},
+        sos_supports_{sos_support_0, sos_support_1, sos_support_2,
+                      sos_support_3, sos_support_4, sos_support_5,
+                      sos_support_6, sos_support_7, sos_support_8,
+                      sos_support_9} {}
+
+ protected:
+  const Variable var_x_{"x"};
+  const Variable var_y_{"y"};
+  const Variable var_z_{"z"};
+  const Expression x_{var_x_};
+  const Expression y_{var_y_};
+  const Expression z_{var_z_};
+  const vector<Expression> exprs_;
+  const vector<Polynomial> polys_;
+
+  /*support_0 is empty*/
+  const Eigen::Matrix<int, 1, 0> support_0;
+  const int support_data_1[1]{1};
+  const Eigen::Matrix<int, 1, 1> support_1{&support_data_1[0]};
+  const int support_data_2[1]{1};
+  const Eigen::Matrix<int, 1, 1> support_2{&support_data_2[0]};
+  const int support_data_3[1]{1};
+  const Eigen::Matrix<int, 1, 1> support_3{&support_data_3[0]};
+  const int support_data_4[2]{1, 1};
+  const Eigen::Matrix<int, 1, 2> support_4{&support_data_4[0]};
+  const int support_data_5[1]{2};
+  const Eigen::Matrix<int, 1, 1> support_5{&support_data_5[0]};
+  const int support_data_6[2]{1, 1};
+  const Eigen::Matrix<int, 1, 2> support_6{&support_data_6[0]};
+  const int support_data_7[4]{1, 2, 1, 0};
+  const Eigen::Matrix<int, 2, 2> support_7{&support_data_7[0]};
+  const int support_data_8[9]{0, 2, 0, 3, 1, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 3, 3> support_8{&support_data_8[0]};
+  const int support_data_9[6]{2, 4, 0, 4, 2, 0};
+  const Eigen::Matrix<int, 3, 2> support_9{&support_data_9[0]};
+  const vector<Eigen::MatrixXi> supports_;
+
+  const Eigen::Matrix<int, 0, 0> polytope_0;
+  const Eigen::Matrix<int, 0, 0> polytope_1;
+  const Eigen::Matrix<int, 0, 0> polytope_2;
+  const Eigen::Matrix<int, 0, 0> polytope_3;
+  const int polytope_data_4[6]{0, 1, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 3, 2> polytope_4{&polytope_data_4[0]};
+  const int polytope_data_5[2]{1, 0};
+  const Eigen::Matrix<int, 2, 1> polytope_5{&polytope_data_5[0]};
+  const int polytope_data_6[6]{0, 1, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 3, 2> polytope_6{&polytope_data_6[0]};
+  const int polytope_data_7[6]{0, 1, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 3, 2> polytope_7{&polytope_data_7[0]};
+  const int polytope_data_8[30]{0, 0, 0, 1, 1, 2, 0, 0, 1, 0, 0, 1, 2, 0, 1,
+                                0, 0, 1, 0, 0, 2, 1, 0, 1, 0, 0, 1, 0, 0, 0};
+  const Eigen::Matrix<int, 10, 3> polytope_8{&polytope_data_8[0]};
+  const int polytope_data_9[20]{0, 1, 2, 3, 0, 1, 2, 0, 1, 0,
+                                3, 2, 1, 0, 2, 1, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 10, 2> polytope_9{&polytope_data_9[0]};
+  const vector<Eigen::MatrixXi> polytopes_;
+
+  const Eigen::Matrix<int, 0, 0> sos_support_0;
+  const Eigen::Matrix<int, 0, 0> sos_support_1;
+  const Eigen::Matrix<int, 0, 0> sos_support_2;
+  const Eigen::Matrix<int, 0, 0> sos_support_3;
+  const Eigen::Matrix<int, 0, 2> sos_support_4;
+  const int sos_support_data_5[1]{1};
+  const Eigen::Matrix<int, 1, 1> sos_support_5{&sos_support_data_5[0]};
+  const Eigen::Matrix<int, 0, 2> sos_support_6;
+  const int sos_support_data_7[2]{1, 0};
+  const Eigen::Matrix<int, 1, 2> sos_support_7{&sos_support_data_7[0]};
+  const int sos_support_data_8[3]{0, 0, 0};
+  const Eigen::Matrix<int, 1, 3> sos_support_8{&sos_support_data_8[0]};
+  const int sos_support_data_9[8]{1, 2, 1, 0, 2, 1, 1, 0};
+  const Eigen::Matrix<int, 4, 2> sos_support_9{&sos_support_data_9[0]};
+  const vector<Eigen::MatrixXi> sos_supports_;
+};
+
+TEST_F(SosUtilTest, GenerateCrossTerms) {
+  const Eigen::Matrix<int, 0, 0> base_matrix_00;
+  const Eigen::Matrix<int, 0, 0> base_matrix_10;
+  const Eigen::Matrix<int, 0, 0> base_matrix_01;
+  const int base_matrix_data_11[1]{1};
+  const Eigen::Matrix<int, 1, 1> base_matrix_11{&base_matrix_data_11[0]};
+  const int base_matrix_data_21[2]{1, 2};
+  const Eigen::Matrix<int, 2, 1> base_matrix_21{&base_matrix_data_21[0]};
+  const int base_matrix_data_12[2]{1, 2};
+  const Eigen::Matrix<int, 1, 2> base_matrix_12{&base_matrix_data_12[0]};
+  const int base_matrix_data_22[4]{1, 0, 0, 1};
+  const Eigen::Matrix<int, 2, 2> base_matrix_22{&base_matrix_data_22[0]};
+  const int base_matrix_data_32[6]{1, 0, 0, 0, 1, 0};
+  const Eigen::Matrix<int, 3, 2> base_matrix_32{&base_matrix_data_32[0]};
+  const int base_matrix_data_23[6]{1, 0, 0, 1, 0, 0};
+  const Eigen::Matrix<int, 2, 3> base_matrix_23{&base_matrix_data_23[0]};
+  const int base_matrix_data_33[9]{1, 0, 0, 0, 1, 0, 0, 0, 1};
+  const Eigen::Matrix<int, 3, 3> base_matrix_33{&base_matrix_data_33[0]};
+  const vector<Eigen::MatrixXi> base_matrices_{
+      base_matrix_00, base_matrix_10, base_matrix_01, base_matrix_11,
+      base_matrix_21, base_matrix_12, base_matrix_22, base_matrix_32,
+      base_matrix_23, base_matrix_33};
+
+  const Eigen::Matrix<int, 0, 0> cross_matrix_00;
+  const Eigen::Matrix<int, 0, 0> cross_matrix_10;
+  const Eigen::Matrix<int, 0, 0> cross_matrix_01;
+  const Eigen::Matrix<int, 0, 0> cross_matrix_11;
+  const int cross_matrix_data_21[1]{3};
+  const Eigen::Matrix<int, 1, 1> cross_matrix_21{&cross_matrix_data_21[0]};
+  const Eigen::Matrix<int, 0, 0> cross_matrix_12;
+  const int cross_matrix_data_22[2]{1, 1};
+  const Eigen::Matrix<int, 1, 2> cross_matrix_22{&cross_matrix_data_22[0]};
+  const int cross_matrix_data_32[6]{1, 1, 0, 1, 0, 1};
+  const Eigen::Matrix<int, 3, 2> cross_matrix_32{&cross_matrix_data_32[0]};
+  const int cross_matrix_data_23[3]{1, 1, 0};
+  const Eigen::Matrix<int, 1, 3> cross_matrix_23{&cross_matrix_data_23[0]};
+  const int cross_matrix_data_33[9]{1, 1, 0, 1, 0, 1, 0, 1, 1};
+  const Eigen::Matrix<int, 3, 3> cross_matrix_33{&cross_matrix_data_33[0]};
+  const vector<Eigen::MatrixXi> cross_matrices_{
+      cross_matrix_00, cross_matrix_10, cross_matrix_01, cross_matrix_11,
+      cross_matrix_21, cross_matrix_12, cross_matrix_22, cross_matrix_32,
+      cross_matrix_23, cross_matrix_33};
+
+  for (int i = 0; i < static_cast<int>(base_matrices_.size()); ++i) {
+    EXPECT_EQ(
+        RowIntersect(GenerateCrossTerms(base_matrices_[i]), cross_matrices_[i]),
+        cross_matrices_[i]);
+    //    EXPECT_EQ(RowIntersect(GenerateCrossTerms(base_matrices_[i]),
+    //    cross_matrices_[i]), cross_matrices_[i]);
+  }
+}
+
+TEST_F(SosUtilTest, DiagConsistentTest) {
+  // only for last test case
+  // TODO(FischerGundlach) Add more test cases where the crossterms are actually
+  // tested within CheckDiagonalConsistency
+  EXPECT_EQ(CheckDiagonalConsistency(support_9, sos_support_9), support_9 / 2);
+}
+
+TEST_F(SosUtilTest, ExponentBoundPolytopeTest) {
+  int i{0};
+  for (auto& p : polys_) {
+    // catches constant and odd polynomial => don't compute
+    // GenerateExponentBoundPolytope
+    if (!((p.TotalDegree() % 2 == 1) || p.indeterminates().empty())) {
+      auto pair_ = PolynomialToSupport(p);
+      EXPECT_EQ(GenerateExponentBoundPolytope(pair_.first), polytopes_[i]);
+    }
+    ++i;
+  }
+}
+
+TEST_F(SosUtilTest, PolynomialToSupportTest) {
+  map map_0;
+  map map_1;
+  map_1.insert(make_pair(var_x_, 0));
+  map map_2;
+  map_2.insert(make_pair(var_x_, 0));
+  map map_3;
+  map_3.insert(make_pair(var_y_, 0));
+  map map_4;
+  map_4.insert(make_pair(var_x_, 0));
+  map_4.insert(make_pair(var_y_, 1));
+  map map_5;
+  map_5.insert(make_pair(var_x_, 0));
+  map map_6;
+  map_6.insert(make_pair(var_x_, 0));
+  map_6.insert(make_pair(var_y_, 1));
+  map map_7;
+  map_7.insert(make_pair(var_x_, 0));
+  map_7.insert(make_pair(var_y_, 1));
+  map map_8;
+  map_8.insert(make_pair(var_x_, 0));
+  map_8.insert(make_pair(var_y_, 1));
+  map_8.insert(make_pair(var_z_, 2));
+  map map_9;
+  map_9.insert(make_pair(var_x_, 0));
+  map_9.insert(make_pair(var_y_, 1));
+
+  const vector<map> maps_{map_0, map_1, map_2, map_3, map_4,
+                          map_5, map_6, map_7, map_8, map_9};
+
+  int i{0};
+  for (auto& p : polys_) {
+    auto pair_ = PolynomialToSupport(p);
+    EXPECT_EQ(pair_.first, supports_[i]);
+    EXPECT_EQ(pair_.second, maps_[i]);
+    ++i;
+  }
+}
+
+TEST_F(SosUtilTest, RandomPruneTest) {
+  // The rows in mat_X correspond to the support by mpow, where 2mpow is
+  // inside/on the boundary of the support pow. Therefore these rows need to be
+  // maintained after pruning!
+
+  int i{0};
+  for (auto& p : polys_) {
+    // catches constant and odd polynomial => don't compute
+    // GenerateExponentBoundPolytope
+    if (!((p.TotalDegree() % 2 == 1) || p.indeterminates().empty())) {
+      Eigen::MatrixXi pow{PolynomialToSupport(p).first};
+      Eigen::MatrixXi mpow{GenerateExponentBoundPolytope(pow)};
+      // performe the test 100 times, as the pruning is a random operation.
+      for (int testruns = 0; testruns < 1; ++testruns) {
+        mpow = RandomlyPruneSupport(pow, mpow, 1);
+        bool contains_interior{false};
+
+        if (RowIntersect(mpow, sos_supports_[i]) == sos_supports_[i]) {
+          contains_interior = true;
+        }
+
+        EXPECT_TRUE(contains_interior);
+      }
+    }
+    ++i;
+  }
+}
+
+TEST_F(SosUtilTest, RemoveRowsTest) {
+  set<int> set_remove_0;
+  set<int> set_remove_1;
+  set<int> set_remove_2;
+  set<int> set_remove_3;
+  array<int, 3> data_remove_4{{0, 1, 2}};
+  set<int> set_remove_4{data_remove_4.begin(), data_remove_4.end()};
+  array<int, 1> data_remove_5{{1}};
+  set<int> set_remove_5{data_remove_5.begin(), data_remove_5.end()};
+  array<int, 3> data_remove_6{{0, 1, 2}};
+  set<int> set_remove_6{data_remove_6.begin(), data_remove_6.end()};
+  array<int, 2> data_remove_7{{0, 2}};
+  set<int> set_remove_7{data_remove_7.begin(), data_remove_7.end()};
+  array<int, 9> data_remove_8{{0, 1, 2, 3, 4, 5, 6, 7, 8}};
+  set<int> set_remove_8{data_remove_8.begin(), data_remove_8.end()};
+  array<int, 6> data_remove_9{{0, 3, 4, 6, 7, 8}};
+  set<int> set_remove_9{data_remove_9.begin(), data_remove_9.end()};
+  const vector<set<int>> vec_remove_{
+      set_remove_0, set_remove_1, set_remove_2, set_remove_3, set_remove_4,
+      set_remove_5, set_remove_6, set_remove_7, set_remove_8, set_remove_9};
+
+  for (int i = 0; i < static_cast<int>(polytopes_.size()); ++i) {
+    EXPECT_EQ(RemoveRows(polytopes_[i], vec_remove_[i]), sos_supports_[i]);
+  }
+}
+
+TEST_F(SosUtilTest, RowIntersectTest) {
+  for (int i = 0; i < static_cast<int>(polytopes_.size()); ++i) {
+    EXPECT_EQ(RowIntersect(sos_supports_[i], polytopes_[i]), sos_supports_[i]);
+    EXPECT_EQ(RowIntersect(polytopes_[i], sos_supports_[i]), sos_supports_[i]);
+  }
+}
+
+TEST_F(SosUtilTest, SupportToGramBasisTest) {
+  const Monomial m_0{pow(x_, 2) * pow(y_, 4)};
+  const Monomial m_1{pow(x_, 4) * pow(y_, 2)};
+  const Monomial m_2{1};
+  const vector<Monomial> ms_{m_0, m_1, m_2};
+
+  auto pair_0 = PolynomialToSupport(polys_[0]);
+  auto gramBasis_0 = SupportToGramBasis(pair_0.first, pair_0.second);
+  EXPECT_EQ(gramBasis_0[0], Monomial());
+
+  // TODO(FischerGundlach) Add more SOS problems
+  auto pair_9 = PolynomialToSupport(polys_[9]);
+  auto gramBasis_9 = SupportToGramBasis(pair_9.first, pair_9.second);
+
+  for (int i = 0; i < static_cast<int>(ms_.size()); ++i) {
+    EXPECT_EQ(gramBasis_9[i], ms_[i]);
+  }
+}
+
+TEST_F(SosUtilTest, UniqueRowsTest) {
+  for (int i = 1; i < static_cast<int>(sos_supports_.size()); ++i) {
+    Eigen::MatrixXi double_support(2 * sos_supports_[i].rows(),
+                                   sos_supports_[i].cols());
+    double_support << sos_supports_[i], sos_supports_[i];
+    EXPECT_EQ(UniqueRows(double_support), sos_supports_[i]);
+  }
+}
+
+}  // namespace build_gram_basis
+}  // namespace solvers
+}  // namespace drake


### PR DESCRIPTION
A preprocessing step for SOS programming is implemented in this PR. 

When constraining a polynomial to be SOS, only those monomials are included in the gram basis which need to appear in the support of the constraint polynomial. 

The algorithm for shrinking the optimization problem are cited in the comments within this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6664)
<!-- Reviewable:end -->
