### PR TITLE
Remove IPOPT from Drake CPS file

### DIFF
--- a/tools/drake.cps
+++ b/tools/drake.cps
@@ -31,11 +31,6 @@
       "Hints": ["@prefix@/lib/cmake/fmt"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "IPOPT": {
-      "Version": "3.12.5",
-      "Hints": ["@prefix@/lib/cmake/ipopt"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "lcm": {
       "Version": "1.3.95",
       "Hints": ["@prefix@/lib/cmake/lcm"],
@@ -93,7 +88,6 @@
         "Eigen3:Eigen",
         "fcl:fcl",
         "fmt:fmt",
-        "IPOPT:ipopt",
         "lcm:lcm",
         "NLopt:nlopt",
         "protobuf:protobuf",


### PR DESCRIPTION
IPOPT is statically linked so it is unnecessary to include here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6917)
<!-- Reviewable:end -->
