### PR TITLE
Disables monolithic p&p test scenario 5.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
@@ -133,6 +133,7 @@ pick_and_place_test(
     ],
 )
 
+# TODO(sam.creasy) Re-enable this test once it is not so sensitive.
 pick_and_place_test(
     name = "pick_and_place_scenario_5",
     # TODO(sam.creasey) This should be a smaller cylindrical target,
@@ -142,6 +143,9 @@ pick_and_place_test(
         "--target=0",
         "--start-position=2",
         "--end-position=0",
+    ],
+    tags = [
+        "manual",  # Disables this brittle test from being run in CI.
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD
@@ -53,7 +53,7 @@ drake_cc_binary(
     ],
 )
 
-# TODO(sam.creasy) Re-enable this test once it is not so sensitive.
+# TODO(sam.creasey) Re-enable this test once it is not so sensitive.
 pick_and_place_test(
     name = "pick_and_place_scenario_1",
     # TODO(sam.creasey) This should be target 1, but that requries
@@ -133,7 +133,7 @@ pick_and_place_test(
     ],
 )
 
-# TODO(sam.creasy) Re-enable this test once it is not so sensitive.
+# TODO(sam.creasey) Re-enable this test once it is not so sensitive.
 pick_and_place_test(
     name = "pick_and_place_scenario_5",
     # TODO(sam.creasey) This should be a smaller cylindrical target,


### PR DESCRIPTION
Disables this brittle test in CI- test can still be run manually- in order to pass the nightly build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7054)
<!-- Reviewable:end -->
