### PR TITLE
Refactor of RoadCurve and Lane classes.

### DIFF
--- a/drake/automotive/maliput/multilane/lane.cc
+++ b/drake/automotive/maliput/multilane/lane.cc
@@ -42,54 +42,18 @@ api::GeoPosition Lane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
   // Recover parameter p from arc-length position s.
   const double p = road_curve_->p_from_s(lane_pos.s(), r0_);
-  // Calculate z (elevation) of (s,0,0);
-  const double z = road_curve_->elevation().f_p(p) * road_curve_->p_scale();
-  // Calculate x,y of (s,0,0).
-  const V2 xy = road_curve_->xy_of_p(p);
-  // Calculate orientation of (s,r,h) basis at (s,0,0).
-  const Rot3 ypr = road_curve_->Rabg_of_p(p);
-
-  // Rotate (0,r,h) and sum with mapped (s,0,0).
-  const V3 xyz =
-      ypr.apply({0., lane_pos.r() + r0_, lane_pos.h()}) + V3(xy.x(), xy.y(), z);
+  const Vector3<double> xyz =
+      road_curve_->W_of_prh(p, lane_pos.r() + r0_, lane_pos.h());
   return {xyz.x(), xyz.y(), xyz.z()};
 }
 
 
 api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
-  // Recover linear parameter p from arc-length position s.
   const double p = road_curve_->p_from_s(lane_pos.s(), r0_);
-  const double r = lane_pos.r() + r0_;
-  const double h = lane_pos.h();
-  // Calculate orientation of (s,r,h) basis at (s,0,0).
-  const Rot3 Rabg = road_curve_->Rabg_of_p(p);
-  const double real_g_prime = road_curve_->elevation().f_dot_p(p);
-
-  // Calculate s,r basis vectors at (s,r,h)...
-  const V3 s_hat = road_curve_->s_hat_of_prh(p, r, h, Rabg, real_g_prime);
-  const V3 r_hat = road_curve_->r_hat_of_Rabg(Rabg);
-  // ...and then derive orientation from those basis vectors.
-  //
-  // (s_hat  r_hat  h_hat) is an orthonormal basis, obtained by rotating the
-  // (x_hat  y_hat  z_hat) basis by some R-P-Y rotation; in this case, we know
-  // the value of (s_hat  r_hat  h_hat) (w.r.t. 'xyz' world frame), so we are
-  // trying to recover the roll/pitch/yaw.  Since (x_hat  y_hat  z_hat) is an
-  // identity matrix (e.g., x_hat = column vector (1, 0, 0), etc), then
-  // (s_hat  r_hat  h_hat) equals the R-P-Y matrix itself.
-  // If we define a = alpha = roll, b = beta = pitch, g = gamma = yaw,
-  // then s_hat is the first column of the rotation, r_hat is the second:
-  //   s_hat = (cb * cg, cb * sg, - sb)
-  //   r_hat = (- ca * sg + sa * sb * cg, ca * cg + sa * sb * sg, sa * cb)
-  // We solve the above for a, b, g.
-  const double gamma = std::atan2(s_hat.y(),
-                                  s_hat.x());
-  const double beta = std::atan2(-s_hat.z(),
-                                 V2(s_hat.x(), s_hat.y()).norm());
-  const double cb = std::cos(beta);
-  const double alpha =
-      std::atan2(r_hat.z() / cb,
-                 ((r_hat.y() * s_hat.x()) - (r_hat.x() * s_hat.y())) / cb);
-  return api::Rotation::FromRpy(alpha, beta, gamma);
+  const Rot3 rotation =
+      road_curve_->Orientation(p, lane_pos.r() + r0_, lane_pos.h());
+  return api::Rotation::FromRpy(rotation.roll(), rotation.pitch(),
+                                rotation.yaw());
 }
 
 

--- a/drake/automotive/maliput/multilane/road_curve.cc
+++ b/drake/automotive/maliput/multilane/road_curve.cc
@@ -4,11 +4,15 @@ namespace drake {
 namespace maliput {
 namespace multilane {
 
-Rot3 RoadCurve::Rabg_of_p(const double p) const {
-  // TODO(agalbachicar)  This method needs test coverage.
-  return Rot3(superelevation().f_p(p) * p_scale(),
-              -std::atan(elevation().f_dot_p(p)),
-              heading_of_p(p));
+Vector3<double> RoadCurve::W_of_prh(double p, double r, double h) const {
+  // Calculates z (elevation) of (p,0,0).
+  const double z = elevation().f_p(p) * p_scale();
+  // Calculates x,y of (p,0,0).
+  const Vector2<double> xy = xy_of_p(p);
+  // Calculates orientation of (p,r,h) basis at (p,0,0).
+  const Rot3 ypr = Rabg_of_p(p);
+  // Rotates (0,r,h) and sums with mapped (p,0,0).
+  return ypr.apply({0., r, h}) + Vector3<double>(xy.x(), xy.y(), z);
 }
 
 
@@ -69,6 +73,42 @@ Vector3<double> RoadCurve::W_prime_of_prh(double p, double r, double h,
                       * d_gamma;
 }
 
+Rot3 RoadCurve::Rabg_of_p(double p) const {
+  // TODO(agalbachicar)  This method needs test coverage.
+  return Rot3(superelevation().f_p(p) * p_scale(),
+              -std::atan(elevation().f_dot_p(p)),
+              heading_of_p(p));
+}
+
+Rot3 RoadCurve::Orientation(double p, double r, double h) const {
+  // Calculate orientation of (s,r,h) basis at (s,0,0).
+  const Rot3 Rabg = Rabg_of_p(p);
+  const double real_g_prime = elevation().f_dot_p(p);
+
+  // Calculate s,r basis vectors at (s,r,h)...
+  const Vector3<double> s_hat = s_hat_of_prh(p, r, h, Rabg, real_g_prime);
+  const Vector3<double> r_hat = r_hat_of_Rabg(Rabg);
+  // ...and then derive orientation from those basis vectors.
+  //
+  // (s_hat  r_hat  h_hat) is an orthonormal basis, obtained by rotating the
+  // (x_hat  y_hat  z_hat) basis by some R-P-Y rotation; in this case, we know
+  // the value of (s_hat  r_hat  h_hat) (w.r.t. 'xyz' world frame), so we are
+  // trying to recover the roll/pitch/yaw.  Since (x_hat  y_hat  z_hat) is an
+  // identity matrix (e.g., x_hat = column vector (1, 0, 0), etc), then
+  // (s_hat  r_hat  h_hat) equals the R-P-Y matrix itself.
+  // If we define a = alpha = roll, b = beta = pitch, g = gamma = yaw,
+  // then s_hat is the first column of the rotation, r_hat is the second:
+  //   s_hat = (cb * cg, cb * sg, - sb)
+  //   r_hat = (- ca * sg + sa * sb * cg, ca * cg + sa * sb * sg, sa * cb)
+  // We solve the above for a, b, g.
+  const double gamma = std::atan2(s_hat.y(), s_hat.x());
+  const double beta =
+      std::atan2(-s_hat.z(), Vector2<double>(s_hat.x(), s_hat.y()).norm());
+  const double cb = std::cos(beta);
+  const double alpha = std::atan2(
+      r_hat.z() / cb, ((r_hat.y() * s_hat.x()) - (r_hat.x() * s_hat.y())) / cb);
+  return {alpha, beta, gamma};
+}
 
 Vector3<double> RoadCurve::s_hat_of_prh(double p, double r, double h,
                                         const Rot3& Rabg,

--- a/drake/automotive/maliput/multilane/road_curve.h
+++ b/drake/automotive/maliput/multilane/road_curve.h
@@ -180,8 +180,8 @@ class RoadCurve {
   virtual bool IsValid(double r_min, double r_max,
                        const api::HBounds& height_bounds) const = 0;
 
-  /// Returns the rotation R_αβγ, evaluated at @p p along the reference curve.
-  Rot3 Rabg_of_p(const double p) const;
+  /// Returns W, the world function evaluated at @p p, @p r, @p h.
+  Vector3<double> W_of_prh(double p, double r, double h) const;
 
   /// Returns W' = ∂W/∂p, the partial differential of W with respect to p,
   /// evaluated at @p p, @p r, @p h.
@@ -192,6 +192,12 @@ class RoadCurve {
   /// here to avoid recomputing it.)
   Vector3<double> W_prime_of_prh(double p, double r, double h, const Rot3& Rabg,
                                  double g_prime) const;
+
+  /// Returns the rotation R_αβγ, evaluated at @p p along the reference curve.
+  Rot3 Rabg_of_p(double p) const;
+
+  /// Returns the rotation R_αβγ, evaluated at @p p, @p r and @p h.
+  Rot3 Orientation(double p, double r, double h) const;
 
   /// Returns the s-axis unit-vector, expressed in the world frame,
   /// of the (s,r,h) `Lane`-frame (with respect to the world frame).


### PR DESCRIPTION
This PR partially addresses issue #7194. It refactors `Lane` and `RoadCurve` classes by moving code from the former to the latter. Now, `Lane` handles `(s,r,h)` to `(p,r,h)` conversion, leaving most of the work to `RoadCurve` class. Two new methods can be found:

1. `Lane::DoToGeoPosition()` --> `RoadCurve::W_of_prh()`
2. `Lane::DoGetOrientation()` --> `RoadCurve::Orientation()`

In addition, this PR provides test coverage to these new methods since they are now part of the public API.

A follow up PR, will focus on `Builder` and `Connection` classes so as to finish issue #7194.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7282)
<!-- Reviewable:end -->
