### PR TITLE
RgbdCamera: Add depth range arguments to the constractor

### DIFF
--- a/drake/systems/sensors/rgbd_camera.cc
+++ b/drake/systems/sensors/rgbd_camera.cc
@@ -63,12 +63,9 @@ const int kPortStateInput = 0;
 const double kClippingPlaneNear = 0.01;
 const double kClippingPlaneFar = 100.;
 
-// TODO(kunimatsu-tri) Add support for the arbitrary image size and the depth
-// ranges.
+// TODO(kunimatsu-tri) Add support for the arbitrary image size.
 const int kImageWidth = 640;  // In pixels
 const int kImageHeight = 480;  // In pixels
-const float kDepthRangeNear = 0.5;
-const float kDepthRangeFar = 5.0;
 const double kTerrainSize = 100.;
 
 // For Zbuffer value conversion.
@@ -247,15 +244,17 @@ void RgbdCamera::ConvertDepthImageToPointCloud(const ImageDepth32F& depth_image,
 class RgbdCamera::Impl : private ModuleInitVtkRenderingOpenGL2 {
  public:
   Impl(const RigidBodyTree<double>& tree, const RigidBodyFrame<double>& frame,
+       double depth_range_near, double depth_range_far,
        double fov_y, bool show_window, bool fix_camera);
 
   Impl(const RigidBodyTree<double>& tree, const RigidBodyFrame<double>& frame,
        const Eigen::Vector3d& position, const Eigen::Vector3d& orientation,
+       double depth_range_near, double depth_range_far,
        double fov_y, bool show_window, bool fix_camera);
 
   ~Impl() {}
 
-  static float CheckRangeAndConvertToMeters(float z_buffer_value);
+  float CheckRangeAndConvertToMeters(float z_buffer_value) const;
 
   const Eigen::Isometry3d& color_camera_optical_pose() const {
     return X_BC_;
@@ -302,6 +301,8 @@ class RgbdCamera::Impl : private ModuleInitVtkRenderingOpenGL2 {
   const Eigen::Isometry3d X_BC_;
   const Eigen::Isometry3d X_BD_;
   const Eigen::Isometry3d X_WB_initial_;
+  const double depth_range_near_;
+  const double depth_range_far_;
   const bool kCameraFixed;
   ColorPalette color_palette_;
   vtkNew<vtkActor> terrain_actor_;
@@ -328,6 +329,7 @@ RgbdCamera::Impl::Impl(const RigidBodyTree<double>& tree,
                        const RigidBodyFrame<double>& frame,
                        const Eigen::Vector3d& position,
                        const Eigen::Vector3d& orientation,
+                       double depth_range_near, double depth_range_far,
                        double fov_y, bool show_window, bool fix_camera)
     : tree_(tree), frame_(frame),
       color_camera_info_(kImageWidth, kImageHeight, fov_y),
@@ -347,7 +349,12 @@ RgbdCamera::Impl::Impl(const RigidBodyTree<double>& tree,
       X_WB_initial_(
           Eigen::Translation3d(position[0], position[1], position[2]) *
           Eigen::Isometry3d(math::rpy2rotmat(orientation))),
+      depth_range_near_(depth_range_near), depth_range_far_(depth_range_far),
       kCameraFixed(fix_camera), color_palette_(tree.bodies.size()) {
+  DRAKE_DEMAND(depth_range_near_ >= kClippingPlaneNear);
+  DRAKE_DEMAND(depth_range_far_ <= kClippingPlaneFar);
+  DRAKE_DEMAND(depth_range_far_ - depth_range_near_ > 0);
+
   if (!show_window) {
     for (auto& window : MakeVtkPointerArray(color_depth_render_window_,
                                             label_render_window_)) {
@@ -414,9 +421,12 @@ RgbdCamera::Impl::Impl(const RigidBodyTree<double>& tree,
 
 RgbdCamera::Impl::Impl(const RigidBodyTree<double>& tree,
                        const RigidBodyFrame<double>& frame,
+                       double depth_range_near, double depth_range_far,
                        double fov_y, bool show_window, bool fix_camera)
     : Impl::Impl(tree, frame, Eigen::Vector3d(0., 0., 0.),
-                 Eigen::Vector3d(0., 0., 0.), fov_y, show_window, fix_camera) {}
+                 Eigen::Vector3d(0., 0., 0.),
+                 depth_range_near, depth_range_far,
+                 fov_y, show_window, fix_camera) {}
 
 
 void RgbdCamera::Impl::SetModelTransformMatrixToVtkCamera(
@@ -701,7 +711,8 @@ void RgbdCamera::Impl::UpdateModelPoses(
   }
 }
 
-float RgbdCamera::Impl::CheckRangeAndConvertToMeters(float z_buffer_value) {
+float RgbdCamera::Impl::CheckRangeAndConvertToMeters(float z_buffer_value)
+    const {
   float checked_depth;
   // When the depth is either closer than kClippingPlaneNear or further than
   // kClippingPlaneFar, `z_buffer_value` becomes `1.f`.
@@ -710,9 +721,9 @@ float RgbdCamera::Impl::CheckRangeAndConvertToMeters(float z_buffer_value) {
   } else {
     float depth = static_cast<float>(kB / (z_buffer_value - kA));
 
-    if (depth > kDepthRangeFar) {
+    if (depth > depth_range_far_) {
       checked_depth = InvalidDepth::kTooFar;
-    } else if (depth < kDepthRangeNear) {
+    } else if (depth < depth_range_near_) {
       checked_depth = InvalidDepth::kTooClose;
     } else {
       checked_depth = depth;
@@ -727,19 +738,26 @@ RgbdCamera::RgbdCamera(const std::string& name,
                        const RigidBodyTree<double>& tree,
                        const Eigen::Vector3d& position,
                        const Eigen::Vector3d& orientation,
+                       double depth_range_near,
+                       double depth_range_far,
                        double fov_y,
                        bool show_window)
     : impl_(new RgbdCamera::Impl(tree, RigidBodyFrame<double>(), position,
-                                 orientation, fov_y, show_window, true)) {
+                                 orientation, depth_range_near, depth_range_far,
+                                 fov_y, show_window, true)) {
   Init(name);
 }
 
 RgbdCamera::RgbdCamera(const std::string& name,
                        const RigidBodyTree<double>& tree,
                        const RigidBodyFrame<double>& frame,
+                       double depth_range_near,
+                       double depth_range_far,
                        double fov_y,
                        bool show_window)
-    : impl_(new RgbdCamera::Impl(tree, frame, fov_y, show_window, false)) {
+    : impl_(new RgbdCamera::Impl(tree, frame,
+                                 depth_range_near, depth_range_far,
+                                 fov_y, show_window, false)) {
   Init(name);
 }
 

--- a/drake/systems/sensors/rgbd_camera.h
+++ b/drake/systems/sensors/rgbd_camera.h
@@ -130,16 +130,26 @@ class RgbdCamera : public LeafSystem<double> {
   /// @param orientation The roll-pitch-yaw orientation of `B` in `W`. This
   /// defines the orientation component of `X_WB`.
   ///
+  /// @param depth_range_near The minimum depth distance RgbdCamera can measure.
+  /// The default is 0.5 meters.
+  ///
+  /// @param depth_range_far The maximum depth distance RgbdCamera can measure.
+  /// The default is 5 meters.
+  ///
   /// @param fov_y The RgbdCamera's vertical field of view.
+  /// The default is PI / 4.
   ///
   /// @param show_window A flag for showing a visible window.  If this is false,
   /// offscreen rendering is executed. This is useful for debugging purposes.
+  /// The default is true.
   RgbdCamera(const std::string& name,
              const RigidBodyTree<double>& tree,
              const Eigen::Vector3d& position,
              const Eigen::Vector3d& orientation,
-             double fov_y,
-             bool show_window);
+             double depth_range_near = 0.5,
+             double depth_range_far = 5.0,
+             double fov_y = M_PI_4,
+             bool show_window = true);
 
   /// A constructor for %RgbdCamera that defines `B` using a RigidBodyFrame.
   /// The pose of %RgbdCamera is fixed to a user-defined frame and will be
@@ -156,15 +166,25 @@ class RgbdCamera : public LeafSystem<double> {
   ///
   /// @param frame The frame in @tree to which this camera is attached.
   ///
+  /// @param depth_range_near The minimum depth distance RgbdCamera can measure.
+  /// The default is 0.5 meters.
+  ///
+  /// @param depth_range_far The maximum depth distance RgbdCamera can measure.
+  /// The default is 5 meters.
+  ///
   /// @param fov_y The RgbdCamera's vertical field of view.
+  /// The default is PI / 4.
   ///
   /// @param show_window A flag for showing a visible window.  If this is false,
   /// offscreen rendering is executed. This is useful for debugging purposes.
+  /// The default is true.
   RgbdCamera(const std::string& name,
              const RigidBodyTree<double>& tree,
              const RigidBodyFrame<double>& frame,
-             double fov_y,
-             bool show_window);
+             double depth_range_near = 0.5,
+             double depth_range_far = 5.0,
+             double fov_y = M_PI_4,
+             bool show_window = true);
 
   ~RgbdCamera();
 

--- a/drake/systems/sensors/test/models/three_boxes.sdf
+++ b/drake/systems/sensors/test/models/three_boxes.sdf
@@ -59,7 +59,8 @@
     <static>1</static>
   </model>
   <model name="mesh_box3">
-    <pose>0 2.5 1 0 0 0</pose>
+    <!-- This is placing the object outside of the view frustum. -->
+    <pose>0 10 1 0 0 0</pose>
     <link name="box3">
       <pose>0 0 0 0 0 0</pose>
       <inertial>

--- a/drake/systems/sensors/test/rgbd_camera_test.cc
+++ b/drake/systems/sensors/test/rgbd_camera_test.cc
@@ -36,13 +36,16 @@ const double kColorPixelTolerance = 1.001;
 const double kDepthTolerance = 1e-4;
 const double kFovY = M_PI_4;
 const bool kShowWindow = false;
+const double kDepthRangeNear = 0.5;
+const double kDepthRangeFar = 5.;
 
 class RgbdCameraTest : public ::testing::Test {
  public:
   RgbdCameraTest() : dut_("rgbd_camera", RigidBodyTree<double>(),
                           Eigen::Vector3d(1., 2., 3.),
                           Eigen::Vector3d(0.1, 0.2, 0.3),
-                          kFovY,  kShowWindow) {}
+                          kDepthRangeNear, kDepthRangeFar,
+                          kFovY, kShowWindow) {}
 
   void SetUp() {}
 
@@ -117,8 +120,8 @@ class RenderingSim : public systems::Diagram<double> {
   void InitFixedCamera(const Eigen::Vector3d& position,
                        const Eigen::Vector3d& orientation) {
     rgbd_camera_ = builder_.AddSystem<RgbdCamera>(
-        "rgbd_camera", plant_->get_rigid_body_tree(),
-        position, orientation, kFovY, kShowWindow);
+        "rgbd_camera", plant_->get_rigid_body_tree(), position, orientation,
+        kDepthRangeNear, kDepthRangeFar, kFovY, kShowWindow);
     rgbd_camera_->set_name("rgbd_camera");
     Connect();
   }
@@ -132,7 +135,7 @@ class RenderingSim : public systems::Diagram<double> {
 
     rgbd_camera_ = builder_.AddSystem<RgbdCamera>(
         "rgbd_camera", plant_->get_rigid_body_tree(), *rgbd_camera_frame_.get(),
-        kFovY, kShowWindow);
+        kDepthRangeNear, kDepthRangeFar, kFovY, kShowWindow);
     rgbd_camera_->set_name("rgbd_camera");
     Connect();
   }

--- a/drake/systems/sensors/test/rgbd_camera_test.cc
+++ b/drake/systems/sensors/test/rgbd_camera_test.cc
@@ -105,15 +105,6 @@ class RenderingSim : public systems::Diagram<double> {
 
     plant_ = builder_.AddSystem<RigidBodyPlant<double>>(std::move(tree));
     plant_->set_name("rigid_body_plant");
-    const double kPenetrationStiffness = 3000.;
-    const double kPenetrationDamping = 10.;
-    const double kStaticFriction = 0.9;
-    const double kDynamicFriction = 0.5;
-    const double kStictionSlipTolerance = 0.01;
-    plant_->set_normal_contact_parameters(kPenetrationStiffness,
-                                          kPenetrationDamping);
-    plant_->set_friction_contact_parameters(kStaticFriction, kDynamicFriction,
-                                            kStictionSlipTolerance);
   }
 
   // For fixed camera base.
@@ -528,13 +519,13 @@ class DepthImageToPointCloudConversionTest : public ::testing::Test {
       kWidth, kHeight, kFocal, kFocal, kWidth * 0.5, kHeight * 0.5),
       depth_image_(kWidth, kHeight, 1) {}
 
+  // kTooClose is treated as kTooFar. For the detail, refer to the document of
+  // RgbdCamera::ConvertDepthImageToPointCloud.
   void VerifyTooFarTooClose() {
     for (int v = 0; v < depth_image_.height(); ++v) {
       for (int u = 0; u < depth_image_.width(); ++u) {
         const int i = v * depth_image_.width() + u;
-        Eigen::Vector3f actual(Eigen::Map<Eigen::Vector3f>(
-            actual_point_cloud_.col(i).data(), actual_point_cloud_.rows()));
-
+        Eigen::Vector3f actual = actual_point_cloud_.col(i);
         EXPECT_EQ(actual(0), RgbdCamera::InvalidDepth::kTooFar);
         EXPECT_EQ(actual(1), RgbdCamera::InvalidDepth::kTooFar);
         EXPECT_EQ(actual(2), RgbdCamera::InvalidDepth::kTooFar);
@@ -568,8 +559,7 @@ TEST_F(DepthImageToPointCloudConversionTest, ValidValueTest) {
   for (int v = 0; v < depth_image_.height(); ++v) {
     for (int u = 0; u < depth_image_.width(); ++u) {
       const int i = v * depth_image_.width() + u;
-      Eigen::Vector3f actual(Eigen::Map<Eigen::Vector3f>(
-          actual_point_cloud_.col(i).data(), actual_point_cloud_.rows()));
+      Eigen::Vector3f actual = actual_point_cloud_.col(i);
 
       EXPECT_NEAR(actual(0), kDepthValue * (u - kWidth * 0.5) / kFocal,
                   kDistanceTolerance);
@@ -591,8 +581,7 @@ TEST_F(DepthImageToPointCloudConversionTest, NanValueTest) {
   for (int v = 0; v < depth_image_.height(); ++v) {
     for (int u = 0; u < depth_image_.width(); ++u) {
       const int i = v * depth_image_.width() + u;
-      Eigen::Vector3f actual(Eigen::Map<Eigen::Vector3f>(
-          actual_point_cloud_.col(i).data(), actual_point_cloud_.rows()));
+      Eigen::Vector3f actual = actual_point_cloud_.col(i);
 
       EXPECT_TRUE(std::isnan(actual(0)));
       EXPECT_TRUE(std::isnan(actual(1)));

--- a/drake/systems/sensors/test/rgbd_camera_test.cc
+++ b/drake/systems/sensors/test/rgbd_camera_test.cc
@@ -247,13 +247,13 @@ class ImageTest : public ::testing::Test {
         }
       }
     }
-    // We have three objects plus the sky and the terrain.
-    const int kExpectedNumIds{5};
+    // We have three objects, but one of them is outside of the view frustum.
+    // In addition, we have the sky and the terrain.
+    const int kExpectedNumIds{4};
     EXPECT_EQ(kExpectedNumIds, actual_ids.size());
 
     ASSERT_EQ(label_image.at(320, 205)[0], 1);
     ASSERT_EQ(label_image.at(470, 205)[0], 2);
-    ASSERT_EQ(label_image.at(170, 205)[0], 3);
     // Terrain
     ASSERT_EQ(label_image.at(0, 479)[0], RgbdCamera::Label::kFlatTerrain);
     // Sky


### PR DESCRIPTION
This allows users to create `RgbdCamera` that has arbitrary depth measurement range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6851)
<!-- Reviewable:end -->
