### PR TITLE
Add Maliput's RNDF implementation Builder class with lane support only

### DIFF
--- a/drake/automotive/maliput/rndf/BUILD
+++ b/drake/automotive/maliput/rndf/BUILD
@@ -14,15 +14,22 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_library(
     name = "builder",
     srcs = [
+        "builder.cc",
         "connection.cc",
         "directed_waypoint.cc",
     ],
     hdrs = [
+        "builder.h",
         "connection.h",
         "directed_waypoint.h",
     ],
     deps = [
+        ":lanes",
+        "//drake/automotive/maliput/api",
         "//drake/common",
+        "//drake/common/trajectories:piecewise_polynomial",
+        "//drake/math:geometric_transform",
+        "//drake/math:saturate",
         "@ignition_math",
         "@ignition_rndf",
     ],
@@ -77,6 +84,14 @@ drake_cc_googletest(
         ":ignition_types_compare",
         "@ignition_math",
         "@ignition_rndf",
+    ],
+)
+
+drake_cc_googletest(
+    name = "builder_test",
+    deps = [
+        ":builder",
+        "//drake/automotive/maliput/api:maliput_types_compare",
     ],
 )
 

--- a/drake/automotive/maliput/rndf/builder.cc
+++ b/drake/automotive/maliput/rndf/builder.cc
@@ -1,0 +1,636 @@
+#include "drake/automotive/maliput/rndf/builder.h"
+
+#include <algorithm>
+#include <cmath>
+#include <tuple>
+#include <utility>
+
+#include "ignition/rndf/UniqueId.hh"
+
+#include "drake/automotive/maliput/rndf/branch_point.h"
+#include "drake/automotive/maliput/rndf/junction.h"
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+#include "drake/automotive/maliput/rndf/segment.h"
+#include "drake/automotive/maliput/rndf/spline_lane.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/text_logging.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+namespace {
+
+using std::cos;
+using std::copysign;
+using std::find;
+using std::make_unique;
+using std::map;
+using std::move;
+using std::pair;
+using std::sin;
+using std::sort;
+using std::string;
+using std::to_string;
+using std::tuple;
+using std::unique_ptr;
+using std::vector;
+
+// Let p and q be the position of two RNDF waypoints w1 and w2 which belong
+// to two different RNDF lanes on the same RNDF segment. Let F1 and F2 be the
+// curve functions that parameterizes each lane. In addition, let q' be the
+// intersection point of the normal vector of q at F1's trajectory. We can
+// define the distance between q' and p as D, and when D is less than
+// kWaypointDistancePhase no new DirectedWaypoint will be inserted into the
+// set of DirectedWaypoints that will describe F1. In other words,
+// kWaypointDistancePhase sets a tolerance for waypoint alignment and thus
+// prevents the proliferation of very short segments that in turn would pose
+// a strain on spline interpolation attempting to ensure convexity and
+// monotonicity.
+const double kWaypointDistancePhase = 2.0;
+
+// Let F be a function that describes a reference curve for a Lane. To find
+// the point on the reference curve whose Euclidean distance to another
+// arbitrary point is minimum, F will be sampled every kLinearStep, directly
+// affecting the accuracy of the approximation.
+const double kLinearStep = 1e-2;
+
+// Determines the heading (in xy-plane) along the centerline when traveling
+// towards/into the @p lane, from the specified @p end.
+double HeadingIntoLane(const api::Lane* const lane,
+                       const api::LaneEnd::Which end) {
+  switch (end) {
+    case api::LaneEnd::kStart: {
+      return lane->GetOrientation({0., 0., 0.}).yaw();
+    }
+    case api::LaneEnd::kFinish: {
+      return lane->GetOrientation({lane->length(), 0., 0.}).yaw() + M_PI;
+    }
+    default: { DRAKE_ABORT(); }
+  }
+}
+
+// Computes the Euclidean distance between @p base and @p target,
+// projected along base's tangent.
+double ComputeProjectedDistance(const DirectedWaypoint& base,
+                                const DirectedWaypoint& target) {
+  return (target.position() - base.position())
+      .Dot(ignition::math::Vector3d(base.tangent()).Normalize());
+}
+
+// Builds an ignition::math::Spline from a set of @p waypoints.
+//
+// When at least three (3) valid waypoints are provided, a PChip
+// algorithm is used to ensure monotonicity and convexity by means
+// of calling CreatePChipBasedSpline().
+// @remarks Any invalid waypoint in @p waypoints will not be taken into
+// account.
+// @pre There must be at least two (2) valid waypoints in @p waypoints.
+// @warning This method will abort if any preconditions are not met.
+unique_ptr<ignition::math::Spline> CreateSpline(
+    const vector<DirectedWaypoint>& waypoints) {
+  vector<ignition::math::Vector3d> positions;
+  for (const DirectedWaypoint& waypoint : waypoints) {
+    if (waypoint.id().Valid()) {
+      positions.push_back(waypoint.position());
+    }
+  }
+  DRAKE_DEMAND(positions.size() > 1);
+  // PChip will provide a first derivative with null vectors at one of the
+  // extents which is not a valid value, so for that specific case, a spline
+  // is built directly from provided points.
+  if (positions.size() == 2) {
+    unique_ptr<ignition::math::Spline> spline =
+        make_unique<ignition::math::Spline>();
+    spline->AutoCalculate(true);
+    spline->AddPoint(positions[0]);
+    spline->AddPoint(positions[1]);
+    return spline;
+  }
+  return CreatePChipBasedSpline(positions);
+}
+
+// Interpolates tangents for each of the @p waypoints using a spline curve,
+// applying CreateSpline() with the @p waypoints' positions only.
+// @pre The given @p waypoints collection must not be a nullptr.
+// @warning This method will abort if any preconditions are not met.
+void BuildTangentsForWaypoints(vector<DirectedWaypoint>* waypoints) {
+  DRAKE_DEMAND(waypoints != nullptr);
+  // Builds a spline to obtain tangent information.
+  const unique_ptr<ignition::math::Spline> spline = CreateSpline(*waypoints);
+  for (size_t base_index = 0, index = 0; index < waypoints->size(); index++) {
+    if (!waypoints->at(index).id().Valid()) {
+      base_index = index;
+    } else {
+      waypoints->at(index).set_tangent(spline->Tangent(index - base_index));
+    }
+  }
+}
+
+// Identifies the @p connections that come first in the direction the whole
+// collection of connections flows, by computing the projection of every
+// waypoint at @p index onto every other waypoint's tangent at @p index so
+// as to identify those that have the most projections ahead of them in the
+// relative direction sense.
+// @pre All @p connections flow in the same relative direction.
+// @param connections A collection of Connections to be inspected.
+// @param index The index to the waypoints within the @p connections.
+// @return A collection with the indexes of the @p connections that come
+// first. When the collection is empty, it means that all the @p connections'
+// waypoints are in line with the @p connections' normal (thus no one comes
+// first).
+vector<int> GetInitialConnectionToProcess(const vector<Connection>& connections,
+                                          size_t index) {
+  // Computes the number of valid distances between connections.
+  vector<pair<int, int>> index_valid_distances;
+  for (size_t i = 0; i < connections.size(); ++i) {
+    int number_of_valid_distances = 0;
+    for (size_t j = 0; j < connections.size(); ++j) {
+      // Skips distance computation if one of the connections is shorter than
+      // the other in terms of waypoints or a waypoint is being compared against
+      // itself (i == j).
+      if (i != j && index < connections[i].waypoints().size() &&
+          index < connections[j].waypoints().size()) {
+        // Computes the distance, that will only be considered if it's above
+        // the kWaypointDistancePhase minimum.
+        double distance =
+            ComputeProjectedDistance(connections[i].waypoints()[index],
+                                     connections[j].waypoints()[index]);
+        if (distance > kWaypointDistancePhase) {
+          number_of_valid_distances++;
+        }
+      }
+    }
+    index_valid_distances.emplace_back(i, number_of_valid_distances);
+  }
+  // Sorts the vector by increasing number of valid distances. It gives us as
+  // the first items the ids of the Connections to process.
+  sort(index_valid_distances.begin(), index_valid_distances.end(),
+       [](const pair<int, int>& t_a, const pair<int, int>& t_b) {
+         return t_a.second > t_b.second;
+       });
+  // Creates a vector with all the connection ids that appear first.
+  vector<int> ids;
+  for (const pair<int, int>& id_zeros : index_valid_distances) {
+    if (id_zeros.second == index_valid_distances[0].second)
+      ids.push_back(id_zeros.first);
+  }
+  // In case we have all the lane ids, no one is the first, all are on the same
+  // line.
+  if (ids.size() == index_valid_distances.size()) {
+    ids.clear();
+  }
+  return ids;
+}
+
+// Computes the momentum @f$ \tau^W @f$ exerted by the fictitious unitary
+// force @f$ f^W @f$ on @p waypoint @f$ W @f$ around the @p center_of_rotation
+// @f$ R @f$. This force is applied on the @p waypoint's tangent direction.
+// @remarks Since RNDF provides no information on the z coordinate, all
+// waypoints are on the @f$ z = 0 @f$ plane and the torque will always be
+// applied entirely on the z-axis.
+// @return The computed momentum's z-axis component.
+double CalculateMomentum(const ignition::math::Vector3d& center_of_rotation,
+                         const DirectedWaypoint& waypoint) {
+  // Calculates waypoint W position with respect to the center of rotation R.
+  const ignition::math::Vector3d p_WR =
+      waypoint.position() - center_of_rotation;
+  // Computes torque t on waypoint W applied around the center of rotation R.
+  ignition::math::Vector3d f_W = waypoint.tangent().Normalized();
+  const ignition::math::Vector3d t_WR = f_W.Cross(p_WR);
+  // As all the points should lie on the x-y plane, the cross product should
+  // be collinear with the z-axis, thus the only non zero component is z.
+  return t_WR.Z();
+}
+
+// Computes the momentum sum of all the @p waypoints around @p origin
+// using CalculateMomentum(). This is helpful to determine the relative
+// direction of a given connection with respect to adjacent ones (lanes in
+// a segment).
+double CalculateConnectionMomentum(
+    const ignition::math::Vector3d& center_of_rotation,
+    const vector<DirectedWaypoint>& waypoints) {
+  double momentum = 0.0;
+  for (const DirectedWaypoint& waypoint : waypoints) {
+    momentum += CalculateMomentum(center_of_rotation, waypoint);
+  }
+  return momentum;
+}
+
+// Groups @p connections in separate @p connection_groups based on
+// their relative direction.
+// @param connections A collection of Connections to be grouped.
+// @param connection_groups A mapping for connection group numbers
+// to connection groups.
+// @pre The given @p connection_groups collection must not be a nullptr.
+// @warning This method will abort execution if any preconditions are not met.
+void GroupConnectionsByDirection(
+    const vector<Connection>& connections,
+    map<int, vector<Connection>>* connection_groups) {
+  DRAKE_DEMAND(connection_groups != nullptr);
+  int connection_group_id = 0;
+  bool current_inversion = connections.front().inverse_direction();
+  for (const Connection& connection : connections) {
+    if (current_inversion != connection.inverse_direction()) {
+      current_inversion = connection.inverse_direction();
+      connection_group_id++;
+    }
+    // Creates an entry for the map if it doesn't exist.
+    if (connection_groups->find(connection_group_id) ==
+        connection_groups->end()) {
+      (*connection_groups)[connection_group_id] = vector<Connection>();
+    }
+    // Adds the lane to the group.
+    (*connection_groups)[connection_group_id].push_back(connection);
+  }
+}
+
+// Orders a collection of @p ids, each identifying a connection at the
+// same index in @p connections, in a right to left sense. To perform such
+// ordering, it uses the first waypoint on each connection.
+// @param connections A collection of Connections.
+// @param ids The collection of ids for each one of the @p connections.
+// @pre The given @p ids collection must not be a nullptr.
+// @warning This method will abort execution if any preconditions are not met.
+void OrderConnectionIds(const vector<Connection>& connections,
+                        vector<int>* ids) {
+  DRAKE_DEMAND(ids != nullptr);
+  // Checks for the single connection case, where it is nonsense to compute
+  // anything.
+  if (ids->size() == 1) return;
+  // Fills the id_waypoint_list.
+  vector<pair<int, DirectedWaypoint>> id_waypoint_list;
+  for (size_t i = 0; i < ids->size(); ++i) {
+    id_waypoint_list.emplace_back(ids->at(i),
+                                  connections.at(i).waypoints().front());
+  }
+  // Sorts the list using the dot product between the position of waypoint
+  // B in waypoint A frame `p_AB` and the normalized normal to waypoint A's
+  // direction `n_A`, essentially using a metric that gets larger in the
+  // positive numbers as waypoint B is farther to the right of waypoint A
+  // (and vice versa).
+  sort(id_waypoint_list.begin(), id_waypoint_list.end(),
+       [](const pair<int, DirectedWaypoint>& a,
+          const pair<int, DirectedWaypoint>& b) {
+         const ignition::math::Vector3d p_ab =
+             b.second.position() - a.second.position();
+         ignition::math::Vector3d n_a(-a.second.tangent().Y(),
+                                      a.second.tangent().X(), 0.0);
+         n_a.Normalize();
+         return (p_ab.Dot(n_a) > 0.0);
+       });
+  ids->clear();
+  for (const auto& it : id_waypoint_list) {
+    ids->push_back(it.first);
+  }
+}
+
+// Builds a Lane from the given @p connection into the parent @p segment.
+// @param connection A Connection that holds the waypoints to build the lane.
+// @param segment The parent Segment.
+// @return The built Lane.
+// @pre The given @p segment must not be a nullptr.
+// @warning This method will abort if preconditions are not met.
+Lane* BuildConnection(const Connection& connection, Segment* segment) {
+  DRAKE_DEMAND(segment != nullptr);
+  api::LaneId lane_id{"l:" + connection.id()};
+  vector<tuple<ignition::math::Vector3d, ignition::math::Vector3d>>
+      points_tangents;
+  for (const DirectedWaypoint& directed_waypoint : connection.waypoints()) {
+    points_tangents.emplace_back(directed_waypoint.position(),
+                                 directed_waypoint.tangent());
+  }
+  return segment->NewSplineLane(lane_id, points_tangents, connection.width());
+}
+
+// Attaches a @p lane to a @p branch_point at the specified @p end.
+// @pre The given @p lane must not be a nullptr.
+// @pre The given @p branch_point must not be a nullptr.
+// @warning This method will abort if preconditions are not met.
+void AttachLaneEndToBranchPoint(const api::LaneEnd::Which end, Lane* lane,
+                                BranchPoint* branch_point) {
+  DRAKE_DEMAND(lane != nullptr);
+  DRAKE_DEMAND(branch_point != nullptr);
+  // Tells the lane about its branch-point.
+  switch (end) {
+    case api::LaneEnd::kStart: {
+      lane->SetStartBp(branch_point);
+      break;
+    }
+    case api::LaneEnd::kFinish: {
+      lane->SetEndBp(branch_point);
+      break;
+    }
+    default: { DRAKE_ABORT(); }
+  }
+  // Tells the BranchPoint about the lane. When the A-Side is empty, it adds
+  // the LaneEnd to it.
+  if (branch_point->GetASide()->size() == 0) {
+    branch_point->AddABranch({lane, end});
+    return;
+  }
+  // Checks the direction of the LaneEnd. When it is parallel to the first
+  // LaneEnd, it will be added to the A-Side. If not, it will be added to the
+  // B-Side.
+  const double new_h = HeadingIntoLane(lane, end);
+  const api::LaneEnd old_le = branch_point->GetASide()->get(0);
+  const double old_h = HeadingIntoLane(old_le.lane, old_le.end);
+  if (((cos(new_h) * cos(old_h)) + (sin(new_h) * sin(old_h))) > 0.) {
+    branch_point->AddABranch({lane, end});
+  } else {
+    branch_point->AddBBranch({lane, end});
+  }
+}
+
+// Builds or updates a BranchPoint given a @p connection and the corresponding
+// @p lane. The former provides the start and end waypoints of the lane,
+// which are necessary to lookup the branch points in the @p branch_point_map.
+// @param connection The Connection that provides the start and end waypoints.
+// @param lane The Lane to be attached to the right corresponding
+// branch points.
+// @param branch_point_map The mapping from RNDF (entry or exit) waypoint IDs
+// to BranchPoints.
+// @param road_geometry The RoadGeometry to create the BranchPoints into.
+// @pre The given @p connection must not be a nullptr.
+// @pre The given @p lane must not be a nullptr.
+// @pre The given @p branch_point_map must not be a nullptr.
+// @pre The given @p road_geometry must not be a nullptr.
+// @warning This method will abort if preconditions are not met.
+void BuildOrUpdateBranchpoints(Connection* connection, Lane* lane,
+                               map<string, BranchPoint*>* branch_point_map,
+                               RoadGeometry* road_geometry) {
+  DRAKE_DEMAND(connection != nullptr);
+  DRAKE_DEMAND(lane != nullptr);
+  DRAKE_DEMAND(branch_point_map != nullptr);
+  DRAKE_DEMAND(road_geometry != nullptr);
+  // Sets the start of the BranchPoint.
+  BranchPoint* bp{nullptr};
+  auto it = branch_point_map->find(connection->start().id().String());
+  if (it == branch_point_map->end()) {
+    bp = road_geometry->NewBranchPoint(api::BranchPointId{
+        "bp:" + to_string(road_geometry->num_branch_points())});
+    DRAKE_DEMAND(bp != nullptr);
+    (*branch_point_map)[connection->start().id().String()] = bp;
+  } else {
+    bp = it->second;
+  }
+  AttachLaneEndToBranchPoint(api::LaneEnd::kStart, lane, bp);
+  // Sets the end of the BranchPoint.
+  bp = nullptr;
+  it = branch_point_map->find(connection->end().id().String());
+  if (it == branch_point_map->end()) {
+    bp = road_geometry->NewBranchPoint(api::BranchPointId{
+        "bp:" + to_string(road_geometry->num_branch_points())});
+    DRAKE_DEMAND(bp != nullptr);
+    (*branch_point_map)[connection->end().id().String()] = bp;
+  } else {
+    bp = it->second;
+  }
+  AttachLaneEndToBranchPoint(api::LaneEnd::kFinish, lane, bp);
+}
+
+// Adds either invalid or interpolated extra waypoints on those @p connections
+// not listed in the @p ids of the @p connections that come first for the
+// given @p index, as computed by GetInitialConnectionToProcess(), to
+// make all waypoints at @p index lie in line with @p connections's normal.
+// That is to say, to lie in a row.
+// @param ids A collection of the indexes of the @p connections that come
+// first.
+// @param connections A collection of Connections to add waypoints to if
+// necessary.
+// @param index The index of the @p connection's waypoints to look at.
+// @param linear_tolearance The tolerance for connections' waypoints spline
+// interpolation for road geometrical inference.
+// @pre The given @p connections collection must not be a nullptr.
+// @warning This method will abort execution if any preconditions are not met.
+void AddWaypointsIfNecessary(const vector<int>& ids,
+                             vector<Connection>* connections, size_t index,
+                             double linear_tolerance) {
+  DRAKE_DEMAND(connections != nullptr);
+  for (size_t i = 0; i < connections->size(); i++) {
+    Connection& connection = connections->at(i);
+    // Checks that `i` index is in the ids vector which holds
+    // the indexes of connections with reference waypoints.
+    if (find(ids.begin(), ids.end(), i) != ids.end()) {
+      continue;
+    }
+
+    size_t waypoint_count = connection.waypoints().size();
+    // Checks if we don't have any index on the vector.
+    if (ids.size() == 0 && waypoint_count > index) {
+      continue;
+    }
+    if (waypoint_count <= index) {
+      // Adds an invalid waypoint to keep consistency since there is no more
+      // valid waypoints in the connection.
+      connection.AddWaypoint(DirectedWaypoint(), waypoint_count);
+    } else if (connection.waypoints()[index].id().Z() == 1) {
+      // As the waypoint is at the top of the connection's vector, it adds an
+      // invalid one before the first waypoint.
+      connection.AddWaypoint(DirectedWaypoint(), 0);
+    } else {
+      // Index cannot ever be zero, as every first waypoint would be
+      // caught by the upper if clause.
+      DRAKE_DEMAND(index != 0);
+      // Adds a waypoint to the projected position of the side lane.
+      unique_ptr<ignition::math::Spline> spline =
+          CreateSpline(connections->at(i).waypoints());
+      unique_ptr<ArcLengthParameterizedSpline> arc_length_param_spline =
+          make_unique<ArcLengthParameterizedSpline>(move(spline),
+                                                    linear_tolerance);
+      const double s = arc_length_param_spline->FindClosestPointTo(
+          connections->at(ids[0]).waypoints()[index].position(), kLinearStep);
+      // Builds a new waypoint and adds it to the connection.
+      DirectedWaypoint new_wp(
+          ignition::rndf::UniqueId(
+              connections->at(i).waypoints()[index - 1].id().X(),
+              connections->at(i).waypoints()[index - 1].id().Y(),
+              connections->at(i).waypoints().size() + 1),
+          arc_length_param_spline->InterpolateMthDerivative(0, s),
+          arc_length_param_spline->InterpolateMthDerivative(1, s), false,
+          false);
+      connection.AddWaypoint(new_wp, index);
+    }
+  }
+}
+
+// Adds waypoints to the given @p connections so as to ensure that their
+// spatial distribution is akin to a grid (thus enabling index operations).
+// @param connections A collection of Connections to create waypoints into
+// if necessary.
+// @param linear_tolearance The tolerance for connections' waypoints spline
+// interpolation for road geometrical inference.
+// @pre The given @p connections collection must not be a nullptr.
+// @warning This method will abort execution if any preconditions are not met.
+void CreateNewControlPointsForConnections(std::vector<Connection>* connections,
+                                          double linear_tolerance) {
+  DRAKE_DEMAND(connections != nullptr);
+  // Loads the tangents for each of the connections' waypoints.
+  for (Connection& connection : *connections) {
+    vector<DirectedWaypoint> waypoints(connection.waypoints());
+    BuildTangentsForWaypoints(&waypoints);
+    connection.set_waypoints(waypoints);
+  }
+  size_t i = 0;
+  bool should_continue = true;
+  while (should_continue) {
+    // Gets the connection ids which appear first.
+    vector<int> ids = GetInitialConnectionToProcess(*connections, i);
+    // Checks if we need to add waypoints on other connections and does so
+    // if necessary.
+    AddWaypointsIfNecessary(ids, connections, i, linear_tolerance);
+    // Checks if index is bounded to any of the connections.
+    i++;
+    should_continue = false;
+    for (const Connection& connection : *connections) {
+      if (i < connection.waypoints().size()) {
+        should_continue = true;
+        break;
+      }
+    }
+  }
+}
+
+// Establishes the relative direction for each connection in @p connections.
+//
+// To do this, it checks the connection momentum as computed by
+// CalculateConnectionMomentum() and looks for successive sign changes
+// with respect to a reference set with the first connection.
+// @param bounding_box The bounding box for all given @p connections.
+// @param connections A collection of Connections to compare the way
+// connections' waypoints are disposed with respect to the first connection.
+// @pre The given @p connections collection must not be a nullptr.
+// @warning This method will abort execution if any preconditions are not met.
+void SetInvertedConnections(const pair<ignition::math::Vector3d,
+                                       ignition::math::Vector3d>& bounding_box,
+                            vector<Connection>* connections) {
+  DRAKE_DEMAND(connections != nullptr);
+  if (connections->size() == 0) {
+    return;
+  }
+  // Creates a center of rotation outside the bounding box, for connection
+  // direction estimation by means of "momentum" computations.
+  const ignition::math::Vector3d center_of_rotation =
+      bounding_box.first - ignition::math::Vector3d(1., 1., 0);
+  // Gets all the "momentum"s and mark the connections if necessary.
+  double momentum = CalculateConnectionMomentum(center_of_rotation,
+                                                connections->at(0).waypoints());
+  const int first_connection_sign_momentum = copysign(1.0, momentum);
+  for (size_t i = 1; i < connections->size(); ++i) {
+    momentum = CalculateConnectionMomentum(center_of_rotation,
+                                           connections->at(i).waypoints());
+    const int other_connection_sign_momentum = copysign(1.0, momentum);
+    if (other_connection_sign_momentum != first_connection_sign_momentum) {
+      connections->at(i).set_inverse_direction(true);
+    }
+  }
+}
+
+}  // namespace
+
+void Builder::CreateSegmentConnections(int segment_id,
+                                       std::vector<Connection>* connections) {
+  DRAKE_THROW_UNLESS(connections != nullptr);
+  DRAKE_THROW_UNLESS(connections->size() > 0);
+  // Builds the vector of waypoints.
+  for (Connection& connection : *connections) {
+    std::vector<DirectedWaypoint> waypoints(connection.waypoints());
+    BuildTangentsForWaypoints(&waypoints);
+    connection.set_waypoints(waypoints);
+  }
+  // Checks the momentum that each lane produces and then sets the connected
+  // lane accordingly.
+  SetInvertedConnections(bounding_box_, connections);
+  // Splits the connections into groups with the same direction.
+  std::map<int, std::vector<Connection>> segment_groups;
+  GroupConnectionsByDirection(*connections, &segment_groups);
+  for (auto& it : segment_groups) {
+    // Adds DirectedWaypoints when necessary to match projected positions from
+    // one RNDF lane onto the other.
+    CreateNewControlPointsForConnections(&(it.second), linear_tolerance_);
+    for (int i = 0; i < static_cast<int>((it.second[0].waypoints().size() - 1));
+         i++) {
+      // Finds the valid RNDF lane pieces and then orders them from right to
+      // left.
+      std::vector<int> valid_lane_ids;
+      for (int j = 0; j < static_cast<int>(it.second.size()); j++) {
+        if (it.second[j].waypoints()[i].id().Valid() &&
+            it.second[j].waypoints()[i + 1].id().Valid()) {
+          valid_lane_ids.push_back(j);
+        }
+      }
+      OrderConnectionIds(it.second, &valid_lane_ids);
+      const std::string segment_key_name = std::to_string(segment_id) + "-" +
+                                           std::to_string(it.first) + "-" +
+                                           std::to_string(i);
+      // Iterates over the valid lane ids.
+      for (auto lane_it = valid_lane_ids.begin();
+           lane_it != valid_lane_ids.end(); ++lane_it) {
+        // Creates a two waypoint connection.
+        std::vector<DirectedWaypoint> wps;
+        wps.push_back(it.second[*lane_it].waypoints()[i]);
+        wps.push_back(it.second[*lane_it].waypoints()[i + 1]);
+        InsertConnection(segment_key_name, it.second[*lane_it].width(), wps);
+        // Adds the pair of waypoints to the map.
+        directed_waypoints_[wps.front().id().String()] = wps.front();
+        directed_waypoints_[wps.back().id().String()] = wps.back();
+      }
+    }
+  }
+}
+
+std::unique_ptr<const api::RoadGeometry> Builder::Build(
+    const api::RoadGeometryId& id) {
+  auto branch_point_map =
+      std::make_unique<std::map<std::string, BranchPoint*>>();
+  auto road_geometry =
+      std::make_unique<RoadGeometry>(id, linear_tolerance_, angular_tolerance_);
+
+  // Builds a lane per connection and creates their respective BranchPoints.
+  for (const auto& it_connection : connections_) {
+    // Builds a junction and the segment for related lanes.
+    Junction* junction =
+        road_geometry->NewJunction(api::JunctionId{"j:" + it_connection.first});
+    DRAKE_DEMAND(junction != nullptr);
+
+    Segment* segment =
+        junction->NewSegment(api::SegmentId{"s:" + it_connection.first});
+    DRAKE_DEMAND(segment != nullptr);
+
+    for (const auto& connection : it_connection.second) {
+      // Creates a Lane.
+      rndf::Lane* lane = BuildConnection(*connection, segment);
+      DRAKE_DEMAND(lane != nullptr);
+      // Builds the branch points for the lane if necessary.
+      BuildOrUpdateBranchpoints(connection.get(), lane, branch_point_map.get(),
+                                road_geometry.get());
+    }
+  }
+  // Checks there is no failure when checking RoadGeometry invariants.
+  const std::vector<std::string> failures = road_geometry->CheckInvariants();
+  for (const std::string& s : failures) {
+    log()->error(s);
+  }
+  DRAKE_THROW_UNLESS(failures.size() == 0);
+
+  return move(road_geometry);
+}
+
+void Builder::InsertConnection(const std::string& key_id, double width,
+                               const std::vector<DirectedWaypoint>& waypoints) {
+  DRAKE_DEMAND(waypoints.size() > 1);
+  const ignition::rndf::UniqueId& start_id = waypoints.front().id();
+  const ignition::rndf::UniqueId& end_id = waypoints.back().id();
+  const std::string name = start_id.String() + "-" + end_id.String();
+  if (connections_.find(key_id) == connections_.end()) {
+    connections_[key_id] = std::vector<std::unique_ptr<Connection>>();
+  }
+  connections_[key_id].push_back(
+      std::make_unique<Connection>(name, waypoints, width, false));
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/builder.h
+++ b/drake/automotive/maliput/rndf/builder.h
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ignition/math/Spline.hh"
+#include "ignition/math/Vector3.hh"
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/rndf/connection.h"
+#include "drake/automotive/maliput/rndf/directed_waypoint.h"
+#include "drake/automotive/maliput/rndf/road_geometry.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+/// A class to ease the construction of a RoadGeometry from Connection and
+/// DirectedWaypoint objects.
+///
+/// RNDF segments and lanes are mapped to Maliput's Segment and Lane entities,
+/// respectively. This mapping is not straightforward as Maliput is based on
+/// analytical curve parameterizations while RNDF provides a sampled geometry
+/// based on waypoints. RNDF waypoints are thus used as control points in a
+/// cubic spline interpolation that results in SplineLanes. RNDF lanes'
+/// direction is implied by RNDF waypoint IDs
+/// (`segment_num.lane_num.waypoint_num`) which is captured by the
+/// interpolation and reflected in DirectedWaypoints. These DirectedWaypoints
+/// are grouped in Connections, which describe not only RNDF lanes but also the
+/// connections between pairs of exit and entry RNDF waypoints. During the build
+/// process, interpolated waypoints are added to these Connections so as to keep
+/// their distribution akin to a grid (and thus enable index-based operations).
+///
+/// Since lanes in an RNDF segment may flow in different directions, segment
+/// connections are also grouped by its direction relative to the first
+/// connection found in the collection. An arbitrary point outside the bounding
+/// box of the road geometry is selected to be a "center of rotation" and the
+/// sum of all the DirectedWaypoints "momentums" (with normalized tangents) is
+/// computed. It must be said that the "momentum" equation is used to derive
+/// connection direction, but it bears no physical meaning. Since all the
+/// waypoints lay in the @f$ z = 0 @f$ plane, the "momentum" vector will only
+/// contain a non-zero z coordinate value. The sign of the "momentum"'s z
+/// coordinate will be taken as a reference to define the sense of flow. For
+/// all other connections, the "momentum" is computed and compared against the
+/// sign of the reference.
+///
+/// The resulting RoadGeometry presents the following naming for its composed
+/// entities:
+/// - Lane naming: "l:$1-$2", where
+///    1. RNDF exit waypoint ID.
+///    2. RNDF entry waypoint ID.
+/// - Segment naming: "s:$1-$2-$3", where
+///    1. RNDF segment ID.
+///    2. Direction-based grouping index.
+///    3. RNDF segment piece index (in between every 2 waypoints).
+/// - Junction naming: "j:$1-$2-$3", where
+///    1. RNDF segment ID.
+///    2. Direction-based grouping index.
+///    3. RNDF segment piece index (in between every 2 waypoints).
+/// - BranchPoint naming: "bp:$1", where
+///    1. Index in RoadGeometry's inner collection.
+///
+/// An example of how this is achieved is depicted in the following example.
+/// Note that '+' denotes RNDF waypoints, 'x' denotes invalid waypoints
+/// and 'o' denotes interpolated waypoints. Also '|' denotes Segment boundaries.
+///
+/// <pre>
+///          1.1.1                   1.1.2
+///          +-----------------------+            <---- Connection: 1.1.1-1.1.2
+/// 1.2.1                                       1.2.2
+/// +-------------------------------------------+ <---- Connection: 1.2.1-1.2.2
+///          1.3.1                   1.3.2
+///          +-----------------------+            <---- Connection: 1.3.1-1.3.2
+/// </pre>
+///
+/// Mapping the above waypoints to SplineLane and Segment objects will be done
+/// by the Builder. In the end, we end up with something like:
+///
+/// <pre>
+/// |        |1.1.1                  |1.1.2     |
+/// x--------+-----------------------+----------x <---- Connection: 1.1.1-1.1.2
+/// |1.2.1   |1.2.3                  |1.2.4     |1.2.2
+/// +--------o-----------------------o----------+ <---- Connection: 1.2.1-1.2.2
+/// |        |1.3.1                  |1.3.2     |
+/// x--------+-----------------------+----------x <---- Connection: 1.3.1-1.3.2
+/// </pre>
+///
+/// Those new waypoints that appear make possible the concept of Maliput Segment
+/// as a surface that holds all the trajectories (represented by Maliput Lanes).
+/// At the building stage, we can now match waypoints across lanes using an
+/// index-based algorithm, a pair of valid consecutive waypoints in a Connection
+/// are used to create a SplineLane. At the same time, we should
+/// create those Lanes inside the same segment, which is not difficult to do
+/// using the index approach. To sum up, Builder will create the following:
+///
+/// - Segment 1-0-0:
+///   - Lane 1.2.1-1.2.3
+/// - Segment 1-0-1:
+///   - Lane 1.3.1-1.3.2
+///   - Lane 1.2.3-1.2.4
+///   - Lane 1.1.1-1.1.2
+/// - Segment 1-0-2:
+///   - Lane 1.2.4-1.2.2
+///
+class Builder {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Builder)
+
+  /// Constructs a Builder which can be used to specify and assemble
+  /// an RNDF implementation of an api::RoadGeometry.
+  ///
+  /// @param linear_tolerance Linear tolerance for RoadGeometry construction.
+  /// @param angular_tolerance Angular tolerance for RoadGeometry construction.
+  Builder(double linear_tolerance, double angular_tolerance)
+      : linear_tolerance_(linear_tolerance),
+        angular_tolerance_(angular_tolerance) {}
+
+  /// Sets the bounding box of the RNDF map.
+  ///
+  /// @param bounding_box The lower left and upper right corners' position
+  /// pair for the bounding box.
+  /// @remarks Bounding box definition is kept in 3D space for the sake
+  /// of generality, even though there's currently no support for nonplanar
+  /// RNDF geometries and, most of the time, the z-component of the given
+  /// corners will be zero.
+  void SetBoundingBox(const std::pair<ignition::math::Vector3d,
+                                      ignition::math::Vector3d>& bounding_box) {
+    bounding_box_ = bounding_box;
+  }
+
+  /// Populates the Builder's inner connection map with the given
+  /// @p connections representing an RNDF segment.
+  ///
+  /// To do this, the @p connections' waypoints are first used to derive
+  /// a geometry. Then, these @p connections are grouped based on relative
+  /// direction using the first connection found as a reference. Once grouped,
+  /// extra waypoints are added to each of them on a per group basis as
+  /// necessary to ensure a grid-like distribution of waypoints.
+  /// @param segment_id The RNDF segment ID.
+  /// @param connections A collection of Connections representing each RNDF lane
+  /// in the segment.
+  /// @throw std::runtime_error When @p connections is a nullptr.
+  /// @throw std::runtime_error When @p connections is an empty collection.
+  void CreateSegmentConnections(int segment_id,
+                                std::vector<Connection>* connections);
+
+  /// Builds an api::RoadGeometry.
+  ///
+  /// All the groups of connections are traversed. A Junction with a single
+  /// Segment is created per group, and for each connection in that group,
+  /// a Lane is added to the Segment. BranchPoints are updated as needed.
+  /// @param id ID of the api::RoadGeometry to be built.
+  /// @return The built api::RoadGeometry.
+  /// @throw std::runtime_error When the built RoadGeometry does not satisfy
+  /// Maliput roads' constraints (see api::RoadGeometry::CheckInvariants()).
+  std::unique_ptr<const api::RoadGeometry> Build(const api::RoadGeometryId& id);
+
+ private:
+  // Inserts a connection of the given @p width, with the given @p key_id, using
+  // the given @p waypoints to the inner connection map.
+  // @pre The given @p waypoints collection size must be at least two (2).
+  // @warning This method will abort if preconditions are not met.
+  void InsertConnection(const std::string& key_id, double width,
+                        const std::vector<DirectedWaypoint>& waypoints);
+
+  // The tolerance used by the RoadGeometry to check linear invariants.
+  const double linear_tolerance_{};
+  // The tolerance used by the RoadGeometry to check angular invariants.
+  const double angular_tolerance_{};
+  // A map to hold all the connections while they are created.
+  std::map<std::string, std::vector<std::unique_ptr<Connection>>> connections_;
+  // A map to hold all the DirectedWaypoints that are used as Lane extents.
+  std::map<std::string, DirectedWaypoint> directed_waypoints_;
+  // The coordinates of the bounding box that encloses RNDF's waypoints.
+  std::pair<ignition::math::Vector3d, ignition::math::Vector3d> bounding_box_;
+};
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/connection.h
+++ b/drake/automotive/maliput/rndf/connection.h
@@ -32,58 +32,7 @@ namespace rndf {
 /// sense of direction. To define the direction, one of the Connections in the
 /// group will be flagged as the reference, and an interpolated spline is
 /// computed from the the DirectedWaypoints within the reference Connection to
-/// obtain the tangent information. An arbitrary point outside the bounding box
-/// of the road map is selected to be a "center of rotation" and the sum of all
-/// the DirectedWaypoint "momentums" (with normalized tangents) is computed. It
-/// must be said that the "momentum" equation is used to derive lane direction,
-/// but it has no physical meaning. Since all the waypoints lay in the z=0
-/// plane, the "momentum" vector will only contain a non-zero z coordinate
-/// value. The sign of the "momentum"'s z coordinate will be taken as a
-/// reference to define the sense of flow. For all other connections, the
-/// "momentum" is computed and compared against the sign of the reference. This
-/// way, grouping is achieved.
-///
-/// An example of how this is achieved is depicted in the following example.
-/// Please, note that '+' denotes RNDF waypoints, 'x' denotes invalid waypoints
-/// and 'o' denotes interpolated waypoints. Also '|' denotes Segment boundaries.
-///
-/// <pre>
-///          1.1.1                   1.1.2
-///          +-----------------------+            <---- Connection: 1_1_1-1_1_2
-/// 1.2.1                                       1.2.2
-/// +-------------------------------------------+ <---- Connection: 1_2_1-1_2_2
-///          1.3.1                   1.3.2
-///          +-----------------------+            <---- Connection: 1_3_1-1_3_2
-/// </pre>
-///
-/// Mapping the above waypoints to SplineLane and Segment objects will be done
-/// by the Builder. In the end, we end up with something like:
-///
-/// <pre>
-/// |        |1.1.1                  |1.1.2     |
-/// x--------+-----------------------+----------x <---- Connection: 1_1_1-1_1_2
-/// |1.2.1   |1.2.3                  |1.2.4     |1.2.2
-/// +--------o-----------------------o----------+ <---- Connection: 1_2_1-1_2_2
-/// |        |1.3.1                  |1.3.2     |
-/// x--------+-----------------------+----------x <---- Connection: 1_3_1-1_3_2
-/// </pre>
-///
-/// Those new waypoints that appear make possible the concept of Maliput Segment
-/// as a surface that holds all the trajectories (represented by Maliput Lanes).
-/// At the building stage, we can now match waypoints across lanes using an
-/// index-based algorithm, a pair of valid consecutive waypoints in a Connection
-/// are used to create a SplineLane. At the same time, we should
-/// create those Lanes inside the same segment, which is not difficult to do
-/// using the index approach. To sum up, Builder will create the following:
-///
-/// - Segment 1_0:
-///   - Lane 1_2_1-1_2_3
-/// - Segment 1_1:
-///   - Lane 1_3_1-1_3_2
-///   - Lane 1_2_3-1_3_4
-///   - Lane 1_1_1-1_3_2
-/// - Segment 1_2:
-///   - Lane 1_2_4-1_2_2
+/// obtain the tangent information.
 class Connection {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Connection)

--- a/drake/automotive/maliput/rndf/spline_lane.cc
+++ b/drake/automotive/maliput/rndf/spline_lane.cc
@@ -165,7 +165,6 @@ ignition::math::Vector3d SplineLane::GetPositionToLane(double s,
   const Vector2<double> other_lane_beginning = other_lane->xy_of_s(0.);
   const Vector2<double> other_lane_ending =
       other_lane->xy_of_s(other_lane->do_length());
-
   // Converts the beginning and ending positions of the other lane into
   // ignition::math::Vector3d objects.
   const ignition::math::Vector3d q(other_lane_beginning.x(),

--- a/drake/automotive/maliput/rndf/test/builder_test.cc
+++ b/drake/automotive/maliput/rndf/test/builder_test.cc
@@ -1,0 +1,472 @@
+#include "drake/automotive/maliput/rndf/builder.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <ignition/math/Vector3.hh>
+#include <ignition/rndf/UniqueId.hh>
+
+#include "drake/automotive/maliput/api/test/maliput_types_compare.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+namespace {
+
+const double kLaneWidth = 5.0;
+const double kLinearTolerance = 1e-2;
+const double kAngularTolerance = 1e-2 * M_PI;
+
+int FindJunction(const api::RoadGeometry& road_geometry,
+                 const std::string& junction_name) {
+  for (int i = 0; i < road_geometry.num_junctions(); i++) {
+    if (road_geometry.junction(i)->id().string() == junction_name) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+//   * 1.1.1
+//    v
+//      v
+//        * 1.1.2
+//      v
+//    v
+//   * 1.1.3
+//    v
+//      v
+//        * 1.1.4
+//
+// For reference:
+//   - 'v' represents lane's direction.
+//   - '*' represents a lane's waypoint.
+GTEST_TEST(RNDFBuilder, ZigZagLane) {
+  auto builder = std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
+
+  std::vector<DirectedWaypoint> waypoints(4, DirectedWaypoint());
+  waypoints[0].set_id(ignition::rndf::UniqueId(1, 1, 1));
+  waypoints[0].set_position(ignition::math::Vector3d(0., 0.0, 0.0));
+  waypoints[1].set_id(ignition::rndf::UniqueId(1, 1, 2));
+  waypoints[1].set_position(ignition::math::Vector3d(10.0, -10.0, 0.0));
+  waypoints[2].set_id(ignition::rndf::UniqueId(1, 1, 3));
+  waypoints[2].set_position(ignition::math::Vector3d(0.0, -20.0, 0.0));
+  waypoints[3].set_id(ignition::rndf::UniqueId(1, 1, 4));
+  waypoints[3].set_position(ignition::math::Vector3d(10.0, -30.0, 0.0));
+  Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+
+  std::vector<Connection> connected_lanes = {connection};
+
+  const auto bounding_box =
+      std::make_pair(ignition::math::Vector3d(0., -30., 0.),
+                     ignition::math::Vector3d(10., 0., 0.));
+  builder->SetBoundingBox(bounding_box);
+  builder->CreateSegmentConnections(1, &connected_lanes);
+
+  const auto road_geometry = builder->Build(api::RoadGeometryId{"ZigZagLane"});
+  ASSERT_TRUE(road_geometry != nullptr);
+
+  // Checks junctions, segments and lanes.
+  ASSERT_EQ(road_geometry->num_junctions(), 3);
+  EXPECT_EQ(road_geometry->junction(0)->id().string(), "j:1-0-0");
+  ASSERT_EQ(road_geometry->junction(0)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->id().string(), "s:1-0-0");
+  ASSERT_EQ(road_geometry->junction(0)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->id().string(),
+            "l:1.1.1-1.1.2");
+
+  EXPECT_EQ(road_geometry->junction(1)->id().string(), "j:1-0-1");
+  ASSERT_EQ(road_geometry->junction(1)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->id().string(), "s:1-0-1");
+  ASSERT_EQ(road_geometry->junction(1)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->id().string(),
+            "l:1.1.2-1.1.3");
+
+  EXPECT_EQ(road_geometry->junction(2)->id().string(), "j:1-0-2");
+  ASSERT_EQ(road_geometry->junction(2)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->id().string(), "s:1-0-2");
+  ASSERT_EQ(road_geometry->junction(2)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->id().string(),
+            "l:1.1.3-1.1.4");
+
+  // Checks branch points.
+  ASSERT_EQ(road_geometry->num_branch_points(), 4);
+  EXPECT_EQ(road_geometry->branch_point(0)->id().string(), "bp:0");
+  EXPECT_EQ(road_geometry->branch_point(0)->GetASide()->size(), 1);
+  EXPECT_EQ(road_geometry->branch_point(0)->GetBSide()->size(), 0);
+
+  EXPECT_EQ(road_geometry->branch_point(1)->id().string(), "bp:1");
+  EXPECT_EQ(road_geometry->branch_point(1)->GetASide()->size(), 1);
+  EXPECT_EQ(road_geometry->branch_point(1)->GetBSide()->size(), 1);
+
+  EXPECT_EQ(road_geometry->branch_point(2)->id().string(), "bp:2");
+  EXPECT_EQ(road_geometry->branch_point(2)->GetASide()->size(), 1);
+  EXPECT_EQ(road_geometry->branch_point(2)->GetBSide()->size(), 1);
+
+  EXPECT_EQ(road_geometry->branch_point(3)->id().string(), "bp:3");
+  EXPECT_EQ(road_geometry->branch_point(3)->GetASide()->size(), 1);
+  EXPECT_EQ(road_geometry->branch_point(3)->GetBSide()->size(), 0);
+
+  // Checks branch point assigment regarding the lanes.
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kStart),
+            road_geometry->branch_point(0));
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kFinish),
+            road_geometry->branch_point(1));
+
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kStart),
+            road_geometry->branch_point(1));
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kFinish),
+            road_geometry->branch_point(2));
+
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kStart),
+            road_geometry->branch_point(2));
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->GetBranchPoint(
+                api::LaneEnd::kFinish),
+            road_geometry->branch_point(3));
+}
+
+// * 1.2.11  * 1.1.1         1.1.9 *  1.2.1 *
+// ^         v                     ^        v
+// ^         v                     ^        v
+// * 1.2.10  * 1.1.2         1.1.8 *  1.2.2 *
+// ^         v                     ^        v
+// ^         v                     ^        v
+// * 1.2.9   * 1.1.3         1.1.7 *  1.2.3 *
+//  ^         v                   ^        v
+//   ^         v                 ^        v
+//    * 1.2.8   * 1.1.4   1.1.6 *  1.2.4 *
+//     ^         v             ^        v
+//      ^          < <  *  < <         v
+//       ^            1.1.5           v
+//         * 1.2.7             1.2.5 *
+//           > > > > >  *  > > > > >
+//                    1.2.6
+//
+// For reference:
+//   -'^', 'v', '<' and '>' represent lane's direction.
+//   - '*' represents a lane's waypoint.
+GTEST_TEST(RNDFBuilder, UShapedLane) {
+  auto builder = std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
+
+  std::vector<Connection> connected_lanes;
+  {
+    std::vector<DirectedWaypoint> waypoints(9, DirectedWaypoint());
+    waypoints[0].set_id(ignition::rndf::UniqueId(1, 1, 1));
+    waypoints[0].set_position(ignition::math::Vector3d(-20.0, 50.0, 0.0));
+    waypoints[1].set_id(ignition::rndf::UniqueId(1, 1, 2));
+    waypoints[1].set_position(ignition::math::Vector3d(-20.0, 40.0, 0.0));
+    waypoints[2].set_id(ignition::rndf::UniqueId(1, 1, 3));
+    waypoints[2].set_position(ignition::math::Vector3d(-20.0, 30.0, 0.0));
+    waypoints[3].set_id(ignition::rndf::UniqueId(1, 1, 4));
+    waypoints[3].set_position(ignition::math::Vector3d(-10.0, 20.0, 0.0));
+    waypoints[4].set_id(ignition::rndf::UniqueId(1, 1, 5));
+    waypoints[4].set_position(ignition::math::Vector3d(0.0, 10.0, 0.0));
+    waypoints[5].set_id(ignition::rndf::UniqueId(1, 1, 6));
+    waypoints[5].set_position(ignition::math::Vector3d(10.0, 20.0, 0.0));
+    waypoints[6].set_id(ignition::rndf::UniqueId(1, 1, 7));
+    waypoints[6].set_position(ignition::math::Vector3d(20.0, 30.0, 0.0));
+    waypoints[7].set_id(ignition::rndf::UniqueId(1, 1, 8));
+    waypoints[7].set_position(ignition::math::Vector3d(20.0, 40.0, 0.0));
+    waypoints[8].set_id(ignition::rndf::UniqueId(1, 1, 9));
+    waypoints[8].set_position(ignition::math::Vector3d(20.0, 50.0, 0.0));
+    connected_lanes.push_back(
+        Connection(std::to_string(1), waypoints, kLaneWidth, false));
+  }
+
+  {
+    std::vector<DirectedWaypoint> waypoints(11, DirectedWaypoint());
+    waypoints[0].set_id(ignition::rndf::UniqueId(1, 2, 1));
+    waypoints[0].set_position(ignition::math::Vector3d(40.0, 50.0, 0.0));
+    waypoints[1].set_id(ignition::rndf::UniqueId(1, 2, 2));
+    waypoints[1].set_position(ignition::math::Vector3d(40.0, 40.0, 0.0));
+    waypoints[2].set_id(ignition::rndf::UniqueId(1, 2, 3));
+    waypoints[2].set_position(ignition::math::Vector3d(40.0, 30.0, 0.0));
+    waypoints[3].set_id(ignition::rndf::UniqueId(1, 2, 4));
+    waypoints[3].set_position(ignition::math::Vector3d(30.0, 20.0, 0.0));
+    waypoints[4].set_id(ignition::rndf::UniqueId(1, 2, 5));
+    waypoints[4].set_position(ignition::math::Vector3d(20, 5.0, 0.0));
+    waypoints[5].set_id(ignition::rndf::UniqueId(1, 2, 6));
+    waypoints[5].set_position(ignition::math::Vector3d(0.0, 0.0, 0.0));
+    waypoints[6].set_id(ignition::rndf::UniqueId(1, 2, 7));
+    waypoints[6].set_position(ignition::math::Vector3d(-20.0, 5.0, 0.0));
+    waypoints[7].set_id(ignition::rndf::UniqueId(1, 2, 8));
+    waypoints[7].set_position(ignition::math::Vector3d(-30.0, 20.0, 0.0));
+    waypoints[8].set_id(ignition::rndf::UniqueId(1, 2, 9));
+    waypoints[8].set_position(ignition::math::Vector3d(-40.0, 30.0, 0.0));
+    waypoints[9].set_id(ignition::rndf::UniqueId(1, 2, 10));
+    waypoints[9].set_position(ignition::math::Vector3d(-40.0, 40.0, 0.0));
+    waypoints[10].set_id(ignition::rndf::UniqueId(1, 2, 11));
+    waypoints[10].set_position(ignition::math::Vector3d(-40.0, 50.0, 0.0));
+    connected_lanes.push_back(
+        Connection(std::to_string(2), waypoints, kLaneWidth, false));
+  }
+
+  const auto bounding_box =
+      std::make_pair(ignition::math::Vector3d(-40.0, 0.0, 0.0),
+                     ignition::math::Vector3d(40., 50.0, 0.0));
+  builder->SetBoundingBox(bounding_box);
+  builder->CreateSegmentConnections(1, &connected_lanes);
+
+  const auto road_geometry = builder->Build(api::RoadGeometryId{"UShapedLane"});
+  ASSERT_TRUE(road_geometry != nullptr);
+
+  // Checks junction, segments and lanes. Lane naming implies direction
+  // so checking for correct naming implies proper direction inference.
+  std::vector<std::tuple<std::string, std::string, std::string> > name_set = {
+      std::make_tuple("j:1-0-0", "s:1-0-0", "l:1.1.1-1.1.2"),
+      std::make_tuple("j:1-0-1", "s:1-0-1", "l:1.1.2-1.1.3"),
+      std::make_tuple("j:1-0-2", "s:1-0-2", "l:1.1.3-1.1.4"),
+      std::make_tuple("j:1-0-3", "s:1-0-3", "l:1.1.4-1.1.5"),
+      std::make_tuple("j:1-0-4", "s:1-0-4", "l:1.1.5-1.1.6"),
+      std::make_tuple("j:1-0-5", "s:1-0-5", "l:1.1.6-1.1.7"),
+      std::make_tuple("j:1-0-6", "s:1-0-6", "l:1.1.7-1.1.8"),
+      std::make_tuple("j:1-0-7", "s:1-0-7", "l:1.1.8-1.1.9"),
+      std::make_tuple("j:1-1-0", "s:1-1-0", "l:1.2.1-1.2.2"),
+      std::make_tuple("j:1-1-1", "s:1-1-1", "l:1.2.2-1.2.3"),
+      std::make_tuple("j:1-1-2", "s:1-1-2", "l:1.2.3-1.2.4"),
+      std::make_tuple("j:1-1-3", "s:1-1-3", "l:1.2.4-1.2.5"),
+      std::make_tuple("j:1-1-4", "s:1-1-4", "l:1.2.5-1.2.6"),
+      std::make_tuple("j:1-1-5", "s:1-1-5", "l:1.2.6-1.2.7"),
+      std::make_tuple("j:1-1-6", "s:1-1-6", "l:1.2.7-1.2.8"),
+      std::make_tuple("j:1-1-7", "s:1-1-7", "l:1.2.8-1.2.9"),
+      std::make_tuple("j:1-1-8", "s:1-1-8", "l:1.2.9-1.2.10"),
+      std::make_tuple("j:1-1-9", "s:1-1-9", "l:1.2.10-1.2.11")};
+
+  std::string junction_name, segment_name, lane_name;
+  for (const auto& names : name_set) {
+    std::tie(junction_name, segment_name, lane_name) = names;
+    int junction_id = FindJunction(*road_geometry, junction_name);
+    ASSERT_NE(junction_id, -1);
+    const api::Junction* junction = road_geometry->junction(junction_id);
+    ASSERT_TRUE(junction != nullptr);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_TRUE(segment != nullptr);
+    EXPECT_EQ(segment->id().string(), segment_name);
+    ASSERT_EQ(segment->num_lanes(), 1);
+    const api::Lane* lane = segment->lane(0);
+    ASSERT_TRUE(lane != nullptr);
+    EXPECT_EQ(lane->id().string(), lane_name);
+  }
+}
+
+//          1.1.1      1.1.2       1.1.3
+//          * > > > > > * > > > > > *
+//  1.2.1   1.2.2  1.2.3    1.2.4
+//  * > > > * > > > * > > > > *
+//              1.3.2                    1.3.1
+//              * < < < < < < < < < < < < *
+//
+// For reference:
+//   -'<' and '>' represent lane's direction.
+//   - '*' represents a lane's waypoint.
+GTEST_TEST(RNDFBuilder, MultilaneLane) {
+  const api::RBounds single_lane_bounds(-kLaneWidth / 2.0, kLaneWidth / 2.0);
+  const api::RBounds two_lane_bounds_left(-kLaneWidth / 2.0,
+                                          kLaneWidth / 2.0 + 10.0);
+  const api::RBounds two_lane_bounds_right(-kLaneWidth / 2.0 - 10.0,
+                                           kLaneWidth / 2.0);
+
+  auto builder = std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
+  std::vector<Connection> connected_lanes;
+
+  {
+    std::vector<DirectedWaypoint> waypoints(4, DirectedWaypoint());
+    waypoints[0].set_id(ignition::rndf::UniqueId(1, 2, 1));
+    waypoints[0].set_position(ignition::math::Vector3d(0., 0.0, 0.0));
+    waypoints[1].set_id(ignition::rndf::UniqueId(1, 2, 2));
+    waypoints[1].set_position(ignition::math::Vector3d(10.0, 0.0, 0.0));
+    waypoints[2].set_id(ignition::rndf::UniqueId(1, 2, 3));
+    waypoints[2].set_position(ignition::math::Vector3d(15.0, 0.0, 0.0));
+    waypoints[3].set_id(ignition::rndf::UniqueId(1, 2, 4));
+    waypoints[3].set_position(ignition::math::Vector3d(25.0, 0.0, 0.0));
+    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    connected_lanes.push_back(connection);
+  }
+
+  {
+    std::vector<DirectedWaypoint> waypoints(3, DirectedWaypoint());
+    waypoints[0].set_id(ignition::rndf::UniqueId(1, 1, 1));
+    waypoints[0].set_position(ignition::math::Vector3d(10., 10.0, 0.0));
+    waypoints[1].set_id(ignition::rndf::UniqueId(1, 1, 2));
+    waypoints[1].set_position(ignition::math::Vector3d(20.0, 10.0, 0.0));
+    waypoints[2].set_id(ignition::rndf::UniqueId(1, 1, 3));
+    waypoints[2].set_position(ignition::math::Vector3d(30.0, 10.0, 0.0));
+    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    connected_lanes.push_back(connection);
+  }
+
+  {
+    std::vector<DirectedWaypoint> waypoints(2, DirectedWaypoint());
+    waypoints[0].set_id(ignition::rndf::UniqueId(1, 3, 1));
+    waypoints[0].set_position(ignition::math::Vector3d(40., -10.0, 0.0));
+    waypoints[1].set_id(ignition::rndf::UniqueId(1, 3, 2));
+    waypoints[1].set_position(ignition::math::Vector3d(5.0, -10.0, 0.0));
+    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    connected_lanes.push_back(connection);
+  }
+
+  const auto bounding_box =
+      std::make_pair(ignition::math::Vector3d(0., -10., 0.),
+                     ignition::math::Vector3d(40., 10., 0.));
+  builder->SetBoundingBox(bounding_box);
+  builder->CreateSegmentConnections(1, &connected_lanes);
+
+  const auto road_geometry =
+      builder->Build(api::RoadGeometryId{"MultilaneLane"});
+  ASSERT_TRUE(road_geometry != nullptr);
+
+  // Check road creation, naming, which lane is at both sides and bounds.
+  ASSERT_EQ(road_geometry->num_junctions(), 6);
+  EXPECT_EQ(road_geometry->junction(0)->id().string(), "j:1-0-0");
+  ASSERT_EQ(road_geometry->junction(0)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->id().string(), "s:1-0-0");
+  ASSERT_EQ(road_geometry->junction(0)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->id().string(),
+            "l:1.2.1-1.2.2");
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(0)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(0)->segment(0)->lane(0)->driveable_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+
+  EXPECT_EQ(road_geometry->junction(1)->id().string(), "j:1-0-1");
+  ASSERT_EQ(road_geometry->junction(1)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->id().string(), "s:1-0-1");
+  ASSERT_EQ(road_geometry->junction(1)->segment(0)->num_lanes(), 2);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->id().string(),
+            "l:1.2.2-1.2.3");
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(1)->id().string(),
+            "l:1.1.1-1.1.5");
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->to_left(),
+            road_geometry->junction(1)->segment(0)->lane(1));
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(1)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(1)->segment(0)->lane(1)->to_right(),
+            road_geometry->junction(1)->segment(0)->lane(0));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(1)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(1)->segment(0)->lane(1)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(1)->segment(0)->lane(0)->driveable_bounds(0),
+      two_lane_bounds_left, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(1)->segment(0)->lane(1)->driveable_bounds(0),
+      two_lane_bounds_right, kLinearTolerance));
+
+  EXPECT_EQ(road_geometry->junction(2)->id().string(), "j:1-0-2");
+  ASSERT_EQ(road_geometry->junction(2)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->id().string(), "s:1-0-2");
+  ASSERT_EQ(road_geometry->junction(2)->segment(0)->num_lanes(), 2);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->id().string(),
+            "l:1.2.3-1.2.5");
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(1)->id().string(),
+            "l:1.1.5-1.1.2");
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->to_left(),
+            road_geometry->junction(2)->segment(0)->lane(1));
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(1)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(2)->segment(0)->lane(1)->to_right(),
+            road_geometry->junction(2)->segment(0)->lane(0));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(2)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(2)->segment(0)->lane(1)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(2)->segment(0)->lane(0)->driveable_bounds(0),
+      two_lane_bounds_left, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(2)->segment(0)->lane(1)->driveable_bounds(0),
+      two_lane_bounds_right, kLinearTolerance));
+
+  EXPECT_EQ(road_geometry->junction(3)->id().string(), "j:1-0-3");
+  ASSERT_EQ(road_geometry->junction(3)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->id().string(), "s:1-0-3");
+  ASSERT_EQ(road_geometry->junction(3)->segment(0)->num_lanes(), 2);
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(0)->id().string(),
+            "l:1.2.5-1.2.4");
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(1)->id().string(),
+            "l:1.1.2-1.1.6");
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(0)->to_left(),
+            road_geometry->junction(3)->segment(0)->lane(1));
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(1)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(3)->segment(0)->lane(1)->to_right(),
+            road_geometry->junction(3)->segment(0)->lane(0));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(3)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(3)->segment(0)->lane(1)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(3)->segment(0)->lane(0)->driveable_bounds(0),
+      two_lane_bounds_left, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(3)->segment(0)->lane(1)->driveable_bounds(0),
+      two_lane_bounds_right, kLinearTolerance));
+
+  EXPECT_EQ(road_geometry->junction(4)->id().string(), "j:1-0-4");
+  ASSERT_EQ(road_geometry->junction(4)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(4)->segment(0)->id().string(), "s:1-0-4");
+  ASSERT_EQ(road_geometry->junction(4)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(4)->segment(0)->lane(0)->id().string(),
+            "l:1.1.6-1.1.3");
+  EXPECT_EQ(road_geometry->junction(4)->segment(0)->lane(0)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(4)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(4)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(4)->segment(0)->lane(0)->driveable_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+
+  EXPECT_EQ(road_geometry->junction(5)->id().string(), "j:1-1-0");
+  ASSERT_EQ(road_geometry->junction(5)->num_segments(), 1);
+  EXPECT_EQ(road_geometry->junction(5)->segment(0)->id().string(), "s:1-1-0");
+  ASSERT_EQ(road_geometry->junction(5)->segment(0)->num_lanes(), 1);
+  EXPECT_EQ(road_geometry->junction(5)->segment(0)->lane(0)->id().string(),
+            "l:1.3.1-1.3.2");
+  EXPECT_EQ(road_geometry->junction(5)->segment(0)->lane(0)->to_left(),
+            nullptr);
+  EXPECT_EQ(road_geometry->junction(5)->segment(0)->lane(0)->to_right(),
+            nullptr);
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(5)->segment(0)->lane(0)->lane_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      road_geometry->junction(5)->segment(0)->lane(0)->driveable_bounds(0),
+      single_lane_bounds, kLinearTolerance));
+}
+
+}  // namespace
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This pull request is the first of a series of pull requests (a spin-off of #6847, due to LOC size constraints) that aims to add Maliput's RNDF implementation **Builder** class. 

While similar to monolane's Builder class in its motivation, this class defines its own semantic in terms of Connections and DirectedWaypoints, both introduced in #6714, to map RNDF roads to Maliput's. For future reference, a fragment of the Builder's documentation is reproduced below.

*[...] RNDF segments and lanes are mapped to Maliput's Segment and Lane entities, respectively. This mapping is not straightforward, as Maliput is based on curve parameterizations while RNDF provides a sampled geometry based on waypoints. RNDF waypoints are thus used as control points in a cubic spline interpolation in the form of SplineLanes. RNDF lanes' direction is implied by RNDF waypoint IDs (`segment_num.lane_num.waypoint_num`) which is captured by the interpolation and reflected in DirectedWaypoints. These DirectedWaypoints are grouped in Connections, which describe not only RNDF lanes but also the connections between pairs of exit and entry RNDF waypoints. During the build process, interpolated DirectedWaypoints are added to these Connections so as to keep their distribution akin to a grid (and thus enable index-based operations).*

*As lanes in an RNDF segment may or may not flow in the same direction, segment Connections are also grouped by its direction relative to the first Connection found in the collection. An arbitrary point outside the bounding box of the road geometry is selected to be a "center of rotation" and the sum of all the DirectedWaypoints "momentums" (with normalized tangents) is computed. It must be said that the "momentum" equation is used to derive connection direction, but it bears no physical meaning. Since all the waypoints lay in the z = 0 plane, the "momentum" vector will only contain a non-zero z coordinate value. The sign of the "momentum"'s z coordinate will be taken as a reference to define the sense of flow. For all other connections, the "momentum" is computed and compared against the sign of the reference.[...]*

Specifically, this pull request adds support for building lanes only. The next pull request will add support for intersections and zones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6884)
<!-- Reviewable:end -->
