### PR TITLE
Remove :system_scalar_converter deps on :system

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -333,9 +333,11 @@ drake_cc_library(
         "system_type_tag.h",
     ],
     deps = [
-        ":system",
+        "//drake/common:autodiff",
         "//drake/common:essential",
         "//drake/common:hash",
+        "//drake/common:nice_type_name",
+        "//drake/common:symbolic",
     ],
 )
 

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 #include "drake/systems/framework/system.h"

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -13,11 +13,12 @@
 #include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
-#include "drake/systems/framework/system.h"
 #include "drake/systems/framework/system_type_tag.h"
 
 namespace drake {
 namespace systems {
+
+template <typename T> class System;
 
 /// Helper class to convert a System<U> into a System<T>, intended for internal
 /// use by the System framework, not directly by users.

--- a/drake/systems/framework/system_type_tag.h
+++ b/drake/systems/framework/system_type_tag.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "drake/systems/framework/system.h"
-
 namespace drake {
 namespace systems {
+
+template <typename T> class System;
 
 /// A tag object that denotes a System subclass `S` in function signatures.
 ///


### PR DESCRIPTION
This enables `:system` to use `:system_scalar_converter` in the future, which is important for making transmogrification fully generic on scalar type, in particular for Diagrams to be able to reason about the set of scalar types that their child systems support.

The full series of WIP patchsets is at https://github.com/jwnimmer-tri/drake/tree/framework-transmogrify-diagram.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7073)
<!-- Reviewable:end -->
