### PR TITLE
Use unordered_map in SystemScalarConverter

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -319,6 +319,7 @@ drake_cc_library(
     deps = [
         ":system",
         "//drake/common",
+        "//drake/common:hash",
     ],
 )
 

--- a/drake/systems/framework/system_scalar_converter.cc
+++ b/drake/systems/framework/system_scalar_converter.cc
@@ -1,28 +1,35 @@
 #include "drake/systems/framework/system_scalar_converter.h"
 
+#include "drake/common/hash.h"
+
+using std::pair;
+using std::type_index;
+using std::type_info;
+
 namespace drake {
 namespace systems {
 
-namespace {
-std::pair<std::type_index, std::type_index> make_key(
-    const std::type_info& t_info, const std::type_info& u_info) {
-  return std::make_pair(std::type_index(t_info), std::type_index(u_info));
+SystemScalarConverter::Key::Key(
+    const type_info& t_info, const type_info& u_info)
+    : pair<type_index, type_index>(t_info, u_info) {}
+
+size_t SystemScalarConverter::KeyHasher::operator()(const Key& key) const {
+  return hash_combine(size_t{}, key.first, key.second);
 }
-}  // namespace
 
 SystemScalarConverter::SystemScalarConverter() = default;
 
 void SystemScalarConverter::Insert(
     const std::type_info& t_info, const std::type_info& u_info,
     const ErasedConverterFunc& converter) {
-  const auto& key = make_key(t_info, u_info);
+  const auto& key = Key{t_info, u_info};
   const auto& insert_result = funcs_.insert({key, converter});
   DRAKE_ASSERT(insert_result.second);
 }
 
 const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
     const std::type_info& t_info, const std::type_info& u_info) const {
-  const auto& key = make_key(t_info, u_info);
+  const auto& key = Key{t_info, u_info};
   auto iter = funcs_.find(key);
   if (iter != funcs_.end()) {
     return &(iter->second);

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <typeindex>
+#include <unordered_map>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -106,6 +106,14 @@ class SystemScalarConverter {
   // Like ConverterFunc, but with the args and return value decayed into void*.
   using ErasedConverterFunc = std::function<void*(const void*)>;
 
+  // A pair of types {T, U}, usable as an unordered_map key.
+  struct Key : std::pair<std::type_index, std::type_index> {
+    Key(const std::type_info&, const std::type_info&);
+  };
+  struct KeyHasher {
+    size_t operator()(const Key&) const;
+  };
+
   // Given typeid(T), typeid(U), returns a converter.  If no converter has been
   // added yet, returns nullptr.
   const ErasedConverterFunc* Find(
@@ -117,8 +125,7 @@ class SystemScalarConverter {
       const ErasedConverterFunc&);
 
   // Maps from {T, U} to the function that converts from U into T.
-  std::map<std::pair<std::type_index, std::type_index>, ErasedConverterFunc>
-      funcs_;
+  std::unordered_map<Key, ErasedConverterFunc, KeyHasher> funcs_;
 };
 
 #if !defined(DRAKE_DOXYGEN_CXX)


### PR DESCRIPTION
This is more correct (we don't care about iteration order, so O(1) is preferred), and also appears to work around Xcode 7.3 segfaults for the prior `std::map` implementation under `-O2`.

This enhances #6589, and repairs #6684 to build correctly in release mode on OS X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6747)
<!-- Reviewable:end -->
