### PR TITLE
Update support matrix

### DIFF
--- a/drake/doc/developers.rst
+++ b/drake/doc/developers.rst
@@ -71,54 +71,25 @@ officially supports. Supported configurations are tested in continuous
 integration. All other configurations are provided on a best-effort basis.
 
 For CMake builds, the "Unix Makefiles" and "Ninja" CMake generators are
-supported.
+supported. MATLAB is only supported for CMake builds on Ubuntu operating
+systems.
 
-For CMake builds, the supported version of MATLAB is R2015b.
-
-For CMake builds,
-minimal configuration is defined as the minimal required externals
-from the superbuild. This is configured by turning off all externals using
-``ccmake`` or ``cmake-gui`` except for ``WITH_EIGEN``, ``WITH_GOOGLETEST``,
-and  ``WITH_GFLAGS``, which should be set to ``ON``.
-
-Almost all of Drake and Drake's externals are
-supported on Bazel. "Superbuild Deps" are not meaningful in the context
-of Bazel, since there is no configurable superbuild. MATLAB is not supported on
-Bazel, and there are no plans to add support.
-
-+------------------------------+------------------+--------------------+-------------------+---------+
-| Operating System             | Build Systems    | Compilers          | Superbuild Deps   | Build   |
-+==============================+==================+====================+===================+=========+
-| Ubuntu 14.04 LTS ("Trusty")  | | CMake 3.5.2    | | GCC 4.9          | Minimal           | Debug   |
-|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
-|                              |                  |                    |                   | Release |
-|                              |                  |                    +-------------------+---------+
-|                              |                  |                    | Default           | Debug   |
-|                              |                  |                    |                   +---------+
-|                              |                  |                    |                   | Release |
-|                              |                  |                    +-------------------+---------+
-|                              |                  |                    | Default + MATLAB  | Release |
-|                              |                  +--------------------+-------------------+---------+
-|                              |                  | | Clang 3.9        | Default           | Debug   |
-|                              |                  | | Java 1.8         |                   +---------+
-|                              |                  |                    |                   | Release |
-+------------------------------+------------------+--------------------+-------------------+---------+
-| Ubuntu 16.04 LTS ("Xenial")  | | CMake 3.5.1    | | GCC 5.4          | Default           | Debug   |
-|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
-|                              |                  |                    |                   | Release |
-|                              |                  +--------------------+-------------------+---------+
-|                              |                  | | Clang 3.9        | Default           | Debug   |
-|                              |                  | | Java 1.8         |                   +---------+
-|                              |                  |                    |                   | Release |
-+------------------------------+------------------+--------------------+-------------------+---------+
-| OS X 10.11 ("El Capitan")    | | CMake 3.5.2    | | Apple Clang 7.0  | Minimal           | Debug   |
-|                              | | Bazel 0.5.2    | | Java 1.8         |                   +---------+
-|                              |                  |                    |                   | Release |
-|                              |                  |                    +-------------------+---------+
-|                              |                  |                    | Default           | Debug   |
-|                              |                  |                    |                   +---------+
-|                              |                  |                    |                   | Release |
-+------------------------------+------------------+--------------------+-------------------+---------+
++-----------------------------+---------------+-----------------+------------+-------------------+--------+
+| Operating System            | Build System  | C/C++ Compiler  | Java       | MATLAB (Optional) | Python |
++=============================+===============+=================+============+===================+========+
+| Ubuntu 14.04 LTS ("Trusty") | | Bazel 0.5.2 | | Clang 3.9     | Oracle 1.8 | R2017a            | 2.7.5  |
+|                             | | CMake 3.5.2 | | GCC 4.9       |            |                   |        |
++-----------------------------+---------------+-----------------+------------+-------------------+--------+
+| Ubuntu 16.04 LTS ("Xenial") | | Bazel 0.5.2 | | Clang 3.9     | OpenJDK 8  | R2017a            | 2.7.11 |
+|                             | | CMake 3.5.1 | | GCC 5.4       |            |                   |        |
++-----------------------------+---------------+-----------------+------------+-------------------+--------+
+| OS X 10.11 ("El Capitan")   | | Bazel 0.5.2 | Apple Clang 7.0 | Oracle 1.8 | Not Supported     | 2.7.13 |
+|                             | | CMake 3.5.2 |                 |            |                   |        |
+|                             +---------------+-----------------+            |                   |        |
+|                             | Bazel 0.5.2   | Apple Clang 8.0 |            |                   |        |
++-----------------------------+---------------+-----------------+------------+-------------------+--------+
+| macOS 10.12 ("Sierra")      | Bazel 0.5.2   | Apple Clang 8.1 | Oracle 1.8 | Not Supported     | 2.7.13 |
++-----------------------------+---------------+-----------------+------------+-------------------+--------+
 
 Code Review
 ===========


### PR DESCRIPTION
Formalizes the n, n-1 Mac version support, adds the Xenial MATLAB builds, removes the CMake minimal builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6980)
<!-- Reviewable:end -->
