### PR TITLE
Documented the two-symbol (body,point) form of spatial force notation

### DIFF
--- a/drake/multibody/multibody_doxygen.h
+++ b/drake/multibody/multibody_doxygen.h
@@ -588,18 +588,25 @@ specified frame. Thus, unambiguous notation for spatial vectors must specify
 both a point and an expressed-in frame. Motion quantities must also state the
 reference frame with respect to which the motion is measured.
 
-Example spatial quantity      |At |Exp|     Typeset        |   Code
-------------------------------|---|:-:|:------------------:|:-------:
-Body B's spatial velocity in A|Bo | A |@f$^AV^B         @f$|`V_AB`
-Same, but expressed in world  |Bo | W |@f$[^AV^B]_W     @f$|`V_AB_W`
-B's spatial acceleration in W |Bcm| W |@f$^WA^{B_{cm}}  @f$|`A_WBcm`
-Spatial force applied to B    |Bcm| W |@f$[F^{B_{cm}}]_W@f$|`F_Bcm_W`
+Example spatial quantity       |At |Exp|     Typeset        |   Code
+-------------------------------|---|:-:|:------------------:|:-------:
+Body B's spatial velocity in A |Bo | A |@f$^AV^B         @f$|`V_AB`
+Same, but expressed in world   |Bo | W |@f$[^AV^B]_W     @f$|`V_AB_W`
+B's spatial acceleration in W  |Bcm| W |@f$^WA^{B_{cm}}  @f$|`A_WBcm`
+Spatial force acting on body B |Bcm| W |@f$[F^{B_{cm}}]_W@f$|`F_Bcm_W`
+Spatial force acting on body A | Q | W |@f$[F^{A/Q}]_W   @f$|`F_AQ_W`
 
 In the above table "At" is the point at which the translational activity occurs;
-"Exp" is the expressed-in frame in which both vectors are expressed. Note that
-the expressed-in frame defaults to the reference (left) frame and that the point
-defaults to the target (right) frame origin. You should use fully-expanded
-symbols if there is any chance of confusion.
+"Exp" is the expressed-in frame in which both vectors are expressed. The
+expressed-in frame defaults to the reference (left) frame and the point
+defaults to the target (right) frame origin. Note that for spatial forces we
+need to identify the body (actually a frame) on which the force is acting, as
+well as a point rigidly fixed to that body (or frame). When the body is obvious
+from the point name (such as Bo or Bcm above), the body does not need to be
+specified again. However, when the body is not clear it should be listed before
+the point as in the last line of the table above. There it can be read as "the
+point of body A coincident in space with point Q". You should use fully-expanded
+symbols, and helpful comments, if there is any chance of confusion.
 
 Next topic: @ref multibody_spatial_inertia
 **/

--- a/drake/multibody/multibody_doxygen.h
+++ b/drake/multibody/multibody_doxygen.h
@@ -580,32 +580,37 @@ equivalents:
 alpha | α - angular acceleration ||  a   | linear acceleration
   t   | τ - torque               ||  f   | force
 
-While the rotational component of a spatial vector applies to a rigid body as a
-whole, the translational component refers to a particular point on that same
-body. When assigned numerical values for computation, both subvectors must be
-expressed in the same frame, which may be that body's frame or any other
-specified frame. Thus, unambiguous notation for spatial vectors must specify
-both a point and an expressed-in frame. Motion quantities must also state the
-reference frame with respect to which the motion is measured.
+While the rotational component of a spatial vector applies to a rigid body or
+frame as a whole, the translational component refers to a particular point
+rigidly fixed to that same body or frame. When assigned numerical values
+for computation, both subvectors must be expressed in the same frame, which may
+be that body's frame or any other specified frame. Thus, unambiguous notation
+for spatial vectors must specify both a point and an expressed-in frame. Motion
+quantities must also state the reference frame with respect to which the motion
+is measured.
 
-Example spatial quantity       |At |Exp|     Typeset        |   Code
--------------------------------|---|:-:|:------------------:|:-------:
-Body B's spatial velocity in A |Bo | A |@f$^AV^B         @f$|`V_AB`
-Same, but expressed in world   |Bo | W |@f$[^AV^B]_W     @f$|`V_AB_W`
-B's spatial acceleration in W  |Bcm| W |@f$^WA^{B_{cm}}  @f$|`A_WBcm`
-Spatial force acting on body B |Bcm| W |@f$[F^{B_{cm}}]_W@f$|`F_Bcm_W`
-Spatial force acting on body A | Q | W |@f$[F^{A/Q}]_W   @f$|`F_AQ_W`
+Example spatial quantity      |At |Exp|     Typeset        |   Code  |  Full
+------------------------------|---|:-:|:------------------:|:-------:|:--------:
+Body B's spatial velocity in A|Bo | A |@f$^AV^B         @f$|`V_AB`   |`V_ABo_A`
+Same, but expressed in world  |Bo | W |@f$[^AV^B]_W     @f$|`V_AB_W` |`V_ABo_W`
+B's spatial acceleration in W |Bcm| W |@f$^WA^{B_{cm}}  @f$|`A_WBcm` |`A_WBcm_W`
+Spatial force acting on body B|Bcm| W |@f$[F^{B_{cm}}]_W@f$|`F_Bcm_W`|`F_BBcm_W`
+Spatial force acting on body A| Q | W |@f$[F^{A/Q}]_W   @f$|`F_AQ_W` |    —
 
 In the above table "At" is the point at which the translational activity occurs;
 "Exp" is the expressed-in frame in which both vectors are expressed. The
 expressed-in frame defaults to the reference (left) frame and the point
-defaults to the target (right) frame origin. Note that for spatial forces we
-need to identify the body (actually a frame) on which the force is acting, as
-well as a point rigidly fixed to that body (or frame). When the body is obvious
-from the point name (such as Bo or Bcm above), the body does not need to be
-specified again. However, when the body is not clear it should be listed before
-the point as in the last line of the table above. There it can be read as "the
-point of body A coincident in space with point Q". You should use fully-expanded
+defaults to the target (right) frame origin. The "Code" column shows the
+notation to use in code, using the available defaults; "Full" shows the code
+notation with the defaults shown explicitly.
+
+For spatial forces we need to identify the body (actually a frame) on which the
+force is acting, as well as a point rigidly fixed to that body (or frame). When
+the body is obvious from the point name (such as Bo or Bcm above), the body does
+not need to be specified again. However, when the body is not clear it should be
+listed before the point as in the last line of the table above. There it can be
+read as "the point of body A coincident in space with point Q", where point Q
+might be identified with a different body. You should use fully-expanded
 symbols, and helpful comments, if there is any chance of confusion.
 
 Next topic: @ref multibody_spatial_inertia


### PR DESCRIPTION
A spatial force F acts on a particular body (or rigid frame) B, with the translational part applied to a particular point P that must be rigidly fixed to that body. Often the body is obvious from the point name, so for example `Bcm` is the name for the center of mass of body B, so `F_Bcm` is clearly acting on body B, at its center of mass. However, there are occasions when the body can't be inferred from the point, in which case we need to specify the body and point both. The monogram notation for that is `F_BP` which means "a spatial force on body B, applied at a point of B which is coincident in space with point P". This was used very effectively by @amcastro-tri in PR #6723, but @EricCousineau-TRI pointed out that it wasn't in the notation documentation.

This PR adds that form of the notation to the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6798)
<!-- Reviewable:end -->
