### PR TITLE
Factor out os.bzl

### DIFF
--- a/tools/drake_visualizer.bzl
+++ b/tools/drake_visualizer.bzl
@@ -32,43 +32,26 @@ Argument:
     name: A unique name for this rule.
 """
 
+load("@drake//tools:os.bzl", "determine_os")
+
 # TODO(jamiesnape): Publish scripts used to create binaries. There will be a CI
 # job for developers to build new binaries on demand.
 def _impl(repository_ctx):
-    if repository_ctx.os.name == "mac os x":
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+
+    if os_result.is_mac:
         archive = "dv-0.1.0-173-g6e49220-qt-5.9.1-vtk-8.0.1-mac-x86_64.tar.gz"
         sha256 = "65b78914327c82bb8fd7cf2182dedc2a45edeafc44fc229415528ee2180bf9a4"  # noqa
-    elif repository_ctx.os.name == "linux":
-        sed = repository_ctx.which("sed")
-
-        if not sed:
-            fail("Could NOT determine Linux distribution information because" +
-                 " sed is missing")
-
-        result = repository_ctx.execute([
-            sed,
-            "-n",
-            "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
-            "/etc/os-release"])
-
-        if result.return_code != 0:
-            fail("Could NOT determine Linux distribution information",
-                 attr = result.stderr)
-
-        distro = [l.strip() for l in result.stdout.strip().split("\n")]
-        distro = " ".join(distro)
-
-        if distro == "Ubuntu 14.04":
-            archive = "dv-0.1.0-173-g6e49220-qt-4.8.6-vtk-8.0.1-trusty-x86_64.tar.gz"  # noqa
-            sha256 = "a9b03955cc22803f418fc712d98b3b0f83411d480ed63c6544e6ddfa141e92d5"  # noqa
-        elif distro == "Ubuntu 16.04":
-            archive = "dv-0.1.0-173-g6e49220-qt-5.5.1-vtk-8.0.1-xenial-x86_64.tar.gz"  # noqa
-            sha256 = "57ebe3cef758b42bdc1affb50e371a1e5224e73e3c2ebe25dcbba7697b66d24d"  # noqa
-        else:
-            fail("Linux distribution is NOT supported", attr = distro)
+    elif os_result.ubuntu_release == "14.04":
+        archive = "dv-0.1.0-173-g6e49220-qt-4.8.6-vtk-8.0.1-trusty-x86_64.tar.gz"  # noqa
+        sha256 = "a9b03955cc22803f418fc712d98b3b0f83411d480ed63c6544e6ddfa141e92d5"  # noqa
+    elif os_result.ubuntu_release == "16.04":
+        archive = "dv-0.1.0-173-g6e49220-qt-5.5.1-vtk-8.0.1-xenial-x86_64.tar.gz"  # noqa
+        sha256 = "57ebe3cef758b42bdc1affb50e371a1e5224e73e3c2ebe25dcbba7697b66d24d"  # noqa
     else:
-        fail("Operating system is NOT supported",
-             attr = repository_ctx.os.name)
+        fail("Operating system is NOT supported", attr = os_result)
 
     url = "https://d2mbb5ninhlpdu.cloudfront.net/director/{}".format(archive)
     root_path = repository_ctx.path("")

--- a/tools/expat.bzl
+++ b/tools/expat.bzl
@@ -28,9 +28,14 @@ load(
     "@kythe//tools/build_rules/config:pkg_config.bzl",
     "setup_pkg_config_package",
 )
+load("@drake//tools:os.bzl", "determine_os")
 
 def _impl(repository_ctx):
-    if repository_ctx.os.name == "mac os x":
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+
+    if os_result.is_mac:
         repository_ctx.file("empty.cc", executable = False)
 
         repository_ctx.symlink("/usr/include/expat.h", "include/expat.h")

--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -2,10 +2,16 @@
 # This is a Bazel repository_rule for the Gurobi solver.  See
 # https://www.bazel.io/versions/master/docs/skylark/repository_rules.html
 
+load("@drake//tools:os.bzl", "determine_os")
+
 # Ubuntu only: GUROBI_PATH should be the linux64 directory in the Gurobi 7.0.2
 # release.
 def _gurobi_impl(repository_ctx):
-    if repository_ctx.os.name == "mac os x":
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+
+    if os_result.is_mac:
         gurobi_path = "/Library/gurobi702/mac64"
         repository_ctx.symlink(gurobi_path, "gurobi-distro")
         warning = "Gurobi 7.0.2 is not installed."

--- a/tools/os.bzl
+++ b/tools/os.bzl
@@ -1,0 +1,98 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+"""A collection of OS-related utilities intended for use in repository rules,
+i.e., rules used by WORKSPACE files, not BUILD files.
+"""
+
+def exec_using_which(repository_ctx, command):
+    """Run the given command (a list), using which to locate the executable named
+    by the zeroth index of `command`.
+
+    Return struct with attributes:
+    - error (None when success, or else str message)
+    - stdout (str command output, possibly empty)
+    """
+
+    # Find the executable.
+    fullpath = repository_ctx.which(command[0])
+    if fullpath == None:
+        return struct(
+            stdout = "",
+            error = "could not find which '%s'" % command[0])
+
+    # Run the executable.
+    result = repository_ctx.execute([fullpath] + command[1:])
+    if result.return_code != 0:
+        error = "error %d running %r (command %r, stdout %r, stderr %r)" % (
+            result.return_code,
+            command[0],
+            command,
+            result.stdout,
+            result.stderr)
+        return struct(stdout = result.stdout, error = error)
+
+    # Success.
+    return struct(stdout = result.stdout, error = None)
+
+def _make_result(error = None,
+                 is_mac = False,
+                 ubuntu_release = None):
+    """Return a fully-populated struct result for determine_os, below."""
+    return struct(
+        error = error,
+        is_mac = is_mac,
+        is_ubuntu = (ubuntu_release != None),
+        ubuntu_release = ubuntu_release)
+
+def _determine_linux(repository_ctx):
+    """Handle determine_os on Linux."""
+
+    # Shared error message text across different failure cases.
+    error_prologue = "could not determine Linux distribution: "
+
+    # Run sed to determine Linux NAME and VERSION_ID.
+    sed = exec_using_which(repository_ctx, [
+        "sed",
+        "-n",
+        "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
+        "/etc/os-release"])
+    if sed.error != None:
+        return _make_result(error = error_prologue + sed.error)
+
+    # Compute an identifying string, in the form of "$NAME $VERSION_ID".
+    lines = [line.strip() for line in sed.stdout.strip().split("\n")]
+    distro = " ".join([x for x in lines if len(x) > 0])
+
+    # Match supported Ubuntu releases.
+    for ubuntu_release in ["14.04", "16.04"]:
+        if distro == "Ubuntu " + ubuntu_release:
+            return _make_result(ubuntu_release = ubuntu_release)
+
+    # Nothing matched.
+    return _make_result(
+        error = error_prologue + "unsupported distribution '%s'" % distro)
+
+def determine_os(repository_ctx):
+    """
+    A repository_rule helper function that determines which of the supported OS
+    versions we are targeting.
+
+    Argument:
+        repository_ctx: The context passed to the repository_rule calling this.
+
+    Result:
+        a struct, with attributes:
+        - error: str iff any error occurred, else None
+        - is_mac: True iff on a supported macOS or Mac version, else False
+        - is_ubuntu: True iff on a supported Ubuntu version, else False
+        - ubuntu_release: str like "16.04" iff on a supported ubuntu, else None
+    """
+
+    os_name = repository_ctx.os.name
+    if os_name == "mac os x":
+        return _make_result(is_mac = True)
+    elif os_name == "linux":
+        return _determine_linux(repository_ctx)
+    else:
+        return _make_result(error = "unknown or unsupported OS '%s'" % os_name)

--- a/tools/vtk.bzl
+++ b/tools/vtk.bzl
@@ -23,6 +23,8 @@ Argument:
     name: A unique name for this rule.
 """
 
+load("@drake//tools:os.bzl", "determine_os")
+
 VTK_MAJOR_MINOR_VERSION = "8.0"
 
 def _vtk_cc_library(os_name, name, hdrs = None, visibility = None, deps = None,
@@ -75,37 +77,23 @@ cc_library(
     return content
 
 def _impl(repository_ctx):
-    if repository_ctx.os.name == "mac os x":
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+
+    if os_result.is_mac:
         repository_ctx.symlink("/usr/local/opt/vtk@{}/include".format(
             VTK_MAJOR_MINOR_VERSION), "include")
         repository_ctx.file("empty.cc", executable = False)
-
-    elif repository_ctx.os.name == "linux":
-        sed = repository_ctx.which("sed")
-        if sed == None:
-            fail("Could NOT determine Linux distribution information" +
-                 "('sed' is missing?!)", sed)
-        result = repository_ctx.execute([
-            sed,
-            "-n",
-            "/^\(NAME\|VERSION_ID\)=/{s/[^=]*=//;s/\"//g;p}",
-            "/etc/os-release"])
-
-        if result.return_code != 0:
-            fail("Could NOT determine Linux distribution information",
-                 attr = result.stderr)
-
-        distro = [l.strip() for l in result.stdout.strip().split("\n")]
-        distro = " ".join(distro)
-
-        if distro == "Ubuntu 14.04":
+    elif os_result.is_ubuntu:
+        if os_result.ubuntu_release == "14.04":
             archive = "vtk-8.0.1-qt-4.8.6-trusty-x86_64.tar.gz"
             sha256 = "ba58f2fb23a42074ed8f5177f3bc6d4ef8c169a761969f83cfeae32af723b6f1"  # noqa
-        elif distro == "Ubuntu 16.04":
+        elif os_result.ubuntu_release == "16.04":
             archive = "vtk-8.0.1-qt-5.5.1-xenial-x86_64.tar.gz"
             sha256 = "095a88c14c44b8f2655c5932f21ccbfeca840e5815f14b153bc5d5a102940527"  # noqa
         else:
-            fail("Linux distribution is NOT supported", attr = distro)
+            fail("Operating system is NOT supported", attr = os_result)
 
         url = "https://d2mbb5ninhlpdu.cloudfront.net/vtk/{}".format(archive)
         root_path = repository_ctx.path("")
@@ -113,8 +101,7 @@ def _impl(repository_ctx):
         repository_ctx.download_and_extract(url, root_path, sha256 = sha256)
 
     else:
-        fail("Operating system is NOT supported",
-             attr = repository_ctx.os.name)
+        fail("Operating system is NOT supported", attr = os_result)
 
     # Note that we only create library targets for enough of VTK to support
     # those used directly or indirectly by Drake.
@@ -366,7 +353,7 @@ def _impl(repository_ctx):
     )
 
     # Compilation failures with system version of LZ4 on Ubuntu 14.04.
-    if repository_ctx.os.name == "linux" and distro == "Ubuntu 14.04":
+    if os_result.ubuntu_release == "14.04":
         VTKLZ4 = ":vtklz4"
     else:
         VTKLZ4 = "@liblz4"
@@ -549,7 +536,7 @@ def _impl(repository_ctx):
         header_only = True,
     )
 
-    if repository_ctx.os.name == "linux" and distro == "Ubuntu 14.04":
+    if os_result.ubuntu_release == "14.04":
         file_content += _vtk_cc_library(repository_ctx.os.name, "vtklz4")
 
     file_content += _vtk_cc_library(repository_ctx.os.name, "vtkmetaio",

--- a/tools/zlib.bzl
+++ b/tools/zlib.bzl
@@ -28,9 +28,14 @@ load(
     "@kythe//tools/build_rules/config:pkg_config.bzl",
     "setup_pkg_config_package",
 )
+load("@drake//tools:os.bzl", "determine_os")
 
 def _impl(repository_ctx):
-    if repository_ctx.os.name == "mac os x":
+    os_result = determine_os(repository_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+
+    if os_result.is_mac:
         repository_ctx.file("empty.cc", executable = False)
 
         repository_ctx.symlink("/usr/include/zlib.h", "include/zlib.h")


### PR DESCRIPTION
This makes the OS detection reusable (and thus necessarily consistent) across multiple repository rules.

I came up with these helpers when exploring IPOPT solutions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7026)
<!-- Reviewable:end -->
