### PR TITLE
Use correct versions of expat and zlib on Mac

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -394,6 +394,12 @@ vtk_repository(
     name = "vtk",
 )
 
+load("//tools:expat.bzl", "expat_repository")
+
+expat_repository(
+    name = "expat",
+)
+
 pkg_config_package(
     name = "libpng",
     modname = "libpng",
@@ -404,9 +410,10 @@ pkg_config_package(
     modname = "tinyxml",
 )
 
-pkg_config_package(
+load("//tools:zlib.bzl", "zlib_repository")
+
+zlib_repository(
     name = "zlib",
-    modname = "zlib",
 )
 
 load("//tools:drake_visualizer.bzl", "drake_visualizer_repository")

--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -39,7 +39,6 @@ python
 scipy
 tinyxml
 vtk@8.0
-zlib
 EOF
 )
 

--- a/setup/ubuntu/14.04/install_prereqs.sh
+++ b/setup/ubuntu/14.04/install_prereqs.sh
@@ -46,7 +46,7 @@ gfortran-4.9-multilib
 git
 graphviz
 libboost-dev
-libexpat1
+libexpat1-dev
 libfreetype6
 libglib2.0-dev
 libglu1-mesa-dev

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -78,7 +78,7 @@ gfortran-5-multilib
 git
 graphviz
 libboost-dev
-libexpat1
+libexpat1-dev
 libfreetype6
 libglib2.0-dev
 libglu1-mesa-dev

--- a/tools/expat.bzl
+++ b/tools/expat.bzl
@@ -1,0 +1,73 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+"""
+Makes a system-installed Expat XML parser headers and library available to be
+used as a C/C++ dependency. On Ubuntu Trusty and Xenial, pkg-config is used to
+locate the Expat headers and library. On macOS and OS X, no pkg-config expat.pc
+file is installed, but the Expat headers and library are always located in
+/usr/include and /usr/lib, respectively.
+
+Example:
+    WORKSPACE:
+        load("//tools:expat.bzl", "expat_repository")
+        expat_repository(name = "foo")
+
+    BUILD:
+        cc_library(
+            name = "foobar",
+            deps = ["@foo//:expat"],
+            srcs = ["bar.cc"],
+        )
+
+Argument:
+    name: A unique name for this rule.
+"""
+
+load(
+    "@kythe//tools/build_rules/config:pkg_config.bzl",
+    "setup_pkg_config_package",
+)
+
+def _impl(repository_ctx):
+    if repository_ctx.os.name == "mac os x":
+        repository_ctx.file("empty.cc", executable = False)
+
+        repository_ctx.symlink("/usr/include/expat.h", "include/expat.h")
+        repository_ctx.symlink("/usr/include/expat_external.h",
+                               "include/expat_external.h")
+
+        file_content = """
+cc_library(
+    name = "expat",
+    srcs = ["empty.cc"],
+    hdrs = [
+        "include/expat_external.h",
+        "include/expat.h",
+    ],
+    includes = ["include"],
+    linkopts = ["-lexpat"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+        repository_ctx.file("BUILD", content = file_content,
+                            executable = False)
+    else:
+        error = setup_pkg_config_package(repository_ctx).error
+
+        if error != None:
+            fail(error)
+
+expat_repository = repository_rule(
+    attrs = {
+        "modname": attr.string(default = "expat"),
+        "build_file_template": attr.label(
+            default = Label("@kythe//tools/build_rules/config:BUILD.tpl"),
+            single_file = True,
+            allow_files = True,
+        ),
+    },
+    local = True,
+    implementation = _impl,
+)

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -386,9 +386,9 @@ def _impl(repository_ctx):
         deps = [
             ":vtkCommonCore",
             ":vtkCommonDataModel",
-            ":vtkexpat",
             ":vtkIOCore",
             ":vtksys",
+            "@expat",
         ],
     )
 
@@ -520,17 +520,6 @@ def _impl(repository_ctx):
             ":vtkRenderingCore",
             ":vtkglew",
         ],
-    )
-
-    # The packaged version of VTK (both Ubuntu and Mac) uses the system version
-    # of expat, and do not include `vtkexpat` as a shared library.
-    file_content += _vtk_cc_library(
-        repository_ctx.os.name,
-        "vtkexpat",
-        linkopts = [
-            "-lexpat",
-        ],
-        header_only = True,
     )
 
     if repository_ctx.os.name == "mac os x":

--- a/tools/zlib.bzl
+++ b/tools/zlib.bzl
@@ -1,0 +1,72 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+"""
+Makes a system-installed zlib image compression library headers and library
+available to be used as a C/C++ dependency. On Ubuntu Trusty and Xenial,
+pkg-config is used to locate the zlib headers and library. On macOS and OS X,
+no pkg-config zlib.pc file is installed, but the zlib headers and library are
+always located in /usr/include and /usr/lib, respectively.
+
+Example:
+    WORKSPACE:
+        load("//tools:zlib.bzl", "zlib_repository")
+        zlib_repository(name = "foo")
+
+    BUILD:
+        cc_library(
+            name = "foobar",
+            deps = ["@foo//:zlib"],
+            srcs = ["bar.cc"],
+        )
+
+Argument:
+    name: A unique name for this rule.
+"""
+
+load(
+    "@kythe//tools/build_rules/config:pkg_config.bzl",
+    "setup_pkg_config_package",
+)
+
+def _impl(repository_ctx):
+    if repository_ctx.os.name == "mac os x":
+        repository_ctx.file("empty.cc", executable = False)
+
+        repository_ctx.symlink("/usr/include/zlib.h", "include/zlib.h")
+        repository_ctx.symlink("/usr/include/zconf.h", "include/zconf.h")
+
+        file_content = """
+cc_library(
+    name = "zlib",
+    srcs = ["empty.cc"],
+    hdrs = [
+      "include/zconf.h",
+      "include/zlib.h",
+    ],
+    includes = ["include"],
+    linkopts = ["-lz"],
+    visibility = ["//visibility:public"],
+)
+"""
+
+        repository_ctx.file("BUILD", content = file_content,
+                            executable = False)
+    else:
+        error = setup_pkg_config_package(repository_ctx).error
+
+        if error != None:
+            fail(error)
+
+zlib_repository = repository_rule(
+    attrs = {
+        "modname": attr.string(default = "zlib"),
+        "build_file_template": attr.label(
+            default = Label("@kythe//tools/build_rules/config:BUILD.tpl"),
+            single_file = True,
+            allow_files = True,
+        ),
+    },
+    local = True,
+    implementation = _impl,
+)


### PR DESCRIPTION
Split from #6903.

Fixes an issue where we were using two different versions of zlib on macOS (though they were ABI-compatible) and avoids the possibility of the same happening with expat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6933)
<!-- Reviewable:end -->
