### PR TITLE
Move detail::is_eigen_* into eigen_types.h and symbolic_expression.h

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -514,6 +514,14 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "eigen_types_test",
+    deps = [
+        ":common",
+        ":nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
     name = "extract_double_test",
     deps = [
         ":common",

--- a/drake/common/symbolic_expression.h
+++ b/drake/common/symbolic_expression.h
@@ -23,6 +23,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/dummy_value.h"
+#include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/polynomial.h"
@@ -895,4 +896,25 @@ CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
 }
 
 }  // namespace symbolic
+
+/*
+ * Determine if two EigenBase<> types are matrices (non-column-vectors) of
+ * Expressions and doubles, to then form an implicit formulas.
+ */
+template <typename DerivedV, typename DerivedB>
+struct is_eigen_nonvector_expression_double_pair
+    : std::integral_constant<
+          bool, is_eigen_nonvector_of<DerivedV, symbolic::Expression>::value &&
+                    is_eigen_nonvector_of<DerivedB, double>::value> {};
+
+/*
+ * Determine if two EigenBase<> types are vectors of Expressions and doubles
+ * that could make a formula.
+ */
+template <typename DerivedV, typename DerivedB>
+struct is_eigen_vector_expression_double_pair
+    : std::integral_constant<
+          bool, is_eigen_vector_of<DerivedV, symbolic::Expression>::value &&
+                    is_eigen_vector_of<DerivedB, double>::value> {};
+
 }  // namespace drake

--- a/drake/common/symbolic_variable.h
+++ b/drake/common/symbolic_variable.h
@@ -14,6 +14,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 #include "drake/common/hash.h"
 
 namespace drake {
@@ -133,10 +134,8 @@ namespace symbolic {
 /// equal to `m2(i, j)` for all `i`, `j`.
 template <typename DerivedA, typename DerivedB>
 typename std::enable_if<
-    std::is_base_of<Eigen::MatrixBase<DerivedA>, DerivedA>::value &&
-        std::is_base_of<Eigen::MatrixBase<DerivedB>, DerivedB>::value &&
-        std::is_same<typename DerivedA::Scalar, Variable>::value &&
-        std::is_same<typename DerivedB::Scalar, Variable>::value,
+    is_eigen_scalar_same<DerivedA, Variable>::value &&
+        is_eigen_scalar_same<DerivedB, Variable>::value,
     bool>::type
 CheckStructuralEquality(const DerivedA& m1, const DerivedB& m2) {
   EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(DerivedA, DerivedB);

--- a/drake/common/test/CMakeLists.txt
+++ b/drake/common/test/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(eigen_matrix_compare_test drakeCommon)
 drake_add_cc_test(eigen_stl_types_test)
 target_link_libraries(eigen_stl_types_test Eigen3::Eigen)
 
+drake_add_cc_test(eigen_types_test)
+target_link_libraries(eigen_types_test drakeCommon)
+
 drake_add_cc_test(extract_double_test)
 target_link_libraries(extract_double_test drakeCommon)
 

--- a/drake/common/test/eigen_types_test.cc
+++ b/drake/common/test/eigen_types_test.cc
@@ -1,0 +1,90 @@
+#include "drake/common/eigen_types.h"
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/nice_type_name.h"
+
+using Eigen::MatrixXd;
+using Eigen::Matrix3d;
+using Eigen::VectorXd;
+using Eigen::Vector3d;
+using Eigen::ArrayXXd;
+using Eigen::Array33d;
+using Eigen::ArrayXd;
+using Eigen::Array3d;
+
+namespace drake {
+namespace {
+
+template <typename Derived>
+void CheckTraits(bool is_vector) {
+  std::string info = "Type: " + NiceTypeName::Get<Derived>() + "\n";
+  EXPECT_TRUE(is_eigen_type<Derived>::value) << info;
+  EXPECT_TRUE((is_eigen_scalar_same<Derived, double>::value)) << info;
+  EXPECT_EQ(is_vector, (is_eigen_vector_of<Derived, double>::value)) << info;
+  EXPECT_EQ(!is_vector, (is_eigen_nonvector_of<Derived, double>::value))
+      << info;
+}
+
+// Test traits within eigen_types.h
+GTEST_TEST(EigenTypesTest, TraitsPositive) {
+  // MatrixBase<>
+  CheckTraits<MatrixXd>(false);
+  CheckTraits<Matrix3d>(false);
+  CheckTraits<VectorXd>(true);
+  CheckTraits<Vector3d>(true);
+  // ArrayBase<>
+  CheckTraits<ArrayXXd>(false);
+  CheckTraits<Array33d>(false);
+  CheckTraits<ArrayXd>(true);
+  CheckTraits<Array3d>(true);
+}
+
+// SFINAE check.
+bool IsEigen(...) {
+  return false;
+}
+template <typename T,
+          typename Cond = typename std::enable_if<
+              is_eigen_type<T>::value>::type>
+bool IsEigen(const T&) {
+  return true;
+}
+
+// SFINAE check with edge case described below.
+bool IsEigenOfDouble(...) {
+  return false;
+}
+template <typename T,
+          typename Cond = typename std::enable_if<
+              is_eigen_scalar_same<T, double>::value>::type>
+bool IsEigenOfDouble(const T&) {
+  return true;
+}
+
+// Ensure that we do not capture non-eigen things.
+template <typename Derived>
+class NonEigenBase {};
+class NonEigen : public NonEigenBase<NonEigen> {
+ public:
+  typedef double Scalar;
+};
+
+GTEST_TEST(EigenTypesTest, TraitsSFINAE) {
+  EXPECT_TRUE(IsEigen(MatrixXd()));
+  EXPECT_TRUE(IsEigenOfDouble(MatrixXd()));
+  EXPECT_TRUE(IsEigen(ArrayXXd()));
+  EXPECT_TRUE(IsEigenOfDouble(ArrayXXd()));
+  EXPECT_FALSE(IsEigen(NonEigen()));
+  EXPECT_FALSE(IsEigenOfDouble(NonEigen()));
+  EXPECT_FALSE(IsEigen(1));
+  // TODO(eric.cousineau): See if there is a way to short-circuit conditionals.
+  // Presently, the following code will throw an error, even in SFINAE.
+  // EXPECT_FALSE(IsEigenOfDouble(1));
+  // EXPECT_FALSE((is_eigen_vector_of<std::string, double>::value));
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1068,7 +1068,7 @@ class MathematicalProgram {
    */
   template <typename Derived>
   typename std::enable_if<
-      detail::is_eigen_scalar_same<Derived, symbolic::Formula>::value,
+      is_eigen_scalar_same<Derived, symbolic::Formula>::value,
       Binding<LinearConstraint>>::type
   AddLinearConstraint(const Eigen::ArrayBase<Derived>& formulas) {
     return AddConstraint(internal::ParseLinearConstraint(formulas));
@@ -1124,7 +1124,7 @@ class MathematicalProgram {
    */
   template <typename DerivedV, typename DerivedB>
   typename std::enable_if<
-      detail::is_eigen_vector_expression_double_pair<DerivedV, DerivedB>::value,
+      is_eigen_vector_expression_double_pair<DerivedV, DerivedB>::value,
       Binding<LinearEqualityConstraint>>::type
   AddLinearEqualityConstraint(const Eigen::MatrixBase<DerivedV>& v,
                               const Eigen::MatrixBase<DerivedB>& b) {
@@ -1152,7 +1152,7 @@ class MathematicalProgram {
    */
   template <typename DerivedV, typename DerivedB>
   typename std::enable_if<
-      detail::is_eigen_matrix_expression_double_pair<DerivedV, DerivedB>::value,
+      is_eigen_nonvector_expression_double_pair<DerivedV, DerivedB>::value,
       Binding<LinearEqualityConstraint>>::type
   AddLinearEqualityConstraint(const Eigen::MatrixBase<DerivedV>& V,
                               const Eigen::MatrixBase<DerivedB>& B,

--- a/drake/solvers/mixed_integer_optimization_util.h
+++ b/drake/solvers/mixed_integer_optimization_util.h
@@ -148,10 +148,10 @@ void AddLogarithmicSos1Constraint(
 template <typename DerivedPhiX, typename DerivedPhiY, typename DerivedBx,
           typename DerivedBy>
 typename std::enable_if<
-    detail::is_eigen_vector_of<DerivedPhiX, double>::value &&
-        detail::is_eigen_vector_of<DerivedPhiY, double>::value &&
-        detail::is_eigen_vector_of<DerivedBx, symbolic::Variable>::value &&
-        detail::is_eigen_vector_of<DerivedBy, symbolic::Variable>::value,
+    is_eigen_vector_of<DerivedPhiX, double>::value &&
+        is_eigen_vector_of<DerivedPhiY, double>::value &&
+        is_eigen_vector_of<DerivedBx, symbolic::Variable>::value &&
+        is_eigen_vector_of<DerivedBy, symbolic::Variable>::value,
     MatrixDecisionVariable<DerivedPhiX::RowsAtCompileTime,
                            DerivedPhiY::RowsAtCompileTime>>::type
 AddBilinearProductMcCormickEnvelopeSos2(


### PR DESCRIPTION
This moves the trait operations, and adds unittests for basic Eigen matrix types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6678)
<!-- Reviewable:end -->
