### PR TITLE
Removes CarVisApplicator's resizing of output port's abstract value.

### DIFF
--- a/drake/automotive/car_vis_applicator.cc
+++ b/drake/automotive/car_vis_applicator.cc
@@ -80,11 +80,6 @@ void CarVisApplicator<T>::CalcPoseBundleOutput(
           input_port_index_)->template GetValue<PoseBundle<T>>();
   DRAKE_ASSERT(vehicle_poses.get_num_poses() == num_cars());
 
-  // Resize the output PoseBundle as necessary.
-  if (visualization_poses->get_num_poses() != num_vis_poses()) {
-    *visualization_poses = PoseBundle<T>(num_vis_poses());
-  }
-
   if (vehicle_poses.get_num_poses() != static_cast<int>(visualizers_.size())) {
     throw std::runtime_error("CarVisApplicator::DoCalcOutput(): Input "
         "PoseBundle has " + std::to_string(vehicle_poses.get_num_poses()) +


### PR DESCRIPTION
The resize is not necessary since the memory is allocated in `CarVisApplicator<T>::MakePoseBundleOutput()` and should not change once allocated.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6987)
<!-- Reviewable:end -->
