### PR TITLE
Removing global_inverse_kinematics_feasible_posture_test From ASan

### DIFF
--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -114,7 +114,10 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    tags = gurobi_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + [
+        "no_asan",
+        "no_tsan",
+    ],
     deps = [
         ":global_inverse_kinematics_test_util",
     ],


### PR DESCRIPTION
[Failing Build](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-asan-everything/311/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7211)
<!-- Reviewable:end -->
