### PR TITLE
Fixes Maliput Lane Data tests to pass Mac's compiler

### DIFF
--- a/drake/automotive/maliput/api/test/lane_data_test.cc
+++ b/drake/automotive/maliput/api/test/lane_data_test.cc
@@ -235,7 +235,7 @@ TEST_F(RotationTest, QuaternionSetter) {
 #undef CHECK_ALL_ROTATION_ACCESSORS
 
 GTEST_TEST(RBoundsTest, DefaultConstructor) {
-  const RBounds dut;
+  const RBounds dut{};
   // Checks correct default value assignment.
   EXPECT_EQ(dut.min(), 0.);
   EXPECT_EQ(dut.max(), 0.);
@@ -268,7 +268,7 @@ GTEST_TEST(RBoundsTest, Setters) {
 }
 
 GTEST_TEST(HBoundsTest, DefaultConstructor) {
-  const HBounds dut;
+  const HBounds dut{};
   // Checks correct default value assignment.
   EXPECT_EQ(dut.min(), 0.);
   EXPECT_EQ(dut.max(), 0.);


### PR DESCRIPTION
Because of PR #7239 a bug was introduced on tests and Mac's clang compiler detected. Revert PR #7248 was created to fix it, and this PR aims to solve it before the revert is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7249)
<!-- Reviewable:end -->
