### PR TITLE
Enforces checks on HBounds' and RBounds' setters.

### DIFF
--- a/drake/automotive/maliput/api/lane_data.h
+++ b/drake/automotive/maliput/api/lane_data.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/math/quaternion.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -279,9 +280,11 @@ class RBounds {
   RBounds() = default;
 
   /// Fully parameterized constructor.
+  /// @throws std::runtime_error When @p min is greater than 0.
+  /// @throws std::runtime_error When @p max is smaller than 0.
   RBounds(double min, double max) : min_(min), max_(max) {
-    DRAKE_DEMAND(min <= 0.);
-    DRAKE_DEMAND(max >= 0.);
+    DRAKE_THROW_UNLESS(min <= 0.);
+    DRAKE_THROW_UNLESS(max >= 0.);
   }
 
   /// @name Getters and Setters
@@ -289,11 +292,19 @@ class RBounds {
   /// Gets minimum bound.
   double min() const { return min_; }
   /// Sets minimum bound.
-  void set_min(double min) { min_ = min; }
+  /// @throws std::runtime_error When @p min is greater than 0.
+  void set_min(double min) {
+    DRAKE_THROW_UNLESS(min <= 0.);
+    min_ = min;
+  }
   /// Gets maximum bound.
   double max() const { return max_; }
   /// Sets maximum bound.
-  void set_max(double max) { max_ = max; }
+  /// @throws std::runtime_error When @p max is smaller than 0.
+  void set_max(double max) {
+    DRAKE_THROW_UNLESS(max >= 0.);
+    max_ = max;
+  }
   //@}
 
  private:
@@ -314,9 +325,11 @@ class HBounds {
   HBounds() = default;
 
   /// Fully parameterized constructor.
+  /// @throws std::runtime_error When @p min is greater than 0.
+  /// @throws std::runtime_error When @p max is smaller than 0.
   HBounds(double min, double max) : min_(min), max_(max) {
-    DRAKE_DEMAND(min <= 0.);
-    DRAKE_DEMAND(max >= 0.);
+    DRAKE_THROW_UNLESS(min <= 0.);
+    DRAKE_THROW_UNLESS(max >= 0.);
   }
 
   /// @name Getters and Setters
@@ -324,11 +337,19 @@ class HBounds {
   /// Gets minimum bound.
   double min() const { return min_; }
   /// Sets minimum bound.
-  void set_min(double min) { min_ = min; }
+  /// @throws std::runtime_error When @p min is greater than 0.
+  void set_min(double min) {
+    DRAKE_THROW_UNLESS(min <= 0.);
+    min_ = min;
+  }
   /// Gets maximum bound.
   double max() const { return max_; }
   /// Sets maximum bound.
-  void set_max(double max) { max_ = max; }
+  /// @throws std::runtime_error When @p max is smaller than 0.
+  void set_max(double max) {
+    DRAKE_THROW_UNLESS(max >= 0.);
+    max_ = max;
+  }
   //@}
 
  private:

--- a/drake/automotive/maliput/api/test/lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/lane_data_test.cc
@@ -234,6 +234,72 @@ TEST_F(RotationTest, QuaternionSetter) {
 
 #undef CHECK_ALL_ROTATION_ACCESSORS
 
+GTEST_TEST(RBoundsTest, DefaultConstructor) {
+  const RBounds dut;
+  // Checks correct default value assignment.
+  EXPECT_EQ(dut.min(), 0.);
+  EXPECT_EQ(dut.max(), 0.);
+}
+
+GTEST_TEST(RBoundsTest, ParameterizedConstructor) {
+  const double kMin{-5.};
+  const double kMax{5.};
+  RBounds dut(kMin, kMax);
+  // Checks correct value assignment.
+  EXPECT_EQ(dut.min(), kMin);
+  EXPECT_EQ(dut.max(), kMax);
+  // Checks constraints on the constructor.
+  EXPECT_THROW(RBounds(kMax, kMax), std::runtime_error);
+  EXPECT_THROW(RBounds(kMin, kMin), std::runtime_error);
+}
+
+GTEST_TEST(RBoundsTest, Setters) {
+  const double kMin{-5.};
+  const double kMax{5.};
+  RBounds dut(kMin, kMax);
+  // Set min and max correct values.
+  dut.set_min(2. * kMin);
+  EXPECT_EQ(dut.min(), 2. * kMin);
+  dut.set_max(2. * kMax);
+  EXPECT_EQ(dut.max(), 2. * kMax);
+  // Checks constraints on the setters.
+  EXPECT_THROW(dut.set_min(kMax), std::runtime_error);
+  EXPECT_THROW(dut.set_max(kMin), std::runtime_error);
+}
+
+GTEST_TEST(HBoundsTest, DefaultConstructor) {
+  const HBounds dut;
+  // Checks correct default value assignment.
+  EXPECT_EQ(dut.min(), 0.);
+  EXPECT_EQ(dut.max(), 0.);
+}
+
+GTEST_TEST(HBoundsTest, ParameterizedConstructor) {
+  const double kMin{-5.};
+  const double kMax{5.};
+  HBounds dut(kMin, kMax);
+  // Checks correct value assignment.
+  EXPECT_EQ(dut.min(), kMin);
+  EXPECT_EQ(dut.max(), kMax);
+  // Checks constraints on the constructor.
+  EXPECT_THROW(HBounds(kMax, kMax), std::runtime_error);
+  EXPECT_THROW(HBounds(kMin, kMin), std::runtime_error);
+}
+
+GTEST_TEST(HBoundsTest, Setters) {
+  const double kMin{-5.};
+  const double kMax{5.};
+  HBounds dut(kMin, kMax);
+  // Set min and max correct values.
+  dut.set_min(2. * kMin);
+  EXPECT_EQ(dut.min(), 2. * kMin);
+  dut.set_max(2. * kMax);
+  EXPECT_EQ(dut.max(), 2. * kMax);
+  // Checks constraints on the setters.
+  EXPECT_THROW(dut.set_min(kMax), std::runtime_error);
+  EXPECT_THROW(dut.set_max(kMin), std::runtime_error);
+}
+
 }  // namespace
 }  // namespace api
 }  // namespace maliput


### PR DESCRIPTION
This PR addresses issue #7231. It changes `DRAKE_DEMAND` to `DRAKE_THROW_UNLESS` on `HBounds` and `RBounds` parametrized constructors and adds assertions to setters so as to avoid data corruption. Unit tests are also provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7239)
<!-- Reviewable:end -->
