### PR TITLE
Add missing stx dependency

### DIFF
--- a/tools/drake.cps
+++ b/tools/drake.cps
@@ -98,6 +98,7 @@
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "SDFormat:sdformat",
         "spdlog:spdlog",
+        "stx:stx",
         "yaml-cpp:yaml-cpp"
       ]
     },


### PR DESCRIPTION
PR #7241 broke the CMake installation.  PR #7247 fixed one error; this PR fixes another. Issue #7260 tracks the need for CI coverage to avoid this in the future.

PR #7257 proposes a related change to the `stx` include paths, but I'd like to get my dependency mistake fixed with high priority; we can debate the include path changes in due time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7265)
<!-- Reviewable:end -->
