### PR TITLE
Random inputs

### DIFF
--- a/drake/common/constants.h
+++ b/drake/common/constants.h
@@ -17,4 +17,15 @@ constexpr int kTwistSize = 6;
 constexpr int kHomogeneousTransformSize = 16;
 
 const int kRotmatSize = kSpaceDimension * kSpaceDimension;
+
+/// Drake supports explicit reasoning about a few carefully chosen random
+/// distributions.
+enum class RandomDistribution {
+  kUniform = 0,   ///< Anticipated vector elements are independent and
+                  /// uniformly distributed ∈ [0,1].
+  kGaussian = 1,  ///< Anticipated vector elements are independent and
+                  /// drawn from a mean-zero, unit-variance normal
+                  /// distribution.
+};
+
 }  // namespace drake

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -1405,7 +1405,8 @@ class Diagram : public System<T>,
     // Add this port to our externally visible topology.
     const auto& subsystem_descriptor = sys->get_input_port(port_index);
     this->DeclareInputPort(subsystem_descriptor.get_data_type(),
-                           subsystem_descriptor.size());
+                           subsystem_descriptor.size(),
+                           subsystem_descriptor.get_random_type());
   }
 
   // Exposes the given subsystem output port as an output of the Diagram.

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -312,6 +312,9 @@ class DiagramBuilder {
     }
   }
 
+  // TODO(russt): Implement AddRandomSources method to wire up all dangling
+  // random input ports with a compatible RandomSource system.
+
   // Produces the Blueprint that has been described by the calls to
   // Connect, ExportInput, and ExportOutput. Throws std::logic_error if the
   // graph is empty or contains algebraic loops.

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -724,12 +724,15 @@ class LeafSystem : public System<T> {
   /// This is the best way to declare LeafSystem input ports that require
   /// subclasses of BasicVector.  The port's size will be model_vector.size(),
   /// and LeafSystem's default implementation of DoAllocateInputVector will be
-  /// model_vector.Clone().  If the @p model_vector declares any
+  /// model_vector.Clone(). If the port is intended to model a random noise or
+  /// disturbance input, @p random_type can (optionally) be used to label it
+  /// as such.  If the @p model_vector declares any
   /// VectorBase::CalcInequalityConstraint() constraints, they will be
   /// re-declared as inequality constraints on this system (see
   /// DeclareInequalityConstraint()).
   const InputPortDescriptor<T>& DeclareVectorInputPort(
-      const BasicVector<T>& model_vector) {
+      const BasicVector<T>& model_vector,
+      optional<RandomDistribution> random_type = nullopt) {
     const int size = model_vector.size();
     const int index = this->get_num_input_ports();
     model_input_values_.AddVectorModel(index, model_vector.Clone());
@@ -740,7 +743,7 @@ class LeafSystem : public System<T> {
           DRAKE_DEMAND(input != nullptr);
           return *input;
         });
-    return this->DeclareInputPort(kVectorValued, size);
+    return this->DeclareInputPort(kVectorValued, size, random_type);
   }
 
   // Avoid shadowing out the no-arg DeclareAbstractInputPort().

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -1280,11 +1280,18 @@ class System {
   System() {}
 
   /// Adds a port with the specified @p type and @p size to the input topology.
+  /// If the port is intended to model a random noise or disturbance input,
+  /// @p random_type can (optionally) be used to label it as such; doing so
+  /// enables algorithms for design and analysis (e.g. state estimation) to
+  /// reason explicitly about randomness at the system level.  All random input
+  /// ports are assumed to be statistically independent.
   /// @return descriptor of declared port.
-  const InputPortDescriptor<T>& DeclareInputPort(PortDataType type, int size) {
+  const InputPortDescriptor<T>& DeclareInputPort(
+      PortDataType type, int size,
+      optional<RandomDistribution> random_type = nullopt) {
     int port_index = get_num_input_ports();
-    input_ports_.push_back(
-        std::make_unique<InputPortDescriptor<T>>(this, port_index, type, size));
+    input_ports_.push_back(std::make_unique<InputPortDescriptor<T>>(
+        this, port_index, type, size, random_type));
     return *input_ports_.back();
   }
 

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -119,7 +119,8 @@ class DiagramContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0,
+                                           nullopt);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -830,6 +830,32 @@ GTEST_TEST(PortDependentFeedthroughTest, DetectFeedthrough) {
   EXPECT_TRUE(diagram->HasDirectFeedthrough(0, 0));
 }
 
+// A system with a random source inputs.
+class RandomInputSystem : public LeafSystem<double> {
+ public:
+  RandomInputSystem() {
+    this->DeclareInputPort(kVectorValued, 1);
+    this->DeclareInputPort(kVectorValued, 1,
+                           RandomDistribution::kUniform);
+    this->DeclareInputPort(kVectorValued, 1,
+                           RandomDistribution::kGaussian);
+  }
+};
+
+GTEST_TEST(RandomInputSystemTest, RandomInputTest) {
+  DiagramBuilder<double> builder;
+  auto random = builder.AddSystem<RandomInputSystem>();
+  builder.ExportInput(random->get_input_port(0));
+  builder.ExportInput(random->get_input_port(1));
+  builder.ExportInput(random->get_input_port(2));
+  auto diagram = builder.Build();
+  EXPECT_FALSE(diagram->get_input_port(0).get_random_type());
+  EXPECT_EQ(diagram->get_input_port(1).get_random_type(),
+            RandomDistribution::kUniform);
+  EXPECT_EQ(diagram->get_input_port(2).get_random_type(),
+            RandomDistribution::kGaussian);
+}
+
 // A vector with a scalar configuration and scalar velocity.
 class SecondOrderStateVector : public BasicVector<double> {
  public:

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -84,7 +84,8 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0,
+                                           nullopt);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 
@@ -92,7 +93,8 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const std::string* ReadStringInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0,
+                                           nullopt);
     return context.EvalInputValue<std::string>(nullptr, descriptor);
   }
 
@@ -100,7 +102,8 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const AbstractValue* ReadAbstractInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0);
+    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0,
+                                           nullopt);
     return context.EvalAbstractInput(nullptr, descriptor);
   }
 

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -381,6 +381,10 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
     this->DeclareInputPort(kVectorValued, 1);
     this->DeclareVectorInputPort(MyVector2d());
     this->DeclareAbstractInputPort(Value<int>(22));
+    this->DeclareVectorInputPort(MyVector2d(),
+                                 RandomDistribution::kUniform);
+    this->DeclareVectorInputPort(MyVector2d(),
+                                 RandomDistribution::kGaussian);
 
     // Output port 0 uses a BasicVector base class model.
     this->DeclareVectorOutputPort(BasicVector<double>(3),
@@ -444,12 +448,14 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
 GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   DeclaredModelPortsSystem dut;
 
-  ASSERT_EQ(dut.get_num_input_ports(), 3);
+  ASSERT_EQ(dut.get_num_input_ports(), 5);
   ASSERT_EQ(dut.get_num_output_ports(), 4);
 
   const InputPortDescriptor<double>& in0 = dut.get_input_port(0);
   const InputPortDescriptor<double>& in1 = dut.get_input_port(1);
   const InputPortDescriptor<double>& in2 = dut.get_input_port(2);
+  const InputPortDescriptor<double>& in3 = dut.get_input_port(3);
+  const InputPortDescriptor<double>& in4 = dut.get_input_port(4);
 
   const OutputPort<double>& out0 = dut.get_output_port(0);
   const OutputPort<double>& out1 = dut.get_output_port(1);
@@ -459,6 +465,8 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   EXPECT_EQ(in0.get_data_type(), kVectorValued);
   EXPECT_EQ(in1.get_data_type(), kVectorValued);
   EXPECT_EQ(in2.get_data_type(), kAbstractValued);
+  EXPECT_EQ(in3.get_data_type(), kVectorValued);
+  EXPECT_EQ(in4.get_data_type(), kVectorValued);
 
   EXPECT_EQ(out0.get_data_type(), kVectorValued);
   EXPECT_EQ(out1.get_data_type(), kVectorValued);
@@ -467,10 +475,24 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
 
   EXPECT_EQ(in0.size(), 1);
   EXPECT_EQ(in1.size(), 2);
+  EXPECT_EQ(in3.size(), 2);
+  EXPECT_EQ(in4.size(), 2);
 
   EXPECT_EQ(out0.size(), 3);
   EXPECT_EQ(out1.size(), 4);
   EXPECT_EQ(out3.size(), 2);
+
+  EXPECT_FALSE(in0.is_random());
+  EXPECT_FALSE(in1.is_random());
+  EXPECT_FALSE(in2.is_random());
+  EXPECT_TRUE(in3.is_random());
+  EXPECT_TRUE(in4.is_random());
+
+  EXPECT_FALSE(in0.get_random_type());
+  EXPECT_FALSE(in1.get_random_type());
+  EXPECT_FALSE(in2.get_random_type());
+  EXPECT_EQ(in3.get_random_type(), RandomDistribution::kUniform);
+  EXPECT_EQ(in4.get_random_type(), RandomDistribution::kGaussian);
 }
 
 // Tests that the model values specified in Declare{...} are actually used by

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -392,7 +392,12 @@ class ValueIOTestSystem : public System<T> {
         }));
 
     this->DeclareInputPort(kVectorValued, 1);
-    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(*this,
+    this->DeclareInputPort(kVectorValued, 1,
+                           RandomDistribution::kUniform);
+    this->DeclareInputPort(kVectorValued, 1,
+                           RandomDistribution::kGaussian);
+    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
+        *this,
         1,  // Vector size.
         [](const Context<T>&) {
           return std::make_unique<Value<BasicVector<T>>>(1);
@@ -428,8 +433,8 @@ class ValueIOTestSystem : public System<T> {
 
   BasicVector<T>* DoAllocateInputVector(
       const InputPortDescriptor<T>& descriptor) const override {
-    // Should only get called for the second input.
-    EXPECT_EQ(descriptor.get_index(), 1);
+    // Should not get called for the first (abstract) input.
+    EXPECT_GE(descriptor.get_index(), 1);
     return new TestTypedVector<T>();
   }
 
@@ -556,7 +561,7 @@ class SystemIOTest : public ::testing::Test {
 TEST_F(SystemIOTest, SystemValueIOTest) {
   test_sys_.CalcOutput(*context_, output_.get());
 
-  EXPECT_EQ(context_->get_num_input_ports(), 2);
+  EXPECT_EQ(context_->get_num_input_ports(), 4);
   EXPECT_EQ(output_->get_num_ports(), 2);
 
   EXPECT_EQ(output_->get_data(0)->GetValue<std::string>(),
@@ -566,7 +571,7 @@ TEST_F(SystemIOTest, SystemValueIOTest) {
   // Test AllocateInput*
   // Second input is not (yet) a TestTypedVector, since I haven't called the
   // Allocate methods directly yet.
-  EXPECT_EQ(dynamic_cast<const TestTypedVector<double>*>(
+  EXPECT_EQ(dynamic_cast<const TestTypedVector<double> *>(
                 test_sys_.EvalVectorInput(*context_, 1)),
             nullptr);
   // Now allocate.
@@ -575,9 +580,24 @@ TEST_F(SystemIOTest, SystemValueIOTest) {
   EXPECT_EQ(test_sys_.EvalAbstractInput(*context_, 0)->GetValue<std::string>(),
             "");
   // Second input should now be of type TestTypedVector.
-  EXPECT_NE(dynamic_cast<const TestTypedVector<double>*>(
+  EXPECT_NE(dynamic_cast<const TestTypedVector<double> *>(
                 test_sys_.EvalVectorInput(*context_, 1)),
             nullptr);
+}
+
+// Checks that the input ports randomness labels were set as expected.
+TEST_F(SystemIOTest, RandomInputPortTest) {
+  EXPECT_FALSE(test_sys_.get_input_port(0).is_random());
+  EXPECT_FALSE(test_sys_.get_input_port(1).is_random());
+  EXPECT_TRUE(test_sys_.get_input_port(2).is_random());
+  EXPECT_TRUE(test_sys_.get_input_port(3).is_random());
+
+  EXPECT_FALSE(test_sys_.get_input_port(0).get_random_type());
+  EXPECT_FALSE(test_sys_.get_input_port(1).get_random_type());
+  EXPECT_EQ(test_sys_.get_input_port(2).get_random_type(),
+            RandomDistribution::kUniform);
+  EXPECT_EQ(test_sys_.get_input_port(3).get_random_type(),
+            RandomDistribution::kGaussian);
 }
 
 // Tests that FixInputPortsFrom allocates ports of the same dimension as the

--- a/drake/systems/primitives/random_source.h
+++ b/drake/systems/primitives/random_source.h
@@ -100,23 +100,10 @@ class RandomSource : public LeafSystem<double> {
   Seed seed_{RandomState::default_seed};
 };
 
-namespace internal {
-/// Defines a version of the std::uniform_real_distribution that uses the
-/// interval [-1,1] with the default parameters.  This is a more natural
-/// distribution for random signals.
-class mean_zero_uniform_real_distribution
-    : public std::uniform_real_distribution<double> {
- public:
-  mean_zero_uniform_real_distribution()
-      : std::uniform_real_distribution<double>(-1.0, 1.0) {}
-};
-
-}  // namespace internal
-
-/// Generates uniformly distributed random numbers in the interval [-1,1].
+/// Generates uniformly distributed random numbers in the interval [0,1].
 ///
 /// @ingroup primitive_systems
-typedef RandomSource<internal::mean_zero_uniform_real_distribution>
+typedef RandomSource<std::uniform_real_distribution<double>>
     UniformRandomSource;
 
 /// Generates uniformly distributed random numbers with mean zero and unit

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -33,17 +33,36 @@ GTEST_TEST(TestSignalLogger, GaussianWhiteNoise) {
       0, 0.0);
 
   simulator.Initialize();
-  simulator.StepTo(5);
+  simulator.StepTo(20);
 
   const auto& x = logger->data();
 
-  for (double threshold = -2.0; threshold < 2.0; threshold += 0.5) {
-    double count = (x.array() < threshold).cast<double>().matrix().sum();
-    // Probability of x < threshold for a Gaussian can be computed with erf:
-    EXPECT_NEAR(count / x.size(),
-                .5 + std::erf(threshold / std::sqrt(2.0)) / 2.0,
-                0.02);  // Note intentionally very large tolerance.
-    // TODO(russt): Tighten tolerance once #4325 is resolved.
+  // Cumulative distribution function of the standard normal distribution.
+  auto Phi = [](double z) { return 0.5 * std::erfc(-z / std::sqrt(2.0)); };
+
+  const double h = 0.1;
+  const int N = x.size();
+  // Evaluate all subintervals (a,a+h) in (-2,2).
+  for (double a = -2.0; a <= 2.0 - h; a += h) {
+    // Counts the number of samples in (a,a+h).
+    const double count =
+        (x.array() >= a && x.array() <= a + h).cast<double>().matrix().sum();
+
+    // Basic confidence interval statistics.  See, for instance,
+    //    Simulation and the Monte Carlo Method (Third Edition)
+    //      by Rubinstein and Kroese, 2017
+    //    page 108,
+    // where I've used Y as the indicator function of a ≤ X ≤ a+h,
+    // E[Y] = Phi(a+h)-Phi(a), Var(Y) = E[Y]-E[Y]², since E[Y²]=E[Y],
+    // and Phi(x) is the cdf of the standard normal distribution.
+    // We expect a perfect sampler to obtain a value
+    //    count/N = E[Y] ± 1.645 √(Var(Y)/N)
+    // with 95% confidence.  Checks that our pseudo-random sampler
+    // accomplishes this bound within a factor of tol.
+    const double EY = Phi(a + h) - Phi(a);
+    const double VarY = EY - EY * EY;
+    const double tol = 2.0;
+    EXPECT_NEAR(count / N, EY, tol * 1.645 * std::sqrt(VarY / N));
   }
 }
 
@@ -66,15 +85,28 @@ GTEST_TEST(TestSignalLogger, UniformWhiteNoise) {
       0, 0.0);
 
   simulator.Initialize();
-  simulator.StepTo(5);
+  simulator.StepTo(20);
 
   const auto& x = logger->data();
 
-  for (double threshold = 0.0; threshold < 1.0; threshold += 0.1) {
-    double count = (x.array() < threshold).cast<double>().matrix().sum();
-    EXPECT_NEAR(count / x.size(), threshold,
-                0.02);  // Note intentionally very large tolerance.
-    // TODO(russt): Tighten tolerance once #4325 is resolved.
+  const double h = 0.1;
+  const int N = x.size();
+  // Evaluate all subintervals (a,a+h) in (0,1).
+  for (double a = 0.0; a <= 1.0 - h; a += h) {
+    // Counts the number of samples in (a,a+h).
+    const double count =
+        (x.array() >= a && x.array() <= a + h).cast<double>().matrix().sum();
+
+    // Basic confidence interval statistics.  See, for instance,
+    //    Simulation and the Monte Carlo Method (Third Edition)
+    //      by Rubinstein and Kroese, 2017
+    //    page 108,
+    // where I've used Y as the indicator function of a ≤ X ≤ a+h,
+    // E[Y] = h, Var(Y) = h-h². We expect a perfect sampler to obtain
+    // a value
+    //   count/N = E[Y] ± 1.645 √(Var(Y)/N)
+    // with 95% confidence.
+    EXPECT_NEAR(count / N, h, 1.645 * std::sqrt((h - h * h) / N));
   }
 }
 

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -70,11 +70,9 @@ GTEST_TEST(TestSignalLogger, UniformWhiteNoise) {
 
   const auto& x = logger->data();
 
-  for (double threshold = -1.0; threshold < 1.0; threshold += 0.1) {
+  for (double threshold = 0.0; threshold < 1.0; threshold += 0.1) {
     double count = (x.array() < threshold).cast<double>().matrix().sum();
-    // Probability of x < threshold for this uniform distribution is
-    // (threshold+1)/2.
-    EXPECT_NEAR(count / x.size(), (threshold + 1.0) / 2.0,
+    EXPECT_NEAR(count / x.size(), threshold,
                 0.02);  // Note intentionally very large tolerance.
     // TODO(russt): Tighten tolerance once #4325 is resolved.
   }


### PR DESCRIPTION
Adds annotation to InputPortDescriptor for inputs that are anticipated as random noise/disturbances, as discussed in #6374.  pipes optional input through System, LeafSystem, and DiagramBuilder/Diagram, and adds basic unit test coverage.

Also change UniformRandomSource to have range [0,1]. I was on the fence about this vs [-1,1] in the first place, and it is clear now that [0,1] is the right choice because otherwise I will have to carry through the overloads of std::uniform_real_distribution everywhere. Fortunately(?), it seems that there were no systems actually using this source yet, anyhow.  

These come in together in this PR because the syntax for kUniformRandom input types should match the UniformRandomSource output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6994)
<!-- Reviewable:end -->
