### PR TITLE
Set C locale on automotive demo python launcher

### DIFF
--- a/drake/automotive/automotive_demo.py
+++ b/drake/automotive/automotive_demo.py
@@ -77,7 +77,8 @@ class Launcher(object):
             raise RuntimeError(command[0] + " not found")
 
         # Create a new execution environment by copying the current one, but
-        # making sure to use the C locale
+        # making sure to use the C locale, so that obj meshes are properly
+        # parsed.
         command_env = dict(os.environ)
         command_env['LC_ALL'] = 'C'
 

--- a/drake/automotive/automotive_demo.py
+++ b/drake/automotive/automotive_demo.py
@@ -75,10 +75,18 @@ class Launcher(object):
             sys.stdout.flush()
             subprocess.call(["/usr/bin/find", "-L", "."])
             raise RuntimeError(command[0] + " not found")
+
+        # Create a new execution environment by copying the current one, but
+        # making sure to use the C locale
+        command_env = dict(os.environ)
+        command_env['LC_ALL'] = 'C'
+
         process = subprocess.Popen(
             command,
             stdin=self.devnull,
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=command_env)
         flags = fcntl.fcntl(process.stdout, fcntl.F_GETFL)
         fcntl.fcntl(process.stdout, fcntl.F_SETFL, flags | os.O_NONBLOCK)
         self.children.append(TrackedProcess(label, process))


### PR DESCRIPTION
If the locale of the machine running Drake doesn't use `.` as a decimal separator the road meshes of the automotive demo won't show in the visualizer, failing silently. Assuming you have the `es_AR.UTF-8` locale installed, a consistent way to reproduce this is to execute:

```
$ export LC_ALL=es_AR.UTF-8
$ bazel run //drake/automotive:demo -- --num_dragway_lanes=3 --num_trajectory_car=1
```
which results in

![road-before](https://user-images.githubusercontent.com/4070228/30446900-c63ab802-998a-11e7-92b3-b73f4a3d84bc.png)

With the change of this PR in place the same execution renders the expected mesh:

![road-after](https://user-images.githubusercontent.com/4070228/30446958-e7384c22-998a-11e7-8ed9-b51d2ae57937.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7021)
<!-- Reviewable:end -->
