### PR TITLE
Fix or mitigate too-long lines

### DIFF
--- a/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
+++ b/drake/examples/QPInverseDynamicsForHumanoids/system/valkyrie_controller.h
@@ -28,9 +28,9 @@ using systems::controllers::qp_inverse_dynamics::QpInverseDynamicsSystem;
 
 /**
  * A controller for humanoid balancing built on top of HumanoidPlanEvalSystem
- * and QpInverseDynamicsSystemSystem. This diagram does not have any input or output ports.
- * The state and plan inputs and control outputs are sent through LCM messages
- * directly.
+ * and QpInverseDynamicsSystemSystem. This diagram does not have any input or
+ * output ports.  The state and plan inputs and control outputs are sent
+ * through LCM messages directly.
  */
 class ValkyrieController : public systems::Diagram<double> {
  public:

--- a/drake/geometry/identifier.h
+++ b/drake/geometry/identifier.h
@@ -82,7 +82,8 @@ namespace geometry {
  @code
     using AId = Identifier<class ATag>;
     using BId = Identifier<class BTag>;
-    AId a1;                              // Compiler error. There is no default constructor.
+    AId a1;                              // Compiler error; there is no
+                                         //   default constructor.
     AId a2 = AId::get_new_id();          // Ok.
     AId a3(a2);                          // Ok.
     AId a4 = AId::get_new_id();          // Ok.

--- a/drake/math/evenly_distributed_pts_on_sphere.h
+++ b/drake/math/evenly_distributed_pts_on_sphere.h
@@ -6,7 +6,8 @@ namespace math {
 /**
  * Deterministically generates approximate evenly distributed points on a unit
  * sphere. This method uses Fibonacci number. For the detailed math, please
- * refer to http://stackoverflow.com/questions/9600801/evenly-distributing-n-points-on-a-sphere
+ * refer to
+ * http://stackoverflow.com/questions/9600801/evenly-distributing-n-points-on-a-sphere
  * This algorithm generates the points in O(n) time, where `n` is the number of
  * points.
  * @param num_points The number of points we want on the unit sphere.

--- a/drake/multibody/approximate_ik.cc
+++ b/drake/multibody/approximate_ik.cc
@@ -202,7 +202,8 @@ void approximateIK(RigidBodyTree<double>* model,
     {
       GRBgetcoeff(grb_model, i, j,&J(i, j));
     }
-    GRBgetdblattrarray(grb_model, GRB_DBL_ATTR_RHS, 0, num_gurobi_cnst, rhs.data());
+    GRBgetdblattrarray(grb_model, GRB_DBL_ATTR_RHS, 0, num_gurobi_cnst,
+                       rhs.data());
   }
   */
 

--- a/drake/multibody/global_inverse_kinematics.h
+++ b/drake/multibody/global_inverse_kinematics.h
@@ -138,7 +138,8 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * <pre>
    *    trace(R1ᵀ * R2) = 2 * cos(θ) + 1
    * </pre>
-   * as in http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/
+   * as in
+   * http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/
    * To constraint `θ < angle_tol`, we can impose the following constraint
    * <pre>
    *    2 * cos(angle_tol) + 1 <= trace(R1ᵀ * R2) <= 3

--- a/drake/multibody/multibody_tree/body_node_impl.h
+++ b/drake/multibody/multibody_tree/body_node_impl.h
@@ -26,8 +26,8 @@ namespace internal {
 template <typename T, int  num_positions, int num_velocities>
 class BodyNodeImpl : public BodyNode<T> {
  public:
-  // static constexpr int i = 42; discouraged.
-  // See answer in: http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
+  // static constexpr int i = 42; discouraged.  See answer in:
+  // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
   enum : int {nq = num_positions, nv = num_velocities};
 
   /// Given a body and its inboard mobilizer in a MultibodyTree this constructor

--- a/drake/multibody/multibody_tree/mobilizer_impl.h
+++ b/drake/multibody/multibody_tree/mobilizer_impl.h
@@ -69,8 +69,8 @@ class MobilizerImpl : public Mobilizer<T> {
 
  protected:
   // Handy enum to grant specific implementations compile time sizes.
-  // static constexpr int i = 42; discouraged.
-  // See answer in: http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
+  // static constexpr int i = 42; discouraged.  See answer in:
+  // http://stackoverflow.com/questions/37259807/static-constexpr-int-vs-old-fashioned-enum-when-and-why
   enum : int {kNq = num_positions, kNv = num_velocities};
 
   /// @name Helper methods to retrieve entries from MultibodyTreeContext.

--- a/drake/solvers/qp.cc
+++ b/drake/solvers/qp.cc
@@ -361,8 +361,9 @@ int myGRBaddconstrs(GRBmodel* model, MatrixBase<DerivedA> const& A,
     // todo: it seems like I should just be able to do something like this:
     SparseMatrix<double, RowMajor> sparseAeq(Aeq.sparseView());
     sparseAeq.makeCompressed();
-    error =
-    GRBaddconstrs(model, nq_con, sparseAeq.nonZeros(), sparseAeq.InnerIndices(), sparseAeq.OuterStarts(), sparseAeq.Values(), beq.data(), NULL);
+    error = GRBaddconstrs(
+        model, nq_con, sparseAeq.nonZeros(), sparseAeq.InnerIndices(),
+        sparseAeq.OuterStarts(), sparseAeq.Values(), beq.data(), NULL);
   */
 
   int* cind = new int[A.cols()];

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -919,14 +919,15 @@ class IntegratorBase {
    * - `nz` miscellaneous continuous state variables `z`.
    *
    * Weights on the generalized velocity variables `v (= dꝗ/dt)` are derived
-   * directly from the weights on `ꝗ`, weighted by a characteristic time. Weights
-   * on the actual `nq` generalized coordinates can
+   * directly from the weights on `ꝗ`, weighted by a characteristic time.
+   * Weights on the actual `nq` generalized coordinates can
    * be calculated efficiently from weights on the quasi-coordinates (details
    * below).
    *
    * <h4>How the weights are used</h4>
    *
-   * The errors in the `ꝗ` and `z` variables are weighted by the diagonal elements
+   * The errors in the `ꝗ` and `z` variables are weighted by the diagonal
+   * elements
    * of diagonal weighting matrices Wꝗ and Wz, respectively. (The block-diagonal
    * weighting matrix `Wq` on the original generalized coordinates `q` is
    * calculated from `N` and `Wꝗ`; see below.) In the absence of
@@ -973,8 +974,9 @@ class IntegratorBase {
    * matrix); however, `N N⁺ != I`, as `N` has more rows than columns generally.
    * [Nikravesh 1988] shows how such a matrix `N` can be determined and provides
    * more information. Given this relationship between `N` and `N⁺`, we can
-   * relate weighted errors in configuration coordinates `q` to weighted errors in
-   * generalized quasi-coordinates `ꝗ`, as the following derivation shows: <pre>
+   * relate weighted errors in configuration coordinates `q` to weighted errors
+   * in generalized quasi-coordinates `ꝗ`, as the following derivation shows:
+   * <pre>
    *            v = N⁺ qdot         Inverse kinematic differential equation
    *        dꝗ/dt = N⁺ dq/dt        Use synonyms for v and qdot
    *           dꝗ = N⁺ dq           Change time derivatives to differentials

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -288,14 +288,14 @@ class IntegratorBase {
    * diagnostic to figure out what aspect of your simulation is requiring small
    * steps. You can set the minimum to what should be a "reasonable" minimum
    * based on what you know about the physical system. You will then get an
-   * std::runtime_error exception thrown at any point in time where your model 
+   * std::runtime_error exception thrown at any point in time where your model
    * behaves unexpectedly (due to, e.g., a discontinuity in the derivative
    * evaluation function).
    *
    * If you disable the exception (via
    * `set_throw_on_minimum_step_size_violation(false)`), the integrator will
    * simply proceed with a step of the minimum size: accuracy is guaranteed
-   * only when the minimum step size is not violated. Beware that there can be 
+   * only when the minimum step size is not violated. Beware that there can be
    * no guarantee about the magnitude of any errors introduced by violating the
    * accuracy "requirements" in this manner, so disabling the exception should
    * be done warily.
@@ -312,8 +312,8 @@ class IntegratorBase {
    * You may request a larger minimum step size `h_min`. Then at every time t,
    * the integrator determines a "working" minimum `h_work=max(h_min,h_floor)`.
    * If the step size selection algorithm determines that a step smaller than
-   * `h_work` is needed to meet accuracy or other needs, then a 
-   * std::runtime_error exception will be thrown and the simulation halted. On 
+   * `h_work` is needed to meet accuracy or other needs, then a
+   * std::runtime_error exception will be thrown and the simulation halted. On
    * the other hand, if you have suppressed the exception (again, via
    * `set_throw_on_minimum_step_size_violation(false)`), the integration
    * will continue, taking a step of size `h_work`.

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -742,7 +742,8 @@ class System {
   // These three methods would ideally be designated as "protected", but
   // Diagram::AllocateForcedXEventCollection() needs to call these methods and,
   // perhaps surprisingly, is not able to access these methods when they are
-  // protected. See: https://stackoverflow.com/questions/16785069/why-cant-a-derived-class-call-protected-member-function-in-this-code.
+  // protected. See:
+  // https://stackoverflow.com/questions/16785069/why-cant-a-derived-class-call-protected-member-function-in-this-code.
   // To address this problem, we keep the methods "public" and
   // (1) Make the overriding methods in LeafSystem and Diagram "final" and
   // (2) Use the doxygen cond/endcond tags so that these methods are hidden


### PR DESCRIPTION
Also remove trailing whitespace.

I was trying to teach our linter to enforce <= 80 in comments, but that is going to be more work than I thought, so for now I'll just push the manual fixes.  We can add enforcement later if need be.

Rule of thumb on URLs here is that they are allowed to overwhelm the limit, but should appear on their own line (excepting for comment markers) to minimize the damage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7029)
<!-- Reviewable:end -->
