### PR TITLE
Add the kinematics data transport functionality

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -11,6 +11,22 @@ load("//tools:lint.bzl", "add_lint_tests")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "frame_kinematics",
+    srcs = [
+        "frame_id_vector.cc",
+        "frame_kinematics_vector.cc",
+    ],
+    hdrs = [
+        "frame_id_vector.h",
+        "frame_kinematics_vector.h",
+    ],
+    deps = [
+        ":geometry_ids",
+        "//drake/common",
+    ],
+)
+
+drake_cc_library(
     name = "geometry_frame",
     srcs = [],
     hdrs = ["geometry_frame.h"],
@@ -47,6 +63,7 @@ drake_cc_library(
     srcs = ["geometry_state.cc"],
     hdrs = ["geometry_state.h"],
     deps = [
+        ":frame_kinematics",
         ":geometry_frame",
         ":geometry_ids",
         ":geometry_index",
@@ -117,6 +134,22 @@ drake_cc_library(
     name = "expect_error_message",
     srcs = [],
     hdrs = ["test/expect_error_message.h"],
+)
+
+drake_cc_googletest(
+    name = "frame_id_vector_test",
+    deps = [
+        ":expect_error_message",
+        ":frame_kinematics",
+    ],
+)
+
+drake_cc_googletest(
+    name = "frame_kinematics_vector_test",
+    deps = [
+        ":frame_kinematics",
+        "//drake/common:eigen_matrix_compare",
+    ],
 )
 
 drake_cc_googletest(

--- a/drake/geometry/frame_id_vector.cc
+++ b/drake/geometry/frame_id_vector.cc
@@ -1,0 +1,61 @@
+#include "drake/geometry/frame_id_vector.h"
+
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace drake {
+namespace geometry {
+
+using std::vector;
+
+FrameIdVector::FrameIdVector(SourceId source_id) : source_id_(source_id) {}
+
+FrameIdVector::FrameIdVector(SourceId source_id, const vector<FrameId>& ids)
+    : source_id_(source_id) {
+  AddFrameIds(ids);
+}
+
+int FrameIdVector::GetIndex(FrameId frame_id) const {
+  auto iter = id_index_map_.find(frame_id);
+  if (iter != id_index_map_.end()) {
+    return iter->second;
+  }
+  using std::to_string;
+  throw std::logic_error(
+      "The given frame id (" + to_string(frame_id) + ") is not in the set.");
+}
+
+void FrameIdVector::AddFrameId(FrameId frame_id) {
+  ThrowIfContains(frame_id);
+  int index = static_cast<int>(id_index_map_.size());
+  id_index_map_[frame_id] = index;
+  index_id_map_.push_back(frame_id);
+}
+
+void FrameIdVector::AddFrameIds(const vector<FrameId>& ids) {
+  ThrowIfContainsDuplicates(ids);
+  id_index_map_.reserve(id_index_map_.size() + ids.size());
+  for (auto id : ids) {
+    AddFrameId(id);
+  }
+}
+
+void FrameIdVector::ThrowIfContainsDuplicates(
+    const std::vector<FrameId>& frame_ids) {
+  std::unordered_set<FrameId> unique_ids{frame_ids.begin(), frame_ids.end()};
+  if (unique_ids.size() != frame_ids.size()) {
+    throw std::logic_error("Input vector of frame ids contains duplicates.");
+  }
+}
+
+void FrameIdVector::ThrowIfContains(FrameId frame_id) {
+  if (id_index_map_.find(frame_id) != id_index_map_.end()) {
+    using std::to_string;
+    throw std::logic_error("Id vector already contains frame id: " +
+        to_string(frame_id) + ".");
+  }
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/frame_id_vector.h
+++ b/drake/geometry/frame_id_vector.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+// TODO(SeanCurtis-TRI): Extend documentation to give usage examples.
+//  Usage notes:
+//    0. *Set* semantics. It is represented by an ordered structure for
+//       performance reasons. However, the frame ids in the set must be unique.
+//      a. Debug build provides data validation and correctness (to the extent
+//         that it can.)
+//    1. Expectation of constructing once and updating as you go.
+
+/** Represents an _ordered_ set of frame identifiers. Instances of this class
+ work in conjunction with instances of FramePoseVector and FrameVelocityVector
+ to communicate frame kinematics to GeometryWorld and GeometrySystem. Considered
+ together, they represent a "struct-of-arrays" paradigm. The iᵗʰ value in the
+ %FrameIdVector is the frame identifier whose position is specified by
+ the iᵗʰ value in the corresponding FramePoseVector (and analogously for the
+ FrameVelocityVector).
+
+ The geometry source can use arbitrary logic to define the _order_ of the ids.
+ However, all frames registered by the source must be included. Omitting a
+ registered frame id is considered an error (and will cause an exception
+ when GeometryWorld/GeometrySystem evaluates the data.
+
+ @internal In future iterations, this will be relaxed to allow only
+ communicating kinematics for frames that have _changed_. But in the initial
+ version, this requirement is in place for pedagogical purposes to help users
+ use GeometryWorld/GeometrySystem correctly. */
+class FrameIdVector {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameIdVector)
+
+  typedef std::vector<FrameId>::const_iterator ConstIterator;
+
+  /** Constructor for an _empty_ id vector.
+   @param source_id   The id for the geometry source reporting frame kinematics.
+   */
+  explicit FrameIdVector(SourceId source_id);
+
+  /** Constructor which initializes the frame ids by _copying_ the given `ids`.
+   In Debug builds, the input `ids` will be tested for duplicates; an exception
+   is thrown if duplicates are found.
+   @param source_id   The id for the geometry source reporting frame kinematics.
+   @param ids         The vector of ids which are copied into this vector.
+   @throws std::logic_error (in Debug) if any of the ids are duplicated. */
+  FrameIdVector(SourceId source_id, const std::vector<FrameId>& ids);
+
+  /** Reports the source id for this data. */
+  SourceId get_source_id() const { return source_id_; }
+
+  /** Reports the number of ids stored in the vector. */
+  int size() const { return static_cast<int>(id_index_map_.size()); }
+
+  /** Returns the iᵗʰ frame id. */
+  FrameId get_frame_id(int i) const { return index_id_map_[i]; }
+
+  /** Returns the index of the given frame id.
+   @throws std::logic_error if the frame id is not in the set. */
+  int GetIndex(FrameId frame_id) const;
+
+  /** Appends the given frame identifier to the set.
+   @param frame_id    The frame identifier to add.
+   @throws std::logic_error if the frame_id already exists in the vector.  */
+  void AddFrameId(FrameId frame_id);
+
+  /** Appends the given set of frame `ids` to the set. In Debug build, the
+   resultant set is tested for duplicate frame ids.
+   @param ids  The ordered set of frame ids to append to the current set.
+   @throws std::logic_error if there are duplicate ids in the resultant set. */
+  void AddFrameIds(const std::vector<FrameId>& ids);
+
+  /** @name  Support for range-based loop iteration */
+  //@{
+
+  ConstIterator begin() const { return index_id_map_.cbegin(); }
+  ConstIterator end() const { return index_id_map_.cend(); }
+
+  //@}
+
+ private:
+  // Throws an exception if the given vector contains duplicates values. This
+  // does not consider the contents of index_id_map_.
+  static void ThrowIfContainsDuplicates(const std::vector<FrameId>& frame_ids);
+
+  // Throws an exception if the given frame_id is already in id_index_map_.
+  void ThrowIfContains(FrameId frame_id);
+
+  // The id of the reporting geometry source.
+  SourceId source_id_;
+
+  // A mapping from frame_id to its index value. For N frames, the map should
+  // span the range [0, N-1]. For a given frame id (f_id), the following should
+  // hold:
+  //   f_id == index_id_map_[id_index_map_[f_id]];
+  std::unordered_map<FrameId, int> id_index_map_;
+
+  // A mapping from index to frame id.
+  std::vector<FrameId> index_id_map_;
+};
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/frame_kinematics_vector.cc
+++ b/drake/geometry/frame_kinematics_vector.cc
@@ -1,0 +1,29 @@
+#include "drake/geometry/frame_kinematics_vector.h"
+
+#include <utility>
+
+namespace drake {
+namespace geometry {
+
+using std::move;
+
+template <typename KinematicsValue>
+FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
+    SourceId source_id)
+    : source_id_(source_id) {}
+
+template <typename KinematicsValue>
+FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
+    SourceId source_id, const std::vector<KinematicsValue>& values)
+    : vector_(values), source_id_(source_id) {}
+
+template <typename KinematicsValue>
+FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
+    SourceId source_id, std::vector<KinematicsValue>&& values)
+    : vector_(move(values)), source_id_(source_id) {}
+
+// Explicitly instantiates on the most common scalar types.
+template class FrameKinematicsVector<Isometry3<double>>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/frame_kinematics_vector.h
+++ b/drake/geometry/frame_kinematics_vector.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+/** A %FrameKinematicsVector associates a std::vector with a geometry source.
+ It serves as the basis of FramePoseVector, FrameVelocityVector, and
+ FrameAccelerationVector. Geometry sources report the kinematics values for
+ their registered frame through these classes.
+
+ The %FrameKinematicsVector must be constructed with the source's SourceId
+ and then one kinematics value (e.g., pose) must be added to the underlying
+ vector for each registered frame. The values are interpreted by the order of
+ FrameId values in the corresponding FrameIdVector; the iᵗʰ value is attributed
+ to the frame identified by the iᵗʰ FrameId in the FrameIdVector.
+
+ @internal The FrameVelocityVector and FrameAccelerationVector are still to
+ come.
+
+ The intent is for the vector to be manipulated directly. Access the vector
+ through a call to mutable_vector() and operate directly on the vector to
+ improve performance. For example, for a FramePoseVector `poses`:
+
+   - Reserving space for `n` frame poses (e.g.,
+     `poses.mutable_vector().reserve(n);`).
+   - Making use of `emplace_back()` or writing directly to mutable references
+     via `poses.mutable_vector()[i] = KinematicsValue()`.
+
+ @tparam KinematicsValue  The underlying data type of for the order of
+                          kinematics data (e.g., pose, velocity, or
+                          acceleration).
+
+ One should never interact with the %FrameKinematicsVector class directly.
+ Instead, the FramePoseVector, FrameVelocityVector, and FrameAccelerationVector
+ classes are aliases of the %FrameKinematicsVector instantiated on specific
+ data types (Isometry3, SpatialVector, and SpatialAcceleration, respectively).
+ Each of these data types are templated on Eigen scalars. All supported
+ combinations of data type and scalar type are already available to link against
+ in the containing library. No other values for KinematicsValue are supported.
+
+ Currently, the following data types with the following scalar types are
+ supported:
+
+  Alias           | Instantiation                            | Scalar types
+ -----------------|------------------------------------------|--------------
+  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | double
+
+  @see FrameIdVector */
+template <class KinematicsValue>
+class FrameKinematicsVector {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameKinematicsVector)
+
+  /** Constructs an empty vector. */
+  explicit FrameKinematicsVector(SourceId source_id);
+
+  /** Copy constructs from a std::vector of KinematicsValue type. */
+  FrameKinematicsVector(SourceId source_id,
+                        const std::vector<KinematicsValue>& values);
+
+  /** Move constructs from a std::vector of KinematicsValue type. */
+  FrameKinematicsVector(SourceId source_id,
+                        std::vector<KinematicsValue>&& values);
+
+  SourceId get_source_id() const { return source_id_; }
+  const std::vector<KinematicsValue>& vector() const { return vector_; }
+  std::vector<KinematicsValue>& mutable_vector() { return vector_; }
+
+ private:
+  // The underlying data.
+  std::vector<KinematicsValue> vector_;
+
+  // The source id this data is associated with.
+  SourceId source_id_;
+};
+
+/** Class for communicating ordered _pose_ information to GeometryWorld/
+ GeometrySystem for registered frames.
+
+ @tparam T The scalar type. Must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double
+
+ They are already available to link against in the containing library.
+ No other values for T are currently supported.
+ */
+template <typename T>
+using FramePoseVector = FrameKinematicsVector<Isometry3<T>>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_system.h
+++ b/drake/geometry/geometry_system.h
@@ -62,10 +62,10 @@ class GeometryInstance;
  pose port will be interpreted. Use get_source_frame_id_port() to acquire the
  port for a given source.
 
- __pose port__: An abstract-valued port containing an instance of FramePoseSet.
- There should be one pose value for each id in the the identifier port value.
- The iᵗʰ pose belongs to the iᵗʰ id. Use get_source_pose_port() to acquire the
- port for a given source.
+ __pose port__: An abstract-valued port containing an instance of
+ FramePoseVector. There should be one pose value for each id in the the
+ identifier port value. The iᵗʰ pose belongs to the iᵗʰ id. Use
+ get_source_pose_port() to acquire the port for a given source.
 
  For source systems, there are some implicit assumptions regarding these input
  ports. Generally, we assume that the source system already has some logic for

--- a/drake/geometry/test/frame_id_vector_test.cc
+++ b/drake/geometry/test/frame_id_vector_test.cc
@@ -1,0 +1,145 @@
+#include "drake/geometry/frame_id_vector.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/test/expect_error_message.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using std::vector;
+
+// Simply tests successful construction.
+GTEST_TEST(FrameIdVector, ConstructorSuccess) {
+  SourceId source_id = SourceId::get_new_id();
+
+  // Case: Empty set.
+  FrameIdVector ids1(source_id);
+  EXPECT_EQ(ids1.get_source_id(), source_id);
+  EXPECT_EQ(ids1.size(), 0);
+
+  // Case: Copy from vector.
+  vector<FrameId> frames{FrameId::get_new_id(), FrameId::get_new_id(),
+                         FrameId::get_new_id(), FrameId::get_new_id()};
+  const int frame_count = static_cast<int>(frames.size());
+  FrameIdVector ids2(source_id, frames);
+  EXPECT_EQ(ids2.get_source_id(), source_id);
+  EXPECT_EQ(ids2.size(), frame_count);
+  // Confirms successful copy.
+  for (int i = 0; i < frame_count; ++i) {
+    EXPECT_EQ(ids2.get_frame_id(i), frames[i]);
+  }
+}
+
+// Tests the range iterators.
+GTEST_TEST(FrameIdVector, RangeIteration) {
+  vector<FrameId> frames{FrameId::get_new_id(), FrameId::get_new_id(),
+                         FrameId::get_new_id(), FrameId::get_new_id()};
+  FrameIdVector ids(SourceId::get_new_id(), frames);
+  int i = 0;
+  for (auto id : ids) {
+    EXPECT_EQ(id, frames[i++]);
+  }
+  EXPECT_EQ(i, static_cast<int>(frames.size()));
+}
+
+// Tests conditions where input vector of ids contain duplicates.
+GTEST_TEST(FrameIdVector, ConstructorWithDuplicates) {
+  SourceId source_id = SourceId::get_new_id();
+  vector<FrameId> frames{FrameId::get_new_id(), FrameId::get_new_id(),
+                         FrameId::get_new_id(), FrameId::get_new_id()};
+  frames.push_back(frames[0]);
+
+  // Case: Construct by copying frames.
+  EXPECT_ERROR_MESSAGE(
+      FrameIdVector(source_id, frames), std::logic_error,
+      "Input vector of frame ids contains duplicates.");
+
+  // Case: Construct by moving frames.
+  EXPECT_ERROR_MESSAGE(
+      FrameIdVector(source_id, move(frames)), std::logic_error,
+      "Input vector of frame ids contains duplicates.");
+}
+
+// Tests the functionality for adding single frames to the set.
+GTEST_TEST(FrameIdVector, AddingFramesSingle) {
+  FrameIdVector ids(SourceId::get_new_id());
+  // Do *not* re-order these tests; the logic depends on the sequence.
+  // Case: Add single to empty.
+  FrameId f0 = FrameId::get_new_id();
+  EXPECT_NO_THROW(ids.AddFrameId(f0));
+  EXPECT_EQ(ids.size(), 1);
+  EXPECT_EQ(ids.get_frame_id(0), f0);
+
+  // Case: Add single to non-empty (unique).
+  FrameId f1 = FrameId::get_new_id();
+  EXPECT_NO_THROW(ids.AddFrameId(f1));
+  EXPECT_EQ(ids.size(), 2);
+  EXPECT_EQ(ids.get_frame_id(1), f1);
+
+  // Case: Add single to non-empty (not unique).
+  EXPECT_ERROR_MESSAGE(ids.AddFrameId(f0), std::logic_error,
+                       "Id vector already contains frame id: \\d+.");
+}
+
+// Tests the functionality for adding multiple frames to the set.
+GTEST_TEST(FrameIdVector, AddingFramesMultiple) {
+  vector<FrameId> unique1{FrameId::get_new_id(), FrameId::get_new_id(),
+                          FrameId::get_new_id(), FrameId::get_new_id()};
+  vector<FrameId> unique2{FrameId::get_new_id(), FrameId::get_new_id(),
+                          FrameId::get_new_id(), FrameId::get_new_id()};
+  vector<FrameId> duplicate{unique1[0]};
+  FrameIdVector ids(SourceId::get_new_id());
+  // Do *not* re-order these tests; the logic depends on the sequence.
+
+  // Case: Add multiple to empty (all unique).
+  EXPECT_NO_THROW(ids.AddFrameIds(unique1));
+  for (int i = 0; i < static_cast<int>(unique1.size()); ++i) {
+    EXPECT_EQ(ids.get_frame_id(i), unique1[i]);
+  }
+
+  // Case: Add multiple to non-empty (unique result).
+  EXPECT_NO_THROW(ids.AddFrameIds(unique2));
+  int i = 0;
+  for (; i < static_cast<int>(unique1.size()); ++i) {
+    EXPECT_EQ(ids.get_frame_id(i), unique1[i]);
+  }
+  for (int j = 0; i < static_cast<int>(unique1.size() + unique2.size());
+       ++i, ++j) {
+    EXPECT_EQ(ids.get_frame_id(i), unique2[j]);
+  }
+
+  // Case: Add multiple to non-empty (non-unique result).
+  EXPECT_ERROR_MESSAGE(ids.AddFrameIds(duplicate), std::logic_error,
+                       "Id vector already contains frame id: \\d+.");
+
+  // Case: Add vector of ids that do not duplicate previous contents but
+  // contains duplicate values.
+  FrameId new_id = FrameId::get_new_id();
+  vector<FrameId> redundant{new_id, new_id};
+  EXPECT_ERROR_MESSAGE(
+      ids.AddFrameIds(redundant), std::logic_error,
+      "Input vector of frame ids contains duplicates.");
+}
+
+// Tests the functionality that tries to report the index of the desired frame.
+GTEST_TEST(FrameIdVector, FrameLookup) {
+  vector<FrameId> frames{FrameId::get_new_id(), FrameId::get_new_id(),
+                         FrameId::get_new_id(), FrameId::get_new_id()};
+  FrameIdVector ids(SourceId::get_new_id(), frames);
+  int index = -1;
+  int expected_index = 2;
+  EXPECT_NO_THROW(index = ids.GetIndex(frames[expected_index]));
+  EXPECT_EQ(index, expected_index);
+
+  EXPECT_ERROR_MESSAGE(ids.GetIndex(FrameId::get_new_id()), std::logic_error,
+                       "The given frame id \\(\\d+\\) is not in the set.");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/frame_kinematics_vector_test.cc
+++ b/drake/geometry/test/frame_kinematics_vector_test.cc
@@ -1,0 +1,78 @@
+#include "drake/geometry/frame_kinematics_vector.h"
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_matrix_compare.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace test {
+
+using std::move;
+using std::vector;
+
+// Because FrameKinematicsVector inherits from std::vector, we assume that class
+// has been properly tested. We limit the testing to the public constructors
+// and single additional field.
+
+GTEST_TEST(FrameKinematicsVector, DefaultConstructor) {
+  SourceId source_id = SourceId::get_new_id();
+
+  FramePoseVector<double> poses(source_id);
+
+  EXPECT_EQ(poses.get_source_id(), source_id);
+  EXPECT_EQ(poses.vector().size(), 0);
+  EXPECT_EQ(poses.vector().begin(), poses.vector().end());
+}
+
+GTEST_TEST(FrameKinematicsVector, CopyConstructor) {
+  SourceId source_id = SourceId::get_new_id();
+  std::vector<Isometry3<double>> pose_source;
+  int kPoseCount = 5;
+  for (int i = 0; i < kPoseCount; ++i) {
+    Isometry3<double> pose = Isometry3<double>::Identity();
+    pose.translation() << i, i, i;
+    pose_source.push_back(pose);
+  }
+
+  FramePoseVector<double> poses(source_id, pose_source);
+
+  EXPECT_EQ(poses.get_source_id(), source_id);
+  EXPECT_EQ(pose_source.size(), kPoseCount);
+  EXPECT_EQ(poses.vector().size(), kPoseCount);
+  for (int i = 0; i < kPoseCount; ++i) {
+    const double kValue = i;
+    Vector3<double> pose{kValue, kValue, kValue};
+    EXPECT_EQ(poses.mutable_vector()[i].translation(), pose);
+  }
+}
+
+GTEST_TEST(FrameKinematicsVector, MoveConstructor) {
+  SourceId source_id = SourceId::get_new_id();
+  std::vector<Isometry3<double>> pose_source;
+  int kPoseCount = 5;
+  for (int i = 0; i < kPoseCount; ++i) {
+    Isometry3<double> pose = Isometry3<double>::Identity();
+    pose.translation() << i, i, i;
+    pose_source.push_back(pose);
+  }
+
+  FramePoseVector<double> poses(source_id, move(pose_source));
+
+  EXPECT_EQ(poses.get_source_id(), source_id);
+  EXPECT_EQ(pose_source.size(), 0);
+  EXPECT_EQ(poses.vector().size(), kPoseCount);
+  for (int i = 0; i < kPoseCount; ++i) {
+    const double kValue = i;
+    Vector3<double> pose{kValue, kValue, kValue};
+    EXPECT_EQ(poses.mutable_vector()[i].translation(), pose);
+  }
+}
+
+}  // namespace test
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
These are the values for the `AbstractValue`d ports and interface to
communicating frame kinematics from geometry sources to state (via
GeometrySystem). This includes pose kinematics only -- velocity and
acceleration will come in subsequent PRs.

It's a big PR but not as intimidating as it first looks:

The 807 additions are comprised of:
```
blank lines: 132
comments:    166
code:        509
------------------
total:       807
```

If the feeling is that this PR is too large, I can break it up, introducing the data types and their tests in this PR and the integration into `GeometryState` in the next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6888)
<!-- Reviewable:end -->
