### PR TITLE
Allow LeafSystem<Expression> to be instantiated

### DIFF
--- a/drake/systems/framework/leaf_system.cc
+++ b/drake/systems/framework/leaf_system.cc
@@ -1,9 +1,12 @@
 #include "drake/systems/framework/leaf_system.h"
 
+#include "drake/common/symbolic.h"
+
 namespace drake {
 namespace systems {
 
 template class LeafSystem<double>;
+template class LeafSystem<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Move `LeafSystem::GetNextSample` from a static class method to a free function, so that we only try to instantiate it for supported types.

To grow Drake's set of scalar types, we are going to use a macro to abstract explicit instantiations, which means that all class templates must support all methods for all scalar types.  This was the only method in the framework that didn't.

The full series of WIP patchsets is at https://github.com/jwnimmer-tri/drake/tree/autodiffnd-spike.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7078)
<!-- Reviewable:end -->
