### PR TITLE
direct trajectory optimization cleanup

### DIFF
--- a/drake/automotive/test/trajectory_optimization_test.cc
+++ b/drake/automotive/test/trajectory_optimization_test.cc
@@ -44,12 +44,10 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
                                              kTrajectoryTimeUpperBound);
 
   // Input limits (note that the steering limit imposed by SimpleCar is larger).
-  DrivingCommand<double> lower_limit, upper_limit;
-  lower_limit.set_steering_angle(-M_PI_2);
-  lower_limit.set_acceleration(-std::numeric_limits<double>::infinity());
-  upper_limit.set_steering_angle(M_PI_2);
-  upper_limit.set_acceleration(std::numeric_limits<double>::infinity());
-  prog.AddInputBounds(lower_limit.get_value(), upper_limit.get_value());
+  DrivingCommand<symbolic::Expression> input;
+  input.SetFromVector(prog.input().cast<symbolic::Expression>());
+  prog.AddConstraintToAllKnotPoints(input.steering_angle() <= M_PI_2);
+  prog.AddConstraintToAllKnotPoints(-M_PI_2 <= input.steering_angle());
 
   // Ensure that time intervals are (relatively) evenly spaced.
   prog.AddTimeIntervalBounds(kTrajectoryTimeLowerBound / (kNumTimeSamples - 1),

--- a/drake/examples/acrobot/acrobot_run_swing_up_traj_optimization.cc
+++ b/drake/examples/acrobot/acrobot_run_swing_up_traj_optimization.cc
@@ -50,7 +50,7 @@ int do_main() {
   systems::DircolTrajectoryOptimization dircol_traj(
       acrobot.get(), *context, kNumTimeSamples, kTrajectoryTimeLowerBound,
       kTrajectoryTimeUpperBound);
-  AddSwingUpTrajectoryParams(kNumTimeSamples, x0, xG, &dircol_traj);
+  AddSwingUpTrajectoryParams(x0, xG, &dircol_traj);
 
   const double timespan_init = 4;
   auto traj_init_x =

--- a/drake/examples/acrobot/acrobot_swing_up.h
+++ b/drake/examples/acrobot/acrobot_swing_up.h
@@ -19,7 +19,6 @@ namespace acrobot {
  * between @p x0 and @p xG).
  */
 void AddSwingUpTrajectoryParams(
-    int num_time_samples,
     const Eigen::Vector4d& x0, const Eigen::Vector4d& xG,
     systems::DircolTrajectoryOptimization*);
 

--- a/drake/examples/pendulum/pendulum_swing_up.cc
+++ b/drake/examples/pendulum/pendulum_swing_up.cc
@@ -23,16 +23,16 @@ namespace pendulum {
 void AddSwingUpTrajectoryParams(const Eigen::Vector2d& x0,
                                 const Eigen::Vector2d& xG,
                                 systems::DircolTrajectoryOptimization* dircol) {
-  const int kTorqueLimit = 3;  // Arbitrary, taken from PendulumPlant.m.
-  const drake::Vector1d umin(-kTorqueLimit);
-  const drake::Vector1d umax(kTorqueLimit);
-  dircol->AddInputBounds(umin, umax);
+  auto u = dircol->input();
+
+  const double kTorqueLimit = 3.0;  // N*m.
+  dircol->AddConstraintToAllKnotPoints(-kTorqueLimit <= u(0));
+  dircol->AddConstraintToAllKnotPoints(u(0) <= kTorqueLimit);
 
   dircol->AddLinearConstraint(dircol->initial_state() == x0);
   dircol->AddLinearConstraint(dircol->final_state() == xG);
 
   const double R = 10;  // Cost on input "effort".
-  auto u = dircol->input();
   dircol->AddRunningCost((R * u) * u);
 }
 

--- a/drake/systems/trajectory_optimization/direct_collocation.h
+++ b/drake/systems/trajectory_optimization/direct_collocation.h
@@ -12,7 +12,7 @@ namespace drake {
 namespace systems {
 
 /**
- * DircolTrajectoryOptimization implements a direct colocation
+ * DircolTrajectoryOptimization implements a direct collocation
  * approach to trajectory optimization, as described in
  *   C. R. Hargraves and S. W. Paris. Direct trajectory optimization using
  *    nonlinear programming and collocation. J Guidance, 10(4):338-342,
@@ -56,8 +56,6 @@ class DircolTrajectoryOptimization : public DirectTrajectoryOptimization {
 
  private:
   void DoAddRunningCost(const symbolic::Expression& e) override;
-
-  void DoAddRunningCost(std::shared_ptr<solvers::Cost> cost) override;
 
   const System<double>* system_{nullptr};
   const std::unique_ptr<Context<double>> context_{nullptr};

--- a/drake/systems/trajectory_optimization/direct_trajectory_optimization.cc
+++ b/drake/systems/trajectory_optimization/direct_trajectory_optimization.cc
@@ -54,20 +54,6 @@ DirectTrajectoryOptimization::DirectTrajectoryOptimization(
   AddLinearConstraint(h_vars_.array() >= 0.0);
 }
 
-void DirectTrajectoryOptimization::AddInputBounds(
-    const Eigen::VectorXd& lower_bound, const Eigen::VectorXd& upper_bound) {
-  DRAKE_ASSERT(lower_bound.size() == num_inputs_);
-  DRAKE_ASSERT(upper_bound.size() == num_inputs_);
-
-  Eigen::VectorXd lb_all(num_inputs_ * N_);
-  Eigen::VectorXd ub_all(num_inputs_ * N_);
-  for (int i = 0; i < N_; i++) {
-    lb_all.segment(num_inputs_ * i, num_inputs_) = lower_bound;
-    ub_all.segment(num_inputs_ * i, num_inputs_) = upper_bound;
-  }
-  AddBoundingBoxConstraint(lb_all, ub_all, u_vars_);
-}
-
 void DirectTrajectoryOptimization::AddTimeIntervalBounds(
     const Eigen::VectorXd& lower_bound, const Eigen::VectorXd& upper_bound) {
   AddBoundingBoxConstraint(lower_bound, upper_bound, h_vars_);
@@ -86,61 +72,6 @@ void DirectTrajectoryOptimization::AddTimeIntervalBounds(
 void DirectTrajectoryOptimization::AddTimeIntervalBounds(double lower_bound,
                                                          double upper_bound) {
   AddBoundingBoxConstraint(lower_bound, upper_bound, h_vars_);
-}
-
-namespace {
-/// Since the final cost evaluation needs a total time, we need a
-/// wrapper which will calculate the total time from the individual
-/// time steps and mangle the output appropriately.
-class FinalCostWrapper : public solvers::Cost {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FinalCostWrapper)
-
-  FinalCostWrapper(int num_time_samples, int num_states,
-                   std::shared_ptr<solvers::Cost> cost)
-      : Cost((num_time_samples - 1) + num_states),
-        num_time_samples_(num_time_samples),
-        num_states_(num_states),
-        cost_(cost) {}
-
- protected:
-  void DoEval(const Eigen::Ref<const Eigen::VectorXd>&,
-              Eigen::VectorXd&) const override {
-    // TODO(sam.creasey) If we actually need this, we could cut and
-    // paste most of the implementation below (or maybe delegate to a
-    // templated version).  I don't expect that scenario to occur.
-    throw std::runtime_error("Non-Taylor constraint eval not implemented.");
-  }
-
-  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
-              AutoDiffVecXd& y) const override {
-    DRAKE_ASSERT(x.rows() == (num_time_samples_ - 1) + num_states_);
-
-    AutoDiffVecXd wrapped_x(num_states_ + 1);
-    wrapped_x(0) = x.head(num_time_samples_ - 1).sum();
-    wrapped_x.tail(num_states_) = x.tail(num_states_);
-    DRAKE_ASSERT(wrapped_x(0).derivatives().rows() ==
-                 x(0).derivatives().rows());
-
-    cost_->Eval(wrapped_x, y);
-    DRAKE_ASSERT(y(0).derivatives().rows() == x(0).derivatives().rows());
-  };
-
- private:
-  const int num_time_samples_;
-  const int num_states_;
-  std::shared_ptr<solvers::Cost> cost_;
-};
-
-}  // namespace
-
-// We just use a generic constraint here since we need to mangle the
-// input and output anyway.
-void DirectTrajectoryOptimization::AddFinalCost(
-    std::shared_ptr<solvers::Cost> constraint) {
-  auto wrapper =
-      std::make_shared<FinalCostWrapper>(N_, num_states_, constraint);
-  AddCost(wrapper, {h_vars_, x_vars_.tail(num_states_)});
 }
 
 void DirectTrajectoryOptimization::GetInitialVars(
@@ -224,9 +155,9 @@ std::vector<Eigen::MatrixXd> DirectTrajectoryOptimization::GetStateVector()
   return states;
 }
 
-symbolic::Expression
-DirectTrajectoryOptimization::SubstitutePlaceholderVariables(
-    const symbolic::Expression& e, int interval_index) const {
+symbolic::Substitution
+DirectTrajectoryOptimization::ConstructPlaceholderVariableSubstitution(
+    int interval_index) const {
   symbolic::Substitution sub;
 
   // time(i) is the sum of h intervals 0...(i-1)
@@ -240,7 +171,19 @@ DirectTrajectoryOptimization::SubstitutePlaceholderVariables(
   for (int i = 0; i < num_inputs_; i++)
     sub.emplace(placeholder_u_vars_(i),
                 u_vars_(interval_index * num_inputs_ + i));
-  return e.Substitute(sub);
+  return sub;
+}
+
+symbolic::Expression
+DirectTrajectoryOptimization::SubstitutePlaceholderVariables(
+    const symbolic::Expression& e, int interval_index) const {
+  return e.Substitute(ConstructPlaceholderVariableSubstitution(interval_index));
+}
+
+symbolic::Formula
+DirectTrajectoryOptimization::SubstitutePlaceholderVariables(
+    const symbolic::Formula& f, int interval_index) const {
+  return f.Substitute(ConstructPlaceholderVariableSubstitution(interval_index));
 }
 
 void DirectTrajectoryOptimization::GetResultSamples(

--- a/drake/systems/trajectory_optimization/direct_trajectory_optimization.h
+++ b/drake/systems/trajectory_optimization/direct_trajectory_optimization.h
@@ -18,22 +18,21 @@
 namespace drake {
 namespace systems {
 
-/**
- * DirectTrajectoryOptimization is an abstract class for direct method
- * approaches to trajectory optimization.
- *
- * Subclasses must implement the abstract method:
- *  DoAddRunningCost()
- * and should add any dynamic constraints in their constructor.
- *
- * This class assumes that there are a fixed number (N) time steps/samples, and
- * that the trajectory is discretized into timesteps h (N-1 of these), state x
- * (N of these), and control input u (N of these).
- *
- * To maintain nominal sparsity in the optimization programs, this
- * implementation assumes that all constraints and costs are
- * time-invariant.
- */
+///
+/// DirectTrajectoryOptimization is an abstract class for direct method
+/// approaches to trajectory optimization.
+///
+/// Subclasses must implement the abstract method:
+///  DoAddRunningCost()
+/// and should add any dynamic constraints in their constructor.
+///
+/// This class assumes that there are a fixed number (N) time steps/samples, and
+/// that the trajectory is discretized into timesteps h (N-1 of these), state x
+/// (N of these), and control input u (N of these).
+///
+/// To maintain nominal sparsity in the optimization programs, this
+/// implementation assumes that all constraints and costs are
+/// time-invariant.
 class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DirectTrajectoryOptimization)
@@ -123,121 +122,54 @@ class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
     DoAddRunningCost(g(0, 0));
   }
 
-  /**
-   * Adds an integrated cost to all time steps.
-   *
-   * @param f A callable which meets the requirments of
-   * MathematicalProgram::AddCost().
-   */
-  template <typename F>
-  typename std::enable_if<solvers::detail::is_cost_functor_candidate<F>::value,
-                          std::shared_ptr<solvers::Cost>>::type
-  AddRunningCostFunc(F&& f) {
-    auto c = solvers::MakeFunctionCost(std::forward<F>(f));
-    AddRunningCost(c);
-    return c;
-  }
-
-  // TODO(russt): Remove the methods below that add constraints without
-  // requesting the variable list to be passed in.  We should force the user
-  // to specify the variables to provide clarity and robustness.
-  // The "add to a list of times" utilities are still useful... we can replace
-  // them with methods of the form AddCost(..., MatrixXDecisionVariable), which
-  // adds the same constraint to each column of the variable matrix.
-
-  // Adds an integrated cost to all time steps.
-  //
-  // @param constraint A constraint which expects a timestep, state, and input
-  // as the elements of x when Eval is invoked.
-  void AddRunningCost(std::shared_ptr<solvers::Cost> cost) {
-    DoAddRunningCost(cost);
-  }
-
-  /**
-   * Add upper and lower bounds on the input values.  Calling this
-   * function multiple times will add additional bounds on the input
-   * rather than resetting any bounds from previous invocations.
-   */
-  void AddInputBounds(const Eigen::VectorXd& lower_bound,
-                      const Eigen::VectorXd& upper_bound);
-
-  /**
-   * Add a constraint on the input at the specified time indices.
-   *
-   * @param constraint The constraint to be applied.
-   *
-   * @param time_indices Apply the constraints only at these time
-   * indices (zero offset).
-   */
-  template <typename ConstraintT>
-  void AddInputConstraint(std::shared_ptr<ConstraintT> constraint,
-                          const std::vector<int>& time_indices) {
-    for (const int i : time_indices) {
-      DRAKE_ASSERT(i < N_);
-      AddConstraint(constraint, u_vars_.segment(i * num_inputs_, num_inputs_));
+  /// Adds a constraint to all knot points, where any instances of time(),
+  /// state(), and/or input() placeholder variables are substituted with the
+  /// relevant variables for each current time index.
+  void AddConstraintToAllKnotPoints(const symbolic::Formula& f) {
+    for (int i = 0; i < N_; i++) {
+      // TODO(russt): update this to AddConstraint once MathematicalProgram
+      // supports AddConstraint for Formulas.
+      // For now, non-linear constraints can be added by users by simply adding
+      // the constraint manually for each
+      // time index in a loop.
+      AddLinearConstraint(SubstitutePlaceholderVariables(f, i));
     }
   }
 
-  /**
-   * Add a constraint on the state at the specified time indices.
-   *
-   * @param constraint The constraint to be applied.
-   *
-   * @param time_indices Apply the constraints only at these time
-   * indices (zero offset).
-   */
-  template <typename ConstraintT>
-  void AddStateConstraint(std::shared_ptr<ConstraintT> constraint,
-                          const std::vector<int>& time_indices) {
-    for (const int i : time_indices) {
-      DRAKE_ASSERT(i < N_);
-      AddConstraint(constraint, x_vars_.segment(i * num_states_, num_states_));
-    }
-  }
+  // TODO(russt): Add additional cost/constraint wrappers that assign e.g.
+  // non-symbolic costs (like QuadraticCost)
+  // by taking in a list of vars that could contain placeholder vars, or that
+  // assign costs/constraints to a set of
+  // interval indices.
 
-  /**
-   * Add bounds on a set of time intervals, such that
-   * lower_bound(i) <= h_vars_(interval_indices[i]) <= upper_bound(i)
-   * where h_vars_[j] is the time interval between j'th and j+1'th sample
-   * (starting
-   * from 0'th sample).
-   * @param lower_bound  A vector of lower bounds.
-   * @param upper_bound  A vector of upper bounds.
-   * @param interval_indices A vector of interval indices.
-   */
+  /// Add bounds on a set of time intervals, such that
+  /// lower_bound(i) <= h_vars_(interval_indices[i]) <= upper_bound(i)
+  /// where h_vars_[j] is the time interval between j'th and j+1'th sample
+  /// (starting
+  /// from 0'th sample).
+  /// @param lower_bound  A vector of lower bounds.
+  /// @param upper_bound  A vector of upper bounds.
+  /// @param interval_indices A vector of interval indices.
   void AddTimeIntervalBounds(const Eigen::VectorXd& lower_bound,
                              const Eigen::VectorXd& upper_bound,
                              const std::vector<int>& interval_indices);
 
-  /**
-   * Add bounds on all time intervals, such that
-   * lower_bound(i) <= h_vars_(i) <= upper_bound(i)
-   * where h_vars_[i] is the time interval between i'th and i+1'th sample
-   * (starting
-   * from 0'th sample).
-   * @param lower_bound  A vector of lower bounds.
-   * @param upper_bound  A vector of upper bounds.
-   */
+  /// Add bounds on all time intervals, such that
+  /// lower_bound(i) <= h_vars_(i) <= upper_bound(i)
+  /// where h_vars_[i] is the time interval between i'th and i+1'th sample
+  /// (starting
+  /// from 0'th sample).
+  /// @param lower_bound  A vector of lower bounds.
+  /// @param upper_bound  A vector of upper bounds.
   void AddTimeIntervalBounds(const Eigen::VectorXd& lower_bound,
                              const Eigen::VectorXd& upper_bound);
 
-  /**
-   * Add bounds on all time intervals, such that
-   * lower_bound <= h_vars_(i) <= upper_bound
-   * for all time intervals.
-   * @param lower_bound  A scalar double lower bound.
-   * @param upper_bound  A scalar double upper bound.
-   */
+  /// Add bounds on all time intervals, such that
+  /// lower_bound <= h_vars_(i) <= upper_bound
+  /// for all time intervals.
+  /// @param lower_bound  A scalar double lower bound.
+  /// @param upper_bound  A scalar double upper bound.
   void AddTimeIntervalBounds(double lower_bound, double upper_bound);
-
-  /**
-   * Add a cost to the final state and total time.
-   *
-   * @param cost A cost which expects total time as the
-   * first element of x when Eval is invoked, followed by the final
-   * state (num_states additional elements).
-   */
-  void AddFinalCost(std::shared_ptr<solvers::Cost> cost);
 
   /// Adds a cost to the final time, of the form
   ///    @f[ cost = e(t,x,u), @f]
@@ -258,76 +190,51 @@ class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
     AddFinalCost(e(0, 0));
   }
 
-  /**
-   * Add a cost to the final state and total time.
-   *
-   * @param f A callable which meets the requirments of
-   * MathematicalProgram::AddCost().
-   */
-  template <typename F>
-  typename std::enable_if<solvers::detail::is_cost_functor_candidate<F>::value,
-                          std::shared_ptr<solvers::Cost>>::type
-  AddFinalCostFunc(F&& f) {
-    auto c = solvers::MakeFunctionCost(std::forward<F>(f));
-    AddFinalCost(c);
-    return c;
-  }
-
-  /**
-   * Solve the nonlinear program and return the resulting trajectory.
-   *
-   * @param timespan_init The initial guess for the timespan of
-   * the resulting trajectory.
-   *
-   * @param traj_init_u Initial guess for trajectory for control
-   * input. The number of rows for each segment in @p traj_init_u must
-   * be equal to num_inputs (the first param of the constructor).
-   *
-   * @param traj_init_x Initial guess for trajectory for state
-   * input. The number of rows for each segment in @p traj_init_x must
-   * be equal to num_states (the second param of the constructor).
-   */
+  /// Solve the nonlinear program and return the resulting trajectory.
+  ///
+  /// @param timespan_init The initial guess for the timespan of
+  /// the resulting trajectory.
+  ///
+  /// @param traj_init_u Initial guess for trajectory for control
+  /// input. The number of rows for each segment in @p traj_init_u must
+  /// be equal to num_inputs (the first param of the constructor).
+  ///
+  /// @param traj_init_x Initial guess for trajectory for state
+  /// input. The number of rows for each segment in @p traj_init_x must
+  /// be equal to num_states (the second param of the constructor).
   solvers::SolutionResult SolveTraj(
       double timespan_init, const PiecewisePolynomial<double>& traj_init_u,
       const PiecewisePolynomial<double>& traj_init_x);
   // TODO(Lucy-tri) If timespan_init has any relationship to
   // trajectory_time_{lower,upper}_bound, then add doc and asserts.
 
-  /**
-   * Extract the result of the trajectory solution as a set of
-   * discrete samples.  Output matrices contain one set of input/state
-   * per column, and the number of columns is equal to the number of
-   * time samples.  @p times will be populated with the times
-   * corresponding to each column.
-   */
+  /// Extract the result of the trajectory solution as a set of
+  /// discrete samples.  Output matrices contain one set of input/state
+  /// per column, and the number of columns is equal to the number of
+  /// time samples.  @p times will be populated with the times
+  /// corresponding to each column.
   void GetResultSamples(Eigen::MatrixXd* inputs, Eigen::MatrixXd* states,
                         std::vector<double>* times) const;
 
-  /**
-   * Get the input trajectory as a PiecewisePolynomialTrajectory
-   */
+  /// Get the input trajectory as a PiecewisePolynomialTrajectory
   PiecewisePolynomialTrajectory ReconstructInputTrajectory() const;
 
-  /**
-   * Get the state trajectory as a PiecewisePolynomialTrajectory
-   */
+  /// Get the state trajectory as a PiecewisePolynomialTrajectory
   virtual PiecewisePolynomialTrajectory ReconstructStateTrajectory() const;
 
  protected:
-  /**
-   * Construct a DirectTrajectoryOptimization object. The dimensions
-   * of the trajectory are established at construction, though other
-   * parameters (costs, bounds, constraints, etc) can be set before
-   * calling SolveTraj.
-   *
-   * @param num_inputs Number of inputs at each sample point.
-   * @param num_states Number of states at each sample point.
-   * @param num_time_samples Number of time samples.
-   * @param trajectory_time_lower_bound Bound on total time for
-   *        trajectory.
-   * @param trajectory_time_upper_bound Bound on total time for
-   *        trajectory.
-   */
+  /// Construct a DirectTrajectoryOptimization object. The dimensions
+  /// of the trajectory are established at construction, though other
+  /// parameters (costs, bounds, constraints, etc) can be set before
+  /// calling SolveTraj.
+  ///
+  /// @param num_inputs Number of inputs at each sample point.
+  /// @param num_states Number of states at each sample point.
+  /// @param num_time_samples Number of time samples.
+  /// @param trajectory_time_lower_bound Bound on total time for
+  ///        trajectory.
+  /// @param trajectory_time_upper_bound Bound on total time for
+  ///        trajectory.
   // TODO(russt): update comment above. Note that system/context are cloned
   // internally... must use accessors to make any changes to the system.
   DirectTrajectoryOptimization(int num_inputs, int num_states,
@@ -337,27 +244,24 @@ class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
   // TODO(Lucy-tri) add param to indicate whether time steps are constant or
   // independent, and modify implementation to handle.
 
-  /**
-   * Returns a vector containing the elapsed time at each knot point.
-   */
+  /// Returns a vector containing the elapsed time at each knot point.
   std::vector<double> GetTimeVector() const;
 
-  /**
-   * Returns a vector containing the input values at each knot point.
-   */
+  /// Returns a vector containing the input values at each knot point.
   std::vector<Eigen::MatrixXd> GetInputVector() const;
 
-  /**
-   * Returns a vector containing the state values at each knot point.
-   */
+  /// Returns a vector containing the state values at each knot point.
   std::vector<Eigen::MatrixXd> GetStateVector() const;
 
-  /**
-   * Replaces e.g. placeholder_x_var_ with x_vars_ at time interval
-   * @p interval_index, for all placeholder variables.
-   */
+  /// Replaces e.g. placeholder_x_var_ with x_vars_ at time interval
+  /// @p interval_index, for all placeholder variables.
   symbolic::Expression SubstitutePlaceholderVariables(
       const symbolic::Expression& e, int interval_index) const;
+
+  /// Replaces e.g. placeholder_x_var_ with x_vars_ at time interval
+  /// @p interval_index, for all placeholder variables.
+  symbolic::Formula SubstitutePlaceholderVariables(const symbolic::Formula& f,
+                                                   int interval_index) const;
 
   int num_inputs() const { return num_inputs_; }
   int num_states() const { return num_states_; }
@@ -367,27 +271,27 @@ class DirectTrajectoryOptimization : public solvers::MathematicalProgram {
   const solvers::VectorXDecisionVariable& x_vars() const { return x_vars_; }
 
  private:
-  /**
-   * Evaluate the initial trajectories at the sampled times and construct the
-   * nominal initial vectors.
-   *
-   * @param timespan_init The final time of the solution.
-   *
-   * @param traj_init_u Initial guess for trajectory for control
-   * input. The number of rows for each segment in @p traj_init_u must
-   * be equal to num_inputs (the first param of the constructor).
-   *
-   * @param traj_init_x Initial guess for trajectory for state
-   * input. The number of rows for each segment in @p traj_init_x must
-   * be equal to num_states (the second param of the constructor).
-   */
+  // Evaluate the initial trajectories at the sampled times and construct the
+  // nominal initial vectors.
+  //
+  // @param timespan_init The final time of the solution.
+  //
+  // @param traj_init_u Initial guess for trajectory for control
+  // input. The number of rows for each segment in @p traj_init_u must
+  // be equal to num_inputs (the first param of the constructor).
+  //
+  // @param traj_init_x Initial guess for trajectory for state
+  // input. The number of rows for each segment in @p traj_init_x must
+  // be equal to num_states (the second param of the constructor).
   void GetInitialVars(double timespan_init_in,
                       const PiecewisePolynomial<double>& traj_init_u,
                       const PiecewisePolynomial<double>& traj_init_x);
 
   virtual void DoAddRunningCost(const symbolic::Expression& g) = 0;
 
-  virtual void DoAddRunningCost(std::shared_ptr<solvers::Cost> cost) = 0;
+  // Helper method that performs the work for SubstitutePlaceHolderVariables
+  symbolic::Substitution ConstructPlaceholderVariableSubstitution(
+      int interval_index) const;
 
   const int num_inputs_{};
   const int num_states_{};


### PR DESCRIPTION
remove all methods in direct trajectory optimization that accept a cost/constraint without an explicit declaration of the associated variables.  these methods assumed the user understood the correct variable order in the mathematical program, which is far too fragile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6837)
<!-- Reviewable:end -->
