### PR TITLE
Expand pydrake IK bindings

### DIFF
--- a/drake/bindings/pybind11/pydrake_ik.cc
+++ b/drake/bindings/pybind11/pydrake_ik.cc
@@ -38,6 +38,25 @@ PYBIND11_PLUGIN(_pydrake_ik) {
          py::arg("ub"),
          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
 
+  py::class_<RelativePositionConstraint, RigidBodyConstraint>(
+    m, "RelativePositionConstraint")
+    .def(py::init<RigidBodyTree<double>*,
+                  const Eigen::Matrix3Xd&,
+                  const Eigen::MatrixXd&,
+                  const Eigen::MatrixXd&,
+                  int,
+                  int,
+                  const Eigen::Matrix<double, 7, 1>&,
+                  const Eigen::Vector2d&>(),
+         py::arg("model"),
+         py::arg("pts"),
+         py::arg("lb"),
+         py::arg("ub"),
+         py::arg("bodyA_idx"),
+         py::arg("bodyB_idx"),
+         py::arg("bTbp"),
+         py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
+
   py::class_<WorldPositionInFrameConstraint, RigidBodyConstraint>(
     m, "WorldPositionInFrameConstraint")
     .def(py::init<RigidBodyTree<double>*,
@@ -68,6 +87,53 @@ PYBIND11_PLUGIN(_pydrake_ik) {
          py::arg("axis"),
          py::arg("dir"),
          py::arg("conethreshold"),
+         py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
+
+  py::class_<WorldGazeTargetConstraint, RigidBodyConstraint>(
+    m, "WorldGazeTargetConstraint")
+    .def(py::init<RigidBodyTree<double>*,
+                  int,
+                  const Eigen::Vector3d&,
+                  const Eigen::Vector3d&,
+                  const Eigen::Vector3d&,
+                  double,
+                  const Eigen::Vector2d&>(),
+        py::arg("model"),
+        py::arg("body"),
+        py::arg("axis"),
+        py::arg("target"),
+        py::arg("gaze_origin"),
+        py::arg("conethreshold"),
+        py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
+
+  py::class_<RelativeGazeDirConstraint, RigidBodyConstraint>(
+    m, "RelativeGazeDirConstraint")
+    .def(py::init<RigidBodyTree<double>*,
+                  int,
+                  int,
+                  const Eigen::Vector3d&,
+                  const Eigen::Vector3d&,
+                  double,
+                  const Eigen::Vector2d&>(),
+         py::arg("model"),
+         py::arg("bodyA_idx"),
+         py::arg("bodyB_idx"),
+         py::arg("axis"),
+         py::arg("dir"),
+         py::arg("conethreshold"),
+         py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
+
+  py::class_<MinDistanceConstraint, RigidBodyConstraint>(
+    m, "MinDistanceConstraint")
+    .def(py::init<RigidBodyTree<double>*,
+                  double,
+                  const std::vector<int>&,
+                  const std::set<std::string>&,
+                  const Eigen::Vector2d&>(),
+         py::arg("model"),
+         py::arg("min_distance"),
+         py::arg("active_bodies_idx"),
+         py::arg("active_group_names"),
          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan);
 
   py::class_<WorldEulerConstraint, RigidBodyConstraint>(

--- a/drake/bindings/pybind11/pydrake_rbtree.cc
+++ b/drake/bindings/pybind11/pydrake_rbtree.cc
@@ -113,6 +113,10 @@ PYBIND11_PLUGIN(_pydrake_rbtree) {
            RigidBodyTreeConstants::default_model_instance_id_set,
          py::arg("in_terms_of_qdot") = false)
     .def("get_num_bodies", &RigidBodyTree<double>::get_num_bodies)
+    .def("get_num_frames", &RigidBodyTree<double>::get_num_frames)
+    .def("getBodyOrFrameName",
+         &RigidBodyTree<double>::getBodyOrFrameName,
+         py::arg("body_or_frame_id"))
     .def("number_of_positions", &RigidBodyTree<double>::get_num_positions)
     .def("get_num_positions", &RigidBodyTree<double>::get_num_positions)
     .def("number_of_velocities", &RigidBodyTree<double>::get_num_velocities)

--- a/drake/bindings/python/pydrake/solvers/ik.py
+++ b/drake/bindings/python/pydrake/solvers/ik.py
@@ -8,9 +8,13 @@ from ._pydrake_ik import (IKResults,
                           InverseKinTraj,
                           InverseKinPointwise,
                           PostureConstraint,
+                          RelativePositionConstraint,
                           WorldEulerConstraint,
                           WorldQuatConstraint,
                           WorldGazeDirConstraint,
+                          WorldGazeTargetConstraint,
+                          RelativeGazeDirConstraint,
+                          MinDistanceConstraint,
                           QuasiStaticConstraint)
 
 from ._pydrake_ik import WorldPositionConstraint as _WorldPositionConstraint

--- a/drake/bindings/python/pydrake/test/testRBTIK.py
+++ b/drake/bindings/python/pydrake/test/testRBTIK.py
@@ -66,9 +66,9 @@ class TestRBTIK(unittest.TestCase):
         gaze_constraint = ik.WorldGazeTargetConstraint(
             self.r,             # model
             2,                  # body
-            np.ones([3,1]),     # axis
-            np.ones([3,1]),     # target
-            np.zeros([3,1]),    # gaze_origin
+            np.ones([3, 1]),    # axis
+            np.ones([3, 1]),    # target
+            np.zeros([3, 1]),   # gaze_origin
             1e-3                # conethreshold
         )
 
@@ -76,26 +76,26 @@ class TestRBTIK(unittest.TestCase):
         gaze_constraint = ik.WorldGazeTargetConstraint(
             self.r,             # model
             2,                  # body
-            np.ones([3,1]),     # axis
-            np.ones([3,1]),     # target
-            np.zeros([3,1]),    # gaze_origin
+            np.ones([3, 1]),    # axis
+            np.ones([3, 1]),    # target
+            np.zeros([3, 1]),   # gaze_origin
             1e-3,               # conethreshold
-            np.array([0.,1.])   # tspan
+            np.array([0., 1.])  # tspan
         )
 
     def testRelativePositionConstraint(self):
         # Transform from origin of B to points on B
         bTbp = np.concatenate([
-            np.zeros(3),           # Translation (identity)
-            np.array([1, 0, 0, 0]) # Rotation (identity quaternion)
+            np.zeros(3),            # Translation (identity)
+            np.array([1, 0, 0, 0])  # Rotation (identity quaternion)
         ]).reshape(7, 1)
 
         # Test that construction doesn't fail (default timespan)
         position_constraint = ik.RelativePositionConstraint(
             self.r,             # model
-            np.zeros([3,1]),    # pts
-            -np.ones([3,1]),    # lb
-            np.ones([3,1]),     # ub
+            np.zeros([3, 1]),   # pts
+            -np.ones([3, 1]),   # lb
+            np.ones([3, 1]),    # ub
             1,                  # bodyA_idx
             2,                  # bodyB_idx
             bTbp                # bTbp
@@ -104,13 +104,13 @@ class TestRBTIK(unittest.TestCase):
         # Test that construction doesn't fail (given timespan)
         position_constraint2 = ik.RelativePositionConstraint(
             self.r,             # model
-            np.zeros([3,1]),    # pts
-            -np.ones([3,1]),    # lb
-            np.ones([3,1]),     # ub
+            np.zeros([3, 1]),   # pts
+            -np.ones([3, 1]),   # lb
+            np.ones([3, 1]),    # ub
             1,                  # bodyA_idx
             2,                  # bodyB_idx
             bTbp,               # bTbp
-            np.array([0.,1.])   # tspan
+            np.array([0., 1.])  # tspan
         )
 
     def testRelativeGazeDirConstraint(self):
@@ -119,8 +119,8 @@ class TestRBTIK(unittest.TestCase):
             self.r,             # model
             1,                  # bodyA_idx
             2,                  # bodyB_idx
-            np.ones([3,1]),     # axis
-            np.ones([3,1]),     # dir
+            np.ones([3, 1]),     # axis
+            np.ones([3, 1]),     # dir
             1e-3                # conethreshold
         )
 
@@ -129,10 +129,10 @@ class TestRBTIK(unittest.TestCase):
             self.r,             # model
             1,                  # bodyA_idx
             2,                  # bodyB_idx
-            np.ones([3,1]),     # axis
-            np.ones([3,1]),     # dir
+            np.ones([3, 1]),    # axis
+            np.ones([3, 1]),    # dir
             1e-3,               # conethreshold
-            np.array([0.,1.])   # tspan
+            np.array([0., 1.])  # tspan
         )
 
     def testMinDistanceConstraint(self):
@@ -150,8 +150,9 @@ class TestRBTIK(unittest.TestCase):
             1e-2,               # min_distance
             list(),             # active_bodies_idx
             set(),              # active_group_names
-            np.array([0.,1.])   # tspan
+            np.array([0., 1.])  # tspan
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/drake/bindings/python/pydrake/test/testRBTIK.py
+++ b/drake/bindings/python/pydrake/test/testRBTIK.py
@@ -62,96 +62,73 @@ class TestRBTIK(unittest.TestCase):
         self.assertAlmostEqual(results.q_sol[1][6], q, 1e-9)
 
     def testWorldGazeTargetConstraint(self):
-        # Test that construction doesn't fail (default timespan)
-        gaze_constraint = ik.WorldGazeTargetConstraint(
-            self.r,             # model
-            2,                  # body
-            np.ones([3, 1]),    # axis
-            np.ones([3, 1]),    # target
-            np.zeros([3, 1]),   # gaze_origin
-            1e-3                # conethreshold
-        )
+        model = self.r
+        body = 2
+        axis = np.ones([3, 1])
+        target = np.ones([3, 1])
+        gaze_origin = np.zeros([3, 1])
+        cone_threshold = 1e-3
+        tspan = np.array([0., 1.])
 
-        # Test that construction doesn't fail (given timespan)
-        gaze_constraint = ik.WorldGazeTargetConstraint(
-            self.r,             # model
-            2,                  # body
-            np.ones([3, 1]),    # axis
-            np.ones([3, 1]),    # target
-            np.zeros([3, 1]),   # gaze_origin
-            1e-3,               # conethreshold
-            np.array([0., 1.])  # tspan
-        )
+        # Test that construction doesn't fail with the default timespan.
+        ik.WorldGazeTargetConstraint(model, body, axis, target, gaze_origin,
+                                     cone_threshold)
+
+        # Test that construction doesn't fail with a given timespan.
+        ik.WorldGazeTargetConstraint(model, body, axis, target, gaze_origin,
+                                     cone_threshold, tspan)
 
     def testRelativePositionConstraint(self):
-        # Transform from origin of B to points on B
-        bTbp = np.concatenate([
-            np.zeros(3),            # Translation (identity)
-            np.array([1, 0, 0, 0])  # Rotation (identity quaternion)
-        ]).reshape(7, 1)
+        model = self.r
+        pts = np.zeros([3, 1])
+        lb = -np.ones([3, 1])
+        ub = np.ones([3, 1])
+        bodyA_idx = 1
+        bodyB_idx = 2
+        translation = np.zeros(3)
+        quaternion = np.array([1, 0, 0, 0])
+        bTbp = np.concatenate([translation, quaternion]).reshape(7, 1)
+        tspan = np.array([0., 1.])
 
-        # Test that construction doesn't fail (default timespan)
-        position_constraint = ik.RelativePositionConstraint(
-            self.r,             # model
-            np.zeros([3, 1]),   # pts
-            -np.ones([3, 1]),   # lb
-            np.ones([3, 1]),    # ub
-            1,                  # bodyA_idx
-            2,                  # bodyB_idx
-            bTbp                # bTbp
-        )
+        # Test that construction doesn't fail with the default timespan.
+        ik.RelativePositionConstraint(model, pts, lb, ub, bodyA_idx, bodyB_idx,
+                                      bTbp)
 
-        # Test that construction doesn't fail (given timespan)
-        position_constraint2 = ik.RelativePositionConstraint(
-            self.r,             # model
-            np.zeros([3, 1]),   # pts
-            -np.ones([3, 1]),   # lb
-            np.ones([3, 1]),    # ub
-            1,                  # bodyA_idx
-            2,                  # bodyB_idx
-            bTbp,               # bTbp
-            np.array([0., 1.])  # tspan
-        )
+        # Test that construction doesn't fail with a given timespan.
+        ik.RelativePositionConstraint(model, pts, lb, ub, bodyA_idx, bodyB_idx,
+                                      bTbp, tspan)
 
     def testRelativeGazeDirConstraint(self):
-        # Test that construction doesn't fail (default timespan)
-        gaze_constraint = ik.RelativeGazeDirConstraint(
-            self.r,             # model
-            1,                  # bodyA_idx
-            2,                  # bodyB_idx
-            np.ones([3, 1]),     # axis
-            np.ones([3, 1]),     # dir
-            1e-3                # conethreshold
-        )
+        model = self.r
+        bodyA_idx = 1
+        bodyB_idx = 2
+        axis = np.ones([3, 1])
+        dir = np.ones([3, 1])
+        conethreshold = 1e-3
+        tspan = np.array([0., 1.])
 
-        # Test that construction doesn't fail (given timespan)
-        gaze_constraint = ik.RelativeGazeDirConstraint(
-            self.r,             # model
-            1,                  # bodyA_idx
-            2,                  # bodyB_idx
-            np.ones([3, 1]),    # axis
-            np.ones([3, 1]),    # dir
-            1e-3,               # conethreshold
-            np.array([0., 1.])  # tspan
-        )
+        # Test that construction doesn't fail with the default timespan.
+        ik.RelativeGazeDirConstraint(model, bodyA_idx, bodyB_idx, axis, dir,
+                                     conethreshold)
+
+        # Test that construction doesn't fail with a given timespan.
+        ik.RelativeGazeDirConstraint(model, bodyA_idx, bodyB_idx, axis, dir,
+                                     conethreshold, tspan)
 
     def testMinDistanceConstraint(self):
-        # Test that construction doesn't fail (default timespan)
-        distance_constraint = ik.MinDistanceConstraint(
-            self.r,             # model
-            1e-2,               # min_distance
-            list(),             # active_bodies_idx
-            set()               # active_group_names
-        )
+        model = self.r
+        min_distance = 1e-2
+        active_bodies_idx = list()
+        active_group_name = set()
+        tspan = np.array([0., 1.])
 
-        # Test that construction doesn't fail (given timespan)
-        distance_constraint = ik.MinDistanceConstraint(
-            self.r,             # model
-            1e-2,               # min_distance
-            list(),             # active_bodies_idx
-            set(),              # active_group_names
-            np.array([0., 1.])  # tspan
-        )
+        # Test that construction doesn't fail with the default timespan.
+        ik.MinDistanceConstraint(model, min_distance, active_bodies_idx,
+                                 active_group_name)
+
+        # Test that construction doesn't fail with a given timespan.
+        ik.MinDistanceConstraint(model, min_distance, active_bodies_idx,
+                                 active_group_name, tspan)
 
 
 if __name__ == '__main__':

--- a/drake/bindings/python/pydrake/test/testRBTIK.py
+++ b/drake/bindings/python/pydrake/test/testRBTIK.py
@@ -8,12 +8,14 @@ import os.path
 
 
 class TestRBTIK(unittest.TestCase):
-    def testPostureConstraint(self):
-        r = pydrake.rbtree.RigidBodyTree(
+    def setUp(self):
+        self.r = pydrake.rbtree.RigidBodyTree(
             os.path.join(pydrake.getDrakePath(),
                          "examples/pendulum/Pendulum.urdf"))
+
+    def testPostureConstraint(self):
         q = -0.9
-        posture_constraint = ik.PostureConstraint(r)
+        posture_constraint = ik.PostureConstraint(self.r)
         posture_constraint.setJointLimits(np.array([[6]], dtype=np.int32),
                                           np.array([[q]]),
                                           np.array([[q]]))
@@ -24,9 +26,9 @@ class TestRBTIK(unittest.TestCase):
         q_nom = np.vstack((np.zeros((6, 1)),
                            0.))
 
-        options = ik.IKoptions(r)
+        options = ik.IKoptions(self.r)
         results = ik.InverseKin(
-            r, q_seed, q_nom, [posture_constraint], options)
+            self.r, q_seed, q_nom, [posture_constraint], options)
         self.assertEqual(results.info[0], 1)
         self.assertAlmostEqual(results.q_sol[0][6], q, 1e-9)
 
@@ -36,7 +38,7 @@ class TestRBTIK(unittest.TestCase):
         q_seed_array = np.transpose(np.array([q_seed, q_seed]))[0]
         q_nom_array = np.transpose(np.array([q_nom, q_nom]))[0]
 
-        results = ik.InverseKinPointwise(r, t, q_seed_array, q_nom_array,
+        results = ik.InverseKinPointwise(self.r, t, q_seed_array, q_nom_array,
                                          [posture_constraint], options)
         self.assertEqual(len(results.info), 2)
         self.assertEqual(len(results.q_sol), 2)
@@ -48,7 +50,7 @@ class TestRBTIK(unittest.TestCase):
         self.assertEqual(results.info[1], 1)
         self.assertAlmostEqual(results.q_sol[1][6], q, 1e-9)
 
-        results = ik.InverseKinTraj(r, t, q_seed_array, q_nom_array,
+        results = ik.InverseKinTraj(self.r, t, q_seed_array, q_nom_array,
                                     [posture_constraint], options)
         self.assertEqual(len(results.info), 1)
         self.assertEqual(len(results.q_sol), 2)
@@ -59,6 +61,97 @@ class TestRBTIK(unittest.TestCase):
         self.assertAlmostEqual(results.q_sol[0][6], q_seed[6], 1e-9)
         self.assertAlmostEqual(results.q_sol[1][6], q, 1e-9)
 
+    def testWorldGazeTargetConstraint(self):
+        # Test that construction doesn't fail (default timespan)
+        gaze_constraint = ik.WorldGazeTargetConstraint(
+            self.r,             # model
+            2,                  # body
+            np.ones([3,1]),     # axis
+            np.ones([3,1]),     # target
+            np.zeros([3,1]),    # gaze_origin
+            1e-3                # conethreshold
+        )
+
+        # Test that construction doesn't fail (given timespan)
+        gaze_constraint = ik.WorldGazeTargetConstraint(
+            self.r,             # model
+            2,                  # body
+            np.ones([3,1]),     # axis
+            np.ones([3,1]),     # target
+            np.zeros([3,1]),    # gaze_origin
+            1e-3,               # conethreshold
+            np.array([0.,1.])   # tspan
+        )
+
+    def testRelativePositionConstraint(self):
+        # Transform from origin of B to points on B
+        bTbp = np.concatenate([
+            np.zeros(3),           # Translation (identity)
+            np.array([1, 0, 0, 0]) # Rotation (identity quaternion)
+        ]).reshape(7, 1)
+
+        # Test that construction doesn't fail (default timespan)
+        position_constraint = ik.RelativePositionConstraint(
+            self.r,             # model
+            np.zeros([3,1]),    # pts
+            -np.ones([3,1]),    # lb
+            np.ones([3,1]),     # ub
+            1,                  # bodyA_idx
+            2,                  # bodyB_idx
+            bTbp                # bTbp
+        )
+
+        # Test that construction doesn't fail (given timespan)
+        position_constraint2 = ik.RelativePositionConstraint(
+            self.r,             # model
+            np.zeros([3,1]),    # pts
+            -np.ones([3,1]),    # lb
+            np.ones([3,1]),     # ub
+            1,                  # bodyA_idx
+            2,                  # bodyB_idx
+            bTbp,               # bTbp
+            np.array([0.,1.])   # tspan
+        )
+
+    def testRelativeGazeDirConstraint(self):
+        # Test that construction doesn't fail (default timespan)
+        gaze_constraint = ik.RelativeGazeDirConstraint(
+            self.r,             # model
+            1,                  # bodyA_idx
+            2,                  # bodyB_idx
+            np.ones([3,1]),     # axis
+            np.ones([3,1]),     # dir
+            1e-3                # conethreshold
+        )
+
+        # Test that construction doesn't fail (given timespan)
+        gaze_constraint = ik.RelativeGazeDirConstraint(
+            self.r,             # model
+            1,                  # bodyA_idx
+            2,                  # bodyB_idx
+            np.ones([3,1]),     # axis
+            np.ones([3,1]),     # dir
+            1e-3,               # conethreshold
+            np.array([0.,1.])   # tspan
+        )
+
+    def testMinDistanceConstraint(self):
+        # Test that construction doesn't fail (default timespan)
+        distance_constraint = ik.MinDistanceConstraint(
+            self.r,             # model
+            1e-2,               # min_distance
+            list(),             # active_bodies_idx
+            set()               # active_group_names
+        )
+
+        # Test that construction doesn't fail (given timespan)
+        distance_constraint = ik.MinDistanceConstraint(
+            self.r,             # model
+            1e-2,               # min_distance
+            list(),             # active_bodies_idx
+            set(),              # active_group_names
+            np.array([0.,1.])   # tspan
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I needed these constraints for my work with Draper this summer. No functional changes were made; the items below were simply added to the bindings.

Constraints added:

* WorldGazeTargetConstraint
* RelativePositionConstraint
* RelativeGazeDirConstraint
* MinDistanceConstraint

Functions added:

* RigidBodyTree::get_num_frames
* RigidBodyTree::getBodyOrFrameName

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6844)
<!-- Reviewable:end -->
