### PR TITLE
Suppressing an Undefined Behavior in Eigen

### DIFF
--- a/tools/ubsan.supp
+++ b/tools/ubsan.supp
@@ -8,3 +8,7 @@ shift-base:BulletCollision/BroadphaseCollision/btOverlappingPairCache.h
 # http://llvm.org/viewvc/llvm-project/llvm/trunk/utils/sanitizers/ubsan_blacklist.txt?view=markup&pathrev=291918
 alignment:bits/stl_tree.h
 alignment:bits/stl_pair.h
+
+# Bug in Eigen, has been fixed somewhere after tag 3.3.4.  Present in
+# branches/3.3
+null:external/eigen/Eigen/src/Core/util/BlasUtil.h


### PR DESCRIPTION
This seems like a bug in Eigen's handling of zero sized vectors, [reproducible with Eigen 3.3.3 using this gist](https://gist.github.com/m-chaturvedi/5eb211e43b55943d3e86f7f13cd429b3).  The problem seems to have been fixed somewhere between 3.3.4 and the current default branch. 

When we update Eigen to the default branch, both these tests pass.
[Ref ](https://github.com/RobotLocomotion/drake/issues/6910)

`bazel test   -c  dbg --copt -O0 --config=ubsan --test_output=all //drake/examples/rod2d:rod2d_test //drake/multibody/constraint:constraint_solver_test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6967)
<!-- Reviewable:end -->
