### PR TITLE
Fix beam model

### DIFF
--- a/drake/systems/sensors/BUILD
+++ b/drake/systems/sensors/BUILD
@@ -17,10 +17,53 @@ drake_cc_library(
     hdrs = [],
     deps = [
         ":accelerometer",
+        ":beam_model",
         ":camera_info",
         ":depth_sensor",
         ":rgbd_camera",
         ":rotary_encoders",
+    ],
+)
+
+drake_cc_library(
+    name = "accelerometer",
+    srcs = [
+        "accelerometer.cc",
+        "accelerometer_output.cc",
+    ],
+    hdrs = [
+        "accelerometer.h",
+        "accelerometer_output.h",
+    ],
+    deps = [
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/rigid_body_plant",
+        "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "beam_model_params",
+    srcs = [
+        "gen/beam_model_params.cc",
+    ],
+    hdrs = [
+        "gen/beam_model_params.h",
+    ],
+    deps = [
+        "//drake/systems/framework:vector",
+    ],
+)
+
+drake_cc_library(
+    name = "beam_model",
+    srcs = ["beam_model.cc"],
+    hdrs = ["beam_model.h"],
+    deps = [
+        ":beam_model_params",
+        ":depth_sensor",
+        "//drake/common:unused",
+        "//drake/systems/framework",
     ],
 )
 
@@ -64,33 +107,6 @@ drake_cc_library(
         "//drake/systems/framework",
         "@lcmtypes_robotlocomotion",
         "@zlib",
-    ],
-)
-
-drake_cc_library(
-    name = "rotary_encoders",
-    srcs = ["rotary_encoders.cc"],
-    hdrs = ["rotary_encoders.h"],
-    deps = [
-        "//drake/common:unused",
-        "//drake/systems/framework",
-    ],
-)
-
-drake_cc_library(
-    name = "accelerometer",
-    srcs = [
-        "accelerometer.cc",
-        "accelerometer_output.cc",
-    ],
-    hdrs = [
-        "accelerometer.h",
-        "accelerometer_output.h",
-    ],
-    deps = [
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/systems/framework",
     ],
 )
 
@@ -209,6 +225,16 @@ drake_cc_binary(
 )
 
 drake_cc_library(
+    name = "rotary_encoders",
+    srcs = ["rotary_encoders.cc"],
+    hdrs = ["rotary_encoders.h"],
+    deps = [
+        "//drake/common:unused",
+        "//drake/systems/framework",
+    ],
+)
+
+drake_cc_library(
     name = "accelerometer_example_diagram",
     testonly = 1,
     srcs = [
@@ -256,31 +282,6 @@ drake_cc_binary(
 # === test/ ===
 
 drake_cc_googletest(
-    name = "camera_info_test",
-    deps = [
-        ":camera_info",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-    ],
-)
-
-drake_cc_googletest(
-    name = "image_test",
-    deps = [
-        ":image",
-    ],
-)
-
-drake_cc_googletest(
-    name = "rotary_encoders_test",
-    deps = [
-        ":rotary_encoders",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:symbolic_test_util",
-        "//drake/systems/framework/test_utilities",
-    ],
-)
-
-drake_cc_googletest(
     name = "accelerometer_test",
     srcs = [
         "test/accelerometer_test/accelerometer_test.cc",
@@ -294,6 +295,33 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/lcm:mock",
         "//drake/systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "beam_model_test",
+    deps = [
+        ":beam_model",
+        "//drake/common/proto:call_matlab",
+        "//drake/systems/analysis:simulator",
+        "//drake/systems/primitives:constant_vector_source",
+        "//drake/systems/primitives:random_source",
+        "//drake/systems/primitives:signal_logger",
+    ],
+)
+
+drake_cc_googletest(
+    name = "camera_info_test",
+    deps = [
+        ":camera_info",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "image_test",
+    deps = [
+        ":image",
     ],
 )
 
@@ -378,6 +406,16 @@ sh_test(
         ":test_models",
     ],
     tags = ["manual"],
+)
+
+drake_cc_googletest(
+    name = "rotary_encoders_test",
+    deps = [
+        ":rotary_encoders",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/common/test_utilities:symbolic_test_util",
+        "//drake/systems/framework/test_utilities",
+    ],
 )
 
 drake_cc_googletest(

--- a/drake/systems/sensors/beam_model.cc
+++ b/drake/systems/sensors/beam_model.cc
@@ -1,0 +1,116 @@
+#include "drake/systems/sensors/beam_model.h"
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+template <typename T>
+BeamModel<T>::BeamModel(int num_depth_readings, double max_range)
+    : max_range_(max_range) {
+  DRAKE_DEMAND(num_depth_readings > 0);
+  DRAKE_DEMAND(max_range >= 0.0);
+  // Declare depth input port.
+  this->DeclareInputPort(kVectorValued, num_depth_readings);
+  // Declare "event" random input port.
+  this->DeclareInputPort(kVectorValued, num_depth_readings,
+                         RandomDistribution::kUniform);
+  // Declare "hit" random input port.
+  this->DeclareInputPort(kVectorValued, num_depth_readings,
+                         RandomDistribution::kGaussian);
+  // Declare "short" random input port.
+  this->DeclareInputPort(kVectorValued, num_depth_readings,
+                         RandomDistribution::kExponential);
+  // Declare "uniform" random input port.
+  this->DeclareInputPort(kVectorValued, num_depth_readings,
+                         RandomDistribution::kUniform);
+  // Declare measurement output port.
+  this->DeclareVectorOutputPort(BasicVector<T>(num_depth_readings),
+                                &BeamModel<T>::CalcOutput);
+
+  this->DeclareNumericParameter(BeamModelParams<T>());
+
+  // Add a constraint that the "event" probabilities in BeamModelParams sum to
+  // one.   Since probability_hit() is defined implicitly, this becomes the
+  // inequality constraint:
+  //   1 - probability_short() - probability_miss() - probability_uniform() ≥ 0.
+  typename SystemConstraint<T>::CalcCallback
+      calc_event_probabilities_constraint =
+          [](const Context<T>& context, VectorX<T>* value) {
+            const auto* params = dynamic_cast<const BeamModelParams<T>*>(
+                context.get_numeric_parameter(0));
+            DRAKE_DEMAND(params != nullptr);
+            (*value)[0] = 1.0 - params->probability_short() -
+                          params->probability_miss() -
+                          params->probability_uniform();
+          };
+  this->AddConstraint(std::make_unique<SystemConstraint<T>>(
+      calc_event_probabilities_constraint, 1, SystemConstraintType::kInequality,
+      "event probabilities sum to one"));
+}
+
+template <typename T>
+BeamModel<T>::BeamModel(const DepthSensorSpecification& specification)
+    : BeamModel(specification.num_depth_readings(), specification.max_range()) {
+}
+
+template <typename T>
+BeamModelParams<T>* BeamModel<T>::get_mutable_parameters(
+    Context<T>* context) const {
+  return this->template GetMutableNumericParameter<BeamModelParams>(context, 0);
+}
+
+template <typename T>
+void BeamModel<T>::CalcOutput(const systems::Context<T>& context,
+                              BasicVector<T>* output) const {
+  const auto params =
+      dynamic_cast<const BeamModelParams<T>*>(context.get_numeric_parameter(0));
+  DRAKE_DEMAND(params != nullptr);
+  const auto& depth = this->EvalEigenVectorInput(context, 0);
+  const auto& w_event = this->EvalEigenVectorInput(context, 1);
+  const auto& w_hit = this->EvalEigenVectorInput(context, 2);
+  const auto& w_short = this->EvalEigenVectorInput(context, 3);
+  const auto& w_uniform = this->EvalEigenVectorInput(context, 4);
+
+  auto measurement = output->get_mutable_value();
+
+  // Loop through depth inputs and compute a noisy measurement based on the
+  // mixture model.
+  for (int i = 0; i < static_cast<int>(depth.size()); i++) {
+    if (w_event[i] <= params->probability_uniform()) {
+      // Then "uniform".
+      measurement[i] = max_range_ * w_uniform[i];
+    } else if (w_event[i] <=
+               params->probability_uniform() + params->probability_miss()) {
+      // Then "miss".
+      measurement[i] = max_range_;
+    } else if (w_event[i] <= params->probability_uniform() +
+                                 params->probability_miss() +
+                                 params->probability_short() &&
+        (w_short[i] / params->lambda_short()) <= depth[i]) {
+      // Then "short".
+      // Note: Returns that would have been greater than depth[i] are instead
+      // evaluated as "hit".
+      measurement[i] = w_short[i] / params->lambda_short();
+    } else {
+      // Then "hit".
+      // Note: The tails of the Gaussian distribution are truncated to return
+      // a value in [0, max_range_].  (Both) tails of the distribution are
+      // treated as missed returns, so return max_range_.
+      measurement[i] = depth[i] + params->sigma_hit() * w_hit[i];
+      if (measurement[i] < 0.0 || measurement[i] > max_range_) {
+        measurement[i] = max_range_;
+      }
+    }
+  }
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::systems::sensors::BeamModel)

--- a/drake/systems/sensors/beam_model.h
+++ b/drake/systems/sensors/beam_model.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/sensors/depth_sensor_specification.h"
+#include "drake/systems/sensors/gen/beam_model_params.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// Implements the "Beam Models of Range Finders" from section 6.3 of
+///   Probabilistic Robotics (2006), by Thrun, Burgard, and Fox
+///
+/// This system takes a depth measurement signal as input, and outputs a noisy
+/// measurement version of that signal, with some probability of returning the
+/// true measurement with Gaussian noise, but also with some probability of
+/// occlusions (short returns), of missed detections (returning the max depth),
+/// and of returning just a (uniform) random measurement.
+///
+/// Four additional input ports (each of the same dimension as the depth signal)
+/// are provided for the random inputs:  One for determining which of the events
+/// occurred (true + noise, short return, max return, or uniform return), and
+/// one
+/// each for modeling the distribution of short true but noisy returns, short
+/// returns, and uniform returns).
+///
+/// We deviate from the textbook model in one respect: both here and in the
+/// textbook, the distribution over short returns and the distribution over
+/// getting a noisy version of the true return (aka a "hit") are truncated.  The
+/// short returns are from an exponential distribution but truncated to be less
+/// than the input depth, and "hits" are drawn from a Gaussian centered at the
+/// input depth but truncated at the maximum range of the sensor.  In the book,
+/// these distributions are normalized so that the total probability of getting
+/// a short return and/or hit stays constant (independent of the input depth).
+/// Here we do not normalize, so that the probability of getting a short return
+/// decreases as the input depth is smaller (there is a modeled obstacle closer
+/// to the robot), and the tails of the "hit" distribution simply cause more max
+/// returns as the input depth gets closer to the max range.  This was done both
+/// because it is arguably a better model and because it keeps the code much
+/// simpler (to allow AutoDiff and Symbolic) given the modeling framework we
+/// have here that builds the output out of simple (non-truncated) random
+/// variable inputs.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+///
+/// @ingroup sensor_systems
+// TODO(russt): Add support for symbolic.
+template <typename T>
+class BeamModel final : public LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BeamModel)
+
+  BeamModel(int num_depth_readings, double max_range);
+
+  explicit BeamModel(const DepthSensorSpecification& specification);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit BeamModel(const BeamModel<U>&);
+
+  const InputPortDescriptor<T>& get_depth_input_port() const {
+    return this->get_input_port(0);
+  }
+  const InputPortDescriptor<T>& get_event_random_input_port() const {
+    return this->get_input_port(1);
+  }
+  const InputPortDescriptor<T>& get_hit_random_input_port() const {
+    return this->get_input_port(2);
+  }
+  const InputPortDescriptor<T>& get_short_random_input_port() const {
+    return this->get_input_port(3);
+  }
+  const InputPortDescriptor<T>& get_uniform_random_input_port() const {
+    return this->get_input_port(4);
+  }
+
+  BeamModelParams<T>* get_mutable_parameters(Context<T>* context) const;
+
+  double max_range() const { return max_range_; }
+
+ private:
+  void CalcOutput(const Context<T>& context, BasicVector<T>* output) const;
+
+  const double max_range_{1.0};
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/beam_model_gen.sh
+++ b/drake/systems/sensors/beam_model_gen.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Generates the source files for the BeamModelParams vector.
+
+me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')
+mydir=$(dirname "$me")
+systems=$(dirname "$mydir")
+drake=$(dirname "$systems")
+
+namespace="drake::systems::sensors"
+
+source $drake/tools/lcm_vector_gen.sh
+
+gen_vector_proto "beam model params" $mydir/beam_model_params.named_vector

--- a/drake/systems/sensors/beam_model_params.named_vector
+++ b/drake/systems/sensors/beam_model_params.named_vector
@@ -1,0 +1,40 @@
+
+element {
+    name: "lambda_short"
+    doc: "The rate parameter of the (truncated) exponential distribution governing short returns"
+    doc_units: "dimensionless"
+    default_value: "1.0"
+    min_value: "0.0"
+}
+element {
+    name: "sigma_hit"
+    doc: "The standard deviation of the (truncated) Gaussian distribution governing the noisy returns of the true depth (aka hit)"
+    doc_units: "m"
+    default_value: "0.0"
+    min_value: "0.0"
+}
+element {
+    name: "probability_short"
+    doc: "The total probability of getting a short return is probability_short * p(lambda_short*w_short <= input_depth)"
+    doc_units: "dimensionless"
+    default_value: "0.0"
+    min_value: "0.0"
+    max_value: "1.0"
+}
+element {
+    name: "probability_miss"
+    doc: "The probability of ignoring the input depth and simply returning the max range of the sensor"
+    doc_units: "dimensionless"
+    default_value: "0.0"
+    min_value: "0.0"
+    max_value: "1.0"
+}
+element {
+    name: "probability_uniform"
+    doc: "The probability of ignoring the input depth and simple returning a uniform random value between 0 and the max range of the sensor"
+    doc_units: "dimensionless"
+    default_value: "0.0"
+    min_value: "0.0"
+    max_value: "1.0"
+}
+

--- a/drake/systems/sensors/depth_sensor_specification.cc
+++ b/drake/systems/sensors/depth_sensor_specification.cc
@@ -66,11 +66,11 @@ void DepthSensorSpecification::set_max_pitch(double max_pitch) {
   max_pitch_ = max_pitch;
 }
 
-void DepthSensorSpecification::set_num_yaw_values(double num_yaw_values) {
+void DepthSensorSpecification::set_num_yaw_values(int num_yaw_values) {
   num_yaw_values_ = num_yaw_values;
 }
 
-void DepthSensorSpecification::set_num_pitch_values(double num_pitch_values) {
+void DepthSensorSpecification::set_num_pitch_values(int num_pitch_values) {
   num_pitch_values_ = num_pitch_values;
 }
 

--- a/drake/systems/sensors/depth_sensor_specification.h
+++ b/drake/systems/sensors/depth_sensor_specification.h
@@ -83,8 +83,8 @@ class DepthSensorSpecification {
   void set_max_yaw(double max_yaw);
   void set_min_pitch(double min_pitch);
   void set_max_pitch(double max_pitch);
-  void set_num_yaw_values(double num_yaw_values);
-  void set_num_pitch_values(double num_yaw_values);
+  void set_num_yaw_values(int num_yaw_values);
+  void set_num_pitch_values(int num_pitch_values);
   void set_min_range(double min_range);
   void set_max_range(double max_range);
 

--- a/drake/systems/sensors/gen/beam_model_params.cc
+++ b/drake/systems/sensors/gen/beam_model_params.cc
@@ -1,0 +1,28 @@
+#include "drake/systems/sensors/gen/beam_model_params.h"
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+const int BeamModelParamsIndices::kNumCoordinates;
+const int BeamModelParamsIndices::kLambdaShort;
+const int BeamModelParamsIndices::kSigmaHit;
+const int BeamModelParamsIndices::kProbabilityShort;
+const int BeamModelParamsIndices::kProbabilityMiss;
+const int BeamModelParamsIndices::kProbabilityUniform;
+
+const std::vector<std::string>& BeamModelParamsIndices::GetCoordinateNames() {
+  static const never_destroyed<std::vector<std::string>> coordinates(
+      std::vector<std::string>{
+          "lambda_short", "sigma_hit", "probability_short", "probability_miss",
+          "probability_uniform",
+      });
+  return coordinates.access();
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/gen/beam_model_params.h
+++ b/drake/systems/sensors/gen/beam_model_params.h
@@ -1,0 +1,153 @@
+#pragma once
+
+// GENERATED FILE DO NOT EDIT
+// See drake/tools/lcm_vector_gen.py.
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+#include "drake/common/never_destroyed.h"
+#include "drake/systems/framework/basic_vector.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// Describes the row indices of a BeamModelParams.
+struct BeamModelParamsIndices {
+  /// The total number of rows (coordinates).
+  static const int kNumCoordinates = 5;
+
+  // The index of each individual coordinate.
+  static const int kLambdaShort = 0;
+  static const int kSigmaHit = 1;
+  static const int kProbabilityShort = 2;
+  static const int kProbabilityMiss = 3;
+  static const int kProbabilityUniform = 4;
+
+  /// Returns a vector containing the names of each coordinate within this
+  /// class. The indices within the returned vector matches that of this class.
+  /// In other words, `BeamModelParamsIndices::GetCoordinateNames()[i]`
+  /// is the name for `BasicVector::GetAtIndex(i)`.
+  static const std::vector<std::string>& GetCoordinateNames();
+};
+
+/// Specializes BasicVector with specific getters and setters.
+template <typename T>
+class BeamModelParams : public systems::BasicVector<T> {
+ public:
+  /// An abbreviation for our row index constants.
+  typedef BeamModelParamsIndices K;
+
+  /// Default constructor.  Sets all rows to their default value:
+  /// @arg @c lambda_short defaults to 1.0 dimensionless.
+  /// @arg @c sigma_hit defaults to 0.0 m.
+  /// @arg @c probability_short defaults to 0.0 dimensionless.
+  /// @arg @c probability_miss defaults to 0.0 dimensionless.
+  /// @arg @c probability_uniform defaults to 0.0 dimensionless.
+  BeamModelParams() : systems::BasicVector<T>(K::kNumCoordinates) {
+    this->set_lambda_short(1.0);
+    this->set_sigma_hit(0.0);
+    this->set_probability_short(0.0);
+    this->set_probability_miss(0.0);
+    this->set_probability_uniform(0.0);
+  }
+
+  BeamModelParams<T>* DoClone() const override { return new BeamModelParams; }
+
+  /// @name Getters and Setters
+  //@{
+  /// The rate parameter of the (truncated) exponential distribution governing
+  /// short returns
+  /// @note @c lambda_short is expressed in units of dimensionless.
+  /// @note @c lambda_short has a limited domain of [0.0, +Inf].
+  const T& lambda_short() const { return this->GetAtIndex(K::kLambdaShort); }
+  void set_lambda_short(const T& lambda_short) {
+    this->SetAtIndex(K::kLambdaShort, lambda_short);
+  }
+  /// The standard deviation of the (truncated) Gaussian distribution governing
+  /// the noisy returns of the true depth (aka hit)
+  /// @note @c sigma_hit is expressed in units of m.
+  /// @note @c sigma_hit has a limited domain of [0.0, +Inf].
+  const T& sigma_hit() const { return this->GetAtIndex(K::kSigmaHit); }
+  void set_sigma_hit(const T& sigma_hit) {
+    this->SetAtIndex(K::kSigmaHit, sigma_hit);
+  }
+  /// The total probability of getting a short return is probability_short *
+  /// p(lambda_short*w_short <= input_depth)
+  /// @note @c probability_short is expressed in units of dimensionless.
+  /// @note @c probability_short has a limited domain of [0.0, 1.0].
+  const T& probability_short() const {
+    return this->GetAtIndex(K::kProbabilityShort);
+  }
+  void set_probability_short(const T& probability_short) {
+    this->SetAtIndex(K::kProbabilityShort, probability_short);
+  }
+  /// The probability of ignoring the input depth and simply returning the max
+  /// range of the sensor
+  /// @note @c probability_miss is expressed in units of dimensionless.
+  /// @note @c probability_miss has a limited domain of [0.0, 1.0].
+  const T& probability_miss() const {
+    return this->GetAtIndex(K::kProbabilityMiss);
+  }
+  void set_probability_miss(const T& probability_miss) {
+    this->SetAtIndex(K::kProbabilityMiss, probability_miss);
+  }
+  /// The probability of ignoring the input depth and simple returning a uniform
+  /// random value between 0 and the max range of the sensor
+  /// @note @c probability_uniform is expressed in units of dimensionless.
+  /// @note @c probability_uniform has a limited domain of [0.0, 1.0].
+  const T& probability_uniform() const {
+    return this->GetAtIndex(K::kProbabilityUniform);
+  }
+  void set_probability_uniform(const T& probability_uniform) {
+    this->SetAtIndex(K::kProbabilityUniform, probability_uniform);
+  }
+  //@}
+
+  /// See BeamModelParamsIndices::GetCoordinateNames().
+  static const std::vector<std::string>& GetCoordinateNames() {
+    return BeamModelParamsIndices::GetCoordinateNames();
+  }
+
+  /// Returns whether the current values of this vector are well-formed.
+  decltype(T() < T()) IsValid() const {
+    using std::isnan;
+    auto result = (T(0) == T(0));
+    result = result && !isnan(lambda_short());
+    result = result && (lambda_short() >= T(0.0));
+    result = result && !isnan(sigma_hit());
+    result = result && (sigma_hit() >= T(0.0));
+    result = result && !isnan(probability_short());
+    result = result && (probability_short() >= T(0.0));
+    result = result && (probability_short() <= T(1.0));
+    result = result && !isnan(probability_miss());
+    result = result && (probability_miss() >= T(0.0));
+    result = result && (probability_miss() <= T(1.0));
+    result = result && !isnan(probability_uniform());
+    result = result && (probability_uniform() >= T(0.0));
+    result = result && (probability_uniform() <= T(1.0));
+    return result;
+  }
+
+  // VectorBase override.
+  void CalcInequalityConstraint(VectorX<T>* value) const override {
+    value->resize(8);
+    (*value)[0] = lambda_short() - T(0.0);
+    (*value)[1] = sigma_hit() - T(0.0);
+    (*value)[2] = probability_short() - T(0.0);
+    (*value)[3] = T(1.0) - probability_short();
+    (*value)[4] = probability_miss() - T(0.0);
+    (*value)[5] = T(1.0) - probability_miss();
+    (*value)[6] = probability_uniform() - T(0.0);
+    (*value)[7] = T(1.0) - probability_uniform();
+  }
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/beam_model_test.cc
+++ b/drake/systems/sensors/test/beam_model_test.cc
@@ -1,0 +1,200 @@
+#include "drake/systems/sensors/beam_model.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/proto/call_matlab.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/constant_vector_source.h"
+#include "drake/systems/primitives/random_source.h"
+#include "drake/systems/primitives/signal_logger.h"
+#include "drake/systems/sensors/gen/beam_model_params.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace {
+
+GTEST_TEST(BeamModelTest, TestSpecConstructor) {
+  const double kMaxRange = 5.0;
+
+  DepthSensorSpecification spec;
+  spec.set_max_range(kMaxRange);
+  spec.set_num_pitch_values(4);
+  spec.set_num_yaw_values(10);
+
+  BeamModel<double> model(spec);
+  EXPECT_EQ(model.max_range(), kMaxRange);
+  EXPECT_EQ(model.get_depth_input_port().size(), 40);
+}
+
+GTEST_TEST(BeamModelTest, TestInputPorts) {
+  const int kNumReadings = 10;
+  const double kMaxRange = 5.0;
+  BeamModel<double> model(kNumReadings, kMaxRange);
+
+  EXPECT_EQ(model.get_depth_input_port().size(), kNumReadings);
+  EXPECT_FALSE(model.get_depth_input_port().is_random());
+
+  EXPECT_EQ(model.get_event_random_input_port().size(), kNumReadings);
+  EXPECT_EQ(model.get_event_random_input_port().get_random_type().value(),
+            RandomDistribution::kUniform);
+
+  EXPECT_EQ(model.get_hit_random_input_port().size(), kNumReadings);
+  EXPECT_EQ(model.get_hit_random_input_port().get_random_type().value(),
+            RandomDistribution::kGaussian);
+
+  EXPECT_EQ(model.get_short_random_input_port().size(), kNumReadings);
+  EXPECT_EQ(model.get_short_random_input_port().get_random_type().value(),
+            RandomDistribution::kExponential);
+
+  EXPECT_EQ(model.get_uniform_random_input_port().size(), kNumReadings);
+  EXPECT_EQ(model.get_uniform_random_input_port().get_random_type().value(),
+            RandomDistribution::kUniform);
+}
+
+// Compare random samples to an analytic form of the probability density
+// function.
+GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
+  systems::DiagramBuilder<double> builder;
+
+  const double kDepthInput = 3.0;
+  const double kMaxRange = 5.0;
+  auto beam_model = builder.AddSystem<BeamModel>(1, kMaxRange);
+
+  auto constant_depth =
+      builder.AddSystem<ConstantVectorSource>(Vector1d(kDepthInput));
+  builder.Connect(constant_depth->get_output_port(),
+                  beam_model->get_depth_input_port());
+
+  auto w_event = builder.AddSystem<UniformRandomSource>(1, 0.0025);
+  builder.Connect(w_event->get_output_port(0),
+                  beam_model->get_event_random_input_port());
+
+  auto w_hit = builder.AddSystem<GaussianRandomSource>(1, 0.0025);
+  builder.Connect(w_hit->get_output_port(0),
+                  beam_model->get_hit_random_input_port());
+
+  auto w_short = builder.AddSystem<ExponentialRandomSource>(1, 0.0025);
+  builder.Connect(w_short->get_output_port(0),
+                  beam_model->get_short_random_input_port());
+
+  auto w_uniform = builder.AddSystem<UniformRandomSource>(1, 0.0025);
+  builder.Connect(w_uniform->get_output_port(0),
+                  beam_model->get_uniform_random_input_port());
+
+  // TODO(russt): Remove these when #7149 lands.
+  w_event->set_random_seed(142);
+  w_hit->set_random_seed(43);
+  w_short->set_random_seed(44);
+  w_uniform->set_random_seed(45);
+
+  auto logger = LogOutput(beam_model->get_output_port(0), &builder);
+
+  auto diagram = builder.Build();
+
+  systems::Simulator<double> simulator(*diagram);
+
+  // Zero all initial state.
+  for (int i = 0; i < simulator.get_context().get_num_discrete_state_groups();
+       i++) {
+    BasicVector<double>* state =
+        simulator.get_mutable_context()->get_mutable_discrete_state(0);
+    for (int j = 0; j < state->size(); j++) {
+      state->SetAtIndex(j, 0.0);
+    }
+  }
+
+  auto* params =
+      beam_model->get_mutable_parameters(&diagram->GetMutableSubsystemContext(
+          *beam_model, simulator.get_mutable_context()));
+
+  // Set some testable beam model parameters.
+  params->set_lambda_short(2.0);
+  params->set_sigma_hit(0.25);
+  params->set_probability_short(0.2);
+  params->set_probability_miss(0.05);
+  params->set_probability_uniform(0.05);
+
+  double probability_hit = 1.0 - params->probability_uniform() -
+                           params->probability_miss() -
+                           params->probability_short();
+  // Truncated tail of the exponential adds to "hit".
+  probability_hit += std::exp(-params->lambda_short() * kDepthInput);
+
+  auto probability_density_function = [&](double z) {
+    DRAKE_DEMAND(z >= 0.0 && z < kMaxRange);  // Doesn't capture the delta
+                                              // function (with height p_miss)
+                                              // at kMaxRange.
+    const double p_short =
+        (z <= kDepthInput)
+            ? params->lambda_short() * std::exp(-params->lambda_short() * z)
+            : 0.0;
+
+    const double sigma_sq = params->sigma_hit() * params->sigma_hit();
+    return params->probability_uniform() / kMaxRange +
+           params->probability_short() * p_short +
+           probability_hit * std::exp(-0.5 * (z - kDepthInput) *
+                                      (z - kDepthInput) / sigma_sq) /
+               std::sqrt(2 * M_PI * sigma_sq);
+  };
+
+  simulator.Initialize();
+  simulator.StepTo(50);
+
+  const auto& x = logger->data();
+
+  const int N = x.size();
+
+  // All values are in [0.0, kMaxRange]
+  EXPECT_TRUE((x.array() >= 0.0 && x.array() <= kMaxRange).all());
+
+  // Matlab visual debugging:
+  const Eigen::VectorXd depth =
+      Eigen::VectorXd::LinSpaced(1000, 0.0, kMaxRange - 1e-6);
+  Eigen::VectorXd pdf(depth.size());
+  for (int i = 0; i < static_cast<int>(depth.size()); i++) {
+    pdf[i] = probability_density_function(depth[i]);
+  }
+  using common::CallMatlab;
+  CallMatlab("clf");
+  CallMatlab("plot", depth, pdf);
+  CallMatlab("xlabel", "depth (m)");
+  CallMatlab("ylabel", "probability density");
+  CallMatlab("hold", "on");
+
+  const double h = 0.2;
+  // Evaluate all subintervals [a,a+h] in [0,kMaxRange).
+  for (double a = 0.0; a < kMaxRange; a += h) {
+    // Counts the number of samples in (a,a+h).
+    const double count = (x.array() >= a && x.array() < a + h - 1e-8)
+                             .template cast<double>()
+                             .matrix()
+                             .sum();
+
+    EXPECT_NEAR(count / N, probability_density_function(a + h / 2) * h, 1e-2);
+    CallMatlab("plot", a + h / 2, count / N / h, "r.");
+  }
+
+  // Check the max returns.
+  // Cumulative distribution function of the standard normal distribution.
+  auto Phi = [](double z) { return 0.5 * std::erfc(-z / std::sqrt(2.0)); };
+  const double p_max =
+      params->probability_miss() +
+      probability_hit *
+          Phi(-kDepthInput /
+              params->sigma_hit())  // "hit" would have returned < 0.0.
+      +
+      probability_hit *
+          Phi((kDepthInput - kMaxRange) /
+              params->sigma_hit());  // "hit" would have returned > kMaxRange.
+  EXPECT_NEAR(
+      (x.array() == kMaxRange).template cast<double>().matrix().sum() / N,
+      p_max, 2e-3);
+}
+
+}  // namespace
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/beam_model_test.cc
+++ b/drake/systems/sensors/test/beam_model_test.cc
@@ -173,7 +173,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
                              .matrix()
                              .sum();
 
-    EXPECT_NEAR(count / N, probability_density_function(a + h / 2) * h, 1e-2);
+    EXPECT_NEAR(count / N, probability_density_function(a + h / 2) * h, 1.5e-2);
     CallMatlab("plot", a + h / 2, count / N / h, "r.");
   }
 


### PR DESCRIPTION
reverts the revert of my PR on the beam model.  
The original failure was here:
https://gist.github.com/m-chaturvedi/9215c61572085767087b6a2bde78c1a5

The reverting PR was #7183 

my fix was exactly one character, with commit log:
increase tolerance for mac. this was not tripped until the build servers due to differences in the random number generators on mac and linux

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7191)
<!-- Reviewable:end -->
