### PR TITLE
Decrease DrakeVisualizer load message delay window size

### DIFF
--- a/drake/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.cc
@@ -26,7 +26,6 @@ DrakeVisualizer::DrakeVisualizer(const RigidBodyTree<double>& tree,
   const int vector_size =
       tree.get_num_positions() + tree.get_num_velocities();
   DeclareInputPort(kVectorValued, vector_size);
-  this->DeclareDiscreteState(1);
   if (enable_playback) log_.reset(new SignalLog<double>(vector_size));
 }
 
@@ -37,24 +36,14 @@ void DrakeVisualizer::set_publish_period(double period) {
 void DrakeVisualizer::DoCalcNextUpdateTime(
     const Context<double>& context, CompositeEventCollection<double>* events,
     double* time) const {
-  if (is_load_message_sent(context)) {
+  // NOTE: This *might* be better placed in an Initialize() method. (Once the
+  // semantics of such an interface is defined.)
+  if (is_load_message_sent()) {
     return LeafSystem<double>::DoCalcNextUpdateTime(context, events, time);
   } else {
-    // TODO(siyuan): cleanup after #5725 is resolved.
-    *time = context.get_discrete_state(0)->GetAtIndex(0);
-    DiscreteUpdateEvent<double> event(Event<double>::TriggerType::kTimed);
-    event.add_to_composite(events);
+    PublishLoadRobot();
+    set_is_load_message_sent(true);
   }
-}
-
-void DrakeVisualizer::DoCalcDiscreteVariableUpdates(
-    const Context<double>& context,
-    const std::vector<const DiscreteUpdateEvent<double>*>&,
-    DiscreteValues<double>* discrete_state) const {
-  DRAKE_DEMAND(!is_load_message_sent(context));
-
-  PublishLoadRobot();
-  set_is_load_message_sent(discrete_state, true);
 }
 
 void DrakeVisualizer::ReplayCachedSimulation() const {
@@ -138,7 +127,7 @@ void DrakeVisualizer::PlaybackTrajectory(
 
 void DrakeVisualizer::DoPublish(const Context<double>& context,
     const std::vector<const PublishEvent<double>*>&) const {
-  if (!is_load_message_sent(context)) {
+  if (!is_load_message_sent()) {
     drake::log()->warn(
         "DrakeVisualizer::Publish() called before PublishLoadRobot()");
     return;

--- a/drake/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.cc
@@ -41,7 +41,7 @@ void DrakeVisualizer::DoCalcNextUpdateTime(
     return LeafSystem<double>::DoCalcNextUpdateTime(context, events, time);
   } else {
     // TODO(siyuan): cleanup after #5725 is resolved.
-    *time = context.get_time() + 0.0001;
+    *time = context.get_discrete_state(0)->GetAtIndex(0);
     DiscreteUpdateEvent<double> event(Event<double>::TriggerType::kTimed);
     event.add_to_composite(events);
   }

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -111,16 +111,20 @@ class DrakeVisualizer : public LeafSystem<double> {
  private:
   // Returns true if initialization phase has been completed.
   bool is_load_message_sent(const Context<double>& context) const {
-    return context.get_discrete_state(0)->GetAtIndex(0) > 0;
+    return context.get_discrete_state(0)->GetAtIndex(0) < 0;
   }
 
   // Sets the discrete state to @p flag.
   void set_is_load_message_sent(DiscreteValues<double>* state,
                                 bool flag) const {
+    // NOTE: The discrete state *is* the time at which the load robot message
+    // should be broadcast. When the message has *not* been sent, the time
+    // is set to an early point in the simulation. When it has been set, the
+    // time is negative (indicating that no further effort is required).
     if (flag)
-      state->get_mutable_vector(0)->SetAtIndex(0, 1);
+      state->get_mutable_vector(0)->SetAtIndex(0, -1);
     else
-      state->get_mutable_vector(0)->SetAtIndex(0, 0);
+      state->get_mutable_vector(0)->SetAtIndex(0, 1e-4);
   }
 
   // Set the default to "initialization phase has not been completed."


### PR DESCRIPTION
This is related to #7205.

By reducing the window for performing the *discrete* update from 1e-4 to 1e-8 the odds that the simulation would prevent the drake visualizer from successfully dispatching its load robot message are significantly reduced. (Easily reproduced by running a simulation with a fixed-step integrator and a time step of 0.99e-4 or smaller.)

This is merely extending the hack to make it more robust. Something more rigorous is probably unnecessary because 
    a) We have plans for the system which will allow better evaluation of "now" events, and
    b) This will mostly be supplanted by geometry world functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7207)
<!-- Reviewable:end -->
