### PR TITLE
Add anchored geometry to geometry state

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -77,11 +77,13 @@ drake_cc_library(
 
 drake_cc_library(
     name = "internal_geometry",
-    srcs = [],
+    srcs = ["internal_geometry.cc"],
     hdrs = ["internal_geometry.h"],
     deps = [
         ":geometry_ids",
+        ":shape_specification",
         "//drake/common",
+        "//drake/common:copyable_unique_ptr",
     ],
 )
 
@@ -112,6 +114,7 @@ drake_cc_googletest(
     deps = [
         ":expect_error_message",
         ":geometry_state",
+        "//drake/common:eigen_matrix_compare",
     ],
 )
 

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
@@ -10,8 +11,7 @@
 namespace drake {
 namespace geometry {
 
-/**
- A geometry instance combines a geometry definition (i.e., a shape of some
+/** A geometry instance combines a geometry definition (i.e., a shape of some
  sort), a pose (relative to a parent "frame" P), material information, and an
  opaque collection of metadata. The parent frame can be a registered frame or
  another registered geometry. */
@@ -28,6 +28,8 @@ class GeometryInstance {
   void set_pose(const Isometry3<double>& X_PG) { X_PG_ = X_PG; }
 
   const Shape& get_shape() const { return *shape_; }
+  /** Releases the shape from the instance. */
+  std::unique_ptr<Shape> release_shape() { return std::move(shape_); }
 
  private:
   // The pose of the geometry relative to the parent frame it hangs on.

--- a/drake/geometry/geometry_state.cc
+++ b/drake/geometry/geometry_state.cc
@@ -13,11 +13,13 @@
 namespace drake {
 namespace geometry {
 
+using internal::InternalAnchoredGeometry;
 using internal::InternalFrame;
 using internal::InternalGeometry;
 using std::make_pair;
 using std::make_unique;
 using std::move;
+using std::to_string;
 
 //-----------------------------------------------------------------------------
 
@@ -34,7 +36,7 @@ using std::move;
 // make_message().
 template <class Key, class Findable>
 void FindOrThrow(const Key& key, const Findable& source,
-                 std::function<std::string()> make_message) {
+                 const std::function<std::string()>& make_message) {
   if (source.find(key) == source.end()) throw std::logic_error(make_message());
 }
 // Definition of error message for a missing key lookup.
@@ -47,9 +49,9 @@ std::string get_missing_id_message(const Key& key) {
 // The look up and error-throwing method for const values.
 template <class Key, class Value>
 const Value& GetValueOrThrow(const Key& key,
-                             const std::unordered_map<Key, Value>* map) {
-  auto itr = map->find(key);
-  if (itr != map->end()) {
+                             const std::unordered_map<Key, Value>& map) {
+  auto itr = map.find(key);
+  if (itr != map.end()) {
     return itr->second;
   }
   throw std::logic_error(get_missing_id_message(key));
@@ -100,7 +102,6 @@ bool GeometryState<T>::source_is_registered(SourceId source_id) const {
 
 template <typename T>
 const std::string& GeometryState<T>::get_source_name(SourceId id) const {
-  using std::to_string;
   auto itr = source_names_.find(id);
   if (itr != source_names_.end()) return itr->second;
   throw std::logic_error(
@@ -108,14 +109,20 @@ const std::string& GeometryState<T>::get_source_name(SourceId id) const {
 }
 
 template <typename T>
+const Isometry3<double>& GeometryState<T>::GetPoseInParent(
+    GeometryId geometry_id) const {
+  const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
+  return geometry.get_pose_in_parent();
+}
+
+template <typename T>
 SourceId GeometryState<T>::RegisterNewSource(const std::string& name) {
   SourceId source_id = SourceId::get_new_id();
-  using std::to_string;
   const std::string final_name =
       name != "" ? name : "Source_" + to_string(source_id);
 
   // The user can provide bad names, _always_ test.
-  for (const auto &pair : source_names_) {
+  for (const auto& pair : source_names_) {
     if (pair.second == final_name) {
       throw std::logic_error(
           "Registering new source with duplicate name: " + final_name + ".");
@@ -124,6 +131,7 @@ SourceId GeometryState<T>::RegisterNewSource(const std::string& name) {
 
   source_frame_id_map_[source_id];
   source_root_frame_map_[source_id];
+  source_anchored_geometry_map_[source_id];
   source_names_[source_id] = final_name;
   return source_id;
 }
@@ -137,7 +145,6 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id,
 template <typename T>
 FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                         const GeometryFrame&) {
-  using std::to_string;
   FrameId frame_id = FrameId::get_new_id();
 
   FrameIdSet& f_set = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
@@ -161,7 +168,6 @@ template <typename T>
 GeometryId GeometryState<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  using std::to_string;
   if (geometry == nullptr) {
     throw std::logic_error(
         "Registering null geometry to frame " + to_string(frame_id) +
@@ -184,7 +190,8 @@ GeometryId GeometryState<T>::RegisterGeometry(
   // TODO(SeanCurtis-TRI): Get name from geometry instance (when available).
   geometries_.emplace(
       geometry_id,
-      InternalGeometry(frame_id, geometry_id));
+      InternalGeometry(geometry->release_shape(), frame_id, geometry_id,
+                       geometry->get_pose()));
   return geometry_id;
 }
 
@@ -200,7 +207,6 @@ GeometryId GeometryState<T>::RegisterGeometryWithParent(
   // Only #1 is tested directly. #2 and #3 are tested implicitly during the act
   // of registering the geometry.
 
-  using std::to_string;
   if (geometry == nullptr) {
     throw std::logic_error(
         "Registering null geometry to geometry " + to_string(geometry_id) +
@@ -222,6 +228,29 @@ GeometryId GeometryState<T>::RegisterGeometryWithParent(
 }
 
 template <typename T>
+GeometryId GeometryState<T>::RegisterAnchoredGeometry(
+    SourceId source_id,
+    std::unique_ptr<GeometryInstance> geometry) {
+  if (geometry == nullptr) {
+    throw std::logic_error(
+        "Registering null anchored geometry on source "
+        + to_string(source_id) + ".");
+  }
+  auto& set = GetMutableValueOrThrow(source_id, &source_anchored_geometry_map_);
+
+  GeometryId geometry_id = GeometryId::get_new_id();
+  set.emplace(geometry_id);
+
+  // TODO(SeanCurtis-TRI): Pass the geometry instance to the geometry engine.
+
+  anchored_geometries_.emplace(
+      geometry_id,
+      InternalAnchoredGeometry(
+          geometry->release_shape(), geometry_id, geometry->get_pose()));
+  return geometry_id;
+}
+
+template <typename T>
 void GeometryState<T>::ClearSource(SourceId source_id) {
   FrameIdSet& frames = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
   for (auto frame_id : frames) {
@@ -233,7 +262,6 @@ void GeometryState<T>::ClearSource(SourceId source_id) {
 
 template <typename T>
 void GeometryState<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
-  using std::to_string;
   if (!BelongsToSource(frame_id, source_id)) {
     throw std::logic_error("Trying to remove frame " + to_string(frame_id) +
         " from source " + to_string(source_id) +
@@ -245,14 +273,17 @@ void GeometryState<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
 template <typename T>
 void GeometryState<T>::RemoveGeometry(SourceId source_id,
                                       GeometryId geometry_id) {
-  using std::to_string;
   if (!BelongsToSource(geometry_id, source_id)) {
     throw std::logic_error(
         "Trying to remove geometry " + to_string(geometry_id) + " from "
             "source " + to_string(source_id) + ", but the geometry doesn't "
             "belong to that source.");
   }
-  RemoveGeometryUnchecked(geometry_id, RemoveGeometryOrigin::kGeometry);
+  if (is_dynamic(geometry_id)) {
+    RemoveGeometryUnchecked(geometry_id, RemoveGeometryOrigin::kGeometry);
+  } else {
+    RemoveAnchoredGeometryUnchecked(geometry_id);
+  }
 }
 
 template <typename T>
@@ -260,7 +291,7 @@ bool GeometryState<T>::BelongsToSource(FrameId frame_id,
                                        SourceId source_id) const {
   // Confirm that the source_id is valid; use the utility function to confirm
   // source_id is valid and throw an exception with a known message.
-  GetValueOrThrow(source_id, &source_frame_id_map_);
+  GetValueOrThrow(source_id, source_frame_id_map_);
   // If valid, test the frame.
   return get_source_id(frame_id) == source_id;
 }
@@ -268,27 +299,34 @@ bool GeometryState<T>::BelongsToSource(FrameId frame_id,
 template <typename T>
 bool GeometryState<T>::BelongsToSource(GeometryId geometry_id,
                                        SourceId source_id) const {
-  // Look among the dynamic geometry, if not found, the geometry_id
+  // Geometry could be anchored. This also implicitly tests that source_id is
+  // valid and throws an exception if not.
+  const auto& anchored_geometries =
+      GetValueOrThrow(source_id, source_anchored_geometry_map_);
+  if (anchored_geometries.find(geometry_id) != anchored_geometries.end()) {
+    return true;
+  }
+  // If not anchored, geometry must be dynamic. If this fails, the geometry_id
   // is not valid and an exception is thrown.
-  const auto& geometry = GetValueOrThrow(geometry_id, &geometries_);
+  const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return BelongsToSource(geometry.get_frame_id(), source_id);
 }
 
 template <typename T>
 FrameId GeometryState<T>::GetFrameId(GeometryId geometry_id) const {
-  auto& geometry = GetValueOrThrow(geometry_id, &geometries_);
+  const auto& geometry = GetValueOrThrow(geometry_id, geometries_);
   return geometry.get_frame_id();
 }
 
 template <typename T>
 const FrameIdSet& GeometryState<T>::GetFramesForSource(
     SourceId source_id) const {
-  return GetValueOrThrow(source_id, &source_frame_id_map_);
+  return GetValueOrThrow(source_id, source_frame_id_map_);
 }
 
 template <typename T>
 SourceId GeometryState<T>::get_source_id(FrameId frame_id) const {
-  auto& frame = GetValueOrThrow(frame_id, &frames_);
+  const auto& frame = GetValueOrThrow(frame_id, frames_);
   return frame.get_source_id();
 }
 
@@ -335,7 +373,7 @@ void GeometryState<T>::RemoveFrameUnchecked(FrameId frame_id,
 template <typename T>
 void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
                                                RemoveGeometryOrigin caller) {
-  const InternalGeometry& geometry = GetValueOrThrow(geometry_id, &geometries_);
+  const InternalGeometry& geometry = GetValueOrThrow(geometry_id, geometries_);
 
   if (caller != RemoveGeometryOrigin::kFrame) {
     // Clear children
@@ -360,6 +398,13 @@ void GeometryState<T>::RemoveGeometryUnchecked(GeometryId geometry_id,
 
   // Remove from the geometries.
   geometries_.erase(geometry_id);
+}
+
+template <typename T>
+void GeometryState<T>::RemoveAnchoredGeometryUnchecked(GeometryId geometry_id) {
+  FindOrThrow(geometry_id, anchored_geometries_,
+              [geometry_id]() { return get_missing_id_message(geometry_id); });
+  anchored_geometries_.erase(geometry_id);
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/geometry/internal_geometry.cc
+++ b/drake/geometry/internal_geometry.cc
@@ -1,0 +1,26 @@
+#include "drake/geometry/internal_geometry.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+InternalGeometry::InternalGeometry() : InternalGeometryBase() {}
+
+InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
+                                   FrameId frame_id, GeometryId geometry_id,
+                                   const Isometry3<double>& X_PG,
+                                   const optional<GeometryId>& parent_id)
+    : InternalGeometryBase(std::move(shape), geometry_id, X_PG),
+      frame_id_(frame_id),
+      parent_id_(parent_id) {}
+
+InternalAnchoredGeometry::InternalAnchoredGeometry() : InternalGeometryBase() {}
+
+InternalAnchoredGeometry::InternalAnchoredGeometry(
+    std::unique_ptr<Shape> shape, GeometryId geometry_id,
+    const Isometry3<double>& X_WG)
+    : InternalGeometryBase(std::move(shape), geometry_id, X_WG) {}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/internal_geometry.h
+++ b/drake/geometry/internal_geometry.h
@@ -1,51 +1,93 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
 namespace internal {
 
-/** This class represents the internal representation of registered geometry
- and its topological relationships. */
-class InternalGeometry {
+// TODO(SeanCurtis-TRI): Include additional user-specified payload metadata when
+// added to the declaration of GeometryInstance.
+/** Base class for the internal representation of registered geometry. It
+ includes the data common to both anchored and dynamic geometry. */
+class InternalGeometryBase {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalGeometry)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalGeometryBase)
 
-  /** Default constructor. The ids will be invalid, with no children, and no
-   parent geometry identifier. */
-  InternalGeometry() {}
+  /** Default constructor. The geometry id will be invalid, the shape will
+   be nullptr, and the pose will be uninitialized. */
+  InternalGeometryBase() {}
 
   /** Full constructor.
-   @param frame_id      The identifier of the frame this belongs to.
+   @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
-   @param parent_id     The optional id of the parent geometry.
-   */
-  InternalGeometry(FrameId frame_id, GeometryId geometry_id,
-                   const optional<GeometryId>& parent_id = {}) :
-      frame_id_(frame_id),
-      id_(geometry_id),
-      parent_id_(parent_id) {}
+   @param X_PG          The pose of the geometry G in the parent frame P. */
+  InternalGeometryBase(std::unique_ptr<Shape> shape, GeometryId geometry_id,
+                       const Isometry3<double>& X_PG)
+      : shape_spec_(std::move(shape)),
+        id_(geometry_id),
+        X_PG_(X_PG) {}
 
-  /** Compares two %InternalGeometry instances for "equality". Two internal
-   frames are considered equal if they have the same geometry identifier. */
-  bool operator==(const InternalGeometry &other) const {
+  /** Compares two %InternalGeometryBase instances for "equality". Two internal
+   geometries are considered equal if they have the same geometry identifier. */
+  bool operator==(const InternalGeometryBase &other) const {
     return id_ == other.id_;
   }
 
   /** Compares two %InternalGeometry instances for inequality. See operator==()
    for the definition of equality. */
-  bool operator!=(const InternalGeometry &other) const {
+  bool operator!=(const InternalGeometryBase &other) const {
     return !(*this == other);
   }
 
-  FrameId get_frame_id() const { return frame_id_; }
+  const Shape& get_shape() const { return *shape_spec_; }
   GeometryId get_id() const { return id_; }
+  const Isometry3<double>& get_pose_in_parent() const { return X_PG_; }
+
+ private:
+  // The specification for this instance's shape.
+  copyable_unique_ptr<Shape> shape_spec_;
+
+  // The identifier for this frame.
+  GeometryId id_;
+
+  // The pose of this geometry in the parent frame. The parent may be a frame or
+  // another registered geometry.
+  Isometry3<double> X_PG_;
+};
+
+/** This class represents the internal representation of registered _dynamic_
+ geometry. It includes the user-specified meta data (e.g., name) and internal
+ topology representations. */
+class InternalGeometry : public InternalGeometryBase {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalGeometry)
+
+  /** Default constructor. The parent and frame ids will be invalid as well as
+   the state documented in InternalGeometryBase(). */
+  InternalGeometry();
+
+  /** Full constructor.
+   @param shape         The shape specification for this instance.
+   @param frame_id      The identifier of the frame this belongs to.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param X_PG          The pose of the geometry G in the parent frame P. The
+                        parent may be a frame, or another registered geometry.
+   @param parent_id     The optional id of the parent geometry. */
+  InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
+                   GeometryId geometry_id, const Isometry3<double>& X_PG,
+                   const optional<GeometryId>& parent_id = {});
+
+  FrameId get_frame_id() const { return frame_id_; }
   optional<GeometryId> get_parent_id() const { return parent_id_; }
   void set_parent_id(GeometryId id) { parent_id_ = id; }
 
@@ -90,14 +132,29 @@ class InternalGeometry {
   // The identifier of the frame to which this geometry belongs.
   FrameId frame_id_;
 
-  // The identifier for this frame.
-  GeometryId id_;
-
   // The identifier for this frame's parent frame.
   optional<GeometryId> parent_id_;
 
   // The identifiers for the geometry hung on this frame.
   std::unordered_set<GeometryId> child_geometry_ids_;
+};
+
+/** This class represents the internal representation of registered _anchored_
+ geometry. It includes the user-specified meta data (e.g., name) and internal
+ topology representations. */
+class InternalAnchoredGeometry : public InternalGeometryBase {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalAnchoredGeometry)
+
+  /** Default constructor. All ids will be invalid. */
+  InternalAnchoredGeometry();
+
+  /** Full constructor.
+   @param shape         The shape specification for this instance.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param X_WG          The pose of the geometry G in the world frame W. */
+  InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
+                           const Isometry3<double>& X_WG);
 };
 
 }  // namespace internal


### PR DESCRIPTION
1. Introduce the notion of *anchored* geometry.
2. Extend internal geometry to store specified parameters:
   a. Shape specification (used later to tie into visualization)
   b. Pose in parent (including methods for extracting it).

The three areas of change are:
1. `geometry_instance.h|cc` included a new class and refactored the previous `InternalGeometry` to eliminate common fields.
2. `geometry_state.h|cc` adds operations for registering/removing anchored geometry. Also refines definitions distinguishing between dynamic and anchored geometry.
3. `geometry_state_test.cc` tests the newly added functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6854)
<!-- Reviewable:end -->
