### PR TITLE
Adds an interface to mock the Optitrack system

### DIFF
--- a/drake/systems/sensors/BUILD.bazel
+++ b/drake/systems/sensors/BUILD.bazel
@@ -303,6 +303,27 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_library(
+    name = "optitrack_sender",
+    srcs = ["optitrack_sender.cc"],
+    hdrs = ["optitrack_sender.h"],
+    deps = [
+        ":optitrack_encoder",
+        "//drake/systems/framework:leaf_system",
+        "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
+drake_cc_library(
+    name = "optitrack_encoder",
+    srcs = ["optitrack_encoder.cc"],
+    hdrs = ["optitrack_encoder.h"],
+    deps = [
+        "//drake/systems/framework:leaf_system",
+        "//drake/systems/rendering:pose_bundle",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -468,6 +489,15 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "image_to_lcm_image_array_t_test",
     deps = [":image_to_lcm_image_array_t"],
+)
+
+drake_cc_googletest(
+    name = "optitrack_encoder_test",
+    srcs = ["test/optitrack_encoder_test.cc"],
+    deps = [
+        ":optitrack_encoder",
+        "//drake/systems/framework",
+    ],
 )
 
 add_lint_tests()

--- a/drake/systems/sensors/BUILD.bazel
+++ b/drake/systems/sensors/BUILD.bazel
@@ -500,4 +500,15 @@ drake_cc_googletest(
     ],
 )
 
+drake_cc_googletest(
+    name = "optitrack_sender_test",
+    srcs = ["test/optitrack_sender_test.cc"],
+    deps = [
+        ":optitrack_encoder",
+        ":optitrack_sender",
+        "//drake/systems/framework",
+        "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
 add_lint_tests()

--- a/drake/systems/sensors/optitrack_encoder.cc
+++ b/drake/systems/sensors/optitrack_encoder.cc
@@ -1,0 +1,113 @@
+#include "drake/systems/sensors/optitrack_encoder.h"
+
+#include <algorithm>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/systems/rendering/pose_bundle.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using systems::sensors::TrackedBody;
+using systems::rendering::PoseBundle;
+
+OptitrackEncoder::OptitrackEncoder(
+    const std::map<std::string, int>& frame_name_to_id_map,
+    std::vector<std::string> rigid_body_names,
+    double optitrack_lcm_publish_period) {
+
+  // Abstract input port of type PoseBundle.
+  pose_bundle_input_port_index_ = this->DeclareAbstractInputPort().get_index();
+
+  // Abstract output port of type vector<TrackedBody>.
+  optitrack_output_port_index_ = this->DeclareAbstractOutputPort(
+      &OptitrackEncoder::MakeOutputValue,
+      &OptitrackEncoder::CalcOutputValue).get_index();
+
+  if (!rigid_body_names.empty()
+      && (rigid_body_names.size() != frame_name_to_id_map.size())) {
+    throw std::runtime_error("OptitrackEncoder::OptitrackEncoder Error: "
+                                 "Input parameters frame_name_to_id_map and "
+                                 "rigid_body_names must have the same size.");
+  } else if (rigid_body_names.empty()) {
+    for (auto it = frame_name_to_id_map.begin();
+         it != frame_name_to_id_map.end(); ++it) {
+      rigid_body_names.push_back(it->first);
+    }
+  }
+
+  auto body_name = rigid_body_names.begin();
+  auto name_to_id = frame_name_to_id_map.begin();
+  while (name_to_id != frame_name_to_id_map.end()
+      && body_name != rigid_body_names.end()) {
+    if (!CheckIdValidity(name_to_id->second)) {
+      throw std::runtime_error("OptitrackEnc::OptitrackEnc: ERROR: "
+                                   "Found invalid Optitrack rigid body id.");
+    }
+    rigid_body_info_map_[name_to_id->first] =
+        std::make_pair(*body_name, name_to_id->second);
+    ++body_name;
+    ++name_to_id;
+  }
+
+  this->DeclarePeriodicUnrestrictedUpdate(optitrack_lcm_publish_period, 0);
+}
+
+bool OptitrackEncoder::CheckIdValidity(const int id) {
+  auto it = std::find_if(
+      rigid_body_info_map_.begin(), rigid_body_info_map_.end(),
+      [id](const std::pair<std::string, std::pair<std::string, int>>& obj) {
+        return obj.second.second == id;
+      });
+  if (it != rigid_body_info_map_.end()) {
+    return false;
+  } else {
+    return (id >= 0);
+  }
+}
+
+std::vector<TrackedBody> OptitrackEncoder::MakeOutputValue() const {
+  return std::vector<TrackedBody>{rigid_body_info_map_.size()};
+}
+
+void OptitrackEncoder::CalcOutputValue(const systems::Context<double>& context,
+                                       std::vector<TrackedBody>* output) const {
+  std::vector<TrackedBody>& optitrack_objects = *output;
+
+  // Extract the input port for the PoseBundle object, get the transformation of
+  // the bodies we care about, and fill in the optitrack_objects vector.
+  const PoseBundle<double>* pose_bundle =
+      this->EvalInputValue<PoseBundle<double>>(
+          context, pose_bundle_input_port_index_);
+
+  // Create a frame name to index map for easy indexing within the PoseBundle.
+  std::map<std::string, int> frame_name_to_index_map;
+  for (int i = 0; i < pose_bundle->get_num_poses(); i++) {
+    frame_name_to_index_map[pose_bundle->get_name(i)] = i;
+  }
+
+  DRAKE_DEMAND(optitrack_objects.size() == rigid_body_info_map_.size());
+  int optitrack_obj_index = 0;
+  for (auto it : rigid_body_info_map_) {
+    optitrack_objects[optitrack_obj_index].body_name = it.second.first;
+    optitrack_objects[optitrack_obj_index].id = it.second.second;
+    int pose_index = frame_name_to_index_map[it.first];
+    optitrack_objects[optitrack_obj_index].T_WF =
+        pose_bundle->get_pose(pose_index);
+    ++optitrack_obj_index;
+  }
+  // Sort the tracked objects by Optitrack body ID.
+  std::sort(optitrack_objects.begin(), optitrack_objects.end(),
+            [](const TrackedBody& body1, const TrackedBody& body2) {
+              return body1.id < body2.id;
+            });
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/optitrack_encoder.cc
+++ b/drake/systems/sensors/optitrack_encoder.cc
@@ -93,10 +93,10 @@ void OptitrackEncoder::CalcOutputValue(const systems::Context<double>& context,
 
   DRAKE_DEMAND(optitrack_objects.size() == rigid_body_info_map_.size());
   int optitrack_obj_index = 0;
-  for (auto it : rigid_body_info_map_) {
-    optitrack_objects[optitrack_obj_index].body_name = it.second.first;
-    optitrack_objects[optitrack_obj_index].id = it.second.second;
-    int pose_index = frame_name_to_index_map[it.first];
+  for (const auto& pair : rigid_body_info_map_) {
+    optitrack_objects[optitrack_obj_index].body_name = pair.second.first;
+    optitrack_objects[optitrack_obj_index].id = pair.second.second;
+    int pose_index = frame_name_to_index_map[pair.first];
     optitrack_objects[optitrack_obj_index].T_WF =
         pose_bundle->get_pose(pose_index);
     ++optitrack_obj_index;

--- a/drake/systems/sensors/optitrack_encoder.h
+++ b/drake/systems/sensors/optitrack_encoder.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/leaf_system.h"
+#include "drake/systems/rendering/pose_bundle.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+constexpr double kLcmStatusPeriod = 1.0 / 120.0;
+
+/**
+ * A structure used to store the attributes of a tracked rigid body. These are a
+ * subset of the complete set of attributes which the real Optitrack hardware
+ * maintains, but is typically sufficient for most applications.
+ * @param id The rigid body ID as defined in the Optitrack software
+ *        (e.g., Motive). This value must be unique and non-negative.
+ * @param body_name The name of the Optitrack rigid body that is being tracked
+ *        (not necessarily unique).
+ * @param T_WF The pose of this rigid body w.r.t. the world.
+ *
+ */
+struct TrackedBody {
+  int id{};
+  std::string body_name;
+  Eigen::Isometry3d T_WF;
+};
+
+/**
+ * Implements a class that allows a simulation to mock the basic output of the
+ * Optitrack system. This class is useful when designing systems that interface
+ * with actual Optitrack hardware, but are to be tested and vetted in
+ * simulation. It maintains a set of attributes for each tracked object that is
+ * a subset of the attributes maintained by the real hardware, but is typically
+ * sufficient for most applications. Specifically each tracked rigid body is
+ * described by its Optitrack ID, its name, and its pose w.r.t. the world. No
+ * information about markers, marker sets, etc. is stored in this class. This
+ * system has one abstract valued input port of type
+ * systems::rendering::PoseBundle<double> and one abstract valued output port of
+ * type std::vector<TrackedBody>. The output of this system can be connected to
+ * an OptitrackFrameSender system which populates an optitrack_frame_t object
+ * for publishing via LCM.
+ * Optitrack bodies are created by specifying a set of frame names to track.
+ * These frame names, provided at the time of construction, should have a match
+ * within the set of names contained in the incoming PoseBundle object. Since
+ * the incoming PoseBundle class requires frame names to be unique (when model
+ * instance IDs are the same), there is also the option to provide a custom name
+ * for each rigid body. These @p rigid_body_names need not be unique (as is the
+ * case for the actual Optitrack hardware). This is because Optitrack IDs
+ * (not names) are used to differentiate tracked rigid bodies. If no set of @p
+ * rigid_body_names are provided, the corresponding frame name
+ * from the incoming PoseBundle object is used.
+ */
+// TODO(rcory): Add support for markers and marker sets.
+class OptitrackEncoder : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackEncoder)
+  /**
+   * Constructs an OptitrackEncoder object that defines a set of Optitrack rigid
+   * bodies to track. Each rigid body is associated with a unique pose element
+   * in the incoming PoseBundle object.
+   * @param frame_name_to_id_map A mapping of frame names (contained in the
+   *        incoming PoseBundle object) to Optitrack body ID. Each ID should be
+   *        a unique non-negative integer.
+   * @param rigid_body_names A vector of user defined names for the rigid
+   *        bodies. These names do not necessarily have to match the incoming
+   *        PoseBundle frame names, and they also not need be unique. The
+   *        ordering of the names in this vector should correspond with the
+   *        ordering of @p frame_name_to_id_map. If rigid_body_names.empty()
+   *        returns true during construction, the associated frame names from
+   *        @p frame_name_to_id_map are used in the same order as they appear.
+   * @param optitrack_lcm_publish_period The update period for this system. This
+   *        should match the publish period for the LCM publisher system.
+   */
+  OptitrackEncoder(
+      const std::map<std::string, int>& frame_name_to_id_map,
+      std::vector<std::string> rigid_body_names = std::vector<std::string>(),
+      double optitrack_lcm_publish_period = kLcmStatusPeriod);
+
+  /**
+   * This InputPortDescriptor represents an abstract valued input port of type
+   * PoseBundle<double>.
+   */
+  const systems::InputPortDescriptor<double>& get_pose_bundle_input_port()
+  const {
+    return get_input_port(pose_bundle_input_port_index_);
+  }
+
+  int get_pose_bundle_input_port_index() const {
+    return pose_bundle_input_port_index_;
+  }
+
+  /**
+   * This OutputPort represents an abstract valued output port of type
+   * systems::sensors::TrackedBody.
+   */
+  const systems::OutputPort<double>& get_optitrack_output_port() const {
+    return get_output_port(optitrack_output_port_index_);
+  }
+
+  int get_optitrack_output_port_index() const {
+    return optitrack_output_port_index_;
+  }
+
+ private:
+  // Checks whether the Optitrack ID is valid, i.e., is non-negative and unique.
+  bool CheckIdValidity(const int id);
+
+  std::vector<TrackedBody> MakeOutputValue() const;
+
+  void CalcOutputValue(const systems::Context<double>& context,
+                       std::vector<TrackedBody>* output) const;
+
+  int pose_bundle_input_port_index_{-1};
+  int optitrack_output_port_index_{-1};
+  std::map<std::string, std::pair<std::string, int>> rigid_body_info_map_;
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/optitrack_sender.cc
+++ b/drake/systems/sensors/optitrack_sender.cc
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "external/optitrack_driver/lcmtypes/optitrack/optitrack_rigid_body_t.hpp"
+#include "optitrack/optitrack_frame_t.hpp"
 
 #include "drake/systems/sensors/optitrack_encoder.h"
 
@@ -12,30 +12,30 @@ namespace sensors {
 
 using systems::sensors::TrackedBody;
 
-OptitrackFrameSender::OptitrackFrameSender(int num_rigid_bodies)
+OptitrackLCMFrameSender::OptitrackLCMFrameSender(int num_rigid_bodies)
     : num_rigid_bodies_(num_rigid_bodies) {
   DRAKE_DEMAND(num_rigid_bodies >= 0);
   this->DeclareAbstractInputPort();
-  this->DeclareAbstractOutputPort(&OptitrackFrameSender::CreateNewMessage,
-                                  &OptitrackFrameSender::PopulateMessage);
+  this->DeclareAbstractOutputPort(&OptitrackLCMFrameSender::CreateNewMessage,
+                                  &OptitrackLCMFrameSender::PopulateMessage);
 }
 
-optitrack::optitrack_frame_t OptitrackFrameSender::CreateNewMessage() const {
+optitrack::optitrack_frame_t OptitrackLCMFrameSender::CreateNewMessage() const {
   optitrack::optitrack_frame_t msg{};
 
   msg.num_rigid_bodies = num_rigid_bodies_;
-  msg.rigid_bodies.resize(num_rigid_bodies_);
+  msg.rigid_bodies.resize(static_cast<size_t>(num_rigid_bodies_));
 
   return msg;
 }
 
-void OptitrackFrameSender::PopulateMessage(
+void OptitrackLCMFrameSender::PopulateMessage(
     const Context<double>& context,
     optitrack::optitrack_frame_t* output) const {
 
   optitrack::optitrack_frame_t& status = *output;
 
-  status.utime = context.get_time() * 1e6;
+  status.utime = static_cast<int64_t >(context.get_time() * 1e6);
 
   const std::vector<TrackedBody>* mocap_objects =
       this->EvalInputValue<std::vector<TrackedBody>>(context, 0);

--- a/drake/systems/sensors/optitrack_sender.cc
+++ b/drake/systems/sensors/optitrack_sender.cc
@@ -1,0 +1,63 @@
+#include "drake/systems/sensors/optitrack_sender.h"
+
+#include <vector>
+
+#include "external/optitrack_driver/lcmtypes/optitrack/optitrack_rigid_body_t.hpp"
+
+#include "drake/systems/sensors/optitrack_encoder.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using systems::sensors::TrackedBody;
+
+OptitrackFrameSender::OptitrackFrameSender(int num_rigid_bodies)
+    : num_rigid_bodies_(num_rigid_bodies) {
+  DRAKE_DEMAND(num_rigid_bodies >= 0);
+  this->DeclareAbstractInputPort();
+  this->DeclareAbstractOutputPort(&OptitrackFrameSender::CreateNewMessage,
+                                  &OptitrackFrameSender::PopulateMessage);
+}
+
+optitrack::optitrack_frame_t OptitrackFrameSender::CreateNewMessage() const {
+  optitrack::optitrack_frame_t msg{};
+
+  msg.num_rigid_bodies = num_rigid_bodies_;
+  msg.rigid_bodies.resize(num_rigid_bodies_);
+
+  return msg;
+}
+
+void OptitrackFrameSender::PopulateMessage(
+    const Context<double>& context,
+    optitrack::optitrack_frame_t* output) const {
+
+  optitrack::optitrack_frame_t& status = *output;
+
+  status.utime = context.get_time() * 1e6;
+
+  const std::vector<TrackedBody>* mocap_objects =
+      this->EvalInputValue<std::vector<TrackedBody>>(context, 0);
+
+  for (size_t i = 0; i < mocap_objects->size(); ++i) {
+    status.rigid_bodies[i].id = (*mocap_objects)[i].id;
+
+    const Eigen::Vector3d trans = (*mocap_objects)[i].T_WF.translation();
+    const Eigen::Quaterniond rot = Eigen::Quaterniond(
+        (*mocap_objects)[i].T_WF.linear());
+
+    status.rigid_bodies[i].xyz[0] = static_cast<float>(trans[0]);
+    status.rigid_bodies[i].xyz[1] = static_cast<float>(trans[1]);
+    status.rigid_bodies[i].xyz[2] = static_cast<float>(trans[2]);
+
+    status.rigid_bodies[i].quat[0] = static_cast<float>(rot.x());
+    status.rigid_bodies[i].quat[1] = static_cast<float>(rot.y());
+    status.rigid_bodies[i].quat[2] = static_cast<float>(rot.z());
+    status.rigid_bodies[i].quat[3] = static_cast<float>(rot.w());
+  }
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/optitrack_sender.h
+++ b/drake/systems/sensors/optitrack_sender.h
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "external/optitrack_driver/lcmtypes/optitrack/optitrack_frame_t.hpp"
+/// @file This file implements a system which populates optitrack_frame_t
+/// messages for publishing over a message passing system. Currently we support
+/// publishing over LCM, and may support other messaging protocols in the
+/// future.
+
+#include "optitrack/optitrack_frame_t.hpp"
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
@@ -10,9 +15,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-/// @file This file implements a system which populates optitrack_frame_t
-/// messages for publishing over LCM.
-///
+
 /// The system has one abstract-valued input port and one abstract-valued
 /// output port. The abstract input port is templated on a std::vector of type
 /// manipulation::perception::TrackedBody, and the abstract output port value
@@ -20,13 +23,13 @@ namespace sensors {
 ///
 /// Note that this system does not actually send this message on an LCM channel.
 /// To send the message, the output of this system should be connected to an
-/// input port of a systems::Value objected templated on type
+/// input port of a systems::Value objecte templated on type
 /// `optitrack_frame_t`.
-class OptitrackFrameSender : public systems::LeafSystem<double> {
+class OptitrackLCMFrameSender : public systems::LeafSystem<double> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackFrameSender)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackLCMFrameSender)
 
-  explicit OptitrackFrameSender(int num_rigid_bodies);
+  explicit OptitrackLCMFrameSender(int num_rigid_bodies);
 
   const systems::InputPortDescriptor<double>& get_optitrack_input_port() const {
     return get_input_port(0);

--- a/drake/systems/sensors/optitrack_sender.h
+++ b/drake/systems/sensors/optitrack_sender.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "external/optitrack_driver/lcmtypes/optitrack/optitrack_frame_t.hpp"
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+/// @file This file implements a system which populates optitrack_frame_t
+/// messages for publishing over LCM.
+///
+/// The system has one abstract-valued input port and one abstract-valued
+/// output port. The abstract input port is templated on a std::vector of type
+/// manipulation::perception::TrackedBody, and the abstract output port value
+/// is templated on type `optitrack_frame_t`.
+///
+/// Note that this system does not actually send this message on an LCM channel.
+/// To send the message, the output of this system should be connected to an
+/// input port of a systems::Value objected templated on type
+/// `optitrack_frame_t`.
+class OptitrackFrameSender : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OptitrackFrameSender)
+
+  explicit OptitrackFrameSender(int num_rigid_bodies);
+
+  const systems::InputPortDescriptor<double>& get_optitrack_input_port() const {
+    return get_input_port(0);
+  }
+
+  const systems::OutputPort<double>& get_lcm_output_port() const {
+    return get_output_port(0);
+  }
+
+ private:
+  // This is the method to use for the output port allocator.
+  optitrack::optitrack_frame_t CreateNewMessage() const;
+
+  // This is the calculator method for the output port.
+  void PopulateMessage(const systems::Context<double>& context,
+                       optitrack::optitrack_frame_t* output) const;
+
+  const int num_rigid_bodies_;
+};
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/optitrack_encoder_test.cc
+++ b/drake/systems/sensors/test/optitrack_encoder_test.cc
@@ -1,0 +1,127 @@
+#include "drake/systems/sensors/optitrack_encoder.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using systems::rendering::PoseBundle;
+
+class OptitrackEncoderTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    Eigen::Vector3d axis(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3));
+
+    // Create a mock PoseBundle with three arbitrarily chosen poses.
+    pose_bundle_ = new PoseBundle<double>(3);
+    pose_bundle_->set_name(0, "iiwa_frame_0");
+    pose_bundle_->set_pose(
+        0, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.1, axis)));
+    pose_bundle_->set_name(1, "iiwa_frame_1");
+    pose_bundle_->set_pose(
+        1, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)));
+    pose_bundle_->set_name(2, "iiwa_frame_2");
+    pose_bundle_->set_pose(
+        2, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.3, axis)));
+
+    // The OptitrackEncoder class constructor takes a map of unique frame names
+    // (that have a match in the PoseBundle input object) to unique Optitrack
+    // IDs.
+    frame_name_to_id_map_["iiwa_frame_0"] = 1;
+    frame_name_to_id_map_["iiwa_frame_1"] = 2;
+    frame_name_to_id_map_["iiwa_frame_2"] = 3;
+
+    // Create a set of custom names for our tracked rigid bodies. These are
+    // optional. If not provided, rigid body names will match the frame names
+    // contained in the PoseBundle input. These names are not necessarily unique
+    // (as in the case for the Optitrack application software, e.g., Motive).
+    rigid_body_names_.push_back("body_1");
+    rigid_body_names_.push_back("body_2");
+    rigid_body_names_.push_back("body_3");
+  }
+
+  std::vector<TrackedBody> UpdateInputCalcOutput(
+      const OptitrackEncoder& dut) {
+    std::unique_ptr<systems::AbstractValue> input(
+    new systems::Value<PoseBundle<double>>(pose_bundle_->get_num_poses()));
+    input->SetValue(*pose_bundle_);
+
+    auto context = dut.CreateDefaultContext();
+    auto output = dut.AllocateOutput(*context);
+    context->FixInputPort(
+        dut.get_pose_bundle_input_port_index() /* input port ID*/,
+        std::move(input));
+
+    dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+    dut.CalcOutput(*context, output.get());
+    auto output_value =
+        output->get_data(dut.get_optitrack_output_port_index());
+
+    return output_value->GetValue<std::vector<TrackedBody>>();
+  }
+
+  virtual void TearDown() {
+    delete pose_bundle_;
+  }
+
+  std::map<std::string, int> frame_name_to_id_map_;
+  std::vector<std::string> rigid_body_names_;
+
+ private:
+  PoseBundle<double>* pose_bundle_;
+};
+
+TEST_F(OptitrackEncoderTest, InvalidOptitrackIdTest) {
+  // Repeat the first Optitrack ID for the third frame (therefore invalid).
+  frame_name_to_id_map_["iiwa_frame_2"] = 1;
+  EXPECT_ANY_THROW(OptitrackEncoder(frame_name_to_id_map_,
+                                    std::vector<std::string>()));
+
+  // Make the third Optitrack ID negative (therefore invalid).
+  frame_name_to_id_map_["iiwa_frame_2"] = -2;
+  EXPECT_ANY_THROW(OptitrackEncoder(frame_name_to_id_map_,
+                                    std::vector<std::string>()));
+}
+
+// Create a default OptitrackEncoder without specifying custom rigid body names.
+// This test checks the assigned rigid body names have a match within the set of
+// incoming frame names within the PoseBundle object.
+TEST_F(OptitrackEncoderTest, WithoutRigidBodyNamesTest) {
+  OptitrackEncoder dut(frame_name_to_id_map_, std::vector<std::string>());
+  auto tracked_objects = UpdateInputCalcOutput(dut);
+
+  for (auto it = tracked_objects.begin(); it != tracked_objects.end(); ++it) {
+    EXPECT_EQ((*it).id, frame_name_to_id_map_[(*it).body_name]);
+  }
+}
+
+// Create an OptitrackEncoder and specify custom rigid body names. This test
+// implements a consistency check between the output of this leaf system and
+// the parameters passed in at object construction. We ensure each TrackedBody
+// stores the correct body name, by comparing these against names passed to the
+// constructor.
+TEST_F(OptitrackEncoderTest, WithRigidBodyNamesTest) {
+  OptitrackEncoder dut(frame_name_to_id_map_, rigid_body_names_);
+  auto tracked_objects = UpdateInputCalcOutput(dut);
+
+  EXPECT_EQ(frame_name_to_id_map_.size(), rigid_body_names_.size());
+  auto rb_name_iter = rigid_body_names_.begin();
+  auto fr_map_iter = frame_name_to_id_map_.begin();
+  while (fr_map_iter != frame_name_to_id_map_.end() &&
+      rb_name_iter != rigid_body_names_.end()) {
+    auto obj_it = std::find_if(tracked_objects.begin(), tracked_objects.end(),
+                               [&fr_map_iter](const TrackedBody& tobj) {
+                                 return tobj.id == fr_map_iter->second;
+                               });
+    EXPECT_EQ(*rb_name_iter, (*obj_it).body_name);
+    fr_map_iter++;
+    rb_name_iter++;
+  }
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/drake/systems/sensors/test/optitrack_encoder_test.cc
+++ b/drake/systems/sensors/test/optitrack_encoder_test.cc
@@ -19,13 +19,16 @@ class OptitrackEncoderTest : public ::testing::Test {
     pose_bundle_ = new PoseBundle<double>(3);
     pose_bundle_->set_name(0, "iiwa_frame_0");
     pose_bundle_->set_pose(
-        0, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.1, axis)));
+        0, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.1, axis)).
+            pretranslate(Eigen::Vector3d(0.2, 0.3, 0.7)));
     pose_bundle_->set_name(1, "iiwa_frame_1");
     pose_bundle_->set_pose(
-        1, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)));
+        1, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)).
+            pretranslate(Eigen::Vector3d(0.5, 0.8, 0.9)));
     pose_bundle_->set_name(2, "iiwa_frame_2");
     pose_bundle_->set_pose(
-        2, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.3, axis)));
+        2, Eigen::Isometry3d(Eigen::AngleAxis<double>(0.3, axis)).
+            pretranslate(Eigen::Vector3d(0.1, 0.4, 0.8)));
 
     // The OptitrackEncoder class constructor takes a map of unique frame names
     // (that have a match in the PoseBundle input object) to unique Optitrack

--- a/drake/systems/sensors/test/optitrack_sender_test.cc
+++ b/drake/systems/sensors/test/optitrack_sender_test.cc
@@ -1,0 +1,75 @@
+#include "drake/systems/sensors/optitrack_sender.h"
+
+#include <gtest/gtest.h>
+#include "optitrack/optitrack_frame_t.hpp"
+
+#include "drake/systems/framework/context.h"
+#include "drake/systems/sensors/optitrack_encoder.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+
+using systems::sensors::TrackedBody;
+using optitrack::optitrack_frame_t;
+
+// This test sets up a systems::sensors::TrackedBody structure to be passed
+// through by the OptitrackLCMFrameSender test object. The output should be
+// an abstract value object templated on type `optitrack_frame_t`. This test
+// ensures that the TrackedBody input to the OptitrackLCMFrameSender system
+// matches the output `optitrack_frame_t` object.
+GTEST_TEST(OptitrackSenderTest, OptitrackLCMSenderTest) {
+  OptitrackLCMFrameSender dut(1);  // Create a frame sender with 1 rigid body.
+  std::vector<TrackedBody> tracked_body(1);
+
+  constexpr double tx = 0.2;  // x-translation for the test object
+  constexpr double ty = 0.4;  // y-translation for the test object
+  constexpr double tz = 0.7;  // z-translation for the test object
+
+  // Sets up a test body with an arbitrarily chosen pose.
+  Eigen::Vector3d axis(1 / sqrt(3), 1 / sqrt(3), 1 / sqrt(3));
+  tracked_body[0].id = 1;
+  tracked_body[0].body_name = "test_body";
+  tracked_body[0].T_WF = Eigen::Isometry3d(Eigen::AngleAxis<double>(0.2, axis)).
+      pretranslate(Eigen::Vector3d(tx, ty, tz));
+
+  EXPECT_EQ(tracked_body[0].T_WF.translation()[0], tx);
+  EXPECT_EQ(tracked_body[0].T_WF.translation()[1], ty);
+  EXPECT_EQ(tracked_body[0].T_WF.translation()[2], tz);
+
+  std::unique_ptr<systems::AbstractValue> input(
+      new systems::Value<std::vector<TrackedBody>>());
+  input->SetValue(tracked_body);
+
+  auto context = dut.CreateDefaultContext();
+  auto output = dut.AllocateOutput(*context);
+  context->FixInputPort(0 /* input port ID*/, std::move(input));
+
+  dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+  dut.CalcOutput(*context, output.get());
+  auto output_value = output->get_data(0);
+
+  auto lcm_frame =  output_value->GetValue<optitrack_frame_t>();
+
+  // Compare the resultant lcm_frame values to those provided at the input to
+  // the system.
+  EXPECT_EQ(lcm_frame.utime, 0);
+  EXPECT_EQ(lcm_frame.num_rigid_bodies, 1);
+
+  // Check the translations. Allow for some numerical error.
+  EXPECT_NEAR(lcm_frame.rigid_bodies[0].xyz[0], tx, 1e-7);
+  EXPECT_NEAR(lcm_frame.rigid_bodies[0].xyz[1], ty, 1e-7);
+  EXPECT_NEAR(lcm_frame.rigid_bodies[0].xyz[2], tz, 1e-7);
+
+  // Check the rotations.
+  const Eigen::Quaterniond quat_rotation = Eigen::Quaterniond(
+      lcm_frame.rigid_bodies[0].quat[3], lcm_frame.rigid_bodies[0].quat[0],
+      lcm_frame.rigid_bodies[0].quat[1], lcm_frame.rigid_bodies[0].quat[2]);
+  Eigen::Isometry3d body_pose = Eigen::Isometry3d(quat_rotation).
+      pretranslate(Eigen::Vector3d(tx, ty, tz));
+  EXPECT_TRUE(body_pose.isApprox(tracked_body[0].T_WF, 1e-1));
+}
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
Implements an interface for defining frames that are treated as Optitrack rigid bodies. This is useful when implementing systems that are meant to interface with actual Optitrack hardware, but are to be tested in simulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7213)
<!-- Reviewable:end -->
