### PR TITLE
Fix BUILD file style issues

### DIFF
--- a/drake/BUILD
+++ b/drake/BUILD
@@ -11,7 +11,8 @@ load("//tools:transitive_hdrs.bzl", "transitive_hdrs_library")
 # any new external dependencies to :external_licenses.
 
 # This is the *sorted* output of the following Bazel query:
-# bazel query 'kind("cc_library", visible("//drake:libdrake.so", "//drake/..."))
+# bazel query 'kind("cc_library",
+# visible("//drake:libdrake.so", "//drake/..."))
 # except("//drake/examples/...")
 # except(attr("testonly", "1", "//drake/..."))
 # except("//drake/lcmtypes/...")
@@ -104,7 +105,7 @@ _LIBDRAKE_COMPONENTS = [
     "//drake:mosek_deps",
     "//drake/multibody:approximate_ik",
     "//drake/multibody/benchmarks/acrobot:acrobot",
-    "//drake/multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",
+    "//drake/multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",  # noqa
     "//drake/multibody/collision:bullet_collision",
     "//drake/multibody/collision:collision_api",
     "//drake/multibody/collision:fcl_collision",

--- a/drake/automotive/maliput/dragway/BUILD
+++ b/drake/automotive/maliput/dragway/BUILD
@@ -2,7 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_binary", "drake_cc_googletest", "drake_cc_library")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
 
 package(default_visibility = ["//visibility:public"])
 

--- a/drake/automotive/maliput/monolane/BUILD
+++ b/drake/automotive/maliput/monolane/BUILD
@@ -2,7 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_binary", "drake_cc_googletest", "drake_cc_library")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
 load("//tools:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])

--- a/drake/automotive/maliput/multilane/BUILD
+++ b/drake/automotive/maliput/multilane/BUILD
@@ -2,7 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_binary", "drake_cc_googletest", "drake_cc_library")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
 load("//tools:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])

--- a/drake/bindings/pybind.bzl
+++ b/drake/bindings/pybind.bzl
@@ -2,7 +2,7 @@
 
 load("//tools:drake.bzl", "drake_cc_binary")
 
-def drake_pybind_cc_binary(name, srcs=[], copts=[], **kwargs):
+def drake_pybind_cc_binary(name, srcs = [], copts = [], **kwargs):
     """Declare a pybind11 shared library with the given name and srcs.  The
     libdrake.so library and its headers are already automatically depended-on
     by this rule.

--- a/drake/examples/QPInverseDynamicsForHumanoids/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/BUILD
@@ -41,7 +41,7 @@ drake_cc_library(
     hdrs = ["humanoid_status.h"],
     deps = [
         "//drake/common",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",  # noqa
         "//drake/multibody:rigid_body_tree",
         "//drake/systems/robotInterfaces:side",
     ],
@@ -126,7 +126,7 @@ drake_cc_googletest(
         ":qp_controller",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
         "//drake/examples/valkyrie:valkyrie_constants",
         "//drake/multibody/parsers",
     ],
@@ -146,7 +146,7 @@ drake_cc_googletest(
         ":qp_controller",
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
         "//drake/multibody/parsers",
     ],
 )

--- a/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/param_parsers/BUILD
@@ -6,8 +6,9 @@ load("//tools:drake.bzl", "drake_cc_library", "drake_cc_googletest")
 load("@protobuf//:protobuf.bzl", "cc_proto_library")
 
 package(
-    default_visibility =
-        ["//drake/examples/QPInverseDynamicsForHumanoids:__subpackages__"],
+    default_visibility = [
+        "//drake/examples/QPInverseDynamicsForHumanoids:__subpackages__",
+    ],
 )
 
 drake_cc_library(

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/BUILD
@@ -28,8 +28,8 @@ drake_cc_library(
         "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
         "//drake/examples/QPInverseDynamicsForHumanoids:humanoid_status",
         "//drake/examples/QPInverseDynamicsForHumanoids:qp_controller_common",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",  # noqa
         "//drake/manipulation/util:trajectory_utils",
         "//drake/systems/framework:value",
     ],
@@ -54,8 +54,8 @@ drake_cc_library(
 drake_cc_googletest(
     name = "manipulator_plan_test",
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",  # noqa
         "//drake/manipulation/models/iiwa_description:models",
     ],
     deps = [
@@ -107,11 +107,12 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
 drake_cc_googletest(
     name = "generic_plan_test",
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",  # noqa
         "//drake/manipulation/models/iiwa_description:models",
     ],
     deps = [
@@ -131,8 +132,8 @@ drake_cc_library(
     ],
     deps = [
         "//drake/examples/QPInverseDynamicsForHumanoids:humanoid_status",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",  # noqa
     ],
 )
 

--- a/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/BUILD
@@ -51,8 +51,8 @@ drake_cc_library(
     deps = [
         "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
         "//drake/examples/QPInverseDynamicsForHumanoids:humanoid_status",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:rigid_body_tree_alias_groups",  # noqa
         "//drake/systems/framework:leaf_system",
     ],
 )
@@ -63,7 +63,7 @@ drake_cc_library(
     hdrs = ["humanoid_plan_eval_system.h"],
     deps = [
         ":plan_eval_base_system",
-        "//drake/examples/QPInverseDynamicsForHumanoids/plan_eval:humanoid_manipulation_plan",
+        "//drake/examples/QPInverseDynamicsForHumanoids/plan_eval:humanoid_manipulation_plan",  # noqa
     ],
 )
 
@@ -126,8 +126,8 @@ drake_cc_binary(
         "valkyrie_balancing_controller_system.cc",
     ],
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",  # noqa
         "//drake/examples/valkyrie:models",
     ],
     tags = gurobi_test_tags(),
@@ -143,8 +143,8 @@ drake_cc_googletest(
     name = "humanoid_plan_eval_test",
     srcs = ["test/humanoid_plan_eval_system_test.cc"],
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/valkyrie.id_controller_config",  # noqa
         "//drake/examples/valkyrie:models",
     ],
     tags = gurobi_test_tags(),
@@ -155,7 +155,7 @@ drake_cc_googletest(
         "//drake/common:find_resource",
         "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
         "//drake/examples/QPInverseDynamicsForHumanoids:qp_controller",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
         "//drake/examples/valkyrie:valkyrie_constants",
         "//drake/multibody/parsers",
         "//drake/systems/analysis:simulator",
@@ -168,8 +168,8 @@ drake_cc_googletest(
     name = "manipulator_inverse_dynamics_controller_test",
     srcs = ["test/manipulator_inverse_dynamics_controller_test.cc"],
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",  # noqa
         "//drake/manipulation/models/iiwa_description:models",
     ],
     tags = gurobi_test_tags(),
@@ -189,8 +189,8 @@ drake_cc_googletest(
     name = "qp_controller_system_test",
     srcs = ["test/qp_controller_system_test.cc"],
     data = [
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",
-        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.alias_groups",  # noqa
+        "//drake/examples/QPInverseDynamicsForHumanoids:config/iiwa.id_controller_config",  # noqa
         "//drake/manipulation/models/iiwa_description:models",
     ],
     tags = gurobi_test_tags(),
@@ -199,7 +199,7 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
         "//drake/common:find_resource",
         "//drake/examples/QPInverseDynamicsForHumanoids:control_utils",
-        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",
+        "//drake/examples/QPInverseDynamicsForHumanoids/param_parsers:param_parser",  # noqa
         "//drake/multibody/parsers",
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework",

--- a/drake/examples/pendulum/BUILD
+++ b/drake/examples/pendulum/BUILD
@@ -2,7 +2,12 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("//tools:cpplint.bzl", "cpplint")
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library", "drake_cc_binary")
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_binary",
+)
 
 drake_cc_library(
     name = "pendulum_state_vector",

--- a/drake/multibody/collision/BUILD
+++ b/drake/multibody/collision/BUILD
@@ -87,8 +87,8 @@ drake_cc_library(
     ],
     defines = ["BULLET_COLLISION"],
     deps = [
-        ":collision_api",
         ":bullet_collision",
+        ":collision_api",
         ":fcl_collision",
         ":unusable_collision",
     ],

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -226,7 +226,7 @@ drake_cc_library(
         "//drake/common:find_resource",
         "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/multibody/rigid_body_plant:rigid_body_plant_that_publishes_xdot",
+        "//drake/multibody/rigid_body_plant:rigid_body_plant_that_publishes_xdot",  # noqa
         "//drake/systems/lcm:lcmt_drake_signal_translator",
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:signal_logger",

--- a/tools/bazel_lint.bzl
+++ b/tools/bazel_lint.bzl
@@ -46,7 +46,7 @@ def bazel_lint(name = "bazel", ignore = [265, 302, 305]):
 
     Example:
         BUILD:
-            load("//tools:python_lint.bzl", "bazel_lint")
+            load("//tools:bazel_lint.bzl", "bazel_lint")
 
             bazel_lint()
     """


### PR DESCRIPTION
This is in preparation for turning on `bazel_lint()` everywhere.  For context, the full related patchset is at https://github.com/jwnimmer-tri/drake/tree/build-common-lint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6703)
<!-- Reviewable:end -->
