### PR TITLE
Teach PassThrough to handle AbstractValue's.

### DIFF
--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -413,6 +413,7 @@ drake_cc_googletest(
         ":zero_order_hold",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -5,31 +5,80 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+#include <memory>
+#include <utility>
+
 #include "drake/common/unused.h"
 #include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
 namespace systems {
 
-// TODO(amcastro-tri): remove the size parameter from the constructor once
-// #3109 supporting automatic sizes is resolved.
+// TODO(amcastro-tri): remove the vector_size parameter from the constructor
+// once #3109 supporting automatic sizes is resolved.
 template <typename T>
-PassThrough<T>::PassThrough(int size)
-    : VectorSystem<T>(SystemTypeTag<systems::PassThrough>{}, size, size) {}
+PassThrough<T>::PassThrough(
+    int vector_size,
+    std::unique_ptr<const AbstractValue> abstract_model_value)
+    : LeafSystem<T>(SystemTypeTag<systems::PassThrough>()),
+      abstract_model_value_(std::move(abstract_model_value)) {
+  if (!is_abstract()) {
+    DRAKE_DEMAND(vector_size != -1);
+    BasicVector<T> model_value(vector_size);
+    this->DeclareVectorInputPort(model_value);
+    this->DeclareVectorOutputPort(
+        model_value, &PassThrough::DoCalcVectorOutput);
+  } else {
+    DRAKE_DEMAND(vector_size == -1);
+    // TODO(eric.cousineau): Remove value parameter from the constructor once
+    // the equivalent of #3109 for abstract values is also resolved.
+    this->DeclareAbstractInputPort(*abstract_model_value_);
+    // Use the std::function<> overloads to work with `AbstractValue` type
+    // directly and maintain type erasure.
+    auto abstract_value_allocator = [this](const Context<T>&) {
+      return abstract_model_value_->Clone();
+    };
+    namespace sp = std::placeholders;
+    this->DeclareAbstractOutputPort(
+        abstract_value_allocator,
+        std::bind(&PassThrough::DoCalcAbstractOutput, this, sp::_1, sp::_2));
+  }
+}
 
 template <typename T>
 template <typename U>
 PassThrough<T>::PassThrough(const PassThrough<U>& other)
-    : PassThrough<T>(other.get_input_port().size()) {}
+    : PassThrough(other.is_abstract() ? -1 : other.get_input_port().size(),
+                  other.is_abstract() ? other.abstract_model_value_->Clone()
+                                      : nullptr) {}
 
 template <typename T>
 void PassThrough<T>::DoCalcVectorOutput(
-    const Context<T>&,
-    const Eigen::VectorBlock<const VectorX<T>>& input,
-    const Eigen::VectorBlock<const VectorX<T>>& state,
-    Eigen::VectorBlock<VectorX<T>>* output) const {
-  unused(state);
-  *output = input;
+      const Context<T>& context,
+      BasicVector<T>* output) const {
+  DRAKE_ASSERT(!is_abstract());
+  const BasicVector<T>& input = *this->EvalVectorInput(context, 0);
+  DRAKE_ASSERT(input.size() == output->size());
+  output->SetFrom(input);
+}
+
+template <typename T>
+void PassThrough<T>::DoCalcAbstractOutput(const Context<T>& context,
+                                          AbstractValue* output) const {
+  DRAKE_ASSERT(is_abstract());
+  const AbstractValue& input =
+      *this->EvalAbstractInput(context, 0);
+  output->SetFrom(input);
+}
+
+template <typename T>
+optional<bool> PassThrough<T>::DoHasDirectFeedthrough(
+    int input_port, int output_port) const {
+  DRAKE_DEMAND(input_port == 0);
+  DRAKE_DEMAND(output_port == 0);
+  // By definition, a pass-through will have direct feedthrough, as the
+  // output depends directly on the input.
+  return true;
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -37,28 +37,72 @@ namespace systems {
 /// They are already available to link against in the containing library.
 /// @ingroup primitive_systems
 template <typename T>
-class PassThrough final : public VectorSystem<T> {
+class PassThrough final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PassThrough)
 
-  /// Constructs a pass thorough system (`y = u`).
-  /// @param size number of elements in the signal to be processed.
-  explicit PassThrough(int size);
+  /// Constructs a pass through system (`y = u`).
+  /// @param vector_size number of elements in the signal to be processed.
+  explicit PassThrough(int vector_size)
+      : PassThrough(vector_size, nullptr) {}
 
-  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  /// Constructs a pass through system (`y = u`).
+  /// @param abstract_model_value A model abstract value.
+  explicit PassThrough(const AbstractValue& abstract_model_value)
+      : PassThrough(-1, abstract_model_value.Clone()) {}
+
+  /// Scalar-type converting copy constructor.
+  /// See @ref system_scalar_conversion.
   template <typename U>
   explicit PassThrough(const PassThrough<U>&);
 
-  // TODO(eric.cousineau): Ensure that this system can also handle
-  // AbstractValue's akin to ZeroOrderHold (#6491).
+  virtual ~PassThrough() {}
+
+  // TODO(eric.cousineau): Possibly share single port interface with
+  // ZeroOrderHold (#6490).
+
+  /// Returns the sole input port.
+  const InputPortDescriptor<T>& get_input_port() const {
+    return LeafSystem<T>::get_input_port(0);
+  }
+
+  // Don't use the indexed get_input_port when calling this system directly.
+  void get_input_port(int) = delete;
+
+  /// Returns the sole output port.
+  const OutputPort<T>& get_output_port() const {
+    return LeafSystem<T>::get_output_port(0);
+  }
+
+  // Don't use the indexed get_output_port when calling this system directly.
+  void get_output_port(int) = delete;
 
  protected:
   /// Sets the output port to equal the input port.
   void DoCalcVectorOutput(
       const Context<T>& context,
-      const Eigen::VectorBlock<const VectorX<T>>& input,
-      const Eigen::VectorBlock<const VectorX<T>>& state,
-      Eigen::VectorBlock<VectorX<T>>* output) const override;
+      BasicVector<T>* output) const;
+
+  // Same as `DoCalcVectorOutput`, but for abstract values.
+  void DoCalcAbstractOutput(
+      const Context<T>& context,
+      AbstractValue* output) const;
+
+  // Override feedthrough detection to avoid the need for `DoToSymbolic()`.
+  optional<bool> DoHasDirectFeedthrough(
+      int input_port, int output_port) const override;
+
+ private:
+  bool is_abstract() const { return abstract_model_value_ != nullptr; }
+
+  // Delegated constructor so that we may clone properly at run-time.
+  PassThrough(int vector_size,
+              std::unique_ptr<const AbstractValue> abstract_model_value);
+
+  // Allow different specializations to access each other's private data.
+  template <typename U> friend class PassThrough;
+
+  const std::unique_ptr<const AbstractValue> abstract_model_value_;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/test/pass_through_test.cc
+++ b/drake/systems/primitives/test/pass_through_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/pass_through.h"
 
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -9,41 +10,70 @@
 #include "drake/systems/framework/input_port_value.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
-using Eigen::AutoDiffScalar;
-using Eigen::Vector2d;
-using Eigen::Vector3d;
+using Eigen::VectorXd;
 using std::make_unique;
 
 namespace drake {
 namespace systems {
 namespace {
 
-class PassThroughTest : public ::testing::Test {
+// A simple type containing a vector, to simplify checking expected values for
+// a vector-valued pass through (`BasicValue`) and an abstract-valued pass
+// through (`Value<SimpleAbstractType>`).
+class SimpleAbstractType {
+ public:
+  explicit SimpleAbstractType(int size)
+      : value_(size) {}
+  explicit SimpleAbstractType(const Eigen::VectorXd& value)
+      : value_(value) {}
+  const Eigen::VectorXd& value() const { return value_; }
+ private:
+  Eigen::VectorXd value_;
+};
+
+class PassThroughTest : public ::testing::TestWithParam<bool> {
  protected:
+  PassThroughTest()
+      : is_abstract_(GetParam()) {}
+
   void SetUp() override {
-    pass_through_ = make_unique<PassThrough<double>>(3 /* size */);
+    const int size = 3;
+    input_value_.resize(size);
+    input_value_ << 1.0, 3.14, 2.18;
+
+    if (!is_abstract_) {
+      pass_through_ = make_unique<PassThrough<double>>(size);
+    } else {
+      pass_through_ =
+          make_unique<PassThrough<double>>(Value<SimpleAbstractType>(size));
+    }
     context_ = pass_through_->CreateDefaultContext();
     output_ = pass_through_->AllocateOutput(*context_);
-    input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 
+  const bool is_abstract_;
+
+  Eigen::VectorXd input_value_;
   std::unique_ptr<System<double>> pass_through_;
   std::unique_ptr<Context<double>> context_;
   std::unique_ptr<SystemOutput<double>> output_;
-  std::unique_ptr<BasicVector<double>> input_;
 };
 
 // Tests that the output of this system equals its input.
-TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
+TEST_P(PassThroughTest, VectorThroughPassThroughSystem) {
   /// Checks that the number of input ports in the system and in the context
   // are consistent.
   ASSERT_EQ(1, context_->get_num_input_ports());
   ASSERT_EQ(1, pass_through_->get_num_input_ports());
-  Eigen::Vector3d input_vector(1.0, 3.14, 2.18);
-  input_->get_mutable_value() << input_vector;
 
   // Hook input of the expected size.
-  context_->FixInputPort(0, std::move(input_));
+  if (!is_abstract_) {
+    context_->FixInputPort(
+        0, std::make_unique<BasicVector<double>>(input_value_));
+  } else {
+    context_->FixInputPort(
+        0, AbstractValue::Make(SimpleAbstractType(input_value_)));
+  }
 
   pass_through_->CalcOutput(*context_, output_.get());
 
@@ -51,27 +81,41 @@ TEST_F(PassThroughTest, VectorThroughPassThroughSystem) {
   // output are consistent.
   ASSERT_EQ(1, output_->get_num_ports());
   ASSERT_EQ(1, pass_through_->get_num_output_ports());
-  const BasicVector<double>* output_vector = output_->get_vector_data(0);
-  ASSERT_NE(nullptr, output_vector);
-  EXPECT_EQ(input_vector, output_vector->get_value());
+
+  Eigen::VectorXd output;
+  if (!is_abstract_) {
+    const BasicVector<double>* output_vector = output_->get_vector_data(0);
+    ASSERT_NE(nullptr, output_vector);
+    output = output_vector->get_value();
+  } else {
+    output = output_->get_data(0)->GetValue<SimpleAbstractType>().value();
+  }
+  EXPECT_EQ(input_value_, output);
 }
 
 // Tests that PassThrough allocates no state variables in the context_.
-TEST_F(PassThroughTest, PassThroughIsStateless) {
+TEST_P(PassThroughTest, PassThroughIsStateless) {
   EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_abstract_state()->size());
+  EXPECT_EQ(0, context_->get_discrete_state()->num_groups());
 }
 
-TEST_F(PassThroughTest, DirectFeedthrough) {
+// Tests that PassThrough is direct feedthrough.
+TEST_P(PassThroughTest, DirectFeedthrough) {
   EXPECT_TRUE(pass_through_->HasAnyDirectFeedthrough());
 }
 
-TEST_F(PassThroughTest, ToAutoDiff) {
+TEST_P(PassThroughTest, ToAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(*pass_through_));
 }
 
-TEST_F(PassThroughTest, ToSymbolic) {
+TEST_P(PassThroughTest, ToSymbolic) {
   EXPECT_TRUE(is_symbolic_convertible(*pass_through_));
 }
+
+// Instantiate parameterized test cases for is_abstract_ = {false, true}
+INSTANTIATE_TEST_CASE_P(test, PassThroughTest,
+    ::testing::Values(false, true));
 
 }  // namespace
 }  // namespace systems

--- a/drake/systems/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/primitives/test/zero_order_hold_test.cc
@@ -11,6 +11,7 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
 #include "drake/systems/framework/output_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
 namespace systems {
@@ -194,6 +195,14 @@ TEST_P(ZeroOrderHoldTest, Update) {
     value = state->get_abstract_state<SimpleAbstractType>(0).value();
   }
   EXPECT_EQ(input_value_, value);
+}
+
+TEST_P(ZeroOrderHoldTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*hold_));
+}
+
+TEST_P(ZeroOrderHoldTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*hold_));
 }
 
 // Instantiate parameterized test cases for is_abstract_ = {false, true}

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -6,6 +6,7 @@
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "drake/common/unused.h"
@@ -15,34 +16,48 @@ namespace drake {
 namespace systems {
 
 template <typename T>
-ZeroOrderHold<T>::ZeroOrderHold(double period_sec, int size)
-    : period_sec_(period_sec) {
-  // TODO(david-german-tri): remove the size parameter from the constructor
-  // once #3109 supporting automatic sizes is resolved.
-  BasicVector<T> dummy_value(size);
-  this->DeclareVectorInputPort(dummy_value);
-  this->DeclareVectorOutputPort(
-      dummy_value, &ZeroOrderHold::DoCalcVectorOutput);
-  this->DeclareDiscreteState(size);
-  this->DeclarePeriodicDiscreteUpdate(period_sec);
+ZeroOrderHold<T>::ZeroOrderHold(
+    double period_sec, int vector_size,
+    std::unique_ptr<const AbstractValue> abstract_model_value)
+    : LeafSystem<T>(SystemTypeTag<systems::ZeroOrderHold>()),
+      period_sec_(period_sec),
+      abstract_model_value_(std::move(abstract_model_value)) {
+  if (!is_abstract()) {
+    DRAKE_DEMAND(vector_size != -1);
+    // TODO(david-german-tri): remove the size parameter from the constructor
+    // once #3109 supporting automatic sizes is resolved.
+    BasicVector<T> model_value(vector_size);
+    this->DeclareVectorInputPort(model_value);
+    this->DeclareVectorOutputPort(
+        model_value, &ZeroOrderHold::DoCalcVectorOutput);
+    this->DeclareDiscreteState(vector_size);
+    this->DeclarePeriodicDiscreteUpdate(period_sec_);
+  } else {
+    DRAKE_DEMAND(vector_size == -1);
+    // TODO(eric.cousineau): Remove value parameter from the constructor once
+    // the equivalent of #3109 for abstract values is also resolved.
+    this->DeclareAbstractInputPort(*abstract_model_value_);
+    // Use the std::function<> overloads to work with `AbstractValue` type
+    // directly and maintain type erasure.
+    auto abstract_value_allocator = [this](const Context<T>&) {
+      return abstract_model_value_->Clone();
+    };
+    namespace sp = std::placeholders;
+    this->DeclareAbstractOutputPort(
+        abstract_value_allocator,
+        std::bind(&ZeroOrderHold::DoCalcAbstractOutput, this, sp::_1, sp::_2));
+    this->DeclareAbstractState(abstract_model_value_->Clone());
+    this->DeclarePeriodicUnrestrictedUpdate(period_sec_, 0.);
+  }
 }
 
 template <typename T>
-ZeroOrderHold<T>::ZeroOrderHold(double period_sec,
-                                const AbstractValue& model_value)
-    : period_sec_(period_sec), abstract_model_value_(model_value.Clone()) {
-  // TODO(eric.cousineau): Remove value parameter from the constructor once
-  // the equivalent of #3109 for abstract values is also resolved.
-  this->DeclareAbstractInputPort(model_value);
-  // Use the std::function<> overloads to work with `AbstractValue` type
-  // directly and maintain type erasure.
-  namespace sp = std::placeholders;
-  this->DeclareAbstractOutputPort(
-      std::bind(&ZeroOrderHold::AllocateAbstractValue, this, sp::_1),
-      std::bind(&ZeroOrderHold::DoCalcAbstractOutput, this, sp::_1, sp::_2));
-  this->DeclareAbstractState(model_value.Clone());
-  this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0.);
-}
+template <typename U>
+ZeroOrderHold<T>::ZeroOrderHold(const ZeroOrderHold<U>& other)
+    : ZeroOrderHold(other.period_sec_,
+                    other.is_abstract() ? -1 : other.get_input_port().size(),
+                    other.is_abstract() ? other.abstract_model_value_->Clone()
+                                        : nullptr) {}
 
 template <typename T>
 void ZeroOrderHold<T>::DoCalcVectorOutput(
@@ -65,12 +80,6 @@ void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
 }
 
 template <typename T>
-std::unique_ptr<AbstractValue>
-ZeroOrderHold<T>::AllocateAbstractValue(const Context<T>&) const {
-  return abstract_model_value_->Clone();
-}
-
-template <typename T>
 void ZeroOrderHold<T>::DoCalcAbstractOutput(const Context<T>& context,
                                             AbstractValue* output) const {
   DRAKE_ASSERT(is_abstract());
@@ -85,7 +94,7 @@ template <typename T>
 void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
     const Context<T>& context,
     const std::vector<const UnrestrictedUpdateEvent<T>*>&,
-    State<T> *state) const {
+    State<T>* state) const {
   DRAKE_ASSERT(is_abstract());
   const AbstractValue& input_value = *this->EvalAbstractInput(context, 0);
   // See `DoCalcAbstractOutput` for rationale regarding non-templated value
@@ -103,18 +112,6 @@ optional<bool> ZeroOrderHold<T>::DoHasDirectFeedthrough(
   // By definition, a zero-order hold will not have direct feedthrough, as the
   // output only depends on the state, not the input.
   return false;
-}
-
-template <typename T>
-ZeroOrderHold<symbolic::Expression>* ZeroOrderHold<T>::DoToSymbolic() const {
-  if (!is_abstract()) {
-    return new ZeroOrderHold<symbolic::Expression>(
-        period_sec_, this->get_input_port().size());
-  } else {
-    // Return `nullptr` to enable control to reach `DoHasDirectFeedthrough`.
-    // See Doxygen comments regarding transmogrification.
-    return nullptr;
-  }
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/zero_order_hold.h
+++ b/drake/systems/primitives/zero_order_hold.h
@@ -24,19 +24,26 @@ class ZeroOrderHold : public LeafSystem<T> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ZeroOrderHold)
 
   /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
-  /// vector-valued input of size @p size. The default initial value for this
-  /// system will be zero.
-  ZeroOrderHold(double period_sec, int size);
+  /// vector-valued input of size `vector_size`. The default initial
+  /// value for this system will be zero.
+  ZeroOrderHold(double period_sec, int vector_size)
+      : ZeroOrderHold(period_sec, vector_size, nullptr) {}
 
   /// Constructs a ZeroOrderHold system with the given @p period_sec, over a
-  /// abstract-valued input @p model_value. The default initial value for this
-  /// system will be @p model_value.
-  ZeroOrderHold(double period_sec, const AbstractValue& model_value);
+  /// abstract-valued input `abstract_model_value`. The default initial value
+  /// for this system will be `abstract_model_value`.
+  ZeroOrderHold(double period_sec, const AbstractValue& abstract_model_value)
+      : ZeroOrderHold(period_sec, -1, abstract_model_value.Clone()) {}
+
+  /// Scalar-type converting copy constructor.
+  /// See @ref system_scalar_conversion.
+  template <typename U>
+  explicit ZeroOrderHold(const ZeroOrderHold<U>& other);
 
   ~ZeroOrderHold() override {}
 
-  // TODO(eric.cousineau): Create a SisoSystem that is type-agnostic, and
-  // have both this and SisoVectorSystem inherit from it (#6490).
+  // TODO(eric.cousineau): Possibly share single port interface with
+  // PassThrough (#6490).
 
   /// Returns the sole input port.
   const InputPortDescriptor<T>& get_input_port() const {
@@ -60,24 +67,17 @@ class ZeroOrderHold : public LeafSystem<T> {
   optional<bool> DoHasDirectFeedthrough(
       int input_port, int output_port) const override;
 
-  // System<T> override.  Returns a ZeroOrderHold<symbolic::Expression> with
-  // the same dimensions as this ZeroOrderHold.
-  ZeroOrderHold<symbolic::Expression>* DoToSymbolic() const override;
-
-  /// Sets the output port value to the vector value that is currently
-  /// latched in the zero-order hold.
+  // Sets the output port value to the vector value that is currently
+  // latched in the zero-order hold.
   void DoCalcVectorOutput(
       const Context<T>& context,
       BasicVector<T>* output) const;
 
-  /// Latches the input port into the discrete vector-valued state.
+  // Latches the input port into the discrete vector-valued state.
   void DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>& events,
       DiscreteValues<T>* discrete_state) const override;
-
-  // Return a cloned copy of the initial abstract value.
-  std::unique_ptr<AbstractValue> AllocateAbstractValue(const Context<T>&) const;
 
   // Same as `DoCalcVectorOutput`, but for abstract values.
   void DoCalcAbstractOutput(
@@ -93,8 +93,14 @@ class ZeroOrderHold : public LeafSystem<T> {
  private:
   bool is_abstract() const { return abstract_model_value_ != nullptr; }
 
-  const double period_sec_{};
-  const std::unique_ptr<const AbstractValue> abstract_model_value_;
+  ZeroOrderHold(double period_sec, int vector_size,
+                std::unique_ptr<const AbstractValue> model_value);
+
+  // Allow different specializations to access each other's private data.
+  template <typename U> friend class ZeroOrderHold;
+
+  double period_sec_{};
+  std::unique_ptr<const AbstractValue> abstract_model_value_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
Ran into a use case where I would like to use `PassThrough` to connect a diagram's exported input to multiple subsystems with an abstract value.

This implementation mostly reflects that of `ZeroOrderHold` - should they share these implementation details (which are effectively duplicated)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7008)
<!-- Reviewable:end -->
