### PR TITLE
Port some primitives to SystemScalarConverter

### DIFF
--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -304,6 +304,7 @@ drake_cc_googletest(
         "//drake/common:eigen_matrix_compare",
         "//drake/common:symbolic",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -291,6 +291,7 @@ drake_cc_googletest(
         ":first_order_low_pass_filter",
         "//drake/common:unused",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -278,6 +278,7 @@ drake_cc_googletest(
         ":demultiplexer",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -362,6 +362,7 @@ drake_cc_googletest(
         ":pass_through",
         "//drake/common:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/demultiplexer.cc
+++ b/drake/systems/primitives/demultiplexer.cc
@@ -2,15 +2,16 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace systems {
 
 template <typename T>
-Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes) {
-  // size must be a multiple of output_ports_sizes.
+Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes)
+    : LeafSystem<T>(SystemTypeTag<systems::Demultiplexer>{}) {
+  // The size must be a multiple of output_ports_sizes.
   DRAKE_DEMAND(size % output_ports_sizes == 0);
-
   const int num_output_ports = size / output_ports_sizes;
 
   // TODO(amcastro-tri): remove the size parameter from the constructor once
@@ -27,6 +28,12 @@ Demultiplexer<T>::Demultiplexer(int size, int output_ports_sizes) {
 }
 
 template <typename T>
+template <typename U>
+Demultiplexer<T>::Demultiplexer(const Demultiplexer<U>& other)
+    : Demultiplexer<T>(other.get_input_port(0).size(),
+                       other.get_output_port(0).size()) {}
+
+template <typename T>
 void Demultiplexer<T>::CopyToOutput(const Context<T>& context,
                                     OutputPortIndex port_index,
                                     BasicVector<T>* output) const {
@@ -40,15 +47,9 @@ void Demultiplexer<T>::CopyToOutput(const Context<T>& context,
   out_vector = in_vector.segment(port_index * out_size, out_size);
 }
 
-template <typename T>
-Demultiplexer<symbolic::Expression>* Demultiplexer<T>::DoToSymbolic() const {
-  const int size = this->get_input_port(0).size();
-  return new Demultiplexer<symbolic::Expression>(
-      size, size / this->get_num_output_ports());
-}
-
 template class Demultiplexer<double>;
 template class Demultiplexer<AutoDiffXd>;
+template class Demultiplexer<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/primitives/demultiplexer.h
+++ b/drake/systems/primitives/demultiplexer.h
@@ -9,8 +9,9 @@
 namespace drake {
 namespace systems {
 
-/// This system splits a vector valued signal in its inputs of size `size`
-/// into `size` output scalar valued signals.
+/// This system splits a vector valued signal on its input into multiple
+/// outputs.
+///
 /// The input to this system directly feeds through to its output.
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
@@ -18,12 +19,13 @@ namespace systems {
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup primitive_systems
 template <typename T>
-class Demultiplexer : public LeafSystem<T> {
+class Demultiplexer final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Demultiplexer)
 
@@ -36,19 +38,18 @@ class Demultiplexer : public LeafSystem<T> {
   ///
   /// @param size is the size of the input signal to be demultiplexed into its
   /// individual components.
-  /// @param output_ports_sizes The size of the output ports. @p length must be
+  /// @param output_ports_sizes The size of the output ports. @p size must be
   /// a multiple of @p output_ports_sizes.
   explicit Demultiplexer(int size, int output_ports_sizes = 1);
 
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit Demultiplexer(const Demultiplexer<U>&);
+
  private:
-  // Sets the i-th output port to the value of the i-th component of the input
-  // port.
+  // Sets the port_index-th output port value.
   void CopyToOutput(const Context<T>& context, OutputPortIndex port_index,
                     BasicVector<T>* output) const;
-
-  // Returns a Demultiplexer<symbolic::Expression> with the same dimensions as
-  // this Demultiplexer.
-  Demultiplexer<symbolic::Expression>* DoToSymbolic() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/first_order_low_pass_filter.cc
+++ b/drake/systems/primitives/first_order_low_pass_filter.cc
@@ -11,19 +11,26 @@ namespace systems {
 
 template <typename T>
 FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
-    double time_constant, int size) :
-    FirstOrderLowPassFilter(VectorX<double>::Ones(size) * time_constant) {
-}
+    double time_constant, int size)
+    : FirstOrderLowPassFilter(VectorX<double>::Ones(size) * time_constant) {}
 
 template <typename T>
 FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
     const VectorX<double>& time_constants)
-    : VectorSystem<T>(time_constants.size(), time_constants.size()),
+    : VectorSystem<T>(
+          SystemTypeTag<systems::FirstOrderLowPassFilter>{},
+          time_constants.size(), time_constants.size()),
       time_constants_(time_constants) {
   DRAKE_ASSERT(time_constants.size() > 0);
   DRAKE_ASSERT((time_constants.array() > 0).all());
   this->DeclareContinuousState(time_constants.size());
 }
+
+template <typename T>
+template <typename U>
+FirstOrderLowPassFilter<T>::FirstOrderLowPassFilter(
+    const FirstOrderLowPassFilter<U>& other)
+    : FirstOrderLowPassFilter<T>(other.get_time_constants_vector()) {}
 
 template <typename T>
 double FirstOrderLowPassFilter<T>::get_time_constant() const {
@@ -69,13 +76,6 @@ void FirstOrderLowPassFilter<T>::DoCalcVectorOutput(
     Eigen::VectorBlock<VectorX<T>>* output) const {
   unused(input);
   *output = state;
-}
-
-template <typename T>
-FirstOrderLowPassFilter<symbolic::Expression>*
-FirstOrderLowPassFilter<T>::DoToSymbolic() const {
-  return new FirstOrderLowPassFilter<symbolic::Expression>(
-      this->get_time_constants_vector());
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/systems/primitives/first_order_low_pass_filter.h
+++ b/drake/systems/primitives/first_order_low_pass_filter.h
@@ -41,7 +41,7 @@ namespace systems {
 ///
 /// @ingroup primitive_systems
 template <typename T>
-class FirstOrderLowPassFilter : public VectorSystem<T> {
+class FirstOrderLowPassFilter final : public VectorSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FirstOrderLowPassFilter)
 
@@ -60,6 +60,10 @@ class FirstOrderLowPassFilter : public VectorSystem<T> {
   /// @param[in] time_constants Vector of time constants. Each entry in this
   ///                           vector must be positive.
   explicit FirstOrderLowPassFilter(const VectorX<double>& time_constants);
+
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit FirstOrderLowPassFilter(const FirstOrderLowPassFilter<U>&);
 
   /// Returns the time constant of the filter for filters that have the same
   /// time constant τ for all signals.
@@ -88,10 +92,6 @@ class FirstOrderLowPassFilter : public VectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
-
-  // System<T> override. Returns a FirstOrderLowPassFilter<symbolic::Expression>
-  // with the same time constants and dimensions as this filter.
-  FirstOrderLowPassFilter<symbolic::Expression>* DoToSymbolic() const override;
 
   const VectorX<double> time_constants_;
 };

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -22,7 +22,13 @@ Gain<T>::Gain(double k, int size) : Gain(Eigen::VectorXd::Ones(size) * k) {}
 
 template <typename T>
 Gain<T>::Gain(const Eigen::VectorXd& k)
-    : VectorSystem<T>(k.size(), k.size()), k_(k) {}
+    : VectorSystem<T>(SystemTypeTag<systems::Gain>{}, k.size(), k.size()),
+      k_(k) {}
+
+template <typename T>
+template <typename U>
+Gain<T>::Gain(const Gain<U>& other)
+    : Gain<T>(other.get_gain_vector()) {}
 
 template <typename T>
 double Gain<T>::get_gain() const {
@@ -48,11 +54,6 @@ void Gain<T>::DoCalcVectorOutput(
     Eigen::VectorBlock<VectorX<T>>* output) const {
   unused(state);
   *output = k_.array() * input.array();
-}
-
-template <typename T>
-Gain<symbolic::Expression>* Gain<T>::DoToSymbolic() const {
-  return new Gain<symbolic::Expression>(k_);
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -19,6 +19,7 @@ namespace systems {
 /// Instantiated templates for the following scalar types @p T are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 ///
@@ -27,7 +28,7 @@ namespace systems {
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 /// @ingroup primitive_systems
 template <typename T>
-class Gain : public VectorSystem<T> {
+class Gain final : public VectorSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Gain)
 
@@ -45,6 +46,10 @@ class Gain : public VectorSystem<T> {
   /// subscript `i` indicates the i-th element of the vector.
   explicit Gain(const Eigen::VectorXd& k);
 
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit Gain(const Gain<U>&);
+
   /// Returns the gain constant. This method should only be called if the gain
   /// can be represented as a scalar value, i.e., every element in the gain
   /// vector is the same. It will abort if the gain cannot be represented as a
@@ -60,10 +65,6 @@ class Gain : public VectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
-
-  // System<T> override.  Returns a Gain<symbolic::Expression> with the
-  // same dimensions as this Gain.
-  Gain<symbolic::Expression>* DoToSymbolic() const override;
 
   const Eigen::VectorXd k_;
 };

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -14,7 +14,13 @@ namespace systems {
 // TODO(amcastro-tri): remove the size parameter from the constructor once
 // #3109 supporting automatic sizes is resolved.
 template <typename T>
-PassThrough<T>::PassThrough(int size) : VectorSystem<T>(size, size) { }
+PassThrough<T>::PassThrough(int size)
+    : VectorSystem<T>(SystemTypeTag<systems::PassThrough>{}, size, size) {}
+
+template <typename T>
+template <typename U>
+PassThrough<T>::PassThrough(const PassThrough<U>& other)
+    : PassThrough<T>(other.get_input_port().size()) {}
 
 template <typename T>
 void PassThrough<T>::DoCalcVectorOutput(
@@ -24,11 +30,6 @@ void PassThrough<T>::DoCalcVectorOutput(
     Eigen::VectorBlock<VectorX<T>>* output) const {
   unused(state);
   *output = input;
-}
-
-template <typename T>
-PassThrough<symbolic::Expression>* PassThrough<T>::DoToSymbolic() const {
-  return new PassThrough<symbolic::Expression>(this->get_input_port().size());
 }
 
 }  // namespace systems

--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -26,23 +26,28 @@ namespace systems {
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
-/// This class uses Drake's `-inl.h` pattern.  When seeing linker errors from
+/// This class uses Drake's `-inl.h` pattern. When seeing linker errors from
 /// this class, please refer to http://drake.mit.edu/cxx_inl.html.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
 /// - AutoDiffXd
+/// - symbolic::Expression
 ///
 /// They are already available to link against in the containing library.
 /// @ingroup primitive_systems
 template <typename T>
-class PassThrough : public VectorSystem<T> {
+class PassThrough final : public VectorSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PassThrough)
 
   /// Constructs a pass thorough system (`y = u`).
   /// @param size number of elements in the signal to be processed.
   explicit PassThrough(int size);
+
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit PassThrough(const PassThrough<U>&);
 
   // TODO(eric.cousineau): Ensure that this system can also handle
   // AbstractValue's akin to ZeroOrderHold (#6491).
@@ -54,10 +59,6 @@ class PassThrough : public VectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
-
-  /// Returns an PassThrough<symbolic::Expression> with the same dimensions as
-  /// this PassThrough.
-  PassThrough<symbolic::Expression>* DoToSymbolic() const override;
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/primitives/test/demultiplexer_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;
@@ -105,6 +106,23 @@ TEST_F(DemultiplexerTest, DirectFeedthrough) {
   for (int i = 0; i < demux_->get_num_output_ports(); ++i) {
     EXPECT_TRUE(demux_->HasDirectFeedthrough(0, i));
   }
+}
+
+// Tests converting to different scalar types.
+TEST_F(DemultiplexerTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*demux_, [&](const auto& converted) {
+    EXPECT_EQ(1, converted.get_num_input_ports());
+    EXPECT_EQ(3, converted.get_num_output_ports());
+
+    EXPECT_EQ(3, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_output_port(0).size());
+    EXPECT_EQ(1, converted.get_output_port(1).size());
+    EXPECT_EQ(1, converted.get_output_port(2).size());
+  }));
+}
+
+TEST_F(DemultiplexerTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*demux_));
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/drake/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
 namespace systems {
@@ -114,6 +115,22 @@ TEST_F(FirstOrderLowPassFilterTest, Derivatives) {
 TEST_F(FirstOrderLowPassFilterTest, FilterIsNotDirectFeedthrough) {
   SetUpSingleTimeConstantFilter();
   EXPECT_FALSE(filter_->HasAnyDirectFeedthrough());
+}
+
+TEST_F(FirstOrderLowPassFilterTest, ToAutoDiff) {
+  SetUpMultipleTimeConstantsFilter();
+  EXPECT_TRUE(is_autodiffxd_convertible(*filter_, [&](const auto& converted) {
+    EXPECT_EQ(kSignalSize, converted.get_input_port().size());
+    EXPECT_EQ(kSignalSize, converted.get_output_port().size());
+    EXPECT_EQ(
+        Vector3<double>(4.0, 3.5, 3.0),
+        converted.get_time_constants_vector());
+  }));
+}
+
+TEST_F(FirstOrderLowPassFilterTest, ToSymbolic) {
+  SetUpMultipleTimeConstantsFilter();
+  EXPECT_TRUE(is_symbolic_convertible(*filter_));
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/gain_test.cc
+++ b/drake/systems/primitives/test/gain_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 using Eigen::Vector3d;
 using std::make_unique;
@@ -99,6 +100,19 @@ GTEST_TEST(GainDeathTest, GainAccessorTest) {
   EXPECT_THROW(gain_system->get_gain(), std::runtime_error);
 }
 
+GTEST_TEST(GainTest, ToAutoDiff) {
+  const Gain<double> gain(2.0, 3);
+  EXPECT_TRUE(is_autodiffxd_convertible(gain, [&](const auto& converted) {
+    EXPECT_EQ(1, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+    EXPECT_EQ(Vector3d::Constant(2.0), converted.get_gain_vector());
+  }));
+}
+
+GTEST_TEST(GainTest, ToSymbolic) {
+  const Gain<double> gain(2.0, 3);
+  EXPECT_TRUE(is_symbolic_convertible(gain));
+}
 
 }  // namespace
 }  // namespace systems

--- a/drake/systems/primitives/test/pass_through_test.cc
+++ b/drake/systems/primitives/test/pass_through_test.cc
@@ -7,6 +7,7 @@
 #include "drake/common/autodiff_overloads.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 using Eigen::AutoDiffScalar;
 using Eigen::Vector2d;
@@ -62,6 +63,14 @@ TEST_F(PassThroughTest, PassThroughIsStateless) {
 
 TEST_F(PassThroughTest, DirectFeedthrough) {
   EXPECT_TRUE(pass_through_->HasAnyDirectFeedthrough());
+}
+
+TEST_F(PassThroughTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*pass_through_));
+}
+
+TEST_F(PassThroughTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*pass_through_));
 }
 
 }  // namespace


### PR DESCRIPTION
FYI The Doxygen at http://drake.mit.edu/doxygen_cxx/group__system__scalar__conversion.html helps explain what's going on here.

Details:
- Port Gain to SystemScalarConverter
- Port PassThrough to SystemScalarConverter
- Port Demultiplexer to SystemScalarConverter
- Port FirstOrderLowPassFilter to SystemScalarConverter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7047)
<!-- Reviewable:end -->
