### PR TITLE
Fix pycodestyle errors

### DIFF
--- a/drake/automotive/gen/bicycle_car_parameters.h
+++ b/drake/automotive/gen/bicycle_car_parameters.h
@@ -44,12 +44,12 @@ class BicycleCarParameters : public systems::BasicVector<T> {
   typedef BicycleCarParametersIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c mass defaults to 2278.0 in units of kg.
-  /// @arg @c lf defaults to 1.292 in units of m.
-  /// @arg @c lr defaults to 1.515 in units of m.
-  /// @arg @c Iz defaults to 3210.0 in units of kg m^2.
-  /// @arg @c Cf defaults to 10.8e4 in units of N / rad.
-  /// @arg @c Cr defaults to 10.8e4 in units of N / rad.
+  /// @arg @c mass defaults to 2278.0 kg.
+  /// @arg @c lf defaults to 1.292 m.
+  /// @arg @c lr defaults to 1.515 m.
+  /// @arg @c Iz defaults to 3210.0 kg m^2.
+  /// @arg @c Cf defaults to 10.8e4 N / rad.
+  /// @arg @c Cr defaults to 10.8e4 N / rad.
   BicycleCarParameters() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_mass(2278.0);
     this->set_lf(1.292);

--- a/drake/automotive/gen/driving_command.h
+++ b/drake/automotive/gen/driving_command.h
@@ -40,8 +40,8 @@ class DrivingCommand : public systems::BasicVector<T> {
   typedef DrivingCommandIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c steering_angle defaults to 0.0 in units of rad.
-  /// @arg @c acceleration defaults to 0.0 in units of m/s^2.
+  /// @arg @c steering_angle defaults to 0.0 rad.
+  /// @arg @c acceleration defaults to 0.0 m/s^2.
   DrivingCommand() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_steering_angle(0.0);
     this->set_acceleration(0.0);

--- a/drake/automotive/gen/idm_planner_parameters.h
+++ b/drake/automotive/gen/idm_planner_parameters.h
@@ -47,15 +47,15 @@ class IdmPlannerParameters : public systems::BasicVector<T> {
   typedef IdmPlannerParametersIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c v_ref defaults to 10.0 in units of m/s.
-  /// @arg @c a defaults to 1.0 in units of m/s^2.
-  /// @arg @c b defaults to 3.0 in units of m/s^2.
-  /// @arg @c s_0 defaults to 1.0 in units of m.
-  /// @arg @c time_headway defaults to 0.1 in units of s.
-  /// @arg @c delta defaults to 4.0 in units of dimensionless.
-  /// @arg @c bloat_diameter defaults to 4.5 in units of m.
-  /// @arg @c distance_lower_limit defaults to 1e-2 in units of m.
-  /// @arg @c scan_ahead_distance defaults to 100.0 in units of m.
+  /// @arg @c v_ref defaults to 10.0 m/s.
+  /// @arg @c a defaults to 1.0 m/s^2.
+  /// @arg @c b defaults to 3.0 m/s^2.
+  /// @arg @c s_0 defaults to 1.0 m.
+  /// @arg @c time_headway defaults to 0.1 s.
+  /// @arg @c delta defaults to 4.0 dimensionless.
+  /// @arg @c bloat_diameter defaults to 4.5 m.
+  /// @arg @c distance_lower_limit defaults to 1e-2 m.
+  /// @arg @c scan_ahead_distance defaults to 100.0 m.
   IdmPlannerParameters() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_v_ref(10.0);
     this->set_a(1.0);

--- a/drake/automotive/gen/maliput_railcar_params.h
+++ b/drake/automotive/gen/maliput_railcar_params.h
@@ -42,10 +42,10 @@ class MaliputRailcarParams : public systems::BasicVector<T> {
   typedef MaliputRailcarParamsIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c r defaults to 0.0 in units of m.
-  /// @arg @c h defaults to 0.0 in units of m.
-  /// @arg @c max_speed defaults to 45.0 in units of m/s.
-  /// @arg @c velocity_limit_kp defaults to 10.0 in units of Hz.
+  /// @arg @c r defaults to 0.0 m.
+  /// @arg @c h defaults to 0.0 m.
+  /// @arg @c max_speed defaults to 45.0 m/s.
+  /// @arg @c velocity_limit_kp defaults to 10.0 Hz.
   MaliputRailcarParams() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_r(0.0);
     this->set_h(0.0);

--- a/drake/automotive/gen/mobil_planner_parameters.h
+++ b/drake/automotive/gen/mobil_planner_parameters.h
@@ -41,9 +41,9 @@ class MobilPlannerParameters : public systems::BasicVector<T> {
   typedef MobilPlannerParametersIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c p defaults to 0.5 in units of dimensionless.
-  /// @arg @c threshold defaults to 0.1 in units of m/s^2.
-  /// @arg @c max_deceleration defaults to 4.0 in units of m/s^2.
+  /// @arg @c p defaults to 0.5 dimensionless.
+  /// @arg @c threshold defaults to 0.1 m/s^2.
+  /// @arg @c max_deceleration defaults to 4.0 m/s^2.
   MobilPlannerParameters() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_p(0.5);
     this->set_threshold(0.1);

--- a/drake/automotive/gen/pure_pursuit_params.h
+++ b/drake/automotive/gen/pure_pursuit_params.h
@@ -39,7 +39,7 @@ class PurePursuitParams : public systems::BasicVector<T> {
   typedef PurePursuitParamsIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c s_lookahead defaults to 15.0 in units of m.
+  /// @arg @c s_lookahead defaults to 15.0 m.
   PurePursuitParams() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_s_lookahead(15.0);
   }

--- a/drake/automotive/gen/simple_car_params.h
+++ b/drake/automotive/gen/simple_car_params.h
@@ -44,12 +44,12 @@ class SimpleCarParams : public systems::BasicVector<T> {
   typedef SimpleCarParamsIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c wheelbase defaults to 2.700 in units of m.
-  /// @arg @c track defaults to 1.521 in units of m.
-  /// @arg @c max_abs_steering_angle defaults to 0.471 in units of rad.
-  /// @arg @c max_velocity defaults to 45.0 in units of m/s.
-  /// @arg @c max_acceleration defaults to 4.0 in units of m/s^2.
-  /// @arg @c velocity_limit_kp defaults to 10.0 in units of Hz.
+  /// @arg @c wheelbase defaults to 2.700 m.
+  /// @arg @c track defaults to 1.521 m.
+  /// @arg @c max_abs_steering_angle defaults to 0.471 rad.
+  /// @arg @c max_velocity defaults to 45.0 m/s.
+  /// @arg @c max_acceleration defaults to 4.0 m/s^2.
+  /// @arg @c velocity_limit_kp defaults to 10.0 Hz.
   SimpleCarParams() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_wheelbase(2.700);
     this->set_track(1.521);

--- a/drake/examples/geometry_world/gen/bouncing_ball_vector.h
+++ b/drake/examples/geometry_world/gen/bouncing_ball_vector.h
@@ -23,8 +23,8 @@ struct BouncingBallVectorIndices {
   static const int kNumCoordinates = 2;
 
   // The index of each individual coordinate.
-static const int kZ = 0;
-static const int kZdot = 1;
+  static const int kZ = 0;
+  static const int kZdot = 1;
 
   /// Returns a vector containing the names of each coordinate within this
   /// class. The indices within the returned vector matches that of this class.
@@ -53,14 +53,10 @@ class BouncingBallVector : public systems::BasicVector<T> {
   //@{
   /// z
   const T& z() const { return this->GetAtIndex(K::kZ); }
-  void set_z(const T& z) {
-    this->SetAtIndex(K::kZ, z);
-  }
+  void set_z(const T& z) { this->SetAtIndex(K::kZ, z); }
   /// zdot
   const T& zdot() const { return this->GetAtIndex(K::kZdot); }
-  void set_zdot(const T& zdot) {
-    this->SetAtIndex(K::kZdot, zdot);
-  }
+  void set_zdot(const T& zdot) { this->SetAtIndex(K::kZdot, zdot); }
   //@}
 
   /// See BouncingBallVectorIndices::GetCoordinateNames().

--- a/drake/tools/clang_format_includes.py
+++ b/drake/tools/clang_format_includes.py
@@ -2,8 +2,8 @@
 
 """Rewrite the filenames given on the command line to obey formatting rules for
 #include statements.  The only changes this script will make are to relocate
-#include statements, and possibly some associated additions or removals of blank
-lines near the #include blocks.
+#include statements, and possibly some associated additions or removals of
+blank lines near the #include blocks.
 
 """
 

--- a/drake/tools/test/gen/sample.h
+++ b/drake/tools/test/gen/sample.h
@@ -42,9 +42,9 @@ class Sample : public systems::BasicVector<T> {
   typedef SampleIndices K;
 
   /// Default constructor.  Sets all rows to their default value:
-  /// @arg @c x defaults to 42.0 in units of m/s.
-  /// @arg @c two_word defaults to 0.0 in units of unknown.
-  /// @arg @c absone defaults to 0.0 in units of unknown.
+  /// @arg @c x defaults to 42.0 m/s.
+  /// @arg @c two_word defaults to 0.0 with unknown units.
+  /// @arg @c absone defaults to 0.0 with unknown units.
   Sample() : systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_x(42.0);
     this->set_two_word(0.0);

--- a/tools/cmake_configure_file.py
+++ b/tools/cmake_configure_file.py
@@ -61,6 +61,7 @@ def _transform(line, definitions):
 
     return line
 
+
 # Looks like "set(VAR value)".
 _set_var = re.compile(r'^\s*set\s*\(\s*(.+)\s+(.+)\s*\)\s*$')
 
@@ -120,6 +121,7 @@ def main():
                 output_line = _transform(input_line, definitions)
                 output_file.write(output_line)
     os.rename(args.output + '.tmp', args.output)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is in preparation for turning on `python_lint()` everywhere. For context, the full related patchset is at https://github.com/jwnimmer-tri/drake/tree/build-common-lint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6704)
<!-- Reviewable:end -->
