### PR TITLE
Fix up OSX-specific clang complaint

### DIFF
--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -782,7 +782,7 @@ TEST_F(DiagramTest, SubclassTransmogrificationTest) {
   // Diagram subclasses that declare a specific SystemTypeTag but then use a
   // subclass at runtime will fail-fast.
   class SubclassOfFeedbackDiagram : public FeedbackDiagram<double> {};
-  const SubclassOfFeedbackDiagram subclass_dut;
+  const SubclassOfFeedbackDiagram subclass_dut{};
   EXPECT_THROW(({
     try {
       subclass_dut.ToAutoDiffXd();


### PR DESCRIPTION
This might be an elcapitan-specific bug in clang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7110)
<!-- Reviewable:end -->
