### PR TITLE
Make drake/common tests insensitive to drake package name

### DIFF
--- a/drake/common/BUILD.bazel
+++ b/drake/common/BUILD.bazel
@@ -460,6 +460,10 @@ genrule(
 sh_test(
     name = "drake_assert_test_compile_variants",
     srcs = ["test/drake_assert_test_compile_variants.sh"],
+    args = [
+        "$(location :capture_cc.env)",
+        "$(location :test/drake_assert_test_compile.cc)",
+    ],
     data = [
         "capture_cc.env",
         "drake_assert.h",
@@ -806,6 +810,7 @@ drake_cc_googletest(
 drake_py_test(
     name = "drake_cc_googletest_main_test_py",
     srcs = ["test/drake_cc_googletest_main_test.py"],
+    args = ["$(location :drake_cc_googletest_main_test)"],
     data = [":drake_cc_googletest_main_test"],
     main = "test/drake_cc_googletest_main_test.py",
 )
@@ -813,6 +818,10 @@ drake_py_test(
 drake_py_test(
     name = "cpplint_wrapper_test",
     srcs = ["test/cpplint_wrapper_test.py"],
+    args = [
+        "$(location :cpplint_wrapper)",
+        "$(location :eigen_types.h)",
+    ],
     data = [
         ":cpplint_wrapper",
         ":eigen_types.h",

--- a/drake/common/test/cpplint_wrapper_test.py
+++ b/drake/common/test/cpplint_wrapper_test.py
@@ -8,18 +8,27 @@ import subprocess
 import sys
 import unittest
 
+# Set on command-line to the location of cpplint_wrapper.
+_cpplint_wrapper_exe = None
+
+# Set on command-line to the location of a valid header file.
+_valid_header = None
+
 
 class TestStringMethods(unittest.TestCase):
 
     def get_valid_header_filename(self):
         """This header should always exist, and pass cpplint."""
-        return "drake/common/eigen_types.h"
+        self.assertTrue(os.path.exists(_valid_header))
+        return _valid_header
 
     def run_and_expect(self, args, expected_exitcode, expected_regexps=None):
         try:
-            cpplint_wrapper = "drake/common/cpplint_wrapper"
+            self.assertTrue(_cpplint_wrapper_exe is not None)
+            self.assertTrue(
+                os.path.exists(_cpplint_wrapper_exe), _cpplint_wrapper_exe)
             output = subprocess.check_output(
-                [sys.executable, cpplint_wrapper] + args,
+                [sys.executable, _cpplint_wrapper_exe] + args,
                 stderr=subprocess.STDOUT)
             returncode = 0
         except subprocess.CalledProcessError as e:
@@ -69,8 +78,9 @@ class TestStringMethods(unittest.TestCase):
              r"whitespace/line_length"])
 
     def test_ignored_extension(self):
+        some_py_filename = sys.argv[0]
         self.run_and_expect(
-            ["drake/common/test/cpplint_wrapper_test.py"],
+            [some_py_filename],
             0,
             [r"Ignoring .*[/\\]cpplint_wrapper_test.py",
              r"TOTAL 0 files"])
@@ -99,4 +109,6 @@ class TestStringMethods(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    _cpplint_wrapper_exe = sys.argv.pop(1)
+    _valid_header = sys.argv.pop(1)
     unittest.main()

--- a/drake/common/test/drake_assert_test_compile_variants.sh
+++ b/drake/common/test/drake_assert_test_compile_variants.sh
@@ -1,18 +1,26 @@
 # This test should only be invoked via Bazel.
-
 set -ex
 
 find .  # Get some debugging output.
 
+capture_cc_env="$1"
+drake_assert_test_compile_cc="$2"
+
 # Make sure we know what C++ compiler to use.
-source drake/common/capture_cc.env
-[ ! -z "$BAZEL_CC" ]
-[ -x "$BAZEL_CC" ]
+source "$capture_cc_env"
+[[ ! -z "$BAZEL_CC" ]]
+[[ -x "$BAZEL_CC" ]]
 "$BAZEL_CC" --version
+
+# TODO(#6996) Do this unconditionally once #6996 is fully merged.
+if [[ ! -e ./drake ]]; then
+  # Mimic `include_prefix = "drake"` per drake_cc_library's default.
+  ln -s . drake
+fi
 
 # Confirm that it compiles successfully, whether or not assertions are enabled.
 TESTING_CXXFLAGS="-std=c++1y -I . \
-    -c drake/common/test/drake_assert_test_compile.cc \
+    -c $drake_assert_test_compile_cc \
     -o /dev/null"
 "$BAZEL_CC" $TESTING_CXXFLAGS
 "$BAZEL_CC" $TESTING_CXXFLAGS -DDRAKE_ENABLE_ASSERTS -UDRAKE_DISABLE_ASSERTS

--- a/drake/common/test/drake_cc_googletest_main_test.py
+++ b/drake/common/test/drake_cc_googletest_main_test.py
@@ -7,16 +7,22 @@ with a variety of command-line flags.
 import re
 import subprocess
 import os
+import sys
 import unittest
+
+# Set on command-line to the location of drake_cc_googletest_main_test.
+_main_exe = None
 
 
 class TestGtestMain(unittest.TestCase):
     def _check_call(self, args, expected_returncode=0):
-        """Run drake_cc_googletest_main with the given args; return output.
+        """Run _main_exe with the given args; return output.
         """
         try:
+            self.assertTrue(_main_exe is not None)
+            self.assertTrue(os.path.exists(_main_exe), _main_exe)
             output = subprocess.check_output(
-                ["drake/common/drake_cc_googletest_main_test"] + args,
+                [_main_exe] + args,
                 stderr=subprocess.STDOUT)
             returncode = 0
         except subprocess.CalledProcessError as e:
@@ -44,7 +50,7 @@ class TestGtestMain(unittest.TestCase):
             "--help",
             ], expected_returncode=1)
         self.assertGreater(len(output), 1000)
-        self.assertTrue("Using drake/test/drake_cc_googletest_main" in output)
+        self.assertTrue("Using drake_cc_googletest_main" in output)
         self.assertTrue("-gtest_list_tests" in output)
         self.assertTrue("-spdlog_level" in output)
         self.assertTrue("-magic_number" in output)
@@ -65,4 +71,5 @@ class TestGtestMain(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    _main_exe = sys.argv.pop(1)
     unittest.main()

--- a/drake/common/test_utilities/drake_cc_googletest_main.cc
+++ b/drake/common/test_utilities/drake_cc_googletest_main.cc
@@ -14,7 +14,7 @@
 DEFINE_string(gunit_color, "", "");
 
 int main(int argc, char** argv) {
-  std::cout << "Using drake/test/drake_cc_googletest_main.cc\n";
+  std::cout << "Using drake_cc_googletest_main.cc\n";
 
   // Initialize gtest and gmock.
   testing::InitGoogleMock(&argc, argv);

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -7,6 +7,8 @@ package(default_visibility = ["//visibility:public"])
 exports_files(
     ["com_github_bazelbuild_bazel/tools/cpp/osx_cc_wrapper.sh"],
     visibility = [
+        "//common:__pkg__",
+        # TODO(6996) Remove the next line once #6996 is fully merged.
         "//drake/common:__pkg__",
         "//tools/cc_toolchain:__pkg__",
     ],


### PR DESCRIPTION
Relates #6996.  Full WIP branch at https://github.com/jwnimmer-tri/drake/commits/build-drake-folder-6996.

The premise is that for #6996, we want the `git mv` commit to be about moving files, not fixing paths.  So ahead of time, we adjust any path logic so that it can deal with both folder layouts.  At head of my branch, if you run `./hoist-up` (which moves all of `drake-distro/drake` one folder higher) then `bazel test //common:* -k`, you'll see that all tests (except the three `find_resource` ones) pass.

This adjusts all necessary tests in the `common` folder -- except for anything `find_resource`-related, which will be finicky and isolated as its own commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7254)
<!-- Reviewable:end -->
