### PR TITLE
adds utility for counting the total number of states. 

### DIFF
--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -85,6 +85,17 @@ class Context {
     return nxd > 0 && nxc == 0 && nxa == 0;
   }
 
+  /// Returns the total dimension of all of the basic vector states (as if they
+  /// were muxed).
+  /// @throws std::runtime_error if the system contains any abstract state.
+  int get_num_total_states() const {
+    DRAKE_THROW_UNLESS(get_num_abstract_state_groups() == 0);
+    int count = get_continuous_state()->size();
+    for (int i = 0; i < get_num_discrete_state_groups(); i++)
+      count += get_discrete_state(i)->size();
+    return count;
+  }
+
   /// Sets the continuous state to @p xc, deleting whatever was there before.
   void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
     get_mutable_state()->set_continuous_state(std::move(xc));

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -197,6 +197,31 @@ TEST_F(LeafContextTest, HasOnlyDiscreteState) {
   EXPECT_TRUE(context_.has_only_discrete_state());
 }
 
+TEST_F(LeafContextTest, GetNumStates) {
+  LeafContext<double> context;
+  EXPECT_EQ(context.get_num_total_states(), 0);
+
+  // Reserve a continuous state with five elements.
+  context.set_continuous_state(std::make_unique<ContinuousState<double>>(
+      BasicVector<double>::Make({1.0, 2.0, 3.0, 5.0, 8.0})));
+  EXPECT_EQ(context.get_num_total_states(), 5);
+
+  // Reserve a discrete state with two elements, of size 1 and size 2.
+  std::vector<std::unique_ptr<BasicVector<double>>> xd;
+  xd.push_back(BasicVector<double>::Make({128.0}));
+  xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
+  context.set_discrete_state(
+      std::make_unique<DiscreteValues<double>>(std::move(xd)));
+  EXPECT_EQ(context.get_num_total_states(), 8);
+
+  // Reserve an abstract state with one element, which is not owned.
+  std::unique_ptr<AbstractValue> abstract_state = PackValue(42);
+  std::vector<AbstractValue*> xa;
+  xa.push_back(abstract_state.get());
+  context.set_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
+  EXPECT_THROW(context.get_num_total_states(), std::runtime_error);
+}
+
 TEST_F(LeafContextTest, GetVectorInput) {
   LeafContext<double> context;
   context.SetNumInputPorts(2);


### PR DESCRIPTION
very useful for e.g. passing num_states arguments into constructors for algorithms that may work for discrete and/or continuous systems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6879)
<!-- Reviewable:end -->
