### PR TITLE
add extra constraints to trajectory optimization example

### DIFF
--- a/drake/solvers/ipopt_solver.cc
+++ b/drake/solvers/ipopt_solver.cc
@@ -14,6 +14,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/math/autodiff.h"
 #include "drake/solvers/mathematical_program.h"
@@ -176,7 +177,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     n = problem_->num_vars();
 
     // The IPOPT interface defines eval_f() and eval_grad_f() as
-    // ouputting a single Number for the result, and the size of the
+    // ouputting a single number for the result, and the size of the
     // output gradient array at the same order as the x variables.
     // Initialize the cost cache with those dimensions.
     cost_cache_.reset(new ResultCache(n, 1, n));
@@ -401,6 +402,10 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
       }
       case Ipopt::MAXITER_EXCEEDED: {
         result_ = SolutionResult::kIterationLimit;
+        drake::log()->warn(
+            "IPOPT terminated after exceeding the maximum iteration limit.  "
+            "Hint: Remember that IPOPT is an interior-point method "
+            "and performs badly if any variables are unbounded.");
         break;
       }
       default: {


### PR DESCRIPTION
was doing it to see if I could make IPOPT work for this example.  the change wasn't quite enough to re-enable IPOPT, but it did seem to help.  and I think the code is better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6868)
<!-- Reviewable:end -->
