### PR TITLE
Add valgrind suppression for MSK_checkoutlicense via MosekSolver::AcquireLicense().

### DIFF
--- a/tools/valgrind.supp
+++ b/tools/valgrind.supp
@@ -77,6 +77,20 @@
     fun:MSKP_optimizeconic
 }
 
+# Similar to <mosek-4>, but specific to calling MSK_checkoutlicense via
+# MosekSolver::AcquireLicense().
+{
+   <mosek-7>
+   Memcheck:Cond
+   fun:__intel_sse2_strcpy
+   fun:MSKP_strdupenv
+   fun:checkout_from_flexlm
+   fun:MSK_ehajakopr
+   fun:MSK_checkoutlicense
+   ...
+   fun:_ZN5drake7solvers11MosekSolver14AcquireLicenseEv
+}
+
 # Started happening when Gurobi got updated to 7.0.2. PR 6332.
 {
     <gurobi-1>


### PR DESCRIPTION
Discarding a `memcheck` warning that was introduced via #7079 (conditional-uninitialized-jump like `<mosek-4>` in `//tools:valgrind.supp`).

An example CI failure without the suppression:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/138/console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7094)
<!-- Reviewable:end -->
