### PR TITLE
Update Luenberger observe to use derived type of the observed system

### DIFF
--- a/drake/examples/acrobot/acrobot_run_lqr_w_estimator.cc
+++ b/drake/examples/acrobot/acrobot_run_lqr_w_estimator.cc
@@ -116,12 +116,9 @@ int do_main(int argc, char* argv[]) {
   systems::Simulator<double> simulator(*diagram);
 
   // Set an initial condition near the upright fixed point.
-  auto x0 = dynamic_cast<AcrobotStateVector<double>*>(
-      dynamic_cast<systems::DiagramContext<double>*>(
-          &diagram->GetMutableSubsystemContext(*acrobot_w_encoder,
-                                              simulator.get_mutable_context()))
-          ->GetMutableSubsystemContext(0)
-          .get_mutable_continuous_state_vector());
+  auto x0 = acrobot_w_encoder->get_mutable_acrobot_state(
+      &(diagram->GetMutableSubsystemContext(*acrobot_w_encoder,
+                                            simulator.get_mutable_context())));
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(M_PI + 0.1);
   x0->set_theta2(-.1);
@@ -150,16 +147,15 @@ int do_main(int argc, char* argv[]) {
   using common::CallMatlab;
   CallMatlab("figure", 1);
   CallMatlab("plot", x_logger->sample_times(),
-                (x_logger->data().row(0).array() - M_PI).matrix(),
-                x_logger->sample_times(), x_logger->data().row(1));
+             (x_logger->data().row(0).array() - M_PI).matrix(),
+             x_logger->sample_times(), x_logger->data().row(1));
   CallMatlab("legend", "theta1 - PI", "theta2");
   CallMatlab("axis", "tight");
 
   CallMatlab("figure", 2);
   CallMatlab("plot", x_logger->sample_times(),
-                (x_logger->data().array() - xhat_logger->data().array())
-                    .matrix()
-                    .transpose());
+             (x_logger->data().array() - xhat_logger->data().array())
+                 .matrix().transpose());
   CallMatlab("ylabel", "error");
   CallMatlab("legend", "theta1", "theta2", "theta1dot", "theta2dot");
   CallMatlab("axis", "tight");

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -48,6 +48,8 @@ drake_cc_googletest(
     deps = [
         ":luenberger_observer",
         "//drake/common:eigen_matrix_compare",
+        "//drake/common:is_dynamic_castable",
+        "//drake/examples/pendulum:pendulum_plant",
         "//drake/systems/primitives:linear_system",
     ],
 )

--- a/drake/systems/estimators/luenberger_observer.h
+++ b/drake/systems/estimators/luenberger_observer.h
@@ -39,6 +39,7 @@ class LuenbergerObserver : public systems::LeafSystem<T> {
   ///
   /// Note: Takes ownership of the unique_ptrs to the observed_system and the
   /// observed_system_context.
+  /// @throws std::bad_cast if the observed_system output is not vector-valued.
   LuenbergerObserver(
       std::unique_ptr<systems::System<T>> observed_system,
       std::unique_ptr<systems::Context<T>> observed_system_context,

--- a/drake/systems/estimators/test/CMakeLists.txt
+++ b/drake/systems/estimators/test/CMakeLists.txt
@@ -1,6 +1,3 @@
 
-drake_add_cc_test(luenberger_observer_test)
-target_link_libraries(luenberger_observer_test drakeEstimators)
-
 drake_add_cc_test(kalman_filter_test)
 target_link_libraries(kalman_filter_test drakeEstimators)

--- a/drake/systems/estimators/test/luenberger_observer_test.cc
+++ b/drake/systems/estimators/test/luenberger_observer_test.cc
@@ -7,6 +7,8 @@
 
 #include "drake/common/eigen_matrix_compare.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/test/is_dynamic_castable.h"
+#include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/systems/primitives/linear_system.h"
 
 namespace drake {
@@ -72,6 +74,30 @@ GTEST_TEST(LuenbergerObserverTest, ErrorDynamics) {
   EXPECT_TRUE(CompareMatrices(xhatdot, derivatives->CopyToVector(), tol));
   EXPECT_TRUE(CompareMatrices(
       xhat, output->GetMutableVectorData(0)->CopyToVector(), tol));
+}
+
+// Check that the observer inherits the dynamic types of the pendulum.
+GTEST_TEST(LuenbergerObserverTest, DerivedTypes) {
+  auto plant = std::make_unique<examples::pendulum::PendulumPlant<double>>();
+  auto plant_context = plant->CreateDefaultContext();
+  const Eigen::Matrix2d L = Eigen::Matrix2d::Identity();
+  auto observer =
+      std::make_unique<systems::estimators::LuenbergerObserver<double>>(
+          std::move(plant), std::move(plant_context), L);
+  auto context = observer->CreateDefaultContext();
+
+  // The first input is the output of the plant (here the pendulum state).
+  auto input0 = observer->AllocateInputVector(observer->get_input_port(0));
+  EXPECT_TRUE(is_dynamic_castable<examples::pendulum::PendulumState<double>>(
+      input0.get()));
+
+  // The second input is the input of the plant.
+  auto input1 = observer->AllocateInputVector(observer->get_input_port(1));
+  EXPECT_TRUE(is_dynamic_castable<examples::pendulum::PendulumInput<double>>(
+      input1.get()));
+
+  // Would love to make the state and output have type PendulumState, but it
+  // is not that way yet (see #6998).
 }
 
 }  // namespace


### PR DESCRIPTION
... where possible.  Baby steps towards #6938.

Also needed to add the gunit hack to be able to debug the acrobot example in CLion.  Yuck.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/6999)
<!-- Reviewable:end -->
