### PR TITLE
Adjust include path for new spelling

### DIFF
--- a/drake/CMakeLists.txt
+++ b/drake/CMakeLists.txt
@@ -57,7 +57,7 @@ target_include_directories(stx PUBLIC ../third_party/com_github_tcbrindle_cpp17_
 set_target_properties(stx PROPERTIES LINKER_LANGUAGE CXX)
 drake_install_libraries(stx)
 install(FILES ../third_party/com_github_tcbrindle_cpp17_headers/stx/optional.hpp
-  DESTINATION "${DRAKE_INSTALL_INCLUDE_DIR}/stx/stx/optional.hpp")
+  DESTINATION "include/stx/stx/optional.hpp")
 
 add_subdirectory(common)
 add_subdirectory(math)


### PR DESCRIPTION
Merging #7241 and #7235 across each other broke the MATLAB builds.  This resolves that problem.

Repairs 7e01460bd9784a87038fcfa1700709031b9133b1 cross-merge error.  The new spelling comes from 95c623fbe8daeb9671c6c26f95e52dacf0e8a596.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7247)
<!-- Reviewable:end -->
