### PR TITLE
Fix 2PI constant in RotaryEncoders

### DIFF
--- a/drake/systems/sensors/rotary_encoders.cc
+++ b/drake/systems/sensors/rotary_encoders.cc
@@ -81,8 +81,8 @@ void RotaryEncoders<T>::DoCalcVectorOutput(
     // Quantization.
     if (!ticks_per_revolution_.empty()) {
       using std::floor;
-      y(i) = floor(y(i) * ticks_per_revolution_[i] / M_2_PI) * M_2_PI /
-             ticks_per_revolution_[i];
+      const T ticks_per_radian = ticks_per_revolution_[i] / (2.0 * M_PI);
+      y(i) = floor(y(i) * ticks_per_radian) / ticks_per_radian;
     }
   }
 }

--- a/drake/systems/sensors/test/rotary_encoders_test.cc
+++ b/drake/systems/sensors/test/rotary_encoders_test.cc
@@ -10,6 +10,8 @@
 namespace drake {
 namespace {
 
+constexpr double k2Pi = 2.0 * M_PI;
+
 // Test with the simple quantization-only constructor.
 GTEST_TEST(TestEncoders, QuantizeOnly) {
   // Construct a system where all inputs are encoders, with quantization
@@ -18,7 +20,7 @@ GTEST_TEST(TestEncoders, QuantizeOnly) {
   systems::sensors::RotaryEncoders<double> encoders(tick_counts);
 
   Eigen::Vector2d ticks_per_radian;
-  ticks_per_radian << tick_counts[0] / M_2_PI, tick_counts[1] / M_2_PI;
+  ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
   auto output = encoders.AllocateOutput(*context);
@@ -85,7 +87,7 @@ GTEST_TEST(TestEncoders, QuantizationAndSelector) {
   systems::sensors::RotaryEncoders<double> encoders(4, indices, tick_counts);
 
   Eigen::Vector2d ticks_per_radian;
-  ticks_per_radian << tick_counts[0] / M_2_PI, tick_counts[1] / M_2_PI;
+  ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
   auto output = encoders.AllocateOutput(*context);
@@ -124,7 +126,7 @@ GTEST_TEST(TestEncoders, CalibrationOffsets) {
   systems::sensors::RotaryEncoders<double> encoders(tick_counts);
 
   Eigen::Vector2d ticks_per_radian;
-  ticks_per_radian << tick_counts[0] / M_2_PI, tick_counts[1] / M_2_PI;
+  ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
   auto output = encoders.AllocateOutput(*context);


### PR DESCRIPTION
... as discovered during transmogrification unit testing (to be PR'd later).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6729)
<!-- Reviewable:end -->
