### PR TITLE
Improve `getDrakePath()` to search source directory or install directory

### DIFF
--- a/drake/bindings/python/autogenerated_path.py.in
+++ b/drake/bindings/python/autogenerated_path.py.in
@@ -2,5 +2,14 @@ import os.path
 
 
 def getDrakePath():
-    return os.path.realpath(os.path.join(
-        os.path.dirname(__file__), '@RELATIVE_PATH_PYDRAKE_DRAKE@'))
+    # Find if we are in the install tree.
+    install_path = os.path.realpath(os.path.join(
+        os.path.dirname(__file__), '../../../../share/drake'))
+    sentinel = ".drake-resource-sentinel"
+    if os.path.isfile(os.path.join(install_path, sentinel)):
+        print("isntall path: {}".format(install_path))
+        return os.path.join(install_path, 'drake')
+    # Otherwise assume we are in the build tree.
+    source_path = os.path.realpath(os.path.join(
+    os.path.dirname(__file__), '@RELATIVE_PATH_PYDRAKE_DRAKE@'))
+    return source_path


### PR DESCRIPTION
`getDrakePath()` should work both from drake source and install directory. This
improves `getDrakePath()` to searches for the resource sentinel file
`.drake-resource-sentinel` in the expected install directory. If it doesn't
find it, it assumes that we are working in drake source directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6771)
<!-- Reviewable:end -->
