### PR TITLE
Rename ProjectMatTo{Rot => Orthonormal}Mat for O(3) projection, add ProjectMatToRotMat with SO(3) projection

### DIFF
--- a/drake/math/rotation_matrix.h
+++ b/drake/math/rotation_matrix.h
@@ -235,7 +235,7 @@ Matrix3<T> ZRotation(const T& theta) {
 /// Projects a full-rank 3x3 matrix @p M onto O(3), defined as
 /// <pre>
 ///   min_R  \sum_i,j | R(i,j) - M(i,j) |^2
-///  subject to   R*R^T = I.
+///  subject to   R*R^T = I  =>  R ∈ O(3)
 /// </pre>
 ///
 /// The algorithm (just SVD) can be derived as a small modification of
@@ -244,7 +244,7 @@ Matrix3<T> ZRotation(const T& theta) {
 /// Note that it does not enforce det(R)=1; you could get det(R)=-1 if that
 /// solution is closer to the matrix M using the norm above.
 template <typename Derived>
-Matrix3<typename Derived::Scalar> ProjectMatToRotMat(
+Matrix3<typename Derived::Scalar> ProjectMatToOrthonormalMat(
     const Eigen::MatrixBase<Derived>& M) {
   DRAKE_DEMAND(M.rows() == 3 && M.cols() == 3);
   const auto svd = M.jacobiSvd(Eigen::ComputeFullU | Eigen::ComputeFullV);

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -56,22 +56,22 @@ GTEST_TEST(RotationMatrixTest, TestProjection) {
   double tol = 1e-12;
 
   // Identity => Identity
-  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(Matrix3d::Identity()),
+  EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(Matrix3d::Identity()),
                               Matrix3d::Identity(), tol));
 
   // R1 (a valid rotation matrix) => R1
   Matrix3d R1 = rpy2rotmat(Vector3d(0.1, 0.2, 0.3));
-  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(R1), R1, tol));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(R1), R1, tol));
 
   // 2*R1 => R1
-  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(2 * R1), R1, tol));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(2 * R1), R1, tol));
 
   // Non-rotation matrix in gets an orthonormal matrix out.
   Matrix3d M2;
   M2 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  Matrix3d R2 = ProjectMatToRotMat(M2);
-  EXPECT_TRUE(CompareMatrices(R2.transpose(), R2.inverse(), tol));
 
+  Matrix3d R2 = ProjectMatToOrthonormalMat(M2);
+  EXPECT_TRUE(CompareMatrices(R2.transpose(), R2.inverse(), tol));
   // Determinant could be -1 or 1.
   EXPECT_NEAR(std::abs(R2.determinant()), 1.0, tol);
 }

--- a/drake/math/test/rotation_matrix_test.cc
+++ b/drake/math/test/rotation_matrix_test.cc
@@ -58,22 +58,33 @@ GTEST_TEST(RotationMatrixTest, TestProjection) {
   // Identity => Identity
   EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(Matrix3d::Identity()),
                               Matrix3d::Identity(), tol));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(Matrix3d::Identity()),
+                                Matrix3d::Identity(), tol));
 
   // R1 (a valid rotation matrix) => R1
   Matrix3d R1 = rpy2rotmat(Vector3d(0.1, 0.2, 0.3));
   EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(R1), R1, tol));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(R1), R1, tol));
 
-  // 2*R1 => R1
+  // 2*R1 => R1 (linear scaling)
   EXPECT_TRUE(CompareMatrices(ProjectMatToOrthonormalMat(2 * R1), R1, tol));
+  EXPECT_TRUE(CompareMatrices(ProjectMatToRotMat(2 * R1), R1, tol));
 
-  // Non-rotation matrix in gets an orthonormal matrix out.
+  // Non-rotation matrix in gets an orthonormal matrix out, using a full-rank
+  // matrix with det(M) < 0.
   Matrix3d M2;
-  M2 << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-
+  M2 << 1, 2, 3, 4, 5, 6, 7, 8, 10;
+  EXPECT_LT(M2.determinant(), 0);
   Matrix3d R2 = ProjectMatToOrthonormalMat(M2);
   EXPECT_TRUE(CompareMatrices(R2.transpose(), R2.inverse(), tol));
-  // Determinant could be -1 or 1.
-  EXPECT_NEAR(std::abs(R2.determinant()), 1.0, tol);
+  // Determinant should be -1.
+  EXPECT_NEAR(R2.determinant(), -1.0, tol);
+  // Check that we get SO(3) with Moakher's formulation.
+  Matrix3d R2_SO3 = ProjectMatToRotMat(M2);
+  EXPECT_TRUE(CompareMatrices(R2_SO3.transpose(), R2_SO3.inverse(), tol));
+  EXPECT_NEAR(R2_SO3.determinant(), 1.0, tol);
+  // TODO(eric.cousineau): Check SO(3) projection against a nonlinear
+  // optimization for additional sanity check.
 }
 
 // Take many possible samples of the rotation angle θ, make sure the rotation

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -179,7 +179,7 @@ void GlobalInverseKinematics::ReconstructGeneralizedPositionSolutionForBody(
     if (joint->is_floating()) {
       // p_WBi is the position of the body frame in the world frame.
       Vector3d p_WBi = GetSolution(p_WBo_[body_idx]);
-      Matrix3d normalized_rotmat = math::ProjectMatToOrthonormalMat(R_WC);
+      Matrix3d normalized_rotmat = math::ProjectMatToRotMat(R_WC);
 
       q.segment<3>(body.get_position_start_index()) = p_WBi;
       if (num_positions == 6) {

--- a/drake/multibody/global_inverse_kinematics.cc
+++ b/drake/multibody/global_inverse_kinematics.cc
@@ -179,7 +179,7 @@ void GlobalInverseKinematics::ReconstructGeneralizedPositionSolutionForBody(
     if (joint->is_floating()) {
       // p_WBi is the position of the body frame in the world frame.
       Vector3d p_WBi = GetSolution(p_WBo_[body_idx]);
-      Matrix3d normalized_rotmat = math::ProjectMatToRotMat(R_WC);
+      Matrix3d normalized_rotmat = math::ProjectMatToOrthonormalMat(R_WC);
 
       q.segment<3>(body.get_position_start_index()) = p_WBi;
       if (num_positions == 6) {


### PR DESCRIPTION
This renames the O(3) projection to `ProjectMatToOrthonormalMat`, and adds an SO(3) projection, `ProjectMatToRotMat`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6752)
<!-- Reviewable:end -->
