### PR TITLE
Install bits and pieces for drake_visualiser

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ alias(
 DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "bullet",
     "ccd",
+    "director",
     "eigen",
     "fcl",
     "fmt",

--- a/tools/director.bzl
+++ b/tools/director.bzl
@@ -50,7 +50,45 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """
-
+    file_content += """
+load("@drake//tools:install.bzl", "install", "install_files")
+install_files(
+    name = "install_binaries",
+    dest = ".",
+    files = glob([
+        "**/*",
+        ],
+        exclude=["share/**/*", "include/**/*", "lib/pkg-config/*", "**/*lcm*", "**/python*/**/*"],
+    ),
+    visibility = ["//visibility:public"],
+)
+install_files(
+    name = "install_binaries_lcm_hack",
+    dest = ".",
+    files = ["lib/liblcm.so.1"],
+    visibility = ["//visibility:public"],
+)
+install_files(
+    name = "install_python",
+    dest = "lib/python2.7/site-packages",
+    files = glob([
+        "lib/python*/**/*",
+        ],
+        exclude=["**/lcm/*", "**/robotlocomotion/*", "**/bot_core/*", "**/*.pyc"],
+    ),
+    strip_prefix = ["lib/python2.7/dist-packages"],
+    visibility = ["//visibility:public"],
+)
+install(
+    name = "install",
+    deps = [
+        "install_binaries",
+        "install_binaries_lcm_hack",
+        "install_python",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
     repository_ctx.file("BUILD", content = file_content, executable = False)
 
 director_repository = repository_rule(implementation = _impl)


### PR DESCRIPTION
But not everything from the director's list of external dependencies since it will conflict with drake's externals (lcm / eigen / bot_core). This resolves #6680.

It has one nasty hack, that is, installing `lib/liblcm.so.1` since Drake's bazel install does not produce this and the pre-compiled drake visualizer is looking for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6781)
<!-- Reviewable:end -->
