### PR TITLE
Rotation constraint big m

### DIFF
--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -775,29 +775,30 @@ void AddMcCormickVectorConstraints(
 
               // Cross-product constraint: ideally v2 = v.cross(v1).
               // Since v is within theta of normal, we will prove that
-              // |v2 - normal.cross(v1)| <= 2 * sin(theta / 2)
+              // |v2 - normal.cross(v1)| <= 2 * sin(θ / 2)
               // Notice that (v2 - normal.cross(v1))ᵀ * (v2 - normal.cross(v1))
               // = v2ᵀ * v2 + |normal.cross(v1))|² -
               //      2 * v2ᵀ * (normal.cross(v1))
               // = 1 + |normal.cross(v1))|² - 2 * normalᵀ*(v1.cross(v2))
               // = 1 + |normal.cross(v1))|² - 2 * normalᵀ*v
-              // <= 1 + 1 - 2 * cos(theta)
-              // = (2 * sin(theta / 2))²
-              // Thus we get |v2 - normal.cross(v1)| <= 2 * sin(theta / 2)
+              // <= 1 + 1 - 2 * cos(θ)
+              // = (2 * sin(θ / 2))²
+              // Thus we get |v2 - normal.cross(v1)| <= 2 * sin(θ / 2)
               // Here we consider to use an elementwise linear constraint
-              // -2*sin(theta / 2) <=  v2 - normal.cross(v1) <= 2*sin(theta / 2)
-              // Since 0<=theta<=pi/2, this should be enough to rule out the
+              // -2*sin(theta / 2) <=  v2 - normal.cross(v1) <= 2*sin(θ / 2)
+              // Since 0<=θ<=pi/2, this should be enough to rule out the
               // det(R)=-1 case (the shortest projection of a line across the
               // circle onto a single axis has length 2sqrt(3)/3 > 1.15), and
               // can be significantly tighter.
 
               // To activate this only when the box is active, the complete
               // constraints are
-              //  -2*sin(theta/2)-2*(3-(cxi+cyi+czi)) <= v2-normal.cross(v1)
-              //    v2-normal.cross(v1) <= 2*sin(theta/2)+2*(3-(cxi+cyi+czi))
+              //  -2*sin(θ/2)-(2 - 2sin(θ/2))*(3-(cxi+cyi+czi))
+              //   <= v2-normal.cross(v1)
+              //     <= 2*sin(θ/2)+(2 - 2sin(θ/2))*(3-(cxi+cyi+czi))
               // Note: Again this constraint could be tighter as a Lorenz cone
               // constraint of the form:
-              //   |v2 - normal.cross(v1)| <= 2*sin(theta/2).
+              //   |v2 - normal.cross(v1)| <= 2*sin(θ/2).
               const double sin_theta2 = sin(theta/2);
               const Vector3<symbolic::Expression> v2_minus_n_cross_n1{
                   v2 - orthant_normal.cross(v1)};

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -800,15 +800,15 @@ void AddMcCormickVectorConstraints(
               // constraint of the form:
               //   |v2 - normal.cross(v1)| <= 2*sin(θ/2).
               const double sin_theta2 = sin(theta/2);
-              const Vector3<symbolic::Expression> v2_minus_n_cross_n1{
+              const Vector3<symbolic::Expression> v2_minus_n_cross_v1{
                   v2 - orthant_normal.cross(v1)};
               prog->AddLinearConstraint(
-                  v2_minus_n_cross_n1 <=
+                  v2_minus_n_cross_v1 <=
                   Vector3<symbolic::Expression>::Constant(
                       2 * sin_theta2 +
                       (2 - 2 * sin_theta2) * (3 - orthant_c_sum)));
               prog->AddLinearConstraint(
-                  v2_minus_n_cross_n1 >=
+                  v2_minus_n_cross_v1 >=
                   Vector3<symbolic::Expression>::Constant(
                       -2 * sin_theta2 +
                       (-2 + 2 * sin_theta2) * (3 - orthant_c_sum)));

--- a/drake/solvers/rotation_constraint.cc
+++ b/drake/solvers/rotation_constraint.cc
@@ -724,6 +724,8 @@ void AddMcCormickVectorConstraints(
                 prog->AddLinearConstraint(
                   orthant_normal.transpose(), -1, 1, v);
 
+              const symbolic::Expression orthant_c_sum{orthant_c.sum()};
+
               // Dot-product constraint: ideally v.dot(v1) = v.dot(v2) = 0.
               // The cone of (unit) vectors within theta of the normal vector
               // defines a band of admissible vectors v1 and v2 which are
@@ -738,11 +740,6 @@ void AddMcCormickVectorConstraints(
               //                |normal||vi| cos(pi/2 - theta).
               // Since normal and vi are both unit length,
               //     -sin(theta) <= normal.dot(vi) <= sin(theta).
-              // To activate this only when this box is active, we use
-              //   -sin(theta)-3+c[xi](0)+c[yi](1)+c[zi](2) <=
-              //   normal.dot(vi)
-              //     normal.dot(vi) <=
-              //     sin(theta)+3-c[xi](0)-c[yi](1)-c[zi](2).
               // Note: (An alternative tighter, but SOCP constraint)
               //   v, v1, v2 forms an orthornormal basis. So n'*v is the
               //   projection of n in the v direction, same for n'*v1, n'*v2.
@@ -752,21 +749,30 @@ void AddMcCormickVectorConstraints(
               //   sum of squares of the vector projected onto each axes of an
               //   orthornormal basis".
               //   This equation is the same as
-              //     (n'*v1)² + (n'*v2)² <= sin(theta)²
-              //   So actually instead of imposing
-              //     -sin(theta)<=n'*vi <=sin(theta),
+              //     (nᵀ*v1)² + (nᵀ*v2)² <= sin(theta)²
               //   we can impose a tighter Lorentz cone constraint
-              //     [|sin(theta)|, n'*v1, n'*v2] is in the Lorentz cone.
-              prog->AddLinearConstraint(
-                orthant_normal.dot(v1) - orthant_c.sum() >= -sin(theta) - 3);
-              prog->AddLinearConstraint(
-                orthant_normal.dot(v2) - orthant_c.sum() >= -sin(theta) - 3);
+              //     [|sin(theta)|, nᵀ*v1, nᵀ*v2] is in the Lorentz cone.
+              // We relax this Lorentz cone constraint by linear constraints
+              // -sinθ <= nᵀ * v1 <= sinθ
+              // -sinθ <= nᵀ * v2 <= sinθ
+              // To activate this constraint, we define
+              // c_sum = c[xi](0) + c[yi](1) + c[zi](2), and impose the
+              // following constraint using big-M approach.
+              // nᵀ * v1 - sinθ <= (1 - sinθ)*(3 - c_sum)
+              // nᵀ * v2 - sinθ <= (1 - sinθ)*(3 - c_sum)
+              // nᵀ * v1 + sinθ >= (-1 + sinθ)*(3 - c_sum)
+              // nᵀ * v2 + sinθ >= (-1 + sinθ)*(3 - c_sum)
+              const double sin_theta{sin(theta)};
+              prog->AddLinearConstraint(orthant_normal.dot(v1) + sin_theta >=
+                                        (-1 + sin_theta) * (3 - orthant_c_sum));
+              prog->AddLinearConstraint(orthant_normal.dot(v2) + sin_theta >=
+                                        (-1 + sin_theta) * (3 - orthant_c_sum));
 
-              prog->AddLinearConstraint(
-                orthant_normal.dot(v1) + orthant_c.sum() <= sin(theta) + 3);
-              prog->AddLinearConstraint(
-                orthant_normal.dot(v2) + orthant_c.sum() <= sin(theta) + 3);
-              
+              prog->AddLinearConstraint(orthant_normal.dot(v1) - sin_theta <=
+                                        (1 - sin_theta) * (3 - orthant_c_sum));
+              prog->AddLinearConstraint(orthant_normal.dot(v2) - sin_theta <=
+                                        (1 - sin_theta) * (3 - orthant_c_sum));
+
               // Cross-product constraint: ideally v2 = v.cross(v1).
               // Since v is within theta of normal, we will prove that
               // |v2 - normal.cross(v1)| <= 2 * sin(theta / 2)
@@ -787,20 +793,24 @@ void AddMcCormickVectorConstraints(
 
               // To activate this only when the box is active, the complete
               // constraints are
-              //  -2*sin(theta/2)-sqrt(2)*(3-(cxi+cyi+czi)) <= v2-normal.cross(v1)
-              //    v2-normal.cross(v1) <= 2*sin(theta/2)+sqrt(2)*(3-(cxi+cyi+czi))
+              //  -2*sin(theta/2)-2*(3-(cxi+cyi+czi)) <= v2-normal.cross(v1)
+              //    v2-normal.cross(v1) <= 2*sin(theta/2)+2*(3-(cxi+cyi+czi))
               // Note: Again this constraint could be tighter as a Lorenz cone
               // constraint of the form:
               //   |v2 - normal.cross(v1)| <= 2*sin(theta/2).
               const double sin_theta2 = sin(theta/2);
+              const Vector3<symbolic::Expression> v2_minus_n_cross_n1{
+                  v2 - orthant_normal.cross(v1)};
               prog->AddLinearConstraint(
-                Vector3<Expression>::Constant(
-                  -2*sin_theta2 - 2*(3 - orthant_c.sum()))
-                <= v2 - orthant_normal.cross(v1));
+                  v2_minus_n_cross_n1 <=
+                  Vector3<symbolic::Expression>::Constant(
+                      2 * sin_theta2 +
+                      (2 - 2 * sin_theta2) * (3 - orthant_c_sum)));
               prog->AddLinearConstraint(
-                v2 - orthant_normal.cross(v1) <=
-                Vector3<Expression>::Constant(
-                  2*sin_theta2 + 2* (3 - orthant_c.sum())));
+                  v2_minus_n_cross_n1 >=
+                  Vector3<symbolic::Expression>::Constant(
+                      -2 * sin_theta2 +
+                      (-2 + 2 * sin_theta2) * (3 - orthant_c_sum)));
             }
           }
         } else {


### PR DESCRIPTION
Changed the big M number in two constraints. Potentially this should help the lower bound to increase faster, and mixed-integer problem would converge quicker.

In the `rotation_constraint_limit_test`, I compare the speed before and after this PR

| test number | 1 | 2 | 3 | 4 |
|---|--|--|--|--|
| before this PR (s)| 13.34 | 102.36 | 19.82 | 233.06 |
| after this PR (s) | 12 | 88 | 14.5 | 198.24 |

I do not have other tests that look for an optimal solution using `rotation_constraint.cc`. @gizatt it might help your pose estimation problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6872)
<!-- Reviewable:end -->
