### PR TITLE
Fix varoius nits in primitives

### DIFF
--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -12,7 +12,6 @@
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/primitives/signal_log.h"
 
 namespace drake {

--- a/drake/systems/framework/input_port_evaluator_interface.h
+++ b/drake/systems/framework/input_port_evaluator_interface.h
@@ -4,7 +4,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/input_port_descriptor.h"
-#include "drake/systems/framework/output_port_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/single_output_vector_source.h
+++ b/drake/systems/framework/single_output_vector_source.h
@@ -7,7 +7,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/framework/test/output_port_test.cc
+++ b/drake/systems/framework/test/output_port_test.cc
@@ -14,7 +14,6 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/system.h"

--- a/drake/systems/framework/vector_system.h
+++ b/drake/systems/framework/vector_system.h
@@ -13,7 +13,6 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/lcm/lcm_publisher_system.h
+++ b/drake/systems/lcm/lcm_publisher_system.h
@@ -6,7 +6,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/lcm/drake_lcm_interface.h"
-#include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "drake/systems/lcm/lcm_translator_dictionary.h"

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -7,7 +7,6 @@
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/output_port_value.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -10,7 +10,6 @@
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
 #include "drake/systems/lcm/lcm_translator_dictionary.h"

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -5,9 +5,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/vector_base.h"
 
 namespace drake {

--- a/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/drake/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -7,7 +7,6 @@
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/systems/framework/input_port_value.h"
-#include "drake/systems/framework/leaf_context.h"
 #include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/subvector.h"

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -158,7 +158,6 @@ drake_cc_library(
         "pass_through-inl.h",
     ],
     deps = [
-        "//drake/common:unused",
         "//drake/systems/framework",
     ],
 )
@@ -197,7 +196,8 @@ drake_cc_library(
     srcs = ["signal_log.cc"],
     hdrs = ["signal_log.h"],
     deps = [
-        "//drake/systems/framework",
+        "//drake/common:autodiff",
+        "//drake/common:essential",
     ],
 )
 
@@ -219,7 +219,6 @@ drake_cc_library(
         "zero_order_hold-inl.h",
     ],
     deps = [
-        "//drake/common:unused",
         "//drake/systems/framework",
     ],
 )

--- a/drake/systems/primitives/adder.cc
+++ b/drake/systems/primitives/adder.cc
@@ -1,13 +1,8 @@
 #include "drake/systems/primitives/adder.h"
 
-#include <stdexcept>
-#include <string>
-
 #include "drake/common/autodiff_overloads.h"
-#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/adder.h
+++ b/drake/systems/primitives/adder.h
@@ -1,14 +1,9 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-
 #include "drake/common/drake_copyable.h"
-#include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
-#include "drake/systems/framework/system.h"
+#include "drake/systems/framework/output_port.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -8,7 +8,6 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/symbolic_decompose.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/constant_value_source-inl.h
+++ b/drake/systems/primitives/constant_value_source-inl.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <utility>
-
 /// @file
 /// Template method implementations for constant_value_source.h.
 /// Most users should only include that file, not this one.
@@ -10,11 +7,8 @@
 
 #include "drake/systems/primitives/constant_value_source.h"
 
-#include <stdexcept>
-#include <string>
-
-#include "drake/common/drake_assert.h"
-#include "drake/systems/framework/leaf_context.h"
+#include <memory>
+#include <utility>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/constant_value_source.h
+++ b/drake/systems/primitives/constant_value_source.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <cstdint>
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {

--- a/drake/systems/primitives/demultiplexer.cc
+++ b/drake/systems/primitives/demultiplexer.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/primitives/demultiplexer.h"
 
 #include "drake/common/autodiff_overloads.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/symbolic.h"
 

--- a/drake/systems/primitives/demultiplexer.h
+++ b/drake/systems/primitives/demultiplexer.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {

--- a/drake/systems/primitives/first_order_low_pass_filter.h
+++ b/drake/systems/primitives/first_order_low_pass_filter.h
@@ -2,7 +2,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/vector_system.h"
 
 namespace drake {

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -9,7 +9,6 @@
 
 #include <sstream>
 
-#include "drake/common/drake_assert.h"
 #include "drake/common/unused.h"
 
 namespace drake {

--- a/drake/systems/primitives/gain.h
+++ b/drake/systems/primitives/gain.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/vector_system.h"

--- a/drake/systems/primitives/integrator.cc
+++ b/drake/systems/primitives/integrator.cc
@@ -1,14 +1,10 @@
 #include "drake/systems/primitives/integrator.h"
 
-#include <stdexcept>
-#include <string>
-
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/unused.h"
-#include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/leaf_context.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/integrator.h
+++ b/drake/systems/primitives/integrator.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <cstdint>
-#include <memory>
-
 #include "drake/common/drake_copyable.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/vector_system.h"
 

--- a/drake/systems/primitives/multiplexer.h
+++ b/drake/systems/primitives/multiplexer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <utility>
 
-#include "drake/common/unused.h"
 #include "drake/systems/primitives/pass_through.h"
 
 namespace drake {

--- a/drake/systems/primitives/pass_through.cc
+++ b/drake/systems/primitives/pass_through.cc
@@ -3,6 +3,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/pass_through.h
+++ b/drake/systems/primitives/pass_through.h
@@ -3,8 +3,7 @@
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/symbolic.h"
-#include "drake/systems/framework/vector_system.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/saturation.cc
+++ b/drake/systems/primitives/saturation.cc
@@ -1,11 +1,9 @@
 #include "drake/systems/primitives/saturation.h"
 
-#include <algorithm>
 #include <limits>
 
 #include "drake/common/eigen_types.h"
 #include "drake/math/saturate.h"
-#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/saturation.h
+++ b/drake/systems/primitives/saturation.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <memory>
-
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/leaf_system.h"

--- a/drake/systems/primitives/signal_logger.h
+++ b/drake/systems/primitives/signal_logger.h
@@ -9,7 +9,7 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
+#include "drake/systems/framework/output_port.h"
 #include "drake/systems/primitives/signal_log.h"
 
 namespace drake {

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/unused.h"
 #include "drake/systems/primitives/zero_order_hold.h"
 
 namespace drake {

--- a/drake/systems/primitives/zero_order_hold.cc
+++ b/drake/systems/primitives/zero_order_hold.cc
@@ -3,6 +3,7 @@
 
 #include "drake/common/autodiff_overloads.h"
 #include "drake/common/eigen_autodiff_types.h"
+#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/zero_order_hold.h
+++ b/drake/systems/primitives/zero_order_hold.h
@@ -5,7 +5,6 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/symbolic.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 

--- a/drake/systems/sensors/accelerometer.h
+++ b/drake/systems/sensors/accelerometer.h
@@ -10,7 +10,6 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/sensors/accelerometer_output.h"
 

--- a/drake/systems/sensors/depth_sensor.cc
+++ b/drake/systems/sensors/depth_sensor.cc
@@ -12,7 +12,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/text_logging.h"
 #include "drake/systems/framework/basic_vector.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/depth_sensor_output.h"
 

--- a/drake/systems/sensors/depth_sensor.h
+++ b/drake/systems/sensors/depth_sensor.h
@@ -10,7 +10,6 @@
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/depth_sensor_output.h"

--- a/drake/systems/sensors/gyroscope.h
+++ b/drake/systems/sensors/gyroscope.h
@@ -9,7 +9,6 @@
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 #include "drake/systems/framework/system.h"
 #include "drake/systems/sensors/gyroscope_output.h"
 

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
@@ -7,7 +7,6 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
-#include "drake/systems/framework/output_port_value.h"
 
 namespace drake {
 namespace systems {


### PR DESCRIPTION
Also fix the same problem(s) in other places in the tree with the same problem, where grep could find the same problem(s).

Mostly:
- Systems should not be including `output_port_value.h`.
- Systems should not be including `leaf_context.h` (though `myfoo_context.h` can and should).
- Deadwood includes.

Discovered while working #7039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7095)
<!-- Reviewable:end -->
