### PR TITLE
Tidy up name preservation, take 2

### DIFF
--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -58,10 +58,6 @@ void PidControlledSystem<T>::Initialize(
     const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd) {
   DRAKE_DEMAND(plant != nullptr);
 
-  if (plant->get_name().empty()) {
-    plant->set_name("plant");
-  }
-
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
   DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -120,18 +120,6 @@ void PidController<T>::CalcControl(const Context<T>& context,
        (ki_.array() * state_block.array()).matrix()));
 }
 
-// Adds a simple record-based representation of the PID controller to @p dot.
-template <typename T>
-void PidController<T>::GetGraphvizFragment(std::stringstream* dot) const {
-  std::string name = this->get_name();
-  if (name.empty()) {
-    name = "PID Controller";
-  }
-  *dot << this->GetGraphvizId() << " [shape=record, label=\"" << name;
-  *dot << " | { {<u0> x |<u1> x_d} |<y0> y}";
-  *dot << "\"];" << std::endl;
-}
-
 }  // namespace controllers
 }  // namespace systems
 }  // namespace drake

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -178,13 +178,6 @@ class PidController : public StateFeedbackControllerInterface<T>,
   }
 
  protected:
-  /**
-   * Appends to @p dot a simplified Graphviz representation of the PID
-   * controller, since the internal wiring is unimportant and hard for human
-   * viewers to parse.
-   */
-  void GetGraphvizFragment(std::stringstream* dot) const override;
-
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override;
 

--- a/drake/systems/controllers/test/pid_controlled_system_test.cc
+++ b/drake/systems/controllers/test/pid_controlled_system_test.cc
@@ -154,18 +154,6 @@ class PidControlledSystemTest : public ::testing::Test {
   std::unique_ptr<Diagram<double>> diagram_;
 };
 
-// Tests that the PidController assigns default names to the plant.
-TEST_F(PidControlledSystemTest, DefaultNamesAssigned) {
-  auto plant = std::make_unique<TestPlantWithMinOutputs>();
-  auto plant_ptr = plant.get();
-  const int state_size = plant->get_output_port(0).size();
-
-  PidControlledSystem<double> controller(
-      std::move(plant), MatrixX<double>::Identity(state_size, state_size),
-      Kp_, Ki_, Kd_);
-  EXPECT_EQ("plant", plant_ptr->get_name());
-}
-
 // Tests that the PidController preserves the names of the plant.
 TEST_F(PidControlledSystemTest, ExistingNamesRespected) {
   auto plant = std::make_unique<TestPlantWithMinOutputs>();

--- a/drake/systems/controllers/test/pid_controller_test.cc
+++ b/drake/systems/controllers/test/pid_controller_test.cc
@@ -97,14 +97,6 @@ TEST_F(PidControllerTest, GetterVectorKd) {
   EXPECT_THROW(controller.get_Kd_singleton(), std::runtime_error);
 }
 
-TEST_F(PidControllerTest, Graphviz) {
-  const std::string dot = controller_.GetGraphvizString();
-  EXPECT_NE(
-      std::string::npos,
-      dot.find("label=\"PID Controller | { {<u0> x |<u1> x_d} |<y0> y}\""))
-      << dot;
-}
-
 // Evaluates the output and asserts correctness.
 TEST_F(PidControllerTest, CalcOutput) {
   ASSERT_NE(nullptr, context_);

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -525,9 +525,7 @@ class Diagram : public System<T>,
     *dot << "subgraph cluster" << id << "diagram" " {" << std::endl;
     *dot << "color=black" << std::endl;
     *dot << "concentrate=true" << std::endl;
-    std::string name = this->get_name();
-    if (name.empty()) name = std::to_string(id);
-    *dot << "label=\"" << name << "\";" << std::endl;
+    *dot << "label=\"" << this->get_name() << "\";" << std::endl;
 
     // Add a cluster for the input port nodes.
     *dot << "subgraph cluster" << id << "inputports" << " {" << std::endl;
@@ -1177,13 +1175,6 @@ class Diagram : public System<T>,
           template Convert<NewType>(*old_system);
       DRAKE_DEMAND(new_system != nullptr);
 
-      // Scalar conversion preserves the name; however, if DiagramBuilder
-      // assigned a default name that includes the memory address, we will
-      // update it here to reflect the new memory address.
-      if (old_system->get_name() == old_system->GetMemoryObjectName()) {
-        new_system->set_name(new_system->GetMemoryObjectName());
-      }
-
       // Update our mapping and take ownership.
       old_to_new_map[old_system.get()] = new_system.get();
       new_systems.push_back(std::move(new_system));
@@ -1488,9 +1479,6 @@ class Diagram : public System<T>,
     for (const auto& system : registered_systems_) {
       const std::string& name = system->get_name();
       if (name.empty()) {
-        // This can only happen if someone blanks out the name *after* adding
-        // it to DiagramBuilder; if an empty name is given to DiagramBuilder,
-        // a default non-empty name is automatically assigned.
         log()->error("Subsystem of type {} has no name",
                      NiceTypeName::Get(*system));
         // We skip names.insert here, so that the return value will be false.

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -36,9 +36,6 @@ class DiagramBuilder {
   /// pointer to the System, which will remain valid for the lifetime of the
   /// Diagram built by this builder.
   ///
-  /// If the system's name is unset, sets it to System::GetMemoryObjectName()
-  /// as a default in order to have unique names within the diagram.
-  ///
   /// @code
   ///   DiagramBuilder<T> builder;
   ///   auto foo = builder.AddSystem(std::make_unique<Foo<T>>());
@@ -47,9 +44,6 @@ class DiagramBuilder {
   /// @tparam S The type of system to add.
   template<class S>
   S* AddSystem(std::unique_ptr<S> system) {
-    if (system->get_name().empty()) {
-      system->set_name(system->GetMemoryObjectName());
-    }
     S* raw_sys_ptr = system.get();
     systems_.insert(raw_sys_ptr);
     registered_systems_.push_back(std::move(system));

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -385,27 +385,26 @@ class LeafSystem : public System<T> {
   /// records. For instance, a leaf system with 2 inputs and 1 output is:
   ///
   /// @verbatim
-  /// 123456 [shape= record, label="name | {<u0> 0 |<y0> 0} | {<u1> 1 | }"];
+  /// 123456 [shape=record,
+  ///   label="name | type | {<u0> 0 |<y0> 0} | {<u1> 1 | }"];
   /// @endverbatim
   ///
   /// which looks like:
   ///
   /// @verbatim
-  /// +------------+----+
-  /// | name  | u0 | u1 |
-  /// |       | y0 |    |
-  /// +-------+----+----+
+  /// +------+------+----+----+
+  /// | name | type | u0 | u1 |
+  /// |      |      | y0 |    |
+  /// +------+------+----+----+
   /// @endverbatim
   void GetGraphvizFragment(std::stringstream* dot) const override {
     // Use the this pointer as a unique ID for the node in the dotfile.
     const int64_t id = this->GetGraphvizId();
-    std::string name = this->get_name();
-    if (name.empty()) {
-      name = this->GetMemoryObjectName();
-    }
 
     // Open the attributes and label.
-    *dot << id << " [shape=record, label=\"" << name << "|{";
+    *dot << id << " [shape=record, label=\""
+         << this->get_name() << "|"
+         << this->GetMemoryObjectName() << "|{";
 
     // Append input ports to the label.
     // TODO(david-german-tri): Provide a way to customize port names.

--- a/drake/systems/framework/system.cc
+++ b/drake/systems/framework/system.cc
@@ -1,19 +1,22 @@
 #include "drake/systems/framework/system.h"
 
+#include <atomic>
 #include <iomanip>
 #include <ios>
 #include <regex>
 
 #include "drake/common/default_scalars.h"
+#include "drake/common/never_destroyed.h"
+
+using std::setfill;
+using std::setw;
+using std::hex;
 
 namespace drake {
 namespace systems {
 
 std::string SystemImpl::GetMemoryObjectName(
     const std::string& nice_type_name, int64_t address) {
-  using std::setfill;
-  using std::setw;
-  using std::hex;
 
   // Remove the template parameter(s).
   const std::string type_name_without_templates = std::regex_replace(
@@ -26,6 +29,20 @@ std::string SystemImpl::GetMemoryObjectName(
   // Append the address spelled like "@0123456789abcdef".
   std::ostringstream result;
   result << default_name << '@' << setfill('0') << setw(16) << hex << address;
+  return result.str();
+}
+
+namespace {
+// Return an ever-increasing sequence number
+uint64_t get_next_id() {
+  static never_destroyed<std::atomic<uint64_t>> next_id{0};
+  return next_id.access()++;
+}
+}  // namespace
+
+std::string SystemImpl::MakeRandomName() {
+  std::ostringstream result;
+  result << "DrakeSystem/" << setfill('0') << setw(16) << hex << get_next_id();
   return result.str();
 }
 

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -260,7 +260,7 @@ TEST_F(DiagramTest, Graphviz) {
       "_" + id + "_y2[color=green, label=\"y2\"")) << dot;
   // Check that subsystem records appear.
   EXPECT_NE(std::string::npos, dot.find(
-      "[shape=record, label=\"adder1|{{<u0>u0|<u1>u1} | {<y0>y0}}\"]")) << dot;
+      "[shape=record, label=\"adder1|")) << dot;
   // Check that internal edges appear.
   const std::string adder1_id = std::to_string(
       reinterpret_cast<int64_t>(diagram_->adder1()));
@@ -449,7 +449,6 @@ GTEST_TEST(DiagramTest2, ToAutoDiffDefaultName) {
   // The integrator1 was assigned a default name.
   // The integrator2's name remained intact.
   const std::string original_name1 = integrator1->get_name();
-  EXPECT_EQ(original_name1, integrator1->GetMemoryObjectName());
   EXPECT_EQ(integrator2->get_name(), "integrator2");
 
   // Convert to a new scalar type, and find the Integrators.
@@ -465,11 +464,8 @@ GTEST_TEST(DiagramTest2, ToAutoDiffDefaultName) {
   const auto& new_integrator2 =
       dynamic_cast<const Integrator<AutoDiffXd>&>(*new_subsystem2);
 
-  // After transmogrification, the integrator1 has a different name, but
-  // integrator2 stays the same.
-  const std::string new_name1 = new_integrator1.get_name();
-  EXPECT_NE(new_name1, original_name1);
-  EXPECT_EQ(new_name1, new_integrator1.GetMemoryObjectName());
+  // After transmogrification, both have the same name.
+  EXPECT_EQ(new_integrator1.get_name(), original_name1);
   EXPECT_EQ(new_integrator2.get_name(), "integrator2");
 }
 
@@ -1583,17 +1579,6 @@ GTEST_TEST(NonUniqueNamesTest, DefaultEmptyNames) {
   builder.AddSystem<Adder<double>>(kInputs, kSize);
   builder.AddSystem<Adder<double>>(kInputs, kSize);
   EXPECT_NO_THROW(builder.Build());
-}
-
-// Tests that an exception is thrown if a system is reset to an empty name
-// *after* being added to the diagram builder.
-GTEST_TEST(NonUniqueNamesTest, ForcedEmptyNames) {
-  DiagramBuilder<double> builder;
-  const int kInputs = 2;
-  const int kSize = 1;
-  builder.AddSystem<Adder<double>>(kInputs, kSize);
-  builder.AddSystem<Adder<double>>(kInputs, kSize)->set_name("");
-  EXPECT_THROW(builder.Build(), std::runtime_error);
 }
 
 // A system for testing per step actions.

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -1166,15 +1166,17 @@ GTEST_TEST(LeafSystemScalarConverterTest, SymbolicNo) {
 
 GTEST_TEST(GraphvizTest, Attributes) {
   DefaultFeedthroughSystem system;
+  system.set_name("GraphvizTestAttributes");
   // Check that the ID is the memory address.
   ASSERT_EQ(reinterpret_cast<int64_t>(&system), system.GetGraphvizId());
   const std::string dot = system.GetGraphvizString();
   // Check that left-to-right ranking is imposed.
   EXPECT_THAT(dot, ::testing::HasSubstr("rankdir=LR"));
-  // Check that NiceTypeName is used to compute the label.
+  // Check that the name and NiceTypeName are used to compute the label.
   EXPECT_THAT(
-      dot, ::testing::HasSubstr(
-               "label=\"drake/systems/(anonymous)/DefaultFeedthroughSystem@"));
+      dot, ::testing::MatchesRegex(
+          ".*label=\"GraphvizTestAttributes\\|"
+          "drake/systems/[^/]*/DefaultFeedthroughSystem@.*"));
 }
 
 GTEST_TEST(GraphvizTest, Ports) {


### PR DESCRIPTION
- All Systems have a name assigned by default at ctor time.
- System names can no longer be empty, ever.
- Diagram transmogrification leaves subsystem names untouched.
- Graphviz output always shows both name and type@addr.
- PidControlledSystem no longer forces a name upon its plant.
- PidController no longer specializes GraphViz, because it's no longer a complicated Diagram.

Fixes some post-merge discussions around #7113.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7115)
<!-- Reviewable:end -->
