### PR TITLE
Remove hardcoded file names in TestCommonInstall

### DIFF
--- a/drake/bindings/python/pydrake/test/testCommonInstall.py
+++ b/drake/bindings/python/pydrake/test/testCommonInstall.py
@@ -18,20 +18,20 @@ class TestCommonInstall(unittest.TestCase):
             ["install",
              os.path.abspath(tmp_folder),
              ])
-        self.assertEqual(set(os.listdir(tmp_folder)),
-                         set(['libexec', 'lib', 'include',
-                             'share', 'bin', 'plugins']))
+        content_install_folder = os.listdir(tmp_folder)
+        # Check that `lib` and `share` folders are installed since they are
+        # used in this test.
+        self.assertIn('lib', content_install_folder)
+        self.assertIn('share', content_install_folder)
         # Remove Bazel build artifacts, and ensure that we only have install
         # artifacts.
-        shutil.rmtree("drake")
-        os.remove(".drake-resource-sentinel")
-        os.remove("LICENSE.TXT")
-        os.remove("__init__.py")
-        shutil.rmtree("_solib_k8")
-        shutil.rmtree("external")
-        shutil.rmtree("third_party")
-        shutil.rmtree("tools")
-        os.remove("install")
+        content_test_folder = os.listdir(os.getcwd())
+        content_test_folder.remove('tmp')
+        for element in content_test_folder:
+            if os.path.isdir(element):
+                shutil.rmtree(element)
+            else:
+                os.remove(element)
         self.assertEqual(os.listdir("."), [tmp_folder])
 
         # Set the correct PYTHONPATH and (DY)LD_LIBRARY_PATH to use the


### PR DESCRIPTION
Different system may return different content of install folder and
test folder. To avoid having to manually specify each possible configuration,
this patch removes the hardcoded file names and folder names, and finds the
files and folders programmatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7297)
<!-- Reviewable:end -->
