### PR TITLE
Fix removal of elements in BulletModel.

### DIFF
--- a/drake/multibody/collision/bullet_model.cc
+++ b/drake/multibody/collision/bullet_model.cc
@@ -391,6 +391,17 @@ void BulletModel::DoAddElement(const Element& element) {
   }
 }
 
+void BulletModel::DoRemoveElement(ElementId id) {
+  for (BulletCollisionWorldWrapper* world :
+       {&bullet_world_, &bullet_world_no_margin_}) {
+    const auto& itr = world->bt_collision_objects.find(id);
+    if (itr != world->bt_collision_objects.end()) {
+      world->bt_collision_world->removeCollisionObject(itr->second.get());
+      world->bt_collision_objects.erase(itr);
+    }
+  }
+}
+
 bool BulletModel::CollidingPointsCheckOnly(
     const std::vector<Vector3d>& input_points, double collision_threshold) {
   // Create sphere geometry

--- a/drake/multibody/collision/bullet_model.h
+++ b/drake/multibody/collision/bullet_model.h
@@ -65,6 +65,8 @@ class BulletModel : public Model {
 
   void DoAddElement(const Element& element) override;
 
+  void DoRemoveElement(ElementId id) override;
+
   bool UpdateElementWorldTransform(
       ElementId, const Eigen::Isometry3d& T_local_to_world) override;
 

--- a/drake/multibody/collision/model.cc
+++ b/drake/multibody/collision/model.cc
@@ -29,6 +29,7 @@ Element* Model::AddElement(std::unique_ptr<Element> element) {
 }
 
 bool Model::RemoveElement(ElementId id) {
+  DoRemoveElement(id);
   return elements.erase(id) > 0;
 }
 
@@ -86,6 +87,8 @@ bool Model::TransformCollisionFrame(
 }
 
 void Model::DoAddElement(const Element&) {}
+
+void Model::DoRemoveElement(ElementId) {}
 
 /**
  * A toString for the collision model.

--- a/drake/multibody/collision/model.h
+++ b/drake/multibody/collision/model.h
@@ -43,6 +43,12 @@ class Model {
    error configuring collision  model, etc.) **/
   Element* AddElement(std::unique_ptr<Element> element);
 
+  /** Removes a collision element from this model.
+
+   @param id The id of the element that will be removed.
+
+   @return True if the element is successfully removed, false if the model does
+   not contain an element with the given id. **/
   bool RemoveElement(ElementId id);
 
   /** Gets a read-only pointer to a collision element in this model.
@@ -256,6 +262,14 @@ class Model {
 
    @throws std::runtime_error If there was a problem processing the element. **/
   virtual void DoAddElement(const Element& element);
+
+  /** Allows sub-classes to do additional processing when elements are
+   removed from the collision model. This is called by Model::RemoveElement()
+   prior to removing id from elements. The derived class should not do this
+   removal.
+
+   @param id The id of the element that will be removed. **/
+  virtual void DoRemoveElement(ElementId id);
 
   // Protected member variables are forbidden by the style guide.
   // Please do not add new references to this member.  Instead, use


### PR DESCRIPTION
Resolves #6803. Previously, the corresponding `btCollisionObject`s were
not removed from the Bullet collision world. This led to segfaults in
the collision callback, as those `btCollisionObject`s held pointers to the
(now deleted) `drake::collision::Element` objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6812)
<!-- Reviewable:end -->
