### PR TITLE
Ensures that "primal" variables in LCP problem are sized correctly and set to zero on failure to solve LCP.

### DIFF
--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -368,7 +368,7 @@ bool MobyLCPSolver<T>::SolveLcpFast(const MatrixX<T>& M,
         << std::endl;
 
   // if we're here, then the maximum number of pivots has been exceeded
-  z->setZero(N);  
+  z->setZero(N);
   return false;
 }
 

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -368,6 +368,7 @@ bool MobyLCPSolver<T>::SolveLcpFast(const MatrixX<T>& M,
         << std::endl;
 
   // if we're here, then the maximum number of pivots has been exceeded
+  z->setZero(N);  
   return false;
 }
 
@@ -785,6 +786,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
       Log() << "MobyLCPSolver::SolveLcpLemke() exiting" << std::endl;
+      z->setZero(n);
       return false;
     }
 
@@ -839,6 +841,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
     if (j_.empty()) {
       Log() << "zero tolerance too low?" << std::endl;
       Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      z->setZero(n);
       return false;
     }
 
@@ -878,6 +881,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
   Log() << " -- maximum number of iterations exceeded (n=" << n
         << ", max=" << max_iter << ")" << std::endl;
   Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+  z->setZero(n);
   return false;
 }
 
@@ -1203,8 +1207,10 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
     // We go ahead and return failure here as the basis matrix has become
     // singular due to too many pivoting operations; without this change,
     // failure would presumably occur (eventually).
-    if (solver->info() != Eigen::ComputationInfo::Success)
+    if (solver->info() != Eigen::ComputationInfo::Success) {
+      z->setZero(n);
       return false;
+    }
     dl = solver->solve(Be);
 
     // use a new pivot tolerance if necessary
@@ -1225,6 +1231,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
           << "MobyLCPSolver::SolveLcpLemke() - no new pivots (ray termination)"
           << std::endl;
       Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      z->setZero(n);
       return false;
     }
 
@@ -1259,6 +1266,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
     if (j_.empty()) {
       Log() << "zero tolerance too low?" << std::endl;
       Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+      z->setZero(n);
       return false;
     }
 
@@ -1297,6 +1305,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
 
   Log() << " -- maximum number of iterations exceeded" << std::endl;
   Log() << "MobyLCPSolver::SolveLcpLemke() exited" << std::endl;
+  z->setZero(n);
   return false;
 }
 

--- a/drake/solvers/moby_lcp_solver.h
+++ b/drake/solvers/moby_lcp_solver.h
@@ -108,7 +108,8 @@ class MobyLCPSolver : public MathematicalProgramSolverInterface {
   /// @param[in,out] z the solution to the LCP on return (if the solver
   ///                succeeds). If the length of z is equal to the length of q,
   ///                the solver will attempt to use z's value as a starting
-  ///                solution.
+  ///                solution. If the solver fails (returns `false`), `z` will
+  ///                be set to the zero vector.
   /// @param[in] zero_tol The tolerance for testing against zero. If the
   ///            tolerance is negative (default) the solver will determine a
   ///            generally reasonable tolerance.
@@ -202,7 +203,8 @@ class MobyLCPSolver : public MathematicalProgramSolverInterface {
   ///                the solver will attempt to use z's value as a starting
   ///                solution. **This warmstarting is generally not
   ///                recommended**: it has a predisposition to lead to a failing
-  ///                pivoting sequence.
+  ///                pivoting sequence. If the solver fails (returns `false`),
+  ///                `z` will be set to the zero vector.
   /// @param[in] zero_tol The tolerance for testing against zero. If the
   ///            tolerance is negative (default) the solver will determine a
   ///            generally reasonable tolerance.

--- a/drake/solvers/test/moby_lcp_solver_test.cc
+++ b/drake/solvers/test/moby_lcp_solver_test.cc
@@ -425,6 +425,42 @@ GTEST_TEST(testMobyLCP, ThrowsOnNaN) {
   EXPECT_LE(lcp.get_num_pivots(), 1);
 }
 
+// Verifies that z is zero on LCP solver failure.
+GTEST_TEST(testMobyLCP, testFailure) {
+  Eigen::MatrixXd neg_M(1, 1);
+  Eigen::VectorXd neg_q(1);
+
+  // This LCP is unsolvable: -z - 1 cannot be greater than zero when z is
+  // restricted to be non-negative.
+  neg_M(0, 0) = -1;
+  neg_q[0] = -1;
+  Eigen::VectorXd z;
+  MobyLCPSolver<double> l;
+  l.SetLoggingEnabled(verbose);
+
+  bool result = l.SolveLcpFast(neg_M, neg_q, &z);
+  EXPECT_FALSE(result);
+  ASSERT_EQ(z.size(), neg_q.size());
+  EXPECT_EQ(z[0], 0.0);
+
+  result = l.SolveLcpLemke(neg_M, neg_q, &z);
+  EXPECT_FALSE(result);
+  ASSERT_EQ(z.size(), neg_q.size());
+  EXPECT_EQ(z[0], 0.0);
+
+  Eigen::SparseMatrix<double> neg_sparse_M(1, 1);
+  neg_sparse_M.setIdentity();
+  neg_sparse_M *= -1;
+  result = l.SolveLcpLemke(neg_sparse_M, neg_q, &z);
+  EXPECT_FALSE(result);
+  ASSERT_EQ(z.size(), neg_q.size());
+  EXPECT_EQ(z[0], 0.0);
+
+  // Note: we do not test regularized solvers here, as we're specifically
+  // interested in algorithm failure and the regularized solvers are designed
+  // not to fail.
+}
+
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/test/moby_lcp_solver_test.cc
+++ b/drake/solvers/test/moby_lcp_solver_test.cc
@@ -442,11 +442,14 @@ GTEST_TEST(testMobyLCP, testFailure) {
   EXPECT_FALSE(result);
   ASSERT_EQ(z.size(), neg_q.size());
   EXPECT_EQ(z[0], 0.0);
+  LinearComplementarityConstraint constraint(neg_M, neg_q);
+  EXPECT_FALSE(constraint.CheckSatisfied(z));
 
   result = l.SolveLcpLemke(neg_M, neg_q, &z);
   EXPECT_FALSE(result);
   ASSERT_EQ(z.size(), neg_q.size());
   EXPECT_EQ(z[0], 0.0);
+  EXPECT_FALSE(constraint.CheckSatisfied(z));
 
   Eigen::SparseMatrix<double> neg_sparse_M(1, 1);
   neg_sparse_M.setIdentity();
@@ -455,6 +458,7 @@ GTEST_TEST(testMobyLCP, testFailure) {
   EXPECT_FALSE(result);
   ASSERT_EQ(z.size(), neg_q.size());
   EXPECT_EQ(z[0], 0.0);
+  EXPECT_FALSE(constraint.CheckSatisfied(z));
 
   // Note: we do not test regularized solvers here, as we're specifically
   // interested in algorithm failure and the regularized solvers are designed


### PR DESCRIPTION
For the LCP (q,M), meaning that we seek z and w such that Mz + q = w, z >= 0, w >= 0, z'w = 0, it is desired that the z vector be set to the correct size (that of q) on LCP solver failure. By doing so, we are able to compute w regardless of whether or not the solver succeeded. In other words, we are able to do this:

bool result = SolveLcpLemke(M, q, &z);
w = M*z + q;
DRAKE_DEMAND(!result || w.minCoeff() < -eps || z.minCoeff() < -eps || abs(z.dot(w)) > eps));

The code currently in master does not guarantee that z is the correct size on returning failure (the Lemke algorithm, in particular, resizes z from dimension n to dimension 2n on entry).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6947)
<!-- Reviewable:end -->
