### PR TITLE
System framework API return value cleanup

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -555,10 +555,9 @@ void AutomotiveSimulator<T>::InitializeMaliputRailcars() {
     DRAKE_ASSERT(state);
     state->set_value(initial_state.get_value());
 
-    MaliputRailcarParams<T>* railcar_system_params =
+    MaliputRailcarParams<T>& railcar_system_params =
         car->get_mutable_parameters(&context);
-    DRAKE_DEMAND(railcar_system_params != nullptr);
-    railcar_system_params->set_value(params.get_value());
+    railcar_system_params.set_value(params.get_value());
   }
 }
 

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -125,7 +125,7 @@ const OutputPort<T>& MaliputRailcar<T>::velocity_output() const {
 }
 
 template <typename T>
-MaliputRailcarParams<T>* MaliputRailcar<T>::get_mutable_parameters(
+MaliputRailcarParams<T>& MaliputRailcar<T>::get_mutable_parameters(
     systems::Context<T>* context) const {
   return this->template GetMutableNumericParameter<MaliputRailcarParams>(
       context, 0);

--- a/drake/automotive/maliput_railcar.h
+++ b/drake/automotive/maliput_railcar.h
@@ -106,7 +106,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   static void SetDefaultState(MaliputRailcarState<T>* railcar_state);
 
   /// Returns a mutable pointer to the parameters in the given @p context.
-  MaliputRailcarParams<T>* get_mutable_parameters(
+  MaliputRailcarParams<T>& get_mutable_parameters(
       systems::Context<T>* context) const;
 
   /// Getter methods for input and output ports.

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -49,7 +49,8 @@ const DrivingCommand<T>& get_input(const SimpleCar<T>* simple_car,
 template <typename T>
 const SimpleCarParams<T>& get_params(const systems::Context<T>& context) {
   const SimpleCarParams<T>* const params =
-      dynamic_cast<const SimpleCarParams<T>*>(context.get_numeric_parameter(0));
+      dynamic_cast<const SimpleCarParams<T>*>(
+          &context.get_numeric_parameter(0));
   DRAKE_DEMAND(params);
   return *params;
 }

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -224,7 +224,7 @@ class MaliputRailcarTest : public ::testing::Test {
 
   // Sets the configuration parameters of the railcar.
   void SetParams(const MaliputRailcarParams<double>& params) {
-    dut_->get_mutable_parameters(context_.get())->SetFrom(params);
+    dut_->get_mutable_parameters(context_.get()).SetFrom(params);
   }
 
   // Obtains the lanes created by the call to InitializeTwoLaneStretchOfRoad().

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -394,7 +394,7 @@ TEST_F(SimpleCarTest, TestConstraints) {
   using systems::SystemConstraintIndex;
 
   SimpleCarParams<double>* params = dynamic_cast<SimpleCarParams<double>*>(
-      context_->get_mutable_numeric_parameter(0));
+      &context_->get_mutable_numeric_parameter(0));
   EXPECT_TRUE(params);
   SimpleCarState<double>* state = continuous_state();
 

--- a/drake/automotive/test/trajectory_optimization_test.cc
+++ b/drake/automotive/test/trajectory_optimization_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(TrajectoryOptimizationTest, SimpleCarDircolTest) {
 
   const SimpleCarParams<double>* params =
       dynamic_cast<const SimpleCarParams<double>*>(
-          context->get_numeric_parameter(0));
+          &context->get_numeric_parameter(0));
   DRAKE_DEMAND(params != nullptr);
 
   // Impose limits that are inside the true command limits.

--- a/drake/examples/geometry_world/solar_system.cc
+++ b/drake/examples/geometry_world/solar_system.cc
@@ -83,8 +83,8 @@ void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
   xc->SetFromVector(initial_state);
   DiscreteValues<T>* xd = state->get_mutable_discrete_state();
   for (int i = 0; i < xd->num_groups(); i++) {
-    BasicVector<T>* s = xd->get_mutable_vector(i);
-    s->SetFromVector(VectorX<T>::Zero(s->size()));
+    BasicVector<T>& s = xd->get_mutable_vector(i);
+    s.SetFromVector(VectorX<T>::Zero(s.size()));
   }
 }
 

--- a/drake/examples/kinova_jaco_arm/jaco_lcm.cc
+++ b/drake/examples/kinova_jaco_arm/jaco_lcm.cc
@@ -43,7 +43,7 @@ void JacoCommandReceiver::set_initial_position(
     Context<double>* context,
     const Eigen::Ref<const VectorX<double>> x) const {
   auto state_value =
-      context->get_mutable_discrete_state(0)->get_mutable_value();
+      context->get_mutable_discrete_state(0).get_mutable_value();
   DRAKE_ASSERT(x.size() == num_joints_ + num_fingers_);
   state_value.head(num_joints_ + num_fingers_) = x;
   state_value.tail(num_joints_ + num_fingers_) =
@@ -60,8 +60,8 @@ void JacoCommandReceiver::DoCalcDiscreteVariableUpdates(
 
   // If we're using a default constructed message (haven't received
   // a command yet), keep using the initial state.
-  BasicVector<double>* state = discrete_state->get_mutable_vector(0);
-  auto state_value = state->get_mutable_value();
+  BasicVector<double>& state = discrete_state->get_mutable_vector(0);
+  auto state_value = state.get_mutable_value();
   auto velocities = state_value.tail(num_joints_ + num_fingers_);
 
   DRAKE_DEMAND(command.num_joints == 0 || command.num_joints == num_joints_);
@@ -84,7 +84,7 @@ void JacoCommandReceiver::OutputCommand(const Context<double>& context,
                                         BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec =
       output->get_mutable_value();
-  output_vec = context.get_discrete_state(0)->get_value();
+  output_vec = context.get_discrete_state(0).get_value();
 }
 
 JacoCommandSender::JacoCommandSender(int num_joints, int num_fingers)
@@ -141,8 +141,8 @@ void JacoStatusReceiver::DoCalcDiscreteVariableUpdates(
   DRAKE_ASSERT(input != nullptr);
   const auto& status = input->GetValue<lcmt_jaco_status>();
 
-  BasicVector<double>* state = discrete_state->get_mutable_vector(0);
-  auto state_value = state->get_mutable_value();
+  BasicVector<double>& state = discrete_state->get_mutable_vector(0);
+  auto state_value = state.get_mutable_value();
   auto velocities = state_value.tail(num_joints_ + num_fingers_);
 
   DRAKE_DEMAND(status.num_joints == 0 || status.num_joints == num_joints_);
@@ -171,7 +171,7 @@ void JacoStatusReceiver::OutputStatus(const Context<double>& context,
                                       BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec =
       output->get_mutable_value();
-  output_vec = context.get_discrete_state(0)->get_value();
+  output_vec = context.get_discrete_state(0).get_value();
 }
 
 JacoStatusSender::JacoStatusSender(int num_joints, int num_fingers)

--- a/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -35,7 +35,7 @@ void IiwaCommandReceiver::set_initial_position(
     Context<double>* context,
     const Eigen::Ref<const VectorX<double>> x) const {
   auto state_value =
-      context->get_mutable_discrete_state(0)->get_mutable_value();
+      context->get_mutable_discrete_state(0).get_mutable_value();
   DRAKE_ASSERT(x.size() == num_joints_);
   state_value.head(num_joints_) = x;
   state_value.tail(num_joints_) = VectorX<double>::Zero(num_joints_);
@@ -61,8 +61,8 @@ void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
       new_positions(i) = command.joint_position[i];
     }
 
-    BasicVector<double>* state = discrete_state->get_mutable_vector(0);
-    auto state_value = state->get_mutable_value();
+    BasicVector<double>& state = discrete_state->get_mutable_vector(0);
+    auto state_value = state.get_mutable_value();
     state_value.tail(num_joints_) =
         (new_positions - state_value.head(num_joints_)) / kIiwaLcmStatusPeriod;
     state_value.head(num_joints_) = new_positions;
@@ -73,7 +73,7 @@ void IiwaCommandReceiver::OutputCommand(const Context<double>& context,
                                         BasicVector<double>* output) const {
   Eigen::VectorBlock<VectorX<double>> output_vec =
       output->get_mutable_value();
-  output_vec = context.get_discrete_state(0)->get_value();
+  output_vec = context.get_discrete_state(0).get_value();
 }
 
 IiwaCommandSender::IiwaCommandSender(int num_joints)
@@ -154,8 +154,8 @@ void IiwaStatusReceiver::DoCalcDiscreteVariableUpdates(
       commanded_position(i) = status.joint_position_commanded[i];
     }
 
-    BasicVector<double>* state = discrete_state->get_mutable_vector(0);
-    auto state_value = state->get_mutable_value();
+    BasicVector<double>& state = discrete_state->get_mutable_vector(0);
+    auto state_value = state.get_mutable_value();
     state_value.head(num_joints_) = measured_position;
     state_value.segment(num_joints_, num_joints_) = estimated_velocity;
     state_value.tail(num_joints_) = commanded_position;
@@ -164,7 +164,7 @@ void IiwaStatusReceiver::DoCalcDiscreteVariableUpdates(
 
 void IiwaStatusReceiver::OutputMeasuredPosition(const Context<double>& context,
                                        BasicVector<double>* output) const {
-  const auto state_value = context.get_discrete_state(0)->get_value();
+  const auto state_value = context.get_discrete_state(0).get_value();
 
   Eigen::VectorBlock<VectorX<double>> measured_position_output =
       output->get_mutable_value();
@@ -173,7 +173,7 @@ void IiwaStatusReceiver::OutputMeasuredPosition(const Context<double>& context,
 
 void IiwaStatusReceiver::OutputCommandedPosition(
     const Context<double>& context, BasicVector<double>* output) const {
-  const auto state_value = context.get_discrete_state(0)->get_value();
+  const auto state_value = context.get_discrete_state(0).get_value();
 
   Eigen::VectorBlock<VectorX<double>> commanded_position_output =
       output->get_mutable_value();

--- a/drake/examples/pendulum/test/pendulum_plant_test.cc
+++ b/drake/examples/pendulum/test/pendulum_plant_test.cc
@@ -44,7 +44,7 @@ GTEST_TEST(PendulumPlantTest, CalcTotalEnergy) {
   const auto context = plant.CreateDefaultContext();
 
   const auto params = dynamic_cast<const PendulumParams<double>*>(
-      context->get_numeric_parameter(0));
+      &context->get_numeric_parameter(0));
   EXPECT_TRUE(params);
 
   auto* state = dynamic_cast<PendulumState<double>*>(

--- a/drake/examples/rod2d/rod2d-inl.h
+++ b/drake/examples/rod2d/rod2d-inl.h
@@ -689,7 +689,7 @@ void Rod2D<T>::CopyStateOut(const systems::Context<T>& context,
                             systems::BasicVector<T>* state_port_value) const {
   // Output port value is just the continuous or discrete state.
   const VectorX<T> state = (simulation_type_ == SimulationType::kTimeStepping)
-                               ? context.get_discrete_state(0)->CopyToVector()
+                               ? context.get_discrete_state(0).CopyToVector()
                                : context.get_continuous_state()->CopyToVector();
   state_port_value->SetFromVector(state);
 }
@@ -699,7 +699,7 @@ void Rod2D<T>::CopyPoseOut(
     const systems::Context<T>& context,
     systems::rendering::PoseVector<T>* pose_port_value) const {
   const VectorX<T> state = (simulation_type_ == SimulationType::kTimeStepping)
-                               ? context.get_discrete_state(0)->CopyToVector()
+                               ? context.get_discrete_state(0).CopyToVector()
                                : context.get_continuous_state()->CopyToVector();
   ConvertStateToPose(state, pose_port_value);
 }
@@ -723,7 +723,7 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
   const double cfm = get_cfm();
 
   // Get the necessary state variables.
-  const systems::BasicVector<T>& state = *context.get_discrete_state(0);
+  const systems::BasicVector<T>& state = context.get_discrete_state(0);
   const auto& q = state.get_value().template segment<3>(0);
   Vector3<T> v = state.get_value().template segment<3>(3);
   const T& x = q(0);
@@ -855,9 +855,9 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> qplus = q + vplus*dt_;
 
   // Set the new discrete state.
-  systems::BasicVector<T>* new_state = discrete_state->get_mutable_vector(0);
-  new_state->get_mutable_value().segment(0, 3) = qplus;
-  new_state->get_mutable_value().segment(3, 3) = vplus;
+  systems::BasicVector<T>& new_state = discrete_state->get_mutable_vector(0);
+  new_state.get_mutable_value().segment(0, 3) = qplus;
+  new_state.get_mutable_value().segment(3, 3) = vplus;
 }
 
 /// Models impact using an inelastic impact model with friction.
@@ -2235,7 +2235,7 @@ void Rod2D<T>::SetDefaultState(const systems::Context<T>&,
   x0 << half_len * r22, half_len * r22, M_PI / 4.0, -1, 0, 0;  // Initial state.
   if (simulation_type_ == SimulationType::kTimeStepping) {
     state->get_mutable_discrete_state()->get_mutable_vector(0)
-        ->SetFromVector(x0);
+        .SetFromVector(x0);
   } else {
     // Continuous variables.
     state->get_mutable_continuous_state()->SetFromVector(x0);

--- a/drake/examples/rod2d/test/rod2d_test.cc
+++ b/drake/examples/rod2d/test/rod2d_test.cc
@@ -1102,7 +1102,7 @@ class Rod2DTimeSteppingTest : public ::testing::Test {
     context_->FixInputPort(0, std::move(ext_input));
   }
 
-  BasicVector<double> *mutable_discrete_state() {
+  BasicVector<double>& mutable_discrete_state() {
     return context_->get_mutable_discrete_state(0);
   }
 // Sets a secondary initial Rod2D configuration.
@@ -1116,7 +1116,7 @@ class Rod2DTimeSteppingTest : public ::testing::Test {
     using std::sqrt;
     const double half_len = dut_->get_rod_half_length();
     const double r22 = std::sqrt(2) / 2;
-    auto xd = mutable_discrete_state()->get_mutable_value();
+    auto xd = mutable_discrete_state().get_mutable_value();
 
     xd[0] = -half_len * r22;
     xd[1] = half_len * r22;
@@ -1146,7 +1146,7 @@ TEST_F(Rod2DTimeSteppingTest, RodGoesToRest) {
   simulator.StepTo(t_final);
 
   // Get angular orientation and velocity.
-  const auto xd = simulator.get_context().get_discrete_state(0)->get_value();
+  const auto xd = simulator.get_context().get_discrete_state(0).get_value();
   const double theta = xd(2);
   const double theta_dot = xd(5);
 
@@ -1215,7 +1215,7 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSliding) {
 
   // See whether the states are equal.
   const Context<double>& context_ts_new = simulator_ts.get_context();
-  const auto& xd = context_ts_new.get_discrete_state(0)->get_value();
+  const auto& xd = context_ts_new.get_discrete_state(0).get_value();
 
   // Check that the solution is nearly identical.
   const double tol = std::numeric_limits<double>::epsilon() * 10;
@@ -1258,7 +1258,7 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSticking) {
   const double half_len = pdae.get_rod_half_length();
   ContinuousState<double>& xc =
       *context_pdae->get_mutable_continuous_state();
-  auto xd = context_ts->get_mutable_discrete_state(0)->get_mutable_value();
+  auto xd = context_ts->get_mutable_discrete_state(0).get_mutable_value();
   xc[0] = xd[0] = 0.0;
   xc[1] = xd[1] = half_len;
   xc[2] = xd[2] = M_PI_2;

--- a/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
+++ b/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
@@ -32,7 +32,7 @@ class SimpleMixedContinuousTimeDiscreteTimeSystem
       const drake::systems::Context<double>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<double>*>&,
       drake::systems::DiscreteValues<double>* updates) const override {
-    const double x = context.get_discrete_state(0)->GetAtIndex(0);
+    const double x = context.get_discrete_state(0).GetAtIndex(0);
     const double xn = std::pow(x, 3.0);
     (*updates)[0] = xn;
   }
@@ -50,7 +50,7 @@ class SimpleMixedContinuousTimeDiscreteTimeSystem
   void CopyStateOut(
       const drake::systems::Context<double>& context,
       drake::systems::BasicVector<double>* output) const {
-    const double x1 = context.get_discrete_state(0)->GetAtIndex(0);
+    const double x1 = context.get_discrete_state(0).GetAtIndex(0);
     output->SetAtIndex(0, x1);
 
     const double x2 = context.get_continuous_state_vector().GetAtIndex(0);

--- a/drake/examples/van_der_pol/van_der_pol.cc
+++ b/drake/examples/van_der_pol/van_der_pol.cc
@@ -28,7 +28,7 @@ VanDerPolOscillator<T>::VanDerPolOscillator() : systems::LeafSystem<T>() {
   typename systems::SystemConstraint<T>::CalcCallback mu = [](
       const systems::Context<T>& context, VectorX<T>* value) {
     // Extract μ from the parameters.
-    *value = Vector1<T>(context.get_numeric_parameter(0)->GetAtIndex(0));
+    *value = Vector1<T>(context.get_numeric_parameter(0).GetAtIndex(0));
   };
   this->DeclareInequalityConstraint(mu, 1, "mu ≥ 0");
 }
@@ -42,7 +42,7 @@ void VanDerPolOscillator<T>::DoCalcTimeDerivatives(
       context.get_continuous_state()->get_generalized_position().GetAtIndex(0);
   const T qdot =
       context.get_continuous_state()->get_generalized_velocity().GetAtIndex(0);
-  const T mu = context.get_numeric_parameter(0)->GetAtIndex(0);
+  const T mu = context.get_numeric_parameter(0).GetAtIndex(0);
 
   using std::pow;
   const T qddot = -mu * (q * q - 1) * qdot - q;

--- a/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -43,7 +43,7 @@ void SchunkWsgTrajectoryGenerator::OutputTarget(
 
   const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
       dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          context.get_discrete_state(0));
+          &context.get_discrete_state(0));
 
   if (trajectory_) {
     output->get_mutable_value() = trajectory_->value(
@@ -60,7 +60,7 @@ void SchunkWsgTrajectoryGenerator::OutputForce(
 
   const SchunkWsgTrajectoryGeneratorStateVector<double>* traj_state =
       dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          context.get_discrete_state(0));
+          &context.get_discrete_state(0));
   output->get_mutable_value() = Vector1d(traj_state->max_force());
 }
 
@@ -87,10 +87,10 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
 
   const SchunkWsgTrajectoryGeneratorStateVector<double>* last_traj_state =
       dynamic_cast<const SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          context.get_discrete_state(0));
+          &context.get_discrete_state(0));
   SchunkWsgTrajectoryGeneratorStateVector<double>* new_traj_state =
       dynamic_cast<SchunkWsgTrajectoryGeneratorStateVector<double>*>(
-          discrete_state->get_mutable_vector(0));
+          &discrete_state->get_mutable_vector(0));
   new_traj_state->set_last_position(cur_position);
 
   double max_force = command.force;

--- a/drake/multibody/dev/test/quadrotor_test.cc
+++ b/drake/multibody/dev/test/quadrotor_test.cc
@@ -112,7 +112,7 @@ GTEST_TEST(QuadrotorTest, Equality) {
   // Set the initial conditions for the discrete plant.
   Context<double>& discrete_context = discrete_model.GetMutableSubsystemContext(
       discrete_plant, discrete_sim.get_mutable_context());
-  discrete_context.get_mutable_discrete_state()->get_mutable_vector()->
+  discrete_context.get_mutable_discrete_state()->get_mutable_vector().
       SetFromVector(x0);
 
   // Step both forward by one step into the future.

--- a/drake/multibody/dev/time_stepping_rigid_body_plant.cc
+++ b/drake/multibody/dev/time_stepping_rigid_body_plant.cc
@@ -148,7 +148,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   const auto& tree = this->get_rigid_body_tree();
 
   // Get the system state.
-  auto x = context.get_discrete_state(0)->get_value();
+  auto x = context.get_discrete_state(0).get_value();
   VectorX<T> q = x.topRows(nq);
   VectorX<T> v = x.bottomRows(nv);
   auto kcache = tree.doKinematics(q, v);
@@ -242,7 +242,7 @@ void TimeSteppingRigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
   // qn = q + dt*qdot.
   VectorX<T> xn(this->get_num_states());
   xn << q + dt * tree.transformVelocityToQDot(kcache, vnew), vnew;
-  updates->get_mutable_vector(0)->SetFromVector(xn);
+  updates->get_mutable_vector(0).SetFromVector(xn);
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -111,16 +111,16 @@ class DrakeVisualizer : public LeafSystem<double> {
  private:
   // Returns true if initialization phase has been completed.
   bool is_load_message_sent(const Context<double>& context) const {
-    return context.get_discrete_state(0)->GetAtIndex(0) > 0;
+    return context.get_discrete_state(0).GetAtIndex(0) > 0;
   }
 
   // Sets the discrete state to @p flag.
   void set_is_load_message_sent(DiscreteValues<double>* state,
                                 bool flag) const {
     if (flag)
-      state->get_mutable_vector(0)->SetAtIndex(0, 1);
+      state->get_mutable_vector(0).SetAtIndex(0, 1);
     else
-      state->get_mutable_vector(0)->SetAtIndex(0, 0);
+      state->get_mutable_vector(0).SetAtIndex(0, 0);
   }
 
   // Set the default to "initialization phase has not been completed."

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -265,7 +265,7 @@ void RigidBodyPlant<T>::set_position(Context<T>* context, int position_index,
                                      T position) const {
   DRAKE_ASSERT(context != nullptr);
   if (is_state_discrete()) {
-    context->get_mutable_discrete_state(0)->SetAtIndex(position_index,
+    context->get_mutable_discrete_state(0).SetAtIndex(position_index,
                                                        position);
   } else {
     context->get_mutable_continuous_state()
@@ -279,7 +279,7 @@ void RigidBodyPlant<T>::set_velocity(Context<T>* context, int velocity_index,
                                      T velocity) const {
   DRAKE_ASSERT(context != nullptr);
   if (is_state_discrete()) {
-    context->get_mutable_discrete_state(0)->SetAtIndex(
+    context->get_mutable_discrete_state(0).SetAtIndex(
         get_num_positions() + velocity_index, velocity);
   } else {
     context->get_mutable_continuous_state()
@@ -302,7 +302,7 @@ void RigidBodyPlant<T>::set_state_vector(
   DRAKE_ASSERT(x.size() == get_num_states());
   if (is_state_discrete()) {
     auto* xd = state->get_mutable_discrete_state();
-    xd->get_mutable_vector(0)->SetFromVector(x);
+    xd->get_mutable_vector(0).SetFromVector(x);
   } else {
     state->get_mutable_continuous_state()->SetFromVector(x);
   }
@@ -395,7 +395,7 @@ void RigidBodyPlant<T>::CopyStateToOutput(const Context<T>& context,
   // TODO(amcastro-tri): Remove this copy by allowing output ports to be
   // mere pointers to state variables (or cache lines).
   const VectorX<T> state_vector =
-      (is_state_discrete()) ? context.get_discrete_state(0)->CopyToVector()
+      (is_state_discrete()) ? context.get_discrete_state(0).CopyToVector()
                             : context.get_continuous_state()->CopyToVector();
 
   state_output_vector->get_mutable_value() = state_vector;
@@ -408,7 +408,7 @@ void RigidBodyPlant<T>::CalcInstanceOutput(
     BasicVector<T>* instance_output) const {
   // TODO(sherm1) Should reference state rather than copy it here.
   const VectorX<T> state_vector =
-      (is_state_discrete()) ? context.get_discrete_state(0)->CopyToVector()
+      (is_state_discrete()) ? context.get_discrete_state(0).CopyToVector()
                             : context.get_continuous_state()->CopyToVector();
 
   auto values = instance_output->get_mutable_value();
@@ -555,7 +555,7 @@ void RigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   VectorX<T> u = EvaluateActuatorInputs(context);
 
-  auto x = context.get_discrete_state(0)->get_value();
+  auto x = context.get_discrete_state(0).get_value();
 
   const int nq = get_num_positions();
   const int nv = get_num_velocities();
@@ -595,7 +595,7 @@ void RigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // qn = q + h*qdn.
   xn << q + timestep_ * tree_->transformVelocityToQDot(kinsol, vn_sol), vn_sol;
-  updates->get_mutable_vector(0)->SetFromVector(xn);
+  updates->get_mutable_vector(0).SetFromVector(xn);
 }
 
 template <typename T>

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -218,13 +218,12 @@ class RigidBodyPlant : public LeafSystem<T> {
     x0.head(get_num_positions()) = tree_->getZeroConfiguration();
 
     if (is_state_discrete()) {
-      // Extract a pointer to the discrete state from the context.
-      BasicVector<T>* xd =
+      // Extract a reference to the discrete state from the context.
+      BasicVector<T>& xd =
           state->get_mutable_discrete_state()->get_mutable_vector(0);
-      DRAKE_DEMAND(xd != nullptr);
 
       // Write the zero configuration into the discrete state.
-      xd->SetFromVector(x0);
+      xd.SetFromVector(x0);
     } else {
       // Extract a pointer to continuous state from the context.
       ContinuousState<T>* xc = state->get_mutable_continuous_state();

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -547,7 +547,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   EXPECT_TRUE(continuous_context->has_only_continuous_state());
   EXPECT_TRUE(time_stepping_context->has_only_discrete_state());
   EXPECT_EQ(continuous_context->get_continuous_state()->size(),
-            time_stepping_context->get_discrete_state(0)->size());
+            time_stepping_context->get_discrete_state(0).size());
 
   // Check that the dynamics of the time-stepping model match the
   // (backwards-)Euler approximation of the continuous time dynamics.
@@ -559,7 +559,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
 
   const VectorXd x = continuous_context->get_continuous_state()->CopyToVector();
   EXPECT_TRUE(CompareMatrices(
-      x, time_stepping_context->get_discrete_state(0)->CopyToVector()));
+      x, time_stepping_context->get_discrete_state(0).CopyToVector()));
 
   const VectorXd q = continuous_context->get_continuous_state()
                          ->get_generalized_position()
@@ -580,7 +580,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   VectorXd xn(qn.rows() + vn.rows());
   xn << qn, vn;
 
-  EXPECT_TRUE(CompareMatrices(updates->get_vector(0)->CopyToVector(), xn));
+  EXPECT_TRUE(CompareMatrices(updates->get_vector(0).CopyToVector(), xn));
 }
 
 }  // namespace

--- a/drake/systems/controllers/linear_model_predictive_controller.cc
+++ b/drake/systems/controllers/linear_model_predictive_controller.cc
@@ -29,7 +29,7 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
       model_(std::move(model)),
       base_context_(std::move(base_context)),
       num_states_(
-          model_->CreateDefaultContext()->get_discrete_state(0)->size()),
+          model_->CreateDefaultContext()->get_discrete_state(0).size()),
       num_inputs_(model_->get_input_port(0).size()),
       Q_(Q),
       R_(R),
@@ -103,7 +103,7 @@ VectorX<T> LinearModelPredictiveController<T>::SetupAndSolveQp(
                       input_error.transpose() * R_ * input_error);
 
   const VectorX<T> state_ref =
-      base_context.get_discrete_state()->get_vector()->CopyToVector();
+      base_context.get_discrete_state()->get_vector().CopyToVector();
   prog.AddLinearConstraint(prog.initial_state() == current_state - state_ref);
 
   DRAKE_DEMAND(prog.Solve() == solvers::SolutionResult::kSolutionFound);

--- a/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -40,7 +40,7 @@ class TestMpcWithDoubleIntegrator : public ::testing::Test {
     std::unique_ptr<Context<double>> system_context =
         system->CreateDefaultContext();
     system_context->FixInputPort(0, u0);
-    system_context->get_mutable_discrete_state(0)->SetFromVector(x0);
+    system_context->get_mutable_discrete_state(0).SetFromVector(x0);
 
     dut_.reset(new LinearModelPredictiveController<double>(
         std::move(system), std::move(system_context), Q_, R_, kTimeStep,
@@ -112,15 +112,15 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* next_state) const final {
     using std::pow;
-    const T& x1 = context.get_discrete_state(0)->get_value()[0];
+    const T& x1 = context.get_discrete_state(0).get_value()[0];
     const T& u = this->EvalVectorInput(context, 0)->get_value()[0];
-    next_state->get_mutable_vector(0)->SetAtIndex(0, u);
-    next_state->get_mutable_vector(0)->SetAtIndex(1, pow(x1, 3.));
+    next_state->get_mutable_vector(0).SetAtIndex(0, u);
+    next_state->get_mutable_vector(0).SetAtIndex(1, pow(x1, 3.));
   }
 
   void OutputState(const systems::Context<T>& context,
                    BasicVector<T>* output) const {
-    output->set_value(context.get_discrete_state(0)->get_value());
+    output->set_value(context.get_discrete_state(0).get_value());
   }
 
   // TODO(jadecastro) We know a discrete system of this format does not have
@@ -154,9 +154,9 @@ class TestMpcWithCubicSystem : public ::testing::Test {
     context->FixInputPort(0, Vector1d::Constant(0.));
 
     // Set the nominal state.
-    BasicVector<double>* x =
+    BasicVector<double>& x =
         context->get_mutable_discrete_state()->get_mutable_vector();
-    x->SetFromVector(Eigen::Vector2d::Zero());  // Fixed point is zero.
+    x.SetFromVector(Eigen::Vector2d::Zero());  // Fixed point is zero.
 
     dut_.reset(new LinearModelPredictiveController<double>(
         std::move(system_), std::move(context), Q_, R_, time_step_,
@@ -198,11 +198,11 @@ class TestMpcWithCubicSystem : public ::testing::Test {
     Context<double>& cubic_system_context =
         diagram_->GetMutableSubsystemContext(cubic_system,
                                              simulator_->get_mutable_context());
-    BasicVector<double>* x0 =
+    BasicVector<double>& x0 =
         cubic_system_context.get_mutable_discrete_state()->get_mutable_vector();
 
     // Set an initial condition near the fixed point.
-    x0->SetFromVector(10. * Eigen::Vector2d::Ones());
+    x0.SetFromVector(10. * Eigen::Vector2d::Ones());
 
     simulator_->set_target_realtime_rate(1.);
     simulator_->Initialize();
@@ -232,7 +232,7 @@ TEST_F(TestMpcWithCubicSystem, TimeInvariantMpc) {
   // Result should be deadbeat; expect convergence to within a tiny tolerance in
   // one step.
   Eigen::Vector2d result =
-      simulator_->get_mutable_context()->get_discrete_state(0)->get_value();
+      simulator_->get_mutable_context()->get_discrete_state(0).get_value();
   EXPECT_TRUE(CompareMatrices(result, Eigen::Vector2d::Zero(), kTolerance));
 }
 

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -92,7 +92,7 @@ class Context {
     DRAKE_THROW_UNLESS(get_num_abstract_state_groups() == 0);
     int count = get_continuous_state()->size();
     for (int i = 0; i < get_num_discrete_state_groups(); i++)
-      count += get_discrete_state(i)->size();
+      count += get_discrete_state(i).size();
     return count;
   }
 
@@ -136,8 +136,8 @@ class Context {
 
   /// Returns a reference to the discrete state vector. The vector may be of
   /// size zero.
-  const VectorBase<T>& get_discrete_state_vector() const {
-    return *get_discrete_state()->get_vector();
+  const BasicVector<T>& get_discrete_state_vector() const {
+    return get_discrete_state()->get_vector();
   }
 
   /// Returns a mutable pointer to the discrete component of the state,
@@ -148,7 +148,7 @@ class Context {
 
   /// Returns a mutable pointer to element @p index of the discrete state.
   /// Asserts if @p index doesn't exist.
-  BasicVector<T>* get_mutable_discrete_state(int index) {
+  BasicVector<T>& get_mutable_discrete_state(int index) {
     DiscreteValues<T>* xd = get_mutable_discrete_state();
     return xd->get_mutable_vector(index);
   }
@@ -160,7 +160,7 @@ class Context {
 
   /// Returns a const pointer to the discrete component of the
   /// state at @p index.  Asserts if @p index doesn't exist.
-  const BasicVector<T>* get_discrete_state(int index) const {
+  const BasicVector<T>& get_discrete_state(int index) const {
     const DiscreteValues<T>* xd = get_state().get_discrete_state();
     return xd->get_vector(index);
   }
@@ -343,13 +343,13 @@ class Context {
 
   /// Returns a const pointer to the vector-valued parameter at @p index.
   /// Asserts if @p index doesn't exist.
-  const BasicVector<T>* get_numeric_parameter(int index) const {
+  const BasicVector<T>& get_numeric_parameter(int index) const {
     return get_parameters().get_numeric_parameter(index);
   }
 
   /// Returns a mutable pointer to element @p index of the vector-valued
   /// parameters. Asserts if @p index doesn't exist.
-  BasicVector<T>* get_mutable_numeric_parameter(int index) {
+  BasicVector<T>& get_mutable_numeric_parameter(int index) {
     return get_mutable_parameters().get_mutable_numeric_parameter(index);
   }
 

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -352,7 +352,7 @@ class Diagram : public System<T>,
 
       std::vector<BasicVector<T>*> numeric_params;
       for (int j = 0; j < subcontext.num_numeric_parameters(); ++j) {
-        numeric_params.push_back(params->get_mutable_numeric_parameter(
+        numeric_params.push_back(&params->get_mutable_numeric_parameter(
             numeric_parameter_offset + j));
       }
       numeric_parameter_offset += subcontext.num_numeric_parameters();
@@ -418,7 +418,7 @@ class Diagram : public System<T>,
       std::vector<BasicVector<T>*> numeric_params;
       std::vector<AbstractValue*> abstract_params;
       for (int j = 0; j < subcontext.num_numeric_parameters(); ++j) {
-        numeric_params.push_back(params->get_mutable_numeric_parameter(
+        numeric_params.push_back(&params->get_mutable_numeric_parameter(
             numeric_parameter_offset + j));
       }
       numeric_parameter_offset += subcontext.num_numeric_parameters();
@@ -1149,8 +1149,8 @@ class Diagram : public System<T>,
     // current values.
     // TODO(siyuan): should have a API level CopyFrom for DiscreteValues.
     for (int i = 0; i < diagram_discrete->num_groups(); ++i) {
-      diagram_discrete->get_mutable_vector(i)->set_value(
-          context.get_discrete_state(i)->get_value());
+      diagram_discrete->get_mutable_vector(i).set_value(
+          context.get_discrete_state(i).get_value());
     }
 
     const DiagramEventCollection<DiscreteUpdateEvent<T>>& info =

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -215,7 +215,7 @@ class DiagramContext : public Context<T> {
     for (auto& subcontext : contexts_) {
       Parameters<T>& subparams = subcontext->get_mutable_parameters();
       for (int i = 0; i < subparams.num_numeric_parameters(); ++i) {
-        numeric_params.push_back(subparams.get_mutable_numeric_parameter(i));
+        numeric_params.push_back(&subparams.get_mutable_numeric_parameter(i));
       }
       for (int i = 0; i < subparams.num_abstract_parameters(); ++i) {
         abstract_params.push_back(

--- a/drake/systems/framework/discrete_values.h
+++ b/drake/systems/framework/discrete_values.h
@@ -12,16 +12,20 @@
 namespace drake {
 namespace systems {
 
-/// The DiscreteValues is a container for numerical but non-continuous state
+/// %DiscreteValues is a container for numerical but non-continuous state
 /// and parameters. It may own its underlying data, for use with leaf Systems,
 /// or not, for use with Diagrams.
 ///
-/// DiscreteValues is an ordered collection of vectors xd = [xd0, xd1...].
-/// Requesting a specific index from this collection is the most granular way
+/// %DiscreteValues is an ordered collection xd of BasicVector "groups" so
+/// xd = [xd₀, xd₁...], where each group xdᵢ is a contiguous vector. Requesting
+/// a specific group index from this collection is the most granular way
 /// to retrieve discrete values from the Context, and thus is the unit of
 /// cache invalidation. System authors are encouraged to partition their
 /// DiscreteValues such that each cacheable computation within the System may
 /// depend on only the elements of DiscreteValues that it needs.
+///
+/// None of the contained vectors (groups) may be null, although any of them may
+/// be zero-length.
 ///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
 template <typename T>
@@ -30,25 +34,37 @@ class DiscreteValues {
   // DiscreteValues is not copyable or moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteValues)
 
-  /// Constructs an empty discrete values.
+  /// Constructs an empty %DiscreteValues.
   DiscreteValues() {}
 
-  /// Constructs a DiscreteValues that does not own the underlying @p data.
-  /// The data must outlive this DiscreteValues.
+  /// Constructs a %DiscreteValues that does not own the underlying @p data.
+  /// The referenced data must outlive this DiscreteValues. Every entry must be
+  /// non-null.
   explicit DiscreteValues(const std::vector<BasicVector<T>*>& data)
-      : data_(data) {}
+      : data_(data) {
+    for (BasicVector<T>* basic_vector_ptr : data_) {
+      if (basic_vector_ptr == nullptr)
+        throw std::logic_error("DiscreteValues: null groups not allowed");
+    }
+  }
 
-  /// Constructs a DiscreteValues that owns the underlying @p data.
+  /// Constructs a %DiscreteValues that owns the underlying @p data. Every entry
+  /// must be non-null.
   explicit DiscreteValues(std::vector<std::unique_ptr<BasicVector<T>>>&& data)
       : owned_data_(std::move(data)) {
     // Initialize the unowned pointers.
     for (auto& datum : owned_data_) {
+      if (datum == nullptr)
+        throw std::logic_error("DiscreteValues: null groups not allowed");
       data_.push_back(datum.get());
     }
   }
 
-  /// Constructs a DiscreteValues that owns a single @p datum vector.
+  /// Constructs a one-group %DiscreteValues object that owns a single @p datum
+  /// vector which may not be null.
   explicit DiscreteValues(std::unique_ptr<BasicVector<T>> datum) {
+    if (datum == nullptr)
+      throw std::logic_error("DiscreteValues: null groups not allowed");
     data_.push_back(datum.get());
     owned_data_.push_back(std::move(datum));
   }
@@ -60,47 +76,58 @@ class DiscreteValues {
   const std::vector<BasicVector<T>*>& get_data() const { return data_; }
 
   //----------------------------------------------------------------------------
-  /// @name Convenience accessors for DiscreteValues with just one group.
-  ///
+  /// @name Convenience accessors for %DiscreteValues with just one group.
+  /// These will fail (at least in Debug builds) if there is more than one
+  /// group in this %DiscreteValues object.
   //@{
 
-  /// Returns the number of elements in the only DiscreteValues group.
+  /// Returns the number of elements in the only %DiscreteValues group.
   int size() const {
     DRAKE_ASSERT(num_groups() == 1);
     return data_[0]->size();
   }
 
+  /// Returns a mutable reference to an element in the _only_ group.
   T& operator[](std::size_t idx) {
     DRAKE_ASSERT(num_groups() == 1);
     return (*data_[0])[idx];
   }
 
+  /// Returns a const reference to an element in the _only_ group.
   const T& operator[](std::size_t idx) const {
     DRAKE_ASSERT(num_groups() == 1);
     return (*data_[0])[idx];
   }
 
-  const BasicVector<T>* get_vector() const {
+  /// Returns a const reference to the BasicVector containing the values for
+  /// the _only_ group.
+  const BasicVector<T>& get_vector() const {
     DRAKE_ASSERT(num_groups() == 1);
     return get_vector(0);
   }
 
-  BasicVector<T>* get_mutable_vector() {
+  /// Returns a mutable reference to the BasicVector containing the values for
+  /// the _only_ group.
+  BasicVector<T>& get_mutable_vector() {
     DRAKE_ASSERT(num_groups() == 1);
     return get_mutable_vector(0);
   }
-
   //@}
 
-
-  const BasicVector<T>* get_vector(int index) const {
+  /// Returns a const reference to the vector holding data for the indicated
+  /// group.
+  const BasicVector<T>& get_vector(int index) const {
     DRAKE_ASSERT(index >= 0 && index < num_groups());
-    return data_[index];
+    DRAKE_ASSERT(data_[index] != nullptr);
+    return *data_[index];
   }
 
-  BasicVector<T>* get_mutable_vector(int index) {
+  /// Returns a mutable reference to the vector holding data for the indicated
+  /// group.
+  BasicVector<T>& get_mutable_vector(int index) {
     DRAKE_ASSERT(index >= 0 && index < num_groups());
-    return data_[index];
+    DRAKE_ASSERT(data_[index] != nullptr);
+    return *data_[index];
   }
 
   /// Writes the values from @p other into this DiscreteValues, possibly
@@ -115,6 +142,7 @@ class DiscreteValues {
   /// Returns a deep copy of all the data in this DiscreteValues. The clone
   /// will own its own data. This is true regardless of whether the values being
   /// cloned had ownership of its data or not.
+  // TODO(sherm1) This slices DiagramDiscreteVariables and needs to be reworked.
   std::unique_ptr<DiscreteValues> Clone() const {
     std::vector<std::unique_ptr<BasicVector<T>>> cloned_data;
     cloned_data.reserve(data_.size());
@@ -137,10 +165,9 @@ class DiscreteValues {
   void SetFromGeneric(const DiscreteValues<U>& other) {
     DRAKE_ASSERT(num_groups() == other.num_groups());
     for (int i = 0; i < num_groups(); i++) {
-      DRAKE_ASSERT(other.get_vector(i) != nullptr);
       DRAKE_ASSERT(data_[i] != nullptr);
       data_[i]->set_value(
-          other.get_vector(i)->get_value().template cast<T>());
+          other.get_vector(i).get_value().template cast<T>());
     }
   }
 };

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -147,8 +147,8 @@ class LeafSystem : public System<T> {
     // -- The numeric parameters must all be valid BasicVectors.
     const int num_numeric_parameters = context->num_numeric_parameters();
     for (int i = 0; i < num_numeric_parameters; ++i) {
-      const BasicVector<T>* const group = context->get_numeric_parameter(i);
-      detail::CheckBasicVectorInvariants(group);
+      const BasicVector<T>& group = context->get_numeric_parameter(i);
+      detail::CheckBasicVectorInvariants(&group);
     }
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.
@@ -174,8 +174,8 @@ class LeafSystem : public System<T> {
     }
     DiscreteValues<T>* xd = state->get_mutable_discrete_state();
     for (int i = 0; i < xd->num_groups(); i++) {
-      BasicVector<T>* s = xd->get_mutable_vector(i);
-      s->SetFromVector(VectorX<T>::Zero(s->size()));
+      BasicVector<T>& s = xd->get_mutable_vector(i);
+      s.SetFromVector(VectorX<T>::Zero(s.size()));
     }
   }
 
@@ -187,12 +187,12 @@ class LeafSystem : public System<T> {
                             Parameters<T>* parameters) const override {
     unused(context);
     for (int i = 0; i < parameters->num_numeric_parameters(); i++) {
-      BasicVector<T>* p = parameters->get_mutable_numeric_parameter(i);
+      BasicVector<T>& p = parameters->get_mutable_numeric_parameter(i);
       auto model_vector = model_numeric_parameters_.CloneVectorModel<T>(i);
       if (model_vector != nullptr) {
-        p->SetFrom(*model_vector);
+        p.SetFrom(*model_vector);
       } else {
-        p->SetFromVector(VectorX<T>::Constant(p->size(), 1.0));
+        p.SetFromVector(VectorX<T>::Constant(p.size(), 1.0));
       }
     }
   }
@@ -523,9 +523,8 @@ class LeafSystem : public System<T> {
     MaybeDeclareVectorBaseInequalityConstraint(
         "parameter " + std::to_string(index), model_vector,
         [index](const Context<T>& context) -> const VectorBase<T>& {
-          const BasicVector<T>* result = context.get_numeric_parameter(index);
-          DRAKE_DEMAND(result != nullptr);
-          return *result;
+          const BasicVector<T>& result = context.get_numeric_parameter(index);
+          return result;
         });
     return index;
   }
@@ -540,7 +539,7 @@ class LeafSystem : public System<T> {
     const auto& leaf_context =
         dynamic_cast<const systems::LeafContext<T>&>(context);
     const auto* const params =
-        dynamic_cast<const U<T>*>(leaf_context.get_numeric_parameter(index));
+        dynamic_cast<const U<T>*>(&leaf_context.get_numeric_parameter(index));
     DRAKE_ASSERT(params != nullptr);
     return *params;
   }
@@ -549,15 +548,15 @@ class LeafSystem : public System<T> {
   /// Asserts if the context is not a LeafContext, or if it does not have a
   /// vector-valued parameter of type U at @p index.
   template <template <typename> class U = BasicVector>
-  U<T>* GetMutableNumericParameter(Context<T>* context, int index) const {
+  U<T>& GetMutableNumericParameter(Context<T>* context, int index) const {
     static_assert(std::is_base_of<BasicVector<T>, U<T>>::value,
                   "U must be a subclass of BasicVector.");
     auto* leaf_context = dynamic_cast<systems::LeafContext<T>*>(context);
     DRAKE_ASSERT(leaf_context != nullptr);
-    auto* params =
-        dynamic_cast<U<T>*>(leaf_context->get_mutable_numeric_parameter(index));
+    auto* const params = dynamic_cast<U<T>*>(
+        &leaf_context->get_mutable_numeric_parameter(index));
     DRAKE_ASSERT(params != nullptr);
-    return params;
+    return *params;
   }
 
   /// Declares that this System has a simple, fixed-period event specified with

--- a/drake/systems/framework/parameters.h
+++ b/drake/systems/framework/parameters.h
@@ -73,13 +73,13 @@ class Parameters {
 
   /// Returns the vector-valued parameter at @p index. Asserts if the index
   /// is out of bounds.
-  const BasicVector<T>* get_numeric_parameter(int index) const {
+  const BasicVector<T>& get_numeric_parameter(int index) const {
     return numeric_parameters_->get_vector(index);
   }
 
   /// Returns the vector-valued parameter at @p index. Asserts if the index
   /// is out of bounds.
-  BasicVector<T>* get_mutable_numeric_parameter(int index) {
+  BasicVector<T>& get_mutable_numeric_parameter(int index) {
     return numeric_parameters_->get_mutable_vector(index);
   }
 

--- a/drake/systems/framework/system_symbolic_inspector.cc
+++ b/drake/systems/framework/system_symbolic_inspector.cc
@@ -113,7 +113,7 @@ void SystemSymbolicInspector::InitializeDiscreteState() {
   // expression whose value is the variable "xdi_j".
   auto& xd = *context_->get_mutable_discrete_state();
   for (int i = 0; i < context_->get_num_discrete_state_groups(); ++i) {
-    auto& xdi = *xd.get_mutable_vector(i);
+    auto& xdi = xd.get_mutable_vector(i);
     discrete_state_variables_[i].resize(xdi.size());
     for (int j = 0; j < xdi.size(); ++j) {
       std::ostringstream name;
@@ -128,7 +128,7 @@ void SystemSymbolicInspector::InitializeParameters() {
   // For each numeric parameter vector i, set each element j to a symbolic
   // expression whose value is the variable "pi_j".
   for (int i = 0; i < context_->num_numeric_parameters(); ++i) {
-    auto& pi = *(context_->get_mutable_numeric_parameter(i));
+    auto& pi = context_->get_mutable_numeric_parameter(i);
     numeric_parameters_[i].resize(pi.size());
     for (int j = 0; j < pi.size(); ++j) {
       std::ostringstream name;
@@ -227,7 +227,7 @@ bool SystemSymbolicInspector::IsTimeInvariant() const {
     return false;
   }
   for (int i = 0; i < discrete_updates_->num_groups(); ++i) {
-    if (!is_time_invariant(discrete_updates_->get_vector(i)->get_value(),
+    if (!is_time_invariant(discrete_updates_->get_vector(i).get_value(),
                            time_)) {
       return false;
     }
@@ -283,7 +283,7 @@ bool SystemSymbolicInspector::HasAffineDynamics() const {
     return false;
   }
   for (int i = 0; i < discrete_updates_->num_groups(); ++i) {
-    if (!is_affine(discrete_updates_->get_vector(i)->get_value(), vars)) {
+    if (!is_affine(discrete_updates_->get_vector(i).get_value(), vars)) {
       return false;
     }
   }

--- a/drake/systems/framework/system_symbolic_inspector.h
+++ b/drake/systems/framework/system_symbolic_inspector.h
@@ -114,7 +114,7 @@ class SystemSymbolicInspector {
   Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
       int i) const {
     DRAKE_DEMAND(i >= 0 && i < static_cast<int>(discrete_updates_->size()));
-    return discrete_updates_->get_vector(i)->get_value();
+    return discrete_updates_->get_vector(i).get_value();
   }
 
   /// Returns a reference to the symbolic representation of the output.

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -98,10 +98,10 @@ class DiagramContextTest : public ::testing::Test {
     xc->get_mutable_vector()->SetAtIndex(1, 43.0);
 
     DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
-    xd->get_mutable_vector(0)->SetAtIndex(0, 44.0);
+    xd->get_mutable_vector(0).SetAtIndex(0, 44.0);
 
-    context_->get_mutable_numeric_parameter(0)->SetAtIndex(0, 76.0);
-    context_->get_mutable_numeric_parameter(0)->SetAtIndex(1, 77.0);
+    context_->get_mutable_numeric_parameter(0).SetAtIndex(0, 76.0);
+    context_->get_mutable_numeric_parameter(0).SetAtIndex(1, 77.0);
   }
 
   void AddSystem(const System<double>& sys, int index) {
@@ -145,7 +145,7 @@ void VerifyClonedState(const State<double>& clone) {
   EXPECT_EQ(43.0, xc->get_vector().GetAtIndex(1));
   // - Discrete
   const DiscreteValues<double>* xd = clone.get_discrete_state();
-  EXPECT_EQ(44.0, xd->get_vector(0)->GetAtIndex(0));
+  EXPECT_EQ(44.0, xd->get_vector(0).GetAtIndex(0));
   // - Abstract
   const AbstractValues* xa = clone.get_abstract_state();
   EXPECT_EQ(42, xa->get_value(0).GetValue<int>());
@@ -155,8 +155,8 @@ void VerifyClonedState(const State<double>& clone) {
 // DiagramContextTest::SetUp.
 void VerifyClonedParameters(const Parameters<double>& params) {
   ASSERT_EQ(1, params.num_numeric_parameters());
-  EXPECT_EQ(76.0, params.get_numeric_parameter(0)->GetAtIndex(0));
-  EXPECT_EQ(77.0, params.get_numeric_parameter(0)->GetAtIndex(1));
+  EXPECT_EQ(76.0, params.get_numeric_parameter(0).GetAtIndex(0));
+  EXPECT_EQ(77.0, params.get_numeric_parameter(0).GetAtIndex(1));
   ASSERT_EQ(1, params.num_abstract_parameters());
   EXPECT_EQ(2048, UnpackIntValue(params.get_abstract_parameter(0)));
 }
@@ -197,7 +197,7 @@ TEST_F(DiagramContextTest, State) {
   // The zero-order hold has a discrete state vector of length 1.
   DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
   EXPECT_EQ(1, xd->num_groups());
-  EXPECT_EQ(1, xd->get_vector(0)->size());
+  EXPECT_EQ(1, xd->get_vector(0).size());
 
   // Changes to the diagram state write through to constituent system states.
   // - Continuous
@@ -210,15 +210,15 @@ TEST_F(DiagramContextTest, State) {
   // - Discrete
   DiscreteValues<double>* hold_xd =
       context_->GetMutableSubsystemContext(4).get_mutable_discrete_state();
-  EXPECT_EQ(44.0, hold_xd->get_vector(0)->GetAtIndex(0));
+  EXPECT_EQ(44.0, hold_xd->get_vector(0).GetAtIndex(0));
 
   // Changes to constituent system states appear in the diagram state.
   // - Continuous
   integrator1_xc->get_mutable_vector()->SetAtIndex(0, 1000.0);
   EXPECT_EQ(1000.0, xc->get_vector().GetAtIndex(1));
   // - Discrete
-  hold_xd->get_mutable_vector(0)->SetAtIndex(0, 1001.0);
-  EXPECT_EQ(1001.0, xd->get_vector(0)->GetAtIndex(0));
+  hold_xd->get_mutable_vector(0).SetAtIndex(0, 1001.0);
+  EXPECT_EQ(1001.0, xd->get_vector(0).GetAtIndex(0));
 }
 
 // Tests that the pointers to substates in the DiagramState are equal to the

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -1392,10 +1392,10 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   // Initialize the zero-order holds to different values than their input ports.
   Context<double>& ctx1 =
       diagram_.GetMutableSubsystemContext(*diagram_.hold1(), context_.get());
-  ctx1.get_mutable_discrete_state(0)->SetAtIndex(0, 1001.0);
+  ctx1.get_mutable_discrete_state(0).SetAtIndex(0, 1001.0);
   Context<double>& ctx2 =
       diagram_.GetMutableSubsystemContext(*diagram_.hold2(), context_.get());
-  ctx2.get_mutable_discrete_state(0)->SetAtIndex(0, 1002.0);
+  ctx2.get_mutable_discrete_state(0).SetAtIndex(0, 1002.0);
 
   // Allocate the discrete variables.
   std::unique_ptr<DiscreteValues<double>> updates =
@@ -1415,11 +1415,11 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
   context_->get_mutable_discrete_state()->SetFrom(*updates);
-  EXPECT_EQ(1001.0, ctx1.get_discrete_state(0)->GetAtIndex(0));
-  EXPECT_EQ(23.0, ctx2.get_discrete_state(0)->GetAtIndex(0));
+  EXPECT_EQ(1001.0, ctx1.get_discrete_state(0).GetAtIndex(0));
+  EXPECT_EQ(23.0, ctx2.get_discrete_state(0).GetAtIndex(0));
 
   // Restore hold2 to its original value.
-  ctx2.get_mutable_discrete_state(0)->SetAtIndex(0, 1002.0);
+  ctx2.get_mutable_discrete_state(0).SetAtIndex(0, 1002.0);
   // Set the time to 11.5, so both hold1 and hold2 update.
   context_->set_time(11.5);
   time = diagram_.CalcNextUpdateTime(*context_, events.get());
@@ -1431,8 +1431,8 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
   context_->get_mutable_discrete_state()->SetFrom(*updates);
-  EXPECT_EQ(17.0, ctx1.get_discrete_state(0)->GetAtIndex(0));
-  EXPECT_EQ(23.0, ctx2.get_discrete_state(0)->GetAtIndex(0));
+  EXPECT_EQ(17.0, ctx1.get_discrete_state(0).GetAtIndex(0));
+  EXPECT_EQ(23.0, ctx2.get_discrete_state(0).GetAtIndex(0));
 }
 
 // Tests that a publish action is taken at 19 sec.
@@ -1833,7 +1833,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
       const Context<double>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>& events,
       DiscreteValues<double>* discrete_state) const override {
-    (*discrete_state)[0] = context.get_discrete_state(0)->GetAtIndex(0) + 1;
+    (*discrete_state)[0] = context.get_discrete_state(0).GetAtIndex(0) + 1;
   }
 
   void DoCalcUnrestrictedUpdate(
@@ -1841,7 +1841,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
       const std::vector<const UnrestrictedUpdateEvent<double>*>& events,
       State<double>* state) const override {
     int int_num =
-        static_cast<int>(context.get_discrete_state(0)->GetAtIndex(0));
+        static_cast<int>(context.get_discrete_state(0).GetAtIndex(0));
     state->get_mutable_abstract_state<std::string>(0) =
         "wow" + std::to_string(int_num);
   }
@@ -1921,17 +1921,17 @@ GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
 
   // sys0 doesn't have any updates.
   auto& sys0_context = diagram->GetSubsystemContext(*sys0, *context);
-  EXPECT_EQ(sys0_context.get_discrete_state(0)->GetAtIndex(0), 0);
+  EXPECT_EQ(sys0_context.get_discrete_state(0).GetAtIndex(0), 0);
   EXPECT_EQ(sys0_context.get_abstract_state<std::string>(0), "wow");
 
   // sys1 should have an unrestricted update then a discrete update.
   auto& sys1_context = diagram->GetSubsystemContext(*sys1, *context);
-  EXPECT_EQ(sys1_context.get_discrete_state(0)->GetAtIndex(0), 1);
+  EXPECT_EQ(sys1_context.get_discrete_state(0).GetAtIndex(0), 1);
   EXPECT_EQ(sys1_context.get_abstract_state<std::string>(0), "wow0");
 
   // sys2 should have a unrestricted update then a publish.
   auto& sys2_context = diagram->GetSubsystemContext(*sys2, *context);
-  EXPECT_EQ(sys2_context.get_discrete_state(0)->GetAtIndex(0), 0);
+  EXPECT_EQ(sys2_context.get_discrete_state(0).GetAtIndex(0), 0);
   EXPECT_EQ(sys2_context.get_abstract_state<std::string>(0), "wow0");
 }
 
@@ -2192,10 +2192,10 @@ GTEST_TEST(DiagramParametersTest, ParameterTest) {
 
   // Get pointers to the parameters.
   auto params1 = dynamic_cast<examples::pendulum::PendulumParams<double>*>(
-      diagram->GetMutableSubsystemContext(*pendulum1, context.get())
+      &diagram->GetMutableSubsystemContext(*pendulum1, context.get())
           .get_mutable_numeric_parameter(0));
   auto params2 = dynamic_cast<examples::pendulum::PendulumParams<double>*>(
-      diagram->GetMutableSubsystemContext(*pendulum2, context.get())
+      &diagram->GetMutableSubsystemContext(*pendulum2, context.get())
           .get_mutable_numeric_parameter(0));
 
   const double original_damping = params1->damping();
@@ -2238,9 +2238,9 @@ class RandomContextTestSystem : public LeafSystem<double> {
                            Parameters<double>* params,
                            RandomGenerator* generator) const override {
     std::uniform_real_distribution<double> uniform;
-    for (int i = 0; i < context.get_numeric_parameter(0)->size(); i++) {
-      params->get_mutable_numeric_parameter(0)->SetAtIndex(i,
-                                                           uniform(*generator));
+    for (int i = 0; i < context.get_numeric_parameter(0).size(); i++) {
+      params->get_mutable_numeric_parameter(0).SetAtIndex(i,
+                                                          uniform(*generator));
     }
   }
 };
@@ -2257,8 +2257,8 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
 
   // Back-up the numeric context values.
   Eigen::Vector4d state = context->get_continuous_state_vector().CopyToVector();
-  Eigen::Vector3d params0 = context->get_numeric_parameter(0)->CopyToVector();
-  Eigen::Vector3d params1 = context->get_numeric_parameter(1)->CopyToVector();
+  Eigen::Vector3d params0 = context->get_numeric_parameter(0).CopyToVector();
+  Eigen::Vector3d params1 = context->get_numeric_parameter(1).CopyToVector();
 
   // Should return the (same) original values.
   diagram->SetDefaultContext(context.get());
@@ -2266,10 +2266,10 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE((params0.array() ==
-               context->get_numeric_parameter(0)->get_value().array())
+               context->get_numeric_parameter(0).get_value().array())
                   .all());
   EXPECT_TRUE((params1.array() ==
-               context->get_numeric_parameter(1)->get_value().array())
+               context->get_numeric_parameter(1).get_value().array())
                   .all());
 
   RandomGenerator generator;
@@ -2280,16 +2280,16 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE((params0.array() !=
-               context->get_numeric_parameter(0)->get_value().array())
+               context->get_numeric_parameter(0).get_value().array())
                   .all());
   EXPECT_TRUE((params1.array() !=
-               context->get_numeric_parameter(1)->get_value().array())
+               context->get_numeric_parameter(1).get_value().array())
                   .all());
 
   // Update backup.
   state = context->get_continuous_state_vector().CopyToVector();
-  params0 = context->get_numeric_parameter(0)->CopyToVector();
-  params1 = context->get_numeric_parameter(1)->CopyToVector();
+  params0 = context->get_numeric_parameter(0).CopyToVector();
+  params1 = context->get_numeric_parameter(1).CopyToVector();
 
   // Should return different values (again).
   diagram->SetRandomContext(context.get(), &generator);
@@ -2297,10 +2297,10 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE((params0.array() !=
-               context->get_numeric_parameter(0)->get_value().array())
+               context->get_numeric_parameter(0).get_value().array())
                   .all());
   EXPECT_TRUE((params1.array() !=
-               context->get_numeric_parameter(1)->get_value().array())
+               context->get_numeric_parameter(1).get_value().array())
                   .all());
 }
 

--- a/drake/systems/framework/test/discrete_values_test.cc
+++ b/drake/systems/framework/test/discrete_values_test.cc
@@ -1,6 +1,7 @@
 #include "drake/systems/framework/discrete_values.h"
 
 #include <memory>
+#include <stdexcept>
 
 #include <gtest/gtest.h>
 
@@ -24,29 +25,39 @@ class DiscreteValuesTest : public ::testing::Test {
 
 TEST_F(DiscreteValuesTest, OwnedState) {
   DiscreteValues<double> xd(std::move(data_));
-  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_vector(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_vector(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_vector(1).GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_vector(1).GetAtIndex(1));
 }
 
 TEST_F(DiscreteValuesTest, UnownedState) {
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
-  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_vector(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_vector(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_vector(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(1));
+  EXPECT_EQ(2.0, xd.get_vector(1).GetAtIndex(0));
+  EXPECT_EQ(3.0, xd.get_vector(1).GetAtIndex(1));
+}
+
+TEST_F(DiscreteValuesTest, NoNullsAllowed) {
+  // Unowned.
+  EXPECT_THROW(DiscreteValues<double>(
+      std::vector<BasicVector<double>*>{nullptr, data_[1].get()}),
+               std::logic_error);
+  // Owned.
+  data_.push_back(nullptr);
+  EXPECT_THROW(DiscreteValues<double>(std::move(data_)), std::logic_error);
 }
 
 TEST_F(DiscreteValuesTest, Clone) {
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
   std::unique_ptr<DiscreteValues<double>> clone = xd.Clone();
-  EXPECT_EQ(1.0, clone->get_vector(0)->GetAtIndex(0));
-  EXPECT_EQ(1.0, clone->get_vector(0)->GetAtIndex(1));
-  EXPECT_EQ(2.0, clone->get_vector(1)->GetAtIndex(0));
-  EXPECT_EQ(3.0, clone->get_vector(1)->GetAtIndex(1));
+  EXPECT_EQ(1.0, clone->get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(1.0, clone->get_vector(0).GetAtIndex(1));
+  EXPECT_EQ(2.0, clone->get_vector(1).GetAtIndex(0));
+  EXPECT_EQ(3.0, clone->get_vector(1).GetAtIndex(1));
 }
 
 TEST_F(DiscreteValuesTest, SetFrom) {
@@ -55,7 +66,7 @@ TEST_F(DiscreteValuesTest, SetFrom) {
   DiscreteValues<double> double_xd(BasicVector<double>::Make({3.0, 4.0}));
   ad_xd.SetFrom(double_xd);
 
-  const BasicVector<AutoDiffXd>& vec = *ad_xd.get_vector(0);
+  const BasicVector<AutoDiffXd>& vec = ad_xd.get_vector(0);
   EXPECT_EQ(3.0, vec[0].value());
   EXPECT_EQ(0, vec[0].derivatives().size());
   EXPECT_EQ(4.0, vec[1].value());
@@ -70,8 +81,8 @@ GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugar) {
   EXPECT_EQ(42.0, xd[0]);
   EXPECT_EQ(43.0, xd[1]);
   xd[0] = 100.0;
-  EXPECT_EQ(100.0, xd.get_vector()->GetAtIndex(0));
-  xd.get_mutable_vector()->SetAtIndex(1, 1000.0);
+  EXPECT_EQ(100.0, xd.get_vector().GetAtIndex(0));
+  xd.get_mutable_vector().SetAtIndex(1, 1000.0);
   EXPECT_EQ(1000.0, xd[1]);
 }
 

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -123,17 +123,17 @@ void VerifyClonedState(const State<double>& clone) {
   }
 
   EXPECT_EQ(2, clone.get_discrete_state()->num_groups());
-  const BasicVector<double>* xd0 = clone.get_discrete_state()->get_vector(0);
-  const BasicVector<double>* xd1 = clone.get_discrete_state()->get_vector(1);
+  const BasicVector<double>& xd0 = clone.get_discrete_state()->get_vector(0);
+  const BasicVector<double>& xd1 = clone.get_discrete_state()->get_vector(1);
   {
-    VectorX<double> contents = xd0->CopyToVector();
+    VectorX<double> contents = xd0.CopyToVector();
     VectorX<double> expected(1);
     expected << 128.0;
     EXPECT_EQ(expected, contents);
   }
 
   {
-    VectorX<double> contents = xd1->CopyToVector();
+    VectorX<double> contents = xd1.CopyToVector();
     VectorX<double> expected(2);
     expected << 256.0, 512.0;
     EXPECT_EQ(expected, contents);
@@ -295,10 +295,10 @@ TEST_F(LeafContextTest, Clone) {
   EXPECT_EQ(5.0, context_.get_continuous_state_vector().GetAtIndex(3));
 
   // -- Discrete
-  BasicVector<double>* xd1 = clone->get_mutable_discrete_state(1);
-  xd1->SetAtIndex(0, 1024.0);
-  EXPECT_EQ(1024.0, clone->get_discrete_state(1)->GetAtIndex(0));
-  EXPECT_EQ(256.0, context_.get_discrete_state(1)->GetAtIndex(0));
+  BasicVector<double>& xd1 = clone->get_mutable_discrete_state(1);
+  xd1.SetAtIndex(0, 1024.0);
+  EXPECT_EQ(1024.0, clone->get_discrete_state(1).GetAtIndex(0));
+  EXPECT_EQ(256.0, context_.get_discrete_state(1).GetAtIndex(0));
 
   // -- Abstract (even though it's not owned in context_)
   clone->get_mutable_abstract_state<int>(0) = 2048;
@@ -310,11 +310,11 @@ TEST_F(LeafContextTest, Clone) {
   LeafContext<double>* leaf_clone =
       dynamic_cast<LeafContext<double>*>(clone.get());
   EXPECT_EQ(2, leaf_clone->num_numeric_parameters());
-  const BasicVector<double>& param0 = *leaf_clone->get_numeric_parameter(0);
+  const BasicVector<double>& param0 = leaf_clone->get_numeric_parameter(0);
   EXPECT_EQ(1.0, param0[0]);
   EXPECT_EQ(2.0, param0[1]);
   EXPECT_EQ(4.0, param0[2]);
-  const BasicVector<double>& param1 = *leaf_clone->get_numeric_parameter(1);
+  const BasicVector<double>& param1 = leaf_clone->get_numeric_parameter(1);
   EXPECT_EQ(8.0, param1[0]);
   EXPECT_EQ(16.0, param1[1]);
   EXPECT_EQ(32.0, param1[2]);
@@ -324,8 +324,8 @@ TEST_F(LeafContextTest, Clone) {
       &leaf_clone->get_abstract_parameter(0).GetValue<TestAbstractType>()));
 
   // Verify that changes to the cloned parameters do not affect the originals.
-  (*leaf_clone->get_mutable_numeric_parameter(0))[0] = 76.0;
-  EXPECT_EQ(1.0, context_.get_numeric_parameter(0)->GetAtIndex(0));
+  leaf_clone->get_mutable_numeric_parameter(0)[0] = 76.0;
+  EXPECT_EQ(1.0, context_.get_numeric_parameter(0).GetAtIndex(0));
 }
 
 // Tests that a LeafContext can provide a clone of its State.
@@ -338,13 +338,13 @@ TEST_F(LeafContextTest, CloneState) {
 TEST_F(LeafContextTest, CopyStateFrom) {
   std::unique_ptr<Context<double>> clone = context_.Clone();
   (*clone->get_mutable_continuous_state())[0] = 81.0;
-  (*clone->get_mutable_discrete_state(0))[0] = 243.0;
+  clone->get_mutable_discrete_state(0)[0] = 243.0;
   clone->get_mutable_abstract_state<int>(0) = 729;
 
   context_.get_mutable_state()->CopyFrom(clone->get_state());
 
   EXPECT_EQ(81.0, (*context_.get_continuous_state())[0]);
-  EXPECT_EQ(243.0, (*context_.get_discrete_state(0))[0]);
+  EXPECT_EQ(243.0, context_.get_discrete_state(0)[0]);
   EXPECT_EQ(729, context_.get_abstract_state<int>(0));
 }
 
@@ -399,10 +399,10 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   EXPECT_EQ(kGeneralizedPositionSize, xc.get_generalized_position().size());
   EXPECT_EQ(5.0, xc.get_generalized_velocity()[1].value());
   EXPECT_EQ(0, xc.get_generalized_velocity()[1].derivatives().size());
-  EXPECT_EQ(128.0, target.get_discrete_state(0)->GetAtIndex(0));
+  EXPECT_EQ(128.0, target.get_discrete_state(0).GetAtIndex(0));
   // Verify that parameters were set.
   target.get_numeric_parameter(0);
-  EXPECT_EQ(2.0, (target.get_numeric_parameter(0)->GetAtIndex(1).value()));
+  EXPECT_EQ(2.0, (target.get_numeric_parameter(0).GetAtIndex(1).value()));
 
   // Set the accuracy in the context.
   context_.set_accuracy(accuracy);

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -629,7 +629,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelNumericParams) {
   ASSERT_EQ(context->num_numeric_parameters(), 1);
   const BasicVector<double>& param = context->get_numeric_parameter(0);
   // Check that type was preserved.
-  ASSERT_NE(nullptr, dynamic_cast<const MyVector2d*>(&param));
+  ASSERT_TRUE(is_dynamic_castable<const MyVector2d>(&param));
   EXPECT_EQ(2, param.size());
   EXPECT_EQ(1.1, param.GetAtIndex(0));
   EXPECT_EQ(2.2, param.GetAtIndex(1));

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -80,10 +80,10 @@ class TestSystem : public LeafSystem<T> {
 
   void SetDefaultParameters(const Context<T>& context,
                             Parameters<T>* params) const override {
-    BasicVector<T>* param = params->get_mutable_numeric_parameter(0);
+    BasicVector<T>& param = params->get_mutable_numeric_parameter(0);
     Vector2<T> p0;
     p0 << 13.0, 7.0;
-    param->SetFromVector(p0);
+    param.SetFromVector(p0);
   }
 
   const BasicVector<T>& GetVanillaNumericParameters(
@@ -91,7 +91,7 @@ class TestSystem : public LeafSystem<T> {
     return this->GetNumericParameter(context, 0 /* index */);
   }
 
-  BasicVector<T>* GetVanillaMutableNumericParameters(
+  BasicVector<T>& GetVanillaMutableNumericParameters(
       Context<T>* context) const {
     return this->GetMutableNumericParameter(context, 0 /* index */);
   }
@@ -319,9 +319,9 @@ TEST_F(LeafSystemTest, Parameters) {
       system_.GetVanillaNumericParameters(*context);
   EXPECT_EQ(13.0, vec[0]);
   EXPECT_EQ(7.0, vec[1]);
-  BasicVector<double>* mutable_vec =
+  BasicVector<double>& mutable_vec =
       system_.GetVanillaMutableNumericParameters(context.get());
-  mutable_vec->SetAtIndex(1, 42.0);
+  mutable_vec.SetAtIndex(1, 42.0);
   EXPECT_EQ(42.0, vec[1]);
 }
 
@@ -627,12 +627,12 @@ GTEST_TEST(ModelLeafSystemTest, ModelNumericParams) {
   DeclaredModelPortsSystem dut;
   auto context = dut.CreateDefaultContext();
   ASSERT_EQ(context->num_numeric_parameters(), 1);
-  const BasicVector<double>* const param = context->get_numeric_parameter(0);
+  const BasicVector<double>& param = context->get_numeric_parameter(0);
   // Check that type was preserved.
-  ASSERT_NE(nullptr, dynamic_cast<const MyVector2d*>(param));
-  EXPECT_EQ(2, param->size());
-  EXPECT_EQ(1.1, param->GetAtIndex(0));
-  EXPECT_EQ(2.2, param->GetAtIndex(1));
+  ASSERT_NE(nullptr, dynamic_cast<const MyVector2d*>(&param));
+  EXPECT_EQ(2, param.size());
+  EXPECT_EQ(1.1, param.GetAtIndex(0));
+  EXPECT_EQ(2.2, param.GetAtIndex(1));
 }
 
 // Tests that DeclareAbstractState works expectedly.
@@ -1545,7 +1545,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   auto context = dut.CreateDefaultContext();
 
   // `param0[0] >= 11.0` with `param0[0] == 1.0` produces `-10.0 >= 0.0`.
-  context->get_mutable_numeric_parameter(0)->SetAtIndex(0, 1.0);
+  context->get_mutable_numeric_parameter(0).SetAtIndex(0, 1.0);
   Eigen::VectorXd value0;
   constraint0.Calc(*context, &value0);
   EXPECT_TRUE(CompareMatrices(value0, Vector1<double>::Constant(-10.0)));
@@ -1592,9 +1592,9 @@ class RandomContextTestSystem : public LeafSystem<double> {
                            Parameters<double>* params,
                            RandomGenerator* generator) const override {
     std::uniform_real_distribution<double> uniform;
-    for (int i = 0; i < context.get_numeric_parameter(0)->size(); i++) {
-      params->get_mutable_numeric_parameter(0)->SetAtIndex(i,
-                                                           uniform(*generator));
+    for (int i = 0; i < context.get_numeric_parameter(0).size(); i++) {
+      params->get_mutable_numeric_parameter(0).SetAtIndex(i,
+                                                          uniform(*generator));
     }
   }
 };
@@ -1606,7 +1606,7 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
 
   // Back-up the numeric context values.
   Eigen::Vector2d state = context->get_continuous_state_vector().CopyToVector();
-  Eigen::Vector3d params = context->get_numeric_parameter(0)->CopyToVector();
+  Eigen::Vector3d params = context->get_numeric_parameter(0).CopyToVector();
 
   // Should return the (same) original values.
   system.SetDefaultContext(context.get());
@@ -1614,7 +1614,7 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE(
-      (params.array() == context->get_numeric_parameter(0)->get_value().array())
+      (params.array() == context->get_numeric_parameter(0).get_value().array())
           .all());
 
   RandomGenerator generator;
@@ -1625,12 +1625,12 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE(
-      (params.array() != context->get_numeric_parameter(0)->get_value().array())
+      (params.array() != context->get_numeric_parameter(0).get_value().array())
           .all());
 
   // Update backup.
   state = context->get_continuous_state_vector().CopyToVector();
-  params = context->get_numeric_parameter(0)->CopyToVector();
+  params = context->get_numeric_parameter(0).CopyToVector();
 
   // Should return different values (again).
   system.SetRandomContext(context.get(), &generator);
@@ -1638,7 +1638,7 @@ GTEST_TEST(RandomContextTest, SetRandomTest) {
                context->get_continuous_state_vector().CopyToVector().array())
                   .all());
   EXPECT_TRUE(
-      (params.array() != context->get_numeric_parameter(0)->get_value().array())
+      (params.array() != context->get_numeric_parameter(0).get_value().array())
           .all());
 }
 

--- a/drake/systems/framework/test/parameters_test.cc
+++ b/drake/systems/framework/test/parameters_test.cc
@@ -14,10 +14,10 @@ class ParametersTest : public ::testing::Test {
  protected:
   void SetUp() override {
     params_ = MakeParams<double>();
-    BasicVector<double>& p0 = *params_->get_mutable_numeric_parameter(0);
+    BasicVector<double>& p0 = params_->get_mutable_numeric_parameter(0);
     p0[0] = 3.0;
     p0[1] = 6.0;
-    BasicVector<double>& p1 = *params_->get_mutable_numeric_parameter(1);
+    BasicVector<double>& p1 = params_->get_mutable_numeric_parameter(1);
     p1[0] = 9.0;
     p1[1] = 12.0;
   }
@@ -43,13 +43,13 @@ class ParametersTest : public ::testing::Test {
 TEST_F(ParametersTest, Numeric) {
   ASSERT_EQ(2, params_->num_numeric_parameters());
   ASSERT_EQ(2, params_->get_numeric_parameters().num_groups());
-  EXPECT_EQ(3.0, params_->get_numeric_parameter(0)->GetAtIndex(0));
-  EXPECT_EQ(6.0, params_->get_numeric_parameter(0)->GetAtIndex(1));
-  EXPECT_EQ(9.0, params_->get_numeric_parameter(1)->GetAtIndex(0));
-  EXPECT_EQ(12.0, params_->get_numeric_parameter(1)->GetAtIndex(1));
+  EXPECT_EQ(3.0, params_->get_numeric_parameter(0).GetAtIndex(0));
+  EXPECT_EQ(6.0, params_->get_numeric_parameter(0).GetAtIndex(1));
+  EXPECT_EQ(9.0, params_->get_numeric_parameter(1).GetAtIndex(0));
+  EXPECT_EQ(12.0, params_->get_numeric_parameter(1).GetAtIndex(1));
 
-  params_->get_mutable_numeric_parameter(0)->SetAtIndex(1, 42.0);
-  EXPECT_EQ(42.0, params_->get_numeric_parameter(0)->GetAtIndex(1));
+  params_->get_mutable_numeric_parameter(0).SetAtIndex(1, 42.0);
+  EXPECT_EQ(42.0, params_->get_numeric_parameter(0).GetAtIndex(1));
 }
 
 TEST_F(ParametersTest, Abstract) {
@@ -64,14 +64,14 @@ TEST_F(ParametersTest, Abstract) {
 TEST_F(ParametersTest, Clone) {
   // Test that data is copied into the clone.
   auto clone = params_->Clone();
-  EXPECT_EQ(3.0, clone->get_numeric_parameter(0)->GetAtIndex(0));
+  EXPECT_EQ(3.0, clone->get_numeric_parameter(0).GetAtIndex(0));
   EXPECT_EQ(72, UnpackIntValue(clone->get_abstract_parameter(0)));
   EXPECT_EQ(144, UnpackIntValue(clone->get_abstract_parameter(1)));
 
   // Test that changes to the clone don't write through to the original.
   // - numeric
-  clone->get_mutable_numeric_parameter(0)->SetAtIndex(1, 42.0);
-  EXPECT_EQ(6.0, params_->get_numeric_parameter(0)->GetAtIndex(1));
+  clone->get_mutable_numeric_parameter(0).SetAtIndex(1, 42.0);
+  EXPECT_EQ(6.0, params_->get_numeric_parameter(0).GetAtIndex(1));
   // - abstract
   clone->get_mutable_abstract_parameter(0).SetValue<int>(256);
   EXPECT_EQ(72, UnpackIntValue(params_->get_abstract_parameter(0)));
@@ -84,10 +84,10 @@ TEST_F(ParametersTest, SetSymbolicFromDouble) {
   symbolic_params->SetFrom(*params_);
 
   // The numeric parameters have been converted to symbolic constants.
-  const auto& p0 = *symbolic_params->get_numeric_parameter(0);
+  const auto& p0 = symbolic_params->get_numeric_parameter(0);
   EXPECT_EQ("3", p0.GetAtIndex(0).to_string());
   EXPECT_EQ("6", p0.GetAtIndex(1).to_string());
-  const auto& p1 = *symbolic_params->get_numeric_parameter(1);
+  const auto& p1 = symbolic_params->get_numeric_parameter(1);
   EXPECT_EQ("9", p1.GetAtIndex(0).to_string());
   EXPECT_EQ("12", p1.GetAtIndex(1).to_string());
 
@@ -103,10 +103,10 @@ TEST_F(ParametersTest, SetAutodiffFromDouble) {
   autodiff_params->SetFrom(*params_);
 
   // The numeric parameters have been converted to autodiff.
-  const auto& p0 = *autodiff_params->get_numeric_parameter(0);
+  const auto& p0 = autodiff_params->get_numeric_parameter(0);
   EXPECT_EQ(3.0, p0.GetAtIndex(0).value());
   EXPECT_EQ(6.0, p0.GetAtIndex(1).value());
-  const auto& p1 = *autodiff_params->get_numeric_parameter(1);
+  const auto& p1 = autodiff_params->get_numeric_parameter(1);
   EXPECT_EQ(9.0, p1.GetAtIndex(0).value());
   EXPECT_EQ(12.0, p1.GetAtIndex(1).value());
 

--- a/drake/systems/framework/test/system_scalar_conversion_doxygen_test.cc
+++ b/drake/systems/framework/test/system_scalar_conversion_doxygen_test.cc
@@ -40,9 +40,9 @@ GTEST_TEST(SystemScalarConversionDoxygen, PendulumPlantAutodiff) {
 
   // TODO(#6944) This is a hack to work around AutoDiffXd being broken.
   // (This stanza is excluded from the Doxygen twin of this unit test.)
-  auto* params = autodiff_context->get_mutable_numeric_parameter(0);
-  for (int i = 0; i < params->size(); ++i) {
-    (*params)[i].derivatives() = Vector1d::Zero(1);
+  auto& params = autodiff_context->get_mutable_numeric_parameter(0);
+  for (int i = 0; i < params.size(); ++i) {
+    params[i].derivatives() = Vector1d::Zero(1);
   }
 
   // Compute denergy/dtheta around its initial conditions.

--- a/drake/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/drake/systems/framework/test/system_symbolic_inspector_test.cc
@@ -59,7 +59,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
               BasicVector<symbolic::Expression>* y1) const {
     const auto& u0 = *(this->EvalVectorInput(context, 0));
     const auto& u1 = *(this->EvalVectorInput(context, 1));
-    const auto& xd = *(context.get_discrete_state(0));
+    const auto& xd = context.get_discrete_state(0);
 
     // Output 1 depends on both inputs and the discrete state.
     y1->set_value(u0.get_value() + u1.get_value() + xd.get_value());
@@ -99,14 +99,14 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
     const auto u0 = this->EvalVectorInput(context, 0)->CopyToVector();
     const auto u1 = this->EvalVectorInput(context, 1)->CopyToVector();
     const Vector2<symbolic::Expression> xd =
-        context.get_discrete_state(0)->get_value();
+        context.get_discrete_state(0).get_value();
     const Eigen::Matrix2d A = 7 * Eigen::Matrix2d::Identity();
     const Eigen::Matrix2d B1 = 8 * Eigen::Matrix2d::Identity();
     const Eigen::Matrix2d B2 = 9 * Eigen::Matrix2d::Identity();
     const Eigen::Vector2d f0(10.0, 11.0);
     const Vector2<symbolic::Expression> next_xd =
         A * xd + B1 * u0 + B2 * u1 + f0;
-    discrete_state->get_mutable_vector(0)->SetFromVector(next_xd);
+    discrete_state->get_mutable_vector(0).SetFromVector(next_xd);
   }
 };
 

--- a/drake/systems/framework/test/vector_system_test.cc
+++ b/drake/systems/framework/test/vector_system_test.cc
@@ -268,7 +268,7 @@ TEST_F(VectorSystemTest, OutputDiscrete) {
   auto& output_port = dut.get_output_port();
   std::unique_ptr<AbstractValue> output = output_port.Allocate(*context);
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
-  context->get_mutable_discrete_state(0)->SetFromVector(
+  context->get_mutable_discrete_state(0).SetFromVector(
       Eigen::Vector2d::Ones());
   output_port.Calc(*context, output.get());
   EXPECT_EQ(dut.get_output_count(), 1);
@@ -332,14 +332,14 @@ TEST_F(VectorSystemTest, DiscreteVariableUpdates) {
   dut.set_prototype_discrete_state_count(1);
   context = dut.CreateDefaultContext();
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
-  context->get_mutable_discrete_state(0)->SetFromVector(
+  context->get_mutable_discrete_state(0).SetFromVector(
       Eigen::Vector2d::Ones());
   discrete_updates = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
   EXPECT_EQ(dut.get_last_context(), context.get());
   EXPECT_EQ(dut.get_discrete_variable_updates_count(), 1);
-  EXPECT_EQ(discrete_updates->get_vector(0)->GetAtIndex(0), 2.0);
-  EXPECT_EQ(discrete_updates->get_vector(0)->GetAtIndex(1), 3.0);
+  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(0), 2.0);
+  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(1), 3.0);
 
   // Nothing else weird happened.
   EXPECT_EQ(dut.get_time_derivatives_count(), 0);
@@ -416,12 +416,12 @@ class NoInputNoOutputDiscreteTimeSystem : public VectorSystem<double> {
 TEST_F(VectorSystemTest, NoInputNoOutputDiscreteTimeSystemTest) {
   NoInputNoOutputDiscreteTimeSystem dut;
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_discrete_state()->get_mutable_vector()->SetFromVector(
+  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(
       Vector1d::Constant(2.0));
 
   auto discrete_updates = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get());
-  EXPECT_EQ(discrete_updates->get_vector(0)->GetAtIndex(0), 8.0);
+  EXPECT_EQ(discrete_updates->get_vector(0).GetAtIndex(0), 8.0);
 
   EXPECT_EQ(dut.get_num_output_ports(), 0);
 }
@@ -540,7 +540,7 @@ TEST_F(VectorSystemTest, MissingMethodsDiscreteTimeSystemTest) {
   MissingMethodsDiscreteTimeSystem dut;
   auto context = dut.CreateDefaultContext();
 
-  context->get_mutable_discrete_state()->get_mutable_vector()->SetFromVector(
+  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(
       Vector1d::Constant(2.0));
   auto discrete_updates = dut.AllocateDiscreteVariables();
   EXPECT_THROW(

--- a/drake/systems/framework/vector_system.h
+++ b/drake/systems/framework/vector_system.h
@@ -135,7 +135,7 @@ class VectorSystem : public LeafSystem<T> {
       state_vector = dynamic_cast<const BasicVector<T>*>(&vector_base);
     } else {
       DRAKE_ASSERT(context.has_only_discrete_state());
-      state_vector = context.get_discrete_state(0);
+      state_vector = &context.get_discrete_state(0);
     }
     DRAKE_DEMAND(state_vector != nullptr);
     return state_vector->get_value();
@@ -186,18 +186,16 @@ class VectorSystem : public LeafSystem<T> {
 
     // Obtain the block form of xd before the update (i.e., the prior state).
     DRAKE_ASSERT(context.has_only_discrete_state());
-    const BasicVector<T>* const state_vector = context.get_discrete_state(0);
-    DRAKE_ASSERT(state_vector != nullptr);
+    const BasicVector<T>& state_vector = context.get_discrete_state(0);
     const Eigen::VectorBlock<const VectorX<T>> state_block =
-        state_vector->get_value();
+        state_vector.get_value();
 
     // Obtain the block form of xd after the update (i.e., the next state).
     DRAKE_ASSERT(discrete_state != nullptr);
-    BasicVector<T>* const discrete_update_vector =
+    BasicVector<T>& discrete_update_vector =
         discrete_state->get_mutable_vector();
-    DRAKE_ASSERT(discrete_update_vector != nullptr);
     Eigen::VectorBlock<VectorX<T>> discrete_update_block =
-        discrete_update_vector->get_mutable_value();
+        discrete_update_vector.get_mutable_value();
 
     // Delegate to subclass.
     DoCalcVectorDiscreteVariableUpdates(context, input_block, state_block,

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -106,10 +106,10 @@ void LcmSubscriberSystem::ProcessMessageAndStoreToDiscreteState(
   if (!received_message_.empty()) {
     translator_->Deserialize(
         received_message_.data(), received_message_.size(),
-        discrete_state->get_mutable_vector(kStateIndexMessage));
+        &discrete_state->get_mutable_vector(kStateIndexMessage));
   }
   discrete_state->get_mutable_vector(kStateIndexMessageCount)
-      ->SetAtIndex(0, received_message_count_);
+      .SetAtIndex(0, received_message_count_);
 }
 
 void LcmSubscriberSystem::ProcessMessageAndStoreToAbstractState(
@@ -137,7 +137,7 @@ int LcmSubscriberSystem::GetMessageCount(const Context<double>& context) const {
   } else {
     DRAKE_ASSERT(serializer_ == nullptr);
     last_message_count = static_cast<int>(
-        context.get_discrete_state(kStateIndexMessageCount)->GetAtIndex(0));
+        context.get_discrete_state(kStateIndexMessageCount).GetAtIndex(0));
   }
   return last_message_count;
 }
@@ -260,7 +260,7 @@ LcmSubscriberSystem::AllocateTranslatorOutputValue() const {
 void LcmSubscriberSystem::CalcTranslatorOutputValue(
     const Context<double>& context, BasicVector<double>* output_vector) const {
   DRAKE_DEMAND(translator_ != nullptr && serializer_ == nullptr);
-  output_vector->SetFrom(*context.get_discrete_state(kStateIndexMessage));
+  output_vector->SetFrom(context.get_discrete_state(kStateIndexMessage));
 }
 
 // This is only called if our output port is abstract-valued, because we are

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -75,7 +75,7 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
     const VectorX<T>& x = (this->time_period() == 0.)
         ? dynamic_cast<const BasicVector<T>&>(
             context.get_continuous_state_vector()).get_value()
-        : context.get_discrete_state()->get_vector()->get_value();
+        : context.get_discrete_state()->get_vector().get_value();
     y += Ct * x;
   }
 
@@ -135,7 +135,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> xn = f0(t);
   DRAKE_DEMAND(xn.rows() == num_states_);
 
-  const auto& x = context.get_discrete_state(0)->get_value();
+  const auto& x = context.get_discrete_state(0).get_value();
 
   const MatrixX<T> At = A(t);
   DRAKE_DEMAND(At.rows() == num_states_ && At.cols() == num_states_);
@@ -150,7 +150,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     DRAKE_DEMAND(Bt.rows() == num_states_ && Bt.cols() == num_inputs_);
     xn += Bt * u;
   }
-  updates->get_mutable_vector()->SetFromVector(xn);
+  updates->get_mutable_vector().SetFromVector(xn);
 }
 
 // Our public constructor declares that our most specific subclass is
@@ -245,7 +245,7 @@ void AffineSystem<T>::CalcOutputY(const Context<T>& context,
   const VectorX<T>& x = (this->time_period() == 0.)
       ? dynamic_cast<const BasicVector<T>&>(
           context.get_continuous_state_vector()).get_value()
-      : context.get_discrete_state()->get_vector()->get_value();
+      : context.get_discrete_state()->get_vector().get_value();
 
   auto y = output_vector->get_mutable_value();
   y = C_ * x + y0_;
@@ -286,7 +286,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
     drake::systems::DiscreteValues<T>* updates) const {
   if (this->num_states() == 0 || this->time_period() == 0.0) return;
 
-  const auto& x = context.get_discrete_state(0)->get_value();
+  const auto& x = context.get_discrete_state(0).get_value();
 
   VectorX<T> xnext = A_ * x + f0_;
 
@@ -297,7 +297,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
 
     xnext += B_ * u;
   }
-  updates->get_mutable_vector()->SetFromVector(xnext);
+  updates->get_mutable_vector().SetFromVector(xnext);
 }
 
 

--- a/drake/systems/primitives/constant_vector_source.cc
+++ b/drake/systems/primitives/constant_vector_source.cc
@@ -37,7 +37,7 @@ const BasicVector<T>& ConstantVectorSource<T>::get_source_value(
 }
 
 template <typename T>
-BasicVector<T>* ConstantVectorSource<T>::get_mutable_source_value(
+BasicVector<T>& ConstantVectorSource<T>::get_mutable_source_value(
     Context<T>* context) {
   return this->GetMutableNumericParameter(context, source_value_index_);
 }

--- a/drake/systems/primitives/constant_vector_source.h
+++ b/drake/systems/primitives/constant_vector_source.h
@@ -49,9 +49,9 @@ class ConstantVectorSource : public SingleOutputVectorSource<T> {
   /// given @p context.
   const BasicVector<T>& get_source_value(const Context<T>& context) const;
 
-  /// Return a mutable pointer to the source value of this block in the given
+  /// Return a mutable reference to the source value of this block in the given
   /// @p context.
-  BasicVector<T>* get_mutable_source_value(Context<T>* context);
+  BasicVector<T>& get_mutable_source_value(Context<T>* context);
 
  private:
   // Outputs a signal with a fixed value as specified by the user.

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -153,14 +153,14 @@ MakeStateAndInputMatrices(
     return std::make_pair(math::autoDiffToGradientMatrix(autodiff_xdot_vec),
                           math::autoDiffToValueMatrix(autodiff_xdot_vec));
   }
-  auto autodiff_x0 =
+  auto& autodiff_x0 =
       autodiff_context->get_mutable_discrete_state()->get_mutable_vector();
-  autodiff_x0->SetFromVector(autodiff_x0_vec);
+  autodiff_x0.SetFromVector(autodiff_x0_vec);
   std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
       autodiff_system.AllocateDiscreteVariables();
   autodiff_system.CalcDiscreteVariableUpdates(*autodiff_context,
                                               autodiff_x1.get());
-  auto autodiff_x1_vec = autodiff_x1->get_vector()->CopyToVector();
+  auto autodiff_x1_vec = autodiff_x1->get_vector().CopyToVector();
 
   if (!(math::autoDiffToValueMatrix(autodiff_x1_vec) -
         math::autoDiffToValueMatrix(autodiff_x0_vec))
@@ -214,7 +214,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   const Eigen::VectorXd x0 =
       (context.has_only_continuous_state())
           ? context.get_continuous_state_vector().CopyToVector()
-          : context.get_discrete_state(0)->get_value();
+          : context.get_discrete_state(0).get_value();
   const int num_states = x0.size();
 
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);

--- a/drake/systems/primitives/random_source.h
+++ b/drake/systems/primitives/random_source.h
@@ -108,7 +108,7 @@ class RandomSource : public LeafSystem<double> {
   // Output is the zero-order hold of the discrete state.
   void CopyStateToOutput(const Context<double>& context,
                          BasicVector<double>* output) const {
-    output->SetFromVector(context.get_discrete_state(0)->CopyToVector());
+    output->SetFromVector(context.get_discrete_state(0).CopyToVector());
   }
 
   Seed seed_{RandomState::default_seed};

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -186,14 +186,14 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
 
   Eigen::Vector3d x0(26, 27, 28);
 
-  context->get_mutable_discrete_state(0)->SetFromVector(x0);
+  context->get_mutable_discrete_state(0).SetFromVector(x0);
   double u0 = 29;
   context->FixInputPort(0, Vector1d::Constant(u0));
 
   auto update = system.AllocateDiscreteVariables();
   system.CalcDiscreteVariableUpdates(*context, update.get());
 
-  EXPECT_TRUE(CompareMatrices(update->get_vector(0)->CopyToVector(),
+  EXPECT_TRUE(CompareMatrices(update->get_vector(0).CopyToVector(),
                               A * x0 + B * u0 + f0));
 
   // Test TimeVaryingAffineSystem accessor methods.
@@ -276,13 +276,13 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
 
   auto context = sys.CreateDefaultContext();
   context->set_time(t);
-  context->get_mutable_discrete_state()->get_mutable_vector()->SetFromVector(x);
+  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(x);
   context->FixInputPort(0, BasicVector<double>::Make(42.0));
 
   auto updates = sys.AllocateDiscreteVariables();
   sys.CalcDiscreteVariableUpdates(*context, updates.get());
   EXPECT_TRUE(CompareMatrices(sys.A(t) * x + 42.0 * sys.B(t),
-                              updates->get_vector()->CopyToVector()));
+                              updates->get_vector().CopyToVector()));
 
   auto output = sys.AllocateOutput(*context);
   sys.CalcOutput(*context, output.get());

--- a/drake/systems/primitives/test/constant_vector_source_test.cc
+++ b/drake/systems/primitives/test/constant_vector_source_test.cc
@@ -54,10 +54,10 @@ TEST_F(ConstantVectorSourceTest, EigenModel) {
 
   // Tests that the output reflects changes to the parameter value in the
   // context.
-  BasicVector<double>* source_value =
+  BasicVector<double>& source_value =
       static_cast<ConstantVectorSource<double>*>(source_.get())
           ->get_mutable_source_value(context_.get());
-  source_value->SetFromVector(2.0 * source_value->get_value());
+  source_value.SetFromVector(2.0 * source_value.get_value());
 
   source_->get_output_port(0).Calc(*context_, output_.get());
 
@@ -82,10 +82,10 @@ TEST_F(ConstantVectorSourceTest, BasicVectorModel) {
 
   // Tests that the output reflects changes to the parameter value in the
   // context.
-  BasicVector<double>* source_value =
+  BasicVector<double>& source_value =
       static_cast<ConstantVectorSource<double>*>(source_.get())
           ->get_mutable_source_value(context_.get());
-  source_value->SetFromVector(2.0 * source_value->get_value());
+  source_value.SetFromVector(2.0 * source_value.get_value());
 
   source_->get_output_port(0).Calc(*context_, output_.get());
 

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -247,9 +247,9 @@ TEST_F(TestLinearizeFromAffine, DiscreteAtEquilibrium) {
   const Eigen::Matrix3d eye = Eigen::Matrix3d::Identity();
   const Eigen::Vector3d x0 =
       (eye - A_).colPivHouseholderQr().solve(B_ * u0_ + f0_);
-  systems::BasicVector<double>* xd =
+  systems::BasicVector<double>& xd =
       context->get_mutable_discrete_state()->get_mutable_vector();
-  xd->SetFromVector(x0);
+  xd.SetFromVector(x0);
 
   auto linearized_system = Linearize(*discrete_system_, *context);
 
@@ -279,9 +279,9 @@ TEST_F(TestLinearizeFromAffine, DiscreteAtEquilibrium) {
 TEST_F(TestLinearizeFromAffine, DiscreteAtNonEquilibrium) {
   auto context = discrete_system_->CreateDefaultContext();
   context->FixInputPort(0, Vector1d::Constant(u0_));
-  systems::BasicVector<double>* xd =
+  systems::BasicVector<double>& xd =
       context->get_mutable_discrete_state()->get_mutable_vector();
-  xd->SetFromVector(x0_);
+  xd.SetFromVector(x0_);
 
   // This Context is not an equilibrium point.
   EXPECT_THROW(Linearize(*discrete_system_, *context), std::runtime_error);
@@ -321,7 +321,7 @@ class TestNonPeriodicSystem : public LeafSystem<double> {
       const Context<double>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>&,
       DiscreteValues<double>* discrete_state) const override {
-    (*discrete_state)[0] = context.get_discrete_state(0)->GetAtIndex(0) + 1;
+    (*discrete_state)[0] = context.get_discrete_state(0).GetAtIndex(0) + 1;
   }
 };
 
@@ -504,7 +504,7 @@ TEST_F(LinearSystemTest, LinearizeSystemWithParameters) {
 
   const auto params =
       dynamic_cast<const examples::pendulum::PendulumParams<double>*>(
-          context->get_numeric_parameter(0));
+          &context->get_numeric_parameter(0));
   EXPECT_TRUE(params);
 
   // Compare against manual linearization of the pendulum dynamics.

--- a/drake/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/drake/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -106,7 +106,7 @@ TEST_P(PiecewisePolynomialAffineSystemTest, DiscreteUpdates) {
   if (time_period_ == 0.) {
     continuous_state_->SetFromVector(x);
   } else {
-    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+    discrete_state_->get_mutable_vector(0).SetFromVector(x);
   }
 
   const double tol = 1e-10;
@@ -122,7 +122,7 @@ TEST_P(PiecewisePolynomialAffineSystemTest, DiscreteUpdates) {
     } else {
       dut_->CalcDiscreteVariableUpdates(*context_, updates_.get());
       EXPECT_TRUE(CompareMatrices(
-          A * x + B * u + f0, updates_->get_vector(0)->CopyToVector(), tol));
+          A * x + B * u + f0, updates_->get_vector(0).CopyToVector(), tol));
     }
   }
 }
@@ -139,7 +139,7 @@ TEST_P(PiecewisePolynomialAffineSystemTest, Output) {
   if (time_period_ == 0.) {
     continuous_state_->SetFromVector(x);
   } else {
-    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+    discrete_state_->get_mutable_vector(0).SetFromVector(x);
   }
 
   const double tol = 1e-10;

--- a/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -100,7 +100,7 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Derivatives) {
   if (time_period_ == 0.) {
     continuous_state_->SetFromVector(x);
   } else {
-    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+    discrete_state_->get_mutable_vector(0).SetFromVector(x);
   }
 
   std::vector<double> times{0., 1e-5 * kDiscreteTimeStep,
@@ -118,7 +118,7 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Derivatives) {
     } else {
       dut_->CalcDiscreteVariableUpdates(*context_, updates_.get());
       EXPECT_TRUE(CompareMatrices(
-          A * x + B * u, updates_->get_vector(0)->CopyToVector(), tol));
+          A * x + B * u, updates_->get_vector(0).CopyToVector(), tol));
     }
   }
 }
@@ -135,7 +135,7 @@ TEST_P(PiecewisePolynomialLinearSystemTest, Output) {
   if (time_period_ == 0.) {
     continuous_state_->SetFromVector(x);
   } else {
-    discrete_state_->get_mutable_vector(0)->SetFromVector(x);
+    discrete_state_->get_mutable_vector(0).SetFromVector(x);
   }
 
   std::vector<double> times{0., 1e-5 * kDiscreteTimeStep,

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -38,10 +38,10 @@ void CheckStatistics(
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);
-  BasicVector<double>* state =
+  BasicVector<double>& state =
       simulator.get_mutable_context()->get_mutable_discrete_state(0);
-  for (int i = 0; i < state->size(); i++) {
-    state->SetAtIndex(i, 0.0);
+  for (int i = 0; i < state.size(); i++) {
+    state.SetAtIndex(i, 0.0);
   }
 
   simulator.Initialize();

--- a/drake/systems/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/primitives/test/zero_order_hold_test.cc
@@ -112,10 +112,9 @@ TEST_P(ZeroOrderHoldTest, InitialState) {
   const Eigen::Vector3d value_expected = Eigen::Vector3d::Zero();
   Eigen::Vector3d value;
   if (!is_abstract_) {
-    const VectorBase<double>* xd = context_->get_discrete_state(0);
-    ASSERT_NE(nullptr, xd);
-    EXPECT_EQ(kLength, xd->size());
-    value = xd->CopyToVector();
+    const BasicVector<double>& xd = context_->get_discrete_state(0);
+    EXPECT_EQ(kLength, xd.size());
+    value = xd.CopyToVector();
   } else {
     const SimpleAbstractType& state_value =
         context_->get_abstract_state<SimpleAbstractType>(0);
@@ -129,9 +128,8 @@ TEST_P(ZeroOrderHoldTest, Output) {
   const Eigen::Vector3d output_expected = state_value_override_;
   Eigen::Vector3d output;
   if (!is_abstract_) {
-    BasicVector<double>* xd = dynamic_cast<BasicVector<double>*>(
-        context_->get_mutable_discrete_state(0));
-    xd->get_mutable_value() << output_expected;
+    BasicVector<double>& xd = context_->get_mutable_discrete_state(0);
+    xd.get_mutable_value() << output_expected;
 
     hold_->CalcOutput(*context_, output_.get());
 
@@ -187,8 +185,8 @@ TEST_P(ZeroOrderHoldTest, Update) {
         hold_->AllocateDiscreteVariables();
     hold_->CalcDiscreteVariableUpdates(*context_, update.get());
     // Check that the state has been updated to the input.
-    const VectorBase<double>* xd = update->get_vector(0);
-    value = xd->CopyToVector();
+    const BasicVector<double>& xd = update->get_vector(0);
+    value = xd.CopyToVector();
   } else {
     State<double>* state = context_->get_mutable_state();
     hold_->CalcUnrestrictedUpdate(*context_, state);
@@ -221,7 +219,7 @@ class SymbolicZeroOrderHoldTest : public ::testing::Test {
     context_ = hold_->CreateDefaultContext();
     context_->FixInputPort(0, BasicVector<symbolic::Expression>::Make(
         symbolic::Variable("u0")));
-    auto& xd = *context_->get_mutable_discrete_state(0);
+    auto& xd = context_->get_mutable_discrete_state(0);
     xd[0] = symbolic::Variable("x0");
 
     output_ = hold_->AllocateOutput(*context_);
@@ -243,7 +241,7 @@ TEST_F(SymbolicZeroOrderHoldTest, Output) {
 
 TEST_F(SymbolicZeroOrderHoldTest, Update) {
   hold_->CalcDiscreteVariableUpdates(*context_, update_.get());
-  const auto& xd = *update_->get_vector(0);
+  const auto& xd = update_->get_vector(0);
   EXPECT_EQ("u0", xd[0].to_string());
 }
 

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -63,7 +63,7 @@ void ZeroOrderHold<T>::DoCalcVectorOutput(
       const Context<T>& context,
       BasicVector<T>* output) const {
   DRAKE_ASSERT(!is_abstract());
-  const BasicVector<T>& state_value = *context.get_discrete_state(0);
+  const BasicVector<T>& state_value = context.get_discrete_state(0);
   output->SetFrom(state_value);
 }
 
@@ -74,7 +74,7 @@ void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
     DiscreteValues<T>* discrete_state) const {
   DRAKE_ASSERT(!is_abstract());
   const BasicVector<T>& input_value = *this->EvalVectorInput(context, 0);
-  BasicVector<T>& state_value = *discrete_state->get_mutable_vector(0);
+  BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
   state_value.SetFrom(input_value);
 }
 

--- a/drake/systems/sensors/beam_model.cc
+++ b/drake/systems/sensors/beam_model.cc
@@ -41,7 +41,7 @@ BeamModel<T>::BeamModel(int num_depth_readings, double max_range)
       calc_event_probabilities_constraint =
           [](const Context<T>& context, VectorX<T>* value) {
             const auto* params = dynamic_cast<const BeamModelParams<T>*>(
-                context.get_numeric_parameter(0));
+                &context.get_numeric_parameter(0));
             DRAKE_DEMAND(params != nullptr);
             (*value)[0] = 1.0 - params->probability_short() -
                           params->probability_miss() -
@@ -58,7 +58,7 @@ BeamModel<T>::BeamModel(const DepthSensorSpecification& specification)
 }
 
 template <typename T>
-BeamModelParams<T>* BeamModel<T>::get_mutable_parameters(
+BeamModelParams<T>& BeamModel<T>::get_mutable_parameters(
     Context<T>* context) const {
   return this->template GetMutableNumericParameter<BeamModelParams>(context, 0);
 }
@@ -66,8 +66,8 @@ BeamModelParams<T>* BeamModel<T>::get_mutable_parameters(
 template <typename T>
 void BeamModel<T>::CalcOutput(const systems::Context<T>& context,
                               BasicVector<T>* output) const {
-  const auto params =
-      dynamic_cast<const BeamModelParams<T>*>(context.get_numeric_parameter(0));
+  const auto params = dynamic_cast<const BeamModelParams<T>*>(
+      &context.get_numeric_parameter(0));
   DRAKE_DEMAND(params != nullptr);
   const auto& depth = this->EvalEigenVectorInput(context, 0);
   const auto& w_event = this->EvalEigenVectorInput(context, 1);

--- a/drake/systems/sensors/beam_model.h
+++ b/drake/systems/sensors/beam_model.h
@@ -77,7 +77,7 @@ class BeamModel final : public LeafSystem<T> {
     return this->get_input_port(4);
   }
 
-  BeamModelParams<T>* get_mutable_parameters(Context<T>* context) const;
+  BeamModelParams<T>& get_mutable_parameters(Context<T>* context) const;
 
   double max_range() const { return max_range_; }
 

--- a/drake/systems/sensors/test/beam_model_test.cc
+++ b/drake/systems/sensors/test/beam_model_test.cc
@@ -99,29 +99,29 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   // Zero all initial state.
   for (int i = 0; i < simulator.get_context().get_num_discrete_state_groups();
        i++) {
-    BasicVector<double>* state =
+    BasicVector<double>& state =
         simulator.get_mutable_context()->get_mutable_discrete_state(0);
-    for (int j = 0; j < state->size(); j++) {
-      state->SetAtIndex(j, 0.0);
+    for (int j = 0; j < state.size(); j++) {
+      state.SetAtIndex(j, 0.0);
     }
   }
 
-  auto* params =
+  auto& params =
       beam_model->get_mutable_parameters(&diagram->GetMutableSubsystemContext(
           *beam_model, simulator.get_mutable_context()));
 
   // Set some testable beam model parameters.
-  params->set_lambda_short(2.0);
-  params->set_sigma_hit(0.25);
-  params->set_probability_short(0.2);
-  params->set_probability_miss(0.05);
-  params->set_probability_uniform(0.05);
+  params.set_lambda_short(2.0);
+  params.set_sigma_hit(0.25);
+  params.set_probability_short(0.2);
+  params.set_probability_miss(0.05);
+  params.set_probability_uniform(0.05);
 
-  double probability_hit = 1.0 - params->probability_uniform() -
-                           params->probability_miss() -
-                           params->probability_short();
+  double probability_hit = 1.0 - params.probability_uniform() -
+                           params.probability_miss() -
+                           params.probability_short();
   // Truncated tail of the exponential adds to "hit".
-  probability_hit += std::exp(-params->lambda_short() * kDepthInput);
+  probability_hit += std::exp(-params.lambda_short() * kDepthInput);
 
   auto probability_density_function = [&](double z) {
     DRAKE_DEMAND(z >= 0.0 && z < kMaxRange);  // Doesn't capture the delta
@@ -129,12 +129,12 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
                                               // at kMaxRange.
     const double p_short =
         (z <= kDepthInput)
-            ? params->lambda_short() * std::exp(-params->lambda_short() * z)
+            ? params.lambda_short() * std::exp(-params.lambda_short() * z)
             : 0.0;
 
-    const double sigma_sq = params->sigma_hit() * params->sigma_hit();
-    return params->probability_uniform() / kMaxRange +
-           params->probability_short() * p_short +
+    const double sigma_sq = params.sigma_hit() * params.sigma_hit();
+    return params.probability_uniform() / kMaxRange +
+           params.probability_short() * p_short +
            probability_hit * std::exp(-0.5 * (z - kDepthInput) *
                                       (z - kDepthInput) / sigma_sq) /
                std::sqrt(2 * M_PI * sigma_sq);
@@ -181,14 +181,14 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   // Cumulative distribution function of the standard normal distribution.
   auto Phi = [](double z) { return 0.5 * std::erfc(-z / std::sqrt(2.0)); };
   const double p_max =
-      params->probability_miss() +
+      params.probability_miss() +
       probability_hit *
           Phi(-kDepthInput /
-              params->sigma_hit())  // "hit" would have returned < 0.0.
+              params.sigma_hit())  // "hit" would have returned < 0.0.
       +
       probability_hit *
           Phi((kDepthInput - kMaxRange) /
-              params->sigma_hit());  // "hit" would have returned > kMaxRange.
+              params.sigma_hit());  // "hit" would have returned > kMaxRange.
   EXPECT_NEAR(
       (x.array() == kMaxRange).template cast<double>().matrix().sum() / N,
       p_max, 2e-3);

--- a/drake/systems/trajectory_optimization/direct_transcription.cc
+++ b/drake/systems/trajectory_optimization/direct_transcription.cc
@@ -78,10 +78,10 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
       input_port_value_->GetMutableVectorData<AutoDiffXd>()->SetFromVector(
           input);
     }
-    context_->get_mutable_discrete_state(0)->SetFromVector(state);
+    context_->get_mutable_discrete_state(0).SetFromVector(state);
 
     system_.CalcDiscreteVariableUpdates(*context_, discrete_state_);
-    y = next_state - discrete_state_->get_vector(0)->CopyToVector();
+    y = next_state - discrete_state_->get_vector(0).CopyToVector();
   }
 
  private:
@@ -216,7 +216,7 @@ bool DirectTranscription::AddSymbolicDynamicConstraints(
 
   symbolic::Substitution sub;
   for (int i = 0; i < context.num_numeric_parameters(); i++) {
-    const auto& params = context.get_numeric_parameter(i)->get_value();
+    const auto& params = context.get_numeric_parameter(i).get_value();
     for (int j = 0; j < params.size(); j++) {
       sub.emplace(inspector->numeric_parameters(i)[j], params[j]);
     }
@@ -285,7 +285,7 @@ void DirectTranscription::ValidateSystem(const System<double>& system,
   // (#6878).
 
   DRAKE_DEMAND(context.get_num_discrete_state_groups() == 1);
-  DRAKE_DEMAND(num_states() == context.get_discrete_state(0)->size());
+  DRAKE_DEMAND(num_states() == context.get_discrete_state(0).size());
   DRAKE_DEMAND(system.get_num_input_ports() <= 1);
   DRAKE_DEMAND(num_inputs() == (context.get_num_input_ports() > 0
                                 ? system.get_input_port(0).size()

--- a/drake/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/drake/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -61,8 +61,8 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
     using std::pow;
-    discrete_state->get_mutable_vector(0)->SetAtIndex(
-        0, pow(context.get_discrete_state(0)->GetAtIndex(0), 3.0));
+    discrete_state->get_mutable_vector(0).SetAtIndex(
+        0, pow(context.get_discrete_state(0).GetAtIndex(0), 3.0));
   }
 
   const double timestep_{0.0};
@@ -92,9 +92,9 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
-    discrete_state->get_mutable_vector(0)->SetAtIndex(
-        0, context.get_numeric_parameter(0)->GetAtIndex(0) *
-               context.get_discrete_state(0)->GetAtIndex(0));
+    discrete_state->get_mutable_vector(0).SetAtIndex(
+        0, context.get_numeric_parameter(0).GetAtIndex(0) *
+               context.get_discrete_state(0).GetAtIndex(0));
   }
 };
 
@@ -323,7 +323,7 @@ GTEST_TEST(DirectTranscriptionTest, LinearSystemWParamsTest) {
 
   const auto context = system.CreateDefaultContext();
   const double kGain = -1.0;
-  context->get_mutable_numeric_parameter(0)->SetAtIndex(0, kGain);
+  context->get_mutable_numeric_parameter(0).SetAtIndex(0, kGain);
   const int kNumSampleTimes = 3;
   DirectTranscription prog(&system, *context, kNumSampleTimes);
 

--- a/drake/tools/BUILD.bazel
+++ b/drake/tools/BUILD.bazel
@@ -83,6 +83,7 @@ drake_cc_googletest(
     name = "sample_translator_test",
     deps = [
         ":sample_translator",
+        "//drake/common/test_utilities",
     ],
 )
 

--- a/drake/tools/test/sample_translator_test.cc
+++ b/drake/tools/test/sample_translator_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/tools/test/gen/sample.h"
 
 namespace drake {
@@ -41,8 +42,7 @@ GTEST_TEST(SampleTranslatorTest, RoundtripTest) {
   std::unique_ptr<systems::VectorBase<double>> allocated_vector =
       dut.AllocateOutputVector();
   ASSERT_NE(nullptr, allocated_vector.get());
-  ASSERT_NE(nullptr, dynamic_cast<Sample<double>*>(
-      allocated_vector.get()));
+  ASSERT_TRUE(is_dynamic_castable<Sample<double>>(allocated_vector.get()));
 }
 
 }  // namespace


### PR DESCRIPTION
This is a minor cleanup pass on the API to address part of #7017, #7174 and the like, where we have been inconsistent about returning pointers vs. references. The System framework policy will be to return references whenever possible, so pointers will be returned only if null is a legitimate possibility.

In this first PR, DiscreteValues and Parameter APIs are repaired. That's not the end but this seems like a good size to review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7312)
<!-- Reviewable:end -->
