### PR TITLE
Move ctor to cc file to placate broken OS X build

### DIFF
--- a/drake/systems/framework/system_scalar_converter.cc
+++ b/drake/systems/framework/system_scalar_converter.cc
@@ -10,6 +10,8 @@ std::pair<std::type_index, std::type_index> make_key(
 }
 }  // namespace
 
+SystemScalarConverter::SystemScalarConverter() = default;
+
 void SystemScalarConverter::Insert(
     const std::type_info& t_info, const std::type_info& u_info,
     const ErasedConverterFunc& converter) {

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -29,7 +29,7 @@ class SystemScalarConverter {
   /// Creates an object that returns nullptr for all Convert() requests.  The
   /// single-argument constructor below is the typical way to create a useful
   /// instance of this type.
-  SystemScalarConverter() = default;
+  SystemScalarConverter();
 
   /// Creates an object that uses S's scalar-type converting copy constructor.
   /// That constructor takes the form of, e.g.:


### PR DESCRIPTION
This doesn't show up locally; it only happens on CI for some reason.
(Perhaps the version of clang being used is not locked down.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6722)
<!-- Reviewable:end -->
