### PR TITLE
Mark a narrow testonly library as private in primitives, sensors

### DIFF
--- a/drake/BUILD
+++ b/drake/BUILD
@@ -255,7 +255,6 @@ _LIBDRAKE_COMPONENTS = [
     "//drake/systems/robotInterfaces:qp_locomotion_plan",
     "//drake/systems/robotInterfaces:side",
     "//drake/systems/sensors:accelerometer",
-    "//drake/systems/sensors:accelerometer_example_diagram",
     "//drake/systems/sensors:camera_info",
     "//drake/systems/sensors:depth_sensor",
     "//drake/systems/sensors:depth_sensor_to_lcm_point_cloud_message",

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -229,6 +229,7 @@ drake_cc_library(
     name = "affine_linear_test",
     testonly = 1,
     hdrs = ["test/affine_linear_test.h"],
+    visibility = ["//visibility:private"],
 )
 
 drake_cc_googletest(

--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -210,6 +210,7 @@ drake_cc_binary(
 
 drake_cc_library(
     name = "accelerometer_example_diagram",
+    testonly = 1,
     srcs = [
         "test/accelerometer_test/accelerometer_example_diagram.cc",
         "test/accelerometer_test/accelerometer_test_logger.cc",
@@ -223,6 +224,7 @@ drake_cc_library(
     data = [
         "//drake/examples/pendulum:models",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         ":accelerometer",
         "//drake/common:essential",
@@ -238,6 +240,7 @@ drake_cc_library(
 
 drake_cc_binary(
     name = "accelerometer_example",
+    testonly = 1,
     srcs = [
         "test/accelerometer_test/accelerometer_example.cc",
     ],


### PR DESCRIPTION
Per discussion in Drake's `#bazel` channel 2017-09-20, we're proposing a convention that widely shared testonly `cc_library` targets live in a subfolder named `test_utilities`, for easier discoverability and less `deps=` ceremony when there is more than one helper class.

In this case, the `cc_library` targets are _not_ intended to be reused, but rather they are local and specific to a couple tests.  Thus, we mark them private (and testonly! (and not installed!!)) to reflect the narrower intended scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7126)
<!-- Reviewable:end -->
