### PR TITLE
In WORKSPACE macros, treat empty checksum as None

### DIFF
--- a/tools/bitbucket.bzl
+++ b/tools/bitbucket.bzl
@@ -32,7 +32,7 @@ def bitbucket_archive(
         fail("Missing repository=")
     if commit == None:
         fail("Missing commit=")
-    if sha256 == None:
+    if sha256 == None or len(sha256) == 0:
         # This is mostly-required, but we fallback to a wrong-default value to
         # allow the first attempt to fail and print the correct sha256.
         sha256 = "0" * 64

--- a/tools/github.bzl
+++ b/tools/github.bzl
@@ -33,7 +33,7 @@ def github_archive(
         fail("Missing repository=")
     if commit == None:
         fail("Missing commit=")
-    if sha256 == None:
+    if sha256 == None or len(sha256) == 0:
         # This is mostly-required, but we fallback to a wrong-default value to
         # allow the first attempt to fail and print the correct sha256.
         sha256 = "0" * 64


### PR DESCRIPTION
This means that there is no facility to turn off integrity verification (a good thing) and reduces user confusion in case they tried to use the empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7181)
<!-- Reviewable:end -->
