### PR TITLE
Force using `python2` executable in testCommonInstall.py

### DIFF
--- a/drake/bindings/python/pydrake/test/testCommonInstall.py
+++ b/drake/bindings/python/pydrake/test/testCommonInstall.py
@@ -49,8 +49,12 @@ class TestCommonInstall(unittest.TestCase):
             os.path.join(tmp_folder, "lib")
         )
         data_folder = os.path.join(tmp_folder, "share", "drake", "drake")
+        # Call python2 to force using python brew install. Calling python
+        # system would result in a crash since pydrake was built against
+        # brew python. On Linux this will still work and force using
+        # python2 which should be a link to the actual executable.
         output_path = subprocess.check_output(
-            ["python",
+            ["python2",
              "-c", "import pydrake; print(pydrake.getDrakePath())"
              ],
             env=tool_env,


### PR DESCRIPTION
On MacOS, using the executable named `python` might result in running the
system `python` which could lead to the following crash:

Fatal Python error: PyThreadState_Get: no current thread

Using `python2` instead of `python` forces the usage of the brew installation
of `python` against which `pydrake` has been built.

On Linux, `python` is typically a symbolic link to `python2` which is a
symbolic link to `python2.7`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7300)
<!-- Reviewable:end -->
