### PR TITLE
Initializing coulomb_window_ to epsilon

### DIFF
--- a/drake/multibody/joints/fixed_axis_one_dof_joint.h
+++ b/drake/multibody/joints/fixed_axis_one_dof_joint.h
@@ -27,10 +27,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
                        const Eigen::Isometry3d& transform_to_parent_body,
                        const drake::TwistVector<double>& _joint_axis)
       : DrakeJointImpl<Derived>(derived, name, transform_to_parent_body, 1, 1),
-        joint_axis_(_joint_axis),
-        damping_(0.0),
-        coulomb_friction_(0.0),
-        coulomb_window_(0.0) {}
+        joint_axis_(_joint_axis) {}
 
  public:
   virtual ~FixedAxisOneDoFJoint() {}
@@ -181,6 +178,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
     damping_ = damping;
     coulomb_friction_ = coulomb_friction;
     coulomb_window_ = coulomb_window;
+    DRAKE_ASSERT(coulomb_window_ > 0);
   }
 
   std::string get_position_name(int index) const override {
@@ -218,6 +216,9 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
   drake::TwistVector<double> joint_axis_;
   double damping_{};
   double coulomb_friction_{};
-  double coulomb_window_{};
+  // We're trying to emulate MATLAB's code:
+  // NOLINTNEXTLINE(whitespace/line_length)
+  // https://github.com/RobotLocomotion/drake/blob/d7f3c011d37d471d7b9293ecf2066c98d88b2a05/drake/matlab/systems/plants/RigidBody.m#L29
+  double coulomb_window_{std::numeric_limits<double>::epsilon()};
 };
 #pragma GCC diagnostic pop  // pop -Wno-overloaded-virtual


### PR DESCRIPTION
To reproduce:
`bazel test -c dbg --copt -O0 --config=ubsan --test_output=all //drake/automotive:car_sim_lcm_test`

Same reason as #6539
[Before](https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-linux-xenial-clang-bazel-experimental-memcheck-ubsan-everything-debug-11&field2=buildstarttime&compare2=84&value2=now)

[After](https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-linux-xenial-clang-bazel-experimental-memcheck-ubsan-everything-debug-12&field2=buildstarttime&compare2=84&value2=now)



#
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6841)
<!-- Reviewable:end -->
