### PR TITLE
Add extra_srcs for python_lint().

### DIFF
--- a/tools/lint.bzl
+++ b/tools/lint.bzl
@@ -9,6 +9,7 @@ def add_lint_tests(
         cpplint_extra_srcs = None,
         python_lint_ignore = None,
         python_lint_exclude = None,
+        python_lint_extra_srcs = None,
         bazel_lint_ignore = None):
     """For every rule in the BUILD file so far, and for all Bazel files in this
     directory, adds test rules that run Drake's standard lint suite over the
@@ -29,6 +30,7 @@ def add_lint_tests(
     python_lint(
         existing_rules = existing_rules,
         ignore = python_lint_ignore,
-        exclude = python_lint_exclude)
+        exclude = python_lint_exclude,
+        extra_srcs = python_lint_extra_srcs)
     bazel_lint(
         ignore = bazel_lint_ignore)

--- a/tools/python_lint.bzl
+++ b/tools/python_lint.bzl
@@ -20,7 +20,8 @@ def _python_lint(name, files, ignore):
     )
 
 #------------------------------------------------------------------------------
-def python_lint(existing_rules = None, ignore = None, exclude = None):
+def python_lint(existing_rules = None, ignore = None, exclude = None,
+                extra_srcs = None):
     """
     Runs the pycodestyle PEP 8 code style checker on all Python source files
     declared in rules in a BUILD file.
@@ -32,6 +33,7 @@ def python_lint(existing_rules = None, ignore = None, exclude = None):
         ignore: List of errors (as integers, without the 'E') to ignore
             (default = []).
         exclude: List of labels to exclude from linting, e.g., [:foo.py].
+        extra_srcs: Source files that are not discoverable via rules.
 
     Example:
         BUILD:
@@ -72,3 +74,9 @@ def python_lint(existing_rules = None, ignore = None, exclude = None):
                 files = files,
                 ignore = ignore,
             )
+    if extra_srcs:
+        _python_lint(
+            name = "extra_srcs_pycodestyle",
+            files = extra_srcs,
+            ignore = ignore,
+        )


### PR DESCRIPTION
This enables extra sources to be added for python linting (e.g. `director` scripts).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6955)
<!-- Reviewable:end -->
