### PR TITLE
Add comparison operators to EigenPtr for verbose assertion messages.

### DIFF
--- a/drake/common/eigen_types.h
+++ b/drake/common/eigen_types.h
@@ -313,7 +313,11 @@ class EigenPtr {
   RefType* operator->() const { return get_reference(); }
 
   /// Returns whether or not this contains a valid reference.
-  operator bool() const { return static_cast<bool>(m_); }
+  operator bool() const { return is_valid(); }
+
+  bool operator==(std::nullptr_t) const { return !is_valid(); }
+
+  bool operator!=(std::nullptr_t) const { return is_valid(); }
 
  private:
   // Use unique_ptr<> so that we may "reconstruct" the reference, making this
@@ -338,6 +342,10 @@ class EigenPtr {
   RefType* get_reference() const {
     if (!m_) throw std::runtime_error("EigenPtr: nullptr dereference");
     return m_.get();
+  }
+
+  bool is_valid() const {
+    return static_cast<bool>(m_);
   }
 };
 

--- a/drake/common/test/eigen_types_test.cc
+++ b/drake/common/test/eigen_types_test.cc
@@ -89,8 +89,19 @@ GTEST_TEST(EigenTypesTest, TraitsSFINAE) {
 GTEST_TEST(EigenTypesTest, EigenPtr_Null) {
   EigenPtr<const Matrix3d> null_ptr = nullptr;
   EXPECT_FALSE(null_ptr);
+  EXPECT_FALSE(null_ptr != nullptr);
   EXPECT_TRUE(!null_ptr);
+  EXPECT_TRUE(null_ptr == nullptr);
   EXPECT_THROW(*null_ptr, std::runtime_error);
+
+  Matrix3d X;
+  X.setConstant(0);
+  EigenPtr<const Matrix3d> ptr = &X;
+  EXPECT_TRUE(ptr);
+  EXPECT_TRUE(ptr != nullptr);
+  EXPECT_FALSE(!ptr);
+  EXPECT_FALSE(ptr == nullptr);
+  EXPECT_NO_THROW(*ptr);
 }
 
 bool ptr_optional_arg(EigenPtr<MatrixXd> arg = nullptr) {


### PR DESCRIPTION
Per [discussion](https://reviewable.io/reviews/robotlocomotion/drake/6958#-KtHeGnhcuwjnrrwNCGt:-KtHq1ZWk6_AEOHTLB54:b-7fblx1) in #6958, this adds a simple comparison operator for `ptr != nullptr` and `ptr == nullptr` per @amcastro-tri's request.

Note that this does not add comparison for `lhs_ptr == rhs_ptr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6970)
<!-- Reviewable:end -->
