### PR TITLE
[Multilane] Segments with multiple lanes

### DIFF
--- a/drake/automotive/maliput/multilane/BUILD
+++ b/drake/automotive/maliput/multilane/BUILD
@@ -137,6 +137,17 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "multilane_segments_test",
+    size = "small",
+    srcs = ["test/multilane_segments_test.cc"],
+    deps = [
+        ":lanes",
+        "//drake/automotive/maliput/api/test_utilities:maliput_types_compare",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
 drake_cc_binary(
     name = "yaml_load",
     testonly = 1,

--- a/drake/automotive/maliput/multilane/builder.h
+++ b/drake/automotive/maliput/multilane/builder.h
@@ -24,7 +24,7 @@ class RoadGeometry;
 /// network.
 ///
 /// multilane is a simple road-network implementation:
-///  - single lane per segment;
+///  - multiple lanes per segment;
 ///  - constant lane_bounds, driveable_bounds, and elevation_bounds,
 ///    same for all lanes;
 ///  - only linear and constant-curvature-arc primitives in XY-plane;

--- a/drake/automotive/maliput/multilane/junction.cc
+++ b/drake/automotive/maliput/multilane/junction.cc
@@ -11,10 +11,10 @@ const api::RoadGeometry* Junction::do_road_geometry() const {
 }
 
 
-Segment* Junction::NewSegment(api::SegmentId id,
+Segment* Junction::NewSegment(const api::SegmentId& id,
                               std::unique_ptr<RoadCurve> road_curve,
                               double r_min, double r_max,
-                              const api::HBounds elevation_bounds) {
+                              const api::HBounds& elevation_bounds) {
   segments_.push_back(std::make_unique<Segment>(
       id, this, std::move(road_curve), r_min, r_max, elevation_bounds));
   return segments_.back().get();

--- a/drake/automotive/maliput/multilane/junction.h
+++ b/drake/automotive/maliput/multilane/junction.h
@@ -27,7 +27,7 @@ class Junction : public api::Junction {
   Junction(const api::JunctionId& id, api::RoadGeometry* road_geometry)
       : id_(id), road_geometry_(road_geometry) {}
 
-  /// Creates and adds a new Segment with the specified @p id and @p road_curve.
+  /// Creates and adds a new Segment.
   /// @param id Segment's ID.
   /// @param road_curve Reference trajectory over the Segment's surface.
   /// @param r_min Lateral distance to the minimum extent of road_curve's curve
@@ -36,9 +36,9 @@ class Junction : public api::Junction {
   /// from where Segment's surface ends.
   /// @param elevation_bounds The height bounds over the segment' surface.
   /// @return A Segment object.
-  Segment* NewSegment(api::SegmentId id, std::unique_ptr<RoadCurve> road_curve,
-                      double r_min, double r_max,
-                      const api::HBounds elevation_bounds);
+  Segment* NewSegment(const api::SegmentId& id,
+                      std::unique_ptr<RoadCurve> road_curve, double r_min,
+                      double r_max, const api::HBounds& elevation_bounds);
 
   ~Junction() override = default;
 

--- a/drake/automotive/maliput/multilane/segment.cc
+++ b/drake/automotive/maliput/multilane/segment.cc
@@ -10,19 +10,24 @@ const api::Junction* Segment::do_junction() const {
 
 Lane* Segment::NewLane(api::LaneId id, double r0,
                        const api::RBounds& lane_bounds) {
-  DRAKE_DEMAND(lane_.get() == nullptr);
+  const int index = lanes_.size();
   DRAKE_DEMAND(r_min_ <= r0 && r0 <= r_max_);
+  if (lanes_.size() != 0) {
+    DRAKE_DEMAND(r0 > lanes_.back()->r0());
+  }
   const api::RBounds driveable_bounds(r_min_ - r0, r_max_ - r0);
   DRAKE_DEMAND(lane_bounds.min() >= driveable_bounds.min() &&
                lane_bounds.max() <= driveable_bounds.max());
-  lane_ = std::make_unique<Lane>(id, this, lane_bounds, driveable_bounds,
-                                 elevation_bounds_, road_curve_.get(), r0);
-  return lane_.get();
+  auto lane_ =
+      std::make_unique<Lane>(id, this, index, lane_bounds, driveable_bounds,
+                             elevation_bounds_, road_curve_.get(), r0);
+  lanes_.push_back(std::move(lane_));
+  return lanes_.back().get();
 }
 
 const api::Lane* Segment::do_lane(int index) const {
-  DRAKE_DEMAND(index == 0);
-  return lane_.get();
+  DRAKE_DEMAND(index >= 0 && index < static_cast<int>(lanes_.size()));
+  return lanes_[index].get();
 }
 
 

--- a/drake/automotive/maliput/multilane/segment.h
+++ b/drake/automotive/maliput/multilane/segment.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
@@ -26,19 +27,19 @@ class Segment : public api::Segment {
 
   /// Constructs a new Segment.
   ///
-  /// The Segment is not fully initialized until NewLane() is called exactly
-  /// once. @p junction must remain valid for the lifetime of this class.
-  /// @param id ID of the segment.
+  /// The Segment is not fully initialized until NewLane() is called at least
+  /// once. `junction` must remain valid for the lifetime of this class.
+  /// @param id Segment's ID.
   /// @param junction Parent junction.
   /// @param road_curve A curve that defines the reference trajectory over the
   /// segment. A child Lane object will be constructed from an offset of the
   /// road_curve's reference curve.
   /// @param r_min Lateral distance to the minimum extent of road_curve's curve
   /// from where Segment's surface starts. It must be smaller or equal than
-  /// @p r_max.
+  /// `r_max`.
   /// @param r_max Lateral distance to the maximum extent of road_curve's curve
   /// from where Segment's surface ends. It should be greater or equal than
-  /// @p r_min.
+  /// `r_min`.
   /// @param elevation_bounds The height bounds over the segment' surface.
   Segment(const api::SegmentId& id, api::Junction* junction,
           std::unique_ptr<RoadCurve> road_curve, double r_min, double r_max,
@@ -55,13 +56,18 @@ class Segment : public api::Segment {
   }
 
   /// Creates a new Lane object.
-  /// This method should be called only once in the lifespan of the object. The
-  /// Segment class only supports one Lane.
-  /// Lane's lane bounds will be assigned as the driveable_bounds of the
-  /// segment.
+  ///
+  /// Driveable bounds of the lane will be derived based on the lateral offset
+  /// of it so as to reach `r_min` and `r_max` distances (see class constructor
+  /// for more details).
   /// @param id Lane's ID.
   /// @param r0 Lateral displacement of the Lane with respect to segment
-  /// RoadCurve's reference curve.
+  /// RoadCurve's reference curve. It must be greater than `r_min` and smaller
+  /// than `r_max`, and be greater than the last lane's r0 displacement (if
+  /// any).
+  /// @param lane_bounds Nominal bounds of the lane, uniform along the entire
+  /// reference path. It must fit inside segments bounds when those are
+  /// translated to `r0` offset distance.
   /// @return A Lane object.
   Lane* NewLane(api::LaneId id, double r0, const api::RBounds& lane_bounds);
 
@@ -72,7 +78,7 @@ class Segment : public api::Segment {
 
   const api::Junction* do_junction() const override;
 
-  int do_num_lanes() const override { return 1; }
+  int do_num_lanes() const override { return lanes_.size(); }
 
   const api::Lane* do_lane(int index) const override;
 
@@ -80,8 +86,8 @@ class Segment : public api::Segment {
   api::SegmentId id_;
   // Parent junction.
   api::Junction* junction_{};
-  // Child Lane pointer.
-  std::unique_ptr<Lane> lane_;
+  // Child Lane vector.
+  std::vector<std::unique_ptr<Lane>> lanes_;
   // Reference trajectory over the Segment's surface.
   std::unique_ptr<RoadCurve> road_curve_;
   // Lateral distance to the minimum extent of road_curve_'s curve from where

--- a/drake/automotive/maliput/multilane/test/multilane_segments_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_segments_test.cc
@@ -1,0 +1,75 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/multilane/segment.h"
+/* clang-format on */
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
+#include "drake/automotive/maliput/multilane/arc_road_curve.h"
+#include "drake/automotive/maliput/multilane/junction.h"
+#include "drake/automotive/maliput/multilane/lane.h"
+#include "drake/automotive/maliput/multilane/line_road_curve.h"
+#include "drake/automotive/maliput/multilane/road_curve.h"
+#include "drake/automotive/maliput/multilane/road_geometry.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+const double kLinearTolerance = 1e-6;
+const double kAngularTolerance = 1e-6;
+const double kZeroTolerance = 0.;
+
+GTEST_TEST(MultilaneSegmentsTest, MultipleLanes) {
+  CubicPolynomial zp{0., 0., 0., 0.};
+  const double kR0 = 10.;
+  const int kNumLanes = 3;
+  const double kRSpacing = 15.;
+  const double kRMin = 2.;
+  const double kRMax = 42.;
+  const double kHalfLaneWidth = 0.5 * kRSpacing;
+  const double kMaxHeight = 5.;
+
+  RoadGeometry rg(api::RoadGeometryId{"apple"}, kLinearTolerance,
+                  kAngularTolerance);
+  std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<LineRoadCurve>(
+      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp);
+  Segment* s1 =
+      rg.NewJunction(api::JunctionId{"j1"})
+          ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1), kRMin,
+                       kRMax, {0., kMaxHeight});
+  EXPECT_EQ(s1->id(), api::SegmentId("s1"));
+  EXPECT_EQ(s1->num_lanes(), 0);
+
+  Lane* l0 = s1->NewLane(api::LaneId{"l0"}, kR0, {-8., kHalfLaneWidth});
+  EXPECT_EQ(s1->num_lanes(), 1);
+  EXPECT_EQ(s1->lane(0), l0);
+  Lane* l1 = s1->NewLane(api::LaneId{"l1"}, kR0 + kRSpacing,
+                         {-kHalfLaneWidth, kHalfLaneWidth});
+  EXPECT_EQ(s1->num_lanes(), 2);
+  EXPECT_EQ(s1->lane(1), l1);
+  Lane* l2 = s1->NewLane(api::LaneId{"l2"}, kR0 + 2. * kRSpacing,
+                         {-kHalfLaneWidth, 2.});
+  EXPECT_EQ(s1->num_lanes(), kNumLanes);
+  EXPECT_EQ(s1->lane(2), l2);
+
+  EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
+
+  EXPECT_TRUE(api::test::IsRBoundsClose(l0->lane_bounds(0.),
+                                        {-8., kHalfLaneWidth}, kZeroTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(l0->driveable_bounds(0.), {-8., 32.},
+                                        kZeroTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      l1->lane_bounds(0.), {-kHalfLaneWidth, kHalfLaneWidth}, kZeroTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(l1->driveable_bounds(0.), {-23., 17.},
+                                        kZeroTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(l2->lane_bounds(0.),
+                                        {-kHalfLaneWidth, 2.}, kZeroTolerance));
+  EXPECT_TRUE(api::test::IsRBoundsClose(l2->driveable_bounds(0.), {-38., 2.},
+                                        kZeroTolerance));
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
Towards #4934 completion, this PR makes `multilane::Segment`s able to create and hold more than one `multilane::Lane`.

Previous PR ( #6985  ) changed `multilane::RoadCurve` interface to provide support of lateral displacements of `multilane::Lane`s, which is used by this code to separate `multilane::Lane`'s centerlines from the reference curve of their parent `multilane::Segment` and distribute them along the _driveable bounds_.

Some new attributes are introduced to `multilane::Segment` class which are necessary to create equally spaced `multilane::Lane`:

- `num_lanes`: the number of lanes that segment will be allowed to build.
- `r_spacing`: the constant lateral distance between lane's centerlines.
- `r0`: this attributed was introduced in the last PR, and now is promoted to the `multilane::Segment`. It means the lateral distance from the reference curve to the first lane centerline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7127)
<!-- Reviewable:end -->
