### PR TITLE
Fix dual arm kuka simulation

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_binary(
         ":iiwa_common",
         ":iiwa_lcm",
         "//drake/common:find_resource",
+        "//drake/common:text_logging_gflags",
         "//drake/lcm",
         "//drake/manipulation/util:sim_diagram_builder",
         "//drake/manipulation/util:world_sim_tree_builder",
@@ -182,6 +183,23 @@ drake_cc_googletest(
     name = "optitrack_test",
     deps = [
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
+    ],
+)
+
+# Test that kuka_simulation can load the dual arm urdf
+sh_test(
+    name = "dual_kuka_simulation_test",
+    size = "small",
+    srcs = ["kuka_simulation"],
+    args = [
+        "$(location :kuka_simulation)",
+        "--urdf",
+        "$(location //drake/manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf)",  # noqa
+        "--simulation_sec=0.01",
+        "--novisualize_frames",
+    ],
+    data = [
+        "//drake/manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf",  # noqa
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/kuka_sim_dual.pmd
+++ b/drake/examples/kuka_iiwa_arm/kuka_sim_dual.pmd
@@ -1,12 +1,12 @@
 group "0.sim" {
 
   cmd "0.kuka_simulation" {
-    exec = "build/drake/examples/kuka_iiwa_arm/kuka_simulation --urdf drake/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf";
+    exec = "bazel-bin/drake/examples/kuka_iiwa_arm/kuka_simulation --urdf drake/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf --novisualize_frames";
     host = "localhost";
   }
 
   cmd "1.iiwa_controller" {
-    exec = "build/drake/examples/kuka_iiwa_arm/iiwa_controller --urdf drake/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf";
+    exec = "bazel-bin/drake/examples/kuka_iiwa_arm/iiwa_controller --urdf drake/manipulation/models/iiwa_description/urdf/dual_iiwa14_polytope_collision.urdf";
     host = "localhost";
   }
 

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -11,6 +11,8 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/text_logging.h"
+#include "drake/common/text_logging_gflags.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 #include "drake/lcm/drake_lcm.h"
@@ -33,6 +35,7 @@
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate.");
 DEFINE_string(urdf, "", "Name of urdf to load");
+DEFINE_bool(visualize_frames, true, "Visualize end effector frames");
 
 namespace drake {
 namespace examples {
@@ -123,19 +126,34 @@ int DoMain() {
   base_builder->Connect(status_sender->get_output_port(0),
                         status_pub->get_input_port(0));
 
-  // Visualizes the end effector frame and 7th body's frame.
-  std::vector<RigidBodyFrame<double>> local_transforms;
-  local_transforms.push_back(
-      RigidBodyFrame<double>("iiwa_link_ee", tree.FindBody("iiwa_link_ee"),
-                             Isometry3<double>::Identity()));
-  local_transforms.push_back(
-      RigidBodyFrame<double>("iiwa_link_7", tree.FindBody("iiwa_link_7"),
-                             Isometry3<double>::Identity()));
-  auto frame_viz = base_builder->AddSystem<systems::FrameVisualizer>(
-      &tree, local_transforms, &lcm);
-  base_builder->Connect(plant->get_output_port(0),
-                        frame_viz->get_input_port(0));
-  frame_viz->set_publish_period(kIiwaLcmStatusPeriod);
+  if (FLAGS_visualize_frames) {
+    // TODO(sam.creasey) This try/catch block is here because even
+    // though RigidBodyTree::FindBody returns a pointer and could return
+    // null to indicate failure, it throws instead.  At any rate, warn
+    // instead of dying if the links aren't named as expected.  This
+    // happens (for example) when loading
+    // dual_iiwa14_polytope_collision.urdf.
+    try {
+    // Visualizes the end effector frame and 7th body's frame.
+      std::vector<RigidBodyFrame<double>> local_transforms;
+      local_transforms.push_back(
+          RigidBodyFrame<double>("iiwa_link_ee", tree.FindBody("iiwa_link_ee"),
+                                 Isometry3<double>::Identity()));
+      local_transforms.push_back(
+          RigidBodyFrame<double>("iiwa_link_7", tree.FindBody("iiwa_link_7"),
+                                 Isometry3<double>::Identity()));
+      auto frame_viz = base_builder->AddSystem<systems::FrameVisualizer>(
+          &tree, local_transforms, &lcm);
+      base_builder->Connect(plant->get_output_port(0),
+                            frame_viz->get_input_port(0));
+      frame_viz->set_publish_period(kIiwaLcmStatusPeriod);
+    } catch (std::logic_error& ex) {
+      drake::log()->error("Unable to visualize end effector frames:\n{}\n"
+                          "Maybe use --novisualize_frames?",
+                          ex.what());
+      return 1;
+    }
+  }
 
   auto sys = builder.Build();
 
@@ -163,5 +181,6 @@ int DoMain() {
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  drake::logging::HandleSpdlogGflags();
   return drake::examples::kuka_iiwa_arm::DoMain();
 }

--- a/drake/manipulation/models/iiwa_description/BUILD.bazel
+++ b/drake/manipulation/models/iiwa_description/BUILD.bazel
@@ -7,8 +7,10 @@ load(
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+# This package is public so that other packages can refer to
+# individual files in model from their bazel rules.
 package(
-    default_visibility = [":__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 # === test/ ===


### PR DESCRIPTION
As noted in #7314, the dual arm simulation of the iiwa described in
kuka_sim_dual.pmd no longer works.  This fixes it by conditonally
ignoring the errors trying to find the frames to visualize, and adds a
test to confirm that the simulation works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7317)
<!-- Reviewable:end -->
