### PR TITLE
Revert "Add SystemScalarConverter::GuaranteedSubtype... option"

### DIFF
--- a/drake/systems/framework/system_scalar_converter.h
+++ b/drake/systems/framework/system_scalar_converter.h
@@ -87,33 +87,6 @@ class SystemScalarConverter {
     AddIfSupported<S, AutoDiffXd, Expression>();
   }
 
-  /// A configuration option for our constructor, controlling whether or not
-  /// the Convert implementation requires that the System subclass type is
-  /// preserved.
-  enum class GuaranteedSubtypePreservation {
-    /// The argument to Convert must be of the exact type S that was used to
-    /// populate the SystemScalarConverter.
-    kEnabled,
-    /// The argument to Convert need not be the exact type S that was used to
-    /// populate the SystemScalarConverter -- it can be either exactly that S,
-    /// or a subtype of that S.  This permits subtype information to be lost
-    /// across conversion.
-    kDisabled,
-  };
-
-  /// (Advanced.)  Creates using S's scalar-type converting copy constructor.
-  /// Behaves exactly like SystemScalarConverter(SystemTypeTag<S>), but with
-  /// the additional option to turn off guaranteed subtype preservation of the
-  /// System being converted.  In general, subtype preservation is an important
-  /// invariant during scalar conversion, so be cautious about disabling it.
-  template <template <typename> class S>
-  SystemScalarConverter(
-      SystemTypeTag<S> tag, GuaranteedSubtypePreservation subtype_preservation)
-      : SystemScalarConverter(tag) {
-    subtype_preservation_ =
-        (subtype_preservation == GuaranteedSubtypePreservation::kEnabled);
-  }
-
   /// A std::function used to convert a System<U> into a System<T>.
   template <typename T, typename U>
   using ConverterFunction =
@@ -174,9 +147,6 @@ class SystemScalarConverter {
 
   // Maps from {T, U} to the function that converts from U into T.
   std::unordered_map<Key, ErasedConverterFunc, KeyHasher> funcs_;
-
-  // True iff our GuaranteedSubtypePreservation is enabled.
-  bool subtype_preservation_{true};
 };
 
 #if !defined(DRAKE_DOXYGEN_CXX)
@@ -217,11 +187,10 @@ namespace system_scalar_converter_detail {
 // When Traits says that conversion is supported.
 template <template <typename> class S, typename T, typename U>
 static std::unique_ptr<System<T>> Make(
-    bool subtype_preservation, const System<U>& other, std::true_type) {
+    const System<U>& other, std::true_type) {
   // We require that system scalar conversion maintain the exact system type.
   // Fail fast if `other` is not of exact type S<U>.
-  if (subtype_preservation &&
-      (std::type_index{typeid(other)} != std::type_index{typeid(S<U>)})) {
+  if (std::type_index{typeid(other)} != std::type_index{typeid(S<U>)}) {
     std::ostringstream msg;
     msg << "SystemScalarConverter::Convert was configured to convert a "
         << NiceTypeName::Get<S<U>>() << " into a "
@@ -235,7 +204,7 @@ static std::unique_ptr<System<T>> Make(
 // When Traits says not to convert.
 template <template <typename> class S, typename T, typename U>
 static std::unique_ptr<System<T>> Make(
-    bool, const System<U>&, std::false_type) {
+    const System<U>&, std::false_type) {
   // AddIfSupported is guaranteed not to call us, but we *will* be compiled,
   // so we have to have some kind of function body.
   DRAKE_ABORT();
@@ -247,12 +216,11 @@ void SystemScalarConverter::AddIfSupported() {
   using supported =
       typename scalar_conversion::Traits<S>::template supported<T, U>;
   if (supported::value) {
-    const ConverterFunction<T, U> func = [this](const System<U>& other) {
+    const ConverterFunction<T, U> func = [](const System<U>& other) {
       // Dispatch to an overload based on whether S<U> ==> S<T> is supported.
       // (At runtime, this block is only executed for supported conversions,
       // but at compile time, Make will be instantiated unconditionally.)
-      return system_scalar_converter_detail::Make<S, T, U>(
-          this->subtype_preservation_, other, supported{});
+      return system_scalar_converter_detail::Make<S, T, U>(other, supported{});
     };
     Add(func);
   }

--- a/drake/systems/framework/test/system_scalar_converter_test.cc
+++ b/drake/systems/framework/test/system_scalar_converter_test.cc
@@ -272,16 +272,6 @@ GTEST_TEST(SystemScalarConverterTest, SubclassMismatch) {
       }
     }), std::runtime_error);
   }
-
-  // However, if subtype checking is off, the conversion is allowed to upcast.
-  {
-    SystemScalarConverter dut(
-        SystemTypeTag<AnyToAnySystem>{},
-        SystemScalarConverter::GuaranteedSubtypePreservation::kDisabled);
-    const SubclassOfAnyToAnySystem<double> original;
-    EXPECT_TRUE(is_dynamic_castable<AnyToAnySystem<AutoDiffXd>>(
-        dut.Convert<AutoDiffXd, double>(original)));
-  }
 }
 
 GTEST_TEST(SystemScalarConverterTest, RemoveUnlessAlsoSupportedBy) {


### PR DESCRIPTION
This reverts commit a2708a348eb130713e3622b6dcf6661e49a31901 from #7074, which contained a use-after-free defect.

This is an alternative to #7083.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7085)
<!-- Reviewable:end -->
