### PR TITLE
Use the tables even when formatting a single file

### DIFF
--- a/tools/buildifier.sh
+++ b/tools/buildifier.sh
@@ -80,8 +80,8 @@ fi
 
 if [[ -z $format_all ]]; then
   echo "Running buildifier with passed arguments..."
-  echo "$buildifier $@"
-  "$buildifier" "$@"
+  echo "$buildifier -add_tables=$tables $@"
+  "$buildifier" -add_tables="$tables" "$@"
 else
   echo "Applying buildifier to everything! This may take a moment..."
   find "$workspace" \


### PR DESCRIPTION
This matters for, e.g., `WORKSPACE` where we have custom formatting.  Without this patch, `buildifier -f` and `buildifier WORKSPACE` disagree.

Missed in #6482.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6692)
<!-- Reviewable:end -->
