### PR TITLE
Add LinearSystem and TimeVaryingLinearSystem specializations to Direct Transcription

### DIFF
--- a/drake/systems/primitives/BUILD
+++ b/drake/systems/primitives/BUILD
@@ -23,6 +23,7 @@ drake_cc_library(
         ":matrix_gain",
         ":multiplexer",
         ":pass_through",
+        ":piecewise_polynomial_linear_system",
         ":random_source",
         ":saturation",
         ":signal_log",
@@ -159,6 +160,19 @@ drake_cc_library(
     ],
     deps = [
         "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "piecewise_polynomial_linear_system",
+    srcs = ["piecewise_polynomial_linear_system.cc"],
+    hdrs = ["piecewise_polynomial_linear_system.h"],
+    deps = [
+        ":linear_system",
+        "//drake/common:default_scalars",
+        "//drake/common:essential",
+        "//drake/common:extract_double",
+        "//drake/common/trajectories:piecewise_polynomial_trajectory",
     ],
 )
 
@@ -398,6 +412,16 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/systems/analysis:simulator",
         "//drake/systems/framework",
+    ],
+)
+
+drake_cc_googletest(
+    name = "piecewise_polynomial_linear_system_test",
+    deps = [
+        ":piecewise_polynomial_linear_system",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -334,3 +334,6 @@ bool IsObservable(const LinearSystem<double>& sys, double threshold) {
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::LinearSystem)
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::TimeVaryingLinearSystem)

--- a/drake/systems/primitives/piecewise_polynomial_linear_system.cc
+++ b/drake/systems/primitives/piecewise_polynomial_linear_system.cc
@@ -1,0 +1,6 @@
+#include "drake/systems/primitives/piecewise_polynomial_linear_system.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::systems::PiecewisePolynomialLinearSystem)

--- a/drake/systems/primitives/piecewise_polynomial_linear_system.h
+++ b/drake/systems/primitives/piecewise_polynomial_linear_system.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/extract_double.h"
+#include "drake/common/trajectories/piecewise_polynomial_trajectory.h"
+#include "drake/systems/primitives/linear_system.h"
+
+namespace drake {
+namespace systems {
+
+/// Stores time-varying matrix data necessary to construct a Linear Time-Varying
+/// system.  The trajectory matrices must obey the following dimensions :
+/// | Matrix  | Num Rows    | Num Columns |
+/// |:-------:|:-----------:|:-----------:|
+/// | A       | num states  | num states  |
+/// | B       | num states  | num inputs  |
+/// | C       | num outputs | num states  |
+/// | D       | num outputs | num inputs  |
+struct LinearTimeVaryingData {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LinearTimeVaryingData)
+
+  /// Default constructor.
+  LinearTimeVaryingData() = default;
+  /// Fully-parameterized constructor of PiecewisePolynomials.
+  LinearTimeVaryingData(const PiecewisePolynomial<double>& Ain,
+                        const PiecewisePolynomial<double>& Bin,
+                        const PiecewisePolynomial<double>& Cin,
+                        const PiecewisePolynomial<double>& Din)
+      : LinearTimeVaryingData(PiecewisePolynomialTrajectory(Ain),
+                              PiecewisePolynomialTrajectory(Bin),
+                              PiecewisePolynomialTrajectory(Cin),
+                              PiecewisePolynomialTrajectory(Din)) {}
+  /// Fully-parameterized constructor of PiecewisePolynomialTrajectories.
+  LinearTimeVaryingData(const PiecewisePolynomialTrajectory& Ain,
+                        const PiecewisePolynomialTrajectory& Bin,
+                        const PiecewisePolynomialTrajectory& Cin,
+                        const PiecewisePolynomialTrajectory& Din)
+      : A(Ain), B(Bin), C(Cin), D(Din) {
+    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+                 B.get_piecewise_polynomial().getNumberOfSegments());
+    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+                 C.get_piecewise_polynomial().getNumberOfSegments());
+    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+                 D.get_piecewise_polynomial().getNumberOfSegments());
+    DRAKE_DEMAND(A.rows() == A.cols());
+    DRAKE_DEMAND(B.rows() == A.cols());
+    DRAKE_DEMAND(C.cols() == A.cols());
+    DRAKE_DEMAND(D.rows() == C.rows());
+    DRAKE_DEMAND(D.cols() == B.cols());
+  }
+
+  PiecewisePolynomialTrajectory A{PiecewisePolynomial<double>()};
+  PiecewisePolynomialTrajectory B{PiecewisePolynomial<double>()};
+  PiecewisePolynomialTrajectory C{PiecewisePolynomial<double>()};
+  PiecewisePolynomialTrajectory D{PiecewisePolynomial<double>()};
+};
+
+// Return a vector of the given size, with result[i] == i * step.
+inline std::vector<double> vector_iota(int size, double step) {
+  std::vector<double> result(size);
+  for (int i{0}; i < size; ++i) result[i] = i * step;
+  return result;
+}
+
+/// A continuous- or discrete-time Linear Time-Varying system described by a
+/// piecewise polynomial trajectory of system matrices.
+///
+/// @tparam T The scalar element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// They are already available to link against in the containing library.
+/// No other values for T are currently supported.
+///
+/// @ingroup primitive_systems
+///
+template <typename T>
+class PiecewisePolynomialLinearSystem final
+    : public TimeVaryingLinearSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PiecewisePolynomialLinearSystem)
+
+  /// Constructs a PiecewisePolynomialLinearSystem described by a trajectory of
+  /// system matrices.
+  ///
+  /// @param time_period Defines the period of the discrete time system; use
+  ///  time_period=0.0 to denote a continuous time system.  @default 0.0
+  PiecewisePolynomialLinearSystem(const PiecewisePolynomialTrajectory& A,
+                                  const PiecewisePolynomialTrajectory& B,
+                                  const PiecewisePolynomialTrajectory& C,
+                                  const PiecewisePolynomialTrajectory& D,
+                                  double time_period = 0.)
+      : PiecewisePolynomialLinearSystem<T>(
+            SystemTypeTag<systems::PiecewisePolynomialLinearSystem>{},
+            {A, B, C, D}, time_period) {}
+
+  /// Constructs a PiecewisePolynomialLinearSystem described by a
+  /// time-sample-indexed vector of system matrices, whose i-th element
+  /// corresponds to time = i * time_period.  The matrix values are interpolated
+  /// linearly in between time steps.
+  ///
+  /// @param time_period Defines the period of the discrete time system; use
+  ///  time_period=0.0 to denote a continuous time system.  @default 0.0
+  PiecewisePolynomialLinearSystem(const std::vector<Eigen::MatrixXd>& A,
+                                  const std::vector<Eigen::MatrixXd>& B,
+                                  const std::vector<Eigen::MatrixXd>& C,
+                                  const std::vector<Eigen::MatrixXd>& D,
+                                  double time_period = 0.)
+      : PiecewisePolynomialLinearSystem<T>(
+            SystemTypeTag<systems::PiecewisePolynomialLinearSystem>{},
+            {PiecewisePolynomial<double>::FirstOrderHold(
+                vector_iota(A.size(), time_period), A),
+             PiecewisePolynomial<double>::FirstOrderHold(
+                 vector_iota(B.size(), time_period), B),
+             PiecewisePolynomial<double>::FirstOrderHold(
+                 vector_iota(C.size(), time_period), C),
+             PiecewisePolynomial<double>::FirstOrderHold(
+                 vector_iota(D.size(), time_period), D)},
+            time_period) {}
+
+  /// Constructs a PiecewisePolynomialLinearSystem from a LinearTimeVaryingData
+  /// structure.
+  ///
+  /// @param time_period Defines the period of the discrete time system; use
+  ///  time_period=0.0 to denote a continuous time system.  @default 0.0
+  PiecewisePolynomialLinearSystem(const LinearTimeVaryingData& data,
+                                  double time_period = 0.)
+      : PiecewisePolynomialLinearSystem<T>(
+            SystemTypeTag<systems::PiecewisePolynomialLinearSystem>{}, data,
+            time_period) {}
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit PiecewisePolynomialLinearSystem(
+      const PiecewisePolynomialLinearSystem<U>& other)
+      : PiecewisePolynomialLinearSystem<T>(other.data_, other.time_period()) {}
+
+  /// @name Implementations of PiecewisePolynomialLinearSystem<T>'s pure virtual
+  /// methods.
+  /// @{
+  MatrixX<T> A(const T& t) const final {
+    return data_.A.value(ExtractDoubleOrThrow(t));
+  }
+  MatrixX<T> B(const T& t) const final {
+    return data_.B.value(ExtractDoubleOrThrow(t));
+  }
+  MatrixX<T> C(const T& t) const final {
+    return data_.C.value(ExtractDoubleOrThrow(t));
+  }
+  MatrixX<T> D(const T& t) const final {
+    return data_.D.value(ExtractDoubleOrThrow(t));
+  }
+  /// @}
+
+ protected:
+  /// Constructor that specifies scalar-type conversion support.
+  /// @param converter scalar-type conversion support helper (i.e., AutoDiff,
+  /// etc.); pass a default-constructed object if such support is not desired.
+  /// See @ref system_scalar_conversion and examples related to scalar-type
+  /// conversion support for more details.
+  PiecewisePolynomialLinearSystem(SystemScalarConverter converter,
+                                  const LinearTimeVaryingData& data,
+                                  double time_period)
+      : TimeVaryingLinearSystem<T>(std::move(converter), data.A.rows(),
+                                   data.B.cols(), data.C.rows(), time_period),
+        data_(data) {}
+
+ private:
+  // Allow different specializations to access each other's private data.
+  template <typename>
+  friend class PiecewisePolynomialLinearSystem;
+
+  // Return a vector of the given size, with result[i] == i * step.
+  static std::vector<double> vector_iota(int size, double step) {
+    std::vector<double> result(size);
+    for (int i{0}; i < size; ++i) result[i] = i * step;
+    return result;
+  }
+
+  const LinearTimeVaryingData data_;
+};
+
+// Exclude symbolic::Expression from the scalartype conversion of
+// PiecewisePolynomialLinearSystem.
+namespace scalar_conversion {
+template <>
+struct Traits<PiecewisePolynomialLinearSystem> : public NonSymbolicTraits {};
+}  // namespace scalar_conversion
+
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -212,7 +212,8 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
                               C * x0 + D * u0 + y0));
 }
 
-// xdot = rotmat(t)*x, y = x;
+// [ẋ₁, ẋ₂]ᵀ = rotmat(t)*[x₁, x₂]ᵀ + u*[1, 1]ᵀ,
+// [y₁, y₂] = [x₁, x₂] + (u + 1)*[1, 1].
 class SimpleTimeVaryingAffineSystem : public TimeVaryingAffineSystem<double> {
  public:
   static constexpr int kNumStates = 2;

--- a/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -1,0 +1,272 @@
+#include "drake/systems/primitives/piecewise_polynomial_linear_system.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+using std::make_unique;
+using std::unique_ptr;
+
+namespace drake {
+namespace systems {
+namespace {
+
+static constexpr double kDiscreteTimeStep = 0.1;
+
+// A helper for accessing the underlying PiecewisePolynomialTrajectory data.
+struct MatrixData {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(MatrixData)
+
+  MatrixData() {}
+  /// Fully-parameterized constructor.
+  MatrixData(const std::vector<double>& times_in,
+             const std::vector<Eigen::MatrixXd>& Avec_in,
+             const std::vector<Eigen::MatrixXd>& Bvec_in,
+             const std::vector<Eigen::MatrixXd>& Cvec_in,
+             const std::vector<Eigen::MatrixXd>& Dvec_in)
+      : times(times_in),
+        Avec(Avec_in),
+        Bvec(Bvec_in),
+        Cvec(Cvec_in),
+        Dvec(Dvec_in) {}
+  std::vector<double> times{};
+  std::vector<Eigen::MatrixXd> Avec;
+  std::vector<Eigen::MatrixXd> Bvec;
+  std::vector<Eigen::MatrixXd> Cvec;
+  std::vector<Eigen::MatrixXd> Dvec;
+};
+
+// Define a simple LinearTimeVaryingData struct via member assignment.
+std::pair<LinearTimeVaryingData, MatrixData> ExampleLinearTimeVaryingData() {
+  const std::vector<double> times{0., kDiscreteTimeStep, 2 * kDiscreteTimeStep};
+  std::vector<Eigen::MatrixXd> Avec(times.size());
+  std::vector<Eigen::MatrixXd> Bvec(times.size());
+  std::vector<Eigen::MatrixXd> Cvec(times.size());
+  std::vector<Eigen::MatrixXd> Dvec(times.size());
+  Eigen::Matrix2d A0;
+  A0 << 1, 2, 3, 4;
+  Eigen::Matrix2d B0;
+  B0 << 5, 6, 7, 8;
+  Eigen::Matrix2d C0;
+  C0 << 9, 10, 11, 12;
+  Eigen::Matrix2d D0;
+  D0 << 13, 14, 15, 16;
+  for (int i{0}; i < static_cast<int>(times.size()); ++i) {
+    Avec[i] = A0 + i * Eigen::Matrix2d::Ones();
+    Bvec[i] = B0 + i * Eigen::Matrix2d::Ones();
+    Cvec[i] = C0 + i * Eigen::Matrix2d::Ones();
+    Dvec[i] = D0 + i * Eigen::Matrix2d::Ones();
+  }
+
+  const auto Apoly = PiecewisePolynomial<double>::FirstOrderHold(times, Avec);
+  const auto Bpoly = PiecewisePolynomial<double>::FirstOrderHold(times, Bvec);
+  const auto Cpoly = PiecewisePolynomial<double>::FirstOrderHold(times, Cvec);
+  const auto Dpoly = PiecewisePolynomial<double>::FirstOrderHold(times, Dvec);
+
+  LinearTimeVaryingData result;
+  result.A = PiecewisePolynomialTrajectory(Apoly);
+  result.B = PiecewisePolynomialTrajectory(Bpoly);
+  result.C = PiecewisePolynomialTrajectory(Cpoly);
+  result.D = PiecewisePolynomialTrajectory(Dpoly);
+
+  return std::make_pair(result, MatrixData{times, Avec, Bvec, Cvec, Dvec});
+}
+
+GTEST_TEST(LinearTimeVaryingData, PiecewisePolynomialConstructor) {
+  LinearTimeVaryingData ppt_data;
+  MatrixData mat_data;
+  std::tie(ppt_data, mat_data) = ExampleLinearTimeVaryingData();
+
+  // Construct a LinearTimeVaryingData struct from PiecewisePolynomials.
+  const LinearTimeVaryingData dut_from_pp =
+      LinearTimeVaryingData(PiecewisePolynomial<double>::FirstOrderHold(
+                                mat_data.times, mat_data.Avec),
+                            PiecewisePolynomial<double>::FirstOrderHold(
+                                mat_data.times, mat_data.Bvec),
+                            PiecewisePolynomial<double>::FirstOrderHold(
+                                mat_data.times, mat_data.Cvec),
+                            PiecewisePolynomial<double>::FirstOrderHold(
+                                mat_data.times, mat_data.Dvec));
+  for (const double t :
+       ppt_data.A.get_piecewise_polynomial().getSegmentTimes()) {
+    EXPECT_TRUE(CompareMatrices(dut_from_pp.A.value(t), ppt_data.A.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_pp.B.value(t), ppt_data.B.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_pp.C.value(t), ppt_data.C.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_pp.D.value(t), ppt_data.D.value(t)));
+  }
+}
+
+GTEST_TEST(LinearTimeVaryingData, PiecewisePolynomialTrajectoryConstructor) {
+  LinearTimeVaryingData data;
+  std::tie(data, std::ignore) = ExampleLinearTimeVaryingData();
+
+  // Construct a LinearTimeVaryingData struct from
+  // PiecewisePolynomialTrajectories.
+  const LinearTimeVaryingData dut_from_ppt =
+      LinearTimeVaryingData(data.A, data.B, data.C, data.D);
+  for (const double t : data.A.get_piecewise_polynomial().getSegmentTimes()) {
+    EXPECT_TRUE(CompareMatrices(dut_from_ppt.A.value(t), data.A.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_ppt.B.value(t), data.B.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_ppt.C.value(t), data.C.value(t)));
+    EXPECT_TRUE(CompareMatrices(dut_from_ppt.D.value(t), data.D.value(t)));
+  }
+}
+
+enum ConstructorType {
+  FromDataContinuous,
+  FromStructContinuous,
+  FromStructDiscrete
+};
+
+class PiecewisePolynomialLinearSystemTest
+    : public ::testing::TestWithParam<double> {
+ public:
+  void SetUp() override {
+    std::tie(ltv_data_, mat_data_) = ExampleLinearTimeVaryingData();
+
+    // Set up an arbitrary PiecewisePolynomialLinearSystem.
+    if (this->GetParam() == ConstructorType::FromDataContinuous) {
+      dut_ =
+          std::make_unique<PiecewisePolynomialLinearSystem<double>>(ltv_data_);
+    } else if (this->GetParam() == ConstructorType::FromStructContinuous) {
+      dut_ = std::make_unique<PiecewisePolynomialLinearSystem<double>>(
+          ltv_data_.A, ltv_data_.B, ltv_data_.C, ltv_data_.D);
+    } else if (this->GetParam() == ConstructorType::FromStructDiscrete) {
+      time_period_ = kDiscreteTimeStep;
+      dut_ = std::make_unique<PiecewisePolynomialLinearSystem<double>>(
+          mat_data_.Avec, mat_data_.Bvec, mat_data_.Cvec, mat_data_.Dvec,
+          time_period_);
+    }
+    context_ = dut_->CreateDefaultContext();
+    input_vector_ = std::make_unique<BasicVector<double>>(2 /* size */);
+    system_output_ = dut_->AllocateOutput(*context_);
+    continuous_state_ = context_->get_mutable_continuous_state();
+    discrete_state_ = context_->get_mutable_discrete_state();
+    derivatives_ = dut_->AllocateTimeDerivatives();
+    updates_ = dut_->AllocateDiscreteVariables();
+  }
+
+ protected:
+  // The Device Under Test (DUT) is a PiecewisePolynomialLinearSystem<double>.
+  std::unique_ptr<PiecewisePolynomialLinearSystem<double>> dut_;
+  std::unique_ptr<Context<double>> context_;
+  std::unique_ptr<SystemOutput<double>> system_output_;
+
+  ContinuousState<double>* continuous_state_{nullptr};
+  DiscreteValues<double>* discrete_state_{nullptr};
+  std::unique_ptr<BasicVector<double>> input_vector_;
+  std::unique_ptr<ContinuousState<double>> derivatives_;
+  std::unique_ptr<DiscreteValues<double>> updates_;
+
+  LinearTimeVaryingData ltv_data_;
+  MatrixData mat_data_;
+  double time_period_{0.};  // Defaults to continuous-time.
+};
+
+TEST_P(PiecewisePolynomialLinearSystemTest, Constructor) {
+  EXPECT_EQ(1, context_->get_num_input_ports());
+  EXPECT_EQ(dut_->A(0.), ltv_data_.A.value(0.));
+  EXPECT_EQ(dut_->B(0.), ltv_data_.B.value(0.));
+  EXPECT_EQ(dut_->C(0.), ltv_data_.C.value(0.));
+  EXPECT_EQ(dut_->D(0.), ltv_data_.D.value(0.));
+  EXPECT_EQ(dut_->time_period(), time_period_);
+  EXPECT_EQ(1, dut_->get_num_output_ports());
+  EXPECT_EQ(1, dut_->get_num_input_ports());
+}
+
+TEST_P(PiecewisePolynomialLinearSystemTest, KnotPointConsistency) {
+  for (int i{0}; i < static_cast<int>(mat_data_.times.size()); ++i) {
+    EXPECT_TRUE(
+        CompareMatrices(dut_->A(mat_data_.times[i]), mat_data_.Avec[i]));
+    EXPECT_TRUE(
+        CompareMatrices(dut_->B(mat_data_.times[i]), mat_data_.Bvec[i]));
+    EXPECT_TRUE(
+        CompareMatrices(dut_->C(mat_data_.times[i]), mat_data_.Cvec[i]));
+    EXPECT_TRUE(
+        CompareMatrices(dut_->D(mat_data_.times[i]), mat_data_.Dvec[i]));
+  }
+}
+
+// Tests that the derivatives are correctly computed.
+TEST_P(PiecewisePolynomialLinearSystemTest, Derivatives) {
+  Eigen::Vector2d u(7, 42);
+  input_vector_->get_mutable_value() << u;
+  context_->FixInputPort(0, std::move(input_vector_));
+
+  EXPECT_NE(derivatives_, nullptr);
+  EXPECT_NE(updates_, nullptr);
+
+  Eigen::Vector2d x(0.101, 3.7);
+
+  if (time_period_ == 0.) {
+    continuous_state_->SetFromVector(x);
+  } else {
+    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+  }
+
+  std::vector<double> times{0., 1e-5 * kDiscreteTimeStep,
+                            0.25 * kDiscreteTimeStep, kDiscreteTimeStep,
+                            1.5 * kDiscreteTimeStep};
+  for (const double t : times) {
+    context_->set_time(t);
+    const Eigen::Matrix2d A = ltv_data_.A.value(t);
+    const Eigen::Matrix2d B = ltv_data_.B.value(t);
+    if (time_period_ == 0.) {
+      dut_->CalcTimeDerivatives(*context_, derivatives_.get());
+      EXPECT_EQ(A * x + B * u, derivatives_->get_vector().CopyToVector());
+    } else {
+      dut_->CalcDiscreteVariableUpdates(*context_, updates_.get());
+      EXPECT_EQ(A * x + B * u, updates_->get_vector(0)->CopyToVector());
+    }
+  }
+}
+
+// Tests that the outputs are correctly computed.
+TEST_P(PiecewisePolynomialLinearSystemTest, Output) {
+  // Sets the context's input port.
+  Eigen::Vector2d u(5.6, -10.1);
+  input_vector_->get_mutable_value() << u;
+  context_->FixInputPort(0, std::move(input_vector_));
+
+  // Sets the state.
+  Eigen::Vector2d x(0.8, -22.1);
+  if (time_period_ == 0.) {
+    continuous_state_->SetFromVector(x);
+  } else {
+    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+  }
+
+  std::vector<double> times{0., 1e-5 * kDiscreteTimeStep,
+                            0.25 * kDiscreteTimeStep, kDiscreteTimeStep,
+                            1.5 * kDiscreteTimeStep};
+  Eigen::VectorXd expected_output(2);
+  for (const double t : times) {
+    context_->set_time(t);
+    dut_->CalcOutput(*context_, system_output_.get());
+    const Eigen::Matrix2d C = ltv_data_.C.value(t);
+    const Eigen::Matrix2d D = ltv_data_.D.value(t);
+    EXPECT_EQ(C * x + D * u, system_output_->get_vector_data(0)->get_value());
+  }
+}
+
+// Tests that conversion to different scalar types is possible.
+TEST_P(PiecewisePolynomialLinearSystemTest, ScalarTypeConversion) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& converted) {
+    EXPECT_EQ(converted.A(0.), ltv_data_.A.value(0.));
+    EXPECT_EQ(converted.B(0.), ltv_data_.B.value(0.));
+    EXPECT_EQ(converted.C(0.), ltv_data_.C.value(0.));
+    EXPECT_EQ(converted.D(0.), ltv_data_.D.value(0.));
+    EXPECT_EQ(converted.time_period(), time_period_);
+  }));
+  EXPECT_FALSE(is_symbolic_convertible(*dut_));
+}
+
+INSTANTIATE_TEST_CASE_P(Constructor, PiecewisePolynomialLinearSystemTest,
+                        testing::Values(ConstructorType::FromDataContinuous,
+                                        ConstructorType::FromStructContinuous,
+                                        ConstructorType::FromStructDiscrete));
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/trajectory_optimization/BUILD
+++ b/drake/systems/trajectory_optimization/BUILD
@@ -45,6 +45,8 @@ drake_cc_library(
         ":multiple_shooting",
         "//drake/math:autodiff",
         "//drake/math:gradient",
+        "//drake/systems/primitives:linear_system",
+        "//drake/systems/primitives:piecewise_polynomial_linear_system",
     ],
 )
 
@@ -80,7 +82,6 @@ drake_cc_googletest(
         ":direct_transcription",
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/systems/primitives:linear_system",
     ],
 )
 

--- a/drake/systems/trajectory_optimization/direct_transcription.h
+++ b/drake/systems/trajectory_optimization/direct_transcription.h
@@ -5,6 +5,8 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/system.h"
+#include "drake/systems/primitives/linear_system.h"
+#include "drake/systems/primitives/piecewise_polynomial_linear_system.h"
 #include "drake/systems/trajectory_optimization/multiple_shooting.h"
 
 namespace drake {
@@ -39,6 +41,39 @@ class DirectTranscription : public MultipleShooting {
   DirectTranscription(const System<double>* system,
                       const Context<double>& context, int num_time_samples);
 
+  /// Constructs the MathematicalProgram and adds the dynamic constraints.
+  /// This version of the constructor is only for *linear* discrete-time systems
+  /// (with a single periodic timestep update).
+  ///
+  /// @param system A linear system to be used in the dynamic constraints.
+  ///    Note that this is aliased for the lifetime of this object.
+  /// @param context Required to describe any parameters of the system.  The
+  ///    values of the state in this context do not have any effect.  This
+  ///    context will also be "cloned" by the optimization; changes to the
+  ///    context after calling this method will NOT impact the trajectory
+  ///    optimization.
+  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @throws std::runtime_error If the system is not discrete time (only).
+
+  DirectTranscription(const LinearSystem<double>* system,
+                      const Context<double>& context, int num_time_samples);
+
+  /// Constructs the MathematicalProgram and adds the dynamic constraints.  This
+  /// version of the constructor is only for *linear time-varying* discrete-time
+  /// systems (with a single periodic timestep update).
+  ///
+  /// @param system A linear time-varying system to be used in the dynamic
+  ///    constraints. Note that this is aliased for the lifetime of this object.
+  /// @param context Required to describe any parameters of the system.  The
+  ///    values of the state in this context do not have any effect.  This
+  ///    context will also be "cloned" by the optimization; changes to the
+  ///    context after calling this method will NOT impact the trajectory
+  ///    optimization.
+  /// @param num_time_samples The number of knot points in the trajectory.
+  /// @throws std::runtime_error If the system is not discrete time (only).
+  DirectTranscription(const TimeVaryingLinearSystem<double>* system,
+                      const Context<double>& context, int num_time_samples);
+
   // TODO(russt):  implement constructors for continuous time systems with
   // fixed timesteps AND the version with time as a decision variable.
 
@@ -69,6 +104,21 @@ class DirectTranscription : public MultipleShooting {
   // Aborts if the conversion ToAutoDiffXd fails.
   void AddAutodiffDynamicConstraints(const System<double>* system,
                                      const Context<double>& context);
+
+  // Constrain the final input to match the penultimate, otherwise the final
+  // input is unconstrained.
+  // (Note that it might be more ideal to have fewer decision variables
+  // allocated, but this is a reasonable work-around).
+  //
+  // TODO(jadecastro) Allow MultipleShooting to take on N-1 inputs, and remove
+  // this constraint.
+  void ConstrainEqualInputAtFinalTwoTimesteps();
+
+  // Ensures that the MultipleShooting problem is well-formed and that the
+  // provided @p system and @p context have only one group of discrete states
+  // and only one (possibly multidimensional) input.
+  void ValidateSystem(const System<double>& system,
+                      const Context<double>& context);
 
   // AutoDiff versions of the System components (for the constraints).
   // These values are allocated iff the dynamic constraints are allocated

--- a/drake/systems/trajectory_optimization/multiple_shooting.h
+++ b/drake/systems/trajectory_optimization/multiple_shooting.h
@@ -226,6 +226,11 @@ class MultipleShooting : public solvers::MathematicalProgram {
   /// %PiecewisePolynomialTrajectory%.
   virtual PiecewisePolynomialTrajectory ReconstructStateTrajectory() const = 0;
 
+  double fixed_timestep() const {
+    DRAKE_THROW_UNLESS(!timesteps_are_decision_variables_);
+    return fixed_timestep_;
+  }
+
  protected:
   /// Constructs a MultipleShooting instance with fixed sample times.
   ///
@@ -265,11 +270,6 @@ class MultipleShooting : public solvers::MathematicalProgram {
 
   bool timesteps_are_decision_variables() const {
     return timesteps_are_decision_variables_;
-  }
-
-  double fixed_timestep() const {
-    DRAKE_THROW_UNLESS(!timesteps_are_decision_variables_);
-    return fixed_timestep_;
   }
 
   const solvers::VectorXDecisionVariable& h_vars() const { return h_vars_; }

--- a/drake/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/drake/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -10,6 +10,7 @@
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
 #include "drake/systems/primitives/linear_system.h"
+#include "drake/systems/primitives/piecewise_polynomial_linear_system.h"
 
 namespace drake {
 namespace systems {
@@ -97,6 +98,18 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
   }
 };
 
+std::unique_ptr<AffineSystem<double>> MakeAffineSystem(const double time_step) {
+  // x[n+1] = x[n] + 2 * u[n] + 3,
+  // y[n] = 4 * x[n] + 5 * u[n] + 6.
+  const Eigen::Matrix<double, 1, 1> A(1.0);
+  const Eigen::Matrix<double, 1, 1> B(2.0);
+  const Vector1d f0(3.0);
+  const Eigen::Matrix<double, 1, 1> C(4.0);
+  const Eigen::Matrix<double, 1, 1> D(5.0);
+  const Eigen::Matrix<double, 1, 1> y0(6.0);
+  return std::make_unique<AffineSystem<double>>(A, B, f0, C, D, y0, time_step);
+}
+
 }  // namespace
 
 // This example will NOT use the symbolic constraints.
@@ -131,6 +144,48 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeConstraintTest) {
 
 // This example WILL use the symbolic constraints.
 GTEST_TEST(DirectTranscriptionTest, DiscreteTimeSymbolicConstraintTest) {
+  const double kTimeStep = 0.1;
+  std::unique_ptr<AffineSystem<double>> system = MakeAffineSystem(kTimeStep);
+
+  const auto context = system->CreateDefaultContext();
+  int kNumSampleTimes = 3;
+  DirectTranscription prog(system.get(), *context, kNumSampleTimes);
+
+  // TODO(russt):  Uncomment this upon resolution of #6878.
+  // EXPECT_EQ(prog.fixed_timestep(),kTimeStep);
+
+  // Sets all decision variables to trivial known values (1,2,3,...).
+  prog.SetDecisionVariableValues(
+      Eigen::VectorXd::LinSpaced(prog.num_vars(), 1, prog.num_vars()));
+
+  // Constructor should add dynamic constraints, and these should have been
+  // added as linear equality constraints.
+  const std::vector<solvers::Binding<solvers::LinearEqualityConstraint>>&
+      dynamic_constraints = prog.linear_equality_constraints();
+  EXPECT_EQ(dynamic_constraints.size(), kNumSampleTimes);
+  // Check that there are no nonlinear constraints in the program.
+  EXPECT_EQ(prog.generic_constraints().size(), 0);
+
+  for (int i = 0; i < (kNumSampleTimes - 1); i++) {
+    const Vector1d dynamic_constraint_val =
+        prog.EvalBindingAtSolution(dynamic_constraints[i]) -
+        dynamic_constraints[i].constraint()->lower_bound();
+    const Vector1d dynamic_constraint_expected =
+        prog.GetSolution(prog.state(i + 1)) -
+        system->A() * prog.GetSolution(prog.state(i)) -
+        system->B() * prog.GetSolution(prog.input(i)) -
+        system->f0();
+
+    // Check that the system's state equation still holds with equality,
+    // regardless of the specific encoding MathematicalProgram chooses.
+    EXPECT_TRUE(
+        CompareMatrices(dynamic_constraint_val, dynamic_constraint_expected) ||
+        CompareMatrices(dynamic_constraint_val, -dynamic_constraint_expected));
+  }
+}
+
+// This example tests the LinearSystem specialization of the constructor.
+GTEST_TEST(DirectTranscriptionTest, DiscreteTimeLinearSystemTest) {
   Eigen::Matrix2d A, B;
   // clang-format off
   A << 1, 2,
@@ -146,60 +201,128 @@ GTEST_TEST(DirectTranscriptionTest, DiscreteTimeSymbolicConstraintTest) {
   int kNumSampleTimes = 3;
   DirectTranscription prog(&system, *context, kNumSampleTimes);
 
-  // TODO(russt):  Uncomment this upon resolution of #6878.
-  // EXPECT_EQ(prog.fixed_timestep(),kTimeStep);
+  EXPECT_EQ(prog.fixed_timestep(), kTimeStep);
 
   // Sets all decision variables to trivial known values (1,2,3,...).
   prog.SetDecisionVariableValues(
       Eigen::VectorXd::LinSpaced(prog.num_vars(), 1, prog.num_vars()));
 
   // Constructor should add dynamic constraints, and these should have been
-  // added as linear equality constraints. (There is also one linear
-  // equality constraint for the control input).
+  // added as linear equality constraints.
   const std::vector<solvers::Binding<solvers::LinearEqualityConstraint>>&
       dynamic_constraints = prog.linear_equality_constraints();
   EXPECT_EQ(dynamic_constraints.size(), kNumSampleTimes);
   // Check that there are no nonlinear constraints in the program.
   EXPECT_EQ(prog.generic_constraints().size(), 0);
 
+  const double kNumericalTolerance = 1e-10;
   for (int i = 0; i < (kNumSampleTimes - 1); i++) {
     EXPECT_TRUE(
         CompareMatrices(prog.EvalBindingAtSolution(dynamic_constraints[i]),
                         prog.GetSolution(prog.state(i + 1)) -
-                            A * prog.GetSolution(prog.state(i)) -
-                            B * prog.GetSolution(prog.input(i))));
+                          A * prog.GetSolution(prog.state(i)) -
+                          B * prog.GetSolution(prog.input(i)),
+                        kNumericalTolerance));
+  }
+}
+
+// This example tests the TimeVaryingLinearSystem specialization of the
+// constructor.
+GTEST_TEST(DirectTranscriptionTest, TimeVaryingLinearSystemTest) {
+  const std::vector<double> times {0., 1.};
+  std::vector<Eigen::MatrixXd> Avec(times.size());
+  std::vector<Eigen::MatrixXd> Bvec(times.size());
+  std::vector<Eigen::MatrixXd> Cvec(times.size());
+  std::vector<Eigen::MatrixXd> Dvec(times.size());
+  Eigen::Matrix2d A0;
+  A0 << 1, 2, 3, 4;
+  Eigen::Matrix2d B0;
+  B0 << 5, 6, 7, 8;
+  Eigen::Matrix2d C0;
+  C0 << 9, 10, 11, 12;
+  Eigen::Matrix2d D0;
+  D0 << 13, 14, 15, 16;
+  for (int i{0}; i < static_cast<int>(times.size()); ++i) {
+    Avec[i] = A0 + i * Eigen::Matrix2d::Ones();
+    Bvec[i] = B0 + i * Eigen::Matrix2d::Ones();
+    Cvec[i] = C0 + i * Eigen::Matrix2d::Ones();
+    Dvec[i] = D0 + i * Eigen::Matrix2d::Ones();
+  }
+  const auto Apoly =
+      PiecewisePolynomial<double>::FirstOrderHold(times, Avec);
+  const auto Bpoly =
+      PiecewisePolynomial<double>::FirstOrderHold(times, Bvec);
+  const auto Cpoly =
+      PiecewisePolynomial<double>::FirstOrderHold(times, Cvec);
+  const auto Dpoly =
+      PiecewisePolynomial<double>::FirstOrderHold(times, Dvec);
+  const PiecewisePolynomialTrajectory A(Apoly);
+  const PiecewisePolynomialTrajectory B(Bpoly);
+  const PiecewisePolynomialTrajectory C(Cpoly);
+  const PiecewisePolynomialTrajectory D(Dpoly);
+
+  const double kTimeStep = .1;
+  PiecewisePolynomialLinearSystem<double> system(A, B, C, D, kTimeStep);
+
+  const auto context = system.CreateDefaultContext();
+  int kNumSampleTimes = 3;
+  DirectTranscription prog(&system, *context, kNumSampleTimes);
+
+  EXPECT_EQ(prog.fixed_timestep(), kTimeStep);
+
+  // Sets all decision variables to trivial known values (1,2,3,...).
+  prog.SetDecisionVariableValues(
+      Eigen::VectorXd::LinSpaced(prog.num_vars(), 1, prog.num_vars()));
+
+  // Constructor should add dynamic constraints, and these should have been
+  // added as linear equality constraints.
+  const std::vector<solvers::Binding<solvers::LinearEqualityConstraint>>&
+      dynamic_constraints = prog.linear_equality_constraints();
+  EXPECT_EQ(dynamic_constraints.size(), kNumSampleTimes);
+  // Check that there are no nonlinear constraints in the program.
+  EXPECT_EQ(prog.generic_constraints().size(), 0);
+
+  const double kNumericalTolerance = 1e-10;
+  for (int i = 0; i < (kNumSampleTimes - 1); i++) {
+    const double t = system.time_period() * i;
+    EXPECT_TRUE(
+        CompareMatrices(prog.EvalBindingAtSolution(dynamic_constraints[i]),
+                        prog.GetSolution(prog.state(i + 1)) -
+                          A.value(t) * prog.GetSolution(prog.state(i)) -
+                          B.value(t) * prog.GetSolution(prog.input(i)),
+                        kNumericalTolerance));
   }
 }
 
 GTEST_TEST(DirectTranscriptionTest, AddRunningCostTest) {
-  // x[n+1] = 1.
-  const Eigen::Matrix<double, 1, 1> A(0.0);
-  const Eigen::Matrix<double, 1, 0> B;
-  const Vector1d f0(1.0);
-  const Eigen::Matrix<double, 0, 1> C;
-  const Eigen::Matrix<double, 0, 0> D;
-  const Eigen::Matrix<double, 0, 1> y0;
   const double kTimeStep = 0.1;
-  AffineSystem<double> system(A, B, f0, C, D, y0, kTimeStep);
+  std::unique_ptr<AffineSystem<double>> system = MakeAffineSystem(kTimeStep);
 
-  const auto context = system.CreateDefaultContext();
+  const auto context = system->CreateDefaultContext();
   const int kNumSamples{5};
 
-  DirectTranscription prog(&system, *context, kNumSamples);
+  DirectTranscription prog(system.get(), *context, kNumSamples);
 
   // Check that there are no nonlinear constraints in the program.
   EXPECT_EQ(prog.generic_constraints().size(), 0);
 
-  // x[0] = 0.
+  // x[0] = 1.0
   prog.AddLinearConstraint(prog.initial_state() == Vector1d(1.0));
 
-  prog.AddRunningCost(prog.state());
-  prog.AddFinalCost(prog.state().cast<symbolic::Expression>());
+  prog.AddRunningCost(prog.state() * prog.state());
+  prog.AddFinalCost(prog.state() * prog.state());
 
   EXPECT_EQ(prog.Solve(), solvers::SolutionResult::kSolutionFound);
 
-  // Cost is x[N] + \sum_{0...N-1} h*x[i]
-  EXPECT_NEAR(prog.GetOptimalCost(), kTimeStep * (kNumSamples - 1) + 1, 1e-6);
+  // Compute the expected cost as c[N] + \Sum_{i = 0...N-1} h * c[i]
+  //   where c[i] is the running cost and c[N] is the terminal cost.
+  double expected_cost{0.};
+  for (int i{0}; i < kNumSamples - 1; i++) {
+    expected_cost +=
+        kTimeStep * std::pow(prog.GetSolution(prog.state(i))[0], 2.);
+  }
+
+  EXPECT_NEAR(prog.GetOptimalCost(), expected_cost, 1e-6);
 }
 
 // Check symbolic dynamics with parameters.


### PR DESCRIPTION
Additionally:
- Introduce the TimeVaryingLinearSystem class (and unit tests).
- Update the unit tests for DirTran, namely for the symbolic constraints, and extend to encompass the new constructors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7164)
<!-- Reviewable:end -->
