### PR TITLE
Time stepping rigid body plant (without constraints)

### DIFF
--- a/drake/examples/quadrotor/BUILD
+++ b/drake/examples/quadrotor/BUILD
@@ -10,6 +10,12 @@ load(
 load("//tools:install_data.bzl", "install_data")
 load("//tools:lint.bzl", "add_lint_tests")
 
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
 drake_cc_library(
     name = "quadrotor_plant",
     srcs = ["quadrotor_plant.cc"],

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -11,15 +11,15 @@ load("//tools:lint.bzl", "add_lint_tests")
 
 drake_cc_library(
     name = "time_stepping_rigid_body_plant",
+    srcs = ["time_stepping_rigid_body_plant.cc"],
     hdrs = [
         "time_stepping_rigid_body_plant.h",
     ],
-    srcs = ["time_stepping_rigid_body_plant.cc"],
     deps = [
         "//drake/common",
-	"//drake/multibody/rigid_body_plant",
-	"//drake/multibody/constraint",
-	"//drake/multibody/constraint:constraint_solver",
+        "//drake/multibody/constraint",
+        "//drake/multibody/constraint:constraint_solver",
+        "//drake/multibody/rigid_body_plant",
     ],
 )
 
@@ -46,8 +46,9 @@ drake_cc_library(
 drake_cc_googletest(
     name = "quadrotor_test",
     srcs = ["test/quadrotor_test.cc"],
+    data = ["//drake/examples/quadrotor:models"],
     deps = [
-	":time_stepping_rigid_body_plant",
+        ":time_stepping_rigid_body_plant",
         "//drake/common:find_resource",
         "//drake/examples/quadrotor:quadrotor_plant",
         "//drake/lcm",
@@ -62,7 +63,6 @@ drake_cc_googletest(
         "//drake/systems/primitives:constant_vector_source",
         "@com_github_gflags_gflags//:gflags",
     ],
-    data = ["//drake/examples/quadrotor:models"],
 )
 
 drake_cc_googletest(

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -10,6 +10,20 @@ load("//tools:gurobi.bzl", "gurobi_test_tags")
 load("//tools:lint.bzl", "add_lint_tests")
 
 drake_cc_library(
+    name = "time_stepping_rigid_body_plant",
+    hdrs = [
+        "time_stepping_rigid_body_plant.h",
+    ],
+    srcs = ["time_stepping_rigid_body_plant.cc"],
+    deps = [
+        "//drake/common",
+	"//drake/multibody/rigid_body_plant",
+	"//drake/multibody/constraint",
+	"//drake/multibody/constraint:constraint_solver",
+    ],
+)
+
+drake_cc_library(
     name = "global_inverse_kinematics_test_util",
     testonly = 1,
     srcs = [

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -44,6 +44,28 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
+    name = "quadrotor_test",
+    srcs = ["test/quadrotor_test.cc"],
+    deps = [
+	":time_stepping_rigid_body_plant",
+        "//drake/common:find_resource",
+        "//drake/examples/quadrotor:quadrotor_plant",
+        "//drake/lcm",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody:rigid_body_tree_construction",
+        "//drake/multibody/parsers",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/multibody/rigid_body_plant:drake_visualizer",
+        "//drake/systems/analysis:semi_explicit_euler_integrator",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/primitives:constant_vector_source",
+        "@com_github_gflags_gflags//:gflags",
+    ],
+    data = ["//drake/examples/quadrotor:models"],
+)
+
+drake_cc_googletest(
     name = "global_inverse_kinematics_test",
     size = "medium",
     srcs = ["test/global_inverse_kinematics_test.cc"],

--- a/drake/multibody/dev/test/quadrotor_test.cc
+++ b/drake/multibody/dev/test/quadrotor_test.cc
@@ -1,8 +1,8 @@
 /// @file
 ///
-/// This demo sets up a passive Quadrotor plant in a world described by the
-/// warehouse model. The robot simply rests on the floor within the walls
-/// of the warehouse.
+/// This example cross-checks the TimeSteppingRigidBodyPlant (using discrete
+/// state) dynamics against those of a rigid body model using RigidBodyPlant
+/// with continuous state.
 
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
@@ -49,9 +49,6 @@ class Quadrotor : public systems::Diagram<T> {
     ModelInstanceIdTable model_id_table = AddModelInstanceFromUrdfFileToWorld(
         FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"),
         kRollPitchYaw, tree.get());
-    AddModelInstancesFromSdfFile(
-        FindResourceOrThrow("drake/examples/quadrotor/warehouse.sdf"),
-        kFixed, nullptr /* weld to frame */, tree.get());
     drake::multibody::AddFlatTerrainToWorld(tree.get());
 
     systems::DiagramBuilder<T> builder;

--- a/drake/multibody/dev/test/quadrotor_test.cc
+++ b/drake/multibody/dev/test/quadrotor_test.cc
@@ -1,0 +1,148 @@
+/// @file
+///
+/// This demo sets up a passive Quadrotor plant in a world described by the
+/// warehouse model. The robot simply rests on the floor within the walls
+/// of the warehouse.
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
+#include "drake/examples/quadrotor/quadrotor_plant.h"
+#include "drake/lcm/drake_lcm.h"
+#include "drake/multibody/dev/time_stepping_rigid_body_plant.h"
+#include "drake/multibody/parsers/model_instance_id_table.h"
+#include "drake/multibody/parsers/sdf_parser.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_plant/drake_visualizer.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/multibody/rigid_body_tree_construction.h"
+#include "drake/systems/analysis/runge_kutta2_integrator.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+
+namespace drake {
+
+using multibody::joints::kFixed;
+using multibody::joints::kRollPitchYaw;
+using parsers::ModelInstanceIdTable;
+using parsers::urdf::AddModelInstanceFromUrdfFileToWorld;
+using parsers::sdf::AddModelInstancesFromSdfFile;
+using systems::InputPortDescriptor;
+using systems::RigidBodyPlant;
+using systems::TimeSteppingRigidBodyPlant;
+
+namespace multibody {
+namespace {
+
+template <typename T>
+class Quadrotor : public systems::Diagram<T> {
+ public:
+  Quadrotor(double dt) {
+    this->set_name("Quadrotor");
+
+    auto tree = std::make_unique<RigidBodyTree<T>>();
+    ModelInstanceIdTable model_id_table = AddModelInstanceFromUrdfFileToWorld(
+        FindResourceOrThrow("drake/examples/quadrotor/quadrotor.urdf"),
+        kRollPitchYaw, tree.get());
+    const int quadrotor_id = model_id_table.at("quadrotor");
+    AddModelInstancesFromSdfFile(
+        FindResourceOrThrow("drake/examples/quadrotor/warehouse.sdf"),
+        kFixed, nullptr /* weld to frame */, tree.get());
+    drake::multibody::AddFlatTerrainToWorld(tree.get());
+
+    systems::DiagramBuilder<T> builder;
+
+    if (dt > 0.0) {
+      plant_ = builder.template AddSystem<RigidBodyPlant<T>>(
+          std::move(tree));
+    } else {
+      plant_ = builder.template AddSystem<TimeSteppingRigidBodyPlant<T>>(
+          std::move(tree), dt);
+    }
+
+    plant_->set_name("plant");
+
+    // Verifies that the quadrotor has no actuators.
+    DRAKE_DEMAND(plant_->get_num_actuators() == 0);
+    DRAKE_DEMAND(plant_->get_num_actuators(quadrotor_id) == 0);
+
+    VectorX<T> hover_input(plant_->get_input_size());
+    hover_input.setZero();
+
+    systems::DrakeVisualizer* publisher =
+        builder.template AddSystem<systems::DrakeVisualizer>(
+            plant_->get_rigid_body_tree(), &lcm_);
+
+    builder.Connect(plant_->get_output_port(0), publisher->get_input_port(0));
+
+    builder.BuildInto(this);
+  }
+
+  void SetDefaultState(const systems::Context<T>& context,
+                       systems::State<T>* state) const override {
+    DRAKE_DEMAND(state != nullptr);
+    systems::Diagram<T>::SetDefaultState(context, state);
+    systems::State<T>& plant_state =
+        this->GetMutableSubsystemState(*plant_, state);
+    VectorX<T> x0(plant_->get_num_states());
+    x0.setZero();
+    /* x0 is the initial state where
+     * x0(0), x0(1), x0(2) are the quadrotor's x, y, z -states
+     * x0(3), x0(4), x0(5) are the quedrotor's Euler angles phi, theta, psi
+     */
+    x0(2) = 0.2;  // Sets arbitrary z-position. This is the initial height of
+                  // the quadrotor in the world frame.
+    plant_->set_state_vector(&plant_state, x0);
+  }
+
+ private:
+  systems::RigidBodyPlant<T>* plant_{};
+  lcm::DrakeLcm lcm_;
+};
+
+// Verifies that the output of the time stepping rigid body plant and the
+// continuous rigid body plant are equal with 
+GTEST_TEST(QuadrotorTest, Equality) {
+  //  Set the step size.
+  const double step_size = 1e-3;
+
+  // Construct the two models.
+  Quadrotor<double> continuous_model(0.0);
+  Quadrotor<double> discrete_model(step_size);
+
+  // Construct two simulators for those models.
+  systems::Simulator<double> continuous_sim(continuous_model);
+  systems::Simulator<double> discrete_sim(discrete_model);
+
+  // Make them use the same "integrator".
+  continuous_sim.reset_integrator<systems::SemiExplicitEulerIntegrator<double>>(
+      continuous_model, step_size, continuous_sim.get_mutable_context());
+
+  // Initialize the simulators.
+  continuous_sim.Initialize();
+  discrete_sim.Initialize();
+
+  // Step both forward by ten seconds (i.e., a long time into the future).
+  continuous_sim.StepTo(duration);
+  discrete_sim.StepTo(duration);
+
+  // Compare the states.
+  auto continuous_state = continuous_model.GetStateVector(
+      continuous_sim.get_context());
+  auto discrete_state = discrete_model.GetStateVector(
+      discrete_sim.get_context());
+  ASSERT_EQ(continuous_state.size(), discrete_state.size());
+  for (int i = 0; i < discrete_state.size(); ++i) {
+    EXPECT_NEAR(discrete_state[i], continuous_state[i],
+      10 * std::numeric_limits<double>::epsilon());
+  }
+}
+
+}  // namespace
+}  // namespace multibody 
+}  // namespace drake
+

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -42,6 +42,14 @@ TimeSteppingRigidBodyPlant<T>::TimeSteppingRigidBodyPlant(
   this->DeclarePeriodicDiscreteUpdate(timestep);
 }
 
+template <class T>
+void TimeSteppingRigidBodyPlant<T>::CalcContactStiffnessAndDamping(
+    const drake::multibody::collision::PointPair& contact,
+    double* stiffness,
+    double* damping) const {
+  DRAKE_DEMAND("CalcContactStiffnessAndDamping() not yet implemented.");
+}
+
 // Gets A's translational velocity relative to B's translational velocity at a
 // point common to the two rigid bodies.
 // @param p_W The point of contact (defined in the world frame).
@@ -51,6 +59,7 @@ Vector3<T> TimeSteppingRigidBodyPlant<T>::CalcRelTranslationalVelocity(
     const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
     const Vector3<T>& p_W) const {
   DRAKE_DEMAND("CalcRelTranslationalVelocity() not yet implemented.");
+  return Vector3<T>::Zero();
 }
 
 // Updates a generalized force from a force of f (expressed in the world frame)
@@ -273,7 +282,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   data.kN.resize(contacts.size());
   for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
     double stiffness, damping;
-    CalcStiffnessAndDamping(contacts[i], &stiffness, &damping);
+    CalcContactStiffnessAndDamping(contacts[i], &stiffness, &damping);
     const double denom = dt * stiffness + damping;
     double contact_cfm = 1.0 / denom;
     double contact_erp = dt * stiffness / denom;

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -276,19 +276,20 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
     return result;
   };
 
-  // Set the stabilization and softening terms for contact normal direction 
-  // (kN and gammaN), contact tangent directions (kF and gammaF, gammaE),
-  // joint limit constraints (kL and gammaL).
+  // 1. Set the stabilization term for contact normal direction (kN)
   data.kN.resize(contacts.size());
   for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
     double stiffness, damping;
     CalcContactStiffnessAndDamping(contacts[i], &stiffness, &damping);
     const double denom = dt * stiffness + damping;
-    double contact_cfm = 1.0 / denom;
     double contact_erp = dt * stiffness / denom;
     data.kN[i] = contact_erp * contacts[i].distance / dt;
   }
+
+  // 2. Set the stabilization term for contact tangent directions (kF).
   data.kF.setZero(total_friction_cone_edges);
+
+  // 3. Set the stabilization term for joint limit constraints (kL). 
   data.kL.resize(limits.size());
   for (int i = 0; i < static_cast<int>(limits.size()); ++i)
     data.kL[i] = erp_ * limits[i].error / dt;

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -161,7 +161,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   DRAKE_DEMAND(ldlt.info() == Eigen::Success);
 
   // Set the inertia matrix solver.
-  data.solve_inertia = [this, &ldlt](const MatrixX<T>& m) {
+  data.solve_inertia = [&ldlt](const MatrixX<T>& m) {
     return ldlt.solve(m);
   };
 

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -184,7 +184,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   data.mu.resize(contacts.size());
   data.r.resize(contacts.size());
   for (int i = 0; i < data.mu.rows(); ++i) {
-    // TODO(edrumwri): Replace this with parsed mu once #7016 lands. 
+    // TODO(edrumwri): Replace this with parsed mu once #7016 lands.
     data.mu[i] = mu_;
     data.r[i] = half_cone_edges_;
   }
@@ -265,7 +265,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
     return result;
   };
 
-  // Set the unilateral constraint operator (for evaluating effect of forces 
+  // Set the unilateral constraint operator (for evaluating effect of forces
   // at joint limits on generalized forces).
   data.L_transpose_mult = [this, &v, &limits](const VectorX<T>& lambda) {
     VectorX<T> result = VectorX<T>::Zero(v.size());
@@ -289,7 +289,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   // 2. Set the stabilization term for contact tangent directions (kF).
   data.kF.setZero(total_friction_cone_edges);
 
-  // 3. Set the stabilization term for joint limit constraints (kL). 
+  // 3. Set the stabilization term for joint limit constraints (kL).
   data.kL.resize(limits.size());
   for (int i = 0; i < static_cast<int>(limits.size()); ++i)
     data.kL[i] = erp_ * limits[i].error / dt;

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -1,0 +1,306 @@
+#include "drake/multibody/dev/time_stepping_rigid_body_plant.h"
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#include <Eigen/Cholesky>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/constraint/constraint_problem_data.h"
+#include "drake/multibody/kinematics_cache.h"
+#include "drake/solvers/mathematical_program.h"
+
+using std::make_unique;
+using std::move;
+using std::runtime_error;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+using drake::multibody::collision::ElementId;
+using drake::multibody::constraint::ConstraintSolver;
+
+namespace drake {
+namespace systems {
+
+template <typename T>
+TimeSteppingRigidBodyPlant<T>::TimeSteppingRigidBodyPlant(
+    std::unique_ptr<const RigidBodyTree<T>> tree, double timestep)
+    : RigidBodyPlant<T>(std::move(tree), timestep) {
+
+  // Verify that the time-step is strictly positive.
+  if (timestep <= 0.0) {
+    throw std::logic_error("TimeSteppingRigidBodyPlant requires a positive "
+                               "integration time step.");
+  }
+
+  // Schedule the time stepping.
+  this->DeclarePeriodicDiscreteUpdate(timestep);
+}
+
+// Gets A's translational velocity relative to B's translational velocity at a
+// point common to the two rigid bodies.
+// @param p_W The point of contact (defined in the world frame).
+// @returns the relative velocity at p_W expressed in the world frame.
+template <class T>
+Vector3<T> TimeSteppingRigidBodyPlant<T>::CalcRelTranslationalVelocity(
+    const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
+    const Vector3<T>& p_W) const {
+  DRAKE_DEMAND("CalcRelTranslationalVelocity() not yet implemented.");
+}
+
+// Updates a generalized force from a force of f (expressed in the world frame)
+// applied at point p (defined in the global frame).
+template <class T>
+void TimeSteppingRigidBodyPlant<T>::UpdateGeneralizedForce(
+    const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
+    const Vector3<T>& p_W, const Vector3<T>& f, VectorX<T>* gf) const {
+  DRAKE_DEMAND("UpdateGeneralizedForce() not yet implemented.");
+}
+
+// Evaluates the relative velocities between two bodies projected along the
+// contact normals.
+template <class T>
+VectorX<T> TimeSteppingRigidBodyPlant<T>::N_mult(
+    const std::vector<drake::multibody::collision::PointPair>& contacts,
+    const VectorX<T>& q,
+    const VectorX<T>& v) const {
+  DRAKE_DEMAND("N_mult() not yet implemented.");
+  return VectorX<T>::Zero(contacts.size());
+}
+
+// Applies forces along the contact normals at the contact points and gets the
+// effect out on the generalized forces.
+template <class T>
+VectorX<T> TimeSteppingRigidBodyPlant<T>::N_transpose_mult(
+    const std::vector<drake::multibody::collision::PointPair>& contacts,
+    const VectorX<T>& q,
+    const VectorX<T>& v,
+    const VectorX<T>& f) const {
+  DRAKE_DEMAND("N_transpose_mult() not yet implemented.");
+  return VectorX<T>::Zero(v.size());
+}
+
+// Evaluates the relative velocities between two bodies projected along the
+// contact tangent directions.
+template <class T>
+VectorX<T> TimeSteppingRigidBodyPlant<T>::F_mult(
+    const std::vector<drake::multibody::collision::PointPair>& contacts,
+    const VectorX<T>& q,
+    const VectorX<T>& v) const {
+  DRAKE_DEMAND("F_mult() not yet implemented.");
+  return VectorX<T>::Zero(contacts.size() * half_cone_edges_);
+}
+
+// Applies a force at the contact spanning directions at all contacts and gets
+// the effect out on the generalized forces.
+template <class T>
+VectorX<T> TimeSteppingRigidBodyPlant<T>::F_transpose_mult(
+    const std::vector<drake::multibody::collision::PointPair>& contacts,
+    const VectorX<T>& q,
+    const VectorX<T>& v,
+    const VectorX<T>& f) const {
+  DRAKE_DEMAND("F_transpose_mult() not yet implemented.");
+  return VectorX<T>::Zero(v.size());
+}
+
+template <typename T>
+void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
+    const drake::systems::Context<T>& context,
+    const std::vector<const drake::systems::DiscreteUpdateEvent<double>*>&,
+    drake::systems::DiscreteValues<T>* updates) const {
+  using std::abs;
+  std::vector<JointLimit> limits;
+
+  static_assert(std::is_same<double, T>::value,
+                "Only support templating on double for now");
+
+  // Get the time step.
+  double dt = this->get_time_step();
+  DRAKE_DEMAND(dt > 0.0);
+
+  VectorX<T> u = this->EvaluateActuatorInputs(context);
+
+  const int nq = this->get_num_positions();
+  const int nv = this->get_num_velocities();
+  const int num_actuators = this->get_num_actuators();
+
+  // Initialize the velocity problem data.
+  drake::multibody::constraint::ConstraintVelProblemData<T> data(nv);
+
+  // Get the rigid body tree.
+  const auto& tree = this->get_rigid_body_tree();
+
+  // Get the system state.
+  auto x = context.get_discrete_state(0)->get_value();
+  VectorX<T> q = x.topRows(nq);
+  VectorX<T> v = x.bottomRows(nv);
+  auto kcache = tree.doKinematics(q, v);
+
+  // Get the generalized inertia matrix and set up the inertia solve function.
+  auto H = tree.massMatrix(kcache);
+
+  // Compute the LDLT factorizations, which will be used by the solver.
+  Eigen::LDLT<MatrixX<T>> ldlt(H);
+  DRAKE_DEMAND(ldlt.info() == Eigen::Success);
+
+  // Set the inertia matrix solver.
+  data.solve_inertia = [this, &ldlt](const MatrixX<T>& m) {
+    return ldlt.solve(m);
+  };
+
+  // There are no external wrenches, but it is a required argument in
+  // dynamicsBiasTerm().
+  const typename RigidBodyTree<T>::BodyToWrenchMap no_external_wrenches;
+
+  // right_hand_side is the right hand side of the system's equations:
+  //   right_hand_side = B*u - C(q,v)
+  VectorX<T> right_hand_side =
+      -tree.dynamicsBiasTerm(kcache, no_external_wrenches);
+  if (num_actuators > 0) right_hand_side += tree.B * u;
+
+  // Determine the set of contact points corresponding to the current q.
+  std::vector<drake::multibody::collision::PointPair> contacts =
+      const_cast<RigidBodyTree<T>*>(&tree)->ComputeMaximumDepthCollisionPoints(
+          kcache, true);
+
+  // Verify the friction directions are set correctly.
+  DRAKE_DEMAND(half_cone_edges_ >= 2);
+
+  // Set the coefficients of friction.
+  data.mu.resize(contacts.size());
+  data.r.resize(contacts.size());
+  for (int i = 0; i < data.mu.rows(); ++i) {
+    // TODO(edrumwri): Replace this with parsed mu once #7016 lands. 
+    data.mu[i] = mu_;
+    data.r[i] = half_cone_edges_;
+  }
+  const int total_friction_cone_edges = std::accumulate(
+      data.r.begin(), data.r.end(), 0);
+
+  // Set the joint range of motion limits.
+  for (auto const& b : tree.bodies) {
+    if (!b->has_parent_body()) continue;
+    auto const& joint = b->getJoint();
+
+    // Joint limit forces are only implemented for single-axis joints.
+    if (joint.get_num_positions() == 1 && joint.get_num_velocities() == 1) {
+      const T qmin = joint.getJointLimitMin()(0);
+      const T qmax = joint.getJointLimitMax()(0);
+      DRAKE_DEMAND(qmin < qmax);
+
+      // Get the current joint position and velocity.
+      const T& qjoint = q(b->get_position_start_index());
+      const T& vjoint = v(b->get_velocity_start_index());
+
+      // See whether the joint is beyond its limit or whether the *current*
+      // joint velocity might lead to a limit violation.
+      if (qjoint < qmin || qjoint + vjoint * dt < qmin) {
+        // Institute a lower limit.
+        limits.push_back(JointLimit());
+        limits.back().v_index = b->get_velocity_start_index();
+        limits.back().error = (qjoint - qmin);
+        limits.back().lower_limit = true;
+      }
+      if (qjoint > qmax || qjoint + vjoint * dt > qmax) {
+        // Institute an upper limit.
+        limits.push_back(JointLimit());
+        limits.back().v_index = b->get_velocity_start_index();
+        limits.back().error = (qmax - qjoint);
+        limits.back().lower_limit = false;
+      }
+    }
+  }
+
+  // Set the number of generic unilateral constraint functions.
+  data.num_limit_constraints = limits.size();
+
+  // Set up the N multiplication operator (projected velocity along the contact
+  // normals).
+  data.N_mult = [this, &contacts, &q](const VectorX<T>& w) -> VectorX<T> {
+    return N_mult(contacts, q, w);
+  };
+
+  // Set up the N' multiplication operator (effect of contact normal forces
+  // on generalized forces).
+  data.N_transpose_mult = [this, &contacts, &q, &v](const VectorX<T>& f) ->
+      VectorX<T> {
+    return N_transpose_mult(contacts, q, v, f);
+  };
+
+  // Set up the F multiplication operator (projected velocity along the contact
+  // tangent directions).
+  data.F_mult = [this, &contacts, &q](const VectorX<T>& w) -> VectorX<T> {
+    return F_mult(contacts, q, w);
+  };
+
+  // Set up the F' multiplication operator (effect of contact frictional forces
+  // on generalized forces).
+  data.F_transpose_mult = [this, &contacts, &q, &v](const VectorX<T>& f) ->
+      VectorX<T> {
+    return F_transpose_mult(contacts, q, v, f);
+  };
+
+  // Set the unilateral constraint operator (for evaluating joint velocities
+  // at joint limit constraints).
+  data.L_mult = [this, &limits](const VectorX<T>& w) -> VectorX<T> {
+    VectorX<T> result(limits.size());
+    for (int i = 0; static_cast<size_t>(i) < limits.size(); ++i) {
+      const int index = limits[i].v_index;
+      result[i] = (limits[i].lower_limit) ? w[index] : -w[index];
+    }
+    return result;
+  };
+
+  // Set the unilateral constraint operator (for evaluating effect of forces 
+  // at joint limits on generalized forces).
+  data.L_transpose_mult = [this, &v, &limits](const VectorX<T>& lambda) {
+    VectorX<T> result = VectorX<T>::Zero(v.size());
+    for (int i = 0; static_cast<size_t>(i) < limits.size(); ++i) {
+      const int index = limits[i].v_index;
+      result[index] = (limits[i].lower_limit) ? lambda[i] : -lambda[i];
+    }
+    return result;
+  };
+
+  // Set the stabilization and softening terms for contact normal direction 
+  // (kN and gammaN), contact tangent directions (kF and gammaF, gammaE),
+  // joint limit constraints (kL and gammaL).
+  data.kN.resize(contacts.size());
+  for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
+    double stiffness, damping;
+    CalcStiffnessAndDamping(contacts[i], &stiffness, &damping);
+    const double denom = dt * stiffness + damping;
+    double contact_cfm = 1.0 / denom;
+    double contact_erp = dt * stiffness / denom;
+    data.kN[i] = contact_erp * contacts[i].distance / dt;
+  }
+  data.kF.setZero(total_friction_cone_edges);
+  data.kL.resize(limits.size());
+  for (int i = 0; i < static_cast<int>(limits.size()); ++i)
+    data.kL[i] = erp_ * limits[i].error / dt;
+
+  // Integrate the forces into the velocity.
+  data.v = v + data.solve_inertia(right_hand_side) * dt;
+
+  // Solve the rigid impact problem.
+  VectorX<T> vnew, cf;
+  constraint_solver_.SolveImpactProblem(cfm_, data, &cf);
+  constraint_solver_.ComputeGeneralizedVelocityChange(data, cf, &vnew);
+  vnew += data.v;
+
+  // qn = q + h*qdot.
+  VectorX<T> xn(this->get_num_states());
+  xn << q + dt * tree.transformVelocityToQDot(kcache, vnew), vnew;
+  updates->get_mutable_vector(0)->SetFromVector(xn);
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class TimeSteppingRigidBodyPlant<double>;
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -46,9 +46,9 @@ TimeSteppingRigidBodyPlant<T>::TimeSteppingRigidBodyPlant(
 // geometries.
 template <class T>
 void TimeSteppingRigidBodyPlant<T>::CalcContactStiffnessAndDamping(
-    const drake::multibody::collision::PointPair& contact,
-    double* stiffness,
-    double* damping) const {
+    const drake::multibody::collision::PointPair&,
+    double*,
+    double*) const {
   DRAKE_DEMAND("CalcContactStiffnessAndDamping() not yet implemented.");
 }
 
@@ -58,8 +58,8 @@ void TimeSteppingRigidBodyPlant<T>::CalcContactStiffnessAndDamping(
 // @returns the relative velocity at p_W expressed in the world frame.
 template <class T>
 Vector3<T> TimeSteppingRigidBodyPlant<T>::CalcRelTranslationalVelocity(
-    const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
-    const Vector3<T>& p_W) const {
+    const KinematicsCache<T>&, int, int,
+    const Vector3<T>&) const {
   DRAKE_DEMAND("CalcRelTranslationalVelocity() not yet implemented.");
   return Vector3<T>::Zero();
 }
@@ -68,8 +68,8 @@ Vector3<T> TimeSteppingRigidBodyPlant<T>::CalcRelTranslationalVelocity(
 // applied at point p (defined in the global frame).
 template <class T>
 void TimeSteppingRigidBodyPlant<T>::UpdateGeneralizedForce(
-    const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
-    const Vector3<T>& p_W, const Vector3<T>& f, VectorX<T>* gf) const {
+    const KinematicsCache<T>&, int, int,
+    const Vector3<T>&, const Vector3<T>&, VectorX<T>*) const {
   DRAKE_DEMAND("UpdateGeneralizedForce() not yet implemented.");
 }
 
@@ -77,9 +77,9 @@ void TimeSteppingRigidBodyPlant<T>::UpdateGeneralizedForce(
 // contact normals.
 template <class T>
 VectorX<T> TimeSteppingRigidBodyPlant<T>::N_mult(
-    const std::vector<drake::multibody::collision::PointPair>& contacts,
-    const VectorX<T>& q,
-    const VectorX<T>& v) const {
+    const std::vector<drake::multibody::collision::PointPair>&,
+    const VectorX<T>&,
+    const VectorX<T>&) const {
   DRAKE_DEMAND("N_mult() not yet implemented.");
   return VectorX<T>::Zero(contacts.size());
 }
@@ -88,10 +88,10 @@ VectorX<T> TimeSteppingRigidBodyPlant<T>::N_mult(
 // effect out on the generalized forces.
 template <class T>
 VectorX<T> TimeSteppingRigidBodyPlant<T>::N_transpose_mult(
-    const std::vector<drake::multibody::collision::PointPair>& contacts,
-    const VectorX<T>& q,
-    const VectorX<T>& v,
-    const VectorX<T>& f) const {
+    const std::vector<drake::multibody::collision::PointPair>&,
+    const VectorX<T>&,
+    const VectorX<T>&,
+    const VectorX<T>&) const {
   DRAKE_DEMAND("N_transpose_mult() not yet implemented.");
   return VectorX<T>::Zero(v.size());
 }
@@ -100,9 +100,9 @@ VectorX<T> TimeSteppingRigidBodyPlant<T>::N_transpose_mult(
 // contact tangent directions.
 template <class T>
 VectorX<T> TimeSteppingRigidBodyPlant<T>::F_mult(
-    const std::vector<drake::multibody::collision::PointPair>& contacts,
-    const VectorX<T>& q,
-    const VectorX<T>& v) const {
+    const std::vector<drake::multibody::collision::PointPair>&,
+    const VectorX<T>&,
+    const VectorX<T>&) const {
   DRAKE_DEMAND("F_mult() not yet implemented.");
   return VectorX<T>::Zero(contacts.size() * half_cone_edges_);
 }
@@ -111,10 +111,10 @@ VectorX<T> TimeSteppingRigidBodyPlant<T>::F_mult(
 // the effect out on the generalized forces.
 template <class T>
 VectorX<T> TimeSteppingRigidBodyPlant<T>::F_transpose_mult(
-    const std::vector<drake::multibody::collision::PointPair>& contacts,
-    const VectorX<T>& q,
-    const VectorX<T>& v,
-    const VectorX<T>& f) const {
+    const std::vector<drake::multibody::collision::PointPair>&,
+    const VectorX<T>&,
+    const VectorX<T>&,
+    const VectorX<T>&) const {
   DRAKE_DEMAND("F_transpose_mult() not yet implemented.");
   return VectorX<T>::Zero(v.size());
 }

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -35,6 +35,9 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   TimeSteppingRigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree,
                           double timestep);
 
+  /// The default Coulomb friction coefficient.
+  double mu_{0.1};
+
   /// Sets the ERP parameter. Aborts if not in the range [0,1]. Default value
   /// is 0.1.
   void set_erp(double erp) { DRAKE_DEMAND(erp >= 0 && erp <= 1); erp_ = erp; }
@@ -66,6 +69,10 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
     T error{0};
   };
 
+  void CalcContactStiffnessAndDamping(
+      const drake::multibody::collision::PointPair& contact,
+      double* stiffness,
+      double* damping) const;
   Vector3<T> CalcRelTranslationalVelocity(
       const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
       const Vector3<T>& p_W) const;

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/rigid_body_plant/kinematics_results.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/multibody/constraint/constraint_solver.h"
+
+namespace drake {
+namespace systems {
+
+/// This class provides a System interface around a multibody dynamics model
+/// of the world represented by a RigidBodyTree.
+///
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
+/// @ingroup rigid_body_systems
+template <typename T>
+class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TimeSteppingRigidBodyPlant)
+
+  /// Instantiates a %TimeSteppingRigidBodyPlant from a Multi-Body Dynamics
+  /// (MBD) model of the world in `tree`.  `tree` must not be `nullptr`.
+  ///
+  /// @param[in] tree the dynamic model to use with this plant.
+  /// @param[in] timestep a strictly positive, floating point value specifying
+  /// the update period of the model (in seconds).
+  TimeSteppingRigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree,
+                          double timestep);
+
+  /// Sets the ERP parameter. Aborts if not in the range [0,1]. Default value
+  /// is 0.1.
+  void set_erp(double erp) { DRAKE_DEMAND(erp >= 0 && erp <= 1); erp_ = erp; }
+
+  /// Sets the CFM parameter. Aborts if negative. Default value is 1e-12.
+  void set_cfm(double cfm) { DRAKE_DEMAND(cfm >= 0); cfm_ = cfm; }
+
+ protected:
+  void DoCalcDiscreteVariableUpdates(const Context<T>& context,
+      const std::vector<const DiscreteUpdateEvent<double>*>&,
+      DiscreteValues<T>* updates) const override;
+
+  // Pointer to the class that performs all constraint computations.
+  multibody::constraint::ConstraintSolver<T> constraint_solver_;
+
+ private:
+  // Structure for storing joint limit data for time stepping.
+  struct JointLimit {
+    // The index for the joint limit.
+    int v_index{-1};
+
+    // Whether the limit is a lower limit or upper limit.
+    bool lower_limit{false};
+
+    // Gets the "error", meaning the amount over the limit (if the error is
+    // positive) or under the limit (if the error is negative). Negative error
+    // is not error per se, but rather a way to limit the movement of a joint
+    // by the step into the future.
+    T error{0};
+  };
+
+  Vector3<T> CalcRelTranslationalVelocity(
+      const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
+      const Vector3<T>& p_W) const;
+  void UpdateGeneralizedForce(
+      const KinematicsCache<T>& kcache, int body_a_index, int body_b_index,
+      const Vector3<T>& p, const Vector3<T>& f, VectorX<T>* gf) const;
+  VectorX<T> N_mult(
+      const std::vector<drake::multibody::collision::PointPair>& contacts,
+      const VectorX<T>& q,
+      const VectorX<T>& v) const;
+  VectorX<T> N_transpose_mult(
+      const std::vector<drake::multibody::collision::PointPair>& contacts,
+      const VectorX<T>& q,
+      const VectorX<T>& v,
+      const VectorX<T>& f) const;
+  VectorX<T> F_mult(
+      const std::vector<drake::multibody::collision::PointPair>& contacts,
+      const VectorX<T>& q,
+      const VectorX<T>& v) const;
+  VectorX<T> F_transpose_mult(
+      const std::vector<drake::multibody::collision::PointPair>& contacts,
+      const VectorX<T>& q,
+      const VectorX<T>& v,
+      const VectorX<T>& f) const;
+
+  // Half of the number of edges in the friction cone approximation for
+  // contacts in 3D. Must be no fewer than 2 (equates to a friction pyramid).
+  int half_cone_edges_{2};
+
+  // The "error reduction parameter" (ERP), first seen in CM Labs' Vortex and
+  // Open Dynamics Engine, and formulated from [Lacoursiere 2007], which
+  // determines how rapidly constraint errors are corrected. ERP values of zero
+  // indicate constraint errors will not be corrected, while ERP values of one
+  // indicate constraint errors will be corrected at every time step (ERP values
+  // outside of the range [0,1] are invalid, and will cause assertion failures).
+  // Since Lacoursiere's constraint stabilization process assumes that the
+  // constraint function is approximately linear in position, values of ERP
+  // smaller than unity are generally recommended. A generally safe value of 0.1
+  // is the the default, and can be increased as desired to mitigate constraint
+  // error.
+  double erp_{0.1};
+
+  // The "constraint force mixing" (CFM) parameter, first seen in CM Labs'
+  // Vortex and Open Dynamics Engine, and formulated from [Lacoursiere 2007],
+  // which determines how constraints are "softened" (allowed to become
+  // violated), which generally provides numerical robustness along with a
+  // reduction in constraint stiffness (particularly useful for contact). CFM
+  // values of zero yield no softening, while CFM values of infinity yield
+  // constraints that are completely unenforced. Typical values for CFM
+  // lie in the range [1e-12, 1e-6], but this range is just a rough guideline.
+  double cfm_{1e-12};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -96,9 +96,9 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   // outside of the range [0,1] are invalid, and will cause assertion failures).
   // Since Lacoursiere's constraint stabilization process assumes that the
   // constraint function is approximately linear in position, values of ERP
-  // smaller than unity are generally recommended. A generally safe value of 0.1
-  // is the the default, and can be increased as desired to mitigate constraint
-  // error.
+  // strictly smaller than unity are generally recommended. A generally safe
+  // value of 0.1 is the the default, and can be increased as desired to
+  // mitigate constraint error.
   double erp_{0.1};
 
   // The "constraint force mixing" (CFM) parameter, first seen in CM Labs'

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -45,7 +45,7 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   /// Sets the CFM parameter. Aborts if negative. Default value is 1e-12.
   void set_cfm(double cfm) { DRAKE_DEMAND(cfm >= 0); cfm_ = cfm; }
 
- protected:
+ private:
   void DoCalcDiscreteVariableUpdates(const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>&,
       DiscreteValues<T>* updates) const override;
@@ -53,7 +53,6 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   // Pointer to the class that performs all constraint computations.
   multibody::constraint::ConstraintSolver<T> constraint_solver_;
 
- private:
   void CalcContactStiffnessAndDamping(
       const drake::multibody::collision::PointPair& contact,
       double* stiffness,

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -8,10 +8,10 @@
 #include <Eigen/Geometry>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/constraint/constraint_solver.h"
 #include "drake/multibody/rigid_body_plant/kinematics_results.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/multibody/rigid_body_tree.h"
-#include "drake/multibody/constraint/constraint_solver.h"
 
 namespace drake {
 namespace systems {

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -66,21 +66,19 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
       const Vector3<T>& p, const Vector3<T>& f, VectorX<T>* gf) const;
   VectorX<T> N_mult(
       const std::vector<drake::multibody::collision::PointPair>& contacts,
-      const VectorX<T>& q,
-      const VectorX<T>& v) const;
+      const KinematicsCache<T>& kcache,
+      const VectorX<T>& w) const;
   VectorX<T> N_transpose_mult(
       const std::vector<drake::multibody::collision::PointPair>& contacts,
-      const VectorX<T>& q,
-      const VectorX<T>& v,
+      const KinematicsCache<T>& kcache,
       const VectorX<T>& f) const;
   VectorX<T> F_mult(
       const std::vector<drake::multibody::collision::PointPair>& contacts,
-      const VectorX<T>& q,
-      const VectorX<T>& v) const;
+      const KinematicsCache<T>& kcache,
+      const VectorX<T>& w) const;
   VectorX<T> F_transpose_mult(
       const std::vector<drake::multibody::collision::PointPair>& contacts,
-      const VectorX<T>& q,
-      const VectorX<T>& v,
+      const KinematicsCache<T>& kcache,
       const VectorX<T>& f) const;
 
   // Half of the number of edges in the friction cone approximation for

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -17,7 +17,9 @@ namespace drake {
 namespace systems {
 
 /// This class provides a System interface around a multibody dynamics model
-/// of the world represented by a RigidBodyTree.
+/// of the world represented by a RigidBodyTree, implemented as a first order
+/// discretization of rigid body dynamics and constraint equations, without
+/// stepping to event times.
 ///
 /// @tparam T The scalar type. Must be a valid Eigen scalar.
 /// @ingroup rigid_body_systems
@@ -32,11 +34,9 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   /// @param[in] tree the dynamic model to use with this plant.
   /// @param[in] timestep a strictly positive, floating point value specifying
   /// the update period of the model (in seconds).
+  /// @throws std::logic_error when timestep is non-positive.
   TimeSteppingRigidBodyPlant(std::unique_ptr<const RigidBodyTree<T>> tree,
                           double timestep);
-
-  /// The default Coulomb friction coefficient.
-  double mu_{0.1};
 
   /// Sets the ERP parameter. Aborts if not in the range [0,1]. Default value
   /// is 0.1.
@@ -85,7 +85,11 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
 
   // Half of the number of edges in the friction cone approximation for
   // contacts in 3D. Must be no fewer than 2 (equates to a friction pyramid).
+  // TODO(edrumwri): Make this user settable.
   int half_cone_edges_{2};
+
+  /// The default Coulomb friction coefficient.
+  double mu_{0.1};
 
   // The "error reduction parameter" (ERP), first seen in CM Labs' Vortex and
   // Open Dynamics Engine, and formulated from [Lacoursiere 2007], which

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.h
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.h
@@ -54,21 +54,6 @@ class TimeSteppingRigidBodyPlant : public RigidBodyPlant<T> {
   multibody::constraint::ConstraintSolver<T> constraint_solver_;
 
  private:
-  // Structure for storing joint limit data for time stepping.
-  struct JointLimit {
-    // The index for the joint limit.
-    int v_index{-1};
-
-    // Whether the limit is a lower limit or upper limit.
-    bool lower_limit{false};
-
-    // Gets the "error", meaning the amount over the limit (if the error is
-    // positive) or under the limit (if the error is negative). Negative error
-    // is not error per se, but rather a way to limit the movement of a joint
-    // by the step into the future.
-    T error{0};
-  };
-
   void CalcContactStiffnessAndDamping(
       const drake::multibody::collision::PointPair& contact,
       double* stiffness,

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -334,6 +334,10 @@ class RigidBodyPlant : public LeafSystem<T> {
   double get_time_step() const { return timestep_; }
 
  protected:
+  // Evaluates the actuator command input ports and throws a runtime_error
+  // exception if at least one of the ports is not connected.
+  VectorX<T> EvaluateActuatorInputs(const Context<T>& context) const;
+
   // LeafSystem<T> overrides.
 
   std::unique_ptr<ContinuousState<T>> AllocateContinuousState() const override;
@@ -396,10 +400,6 @@ class RigidBodyPlant : public LeafSystem<T> {
                                 ContactResults<T>* output) const;
 
   void ExportModelInstanceCentricPorts();
-
-  // Evaluates the actuator command input ports and throws a runtime_error
-  // exception if at least one of the ports is not connected.
-  VectorX<T> EvaluateActuatorInputs(const Context<T>& context) const;
 
   std::unique_ptr<const RigidBodyTree<T>> tree_;
 


### PR DESCRIPTION
Adds time stepping version of rigid body plant (under "dev") *without incorporating constraints*.

Skeleton for functions necessary to incorporate constraints has been put into place.

Time stepping rigid body plant (discrete state) is tested against rigid body plant (continuous state, integrated under the semi-explicit integration scheme) to verify that identical results are returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7066)
<!-- Reviewable:end -->
