### PR TITLE
Add simple initial implementation for a PointCloud container.

### DIFF
--- a/drake/perception/BUILD
+++ b/drake/perception/BUILD
@@ -1,0 +1,49 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
+load("//tools:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "point_cloud_flags",
+    srcs = ["point_cloud_flags.cc"],
+    hdrs = ["point_cloud_flags.h"],
+    deps = [
+        "//drake/common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "point_cloud",
+    srcs = ["point_cloud.cc"],
+    hdrs = ["point_cloud.h"],
+    deps = [
+        ":point_cloud_flags",
+        "//drake/common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "point_cloud_flags_test",
+    srcs = ["test/point_cloud_flags_test.cc"],
+    deps = [
+        ":point_cloud_flags",
+    ],
+)
+
+drake_cc_googletest(
+    name = "point_cloud_test",
+    srcs = ["test/point_cloud_test.cc"],
+    deps = [
+        ":point_cloud",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+add_lint_tests()

--- a/drake/perception/point_cloud.cc
+++ b/drake/perception/point_cloud.cc
@@ -1,0 +1,269 @@
+#include "drake/perception/point_cloud.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include "drake/common/drake_assert.h"
+
+using Eigen::Map;
+using Eigen::NoChange;
+
+namespace drake {
+namespace perception {
+
+namespace {
+
+// Convenience aliases.
+typedef PointCloud::T T;
+typedef PointCloud::D D;
+
+}  // namespace
+
+/*
+ * Provides encapsulated storage for a `PointCloud`.
+ *
+ * This storage is not responsible for initializing default values.
+ */
+class PointCloud::Storage {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Storage)
+
+  Storage(int new_size, pc_flags::Fields fields)
+      : fields_(fields) {
+    // Ensure that we incorporate the size of the descriptors.
+    descriptors_.resize(fields_.descriptor_type().size(), 0);
+    // Resize as normal.
+    resize(new_size);
+  }
+
+  // Returns size of the storage.
+  int size() const { return size_; }
+
+  // Resize to parent cloud's size.
+  void resize(int new_size) {
+    size_ = new_size;
+    if (fields_.contains(pc_flags::kXYZs))
+      xyzs_.conservativeResize(NoChange, new_size);
+    if (fields_.has_descriptor())
+      descriptors_.conservativeResize(NoChange, new_size);
+    CheckInvariants();
+  }
+
+  Eigen::Ref<Matrix3X<T>> xyzs() { return xyzs_; }
+  Eigen::Ref<MatrixX<T>> descriptors() { return descriptors_; }
+
+ private:
+  void CheckInvariants() const {
+    if (fields_.contains(pc_flags::kXYZs)) {
+      const int xyz_size = xyzs_.cols();
+      DRAKE_DEMAND(xyz_size == size());
+    }
+    if (fields_.has_descriptor()) {
+      const int descriptor_size = descriptors_.cols();
+      DRAKE_DEMAND(descriptor_size == size());
+    }
+  }
+
+  const pc_flags::Fields fields_;
+  int size_{};
+  Matrix3X<T> xyzs_;
+  MatrixX<T> descriptors_;
+};
+
+namespace {
+
+pc_flags::Fields ResolveFields(
+    const PointCloud& other, pc_flags::Fields fields) {
+  if (fields == pc_flags::kInherit) {
+    return other.fields();
+  } else {
+    return fields;
+  }
+}
+
+// Resolves the fields from a pair of point clouds and desired fields.
+// Implements the resolution rules in `SetFrom`.
+// @pre Valid point clouds `a` and `b`.
+// @returns Fields that both point clouds have.
+pc_flags::Fields ResolvePairFields(
+    const PointCloud& a,
+    const PointCloud& b,
+    pc_flags::Fields fields) {
+  if (fields == pc_flags::kInherit) {
+    // If we do not permit a subset, expect the exact same fields.
+    a.RequireExactFields(b.fields());
+    return a.fields();
+  } else {
+    a.RequireFields(fields);
+    b.RequireFields(fields);
+    return fields;
+  }
+}
+
+}  // namespace
+
+PointCloud::PointCloud(
+    int new_size, pc_flags::Fields fields, bool skip_initialize)
+    : size_(new_size),
+      fields_(fields) {
+  if (fields_ == pc_flags::kNone)
+    throw std::runtime_error("Cannot construct a PointCloud without fields");
+  if (fields_.contains(pc_flags::kInherit))
+    throw std::runtime_error("Cannot construct a PointCloud with kInherit");
+  storage_.reset(new Storage(size_, fields_));
+  if (!skip_initialize) {
+    SetDefault(0, size_);
+  }
+}
+
+PointCloud::PointCloud(const PointCloud& other,
+                       pc_flags::Fields copy_fields)
+    : PointCloud(other.size(), ResolveFields(other, copy_fields)) {
+  SetFrom(other);
+}
+
+PointCloud::PointCloud(PointCloud&& other)
+    : PointCloud(0, other.fields(), true) {
+  // This has zero size. Directly swap storages.
+  storage_.swap(other.storage_);
+  std::swap(size_, other.size_);
+  DRAKE_DEMAND(storage_->size() == size());
+}
+
+PointCloud& PointCloud::operator=(const PointCloud& other) {
+  SetFrom(other);
+  return *this;
+}
+
+PointCloud& PointCloud::operator=(PointCloud&& other) {
+  // We may only take rvalue references if the fields match exactly.
+  RequireExactFields(other.fields());
+  // Swap storages.
+  size_ = other.size_;
+  storage_.swap(other.storage_);
+  DRAKE_DEMAND(storage_->size() == size());
+  // Empty out the other cloud, but let it remain being a valid point cloud
+  // (with non-null storage).
+  other.resize(0, false);
+  return *this;
+}
+
+// Define destructor here to use complete definition of `Storage`.
+PointCloud::~PointCloud() {}
+
+void PointCloud::resize(int new_size, bool skip_initialization) {
+  DRAKE_DEMAND(new_size >= 0);
+  int old_size = size();
+  size_ = new_size;
+  storage_->resize(new_size);
+  DRAKE_DEMAND(storage_->size() == new_size);
+  if (new_size > old_size && !skip_initialization) {
+    int size_diff = new_size - old_size;
+    SetDefault(old_size, size_diff);
+  }
+}
+
+void PointCloud::SetDefault(int start, int num) {
+  auto set = [=](auto ref, auto value) {
+    ref.middleCols(start, num).setConstant(value);
+  };
+  if (has_xyzs()) {
+    set(mutable_xyzs(), kDefaultValue);
+  }
+  if (has_descriptors()) {
+    set(mutable_descriptors(), kDefaultValue);
+  }
+}
+
+void PointCloud::SetFrom(const PointCloud& other,
+                         pc_flags::Fields fields_in,
+                         bool allow_resize) {
+  int old_size = size();
+  int new_size = other.size();
+  if (allow_resize) {
+    resize(new_size);
+  } else if (new_size != old_size) {
+    throw std::runtime_error(
+        fmt::format("SetFrom: {} != {}", new_size, old_size));
+  }
+  pc_flags::Fields fields_resolved =
+      ResolvePairFields(*this, other, fields_in);
+  if (fields_resolved.contains(pc_flags::kXYZs)) {
+    mutable_xyzs() = other.xyzs();
+  }
+  if (fields_resolved.has_descriptor()) {
+    mutable_descriptors() = other.descriptors();
+  }
+}
+
+void PointCloud::Expand(
+    int add_size,
+    bool skip_initialization) {
+  DRAKE_DEMAND(add_size >= 0);
+  const int new_size = size() + add_size;
+  resize(new_size, skip_initialization);
+}
+
+bool PointCloud::has_xyzs() const {
+  return fields_.contains(pc_flags::kXYZs);
+}
+Eigen::Ref<const Matrix3X<T>> PointCloud::xyzs() const {
+  DRAKE_DEMAND(has_xyzs());
+  return storage_->xyzs();
+}
+Eigen::Ref<Matrix3X<T>> PointCloud::mutable_xyzs() {
+  DRAKE_DEMAND(has_xyzs());
+  return storage_->xyzs();
+}
+
+bool PointCloud::has_descriptors() const {
+  return fields_.has_descriptor();
+}
+bool PointCloud::has_descriptors(
+    const pc_flags::DescriptorType& descriptor_type) const {
+  return fields_.contains(descriptor_type);
+}
+Eigen::Ref<const MatrixX<D>> PointCloud::descriptors() const {
+  DRAKE_DEMAND(has_descriptors());
+  return storage_->descriptors();
+}
+Eigen::Ref<MatrixX<D>> PointCloud::mutable_descriptors() {
+  DRAKE_DEMAND(has_descriptors());
+  return storage_->descriptors();
+}
+
+bool PointCloud::HasFields(
+    pc_flags::Fields fields_in) const {
+  DRAKE_DEMAND(!fields_in.contains(pc_flags::kInherit));
+  return fields_.contains(fields_in);
+}
+
+void PointCloud::RequireFields(
+    pc_flags::Fields fields_in) const {
+  if (!HasFields(fields_in)) {
+    throw std::runtime_error(
+        fmt::format("PointCloud does not have expected fields.\n"
+                    "Expected {}, got {}",
+                    fields_in, fields()));
+  }
+}
+
+bool PointCloud::HasExactFields(
+    pc_flags::Fields fields_in) const {
+  return fields() == fields_in;
+}
+
+void PointCloud::RequireExactFields(
+    pc_flags::Fields fields_in) const {
+  if (!HasExactFields(fields_in)) {
+    throw std::runtime_error(
+        fmt::format("PointCloud does not have the exact expected fields."
+                    "\nExpected {}, got {}",
+                    fields_in, fields()));
+  }
+}
+
+}  // namespace perception
+}  // namespace drake

--- a/drake/perception/point_cloud.h
+++ b/drake/perception/point_cloud.h
@@ -1,0 +1,272 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "drake/common/eigen_types.h"
+#include "drake/perception/point_cloud_flags.h"
+
+namespace drake {
+namespace perception {
+
+/// Implements a point cloud (with contiguous storage), whose main goal is to
+/// offer a convenient, synchronized interface to commonly used fields and
+/// data types applicable for basic 3D perception.
+///
+/// This is a mix between the philosophy of PCL (templated interface to
+/// provide a compile-time open set, run-time closed set) and VTK (non-templated
+/// interface to provide a very free form run-time open set).
+/// You may construct one PointCloud which will contain different sets of
+/// data, but you cannot change the contained data types after construction.
+/// However, you can mutate the data contained within the structure and resize
+/// the cloud.
+///
+/// Definitions:
+///  - point - An entry in a point cloud (not exclusively an XYZ point).
+///  - feature - Abstract representation of local properties (geometric and
+/// non-geometric)
+///  - descriptor - Concrete representation of a feature.
+///  - field - A feature or descriptor described by the point cloud.
+///
+/// This point cloud class provides the following fields:
+///  - xyz - Cartesian XYZ coordinates (float[3]).
+///  - descriptor - An descriptor that is run-time defined (float[X]).
+///
+/// @note "contiguous" here means contiguous in memory. This was chosen to
+/// avoid ambiguity between PCL and Eigen, where in PCL "dense" implies that
+/// the point cloud corresponds to a cloud with invalid values, and in Eigen
+/// "dense" implies contiguous storage.
+///
+/// @note The accessors / mutators for the point fields of this class returns
+/// references to the original Eigen matrices. This implies that they are
+/// invalidated whenever memory is reallocated for the values. Given this,
+/// minimize the lifetime of these references to be as short as possible.
+/// Additionally, algorithms wanting fast access to values should avoid the
+/// single point accessors / mutatotrs (e.g. `xyz(i)`, `mutable_descriptor(i)`)
+/// to avoid overhead when accessing a single element (either copying or
+/// creating a reference).
+///
+/// @note The definitions presented here for "feature" and "descriptor" are
+/// loosely based on their definitions within PCL and Radu Rusu's dissertation:
+///   Rusu, Radu Bogdan. "Semantic 3d object maps for everyday manipulation in
+///   human living environments." KI-Künstliche Intelligenz 24.4 (2010):
+///   345-348.
+/// This differs from other definitions, such as having "feature"
+/// describe geometric quantities and "descriptor" describe non-geometric
+/// quantities which is presented in the following survey paper:
+///   Pomerleau, François, Francis Colas, and Roland Siegwart. "A review of
+///   point cloud registration algorithms for mobile robotics." Foundations and
+///   Trends® in Robotics 4.1 (2015): 1-104.
+class PointCloud final {
+ public:
+  /// Geometric scalar type.
+  using T = float;
+
+  /// Descriptor scalar type.
+  using D = T;
+
+  /// Represents an invalid or uninitialized value.
+  static constexpr T kDefaultValue = std::numeric_limits<T>::quiet_NaN();
+  static inline bool IsDefaultValue(T value) { return std::isnan(value); }
+  static inline bool IsInvalidValue(T value) { return !std::isfinite(value); }
+
+  /// Constructs a point cloud of a given `new_size`, with the prescribed
+  /// `fields`. If `kDescriptors` is one of the fields, then
+  /// `descriptor` should be included and should not be `kNone`.
+  /// @param new_size
+  ///   Size of the point cloud after construction.
+  /// @param fields
+  ///   Fields that the point cloud contains.
+  /// @param skip_initialize
+  ///    Do not default-initialize new values.
+  explicit PointCloud(int new_size, pc_flags::Fields fields = pc_flags::kXYZs,
+                      bool skip_initialize = false);
+
+  /// Copies another point cloud's fields and data.
+  PointCloud(const PointCloud& other)
+      : PointCloud(other, pc_flags::kInherit) {}
+
+  /// Takes ownership of another point cloud's data.
+  PointCloud(PointCloud&& other);
+
+  /// Copies another point cloud's fields and data.
+  /// @param copy_fields
+  ///   Fields to copy. If this is `kInherit`, then `other`s fields will be
+  ///   copied. Otherwise, only the specified fields will be copied; the
+  ///   remaining fields in this cloud are left default initialized.
+  // Do not define a default argument for `copy_fields` so that this is
+  // not ambiguous w.r.t. the copy constructor.
+  PointCloud(const PointCloud& other, pc_flags::Fields copy_fields);
+
+  PointCloud& operator=(const PointCloud& other);
+  PointCloud& operator=(PointCloud&& other);
+
+  ~PointCloud();
+
+  // TODO(eric.cousineau): Consider locking the point cloud or COW to permit
+  // shallow copies.
+
+  /// Returns the fields provided by this point cloud.
+  pc_flags::Fields fields() const { return fields_; }
+
+  /// Returns the number of points in this point cloud.
+  int size() const { return size_; }
+
+  /// Conservative resize; will maintain existing data, and initialize new
+  /// data to their invalid values.
+  /// @param new_size
+  ///    The new size of the value. If less than the present `size()`, then
+  ///    the values will be truncated. If greater than the present `size()`,
+  ///    then the new values will be uninitialized if `skip_initialize` is not
+  ///    true.
+  /// @param skip_initialize
+  ///    Do not default-initialize new values.
+  void resize(int new_size, bool skip_initialize = false);
+
+
+  /// @name Geometric Descriptors
+  /// @{
+
+  /// Returns if this cloud provides XYZ values.
+  bool has_xyzs() const;
+
+  /// Returns access to XYZ values.
+  /// @pre `has_xyzs()` must be true.
+  Eigen::Ref<const Matrix3X<T>> xyzs() const;
+
+  /// Returns mutable access to XYZ values.
+  /// @pre `has_xyzs()` must be true.
+  Eigen::Ref<Matrix3X<T>> mutable_xyzs();
+
+  /// Returns access to a XYZ values.
+  /// @pre `has_xyzs()` must be true.
+  Vector3<T> xyz(int i) const { return xyzs().col(i); }
+
+  /// Returns mutable access to a XYZ values.
+  /// @pre `has_xyzs()` must be true.
+  Eigen::Ref<Vector3<T>> mutable_xyz(int i) {
+    return mutable_xyzs().col(i);
+  }
+
+  ///@}
+
+  /// @name Run-Time Descriptors
+  /// @{
+
+  /// Returns if this point cloud provides descriptor values.
+  bool has_descriptors() const;
+
+  /// Returns if the point cloud provides a specific descriptor.
+  bool has_descriptors(const pc_flags::DescriptorType& descriptor_type) const;
+
+  /// Returns the descriptor type.
+  const pc_flags::DescriptorType& descriptor_type() const {
+    return fields_.descriptor_type();
+  }
+
+  /// Returns access to descriptor values.
+  /// @pre `has_descriptors()` must be true.
+  Eigen::Ref<const MatrixX<D>> descriptors() const;
+
+  /// Returns mutable access to descriptor values.
+  /// @pre `has_descriptors()` must be true.
+  Eigen::Ref<MatrixX<D>> mutable_descriptors();
+
+  /// Returns access to a descriptor values.
+  /// @pre `has_descriptors()` must be true.
+  VectorX<T> descriptor(int i) const { return descriptors().col(i); }
+
+  /// Returns mutable access to a descriptor values.
+  /// @pre `has_descriptors()` must be true.
+  Eigen::Ref<VectorX<T>> mutable_descriptor(int i) {
+    return mutable_descriptors().col(i);
+  }
+
+  /// @}
+
+  /// @name Container Manipulation
+  /// @{
+
+  /// Copies all points from another point cloud.
+  /// @param other
+  ///    Other point cloud.
+  /// @param fields_in
+  ///    Fields to copy. If this is `kInherit`, then both clouds must have the
+  ///    exact same fields. Otherwise, both clouds must support the fields
+  ///    indicated this parameter.
+  /// @param allow_resize
+  ///    Permit resizing to the other cloud's size.
+  void SetFrom(
+      const PointCloud& other,
+      pc_flags::Fields fields_in = pc_flags::kInherit,
+      bool allow_resize = true);
+
+  // TODO(eric.cousineau): Add indexed version.
+
+  /// Adds `add_size` default-initialized points.
+  /// @param add_size
+  ///    Number of points to add.
+  /// @param skip_initialization
+  ///    Do not require that the new values be initialized.
+  void Expand(int add_size, bool skip_initialization = false);
+
+  /// @}
+
+  /// @name Fields
+  /// @{
+
+  /// Returns if a point cloud has a given set of fields.
+  bool HasFields(pc_flags::Fields fields_in) const;
+
+  /// Requires a given set of fields.
+  /// @see HasFields for preconditions.
+  /// @throws std::runtime_error if this point cloud does not have these
+  /// fields.
+  void RequireFields(pc_flags::Fields fields_in) const;
+
+  /// Returns if a point cloud has exactly a given set of fields.
+  /// @see HasFields for preconditions.
+  bool HasExactFields(pc_flags::Fields fields_in) const;
+
+  /// Requires the exact given set of fields.
+  /// @see HasFields for preconditions.
+  /// @throws std::runtime_error if this point cloud does not have exactly
+  /// these fields.
+  void RequireExactFields(pc_flags::Fields field_set) const;
+
+  /// @}
+
+  // TODO(eric.cousineau): Add storage for indices, with SHOT as a motivating
+  // example.
+
+  // TODO(eric.cousineau): Add mechanism for handling organized / unorganized
+  // point clouds.
+
+ private:
+  void SetDefault(int start, int num);
+
+  // Provides PIMPL encapsulation of storage mechanism.
+  class Storage;
+
+  // Represents the size of the point cloud.
+  int size_{};
+  // Represents which fields are enabled for this point cloud.
+  const pc_flags::Fields fields_{pc_flags::kXYZs};
+  // Owns storage used for the point cloud.
+  std::unique_ptr<Storage> storage_;
+};
+
+// TODO(eric.cousineau): Consider a way of reinterpret_cast<>ing the array
+// data to permit more semantic access to members, PCL-style
+// (e.g. point.x, point.r, etc: the reverse of PointCloud<>::getMatrixXfMap()).
+// Need to ensure alignments are commensurate. Will only work with
+// homogeneous data (possibly with heterogeneous data, if strides can be
+// used).
+
+}  // namespace perception
+}  // namespace drake

--- a/drake/perception/point_cloud_flags.cc
+++ b/drake/perception/point_cloud_flags.cc
@@ -1,0 +1,44 @@
+#include "drake/perception/point_cloud_flags.h"
+
+#include <sstream>
+#include <vector>
+
+namespace drake {
+namespace perception {
+
+namespace {
+
+// Utility for `ToString`.
+// TODO(eric.cousineau): Move to `drake/common`, consider using `infix_iterator`
+// per Soonho's suggestion: https://codereview.stackexchange.com/a/13209
+std::ostream& join(std::ostream& os,
+                   const std::vector<std::string>& elements,
+                   const std::string& delim) {
+  for (size_t i = 0; i < elements.size(); ++i) {
+    os << elements[i];
+    if (i + 1 < elements.size())
+      os << delim;
+  }
+  return os;
+}
+
+}  // namespace
+
+namespace pc_flags {
+
+std::ostream& operator<<(std::ostream& os, const Fields& fields) {
+  std::vector<std::string> values;
+  if (fields.contains(pc_flags::kXYZs))
+    values.push_back("kXYZs");
+  if (fields.has_descriptor()) {
+    values.push_back(fields.descriptor_type().name());
+  }
+  os << "(";
+  join(os, values, " | ");
+  return os << ")";
+}
+
+}  // namespace pc_flags
+
+}  // namespace perception
+}  // namespace drake

--- a/drake/perception/point_cloud_flags.h
+++ b/drake/perception/point_cloud_flags.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace perception {
+
+/// Point cloud flags.
+namespace pc_flags {
+
+typedef int BaseFieldT;
+/// Indicates the data the point cloud stores.
+enum BaseField : int {
+  kNone = 0,
+  /// Inherit other fields. May imply an intersection of all
+  /// compatible descriptors.
+  kInherit = 1 << 0,
+  /// XYZ point in Cartesian space.
+  kXYZs = 1 << 1,
+};
+
+/// Describes an descriptor field with a name and the descriptor's size.
+///
+/// @note This is defined as follows to enable an open set of descriptors, but
+/// ensure that these descriptor types are appropriately matched.
+/// As `PointCloud` evolves and more algorithms are mapped into Drake,
+/// promoting an descriptor field to a proper field should be considered if (a)
+/// it is used frequently enough AND (b) if it is often used in conjunction
+/// with other fields.
+class DescriptorType final {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(DescriptorType)
+
+  constexpr DescriptorType(int size, const char* name)
+      : size_(size),
+        name_(name) {}
+
+  inline int size() const { return size_; }
+  inline std::string name() const { return name_; }
+  inline bool operator==(const DescriptorType& other) const {
+    return size_ == other.size_ && name() == other.name();
+  }
+  inline bool operator!=(const DescriptorType& other) const {
+    return !(*this == other);
+  }
+
+ private:
+  int size_{};
+  const char* name_{nullptr};
+};
+
+/// No descriptor.
+constexpr DescriptorType kDescriptorNone(0, "kDescriptorNone");
+/// Curvature.
+constexpr DescriptorType kDescriptorCurvature(1, "kDescriptorCurvature");
+/// Point-feature-histogram.
+constexpr DescriptorType kDescriptorFPFH(33, "kDescriptorFPFH");
+
+/**
+ * Allows combination of `BaseField` and `DescriptorType` for a `PointCloud`.
+ * You may combine multiple `BaseField`s, but you may have only zero or one
+ * `DescriptorType`.
+ *
+ * This provides the mechanism to use basic bit-mask operators (| &) to
+ * combine / intersect fields for convenience.
+ */
+class Fields {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Fields)
+
+  /// @throws std::runtime_error if `base_fields` is not composed of valid
+  /// `BaseField`s.
+  Fields(BaseFieldT base_fields, DescriptorType descriptor_type)
+      : base_fields_(base_fields),
+        descriptor_type_(descriptor_type) {}
+
+  /// @throws std::runtime_error if `base_fields` is not composed of valid
+  /// `BaseField`s.
+  // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
+  Fields(BaseFieldT base_fields)
+      : base_fields_(base_fields) {
+    if (base_fields < 0 || base_fields >= (kXYZs << 1))
+      throw std::runtime_error("Invalid BaseField specified.");
+  }
+
+  // NOLINTNEXTLINE(runtime/explicit): This conversion is desirable.
+  Fields(const DescriptorType& descriptor_type)
+      : descriptor_type_(descriptor_type) {}
+
+  /// Returns the contained base fields.
+  BaseFieldT base_fields() const { return base_fields_; }
+
+  /// Returns whether there are any base fields contained by this set of fields.
+  bool has_base_fields() const {
+    return base_fields_ != kNone;
+  }
+
+  /// Returns the contained descriptor type.
+  const DescriptorType& descriptor_type() const { return descriptor_type_; }
+
+  /// Returns whether there is a descriptor contained by this set of fields.
+  bool has_descriptor() const {
+    return descriptor_type_ != kDescriptorNone;
+  }
+
+  /// Provides in-place union.
+  /// @throws std::runtime_error if multiple non-None `DescriptorType`s are
+  /// specified.
+  Fields& operator|=(const Fields& rhs) {
+    base_fields_ = base_fields_ | rhs.base_fields_;
+    if (has_descriptor())
+      throw std::runtime_error(
+          "Cannot have multiple Descriptor flags. "
+          "Can only add flags iff (!rhs.has_descriptor()).");
+    descriptor_type_ = rhs.descriptor_type_;
+    return *this;
+  }
+
+  /// Provides union.
+  /// @see operator|= for preconditions.
+  Fields operator|(const Fields& rhs) const {
+    return Fields(*this) |= rhs;
+  }
+
+  /// Provides in-place intersection.
+  Fields& operator&=(const Fields& rhs) {
+    base_fields_ &= rhs.base_fields_;
+    if (descriptor_type_ != rhs.descriptor_type_) {
+      descriptor_type_ = kDescriptorNone;
+    }
+    return *this;
+  }
+
+  /// Provides intersection.
+  Fields operator&(const Fields& rhs) const {
+    return Fields(*this) &= rhs;
+  }
+
+  /// Returns whether both value types (BaseField + DescriptorType) are none.
+  bool empty() const {
+    return !has_base_fields() && !has_descriptor();
+  }
+
+  /// Returns whether this set of fields contains (is a superset of) `rhs`.
+  bool contains(const Fields& rhs) const {
+    return (*this & rhs) == rhs;
+  }
+
+  bool operator==(const Fields& rhs) const {
+    return (base_fields_ == rhs.base_fields_
+            && descriptor_type_ == rhs.descriptor_type_);
+  }
+
+  bool operator!=(const Fields& rhs) const {
+    return !(*this == rhs);
+  }
+
+  /// Provides human-readable output.
+  friend std::ostream& operator<<(std::ostream& os, const Fields& rhs);
+
+ private:
+  // TODO(eric.cousineau): Use `optional` to avoid the need for `none` objects?
+  BaseFieldT base_fields_{kNone};
+  DescriptorType descriptor_type_{kDescriptorNone};
+};
+
+/// Makes operator| compatible for `BaseField` + `DescriptorType`.
+/// @see Fields::operator|= for preconditions.
+// Do not use implicit conversion because it becomes ambiguous.
+inline Fields operator|(const BaseFieldT& lhs, const DescriptorType& rhs) {
+  return Fields(lhs) | Fields(rhs);
+}
+
+/// Makes operator| compatible for `DescriptorType` + `Fields`
+// (`DescriptorType` or `BaseFields`).
+/// @see Fields::operator|= for preconditions.
+inline Fields operator|(const DescriptorType& lhs, const Fields& rhs) {
+  return Fields(lhs) | rhs;
+}
+
+// TODO(eric.cousineau): Add compatible operator& if the need arises.
+
+}  // namespace pc_flags
+
+}  // namespace perception
+}  // namespace drake

--- a/drake/perception/test/point_cloud_flags_test.cc
+++ b/drake/perception/test/point_cloud_flags_test.cc
@@ -1,0 +1,67 @@
+#include "drake/perception/point_cloud_flags.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace perception {
+
+namespace pcf = pc_flags;
+
+namespace {
+
+GTEST_TEST(PointCloudFlagsTest, ConstExpr) {
+  // @note This is demonstrating that `DescriptorType` can be a literal type
+  // (suitable for being a `constexpr`). However, this is not necessary
+  // to ensure this contract, as the compiler will throw an error if a
+  // `constexpr` is attempted with a non-literal-type class (as of C++14).
+  // TODO(eric.cousineau): Replace with the successor of is_literal_type.
+  // @ref https://stackoverflow.com/a/40352351/7829525
+  EXPECT_TRUE(std::is_literal_type<pcf::DescriptorType>::value);
+}
+
+GTEST_TEST(PointCloudFlagsTest, Basic) {
+  // Check human-friendly formatting.
+  {
+    std::ostringstream os;
+    os << (pcf::kXYZs | pcf::kDescriptorCurvature);
+    EXPECT_EQ("(kXYZs | kDescriptorCurvature)", os.str());
+  }
+
+  // Check basics.
+  pcf::Fields lhs = pcf::kXYZs;
+  pcf::Fields rhs = pcf::kXYZs;
+  EXPECT_EQ(lhs, rhs);
+  EXPECT_TRUE(lhs.contains(pcf::kXYZs));
+  EXPECT_FALSE(lhs.contains(pcf::kDescriptorCurvature));
+  lhs |= pcf::kDescriptorFPFH;
+  EXPECT_NE(lhs, rhs);
+  EXPECT_TRUE(lhs.contains(pcf::kDescriptorFPFH));
+
+  // TODO(eric.cousineau): Add check for intersection when there is more
+  // than one `BaseField`.
+  EXPECT_EQ(lhs & pcf::kXYZs, pcf::kXYZs);
+  EXPECT_EQ(lhs & pcf::kDescriptorFPFH, pcf::kDescriptorFPFH);
+
+  // Check implicit conversion.
+  EXPECT_EQ(pcf::Fields(pcf::kXYZs), pcf::kXYZs);
+  EXPECT_EQ(pcf::Fields(pcf::kNone), pcf::Fields(pcf::kDescriptorNone));
+
+  // Check negatives.
+  EXPECT_THROW(pcf::Fields(-100), std::runtime_error);
+  EXPECT_THROW(pcf::Fields(100), std::runtime_error);
+
+  // Check combinations with `None` (effectively zero) values.
+  EXPECT_NO_THROW(pcf::kDescriptorNone | pcf::kDescriptorCurvature);
+  EXPECT_NO_THROW(pcf::kNone | pcf::kDescriptorCurvature);
+
+  // Cannot have two descriptors.
+  EXPECT_THROW(pcf::kDescriptorFPFH | pcf::kDescriptorCurvature,
+               std::runtime_error);
+}
+
+}  // namespace
+}  // namespace perception
+}  // namespace drake

--- a/drake/perception/test/point_cloud_test.cc
+++ b/drake/perception/test/point_cloud_test.cc
@@ -1,0 +1,217 @@
+#include "drake/perception/point_cloud.h"
+
+#include <iostream>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+using Eigen::Matrix3Xf;
+using Eigen::Matrix4Xf;
+
+using ::testing::AssertionResult;
+using ::testing::AssertionSuccess;
+using ::testing::AssertionFailure;
+
+
+namespace drake {
+namespace perception {
+namespace {
+
+// Provides a helper mechanism to (a) check default types and (b) compare
+// matrices, handling the special case of unsigned values.
+template <typename T>
+struct check_helper {
+  template <typename XprType>
+  static bool IsDefault(const XprType& xpr) {
+    return xpr.array().isNaN().all();
+  }
+
+  template <typename XprTypeA, typename XprTypeB>
+  static AssertionResult Compare(const XprTypeA& a, const XprTypeB& b) {
+    return CompareMatrices(a, b);
+  }
+};
+
+GTEST_TEST(PointCloudTest, Basic) {
+  const int count = 5;
+
+  auto CheckFields = [count](auto values_expected, pc_flags::Fields fields,
+                             auto get_mutable_values, auto get_values,
+                             auto get_mutable_value, auto get_value) {
+    PointCloud cloud(count, fields);
+    EXPECT_EQ(count, cloud.size());
+    typedef decltype(values_expected) XprType;
+    typedef typename XprType::Scalar T;
+
+    // Shim normal comparison to use unsigned-type friendly comparators.
+    auto CompareMatrices = [](const auto& a, const auto& b) {
+      return check_helper<T>::Compare(a, b);
+    };
+
+    // Expect the values to be default-initialized.
+    EXPECT_TRUE(check_helper<T>::IsDefault(get_mutable_values(cloud)));
+
+    // Set values using the mutable accessor.
+    get_mutable_values(cloud) = values_expected;
+
+    EXPECT_TRUE(CompareMatrices(values_expected, get_mutable_values(cloud)));
+    EXPECT_TRUE(CompareMatrices(values_expected, get_values(cloud)));
+
+    // Check element-by-element.
+    for (int i = 0; i < count; ++i) {
+      const auto value_expected = values_expected.col(i);
+      EXPECT_TRUE(CompareMatrices(value_expected, get_value(cloud, i)));
+      EXPECT_TRUE(CompareMatrices(value_expected, get_mutable_value(cloud, i)));
+    }
+
+    // Check copy and move constructors.
+    {
+      PointCloud cloud_copy(cloud);
+      EXPECT_TRUE(
+          CompareMatrices(values_expected, get_values(cloud_copy)));
+
+      PointCloud cloud_move(std::move(cloud_copy));
+      EXPECT_TRUE(
+          CompareMatrices(values_expected, get_values(cloud_move)));
+      // Ensure the original cloud was emptied out.
+      EXPECT_EQ(0, cloud_copy.size());
+    }
+
+    // Check copy and move assignment.
+    {
+      PointCloud cloud_copy(0, fields);
+      cloud_copy = cloud;
+      EXPECT_TRUE(
+          CompareMatrices(values_expected, get_values(cloud_copy)));
+
+      PointCloud cloud_move(0, fields);
+      cloud_move = std::move(cloud_copy);
+      EXPECT_TRUE(
+          CompareMatrices(values_expected, get_values(cloud_move)));
+      // Ensure the original cloud was emptied out.
+      EXPECT_EQ(0, cloud_copy.size());
+    }
+
+    // Add item which should be default-initialized.
+    int last = cloud.size();
+    cloud.Expand(1);
+    EXPECT_EQ(count + 1, cloud.size());
+    // Check default-initialized.
+    EXPECT_TRUE(check_helper<T>::IsDefault(get_value(cloud, last)));
+    // Ensure that we preserve the values.
+    EXPECT_TRUE(
+        CompareMatrices(values_expected,
+                        get_values(cloud).middleCols(0, last)));
+
+    // Resize to a size smaller.
+    int small_size = 3;
+    cloud.resize(small_size);
+    EXPECT_EQ(small_size, cloud.size());
+    EXPECT_TRUE(
+        CompareMatrices(values_expected.middleCols(0, small_size),
+                        get_values(cloud)));
+
+    // Resize to a size larger.
+    int large_size = 6;
+    cloud.resize(large_size);
+    EXPECT_EQ(large_size, cloud.size());
+    EXPECT_TRUE(
+        CompareMatrices(values_expected.middleCols(0, small_size),
+                        get_values(cloud).middleCols(0, small_size)));
+    EXPECT_TRUE(
+        check_helper<T>::IsDefault(
+            get_values(cloud).middleCols(small_size, large_size - small_size)));
+  };
+
+  // TODO(eric.cousineau): Iterate through the combinatorics of fields.
+
+  // Points.
+  Matrix3Xf xyzs_expected(3, count);
+  xyzs_expected.transpose() <<
+    1, 2, 3,
+    10, 20, 30,
+    100, 200, 300,
+    4, 5, 6,
+    40, 50, 60;
+  CheckFields(xyzs_expected, pc_flags::kXYZs,
+              [](PointCloud& cloud) { return cloud.mutable_xyzs(); },
+              [](PointCloud& cloud) { return cloud.xyzs(); },
+              [](PointCloud& cloud, int i) { return cloud.mutable_xyz(i); },
+              [](PointCloud& cloud, int i) { return cloud.xyz(i); });
+
+  // Descriptors (Curvature).
+  Eigen::RowVectorXf descriptors_expected(count);
+  descriptors_expected <<
+    1, 2, 3, 4, 5;
+  CheckFields(descriptors_expected, pc_flags::kDescriptorCurvature,
+              [](PointCloud& cloud) { return cloud.mutable_descriptors(); },
+              [](PointCloud& cloud) { return cloud.descriptors(); },
+              [](PointCloud& cloud, int i) {
+                return cloud.mutable_descriptor(i);
+              },
+              [](PointCloud& cloud, int i) { return cloud.descriptor(i); });
+}
+
+GTEST_TEST(PointCloudTest, Fields) {
+  // Check zero-size.
+  {
+    PointCloud cloud(0, pc_flags::kXYZs);
+    EXPECT_EQ(0, cloud.size());
+  }
+
+  // Check basic requirements.
+  {
+    PointCloud cloud(1, pc_flags::kXYZs);
+    EXPECT_TRUE(cloud.has_xyzs());
+    EXPECT_TRUE(cloud.HasFields(pc_flags::kXYZs));
+    EXPECT_NO_THROW(cloud.RequireFields(pc_flags::kXYZs));
+    EXPECT_FALSE(cloud.HasFields(pc_flags::kDescriptorFPFH));
+    EXPECT_THROW(cloud.RequireFields(pc_flags::kDescriptorFPFH),
+                 std::runtime_error);
+  }
+
+  // Check with exact fields.
+  {
+    PointCloud cloud(1, pc_flags::kXYZs | pc_flags::kDescriptorCurvature);
+    EXPECT_TRUE(cloud.HasExactFields(
+        pc_flags::kXYZs | pc_flags::kDescriptorCurvature));
+    EXPECT_NO_THROW(cloud.RequireExactFields(
+        pc_flags::kXYZs | pc_flags::kDescriptorCurvature));
+    EXPECT_FALSE(cloud.HasExactFields(pc_flags::kXYZs));
+    EXPECT_THROW(cloud.RequireExactFields(pc_flags::kXYZs),
+                 std::runtime_error);
+  }
+
+  // Check invalid fields.
+  {
+    EXPECT_THROW(PointCloud(1, 0), std::runtime_error);
+    EXPECT_THROW(PointCloud(1, 100), std::runtime_error);
+    EXPECT_THROW(PointCloud(1, -100), std::runtime_error);
+  }
+
+  // Check with descriptors.
+  {
+    PointCloud cloud(1, pc_flags::kDescriptorCurvature);
+    EXPECT_FALSE(cloud.has_xyzs());
+    EXPECT_TRUE(cloud.has_descriptors());
+    EXPECT_TRUE(cloud.has_descriptors(pc_flags::kDescriptorCurvature));
+    EXPECT_FALSE(cloud.has_descriptors(pc_flags::kDescriptorFPFH));
+
+    // Negative tests for `has_descriptors`.
+    PointCloud simple_cloud(1, pc_flags::kXYZs);
+    EXPECT_FALSE(simple_cloud.has_descriptors());
+    EXPECT_FALSE(simple_cloud.has_descriptors(pc_flags::kDescriptorCurvature));
+
+    // Negative tests for construction.
+    EXPECT_THROW(PointCloud(1, pc_flags::kNone),
+                     std::runtime_error);
+    EXPECT_THROW(PointCloud(1, pc_flags::kDescriptorNone),
+                 std::runtime_error);
+  }
+}
+
+}  // namespace
+}  // namespace perception
+}  // namespace drake


### PR DESCRIPTION
This is a preliminary implementation for a point cloud.

The interface presently supports a minimum set of scalars (same as `Image` for now), and can be opened up to glass boxing at a later point.
It is also designed to be able to use other storage mechanisms, such as a `vtkPolyData` structure (see [here](https://github.com/EricCousineau-TRI/drake/blob/feature/point_cloud_vtk-wip/drake/perception/dev/point_cloud.cc#L82) for a proof-of-concept), or using a subset of PCL point cloud types (where `pcl::PointCloud<>::getMatrixXfMap` could work).

This only contains fields for XYZ and extra fields (to focus the review). Colors and normals (and possibly other fields) will be added in subsequent PRs (see [here](https://github.com/EricCousineau-TRI/drake/blob/feature/point_cloud-wip/drake/perception/point_cloud.h#L23) for an example).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7104)
<!-- Reviewable:end -->
