### PR TITLE
Change DoTo transmogrification methods to use unique_ptr

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -908,14 +908,14 @@ class Diagram : public System<T>,
   /// to override to initialize additional member data. If any contained
   /// subsystem does not support ToAutoDiffXd, then this result is nullptr.
   /// This is the NVI implementation of ToAutoDiffXd.
-  Diagram<AutoDiffXd>* DoToAutoDiffXd() const override {
+  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const override {
     using FromType = System<double>;
     using ToType = std::unique_ptr<System<AutoDiffXd>>;
     std::function<ToType(const FromType&)> subsystem_converter{
         [](const FromType& subsystem) {
           return subsystem.ToAutoDiffXdMaybe();
         }};
-    return ConvertScalarType<AutoDiffXd>(subsystem_converter).release();
+    return ConvertScalarType<AutoDiffXd>(subsystem_converter);
   }
 
   /// Creates a deep copy of this Diagram<double>, converting the scalar type
@@ -923,15 +923,14 @@ class Diagram : public System<T>,
   /// Subclasses may wish to override to initialize additional member data.
   /// If any contained subsystem does not support ToSymbolic, then this
   /// result is nullptr. This is the NVI implementation of ToSymbolic.
-  Diagram<symbolic::Expression>* DoToSymbolic() const override {
+  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
     using FromType = System<double>;
     using ToType = std::unique_ptr<System<symbolic::Expression>>;
     std::function<ToType(const FromType&)> subsystem_converter{
         [](const FromType& subsystem) {
           return subsystem.ToSymbolicMaybe();
         }};
-    return ConvertScalarType<symbolic::Expression>(subsystem_converter)
-        .release();
+    return ConvertScalarType<symbolic::Expression>(subsystem_converter);
   }
 
   BasicVector<T>* DoAllocateInputVector(

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -268,13 +268,12 @@ class LeafSystem : public System<T> {
             UnrestrictedUpdateEvent<T>>::MakeForcedEventCollection());
   }
 
-  System<AutoDiffXd>* DoToAutoDiffXd() const override {
-    return system_scalar_converter_.Convert<AutoDiffXd, T>(*this).release();
+  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const override {
+    return system_scalar_converter_.Convert<AutoDiffXd, T>(*this);
   }
 
-  System<symbolic::Expression>* DoToSymbolic() const override {
-    return system_scalar_converter_.Convert<symbolic::Expression, T>(*this).
-        release();
+  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
+    return system_scalar_converter_.Convert<symbolic::Expression, T>(*this);
   }
 
   /// Provides a new instance of the leaf context for this system. Derived

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -1524,15 +1524,17 @@ class System {
     qdot->SetFromVector(generalized_velocity);
   }
 
-  /// NVI implementation of ToAutoDiffXdMaybe. Caller takes ownership of the
-  /// returned pointer.
+  /// NVI implementation of ToAutoDiffXdMaybe.
   /// @return nullptr if this System does not support autodiff
-  virtual System<AutoDiffXd>* DoToAutoDiffXd() const { return nullptr; }
+  virtual std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const {
+    return nullptr;
+  }
 
-  /// NVI implementation of ToSymbolicMaybe. Caller takes ownership of the
-  /// returned pointer.
+  /// NVI implementation of ToSymbolicMaybe.
   /// @return nullptr if this System does not support symbolic form
-  virtual System<symbolic::Expression>* DoToSymbolic() const { return nullptr; }
+  virtual std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const {
+    return nullptr;
+  }
   //@}
 
 //----------------------------------------------------------------------------

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -60,8 +60,8 @@ class ConstAndEcho : public LeafSystem<T> {
     echo->get_mutable_value() = input_vector->get_value();
   }
 
-  ConstAndEcho<symbolic::Expression>* DoToSymbolic() const override {
-    return new ConstAndEcho<symbolic::Expression>();
+  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
+    return std::make_unique<ConstAndEcho<symbolic::Expression>>();
   }
 };
 


### PR DESCRIPTION
_"Prefer to use std::unique_ptr to make ownership transfer explicit"_
-- https://google.github.io/styleguide/cppguide.html#Ownership_and_Smart_Pointers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7069)
<!-- Reviewable:end -->
