### PR TITLE
Add in new dependencies for system protobuf usage.

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -39,6 +39,7 @@ lz4
 numpy
 patchutils
 pkg-config
+protobuf@2.6
 python
 scipy
 tinyxml

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -74,6 +74,7 @@ libnetcdf-c++4
 libnetcdf11
 libogg0
 libpng-dev
+libprotobuf-dev
 libqt5multimedia5
 libqt5opengl5
 libqt5x11extras5
@@ -88,6 +89,7 @@ mesa-common-dev
 openjdk-8-jdk
 patchutils
 pkg-config
+protobuf-compiler
 python-dev
 python-gtk2
 python-lxml

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -94,6 +94,7 @@ python-dev
 python-gtk2
 python-lxml
 python-numpy
+python-protobuf
 python-pygame
 python-scipy
 python-sphinx


### PR DESCRIPTION
This adds two new packages to Ubuntu, and one new package to
MacOS, to support the upcoming switch to the system protobuf
packages.

This is the first part of the split of #7278 , where we just install the prerequisites.  As requested in https://github.com/RobotLocomotion/drake/pull/7278#issuecomment-337891096 , I did a test locally using the branch in #7278 in docker to test out the dependencies.  I edited `setup/docker/Dockerfile.ubuntu16.04.opensource` so it contained this RUN line:

```
RUN cd /drake-distro && bazel build //... && bazel test //...
```

And ran it, and everything was successful.  Thus, I think these dependencies should be enough to get us started.  Note that I know that the `protobuf@2.6` package exists in MacOS homebrew, but I have not done further tests on MacOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7303)
<!-- Reviewable:end -->
