### PR TITLE
fix the logging in gurobi_solver

### DIFF
--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -817,7 +817,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
         // If the problem is a mixed-integer optimization program, provide
         // Gurobi's lower bound.
         double lower_bound;
-        auto error = GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
+        error = GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
         if (error) {
           drake::log()->error("GRB error {} getting lower bound: {}\n", error,
                               GRBgeterrormsg(GRBgetenv(model)));

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -101,7 +101,7 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
     auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
                           callback_info->solver_sol_vector.data());
     if (error) {
-      drake::log()->error("GRB error %d in MIPSol callback cbget: %s\n", error,
+      drake::log()->error("GRB error {} in MIPSol callback cbget: {}\n", error,
                           GRBgeterrormsg(GRBgetenv(model)));
       return 0;
     }
@@ -119,7 +119,7 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
     auto error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_STATUS, &sol_status);
     if (error) {
       drake::log()->error(
-          "GRB error %d in MIPNode callback getting sol status: %s\n", error,
+          "GRB error {} in MIPNode callback getting sol status: {}\n", error,
           GRBgeterrormsg(GRBgetenv(model)));
       return 0;
     } else if (sol_status == GRB_OPTIMAL) {
@@ -128,7 +128,7 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
       auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
                             callback_info->solver_sol_vector.data());
       if (error) {
-        drake::log()->error("GRB error %d in MIPSol callback cbget: %s\n",
+        drake::log()->error("GRB error {} in MIPSol callback cbget: {}\n",
                             error, GRBgeterrormsg(GRBgetenv(model)));
         return 0;
       }
@@ -156,7 +156,7 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
         double objective_solution;
         error = GRBcbsolution(cbdata, new_sol.data(), &objective_solution);
         if (error) {
-          drake::log()->error("GRB error %d in injection: %s\n", error,
+          drake::log()->error("GRB error {} in injection: {}\n", error,
                               GRBgeterrormsg(GRBgetenv(model)));
         }
       }
@@ -629,6 +629,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
                            std::numeric_limits<double>::infinity());
 
   std::vector<char> gurobi_var_type(num_prog_vars);
+  bool is_mip{false};
   for (int i = 0; i < num_prog_vars; ++i) {
     switch (prog.decision_variable(i).get_type()) {
       case MathematicalProgram::VarType::CONTINUOUS:
@@ -636,9 +637,11 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
         break;
       case MathematicalProgram::VarType::BINARY:
         gurobi_var_type[i] = GRB_BINARY;
+        is_mip = true;
         break;
       case MathematicalProgram::VarType::INTEGER:
         gurobi_var_type[i] = GRB_INTEGER;
+        is_mip = true;
       case MathematicalProgram::VarType::BOOLEAN:
         throw std::runtime_error(
             "Boolean variables should not be used with Gurobi solver.");
@@ -760,8 +763,9 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   // TODO(naveenoid) : Properly handle gurobi specific error.
   // message.
   if (error) {
-    // TODO(naveenoid) : log error message using GRBgeterrormsg(env).
     result = SolutionResult::kInvalidInput;
+    drake::log()->info("Gurobi returns code {}, with message \"{}\".\n", error,
+                       GRBgeterrormsg(env));
   } else {
     int optimstatus = 0;
     GRBgetintattr(model, GRB_INT_ATTR_STATUS, &optimstatus);
@@ -809,14 +813,17 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       // Provide Gurobi's computed cost in addition to the constant cost.
       prog.SetOptimalCost(optimal_cost + constant_cost);
 
-      // Provide Gurobi's lower bound.
-      double lower_bound;
-      auto error = GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
-      if (error) {
-        drake::log()->error("GRB error %d getting lower bound: %s\n", error,
-                            GRBgeterrormsg(GRBgetenv(model)));
-      } else {
-        prog.SetLowerBoundCost(lower_bound);
+      if (is_mip) {
+        // If the problem is a mixed-integer optimization program, provide
+        // Gurobi's lower bound.
+        double lower_bound;
+        auto error = GRBgetdblattr(model, GRB_DBL_ATTR_OBJBOUND, &lower_bound);
+        if (error) {
+          drake::log()->error("GRB error {} getting lower bound: {}\n", error,
+                              GRBgeterrormsg(GRBgetenv(model)));
+        } else {
+          prog.SetLowerBoundCost(lower_bound);
+        }
       }
     }
   }

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1959,7 +1959,12 @@ class MathematicalProgram {
    */
   double GetLowerBoundCost() const { return lower_bound_cost_; }
   /**
-   * Setter for lower bound on optimal cost.
+   * Setter for lower bound on optimal cost. This function is meant
+   * to be called by the appropriate solver, not by the user. It sets
+   * the lower bound of the cost found by the solver, during the optimization
+   * process. For example, for mixed-integer optimization, the branch-and-bound
+   * algorithm can find the lower bound of the optimal cost, along the branching
+   * process.
    */
   void SetLowerBoundCost(double lower_bound_cost) {
     lower_bound_cost_ = lower_bound_cost;
@@ -2227,7 +2232,8 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   optional<SolverId> solver_id_;
   double optimal_cost_{};
-  double lower_bound_cost_{};
+  double lower_bound_cost_{}; // The lower bound of the objective found by the
+  // solver, during the optimization process.
   std::map<SolverId, std::map<std::string, double>> solver_options_double_;
   std::map<SolverId, std::map<std::string, int>> solver_options_int_;
   std::map<SolverId, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2232,8 +2232,9 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   optional<SolverId> solver_id_;
   double optimal_cost_{};
-  double lower_bound_cost_{};  // The lower bound of the objective found by the
-  // solver, during the optimization process.
+  // The lower bound of the objective found by the solver, during the
+  // optimization process.
+  double lower_bound_cost_{};
   std::map<SolverId, std::map<std::string, double>> solver_options_double_;
   std::map<SolverId, std::map<std::string, int>> solver_options_int_;
   std::map<SolverId, std::map<std::string, std::string>> solver_options_str_;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1963,8 +1963,8 @@ class MathematicalProgram {
    * to be called by the appropriate solver, not by the user. It sets
    * the lower bound of the cost found by the solver, during the optimization
    * process. For example, for mixed-integer optimization, the branch-and-bound
-   * algorithm can find the lower bound of the optimal cost, along the branching
-   * process.
+   * algorithm can find the lower bound of the optimal cost, during the
+   * branching process.
    */
   void SetLowerBoundCost(double lower_bound_cost) {
     lower_bound_cost_ = lower_bound_cost;

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2232,7 +2232,7 @@ class MathematicalProgram {
   std::shared_ptr<SolverData> solver_data_;
   optional<SolverId> solver_id_;
   double optimal_cost_{};
-  double lower_bound_cost_{}; // The lower bound of the objective found by the
+  double lower_bound_cost_{};  // The lower bound of the objective found by the
   // solver, during the optimization process.
   std::map<SolverId, std::map<std::string, double>> solver_options_double_;
   std::map<SolverId, std::map<std::string, int>> solver_options_int_;

--- a/drake/solvers/test/gurobi_solver_test.cc
+++ b/drake/solvers/test/gurobi_solver_test.cc
@@ -182,11 +182,11 @@ GTEST_TEST(GurobiTest, TestCallbacks) {
           std::bind(MipNodeCallbackFunctionTest, std::placeholders::_1,
                     std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, &cb_info);
-      GurobiSolver::MipSolCallbackFunction mip_sol_callback_function_wrappre =
+      GurobiSolver::MipSolCallbackFunction mip_sol_callback_function_wrapper =
           std::bind(MipSolCallbackFunctionTest, std::placeholders::_1,
                     std::placeholders::_2, &cb_info);
       solver.AddMipNodeCallback(mip_node_callback_function_wrapper);
-      solver.AddMipSolCallback(mip_sol_callback_function_wrappre);
+      solver.AddMipSolCallback(mip_sol_callback_function_wrapper);
 
       SolutionResult result = solver.Solve(prog);
       EXPECT_EQ(result, SolutionResult::kSolutionFound);


### PR DESCRIPTION
Previously `gurobi_solver` always try to get `ObjBound`. But this attribute is not accessible, for a problem without integer variables. Thus we end up with the following output when running gurobi solver
```
[2017-07-26 21:46:20.268] [console] [error] GRB error %d getting lower bound: %s
```
In this PR, we change the logged error format, and also only get `ObjBound` for a mixed-integer optimization program, so now that error message does not pop up when running `gurobi_solver_test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6682)
<!-- Reviewable:end -->
