### PR TITLE
Update matlab compiler instructions for mac

### DIFF
--- a/drake/doc/from_source.rst
+++ b/drake/doc/from_source.rst
@@ -10,8 +10,8 @@ Optional: Setting up the MATLAB Compiler
 Make sure that the MATLAB executable is in your path.  (e.g., typing ``matlab``
 at the system command line should start an instance of MATLAB).  For example,
 on Mac you might consider
-``sudo ln -s /Applications/MATLAB_R2014a.app/bin/matlab /usr/bin/matlab``,
-or you can actually add the MATLAB/bin directory to your system path.
+``sudo ln -s /Applications/MATLAB_R2016a.app/bin/matlab /usr/local/bin/matlab``
+, or you can actually add the MATLAB/bin directory to your system path.
 
 .. _getting_drake:
 


### PR DESCRIPTION
Changes:
 - `2014a` -> `2016a`
 - `/usr/bin` -> `/usr/local/bin` because `/usr/bin` is under [SIP (System Integrity Protection)](https://support.apple.com/en-us/HT204899).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6762)
<!-- Reviewable:end -->
