### PR TITLE
Make camera config selectable

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -198,6 +198,7 @@ drake_cc_binary(
         "//drake/multibody:rigid_body_tree_construction",
         "//drake/multibody/parsers",
         "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
         "//drake/systems/analysis:simulator",
         "//drake/systems/lcm",
         "//drake/systems/rendering:pose_stamped_t_pose_vector_translator",

--- a/drake/systems/sensors/models/box.sdf
+++ b/drake/systems/sensors/models/box.sdf
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <model name="box">
+    <pose>0 0 0.3 0 0 0</pose>
+    <link name="box">
+      <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>5.</mass>
+        </inertial>
+      <visual name="box">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.05 0.05 0.05</size>
+          </box>
+        </geometry>
+        <material/>
+      </visual>
+      <collision name="box">
+        <geometry>
+          <box>
+            <size>0.05 0.05 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>

--- a/drake/systems/sensors/models/rgbd_camera_example.sdf
+++ b/drake/systems/sensors/models/rgbd_camera_example.sdf
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<sdf version="1.4">
+  <model name="sphere">
+    <pose>0 0 .3 0 0 0</pose>
+    <link name="sphere">
+      <pose>0 0 0 0 0 0</pose>
+      <inertial>
+        <mass>1.</mass>
+      </inertial>
+      <visual name="sphere">
+        <pose>0 0 0 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.1</radius>
+          </sphere>
+        </geometry>
+        <material/>
+      </visual>
+      <collision name="sphere">
+        <geometry>
+          <sphere>
+            <radius>0.1</radius>
+          </sphere>
+        </geometry>
+      </collision>
+    </link>
+    <static>1</static>
+  </model>
+
+  <!-- Note that this model intentionally doesn't have visual element. -->
+  <model name="invisible_box">
+    <pose>0 0 0.015 0 0 0</pose>
+    <link name="box">
+      <pose>0 0 0 0 0 0</pose>
+        <inertial>
+          <mass>1.</mass>
+        </inertial>
+        <collision name="box">
+          <geometry>
+            <box>
+              <size>0.02 1.0 0.03</size>
+            </box>
+          </geometry>
+        </collision>
+    </link>
+    <static>1</static>
+  </model>
+</sdf>

--- a/drake/systems/sensors/models/sphere.sdf
+++ b/drake/systems/sensors/models/sphere.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.4">
   <model name="sphere">
-    <pose>0 0 .3 0 0 0</pose>
+    <pose>0 0 0 0 0 0</pose>
     <link name="sphere">
       <pose>0 0 0 0 0 0</pose>
       <inertial>
@@ -23,25 +23,6 @@
           </sphere>
         </geometry>
       </collision>
-    </link>
-    <static>1</static>
-  </model>
-
-  <!-- Note that this model intentionally doesn't have visual element. -->
-  <model name="invisible_box">
-    <pose>0 0 0.015 0 0 0</pose>
-    <link name="box">
-      <pose>0 0 0 0 0 0</pose>
-        <inertial>
-          <mass>1.</mass>
-        </inertial>
-        <collision name="box">
-          <geometry>
-            <box>
-              <size>0.02 1.0 0.03</size>
-            </box>
-          </geometry>
-        </collision>
     </link>
     <static>1</static>
   </model>

--- a/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/drake/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -29,9 +29,17 @@ namespace systems {
 namespace sensors {
 namespace {
 
-bool ValidateSdf(const char* flagname, const std::string& sdf) {
-  if (sdf.empty()) {
-    cout << "Invalid filename for --" << flagname << ": " << sdf << endl;
+bool ValidateSdf(const char* flagname, const std::string& filename) {
+  if (filename.substr(filename.find_last_of(".") + 1) == "sdf") {
+    return true;
+  }
+  cout << "Invalid filename for --" << flagname << ": " << filename << endl;
+  return false;
+}
+
+bool ValidateDir(const char* flagname, const std::string& dir) {
+  if (dir.empty()) {
+    cout << "Invalid directory for --" << flagname << ": " << dir << endl;
     return false;
   }
   return true;
@@ -47,10 +55,9 @@ DEFINE_string(sdf_fixed, "sphere.sdf",
               "The filename for a SDF that contains fixed base objects.");
 DEFINE_string(sdf_floating, "box.sdf",
               "The filename for a SDF that contains floating base objects.");
-DEFINE_validator(sdf_dir, &ValidateSdf);
+DEFINE_validator(sdf_dir, &ValidateDir);
 DEFINE_validator(sdf_fixed, &ValidateSdf);
 DEFINE_validator(sdf_floating, &ValidateSdf);
-
 
 constexpr double kCameraPosePublishPeriod{0.01};
 constexpr double kImageArrayPublishPeriod{0.01};
@@ -66,9 +73,9 @@ constexpr char kPoseLcmChannelName[] = "DRAKE_RGBD_CAMERA_POSE";
 struct CameraConfig {
   Eigen::Vector3d pos;
   Eigen::Vector3d rpy;
-  double fov_y;
-  double depth_range_near;
-  double depth_range_far;
+  double fov_y{};
+  double depth_range_near{};
+  double depth_range_far{};
 };
 
 }  // anonymous namespace


### PR DESCRIPTION
With this change, users now can choose one of two fixed camera poses at `rgbd_camera_publish_lcm_example`.

Also, added a suitable example scene (sdf) for the camera's looking up at the sky configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6866)
<!-- Reviewable:end -->
