### PR TITLE
Reimplement hash functions used in maliput's GenerateObj

### DIFF
--- a/drake/automotive/maliput/utility/BUILD
+++ b/drake/automotive/maliput/utility/BUILD
@@ -23,6 +23,7 @@ drake_cc_library(
     ],
     deps = [
         "//drake/automotive/maliput/api",
+        "//drake/common:hash",
         "//drake/math:geometric_transform",
         "@fmt",
     ],

--- a/drake/automotive/maliput/utility/generate_obj.cc
+++ b/drake/automotive/maliput/utility/generate_obj.cc
@@ -18,6 +18,7 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/hash.h"
 
 namespace drake {
 namespace maliput {
@@ -70,10 +71,10 @@ class GeoVertex {
   // A hasher operation suitable for std::unordered_map.
   struct Hash {
     size_t operator()(const GeoVertex& gv) const {
-      const size_t hx(std::hash<double>()(gv.v().x()));
-      const size_t hy(std::hash<double>()(gv.v().y()));
-      const size_t hz(std::hash<double>()(gv.v().z()));
-      return hx ^ (hy << 1) ^ (hz << 2);
+      return hash_combine(0,
+                          gv.v().x(),
+                          gv.v().y(),
+                          gv.v().z());
     }
   };
 
@@ -101,10 +102,10 @@ class GeoNormal {
   // A hasher operation suitable for std::unordered_map.
   struct Hash {
     size_t operator()(const GeoNormal& gn) const {
-      const size_t hx(std::hash<double>()(gn.n().x()));
-      const size_t hy(std::hash<double>()(gn.n().y()));
-      const size_t hz(std::hash<double>()(gn.n().z()));
-      return hx ^ (hy << 1) ^ (hz << 2);
+      return hash_combine(0,
+                          gn.n().x(),
+                          gn.n().y(),
+                          gn.n().z());
     }
   };
 


### PR DESCRIPTION
As a demonstration of the power and wisdom in the style-guide amendment
proposed in #6937, the lousy "something I found on the internet" composite
hash functions for GeoVertex and GeoNormal have been rewritten using the
machinery provided by `common/hash.h`.

The hashers have not been named `std::hash` here because they are only
intended to be used specifically for the indexing of vertices and normals
being assembled into an OBJ file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7190)
<!-- Reviewable:end -->
