### PR TITLE
Fix drake_visualizer PYTHONPATH

### DIFF
--- a/tools/drake_visualizer_apple.sh
+++ b/tools/drake_visualizer_apple.sh
@@ -14,6 +14,6 @@ if ! [ -d "external/drake_visualizer" ]; then
     fi
 fi
 
-export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/drake_visualizer/bin/drake-visualizer" "$@"

--- a/tools/drake_visualizer_linux.sh
+++ b/tools/drake_visualizer_linux.sh
@@ -15,6 +15,6 @@ if ! [ -d "external/drake_visualizer" ]; then
 fi
 
 export LD_LIBRARY_PATH="external/vtk/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external/vtk/lib/python2.7/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external/vtk/lib/python2.7/site-packages:external${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/drake_visualizer/bin/drake-visualizer" "$@"


### PR DESCRIPTION
The directory `external` needs to be at the end of the PYTHONPATH, otherwise Python attempts to load VTK from `external/vtk` which is empty except for an autogenerated `__init__.py` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6898)
<!-- Reviewable:end -->
