### PR TITLE
run_quadrotor_dynamics default arguments modified to prevent sim from exploding

### DIFF
--- a/drake/examples/quadrotor/BUILD
+++ b/drake/examples/quadrotor/BUILD
@@ -36,7 +36,10 @@ drake_cc_binary(
     srcs = ["run_quadrotor_dynamics.cc"],
     add_test_rule = 1,
     data = [":models"],
-    test_rule_args = ["--duration=1.0"],
+    test_rule_args = [
+        "--duration=0.1",
+        "--initial_height=0.051",
+    ],
     test_rule_size = "medium",
     deps = [
         ":quadrotor_plant",

--- a/drake/examples/quadrotor/run_quadrotor_dynamics.cc
+++ b/drake/examples/quadrotor/run_quadrotor_dynamics.cc
@@ -1,8 +1,9 @@
 /// @file
 ///
 /// This demo sets up a passive Quadrotor plant in a world described by the
-/// warehouse model. The robot simply rests on the floor within the walls
-/// of the warehouse.
+/// warehouse model. The robot simply passively falls to the floor within the
+/// walls of the warehouse, falling from the initial_height command line
+/// argument.
 
 #include <gflags/gflags.h>
 
@@ -34,7 +35,8 @@ namespace examples {
 namespace quadrotor {
 namespace {
 
-DEFINE_double(duration, 3, "Total duration of simulation.");
+DEFINE_double(duration, 0.5, "Total duration of simulation.");
+DEFINE_double(initial_height, 0.051, "Initial height of the Quadrotor.");
 
 template <typename T>
 class Quadrotor : public systems::Diagram<T> {
@@ -62,9 +64,6 @@ class Quadrotor : public systems::Diagram<T> {
     DRAKE_DEMAND(plant_->get_num_actuators() == 0);
     DRAKE_DEMAND(plant_->get_num_actuators(quadrotor_id) == 0);
 
-    VectorX<T> hover_input(plant_->get_input_size());
-    hover_input.setZero();
-
     systems::DrakeVisualizer* publisher =
         builder.template AddSystem<systems::DrakeVisualizer>(
             plant_->get_rigid_body_tree(), &lcm_);
@@ -84,10 +83,9 @@ class Quadrotor : public systems::Diagram<T> {
     x0.setZero();
     /* x0 is the initial state where
      * x0(0), x0(1), x0(2) are the quadrotor's x, y, z -states
-     * x0(3), x0(4), x0(5) are the quedrotor's Euler angles phi, theta, psi
+     * x0(3), x0(4), x0(5) are the quadrotor's Euler angles phi, theta, psi
      */
-    x0(2) = 0.2;  // Sets arbitrary z-position. This is the initial height of
-                  // the quadrotor in the world frame.
+    x0(2) = FLAGS_initial_height;  // Sets arbitrary z-position.
     plant_->set_state_vector(&plant_state, x0);
   }
 
@@ -104,9 +102,9 @@ int do_main(int argc, char* argv[]) {
 
   // Same as the nominal step size, since we're using a fixed step integrator.
   const double max_step_size = 1e-3;
-  simulator.Initialize();
   simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
       model, max_step_size, simulator.get_mutable_context());
+  simulator.Initialize();
   simulator.StepTo(FLAGS_duration);
   return 0;
 }


### PR DESCRIPTION
The run_quadrotor_dynamics was broken for a while because the fixed time step integrator lead it to behave erratically on collision (the sim is of a passive quad falling in a world by 20 cms to collide with ground). This resulting explosion of the model was only picked up by ubsan. The fix is to revert to the default variable time step integrator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7212)
<!-- Reviewable:end -->
