### PR TITLE
adds a helper utility to wire up random input ports on a DiagramBuilder

### DIFF
--- a/drake/doc/doxygen_instructions.rst
+++ b/drake/doc/doxygen_instructions.rst
@@ -16,6 +16,17 @@ Coming soon. See issue
 `#2051 <https://github.com/RobotLocomotion/drake/issues/2051>`_ and PR
 `#2359 <https://github.com/RobotLocomotion/drake/pull/2359>`_.
 
+
+Documentation Tips and Tricks
+=============================
+
+We encourage the use of `unicode <unicode_tips_tricks>`_ in documentation.
+
+For documenting block diagrams, consider using ascii art.  See, for instance,
+
+- http://asciiflow.com/
+
+
 .. _doxygen-generation:
 
 Doxygen Website Generation

--- a/drake/systems/framework/diagram_builder.h
+++ b/drake/systems/framework/diagram_builder.h
@@ -351,6 +351,8 @@ class DiagramBuilder {
   std::unordered_set<const System<T>*> systems_;
   // The Systems in this DiagramBuilder, in the order they were registered.
   std::vector<std::unique_ptr<System<T>>> registered_systems_;
+
+  friend int AddRandomInputs(double, systems::DiagramBuilder<double>*);
 };
 
 }  // namespace systems

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -167,6 +167,7 @@ drake_cc_library(
     srcs = ["random_source.cc"],
     hdrs = ["random_source.h"],
     deps = [
+        "//drake/common:essential",
         "//drake/common:unused",
         "//drake/systems/framework:diagram_builder",
         "//drake/systems/framework:leaf_system",

--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -167,7 +167,9 @@ drake_cc_library(
     srcs = ["random_source.cc"],
     hdrs = ["random_source.h"],
     deps = [
-        "//drake/systems/framework",
+        "//drake/common:unused",
+        "//drake/systems/framework:diagram_builder",
+        "//drake/systems/framework:leaf_system",
     ],
 )
 
@@ -371,6 +373,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "random_source_test",
     deps = [
+        ":constant_vector_source",
         ":random_source",
         ":signal_logger",
         "//drake/common/test_utilities:eigen_matrix_compare",

--- a/drake/systems/primitives/random_source.cc
+++ b/drake/systems/primitives/random_source.cc
@@ -1,4 +1,56 @@
-// For now, this is an empty .cc file that only serves to confirm
-// random_source.h is a stand-alone header.
-
 #include "drake/systems/primitives/random_source.h"
+
+namespace drake {
+namespace systems {
+
+int AddRandomInputs(double sampling_interval_sec,
+                    DiagramBuilder<double>* builder) {
+  int count = 0;
+  for (const auto system : builder->GetMutableSystems()) {
+    for (int i = 0; i < system->get_num_input_ports(); i++) {
+      const systems::InputPortDescriptor<double>& port =
+          system->get_input_port(i);
+      // Check for the random label.
+      if (!port.is_random()) {
+        continue;
+      }
+
+      typedef typename Diagram<double>::PortIdentifier PortIdentifier;
+      // Check if the input is already wired up.
+      PortIdentifier id{port.get_system(), port.get_index()};
+      if (builder->dependency_graph_.find(id) !=
+              builder->dependency_graph_.end() ||
+          builder->diagram_input_set_.find(id) !=
+              builder->diagram_input_set_.end()) {
+        continue;
+      }
+
+      switch (port.get_random_type().value()) {
+        case RandomDistribution::kUniform: {
+          const auto uniform = builder->AddSystem<UniformRandomSource>(
+              port.size(), sampling_interval_sec);
+          builder->Connect(uniform->get_output_port(0), port);
+        } break;
+        case RandomDistribution::kGaussian: {
+          const auto gaussian = builder->AddSystem<GaussianRandomSource>(
+              port.size(), sampling_interval_sec);
+          builder->Connect(gaussian->get_output_port(0), port);
+        } break;
+        case RandomDistribution::kExponential: {
+          const auto exponential = builder->AddSystem<ExponentialRandomSource>(
+              port.size(), sampling_interval_sec);
+          builder->Connect(exponential->get_output_port(0), port);
+        } break;
+        default: {
+          DRAKE_ABORT_MSG(
+              "InputPortDescriptor has an unsupported RandomDistribution.");
+        }
+      }
+      count++;
+    }
+  }
+  return count;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/random_source.cc
+++ b/drake/systems/primitives/random_source.cc
@@ -1,12 +1,28 @@
 #include "drake/systems/primitives/random_source.h"
 
+#include "drake/common/never_destroyed.h"
+
 namespace drake {
 namespace systems {
+
+namespace internal {
+template<typename Generator>
+typename Generator::result_type generate_unique_seed() {
+  static never_destroyed<typename Generator::result_type> seed(
+      Generator::default_seed);
+  return seed.access()++;
+}
+
+template std::mt19937::result_type generate_unique_seed<std::mt19937>();
+
+}  // namespace internal
 
 int AddRandomInputs(double sampling_interval_sec,
                     DiagramBuilder<double>* builder) {
   int count = 0;
-  for (const auto system : builder->GetMutableSystems()) {
+  // Note: the mutable assignment to const below looks odd, but
+  // there is (currently) no builder->GetSystems() method.
+  for (const auto* system : builder->GetMutableSystems()) {
     for (int i = 0; i < system->get_num_input_ports(); i++) {
       const systems::InputPortDescriptor<double>& port =
           system->get_input_port(i);
@@ -18,26 +34,24 @@ int AddRandomInputs(double sampling_interval_sec,
       typedef typename Diagram<double>::PortIdentifier PortIdentifier;
       // Check if the input is already wired up.
       PortIdentifier id{port.get_system(), port.get_index()};
-      if (builder->dependency_graph_.find(id) !=
-              builder->dependency_graph_.end() ||
-          builder->diagram_input_set_.find(id) !=
-              builder->diagram_input_set_.end()) {
+      if (builder->dependency_graph_.count(id) > 0 ||
+          builder->diagram_input_set_.count(id) > 0) {
         continue;
       }
 
       switch (port.get_random_type().value()) {
         case RandomDistribution::kUniform: {
-          const auto uniform = builder->AddSystem<UniformRandomSource>(
+          const auto* uniform = builder->AddSystem<UniformRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(uniform->get_output_port(0), port);
         } break;
         case RandomDistribution::kGaussian: {
-          const auto gaussian = builder->AddSystem<GaussianRandomSource>(
+          const auto* gaussian = builder->AddSystem<GaussianRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(gaussian->get_output_port(0), port);
         } break;
         case RandomDistribution::kExponential: {
-          const auto exponential = builder->AddSystem<ExponentialRandomSource>(
+          const auto* exponential = builder->AddSystem<ExponentialRandomSource>(
               port.size(), sampling_interval_sec);
           builder->Connect(exponential->get_output_port(0), port);
         } break;
@@ -54,3 +68,4 @@ int AddRandomInputs(double sampling_interval_sec,
 
 }  // namespace systems
 }  // namespace drake
+

--- a/drake/systems/primitives/random_source.h
+++ b/drake/systems/primitives/random_source.h
@@ -12,6 +12,11 @@
 namespace drake {
 namespace systems {
 
+namespace internal {
+
+template <typename Generator = std::mt19937>
+typename Generator::result_type generate_unique_seed();
+
 /// State for a given random distribution and generator. This owns both the
 /// distribution and the generator.
 template <typename Distribution, typename Generator = std::mt19937>
@@ -20,8 +25,7 @@ class RandomState {
   typedef typename Generator::result_type Seed;
   static constexpr Seed default_seed = Generator::default_seed;
 
-  explicit RandomState(Seed seed = Generator::default_seed)
-      : generator_(seed) {}
+  explicit RandomState(Seed seed) : generator_(seed) {}
 
   /// Generate the next random value with the given distribution.
   double GetNextValue() { return distribution_(generator_); }
@@ -55,13 +59,14 @@ class RandomSource : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RandomSource)
 
-  typedef systems::RandomState<Distribution, Generator> RandomState;
+  typedef internal::RandomState<Distribution, Generator> RandomState;
   typedef typename RandomState::Seed Seed;
 
   /// Constructs the RandomSource system.
   /// @param num_outputs The dimension of the (single) vector output port.
   /// @param sampling_interval_sec The sampling interval in seconds.
-  RandomSource(int num_outputs, double sampling_interval_sec) {
+  RandomSource(int num_outputs, double sampling_interval_sec)
+      : seed_(generate_unique_seed()) {
     this->DeclarePeriodicUnrestrictedUpdate(sampling_interval_sec, 0.);
     this->DeclareVectorOutputPort(BasicVector<double>(num_outputs),
                                   &RandomSource::CopyStateToOutput);
@@ -76,11 +81,9 @@ class RandomSource : public LeafSystem<double> {
  private:
   // Computes a random number and stores it in the discrete state.
   void DoCalcUnrestrictedUpdate(
-      const Context<double>& context,
-      const std::vector<const UnrestrictedUpdateEvent<double>*>& events,
+      const Context<double>&,
+      const std::vector<const UnrestrictedUpdateEvent<double>*>&,
       State<double>* state) const override {
-    unused(context);
-    unused(events);
     auto& random_state =
         state->template get_mutable_abstract_state<RandomState>(0);
     auto* updates = state->get_mutable_discrete_state();
@@ -104,28 +107,31 @@ class RandomSource : public LeafSystem<double> {
   Seed seed_{RandomState::default_seed};
 };
 
+}  // namespace internal
+
 /// Generates uniformly distributed random numbers in the interval [0,1].
 ///
 /// @ingroup primitive_systems
-typedef RandomSource<std::uniform_real_distribution<double>>
+typedef internal::RandomSource<std::uniform_real_distribution<double>>
     UniformRandomSource;
 
 /// Generates normally distributed random numbers with mean zero and unit
 /// covariance.
 ///
 /// @ingroup primitive_systems
-typedef RandomSource<std::normal_distribution<double>> GaussianRandomSource;
+typedef internal::RandomSource<std::normal_distribution<double>>
+    GaussianRandomSource;
 
 /// Generates exponentially distributed random numbers with mean, standard
 /// deviation, and scale parameter (aka 1/λ) set to one.
 ///
 /// @ingroup primitive_systems
-typedef RandomSource<std::exponential_distribution<double>>
+typedef internal::RandomSource<std::exponential_distribution<double>>
     ExponentialRandomSource;
 
 /// For each subsystem input port in @p builder that is (a) not yet connected
-/// and (b) labeled as random in the InputPortDescriptor, this method will Add a
-/// new RandomSource system of the appropriate type and Connect it to the
+/// and (b) labeled as random in the InputPortDescriptor, this method will add a
+/// new RandomSource system of the appropriate type and connect it to the
 /// subsystem input port.
 ///
 /// @param sampling_interval_sec interval to be used for all new sources.

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -24,9 +24,9 @@ template <typename Distribution, typename Generator>
 void CheckStatistics(
     const std::function<double(double)>& cumulative_distribution,
     double min_value, double max_value, double h, double fudge_factor,
-    std::unique_ptr<RandomSource<Distribution, Generator>>
+    std::unique_ptr<internal::RandomSource<Distribution, Generator>>
         random_source_system) {
-  systems::DiagramBuilder<double> builder;
+  DiagramBuilder<double> builder;
 
   auto source = builder.AddSystem(std::move(random_source_system));
   source->set_name("source");
@@ -127,41 +127,62 @@ class TestSystem : public LeafSystem<double> {
   using LeafSystem::EvalVectorInput;
 };
 
+
+//      +-------------------------+
+//      |                         |
+//      | +--------+              |
+//      | |uniform |              |
+//      | +--------+       +----+ |
+//      |          +------>|sys1| |
+// +---------------------->|    | |
+//      |                  +----+ |
+//      | +--------+              |
+//      | |gaussian|---+          |
+//      | +--------+   |   +----+ |
+//      | +--------+   +-->|    | |
+//      | |exponent|------>|sys2| |
+//      | +--------+   +-->|    | |
+//      | +--------+   |   +----+ |
+//      | |constant|---+          |
+//      | +--------+              |
+//      |                         |
+//      +-------------------------+
 GTEST_TEST(RandomSourceTest, AddToDiagramBuilderTest) {
   DiagramBuilder<double> builder;
 
-  auto sys1 = builder.AddSystem<TestSystem>();
+  auto* sys1 = builder.AddSystem<TestSystem>();
   sys1->DeclareInputPort(kVectorValued, 3, RandomDistribution::kUniform);
   sys1->DeclareInputPort(kVectorValued, 2, RandomDistribution::kExponential);
 
-  auto sys2 = builder.AddSystem<TestSystem>();
+  auto* sys2 = builder.AddSystem<TestSystem>();
   sys2->DeclareInputPort(kVectorValued, 5, RandomDistribution::kGaussian);
-  sys2->DeclareInputPort(kVectorValued, 2, RandomDistribution::kGaussian);
+  sys2->DeclareInputPort(kVectorValued, 2, RandomDistribution::kExponential);
   sys2->DeclareInputPort(kVectorValued, 1, RandomDistribution::kGaussian);
 
   // Export input 1.
   builder.ExportInput(sys2->get_input_port(1));
 
   // Connect input 2 to a different block.
-  auto constant_input = builder.AddSystem<ConstantVectorSource<double>>(14.0);
+  const auto* constant_input =
+      builder.AddSystem<ConstantVectorSource<double>>(14.0);
   builder.Connect(constant_input->get_output_port(), sys2->get_input_port(2));
 
   EXPECT_EQ(AddRandomInputs(1e-3, &builder), 3);
 
-  auto diagram = builder.Build();
+  const auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
 
-  // Check that new Uniform source was created properly.
+  // Check that the uniform input port is connected.
   EXPECT_NE(
       sys1->EvalVectorInput(diagram->GetSubsystemContext(*sys1, *context), 0),
       nullptr);
 
-  // Check that new Exponential source was created properly.
+  // Check that the exponential input port is connected.
   EXPECT_NE(
       sys1->EvalVectorInput(diagram->GetSubsystemContext(*sys1, *context), 1),
       nullptr);
 
-  // Check that new Gaussian source was created properly.
+  // Check that the Gaussian input port is connected.
   EXPECT_NE(
       sys2->EvalVectorInput(diagram->GetSubsystemContext(*sys2, *context), 0),
       nullptr);
@@ -174,6 +195,42 @@ GTEST_TEST(RandomSourceTest, AddToDiagramBuilderTest) {
   EXPECT_EQ(sys2->EvalEigenVectorInput(
                 diagram->GetSubsystemContext(*sys2, *context), 2)[0],
             14.0);
+}
+
+GTEST_TEST(RandomSourceTest, CorrelationTest) {
+  // Tests that two separate input ports, with the default seeds, are
+  // uncorrelated.
+
+  DiagramBuilder<double> builder;
+  const int kSize = 1;
+  const double kSampleTime = 0.0025;
+  const auto* random1 =
+      builder.AddSystem<GaussianRandomSource>(kSize, kSampleTime);
+  const auto* log1 = LogOutput(random1->get_output_port(0), &builder);
+
+  const auto* random2 =
+      builder.AddSystem<GaussianRandomSource>(kSize, kSampleTime);
+  const auto* log2 = LogOutput(random2->get_output_port(0), &builder);
+
+  const auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+  simulator.Initialize();
+  simulator.StepTo(20);
+
+  const auto& x1 = log1->data();
+  const auto& x2 = log2->data();
+
+  EXPECT_EQ(x1.size(), x2.size());
+  const int N = static_cast<int>(x1.size()) / 2;
+  for (int i = 0; i < N; i++) {
+    // Compute cross-correlation
+    const double xcorr =
+        (x1.middleCols(0, N).array() * x2.middleCols(i, N).array()).sum();
+    // Note: The threshold doesn't need to be small.  Any correlations due to
+    // using the same seed will lead to numbers ≊ 1.
+    EXPECT_LE(xcorr / N, 0.1);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Also makes default seeds for RandomSource blocks unique  …
(resolves nasty "feature" where all of our random source blocks were accidentally perfectly correlated)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7149)
<!-- Reviewable:end -->
