### PR TITLE
Add Maliput's RNDF implementation Loader class

### DIFF
--- a/drake/automotive/maliput/rndf/BUILD
+++ b/drake/automotive/maliput/rndf/BUILD
@@ -12,6 +12,35 @@ load("//tools:lint.bzl", "add_lint_tests")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "rndf",
+    srcs = [],
+    hdrs = [],
+    deps = [
+        ":builder",
+        ":lanes",
+        ":loader",
+    ],
+)
+
+drake_cc_library(
+    name = "loader",
+    srcs = [
+        "loader.cc",
+    ],
+    hdrs = [
+        "loader.h",
+    ],
+    deps = [
+        ":builder",
+        ":lanes",
+        "//drake/automotive/maliput/api",
+        "//drake/common",
+        "@ignition_math",
+        "@ignition_rndf",
+    ],
+)
+
+drake_cc_library(
     name = "builder",
     srcs = [
         "builder.cc",
@@ -67,6 +96,25 @@ drake_cc_library(
 
 # === test/ ===
 
+drake_cc_binary(
+    name = "rndf_load",
+    testonly = 1,
+    srcs = ["test/rndf_load.cc"],
+    add_test_rule = 1,
+    data = [
+        ":test_maps",
+    ],
+    test_rule_args = [
+        "-rndf_file",
+        "drake/automotive/maliput/rndf/test/maps/cross.rndf",
+    ],
+    test_rule_size = "small",
+    deps = [
+        ":loader",
+        "//drake/common:text_logging_gflags",
+    ],
+)
+
 drake_cc_googletest(
     name = "connection_test",
     deps = [
@@ -92,6 +140,26 @@ drake_cc_googletest(
     deps = [
         ":builder",
         "//drake/automotive/maliput/api/test_utilities",
+    ],
+)
+
+filegroup(
+    name = "test_maps",
+    srcs = glob([
+        "test/maps/*.rndf",
+    ]),
+)
+
+drake_cc_googletest(
+    name = "loader_test",
+    data = [
+        ":test_maps",
+    ],
+    deps = [
+        ":loader",
+        "//drake/automotive/maliput/api",
+        "//drake/automotive/maliput/api/test_utilities",
+        "//drake/common:find_resource",
     ],
 )
 

--- a/drake/automotive/maliput/rndf/loader.cc
+++ b/drake/automotive/maliput/rndf/loader.cc
@@ -1,0 +1,299 @@
+#include "drake/automotive/maliput/rndf/loader.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "ignition/math/SphericalCoordinates.hh"
+#include "ignition/math/Vector3.hh"
+#include "ignition/rndf/Exit.hh"
+#include "ignition/rndf/Lane.hh"
+#include "ignition/rndf/Perimeter.hh"
+#include "ignition/rndf/RNDF.hh"
+#include "ignition/rndf/RNDFNode.hh"
+#include "ignition/rndf/Segment.hh"
+#include "ignition/rndf/UniqueId.hh"
+#include "ignition/rndf/Waypoint.hh"
+#include "ignition/rndf/Zone.hh"
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/rndf/builder.h"
+#include "drake/automotive/maliput/rndf/connection.h"
+#include "drake/automotive/maliput/rndf/directed_waypoint.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+namespace {
+
+// Converts the given @p position in UTM (latitude/longitude) coordinates
+// to ENU (Cartesian) coordinates whose frame is located at @p origin.
+// @remarks As the underlying implementation is planar, the elevation
+// coordinate will be forced to 0.
+// @param origin frame origin in latitude / longitude coordinates.
+// @param position position in latitude / longitude coordinates to
+// be transformed into @p origin's frame.
+// @return @p position at @p origin frame in Cartesian coordinates.
+ignition::math::Vector3d ToGlobalCoordinates(
+    const ignition::math::SphericalCoordinates& origin,
+    const ignition::math::SphericalCoordinates& position) {
+  const ignition::math::Vector3d position_as_vector(
+      position.LatitudeReference().Radian(),
+      position.LongitudeReference().Radian(), position.ElevationReference());
+  ignition::math::Vector3d position_from_origin = origin.PositionTransform(
+      position_as_vector, ignition::math::SphericalCoordinates::SPHERICAL,
+      ignition::math::SphericalCoordinates::GLOBAL);
+  position_from_origin.Z() = 0;
+  return position_from_origin;
+}
+
+// Computes the lower left and upper right corners' coordinates of the
+// bounding box that comprises all the given @p segments. Coordinates
+// are expressed in the global Cartesian frame located at @p origin.
+// @param segments The Segment collection to compute a bounding box for.
+// @param origin The global Cartesian frame location in latitude / longitude
+// coordinates.
+// @return The computed bounding box as the pair of its minimum and maximum
+// coordinates in the global Cartesian frame.
+std::pair<ignition::math::Vector3d, ignition::math::Vector3d> BuildBoundingBox(
+    const std::vector<ignition::rndf::Segment>& segments,
+    const ignition::math::SphericalCoordinates& origin) {
+  std::vector<DirectedWaypoint> waypoints;
+  for (const ignition::rndf::Segment& segment : segments) {
+    for (const ignition::rndf::Lane& lane : segment.Lanes()) {
+      for (const ignition::rndf::Waypoint& waypoint : lane.Waypoints()) {
+        const ignition::math::Vector3d global_location =
+            ToGlobalCoordinates(origin, waypoint.Location());
+        waypoints.push_back(
+            DirectedWaypoint(ignition::rndf::UniqueId(), global_location,
+                             ignition::math::Vector3d::Zero, false, false));
+      }
+    }
+  }
+  return DirectedWaypoint::CalculateBoundingBox(waypoints);
+}
+
+// Extracts RNDF segment_lanes from @p segment, using the given lane
+// @p default_width when either it's not specified or it's zero. Coordinates
+// are expressed in the global Cartesian frame at @p origin.
+// @param segment The RNDF segment to extract data from.
+// @param origin The global Cartesian frame location in latitude / longitude
+// coordinates.
+// @param default_width The default width for segment lanes if a positive width
+// is not specified.
+// @return The collection of segment lanes as a vector of Connections.
+std::vector<Connection> ExtractSegmentLanes(
+    const ignition::rndf::Segment& segment,
+    const ignition::math::SphericalCoordinates& origin, double default_width) {
+  std::vector<Connection> segment_lanes;
+  for (const ignition::rndf::Lane& lane : segment.Lanes()) {
+    std::vector<DirectedWaypoint> lane_waypoints;
+    for (const ignition::rndf::Waypoint& waypoint : lane.Waypoints()) {
+      const ignition::math::Vector3d global_location =
+          ToGlobalCoordinates(origin, waypoint.Location());
+      lane_waypoints.push_back(DirectedWaypoint(
+          ignition::rndf::UniqueId(segment.Id(), lane.Id(), waypoint.Id()),
+          global_location, ignition::math::Vector3d::Zero, waypoint.IsEntry(),
+          waypoint.IsExit()));
+    }
+    double width = lane.Width();
+    if (width == 0.0) width = default_width;
+    const std::string id =
+        (std::to_string(segment.Id()) + "." + std::to_string(lane.Id()));
+    segment_lanes.push_back(Connection(id, lane_waypoints, width, false));
+  }
+  return segment_lanes;
+}
+
+// Extracts RNDF zone perimeter_waypoints from @p zone. Coordinates are
+// expressed in the global Cartesian frame at @p origin.
+// @param zone The RNDF zone to extract data from.
+// @param origin The global Cartesian frame location in latitude / longitude
+// coordinates.
+// @return The RNDF zone perimeter waypoints as a vector of DirectedWaypoints.
+std::vector<DirectedWaypoint> ExtractZonePerimeter(
+    const ignition::rndf::Zone& zone,
+    const ignition::math::SphericalCoordinates& origin) {
+  std::vector<DirectedWaypoint> perimeter_waypoints;
+  const ignition::rndf::Perimeter& perimeter = zone.Perimeter();
+  // Retrieves all perimeter waypoints in the global Cartesian frame.
+  for (const ignition::rndf::Waypoint& waypoint : perimeter.Points()) {
+    const ignition::math::Vector3d global_location =
+        ToGlobalCoordinates(origin, waypoint.Location());
+    const ignition::rndf::UniqueId id(zone.Id(), 0, waypoint.Id());
+    perimeter_waypoints.push_back(
+        DirectedWaypoint(id, global_location, ignition::math::Vector3d::Zero,
+                         waypoint.IsEntry(), waypoint.IsExit()));
+  }
+  return perimeter_waypoints;
+}
+
+// Computes the minimum Lane width for an intersection given the @p entry_id
+// and @p exit_id of the waypoints that define it, based on the widths of
+// the Lanes this intersection would connect.
+// @param rndf_info The RNDF map description.
+// @param entry_id The intersection's entry waypoint RNDF uid.
+// @param exit_id The intersection's exit waypoint RNDF uid.
+// @param default_width The default width for intersection lanes, if no nonzero
+// width was specified.
+// @return The minimum lane width for the intersection.
+// @pre The given @p entry_id is a valid lane waypoint uid within @p rndf_info.
+// @pre The given @p exit_id is a valid lane waypoint uid within @p rndf_info.
+// @warning This method will abort if preconditions are not met.
+double ComputeIntersectionWidth(const ignition::rndf::RNDF& rndf_info,
+                                const ignition::rndf::UniqueId& entry_id,
+                                const ignition::rndf::UniqueId& exit_id,
+                                double default_width) {
+  const ignition::rndf::RNDFNode* entry_node = rndf_info.Info(entry_id);
+  const ignition::rndf::RNDFNode* exit_node = rndf_info.Info(exit_id);
+  DRAKE_DEMAND(entry_node != nullptr);
+  DRAKE_DEMAND(exit_node != nullptr);
+  double width = std::numeric_limits<double>::infinity();
+  if (entry_node->Lane() != nullptr) {
+    width = std::min(entry_node->Lane()->Width(), width);
+  }
+  if (exit_node->Lane() != nullptr) {
+    width = std::min(exit_node->Lane()->Width(), width);
+  }
+  if (std::isinf(width) || width == 0) {
+    width = default_width;
+  }
+  return width;
+}
+
+// Computes the lane width on a per zone basis.
+//
+// As RNDF zones do not have a direct mapping to Maliput abstractions, fake
+// lanes connect every pair of entry and exit waypoints in the zone perimeter.
+// To that end, zone entry and exit waypoints are matched with their exit and
+// entry lane waypoints, respectively, and the minimum lane width that would
+// yield safe connections on each zone is computed and retrieved.
+// @param rndf_info The RNDF map description.
+// @param default_width The default width for zone lanes, if no nonzero width
+// was specified.
+// @return The mapping from RNDF zones uids to zone widths.
+std::map<int, double> ComputeZoneLaneWidths(
+    const ignition::rndf::RNDF& rndf_info, double default_width) {
+  std::map<int, double> lane_width_per_zone;
+  // Looks up the width of all the lanes that exit into zones.
+  for (const ignition::rndf::Segment& segment : rndf_info.Segments()) {
+    for (const ignition::rndf::Lane& lane : segment.Lanes()) {
+      for (const ignition::rndf::Exit& exit : lane.Exits()) {
+        const ignition::rndf::RNDFNode* node = rndf_info.Info(exit.EntryId());
+        DRAKE_DEMAND(node != nullptr);
+        if (node->Zone() != nullptr) {
+          double width = lane.Width();
+          if (lane_width_per_zone.count(node->Zone()->Id()) != 0) {
+            width = std::min(width, lane_width_per_zone[node->Zone()->Id()]);
+          }
+          lane_width_per_zone[node->Zone()->Id()] = width;
+        }
+      }
+    }
+  }
+  // Looks up the width of all the lanes that the zones exit into.
+  for (const ignition::rndf::Zone& zone : rndf_info.Zones()) {
+    for (const ignition::rndf::Exit& exit : zone.Perimeter().Exits()) {
+      const ignition::rndf::UniqueId& waypointId = exit.EntryId();
+      if (waypointId.Y() != 0) {
+        // Only lane waypoints must be taken into consideration.
+        const ignition::rndf::RNDFNode* node = rndf_info.Info(waypointId);
+        DRAKE_DEMAND(node != nullptr);
+        DRAKE_DEMAND(node->Lane() != nullptr);
+        double width = node->Lane()->Width();
+        if (lane_width_per_zone.count(zone.Id()) != 0) {
+          width = std::min(width, lane_width_per_zone[zone.Id()]);
+        }
+        lane_width_per_zone[zone.Id()] = width;
+      }
+    }
+    if (lane_width_per_zone.count(zone.Id()) == 0) {
+      lane_width_per_zone[zone.Id()] = default_width;
+    }
+  }
+  return lane_width_per_zone;
+}
+
+}  // namespace
+
+std::unique_ptr<const api::RoadGeometry> LoadFile(const std::string& filepath) {
+  RoadCharacteristics road_characteristics{};
+  return LoadFile(filepath, road_characteristics);
+}
+
+std::unique_ptr<const api::RoadGeometry> LoadFile(
+    const std::string& filepath,
+    const RoadCharacteristics& road_characteristics) {
+  // Attempts to load the given file as an RNDF.
+  const ignition::rndf::RNDF rndf_info(filepath);
+  DRAKE_THROW_UNLESS(rndf_info.Valid());
+
+  Builder builder(road_characteristics.linear_tolerance,
+                  road_characteristics.angular_tolerance);
+
+  // Gets the segments in the given RNDF.
+  const std::vector<ignition::rndf::Segment>& segments = rndf_info.Segments();
+  DRAKE_THROW_UNLESS(segments.size() > 0);
+  DRAKE_THROW_UNLESS(segments[0].Lanes().size() > 0);
+  DRAKE_THROW_UNLESS(segments[0].Lanes()[0].Waypoints().size() > 0);
+
+  // Gets the location of the first waypoint on the first lane of the first
+  // segment and uses it as the origin for Maliput's api::RoadGeometry Cartesian
+  // frame.
+  const ignition::math::SphericalCoordinates& origin_location =
+      segments[0].Lanes()[0].Waypoints()[0].Location();
+  const std::pair<ignition::math::Vector3d, ignition::math::Vector3d>
+      bounding_box = BuildBoundingBox(segments, origin_location);
+  builder.SetBoundingBox(bounding_box);
+
+  // Extracts all segments' lanes and creates the corresponding connections. All
+  // segments are built first, followed by zones, so that all waypoints are
+  // known to the Builder before going into further lane connections.
+  for (const ignition::rndf::Segment& segment : rndf_info.Segments()) {
+    std::vector<Connection> segment_lanes = ExtractSegmentLanes(
+        segment, origin_location, road_characteristics.default_width);
+    builder.CreateSegmentConnections(segment.Id(), &segment_lanes);
+  }
+
+  // Computes each zone's fake inner lanes.
+  const std::map<int, double> lane_width_per_zone =
+      ComputeZoneLaneWidths(rndf_info, road_characteristics.default_width);
+  // Extracts zone perimeter's waypoints and creates fake inner lanes between
+  // every entry and exit waypoint. Also connects the zone with the outgoing
+  // lanes.
+  for (const ignition::rndf::Zone& zone : rndf_info.Zones()) {
+    std::vector<DirectedWaypoint> perimeter_waypoints =
+        ExtractZonePerimeter(zone, origin_location);
+    builder.CreateConnectionsForZones(lane_width_per_zone.at(zone.Id()),
+                                      &perimeter_waypoints);
+    for (const ignition::rndf::Exit& exit : zone.Perimeter().Exits()) {
+      builder.CreateConnection(lane_width_per_zone.at(zone.Id()), exit.ExitId(),
+                               exit.EntryId());
+    }
+  }
+
+  // Iterates over each lane exit and creates the intersection lane that
+  // connects the corresponding exit and entry waypoints.
+  for (const ignition::rndf::Segment& segment : rndf_info.Segments()) {
+    for (const ignition::rndf::Lane& lane : segment.Lanes()) {
+      for (const ignition::rndf::Exit& exit : lane.Exits()) {
+        const double width =
+            ComputeIntersectionWidth(rndf_info, exit.EntryId(), exit.ExitId(),
+                                     road_characteristics.default_width);
+        builder.CreateConnection(width, exit.ExitId(), exit.EntryId());
+      }
+    }
+  }
+  // Builds and returns the api::RoadGeometry for the given RNDF description.
+  return builder.Build(api::RoadGeometryId{rndf_info.Name()});
+}
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/loader.h
+++ b/drake/automotive/maliput/rndf/loader.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+
+/// Holds common api::RoadGeometry characteristics needed to construct one.
+struct RoadCharacteristics {
+  RoadCharacteristics() = default;
+
+  /// Constructor for custom geometry characteristics.
+  /// @param default_width_in The default lane width in meters, used when either
+  /// no lane width or zero lane width was specified in the RNDF (as lane widths
+  /// are an optional non negative quantity in the RNDF format).
+  /// @param linear_tolerance_in The linear tolerance for lane geometries, in
+  /// radians.
+  /// @param angular_tolerance_in The angular tolerance for lane geometries, in
+  /// radians.
+  explicit RoadCharacteristics(double default_width_in,
+                               double linear_tolerance_in,
+                               double angular_tolerance_in)
+      : default_width(default_width_in),
+        linear_tolerance(linear_tolerance_in),
+        angular_tolerance(angular_tolerance_in) {}
+
+  /// Default width for RNDF Lanes, in meters.
+  double default_width{4.};
+  /// Linear tolerance for RNDF RoadGeometry, in radians.
+  double linear_tolerance{0.01};
+  /// Angular tolerance for RNDF RoadGeometry, in radians.
+  double angular_tolerance{0.01 * M_PI};
+};
+
+/// Loads a given RNDF at @p filepath and builds an equivalent
+/// api::RoadGeometry with the given @p road_characteristics.
+///
+/// RNDF waypoints are given in UTM (latitude / longitude) coordinates.
+/// In the resulting api::RoadGeometry, they are mapped to ENU (Cartesian)
+/// coordinates whose origin coincides with the location of waypoint '1.1.1'.
+/// Note that due to the planar nature of the underlying api::RoadGeometry
+/// implementation, the elevation coordinate will be forced to 0.
+///
+/// @param filepath The RNDF path.
+/// @param road_characteristics The common geometrical aspects to comply with
+/// when building the api::RoadGeometry.
+/// @return The built api::RoadGeometry.
+/// @throw std::runtime_error When the given file is not a valid RNDF.
+/// @throw std::runtime_error When the given RNDF doesn't have at least
+/// a single lane segment with one or more waypoints. RNDFs containing
+/// only zones are not supported.
+std::unique_ptr<const api::RoadGeometry> LoadFile(
+    const std::string& filepath,
+    const RoadCharacteristics& road_characteristics);
+
+/// Loads a given RNDF at @p filepath and builds an equivalent
+/// api::RoadGeometry.using default RoadCharacteristics.
+///
+/// This is an overloaded function provided for convenience. See
+/// LoadFile(const std::string&, const RoadCharacteristics&).
+std::unique_ptr<const api::RoadGeometry> LoadFile(
+    const std::string& filepath);
+
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/spline_lane.h
+++ b/drake/automotive/maliput/rndf/spline_lane.h
@@ -137,7 +137,7 @@ class SplineLane : public Lane {
 
   // TODO(@agalbachicar) Not implemented yet.
   api::HBounds do_elevation_bounds(double, double) const override {
-    return api::HBounds(0., 0.);
+    return api::HBounds(0., 20.);
   }
 
   // Computes the lane_bounds taking into account the Lane::width. Based

--- a/drake/automotive/maliput/rndf/test/loader_test.cc
+++ b/drake/automotive/maliput/rndf/test/loader_test.cc
@@ -1,0 +1,396 @@
+#include "drake/automotive/maliput/rndf/loader.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
+#include "drake/common/find_resource.h"
+
+namespace drake {
+namespace maliput {
+namespace rndf {
+namespace {
+
+// Tolerance for floating point number comparison, loose enough
+// to accommodate for the discrepancies that arise due to the
+// numerical approximations involved in dealing with splines.
+const double kTolerance = 1e-3;
+
+// A passive data structure to hold all RNDF related
+// information that tests require.
+struct SingleLaneRndfDescription {
+  // A mapping from LaneIds to a tuple whose elements
+  // are: global position at the start of the lane,
+  // global position at the end of the lane and lane
+  // bounds of the lane.
+  typedef std::map<api::LaneId,
+                   std::tuple<api::GeoPosition, api::GeoPosition, api::RBounds>>
+      LaneTable;
+
+  // A collection of tuples whose elements describe A-to-B branch
+  // connections between lanes.
+  typedef std::vector<std::tuple<api::LaneId, api::LaneId>> BranchList;
+
+  SingleLaneRndfDescription(const std::string& file_path_in,
+                            const LaneTable& lane_table_in,
+                            const BranchList& branch_list_in)
+      : file_path(file_path_in),
+        lane_table(lane_table_in),
+        branch_list(branch_list_in) {}
+
+  // A relative path to the map file, relative to Drake's
+  // repository root (so that drake::common::FindResource() can
+  // find it).
+  std::string file_path{};
+  // A table describing the map's lane layout.
+  LaneTable lane_table{};
+  // A list of the map's lane interconnections.
+  BranchList branch_list{};
+};
+
+// RNDF test fixture parameterized on map description.
+class SingleLaneRNDFLoaderTest
+    : public ::testing::TestWithParam<SingleLaneRndfDescription> {};
+
+// Tests that the loaded lanes match the RNDF description.
+TEST_P(SingleLaneRNDFLoaderTest, LoadTest) {
+  const SingleLaneRndfDescription& map_description = GetParam();
+  const std::string file_path = FindResourceOrThrow(map_description.file_path);
+  const auto road_geometry = LoadFile(file_path);
+  ASSERT_EQ(road_geometry->num_junctions(), map_description.lane_table.size());
+  std::map<api::LaneId, std::vector<api::LaneId>> ongoing_lanes_per_lane;
+  for (int i = 0; i < road_geometry->num_junctions(); ++i) {
+    const api::Junction* junction = road_geometry->junction(i);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_EQ(segment->num_lanes(), 1);
+    const api::Lane* lane = segment->lane(0);
+    ASSERT_TRUE(map_description.lane_table.count(lane->id()))
+        << "No " << lane->id().string() << " lane was found";
+    api::RBounds lane_bounds;
+    api::GeoPosition start_position, end_position;
+    std::tie(start_position, end_position, lane_bounds) =
+        map_description.lane_table.at(lane->id());
+    EXPECT_NEAR(lane->lane_bounds(0).min(), lane_bounds.min(), kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(0).max(), lane_bounds.max(), kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).min(), lane_bounds.min(),
+                kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).max(), lane_bounds.max(),
+                kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)), start_position,
+        kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
+        end_position, kTolerance));
+    // Populate ongoing lanes map for further testing.
+    const api::LaneEndSet* ongoing_branches =
+        lane->GetOngoingBranches(api::LaneEnd::kFinish);
+    std::vector<api::LaneId>& ongoing_lanes =
+        ongoing_lanes_per_lane[lane->id()];
+    for (int j = 0; j < ongoing_branches->size(); ++j) {
+      ongoing_lanes.push_back(ongoing_branches->get(j).lane->id());
+    }
+  }
+  for (auto& branch : map_description.branch_list) {
+    const api::LaneId a_side_lane_id(std::get<0>(branch));
+    const api::LaneId b_side_lane_id(std::get<1>(branch));
+    ASSERT_TRUE(ongoing_lanes_per_lane.count(a_side_lane_id));
+    const std::vector<api::LaneId>& ongoing_lanes =
+        ongoing_lanes_per_lane.at(a_side_lane_id);
+    EXPECT_TRUE(std::find(ongoing_lanes.begin(), ongoing_lanes.end(),
+                          b_side_lane_id) != ongoing_lanes.end());
+  }
+}
+
+// Returns a collection of single lane RNDF map descriptions for
+// testing parameterization.
+std::vector<SingleLaneRndfDescription> GetSingleLaneRNDFsToTest() {
+  std::vector<SingleLaneRndfDescription> maps{
+      SingleLaneRndfDescription{
+          // T intersection map description
+          //
+          // 1.1.1  2.1.3      1.1.3
+          //   * > > * > * > > > *
+          //         ^  / 1.1.2
+          //         ^ /
+          //         ^/
+          //         * 2.1.2
+          //         ^
+          //         ^
+          //         ^
+          //         * 2.1.1
+          //
+          // For reference:
+          //   -'^' and '>' represent lane's direction.
+          //   -'/' represents crossing intersections.
+          //   - '*' represents a lane's waypoint.
+          "drake/automotive/maliput/rndf/test/maps/t_intersection.rndf",
+          {
+              {api::LaneId{"l:1.1.1-1.1.2"},
+               std::make_tuple(
+                   api::GeoPosition(0.0, 0.0, 0.0),
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:1.1.2-1.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::GeoPosition(199.982, 0.000553, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.1-2.1.2"},
+               std::make_tuple(
+                   api::GeoPosition(99.9914, -99.9893, 0.0),
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.2-2.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::GeoPosition(99.9911, 0.000138, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.2-1.1.2"},
+               std::make_tuple(
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))}  // 13 feet wide
+          },
+          {
+              std::make_tuple(api::LaneId{"l:2.1.1-2.1.2"},
+                              api::LaneId{"l:2.1.2-1.1.2"}),
+              std::make_tuple(api::LaneId{"l:2.1.2-1.1.2"},
+                              api::LaneId{"l:1.1.2-1.1.3"}),
+          }},
+      SingleLaneRndfDescription{
+          // Cross map description
+          //
+          //               * 2.1.4
+          //               ^
+          //               ^
+          //               ^
+          //               * 2.1.3
+          //             / ^
+          // 1.1.1      /  ^  1.1.3
+          //   * > > > * > > > * > > > *
+          //        1.1.2  ^  /       1.1.4
+          //               * /
+          //               ^ 2.1.2
+          //               ^
+          //               ^
+          //               * 2.1.1
+          // For reference:
+          //   -'^' and '>' represent lane's direction.
+          //   - '/' represents crossing intersections.
+          //   - '*' represents a lane's waypoint.
+          "drake/automotive/maliput/rndf/test/maps/cross.rndf",
+          {
+              {api::LaneId{"l:1.1.1-1.1.2"},
+               std::make_tuple(
+                   api::GeoPosition(0.0, 0.0, 0.0),
+                   api::GeoPosition(96.0441, 0.000127, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:1.1.2-1.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(96.0441, 0.000127, 0.0),
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:1.1.3-1.1.4"},
+               std::make_tuple(
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::GeoPosition(199.982, 0.000553, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.1-2.1.2"},
+               std::make_tuple(
+                   api::GeoPosition(99.9908, 99.9896, 0.0),
+                   api::GeoPosition(99.9911, 3.98202, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.2-2.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(99.9911, 3.98202, 0.0),
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.3-2.1.4"},
+               std::make_tuple(
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::GeoPosition(99.9914, -99.9893, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:1.1.2-2.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(96.0441, 0.000127, 0.0),
+                   api::GeoPosition(99.9911, -3.98174, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))},  // 13 feet wide
+              {api::LaneId{"l:2.1.2-1.1.3"},
+               std::make_tuple(
+                   api::GeoPosition(99.9911, 3.98202, 0.0),
+                   api::GeoPosition(103.938, 0.000149, 0.0),
+                   api::RBounds(-3.9624 / 2, 3.9624 / 2))}  // 13 feet wide
+          },
+          {
+              std::make_tuple(api::LaneId{"l:1.1.1-1.1.2"},
+                              api::LaneId{"l:1.1.2-2.1.3"}),
+              std::make_tuple(api::LaneId{"l:1.1.2-2.1.3"},
+                              api::LaneId{"l:2.1.3-2.1.4"}),
+              std::make_tuple(api::LaneId{"l:2.1.1-2.1.2"},
+                              api::LaneId{"l:2.1.2-1.1.3"}),
+              std::make_tuple(api::LaneId{"l:2.1.2-1.1.3"},
+                              api::LaneId{"l:1.1.3-1.1.4"}),
+          }}};
+  return maps;
+}
+
+INSTANTIATE_TEST_CASE_P(ParameterizedSingleLaneRNDFLoaderTest,
+                        SingleLaneRNDFLoaderTest,
+                        ::testing::ValuesIn(GetSingleLaneRNDFsToTest()));
+
+// Tests a multilane segment RNDF.
+//
+// 1.2.1       1.2.2       1.2.3
+//   * > > > > > * > > > > > *
+//                            |
+//               * > > > > > > * > > > > > *
+//             1.1.1         1.1.2        1.1.3
+//
+// For reference:
+//   - '>' represents lane's direction.
+//   - '*' represents a lane's waypoint.
+GTEST_TEST(MultiLaneRNDFLoaderTest, LoadTest) {
+  static const char* const kTwoLaneRNDFPath =
+      "drake/automotive/maliput/rndf/test/maps/two_lane.rndf";
+  static const double kLaneWidth = 3.9624;
+  const std::string file_path = FindResourceOrThrow(kTwoLaneRNDFPath);
+  const auto road_geometry = LoadFile(file_path);
+  ASSERT_EQ(road_geometry->num_junctions(), 4);
+
+  {
+    // Checks the first segment, which holds a single lane (pictured on the
+    // left side).
+    const api::Junction* junction = road_geometry->junction(0);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_EQ(segment->num_lanes(), 1);
+    const api::Lane* lane = segment->lane(0);
+    EXPECT_NEAR(lane->lane_bounds(0).min(), -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(0).max(), kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).min(), -kLaneWidth / 2,
+                kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).max(), kLaneWidth / 2,
+                kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
+        api::GeoPosition(-199.982, 4.42486, 0.0), kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
+        api::GeoPosition(0, 4.42486, 0.0), kTolerance));
+  }
+
+  {
+    // Checks the second segment, which holds two lanes (pictured in the
+    // middle).
+    const api::Junction* junction = road_geometry->junction(1);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_EQ(segment->num_lanes(), 2);
+    const api::Lane* first_lane = segment->lane(0);
+    EXPECT_NEAR(first_lane->lane_bounds(0).min(), -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(first_lane->lane_bounds(0).max(), kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(first_lane->lane_bounds(first_lane->length()).min(),
+                -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(first_lane->lane_bounds(first_lane->length()).max(),
+                kLaneWidth / 2, kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        first_lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
+        api::GeoPosition(0.0, 0.0, 0.0), kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        first_lane->ToGeoPosition(
+            api::LanePosition(first_lane->length(), 0.0, 0.0)),
+        api::GeoPosition(81.3524, 0.0, 0.0), kTolerance));
+    const api::Lane* second_lane = segment->lane(1);
+    EXPECT_NEAR(second_lane->lane_bounds(0).min(), -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(second_lane->lane_bounds(0).max(), kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(second_lane->lane_bounds(second_lane->length()).min(),
+                -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(second_lane->lane_bounds(second_lane->length()).max(),
+                kLaneWidth / 2, kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        second_lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
+        api::GeoPosition(0.0, 4.4244, 0.0), kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        second_lane->ToGeoPosition(
+            api::LanePosition(second_lane->length(), 0.0, 0.0)),
+        api::GeoPosition(79.3789, 4.4244, 0.0), kTolerance));
+  }
+
+  {
+    // Checks the third segment, which holds a single lane (pictured on the
+    // right).
+    const api::Junction* junction = road_geometry->junction(2);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_EQ(segment->num_lanes(), 1);
+    const api::Lane* lane = segment->lane(0);
+    EXPECT_NEAR(lane->lane_bounds(0).min(), -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(0).max(), kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).min(), -kLaneWidth / 2,
+                kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).max(), kLaneWidth / 2,
+                kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
+        api::GeoPosition(81.3524, 0.0, 0.0), kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
+        api::GeoPosition(199.982, 0.0, 0.0), kTolerance));
+  }
+
+  {
+    // Checks the intersection segment, that holds a single lane.
+    const api::Junction* junction = road_geometry->junction(3);
+    ASSERT_EQ(junction->num_segments(), 1);
+    const api::Segment* segment = junction->segment(0);
+    ASSERT_EQ(segment->num_lanes(), 1);
+    const api::Lane* lane = segment->lane(0);
+    EXPECT_NEAR(lane->lane_bounds(0).min(), -kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(0).max(), kLaneWidth / 2, kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).min(), -kLaneWidth / 2,
+                kTolerance);
+    EXPECT_NEAR(lane->lane_bounds(lane->length()).max(), kLaneWidth / 2,
+                kTolerance);
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(0.0, 0.0, 0.0)),
+        api::GeoPosition(79.3789, 4.4244, 0.0), kTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition(api::LanePosition(lane->length(), 0.0, 0.0)),
+        api::GeoPosition(81.3524, 0.0, 0.0), kTolerance));
+
+    const api::LaneEndSet* incoming_branches =
+        lane->GetOngoingBranches(api::LaneEnd::kStart);
+    ASSERT_EQ(incoming_branches->size(), 1);
+    EXPECT_EQ(incoming_branches->get(0).lane->id(),
+              api::LaneId{"l:1.2.2-1.2.3"});
+    const api::LaneEndSet* outgoing_branches =
+        lane->GetOngoingBranches(api::LaneEnd::kFinish);
+    ASSERT_EQ(outgoing_branches->size(), 1);
+    EXPECT_EQ(outgoing_branches->get(0).lane->id(),
+              api::LaneId{"l:1.1.2-1.1.3"});
+  }
+}
+
+// Tests that the Loader throws upon loading a zones only RNDF.
+GTEST_TEST(RNDFLoaderFailureTests, ZonesOnlyRNDFTest) {
+  static const char* const kZonesRNDFPath =
+      "drake/automotive/maliput/rndf/test/maps/zones.rndf";
+  const std::string file_path = FindResourceOrThrow(kZonesRNDFPath);
+  ASSERT_THROW(LoadFile(file_path), std::runtime_error);
+}
+
+// Tests that the Loader throws upon loading an invalid RNDF.
+GTEST_TEST(RNDFLoaderFailureTests, InvalidRNDFTest) {
+  ASSERT_THROW(LoadFile("not-a-valid-rndf-path"), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace rndf
+}  // namespace maliput
+}  // namespace drake

--- a/drake/automotive/maliput/rndf/test/maps/cross.rndf
+++ b/drake/automotive/maliput/rndf/test/maps/cross.rndf
@@ -1,0 +1,31 @@
+RNDF_name   Cross
+num_segments   2
+num_zones   0
+format_version   1.0
+segment   1
+num_lanes   1
+segment_name   s1
+lane   1.1
+num_waypoints   4
+lane_width   13
+exit   1.1.2   2.1.3
+1.1.1   10.000000   64.999088
+1.1.2   10.000000   64.999964
+1.1.3   10.000000   65.000036
+1.1.4   10.000000   65.000912
+end_lane
+end_segment
+segment   2
+num_lanes   1
+segment_name   s2
+lane   2.1
+num_waypoints   4
+lane_width   13
+exit   2.1.2   1.1.3
+2.1.1   10.000904   65.000000
+2.1.2   10.000036   65.000000
+2.1.3   9.999964   65.000000
+2.1.4   9.999096   65.000000
+end_lane
+end_segment
+end_file

--- a/drake/automotive/maliput/rndf/test/maps/t_intersection.rndf
+++ b/drake/automotive/maliput/rndf/test/maps/t_intersection.rndf
@@ -1,0 +1,28 @@
+RNDF_name   T_intersection_in
+num_segments   2
+num_zones   0
+format_version   1.0
+segment   1
+num_lanes   1
+segment_name   s1
+lane   1.1
+num_waypoints   3
+lane_width   13
+1.1.1   10.000000   64.999088
+1.1.2   10.000000   65.000036
+1.1.3   10.000000   65.000912
+end_lane
+end_segment
+segment   2
+num_lanes   1
+segment_name   s2
+lane   2.1
+num_waypoints   3
+lane_width   13
+exit   2.1.2   1.1.2
+2.1.1   9.999096   65.000000
+2.1.2   9.999964   65.000000
+2.1.3   10.000000   65.000000
+end_lane
+end_segment
+end_file

--- a/drake/automotive/maliput/rndf/test/maps/two_lane.rndf
+++ b/drake/automotive/maliput/rndf/test/maps/two_lane.rndf
@@ -1,0 +1,24 @@
+RNDF_name       TwoLaneStreet
+num_segments    1
+num_zones       0
+format_version  1.0
+segment 1
+num_lanes       2
+segment_name    s1
+lane    1.1
+num_waypoints   3
+lane_width      13
+1.1.1   10.000000       65.000000
+1.1.2   10.000000       65.000742
+1.1.3   10.000000       65.001824
+end_lane
+lane    1.2
+num_waypoints   3
+lane_width      13
+exit   1.2.3   1.1.2
+1.2.1   10.000040       64.998176
+1.2.2   10.000040       65.000000
+1.2.3   10.000040       65.000724
+end_lane
+end_segment
+end_file

--- a/drake/automotive/maliput/rndf/test/maps/zones.rndf
+++ b/drake/automotive/maliput/rndf/test/maps/zones.rndf
@@ -1,0 +1,18 @@
+RNDF_name       Parking_Lot
+num_segments    0
+num_zones       1
+format_version  1.0
+zone            1
+num_spots       0
+zone_name       Parking_Lot
+perimeter       1.0
+num_perimeterpoints    6
+1.0.1   38.872271       -77.203339
+1.0.2   38.872258       -77.202804
+1.0.3   38.872264       -77.202315
+1.0.4   38.871959       -77.202309
+1.0.5   38.871948       -77.203136
+1.0.6   38.871947       -77.203331
+end_perimeter
+end_zone
+end_file

--- a/drake/automotive/maliput/rndf/test/rndf_load.cc
+++ b/drake/automotive/maliput/rndf/test/rndf_load.cc
@@ -1,0 +1,34 @@
+// Attempts to load a RNDF file as input and build a RNDF road geometry.
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "drake/automotive/maliput/rndf/loader.h"
+#include "drake/common/text_logging.h"
+
+namespace rndf = drake::maliput::rndf;
+
+DEFINE_string(rndf_file, "", "RNDF input file defining a RNDF road geometry");
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_rndf_file.empty()) {
+    drake::log()->error("No input file!");
+    return 1;
+  }
+  drake::log()->info("Loading '{}'.", FLAGS_rndf_file);
+  const auto road_geometry = rndf::LoadFile(FLAGS_rndf_file);
+  const std::vector<std::string> failures = road_geometry->CheckInvariants();
+
+  if (!failures.empty()) {
+    for (const auto& f : failures) {
+      drake::log()->error(f);
+    }
+    return 1;
+  }
+
+  return 0;
+}

--- a/drake/automotive/maliput/rndf/test/spline_helpers_test.cc
+++ b/drake/automotive/maliput/rndf/test/spline_helpers_test.cc
@@ -500,12 +500,12 @@ GTEST_TEST(RNDFMakeBezierCurveMonotonicTest, CaseObliqueNonConvexConnection) {
                                             p0,
                                             kLinearTolerance));
   EXPECT_TRUE(test::IsIgnitionVector3dClose(output_bezier_points[1],
-                                            ignition::math::Vector3d(5.0,
-                                              5.0,
+                                            ignition::math::Vector3d(0.5,
+                                              9.5,
                                               0.0),
                                             kLinearTolerance));
   EXPECT_TRUE(test::IsIgnitionVector3dClose(output_bezier_points[2],
-                                            ignition::math::Vector3d(-5.0,
+                                            ignition::math::Vector3d(-0.5,
                                               0.0,
                                               0.0),
                                             kLinearTolerance));

--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -38,6 +38,27 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "rndf_to_obj",
+    srcs = ["rndf_to_obj.cc"],
+    add_test_rule = 1,
+    data = [
+        "//drake/automotive/maliput/rndf:test_maps",
+    ],
+    test_rule_args = [
+        "-rndf_file",
+        "drake/automotive/maliput/rndf/test/maps/t_intersection.rndf",
+        "-obj_file",
+        "t_intersection",
+    ],
+    test_rule_size = "small",
+    deps = [
+        ":utility",
+        "//drake/automotive/maliput/rndf",
+        "//drake/common:text_logging_gflags",
+    ],
+)
+
 # === test/ ===
 
 filegroup(

--- a/drake/automotive/maliput/utility/rndf_to_obj.cc
+++ b/drake/automotive/maliput/utility/rndf_to_obj.cc
@@ -1,0 +1,47 @@
+// Takes a RNDF file as input, builds the resulting RNDF road geometry and
+// renders the road surface, saved as a WaveFront OBJ output file.
+#include <gflags/gflags.h>
+
+#include "drake/automotive/maliput/rndf/loader.h"
+#include "drake/automotive/maliput/utility/generate_obj.h"
+#include "drake/common/text_logging.h"
+#include "drake/common/text_logging_gflags.h"
+
+namespace rndf = drake::maliput::rndf;
+namespace utility = drake::maliput::utility;
+
+DEFINE_string(rndf_file, "", "RNDF input file");
+DEFINE_string(obj_dir, ".", "Directory to contain rendered road surface");
+DEFINE_string(obj_file, "", "Basename for output Wavefront OBJ and MTL files");
+DEFINE_double(max_grid_unit, utility::ObjFeatures().max_grid_unit,
+              "Maximum size of a grid unit in the rendered mesh covering the"
+              " road surface");
+DEFINE_double(min_grid_resolution, utility::ObjFeatures().min_grid_resolution,
+              "Minimum number of grid-units in either lateral or longitudinal"
+              " direction in the rendered mesh covering the road surface");
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  drake::logging::HandleSpdlogGflags();
+
+  if (FLAGS_rndf_file.empty()) {
+    drake::log()->critical("No input file specified.");
+    return 1;
+  }
+  if (FLAGS_obj_file.empty()) {
+    drake::log()->critical("No output file specified.");
+    return 1;
+  }
+
+  drake::log()->info("Loading road geometry.");
+  const auto road_geometry = rndf::LoadFile(FLAGS_rndf_file);
+
+  utility::ObjFeatures features;
+  features.max_grid_unit = FLAGS_max_grid_unit;
+  features.min_grid_resolution = FLAGS_min_grid_resolution;
+
+  drake::log()->info("Generating OBJ.");
+  utility::GenerateObjFile(road_geometry.get(), FLAGS_obj_dir, FLAGS_obj_file,
+                           features);
+  return 0;
+}


### PR DESCRIPTION
This pull request adds Maliput's RNDF implementation **Loader** class, that leverages the `ignition-rndf` external library and the **Builder** class (introduced by #6884 and #6885) to parse an actual RNDF file and build a RoadGeometry, respectively. 

Below, the classic DARPA RNDF example is shown as rendered on `drake_visualizer`.

![darpa_full](https://user-images.githubusercontent.com/13500507/30865812-fcdf59f4-a2ad-11e7-8898-bbf78bd0d5d3.png)

Note that this is the last pull request of the Maliput's RNDF implementation series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7107)
<!-- Reviewable:end -->
