### PR TITLE
Fixing ASan Bugs Caught in Sierra

### DIFF
--- a/drake/automotive/idm_controller.cc
+++ b/drake/automotive/idm_controller.cc
@@ -97,8 +97,9 @@ void IdmController<T>::ImplCalcAcceleration(
   using std::max;
 
   DRAKE_DEMAND(idm_params.IsValid());
+  Isometry3<T> ego_pose_isometry = ego_pose.get_isometry();
+  const auto translation = ego_pose_isometry.translation();
 
-  const auto translation = ego_pose.get_isometry().translation();
   const maliput::api::GeoPosition geo_position(translation.x(), translation.y(),
                                                translation.z());
   const RoadPosition ego_position =

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -125,7 +125,9 @@ T PoseSelector<T>::GetSigmaVelocity(const RoadOdometry<T>& road_odometry) {
   DRAKE_DEMAND(IsWithinLane(road_odometry.pos, road_odometry.lane));
   const maliput::api::Rotation rot =
       road_odometry.lane->GetOrientation(road_odometry.pos);
-  const Vector3<T>& vel = road_odometry.vel.get_velocity().translational();
+  multibody::SpatialVelocity<T> road_odometry_velocity =
+      road_odometry.vel.get_velocity();
+  const Vector3<T>& vel = road_odometry_velocity.translational();
   return vel(0) * std::cos(rot.yaw()) + vel(1) * std::sin(rot.yaw());
 }
 

--- a/drake/examples/rod2d/rod2d-inl.h
+++ b/drake/examples/rod2d/rod2d-inl.h
@@ -594,8 +594,9 @@ void Rod2D<T>::CalcConstraintProblemData(
   Vector3<T> Qrow;
   for (int i = 0; i < static_cast<int>(sliding_contacts.size()); ++i) {
     const int contact_index = sliding_contacts[i];
-    const auto& sliding_dir = GetSlidingContactFrameToWorldTransform(
-        tangent_vels[contact_index]).col(1);
+    Matrix2<T> sliding_contract_frame = GetSlidingContactFrameToWorldTransform(
+        tangent_vels[contact_index]);
+    const auto& sliding_dir = sliding_contract_frame.col(1);
     Qrow = GetJacobianRow(context, points[contact_index], sliding_dir);
     N_minus_mu_Q.row(contact_index) -= data->mu_sliding[i] * Qrow;
   }


### PR DESCRIPTION
[Fixing ASan bugs caught in Sierra, they are all `stack-use-after-scope`](https://drake-jenkins.csail.mit.edu/view/Nightly/job/mac-sierra-clang-bazel-nightly-memcheck-asan/62/)

To reproduce for `automative_simulator_test`:
`bazel test --test_output=all --copt -O0  --compilation_mode=dbg --config=asan //drake/automotive:automotive_simulator_test`

[Stack with a temporary variable which goes out of scope](https://gist.github.com/m-chaturvedi/b0de9d7911cae03b7c438a7c6df7b4e7#file-sirra_asan_automotive_simulator_test-L388)

---
To reproduce for `constraint_solver_test`:
`bazel test --test_output=all --copt -O0 --compilation_mode=dbg --config=asan //drake/multibody/constraint:constraint_solver_test`

[Stack](https://gist.github.com/m-chaturvedi/6ed3721ea20744dd4f36e2634de366cc#file-asan_sierra_constraint_solver-cpp-L96)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7170)
<!-- Reviewable:end -->