### PR TITLE
Fix requirements/link flags in Ignition RNDF and SDFormat CPS files

### DIFF
--- a/tools/ignition_rndf-create-cps.py
+++ b/tools/ignition_rndf-create-cps.py
@@ -25,7 +25,8 @@ content = """
     "ignition-rndf0": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libignition_rndf.so",
-      "Includes": [ "@prefix@/include" ]
+      "Includes": [ "@prefix@/include" ],
+      "Requires": [ "ignition-math3:ignition-math3" ]
     }
   }
 }

--- a/tools/sdformat-create-cps.py
+++ b/tools/sdformat-create-cps.py
@@ -26,7 +26,8 @@ content = """
     "sdformat": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libsdformat.so",
-      "Includes": [ "@prefix@/include" ]
+      "Includes": [ "@prefix@/include" ],
+      "Link-Flags": [ "-ltinyxml" ]
     }
   }
 }

--- a/tools/sdformat-create-cps.py
+++ b/tools/sdformat-create-cps.py
@@ -27,7 +27,8 @@ content = """
       "Type": "dylib",
       "Location": "@prefix@/lib/libsdformat.so",
       "Includes": [ "@prefix@/include" ],
-      "Link-Flags": [ "-ltinyxml" ]
+      "Link-Flags": [ "-ltinyxml" ],
+      "Requires": [ "ignition-math3:ignition-math3" ]
     }
   }
 }


### PR DESCRIPTION
Fixes #6746. Note that this is not going to change the output of `ldd /opt/drake/lib/libsdformat.so`. That is a Bazel problem that they will have to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6817)
<!-- Reviewable:end -->