### PR TITLE
Change ToAutoDiff and ToSymbolic to throw when unsupported

### DIFF
--- a/drake/automotive/test/trajectory_car_test.cc
+++ b/drake/automotive/test/trajectory_car_test.cc
@@ -272,7 +272,7 @@ GTEST_TEST(TrajectoryCarTest, ToSymbolic) {
   const TrajectoryCar<double> dut{curve};
 
   // We do not support symbolic form.
-  EXPECT_EQ(dut.ToSymbolic(), nullptr);
+  EXPECT_EQ(dut.ToSymbolicMaybe(), nullptr);
 }
 
 }  // namespace

--- a/drake/examples/pendulum/test/pendulum_plant_test.cc
+++ b/drake/examples/pendulum/test/pendulum_plant_test.cc
@@ -20,7 +20,7 @@ GTEST_TEST(PendulumPlantTest, ToAutoDiff) {
 
   // Transmogrify the plant to autodiff.
   std::unique_ptr<PendulumPlant<AutoDiffXd>> ad_plant =
-      systems::System<double>::ToAutoDiffXd<PendulumPlant>(plant);
+      systems::System<double>::ToAutoDiffXd(plant);
   ASSERT_NE(nullptr, ad_plant);
 
   // Construct a new context based on autodiff.

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -495,6 +495,7 @@ drake_cc_googletest(
         "//drake/systems/analysis:stateless_system",
         "//drake/systems/framework/test_utilities:pack_value",
         "//drake/systems/primitives:adder",
+        "//drake/systems/primitives:constant_value_source",
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:gain",
         "//drake/systems/primitives:integrator",

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -1292,7 +1292,7 @@ class LeafSystem : public System<T> {
   // symbolic representation.
   std::unique_ptr<SystemSymbolicInspector> MakeSystemSymbolicInspector() const {
     std::unique_ptr<System<symbolic::Expression>> symbolic_system =
-        this->ToSymbolic();
+        this->ToSymbolicMaybe();
     if (symbolic_system) {
       return std::make_unique<SystemSymbolicInspector>(*symbolic_system);
     } else {

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -983,42 +983,58 @@ class System {
   //@{
 
   /// Creates a deep copy of this System, transmogrified to use the autodiff
-  /// scalar type, with a dynamic-sized vector of partial derivatives.
-  /// Concrete Systems may shadow this with a more specific return type.
+  /// scalar type, with a dynamic-sized vector of partial derivatives.  The
+  /// result is never nullptr.
+  /// @throw exception if this System does not support autodiff
   std::unique_ptr<System<AutoDiffXd>> ToAutoDiffXd() const {
-    System<AutoDiffXd>* sys = DoToAutoDiffXd();
-    if (sys != nullptr) {
-      sys->set_name(this->get_name());
-    }
-    return std::unique_ptr<System<AutoDiffXd>>(sys);
+    return System<T>::ToAutoDiffXd(*this);
   }
 
-  /// Creates a deep copy of `from`, transmogrified to use the autodiff
-  /// scalar type, with a dynamic-sized vector of partial derivatives. Returns
-  /// `nullptr` if the template parameter `S` is not the type of the concrete
-  /// system, or a superclass thereof.
+  /// Creates a deep copy of `from`, transmogrified to use the autodiff scalar
+  /// type, with a dynamic-sized vector of partial derivatives.  The result is
+  /// never nullptr.
+  /// @throw exception if `from` does not support autodiff
   ///
   /// Usage: @code
   ///   MySystem<double> plant;
   ///   std::unique_ptr<MySystem<AutoDiffXd>> ad_plant =
-  ///       systems::System<double>::ToAutoDiffXd<MySystem>(plant);
+  ///       systems::System<double>::ToAutoDiffXd(plant);
   /// @endcode
   ///
-  /// @tparam S The specific System pointer type to return.
+  /// @tparam S The specific System type to accept and return.
   template <template <typename> class S = ::drake::systems::System>
-  static std::unique_ptr<S<AutoDiffXd>> ToAutoDiffXd(
-      const System<double>& from) {
-    // Capture the copy as System<AutoDiffXd>.
-    std::unique_ptr<System<AutoDiffXd>> clone(from.DoToAutoDiffXd());
-    // Attempt to downcast to S<AutoDiffXd>.
-    S<AutoDiffXd>* downcast = dynamic_cast<S<AutoDiffXd>*>(clone.get());
-    // If the downcast fails, return nullptr, letting the copy be deleted.
-    if (downcast == nullptr) {
-      return nullptr;
+  static std::unique_ptr<S<AutoDiffXd>> ToAutoDiffXd(const S<T>& from) {
+    using U = AutoDiffXd;
+    const System<T>& from_system = from;  // Upcast to unlock protected methods.
+    std::unique_ptr<System<U>> base_result{from_system.DoToAutoDiffXd()};
+    if (!base_result) {
+      std::stringstream ss;
+      ss << "The object named [" << from.get_name() << "] of type"
+         << NiceTypeName::Get(from) << " does not support ToAutoDiffXd.";
+      throw std::logic_error(ss.str().c_str());
     }
-    // If the downcast succeeds, redo it, taking ownership this time.
-    return std::unique_ptr<S<AutoDiffXd>>(
-        dynamic_cast<S<AutoDiffXd>*>(clone.release()));
+
+    // Downcast to the derived type S (throwing on error), and then transfer
+    // ownership to a correctly-typed unique_ptr.
+    // NOLINTNEXTLINE(runtime/casting)
+    std::unique_ptr<S<U>> result{&dynamic_cast<S<U>&>(*base_result)};
+    base_result.release();
+
+    // Match the result's name to its originator.
+    result->set_name(from.get_name());
+    return result;
+  }
+
+  /// Creates a deep copy of this system exactly like ToAutoDiffXd(), but
+  /// returns nullptr if this System does not support autodiff, instead of
+  /// throwing an exception.
+  std::unique_ptr<System<AutoDiffXd>> ToAutoDiffXdMaybe() const {
+    std::unique_ptr<System<AutoDiffXd>> result{DoToAutoDiffXd()};
+    if (result) {
+      // Match the result's name to its originator.
+      result->set_name(this->get_name());
+    }
+    return result;
   }
   //@}
 
@@ -1032,44 +1048,56 @@ class System {
   //@{
 
   /// Creates a deep copy of this System, transmogrified to use the symbolic
-  /// scalar type. Returns `nullptr` if DoToSymbolic has not been implemented.
-  ///
-  /// Concrete Systems may shadow this with a more specific return type.
+  /// scalar type. The result is never nullptr.
+  /// @throw exception if this System does not support symbolic
   std::unique_ptr<System<symbolic::Expression>> ToSymbolic() const {
-    System<symbolic::Expression>* sys = DoToSymbolic();
-    if (sys != nullptr) {
-      sys->set_name(this->get_name());
-    }
-    return std::unique_ptr<System<symbolic::Expression>>(sys);
+    return System<T>::ToSymbolic(*this);
   }
 
-  /// Creates a deep copy of `from`, transmogrified to use the symbolic
-  /// scalar type. Returns `nullptr` if the template parameter `S` is not the
-  /// type of the concrete system, or a superclass thereof. Returns `nullptr`
-  /// if DoToSymbolic has not been implemented.
+  /// Creates a deep copy of `from`, transmogrified to use the symbolic scalar
+  /// type. The result is never nullptr.
+  /// @throw exception if this System does not support symbolic
   ///
   /// Usage: @code
   ///   MySystem<double> plant;
-  ///   std::unique_ptr<MySystem<symbolic::Expression>> ad_plant =
-  ///       systems::System<double>::ToSymbolic<MySystem>(plant);
+  ///   std::unique_ptr<MySystem<symbolic::Expression>> sym_plant =
+  ///       systems::System<double>::ToSymbolic(plant);
   /// @endcode
   ///
   /// @tparam S The specific System pointer type to return.
   template <template <typename> class S = ::drake::systems::System>
-  static std::unique_ptr<S<symbolic::Expression>> ToSymbolic(
-      const System<double>& from) {
-    // Capture the copy as System<symbolic::Expression>.
-    std::unique_ptr<System<symbolic::Expression>> clone(from.DoToSymbolic());
-    // Attempt to downcast to S<symbolic::Expression>.
-    S<symbolic::Expression>* downcast =
-        dynamic_cast<S<symbolic::Expression>*>(clone.get());
-    // If the downcast fails, return nullptr, letting the copy be deleted.
-    if (downcast == nullptr) {
-      return nullptr;
+  static std::unique_ptr<S<symbolic::Expression>> ToSymbolic(const S<T>& from) {
+    using U = symbolic::Expression;
+    const System<T>& from_system = from;  // Upcast to unlock protected methods.
+    std::unique_ptr<System<U>> base_result{from_system.DoToSymbolic()};
+    if (!base_result) {
+      std::stringstream ss;
+      ss << "The object named [" << from.get_name() << "] of type"
+         << NiceTypeName::Get(from) << " does not support ToSymbolic.";
+      throw std::logic_error(ss.str().c_str());
     }
-    // If the downcast succeeds, redo it, taking ownership this time.
-    return std::unique_ptr<S<symbolic::Expression>>(
-        dynamic_cast<S<symbolic::Expression>*>(clone.release()));
+
+    // Downcast to the derived type S (throwing on error), and then transfer
+    // ownership to a correctly-typed unique_ptr.
+    // NOLINTNEXTLINE(runtime/casting)
+    std::unique_ptr<S<U>> result{&dynamic_cast<S<U>&>(*base_result)};
+    base_result.release();
+
+    // Match the result's name to its originator.
+    result->set_name(from.get_name());
+    return result;
+  }
+
+  /// Creates a deep copy of this system exactly like ToSymbolic(), but returns
+  /// nullptr if this System does not support symbolic, instead of throwing an
+  /// exception.
+  std::unique_ptr<System<symbolic::Expression>> ToSymbolicMaybe() const {
+    std::unique_ptr<System<symbolic::Expression>> result{DoToSymbolic()};
+    if (result) {
+      // Match the result's name to its originator.
+      result->set_name(this->get_name());
+    }
+    return result;
   }
   //@}
 
@@ -1483,34 +1511,14 @@ class System {
     qdot->SetFromVector(generalized_velocity);
   }
 
-  /// NVI implementation of ToAutoDiffXd. Caller takes ownership of the returned
-  /// pointer. Overrides should return a more specific covariant type.
-  /// Templated overrides may assume that they are subclasses of System<double>.
-  ///
-  /// No default implementation is provided in LeafSystem, since the member data
-  /// of a particular concrete leaf system is not knowable to the framework.
-  /// A default implementation is provided in Diagram, which Diagram subclasses
-  /// with member data should override.
-  virtual System<AutoDiffXd>* DoToAutoDiffXd() const {
-    std::stringstream ss;
-    ss << "Override DoToAutoDiffXd for object named [" << this->get_name()
-       << "] of type " << NiceTypeName::Get(*this)
-       << " before using ToAutoDiffXd.";
-    DRAKE_ABORT_MSG(ss.str().c_str());
-    return nullptr;
-  }
+  /// NVI implementation of ToAutoDiffXdMaybe. Caller takes ownership of the
+  /// returned pointer.
+  /// @return nullptr if this System does not support autodiff
+  virtual System<AutoDiffXd>* DoToAutoDiffXd() const { return nullptr; }
 
-  /// NVI implementation of ToSymbolic. Caller takes ownership of the returned
-  /// pointer. Overrides should return a more specific covariant type.
-  /// Templated overrides may assume that they are subclasses of System<double>.
-  ///
-  /// Returns `nullptr` by default.  Direct-feedthrough detection relies on
-  /// this behavior.
-  ///
-  /// No default implementation is provided in LeafSystem, since the member data
-  /// of a particular concrete leaf system is not knowable to the framework.
-  /// A default implementation is provided in Diagram, which Diagram subclasses
-  /// with member data should override.
+  /// NVI implementation of ToSymbolicMaybe. Caller takes ownership of the
+  /// returned pointer.
+  /// @return nullptr if this System does not support symbolic form
   virtual System<symbolic::Expression>* DoToSymbolic() const { return nullptr; }
   //@}
 

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -1063,16 +1063,76 @@ GTEST_TEST(FeedthroughTest, SymbolicSparsity) {
   EXPECT_EQ(feedthrough_pairs, expected);
 }
 
-// Sanity check the default implementation of ToAutoDiffXd.
-GTEST_TEST(AutoDiffTest, ScalarConverter) {
+// Sanity check the default implementation of ToAutoDiffXd, for cases that
+// should succeed.
+GTEST_TEST(LeafSystemScalarConverterTest, AutoDiffYes) {
   SymbolicSparsitySystem<double> dut;
+  dut.set_name("special_name");
 
-  // Convert to AutoDiffXd.
-  std::unique_ptr<System<AutoDiffXd>> autodiff = dut.ToAutoDiffXd();
-  ASSERT_NE(autodiff, nullptr);
-  const auto* const downcast =
-      dynamic_cast<SymbolicSparsitySystem<AutoDiffXd>*>(autodiff.get());
-  ASSERT_NE(downcast, nullptr);
+  // Static method automatically downcasts.
+  std::unique_ptr<SymbolicSparsitySystem<AutoDiffXd>> clone =
+      System<double>::ToAutoDiffXd(dut);
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->get_name(), "special_name");
+
+  // Instance method that reports failures via exception.
+  EXPECT_NE(dut.ToAutoDiffXd(), nullptr);
+
+  // Instance method that reports failures via nullptr.
+  auto maybe = dut.ToAutoDiffXdMaybe();
+  ASSERT_NE(maybe, nullptr);
+  EXPECT_EQ(maybe->get_name(), "special_name");
+}
+
+// Sanity check the default implementation of ToAutoDiffXd, for cases that
+// should fail.
+GTEST_TEST(LeafSystemScalarConverterTest, AutoDiffNo) {
+  TestSystem<double> dut;
+
+  // Static method.
+  EXPECT_THROW(System<double>::ToAutoDiffXd(dut), std::exception);
+
+  // Instance method that reports failures via exception.
+  EXPECT_THROW(dut.ToAutoDiffXd(), std::exception);
+
+  // Instance method that reports failures via nullptr.
+  EXPECT_EQ(dut.ToAutoDiffXdMaybe(), nullptr);
+}
+
+// Sanity check the default implementation of ToSymbolic, for cases that
+// should succeed.
+GTEST_TEST(LeafSystemScalarConverterTest, SymbolicYes) {
+  SymbolicSparsitySystem<double> dut;
+  dut.set_name("special_name");
+
+  // Static method automatically downcasts.
+  std::unique_ptr<SymbolicSparsitySystem<symbolic::Expression>> clone =
+      System<double>::ToSymbolic(dut);
+  ASSERT_NE(clone, nullptr);
+  EXPECT_EQ(clone->get_name(), "special_name");
+
+  // Instance method that reports failures via exception.
+  EXPECT_NE(dut.ToSymbolic(), nullptr);
+
+  // Instance method that reports failures via nullptr.
+  auto maybe = dut.ToSymbolicMaybe();
+  ASSERT_NE(maybe, nullptr);
+  EXPECT_EQ(maybe->get_name(), "special_name");
+}
+
+// Sanity check the default implementation of ToSymbolic, for cases that
+// should fail.
+GTEST_TEST(LeafSystemScalarConverterTest, SymbolicNo) {
+  TestSystem<double> dut;
+
+  // Static method.
+  EXPECT_THROW(System<double>::ToSymbolic(dut), std::exception);
+
+  // Instance method that reports failures via exception.
+  EXPECT_THROW(dut.ToSymbolic(), std::exception);
+
+  // Instance method that reports failures via nullptr.
+  EXPECT_EQ(dut.ToSymbolicMaybe(), nullptr);
 }
 
 GTEST_TEST(GraphvizTest, Attributes) {

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -349,6 +349,22 @@ TEST_F(SystemTest, GetMemoryObjectName) {
   EXPECT_THAT(name, ::testing::ContainsRegex("/TestSystem@[0-9a-fA-F]{16}$"));
 }
 
+// Tests that by default, transmogrification fails appropriately.
+// (For testing transmogrification success, we rely on leaf_system_test.)
+TEST_F(SystemTest, TransmogrifyNotSupported) {
+  // Use the static method.
+  EXPECT_THROW(System<double>::ToAutoDiffXd<System>(system_), std::exception);
+  EXPECT_THROW(System<double>::ToSymbolic<System>(system_), std::exception);
+
+  // Use the instance method that throws.
+  EXPECT_THROW(system_.ToAutoDiffXd(), std::exception);
+  EXPECT_THROW(system_.ToSymbolic(), std::exception);
+
+  // Use the instance method that returns nullptr.
+  EXPECT_EQ(system_.ToAutoDiffXdMaybe(), nullptr);
+  EXPECT_EQ(system_.ToSymbolicMaybe(), nullptr);
+}
+
 template <typename T>
 using TestTypedVector = MyVector<1, T>;
 

--- a/drake/systems/framework/test_utilities/scalar_conversion.h
+++ b/drake/systems/framework/test_utilities/scalar_conversion.h
@@ -32,7 +32,7 @@ template <template <typename> class S, typename Callback>
 ::testing::AssertionResult is_autodiffxd_convertible(
      const S<double>& dut, Callback callback) {
   // Check if a proper type came out; return early if not.
-  std::unique_ptr<System<AutoDiffXd>> converted = dut.ToAutoDiffXd();
+  std::unique_ptr<System<AutoDiffXd>> converted = dut.ToAutoDiffXdMaybe();
   ::testing::AssertionResult result =
         is_dynamic_castable<S<AutoDiffXd>>(converted);
   if (!result) { return result; }
@@ -62,7 +62,8 @@ template <template <typename> class S, typename Callback>
 ::testing::AssertionResult is_symbolic_convertible(
      const S<double>& dut, Callback callback) {
   // Check if a proper type came out; return early if not.
-  std::unique_ptr<System<symbolic::Expression>> converted = dut.ToSymbolic();
+  std::unique_ptr<System<symbolic::Expression>> converted =
+      dut.ToSymbolicMaybe();
   ::testing::AssertionResult result =
         is_dynamic_castable<S<symbolic::Expression>>(converted);
   if (!result) { return result; }

--- a/drake/systems/trajectory_optimization/direct_transcription.cc
+++ b/drake/systems/trajectory_optimization/direct_transcription.cc
@@ -175,7 +175,7 @@ PiecewisePolynomialTrajectory DirectTranscription::ReconstructStateTrajectory()
 
 bool DirectTranscription::AddSymbolicDynamicConstraints(
     const System<double>* system, const Context<double>& context) {
-  const auto symbolic_system = system->ToSymbolic();
+  const auto symbolic_system = system->ToSymbolicMaybe();
   if (!symbolic_system) {
     return false;
   }


### PR DESCRIPTION
Fixes #6920.

Change `ToAutoDiffXd` to throw when autodiff is unsupported.
Add `-Maybe` variant that returns `nullptr` when unsupported.

We used to `DRAKE_ABORT_MSG` but that got lost recently; this puts the nice error back, this time as an exception to be nicer to users.  It also extends the nice exception to hold for symbolic conversion.

While we're here, substantially clean up the implementation.
The static method formulation no longer needs explicit choice of type.

Fix the static method formulation to `set_name`, like the instance method already did.

Throw `bad_cast` if `DoToFoo` is broken; don't just return `nullptr`.

Fix `Diagram` to obey the `-Maybe` contract, instead of always throwing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6950)
<!-- Reviewable:end -->
