### PR TITLE
Make DoTo transmog methods final in LeafSystem

### DIFF
--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -268,11 +268,11 @@ class LeafSystem : public System<T> {
             UnrestrictedUpdateEvent<T>>::MakeForcedEventCollection());
   }
 
-  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const override {
+  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const final {
     return system_scalar_converter_.Convert<AutoDiffXd, T>(*this);
   }
 
-  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
+  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const final {
     return system_scalar_converter_.Convert<symbolic::Expression, T>(*this);
   }
 

--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -29,14 +29,18 @@ GTEST_TEST(DiagramBuilderTest, Empty) {
 // system *has* feedthrough, but a cycle in the diagram graph does not imply
 // an algebraic loop.
 template <typename T>
-class ConstAndEcho : public LeafSystem<T> {
+class ConstAndEcho final : public LeafSystem<T> {
  public:
-  ConstAndEcho() {
+  ConstAndEcho() : LeafSystem<T>(SystemTypeTag<systems::ConstAndEcho>{}) {
     this->DeclareInputPort(kVectorValued, 1);
     this->DeclareVectorOutputPort(BasicVector<T>(1), &ConstAndEcho::CalcEcho);
     this->DeclareVectorOutputPort(BasicVector<T>(1),
                                   &ConstAndEcho::CalcConstant);
   }
+
+  // Scalar-converting copy constructor.
+  template <typename U>
+  explicit ConstAndEcho(const ConstAndEcho<U>&) : ConstAndEcho() {}
 
   const systems::InputPortDescriptor<T>& get_vec_input_port() {
     return this->get_input_port(0);
@@ -58,10 +62,6 @@ class ConstAndEcho : public LeafSystem<T> {
   void CalcEcho(const Context<T>& context, BasicVector<T>* echo) const {
     const BasicVector<T>* input_vector = this->EvalVectorInput(context, 0);
     echo->get_mutable_value() = input_vector->get_value();
-  }
-
-  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
-    return std::make_unique<ConstAndEcho<symbolic::Expression>>();
   }
 };
 


### PR DESCRIPTION
All LeafSystems must use SystemScalarConverter.  We are going to add more scalar types, and cannot expect or allow the various LeafSystem subclasses to keep up with the correct list of overrides.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7071)
<!-- Reviewable:end -->
