### PR TITLE
remove generic `GetSolutionVectorValues` method. 

### DIFF
--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -2095,15 +2095,6 @@ class MathematicalProgram {
   /** Getter for the initial guess */
   const Eigen::VectorXd& initial_guess() const { return x_initial_guess_; }
 
-  /**
-   * Returns the solution in a flat Eigen::VectorXd. The caller needs to
-   * compute the solution first by calling Solve.
-   * @return a flat Eigen vector that represents the solution.
-   */
-  const Eigen::VectorXd GetSolutionVectorValues() const {
-    return GetSolution(decision_variables_);
-  }
-
   /** Returns the index of the decision variable. Internally the solvers thinks
    * all variables are stored in an array, and it acceses each individual
    * variable using its index. This index is used when adding constraints

--- a/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics.cc
+++ b/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics.cc
@@ -618,7 +618,7 @@ int QpInverseDynamics::Control(const RobotKinematicState<double>& rs,
     std::cerr << "solution not found\n";
     return -1;
   }
-  solution_ = prog_->GetSolutionVectorValues();
+  solution_ = prog_->GetSolution(prog_->decision_variables());
 
   ////////////////////////////////////////////////////////////////////
   // Examples of inspecting each cost / eq, ineq term


### PR DESCRIPTION
we want to discourage code outside of mathematical program from assuming anything about the internal representation of the decision variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6860)
<!-- Reviewable:end -->
