### PR TITLE
Fix anchor links in code_style_guide

### DIFF
--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -99,7 +99,7 @@ Clarifications
   ``drake/foo/test/bar_test.cc``.
   (`#2182 <https://github.com/RobotLocomotion/drake/issues/2182>`_)
 * When using `Integer Types
-  <https://google.github.io/styleguide/cppguide.html#Integer>`_
+  <https://google.github.io/styleguide/cppguide.html#Integer_Types>`_
   within Drake, unsigned types are forbidden, with the following exceptions
   (per `#2514 <https://github.com/RobotLocomotion/drake/issues/2514>`_):
 
@@ -110,7 +110,7 @@ Clarifications
     below zero is obviously not at risk.
 
 * When using `Integer Types
-  <https://google.github.io/styleguide/cppguide.html#Integer>`_
+  <https://google.github.io/styleguide/cppguide.html#Integer_Types>`_
   within Drake, `ptrdiff_t` is forbidden, with the following exceptions
   (per `#2514 <https://github.com/RobotLocomotion/drake/issues/2514>`_):
 


### PR DESCRIPTION
https://google.github.io/styleguide/cppguide.html#Integer is not a valid anchor link, while https://google.github.io/styleguide/cppguide.html#Integer_Types is a valid anchor link.

Note that the contribution guide states:

> Feature Review. After creating your pull request, assign it to someone else on your team for feature review.

but it is not clear how this works for external contributors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7143)
<!-- Reviewable:end -->
