### PR TITLE
Add humanoid_controller/dev/BUILD.bazel

### DIFF
--- a/drake/examples/humanoid_controller/BUILD.bazel
+++ b/drake/examples/humanoid_controller/BUILD.bazel
@@ -51,30 +51,11 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "humanoid_manipulation_plan",
-    srcs = [
-        "dev/humanoid_manipulation_plan.cc",
-    ],
-    hdrs = [
-        "dev/humanoid_manipulation_plan.h",
-    ],
-    deps = [
-        "//drake/manipulation/util:robot_state_msg_translator",
-        "//drake/systems/controllers:zmp_planner",
-        "//drake/systems/controllers/plan_eval:generic_plan",
-        "//drake/systems/controllers/qp_inverse_dynamics:lcm_utils",
-        "//drake/util",
-        "@lcmtypes_bot2_core",
-        "@lcmtypes_robotlocomotion",
-    ],
-)
-
-drake_cc_library(
     name = "humanoid_plan_eval_system",
     srcs = ["humanoid_plan_eval_system.cc"],
     hdrs = ["humanoid_plan_eval_system.h"],
     deps = [
-        ":humanoid_manipulation_plan",
+        "//drake/examples/humanoid_controller/dev:humanoid_manipulation_plan",
         "//drake/systems/controllers/plan_eval:plan_eval_base_system",
     ],
 )

--- a/drake/examples/humanoid_controller/dev/BUILD.bazel
+++ b/drake/examples/humanoid_controller/dev/BUILD.bazel
@@ -1,0 +1,28 @@
+# -*- python -*-
+# This file contains rules for Bazel; see drake/doc/bazel.rst.
+
+load("//tools:drake.bzl", "drake_cc_library")
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "humanoid_manipulation_plan",
+    srcs = [
+        "humanoid_manipulation_plan.cc",
+    ],
+    hdrs = [
+        "humanoid_manipulation_plan.h",
+    ],
+    deps = [
+        "//drake/manipulation/util:robot_state_msg_translator",
+        "//drake/systems/controllers:zmp_planner",
+        "//drake/systems/controllers/plan_eval:generic_plan",
+        "//drake/systems/controllers/qp_inverse_dynamics:lcm_utils",
+        "//drake/util",
+        "@lcmtypes_bot2_core",
+        "@lcmtypes_robotlocomotion",
+    ],
+)
+
+add_lint_tests()


### PR DESCRIPTION
All `dev` folders are required to have a `BUILD.bazel` file.

This completes the implementation of the #7236 proposal (following-up on #7234).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7238)
<!-- Reviewable:end -->
