### PR TITLE
Add basic MPC that regulates to a static fixed point, without externally-imposed constraints

### DIFF
--- a/drake/systems/controllers/BUILD
+++ b/drake/systems/controllers/BUILD
@@ -43,6 +43,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "linear_model_predictive_controller",
+    srcs = ["linear_model_predictive_controller.cc"],
+    hdrs = ["linear_model_predictive_controller.h"],
+    deps = [
+        "//drake/common/trajectories:piecewise_polynomial_trajectory",
+        "//drake/systems/primitives:linear_system",
+        "//drake/systems/trajectory_optimization:direct_transcription",
+    ],
+)
+
+drake_cc_library(
     name = "linear_quadratic_regulator",
     srcs = ["linear_quadratic_regulator.cc"],
     hdrs = ["linear_quadratic_regulator.h"],
@@ -200,6 +211,16 @@ drake_cc_googletest(
         "//drake/common:find_resource",
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/multibody/parsers",
+    ],
+)
+
+drake_cc_googletest(
+    name = "linear_model_predictive_controller_test",
+    deps = [
+        ":linear_model_predictive_controller",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/math:discrete_algebraic_riccati_equation",
+        "//drake/systems/analysis:simulator",
     ],
 )
 

--- a/drake/systems/controllers/linear_model_predictive_controller.cc
+++ b/drake/systems/controllers/linear_model_predictive_controller.cc
@@ -1,0 +1,118 @@
+#include "drake/systems/controllers/linear_model_predictive_controller.h"
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/trajectory_optimization/direct_transcription.h"
+
+namespace drake {
+namespace systems {
+namespace controllers {
+
+using solvers::VectorXDecisionVariable;
+using trajectory_optimization::DirectTranscription;
+
+template <typename T>
+LinearModelPredictiveController<T>::LinearModelPredictiveController(
+    std::unique_ptr<systems::System<double>> model,
+    std::unique_ptr<systems::Context<double>> base_context,
+    const Eigen::MatrixXd& Q, const Eigen::MatrixXd& R, double time_period,
+    double time_horizon)
+    : state_input_index_(
+          this->DeclareVectorInputPort(BasicVector<T>(Q.cols())).get_index()),
+      control_output_index_(
+          this->DeclareVectorOutputPort(
+                  BasicVector<T>(R.cols()),
+                  &LinearModelPredictiveController<T>::CalcControl)
+              .get_index()),
+      model_(std::move(model)),
+      base_context_(std::move(base_context)),
+      num_states_(
+          model_->CreateDefaultContext()->get_discrete_state(0)->size()),
+      num_inputs_(model_->get_input_port(0).size()),
+      Q_(Q),
+      R_(R),
+      time_period_(time_period),
+      time_horizon_(time_horizon) {
+  DRAKE_DEMAND(time_period_ > 0.);
+  DRAKE_DEMAND(time_horizon_ > 0.);
+
+  // Check that the model is SISO and has discrete states belonging to a single
+  // group.
+  const auto model_context = model_->CreateDefaultContext();
+  DRAKE_DEMAND(model_context->get_num_discrete_state_groups() == 1);
+  DRAKE_DEMAND(model_context->get_continuous_state()->size() == 0);
+  DRAKE_DEMAND(model_context->get_num_abstract_state_groups() == 0);
+  DRAKE_DEMAND(model_->get_num_input_ports() == 1);
+  DRAKE_DEMAND(model_->get_num_output_ports() == 1);
+
+  // Check that the provided  x0, u0, Q, R are consistent with the model.
+  DRAKE_DEMAND(num_states_ > 0 && num_inputs_ > 0);
+  DRAKE_DEMAND(Q.rows() == num_states_ && Q.cols() == num_states_);
+  DRAKE_DEMAND(R.rows() == num_inputs_ && R.cols() == num_inputs_);
+
+  // N.B. A Cholesky decomposition exists if and only if it is positive
+  // semidefinite, however it turns out that Eigen's algorithm for checking this
+  // is incomplete: it only succeeds on *strictly* positive definite
+  // matrices. We exploit the fact here to check for strict
+  // positive-definiteness of R.
+  Eigen::LLT<Eigen::MatrixXd> R_cholesky(R);
+  if (R_cholesky.info() != Eigen::Success) {
+    throw std::runtime_error("R must be positive definite");
+  }
+
+  this->DeclarePeriodicDiscreteUpdate(time_period_);
+
+  if (base_context_ != nullptr) {
+    linear_model_ = Linearize(*model_, *base_context_);
+  }
+}
+
+template <typename T>
+void LinearModelPredictiveController<T>::CalcControl(
+    const Context<T>& context, BasicVector<T>* control) const {
+  const Eigen::VectorBlock<const VectorX<T>> current_state =
+      this->EvalEigenVectorInput(context, state_input_index_);
+
+  const Eigen::VectorXd current_input =
+      SetupAndSolveQp(*base_context_, current_state);
+
+  const VectorX<T> input_ref = model_->EvalEigenVectorInput(*base_context_, 0);
+
+  control->SetFromVector(current_input + input_ref);
+
+  // TODO(jadecastro) Implement the time-varying case.
+}
+
+template <typename T>
+VectorX<T> LinearModelPredictiveController<T>::SetupAndSolveQp(
+    const Context<T>& base_context, const VectorX<T>& current_state) const {
+  DRAKE_DEMAND(linear_model_ != nullptr);
+
+  const int kNumSampleTimes =
+      static_cast<int>(time_horizon_ / time_period_ + 0.5);
+
+  DirectTranscription prog(linear_model_.get(), *base_context_,
+                           kNumSampleTimes);
+
+  const auto state_error = prog.state();
+  const auto input_error = prog.input();
+
+  prog.AddRunningCost(state_error.transpose() * Q_ * state_error +
+                      input_error.transpose() * R_ * input_error);
+
+  const VectorX<T> state_ref =
+      base_context.get_discrete_state()->get_vector()->CopyToVector();
+  prog.AddLinearConstraint(prog.initial_state() == current_state - state_ref);
+
+  DRAKE_DEMAND(prog.Solve() == solvers::SolutionResult::kSolutionFound);
+
+  return prog.GetInputSamples().col(0);
+}
+
+template class LinearModelPredictiveController<double>;
+
+}  // namespace controllers
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/controllers/linear_model_predictive_controller.h
+++ b/drake/systems/controllers/linear_model_predictive_controller.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
+#include "drake/systems/primitives/linear_system.h"
+
+namespace drake {
+namespace systems {
+namespace controllers {
+
+/// Implements a basic Model Predictive Controller that linearizes the system
+/// about an equilibrium condition and regulates to the same point by solving an
+/// optimal control problem over a finite time horizon.  In particular, MPC
+/// solves, at each time step k, the following problem to find an optimal u(k)
+/// as a function of x(k):
+///
+///   @f[ \min_{u(k),\ldots,u(k+N),x(k+1),\ldots,x(k+N)}
+///          \Sum_{i=k}^{k+N} ((x(i) - xd(i))ᵀQ(x(i) - xd(i)) +
+///                            (u(i) - ud(i))ᵀR(u(i) - ud(i))) @f]
+///   @f[ \mathrm{s.t. } x(k+1) = A(k)x(k) + B(k)u(k) @f]
+///
+/// and subject to linear inequality constraints on the inputs and states, where
+/// N is the horizon length, Q and R are cost matrices, and xd and ud are the
+/// desired states and inputs, respectively.  Note that the present
+/// implementation solves the QP in whole at every time step, discarding any
+/// information between steps.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+///
+/// @ingroup control_systems
+template <typename T>
+class LinearModelPredictiveController : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LinearModelPredictiveController)
+
+  /// Constructor for an unconstrained MPC formulation with linearization
+  /// occurring about the provided base_context.  Since this formulation is
+  /// devoid of any externally-imposed input/state constraints, the controller
+  /// essentially behaves the same as a finite-time LQR.
+  ///
+  /// @param model The plant model of the System to be controlled.
+  /// @param base_context The fixed base point about which to linearize of the
+  /// system and regulate the system.  To be valid, @p base_context must
+  /// correspond to an equilibrium point of the system.
+  /// @param Q A symmetric positive semi-definite state cost matrix of size
+  /// (num_states x num_states).
+  /// @param R A symmetric positive definite control effort cost matrix of size
+  /// (num_inputs x num_inputs).
+  /// @param time_period The discrete time period (in seconds) at which
+  /// controller updates occur.
+  /// @param time_horizon The prediction time horizon (seconds).
+  ///
+  /// @pre model must have discrete states of dimension num_states and inputs
+  /// of dimension num_inputs.
+  /// @pre base_context must have discrete states set as appropriate for the
+  /// given @p model.  The input must also be initialized via
+  /// `base_context->FixInputPort(0, u0)`, or otherwise initialized via Diagram.
+
+  // TODO(jadecastro) Implement a version that regulates to an arbitrary
+  // trajectory.
+  LinearModelPredictiveController(
+      std::unique_ptr<systems::System<double>> model,
+      std::unique_ptr<systems::Context<double>> base_context,
+      const Eigen::MatrixXd& Q, const Eigen::MatrixXd& R, double time_period,
+      double time_horizon);
+    // TODO(jadecastro) Get time_period directly from the plant model.
+
+  const InputPortDescriptor<T>& get_state_port() const {
+    return this->get_input_port(state_input_index_);
+  }
+  const OutputPort<T>& get_control_port() const {
+    return this->get_output_port(control_output_index_);
+  }
+
+ private:
+  void CalcControl(const Context<T>& context, BasicVector<T>* control) const;
+
+  // Sets up a DirectTranscription problem and solves for the current control
+  // input.
+  VectorX<T> SetupAndSolveQp(const Context<T>& base_context,
+                             const VectorX<T>& current_state) const;
+
+  const int state_input_index_{-1};
+  const int control_output_index_{-1};
+
+  const std::unique_ptr<systems::System<double>> model_;
+  // The base context that contains the reference point to regulate.
+  const std::unique_ptr<systems::Context<double>> base_context_;
+
+  const int num_states_{};
+  const int num_inputs_{};
+
+  const Eigen::MatrixXd Q_;
+  const Eigen::MatrixXd R_;
+
+  const double time_period_{};
+  const double time_horizon_{};
+
+  // Descrption of the linearized plant model.
+  std::unique_ptr<LinearSystem<double>> linear_model_;
+};
+
+}  // namespace controllers
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -1,0 +1,269 @@
+#include "drake/systems/controllers/linear_model_predictive_controller.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/discrete_algebraic_riccati_equation.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/linear_system.h"
+
+namespace drake {
+namespace systems {
+namespace controllers {
+namespace {
+
+using math::DiscreteAlgebraicRiccatiEquation;
+
+class TestMpcWithDoubleIntegrator : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const double kTimeStep = 0.1;     // discrete time step.
+    const double kTimeHorizon = 10.;  // Time horizon.
+
+    // A discrete approximation of a double integrator.
+    Eigen::Matrix2d A;
+    Eigen::Vector2d B;
+    A << 1, 0.1, 0, 1;
+    B << 0.005, 0.1;
+    const auto C = Eigen::Matrix<double, 2, 2>::Identity();
+    const auto D = Eigen::Matrix<double, 2, 1>::Zero();
+
+    std::unique_ptr<LinearSystem<double>> system =
+        std::make_unique<LinearSystem<double>>(A, B, C, D, kTimeStep);
+
+    // Nominal, fixed reference condition.
+    const Eigen::Vector2d x0 = Eigen::Vector2d::Zero();
+    const Vector1d u0 = Vector1d::Zero();
+
+    std::unique_ptr<Context<double>> system_context =
+        system->CreateDefaultContext();
+    system_context->FixInputPort(0, u0);
+    system_context->get_mutable_discrete_state(0)->SetFromVector(x0);
+
+    dut_.reset(new LinearModelPredictiveController<double>(
+        std::move(system), std::move(system_context), Q_, R_, kTimeStep,
+        kTimeHorizon));
+
+    // Store another copy of the linear plant model.
+    system_.reset(new LinearSystem<double>(A, B, C, D, kTimeStep));
+  }
+
+  // Cost matrices.
+  const Eigen::Matrix2d Q_ = Eigen::Matrix2d::Identity();
+  const Vector1d R_ = Vector1d::Constant(1.);
+
+  std::unique_ptr<LinearModelPredictiveController<double>> dut_;
+  std::unique_ptr<LinearSystem<double>> system_;
+};
+
+TEST_F(TestMpcWithDoubleIntegrator, TestAgainstInfiniteHorizonSolution) {
+  const double kTolerance = 1e-5;
+
+  const Eigen::Matrix2d A = system_->A();
+  const Eigen::Matrix<double, 2, 1> B = system_->B();
+
+  // Analytical solution to the LQR problem.
+  const Eigen::Matrix2d S = DiscreteAlgebraicRiccatiEquation(A, B, Q_, R_);
+  const Eigen::Matrix<double, 1, 2> K =
+      -(R_ + B.transpose() * S * B).inverse() * (B.transpose() * S * A);
+
+  const Eigen::Matrix<double, 2, 1> x0 = Eigen::Vector2d::Ones();
+
+  auto context = dut_->CreateDefaultContext();
+  context->FixInputPort(0, BasicVector<double>::Make(x0(0), x0(1)));
+  std::unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context);
+
+  dut_->CalcOutput(*context, output.get());
+
+  EXPECT_TRUE(CompareMatrices(K * x0, output->get_vector_data(0)->get_value(),
+                              kTolerance));
+}
+
+namespace {
+
+// A discrete-time cubic polynomial system.
+template <typename T>
+class CubicPolynomialSystem final : public LeafSystem<T> {
+ public:
+  explicit CubicPolynomialSystem(double time_step)
+      : LeafSystem<T>(
+            SystemTypeTag<systems::controllers::CubicPolynomialSystem>{}),
+        time_step_(time_step) {
+    this->DeclareInputPort(systems::kVectorValued, 1);
+    this->DeclareVectorOutputPort(BasicVector<T>(2),
+                                  &CubicPolynomialSystem::OutputState);
+    this->DeclareDiscreteState(2);
+    this->DeclarePeriodicDiscreteUpdate(time_step);
+  }
+
+  template <typename U>
+  CubicPolynomialSystem(const CubicPolynomialSystem<U>& other)
+      : CubicPolynomialSystem(other.time_step_) {}
+
+ private:
+  template <typename> friend class CubicPolynomialSystem;
+
+  // x1(k+1) = u(k)
+  // x2(k+1) = -x1³(k)
+  void DoCalcDiscreteVariableUpdates(
+      const Context<T>& context,
+      const std::vector<const DiscreteUpdateEvent<T>*>&,
+      DiscreteValues<T>* next_state) const final {
+    using std::pow;
+    const T& x1 = context.get_discrete_state(0)->get_value()[0];
+    const T& u = this->EvalVectorInput(context, 0)->get_value()[0];
+    next_state->get_mutable_vector(0)->SetAtIndex(0, u);
+    next_state->get_mutable_vector(0)->SetAtIndex(1, pow(x1, 3.));
+  }
+
+  void OutputState(const systems::Context<T>& context,
+                   BasicVector<T>* output) const {
+    output->set_value(context.get_discrete_state(0)->get_value());
+  }
+
+  // TODO(jadecastro) We know a discrete system of this format does not have
+  // direct feedthrough, even though sparsity reports the opposite.  This is a
+  // hack to patch in the correct result.
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
+    return false;
+  }
+
+  const double time_step_{0.};
+};
+
+template class CubicPolynomialSystem<double>;
+template class CubicPolynomialSystem<AutoDiffXd>;
+
+}  // namespace
+
+class TestMpcWithCubicSystem : public ::testing::Test {
+ protected:
+  const System<double>& GetSystemByName(std::string name,
+                                        const Diagram<double>& diagram) {
+    const System<double>* result{nullptr};
+    for (const System<double>* system : diagram.GetSystems()) {
+      if (system->get_name() == name) result = system;
+    }
+    return *result;
+  }
+
+  void MakeTimeInvariantMpcController() {
+    EXPECT_NE(nullptr, system_);
+    auto context = system_->CreateDefaultContext();
+
+    // Set nominal input to zero.
+    context->FixInputPort(0, Vector1d::Constant(0.));
+
+    // Set the nominal state.
+    BasicVector<double>* x =
+        context->get_mutable_discrete_state()->get_mutable_vector();
+    x->SetFromVector(Eigen::Vector2d::Zero());  // Fixed point is zero.
+
+    dut_.reset(new LinearModelPredictiveController<double>(
+        std::move(system_), std::move(context), Q_, R_, time_step_,
+        time_horizon_));
+  }
+
+  void MakeControlledSystem(bool is_time_varying) {
+    EXPECT_FALSE(is_time_varying);  // TODO(jadecastro) Introduce tests for the
+                                    // time-varying case.
+    EXPECT_EQ(nullptr, diagram_);
+
+    system_.reset(new CubicPolynomialSystem<double>(time_step_));
+    EXPECT_FALSE(system_->HasAnyDirectFeedthrough());
+
+    DiagramBuilder<double> builder;
+    auto cubic_system = builder.AddSystem<CubicPolynomialSystem>(time_step_);
+    cubic_system->set_name("cubic_system");
+
+    MakeTimeInvariantMpcController();
+    EXPECT_NE(nullptr, dut_);
+    auto controller = builder.AddSystem(std::move(dut_));
+    controller->set_name("controller");
+
+    builder.Connect(cubic_system->get_output_port(0),
+                    controller->get_state_port());
+    builder.Connect(controller->get_control_port(),
+                    cubic_system->get_input_port(0));
+
+    diagram_ = builder.Build();
+  }
+
+  void Simulate() {
+    EXPECT_NE(nullptr, diagram_);
+    EXPECT_EQ(nullptr, simulator_);
+
+    simulator_.reset(new Simulator<double>(*diagram_));
+
+    const auto& cubic_system = GetSystemByName("cubic_system", *diagram_);
+    Context<double>& cubic_system_context =
+        diagram_->GetMutableSubsystemContext(cubic_system,
+                                             simulator_->get_mutable_context());
+    BasicVector<double>* x0 =
+        cubic_system_context.get_mutable_discrete_state()->get_mutable_vector();
+
+    // Set an initial condition near the fixed point.
+    x0->SetFromVector(10. * Eigen::Vector2d::Ones());
+
+    simulator_->set_target_realtime_rate(1.);
+    simulator_->Initialize();
+    simulator_->StepTo(time_horizon_);
+  }
+
+  const double time_step_ = 0.1;
+  const double time_horizon_ = 0.2;
+
+  // Set up the quadratic cost matrices.
+  const Eigen::Matrix2d Q_ = Eigen::Matrix2d::Identity();
+  const Vector1d R_ = Vector1d::Constant(1.);
+
+  std::unique_ptr<Simulator<double>> simulator_;
+
+ private:
+  std::unique_ptr<LinearModelPredictiveController<double>> dut_;
+  std::unique_ptr<CubicPolynomialSystem<double>> system_;
+  std::unique_ptr<Diagram<double>> diagram_;
+};
+
+TEST_F(TestMpcWithCubicSystem, TimeInvariantMpc) {
+  const double kTolerance = 1e-10;
+  MakeControlledSystem(false /* is NOT time-varying */);
+  Simulate();
+
+  // Result should be deadbeat; expect convergence to within a tiny tolerance in
+  // one step.
+  Eigen::Vector2d result =
+      simulator_->get_mutable_context()->get_discrete_state(0)->get_value();
+  EXPECT_TRUE(CompareMatrices(result, Eigen::Vector2d::Zero(), kTolerance));
+}
+
+GTEST_TEST(TestMpcConstructor, ThrowIfRNotStrictlyPositiveDefinite) {
+  const auto A = Eigen::Matrix<double, 2, 2>::Identity();
+  const auto B = Eigen::Matrix<double, 2, 2>::Identity();
+  const auto C = Eigen::Matrix<double, 2, 2>::Identity();
+  const auto D = Eigen::Matrix<double, 2, 2>::Zero();
+
+  std::unique_ptr<LinearSystem<double>> system =
+      std::make_unique<LinearSystem<double>>(A, B, C, D, 1.);
+
+  std::unique_ptr<Context<double>> context = system->CreateDefaultContext();
+  context->FixInputPort(0, BasicVector<double>::Make(0., 0.));
+
+  const Eigen::Matrix2d Q = Eigen::Matrix2d::Identity();
+
+  // Provide a positive-definite matrix (but not strict).
+  Eigen::Matrix2d R = Eigen::Matrix2d::Identity();
+  R(0, 0) = 0.;
+
+  // Expect the constructor to throw since R is not strictly positive definite.
+  EXPECT_THROW(LinearModelPredictiveController<double>(
+      std::move(system), std::move(context), Q, R, 1., 1.),
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace controllers
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This is the first in a series of PRs introducing MPC that sets up and solves an online QP using the MathematicalProgram interface.  This PR introduces a basic MPC formulation that linearizes the system about a fixed equilibrium point and regulates to the same point.  The current formulation excludes input/state constraints, making it essentially identical to a finite-time LQR.

Later contributions will introduce input/state constraints and regulate to a trajectory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6988)
<!-- Reviewable:end -->
