### PR TITLE
add the nonlinear complementary constraint

### DIFF
--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -34,6 +34,18 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "contact_implicit_constraints",
+    srcs = ["contact_implicit_constraints.cc"],
+    hdrs = ["contact_implicit_constraints.h"],
+    deps = [
+        "//drake/multibody:rigid_body_tree",
+        "//drake/solvers:binding",
+        "//drake/solvers:constraint",
+        "//drake/solvers:mathematical_program",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -53,6 +65,13 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
         "//drake/common/trajectories:piecewise_polynomial",
         "//drake/systems/primitives:linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_implicit_constraints_test",
+    deps = [
+        ":contact_implicit_constraints",
     ],
 )
 

--- a/drake/systems/trajectory_optimization/CMakeLists.txt
+++ b/drake/systems/trajectory_optimization/CMakeLists.txt
@@ -21,6 +21,22 @@ drake_install_pkg_config_file(drake-trajectory-optimization
     drake-trajectories
     eigen3)
 
+add_library_with_exports(LIB_NAME drakeContactImplicitConstraints SOURCE_FILES
+        contact_implicit_constraints.cc)
+target_link_libraries(drakeContactImplicitConstraints
+        drakeOptimization
+        drakeRBM)
+drake_install_libraries(drakeContactImplicitConstraints)
+drake_install_headers(
+        contact_implicit_constraints.h
+)
+drake_install_pkg_config_file(drake-contact-implicit-constraints
+        TARGET drakeContactImplicitConstraints
+        LIBS -ldrakeContactImplicitConstraints
+        REQUIRES
+          drake-optimization
+          drake-rbm)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/drake/systems/trajectory_optimization/contact_implicit_constraints.cc
+++ b/drake/systems/trajectory_optimization/contact_implicit_constraints.cc
@@ -45,10 +45,11 @@ GeneralNonlinearComplementaryConstraint::DoAddConstraintToProgram(
   DRAKE_ASSERT(z_size_ == z.rows());
   auto alpha = prog->NewContinuousVariables(num_complementary_);
   auto beta = prog->NewContinuousVariables(num_complementary_);
-  auto nonlinear_constraint{
-      std::make_shared<NonlinearComplementaryNonlinearConstraint>(
-          g_double_, g_autodiff_, h_double_, h_autodiff_, num_complementary_,
-          z_size_, complementary_epsilon_)};
+  std::shared_ptr<NonlinearComplementaryNonlinearConstraint>
+      nonlinear_constraint{
+          std::make_shared<NonlinearComplementaryNonlinearConstraint>(
+              g_double_, g_autodiff_, h_double_, h_autodiff_,
+              num_complementary_, z_size_, complementary_epsilon_)};
   auto nonlinear_binding =
       prog->AddConstraint(nonlinear_constraint, {z, alpha, beta});
   auto bounding_box_binding = prog->AddBoundingBoxConstraint(

--- a/drake/systems/trajectory_optimization/contact_implicit_constraints.cc
+++ b/drake/systems/trajectory_optimization/contact_implicit_constraints.cc
@@ -1,0 +1,69 @@
+#include "drake/systems/trajectory_optimization/contact_implicit_constraints.h"
+
+#include <limits>
+#include <memory>
+
+namespace drake {
+namespace systems {
+void GeneralNonlinearComplementaryConstraint::
+    NonlinearComplementaryNonlinearConstraint::DoEval(
+        const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
+  const Eigen::VectorXd z = x.head(z_size_);
+  const Eigen::VectorXd alpha = x.block(z_size_, 0, num_complementary_, 1);
+  const Eigen::VectorXd beta = x.tail(num_complementary_);
+  y.resize(3 * num_complementary_);
+  g_double_(z, y.head(num_complementary_));
+  y.head(num_complementary_) -= alpha;
+  h_double_(z, y.block(num_complementary_, 0, num_complementary_, 1));
+  y.block(num_complementary_, 0, num_complementary_, 1) -= beta;
+  y.tail(num_complementary_) = (alpha.array() * beta.array()).matrix();
+}
+
+void GeneralNonlinearComplementaryConstraint::
+    NonlinearComplementaryNonlinearConstraint::DoEval(
+        const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd& y) const {
+  y.resize(3 * num_complementary_);
+  g_autodiff_(x.head(z_size_), y.head(num_complementary_));
+  y.head(num_complementary_) -= x.block(z_size_, 0, num_complementary_, 1);
+  h_autodiff_(x.head(z_size_),
+              y.block(num_complementary_, 0, num_complementary_, 1));
+  y.block(num_complementary_, 0, num_complementary_, 1) -=
+      x.tail(num_complementary_);
+  y.tail(num_complementary_) =
+      (x.block(z_size_, 0, num_complementary_, 1).array() *
+       x.tail(num_complementary_).array())
+          .matrix();
+}
+
+std::tuple<solvers::Binding<solvers::BoundingBoxConstraint>,
+           solvers::Binding<solvers::LinearConstraint>,
+           solvers::Binding<solvers::Constraint>,
+           solvers::VectorXDecisionVariable>
+GeneralNonlinearComplementaryConstraint::DoAddConstraintToProgram(
+    solvers::MathematicalProgram* prog,
+    const Eigen::Ref<const solvers::VectorXDecisionVariable>& z) const {
+  DRAKE_ASSERT(z_size_ == z.rows());
+  auto alpha = prog->NewContinuousVariables(num_complementary_);
+  auto beta = prog->NewContinuousVariables(num_complementary_);
+  auto nonlinear_constraint{
+      std::make_shared<NonlinearComplementaryNonlinearConstraint>(
+          g_double_, g_autodiff_, h_double_, h_autodiff_, num_complementary_,
+          z_size_, complementary_epsilon_)};
+  auto nonlinear_binding =
+      prog->AddConstraint(nonlinear_constraint, {z, alpha, beta});
+  auto bounding_box_binding = prog->AddBoundingBoxConstraint(
+      0, std::numeric_limits<double>::infinity(), {alpha, beta});
+  // An empty linear constraint with 0 rows.
+  solvers::Binding<solvers::LinearConstraint> linear_binding{
+      std::make_shared<solvers::LinearConstraint>(
+          Eigen::Matrix<double, 0, Eigen::Dynamic>::Zero(0, z_size_),
+          Eigen::Matrix<double, 0, 1>::Zero(),
+          Eigen::Matrix<double, 0, 1>::Zero()),
+      z};
+  solvers::VectorXDecisionVariable new_vars{2 * num_complementary_};
+  new_vars << alpha, beta;
+  return std::make_tuple(bounding_box_binding, linear_binding,
+                         nonlinear_binding, new_vars);
+}
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/trajectory_optimization/contact_implicit_constraints.h
+++ b/drake/systems/trajectory_optimization/contact_implicit_constraints.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/solvers/binding.h"
+#include "drake/solvers/constraint.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace systems {
+/**
+ * This constraint formulates the general nonlinear complementary constraint
+ * <pre>
+ *   0 ≤ g(z) ⊥ h(z) ≥ 0    (1)
+ * </pre>
+ * where g(z) and h(z) are column vectors of the same dimension. The inequality
+ * is elementwise.
+ * To solve a problem with this nonlinear complementary constraint through
+ * nonlinear optimization, we formulate (and relax) it as
+ * <pre>
+ *   α = g(z)
+ *   β = h(z)
+ *   α, β ≥ 0
+ *   αᵢ * βᵢ ≤ ε
+ * </pre>
+ * where α, β are additional slack variables. ε > 0 is a small positive
+ * tolerance. As ε → 0, the relaxation becomes tight as the original constraint
+ * (1). Check equation 26 - 29 in the paper
+ * A Direct Method for Trajectory Optimization of Rigid Bodies Through Contact
+ * Michael Posa, Cecilia Cantu, and Russ Tedrake. IJRR, 2014.
+ */
+class GeneralNonlinearComplementaryConstraint {
+ public:
+  typedef void (*nonlinear_fun_double)(const Eigen::Ref<const Eigen::VectorXd>&,
+                                       Eigen::Ref<Eigen::VectorXd>);
+  typedef void (*nonlinear_fun_autodiff)(const Eigen::Ref<const AutoDiffVecXd>&,
+                                         Eigen::Ref<AutoDiffVecXd>);
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GeneralNonlinearComplementaryConstraint)
+
+  /**
+   * Construct a container that wraps the information about this complementary
+   * constraint.
+   * @param g_double The function that evaluates `g` with Eigen double vector.
+   * @param g_autodiff The function that evaluates `g` with Eigen autodiff
+   * vector.
+   * @param h_double The function that evaluates `h` with Eigen double vector.
+   * @param h_autodiff The function that evaluates `h` with Eigen autodiff
+   * vector.
+   * @param num_complementary The number of rows in `g` and `h`.
+   * @param z_size The size of the vector `z`.
+   * @param complementary_epsilon The threshold for the complementary condition.
+   */
+  GeneralNonlinearComplementaryConstraint(nonlinear_fun_double g_double,
+                                          nonlinear_fun_autodiff g_autodiff,
+                                          nonlinear_fun_double h_double,
+                                          nonlinear_fun_autodiff h_autodiff,
+                                          int num_complementary, int z_size,
+                                          double complementary_epsilon)
+      : g_double_{g_double},
+        g_autodiff_{g_autodiff},
+        h_double_{h_double},
+        h_autodiff_{h_autodiff},
+        num_complementary_{num_complementary},
+        z_size_{z_size},
+        complementary_epsilon_{complementary_epsilon} {
+    DRAKE_ASSERT(num_complementary > 0);
+    DRAKE_ASSERT(complementary_epsilon >= 0);
+  }
+
+  /**
+   * This class contains the nonlinear constraints inside the complementary
+   * constraint.
+   */
+  class NonlinearComplementaryNonlinearConstraint : public solvers::Constraint {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(NonlinearComplementaryNonlinearConstraint)
+
+    NonlinearComplementaryNonlinearConstraint(nonlinear_fun_double g_double,
+                                              nonlinear_fun_autodiff g_autodiff,
+                                              nonlinear_fun_double h_double,
+                                              nonlinear_fun_autodiff h_autodiff,
+                                              int num_complementary, int z_size,
+                                              double complementary_epsilon)
+        : solvers::Constraint(num_complementary * 3,
+                              z_size + 2 * num_complementary,
+                              Eigen::VectorXd::Zero(3 * num_complementary),
+                              Eigen::VectorXd::Zero(3 * num_complementary)),
+          g_double_{g_double},
+          g_autodiff_{g_autodiff},
+          h_double_{h_double},
+          h_autodiff_{h_autodiff},
+          num_complementary_{num_complementary},
+          z_size_{z_size} {
+      DRAKE_ASSERT(num_complementary_ > 0);
+      Eigen::VectorXd ub(3 * num_complementary);
+      ub.tail(num_complementary) =
+          Eigen::VectorXd::Constant(num_complementary, complementary_epsilon);
+      UpdateUpperBound(ub);
+    }
+
+    ~NonlinearComplementaryNonlinearConstraint() override {}
+
+   protected:
+    void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+                Eigen::VectorXd& y) const override;
+
+    void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+                AutoDiffVecXd& y) const override;
+
+   private:
+    const nonlinear_fun_double g_double_;
+    const nonlinear_fun_autodiff g_autodiff_;
+    const nonlinear_fun_double h_double_;
+    const nonlinear_fun_autodiff h_autodiff_;
+    const int num_complementary_;
+    const int z_size_;
+  };
+
+  /**
+   * Add the generalized nonlinear complementary constraint into the
+   * optimization program.
+   * @param prog The optimization program to be changed.
+   * @param z The generalized nonlinear complementary constraint is imposed on
+   * variable `z`.
+   */
+  void AddConstraintToProgram(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& z) const {
+    return DoAddConstraintToProgram(prog, z);
+  }
+
+  virtual ~GeneralNonlinearComplementaryConstraint() {}
+
+ protected:
+  const nonlinear_fun_double g_double_;
+  const nonlinear_fun_autodiff g_autodiff_;
+  const nonlinear_fun_double h_double_;
+  const nonlinear_fun_autodiff h_autodiff_;
+  const int num_complementary_;
+  const int z_size_;
+  const double complementary_epsilon_;
+
+ private:
+  virtual void DoAddConstraintToProgram(
+      solvers::MathematicalProgram* prog,
+      const Eigen::Ref<const solvers::VectorXDecisionVariable>& z) const;
+};
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/trajectory_optimization/contact_implicit_constraints.h
+++ b/drake/systems/trajectory_optimization/contact_implicit_constraints.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <tuple>
+
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/solvers/binding.h"
 #include "drake/solvers/constraint.h"
@@ -122,8 +124,16 @@ class GeneralNonlinearComplementaryConstraint {
    * @param prog The optimization program to be changed.
    * @param z The generalized nonlinear complementary constraint is imposed on
    * variable `z`.
+   * @return T. T is a tuple
+   * T.get<0>() The newly created bounding box constraint.
+   * T.get<1>() The newly created linear constraint.
+   * T.get<2>() The newly created nonlinear constraint.
+   * T.get<3>() The newly added slack variables.
    */
-  void AddConstraintToProgram(
+  std::tuple<solvers::Binding<solvers::BoundingBoxConstraint>,
+             solvers::Binding<solvers::LinearConstraint>,
+             solvers::Binding<solvers::Constraint>,
+             solvers::VectorXDecisionVariable> AddConstraintToProgram(
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& z) const {
     return DoAddConstraintToProgram(prog, z);
@@ -141,7 +151,11 @@ class GeneralNonlinearComplementaryConstraint {
   const double complementary_epsilon_;
 
  private:
-  virtual void DoAddConstraintToProgram(
+  virtual std::tuple<solvers::Binding<solvers::BoundingBoxConstraint>,
+                     solvers::Binding<solvers::LinearConstraint>,
+                     solvers::Binding<solvers::Constraint>,
+                     solvers::VectorXDecisionVariable>
+  DoAddConstraintToProgram(
       solvers::MathematicalProgram* prog,
       const Eigen::Ref<const solvers::VectorXDecisionVariable>& z) const;
 };

--- a/drake/systems/trajectory_optimization/test/CMakeLists.txt
+++ b/drake/systems/trajectory_optimization/test/CMakeLists.txt
@@ -1,2 +1,5 @@
 drake_add_cc_test(direct_collocation_constraint_test)
 target_link_libraries(direct_collocation_constraint_test drakeTrajectoryOptimization)
+
+drake_add_cc_test(contact_implicit_constraints_test)
+target_link_libraries(contact_implicit_constraints_test drakeContactImplicitConstraints)

--- a/drake/systems/trajectory_optimization/test/contact_implicit_constraints_test.cc
+++ b/drake/systems/trajectory_optimization/test/contact_implicit_constraints_test.cc
@@ -1,0 +1,60 @@
+#include "drake/systems/trajectory_optimization/contact_implicit_constraints.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace systems {
+namespace {
+// Test the general nonlinear complementary constraint
+// g(x) = [x(0)² + x(0) * x(1); x(0) + 3 - x(2)²]
+// h(x) = [x(1) - x(2) * x(0) + 1; x(2) - x(1)²]
+// 0 ≤ g(x) ⊥ h(x) ≥ 0
+// One solution is (1, -1, 2)
+template <typename DerivedX, typename DerivedY>
+typename std::enable_if<std::is_same<typename DerivedX::Scalar,
+                                     typename DerivedY::Scalar>::value>::type
+g_test(const Eigen::Ref<const DerivedX>& x, Eigen::Ref<DerivedY> y) {
+  y << x(0) * x(0) + x(0) * x(1), x(0) + 3 - x(2) * x(2);
+}
+
+template <typename DerivedX, typename DerivedY>
+typename std::enable_if<std::is_same<typename DerivedX::Scalar,
+                                     typename DerivedY::Scalar>::value>::type
+h_test(const Eigen::Ref<const DerivedX>& x, Eigen::Ref<DerivedY> y) {
+  y << x(1) - x(2) * x(0) + 1, x(2) - x(1) * x(1);
+}
+
+GTEST_TEST(ContactImplicitConstraintsTest,
+           NonlinearComplementaryConstraintTest) {
+  GeneralNonlinearComplementaryConstraint::nonlinear_fun_double g_double{
+      g_test<Eigen::VectorXd, Eigen::VectorXd>};
+  GeneralNonlinearComplementaryConstraint::nonlinear_fun_double h_double{
+      h_test<Eigen::VectorXd, Eigen::VectorXd>};
+  GeneralNonlinearComplementaryConstraint::nonlinear_fun_autodiff g_autodiff{
+      g_test<AutoDiffVecXd, AutoDiffVecXd>};
+  GeneralNonlinearComplementaryConstraint::nonlinear_fun_autodiff h_autodiff{
+      h_test<AutoDiffVecXd, AutoDiffVecXd>};
+  GeneralNonlinearComplementaryConstraint dut{
+      g_double, g_autodiff, h_double, h_autodiff, 2, 3, 0};
+  solvers::MathematicalProgram prog;
+  auto z = prog.NewContinuousVariables<3>();
+  const auto new_constraints = dut.AddConstraintToProgram(&prog, z);
+  // Check the size of the slack variables.
+  EXPECT_EQ(std::get<3>(new_constraints).rows(), 4);
+  // Check the linear constraint is just empty.
+  EXPECT_EQ(std::get<1>(new_constraints).constraint()->A().rows(), 0);
+
+  solvers::SolutionResult result = prog.Solve();
+  EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound);
+  const auto z_val = prog.GetSolution(z);
+  Eigen::Vector2d g_val;
+  Eigen::Vector2d h_val;
+  g_test<Eigen::Vector3d, Eigen::Vector2d>(z_val, g_val);
+  h_test<Eigen::Vector3d, Eigen::Vector2d>(z_val, h_val);
+  EXPECT_TRUE((g_val.array() >= 0).all());
+  EXPECT_TRUE((h_val.array() >= 0).all());
+  EXPECT_NEAR(g_val.dot(h_val), 0, 1E-6);
+}
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This is the first step to bring in contact implicit trajectory optimization.

The main challenge I face is that the complementary condition
```
0 ≤ g(z) ⊥ h(z) ≥ 0
```
is transformed to a set of constraints (including both nonlinear and bounding box constraint)
```
α = g(z)
β = h(z)
α, β ≥ 0
αᵢ * βᵢ ≤ ε
```
So I create a separate class, derived from `Constraint`, to store the nonlinear constraints.

@EricCousineau-TRI @jwnimmer-tri would you recommend a better way to do this, without creating these nonlinear constraints in https://github.com/hongkai-dai/drake/blob/nonlinear_complementary_constraint/drake/systems/trajectory_optimization/contact_implicit_constraints.h#L76-L119? This constraint share a lot in common with `GeneralizedNonlinearComplementaryConstraint` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6796)
<!-- Reviewable:end -->
