### PR TITLE
Fix AffineSystem's output in the discrete-time case

### DIFF
--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -71,9 +71,10 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
   if (num_states_ > 0) {
     const MatrixX<T> Ct = C(t);
     DRAKE_DEMAND(Ct.rows() == num_outputs_ && Ct.cols() == num_states_);
-    const auto& x = dynamic_cast<const BasicVector<T>&>(
-                        context.get_continuous_state_vector())
-                        .get_value();
+    const VectorX<T>& x = (this->time_period() == 0.)
+        ? dynamic_cast<const BasicVector<T>&>(
+            context.get_continuous_state_vector()).get_value()
+        : context.get_discrete_state()->get_vector()->get_value();
     y += Ct * x;
   }
 
@@ -230,9 +231,10 @@ AffineSystem<symbolic::Expression>* AffineSystem<T>::DoToSymbolic() const {
 template <typename T>
 void AffineSystem<T>::CalcOutputY(const Context<T>& context,
                                   BasicVector<T>* output_vector) const {
-  const auto& x =
-      dynamic_cast<const BasicVector<T>&>(context.get_continuous_state_vector())
-          .get_value();
+  const VectorX<T>& x = (this->time_period() == 0.)
+      ? dynamic_cast<const BasicVector<T>&>(
+          context.get_continuous_state_vector()).get_value()
+      : context.get_discrete_state()->get_vector()->get_value();
 
   auto y = output_vector->get_mutable_value();
   y = C_ * x + y0_;


### PR DESCRIPTION
The respective output calculators `CalcOutputY()` for AffineSystem and TimeVaryingAffineSystem always draw from the continuous state vector, regardless of whether they are constructed as purely continuous-time or purely discrete-time systems. This PR fixes the behavior in the discrete-time case and adds unit test coverage.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6931)
<!-- Reviewable:end -->
