### PR TITLE
 	fixed case sensitivity issue for docker installation

### DIFF
--- a/setup/docker/Dockerfile.ubuntu16.04.nvidia
+++ b/setup/docker/Dockerfile.ubuntu16.04.nvidia
@@ -5,5 +5,5 @@ RUN apt-get update && yes "Y" \
       | /drake-distro/setup/ubuntu/16.04/install_prereqs.sh \
       && rm -rf /var/lib/apt/lists/* \
       && apt-get clean all
-RUN cd /drake-distro && bazel build //tools:drake_visualizer && bazel build //drake/examples/Acrobot:acrobot_run_passive
+RUN cd /drake-distro && bazel build //tools:drake_visualizer && bazel build //drake/examples/acrobot:acrobot_run_passive
 ENTRYPOINT ["/drake-distro/setup/docker/entrypoint.sh"]

--- a/setup/docker/Dockerfile.ubuntu16.04.opensource
+++ b/setup/docker/Dockerfile.ubuntu16.04.opensource
@@ -5,5 +5,5 @@ RUN apt-get update && yes "Y" \
       | /drake-distro/setup/ubuntu/16.04/install_prereqs.sh \
       && rm -rf /var/lib/apt/lists/* \
       && apt-get clean all
-RUN cd /drake-distro && bazel build //tools:drake_visualizer && bazel build //drake/examples/Acrobot:acrobot_run_passive
+RUN cd /drake-distro && bazel build //tools:drake_visualizer && bazel build //drake/examples/acrobot:acrobot_run_passive
 ENTRYPOINT ["/drake-distro/setup/docker/entrypoint.sh"]

--- a/setup/docker/entrypoint.sh
+++ b/setup/docker/entrypoint.sh
@@ -9,7 +9,7 @@ set -e -u
   bazel build //tools:drake_visualizer
   ./bazel-bin/tools/drake_visualizer&
   sleep 2
-  bazel run //drake/examples/Acrobot:acrobot_run_passive
+  bazel run //drake/examples/acrobot:acrobot_run_passive
 } || {
   eval "$@"
 }


### PR DESCRIPTION
I couldn't create a Docker image because Acrobat was referenced with an uppercase A instead of a lowercase like in the directory "acrobat". Now the image is created successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6941)
<!-- Reviewable:end -->
