### PR TITLE
Adds diffstat to install_prereqs.sh

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -28,6 +28,7 @@ brew install $(tr '\n' ' ' <<EOF
 bazel
 boost
 clang-format
+diffstat
 doxygen
 glew
 glib

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -48,6 +48,7 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 bash-completion
 binutils
 coinor-libipopt-dev
+diffstat
 doxygen
 g++
 g++-5


### PR DESCRIPTION
This PR adds `diffstat` to `install_prereqs.sh` script. Ubuntu 16.04 comes with it but base docker image does not. `drake/tools/prstat` is using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7246)
<!-- Reviewable:end -->
