### PR TITLE
kcov: Fix issue #6603

### DIFF
--- a/tools/kcov.sh
+++ b/tools/kcov.sh
@@ -14,4 +14,5 @@ kcov \
     --include-path=$WORKSPACE \
     --exclude-pattern=thirdParty,externals \
     $WORKSPACE/bazel-kcov \
+    --replace-src-path=/proc/self/cwd:$WORKSPACE \
     "$@"


### PR DESCRIPTION
Newer bazel (0.5.0 and later) presents the source paths as starting with
"/proc/self/cwd" on Linux, and kcov needs some help unwinding that to actually
find sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6880)
<!-- Reviewable:end -->
