### PR TITLE
Add shape specification to geometry

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -94,7 +94,7 @@ drake_cc_library(
 
 drake_cc_library(
     name = "shape_specification",
-    srcs = [],
+    srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
     deps = ["//drake/common"],
 )

--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -29,7 +29,9 @@ drake_cc_library(
     srcs = ["geometry_instance.cc"],
     hdrs = ["geometry_instance.h"],
     deps = [
+        ":shape_specification",
         "//drake/common",
+        "//drake/common:copyable_unique_ptr",
     ],
 )
 
@@ -87,6 +89,13 @@ drake_cc_library(
     name = "identifier",
     srcs = [],
     hdrs = ["identifier.h"],
+    deps = ["//drake/common"],
+)
+
+drake_cc_library(
+    name = "shape_specification",
+    srcs = [],
+    hdrs = ["shape_specification.h"],
     deps = ["//drake/common"],
 )
 

--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -120,4 +120,13 @@ drake_cc_googletest(
     deps = [":identifier"],
 )
 
+drake_cc_googletest(
+    name = "shape_specification_test",
+    deps = [
+        ":shape_specification",
+        "//drake/common:eigen_matrix_compare",
+        "//drake/common:is_dynamic_castable",
+    ],
+)
+
 add_lint_tests()

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -25,10 +25,7 @@ namespace geometry {
  instance id defined by the RigidBodyTree and used again in automotive to
  serve as unique car identifiers.
 
- @see GeometryWorld
-
- @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
-template <typename T>
+ @see GeometryWorld */
 class GeometryFrame {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryFrame)

--- a/drake/geometry/geometry_instance.cc
+++ b/drake/geometry/geometry_instance.cc
@@ -5,13 +5,9 @@
 namespace drake {
 namespace geometry {
 
-template <typename T>
-GeometryInstance<T>::GeometryInstance(const Isometry3<T>& X_PG,
-                                      std::unique_ptr<Shape> shape)
-    : X_FG_(X_PG), shape_(std::move(shape)) {}
-
-// Explicitly instantiates on the most common scalar types.
-template class GeometryInstance<double>;
+GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
+                                   std::unique_ptr<Shape> shape)
+    : X_PG_(X_PG), shape_(std::move(shape)) {}
 
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_instance.cc
+++ b/drake/geometry/geometry_instance.cc
@@ -1,7 +1,14 @@
 #include "drake/geometry/geometry_instance.h"
 
+#include <utility>
+
 namespace drake {
 namespace geometry {
+
+template <typename T>
+GeometryInstance<T>::GeometryInstance(const Isometry3<T>& X_PG,
+                                      std::unique_ptr<Shape> shape)
+    : X_FG_(X_PG), shape_(std::move(shape)) {}
 
 // Explicitly instantiates on the most common scalar types.
 template class GeometryInstance<double>;

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <memory>
+
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
@@ -23,7 +28,23 @@ class GeometryInstance {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryInstance)
 
-  GeometryInstance() = default;
+  /** Constructor.
+   @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
+   @param shape  The underlying shape for this geometry instance. */
+  GeometryInstance(const Isometry3<T>& X_PG, std::unique_ptr<Shape> shape);
+
+  const Isometry3<T>& get_pose() const { return X_FG_; }
+  void set_pose(const Isometry3<T>& X_PG) { X_FG_ = X_PG; }
+
+  const Shape& get_shape() const { return *shape_; }
+
+ private:
+  // The pose of the geometry relative to the source frame it ultimately hangs
+  // from.
+  Isometry3<T> X_FG_;
+
+  // The shape associated with this instance.
+  copyable_unique_ptr<Shape> shape_;
 };
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -12,18 +12,9 @@ namespace geometry {
 
 /**
  A geometry instance combines a geometry definition (i.e., a shape of some
- sort), a pose (relative to a parent frame), material information, and an
- opaque collection of metadata.
-
- @tparam T  The underlying scalar type. Must be a valid Eigen scalar.
-
- Instantiated templates for the following kinds of T's are provided:
-    - double
-
- They are already available to link against in the containing library.
- No other values for T are currently supported. */
-// TODO(SeanCurtis-TRI): Add support for AutoDiffXd.
-template <typename T>
+ sort), a pose (relative to a parent "frame" P), material information, and an
+ opaque collection of metadata. The parent frame can be a registered frame or
+ another registered geometry. */
 class GeometryInstance {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryInstance)
@@ -31,17 +22,16 @@ class GeometryInstance {
   /** Constructor.
    @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
    @param shape  The underlying shape for this geometry instance. */
-  GeometryInstance(const Isometry3<T>& X_PG, std::unique_ptr<Shape> shape);
+  GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape);
 
-  const Isometry3<T>& get_pose() const { return X_FG_; }
-  void set_pose(const Isometry3<T>& X_PG) { X_FG_ = X_PG; }
+  const Isometry3<double>& get_pose() const { return X_PG_; }
+  void set_pose(const Isometry3<double>& X_PG) { X_PG_ = X_PG; }
 
   const Shape& get_shape() const { return *shape_; }
 
  private:
-  // The pose of the geometry relative to the source frame it ultimately hangs
-  // from.
-  Isometry3<T> X_FG_;
+  // The pose of the geometry relative to the parent frame it hangs on.
+  Isometry3<double> X_PG_;
 
   // The shape associated with this instance.
   copyable_unique_ptr<Shape> shape_;

--- a/drake/geometry/geometry_state.cc
+++ b/drake/geometry/geometry_state.cc
@@ -130,13 +130,13 @@ SourceId GeometryState<T>::RegisterNewSource(const std::string& name) {
 
 template <typename T>
 FrameId GeometryState<T>::RegisterFrame(SourceId source_id,
-                                        const GeometryFrame<T>& frame) {
+                                        const GeometryFrame& frame) {
   return RegisterFrame(source_id, InternalFrame::get_world_frame_id(), frame);
 }
 
 template <typename T>
 FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
-                                        const GeometryFrame<T>&) {
+                                        const GeometryFrame&) {
   using std::to_string;
   FrameId frame_id = FrameId::get_new_id();
 
@@ -160,7 +160,7 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
 template <typename T>
 GeometryId GeometryState<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
-    std::unique_ptr<GeometryInstance<T>> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) {
   using std::to_string;
   if (geometry == nullptr) {
     throw std::logic_error(
@@ -191,7 +191,7 @@ GeometryId GeometryState<T>::RegisterGeometry(
 template <typename T>
 GeometryId GeometryState<T>::RegisterGeometryWithParent(
     SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance<T>> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) {
   // There are three error conditions in the doxygen:.
   //    1. geometry == nullptr,
   //    2. source_id is not a registered source, and

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -15,9 +15,9 @@
 namespace drake {
 namespace geometry {
 
-template <typename T> class GeometryFrame;
+class GeometryFrame;
 
-template <typename T> class GeometryInstance;
+class GeometryInstance;
 
 template <typename T> class GeometrySystem;
 
@@ -95,7 +95,7 @@ class GeometryState {
    @returns  A newly allocated frame id.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
                              source. */
-  FrameId RegisterFrame(SourceId source_id, const GeometryFrame<T>& frame);
+  FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame for the given source as a child of a previously
    registered frame. The id of the new frame is returned.
@@ -108,7 +108,7 @@ class GeometryState {
                              2. If the `parent_id` does _not_ map to a known
                              frame or does not belong to the source. */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
-                        const GeometryFrame<T>& frame);
+                        const GeometryFrame& frame);
 
   /** Registers a GeometryInstance with the state. The state takes ownership of
    the geometry and associates it with the given frame and source. Returns the
@@ -124,7 +124,7 @@ class GeometryState {
                              2. the `frame_id` doesn't belong to the source, or
                              3. The `geometry` is equal to `nullptr`. */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
-                              std::unique_ptr<GeometryInstance<T>> geometry);
+                              std::unique_ptr<GeometryInstance> geometry);
 
   /** Registers a GeometryInstance with the state. Rather than hanging directly
    from a _frame_, the instance hangs on another geometry instance. The input
@@ -146,7 +146,7 @@ class GeometryState {
                             3. the `geometry` is equal to `nullptr`. */
   GeometryId RegisterGeometryWithParent(
       SourceId source_id, GeometryId geometry_id,
-      std::unique_ptr<GeometryInstance<T>> geometry);
+      std::unique_ptr<GeometryInstance> geometry);
 
   /** Removes all frames and geometry registered from the identified source.
    The source remains registered and further frames and geometry can be

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -68,14 +68,14 @@ GeometrySystem<T>::get_source_pose_port(SourceId id) {
 
 template <typename T>
 FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id,
-                                         const GeometryFrame<T>& frame) {
+                                         const GeometryFrame& frame) {
   THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, frame);
 }
 
 template <typename T>
 FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
-                                         const GeometryFrame<T>& frame) {
+                                         const GeometryFrame& frame) {
   THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, parent_id, frame);
 }
@@ -83,7 +83,7 @@ FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
 template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
-    std::unique_ptr<GeometryInstance<T>> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) {
   THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometry(source_id, frame_id,
                                           std::move(geometry));
@@ -92,7 +92,7 @@ GeometryId GeometrySystem<T>::RegisterGeometry(
 template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
-    std::unique_ptr<GeometryInstance<T>> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) {
   THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
                                                     std::move(geometry));
@@ -101,7 +101,7 @@ GeometryId GeometrySystem<T>::RegisterGeometry(
 template <typename T>
 GeometryId GeometrySystem<T>::RegisterAnchoredGeometry(
     SourceId source_id,
-    std::unique_ptr<GeometryInstance<T>> geometry) {
+    std::unique_ptr<GeometryInstance> geometry) {
   // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
   // and use all parameters.
   unused(source_id, geometry);

--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -14,7 +14,7 @@
 namespace drake {
 namespace geometry {
 
-template <typename T> class GeometryInstance;
+class GeometryInstance;
 
 /** GeometrySystem serves as a system-level wrapper for GeometryWorld. It serves
  as the nexus for all geometry (and geometry-based operations) in a Diagram.
@@ -281,7 +281,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
    @returns  A newly allocated frame id.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
                              source or if a context has been allocated. */
-  FrameId RegisterFrame(SourceId source_id, const GeometryFrame<T>& frame);
+  FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame F for this source. This hangs frame F on another
    previously registered frame P (indicated by `parent_id`). The pose of the new
@@ -297,7 +297,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
                              frame or does not belong to the source, or
                              3. a context has been allocated. */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
-                        const GeometryFrame<T>& frame);
+                        const GeometryFrame& frame);
 
   /** Registers a new geometry G for this source. This hangs geometry G on a
    previously registered frame F (indicated by `frame_id`). The pose of the
@@ -314,7 +314,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
                              4. a context has been allocated. */
   GeometryId RegisterGeometry(SourceId source_id,
                               FrameId frame_id,
-                              std::unique_ptr<GeometryInstance<T>> geometry);
+                              std::unique_ptr<GeometryInstance> geometry);
 
   /** Registers a new geometry G for this source. This hangs geometry G on a
    previously registered geometry P (indicated by `geometry_id`). The pose of
@@ -333,7 +333,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
                             4. a context has been allocated. */
   GeometryId RegisterGeometry(SourceId source_id,
                               GeometryId geometry_id,
-                              std::unique_ptr<GeometryInstance<T>> geometry);
+                              std::unique_ptr<GeometryInstance> geometry);
 
   /** Registers a new _anchored_ geometry G for this source. This hangs geometry
    G from the world frame (W). Its pose is defined in that frame (i.e., `X_WG`).
@@ -345,7 +345,7 @@ class GeometrySystem : public systems::LeafSystem<T> {
                              source or a context has been allocated. */
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id,
-      std::unique_ptr<GeometryInstance<T>> geometry);
+      std::unique_ptr<GeometryInstance> geometry);
 
   /** Clears of all the registered frames and geometries from this source, but
    the source is still registered, allowing future registration of frames

--- a/drake/geometry/shape_specification.cc
+++ b/drake/geometry/shape_specification.cc
@@ -1,0 +1,58 @@
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+
+Shape::~Shape() {}
+
+void Shape::Reify(ShapeReifier* reifier) const {
+  reifier_(reifier);
+}
+
+std::unique_ptr<Shape> Shape::Clone() const {
+  return cloner_();
+}
+
+Sphere::Sphere(double radius) :
+    Shape(static_cast<Sphere*>(nullptr)), radius_(radius) {}
+
+HalfSpace::HalfSpace() : Shape(static_cast<HalfSpace*>(nullptr)) {}
+
+Isometry3<double> HalfSpace::MakePose(const Vector3<double>& normal_F,
+                                      const Vector3<double>& r_FP) {
+  double norm = normal_F.norm();
+  // Note: this value of epsilon is somewhat arbitrary. It's merely a minor
+  // fence over which ridiculous vectors will trip.
+  if (norm < 1e-10)
+    throw std::logic_error("Can't make pose from a zero vector.");
+
+  // First create basis.
+  // Projects the normal into the first quadrant in order to identify the
+  // *smallest* component of the normal.
+  const Vector3<double> u(normal_F.cwiseAbs());
+  int minAxis;
+  u.minCoeff(&minAxis);
+  // The axis corresponding to the smallest component of the normal will be
+  // *most* perpendicular.
+  Vector3<double> perpAxis;
+  perpAxis << (minAxis == 0 ? 1 : 0), (minAxis == 1 ? 1 : 0),
+      (minAxis == 2 ? 1 : 0);
+  // Now define x-, y-, and z-axes. The z-axis lies in the normal direction.
+  Vector3<double> z_axis_W = normal_F / norm;
+  Vector3<double> x_axis_W = normal_F.cross(perpAxis).normalized();
+  Vector3<double> y_axis_W = z_axis_W.cross(x_axis_W);
+  // Transformation from world frame to local frame.
+  Matrix3<double> R_WL;
+  R_WL.col(0) = x_axis_W;
+  R_WL.col(1) = y_axis_W;
+  R_WL.col(2) = z_axis_W;
+
+  // Construct pose from basis and point.
+  Isometry3<double> X_FC = Isometry3<double>::Identity();
+  X_FC.linear() = R_WL;
+  // Find the *minimum* translation to make sure the point lies on the plane.
+  X_FC.translation() = z_axis_W.dot(r_FP) * z_axis_W;
+  return X_FC;
+}
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/shape_specification.cc
+++ b/drake/geometry/shape_specification.cc
@@ -5,9 +5,9 @@ namespace geometry {
 
 Shape::~Shape() {}
 
-void Shape::Reify(ShapeReifier* reifier) const { reifier_(reifier); }
+void Shape::Reify(ShapeReifier* reifier) const { reifier_(*this, reifier); }
 
-std::unique_ptr<Shape> Shape::Clone() const { return cloner_(); }
+std::unique_ptr<Shape> Shape::Clone() const { return cloner_(*this); }
 
 Sphere::Sphere(double radius)
     : Shape(static_cast<Sphere*>(nullptr)), radius_(radius) {}

--- a/drake/geometry/shape_specification.cc
+++ b/drake/geometry/shape_specification.cc
@@ -5,16 +5,12 @@ namespace geometry {
 
 Shape::~Shape() {}
 
-void Shape::Reify(ShapeReifier* reifier) const {
-  reifier_(reifier);
-}
+void Shape::Reify(ShapeReifier* reifier) const { reifier_(reifier); }
 
-std::unique_ptr<Shape> Shape::Clone() const {
-  return cloner_();
-}
+std::unique_ptr<Shape> Shape::Clone() const { return cloner_(); }
 
-Sphere::Sphere(double radius) :
-    Shape(static_cast<Sphere*>(nullptr)), radius_(radius) {}
+Sphere::Sphere(double radius)
+    : Shape(static_cast<Sphere*>(nullptr)), radius_(radius) {}
 
 HalfSpace::HalfSpace() : Shape(static_cast<HalfSpace*>(nullptr)) {}
 

--- a/drake/geometry/shape_specification.h
+++ b/drake/geometry/shape_specification.h
@@ -140,6 +140,7 @@ Shape::Shape(S* shape) {
     return std::unique_ptr<Shape>(new S(derived_shape));
   };
   reifier_ = [](const Shape& shape_arg, ShapeReifier* reifier) {
+    DRAKE_DEMAND(typeid(shape_arg) == typeid(S));
     const S& derived_shape = static_cast<const S&>(shape_arg);
     reifier->ImplementGeometry(derived_shape);
   };

--- a/drake/geometry/shape_specification.h
+++ b/drake/geometry/shape_specification.h
@@ -98,9 +98,9 @@ class HalfSpace : public ReifiableShape<HalfSpace> {
 
   HalfSpace() : ReifiableShape() {}
 
-  /** Given a plane `normal` and a point `X_FP` on the plane, both expressed in
-   frame F, creates the transform `X_FC` from the half-space's canonical space
-   to frame F.
+  /** Given a plane `normal_F` and a point on the plane `X_FP`, both expressed
+   in frame F, creates the transform `X_FC` from the half-space's canonical
+   space to frame F.
    @param normal_F  A vector perpendicular to the half-space's plane boundary
                     expressed in frame F. It must be a non-zero vector but need
                     not be unit length.
@@ -134,7 +134,7 @@ class HalfSpace : public ReifiableShape<HalfSpace> {
     // Now define x-, y-, and z-axes. The z-axis lies in the normal direction.
     Vector3<T> z_axis_W = normal_F / norm;
     Vector3<T> x_axis_W = normal_F.cross(perpAxis).normalized();
-    Vector3<T> y_axis_W = normal_F.cross(x_axis_W);
+    Vector3<T> y_axis_W = z_axis_W.cross(x_axis_W);
     // Transformation from world frame to local frame.
     Matrix3<T> R_WL;
     R_WL.col(0) = x_axis_W;
@@ -144,7 +144,8 @@ class HalfSpace : public ReifiableShape<HalfSpace> {
     // Construct pose from basis and point.
     Isometry3<T> X_FC = Isometry3<T>::Identity();
     X_FC.linear() = R_WL;
-    X_FC.translation() = r_FP;
+    // Find the *minimum* translation to make sure the point lies on the plane.
+    X_FC.translation() = z_axis_W.dot(r_FP) * z_axis_W;
     return X_FC;
   }
 };

--- a/drake/geometry/shape_specification.h
+++ b/drake/geometry/shape_specification.h
@@ -120,8 +120,8 @@ class HalfSpace final : public Shape {
 class ShapeReifier {
  public:
   virtual ~ShapeReifier() {}
-  virtual void implementGeometry(const Sphere& sphere) = 0;
-  virtual void implementGeometry(const HalfSpace& half_space) = 0;
+  virtual void ImplementGeometry(const Sphere& sphere) = 0;
+  virtual void ImplementGeometry(const HalfSpace& half_space) = 0;
 };
 
 template <typename S>
@@ -133,7 +133,7 @@ Shape::Shape(S*) {
     return std::unique_ptr<Shape>(new S(*static_cast<const S*>(this)));
   };
   reifier_ = [this](ShapeReifier* reifier) {
-    reifier->implementGeometry(*static_cast<const S*>(this));
+    reifier->ImplementGeometry(*static_cast<const S*>(this));
   };
 }
 

--- a/drake/geometry/shape_specification.h
+++ b/drake/geometry/shape_specification.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+/** @file
+ Provides the classes through which geometric shapes are introduced into
+ GeometryWorld. This includes the specific classes which specify shapes as well
+ as an interface for _processing_ those specifications.
+ */
+
+namespace drake {
+namespace geometry {
+
+class ShapeReifier;
+
+/** The base interface for all shape specifications. Shapes have two basic
+ requirements:
+   - hey must be cloneable, and
+   - they must invoke the correct method for themselves on a ShapeReifier. */
+class Shape {
+ public:
+  virtual ~Shape() {}
+
+  /** Causes this description to be reified in the given `reifier`. Each
+   concrete subclass must invoke the single, matching method on the reifier. */
+  virtual void Reify(ShapeReifier* reifier) const = 0;
+
+  /** Creates a unique copy of this shape. Invokes the protected DoClone(). */
+  std::unique_ptr<Shape> Clone() const {
+    return std::unique_ptr<Shape>(DoClone());
+  }
+
+ protected:
+  /** Performs the work of cloning a concrete shape. */
+  virtual Shape* DoClone() const = 0;
+};
+
+/** Utility class for making sure that concrete Shapes satisfy the requirements
+ for shapes (cloneable and reifiable).
+
+ Concrete shape classes should be derived from this class (in a CRTP way). They
+ must also define a copy constructor. By doing so, concrete classes do not have
+ to explicitly implement the cloning mechanism _or_ the reification mechanism.
+
+ @internal Technically, this class could be rolled into Shape. But we want to
+ be able to talk about Shapes without a hint of templating. So, this serves as
+ an intermediate class to gain the CRTP benefit without cluttering up the
+ public API.
+
+ @tparam S The recursively-defined concrete Shape class.
+ */
+template <typename S>
+class ReifiableShape : public Shape {
+ public:
+  ReifiableShape() : Shape() {
+    // This enforces the existence of a copy constructor and the recursive
+    // nature of the sub-classes.
+    static_assert(std::is_base_of<Shape, S>::value &&
+                      std::is_copy_constructible<S>::value,
+                  "ReifiableShape should only be instantiated recursively on "
+                  "concrete derivations of the Shape class.");
+  }
+
+  void Reify(ShapeReifier* reifier) const override;
+
+ protected:
+  Shape* DoClone() const override {
+    return new S(*static_cast<const S*>(this));
+  }
+};
+
+/** Definition of sphere. It is centered in its canonical frame with the
+ given radius. */
+class Sphere : public ReifiableShape<Sphere> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Sphere)
+
+  explicit Sphere(double radius) : radius_(radius) {}
+
+  double get_radius() const { return radius_; }
+
+ private:
+  double radius_{};
+};
+
+/** Definition of a half space. In its canonical frame, the plan defining the
+ boundary of the half space is that frame's z = 0 plane. By implication, the
+ plane's normal points in the +z direction and the origin lies on the plane.
+ Other shapes are considered to be penetrating the half space if there exists
+ a point on the test shape that lies on the side of the plane opposite the
+ normal. */
+class HalfSpace : public ReifiableShape<HalfSpace> {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(HalfSpace)
+
+  HalfSpace() : ReifiableShape() {}
+
+  /** Given a plane `normal` and a point `X_FP` on the plane, both expressed in
+   frame F, creates the transform `X_FC` from the half-space's canonical space
+   to frame F.
+   @param normal   A vector perpendicular to the half-space's plane boundary.
+                   Must be a non-zero vector but need not be unit length.
+   @param X_FP     A point lying on the half-space's plane boundary.
+   @retval `X_FC`  The pose of the canonical half-space in frame F.
+   @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
+                            ‖normal‖₂ < ε).
+
+   @tparam T       The underlying scalar type. Must be a valid Eigen scalar. */
+  template <typename T>
+  static Isometry3<T> MakePose(const Vector3<T>& normal,
+                               const Vector3<T>& X_FP) {
+    T norm = normal.norm();
+    // Note: this value of epsilon is somewhat arbitrary. It's merely a minor
+    // fence over which ridiculous vectors will trip.
+    if (norm < 1e-10)
+      throw std::logic_error("Can't make pose from a zero vector.");
+
+    // First create basis.
+    // Projects the normal into the first quadrant in order to identify the
+    // *smallest* component of the normal.
+    const Vector3<T> u(normal.cwiseAbs());
+    int minAxis;
+    u.minCoeff(&minAxis);
+    // The axis corresponding to the smallest component of the normal will be
+    // *most* perpendicular.
+    Vector3<T> perpAxis;
+    perpAxis << (minAxis == 0 ? 1 : 0), (minAxis == 1 ? 1 : 0),
+        (minAxis == 2 ? 1 : 0);
+    // Now define x-, y-, and z-axes. The z-axis lies in the normal direction.
+    Vector3<T> z_axis_W = normal / norm;
+    Vector3<T> x_axis_W = normal.cross(perpAxis).normalized();
+    Vector3<T> y_axis_W = normal.cross(x_axis_W);
+    // Transformation from world frame to local frame.
+    Matrix3<T> R_WL;
+    R_WL.col(0) = x_axis_W;
+    R_WL.col(1) = y_axis_W;
+    R_WL.col(2) = z_axis_W;
+
+    // Construct pose from basis and point.
+    Isometry3<T> X_FC = Isometry3<T>::Identity();
+    X_FC.linear() = R_WL;
+    X_FC.translation() = X_FP;
+    return X_FC;
+  }
+};
+
+/** The interface for converting shape descriptions to real shapes. Any entity
+ that consumes shape descriptions _must_ implement this interface.
+
+ This class explicitly enumerates all concrete shapes in its methods. The
+ addition of a new concrete shape class requires the addition of a new
+ corresponding method. There should *never* be a method that accepts the Shape
+ base class as an argument; it should _only_ operate on concrete derived
+ classes. */
+class ShapeReifier {
+ public:
+  virtual ~ShapeReifier() {}
+  virtual void implementGeometry(const Sphere& sphere) = 0;
+  virtual void implementGeometry(const HalfSpace& half_space) = 0;
+};
+
+template <typename S>
+void ReifiableShape<S>::Reify(ShapeReifier* reifier) const {
+  reifier->implementGeometry(*static_cast<const S*>(this));
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -84,10 +84,10 @@ class GeometrySystemTest : public ::testing::Test {
     return query_handle_;
   }
 
-  static std::unique_ptr<GeometryInstance<double>> make_sphere_instance(
+  static std::unique_ptr<GeometryInstance> make_sphere_instance(
       double radius = 1.0) {
-    return make_unique<GeometryInstance<double>>(Isometry3<double>::Identity(),
-                                                 make_unique<Sphere>(radius));
+    return make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+                                         make_unique<Sphere>(radius));
   }
 
   GeometrySystem<double> system_;
@@ -185,7 +185,7 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
   // Attach frame to world.
   EXPECT_ERROR_MESSAGE(
       system_.RegisterFrame(
-          id, GeometryFrame<double>()),
+          id, GeometryFrame()),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");
@@ -194,7 +194,7 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
   EXPECT_ERROR_MESSAGE(
       system_.RegisterFrame(
           id, FrameId::get_new_id(),
-          GeometryFrame<double>()),
+          GeometryFrame()),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -86,7 +86,8 @@ class GeometrySystemTest : public ::testing::Test {
 
   static std::unique_ptr<GeometryInstance<double>> make_sphere_instance(
       double radius = 1.0) {
-    return make_unique<GeometryInstance<double>>();
+    return make_unique<GeometryInstance<double>>(Isometry3<double>::Identity(),
+                                                 make_unique<Sphere>(radius));
   }
 
   GeometrySystem<double> system_;

--- a/drake/geometry/test/shape_specification_test.cc
+++ b/drake/geometry/test/shape_specification_test.cc
@@ -1,0 +1,201 @@
+#include "drake/geometry/shape_specification.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/test/is_dynamic_castable.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+// Confirm correct interactions with the Reifier.
+
+class ReifierTest : public ShapeReifier, public ::testing::Test {
+ public:
+  void implementGeometry(const Sphere& sphere) override {
+    sphere_made_ = true;
+  }
+  void implementGeometry(const HalfSpace& half_space) override {
+    half_space_made_ = true;
+  }
+ protected:
+  bool sphere_made_{false};
+  bool half_space_made_{false};
+};
+
+// This confirms that the shapes invoke the correct Reify method.
+TEST_F(ReifierTest, SphereReification) {
+  implementGeometry(Sphere(1.0));
+  ASSERT_TRUE(sphere_made_);
+  ASSERT_FALSE(half_space_made_);
+  // NOTE: Because of the CRTP nature of this code, as long as new shape
+  // specifications inherit from ReifiableShape, this test does *not* need to
+  // be extended. The template functionality has already been sufficiently
+  // tested.
+}
+
+// This confirms that the shapes invoke the correct Reify method.
+TEST_F(ReifierTest, HalfSpaceReification) {
+  implementGeometry(HalfSpace());
+  ASSERT_FALSE(sphere_made_);
+  ASSERT_TRUE(half_space_made_);
+  // NOTE: Because of the CRTP nature of this code, as long as new shape
+  // specifications inherit from ReifiableShape, this test does *not* need to
+  // be extended. The template functionality has already been sufficiently
+  // tested.
+}
+
+
+// Confirms that the ReifiableShape properly clones the right types.
+GTEST_TEST(ShapeSpecificationTest, CloningShapes) {
+  Sphere s{1.0};
+  ASSERT_TRUE(is_dynamic_castable<Sphere>(s.Clone().get()));
+  HalfSpace h;
+  ASSERT_TRUE(is_dynamic_castable<HalfSpace>(h.Clone().get()));
+}
+
+
+// Given the pose of a plane and its expected translation and z-axis, confirms
+// that the pose conforms to expectations. Also confirms that the rotational
+// component is orthonormal.
+::testing::AssertionResult ValidatePlanePose(
+    const Eigen::Isometry3d& pose, const Vector3<double>& expected_z,
+    const Vector3<double>& expected_translation, double tolerance = 1e-14) {
+  using std::abs;
+
+  // Test expected z-axis value.
+  const auto& z_axis = pose.linear().col(2);
+  if (!CompareMatrices(z_axis, expected_z, tolerance,
+                       MatrixCompareType::absolute)) {
+    return ::testing::AssertionFailure()
+        << "pose =\n"
+        << pose.matrix() << "\nExpected z-axis " << expected_z.transpose()
+        << " does not match pose's z-axis " << z_axis.transpose();
+  }
+
+  // Test expected translation.
+  if (!CompareMatrices(pose.translation(), expected_translation, tolerance,
+                       MatrixCompareType::absolute)) {
+    return ::testing::AssertionFailure()
+        << "pose =\n"
+        << pose.matrix() << "\nExpected translation "
+        << expected_translation.transpose()
+        << " does not match pose's translation "
+        << pose.translation().transpose();
+  }
+
+  // Test unit-length rotation.
+  char axis_labels[] = {'x', 'y', 'z'};
+  for (int i = 0; i < 3; ++i) {
+    if (abs(pose.linear().col(i).norm() - 1) > tolerance) {
+      return ::testing::AssertionFailure()
+          << "pose =\n"
+          << pose.matrix() << "\ndoes not have unit length " << axis_labels[i]
+          << "-axis " << pose.linear().col(i).transpose();
+    }
+  }
+
+  // Test orthogonality.
+  for (int i = 0; i < 2; ++i) {
+    for (int j = i + 1; j < 3; ++j) {
+      double dot_product = pose.linear().col(i).dot(pose.linear().col(j));
+      if (abs(dot_product) > tolerance) {
+        return ::testing::AssertionFailure()
+            << "For pose =\n"
+            << pose.matrix() << "\nThe " << axis_labels[i] << "-axis and "
+            << axis_labels[j] << "-axis are not orthogonal";
+      }
+    }
+  }
+  return ::testing::AssertionSuccess()
+      << "pose =\n"
+      << pose.matrix() << "\nhas expected z-axis = " << expected_z.transpose()
+      << "\nand expected translation = " << expected_translation.transpose();
+}
+
+// Confirms that the pose computed by HalfSpace::MakePose is consistent with
+// the normal and point provided.
+GTEST_TEST(HalfSpaceTest, MakePose) {
+  Vector3<double> n;
+  Vector3<double> p;
+
+  // All of this assumes that, in the canonical space, the half space's outward-
+  // pointing normal points in the +z axis direction.
+
+  // Case: n(0, 0, 1), p(0, 0, 0) --> <0, 0, 1> z-axis
+  {
+    n << 0, 0, 1;
+    p << 0, 0, 0;
+    auto pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(pose, n, p));
+  }
+
+  // Case: n(0, 0, 1), p(0, 0, 1) --> <0, 0, 1> z-axis, <0, 0, 1> translation.
+  {
+    n << 0, 0, 1;
+    p << 0, 0, 1;
+    auto pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(pose, n, p));
+  }
+
+  // Case: n(0, 0, 1), p(1, 0, 0) --> <0, 0, 1> z-axis, <0, 0, 0> transform.
+  // Confirms that the pose's translation is the minimum translation.
+  {
+    n << 0, 0, 1;
+    p << 1, 0, 0;
+    auto pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(pose, n, Vector3<double>::Zero()));
+  }
+
+  // Case: n(0, 0, 1), p(1, 1, 1) --> identity rotation, <0, 0, 1> translation.
+  // Confirms that the pose's translation is the minimum translation.
+  {
+    n << 0, 0, 1;
+    p << 1, 1, 1;
+    auto pose = HalfSpace::MakePose(n, p);
+    p << 0, 0, 1;
+    EXPECT_TRUE(ValidatePlanePose(pose, n, p));
+  }
+
+  // Case: n(1, 1, 1), p(0, 0, 0) --> rotation z-axis = <1, 1, 1> / √3,
+  //       <0, 0, 0> translation. Rotation matrix orthonormal.
+  {
+    n << 1, 1, 1;
+    p << 0, 0, 0;
+    auto pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
+  }
+
+  // Case: n(1, 1, 1), p(1, 1, 1) --> rotation z-axis = <1, 1, 1> / √3,
+  //       <1, 1, 1> translation. Rotation matrix orthonormal.
+  {
+    n << 1, 1, 1;
+    p << 1, 1, 1;
+    auto pose = HalfSpace::MakePose(n, p);
+    EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
+  }
+
+  // Case: n(1, 1, 1), p(1, 0, 0) --> rotation z-axis = <1, 1, 1> / √3,
+  //       <1/3, 1/3, 1/3> translation. Rotation matrix orthonormal.
+  // Confirms that the pose's translation is the minimum translation.
+  {
+    n << 1, 1, 1;
+    p << 1, 0, 0;
+    auto pose = HalfSpace::MakePose(n, p);
+    p = n / 3.0;
+    EXPECT_TRUE(ValidatePlanePose(pose, n.normalized(), p));
+  }
+
+  // Case: Normal magnitude too small should produce an exception.
+  {
+    n << 1, 1, 1;
+    n *= 1e-11;
+    p << 0, 0, 0;
+    EXPECT_THROW(HalfSpace::MakePose(n, p), std::logic_error);
+  }
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
This introduces the basic infrastructure for declaring geometric *shapes*
into the system. It includes to preliminary shapes (a half space and a
sphere). This is *not* a complete set of shapes. It merely provides
sufficient elements so that some computation can be illustrated. It also
defines the interface through which specifications become actual
operational geometry without the expediency of type enumerations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6814)
<!-- Reviewable:end -->
