### PR TITLE
Faster bilateral constraints.

### DIFF
--- a/drake/multibody/constraint/constraint_solver.h
+++ b/drake/multibody/constraint/constraint_solver.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/text_logging.h"
 #include "drake/multibody/constraint/constraint_problem_data.h"
 #include "drake/solvers/moby_lcp_solver.h"
 
@@ -62,7 +63,6 @@ namespace constraint {
 /// - [Sargent 1978]  R. W. H. Sargent. An efficient implementation of the Lemke
 ///                   Algorithm and its extension to deal with upper and lower
 ///                   bounds. Mathematical Programming Study, 7, 1978.
-///
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
@@ -272,143 +272,27 @@ class ConstraintSolver {
       MatrixX<T>* MM, VectorX<T>* qq) const;
 
   template <typename ProblemData>
-  void DetermineIndependentConstraints(
-      int num_generalized_velocities,
-      const ProblemData* problem_data,
-      std::vector<int>* indep_constraints,
-      std::function<VectorX<T>(const VectorX<T>&)>* G_mult,
-      std::function<VectorX<T>(const VectorX<T>&)>* G_transpose_mult,
-      Eigen::LLT<MatrixX<T>>* Del) const;
-
-  template <typename ProblemData>
   void DetermineNewPartialInertiaSolveOperator(
-      const ProblemData* problem_data,
-      int num_generalized_velocities,
-      const std::vector<int>* indep_constraints,
-      std::function<VectorX<T>(const VectorX<T>&)> G_mult,
-      std::function<VectorX<T>(const VectorX<T>&)> G_transpose_mult,
-      const Eigen::LLT<MatrixX<T>>* Del,
-      std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const;
+    const ProblemData* problem_data,
+    int num_generalized_velocities,
+    const Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>* Del_QR,
+    std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const;
 
   template <typename ProblemData>
   void DetermineNewFullInertiaSolveOperator(
-      const ProblemData* problem_data,
-      int num_generalized_velocities,
-      const std::vector<int>* indep_constraints,
-      std::function<VectorX<T>(const VectorX<T>&)> G_mult,
-      std::function<VectorX<T>(const VectorX<T>&)> G_transpose_mult,
-      const Eigen::LLT<MatrixX<T>>* Del,
-      std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const;
+    const ProblemData* problem_data,
+    int num_generalized_velocities,
+    const Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>* Del_QR,
+    std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const;
 
   template <typename ProblemData>
   ProblemData* UpdateProblemDataForUnilateralConstraints(
       const ProblemData& problem_data,
-      const std::vector<int>& indep_constraints,
       std::function<const MatrixX<T>(const MatrixX<T>&)> modified_inertia_solve,
       ProblemData* modified_problem_data) const;
 
   drake::solvers::MobyLCPSolver<T> lcp_;
 };
-
-// Determines the set of linearly independent constraints and new versions of
-// G_mult and G_transpose_mult that use only these linearly independent
-// constraints.
-// @param num_generalized_velocities The dimension of the system generalized
-//        velocities.
-// @param problem_data The constraint problem data.
-// @param[out] indep_constraints On return, contains indices of the independent
-//             constraints.
-// @param[out] G_mult On return, contains the new G_mult function (to be used
-//             in place of problem_data.G_mult). The resulting G_mult function
-//             should not be used beyond the life of `problem_data` or
-//             `indep_constraints`.
-// @param[out] G_transpose_mult On return, contains the new G_transpose_mult
-//             function (to be used in place of problem_data.G_transpose_mult).
-//             The resulting `G_transpose_mult` function should not be used
-//             beyond the life of `problem_data` or `indep_constraints`.
-// @param[out] Del On return, contains the Cholesky factorization of the
-//             Delassus Matrix GM⁻¹Gᵀ.
-template <typename T>
-template <typename ProblemData>
-void ConstraintSolver<T>::DetermineIndependentConstraints(
-    int num_generalized_velocities,
-    const ProblemData* problem_data,
-    std::vector<int>* indep_constraints,
-    std::function<VectorX<T>(const VectorX<T>&)>* G_mult,
-    std::function<VectorX<T>(const VectorX<T>&)>* G_transpose_mult,
-    Eigen::LLT<MatrixX<T>>* Del) const {
-  DRAKE_DEMAND(indep_constraints);
-  DRAKE_DEMAND(G_mult);
-  DRAKE_DEMAND(G_transpose_mult);
-
-  // Clear the set of independent constraints.
-  indep_constraints->clear();
-
-  // Determine new G_mult using active constraints.
-  *G_mult = [problem_data, indep_constraints](
-      const VectorX<T>& v) -> VectorX<T> {
-    VectorX<T> result_full = problem_data->G_mult(v);
-    VectorX<T> result(indep_constraints->size());
-    for (int i = 0; i < static_cast<int>(indep_constraints->size()); ++i)
-      result[i] = result_full[(*indep_constraints)[i]];
-    return result;
-  };
-
-  // Determine new G_transpose_mult using active constraints
-  *G_transpose_mult = [problem_data, indep_constraints](
-      const VectorX<T>& f) -> VectorX<T> {
-    VectorX<T> lambda = VectorX<T>::Zero(problem_data->kG.size());
-    for (int i = 0; i < static_cast<int>(indep_constraints->size()); ++i)
-      lambda[(*indep_constraints)[i]] = f[i];
-    return problem_data->G_transpose_mult(lambda);
-  };
-
-  // Verify that we did indeed change the G_mult and G_transpose_mult operators.
-  typedef VectorX<T> (*Op)(const VectorX<T>&);
-  DRAKE_ASSERT(!problem_data->G_mult.template target<Op>() ||
-      *G_mult->template target<Op>() !=
-          *problem_data->G_mult.template target<Op>());
-  DRAKE_ASSERT(!problem_data->G_transpose_mult.template target<Op>() ||
-      *G_transpose_mult->template target<Op>() !=
-          *problem_data->G_transpose_mult.template target<Op>());
-
-  // Determine the set of active constraints.
-  MatrixX<T> iM_GT;
-  MatrixX<T> tentative_Del;
-  Eigen::LLT<MatrixX<T>> last_successful_Del;
-  for (int i = 0; i < problem_data->kG.size(); ++i) {
-    // Tentatively add the constraint to the active set of constraints.
-    indep_constraints->push_back(i);
-
-    // Form the tentative Delassus matrix.
-    iM_GT.resize(num_generalized_velocities, indep_constraints->size());
-    ComputeInverseInertiaTimesGT(problem_data->solve_inertia,
-                                 *G_transpose_mult,
-                                 indep_constraints->size(), &iM_GT);
-    tentative_Del.resize(indep_constraints->size(), indep_constraints->size());
-    ComputeConstraintSpaceComplianceMatrix(*G_mult,
-                                           indep_constraints->size(),
-                                           iM_GT, tentative_Del);
-
-    // Try to do a Cholesky factorization.
-    Del->compute(tentative_Del);
-    if (Del->info() != Eigen::Success) {
-      // Remove the constraint from the active constraint set.
-      indep_constraints->pop_back();
-    } else {
-      // If the problem is fully constrained, do not keep looping.
-      if (tentative_Del.rows() == num_generalized_velocities)
-        break;
-      last_successful_Del = *Del;
-    }
-  }
-
-  // See whether we need to recompute the factorization.
-  if (!indep_constraints->empty() && Del->info() != Eigen::Success) {
-    DRAKE_DEMAND(last_successful_Del.info() == Eigen::Success);
-    *Del = last_successful_Del;
-  }
-}
 
 // Given a matrix A of blocks consisting of generalized inertia (M) and the
 // Jacobian of bilaterals constraints (G):
@@ -437,21 +321,19 @@ template <typename ProblemData>
 void ConstraintSolver<T>::DetermineNewPartialInertiaSolveOperator(
     const ProblemData* problem_data,
     int num_generalized_velocities,
-    const std::vector<int>* indep_constraints,
-    std::function<VectorX<T>(const VectorX<T>&)> G_mult,
-    std::function<VectorX<T>(const VectorX<T>&)> G_transpose_mult,
-    const Eigen::LLT<MatrixX<T>>* Del,
+    const Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>* Del_QR,
     std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const {
-  *A_solve = [problem_data, Del, G_mult, G_transpose_mult,
-      indep_constraints, num_generalized_velocities](const MatrixX<T>& X)
-      -> MatrixX<T> {
+  const int num_eq_constraints = problem_data->kG.size();
+
+  *A_solve = [problem_data, Del_QR, num_eq_constraints, 
+              num_generalized_velocities](const MatrixX<T>& X) -> MatrixX<T> {
     // ************************************************************************
     // See DetermineNewFullInertiaSolveOperator() for block inversion formula.
     // ************************************************************************
 
     // Set the result matrix.
     const int C_rows = num_generalized_velocities;
-    const int E_cols = indep_constraints->size();
+    const int E_cols = num_eq_constraints;
     MatrixX<T> result(C_rows + E_cols, X.cols());
 
     // Begin computation of components of C (upper left hand block of inverse
@@ -461,13 +343,13 @@ void ConstraintSolver<T>::DetermineNewPartialInertiaSolveOperator(
     // Compute G M⁻¹ X
     MatrixX<T> G_iM_X(E_cols, X.cols());
     for (int i = 0; i < X.cols(); ++i)
-      G_iM_X.col(i) = G_mult(iM_X.col(i));
+      G_iM_X.col(i) = problem_data->G_mult(iM_X.col(i));
 
     // Compute (GM⁻¹Gᵀ)⁻¹GM⁻¹X
-    const MatrixX<T> Del_G_iM_X = Del->solve(G_iM_X);
+    const MatrixX<T> Del_G_iM_X = Del_QR->solve(G_iM_X);
 
     // Compute Gᵀ(GM⁻¹Gᵀ)⁻¹GM⁻¹X
-    const MatrixX<T> GT_Del_G_iM_X = G_transpose_mult(Del_G_iM_X);
+    const MatrixX<T> GT_Del_G_iM_X = problem_data->G_transpose_mult(Del_G_iM_X);
 
     // Compute M⁻¹Gᵀ(GM⁻¹Gᵀ)⁻¹GM⁻¹X
     const MatrixX<T> iM_GT_Del_G_iM_X = problem_data->solve_inertia(
@@ -503,14 +385,13 @@ template <typename ProblemData>
 void ConstraintSolver<T>::DetermineNewFullInertiaSolveOperator(
     const ProblemData* problem_data,
     int num_generalized_velocities,
-    const std::vector<int>* indep_constraints,
-    std::function<VectorX<T>(const VectorX<T>&)> G_mult,
-    std::function<VectorX<T>(const VectorX<T>&)> G_transpose_mult,
-    const Eigen::LLT<MatrixX<T>>* Del,
+    const Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>* Del_QR,
     std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const {
-  *A_solve = [problem_data, Del, G_mult, G_transpose_mult,
-      indep_constraints, num_generalized_velocities](const MatrixX<T>& B)
-      -> MatrixX<T> {
+  // Get the number of equality constraints.
+  const int num_eq_constraints = problem_data->kG.size();
+
+  *A_solve = [problem_data, Del_QR, num_eq_constraints,
+              num_generalized_velocities](const MatrixX<T>& B) -> MatrixX<T> {
     // From a block matrix inversion,
     // | M  -Gᵀ |⁻¹ | Y | = |  C  E || Y | = | CY + EZ   |
     // | G'  0  |   | Z |   | -Eᵀ F || Z |   | -EᵀY + FZ |
@@ -523,7 +404,7 @@ void ConstraintSolver<T>::DetermineNewFullInertiaSolveOperator(
 
     // Set the result matrix (X).
     const int C_rows = num_generalized_velocities;
-    const int E_cols = indep_constraints->size();
+    const int E_cols = num_eq_constraints;
     MatrixX<T> X(C_rows + E_cols, B.cols());
 
     // Name the blocks of B and X.
@@ -539,13 +420,13 @@ void ConstraintSolver<T>::DetermineNewFullInertiaSolveOperator(
     // Compute G M⁻¹ Y
     MatrixX<T> G_iM_Y(E_cols, Y.cols());
     for (int i = 0; i < Y.cols(); ++i)
-      G_iM_Y.col(i) = G_mult(iM_Y.col(i));
+      G_iM_Y.col(i) = problem_data->G_mult(iM_Y.col(i));
 
     // Compute (GM⁻¹Gᵀ)⁻¹GM⁻¹Y
-    const MatrixX<T> Del_G_iM_Y = Del->solve(G_iM_Y);
+    const MatrixX<T> Del_G_iM_Y = Del_QR->solve(G_iM_Y);
 
     // Compute Gᵀ(GM⁻¹Gᵀ)⁻¹GM⁻¹Y
-    const MatrixX<T> GT_Del_G_iM_Y = G_transpose_mult(Del_G_iM_Y);
+    const MatrixX<T> GT_Del_G_iM_Y = problem_data->G_transpose_mult(Del_G_iM_Y);
 
     // Compute M⁻¹Gᵀ(GM⁻¹Gᵀ)⁻¹GM⁻¹Y
     const MatrixX<T> iM_GT_Del_G_iM_Y = problem_data->solve_inertia(
@@ -553,10 +434,10 @@ void ConstraintSolver<T>::DetermineNewFullInertiaSolveOperator(
 
     // 2. Begin computation of components of E
     // Compute (GM⁻¹Gᵀ)⁻¹Z
-    const MatrixX<T> Del_Z = Del->solve(Z);
+    const MatrixX<T> Del_Z = Del_QR->solve(Z);
 
     // Compute Gᵀ(GM⁻¹Gᵀ)⁻¹Z
-    const MatrixX<T> GT_Del_Z = G_transpose_mult(Del_Z);
+    const MatrixX<T> GT_Del_Z = problem_data->G_transpose_mult(Del_Z);
 
     // Compute M⁻¹Gᵀ(GM⁻¹Gᵀ)⁻¹Z = EZ
     const MatrixX<T> iM_GT_Del_Z = problem_data->solve_inertia(GT_Del_Z);
@@ -565,7 +446,7 @@ void ConstraintSolver<T>::DetermineNewFullInertiaSolveOperator(
     X_top = problem_data->solve_inertia(Y) - iM_GT_Del_G_iM_Y + iM_GT_Del_Z;
 
     // Set the bottom block of the result.
-    X_bot = Del->solve(Z) - Del_G_iM_Y;
+    X_bot = Del_QR->solve(Z) - Del_G_iM_Y;
 
     return X;
   };
@@ -575,14 +456,16 @@ template <typename T>
 template <typename ProblemData>
 ProblemData* ConstraintSolver<T>::UpdateProblemDataForUnilateralConstraints(
     const ProblemData& problem_data,
-    const std::vector<int>& indep_constraints,
     std::function<const MatrixX<T>(const MatrixX<T>&)> modified_inertia_solve,
     ProblemData* modified_problem_data) const {
   // Verify that the modified problem data points to something.
   DRAKE_DEMAND(modified_problem_data);
 
+  // Get the number of equality constraints.
+  const int num_eq_constraints = problem_data.kG.size();
+
   // Construct a new problem data.
-  if (indep_constraints.empty()) {
+  if (num_eq_constraints == 0) {
     // Just point to the original problem data.
     return const_cast<ProblemData*>(&problem_data);
   } else {
@@ -592,11 +475,6 @@ ProblemData* ConstraintSolver<T>::UpdateProblemDataForUnilateralConstraints(
 
     // Copy most of the data unchanged.
     new_data = problem_data;
-
-    // Update kG.
-    new_data.kG.resize(indep_constraints.size());
-    for (int i = 0; i < static_cast<int>(indep_constraints.size()); ++i)
-      new_data.kG[i] = problem_data.kG[indep_constraints[i]];
 
     // Update the inertia function pointer.
     new_data.solve_inertia = modified_inertia_solve;
@@ -744,45 +622,52 @@ void ConstraintSolver<T>::SolveConstraintProblem(
   // are dependent upon time (e.g., prescribed motion constraints) might not be
   // fully satisfiable.
 
-  // Determine the set of linearly independent constraints.
-  std::vector<int> indep_constraints;
-  Eigen::LLT<MatrixX<T>> Del;
-  std::function<VectorX<T>(const VectorX<T>&)> G_mult, G_transpose_mult;
-  DetermineIndependentConstraints(num_generalized_velocities, &problem_data,
-                                  &indep_constraints, &G_mult,
-                                  &G_transpose_mult, &Del);
+  // Form the Delassus matrix for the bilateral constraints.
+  MatrixX<T> Del(num_eq_constraints, num_eq_constraints);
+  MatrixX<T> iM_GT(num_generalized_velocities, num_eq_constraints);
+  ComputeInverseInertiaTimesGT(problem_data.solve_inertia,
+                               problem_data.G_transpose_mult,
+                               num_eq_constraints, &iM_GT);
+  ComputeConstraintSpaceComplianceMatrix(problem_data.G_mult,
+                                         num_eq_constraints,
+                                         iM_GT, Del);
+
+  // Compute the complete orthogonal factorization. 
+  std::unique_ptr<Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>> Del_QR;
+  if (Del.rows() > 0) {
+    Del_QR = std::make_unique<
+      Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>>(Del);
+  }
 
   // Determine a new "inertia" solve operator, which solves AX = B, where
   // A = | M  -Gᵀ |
   //     | G   0  |
-  // using the newly reduced set of constraints. This will allow transforming
-  // the mixed LCP into a pure LCP.
+  // using a least-squares solution to accommodate rank-deficiency in G. This
+  // will allow transforming the mixed LCP into a pure LCP.
   std::function<MatrixX<T>(const MatrixX<T>&)> A_solve;
   DetermineNewFullInertiaSolveOperator(
-      &problem_data, num_generalized_velocities, &indep_constraints, G_mult,
-      G_transpose_mult, &Del, &A_solve);
-  if (indep_constraints.empty())
+      &problem_data, num_generalized_velocities, Del_QR.get(), &A_solve);
+  if (num_eq_constraints == 0)
     A_solve = problem_data.solve_inertia;
 
   // Determine a new "inertia" solve operator, using only the upper left block
   // of A⁻¹ (denoted C above) to exploit zero blocks in common operations.
   std::function<MatrixX<T>(const MatrixX<T>&)> fast_A_solve;
   DetermineNewPartialInertiaSolveOperator(
-      &problem_data, num_generalized_velocities, &indep_constraints, G_mult,
-      G_transpose_mult, &Del, &fast_A_solve);
+      &problem_data, num_generalized_velocities, Del_QR.get(), &fast_A_solve);
 
   // Copy the problem data and then update it to account for bilateral
   // constraints.
   ConstraintAccelProblemData<T> modified_problem_data(
-      problem_data.tau.size() + indep_constraints.size());
+      problem_data.tau.size() + num_eq_constraints);
   ConstraintAccelProblemData<T>* data_ptr = &modified_problem_data;
   data_ptr = UpdateProblemDataForUnilateralConstraints(
-      problem_data, indep_constraints, fast_A_solve, data_ptr);
+      problem_data, fast_A_solve, data_ptr);
 
   // Compute a and A⁻¹a.
-  VectorX<T> a(problem_data.tau.size() + indep_constraints.size());
+  VectorX<T> a(problem_data.tau.size() + num_eq_constraints);
   a.head(problem_data.tau.size()) = -problem_data.tau;
-  a.tail(indep_constraints.size()) = data_ptr->kG;
+  a.tail(num_eq_constraints) = data_ptr->kG;
   const VectorX<T> invA_a = A_solve(a);
   const VectorX<T> trunc_neg_invA_a = -invA_a.head(problem_data.tau.size());
 
@@ -846,7 +731,7 @@ void ConstraintSolver<T>::SolveConstraintProblem(
   // allowing the mixed LCP to be converted to a "pure" LCP (q, M) by:
   // q = b - DA⁻¹a
   // M = B - DA⁻¹C
-  if (indep_constraints.size() > 0) {
+  if (num_eq_constraints > 0) {
     // In this case, Xv = -(Nᵀ + μQᵀ)fN - DᵀfD - LᵀfL and a = | -f |.
     //                                                        | kG |
     const VectorX<T> Xv = -data_ptr->N_minus_muQ_transpose_mult(fN)
@@ -857,11 +742,7 @@ void ConstraintSolver<T>::SolveConstraintProblem(
     const VectorX<T> u = -A_solve(aug);
     auto lambda = cf->segment(
         num_contacts + num_spanning_vectors + num_limits, num_eq_constraints);
-    lambda.setZero();
-    for (int i = 0, j = problem_data.tau.size();
-         i < static_cast<int>(indep_constraints.size()); ++i, ++j) {
-      lambda[indep_constraints[i]] = u[j];
-    }
+    lambda = u.tail(num_eq_constraints);
   }
 }
 
@@ -1002,13 +883,23 @@ void ConstraintSolver<T>::SolveImpactProblem(
   // are dependent upon time (e.g., prescribed motion constraints) might not be
   // fully satisfiable.
 
-  // Determine the set of linearly independent constraints.
-  std::vector<int> indep_constraints;
-  Eigen::LLT<MatrixX<T>> Del;
-  std::function<VectorX<T>(const VectorX<T>&)> G_mult, G_transpose_mult;
-  DetermineIndependentConstraints(num_generalized_velocities, &problem_data,
-                                  &indep_constraints, &G_mult,
-                                  &G_transpose_mult, &Del);
+  // Form the Delassus matrix for the bilateral constraints.
+  MatrixX<T> Del(num_eq_constraints, num_eq_constraints);
+  MatrixX<T> iM_GT(num_generalized_velocities, num_eq_constraints);
+  ComputeInverseInertiaTimesGT(problem_data.solve_inertia,
+                               problem_data.G_transpose_mult,
+                               num_eq_constraints, &iM_GT);
+  ComputeConstraintSpaceComplianceMatrix(problem_data.G_mult,
+                                         num_eq_constraints,
+                                         iM_GT, Del);
+
+  // Compute the complete orthogonal factorization. 
+  std::unique_ptr<Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>> Del_QR;
+  if (Del.rows() > 0) {
+    Del_QR = std::make_unique<
+      Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>>(Del);
+  }
+
 
   // Determine a new "inertia" solve operator, which solves AX = B, where
   // A = | M  -Gᵀ |
@@ -1017,25 +908,23 @@ void ConstraintSolver<T>::SolveImpactProblem(
   // the mixed LCP into a pure LCP.
   std::function<MatrixX<T>(const MatrixX<T>&)> A_solve;
   DetermineNewFullInertiaSolveOperator(
-      &problem_data, num_generalized_velocities, &indep_constraints, G_mult,
-      G_transpose_mult, &Del, &A_solve);
-  if (indep_constraints.empty())
+      &problem_data, num_generalized_velocities, Del_QR.get(), &A_solve);
+  if (num_eq_constraints == 0)
     A_solve = problem_data.solve_inertia;
 
   // Determine a new "inertia" solve operator, using only the upper left block
   // of A⁻¹ to exploit zeros in common operations.
   std::function<MatrixX<T>(const MatrixX<T>&)> fast_A_solve;
   DetermineNewPartialInertiaSolveOperator(
-      &problem_data, num_generalized_velocities, &indep_constraints, G_mult,
-      G_transpose_mult, &Del, &fast_A_solve);
+      &problem_data, num_generalized_velocities, Del_QR.get(), &fast_A_solve);
 
   // Copy the problem data and then update it to account for bilateral
   // constraints.
   ConstraintVelProblemData<T> modified_problem_data(
-      problem_data.v.size() + indep_constraints.size());
+      problem_data.v.size() + num_eq_constraints);
   ConstraintVelProblemData<T>* data_ptr = &modified_problem_data;
   data_ptr = UpdateProblemDataForUnilateralConstraints(
-      problem_data, indep_constraints, fast_A_solve, data_ptr);
+      problem_data, fast_A_solve, data_ptr);
 
   // Compute a and A⁻¹a.
   // TODO(edrumwri): Replace this nasty operation by replacing v in problem
@@ -1046,9 +935,9 @@ void ConstraintSolver<T>::SolveImpactProblem(
   Eigen::LLT<MatrixX<T>> inv_M_llt(inv_M);
   DRAKE_DEMAND(inv_M_llt.info() == Eigen::Success);
   VectorX<T> Mv = inv_M_llt.solve(problem_data.v);
-  VectorX<T> a(problem_data.v.size() + indep_constraints.size());
+  VectorX<T> a(problem_data.v.size() + num_eq_constraints);
   a.head(problem_data.v.size()) = -Mv;
-  a.tail(indep_constraints.size()) = data_ptr->kG;
+  a.tail(num_eq_constraints) = data_ptr->kG;
   const VectorX<T> invA_a = A_solve(a);
   const VectorX<T> trunc_neg_invA_a = -invA_a.head(problem_data.v.size());
 
@@ -1082,8 +971,16 @@ void ConstraintSolver<T>::SolveImpactProblem(
         ww.minCoeff() < -num_vars * npivots * zero_tol ||
         max_dot > max(T(1), zz.maxCoeff()) * max(T(1), ww.maxCoeff()) *
             num_vars * npivots * zero_tol))) {
+    SPDLOG_DEBUG(drake::log(), "LCP matrix: {}", MM);
+    SPDLOG_DEBUG(drake::log(), "LCP vector: {}", qq);
+/*
     throw std::runtime_error("Unable to solve LCP- more regularization might "
                                  "be necessary.");
+*/
+    const int min_exp = -20;
+    const int step_exp = 1;
+    const int max_exp = +20;
+    lcp_.SolveLcpLemkeRegularized(MM, qq, &zz, min_exp, step_exp, max_exp, -1, zero_tol);
   }
 
   // Alias constraint force segments.
@@ -1099,6 +996,11 @@ void ConstraintSolver<T>::SolveImpactProblem(
   cf->segment(0, num_contacts) = fN;
   cf->segment(num_contacts, num_spanning_vectors) = fD_plus - fD_minus;
   cf->segment(num_contacts + num_spanning_vectors, num_limits) = fL;
+  SPDLOG_DEBUG(drake::log(), "Normal contact impulses: {}", fN.transpose());
+  SPDLOG_DEBUG(drake::log(), "Frictional contact impulses: {}",
+               (fD_plus - fD_minus).transpose());
+  SPDLOG_DEBUG(drake::log(), "Generic unilateral constraint impulses: {}",
+               fL.transpose());
 
   // Determine the new velocity and the bilateral constraint impulses.
   //     Au + Xv + a = 0
@@ -1112,7 +1014,7 @@ void ConstraintSolver<T>::SolveImpactProblem(
   // allowing the mixed LCP to be converted to a "pure" LCP (q, M) by:
   // q = b - DA⁻¹a
   // M = B - DA⁻¹C
-  if (indep_constraints.size() > 0) {
+  if (num_eq_constraints > 0) {
     // In this case, Xv = -NᵀfN - DᵀfD -LᵀfL and a = | -Mv(t) |.
     //                                               |   kG   |
     const VectorX<T> Xv = -data_ptr->N_transpose_mult(fN)
@@ -1123,11 +1025,9 @@ void ConstraintSolver<T>::SolveImpactProblem(
     const VectorX<T> u = -A_solve(aug);
     auto lambda = cf->segment(
         num_contacts + num_spanning_vectors + num_limits, num_eq_constraints);
-    lambda.setZero();
-    for (int i = 0, j = problem_data.v.size();
-         i < static_cast<int>(indep_constraints.size()); ++i, ++j) {
-      lambda[indep_constraints[i]] = u[j];
-    }
+    lambda = u.tail(num_eq_constraints);
+    SPDLOG_DEBUG(drake::log(), "Bilateral constraint impulses: {}",
+                 lambda.transpose());
   }
 }
 
@@ -1335,6 +1235,7 @@ void ConstraintSolver<T>::FormSustainedConstraintLCP(
   // 0
   // L⋅A⁻¹⋅a + kL
   // where, as above, D is defined as [F -F] (and kD is defined as [kF -kF].
+  VectorX<T> M_inv_x_f = problem_data.solve_inertia(problem_data.tau);
   qq->resize(num_vars, 1);
   qq->segment(0, nc) = N(trunc_neg_invA_a) + kN;
   qq->segment(nc, nr) = F(trunc_neg_invA_a) + kF;

--- a/drake/multibody/constraint/constraint_solver.h
+++ b/drake/multibody/constraint/constraint_solver.h
@@ -325,7 +325,7 @@ void ConstraintSolver<T>::DetermineNewPartialInertiaSolveOperator(
     std::function<MatrixX<T>(const MatrixX<T>&)>* A_solve) const {
   const int num_eq_constraints = problem_data->kG.size();
 
-  *A_solve = [problem_data, Del_QR, num_eq_constraints, 
+  *A_solve = [problem_data, Del_QR, num_eq_constraints,
               num_generalized_velocities](const MatrixX<T>& X) -> MatrixX<T> {
     // ************************************************************************
     // See DetermineNewFullInertiaSolveOperator() for block inversion formula.
@@ -632,7 +632,7 @@ void ConstraintSolver<T>::SolveConstraintProblem(
                                          num_eq_constraints,
                                          iM_GT, Del);
 
-  // Compute the complete orthogonal factorization. 
+  // Compute the complete orthogonal factorization.
   std::unique_ptr<Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>> Del_QR;
   if (Del.rows() > 0) {
     Del_QR = std::make_unique<
@@ -893,7 +893,7 @@ void ConstraintSolver<T>::SolveImpactProblem(
                                          num_eq_constraints,
                                          iM_GT, Del);
 
-  // Compute the complete orthogonal factorization. 
+  // Compute the complete orthogonal factorization.
   std::unique_ptr<Eigen::CompleteOrthogonalDecomposition<MatrixX<T>>> Del_QR;
   if (Del.rows() > 0) {
     Del_QR = std::make_unique<
@@ -971,16 +971,8 @@ void ConstraintSolver<T>::SolveImpactProblem(
         ww.minCoeff() < -num_vars * npivots * zero_tol ||
         max_dot > max(T(1), zz.maxCoeff()) * max(T(1), ww.maxCoeff()) *
             num_vars * npivots * zero_tol))) {
-    SPDLOG_DEBUG(drake::log(), "LCP matrix: {}", MM);
-    SPDLOG_DEBUG(drake::log(), "LCP vector: {}", qq);
-/*
     throw std::runtime_error("Unable to solve LCP- more regularization might "
                                  "be necessary.");
-*/
-    const int min_exp = -20;
-    const int step_exp = 1;
-    const int max_exp = +20;
-    lcp_.SolveLcpLemkeRegularized(MM, qq, &zz, min_exp, step_exp, max_exp, -1, zero_tol);
   }
 
   // Alias constraint force segments.

--- a/drake/multibody/constraint/constraint_solver.h
+++ b/drake/multibody/constraint/constraint_solver.h
@@ -306,9 +306,9 @@ class ConstraintSolver {
 // @param num_generalized_velocities The dimension of the system generalized
 //        velocities.
 // @param problem_data The constraint problem data.
-// @param Del The factorization of the Delassus Matrix GM⁻¹Gᵀ,
-//            where G is the constraint Jacobian corresponding to the
-//            independent constraints.
+// @param Del_QR The factorization of the Delassus Matrix GM⁻¹Gᵀ,
+//               where G is the constraint Jacobian corresponding to the
+//               independent constraints.
 // @param[out] A_solve The operator for solving AX = B, on return.
 template <typename T>
 template <typename ProblemData>
@@ -364,9 +364,9 @@ void ConstraintSolver<T>::DetermineNewPartialInertiaSolveOperator(
 // @param num_generalized_velocities The dimension of the system generalized
 //        velocities.
 // @param problem_data The constraint problem data.
-// @param Del The factorization of the Delassus Matrix GM⁻¹Gᵀ,
-//            where G is the constraint Jacobian corresponding to the
-//            independent constraints.
+// @param Del_QR The factorization of the Delassus Matrix GM⁻¹Gᵀ,
+//               where G is the constraint Jacobian corresponding to the
+//               independent constraints.
 // @param[out] A_solve The operator for solving AX = B, on return.
 template <typename T>
 template <typename ProblemData>

--- a/drake/multibody/constraint/constraint_solver.h
+++ b/drake/multibody/constraint/constraint_solver.h
@@ -1227,7 +1227,6 @@ void ConstraintSolver<T>::FormSustainedConstraintLCP(
   // 0
   // L⋅A⁻¹⋅a + kL
   // where, as above, D is defined as [F -F] (and kD is defined as [kF -kF].
-  VectorX<T> M_inv_x_f = problem_data.solve_inertia(problem_data.tau);
   qq->resize(num_vars, 1);
   qq->segment(0, nc) = N(trunc_neg_invA_a) + kN;
   qq->segment(nc, nr) = F(trunc_neg_invA_a) + kF;


### PR DESCRIPTION
The mixed linear complementarity problem with potentially rank-deficient bilateral constraint Jacobian had been addressed by determining a minimum set of nonredundant constraints using repeated Cholesky factorizations. The time complexity was not problematic- particularly if we were to use rank-1 Cholesky updates, which we were not- but it was certainly less efficient than desired to do repeated Cholesky factorizations from scratch. 

This PR uses the complete orthogonal factorization instead, thereby simplifying the code considerably and conferring the side benefit of determining a minimum-norm bilateral constraint solution. We hadn't adopted this approach previously because it appeared that we would have to do a full factorization of the blocked saddle point matrix containing the generalized inertia (which would thus preclude the speedup from the O(N) time dynamics algorithms). This new strategy allows our block inversion strategy to make use of the fact that all necessary computations are of the form (GM⁻¹Gᵀ)⁻¹G, meaning that the less-than-full row rank of G is inconsequential.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7263)
<!-- Reviewable:end -->
