### PR TITLE
Port AffineSystem to SystemScalarConverter

### DIFF
--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -618,6 +618,7 @@ drake_cc_googletest(
     name = "simple_powertrain_test",
     deps = [
         "//drake/automotive:simple_powertrain",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/automotive/simple_powertrain.cc
+++ b/drake/automotive/simple_powertrain.cc
@@ -9,6 +9,7 @@ namespace automotive {
 // simple_powertrain.h.
 template class SimplePowertrain<double>;
 template class SimplePowertrain<AutoDiffXd>;
+template class SimplePowertrain<symbolic::Expression>;
 
 }  // namespace automotive
 }  // namespace drake

--- a/drake/automotive/simple_powertrain.h
+++ b/drake/automotive/simple_powertrain.h
@@ -21,12 +21,13 @@ namespace automotive {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 ///
 /// @ingroup automotive_plants
 template <typename T>
-class SimplePowertrain : public systems::LinearSystem<T> {
+class SimplePowertrain final : public systems::LinearSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SimplePowertrain);
 
@@ -34,13 +35,22 @@ class SimplePowertrain : public systems::LinearSystem<T> {
   /// and scalar gain.  The inputs are as follows:
   /// @param time_constant is the rise time of the first-order lag [s].
   /// @param gain is the gain converting throttle input to force output [N].
-  SimplePowertrain(const double time_constant, const double gain)
-      : systems::LinearSystem<T>(Vector1d(-1. / time_constant),
-                                 Vector1d(gain),
-                                 Vector1d(1. / time_constant),
-                                 Vector1d(0.)),
+  SimplePowertrain(double time_constant, double gain)
+      : systems::LinearSystem<T>(
+            systems::SystemTypeTag<automotive::SimplePowertrain>{},
+            Vector1d(-1. / time_constant),
+            Vector1d(gain),
+            Vector1d(1. / time_constant),
+            Vector1d(0.),
+            0.0 /* time_period */),
         time_constant_(time_constant),
         gain_(gain) {}
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit SimplePowertrain(const SimplePowertrain<U>& other)
+      : SimplePowertrain<T>(other.get_time_constant(), other.get_gain()) {}
+
   ~SimplePowertrain() override = default;
 
   const systems::InputPortDescriptor<T>& get_throttle_input_port() const {

--- a/drake/automotive/test/simple_powertrain_test.cc
+++ b/drake/automotive/test/simple_powertrain_test.cc
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
 using std::make_unique;
 
 namespace drake {
@@ -37,6 +39,14 @@ TEST_F(SimplePowertrainTest, SystemMatrices) {
   EXPECT_EQ(Vector1<double>(-1. / kPowertrainTimeConstant), dut_->A());
   EXPECT_EQ(Vector1<double>(kPowertrainGain), dut_->B());
   EXPECT_EQ(Vector1<double>(1. / kPowertrainTimeConstant), dut_->C());
+}
+
+TEST_F(SimplePowertrainTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_));
+}
+
+TEST_F(SimplePowertrainTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*dut_));
 }
 
 }  // namespace

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -242,9 +242,22 @@ class LeafSystem : public System<T> {
 
  protected:
   /// Default constructor that declares no inputs, outputs, state, parameters,
-  /// events, nor scalar-type conversion support (i.e., AutoDiff, etc.).  To
-  /// enable AutoDiff support, use the constructor that takes a SystemTypeTag.
-  LeafSystem() {
+  /// events, nor scalar-type conversion support (AutoDiff, etc.).  To enable
+  /// AutoDiff support, use the SystemScalarConverter-based constructor.
+  LeafSystem() : LeafSystem(SystemScalarConverter{}) {}
+
+  /// Constructor that declares no inputs, outputs, state, parameters, or
+  /// events, but allows subclasses to declare scalar-type conversion support
+  /// (AutoDiff, etc.).
+  ///
+  /// The scalar-type conversion support will use @p converter.
+  /// To enable scalar-type conversion support, pass a `SystemTypeTag<S>{}`
+  /// where `S` must be the exact class of `this` being constructed.
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
+  explicit LeafSystem(SystemScalarConverter converter)
+      : system_scalar_converter_(std::move(converter)) {
     this->set_forced_publish_events(
         LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection());
     this->set_forced_discrete_update_events(
@@ -253,20 +266,6 @@ class LeafSystem : public System<T> {
     this->set_forced_unrestricted_update_events(
         LeafEventCollection<
             UnrestrictedUpdateEvent<T>>::MakeForcedEventCollection());
-  }
-
-  /// Constructor that declares no inputs, outputs, state, parameters, events,
-  /// but *does* declare scalar-type conversion support (i.e., AutoDiff, etc.).
-  ///
-  /// The scalar-type conversion support will use `S` as the system type to
-  /// construct when changing the scalar type.  Systems may specialize their
-  /// scalar_conversion::Traits<S> to govern the supported scalar types; by
-  /// default, both AutoDiff and symbolic types are enabled.
-  ///
-  /// @tparam S must be the most-derived concrete System subclass of `this`.
-  template <template <typename> class S>
-  explicit LeafSystem(SystemTypeTag<S>) : LeafSystem() {
-    system_scalar_converter_ = SystemScalarConverter(SystemTypeTag<S>{});
   }
 
   System<AutoDiffXd>* DoToAutoDiffXd() const override {
@@ -1388,7 +1387,7 @@ class LeafSystem : public System<T> {
   detail::ModelValues model_numeric_parameters_;
 
   // Functions to convert this system to use alternative scalar types.
-  SystemScalarConverter system_scalar_converter_;
+  const SystemScalarConverter system_scalar_converter_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -987,6 +987,9 @@ class System {
   /// scalar type, with a dynamic-sized vector of partial derivatives.  The
   /// result is never nullptr.
   /// @throw exception if this System does not support autodiff
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
   std::unique_ptr<System<AutoDiffXd>> ToAutoDiffXd() const {
     return System<T>::ToAutoDiffXd(*this);
   }
@@ -1003,6 +1006,9 @@ class System {
   /// @endcode
   ///
   /// @tparam S The specific System type to accept and return.
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
   template <template <typename> class S = ::drake::systems::System>
   static std::unique_ptr<S<AutoDiffXd>> ToAutoDiffXd(const S<T>& from) {
     using U = AutoDiffXd;
@@ -1010,7 +1016,7 @@ class System {
     std::unique_ptr<System<U>> base_result{from_system.DoToAutoDiffXd()};
     if (!base_result) {
       std::stringstream ss;
-      ss << "The object named [" << from.get_name() << "] of type"
+      ss << "The object named [" << from.get_name() << "] of type "
          << NiceTypeName::Get(from) << " does not support ToAutoDiffXd.";
       throw std::logic_error(ss.str().c_str());
     }
@@ -1051,6 +1057,9 @@ class System {
   /// Creates a deep copy of this System, transmogrified to use the symbolic
   /// scalar type. The result is never nullptr.
   /// @throw exception if this System does not support symbolic
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
   std::unique_ptr<System<symbolic::Expression>> ToSymbolic() const {
     return System<T>::ToSymbolic(*this);
   }
@@ -1066,6 +1075,9 @@ class System {
   /// @endcode
   ///
   /// @tparam S The specific System pointer type to return.
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
   template <template <typename> class S = ::drake::systems::System>
   static std::unique_ptr<S<symbolic::Expression>> ToSymbolic(const S<T>& from) {
     using U = symbolic::Expression;
@@ -1073,7 +1085,7 @@ class System {
     std::unique_ptr<System<U>> base_result{from_system.DoToSymbolic()};
     if (!base_result) {
       std::stringstream ss;
-      ss << "The object named [" << from.get_name() << "] of type"
+      ss << "The object named [" << from.get_name() << "] of type "
          << NiceTypeName::Get(from) << " does not support ToSymbolic.";
       throw std::logic_error(ss.str().c_str());
     }

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -65,9 +65,14 @@ class SystemScalarConverter {
   ///
   /// @tparam S is the System type to convert
   ///
+  /// This an implicit conversion constructor (not marked `explicit`), in order
+  /// to make calling code substantially more readable, with relatively little
+  /// risk of an unwanted accidental conversion happening.
+  ///
   /// See @ref system_scalar_conversion for additional overview documentation.
   template <template <typename> class S>
-  explicit SystemScalarConverter(SystemTypeTag<S>) : SystemScalarConverter() {
+  // NOLINTNEXTLINE(runtime/explicit)
+  SystemScalarConverter(SystemTypeTag<S>) : SystemScalarConverter() {
     using Expression = symbolic::Expression;
     // From double to all other types.
     AddIfSupported<S, AutoDiffXd, double>();

--- a/drake/systems/framework/vector_system.h
+++ b/drake/systems/framework/vector_system.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
@@ -77,40 +78,37 @@ class VectorSystem : public LeafSystem<T> {
 
  protected:
   /// Creates a system with one input port and one output port of the given
-  /// sizes.  Does not declare any state -- subclasses may optionally declare
-  /// continuous or discrete state, but not both.
+  /// sizes, when the sizes are non-zero.  Either size can be zero, in which
+  /// case no input (or output) port is created.
+  ///
+  /// Does *not* declare scalar-type conversion support (AutoDiff, etc.).  To
+  /// enable AutoDiff support, use the SystemScalarConverter-based constructor.
+  /// (For that, see @ref system_scalar_conversion at the example titled
+  /// "Example using drake::systems::VectorSystem as the base class".)
   VectorSystem(int input_size, int output_size)
-      : LeafSystem<T>() {
-    DoConstructorBody(input_size, output_size);
-  }
+      : VectorSystem(SystemScalarConverter{}, input_size, output_size) {}
 
-  /// Like VectorSystem(int, int), but also declares that this System object is
-  /// of dynamic type S, which enables conversion to other scalar-types such as
-  /// AutoDiff or symbolic form.  Subclasses that wish to support conversion to
-  /// other scalar types should use this constructor.
+  /// Creates a system with one input port and one output port of the given
+  /// sizes, when the sizes are non-zero.  Either size can be zero, in which
+  /// case no input (or output) port is created.  This constructor allows
+  /// subclasses to declare scalar-type conversion support (AutoDiff, etc.).
   ///
-  /// Example:
+  /// The scalar-type conversion support will use @p converter.
+  /// To enable scalar-type conversion support, pass a `SystemTypeTag<S>{}`
+  /// where `S` must be the exact class of `this` being constructed.
   ///
-  /// @code
-  /// namespace sample {
-  /// template <typename T>
-  /// class MySystem : public VectorSystem<T> {
-  ///  public:
-  ///   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MySystem);
-  ///
-  ///   /// Default constructor.
-  ///   MySystem() : VectorSystem<T>(SystemTypeTag<sample::MySystem>{}, 1, 1) {}
-  ///
-  ///   /// Scalar-converting copy constructor.
-  ///   template <typename U>
-  ///   explicit MySystem(const MySystem<U>&) : MySystem<T>() {}
-  ///
-  ///   ...
-  /// @endcode
-  template <template <typename> class S>
-  VectorSystem(SystemTypeTag<S> tag, int input_size, int output_size)
-      : LeafSystem<T>(tag) {
-    DoConstructorBody(input_size, output_size);
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support, especially the example titled
+  /// "Example using drake::systems::VectorSystem as the base class".
+  VectorSystem(SystemScalarConverter converter, int input_size, int output_size)
+      : LeafSystem<T>(std::move(converter)) {
+    if (input_size > 0) {
+      this->DeclareInputPort(kVectorValued, input_size);
+    }
+    if (output_size > 0) {
+      this->DeclareVectorOutputPort(BasicVector<T>(output_size),
+                                    &VectorSystem::CalcVectorOutput);
+    }
   }
 
   /// Causes the vector-valued input port to become up-to-date, and returns
@@ -287,22 +285,6 @@ class VectorSystem : public LeafSystem<T> {
       Eigen::VectorBlock<VectorX<T>>* next_state) const {
     unused(context, input, state);
     DRAKE_THROW_UNLESS(next_state->size() == 0);
-  }
-
- private:
-  // All constructors should call this method immediately after invoking the
-  // base class constructor, as if this were using constructor delegation.
-  ///
-  // We cannot use C++'s constructor delegation, because we need to invoke a
-  // different LeafSystem constructor from each of our constructors.
-  void DoConstructorBody(int input_size, int output_size) {
-    if (input_size > 0) {
-      this->DeclareInputPort(kVectorValued, input_size);
-    }
-    if (output_size > 0) {
-      this->DeclareVectorOutputPort(BasicVector<T>(output_size),
-                                    &VectorSystem::CalcVectorOutput);
-    }
   }
 };
 

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/primitives/affine_system.h"
 
+#include <utility>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
@@ -15,11 +17,11 @@ using std::make_unique;
 using std::unique_ptr;
 
 template <typename T>
-TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(int num_states,
-                                                    int num_inputs,
-                                                    int num_outputs,
-                                                    double time_period)
-    : num_states_(num_states),
+TimeVaryingAffineSystem<T>::TimeVaryingAffineSystem(
+    SystemScalarConverter converter,
+    int num_states, int num_inputs, int num_outputs, double time_period)
+    : LeafSystem<T>(std::move(converter)),
+      num_states_(num_states),
       num_inputs_(num_inputs),
       num_outputs_(num_outputs),
       time_period_(time_period) {
@@ -155,6 +157,8 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
 template class TimeVaryingAffineSystem<double>;
 template class TimeVaryingAffineSystem<AutoDiffXd>;
 
+// Our public constructor declares that our most specific subclass is
+// AffineSystem, and then delegates to our protected constructor.
 template <typename T>
 AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                               const Eigen::Ref<const Eigen::MatrixXd>& B,
@@ -163,7 +167,23 @@ AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                               const Eigen::Ref<const Eigen::MatrixXd>& D,
                               const Eigen::Ref<const Eigen::VectorXd>& y0,
                               double time_period)
-    : TimeVaryingAffineSystem<T>(f0.size(), D.cols(), D.rows(), time_period),
+    : AffineSystem<T>(
+          SystemTypeTag<systems::AffineSystem>{},
+          A, B, f0, C, D, y0, time_period) {}
+
+// Our protected constructor does all of the real work -- everything else
+// delegates to here.
+template <typename T>
+AffineSystem<T>::AffineSystem(SystemScalarConverter converter,
+                              const Eigen::Ref<const Eigen::MatrixXd>& A,
+                              const Eigen::Ref<const Eigen::MatrixXd>& B,
+                              const Eigen::Ref<const Eigen::VectorXd>& f0,
+                              const Eigen::Ref<const Eigen::MatrixXd>& C,
+                              const Eigen::Ref<const Eigen::MatrixXd>& D,
+                              const Eigen::Ref<const Eigen::VectorXd>& y0,
+                              double time_period)
+    : TimeVaryingAffineSystem<T>(
+          std::move(converter), f0.size(), D.cols(), D.rows(), time_period),
       A_(A),
       B_(B),
       f0_(f0),
@@ -179,6 +199,14 @@ AffineSystem<T>::AffineSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
   DRAKE_DEMAND(this->num_outputs() == C.rows());
   DRAKE_DEMAND(this->num_outputs() == D.rows());
 }
+
+// Our copy constructor delegates to the public constructor; this used only by
+// SystemScalarConverter as known to our public constructor, not by subclasses.
+template <typename T>
+template <typename U>
+AffineSystem<T>::AffineSystem(const AffineSystem<U>& other)
+    : AffineSystem(other.A(), other.B(), other.f0(), other.C(), other.D(),
+                   other.y0(), other.time_period()) {}
 
 template <typename T>
 unique_ptr<AffineSystem<T>> AffineSystem<T>::MakeAffineSystem(
@@ -213,19 +241,6 @@ unique_ptr<AffineSystem<T>> AffineSystem<T>::MakeAffineSystem(
   const auto D = CD.rightCols(num_inputs);
 
   return make_unique<AffineSystem<T>>(A, B, f0, C, D, y0, time_period);
-}
-
-// Setup equivalent system with a different scalar type.
-template <typename T>
-AffineSystem<AutoDiffXd>* AffineSystem<T>::DoToAutoDiffXd() const {
-  return new AffineSystem<AutoDiffXd>(A_, B_, f0_, C_, D_, y0_,
-                                      this->time_period());
-}
-
-template <typename T>
-AffineSystem<symbolic::Expression>* AffineSystem<T>::DoToSymbolic() const {
-  return new AffineSystem<symbolic::Expression>(A_, B_, f0_, C_, D_, y0_,
-                                                this->time_period());
 }
 
 template <typename T>

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -9,6 +9,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/symbolic_decompose.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
@@ -27,8 +28,27 @@ LinearSystem<T>::LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                               const Eigen::Ref<const Eigen::MatrixXd>& C,
                               const Eigen::Ref<const Eigen::MatrixXd>& D,
                               double time_period)
-    : AffineSystem<T>(A, B, Eigen::VectorXd::Zero(A.rows()), C, D,
-                      Eigen::VectorXd::Zero(C.rows()), time_period) {}
+    : LinearSystem<T>(
+          SystemTypeTag<systems::LinearSystem>{},
+          A, B, C, D, time_period) {}
+
+template <typename T>
+template <typename U>
+LinearSystem<T>::LinearSystem(const LinearSystem<U>& other)
+    : LinearSystem<T>(
+          other.A(), other.B(), other.C(), other.D(), other.time_period()) {}
+
+template <typename T>
+LinearSystem<T>::LinearSystem(SystemScalarConverter converter,
+                              const Eigen::Ref<const Eigen::MatrixXd>& A,
+                              const Eigen::Ref<const Eigen::MatrixXd>& B,
+                              const Eigen::Ref<const Eigen::MatrixXd>& C,
+                              const Eigen::Ref<const Eigen::MatrixXd>& D,
+                              double time_period)
+    : AffineSystem<T>(
+          std::move(converter),
+          A, B, Eigen::VectorXd::Zero(A.rows()), C, D,
+          Eigen::VectorXd::Zero(C.rows()), time_period) {}
 
 template <typename T>
 unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(
@@ -65,6 +85,7 @@ unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(
 
 template class LinearSystem<double>;
 template class LinearSystem<AutoDiffXd>;
+template class LinearSystem<symbolic::Expression>;
 
 namespace {
 

--- a/drake/systems/primitives/linear_system.h
+++ b/drake/systems/primitives/linear_system.h
@@ -29,6 +29,7 @@ namespace systems {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
@@ -51,11 +52,17 @@ class LinearSystem : public AffineSystem<T> {
   /// | B       | num states  | num inputs  |
   /// | C       | num outputs | num states  |
   /// | D       | num outputs | num inputs  |
+  ///
+  /// Subclasses must use the protected constructor, not this one.
   LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                const Eigen::Ref<const Eigen::MatrixXd>& B,
                const Eigen::Ref<const Eigen::MatrixXd>& C,
                const Eigen::Ref<const Eigen::MatrixXd>& D,
                double time_period = 0.0);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit LinearSystem(const LinearSystem<U>&);
 
   /// Creates a unique pointer to LinearSystem<T> by decomposing @p dynamics and
   /// @p outputs using @p state_vars and @p input_vars.
@@ -68,6 +75,19 @@ class LinearSystem : public AffineSystem<T> {
       const Eigen::Ref<const VectorX<symbolic::Variable>>& state_vars,
       const Eigen::Ref<const VectorX<symbolic::Variable>>& input_vars,
       double time_period = 0.0);
+
+ protected:
+  /// Constructor that specifies scalar-type conversion support.
+  /// @param converter scalar-type conversion support helper (i.e., AutoDiff,
+  /// etc.); pass a default-constructed object if such support is not desired.
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
+  LinearSystem(SystemScalarConverter converter,
+               const Eigen::Ref<const Eigen::MatrixXd>& A,
+               const Eigen::Ref<const Eigen::MatrixXd>& B,
+               const Eigen::Ref<const Eigen::MatrixXd>& C,
+               const Eigen::Ref<const Eigen::MatrixXd>& D,
+               double time_period);
 };
 
 /// Takes the first-order Taylor expansion of a System around a nominal

--- a/drake/systems/primitives/matrix_gain.cc
+++ b/drake/systems/primitives/matrix_gain.cc
@@ -3,12 +3,13 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace systems {
 
 namespace {
-const int kNumStates{0};
+constexpr int kNumStates{0};
 }  // namespace
 
 template <typename T>
@@ -17,13 +18,22 @@ MatrixGain<T>::MatrixGain(int size)
 
 template <typename T>
 MatrixGain<T>::MatrixGain(const Eigen::MatrixXd& D)
-    : LinearSystem<T>(Eigen::MatrixXd::Zero(kNumStates, kNumStates),  // A
-                      Eigen::MatrixXd::Zero(kNumStates, D.cols()),    // B
-                      Eigen::MatrixXd::Zero(D.rows(), kNumStates),    // C
-                      D) {}
+    : LinearSystem<T>(
+          SystemTypeTag<systems::MatrixGain>{},
+          Eigen::MatrixXd::Zero(kNumStates, kNumStates),  // A
+          Eigen::MatrixXd::Zero(kNumStates, D.cols()),    // B
+          Eigen::MatrixXd::Zero(D.rows(), kNumStates),    // C
+          D,
+          0.0 /* time_period */) {}
+
+template <typename T>
+template <typename U>
+MatrixGain<T>::MatrixGain(const MatrixGain<U>& other)
+    : MatrixGain<T>(other.D()) {}
 
 template class MatrixGain<double>;
 template class MatrixGain<AutoDiffXd>;
+template class MatrixGain<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/matrix_gain.h
+++ b/drake/systems/primitives/matrix_gain.h
@@ -20,6 +20,7 @@ namespace systems {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
@@ -29,7 +30,7 @@ namespace systems {
 /// @see AffineSystem
 /// @see LinearSystem
 template <typename T>
-class MatrixGain : public LinearSystem<T> {
+class MatrixGain final : public LinearSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MatrixGain)
 
@@ -39,6 +40,10 @@ class MatrixGain : public LinearSystem<T> {
 
   /// A constructor where the gain matrix `D` is @p D.
   explicit MatrixGain(const Eigen::MatrixXd& D);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit MatrixGain(const MatrixGain<U>&);
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -220,8 +220,9 @@ class SimpleTimeVaryingAffineSystem : public TimeVaryingAffineSystem<double> {
   static constexpr int kNumOutputs = 2;
 
   explicit SimpleTimeVaryingAffineSystem(double time_period)
-      : TimeVaryingAffineSystem(kNumStates, kNumInputs, kNumOutputs,
-                                time_period) {}
+      : TimeVaryingAffineSystem(
+            SystemScalarConverter{},  // BR
+            kNumStates, kNumInputs, kNumOutputs, time_period) {}
   ~SimpleTimeVaryingAffineSystem() override {}
 
   Eigen::MatrixXd A(const double& t) const override {

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -89,15 +89,13 @@ TEST_F(LinearSystemTest, Output) {
 
 // Tests converting to different scalar types.
 TEST_F(LinearSystemTest, ConvertScalarType) {
-  // TODO(jwnimmer-tri) We would prefer that these are true, but right now,
-  // LinearSystem does not transmogrify correctly.
-  EXPECT_FALSE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
     EXPECT_EQ(converted.A(), A_);
     EXPECT_EQ(converted.B(), B_);
     EXPECT_EQ(converted.C(), C_);
     EXPECT_EQ(converted.D(), D_);
   }));
-  EXPECT_FALSE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+  EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
     EXPECT_EQ(converted.A(), A_);
     EXPECT_EQ(converted.B(), B_);
     EXPECT_EQ(converted.C(), C_);

--- a/drake/systems/primitives/test/matrix_gain_test.cc
+++ b/drake/systems/primitives/test/matrix_gain_test.cc
@@ -79,12 +79,10 @@ TEST_F(MatrixGainTest, Output) {
 
 // Tests converting to different scalar types.
 TEST_F(MatrixGainTest, ConvertScalarType) {
-  // TODO(jwnimmer-tri) We would prefer that these are true, but right now,
-  // MatrixGain does not transmogrify correctly.
-  EXPECT_FALSE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
     EXPECT_EQ(converted.D(), D_);
   }));
-  EXPECT_FALSE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+  EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
     EXPECT_EQ(converted.D(), D_);
   }));
 }


### PR DESCRIPTION
This is an illustration of how scalar-converting copy constructors operate across type hierarchies.  I believe these are currently the only two `System`s in the tree that use both inheritance and scalar conversion at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6743)
<!-- Reviewable:end -->
