### PR TITLE
Linearize about a non-equilibrium point

### DIFF
--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -18,6 +18,11 @@
 
 namespace drake {
 namespace systems {
+namespace {
+
+enum class WhichAction { DoLinearize, DoThrow };
+
+}  // namespace
 
 using std::make_unique;
 using std::unique_ptr;
@@ -112,32 +117,41 @@ double GetTimePeriodIfDiscreteUpdatesArePeriodic(
   return time_period;
 }
 
+void ThrowNonEquilibrium() {
+  throw std::runtime_error(
+      "The nominal operating point (x0,u0) is not an equilibrium point of "
+      "the system.  Without additional information, a time-invariant "
+      "linearization of this system is not well defined.");
+}
+
 // Builds the A and B matrices of the system's discrete/continuous state
-// equation.
-Eigen::MatrixXd MakeStateAndInputMatrices(
+// equation.  Returns a pair consisting of the concatenated matrix [A, B], along
+// with the value of the state equation f(x0,u0) (note that this is *not* the
+// affine term f0).
+std::pair<Eigen::MatrixXd, Eigen::VectorXd>
+MakeStateAndInputMatrices(
     const VectorX<AutoDiffXd>& autodiff_x0_vec,
     double equilibrium_check_tolerance,
     const System<AutoDiffXd>& autodiff_system,
-    Context<AutoDiffXd>* autodiff_context) {
-  const std::string nonequilibrium_error_msg =
-      "The nominal operating point (x0,u0) is not an equilibrium point of "
-      "the system.  Without additional information, a time-invariant "
-      "linearization of this system is not well defined.";
+    Context<AutoDiffXd>* autodiff_context,
+    WhichAction which_action) {
   if (autodiff_context->has_only_continuous_state()) {
     autodiff_context->get_mutable_continuous_state_vector()->SetFromVector(
         autodiff_x0_vec);
     std::unique_ptr<ContinuousState<AutoDiffXd>> autodiff_xdot =
         autodiff_system.AllocateTimeDerivatives();
-    autodiff_system.CalcTimeDerivatives(*autodiff_context,
-                                        autodiff_xdot.get());
+    autodiff_system.CalcTimeDerivatives(*autodiff_context, autodiff_xdot.get());
     auto autodiff_xdot_vec = autodiff_xdot->CopyToVector();
 
-    // Ensure that xdot0 = f(x0,u0) == 0.
     if (!math::autoDiffToValueMatrix(autodiff_xdot_vec)
-        .isZero(equilibrium_check_tolerance)) {
-      throw std::runtime_error(nonequilibrium_error_msg);
+             .isZero(equilibrium_check_tolerance)) {
+      if (which_action == WhichAction::DoThrow) {
+        // Ensure that xdot0 = f(x0,u0) == 0 if we require an equilibrium point.
+        ThrowNonEquilibrium();
+      }
     }
-    return math::autoDiffToGradientMatrix(autodiff_xdot_vec);
+    return std::make_pair(math::autoDiffToGradientMatrix(autodiff_xdot_vec),
+                          math::autoDiffToValueMatrix(autodiff_xdot_vec));
   }
   auto autodiff_x0 =
       autodiff_context->get_mutable_discrete_state()->get_mutable_vector();
@@ -148,20 +162,23 @@ Eigen::MatrixXd MakeStateAndInputMatrices(
                                               autodiff_x1.get());
   auto autodiff_x1_vec = autodiff_x1->get_vector()->CopyToVector();
 
-  // Ensure that x1 = f(x0,u0) == x0.
   if (!(math::autoDiffToValueMatrix(autodiff_x1_vec) -
-        math::autoDiffToValueMatrix(autodiff_x0_vec)).isZero(
-            equilibrium_check_tolerance)) {
-    throw std::runtime_error(nonequilibrium_error_msg);
+        math::autoDiffToValueMatrix(autodiff_x0_vec))
+           .isZero(equilibrium_check_tolerance)) {
+    if (which_action == WhichAction::DoThrow) {
+      // Ensure that x1 = f(x0,u0) == x0 if we require an equilibrium point.
+      ThrowNonEquilibrium();
+    }
   }
-  return math::autoDiffToGradientMatrix(autodiff_x1_vec);
+  return std::make_pair(math::autoDiffToGradientMatrix(autodiff_x1_vec),
+                        math::autoDiffToValueMatrix(autodiff_x1_vec));
 }
 
-}  // namespace
-
-std::unique_ptr<LinearSystem<double>> Linearize(
-    const System<double>& system, const Context<double>& context,
-    double equilibrium_check_tolerance) {
+std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
+    const System<double>& system,
+    const Context<double>& context,
+    double equilibrium_check_tolerance,
+    WhichAction which_action) {
   DRAKE_ASSERT_VOID(system.CheckValidContext(context));
 
   const bool has_only_discrete_states_contained_in_one_group =
@@ -172,6 +189,8 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 
   const double time_period =
       GetTimePeriodIfDiscreteUpdatesArePeriodic(system, context);
+  // N.B. Placement here allows us to fail fast if non-periodic updates are
+  // detected.
 
   DRAKE_DEMAND(system.get_num_input_ports() <= 1);
   DRAKE_DEMAND(system.get_num_output_ports() <= 1);
@@ -192,15 +211,16 @@ std::unique_ptr<LinearSystem<double>> Linearize(
       autodiff_system->CreateDefaultContext();
   autodiff_context->SetTimeStateAndParametersFrom(context);
 
+  const Eigen::VectorXd x0 =
+      (context.has_only_continuous_state())
+          ? context.get_continuous_state_vector().CopyToVector()
+          : context.get_discrete_state(0)->get_value();
+  const int num_states = x0.size();
+
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);
   if (num_inputs > 0) {
     u0 = system.EvalEigenVectorInput(context, 0);
   }
-
-  const Eigen::VectorXd x0 = (context.has_only_continuous_state())
-      ? context.get_continuous_state_vector().CopyToVector()
-      : context.get_discrete_state(0)->get_value();
-  const int num_states = x0.size();
 
   auto autodiff_args = math::initializeAutoDiffTuple(x0, u0);
   if (num_inputs > 0) {
@@ -211,16 +231,19 @@ std::unique_ptr<LinearSystem<double>> Linearize(
         std::make_unique<FreestandingInputPortValue>(std::move(input_vector)));
   }
 
-  const Eigen::MatrixXd AB =
-      MakeStateAndInputMatrices(std::get<0>(autodiff_args),
-                                equilibrium_check_tolerance,
-                                *autodiff_system, autodiff_context.get());
-  const Eigen::MatrixXd A = AB.leftCols(num_states);
-  const Eigen::MatrixXd B = AB.rightCols(num_inputs);
+  Eigen::MatrixXd AB;
+  Eigen::VectorXd f_at_basepoint;
+  std::tie(AB, f_at_basepoint) = MakeStateAndInputMatrices(
+      std::get<0>(autodiff_args), equilibrium_check_tolerance, *autodiff_system,
+      autodiff_context.get(), which_action);
+  const Eigen::MatrixXd& A = AB.leftCols(num_states);
+  const Eigen::MatrixXd& B = AB.rightCols(num_inputs);
+  const Eigen::VectorXd& f0 = f_at_basepoint - A * x0 - B * u0;
 
   Eigen::MatrixXd C = Eigen::MatrixXd::Zero(num_outputs, num_states);
   Eigen::MatrixXd D = Eigen::MatrixXd::Zero(num_outputs, num_inputs);
 
+  Eigen::VectorXd y0 = Eigen::VectorXd::Zero(num_outputs);
   if (num_outputs > 0) {
     std::unique_ptr<SystemOutput<AutoDiffXd>> autodiff_y0 =
         autodiff_system->AllocateOutput(*autodiff_context);
@@ -230,9 +253,34 @@ std::unique_ptr<LinearSystem<double>> Linearize(
     Eigen::MatrixXd CD = math::autoDiffToGradientMatrix(autodiff_y0_vec);
     C = CD.leftCols(num_states);
     D = CD.rightCols(num_inputs);
+
+    const Eigen::VectorXd& y_at_basepoint =
+        math::autoDiffToValueMatrix(autodiff_y0_vec);
+    y0 = y_at_basepoint - C * x0 - D * u0;
   }
 
-  return std::make_unique<LinearSystem<double>>(A, B, C, D, time_period);
+  return std::make_unique<AffineSystem<double>>(
+      A, B, f0, C, D, y0, time_period);
+}
+
+}  // namespace
+
+std::unique_ptr<LinearSystem<double>> Linearize(
+    const System<double>& system, const Context<double>& context,
+    double equilibrium_check_tolerance) {
+  std::unique_ptr<AffineSystem<double>> affine =
+      DoFirstOrderTaylorApproximation(
+          system, context, equilibrium_check_tolerance, WhichAction::DoThrow);
+  return std::make_unique<LinearSystem<double>>(
+      affine->A(), affine->B(), affine->C(), affine->D(),
+      affine->time_period());
+}
+
+std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
+    const System<double>& system, const Context<double>& context) {
+  return DoFirstOrderTaylorApproximation(
+      system, context, 0. /* equilibrium tolerance (not used) */,
+      WhichAction::DoLinearize);
 }
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].

--- a/drake/systems/primitives/linear_system.h
+++ b/drake/systems/primitives/linear_system.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/symbolic.h"
@@ -119,6 +120,37 @@ class LinearSystem : public AffineSystem<T> {
 std::unique_ptr<LinearSystem<double>> Linearize(
     const System<double>& system, const Context<double>& context,
     double equilibrium_check_tolerance = 1e-6);
+
+/// A first-order Taylor series approximation to a @p system in the neighborhood
+/// of an arbitrary point.  When Taylor-expanding a system at a non-equilibrium
+/// point, it may be represented either of the form:
+///   @f[ \dot{x} - \dot{x0} = A (x - x0) + B (u - u0), @f]
+/// for continuous time, or
+///   @f[ x[n+1] - x0[n+1] = A (x[n] - x0[n]) + B (u[n] - u0[n]), @f]
+/// for discrete time.  As above, we denote x0, u0 to be the nominal state and
+/// input at the provided @p context.  The system description is affine when the
+/// terms @f$ \dot{x0} - A x0 - B u0 @f$ and @f$ x0[n+1] - A x0[n] - B u0[n] @f$
+/// are nonzero.
+///
+/// More precisely, let x be a state and u be an input.  This function returns
+/// an AffineSystem of the form:
+///   @f[ \dot{x} = A x + B u + f0, @f] (CT)
+///   @f[ x[n+1] = A x[n] + B u[n] + f0, @f] (DT)
+/// where @f$ f0 = \dot{x0} - A x0 - B u0 @f$ (CT) and
+/// @f$ f0 = x0[n+1] - A x[n] - B u[n] @f$ (DT).
+///
+/// @param system The system or subsystem to linearize.
+/// @param context Defines the nominal operating point about which the system
+/// should be linearized.
+/// @returns An AffineSystem at this linearization point.
+///
+/// Note that x, u and y are in the same coordinate system as the original
+/// @p system, since the terms involving x0, u0 reside in f0.
+///
+/// @ingroup primitive_systems
+///
+std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
+    const System<double>& system, const Context<double>& context);
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
 /// @ingroup control_systems

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -62,8 +62,7 @@ TEST_F(LinearSystemTest, Derivatives) {
   EXPECT_NE(derivatives_, nullptr);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
 
-  Eigen::VectorXd expected_derivatives(2);
-  expected_derivatives = A_ * x + B_ * u;
+  Eigen::VectorXd expected_derivatives = A_ * x + B_ * u;
 
   EXPECT_EQ(expected_derivatives, derivatives_->get_vector().CopyToVector());
 }
@@ -80,9 +79,7 @@ TEST_F(LinearSystemTest, Output) {
 
   dut_->CalcOutput(*context_, system_output_.get());
 
-  Eigen::VectorXd expected_output(2);
-
-  expected_output = C_ * x + D_ * u;
+  Eigen::VectorXd expected_output = C_ * x + D_ * u;
 
   EXPECT_EQ(expected_output, system_output_->get_vector_data(0)->get_value());
 }
@@ -103,93 +100,166 @@ TEST_F(LinearSystemTest, ConvertScalarType) {
   }));
 }
 
+class TestLinearizeFromAffine : public ::testing::Test {
+ protected:
+  void SetUp() {
+    A_ << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+    B_ << 10, 11, 12;
+    f0_ << 13, 14, 15;
+    C_ << 16, 17, 18, 19, 20, 21;
+    D_ << 22, 23;
+    y0_ << 24, 25;
+
+    continuous_system_.reset(new AffineSystem<double>(
+        A_, B_, f0_, C_, D_, y0_));
+    discrete_system_.reset(new AffineSystem<double>(
+        A_, B_, f0_, C_, D_, y0_, time_period_));
+  }
+
+  Eigen::Matrix3d A_;
+  Eigen::Matrix<double, 3, 1> B_;
+  Eigen::Vector3d f0_;
+  Eigen::Matrix<double, 2, 3> C_;
+  Eigen::Vector2d D_;
+  Eigen::Vector2d y0_;
+
+  Eigen::Vector3d x0_{26, 27, 28};
+  double u0_{29};
+
+  const double time_period_ = 0.1;
+
+  std::unique_ptr<AffineSystem<double>> continuous_system_;
+  std::unique_ptr<AffineSystem<double>> discrete_system_;
+};
+
 // Test that linearizing a continuous-time affine system returns the original
 // A,B,C,D matrices.
-GTEST_TEST(TestLinearize, FromAffine) {
-  Eigen::Matrix3d A;
-  Eigen::Matrix<double, 3, 1> B;
-  Eigen::Vector3d f0;
-  Eigen::Matrix<double, 2, 3> C;
-  Eigen::Vector2d D;
-  Eigen::Vector2d y0;
-  A << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  B << 10, 11, 12;
-  f0 << 13, 14, 15;
-  C << 16, 17, 18, 19, 20, 21;
-  D << 22, 23;
-  y0 << 24, 25;
-  AffineSystem<double> system(A, B, f0, C, D, y0);
-  auto context = system.CreateDefaultContext();
-  Eigen::Vector3d x0(26, 27, 28);
-  context->get_mutable_continuous_state_vector()->SetFromVector(x0);
-  double u0 = 29;
-  context->FixInputPort(0, Vector1d::Constant(u0));
-
-  // This Context is not an equilibrium point.
-  EXPECT_THROW(Linearize(system, *context), std::runtime_error);
+TEST_F(TestLinearizeFromAffine, ContinuousAtEquilibrium) {
+  auto context = continuous_system_->CreateDefaultContext();
+  context->FixInputPort(0, Vector1d::Constant(u0_));
 
   // Set x0 to the actual equilibrium point.
-  x0 = A.colPivHouseholderQr().solve(-B * u0 - f0);
+  const Eigen::Vector3d x0 = A_.colPivHouseholderQr().solve(-B_ * u0_ - f0_);
   context->get_mutable_continuous_state_vector()->SetFromVector(x0);
 
-  auto linearized_system = Linearize(system, *context);
+  auto linearized_system = Linearize(*continuous_system_, *context);
 
   double tol = 1e-10;
-  EXPECT_TRUE(CompareMatrices(A, linearized_system->A(), tol,
+  EXPECT_TRUE(CompareMatrices(A_, linearized_system->A(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(B, linearized_system->B(), tol,
+  EXPECT_TRUE(CompareMatrices(B_, linearized_system->B(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(C, linearized_system->C(), tol,
+  EXPECT_TRUE(CompareMatrices(C_, linearized_system->C(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(D, linearized_system->D(), tol,
+  EXPECT_TRUE(CompareMatrices(D_, linearized_system->D(), tol,
+                              MatrixCompareType::absolute));
+
+  std::unique_ptr<AffineSystem<double>> affine_system =
+      FirstOrderTaylorApproximation(*continuous_system_, *context);
+  // Verify that the affine term f0 is just the linear terms.
+  EXPECT_TRUE(CompareMatrices(-A_ * x0 - B_ * u0_, affine_system->f0(), tol,
+                              MatrixCompareType::absolute));
+  // Verify that the affine term y0 is just the affine term.
+  EXPECT_TRUE(CompareMatrices(y0_, affine_system->y0(), tol,
                               MatrixCompareType::absolute));
 }
 
-// Test that linearizing a discrete-time affine system returns the original
-// A,B,C,D matrices and time period.
-GTEST_TEST(TestLinearize, FromDiscreteAffine) {
-  Eigen::Matrix3d A;
-  Eigen::Matrix<double, 3, 1> B;
-  Eigen::Vector3d f0;
-  Eigen::Matrix<double, 2, 3> C;
-  Eigen::Vector2d D;
-  Eigen::Vector2d y0;
-  A << 1, 2, 3, 4, 5, 6, 7, 8, 9;
-  B << 10, 11, 12;
-  f0 << 13, 14, 15;
-  C << 16, 17, 18, 19, 20, 21;
-  D << 22, 23;
-  y0 << 24, 25;
-  const double time_period = 0.1;
-  AffineSystem<double> discrete_system(A, B, f0, C, D, y0, time_period);
-  auto context = discrete_system.CreateDefaultContext();
-  Eigen::Vector3d x0(26, 27, 28);
+// Test that linearizing a continuous-time affine system about a point that is
+// not at equilibrium returns the original A,B,C,D matrices and affine terms.
+TEST_F(TestLinearizeFromAffine, ContinuousAtNonEquilibrium) {
+  auto context = continuous_system_->CreateDefaultContext();
+  context->FixInputPort(0, Vector1d::Constant(u0_));
+  context->get_mutable_continuous_state_vector()->SetFromVector(x0_);
+
+  // This Context is not an equilibrium point.
+  EXPECT_THROW(Linearize(*continuous_system_, *context), std::runtime_error);
+
+  // Obtain a linearization at this nonequilibrium condition.
+  std::unique_ptr<AffineSystem<double>> affine_system =
+      FirstOrderTaylorApproximation(*continuous_system_, *context);
+
+  double tol = 1e-10;
+  // We recover the original affine system.
+  EXPECT_TRUE(CompareMatrices(A_, affine_system->A(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(B_, affine_system->B(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(C_, affine_system->C(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(D_, affine_system->D(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(f0_, affine_system->f0(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(y0_, affine_system->y0(), tol,
+                              MatrixCompareType::absolute));
+}
+
+TEST_F(TestLinearizeFromAffine, DiscreteAtEquilibrium) {
+  auto context = discrete_system_->CreateDefaultContext();
+  context->FixInputPort(0, Vector1d::Constant(u0_));
+
+  // Set x0 to the actual equilibrium point.
+  const Eigen::Matrix3d eye = Eigen::Matrix3d::Identity();
+  const Eigen::Vector3d x0 =
+      (eye - A_).colPivHouseholderQr().solve(B_ * u0_ + f0_);
   systems::BasicVector<double>* xd =
       context->get_mutable_discrete_state()->get_mutable_vector();
   xd->SetFromVector(x0);
-  double u0 = 29;
-  context->FixInputPort(0, Vector1d::Constant(u0));
 
-  // This Context is not an equilibrium point.
-  EXPECT_THROW(Linearize(discrete_system, *context), std::runtime_error);
-
-  // Set x0 to the actual equilibrium point.
-  Eigen::Matrix3d eye = Eigen::Matrix3d::Identity();
-  x0 = (eye - A).colPivHouseholderQr().solve(B * u0 + f0);
-  xd->SetFromVector(x0);
-
-  auto linearized_system = Linearize(discrete_system, *context);
+  auto linearized_system = Linearize(*discrete_system_, *context);
 
   double tol = 1e-10;
-  EXPECT_TRUE(CompareMatrices(A, linearized_system->A(), tol,
+  EXPECT_TRUE(CompareMatrices(A_, linearized_system->A(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(B, linearized_system->B(), tol,
+  EXPECT_TRUE(CompareMatrices(B_, linearized_system->B(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(C, linearized_system->C(), tol,
+  EXPECT_TRUE(CompareMatrices(C_, linearized_system->C(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(D, linearized_system->D(), tol,
+  EXPECT_TRUE(CompareMatrices(D_, linearized_system->D(), tol,
                               MatrixCompareType::absolute));
-  EXPECT_EQ(time_period, linearized_system->time_period());
+  EXPECT_EQ(time_period_, linearized_system->time_period());
+
+  std::unique_ptr<AffineSystem<double>> affine_system =
+      FirstOrderTaylorApproximation(*discrete_system_, *context);
+  // Verify that the affine term f0 is just the linear terms.
+  EXPECT_TRUE(CompareMatrices(-A_ * x0 - B_ * u0_ + x0, affine_system->f0(),
+                              tol, MatrixCompareType::absolute));
+  // Verify that the affine term y0 is just the affine term.
+  EXPECT_TRUE(CompareMatrices(y0_, affine_system->y0(), tol,
+                              MatrixCompareType::absolute));
+}
+
+// Test that linearizing a discrete-time affine system about a point that is not
+// at equilibrium returns the original A,B,C,D matrices and affine terms.
+TEST_F(TestLinearizeFromAffine, DiscreteAtNonEquilibrium) {
+  auto context = discrete_system_->CreateDefaultContext();
+  context->FixInputPort(0, Vector1d::Constant(u0_));
+  systems::BasicVector<double>* xd =
+      context->get_mutable_discrete_state()->get_mutable_vector();
+  xd->SetFromVector(x0_);
+
+  // This Context is not an equilibrium point.
+  EXPECT_THROW(Linearize(*discrete_system_, *context), std::runtime_error);
+
+  // Obtain a linearization at this nonequilibrium condition.
+  std::unique_ptr<AffineSystem<double>> affine_system =
+      FirstOrderTaylorApproximation(*discrete_system_, *context);
+
+  double tol = 1e-10;
+  // We recover the original affine system.
+  EXPECT_TRUE(CompareMatrices(A_, affine_system->A(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(B_, affine_system->B(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(C_, affine_system->C(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(D_, affine_system->D(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(f0_, affine_system->f0(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(y0_, affine_system->y0(), tol,
+                              MatrixCompareType::absolute));
+  EXPECT_EQ(time_period_, affine_system->time_period());
 }
 
 // A trivial system with discrete state that is not bound to a periodic update


### PR DESCRIPTION
This enables linearization along a trajectory for purposes such as trajectory-tracking controller design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7140)
<!-- Reviewable:end -->
