### PR TITLE
Enable all lint tests in drake/perception/dev

### DIFF
--- a/drake/perception/dev/BUILD
+++ b/drake/perception/dev/BUILD
@@ -1,14 +1,12 @@
 # -*- python -*-
 # This file contains rules for Bazel; see drake/doc/bazel.rst.
 
-load("//tools:cpplint.bzl", "cpplint")
 load(
     "//tools:drake.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
-    "drake_cc_binary",
 )
-load("//tools:python_lint.bzl", "python_lint")
+load("//tools:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -39,6 +37,7 @@ drake_cc_library(
 )
 
 # === test/ ===
+
 drake_cc_googletest(
     name = "feedforward_neural_network_test",
     srcs = ["test/feedforward_neural_network_test.cc"],
@@ -47,3 +46,5 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
     ],
 )
+
+add_lint_tests()

--- a/drake/perception/dev/BUILD
+++ b/drake/perception/dev/BUILD
@@ -13,39 +13,37 @@ load("//tools:python_lint.bzl", "python_lint")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
-  name = "neural_network",
-  srcs = [
-          ],
-  hdrs = [
-          "neural_network.h",
-          ],
-  deps = [
-          "//drake/systems/framework",
-         ],
+    name = "neural_network",
+    srcs = [
+    ],
+    hdrs = [
+        "neural_network.h",
+    ],
+    deps = [
+        "//drake/systems/framework",
+    ],
 )
 
 drake_cc_library(
-  name = "feedforward_neural_network",
-  srcs = [
-          "feedforward_neural_network.cc",
-          ],
-  hdrs = [
-          "feedforward_neural_network.h",
-          ],
-  deps = [
-          ":neural_network",
-          "//drake/systems/framework",
-         ],
+    name = "feedforward_neural_network",
+    srcs = [
+        "feedforward_neural_network.cc",
+    ],
+    hdrs = [
+        "feedforward_neural_network.h",
+    ],
+    deps = [
+        ":neural_network",
+        "//drake/systems/framework",
+    ],
 )
-
 
 # === test/ ===
 drake_cc_googletest(
-  name = "feedforward_neural_network_test",
-  srcs = ["test/feedforward_neural_network_test.cc"],
-  deps = [
-          ":feedforward_neural_network",
-          "//drake/common:eigen_matrix_compare",
-          ],
+    name = "feedforward_neural_network_test",
+    srcs = ["test/feedforward_neural_network_test.cc"],
+    deps = [
+        ":feedforward_neural_network",
+        "//drake/common:eigen_matrix_compare",
+    ],
 )
-

--- a/drake/perception/dev/feedforward_neural_network.cc
+++ b/drake/perception/dev/feedforward_neural_network.cc
@@ -241,5 +241,5 @@ void FeedforwardNeuralNetwork<T>::WriteOutput(const VectorX<T> value,
 template class FeedforwardNeuralNetwork<double>;
 template class FeedforwardNeuralNetwork<AutoDiffXd>;
 
-}  // namespace automotive
+}  // namespace perception
 }  // namespace drake

--- a/drake/perception/dev/feedforward_neural_network.h
+++ b/drake/perception/dev/feedforward_neural_network.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <memory>
+
+#include <Eigen/Dense>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/perception/dev/neural_network.h"
 #include "drake/systems/framework/leaf_system.h"
-
-#include <Eigen/Dense>
 
 namespace drake {
 namespace perception {

--- a/drake/perception/dev/feedforward_neural_network.h
+++ b/drake/perception/dev/feedforward_neural_network.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/Dense>
 
@@ -92,5 +93,5 @@ class FeedforwardNeuralNetwork : public NeuralNetwork<T> {
   int num_layers_;
 };
 
-}  // namespace automotive
+}  // namespace perception
 }  // namespace drake

--- a/drake/perception/dev/test/feedforward_neural_network_test.cc
+++ b/drake/perception/dev/test/feedforward_neural_network_test.cc
@@ -1,9 +1,13 @@
 #include "drake/perception/dev/feedforward_neural_network.h"
+
 #include <stdlib.h>
+
 #include <iostream>
 #include <memory>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
+
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
 


### PR DESCRIPTION
I noticed this when I ran `tools/buildifier.sh` (with arguments, so for the whole tree) and it made a changed to a file from `master`!  That is not supposed to happen.

For the cpplint checks in a `dev` folder, developers may globally opt-out by warning name or filename using a `CPPLINT.cfg` in that folder if desired, but the build system should always have `add_lint_tests()` enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6983)
<!-- Reviewable:end -->
