### PR TITLE
Remove symbolic inspector from LeafSystem feedthrough API

### DIFF
--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -298,8 +298,7 @@ MaliputRailcar<T>::AllocateAbstractState() const {
 }
 
 template <typename T>
-bool MaliputRailcar<T>::DoHasDirectFeedthrough(
-    const SystemSymbolicInspector*, int, int) const {
+optional<bool> MaliputRailcar<T>::DoHasDirectFeedthrough(int, int) const {
   return false;
 }
 

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -125,8 +125,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   // LeafSystem<T> overrides.
   std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
       const override;
-  bool DoHasDirectFeedthrough(const systems::SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override;
+  optional<bool> DoHasDirectFeedthrough(int, int) const override;
   void DoCalcNextUpdateTime(const systems::Context<T>& context,
                             systems::CompositeEventCollection<T>*,
                             T* time) const override;

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.h
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/state_machine_system.h
@@ -44,8 +44,7 @@ class PickAndPlaceStateMachineSystem : public systems::LeafSystem<double> {
       const override;
 
   // This kind of a system is not a direct feedthrough.
-  bool DoHasDirectFeedthrough(const systems::SystemSymbolicInspector*,
-                              int, int) const final {
+  optional<bool> DoHasDirectFeedthrough(int, int) const final {
     return false;
   }
 

--- a/drake/examples/quadrotor/quadrotor_plant.h
+++ b/drake/examples/quadrotor/quadrotor_plant.h
@@ -52,8 +52,7 @@ class QuadrotorPlant : public systems::LeafSystem<T> {
   /// type because it invokes the Cholesky LDLT decomposition, which uses
   /// conditionals in its implementation. Therefore, we must specify sparsity
   /// by hand.
-  bool DoHasDirectFeedthrough(const systems::SystemSymbolicInspector*,
-                              int, int) const override {
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
     return false;
   }
 

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -53,7 +53,8 @@ class GeometrySystemTester {
   }
   static bool HasDirectFeedthrough(const GeometrySystem<double>& system,
                                    int input_port, int output_port) {
-    return system.DoHasDirectFeedthrough(nullptr, input_port, output_port);
+    return system.DoHasDirectFeedthrough(
+        input_port, output_port).value_or(true);
   }
 };
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -170,8 +170,7 @@ void RigidBodyPlant<T>::set_friction_contact_parameters(
 }
 
 template <typename T>
-bool RigidBodyPlant<T>::DoHasDirectFeedthrough(const SystemSymbolicInspector*,
-                                               int, int) const {
+optional<bool> RigidBodyPlant<T>::DoHasDirectFeedthrough(int, int) const {
   return false;
 }
 

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -334,8 +334,7 @@ class RigidBodyPlant : public LeafSystem<T> {
       const std::vector<const DiscreteUpdateEvent<double>*>&,
       DiscreteValues<T>* updates) const override;
 
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override;
+  optional<bool> DoHasDirectFeedthrough(int, int) const override;
 
   // TODO(amcastro-tri): provide proper implementations for these methods to
   // track energy conservation.

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -57,8 +57,7 @@ class TestPlantWithMinOutputs : public TestPlant {
   }
 
  protected:
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override {
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
     return false;
   }
 };
@@ -101,8 +100,7 @@ class TestPlantWithMoreOutputs : public TestPlant {
   }
 
  protected:
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override {
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
     return false;
   }
 };

--- a/drake/systems/estimators/luenberger_observer.h
+++ b/drake/systems/estimators/luenberger_observer.h
@@ -61,8 +61,7 @@ class LuenbergerObserver : public systems::LeafSystem<T> {
                           systems::BasicVector<T>* output) const;
 
   /// This system is not direct feedthrough.
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector*, int,
-                              int) const override {
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
     return false;
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -200,11 +200,39 @@ class LeafSystem : public System<T> {
   }
 
   std::multimap<int, int> GetDirectFeedthroughs() const final {
-    auto sparsity = MakeSystemSymbolicInspector();
+    // A helper object that is latch-initialized the first time it is needed,
+    // but not before.  The optional<> wrapper represents whether or not the
+    // latch-init has been attempted; the unique_ptr's non-nullness represents
+    // whether or not symbolic form is supported.
+    optional<std::unique_ptr<SystemSymbolicInspector>> inspector;
+
+    // This predicate answers a feedthrough query using symbolic form, or
+    // returns "true" if symbolic form is unavailable.  It is lazy, in that it
+    // will not create the symbolic form until the first time it is invoked.
+    auto inspect_symbolic_feedthrough = [this, &inspector](int u, int v) {
+      // The very first time we are called, latch-initialize the inspector.
+      if (!inspector) { inspector = MakeSystemSymbolicInspector(); }
+
+      // If we have an inspector, delegate to it.  Otherwise, be conservative.
+      if (SystemSymbolicInspector* inspector_value = inspector.value().get()) {
+        return inspector_value->IsConnectedInputToOutput(u, v);
+      } else {
+        return true;
+      }
+    };
+
+    // Iterate all input-output pairs, populating the map with the "true" terms.
     std::multimap<int, int> pairs;
     for (int u = 0; u < this->get_num_input_ports(); ++u) {
       for (int v = 0; v < this->get_num_output_ports(); ++v) {
-        if (DoHasDirectFeedthrough(sparsity.get(), u, v)) {
+        // Ask our subclass whether it wants to directly express feedthrough.
+        const optional<bool> overridden_feedthrough =
+            DoHasDirectFeedthrough(u, v);
+        // If our subclass didn't provide an answer, use symbolic form instead.
+        const bool direct_feedthrough =
+            overridden_feedthrough ? overridden_feedthrough.value() :
+            inspect_symbolic_feedthrough(u, v);
+        if (direct_feedthrough) {
           pairs.emplace(u, v);
         }
       }
@@ -436,43 +464,36 @@ class LeafSystem : public System<T> {
   }
 
   /// Returns true if there is direct-feedthrough from the given @p input_port
-  /// to the given @p output_port, and false otherwise, according to the given
-  /// @p sparsity.
+  /// to the given @p output_port, false if there is not direct-feedthrough, or
+  /// nullopt if unknown (in which case SystemSymbolicInspector will attempt to
+  /// measure the feedthrough using symbolic form).
   ///
-  /// If @p sparsity is nullptr, returns true, so that by default we assume
-  /// there is direct feedthrough of values from every input to every output.
+  /// By default, %LeafSystem assumes there is direct feedthrough of values
+  /// from every input to every output.
   /// This is a conservative assumption that ensures we detect and can prevent
   /// the formation of algebraic loops (implicit computations) in system
   /// Diagrams. Systems which do not have direct feedthrough may override that
   /// assumption in two ways:
   ///
-  /// - Override DoToSymbolic, allowing this function to infer the sparsity
+  /// - Override DoToSymbolic, allowing %LeafSystem to infer the sparsity
   ///   from the symbolic equations. This method is typically preferred for
   ///   systems that have a symbolic form, but should be avoided in certain
   ///   corner cases where fully descriptive symbolic analysis is impossible,
-  ///   e.g. when the symbolic form depends on C++ native conditionals. For
+  ///   e.g., when the symbolic form depends on C++ native conditionals. For
   ///   additional discussion, consult the documentation for
   ///   SystemSymbolicInspector.
   ///
   /// - Override this function directly, reporting manual sparsity. This method
-  ///   is recommended when ToSymbolic has not been implemented, or when its
+  ///   is recommended when DoToSymbolic has not been implemented, or when
+  ///   creating the symbolic form is too computationally expensive, or when its
   ///   output is not fully descriptive, as discussed above. Manually configured
   ///   sparsity must be conservative: if there is any Context for which an
   ///   input port is direct-feedthrough to an output port, this function must
-  ///   return true for those two ports.
-  virtual bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                                      int input_port, int output_port) const {
-    DRAKE_ASSERT(input_port >= 0);
-    DRAKE_ASSERT(input_port < this->get_num_input_ports());
-    DRAKE_ASSERT(output_port >= 0);
-    DRAKE_ASSERT(output_port < this->get_num_output_ports());
-
-    // If no symbolic sparsity matrix is available, assume direct feedthrough
-    // by default.
-    if (sparsity == nullptr) {
-      return true;
-    }
-    return sparsity->IsConnectedInputToOutput(input_port, output_port);
+  ///   return either true or nullopt for those two ports.
+  virtual optional<bool> DoHasDirectFeedthrough(
+      int input_port, int output_port) const {
+    unused(input_port, output_port);
+    return nullopt;
   }
 
   // =========================================================================

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -749,8 +749,7 @@ class Reduce : public LeafSystem<double> {
     output->get_mutable_value() = input_vector->get_value();
   }
 
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override {
+  optional<bool> DoHasDirectFeedthrough(int input_port, int) const override {
     return input_port == feedthrough_input_;
   }
 

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -977,8 +977,8 @@ class ManualSparsitySystem : public DefaultFeedthroughSystem {
   }
 
  protected:
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override {
+  optional<bool> DoHasDirectFeedthrough(
+      int input_port, int output_port) const override {
     if (input_port == 0 && output_port == 1) {
       return true;
     }

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -96,8 +96,8 @@ void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
 }
 
 template <typename T>
-bool ZeroOrderHold<T>::DoHasDirectFeedthrough(
-    const SystemSymbolicInspector*, int input_port, int output_port) const {
+optional<bool> ZeroOrderHold<T>::DoHasDirectFeedthrough(
+    int input_port, int output_port) const {
   DRAKE_DEMAND(input_port == 0);
   DRAKE_DEMAND(output_port == 0);
   // By definition, a zero-order hold will not have direct feedthrough, as the

--- a/drake/systems/primitives/zero_order_hold.h
+++ b/drake/systems/primitives/zero_order_hold.h
@@ -57,8 +57,8 @@ class ZeroOrderHold : public LeafSystem<T> {
 
  protected:
   // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
-  bool DoHasDirectFeedthrough(const SystemSymbolicInspector* sparsity,
-                              int input_port, int output_port) const override;
+  optional<bool> DoHasDirectFeedthrough(
+      int input_port, int output_port) const override;
 
   // System<T> override.  Returns a ZeroOrderHold<symbolic::Expression> with
   // the same dimensions as this ZeroOrderHold.


### PR DESCRIPTION
`LeafSystem::DoHasDirectFeedthrough` previously accepted an already-constructed `SystemSymbolicInspector`, which means that we were trying to create symbolic form even for systems that directly expressed their sparsity.  It was also a confusing API for users to understand.

Fixes #6951.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6973)
<!-- Reviewable:end -->
