### PR TITLE
Remove `tags = ["snopt"]` from several tests which pass with IPOPT

### DIFF
--- a/drake/examples/kinova_jaco_arm/BUILD
+++ b/drake/examples/kinova_jaco_arm/BUILD
@@ -55,7 +55,6 @@ drake_cc_binary(
     data = [
         "//drake/manipulation/models/jaco_description:models",
     ],
-    tags = ["snopt"],
     test_rule_args = ["--simulation_sec=0.1"],
     deps = [
         ":jaco_common",
@@ -78,7 +77,6 @@ drake_cc_binary(
     data = [
         "//drake/manipulation/models/jaco_description:models",
     ],
-    tags = ["snopt"],
     test_rule_args = ["--simulation_sec=0.1"],
     deps = [
         ":jaco_common",

--- a/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
+++ b/drake/examples/kuka_iiwa_arm/controlled_kuka/BUILD
@@ -17,7 +17,6 @@ drake_cc_binary(
         "//drake/examples/kuka_iiwa_arm:models",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = ["snopt"],
     deps = [
         "//drake/common:find_resource",
         "//drake/examples/kuka_iiwa_arm:iiwa_common",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7032)
<!-- Reviewable:end -->
