### PR TITLE
partially repair broken kuka examples and add README

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/BUILD.bazel
@@ -122,7 +122,7 @@ drake_cc_binary(
         ":models",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    test_rule_args = ["--simulation_sec=0.1"],
+    test_rule_args = ["--simulation_sec=0.1 --target_realtime_rate=0.0"],
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",

--- a/drake/examples/kuka_iiwa_arm/README.md
+++ b/drake/examples/kuka_iiwa_arm/README.md
@@ -1,0 +1,49 @@
+IIWA Manipulation Examples
+==========================
+
+There are a number of examples contained in these directories.  
+
+The following instructions assume Drake was
+[built using bazel](http://drake.mit.edu/bazel.html?highlight=bazel).
+
+Prerequisites
+-------------
+
+Ensure that you have installed the drake visualizer with
+```
+bazel build //tools:drake_visualizer
+```
+
+Ensure that you have set your
+[PYTHONPATH](http://drake.mit.edu/python_bindings.html?highlight=python).
+
+All instructions assume that you are launching from the `drake-distro`
+directory.
+```
+cd drake-distro
+```
+
+
+Basic IIWA Simulation
+---------------------
+
+Launch the visualizer
+```
+bazel-bin/tools/drake_visualizer
+```
+
+Launch the kuka simulation
+```
+bazel-bin/drake/examples/kuka_iiwa_arm/kuka_simulation
+```
+
+Launch the "plan runner" (which produces position commands over time
+upon receiving a single plan message)
+```
+bazel-bin/drake/examples/kuka_iiwa_arm/kuka_plan_runner
+```
+
+Coming back soon - generate plans using the graphical IK interface.
+See https://github.com/RobotLocomotion/drake/issues/7321 .
+
+

--- a/drake/examples/kuka_iiwa_arm/kuka_sim.pmd
+++ b/drake/examples/kuka_iiwa_arm/kuka_sim.pmd
@@ -1,12 +1,12 @@
 group "0.sim" {
 
   cmd "0.kuka_simulation" {
-    exec = "build/drake/examples/kuka_iiwa_arm/kuka_simulation";
+    exec = "bazel-bin/drake/examples/kuka_iiwa_arm/kuka_simulation";
     host = "localhost";
   }
 
   cmd "1.kuka_plan_runner" {
-    exec = "build/drake/examples/kuka_iiwa_arm/kuka_plan_runner";
+    exec = "bazel-bin/drake/examples/kuka_iiwa_arm/kuka_plan_runner";
     host = "localhost";
   }
 
@@ -19,7 +19,7 @@ group "0.sim" {
 group "1.tools" {
 
   cmd "0.drake-visualizer" {
-    exec = "build/install/bin/drake-visualizer";
+    exec = "bazel-bin/tools/drake_visualizer";
     host = "localhost";
   }
 
@@ -28,10 +28,4 @@ group "1.tools" {
     exec = "build/install/bin/directorPython drake/examples/kuka_iiwa_arm/director_ik_app.py --director_config drake/examples/kuka_iiwa_arm/director_config.json";
     host = "localhost";
   }
-
-  cmd "2.signal-scope" {
-    exec = "build/install/bin/signal-scope drake/examples/kuka_iiwa_arm/kuka_iiwa_signal_scope.py";
-    host = "localhost";
-  }
-
 }

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -36,6 +36,9 @@ DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate.");
 DEFINE_string(urdf, "", "Name of urdf to load");
 DEFINE_bool(visualize_frames, true, "Visualize end effector frames");
+DEFINE_double(target_realtime_rate, 1.0,
+              "Playback speed.  See documentation for "
+              "Simulator::set_target_realtime_rate() for details.");
 
 namespace drake {
 namespace examples {
@@ -161,6 +164,7 @@ int DoMain() {
 
   lcm.StartReceiveThread();
   simulator.set_publish_every_time_step(false);
+  simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
 
   command_receiver->set_initial_position(


### PR DESCRIPTION
There was no README in the kuka examples directory.  Running anything took knowledge most people would not have.  I've take a very rough pass, but hope others can contribute more.

Also set the default realtime rate to 1.0 so that users with sufficiently fast machines experience what they would expect to experience.  

The existing .pmd files in the root kuka directory were broken.  They still are broken, but less broken after this pull request.  I will open an additional issue to track.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7313)
<!-- Reviewable:end -->
