### PR TITLE
Adds a simple solar system example

### DIFF
--- a/drake/examples/geometry_world/BUILD
+++ b/drake/examples/geometry_world/BUILD
@@ -30,9 +30,7 @@ drake_cc_library(
 
 drake_cc_binary(
     name = "bouncing_ball_run_dynamics",
-    testonly = 1,
     srcs = ["bouncing_ball_run_dynamics.cc"],
-    add_test_rule = 1,
     deps = [
         ":bouncing_ball_plant",
         "//drake/systems/analysis:simulator",
@@ -40,6 +38,34 @@ drake_cc_binary(
         "//drake/systems/lcm",
         "//drake/systems/primitives:constant_vector_source",
         "//drake/systems/primitives:signal_logger",
+    ],
+)
+
+drake_cc_library(
+    name = "solar_system",
+    srcs = ["solar_system.cc"],
+    hdrs = ["solar_system.h"],
+    deps = [
+        "//drake/geometry:geometry_ids",
+        "//drake/geometry:geometry_system",
+        "//drake/math:geometric_transform",
+        "//drake/systems/framework:leaf_system",
+    ],
+)
+
+drake_cc_binary(
+    name = "solar_system_run_dynamics",
+    srcs = ["solar_system_run_dynamics.cc"],
+    deps = [
+        ":solar_system",
+        "//drake/geometry:geometry_system",
+        "//drake/geometry:geometry_visualization",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/lcm",
+        "//drake/systems/primitives:constant_vector_source",
+        "//drake/systems/primitives:signal_logger",
+        "//drake/systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/drake/examples/geometry_world/solar_system.cc
+++ b/drake/examples/geometry_world/solar_system.cc
@@ -1,0 +1,235 @@
+#include "drake/examples/geometry_world/solar_system.h"
+
+#include <memory>
+#include <vector>
+
+#include "drake/geometry/frame_id_vector.h"
+#include "drake/geometry/frame_kinematics_vector.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/math/axis_angle.h"
+#include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/discrete_values.h"
+
+namespace drake {
+namespace examples {
+namespace solar_system {
+
+using Eigen::Vector4d;
+using geometry::FrameId;
+using geometry::FrameIdVector;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryInstance;
+using geometry::GeometrySystem;
+using geometry::Sphere;
+using systems::BasicVector;
+using systems::Context;
+using systems::ContinuousState;
+using systems::DiscreteValues;
+using std::make_unique;
+
+template <typename T>
+SolarSystem<T>::SolarSystem(GeometrySystem<T>* geometry_system) {
+  DRAKE_DEMAND(geometry_system);
+  source_id_ = geometry_system->RegisterSource("solar_system");
+  geometry_id_port_ =
+      this->DeclareAbstractOutputPort(&SolarSystem::AllocateFrameIdOutput,
+                                      &SolarSystem::CalcFrameIdOutput)
+          .get_index();
+  geometry_pose_port_ =
+      this->DeclareAbstractOutputPort(&SolarSystem::AllocateFramePoseOutput,
+                                      &SolarSystem::CalcFramePoseOutput)
+          .get_index();
+
+  this->DeclareContinuousState(kBodyCount /* num_q */, kBodyCount /* num_v */,
+                               0 /* num_z */);
+
+  AllocateGeometry(geometry_system);
+}
+
+template <typename T>
+const systems::OutputPort<T>& SolarSystem<T>::get_geometry_id_output_port()
+    const {
+  return systems::System<T>::get_output_port(geometry_id_port_);
+}
+
+template <typename T>
+const systems::OutputPort<T>& SolarSystem<T>::get_geometry_pose_output_port()
+    const {
+  return systems::System<T>::get_output_port(geometry_pose_port_);
+}
+
+template <typename T>
+void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
+                     systems::State<T>* state) const {
+  DRAKE_DEMAND(state != nullptr);
+  ContinuousState<T>* xc = state->get_mutable_continuous_state();
+  VectorX<T> initial_state;
+  initial_state.resize(kBodyCount * 2);
+  // clang-format off
+  initial_state << 0,               // Earth initial position
+                   M_PI / 2,        // moon initial position
+                   -M_PI / 2,       // Mars initial position
+                   0,               // phobos initial position
+                   2 * M_PI / 5,    // Earth revolution lasts 5 seconds.
+                   2 * M_PI,        // moon revolution lasts 1 second.
+                   2 * M_PI / 6,    // Mars revolution lasts 6 seconds.
+                   2 * M_PI / 1.1;  // phobos revolution lasts 1.1 seconds.
+  // clang-format on
+  DRAKE_DEMAND(xc->size() == initial_state.size());
+  xc->SetFromVector(initial_state);
+  DiscreteValues<T>* xd = state->get_mutable_discrete_state();
+  for (int i = 0; i < xd->num_groups(); i++) {
+    BasicVector<T>* s = xd->get_mutable_vector(i);
+    s->SetFromVector(VectorX<T>::Zero(s->size()));
+  }
+}
+
+template <typename T>
+void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
+  body_ids_.reserve(kBodyCount);
+  body_offset_.reserve(kBodyCount);
+  axes_.reserve(kBodyCount);
+
+  // Allocate the sun.
+  // NOTE: we don't store the id of the sun geometry because we have no need
+  // for subsequent access (the same is also true for dynamic geometries).
+  geometry_system->RegisterAnchoredGeometry(
+      source_id_, make_unique<GeometryInstance>(Isometry3<double>::Identity(),
+                                                make_unique<Sphere>(1.f)));
+
+  // Allocate the "celestial bodies": two planets orbiting on different planes,
+  // each with a moon.
+
+  // Earth - Earth's frame is at the center of the sun.
+  FrameId planet_id = geometry_system->RegisterFrame(
+      source_id_, GeometryFrame("Earth", Isometry3<double>::Identity()));
+  body_ids_.push_back(planet_id);
+  body_offset_.push_back(Isometry3<double>::Identity());
+  axes_.push_back(Vector3<double>::UnitZ());
+
+  // The geometry is displaced from the Earth _frame_ so that it orbits.
+  const double kEarthOrbitRadius = 3.0;
+  Isometry3<double> earth_pose = Isometry3<double>::Identity();
+  earth_pose.translation() << kEarthOrbitRadius, 0, 0;
+  geometry_system->RegisterGeometry(
+      source_id_, planet_id,
+      make_unique<GeometryInstance>(earth_pose, make_unique<Sphere>(0.25f)));
+
+  // Luna - Luna's frame is at the center of the Earth.
+  FrameId luna_id = geometry_system->RegisterFrame(
+      source_id_, planet_id, GeometryFrame("Luna", earth_pose));
+  body_ids_.push_back(luna_id);
+  body_offset_.push_back(earth_pose);
+  Vector3<double> plane_normal;
+  plane_normal << 1, 1, 1;
+  axes_.push_back(plane_normal.normalized());
+
+  // The geometry is displaced from Luna's frame so that it orbits.
+  const double kLunaOrbitRadius = 0.35;
+  Isometry3<double> luna_pose = Isometry3<double>::Identity();
+  // Pick a position at kLunaOrbitRadius distance from the Earth's origin on
+  // the plane _perpendicular_ to the moon's normal (axes_.back()).
+  Vector3<double> luna_position(-1, 0.5, 0.5);
+  luna_pose.translation() = luna_position.normalized() * kLunaOrbitRadius;
+  geometry_system->RegisterGeometry(
+      source_id_, luna_id,
+      make_unique<GeometryInstance>(luna_pose, make_unique<Sphere>(0.075f)));
+
+  // Mars - Mars's frame is at the center of the sun.
+  planet_id = geometry_system->RegisterFrame(
+      source_id_, GeometryFrame("Mars", Isometry3<double>::Identity()));
+  body_ids_.push_back(planet_id);
+  body_offset_.push_back(Isometry3<double>::Identity());
+  plane_normal << .1, .1, 1;
+  axes_.push_back(plane_normal.normalized());
+
+  // The geometry is displaced from the Mars _frame_ so that it orbits.
+  const double kMarsOrbitRadius = 5.0;
+  Isometry3<double> mars_pose = Isometry3<double>::Identity();
+  // Pick a position at kMarsOrbitRadius distance from the sun's origin on
+  // the plane _perpendicular_ to Mars's normal (axes_.back()).
+  Vector3<double> mars_position(1, 1, -.2);
+  mars_pose.translation() = mars_position.normalized() * kMarsOrbitRadius;
+  geometry_system->RegisterGeometry(
+      source_id_, planet_id,
+      make_unique<GeometryInstance>(mars_pose, make_unique<Sphere>(0.24f)));
+
+  // Mars moon - Phobos's frame is centered on Mars, but its orientation is
+  // reversed so that it revolves in the opposite direction
+  Isometry3<T> phobos_rotation_pose = Isometry3<double>::Identity();
+  phobos_rotation_pose.linear() =
+      AngleAxis<T>(M_PI / 2, Vector3<T>::UnitX()).matrix();
+  FrameId phobos_id = geometry_system->RegisterFrame(
+      source_id_, planet_id, GeometryFrame("phobos", phobos_rotation_pose));
+  body_ids_.push_back(phobos_id);
+  body_offset_.push_back(mars_pose);
+  plane_normal << 0, 0, 1;
+  axes_.push_back(plane_normal.normalized());
+
+  // The geometry is displaced from the Phobos's _frame_ so that it orbits.
+  const double kPhobosOrbitRadius = 0.34;
+  Isometry3<double> phobos_pose = Isometry3<double>::Identity();
+  phobos_pose.translation() << kPhobosOrbitRadius, 0, 0;
+  geometry_system->RegisterGeometry(
+      source_id_, phobos_id,
+      make_unique<GeometryInstance>(phobos_pose, make_unique<Sphere>(0.06f)));
+
+  DRAKE_DEMAND(static_cast<int>(body_ids_.size()) == kBodyCount);
+}
+
+template <typename T>
+FramePoseVector<T> SolarSystem<T>::AllocateFramePoseOutput(
+    const Context<T>&) const {
+  DRAKE_DEMAND(source_id_.is_valid());
+  DRAKE_DEMAND(static_cast<int>(body_offset_.size()) == kBodyCount);
+  // NOTE: We initialize with the translational offset during allocation so that
+  // the `CalcFramePoseOutput` need only update the rotational component.
+  return FramePoseVector<T>(source_id_, body_offset_);
+}
+
+template <typename T>
+void SolarSystem<T>::CalcFramePoseOutput(const Context<T>& context,
+                                         FramePoseVector<T>* poses) const {
+  const BasicVector<T>& state = get_state(context);
+  DRAKE_ASSERT(poses->vector().size() == body_ids_.size());
+  std::vector<Isometry3<T>>& pose_data = poses->mutable_vector();
+  for (size_t i = 0; i < body_ids_.size(); ++i) {
+    // Frames only revolve around their origin; it is only necessary to set the
+    // rotation value.
+    T rot{state[i]};
+    pose_data[i].linear() = AngleAxis<T>(rot, axes_[i]).matrix();
+  }
+}
+
+template <typename T>
+FrameIdVector SolarSystem<T>::AllocateFrameIdOutput(const MyContext&) const {
+  DRAKE_DEMAND(source_id_.is_valid());
+  DRAKE_DEMAND(static_cast<int>(body_offset_.size()) == kBodyCount);
+  FrameIdVector ids(source_id_);
+  ids.AddFrameIds(body_ids_);
+  return ids;
+}
+
+template <typename T>
+void SolarSystem<T>::CalcFrameIdOutput(const MyContext&, FrameIdVector*) const {
+  // NOTE: This only needs to do work if the topology changes. This system makes
+  // no topology changes.
+}
+
+template <typename T>
+void SolarSystem<T>::DoCalcTimeDerivatives(
+    const MyContext& context, MyContinuousState* derivatives) const {
+  const BasicVector<T>& state = get_state(context);
+  BasicVector<T>* derivative_vector = get_mutable_state(derivatives);
+  derivative_vector->SetZero();
+  derivative_vector->get_mutable_value().head(kBodyCount) =
+      state.get_value().tail(kBodyCount);
+}
+
+template class SolarSystem<double>;
+
+}  // namespace solar_system
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/geometry_world/solar_system.h
+++ b/drake/examples/geometry_world/solar_system.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_system.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+
+namespace examples {
+namespace solar_system {
+
+// TODO(SeanCurtis-TRI): When textures are available, modify this so that planet
+// rotations become apparent as well (and not just revolutions).
+/** A model of an orrery -- a simple mechanical model of the solar system.
+
+ The orrery contains one sun and four orbiting bodies: two planets (Earth and
+ Mars) each with one moon. The orrery is articulated by placing the _frame_ for
+ each body at its parent's origin, and then displacing the geometry from that
+ origin to its orbital distance. Then each orbiting frame has a single degree of
+ freedom: its angular position around its axis of rotation.
+
+ - The sun is stationary -- an anchored geometry.
+ - Earth orbits on the xy-plane. Its moon (Luna) revolves around the earth on an
+ different arbitrary plane (illustrating transform compositions).
+ - Mars orbits the sun at a farther distance on a plane that is tilted off of
+ the xy-plane. Its moon (Phobos) orbits around Mars on a plane parallel to
+ Mars's orbital plane.
+
+ This system illustrates the following features:
+
+ 1. Registering anchored geometry.
+ 2. Registering frames as children of other frames.
+ 3. Creating a fixed FrameIdVector output.
+ 4. Updating the context-dependent FramePoseVector output.
+
+ Illustration of the orrery:
+
+ Legend:
+     Body Symbol | Meaning
+    :-----------:|:--------------------
+        E - ◯    | Earth
+        L - ◑    | Luna (Earth's moon)
+        M - ◍    | Mars
+        P - ●    | Phobos (Mars's moon)
+
+    Frame Symbol | Meaning
+    :-----------:|:--------------------
+        X_SE     | Earth's frame (centered on the sun) (X_SE == X_SM)
+        X_SM     | Mar's frame (centered on the sun)
+        X_EL     | Luna's frame (centered on the Earth)
+        X_MP     | Phobos's frame (centered on Mars)
+        X_EG     | The fixed offset of Earth's geometry from X_SE (at Earth's orbit radius).
+        X_LG     | The fixed offset of Luna's geometry from X_EL (at Luna's orbit radius).
+        X_MG     | The fixed offset of Mars's geometry from X_SM (at Mars's orbit radius).
+        X_PG     | The fixed offset of Phobos's geometry from X_MP (at Phobos's orbit radius).
+
+```
+    X_EG X_LG                            X_MG X_PG
+      ↓   ↓                                ↓   ↓
+      E   L         ▁▁▁                    M   p
+      ◯   ◑        ╱   ╲                   ◍   ●
+X_EL →├───┘       │  S  │           X_MP → ├───┘
+      │            ╲▁▁▁╱                   │
+      │              │                     │
+      └──────────────┴─────────────────────┘
+                     ↑
+                     X_SE, X_SM
+```
+
+ @tparam T The vector element type, which must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double */
+template <typename T>
+class SolarSystem : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SolarSystem)
+
+  explicit SolarSystem(geometry::GeometrySystem<T>* geometry_system);
+  ~SolarSystem() override = default;
+
+  using MyContext = systems::Context<T>;
+  using MyContinuousState = systems::ContinuousState<T>;
+
+  geometry::SourceId source_id() const { return source_id_; }
+
+  const systems::OutputPort<T>& get_geometry_id_output_port() const;
+  const systems::OutputPort<T>& get_geometry_pose_output_port() const;
+
+  // The default leaf system zeros out all of the state as "default" behavior.
+  // This subverts that (as a quick test) to make sure that's the source of my
+  // problems. The long term solution is to make sure SetDefaultState uses the
+  // model values if they exist (and zeros otherwise).
+  // TODO(SeanCurtis-TRI): Kill this override when LeafSystem::SetDefaultState()
+  // pulls from the models instead of simply zeroing things out.
+  void SetDefaultState(const systems::Context<T>&,
+                       systems::State<T>*) const override;
+
+ protected:
+  // No inputs implies no feedthrough; this makes it explicit.
+  optional<bool> DoHasDirectFeedthrough(int, int) const override {
+    return false;
+  }
+
+ private:
+  // Allocate all of the geometry.
+  void AllocateGeometry(geometry::GeometrySystem<T>* geometry_system);
+
+  // Allocate the frame pose set output port value.
+  geometry::FramePoseVector<T> AllocateFramePoseOutput(
+      const MyContext& context) const;
+
+  // Calculate the frame pose set output port value.
+  void CalcFramePoseOutput(const MyContext& context,
+                           geometry::FramePoseVector<T>* poses) const;
+
+  // Allocate the id output.
+  geometry::FrameIdVector AllocateFrameIdOutput(const MyContext& context) const;
+  // Calculate the id output.
+  void CalcFrameIdOutput(const MyContext& context,
+                         geometry::FrameIdVector* id_set) const;
+
+  void DoCalcTimeDerivatives(const MyContext& context,
+                             MyContinuousState* derivatives) const override;
+
+  static const systems::BasicVector<T>& get_state(
+      const MyContinuousState& cstate) {
+    return dynamic_cast<const systems::BasicVector<T>&>(cstate.get_vector());
+  }
+
+  static systems::BasicVector<T>* get_mutable_state(MyContinuousState* cstate) {
+    return dynamic_cast<systems::BasicVector<T>*>(cstate->get_mutable_vector());
+  }
+
+  static const systems::BasicVector<T>& get_state(const MyContext& context) {
+    return get_state(*context.get_continuous_state());
+  }
+
+  // Geometry source identifier for this system to interact with geometry system
+  geometry::SourceId source_id_{};
+
+  // Port handles
+  int geometry_id_port_{-1};
+  int geometry_pose_port_{-1};
+
+  // Solar system specification
+  const int kBodyCount = 4;
+  // The ids for each celestial body frame
+  std::vector<geometry::FrameId> body_ids_;
+  // The axes around each body revolves (expressed in its parent's frame)
+  std::vector<Vector3<double>> axes_;
+  // The translational offset of each body from its parent frame
+  std::vector<Isometry3<double>> body_offset_;
+};
+
+}  // namespace solar_system
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/geometry_world/solar_system_run_dynamics.cc
+++ b/drake/examples/geometry_world/solar_system_run_dynamics.cc
@@ -1,0 +1,75 @@
+#include "drake/examples/geometry_world/solar_system.h"
+#include "drake/geometry/geometry_system.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_viewer_draw.hpp"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/lcm/serializer.h"
+#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
+
+namespace drake {
+namespace examples {
+namespace solar_system {
+namespace {
+
+using geometry::GeometrySystem;
+using geometry::SourceId;
+using lcm::DrakeLcm;
+using systems::rendering::PoseBundleToDrawMessage;
+using systems::lcm::LcmPublisherSystem;
+using systems::lcm::Serializer;
+
+int do_main() {
+  systems::DiagramBuilder<double> builder;
+
+  auto geometry_system = builder.AddSystem<GeometrySystem<double>>();
+  geometry_system->set_name("geometry_system");
+
+  auto solar_system = builder.AddSystem<SolarSystem>(geometry_system);
+  solar_system->set_name("SolarSystem");
+
+  DrakeLcm lcm;
+  PoseBundleToDrawMessage* converter =
+      builder.template AddSystem<PoseBundleToDrawMessage>();
+  LcmPublisherSystem* publisher =
+      builder.template AddSystem<LcmPublisherSystem>(
+          "DRAKE_VIEWER_DRAW",
+          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
+  publisher->set_publish_period(1 / 60.0);
+
+  builder.Connect(
+      solar_system->get_geometry_id_output_port(),
+      geometry_system->get_source_frame_id_port(solar_system->source_id()));
+  builder.Connect(
+      solar_system->get_geometry_pose_output_port(),
+      geometry_system->get_source_pose_port(solar_system->source_id()));
+
+  builder.Connect(geometry_system->get_pose_bundle_output_port(),
+                  converter->get_input_port(0));
+  builder.Connect(*converter, *publisher);
+
+  // Last thing before building the diagram; dispatch the message to load
+  // geometry.
+  geometry::DispatchLoadMessage(*geometry_system);
+
+  auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+
+  simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.set_publish_every_time_step(false);
+  simulator.set_target_realtime_rate(1);
+  simulator.Initialize();
+  simulator.StepTo(13);
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace solar_system
+}  // namespace examples
+}  // namespace drake
+
+int main() { return drake::examples::solar_system::do_main(); }


### PR DESCRIPTION
This illustrates a geometry source that registers geometry and drives
frames but performs no queries.

Currently all "celestial bodies" have a default grey material.

PR stats:
```
Category            added  modified  removed  
----------------------------------------------
code                307    0         0        
comments            63     0         0        
blank               72     0         0        
----------------------------------------------
TOTAL               442    0         0 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7061)
<!-- Reviewable:end -->
