### PR TITLE
Make tests with LCM self-test flaky

### DIFF
--- a/drake/automotive/BUILD.bazel
+++ b/drake/automotive/BUILD.bazel
@@ -405,6 +405,8 @@ drake_cc_binary(
         "//drake/automotive/models:prod_models",
     ],
     test_rule_args = [" --simulation_sec=0.01"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    test_rule_flaky = 1,
     deps = [
         ":automotive_simulator",
         "//drake/common:find_resource",
@@ -453,6 +455,8 @@ drake_py_binary(
 drake_cc_googletest(
     name = "automotive_simulator_test",
     data = ["//drake/automotive/models:prod_models"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    flaky = 1,
     local = 1,
     deps = [
         "//drake/automotive:automotive_simulator",

--- a/drake/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/BUILD.bazel
@@ -93,6 +93,8 @@ drake_cc_binary(
         "//drake/manipulation/models/wsg_50_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.01"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    test_rule_flaky = 1,
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
@@ -123,6 +125,8 @@ drake_cc_binary(
         "//drake/manipulation/models/iiwa_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    test_rule_flaky = 1,
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",

--- a/drake/examples/kuka_iiwa_arm/dev/box_rotation/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/dev/box_rotation/BUILD.bazel
@@ -61,6 +61,8 @@ drake_cc_binary(
         "//drake/manipulation/models/iiwa_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.01"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    test_rule_flaky = 1,
     deps = [
         ":iiwa_box_diagram_factory",
         "//drake/common:find_resource",

--- a/drake/examples/schunk_wsg/BUILD.bazel
+++ b/drake/examples/schunk_wsg/BUILD.bazel
@@ -27,6 +27,8 @@ drake_cc_binary(
         "//drake/manipulation/models/wsg_50_description:models",
     ],
     test_rule_args = ["--simulation_sec=0.1"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    test_rule_flaky = 1,
     deps = [
         ":simulated_schunk_wsg_system",
         "//drake/lcm",

--- a/drake/examples/valkyrie/BUILD.bazel
+++ b/drake/examples/valkyrie/BUILD.bazel
@@ -162,6 +162,8 @@ drake_cc_googletest(
     name = "valkyrie_simulation_test",
     srcs = ["test/valkyrie_simulation_test.cc"],
     data = [":models"],
+    # Flaky because LCM self-test can fail (PR #7311)
+    flaky = 1,
     deps = [":valkyrie_simulator"],
 )
 

--- a/drake/lcm/BUILD.bazel
+++ b/drake/lcm/BUILD.bazel
@@ -84,6 +84,8 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "drake_lcm_test",
+    # Flaky because LCM self-test can fail (PR #7311)
+    flaky = 1,
     local = 1,
     deps = [
         ":lcm",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -115,6 +115,7 @@ def drake_cc_binary(
         add_test_rule = 0,
         test_rule_args = [],
         test_rule_size = None,
+        test_rule_flaky = 0,
         **kwargs):
     """Creates a rule to declare a C++ binary.
 
@@ -160,6 +161,7 @@ def drake_cc_binary(
             deps = deps,
             copts = copts,
             size = test_rule_size,
+            flaky = test_rule_flaky,
             testonly = testonly,
             linkstatic = linkstatic,
             args = test_rule_args,


### PR DESCRIPTION
[The list of tests](https://gist.github.com/m-chaturvedi/3933ffb663322f4103f79b42bcc91d94) was obtained using:
`bazel test //drake/...` after blocking 7667 using:
`iptables -A INPUT -p udp --dport 7667 -j DROP`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7311)
<!-- Reviewable:end -->
