### PR TITLE
Disable rotation_constraint_limit_test under asan

### DIFF
--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -839,8 +839,12 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "rotation_constraint_test",
     size = "large",
-    # Excluding because an assertion fails in LLVM code. Issue #6179.
-    tags = gurobi_test_tags() + mosek_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + mosek_test_tags() + [
+        # Excluding asan because it is unreasonably slow (> 30 minutes).
+        "no_asan",
+        # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
+        "no_tsan",
+    ],
     deps = [
         ":gurobi_solver",
         ":mathematical_program",
@@ -875,7 +879,7 @@ drake_cc_binary(
 drake_cc_googletest(
     name = "rotation_constraint_limit_test",
     size = "large",
-    # Excluding because an assertion fails in LLVM code. Issue #6179.
+    # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
     tags = gurobi_test_tags() + ["no_tsan"],
     deps = [
         ":gurobi_solver",


### PR DESCRIPTION
Disable `rotation_constraint_limit_test` under `asan` because it is unreasonably slow (> 30 minutes).  This PR currently has no effect within CI because of the CI configuration defect #7176 (this test is already always disabled under asan accidentally), but this PR ensures that it says disabled if the configuration is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7193)
<!-- Reviewable:end -->
