### PR TITLE
Tidy up name preservation, take 3

### DIFF
--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -1177,13 +1177,6 @@ class Diagram : public System<T>,
           template Convert<NewType>(*old_system);
       DRAKE_DEMAND(new_system != nullptr);
 
-      // Scalar conversion preserves the name; however, if DiagramBuilder
-      // assigned a default name that includes the memory address, we will
-      // update it here to reflect the new memory address.
-      if (old_system->get_name() == old_system->GetMemoryObjectName()) {
-        new_system->set_name(new_system->GetMemoryObjectName());
-      }
-
       // Update our mapping and take ownership.
       old_to_new_map[old_system.get()] = new_system.get();
       new_systems.push_back(std::move(new_system));

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -785,10 +785,10 @@ class System {
   void set_name(const std::string& name) { name_ = name; }
 
   /// Returns the name last supplied to set_name(), or empty if set_name() was
-  /// never called.  Systems created through transmogrification have by default
-  /// an identical name to the system they were created from.  Systems with an
-  /// empty name that are added to a Diagram will have a default name
-  /// automatically assigned; that name might change during transmogrification.
+  /// never called.  Systems with an empty name that are added to a Diagram
+  /// will have a default name automatically assigned.  Systems created through
+  /// transmogrification have by default an identical name to the system they
+  /// were created from.
   std::string get_name() const { return name_; }
 
   /// Returns a name for this %System based on a stringification of its type

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -436,43 +436,6 @@ TEST_F(DiagramTest, ToSymbolic) {
   EXPECT_THROW(diagram_with_double_only->ToSymbolic(), std::exception);
 }
 
-GTEST_TEST(DiagramTest2, ToAutoDiffDefaultName) {
-  DiagramBuilder<double> builder;
-  auto* integrator1 = builder.AddSystem<Integrator<double>>(1);
-  auto* integrator2 = builder.AddSystem<Integrator<double>>(1);
-  integrator2->set_name("integrator2");
-  builder.ExportInput(integrator1->get_input_port());
-  builder.Cascade(*integrator1, *integrator2);
-  builder.ExportOutput(integrator2->get_output_port());
-  std::unique_ptr<Diagram<double>> diagram = builder.Build();
-
-  // The integrator1 was assigned a default name.
-  // The integrator2's name remained intact.
-  const std::string original_name1 = integrator1->get_name();
-  EXPECT_EQ(original_name1, integrator1->GetMemoryObjectName());
-  EXPECT_EQ(integrator2->get_name(), "integrator2");
-
-  // Convert to a new scalar type, and find the Integrators.
-  std::unique_ptr<System<AutoDiffXd>> new_system = diagram->ToAutoDiffXd();
-  const auto& new_diagram =
-      dynamic_cast<const Diagram<AutoDiffXd>&>(*new_system);
-  auto new_subsystems = new_diagram.GetSystems();
-  ASSERT_EQ(new_subsystems.size(), 2);
-  const System<AutoDiffXd>* new_subsystem1 = new_subsystems.front();
-  const System<AutoDiffXd>* new_subsystem2 = new_subsystems.back();
-  const auto& new_integrator1 =
-      dynamic_cast<const Integrator<AutoDiffXd>&>(*new_subsystem1);
-  const auto& new_integrator2 =
-      dynamic_cast<const Integrator<AutoDiffXd>&>(*new_subsystem2);
-
-  // After transmogrification, the integrator1 has a different name, but
-  // integrator2 stays the same.
-  const std::string new_name1 = new_integrator1.get_name();
-  EXPECT_NE(new_name1, original_name1);
-  EXPECT_EQ(new_name1, new_integrator1.GetMemoryObjectName());
-  EXPECT_EQ(new_integrator2.get_name(), "integrator2");
-}
-
 // Tests that the same diagram can be evaluated into the same output with
 // different contexts interchangeably.
 TEST_F(DiagramTest, Clone) {


### PR DESCRIPTION
When transmogrifying subsystems within a Diagram, do not touch their name. This means that their name might still be a memory address of the original system, but this has always been the case.

This reverts most of c3aa7eed50a1ca91de9efca99d1799e622c530a8.

This fixes open review discussions carried over from #7113.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7123)
<!-- Reviewable:end -->
