### PR TITLE
Port PoseAggregator to SystemScalarConverter

### DIFF
--- a/drake/systems/rendering/test/pose_aggregator_test.cc
+++ b/drake/systems/rendering/test/pose_aggregator_test.cc
@@ -71,7 +71,7 @@ PoseBundle<AutoDiffXd> ToAutoDiffXd(const PoseBundle<double>& original) {
 }
 }  // namespace
 
-// Tests that PoseAggregator aggregates poses fromtwo PoseVector inputs (one
+// Tests that PoseAggregator aggregates poses from two PoseVector inputs (one
 // with velocity and one without), and a PoseBundle input.
 TEST_F(PoseAggregatorTest, CompositeAggregation) {
   // Set some arbitrary translations in the PoseBundle input, and a velocity


### PR DESCRIPTION
This adds `symbolic::Expression` support as a side-effect.  We rely on the existing `AutoDiffXd` test cases to infer that symbolic will work correctly because they share the same codepath, and thus are not adding new symbolic-specific unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6750)
<!-- Reviewable:end -->
