### PR TITLE
[Multilane] Adds support for multi-lane connections

### DIFF
--- a/drake/automotive/maliput/multilane/BUILD.bazel
+++ b/drake/automotive/maliput/multilane/BUILD.bazel
@@ -104,6 +104,8 @@ drake_cc_googletest(
     srcs = ["test/multilane_builder_test.cc"],
     deps = [
         ":builder",
+        "//drake/automotive/maliput/api/test_utilities",
+        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/drake/automotive/maliput/multilane/builder.cc
+++ b/drake/automotive/maliput/multilane/builder.cc
@@ -16,42 +16,36 @@ namespace drake {
 namespace maliput {
 namespace multilane {
 
-Builder::Builder(const api::RBounds& lane_bounds,
-                 const api::RBounds& driveable_bounds,
-                 const api::HBounds& elevation_bounds,
-                 const double linear_tolerance,
-                 const double angular_tolerance)
-    : lane_bounds_(lane_bounds),
-      driveable_bounds_(driveable_bounds),
+Builder::Builder(double lane_width, const api::HBounds& elevation_bounds,
+                 double linear_tolerance, double angular_tolerance)
+    : lane_width_(lane_width),
       elevation_bounds_(elevation_bounds),
       linear_tolerance_(linear_tolerance),
       angular_tolerance_(angular_tolerance) {
-  DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
-  DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
+  DRAKE_DEMAND(lane_width_ >= 0.);
+  DRAKE_DEMAND(linear_tolerance_ >= 0.);
+  DRAKE_DEMAND(angular_tolerance_ >= 0.);
 }
 
-
-const Connection* Builder::Connect(
-    const std::string& id,
-    const Endpoint& start,
-    const double length,
-    const EndpointZ& z_end) {
-
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double r0, double left_shoulder,
+                                   double right_shoulder, const Endpoint& start,
+                                   double length, const EndpointZ& z_end) {
   const Endpoint end(
       EndpointXy(start.xy().x() + (length * std::cos(start.xy().heading())),
                  start.xy().y() + (length * std::sin(start.xy().heading())),
                  start.xy().heading()),
       z_end);
-  connections_.push_back(std::make_unique<Connection>(id, start, end));
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, end, num_lanes, r0, left_shoulder, right_shoulder));
   return connections_.back().get();
 }
 
-
-const Connection* Builder::Connect(
-    const std::string& id,
-    const Endpoint& start,
-    const ArcOffset& arc,
-    const EndpointZ& z_end) {
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double r0, double left_shoulder,
+                                   double right_shoulder, const Endpoint& start,
+                                   const ArcOffset& arc,
+                                   const EndpointZ& z_end) {
   const double alpha = start.xy().heading();
   const double theta0 = alpha - std::copysign(M_PI / 2., arc.d_theta());
   const double theta1 = theta0 + arc.d_theta();
@@ -65,15 +59,17 @@ const Connection* Builder::Connect(
                      z_end);
 
   connections_.push_back(std::make_unique<Connection>(
-      id, start, end, cx, cy, arc.radius(), arc.d_theta()));
+      id, start, end, num_lanes, r0, left_shoulder, right_shoulder, cx, cy,
+      arc.radius(), arc.d_theta()));
   return connections_.back().get();
 }
 
-
-void Builder::SetDefaultBranch(
-    const Connection* in, const api::LaneEnd::Which in_end,
-    const Connection* out, const api::LaneEnd::Which out_end) {
-  default_branches_.push_back({in, in_end, out, out_end});
+void Builder::SetDefaultBranch(const Connection* in, int in_lane_index,
+                               const api::LaneEnd::Which in_end,
+                               const Connection* out, int out_lane_index,
+                               const api::LaneEnd::Which out_end) {
+  default_branches_.push_back(
+      {in, in_lane_index, in_end, out, out_lane_index, out_end});
 }
 
 
@@ -120,6 +116,34 @@ double HeadingIntoLane(const api::Lane* const lane,
     }
     default: { DRAKE_ABORT(); }
   }
+}
+
+// Computes the location and heading of a `lane` at given `end` creating an
+// Endpoint with that information. `road_curve` is used to compute z
+// derivative with respect to p at the start or end of the `lane` respectively.
+Endpoint ComputeEndpointForLane(const RoadCurve& road_curve, const Lane* lane,
+                                const api::LaneEnd::Which end,
+                                const EndpointZ& zpoint) {
+  double p{}, length{};
+  switch (end) {
+    case api::LaneEnd::kStart:
+      p = 0.;
+      length = 0.;
+      break;
+    case api::LaneEnd::kFinish:
+      p = 1.;
+      length = lane->length();
+      break;
+    default: { DRAKE_ABORT(); }
+  }
+  const api::GeoPosition position = lane->ToGeoPosition({length, 0., 0.});
+  const api::Rotation rotation = lane->GetOrientation({length, 0., 0.});
+  const Vector3<double> w_prime =
+      road_curve.W_prime_of_prh(p, lane->r0(), 0., road_curve.Rabg_of_p(p),
+                                road_curve.elevation().f_dot_p(p));
+  return Endpoint(
+      EndpointXy(position.x(), position.y(), rotation.yaw()),
+      EndpointZ(position.z(), w_prime.z(), zpoint.theta(), zpoint.theta_dot()));
 }
 }  // namespace
 
@@ -184,13 +208,11 @@ void Builder::AttachBranchPoint(
   }
 }
 
-
-Lane* Builder::BuildConnection(
-    const Connection* const conn,
-    Junction* const junction,
+std::vector<Lane*> Builder::BuildConnection(
+    const Connection* const conn, Junction* const junction,
     RoadGeometry* const road_geometry,
     std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder>* const bp_map) const {
-  std::unique_ptr<RoadCurve> road_curve;
+  std::unique_ptr<RoadCurve> p_road_curve;
   switch (conn->type()) {
     case Connection::kLine: {
       const V2 xy0(conn->start().xy().x(),
@@ -209,8 +231,8 @@ Lane* Builder::BuildConnection(
           conn->end().z().theta() - conn->start().z().theta(),
           conn->start().z().theta_dot(),
           conn->end().z().theta_dot()));
-      road_curve = std::make_unique<LineRoadCurve>(
-          xy0, dxy, elevation, superelevation);
+      p_road_curve =
+          std::make_unique<LineRoadCurve>(xy0, dxy, elevation, superelevation);
       break;
     }
     case Connection::kArc: {
@@ -232,7 +254,7 @@ Lane* Builder::BuildConnection(
           conn->end().z().theta() - conn->start().z().theta(),
           conn->start().z().theta_dot(),
           conn->end().z().theta_dot()));
-      road_curve = std::make_unique<ArcRoadCurve>(
+      p_road_curve = std::make_unique<ArcRoadCurve>(
           center, radius, theta0, d_theta, elevation, superelevation);
       break;
     }
@@ -240,16 +262,37 @@ Lane* Builder::BuildConnection(
       DRAKE_ABORT();
     }
   }
-  api::LaneId lane_id{std::string("l:") + conn->id()};
+  // Computes segment lateral extent.
+  const double r_min = conn->r0() - lane_width_ / 2. - conn->right_shoulder();
+  const double r_max =
+      conn->r0() +
+      lane_width_ * (static_cast<double>(conn->num_lanes() - 1) + 0.5) +
+      conn->left_shoulder();
+  const RoadCurve& road_curve = *p_road_curve;
   Segment* segment = junction->NewSegment(
-      api::SegmentId{std::string("s:") + conn->id()}, std::move(road_curve),
-      driveable_bounds_.min(), driveable_bounds_.max(), elevation_bounds_);
-  Lane* lane = segment->NewLane(lane_id, 0., lane_bounds_);
-  AttachBranchPoint(
-      conn->start(), lane, api::LaneEnd::kStart, road_geometry, bp_map);
-  AttachBranchPoint(
-      conn->end(), lane, api::LaneEnd::kFinish, road_geometry, bp_map);
-  return lane;
+      api::SegmentId{std::string("s:") + conn->id()}, std::move(p_road_curve),
+      r_min, r_max, elevation_bounds_);
+  std::vector<Lane*> lanes;
+  for (int i = 0; i < conn->num_lanes(); i++) {
+    Lane* lane =
+        segment->NewLane(api::LaneId{std::string("l:") + conn->id() +
+                                     std::string("_") + std::to_string(i)},
+                         conn->r0() + lane_width_ * static_cast<double>(i),
+                         {-lane_width_ / 2., lane_width_ / 2.});
+    // Creates endpoints for the extents of the lane since they may not be
+    // over the reference curve.
+    const Endpoint start_endpoint = ComputeEndpointForLane(
+        road_curve, lane, api::LaneEnd::kStart, conn->start().z());
+    const Endpoint finish_endpoint = ComputeEndpointForLane(
+        road_curve, lane, api::LaneEnd::kFinish, conn->end().z());
+    AttachBranchPoint(start_endpoint, lane, api::LaneEnd::kStart, road_geometry,
+                      bp_map);
+    AttachBranchPoint(finish_endpoint, lane, api::LaneEnd::kFinish,
+                      road_geometry, bp_map);
+    lanes.push_back(lane);
+  }
+
+  return lanes;
 }
 
 
@@ -259,7 +302,7 @@ std::unique_ptr<const api::RoadGeometry> Builder::Build(
       id, linear_tolerance_, angular_tolerance_);
   std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder> bp_map(
       (EndpointFuzzyOrder(linear_tolerance_)));
-  std::map<const Connection*, Lane*> lane_map;
+  std::map<const Connection*, std::vector<Lane*>> lane_map;
   std::map<const Connection*, bool> connection_was_built;
 
   for (const std::unique_ptr<Connection>& connection : connections_) {
@@ -295,8 +338,8 @@ std::unique_ptr<const api::RoadGeometry> Builder::Build(
   }
 
   for (const DefaultBranch& def : default_branches_) {
-    Lane* in_lane = lane_map[def.in];
-    Lane* out_lane = lane_map[def.out];
+    Lane* in_lane = lane_map[def.in][def.in_lane_index];
+    Lane* out_lane = lane_map[def.out][def.out_lane_index];
     DRAKE_DEMAND((def.in_end == api::LaneEnd::kStart) ||
                  (def.in_end == api::LaneEnd::kFinish));
     ((def.in_end == api::LaneEnd::kStart) ?

--- a/drake/automotive/maliput/multilane/builder.h
+++ b/drake/automotive/maliput/multilane/builder.h
@@ -25,8 +25,8 @@ class RoadGeometry;
 ///
 /// multilane is a simple road-network implementation:
 ///  - multiple lanes per segment;
-///  - constant lane_bounds, driveable_bounds, and elevation_bounds,
-///    same for all lanes;
+///  - constant lane width, lane_bounds, and elevation_bounds, same for all
+///    lanes;
 ///  - only linear and constant-curvature-arc primitives in XY-plane;
 ///  - cubic polynomials (parameterized on XY-arc-length) for elevation
 ///    and superelevation;
@@ -40,11 +40,22 @@ class RoadGeometry;
 /// start Endpoint to an end Endpoint calculated via a linear or arc
 /// displacement (ArcOffset).  A Group is a collection of Connections.
 ///
-/// Builder::Build() constructs a RoadGeometry.  Each Connection yields a
-/// Segment bearing a single Lane.  Each Group yields a Junction containing
+/// Builder::Build() constructs a RoadGeometry. Each Connection yields a
+/// Segment bearing multiple Lanes. Each Group yields a Junction containing
 /// the Segments associated with the grouped Connections; ungrouped
 /// Connections each receive their own Junction.
-
+///
+/// Specific suffixes are used to name Maliput entities. The following list
+/// explains the naming convention:
+///
+///  - Junctions: "j:" + Group::id(), or "j" + Connection::id() for an
+///    ungrouped Connection.
+///  - Segments: "s:" + Connection::id()
+///  - Lanes: "l:" + Connection::id() + "_" + lane_index
+///  - BranchPoints: "bp:" + branch_point_index
+///
+/// Note: 'lane_index' is the index in the Segment, and 'branch_point_index' is
+/// is the index in the RoadGeometry.
 
 /// XY-plane-only parameters for an endpoint of a connection, specified in
 /// the world frame.
@@ -157,7 +168,7 @@ class Endpoint {
 
 
 /// Specification for path offset along a circular arc.
-///  * radius: radius of the arc, which must be non-negative
+///  * radius: radius of the arc, which must be positive
 ///  * d_theta:  angle of arc segment (Δθ)
 ///    * d_theta > 0 is counterclockwise ('veer to left')
 ///    * d_theta < 0 is clockwise ('veer to right')
@@ -186,7 +197,7 @@ class ArcOffset {
 /// Representation of a reference path connecting two endpoints.
 ///
 /// Upon building the RoadGeometry, a Connection yields a Segment
-/// bearing a single Lane with the specified reference path.  The
+/// bearing multiple Lanes with offsets from the reference path. The
 /// Segment will belong to its own Junction, unless the Connection was
 /// grouped with other Connections into a Group.
 ///
@@ -202,23 +213,67 @@ class Connection {
   /// Possible connection geometries:  line- or arc-segment.
   enum Type { kLine, kArc };
 
-  /// Constructs a line-segment connection joining @p start to @p end.
-  Connection(const std::string& id,
-             const Endpoint& start, const Endpoint& end)
-      : type_(kLine), id_(id), start_(start), end_(end) {}
+  /// Constructs a line-segment connection joining `start` to `end`.
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// First Lane centerline will be placed at `r0` distance from the reference
+  /// curve.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, const Endpoint& end,
+             int num_lanes, double r0, double left_shoulder,
+             double right_shoulder)
+      : type_(kLine),
+        id_(id),
+        start_(start),
+        end_(end),
+        num_lanes_(num_lanes),
+        r0_(r0),
+        left_shoulder_(left_shoulder),
+        right_shoulder_(right_shoulder) {
+    DRAKE_DEMAND(num_lanes_ > 0);
+    DRAKE_DEMAND(left_shoulder_ >= 0);
+    DRAKE_DEMAND(right_shoulder_ >= 0);
+  }
 
-  /// Constructs an arc-segment connection joining @p start to @p end.
+  /// Constructs an arc-segment connection joining `start` to `end`.
   ///
-  /// @p cx, @p cy specify the center of the arc. @p radius is the radius,
-  /// and @p d_theta is the angle of arc.
+  /// `cx`, `cy` specify the center of the arc. `radius` is the radius,
+  /// and `d_theta` is the angle of arc.
   ///
-  /// @p radius must be non-negative.  @p d_theta > 0 indicates a
+  /// `radius` must be positive.  `d_theta` > 0 indicates a
   /// counterclockwise arc from start to end.
-  Connection(const std::string& id,
-             const Endpoint& start, const Endpoint& end,
-             double cx, double cy, double radius, double d_theta)
-      : type_(kArc), id_(id), start_(start), end_(end),
-        cx_(cx), cy_(cy), radius_(radius), d_theta_(d_theta) {}
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// First Lane centerline will be placed at `r0` distance from the reference
+  /// curve.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, const Endpoint& end,
+             int num_lanes, double r0, double left_shoulder,
+             double right_shoulder, double cx, double cy, double radius,
+             double d_theta)
+      : type_(kArc),
+        id_(id),
+        start_(start),
+        end_(end),
+        num_lanes_(num_lanes),
+        r0_(r0),
+        left_shoulder_(left_shoulder),
+        right_shoulder_(right_shoulder),
+        cx_(cx),
+        cy_(cy),
+        radius_(radius),
+        d_theta_(d_theta) {
+    DRAKE_DEMAND(num_lanes_ > 0);
+    DRAKE_DEMAND(left_shoulder_ >= 0);
+    DRAKE_DEMAND(right_shoulder_ >= 0);
+    DRAKE_DEMAND(radius_ > 0);
+  }
 
   /// Returns the geometric type of the path.
   Type type() const { return type_; }
@@ -256,11 +311,28 @@ class Connection {
     return d_theta_;
   }
 
+  /// Returns the number of lanes the Segment will contain.
+  int num_lanes() const { return num_lanes_; }
+
+  /// Returns the lateral offset from the reference curve to the first Lane
+  /// centerline.
+  double r0() const { return r0_; }
+
+  /// Returns the left shoulder distance of the segment.
+  double left_shoulder() const { return left_shoulder_; }
+
+  /// Returns the right shoulder distance of the segment.
+  double right_shoulder() const { return right_shoulder_; }
+
  private:
   Type type_{};
   std::string id_;
   Endpoint start_;
   Endpoint end_;
+  const int num_lanes_{};
+  const double r0_{};
+  const double left_shoulder_{};
+  const double right_shoulder_{};
 
   // Bits specific to type_ == kArc:
   double cx_{};
@@ -278,10 +350,10 @@ class Group {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Group)
 
-  /// Constructs an empty Group with the specified @p id.
+  /// Constructs an empty Group with the specified `id`.
   explicit Group(const std::string& id) : id_(id) {}
 
-  /// Constructs a Group with @p id, populated by @p connections.
+  /// Constructs a Group with `id`, populated by `connections`.
   Group(const std::string& id,
         const std::vector<const Connection*>& connections)
       : id_(id) {
@@ -320,63 +392,69 @@ class Builder {
   /// Constructs a Builder which can be used to specify and assemble a
   /// multilane implementation of an api::RoadGeometry.
   ///
-  /// The bounds @p lane_bounds, @p driveable_bounds, and @p elevation_bounds
-  /// are applied uniformly to the single lanes of every segment;
-  /// @p lane_bounds must be a subset of @p driveable_bounds.
-  /// @p linear_tolerance and @p angular_tolerance specify the respective
+  /// `lane_width` is the width assigned to all Lanes. It must be greater or
+  /// equal to zero. Lane reference path (which are offsets of parent Segment
+  /// reference curve) are centered within the Lane. Lane spacing will be
+  /// `lane_width` too. Segment extents will be derived from the composition of
+  /// left and right shoulders, number of lanes and lane spacing. The
+  /// `elevation_bounds` is applied uniformly to all lanes of every segment.
+  /// `linear_tolerance` and `angular_tolerance` specify the respective
   /// tolerances for the resulting RoadGeometry.
-  Builder(const api::RBounds& lane_bounds,
-          const api::RBounds& driveable_bounds,
-          const api::HBounds& elevation_bounds,
-          const double linear_tolerance,
-          const double angular_tolerance);
+  Builder(double lane_width, const api::HBounds& elevation_bounds,
+          double linear_tolerance, double angular_tolerance);
 
-  /// Connects @p start to an end-point linearly displaced from @p start.
-  /// @p length specifies the length of displacement (in the direction of the
-  /// heading of @p start).  @p z_end specifies the elevation characteristics
-  /// at the end-point.
-  const Connection* Connect(
-      const std::string& id,
-      const Endpoint& start,
-      const double length,
-      const EndpointZ& z_end);
+  /// Connects `start` to an end-point linearly displaced from `start`.
+  /// `length` specifies the length of displacement (in the direction of the
+  /// heading of `start`). `z_end` specifies the elevation characteristics at
+  /// the end-point.
+  /// `r0` is the distance from the reference curve to the first Lane
+  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
+  /// distances added to the extents of the Segment after the first and last
+  /// Lanes positions are determined.
+  const Connection* Connect(const std::string& id, int num_lanes, double r0,
+                            double left_shoulder, double right_shoulder,
+                            const Endpoint& start, double length,
+                            const EndpointZ& z_end);
 
-  /// Connects @p start to an end-point displaced from @p start via an arc.
-  /// @p arc specifies the shape of the arc.  @p z_end specifies the
-  /// elevation characteristics at the end-point.
-  const Connection* Connect(
-      const std::string& id,
-      const Endpoint& start,
-      const ArcOffset& arc,
-      const EndpointZ& z_end);
+  /// Connects `start` to an end-point displaced from `start` via an arc.
+  /// `arc` specifies the shape of the arc. `z_end` specifies the elevation
+  /// characteristics at the end-point.
+  /// `r0` is the distance from the reference curve to the first Lane
+  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
+  /// distances added to the extents of the Segment after the first and last
+  /// Lanes positions are determined.
+  const Connection* Connect(const std::string& id, int num_lanes, double r0,
+                            double left_shoulder, double right_shoulder,
+                            const Endpoint& start, const ArcOffset& arc,
+                            const EndpointZ& z_end);
 
   /// Sets the default branch for one end of a connection.
   ///
-  /// The default branch for the @p in_end of connection @p in will set to be
-  /// @p out_end of connection @p out.  The specified connections must
-  /// actually be joined at the specified ends (i.e., the Endpoint's for
-  /// those ends must be coincident and (anti)parallel within the tolerances
-  /// for the Builder).
-  void SetDefaultBranch(
-      const Connection* in, const api::LaneEnd::Which in_end,
-      const Connection* out, const api::LaneEnd::Which out_end);
+  /// The default branch for the `in_end` of connection `in` at Lane
+  /// `in_lane_index`will set to be `out_end` of connection `out` at Lane
+  /// `out_lane_index`. The specified connections must actually be joined at the
+  /// specified ends (i.e., the Endpoint's for those ends must be coincident and
+  /// (anti)parallel within the tolerances for the Builder).
+  void SetDefaultBranch(const Connection* in, int in_lane_index,
+                        const api::LaneEnd::Which in_end, const Connection* out,
+                        int out_lane_index, const api::LaneEnd::Which out_end);
 
-  /// Creates a new empty connection group with ID string @p id.
+  /// Creates a new empty connection group with ID string `id`.
   Group* MakeGroup(const std::string& id);
 
-  /// Creates a new connection group with ID @p id, populated with the
-  /// given @p connections.
+  /// Creates a new connection group with ID `id`, populated with the
+  /// given `connections`.
   Group* MakeGroup(const std::string& id,
                    const std::vector<const Connection*>& connections);
 
-  /// Produces a RoadGeometry, with the ID @p id.
+  /// Produces a RoadGeometry, with the ID `id`.
   std::unique_ptr<const api::RoadGeometry> Build(
       const api::RoadGeometryId& id) const;
 
  private:
   // EndpointFuzzyOrder is an arbitrary strict complete ordering of Endpoints
   // useful for, e.g., std::map.  It provides a comparison operation that
-  // treats two Endpoints within @p linear_tolerance of one another as
+  // treats two Endpoints within `linear_tolerance` of one another as
   // equivalent.
   //
   // This is used to match up the endpoints of Connections, to determine
@@ -429,20 +507,26 @@ class Builder {
   struct DefaultBranch {
     DefaultBranch() = default;
 
-    DefaultBranch(
-        const Connection* ain, const api::LaneEnd::Which ain_end,
-        const Connection* aout, const api::LaneEnd::Which aout_end)
-        : in(ain), in_end(ain_end), out(aout), out_end(aout_end) {}
+    DefaultBranch(const Connection* ain, int ain_lane_index,
+                  const api::LaneEnd::Which ain_end, const Connection* aout,
+                  int aout_lane_index, const api::LaneEnd::Which aout_end)
+        : in(ain),
+          in_lane_index(ain_lane_index),
+          in_end(ain_end),
+          out(aout),
+          out_lane_index(aout_lane_index),
+          out_end(aout_end) {}
 
     const Connection* in{};
+    const int in_lane_index{};
     api::LaneEnd::Which in_end{};
     const Connection* out{};
+    const int out_lane_index{};
     api::LaneEnd::Which out_end{};
   };
 
-  Lane* BuildConnection(
-      const Connection* const cnx,
-      Junction* const junction,
+  std::vector<Lane*> BuildConnection(
+      const Connection* const cnx, Junction* const junction,
       RoadGeometry* const rg,
       std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder>* const bp_map) const;
 
@@ -456,11 +540,10 @@ class Builder {
       RoadGeometry* rg,
       std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder>* bp_map) const;
 
-  api::RBounds lane_bounds_;
-  api::RBounds driveable_bounds_;
-  api::HBounds elevation_bounds_;
-  double linear_tolerance_{};
-  double angular_tolerance_{};
+  const double lane_width_{};
+  const api::HBounds elevation_bounds_;
+  const double linear_tolerance_{};
+  const double angular_tolerance_{};
   std::vector<std::unique_ptr<Connection>> connections_;
   std::vector<DefaultBranch> default_branches_;
   std::vector<std::unique_ptr<Group>> groups_;

--- a/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -3,22 +3,27 @@
 /* clang-format on */
 
 #include <cmath>
-#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
 
 namespace drake {
 namespace maliput {
 namespace multilane {
 
 GTEST_TEST(MultilaneBuilderTest, Fig8) {
-  const api::RBounds kLaneBounds(-2., 2.);
-  const api::RBounds kDriveableBounds(-4., 4.);
+  const double kLaneWidth = 4.;
+  const double kLeftShoulder = 2.;
+  const double kRightShoulder = 2.;
   const api::HBounds kElevationBounds(0., 5.);
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-            kLinearTolerance, kAngularTolerance);
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
 
   const EndpointZ kLowFlatZ(0., 0., 0., 0.);
   const EndpointZ kMidFlatZ(3., 0., 0., 0.);
@@ -29,18 +34,27 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
   const ArcOffset kCounterClockwiseArc(50., 0.75 * M_PI);  // 135deg, 50m radius
   const ArcOffset kClockwiseArc(50., -0.75 * M_PI);  // 135deg, 50m radius
 
+  const int kOneLane = 1;
+  const double kZeroR0 = 0.;
+
   Endpoint start {{0., 0., -M_PI / 4.}, kLowFlatZ};
-  auto c0 = b.Connect("0", start,
-                      50., kMidFlatZ);
+  auto c0 = b.Connect("0", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      start, 50., kMidFlatZ);
 
-  auto c1 = b.Connect("1", c0->end(), kCounterClockwiseArc, kMidTiltLeftZ);
-  auto c2 = b.Connect("2", c1->end(), kCounterClockwiseArc, kMidFlatZ);
+  auto c1 = b.Connect("1", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c0->end(), kCounterClockwiseArc, kMidTiltLeftZ);
+  auto c2 = b.Connect("2", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c1->end(), kCounterClockwiseArc, kMidFlatZ);
 
-  auto c3 = b.Connect("3", c2->end(), 50., kHighFlatZ);
-  auto c4 = b.Connect("4", c3->end(), 50., kMidFlatZ);
+  auto c3 = b.Connect("3", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c2->end(), 50., kHighFlatZ);
+  auto c4 = b.Connect("4", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c3->end(), 50., kMidFlatZ);
 
-  auto c5 = b.Connect("5", c4->end(), kClockwiseArc, kMidTiltRightZ);
-  auto c6 = b.Connect("6", c5->end(), kClockwiseArc, kMidFlatZ);
+  auto c5 = b.Connect("5", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c4->end(), kClockwiseArc, kMidTiltRightZ);
+  auto c6 = b.Connect("6", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                      c5->end(), kClockwiseArc, kMidFlatZ);
 
   // Tweak ends to check if fuzzy-matching is working.
   Endpoint c6end = c6->end();
@@ -55,7 +69,8 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
                         c0start_z.z_dot(),
                         c0start_z.theta(), c0start_z.theta_dot());
 
-  b.Connect("7", c6end, 50., c0start_z);
+  b.Connect("7", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder, c6end, 50.,
+            c0start_z);
 
   std::unique_ptr<const api::RoadGeometry> rg =
       b.Build(api::RoadGeometryId{"figure-eight"});
@@ -70,7 +85,7 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
 
     const api::Segment* seg = jnx->segment(0);
     EXPECT_EQ(seg->junction(), jnx);
-    EXPECT_EQ(seg->num_lanes(), 1);
+    EXPECT_EQ(seg->num_lanes(), kOneLane);
 
     const api::Lane* lane = seg->lane(0);
     EXPECT_EQ(lane->segment(), seg);
@@ -97,13 +112,13 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
 
 
 GTEST_TEST(MultilaneBuilderTest, QuadRing) {
-  const api::RBounds kLaneBounds(-2., 2.);
-  const api::RBounds kDriveableBounds(-4., 4.);
+  const double kLaneWidth = 4.;
+  const double kLeftShoulder = 2.;
+  const double kRightShoulder = 2.;
   const api::HBounds kElevationBounds(0., 5.);
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-            kLinearTolerance, kAngularTolerance);
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
 
   const EndpointZ kFlatZ(0., 0., 0., 0.);
   const ArcOffset kLargeClockwiseLoop(150., -2. * M_PI);
@@ -111,20 +126,27 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   const ArcOffset kLargeCounterClockwiseLoop(150., 2. * M_PI);
   const ArcOffset kSmallCounterClockwiseLoop(50., 2. * M_PI);
 
+  const int kOneLane = 1;
+  const double kZeroR0 = 0.;
+
   Endpoint northbound {{0., 0., M_PI / 2.}, kFlatZ};
 
   // This heads -y, loops to -x, clockwise, back to origin.
-  auto left1 = b.Connect("left1", northbound.reverse(),
-                         kLargeClockwiseLoop, kFlatZ);
+  auto left1 =
+      b.Connect("left1", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                northbound.reverse(), kLargeClockwiseLoop, kFlatZ);
   // This heads +y, loops to -x, counterclockwise, back to origin.
-  auto left0 = b.Connect("left0", northbound,
-                         kSmallCounterClockwiseLoop, kFlatZ);
+  auto left0 =
+      b.Connect("left0", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                northbound, kSmallCounterClockwiseLoop, kFlatZ);
   // This heads +y, loops to +x, clockwise, back to origin.
-  auto right0 = b.Connect("right0", northbound,
-                          kSmallClockwiseLoop, kFlatZ);
+  auto right0 =
+      b.Connect("right0", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                northbound, kSmallClockwiseLoop, kFlatZ);
   // This heads -y, loops to +x, counterclockwise, back to origin.
-  auto right1 = b.Connect("right1", northbound.reverse(),
-                          kLargeCounterClockwiseLoop, kFlatZ);
+  auto right1 =
+      b.Connect("right1", kOneLane, kZeroR0, kLeftShoulder, kRightShoulder,
+                northbound.reverse(), kLargeCounterClockwiseLoop, kFlatZ);
 
   // There is only one branch-point in this topology, since every lane is
   // a ring connecting back to itself and all other lanes.
@@ -140,21 +162,22 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   //  #  -----< right1/start  o--      ---o right1/finish <------  #
   //
   // Make up some combination of default routes:
-  b.SetDefaultBranch(
-      left1, api::LaneEnd::kStart, left1, api::LaneEnd::kFinish);
-  b.SetDefaultBranch(
-      left0, api::LaneEnd::kFinish, right0, api::LaneEnd::kStart);
-  b.SetDefaultBranch(
-      right0, api::LaneEnd::kFinish, right1, api::LaneEnd::kFinish);
-  b.SetDefaultBranch(
-      right1, api::LaneEnd::kStart, left1, api::LaneEnd::kFinish);
+  const int kLaneIndex{0};
+  b.SetDefaultBranch(left1, kLaneIndex, api::LaneEnd::kStart, left1, kLaneIndex,
+                     api::LaneEnd::kFinish);
+  b.SetDefaultBranch(left0, kLaneIndex, api::LaneEnd::kFinish, right0,
+                     kLaneIndex, api::LaneEnd::kStart);
+  b.SetDefaultBranch(right0, kLaneIndex, api::LaneEnd::kFinish, right1,
+                     kLaneIndex, api::LaneEnd::kFinish);
+  b.SetDefaultBranch(right1, kLaneIndex, api::LaneEnd::kStart, left1,
+                     kLaneIndex, api::LaneEnd::kFinish);
 
-  b.SetDefaultBranch(
-      left1, api::LaneEnd::kFinish, left1, api::LaneEnd::kStart);
-  b.SetDefaultBranch(
-      left0, api::LaneEnd::kStart, right1, api::LaneEnd::kStart);
-  b.SetDefaultBranch(
-      right0, api::LaneEnd::kStart, right1, api::LaneEnd::kStart);
+  b.SetDefaultBranch(left1, kLaneIndex, api::LaneEnd::kFinish, left1,
+                     kLaneIndex, api::LaneEnd::kStart);
+  b.SetDefaultBranch(left0, kLaneIndex, api::LaneEnd::kStart, right1,
+                     kLaneIndex, api::LaneEnd::kStart);
+  b.SetDefaultBranch(right0, kLaneIndex, api::LaneEnd::kStart, right1,
+                     kLaneIndex, api::LaneEnd::kStart);
   // And, leave right1/finish without a default branch.
 
   b.MakeGroup("all", {right1, right0, left0, left1});
@@ -173,43 +196,43 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   EXPECT_EQ(junction->num_segments(), 4);
   for (int si = 0; si < junction->num_segments(); ++si) {
     const api::Segment* segment = junction->segment(si);
-    EXPECT_EQ(segment->num_lanes(), 1);
+    EXPECT_EQ(segment->num_lanes(), kOneLane);
     const api::Lane* lane = segment->lane(0);
 
-    if (lane->id() == api::LaneId("l:left1")) {
+    if (lane->id() == api::LaneId("l:left1_0")) {
       EXPECT_EQ(lane->segment()->id(), api::SegmentId("s:left1"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->lane->id(),
-                api::LaneId("l:left1"));
+                api::LaneId("l:left1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kFinish);
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->lane->id(),
-                api::LaneId("l:left1"));
+                api::LaneId("l:left1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->end,
                 api::LaneEnd::kStart);
-    } else if (lane->id() == api::LaneId("l:left0")) {
+    } else if (lane->id() == api::LaneId("l:left0_0")) {
       EXPECT_EQ(lane->segment()->id(), api::SegmentId("s:left0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->lane->id(),
-                api::LaneId("l:right1"));
+                api::LaneId("l:right1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kStart);
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->lane->id(),
-                api::LaneId("l:right0"));
+                api::LaneId("l:right0_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->end,
                 api::LaneEnd::kStart);
-    } else if (lane->id() == api::LaneId("l:right0")) {
+    } else if (lane->id() == api::LaneId("l:right0_0")) {
       EXPECT_EQ(lane->segment()->id(), api::SegmentId("s:right0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->lane->id(),
-                api::LaneId("l:right1"));
+                api::LaneId("l:right1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kStart);
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->lane->id(),
-                api::LaneId("l:right1"));
+                api::LaneId("l:right1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish)->end,
                 api::LaneEnd::kFinish);
-    } else if (lane->id() == api::LaneId("l:right1")) {
+    } else if (lane->id() == api::LaneId("l:right1_0")) {
       EXPECT_EQ(lane->segment()->id(), api::SegmentId("s:right1"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->lane->id(),
-                api::LaneId("l:left1"));
+                api::LaneId("l:left1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kFinish);
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish).get(), nullptr);
@@ -219,6 +242,318 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   }
 };
 
+// Holds Lane IDs for each Lane, both at the start and end of the Lane.
+struct BranchPointLaneIds {
+  std::vector<std::string> start_a_side;
+  std::vector<std::string> start_b_side;
+  std::vector<std::string> finish_a_side;
+  std::vector<std::string> finish_b_side;
+};
+
+class MultilaneBuilderPrimitivesTest : public ::testing::Test {
+ protected:
+  const double kR0{10.};
+  const double kLaneWidth{4.};
+  const double kLeftShoulder{2.};
+  const double kRightShoulder{2.};
+  const api::HBounds kElevationBounds{0., 5.};
+  const double kLinearTolerance{0.01};
+  const double kAngularTolerance{0.01 * M_PI};
+  const int kNumLanes{3};
+  const EndpointZ kLowFlatZ{0., 0., 0., 0.};
+  const double kStartHeading{-M_PI / 4.};
+  const Endpoint start{{0., 0., kStartHeading}, kLowFlatZ};
+};
+
+// Checks that a multi-lane line segment is correctly created.
+TEST_F(MultilaneBuilderPrimitivesTest, MultilaneLineSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kLength = 50.;
+  b.Connect("c0", kNumLanes, kR0, kLeftShoulder, kRightShoulder, start, kLength,
+            kLowFlatZ);
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{"multilane-line-segment"});
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-line-segment"));
+  EXPECT_EQ(rg->num_junctions(), 1);
+  EXPECT_NE(rg->junction(0), nullptr);
+  EXPECT_EQ(rg->junction(0)->id(), api::JunctionId("j:c0"));
+  EXPECT_EQ(rg->junction(0)->num_segments(), 1);
+  EXPECT_NE(rg->junction(0)->segment(0), nullptr);
+  EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
+  EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
+
+  const Vector3<double> r_versor(-std::sin(kStartHeading),
+                                 std::cos(kStartHeading), 0.);
+  const Vector3<double> start_reference_curve(start.xy().x(), start.xy().y(),
+                                              start.z().z());
+  for (int i = 0; i < kNumLanes; i++) {
+    const api::Lane* lane = rg->junction(0)->segment(0)->lane(i);
+    // Checks Lane's ID.
+    EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
+    // Checks lane start geo position to verify that spacing is correctly
+    // applied.
+    const Vector3<double> lane_start_geo =
+        start_reference_curve +
+        (kR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition({0., 0., 0.}),
+        api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
+    // Checks lane start and end BranchPoint.
+    const api::BranchPoint* const start_bp =
+        lane->GetBranchPoint(api::LaneEnd::kStart);
+    EXPECT_EQ(start_bp->GetASide()->size(), 1);
+    EXPECT_EQ(start_bp->GetASide()->get(0).lane, lane);
+    EXPECT_EQ(start_bp->GetBSide()->size(), 0);
+    const api::BranchPoint* const end_bp =
+        lane->GetBranchPoint(api::LaneEnd::kFinish);
+    EXPECT_EQ(end_bp->GetASide()->size(), 1);
+    EXPECT_EQ(end_bp->GetASide()->get(0).lane, lane);
+    EXPECT_EQ(end_bp->GetBSide()->size(), 0);
+  }
+  // Checks the number of branch points.
+  EXPECT_EQ(rg->num_branch_points(), 2 * kNumLanes);
+}
+
+// Checks that a multi-lane arc segment is correctly created.
+TEST_F(MultilaneBuilderPrimitivesTest, MultilaneArcSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kRadius = 30.;
+  const double kDTheta = 0.5 * M_PI;
+  b.Connect("c0", kNumLanes, kR0, kLeftShoulder, kRightShoulder, start,
+            ArcOffset(kRadius, kDTheta), kLowFlatZ);
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{"multilane-arc-segment"});
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-arc-segment"));
+  EXPECT_EQ(rg->num_junctions(), 1);
+  EXPECT_NE(rg->junction(0), nullptr);
+  EXPECT_EQ(rg->junction(0)->id(), api::JunctionId("j:c0"));
+  EXPECT_EQ(rg->junction(0)->num_segments(), 1);
+  EXPECT_NE(rg->junction(0)->segment(0), nullptr);
+  EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
+  EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
+
+  const Vector3<double> r_versor(-std::sin(kStartHeading),
+                                 std::cos(kStartHeading), 0.);
+  const Vector3<double> start_reference_curve(start.xy().x(), start.xy().y(),
+                                              start.z().z());
+  for (int i = 0; i < kNumLanes; i++) {
+    const api::Lane* const lane = rg->junction(0)->segment(0)->lane(i);
+    // Checks Lane's ID.
+    EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
+    // Checks lane start geo position to verify that spacing is correctly
+    // applied.
+    const Vector3<double> lane_start_geo =
+        start_reference_curve +
+        (kR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        lane->ToGeoPosition({0., 0., 0.}),
+        api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
+    // Checks lane start and end BranchPoint.
+    const api::BranchPoint* const start_bp =
+        lane->GetBranchPoint(api::LaneEnd::kStart);
+    EXPECT_EQ(start_bp->GetASide()->size(), 1);
+    EXPECT_EQ(start_bp->GetASide()->get(0).lane, lane);
+    EXPECT_EQ(start_bp->GetBSide()->size(), 0);
+    const api::BranchPoint* const end_bp =
+        lane->GetBranchPoint(api::LaneEnd::kFinish);
+    EXPECT_EQ(end_bp->GetASide()->size(), 1);
+    EXPECT_EQ(end_bp->GetASide()->get(0).lane, lane);
+    EXPECT_EQ(end_bp->GetBSide()->size(), 0);
+  }
+  // Checks the number of branch points.
+  EXPECT_EQ(rg->num_branch_points(), 2 * kNumLanes);
+}
+
+// Checks that Junctions, Segments, Lanes and BranchPoints are correctly made
+// after creating the following RoadGeometry.
+// The following graph shows a flat cross connection. 'cX' is used to name the
+// connections that later are used in code. 'x' characters are used to locate
+// BranchPoints. '0', '1' and '2' mean Lane indexes. Finally, '-', '|' and '\'
+// are used to draw Lane centerlines.
+// <pre>
+//
+//                                0 1
+//                        d       x x
+//                                | | c5
+//                                | |
+//                                | |
+//                                | |
+//                                | |
+//                        e       f x
+//                              c7| |\\ c6
+//   c1                    c2     |\| \\   c3
+// 2 x--------------------x---\---|-|--\\x------------------x 1
+// 1 x--------------------x----\--|-|-\\-x------------------x 0
+// 0 a--------------------b-- \ \ | |    c
+//                         c4\ \ \| |
+//                            \ \ |\|
+//                        g     x x x
+//                              | | | c8
+//                              | | |
+//                              | | |
+//                              | | |
+//                              | | |
+//                              | | |
+//                              | | |
+//                              x x x
+//                              0 1 2
+// </pre>
+GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
+  const double kLaneWidth{4.};
+  const double kLeftShoulder{1.};
+  const double kRightShoulder{1.};
+  const api::HBounds kElevationBounds{0., 5.};
+  const double kLinearTolerance{0.01};
+  const double kAngularTolerance{0.01 * M_PI};
+  const int kTwoLanes{2};
+  const int kThreeLanes{3};
+  const EndpointZ kLowFlatZ{0., 0., 0., 0.};
+
+  const Endpoint endpoint_a{{0., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_b{{50., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_c{{70., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_d{{50., 50., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_e{{50., 14., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_f{{60., 14., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_g{{50., -6., -M_PI / 2.}, kLowFlatZ};
+
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  // Creates connections.
+  b.Connect("c1", kThreeLanes, 0, kLeftShoulder, kRightShoulder, endpoint_a,
+            50., kLowFlatZ);
+  auto c2 = b.Connect("c2", kTwoLanes, 4., kLeftShoulder, kRightShoulder,
+                      endpoint_b, 20., kLowFlatZ);
+  b.Connect("c3", kTwoLanes, 4., kLeftShoulder, kRightShoulder, endpoint_c, 30.,
+            kLowFlatZ);
+  auto c4 = b.Connect("c4", kThreeLanes, 0., kLeftShoulder, kRightShoulder,
+                      endpoint_b, ArcOffset(6., -M_PI / 2.), kLowFlatZ);
+  b.Connect("c5", kTwoLanes, 10., kLeftShoulder, kRightShoulder, endpoint_d,
+            36., kLowFlatZ);
+  auto c6 = b.Connect("c6", kTwoLanes, 0., kLeftShoulder, kRightShoulder,
+                      endpoint_f, ArcOffset(10., M_PI / 2.), kLowFlatZ);
+  auto c7 = b.Connect("c7", kTwoLanes, 10., kLeftShoulder, kRightShoulder,
+                      endpoint_e, 20., kLowFlatZ);
+  b.Connect("c8", kThreeLanes, 6., kLeftShoulder, kRightShoulder, endpoint_g,
+            44., kLowFlatZ);
+  // Creates the crossing junction.
+  std::vector<const Connection*> connections{c2, c4, c6, c7};
+  b.MakeGroup("cross", connections);
+
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{"multilane-arc-segment"});
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-arc-segment"));
+
+  // Junction ID --> Segment IDs.
+  const std::map<std::string, std::vector<std::string>> junction_truth_map{
+      {"j:c1", {"s:c1"}},
+      {"j:c3", {"s:c3"}},
+      {"j:c5", {"s:c5"}},
+      {"j:c8", {"s:c8"}},
+      {"j:cross", {"s:c2", "s:c4", "s:c6", "s:c7"}}};
+  // Segment ID --> Lane IDs.
+  const std::map<std::string, std::vector<std::string>> segment_truth_map{
+      {"s:c1", {"l:c1_0", "l:c1_1", "l:c1_2"}},
+      {"s:c2", {"l:c2_0", "l:c2_1"}},
+      {"s:c3", {"l:c3_0", "l:c3_1"}},
+      {"s:c4", {"l:c4_0", "l:c4_1", "l:c4_2"}},
+      {"s:c5", {"l:c5_0", "l:c5_1"}},
+      {"s:c6", {"l:c6_0", "l:c6_1"}},
+      {"s:c7", {"l:c7_0", "l:c7_1"}},
+      {"s:c8", {"l:c8_0", "l:c8_1", "l:c8_2"}}};
+  // Lane ID --> {Start_A_Side_Lane_IDs, Start_B_Side_Lane_IDs,
+  //              Finish_A_Side_Lane_IDs, Finish_B_Side_Lane_IDs}.
+  const std::map<std::string, BranchPointLaneIds> lane_truth_map{
+      {"l:c1_0", {{"l:c1_0"}, {}, {"l:c4_0"}, {"l:c1_0"}}},
+      {"l:c1_1", {{"l:c1_1"}, {}, {"l:c2_0", "l:c4_1"}, {"l:c1_1"}}},
+      {"l:c1_2", {{"l:c1_2"}, {}, {"l:c2_1", "l:c4_2"}, {"l:c1_2"}}},
+      {"l:c2_0",
+       {{"l:c2_0", "l:c4_1"}, {"l:c1_1"}, {"l:c2_0", "l:c6_0"}, {"l:c3_0"}}},
+      {"l:c2_1",
+       {{"l:c2_1", "l:c4_2"}, {"l:c1_2"}, {"l:c2_1", "l:c6_1"}, {"l:c3_1"}}},
+      {"l:c3_0", {{"l:c2_0", "l:c6_0"}, {"l:c3_0"}, {"l:c3_0"}, {}}},
+      {"l:c3_1", {{"l:c2_1", "l:c6_1"}, {"l:c3_1"}, {"l:c3_1"}, {}}},
+      {"l:c4_0", {{"l:c4_0"}, {"l:c1_0"}, {"l:c4_0"}, {"l:c8_0"}}},
+      {"l:c4_1",
+       {{"l:c2_0", "l:c4_1"}, {"l:c1_1"}, {"l:c4_1", "l:c7_0"}, {"l:c8_1"}}},
+      {"l:c4_2",
+       {{"l:c2_1", "l:c4_2"}, {"l:c1_2"}, {"l:c4_2", "l:c7_1"}, {"l:c8_2"}}},
+      {"l:c5_0", {{"l:c5_0"}, {}, {"l:c6_0", "l:c7_0"}, {"l:c5_0"}}},
+      {"l:c5_1", {{"l:c5_1"}, {}, {"l:c6_1", "l:c7_1"}, {"l:c5_1"}}},
+      {"l:c6_0",
+       {{"l:c6_0", "l:c7_0"}, {"l:c5_0"}, {"l:c2_0", "l:c6_0"}, {"l:c3_0"}}},
+      {"l:c6_1",
+       {{"l:c6_1", "l:c7_1"}, {"l:c5_1"}, {"l:c2_1", "l:c6_1"}, {"l:c3_1"}}},
+      {"l:c7_0",
+       {{"l:c6_0", "l:c7_0"}, {"l:c5_0"}, {"l:c4_1", "l:c7_0"}, {"l:c8_1"}}},
+      {"l:c7_1",
+       {{"l:c6_1", "l:c7_1"}, {"l:c5_1"}, {"l:c4_2", "l:c7_1"}, {"l:c8_2"}}},
+      {"l:c8_0", {{"l:c4_0"}, {"l:c8_0"}, {"l:c8_0"}, {}}},
+      {"l:c8_1", {{"l:c4_1", "l:c7_0"}, {"l:c8_1"}, {"l:c8_1"}, {}}},
+      {"l:c8_2", {{"l:c4_2", "l:c7_1"}, {"l:c8_2"}, {"l:c8_2"}, {}}}};
+
+  EXPECT_EQ(rg->num_junctions(), junction_truth_map.size());
+  for (int i = 0; i < rg->num_junctions(); i++) {
+    // Checks each Junction.
+    const api::Junction* const junction = rg->junction(i);
+    EXPECT_NE(junction_truth_map.find(junction->id().string()),
+              junction_truth_map.end());
+    const std::vector<std::string>& segment_ids =
+        junction_truth_map.at(junction->id().string());
+    EXPECT_EQ(segment_ids.size(), junction->num_segments());
+    for (int j = 0; j < junction->num_segments(); j++) {
+      // Checks each Segment.
+      const api::Segment* const segment = junction->segment(j);
+      EXPECT_EQ(segment->id().string(), segment_ids[j]);
+      EXPECT_NE(segment_truth_map.find(segment->id().string()),
+                segment_truth_map.end());
+      const std::vector<std::string>& lane_ids =
+          segment_truth_map.at(segment->id().string());
+      EXPECT_EQ(segment->num_lanes(), lane_ids.size());
+      for (int k = 0; k < segment->num_lanes(); k++) {
+        // Checks each Lane.
+        const api::Lane* const lane = segment->lane(k);
+        EXPECT_NE(lane_truth_map.find(lane->id().string()),
+                  lane_truth_map.end());
+        const BranchPointLaneIds& bp_lane_ids =
+            lane_truth_map.at(lane->id().string());
+        const api::BranchPoint* const start_bp =
+            lane->GetBranchPoint(api::LaneEnd::kStart);
+        EXPECT_EQ(start_bp->GetASide()->size(),
+                  bp_lane_ids.start_a_side.size());
+        for (int lane_index = 0; lane_index < start_bp->GetASide()->size();
+             lane_index++) {
+          EXPECT_EQ(start_bp->GetASide()->get(lane_index).lane->id().string(),
+                    bp_lane_ids.start_a_side[lane_index]);
+        }
+        EXPECT_EQ(start_bp->GetBSide()->size(),
+                  bp_lane_ids.start_b_side.size());
+        for (int lane_index = 0; lane_index < start_bp->GetBSide()->size();
+             lane_index++) {
+          EXPECT_EQ(start_bp->GetBSide()->get(lane_index).lane->id().string(),
+                    bp_lane_ids.start_b_side[lane_index]);
+        }
+        const api::BranchPoint* const end_bp =
+            lane->GetBranchPoint(api::LaneEnd::kFinish);
+        EXPECT_EQ(end_bp->GetASide()->size(), bp_lane_ids.finish_a_side.size());
+        for (int lane_index = 0; lane_index < end_bp->GetASide()->size();
+             lane_index++) {
+          EXPECT_EQ(end_bp->GetASide()->get(lane_index).lane->id().string(),
+                    bp_lane_ids.finish_a_side[lane_index]);
+        }
+        EXPECT_EQ(end_bp->GetBSide()->size(), bp_lane_ids.finish_b_side.size());
+        for (int lane_index = 0; lane_index < end_bp->GetBSide()->size();
+             lane_index++) {
+          EXPECT_EQ(end_bp->GetBSide()->get(lane_index).lane->id().string(),
+                    bp_lane_ids.finish_b_side[lane_index]);
+        }
+      }
+    }
+  }
+  EXPECT_EQ(rg->num_branch_points(), 20);
+}
 
 }  // namespace multilane
 }  // namespace maliput


### PR DESCRIPTION
This PR provides support to `multilane::Builder` to to create multi-lane segments in the context of #4934.

`multilane::Connections` were modified to accept new parameters that better describe Segment's requirements. Those are needed by the `multilane::Builder` to compute the asphalt extents as well as lanes and its lateral offset (lane's _r0_). New parameters are:

-  `num_lanes`: the number of lanes.
- `r0`: distance from the reference curve to first lane centerline.
- `left_shoulder` and `right_shoulder`: extra lateral space at the sides of the lanes.

`multilane::Builder` will create Lanes with the same `lane_width` width, their centerlines will be centered and centerlines distance between each other will be `lane_width` too. Aside from lanes, also new `multilane::BranchPoints` should be created to correctly start and end each lane. No change is needed on `multilane::BranchPoints` though.

YAML format changes will come in a subsequent PR once `multilane::Builder` code is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7171)
<!-- Reviewable:end -->
