### PR TITLE
Add drake visualization infrastructure

### DIFF
--- a/drake/geometry/BUILD
+++ b/drake/geometry/BUILD
@@ -27,6 +27,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "geometry_context",
+    srcs = ["geometry_context.cc"],
+    hdrs = ["geometry_context.h"],
+    deps = [
+        ":geometry_state",
+        "//drake/systems/framework:leaf_context",
+    ],
+)
+
+drake_cc_library(
     name = "geometry_frame",
     srcs = [],
     hdrs = ["geometry_frame.h"],
@@ -81,12 +91,25 @@ drake_cc_library(
         "query_handle.h",
     ],
     deps = [
-        ":geometry_frame",
-        ":geometry_instance",
+        ":geometry_context",
         ":geometry_state",
         "//drake/common",
         "//drake/geometry/query_results:penetration_as_point_pair",
         "//drake/systems/framework",
+        "//drake/systems/rendering:pose_bundle",
+    ],
+)
+
+drake_cc_library(
+    name = "geometry_visualization",
+    srcs = ["geometry_visualization.cc"],
+    hdrs = ["geometry_visualization.h"],
+    deps = [
+        ":geometry_state",
+        ":geometry_system",
+        "//drake/lcm",
+        "//drake/lcmtypes:viewer",
+        "//drake/math:geometric_transform",
     ],
 )
 
@@ -174,6 +197,7 @@ drake_cc_googletest(
     deps = [
         ":expect_error_message",
         ":geometry_system",
+        ":geometry_visualization",
     ],
 )
 

--- a/drake/geometry/geometry_context.cc
+++ b/drake/geometry/geometry_context.cc
@@ -1,0 +1,28 @@
+#include "drake/geometry/geometry_context.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+GeometryContext<T>::GeometryContext(int geometry_state_index)
+    : drake::systems::LeafContext<T>(),
+      geometry_state_index_(geometry_state_index) {}
+
+template <typename T>
+GeometryState<T>& GeometryContext<T>::get_mutable_geometry_state() {
+  return this->get_mutable_state()
+      ->template get_mutable_abstract_state<GeometryState<T>>(
+          geometry_state_index_);
+}
+
+template <typename T>
+const GeometryState<T>& GeometryContext<T>::get_geometry_state() const {
+  return this->get_state().template get_abstract_state<GeometryState<T>>(
+      geometry_state_index_);
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class GeometryContext<double>;
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_context.h
+++ b/drake/geometry/geometry_context.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_state.h"
+#include "drake/systems/framework/leaf_context.h"
+
+namespace drake {
+namespace geometry {
+
+/** The custom leaf context type for GeometrySystem and GeometryWorld.
+
+ @tparam T The scalar type. Must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double
+
+ They are already available to link against in the containing library.
+ No other values for T are currently supported. */
+template <typename T>
+class GeometryContext final : public systems::LeafContext<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GeometryContext)
+
+  /** Constructs the context with the given index for the geometry state. */
+  explicit GeometryContext(int geometry_state_index);
+
+  /** Returns a mutable reference of the underlying geometry state. */
+  GeometryState<T>& get_mutable_geometry_state();
+
+  /** Returns a const reference of the underlying geometry state. */
+  const GeometryState<T>& get_geometry_state() const;
+
+ private:
+  // The index of the geometry state abstract state.
+  const int geometry_state_index_{-1};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -5,9 +5,11 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"
+#include "drake/geometry/geometry_context.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/systems/framework/context.h"
+#include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
 namespace geometry {
@@ -19,17 +21,23 @@ using systems::LeafContext;
 using systems::LeafSystem;
 using systems::SystemSymbolicInspector;
 using systems::SystemOutput;
+using systems::rendering::PoseBundle;
 using std::make_unique;
 using std::vector;
 
-#define THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
+#define GS_THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
 
 template <typename T>
 GeometrySystem<T>::GeometrySystem() : LeafSystem<T>() {
   std::unique_ptr<GeometryState<T>> state = make_unique<GeometryState<T>>();
   auto state_value = AbstractValue::Make<GeometryState<T>>(*state.get());
   initial_state_ = &state_value->template GetMutableValue<GeometryState<T>>();
-  this->DeclareAbstractState(std::move(state_value));
+  geometry_state_index_ = this->DeclareAbstractState(std::move(state_value));
+
+  bundle_port_index_ =
+      this->DeclareAbstractOutputPort(&GeometrySystem::MakePoseBundle,
+                                      &GeometrySystem::CalcPoseBundle)
+          .get_index();
 
   query_port_index_ =
       this->DeclareAbstractOutputPort(&GeometrySystem::MakeQueryHandle,
@@ -39,7 +47,7 @@ GeometrySystem<T>::GeometrySystem() : LeafSystem<T>() {
 
 template <typename T>
 SourceId GeometrySystem<T>::RegisterSource(const std::string &name) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   SourceId source_id = initial_state_->RegisterNewSource(name);
   // This will fail only if the source generator starts recycling source ids.
   DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
@@ -69,14 +77,14 @@ GeometrySystem<T>::get_source_pose_port(SourceId id) {
 template <typename T>
 FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id,
                                          const GeometryFrame& frame) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, frame);
 }
 
 template <typename T>
 FrameId GeometrySystem<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                          const GeometryFrame& frame) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterFrame(source_id, parent_id, frame);
 }
 
@@ -84,7 +92,7 @@ template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, FrameId frame_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometry(source_id, frame_id,
                                           std::move(geometry));
 }
@@ -93,7 +101,7 @@ template <typename T>
 GeometryId GeometrySystem<T>::RegisterGeometry(
     SourceId source_id, GeometryId geometry_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   return initial_state_->RegisterGeometryWithParent(source_id, geometry_id,
                                                     std::move(geometry));
 }
@@ -102,29 +110,27 @@ template <typename T>
 GeometryId GeometrySystem<T>::RegisterAnchoredGeometry(
     SourceId source_id,
     std::unique_ptr<GeometryInstance> geometry) {
-  // TODO(SeanCurtis-TRI): Replace dummy geometry id with actual registration.
-  // and use all parameters.
-  unused(source_id, geometry);
-  THROW_IF_CONTEXT_ALLOCATED
-  return GeometryId::get_new_id();
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  return initial_state_->RegisterAnchoredGeometry(source_id,
+                                                  std::move(geometry));
 }
 
 template <typename T>
 void GeometrySystem<T>::ClearSource(SourceId source_id) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->ClearSource(source_id);
 }
 
 template <typename T>
 void GeometrySystem<T>::RemoveFrame(SourceId source_id, FrameId frame_id) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->RemoveFrame(source_id, frame_id);
 }
 
 template <typename T>
 void GeometrySystem<T>::RemoveGeometry(SourceId source_id,
                                        GeometryId geometry_id) {
-  THROW_IF_CONTEXT_ALLOCATED
+  GS_THROW_IF_CONTEXT_ALLOCATED
   initial_state_->RemoveGeometry(source_id, geometry_id);
 }
 
@@ -167,10 +173,108 @@ void GeometrySystem<T>::CalcQueryHandle(const Context<T>& context,
 }
 
 template <typename T>
+PoseBundle<T> GeometrySystem<T>::MakePoseBundle(
+    const Context<T>& context) const {
+  const auto& g_context = static_cast<const GeometryContext<T>&>(context);
+  const auto& g_state = g_context.get_geometry_state();
+  PoseBundle<T> bundle(g_state.get_num_frames());
+  int i = 0;
+  for (FrameId f_id : g_state.get_frame_ids()) {
+    int frame_group = g_state.get_frame_group(f_id);
+    bundle.set_model_instance_id(i, frame_group);
+
+    SourceId s_id = g_state.get_source_id(f_id);
+    const std::string& src_name = g_state.get_source_name(s_id);
+    const std::string& frm_name = g_state.get_frame_name(f_id);
+    std::string name = src_name + "::" + frm_name;
+    bundle.set_name(i, name);
+    ++i;
+  }
+  return bundle;
+}
+
+template <typename T>
+void GeometrySystem<T>::CalcPoseBundle(const Context<T>& context,
+                                       PoseBundle<T>* output) const {
+  // NOTE: Adding/removing frames during discrete updates will
+  // change the size/composition of the pose bundle. This calculation will *not*
+  // explicitly test this. It is assumed the discrete update will also be
+  // responsible for updating the bundle in the output port.
+  int i = 0;
+
+  const auto& g_context = static_cast<const GeometryContext<T>&>(context);
+  // TODO(SeanCurtis-TRI): Modify this when the cache is available to use the
+  // cache instead of this heavy-handed update.
+  FullPoseUpdate(g_context);
+  const auto& g_state = g_context.get_geometry_state();
+  for (FrameId f_id : g_state.get_frame_ids()) {
+    output->set_pose(i, g_state.get_pose_in_world(f_id));
+    // TODO(SeanCurtis-TRI): Handle velocity.
+    ++i;
+  }
+}
+
+template <typename T>
+void GeometrySystem<T>::FullPoseUpdate(
+    const GeometryContext<T>& context) const {
+  // TODO(SeanCurtis-TRI): Update this when the cache is available.
+  // This method is const and the context is const. Ultimately, this will pull
+  // cached entities to do the query work. For now, we have to const cast the
+  // thing so that we can update the geometry engine contained.
+
+  using std::to_string;
+
+  const GeometryState<T>& state = context.get_geometry_state();
+  GeometryState<T>& mutable_state = const_cast<GeometryState<T>&>(state);
+
+  auto throw_error = [](SourceId source_id, const std::string& origin) {
+    throw std::logic_error(
+        "Source " + to_string(source_id) + " has registered frames "
+            "but does not provide " + origin + " values on the input port.");
+  };
+
+  for (const auto& pair : state.source_frame_id_map_) {
+    if (pair.second.size() > 0) {
+      SourceId source_id = pair.first;
+      const auto itr = input_source_ids_.find(source_id);
+      DRAKE_ASSERT(itr != input_source_ids_.end());
+      const int id_port = itr->second.id_port;
+      const auto id_port_value =
+          this->template EvalAbstractInput(context, id_port);
+      if (id_port_value) {
+        const FrameIdVector& ids =
+            id_port_value->template GetValue<FrameIdVector>();
+        // TODO(SeanCurtis-TRI): In future versions consider moving this to
+        // a DRAKE_ASSERT_VOID execution.
+        state.ValidateFrameIds(ids);
+        const int pose_port = itr->second.pose_port;
+        const auto pose_port_value =
+            this->template EvalAbstractInput(context, pose_port);
+        if (pose_port_value) {
+          const auto& poses =
+              pose_port_value->template GetValue<FramePoseVector<T>>();
+          mutable_state.SetFramePoses(ids, poses);
+        } else {
+          throw_error(source_id, "pose");
+        }
+      } else {
+        throw_error(source_id, "id");
+      }
+    }
+  }
+
+  // TODO(SeanCurtis-TRI): Propagate changes to the geometry engine.
+  // Again, this will change significantly when caching becomes available.
+
+  // TODO(SeanCurtis-TRI): Add velocity as appropriate.
+}
+
+template <typename T>
 std::unique_ptr<LeafContext<T>> GeometrySystem<T>::DoMakeContext() const {
   // Disallow further geometry source additions.
   initial_state_ = nullptr;
-  return std::make_unique<LeafContext<T>>();
+  DRAKE_ASSERT(geometry_state_index_ >= 0);
+  return make_unique<GeometryContext<T>>(geometry_state_index_);
 }
 
 template <typename T>
@@ -194,6 +298,9 @@ void GeometrySystem<T>::ThrowUnlessRegistered(SourceId source_id,
 
 // Explicitly instantiates on the most common scalar types.
 template class GeometrySystem<double>;
+
+// Don't leave the macro defined.
+#undef GS_THROW_IF_CONTEXT_ALLOCATED
 
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_visualization.cc
+++ b/drake/geometry/geometry_visualization.cc
@@ -1,0 +1,178 @@
+#include "drake/geometry/geometry_visualization.h"
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_state.h"
+#include "drake/geometry/geometry_system.h"
+#include "drake/geometry/internal_geometry.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmtypes/drake/lcmt_viewer_geometry_data.hpp"
+#include "drake/lcmtypes/drake/lcmt_viewer_load_robot.hpp"
+#include "drake/math/rotation_matrix.h"
+
+namespace drake {
+namespace geometry {
+
+namespace {
+
+// Simple class for converting shape specifications into LCM-compatible shapes.
+class ShapeToLcm : public ShapeReifier {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShapeToLcm)
+
+  ShapeToLcm() = default;
+  ~ShapeToLcm() override = default;
+
+  lcmt_viewer_geometry_data Convert(const Shape& shape,
+                                    const Isometry3<double>& X_PG,
+                                    const Eigen::Vector4d& in_color) {
+    X_PG_ = X_PG;
+    // NOTE: Reify *may* change X_PG_ based on the shape. For example, the
+    // half-space requires an additional offset to shift the box representing
+    // the plane *to* the plane.
+    shape.Reify(this);
+
+    // Saves the location and orientation of the visualization geometry in the
+    // `lcmt_viewer_geometry_data` object. The location and orientation are
+    // specified in the body's frame.
+    Eigen::Map<Eigen::Vector3f> position(geometry_data_.position);
+    position = X_PG_.translation().cast<float>();
+    // LCM quaternion must be w, x, y, z.
+    Eigen::Quaternion<double> q(X_PG_.rotation());
+    geometry_data_.quaternion[0] = q.w();
+    geometry_data_.quaternion[1] = q.x();
+    geometry_data_.quaternion[2] = q.y();
+    geometry_data_.quaternion[3] = q.z();
+
+    Eigen::Map<Eigen::Vector4f> color(geometry_data_.color);
+    color = in_color.cast<float>();
+    return geometry_data_;
+  }
+
+  void ImplementGeometry(const Sphere& sphere) override {
+    geometry_data_.type = geometry_data_.SPHERE;
+    geometry_data_.num_float_data = 1;
+    geometry_data_.float_data.push_back(static_cast<float>(
+                                           sphere.get_radius()));
+  }
+
+  void ImplementGeometry(const HalfSpace&) override {
+    // Currently representing a half space as a big box. This assumes that the
+    // underlying box representation is centered on the origin.
+    geometry_data_.type = geometry_data_.BOX;
+    geometry_data_.num_float_data = 3;
+    // Box width, height, and thickness.
+    geometry_data_.float_data.push_back(50);
+    geometry_data_.float_data.push_back(50);
+    const float thickness = 1;
+    geometry_data_.float_data.push_back(thickness);
+
+    // The final pose of the box is the half-space's pose pre-multiplied by
+    // an offset sufficient to move the box down so it's top face lies on the
+    // z = 0 plane.
+    Isometry3<double> box_xform = Isometry3<double>::Identity();
+    // Shift it down so that the origin lies on the top surface.
+    box_xform.translation() << 0, 0, -thickness / 2;
+    X_PG_ = X_PG_ * box_xform;
+  }
+
+ private:
+  lcmt_viewer_geometry_data geometry_data_{};
+  // The transform from the geometry frame to its parent frame.
+  Eigen::Isometry3d X_PG_;
+};
+
+lcmt_viewer_geometry_data MakeGeometryData(const Shape& shape,
+                                           const Isometry3<double>& X_PG,
+                                           const Eigen::Vector4d& in_color) {
+  ShapeToLcm converter;
+  return converter.Convert(shape, X_PG, in_color);
+}
+
+}  // namespace
+
+void DispatchLoadMessage(const GeometryState<double>& state) {
+  using internal::InternalAnchoredGeometry;
+  using internal::InternalGeometry;
+  using lcm::DrakeLcm;
+
+  lcmt_viewer_load_robot message{};
+  // Populate the message.
+  const int frame_count = state.get_num_frames();
+  const int anchored_count =
+      static_cast<int>(state.anchored_geometry_index_id_map_.size());
+
+  // Include the world frame as one of the frames (if there are anchored
+  // geometries).
+  int total_link_count = frame_count + (anchored_count > 0 ? 1 : 0);
+  message.num_links = total_link_count;
+  message.link.resize(total_link_count);
+
+  Eigen::Vector4d default_color(0.8, 0.8, 0.8, 1.0);
+
+  int link_index = 0;
+  // Load anchored geometry into the world frame.
+  {
+    if (anchored_count) {
+      message.link[0].name = "world";
+      message.link[0].robot_num = 0;
+      message.link[0].num_geom = anchored_count;
+      message.link[0].geom.resize(anchored_count);
+      int geom_index = 0;
+      for (const auto& pair : state.anchored_geometries_) {
+        const InternalAnchoredGeometry& geometry = pair.second;
+        const Shape& shape = geometry.get_shape();
+        message.link[0].geom[geom_index] = MakeGeometryData(
+            shape, geometry.get_pose_in_parent(), default_color);
+        ++geom_index;
+      }
+      link_index = 1;
+    }
+  }
+
+  // Load dynamic geometry into their own frames.
+  for (const auto& pair : state.frames_) {
+    const internal::InternalFrame& frame = pair.second;
+    SourceId s_id = state.get_source_id(frame.get_id());
+    const std::string& src_name = state.get_source_name(s_id);
+    // TODO(SeanCurtis-TRI): The name in the load message *must* match the name
+    // in the update message. Make sure this code and the GeometrySystem output
+    // use a common code-base to translate (source_id, frame) -> name.
+    message.link[link_index].name = src_name + "::" + frame.get_name();
+    message.link[link_index].robot_num = frame.get_frame_group();
+    const int geom_count = static_cast<int>(
+        frame.get_child_geometries().size());
+    message.link[link_index].num_geom = geom_count;
+    message.link[link_index].geom.resize(geom_count);
+    int geom_index = 0;
+    for (GeometryId geom_id : frame.get_child_geometries()) {
+      const InternalGeometry& geometry = state.geometries_.at(geom_id);
+      GeometryIndex index = state.geometries_.at(geom_id).get_engine_index();
+      const Shape& shape = geometry.get_shape();
+      const Isometry3<double> X_FG = state.X_FG_.at(index);
+      message.link[link_index].geom[geom_index] =
+          MakeGeometryData(shape, X_FG, default_color);
+      ++geom_index;
+    }
+    ++link_index;
+  }
+
+  // Send a load message.
+  const int message_length = message.getEncodedSize();
+  std::vector<uint8_t> message_bytes(message_length);
+  message.encode(message_bytes.data(), 0, message_length);
+  DrakeLcm lcm;
+  lcm.Publish("DRAKE_VIEWER_LOAD_ROBOT", message_bytes.data(),
+              message_bytes.size());
+}
+
+void DispatchLoadMessage(const GeometrySystem<double>& system) {
+  system.ThrowIfContextAllocated("DisplatchLoadMessage");
+  DispatchLoadMessage(*system.initial_state_);
+}
+
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/geometry_visualization.h
+++ b/drake/geometry/geometry_visualization.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/** @file
+ Provides a set of functions to facilitate visualization operations based on
+ geometry world state. */
+
+namespace drake {
+namespace geometry {
+
+template <typename T> class GeometrySystem;
+
+/** Dispatches an LCM load message based on the registered geometry. It should
+ be invoked _after_ registration is complete, but before context allocation.
+ @param system      The system whose geometry will be sent in an LCM message.
+ @throws std::logic_error if the system has already had its context allocated.
+ */
+void DispatchLoadMessage(const GeometrySystem<double>& system);
+
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Adds the infrastructure to connect geometry system with drake visualizer.
  1. Add output connections from `GeometrySystem` that can feed into ` DrakeVisualizer`.
  2. Add interface for dispatching LCM load message.
  3. Finish wiring up registration from system to state.
  4. Extend state to allow:
      1. Computation of frame position in world.
      2. Iterate through the frames in the system.

NOTE: This includes code that doesn't reflect the final state of functionality. THere are members of `GeometrySystem` and `GeometryState` that exist the way they do because they are waiting on the cache system.

The next PR will actually produce moving bodies that can be seen!

Breakdown of changes:
```
Category            added  modified  removed  
----------------------------------------------
code                506    10        2        
comments            133    7         1        
blank               94     0         0        
----------------------------------------------
TOTAL               733    17        3
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6953)
<!-- Reviewable:end -->
