### PR TITLE
Fix segmentation fault in region_of_attraction.cc

### DIFF
--- a/drake/examples/cubic_polynomial/region_of_attraction.cc
+++ b/drake/examples/cubic_polynomial/region_of_attraction.cc
@@ -73,7 +73,7 @@ void ComputeRegionOfAttraction() {
   // Maximize ρ s.t. V̇ ≥ 0 ∧ x ≠ 0 ⇒ V ≥ ρ,
   // implemented as (V(x) - ρ)x² - λ(x)V̇(x) is SOS;
   //                 λ(x) is SOS.
-  const Variable& rho{prog.NewContinuousVariables<1>("rho").coeff(0)};
+  const Variable rho{prog.NewContinuousVariables<1>("rho").coeff(0)};
   const Polynomial rho_poly{rho, {} /* no indeterminate */};
 
   const Polynomial lambda{prog.NewSosPolynomial({x}, 4).first};


### PR DESCRIPTION
Reproducible in macOS by running:

bazel test //drake/examples/cubic_polynomial:region_of_attraction_test --config everything

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7188)
<!-- Reviewable:end -->
