### PR TITLE
Introduce pose data into the state

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -25,6 +25,13 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "geometry_index",
+    srcs = [],
+    hdrs = ["geometry_index.h"],
+    deps = ["//drake/common:type_safe_index"],
+)
+
+drake_cc_library(
     name = "geometry_instance",
     srcs = ["geometry_instance.cc"],
     hdrs = ["geometry_instance.h"],
@@ -42,6 +49,7 @@ drake_cc_library(
     deps = [
         ":geometry_frame",
         ":geometry_ids",
+        ":geometry_index",
         ":geometry_instance",
         ":internal_frame",
         ":internal_geometry",
@@ -71,6 +79,7 @@ drake_cc_library(
     hdrs = ["internal_frame.h"],
     deps = [
         ":geometry_ids",
+        ":geometry_index",
         "//drake/common",
     ],
 )
@@ -81,6 +90,7 @@ drake_cc_library(
     hdrs = ["internal_geometry.h"],
     deps = [
         ":geometry_ids",
+        ":geometry_index",
         ":shape_specification",
         "//drake/common",
         "//drake/common:copyable_unique_ptr",
@@ -107,6 +117,14 @@ drake_cc_library(
     name = "expect_error_message",
     srcs = [],
     hdrs = ["test/expect_error_message.h"],
+)
+
+drake_cc_googletest(
+    name = "geometry_instance_test",
+    deps = [
+        ":geometry_instance",
+        "//drake/common:copyable_unique_ptr",
+    ],
 )
 
 drake_cc_googletest(

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -30,7 +30,33 @@ class GeometryFrame {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryFrame)
 
-  GeometryFrame() = default;
+  /** Constructor.
+   @param frame_name        The name of the frame.
+   @param X_PF              The initial pose of this frame F, measured and
+                            expressed in the _intended_ parent frame P.
+   @param frame_group_id    The optional frame group identifier. If unspecified,
+                            defaults to the common, 0 group. */
+  GeometryFrame(const std::string& frame_name, const Isometry3<double>& X_PF,
+                int frame_group_id = 0)
+      : name_(frame_name), X_PF_(X_PF), frame_group_(frame_group_id) {}
+
+  const std::string& get_name() const { return name_; }
+  const Isometry3<double>& get_pose() const { return X_PF_; }
+  int get_frame_group() const { return frame_group_; }
+
+ private:
+  // The name of the frame. Must be unique across frames from the same geometry
+  // source.
+  std::string name_;
+
+  // The initial pose of frame F, measured and expressed in the parent frame P.
+  Isometry3<double> X_PF_;
+
+  // TODO(SeanCurtis-TRI): Consider whether this should be an Identifier or
+  // TypeSafeIndex type.
+  // The frame group to which this frame belongs.
+  int frame_group_;
 };
+
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_index.h
+++ b/drake/geometry/geometry_index.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "drake/common/type_safe_index.h"
+
+namespace drake {
+namespace geometry {
+
+/** Type used to locate a dynamic geometry in the geometry engine. */
+using GeometryIndex = TypeSafeIndex<class GeometryTag>;
+
+/** Type used to locate an anchored geometry in the geometry engine. */
+using AnchoredGeometryIndex = TypeSafeIndex<class AnchoredGeometryTag>;
+
+/** Type used to locate a frame pose in the geometry state. */
+using PoseIndex = TypeSafeIndex<class GeometryPoseTag>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/internal_frame.cc
+++ b/drake/geometry/internal_frame.cc
@@ -6,6 +6,26 @@ namespace internal {
 
 const FrameId InternalFrame::kWorldFrame{FrameId::get_new_id()};
 
+InternalFrame::InternalFrame() {}
+
+InternalFrame::InternalFrame(SourceId source_id, FrameId frame_id,
+                             const std::string& name, int frame_group,
+                             PoseIndex pose_index, FrameId parent_id)
+    : source_id_(source_id),
+      id_(frame_id),
+      name_(name),
+      frame_group_(frame_group),
+      pose_index_(pose_index),
+      parent_id_(parent_id) {}
+
+bool InternalFrame::operator==(const InternalFrame& other) const {
+  return id_ == other.id_;
+}
+
+bool InternalFrame::operator!=(const InternalFrame& other) const {
+  return !(*this == other);
+}
+
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/internal_frame.h
+++ b/drake/geometry/internal_frame.h
@@ -5,6 +5,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_index.h"
 
 namespace drake {
 namespace geometry {
@@ -24,32 +25,34 @@ class InternalFrame {
 
   /** Default constructor. The parent identifier and pose index will be
    invalid. */
-  InternalFrame() {}
+  InternalFrame();
 
   /** Full constructor.
    @param source_id     The identifier of the source this belongs to.
    @param frame_id      The identifier of _this_ frame.
+   @param name          The name of the frame.
+   @param frame_group   The frame's frame group membership.
+   @param pose_index    The position in the pose vector of this frame's last
+                        known pose.
    @param parent_id     The id of the parent frame.
    */
-  InternalFrame(SourceId source_id, FrameId frame_id, FrameId parent_id) :
-      source_id_(source_id),
-      id_(frame_id),
-      parent_id_(parent_id) {}
+  InternalFrame(SourceId source_id, FrameId frame_id, const std::string &name,
+                int frame_group, PoseIndex pose_index, FrameId parent_id);
 
   /** Compares two %InternalFrame instances for "equality". Two internal frames
    are considered equal if they have the same frame identifier. */
-  bool operator==(const InternalFrame &other) const {
-    return id_ == other.id_;
-  }
+  bool operator==(const InternalFrame &other) const;
 
   /** Compares two %InternalFrame instances for inequality. See operator==()
    for the definition of equality. */
-  bool operator!=(const InternalFrame &other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const InternalFrame &other) const;
 
   SourceId get_source_id() const { return source_id_; }
   FrameId get_id() const { return id_; }
+  const std::string &get_name() const { return name_; }
+  int get_frame_group() const { return frame_group_; }
+  PoseIndex get_pose_index() const { return pose_index_; }
+  void set_pose_index(PoseIndex index) { pose_index_ = index; }
 
   /** Returns true if this frame is the child of the identified frame. */
   bool has_parent(FrameId parent) const { return parent_id_ == parent; }
@@ -111,6 +114,20 @@ class InternalFrame {
   // The identifier of this frame.
   FrameId id_;
 
+  // The name of the frame. Must be unique across frames from the same
+  // geometry source.
+  std::string name_;
+
+  // TODO(SeanCurtis-TRI): Consider whether this should be an Identifier or
+  // TypeSafeIndex type.
+  // The frame group to which this frame belongs.
+  int frame_group_{0};
+
+  // TODO(SeanCurtis-TRI): Use default constructor when the type safe index
+  // default value PR lands.
+  // The index in the pose vector where this frame's pose lives.
+  PoseIndex pose_index_{0};
+
   // The identifier of this frame's parent frame.
   FrameId parent_id_;
 
@@ -130,15 +147,3 @@ class InternalFrame {
 }  // namespace internal
 }  // namespace geometry
 }  // namespace drake
-
-namespace std {
-/** Enables use of the %InternalFrame to serve as a key in STL containers.
- @relates InternalFrame */
-template <>
-struct hash<drake::geometry::internal::InternalFrame> {
-  size_t operator()(
-      const drake::geometry::internal::InternalFrame& frame) const {
-    return hash<drake::geometry::FrameId>()(frame.get_id());
-  }
-};
-}  // namespace std

--- a/drake/geometry/internal_geometry.cc
+++ b/drake/geometry/internal_geometry.cc
@@ -9,17 +9,20 @@ InternalGeometry::InternalGeometry() : InternalGeometryBase() {}
 InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
                                    FrameId frame_id, GeometryId geometry_id,
                                    const Isometry3<double>& X_PG,
+                                   GeometryIndex engine_index,
                                    const optional<GeometryId>& parent_id)
     : InternalGeometryBase(std::move(shape), geometry_id, X_PG),
       frame_id_(frame_id),
+      engine_index_(engine_index),
       parent_id_(parent_id) {}
 
 InternalAnchoredGeometry::InternalAnchoredGeometry() : InternalGeometryBase() {}
 
 InternalAnchoredGeometry::InternalAnchoredGeometry(
     std::unique_ptr<Shape> shape, GeometryId geometry_id,
-    const Isometry3<double>& X_WG)
-    : InternalGeometryBase(std::move(shape), geometry_id, X_WG) {}
+    const Isometry3<double>& X_WG, AnchoredGeometryIndex engine_index)
+    : InternalGeometryBase(std::move(shape), geometry_id, X_WG),
+      engine_index_(engine_index) {}
 
 }  // namespace internal
 }  // namespace geometry

--- a/drake/geometry/internal_geometry.h
+++ b/drake/geometry/internal_geometry.h
@@ -9,6 +9,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_index.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -82,14 +83,18 @@ class InternalGeometry : public InternalGeometryBase {
    @param geometry_id   The identifier for _this_ geometry.
    @param X_PG          The pose of the geometry G in the parent frame P. The
                         parent may be a frame, or another registered geometry.
+   @param engine_index  The position in the geometry engine of this geometry.
    @param parent_id     The optional id of the parent geometry. */
   InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
                    GeometryId geometry_id, const Isometry3<double>& X_PG,
+                   GeometryIndex engine_index,
                    const optional<GeometryId>& parent_id = {});
 
   FrameId get_frame_id() const { return frame_id_; }
   optional<GeometryId> get_parent_id() const { return parent_id_; }
   void set_parent_id(GeometryId id) { parent_id_ = id; }
+  GeometryIndex get_engine_index() const { return engine_index_; }
+  void set_engine_index(GeometryIndex index) { engine_index_ = index; }
 
   /** Returns true if this geometry has a geometry parent and the parent has the
    given `geometry_id`. */
@@ -132,6 +137,9 @@ class InternalGeometry : public InternalGeometryBase {
   // The identifier of the frame to which this geometry belongs.
   FrameId frame_id_;
 
+  // The index of the geometry in the engine.
+  GeometryIndex engine_index_;
+
   // The identifier for this frame's parent frame.
   optional<GeometryId> parent_id_;
 
@@ -146,15 +154,25 @@ class InternalAnchoredGeometry : public InternalGeometryBase {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalAnchoredGeometry)
 
-  /** Default constructor. All ids will be invalid. */
+  /** Default constructor. State will be as documented in
+   InternalGeometryBase(). */
   InternalAnchoredGeometry();
 
   /** Full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
-   @param X_WG          The pose of the geometry G in the world frame W. */
+   @param X_WG          The pose of the geometry G in the world frame W.
+   @param engine_index  The position in the geometry engine of this geometry. */
   InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
-                           const Isometry3<double>& X_WG);
+                           const Isometry3<double>& X_WG,
+                           AnchoredGeometryIndex engine_index);
+
+  AnchoredGeometryIndex get_engine_index() const { return engine_index_; }
+  void set_engine_index(AnchoredGeometryIndex index) { engine_index_ = index; }
+
+ private:
+  // The index of the geometry in the engine.
+  AnchoredGeometryIndex engine_index_;
 };
 
 }  // namespace internal

--- a/drake/geometry/test/geometry_instance_test.cc
+++ b/drake/geometry/test/geometry_instance_test.cc
@@ -1,0 +1,18 @@
+#include "drake/geometry/geometry_instance.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/copyable_unique_ptr.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+// Confirms that the instance is copyable.
+GTEST_TEST(GeometryInstanceTest, IsCopyable) {
+  EXPECT_TRUE(is_copyable_unique_ptr_compatible<GeometryInstance>::value);
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -8,6 +8,7 @@
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/query_handle.h"
+#include "drake/geometry/shape_specification.h"
 #include "drake/geometry/test/expect_error_message.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -185,7 +186,7 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
   // Attach frame to world.
   EXPECT_ERROR_MESSAGE(
       system_.RegisterFrame(
-          id, GeometryFrame()),
+          id, GeometryFrame("frame", Isometry3<double>::Identity())),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");
@@ -194,7 +195,7 @@ TEST_F(GeometrySystemTest, TopologyAfterAllocation) {
   EXPECT_ERROR_MESSAGE(
       system_.RegisterFrame(
           id, FrameId::get_new_id(),
-          GeometryFrame()),
+          GeometryFrame("frame", Isometry3<double>::Identity())),
       std::logic_error,
       "The call to RegisterFrame is invalid; a context has already been "
       "allocated.");


### PR DESCRIPTION
1. Add representations of frame and geometry poses
2. Add operations on those poses
3. Incidentally, include previously missing `GeometryInstance` test --
   confirm that it is compatible with `copyable_unique_ptr`.

* NOTE: The has function on the `InternalFrame` was deleted as an anachronism. It shouldn't have been committed in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6873)
<!-- Reviewable:end -->
