### PR TITLE
Move SystemScalarConverter from LeafSystem to System

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -289,6 +289,7 @@ drake_cc_library(
         ":event_collection",
         ":system_common",
         ":system_constraint",
+        ":system_scalar_converter",
         ":value",
         "//drake/common:autodiff",
         "//drake/common:essential",

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -659,7 +659,7 @@ class Diagram : public System<T>,
  protected:
   /// Constructs an uninitialized Diagram. Subclasses that use this constructor
   /// are obligated to call DiagramBuilder::BuildInto(this).
-  Diagram() {}
+  Diagram() : System<T>(SystemScalarConverter{}) {}
 
   /// For the subsystem associated with @p witness_func, gets its subcontext
   /// from @p context, passes the subcontext to @p witness_func' Evaulate
@@ -1329,7 +1329,7 @@ class Diagram : public System<T>,
   // Constructs a Diagram from the Blueprint that a DiagramBuilder produces.
   // This constructor is private because only DiagramBuilder calls it. The
   // constructor takes the systems from the blueprint.
-  explicit Diagram(std::unique_ptr<Blueprint> blueprint) {
+  explicit Diagram(std::unique_ptr<Blueprint> blueprint) : Diagram() {
     Initialize(std::move(blueprint));
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -296,7 +296,7 @@ class LeafSystem : public System<T> {
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
   explicit LeafSystem(SystemScalarConverter converter)
-      : system_scalar_converter_(std::move(converter)) {
+      : System<T>(std::move(converter)) {
     this->set_forced_publish_events(
         LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection());
     this->set_forced_discrete_update_events(
@@ -308,11 +308,11 @@ class LeafSystem : public System<T> {
   }
 
   std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const final {
-    return system_scalar_converter_.Convert<AutoDiffXd, T>(*this);
+    return System<T>::DoToAutoDiffXd();
   }
 
   std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const final {
-    return system_scalar_converter_.Convert<symbolic::Expression, T>(*this);
+    return System<T>::DoToSymbolic();
   }
 
   /// Provides a new instance of the leaf context for this system. Derived
@@ -1448,9 +1448,6 @@ class LeafSystem : public System<T> {
 
   // Model outputs to be used in AllocateParameters.
   detail::ModelValues model_numeric_parameters_;
-
-  // Functions to convert this system to use alternative scalar types.
-  const SystemScalarConverter system_scalar_converter_;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -1083,6 +1083,12 @@ GTEST_TEST(LeafSystemScalarConverterTest, AutoDiffYes) {
   auto maybe = dut.ToAutoDiffXdMaybe();
   ASSERT_NE(maybe, nullptr);
   EXPECT_EQ(maybe->get_name(), "special_name");
+
+  // Spot check the specific converter object.
+  EXPECT_TRUE((
+      dut.get_system_scalar_converter().IsConvertible<AutoDiffXd, double>()));
+  EXPECT_FALSE((
+      dut.get_system_scalar_converter().IsConvertible<double, double>()));
 }
 
 // Sanity check the default implementation of ToAutoDiffXd, for cases that

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -25,7 +25,7 @@ const int kSize = 3;
 // A shell System to test the default implementations.
 class TestSystem : public System<double> {
  public:
-  TestSystem() {
+  TestSystem() : System<double>(SystemScalarConverter{}) {
     this->set_forced_publish_events(
         this->AllocateForcedPublishEventCollection());
     this->set_forced_discrete_update_events(
@@ -363,6 +363,10 @@ TEST_F(SystemTest, TransmogrifyNotSupported) {
   // Use the instance method that returns nullptr.
   EXPECT_EQ(system_.ToAutoDiffXdMaybe(), nullptr);
   EXPECT_EQ(system_.ToSymbolicMaybe(), nullptr);
+
+  // Spot check the specific converter object.
+  EXPECT_FALSE((
+      system_.get_system_scalar_converter().IsConvertible<double, double>()));
 }
 
 template <typename T>
@@ -376,7 +380,7 @@ class ValueIOTestSystem : public System<T> {
   // The first input / output pair are abstract type, but assumed to be
   // std::string.
   // The second input / output pair are vector type with length 1.
-  ValueIOTestSystem() {
+  ValueIOTestSystem() : System<T>(SystemScalarConverter{}) {
     this->set_forced_publish_events(
         this->AllocateForcedPublishEventCollection());
     this->set_forced_discrete_update_events(


### PR DESCRIPTION
This is important for making transmogrification fully generic on scalar type, in particular for Diagrams to be able to reason about the set of scalar types that their child systems support.

The full series of WIP patchsets is at https://github.com/jwnimmer-tri/drake/tree/framework-transmogrify-diagram.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7076)
<!-- Reviewable:end -->
