### PR TITLE
Add targets for vtkIOXML module to `vtk.bzl`

### DIFF
--- a/drake/perception/estimators/dev/BUILD
+++ b/drake/perception/estimators/dev/BUILD
@@ -5,6 +5,7 @@ load(
     "//tools:drake.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_test",
 )
 load("//tools:lint.bzl", "add_lint_tests")
 
@@ -87,6 +88,16 @@ drake_cc_googletest(
         "//drake/multibody/rigid_body_plant:create_load_robot_message",
         "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/solvers:mathematical_program",
+    ],
+)
+
+drake_cc_test(
+    name = "tmp_vtk_io_xml_test",
+    data = [
+        "test/tmp_vtk_io_xml_test.vtp",
+    ],
+    deps = [
+        "@vtk//:vtkIOXML",
     ],
 )
 

--- a/drake/perception/estimators/dev/test/tmp_vtk_io_xml_test.cc
+++ b/drake/perception/estimators/dev/test/tmp_vtk_io_xml_test.cc
@@ -1,0 +1,19 @@
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkXMLPolyDataReader.h>
+
+// Read a point cloud.
+// Derived from VTK examples, VTK/Examples/Cxx/...:
+//  * IO/ReadPolyData
+//  * IO/WriteVTP
+//  * PolyData/PointSource
+
+int main() {
+  // Read a file that was generated with a random point cloud.
+  const char* filename = "tmp_vtk_io_xml_test.vtp";
+  vtkSmartPointer<vtkXMLPolyDataReader> reader =
+    vtkSmartPointer<vtkXMLPolyDataReader>::New();
+  reader->SetFileName(filename);
+  reader->Update();
+  return 0;
+}

--- a/drake/perception/estimators/dev/test/tmp_vtk_io_xml_test.vtp
+++ b/drake/perception/estimators/dev/test/tmp_vtk_io_xml_test.vtp
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+  <PolyData>
+    <Piece NumberOfPoints="50"                   NumberOfVerts="1"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="0"                   >
+      <PointData>
+      </PointData>
+      <CellData>
+      </CellData>
+      <Points>
+        <DataArray type="Float32" Name="Points" NumberOfComponents="3" format="appended" RangeMin="1.4376629654"         RangeMax="4.9799350443"         offset="0"                   />
+      </Points>
+      <Verts>
+        <DataArray type="Int64" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="840"                 />
+        <DataArray type="Int64" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="988"                 />
+      </Verts>
+      <Lines>
+        <DataArray type="Int64" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="1028"                />
+        <DataArray type="Int64" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="1044"                />
+      </Lines>
+      <Strips>
+        <DataArray type="Int64" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="1060"                />
+        <DataArray type="Int64" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="1076"                />
+      </Strips>
+      <Polys>
+        <DataArray type="Int64" Name="connectivity" format="appended" RangeMin=""                     RangeMax=""                     offset="1092"                />
+        <DataArray type="Int64" Name="offsets" format="appended" RangeMin=""                     RangeMax=""                     offset="1108"                />
+      </Polys>
+    </Piece>
+  </PolyData>
+  <AppendedData encoding="base64">
+   _AQAAAACAAABYAgAAYwIAAA==eJwBWAKn/S2VA78RUDs/fP+SQCwhqr5KEb6/JTisv59Jrr/rfo2+ZSe9PhaUvr9Q8fs/wCoqQLtG0z+Nf1m/DmeAQMMOkUBu9ug/uj3XPji3OMBDTitAOJH2P1CuAkCtpgBAG0uDPyFagz0lSLI/AcMiwHSMpL9MMnZA1I6yv7hI/D8gdqa/zrl+Pliamb//QwhAH8snwNqJRcBjPns/SwZFv6F1CL9H/wU+dkKRQGm4EkAQ5G/A0QgivxHKlb9NFGVAWc/GvjsQIT//6oY/A2CFwChWfcDJldy/H1L/P1o8GMAiFiTAQ4VhwPeXDL84+iBASU1bvpUK4b8fDV/Ad/olwGmtMMDYgt4/kWY9vERwf8Ba5u6+bdYSQAnS6D/gjgRALSkGwAdmLsA1016+xApGQBB2akDtHpy/Mo2ev2S5AMC8JkhAjObMPyCx07+iKoFAomP3vsrRIMA5HhW/NVeHwAd00T/lGxHAXFoNwHiUH0Bxlk1APy53PvY6Db+h+jrAhzhaQHxyhj/53be95UJtQIbqEb49uADASulGwDlp7z8JLWe/DuyKQNMGE0C60cm/oVQjwGIl679b7vM+TUGBQC3oS8A4ERhAXIQLwIevA0AQ+h0/k7tnPpZzO8BJY3O+YvoLPw6G1L8QGqW+odgUQB59gMBPC4w/q2WHv9th6D+xcoq/dPk6wEAaicBDWzs/Ko4bwPKp5D/F3a4/AoSLwFkS179+FA3AtLVaP2lJ8b/zgTe/wTQYQCZPPMDtwj1AfJAKvrwzBEDmVY2/E288P2D5N0DYr6q+oJRgwDupFmI=AQAAAACAAACQAQAAXQAAAA==eJwtxdcCgQAAAMDMyGggsikr+/9/zoO7lwuCv4abbrntjrsO3XPfkQceeuSxYydOnXniqWfOPffChZdeee2Nt95574OPLl355LMvvvrm2nc//PTLb3/89Q+MdgTKAQAAAACAAAAIAAAACwAAAA==eJwzYoAAAAGYADM=AAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAAAAAAAACAAAAAAAAA
+  </AppendedData>
+</VTKFile>

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -26,7 +26,7 @@ Argument:
 VTK_MAJOR_MINOR_VERSION = "8.0"
 
 def _vtk_cc_library(os_name, name, hdrs = None, visibility = None, deps = None,
-                    header_only = False):
+                    header_only = False, linkopts = []):
     hdr_paths = []
 
     if hdrs:
@@ -46,14 +46,13 @@ def _vtk_cc_library(os_name, name, hdrs = None, visibility = None, deps = None,
     if not deps:
         deps = []
 
-    linkopts = []
     srcs = []
 
     if os_name == "mac os x":
         srcs = ["empty.cc"]
 
         if not header_only:
-            linkopts = [
+            linkopts = linkopts + [
                 "-L/usr/local/opt/vtk@{}/lib".format(VTK_MAJOR_MINOR_VERSION),
                 "-l{}-{}".format(name, VTK_MAJOR_MINOR_VERSION),
             ]
@@ -121,6 +120,11 @@ def _impl(repository_ctx):
     # those used directly or indirectly by Drake.
 
     # TODO(jamiesnape): Create a script to help generate the targets.
+
+    # To see what the VTK module dependencies are, you can inspect VTK's source
+    # tree. For example, for vtkIOXML and vtkIOXMLParser:
+    #   VTK/IO/XML/module.cmake
+    #   VTK/IO/XMLParser/module.cmake
 
     file_content = _vtk_cc_library(
         repository_ctx.os.name,
@@ -372,6 +376,40 @@ def _impl(repository_ctx):
         ],
     )
 
+    # See: VTK/IO/XMLParser/{*.h,module.cmake}
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOXMLParser",
+        deps = [
+            ":vtkCommonCore",
+            ":vtkCommonDataModel",
+            ":vtkexpat",
+            ":vtkIOCore",
+            ":vtksys",
+        ],
+    )
+
+    # See: VTK/IO/XML/{*.h,module.cmake}
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkIOXML",
+        hdrs = [
+            "vtkIOXMLModule.h",
+            "vtkXMLDataReader.h",
+            "vtkXMLPolyDataReader.h",
+            "vtkXMLReader.h",
+            "vtkXMLUnstructuredDataReader.h",
+        ],
+        deps = [
+            ":vtkCommonCore",
+            ":vtkCommonDataModel",
+            ":vtkCommonExecutionModel",
+            ":vtkIOCore",
+            ":vtkIOXMLParser",
+            ":vtksys",
+        ],
+    )
+
     file_content += _vtk_cc_library(
         repository_ctx.os.name,
         "vtkIOGeometry",
@@ -479,6 +517,17 @@ def _impl(repository_ctx):
             ":vtkRenderingCore",
             ":vtkglew",
         ],
+    )
+
+    # The packaged version of VTK (both Ubuntu and Mac) uses the system version
+    # of expat, and do not include `vtkexpat` as a shared library.
+    file_content += _vtk_cc_library(
+        repository_ctx.os.name,
+        "vtkexpat",
+        linkopts = [
+            "-lexpat",
+        ],
+        header_only = True,
     )
 
     if repository_ctx.os.name == "mac os x":


### PR DESCRIPTION
This adds `vtkIOXML` to `vtk.bzl` for using a concrete `vtkPolyDataReader`.

Tested link failures briefly with the following script:
```bash
#!/bin/bash
set -e -u

mkdir -p tmp
cd tmp

cat > BUILD <<EOF
cc_test(
    name = "vtk_io_test",
    srcs = ["vtk_io_test.cc"],
    deps = [
        "@vtk//:vtkIOXML",
    ],
)
EOF

cat > vtk_io_test.cc <<EOF
int main() {}
EOF

bazel run :vtk_io_test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6825)
<!-- Reviewable:end -->
