### PR TITLE
Fixing an ASan Bug with Mac

### DIFF
--- a/drake/examples/kuka_iiwa_arm/pick_and_place/test/world_state_test.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/test/world_state_test.cc
@@ -52,6 +52,7 @@ GTEST_TEST(PickAndPlaceWorldStateTest, EndEffectorTest) {
   iiwa_msg.joint_velocity.push_back(-0.4807268);
   iiwa_msg.joint_velocity.push_back(0.45032358);
   iiwa_msg.joint_velocity.push_back(-0.8845549);
+  iiwa_msg.joint_velocity.push_back(0.0);
 
   dut.HandleIiwaStatus(iiwa_msg);
 

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.cc
@@ -50,6 +50,11 @@ void WorldState::HandleIiwaStatus(const bot_core::robot_state_t& iiwa_msg) {
 
   iiwa_time_ = iiwa_msg.utime / 1e6;
 
+  DRAKE_ASSERT(static_cast<size_t>(iiwa_msg.num_joints) ==
+      iiwa_msg.joint_velocity.size());
+  DRAKE_ASSERT(static_cast<size_t>(iiwa_msg.num_joints) ==
+      iiwa_msg.joint_position.size());
+
   for (int i = 0; i < iiwa_msg.num_joints; ++i) {
     iiwa_v_[i] = iiwa_msg.joint_velocity[i];
     iiwa_q_[i] = iiwa_msg.joint_position[i];


### PR DESCRIPTION
To reproduce:
`bazel test --config=asan //drake/examples/kuka_iiwa_arm/pick_and_place:world_state_test`

We might have forgotten to add a velocity, because the number of joints(7) is not equal to the number of velocities (6), and we're assuming them to be equal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6751)
<!-- Reviewable:end -->
