### PR TITLE
clean up pass on SetDefaultContext pipeline

### DIFF
--- a/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -137,7 +137,7 @@ int DoMain() {
   systems::Context<double>* diagram_context = loop.get_mutable_context();
   systems::Context<double>& status_sub_context =
       diagram->GetMutableSubsystemContext(*status_sub, diagram_context);
-  status_sub->SetDefaults(&status_sub_context);
+  status_sub->SetDefaultContext(&status_sub_context);
 
   // Explicit initialization.
   diagram_context->set_time(msg_time);

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -387,7 +387,7 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateUnconnectedId) {
   auto diagram = builder.Build();
 
   auto diagram_context = diagram->AllocateContext();
-  diagram->SetDefaults(diagram_context.get());
+  diagram->SetDefaultContext(diagram_context.get());
   auto& geometry_context = dynamic_cast<GeometryContext<double>&>(
       diagram->GetMutableSubsystemContext(*geometry_system,
                                           diagram_context.get()));
@@ -408,7 +408,7 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateNoIdConnection) {
                   geometry_system->get_source_pose_port(source_id));
   auto diagram = builder.Build();
   auto diagram_context = diagram->AllocateContext();
-  diagram->SetDefaults(diagram_context.get());
+  diagram->SetDefaultContext(diagram_context.get());
   auto& geometry_context = dynamic_cast<GeometryContext<double>&>(
       diagram->GetMutableSubsystemContext(*geometry_system,
                                           diagram_context.get()));
@@ -432,7 +432,7 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateNoPoseConnection) {
                   geometry_system->get_source_frame_id_port(source_id));
   auto diagram = builder.Build();
   auto diagram_context = diagram->AllocateContext();
-  diagram->SetDefaults(diagram_context.get());
+  diagram->SetDefaultContext(diagram_context.get());
   auto& geometry_context = dynamic_cast<GeometryContext<double>&>(
       diagram->GetMutableSubsystemContext(*geometry_system,
                                           diagram_context.get()));
@@ -453,7 +453,7 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateNoConnections) {
   source_system->set_name("source_system");
   auto diagram = builder.Build();
   auto diagram_context = diagram->AllocateContext();
-  diagram->SetDefaults(diagram_context.get());
+  diagram->SetDefaultContext(diagram_context.get());
   auto& geometry_context = dynamic_cast<GeometryContext<double>&>(
       diagram->GetMutableSubsystemContext(*geometry_system,
                                           diagram_context.get()));

--- a/drake/multibody/multibody_tree/multibody_tree.cc
+++ b/drake/multibody/multibody_tree/multibody_tree.cc
@@ -163,12 +163,12 @@ MultibodyTree<T>::CreateDefaultContext() const {
         "to create a context.");
   }
   auto context = std::make_unique<MultibodyTreeContext<T>>(topology_);
-  SetDefaults(context.get());
+  SetDefaultContext(context.get());
   return std::move(context);
 }
 
 template <typename T>
-void MultibodyTree<T>::SetDefaults(systems::Context<T>* context) const {
+void MultibodyTree<T>::SetDefaultContext(systems::Context<T> *context) const {
   for (const auto& mobilizer : owned_mobilizers_) {
     mobilizer->set_zero_configuration(context);
   }

--- a/drake/multibody/multibody_tree/multibody_tree.h
+++ b/drake/multibody/multibody_tree/multibody_tree.h
@@ -651,7 +651,7 @@ class MultibodyTree {
   /// Sets default values in the context. For mobilizers, this method sets them
   /// to their _zero_ configuration according to
   /// Mobilizer::set_zero_configuration().
-  void SetDefaults(systems::Context<T>* context) const;
+  void SetDefaultContext(systems::Context<T> *context) const;
 
   /// Computes into the position kinematics `pc` all the kinematic quantities
   /// that depend on the generalized positions only. These include:

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -537,10 +537,10 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   RigidBodyPlant<double> time_stepping_plant(move(tree_ptr), timestep);
 
   auto continuous_context = continuous_plant.AllocateContext();
-  continuous_plant.SetDefaults(continuous_context.get());
+  continuous_plant.SetDefaultContext(continuous_context.get());
 
   auto time_stepping_context = time_stepping_plant.AllocateContext();
-  time_stepping_plant.SetDefaults(time_stepping_context.get());
+  time_stepping_plant.SetDefaultContext(time_stepping_context.get());
 
   // Check that the time-stepping model has the same states as the continuous,
   // but as discrete state.

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -531,6 +531,7 @@ drake_cc_googletest(
         ":diagram",
         "//drake/common:essential",
         "//drake/common/test_utilities:is_dynamic_castable",
+        "//drake/examples/pendulum:pendulum_plant",
         "//drake/systems/analysis:stateless_system",
         "//drake/systems/framework/test_utilities",
         "//drake/systems/primitives:adder",

--- a/drake/systems/framework/BUILD
+++ b/drake/systems/framework/BUILD
@@ -432,6 +432,7 @@ drake_cc_library(
         "//drake/common:essential",
         "//drake/common:symbolic",
         "//drake/common:type_safe_index",
+        "//drake/common:unused",
     ],
 )
 
@@ -650,6 +651,7 @@ drake_cc_googletest(
         ":leaf_output_port",
         ":system",
         "//drake/common:essential",
+        "//drake/common:unused",
         "//drake/systems/framework/test_utilities",
     ],
 )

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -325,14 +325,14 @@ class Diagram : public System<T>,
     }
   }
 
-  void SetDefaults(Context<T>* context) const final {
+  void SetDefaultContext(Context<T> *context) const final {
     auto diagram_context = dynamic_cast<DiagramContext<T>*>(context);
     DRAKE_DEMAND(diagram_context != nullptr);
 
     // Set defaults of each constituent system.
     for (int i = 0; i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetMutableSubsystemContext(i);
-      registered_systems_[i]->SetDefaults(&subcontext);
+      registered_systems_[i]->SetDefaultContext(&subcontext);
     }
   }
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -325,14 +325,50 @@ class Diagram : public System<T>,
     }
   }
 
-  void SetDefaultContext(Context<T> *context) const final {
-    auto diagram_context = dynamic_cast<DiagramContext<T>*>(context);
+  void SetDefaultParameters(const Context<T>& context,
+                            Parameters<T>* params) const override {
+    auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
 
-    // Set defaults of each constituent system.
+    int numeric_parameter_offset = 0;
+    int abstract_parameter_offset = 0;
+
+    // Set default state of each constituent system.
     for (int i = 0; i < num_subsystems(); ++i) {
-      auto& subcontext = diagram_context->GetMutableSubsystemContext(i);
-      registered_systems_[i]->SetDefaultContext(&subcontext);
+      auto& subcontext = diagram_context->GetSubsystemContext(i);
+
+      if (!subcontext.num_numeric_parameters() &&
+          !subcontext.num_abstract_parameters()) {
+        // Then there is no work to do for this subcontext.
+        continue;
+      }
+
+      // Make a new Parameters<T> structure with pointers to the mutable
+      // subsystem parameter values.  This does not make a copy of the
+      // underlying data.
+      // TODO(russt): Consider implementing a DiagramParameters, analogous to
+      // DiagramState, to avoid these dynamic allocations if they prove
+      // expensive.
+
+      std::vector<BasicVector<T>*> numeric_params;
+      std::vector<AbstractValue*> abstract_params;
+      for (int j = 0; j < subcontext.num_numeric_parameters(); ++j) {
+        numeric_params.push_back(params->get_mutable_numeric_parameter(
+            numeric_parameter_offset + j));
+      }
+      numeric_parameter_offset += subcontext.num_numeric_parameters();
+      for (int j = 0; j < subcontext.num_abstract_parameters(); ++j) {
+        abstract_params.push_back(&params->get_mutable_abstract_parameter(
+            abstract_parameter_offset + j));
+      }
+      abstract_parameter_offset += subcontext.num_abstract_parameters();
+      Parameters<T> subparameters;
+      subparameters.set_numeric_parameters(
+          std::make_unique<DiscreteValues<T>>(numeric_params));
+      subparameters.set_abstract_parameters(
+          std::make_unique<AbstractValues>(abstract_params));
+
+      registered_systems_[i]->SetDefaultParameters(subcontext, &subparameters);
     }
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -191,7 +191,7 @@ class LeafSystem : public System<T> {
   }
 
   // Sets Context fields to their default values.
-  void SetDefaults(Context<T>* context) const final {
+  void SetDefaultContext(Context<T> *context) const final {
     systems::LeafContext<T>* leaf_context =
         dynamic_cast<systems::LeafContext<T>*>(context);
     DRAKE_DEMAND(leaf_context != nullptr);

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -183,8 +183,8 @@ class LeafSystem : public System<T> {
   /// given to DeclareNumericParameter, or else if no model was provided sets
   /// the numeric parameter to one.  It makes no attempt to set abstract
   /// parameter values.  Overrides must not change the number of parameters.
-  virtual void SetDefaultParameters(const LeafContext<T>& context,
-                                    Parameters<T>* parameters) const {
+  void SetDefaultParameters(const Context<T>& context,
+                            Parameters<T>* parameters) const override {
     unused(context);
     for (int i = 0; i < parameters->num_numeric_parameters(); i++) {
       BasicVector<T>* p = parameters->get_mutable_numeric_parameter(i);
@@ -195,35 +195,6 @@ class LeafSystem : public System<T> {
         p->SetFromVector(VectorX<T>::Constant(p->size(), 1.0));
       }
     }
-  }
-
-  // Sets Context fields to their default values.
-  void SetDefaultContext(Context<T> *context) const final {
-    systems::LeafContext<T>* leaf_context =
-        dynamic_cast<systems::LeafContext<T>*>(context);
-    DRAKE_DEMAND(leaf_context != nullptr);
-
-    // Set the default state, checking that the number of state variables does
-    // not change.
-    const int n_xc = context->get_continuous_state()->size();
-    const int n_xd = context->get_num_discrete_state_groups();
-    const int n_xa = context->get_num_abstract_state_groups();
-
-    SetDefaultState(*context, context->get_mutable_state());
-
-    DRAKE_DEMAND(n_xc == context->get_continuous_state()->size());
-    DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
-    DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
-
-    // Set the default parameters, checking that the number of parameters does
-    // not change.
-    const int num_params = leaf_context->num_numeric_parameters();
-    SetDefaultParameters(*leaf_context,
-                         &leaf_context->get_mutable_parameters());
-    DRAKE_DEMAND(num_params == leaf_context->num_numeric_parameters());
-
-    // Verify that this context satisfies all of the constraints.
-    DRAKE_ASSERT(this->CheckSystemConstraints(*context));
   }
 
   std::unique_ptr<SystemOutput<T>> AllocateOutput(

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -146,10 +146,10 @@ class System {
   }
 
   /// This convenience method allocates a context using AllocateContext() and
-  /// sets its default values using SetDefaults().
+  /// sets its default values using SetDefaultContext().
   std::unique_ptr<Context<T>> CreateDefaultContext() const {
     std::unique_ptr<Context<T>> context = AllocateContext();
-    SetDefaults(context.get());
+    SetDefaultContext(context.get());
     return context;
   }
 
@@ -160,7 +160,7 @@ class System {
 
   // Sets Context fields to their default values.  User code should not
   // override.
-  virtual void SetDefaults(Context<T>* context) const = 0;
+  virtual void SetDefaultContext(Context<T> *context) const = 0;
 
   /// For each input port, allocates a freestanding input of the concrete type
   /// that this System requires, and binds it to the port, disconnecting any

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -159,6 +159,11 @@ class System {
   virtual void SetDefaultState(const Context<T>& context,
                                State<T>* state) const = 0;
 
+  /// Assigns default values to all parameters. Overrides must not
+  /// change the number of parameters.
+  virtual void SetDefaultParameters(const Context<T>& context,
+                                    Parameters<T>* parameters) const = 0;
+
   // Sets Context fields to their default values.  User code should not
   // override.
   void SetDefaultContext(Context<T> *context) const {

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -17,6 +17,7 @@
 #include "drake/common/eigen_autodiff_types.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/common/symbolic.h"
+#include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
@@ -160,7 +161,25 @@ class System {
 
   // Sets Context fields to their default values.  User code should not
   // override.
-  virtual void SetDefaultContext(Context<T> *context) const = 0;
+  void SetDefaultContext(Context<T> *context) const {
+    // Set the default state, checking that the number of state variables does
+    // not change.
+    const int n_xc = context->get_continuous_state()->size();
+    const int n_xd = context->get_num_discrete_state_groups();
+    const int n_xa = context->get_num_abstract_state_groups();
+
+    SetDefaultState(*context, context->get_mutable_state());
+
+    DRAKE_DEMAND(n_xc == context->get_continuous_state()->size());
+    DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
+    DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
+
+    // Set the default parameters, checking that the number of parameters does
+    // not change.
+    const int num_params = context->num_numeric_parameters();
+    SetDefaultParameters(*context, &context->get_mutable_parameters());
+    DRAKE_DEMAND(num_params == context->num_numeric_parameters());
+  }
 
   /// For each input port, allocates a freestanding input of the concrete type
   /// that this System requires, and binds it to the port, disconnecting any
@@ -868,6 +887,22 @@ class System {
                               " constraints.");
     }
     return *constraints_[constraint_index];
+  }
+
+  /// Returns true if @p context satisfies all of the registered
+  /// SystemConstraints with tolerance @p tol.
+  bool CheckSystemConstraints(const Context<T>& context,
+                              double tol = 1E-6) const {
+    DRAKE_DEMAND(tol >= 0.0);
+    for (const auto& constraint : constraints_) {
+      if (!constraint->CheckSatisfied(context, tol)) {
+        SPDLOG_DEBUG(drake::log(),
+                     "Context fails to satisfy SystemConstraint {}",
+                     constraint->description());
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Returns the total dimension of all of the input ports (as if they were

--- a/drake/systems/framework/system_constraint.h
+++ b/drake/systems/framework/system_constraint.h
@@ -9,6 +9,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/type_safe_index.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace systems {
@@ -99,6 +100,16 @@ class SystemConstraint {
     } else {
       return (value.array() >= -tol).all();
     }
+  }
+
+  /// Supports CheckSastisfied calls for non-numeric scalar types by simply
+  /// returning true.
+  template <typename T1 = T>
+  typename std::enable_if<!is_numeric<T1>::value, bool>::type CheckSatisfied(
+      const Context<T1>& context, double tol = 1E-6) const {
+    DRAKE_DEMAND(tol >= 0.0);
+    unused(context);
+    return true;
   }
 
   // Accessor methods.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
+#include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/systems/analysis/test/stateless_system.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -1922,6 +1923,47 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
   VectorX<symbolic::Expression> symbolic_value;
   symbolic_constraint.Calc(*symbolic_context, &symbolic_value);
   EXPECT_EQ(symbolic_value[0], 11.0);
+}
+
+GTEST_TEST(DiagramParametersTest, ParameterTest) {
+  // Construct a diagram with multiple subsytems that have parameters.
+  systems::DiagramBuilder<double> builder;
+  auto pendulum1 =
+      builder.AddSystem<examples::pendulum::PendulumPlant<double>>();
+  auto pendulum2 =
+      builder.AddSystem<examples::pendulum::PendulumPlant<double>>();
+  auto constant_torque =
+      builder.AddSystem<ConstantVectorSource<double>>(Vector1d(1.0));
+  builder.Cascade(*constant_torque, *pendulum1);
+  builder.Cascade(*constant_torque, *pendulum2);
+  auto diagram = builder.Build();
+
+  auto context = diagram->CreateDefaultContext();
+
+  // Get pointers to the parameters.
+  auto params1 = dynamic_cast<examples::pendulum::PendulumParams<double>*>(
+      diagram->GetMutableSubsystemContext(*pendulum1, context.get())
+          .get_mutable_numeric_parameter(0));
+  auto params2 = dynamic_cast<examples::pendulum::PendulumParams<double>*>(
+      diagram->GetMutableSubsystemContext(*pendulum2, context.get())
+          .get_mutable_numeric_parameter(0));
+
+  const double original_damping = params1->damping();
+  const double new_damping = 5.0*original_damping;
+  EXPECT_EQ(params2->damping(), original_damping);
+
+  params1->set_damping(new_damping);
+  // Check that I didn't change params2.
+  EXPECT_EQ(params2->damping(), original_damping);
+
+  diagram->SetDefaultContext(context.get());
+  // Check that the original value is restored.
+  EXPECT_EQ(params1->damping(), original_damping);
+
+  params2->set_damping(new_damping);
+  diagram->SetDefaultParameters(*context, &context->get_mutable_parameters());
+  // Check that the original value is restored.
+  EXPECT_EQ(params2->damping(), original_damping);
 }
 
 // TODO(siyuan) add direct tests for EventCollection

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -64,7 +64,7 @@ class TestSystem : public LeafSystem<T> {
     return std::make_unique<Parameters<T>>(std::make_unique<BasicVector<T>>(2));
   }
 
-  void SetDefaultParameters(const LeafContext<T>& context,
+  void SetDefaultParameters(const Context<T>& context,
                             Parameters<T>* params) const override {
     BasicVector<T>* param = params->get_mutable_numeric_parameter(0);
     Vector2<T> p0;

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -55,7 +55,7 @@ class TestSystem : public System<double> {
   void SetDefaultState(const Context<double>& context,
                        State<double>* state) const override {}
 
-  void SetDefaults(Context<double>* context) const override {}
+  void SetDefaultContext(Context<double> *context) const override {}
 
   std::unique_ptr<SystemOutput<double>> AllocateOutput(
       const Context<double>& context) const override {
@@ -460,7 +460,7 @@ class ValueIOTestSystem : public System<T> {
   void SetDefaultState(const Context<T>& context,
                        State<T>* state) const override {}
 
-  void SetDefaults(Context<T>* context) const override {}
+  void SetDefaultContext(Context<T> *context) const override {}
 
   std::multimap<int, int> GetDirectFeedthroughs() const override {
     std::multimap<int, int> pairs;

--- a/drake/systems/framework/test/system_test.cc
+++ b/drake/systems/framework/test/system_test.cc
@@ -56,7 +56,8 @@ class TestSystem : public System<double> {
   void SetDefaultState(const Context<double>& context,
                        State<double>* state) const override {}
 
-  void SetDefaultContext(Context<double> *context) const override {}
+  void SetDefaultParameters(const Context<double>& context,
+                            Parameters<double>* params) const override {}
 
   std::unique_ptr<SystemOutput<double>> AllocateOutput(
       const Context<double>& context) const override {
@@ -470,7 +471,8 @@ class ValueIOTestSystem : public System<T> {
   void SetDefaultState(const Context<T>& context,
                        State<T>* state) const override {}
 
-  void SetDefaultContext(Context<T> *context) const override {}
+  void SetDefaultParameters(const Context<T>& context,
+                            Parameters<T>* params) const override {}
 
   std::multimap<int, int> GetDirectFeedthroughs() const override {
     std::multimap<int, int> pairs;

--- a/drake/systems/sensors/rotary_encoders.cc
+++ b/drake/systems/sensors/rotary_encoders.cc
@@ -58,6 +58,8 @@ RotaryEncoders<T>::RotaryEncoders(int input_port_size,
   DRAKE_ASSERT(ticks_per_revolution_.empty() ||
                *std::min_element(ticks_per_revolution_.begin(),
                                  ticks_per_revolution_.end()) >= 0);
+  this->DeclareNumericParameter(
+      BasicVector<T>(VectorX<T>::Zero(num_encoders_)));
 }
 
 template <typename T>
@@ -94,20 +96,6 @@ void RotaryEncoders<T>::DoCalcVectorOutput(
       y(i) = floor(y(i) * ticks_per_radian) / ticks_per_radian;
     }
   }
-}
-
-template <typename T>
-std::unique_ptr<Parameters<T>> RotaryEncoders<T>::AllocateParameters() const {
-  // Use parameters for the (unnamed) calibration offsets.
-  return std::make_unique<Parameters<T>>(
-      std::make_unique<BasicVector<T>>(num_encoders_));
-}
-
-template <typename T>
-void RotaryEncoders<T>::SetDefaultParameters(
-    const LeafContext<T>&,
-    Parameters<T>* params) const {
-  params->get_mutable_numeric_parameter(0)->SetZero();
 }
 
 template <typename T>

--- a/drake/systems/sensors/rotary_encoders.h
+++ b/drake/systems/sensors/rotary_encoders.h
@@ -45,9 +45,6 @@ class RotaryEncoders final : public VectorSystem<T> {
   template <typename U>
   explicit RotaryEncoders(const RotaryEncoders<U>&);
 
-  /// Calibration offsets are defined as parameters.
-  std::unique_ptr<Parameters<T>> AllocateParameters() const override;
-
   /// Set the calibration offset parameters.
   void set_calibration_offsets(
       Context<T>* context,
@@ -67,9 +64,6 @@ class RotaryEncoders final : public VectorSystem<T> {
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
-
-  void SetDefaultParameters(const LeafContext<T>& context,
-                            Parameters<T>* params) const override;
 
   const int num_encoders_{0};       // Dimension of the output port.
   const std::vector<int> indices_;  // Selects from the input port.


### PR DESCRIPTION
(in preparation for the `SetRandomContext` pipeline that is my real goal)

- refactors `SetDefaults` -> `SetDefaultContext`
- adds a debug-only check that the output of `SetDefaultContext` satisfies all registered `SystemConstraint`s
- moves `SetDefaultParameters` from `LeafSystem` up to `System`, and adds the implementation for `Diagram`.  The diagram implementation was less beautiful than I hoped -- parameters are definitely a second-class citizen at the `Diagram` level.  Perhaps another thing to consider in #7017.

Note that I've curated the commits... it might be easiest to review them sequentially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7145)
<!-- Reviewable:end -->
