### PR TITLE
Symbolic Direct Transcription

### DIFF
--- a/drake/systems/trajectory_optimization/direct_transcription.cc
+++ b/drake/systems/trajectory_optimization/direct_transcription.cc
@@ -8,6 +8,7 @@
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/solvers/constraint.h"
+#include "drake/systems/framework/system_symbolic_inspector.h"
 
 namespace drake {
 namespace systems {
@@ -19,7 +20,6 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteTimeSystemConstraint)
 
- public:
   // @param evaluation_time  The time along the trajectory at which this
   // constraint is evaluated.
   DiscreteTimeSystemConstraint(const System<AutoDiffXd>& system,
@@ -39,7 +39,11 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
         num_inputs_(num_inputs),
         evaluation_time_(evaluation_time) {
     DRAKE_DEMAND(evaluation_time >= 0.0);
-    DRAKE_DEMAND(context->has_only_discrete_state());
+    DRAKE_DEMAND(context_->has_only_discrete_state());
+    DRAKE_DEMAND(context_ != nullptr);
+    DRAKE_DEMAND(discrete_state_ != nullptr);
+    DRAKE_DEMAND(context_->get_num_input_ports() == 0 ||
+                 input_port_value_ != nullptr);
 
     // Makes sure the autodiff vector is properly initialized.
     evaluation_time_.derivatives().resize(2 * num_states_ + num_inputs_);
@@ -98,11 +102,10 @@ DirectTranscription::DirectTranscription(const System<double>* system,
                        context.get_num_total_states(), num_time_samples,
                        0.1),  // TODO(russt): Replace this with the actual
                               // sample time of the discrete update (#6878).
-      system_(System<double>::ToAutoDiffXd(*system)),
-      context_(system_->CreateDefaultContext()),
-      discrete_state_(system_->AllocateDiscreteVariables()) {
+      discrete_time_system_(true) {
   // This is the constructor for discrete-time systems.  For continuous-time
-  // systems, you must use a different constructor that specifies the timesteps.
+  // systems, you must use a different constructor that specifies the
+  // timesteps.
   DRAKE_THROW_UNLESS(context.has_only_discrete_state());
 
   // TODO(russt): Check that the system has ONLY simple periodic updates
@@ -110,10 +113,108 @@ DirectTranscription::DirectTranscription(const System<double>* system,
 
   DRAKE_DEMAND(context.get_num_discrete_state_groups() == 1);
   DRAKE_DEMAND(num_states() == context.get_discrete_state(0)->size());
-  DRAKE_DEMAND(system_->get_num_input_ports() <= 1);
+  DRAKE_DEMAND(system->get_num_input_ports() <= 1);
   DRAKE_DEMAND(num_inputs() == (context.get_num_input_ports() > 0
-                                    ? system_->get_input_port(0).size()
+                                    ? system->get_input_port(0).size()
                                     : 0));
+
+  // First try symbolic dynamics.
+  if (!AddSymbolicDynamicConstraints(system, context)) {
+    AddAutodiffDynamicConstraints(system, context);
+  }
+
+  // Constrain the final input to match the penultimate, otherwise the final
+  // input is unconstrained.
+  // (Note that it might be more ideal to have less decision variables
+  // allocated
+  // for this specific case, but this is a reasonable work-around).
+  if (num_inputs() > 0) {
+    AddLinearConstraint(input(N() - 2) == input(N() - 1));
+  }
+}
+
+void DirectTranscription::DoAddRunningCost(const symbolic::Expression& g) {
+  DRAKE_DEMAND(discrete_time_system_);  // TODO(russt): implement
+                                        // continuous-time version.
+
+  // Cost = \sum_n g(n,x[n],u[n]) dt
+  for (int i = 0; i < N() - 1; i++) {
+    AddCost(SubstitutePlaceholderVariables(g * fixed_timestep(), i));
+  }
+}
+
+PiecewisePolynomialTrajectory DirectTranscription::ReconstructInputTrajectory()
+    const {
+  Eigen::VectorXd times = GetSampleTimes();
+  std::vector<double> times_vec(N());
+  std::vector<Eigen::MatrixXd> inputs(N());
+
+  for (int i = 0; i < N(); i++) {
+    times_vec[i] = times(i);
+    inputs[i] = GetSolution(input(i));
+  }
+  // TODO(russt): Implement DTTrajectories and return one of those instead.
+  return PiecewisePolynomialTrajectory(
+      PiecewisePolynomial<double>::ZeroOrderHold(times_vec, inputs));
+}
+
+PiecewisePolynomialTrajectory DirectTranscription::ReconstructStateTrajectory()
+    const {
+  Eigen::VectorXd times = GetSampleTimes();
+  std::vector<double> times_vec(N());
+  std::vector<Eigen::MatrixXd> states(N());
+
+  for (int i = 0; i < N(); i++) {
+    times_vec[i] = times(i);
+    states[i] = GetSolution(state(i));
+  }
+  // TODO(russt): Implement DTTrajectories and return one of those instead.
+  return PiecewisePolynomialTrajectory(
+      PiecewisePolynomial<double>::ZeroOrderHold(times_vec, states));
+}
+
+bool DirectTranscription::AddSymbolicDynamicConstraints(
+    const System<double>* system, const Context<double>& context) {
+  const auto symbolic_system = system->ToSymbolic();
+  if (!symbolic_system) {
+    return false;
+  }
+
+  const auto inspector =
+      std::make_unique<SystemSymbolicInspector>(*symbolic_system);
+  if (!inspector->HasAffineDynamics()) {
+    return false;
+  }
+
+  // TODO(russt): Substitute parameter values from Context<double>.
+  unused(context);
+
+  for (int i = 0; i < N() - 1; i++) {
+    VectorX<symbolic::Expression> update = inspector->discrete_update(0);
+    symbolic::Substitution sub;
+    sub.emplace(inspector->time(), i * fixed_timestep());
+    // TODO(russt/soonho): Can we make a cleaner way to do substitutions
+    // with Vectors to avoid these loops appearing everywhere? #6925
+    for (int j = 0; j < num_states(); j++) {
+      sub.emplace(inspector->discrete_state(0)[j], state(i)[j]);
+    }
+    for (int j = 0; j < num_inputs(); j++) {
+      sub.emplace(inspector->input(0)[j], input(i)[j]);
+    }
+    for (int j = 0; j < num_states(); j++) {
+      update(j) = update(j).Substitute(sub);
+    }
+    AddLinearConstraint(state(i + 1) == update);
+  }
+  return true;
+}
+
+void DirectTranscription::AddAutodiffDynamicConstraints(
+    const System<double>* system, const Context<double>& context) {
+  system_ = system->ToAutoDiffXd();
+  DRAKE_DEMAND(system_ != nullptr);
+  context_ = system_->CreateDefaultContext();
+  discrete_state_ = system_->AllocateDiscreteVariables();
 
   context_->SetTimeStateAndParametersFrom(context);
 
@@ -153,53 +254,6 @@ DirectTranscription::DirectTranscription(const System<double>* system,
 
     AddConstraint(constraint, {input(i), state(i), state(i + 1)});
   }
-
-  // Constrain the final input to match the penultimate, otherwise the final
-  // input is unconstrained.
-  // (Note that it might be more ideal to have less decision variables allocated
-  // for this specific case, but this is a reasonable work-around).
-  if (num_inputs() > 0) {
-    AddLinearConstraint(input(N() - 2) == input(N() - 1));
-  }
-}
-
-void DirectTranscription::DoAddRunningCost(const symbolic::Expression& g) {
-  if (context_->has_only_discrete_state()) {
-    // Cost = \sum_n g(n,x[n],u[n]) dt
-    for (int i = 0; i < N() - 1; i++) {
-      AddCost(SubstitutePlaceholderVariables(g * fixed_timestep(), i));
-    }
-  }
-}
-
-PiecewisePolynomialTrajectory DirectTranscription::ReconstructInputTrajectory()
-    const {
-  Eigen::VectorXd times = GetSampleTimes();
-  std::vector<double> times_vec(N());
-  std::vector<Eigen::MatrixXd> inputs(N());
-
-  for (int i = 0; i < N(); i++) {
-    times_vec[i] = times(i);
-    inputs[i] = GetSolution(input(i));
-  }
-  // TODO(russt): Implement DTTrajectories and return one of those instead.
-  return PiecewisePolynomialTrajectory(
-      PiecewisePolynomial<double>::ZeroOrderHold(times_vec, inputs));
-}
-
-PiecewisePolynomialTrajectory DirectTranscription::ReconstructStateTrajectory()
-    const {
-  Eigen::VectorXd times = GetSampleTimes();
-  std::vector<double> times_vec(N());
-  std::vector<Eigen::MatrixXd> states(N());
-
-  for (int i = 0; i < N(); i++) {
-    times_vec[i] = times(i);
-    states[i] = GetSolution(state(i));
-  }
-  // TODO(russt): Implement DTTrajectories and return one of those instead.
-  return PiecewisePolynomialTrajectory(
-      PiecewisePolynomial<double>::ZeroOrderHold(times_vec, states));
 }
 
 }  // namespace trajectory_optimization

--- a/drake/systems/trajectory_optimization/direct_transcription.h
+++ b/drake/systems/trajectory_optimization/direct_transcription.h
@@ -58,12 +58,28 @@ class DirectTranscription : public MultipleShooting {
   // Implements a running cost at all timesteps.
   void DoAddRunningCost(const symbolic::Expression& e) override;
 
-  // Create AutoDiff versions of the System components (for the constraints).
-  const std::unique_ptr<const System<AutoDiffXd>> system_;
-  const std::unique_ptr<Context<AutoDiffXd>> context_;
-  const std::unique_ptr<DiscreteValues<AutoDiffXd>> discrete_state_;
+  // Attempts to create a symbolic version of the plant, and to add linear
+  // constraints to impose the dynamics if possible.  Returns true iff the
+  // constraints are added.
+  bool AddSymbolicDynamicConstraints(const System<double>* system,
+                                     const Context<double>& context);
+
+  // Attempts to create an autodiff version of the plant, and to impose
+  // the generic (nonlinear) constraints to impose the dynamics.
+  // Aborts if the conversion ToAutoDiffXd fails.
+  void AddAutodiffDynamicConstraints(const System<double>* system,
+                                     const Context<double>& context);
+
+  // AutoDiff versions of the System components (for the constraints).
+  // These values are allocated iff the dynamic constraints are allocated
+  // as DiscreteTimeSystemConstraints, otherwise they are nullptr.
+  std::unique_ptr<const System<AutoDiffXd>> system_;
+  std::unique_ptr<Context<AutoDiffXd>> context_;
+  std::unique_ptr<DiscreteValues<AutoDiffXd>> discrete_state_;
   FreestandingInputPortValue* input_port_value_{
       nullptr};  // Owned by the context.
+
+  const bool discrete_time_system_{false};
 };
 
 }  // namespace trajectory_optimization


### PR DESCRIPTION
uses the symbolic inspector to check if a system is affine or not.  If yes, then it adds linear constraints to enforce the dynamics instead of the general nonlinear dynamic constraints.  the result:  if you pass in a system that is affine (or linear) that supports DoToSymbolic, add only quadratic costs and linear constraints, then dirtran ends up as a QP instead of an NLP. 

this makes me so happy inside.  ;-)

NB - this PR contains the two commits from #6887 which is about ready to go in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6921)
<!-- Reviewable:end -->
