### PR TITLE
Correction of include order in geometry_world

### DIFF
--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -5,9 +5,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_handle.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
-#include "drake/geometry/geometry_state.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 

--- a/drake/geometry/internal_frame.h
+++ b/drake/geometry/internal_frame.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <unordered_set>
 #include <string>
+#include <unordered_set>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"


### PR DESCRIPTION
A PR had gone in without having been sufficiently tested against the new cpplint behavior. Some badly ordered include files had slipped in.  This patches those mistakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6758)
<!-- Reviewable:end -->
