### PR TITLE
Wrap FindResourceOrThrow in Python in pydrake

### DIFF
--- a/drake/bindings/BUILD
+++ b/drake/bindings/BUILD
@@ -146,6 +146,7 @@ py_test(
     name = "pydrake_common_test",
     size = "small",
     srcs = ["python/pydrake/test/testCommon.py"],
+    data = ["//drake/examples/atlas:models"],
     main = "python/pydrake/test/testCommon.py",
     deps = [":pydrake"],
 )

--- a/drake/bindings/pybind11/pydrake_common.cc
+++ b/drake/bindings/pybind11/pydrake_common.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_assertion_error.h"
+#include "drake/common/find_resource.h"
 
 namespace py = pybind11;
 
@@ -30,6 +31,12 @@ PYBIND11_PLUGIN(_pydrake_common) {
         PyErr_SetString(PyExc_SystemExit, e.what());
       }
     });
+  // Convenient wrapper for querying FindResource(resource_path).
+  m.def("FindResourceOrThrow", &drake::FindResourceOrThrow,
+        "Attempts to locate a Drake resource named by the given path string. "
+        "The path refers to the relative path within the Drake repository, "
+        "e.g., drake/examples/pendulum/Pendulum.urdf. Raises an exception "
+        "if the resource was not found.");
 
   // These are meant to be called internally by pydrake; not by users.
   m.def("set_assertion_failure_to_throw_exception",

--- a/drake/bindings/python/pydrake/test/testCommon.py
+++ b/drake/bindings/python/pydrake/test/testCommon.py
@@ -23,6 +23,11 @@ class TestCommon(unittest.TestCase):
                     " condition 'false' failed",
                 ]))
 
+    def testDrakeFindResourceOrThrow(self):
+        pydrake.common.FindResourceOrThrow(
+            'drake/examples/atlas/urdf/atlas_convex_hull.urdf'
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is convenient to find the resource files in an installed directory of
drake. This can replace the call of `pydrake.getDrakePath()` which only works
with drake's source tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6766)
<!-- Reviewable:end -->
