### PR TITLE
Ensure that `dev` code is always in its own Bazel package

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/dev/BUILD.bazel
@@ -1,0 +1,4 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that we can
+# be sure that dev code always has "dev" in its package name.

--- a/drake/examples/kuka_iiwa_arm/dev/box_rotation/BUILD
+++ b/drake/examples/kuka_iiwa_arm/dev/box_rotation/BUILD
@@ -63,11 +63,11 @@ drake_cc_binary(
     ],
     test_rule_args = ["--simulation_sec=0.01"],
     deps = [
+        ":iiwa_box_diagram_factory",
         "//drake/common:find_resource",
         "//drake/examples/kuka_iiwa_arm:iiwa_common",
         "//drake/examples/kuka_iiwa_arm:iiwa_lcm",
         "//drake/examples/kuka_iiwa_arm:oracular_state_estimator",
-        "//drake/examples/kuka_iiwa_arm/dev/box_rotation:iiwa_box_diagram_factory",  # noqa
         "//drake/lcm",
         "//drake/lcmtypes:contact_info_for_viz",
         "//drake/lcmtypes:contact_results_for_viz",

--- a/drake/systems/estimators/BUILD
+++ b/drake/systems/estimators/BUILD
@@ -5,10 +5,8 @@ load(
     "//tools:drake.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
-    "drake_cc_test",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -52,26 +50,6 @@ drake_cc_googletest(
         "//drake/common/test_utilities:is_dynamic_castable",
         "//drake/examples/pendulum:pendulum_plant",
         "//drake/systems/primitives:linear_system",
-    ],
-)
-
-drake_cc_test(
-    name = "pose_estimation_test",
-    srcs = [
-        "dev/pose_estimation_test.cc",
-        "dev/rotation.h",
-    ],
-    data = ["//drake/multibody:models"],
-    tags = mosek_test_tags(),
-    deps = [
-        "//drake/common:essential",
-        "//drake/common:find_resource",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/collision",
-        "//drake/multibody/parsers",
-        "//drake/solvers:mathematical_program",
-        "@lcm",
-        "@lcmtypes_bot2_core",
     ],
 )
 

--- a/drake/systems/estimators/dev/BUILD.bazel
+++ b/drake/systems/estimators/dev/BUILD.bazel
@@ -1,0 +1,33 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load(
+    "//tools:drake.bzl",
+    "drake_cc_test",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_test(
+    name = "pose_estimation_test",
+    srcs = [
+        "pose_estimation_test.cc",
+        "rotation.h",
+    ],
+    data = ["//drake/multibody:models"],
+    tags = mosek_test_tags(),
+    deps = [
+        "//drake/common:essential",
+        "//drake/common:find_resource",
+        "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/collision",
+        "//drake/multibody/parsers",
+        "//drake/solvers:mathematical_program",
+        "@lcm",
+        "@lcmtypes_bot2_core",
+    ],
+)
+
+add_lint_tests()


### PR DESCRIPTION
This fixes all cases in-tree right now, except for one.

This implements the proposed policy documented in #7236.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7234)
<!-- Reviewable:end -->
