### PR TITLE
support fixed timesteps in direct trajectory optimization 

### DIFF
--- a/drake/automotive/test/trajectory_optimization_test.cc
+++ b/drake/automotive/test/trajectory_optimization_test.cc
@@ -49,10 +49,6 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
   prog.AddConstraintToAllKnotPoints(input.steering_angle() <= M_PI_2);
   prog.AddConstraintToAllKnotPoints(-M_PI_2 <= input.steering_angle());
 
-  // Ensure that time intervals are (relatively) evenly spaced.
-  prog.AddTimeIntervalBounds(kTrajectoryTimeLowerBound / (kNumTimeSamples - 1),
-                             kTrajectoryTimeUpperBound / (kNumTimeSamples - 1));
-
   // Fix initial conditions.
   prog.AddLinearConstraint(prog.initial_state() == x0.get_value());
 
@@ -66,9 +62,9 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
   auto initial_state_trajectory = PiecewisePolynomial<double>::FirstOrderHold(
       {0, initial_duration}, {x0.get_value(), xf.get_value()});
 
-  solvers::SolutionResult result =
-      prog.SolveTraj(initial_duration, PiecewisePolynomial<double>(),
-                     initial_state_trajectory);
+  prog.SetInitialTrajectory(PiecewisePolynomial<double>(),
+                            initial_state_trajectory);
+  solvers::SolutionResult result = prog.Solve();
 
   EXPECT_EQ(result, solvers::SolutionResult::kSolutionFound);
 

--- a/drake/examples/acrobot/test/acrobot_run_swing_up_traj_optimization.cc
+++ b/drake/examples/acrobot/test/acrobot_run_swing_up_traj_optimization.cc
@@ -54,8 +54,8 @@ int do_main() {
   const double timespan_init = 4;
   auto traj_init_x =
       PiecewisePolynomialType::FirstOrderHold({0, timespan_init}, {x0, xG});
-  SolutionResult result = dircol_traj.SolveTraj(
-      timespan_init, PiecewisePolynomialType(), traj_init_x);
+  dircol_traj.SetInitialTrajectory(PiecewisePolynomialType(), traj_init_x);
+  SolutionResult result = dircol_traj.Solve();
   if (result != SolutionResult::kSolutionFound) {
     std::cerr << "No solution found.\n";
     return 1;

--- a/drake/examples/pendulum/pendulum_run_swing_up.cc
+++ b/drake/examples/pendulum/pendulum_run_swing_up.cc
@@ -72,8 +72,8 @@ int do_main() {
   const double timespan_init = 4;
   auto traj_init_x =
       PiecewisePolynomial<double>::FirstOrderHold({0, timespan_init}, {x0, xG});
-  SolutionResult result = dircol.SolveTraj(
-      timespan_init, PiecewisePolynomial<double>(), traj_init_x);
+  dircol.SetInitialTrajectory(PiecewisePolynomial<double>(), traj_init_x);
+  SolutionResult result = dircol.Solve();
   if (result != SolutionResult::kSolutionFound) {
     std::cerr << "Result is an Error" << std::endl;
     return 1;

--- a/drake/examples/pendulum/test/pendulum_trajectory_optimization_test.cc
+++ b/drake/examples/pendulum/test/pendulum_trajectory_optimization_test.cc
@@ -36,8 +36,8 @@ GTEST_TEST(PendulumTrajectoryOptimization, PendulumTrajectoryOptimizationTest) {
   const double timespan_init = 4;
   auto traj_init_x =
       PiecewisePolynomialType::FirstOrderHold({0, timespan_init}, {x0, xG});
-  const SolutionResult result =
-      dircol.SolveTraj(timespan_init, PiecewisePolynomialType(), traj_init_x);
+  dircol.SetInitialTrajectory(PiecewisePolynomialType(), traj_init_x);
+  const SolutionResult result = dircol.Solve();
   ASSERT_EQ(result, SolutionResult::kSolutionFound) << "Result is an Error";
 
   Eigen::MatrixXd inputs;


### PR DESCRIPTION
(formulations with time as a decision variable are rarely convex)

Also resolves a TODO with the placeholder vars.

N.B. - the test coverage of the trajectory optimization classes is very weak... and it makes changes painful.  This is the first of a train of PRs to start cleaning that up.  I also have a PR queued up to allow DirectCollocation to use fixed timesteps, but it was a big change so I've split it up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6850)
<!-- Reviewable:end -->
