### PR TITLE
Add intersection and zone support to Maliput's RNDF implementation Builder class

### DIFF
--- a/drake/automotive/maliput/rndf/builder.cc
+++ b/drake/automotive/maliput/rndf/builder.cc
@@ -539,11 +539,11 @@ void SetInvertedConnections(const pair<ignition::math::Vector3d,
 }
 
 // Creates a pair of waypoints based on the given @p exit and @p entry
-// ones, keeping their heading but affecting tangent norms to
-// achieve smooth transitions by making use of cubic Bezier interpolants.
+// ones, keeping their heading but affecting tangent norms to achieve
+// smooth transitions by making use of cubic Bezier interpolants.
 // This is helpful for connecting lanes at intersections.
-// @param exit The start DirectedWaypoint of the lane's reference curve.
-// @param entry The end DirectedWaypoint of the lane's reference curve.
+// @param exit The start DirectedWaypoint of the lane's curve.
+// @param entry The end DirectedWaypoint of the lane's curve.
 // @return A vector with the two (2) waypoints that represent the
 // extents of the connection.
 vector<DirectedWaypoint> CreateDirectedWaypointsForConnections(

--- a/drake/automotive/maliput/rndf/builder.cc
+++ b/drake/automotive/maliput/rndf/builder.cc
@@ -60,11 +60,11 @@ const double kLinearStep = 1e-2;
 // Let S be a cubic Bezier spline, with control points p0, p1, p2 and p3.
 //          c
 //         / \        Define a critical point c where lines (p1-p0)*t + p0
-//        /   \       and (p2-p3)*w + p3 meet, t and w being real scalars.
+//        /   \       and (p2-p3)*w + p3 meet, where t and w are real scalars.
 //       /     \      To prevent loops and cusps, it is sufficient to ensure
 //      p1 --- p2     that control points p1 and p2 lie in the region bounded
 //      /        \    by the line segments (c - p0)*u + p0 and (c - p3)*v + p3,
-//     p0         \   u and v being real scalars.
+//     p0         \   where u and v are real scalars.
 //                p3
 // Here we make u = v = kBezierScaling. Note that a unitary scaling will place
 // inner control points p1 = (c - p0)*u + p0 and p2 = (c - p3)*v + p3 at the
@@ -440,7 +440,7 @@ void AddWaypointsIfNecessary(const vector<int>& ids,
       // valid waypoints in the connection.
       connection.AddWaypoint(DirectedWaypoint(), waypoint_count);
     } else if (connection.waypoints()[index].id().Z() == 1) {
-      // As the waypoint is at the beggining of the connection's vector, it
+      // As the waypoint is at the beginning of the connection's vector, it
       // adds an invalid one before the first waypoint.
       connection.AddWaypoint(DirectedWaypoint(), 0);
     } else {

--- a/drake/automotive/maliput/rndf/builder.cc
+++ b/drake/automotive/maliput/rndf/builder.cc
@@ -553,13 +553,13 @@ void SetInvertedConnections(const pair<ignition::math::Vector3d,
 vector<DirectedWaypoint> CreateDirectedWaypointsForConnection(
     const DirectedWaypoint& exit, const DirectedWaypoint& entry) {
   // Converts points and tangents into Bezier control points.
-  const vector<ignition::math::Vector3d>& bezier_points = SplineToBezier(
+  const vector<ignition::math::Vector3d> bezier_points = SplineToBezier(
       exit.position(), exit.tangent(), entry.position(), entry.tangent());
   // Adjusts these controls points to prevent loops and cusps.
-  const vector<ignition::math::Vector3d>& adapted_bezier_points =
+  const vector<ignition::math::Vector3d> adapted_bezier_points =
       MakeBezierCurveMonotonic(bezier_points, kBezierScaling);
   // Converts those Bezier control points to Hermite control points.
-  const vector<ignition::math::Vector3d>& hermite_points =
+  const vector<ignition::math::Vector3d> hermite_points =
       BezierToSpline(adapted_bezier_points[0], adapted_bezier_points[1],
                      adapted_bezier_points[2], adapted_bezier_points[3]);
   // Creates a pair of DirectedWaypoints and returns them.

--- a/drake/automotive/maliput/rndf/builder.cc
+++ b/drake/automotive/maliput/rndf/builder.cc
@@ -58,13 +58,17 @@ const double kWaypointDistancePhase = 2.0;
 const double kLinearStep = 1e-2;
 
 // Let S be a cubic Bezier spline, with control points p0, p1, p2 and p3.
-//                        Define a critical point c where lines (p1-p0)*t +
-//      p1 -- p2          p0 and (p2-p3)*w + p3 meet. To prevent loops and
-//      /       \         cusps, it sufficient to ensure that control points
-//     p0        \        p1 and p2 lie in the line segments (c - p0)*u + p0
-//               p3       and (c - p3)*v + p3.
-// Here we make u = v = kBezierScaling. Note that a unitary scaling will
-// place inner control points p1 and p2 at the critical point c.
+//          c
+//         / \        Define a critical point c where lines (p1-p0)*t + p0
+//        /   \       and (p2-p3)*w + p3 meet, t and w being real scalars.
+//       /     \      To prevent loops and cusps, it is sufficient to ensure
+//      p1 --- p2     that control points p1 and p2 lie in the region bounded
+//      /        \    by the line segments (c - p0)*u + p0 and (c - p3)*v + p3,
+//     p0         \   u and v being real scalars.
+//                p3
+// Here we make u = v = kBezierScaling. Note that a unitary scaling will place
+// inner control points p1 = (c - p0)*u + p0 and p2 = (c - p3)*v + p3 at the
+// critical point c.
 const double kBezierScaling = 1.0;
 
 // Determines the heading (in xy-plane) along the centerline when traveling
@@ -140,7 +144,7 @@ void BuildTangentsForWaypoints(vector<DirectedWaypoint>* waypoints) {
 }
 
 // Identifies the @p connections that come first in the direction the whole
-// collection of connections flows, by computing the projection of every
+// collection of connections flow, by computing the projection of every
 // waypoint at @p index onto every other waypoint's tangent at @p index so
 // as to identify those that have the most projections ahead of them in the
 // relative direction sense.
@@ -175,8 +179,7 @@ vector<int> GetInitialConnectionToProcess(const vector<Connection>& connections,
     }
     index_valid_distances.emplace_back(i, number_of_valid_distances);
   }
-  // Sorts the vector by increasing number of valid distances. It gives us as
-  // the first items the ids of the Connections to process.
+  // Sorts the vector by increasing number of valid distances.
   sort(index_valid_distances.begin(), index_valid_distances.end(),
        [](const pair<int, int>& t_a, const pair<int, int>& t_b) {
          return t_a.second > t_b.second;
@@ -187,8 +190,8 @@ vector<int> GetInitialConnectionToProcess(const vector<Connection>& connections,
     if (id_zeros.second == index_valid_distances[0].second)
       ids.push_back(id_zeros.first);
   }
-  // In case we have all the lane ids, no one is the first, all are on the same
-  // line.
+  // In case we have all the connection ids, no one is the first, all
+  // are on the same line.
   if (ids.size() == index_valid_distances.size()) {
     ids.clear();
   }
@@ -208,7 +211,7 @@ double CalculateMomentum(const ignition::math::Vector3d& center_of_rotation,
   const ignition::math::Vector3d p_WR =
       waypoint.position() - center_of_rotation;
   // Computes torque t on waypoint W applied around the center of rotation R.
-  ignition::math::Vector3d f_W = waypoint.tangent().Normalized();
+  const ignition::math::Vector3d f_W = waypoint.tangent().Normalized();
   const ignition::math::Vector3d t_WR = f_W.Cross(p_WR);
   // As all the points should lie on the x-y plane, the cross product should
   // be collinear with the z-axis, thus the only non zero component is z.
@@ -305,7 +308,7 @@ void OrderConnectionIds(const vector<Connection>& connections,
 // @warning This method will abort if preconditions are not met.
 Lane* BuildConnection(const Connection& connection, Segment* segment) {
   DRAKE_DEMAND(segment != nullptr);
-  api::LaneId lane_id{"l:" + connection.id()};
+  const api::LaneId lane_id{"l:" + connection.id()};
   vector<tuple<ignition::math::Vector3d, ignition::math::Vector3d>>
       points_tangents;
   for (const DirectedWaypoint& directed_waypoint : connection.waypoints()) {
@@ -355,7 +358,7 @@ void AttachLaneEndToBranchPoint(const api::LaneEnd::Which end, Lane* lane,
 }
 
 // Builds or updates a BranchPoint given a @p connection and the corresponding
-// @p lane. The former provides the start and end waypoints of the lane,
+// @p lane. The former provides the start and end waypoints of the latter,
 // which are necessary to lookup the branch points in the @p branch_point_map.
 // @param connection The Connection that provides the start and end waypoints.
 // @param lane The Lane to be attached to the right corresponding
@@ -401,7 +404,7 @@ void BuildOrUpdateBranchpoints(Connection* connection, Lane* lane,
   AttachLaneEndToBranchPoint(api::LaneEnd::kFinish, lane, bp);
 }
 
-// Adds either invalid or interpolated extra waypoints on those @p connections
+// Adds either invalid or interpolated extra waypoints on those connections
 // not listed in the @p ids of the @p connections that come first for the
 // given @p index, as computed by GetInitialConnectionToProcess(), to
 // make all waypoints at @p index lie in line with @p connections's normal.
@@ -411,8 +414,8 @@ void BuildOrUpdateBranchpoints(Connection* connection, Lane* lane,
 // @param connections A collection of Connections to add waypoints to if
 // necessary.
 // @param index The index of the @p connection's waypoints to look at.
-// @param linear_tolearance The tolerance for connections' waypoints spline
-// interpolation for road geometrical inference.
+// @param linear_tolerance The tolerance for spline interpolation of
+// connection waypoints.
 // @pre The given @p connections collection must not be a nullptr.
 // @warning This method will abort execution if any preconditions are not met.
 void AddWaypointsIfNecessary(const vector<int>& ids,
@@ -422,12 +425,12 @@ void AddWaypointsIfNecessary(const vector<int>& ids,
   for (size_t i = 0; i < connections->size(); i++) {
     Connection& connection = connections->at(i);
     // Checks that `i` index is in the ids vector which holds
-    // the indexes of connections with reference waypoints.
+    // the indexes of connections.
     if (find(ids.begin(), ids.end(), i) != ids.end()) {
       continue;
     }
 
-    size_t waypoint_count = connection.waypoints().size();
+    const size_t waypoint_count = connection.waypoints().size();
     // Checks if we don't have any index on the vector.
     if (ids.size() == 0 && waypoint_count > index) {
       continue;
@@ -437,8 +440,8 @@ void AddWaypointsIfNecessary(const vector<int>& ids,
       // valid waypoints in the connection.
       connection.AddWaypoint(DirectedWaypoint(), waypoint_count);
     } else if (connection.waypoints()[index].id().Z() == 1) {
-      // As the waypoint is at the top of the connection's vector, it adds an
-      // invalid one before the first waypoint.
+      // As the waypoint is at the beggining of the connection's vector, it
+      // adds an invalid one before the first waypoint.
       connection.AddWaypoint(DirectedWaypoint(), 0);
     } else {
       // Index cannot ever be zero, as every first waypoint would be
@@ -453,7 +456,7 @@ void AddWaypointsIfNecessary(const vector<int>& ids,
       const double s = arc_length_param_spline->FindClosestPointTo(
           connections->at(ids[0]).waypoints()[index].position(), kLinearStep);
       // Builds a new waypoint and adds it to the connection.
-      DirectedWaypoint new_wp(
+      const DirectedWaypoint new_wp(
           ignition::rndf::UniqueId(
               connections->at(i).waypoints()[index - 1].id().X(),
               connections->at(i).waypoints()[index - 1].id().Y(),
@@ -466,12 +469,13 @@ void AddWaypointsIfNecessary(const vector<int>& ids,
   }
 }
 
-// Adds waypoints to the given @p connections so as to ensure that their
-// spatial distribution is akin to a grid (thus enabling index operations).
+// Adds waypoints to the given @p connections to ensure that their spatial
+// distribution is such that for every index all valid waypoints share the same
+// s coordinate on the reference lane curve frame.
 // @param connections A collection of Connections to create waypoints into
 // if necessary.
-// @param linear_tolearance The tolerance for connections' waypoints spline
-// interpolation for road geometrical inference.
+// @param linear_tolerance The tolerance for spline interpolation of
+// connection waypoints.
 // @pre The given @p connections collection must not be a nullptr.
 // @warning This method will abort execution if any preconditions are not met.
 void CreateNewControlPointsForConnections(std::vector<Connection>* connections,
@@ -507,7 +511,7 @@ void CreateNewControlPointsForConnections(std::vector<Connection>* connections,
 //
 // To do this, it checks the connection momentum as computed by
 // CalculateConnectionMomentum() and looks for successive sign changes
-// with respect to a reference set with the first connection.
+// with respect to a reference set by the first connection.
 // @param bounding_box The bounding box for all given @p connections.
 // @param connections A collection of Connections to compare the way
 // connections' waypoints are disposed with respect to the first connection.
@@ -538,15 +542,15 @@ void SetInvertedConnections(const pair<ignition::math::Vector3d,
   }
 }
 
-// Creates a pair of waypoints based on the given @p exit and @p entry
-// ones, keeping their heading but affecting tangent norms to achieve
-// smooth transitions by making use of cubic Bezier interpolants.
-// This is helpful for connecting lanes at intersections.
-// @param exit The start DirectedWaypoint of the lane's curve.
-// @param entry The end DirectedWaypoint of the lane's curve.
+// Creates a pair of waypoints based on the given @p exit and @p entry,
+// keeping their heading but affecting tangent norms to achieve smooth
+// transitions by making use of cubic Bezier interpolants. This is helpful
+// for connecting lanes at intersections.
+// @param exit The start waypoint of the lane's curve.
+// @param entry The end waypoint of the lane's curve.
 // @return A vector with the two (2) waypoints that represent the
 // extents of the connection.
-vector<DirectedWaypoint> CreateDirectedWaypointsForConnections(
+vector<DirectedWaypoint> CreateDirectedWaypointsForConnection(
     const DirectedWaypoint& exit, const DirectedWaypoint& entry) {
   // Converts points and tangents into Bezier control points.
   const vector<ignition::math::Vector3d>& bezier_points = SplineToBezier(
@@ -554,7 +558,7 @@ vector<DirectedWaypoint> CreateDirectedWaypointsForConnections(
   // Adjusts these controls points to prevent loops and cusps.
   const vector<ignition::math::Vector3d>& adapted_bezier_points =
       MakeBezierCurveMonotonic(bezier_points, kBezierScaling);
-  // Converts back those Bezier control points to Hermite control points.
+  // Converts those Bezier control points to Hermite control points.
   const vector<ignition::math::Vector3d>& hermite_points =
       BezierToSpline(adapted_bezier_points[0], adapted_bezier_points[1],
                      adapted_bezier_points[2], adapted_bezier_points[3]);
@@ -577,9 +581,9 @@ void Builder::CreateConnection(double width,
   DRAKE_THROW_UNLESS(exit_it != directed_waypoints_.end());
   DRAKE_THROW_UNLESS(entry_it != directed_waypoints_.end());
 
-  std::vector<DirectedWaypoint> waypoints =
-      CreateDirectedWaypointsForConnections(exit_it->second, entry_it->second);
-  std::string key_id = exit_id.String() + "-" + entry_id.String();
+  const std::vector<DirectedWaypoint> waypoints =
+      CreateDirectedWaypointsForConnection(exit_it->second, entry_it->second);
+  const std::string key_id = exit_id.String() + "-" + entry_id.String();
   InsertConnection(key_id, width, waypoints);
 }
 
@@ -587,7 +591,7 @@ void Builder::CreateConnectionsForZones(
     double width, std::vector<DirectedWaypoint>* perimeter_waypoints) {
   DRAKE_THROW_UNLESS(perimeter_waypoints != nullptr);
   DRAKE_THROW_UNLESS(perimeter_waypoints->size() > 0);
-  // Computes the mean coordinates from all the waypoints of the perimeter.
+  // Computes the mean coordinates of all the perimeter waypoints.
   ignition::math::Vector3d center(0., 0., 0.);
   for (const DirectedWaypoint& waypoint : *perimeter_waypoints) {
     center += waypoint.position();
@@ -606,10 +610,10 @@ void Builder::CreateConnectionsForZones(
       directed_waypoints_[waypoint.id().String()] = waypoint;
     }
   }
-  // Creates connection that join exit waypoints with entry waypoints.
+  // Creates connections that join exit waypoints with entry waypoints.
   for (const DirectedWaypoint& entry : entries) {
     for (const DirectedWaypoint& exit : exits) {
-      std::vector<DirectedWaypoint> control_points = {entry, exit};
+      const std::vector<DirectedWaypoint> control_points{entry, exit};
       const std::string key_id = exit.id().String() + "-" + entry.id().String();
       InsertConnection(key_id, width, control_points);
     }

--- a/drake/automotive/maliput/rndf/builder.h
+++ b/drake/automotive/maliput/rndf/builder.h
@@ -37,7 +37,7 @@ namespace rndf {
 /// their distribution akin to a grid (and thus enable index-based operations).
 ///
 /// Since lanes in an RNDF segment may flow in different directions, segment
-/// connections are also grouped by its direction relative to the first
+/// connections are also grouped by their directions relative to the first
 /// connection found in the collection. An arbitrary point outside the bounding
 /// box of the road geometry is selected to be a "center of rotation" and the
 /// sum of all the DirectedWaypoints "momentums" (with normalized tangents) is
@@ -49,11 +49,11 @@ namespace rndf {
 /// all other connections, the "momentum" is computed and compared against the
 /// sign of the reference.
 ///
-/// RNDF zones do not have a direct mapping to Maliput either. Consequently,
-/// fake connections are added between every entry and exit waypoints on these
-/// to keep them driveable. These waypoints' direction is set so as to head
-/// towards the centroid of all the zone perimeter waypoints. There's currently
-/// no support for RNDF zones' parking spots.
+/// RNDF zones also do not have a direct representation in Maliput either.
+/// To model zones, fake connections are added between every pair of entry
+/// and exit waypoints in a zone. The directions of these waypoints are set to
+/// head towards the centroid of all the zone perimeter waypoints. There's
+/// currently no support for RNDF zones' parking spots.
 ///
 /// The resulting RoadGeometry presents the following naming for its composed
 /// entities:
@@ -118,8 +118,9 @@ namespace rndf {
 /// -# Call SetBoundingBox().
 /// -# Call CreateSegmentConnections() for each RNDF segment.
 /// -# Call CreateConnectionsForZones() for each RNDF zone.
-/// -# Call CreateConnection() for each pair of entry-exit in RNDF lanes and
-/// perimeters.
+/// -# Call CreateConnection() for each pair of entry-exit waypoints
+///    between RNDF lanes and zone perimeters (actually connecting
+///    their fake inner lanes to the outer real ones).
 /// -# Call Build() to get the built api::RoadGeometry.
 class Builder {
  public:
@@ -163,29 +164,32 @@ class Builder {
   void CreateSegmentConnections(int segment_id,
                                 std::vector<Connection>* connections);
 
-  /// Creates a collection of Connections between every pair of entry and exit
-  /// waypoints in @p perimeter_waypoints.
+  /// Creates a collection of Connection objects between every pair of entry and
+  /// exit waypoints in @p perimeter_waypoints.
   ///
   /// RNDF defines zones as areas where free-path driving is allowed. Since
-  /// Maliput does not cover this concept, and to avoid having lanes with closed
-  /// ends, every pair of entry and exit waypoints is connected. These
-  /// waypoints' direction is set to head towards the centroid of all
+  /// Maliput does not cover this concept, and to avoid having dead-end lanes,
+  /// every pair of entry and exit waypoints is connected. These waypoints'
+  /// directions are set to head towards the centroid of all
   /// @p perimeter_waypoints.
-  /// @param width The width of this zone's inner connections.
-  /// @param perimeter_waypoints A collection of DirectedWaypoints describing
-  /// the zone perimeter.
+  /// @param width The width of this zone's inner connections (and thus the
+  /// fake inner lanes' lane bounds).
+  /// @param perimeter_waypoints A collection of DirectedWaypoint objects
+  /// describing the zone's perimeter.
   /// @throw std::runtime_error When @p perimeter_waypoints is a nullptr.
-  /// @throw std::runtime_error When @p perimeter_waypoints' is an empty
+  /// @throw std::runtime_error When @p perimeter_waypoints is an empty
   /// collection.
   void CreateConnectionsForZones(
       double width, std::vector<DirectedWaypoint>* perimeter_waypoints);
 
   /// Creates a connection between two RNDF lanes based on a pair of @p exit and
-  /// @p entry ids that map to specific, existing waypoints.
+  /// @p entry ids that map to specific, existing waypoints. This is helpful
+  /// when building intersections.
   /// @param width The connection's width.
   /// @param exit_id The start waypoint ID of the connection.
   /// @param entry_id The end waypoint ID of the connection.
-  /// @throw std::runtime_error When neither @p exit nor @p entry are found.
+  /// @throw std::runtime_error When neither @p exit_id nor @p entry_id are
+  /// found.
   void CreateConnection(double width, const ignition::rndf::UniqueId& exit_id,
                         const ignition::rndf::UniqueId& entry_id);
 

--- a/drake/automotive/maliput/rndf/test/builder_test.cc
+++ b/drake/automotive/maliput/rndf/test/builder_test.cc
@@ -630,8 +630,8 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
 
   for (const auto& values : branch_point_truth_table) {
     std::string junction_name;
-    api::LaneEnd::Which lane_end;
-    int a_side_count, b_side_count;
+    int a_side_count = 0, b_side_count = 0;
+    api::LaneEnd::Which lane_end = api::LaneEnd::kStart;
     std::tie(junction_name, a_side_count, b_side_count, lane_end) = values;
 
     const int junction_id = FindJunction(*road_geometry, junction_name);

--- a/drake/automotive/maliput/rndf/test/builder_test.cc
+++ b/drake/automotive/maliput/rndf/test/builder_test.cc
@@ -548,7 +548,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   builder->CreateConnection(kLaneWidth, ignition::rndf::UniqueId(2, 1, 2),
                             ignition::rndf::UniqueId(1, 1, 3));
 
-  auto road_geometry =
+  const auto road_geometry =
       builder->Build(api::RoadGeometryId{"MultilaneLaneCross"});
   ASSERT_TRUE(road_geometry != nullptr);
 

--- a/drake/automotive/maliput/rndf/test/builder_test.cc
+++ b/drake/automotive/maliput/rndf/test/builder_test.cc
@@ -479,9 +479,12 @@ GTEST_TEST(RNDFBuilder, MultilaneLane) {
 //                     v   ^
 //                     v   ^
 //               1.1.4 *   * 1.2.1
+// // For reference:
+//   -'^', 'v', '<' and '>' represent lane's direction.
+//   -'|' and '/' represent crossing intersections.
+//   - '*' represents a lane's waypoint.
 GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
-  std::unique_ptr<Builder> builder =
-      std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
+  auto builder = std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
   auto bounding_box = std::make_pair(ignition::math::Vector3d(0., 0., 0.),
                                      ignition::math::Vector3d(40., 50., 0.));
   builder->SetBoundingBox(bounding_box);
@@ -543,23 +546,23 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   builder->CreateConnection(kLaneWidth, ignition::rndf::UniqueId(2, 1, 2),
                             ignition::rndf::UniqueId(1, 1, 3));
 
-  std::unique_ptr<const api::RoadGeometry> road_geometry =
+  auto road_geometry =
       builder->Build(api::RoadGeometryId{"MultilaneLaneCross"});
-  EXPECT_NE(road_geometry, nullptr);
-  EXPECT_EQ(road_geometry->num_junctions(), 11);
+  ASSERT_TRUE(road_geometry != nullptr);
+  ASSERT_EQ(road_geometry->num_junctions(), 11);
 
   // Here I check for the lane creation, naming, and bound coordinates
   int junction_id;
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-0-0"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1-0-0");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1-0-0"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1-0-0");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.1.1-1.1.2"));
+    EXPECT_EQ(lane->id().string(), "l:1.1.1-1.1.2");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(20., 50.0, 0.0), kLinearTolerance));
@@ -569,15 +572,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-0-1"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1-0-1");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1-0-1"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1-0-1");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.1.2-1.1.3"));
+    EXPECT_EQ(lane->id().string(), "l:1.1.2-1.1.3");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(20.0, 40.0, 0.0), kLinearTolerance));
@@ -587,15 +590,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-0-2"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1-0-2");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1-0-2"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1-0-2");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.1.3-1.1.4"));
+    EXPECT_EQ(lane->id().string(), "l:1.1.3-1.1.4");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(20.0, 10.0, 0.0), kLinearTolerance));
@@ -605,15 +608,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-1-0"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1-1-0");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1-1-0"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1-1-0");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.2.1-1.2.2"));
+    EXPECT_EQ(lane->id().string(), "l:1.2.1-1.2.2");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(30.0, 0.0, 0.0), kLinearTolerance));
@@ -623,15 +626,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-1-1"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1-1-1");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1-1-1"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1-1-1");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.2.2-1.2.3"));
+    EXPECT_EQ(lane->id().string(), "l:1.2.2-1.2.3");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(30.0, 30.0, 0.0), kLinearTolerance));
@@ -641,15 +644,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:2-0-0"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:2-0-0");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:2-0-0"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:2-0-0");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:2.1.1-2.1.2"));
+    EXPECT_EQ(lane->id().string(), "l:2.1.1-2.1.2");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(0.0, 20.0, 0.0), kLinearTolerance));
@@ -659,15 +662,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:2-0-1"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:2-0-1");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:2-0-1"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:2-0-1");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:2.1.2-2.1.3"));
+    EXPECT_EQ(lane->id().string(), "l:2.1.2-2.1.3");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
@@ -677,15 +680,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:2-1-0"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:2-1-0");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:2-1-0"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:2-1-0");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:2.2.1-2.2.2"));
+    EXPECT_EQ(lane->id().string(), "l:2.2.1-2.2.2");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(10.0, 30.0, 0.0), kLinearTolerance));
@@ -695,15 +698,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1.1.2-2.2.1"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:1.1.2-2.2.1");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:1.1.2-2.2.1"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:1.1.2-2.2.1");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:1.1.2-2.2.1"));
+    EXPECT_EQ(lane->id().string(), "l:1.1.2-2.2.1");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(20.0, 40.0, 0.0), kLinearTolerance));
@@ -712,15 +715,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
         api::GeoPosition(10.0, 30.0, 0.0), kLinearTolerance));
   }
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:2.1.2-1.2.2"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:2.1.2-1.2.2");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:2.1.2-1.2.2"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:2.1.2-1.2.2");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:2.1.2-1.2.2"));
+    EXPECT_EQ(lane->id().string(), "l:2.1.2-1.2.2");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
@@ -730,15 +733,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:2.1.2-1.1.3"));
-    EXPECT_NE(junction_id, -1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
+    junction_id = FindJunction(*road_geometry, "j:2.1.2-1.1.3");
+    ASSERT_NE(junction_id, -1);
+    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              std::string("s:2.1.2-1.1.3"));
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
+              "s:2.1.2-1.1.3");
+    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
 
     auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), std::string("l:2.1.2-1.1.3"));
+    EXPECT_EQ(lane->id().string(), "l:2.1.2-1.1.3");
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
         api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
@@ -747,37 +750,40 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
         api::GeoPosition(20.0, 10.0, 0.0), kLinearTolerance));
   }
 
-  EXPECT_EQ(road_geometry->num_branch_points(), 12);
+  ASSERT_EQ(road_geometry->num_branch_points(), 12);
   // Checks for the branch points
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-0-0"));
+    junction_id = FindJunction(*road_geometry, "j:1-0-0");
+    ASSERT_NE(junction_id, -1);
     auto branch_point = road_geometry->junction(junction_id)
                             ->segment(0)
                             ->lane(0)
                             ->GetBranchPoint(api::LaneEnd::kFinish);
-    EXPECT_NE(branch_point, nullptr);
+    ASSERT_NE(branch_point, nullptr);
     EXPECT_EQ(branch_point->GetASide()->size(), 1);
     EXPECT_EQ(branch_point->GetBSide()->size(), 2);
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-0-1"));
+    junction_id = FindJunction(*road_geometry, "j:1-0-1");
+    ASSERT_NE(junction_id, -1);
     auto branch_point = road_geometry->junction(junction_id)
                             ->segment(0)
                             ->lane(0)
                             ->GetBranchPoint(api::LaneEnd::kFinish);
-    EXPECT_NE(branch_point, nullptr);
+    ASSERT_TRUE(branch_point != nullptr);
     EXPECT_EQ(branch_point->GetASide()->size(), 2);
     EXPECT_EQ(branch_point->GetBSide()->size(), 1);
   }
 
   {
-    junction_id = FindJunction(*road_geometry, std::string("j:1-1-1"));
+    junction_id = FindJunction(*road_geometry, "j:1-1-1");
+    ASSERT_NE(junction_id, -1);
     auto branch_point = road_geometry->junction(junction_id)
                             ->segment(0)
                             ->lane(0)
                             ->GetBranchPoint(api::LaneEnd::kStart);
-    EXPECT_NE(branch_point, nullptr);
+    ASSERT_TRUE(branch_point != nullptr);
     EXPECT_EQ(branch_point->GetASide()->size(), 2);
     EXPECT_EQ(branch_point->GetBSide()->size(), 1);
   }

--- a/drake/automotive/maliput/rndf/test/builder_test.cc
+++ b/drake/automotive/maliput/rndf/test/builder_test.cc
@@ -57,7 +57,7 @@ GTEST_TEST(RNDFBuilder, ZigZagLane) {
   waypoints[2].set_position(ignition::math::Vector3d(0.0, -20.0, 0.0));
   waypoints[3].set_id(ignition::rndf::UniqueId(1, 1, 4));
   waypoints[3].set_position(ignition::math::Vector3d(10.0, -30.0, 0.0));
-  Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+  const Connection connection("1", waypoints, kLaneWidth, false);
 
   std::vector<Connection> connected_lanes = {connection};
 
@@ -178,8 +178,7 @@ GTEST_TEST(RNDFBuilder, UShapedLane) {
     waypoints[7].set_position(ignition::math::Vector3d(20.0, 40.0, 0.0));
     waypoints[8].set_id(ignition::rndf::UniqueId(1, 1, 9));
     waypoints[8].set_position(ignition::math::Vector3d(20.0, 50.0, 0.0));
-    connected_lanes.push_back(
-        Connection(std::to_string(1), waypoints, kLaneWidth, false));
+    connected_lanes.push_back(Connection("1", waypoints, kLaneWidth, false));
   }
 
   {
@@ -206,8 +205,7 @@ GTEST_TEST(RNDFBuilder, UShapedLane) {
     waypoints[9].set_position(ignition::math::Vector3d(-40.0, 40.0, 0.0));
     waypoints[10].set_id(ignition::rndf::UniqueId(1, 2, 11));
     waypoints[10].set_position(ignition::math::Vector3d(-40.0, 50.0, 0.0));
-    connected_lanes.push_back(
-        Connection(std::to_string(2), waypoints, kLaneWidth, false));
+    connected_lanes.push_back(Connection("2", waypoints, kLaneWidth, false));
   }
 
   const auto bounding_box =
@@ -221,30 +219,33 @@ GTEST_TEST(RNDFBuilder, UShapedLane) {
 
   // Checks junction, segments and lanes. Lane naming implies direction
   // so checking for correct naming implies proper direction inference.
-  std::vector<std::tuple<std::string, std::string, std::string> > name_set = {
-      std::make_tuple("j:1-0-0", "s:1-0-0", "l:1.1.1-1.1.2"),
-      std::make_tuple("j:1-0-1", "s:1-0-1", "l:1.1.2-1.1.3"),
-      std::make_tuple("j:1-0-2", "s:1-0-2", "l:1.1.3-1.1.4"),
-      std::make_tuple("j:1-0-3", "s:1-0-3", "l:1.1.4-1.1.5"),
-      std::make_tuple("j:1-0-4", "s:1-0-4", "l:1.1.5-1.1.6"),
-      std::make_tuple("j:1-0-5", "s:1-0-5", "l:1.1.6-1.1.7"),
-      std::make_tuple("j:1-0-6", "s:1-0-6", "l:1.1.7-1.1.8"),
-      std::make_tuple("j:1-0-7", "s:1-0-7", "l:1.1.8-1.1.9"),
-      std::make_tuple("j:1-1-0", "s:1-1-0", "l:1.2.1-1.2.2"),
-      std::make_tuple("j:1-1-1", "s:1-1-1", "l:1.2.2-1.2.3"),
-      std::make_tuple("j:1-1-2", "s:1-1-2", "l:1.2.3-1.2.4"),
-      std::make_tuple("j:1-1-3", "s:1-1-3", "l:1.2.4-1.2.5"),
-      std::make_tuple("j:1-1-4", "s:1-1-4", "l:1.2.5-1.2.6"),
-      std::make_tuple("j:1-1-5", "s:1-1-5", "l:1.2.6-1.2.7"),
-      std::make_tuple("j:1-1-6", "s:1-1-6", "l:1.2.7-1.2.8"),
-      std::make_tuple("j:1-1-7", "s:1-1-7", "l:1.2.8-1.2.9"),
-      std::make_tuple("j:1-1-8", "s:1-1-8", "l:1.2.9-1.2.10"),
-      std::make_tuple("j:1-1-9", "s:1-1-9", "l:1.2.10-1.2.11")};
+  const std::vector<std::tuple<std::string, std::string, std::string>>
+      name_truth_table{
+          // Tuple elements are, in order: junction name, segment name and lane
+          // name.
+          std::make_tuple("j:1-0-0", "s:1-0-0", "l:1.1.1-1.1.2"),
+          std::make_tuple("j:1-0-1", "s:1-0-1", "l:1.1.2-1.1.3"),
+          std::make_tuple("j:1-0-2", "s:1-0-2", "l:1.1.3-1.1.4"),
+          std::make_tuple("j:1-0-3", "s:1-0-3", "l:1.1.4-1.1.5"),
+          std::make_tuple("j:1-0-4", "s:1-0-4", "l:1.1.5-1.1.6"),
+          std::make_tuple("j:1-0-5", "s:1-0-5", "l:1.1.6-1.1.7"),
+          std::make_tuple("j:1-0-6", "s:1-0-6", "l:1.1.7-1.1.8"),
+          std::make_tuple("j:1-0-7", "s:1-0-7", "l:1.1.8-1.1.9"),
+          std::make_tuple("j:1-1-0", "s:1-1-0", "l:1.2.1-1.2.2"),
+          std::make_tuple("j:1-1-1", "s:1-1-1", "l:1.2.2-1.2.3"),
+          std::make_tuple("j:1-1-2", "s:1-1-2", "l:1.2.3-1.2.4"),
+          std::make_tuple("j:1-1-3", "s:1-1-3", "l:1.2.4-1.2.5"),
+          std::make_tuple("j:1-1-4", "s:1-1-4", "l:1.2.5-1.2.6"),
+          std::make_tuple("j:1-1-5", "s:1-1-5", "l:1.2.6-1.2.7"),
+          std::make_tuple("j:1-1-6", "s:1-1-6", "l:1.2.7-1.2.8"),
+          std::make_tuple("j:1-1-7", "s:1-1-7", "l:1.2.8-1.2.9"),
+          std::make_tuple("j:1-1-8", "s:1-1-8", "l:1.2.9-1.2.10"),
+          std::make_tuple("j:1-1-9", "s:1-1-9", "l:1.2.10-1.2.11")};
 
-  std::string junction_name, segment_name, lane_name;
-  for (const auto& names : name_set) {
+  for (const auto& names : name_truth_table) {
+    std::string junction_name, segment_name, lane_name;
     std::tie(junction_name, segment_name, lane_name) = names;
-    int junction_id = FindJunction(*road_geometry, junction_name);
+    const int junction_id = FindJunction(*road_geometry, junction_name);
     ASSERT_NE(junction_id, -1);
     const api::Junction* junction = road_geometry->junction(junction_id);
     ASSERT_TRUE(junction != nullptr);
@@ -289,7 +290,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLane) {
     waypoints[2].set_position(ignition::math::Vector3d(15.0, 0.0, 0.0));
     waypoints[3].set_id(ignition::rndf::UniqueId(1, 2, 4));
     waypoints[3].set_position(ignition::math::Vector3d(25.0, 0.0, 0.0));
-    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    const Connection connection("1", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
 
@@ -301,7 +302,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLane) {
     waypoints[1].set_position(ignition::math::Vector3d(20.0, 10.0, 0.0));
     waypoints[2].set_id(ignition::rndf::UniqueId(1, 1, 3));
     waypoints[2].set_position(ignition::math::Vector3d(30.0, 10.0, 0.0));
-    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    const Connection connection("1", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
 
@@ -311,7 +312,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLane) {
     waypoints[0].set_position(ignition::math::Vector3d(40., -10.0, 0.0));
     waypoints[1].set_id(ignition::rndf::UniqueId(1, 3, 2));
     waypoints[1].set_position(ignition::math::Vector3d(5.0, -10.0, 0.0));
-    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    const Connection connection("1", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
 
@@ -479,14 +480,15 @@ GTEST_TEST(RNDFBuilder, MultilaneLane) {
 //                     v   ^
 //                     v   ^
 //               1.1.4 *   * 1.2.1
-// // For reference:
+// For reference:
 //   -'^', 'v', '<' and '>' represent lane's direction.
 //   -'|' and '/' represent crossing intersections.
 //   - '*' represents a lane's waypoint.
 GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   auto builder = std::make_unique<Builder>(kLinearTolerance, kAngularTolerance);
-  auto bounding_box = std::make_pair(ignition::math::Vector3d(0., 0., 0.),
-                                     ignition::math::Vector3d(40., 50., 0.));
+  const auto bounding_box =
+      std::make_pair(ignition::math::Vector3d(0., 0., 0.),
+                     ignition::math::Vector3d(40., 50., 0.));
   builder->SetBoundingBox(bounding_box);
 
   std::vector<Connection> connected_lanes;
@@ -500,7 +502,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
     waypoints[2].set_position(ignition::math::Vector3d(20.0, 10.0, 0.0));
     waypoints[3].set_id(ignition::rndf::UniqueId(1, 1, 4));
     waypoints[3].set_position(ignition::math::Vector3d(20.0, 0.0, 0.0));
-    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    const Connection connection("1", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
   {
@@ -511,7 +513,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
     waypoints[1].set_position(ignition::math::Vector3d(30.0, 30.0, 0.0));
     waypoints[2].set_id(ignition::rndf::UniqueId(1, 2, 3));
     waypoints[2].set_position(ignition::math::Vector3d(30.0, 50.0, 0.0));
-    Connection connection(std::to_string(1), waypoints, kLaneWidth, false);
+    const Connection connection("1", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
   builder->CreateSegmentConnections(1, &connected_lanes);
@@ -525,7 +527,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
     waypoints[1].set_position(ignition::math::Vector3d(10.0, 20.0, 0.0));
     waypoints[2].set_id(ignition::rndf::UniqueId(2, 1, 3));
     waypoints[2].set_position(ignition::math::Vector3d(40.0, 20.0, 0.0));
-    Connection connection(std::to_string(2), waypoints, kLaneWidth, false);
+    const Connection connection("2", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
   {
@@ -534,7 +536,7 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
     waypoints[0].set_position(ignition::math::Vector3d(10., 30.0, 0.0));
     waypoints[1].set_id(ignition::rndf::UniqueId(2, 2, 2));
     waypoints[1].set_position(ignition::math::Vector3d(0.0, 30.0, 0.0));
-    Connection connection(std::to_string(2), waypoints, kLaneWidth, false);
+    const Connection connection("2", waypoints, kLaneWidth, false);
     connected_lanes.push_back(connection);
   }
   builder->CreateSegmentConnections(2, &connected_lanes);
@@ -549,243 +551,98 @@ GTEST_TEST(RNDFBuilder, MultilaneLaneCross) {
   auto road_geometry =
       builder->Build(api::RoadGeometryId{"MultilaneLaneCross"});
   ASSERT_TRUE(road_geometry != nullptr);
+
+  // Checks lane creation, naming, and bound coordinates.
   ASSERT_EQ(road_geometry->num_junctions(), 11);
 
-  // Here I check for the lane creation, naming, and bound coordinates
-  int junction_id;
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-0-0");
+  const std::vector<std::tuple<std::string, std::string, std::string,
+                               api::GeoPosition, api::GeoPosition>>
+      lane_truth_table{
+          // Tuple elements are, in order: junction name, segment name, lane
+          // name, lane start api::GeoPosition and lane end api::GeoPosition.
+          std::make_tuple("j:1-0-0", "s:1-0-0", "l:1.1.1-1.1.2",
+                          api::GeoPosition(20.0, 50.0, 0.0),
+                          api::GeoPosition(20.0, 40.0, 0.0)),
+          std::make_tuple("j:1-0-1", "s:1-0-1", "l:1.1.2-1.1.3",
+                          api::GeoPosition(20.0, 40.0, 0.0),
+                          api::GeoPosition(20.0, 10.0, 0.0)),
+          std::make_tuple("j:1-0-2", "s:1-0-2", "l:1.1.3-1.1.4",
+                          api::GeoPosition(20.0, 10.0, 0.0),
+                          api::GeoPosition(20.0, 0.0, 0.0)),
+          std::make_tuple("j:1-1-0", "s:1-1-0", "l:1.2.1-1.2.2",
+                          api::GeoPosition(30.0, 0.0, 0.0),
+                          api::GeoPosition(30.0, 30.0, 0.0)),
+          std::make_tuple("j:1-1-1", "s:1-1-1", "l:1.2.2-1.2.3",
+                          api::GeoPosition(30.0, 30.0, 0.0),
+                          api::GeoPosition(30.0, 50.0, 0.0)),
+          std::make_tuple("j:2-0-0", "s:2-0-0", "l:2.1.1-2.1.2",
+                          api::GeoPosition(0.0, 20.0, 0.0),
+                          api::GeoPosition(10.0, 20.0, 0.0)),
+          std::make_tuple("j:2-0-1", "s:2-0-1", "l:2.1.2-2.1.3",
+                          api::GeoPosition(10.0, 20.0, 0.0),
+                          api::GeoPosition(40.0, 20.0, 0.0)),
+          std::make_tuple("j:2-1-0", "s:2-1-0", "l:2.2.1-2.2.2",
+                          api::GeoPosition(10.0, 30.0, 0.0),
+                          api::GeoPosition(0.0, 30.0, 0.0)),
+          std::make_tuple("j:1.1.2-2.2.1", "s:1.1.2-2.2.1", "l:1.1.2-2.2.1",
+                          api::GeoPosition(20.0, 40.0, 0.0),
+                          api::GeoPosition(10.0, 30.0, 0.0)),
+          std::make_tuple("j:2.1.2-1.2.2", "s:2.1.2-1.2.2", "l:2.1.2-1.2.2",
+                          api::GeoPosition(10.0, 20.0, 0.0),
+                          api::GeoPosition(30.0, 30.0, 0.0)),
+          std::make_tuple("j:2.1.2-1.1.3", "s:2.1.2-1.1.3", "l:2.1.2-1.1.3",
+                          api::GeoPosition(10.0, 20.0, 0.0),
+                          api::GeoPosition(20.0, 10.0, 0.0))};
+
+  for (const auto& values : lane_truth_table) {
+    std::string junction_name, segment_name, lane_name;
+    api::GeoPosition start_position, end_position;
+    std::tie(junction_name, segment_name, lane_name, start_position,
+             end_position) = values;
+
+    const int junction_id = FindJunction(*road_geometry, junction_name);
     ASSERT_NE(junction_id, -1);
     ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
     EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1-0-0");
+              segment_name);
     ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.1.1-1.1.2");
+    const api::Lane* lane =
+        road_geometry->junction(junction_id)->segment(0)->lane(0);
+    EXPECT_EQ(lane->id().string(), lane_name);
     EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(20., 50.0, 0.0), kLinearTolerance));
+        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)), start_position,
+        kLinearTolerance));
     EXPECT_TRUE(api::test::IsGeoPositionClose(
         lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(20.0, 40.0, 0.0), kLinearTolerance));
+        end_position, kLinearTolerance));
   }
 
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-0-1");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1-0-1");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.1.2-1.1.3");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(20.0, 40.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(20.0, 10.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-0-2");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1-0-2");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.1.3-1.1.4");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(20.0, 10.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(20.0, 0.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-1-0");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1-1-0");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.2.1-1.2.2");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(30.0, 0.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(30.0, 30.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-1-1");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1-1-1");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.2.2-1.2.3");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(30.0, 30.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(30.0, 50.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:2-0-0");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:2-0-0");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:2.1.1-2.1.2");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(0.0, 20.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:2-0-1");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:2-0-1");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:2.1.2-2.1.3");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(40.0, 20.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:2-1-0");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:2-1-0");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:2.2.1-2.2.2");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(10.0, 30.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(0.0, 30.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:1.1.2-2.2.1");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:1.1.2-2.2.1");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:1.1.2-2.2.1");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(20.0, 40.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(10.0, 30.0, 0.0), kLinearTolerance));
-  }
-  {
-    junction_id = FindJunction(*road_geometry, "j:2.1.2-1.2.2");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:2.1.2-1.2.2");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:2.1.2-1.2.2");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(30.0, 30.0, 0.0), kLinearTolerance));
-  }
-
-  {
-    junction_id = FindJunction(*road_geometry, "j:2.1.2-1.1.3");
-    ASSERT_NE(junction_id, -1);
-    ASSERT_EQ(road_geometry->junction(junction_id)->num_segments(), 1);
-    EXPECT_EQ(road_geometry->junction(junction_id)->segment(0)->id().string(),
-              "s:2.1.2-1.1.3");
-    ASSERT_EQ(road_geometry->junction(junction_id)->segment(0)->num_lanes(), 1);
-
-    auto lane = road_geometry->junction(junction_id)->segment(0)->lane(0);
-    EXPECT_EQ(lane->id().string(), "l:2.1.2-1.1.3");
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
-        api::GeoPosition(10.0, 20.0, 0.0), kLinearTolerance));
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
-        api::GeoPosition(20.0, 10.0, 0.0), kLinearTolerance));
-  }
-
+  // Checks branch point creation.
   ASSERT_EQ(road_geometry->num_branch_points(), 12);
-  // Checks for the branch points
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-0-0");
-    ASSERT_NE(junction_id, -1);
-    auto branch_point = road_geometry->junction(junction_id)
-                            ->segment(0)
-                            ->lane(0)
-                            ->GetBranchPoint(api::LaneEnd::kFinish);
-    ASSERT_NE(branch_point, nullptr);
-    EXPECT_EQ(branch_point->GetASide()->size(), 1);
-    EXPECT_EQ(branch_point->GetBSide()->size(), 2);
-  }
 
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-0-1");
-    ASSERT_NE(junction_id, -1);
-    auto branch_point = road_geometry->junction(junction_id)
-                            ->segment(0)
-                            ->lane(0)
-                            ->GetBranchPoint(api::LaneEnd::kFinish);
-    ASSERT_TRUE(branch_point != nullptr);
-    EXPECT_EQ(branch_point->GetASide()->size(), 2);
-    EXPECT_EQ(branch_point->GetBSide()->size(), 1);
-  }
+  const std::vector<std::tuple<std::string, int, int, api::LaneEnd::Which>>
+      branch_point_truth_table{
+          // Tuple items are, in order: junction name, branch point A side lane
+          // count, branch point B side lane count and api::LaneEnd::Which type.
+          std::make_tuple("j:1-0-0", 1, 2, api::LaneEnd::kFinish),
+          std::make_tuple("j:1-0-1", 2, 1, api::LaneEnd::kFinish),
+          std::make_tuple("j:1-1-1", 2, 1, api::LaneEnd::kStart)};
 
-  {
-    junction_id = FindJunction(*road_geometry, "j:1-1-1");
+  for (const auto& values : branch_point_truth_table) {
+    std::string junction_name;
+    api::LaneEnd::Which lane_end;
+    int a_side_count, b_side_count;
+    std::tie(junction_name, a_side_count, b_side_count, lane_end) = values;
+
+    const int junction_id = FindJunction(*road_geometry, junction_name);
     ASSERT_NE(junction_id, -1);
-    auto branch_point = road_geometry->junction(junction_id)
-                            ->segment(0)
-                            ->lane(0)
-                            ->GetBranchPoint(api::LaneEnd::kStart);
+    const api::BranchPoint* branch_point = road_geometry->junction(junction_id)
+                                               ->segment(0)
+                                               ->lane(0)
+                                               ->GetBranchPoint(lane_end);
     ASSERT_TRUE(branch_point != nullptr);
-    EXPECT_EQ(branch_point->GetASide()->size(), 2);
-    EXPECT_EQ(branch_point->GetBSide()->size(), 1);
+    EXPECT_EQ(branch_point->GetASide()->size(), a_side_count);
+    EXPECT_EQ(branch_point->GetBSide()->size(), b_side_count);
   }
 }
 


### PR DESCRIPTION
This pull request is the second and last of a series of pull requests (a spin-off of #6847, due to LOC size constraints) that aims to add Maliput's RNDF implementation **Builder** class. As such, it builds on top of the previous one (#6884) and thus depends on it.

Specifically, this pull request adds support for building intersections and zones. 

A future pull request will include the Loader class, that parses an actual RNDF file and makes use of the whole Builder class. It is worth mentioning that, after the Loader class PR, the implementation will be complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6885)
<!-- Reviewable:end -->