### PR TITLE
Impose constraint on the sign of the rotation matrix entries

### DIFF
--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1295,7 +1295,7 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
   if ((num_intervals_per_half_axis & (num_intervals_per_half_axis - 1)) == 0) {
     // num_intervals_per_half_axis is a power of 2.
 
-    // Bpos(i, j) = sign(R(i, j)), Bneg(i, j)= 1 - Bpos(i, j)
+    // Bpos(i, j) = sign(R(i, j)).
     MatrixDecisionVariable<3, 3> Bpos;
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1308,6 +1308,24 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
     AddCrossProductImpliedOrthantConstraint(prog, Bpos);
     AddCrossProductImpliedOrthantConstraint(prog, Bpos.transpose());
   }
+
+  // If num_intervals_per_half_axis = 2, then for each row/column of R, it
+  // cannot have all three entries in the interval [-0.5, 0.5], since that would
+  // imply that the norm of the row/column is less than sqrt(3) / 2. In this
+  // case, B[i][j](1) = 1 => -0.5 <= R(i, j) <= 0.5, so we should have
+  // sum_i B[i][j](1) <= 2 and sum_j B[i][j](1) <= 2
+  if (num_intervals_per_half_axis == 2) {
+    for (int i = 0; i < 3; ++i) {
+      symbolic::Expression row_sum{0};
+      symbolic::Expression col_sum{0};
+      for (int j = 0; j < 3; ++j) {
+        row_sum += B[i][j](1);
+        col_sum += B[j][i](1);
+      }
+      prog->AddLinearConstraint(row_sum <= 2);
+      prog->AddLinearConstraint(col_sum <= 2);
+    }
+  }
   return std::make_pair(B, phi);
 }
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1064,8 +1064,10 @@ void AddCrossProductImpliedOrthantConstraint(
   // ( 0,  1,  0,  0,  1)
   // ( 0,  1,  1,  1,  1)
   // So this polytope has 2⁵ - 8 = 24 vertices in total.
-  Eigen::Matrix<double, 18, 5> A;
-  Eigen::Matrix<double, 18, 1> b;
+  constexpr int A_rows = 18;
+  constexpr int A_cols = 5;
+  Eigen::Matrix<double, A_rows, A_cols> A;
+  Eigen::Matrix<double, A_rows, 1> b;
   A << 0, 0, 0, 0, -1,
        1, 1, 1, -1, -1,
        1, 1, -1, 1, -1,
@@ -1091,7 +1093,7 @@ void AddCrossProductImpliedOrthantConstraint(
     int col2 = (col1 + 1) % 3;
     // R(k, col2) = R(i, col0) * R(j, col1) - R(j, col0) * R(i, col1)
     // where (i, j, k) = (0, 1, 2), (1, 2, 0) or (2, 0, 1)
-    VectorDecisionVariable<5> var;
+    VectorDecisionVariable<A_cols> var;
     for (int i = 0; i < 3; ++i) {
       int j = (i + 1) % 3;
       int k = (j + 1) % 3;
@@ -1292,7 +1294,7 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
   // the sign of R(i, j). Namely
   // B[i][j](0) = 0 => R(i, j) <= 0
   // B[i][j](0) = 1 => R(i, j) >= 0
-  // We can thus impose constraint on B[i][j](0).
+  // We can thus impose constraints on B[i][j](0).
   if ((num_intervals_per_half_axis & (num_intervals_per_half_axis - 1)) == 0) {
     // num_intervals_per_half_axis is a power of 2.
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1308,26 +1308,27 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
 
     AddCrossProductImpliedOrthantConstraint(prog, Bpos);
     AddCrossProductImpliedOrthantConstraint(prog, Bpos.transpose());
-  }
 
-  // If num_intervals_per_half_axis = 2, then for each row/column of R, it
-  // cannot have all three entries in the interval [-0.5, 0.5], since that would
-  // imply that the norm of the row/column is less than sqrt(3) / 2. In this
-  // case, B[i][j](1) = 1 => -0.5 <= R(i, j) <= 0.5, so we should have
-  // sum_i B[i][j](1) <= 2 and sum_j B[i][j](1) <= 2
-  // TODO(hongkai.dai): generalize this to other num_intervals_per_half_axis.
-  if (num_intervals_per_half_axis == 2) {
-    for (int i = 0; i < 3; ++i) {
-      symbolic::Expression row_sum{0};
-      symbolic::Expression col_sum{0};
-      for (int j = 0; j < 3; ++j) {
-        row_sum += B[i][j](1);
-        col_sum += B[j][i](1);
+    // If num_intervals_per_half_axis is a power of 2, and it's >= 2, then
+    // B[i][j](1) = 1 => -0.5 <= R(i, j) <= 0.5. Furthermore, we know for
+    // each row/column of R, it cannot have all three entries in the interval
+    // [-0.5, 0.5], since that would imply the norm of the row/column being
+    // less than sqrt(3)/2. Thus, we have
+    // sum_i B[i][j](1) <= 2 and sum_j B[i][j](1) <= 2
+    if (num_intervals_per_half_axis >= 2) {
+      for (int i = 0; i < 3; ++i) {
+        symbolic::Expression row_sum{0};
+        symbolic::Expression col_sum{0};
+        for (int j = 0; j < 3; ++j) {
+          row_sum += B[i][j](1);
+          col_sum += B[j][i](1);
+        }
+        prog->AddLinearConstraint(row_sum <= 2);
+        prog->AddLinearConstraint(col_sum <= 2);
       }
-      prog->AddLinearConstraint(row_sum <= 2);
-      prog->AddLinearConstraint(col_sum <= 2);
     }
   }
+
   return std::make_pair(B, phi);
 }
 

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -1064,6 +1064,13 @@ void AddCrossProductImpliedOrthantConstraint(
   // ( 0,  1,  0,  0,  1)
   // ( 0,  1,  1,  1,  1)
   // So this polytope has 2⁵ - 8 = 24 vertices in total.
+  // The matrix A and b are obtained by converting this polytope from its
+  // vertices (V-representation), to its facets (H-representation). We did
+  // this conversion through Multi-parametric toolbox. Here is the MATLAB code
+  // P = Polyhedron(V);
+  // P.computeHRep();
+  // A = P.A;
+  // b = P.b;
   constexpr int A_rows = 18;
   constexpr int A_cols = 5;
   Eigen::Matrix<double, A_rows, A_cols> A;
@@ -1100,7 +1107,7 @@ void AddCrossProductImpliedOrthantConstraint(
       var << Bpos0(i, col0), Bpos0(j, col1), Bpos0(j, col0), Bpos0(i, col1),
           Bpos0(k, col2);
       prog->AddLinearConstraint(A,
-                                Eigen::Matrix<double, 18, 1>::Constant(
+                                Eigen::Matrix<double, A_rows, 1>::Constant(
                                     -std::numeric_limits<double>::infinity()),
                                 b, var);
     }

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -568,9 +568,10 @@ INSTANTIATE_TEST_CASE_P(
                            {false, true}),  // row vector or column vector
                        ::testing::ValuesIn<std::array<std::pair<int, int>, 3>>(
                            vector_indices()),  // vector indices
-                       ::testing::ValuesIn<std::vector<bool>>({false, true}),  // same of opposite orthant
-                           ::testing::ValuesIn<std::vector<bool>>(
-                               {false, true}))); // replace bilinear or not.
+                       ::testing::ValuesIn<std::vector<bool>>(
+                           {false, true}),  // same of opposite orthant
+                       ::testing::ValuesIn<std::vector<bool>>(
+                           {false, true})));  // replace bilinear or not.
 }  // namespace
 }  // namespace solvers
 }  // namespace drake


### PR DESCRIPTION
Based on the sign of some entries in the rotation matrix, we can imply the sign of other entries. This can be used to impose linear constraints on the binary variables, in the SO(3) relaxation. Potentially these linear constraints should make the mixed-integer optimization faster.

In this PR, we consider the constraints on the signs, implied by the orthogonality and cross product constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6693)
<!-- Reviewable:end -->
