### PR TITLE
The state support for GEOMETRY topology operations

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -42,6 +42,7 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_instance",
         ":internal_frame",
+        ":internal_geometry",
     ],
 )
 
@@ -66,6 +67,16 @@ drake_cc_library(
     name = "internal_frame",
     srcs = ["internal_frame.cc"],
     hdrs = ["internal_frame.h"],
+    deps = [
+        ":geometry_ids",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
+    name = "internal_geometry",
+    srcs = [],
+    hdrs = ["internal_geometry.h"],
     deps = [
         ":geometry_ids",
         "//drake/common",

--- a/drake/geometry/geometry_state.cc
+++ b/drake/geometry/geometry_state.cc
@@ -168,12 +168,13 @@ template <typename T>
 GeometryId GeometryState<T>::RegisterGeometryWithParent(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance<T>> geometry) {
-  // The error condition is that geometry_id doesn't belong to source_id or
-  // if the source isn't active.  This is decomposed into two equivalent tests
-  // (implicitly):
-  //    1. Failure if the geometry_id doesn't exist at all, otherwise
-  //    2. Failure if the frame it belongs to doesn't belong to the source (or
-  //       active source).
+  // There are three error conditions in the doxygen:.
+  //    1. geometry == nullptr,
+  //    2. source_id is not a registered source, and
+  //    3. geometry_id doesn't belong to source_id.
+  //
+  // Only #1 is tested directly. #2 and #3 are tested implicitly during the act
+  // of registering the geometry.
 
   using std::to_string;
   if (geometry == nullptr) {
@@ -182,12 +183,14 @@ GeometryId GeometryState<T>::RegisterGeometryWithParent(
             ", on source " + to_string(source_id) + ".");
   }
 
-  // Failure condition 1.
+  // This confirms that geometry_id exists at all.
   InternalGeometry& parent_geometry =
       GetMutableValueOrThrow(geometry_id, &geometries_);
   FrameId frame_id = parent_geometry.get_frame_id();
 
-  // Failure condition 2.
+  // This implicitly confirms that source_id is registered (condition #2) and
+  // that frame_id belongs to source_id. By construction, geometry_id must
+  // belong to the same source as frame_id, so this tests  condition #3.
   GeometryId new_id = RegisterGeometryHelper(source_id, frame_id,
                                              move(geometry), geometry_id);
   parent_geometry.add_child(new_id);

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -10,11 +10,14 @@
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/internal_frame.h"
+#include "drake/geometry/internal_geometry.h"
 
 namespace drake {
 namespace geometry {
 
 template <typename T> class GeometryFrame;
+
+template <typename T> class GeometryInstance;
 
 template <typename T> class GeometrySystem;
 
@@ -56,7 +59,12 @@ class GeometryState {
   /** Reports the total number of frames -- across all sources. */
   int get_num_frames() const { return static_cast<int>(frames_.size()); }
 
-  /** Reports true if the given `source_id` references a registered source. */
+  /** Reports the total number of geometries. */
+  int get_num_geometries() const {
+    return static_cast<int>(geometries_.size());
+  }
+
+  /** Reports true if the given `source_id` references an active source. */
   bool source_is_registered(SourceId source_id) const;
 
   /** Reports the source name for the given source id.
@@ -64,28 +72,6 @@ class GeometryState {
    @return The name of the source.
    @throws std::logic_error if the id does _not_ map to a registered source. */
   const std::string& get_source_name(SourceId id) const;
-  //@}
-
-  /** @name       Relationship queries
-
-   Various methods that map identifiers for one type of entity to its related
-   entities. */
-  //@{
-
-  /** Reports if the given frame id was registered to the given source id.
-   @param frame_id      The query frame id.
-   @param source_id     The query source id.
-   @returns True if `frame_id` was registered on `source_id`.
-   @throws std::logic_error  If the `frame_id` does _not_ map to a frame or the
-                             identified source is not registered. */
-  bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
-
-  /** Returns the set of frames registered to the given source.
-   @param source_id     The identifier of the source to query.
-   @return  The set of frames associated with the id.
-   @throws std::logic_error If the `source_id` does _not_ map to a registered
-                            source. */
-  const FrameIdSet& GetFramesForSource(SourceId source_id) const;
 
   //@}
 
@@ -101,26 +87,6 @@ class GeometryState {
                         the number is the value of the returned SourceId.
    @throws std::logic_error is thrown if the name is _not_ unique. */
   SourceId RegisterNewSource(const std::string& name = "");
-
-  /** Removes all frames and geometry registered from the identified source.
-   The source remains registered and further frames and geometry can be
-   registered on it.
-   @param source_id     The identifier for the source to clear.
-   @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source. */
-  void ClearSource(SourceId source_id);
-
-  /** Removes the given frame from the the indicated source's frames. All
-   registered geometries connected to this frame will also be removed from the
-   world.
-   @param source_id     The identifier for the owner geometry source.
-   @param frame_id      The identifier of the frame to remove.
-   @throws std::logic_error  1. If the `source_id` does _not_ map to a
-                             registered source, or
-                             2. the `frame_id` does not map to a valid frame, or
-                             3. the `frame_id` maps to a frame that does not
-                             belong to the indicated source. */
-  void RemoveFrame(SourceId source_id, FrameId frame_id);
 
   /** Registers a new frame for the given source, the id of the new frame is
    returned.
@@ -144,6 +110,114 @@ class GeometryState {
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame<T>& frame);
 
+  /** Registers a GeometryInstance with the state. The state takes ownership of
+   the geometry and associates it with the given frame and source. Returns the
+   new identifier for the GeometryInstance.
+   @param source_id    The id of the source to which the frame and geometry
+                       belongs.
+   @param frame_id     The id of the frame on which the geometry is to hang.
+   @param geometry     The geometry to get the id for. The state takes
+                       ownership of the geometry.
+   @returns  A newly allocated geometry id.
+   @throws std::logic_error  1. the `source_id` does _not_ map to an active
+                             source, or
+                             2. the `frame_id` doesn't belong to the source, or
+                             3. The `geometry` is equal to `nullptr`. */
+  GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
+                              std::unique_ptr<GeometryInstance<T>> geometry);
+
+  /** Registers a GeometryInstance with the state. Rather than hanging directly
+   from a _frame_, the instance hangs on another geometry instance. The input
+   `geometry` instance's pose is assumed to be relative to that parent geometry
+   instance. The state takes ownership of the geometry and associates it with
+   the given geometry parent (and, ultimately, the parent geometry's frame) and
+   source. Returns the new identifier for the input `geometry`.
+   @param source_id    The id of the source on which the geometry is being
+                       declared.
+   @param geometry_id  The parent geometry for this geometry.
+   @param geometry     The geometry to get the id for. The state takes
+                       ownership of the geometry.
+   @returns  A newly allocated geometry id.
+   @throws std::logic_error 1. the `source_id` does _not_ map to an active
+                            source, or
+                            2. the `geometry_id` doesn't belong to the source,
+                            or
+                            3. the `geometry` is equal to `nullptr`. */
+  GeometryId RegisterGeometryWithParent(
+      SourceId source_id, GeometryId geometry_id,
+      std::unique_ptr<GeometryInstance<T>> geometry);
+
+  /** Removes all frames and geometry registered from the identified source.
+   The source remains registered and further frames and geometry can be
+   registered on it.
+   @param source_id     The identifier for the source to clear.
+   @throws std::logic_error  If the `source_id` does _not_ map to a registered
+                             source. */
+  void ClearSource(SourceId source_id);
+
+  /** Removes the given frame from the the indicated source's frames. All
+   registered geometries connected to this frame will also be removed from the
+   world.
+   @param source_id     The identifier for the owner geometry source.
+   @param frame_id      The identifier of the frame to remove.
+   @throws std::logic_error  1. If the `source_id` does _not_ map to a
+                             registered source, or
+                             2. the `frame_id` does not map to a valid frame, or
+                             3. the `frame_id` maps to a frame that does not
+                             belong to the indicated source. */
+  void RemoveFrame(SourceId source_id, FrameId frame_id);
+
+  /** Removes the given geometry from the the indicated source's frames. Any
+   geometry that was hung from the indicated geometry will _also_ be removed.
+   @param source_id     The identifier for the owner geometry source.
+   @param geometry_id   The identifier of the frame to remove.
+   @throws std::logic_error  1. If the `source_id` does _not_ map to an active
+                             source, or
+                             2. the `geometry_id` does not map to a valid
+                             geometry, or
+                             3. the `geometry_id` maps to a geometry that does
+                             not belong to the indicated source. */
+  void RemoveGeometry(SourceId source_id, GeometryId geometry_id);
+
+  //@}
+
+  /** @name       Relationship queries
+
+   Various methods that map identifiers for one type of entity to its related
+   entities. */
+  //@{
+
+  /** Reports if the given frame id was registered to the given source id.
+   @param frame_id      The query frame id.
+   @param source_id     The query source id.
+   @returns True if `frame_id` was registered on `source_id`.
+   @throws std::logic_error  If the `frame_id` does _not_ map to a frame or the
+                             identified source is not registered. */
+  bool BelongsToSource(FrameId frame_id, SourceId source_id) const;
+
+  /** Reports if the given geometry id was ultimately registered to the given
+   source id.
+   @param geometry_id      The query geometry id.
+   @param source_id     The query source id.
+   @returns True if `geometry_id` was registered on `source_id`.
+   @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
+                             geometry or the identified source is not active */
+  bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
+
+  /** Retrieves the frame id on which the given geometry id is declared.
+   @param geometry_id   The query geometry id.
+   @returns An optional FrameId based on a successful lookup.
+   @throws std::logic_error  If the `geometry_id` does _not_ map to a geometry
+                             which belongs to an existing frame.*/
+  FrameId GetFrameId(GeometryId geometry_id) const;
+
+  /** Returns the set of frames registered to the given source.
+   @param source_id     The identifier of the source to query.
+   @return  The set of frames associated with the id.
+   @throws std::logic_error If the `source_id` does _not_ map to a registered
+                            source. */
+  const FrameIdSet& GetFramesForSource(SourceId source_id) const;
+
   //@}
 
  private:
@@ -157,6 +231,15 @@ class GeometryState {
   // Gets the source id for the given frame id. Throws std::logic_error if the
   // frame belongs to no registered source.
   SourceId get_source_id(FrameId frame_id) const;
+
+  // Does the work of registering geometry. Attaches the given geometry to the
+  // identified frame (which must belong to the identified source). The geometry
+  // can have an optional parent.
+  // Throws an exception as documented in RegisterGeometry().
+  GeometryId RegisterGeometryHelper(
+      SourceId source_id, FrameId frame_id,
+      std::unique_ptr<GeometryInstance<T>> geometry,
+      optional<GeometryId> parent = {});
 
   // The origin from where an invocation of RemoveFrameUnchecked was called.
   // The origin changes the work that is required.
@@ -182,6 +265,31 @@ class GeometryState {
   //    but recursion is necessary.
   void RemoveFrameUnchecked(FrameId frame_id, RemoveFrameOrigin caller);
 
+  // The origin from where an invocation of RemoveGeometryUnchecked was called.
+  // The origin changes the work that is required.
+  enum class RemoveGeometryOrigin {
+    kFrame,      // Invoked by RemoveFrame().
+    kGeometry,   // Invoked by RemoveGeometry().
+    kRecurse     // Invoked by recursive call in RemoveGeometryUnchecked.
+  };
+
+  // Performs the work necessary to remove the identified geometry from
+  // GeometryWorld. The amount of work depends on the context from which this
+  // method is invoked:
+  //
+  //  - RemoveFrame(): RemoveFrame() deletes *all* geometry attached to the
+  //    frame. It explicitly iterates through those geometries. Thus,
+  //    recursion is unnecessary, removal from parent references is likewise
+  //    unnecessary (and actually wrong).
+  //  - RemoveGeometry(): A specific geometry (and its corresponding
+  //    hierarchy) is being removed. In addition to recursively removing all
+  //    child geometries, it must also remove this geometry id from its parent
+  //    frame and, if it exists, its parent geometry.
+  //   - RemoveGeometryUnchecked(): This is the recursive call; it's parent
+  //    is already slated for removal, so parent references can be left alone.
+  void RemoveGeometryUnchecked(GeometryId geometry_id,
+                               RemoveGeometryOrigin caller);
+
   // ---------------------------------------------------------------------
   // Maps from registered source ids to the entities registered to those
   // sources (e.g., frames and geometries). This lives in the state to support
@@ -205,6 +313,9 @@ class GeometryState {
 
   // The frame data, keyed on unique frame identifier.
   std::unordered_map<FrameId, internal::InternalFrame> frames_;
+
+  // The geometry data, keyed on unique geometry identifiers.
+  std::unordered_map<GeometryId, internal::InternalGeometry> geometries_;
 };
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -64,7 +64,7 @@ class GeometryState {
     return static_cast<int>(geometries_.size());
   }
 
-  /** Reports true if the given `source_id` references an active source. */
+  /** Reports true if the given `source_id` references a registered source. */
   bool source_is_registered(SourceId source_id) const;
 
   /** Reports the source name for the given source id.
@@ -112,14 +112,14 @@ class GeometryState {
 
   /** Registers a GeometryInstance with the state. The state takes ownership of
    the geometry and associates it with the given frame and source. Returns the
-   new identifier for the GeometryInstance.
+   new identifier for the successfully registered GeometryInstance.
    @param source_id    The id of the source to which the frame and geometry
                        belongs.
    @param frame_id     The id of the frame on which the geometry is to hang.
    @param geometry     The geometry to get the id for. The state takes
                        ownership of the geometry.
    @returns  A newly allocated geometry id.
-   @throws std::logic_error  1. the `source_id` does _not_ map to an active
+   @throws std::logic_error  1. the `source_id` does _not_ map to a registered
                              source, or
                              2. the `frame_id` doesn't belong to the source, or
                              3. The `geometry` is equal to `nullptr`. */
@@ -131,14 +131,15 @@ class GeometryState {
    `geometry` instance's pose is assumed to be relative to that parent geometry
    instance. The state takes ownership of the geometry and associates it with
    the given geometry parent (and, ultimately, the parent geometry's frame) and
-   source. Returns the new identifier for the input `geometry`.
+   source. Returns the new identifier for the successfully registered
+   GeometryInstance.
    @param source_id    The id of the source on which the geometry is being
                        declared.
    @param geometry_id  The parent geometry for this geometry.
    @param geometry     The geometry to get the id for. The state takes
                        ownership of the geometry.
    @returns  A newly allocated geometry id.
-   @throws std::logic_error 1. the `source_id` does _not_ map to an active
+   @throws std::logic_error 1. the `source_id` does _not_ map to a registered
                             source, or
                             2. the `geometry_id` doesn't belong to the source,
                             or
@@ -167,12 +168,12 @@ class GeometryState {
                              belong to the indicated source. */
   void RemoveFrame(SourceId source_id, FrameId frame_id);
 
-  /** Removes the given geometry from the the indicated source's frames. Any
+  /** Removes the given geometry from the the indicated source's geometries. Any
    geometry that was hung from the indicated geometry will _also_ be removed.
    @param source_id     The identifier for the owner geometry source.
    @param geometry_id   The identifier of the frame to remove.
-   @throws std::logic_error  1. If the `source_id` does _not_ map to an active
-                             source, or
+   @throws std::logic_error  1. If the `source_id` does _not_ map to a
+                             registered source, or
                              2. the `geometry_id` does not map to a valid
                              geometry, or
                              3. the `geometry_id` maps to a geometry that does
@@ -201,10 +202,11 @@ class GeometryState {
    @param source_id     The query source id.
    @returns True if `geometry_id` was registered on `source_id`.
    @throws std::logic_error  If the `geometry_id` does _not_ map to a valid
-                             geometry or the identified source is not active */
+                             geometry or the identified source is not
+                             registered */
   bool BelongsToSource(GeometryId geometry_id, SourceId source_id) const;
 
-  /** Retrieves the frame id on which the given geometry id is declared.
+  /** Retrieves the frame id on which the given geometry id is registered.
    @param geometry_id   The query geometry id.
    @returns An optional FrameId based on a successful lookup.
    @throws std::logic_error  If the `geometry_id` does _not_ map to a geometry

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -198,7 +198,7 @@ class GeometryState {
 
   /** Reports if the given geometry id was ultimately registered to the given
    source id.
-   @param geometry_id      The query geometry id.
+   @param geometry_id   The query geometry id.
    @param source_id     The query source id.
    @returns True if `geometry_id` was registered on `source_id`.
    @throws std::logic_error  If the `geometry_id` does _not_ map to a valid

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -234,15 +234,6 @@ class GeometryState {
   // frame belongs to no registered source.
   SourceId get_source_id(FrameId frame_id) const;
 
-  // Does the work of registering geometry. Attaches the given geometry to the
-  // identified frame (which must belong to the identified source). The geometry
-  // can have an optional parent.
-  // Throws an exception as documented in RegisterGeometry().
-  GeometryId RegisterGeometryHelper(
-      SourceId source_id, FrameId frame_id,
-      std::unique_ptr<GeometryInstance<T>> geometry,
-      optional<GeometryId> parent = {});
-
   // The origin from where an invocation of RemoveFrameUnchecked was called.
   // The origin changes the work that is required.
   enum class RemoveFrameOrigin {

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -84,22 +84,18 @@ template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance<T>> geometry) {
-  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
-  // and use all parameters.
-  unused(source_id, frame_id, geometry);
   THROW_IF_CONTEXT_ALLOCATED
-  return GeometryId::get_new_id();
+  return initial_state_->RegisterGeometry(source_id, frame_id,
+                                          std::move(geometry));
 }
 
 template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance<T>> geometry) {
-  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
-  // and use all parameters.
-  unused(source_id, geometry_id, geometry);
   THROW_IF_CONTEXT_ALLOCATED
-  return GeometryId::get_new_id();
+  return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
+                                                    std::move(geometry));
 }
 
 template <typename T>
@@ -128,9 +124,8 @@ void GeometrySystem<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
 template <typename T>
 void GeometrySystem<T>::RemoveGeometry(SourceId source_id,
                                        GeometryId geometry_id) {
-  // TODO(SeanCurtis-TRI): Actually do the work.
-  unused(source_id, geometry_id);
   THROW_IF_CONTEXT_ALLOCATED
+  initial_state_->RemoveGeometry(source_id, geometry_id);
 }
 
 template <typename T>

--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -362,7 +362,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
    @param source_id   The id for the owner geometry source.
    @param frame_id    The id of the frame to remove.
    @throws std::logic_error If:
-                            1. The `source_id` is not an active source,
+                            1. The `source_id` is not a registered source,
                             2. the `frame_id` doesn't belong to the source, or
                             3. a context has been allocated. */
   void RemoveFrame(SourceId source_id, FrameId frame_id);
@@ -373,7 +373,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
    @param source_id   The identifier for the owner geometry source.
    @param geometry_id The identifier of the geometry to remove.
    @throws std::logic_error If:
-                            1. The `source_id` is not an active source,
+                            1. The `source_id` is not a registered source,
                             2. the `geometry_id` doesn't belong to the source,
                                or
                             3. a context has been allocated. */

--- a/drake/geometry/internal_geometry.h
+++ b/drake/geometry/internal_geometry.h
@@ -47,6 +47,7 @@ class InternalGeometry {
   FrameId get_frame_id() const { return frame_id_; }
   GeometryId get_id() const { return id_; }
   optional<GeometryId> get_parent_id() const { return parent_id_; }
+  void set_parent_id(GeometryId id) { parent_id_ = id; }
 
   /** Returns true if this geometry has a geometry parent and the parent has the
    given `geometry_id`. */

--- a/drake/geometry/internal_geometry.h
+++ b/drake/geometry/internal_geometry.h
@@ -11,16 +11,14 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/** This class represents the internal representation of registered geometry.
- It includes the user-specified data (?? and ??, excluding pose data) and
- includes internal topology representations.
- */
+/** This class represents the internal representation of registered geometry
+ and its topological relationships. */
 class InternalGeometry {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalGeometry)
 
-  /** Default constructor. The parent identifier and pose index will be
-   invalid. */
+  /** Default constructor. The ids will be invalid, with no children, and no
+   parent geometry identifier. */
   InternalGeometry() {}
 
   /** Full constructor.
@@ -48,10 +46,10 @@ class InternalGeometry {
 
   FrameId get_frame_id() const { return frame_id_; }
   GeometryId get_id() const { return id_; }
-  optional<GeometryId> get_parent() const { return parent_id_; }
+  optional<GeometryId> get_parent_id() const { return parent_id_; }
 
-  /** Returns true if this geometry has a geometry parent and it is the given
-   `geometry_id`. */
+  /** Returns true if this geometry has a geometry parent and the parent has the
+   given `geometry_id`. */
   bool is_child_of_geometry(GeometryId geometry_id) const {
     return parent_id_ && *parent_id_ == geometry_id;
   }
@@ -62,29 +60,29 @@ class InternalGeometry {
     return frame_id == frame_id_;
   }
 
-  const std::unordered_set<GeometryId>& get_child_geometries() const {
-    return child_geometries_;
+  const std::unordered_set<GeometryId>& get_child_geometry_ids() const {
+    return child_geometry_ids_;
   }
-  std::unordered_set<GeometryId>* get_mutable_child_geometries() {
-    return &child_geometries_;
+  std::unordered_set<GeometryId>* get_mutable_child_geometry_ids() {
+    return &child_geometry_ids_;
   }
 
   /** Returns true if this geometry has a child geometry with the given
    `geometry_id`. */
   bool has_child(GeometryId geometry_id) const {
-    return child_geometries_.find(geometry_id) != child_geometries_.end();
+    return child_geometry_ids_.find(geometry_id) != child_geometry_ids_.end();
   }
 
   /** Adds a geometry with the given `geometry_id` to this geometry's set of
    children. */
   void add_child(GeometryId geometry_id) {
-    child_geometries_.insert(geometry_id);
+    child_geometry_ids_.insert(geometry_id);
   }
 
   /** Removes the given `geometry_id` from this geometry's set of children. If
    the id is not in the set, nothing changes. */
   void remove_child(GeometryId geometry_id) {
-    child_geometries_.erase(geometry_id);
+    child_geometry_ids_.erase(geometry_id);
   }
 
  private:
@@ -98,22 +96,9 @@ class InternalGeometry {
   optional<GeometryId> parent_id_;
 
   // The identifiers for the geometry hung on this frame.
-  std::unordered_set<GeometryId> child_geometries_;
+  std::unordered_set<GeometryId> child_geometry_ids_;
 };
 
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
-
-namespace std {
-/** Enables use of the %InternalGeometry to serve as a key in STL containers.
- @relates InternalGeometry
- */
-template <>
-struct hash<drake::geometry::internal::InternalGeometry> {
-  size_t operator()(
-      const drake::geometry::internal::InternalGeometry& geometry) const {
-    return hash<drake::geometry::GeometryId>()(geometry.get_id());
-  }
-};
-}  // namespace std

--- a/drake/geometry/internal_geometry.h
+++ b/drake/geometry/internal_geometry.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+/** This class represents the internal representation of registered geometry.
+ It includes the user-specified data (?? and ??, excluding pose data) and
+ includes internal topology representations.
+ */
+class InternalGeometry {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalGeometry)
+
+  /** Default constructor. The parent identifier and pose index will be
+   invalid. */
+  InternalGeometry() {}
+
+  /** Full constructor.
+   @param frame_id      The identifier of the frame this belongs to.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param parent_id     The optional id of the parent geometry.
+   */
+  InternalGeometry(FrameId frame_id, GeometryId geometry_id,
+                   const optional<GeometryId>& parent_id = {}) :
+      frame_id_(frame_id),
+      id_(geometry_id),
+      parent_id_(parent_id) {}
+
+  /** Compares two %InternalGeometry instances for "equality". Two internal
+   frames are considered equal if they have the same geometry identifier. */
+  bool operator==(const InternalGeometry &other) const {
+    return id_ == other.id_;
+  }
+
+  /** Compares two %InternalGeometry instances for inequality. See operator==()
+   for the definition of equality. */
+  bool operator!=(const InternalGeometry &other) const {
+    return !(*this == other);
+  }
+
+  FrameId get_frame_id() const { return frame_id_; }
+  GeometryId get_id() const { return id_; }
+  optional<GeometryId> get_parent() const { return parent_id_; }
+
+  /** Returns true if this geometry has a geometry parent and it is the given
+   `geometry_id`. */
+  bool is_child_of_geometry(GeometryId geometry_id) const {
+    return parent_id_ && *parent_id_ == geometry_id;
+  }
+
+  /** Returns true if the geometry is affixed to the frame with the given
+   `frame_id`. */
+  bool is_child_of_frame(FrameId frame_id) const {
+    return frame_id == frame_id_;
+  }
+
+  const std::unordered_set<GeometryId>& get_child_geometries() const {
+    return child_geometries_;
+  }
+  std::unordered_set<GeometryId>* get_mutable_child_geometries() {
+    return &child_geometries_;
+  }
+
+  /** Returns true if this geometry has a child geometry with the given
+   `geometry_id`. */
+  bool has_child(GeometryId geometry_id) const {
+    return child_geometries_.find(geometry_id) != child_geometries_.end();
+  }
+
+  /** Adds a geometry with the given `geometry_id` to this geometry's set of
+   children. */
+  void add_child(GeometryId geometry_id) {
+    child_geometries_.insert(geometry_id);
+  }
+
+  /** Removes the given `geometry_id` from this geometry's set of children. If
+   the id is not in the set, nothing changes. */
+  void remove_child(GeometryId geometry_id) {
+    child_geometries_.erase(geometry_id);
+  }
+
+ private:
+  // The identifier of the frame to which this geometry belongs.
+  FrameId frame_id_;
+
+  // The identifier for this frame.
+  GeometryId id_;
+
+  // The identifier for this frame's parent frame.
+  optional<GeometryId> parent_id_;
+
+  // The identifiers for the geometry hung on this frame.
+  std::unordered_set<GeometryId> child_geometries_;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+namespace std {
+/** Enables use of the %InternalGeometry to serve as a key in STL containers.
+ @relates InternalGeometry
+ */
+template <>
+struct hash<drake::geometry::internal::InternalGeometry> {
+  size_t operator()(
+      const drake::geometry::internal::InternalGeometry& geometry) const {
+    return hash<drake::geometry::GeometryId>()(geometry.get_id());
+  }
+};
+}  // namespace std


### PR DESCRIPTION
Extends the geometry state to include registration and removal of dynamic
geometries.

NOTE: About 100 lines of "additions" is just fixing the ordering of methods. I found my .h and .cc files had
ended up in a weird ordering.

The following methods have simply been moved (without implementation changes).
  - GeometryState::BelongsToSource(FrameId)
  - GeometryState::ClearSource
  - GeometryState::RemoveFrame
  - GeometryState::GetFramesForSource

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6774)
<!-- Reviewable:end -->
