### PR TITLE
Increase timeout for constraint_solver_test

### DIFF
--- a/drake/multibody/constraint/BUILD
+++ b/drake/multibody/constraint/BUILD
@@ -37,6 +37,8 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "constraint_solver_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":constraint_solver",
         "//drake/examples/rod2d",


### PR DESCRIPTION
Failing Builds: [1](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/152/) [2](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/151/) [3](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-snopt/73/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7208)
<!-- Reviewable:end -->
