### PR TITLE
Ensure LCM messages are initialized in articulated_icp_test.

### DIFF
--- a/drake/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/drake/perception/estimators/dev/test/articulated_icp_test.cc
@@ -154,7 +154,7 @@ class IcpVisualizer {
   }
   void PublishScene(const SceneState& scene_state) {
     const ViewerDrawTranslator draw_msg_tx(scene_->tree());
-    drake::lcmt_viewer_draw draw_msg;
+    drake::lcmt_viewer_draw draw_msg{};
     vector<uint8_t> bytes;
     const int num_q = scene_->tree().get_num_positions();
     const int num_v = scene_->tree().get_num_velocities();
@@ -167,7 +167,7 @@ class IcpVisualizer {
     lcm_.Publish("DRAKE_VIEWER_DRAW", bytes.data(), bytes.size());
   }
   void PublishCloud(const Matrix3Xd& points) {
-    bot_core::pointcloud_t pt_msg;
+    bot_core::pointcloud_t pt_msg{};
     PointCloudToLcm(points, &pt_msg);
     vector<uint8_t> bytes(pt_msg.getEncodedSize());
     pt_msg.encode(bytes.data(), 0, bytes.size());


### PR DESCRIPTION
Adds mustaches to LCM messages to appease `valgrind`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6734)
<!-- Reviewable:end -->
