### PR TITLE
Make sure to use full-precision when printing symbolic expression

### DIFF
--- a/drake/common/symbolic_expression.cc
+++ b/drake/common/symbolic_expression.cc
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <ios>
+#include <limits>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -22,11 +24,13 @@ namespace symbolic {
 
 using std::make_shared;
 using std::map;
+using std::numeric_limits;
 using std::ostream;
 using std::ostringstream;
 using std::pair;
 using std::runtime_error;
 using std::shared_ptr;
+using std::streamsize;
 using std::string;
 using std::vector;
 
@@ -495,8 +499,28 @@ Expression& operator/=(Expression& lhs, const Expression& rhs) {
   return lhs;
 }
 
+namespace {
+// Changes the precision of `os` to be the `new_precision` and saves the
+// original precision so that it can be reverted when an instance of this class
+// is destructed. It is used in `operator<<` of symbolic expression.
+class PrecisionGuard {
+ public:
+  PrecisionGuard(ostream* const os, const streamsize& new_precision)
+      : os_{os}, original_precision_{os->precision()} {
+    os_->precision(new_precision);
+  }
+  ~PrecisionGuard() { os_->precision(original_precision_); }
+
+ private:
+  ostream* const os_;
+  const streamsize original_precision_;
+};
+}  // namespace
+
 ostream& operator<<(ostream& os, const Expression& e) {
   DRAKE_ASSERT(e.ptr_ != nullptr);
+  const PrecisionGuard precision_guard{&os,
+                                       numeric_limits<double>::max_digits10};
   return e.ptr_->Display(os);
 }
 

--- a/drake/common/symbolic_expression_cell.cc
+++ b/drake/common/symbolic_expression_cell.cc
@@ -38,7 +38,6 @@ using std::ostream;
 using std::ostringstream;
 using std::pair;
 using std::runtime_error;
-using std::setprecision;
 using std::shared_ptr;
 using std::static_pointer_cast;
 using std::string;
@@ -369,11 +368,7 @@ Expression ExpressionConstant::Differentiate(const Variable&) const {
   return Expression::Zero();
 }
 
-ostream& ExpressionConstant::Display(ostream& os) const {
-  ostringstream oss;
-  oss << setprecision(numeric_limits<double>::max_digits10) << v_;
-  return os << oss.str();
-}
+ostream& ExpressionConstant::Display(ostream& os) const { return os << v_; }
 
 ExpressionNaN::ExpressionNaN()
     : ExpressionCell{ExpressionKind::NaN, 41, false} {

--- a/drake/common/test/symbolic_expression_test.cc
+++ b/drake/common/test/symbolic_expression_test.cc
@@ -1808,9 +1808,15 @@ TEST_F(SymbolicExpressionTest, Swap) {
 TEST_F(SymbolicExpressionTest, ToString) {
   const Expression e1{sin(x_ + y_ * z_)};
   const Expression e2{cos(x_ * x_ + pow(y_, 2) * z_)};
+  const Expression e3{M_PI * x_ * pow(y_, M_E)};
+  const Expression e4{M_E + x_ + M_PI * y_};
 
   EXPECT_EQ(e1.to_string(), "sin((x + (y * z)))");
   EXPECT_EQ(e2.to_string(), "cos(((pow(y, 2) * z) + pow(x, 2)))");
+  EXPECT_EQ(e3.to_string(),
+            "(3.1415926535897931 * x * pow(y, 2.7182818284590451))");
+  EXPECT_EQ(e4.to_string(),
+            "(2.7182818284590451 + x + 3.1415926535897931 * y)");
   EXPECT_EQ(e_uf_.to_string(), "uf({x, y})");
 }
 


### PR DESCRIPTION
Related issue: #6727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6735)
<!-- Reviewable:end -->
