### PR TITLE
Add two more SystemScalarConverter methods

### DIFF
--- a/drake/common/test_utilities/is_dynamic_castable.h
+++ b/drake/common/test_utilities/is_dynamic_castable.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 #include <string>
 

--- a/drake/common/test_utilities/is_memcpy_movable.h
+++ b/drake/common/test_utilities/is_memcpy_movable.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -677,6 +677,7 @@ drake_cc_googletest(
     deps = [
         ":leaf_system",
         ":system_scalar_converter",
+        "//drake/common/test_utilities",
         "//drake/systems/framework/test_utilities:scalar_conversion",
     ],
 )

--- a/drake/systems/framework/system_scalar_converter.cc
+++ b/drake/systems/framework/system_scalar_converter.cc
@@ -38,5 +38,19 @@ const SystemScalarConverter::ErasedConverterFunc* SystemScalarConverter::Find(
   }
 }
 
+void SystemScalarConverter::RemoveUnlessAlsoSupportedBy(
+    const SystemScalarConverter& other) {
+  // Remove the items from `funcs_` whose key is absent from `other`.
+  // (This would use erase_if, if we had it.)
+  for (auto iter = funcs_.begin(); iter != funcs_.end(); ) {
+    const Key& our_key = iter->first;
+    if (other.funcs_.count(our_key) == 0) {
+      iter = funcs_.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+}
+
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -103,6 +103,10 @@ class SystemScalarConverter {
   template <template <typename> class S, typename T, typename U>
   void AddIfSupported();
 
+  /// Removes from this converter all pairs where `other.IsConvertible<T, U>`
+  /// is false.  The subtype `S` need not be the same between this and `other`.
+  void RemoveUnlessAlsoSupportedBy(const SystemScalarConverter& other);
+
   /// Returns true iff this object can convert a System<U> into a System<T>,
   /// i.e., whether Convert() will return non-null.
   ///

--- a/drake/systems/framework/test/system_scalar_converter_test.cc
+++ b/drake/systems/framework/test/system_scalar_converter_test.cc
@@ -272,6 +272,16 @@ GTEST_TEST(SystemScalarConverterTest, SubclassMismatch) {
       }
     }), std::runtime_error);
   }
+
+  // However, if subtype checking is off, the conversion is allowed to upcast.
+  {
+    SystemScalarConverter dut(
+        SystemTypeTag<AnyToAnySystem>{},
+        SystemScalarConverter::GuaranteedSubtypePreservation::kDisabled);
+    const SubclassOfAnyToAnySystem<double> original;
+    EXPECT_TRUE(is_dynamic_castable<AnyToAnySystem<AutoDiffXd>>(
+        dut.Convert<AutoDiffXd, double>(original)));
+  }
 }
 
 GTEST_TEST(SystemScalarConverterTest, RemoveUnlessAlsoSupportedBy) {

--- a/drake/systems/framework/test/system_scalar_converter_test.cc
+++ b/drake/systems/framework/test/system_scalar_converter_test.cc
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
@@ -271,6 +272,43 @@ GTEST_TEST(SystemScalarConverterTest, SubclassMismatch) {
       }
     }), std::runtime_error);
   }
+}
+
+GTEST_TEST(SystemScalarConverterTest, RemoveUnlessAlsoSupportedBy) {
+  SystemScalarConverter dut(SystemTypeTag<AnyToAnySystem>{});
+  const SystemScalarConverter non_symbolic(SystemTypeTag<NonSymbolicSystem>{});
+  const SystemScalarConverter from_double(SystemTypeTag<FromDoubleSystem>{});
+
+  // These are the defaults per TestAnyToAnySystem above.
+  EXPECT_TRUE((dut.IsConvertible<double,     AutoDiffXd>()));
+  EXPECT_TRUE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_TRUE((dut.IsConvertible<AutoDiffXd, double    >()));
+  EXPECT_TRUE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_TRUE((dut.IsConvertible<Expression, double    >()));
+  EXPECT_TRUE((dut.IsConvertible<Expression, AutoDiffXd>()));
+
+  // We remove symbolic support.  Only double <=> AutoDiff remains.
+  dut.RemoveUnlessAlsoSupportedBy(non_symbolic);
+  EXPECT_TRUE((dut.IsConvertible< double,     AutoDiffXd>()));
+  EXPECT_TRUE((dut.IsConvertible< AutoDiffXd, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
+
+  // We remove from-AutoDiff support.  Only AutoDiff <= double remains.
+  dut.RemoveUnlessAlsoSupportedBy(from_double);
+  EXPECT_TRUE((dut.IsConvertible< AutoDiffXd, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<double,     AutoDiffXd>()));
+  EXPECT_FALSE((dut.IsConvertible<double,     Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<AutoDiffXd, Expression>()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, double    >()));
+  EXPECT_FALSE((dut.IsConvertible<Expression, AutoDiffXd>()));
+
+  // The conversion still actually works.
+  const AnyToAnySystem<double> system{22};
+  EXPECT_TRUE(is_dynamic_castable<AnyToAnySystem<AutoDiffXd>>(
+      dut.Convert<AutoDiffXd, double>(system)));
 }
 
 }  // namespace


### PR DESCRIPTION
Specifically, add `Intersect` and a ctor overload using `SubtypeChecking`.

`Intersect` is important for making transmogrification fully generic on scalar type, in particular for Diagrams to be able to reason about the set of scalar types that their child systems support.

`SubtypeChecking` is important because some diagrams will purposefully discard their Diagram subtype during transmogrification.

The full series of WIP patchsets is at https://github.com/jwnimmer-tri/drake/tree/framework-transmogrify-diagram.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7074)
<!-- Reviewable:end -->
