### PR TITLE
adds NVI Clone() to VectorBase interface.

### DIFF
--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -48,6 +48,7 @@ drake_cc_googletest(
     deps = [
         ":luenberger_observer",
         "//drake/common:eigen_matrix_compare",
+        "//drake/examples/pendulum:pendulum_plant",
         "//drake/systems/primitives:linear_system",
     ],
 )

--- a/drake/systems/estimators/luenberger_observer.cc
+++ b/drake/systems/estimators/luenberger_observer.cc
@@ -33,45 +33,36 @@ LuenbergerObserver<T>::LuenbergerObserver(
 
   // Observer state is the (estimated) state of the observed system
   // (returned by overloaded AllocateContinuousState).
-  auto x = observed_system_context_->get_continuous_state();
+  const auto& xc = observed_system_context_->get_continuous_state_vector();
+  this->DeclareContinuousState(xc);
 
   // Output port is the (estimated) state of the observed system.
-  this->DeclareVectorOutputPort(systems::BasicVector<T>(x->size()),
+  // Note: The derived type of the state vector is lost here, because xc
+  // is only guaranteed to be a VectorBase, not a BasicVector.
+  this->DeclareVectorOutputPort(BasicVector<T>(xc.size()),
                                 &LuenbergerObserver::CalcEstimatedState);
-  // TODO(russt): Could overload AllocateContinuousState and AllocateOutput to
-  // call AllocateContinuousState on the observed system so that I can use the
-  // actual derived class types.
 
   // First input port is the output of the observed system.
-  this->DeclareInputPort(systems::kVectorValued,
-                         observed_system_->get_output_port(0).size());
+  // Note: Throws bad_cast if the output is not vector-valued.
+  this->DeclareVectorInputPort(*observed_system_output_->get_vector_data(0));
 
   // Check the size of the gain matrix.
-  DRAKE_DEMAND(observer_gain_.rows() == x->size());
+  DRAKE_DEMAND(observer_gain_.rows() == xc.size());
   DRAKE_DEMAND(observer_gain_.cols() ==
                observed_system_->get_output_port(0).size());
 
   // Second input port is the input to the observed system (if it exists).
   if (observed_system_->get_num_input_ports() > 0) {
-    this->DeclareInputPort(systems::kVectorValued,
-                           observed_system_->get_input_port(0).size());
+    auto input_vec = observed_system_->AllocateInputVector(
+        observed_system_->get_input_port(0));
+    this->DeclareVectorInputPort(*input_vec);
   }
-
-  // State has the same dimensions as the system being observed.
-  const ContinuousState<T>& xc =
-      *observed_system_context_->get_continuous_state();
-  const int num_q = xc.get_generalized_position().size();
-  const int num_v = xc.get_generalized_velocity().size();
-  const int num_z = xc.get_misc_continuous_state().size();
-  this->DeclareContinuousState(num_q, num_v, num_z);
 }
 
 template <typename T>
 void LuenbergerObserver<T>::CalcEstimatedState(
-    const systems::Context<T>& context,
-    systems::BasicVector<T>* output) const {
-  output->set_value(
-      context.get_continuous_state_vector().CopyToVector());
+    const systems::Context<T>& context, systems::BasicVector<T>* output) const {
+  output->set_value(context.get_continuous_state_vector().CopyToVector());
 }
 
 template <typename T>
@@ -107,8 +98,8 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
   auto xdothat = observed_system_derivatives_->get_mutable_vector();
 
   // xdothat = f(xhat,u) + L(y-yhat).
-  derivatives->SetFromVector(
-      xdothat->CopyToVector() + observer_gain_ * (y - yhat));
+  derivatives->SetFromVector(xdothat->CopyToVector() +
+                             observer_gain_ * (y - yhat));
 }
 
 template class LuenbergerObserver<double>;

--- a/drake/systems/estimators/luenberger_observer.h
+++ b/drake/systems/estimators/luenberger_observer.h
@@ -39,6 +39,7 @@ class LuenbergerObserver : public systems::LeafSystem<T> {
   ///
   /// Note: Takes ownership of the unique_ptrs to the observed_system and the
   /// observed_system_context.
+  /// @throws std::bad_cast if the observed_system output is not vector-valued.
   LuenbergerObserver(
       std::unique_ptr<systems::System<T>> observed_system,
       std::unique_ptr<systems::Context<T>> observed_system_context,

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -574,6 +574,7 @@ drake_cc_googletest(
     deps = [
         ":vector",
         "//drake/common",
+        "//drake/common:eigen_matrix_compare",
     ],
 )
 

--- a/drake/systems/framework/basic_vector.h
+++ b/drake/systems/framework/basic_vector.h
@@ -133,7 +133,7 @@ class BasicVector : public VectorBase<T> {
   ///
   /// Subclasses of BasicVector must override DoClone to return their covariant
   /// type.
-  virtual BasicVector<T>* DoClone() const {
+  BasicVector<T>* DoClone() const override {
     return new BasicVector<T>(this->size());
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -648,7 +648,7 @@ class LeafSystem : public System<T> {
   /// @p model_vector.size() miscellaneous state variables, stored in a
   /// vector Cloned from @p model_vector.  Has no effect if
   /// AllocateContinuousState is overridden.
-  void DeclareContinuousState(const BasicVector<T>& model_vector) {
+  void DeclareContinuousState(const VectorBase<T>& model_vector) {
     const int num_q = 0, num_v = 0;
     const int num_z = model_vector.size();
     DeclareContinuousState(model_vector, num_q, num_v, num_z);
@@ -659,7 +659,7 @@ class LeafSystem : public System<T> {
   /// miscellaneous state variables, stored in a vector Cloned from
   /// @p model_vector. Aborts if @p model_vector has the wrong size. Has no
   /// effect if AllocateContinuousState is overridden.
-  void DeclareContinuousState(const BasicVector<T>& model_vector, int num_q,
+  void DeclareContinuousState(const VectorBase<T>& model_vector, int num_q,
                               int num_v, int num_z) {
     DRAKE_DEMAND(model_vector.size() == num_q + num_v + num_z);
     model_continuous_state_vector_ = model_vector.Clone();
@@ -1370,7 +1370,7 @@ class LeafSystem : public System<T> {
   LeafCompositeEventCollection<T> per_step_events_;
 
   // A model continuous state to be used in AllocateDefaultContext.
-  std::unique_ptr<BasicVector<T>> model_continuous_state_vector_;
+  std::unique_ptr<VectorBase<T>> model_continuous_state_vector_;
   int num_generalized_positions_{0};
   int num_generalized_velocities_{0};
   int num_misc_continuous_states_{0};

--- a/drake/systems/framework/subvector.h
+++ b/drake/systems/framework/subvector.h
@@ -55,6 +55,11 @@ class Subvector : public VectorBase<T> {
     return vector_->GetAtIndex(first_element_ + index);
   }
 
+ protected:
+  Subvector<T>* DoClone() const override {
+    return new Subvector<T>(vector_, first_element_, num_elements_);
+  }
+
  private:
   VectorBase<T>* vector_{nullptr};
   int first_element_{0};

--- a/drake/systems/framework/supervector.h
+++ b/drake/systems/framework/supervector.h
@@ -50,6 +50,12 @@ class Supervector : public VectorBase<T> {
     return target.first->GetAtIndex(target.second);
   }
 
+ protected:
+  Supervector<T>* DoClone() const override {
+    return new Supervector<T>(vectors_);
+  }
+
+
  private:
   // Given an index into the supervector, returns the subvector that
   // contains that index, and its offset within the subvector. This operation

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -103,9 +103,9 @@ class System {
   /// Returns a container that can hold the values of all of this System's
   /// output ports. It is sized with the number of output ports and uses each
   /// output port's allocation method to provide an object of the right type
-  /// for that port. A Context is provided as
-  /// an argument to support some specialized use cases. Most typical
-  /// System implementations should ignore it.
+  /// for that port. A Context is provided as an argument to support some
+  /// specialized use cases. Most typical System implementations should ignore
+  /// it.
   virtual std::unique_ptr<SystemOutput<T>> AllocateOutput(
       const Context<T>& context) const = 0;
 

--- a/drake/systems/framework/test/subvector_test.cc
+++ b/drake/systems/framework/test/subvector_test.cc
@@ -211,6 +211,15 @@ TEST_F(SubvectorTest, PlusEqScaled) {
   EXPECT_EQ(orig_vec.GetAtIndex(1), 446);
 }
 
+// Tests that when Subvector is cloned, its data is preserved.
+TEST_F(SubvectorTest, Clone) {
+  Subvector<double> vec(vector_.get(), 1, 2);
+  std::unique_ptr<VectorBase<double>> clone = vec.Clone();
+
+  EXPECT_TRUE(CompareMatrices(vec.CopyToVector(), clone->CopyToVector()));
+}
+
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/test/supervector_test.cc
+++ b/drake/systems/framework/test/supervector_test.cc
@@ -5,6 +5,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_matrix_compare.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/vector_base.h"
 
@@ -74,6 +75,15 @@ TEST_F(SupervectorTest, Empty) {
   Supervector<double> supervector(std::vector<VectorBase<double>*>{});
   EXPECT_EQ(0, supervector.size());
 }
+
+// Tests that when Supervector is cloned, its data is preserved.
+TEST_F(SupervectorTest, Clone) {
+  std::unique_ptr<VectorBase<double>> clone = supervector_->Clone();
+
+  EXPECT_TRUE(
+      CompareMatrices(supervector_->CopyToVector(), clone->CopyToVector()));
+}
+
 
 }  // namespace
 }  // namespace systems

--- a/drake/systems/framework/vector_base.h
+++ b/drake/systems/framework/vector_base.h
@@ -170,7 +170,26 @@ class VectorBase {
     return norm;
   }
 
+  /// Copies the entire vector to a new VectorBase, with the same concrete
+  /// implementation type.
+  ///
+  /// Uses the Non-Virtual Interface idiom because smart pointers do not have
+  /// type covariance.
+  std::unique_ptr<VectorBase<T>> Clone() const {
+    auto clone = std::unique_ptr<VectorBase<T>>(DoClone());
+    clone->SetFrom(*this);
+    return clone;
+  }
+
  protected:
+  /// Returns a new VectorBase containing a copy of the entire vector.
+  /// Caller must take ownership, and may rely on the NVI wrapper to initialize
+  /// the clone elementwise.
+  ///
+  /// Subclasses of VectorBase must override DoClone to return their covariant
+  /// type.
+  virtual VectorBase<T>* DoClone() const = 0;
+
   VectorBase() {}
 
   /// Adds in multiple scaled vectors to this vector. All vectors


### PR DESCRIPTION
also...
adds DoClone() implementations for Subvector and Supervector.
updates LeafSystem's model_continuous_state_vector to be any VectorBase (instead of BasicVector).
updates the Luenberger observer to derive the dynamic types (toward #6938).
The "continuous state is not a BasicVector" continues to be a pain point (see comment in Luenberger).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6997)
<!-- Reviewable:end -->
