### PR TITLE
Implement FclModel::ComputeMaximumDepthCollisionPoints for Spheres and Cylinders

### DIFF
--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -2,16 +2,81 @@
 
 #include <utility>
 
+#include <Eigen/Dense>
 #include <fcl/fcl.h>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"
 
+using Eigen::Isometry3d;
+using Eigen::Vector3d;
+
 namespace drake {
 namespace multibody {
 namespace collision {
+namespace {
+// Struct for use in CollisionCallback(). Contains the collision request and
+// accumulates results in a drake::multibody::collision::PointPair vector.
+struct CollisionData {
+  // Collision request
+  fcl::CollisionRequestd request;
 
-// TODO(jamiesnape): Implement the model.
+  // Vector of distance results
+  std::vector<PointPair>* closest_points{};
+};
+
+// Callback function for FCL's collide() function.
+bool CollisionCallback(fcl::CollisionObjectd* fcl_object_A,
+                       fcl::CollisionObjectd* fcl_object_B,
+                       void* callback_data) {
+  // Retrieve the drake::multibody::collision::Element object associated with
+  // each FCL collision object.
+  auto element_A = static_cast<const Element*>(fcl_object_A->getUserData());
+  auto element_B = static_cast<const Element*>(fcl_object_B->getUserData());
+  // Do not proceed with collision checking if this pair of elements is excluded
+  // by either of our collision filtering mechanisms (filter groups and
+  // cliques).
+  if (element_A && element_B && element_A->CanCollideWith(element_B)) {
+    // Unpack the callback data
+    auto* collision_data = static_cast<CollisionData*>(callback_data);
+    const fcl::CollisionRequestd& request = collision_data->request;
+    fcl::CollisionResultd result;
+
+    // Perform nearphase collision detection
+    fcl::collide(fcl_object_A, fcl_object_B, request, result);
+
+    // Process the contact points
+    std::vector<fcl::Contactd> contacts;
+    result.getContacts(contacts);
+    if (!contacts.empty()) {
+      const fcl::Contactd& contact{contacts[0]};
+      //  By convention, Drake requires the contact normal to point out of B and
+      //  into A. FCL uses the opposite convention.
+      Vector3d drake_normal = -contact.normal;
+
+      // Signed distance is negative when penetration depth is positive.
+      double signed_distance = -contact.penetration_depth;
+
+      // FCL returns a single contact point, but PointPair expects two, one on
+      // the surface of body A (Ac) and one on the surface of body B (Bc).
+      // Choose points along the line defined by the contact point and normal,
+      // equi-distant to the contact point. Recall that signed_distance is
+      // strictly non-positive, so signed_distance * drake_normal points out of
+      // A and into B.
+      const Vector3d p_WAc{contact.pos + 0.5 * signed_distance * drake_normal};
+      const Vector3d p_WBc{contact.pos - 0.5 * signed_distance * drake_normal};
+
+      collision_data->closest_points->emplace_back(
+          element_A, element_B, p_WAc, p_WBc, drake_normal, signed_distance);
+    }
+  }
+
+  // Returning true would tell the broadphase manager to terminate early. Since
+  // we want to find all the collisions present in the model's current
+  // configuration, we return false.
+  return false;
+}
+}  // namespace
 
 void FclModel::DoAddElement(const Element& element) {
   ElementId id = element.getId();
@@ -53,8 +118,16 @@ void FclModel::DoAddElement(const Element& element) {
   fcl_collision_objects_.insert(std::make_pair(id, move(fcl_object)));
 }
 
-void FclModel::UpdateModel() {
-  DRAKE_ABORT_MSG("Not implemented.");
+void FclModel::UpdateModel() { broadphase_manager_.update(); }
+
+bool FclModel::UpdateElementWorldTransform(ElementId id,
+                                           const Isometry3d& X_WL) {
+  const bool element_exists(Model::UpdateElementWorldTransform(id, X_WL));
+  if (element_exists) {
+    fcl_collision_objects_[id]->setTransform(
+        FindElement(id)->getWorldTransform());
+  }
+  return element_exists;
 }
 
 bool FclModel::ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
@@ -66,10 +139,13 @@ bool FclModel::ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
 }
 
 bool FclModel::ComputeMaximumDepthCollisionPoints(
-    bool use_margins, std::vector<PointPair>* points) {
-  drake::unused(use_margins, points);
-  DRAKE_ABORT_MSG("Not implemented.");
-  return false;
+    bool, std::vector<PointPair>* points) {
+  CollisionData collision_data;
+  collision_data.closest_points = points;
+  collision_data.request.enable_contact = true;
+  broadphase_manager_.collide(static_cast<void*>(&collision_data),
+                              CollisionCallback);
+  return true;
 }
 
 bool FclModel::ClosestPointsPairwise(const std::vector<ElementIdPair>& id_pairs,

--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -91,6 +91,12 @@ void FclModel::DoAddElement(const Element& element) {
           static_cast<const DrakeShapes::Sphere&>(element.getGeometry());
       fcl_geometry = std::make_shared<fcl::Sphered>(sphere.radius);
     } break;
+    case DrakeShapes::CYLINDER: {
+      const auto cylinder =
+          static_cast<const DrakeShapes::Cylinder&>(element.getGeometry());
+      fcl_geometry =
+          std::make_shared<fcl::Cylinderd>(cylinder.radius, cylinder.length);
+    } break;
     default:
       DRAKE_ABORT_MSG("Not implemented.");
       break;

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -47,6 +47,8 @@ class FclModel : public Model {
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>* closest_points) override;
   void UpdateModel() override;
+  bool UpdateElementWorldTransform(
+      ElementId, const Eigen::Isometry3d& T_local_to_world) override;
 
  private:
   fcl::DynamicAABBTreeCollisionManager<double> broadphase_manager_;

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include <Eigen/Dense>
+#include <fcl/fcl.h>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/multibody/collision/element.h"
@@ -44,6 +47,11 @@ class FclModel : public Model {
       const Eigen::Matrix3Xd& points, bool use_margins,
       std::vector<PointPair>* closest_points) override;
   void UpdateModel() override;
+
+ private:
+  fcl::DynamicAABBTreeCollisionManager<double> broadphase_manager_;
+  std::unordered_map<ElementId, std::unique_ptr<fcl::CollisionObject<double>>>
+      fcl_collision_objects_;
 };
 
 }  // namespace collision

--- a/drake/multibody/collision/test/model_test.cc
+++ b/drake/multibody/collision/test/model_test.cc
@@ -90,6 +90,11 @@ class AllModelTypesTests : public ModelTestBase,
 
 TEST_P(AllModelTypesTests, NewModel) { EXPECT_FALSE(model_ == nullptr); }
 
+TEST_P(AllModelTypesTests, AddElement) {
+  Element* elem = AddSphere();
+  EXPECT_EQ(elem->getShape(), DrakeShapes::SPHERE);
+}
+
 #ifdef BULLET_COLLISION
 
 #ifndef DRAKE_DISABLE_FCL
@@ -152,11 +157,6 @@ class FclModelDeathTests : public ModelTestBase,
     model_->AddElement(make_unique<Element>(geom));
   }
 
-  void CallAddSphere() {
-    const DrakeShapes::Sphere geom{1};
-    model_->AddElement(make_unique<Element>(geom));
-  }
-
   void CallAddCylinder() {
     const DrakeShapes::Cylinder geom{1, 1};
     model_->AddElement(make_unique<Element>(geom));
@@ -216,8 +216,7 @@ TEST_P(FclModelDeathTests, NotImplemented) {
 INSTANTIATE_TEST_CASE_P(
     NotImplementedTest, FclModelDeathTests,
     ::testing::Values(
-        &FclModelDeathTests::CallAddBox, &FclModelDeathTests::CallAddSphere,
-        &FclModelDeathTests::CallAddCylinder,
+        &FclModelDeathTests::CallAddBox, &FclModelDeathTests::CallAddCylinder,
         &FclModelDeathTests::CallAddCapsule, &FclModelDeathTests::CallAddMesh,
         &FclModelDeathTests::CallUpdateModel,
         &FclModelDeathTests::CallClosestPointsAllToAll,


### PR DESCRIPTION
This PR implements `ComputeMaximumDepthCollisionPoints()` and supporting methods in `FclModel`. The only supported shapes in this PR are spheres and cylinders. Other shapes require upstream fixes to FCL and/or libccd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7063)
<!-- Reviewable:end -->
