### PR TITLE
Fixing Valgrind build

### DIFF
--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -538,6 +538,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "test_ik_traj",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     data = ["//drake/examples/atlas:models"],
     tags = ["snopt"],
     deps = [

--- a/drake/multibody/dev/BUILD
+++ b/drake/multibody/dev/BUILD
@@ -72,8 +72,12 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    # Excluding because an assertion fails in LLVM code. Issue #6179.
-    tags = gurobi_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + [
+        # Takes too long (~2300 s) to run with Valgrind.
+        "no_memcheck",
+        # Excluding because an assertion fails in LLVM code. Issue #6179.
+        "no_tsan",
+    ],
     deps = [
         ":global_inverse_kinematics_test_util",
     ],
@@ -86,8 +90,12 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    # Excluding because an assertion fails in LLVM code. Issue #6179.
-    tags = gurobi_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + [
+        # Takes too long (~7500 s) to run with Valgrind.
+        "no_memcheck",
+        # Excluding because an assertion fails in LLVM code. Issue #6179.
+        "no_tsan",
+    ],
     deps = [
         ":global_inverse_kinematics_test_util",
     ],
@@ -100,8 +108,12 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    # Excluding because an assertion fails in LLVM code. Issue #6179.
-    tags = gurobi_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + [
+        # Takes too long (~3200 s) to run with Valgrind.
+        "no_memcheck",
+        # Excluding because an assertion fails in LLVM code. Issue #6179.
+        "no_tsan",
+    ],
     deps = [
         ":global_inverse_kinematics_test_util",
     ],
@@ -116,6 +128,8 @@ drake_cc_googletest(
     ],
     tags = gurobi_test_tags() + [
         "no_asan",
+        # Times out with Valgrind
+        "no_memcheck",
         "no_tsan",
     ],
     deps = [

--- a/drake/solvers/BUILD
+++ b/drake/solvers/BUILD
@@ -842,6 +842,8 @@ drake_cc_googletest(
     tags = gurobi_test_tags() + mosek_test_tags() + [
         # Excluding asan because it is unreasonably slow (> 30 minutes).
         "no_asan",
+        # Times out with Valgrind
+        "no_memcheck",
         # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
         "no_tsan",
     ],
@@ -879,8 +881,12 @@ drake_cc_binary(
 drake_cc_googletest(
     name = "rotation_constraint_limit_test",
     size = "large",
-    # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
-    tags = gurobi_test_tags() + ["no_tsan"],
+    tags = gurobi_test_tags() + [
+        # Times out with Valgrind
+        "no_memcheck",
+        # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
+        "no_tsan",
+    ],
     deps = [
         ":gurobi_solver",
         ":mathematical_program",

--- a/tools/dynamic_analysis/valgrind.supp
+++ b/tools/dynamic_analysis/valgrind.supp
@@ -99,18 +99,4 @@
     fun:malloc
     fun:mkl_serv_thread_free_buffers
     fun:PRIVATE*
-    ...
-    fun:GRBoptimize
-}
-
-# Started happening when Gurobi got updated to 7.0.2.
-{
-    <gurobi-2>
-    Memcheck:Leak
-    match-leak-kinds: possible
-    fun:malloc
-    fun:mkl_serv_thread_free_buffers
-    fun:PRIVATE*
-    ...
-    fun:start_thread
 }


### PR DESCRIPTION
Fixing the build: [`linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything`](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/153/consoleText)

[This is the list of the Valgrind tests with the times they take](https://docs.google.com/spreadsheets/d/1-vqVN65lNs5EQhxIfBW1MesNCPQhvovPbFHB3BHdDeg/edit#gid=0) obtained by running with [`--test_summary=short` on CI](https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-experimental-memcheck-valgrind-everything/29/consoleText)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7222)
<!-- Reviewable:end -->
