### PR TITLE
Add installation script for Ubuntu 14.04

### DIFF
--- a/drake/doc/ubuntu_trusty.rst
+++ b/drake/doc/ubuntu_trusty.rst
@@ -7,8 +7,22 @@ Ubuntu 14.04 LTS (Trusty)
 The following instructions are written for Ubuntu 14.04 LTS, which is a
 supported Drake platform.
 
-Install Prerequisites
-=====================
+Using the Bazel Build System
+============================
+
+Prerequisite setup is automated. Simply run::
+
+    sudo ./setup/ubuntu/14.04/install_prereqs.sh
+
+You may need to respond to interactive prompts to confirm that you agree to add
+various `apt` repositories to your system and that you agree to the license
+conditions of certain software therein.
+
+After running the script, return to :doc:`from_source` to complete and test your
+installation.
+
+Using the Legacy CMake Build System
+===================================
 
 C++ Compiler
 ------------

--- a/setup/ubuntu/14.04/install_prereqs.sh
+++ b/setup/ubuntu/14.04/install_prereqs.sh
@@ -46,11 +46,17 @@ gfortran-4.9-multilib
 git
 graphviz
 libboost-dev
+libexpat1
+libfreetype6
 libglib2.0-dev
 libglu1-mesa-dev
+libjpeg8
 libpng-dev
+libqt4-opengl
+libtiff5
 libtinyxml-dev
 libtool
+libxml2
 libxt6
 lldb-3.9
 make

--- a/setup/ubuntu/14.04/install_prereqs.sh
+++ b/setup/ubuntu/14.04/install_prereqs.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Prerequisite set-up script for a Drake build with Bazel on Ubuntu 14.04.
+
+set -euo pipefail
+
+apt update
+apt install --no-install-recommends $(tr "\n" " " <<EOF
+curl
+lsb-release
+software-properties-common
+EOF
+)
+
+# Add APT repository for (clang|clang-format|lldb)-3.9.
+readonly lsb_release_codename="$(lsb_release -sc)"
+# In this form, add-apt-repository is only truly idempotent when --enable-source
+# is added, since it otherwise duplicates the commented deb-src line.
+add-apt-repository --enable-source \
+    "deb http://apt.llvm.org/${lsb_release_codename}/ llvm-toolchain-${lsb_release_codename}-3.9 main"
+curl --location http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+# Add APT repository for (g++|gcc|gfortran)-(4.9|5).
+add-apt-repository ppa:ubuntu-toolchain-r/test
+
+# Add APT repository for oracle-java8-installer.
+add-apt-repository ppa:webupd8team/java
+
+apt update
+apt install --no-install-recommends $(tr "\n" " " <<EOF
+bash-completion
+binutils
+clang-3.9
+clang-format-3.9
+doxygen
+g++
+g++-4.9
+g++-4.9-multilib
+gcc
+gcc-4.9
+gcc-4.9-multilib
+gdb
+gfortran
+gfortran-4.9
+gfortran-4.9-multilib
+git
+graphviz
+libboost-dev
+libglib2.0-dev
+libglu1-mesa-dev
+libpng-dev
+libtinyxml-dev
+libtool
+libxt6
+lldb-3.9
+make
+mesa-common-dev
+oracle-java8-installer
+patchutils
+pkg-config
+python-dev
+python-numpy
+python-sphinx
+valgrind
+zip
+zlib1g-dev
+EOF
+)
+
+# Download, verify, and install Bazel 0.5.2.
+pushd /tmp
+readonly bazel_version="0.5.2"
+readonly bazel_deb_filename="bazel_${bazel_version}-linux-x86_64.deb"
+curl --location --remote-name \
+    "https://github.com/bazelbuild/bazel/releases/download/${bazel_version}/${bazel_deb_filename}"
+echo "b14c8773dab078d3422fe4082f3ab4d9e14f02313c3b3eb4b5b40c44ce29ed59 ${bazel_deb_filename}" \
+    > "${bazel_deb_filename}.sha256"
+sha256sum --check "${bazel_deb_filename}.sha256" \
+    && dpkg --install "${bazel_deb_filename}"
+rm "${bazel_deb_filename}.sha256" "${bazel_deb_filename}"
+popd


### PR DESCRIPTION
Obviously, Trusty support is winding down, but for now, we are building binary packages for supported platforms and that occurs on ephemeral, un-provisioned instances. Hence, we need a script to provision an instance for a Bazel-only build on Trusty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6687)
<!-- Reviewable:end -->
