### PR TITLE
Missing dependency for drake library

### DIFF
--- a/tools/drake.cps
+++ b/tools/drake.cps
@@ -40,6 +40,7 @@
       ],
       "Compile-Features": ["c++14"],
       "Requires": [
+        ":drake-lcmtypes-cpp",
         "Eigen3:Eigen",
         "lcm:lcm",
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",


### PR DESCRIPTION
The dependency of drake library on drake-lcmtypes-cpp was not declared in
drake.cps which resulted in this dependency not being exposed in
drake-config.cmake that is generated in drake's build process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6672)
<!-- Reviewable:end -->
