### PR TITLE
Add default_scalars and port framework to it

### DIFF
--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -209,6 +209,16 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "default_scalars",
+    hdrs = ["default_scalars.h"],
+    deps = [
+        ":autodiff",
+        ":essential",
+        ":symbolic",
+    ],
+)
+
 # Miscellaneous utilities.
 
 DRAKE_RESOURCE_SENTINEL = "//:.drake-resource-sentinel"

--- a/drake/common/BUILD
+++ b/drake/common/BUILD
@@ -260,13 +260,11 @@ drake_cc_library(
 
 drake_cc_library(
     name = "is_cloneable",
-    srcs = [],
     hdrs = ["is_cloneable.h"],
 )
 
 drake_cc_library(
     name = "copyable_unique_ptr",
-    srcs = [],
     hdrs = ["copyable_unique_ptr.h"],
     deps = [":is_cloneable"],
 )

--- a/drake/common/default_scalars.h
+++ b/drake/common/default_scalars.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "drake/common/autodiff_overloads.h"
+#include "drake/common/symbolic.h"
+
+/// A macro that defines explicit class template instantiations for Drake's
+/// default set of supported scalar types.  This macro should only be used in
+/// .cc files, never in .h files.
+///
+/// @param SomeType the template typename to instantiate, *including* the
+/// leading `class` or `struct` keyword.
+///
+/// Currently the supported types are:
+/// - double
+/// - drake::AutoDiffXd
+/// - drake::symbolic::Expression
+///
+/// Example `my_system.h`:
+/// @code
+/// namespace sample {
+/// template <typename T>
+/// class MySystem final : public LeafSystem<T> {
+///   ...
+/// @endcode
+///
+/// Example `my_system.cc`:
+/// @code
+/// #include "my_system.h"
+///
+/// #include "drake/common/default_scalars.h"
+///
+/// DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+///     class ::sample::MySystem)
+/// @endcode
+///
+/// See also @ref system_scalar_conversion.
+#define DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(SomeType) \
+template SomeType<double>; \
+template SomeType<::drake::AutoDiffXd>; \
+template SomeType<::drake::symbolic::Expression>;

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -59,6 +59,7 @@ drake_cc_library(
     ],
     deps = [
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:dummy_value",
         "//drake/common:essential",
         "//drake/common:symbolic",
@@ -117,6 +118,7 @@ drake_cc_library(
     deps = [
         ":vector",
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -129,6 +131,7 @@ drake_cc_library(
         ":value",
         ":vector",
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -144,6 +147,7 @@ drake_cc_library(
         ":value",
         ":vector",
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -162,6 +166,7 @@ drake_cc_library(
         ":context",
         ":value",
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -173,6 +178,7 @@ drake_cc_library(
     deps = [
         ":abstract_values",
         ":discrete_values",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -197,6 +203,7 @@ drake_cc_library(
     ],
     deps = [
         ":system_common",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -206,6 +213,7 @@ drake_cc_library(
     srcs = ["output_port_listener_interface.cc"],
     hdrs = ["output_port_listener_interface.h"],
     deps = [
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -219,6 +227,7 @@ drake_cc_library(
         ":value",
         ":value_checker",
         ":vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -254,6 +263,7 @@ drake_cc_library(
         ":input_port_value",
         ":parameters",
         ":state",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -267,6 +277,7 @@ drake_cc_library(
         ":context",
         ":parameters",
         ":vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -292,6 +303,7 @@ drake_cc_library(
         ":system_scalar_converter",
         ":value",
         "//drake/common:autodiff",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/common:symbolic",
         "//drake/common:type_safe_index",
@@ -307,6 +319,7 @@ drake_cc_library(
         ":system",
         ":value",
         ":vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -354,6 +367,7 @@ drake_cc_library(
         ":system_scalar_converter",
         ":system_symbolic_inspector",
         ":value_checker",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/common:number_traits",
         "//drake/common:unused",
@@ -366,6 +380,7 @@ drake_cc_library(
     hdrs = ["diagram_continuous_state.h"],
     deps = [
         ":state",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -378,6 +393,7 @@ drake_cc_library(
         ":context",
         ":diagram_continuous_state",
         ":vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -390,6 +406,7 @@ drake_cc_library(
         ":cache",
         ":diagram_context",
         ":system",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/common:number_traits",
     ],
@@ -401,6 +418,7 @@ drake_cc_library(
     hdrs = ["diagram_builder.h"],
     deps = [
         ":diagram",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
@@ -410,6 +428,7 @@ drake_cc_library(
     srcs = ["system_constraint.cc"],
     hdrs = ["system_constraint.h"],
     deps = [
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/common:symbolic",
         "//drake/common:type_safe_index",
@@ -433,6 +452,7 @@ drake_cc_library(
     hdrs = ["single_output_vector_source.h"],
     deps = [
         ":leaf_system",
+        "//drake/common:default_scalars",
     ],
 )
 
@@ -442,6 +462,7 @@ drake_cc_library(
     hdrs = ["vector_system.h"],
     deps = [
         ":leaf_system",
+        "//drake/common:default_scalars",
         "//drake/common:unused",
     ],
 )

--- a/drake/systems/framework/basic_vector.cc
+++ b/drake/systems/framework/basic_vector.cc
@@ -1,15 +1,6 @@
 #include "drake/systems/framework/basic_vector.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/symbolic.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class BasicVector<double>;
-template class BasicVector<AutoDiffXd>;
-template class BasicVector<symbolic::Expression>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::BasicVector)

--- a/drake/systems/framework/context.cc
+++ b/drake/systems/framework/context.cc
@@ -1,11 +1,9 @@
 #include "drake/systems/framework/context.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template struct StepInfo<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    struct ::drake::systems::StepInfo)
 
-template class Context<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Context)

--- a/drake/systems/framework/continuous_state.cc
+++ b/drake/systems/framework/continuous_state.cc
@@ -1,13 +1,6 @@
 #include "drake/systems/framework/continuous_state.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class ContinuousState<double>;
-template class ContinuousState<AutoDiffXd>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::ContinuousState)

--- a/drake/systems/framework/diagram.cc
+++ b/drake/systems/framework/diagram.cc
@@ -1,26 +1,18 @@
 #include "drake/systems/framework/diagram.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/symbolic.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-namespace internal {
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::internal::DiagramOutputPort)
 
-template class DiagramOutputPort<double>;
-template class DiagramOutputPort<AutoDiffXd>;
-template class DiagramOutputPort<symbolic::Expression>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::internal::DiagramOutput)
 
-template class DiagramOutput<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::internal::DiagramTimeDerivatives)
 
-template class DiagramTimeDerivatives<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::internal::DiagramDiscreteVariables)
 
-template class DiagramDiscreteVariables<double>;
-
-}  // namespace internal
-
-template class Diagram<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Diagram)

--- a/drake/systems/framework/diagram_builder.cc
+++ b/drake/systems/framework/diagram_builder.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/diagram_builder.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class DiagramBuilder<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramBuilder)

--- a/drake/systems/framework/diagram_context.cc
+++ b/drake/systems/framework/diagram_context.cc
@@ -1,12 +1,9 @@
 #include "drake/systems/framework/diagram_context.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class DiagramState<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramState)
 
-template class DiagramContext<double>;
-
-}  // namespace systems
-}  // namespace drake
-
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramContext)

--- a/drake/systems/framework/diagram_continuous_state.cc
+++ b/drake/systems/framework/diagram_continuous_state.cc
@@ -1,10 +1,6 @@
 #include "drake/systems/framework/diagram_continuous_state.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class DiagramContinuousState<double>;
-
-}  // namespace systems
-}  // namespace drake
-
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramContinuousState)

--- a/drake/systems/framework/discrete_values.cc
+++ b/drake/systems/framework/discrete_values.cc
@@ -1,13 +1,6 @@
 #include "drake/systems/framework/discrete_values.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class DiscreteValues<double>;
-template class DiscreteValues<AutoDiffXd>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteValues)

--- a/drake/systems/framework/event_collection.cc
+++ b/drake/systems/framework/event_collection.cc
@@ -1,26 +1,18 @@
 #include "drake/systems/framework/event_collection.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/drake_assert.h"
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::PublishEvent)
 
-template class PublishEvent<double>;
-template class PublishEvent<AutoDiffXd>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteUpdateEvent)
 
-template class DiscreteUpdateEvent<double>;
-template class DiscreteUpdateEvent<AutoDiffXd>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::UnrestrictedUpdateEvent)
 
-template class UnrestrictedUpdateEvent<double>;
-template class UnrestrictedUpdateEvent<AutoDiffXd>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::LeafCompositeEventCollection)
 
-template class LeafCompositeEventCollection<double>;
-template class LeafCompositeEventCollection<AutoDiffXd>;
-
-template class DiagramCompositeEventCollection<double>;
-template class DiagramCompositeEventCollection<AutoDiffXd>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramCompositeEventCollection)

--- a/drake/systems/framework/input_port_descriptor.cc
+++ b/drake/systems/framework/input_port_descriptor.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/input_port_descriptor.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class InputPortDescriptor<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::InputPortDescriptor)

--- a/drake/systems/framework/input_port_evaluator_interface.cc
+++ b/drake/systems/framework/input_port_evaluator_interface.cc
@@ -1,11 +1,6 @@
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 
-namespace drake {
-namespace systems {
-namespace detail {
+#include "drake/common/default_scalars.h"
 
-template class InputPortEvaluatorInterface<double>;
-
-}  // namespace detail
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::detail::InputPortEvaluatorInterface)

--- a/drake/systems/framework/leaf_context.cc
+++ b/drake/systems/framework/leaf_context.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/leaf_context.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class LeafContext<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::LeafContext)

--- a/drake/systems/framework/leaf_output_port.cc
+++ b/drake/systems/framework/leaf_output_port.cc
@@ -4,10 +4,10 @@
 #include <sstream>
 
 #include "drake/common/autodiff_overloads.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/nice_type_name.h"
-#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace systems {
@@ -82,12 +82,11 @@ const AbstractValue& LeafOutputPort<T>::DoEval(
 
 // The Vector2/3 instantiations here are for the benefit of some
 // older unit tests but are not otherwise advertised.
-
-template class LeafOutputPort<double>;
-template class LeafOutputPort<AutoDiffXd>;
-template class LeafOutputPort<symbolic::Expression>;
 template class LeafOutputPort<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
 template class LeafOutputPort<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
 
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::LeafOutputPort)

--- a/drake/systems/framework/leaf_system.cc
+++ b/drake/systems/framework/leaf_system.cc
@@ -1,12 +1,6 @@
 #include "drake/systems/framework/leaf_system.h"
 
-#include "drake/common/symbolic.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class LeafSystem<double>;
-template class LeafSystem<symbolic::Expression>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::LeafSystem)

--- a/drake/systems/framework/output_port.cc
+++ b/drake/systems/framework/output_port.cc
@@ -5,9 +5,9 @@
 #include <typeinfo>
 
 #include "drake/common/autodiff_overloads.h"
+#include "drake/common/default_scalars.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/nice_type_name.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/system.h"
 
 namespace drake {
@@ -133,12 +133,11 @@ void OutputPort<T>::CheckValidBasicVector(
 
 // The Vector2/3 instantiations here are for the benefit of some
 // older unit tests but are not otherwise advertised.
-
-template class OutputPort<double>;
-template class OutputPort<AutoDiffXd>;
-template class OutputPort<symbolic::Expression>;
 template class OutputPort<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
 template class OutputPort<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
 
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::OutputPort)

--- a/drake/systems/framework/output_port_value.cc
+++ b/drake/systems/framework/output_port_value.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/framework/output_port_value.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace systems {
 
@@ -27,9 +29,11 @@ void OutputPortValue::InvalidateAndIncrement() {
   }
 }
 
-template class SystemOutput<double>;
-
-template class LeafSystemOutput<double>;
-
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::SystemOutput)
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::LeafSystemOutput)

--- a/drake/systems/framework/parameters.cc
+++ b/drake/systems/framework/parameters.cc
@@ -1,15 +1,6 @@
 #include "drake/systems/framework/parameters.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/symbolic.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class Parameters<double>;
-template class Parameters<AutoDiffXd>;
-template class Parameters<symbolic::Expression>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Parameters)

--- a/drake/systems/framework/single_output_vector_source.cc
+++ b/drake/systems/framework/single_output_vector_source.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/single_output_vector_source.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class SingleOutputVectorSource<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::SingleOutputVectorSource)

--- a/drake/systems/framework/state.cc
+++ b/drake/systems/framework/state.cc
@@ -1,13 +1,6 @@
 #include "drake/systems/framework/state.h"
 
-#include "drake/common/autodiff_overloads.h"
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class State<double>;
-template class State<AutoDiffXd>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::State)

--- a/drake/systems/framework/subvector.cc
+++ b/drake/systems/framework/subvector.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/subvector.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class Subvector<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Subvector)

--- a/drake/systems/framework/supervector.cc
+++ b/drake/systems/framework/supervector.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/supervector.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class Supervector<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::Supervector)

--- a/drake/systems/framework/system.cc
+++ b/drake/systems/framework/system.cc
@@ -4,6 +4,8 @@
 #include <ios>
 #include <regex>
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace systems {
 
@@ -27,7 +29,8 @@ std::string SystemImpl::GetMemoryObjectName(
   return result.str();
 }
 
-template class System<double>;
-
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::System)

--- a/drake/systems/framework/system_constraint.cc
+++ b/drake/systems/framework/system_constraint.cc
@@ -1,14 +1,6 @@
 #include "drake/systems/framework/system_constraint.h"
 
-#include "drake/common/eigen_autodiff_types.h"
-#include "drake/common/symbolic.h"
+#include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-template class SystemConstraint<double>;
-template class SystemConstraint<AutoDiffXd>;
-template class SystemConstraint<symbolic::Expression>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::SystemConstraint)

--- a/drake/systems/framework/vector_base.cc
+++ b/drake/systems/framework/vector_base.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/vector_base.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class VectorBase<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::VectorBase)

--- a/drake/systems/framework/vector_system.cc
+++ b/drake/systems/framework/vector_system.cc
@@ -1,9 +1,6 @@
 #include "drake/systems/framework/vector_system.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class VectorSystem<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::VectorSystem)

--- a/drake/systems/framework/witness_function.cc
+++ b/drake/systems/framework/witness_function.cc
@@ -1,6 +1,6 @@
 #include "drake/systems/framework/witness_function.h"
 
-#include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/default_scalars.h"
 #include "drake/systems/framework/system.h"
 
 namespace drake {
@@ -12,11 +12,13 @@ T WitnessFunction<T>::Evaluate(const Context<T>& context) const {
   return DoEvaluate(context);
 }
 
-template class WitnessFunction<double>;
-template class WitnessFunction<AutoDiffXd>;
+// The Vector2/3 instantiations here are for the benefit of some
+// older unit tests but are not otherwise advertised.
 template class WitnessFunction<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
 template class WitnessFunction<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
-template class WitnessFunction<symbolic::Expression>;
 
 }  // namespace systems
 }  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::WitnessFunction)


### PR DESCRIPTION
The `default_scalars.h` provides _"A macro to that defines explicit class template instantiations for Drake's default set of supported scalar types."_

The main intent here is "don't repeat yourself".  Whichever way we decide to phrase template instantiations in the future, we should have standard, terse boilerplate to implement it.

Full WIP patches are published at https://github.com/jwnimmer-tri/drake/tree/autodiffnd-spike.

Relates #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7093)
<!-- Reviewable:end -->
