### PR TITLE
Add cylinder to geometry world

### DIFF
--- a/drake/examples/geometry_world/solar_system.cc
+++ b/drake/examples/geometry_world/solar_system.cc
@@ -16,12 +16,14 @@ namespace examples {
 namespace solar_system {
 
 using Eigen::Vector4d;
+using geometry::Cylinder;
 using geometry::FrameId;
 using geometry::FrameIdVector;
 using geometry::FramePoseVector;
 using geometry::GeometryFrame;
 using geometry::GeometryInstance;
 using geometry::GeometrySystem;
+using geometry::SourceId;
 using geometry::Sphere;
 using systems::BasicVector;
 using systems::Context;
@@ -70,7 +72,7 @@ void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
   // clang-format off
   initial_state << 0,               // Earth initial position
                    M_PI / 2,        // moon initial position
-                   -M_PI / 2,       // Mars initial position
+                   M_PI / 2,        // Mars initial position
                    0,               // phobos initial position
                    2 * M_PI / 5,    // Earth revolution lasts 5 seconds.
                    2 * M_PI,        // moon revolution lasts 1 second.
@@ -86,11 +88,49 @@ void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
   }
 }
 
+// Registers geometry to form an L-shaped arm onto the given frame. The arm is
+// defined as shown below:
+//
+//                        ◯          ← z = height
+//   x = 0                │
+//   ↓                    │ height
+//   ─────────────────────┘          ← z = 0
+//                        ↑
+//                        x = length
+//
+// The arm's horizontal length is oriented with the x-axis. The vertical length
+// is oriented with the z-axis. The origin of the arm is defined at the local
+// origin, and the top of the arm is positioned at the given height.
+template <class ParentId>
+void MakeArm(SourceId source_id, ParentId parent_id, double length,
+             double height, double radius,
+             GeometrySystem<double>* geometry_system) {
+  Isometry3<double> arm_pose = Isometry3<double>::Identity();
+  // tilt it horizontally
+  arm_pose.linear() =
+      Eigen::AngleAxis<double>(M_PI / 2, Vector3<double>::UnitY()).matrix();
+  arm_pose.translation() << length / 2, 0, 0;
+  geometry_system->RegisterGeometry(
+      source_id, parent_id,
+      make_unique<GeometryInstance>(
+          arm_pose, make_unique<Cylinder>(radius, length)));
+
+  Isometry3<double> post_pose = Isometry3<double>::Identity();
+  post_pose.translation() << length, 0, height/2;
+  geometry_system->RegisterGeometry(
+      source_id, parent_id,
+      make_unique<GeometryInstance>(
+          post_pose, make_unique<Cylinder>(radius, height)));
+}
+
 template <typename T>
 void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   body_ids_.reserve(kBodyCount);
   body_offset_.reserve(kBodyCount);
   axes_.reserve(kBodyCount);
+
+  const double orrery_bottom = -1.5;
+  const double pipe_radius = 0.05;
 
   // Allocate the sun.
   // NOTE: we don't store the id of the sun geometry because we have no need
@@ -99,23 +139,39 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
       source_id_, make_unique<GeometryInstance>(Isometry3<double>::Identity(),
                                                 make_unique<Sphere>(1.f)));
 
+  // The fixed pose on which Sun sits and around which all planets rotate.
+  const double post_height = 1;
+  Isometry3<double> post_pose = Isometry3<double>::Identity();
+  post_pose.translation() << 0, 0, (orrery_bottom + post_height / 2);
+  geometry_system->RegisterAnchoredGeometry(
+      source_id_, make_unique<GeometryInstance>(
+                      post_pose,
+                      make_unique<Cylinder>(pipe_radius, post_height)));
+
   // Allocate the "celestial bodies": two planets orbiting on different planes,
   // each with a moon.
 
-  // Earth - Earth's frame is at the center of the sun.
+  // Earth - Earth's frame lies directly *below* the sun (to account for the
+  // orrery arm).
+  const double kEarthBottom = orrery_bottom + 0.25;
+  Isometry3<double> planet_pose = Isometry3<double>::Identity();
+  planet_pose.translation() << 0, 0, kEarthBottom;
   FrameId planet_id = geometry_system->RegisterFrame(
-      source_id_, GeometryFrame("Earth", Isometry3<double>::Identity()));
+      source_id_, GeometryFrame("Earth", planet_pose));
   body_ids_.push_back(planet_id);
-  body_offset_.push_back(Isometry3<double>::Identity());
+  body_offset_.push_back(planet_pose);
   axes_.push_back(Vector3<double>::UnitZ());
 
   // The geometry is displaced from the Earth _frame_ so that it orbits.
   const double kEarthOrbitRadius = 3.0;
   Isometry3<double> earth_pose = Isometry3<double>::Identity();
-  earth_pose.translation() << kEarthOrbitRadius, 0, 0;
+  earth_pose.translation() << kEarthOrbitRadius, 0, -kEarthBottom;
   geometry_system->RegisterGeometry(
       source_id_, planet_id,
       make_unique<GeometryInstance>(earth_pose, make_unique<Sphere>(0.25f)));
+  // Earth's orrery arm.
+  MakeArm(source_id_, planet_id, kEarthOrbitRadius, -kEarthBottom, pipe_radius,
+          geometry_system);
 
   // Luna - Luna's frame is at the center of the Earth.
   FrameId luna_id = geometry_system->RegisterFrame(
@@ -137,24 +193,26 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
       source_id_, luna_id,
       make_unique<GeometryInstance>(luna_pose, make_unique<Sphere>(0.075f)));
 
-  // Mars - Mars's frame is at the center of the sun.
+  // Mars - Mars's frame lies directly *below* the sun (to account for the
+  // orrery arm).
+  planet_pose.translation() << 0, 0, orrery_bottom;
   planet_id = geometry_system->RegisterFrame(
-      source_id_, GeometryFrame("Mars", Isometry3<double>::Identity()));
+      source_id_, GeometryFrame("Mars", planet_pose));
   body_ids_.push_back(planet_id);
-  body_offset_.push_back(Isometry3<double>::Identity());
-  plane_normal << .1, .1, 1;
+  body_offset_.push_back(planet_pose);
+  plane_normal << 0, 0.1, 1;
   axes_.push_back(plane_normal.normalized());
 
   // The geometry is displaced from the Mars _frame_ so that it orbits.
   const double kMarsOrbitRadius = 5.0;
   Isometry3<double> mars_pose = Isometry3<double>::Identity();
-  // Pick a position at kMarsOrbitRadius distance from the sun's origin on
-  // the plane _perpendicular_ to Mars's normal (axes_.back()).
-  Vector3<double> mars_position(1, 1, -.2);
-  mars_pose.translation() = mars_position.normalized() * kMarsOrbitRadius;
+  mars_pose.translation() << kMarsOrbitRadius, 0, -orrery_bottom;
   geometry_system->RegisterGeometry(
       source_id_, planet_id,
       make_unique<GeometryInstance>(mars_pose, make_unique<Sphere>(0.24f)));
+  // Mars's orrery arm.
+  MakeArm(source_id_, planet_id, kMarsOrbitRadius, -orrery_bottom, pipe_radius,
+          geometry_system);
 
   // Mars moon - Phobos's frame is centered on Mars, but its orientation is
   // reversed so that it revolves in the opposite direction

--- a/drake/geometry/geometry_visualization.cc
+++ b/drake/geometry/geometry_visualization.cc
@@ -41,7 +41,7 @@ class ShapeToLcm : public ShapeReifier {
     Eigen::Map<Eigen::Vector3f> position(geometry_data_.position);
     position = X_PG_.translation().cast<float>();
     // LCM quaternion must be w, x, y, z.
-    Eigen::Quaternion<double> q(X_PG_.rotation());
+    Eigen::Quaternion<double> q(X_PG_.linear());
     geometry_data_.quaternion[0] = q.w();
     geometry_data_.quaternion[1] = q.x();
     geometry_data_.quaternion[2] = q.y();
@@ -56,7 +56,16 @@ class ShapeToLcm : public ShapeReifier {
     geometry_data_.type = geometry_data_.SPHERE;
     geometry_data_.num_float_data = 1;
     geometry_data_.float_data.push_back(static_cast<float>(
-                                           sphere.get_radius()));
+                                            sphere.get_radius()));
+  }
+
+  void ImplementGeometry(const Cylinder& cylinder) override {
+    geometry_data_.type = geometry_data_.CYLINDER;
+    geometry_data_.num_float_data = 2;
+    geometry_data_.float_data.push_back(static_cast<float>(
+                                            cylinder.get_radius()));
+    geometry_data_.float_data.push_back(static_cast<float>(
+                                            cylinder.get_length()));
   }
 
   void ImplementGeometry(const HalfSpace&) override {

--- a/drake/geometry/shape_specification.cc
+++ b/drake/geometry/shape_specification.cc
@@ -10,9 +10,14 @@ void Shape::Reify(ShapeReifier* reifier) const { reifier_(*this, reifier); }
 std::unique_ptr<Shape> Shape::Clone() const { return cloner_(*this); }
 
 Sphere::Sphere(double radius)
-    : Shape(static_cast<Sphere*>(nullptr)), radius_(radius) {}
+    : Shape(ShapeTag<Sphere>()), radius_(radius) {}
 
-HalfSpace::HalfSpace() : Shape(static_cast<HalfSpace*>(nullptr)) {}
+Cylinder::Cylinder(double radius, double length)
+    : Shape(ShapeTag<Cylinder>()),
+      radius_(radius),
+      length_(length) {}
+
+HalfSpace::HalfSpace() : Shape(ShapeTag<HalfSpace>()) {}
 
 Isometry3<double> HalfSpace::MakePose(const Vector3<double>& normal_F,
                                       const Vector3<double>& r_FP) {

--- a/drake/geometry/test/shape_specification_test.cc
+++ b/drake/geometry/test/shape_specification_test.cc
@@ -18,10 +18,13 @@ using std::unique_ptr;
 
 class ReifierTest : public ShapeReifier, public ::testing::Test {
  public:
-  void ImplementGeometry(const Sphere &sphere) override {
+  void ImplementGeometry(const Sphere& sphere) override {
     sphere_made_ = true;
   }
-  void ImplementGeometry(const HalfSpace &half_space) override {
+  void ImplementGeometry(const Cylinder& cylinder) override {
+    cylinder_made_ = true;
+  }
+  void ImplementGeometry(const HalfSpace& half_space) override {
     half_space_made_ = true;
   }
   void Reset() {
@@ -30,6 +33,7 @@ class ReifierTest : public ShapeReifier, public ::testing::Test {
   }
  protected:
   bool sphere_made_{false};
+  bool cylinder_made_{false};
   bool half_space_made_{false};
 };
 
@@ -39,6 +43,7 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
   s.Reify(this);
   ASSERT_TRUE(sphere_made_);
   ASSERT_FALSE(half_space_made_);
+  ASSERT_FALSE(cylinder_made_);
 
   Reset();
 
@@ -46,6 +51,7 @@ TEST_F(ReifierTest, ReificationDifferentiation) {
   hs.Reify(this);
   ASSERT_FALSE(sphere_made_);
   ASSERT_TRUE(half_space_made_);
+  ASSERT_FALSE(cylinder_made_);
 
   // NOTE: Because of the implementation of the Shape class, as long as new
   // shape specifications inherit from Shape, this test does *not* need to
@@ -59,6 +65,8 @@ TEST_F(ReifierTest, CloningShapes) {
   ASSERT_TRUE(is_dynamic_castable<Sphere>(s.Clone().get()));
   HalfSpace h;
   ASSERT_TRUE(is_dynamic_castable<HalfSpace>(h.Clone().get()));
+  Cylinder c(0.5, 2.0);
+  ASSERT_TRUE(is_dynamic_castable<Cylinder>(c.Clone().get()));
 
   // Confirms clone independence. The idea that a clone can outlive its
   // source and there aren't any unintentional bindings between the two.
@@ -74,6 +82,7 @@ TEST_F(ReifierTest, CloningShapes) {
   cloned_shape->Reify(this);
   ASSERT_TRUE(sphere_made_);
   ASSERT_FALSE(half_space_made_);
+  ASSERT_FALSE(cylinder_made_);
 }
 
 


### PR DESCRIPTION
Adds the cylinder shape to the set of supported shapes.

Adds cylinders to `solar_system.cc` to illustrate the usage.

```
Category            added  modified  removed  
----------------------------------------------
code                70     11        1        
comments            20     3         1        
blank               10     0         0        
----------------------------------------------
TOTAL               100    14        2  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7163)
<!-- Reviewable:end -->
