### PR TITLE
Define maliput::api::TypedId<T> template, a strongly-typed identifier.

### DIFF
--- a/drake/automotive/maliput/api/BUILD
+++ b/drake/automotive/maliput/api/BUILD
@@ -22,6 +22,7 @@ drake_cc_library(
         "lane_data.h",
         "road_geometry.h",
         "segment.h",
+        "type_specific_identifier.h",
     ],
     deps = [
         "//drake/common",
@@ -32,7 +33,6 @@ drake_cc_library(
 # === test/ ===
 drake_cc_googletest(
     name = "lane_data_test",
-    srcs = ["test/lane_data_test.cc"],
     deps = [
         ":api",
         "//drake/common:eigen_matrix_compare",
@@ -41,7 +41,13 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "maliput_test",
-    srcs = ["test/maliput_test.cc"],
+    deps = [
+        ":api",
+    ],
+)
+
+drake_cc_googletest(
+    name = "type_specific_identifier_test",
     deps = [
         ":api",
     ],

--- a/drake/automotive/maliput/api/test/type_specific_identifier_test.cc
+++ b/drake/automotive/maliput/api/test/type_specific_identifier_test.cc
@@ -1,0 +1,124 @@
+#include "drake/automotive/maliput/api/type_specific_identifier.h"
+
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace {
+
+
+class C {};  // some random class
+
+using CId = TypeSpecificIdentifier<C>;  // ID type specific to class C
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, Construction) {
+  EXPECT_NO_THROW(CId("x"));
+  EXPECT_THROW(CId(""), std::runtime_error);
+}
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, IdentifiedType) {
+  ::testing::StaticAssertTypeEq<CId::identified_type, C>();
+}
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, Accessors) {
+  const CId dut("x");
+  EXPECT_EQ(dut.string(), "x");
+}
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, Equality) {
+  const CId dut_x1("x");
+  const CId dut_x2("x");
+  const CId dut_y("y");
+
+  EXPECT_TRUE(dut_x1 == dut_x2);
+  EXPECT_FALSE(dut_x1 != dut_x2);
+
+  EXPECT_FALSE(dut_x1 == dut_y);
+  EXPECT_TRUE(dut_x1 != dut_y);
+}
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, CopyingAndAssignment) {
+  const CId dut1("x");
+  const CId dut2(dut1);
+  CId dut3("y");
+  dut3 = dut1;
+
+  EXPECT_TRUE(dut1 == dut2);
+  EXPECT_TRUE(dut1 == dut3);
+}
+
+
+GTEST_TEST(TypeSpecificIdentifierTest, HashProhibitionExceptionCanary) {
+  // Since our specialization of std::hash is only allowed because we promised
+  // to call only std::hash<std::string>, attempt to catch a violation of
+  // that promise.
+  const std::string kSomeString("some string");
+  const CId dut(kSomeString);
+  EXPECT_EQ(std::hash<CId>()(dut), std::hash<std::string>()(kSomeString));
+}
+
+
+// Test usage with ordered/unordered sets.
+template <typename T>
+class TypeSpecificIdentifierSetTest : public ::testing::Test {};
+
+typedef ::testing::Types<std::set<CId>,
+                         std::unordered_set<CId>> SetTypes;
+
+TYPED_TEST_CASE(TypeSpecificIdentifierSetTest, SetTypes);
+
+TYPED_TEST(TypeSpecificIdentifierSetTest, SetTypes) {
+  TypeParam dut;
+
+  dut.insert(CId("a"));
+  dut.insert(CId("b"));
+  dut.insert(CId("c"));
+  // Insert a fresh, duplicate instance of "a".
+  dut.insert(CId("a"));
+
+  EXPECT_EQ(dut.size(), 3);
+  EXPECT_EQ(dut.count(CId("a")), 1);
+  EXPECT_EQ(dut.count(CId("b")), 1);
+  EXPECT_EQ(dut.count(CId("c")), 1);
+}
+
+
+// Test usage with ordered/unordered maps.
+template <typename T>
+class TypeSpecificIdentifierMapTest : public ::testing::Test {};
+
+typedef ::testing::Types<std::map<CId, int>,
+                         std::unordered_map<CId, int>> MapTypes;
+
+TYPED_TEST_CASE(TypeSpecificIdentifierMapTest, MapTypes);
+
+TYPED_TEST(TypeSpecificIdentifierMapTest, MapTypes) {
+  TypeParam dut;
+
+  dut[CId("a")] = 1;
+  dut[CId("b")] = 2;
+  dut[CId("c")] = 3;
+  // Insert a fresh, duplicate instance of "a".
+  dut[CId("a")] = 5;
+
+  EXPECT_EQ(dut.size(), 3);
+  EXPECT_EQ(dut[CId("a")], 5);
+  EXPECT_EQ(dut[CId("b")], 2);
+  EXPECT_EQ(dut[CId("c")], 3);
+}
+
+}  // namespace
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/api/type_specific_identifier.h
+++ b/drake/automotive/maliput/api/type_specific_identifier.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+/// %TypeSpecificIdentifier<T> represents an identifier specifically identifying
+/// an entity of type `T`.
+///
+/// A new %TypeSpecificIdentifier is constructed from a non-empty string;
+/// TypeSpecificIdentifiers constructed from equal strings are considered to
+/// be equal.  There is currently no other semantic value attributed to the
+/// contents of the string.
+///
+/// Construction from empty strings is not allowed; there is no notion of
+/// an "unassigned" value for a %TypeSpecificIdentifier.  To represent a
+/// possibly-unassigned %TypeSpecificIdentifier, use
+/// drake::optional<TypeSpecificIdentifier<T>>.
+///
+/// %TypeSpecificIdentifier is EqualityComparable (and provides == and !=
+/// operators), but it is not LessThanComparable; there is no particular
+/// ordering ascribed to %TypeSpecificIdentifier instances.  However,
+/// %TypeSpecificIdentifier does provide a strict weak ordering via a
+/// specialization of std::less for use in ordered containers such as std::set
+/// and std::map.  This ordering may change in future implementations of
+/// %TypeSpecificIdentifier.
+///
+/// %TypeSpecificIdentifier also provides a specialization of std::hash to make
+/// it easy to use with std::unordered_set and std::unordered_map.
+template <typename T>
+class TypeSpecificIdentifier {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(TypeSpecificIdentifier);
+
+  /// The type whose instances are identified by this TypeSpecificIdentifier.
+  typedef T identified_type;
+
+  /// Constructs a %TypeSpecificIdentifier from the given `string`.
+  ///
+  /// @throws std::runtime_error if `string` is empty.
+  explicit TypeSpecificIdentifier(std::string string)
+      : string_(std::move(string)) {
+    DRAKE_THROW_UNLESS(!string_.empty());
+  }
+
+  /// Returns the string representation of the %TypeSpecificIdentifier.
+  const std::string& string() const { return string_; }
+
+  /// Tests for equality with another %TypeSpecificIdentifier.
+  bool operator==(const TypeSpecificIdentifier<T>& rhs) const {
+    return string_ == rhs.string_;
+  }
+
+  /// Tests for inequality with another %TypeSpecificIdentifier, specifically
+  /// returning the opposite of operator==().
+  bool operator!=(const TypeSpecificIdentifier<T>& rhs) const {
+    return !(*this == rhs);
+  }
+
+ private:
+  std::string string_;
+};
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake
+
+
+namespace std {
+
+/// Specialization of std::hash for TypeSpecificIdentifier<T>
+template <typename T>
+struct hash<drake::maliput::api::TypeSpecificIdentifier<T>> {
+  typedef std::size_t result_type;
+  typedef drake::maliput::api::TypeSpecificIdentifier<T> argument_type;
+
+  result_type operator()(const argument_type& id) const {
+    // NB: Per the GSG, our current style guide strictly prohibits
+    // creating new specializations of std::hash on the grounds that
+    // it is in general difficult to do that correctly.  However,
+    // since this implementation is merely a wrapper around
+    // std::string with stricter type checking and since it merely
+    // invokes a C++ standard hash approved by the style guide, it has
+    // been granted an exception.  If this implementation changes, the
+    // exception must be reevaluated.  Conversely, if the (arguably
+    // maladaptive) prohibition is removed from our style guide, this
+    // notice can go away.
+    return hash<string>{}(id.string());
+  }
+};
+
+/// Specialization of std::less for TypeSpecificIdentifier<T> providing a
+/// strict weak ordering over TypeSpecificIdentifier<T> suitable for use with
+/// ordered containers.
+template <typename T>
+struct less<drake::maliput::api::TypeSpecificIdentifier<T>> {
+  typedef std::size_t result_type;
+  typedef drake::maliput::api::TypeSpecificIdentifier<T> first_argument_type;
+  typedef drake::maliput::api::TypeSpecificIdentifier<T> second_argument_type;
+
+  result_type operator()(const first_argument_type& lhs,
+                         const second_argument_type& rhs) const {
+    return lhs.string() < rhs.string();
+  }
+};
+
+}  // namespace std


### PR DESCRIPTION
TypedId<T> will become the basis for better-defined class-specific
identifiers for maliput.  I.e., in an upcoming PR, LaneId will be
redefined as TypedId<Lane>.

TypedId<T> provides equality operators as well as support for use
as a key in ordered/unordered sets and maps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6930)
<!-- Reviewable:end -->
