### PR TITLE
Switch to protobuf version 2.

### DIFF
--- a/drake/common/proto/matlab_rpc.proto
+++ b/drake/common/proto/matlab_rpc.proto
@@ -44,7 +44,7 @@ message MatlabRPC {
 
   repeated MatlabArray rhs = 2;  // the input argument data
 
-  optional string function_name = 3;  // any input allowed by matlab's
-                                      // mexcallmatlab command
+  // any input allowed by matlab's mexcallmatlab command
   // (http://www.mathworks.com/help/matlab/apiref/mexcallmatlab.html)
+  optional string function_name = 3;
 }

--- a/drake/common/proto/matlab_rpc.proto
+++ b/drake/common/proto/matlab_rpc.proto
@@ -44,6 +44,7 @@ message MatlabRPC {
 
   repeated MatlabArray rhs = 2;  // the input argument data
 
-  optional string function_name = 3;  // any input allowed by matlab's mexcallmatlab command
+  optional string function_name = 3;  // any input allowed by matlab's
+                                      // mexcallmatlab command
   // (http://www.mathworks.com/help/matlab/apiref/mexcallmatlab.html)
 }

--- a/drake/common/proto/matlab_rpc.proto
+++ b/drake/common/proto/matlab_rpc.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package drake.common;
 
@@ -15,13 +15,13 @@ message MatlabArray
     CHAR = 2;
     LOGICAL = 3;
   }
-  ArrayType type = 1;
+  optional ArrayType type = 1;
 
   // Dimensions.
-  int32 rows = 2;
-  int32 cols = 3;
+  optional int32 rows = 2;
+  optional int32 cols = 3;
 
-  bytes data = 4;
+  optional bytes data = 4;
 
   /* TODO: Consider adding support for the remainder of the mxArray type:
    *   - If numeric, whether the variable is real or complex
@@ -44,6 +44,6 @@ message MatlabRPC {
 
   repeated MatlabArray rhs = 2;  // the input argument data
 
-  string function_name = 3;  // any input allowed by matlab's mexcallmatlab command
+  optional string function_name = 3;  // any input allowed by matlab's mexcallmatlab command
   // (http://www.mathworks.com/help/matlab/apiref/mexcallmatlab.html)
 }

--- a/drake/multibody/alias_groups.proto
+++ b/drake/multibody/alias_groups.proto
@@ -1,11 +1,11 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package drake.rigid_body_tree;
 
 // Next ID: 3
 message AliasGroup {
     // The name of the group itself.
-    string name = 1;
+    optional string name = 1;
     // The names of the members of the group.
     repeated string member = 2;
 }

--- a/drake/systems/controllers/qp_inverse_dynamics/id_controller_config.proto
+++ b/drake/systems/controllers/qp_inverse_dynamics/id_controller_config.proto
@@ -1,12 +1,12 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package drake.systems.controllers.qp_inverse_dynamics;
 
 // TODO(siyuanfeng): This probably should go to drake/common eventually.
 message Vec3 {
-    double x = 1;
-    double y = 2;
-    double z = 3;
+    optional double x = 1;
+    optional double y = 2;
+    optional double z = 3;
 }
 
 // Contains parameters for specifying desired accelerations for the inverse
@@ -25,7 +25,7 @@ message Vec3 {
 message AccelerationConfig {
     // Name should be a valid group name in the corresponding
     // RigidBodyTreeAliasGroups.
-    string name = 1;
+    optional string name = 1;
 
     // For body tracking, the `kp` and `kd` gains are applied on the pose and
     // velocity measured in the world frame.
@@ -43,27 +43,27 @@ message AccelerationConfig {
 // dynamics controller.
 message ContactConfig {
     // Name should be a valid group name in the corresponding AliasGroups.
-    string name = 1;
+    optional string name = 1;
 
     // Positive weight means the corresponding acceleration will be used as a
     // cost term, 0 means it will be skipped, and negative value means it will
     // be used as a hard constraint.
-    double weight = 2;
+    optional double weight = 2;
 
     // This is used to damp out nonzero contact velocity by setting the
     // desired contact acceleration to `-kd * v`, where v is the measured
     // contact velocity.
-    double kd = 3;
+    optional double kd = 3;
 
     // Friction coefficient.
-    double mu = 4;
+    optional double mu = 4;
 
     // The contact point and norm are specified in the body frame.
     repeated Vec3 contact_point = 5;
-    Vec3 contact_normal = 6;
+    optional Vec3 contact_normal = 6;
 
     // Number of basis vectors used to approximate the friction cone.
-    int32 num_basis_per_contact_point = 7;
+    optional int32 num_basis_per_contact_point = 7;
 }
 
 // Contains parameters for the inverse dynamics controller. There are 4
@@ -74,23 +74,23 @@ message ContactConfig {
 message InverseDynamicsControllerConfig {
     // Name of this set of parameters. Used to distinguish different sets of
     // parameters, e.g. walking_params vs manipulation_params.
-    string name = 1;
+    optional string name = 1;
 
     // Centroidal momentum.
-    AccelerationConfig centroidal_momentum = 2;
+    optional AccelerationConfig centroidal_momentum = 2;
 
     // Body acceleration.
-    AccelerationConfig default_body_motion = 3;
+    optional AccelerationConfig default_body_motion = 3;
     repeated AccelerationConfig body_motion = 4;
 
     // Acceleration in the generalized coordinates.
-    AccelerationConfig default_dof_motion = 5;
+    optional AccelerationConfig default_dof_motion = 5;
     repeated AccelerationConfig dof_motion = 6;
 
     // Contact information.
-    ContactConfig default_contact = 7;
+    optional ContactConfig default_contact = 7;
     repeated ContactConfig contact = 8;
 
     // Regularization weight of the contact force basis.
-    double contact_force_basis_weight = 9;
+    optional double contact_force_basis_weight = 9;
 }

--- a/drake/tools/named_vector.proto
+++ b/drake/tools/named_vector.proto
@@ -15,7 +15,7 @@ message NamedVector {
     repeated NamedVectorElement element = 1;
 
     // A ::-separated namespace for this vector, such as "drake::automotive".
-    string namespace = 2;
+    optional string namespace = 2;
 }
 
 message NamedVectorElement {

--- a/drake/tools/named_vector.proto
+++ b/drake/tools/named_vector.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package tools;
 
@@ -21,24 +21,24 @@ message NamedVector {
 message NamedVectorElement {
     // The short name of this element. Should typically contain only lowercase
     // a-z and underscores, since it appears in generated code.
-    string name = 1;
+    optional string name = 1;
 
     // A free-text description of this element's purpose. Only appears in
     // comments.
-    string doc = 2;
+    optional string doc = 2;
 
     // An optional default value for this element.
-    string default_value = 3;
+    optional string default_value = 3;
 
     // An optional documentation string stating the units of this element.
     // It should be just the units abbreviation, e.g., "m/s".
-    string doc_units = 4;
+    optional string doc_units = 4;
 
     // An optional inclusive lower bound on well-formed values for this
     // element.
-    string min_value = 5;
+    optional string min_value = 5;
 
     // An optional inclusive upper bound on well-formed values for this
     // element.
-    string max_value = 6;
+    optional string max_value = 6;
 }


### PR DESCRIPTION
In order to switch to using the system version of protobuf
on Ubuntu 16.04, we need to switch back to protobuf 2 semantics.
The good news is that libprotobuf version 3 supports generating
code for protobuf version 2 files, so we can do this switch
now before we switch to the system version.  However, note that
the on-disk/on-wire protocols are *not* the same between version 2
and version 3, so any stored configurations will no longer work
after this change.

This is the second part of the split of #7278 , where we change the version of protobuf in use to 2.  Note that this is independent of the first part (#7303), so they can be merged in any order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7304)
<!-- Reviewable:end -->
