### PR TITLE
Add rotated lorentz cone symbolically

### DIFF
--- a/drake/common/test_utilities/symbolic_test_util.h
+++ b/drake/common/test_utilities/symbolic_test_util.h
@@ -115,6 +115,7 @@ void ComparePolynomials(const symbolic::Polynomial& p1,
     EXPECT_LE(std::abs(get_constant_value(p.second)), tol);
   }
 }
+
 }  // namespace test
 }  // namespace symbolic
 }  // namespace drake

--- a/drake/common/test_utilities/symbolic_test_util.h
+++ b/drake/common/test_utilities/symbolic_test_util.h
@@ -98,6 +98,23 @@ inline bool FormulaNotLess(const Formula& f1, const Formula& f2) {
   return !FormulaLess(f1, f2);
 }
 
+/**
+ * Compare if two polynomials p1 and p2 are the same, by checking if all the
+ * coefficients in their difference p1 - p2 is no larger than tol.
+ * @param p1 A polynomial.
+ * @param p2 A polynomial.
+ * @param tol The tolerance on the coefficients of p1 - p2.
+ */
+void ComparePolynomials(const symbolic::Polynomial& p1,
+                        const symbolic::Polynomial& p2, double tol) {
+  const symbolic::Polynomial diff = p1 - p2;
+  // Check if the absolute value of the coefficient for each monomial is less
+  // than tol.
+  const symbolic::Polynomial::MapType& map = diff.monomial_to_coefficient_map();
+  for (const auto& p : map) {
+    EXPECT_LE(std::abs(get_constant_value(p.second)), tol);
+  }
+}
 }  // namespace test
 }  // namespace symbolic
 }  // namespace drake

--- a/drake/math/BUILD.bazel
+++ b/drake/math/BUILD.bazel
@@ -169,7 +169,6 @@ drake_cc_library(
     hdrs = ["quadratic_form.h"],
     deps = [
         "//drake/common:essential",
-        "//drake/common:nice_type_name",
         "@eigen",
     ],
 )
@@ -307,6 +306,7 @@ drake_cc_googletest(
     name = "quadratic_form_test",
     deps = [
         ":quadratic_form",
+        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/drake/math/BUILD.bazel
+++ b/drake/math/BUILD.bazel
@@ -164,6 +164,17 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "quadratic_form",
+    srcs = ["quadratic_form.cc"],
+    hdrs = ["quadratic_form.h"],
+    deps = [
+        "//drake/common:essential",
+        "//drake/common:nice_type_name",
+        "@eigen",
+    ],
+)
+
+drake_cc_library(
     name = "saturate",
     srcs = [],
     hdrs = ["saturate.h"],
@@ -289,6 +300,13 @@ drake_cc_googletest(
     deps = [
         ":orthonormal_basis",
         "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "quadratic_form_test",
+    deps = [
+        ":quadratic_form",
     ],
 )
 

--- a/drake/math/CMakeLists.txt
+++ b/drake/math/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources
   jacobian.cc
   matrix_util.cc
   normalize_vector.cc
+  quadratic_form.cc
   quaternion.cc
   roll_pitch_yaw.cc
   rotation_conversion_gradient.cc
@@ -37,6 +38,7 @@ set(installed_headers
   jacobian.h
   matrix_util.h
   normalize_vector.h
+  quadratic_form.h
   quaternion.h
   random_rotation.h
   roll_pitch_yaw.h

--- a/drake/math/quadratic_form.cc
+++ b/drake/math/quadratic_form.cc
@@ -3,13 +3,13 @@
 #include <iostream>
 
 #include <Eigen/Cholesky>
+#include <Eigen/Eigenvalues>
 
 namespace drake {
 namespace math {
-std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
-DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
-                               const Eigen::Ref<const Eigen::VectorXd>& b,
-                               double c) {
+std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposePositiveQuadraticForm(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c) {
   if (Q.rows() != Q.cols()) {
     throw std::runtime_error("Q should be a square matrix.");
   }
@@ -26,7 +26,6 @@ DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
   M.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
   M(Q.rows(), Q.cols()) = c;
 
-  std::cout << "M:\n" << M << "\n\n";
   Eigen::MatrixXd R;
   Eigen::MatrixXd d;
   // M should be a positive semidefinite matrix, to make sure that the quadratic
@@ -51,7 +50,9 @@ DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
     // First write M = Aᵀ * A
     // TODO(hongkai.dai) The right bottom corner of U is 0, so we should remove
     // this block.
-    Eigen::MatrixXd A =  ldlt.matrixU() * (ldlt.transpositionsP() * Eigen::MatrixXd::Identity(M.rows(), M.cols()));
+    Eigen::MatrixXd A =
+        ldlt.matrixU() * (ldlt.transpositionsP() *
+                          Eigen::MatrixXd::Identity(M.rows(), M.cols()));
     A = ldlt.vectorD().array().real().sqrt().matrix().asDiagonal() * A;
     R = A.block(0, 0, Q.rows() + 1, Q.cols());
     d = A.col(Q.cols());

--- a/drake/math/quadratic_form.cc
+++ b/drake/math/quadratic_form.cc
@@ -1,0 +1,1 @@
+#include "drake/math/quadratic_form.h"

--- a/drake/math/quadratic_form.cc
+++ b/drake/math/quadratic_form.cc
@@ -21,11 +21,12 @@ DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
   // [1]    [b/2   c]   [1]
   // We will call the matrix in the middle as M
   Eigen::MatrixXd M(Q.rows() + 1, Q.rows() + 1);
-  M.block(0, 0, Q.rows(), Q.cols()) = Q;
+  M.block(0, 0, Q.rows(), Q.cols()) = (Q + Q.transpose()) / 2;
   M.block(0, Q.cols(), Q.rows(), 1) = b / 2;
   M.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
   M(Q.rows(), Q.cols()) = c;
 
+  std::cout << "M:\n" << M << "\n\n";
   Eigen::MatrixXd R;
   Eigen::MatrixXd d;
   // M should be a positive semidefinite matrix, to make sure that the quadratic

--- a/drake/math/quadratic_form.cc
+++ b/drake/math/quadratic_form.cc
@@ -1,1 +1,62 @@
 #include "drake/math/quadratic_form.h"
+
+#include <iostream>
+
+#include <Eigen/Cholesky>
+
+namespace drake {
+namespace math {
+std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
+DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
+                               const Eigen::Ref<const Eigen::VectorXd>& b,
+                               double c) {
+  if (Q.rows() != Q.cols()) {
+    throw std::runtime_error("Q should be a square matrix.");
+  }
+  if (b.rows() != Q.rows()) {
+    throw std::runtime_error("b is not in the right size.");
+  }
+  // The quadratic form xᵀQx + bᵀx + c can also be written as
+  // [x]ᵀ * [Q   b/2] * [x]
+  // [1]    [b/2   c]   [1]
+  // We will call the matrix in the middle as M
+  Eigen::MatrixXd M(Q.rows() + 1, Q.rows() + 1);
+  M.block(0, 0, Q.rows(), Q.cols()) = Q;
+  M.block(0, Q.cols(), Q.rows(), 1) = b / 2;
+  M.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
+  M(Q.rows(), Q.cols()) = c;
+
+  Eigen::MatrixXd R;
+  Eigen::MatrixXd d;
+  // M should be a positive semidefinite matrix, to make sure that the quadratic
+  // form xᵀQx + bᵀx + c is always non-negative.
+  // First do a Cholesky decomposition of M, as M = Uᵀ*U. If Cholesky fails,
+  // then
+  // M is not positive definite.
+  Eigen::LLT<Eigen::MatrixXd> llt(M);
+  if (llt.info() == Eigen::Success) {
+    // U is an upper diagonal matrix.
+    // U = [U1 u2]
+    //     [0  u3]
+    Eigen::MatrixXd U = llt.matrixU();
+    R = U.block(0, 0, Q.rows() + 1, Q.cols());
+    d = U.col(Q.cols());
+    return std::make_pair(R, d);
+  }
+  // M should be positive semidefinite, so LDLT should be successful.
+  Eigen::LDLT<Eigen::MatrixXd> ldlt(M);
+  if (ldlt.info() == Eigen::Success && ldlt.isPositive()) {
+    // M = PᵀLDLᵀP
+    // First write M = Aᵀ * A
+    // TODO(hongkai.dai) The right bottom corner of U is 0, so we should remove
+    // this block.
+    Eigen::MatrixXd A =  ldlt.matrixU() * (ldlt.transpositionsP() * Eigen::MatrixXd::Identity(M.rows(), M.cols()));
+    A = ldlt.vectorD().array().real().sqrt().matrix().asDiagonal() * A;
+    R = A.block(0, 0, Q.rows() + 1, Q.cols());
+    d = A.col(Q.cols());
+    return std::make_pair(R, d);
+  }
+  throw std::runtime_error("The quadratic form is not positive semidefinite.");
+};
+}  // namespace math
+}  // namespace drake

--- a/drake/math/quadratic_form.cc
+++ b/drake/math/quadratic_form.cc
@@ -24,10 +24,10 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposePositiveQuadraticForm(
   // [1]    [b/2   c]   [1]
   // We will call the matrix in the middle as M
   Eigen::MatrixXd M(Q.rows() + 1, Q.rows() + 1);
-  M.block(0, 0, Q.rows(), Q.cols()) = (Q + Q.transpose()) / 2;
-  M.block(0, Q.cols(), Q.rows(), 1) = b / 2;
-  M.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
-  M(Q.rows(), Q.cols()) = c;
+  // clang-format on
+  M << (Q + Q.transpose()) / 2, b / 2,
+       b.transpose() / 2, c;
+  // clang-format off
 
   Eigen::MatrixXd R;
   Eigen::MatrixXd d;
@@ -47,10 +47,10 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposePositiveQuadraticForm(
     return std::make_pair(R, d);
   }
   // M should be positive semidefinite.
-  // Ideally I should use robust Cholesky decomposition to decompose M as
+  // Ideally we should use robust Cholesky decomposition to decompose M as
   // Aᵀ * A. Unfortunately there is some bug in Eigen's LDLT code, see
   // http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1479
-  // So I use Eigen value decomposition here.
+  // So w use Eigen value decomposition here.
   // TODO(hongkai.dai): switch to Cholesky decomposition once
   // http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1479 is fixed.
   Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(M);

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -25,6 +25,8 @@ namespace math {
  * [Q    b/2]
  * [bᵀ/2   c]
  * are all greater than -tol. @default is 0.
+ * @retval (R, d). R and d has the same number of rows. We do not guarantee that
+ * R has the same number of rows as Q.
  * @pre 1. The quadratic form is always non-negative, namely the matrix
  *         <pre>
  *         [Q    b/2]

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -1,92 +1,24 @@
 #pragma once
 
-#include <Eigen/Cholesky>
 #include <Eigen/Core>
-#include "drake/common/eigen_types.h"
 
 namespace drake {
 namespace math {
-template <typename DerivedQ, typename DerivedB>
-struct DecomposePositiveQuadraticFormType {
-  static constexpr int kQsize =
-      EigenSizeMinPreferFixed<DerivedQ::RowsAtCompileTime,
-                              DerivedQ::ColsAtCompileTime>::value;
-  static constexpr int kNumVar =
-      EigenSizeMinPreferFixed<kQsize, DerivedB::RowsAtCompileTime>::value;
-  typedef typename DerivedQ::Scalar ScalarType;
-  typedef typename Eigen::Matrix<ScalarType, Eigen::Dynamic, kNumVar,
-                                 Eigen::ColMajor, kNumVar, kNumVar>
-      RType;
-  typedef typename Eigen::Matrix<ScalarType, Eigen::Dynamic, 1, Eigen::ColMajor,
-                                 kNumVar, 1>
-      DType;
-};
-
 /**
  * Rewrite a quadratic form xᵀQx + bᵀx + c to
- * (Rx+d)ᵀ(Rx+d) + e.
+ * (Rx+d)ᵀ(Rx+d)
  * where
  * RᵀR = Q
  * Rᵀd = b / 2
- * e = c - dᵀd
- * @tparam DerivedQ The type of Q
- * @tparam DerivedB The type of b
+ * Notice that this decomposition is not unique. For example, with any
+ * permutation matrix P, we can define
+ * R₁ = P*R
+ * d₁ = P*d
+ * Then (R₁*x+d₁)ᵀ(R₁*x+d₁) gives the same quadratic form.
  */
-template <typename DerivedQ, typename DerivedB>
-std::tuple<
-    typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::RType,
-    typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::DType,
-    double>
-DecomposePositiveQuadraticForm(const DerivedQ& Q, const DerivedB& b, double c) {
-  if (Q.rows() != Q.cols()) {
-    throw std::runtime_error("Q should be a square matrix.");
-  }
-  if (b.rows() != Q.rows() || b.cols() != 1) {
-    throw std::runtime_error("b is not in the right size.");
-  }
-  // The quadratic form xᵀQx + bᵀx + c can also be written as
-  // [x]ᵀ * [Q   b/2] * [x]
-  // [1]    [b/2   c]   [1]
-  // We will call the matrix in the middle as P
-  constexpr int PSize =
-      DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::kNumVar ==
-              Eigen::Dynamic
-          ? Eigen::Dynamic
-          : DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::kNumVar + 1;
-  typedef Eigen::Matrix<typename DecomposePositiveQuadraticFormType<
-                            DerivedQ, DerivedB>::ScalarType,
-                        PSize, PSize>
-      PType;
-  PType P(Q.rows() + 1, Q.rows() + 1);
-  P.block(0, 0, Q.rows(), Q.cols()) = Q;
-  P.block(0, Q.cols(), Q.rows(), 1) = b / 2;
-  P.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
-  P(Q.rows(), Q.cols()) = c;
-
-  typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::RType R;
-  typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::DType d;
-  double e{0};
-  // P should be a positive semidefinite matrix, to make sure that the quadratic
-  // form xᵀQx + bᵀx + c is always non-negative.
-  // First do a Cholesky decomposition of P, as P = Uᵀ*U. If Cholesky fails,
-  // then
-  // P is not positive definite.
-  Eigen::LLT<PType> llt(P);
-  if (llt.info() == Eigen::Success) {
-    // U is an upper diagonal matrix.
-    // U = [U1 u2]
-    //     [0  u3]
-    R = llt.matrixU().nestedExpression().block(0, 0, Q.rows(), Q.cols());
-    d = llt.matrixU().nestedExpression().block(0, Q.cols(), Q.rows(), 1);
-    e = std::pow(llt.matrixU()(Q.rows(), Q.cols()), 2);
-    return std::make_tuple(R, d, e);
-  }
-  // P should be positive semidefinite, so LDLT should be successful.
-  Eigen::LDLT<PType> ldlt(P);
-  if (ldlt.info() == Eigen::Success && ldlt.isPositive()) {
-    return std::make_tuple(R, d, e);
-  }
-  throw std::runtime_error("The quadratic form is not positive semidefinite.");
-};
+std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
+DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
+                               const Eigen::Ref<const Eigen::VectorXd>& b,
+                               double c);
 }  // namespace math
 }  // namespace drake

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include <Eigen/Core>
 
 namespace drake {
@@ -15,10 +17,28 @@ namespace math {
  * R₁ = P*R
  * d₁ = P*d
  * Then (R₁*x+d₁)ᵀ(R₁*x+d₁) gives the same quadratic form.
+ * @param Q The square matrix.
+ * @param b The vector containing the linear coefficients.
+ * @param c The constatnt term.
+ * @param tol We will determine if this quadratic form is always non-negative,
+ * by checking the Eigen values of the matrix
+ * [Q    b/2]
+ * [bᵀ/2   c]
+ * are all greater than -tol. @default is 0.
+ * @pre 1. The quadratic form is always non-negative, namely the matrix
+ *         <pre>
+ *         [Q    b/2]
+ *         [bᵀ/2   c]
+ *         </pre>
+ *         is positive semidefinite.
+ *      2. `Q` and `b` are of the correct size.
+ *      3. `tol` is non-negative.
+ * @throw a runtime_error if the precondition is not
+ * satisfied.
  */
 std::pair<Eigen::MatrixXd, Eigen::MatrixXd>
 DecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q,
                                const Eigen::Ref<const Eigen::VectorXd>& b,
-                               double c);
+                               double c, double tol = 0);
 }  // namespace math
 }  // namespace drake

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -43,7 +43,7 @@ Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
  * [Q    b/2]
  * [bᵀ/2   c]
  * are all greater than -tol. @default is 0.
- * @retval (R, d). R and d has the same number of rows. R.cols() == x.rows().
+ * @retval (R, d). R and d have the same number of rows. R.cols() == x.rows().
  * The matrix X = [R d] has the same number of rows as the rank of
  * <pre>
  *    [Q    b/2]

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -7,6 +7,24 @@
 namespace drake {
 namespace math {
 /**
+ * For a symmetric positive semidefinite matrix Y, decompose it into XᵀX, where
+ * the number of rows in X equals to the rank of Y.
+ * Notice that this decomposition is not unique. For any orthonormal matrix U,
+ * s.t UᵀU = identity, X_prime = UX also satisfies X_primeᵀX_prime = Y. Here
+ * we only return one valid decomposition.
+ * @param Y A symmetric positive semidefinite matrix.
+ * @param zero_tol We will need to check if some value (for example, the
+ * absolute value of Y's eigenvalues) is smaller than zero_tol. If it is, then
+ * we deem that value as 0.
+ * @retval X. The matrix X satisfies XᵀX = Y and X.rows() = rank(Y).
+ * @pre 1. Y is positive semidefinite.
+ *      2. zero_tol is non-negative.
+ *      @throw std::runtime_error when the pre-conditions are not satisfied.
+ */
+Eigen::MatrixXd DecomposePSDmatrixIntoXtransposeTimesX(
+    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol);
+
+/**
  * Rewrite a quadratic form xᵀQx + bᵀx + c to
  * (Rx+d)ᵀ(Rx+d)
  * where
@@ -25,8 +43,12 @@ namespace math {
  * [Q    b/2]
  * [bᵀ/2   c]
  * are all greater than -tol. @default is 0.
- * @retval (R, d). R and d has the same number of rows. We do not guarantee that
- * R has the same number of rows as Q.
+ * @retval (R, d). R and d has the same number of rows. R.cols() == x.rows().
+ * The matrix X = [R d] has the same number of rows as the rank of
+ * <pre>
+ *    [Q    b/2]
+ *    [bᵀ/2   c]
+ * </pre>
  * @pre 1. The quadratic form is always non-negative, namely the matrix
  *         <pre>
  *         [Q    b/2]

--- a/drake/math/quadratic_form.h
+++ b/drake/math/quadratic_form.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <Eigen/Cholesky>
+#include <Eigen/Core>
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace math {
+template <typename DerivedQ, typename DerivedB>
+struct DecomposePositiveQuadraticFormType {
+  static constexpr int kQsize =
+      EigenSizeMinPreferFixed<DerivedQ::RowsAtCompileTime,
+                              DerivedQ::ColsAtCompileTime>::value;
+  static constexpr int kNumVar =
+      EigenSizeMinPreferFixed<kQsize, DerivedB::RowsAtCompileTime>::value;
+  typedef typename DerivedQ::Scalar ScalarType;
+  typedef typename Eigen::Matrix<ScalarType, Eigen::Dynamic, kNumVar,
+                                 Eigen::ColMajor, kNumVar, kNumVar>
+      RType;
+  typedef typename Eigen::Matrix<ScalarType, Eigen::Dynamic, 1, Eigen::ColMajor,
+                                 kNumVar, 1>
+      DType;
+};
+
+/**
+ * Rewrite a quadratic form xᵀQx + bᵀx + c to
+ * (Rx+d)ᵀ(Rx+d) + e.
+ * where
+ * RᵀR = Q
+ * Rᵀd = b / 2
+ * e = c - dᵀd
+ * @tparam DerivedQ The type of Q
+ * @tparam DerivedB The type of b
+ */
+template <typename DerivedQ, typename DerivedB>
+std::tuple<
+    typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::RType,
+    typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::DType,
+    double>
+DecomposePositiveQuadraticForm(const DerivedQ& Q, const DerivedB& b, double c) {
+  if (Q.rows() != Q.cols()) {
+    throw std::runtime_error("Q should be a square matrix.");
+  }
+  if (b.rows() != Q.rows() || b.cols() != 1) {
+    throw std::runtime_error("b is not in the right size.");
+  }
+  // The quadratic form xᵀQx + bᵀx + c can also be written as
+  // [x]ᵀ * [Q   b/2] * [x]
+  // [1]    [b/2   c]   [1]
+  // We will call the matrix in the middle as P
+  constexpr int PSize =
+      DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::kNumVar ==
+              Eigen::Dynamic
+          ? Eigen::Dynamic
+          : DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::kNumVar + 1;
+  typedef Eigen::Matrix<typename DecomposePositiveQuadraticFormType<
+                            DerivedQ, DerivedB>::ScalarType,
+                        PSize, PSize>
+      PType;
+  PType P(Q.rows() + 1, Q.rows() + 1);
+  P.block(0, 0, Q.rows(), Q.cols()) = Q;
+  P.block(0, Q.cols(), Q.rows(), 1) = b / 2;
+  P.block(Q.rows(), 0, 1, Q.cols()) = b.transpose() / 2;
+  P(Q.rows(), Q.cols()) = c;
+
+  typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::RType R;
+  typename DecomposePositiveQuadraticFormType<DerivedQ, DerivedB>::DType d;
+  double e{0};
+  // P should be a positive semidefinite matrix, to make sure that the quadratic
+  // form xᵀQx + bᵀx + c is always non-negative.
+  // First do a Cholesky decomposition of P, as P = Uᵀ*U. If Cholesky fails,
+  // then
+  // P is not positive definite.
+  Eigen::LLT<PType> llt(P);
+  if (llt.info() == Eigen::Success) {
+    // U is an upper diagonal matrix.
+    // U = [U1 u2]
+    //     [0  u3]
+    R = llt.matrixU().nestedExpression().block(0, 0, Q.rows(), Q.cols());
+    d = llt.matrixU().nestedExpression().block(0, Q.cols(), Q.rows(), 1);
+    e = std::pow(llt.matrixU()(Q.rows(), Q.cols()), 2);
+    return std::make_tuple(R, d, e);
+  }
+  // P should be positive semidefinite, so LDLT should be successful.
+  Eigen::LDLT<PType> ldlt(P);
+  if (ldlt.info() == Eigen::Success && ldlt.isPositive()) {
+    return std::make_tuple(R, d, e);
+  }
+  throw std::runtime_error("The quadratic form is not positive semidefinite.");
+};
+}  // namespace math
+}  // namespace drake

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -2,24 +2,63 @@
 
 #include <gtest/gtest.h>
 
-#include "drake/common/nice_type_name.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace math {
 namespace {
+void CheckDecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q, const Eigen::Ref<const Eigen::VectorXd>& b, double c) {
+  Eigen::MatrixXd R;
+  Eigen::VectorXd d;
+  std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c);
+  EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, 1E-10, MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, 1E-10, MatrixCompareType::absolute));
+  EXPECT_NEAR(d.squaredNorm(), c, 1E-10);
+}
+
 GTEST_TEST(TestDecomposePositiveQuadraticForm, Test0) {
-  // Decomposes a positive quadratic form without cross terms.
+  // Decomposes a positive quadratic form without linear terms.
+  // The quadratic form is 4x² + 4y² + 9.
+  // This quadratic form is the same as zᵀ*z, where z is the vector
+  // [2x]
+  // [2y]
+  // [ 3]
   Eigen::Matrix2d Q = 4 * Eigen::Matrix2d::Identity();
   Eigen::Vector2d b = Eigen::Vector2d::Zero();
+  double c = 9;
+  CheckDecomposePositiveQuadraticForm(Q, b, c);
+}
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test1) {
+  // Decomposes a positive quadratic form with linear terms.
+  //   x² + 4xy + 4y² + 2x + 4y + 2
+  // = (x + 2y + 1)² + 1
+  Eigen::Matrix2d Q;
+  Q << 1, 2, 2, 4;
+  Eigen::Vector2d b(2, 4);
+  double c = 2;
+  CheckDecomposePositiveQuadraticForm(Q, b, c);
+}
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test2) {
+  // Decomposes a positive quadratic form with both linear and cross
+  // terms.
+  // x² + 2xy + 4y² + 4y +4
+  Eigen::Matrix2d Q;
+  Q << 1, 1, 1, 4;
+  Eigen::Vector2d b(0, 4);
+  double c = 2;
+  CheckDecomposePositiveQuadraticForm(Q, b, c);
+}
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test3) {
+  // Decomposes a positive form with no constant term.
+  // x² + 4xy + 4y²
+  Eigen::Matrix2d Q;
+  Q << 1, 2, 2, 4;
+  Eigen::Vector2d b(0, 0);
   double c = 0;
-  auto result = DecomposePositiveQuadraticForm(Q, b, c);
-  std::cout << NiceTypeName::Get<decltype(std::get<0>(result))>() << std::endl;
-  std::cout << NiceTypeName::Demangle(typeid(std::get<0>(result)).name()) << std::endl;
-  std::cout << Eigen::ColMajor << std::endl;
-  typedef decltype(std::get<0>(result)) returntype;
-  static_assert(std::is_same<std::decay_t<returntype>,
-                             Eigen::Matrix<double, -1, 2, 0, 2, 2>>::value,
-                "return type is not correct");
+  CheckDecomposePositiveQuadraticForm(Q, b, c);
 }
 }  // namespace
 }  // namespace math

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -60,6 +60,26 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test3) {
   double c = 0;
   CheckDecomposePositiveQuadraticForm(Q, b, c);
 }
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test4) {
+  Eigen::Matrix2d Q;
+  Q << 1, 1.5, 1.5, 1;
+  Eigen::Vector2d b(0, 0);
+  double c = 0;
+  EXPECT_THROW(DecomposePositiveQuadraticForm(Q, b, c), std::runtime_error);
+}
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test5) {
+  Eigen::Matrix3d Q;
+  // clang-format off
+  Q << 1, 2, 0,
+       2, 4, 0,
+       0, 0, 0;
+  // clang-format on
+  Eigen::Vector3d b(2, 4, -1);
+  double c = 1;
+  EXPECT_THROW(DecomposePositiveQuadraticForm(Q, b, c), std::runtime_error);
+}
 }  // namespace
 }  // namespace math
 }  // namespace drake

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -7,18 +7,129 @@
 namespace drake {
 namespace math {
 namespace {
+void CheckDecomposePSDmatrixIntoXtransposeTimesX(
+    const Eigen::Ref<const Eigen::MatrixXd>& Y, double zero_tol,
+    double check_tol = 1E-14) {
+  const Eigen::MatrixXd X = DecomposePSDmatrixIntoXtransposeTimesX(Y, zero_tol);
+  EXPECT_TRUE(CompareMatrices(X.transpose() * X, Y, check_tol,
+                              MatrixCompareType::absolute));
+  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> qr(Y);
+  qr.setThreshold(check_tol);
+  EXPECT_EQ(qr.rank(), X.rows());
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test0) {
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Eigen::Matrix3d::Identity(),
+                                              1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test1) {
+  const Eigen::Matrix3d Y = Eigen::Vector3d(1, 4, 0).asDiagonal();
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test2) {
+  Eigen::Matrix3d Y;
+  // clang-format off
+  Y << 1, 1, 0,
+       1, 1, 0,
+       0, 0, 0;
+  // clang-format on
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test3) {
+  Eigen::Matrix3d Y;
+  // clang-format off
+  Y << 1, 2, 0,
+       2, 4, 0,
+       0, 0, 9;
+  // clang-format on
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test4) {
+  // Y is a rank 1 psd matrix.
+  Eigen::Matrix3d Y;
+  // clang-format off
+  Y << 1, 2, -3,
+       2, 4, -6,
+       -3, -6, 9;
+  // clang-format on
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, Test5) {
+  // Y is a rank 2 psd matrix.
+  Eigen::Matrix3d Y1;
+  Eigen::Matrix3d Y2;
+  // clang-format off
+  Y1 << 1, 2, -3,
+        2, 4, -6,
+       -3, -6, 9;
+  Y2 << 0, 0, 0,
+        0, 1, -1,
+        0, -1, 1;
+  // clang-format on
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y1 + Y2, 1E-15);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, negativeY) {
+  // Y is a negative definite matrix.
+  EXPECT_THROW(
+      DecomposePSDmatrixIntoXtransposeTimesX(-Eigen::Matrix3d::Identity(), 0),
+      std::runtime_error);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, indefiniteY) {
+  // Y is an indefinite matrix.
+  Eigen::Matrix4d Y;
+  // clang-format off
+  Y << 1, 2, 0, 1,
+       2, 4, 0, 2,
+       0, 0, 0, 1,
+       1, 2, 1, 1;
+  // clang-format on
+  EXPECT_THROW(DecomposePSDmatrixIntoXtransposeTimesX(Y, 0),
+               std::runtime_error);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, almost_psd_Y) {
+  // Y is almost PSD.
+  Eigen::Matrix3d U =
+      Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitY()).toRotationMatrix();
+  const Eigen::Matrix3d Y =
+      U * Eigen::Vector3d(1, -1E-10, 2).asDiagonal() * U.transpose();
+  // With tolerance being 0, DecomposePSDmatrixIntoXtransposeTimesX should
+  // detect Y is not PSD.
+  EXPECT_THROW(DecomposePSDmatrixIntoXtransposeTimesX(Y, 0),
+               std::runtime_error);
+  // With tolerance being 1E-10, it should regard Y as a PSD matrix.
+  CheckDecomposePSDmatrixIntoXtransposeTimesX(Y, 2E-10, 1E-9);
+}
+
+GTEST_TEST(TestDecomposePSDmatrixIntoXtransposeTimesX, negative_tol) {
+  EXPECT_THROW(DecomposePSDmatrixIntoXtransposeTimesX(
+                   Eigen::Matrix3d::Identity(), -1E-10),
+               std::runtime_error);
+}
+
 void CheckDecomposePositiveQuadraticForm(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
     const Eigen::Ref<const Eigen::VectorXd>& b, double c, double tol_psd = 0) {
   Eigen::MatrixXd R;
   Eigen::VectorXd d;
-  double tol_check = 1E-10;
+  const double tol_check = 1E-10;
   std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c, tol_psd);
   EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, tol_check,
                               MatrixCompareType::absolute));
   EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, tol_check,
                               MatrixCompareType::absolute));
   EXPECT_NEAR(d.squaredNorm(), c, tol_check);
+  Eigen::MatrixXd Y(Q.rows() + 1, Q.rows() + 1);
+  Y << Q, b/2, b.transpose() / 2, c;
+  Eigen::ColPivHouseholderQR<Eigen::MatrixXd> qr(Y);
+  EXPECT_EQ(qr.rank(), R.rows());
 }
 
 GTEST_TEST(TestDecomposePositiveQuadraticForm, Test0) {
@@ -89,8 +200,8 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test6) {
   Eigen::Matrix3d Q;
   // clang-format off
   Q << 1, 2, 0,
-      2, 4, 0,
-      0, 0, 0;
+       2, 4, 0,
+       0, 0, 0;
   // clang-format on
   Eigen::Vector3d b(2, 4, -1);
   double c = 1;

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -1,0 +1,26 @@
+#include "drake/math/quadratic_form.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace math {
+namespace {
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test0) {
+  // Decomposes a positive quadratic form without cross terms.
+  Eigen::Matrix2d Q = 4 * Eigen::Matrix2d::Identity();
+  Eigen::Vector2d b = Eigen::Vector2d::Zero();
+  double c = 0;
+  auto result = DecomposePositiveQuadraticForm(Q, b, c);
+  std::cout << NiceTypeName::Get<decltype(std::get<0>(result))>() << std::endl;
+  std::cout << NiceTypeName::Demangle(typeid(std::get<0>(result)).name()) << std::endl;
+  std::cout << Eigen::ColMajor << std::endl;
+  typedef decltype(std::get<0>(result)) returntype;
+  static_assert(std::is_same<std::decay_t<returntype>,
+                             Eigen::Matrix<double, -1, 2, 0, 2, 2>>::value,
+                "return type is not correct");
+}
+}  // namespace
+}  // namespace math
+}  // namespace drake

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -9,15 +9,16 @@ namespace math {
 namespace {
 void CheckDecomposePositiveQuadraticForm(
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::VectorXd>& b, double c, double tol = 0) {
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c, double tol_psd = 0) {
   Eigen::MatrixXd R;
   Eigen::VectorXd d;
-  std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c, tol);
-  EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, 1E-10,
+  double tol_check = 1E-10;
+  std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c, tol_psd);
+  EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, tol_check,
                               MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, 1E-10,
+  EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, tol_check,
                               MatrixCompareType::absolute));
-  EXPECT_NEAR(d.squaredNorm(), c, 1E-10);
+  EXPECT_NEAR(d.squaredNorm(), c, tol_check);
 }
 
 GTEST_TEST(TestDecomposePositiveQuadraticForm, Test0) {
@@ -36,7 +37,6 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test0) {
 GTEST_TEST(TestDecomposePositiveQuadraticForm, Test1) {
   // Decomposes a positive quadratic form with linear terms.
   //   x² + 4xy + 4y² + 2x + 4y + 2
-  // = (x + 2y + 1)² + 1
   Eigen::Matrix2d Q;
   Q << 1, 2, 2, 4;
   Eigen::Vector2d b(2, 4);

--- a/drake/math/test/quadratic_form_test.cc
+++ b/drake/math/test/quadratic_form_test.cc
@@ -7,12 +7,16 @@
 namespace drake {
 namespace math {
 namespace {
-void CheckDecomposePositiveQuadraticForm(const Eigen::Ref<const Eigen::MatrixXd>& Q, const Eigen::Ref<const Eigen::VectorXd>& b, double c) {
+void CheckDecomposePositiveQuadraticForm(
+    const Eigen::Ref<const Eigen::MatrixXd>& Q,
+    const Eigen::Ref<const Eigen::VectorXd>& b, double c, double tol = 0) {
   Eigen::MatrixXd R;
   Eigen::VectorXd d;
-  std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c);
-  EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, 1E-10, MatrixCompareType::absolute));
-  EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, 1E-10, MatrixCompareType::absolute));
+  std::tie(R, d) = DecomposePositiveQuadraticForm(Q, b, c, tol);
+  EXPECT_TRUE(CompareMatrices(R.transpose() * R, Q, 1E-10,
+                              MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(R.transpose() * d, b / 2, 1E-10,
+                              MatrixCompareType::absolute));
   EXPECT_NEAR(d.squaredNorm(), c, 1E-10);
 }
 
@@ -37,7 +41,7 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test1) {
   Q << 1, 2, 2, 4;
   Eigen::Vector2d b(2, 4);
   double c = 2;
-  CheckDecomposePositiveQuadraticForm(Q, b, c);
+  CheckDecomposePositiveQuadraticForm(Q, b, c, 1E-15);
 }
 
 GTEST_TEST(TestDecomposePositiveQuadraticForm, Test2) {
@@ -79,6 +83,20 @@ GTEST_TEST(TestDecomposePositiveQuadraticForm, Test5) {
   Eigen::Vector3d b(2, 4, -1);
   double c = 1;
   EXPECT_THROW(DecomposePositiveQuadraticForm(Q, b, c), std::runtime_error);
+}
+
+GTEST_TEST(TestDecomposePositiveQuadraticForm, Test6) {
+  Eigen::Matrix3d Q;
+  // clang-format off
+  Q << 1, 2, 0,
+      2, 4, 0,
+      0, 0, 0;
+  // clang-format on
+  Eigen::Vector3d b(2, 4, -1);
+  double c = 1;
+  // tolerance has to be non-negative.
+  EXPECT_THROW(DecomposePositiveQuadraticForm(Q, b, c, -1E-15),
+               std::runtime_error);
 }
 }  // namespace
 }  // namespace math

--- a/drake/solvers/BUILD.bazel
+++ b/drake/solvers/BUILD.bazel
@@ -85,6 +85,7 @@ drake_cc_library(
         "//drake/common:essential",
         "//drake/common:polynomial",
         "//drake/common:symbolic",
+        "//drake/math:quadratic_form",
     ],
 )
 
@@ -679,6 +680,14 @@ drake_cc_googletest(
         ":mathematical_program",
         ":mathematical_program_test_util",
         "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "create_constraint_test",
+    deps = [
+        ":create_constraint",
+        "//drake/common/test_utilities:symbolic_test_util",
     ],
 )
 

--- a/drake/solvers/CMakeLists.txt
+++ b/drake/solvers/CMakeLists.txt
@@ -46,6 +46,7 @@ list(APPEND optimization_files
 
 add_library(drakeOptimization ${optimization_files})
 target_link_libraries(drakeOptimization
+  drakeMath
   drakeCommon
   Eigen3::Eigen)
 drake_install_headers(

--- a/drake/solvers/create_constraint.cc
+++ b/drake/solvers/create_constraint.cc
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <sstream>
 
-#include "drake/solvers/symbolic_extraction.h"
 #include "drake/math/quadratic_form.h"
+#include "drake/solvers/symbolic_extraction.h"
 
 namespace drake {
 namespace solvers {
@@ -454,14 +454,16 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   return ParseLorentzConeConstraint(expr);
 }
 
-Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(const Eigen::Ref<const VectorX<symbolic::Expression>>& v) {
+Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
+    const Eigen::Ref<const VectorX<symbolic::Expression>>& v) {
   DRAKE_DEMAND(v.rows() >= 3);
   Eigen::MatrixXd A{};
   Eigen::VectorXd b(v.size());
   VectorXDecisionVariable vars{};
   DecomposeLinearExpression(v, &A, &b, &vars);
   DRAKE_DEMAND(vars.rows() >= 1);
-  return CreateBinding(std::make_shared<RotatedLorentzConeConstraint>(A, b), vars);
+  return CreateBinding(std::make_shared<RotatedLorentzConeConstraint>(A, b),
+                       vars);
 }
 
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(

--- a/drake/solvers/create_constraint.cc
+++ b/drake/solvers/create_constraint.cc
@@ -425,6 +425,10 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   return CreateBinding(make_shared<LorentzConeConstraint>(A, b), vars);
 }
 
+namespace internal {
+template <typename DerivedQ, typename DerivedB>
+std::tuple<Eigen::Matrix<double,
+} // namespace internal
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Expression& linear_expr, const Expression& quadratic_expr) {
   const auto& quadratic_p = ExtractVariablesFromExpression(quadratic_expr);

--- a/drake/solvers/create_constraint.cc
+++ b/drake/solvers/create_constraint.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "drake/solvers/symbolic_extraction.h"
+#include "drake/math/quadratic_form.h"
 
 namespace drake {
 namespace solvers {
@@ -425,10 +426,6 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   return CreateBinding(make_shared<LorentzConeConstraint>(A, b), vars);
 }
 
-namespace internal {
-template <typename DerivedQ, typename DerivedB>
-std::tuple<Eigen::Matrix<double,
-} // namespace internal
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Expression& linear_expr, const Expression& quadratic_expr) {
   const auto& quadratic_p = ExtractVariablesFromExpression(quadratic_expr);
@@ -439,6 +436,9 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   Eigen::VectorXd b(quadratic_vars.size());
   double a;
   DecomposeQuadraticPolynomial(poly, quadratic_var_to_index_map, &Q, &b, &a);
+  std::cout << "Q:\n" << Q << "\n\n";
+  std::cout << "b:\n" << b << "\n\n";
+  std::cout << "a:" << a << "\n\n";
   // The constraint that the linear expression v1 satisfying
   // v1 >= sqrt(0.5 * x' * Q * x + b' * x + a), is equivalent to the vector
   // [z; y] being within a Lorentz cone, where
@@ -447,83 +447,13 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   // R is the matrix satisfying Rᵀ * R = Q
 
   VectorX<Expression> expr{};
-
-  double constant;  // constant is a - 0.5 * bᵀ * Q⁻¹ * a
-  // If Q is strictly positive definite, then use LLT
-  Eigen::LLT<Eigen::MatrixXd> llt_Q(Q.selfadjointView<Eigen::Upper>());
-  if (llt_Q.info() == Eigen::Success) {
-    Eigen::MatrixXd R = llt_Q.matrixU();
-    expr.resize(2 + R.rows());
-    expr(0) = linear_expr;
-    expr.segment(1, R.rows()) =
-        1.0 / std::sqrt(2) * (R * quadratic_vars + llt_Q.matrixL().solve(b));
-    constant = a - 0.5 * b.dot(llt_Q.solve(b));
-  } else {
-    // Q is not strictly positive definite.
-    // First check if Q is zero.
-    const bool is_Q_zero = (Q.array() == 0).all();
-
-    if (is_Q_zero) {
-      // Now check if the linear term b is zero. If both Q and b are zero, then
-      // add the linear constraint linear_expr >= sqrt(a); otherwise throw a
-      // runtime error.
-      const bool is_b_zero = (b.array() == 0).all();
-      if (!is_b_zero) {
-        ostringstream oss;
-        oss << "Expression " << quadratic_expr
-            << " is not quadratic, cannot call ParseLorentzConeConstraint.\n";
-        throw runtime_error(oss.str());
-      } else {
-        if (a < 0) {
-          ostringstream oss;
-          oss << "Expression " << quadratic_expr
-              << " is negative, cannot call ParseLorentzConeConstraint.\n";
-          throw runtime_error(oss.str());
-        }
-        Vector2<Expression> expr_constant_quadratic(linear_expr, std::sqrt(a));
-        return ParseLorentzConeConstraint(expr_constant_quadratic);
-      }
-    }
-    // Q is not strictly positive, nor is it zero. Use LDLT to decompose Q
-    // into R * Rᵀ.
-    // Question: is there a better way to compute R * x and R⁻ᵀb? The following
-    // code is really ugly.
-    Eigen::LDLT<Eigen::MatrixXd> ldlt_Q(Q.selfadjointView<Eigen::Upper>());
-    if (ldlt_Q.info() != Eigen::Success || !ldlt_Q.isPositive()) {
-      ostringstream oss;
-      oss << "Expression" << quadratic_expr
-          << " does not have a positive semidefinite Hessian. Cannot be called "
-             "with ParseLorentzConeConstraint.\n";
-      throw runtime_error(oss.str());
-    }
-    Eigen::MatrixXd R1 = ldlt_Q.matrixU();
-    for (int i = 0; i < R1.rows(); ++i) {
-      for (int j = 0; j < i; ++j) {
-        R1(i, j) = 0;
-      }
-      const double d_sqrt = std::sqrt(ldlt_Q.vectorD()(i));
-      for (int j = i; j < R1.cols(); ++j) {
-        R1(i, j) *= d_sqrt;
-      }
-    }
-    Eigen::MatrixXd R = R1 * ldlt_Q.transpositionsP();
-
-    expr.resize(2 + R1.rows());
-    expr(0) = linear_expr;
-    // expr.segment(1, R1.rows()) = 1/sqrt(2) * (R * x + R⁻ᵀb)
-    expr.segment(1, R1.rows()) =
-        1.0 / std::sqrt(2) *
-        (R * quadratic_vars + R.transpose().fullPivHouseholderQr().solve(b));
-    constant = a - 0.5 * b.dot(ldlt_Q.solve(b));
-  }
-  if (constant < 0) {
-    ostringstream oss;
-    oss << "Expression " << quadratic_expr
-        << " is not guaranteed to be non-negative, cannot call it with "
-           "ParseLorentzConeConstraint.\n";
-    throw runtime_error(oss.str());
-  }
-  expr(expr.rows() - 1) = std::sqrt(constant);
+  // expr.segment(1, R1.rows()) = 1/sqrt(2) * (R * x + R⁻ᵀb)
+  Eigen::MatrixXd C;
+  Eigen::VectorXd d;
+  std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a);
+  expr.resize(1 + C.rows());
+  expr(0) = linear_expr;
+  expr.segment(1, C.rows()) = C * quadratic_vars + d;
   return ParseLorentzConeConstraint(expr);
 }
 

--- a/drake/solvers/create_constraint.cc
+++ b/drake/solvers/create_constraint.cc
@@ -427,7 +427,8 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
 }
 
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
-    const Expression& linear_expr, const Expression& quadratic_expr) {
+    const Expression& linear_expr, const Expression& quadratic_expr,
+    double tol) {
   const auto& quadratic_p = ExtractVariablesFromExpression(quadratic_expr);
   const auto& quadratic_vars = quadratic_p.first;
   const auto& quadratic_var_to_index_map = quadratic_p.second;
@@ -440,14 +441,13 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   // v1 >= sqrt(0.5 * x' * Q * x + b' * x + a), is equivalent to the vector
   // [z; y] being within a Lorentz cone, where
   // z = v1
-  // y = [1/sqrt(2) * (R * x + R⁻ᵀb); sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
-  // R is the matrix satisfying Rᵀ * R = Q
+  // y = C * x + d
+  // such that yᵀy = 0.5xᵀQx + bᵀx + a
 
   VectorX<Expression> expr{};
-  // expr.segment(1, R1.rows()) = 1/sqrt(2) * (R * x + R⁻ᵀb)
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
-  std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a);
+  std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a, tol);
   expr.resize(1 + C.rows());
   expr(0) = linear_expr;
   expr.segment(1, C.rows()) = C * quadratic_vars + d;
@@ -469,7 +469,7 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr1,
     const symbolic::Expression& linear_expr2,
-    const symbolic::Expression& quadratic_expr) {
+    const symbolic::Expression& quadratic_expr, double tol) {
   const auto& quadratic_p = ExtractVariablesFromExpression(quadratic_expr);
   const auto& quadratic_vars = quadratic_p.first;
   const auto& quadratic_var_to_index_map = quadratic_p.second;
@@ -481,7 +481,7 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 
   Eigen::MatrixXd C;
   Eigen::VectorXd d;
-  std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a);
+  std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a, tol);
   VectorX<symbolic::Expression> expr(2 + C.rows());
   expr(0) = linear_expr1;
   expr(1) = linear_expr2;

--- a/drake/solvers/create_constraint.cc
+++ b/drake/solvers/create_constraint.cc
@@ -449,7 +449,9 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
   Eigen::VectorXd d;
   std::tie(C, d) = math::DecomposePositiveQuadraticForm(0.5 * Q, b, a, tol);
   expr.resize(1 + C.rows());
+  // expr(0) is z
   expr(0) = linear_expr;
+  // expr.segment(1, C.rows()) = y
   expr.segment(1, C.rows()) = C * quadratic_vars + d;
   return ParseLorentzConeConstraint(expr);
 }

--- a/drake/solvers/create_constraint.h
+++ b/drake/solvers/create_constraint.h
@@ -217,11 +217,48 @@ std::shared_ptr<Constraint> MakePolynomialConstraint(
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
-/*
- * Assist MathematicalProgram::AddLorentzConeConstraint(...).
+/**
+ * Construct a Lorentz cone constraint
+ *   u >= sqrt(v)
+ * where u is a linear expression, and v is a non-negative quadratic expression.
+ * @param linear_expr The linear (affine) expression u. Throws a runtime_error
+ * if u is not linear.
+ * @param quadratic_expr The non-negative quadratic expression v. Throws a
+ * runtime_error if v is not a non-negative quadratic expression.
+ * @return The newly constructed Lorentz cone constraint.
  */
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const symbolic::Expression& linear_expr,
+    const symbolic::Expression& quadratic_expr);
+
+/**
+ * Construct a rotated Lorentz cone constraint
+ * v(0) * v(1) >= v(2)² + v(3)² + ... + v(n-1)²,
+ * v(0) >= 0, v(1) >= 0
+ * where each entry in v is a linear (affine) expression.
+ * @param v A vector of linear (affine) expressions. Throws std::runtime_error
+ * if any entry in v is not linear (affine).
+ * @return The newly constructed rotated Lorentz cone constraint.
+ */
+Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
+    const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
+
+/**
+ * Construct a rotated Lorentz cone constraint
+ * u₁ * u₂ >= v, u₁ >= 0, u₂ >= 0
+ * where u₁, u₂ are linear expressions, and v is a non-negative quadratic
+ * expression.
+ * @param linear_expr1 The linear (affine) expression u₁, throw a
+ * std::runtime_error if u₁ is not linear.
+ * @param linear_expr2 The linear (affine) expression u₂, throw a
+ * std::runtime_error if u₂ is not linear.
+ * @param quadratic_expr The non-negative quadratic expression v, throw a
+ * std::runtime_error if v is not a non-negative quadratic expression.
+ * @return The newly constructed rotated Lorentz cone constraint.
+ */
+Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
+    const symbolic::Expression& linear_expr1,
+    const symbolic::Expression& linear_expr2,
     const symbolic::Expression& quadratic_expr);
 
 // TODO(eric.cousineau): Implement this if variable creation is separated.

--- a/drake/solvers/create_constraint.h
+++ b/drake/solvers/create_constraint.h
@@ -218,63 +218,20 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
 /*
- * Construct a Lorentz cone constraint
- *   u >= sqrt(v)
- * where u is a linear expression, and v is a non-negative quadratic expression.
- * @param linear_expr The linear (affine) expression u. Throws a runtime_error
- * if u is not linear.
- * @param quadratic_expr The non-negative quadratic expression v. Throws a
- * runtime_error if v is not a non-negative quadratic expression.
- * @param tol The tolerance for determining if a matrix is positive semidefinite
- * or not. @see DecomposePositiveQuadraticForm for a detailed explanation.
- * @default is 0.
- * @return The newly constructed Lorentz cone constraint.
+ * Assist MathematicalProgram::AddLorentzConeConstraint(...).
  */
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const symbolic::Expression& linear_expr,
     const symbolic::Expression& quadratic_expr, double tol = 0);
 
-/**
- * Construct a rotated Lorentz cone constraint
- *
- * v(0) * v(1) >= v(2)² + v(3)² + ... + v(n-1)²,
- * v(0) >= 0, v(1) >= 0
- *
- * where each entry in v is a linear (affine) expression.
- * @param v A vector of linear (affine) expressions. Throws std::runtime_error
- * if any entry in v is not linear (affine).
- * @return The newly constructed rotated Lorentz cone constraint.
+/*
+ * Assist MathematicalProgram::AddRotatedLorentzConeConstraint(...)
  */
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
 /*
- * Construct a rotated Lorentz cone constraint
- * u₁ * u₂ >= v, u₁ >= 0, u₂ >= 0
- * where u₁, u₂ are linear expressions, and v is a non-negative quadratic
- * expression.
- * @param linear_expr1 The linear (affine) expression u₁, throw a
- * std::runtime_error if u₁ is not linear.
- * @param linear_expr2 The linear (affine) expression u₂, throw a
- * std::runtime_error if u₂ is not linear.
- * @param quadratic_expr The non-negative quadratic expression v, throw a
- * std::runtime_error if v is not a non-negative quadratic expression.
- * @param tol The tolerance to determine if a matrix is positive semidefinite or
- * not. @see DecomposePositiveQuadraticForm for more information. @default is 0.
- * @return The newly constructed rotated Lorentz cone constraint.
- * @note Numerically this function is not very stable. The reason is that we
- * need to convert the quadratic expression v = xᵀQx + bᵀx + c to the form
- * v = |Ax + b|². This requires to determine if the matrix
- * <pre>
- * [Q    b/2]
- * [bᵀ/2   c]
- * </pre>
- * is positive semidefinite or not. If the matrix is at the boundary of the
- * positive semidefinite cone, then the numerical procedure to determine if the
- * matrix is PSD or not is not very stable. So call this function when you are
- * sure that the quadratic expression is STRICTLY positive definite, otherwise
- * this function MAY throw a runtime error when you think you have a positive
- * semi-definite quadratic expression.
+ * Assist MathematicalProgram::AddRotatedLorentzConeConstraint(...)
  */
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr1,

--- a/drake/solvers/create_constraint.h
+++ b/drake/solvers/create_constraint.h
@@ -217,7 +217,7 @@ std::shared_ptr<Constraint> MakePolynomialConstraint(
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
-/**
+/*
  * Construct a Lorentz cone constraint
  *   u >= sqrt(v)
  * where u is a linear expression, and v is a non-negative quadratic expression.
@@ -225,11 +225,14 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
  * if u is not linear.
  * @param quadratic_expr The non-negative quadratic expression v. Throws a
  * runtime_error if v is not a non-negative quadratic expression.
+ * @param tol The tolerance for determining if a matrix is positive semidefinite
+ * or not. @see DecomposePositiveQuadraticForm for a detailed explanation.
+ * @default is 0.
  * @return The newly constructed Lorentz cone constraint.
  */
 Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
     const symbolic::Expression& linear_expr,
-    const symbolic::Expression& quadratic_expr);
+    const symbolic::Expression& quadratic_expr, double tol = 0);
 
 /**
  * Construct a rotated Lorentz cone constraint
@@ -245,7 +248,7 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const Eigen::Ref<const VectorX<symbolic::Expression>>& v);
 
-/**
+/*
  * Construct a rotated Lorentz cone constraint
  * u₁ * u₂ >= v, u₁ >= 0, u₂ >= 0
  * where u₁, u₂ are linear expressions, and v is a non-negative quadratic
@@ -256,6 +259,8 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
  * std::runtime_error if u₂ is not linear.
  * @param quadratic_expr The non-negative quadratic expression v, throw a
  * std::runtime_error if v is not a non-negative quadratic expression.
+ * @param tol The tolerance to determine if a matrix is positive semidefinite or
+ * not. @see DecomposePositiveQuadraticForm for more information. @default is 0.
  * @return The newly constructed rotated Lorentz cone constraint.
  * @note Numerically this function is not very stable. The reason is that we
  * need to convert the quadratic expression v = xᵀQx + bᵀx + c to the form
@@ -274,7 +279,7 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr1,
     const symbolic::Expression& linear_expr2,
-    const symbolic::Expression& quadratic_expr);
+    const symbolic::Expression& quadratic_expr, double tol = 0);
 
 // TODO(eric.cousineau): Implement this if variable creation is separated.
 // Format would be (tuple(linear_binding, psd_binding), new_vars)

--- a/drake/solvers/create_constraint.h
+++ b/drake/solvers/create_constraint.h
@@ -233,8 +233,10 @@ Binding<LorentzConeConstraint> ParseLorentzConeConstraint(
 
 /**
  * Construct a rotated Lorentz cone constraint
+ *
  * v(0) * v(1) >= v(2)² + v(3)² + ... + v(n-1)²,
  * v(0) >= 0, v(1) >= 0
+ *
  * where each entry in v is a linear (affine) expression.
  * @param v A vector of linear (affine) expressions. Throws std::runtime_error
  * if any entry in v is not linear (affine).
@@ -255,6 +257,19 @@ Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
  * @param quadratic_expr The non-negative quadratic expression v, throw a
  * std::runtime_error if v is not a non-negative quadratic expression.
  * @return The newly constructed rotated Lorentz cone constraint.
+ * @note Numerically this function is not very stable. The reason is that we
+ * need to convert the quadratic expression v = xᵀQx + bᵀx + c to the form
+ * v = |Ax + b|². This requires to determine if the matrix
+ * <pre>
+ * [Q    b/2]
+ * [bᵀ/2   c]
+ * </pre>
+ * is positive semidefinite or not. If the matrix is at the boundary of the
+ * positive semidefinite cone, then the numerical procedure to determine if the
+ * matrix is PSD or not is not very stable. So call this function when you are
+ * sure that the quadratic expression is STRICTLY positive definite, otherwise
+ * this function MAY throw a runtime error when you think you have a positive
+ * semi-definite quadratic expression.
  */
 Binding<RotatedLorentzConeConstraint> ParseRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expr1,

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -472,14 +472,18 @@ MathematicalProgram::AddRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expression1,
     const symbolic::Expression& linear_expression2,
     const symbolic::Expression& quadratic_expression) {
-  return internal::ParseRotatedLorentzConeConstraint(
+  auto binding = internal::ParseRotatedLorentzConeConstraint(
       linear_expression1, linear_expression2, quadratic_expression);
+  AddConstraint(binding);
+  return binding;
 }
 
 Binding<RotatedLorentzConeConstraint>
 MathematicalProgram::AddRotatedLorentzConeConstraint(
     const Eigen::Ref<const VectorX<Expression>>& v) {
-  return internal::ParseRotatedLorentzConeConstraint(v);
+  auto binding = internal::ParseRotatedLorentzConeConstraint(v);
+  AddConstraint(binding);
+  return binding;
 }
 
 Binding<RotatedLorentzConeConstraint>

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -445,9 +445,10 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
-    const Expression& linear_expr, const Expression& quadratic_expr) {
+    const Expression& linear_expr, const Expression& quadratic_expr,
+    double tol) {
   return AddConstraint(
-      internal::ParseLorentzConeConstraint(linear_expr, quadratic_expr));
+      internal::ParseLorentzConeConstraint(linear_expr, quadratic_expr, tol));
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
@@ -471,9 +472,9 @@ Binding<RotatedLorentzConeConstraint>
 MathematicalProgram::AddRotatedLorentzConeConstraint(
     const symbolic::Expression& linear_expression1,
     const symbolic::Expression& linear_expression2,
-    const symbolic::Expression& quadratic_expression) {
+    const symbolic::Expression& quadratic_expression, double tol) {
   auto binding = internal::ParseRotatedLorentzConeConstraint(
-      linear_expression1, linear_expression2, quadratic_expression);
+      linear_expression1, linear_expression2, quadratic_expression, tol);
   AddConstraint(binding);
   return binding;
 }

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -469,14 +469,17 @@ Binding<RotatedLorentzConeConstraint> MathematicalProgram::AddConstraint(
 
 Binding<RotatedLorentzConeConstraint>
 MathematicalProgram::AddRotatedLorentzConeConstraint(
+    const symbolic::Expression& linear_expression1,
+    const symbolic::Expression& linear_expression2,
+    const symbolic::Expression& quadratic_expression) {
+  return internal::ParseRotatedLorentzConeConstraint(
+      linear_expression1, linear_expression2, quadratic_expression);
+}
+
+Binding<RotatedLorentzConeConstraint>
+MathematicalProgram::AddRotatedLorentzConeConstraint(
     const Eigen::Ref<const VectorX<Expression>>& v) {
-  DRAKE_DEMAND(v.rows() >= 3);
-  Eigen::MatrixXd A{};
-  Eigen::VectorXd b(v.size());
-  VectorXDecisionVariable vars{};
-  DecomposeLinearExpression(v, &A, &b, &vars);
-  DRAKE_DEMAND(vars.rows() >= 1);
-  return AddRotatedLorentzConeConstraint(A, b, vars);
+  return internal::ParseRotatedLorentzConeConstraint(v);
 }
 
 Binding<RotatedLorentzConeConstraint>

--- a/drake/solvers/mathematical_program.cc
+++ b/drake/solvers/mathematical_program.cc
@@ -445,10 +445,10 @@ Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(
-    const Expression& linear_expr, const Expression& quadratic_expr,
+    const Expression& linear_expression, const Expression& quadratic_expression,
     double tol) {
-  return AddConstraint(
-      internal::ParseLorentzConeConstraint(linear_expr, quadratic_expr, tol));
+  return AddConstraint(internal::ParseLorentzConeConstraint(
+      linear_expression, quadratic_expression, tol));
 }
 
 Binding<LorentzConeConstraint> MathematicalProgram::AddLorentzConeConstraint(

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -424,8 +424,8 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols> NewBinaryVariables(
-      int rows, int cols, const std::string& name) {
+  MatrixDecisionVariable<Rows, Cols>
+  NewBinaryVariables(int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -354,8 +354,8 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols> NewContinuousVariables(
-      int rows, int cols, const std::string& name) {
+  MatrixDecisionVariable<Rows, Cols>
+  NewContinuousVariables(int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =
@@ -1420,8 +1420,11 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint on the linear expression v1 and quadratic
    * expression v2, such that v1 >= sqrt(v2)
-   * @param v1     The linear expression.
-   * @param v2  The quadratic expression.
+   * @param linear expression     The linear expression v1.
+   * @param quadratic_expression  The quadratic expression v2.
+   * @param tol The tolerance to determine if the matrix in v2 is positive
+   * semidefinite or not. @see DecomposePositiveQuadraticForm for more
+   * explanation. @default is 0.
    * @retval binding The newly added Lorentz cone constraint, together with the
    * bound variables.
    * @pre
@@ -1439,13 +1442,13 @@ class MathematicalProgram {
    * Lorentz cone, where
    * <pre>
    *  z = v1
-   *  y = R * [x;1]
+   *  y = R * x + d
    * </pre>
-   * while R satisfies Rᵀ * R = [Q     b/2]
-   *                            [bᵀ/2    a]
+   * while (R, d) satisfies y'*y = x'*Q*x + b'*x + a
    */
   Binding<LorentzConeConstraint> AddLorentzConeConstraint(
-      const symbolic::Expression& v1, const symbolic::Expression& v2);
+      const symbolic::Expression& linear_expression,
+      const symbolic::Expression& quadratic_expression, double tol = 0);
 
   /**
    * Adds Lorentz cone constraint referencing potentially a subset of the
@@ -1549,9 +1552,12 @@ class MathematicalProgram {
   /**
    * Adds rotated Lorentz cone constraint on the linear expression v1, v2 and
    * quadratic expression u, such that v1 * v2 >= u, v1 >= 0, v2 >= 0
-   * @param linear_expression1  The linear expression v1.
-   * @param linear_expression2  The linear expression v2.
+   * @param linear_expression1 The linear expression v1.
+   * @param linear_expression2 The linear expression v2.
    * @param quadratic_expression The quadratic expression u.
+   * @param tol The tolerance to determine if the matrix in v2 is positive
+   * semidefinite or not. @see DecomposePositiveQuadraticForm for more
+   * explanation. @default is 0.
    * @retval binding The newly added rotated Lorentz cone constraint, together
    * with the bound variables.
    * @pre
@@ -1571,7 +1577,7 @@ class MathematicalProgram {
   Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const symbolic::Expression& linear_expression1,
       const symbolic::Expression& linear_expression2,
-      const symbolic::Expression& quadratic_expression);
+      const symbolic::Expression& quadratic_expression, double tol = 0);
 
   /**
    * Adds a constraint that a symbolic expression @param v is in the rotated

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1420,7 +1420,7 @@ class MathematicalProgram {
   /**
    * Adds Lorentz cone constraint on the linear expression v1 and quadratic
    * expression v2, such that v1 >= sqrt(v2)
-   * @param linear expression     The linear expression v1.
+   * @param linear_expression The linear expression v1.
    * @param quadratic_expression  The quadratic expression v2.
    * @param tol The tolerance to determine if the matrix in v2 is positive
    * semidefinite or not. @see DecomposePositiveQuadraticForm for more

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -189,7 +189,7 @@ enum ProgramAttributes {
 };
 typedef uint32_t AttributesSet;
 
-template<int ...>
+template <int...>
 struct NewVariableNames {};
 /**
    * The type of the names for the newly added variables.
@@ -221,7 +221,7 @@ namespace internal {
  * Return un-initialized new variable names.
  */
 template <int Size>
-typename std::enable_if< Size >= 0, typename NewVariableNames<Size>::type>::type
+typename std::enable_if<Size >= 0, typename NewVariableNames<Size>::type>::type
 CreateNewVariableNames(int) {
   typename NewVariableNames<Size>::type names;
   return names;
@@ -322,7 +322,6 @@ class MathematicalProgram {
     return NewContinuousVariables<Eigen::Dynamic, 1>(rows, 1, name);
   }
 
-
   /**
    * Adds continuous variables, appending them to an internal vector of any
    * existing vars.
@@ -355,10 +354,10 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols>
-  NewContinuousVariables(int rows, int cols, const std::string& name) {
-    rows = Rows == Eigen::Dynamic? rows : Rows;
-    cols = Cols == Eigen::Dynamic? cols : Cols;
+  MatrixDecisionVariable<Rows, Cols> NewContinuousVariables(
+      int rows, int cols, const std::string& name) {
+    rows = Rows == Eigen::Dynamic ? rows : Rows;
+    cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =
         internal::CreateNewVariableNames<MultiplyEigenSizes<Rows, Cols>::value>(
             rows * cols);
@@ -425,8 +424,8 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols>
-  NewBinaryVariables(int rows, int cols, const std::string& name) {
+  MatrixDecisionVariable<Rows, Cols> NewBinaryVariables(
+      int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =
@@ -1547,6 +1546,40 @@ class MathematicalProgram {
       const Binding<RotatedLorentzConeConstraint>& binding);
 
   /**
+   * Adds rotated Lorentz cone constraint on the linear expression v1, v2 and
+   * quadratic expression u, such that v1 * v2 >= u, v1 >= 0, v2 >= 0
+   * @param linear_expression1  The linear expression v1.
+   * @param linear_expression2  The linear expression v2.
+   * @param quadratic_expression The quadratic expression u.
+   * @retval binding The newly added rotated Lorentz cone constraint, together
+   * with the bound variables.
+   * @pre
+   * 1. v1 is a linear (affine) expression, in the form of v1 = c1'*x + d1.
+   * 2. v2 is a linear (affine) expression, in the form of v2 = c2'*x + d2.
+   * 2. `quadratic_expression` is a quadratic expression, in the form of
+   *    <pre>
+   *          u = 0.5 * x'*Q*x + b'x + a
+   *    </pre>
+   *    Also the quadratic expression has to be convex, namely Q is a
+   *    positive semidefinite matrix, and the quadratic expression needs
+   *    to be non-negative for any x.
+   * Throws a runtime_error if the preconditions are not satisfied.
+   *
+   * Notice this constraint is equivalent to the vector [z1;z2;y] is within a
+   * rotated Lorentz cone, where
+   * <pre>
+   *  z1 = v1
+   *  z2 = v2
+   *  y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
+   * </pre>
+   * while R satisfies Rᵀ * R = Q
+   */
+  Binding<LorentzConeConstraint> AddRotatedLorentzConeConstraint(
+      const symbolic::Expression& linear_expression1,
+      const symbolic::Expression& linear_expression2,
+      const symbolic::Expression& quadratic_expression);
+
+  /**
    * Adds a constraint that a symbolic expression @param v is in the rotated
    * Lorentz cone, i.e.,
    * \f[
@@ -1917,14 +1950,12 @@ class MathematicalProgram {
    * https://www.gurobi.com/documentation/6.5/refman/parameters.html
    */
   void SetSolverOption(const SolverId& solver_id,
-                       const std::string& solver_option,
-                       double option_value) {
+                       const std::string& solver_option, double option_value) {
     solver_options_double_[solver_id][solver_option] = option_value;
   }
 
   void SetSolverOption(const SolverId& solver_id,
-                       const std::string& solver_option,
-                       int option_value) {
+                       const std::string& solver_option, int option_value) {
     solver_options_int_[solver_id][solver_option] = option_value;
   }
 
@@ -1952,17 +1983,13 @@ class MathematicalProgram {
   /**
    * Sets the ID of the solver that was used to solve this program.
    */
-  void SetSolverId(SolverId solver_id) {
-    solver_id_ = solver_id;
-  }
+  void SetSolverId(SolverId solver_id) { solver_id_ = solver_id; }
 
   /**
    * Returns the ID of the solver that was used to solve this program.
    * Returns empty if Solve() has not been called.
    */
-  optional<SolverId> GetSolverId() const {
-    return solver_id_;
-  }
+  optional<SolverId> GetSolverId() const { return solver_id_; }
 
   /**
    * Getter for optimal cost at the solution. Will return NaN if there has
@@ -2445,8 +2472,7 @@ class MathematicalProgram {
    */
   template <int Rows>
   MatrixDecisionVariable<Rows, Rows> NewSymmetricVariables(
-      VarType type,
-      const typename NewSymmetricVariableNames<Rows>::type& names,
+      VarType type, const typename NewSymmetricVariableNames<Rows>::type& names,
       int rows = Rows) {
     MatrixDecisionVariable<Rows, Rows> decision_variable_matrix(rows, rows);
     NewVariables_impl(type, names, true, decision_variable_matrix);

--- a/drake/solvers/mathematical_program.h
+++ b/drake/solvers/mathematical_program.h
@@ -1425,10 +1425,10 @@ class MathematicalProgram {
    * @retval binding The newly added Lorentz cone constraint, together with the
    * bound variables.
    * @pre
-   * 1. `linear_expr` is a linear expression, in the form of c'*x + d.
-   * 2. `quadratic_expr` is a quadratic expression, in the form of
+   * 1. `v1` is a linear expression, in the form of c'*x + d.
+   * 2. `v2` is a quadratic expression, in the form of
    *    <pre>
-   *          0.5 * x'*Q*x + b'x + a
+   *          x'*Q*x + b'x + a
    *    </pre>
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
@@ -1439,9 +1439,10 @@ class MathematicalProgram {
    * Lorentz cone, where
    * <pre>
    *  z = v1
-   *  y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
+   *  y = R * [x;1]
    * </pre>
-   * while R satisfies Rᵀ * R = Q
+   * while R satisfies Rᵀ * R = [Q     b/2]
+   *                            [bᵀ/2    a]
    */
   Binding<LorentzConeConstraint> AddLorentzConeConstraint(
       const symbolic::Expression& v1, const symbolic::Expression& v2);
@@ -1554,27 +1555,20 @@ class MathematicalProgram {
    * @retval binding The newly added rotated Lorentz cone constraint, together
    * with the bound variables.
    * @pre
-   * 1. v1 is a linear (affine) expression, in the form of v1 = c1'*x + d1.
-   * 2. v2 is a linear (affine) expression, in the form of v2 = c2'*x + d2.
+   * 1. `linear_expression1` is a linear (affine) expression, in the form of
+   *    v1 = c1'*x + d1.
+   * 2. `linear_expression2` is a linear (affine) expression, in the form of
+   *    v2 = c2'*x + d2.
    * 2. `quadratic_expression` is a quadratic expression, in the form of
    *    <pre>
-   *          u = 0.5 * x'*Q*x + b'x + a
+   *          u = x'*Q*x + b'x + a
    *    </pre>
    *    Also the quadratic expression has to be convex, namely Q is a
    *    positive semidefinite matrix, and the quadratic expression needs
    *    to be non-negative for any x.
    * Throws a runtime_error if the preconditions are not satisfied.
-   *
-   * Notice this constraint is equivalent to the vector [z1;z2;y] is within a
-   * rotated Lorentz cone, where
-   * <pre>
-   *  z1 = v1
-   *  z2 = v2
-   *  y = [1 / sqrt(2) * R * x + R⁻ᵀb; sqrt(a - 0.5 * bᵀ * Q⁻¹ * a)]
-   * </pre>
-   * while R satisfies Rᵀ * R = Q
    */
-  Binding<LorentzConeConstraint> AddRotatedLorentzConeConstraint(
+  Binding<RotatedLorentzConeConstraint> AddRotatedLorentzConeConstraint(
       const symbolic::Expression& linear_expression1,
       const symbolic::Expression& linear_expression2,
       const symbolic::Expression& quadratic_expression);

--- a/drake/solvers/test/create_constraint_test.cc
+++ b/drake/solvers/test/create_constraint_test.cc
@@ -1,0 +1,119 @@
+#include "drake/solvers/create_constraint.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/symbolic_test_util.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+void ComparePolynomials(const symbolic::Polynomial& p1,
+                        const symbolic::Polynomial& p2, double tol) {
+  const symbolic::Polynomial diff = p1 - p2;
+  // Check if the absolute value of the coefficient for each monomial is less
+  // than tol.
+  const symbolic::Polynomial::MapType& map = diff.monomial_to_coefficient_map();
+  for (const auto& p : map) {
+    EXPECT_LE(std::abs(get_constant_value(p.second)), tol);
+  }
+}
+
+void CheckParseLorentzConeConstraint(
+    const symbolic::Expression& linear_expression,
+    const symbolic::Expression& quadratic_expression) {
+  Binding<LorentzConeConstraint> binding = internal::ParseLorentzConeConstraint(
+      linear_expression, quadratic_expression);
+  const Eigen::MatrixXd A = binding.constraint()->A();
+  const Eigen::VectorXd b = binding.constraint()->b();
+  const VectorX<symbolic::Expression> z = A * binding.variables() + b;
+  ComparePolynomials(symbolic::Polynomial(z(0)),
+                     symbolic::Polynomial(linear_expression), 1E-10);
+  ComparePolynomials(symbolic::Polynomial(z.tail(z.rows() - 1).squaredNorm()),
+                     symbolic::Polynomial(quadratic_expression), 1E-10);
+}
+
+class ParseLorentzConeConstraintTest : public ::testing::Test {
+ public:
+  ParseLorentzConeConstraintTest()
+      : x0_{"x0"}, x1_{"x1"}, x2_{"x2"}, x3_{"x3"} {
+    x_ << x0_, x1_, x2_, x3_;
+  }
+
+ protected:
+  symbolic::Variable x0_;
+  symbolic::Variable x1_;
+  symbolic::Variable x2_;
+  symbolic::Variable x3_;
+  Vector4<symbolic::Variable> x_;
+};
+
+TEST_F(ParseLorentzConeConstraintTest, Test0) {
+  // Test x(0) >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
+  CheckParseLorentzConeConstraint(
+      x_(0), x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test1) {
+  // Test 2 * x(0) >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
+  CheckParseLorentzConeConstraint(
+      2 * x_(0), x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test2) {
+  // Test 2 * x(0) + 3 * x(1) + 2 >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
+  CheckParseLorentzConeConstraint(
+      2 * x_(0) + 3 * x_(1) + 2,
+      x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test3) {
+  // Test x(0) >= sqrt(2x(1)² + x(2)² + 3x(3)² + 2)
+  CheckParseLorentzConeConstraint(
+      x_(0), 2 * x_(1) * x_(1) + x_(2) * x_(2) + 3 * x_(3) * x_(3) + 2);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test4) {
+  // Test x(0) + 2x(2) + 3 >= sqrt((x(1) + 2x(3)-1)² + 3(-x(0)+2x(3)+1)² + 3)
+  CheckParseLorentzConeConstraint(x_(0) + 2 * x_(2) + 3,
+                                  2 * pow(x_(1) + 2 * x_(3) - 1, 2) +
+                                      3 * pow(-x_(0) + 2 * x_(3) + 1, 2) + 3);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test5) {
+  // Test 2 >= sqrt((x(1)+2x(2))² + (x(2)-x(0)+2)² + 3)
+  CheckParseLorentzConeConstraint(
+      2, pow(x_(1) + 2 * x_(2), 2) + pow(x_(2) - x_(0) + 2, 2) + 3);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test6) {
+  // The linear expression is not actually linear.
+  EXPECT_THROW(internal::ParseLorentzConeConstraint(
+                   2 * x_(0) * x_(1), x_(0) * x_(0) + x_(1) * x_(1)),
+               std::runtime_error);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test7) {
+  // The quadratic expression is actually linear.
+  EXPECT_THROW(internal::ParseLorentzConeConstraint(2 * x_(0), x_(0) + x_(1)),
+               std::runtime_error);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test8) {
+  // The quadratic expression is actually cubic.
+  EXPECT_THROW(
+      internal::ParseLorentzConeConstraint(2 * x_(0), pow(x_(1), 3) + x_(2)),
+      std::runtime_error);
+}
+
+TEST_F(ParseLorentzConeConstraintTest, Test9) {
+  // The quadratic expression is not positive semidefinite.
+  EXPECT_THROW(internal::ParseLorentzConeConstraint(
+                   x_(0), pow(x_(1) + 2 * x_(2) + 1, 2) - x_(3)),
+               std::runtime_error);
+  EXPECT_THROW(internal::ParseLorentzConeConstraint(
+                   x_(0), pow(x_(1) + x_(2) + 2, 2) - 1),
+               std::runtime_error);
+}
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/test/create_constraint_test.cc
+++ b/drake/solvers/test/create_constraint_test.cc
@@ -106,9 +106,10 @@ TEST_F(ParseLorentzConeConstraintTest, Test3) {
 }
 
 TEST_F(ParseLorentzConeConstraintTest, Test4) {
-  // Test x(0) + 2x(2) + 3 >= sqrt((x(1) + 2x(3)-1)² + 3(-x(0)+2x(3)+1)² + 3)
+  // Test x(0) + 2x(2) + 3 >= sqrt((x(1) + x(0) + 2x(3)-1)² + 3(-x(0)+2x(3)+1)²
+  // + 3)
   CheckParseLorentzConeConstraint(x_(0) + 2 * x_(2) + 3,
-                                  2 * pow(x_(1) + 2 * x_(3) - 1, 2) +
+                                  2 * pow(x_(1) + x_(0) + 2 * x_(3) - 1, 2) +
                                       3 * pow(-x_(0) + 2 * x_(3) + 1, 2) + 3);
 }
 
@@ -197,10 +198,17 @@ TEST_F(ParseRotatedLorentzConeConstraintTest, Test3) {
   // Throw a runtime error when the precondition is not satisfied.
   Eigen::Matrix<symbolic::Expression, 4, 1> expression;
   expression << 2 * x_(0) * x_(1), x_(2), x_(3), 1;
-  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(expression), std::runtime_error);
-  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(0) * x_(1), x_(1), x_(2) * x_(2) + 1), std::runtime_error);
-  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(1), x_(0) * x_(1), x_(2) * x_(2) + 1), std::runtime_error);
-  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(0), x_(1), x_(2) * x_(2) - 1), std::runtime_error);
+  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(expression),
+               std::runtime_error);
+  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(0) * x_(1), x_(1),
+                                                           x_(2) * x_(2) + 1),
+               std::runtime_error);
+  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(1), x_(0) * x_(1),
+                                                           x_(2) * x_(2) + 1),
+               std::runtime_error);
+  EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(x_(0), x_(1),
+                                                           x_(2) * x_(2) - 1),
+               std::runtime_error);
 }
 }  // namespace
 }  // namespace solvers

--- a/drake/solvers/test/create_constraint_test.cc
+++ b/drake/solvers/test/create_constraint_test.cc
@@ -4,65 +4,60 @@
 
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
+using drake::symbolic::Expression;
+
 namespace drake {
 namespace solvers {
 namespace {
-void ComparePolynomials(const symbolic::Polynomial& p1,
-                        const symbolic::Polynomial& p2, double tol) {
-  const symbolic::Polynomial diff = p1 - p2;
-  // Check if the absolute value of the coefficient for each monomial is less
-  // than tol.
-  const symbolic::Polynomial::MapType& map = diff.monomial_to_coefficient_map();
-  for (const auto& p : map) {
-    EXPECT_LE(std::abs(get_constant_value(p.second)), tol);
-  }
-}
 
-void CheckParseLorentzConeConstraint(
-    const symbolic::Expression& linear_expression,
-    const symbolic::Expression& quadratic_expression) {
+void CheckParseLorentzConeConstraint(const Expression& linear_expression,
+                                     const Expression& quadratic_expression) {
   Binding<LorentzConeConstraint> binding = internal::ParseLorentzConeConstraint(
       linear_expression, quadratic_expression);
   const Eigen::MatrixXd A = binding.constraint()->A();
   const Eigen::VectorXd b = binding.constraint()->b();
-  const VectorX<symbolic::Expression> z = A * binding.variables() + b;
-  ComparePolynomials(symbolic::Polynomial(z(0)),
-                     symbolic::Polynomial(linear_expression), 1E-10);
-  ComparePolynomials(symbolic::Polynomial(z.tail(z.rows() - 1).squaredNorm()),
-                     symbolic::Polynomial(quadratic_expression), 1E-10);
+  const VectorX<Expression> z = A * binding.variables() + b;
+  symbolic::test::ComparePolynomials(symbolic::Polynomial(z(0)),
+                                     symbolic::Polynomial(linear_expression),
+                                     1E-10);
+  symbolic::test::ComparePolynomials(
+      symbolic::Polynomial(z.tail(z.rows() - 1).squaredNorm()),
+      symbolic::Polynomial(quadratic_expression), 1E-10);
 }
 
 void CheckParseRotatedLorentzConeConstraint(
-    const Eigen::Ref<const VectorX<symbolic::Expression>>& v) {
+    const Eigen::Ref<const VectorX<Expression>>& v) {
   Binding<RotatedLorentzConeConstraint> binding =
       internal::ParseRotatedLorentzConeConstraint(v);
   const Eigen::MatrixXd A = binding.constraint()->A();
   const Eigen::VectorXd b = binding.constraint()->b();
-  const VectorX<symbolic::Expression> z = A * binding.variables() + b;
+  const VectorX<Expression> z = A * binding.variables() + b;
   for (int i = 0; i < z.rows(); ++i) {
-    ComparePolynomials(symbolic::Polynomial(z(i)), symbolic::Polynomial(v(i)),
-                       1E-10);
+    symbolic::test::ComparePolynomials(symbolic::Polynomial(z(i)),
+                                       symbolic::Polynomial(v(i)), 1E-10);
   }
 }
 
 void CheckParseRotatedLorentzConeConstraint(
-    const symbolic::Expression& linear_expression1,
-    const symbolic::Expression& linear_expression2,
-    const symbolic::Expression& quadratic_expression) {
+    const Expression& linear_expression1, const Expression& linear_expression2,
+    const Expression& quadratic_expression) {
   Binding<RotatedLorentzConeConstraint> binding =
       internal::ParseRotatedLorentzConeConstraint(
           linear_expression1, linear_expression2, quadratic_expression);
   const Eigen::MatrixXd A = binding.constraint()->A();
   const Eigen::VectorXd b = binding.constraint()->b();
-  const VectorX<symbolic::Expression> z = A * binding.variables() + b;
-  ComparePolynomials(symbolic::Polynomial(z(0)),
-                     symbolic::Polynomial(linear_expression1), 1E-10);
-  ComparePolynomials(symbolic::Polynomial(z(1)),
-                     symbolic::Polynomial(linear_expression2), 1E-10);
-  ComparePolynomials(
+  const VectorX<Expression> z = A * binding.variables() + b;
+  const double tol_check{1E-10};
+  symbolic::test::ComparePolynomials(symbolic::Polynomial(z(0)),
+                                     symbolic::Polynomial(linear_expression1),
+                                     tol_check);
+  symbolic::test::ComparePolynomials(symbolic::Polynomial(z(1)),
+                                     symbolic::Polynomial(linear_expression2),
+                                     tol_check);
+  symbolic::test::ComparePolynomials(
       symbolic::Polynomial(
-          z.tail(z.rows() - 2).cast<symbolic::Expression>().squaredNorm()),
-      symbolic::Polynomial(quadratic_expression), 1E-10);
+          z.tail(z.rows() - 2).cast<Expression>().squaredNorm()),
+      symbolic::Polynomial(quadratic_expression), tol_check);
 }
 
 class ParseLorentzConeConstraintTest : public ::testing::Test {
@@ -83,20 +78,19 @@ class ParseLorentzConeConstraintTest : public ::testing::Test {
 TEST_F(ParseLorentzConeConstraintTest, Test0) {
   // Test x(0) >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
   CheckParseLorentzConeConstraint(
-      x_(0), x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+      x_(0), x_.tail<3>().cast<Expression>().squaredNorm());
 }
 
 TEST_F(ParseLorentzConeConstraintTest, Test1) {
   // Test 2 * x(0) >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
   CheckParseLorentzConeConstraint(
-      2 * x_(0), x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+      2 * x_(0), x_.tail<3>().cast<Expression>().squaredNorm());
 }
 
 TEST_F(ParseLorentzConeConstraintTest, Test2) {
   // Test 2 * x(0) + 3 * x(1) + 2 >= sqrt(x(1)² + x(2)² + ... + x(n-1)²)
   CheckParseLorentzConeConstraint(
-      2 * x_(0) + 3 * x_(1) + 2,
-      x_.tail<3>().cast<symbolic::Expression>().squaredNorm());
+      2 * x_(0) + 3 * x_(1) + 2, x_.tail<3>().cast<Expression>().squaredNorm());
 }
 
 TEST_F(ParseLorentzConeConstraintTest, Test3) {
@@ -166,7 +160,7 @@ class ParseRotatedLorentzConeConstraintTest : public ::testing::Test {
 
 TEST_F(ParseRotatedLorentzConeConstraintTest, Test0) {
   // x(0) * x(1) >= x(2)² + x(3)², x(0) >= 0, x(1) >= 0
-  CheckParseRotatedLorentzConeConstraint(x_.cast<symbolic::Expression>());
+  CheckParseRotatedLorentzConeConstraint(x_.cast<Expression>());
   CheckParseRotatedLorentzConeConstraint(x_(0), x_(1),
                                          x_(2) * x_(2) + x_(3) * x_(3));
 }
@@ -175,7 +169,7 @@ TEST_F(ParseRotatedLorentzConeConstraintTest, Test1) {
   // (x(0) + 2) * (2 * x(1) + x(0) + 1) >= x(2)² + x(3)²
   // x(0) + 2 >= 0
   // 2 * x(1) + x(0) + 1 >= 0
-  Vector4<symbolic::Expression> expression;
+  Vector4<Expression> expression;
   expression << x_(0) + 2, 2 * x_(1) + x_(0) + 1, x_(2), x_(3);
   CheckParseRotatedLorentzConeConstraint(expression);
   CheckParseRotatedLorentzConeConstraint(expression(0), expression(1),
@@ -185,7 +179,7 @@ TEST_F(ParseRotatedLorentzConeConstraintTest, Test1) {
 TEST_F(ParseRotatedLorentzConeConstraintTest, Test2) {
   // (x(0) - x(1) + 2) * (3 * x(2)) >= (x(1) + x(2))² + (x(2) + 2 * x(3) + 2)² +
   // 5
-  Eigen::Matrix<symbolic::Expression, 5, 1> expression;
+  Eigen::Matrix<Expression, 5, 1> expression;
   expression << x_(0) - x_(1) + 2, 3 * x_(2), x_(1) + x_(2),
       x_(2) + 2 * x_(3) + 2, std::sqrt(5);
   CheckParseRotatedLorentzConeConstraint(expression);
@@ -196,7 +190,7 @@ TEST_F(ParseRotatedLorentzConeConstraintTest, Test2) {
 
 TEST_F(ParseRotatedLorentzConeConstraintTest, Test3) {
   // Throw a runtime error when the precondition is not satisfied.
-  Eigen::Matrix<symbolic::Expression, 4, 1> expression;
+  Eigen::Matrix<Expression, 4, 1> expression;
   expression << 2 * x_(0) * x_(1), x_(2), x_(3), 1;
   EXPECT_THROW(internal::ParseRotatedLorentzConeConstraint(expression),
                std::runtime_error);

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -2075,12 +2075,12 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
 GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint5) {
   // Add rotated Lorentz cone constraint, using quadratic expression.
   MathematicalProgram prog;
-  auto x = prog.NewContinuousVariables<4>("x");
+  const auto x = prog.NewContinuousVariables<4>("x");
   Expression linear_expression1 = x(0) + 1;
   Expression linear_expression2 = x(1) - x(2);
   Eigen::Matrix2d Q;
   Eigen::Vector2d b;
-  double c{5};
+  const double c{5};
   Q << 1, 0.5, 0.5, 1;
   b << 0, 0.1;
   const Expression quadratic_expression =

--- a/drake/solvers/test/mathematical_program_test.cc
+++ b/drake/solvers/test/mathematical_program_test.cc
@@ -506,8 +506,7 @@ void ExpectBadVar(MathematicalProgram* prog, int num_var, Args&&... args) {
   using internal::CreateBinding;
   auto c = make_shared<C>(std::forward<Args>(args)...);
   VectorXDecisionVariable x(num_var);
-  for (int i = 0; i < num_var; ++i)
-    x(i) = Variable("bad" + std::to_string(i));
+  for (int i = 0; i < num_var; ++i) x(i) = Variable("bad" + std::to_string(i));
   // Use minimal call site (directly on adding Binding<C>).
   // TODO(eric.cousineau): Check if there is a way to parse the error text to
   // ensure that we are capturing the correct error.
@@ -2070,6 +2069,48 @@ GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint4) {
   Matrix<Expression, 5, 1> e;
   e << 2 * x(0) + 3 * x(2) + 3, x(0) - 4 * x(2), 2 * x(2), 3 * x(0) + 1, 4;
   CheckParsedSymbolicRotatedLorentzConeConstraint(&prog, e);
+}
+
+void ComparePolynomials(const symbolic::Polynomial& p1,
+                        const symbolic::Polynomial& p2, double tol) {
+  const symbolic::Polynomial diff = p1 - p2;
+  // Check if the absolute value of the coefficient for each monomial is less
+  // than tol.
+  const symbolic::Polynomial::MapType& map = diff.monomial_to_coefficient_map();
+  for (const auto& p : map) {
+    EXPECT_LE(std::abs(get_constant_value(p.second)), tol);
+  }
+}
+
+GTEST_TEST(testMathematicalProgram, AddSymbolicRotatedLorentzConeConstraint5) {
+  // Add rotated Lorentz cone constraint, using quadratic expression.
+  MathematicalProgram prog;
+  auto x = prog.NewContinuousVariables<4>("x");
+  symbolic::Expression linear_expression1 = x(0) + 1;
+  symbolic::Expression linear_expression2 = x(1) - x(2);
+  Eigen::Matrix2d Q;
+  Eigen::Vector2d b;
+  double c{5};
+  Q << 1, 0.5, 0.5, 1;
+  b << 0, 0.1;
+  symbolic::Expression quadratic_expression =
+      x.head<2>().cast<symbolic::Expression>().dot(Q * x.head<2>() + b) + c;
+  auto binding = prog.AddRotatedLorentzConeConstraint(
+      linear_expression1, linear_expression2, quadratic_expression);
+  EXPECT_EQ(binding.constraint(),
+            prog.rotated_lorentz_cone_constraints().back().constraint());
+  VectorX<symbolic::Expression> z =
+      binding.constraint()->A() * binding.variables() +
+      binding.constraint()->b();
+  ComparePolynomials(symbolic::Polynomial(linear_expression1),
+                     symbolic::Polynomial(z(0)), 1E-10);
+  ComparePolynomials(symbolic::Polynomial(linear_expression2),
+                     symbolic::Polynomial(z(1)), 1E-10);
+  ComparePolynomials(
+      symbolic::Polynomial(quadratic_expression),
+      symbolic::Polynomial(
+          z.tail(z.rows() - 2).cast<symbolic::Expression>().squaredNorm()),
+      1E-10);
 }
 
 namespace {

--- a/drake/solvers/test/rotation_constraint_test.cc
+++ b/drake/solvers/test/rotation_constraint_test.cc
@@ -31,8 +31,8 @@ void AddObjective(MathematicalProgram* prog,
   MatrixDecisionVariable<1, 1> sigma =
       prog->NewContinuousVariables<1, 1>("sigma");
   // trace(R_errorᵀ * R_error) = sum_{i,j} R_error(i,j)²
-  prog->AddLorentzConeConstraint(sigma(0),
-                                 (R_error.transpose() * R_error).trace());
+  prog->AddLorentzConeConstraint(
+      sigma(0), (R_error.transpose() * R_error).trace(), 1E-15);
 
   // min sigma
   prog->AddCost(sigma(0));


### PR DESCRIPTION
Now we can add the rotated Lorentz cone using a quadratic expression, for example
x(0) * x(1) >= x' * Q * x + b' * x + c
instead of having to manually compute the A, d matrix, such that |A * x + d|² = x' * Q * x + b' * x + c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7320)
<!-- Reviewable:end -->
