### PR TITLE
Add -Werror=shadow to clang flags in Bazel, and ensure Bazel + CMake CXX flags are similar

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -77,13 +77,20 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=inconsistent-missing-override")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=sign-compare")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-stack-address")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=non-virtual-dtor")
 else()
   # TODO(jwnimmer-tri) Get a similar complement of flags working on clang.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=extra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-local-addr")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=non-virtual-dtor")
   # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
+  # This is only intended for tests, but is included for the entire build
+  # in CMake since there is not an easy mechanism to enable this only for
+  # tests.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+  # TODO(#2852) Turn on shadow checking for g++ once we use a version that
+  # fixes https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
 endif()
 set(CXX_FLAGS_NO_ERROR_SHADOW -Wno-error=shadow -Wno-shadow)
 set(CXX_FLAGS_NO_SIGN_COMPARE -Wno-sign-compare)

--- a/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
+++ b/drake/examples/QPInverseDynamicsForHumanoids/plan_eval/dev/humanoid_manipulation_plan.cc
@@ -138,8 +138,8 @@ void HumanoidManipulationPlan<T>::HandlePlanGenericPlanDerived(
 
     for (auto& body_knots_pair : body_knots) {
       const RigidBody<T>* body = body_knots_pair.first;
-      std::vector<Isometry3<T>>& body_knots = body_knots_pair.second;
-      body_knots.push_back(robot.CalcBodyPoseInWorldFrame(cache, *body));
+      std::vector<Isometry3<T>>& knots = body_knots_pair.second;
+      knots.push_back(robot.CalcBodyPoseInWorldFrame(cache, *body));
     }
 
     // Computes com.
@@ -172,11 +172,11 @@ void HumanoidManipulationPlan<T>::HandlePlanGenericPlanDerived(
   {
     for (const auto& body_knots_pair : body_knots) {
       const RigidBody<T>* body = body_knots_pair.first;
-      const std::vector<Isometry3<T>>& body_knots = body_knots_pair.second;
+      const std::vector<Isometry3<T>>& knots = body_knots_pair.second;
 
       manipulation::PiecewiseCartesianTrajectory<T> body_traj =
           manipulation::PiecewiseCartesianTrajectory<
-              T>::MakeCubicLinearWithEndLinearVelocity(times, body_knots,
+              T>::MakeCubicLinearWithEndLinearVelocity(times, knots,
                                                        Vector3<T>::Zero(),
                                                        Vector3<T>::Zero());
 

--- a/drake/solvers/gurobi_solver.cc
+++ b/drake/solvers/gurobi_solver.cc
@@ -98,8 +98,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
              callback_info->mip_sol_callback != nullptr) {
     // Extract variable values from Gurobi, and set the current
     // solution of the MathematicalProgram to these values.
-    auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
-                          callback_info->solver_sol_vector.data());
+    int error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
+                         callback_info->solver_sol_vector.data());
     if (error) {
       drake::log()->error("GRB error {} in MIPSol callback cbget: {}\n", error,
                           GRBgeterrormsg(GRBgetenv(model)));
@@ -109,14 +109,15 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
         callback_info->is_new_variable, callback_info->solver_sol_vector,
         &(callback_info->prog_sol_vector), callback_info->prog);
 
-    auto solve_status = GetGurobiSolveStatus(cbdata, where);
+    GurobiSolver::SolveStatusInfo solve_status =
+        GetGurobiSolveStatus(cbdata, where);
 
     callback_info->mip_sol_callback(*(callback_info->prog), solve_status);
 
   } else if (where == GRB_CB_MIPNODE &&
              callback_info->mip_node_callback != nullptr) {
     int sol_status;
-    auto error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_STATUS, &sol_status);
+    int error = GRBcbget(cbdata, where, GRB_CB_MIPNODE_STATUS, &sol_status);
     if (error) {
       drake::log()->error(
           "GRB error {} in MIPNode callback getting sol status: {}\n", error,
@@ -125,8 +126,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
     } else if (sol_status == GRB_OPTIMAL) {
       // Extract variable values from Gurobi, and set the current
       // solution of the MathematicalProgram to these values.
-      auto error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
-                            callback_info->solver_sol_vector.data());
+      error = GRBcbget(cbdata, where, GRB_CB_MIPSOL_SOL,
+                       callback_info->solver_sol_vector.data());
       if (error) {
         drake::log()->error("GRB error {} in MIPSol callback cbget: {}\n",
                             error, GRBgeterrormsg(GRBgetenv(model)));
@@ -136,7 +137,8 @@ int gurobi_callback(GRBmodel* model, void* cbdata, int where, void* usrdata) {
           callback_info->is_new_variable, callback_info->solver_sol_vector,
           &(callback_info->prog_sol_vector), callback_info->prog);
 
-      auto solve_status = GetGurobiSolveStatus(cbdata, where);
+      GurobiSolver::SolveStatusInfo solve_status =
+          GetGurobiSolveStatus(cbdata, where);
 
       Eigen::VectorXd vals;
       VectorXDecisionVariable vars;

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,23 +1,33 @@
 # -*- python -*-
 
+# The CXX_FLAGS will be enabled for all C++ rules in the project
+# building with any compiler.
+CXX_FLAGS = [
+    "-Werror=all",
+    "-Werror=ignored-qualifiers",
+    "-Werror=overloaded-virtual",
+]
+
 # The CLANG_FLAGS will be enabled for all C++ rules in the project when
 # building with clang.
-CLANG_FLAGS = [
-    "-Werror=all",
+CLANG_FLAGS = CXX_FLAGS + [
+    "-Werror=shadow",
     "-Werror=inconsistent-missing-override",
     "-Werror=sign-compare",
-    "-Werror=non-virtual-dtor",
     "-Werror=return-stack-address",
+    "-Werror=non-virtual-dtor",
 ]
 
 # The GCC_FLAGS will be enabled for all C++ rules in the project when
 # building with gcc.
-GCC_FLAGS = [
-    "-Werror=all",
+GCC_FLAGS = CXX_FLAGS + [
     "-Werror=extra",
     "-Werror=return-local-addr",
     "-Werror=non-virtual-dtor",
+    # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
     "-Wno-missing-field-initializers",
+    # TODO(#2852) Turn on shadow checking for g++ once we use a version that
+    # fixes https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
 ]
 
 # The GCC_CC_TEST_FLAGS will be enabled for all cc_test rules in the project


### PR DESCRIPTION
This address #6544, at least for GCC and `clang` versions near `AppleClang 7.3.0`.

This was verified on this dev branch:
https://github.com/RobotLocomotion/drake/compare/master...EricCousineau-TRI:c439e88

More explanation in this comment:
https://github.com/RobotLocomotion/drake/issues/6544#issuecomment-319159000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6721)
<!-- Reviewable:end -->
