### PR TITLE
Give automotive and kuka_iiwa_arm models their own packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,7 +66,7 @@ install(
     docs = ["LICENSE.TXT"],
     deps = [
         "//drake:install",
-        "//drake/automotive:install_data",
+        "//drake/automotive/models:install_data",
         "//drake/bindings:install",
         "//drake/common:install",
         "//drake/examples:install",

--- a/drake/automotive/BUILD
+++ b/drake/automotive/BUILD
@@ -8,7 +8,6 @@ load(
     "drake_cc_binary",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools:install_data.bzl", "install_data")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -229,7 +228,7 @@ drake_cc_library(
     name = "prius_vis",
     srcs = ["prius_vis.cc"],
     hdrs = ["prius_vis.h"],
-    data = ["//drake/automotive:prod_models"],
+    data = ["//drake/automotive/models:prod_models"],
     deps = [
         ":car_vis",
         "//drake/common:find_resource",
@@ -387,7 +386,7 @@ drake_cc_binary(
         "create_trajectory_params.h",
     ],
     data = [
-        "//drake/automotive:prod_models",
+        "//drake/automotive/models:prod_models",
     ],
     deps = [
         ":automotive_simulator",
@@ -406,7 +405,7 @@ drake_cc_binary(
     ],
     add_test_rule = 1,
     data = [
-        "//drake/automotive:prod_models",
+        "//drake/automotive/models:prod_models",
     ],
     test_rule_args = [" --simulation_sec=0.01"],
     deps = [
@@ -452,34 +451,11 @@ py_binary(
     ],
 )
 
-genrule(
-    name = "speed_bump_genrule",
-    srcs = ["models/speed_bump/speed_bump.yaml"],
-    outs = [
-        "models/speed_bump/speed_bump.obj",
-        "models/speed_bump/speed_bump.mtl",
-    ],
-    cmd = " ".join([
-        "$(location //drake/automotive/maliput/utility:yaml_to_obj)",
-        "--yaml_file '$<'",
-        "--obj_dir $(@D)/models/speed_bump",
-        "--obj_file speed_bump",
-    ]),
-    tools = ["//drake/automotive/maliput/utility:yaml_to_obj"],
-)
-
-install_data(
-    extra_prod_models = [
-        "models/speed_bump/speed_bump.mtl",
-        "models/speed_bump/speed_bump.obj",
-    ],
-)
-
 # === test/ ===
 
 drake_cc_googletest(
     name = "automotive_simulator_test",
-    data = ["//drake/automotive:prod_models"],
+    data = ["//drake/automotive/models:prod_models"],
     local = 1,
     deps = [
         "//drake/automotive:automotive_simulator",

--- a/drake/automotive/models/BUILD
+++ b/drake/automotive/models/BUILD
@@ -1,0 +1,32 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools:install_data.bzl", "install_data")
+
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "speed_bump_genrule",
+    srcs = ["speed_bump/speed_bump.yaml"],
+    outs = [
+        "speed_bump/speed_bump.obj",
+        "speed_bump/speed_bump.mtl",
+    ],
+    cmd = " ".join([
+        "$(location //drake/automotive/maliput/utility:yaml_to_obj)",
+        "--yaml_file '$<'",
+        "--obj_dir $(@D)/speed_bump",
+        "--obj_file speed_bump",
+    ]),
+    tools = ["//drake/automotive/maliput/utility:yaml_to_obj"],
+)
+
+install_data(
+    extra_prod_models = [
+        "speed_bump/speed_bump.mtl",
+        "speed_bump/speed_bump.obj",
+    ],
+)
+
+add_lint_tests()

--- a/drake/examples/kuka_iiwa_arm/BUILD
+++ b/drake/examples/kuka_iiwa_arm/BUILD
@@ -156,6 +156,18 @@ drake_cc_binary(
     ],
 )
 
+alias(
+    name = "models",
+    actual = "//drake/examples/kuka_iiwa_arm/models:models",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "prod_models",
+    actual = "//drake/examples/kuka_iiwa_arm/models:prod_models",
+    visibility = ["//visibility:public"],
+)
+
 # === test/ ===
 
 drake_cc_googletest(
@@ -191,6 +203,12 @@ install(
     visibility = ["//visibility:public"],
 )
 
-install_data()
+install(
+    name = "install_data",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//drake/examples/kuka_iiwa_arm/models:install_data",
+    ],
+)
 
 add_lint_tests()

--- a/drake/examples/kuka_iiwa_arm/models/BUILD
+++ b/drake/examples/kuka_iiwa_arm/models/BUILD
@@ -1,0 +1,11 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:install_data.bzl", "install_data")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+install_data()
+
+add_lint_tests()

--- a/drake/multibody/BUILD
+++ b/drake/multibody/BUILD
@@ -440,7 +440,7 @@ drake_cc_googletest(
     srcs = ["test/rigid_body_tree/rigid_body_tree_clone_test.cc"],
     data = [
         ":test_models",
-        "//drake/automotive:prod_models",
+        "//drake/automotive/models",
         "//drake/examples/atlas:models",
         "//drake/examples/pendulum:models",
         "//drake/examples/valkyrie:models",


### PR DESCRIPTION
This prevents the `install_data` glob from illegally crossing package boundaries, which Bazel will start flagging as an error in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7233)
<!-- Reviewable:end -->
