### PR TITLE
[Multilane] RoadCurve interface and LineRoadCurve and ArcRoadCurve implementations

### DIFF
--- a/drake/automotive/maliput/multilane/BUILD
+++ b/drake/automotive/maliput/multilane/BUILD
@@ -26,19 +26,25 @@ drake_cc_library(
     name = "lanes",
     srcs = [
         "arc_lane.cc",
+        "arc_road_curve.cc",
         "branch_point.cc",
         "junction.cc",
         "lane.cc",
         "line_lane.cc",
+        "line_road_curve.cc",
         "road_geometry.cc",
         "segment.cc",
     ],
     hdrs = [
         "arc_lane.h",
+        "arc_road_curve.h",
         "branch_point.h",
+        "cubic_polynomial.h",
         "junction.h",
         "lane.h",
         "line_lane.h",
+        "line_road_curve.h",
+        "road_curve.h",
         "road_geometry.h",
         "segment.h",
     ],
@@ -86,6 +92,15 @@ filegroup(
 # === test/ ===
 
 drake_cc_googletest(
+    name = "multilane_arc_road_curve_test",
+    srcs = ["test/multilane_arc_road_curve_test.cc"],
+    deps = [
+        ":lanes",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "multilane_builder_test",
     size = "small",
     srcs = ["test/multilane_builder_test.cc"],
@@ -101,6 +116,16 @@ drake_cc_googletest(
     deps = [
         ":lanes",
         "//drake/automotive/maliput/api:maliput_types_compare",
+        "//drake/common:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multilane_line_road_curve_test",
+    size = "small",
+    srcs = ["test/multilane_line_road_curve_test.cc"],
+    deps = [
+        ":lanes",
         "//drake/common:eigen_matrix_compare",
     ],
 )

--- a/drake/automotive/maliput/multilane/arc_road_curve.cc
+++ b/drake/automotive/maliput/multilane/arc_road_curve.cc
@@ -1,0 +1,194 @@
+#include "drake/automotive/maliput/multilane/arc_road_curve.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "drake/common/unused.h"
+#include "drake/math/saturate.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+namespace {
+
+// Wraps the input angle θ, casting it onto the range [-π, π].
+double wrap(double theta) {
+  double theta_new = std::fmod(theta + M_PI, 2. * M_PI);
+  if (theta_new < 0.) theta_new += 2. * M_PI;
+  return theta_new - M_PI;
+}
+
+// Implements the saturate function with respect to a range of angles.
+// Specifically, given an angle θ ∈ [-π, π] along with lower and upper bounds
+// θ_min, θ_max, such that -∞ < θ_min <= θ_max < +∞, this function returns the
+// saturated angle sat(θ, θ_min, θ_max) within the range [-π, π].  If θ_max > 2π
+// + θ_min, then no saturation occurs.
+//
+// Note that the interval [θ_min, θ_max] should be mapped into the cyclic
+// range [-π, +π] --- and in doing so, it might remain a single closed
+// interval [a, b], or it might split into a pair of intervals [-π, a] and [b,
+// +π]. In both cases, -π <= a <= b <= +π. If the result is a single
+// interval, saturating is the usual. If the result is two intervals, saturating
+// involves the extra step picking the 'closest' interval to saturate
+// within.
+double saturate_on_wrapped_bounds(double theta, double theta_min,
+                                  double theta_max) {
+  DRAKE_DEMAND(-M_PI <= theta);
+  DRAKE_DEMAND(theta <= M_PI);
+  DRAKE_DEMAND(theta_min <= theta_max);
+
+  if (theta_max >= theta_min + 2. * M_PI) return theta;
+
+  // Wrap on the range [-π, π]. This is not order-preserving.
+  const double theta_0 = wrap(theta_min);
+  const double theta_1 = wrap(theta_max);
+
+  // Criteria for returning the unsaturated result.
+  // First, deal with the case where [θ_min, θ_max] wrapped does not cross the
+  // ±π wrap-point (i.e. θ₀ ≤ θ₁).
+  if (theta_0 <= theta && theta <= theta_1) return theta;
+  // Next, deal with the case where [θ_min, θ_max] wrapped straddles ±π (i.e. θ₁
+  // < θ₀).
+  if (theta <= theta_1 && theta_1 < theta_0) return theta;
+  if (theta_1 < theta_0 && theta_0 <= theta) return theta;
+
+  // Saturate at the appropriate bound.
+  const double delta_0 = std::min(std::abs(theta - theta_0),
+                                  std::abs(theta - 2. * M_PI - theta_0));
+  const double delta_1 = std::min(std::abs(theta - theta_1),
+                                  std::abs(theta + 2. * M_PI - theta_1));
+  return (delta_0 <= delta_1) ? theta_0 : theta_1;
+}
+
+}  // namespace
+
+Vector3<double> ArcRoadCurve::ToCurveFrame(
+    const Vector3<double>& geo_coordinate,
+    const api::RBounds& lateral_bounds,
+    const api::HBounds& height_bounds) const {
+  // TODO(jadecastro): Lift the zero superelevation and zero elevation gradient
+  // restriction.
+  const Vector2<double> p(geo_coordinate.x(), geo_coordinate.y());
+  DRAKE_DEMAND(p != center_);
+
+  // Define a vector from p to the center of the arc.
+  const Vector2<double> v = p - center_;
+
+  const double theta_min = std::min(theta0_, d_theta_ + theta0_);
+  const double theta_max = std::max(theta0_, d_theta_ + theta0_);
+
+  // First, find a saturated theta that is nearest to point p.
+  const double theta_nearest =
+      saturate_on_wrapped_bounds(std::atan2(v(1), v(0)), theta_min, theta_max);
+  // Find the angle swept from the beginning of the lane (s = 0) to
+  // theta_nearest.
+  const double d_theta_nearest = (d_theta_ > 0.)
+      ? theta_nearest - wrap(theta_min) : wrap(theta_max) - theta_nearest;
+  // Then, unwrap this angle (if necessary) to deal with possible crossings with
+  // the ±π wrap-around point.
+  const double d_theta_nearest_unwrapped =
+      (d_theta_nearest < 0.) ? d_theta_nearest + 2. * M_PI : d_theta_nearest;
+  // Convert this angular displacement to arc length (s).
+  const double s = radius_ * d_theta_nearest_unwrapped;
+
+  // Compute r (its direction depends on the direction of the +s-coordinate)
+  const double r_unsaturated = (d_theta_ >= 0.) ?
+                               radius_ - v.norm() : v.norm() - radius_;
+  // Saturate r within drivable bounds.
+  const double r = math::saturate(r_unsaturated, lateral_bounds.min(),
+                                  lateral_bounds.max());
+
+  // Calculate the (uniform) road elevation.
+  const double p_scale = length();
+  // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
+  // `a` coefficient is normalized by lane length).
+  const double h_unsaturated = geo_coordinate.z() - elevation().a() * p_scale;
+  const double h = math::saturate(h_unsaturated, height_bounds.min(),
+                                  height_bounds.max());
+  return Vector3<double>(s, r, h);
+}
+
+bool ArcRoadCurve::IsValid(
+    const api::RBounds& lateral_bounds,
+    const api::HBounds& height_bounds) const {
+  // TODO(@agalbachicar)      There is no check on height constraints. When the
+  //                          curve bends over itself, if it does, it must do it
+  //                          with a difference in height greater than
+  //                          (height_bounds.max() - height_bounds.min()).
+  // TODO(maddog@tri.global)  Include height_bounds in checking against the
+  //                          singularity at the arc center.
+  // TODO(maddog@tri.global)  Check against singularities in curvature of
+  //                          elevation.
+  // TODO(maddog@tri.global)  Check for self-intersecting volumes (e.g., when
+  //                          arc angle >= 2π).
+  unused(height_bounds);
+  // Whether or not user code pays attention to driveable_bounds, at least
+  // ensure that bounds are sane.  Given the singularity at the center of
+  // the arc, it is not well-defined to consider parallel curves offset
+  // from the reference by a distance greater than or equal to the radius
+  // radius_.
+  //
+  // In the presence of superelevation, the bounds are effectively scaled
+  // by cos(superelevation) (the more tilted the road, the narrower the
+  // road looks when projected onto the groundplane).  Thus, the worst case
+  // (widest effective bounds) happens at the position p along the arc
+  // with maximum cos(superelevation).
+  //
+  // In other words, the worst case happens at p in domain [0, 1] with the
+  // minimum abs(superelevation).  There are up to four possible candidates
+  // at which an extremum can occur, since superelevation is cubic.
+  double theta_min = std::numeric_limits<double>::max();
+  double theta_max = std::numeric_limits<double>::min();
+  const CubicPolynomial& f_superelevation = superelevation();
+  auto update_range_given_p = [&theta_min, &theta_max,
+                               &f_superelevation](double p) {
+    // Skip p if outside of domain [0, 1].
+    if ((p < 0.) || (p > 1.)) {
+      return;
+    }
+    const double theta_p = f_superelevation.f_p(p);
+    theta_min = std::min(theta_min, theta_p);
+    theta_max = std::max(theta_max, theta_p);
+  };
+  // ...possible extremum at p = 0.
+  update_range_given_p(0.);
+  // ...possible extremum at p = 1.
+  update_range_given_p(1.);
+  // ...possible extrema at the local min/max of superelevation (if the local
+  // min/max occur within domain [0, 1]).
+  if (f_superelevation.d() != 0) {
+    const double p_plus =
+        (-f_superelevation.c() +
+         std::sqrt((f_superelevation.c() * f_superelevation.c()) -
+                   (3. * f_superelevation.b() * f_superelevation.d()))) /
+        (3. * f_superelevation.d());
+    update_range_given_p(p_plus);
+    const double p_minus =
+        (-f_superelevation.c() -
+         std::sqrt((f_superelevation.c() * f_superelevation.c()) -
+                   (3. * f_superelevation.b() * f_superelevation.d()))) /
+        (3. * f_superelevation.d());
+    update_range_given_p(p_minus);
+  } else if (f_superelevation.c() != 0) {
+    const double p_extremum = -f_superelevation.b() /
+                              (2. * f_superelevation.c());
+    update_range_given_p(p_extremum);
+  }
+  // If theta_min and theta_max flank zero, then min(abs(theta)) is 0....
+  const double max_cos_theta =
+      std::cos(((theta_min < 0.) && (theta_max > 0.))
+                   ? 0.
+                   : std::min(std::abs(theta_min), std::abs(theta_max)));
+  // TODO(maddog@tri.global)  When you have nothing better to do, handle the
+  //                          improbable case of superelevation >= 90 deg, too.
+  if (d_theta_ > 0.) {
+    return ((lateral_bounds.max() * max_cos_theta) < radius_);
+  } else {
+    return ((lateral_bounds.min() * max_cos_theta) > -radius_);
+  }
+  return true;
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/arc_road_curve.h
+++ b/drake/automotive/maliput/multilane/arc_road_curve.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <cmath>
+
+#include "drake/automotive/maliput/multilane/road_curve.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+/// RoadCurve specification for a reference curve that describes a piece
+/// of an arc.
+class ArcRoadCurve : public RoadCurve {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ArcRoadCurve)
+
+  /// Constructor. The reference curve is created from the circle `center`, the
+  /// `radius`, initial angular position `theta0` and the angle span
+  /// `d_theta`. `elevation` and `superelevation` polynomials will be used to
+  /// feed RoadGeometry parent class.
+  /// @param center Center of the reference arc.
+  /// @param radius Radius of the reference arc (must be positive).
+  /// @param theta0 Angle of the start point of the reference arc with respect
+  /// to `center` (0 == parallel to x-axis).
+  /// @param d_theta Central angle of the arc, i.e., angular displacement
+  /// from start to end.  d_theta > 0 is counter-clockwise.
+  /// @param elevation CubicPolynomial object that represents the elevation
+  /// polynomial. See RoadCurve class constructor for more details.
+  /// @param superelevation CubicPolynomial object that represents the
+  /// superelevation polynomial. See RoadCurve class constructor for more
+  /// details.
+  /// @throws std::runtime_error When `radius` is not positive.
+  explicit ArcRoadCurve(const Vector2<double>& center, double radius,
+                        double theta0, double d_theta,
+                        const CubicPolynomial& elevation,
+                        const CubicPolynomial& superelevation)
+      : RoadCurve(elevation, superelevation),
+        center_(center),
+        radius_(radius),
+        theta0_(theta0),
+        d_theta_(d_theta) {
+    DRAKE_THROW_UNLESS(radius > 0.0);
+  }
+
+  ~ArcRoadCurve() override = default;
+
+  Vector2<double> xy_of_p(double p) const override {
+    // The result will be computed with the following function:
+    //      [x;y] = center + [radius * cos(θ); radius * sin(θ)]
+    // and:
+    //      θ = θ₀ + (p * Δθ)
+    const double theta = theta_of_p(p);
+    return center_ + Vector2<double>(radius_ * std::cos(theta),
+                                     radius_ * std::sin(theta));
+  }
+
+  Vector2<double> xy_dot_of_p(double p) const override {
+    // Given:
+    //      [x;y] = center + [radius * cos(θ); radius * sin(θ)]
+    // and:
+    //      θ = θ₀ + (p * Δθ)
+    //      dθ/dp = Δθ
+    // then:
+    //      [dx/dp; dy/dp] = [-radius * sin(θ) * dθ/dp; radius * cos(θ) * dθ/dp]
+    //                     = [-radius * sin(θ) * Δθ; radius * cos(θ) * Δθ]
+    const double theta = theta_of_p(p);
+    return Vector2<double>(-radius_ * std::sin(theta) * d_theta_,
+                           radius_ * std::cos(theta) * d_theta_);
+  }
+
+  double heading_of_p(double p) const override {
+    // Given:
+    //     θ = θ_0 + (p * Δθ)
+    // then:
+    //     heading = θ + sign(Δθ) * π / 2.0
+    // sign(Δθ) is used to express the increasing-p direction of the tangent.
+    const double theta = theta_of_p(p);
+    return theta + std::copysign(M_PI / 2.0, d_theta_);
+  }
+
+  double heading_dot_of_p(double p) const override {
+    // Given:
+    //      heading = θ + sign(Δθ) * π / 2.0
+    // and:
+    //      θ = θ₀ + (p * Δθ)
+    // then:
+    //      dheading/dp = dθ/dp = Δθ
+    unused(p);
+    return d_theta_;
+  }
+
+  double length() const override { return radius_ * std::abs(d_theta_); }
+
+  Vector3<double> ToCurveFrame(
+      const Vector3<double>& geo_coordinate,
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const override;
+
+  /// Evaluates extrema in superelevation polynomial to verify that for the
+  /// given @p lateral_bounds the surface do not fold over itself.
+  /// @param lateral_bounds An api::RBounds object that represents the lateral
+  /// bounds of the surface mapping.
+  /// @param height_bounds An api::HBounds object that represents the elevation
+  /// bounds of the surface mapping.
+  /// @return True.
+  bool IsValid(
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const override;
+
+ private:
+  // Computes the absolute position along reference arc as an angle in
+  // range [theta0_, (theta0 + d_theta_)],
+  // as a function of parameter @p p (in domain [0, 1]).
+  double theta_of_p(double p) const { return theta0_ + (p * d_theta_); }
+
+  // Center of rotation in z=0 plane, world coordinates, for the arc reference
+  // curve.
+  const Vector2<double> center_;
+  // The length of the radius of the arc.
+  const double radius_{};
+  // The angular position at which the piece of arc starts.
+  const double theta0_{};
+  // The aperture angle of the arc. Positive values are counter-clockwise.
+  const double d_theta_{};
+};
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/builder.cc
+++ b/drake/automotive/maliput/multilane/builder.cc
@@ -5,6 +5,7 @@
 
 #include "drake/automotive/maliput/multilane/arc_lane.h"
 #include "drake/automotive/maliput/multilane/branch_point.h"
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/automotive/maliput/multilane/line_lane.h"
 #include "drake/automotive/maliput/multilane/road_geometry.h"
 #include "drake/common/drake_assert.h"

--- a/drake/automotive/maliput/multilane/cubic_polynomial.h
+++ b/drake/automotive/maliput/multilane/cubic_polynomial.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cmath>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+/// A cubic polynomial, f(p) = a + b*p + c*p^2 + d*p^3.
+class CubicPolynomial {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CubicPolynomial)
+
+  /// Default constructor, all zero coefficients.
+  CubicPolynomial() : CubicPolynomial(0., 0., 0., 0.) {}
+
+  /// Constructs a cubic polynomial given all four coefficients.
+  CubicPolynomial(double a, double b, double c, double d)
+      : a_(a), b_(b), c_(c), d_(d) {
+    const double df = f_p(1.) - f_p(0.);
+    s_1_ = std::sqrt(1. + (df * df));
+  }
+
+  // Returns the a coefficient.
+  double a() const { return a_; }
+
+  // Returns the b coefficient.
+  double b() const { return b_; }
+
+  // Returns the c coefficient.
+  double c() const { return c_; }
+
+  // Returns the d coefficient.
+  double d() const { return d_; }
+
+  /// Evaluates the polynomial f at @p p.
+  double f_p(double p) const {
+    return a_ + (b_ * p) + (c_ * p * p) + (d_ * p * p * p);
+  }
+
+  /// Evaluates the derivative df/dp at @p p.
+  double f_dot_p(double p) const {
+    return b_ + (2. * c_ * p) + (3. * d_ * p * p);
+  }
+
+  /// Evaluates the double-derivative d^2f/dp^2 at @p p.
+  double f_ddot_p(double p) const { return (2. * c_) + (6. * d_ * p); }
+
+  // TODO(maddog@tri.global)  s_p() and p_s() need to be replaced with a
+  //                          properly integrated path-length parameterization.
+  //                          For the moment, we are calculating the length by
+  //                          approximating the curve with a single linear
+  //                          segment from (0, f(0)) to (1, f(1)), which is
+  //                          not entirely awful for relatively flat curves.
+  /// Returns the path-length s along the curve (p, f(p)) from p = 0 to @p p.
+  double s_p(double p) const { return s_1_ * p; }
+
+  /// Returns the inverse of the path-length parameterization s_p(p).
+  double p_s(double s) const { return s / s_1_; }
+
+  // TODO(maddog@tri.global) Until s(p) is a properly integrated path-length
+  //                         parameterization, we have a need to calculate the
+  //                         derivative of the actual linear function
+  //                         involved in our bogus path-length approximation.
+  double fake_gprime(double p) const {
+    unused(p);
+    // return df;  which is...
+    return f_p(1.) - f_p(0.);
+  }
+
+ private:
+  double a_{};
+  double b_{};
+  double c_{};
+  double d_{};
+  double s_1_{};
+};
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/lane.h
+++ b/drake/automotive/maliput/multilane/lane.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
@@ -42,83 +43,6 @@ class Rot3 {
 
  private:
   Eigen::Matrix<double, 3, 1, Eigen::DontAlign> rpy_;
-};
-
-
-/// A cubic polynomial, f(p) = a + b*p + c*p^2 + d*p^3.
-class CubicPolynomial {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CubicPolynomial)
-
-  /// Default constructor, all zero coefficients.
-  CubicPolynomial() : CubicPolynomial(0., 0., 0., 0.) {}
-
-  /// Constructs a cubic polynomial given all four coefficients.
-  CubicPolynomial(double a, double b, double c, double d)
-      : a_(a), b_(b), c_(c), d_(d) {
-    const double df = f_p(1.) - f_p(0.);
-    s_1_ = std::sqrt(1. + (df * df));
-  }
-
-  // Returns the a coefficient.
-  double a() const { return a_; }
-
-  // Returns the b coefficient.
-  double b() const { return b_; }
-
-  // Returns the c coefficient.
-  double c() const { return c_; }
-
-  // Returns the d coefficient.
-  double d() const { return d_; }
-
-  /// Evaluates the polynomial f at @p p.
-  double f_p(double p) const {
-    return a_ + (b_ * p) + (c_ * p * p) + (d_ * p * p * p);
-  }
-
-  /// Evaluates the derivative df/dp at @p p.
-  double f_dot_p(double p) const {
-    return b_ + (2. * c_ * p) + (3. * d_ * p * p);
-  }
-
-  /// Evaluates the double-derivative d^2f/dp^2 at @p p.
-  double f_ddot_p(double p) const {
-    return (2. * c_) + (6. * d_ * p);
-  }
-
-  // TODO(maddog@tri.global)  s_p() and p_s() need to be replaced with a
-  //                          properly integrated path-length parameterization.
-  //                          For the moment, we are calculating the length by
-  //                          approximating the curve with a single linear
-  //                          segment from (0, f(0)) to (1, f(1)), which is
-  //                          not entirely awful for relatively flat curves.
-  /// Returns the path-length s along the curve (p, f(p)) from p = 0 to @p p.
-  double s_p(double p) const {
-    return s_1_ * p;
-  }
-
-  /// Returns the inverse of the path-length parameterization s_p(p).
-  double p_s(double s) const {
-    return s / s_1_;
-  }
-
-  // TODO(maddog@tri.global) Until s(p) is a properly integrated path-length
-  //                         parameterization, we have a need to calculate the
-  //                         derivative of the actual linear function
-  //                         involved in our bogus path-length approximation.
-  double fake_gprime(double p) const {
-    unused(p);
-    // return df;  which is...
-    return f_p(1.) - f_p(0.);
-  }
-
- private:
-  double a_{};
-  double b_{};
-  double c_{};
-  double d_{};
-  double s_1_{};
 };
 
 

--- a/drake/automotive/maliput/multilane/line_road_curve.cc
+++ b/drake/automotive/maliput/multilane/line_road_curve.cc
@@ -1,0 +1,39 @@
+#include "drake/automotive/maliput/multilane/line_road_curve.h"
+
+#include "drake/math/saturate.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+const double LineRoadCurve::kMinimumNorm = 1e-12;
+
+Vector3<double> LineRoadCurve::ToCurveFrame(
+    const Vector3<double>& geo_coordinate,
+    const api::RBounds& lateral_bounds,
+    const api::HBounds& height_bounds) const {
+  // TODO(jadecastro): Lift the zero superelevation and zero elevation gradient
+  // restriction.
+  const Vector2<double> s_unit_vector = dp_ / dp_.norm();
+  const Vector2<double> r_unit_vector{-s_unit_vector(1), s_unit_vector(0)};
+
+  const Vector2<double> p(geo_coordinate.x(), geo_coordinate.y());
+  const Vector2<double> lane_origin_to_p = p - p0_;
+
+  // Compute the distance from `p` to the start of the lane.
+  const double s_unsaturated = lane_origin_to_p.dot(s_unit_vector);
+  const double s = math::saturate(s_unsaturated, 0., length());
+  const double r_unsaturated = lane_origin_to_p.dot(r_unit_vector);
+  const double r = math::saturate(r_unsaturated, lateral_bounds.min(),
+                                  lateral_bounds.max());
+  // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
+  // `a` coefficient is normalized by lane length).
+  const double h_unsaturated = geo_coordinate.z() - elevation().a() * length();
+  const double h = math::saturate(h_unsaturated, height_bounds.min(),
+                                  height_bounds.max());
+  return Vector3<double>(s, r, h);
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/line_road_curve.h
+++ b/drake/automotive/maliput/multilane/line_road_curve.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cmath>
+#include <utility>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/multilane/road_curve.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+/// RoadCurve specification for a reference curve that describes a line.
+class LineRoadCurve : public RoadCurve {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LineRoadCurve)
+
+  /// Constructor. Computes a line from @p xy0 as the initial point of the line
+  /// and @p dxy as the difference vector that connects the @p xy0 with the end
+  /// point of the reference curve.
+  /// @param xy0 A 2D vector that represents the first point of the lane.
+  /// @param dxy A 2D difference vector between the last point and @p xy0.
+  /// @param elevation CubicPolynomial object that represents the elevation
+  /// polynomial. See RoadCurve class constructor for more details.
+  /// @param superelevation CubicPolynomial object that represents the
+  /// superelevation polynomial. See RoadCurve class constructor for more
+  /// details.
+  explicit LineRoadCurve(const Vector2<double>& xy0, const Vector2<double>& dxy,
+                         const CubicPolynomial& elevation,
+                         const CubicPolynomial& superelevation)
+      : RoadCurve(elevation, superelevation),
+        p0_(xy0),
+        dp_(dxy),
+        heading_(std::atan2(dxy.y(), dxy.x())) {
+    DRAKE_DEMAND(dxy.norm() > kMinimumNorm);
+  }
+
+  ~LineRoadCurve() override = default;
+
+  Vector2<double> xy_of_p(double p) const override { return p0_ + p * dp_; }
+
+  Vector2<double> xy_dot_of_p(double p) const override {
+    unused(p);
+    return dp_;
+  }
+
+  double heading_of_p(double p) const override {
+    unused(p);
+    return heading_;
+  }
+
+  double heading_dot_of_p(double p) const override {
+    unused(p);
+    return 0.;
+  }
+
+  double length() const override { return dp_.norm(); }
+
+  Vector3<double> ToCurveFrame(
+      const Vector3<double>& geo_coordinate,
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const override;
+
+  /// As the reference curve is a line, the curvature radius is infinity at any
+  /// point in the range of p = [0;1] so no value of elevation or superelevation
+  /// may result in a geometry that intersects with itself.
+  /// @param lateral_bounds An api::RBounds object that represents the lateral
+  /// bounds of the surface mapping.
+  /// @param height_bounds An api::HBounds object that represents the elevation
+  /// bounds of the surface mapping.
+  /// @return True.
+  bool IsValid(
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const override {
+    unused(lateral_bounds);
+    unused(height_bounds);
+    return true;
+  }
+
+ private:
+  // The first point in world coordinates over the z=0 plane of the reference
+  // curve.
+  const Vector2<double> p0_{};
+  // The difference vector that joins the end point of the reference curve with
+  // the first one, p0_.
+  const Vector2<double> dp_{};
+  // The constant angle deviation of dp_ with respect to the x axis of the world
+  // frame.
+  const double heading_{};
+  // The minimum dp_ norm to avoid having issues when computing heading_.
+  static const double kMinimumNorm;
+};
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/road_curve.h
+++ b/drake/automotive/maliput/multilane/road_curve.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <utility>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+/// Defines an interface for a path in a Segment object surface. The path is
+/// defined by an elevation and superelevation CubicPolynomial objects and a
+/// reference curve. This reference curve is a C1 function over the z=0 plane.
+/// Its domain is constrained in [0;1] interval and it should map a ℝ² curve.
+/// As per notation, p is the parameter of the reference curve, and function
+/// interpolations and function derivatives as well as headings and heading
+/// derivatives are expressed in world coordinates, which is the same frame as
+/// api::GeoPosition.
+/// By implementing this interface the road curve is defined and a complete.
+class RoadCurve {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadCurve)
+
+  virtual ~RoadCurve() = default;
+
+  const CubicPolynomial& elevation() const { return elevation_; }
+
+  const CubicPolynomial& superelevation() const { return superelevation_; }
+
+  /// Computes the composed curve path integral in the interval of p = [0; 1].
+  /// @return The path length integral of the curve composed with the elevation
+  /// polynomial.
+  double trajectory_length() const {
+    return elevation_.s_p(1.0) * length();
+  }
+
+  /// Computes the reference curve.
+  /// @param p The reference curve parameter.
+  /// @return The reference curve itself, F(p).
+  virtual Vector2<double> xy_of_p(double p) const = 0;
+
+  /// Computes the first derivative of the reference curve.
+  /// @param p The reference curve parameter.
+  /// @return The derivative of the curve with respect to p, at @p p, i.e.,
+  /// F'(p0) = (dx/dp, dy/dp) at p0.
+  virtual Vector2<double> xy_dot_of_p(double p) const = 0;
+
+  /// Computes the heading of the reference curve.
+  /// @param p The reference curve parameter.
+  /// @return The heading of the curve at @p p, i.e.,
+  /// the angle of the tangent vector (with respect to x-axis) in the
+  /// increasing-p direction.
+  virtual double heading_of_p(double p) const = 0;
+
+  /// Computes the first derivative heading of the reference curve.
+  /// @param p The reference curve parameter.
+  /// @return The derivative of the heading with respect to p, i.e.,
+  /// d_heading/dp evaluated at @p p.
+  virtual double heading_dot_of_p(double p) const = 0;
+
+  /// Computes the path length integral of the reference curve for the interval
+  /// [0;1] of p.
+  /// @return The path length integral of the reference curve.
+  virtual double length() const = 0;
+
+  /// Converts a @p geo_coordinate in the world frame to the composed curve
+  /// frame, i.e., the superposition of the reference curve, elevation and
+  /// superelevation polynomials. The resulting coordinates are saturated to
+  /// @p lateral_bounds and @p height_bounds in the lateral and vertical
+  /// directions over the composed curve trajectory. The path length coordinate
+  /// is saturated in the interval [0; trajectory_length()].
+  /// @param geo_coordinate A 3D vector in the world frame to be converted to
+  /// the composed curve frame.
+  /// @param lateral_bounds An api::RBounds object that represents the lateral
+  /// bounds of the surface mapping.
+  /// @param height_bounds An api::HBounds object that represents the elevation
+  /// bounds of the surface mapping.
+  /// @return A 3D vector that represents the coordinates with respect to the
+  /// composed curve. The first dimension represents the path length coordinate,
+  /// the second dimension is the lateral deviation from the composed curve and
+  /// the third one is the vertical deviation from the composed curve too. The
+  /// frame where this vector is defined is the same as api::LanePosition.
+  virtual Vector3<double> ToCurveFrame(
+      const Vector3<double>& geo_coordinate,
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const = 0;
+
+  /// Checks that there are no self-intersections (singularities) in the volume
+  /// created by applying the constant @p lateral_bounds and @p height_bounds to
+  /// the RoadCurve.
+  /// @param lateral_bounds An api::RBounds object that represents the lateral
+  /// bounds of the surface mapping.
+  /// @param height_bounds An api::HBounds object that represents the elevation
+  /// bounds of the surface mapping.
+  /// @return True when there are no self-intersections.
+  virtual bool IsValid(
+      const api::RBounds& lateral_bounds,
+      const api::HBounds& height_bounds) const = 0;
+
+ protected:
+  /// Constructs a road curve given elevation and superelevation curves.
+  /// @param elevation CubicPolynomial object that represents the elevation
+  /// function (see below for more details).
+  /// @param superelevation CubicPolynomial object that represents the
+  /// superelevation function (see below for more details).
+  ///
+  /// @p elevation and @p superelevation are cubic-polynomial functions which
+  /// define the elevation and superelevation as a function of position along
+  /// the planar reference curve.  @p elevation specifies the z-component of
+  /// the surface at (r,h) = (0,0).  @p superelevation specifies the angle
+  /// of the r-axis with respect to the horizon, i.e., how the road twists.
+  /// Thus, non-zero @p superelevation contributes to the z-component at
+  /// r != 0.
+  ///
+  /// These two functions (@p elevation and @p superelevation) must be
+  /// isotropically scaled to operate over the domain p in [0, 1], where
+  /// p is linear in the path-length of the planar reference curve,
+  /// p = 0 corresponds to the start and p = 1 to the end.  @p p_scale is
+  /// the scale factor.  In other words...
+  ///
+  /// Given:
+  ///  * a reference curve R(p) parameterized by p in domain [0, 1], which
+  ///    has a path-length q(p) in range [0, q_max], linearly related to p,
+  ///    where q_max is the total path-length of R (in real-world units);
+  ///  * the true elevation function E_true(q), parameterized by the
+  ///    path-length q of R;
+  ///  * the true superelevation function S_true(q), parameterized by the
+  ///    path-length q of R;
+  ///
+  /// then:
+  ///  * p_scale is q_max (and p = q / p_scale);
+  ///  * @p elevation is  E_scaled = (1 / p_scale) * E_true(p_scale * p);
+  ///  * @p superelevation is  S_scaled = (1 / p_scale) * S_true(p_scale * p).
+  RoadCurve(const CubicPolynomial& elevation,
+            const CubicPolynomial& superelevation)
+      : elevation_(elevation), superelevation_(superelevation) {}
+
+ private:
+  // A polynomial that represents the elevation change as a function of p.
+  CubicPolynomial elevation_;
+  // A polynomial that represents the superelevation angle change as a function
+  // of p.
+  CubicPolynomial superelevation_;
+};
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/segment.h
+++ b/drake/automotive/maliput/multilane/segment.h
@@ -5,6 +5,7 @@
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/automotive/maliput/multilane/lane.h"
 #include "drake/common/drake_copyable.h"
 

--- a/drake/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -1,0 +1,176 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/multilane/arc_road_curve.h"
+/* clang-format on */
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+class MultilaneArcRoadCurveTest : public ::testing::Test {
+ protected:
+  const Vector2<double> kCenter{10.0, 10.0};
+  const double kRadius{10.0};
+  const double kTheta0{M_PI / 4.0};
+  const double kTheta1{3.0 * M_PI / 4.0};
+  const double kDTheta{kTheta1 - kTheta0};
+  const CubicPolynomial zp;
+  const api::RBounds lateral_bounds{-kRadius * 0.5, kRadius * 0.5};
+  const api::HBounds height_bounds{0.0, 10.0};
+  const double kVeryExact{1e-12};
+};
+
+// Checks ArcRoadCurve constructor constraints.
+TEST_F(MultilaneArcRoadCurveTest, ConstructorTest) {
+  EXPECT_THROW(ArcRoadCurve(kCenter, -kRadius, kTheta0, kDTheta, zp, zp),
+               std::runtime_error);
+  EXPECT_NO_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp));
+}
+
+// Checks arc reference curve interpolations, derivatives, and lengths.
+TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
+  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  // Checks the length.
+  EXPECT_NEAR(dut.length(), kDTheta * kRadius, kVeryExact);
+  EXPECT_NEAR(dut.trajectory_length(), kDTheta * kRadius, kVeryExact);
+  // Checks the evaluation of xy at different values over the reference curve.
+  EXPECT_TRUE(
+      CompareMatrices(dut.xy_of_p(0.0),
+                      kCenter + Vector2<double>(kRadius * std::cos(kTheta0),
+                                                kRadius * std::sin(kTheta0)),
+                      kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.xy_of_p(0.5),
+      kCenter + Vector2<double>(kRadius * std::cos(kTheta0 + kDTheta * 0.5),
+                                kRadius * std::sin(kTheta0 + kDTheta * 0.5)),
+      kVeryExact));
+  EXPECT_TRUE(
+      CompareMatrices(dut.xy_of_p(1.0),
+                      kCenter + Vector2<double>(kRadius * std::cos(kTheta1),
+                                                kRadius * std::sin(kTheta1)),
+                      kVeryExact));
+  // Checks the derivative of xy at different values over the reference curve.
+  EXPECT_TRUE(
+      CompareMatrices(dut.xy_dot_of_p(0.0),
+                      Vector2<double>(-kRadius * std::sin(kTheta0) * kDTheta,
+                                      kRadius * std::cos(kTheta0) * kDTheta),
+                      kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.xy_dot_of_p(0.5),
+      Vector2<double>(-kRadius * std::sin(kTheta0 + 0.5 * kDTheta) * kDTheta,
+                      kRadius * std::cos(kTheta0 + 0.5 * kDTheta) * kDTheta),
+      kVeryExact));
+  EXPECT_TRUE(
+      CompareMatrices(dut.xy_dot_of_p(1.0),
+                      Vector2<double>(-kRadius * std::sin(kTheta1) * kDTheta,
+                                      kRadius * std::cos(kTheta1) * kDTheta),
+                      kVeryExact));
+  // Checks the heading at different values.
+  EXPECT_NEAR(dut.heading_of_p(0.0), kTheta0 + M_PI / 2.0, kVeryExact);
+  EXPECT_NEAR(dut.heading_of_p(0.5), kTheta0 + kDTheta / 2.0 + M_PI / 2.0,
+              kVeryExact);
+  EXPECT_NEAR(dut.heading_of_p(1.0), kTheta1 + M_PI / 2.0, kVeryExact);
+  // Checks the heading derivative of p at different values.
+  EXPECT_NEAR(dut.heading_dot_of_p(0.0), kDTheta, kVeryExact);
+  EXPECT_NEAR(dut.heading_dot_of_p(0.5), kDTheta, kVeryExact);
+  EXPECT_NEAR(dut.heading_dot_of_p(1.0), kDTheta, kVeryExact);
+}
+
+// Checks the validity of the surface for different lateral bounds and
+// geometries.
+GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
+  const Vector2<double> kZeroCenter(0.0, 0.0);
+  const double kRadius = 10.0;
+  const double kInitTheta = 0.0;
+  const double kEndTheta1 = M_PI / 2.0;
+  const double kDTheta1 = kEndTheta1 - kInitTheta;
+  const double kEndTheta2 = -M_PI / 2.0;
+  const double kDTheta2 = kEndTheta2 - kInitTheta;
+  const CubicPolynomial constant_superelevation(M_PI / 4.0, 0.0, 0.0, 0.0);
+  const api::RBounds large_lateral_bounds(-kRadius * 1.5, kRadius * 1.5);
+  const api::RBounds critical_cone_lateral_bounds(
+      -kRadius / std::cos(M_PI / 4.0), kRadius / std::cos(M_PI / 4.0));
+  const api::RBounds lateral_bounds{-kRadius * 0.5, kRadius * 0.5};
+  const api::HBounds height_bounds{0.0, 10.0};
+  const CubicPolynomial zp;
+
+  // Checks over a flat arc surface.
+  const ArcRoadCurve flat_arc_geometry(kZeroCenter, kRadius, kInitTheta,
+                                        kDTheta1, zp, zp);
+  EXPECT_TRUE(flat_arc_geometry.IsValid(lateral_bounds, height_bounds));
+  EXPECT_FALSE(flat_arc_geometry.IsValid(large_lateral_bounds, height_bounds));
+  // Checks over a right handed cone.
+  const ArcRoadCurve right_handed_cone_geometry(
+      kZeroCenter, kRadius, kInitTheta, kDTheta1, zp, constant_superelevation);
+  EXPECT_TRUE(
+      right_handed_cone_geometry.IsValid(lateral_bounds, height_bounds));
+  EXPECT_FALSE(
+      right_handed_cone_geometry.IsValid(large_lateral_bounds, height_bounds));
+  EXPECT_FALSE(right_handed_cone_geometry.IsValid(critical_cone_lateral_bounds,
+                                             height_bounds));
+  // Checks over a left handed cone.
+  const ArcRoadCurve left_handed_cone_geometry(
+      kZeroCenter, kRadius, kInitTheta, kDTheta2, zp, constant_superelevation);
+  EXPECT_TRUE(left_handed_cone_geometry.IsValid(lateral_bounds, height_bounds));
+  EXPECT_FALSE(
+      left_handed_cone_geometry.IsValid(large_lateral_bounds, height_bounds));
+  EXPECT_FALSE(left_handed_cone_geometry.IsValid(critical_cone_lateral_bounds,
+                                                 height_bounds));
+}
+
+// Checks the ToCurve frame coordinate conversion for different points in world
+// coordinates.
+TEST_F(MultilaneArcRoadCurveTest, ToCurveFrameTest) {
+  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  // Checks points over the composed curve.
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(
+          Vector3<double>(kCenter(0) + kRadius * std::cos(kTheta0),
+                          kCenter(1) + kRadius * std::sin(kTheta0), 0.0),
+          lateral_bounds, height_bounds),
+      Vector3<double>(0.0, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(
+          Vector3<double>(
+              kCenter(0) + kRadius * std::cos(kTheta0 + kDTheta / 2.0),
+              kCenter(1) + kRadius * std::sin(kTheta0 + kDTheta / 2.0), 0.0),
+          lateral_bounds, height_bounds),
+      Vector3<double>(kRadius * kDTheta * 0.5, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(
+          Vector3<double>(kCenter(0) + kRadius * std::cos(kTheta1),
+                          kCenter(1) + kRadius * std::sin(kTheta1), 0.0),
+          lateral_bounds, height_bounds),
+      Vector3<double>(kRadius * kDTheta, 0.0, 0.0), kVeryExact));
+  // Checks with lateral and vertical deviations.
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(
+          Vector3<double>(
+              kCenter(0) + (kRadius + 1.0) * std::cos(kTheta0 + M_PI / 8.0),
+              kCenter(1) + (kRadius + 1.0) * std::sin(kTheta0 + M_PI / 8.0),
+              6.0),
+          lateral_bounds, height_bounds),
+      Vector3<double>(kRadius * (M_PI / 8.0), -1.0, 6.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(
+          Vector3<double>(
+              kCenter(0) +
+                  (kRadius - 2.0) *
+                      std::cos(kTheta0 + kDTheta / 2.0 + M_PI / 8.0),
+              kCenter(1) +
+                  (kRadius - 2.0) *
+                      std::sin(kTheta0 + kDTheta / 2.0 + M_PI / 8.0),
+              3.0),
+          lateral_bounds, height_bounds),
+      Vector3<double>(kRadius * (kDTheta / 2.0 + M_PI / 8.0), 2.0, 3.0),
+      kVeryExact));
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -1,0 +1,97 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/multilane/line_road_curve.h"
+/* clang-format on */
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+class MultilaneLineRoadCurveTest : public ::testing::Test {
+ protected:
+  const Vector2<double> kOrigin{10.0, 10.0};
+  const Vector2<double> kDirection{10.0, 10.0};
+  const CubicPolynomial zp;
+  const double kHeading{M_PI / 4.0};
+  const double kHeadingDerivative{0.0};
+  const double kVeryExact{1e-12};
+  const api::RBounds lateral_bounds{-10.0, 10.0};
+  const api::HBounds elevation_bounds{0.0, 10.0};
+};
+
+// Checks line reference curve interpolations, derivatives, and lengths.
+TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
+  const LineRoadCurve dut(kOrigin, kDirection, zp, zp);
+  // Checks the length.
+  EXPECT_NEAR(dut.length(),
+              std::sqrt(kDirection.x() * kDirection.x() +
+                        kDirection.y() * kDirection.y()),
+              kVeryExact);
+  // Check the evaluation of xy at different p values.
+  EXPECT_TRUE(
+      CompareMatrices(dut.xy_of_p(0.0), kOrigin, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(dut.xy_of_p(0.5),
+                              kOrigin + 0.5 * kDirection, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(dut.xy_of_p(1.0),
+                              kOrigin + kDirection, kVeryExact));
+  // Check the derivative of xy with respect to p at different p values.
+  EXPECT_TRUE(CompareMatrices(dut.xy_dot_of_p(0.0), kDirection,
+                              kVeryExact));
+  EXPECT_TRUE(CompareMatrices(dut.xy_dot_of_p(0.5), kDirection,
+                              kVeryExact));
+  EXPECT_TRUE(CompareMatrices(dut.xy_dot_of_p(1.0), kDirection,
+                              kVeryExact));
+  // Check the heading at different p values.
+  EXPECT_NEAR(dut.heading_of_p(0.0), kHeading, kVeryExact);
+  EXPECT_NEAR(dut.heading_of_p(0.5), kHeading, kVeryExact);
+  EXPECT_NEAR(dut.heading_of_p(1.0), kHeading, kVeryExact);
+  // Check the heading derivative of p at different p values.
+  EXPECT_NEAR(dut.heading_dot_of_p(0.0), kHeadingDerivative, kVeryExact);
+  EXPECT_NEAR(dut.heading_dot_of_p(0.5), kHeadingDerivative, kVeryExact);
+  EXPECT_NEAR(dut.heading_dot_of_p(1.0), kHeadingDerivative, kVeryExact);
+}
+
+// Checks that LineRoadCurve::IsValid() returns true.
+TEST_F(MultilaneLineRoadCurveTest, IsValidTest) {
+  const LineRoadCurve dut(kOrigin, kDirection, zp, zp);
+  EXPECT_TRUE(dut.IsValid(lateral_bounds, elevation_bounds));
+}
+
+// Checks the validity of the surface for different lateral bounds and
+// geometries.
+TEST_F(MultilaneLineRoadCurveTest, ToCurveFrameTest) {
+  const LineRoadCurve dut(kOrigin, kDirection, zp, zp);
+  // Checks over the base line.
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(Vector3<double>(10.0, 10.0, 0.0), lateral_bounds,
+                       elevation_bounds),
+      Vector3<double>(0.0, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(Vector3<double>(20.0, 20.0, 0.0), lateral_bounds,
+                       elevation_bounds),
+      Vector3<double>(std::sqrt(2) * 10.0, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(Vector3<double>(15.0, 15.0, 0.0), lateral_bounds,
+                       elevation_bounds),
+      Vector3<double>(std::sqrt(2) * 5.0, 0.0, 0.0), kVeryExact));
+  // Check with lateral and vertical deviation.
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(Vector3<double>(11.0, 12.0, 5.0), lateral_bounds,
+                       elevation_bounds),
+      Vector3<double>(2.12132034355964, 0.707106781186547, 5.0), kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      dut.ToCurveFrame(Vector3<double>(11.0, 10.0, 7.0), lateral_bounds,
+                       elevation_bounds),
+      Vector3<double>(0.707106781186547, -0.707106781186547, 7.0), kVeryExact));
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
As part of the Multilane implementation, this is a first step to start decoupling the geometry management from the Segment - Lane logic. `RoadCurve` class defines the necessary interface for a `Segment` to manage curves for each `Lane`. A `Lane` will be able to consume a `RoadCurve` implementation.

A `RoadCurve` is a composition of three curve functions. `elevation` and `superelevation` are both  `CubicPolynomial` objects that describe how the trajectory modifies its height with respect to the plane z=0 in world coordinates (`maliput::api::GeoPosition` frame)  and the lateral slope angle at each point on the path length. In addition, it provides an interface (similar to what `multilane::Lane` has) to define the reference curve (curve over the _z=0_ plane). Implementing the position interpolation and its derivative, and the heading interpolation and its derivative will be enough to describe the reference curve. In addition, two more methods are requested, `RoadCurve::ToCurveFrame()` and `RoadCurve::IsValid()`. The former provides world coordinate frame to the composed curve's frame (the same as `maliput::api::LanePosition`). The latter will be true whenever the geometry does not produce singularities in the `(s,r,h)` frame. 

Most of the code is copy-paste from current `LineLane` and `ArcLane` classes. Also `CubicPolynomial` class has been moved to its own header file.

This PR is a first step towards deprecating `LineLane` and `ArcLane` classes and changing the `Lane` class implementation. In addition, `Segment` class will have a reference `RoadCurve` and manage its `Lane`'s geometries.

This PR relates to issues: #6754 #4934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6822)
<!-- Reviewable:end -->
