### PR TITLE
Apply test/CPPLINT.cfg by default when available

### DIFF
--- a/tools/cpplint.bzl
+++ b/tools/cpplint.bzl
@@ -50,8 +50,14 @@ def _add_linter_rules(source_labels, source_filenames, name, data = None):
     size = "small"
     tags = ["cpplint", "lint"]
 
+    # For cpplint, require a top-level config file.  By default, also apply
+    # configs from the current directory and test sub-directory when present.
+    cpplint_cfg = ["//:CPPLINT.cfg"] + native.glob([
+        'CPPLINT.cfg',
+        'test/CPPLINT.cfg',
+    ])
+
     # Google cpplint.
-    cpplint_cfg = ["//:CPPLINT.cfg"] + native.glob(['CPPLINT.cfg'])
     native.py_test(
         name = name + "_cpplint",
         srcs = ["@google_styleguide//:cpplint"],


### PR DESCRIPTION
The thought being that since `drake_cc_googletest` looks in `test/foo_test.cc` by default, looking for cpplint configs there as well by default would be consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6984)
<!-- Reviewable:end -->
