### PR TITLE
[Multilane] Adds r0 lateral displacement to Lanes 

### DIFF
--- a/drake/automotive/maliput/multilane/BUILD
+++ b/drake/automotive/maliput/multilane/BUILD
@@ -30,6 +30,7 @@ drake_cc_library(
         "junction.cc",
         "lane.cc",
         "line_road_curve.cc",
+        "road_curve.cc",
         "road_geometry.cc",
         "segment.cc",
     ],

--- a/drake/automotive/maliput/multilane/builder.cc
+++ b/drake/automotive/maliput/multilane/builder.cc
@@ -242,10 +242,9 @@ Lane* Builder::BuildConnection(
   }
   api::LaneId lane_id{std::string("l:") + conn->id()};
   Segment* segment = junction->NewSegment(
-      api::SegmentId{std::string("s:") + conn->id()},
-      std::move(road_curve));
-  Lane* lane = segment->NewLane(lane_id, lane_bounds_, driveable_bounds_,
-                                elevation_bounds_);
+      api::SegmentId{std::string("s:") + conn->id()}, std::move(road_curve),
+      driveable_bounds_.min(), driveable_bounds_.max(), elevation_bounds_);
+  Lane* lane = segment->NewLane(lane_id, 0., lane_bounds_);
   AttachBranchPoint(
       conn->start(), lane, api::LaneEnd::kStart, road_geometry, bp_map);
   AttachBranchPoint(

--- a/drake/automotive/maliput/multilane/junction.cc
+++ b/drake/automotive/maliput/multilane/junction.cc
@@ -12,9 +12,11 @@ const api::RoadGeometry* Junction::do_road_geometry() const {
 
 
 Segment* Junction::NewSegment(api::SegmentId id,
-                              std::unique_ptr<RoadCurve> road_curve) {
-  segments_.push_back(std::make_unique<Segment>(id, this,
-                                                std::move(road_curve)));
+                              std::unique_ptr<RoadCurve> road_curve,
+                              double r_min, double r_max,
+                              const api::HBounds elevation_bounds) {
+  segments_.push_back(std::make_unique<Segment>(
+      id, this, std::move(road_curve), r_min, r_max, elevation_bounds));
   return segments_.back().get();
 }
 

--- a/drake/automotive/maliput/multilane/junction.h
+++ b/drake/automotive/maliput/multilane/junction.h
@@ -30,9 +30,15 @@ class Junction : public api::Junction {
   /// Creates and adds a new Segment with the specified @p id and @p road_curve.
   /// @param id Segment's ID.
   /// @param road_curve Reference trajectory over the Segment's surface.
+  /// @param r_min Lateral distance to the minimum extent of road_curve's curve
+  /// from where Segment's surface starts.
+  /// @param r_max Lateral distance to the maximum extent of road_curve's curve
+  /// from where Segment's surface ends.
+  /// @param elevation_bounds The height bounds over the segment' surface.
   /// @return A Segment object.
-  Segment* NewSegment(api::SegmentId id,
-                      std::unique_ptr<RoadCurve> road_curve);
+  Segment* NewSegment(api::SegmentId id, std::unique_ptr<RoadCurve> road_curve,
+                      double r_min, double r_max,
+                      const api::HBounds elevation_bounds);
 
   ~Junction() override = default;
 

--- a/drake/automotive/maliput/multilane/lane.cc
+++ b/drake/automotive/maliput/multilane/lane.cc
@@ -1,5 +1,7 @@
 #include "drake/automotive/maliput/multilane/lane.h"
 
+#include <cmath>
+
 #include "drake/automotive/maliput/multilane/branch_point.h"
 #include "drake/common/drake_assert.h"
 
@@ -34,122 +36,38 @@ std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
 }
 
 
-double Lane::do_length() const {
-  return road_curve_->trajectory_length();
-}
-
-
-Rot3 Lane::Rabg_of_p(const double p) const {
-  return Rot3(road_curve_->superelevation().f_p(p) * road_curve_->p_scale(),
-              -std::atan(road_curve_->elevation().f_dot_p(p)),
-              road_curve_->heading_of_p(p));
-}
-
-
-double Lane::p_from_s(const double s) const {
-  return road_curve_->elevation().p_s(s / road_curve_->p_scale());
-}
-
-
-V3 Lane::W_prime_of_prh(const double p, const double r, const double h,
-                        const Rot3& Rabg) const {
-  const V2 G_prime = road_curve_->xy_dot_of_p(p);
-  const double g_prime = road_curve_->elevation().f_dot_p(p);
-
-  const Rot3& R = Rabg;
-  const double alpha = R.roll();
-  const double beta = R.pitch();
-  const double gamma = R.yaw();
-
-  const double ca = std::cos(alpha);
-  const double cb = std::cos(beta);
-  const double cg = std::cos(gamma);
-  const double sa = std::sin(alpha);
-  const double sb = std::sin(beta);
-  const double sg = std::sin(gamma);
-
-  // Evaluate dα/dp, dβ/dp, dγ/dp...
-  const double d_alpha = road_curve_->superelevation().f_dot_p(p) *
-                         road_curve_->p_scale();
-  const double d_beta = -cb * cb * road_curve_->elevation().f_ddot_p(p);
-  const double d_gamma = road_curve_->heading_dot_of_p(p);
-
-  // Recall that W is the lane-to-world transform, defined by
-  //   (x,y,z)  = W(p,r,h) = (G(p), Z(p)) + R_αβγ*(0,r,h)
-  // where G is the reference curve, Z is the elevation profile, and R_αβγ is
-  // a rotation matrix derived from reference curve (heading), elevation,
-  // and superelevation.
-  //
-  // Thus, ∂W/∂p = (∂G(p)/∂p, ∂Z(p)/∂p) + (∂R_αβγ/∂p)*(0,r,h), where
-  //
-  //   ∂G(p)/∂p = G'(p)
-  //
-  //   ∂Z(p)/∂p = p_scale * (z / p_scale) = p_scale * g'(p)
-  //
-  //   ∂R_αβγ/∂p = (∂R_αβγ/∂α ∂R_αβγ/∂β ∂R_αβγ/∂γ)*(dα/dp, dβ/dp, dγ/dp)
-  return
-      V3(G_prime.x(),
-         G_prime.y(),
-         road_curve_->p_scale() * g_prime) +
-
-      V3((((sa*sg)+(ca*sb*cg))*r + ((ca*sg)-(sa*sb*cg))*h),
-         (((-sa*cg)+(ca*sb*sg))*r - ((ca*cg)+(sa*sb*sg))*h),
-         ((ca*cb)*r + (-sa*cb)*h))
-      * d_alpha +
-
-      V3(((sa*cb*cg)*r + (ca*cb*cg)*h),
-         ((sa*cb*sg)*r + (ca*cb*sg)*h),
-         ((-sa*sb)*r - (ca*sb)*h))
-      * d_beta +
-
-      V3((((-ca*cg)-(sa*sb*sg))*r + ((+sa*cg)-(ca*sb*sg))*h),
-         (((-ca*sg)+(sa*sb*cg))*r + ((sa*sg)+(ca*sb*cg))*h),
-         0)
-      * d_gamma;
-}
-
-
-V3 Lane::s_hat_of_prh(const double p, const double r, const double h,
-                      const Rot3& Rabg) const {
-  const V3 W_prime = W_prime_of_prh(p, r, h, Rabg);
-  return W_prime * (1.0 / W_prime.norm());
-}
-
-
-V3 Lane::r_hat_of_Rabg(const Rot3& Rabg) const {
-  return Rabg.apply({0., 1., 0.});
-}
-
+double Lane::do_length() const { return road_curve_->s_from_p(1., r0_); }
 
 api::GeoPosition Lane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
   // Recover parameter p from arc-length position s.
-  const double p = p_from_s(lane_pos.s());
+  const double p = road_curve_->p_from_s(lane_pos.s(), r0_);
   // Calculate z (elevation) of (s,0,0);
   const double z = road_curve_->elevation().f_p(p) * road_curve_->p_scale();
   // Calculate x,y of (s,0,0).
   const V2 xy = road_curve_->xy_of_p(p);
   // Calculate orientation of (s,r,h) basis at (s,0,0).
-  const Rot3 ypr = Rabg_of_p(p);
+  const Rot3 ypr = road_curve_->Rabg_of_p(p);
 
   // Rotate (0,r,h) and sum with mapped (s,0,0).
   const V3 xyz =
-      ypr.apply({0., lane_pos.r(), lane_pos.h()}) + V3(xy.x(), xy.y(), z);
+      ypr.apply({0., lane_pos.r() + r0_, lane_pos.h()}) + V3(xy.x(), xy.y(), z);
   return {xyz.x(), xyz.y(), xyz.z()};
 }
 
 
 api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
   // Recover linear parameter p from arc-length position s.
-  const double p = p_from_s(lane_pos.s());
-  const double r = lane_pos.r();
+  const double p = road_curve_->p_from_s(lane_pos.s(), r0_);
+  const double r = lane_pos.r() + r0_;
   const double h = lane_pos.h();
   // Calculate orientation of (s,r,h) basis at (s,0,0).
-  const Rot3 Rabg = Rabg_of_p(p);
+  const Rot3 Rabg = road_curve_->Rabg_of_p(p);
+  const double real_g_prime = road_curve_->elevation().f_dot_p(p);
 
   // Calculate s,r basis vectors at (s,r,h)...
-  const V3 s_hat = s_hat_of_prh(p, r, h, Rabg);
-  const V3 r_hat = r_hat_of_Rabg(Rabg);
+  const V3 s_hat = road_curve_->s_hat_of_prh(p, r, h, Rabg, real_g_prime);
+  const V3 r_hat = road_curve_->r_hat_of_Rabg(Rabg);
   // ...and then derive orientation from those basis vectors.
   //
   // (s_hat  r_hat  h_hat) is an orthonormal basis, obtained by rotating the
@@ -179,23 +97,23 @@ api::LanePosition Lane::DoEvalMotionDerivatives(
     const api::LanePosition& position,
     const api::IsoLaneVelocity& velocity) const {
 
-  const double p = p_from_s(position.s());
-  const double r = position.r();
+  const double p = road_curve_->p_from_s(position.s(), r0_);
+  const double r = position.r() + r0_;
   const double h = position.h();
+  const Rot3 R = road_curve_->Rabg_of_p(p);
+  // TODO(maddog@tri.global)  When s(p) is integrated properly,
+  //                          fake_g_prime should be replaced by real_g_prime.
+  const double real_g_prime = road_curve_->elevation().f_dot_p(p);
+  const double fake_g_prime = road_curve_->elevation().fake_gprime(p);
 
-  // TODO(maddog@tri.global)  When s(p) is integrated properly, do this:
-  //                          const double g_prime = elevation().fdot_p(p);
-  const double g_prime = road_curve_->elevation().fake_gprime(p);
-
-  const Rot3 R = Rabg_of_p(p);
-  const V3 W_prime = W_prime_of_prh(p, r, h, R);
-
-  // The definition of path-length of a path along σ yields dσ = |∂W/∂p| dp.
-  // Similarly, path-length s along the road at r = 0 is related to the
-  // elevation by ds = p_scale * sqrt(1 + g'^2) dp. Chaining yields
-  // ds/dσ:
-  const double ds_dsigma = road_curve_->p_scale() *
-                           std::sqrt(1 + (g_prime * g_prime)) / W_prime.norm();
+  // The definition of path-length of a path along σ yields dσ = |∂W/∂p| dp
+  // evaluated at (p, r, h).
+  // Similarly, path-length s along the segment surface at r = r0 (which is
+  // along the Lane's centerline) is related to p by ds = |∂W/∂p| dp evaluated
+  // at (p, r0, 0).  Chaining yields ds/dσ:
+  const double ds_dsigma =
+      road_curve_->W_prime_of_prh(p, r0_, 0, R, fake_g_prime).norm() /
+      road_curve_->W_prime_of_prh(p, r, h, R, real_g_prime).norm();
 
   return api::LanePosition(ds_dsigma * velocity.sigma_v,
                            velocity.rho_v,
@@ -206,9 +124,22 @@ api::LanePosition Lane::DoToLanePosition(
       const api::GeoPosition& geo_position,
       api::GeoPosition* nearest_position,
       double* distance) const {
-  const api::LanePosition lane_position = api::LanePosition::FromSrh(
-      road_curve_->ToCurveFrame(
-          geo_position.xyz(), driveable_bounds_, elevation_bounds_));
+  // Computes the lateral extents of the surface in terms of the definition of
+  // the reference curve. It implies a translation of the driveable bounds
+  // center by the lane by r0 distance.
+  const double r_min = driveable_bounds_.min() + r0_;
+  const double r_max = driveable_bounds_.max() + r0_;
+  // Lane position is over the segment's road curve frame, so a change is
+  // needed. That implies getting the path length s from p and translating the r
+  // coordinate because of the offset.
+  const V3 lane_position_in_segment_curve_frame = road_curve_->ToCurveFrame(
+      geo_position.xyz(), r_min, r_max, elevation_bounds_);
+  const double s = road_curve_->s_from_p(
+      lane_position_in_segment_curve_frame[0], r0_);
+  const api::LanePosition lane_position = api::LanePosition(
+      s,
+      lane_position_in_segment_curve_frame[1] - r0_,
+      lane_position_in_segment_curve_frame[2]);
 
   const api::GeoPosition nearest = ToGeoPosition(lane_position);
   if (nearest_position != nullptr) {
@@ -221,7 +152,6 @@ api::LanePosition Lane::DoToLanePosition(
 
   return lane_position;
 }
-
 
 }  // namespace multilane
 }  // namespace maliput

--- a/drake/automotive/maliput/multilane/lane.h
+++ b/drake/automotive/maliput/multilane/lane.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <cmath>
 #include <memory>
-
-#include <Eigen/Dense>
 
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
@@ -13,7 +10,6 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
-#include "drake/math/roll_pitch_yaw.h"
 
 namespace drake {
 namespace maliput {
@@ -23,29 +19,6 @@ class BranchPoint;
 
 typedef Vector2<double> V2;
 typedef Vector3<double> V3;
-
-/// An R^3 rotation parameterized by roll, pitch, yaw.
-///
-/// This effects a compound rotation around space-fixed x-y-z axes:
-///
-///   Rot3(yaw,pitch,roll) * V = RotZ(yaw) * RotY(pitch) * RotX(roll) * V
-class Rot3 {
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Rot3)
-
-  Rot3(double roll, double pitch, double yaw) : rpy_(roll, pitch, yaw) {}
-
-  /// Applies the rotation to a 3-vector.
-  V3 apply(const V3& in) const { return math::rpy2rotmat(rpy_) * in; }
-
-  double yaw() const { return rpy_(2); }
-  double pitch() const { return rpy_(1); }
-  double roll() const { return rpy_(0); }
-
- private:
-  Eigen::Matrix<double, 3, 1, Eigen::DontAlign> rpy_;
-};
-
 
 /// Base class for the multilane implementation of api::Lane.
 class Lane : public api::Lane {
@@ -65,6 +38,8 @@ class Lane : public api::Lane {
   ///        entire driveable surface
   /// @param road_curve The trajectory of the Lane over parent @p segment's
   ///        surface.
+  /// @param r0 The lateral displacement with respect to the @p road_curve's
+  ///        reference curve.
   ///
   /// N.B. The override Lane::ToLanePosition() is currently restricted to lanes
   /// in which superelevation and elevation change are both zero.
@@ -72,19 +47,21 @@ class Lane : public api::Lane {
        const api::RBounds& lane_bounds,
        const api::RBounds& driveable_bounds,
        const api::HBounds& elevation_bounds,
-       const RoadCurve *road_curve)
+       const RoadCurve* road_curve,
+       double r0)
       : id_(id), segment_(segment),
         lane_bounds_(lane_bounds),
         driveable_bounds_(driveable_bounds),
         elevation_bounds_(elevation_bounds),
-        road_curve_(road_curve) {
+        road_curve_(road_curve),
+        r0_(r0) {
     DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
     DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
     DRAKE_DEMAND(road_curve != nullptr);
   }
 
-  // TODO(maddog@tri.global)  Allow superelevation to have a center-of-rotation
-  //                          which is different from r = 0.
+  // TODO(maddog-tri)  Allow superelevation to have a center-of-rotation
+  //                   which is different from r = 0.
 
   const CubicPolynomial& elevation() const {
     return road_curve_->elevation();
@@ -153,71 +130,6 @@ class Lane : public api::Lane {
       api::GeoPosition* nearest_position,
       double* distance) const override;
 
-  // The geometry here revolves around an abstract "world function"
-  //
-  //    W: (p,r,h) --> (x,y,z)
-  //
-  // which maps a `Lane`-frame position to its corresponding representation in
-  // world coordinates (with the caveat that instead of the lane's native
-  // longitudinal coordinate 's', the reference curve parameter 'p' is used).
-  //
-  // W is derived from the three functions which define the lane:
-  //
-  //   G: p --> (x,y)     = the reference curve, a.k.a. xy_of_p()
-  //   Z: p --> z / q_max = the elevation function, a.k.a. elevation_
-  //   Θ: p --> θ / q_max = the superelevation function, a.k.a. superelevation_
-  //
-  // as:
-  //
-  //   (x,y,z) = W(p,r,h) = (G(p), Z(p)) + R_αβγ*(0,r,h)
-  //
-  // where R_αβγ is the roll/pitch/yaw rotation given by angles:
-  //
-  //   α = Θ(p)
-  //   β = -atan(dZ/dp) at p
-  //   γ = atan2(dG_y/dp, dG_x/dp) at p
-  //
-  // (R_αβγ is essentially the orientation of the (s,r,h) `Lane`-frame
-  // at a location (s,0,0) on the reference-line of the lane.  However, it
-  // is *not* necessarily the correct orientation at r != 0 or h != 0.)
-  //
-  // The following methods compute various terms derived from the above which
-  // see repeated use.
-  //
-  // Note that xy_of_p(), xy_dot_of_p(), heading_of_p() and heading_dot_of_p(),
-  // as well as the reference to the elevation and superelevation objects live
-  // on the RoadCurve object.
-
-  // Returns the parametric position p along the reference curve corresponding
-  // to longitudinal position @p s along the lane.
-  double p_from_s(const double s) const;
-
-  // Returns the rotation R_αβγ, evaluated at @p p along the reference curve.
-  Rot3 Rabg_of_p(const double p) const;
-
-  // Returns W' = ∂W/∂p, the partial differential of W with respect to p,
-  // evaluated at @p p, @p r, @p h.
-  //
-  // (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
-  // avoid recomputing it.)
-  V3 W_prime_of_prh(const double p, const double r, const double h,
-                    const Rot3& Rabg) const;
-
-  // Returns the s-axis unit-vector, expressed in the world frame,
-  // of the (s,r,h) `Lane`-frame (with respect to the world frame).
-  //
-  // (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
-  // avoid recomputing it.)
-  V3 s_hat_of_prh(const double p, const double r, const double h,
-                  const Rot3& Rabg) const;
-
-  // Returns the r-axis unit-vector, expressed in the world frame,
-  // of the (s,r,h) `Lane`-frame (with respect to the world frame).
-  //
-  // (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
-  // avoid recomputing it.)
-  V3 r_hat_of_Rabg(const Rot3& Rabg) const;
-
   const api::LaneId id_;
   const api::Segment* segment_{};
   BranchPoint* start_bp_{};
@@ -227,6 +139,7 @@ class Lane : public api::Lane {
   const api::RBounds driveable_bounds_;
   const api::HBounds elevation_bounds_;
   const RoadCurve* road_curve_{};
+  const double r0_;
 };
 
 

--- a/drake/automotive/maliput/multilane/line_road_curve.cc
+++ b/drake/automotive/maliput/multilane/line_road_curve.cc
@@ -8,30 +8,50 @@ namespace multilane {
 
 const double LineRoadCurve::kMinimumNorm = 1e-12;
 
+double LineRoadCurve::p_from_s(double s, double r) const {
+  // TODO(@maddog-tri) We should take care of the superelevation() scale that
+  //                   will modify curve's path length.
+  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
+               superelevation().b() == 0. && superelevation().c() == 0. &&
+               superelevation().d() == 0.));
+  unused(r);
+  return elevation().p_s(s / p_scale());
+}
+
+double LineRoadCurve::s_from_p(double p, double r) const {
+  // TODO(@maddog-tri) We should take care of the superelevation() scale that
+  //                   will modify curve's path length.
+  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
+               superelevation().b() == 0. && superelevation().c() == 0. &&
+               superelevation().d() == 0.));
+  unused(r);
+  return p_scale() * elevation().s_p(p);
+}
+
 Vector3<double> LineRoadCurve::ToCurveFrame(
     const Vector3<double>& geo_coordinate,
-    const api::RBounds& lateral_bounds,
+    double r_min, double r_max,
     const api::HBounds& height_bounds) const {
+  DRAKE_DEMAND(r_min <= r_max);
   // TODO(jadecastro): Lift the zero superelevation and zero elevation gradient
   // restriction.
   const Vector2<double> s_unit_vector = dp_ / dp_.norm();
   const Vector2<double> r_unit_vector{-s_unit_vector(1), s_unit_vector(0)};
 
-  const Vector2<double> p(geo_coordinate.x(), geo_coordinate.y());
-  const Vector2<double> lane_origin_to_p = p - p0_;
+  const Vector2<double> q(geo_coordinate.x(), geo_coordinate.y());
+  const Vector2<double> lane_origin_to_q = q - p0_;
 
-  // Compute the distance from `p` to the start of the lane.
-  const double s_unsaturated = lane_origin_to_p.dot(s_unit_vector);
-  const double s = math::saturate(s_unsaturated, 0., p_scale());
-  const double r_unsaturated = lane_origin_to_p.dot(r_unit_vector);
-  const double r = math::saturate(r_unsaturated, lateral_bounds.min(),
-                                  lateral_bounds.max());
+  // Compute the distance from `q` to the start of the lane.
+  const double p_unsaturated = lane_origin_to_q.dot(s_unit_vector) / p_scale();
+  const double p = math::saturate(p_unsaturated, 0., 1.);
+  const double r_unsaturated = lane_origin_to_q.dot(r_unit_vector);
+  const double r = math::saturate(r_unsaturated, r_min, r_max);
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
   const double h_unsaturated = geo_coordinate.z() - elevation().a() * p_scale();
   const double h = math::saturate(h_unsaturated, height_bounds.min(),
                                   height_bounds.max());
-  return Vector3<double>(s, r, h);
+  return Vector3<double>(p, r, h);
 }
 
 }  // namespace multilane

--- a/drake/automotive/maliput/multilane/line_road_curve.h
+++ b/drake/automotive/maliput/multilane/line_road_curve.h
@@ -42,6 +42,10 @@ class LineRoadCurve : public RoadCurve {
 
   ~LineRoadCurve() override = default;
 
+  double p_from_s(double s, double r) const override;
+
+  double s_from_p(double p, double r) const override;
+
   Vector2<double> xy_of_p(double p) const override { return p0_ + p * dp_; }
 
   Vector2<double> xy_dot_of_p(double p) const override {
@@ -63,21 +67,14 @@ class LineRoadCurve : public RoadCurve {
 
   Vector3<double> ToCurveFrame(
       const Vector3<double>& geo_coordinate,
-      const api::RBounds& lateral_bounds,
+      double r_min, double r_max,
       const api::HBounds& height_bounds) const override;
 
-  /// As the reference curve is a line, the curvature radius is infinity at any
-  /// point in the range of p = [0;1] so no value of elevation or superelevation
-  /// may result in a geometry that intersects with itself.
-  /// @param lateral_bounds An api::RBounds object that represents the lateral
-  /// bounds of the surface mapping.
-  /// @param height_bounds An api::HBounds object that represents the elevation
-  /// bounds of the surface mapping.
-  /// @return True.
   bool IsValid(
-      const api::RBounds& lateral_bounds,
+      double r_min, double r_max,
       const api::HBounds& height_bounds) const override {
-    unused(lateral_bounds);
+    unused(r_min);
+    unused(r_max);
     unused(height_bounds);
     return true;
   }

--- a/drake/automotive/maliput/multilane/road_curve.h
+++ b/drake/automotive/maliput/multilane/road_curve.h
@@ -2,25 +2,93 @@
 
 #include <utility>
 
+#include <Eigen/Dense>
+
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
+#include "drake/math/roll_pitch_yaw.h"
 
 namespace drake {
 namespace maliput {
 namespace multilane {
 
+/// An R^3 rotation parameterized by roll, pitch, yaw.
+///
+/// This effects a compound rotation around space-fixed x-y-z axes:
+///
+///   Rot3(roll, pitch, yaw) * V = RotZ(yaw) * RotY(pitch) * RotX(roll) * V
+class Rot3 {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Rot3)
+
+  Rot3(double roll, double pitch, double yaw) : rpy_(roll, pitch, yaw) {}
+
+  /// Applies the rotation to a 3-vector.
+  Vector3<double> apply(const Vector3<double>& in) const {
+    return math::rpy2rotmat(rpy_) * in;
+  }
+
+  double yaw() const { return rpy_(2); }
+  double pitch() const { return rpy_(1); }
+  double roll() const { return rpy_(0); }
+
+ private:
+  Eigen::Matrix<double, 3, 1, Eigen::DontAlign> rpy_;
+};
+
 /// Defines an interface for a path in a Segment object surface. The path is
 /// defined by an elevation and superelevation CubicPolynomial objects and a
-/// reference curve. This reference curve is a C1 function over the z=0 plane.
+/// reference curve. This reference curve is a C1 function in the z=0 plane.
 /// Its domain is constrained in [0;1] interval and it should map a ℝ² curve.
-/// As per notation, p is the parameter of the reference curve, and function
-/// interpolations and function derivatives as well as headings and heading
-/// derivatives are expressed in world coordinates, which is the same frame as
-/// api::GeoPosition.
-/// By implementing this interface the road curve is defined and a complete.
+/// As per notation, p is the parameter of the reference curve, not necessarily
+/// arc length s, and function interpolations and function derivatives as well
+/// as headings and heading derivatives are expressed in world coordinates,
+/// which is the same frame as api::GeoPosition.
+/// By implementing this interface the road curve is defined and complete.
+///
+/// The geometry here revolves around an abstract "world function"
+///
+///    W: (p,r,h) --> (x,y,z)
+///
+/// which maps a `Lane`-frame position to its corresponding representation in
+/// world coordinates (with the caveat that instead of the lane's native
+/// longitudinal coordinate 's', the reference curve parameter 'p' is used).
+///
+/// W is derived from the three functions which define the lane:
+///
+///   G: p --> (x,y)     = the reference curve, a.k.a. xy_of_p()
+///   Z: p --> z / q_max = the elevation function, a.k.a. elevation_
+///   Θ: p --> θ / q_max = the superelevation function, a.k.a. superelevation_
+///
+/// as:
+///
+///   (x,y,z) = W(p,r,h) = (G(p), Z(p)) + R_αβγ*(0,r,h)
+///
+/// where R_αβγ is the roll/pitch/yaw rotation given by angles:
+///
+///   α = Θ(p)
+///   β = -atan(dZ/dp) at p
+///   γ = atan2(dG_y/dp, dG_x/dp) at p
+///
+/// (R_αβγ is essentially the orientation of the (s,r,h) `Lane`-frame
+/// at a location (s,0,0) on the reference-line of the lane.  However, it
+/// is *not* necessarily the correct orientation at r != 0 or h != 0.)
+///
+/// The W(p,r,h) "world function" is defined by the RoadCurve referenced by a
+/// Lane's Segment. A Lane is also defined by a r0 lateral offset with respect
+/// to the reference curve of the RoadCurve. Thus, a mapping from the local
+/// (s,r,h) lane-frame of the Lane becomes:
+///
+/// (x,y,z) = L(s,r,h) = W(P(s, r0), r + r0, h),
+///
+/// where P:(s, r0) --> (p) is a (potentially non-linear) function dependent on
+/// the RoadCurve's reference-curve, elevation, and superelevation functions.
+///
+/// TODO(maddog-tri)  Add support for Lanes with both non-zero r0 and
+///                   superelevation polynomial.
 class RoadCurve {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadCurve)
@@ -31,12 +99,18 @@ class RoadCurve {
 
   const CubicPolynomial& superelevation() const { return superelevation_; }
 
-  /// Computes the composed curve path integral in the interval of p = [0; 1].
+  /// Computes the parametric position p along the reference curve corresponding
+  /// to longitudinal position (in path-length) `s` along a parallel curve
+  /// laterally offset by `r` from the reference curve.
+  /// @return The parametric position p along an offset of the reference curve.
+  virtual double p_from_s(double s, double r) const = 0;
+
+  /// Computes the path length integral in the interval of the parameter [0; p]
+  /// and along a parallel curve laterally offset by `r` the planar reference
+  /// curve.
   /// @return The path length integral of the curve composed with the elevation
   /// polynomial.
-  double trajectory_length() const {
-    return elevation_.s_p(1.0) * p_scale();
-  }
+  virtual double s_from_p(double p, double r) const = 0;
 
   /// Computes the reference curve.
   /// @param p The reference curve parameter.
@@ -65,41 +139,76 @@ class RoadCurve {
   /// Computes the path length integral of the reference curve for the interval
   /// [0;1] of p.
   /// @return The path length integral of the reference curve.
+  // TODO(maddog-tri)  This method should be renamed to match the Maliput's
+  //                   documentation as well as other variable names along the
+  //                   implementation.
   virtual double p_scale() const = 0;
 
   /// Converts a @p geo_coordinate in the world frame to the composed curve
   /// frame, i.e., the superposition of the reference curve, elevation and
-  /// superelevation polynomials. The resulting coordinates are saturated to
-  /// @p lateral_bounds and @p height_bounds in the lateral and vertical
-  /// directions over the composed curve trajectory. The path length coordinate
-  /// is saturated in the interval [0; trajectory_length()].
+  /// superelevation polynomials. The resulting coordinates [p, r, h] are
+  /// saturated in the following domain ranges.
+  ///
+  /// - p: [0, 1]
+  /// - r: [@p r_min, @p r_max]
+  /// - h: [@p height_bounds]
   /// @param geo_coordinate A 3D vector in the world frame to be converted to
   /// the composed curve frame.
-  /// @param lateral_bounds An api::RBounds object that represents the lateral
-  /// bounds of the surface mapping.
+  /// @param r_min Minimum lateral distance from the composed curve to saturate,
+  /// if it is necessary, the result in the given direction.
+  /// @param r_max Maximum lateral distance from the composed curve to evaluate,
+  /// if it is necessary, the result in the given direction
   /// @param height_bounds An api::HBounds object that represents the elevation
   /// bounds of the surface mapping.
-  /// @return A 3D vector that represents the coordinates with respect to the
-  /// composed curve. The first dimension represents the path length coordinate,
-  /// the second dimension is the lateral deviation from the composed curve and
-  /// the third one is the vertical deviation from the composed curve too. The
-  /// frame where this vector is defined is the same as api::LanePosition.
+  /// @return A 3D vector [p, r, h], that represent the domain coordinates of
+  /// the world function, that gives as world function output @p geo_cooridnate.
   virtual Vector3<double> ToCurveFrame(
       const Vector3<double>& geo_coordinate,
-      const api::RBounds& lateral_bounds,
+      double r_min, double r_max,
       const api::HBounds& height_bounds) const = 0;
 
   /// Checks that there are no self-intersections (singularities) in the volume
-  /// created by applying the constant @p lateral_bounds and @p height_bounds to
-  /// the RoadCurve.
-  /// @param lateral_bounds An api::RBounds object that represents the lateral
-  /// bounds of the surface mapping.
+  /// created by applying the constant @p r_min, @p r_max and @p height_bounds
+  /// to the RoadCurve.
+  /// @param r_min Minimum lateral distance from the composed curve to evaluate
+  /// the validity of the geometry.
+  /// @param r_max Maximum lateral distance from the composed curve to evaluate
+  /// the validity of the geometry.
   /// @param height_bounds An api::HBounds object that represents the elevation
   /// bounds of the surface mapping.
   /// @return True when there are no self-intersections.
-  virtual bool IsValid(
-      const api::RBounds& lateral_bounds,
-      const api::HBounds& height_bounds) const = 0;
+  virtual bool IsValid(double r_min, double r_max,
+                       const api::HBounds& height_bounds) const = 0;
+
+  /// Returns the rotation R_αβγ, evaluated at @p p along the reference curve.
+  Rot3 Rabg_of_p(const double p) const;
+
+  /// Returns W' = ∂W/∂p, the partial differential of W with respect to p,
+  /// evaluated at @p p, @p r, @p h.
+  ///
+  /// (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
+  /// avoid recomputing it.)
+  /// (@p g_prime must be the result of elevation().f_dot_p(p) --- passed in
+  /// here to avoid recomputing it.)
+  Vector3<double> W_prime_of_prh(double p, double r, double h, const Rot3& Rabg,
+                                 double g_prime) const;
+
+  /// Returns the s-axis unit-vector, expressed in the world frame,
+  /// of the (s,r,h) `Lane`-frame (with respect to the world frame).
+  ///
+  /// (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
+  /// avoid recomputing it.)
+  /// (@p g_prime must be the result of elevation().f_dot_p(p) --- passed in
+  /// here to avoid recomputing it.)
+  Vector3<double> s_hat_of_prh(double p, double r, double h, const Rot3& Rabg,
+                               double g_prime) const;
+
+  /// Returns the r-axis unit-vector, expressed in the world frame,
+  /// of the (s,r,h) `Lane`-frame (with respect to the world frame).
+  ///
+  /// (@p Rabg must be the result of Rabg_of_p(p) --- passed in here to
+  /// avoid recomputing it.)
+  Vector3<double> r_hat_of_Rabg(const Rot3& Rabg) const;
 
  protected:
   /// Constructs a road curve given elevation and superelevation curves.

--- a/drake/automotive/maliput/multilane/segment.cc
+++ b/drake/automotive/maliput/multilane/segment.cc
@@ -8,13 +8,15 @@ const api::Junction* Segment::do_junction() const {
   return junction_;
 }
 
-Lane* Segment::NewLane(api::LaneId id,
-                       const api::RBounds& lane_bounds,
-                       const api::RBounds& driveable_bounds,
-                       const api::HBounds& elevation_bounds) {
+Lane* Segment::NewLane(api::LaneId id, double r0,
+                       const api::RBounds& lane_bounds) {
   DRAKE_DEMAND(lane_.get() == nullptr);
+  DRAKE_DEMAND(r_min_ <= r0 && r0 <= r_max_);
+  const api::RBounds driveable_bounds(r_min_ - r0, r_max_ - r0);
+  DRAKE_DEMAND(lane_bounds.min() >= driveable_bounds.min() &&
+               lane_bounds.max() <= driveable_bounds.max());
   lane_ = std::make_unique<Lane>(id, this, lane_bounds, driveable_bounds,
-                                 elevation_bounds, road_curve_.get());
+                                 elevation_bounds_, road_curve_.get(), r0);
   return lane_.get();
 }
 

--- a/drake/automotive/maliput/multilane/test/multilane_lanes_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_lanes_test.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include <cmath>
+#include <map>
 
 #include <gtest/gtest.h>
 
@@ -36,21 +37,46 @@ GTEST_TEST(MultilaneLanesTest, Rot3) {
 }
 
 
-GTEST_TEST(MultilaneLanesTest, FlatLineLane) {
-  CubicPolynomial zp {0., 0., 0., 0.};
-  const double kHalfWidth = 10.;
-  const double kMaxHeight = 5.;
+class MultilaneLanesParamTest : public ::testing::TestWithParam<double> {
+ protected:
+  void SetUp() override {
+    r0 = this->GetParam();
+  }
+
+  const CubicPolynomial zp{0., 0., 0., 0.};
+  const double kHalfWidth{10.};
+  const double kMaxHeight{5.};
+  const double kHalfLaneWidth{5.};
+  double r0{};
+  // NB:  kIntegrationScaleMap and kIntegrationFactorMap are regression
+  //      coefficients to match within the integration tolerance the path
+  //      integral of motion derivatives of the lane. The key of the maps is the
+  //      lateral offset r0 and value are scale and factor respectively.
+  const std::map<double, int> kIntegrationScaleMap{
+      {0., 158597}, {5., 150822}, {-5., 166380}};
+  // NB:  '287' is a fudge-factor.  We know the steps should scale roughly
+  //      as (r / r0), but not exactly because of the elevation curve.
+  //      Mostly, we are testing that we end up in the right place in
+  //      roughly the right number of steps. The same applies for -8017 and
+  //      9373 for other offsets.
+  const std::map<double, int> kIntegrationFactorMap{
+      {0., 287}, {5., -8017}, {-5., 9373}};
+};
+
+TEST_P(MultilaneLanesParamTest, FlatLineLane) {
   RoadGeometry rg(api::RoadGeometryId{"apple"},
                   kLinearTolerance, kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<LineRoadCurve>(
       Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp);
-  Segment* s1 =
-      rg.NewJunction(api::JunctionId{"j1"})
-      ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1));
+  const Vector3<double> s_vector = Vector3<double>(100., 50., 0.).normalized();
+  const Vector3<double> r_vector = Vector3<double>(-50, 100., 0.).normalized();
+  const Vector3<double> r_offset_vector = r0 * r_vector;
+  Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
+                    ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
   Lane* l1 =
-      s1->NewLane(api::LaneId{"l1"},
-                  // lane/driveable/elevation bounds
-                  {-5., 5.}, {-kHalfWidth, kHalfWidth}, {0., kMaxHeight});
+      s1->NewLane(api::LaneId{"l1"}, r0, {-kHalfLaneWidth, kHalfLaneWidth});
 
   EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
 
@@ -62,41 +88,52 @@ GTEST_TEST(MultilaneLanesTest, FlatLineLane) {
 
   EXPECT_NEAR(l1->length(), std::sqrt((100. * 100) + (50. * 50.)), kVeryExact);
 
-  EXPECT_TRUE(api::test::IsRBoundsClose(l1->lane_bounds(0.),
-                                        api::RBounds(-5., 5.),
-                                        kVeryExact));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      l1->lane_bounds(0.), api::RBounds(-kHalfLaneWidth, kHalfLaneWidth),
+      kVeryExact));
   EXPECT_TRUE(api::test::IsRBoundsClose(l1->driveable_bounds(0.),
-                                  api::RBounds(-10., 10.), kVeryExact));
-  EXPECT_TRUE(api::test::IsHBoundsClose(l1->elevation_bounds(0., 0.),
-                                  api::HBounds(0., 5.), kVeryExact));
+                                        api::RBounds(-kHalfWidth, kHalfWidth),
+                                        kVeryExact));
+  EXPECT_TRUE(api::test::IsHBoundsClose(
+      l1->elevation_bounds(0., 0.), api::HBounds(0., kMaxHeight), kVeryExact));
 
-  EXPECT_TRUE(api::test::IsGeoPositionClose(l1->ToGeoPosition({0., 0., 0.}),
-                                       api::GeoPosition(100., -75., 0.),
-                                       kLinearTolerance));
+  EXPECT_TRUE(api::test::IsGeoPositionClose(
+      l1->ToGeoPosition({0., 0., 0.}),
+      api::GeoPosition::FromXyz(Vector3<double>(100., -75., 0.) +
+                                r_offset_vector),
+      kLinearTolerance));
 
   // A little bit along the lane, but still on the reference line.
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l1->ToGeoPosition({1., 0., 0.}),
-      api::GeoPosition(100. + ((100. / l1->length()) * 1.),
-                       -75. + ((50. / l1->length()) * 1.), 0.),
+      api::GeoPosition::FromXyz(
+          Vector3<double>(100. + ((100. / l1->length()) * 1.),
+                          -75. + ((50. / l1->length()) * 1.), 0.) +
+          r_offset_vector),
       kLinearTolerance));
   // At the very beginning of the lane, but laterally off the reference line.
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l1->ToGeoPosition({0., 3., 0.}),
-      api::GeoPosition(100. + ((-50. / l1->length()) * 3.),
-                       -75. + ((100. / l1->length()) * 3.), 0.),
+      api::GeoPosition::FromXyz(
+          Vector3<double>(100. + ((-50. / l1->length()) * 3.),
+                          -75. + ((100. / l1->length()) * 3.), 0.) +
+          r_offset_vector),
       kLinearTolerance));
   // At the very end of the lane.
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l1->ToGeoPosition({l1->length(), 0., 0.}),
-      api::GeoPosition(200., -25., 0.), kLinearTolerance));
+      api::GeoPosition(Vector3<double>(200., -25., 0.) + r_offset_vector),
+      kLinearTolerance));
   // Case 1: Tests LineLane::ToLanePosition() with a closest point that lies
   // within the lane bounds.
   const api::GeoPosition point_within_lane{148., -46., 0.};
   api::GeoPosition nearest_position;
   double distance{};
-  const double expected_s = 0.5 * l1->length();
-  const double expected_r = std::sqrt(std::pow(2., 2.) + std::pow(4., 2.));
+  const Vector3<double> d_point_lane_origin = point_within_lane.xyz() -
+                                              Vector3<double>(100., -75., 0.) -
+                                              r_offset_vector;
+  const double expected_s = d_point_lane_origin.dot(s_vector);
+  const double expected_r = d_point_lane_origin.dot(r_vector);
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l1->ToLanePosition(point_within_lane, &nearest_position, &distance),
       api::LanePosition(expected_s, expected_r, 0.), kVeryExact));
@@ -108,18 +145,17 @@ GTEST_TEST(MultilaneLanesTest, FlatLineLane) {
   // outside of the lane bounds, verifying that the result saturates.
   const api::GeoPosition point_outside_lane{-75., 25., 20.};
   const double expected_r_outside = kHalfWidth;
-  const double x_dist_to_edge = kHalfWidth * std::sin(std::atan(0.5));
-  const double y_dist_to_edge = kHalfWidth * std::cos(std::atan(0.5));
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l1->ToLanePosition(point_outside_lane, &nearest_position, &distance),
       api::LanePosition(0., expected_r_outside, kMaxHeight), kVeryExact));
+  const Vector3<double> extreme_lane_point =
+      Vector3<double>(100., -75, 0.0) + r_offset_vector +
+      kHalfWidth * r_vector.normalized() +
+      Vector3<double>(0., 0., kMaxHeight);
   EXPECT_TRUE(api::test::IsGeoPositionClose(
-      nearest_position, api::GeoPosition(100. - x_dist_to_edge,
-                                         -75. + y_dist_to_edge, kMaxHeight),
+      nearest_position, api::GeoPosition::FromXyz(extreme_lane_point),
       kVeryExact));
-  EXPECT_NEAR(distance, std::sqrt(std::pow(175. - x_dist_to_edge, 2.) +
-                                  std::pow(100. - y_dist_to_edge, 2.) +
-                                  std::pow(20. - kMaxHeight, 2.)),
+  EXPECT_NEAR(distance, (point_outside_lane.xyz() - extreme_lane_point).norm(),
               kVeryExact);
 
   // Case 3: Tests LineLane::ToLanePosition() at a non-zero but flat elevation.
@@ -128,25 +164,25 @@ GTEST_TEST(MultilaneLanesTest, FlatLineLane) {
   std::unique_ptr<RoadCurve> road_curve_2 = std::make_unique<LineRoadCurve>(
       Vector2<double>(100., -75.), Vector2<double>(100., 50.),
       CubicPolynomial(elevation / length, 0.0, 0.0, 0.0), zp);
-  Segment* s2 =
-      rg.NewJunction(api::JunctionId{"j2"})
-      ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2));
-  Lane* l1_with_z = s2->NewLane(api::LaneId{"l1_with_z"}, {-5., 5.},
-                                {-kHalfWidth, kHalfWidth}, {0., kMaxHeight});
+  Segment* s2 = rg.NewJunction(api::JunctionId{"j2"})
+                    ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
+  Lane* l1_with_z = s2->NewLane(api::LaneId{"l1_with_z"}, r0,
+                                {-kHalfLaneWidth, kHalfLaneWidth});
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l1_with_z->ToLanePosition(point_outside_lane, &nearest_position,
                                 &distance),
       api::LanePosition(0., expected_r_outside, kMaxHeight), kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       nearest_position,
-      api::GeoPosition(100. - x_dist_to_edge, -75. + y_dist_to_edge,
-                       kMaxHeight + elevation),
+      api::GeoPosition::FromXyz(extreme_lane_point +
+                                Vector3<double>(0., 0., elevation)),
       kVeryExact));
-  EXPECT_NEAR(distance, std::sqrt(std::pow(175. - x_dist_to_edge, 2.) +
-                                  std::pow(100. - y_dist_to_edge, 2.) +
-                                  std::pow(20. - kMaxHeight - elevation, 2.)),
+  EXPECT_NEAR(distance, (point_outside_lane.xyz() - extreme_lane_point -
+                         Vector3<double>(0., 0., elevation))
+                            .norm(),
               kVeryExact);
-
   // Tests the integrity of LineLane::ToLanePosition() with various null
   // argument combinations.
   EXPECT_NO_THROW(l1->ToLanePosition(point_within_lane, &nearest_position,
@@ -198,25 +234,23 @@ GTEST_TEST(MultilaneLanesTest, FlatLineLane) {
 }
 
 
-GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
-  CubicPolynomial zp {0., 0., 0., 0.};
+TEST_P(MultilaneLanesParamTest, FlatArcLane) {
   RoadGeometry rg(api::RoadGeometryId{"apple"},
                   kLinearTolerance, kAngularTolerance);
   const double theta0 = 0.25 * M_PI;
   const double d_theta = 1.5 * M_PI;
   const double radius = 100.;
   const Vector2<double> center{100., -75.};
-  const double kHalfWidth = 10.;
-  const double kMaxHeight = 5.;
+  const double offset_radius = radius - r0;
+
   std::unique_ptr<RoadCurve> road_curve_1 =
       std::make_unique<ArcRoadCurve>(center, radius, theta0, d_theta, zp, zp);
-  Segment* s1 =
-      rg.NewJunction(api::JunctionId{"j1"})
-      ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1));
+  Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
+                    ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
   Lane* l2 =
-      s1->NewLane(api::LaneId{"l2"},
-                  // lane/driveable/elevation bounds
-                  {-5., 5.}, {-kHalfWidth, kHalfWidth}, {0., kMaxHeight});
+      s1->NewLane(api::LaneId{"l2"}, r0, {-kHalfLaneWidth, kHalfLaneWidth});
 
   EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
 
@@ -226,72 +260,80 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
   EXPECT_EQ(l2->to_left(), nullptr);
   EXPECT_EQ(l2->to_right(), nullptr);
 
-  EXPECT_NEAR(l2->length(), 100. * 1.5 * M_PI, kVeryExact);
+  EXPECT_NEAR(l2->length(), offset_radius * d_theta, kVeryExact);
 
-  EXPECT_TRUE(api::test::IsRBoundsClose(l2->lane_bounds(0.),
-                                        api::RBounds(-5., 5.),
-                                        kVeryExact));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      l2->lane_bounds(0.), api::RBounds(-kHalfLaneWidth, kHalfLaneWidth),
+      kVeryExact));
   EXPECT_TRUE(api::test::IsRBoundsClose(l2->driveable_bounds(0.),
-                                  api::RBounds(-10., 10.),
-                                  kVeryExact));  // kHalfWidth
-  EXPECT_TRUE(api::test::IsHBoundsClose(l2->elevation_bounds(0., 0.),
-                                  api::HBounds(0., 5.), kVeryExact));
-  // Recall that the arc has center (100, -75) and radius 100.
+                                        api::RBounds(-kHalfWidth, kHalfWidth),
+                                        kVeryExact));
+  EXPECT_TRUE(api::test::IsHBoundsClose(
+      l2->elevation_bounds(0., 0.), api::HBounds(0., kMaxHeight), kVeryExact));
+  // Recall that the arc has center (100, -75).
+  const Vector3<double> geo_center(100., -75., 0.);
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l2->ToGeoPosition({0., 0., 0.}),
-      api::GeoPosition(100. + (100. * std::cos(0.25 * M_PI)),
-                       -75. + (100. * std::sin(0.25 * M_PI)), 0.),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(std::cos(theta0), std::sin(theta0), 0.0) *
+              offset_radius),
       kLinearTolerance));
 
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l2->ToGeoPosition({1., 0., 0.}),
-      api::GeoPosition(
-          100. + (100. * std::cos((0.25 * M_PI) + (1.5 / l2->length() * M_PI))),
-          -75. + (100. * std::sin((0.25 * M_PI) + (1.5 / l2->length() * M_PI))),
-          0.),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(
+              offset_radius * std::cos(theta0 + 1.0 / offset_radius),
+              offset_radius * std::sin(theta0 + 1.0 / offset_radius), 0.0)),
       kLinearTolerance));
 
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l2->ToGeoPosition({0., 1., 0.}),
-      api::GeoPosition(
-          100. + (100. * std::cos(0.25 * M_PI)) + (1. * std::cos(1.25 * M_PI)),
-          -75. + (100. * std::sin(0.25 * M_PI)) + (1. * std::sin(1.25 * M_PI)),
-          0.),
+      api::GeoPosition::FromXyz(
+          geo_center + Vector3<double>((offset_radius - 1.) * std::cos(theta0),
+                                       (offset_radius - 1.) * std::sin(theta0),
+                                       0.0)),
       kLinearTolerance));
 
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       l2->ToGeoPosition({l2->length(), 0., 0.}),
-      api::GeoPosition(100. + (100. * std::cos(1.75 * M_PI)),
-                       -75. + (100. * std::sin(1.75 * M_PI)), 0.),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(offset_radius * std::cos(theta0 + d_theta),
+                          offset_radius * std::sin(theta0 + d_theta), 0.0)),
       kLinearTolerance));
 
   // Case 1: Tests ArcLane::ToLanePosition() with a closest point that lies
   // within the lane bounds.
-  const api::GeoPosition point_within_lane{
-    center(0) - 50., center(1) + 50., 0.};  // θ = 0.5π.
+  const api::GeoPosition point_within_lane{center(0) - 50., center(1) + 50.,
+                                           0.};  // θ = 0.5π.
   api::GeoPosition nearest_position;
   double distance{};
   const double expected_s = 0.5 * M_PI / d_theta * l2->length();
-  const double expected_r = std::min(radius - std::sqrt(2) * 50., kHalfWidth);
+  const double expected_r =
+      std::min(offset_radius - std::sqrt(2) * 50., kHalfWidth);
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2->ToLanePosition(point_within_lane, &nearest_position, &distance),
       api::LanePosition(expected_s, expected_r, 0.), kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       nearest_position,
-      api::GeoPosition(
-          (radius - kHalfWidth) * std::cos(0.5 * M_PI + theta0) + center(0),
-          (radius - kHalfWidth) * std::sin(0.5 * M_PI + theta0) + center(1),
-          0.),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(
+              (offset_radius - kHalfWidth) * std::cos(0.5 * M_PI + theta0),
+              (offset_radius - kHalfWidth) * std::sin(0.5 * M_PI + theta0),
+              0.)),
       kVeryExact));
-  EXPECT_NEAR(distance,
-              (radius - kHalfWidth) - std::sqrt(std::pow(50., 2.) +
-                                                std::pow(50., 2.)),
+  EXPECT_NEAR(distance, (offset_radius - kHalfWidth) -
+                            std::sqrt(std::pow(50., 2.) + std::pow(50., 2.)),
               kVeryExact);
 
   // Case 2: Tests ArcLane::ToLanePosition() with a closest point that lies
   // outside of the lane bounds, verifying that the result saturates.
-  const api::GeoPosition point_outside_lane{
-    center(0) + 200., center(1) - 20., 20.};  // θ ~= 1.9π.
+  const api::GeoPosition point_outside_lane{center(0) + 200., center(1) - 20.,
+                                            20.};  // θ ~= 1.9π.
   const double expected_r_outside = -kHalfWidth;
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2->ToLanePosition(point_outside_lane, &nearest_position, &distance),
@@ -299,10 +341,12 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
       kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       nearest_position,
-      api::GeoPosition(
-          (radius + kHalfWidth) * std::cos(theta0 + d_theta) + center(0),
-          (radius + kHalfWidth) * std::sin(theta0 + d_theta) + center(1),
-          kMaxHeight),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(
+              (offset_radius + kHalfWidth) * std::cos(theta0 + d_theta),
+              (offset_radius + kHalfWidth) * std::sin(theta0 + d_theta),
+              kMaxHeight)),
       kVeryExact));
   EXPECT_DOUBLE_EQ(distance,
                    (nearest_position.xyz() - point_outside_lane.xyz()).norm());
@@ -312,11 +356,12 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
   std::unique_ptr<RoadCurve> road_curve_2 = std::make_unique<ArcRoadCurve>(
       center, radius, theta0, d_theta,
       CubicPolynomial(elevation / radius / d_theta, 0.0, 0.0, 0.0), zp);
-  Segment* s2 =
-      rg.NewJunction(api::JunctionId{"j2"})
-      ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2));
-  Lane* l2_with_z = s2->NewLane(api::LaneId{"l2_with_z"}, {-5., 5.},
-                                {-kHalfWidth, kHalfWidth}, {0., kMaxHeight});
+  Segment* s2 = rg.NewJunction(api::JunctionId{"j2"})
+                    ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
+  Lane* l2_with_z = s2->NewLane(api::LaneId{"l2_with_z"}, r0,
+                                {-kHalfLaneWidth, kHalfLaneWidth});
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2_with_z->ToLanePosition(point_outside_lane, &nearest_position,
                                 &distance),
@@ -324,10 +369,12 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
       kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       nearest_position,
-      api::GeoPosition(
-          (radius + kHalfWidth) * std::cos(theta0 + d_theta) + center(0),
-          (radius + kHalfWidth) * std::sin(theta0 + d_theta) + center(1),
-          kMaxHeight + elevation),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(
+              (offset_radius + kHalfWidth) * std::cos(theta0 + d_theta),
+              (offset_radius + kHalfWidth) * std::sin(theta0 + d_theta),
+              kMaxHeight + elevation)),
       kVeryExact));
   EXPECT_DOUBLE_EQ(distance,
                    (nearest_position.xyz() - point_outside_lane.xyz()).norm());
@@ -339,24 +386,25 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
       center, radius, theta0, d_theta_overlap, zp, zp);
   Segment* s3 =
       rg.NewJunction(api::JunctionId{"j3"})
-      ->NewSegment(api::SegmentId{"s3"}, std::move(road_curve_3));
-  Lane* l2_overlapping =
-      s3->NewLane(api::LaneId{"l2_overlapping"},
-                  {-5., 5.}, {-kHalfWidth, kHalfWidth},
-                  {0., kMaxHeight});
+      ->NewSegment(api::SegmentId{"s3"}, std::move(road_curve_3),
+                   -kHalfWidth + r0, kHalfWidth + r0, {0., kMaxHeight});
+  Lane* l2_overlapping = s3->NewLane(api::LaneId{"l2_overlapping"}, r0,
+                                     {-kHalfLaneWidth, kHalfLaneWidth});
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2_overlapping->ToLanePosition(point_within_lane, &nearest_position,
                                      &distance),
       api::LanePosition(expected_s, expected_r, 0.), kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
       nearest_position,
-      api::GeoPosition(
-          (radius - kHalfWidth) * std::cos(0.5 * M_PI + theta0) + center(0),
-          (radius - kHalfWidth) * std::sin(0.5 * M_PI + theta0) + center(1),
-          0.),
+      api::GeoPosition::FromXyz(
+          geo_center +
+          Vector3<double>(
+              (offset_radius - kHalfWidth) * std::cos(0.5 * M_PI + theta0),
+              (offset_radius - kHalfWidth) * std::sin(0.5 * M_PI + theta0),
+              0.)),
       kVeryExact));
 
-  EXPECT_NEAR(distance, (radius - kHalfWidth) -
+  EXPECT_NEAR(distance, (offset_radius - kHalfWidth) -
                             std::sqrt(std::pow(50., 2.) + std::pow(50., 2.)),
               kVeryExact);
 
@@ -368,25 +416,25 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
   const double d_theta_wrap = -0.4 * M_PI;
   std::unique_ptr<RoadCurve> road_curve_4 = std::make_unique<ArcRoadCurve>(
       center, radius, theta0_wrap, d_theta_wrap, zp, zp);
-  Segment* s4 =
-      rg.NewJunction(api::JunctionId{"j4"})
-      ->NewSegment(api::SegmentId{"s4"}, std::move(road_curve_4));
-  Lane* l2_wrap = s4->NewLane(api::LaneId{"l2_wrap"},
-                              {-5., 5.}, {-kHalfWidth, kHalfWidth},
-                              {0., kMaxHeight});
-  const api::GeoPosition point_in_third_quadrant{
-    center(0) - 90., center(1) - 25., 0.};  // θ ~= -0.9π.
+  Segment* s4 = rg.NewJunction(api::JunctionId{"j4"})
+                    ->NewSegment(api::SegmentId{"s4"}, std::move(road_curve_4),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
+  Lane* l2_wrap = s4->NewLane(api::LaneId{"l2_wrap"}, r0,
+                              {-kHalfLaneWidth, kHalfLaneWidth});
+  const double offset_radius_wrap = radius + r0 + 2.;
+  const api::GeoPosition point_in_third_quadrant{  // θ ~= -0.9π.
+      center(0) + offset_radius_wrap * std::cos(-0.9 * M_PI),
+      center(1) + offset_radius_wrap * std::sin(-0.9 * M_PI), 0.};
   const double expected_s_wrap =
-      (std::atan2(25, -90) - 0.8 * M_PI) / d_theta * l2->length();  // ~0.28L
-  const double expected_r_wrap =
-      std::sqrt(std::pow(90, 2.) + std::pow(25, 2.)) - radius;
+      std::abs(0.1 * M_PI / d_theta_wrap) * l2_wrap->length();
+  const double expected_r_wrap = 2.;
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2_wrap->ToLanePosition(point_in_third_quadrant, &nearest_position,
                               &distance),
       api::LanePosition(expected_s_wrap, expected_r_wrap, 0.), kVeryExact));
   EXPECT_TRUE(api::test::IsGeoPositionClose(
-      nearest_position, api::GeoPosition(-90 + center(0), -25 + center(1), 0.),
-      kVeryExact));
+      nearest_position, point_in_third_quadrant, kVeryExact));
 
   EXPECT_NEAR(distance, 0. /* within lane */, kVeryExact);
 
@@ -435,22 +483,121 @@ GTEST_TEST(MultilaneLanesTest, FlatArcLane) {
   // from the original 100 down to 90.
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2->EvalMotionDerivatives({0., 10., 0.}, {1., 1., 1.}),
-      api::LanePosition((100. / 90.) * 1., 1., 1.), kVeryExact));
+      api::LanePosition((offset_radius / (offset_radius - 10.0)) * 1., 1., 1.),
+      kVeryExact));
   // Likewise, r = -10 will increase the radius of the path from the
   // original 100 up to 110.
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2->EvalMotionDerivatives({0., -10., 0.}, {1., 1., 1.}),
-      api::LanePosition((100. / 110.) * 1., 1., 1.), kVeryExact));
+      api::LanePosition(offset_radius / (offset_radius + 10.) * 1., 1., 1.),
+      kVeryExact));
   // ...and only r should matter for an otherwise flat arc.
   EXPECT_TRUE(api::test::IsLanePositionClose(
       l2->EvalMotionDerivatives({l2->length(), -10., 100.}, {1., 1., 1.}),
-      api::LanePosition((100. / 110.) * 1., 1., 1.), kVeryExact));
+      api::LanePosition(offset_radius / (offset_radius + 10.), 1., 1.),
+      kVeryExact));
 }
+
+
+namespace {
+api::LanePosition IntegrateTrivially(const api::Lane* lane,
+                                     const api::LanePosition& lp_initial,
+                                     const api::IsoLaneVelocity& velocity,
+                                     const double time_step,
+                                     const int step_count) {
+  api::LanePosition lp_current = lp_initial;
+
+  for (int i = 0; i < step_count; ++i) {
+    const api::LanePosition lp_dot =
+        lane->EvalMotionDerivatives(lp_current, velocity);
+    lp_current.set_srh(lp_current.srh() + (lp_dot.srh() * time_step));
+  }
+  return lp_current;
+}
+}  // namespace
+
+
+TEST_P(MultilaneLanesParamTest, HillIntegration) {
+  RoadGeometry rg(api::RoadGeometryId{"apple"},
+                  kLinearTolerance, kAngularTolerance);
+  const double theta0 = 0.25 * M_PI;
+  const double d_theta = 0.5 * M_PI;
+  const double theta1 = theta0 + d_theta;
+  const double radius = 100.;
+  const double offset_radius = radius - r0;
+  const double p_scale = radius * d_theta;
+  const double z0 = 0.;
+  const double z1 = 20.;
+  // A cubic polynomial such that:
+  //   f(0) = (z0 / p_scale), f(1) = (z1 / p_scale), and f'(0) = f'(1) = 0.
+  const CubicPolynomial kHillPolynomial(z0 / p_scale, 0.,
+                                        (3. * (z1 - z0) / p_scale),
+                                        (-2. * (z1 - z0) / p_scale));
+  std::unique_ptr<RoadCurve> road_curve_1 =
+      std::make_unique<ArcRoadCurve>(Vector2<double>(-100., -100.), radius,
+                                     theta0, d_theta, kHillPolynomial, zp);
+  Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
+                    ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
+                                 -kHalfWidth + r0, kHalfWidth + r0,
+                                 {0., kMaxHeight});
+  Lane* l1 = s1->NewLane(api::LaneId{"l2"}, r0,
+                         {-kHalfLaneWidth, kHalfLaneWidth});
+
+  EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
+
+  const api::IsoLaneVelocity kVelocity {1., 0., 0. };
+  const double kTimeStep = 0.001;
+  const int kStepsForZeroR = kIntegrationScaleMap.find(r0)->second;
+  const double kIntegrationTolerance = 3e-4;
+
+  const api::LanePosition kLpInitialA{0., 0., 0.};
+  EXPECT_TRUE(api::test::IsGeoPositionClose(
+      l1->ToGeoPosition(kLpInitialA),
+      api::GeoPosition(-100. + (offset_radius * std::cos(theta0)),
+                       -100. + (offset_radius * std::sin(theta0)), z0),
+      kLinearTolerance));
+
+  api::LanePosition lp_final_a =
+      IntegrateTrivially(l1, kLpInitialA, kVelocity, kTimeStep,
+                         kStepsForZeroR);
+  EXPECT_TRUE(api::test::IsGeoPositionClose(
+      l1->ToGeoPosition(lp_final_a),
+      api::GeoPosition(-100. + (offset_radius * std::cos(theta1)),
+                       -100. + (offset_radius * std::sin(theta1)), z1),
+      kIntegrationTolerance));
+
+  const api::LanePosition kLpInitialB{0., -10., 0.};
+  EXPECT_TRUE(api::test::IsGeoPositionClose(
+      l1->ToGeoPosition(kLpInitialB),
+      api::GeoPosition(-100. + ((offset_radius + 10.) * std::cos(theta0)),
+                       -100. + ((offset_radius + 10.) * std::sin(theta0)), z0),
+      kLinearTolerance));
+
+  const int kStepsForR10 = ((offset_radius + 10.) / radius * kStepsForZeroR) -
+                           kIntegrationFactorMap.find(r0)->second;
+  api::LanePosition lp_final_b =
+      IntegrateTrivially(l1, kLpInitialB, kVelocity, kTimeStep,
+                         kStepsForR10);
+  EXPECT_TRUE(api::test::IsGeoPositionClose(
+      l1->ToGeoPosition(lp_final_b),
+      api::GeoPosition(-100. + ((offset_radius + 10.) * std::cos(theta1)),
+                       -100. + ((offset_radius + 10.) * std::sin(theta1)), z1),
+      kIntegrationTolerance));
+}
+
+
+INSTANTIATE_TEST_CASE_P(Offset, MultilaneLanesParamTest,
+                        testing::Values(0., 5., -5.));
 
 
 GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
   CubicPolynomial zp {0., 0., 0., 0.};
   const double kTheta = 0.10 * M_PI;  // superelevation
+  const double kR0 = 0.;
+  const double kHalfWidth = 10.;
+  const double kHalfLaneWidth = 5.;
+  const double kMaxHeight = 5.;
+
   RoadGeometry rg(api::RoadGeometryId{"apple"},
                   kLinearTolerance, kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<ArcRoadCurve>(
@@ -458,8 +605,10 @@ GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
       CubicPolynomial((kTheta) / (100. * 1.5 * M_PI), 0., 0., 0.));
   Segment* s1 =
       rg.NewJunction(api::JunctionId{"j1"})
-      ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1));
-  Lane* l2 = s1->NewLane(api::LaneId{"l2"}, {-5., 5.}, {-10., 10.}, {0., 5.});
+      ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1), -kHalfWidth,
+                   kHalfWidth, {0., kMaxHeight});
+  Lane* l2 = s1->NewLane(api::LaneId{"l2"}, kR0,
+                         {-kHalfLaneWidth, kHalfLaneWidth});
 
   EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
 
@@ -542,92 +691,6 @@ GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
               1.,
           1., 1.),
       kVeryExact));
-}
-
-namespace {
-api::LanePosition IntegrateTrivially(const api::Lane* lane,
-                                     const api::LanePosition& lp_initial,
-                                     const api::IsoLaneVelocity& velocity,
-                                     const double time_step,
-                                     const int step_count) {
-  api::LanePosition lp_current = lp_initial;
-
-  for (int i = 0; i < step_count; ++i) {
-    const api::LanePosition lp_dot =
-        lane->EvalMotionDerivatives(lp_current, velocity);
-    lp_current.set_srh(lp_current.srh() + (lp_dot.srh() * time_step));
-  }
-  return lp_current;
-}
-}  // namespace
-
-
-GTEST_TEST(MultilaneLanesTest, HillIntegration) {
-  CubicPolynomial zp {0., 0., 0., 0.};
-  RoadGeometry rg(api::RoadGeometryId{"apple"},
-                  kLinearTolerance, kAngularTolerance);
-  const double theta0 = 0.25 * M_PI;
-  const double d_theta = 0.5 * M_PI;
-  const double theta1 = theta0 + d_theta;
-  const double p_scale = 100. * d_theta;
-  const double z0 = 0.;
-  const double z1 = 20.;
-  // A cubic polynomial such that:
-  //   f(0) = (z0 / p_scale), f(1) = (z1 / p_scale), and f'(0) = f'(1) = 0.
-  const CubicPolynomial kHillPolynomial(z0 / p_scale, 0.,
-                                        (3. * (z1 - z0) / p_scale),
-                                        (-2. * (z1 - z0) / p_scale));
-  std::unique_ptr<RoadCurve> road_curve_1 =
-      std::make_unique<ArcRoadCurve>(Vector2<double>(-100., -100.), 100.,
-                                     theta0, d_theta, kHillPolynomial, zp);
-  Segment* s1 =
-      rg.NewJunction(api::JunctionId{"j1"})
-      ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1));
-  Lane* l1 = s1->NewLane(api::LaneId{"l2"}, {-5., 5.}, {-10., 10.}, {0., 5.});
-
-  EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
-
-  const api::IsoLaneVelocity kVelocity {1., 0., 0. };
-  const double kTimeStep = 0.001;
-  const int kStepsForZeroR = 158597;
-  const double kIntegrationTolerance = 3e-4;
-
-  const api::LanePosition kLpInitialA{0., 0., 0.};
-  EXPECT_TRUE(api::test::IsGeoPositionClose(
-      l1->ToGeoPosition(kLpInitialA),
-      api::GeoPosition(-100. + (100. * std::cos(theta0)),
-                       -100. + (100. * std::sin(theta0)), z0),
-      kLinearTolerance));
-
-  api::LanePosition lp_final_a =
-      IntegrateTrivially(l1, kLpInitialA, kVelocity, kTimeStep,
-                         kStepsForZeroR);
-  EXPECT_TRUE(api::test::IsGeoPositionClose(
-      l1->ToGeoPosition(lp_final_a),
-      api::GeoPosition(-100. + (100. * std::cos(theta1)),
-                       -100. + (100. * std::sin(theta1)), z1),
-      kIntegrationTolerance));
-
-  const api::LanePosition kLpInitialB{0., -10., 0.};
-  EXPECT_TRUE(api::test::IsGeoPositionClose(
-      l1->ToGeoPosition(kLpInitialB),
-      api::GeoPosition(-100. + ((100. + 10.) * std::cos(theta0)),
-                       -100. + ((100. + 10.) * std::sin(theta0)), z0),
-      kLinearTolerance));
-
-  // NB:  '287' is a fudge-factor.  We know the steps should scale roughly
-  //      as (r / r0), but not exactly because of the elevation curve.
-  //      Mostly, we are testing that we end up in the right place in
-  //      roughly the right number of steps.
-  const int kStepsForR10 = ((100. + 10.) / 100. * kStepsForZeroR) - 287;
-  api::LanePosition lp_final_b =
-      IntegrateTrivially(l1, kLpInitialB, kVelocity, kTimeStep,
-                         kStepsForR10);
-  EXPECT_TRUE(api::test::IsGeoPositionClose(
-      l1->ToGeoPosition(lp_final_b),
-      api::GeoPosition(-100. + ((100. + 10.) * std::cos(theta1)),
-                       -100. + ((100. + 10.) * std::sin(theta1)), z1),
-      kIntegrationTolerance));
 }
 
 }  // namespace multilane

--- a/drake/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -22,7 +22,8 @@ class MultilaneLineRoadCurveTest : public ::testing::Test {
   const double kHeading{M_PI / 4.0};
   const double kHeadingDerivative{0.0};
   const double kVeryExact{1e-12};
-  const api::RBounds lateral_bounds{-10.0, 10.0};
+  const double kRMin{-10.0};
+  const double kRMax{10.0};
   const api::HBounds elevation_bounds{0.0, 10.0};
 };
 
@@ -61,7 +62,7 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
 // Checks that LineRoadCurve::IsValid() returns true.
 TEST_F(MultilaneLineRoadCurveTest, IsValidTest) {
   const LineRoadCurve dut(kOrigin, kDirection, zp, zp);
-  EXPECT_TRUE(dut.IsValid(lateral_bounds, elevation_bounds));
+  EXPECT_TRUE(dut.IsValid(kRMin, kRMax, elevation_bounds));
 }
 
 // Checks the validity of the surface for different lateral bounds and
@@ -70,26 +71,64 @@ TEST_F(MultilaneLineRoadCurveTest, ToCurveFrameTest) {
   const LineRoadCurve dut(kOrigin, kDirection, zp, zp);
   // Checks over the base line.
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(Vector3<double>(10.0, 10.0, 0.0), lateral_bounds,
+      dut.ToCurveFrame(Vector3<double>(10.0, 10.0, 0.0), kRMin, kRMax,
                        elevation_bounds),
       Vector3<double>(0.0, 0.0, 0.0), kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(Vector3<double>(20.0, 20.0, 0.0), lateral_bounds,
+      dut.ToCurveFrame(Vector3<double>(20.0, 20.0, 0.0), kRMin, kRMax,
                        elevation_bounds),
-      Vector3<double>(std::sqrt(2) * 10.0, 0.0, 0.0), kVeryExact));
+      Vector3<double>(1., 0.0, 0.0), kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(Vector3<double>(15.0, 15.0, 0.0), lateral_bounds,
+      dut.ToCurveFrame(Vector3<double>(15.0, 15.0, 0.0), kRMin, kRMax,
                        elevation_bounds),
-      Vector3<double>(std::sqrt(2) * 5.0, 0.0, 0.0), kVeryExact));
+      Vector3<double>(0.5, 0.0, 0.0), kVeryExact));
   // Check with lateral and vertical deviation.
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(Vector3<double>(11.0, 12.0, 5.0), lateral_bounds,
+      dut.ToCurveFrame(Vector3<double>(11.0, 12.0, 5.0), kRMin, kRMax,
                        elevation_bounds),
-      Vector3<double>(2.12132034355964, 0.707106781186547, 5.0), kVeryExact));
+      Vector3<double>(0.15, 0.707106781186547, 5.0), kVeryExact));
   EXPECT_TRUE(CompareMatrices(
-      dut.ToCurveFrame(Vector3<double>(11.0, 10.0, 7.0), lateral_bounds,
+      dut.ToCurveFrame(Vector3<double>(11.0, 10.0, 7.0), kRMin, kRMax,
                        elevation_bounds),
-      Vector3<double>(0.707106781186547, -0.707106781186547, 7.0), kVeryExact));
+      Vector3<double>(0.05, -0.707106781186547, 7.0), kVeryExact));
+}
+
+// Checks that p_scale(), p_from_s() and s_from_p() with constant superelevation
+// polynomial and up to linear elevation polynomial behave properly.
+TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
+  const std::vector<double> r_vector{-10., 0., 10.};
+  const std::vector<double> p_vector{0., 0.1, 0.2, 0.5, 0.7, 1.0};
+
+  // Checks for flat LineRoadCurve.
+  const LineRoadCurve flat_dut(kOrigin, kDirection, zp, zp);
+  EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kDirection.norm());
+  // Evaluates inverse function for different path length and offset values.
+  for (double r : r_vector) {
+    for (double p : p_vector) {
+      EXPECT_DOUBLE_EQ(flat_dut.p_from_s(p * kDirection.norm(), r), p);
+    }
+  }
+  // Evaluates the path length integral for different offset values.
+  for (double r : r_vector) {
+    for (double p : p_vector) {
+      EXPECT_DOUBLE_EQ(flat_dut.s_from_p(p, r), p * kDirection.norm());
+    }
+  }
+
+  // Checks for linear elevation applied to the LineRoadCurve.
+  const double slope = 10. / kDirection.norm();
+  const CubicPolynomial linear_elevation(10., slope, 0., 0.);
+  const LineRoadCurve elevated_dut(kOrigin, kDirection, linear_elevation, zp);
+  EXPECT_DOUBLE_EQ(elevated_dut.p_scale(), kDirection.norm());
+  // Evaluates inverse function and path length integral for different values of
+  // p and r lateral offsets.
+  for (double r : r_vector) {
+    for (double p : p_vector) {
+      const double s = p * kDirection.norm() * std::sqrt(1. + slope * slope);
+      EXPECT_DOUBLE_EQ(elevated_dut.p_from_s(s, r), p);
+      EXPECT_DOUBLE_EQ(elevated_dut.s_from_p(p, r), s);
+    }
+  }
 }
 
 }  // namespace multilane


### PR DESCRIPTION
As a next step towards #4934 completion, this PR includes the following main changes:

- Modifies `RoadCurve` API to include `s_from_p()` method, to provide path length integral with support up to linear elevation polynomials.
- Modifies `RoadCurve` API to include `p_from_s()` method, previously owned by `Lane` class, to provide path length integral with support up to linear elevation polynomials
- Adds the `r0` lateral displacement as a property of the `Lane`.
- Modifies `RoadCurve` API to bring several methods that were on `Lane` class as well as code blocks to unify the code and comments in one place.

These changes are in favor of the following hierarchy:

- A `Segment` will own a `RoadCurve` which has the reference trajectory.
- `Lane`s will lay on parent `Segment` surface and follow an offset of `RoadCurve`'s trajectory at distance `r0`.

For example you may define a flat `RoadCurve` whose reference path is an arc of a circle with radius equal to 50m and Δθ equal to π (counterclockwise). Then you can create a `Lane` with a lateral offset `r0` of 10m. `Lane`'s trajectory will end up being half a circle but with a radius of 40m.

Adding `r0` lateral displacement introduced a poor evaluation of the trajectory path length integral since `superelevation` polynomial is not evaluated over the rotation axis anymore and it affects the path length integral. To keep this PR in size and focused, Multilane code is not capable of supporting both non-zero `r0` and `superelevation`.

Discussion on this PR is from comment [326633775](https://github.com/RobotLocomotion/drake/issues/4934#issuecomment-326633775) to [327219342](https://github.com/RobotLocomotion/drake/issues/4934#issuecomment-327219342).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6985)
<!-- Reviewable:end -->
