### PR TITLE
Make image compression optional

### DIFF
--- a/drake/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.cc
@@ -80,7 +80,7 @@ void PackImageToLcmImageT(const Image<kPixelType>& image, int64_t utime,
 ImageToLcmImageArrayT::ImageToLcmImageArrayT(const string& color_frame_name,
                                              const string& depth_frame_name,
                                              const string& label_frame_name,
-                                             const bool do_compress)
+                                             bool do_compress)
     : color_frame_name_(color_frame_name),
       depth_frame_name_(depth_frame_name),
       label_frame_name_(label_frame_name),

--- a/drake/systems/sensors/image_to_lcm_image_array_t.cc
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.cc
@@ -43,9 +43,20 @@ void Compress(const Image<kPixelType>& image, image_t* msg) {
 }
 
 template <PixelType kPixelType>
+void Pack(const Image<kPixelType>& image, image_t* msg) {
+  msg->compression_method = image_t::COMPRESSION_METHOD_NOT_COMPRESSED;
+
+  const int size = image.width() * image.height() * image.kPixelSize;
+  msg->data.resize(size);
+  msg->size = size;
+  memcpy(&msg->data[0], image.at(0, 0), size);
+}
+
+template <PixelType kPixelType>
 void PackImageToLcmImageT(const Image<kPixelType>& image, int64_t utime,
                           uint8_t pixel_format, uint8_t channel_type,
-                          const string& frame_name, image_t* msg) {
+                          const string& frame_name, image_t* msg,
+                          bool do_compress) {
   // TODO(kunimatsu-tri) Fix seq here that is always set to zero.
   msg->header.seq = 0;
   msg->header.utime = utime;
@@ -57,18 +68,23 @@ void PackImageToLcmImageT(const Image<kPixelType>& image, int64_t utime,
   msg->pixel_format = pixel_format;
   msg->channel_type = channel_type;
 
-  // TODO(kunimatsu-tri) Make compression optional and/or selectable.
-  Compress(image, msg);
+  if (do_compress) {
+    Compress(image, msg);
+  } else {
+    Pack(image, msg);
+  }
 }
 
 }  // anonymous namespace
 
 ImageToLcmImageArrayT::ImageToLcmImageArrayT(const string& color_frame_name,
                                              const string& depth_frame_name,
-                                             const string& label_frame_name)
+                                             const string& label_frame_name,
+                                             const bool do_compress)
     : color_frame_name_(color_frame_name),
       depth_frame_name_(depth_frame_name),
-      label_frame_name_(label_frame_name) {
+      label_frame_name_(label_frame_name),
+      do_compress_(do_compress) {
   color_image_input_port_index_ =
       DeclareAbstractInputPort(systems::Value<ImageRgba8U>()).get_index();
 
@@ -127,7 +143,8 @@ void ImageToLcmImageArrayT::CalcImageArray(
     PackImageToLcmImageT(color_image, msg->header.utime,
                          image_t::PIXEL_FORMAT_RGBA,
                          image_t::CHANNEL_TYPE_UINT8, color_frame_name_,
-                         &color_image_msg);
+                         &color_image_msg,
+                         do_compress_);
     msg->images.push_back(color_image_msg);
     msg->num_images++;
   }
@@ -139,7 +156,8 @@ void ImageToLcmImageArrayT::CalcImageArray(
     PackImageToLcmImageT(depth_image, msg->header.utime,
                          image_t::PIXEL_FORMAT_DEPTH,
                          image_t::CHANNEL_TYPE_FLOAT32, depth_frame_name_,
-                         &depth_image_msg);
+                         &depth_image_msg,
+                         do_compress_);
     msg->images.push_back(depth_image_msg);
     msg->num_images++;
   }
@@ -152,7 +170,8 @@ void ImageToLcmImageArrayT::CalcImageArray(
     PackImageToLcmImageT(label_image, msg->header.utime,
                          image_t::PIXEL_FORMAT_LABEL,
                          image_t::CHANNEL_TYPE_INT16, label_frame_name_,
-                         &label_image_msg);
+                         &label_image_msg,
+                         do_compress_);
     msg->images.push_back(label_image_msg);
     msg->num_images++;
   }

--- a/drake/systems/sensors/image_to_lcm_image_array_t.h
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.h
@@ -11,7 +11,7 @@ namespace drake {
 namespace systems {
 namespace sensors {
 
-/// An ImageToLcmImageArrayT takes as input a ImageBgra8U, ImageDepth32F and
+/// An ImageToLcmImageArrayT takes as input an ImageRgba8U, ImageDepth32F and
 /// ImageLabel16I. This system outputs an AbstractValue containing a
 /// `Value<robotlocomotion::image_array_t>` LCM message that defines an array
 /// of images (image_t). This message can then be sent to other processes that
@@ -23,7 +23,7 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ImageToLcmImageArrayT)
 
-  /// A %ImageToLcmImageArrayT constructor.
+  /// An %ImageToLcmImageArrayT constructor.
   ///
   /// @param color_frame_name The frame name used for color image.
   /// @param depth_frame_name The frame name used for depth image.
@@ -52,10 +52,10 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   void CalcImageArray(const systems::Context<double>& context,
                       robotlocomotion::image_array_t* msg) const;
 
-  int color_image_input_port_index_{};
-  int depth_image_input_port_index_{};
-  int label_image_input_port_index_{};
-  int image_array_t_msg_output_port_index_{};
+  int color_image_input_port_index_{-1};
+  int depth_image_input_port_index_{-1};
+  int label_image_input_port_index_{-1};
+  int image_array_t_msg_output_port_index_{-1};
 
   std::string color_frame_name_;
   std::string depth_frame_name_;

--- a/drake/systems/sensors/image_to_lcm_image_array_t.h
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.h
@@ -28,9 +28,12 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   /// @param color_frame_name The frame name used for color image.
   /// @param depth_frame_name The frame name used for depth image.
   /// @param label_frame_name The frame name used for label image.
+  /// @param do_compress When true, zlib compression will be performed. The
+  /// default is false.
   ImageToLcmImageArrayT(const std::string& color_frame_name,
                         const std::string& depth_frame_name,
-                        const std::string& label_frame_name);
+                        const std::string& label_frame_name,
+                        const bool do_compress = false);
 
   /// Returns a descriptor of the input port containing a color image.
   const InputPortDescriptor<double>& color_image_input_port() const;
@@ -57,6 +60,8 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   std::string color_frame_name_;
   std::string depth_frame_name_;
   std::string label_frame_name_;
+
+  const bool do_compress_;
 };
 
 }  // namespace sensors

--- a/drake/systems/sensors/image_to_lcm_image_array_t.h
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.h
@@ -36,7 +36,7 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   ImageToLcmImageArrayT(const std::string& color_frame_name,
                         const std::string& depth_frame_name,
                         const std::string& label_frame_name,
-                        const bool do_compress = false);
+                        bool do_compress = false);
 
   /// Returns a descriptor of the input port containing a color image.
   const InputPortDescriptor<double>& color_image_input_port() const;
@@ -60,9 +60,9 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
   int label_image_input_port_index_{-1};
   int image_array_t_msg_output_port_index_{-1};
 
-  std::string color_frame_name_;
-  std::string depth_frame_name_;
-  std::string label_frame_name_;
+  const std::string color_frame_name_;
+  const std::string depth_frame_name_;
+  const std::string label_frame_name_;
 
   const bool do_compress_;
 };

--- a/drake/systems/sensors/image_to_lcm_image_array_t.h
+++ b/drake/systems/sensors/image_to_lcm_image_array_t.h
@@ -15,9 +15,12 @@ namespace sensors {
 /// ImageLabel16I. This system outputs an AbstractValue containing a
 /// `Value<robotlocomotion::image_array_t>` LCM message that defines an array
 /// of images (image_t). This message can then be sent to other processes that
-/// sbscribe it using LcmPublisherSystem.
+/// sbscribe it using LcmPublisherSystem. Note that you should NOT assume any
+/// particular order of those images stored in robotlocomotion::image_array_t,
+/// instead check the semantic of those images with
+/// robotlocomotion::image_t::pixel_format before using them.
 // TODO(kunimatsu-tri) Instead of assuming fixed pixel types for the input
-// ports, e.g. ImageBgra8U, change the interface to be able to handle arbitrary
+// ports, e.g. ImageRgba8U, change the interface to be able to handle arbitrary
 // pixel types of `Image`.
 class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
  public:

--- a/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -10,6 +10,8 @@ namespace systems {
 namespace sensors {
 namespace {
 
+using robotlocomotion::image_t;
+
 const char* kColorFrameName = "color_frame_name";
 const char* kDepthFrameName = "depth_frame_name";
 const char* kLabelFrameName = "label_frame_name";
@@ -57,19 +59,17 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
 
   auto Verify = [color_image, depth_image, label_image](
                    const ImageToLcmImageArrayT& dut,
-                   const robotlocomotion::image_array_t& output_image_array_t,
+                   const robotlocomotion::image_array_t& output_image_array,
                    uint8_t compression_method) {
     // Verifyies image_array_t
-    EXPECT_EQ(output_image_array_t.header.seq, 0);
-    EXPECT_EQ(output_image_array_t.header.utime, 0);
-    EXPECT_EQ(output_image_array_t.header.frame_name, "");
-    EXPECT_EQ(output_image_array_t.num_images, 3);
-    EXPECT_EQ(output_image_array_t.images.size(), 3);
+    EXPECT_EQ(output_image_array.header.seq, 0);
+    EXPECT_EQ(output_image_array.header.utime, 0);
+    EXPECT_EQ(output_image_array.header.frame_name, "");
+    EXPECT_EQ(output_image_array.num_images, 3);
+    EXPECT_EQ(output_image_array.images.size(), 3);
 
     // Verifyies each image_t.
-    for (int i = 0; i < output_image_array_t.num_images; ++i) {
-      auto const& image = output_image_array_t.images[i];
-
+    for (auto const& image : output_image_array.images) {
       EXPECT_EQ(image.header.seq, 0);
       EXPECT_EQ(image.header.utime, 0);
       EXPECT_EQ(image.width, kImageWidth);
@@ -82,35 +82,26 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
       int row_stride;
       int8_t pixel_format;
       int8_t channel_type;
-      switch (i) {
-        case 0: {
-          frame_name = kColorFrameName;
-          row_stride = color_image.width() * color_image.kNumChannels *
-              sizeof(*color_image.at(0, 0));
-          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_RGBA;
-          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
-          break;
-        }
-        case 1: {
-          frame_name = kDepthFrameName;
-          row_stride = depth_image.width() * depth_image.kNumChannels *
-              sizeof(*depth_image.at(0, 0));
-          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_DEPTH;
-          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_FLOAT32;
-          break;
-        }
-        case 2: {
-          frame_name = kLabelFrameName;
-          row_stride = label_image.width() * label_image.kNumChannels *
-              sizeof(*label_image.at(0, 0));
-          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_LABEL;
-          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_INT16;
-          break;
-        }
-        default: {
-          EXPECT_FALSE(true);
-          break;
-        }
+      if (image.pixel_format == image_t::PIXEL_FORMAT_RGBA) {
+        frame_name = kColorFrameName;
+        row_stride = color_image.width() * color_image.kNumChannels *
+            sizeof(*color_image.at(0, 0));
+        pixel_format = image_t::PIXEL_FORMAT_RGBA;
+        channel_type = image_t::CHANNEL_TYPE_UINT8;
+      } else if (image.pixel_format == image_t::PIXEL_FORMAT_DEPTH) {
+        frame_name = kDepthFrameName;
+        row_stride = depth_image.width() * depth_image.kNumChannels *
+            sizeof(*depth_image.at(0, 0));
+        pixel_format = image_t::PIXEL_FORMAT_DEPTH;
+        channel_type = image_t::CHANNEL_TYPE_FLOAT32;
+      } else if (image.pixel_format == image_t::PIXEL_FORMAT_LABEL) {
+        frame_name = kLabelFrameName;
+        row_stride = label_image.width() * label_image.kNumChannels *
+            sizeof(*label_image.at(0, 0));
+        pixel_format = image_t::PIXEL_FORMAT_LABEL;
+        channel_type = image_t::CHANNEL_TYPE_INT16;
+      } else {
+        EXPECT_FALSE(true);
       }
 
       EXPECT_EQ(image.header.frame_name, frame_name);
@@ -125,14 +116,14 @@ GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
   auto image_array_t_compressed = SetUpInputAndOutput(
           &dut_compressed, color_image, depth_image, label_image);
   Verify(dut_compressed, image_array_t_compressed,
-         robotlocomotion::image_t::COMPRESSION_METHOD_ZLIB);
+         image_t::COMPRESSION_METHOD_ZLIB);
 
   ImageToLcmImageArrayT dut_uncompressed(
       kColorFrameName, kDepthFrameName, kLabelFrameName, false);
   auto image_array_t_uncompressed = SetUpInputAndOutput(
       &dut_uncompressed, color_image, depth_image, label_image);
   Verify(dut_uncompressed, image_array_t_uncompressed,
-         robotlocomotion::image_t::COMPRESSION_METHOD_NOT_COMPRESSED);
+         image_t::COMPRESSION_METHOD_NOT_COMPRESSED);
 }
 
 }  // namespace

--- a/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/drake/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -50,80 +50,89 @@ robotlocomotion::image_array_t SetUpInputAndOutput(
   return output_image_array_t;
 }
 
-
 GTEST_TEST(ImageToLcmImageArrayT, ValidTest) {
   ImageRgba8U color_image(kImageWidth, kImageHeight);
   ImageDepth32F depth_image(kImageWidth, kImageHeight);
   ImageLabel16I label_image(kImageWidth, kImageHeight);
 
-  ImageToLcmImageArrayT dut(kColorFrameName, kDepthFrameName, kLabelFrameName);
+  auto Verify = [color_image, depth_image, label_image](
+                   const ImageToLcmImageArrayT& dut,
+                   const robotlocomotion::image_array_t& output_image_array_t,
+                   uint8_t compression_method) {
+    // Verifyies image_array_t
+    EXPECT_EQ(output_image_array_t.header.seq, 0);
+    EXPECT_EQ(output_image_array_t.header.utime, 0);
+    EXPECT_EQ(output_image_array_t.header.frame_name, "");
+    EXPECT_EQ(output_image_array_t.num_images, 3);
+    EXPECT_EQ(output_image_array_t.images.size(), 3);
 
-  auto output_image_array_t =
-      SetUpInputAndOutput(&dut, color_image, depth_image, label_image);
+    // Verifyies each image_t.
+    for (int i = 0; i < output_image_array_t.num_images; ++i) {
+      auto const& image = output_image_array_t.images[i];
 
-  // Verifyies image_array_t
-  EXPECT_EQ(output_image_array_t.header.seq, 0);
-  EXPECT_EQ(output_image_array_t.header.utime, 0);
-  EXPECT_EQ(output_image_array_t.header.frame_name, "");
-  EXPECT_EQ(output_image_array_t.num_images, 3);
-  EXPECT_EQ(output_image_array_t.images.size(), 3);
+      EXPECT_EQ(image.header.seq, 0);
+      EXPECT_EQ(image.header.utime, 0);
+      EXPECT_EQ(image.width, kImageWidth);
+      EXPECT_EQ(image.height, kImageHeight);
+      EXPECT_EQ(image.data.size(), image.size);
+      EXPECT_FALSE(image.bigendian);
+      EXPECT_EQ(image.compression_method, compression_method);
 
-  // Verifyies each image_t.
-  for (int i = 0; i < output_image_array_t.num_images; ++i) {
-    auto const& image = output_image_array_t.images[i];
-
-    EXPECT_EQ(image.header.seq, 0);
-    EXPECT_EQ(image.header.utime, 0);
-    EXPECT_EQ(image.width, kImageWidth);
-    EXPECT_EQ(image.height, kImageHeight);
-    EXPECT_EQ(image.data.size(), image.size);
-    EXPECT_FALSE(image.bigendian);
-    // This is a workaround for const variable to avoid undefined reference
-    // error: https://goo.gl/3PU0eq
-    uint8_t expected_compression_method =
-        robotlocomotion::image_t::COMPRESSION_METHOD_ZLIB;
-    EXPECT_EQ(image.compression_method, expected_compression_method);
-
-    std::string frame_name;
-    int row_stride;
-    int8_t pixel_format;
-    int8_t channel_type;
-    switch (i) {
-      case 0: {
-        frame_name = kColorFrameName;
-        row_stride = color_image.width() * color_image.kNumChannels *
-            sizeof(*color_image.at(0, 0));
-        pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_RGBA;
-        channel_type = robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
-        break;
+      std::string frame_name;
+      int row_stride;
+      int8_t pixel_format;
+      int8_t channel_type;
+      switch (i) {
+        case 0: {
+          frame_name = kColorFrameName;
+          row_stride = color_image.width() * color_image.kNumChannels *
+              sizeof(*color_image.at(0, 0));
+          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_RGBA;
+          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_UINT8;
+          break;
+        }
+        case 1: {
+          frame_name = kDepthFrameName;
+          row_stride = depth_image.width() * depth_image.kNumChannels *
+              sizeof(*depth_image.at(0, 0));
+          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_DEPTH;
+          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_FLOAT32;
+          break;
+        }
+        case 2: {
+          frame_name = kLabelFrameName;
+          row_stride = label_image.width() * label_image.kNumChannels *
+              sizeof(*label_image.at(0, 0));
+          pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_LABEL;
+          channel_type = robotlocomotion::image_t::CHANNEL_TYPE_INT16;
+          break;
+        }
+        default: {
+          EXPECT_FALSE(true);
+          break;
+        }
       }
-      case 1: {
-        frame_name = kDepthFrameName;
-        row_stride = depth_image.width() * depth_image.kNumChannels *
-            sizeof(*depth_image.at(0, 0));
-        pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_DEPTH;
-        channel_type = robotlocomotion::image_t::CHANNEL_TYPE_FLOAT32;
-        break;
-      }
-      case 2: {
-        frame_name = kLabelFrameName;
-        row_stride = label_image.width() * label_image.kNumChannels *
-            sizeof(*label_image.at(0, 0));
-        pixel_format = robotlocomotion::image_t::PIXEL_FORMAT_LABEL;
-        channel_type = robotlocomotion::image_t::CHANNEL_TYPE_INT16;
-        break;
-      }
-      default: {
-        EXPECT_FALSE(true);
-        break;
-      }
+
+      EXPECT_EQ(image.header.frame_name, frame_name);
+      EXPECT_EQ(image.row_stride, row_stride);
+      EXPECT_EQ(image.pixel_format, pixel_format);
+      EXPECT_EQ(image.channel_type, channel_type);
     }
+  };
 
-    EXPECT_EQ(image.header.frame_name, frame_name);
-    EXPECT_EQ(image.row_stride, row_stride);
-    EXPECT_EQ(image.pixel_format, pixel_format);
-    EXPECT_EQ(image.channel_type, channel_type);
-  }
+  ImageToLcmImageArrayT dut_compressed(
+      kColorFrameName, kDepthFrameName, kLabelFrameName, true);
+  auto image_array_t_compressed = SetUpInputAndOutput(
+          &dut_compressed, color_image, depth_image, label_image);
+  Verify(dut_compressed, image_array_t_compressed,
+         robotlocomotion::image_t::COMPRESSION_METHOD_ZLIB);
+
+  ImageToLcmImageArrayT dut_uncompressed(
+      kColorFrameName, kDepthFrameName, kLabelFrameName, false);
+  auto image_array_t_uncompressed = SetUpInputAndOutput(
+      &dut_uncompressed, color_image, depth_image, label_image);
+  Verify(dut_uncompressed, image_array_t_uncompressed,
+         robotlocomotion::image_t::COMPRESSION_METHOD_NOT_COMPRESSED);
 }
 
 }  // namespace


### PR DESCRIPTION
This PR provides an option for image compression in `ImageToLcmImageArrayT` to a user.

The current compression time is a few milliseconds for RGBA image and 30 to 40 milliseconds for Depth image. So, if you disable the image compressions in `ImageToLcmImageArrayT`, you can gain roughly 40 milliseconds run time improvement per an output port evaluation of `ImageToLcmImageArrayT`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7318)
<!-- Reviewable:end -->
