### PR TITLE
Add missing DoRemoveElement override in FclModel.

### DIFF
--- a/drake/multibody/collision/fcl_model.cc
+++ b/drake/multibody/collision/fcl_model.cc
@@ -124,6 +124,13 @@ void FclModel::DoAddElement(const Element& element) {
   fcl_collision_objects_.insert(std::make_pair(id, move(fcl_object)));
 }
 
+void FclModel::DoRemoveElement(ElementId id) {
+  const auto& itr = fcl_collision_objects_.find(id);
+  if (itr != fcl_collision_objects_.end()) {
+    broadphase_manager_.unregisterObject(itr->second.get());
+  }
+}
+
 void FclModel::UpdateModel() { broadphase_manager_.update(); }
 
 bool FclModel::UpdateElementWorldTransform(ElementId id,

--- a/drake/multibody/collision/fcl_model.h
+++ b/drake/multibody/collision/fcl_model.h
@@ -24,6 +24,7 @@ class FclModel : public Model {
   virtual ~FclModel() {}
 
   void DoAddElement(const Element& element) override;
+  void DoRemoveElement(ElementId id) override;
   bool ClosestPointsAllToAll(const std::vector<ElementId>& ids_to_check,
                              bool use_margins,
                              std::vector<PointPair>* closest_points) override;


### PR DESCRIPTION
This resolves the "heap-use-after-free" error found by [one of the tsan builds](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-tsan/302/) after #7063 went into master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7162)
<!-- Reviewable:end -->
