### PR TITLE
Allow unknown dotfiles in third_party

### DIFF
--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -22,14 +22,14 @@ class UtilTest(unittest.TestCase):
         self.assertTrue('.drake-resource-sentinel' in relpaths)
         self.assertTrue('setup/ubuntu/16.04/install_prereqs.sh' in relpaths)
         THIRD_PARTY_SOURCES_ALLOWED_TO_BE_FOUND = [
-            "third_party",
             "third_party/BUILD.bazel",
         ]
         for one_relpath in relpaths:
             self.assertTrue(".git/" not in one_relpath, one_relpath)
-            if one_relpath in THIRD_PARTY_SOURCES_ALLOWED_TO_BE_FOUND:
-                continue
-            self.assertTrue("third_party" not in one_relpath, one_relpath)
+            if "third_party/" in one_relpath:
+                self.assertTrue(
+                    one_relpath in THIRD_PARTY_SOURCES_ALLOWED_TO_BE_FOUND or
+                    one_relpath.startswith("."))
 
 
 # TODO(jwnimmer-tri) Omitting or mistyping these lines means that no tests get


### PR DESCRIPTION
We want to limit the files in third_party to only a whitelist, but by whistlisting `".*"` here, we allow "hidden" files like Apple's `.DS_Store` file to exist, which seems like a fair compromise.

Closes #7201.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7225)
<!-- Reviewable:end -->
