### PR TITLE
Move externals' installs into /tools/workspace

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,8 +3,7 @@
 # This file is named BUILD.bazel instead of the more typical BUILD, so that on
 # OSX it won't conflict with a build artifacts directory named "build".
 
-load("//tools/install:check_licenses.bzl", "check_licenses")
-load("@drake//tools/install:install.bzl", "install", "install_files")
+load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(
@@ -32,37 +31,6 @@ alias(
     actual = "@protobuf//:protobuf_python",
 )
 
-DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
-    "bullet",
-    "ccd",
-    "drake_visualizer",
-    "eigen",
-    "fcl",
-    "fmt",
-    "ignition_math",
-    "ignition_rndf",
-    "lcm",
-    "lcmtypes_bot2_core",
-    "lcmtypes_robotlocomotion",
-    "libbot",
-    "nlopt",
-    "octomap",
-    "pybind11",
-    "sdformat",
-    "spdlog",
-    "spruce",
-    "stx",
-    "tinydir",
-    "tinyobjloader",
-    "vtk",
-    "yaml_cpp",
-]] + ["//tools/workspace/%s:install" % p for p in [
-    "gflags",
-    "jchart2d",
-    "optitrack_driver",
-    "protobuf",
-]]
-
 install(
     name = "install",
     docs = ["LICENSE.TXT"],
@@ -75,9 +43,8 @@ install(
         "//drake/lcmtypes:install",
         "//drake/manipulation/models:install_data",
         "//tools:install",
-    ] + DRAKE_EXTERNAL_PACKAGE_INSTALLS,
+        "//tools/workspace:install_external_packages",
+    ],
 )
-
-check_licenses(DRAKE_EXTERNAL_PACKAGE_INSTALLS + [":install"])
 
 add_lint_tests()

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -1,12 +1,56 @@
 # -*- python -*-
 
+load("@drake//tools/install:check_licenses.bzl", "check_licenses")
+load("@drake//tools/install:install.bzl", "install")
 load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
 )
+load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_py_binary(
     name = "cmake_configure_file",
     srcs = ["cmake_configure_file.py"],
     visibility = ["//visibility:public"],
 )
+
+_DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
+    "bullet",
+    "ccd",
+    "drake_visualizer",
+    "eigen",
+    "fcl",
+    "fmt",
+    "ignition_math",
+    "ignition_rndf",
+    "lcm",
+    "lcmtypes_bot2_core",
+    "lcmtypes_robotlocomotion",
+    "libbot",
+    "nlopt",
+    "octomap",
+    "pybind11",
+    "sdformat",
+    "spdlog",
+    "spruce",
+    "stx",
+    "tinydir",
+    "tinyobjloader",
+    "vtk",
+    "yaml_cpp",
+]] + ["//tools/workspace/%s:install" % p for p in [
+    "gflags",
+    "jchart2d",
+    "optitrack_driver",
+    "protobuf",
+]]
+
+install(
+    name = "install_external_packages",
+    visibility = ["//:__pkg__"],
+    deps = _DRAKE_EXTERNAL_PACKAGE_INSTALLS,
+)
+
+check_licenses(_DRAKE_EXTERNAL_PACKAGE_INSTALLS)
+
+add_lint_tests()

--- a/tools/workspace/gflags/BUILD.bazel
+++ b/tools/workspace/gflags/BUILD.bazel
@@ -31,7 +31,7 @@ install(
     docs = ["@com_github_gflags_gflags//:COPYING.txt"],
     doc_dest = "share/doc/gflags",
     allowed_externals = ["@com_github_gflags_gflags//:gflags"],
-    visibility = ["//:__pkg__"],
+    visibility = ["//tools/workspace:__pkg__"],
     deps = [":install_cmake_config"],
 )
 

--- a/tools/workspace/jchart2d/BUILD.bazel
+++ b/tools/workspace/jchart2d/BUILD.bazel
@@ -36,7 +36,7 @@ install(
     docs = JCHART_LICENSE_DOCS,
     doc_strip_prefix = ["**/"],
     allowed_externals = JCHART_LICENSE_DOCS + JCHART_TARGETS,
-    visibility = ["//:__pkg__"],
+    visibility = ["//tools/workspace:__pkg__"],
     deps = [":install_cmake_config"],
 )
 


### PR DESCRIPTION
Relates #6996.

This makes more room in the root `BUILD.bazel` file for project-wide items (once Drake moves up a folder), as well as moves the install rules for non-Drake software closer to their point of declaration, for maintainability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7319)
<!-- Reviewable:end -->
