### PR TITLE
Add AutoDiffXd supported version of Lane::ToGeoPosition

### DIFF
--- a/drake/automotive/maliput/api/lane.cc
+++ b/drake/automotive/maliput/api/lane.cc
@@ -6,6 +6,23 @@ namespace api {
 
 // These instantiations must match the API documentation in lane.h.
 template<>
+GeoPositionT<double> Lane::ToGeoPositionT<double>(
+    const LanePositionT<double>& lane_pos) const {
+  return DoToGeoPosition(lane_pos);
+}
+
+template<>
+GeoPositionT<AutoDiffXd> Lane::ToGeoPositionT<AutoDiffXd>(
+    const LanePositionT<AutoDiffXd>& lane_pos) const {
+  // Fail fast if lane_pos contains derivatives of inconsistent sizes.
+  const Eigen::VectorXd deriv = lane_pos.s().derivatives();
+  DRAKE_THROW_UNLESS(deriv.size() == lane_pos.r().derivatives().size());
+  DRAKE_THROW_UNLESS(deriv.size() == lane_pos.h().derivatives().size());
+
+  return DoToGeoPositionAutoDiff(lane_pos);
+}
+
+template<>
 LanePositionT<double> Lane::ToLanePositionT<double>(
     const GeoPositionT<double>& geo_pos,
     GeoPositionT<double>* nearest_point,

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -95,6 +95,13 @@ api::GeoPosition Lane::DoToGeoPosition(
   return {lane_pos.s(), lane_pos.r() + Lane::y_offset(), lane_pos.h()};
 }
 
+api::GeoPositionT<AutoDiffXd> Lane::DoToGeoPositionAutoDiff(
+    const api::LanePositionT<AutoDiffXd>& lane_pos) const {
+  return {lane_pos.s(),
+          lane_pos.r() + AutoDiffXd(Lane::y_offset()),
+          lane_pos.h()};
+}
+
 api::Rotation Lane::DoGetOrientation(
     const api::LanePosition&) const {
   return api::Rotation();  // Default is Identity.

--- a/drake/automotive/maliput/dragway/lane.h
+++ b/drake/automotive/maliput/dragway/lane.h
@@ -157,6 +157,9 @@ class Lane final : public api::Lane {
   api::GeoPosition DoToGeoPosition(const api::LanePosition& lane_pos) const
       final;
 
+  api::GeoPositionT<AutoDiffXd> DoToGeoPositionAutoDiff(
+      const api::LanePositionT<AutoDiffXd>& lane_pos) const final;
+
   api::Rotation DoGetOrientation(const api::LanePosition& lane_pos) const
       final;
 


### PR DESCRIPTION
Also:
- Adopt the implementation in `dragway::Lane`.
- (minor) Reduce the test time for `dragway_test.cc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7268)
<!-- Reviewable:end -->
