### PR TITLE
Add FAQ for fixing OpenGL / VTK errors when using `bazel test`. Use `local = 1` for select tests.

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -349,6 +349,8 @@ drake_cc_googletest(
     data = [
         ":test_models",
     ],
+    # Mitigate driver-related issues when running under `bazel test` (#7004).
+    local = 1,
     tags = ["manual"],
     deps = [
         ":rgbd_camera",


### PR DESCRIPTION
Per [this discussion](https://github.com/RobotLocomotion/drake/pull/6903#issuecomment-328120368) in #6903, some machines may encounter driver related issues when running OpenGL / VTK applications under `bazel test`.

This PR will add documentation to the FAQ, and updates the tests accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7004)
<!-- Reviewable:end -->
