### PR TITLE
Replace Isometry3<T>::rotation() with Isometry3<T>::linear() everywhere

### DIFF
--- a/drake/examples/double_pendulum/test/rigid_body_types_compare.cc
+++ b/drake/examples/double_pendulum/test/rigid_body_types_compare.cc
@@ -19,9 +19,9 @@ namespace test {
     return ::testing::AssertionFailure()
         << "Element local transforms differ:"
         << " elem1 translation = " << iso1.translation().format(fmt)
-        << " rotation = " << iso1.rotation().format(fmt) << ","
+        << " rotation = " << iso1.linear().format(fmt) << ","
         << " elem2 translation = " << iso2.translation().format(fmt)
-        << " rotation = " << iso2.rotation().format(fmt) << ".";
+        << " rotation = " << iso2.linear().format(fmt) << ".";
   }
   const DrakeShapes::Geometry& geom1 = elem1.getGeometry();
   const DrakeShapes::Geometry& geom2 = elem1.getGeometry();

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
@@ -345,8 +345,8 @@ int DoMain(void) {
   const Vector6<double>& object_velocity = world_state.get_object_velocity();
   Isometry3<double> goal = place_locations.back();
   goal.translation()(2) += kTableTopZInWorld;
-  Eigen::Vector3d object_rpy = math::rotmat2rpy(object_pose.rotation());
-  Eigen::Vector3d goal_rpy = math::rotmat2rpy(goal.rotation());
+  Eigen::Vector3d object_rpy = math::rotmat2rpy(object_pose.linear());
+  Eigen::Vector3d goal_rpy = math::rotmat2rpy(goal.linear());
 
   drake::log()->info("Pose: {} {}",
                      object_pose.translation().transpose(),

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
@@ -52,8 +52,8 @@ bool PlanStraightLineMotion(const VectorX<double>& q_current,
                                             X_WEndEffector1.translation()};
   drake::log()->debug(
       "Planning straight line from {} {} to {} {}",
-      pos[0].transpose(), math::rotmat2rpy(X_WEndEffector0.rotation()),
-      pos[1].transpose(), math::rotmat2rpy(X_WEndEffector1.rotation()));
+      pos[0].transpose(), math::rotmat2rpy(X_WEndEffector0.linear()),
+      pos[1].transpose(), math::rotmat2rpy(X_WEndEffector1.linear()));
 
   PiecewiseQuaternionSlerp<double> rot_traj({0, duration}, quats);
   PiecewisePolynomial<double> pos_traj =
@@ -73,7 +73,7 @@ bool PlanStraightLineMotion(const VectorX<double>& q_current,
     drake::log()->debug(
         "via ({}/{}): {} {}", i, num_via_points,
         waypoints[i].pose.translation().transpose(),
-        math::rotmat2rpy(waypoints[i].pose.rotation()).transpose());
+        math::rotmat2rpy(waypoints[i].pose.linear()).transpose());
     if (i != num_via_points) {
       waypoints[i].pos_tol = via_points_pos_tolerance;
       waypoints[i].rot_tol = via_points_rot_tolerance;

--- a/drake/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/drake/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -118,7 +118,7 @@ TEST_F(OptitrackPoseTest, PoseComparisonTest) {
                               MatrixCompareType::absolute));
 
   // Compare quaternions.
-  EXPECT_TRUE(CompareMatrices(extracted_pose.rotation(), test_pose.rotation(),
+  EXPECT_TRUE(CompareMatrices(extracted_pose.linear(), test_pose.linear(),
                               1e-3, MatrixCompareType::absolute));
 }
 

--- a/drake/multibody/multibody_tree/body_node.h
+++ b/drake/multibody/multibody_tree/body_node.h
@@ -331,12 +331,12 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     const Isometry3<T>& X_WP = get_X_WP(pc);
 
     // Orientation (rotation) of frame F with respect to the world frame W.
-    const Matrix3<T> R_WF = X_WP.rotation() * X_PF.rotation();
+    const Matrix3<T> R_WF = X_WP.linear() * X_PF.linear();
 
     // Vector from Mo to Bo expressed in frame F as needed below:
     const Vector3<T> p_MB_F =
         /* p_MB_F = R_FM * p_MB_M */
-        get_X_FM(pc).rotation() * X_MB.translation();
+        get_X_FM(pc).linear() * X_MB.translation();
 
     // Compute V_PB_W = R_WF * V_FM.Shift(p_MoBo_F), Eq. (4).
     // Side note to developers: in operator form for rigid bodies this would be
@@ -356,7 +356,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // CalcPositionKinematicsCache_BaseToTip() and saving the result in the
     // position kinematics cache.
     /* p_PB_W = R_WP * p_PB */
-    Vector3<T> p_PB_W = get_X_WP(pc).rotation() * get_X_PB(pc).translation();
+    Vector3<T> p_PB_W = get_X_WP(pc).linear() * get_X_PB(pc).translation();
 
     // Since we are in a base-to-tip recursion the parent body P's spatial
     // velocity is already available in the cache.
@@ -499,14 +499,14 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // Orientation (rotation) of frame F with respect to the world frame W.
     // TODO(amcastro-tri): consider caching X_WF since also used in velocity
     // kinematics.
-    const Matrix3<T> R_WF = X_WP.rotation() * X_PF.rotation();
+    const Matrix3<T> R_WF = X_WP.linear() * X_PF.linear();
 
     // Vector from Mo to Bo expressed in frame F as needed below:
     // TODO(amcastro-tri): consider caching this since also used in velocity
     // kinematics.
     const Vector3<T> p_MB_F =
         /* p_MB_F = R_FM * p_MB_M */
-        get_X_FM(pc).rotation() * X_MB.translation();
+        get_X_FM(pc).linear() * X_MB.translation();
 
     // Across mobilizer velocity is available from the velocity kinematics.
     const SpatialVelocity<T>& V_FM = get_V_FM(vc);
@@ -542,7 +542,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     // CalcPositionKinematicsCache_BaseToTip() and saving the result in the
     // position kinematics cache.
     /* p_PB_W = R_WP * p_PB */
-    Vector3<T> p_PB_W = get_X_WP(pc).rotation() * get_X_PB(pc).translation();
+    Vector3<T> p_PB_W = get_X_WP(pc).linear() * get_X_PB(pc).translation();
 
     get_mutable_A_WB_from_array(&A_WB_array) =
         A_WP.ComposeWithMovingFrameAcceleration(p_PB_W, V_WP.rotational(),
@@ -698,7 +698,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     DRAKE_DEMAND(frame_M.get_body().get_index() == body_B.get_index());
     const Isometry3<T> X_BM = frame_M.CalcPoseInBodyFrame(context);
     const Vector3<T>& p_BoMo_B = X_BM.translation();
-    const Matrix3<T>& R_WB = get_X_WB(pc).rotation();
+    const Matrix3<T>& R_WB = get_X_WB(pc).linear();
     const Vector3<T> p_BoMo_W = R_WB * p_BoMo_B;
 
     // Output spatial force that would need to be exerted by this node's
@@ -721,7 +721,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
 
       // p_CoMc_W:
       const Frame<T>& frame_Mc = child_node->get_outboard_frame();
-      const Matrix3<T>& R_WC = child_node->get_X_WB(pc).rotation();
+      const Matrix3<T>& R_WC = child_node->get_X_WB(pc).linear();
       const Isometry3<T> X_CMc = frame_Mc.CalcPoseInBodyFrame(context);
       const Vector3<T>& p_CoMc_W = R_WC * X_CMc.translation();
 
@@ -757,7 +757,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     const Isometry3<T>& X_WP = get_X_WP(pc);
     // TODO(amcastro-tri): consider caching X_WF since also used in position and
     // velocity kinematics.
-    const Matrix3<T> R_WF = X_WP.rotation() * X_PF.rotation();
+    const Matrix3<T> R_WF = X_WP.linear() * X_PF.linear();
     const SpatialForce<T> F_BMo_F = R_WF * F_BMo_W;
 
     // Generalized velocities and forces use the same indexing.
@@ -1125,7 +1125,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     const Isometry3<T>& X_WB = get_X_WB(pc);
 
     // Orientation of B in W.
-    const Matrix3<T> R_WB = X_WB.rotation();
+    const Matrix3<T> R_WB = X_WB.linear();
 
     // Body spatial velocity in W.
     const SpatialVelocity<T>& V_WB = get_V_WB(vc);

--- a/drake/multibody/multibody_tree/test/double_pendulum_test.cc
+++ b/drake/multibody/multibody_tree/test/double_pendulum_test.cc
@@ -573,7 +573,7 @@ class PendulumKinematicTests : public PendulumTests {
             -link2_mass_ * acceleration_of_gravity_ * Vector3d::UnitY());
     // Obtain the position of the lower link's center of mass.
     const Isometry3d& X_WL = get_body_pose_in_world(pc, *lower_link_);
-    const Matrix3d R_WL = X_WL.rotation();
+    const Matrix3d R_WL = X_WL.linear();
     const Vector3d p_LoLcm_L = lower_link_->get_default_com();
     const Vector3d p_LoLcm_W = R_WL * p_LoLcm_L;
     const SpatialForce<double> F_L_W = F_Lcm_W.Shift(-p_LoLcm_W);
@@ -848,7 +848,7 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       // spatial velocity and acceleration to the center of mass frame for
       // comparison with the benchmark.
       const Isometry3d& X_WL = get_body_pose_in_world(pc, *lower_link_);
-      const Matrix3d R_WL = X_WL.rotation();
+      const Matrix3d R_WL = X_WL.linear();
       const Vector3d p_LoLcm_L = lower_link_->get_default_com();
       const Vector3d p_LoLcm_W = R_WL * p_LoLcm_L;
 

--- a/drake/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/drake/perception/estimators/dev/test/articulated_icp_test.cc
@@ -91,7 +91,7 @@ class ArticulatedIcpTest : public TestWithParam<ObjectTestType> {
     tree_cache_.reset(new KinematicsCached(tree_->CreateKinematicsCache()));
 
     const Vector3d obj_xyz = setup.X_WB.translation();
-    const Vector3d obj_rpy = math::rotmat2rpy(setup.X_WB.rotation());
+    const Vector3d obj_rpy = math::rotmat2rpy(setup.X_WB.linear());
     const int nq = tree_->get_num_positions();
 
     // Perturbation for initializing local ICP.

--- a/drake/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/drake/perception/estimators/dev/test/articulated_icp_test.cc
@@ -91,7 +91,9 @@ class ArticulatedIcpTest : public TestWithParam<ObjectTestType> {
     tree_cache_.reset(new KinematicsCached(tree_->CreateKinematicsCache()));
 
     const Vector3d obj_xyz = setup.X_WB.translation();
-    const Vector3d obj_rpy = math::rotmat2rpy(setup.X_WB.linear());
+    // TODO(eric.cousineau): change X_WB.rotation() to X_WB.linear() once #7035
+    // is resolved.
+    const Vector3d obj_rpy = math::rotmat2rpy(setup.X_WB.rotation());
     const int nq = tree_->get_num_positions();
 
     // Perturbation for initializing local ICP.

--- a/drake/perception/estimators/dev/test/test_util.cc
+++ b/drake/perception/estimators/dev/test/test_util.cc
@@ -108,12 +108,12 @@ AssertionResult CompareTransforms(
     const Eigen::Isometry3d& X_expected, const Eigen::Isometry3d& X_actual,
     double tolerance) {
   AssertionResult check_R_expected =
-      ExpectRotMat(X_expected.rotation(), tolerance);
+      ExpectRotMat(X_expected.linear(), tolerance);
   if (!check_R_expected) {
     return check_R_expected << "(X_expected)";
   }
   AssertionResult check_R_actual =
-      ExpectRotMat(X_actual.rotation(), tolerance);
+      ExpectRotMat(X_actual.linear(), tolerance);
   if (!check_R_actual) {
     return check_R_actual << "(X_actual)";
   }
@@ -157,8 +157,8 @@ AssertionResult CompareTransformWithoutAxisSign(
     return check_translation;
   }
   // Next, check rotation matrices.
-  return CompareRotMatWithoutAxisSign(X_expected.rotation(),
-                                      X_actual.rotation(), tolerance);
+  return CompareRotMatWithoutAxisSign(X_expected.linear(),
+                                      X_actual.linear(), tolerance);
 }
 
 namespace {
@@ -282,7 +282,7 @@ void PointCloudVisualizer::PublishFrames(
     for (int j = 0; j < 3; ++j) {
       msg.position[i][j] = static_cast<float>(frame.translation()[j]);
     }
-    Quaternion<float> quat(frame.rotation().cast<float>());
+    Quaternion<float> quat(frame.linear().cast<float>());
     msg.quaternion[i][0] = quat.w();
     msg.quaternion[i][1] = quat.x();
     msg.quaternion[i][2] = quat.y();

--- a/drake/perception/estimators/dev/test/test_util.cc
+++ b/drake/perception/estimators/dev/test/test_util.cc
@@ -230,10 +230,15 @@ void GetObjectTestSetup(ObjectTestType type, ObjectTestSetup *setup) {
       //   print(f.transform)
       Isometry3d X_WmB;
       X_WmB.setIdentity();
-      X_WmB.linear() <<
-        0.147663, 0.642632, -0.751811,
-        0.988952, -0.10596, 0.103667,
+      Matrix3d R_WmB;
+      R_WmB <<
+         0.147663,  0.642632, -0.751811,
+         0.988952, -0.105960,  0.103667,
         -0.013042, -0.758812, -0.651179;
+      // R_WmB does not precisely belong to O(3) given that its entries are
+      // only specified with 6 digits of precision. Therefore we project it
+      // onto O(3) before using it:
+      X_WmB.linear() = math::ProjectMatToOrthonormalMat(R_WmB);
       X_WmB.translation() << -0.026111, 0.0496843, 0.548844;
 
       setup->X_WB = X_WmB;

--- a/drake/systems/rendering/drake_visualizer_client.cc
+++ b/drake/systems/rendering/drake_visualizer_client.cc
@@ -76,7 +76,7 @@ lcmt_viewer_geometry_data MakeGeometryData(
   Eigen::Map<Eigen::Vector3f> position(geometry_data.position);
   position = transform.translation().cast<float>();
   Eigen::Map<Eigen::Vector4f> quaternion(geometry_data.quaternion);
-  quaternion = math::rotmat2quat(transform.rotation()).cast<float>();
+  quaternion = math::rotmat2quat(transform.linear()).cast<float>();
 
   Eigen::Map<Eigen::Vector4f> color(geometry_data.color);
   color = visual_element.getMaterial().template cast<float>();

--- a/drake/systems/rendering/pose_bundle_to_draw_message.cc
+++ b/drake/systems/rendering/pose_bundle_to_draw_message.cc
@@ -43,7 +43,7 @@ void PoseBundleToDrawMessage::CalcViewerDrawMessage(
     message.position[i][1] = t.y();
     message.position[i][2] = t.z();
 
-    Eigen::Quaternion<double> q(poses.get_pose(i).rotation());
+    Eigen::Quaternion<double> q(poses.get_pose(i).linear());
     message.quaternion[i].resize(4);
     message.quaternion[i][0] = q.w();
     message.quaternion[i][1] = q.x();

--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -201,7 +201,7 @@ void DepthSensor::CalcPoseOutput(const Context<double>& context,
 
   pose_output->set_translation(
       Eigen::Translation<double, 3>(X_WS.translation()));
-  pose_output->set_rotation(Eigen::Quaternion<double>(X_WS.rotation()));
+  pose_output->set_rotation(Eigen::Quaternion<double>(X_WS.linear()));
 }
 
 std::ostream& operator<<(std::ostream& out, const DepthSensor& sensor) {


### PR DESCRIPTION
This PR replaces all calls `Isometry3<T>::rotation()` with `Isometry3<T>::linear()`.
It happens that `Isometry3<T>::rotation()`  seems to be **computing** the rotational part of a general isometry (which could include for instance shear ans scaling) and therore incurs in unnecessary overhead for our typical transformations.

Whether we like it or not, the zero-cost accessor to our "rotational part" is `Isometry3<T>::linear()`.

In the MultibodyTree code this lead to a 3x speed up. I didn't check in other places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6989)
<!-- Reviewable:end -->
