### PR TITLE
A few unit inertia factories.

### DIFF
--- a/drake/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -233,20 +233,20 @@ GTEST_TEST(UnitInertia, AxiallySymmetric) {
       AngleAxisd(-M_PI_4, Vector3d::UnitX()).toRotationMatrix();
 
   // Unit inertia computed with AxiallySymmetric().
-  UnitInertia<double> G =
+  UnitInertia<double> G_E =
       UnitInertia<double>::AxiallySymmetric(I_axial, I_perp, b_E);
 
   // The expected inertia is that of a cylinder of radius r and height L with
   // its longitudinal axis aligned with b.
-  UnitInertia<double> G_expected =
-      UnitInertia<double>::SolidCylinder(r, L).ReExpress(R_EZ);
+  UnitInertia<double> G_Z = UnitInertia<double>::SolidCylinder(r, L);
+  UnitInertia<double> G_E_expected = G_Z.ReExpress(R_EZ);
 
   // Verify the computed values.
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(
+      G_E_expected.CopyToFullMatrix3(), kEpsilon));
 
   // Verify the principal moments indeed are I_perp and I_axial:
-  Vector3d moments = G.CalcPrincipalMomentsOfInertia();
+  Vector3d moments = G_E.CalcPrincipalMomentsOfInertia();
   // The two smallest moments should match I_perp in this case.
   EXPECT_NEAR(moments(0), I_perp, kTolerance);
   EXPECT_NEAR(moments(1), I_perp, kTolerance);
@@ -282,22 +282,22 @@ GTEST_TEST(UnitInertia, ThinRod) {
       AngleAxisd(-M_PI_4, Vector3d::UnitX()).toRotationMatrix();
 
   // Unit inertia computed with StraightLine().
-  UnitInertia<double> G =
+  UnitInertia<double> G_E =
       UnitInertia<double>::StraightLine(I_rod, b_E);
 
   // The expected inertia is that of a cylinder of zero radius and height L with
   // its longitudinal axis aligned with b.
-  UnitInertia<double> G_expected =
-      UnitInertia<double>::SolidCylinder(0.0, L).ReExpress(R_EZ);
+  UnitInertia<double> G_Z = UnitInertia<double>::SolidCylinder(0.0, L);
+  UnitInertia<double> G_E_expected = G_Z.ReExpress(R_EZ);
 
   // Verify the computed values.
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  EXPECT_TRUE(G_E.CopyToFullMatrix3().isApprox(
+      G_E_expected.CopyToFullMatrix3(), kEpsilon));
 
   // Verify the result from ThinRod():
   UnitInertia<double> G_rod = UnitInertia<double>::ThinRod(L, b_E);
   EXPECT_TRUE(G_rod.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+      G_E_expected.CopyToFullMatrix3(), kEpsilon));
 }
 
 // Tests the methods:

--- a/drake/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -254,19 +254,22 @@ GTEST_TEST(UnitInertia, AxiallySymmetric) {
   EXPECT_NEAR(moments(2), I_axial, kTolerance);
 }
 
-// Unit test for the factory method UnitInertia::ThinRod().
+// Unit test for the factory methods:
+//   - UnitInertia::StraightLine().
+//   - UnitInertia::ThinRod().
 // This test creates the unit inertia for a thin rod or wire of length L with
 // its axis aligned with an arbitrary vector b. The unit inertia is computed
-// using two methods:
-// 1. Using the ThinRod() factory.
+// using three methods:
+// 1. Using the factory StraightLine().
 // 2. Using the SolidCylinder() factory to create the unit inertia of a zero
 //    radius cylinder aligned with the z axis which is then re-expressed to the
 //    same frame E as the vector b_E.
-// The two unit inertias are then compared to verify ThinRod().
+// 3. Using the factory ThinRod().
+// The three unit inertia objects are then compared to verify the results.
 GTEST_TEST(UnitInertia, ThinRod) {
   const double L = 1.5;  // Rod's length.
 
-  // Moment of inertia for an infinitesimally thin rod of lenght L.
+  // Moment of inertia for an infinitesimally thin rod of length L.
   const double I_rod = L * L / 12.0;
 
   // Rod's axis. A vector on the y-z plane, at -pi/4 from the z axis.
@@ -278,9 +281,9 @@ GTEST_TEST(UnitInertia, ThinRod) {
   Matrix3<double> R_EZ =
       AngleAxisd(-M_PI_4, Vector3d::UnitX()).toRotationMatrix();
 
-  // Unit inertia computed with ThinRod().
+  // Unit inertia computed with StraightLine().
   UnitInertia<double> G =
-      UnitInertia<double>::ThinRod(I_rod, b_E);
+      UnitInertia<double>::StraightLine(I_rod, b_E);
 
   // The expected inertia is that of a cylinder of zero radius and height L with
   // its longitudinal axis aligned with b.
@@ -289,6 +292,11 @@ GTEST_TEST(UnitInertia, ThinRod) {
 
   // Verify the computed values.
   EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
+      G_expected.CopyToFullMatrix3(), kEpsilon));
+
+  // Verify the result from ThinRod():
+  UnitInertia<double> G_rod = UnitInertia<double>::ThinRod(L, b_E);
+  EXPECT_TRUE(G_rod.CopyToFullMatrix3().isApprox(
       G_expected.CopyToFullMatrix3(), kEpsilon));
 }
 

--- a/drake/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/drake/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -203,6 +203,95 @@ GTEST_TEST(UnitInertia, SolidCylinderAboutEnd) {
       G_expected.CopyToFullMatrix3(), kEpsilon));
 }
 
+// Unit tests for the factory method UnitInertia::AxiallySymmetric().
+// This test creates the unit inertia for a cylinder of radius r and length L
+// with its longitudinal axis aligned with a vector b using two different
+// methods:
+// 1. Using the AxiallySymmetric() factory.
+// 2. Using the SolidCylinder() factory to create the unit inertia of a cylinder
+//    aligned with the z axis which is then re-expressed to the same frame E as
+//    the vector b_E.
+// The two unit inertias are then compared to verify AxiallySymmetric().
+GTEST_TEST(UnitInertia, AxiallySymmetric) {
+  const double kTolerance = 5 * kEpsilon;
+
+  // Cylinder's radius and length.
+  const double r = 2.5;
+  const double L = 1.5;
+  // Cylinder's moments about its longitudinal axis (I_axial) and about any
+  // other axis perpendicular to its longitudinal axis (I_perp).
+  const double I_perp = (3.0 * r * r + L * L) / 12.0;
+  const double I_axial = r * r / 2.0;
+
+  // Cylinder's axis. A vector on the y-z plane, at -pi/4 from the z axis.
+  // The vector doesn't need to be normalized.
+  const Vector3d b_E = Vector3d::UnitY() + Vector3d::UnitZ();
+
+  // Rotation of -pi/4 about the x axis, from a Z frame having its z axis
+  // aligned with the z-axis of the cylinder to the expressed-in frame E.
+  Matrix3<double> R_EZ =
+      AngleAxisd(-M_PI_4, Vector3d::UnitX()).toRotationMatrix();
+
+  // Unit inertia computed with AxiallySymmetric().
+  UnitInertia<double> G =
+      UnitInertia<double>::AxiallySymmetric(I_axial, I_perp, b_E);
+
+  // The expected inertia is that of a cylinder of radius r and height L with
+  // its longitudinal axis aligned with b.
+  UnitInertia<double> G_expected =
+      UnitInertia<double>::SolidCylinder(r, L).ReExpress(R_EZ);
+
+  // Verify the computed values.
+  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
+      G_expected.CopyToFullMatrix3(), kEpsilon));
+
+  // Verify the principal moments indeed are I_perp and I_axial:
+  Vector3d moments = G.CalcPrincipalMomentsOfInertia();
+  // The two smallest moments should match I_perp in this case.
+  EXPECT_NEAR(moments(0), I_perp, kTolerance);
+  EXPECT_NEAR(moments(1), I_perp, kTolerance);
+  // The largest moments should match I_axial in this case.
+  EXPECT_NEAR(moments(2), I_axial, kTolerance);
+}
+
+// Unit test for the factory method UnitInertia::ThinRod().
+// This test creates the unit inertia for a thin rod or wire of length L with
+// its axis aligned with an arbitrary vector b. The unit inertia is computed
+// using two methods:
+// 1. Using the ThinRod() factory.
+// 2. Using the SolidCylinder() factory to create the unit inertia of a zero
+//    radius cylinder aligned with the z axis which is then re-expressed to the
+//    same frame E as the vector b_E.
+// The two unit inertias are then compared to verify ThinRod().
+GTEST_TEST(UnitInertia, ThinRod) {
+  const double L = 1.5;  // Rod's length.
+
+  // Moment of inertia for an infinitesimally thin rod of lenght L.
+  const double I_rod = L * L / 12.0;
+
+  // Rod's axis. A vector on the y-z plane, at -pi/4 from the z axis.
+  // The vector doesn't need to be normalized.
+  const Vector3d b_E = Vector3d::UnitY() + Vector3d::UnitZ();
+
+  // Rotation of -pi/4 about the x axis, from a Z frame having its z-axis
+  // aligned with the rod to the expressed-in frame E.
+  Matrix3<double> R_EZ =
+      AngleAxisd(-M_PI_4, Vector3d::UnitX()).toRotationMatrix();
+
+  // Unit inertia computed with ThinRod().
+  UnitInertia<double> G =
+      UnitInertia<double>::ThinRod(I_rod, b_E);
+
+  // The expected inertia is that of a cylinder of zero radius and height L with
+  // its longitudinal axis aligned with b.
+  UnitInertia<double> G_expected =
+      UnitInertia<double>::SolidCylinder(0.0, L).ReExpress(R_EZ);
+
+  // Verify the computed values.
+  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
+      G_expected.CopyToFullMatrix3(), kEpsilon));
+}
+
 // Tests the methods:
 //  - ShiftFromCenterOfMassInPlace()
 //  - ShiftFromCenterOfMass()

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -309,8 +311,10 @@ class UnitInertia : public RotationalInertia<T> {
   /// This method aborts if:
   ///   - J is negative. J can be zero.
   ///   - K is negative. K can be zero.
-  ///   - J ≤ 2 * J, this corresponds to the triangle inequality, see
+  ///   - J ≤ 2 * K, this corresponds to the triangle inequality, see
   ///     CouldBePhysicallyValid().
+  ///   - `b_E` is the zero vector. That is if `‖b_E‖₂ < ε`, where ε is the
+  ///     machine epsilon.
   ///
   /// @note J is a principal moment of inertia with principal axis equal to b.
   /// K is a principal moment with multiplicity of two. Any two axes
@@ -322,7 +326,7 @@ class UnitInertia : public RotationalInertia<T> {
   ///   Unit inertia about any axis pependicular to b.
   /// @param[in] b_E
   ///   Vector defining the symmetry axis, expressed in a frame E. `b_E` can
-  ///   have a norm different from one, however it will be normalized before
+  ///   have a norm different from one; however, it will be normalized before
   ///   using it. Therefore its norm is ignored and only its direction is used.
   /// @retval G_Bcm_E
   ///   An axially symmetric unit inertia about body B's center of mass,
@@ -333,6 +337,7 @@ class UnitInertia : public RotationalInertia<T> {
     DRAKE_DEMAND(K >= 0.0);
     // The triangle inequalities for this case reduce to J <= 2*K:
     DRAKE_DEMAND(J <= 2.0 * K);
+    DRAKE_DEMAND(b_E.norm() < std::numeric_limits<double>::epsilon());
     // Normalize b_E before using it. Only direction matters:
     Vector3<T> bhat_E = b_E.normalized();
     Matrix3<T> G_matrix =
@@ -358,7 +363,7 @@ class UnitInertia : public RotationalInertia<T> {
   ///   Unit inertia about any axis pependicular to the line.
   /// @param[in] b_E
   ///   Vector defining the direction of the line, expressed in a frame E.
-  ///   `b_E` can have a norm different from one, its norm is ignored and only
+  ///   `b_E` can have a norm different from one. Its norm is ignored and only
   ///   its direction is needed.
   /// @retval G_Bcm_E
   ///   The unit inertia for a body B of unit mass uniformly distributed along a
@@ -379,7 +384,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @param[in] L The length of the rod. It must be positive.
   /// @param[in] b_E
   ///   Vector defining the axis of the rod, expressed in a frame E. `b_E` can
-  ///   have a norm different from one, its norm is ignored and only its
+  ///   have a norm different from one. Its norm is ignored and only its
   ///   direction is needed.
   /// @retval G_Bcm_E
   ///   The unit inertia of the rod B about its center of mass,

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -341,6 +341,15 @@ class UnitInertia : public RotationalInertia<T> {
                           G_matrix(0, 1), G_matrix(0, 2), G_matrix(1, 2));
   }
 
+  /// Computes the unit inertia for an object of unit-mass with its mass
+  /// uniformly distributed about a straight line with direction `b_E`.
+  /// unit moment of inertia K about its center for any axis perpendicular to
+  /// vector `b_E`.
+  static UnitInertia<T> ThinRod(const T& K, const Vector3<T>& b_E) {
+    DRAKE_DEMAND(K >= 0.0);
+    return AxiallySymmetric(0.0, K, b_E);
+  }
+
   /// Constructs a unit inertia with equal moments of inertia along its
   /// diagonal and with each product of inertia set to zero. This factory
   /// is useful for the unit inertia of a uniform-density sphere or cube.

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -390,7 +390,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @retval G_Bcm_E
   ///   The unit inertia of the rod B about its center of mass `Bcm`,
   ///   expressed in the same frame E as the input unit vector `b_E`.
-  static UnitInertia<T> ThinRod(const T& L, const Vector3 <T>& b_E) {
+  static UnitInertia<T> ThinRod(const T& L, const Vector3<T>& b_E) {
     DRAKE_DEMAND(L > 0.0);
     return StraightLine(L * L / 12.0, b_E);
   }

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -341,13 +341,52 @@ class UnitInertia : public RotationalInertia<T> {
                           G_matrix(0, 1), G_matrix(0, 2), G_matrix(1, 2));
   }
 
-  /// Computes the unit inertia for an object of unit-mass with its mass
-  /// uniformly distributed about a straight line with direction `b_E`.
-  /// unit moment of inertia K about its center for any axis perpendicular to
-  /// vector `b_E`.
-  static UnitInertia<T> ThinRod(const T& K, const Vector3<T>& b_E) {
-    DRAKE_DEMAND(K >= 0.0);
+  /// Computes the unit inertia for a body B of unit-mass uniformly distributed
+  /// along a straight, finite, line L with direction `b_E` and with moment of
+  /// inertia K about any axis perpendicular to this line. Since the mass of the
+  /// body is uniformly distribuited on this line L, its center of mass is
+  /// located right at the center.
+  /// As an example, consider the inertia of a thin for which its transversal
+  /// dimensions can be neglected, see ThinRod().
+  ///
+  /// This method aborts if K not positive.
+  ///
+  /// @note This is the particular case for an axially symmetric unit inertia
+  /// with zero moment about its axis.
+  ///
+  /// @param[in] K
+  ///   Unit inertia about any axis pependicular to the line.
+  /// @param[in] b_E
+  ///   Vector defining the direction of the line, expressed in a frame E.
+  ///   `b_E` can have a norm different from one, its norm is ignored and only
+  ///   its direction is needed.
+  /// @retval G_Bcm_E
+  ///   The unit inertia for a body B of unit mass uniformly distributed along a
+  ///   straigth line L, about its center of mass `Bcm` which is located at the
+  ///   center of the line, expressed in the same frame E as the input unit
+  ///   vector `b_E`.
+  static UnitInertia<T> StraightLine(const T& K, const Vector3 <T>& b_E) {
+    DRAKE_DEMAND(K > 0.0);
     return AxiallySymmetric(0.0, K, b_E);
+  }
+
+  /// Computes the unit inertia for a unit mass rod B of length L, about its
+  /// center of mass, with its mass uniformly distributed along a line parallel
+  /// to vector `b_E`.
+  ///
+  /// This method aborts if L not positive.
+  ///
+  /// @param[in] L The length of the rod. It must be positive.
+  /// @param[in] b_E
+  ///   Vector defining the axis of the rod, expressed in a frame E. `b_E` can
+  ///   have a norm different from one, its norm is ignored and only its
+  ///   direction is needed.
+  /// @retval G_Bcm_E
+  ///   The unit inertia of the rod B about its center of mass,
+  ///   expressed in the same frame E as the input unit vector `b_E`.
+  static UnitInertia<T> ThinRod(const T& L, const Vector3 <T>& b_E) {
+    DRAKE_DEMAND(L > 0.0);
+    return StraightLine(L * L / 12.0, b_E);
   }
 
   /// Constructs a unit inertia with equal moments of inertia along its

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -313,7 +313,7 @@ class UnitInertia : public RotationalInertia<T> {
   ///   - K is negative. K can be zero.
   ///   - J ≤ 2 * K, this corresponds to the triangle inequality, see
   ///     CouldBePhysicallyValid().
-  ///   - `b_E` is the zero vector. That is if `‖b_E‖₂ < ε`, where ε is the
+  ///   - `b_E` is the zero vector. That is if `‖b_E‖₂ ≤ ε`, where ε is the
   ///     machine epsilon.
   ///
   /// @note J is a principal moment of inertia with principal axis equal to b.
@@ -337,7 +337,7 @@ class UnitInertia : public RotationalInertia<T> {
     DRAKE_DEMAND(K >= 0.0);
     // The triangle inequalities for this case reduce to J <= 2*K:
     DRAKE_DEMAND(J <= 2.0 * K);
-    DRAKE_DEMAND(b_E.norm() < std::numeric_limits<double>::epsilon());
+    DRAKE_DEMAND(b_E.norm() > std::numeric_limits<double>::epsilon());
     // Normalize b_E before using it. Only direction matters:
     Vector3<T> bhat_E = b_E.normalized();
     Matrix3<T> G_matrix =

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -351,13 +351,13 @@ class UnitInertia : public RotationalInertia<T> {
   /// inertia K about any axis perpendicular to this line. Since the mass of the
   /// body is uniformly distributed on this line L, its center of mass is
   /// located right at the center.
-  /// As an example, consider the inertia of a thin for which its transversal
-  /// dimensions can be neglected, see ThinRod().
+  /// As an example, consider the inertia of a thin rod for which its
+  /// transversal dimensions can be neglected, see ThinRod().
   ///
-  /// This method aborts if K not positive.
+  /// This method aborts if K is not positive.
   ///
   /// @note This is the particular case for an axially symmetric unit inertia
-  /// with zero moment about its axis.
+  /// with zero moment about its axis, see AxiallySymmetric().
   ///
   /// @param[in] K
   ///   Unit inertia about any axis perpendicular to the line.
@@ -379,15 +379,16 @@ class UnitInertia : public RotationalInertia<T> {
   /// center of mass, with its mass uniformly distributed along a line parallel
   /// to vector `b_E`.
   ///
-  /// This method aborts if L not positive.
+  /// This method aborts if L is not positive.
   ///
-  /// @param[in] L The length of the rod. It must be positive.
+  /// @param[in] L
+  ///   The length of the rod. It must be positive.
   /// @param[in] b_E
   ///   Vector defining the axis of the rod, expressed in a frame E. `b_E` can
   ///   have a norm different from one. Its norm is ignored and only its
   ///   direction is needed.
   /// @retval G_Bcm_E
-  ///   The unit inertia of the rod B about its center of mass,
+  ///   The unit inertia of the rod B about its center of mass `Bcm`,
   ///   expressed in the same frame E as the input unit vector `b_E`.
   static UnitInertia<T> ThinRod(const T& L, const Vector3 <T>& b_E) {
     DRAKE_DEMAND(L > 0.0);

--- a/drake/multibody/multibody_tree/unit_inertia.h
+++ b/drake/multibody/multibody_tree/unit_inertia.h
@@ -27,7 +27,7 @@ namespace multibody {
 /// @note This class has no means to check at construction from user provided
 /// parameters whether it actually represents the unit inertia or gyration
 /// matrix of a unit-mass body. However, as previously noted, once a unit
-/// inertia is created, a number of operations are dissallowed to ensure the
+/// inertia is created, a number of operations are disallowed to ensure the
 /// unit-mass invariant.
 /// Also notice that once a unit inertia is created, it _is_ the unit inertia
 /// of _some_ body, perhaps with scaled geometry from the user's intention.
@@ -115,7 +115,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @retval G_BP_F The same unit inertia for body B about point P but now
   ///                re-expressed in frameF.
   /// @warning This method does not check whether the input matrix `R_FE`
-  /// represents a valid rotation or not. It is the resposibility of users to
+  /// represents a valid rotation or not. It is the responsibility of users to
   /// provide valid rotation matrices.
   UnitInertia<T> ReExpress(const Matrix3<T>& R_FE) const {
     return UnitInertia<T>(RotationalInertia<T>::ReExpress(R_FE));
@@ -297,7 +297,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// that the body's moment of inertia about all lines perpendicular to L are
   /// equal. Examples of bodies with an axially symmetric inertia include
   /// axisymmetric objects such as cylinders and cones. Other commonly occurring
-  /// geometries with this property are, for intance, propellers with 3+ evenly
+  /// geometries with this property are, for instance, propellers with 3+ evenly
   /// spaced blades.
   /// Given a unit vector b defining the symmetry line L, the moment of inertia
   /// J about this line L and the moment of inertia K about any line
@@ -323,7 +323,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// @param[in] J
   ///   Unit inertia about axis b.
   /// @param[in] K
-  ///   Unit inertia about any axis pependicular to b.
+  ///   Unit inertia about any axis perpendicular to b.
   /// @param[in] b_E
   ///   Vector defining the symmetry axis, expressed in a frame E. `b_E` can
   ///   have a norm different from one; however, it will be normalized before
@@ -349,7 +349,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// Computes the unit inertia for a body B of unit-mass uniformly distributed
   /// along a straight, finite, line L with direction `b_E` and with moment of
   /// inertia K about any axis perpendicular to this line. Since the mass of the
-  /// body is uniformly distribuited on this line L, its center of mass is
+  /// body is uniformly distributed on this line L, its center of mass is
   /// located right at the center.
   /// As an example, consider the inertia of a thin for which its transversal
   /// dimensions can be neglected, see ThinRod().
@@ -360,14 +360,14 @@ class UnitInertia : public RotationalInertia<T> {
   /// with zero moment about its axis.
   ///
   /// @param[in] K
-  ///   Unit inertia about any axis pependicular to the line.
+  ///   Unit inertia about any axis perpendicular to the line.
   /// @param[in] b_E
   ///   Vector defining the direction of the line, expressed in a frame E.
   ///   `b_E` can have a norm different from one. Its norm is ignored and only
   ///   its direction is needed.
   /// @retval G_Bcm_E
   ///   The unit inertia for a body B of unit mass uniformly distributed along a
-  ///   straigth line L, about its center of mass `Bcm` which is located at the
+  ///   straight line L, about its center of mass `Bcm` which is located at the
   ///   center of the line, expressed in the same frame E as the input unit
   ///   vector `b_E`.
   static UnitInertia<T> StraightLine(const T& K, const Vector3 <T>& b_E) {


### PR DESCRIPTION
We identified in [this review comment](https://reviewable.io/reviews/robotlocomotion/drake/6723#-KqxrSq4WbfTdNKK8N4g) that we'd like to have some additional unit inertia factories.
This PR introduces the `UnitInertia` factories:
 - `AxiallySymmetric()`
 - `StraightLine()`
 - `ThinRod()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6805)
<!-- Reviewable:end -->
