### PR TITLE
Move drake_java.bzl into tools/skylark

### DIFF
--- a/drake/lcmtypes/BUILD.bazel
+++ b/drake/lcmtypes/BUILD.bazel
@@ -3,11 +3,11 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@drake//tools:install.bzl", "install")
 load(
-    "@drake//tools:drake.bzl",
+    "@drake//tools/skylark:drake_java.bzl",
     "drake_java_binary",
 )
-load("@drake//tools:install.bzl", "install")
 load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_test",

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -1,7 +1,5 @@
 # -*- python -*-
 
-MainClassInfo = provider()
-
 # The CXX_FLAGS will be enabled for all C++ rules in the project
 # building with any compiler.
 CXX_FLAGS = [
@@ -79,58 +77,6 @@ def _check_library_deps_blacklist(name, deps):
             fail("The cc_library '" + name + "' must not depend on a :main " +
                  "function from a cc_library; only cc_binary program should " +
                  "have a main function")
-
-# Generate a launcher file to run installed java binaries
-def _drake_java_binary_install_launcher_impl(ctx):
-    classpath = ctx.attr.target.java.compilation_info.runtime_classpath
-    return [
-        MainClassInfo(
-            main_class = ctx.attr.main_class,
-            classpath = classpath,
-            filename = ctx.attr.filename,
-        )
-    ]
-
-_drake_java_binary_install_launcher = rule(
-    attrs = {
-        "main_class": attr.string(mandatory = True),
-        "filename": attr.string(mandatory = True),
-        "target": attr.label(mandatory = True),
-    },
-    implementation = _drake_java_binary_install_launcher_impl,
-)
-
-"""Generate a launcher for java binary files.
-"""
-
-def drake_java_binary(
-        name,
-        main_class,
-        **kwargs):
-    """Creates a rule to declare a java binary and a MainClassInfo Provider
-
-    The native java_binary creates a java launcher (shell script) that works in
-    the build tree. However, a different launcher needs to be created to run
-    the java binary in the install tree. This function generates a
-    MainClassInfo provider that can be used by the installer (install.bzl) to
-    configure the installation script that will copy the installed files and
-    generate a launcher script at install time.
-    """
-    vkwargs = {
-        key: value for key, value in kwargs.items()
-        if key == "visibility"
-    }
-    native.java_binary(
-        name = name,
-        main_class = main_class,
-        **kwargs)
-    launcher_name = name + "-launcher"
-    _drake_java_binary_install_launcher(
-        name = launcher_name,
-        main_class = main_class,
-        target = ":" + name,
-        filename = launcher_name + ".sh",
-        **vkwargs)
 
 def drake_cc_library(
         name,

--- a/tools/install.bzl
+++ b/tools/install.bzl
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-load("@drake//tools:drake.bzl", "MainClassInfo")
+load("@drake//tools/skylark:drake_java.bzl", "MainClassInfo")
 load(
     "@drake//tools/skylark:pathutils.bzl",
     "dirname",

--- a/tools/skylark/drake_java.bzl
+++ b/tools/skylark/drake_java.bzl
@@ -1,0 +1,55 @@
+# -*- python -*-
+
+MainClassInfo = provider()
+
+# Generate a launcher file to run installed java binaries
+def _drake_java_binary_install_launcher_impl(ctx):
+    classpath = ctx.attr.target.java.compilation_info.runtime_classpath
+    return [
+        MainClassInfo(
+            main_class = ctx.attr.main_class,
+            classpath = classpath,
+            filename = ctx.attr.filename,
+        )
+    ]
+
+_drake_java_binary_install_launcher = rule(
+    attrs = {
+        "main_class": attr.string(mandatory = True),
+        "filename": attr.string(mandatory = True),
+        "target": attr.label(mandatory = True),
+    },
+    implementation = _drake_java_binary_install_launcher_impl,
+)
+
+"""Generate a launcher for java binary files.
+"""
+
+def drake_java_binary(
+        name,
+        main_class,
+        **kwargs):
+    """Creates a rule to declare a java binary and a MainClassInfo Provider
+
+    The native java_binary creates a java launcher (shell script) that works in
+    the build tree. However, a different launcher needs to be created to run
+    the java binary in the install tree. This function generates a
+    MainClassInfo provider that can be used by the installer (install.bzl) to
+    configure the installation script that will copy the installed files and
+    generate a launcher script at install time.
+    """
+    vkwargs = {
+        key: value for key, value in kwargs.items()
+        if key == "visibility"
+    }
+    native.java_binary(
+        name = name,
+        main_class = main_class,
+        **kwargs)
+    launcher_name = name + "-launcher"
+    _drake_java_binary_install_launcher(
+        name = launcher_name,
+        main_class = main_class,
+        target = ":" + name,
+        filename = launcher_name + ".sh",
+        **vkwargs)

--- a/tools/workspace/libbot/libbot.BUILD.bazel
+++ b/tools/workspace/libbot/libbot.BUILD.bazel
@@ -7,13 +7,16 @@ load(
     "install_cmake_config",
 )
 load(
+    "@drake//tools/skylark:drake_java.bzl",
+    "drake_java_binary",
+)
+load(
     "@drake//tools/workspace/lcm:lcm.bzl",
     "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
     "lcm_py_library",
 )
-load("@drake//tools:drake.bzl", "drake_java_binary")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
Relates #6996.

The goal here is to make `/tools` itself relatively thin, putting most features into subdirectories.

We also don't want to have a single `drake.bzl` that has all `drake_*` macros, because then we get dependency bleeding: with a single bzl file, C++ code would need to have load-time access to Java helpers, which can induce extra load-time dependencies.  Keeping dependencies thin will help with #7259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7281)
<!-- Reviewable:end -->
