### PR TITLE
Make @gtest//:main even harder to accidentally use incorrectly

### DIFF
--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -9,6 +9,7 @@ load(
     "drake_cc_library",
     "drake_cc_test",
 )
+load("//tools:gurobi.bzl", "gurobi_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -28,6 +29,8 @@ drake_cc_library(
 )
 
 # This library is empty unless Gurobi is available.
+# TODO(jwnimmer-tri) Port this to use the MathematicalProgram API, so that this
+# code can compile even in the absence of Gurobi, so we can remove select()s.
 drake_cc_library(
     name = "approximate_ik",
     srcs = select({
@@ -543,7 +546,9 @@ drake_cc_googletest(
 )
 
 # This test is empty unless Gurobi is enabled.
-drake_cc_test(
+# TODO(jwnimmer-tri) Port this to use the MathematicalProgram API, so that this
+# code can compile even in the absence of Gurobi, so we can remove select()s.
+drake_cc_googletest(
     name = "test_approximate_ik",
     srcs = select({
         "//tools:with_gurobi": [
@@ -551,6 +556,7 @@ drake_cc_test(
         ],
         "//conditions:default": [],
     }),
+    tags = gurobi_test_tags(),
     data = ["//drake/examples/atlas:models"],
     deps = select({
         "//tools:with_gurobi": [
@@ -558,9 +564,7 @@ drake_cc_test(
             "//drake/common:find_resource",
             "//drake/multibody/parsers",
         ],
-        "//conditions:default": [
-            "@gtest//:main",  # No-op stub for main().
-        ],
+        "//conditions:default": [],
     }),
 )
 

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -295,7 +295,6 @@ drake_cc_binary(
         ":rigid_body_tree",
         "//drake/common:measure_execution",
         "//drake/multibody/parsers",
-        "@gtest//:main",
     ],
 )
 

--- a/drake/multibody/test/test_approximate_ik.cc
+++ b/drake/multibody/test/test_approximate_ik.cc
@@ -3,6 +3,8 @@
 #include <limits>
 #include <memory>
 
+#include <gtest/gtest.h>
+
 #include "drake/common/find_resource.h"
 #include "drake/multibody/constraint/rigid_body_constraint.h"
 #include "drake/multibody/ik_options.h"
@@ -15,7 +17,7 @@
 using namespace std;  // NOLINT(build/namespaces)
 using namespace Eigen;  // NOLINT(build/namespaces)
 
-int main() {
+GTEST_TEST(TestApproximateIK, MainTest) {
   auto model = std::make_unique<RigidBodyTree<double>>();
   drake::parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
       drake::FindResourceOrThrow(
@@ -42,5 +44,4 @@ int main() {
   printf("info = %d\n", info);
   delete com_kc;
   delete[] constraint_array;
-  return 0;
 }

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -210,9 +210,9 @@ def drake_cc_googletest(
     if deps == None:
         deps = []
     if use_default_main:
-        deps.append("@gtest//:main")
+        deps = deps + ["@gtest//:main"]
     else:
-        deps.append("@gtest//:without_main")
+        deps = deps + ["@gtest//:without_main"]
     drake_cc_test(
         name = name,
         deps = deps,

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -133,6 +133,9 @@ def drake_cc_binary(
         cmd = _dsym_command(name),
     )
 
+    if "@gtest//:main" in (deps or []):
+        fail("Use drake_cc_googletest to declare %s as a test" % name)
+
     if add_test_rule:
         drake_cc_test(
             name = name + "_test",


### PR DESCRIPTION
Note that the individual commits are curated, with more specific changes listed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6683)
<!-- Reviewable:end -->
