### PR TITLE
Remove IPOPT from the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,29 +49,6 @@ drake_add_external(googletest CMAKE
     -DBUILD_SHARED_LIBS=ON
     -DCMAKE_INSTALL_NAME_DIR=${CMAKE_INSTALL_PREFIX}/lib)
 
-# ipopt
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # Work around horrific clang* = clang, */cl* = msvc bug in BuildTools/coin.m4
-  get_filename_component(IPOPT_C_COMPILER "${CMAKE_C_COMPILER}" NAME)
-  get_filename_component(IPOPT_CXX_COMPILER "${CMAKE_CXX_COMPILER}" NAME)
-else()
-  set(IPOPT_C_COMPILER "${CMAKE_C_COMPILER}")
-  set(IPOPT_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
-endif()
-
-drake_add_external(ipopt AUTOTOOLS FORTRAN
-  URL https://github.com/RobotLocomotion/ipopt-mirror/archive/aecf5abd3913eebf1b99167c0edd4e65a6b414bc.tar.gz
-  URL_HASH SHA256=d88ea1b6b34c5678ef32ced22a6e9cb00f76a490f233d0b2d56270609eb94e3e
-  AUTOTOOLS_ENV
-    CC=${IPOPT_C_COMPILER}
-    CXX=${IPOPT_CXX_COMPILER}
-  AUTOTOOLS_CONFIGURE_ARGS
-    --disable-shared
-    --includedir=${CMAKE_INSTALL_PREFIX}/include/ipopt
-    --with-blas=BUILD
-    --with-lapack=BUILD
-    --with-pic)
-
 # nlopt
 drake_add_external(nlopt CMAKE ALWAYS
   URL https://github.com/stevengj/nlopt/archive/45553da97c890ef58f95e7ef73c5409d2169e824.tar.gz
@@ -122,7 +99,6 @@ drake_add_external(drake LOCAL CMAKE ALWAYS MATLAB PYTHON
     fmt
     gflags
     googletest
-    ipopt
     nlopt
     protobuf
     pybind11

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -164,38 +164,6 @@ macro(drake_setup_java)
 endmacro()
 
 #------------------------------------------------------------------------------
-# Find and set up Fortran.
-#------------------------------------------------------------------------------
-macro(drake_setup_fortran)
-  option(DISABLE_FORTRAN "Do not use Fortran even if it is supported" OFF)
-  mark_as_advanced(DISABLE_FORTRAN)
-
-  if(NOT DISABLE_FORTRAN)
-    if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-      enable_language(Fortran)
-
-      if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "4.9")
-        message(FATAL_ERROR "GNU Fortran compiler version must be at least 4.9 \
-                             (detected version ${CMAKE_Fortran_COMPILER_VERSION})")
-      endif()
-    else()
-      # Ninja may not support Fortran, so manually find the Fortran
-      # compiler and set any flags passed in by environment variable
-      find_program(CMAKE_Fortran_COMPILER
-        NAMES "$ENV{FC}" gfortran-6 gfortran-5 gfortran-4.9 gfortran-4 gfortran
-        DOC "Fortran compiler")
-      if(CMAKE_Fortran_COMPILER)
-        message(STATUS "Found Fortran compiler: ${CMAKE_Fortran_COMPILER}")
-      else()
-        message(FATAL_ERROR "Could NOT find Fortran compiler")
-      endif()
-      set(CMAKE_Fortran_FLAGS "$ENV{FFLAGS}" CACHE STRING
-        "Flags for Fortran compiler")
-    endif()
-  endif()
-endmacro()
-
-#------------------------------------------------------------------------------
 # Set up Python.
 #------------------------------------------------------------------------------
 macro(drake_setup_python)
@@ -273,9 +241,6 @@ macro(drake_setup_superbuild)
       "Prefix for installation of sub-packages (note: required during build!)"
       FORCE)
   endif()
-
-  # Drake itself does not contain Fortran code.
-  drake_setup_fortran()
 endmacro()
 
 ###############################################################################

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -118,17 +118,6 @@ macro(drake_add_cmake_external PROJECT)
     CMAKE_INSTALL_RPATH
     CMAKE_INSTALL_RPATH_USE_LINK_PATH)
 
-  if(_ext_FORTRAN)
-    list(APPEND _ext_PROPAGATE_CACHE_VARS
-      CMAKE_Fortran_COMPILER
-      CMAKE_Fortran_FLAGS)
-
-    if(NOT _ext_GENERATOR STREQUAL "Unix Makefiles")
-      # Ninja and Xcode may not support Fortran.
-      set(_ext_GENERATOR "Unix Makefiles")
-    endif()
-  endif()
-
   if(_ext_MATLAB AND Matlab_FOUND)
     list(APPEND _ext_PROPAGATE_CACHE_VARS
       Matlab_ROOT_DIR
@@ -279,7 +268,6 @@ endmacro()
 #   CMAKE     - External uses CMake
 #   AUTOTOOLS - External uses Autotools
 #   ALWAYS    - External is always built
-#   FORTRAN   - External uses Fortran
 #   MATLAB    - External uses MATLAB
 #   PYTHON    - External uses Python
 #
@@ -333,7 +321,6 @@ function(drake_add_external PROJECT)
     CMAKE
     AUTOTOOLS
     ALWAYS
-    FORTRAN
     MATLAB
     PYTHON
   )

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -213,9 +213,6 @@ endfunction()
 # Set up options
 #------------------------------------------------------------------------------
 macro(drake_setup_options)
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # BEGIN "system" dependencies
-
   # These are packages that we can build, but which we allow the user to use
   # their own copy (usually provided by the system) if preferred.
 
@@ -250,17 +247,4 @@ macro(drake_setup_options)
   drake_system_dependency(
     TINYOBJLOADER REQUIRES tinyobjloader VERSION 1.0.6
     "Library for reading wavefront mesh files")
-
-  # END "system" dependencies
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # BEGIN external projects that are ON by default
-
-  # IPOPT is currently disabled on Mac when MATLAB is enabled due to MATLAB
-  # compatibility issues:
-  # https://github.com/RobotLocomotion/drake/issues/2578
-  drake_optional_external(IPOPT ON
-    DEPENDS "NOT APPLE OR NOT Matlab_FOUND"
-    "Interior Point Optimizer, for solving non-linear optimizations")
-
-  # END external projects that are ON by default
 endmacro()

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -128,9 +128,6 @@ endfunction()
 # Find external packages.
 #------------------------------------------------------------------------------
 macro(drake_find_packages)
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # BEGIN required packages
-
   drake_find_package(Eigen3 CONFIG REQUIRED)
   set_property(TARGET Eigen3::Eigen APPEND PROPERTY
     INTERFACE_COMPILE_DEFINITIONS EIGEN_MPL2_ONLY)  # Per #4065.
@@ -158,13 +155,4 @@ macro(drake_find_packages)
   endif()
 
   drake_find_package(tinyobjloader CONFIG REQUIRED)
-
-  # END required packages
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # BEGIN optional packages
-
-  drake_find_package(ipopt PKG_CONFIG)
-
-  # END optional packages
-  #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 endmacro()

--- a/drake/bindings/pybind11/CMakeLists.txt
+++ b/drake/bindings/pybind11/CMakeLists.txt
@@ -34,14 +34,6 @@ target_link_libraries(_pydrake_mathematicalprogram PRIVATE drakeOptimization Eig
 target_compile_options(_pydrake_mathematicalprogram PRIVATE "-fvisibility=default")
 install(TARGETS _pydrake_mathematicalprogram DESTINATION ${PYDRAKE_INSTALL_DIR}/solvers)
 
-if(ipopt_FOUND)
-  pybind11_add_module(_pydrake_ipopt pydrake_ipopt.cc)
-  target_link_libraries(_pydrake_ipopt PRIVATE drakeOptimization)
-  set_target_properties(_pydrake_ipopt PROPERTIES OUTPUT_NAME "ipopt")
-  target_compile_options(_pydrake_ipopt PRIVATE "-fvisibility=default")
-  install(TARGETS _pydrake_ipopt DESTINATION ${PYDRAKE_INSTALL_DIR}/solvers)
-endif()
-
 pybind11_add_module(_pydrake_parsers pydrake_parsers.cc)
 target_link_libraries(_pydrake_parsers PRIVATE drakeMultibodyParsers)
 set_target_properties(_pydrake_parsers PROPERTIES OUTPUT_NAME "parsers")

--- a/drake/bindings/python/CMakeLists.txt
+++ b/drake/bindings/python/CMakeLists.txt
@@ -22,8 +22,4 @@ if(BUILD_TESTING)
   drake_add_python_test(pydrake.test.testRBTCoM)
   drake_add_python_test(pydrake.test.testForwardDiff)
   drake_add_python_test(pydrake.test.testSymbolic)
-
-  if(ipopt_FOUND)
-    drake_add_python_test(pydrake.test.test_ipopt_solver)
-  endif()
 endif()

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND optimization_files
   nlopt_solver.cc
   no_dreal.cc
   no_gurobi.cc
+  no_ipopt.cc
   no_mosek.cc
   no_snopt.cc
   snopt_solver_common.cc
@@ -42,11 +43,6 @@ list(APPEND optimization_files
   symbolic_extraction.cc
   system_identification.cc
   )
-if(ipopt_FOUND)
- list(APPEND optimization_files ipopt_solver.cc)
-else()
-  list(APPEND optimization_files no_ipopt.cc)
-endif()
 
 add_library(drakeOptimization ${optimization_files})
 target_link_libraries(drakeOptimization
@@ -69,26 +65,6 @@ drake_install_headers(
   system_identification.h
   )
 drake_install_libraries(drakeOptimization)
-
-if(ipopt_FOUND)
-  target_link_libraries(drakeOptimization ipopt)
-  # IPOPT builds its own version of BLAS during compilation, and links
-  # it into the output library.  On (at least some) ELF systems, you
-  # wind up with a symbol name collision between IPOPT's BLAS and
-  # other BLAS implementations in other dynamic libraries (MATLAB, I'm
-  # looking in your direction...)  Since the actual implementations
-  # are incompatible, this does not end well.  Linking with the
-  # -Bsymbolic flags causes the internal references to these symbols
-  # inside libdrakeOptimization to be handled at compile time, and
-  # prevents the dynamic linker from hijacking IPOPT's calls into
-  # BLAS.
-  #
-  # This should probably be a test for the GNU linker instead of a platform.
-  if(NOT APPLE)
-    set(CMAKE_SHARED_LINKER_FLAGS
-      "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
-  endif()
-endif()
 
 # TODO(jamiesnape): Fix imported target upstream.
 target_include_directories(drakeOptimization PUBLIC ${NLOPT_INCLUDE_DIRS})

--- a/drake/solvers/test/CMakeLists.txt
+++ b/drake/solvers/test/CMakeLists.txt
@@ -61,20 +61,8 @@ target_link_libraries(linear_system_solver_test drakeCommon drakeOptimizationTes
 drake_add_cc_test(mixed_integer_optimization_test)
 target_link_libraries(mixed_integer_optimization_test drakeCommon drakeOptimizationTest)
 
-drake_add_cc_test(gurobi_solver_test)
-target_link_libraries(gurobi_solver_test drakeCommon drakeOptimizationTest)
-
-drake_add_cc_test(mosek_solver_test)
-target_link_libraries(mosek_solver_test drakeCommon drakeOptimizationTest)
-
 drake_add_cc_test(linear_complementary_problem_test)
 target_link_libraries(linear_complementary_problem_test drakeOptimization)
-
-drake_add_cc_test(ipopt_solver_test)
-target_link_libraries(ipopt_solver_test drakeOptimizationTest)
-
-drake_add_cc_test(snopt_solver_test)
-target_link_libraries(snopt_solver_test drakeOptimizationTest)
 
 drake_add_cc_test(solver_id_test)
 target_link_libraries(solver_id_test drakeOptimization)


### PR DESCRIPTION
IPOPT takes up a substantial part of the CMake build time (and the version in our mirror has license issues) and just NLopt is sufficient for the one remaining test that needs a solver during the switchover to using the full Bazel build. Also removes the Gurobi, MOSEK, and SNOPT solver tests as they are also long gone from the CMake build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7150)
<!-- Reviewable:end -->
