### PR TITLE
Update `package.xml` style and update packages to work with Catkin

### DIFF
--- a/drake/automotive/models/prius/package.xml
+++ b/drake/automotive/models/prius/package.xml
@@ -1,3 +1,10 @@
 <package format="2">
   <name>prius</name>
+  <version>0.0.0</version>
+  <description>
+    This package provides Prius models.
+  </description>
+  <author email="drake-users@mit.edu">Drake Users</author>
+  <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
+  <license>BSD</license>
 </package>

--- a/drake/automotive/models/prius/package.xml
+++ b/drake/automotive/models/prius/package.xml
@@ -6,5 +6,5 @@
   </description>
   <author email="drake-users@mit.edu">Drake Users</author>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>Unknown</license>
 </package>

--- a/drake/doc/code_style_guide.rst
+++ b/drake/doc/code_style_guide.rst
@@ -167,10 +167,10 @@ When adding a model to Drake
 (typically in `drake-distro/drake/examples/ <https://github.com/RobotLocomotion/drake/tree/master/drake/examples>`_),
 you will need to add a ``package.xml`` file to the example's directory to enable
 modeling files like URDF and SDF to refer to resources like mesh files contained
-within the example's directory. While a full ``package.xml`` file that contains
-every `required field <http://wiki.ros.org/catkin/package.xml#Required_Tags>`_
-would be ideal, for Drake's purposes, the following minimal ``package.xml`` file
-is sufficient::
+within the example's directory. Please ensure that your ``package.xml`` file
+contains every
+`required field <http://wiki.ros.org/catkin/package.xml#Required_Tags>`_.
+The following minimal ``package.xml`` file can get you started::
 
     <!--
     This XML file is used by:
@@ -181,6 +181,12 @@ is sufficient::
 
     <package format="2">
       <name>package_name</name>
+      <version>0.0.0</version>
+      <description>
+        A description of your package.
+      </description>
+      <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
+      <license>BSD</license>
     </package>
 
 In the above example, replace "package_name" with the name of your package. This

--- a/drake/examples/atlas/package.xml
+++ b/drake/examples/atlas/package.xml
@@ -1,3 +1,10 @@
 <package format="2">
   <name>Atlas</name>
+  <version>0.0.0</version>
+  <description>
+    This package provides Atlas models and URDFs.
+  </description>
+  <author email="drake-users@mit.edu">Drake Users</author>
+  <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
+  <license>BSD</license>
 </package>

--- a/drake/examples/atlas/package.xml
+++ b/drake/examples/atlas/package.xml
@@ -6,5 +6,5 @@
   </description>
   <author email="drake-users@mit.edu">Drake Users</author>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>Unknown</license>
 </package>

--- a/drake/examples/irb140/package.xml
+++ b/drake/examples/irb140/package.xml
@@ -1,3 +1,10 @@
 <package format="2">
   <name>IRB140</name>
+  <version>0.0.0</version>
+  <description>
+    This package provides ABB IRB140 models and URDFs.
+  </description>
+  <author email="drake-users@mit.edu">Drake Users</author>
+  <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
+  <license>BSD</license>
 </package>

--- a/drake/examples/irb140/package.xml
+++ b/drake/examples/irb140/package.xml
@@ -6,5 +6,5 @@
   </description>
   <author email="drake-users@mit.edu">Drake Users</author>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>Unknown</license>
 </package>

--- a/drake/examples/valkyrie/package.xml
+++ b/drake/examples/valkyrie/package.xml
@@ -6,5 +6,5 @@
   </description>
   <author email="drake-users@mit.edu">Drake Users</author>
   <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
-  <license>BSD</license>
+  <license>Unknown</license>
 </package>

--- a/drake/examples/valkyrie/package.xml
+++ b/drake/examples/valkyrie/package.xml
@@ -1,3 +1,10 @@
 <package format="2">
   <name>valkyrie</name>
+  <version>0.0.0</version>
+  <description>
+    This package provides Valkyrie models and URDFs.
+  </description>
+  <author email="drake-users@mit.edu">Drake Users</author>
+  <maintainer email="drake-users@mit.edu">Drake Users</maintainer>
+  <license>BSD</license>
 </package>


### PR DESCRIPTION
Catkin wants all package.xml tags to have name, version, description, maintainer, and license
tags. This adds these tags (with my best guesses at reasonable values) to the example packages
available in Drake.

This came up because I'm trying to create a catkin ws in Spartan, and the catkin build was barfing because Drake's installed packages are visible to it (via installation into Spartan), but don't have completely correct package xml files.

I copied the relevant fields over from `wsg_50_description`'s `package.xml` to flesh out the offending files, and propose a style guide modification to prevent new compatibility issues from coming up as new packages get added. Certainly open to review and other opinions, though -- I don't know too much about your internal use of ROS / what you've encountered!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7224)
<!-- Reviewable:end -->
