### PR TITLE
Improve scalar-conversion unit tests for affine systems

### DIFF
--- a/drake/common/test/is_dynamic_castable.h
+++ b/drake/common/test/is_dynamic_castable.h
@@ -31,13 +31,20 @@ namespace drake {
 /// @endcode
 template <typename ToType, typename FromType>
 ::testing::AssertionResult is_dynamic_castable(const FromType* ptr) {
+  if (ptr == nullptr) {
+    const std::string from_name{NiceTypeName::Get<FromType>()};
+    const std::string to_name{NiceTypeName::Get<ToType>()};
+    return ::testing::AssertionFailure()
+        << "is_dynamic_castable<" << to_name << ">(" << from_name << "* ptr)"
+        << " failed because ptr was already nullptr.";
+  }
   if (dynamic_cast<const ToType* const>(ptr) == nullptr) {
     const std::string from_name{NiceTypeName::Get<FromType>()};
     const std::string to_name{NiceTypeName::Get<ToType>()};
     const std::string dynamic_name{NiceTypeName::Get(*ptr)};
     return ::testing::AssertionFailure()
-           << "is_dynamic_castable<" << to_name << ">(" << from_name << "* ptr)"
-           << " failed because ptr is of dynamic type " << dynamic_name << ".";
+        << "is_dynamic_castable<" << to_name << ">(" << from_name << "* ptr)"
+        << " failed because ptr is of dynamic type " << dynamic_name << ".";
   }
   return ::testing::AssertionSuccess();
 }
@@ -48,6 +55,16 @@ template <typename ToType, typename FromType>
 /// fails.
 template <typename ToType, typename FromType>
 ::testing::AssertionResult is_dynamic_castable(std::shared_ptr<FromType> ptr) {
+  return is_dynamic_castable<ToType, FromType>(ptr.get());
+}
+
+/// Checks if @p ptr, a shared pointer to `FromType` class, can be safely
+/// converted to a shared pointer to `ToType` class. Our motivation is to
+/// provide a good diagnostic for what @p ptr _actually_ was when the test
+/// fails.
+template <typename ToType, typename FromType>
+::testing::AssertionResult is_dynamic_castable(
+     const std::unique_ptr<FromType>& ptr) {
   return is_dynamic_castable<ToType, FromType>(ptr.get());
 }
 

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -635,6 +635,7 @@ drake_cc_googletest(
     name = "vector_system_test",
     deps = [
         ":vector_system",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/framework/test/vector_system_test.cc
+++ b/drake/systems/framework/test/vector_system_test.cc
@@ -6,6 +6,8 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
 namespace drake {
 namespace systems {
 namespace {
@@ -422,35 +424,19 @@ class OpenScalarTypeSystem : public VectorSystem<T> {
 };
 
 TEST_F(VectorSystemTest, ToAutoDiffXdTest) {
-  const int kSomeNumber = 22;
-  OpenScalarTypeSystem<double> dut{kSomeNumber};
-
-  // Convert to AutoDiffXd.
-  std::unique_ptr<System<AutoDiffXd>> autodiff = dut.ToAutoDiffXd();
-  ASSERT_NE(autodiff, nullptr);
-  const auto* const downcast =
-      dynamic_cast<OpenScalarTypeSystem<AutoDiffXd>*>(autodiff.get());
-  ASSERT_NE(downcast, nullptr);
-
   // The member field remains intact.
-  EXPECT_EQ(downcast->get_some_number(), kSomeNumber);
+  const OpenScalarTypeSystem<double> dut{22};
+  EXPECT_TRUE(is_autodiffxd_convertible(dut, [](const auto& converted) {
+    EXPECT_EQ(converted.get_some_number(), 22);
+  }));
 }
 
 TEST_F(VectorSystemTest, ToSymbolicTest) {
-  using Expression = symbolic::Expression;
-
-  const int kSomeNumber = 22;
-  OpenScalarTypeSystem<double> dut{kSomeNumber};
-
-  // Convert to Symbolic form.
-  std::unique_ptr<System<Expression>> autodiff = dut.ToSymbolic();
-  ASSERT_NE(autodiff, nullptr);
-  const auto* const downcast =
-      dynamic_cast<OpenScalarTypeSystem<Expression>*>(autodiff.get());
-  ASSERT_NE(downcast, nullptr);
-
   // The member field remains intact.
-  EXPECT_EQ(downcast->get_some_number(), kSomeNumber);
+  const OpenScalarTypeSystem<double> dut{22};
+  EXPECT_TRUE(is_symbolic_convertible(dut, [](const auto& converted) {
+    EXPECT_EQ(converted.get_some_number(), 22);
+  }));
 }
 
 // This system declares an output and continuous state, but does not define

--- a/drake/systems/framework/test_utilities/BUILD
+++ b/drake/systems/framework/test_utilities/BUILD
@@ -14,6 +14,7 @@ drake_cc_library(
     deps = [
         ":my_vector",
         ":pack_value",
+        ":scalar_conversion",
     ],
 )
 
@@ -35,6 +36,16 @@ drake_cc_library(
     deps = [
         "//drake/common",
         "//drake/systems/framework:vector",
+    ],
+)
+
+drake_cc_library(
+    name = "scalar_conversion",
+    testonly = 1,
+    srcs = [],
+    hdrs = ["scalar_conversion.h"],
+    deps = [
+        "//drake/common:is_dynamic_castable",
     ],
 )
 

--- a/drake/systems/framework/test_utilities/scalar_conversion.h
+++ b/drake/systems/framework/test_utilities/scalar_conversion.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/test/is_dynamic_castable.h"
+
+namespace drake {
+namespace systems {
+
+/// Tests whether the given device under test of type S<double> can be
+/// converted to use AutoDiffXd as its scalar type.  If the test passes,
+/// additional checks on the converted object of type `const S<AutoDiffXd>&`
+/// can be passed via a lambda into @p callback.  The Callback must take an
+/// `const S<AutoDiffXd>&` and return void; a typical value would be a lambda
+/// such as `[](const auto& converted) { EXPECT_TRUE(converted.thing()); }`.
+template <template <typename> class S, typename Callback>
+::testing::AssertionResult is_autodiffxd_convertible(
+     const S<double>& dut, Callback callback) {
+  // Check if a proper type came out; return early if not.
+  std::unique_ptr<System<AutoDiffXd>> converted = dut.ToAutoDiffXd();
+  ::testing::AssertionResult result =
+        is_dynamic_castable<S<AutoDiffXd>>(converted);
+  if (!result) { return result; }
+
+  // Allow calling code to specify additional tests on the converted System.
+  const S<AutoDiffXd>& downcast =
+      dynamic_cast<const S<AutoDiffXd>&>(*converted);
+  callback(downcast);
+
+  return ::testing::AssertionSuccess();
+}
+
+/// Tests whether the given device under test of type S<double> can be
+/// converted to use AutoDiffXd as its scalar type.
+template <template <typename> class S>
+::testing::AssertionResult is_autodiffxd_convertible(const S<double>& dut) {
+  return is_autodiffxd_convertible(dut, [](const auto&){});
+}
+
+/// Tests whether the given device under test of type S<double> can be
+/// converted to use Expression as its scalar type.  If the test passes,
+/// additional checks on the converted object of type `const S<Expression>&`
+/// can be passed via a lambda into @p callback.  The Callback must take an
+/// `const S<Expression>&` and return void; a typical value would be a lambda
+/// such as `[](const auto& converted) { EXPECT_TRUE(converted.thing()); }`.
+template <template <typename> class S, typename Callback>
+::testing::AssertionResult is_symbolic_convertible(
+     const S<double>& dut, Callback callback) {
+  // Check if a proper type came out; return early if not.
+  std::unique_ptr<System<symbolic::Expression>> converted = dut.ToSymbolic();
+  ::testing::AssertionResult result =
+        is_dynamic_castable<S<symbolic::Expression>>(converted);
+  if (!result) { return result; }
+
+  // Allow calling code to specify additional tests on the converted System.
+  const S<symbolic::Expression>& downcast =
+      dynamic_cast<const S<symbolic::Expression>&>(*converted);
+  callback(downcast);
+
+  return ::testing::AssertionSuccess();
+}
+
+/// Tests whether the given device under test of type S<double> can be
+/// converted to use Expression as its scalar type.
+template <template <typename> class S>
+::testing::AssertionResult is_symbolic_convertible(const S<double>& dut) {
+  return is_symbolic_convertible(dut, [](const auto&){});
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -318,6 +318,7 @@ drake_cc_googletest(
         ":linear_system",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 
@@ -328,6 +329,7 @@ drake_cc_googletest(
         ":matrix_gain",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -244,6 +244,7 @@ drake_cc_googletest(
         ":affine_system",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/affine_system.h"
 
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 
 using std::make_unique;
@@ -98,6 +99,26 @@ TEST_F(AffineSystemTest, Output) {
 
   EXPECT_TRUE(CompareMatrices(
       expected_output, system_output_->get_vector_data(0)->get_value(), 1e-10));
+}
+
+// Tests converting to different scalar types.
+TEST_F(AffineSystemTest, ConvertScalarType) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.A(), A_);
+    EXPECT_EQ(converted.B(), B_);
+    EXPECT_EQ(converted.f0(), f0_);
+    EXPECT_EQ(converted.C(), C_);
+    EXPECT_EQ(converted.D(), D_);
+    EXPECT_EQ(converted.y0(), y0_);
+  }));
+  EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.A(), A_);
+    EXPECT_EQ(converted.B(), B_);
+    EXPECT_EQ(converted.f0(), f0_);
+    EXPECT_EQ(converted.C(), C_);
+    EXPECT_EQ(converted.D(), D_);
+    EXPECT_EQ(converted.y0(), y0_);
+  }));
 }
 
 class FeedthroughAffineSystemTest : public ::testing::Test {

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_matrix_compare.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 
 using std::make_unique;
@@ -83,6 +84,24 @@ TEST_F(LinearSystemTest, Output) {
   expected_output = C_ * x + D_ * u;
 
   EXPECT_EQ(expected_output, system_output_->get_vector_data(0)->get_value());
+}
+
+// Tests converting to different scalar types.
+TEST_F(LinearSystemTest, ConvertScalarType) {
+  // TODO(jwnimmer-tri) We would prefer that these are true, but right now,
+  // LinearSystem does not transmogrify correctly.
+  EXPECT_FALSE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.A(), A_);
+    EXPECT_EQ(converted.B(), B_);
+    EXPECT_EQ(converted.C(), C_);
+    EXPECT_EQ(converted.D(), D_);
+  }));
+  EXPECT_FALSE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.A(), A_);
+    EXPECT_EQ(converted.B(), B_);
+    EXPECT_EQ(converted.C(), C_);
+    EXPECT_EQ(converted.D(), D_);
+  }));
 }
 
 // Test that linearizing an affine system returns the original A,B,C,D matrices.

--- a/drake/systems/primitives/test/matrix_gain_test.cc
+++ b/drake/systems/primitives/test/matrix_gain_test.cc
@@ -1,5 +1,6 @@
 #include "drake/systems/primitives/matrix_gain.h"
 
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/test/affine_linear_test.h"
 
 using std::make_unique;
@@ -74,6 +75,18 @@ TEST_F(MatrixGainTest, Output) {
   expected_output = D_ * u;
 
   EXPECT_EQ(system_output_->get_vector_data(0)->get_value(), expected_output);
+}
+
+// Tests converting to different scalar types.
+TEST_F(MatrixGainTest, ConvertScalarType) {
+  // TODO(jwnimmer-tri) We would prefer that these are true, but right now,
+  // MatrixGain does not transmogrify correctly.
+  EXPECT_FALSE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.D(), D_);
+  }));
+  EXPECT_FALSE(is_symbolic_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.D(), D_);
+  }));
 }
 
 }  // namespace


### PR DESCRIPTION
Details are in individual commits:
- Add `unique_ptr` support to `is_dynamic_castable`.  Add explicit `nullptr` diagnostic.
- Improve `vector_system_test` conciseness.
- Add scalar conversion tests for `AffineSystem`.
- Add expected-fail scalar conversion tests for `LinearSystem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6778)
<!-- Reviewable:end -->
