### PR TITLE
Use SystemScalarConverter for Diagram transmogrification

### DIFF
--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -531,7 +531,7 @@ drake_cc_googletest(
         "//drake/common:essential",
         "//drake/common/test_utilities:is_dynamic_castable",
         "//drake/systems/analysis:stateless_system",
-        "//drake/systems/framework/test_utilities:pack_value",
+        "//drake/systems/framework/test_utilities",
         "//drake/systems/primitives:adder",
         "//drake/systems/primitives:constant_value_source",
         "//drake/systems/primitives:constant_vector_source",

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -234,6 +234,11 @@ class Diagram : public System<T>,
 
   typedef typename std::pair<const System<T>*, int> PortIdentifier;
 
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit Diagram(const Diagram<U>& other)
+      : Diagram(other.template ConvertScalarType<T>()) {}
+
   ~Diagram() override {}
 
   /// Returns the list of contained Systems.
@@ -658,8 +663,25 @@ class Diagram : public System<T>,
 
  protected:
   /// Constructs an uninitialized Diagram. Subclasses that use this constructor
-  /// are obligated to call DiagramBuilder::BuildInto(this).
-  Diagram() : System<T>(SystemScalarConverter{}) {}
+  /// are obligated to call DiagramBuilder::BuildInto(this).  Provides scalar-
+  /// type conversion support only if every contained subsystem provides the
+  /// same support.
+  Diagram() : System<T>(
+      SystemScalarConverter(
+          SystemTypeTag<systems::Diagram>{},
+          SystemScalarConverter::GuaranteedSubtypePreservation::kDisabled)) {}
+
+  /// (Advanced) Constructs an uninitialized Diagram.  Subclasses that use this
+  /// constructor are obligated to call DiagramBuilder::BuildInto(this).
+  ///
+  /// Declares scalar-type conversion support using @p converter.  Support for
+  /// a given pair of types `T, U` to convert from and to will be enabled only
+  /// if every contained subsystem supports that pair.
+  ///
+  /// See @ref system_scalar_conversion for detailed background and examples
+  /// related to scalar-type conversion support.
+  explicit Diagram(SystemScalarConverter converter)
+      : System<T>(std::move(converter)) {}
 
   /// For the subsystem associated with @p witness_func, gets its subcontext
   /// from @p context, passes the subcontext to @p witness_func' Evaulate
@@ -903,36 +925,6 @@ class Diagram : public System<T>,
     DoCalcNextUpdateTimeImpl(context, event_info, time);
   }
 
-  /// Creates a deep copy of this Diagram<double>, converting the scalar type
-  /// to AutoDiffXd, and preserving all internal structure. Subclasses may wish
-  /// to override to initialize additional member data. If any contained
-  /// subsystem does not support ToAutoDiffXd, then this result is nullptr.
-  /// This is the NVI implementation of ToAutoDiffXd.
-  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const override {
-    using FromType = System<double>;
-    using ToType = std::unique_ptr<System<AutoDiffXd>>;
-    std::function<ToType(const FromType&)> subsystem_converter{
-        [](const FromType& subsystem) {
-          return subsystem.ToAutoDiffXdMaybe();
-        }};
-    return ConvertScalarType<AutoDiffXd>(subsystem_converter);
-  }
-
-  /// Creates a deep copy of this Diagram<double>, converting the scalar type
-  /// to symbolic::Expression, and preserving all internal structure.
-  /// Subclasses may wish to override to initialize additional member data.
-  /// If any contained subsystem does not support ToSymbolic, then this
-  /// result is nullptr. This is the NVI implementation of ToSymbolic.
-  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const override {
-    using FromType = System<double>;
-    using ToType = std::unique_ptr<System<symbolic::Expression>>;
-    std::function<ToType(const FromType&)> subsystem_converter{
-        [](const FromType& subsystem) {
-          return subsystem.ToSymbolicMaybe();
-        }};
-    return ConvertScalarType<symbolic::Expression>(subsystem_converter);
-  }
-
   BasicVector<T>* DoAllocateInputVector(
       const InputPortDescriptor<T>& descriptor) const override {
     // Ask the subsystem to perform the allocation.
@@ -1168,28 +1160,29 @@ class Diagram : public System<T>,
     return nullptr;
   }
 
-  /// Uses this Diagram<double> to manufacture a Diagram<NewType>, given a
-  /// @p converter for subsystems from System<double> to System<NewType>.
-  /// SFINAE overload for std::is_same<T, double>.
+  /// Uses this Diagram<T> to manufacture a Diagram<NewType>::Blueprint,
+  /// using system scalar conversion.
   ///
   /// @tparam NewType The scalar type to which to convert.
-  /// @tparam T1 SFINAE boilerplate.
-  template <typename NewType, typename T1 = T>
-  std::unique_ptr<Diagram<NewType>> ConvertScalarType(
-      std::function<std::unique_ptr<System<NewType>>(
-          const System<
-              std::enable_if_t<std::is_same<T1, double>::value, double>>&)>
-          converter) const {
+  template <typename NewType>
+  std::unique_ptr<typename Diagram<NewType>::Blueprint> ConvertScalarType()
+      const {
     std::vector<std::unique_ptr<System<NewType>>> new_systems;
     // Recursively convert all the subsystems.
-    std::map<const System<T1>*, const System<NewType>*> old_to_new_map;
+    std::map<const System<T>*, const System<NewType>*> old_to_new_map;
     for (const auto& old_system : registered_systems_) {
-      new_systems.push_back(converter(*old_system));
-      if (!new_systems.back().get()) {
-        // A subsystem could not support the conversion.
-        return nullptr;
-      }
-      old_to_new_map[old_system.get()] = new_systems.back().get();
+      // Convert old_system to new_system using the old_system's converter.
+      std::unique_ptr<System<NewType>> new_system =
+          old_system->get_system_scalar_converter().
+          template Convert<NewType>(*old_system);
+      DRAKE_DEMAND(new_system != nullptr);
+
+      // Match the result's name to its originator.
+      new_system->set_name(old_system->get_name());
+
+      // Update our mapping and take ownership.
+      old_to_new_map[old_system.get()] = new_system.get();
+      new_systems.push_back(std::move(new_system));
     }
 
     // Set up the blueprint.
@@ -1224,24 +1217,7 @@ class Diagram : public System<T>,
     // Move the new systems into the blueprint.
     blueprint->systems = std::move(new_systems);
 
-    // Construct a new Diagram of type NewType from the blueprint.
-    std::unique_ptr<Diagram<NewType>> new_diagram(
-        new Diagram<NewType>(std::move(blueprint)));
-    return std::move(new_diagram);
-  }
-
-  /// Aborts at runtime.
-  /// SFINAE overload for !std::is_same<T, double>.
-  ///
-  /// @tparam NewType The scalar type to which to convert.
-  /// @tparam T1 SFINAE boilerplate.
-  template <typename NewType, typename T1 = T>
-  std::unique_ptr<Diagram<NewType>> ConvertScalarType(
-      std::function<std::unique_ptr<System<NewType>>(
-          const System<std::enable_if_t<!std::is_same<T1, double>::value,
-                                        double>>&)>) const {
-    DRAKE_ABORT_MSG(
-        "Scalar type conversion is only supported from Diagram<double>.");
+    return blueprint;
   }
 
   // Aborts for scalar types that are not numeric, since there is no reasonable
@@ -1382,6 +1358,15 @@ class Diagram : public System<T>,
     }
     for (const PortIdentifier& id : output_port_ids_) {
       ExportOutput(id);
+    }
+
+    // Identify the intersection of the subsystems' scalar conversion support.
+    // Remove all conversions that at least one subsystem did not support.
+    SystemScalarConverter& this_scalar_converter =
+        SystemImpl::get_mutable_system_scalar_converter(this);
+    for (const auto& system : registered_systems_) {
+      this_scalar_converter.RemoveUnlessAlsoSupportedBy(
+          system->get_system_scalar_converter());
     }
 
     this->set_forced_publish_events(
@@ -1539,10 +1524,10 @@ class Diagram : public System<T>,
   // builder can set the internal state correctly.
   friend class DiagramBuilder<T>;
 
-  // For all T, Diagram<T> considers Diagram<double> a friend, so that
-  // Diagram<double> can provide transmogrification methods to more flavorful
-  // scalar types.  See Diagram<T>::ConvertScalarType.
-  friend class Diagram<double>;
+  // For any T1 & T2, Diagram<T1> considers Diagram<T2> a friend, so that
+  // Diagram can provide transmogrification methods across scalar types.
+  // See Diagram<T>::ConvertScalarType.
+  template <typename> friend class Diagram;
 };
 
 }  // namespace systems

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -307,14 +307,6 @@ class LeafSystem : public System<T> {
             UnrestrictedUpdateEvent<T>>::MakeForcedEventCollection());
   }
 
-  std::unique_ptr<System<AutoDiffXd>> DoToAutoDiffXd() const final {
-    return System<T>::DoToAutoDiffXd();
-  }
-
-  std::unique_ptr<System<symbolic::Expression>> DoToSymbolic() const final {
-    return System<T>::DoToSymbolic();
-  }
-
   /// Provides a new instance of the leaf context for this system. Derived
   /// leaf systems with custom derived leaf system contexts should override this
   /// to provide a context of the appropriate type. The returned context should

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -41,6 +41,22 @@ class SystemImpl {
 
   // The implementation of System<T>::GetMemoryObjectName.
   static std::string GetMemoryObjectName(const std::string&, int64_t);
+
+ private:
+  // Attorney-Client idiom to expose a subset of private elements of System.
+  // We are the attorney.  These are the clients that can access our private
+  // members, and thus access some subset of System's private members.
+  template <typename> friend class Diagram;
+
+  // Return a mutable reference to the System's SystemScalarConverter.  Diagram
+  // needs this in order to withdraw support for certain scalar type conversion
+  // operations once it learns about what its subsystems support.
+  template <typename T>
+  static SystemScalarConverter& get_mutable_system_scalar_converter(
+      System<T>* system) {
+    DRAKE_DEMAND(system != nullptr);
+    return system->system_scalar_converter_;
+  }
 };
 /** @endcond */
 
@@ -1693,6 +1709,10 @@ class System {
   }
 
  private:
+  // Attorney-Client idiom to expose a subset of private elements of System.
+  // Refer to SystemImpl comments for details.
+  friend class SystemImpl;
+
   std::string name_;
   // input_ports_ and output_ports_ are vectors of unique_ptr so that references
   // to the descriptors will remain valid even if the vector is resized.
@@ -1713,7 +1733,7 @@ class System {
       forced_unrestricted_update_{nullptr};
 
   // Functions to convert this system to use alternative scalar types.
-  const SystemScalarConverter system_scalar_converter_;
+  SystemScalarConverter system_scalar_converter_;
 
   // TODO(sherm1) Replace these fake cache entries with real cache asap.
   // These are temporaries and hence uninitialized.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/framework/diagram.h"
 
 #include <Eigen/Dense>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
@@ -11,6 +12,7 @@
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/constant_value_source.h"
 #include "drake/systems/primitives/constant_vector_source.h"
@@ -22,6 +24,12 @@ namespace drake {
 namespace systems {
 namespace {
 
+class DoubleOnlySystem : public LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DoubleOnlySystem);
+  DoubleOnlySystem() = default;
+};
+
 /// ExampleDiagram has the following structure:
 /// adder0_: (input0_ + input1_) -> A
 /// adder1_: (A + input2_)       -> B, output 0
@@ -32,7 +40,8 @@ namespace {
 /// witness functions from its subsystems.
 class ExampleDiagram : public Diagram<double> {
  public:
-  explicit ExampleDiagram(int size, bool use_abstract = false) {
+  explicit ExampleDiagram(
+      int size, bool use_abstract = false, bool use_double_only = false) {
     DiagramBuilder<double> builder;
 
     adder0_ = builder.AddSystem<Adder<double>>(2 /* inputs */, size);
@@ -70,6 +79,9 @@ class ExampleDiagram : public Diagram<double> {
     if (use_abstract) {
       builder.AddSystem<ConstantValueSource<double>>(
           std::make_unique<Value<int>>(0));
+    }
+    if (use_double_only) {
+      builder.AddSystem<DoubleOnlySystem>();
     }
 
     builder.BuildInto(this);
@@ -401,10 +413,27 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
     }
   }
 
-  // If the Diagram contains a System that does not support AutoDiffXd, we
-  // cannot transmogrify the Diagram.
-  auto diagram_with_abstract = std::make_unique<ExampleDiagram>(kSize, true);
-  EXPECT_THROW(diagram_with_abstract->ToAutoDiffXd(), std::exception);
+  // When the Diagram contains a System that does not support AutoDiffXd,
+  // we cannot transmogrify the Diagram to AutoDiffXd.
+  const bool use_abstract = false;
+  const bool use_double_only = true;
+  auto diagram_with_double_only = std::make_unique<ExampleDiagram>(
+      kSize, use_abstract, use_double_only);
+  EXPECT_THROW(diagram_with_double_only->ToAutoDiffXd(), std::exception);
+}
+
+/// Tests that a diagram can be transmogrified to symbolic.
+TEST_F(DiagramTest, ToSymbolic) {
+  // We manually specify the template argument so that is_symbolic_convertible
+  // asserts the result is merely a Diagram, not an ExampleDiagram.
+  EXPECT_TRUE(is_symbolic_convertible<systems::Diagram>(*diagram_));
+
+  // No symbolic support when one of the subsystems does not declare support.
+  const bool use_abstract = false;
+  const bool use_double_only = true;
+  auto diagram_with_double_only = std::make_unique<ExampleDiagram>(
+      kSize, use_abstract, use_double_only);
+  EXPECT_THROW(diagram_with_double_only->ToSymbolic(), std::exception);
 }
 
 // Tests that the same diagram can be evaluated into the same output with
@@ -679,10 +708,17 @@ GTEST_TEST(DiagramPublishTest, Publish) {
 // FeedbackDiagram is a diagram containing a feedback loop of two
 // constituent diagrams, an Integrator and a Gain. The Integrator is not
 // direct-feedthrough, so there is no algebraic loop.
+//
+// (N.B. Normally a class that supports scalar conversion, but does not offer a
+// SystemScalarConverter-accepting constructor would be marked `final`, but we
+// leave the `final` off here to test what happens during wrong-subclassing.)
 template <typename T>
 class FeedbackDiagram : public Diagram<T> {
  public:
-  FeedbackDiagram() : Diagram<T>() {
+  FeedbackDiagram()
+      // We choose this constructor from our parent class so that we have a
+      // useful Diagram for the SubclassTransmogrificationTest.
+      : Diagram<T>(SystemTypeTag<systems::FeedbackDiagram>{}) {
     constexpr int kSize = 1;
 
     DiagramBuilder<T> builder;
@@ -711,6 +747,11 @@ class FeedbackDiagram : public Diagram<T> {
     builder.Connect(*gain_diagram, *integrator_diagram);
     builder.BuildInto(this);
   }
+
+  // Scalar-converting copy constructor.
+  template <typename U>
+  explicit FeedbackDiagram(const FeedbackDiagram<U>& other)
+      : Diagram<T>(other) {}
 };
 
 // Tests that since there are no outputs, there is no direct feedthrough.
@@ -725,6 +766,35 @@ GTEST_TEST(FeedbackDiagramTest, DeletionIsMemoryClean) {
   FeedbackDiagram<double> diagram;
   auto context = diagram.CreateDefaultContext();
   EXPECT_NO_THROW(context.reset());
+}
+
+// If a SystemScalarConverter is passed into the Diagram constructor, then
+// transmogrification will preserve the subtype.
+TEST_F(DiagramTest, SubclassTransmogrificationTest) {
+  const FeedbackDiagram<double> dut;
+  EXPECT_TRUE(is_autodiffxd_convertible(dut, [](const auto& converted) {
+    EXPECT_FALSE(converted.HasAnyDirectFeedthrough());
+  }));
+  EXPECT_TRUE(is_symbolic_convertible(dut, [](const auto& converted) {
+    EXPECT_FALSE(converted.HasAnyDirectFeedthrough());
+  }));
+
+  // Diagram subclasses that declare a specific SystemTypeTag but then use a
+  // subclass at runtime will fail-fast.
+  class SubclassOfFeedbackDiagram : public FeedbackDiagram<double> {};
+  const SubclassOfFeedbackDiagram subclass_dut;
+  EXPECT_THROW(({
+    try {
+      subclass_dut.ToAutoDiffXd();
+    } catch (const std::runtime_error& e) {
+      EXPECT_THAT(
+          std::string(e.what()),
+          testing::MatchesRegex(
+              ".*convert a .*::FeedbackDiagram<double>.* called with a"
+              ".*::SubclassOfFeedbackDiagram at runtime"));
+      throw;
+    }
+  }), std::runtime_error);
 }
 
 // A simple class that consumes *two* inputs and passes one input through. The


### PR DESCRIPTION
There are three major features happening here:
1. Diagram's set of supported scalar types will come from (i) the list that SystemScalarConverter curates, but then be limited by (ii) the runtime support for transmogrification provided by whatever subtypes are added into the Diagram.  This allows us to change the set of default scalar types by editing one place (SystemScalarConverter) instead of also having to patch Diagram.
2. Diagram gains support for preserving the Diagram subtype during transmogrification.
3. The NVI methods DoToFoo in System go away, again so that SystemScalarConverter owns more of the responsibility, and thus we have less repetition.

I think it makes sense to consider all of these things together as a whole, but please let me know if separate PRs would be preferable.  The commits are curated, so can still be browsed or reviewed one at a time if desired.

Commits:
- Add SystemImpl::get_mutable_system_scalar_converter.
  - This is not unit tested directly (due to attorney-client privilege), but the diagram_test cases cover it in the next commit.
- Port Diagram to SystemScalarConverter.
- Add Doxygen overview for Diagram transmogrification.
- Remove System::DoTo transmog NVI hooks.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7091)
<!-- Reviewable:end -->
