### PR TITLE
Revert "Start to use SystemScalarConverter"

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -332,7 +332,6 @@ drake_cc_library(
         ":model_values",
         ":sparsity_matrix",
         ":system",
-        ":system_scalar_converter",
         ":value_checker",
         "//drake/common",
         "//drake/common:number_traits",

--- a/drake/systems/framework/test/vector_system_test.cc
+++ b/drake/systems/framework/test/vector_system_test.cc
@@ -399,60 +399,6 @@ TEST_F(VectorSystemTest, NoInputNoOutputDiscreteTimeSystemTest) {
   EXPECT_EQ(dut.get_num_output_ports(), 0);
 }
 
-/// A system that can use any scalar type: AutoDiff, symbolic form, etc.
-template <typename T>
-class OpenScalarTypeSystem : public VectorSystem<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OpenScalarTypeSystem);
-
-  explicit OpenScalarTypeSystem(int some_number)
-      : VectorSystem<T>(SystemTypeTag<systems::OpenScalarTypeSystem>{}, 1, 1),
-        some_number_(some_number) {}
-
-  template <typename U>
-  explicit OpenScalarTypeSystem(const OpenScalarTypeSystem<U>& other)
-      : OpenScalarTypeSystem<T>(other.some_number_) {}
-
-  int get_some_number() const { return some_number_; }
-
- private:
-  template <typename> friend class OpenScalarTypeSystem;
-
-  const int some_number_{};
-};
-
-TEST_F(VectorSystemTest, ToAutoDiffXdTest) {
-  const int kSomeNumber = 22;
-  OpenScalarTypeSystem<double> dut{kSomeNumber};
-
-  // Convert to AutoDiffXd.
-  std::unique_ptr<System<AutoDiffXd>> autodiff = dut.ToAutoDiffXd();
-  ASSERT_NE(autodiff, nullptr);
-  const auto* const downcast =
-      dynamic_cast<OpenScalarTypeSystem<AutoDiffXd>*>(autodiff.get());
-  ASSERT_NE(downcast, nullptr);
-
-  // The member field remains intact.
-  EXPECT_EQ(downcast->get_some_number(), kSomeNumber);
-}
-
-TEST_F(VectorSystemTest, ToSymbolicTest) {
-  using Expression = symbolic::Expression;
-
-  const int kSomeNumber = 22;
-  OpenScalarTypeSystem<double> dut{kSomeNumber};
-
-  // Convert to Symbolic form.
-  std::unique_ptr<System<Expression>> autodiff = dut.ToSymbolic();
-  ASSERT_NE(autodiff, nullptr);
-  const auto* const downcast =
-      dynamic_cast<OpenScalarTypeSystem<Expression>*>(autodiff.get());
-  ASSERT_NE(downcast, nullptr);
-
-  // The member field remains intact.
-  EXPECT_EQ(downcast->get_some_number(), kSomeNumber);
-}
-
 // This system declares an output and continuous state, but does not define
 // the required methods.
 class MissingMethodsContinuousTimeSystem : public VectorSystem<double> {

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -4,7 +4,6 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -67,8 +66,7 @@ SpringMassStateVector<T>* SpringMassStateVector<T>::DoClone() const {
 template <typename T>
 SpringMassSystem<T>::SpringMassSystem(double spring_constant_N_per_m,
                                       double mass_kg, bool system_is_forced)
-    : LeafSystem<T>(SystemTypeTag<systems::SpringMassSystem>{}),
-      spring_constant_N_per_m_(spring_constant_N_per_m),
+    : spring_constant_N_per_m_(spring_constant_N_per_m),
       mass_kg_(mass_kg),
       system_is_forced_(system_is_forced) {
   // Declares input port for forcing term.
@@ -81,14 +79,6 @@ SpringMassSystem<T>::SpringMassSystem(double spring_constant_N_per_m,
   this->DeclareContinuousState(SpringMassStateVector<T>(),
       1 /* num_q */, 1 /* num_v */, 1 /* num_z */);
 }
-
-template <typename T>
-template <typename U>
-SpringMassSystem<T>::SpringMassSystem(const SpringMassSystem<U>& other)
-    : SpringMassSystem(
-          other.get_spring_constant(),
-          other.get_mass(),
-          other.get_system_is_forced()) {}
 
 template <typename T>
 const InputPortDescriptor<T>& SpringMassSystem<T>::get_force_port() const {
@@ -184,10 +174,8 @@ void SpringMassSystem<T>::DoCalcTimeDerivatives(
 
 template class SpringMassStateVector<double>;
 template class SpringMassStateVector<AutoDiffXd>;
-template class SpringMassStateVector<symbolic::Expression>;
 template class SpringMassSystem<double>;
 template class SpringMassSystem<AutoDiffXd>;
-template class SpringMassSystem<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -89,10 +89,6 @@ class SpringMassSystem : public LeafSystem<T> {
   SpringMassSystem(double spring_constant_N_per_m, double mass_kg,
                    bool system_is_forced = false);
 
-  /// Scalar-converting copy constructor.
-  template <typename U>
-  explicit SpringMassSystem(const SpringMassSystem<U>&);
-
   // Provide methods specific to this System.
 
   /// Returns the input port to the externally applied force.
@@ -106,9 +102,6 @@ class SpringMassSystem : public LeafSystem<T> {
 
   /// Returns the mass m that was provided at construction, in kg.
   double get_mass() const { return mass_kg_; }
-
-  /// Returns true iff the system is forced.
-  bool get_system_is_forced() const { return system_is_forced_; }
 
   /// Gets the current position of the mass in the given Context.
   T get_position(const Context<T>& context) const {
@@ -243,7 +236,19 @@ class SpringMassSystem : public LeafSystem<T> {
     *vf = -c1*sin(omega*tf)*omega + c2*cos(omega*tf)*omega;
   }
 
+ protected:
+  System<AutoDiffXd>* DoToAutoDiffXd() const override {
+    return new SpringMassSystem<AutoDiffXd>(this->get_spring_constant(),
+                                            this->get_mass(),
+                                            system_is_forced_);
+  }
+
  private:
+  /// This system is not direct feedthrough.
+  bool DoHasDirectFeedthrough(const SparsityMatrix*, int, int) const override {
+    return false;
+  }
+
   // This is the calculator method for the output port.
   void SetOutputValues(const Context<T>& context,
                        SpringMassStateVector<T>* output) const;

--- a/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -75,7 +75,6 @@ TEST_F(SpringMassSystemTest, Construction) {
   EXPECT_EQ("test_system", system_->get_name());
   EXPECT_EQ(kSpring, system_->get_spring_constant());
   EXPECT_EQ(kMass, system_->get_mass());
-  EXPECT_FALSE(system_->get_system_is_forced());
 }
 
 TEST_F(SpringMassSystemTest, DirectFeedthrough) {
@@ -181,9 +180,6 @@ TEST_F(SpringMassSystemTest, ForcesNegativeDisplacement) {
 TEST_F(SpringMassSystemTest, DynamicsWithExternalForce) {
   // Initializes a spring mass system with an input port for an external force.
   Initialize(true);
-  EXPECT_TRUE(system_->get_system_is_forced());
-  EXPECT_FALSE(system_->HasAnyDirectFeedthrough());
-
   // Asserts exactly one input for this case expecting an external force.
   ASSERT_EQ(1, context_->get_num_input_ports());
 

--- a/drake/systems/trajectory_optimization/direct_collocation.h
+++ b/drake/systems/trajectory_optimization/direct_collocation.h
@@ -23,8 +23,8 @@ namespace systems {
  * achieve a 3rd order integration accuracy.
  *
  * @param system A dynamical system to be used in the dynamic constraints.
- *    This system must support System::ToAutoDiffXd.
- *    Note that this is aliased for the lifetime of this object.
+ *    This system must implement DoToAutoDiffXd. Note that this is aliased for
+ *    the lifetime of this object.
  * @param context Required to describe any parameters of the system.  The
  *    values of the state in this context do not have any effect.  This
  *    context will also be "cloned" by the optimization; changes to the context

--- a/drake/systems/trajectory_optimization/direct_collocation_constraint.h
+++ b/drake/systems/trajectory_optimization/direct_collocation_constraint.h
@@ -64,8 +64,7 @@ class SystemDirectCollocationConstraint : public DirectCollocationConstraint {
 
   /// Creates a direct collocation constraint for a system.
   /// @param system A dynamical system to be used in the dynamic constraints.
-  ///  This system must support System::ToAutoDiffXd.
-  ///  Note that the optimization
+  ///  This system must implement DoToAutoDiffXd.  Note that the optimization
   ///  will "clone" this system for it's internal use; changes to system
   ///  after calling this method will NOT impact the trajectory optimization.
   ///  Currently, this system must have exactly one input port.

--- a/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
+++ b/drake/systems/trajectory_optimization/test/trajectory_optimization_test.cc
@@ -203,20 +203,16 @@ class DoubleIntegrator : public VectorSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DoubleIntegrator);
 
-  DoubleIntegrator()
-      : VectorSystem<T>(
-            SystemTypeTag<systems::DoubleIntegrator>{},
-            1, 1) {
+  DoubleIntegrator() : VectorSystem<T>(1, 1) {
     this->DeclareContinuousState(1, 1, 0);
   }
-
-  template <typename U>
-  explicit DoubleIntegrator(const DoubleIntegrator<U>&)
-      : DoubleIntegrator<T>() {}
-
-  ~DoubleIntegrator() override {}
+  ~DoubleIntegrator() override{};
 
  protected:
+  DoubleIntegrator<AutoDiffXd>* DoToAutoDiffXd() const override {
+    return new DoubleIntegrator<AutoDiffXd>();
+  }
+
   void DoCalcVectorOutput(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,


### PR DESCRIPTION
Dear @jwnimmer-tri ,

The on-call build cop, @m-chaturvedi, believes that your PR #6684 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-clang-bazel-continuous-everything-release/4/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6740)
<!-- Reviewable:end -->
