### PR TITLE
Do not require Simulink when finding MATLAB

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -53,8 +53,7 @@ macro(drake_setup_matlab)
         COMPONENTS
           MAIN_PROGRAM
           MEX_COMPILER
-          MX_LIBRARY
-          SIMULINK)
+          MX_LIBRARY)
     else()
       set(Matlab_FOUND OFF)
       message(STATUS "MATLAB was not found.")

--- a/drake/doc/matlab_faq.rst
+++ b/drake/doc/matlab_faq.rst
@@ -65,14 +65,6 @@ they will get in sync soon, but for now I've decided the best fix is to edit the
 	/*typedef char16_t CHAR16_T;*/
 	typedef UINT16_T CHAR16_T;
 
-
-.. _faq_simulink_not_found:
-
-Drake tells me I don't have Simulink 3D Animation Toolbox, but I'm sure that I do!
-==================================================================================
-
-You might have to actually tell MATLAB to install the tool, running ``vrinstall`` in MATLAB.
-
 .. _faq_undefined_symbol-sincos_stret:
 
 Undefined symbol "___sincos_stret" on Mac.


### PR DESCRIPTION
Dependency was removed in https://github.com/RobotLocomotion/drake/commit/47c4c56d16481af825de10e28f8a95df4917f0fb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6665)
<!-- Reviewable:end -->
