### PR TITLE
Bump pydrake_common_install_test to medium

### DIFF
--- a/drake/bindings/BUILD.bazel
+++ b/drake/bindings/BUILD.bazel
@@ -155,7 +155,7 @@ drake_py_test(
 # `no_everything` because `libgurobi70.so` is not found [Issue #7283].
 drake_py_test(
     name = "pydrake_common_install_test",
-    size = "small",
+    size = "medium",
     srcs = ["python/pydrake/test/testCommonInstall.py"],
     data = ["//:install"],
     main = "python/pydrake/test/testCommonInstall.py",


### PR DESCRIPTION
Our `linux-xenial-clang-bazel-*-debug` builds are sometimes hitting the 60s timeout in CI, possibly due to I/O contention.  In any case, running and validating a full install seems like a fair test to be marked not-small.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7336)
<!-- Reviewable:end -->
