### PR TITLE
Install matlab_rpc protobuf generated header

### DIFF
--- a/drake/BUILD
+++ b/drake/BUILD
@@ -68,6 +68,7 @@ _LIBDRAKE_COMPONENTS = [
     "//drake/common:sorted_vectors_have_intersection",
     "//drake/common:symbolic",
     "//drake/common:text_logging_gflags",
+    "//drake/common/proto:matlab_rpc",
     "//drake/common/proto:protobuf",
     "//drake/common/trajectories:piecewise_function",
     "//drake/common/trajectories:piecewise_polynomial",

--- a/drake/common/proto/BUILD
+++ b/drake/common/proto/BUILD
@@ -13,7 +13,6 @@ package(default_visibility = ["//visibility:public"])
 
 cc_proto_library(
     name = "matlab_rpc",
-    testonly = 1,
     srcs = [
         "matlab_rpc.proto",
     ],

--- a/tools/install/protobuf/BUILD
+++ b/tools/install/protobuf/BUILD
@@ -25,7 +25,8 @@ install_cmake_config(package = "protobuf")  # Creates :install_cmake_config
 #   `find . -type f | sort > header.list`
 # The resulting two lists of files can be compared with `diff` and updated to
 # contain the path of the headers in the source directory by prepending
-# src/google/protobuf/ to the header file paths.
+# src/google/protobuf/ to the header file paths. However, be sure not to
+# exclude operating-system-specific headers.
 excluded_headers = [
     "src/google/protobuf/compiler/cpp/cpp_enum_field.h",
     "src/google/protobuf/compiler/cpp/cpp_enum.h",
@@ -119,7 +120,6 @@ excluded_headers = [
     "src/google/protobuf/map_test_util_impl.h",
     "src/google/protobuf/package_info.h",
     "src/google/protobuf/reflection_internal.h",
-    "src/google/protobuf/stubs/atomicops_internals_macosx.h",
     "src/google/protobuf/stubs/atomicops_internals_pnacl.h",
     "src/google/protobuf/stubs/int128.h",
     "src/google/protobuf/stubs/map_util.h",


### PR DESCRIPTION
Toward using the `libdrake.so` for the MATLAB bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7182)
<!-- Reviewable:end -->
