### PR TITLE
Add optitrack lcmtypes to drake-lcm-spy/drake-visualizer

### DIFF
--- a/drake/lcmtypes/BUILD
+++ b/drake/lcmtypes/BUILD
@@ -303,6 +303,7 @@ java_binary(
         "@libbot//:lcmtypes_bot2_frames_java",
         "@libbot//:lcmtypes_bot2_lcmgl_java",
         "@libbot//:lcmtypes_bot2_param_java",
+        "@optitrack_driver//lcmtypes:lcmtypes_optitrack",
     ],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -34,6 +34,7 @@ sh_binary(
         "//drake/examples:prod_models",
         "//drake/lcmtypes:lcmtypes_py",
         "@drake_visualizer",
+        "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
     ],
 )
 

--- a/tools/drake_visualizer_apple.sh
+++ b/tools/drake_visualizer_apple.sh
@@ -14,6 +14,6 @@ if ! [ -d "external/drake_visualizer" ]; then
     fi
 fi
 
-export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external/optitrack_driver/lcmtypes:external${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/drake_visualizer/bin/drake-visualizer" "$@"

--- a/tools/drake_visualizer_linux.sh
+++ b/tools/drake_visualizer_linux.sh
@@ -15,6 +15,6 @@ if ! [ -d "external/drake_visualizer" ]; then
 fi
 
 export LD_LIBRARY_PATH="external/vtk/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external/vtk/lib/python2.7/site-packages:external${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH="drake/bindings/python:drake/lcmtypes:external/drake_visualizer/lib/python2.7/dist-packages:external/lcmtypes_bot2_core/lcmtypes:external/lcmtypes_robotlocomotion/lcmtypes:external/optitrack_driver/lcmtypes:external/vtk/lib/python2.7/site-packages:external${PYTHONPATH:+:$PYTHONPATH}"
 
 exec "external/drake_visualizer/bin/drake-visualizer" "$@"


### PR DESCRIPTION
I've been asked a few times about this functionality, and pointed people to patches I had on personal branches.  This kinda implies that I should push the changes in question to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7044)
<!-- Reviewable:end -->
