### PR TITLE
Create a lint.bzl for convenience and correctness

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,9 +4,9 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
-load("//tools:bazel_lint.bzl", "bazel_lint")
 load("//tools:check_licenses.bzl", "check_licenses")
 load("//tools:install.bzl", "install", "install_files")
+load("//tools:lint.bzl", "add_lint_tests")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -74,4 +74,4 @@ install(
 
 check_licenses(DRAKE_EXTERNAL_PACKAGE_INSTALLS + [":install"])
 
-bazel_lint()
+add_lint_tests()

--- a/drake/BUILD
+++ b/drake/BUILD
@@ -4,6 +4,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:install.bzl", "install")
+load("//tools:lint.bzl", "add_lint_tests")
 load("//tools:transitive_hdrs.bzl", "transitive_hdrs_library")
 
 # Should include everything any consumer of Drake would ever need.
@@ -364,3 +365,5 @@ cc_library(
         ":vtk_deps",
     ],
 )
+
+add_lint_tests()

--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -1,11 +1,10 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:cpplint.bzl", "cpplint")
 load("//tools:gurobi.bzl", "gurobi_test_tags")
 load("//tools:install.bzl", "install")
+load("//tools:lint.bzl", "add_lint_tests")
 load("//tools:mosek.bzl", "mosek_test_tags")
-load("//tools:python_lint.bzl", "python_lint")
 load(":pybind.bzl", "drake_pybind_cc_binary")
 
 package(default_visibility = ["//visibility:private"])
@@ -253,6 +252,4 @@ py_test(
     deps = [":pydrake"],
 )
 
-cpplint()
-
-python_lint()
+add_lint_tests()

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -1,15 +1,14 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
     "drake_cc_binary",
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools:python_lint.bzl", "python_lint")
 load("//tools:install.bzl", "install")
+load("//tools:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -816,6 +815,4 @@ py_test(
 # - drake_deprecated_test in fancy variants
 # - cpplint_wrapper_test.py
 
-cpplint()
-
-python_lint()
+add_lint_tests()

--- a/drake/doc/BUILD
+++ b/drake/doc/BUILD
@@ -3,6 +3,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//tools:lint.bzl", "add_lint_tests")
+
 genrule(
     name = "sphinx",
     srcs = glob([
@@ -38,3 +40,5 @@ py_binary(
     srcs = ["serve_sphinx.py"],
     data = [":sphinx.zip"],
 )
+
+add_lint_tests(python_lint_exclude = [":conf.py"])

--- a/drake/doc/bazel.rst
+++ b/drake/doc/bazel.rst
@@ -119,6 +119,8 @@ This config turns off sandboxing, which allows a ``genrule`` to access the
 
 For more information, see https://github.com/bazelbuild/bazel/issues/2537.
 
+.. _buildifier:
+
 Updating BUILD files
 ====================
 

--- a/drake/doc/code_style_tools.rst
+++ b/drake/doc/code_style_tools.rst
@@ -14,42 +14,48 @@ to learn about them. Please document your trick and submit a pull request!
    :depth: 3
    :local:
 
-All Languages
-=============
+Automated style checks
+======================
 
-.. _code-style-tools-all-languages:
-
-When using the Bazel build system, code style tests are run by default during
-``bazel test`` and its results are cached so that only edited files are
-re-checked.
-In other words, no special action is required to use the tool.
+Code style tests are run by default during ``bazel test`` and the results are
+cached so that only edited files are re-checked.  In other words, no special
+action is required by a developer.
 
 However, you may still invoke code style checks directly if desired, as
 follows::
 
   cd /path/to/drake-distro
-  bazel test --config lint ...                  # Only run style checks; don't build or test anything else.
-  bazel test --config lint //drake/common/...   # Check common/ and its child subdirectories.
+  bazel test --config lint //...               # Only run style checks; don't build or test anything else.
+  bazel test --config lint //drake/common/...  # Check common/ and its child subdirectories.
 
-  cd drake/systems/framework
-  bazel test --config lint ...                  # Check systems/framework/ and its child subdirectories.
+User manuals for the style-checking tools are as follows:
 
-C/C++
-=====
+- C/C++: See the cpplint ``USAGE`` string at
+  https://github.com/google/styleguide/blob/gh-pages/cpplint/cpplint.py.
+
+  - In particular, note the ``// NOLINT(foo/bar)`` syntax to disable a warning.
+
+- Python: See the pycodestyle manual at
+  http://pycodestyle.readthedocs.io/en/latest/intro.html.
+
+  - The syntax ``# noqa`` can be used to quiet the warning about an overly-long
+    line.
+
+- Bazel: Uses both pycodestyle like Python, and also :ref:`buildifier <buildifier>`.
+
+
+Manual style fixups
+===================
 
 .. _code-style-tools-clang-format:
 
-Clang-Format
-------------
+C/C++: Clang-Format
+-------------------
 
-Installation
-^^^^^^^^^^^^
-
-Follow the
-:ref:`Mandatory platform specific instructions <platform_specific_setup>`.
-
-On Ubuntu, you may also wish to create an alias (assuming ``$HOME/bin`` is
-already on your ``$PATH``)::
+The
+:ref:`Mandatory platform specific instructions <platform_specific_setup>`
+already install clang-format.  On Ubuntu, you may wish to create an alias
+(assuming ``$HOME/bin`` is already on your ``$PATH``)::
 
     ln -s /usr/bin/clang-format-3.9 $HOME/bin/clang-format
 
@@ -57,96 +63,6 @@ You can check whether you've installed it correctly by executing::
 
     clang-format --help
 
-Usage
-^^^^^
-
 To run clang-format::
 
     clang-format -i -style=file [file name]
-
-cpplint
--------
-
-`cpplint <https://github.com/google/styleguide/tree/gh-pages/cpplint>`_
-is a tool for finding compliance violations.
-
-Usage via Bazel
-^^^^^^^^^^^^^^^
-
-Use the command in `All Languages`_, but change the configuration to use
-``cpplint``::
-
-  bazel test --config cpplint ...
-
-
-Python
-======
-
-.. _code-style-tools-pycodestyle:
-
-pycodestyle.py
---------------
-
-``pycodestyle``, which used to be ``pep8``, is the primary code style checker
-used within Drake.
-
-Usage via Bazel
-^^^^^^^^^^^^^^^
-
-Use the command in `All Languages`_, but change the configuration to use
-``pycodestyle``::
-
-  bazel test --config pycodestyle ...
-
-Usage without Bazel
-^^^^^^^^^^^^^^^^^^^
-
-First, ensure that you have ``pycodestyle`` installed. On Ubuntu, install via
-``pip``::
-
-  pip install --user -U pycodestyle
-
-To your ``.bashrc`` or ``.profile``, add the line::
-
-  export PATH=$HOME/.local/bin:$PATH
-
-On OSX, similarly::
-
-  pip install --user -U pycodestyle
-
-To your ``.bashrc`` or ``.bash_profile``, add the line::
-
-  export PATH=$HOME/Library/Python/2.7/bin:$PATH
-
-Run ``pycodestyle`` like this::
-
-  pycodestyle [file name]
-
-It is possible to suppress pycodestyle errors, either via configuration files
-in various locations, or command line options. However, it does not support
-individual suppressions via source code comments. Consult the program's
-`--help` or ``pycodestyle.readthedocs.org`` for details.
-
-.. _code-style-tools-pylint:
-
-pylint
-------
-
-Installation
-^^^^^^^^^^^^
-
-Like ``pycodestyle``, ``pylint`` should be installed via ``pip``.
-Instructions are exactly analogous to those for ``pycodestyle`` above,
-substituting the package name
-``pylint``.
-
-Usage
-^^^^^
-
-To run ``pylint``, with some noisy reports and questionable rules suppressed::
-
-  pylint --reports=n --disable=C,R [file name]
-
-It is possible to suppress pylint complaints, either via configuration files in
-various locations, or by special comments in python source files. Consult the
-program's `--help` or ``docs.pylint.org`` for details.

--- a/drake/tools/BUILD
+++ b/drake/tools/BUILD
@@ -2,9 +2,9 @@
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
 load("@protobuf//:protobuf.bzl", "py_proto_library")
-load("//tools:cpplint.bzl", "cpplint")
 load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
 load("//tools:lcm.bzl", "lcm_cc_library")
+load("//tools:lint.bzl", "add_lint_tests")
 
 py_proto_library(
     name = "named_vector",
@@ -113,4 +113,4 @@ sh_test(
     ],
 )
 
-cpplint(data = ["test/gen/drake/CPPLINT.cfg"])
+add_lint_tests(cpplint_data = ["test/gen/drake/CPPLINT.cfg"])

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,12 +1,12 @@
 # -*- python -*-
 
-load("//tools:bazel_lint.bzl", "bazel_lint")
 load(
     "//tools:install.bzl",
     "cmake_config",
     "exports_create_cps_scripts",
     "install_cmake_config",
 )
+load("//tools:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -371,4 +371,4 @@ config_setting(
     },
 )
 
-bazel_lint()
+add_lint_tests()

--- a/tools/bazel_lint.bzl
+++ b/tools/bazel_lint.bzl
@@ -33,7 +33,7 @@ def _bazel_lint(name, files, ignore):
         )
 
 #------------------------------------------------------------------------------
-def bazel_lint(name = "bazel", ignore = [265, 302, 305]):
+def bazel_lint(name = "bazel", ignore = None):
     """
     Runs the ``bzlcodestyle`` code style checker on all Bazel files in the
     current directory. The tool is based on the ``pycodestyle`` :pep:`8` code
@@ -50,6 +50,9 @@ def bazel_lint(name = "bazel", ignore = [265, 302, 305]):
 
             bazel_lint()
     """
+
+    if ignore == None:
+        ignore = [265, 302, 305]
 
     _bazel_lint(
         name = name,

--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -73,7 +73,7 @@ def _add_linter_rules(source_labels, source_filenames, name, data = None):
         tags = tags,
     )
 
-def cpplint(data = None, extra_srcs = None):
+def cpplint(existing_rules = None, data = None, extra_srcs = None):
     """For every rule in the BUILD file so far, adds a test rule that runs
     cpplint over the C++ sources listed in that rule.  Thus, BUILD file authors
     should call this function at the *end* of every C++-related BUILD file.
@@ -84,9 +84,15 @@ def cpplint(data = None, extra_srcs = None):
     Sources that are not discoverable through the "sources so far" heuristic
     can be passed in as extra_srcs=[].
 
+    The existing_rules may supply the native.existing_result().values(), in
+    case it has already been computed.  When not supplied, the value will be
+    internally (re-)computed.
+
     """
-    # Iterate over all rules.
-    for rule in native.existing_rules().values():
+    if existing_rules == None:
+        existing_rules = native.existing_rules().values()
+
+    for rule in existing_rules:
         if rule.get("generator_function") == "lcm_cc_library":
             # Do not lint generated code.
             continue

--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -87,6 +87,10 @@ def cpplint(data = None, extra_srcs = None):
     """
     # Iterate over all rules.
     for rule in native.existing_rules().values():
+        if rule.get("generator_function") == "lcm_cc_library":
+            # Do not lint generated code.
+            continue
+
         # Extract the list of C++ source code labels and convert to filenames.
         candidate_labels = (
             _extract_labels(rule.get("srcs", ())) +

--- a/tools/lint.bzl
+++ b/tools/lint.bzl
@@ -1,0 +1,34 @@
+# -*- python -*-
+
+load("//tools:bazel_lint.bzl", "bazel_lint")
+load("//tools:cpplint.bzl", "cpplint")
+load("//tools:python_lint.bzl", "python_lint")
+
+def add_lint_tests(
+        cpplint_data = None,
+        cpplint_extra_srcs = None,
+        python_lint_ignore = None,
+        python_lint_exclude = None,
+        bazel_lint_ignore = None):
+    """For every rule in the BUILD file so far, and for all Bazel files in this
+    directory, adds test rules that run Drake's standard lint suite over the
+    sources.  Thus, BUILD file authors should call this function at the *end*
+    of every BUILD file.
+
+    Refer to the specific linters for their semantics and argument details:
+    - bazel_lint.bzl
+    - cpplint.bzl
+    - python_lint.bzl
+
+    """
+    existing_rules = native.existing_rules().values()
+    cpplint(
+        existing_rules = existing_rules,
+        data = cpplint_data,
+        extra_srcs = cpplint_extra_srcs)
+    python_lint(
+        existing_rules = existing_rules,
+        ignore = python_lint_ignore,
+        exclude = python_lint_exclude)
+    bazel_lint(
+        ignore = bazel_lint_ignore)

--- a/tools/python_lint.bzl
+++ b/tools/python_lint.bzl
@@ -5,23 +5,22 @@
 # Internal helper; set up test given name and list of files. Will do nothing
 # if no files given.
 def _python_lint(name, files, ignore):
-    if files:
-        if ignore:
-            ignore = ["--ignore=" + ",".join(["E%s" % e for e in ignore])]
+    if ignore:
+        ignore = ["--ignore=" + ",".join(["E%s" % e for e in ignore])]
 
-        native.py_test(
-            name = name,
-            size = "small",
-            srcs = ["@pycodestyle//:pycodestyle"],
-            data = files,
-            args = ignore + ["$(location %s)" % f for f in files],
-            main = "@pycodestyle//:pycodestyle.py",
-            srcs_version = "PY2AND3",
-            tags = ["pycodestyle", "lint"],
-        )
+    native.py_test(
+        name = name,
+        size = "small",
+        srcs = ["@pycodestyle//:pycodestyle"],
+        data = files,
+        args = (ignore or []) + ["$(location %s)" % f for f in files],
+        main = "@pycodestyle//:pycodestyle.py",
+        srcs_version = "PY2AND3",
+        tags = ["pycodestyle", "lint"],
+    )
 
 #------------------------------------------------------------------------------
-def python_lint(ignore = []):
+def python_lint(ignore = None, exclude = None):
     """
     Runs the pycodestyle PEP 8 code style checker on all Python source files
     declared in rules in a BUILD file.
@@ -29,6 +28,7 @@ def python_lint(ignore = []):
     Args:
         ignore: List of errors (as integers, without the 'E') to ignore
             (default = []).
+        exclude: List of labels to exclude from linting, e.g., [:foo.py].
 
     Example:
         BUILD:
@@ -49,13 +49,21 @@ def python_lint(ignore = []):
                 "lcm_py_library"]:
             continue
 
+        # Extract the list of python sources.
         srcs = rule.get("srcs", ())
-
         if type(srcs) == type(()):
-            src_labels = list(srcs)
+            files = [
+                s for s in srcs
+                if s.endswith(".py") and s not in (exclude or [])]
+        else:
+            # The select() syntax returns an object we (apparently) can't
+            # inspect.  TODO(jwnimmer-tri) Figure out how to lint these files.
+            files = []
 
+        # Add a lint test if necessary.
+        if files:
             _python_lint(
                 name = rule["name"] + "_pycodestyle",
-                files = [s for s in src_labels if s.endswith(".py")],
+                files = files,
                 ignore = ignore,
             )

--- a/tools/python_lint.bzl
+++ b/tools/python_lint.bzl
@@ -20,12 +20,15 @@ def _python_lint(name, files, ignore):
     )
 
 #------------------------------------------------------------------------------
-def python_lint(ignore = None, exclude = None):
+def python_lint(existing_rules = None, ignore = None, exclude = None):
     """
     Runs the pycodestyle PEP 8 code style checker on all Python source files
     declared in rules in a BUILD file.
 
     Args:
+        existing_rules: The value of native.existing_result().values(), in case
+            it has already been computed.  When not supplied, the value will be
+            internally (re-)computed.
         ignore: List of errors (as integers, without the 'E') to ignore
             (default = []).
         exclude: List of labels to exclude from linting, e.g., [:foo.py].
@@ -42,7 +45,9 @@ def python_lint(ignore = None, exclude = None):
             python_lint()
     """
 
-    for rule in native.existing_rules().values():
+    if existing_rules == None:
+        existing_rules = native.existing_rules().values()
+    for rule in existing_rules:
         # Do not lint generated code.
         if rule.get("generator_function") in [
                 "py_proto_library",

--- a/tools/python_lint.bzl
+++ b/tools/python_lint.bzl
@@ -43,6 +43,12 @@ def python_lint(ignore = []):
     """
 
     for rule in native.existing_rules().values():
+        # Do not lint generated code.
+        if rule.get("generator_function") in [
+                "py_proto_library",
+                "lcm_py_library"]:
+            continue
+
         srcs = rule.get("srcs", ())
 
         if type(srcs) == type(()):


### PR DESCRIPTION
Our `BUILD` files should just call out to a single `add_lint_tests()` that does the right thing for all languages.

Detailed commits as follows:
- Do not lint generated code.
- Add `python_lint` argument `exclude`.
- Create a `lint.bzl` for convenience and correctness.
- Rewrite code style advice.
- Port a representative subset of `BUILD`s to `lint.bzl`.

For reference: the feature branch at https://github.com/jwnimmer-tri/drake/tree/build-common-lint contains a final patch (not part of this PR) that ports all of Drake to use `lint.bzl`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6711)
<!-- Reviewable:end -->
