### PR TITLE
Increase Timeout for simulated_schunk_wsg_system_test

### DIFF
--- a/drake/examples/schunk_wsg/BUILD
+++ b/drake/examples/schunk_wsg/BUILD
@@ -78,6 +78,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "simulated_schunk_wsg_system_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     data = [
         "//drake/manipulation/models/wsg_50_description:models",
     ],


### PR DESCRIPTION
We think that this change is needed because of: https://github.com/RobotLocomotion/drake/pull/6677
Timeouts in nightlies: [1](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/) [2](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/) [3](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-snopt/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6865)
<!-- Reviewable:end -->
