### PR TITLE
Enable gflags for all drake_cc_googletest unit tests

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -352,6 +352,17 @@ install(
 
 # === test/ ===
 
+# This is only intended to be used by the drake_cc_googletest() macro.
+drake_cc_library(
+    name = "drake_cc_googletest_main",
+    testonly = 1,
+    srcs = ["test/drake_cc_googletest_main.cc"],
+    deps = [
+        ":text_logging_gflags",
+        "@gtest//:without_main",
+    ],
+)
+
 drake_cc_library(
     name = "random_polynomial_matrix",
     testonly = 1,
@@ -811,6 +822,20 @@ drake_cc_googletest(
     deps = [
         ":scoped_singleton",
     ],
+)
+
+drake_cc_googletest(
+    name = "drake_cc_googletest_main_test",
+    args = ["--magic_number=1.0"],
+)
+
+# Run test/drake_cc_googletest_main_test.py, a unit test written in Python that
+# covers the test/drake_cc_googletest_main.cc software.
+py_test(
+    name = "drake_cc_googletest_main_test_py",
+    srcs = ["test/drake_cc_googletest_main_test.py"],
+    data = [":drake_cc_googletest_main_test"],
+    main = "test/drake_cc_googletest_main_test.py",
 )
 
 py_test(

--- a/drake/common/test/drake_cc_googletest_main.cc
+++ b/drake/common/test/drake_cc_googletest_main.cc
@@ -1,0 +1,25 @@
+/// @file
+/// This is Drake's default main() function for gtest-based unit tests.
+
+#include <gmock/gmock.h>
+
+#include "drake/common/text_logging_gflags.h"
+
+int main(int argc, char** argv) {
+  std::cout << "Using drake/test/drake_cc_googletest_main.cc\n";
+
+  // Initialize gtest and gmock.
+  testing::InitGoogleMock(&argc, argv);
+  std::cout << "\n";  // Put a linebreak between gtest help and gflags help.
+
+  // Initialize gflags; this must happen after gtest initialization, so that the
+  // gtest flags have already been removed from argv and won't confuse gflags.
+  google::SetUsageMessage(" ");  // Nerf a silly warning emitted by gflags.
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Adjust Drake's log setting per the gflags results.
+  drake::logging::HandleSpdlogGflags();
+
+  // Actually run the tests.
+  return RUN_ALL_TESTS();
+}

--- a/drake/common/test/drake_cc_googletest_main_test.cc
+++ b/drake/common/test/drake_cc_googletest_main_test.cc
@@ -1,0 +1,25 @@
+/// @file
+/// This is a sample unit test whose purpose is to provide a binary for
+/// test/drake_cc_googletest_main_test.py to run, in order to assess the
+/// correctness of command-line flag handling.  That python file contains the
+/// majority of the meaningful unit test logic.
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/text_logging.h"
+
+// We expect the invoking shell to set this to 1.0 via the command-line.
+// (If it doesn't, the unit test will fail.)
+DEFINE_double(magic_number, 0.0, "Magic number");
+
+namespace drake {
+namespace {
+
+GTEST_TEST(GtestMainTest, BasicTest) {
+  drake::log()->debug("Cross your fingers for the magic_number {}", 1.0);
+  EXPECT_EQ(FLAGS_magic_number, 1.0);
+}
+
+}  // namespace
+}  // namespace drake

--- a/drake/common/test/drake_cc_googletest_main_test.py
+++ b/drake/common/test/drake_cc_googletest_main_test.py
@@ -1,0 +1,68 @@
+"""This program unit tests the command-line processing capabilities of the
+drake_cc_googletest bazel macro, by running
+`bazel-bin/drake/common/drake_cc_googletest_main_test`
+with a variety of command-line flags.
+"""
+
+import re
+import subprocess
+import os
+import unittest
+
+
+class TestGtestMain(unittest.TestCase):
+    def _check_call(self, args, expected_returncode=0):
+        """Run drake_cc_googletest_main with the given args; return output.
+        """
+        try:
+            output = subprocess.check_output(
+                ["drake/common/drake_cc_googletest_main_test"] + args,
+                stderr=subprocess.STDOUT)
+            returncode = 0
+        except subprocess.CalledProcessError as e:
+            output = e.output
+            returncode = e.returncode
+        self.assertEqual(
+            returncode, expected_returncode,
+            "Expected returncode %r from %r but got %r with output %r" % (
+                expected_returncode, args, returncode, output))
+        return output
+
+    def test_pass(self):
+        # The device under test should pass when -magic_number=1.0 is present.
+        self._check_call(["-magic_number=1.0"], expected_returncode=0)
+
+    def test_no_arguments(self):
+        # The device under test should fail when -magic_number=1.0 is missing.
+        output = self._check_call([], expected_returncode=1)
+        self.assertTrue("Expected: FLAGS_magic_number" in output)
+
+    def test_help(self):
+        # The help string should mention all options.  Just spot-check for one
+        # option from each expected contributor.
+        output = self._check_call([
+            "--help",
+            ], expected_returncode=1)
+        self.assertGreater(len(output), 1000)
+        self.assertTrue("Using drake/test/drake_cc_googletest_main" in output)
+        self.assertTrue("-gtest_list_tests" in output)
+        self.assertTrue("-spdlog_level" in output)
+        self.assertTrue("-magic_number" in output)
+
+    def test_logging(self):
+        # The spdlog flags should be able to enable debug logging.
+
+        # By default, there is no debug log.
+        log_message = "[debug] Cross your fingers for the magic_number 1"
+        args = ["-magic_number=1.0"]
+        output = self._check_call(args, expected_returncode=0)
+        self.assertFalse(log_message in output)
+
+        # Once enabled, we see a debug log.
+        args.append("-spdlog_level=debug")
+        output = self._check_call(args, expected_returncode=0)
+        self.assertTrue(log_message in output, output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -209,13 +209,12 @@ def drake_cc_googletest(
         deps = None,
         use_default_main = True,
         **kwargs):
-    """Creates a rule to declare a C++ unit test using googletest.  Always adds
-    a deps= entry for googletest main (@gtest//:main).
+    """Creates a rule to declare a C++ unit test using googletest.
 
     By default, sets size="small" because that indicates a unit test.
     By default, sets name="test/${name}.cc" per Drake's filename convention.
-    By default, sets use_default_main=True to use GTest's main, via
-    @gtest//:main. Otherwise, it will depend on @gtest//:without_main.
+    By default, sets use_default_main=True to use a default main() function.
+    Otherwise, it will depend on @gtest//:without_main.
 
     If disable_in_compilation_mode_dbg is True, the srcs will be suppressed
     in debug-mode builds, so the test will trivially pass. This option should
@@ -224,7 +223,7 @@ def drake_cc_googletest(
     if deps == None:
         deps = []
     if use_default_main:
-        deps = deps + ["@gtest//:main"]
+        deps = deps + ["//drake/common:drake_cc_googletest_main"]
     else:
         deps = deps + ["@gtest//:without_main"]
     drake_cc_test(


### PR DESCRIPTION
This allows unit tests to add flags, allows modules under test to expose flags, and offers `--spdlog_level=foo` on all unit tests, e.g., to turn on verbose logging on an opt-in basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6968)
<!-- Reviewable:end -->
