### PR TITLE
Fix `namespace drake` being mis-documented

### DIFF
--- a/drake/multibody/inverse_kinematics_backend.cc
+++ b/drake/multibody/inverse_kinematics_backend.cc
@@ -33,6 +33,7 @@ using drake::solvers::MatrixXDecisionVariable;
 using drake::solvers::MathematicalProgram;
 using drake::solvers::SolutionResult;
 
+/// @file
 /// NOTE: The contents of this class are for the most part direct ports of
 /// drake/systems/plants/@RigidBodyManipulator/inverseKinBackend.m from Matlab
 /// to C++; many methods and variables follow Matlab conventions and are


### PR DESCRIPTION
The "NOTE" at the top of http://drake.mit.edu/doxygen_cxx/namespacedrake.html is not what we want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7011)
<!-- Reviewable:end -->
