### PR TITLE
Revert "Add output projection to pid controller"

### DIFF
--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -18,17 +18,7 @@ PidController<T>::PidController(const Eigen::VectorXd& kp,
                     ki, kd) {}
 
 template <typename T>
-PidController<T>::PidController(const MatrixX<double>& state_projection,
-                                const Eigen::VectorXd& kp,
-                                const Eigen::VectorXd& ki,
-                                const Eigen::VectorXd& kd)
-    : PidController(state_projection,
-                    MatrixX<double>::Identity(kp.size(), kp.size()), kp, ki,
-                    kd) {}
-
-template <typename T>
-PidController<T>::PidController(const MatrixX<double>& state_projection,
-                                const MatrixX<double>& output_projection,
+PidController<T>::PidController(const MatrixX<double>& state_selector,
                                 const Eigen::VectorXd& kp,
                                 const Eigen::VectorXd& ki,
                                 const Eigen::VectorXd& kd)
@@ -37,34 +27,18 @@ PidController<T>::PidController(const MatrixX<double>& state_projection,
       ki_(ki),
       kd_(kd),
       num_controlled_q_(kp.size()),
-      num_full_state_(state_projection.cols()),
-      state_projection_(state_projection),
-      output_projection_(output_projection) {
-  if (kp_.size() != kd_.size() || kd_.size() != ki_.size()) {
-    throw std::logic_error("Gains must have equal length: |Kp| = " +
-                           std::to_string(kp_.size()) + ", |Ki| = " +
-                           std::to_string(ki_.size()) + ", |Kd| = " +
-                           std::to_string(kd_.size()));
-  }
-  if (state_projection_.rows() != 2 * num_controlled_q_) {
-    throw std::logic_error(
-        "State projection row dimension mismatch, expecting " +
-        std::to_string(2 * num_controlled_q_) + ", is " +
-        std::to_string(state_projection_.rows()));
-  }
-  if (output_projection_.cols() != kp_.size()) {
-    throw std::logic_error(
-        "Output projection column dimension mismatch, expecting " +
-        std::to_string(kp_.size()) + ", is " +
-        std::to_string(output_projection_.cols()));
-  }
+      num_full_state_(state_selector.cols()),
+      state_selector_(state_selector) {
+  DRAKE_DEMAND(kp_.size() == kd_.size());
+  DRAKE_DEMAND(kd_.size() == ki_.size());
+  DRAKE_DEMAND(state_selector_.rows() == 2 * num_controlled_q_);
 
   this->DeclareContinuousState(num_controlled_q_);
 
   output_index_control_ =
-      this->DeclareVectorOutputPort(BasicVector<T>(output_projection_.rows()),
-                                    &PidController<T>::CalcControl)
-          .get_index();
+      this->DeclareVectorOutputPort(
+          BasicVector<T>(num_controlled_q_),
+          &PidController<T>::CalcControl).get_index();
 
   input_index_state_ =
       this->DeclareInputPort(kVectorValued, num_full_state_).get_index();
@@ -76,8 +50,11 @@ PidController<T>::PidController(const MatrixX<double>& state_projection,
 template <typename T>
 template <typename U>
 PidController<T>::PidController(const PidController<U>& other)
-    : PidController(other.state_projection_, other.output_projection_,
-                    other.kp_, other.ki_, other.kd_) {}
+    : PidController(
+          other.state_selector_,
+          other.kp_,
+          other.ki_,
+          other.kd_) {}
 
 template <typename T>
 void PidController<T>::DoCalcTimeDerivatives(
@@ -90,7 +67,7 @@ void PidController<T>::DoCalcTimeDerivatives(
   // The derivative of the continuous state is the instantaneous position error.
   VectorBase<T>* const derivatives_vector = derivatives->get_mutable_vector();
   const VectorX<T> controlled_state_diff =
-      state_d - (state_projection_.cast<T>() * state);
+      state_d - (state_selector_.cast<T>() * state);
   derivatives_vector->SetFromVector(
       controlled_state_diff.head(num_controlled_q_));
 }
@@ -105,7 +82,7 @@ void PidController<T>::CalcControl(const Context<T>& context,
 
   // State error.
   const VectorX<T> controlled_state_diff =
-      state_d - (state_projection_.cast<T>() * state);
+      state_d - (state_selector_.cast<T>() * state);
 
   // Intergral error, which is stored in the continuous state.
   const VectorBase<T>& state_vector = context.get_continuous_state_vector();
@@ -114,12 +91,11 @@ void PidController<T>::CalcControl(const Context<T>& context,
 
   // Sets output to the sum of all three terms.
   control->SetFromVector(
-      output_projection_.cast<T>() *
-      ((kp_.array() * controlled_state_diff.head(num_controlled_q_).array())
-           .matrix() +
-       (kd_.array() * controlled_state_diff.tail(num_controlled_q_).array())
-           .matrix() +
-       (ki_.array() * state_block.array()).matrix()));
+      (kp_.array() * controlled_state_diff.head(num_controlled_q_).array())
+          .matrix() +
+      (kd_.array() * controlled_state_diff.tail(num_controlled_q_).array())
+          .matrix() +
+      (ki_.array() * state_block.array()).matrix());
 }
 
 // Adds a simple record-based representation of the PID controller to @p dot.

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -16,22 +16,20 @@ namespace controllers {
 // TODO(siyuanfeng): Generalize "q_d - q", e.g. for rotation.
 
 /**
- * Implements the PID controller. Given estimated state `x_in = (q_in, v_in)`,
- * the controlled state `x_c = (q_c, v_c)` is computed by `x_c = P_x * x_in`,
- * where `P_x` is a state projection matrix. The desired state
- * `x_d = (q_d, v_d)`, is in the same space as `x_c`. The output of this
- * controller is:
+ * Implements the PID controller. Given state `(q, v)`, desired state
+ * `(q_d, v_d)`, the output of this controller is
  * <pre>
- * y = P_y * (kp * (q_d - q_c) + kd * (v_d - v_c) + ki * integral(q_d - q_c)),
+ * y = kp * (q_d - q) + kd * (v_d - v) + ki * integral(q_d - q, dt),
  * </pre>
- * where `P_y` is the output projection matrix.
+ * where `integral(q_d - q, dt)` is the integrated position error.
  *
- * This system has one continuous state, which is the integral of position
- * error, two input ports: estimated state `x_in` and desired state `x_d`, and
- * one output port `y`. Note that this class assumes `|q_c| = |v_c|` and
- * `|q_d| = |v_d|`. However, `|q_c|` does not have to equal to `|q_d|`. One
- * typical use case for non-identity `P_x` and `P_y` is to select a subset of
- * state for feedback.
+ * This system has one continuous state which is the integral of position error,
+ * two input ports: estimated state (q, v) and desired state (q_d, v_d), and
+ * one output port y.
+ *
+ * Note that this class assumes |q| = |v|, and |q_d| = |v_d|. Also |q| >= |q_d|.
+ * The user can specify a selection matrix that picks the *controlled* states
+ * from (q, v) for feedback. See constructor documentations for more details.
  *
  * @tparam T The vector element type, which must be a valid Eigen scalar.
  *
@@ -49,54 +47,30 @@ class PidController : public StateFeedbackControllerInterface<T>,
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PidController)
 
   /**
-   * Constructs a PID controller. `P_x` and `P_y` are identity
-   * matrices of proper sizes. The estimated and desired state inputs are
-   * 2 * @p kp's size, and the control output has @p kp's size.
+   * Constructs a PID controller. Assumes that @p kp, @p ki and @p kd have the
+   * same size, the estimated and desired state inputs will have the size of
+   * 2 * @p kp's size, and the control output will have @p kp's size.
    * @param kp P gain.
    * @param ki I gain.
    * @param kd D gain.
-   *
-   * @throws std::logic_error if @p kp, @p ki and @p kd have different
-   * dimensions.
    */
   PidController(const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
                 const Eigen::VectorXd& kd);
 
   /**
-   * Constructs a PID controller. Calls the full constructor, with the output
-   * projection matrix `P_y` being the identity matrix.
-   * @param state_projection The state projection matrix `P_x`.
+   * Constructs a PID controller where some of the input states may not be
+   * controlled. Assumes that @p kp, @p ki and @p kd have the same size. The
+   * estimated and desired state input's size and the control output's size need
+   * to match @p feedback_selector. Note that @p state_selector only affects
+   * the estimated state input but not the desired state.
+   * @param feedback_selector, The selection matrix indicating controlled
+   * states, whose size should be 2 * @p kp's size by the size of the full
+   * state.
    * @param kp P gain.
    * @param ki I gain.
    * @param kd D gain.
-   *
-   * @throws std::logic_error if @p kp, @p ki and @p kd have different
-   * dimensions or `P_x.row() != 2 * |kp|'.
    */
-  PidController(const MatrixX<double>& state_projection,
-                const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
-                const Eigen::VectorXd& kd);
-
-  /**
-   * Constructs a PID controller. This assumes that
-   * <pre>
-   *   1. |kp| = |kd| = |ki| = |q_d| = |v_d|
-   *   2. 2 * |q_d| = P_x.rows
-   *   3. |x_in| = P_x.cols
-   *   4. |y| = P_y.rows
-   *   4. |q_d| = P_y.cols
-   * </pre>
-   *
-   * @param state_projection The state projection matrix `P_x`.
-   * @param output_projection The output projection matrix `P_y`.
-   * @param kp P gain.
-   * @param ki I gain.
-   * @param kd V gain.
-   *
-   * @throws std::logic_error if any assumption is violated.
-   */
-  PidController(const MatrixX<double>& state_projection,
-                const MatrixX<double>& output_projection,
+  PidController(const MatrixX<double>& state_selector,
                 const Eigen::VectorXd& kp, const Eigen::VectorXd& ki,
                 const Eigen::VectorXd& kd);
 
@@ -190,8 +164,7 @@ class PidController : public StateFeedbackControllerInterface<T>,
                              ContinuousState<T>* derivatives) const override;
 
  private:
-  template <typename>
-  friend class PidController;
+  template <typename> friend class PidController;
 
   static double get_single_gain(const VectorX<double>& gain) {
     if (!gain.isConstant(gain[0])) {
@@ -212,10 +185,7 @@ class PidController : public StateFeedbackControllerInterface<T>,
   const int num_full_state_{0};
   // Projection matrix from full state to controlled state, whose size is
   // num_controlled_q_ * 2 X num_full_state_.
-  const MatrixX<double> state_projection_;
-  // Output projection matrix, whose size is num_controlled_q_ by the dimension
-  // of the output port.
-  const MatrixX<double> output_projection_;
+  const MatrixX<double> state_selector_;
 
   int input_index_state_{-1};
   int input_index_desired_state_{-1};

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -5,7 +5,6 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
@@ -99,10 +98,8 @@ TEST_F(PidControllerTest, GetterVectorKd) {
 
 TEST_F(PidControllerTest, Graphviz) {
   const std::string dot = controller_.GetGraphvizString();
-  EXPECT_NE(
-      std::string::npos,
-      dot.find("label=\"PID Controller | { {<u0> x |<u1> x_d} |<y0> y}\""))
-      << dot;
+  EXPECT_NE(std::string::npos, dot.find(
+      "label=\"PID Controller | { {<u0> x |<u1> x_d} |<y0> y}\"")) << dot;
 }
 
 // Evaluates the output and asserts correctness.
@@ -116,8 +113,7 @@ TEST_F(PidControllerTest, CalcOutput) {
   const BasicVector<double>* output_vector = output_->get_vector_data(0);
   EXPECT_EQ(3, output_vector->size());
   EXPECT_EQ((kp_.array() * error_signal_.array() +
-             kd_.array() * error_rate_signal_.array())
-                .matrix(),
+            kd_.array() * error_rate_signal_.array()).matrix(),
             output_vector->get_value());
 
   // Initializes the integral to a non-zero value. A more interesting example.
@@ -125,11 +121,11 @@ TEST_F(PidControllerTest, CalcOutput) {
   integral_value << 3.0, 2.0, 1.0;
   controller_.set_integral_value(context_.get(), integral_value);
   controller_.CalcOutput(*context_, output_.get());
-  EXPECT_EQ((kp_.array() * error_signal_.array() +
-             ki_.array() * integral_value.array() +
-             kd_.array() * error_rate_signal_.array())
-                .matrix(),
-            output_vector->get_value());
+  EXPECT_EQ(
+      (kp_.array() * error_signal_.array() +
+       ki_.array() * integral_value.array() +
+       kd_.array() * error_rate_signal_.array()).matrix(),
+      output_vector->get_value());
 }
 
 // Evaluates derivatives and asserts correctness.
@@ -171,80 +167,6 @@ TEST_F(PidControllerTest, ToAutoDiff) {
   EXPECT_EQ(downcast->get_Kp_vector(), kp_);
   EXPECT_EQ(downcast->get_Ki_vector(), ki_);
   EXPECT_EQ(downcast->get_Kd_vector(), kd_);
-}
-
-GTEST_TEST(PidConstructorTest, TestThrow) {
-  // Gains size mismatch.
-  EXPECT_THROW(PidController<double>(VectorX<double>(2), VectorX<double>(3),
-                                     VectorX<double>(3)),
-               std::logic_error);
-  // State projection row != 2 * |kp|.
-  EXPECT_THROW(PidController<double>(MatrixX<double>(5, 2), VectorX<double>(3),
-                                     VectorX<double>(3), VectorX<double>(3)),
-               std::logic_error);
-  // Output projection col != |kp|
-  EXPECT_THROW(PidController<double>(MatrixX<double>(6, 2),
-                                     MatrixX<double>(3, 2), VectorX<double>(3),
-                                     VectorX<double>(3), VectorX<double>(3)),
-               std::logic_error);
-}
-
-// Tests the full version with non identity P_input and P_output.
-GTEST_TEST(PidIOProjectionTest, Test) {
-  const int num_full_q = 3;
-  const int num_controlled_q = 2;
-  const int num_control = 3;
-
-  std::srand(1234);
-
-  const VectorX<double> kp = VectorX<double>::Random(num_controlled_q);
-  const VectorX<double> kd = VectorX<double>::Random(num_controlled_q);
-  const VectorX<double> ki = VectorX<double>::Random(num_controlled_q);
-  MatrixX<double> P_input =
-      MatrixX<double>::Random(2 * num_controlled_q, 2 * num_full_q);
-  MatrixX<double> P_output =
-      MatrixX<double>::Random(num_control, num_controlled_q);
-
-  PidController<double> dut(P_input, P_output, kp, ki, kd);
-  auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
-
-  VectorX<double> q = VectorX<double>::Random(num_full_q);
-  VectorX<double> v = VectorX<double>::Random(num_full_q);
-
-  VectorX<double> x(2 * num_full_q);
-  x.head(num_full_q) = q;
-  x.tail(num_full_q) = v;
-
-  VectorX<double> q_d = VectorX<double>::Random(num_controlled_q);
-  VectorX<double> v_d = VectorX<double>::Random(num_controlled_q);
-  VectorX<double> x_d(2 * num_controlled_q);
-  x_d.head(num_controlled_q) = q_d;
-  v_d.head(num_controlled_q) = v_d;
-
-  VectorX<double> integral = VectorX<double>::Random(num_controlled_q);
-
-  // State:
-  context->FixInputPort(0, std::make_unique<BasicVector<double>>(x));
-  // Desired state:
-  context->FixInputPort(1, std::make_unique<BasicVector<double>>(x_d));
-  // Integral:
-  dut.set_integral_value(context.get(), integral);
-
-  dut.CalcOutput(*context, output.get());
-
-  VectorX<double> x_err = x_d - P_input * x;
-  auto q_err = x_err.head(num_controlled_q);
-  auto v_err = x_err.tail(num_controlled_q);
-
-  VectorX<double> output_expected = (kp.array() * q_err.array()).matrix() +
-                                    (kd.array() * v_err.array()).matrix() +
-                                    (ki.array() * integral.array()).matrix();
-  output_expected = P_output * output_expected;
-
-  EXPECT_TRUE(CompareMatrices(output_expected,
-                              output->get_vector_data(0)->get_value(), 1e-12,
-                              MatrixCompareType::absolute));
 }
 
 }  // namespace


### PR DESCRIPTION
Dear @siyuanfeng-tri,

The on-call build cop, @liangfok, believes that your PR #6794 may have broken
Drake's continuous integration build [1]. It is possible to break the build
even if your PR passed continuous integration pre-merge, because additional
platforms and tests are built post-merge.

The specific build failures under investigation are:

* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/96/
* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/95/
* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-snopt/17/
* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-memcheck-valgrind/94/
* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-memcheck-valgrind-everything/95/
* https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-memcheck-valgrind-snopt/17/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [2].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous/
[2] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6831)
<!-- Reviewable:end -->
