### PR TITLE
Fix remaining parameter shadowing in articulated_icp.

### DIFF
--- a/drake/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/drake/perception/estimators/dev/test/articulated_icp_test.cc
@@ -43,8 +43,8 @@ const double kQDiffNormMin = 0.01;
  */
 struct Interval {
   Interval() {}
-  Interval(double min, double max)
-      : min(min), max(max) {
+  Interval(double min_in, double max_in)
+      : min(min_in), max(max_in) {
     DRAKE_DEMAND(min <= max);
   }
   double min{};
@@ -55,8 +55,8 @@ struct Interval {
 
 struct Bounds {
   Bounds() {}
-  Bounds(Interval x, Interval y, Interval z)
-      : x(x), y(y), z(z) {}
+  Bounds(Interval x_in, Interval y_in, Interval z_in)
+      : x(x_in), y(y_in), z(z_in) {}
   Interval x;
   Interval y;
   Interval z;


### PR DESCRIPTION
This fixes the remaining parameter shadowing.

I will up the priority for resolving #6544 to avoid this in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6718)
<!-- Reviewable:end -->
