### PR TITLE
Sync sanitizer build flags between foosan and foosan_everything

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -263,6 +263,7 @@ build:ubsan_everything --define=WITH_MOSEK=ON
 build:ubsan_everything --define=WITH_SNOPT=ON
 build:ubsan_everything --copt -g
 build:ubsan_everything --copt -fsanitize=undefined
+build:ubsan_everything --copt -fno-sanitize=float-divide-by-zero
 build:ubsan_everything --copt -O1
 build:ubsan_everything --copt -fno-omit-frame-pointer
 build:ubsan_everything --linkopt -fsanitize=undefined

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -230,6 +230,12 @@ build:tsan_everything --copt -g
 build:tsan_everything --copt -fsanitize=thread
 build:tsan_everything --copt -O1
 build:tsan_everything --copt -fno-omit-frame-pointer
+# From Tsan documentation for Clang-3.9:
+# fsanitize=thread flag will cause Clang to act as though the -fPIE flag
+# had been supplied if compiling without -fPIC, and as though the
+# -pie flag had been supplied if linking an executable
+# Bug in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67308
+build:tsan_everything --noforce_pic
 build:tsan_everything --linkopt -fsanitize=thread
 
 test:tsan_everything --test_env=GRB_LICENSE_FILE


### PR DESCRIPTION
In prior commits, we had adjusted the sanitizers' build flags but forgot to update the "_everything" copy of those flags.  This PR re-syncs those build flags.

This wasn't caught in CI because of #7176.

This highlights the brittleness of the current `bazel.rc` configuration, but for now I'd like to fix the symptom and then refactor it later for robustness.

Relates RobotLocomotion/drake-ci#83.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7204)
<!-- Reviewable:end -->
