### PR TITLE
Add Jaco lcmtypes and send/receive systems

### DIFF
--- a/drake/examples/kinova_jaco_arm/BUILD.bazel
+++ b/drake/examples/kinova_jaco_arm/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "//tools:drake.bzl",
     "drake_cc_library",
     "drake_cc_binary",
+    "drake_cc_googletest",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
@@ -22,6 +23,16 @@ drake_cc_library(
     deps = [
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody/parsers",
+    ],
+)
+
+drake_cc_library(
+    name = "jaco_lcm",
+    srcs = ["jaco_lcm.cc"],
+    hdrs = ["jaco_lcm.h"],
+    deps = [
+        "//drake/lcmtypes:jaco",
+        "//drake/systems/framework:leaf_system",
     ],
 )
 
@@ -94,6 +105,17 @@ drake_cc_binary(
         "//drake/systems/controllers:inverse_dynamics_controller",
         "//drake/systems/primitives:trajectory_source",
         "@com_github_gflags_gflags//:gflags",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "jaco_lcm_test",
+    deps = [
+        ":jaco_lcm",
+        "//drake/systems/framework:diagram",
+        "//drake/systems/framework:diagram_builder",
     ],
 )
 

--- a/drake/examples/kinova_jaco_arm/jaco_lcm.cc
+++ b/drake/examples/kinova_jaco_arm/jaco_lcm.cc
@@ -1,0 +1,233 @@
+#include "drake/examples/kinova_jaco_arm/jaco_lcm.h"
+
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/lcmt_jaco_command.hpp"
+#include "drake/lcmt_jaco_status.hpp"
+
+namespace drake {
+namespace examples {
+namespace kinova_jaco_arm {
+
+using systems::BasicVector;
+using systems::Context;
+using systems::DiscreteValues;
+using systems::DiscreteUpdateEvent;
+
+namespace {
+// Kinova's JACO urdf's have a 0-114 degree (0-2 radian) range for the
+// finger joints, but the SDK's position values range from 0-6800
+// degrees (0-118.68 radian), which I suspect is the speed of the
+// motor driving the finger actuator (it's certainly not the angle of
+// the finger joint).  Convert these as appropriate here.  I
+// (sam.creasey) still don't think we wind up with the correct
+// simulated position vs. where the actual fingers are at the same
+// commanded value, but it's a start.
+constexpr double kFingerSdkToUrdf = 2. / 118.68;
+constexpr double kFingerUrdfToSdk = 118.68 / 2.;
+}  // namespace
+
+JacoCommandReceiver::JacoCommandReceiver(int num_joints, int num_fingers)
+    : num_joints_(num_joints),
+      num_fingers_(num_fingers) {
+  this->DeclareAbstractInputPort();
+  this->DeclareVectorOutputPort(
+      systems::BasicVector<double>((num_joints_ + num_fingers_) * 2),
+      &JacoCommandReceiver::OutputCommand);
+  this->DeclarePeriodicDiscreteUpdate(kJacoLcmStatusPeriod);
+  this->DeclareDiscreteState((num_joints_ + num_fingers_) * 2);
+}
+
+void JacoCommandReceiver::set_initial_position(
+    Context<double>* context,
+    const Eigen::Ref<const VectorX<double>> x) const {
+  auto state_value =
+      context->get_mutable_discrete_state(0)->get_mutable_value();
+  DRAKE_ASSERT(x.size() == num_joints_ + num_fingers_);
+  state_value.head(num_joints_ + num_fingers_) = x;
+  state_value.tail(num_joints_ + num_fingers_) =
+      VectorX<double>::Zero(num_joints_ + num_fingers_);
+}
+
+void JacoCommandReceiver::DoCalcDiscreteVariableUpdates(
+    const Context<double>& context,
+    const std::vector<const DiscreteUpdateEvent<double>*>&,
+    DiscreteValues<double>* discrete_state) const {
+  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
+  DRAKE_ASSERT(input != nullptr);
+  const auto& command = input->GetValue<lcmt_jaco_command>();
+
+  // If we're using a default constructed message (haven't received
+  // a command yet), keep using the initial state.
+  BasicVector<double>* state = discrete_state->get_mutable_vector(0);
+  auto state_value = state->get_mutable_value();
+  auto velocities = state_value.tail(num_joints_ + num_fingers_);
+
+  DRAKE_DEMAND(command.num_joints == 0 || command.num_joints == num_joints_);
+  DRAKE_DEMAND(command.num_fingers == 0 || command.num_fingers == num_fingers_);
+
+  for (int i = 0; i < command.num_joints; ++i) {
+    state_value(i) = command.joint_position[i];
+    velocities(i) = command.joint_velocity[i];
+  }
+
+  for (int i = 0; i < command.num_fingers; ++i) {
+    state_value(i + num_joints_) =
+        command.finger_position[i] * kFingerSdkToUrdf;
+    velocities(i + num_joints_) =
+        command.finger_velocity[i] * kFingerSdkToUrdf;
+  }
+}
+
+void JacoCommandReceiver::OutputCommand(const Context<double>& context,
+                                        BasicVector<double>* output) const {
+  Eigen::VectorBlock<VectorX<double>> output_vec =
+      output->get_mutable_value();
+  output_vec = context.get_discrete_state(0)->get_value();
+}
+
+JacoCommandSender::JacoCommandSender(int num_joints, int num_fingers)
+    : num_joints_(num_joints),
+      num_fingers_(num_fingers) {
+  this->DeclareInputPort(systems::kVectorValued,
+                         (num_joints_ + num_fingers_) * 2);
+  this->DeclareAbstractOutputPort(&JacoCommandSender::OutputCommand);
+}
+
+void JacoCommandSender::OutputCommand(
+    const Context<double>& context, lcmt_jaco_command* output) const {
+
+  output->utime = context.get_time() * 1e6;
+  const systems::BasicVector<double>* input =
+      this->EvalVectorInput(context, 0);
+
+  output->num_joints = num_joints_;
+  output->joint_position.resize(num_joints_);
+  output->joint_velocity.resize(num_joints_);
+  for (int i = 0; i < num_joints_; ++i) {
+    output->joint_position[i] = input->GetAtIndex(i);
+    output->joint_velocity[i] = input->GetAtIndex(
+        i + num_joints_ + num_fingers_);
+  }
+
+  output->num_fingers = num_fingers_;
+  output->finger_position.resize(num_fingers_);
+  output->finger_velocity.resize(num_fingers_);
+  for (int i = 0; i < num_fingers_; ++i) {
+    output->finger_position[i] =
+        input->GetAtIndex(i + num_joints_) * kFingerUrdfToSdk;
+    output->finger_velocity[i] = input->GetAtIndex(
+        i + num_joints_ * 2 + num_fingers_)* kFingerUrdfToSdk;
+  }
+}
+
+JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
+    : num_joints_(num_joints),
+      num_fingers_(num_fingers) {
+  this->DeclareVectorOutputPort(
+      systems::BasicVector<double>((num_joints_ + num_fingers_) * 2),
+      &JacoStatusReceiver::OutputStatus);
+  this->DeclareAbstractInputPort();
+  this->DeclareDiscreteState((num_joints_ + num_fingers_)* 2);
+  this->DeclarePeriodicDiscreteUpdate(kJacoLcmStatusPeriod);
+}
+
+void JacoStatusReceiver::DoCalcDiscreteVariableUpdates(
+    const Context<double>& context,
+    const std::vector<const DiscreteUpdateEvent<double>*>&,
+    DiscreteValues<double>* discrete_state) const {
+  const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
+  DRAKE_ASSERT(input != nullptr);
+  const auto& status = input->GetValue<lcmt_jaco_status>();
+
+  BasicVector<double>* state = discrete_state->get_mutable_vector(0);
+  auto state_value = state->get_mutable_value();
+  auto velocities = state_value.tail(num_joints_ + num_fingers_);
+
+  DRAKE_DEMAND(status.num_joints == 0 || status.num_joints == num_joints_);
+  DRAKE_DEMAND(status.num_fingers == 0 || status.num_fingers == num_fingers_);
+
+  for (int i = 0; i < status.num_joints; ++i) {
+    state_value(i) = status.joint_position[i];
+    // It seems like the Jaco reports half of the actual angular
+    // velocity.  Fix that up here.  Note bug-for-bug compatibility
+    // implemented in JacoStatusSender.
+    velocities(i) = status.joint_velocity[i] * 2;
+  }
+
+  for (int i = 0; i < status.num_fingers; ++i) {
+    state_value(i + num_joints_) =
+        status.finger_position[i] * kFingerSdkToUrdf;
+    // The reported finger velocities are completely bogus.  I
+    // (sam.creasey) am not sure that passing them on here is even
+    // useful.
+    velocities(i + num_joints_) =
+        status.finger_velocity[i] * kFingerSdkToUrdf;
+  }
+}
+
+void JacoStatusReceiver::OutputStatus(const Context<double>& context,
+                                      BasicVector<double>* output) const {
+  Eigen::VectorBlock<VectorX<double>> output_vec =
+      output->get_mutable_value();
+  output_vec = context.get_discrete_state(0)->get_value();
+}
+
+JacoStatusSender::JacoStatusSender(int num_joints, int num_fingers)
+    : num_joints_(num_joints),
+      num_fingers_(num_fingers) {
+  this->DeclareInputPort(systems::kVectorValued,
+                         (num_joints_ + num_fingers_) * 2);
+  this->DeclareAbstractOutputPort(&JacoStatusSender::MakeOutputStatus,
+                                  &JacoStatusSender::OutputStatus);
+}
+
+lcmt_jaco_status JacoStatusSender::MakeOutputStatus() const {
+  lcmt_jaco_status msg{};
+  msg.utime = 0;
+  msg.num_joints = num_joints_;
+  msg.num_fingers = num_fingers_;
+  msg.joint_position.resize(msg.num_joints, 0);
+  msg.joint_velocity.resize(msg.num_joints, 0);
+  msg.joint_torque.resize(msg.num_joints, 0);
+  msg.joint_current.resize(msg.num_joints, 0);
+  msg.finger_position.resize(msg.num_fingers, 0);
+  msg.finger_velocity.resize(msg.num_fingers, 0);
+  msg.finger_torque.resize(msg.num_fingers, 0);
+  msg.finger_current.resize(msg.num_fingers, 0);
+  return msg;
+}
+
+void JacoStatusSender::OutputStatus(
+    const Context<double>& context, lcmt_jaco_status* output) const {
+  output->utime = context.get_time() * 1e6;
+  const systems::BasicVector<double>* input =
+      this->EvalVectorInput(context, 0);
+
+  output->num_joints = num_joints_;
+  output->joint_position.resize(num_joints_);
+  output->joint_velocity.resize(num_joints_);
+  for (int i = 0; i < num_joints_; ++i) {
+    output->joint_position[i] = input->GetAtIndex(i);
+    // It seems like the Jaco reports half of the actual angular
+    // velocity.  Simulate that here.  Note this is also handled in
+    // JacoStatusReceiver.
+    output->joint_velocity[i] =
+        input->GetAtIndex(i + num_joints_ + num_fingers_) / 2;
+  }
+
+  output->num_fingers = num_fingers_;
+  output->finger_position.resize(num_fingers_);
+  output->finger_velocity.resize(num_fingers_);
+  for (int i = 0; i < num_fingers_; ++i) {
+    output->finger_position[i] =
+        input->GetAtIndex(i + num_joints_) * kFingerUrdfToSdk;
+    output->finger_velocity[i] = input->GetAtIndex(
+        i + num_joints_ * 2 + num_fingers_) * kFingerUrdfToSdk;
+  }
+}
+
+}  // namespace kinova_jaco_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kinova_jaco_arm/jaco_lcm.h
+++ b/drake/examples/kinova_jaco_arm/jaco_lcm.h
@@ -1,0 +1,182 @@
+#pragma once
+
+/// @file
+/// This file contains classes dealing with sending/receiving
+/// LCM messages related to the jaco arm.
+///
+/// All (q, v) state vectors in this file are of the format
+/// (joint_positions, finger_positions, joint_velocities,
+/// finger_velocities).
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/lcmt_jaco_command.hpp"
+#include "drake/lcmt_jaco_status.hpp"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace examples {
+namespace kinova_jaco_arm {
+
+/// The LCM system classes for the Jaco default to a 7dof model with 3
+/// fingers.  Different configurations are supported by passing the
+/// proper arguments to the system constructors.
+constexpr int kJacoDefaultArmNumJoints = 7;
+constexpr int kJacoDefaultArmNumFingers = 3;
+
+/// Kinova says 100Hz is the proper frequency for joint velocity
+/// updates.  See
+/// https://github.com/Kinovarobotics/kinova-ros#velocity-control-joint-space-and-cartesian-space
+constexpr double kJacoLcmStatusPeriod = 0.010;
+
+/// Handles lcmt_jaco_command messages from a LcmSubscriberSystem.
+///
+/// This system has one abstract valued input port which expects a
+/// systems::Value object templated on type `lcmt_jaco_command`.
+///
+/// This system has a single output port which publishes the commanded
+/// position and velocity for each joint.
+class JacoCommandReceiver : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JacoCommandReceiver)
+
+  /// @param num_joints The number of joints on the arm (typically 6
+  /// or 7).
+  ///
+  /// @param num_fingers The number of fingers on the gripper
+  /// (typically 2 or 3).
+  explicit JacoCommandReceiver(int num_joints = kJacoDefaultArmNumJoints,
+                               int num_fingers = kJacoDefaultArmNumFingers);
+
+  /// Sets the initial position of the controlled jaco prior to any
+  /// commands being received.  @p x contains the starting position.
+  /// This position will be the commanded position (with zero
+  /// velocity) until a position message is received.  If this
+  /// function is not called, the starting position will be the zero
+  /// configuration.
+  void set_initial_position(
+      systems::Context<double>* context,
+      const Eigen::Ref<const VectorX<double>> x) const;
+
+ private:
+  void OutputCommand(const systems::Context<double>& context,
+                     systems::BasicVector<double>* output) const;
+
+  void DoCalcDiscreteVariableUpdates(
+      const systems::Context<double>& context,
+      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
+      systems::DiscreteValues<double>* discrete_state) const override;
+
+ private:
+  const int num_joints_;
+  const int num_fingers_;
+};
+
+/// Creates and outputs lcmt_jaco_command messages
+///
+/// This system has one vector-valued input port containing the
+/// desired position and velocity.
+///
+/// This system has one abstract valued output port that contains a
+/// systems::Value object templated on type `lcmt_jaco_command`. Note
+/// that this system does not actually send this message on an LCM
+/// channel. To send the message, the output of this system should be
+/// connected to an input port of a systems::lcm::LcmPublisherSystem
+/// that accepts a systems::Value object templated on type
+/// `lcmt_jaco_command`.
+class JacoCommandSender : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JacoCommandSender)
+
+  /// @param num_joints The number of joints on the arm (typically 6
+  /// or 7).
+  ///
+  /// @param num_fingers The number of fingers on the gripper
+  /// (typically 2 or 3).
+  explicit JacoCommandSender(int num_joints = kJacoDefaultArmNumJoints,
+                             int num_fingers = kJacoDefaultArmNumFingers);
+
+ private:
+  void OutputCommand(const systems::Context<double>& context,
+                     lcmt_jaco_command* output) const;
+
+  const int num_joints_;
+  const int num_fingers_;
+};
+
+/// Handles lcmt_jaco_status messages from a LcmSubscriberSystem.
+///
+/// This system has one abstract valued input port which expects a
+/// systems::Value object templated on type `lcmt_jaco_status`.
+///
+/// This system has one vector valued output port which reports
+/// measured position and velocity for each joint and finger.
+///
+/// All ports will continue to output their initial state (typically
+/// zero) until a message is received.
+class JacoStatusReceiver : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JacoStatusReceiver)
+
+  /// @param num_joints The number of joints on the arm (typically 6
+  /// or 7).
+  ///
+  /// @param num_fingers The number of fingers on the gripper
+  /// (typically 2 or 3).
+  explicit JacoStatusReceiver(int num_joints = kJacoDefaultArmNumJoints,
+                              int num_fingers = kJacoDefaultArmNumFingers);
+
+ private:
+  void OutputStatus(const systems::Context<double>& context,
+                    systems::BasicVector<double>* output) const;
+
+  void DoCalcDiscreteVariableUpdates(
+      const systems::Context<double>& context,
+      const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
+      systems::DiscreteValues<double>* discrete_state) const override;
+
+  const int num_joints_;
+  const int num_fingers_;
+};
+
+/// Creates and outputs lcmt_jaco_status messages.
+///
+/// This system has one vector-valued input port containing the
+/// current position and velocity.
+///
+/// This system has one abstract valued output port that contains a
+/// systems::Value object templated on type `lcmt_jaco_status`. Note that this
+/// system does not actually send this message on an LCM channel. To send the
+/// message, the output of this system should be connected to an input port of
+/// a systems::lcm::LcmPublisherSystem that accepts a
+/// systems::Value object templated on type `lcmt_jaco_status`.
+class JacoStatusSender : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(JacoStatusSender)
+
+  /// @param num_joints The number of joints on the arm (typically 6
+  /// or 7).
+  ///
+  /// @param num_fingers The number of fingers on the gripper
+  /// (typically 2 or 3).
+  explicit JacoStatusSender(int num_joints = kJacoDefaultArmNumJoints,
+                            int num_fingers = kJacoDefaultArmNumFingers);
+
+ private:
+  // This is the method to use for the output port allocator.
+  lcmt_jaco_status MakeOutputStatus() const;
+
+  // This is the calculator method for the output port.
+  void OutputStatus(const systems::Context<double>& context,
+                    lcmt_jaco_status* output) const;
+
+  const int num_joints_;
+  const int num_fingers_;
+};
+
+}  // namespace kinova_jaco_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
+++ b/drake/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
@@ -1,0 +1,142 @@
+#include "drake/examples/kinova_jaco_arm/jaco_lcm.h"
+
+#include <Eigen/Dense>
+#include <gtest/gtest.h>
+
+#include "drake/lcmt_jaco_command.hpp"
+#include "drake/lcmt_jaco_status.hpp"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/diagram.h"
+#include "drake/systems/framework/diagram_builder.h"
+
+namespace drake {
+namespace examples {
+namespace kinova_jaco_arm {
+
+// Test that any modification of message values (e.g. finger
+// positions) is symmetric on both sides.
+GTEST_TEST(JacoLcmTest, JacoCommandPassthroughTest) {
+  systems::DiagramBuilder<double> builder;
+  auto command_sender = builder.AddSystem<JacoCommandSender>();
+  auto command_receiver = builder.AddSystem<JacoCommandReceiver>();
+  builder.Connect(command_receiver->get_output_port(0),
+                  command_sender->get_input_port(0));
+  builder.ExportInput(command_receiver->get_input_port(0));
+  builder.ExportOutput(command_sender->get_output_port(0));
+  auto diagram = builder.Build();
+
+  std::unique_ptr<systems::Context<double>> context =
+      diagram->CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output =
+      diagram->AllocateOutput(*context);
+
+  lcmt_jaco_command command{};
+  command.num_joints = kJacoDefaultArmNumJoints;
+  command.joint_position = std::vector<double>{1, 2, 3, 4, 5, 6, 7};
+  command.joint_velocity = std::vector<double>{-1, -2, -3, -4, -5, -6, -7};
+  command.num_fingers = kJacoDefaultArmNumFingers;
+  command.finger_position = std::vector<double>{10, 20, 30, 40, 50, 60, 70};
+  command.finger_velocity = std::vector<double>{
+    -10, -20, -30, -40, -50, -60, -70};
+
+  context->FixInputPort(
+      0, std::make_unique<systems::Value<lcmt_jaco_command>>(command));
+
+  std::unique_ptr<systems::DiscreteValues<double>> update =
+      diagram->AllocateDiscreteVariables();
+  update->SetFrom(*context->get_mutable_discrete_state());
+  diagram->CalcDiscreteVariableUpdates(*context, update.get());
+  context->get_mutable_discrete_state()->CopyFrom(*update);
+  diagram->CalcOutput(*context, output.get());
+
+  lcmt_jaco_command command_out =
+      output->get_data(0)->GetValue<lcmt_jaco_command>();
+
+  ASSERT_EQ(command.num_joints, command_out.num_joints);
+  for (int i = 0; i < command.num_joints; i++) {
+    EXPECT_DOUBLE_EQ(command.joint_position[i], command_out.joint_position[i]);
+    EXPECT_DOUBLE_EQ(command.joint_velocity[i], command_out.joint_velocity[i]);
+  }
+
+  ASSERT_EQ(command.num_fingers, command_out.num_fingers);
+  for (int i = 0; i < command.num_fingers; i++) {
+    EXPECT_DOUBLE_EQ(command.finger_position[i],
+                     command_out.finger_position[i]);
+    EXPECT_DOUBLE_EQ(command.finger_velocity[i],
+                     command_out.finger_velocity[i]);
+  }
+}
+
+// Test that any modification of message values (e.g. finger
+// positions) is symmetric on both sides.
+GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
+  systems::DiagramBuilder<double> builder;
+  auto status_sender = builder.AddSystem<JacoStatusSender>();
+  auto status_receiver = builder.AddSystem<JacoStatusReceiver>();
+  builder.Connect(status_receiver->get_output_port(0),
+                  status_sender->get_input_port(0));
+  builder.ExportInput(status_receiver->get_input_port(0));
+  builder.ExportOutput(status_sender->get_output_port(0));
+  auto diagram = builder.Build();
+
+  std::unique_ptr<systems::Context<double>> context =
+      diagram->CreateDefaultContext();
+  std::unique_ptr<systems::SystemOutput<double>> output =
+      diagram->AllocateOutput(*context);
+
+  lcmt_jaco_status status{};
+  status.num_joints = kJacoDefaultArmNumJoints;
+  status.joint_position.resize(status.num_joints);
+  status.joint_velocity.resize(status.num_joints);
+  status.joint_torque.resize(status.num_joints);
+  status.joint_current.resize(status.num_joints);
+  for (int i = 0; i < status.num_joints; i++) {
+    status.joint_position[i] = i;
+    status.joint_velocity[i] = i * 10;
+    status.joint_torque[i] = i * 100;
+    status.joint_current[i] = i * 1000;
+  }
+
+  status.num_fingers = kJacoDefaultArmNumFingers;
+  status.finger_position.resize(status.num_fingers);
+  status.finger_velocity.resize(status.num_fingers);
+  status.finger_torque.resize(status.num_fingers);
+  status.finger_current.resize(status.num_fingers);
+  for (int i = 0; i < status.num_fingers; i++) {
+    status.finger_position[i] = -i;
+    status.finger_velocity[i] = -i * 10;
+    status.finger_torque[i] = -i * 100;
+    status.finger_current[i] = -i * 1000;
+  }
+
+  context->FixInputPort(
+      0, std::make_unique<systems::Value<lcmt_jaco_status>>(status));
+
+  std::unique_ptr<systems::DiscreteValues<double>> update =
+      diagram->AllocateDiscreteVariables();
+  update->SetFrom(*context->get_mutable_discrete_state());
+  diagram->CalcDiscreteVariableUpdates(*context, update.get());
+  context->get_mutable_discrete_state()->CopyFrom(*update);
+  diagram->CalcOutput(*context, output.get());
+
+  lcmt_jaco_status status_out =
+      output->get_data(0)->GetValue<lcmt_jaco_status>();
+
+  // Force and current won't actually pass through since they're not
+  // part of the state in drake.
+  ASSERT_EQ(status.num_joints, status_out.num_joints);
+  for (int i = 0; i < status.num_joints; i++) {
+    EXPECT_DOUBLE_EQ(status.joint_position[i], status_out.joint_position[i]);
+    EXPECT_DOUBLE_EQ(status.joint_velocity[i], status_out.joint_velocity[i]);
+  }
+
+  ASSERT_EQ(status.num_fingers, status_out.num_fingers);
+  for (int i = 0; i < status.num_fingers; i++) {
+    EXPECT_DOUBLE_EQ(status.finger_position[i], status_out.finger_position[i]);
+    EXPECT_DOUBLE_EQ(status.finger_velocity[i], status_out.finger_velocity[i]);
+  }
+}
+
+}  // namespace kinova_jaco_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/lcmtypes/BUILD.bazel
+++ b/drake/lcmtypes/BUILD.bazel
@@ -243,6 +243,15 @@ drake_lcm_cc_library(
     ],
 )
 
+drake_lcm_cc_library(
+    name = "jaco",
+    lcm_package = "drake",
+    lcm_srcs = [
+        "lcmt_jaco_command.lcm",
+        "lcmt_jaco_status.lcm",
+    ],
+)
+
 # TODO(jwnimmer-tri) Many more C++ messages are missing ...
 
 drake_lcm_py_library(
@@ -278,6 +287,7 @@ DRAKE_LCMTYPES = [
     ":drake_signal",
     ":iiwa",
     ":inverse_dynamics_debug_info",
+    ":jaco",
     ":joint_pd_override",
     ":manipulator_plan_move_end_effector",
     ":piecewise_polynomial",

--- a/drake/lcmtypes/lcmt_jaco_command.lcm
+++ b/drake/lcmtypes/lcmt_jaco_command.lcm
@@ -1,0 +1,16 @@
+package drake;
+
+// Commands a single set of joint states for the arm.  All angular
+// positions/velocities are expressed in radians and radians/second.
+struct lcmt_jaco_command {
+  // The timestamp in microseconds.
+  int64_t utime;
+
+  int32_t num_joints;
+  double joint_position[num_joints];
+  double joint_velocity[num_joints];
+
+  int32_t num_fingers;
+  double finger_position[num_fingers];
+  double finger_velocity[num_fingers];
+}

--- a/drake/lcmtypes/lcmt_jaco_status.lcm
+++ b/drake/lcmtypes/lcmt_jaco_status.lcm
@@ -1,0 +1,28 @@
+package drake;
+
+// The current status of a Kinova Jaco arm.  All angular
+// positions/velocities are expressed in radians and radians/second.
+struct lcmt_jaco_status
+{
+  // The timestamp in microseconds (this is typically the wall clock
+  // time of the sender https://en.wikipedia.org/wiki/Unix_time )
+  int64_t utime;
+
+  int32_t num_joints;
+
+  double joint_position[num_joints];
+  double joint_velocity[num_joints];
+  double joint_torque[num_joints];  // (sometimes called "Angular
+                                    // Force" in Kinova's
+                                    // documentation.
+  double joint_current[num_joints];
+
+  int32_t num_fingers;
+  double finger_position[num_fingers];
+  double finger_velocity[num_fingers];
+  double finger_torque[num_fingers]; // (sometimes called "Angular
+                                     // Force" in Kinova's
+                                     // documentation.
+  double finger_current[num_fingers];
+
+}


### PR DESCRIPTION
I'm slowly working on committing the Jaco related stuff I've already done to master.  I don't think this will necessarily get us to a completely working jaco stack with tested IK like we have for the iiwa, but I don't see any good reason to let stuff I've already done rot on a branch.

I've got another PR to drake after this which adds a simple controller, and then a sample director app and a driver which I need to decide what to do with.

This PR is past the 500 line limit (including whitespace), but a lot of it is either comments or boilerplate, so I hope that's OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7267)
<!-- Reviewable:end -->
