### PR TITLE
Disable memcheck on pick_and_place_state_machine_test due to system IPOPT on CI

### DIFF
--- a/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD
@@ -44,6 +44,10 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
+    # TODO(eric.cousineau): Remove this tag once #3128 or the IK redux lands.
+    # On some CI machines without SNOPT, system IPOPT is used, and exceeds time
+    # limits under memcheck with -c dbg.
+    tags = ["no_memcheck"],
     deps = [
         ":pick_and_place",
         "//drake/common:find_resource",


### PR DESCRIPTION
See example failing test: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/138/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7081)
<!-- Reviewable:end -->
