### PR TITLE
Increase test size for double_pendulum_test

### DIFF
--- a/drake/multibody/multibody_tree/BUILD
+++ b/drake/multibody/multibody_tree/BUILD
@@ -135,6 +135,8 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "double_pendulum_test",
+    # Presently times out in valgrind + debug with default size, "small".
+    size = "medium",
     deps = [
         ":multibody_tree",
         "//drake/multibody/benchmarks/acrobot",


### PR DESCRIPTION
This addresses test failures in the following CI nightly jobs:

https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=751769
https://drake-cdash.csail.mit.edu/viewBuildError.php?buildid=751699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6902)
<!-- Reviewable:end -->
