### PR TITLE
API cleanup 2: make state-returning methods return references consistently

### DIFF
--- a/drake/automotive/automotive_simulator.cc
+++ b/drake/automotive/automotive_simulator.cc
@@ -308,7 +308,7 @@ void AutomotiveSimulator<T>::SetMaliputRailcarAccelerationCommand(int id,
   DRAKE_ASSERT(diagram_ != nullptr);
   DRAKE_ASSERT(simulator_ != nullptr);
   systems::Context<T>& context = diagram_->GetMutableSubsystemContext(
-      *railcar, simulator_->get_mutable_context());
+      *railcar, &simulator_->get_mutable_context());
   context.FixInputPort(railcar->command_input().get_index(),
       systems::BasicVector<double>::Make(acceleration));
 }
@@ -499,7 +499,7 @@ void AutomotiveSimulator<T>::Start(double target_realtime_rate) {
   simulator_->set_target_realtime_rate(target_realtime_rate);
   const double max_step_size = 0.01;
   simulator_->template reset_integrator<RungeKutta2Integrator<T>>(*diagram_,
-      max_step_size, simulator_->get_mutable_context());
+      max_step_size, &simulator_->get_mutable_context());
   simulator_->get_mutable_integrator()->set_fixed_step_mode(true);
   simulator_->Initialize();
 }
@@ -510,12 +510,12 @@ void AutomotiveSimulator<T>::InitializeTrajectoryCars() {
     const TrajectoryCar<T>* const car = pair.first;
     const TrajectoryCarState<T>& initial_state = pair.second;
 
-    systems::VectorBase<T>* context_state =
+    systems::VectorBase<T>& context_state =
         diagram_->GetMutableSubsystemContext(*car,
-                                             simulator_->get_mutable_context())
-        .get_mutable_continuous_state()->get_mutable_vector();
+                                             &simulator_->get_mutable_context())
+        .get_mutable_continuous_state().get_mutable_vector();
     TrajectoryCarState<T>* const state =
-        dynamic_cast<TrajectoryCarState<T>*>(context_state);
+        dynamic_cast<TrajectoryCarState<T>*>(&context_state);
     DRAKE_ASSERT(state);
     state->set_value(initial_state.get_value());
   }
@@ -527,12 +527,12 @@ void AutomotiveSimulator<T>::InitializeSimpleCars() {
     const SimpleCar<T>* const car = pair.first;
     const SimpleCarState<T>& initial_state = pair.second;
 
-    systems::VectorBase<T>* context_state =
+    systems::VectorBase<T>& context_state =
         diagram_->GetMutableSubsystemContext(*car,
-                                             simulator_->get_mutable_context())
-        .get_mutable_continuous_state()->get_mutable_vector();
+                                             &simulator_->get_mutable_context())
+        .get_mutable_continuous_state().get_mutable_vector();
     SimpleCarState<T>* const state =
-        dynamic_cast<SimpleCarState<T>*>(context_state);
+        dynamic_cast<SimpleCarState<T>*>(&context_state);
     DRAKE_ASSERT(state);
     state->set_value(initial_state.get_value());
   }
@@ -546,12 +546,12 @@ void AutomotiveSimulator<T>::InitializeMaliputRailcars() {
     const MaliputRailcarState<T>& initial_state = pair.second.second;
 
     systems::Context<T>& context = diagram_->GetMutableSubsystemContext(
-         *car, simulator_->get_mutable_context());
+         *car, &simulator_->get_mutable_context());
 
-    systems::VectorBase<T>* context_state =
-        context.get_mutable_continuous_state()->get_mutable_vector();
+    systems::VectorBase<T>& context_state =
+        context.get_mutable_continuous_state().get_mutable_vector();
     MaliputRailcarState<T>* const state =
-        dynamic_cast<MaliputRailcarState<T>*>(context_state);
+        dynamic_cast<MaliputRailcarState<T>*>(&context_state);
     DRAKE_ASSERT(state);
     state->set_value(initial_state.get_value());
 

--- a/drake/automotive/bicycle_car.cc
+++ b/drake/automotive/bicycle_car.cc
@@ -103,10 +103,9 @@ void BicycleCar<T>::DoCalcTimeDerivatives(
   DRAKE_ASSERT(force != nullptr);
 
   DRAKE_ASSERT(derivatives != nullptr);
-  systems::VectorBase<T>* derivative_vector = derivatives->get_mutable_vector();
-  DRAKE_ASSERT(derivative_vector != nullptr);
+  systems::VectorBase<T>& derivative_vector = derivatives->get_mutable_vector();
   BicycleCarState<T>* const state_derivatives =
-      dynamic_cast<BicycleCarState<T>*>(derivative_vector);
+      dynamic_cast<BicycleCarState<T>*>(&derivative_vector);
   DRAKE_ASSERT(state_derivatives != nullptr);
 
   ImplCalcTimeDerivatives(params, *state, *steering, *force, state_derivatives);

--- a/drake/automotive/car_sim_lcm.cc
+++ b/drake/automotive/car_sim_lcm.cc
@@ -116,9 +116,9 @@ int main(int argc, char* argv[]) {
   lcm.StartReceiveThread();
   Simulator<double> simulator(*diagram);
 
-  const auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
   simulator.reset_integrator<SemiExplicitEulerIntegrator<double>>(
-      *diagram, 1e-4, context);
+      *diagram, 1e-4, &context);
 
   simulator.Initialize();
   simulator.StepTo(FLAGS_simulation_sec);

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -250,10 +250,9 @@ void MaliputRailcar<T>::DoCalcTimeDerivatives(
   DRAKE_ASSERT(input->size() == 1);
 
   // Obtains the result structure.
-  VectorBase<T>* const vector_derivatives = derivatives->get_mutable_vector();
-  DRAKE_ASSERT(vector_derivatives);
+  VectorBase<T>& vector_derivatives = derivatives->get_mutable_vector();
   MaliputRailcarState<T>* const rates =
-      dynamic_cast<MaliputRailcarState<T>*>(vector_derivatives);
+      dynamic_cast<MaliputRailcarState<T>*>(&vector_derivatives);
   DRAKE_ASSERT(rates != nullptr);
 
   ImplCalcTimeDerivatives(params, state, lane_direction, *input, rates);
@@ -307,12 +306,12 @@ void MaliputRailcar<T>::SetDefaultState(const Context<T>&,
     State<T>* state) const {
   MaliputRailcarState<T>* railcar_state =
       dynamic_cast<MaliputRailcarState<T>*>(
-          state->get_mutable_continuous_state()->get_mutable_vector());
+          &state->get_mutable_continuous_state().get_mutable_vector());
   DRAKE_DEMAND(railcar_state != nullptr);
   SetDefaultState(railcar_state);
 
   LaneDirection& lane_direction =
-      state->get_mutable_abstract_state()->get_mutable_value(0).
+      state->get_mutable_abstract_state().get_mutable_value(0).
           template GetMutableValue<LaneDirection>();
   lane_direction = initial_lane_direction_;
 }
@@ -389,12 +388,10 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
   // Copies the present state into the new one.
   next_state->CopyFrom(context.get_state());
 
-  ContinuousState<T>* cs = next_state->get_mutable_continuous_state();
-  DRAKE_ASSERT(cs != nullptr);
-  VectorBase<T>* cv = cs->get_mutable_vector();
-  DRAKE_ASSERT(cv != nullptr);
+  ContinuousState<T>& cs = next_state->get_mutable_continuous_state();
+  VectorBase<T>& cv = cs.get_mutable_vector();
   MaliputRailcarState<T>* const next_railcar_state =
-      dynamic_cast<MaliputRailcarState<T>*>(cv);
+      dynamic_cast<MaliputRailcarState<T>*>(&cv);
   DRAKE_ASSERT(next_railcar_state != nullptr);
 
   // Handles the case where no lane change or speed adjustment is necessary. No

--- a/drake/automotive/simple_car.cc
+++ b/drake/automotive/simple_car.cc
@@ -159,11 +159,10 @@ void SimpleCar<T>::DoCalcTimeDerivatives(
 
   // Obtain the result structure.
   DRAKE_ASSERT(derivatives != nullptr);
-  systems::VectorBase<T>* const vector_derivatives =
+  systems::VectorBase<T>& vector_derivatives =
       derivatives->get_mutable_vector();
-  DRAKE_ASSERT(vector_derivatives);
   SimpleCarState<T>* const rates =
-      dynamic_cast<SimpleCarState<T>*>(vector_derivatives);
+      dynamic_cast<SimpleCarState<T>*>(&vector_derivatives);
   DRAKE_ASSERT(rates);
 
   ImplCalcTimeDerivatives(params, state, *input, rates);

--- a/drake/automotive/test/bicycle_car_test.cc
+++ b/drake/automotive/test/bicycle_car_test.cc
@@ -28,15 +28,16 @@ class BicycleCarTest : public ::testing::Test {
   }
 
   BicycleCarState<double>* continuous_state() {
-    auto xc = context_->get_mutable_continuous_state_vector();
-    BicycleCarState<double>* state = dynamic_cast<BicycleCarState<double>*>(xc);
+    auto& xc = context_->get_mutable_continuous_state_vector();
+    BicycleCarState<double>* state =
+        dynamic_cast<BicycleCarState<double>*>(&xc);
     DRAKE_DEMAND(state != nullptr);
     return state;
   }
 
   const BicycleCarState<double>* derivatives() const {
     const auto derivatives = dynamic_cast<const BicycleCarState<double>*>(
-        derivatives_->get_mutable_vector());
+        &derivatives_->get_mutable_vector());
     DRAKE_DEMAND(derivatives != nullptr);
     return derivatives;
   }

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -192,7 +192,7 @@ class MaliputRailcarTest : public ::testing::Test {
 
   MaliputRailcarState<double>* continuous_state() {
     auto result = dynamic_cast<MaliputRailcarState<double>*>(
-        context_->get_mutable_continuous_state_vector());
+        &context_->get_mutable_continuous_state_vector());
     if (result == nullptr) { throw std::bad_cast(); }
     return result;
   }
@@ -293,7 +293,7 @@ class MaliputRailcarTest : public ::testing::Test {
     std::unique_ptr<BasicVector<double>> prior_velocity =
         velocity_output()->Clone();
 
-    dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+    dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
 
     if (flip_curve_lane) {
       EXPECT_EQ(continuous_state()->s(), curved_lane->length());
@@ -312,7 +312,8 @@ class MaliputRailcarTest : public ::testing::Test {
     dut_->CalcTimeDerivatives(*context_, derivatives_.get());
     const MaliputRailcarState<double>* const railcar_derivatives =
       dynamic_cast<const MaliputRailcarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
+    ASSERT_NE(nullptr, railcar_derivatives);
     if (flip_curve_lane) {
       EXPECT_LT(railcar_derivatives->s(), -kForwardSpeed);
     } else {
@@ -544,7 +545,7 @@ TEST_F(MaliputRailcarTest, DerivativesDragway) {
   // Grabs a pointer to where the EvalTimeDerivatives results end up.
   const MaliputRailcarState<double>* const result =
       dynamic_cast<const MaliputRailcarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
   ASSERT_NE(nullptr, result);
 
   // Sets the input command.
@@ -606,7 +607,7 @@ TEST_F(MaliputRailcarTest, DerivativesMonolane) {
   // Grabs a pointer to where the EvalTimeDerivatives results end up.
   const MaliputRailcarState<double>* const result =
       dynamic_cast<const MaliputRailcarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
   ASSERT_NE(nullptr, result);
 
   // Sets the input command.
@@ -636,7 +637,7 @@ TEST_F(MaliputRailcarTest, InputPortNotConnected) {
   // Grabs a pointer to where the EvalTimeDerivatives results end up.
   const MaliputRailcarState<double>* const result =
       dynamic_cast<const MaliputRailcarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
   ASSERT_NE(nullptr, result);
 
   ASSERT_NO_FATAL_FAILURE(
@@ -668,7 +669,7 @@ TEST_F(MaliputRailcarTest, DecreasingSDragway) {
   // Grabs a pointer to where the EvalTimeDerivatives results end up.
   const MaliputRailcarState<double>* const result =
       dynamic_cast<const MaliputRailcarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
   ASSERT_NE(nullptr, result);
 
   // Sets the input command.
@@ -1003,12 +1004,12 @@ TEST_F(MaliputRailcarTest, TestStopConditions) {
   continuous_state()->set_speed(kSpeed);
   lane_direction().lane = straight_lane;
   lane_direction().with_s = true;
-  dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+  dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
   EXPECT_EQ(continuous_state()->speed(), kSpeed);
   continuous_state()->set_s(-1e-10);
   lane_direction().lane = straight_lane;
   lane_direction().with_s = false;
-  dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+  dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
   EXPECT_EQ(continuous_state()->speed(), 0);
 
   // Verifies that the car does not stop when it is on the straight lane and is
@@ -1031,7 +1032,7 @@ TEST_F(MaliputRailcarTest, TestStopConditions) {
       for (const auto r : std::list<double>{-1, 0, 1}) {
         params.set_r(r);
         SetParams(params);
-        dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+        dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
         EXPECT_EQ(continuous_state()->speed(), kSpeed);
       }
     }
@@ -1056,7 +1057,7 @@ TEST_F(MaliputRailcarTest, TestStopConditions) {
       for (const auto r : std::list<double>{-1, 0, 1}) {
         params.set_r(r);
         SetParams(params);
-        dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+        dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
         EXPECT_EQ(continuous_state()->speed(), kSpeed);
       }
     }
@@ -1069,11 +1070,11 @@ TEST_F(MaliputRailcarTest, TestStopConditions) {
   continuous_state()->set_speed(kSpeed);
   lane_direction().lane = curved_lane;
   lane_direction().with_s = false;
-  dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+  dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
   EXPECT_EQ(continuous_state()->speed(), kSpeed);
   lane_direction().lane = curved_lane;
   lane_direction().with_s = true;
-  dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+  dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
   EXPECT_EQ(continuous_state()->speed(), 0);
 }
 

--- a/drake/automotive/test/simple_car_test.cc
+++ b/drake/automotive/test/simple_car_test.cc
@@ -40,7 +40,7 @@ class SimpleCarTest : public ::testing::Test {
 
   SimpleCarState<double>* continuous_state() {
     auto result = dynamic_cast<SimpleCarState<double>*>(
-        context_->get_mutable_continuous_state_vector());
+        &context_->get_mutable_continuous_state_vector());
     if (result == nullptr) { throw std::bad_cast(); }
     return result;
   }
@@ -209,7 +209,7 @@ TEST_F(SimpleCarTest, Derivatives) {
   // Grab a pointer to where the EvalTimeDerivatives results end up.
   const SimpleCarState<double>* const result =
       dynamic_cast<const SimpleCarState<double>*>(
-          derivatives_->get_mutable_vector());
+          &derivatives_->get_mutable_vector());
   ASSERT_NE(nullptr, result);
 
   // Starting state is all zeros.
@@ -378,7 +378,7 @@ TEST_F(SimpleCarTest, TransmogrifySymbolic) {
     auto input_value = std::make_unique<DrivingCommand<symbolic::Expression>>();
     other_context->FixInputPort(0, std::move(input_value));
     systems::VectorBase<symbolic::Expression>& xc =
-        *other_context->get_mutable_continuous_state_vector();
+        other_context->get_mutable_continuous_state_vector();
     for (int i = 0; i < xc.size(); ++i) {
       xc[i] = symbolic::Variable("xc" + std::to_string(i));
     }

--- a/drake/automotive/test/trajectory_car_test.cc
+++ b/drake/automotive/test/trajectory_car_test.cc
@@ -89,13 +89,13 @@ GTEST_TEST(TrajectoryCarTest, ConstantSpeedTest) {
     const double end_time = finish_position / it.speed;
 
     systems::Simulator<double> simulator(car_dut);
-    systems::Context<double>* context = simulator.get_mutable_context();
+    systems::Context<double>& context = simulator.get_mutable_context();
     std::unique_ptr<systems::SystemOutput<double>> all_output =
-        car_dut.AllocateOutput(*context);
+        car_dut.AllocateOutput(context);
 
     // Specify the initial position and speed.
     auto car_state = dynamic_cast<TrajectoryCarState<double>*>(
-        context->get_mutable_continuous_state_vector());
+        &context.get_mutable_continuous_state_vector());
     ASSERT_NE(nullptr, car_state);
     car_state->set_position(it.start_position);
     car_state->set_speed(it.speed);  // This speed will be held constant
@@ -113,7 +113,7 @@ GTEST_TEST(TrajectoryCarTest, ConstantSpeedTest) {
       const double kMaxErrorPos = 1e-6;
       const double kMaxErrorRad = 1e-6;
 
-      car_dut.CalcOutput(*context, all_output.get());
+      car_dut.CalcOutput(context, all_output.get());
 
       ASSERT_EQ(3, all_output->get_num_ports());
 
@@ -176,13 +176,13 @@ GTEST_TEST(TrajectoryCarTest, AccelerationInputTest) {
   auto context = dut.CreateDefaultContext();
   auto derivatives = dut.AllocateTimeDerivatives();
   auto car_derivatives = dynamic_cast<const TrajectoryCarState<double>*>(
-      derivatives->get_mutable_vector());
+      &derivatives->get_mutable_vector());
   ASSERT_NE(nullptr, car_derivatives);
   const TrajectoryCarParams<double> default_params;
 
   // Set the initial position and speed.
   auto car_state = dynamic_cast<TrajectoryCarState<double>*>(
-      context->get_mutable_continuous_state_vector());
+      &context->get_mutable_continuous_state_vector());
   ASSERT_NE(nullptr, car_state);
   car_state->set_position(kInitialPathPosition);
   car_state->set_speed(kInitialSpeed);
@@ -212,13 +212,13 @@ GTEST_TEST(TrajectoryCarTest, SaturatingSpeedTest) {
   auto context = dut.CreateDefaultContext();
   auto derivatives = dut.AllocateTimeDerivatives();
   auto car_derivatives = dynamic_cast<const TrajectoryCarState<double>*>(
-      derivatives->get_mutable_vector());
+      &derivatives->get_mutable_vector());
   ASSERT_NE(nullptr, car_derivatives);
   const TrajectoryCarParams<double> default_params;
 
   // Set the initial position and speed.
   auto car_state = dynamic_cast<TrajectoryCarState<double>*>(
-      context->get_mutable_continuous_state_vector());
+      &context->get_mutable_continuous_state_vector());
   ASSERT_NE(nullptr, car_state);
   car_state->set_position(kInitialPathPosition);
 

--- a/drake/automotive/trajectory_car.h
+++ b/drake/automotive/trajectory_car.h
@@ -160,11 +160,10 @@ class TrajectoryCar final : public systems::LeafSystem<T> {
 
     // Obtain the result structure.
     DRAKE_ASSERT(derivatives != nullptr);
-    systems::VectorBase<T>* const vector_derivatives =
+    systems::VectorBase<T>& vector_derivatives =
         derivatives->get_mutable_vector();
-    DRAKE_ASSERT(vector_derivatives);
     TrajectoryCarState<T>* const rates =
-        dynamic_cast<TrajectoryCarState<T>*>(vector_derivatives);
+        dynamic_cast<TrajectoryCarState<T>*>(&vector_derivatives);
     DRAKE_ASSERT(rates);
 
     ImplCalcTimeDerivatives(params, *state, *input, rates);

--- a/drake/examples/acrobot/acrobot_plant.cc
+++ b/drake/examples/acrobot/acrobot_plant.cc
@@ -187,7 +187,7 @@ template <typename T>
 AcrobotStateVector<T>* AcrobotWEncoder<T>::get_mutable_acrobot_state(
     systems::Context<T>* context) const {
   AcrobotStateVector<T>* x = dynamic_cast<AcrobotStateVector<T>*>(
-      this->GetMutableSubsystemContext(*acrobot_plant_, context)
+      &this->GetMutableSubsystemContext(*acrobot_plant_, context)
           .get_mutable_continuous_state_vector());
   DRAKE_DEMAND(x != nullptr);
   return x;
@@ -202,7 +202,7 @@ std::unique_ptr<systems::AffineSystem<double>> BalancingLQRController(
 
   // Set nominal state to the upright fixed point.
   AcrobotStateVector<double>* x = dynamic_cast<AcrobotStateVector<double>*>(
-      context->get_mutable_continuous_state_vector());
+      &context->get_mutable_continuous_state_vector());
   DRAKE_ASSERT(x != nullptr);
   x->set_theta1(M_PI);
   x->set_theta2(0.0);

--- a/drake/examples/acrobot/acrobot_plant_w_lcm.cc
+++ b/drake/examples/acrobot/acrobot_plant_w_lcm.cc
@@ -83,9 +83,9 @@ int DoMain() {
   // Sets an initial condition near the stable fixed point.
   systems::Context<double>& acrobot_context =
       diagram->GetMutableSubsystemContext(*acrobot,
-                                          simulator.get_mutable_context());
+                                          &simulator.get_mutable_context());
   AcrobotStateVector<double>* x0 = dynamic_cast<AcrobotStateVector<double>*>(
-      acrobot_context.get_mutable_continuous_state_vector());
+      &acrobot_context.get_mutable_continuous_state_vector());
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(0.1);
   x0->set_theta2(0.1);

--- a/drake/examples/acrobot/acrobot_run_lqr.cc
+++ b/drake/examples/acrobot/acrobot_run_lqr.cc
@@ -52,11 +52,11 @@ int do_main(int argc, char* argv[]) {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& acrobot_context =
       diagram->GetMutableSubsystemContext(*acrobot,
-                                          simulator.get_mutable_context());
+                                          &simulator.get_mutable_context());
 
   // Set an initial condition near the upright fixed point.
   AcrobotStateVector<double>* x0 = dynamic_cast<AcrobotStateVector<double>*>(
-      acrobot_context.get_mutable_continuous_state_vector());
+      &acrobot_context.get_mutable_continuous_state_vector());
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(M_PI + 0.1);
   x0->set_theta2(-.1);

--- a/drake/examples/acrobot/acrobot_run_lqr_w_estimator.cc
+++ b/drake/examples/acrobot/acrobot_run_lqr_w_estimator.cc
@@ -115,7 +115,7 @@ int do_main(int argc, char* argv[]) {
   // Set an initial condition near the upright fixed point.
   auto x0 = acrobot_w_encoder->get_mutable_acrobot_state(
       &(diagram->GetMutableSubsystemContext(*acrobot_w_encoder,
-                                            simulator.get_mutable_context())));
+                                            &simulator.get_mutable_context())));
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(M_PI + 0.1);
   x0->set_theta2(-.1);
@@ -123,15 +123,14 @@ int do_main(int argc, char* argv[]) {
   x0->set_theta2dot(0.0);
 
   // Set the initial conditions of the observer.
-  auto xhat0 = diagram
-                   ->GetMutableSubsystemContext(*observer,
-                                                simulator.get_mutable_context())
-                   .get_mutable_continuous_state_vector();
-  DRAKE_DEMAND(xhat0 != nullptr);
-  xhat0->SetAtIndex(0, M_PI);
-  xhat0->SetAtIndex(1, 0.0);
-  xhat0->SetAtIndex(2, 0.0);
-  xhat0->SetAtIndex(3, 0.0);
+  auto& xhat0 = diagram
+                    ->GetMutableSubsystemContext(
+                        *observer, &simulator.get_mutable_context())
+                    .get_mutable_continuous_state_vector();
+  xhat0.SetAtIndex(0, M_PI);
+  xhat0.SetAtIndex(1, 0.0);
+  xhat0.SetAtIndex(2, 0.0);
+  xhat0.SetAtIndex(3, 0.0);
 
   // Simulate.
   simulator.set_target_realtime_rate(FLAGS_realtime_factor);

--- a/drake/examples/acrobot/acrobot_run_passive.cc
+++ b/drake/examples/acrobot/acrobot_run_passive.cc
@@ -45,7 +45,7 @@ int do_main(int argc, char* argv[]) {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& acrobot_context =
       diagram->GetMutableSubsystemContext(*acrobot,
-                                          simulator.get_mutable_context());
+                                          &simulator.get_mutable_context());
 
   double tau = 0;
   acrobot_context.FixInputPort(0, Eigen::Matrix<double, 1, 1>::Constant(tau));
@@ -53,7 +53,7 @@ int do_main(int argc, char* argv[]) {
   // Set an initial condition that is sufficiently far from the downright fixed
   // point.
   AcrobotStateVector<double>* x0 = dynamic_cast<AcrobotStateVector<double>*>(
-      acrobot_context.get_mutable_continuous_state_vector());
+      &acrobot_context.get_mutable_continuous_state_vector());
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(1.0);
   x0->set_theta2(1.0);

--- a/drake/examples/acrobot/acrobot_run_swing_up.cc
+++ b/drake/examples/acrobot/acrobot_run_swing_up.cc
@@ -52,11 +52,11 @@ int do_main(int argc, char* argv[]) {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& acrobot_context =
       diagram->GetMutableSubsystemContext(*acrobot,
-                                          simulator.get_mutable_context());
+                                          &simulator.get_mutable_context());
 
   // Sets an initial condition near the upright fixed point.
   AcrobotStateVector<double>* x0 = dynamic_cast<AcrobotStateVector<double>*>(
-      acrobot_context.get_mutable_continuous_state_vector());
+      &acrobot_context.get_mutable_continuous_state_vector());
   DRAKE_DEMAND(x0 != nullptr);
   x0->set_theta1(0.1);
   x0->set_theta2(-0.1);

--- a/drake/examples/acrobot/acrobot_spong_controller.h
+++ b/drake/examples/acrobot/acrobot_spong_controller.h
@@ -43,7 +43,7 @@ class AcrobotSpongController : public systems::LeafSystem<T> {
 
     // Set nominal state to the upright fixed point.
     AcrobotStateVector<double>* x = dynamic_cast<AcrobotStateVector<double>*>(
-        context0->get_mutable_continuous_state_vector());
+        &context0->get_mutable_continuous_state_vector());
     DRAKE_ASSERT(x != nullptr);
     x->set_theta1(M_PI);
     x->set_theta2(0.0);
@@ -102,7 +102,7 @@ class AcrobotSpongController : public systems::LeafSystem<T> {
     auto context_acrobot = acrobot_.CreateDefaultContext();
     AcrobotStateVector<double>* x_acrobot =
         dynamic_cast<AcrobotStateVector<double>*>(
-            context_acrobot->get_mutable_continuous_state_vector());
+            &context_acrobot->get_mutable_continuous_state_vector());
 
     x_acrobot->set_theta1(x->theta1());
     x_acrobot->set_theta2(x->theta2());

--- a/drake/examples/acrobot/test/acrobot_urdf_dynamics_test.cc
+++ b/drake/examples/acrobot/test/acrobot_urdf_dynamics_test.cc
@@ -43,8 +43,8 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
     x = Eigen::Vector4d::Random();
     u = Vector1d::Random();
 
-    context_rbp->get_mutable_continuous_state_vector()->SetFromVector(x);
-    context_p->get_mutable_continuous_state_vector()->SetFromVector(x);
+    context_rbp->get_mutable_continuous_state_vector().SetFromVector(x);
+    context_p->get_mutable_continuous_state_vector().SetFromVector(x);
 
     u_rbp.GetMutableVectorData<double>()->SetFromVector(u);
     u_p.GetMutableVectorData<double>()->SetFromVector(u);

--- a/drake/examples/bead_on_a_wire/bead_on_a_wire-inl.h
+++ b/drake/examples/bead_on_a_wire/bead_on_a_wire-inl.h
@@ -68,7 +68,7 @@ Eigen::VectorXd BeadOnAWire<T>::DoEvalConstraintEquations(
   // Get the position of the bead.
   constexpr int three_d = 3;
   Eigen::Matrix<ArcLength, three_d, 1> x;
-  const auto position = context.get_continuous_state()->
+  const auto position = context.get_continuous_state().
       get_generalized_position().CopyToVector();
   for (int i = 0; i < three_d; ++i)
     x(i).value() = position[i];
@@ -109,7 +109,7 @@ Eigen::VectorXd BeadOnAWire<T>::DoEvalConstraintEquationsDot(
   //              d/dt atan2(x(2),x(1)) - | v(1) v(2) v(3) |
 
   // Compute df/dt (f⁻¹(x)). The result will be a vector.
-  const auto& xc = context.get_continuous_state()->get_vector();
+  const auto& xc = context.get_continuous_state().get_vector();
   Eigen::Matrix<BeadOnAWire<T>::ArcLength, three_d, 1> x;
   x(0).value() = xc.GetAtIndex(0);
   x(1).value() = xc.GetAtIndex(1);
@@ -143,7 +143,7 @@ template <typename T>
 void BeadOnAWire<T>::CopyStateOut(const systems::Context<T>& context,
                                   systems::BasicVector<T>* output) const {
   output->get_mutable_value() =
-      context.get_continuous_state()->CopyToVector();
+      context.get_continuous_state().CopyToVector();
 }
 
 /// Gets the number of constraint equations used for dynamics.
@@ -231,8 +231,7 @@ void BeadOnAWire<T>::DoCalcTimeDerivatives(
 
   // Obtain the structure we need to write into.
   DRAKE_ASSERT(derivatives != nullptr);
-  systems::VectorBase<T>* const f = derivatives->get_mutable_vector();
-  DRAKE_ASSERT(f != nullptr);
+  systems::VectorBase<T>& f = derivatives->get_mutable_vector();
 
   // Get the inputs.
   const auto input = this->EvalEigenVectorInput(context, 0);
@@ -270,8 +269,8 @@ void BeadOnAWire<T>::DoCalcTimeDerivatives(
                           dfds.dot(dfds);
 
     // Set derivative.
-    f->SetAtIndex(0, s_dot);
-    f->SetAtIndex(1, s_ddot);
+    f.SetAtIndex(0, s_dot);
+    f.SetAtIndex(1, s_ddot);
   } else {
     // Compute acceleration from unconstrained Newtonian dynamics.
     const T xdot = state.GetAtIndex(3);
@@ -282,12 +281,12 @@ void BeadOnAWire<T>::DoCalcTimeDerivatives(
     const Vector3<T> fext = input.segment(0, 3);
 
     // Set velocity components of derivative.
-    f->SetAtIndex(0, xdot);
-    f->SetAtIndex(1, ydot);
-    f->SetAtIndex(2, zdot);
-    f->SetAtIndex(3, fext(0));
-    f->SetAtIndex(4, fext(1));
-    f->SetAtIndex(5, fext(2) + get_gravitational_acceleration());
+    f.SetAtIndex(0, xdot);
+    f.SetAtIndex(1, ydot);
+    f.SetAtIndex(2, zdot);
+    f.SetAtIndex(3, fext(0));
+    f.SetAtIndex(4, fext(1));
+    f.SetAtIndex(5, fext(2) + get_gravitational_acceleration());
   }
 }
 
@@ -323,7 +322,7 @@ void BeadOnAWire<T>::SetDefaultState(const systems::Context<T>&,
     x0.resize(state_size);
     x0 << s, s_dot;
   }
-  state->get_mutable_continuous_state()->SetFromVector(x0);
+  state->get_mutable_continuous_state().SetFromVector(x0);
 }
 
 }  // namespace bead_on_a_wire

--- a/drake/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
+++ b/drake/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
@@ -53,8 +53,8 @@ class BeadOnAWireTest : public ::testing::Test {
 
 // Checks output is as expected.
 TEST_F(BeadOnAWireTest, Output) {
-  const systems::ContinuousState<double>& v = *context_abs_->
-                                               get_continuous_state();
+  const systems::ContinuousState<double>& v = context_abs_->
+                                                get_continuous_state();
   dut_abs_->CalcOutput(*context_abs_, output_abs_.get());
   for (int i = 0; i < v.size(); ++i)
     EXPECT_EQ(v[i], output_abs_->get_vector_data(0)->get_value()(i));
@@ -196,8 +196,8 @@ TEST_F(BeadOnAWireTest, ConstraintFunctionEval) {
                                            &inverse_vert_line_function);
 
   // Put the bead directly onto the wire.
-  systems::ContinuousState<double> &xc =
-      *context_abs_->get_mutable_continuous_state();
+  systems::ContinuousState<double>& xc =
+      context_abs_->get_mutable_continuous_state();
   const double s = 1.0;
   xc[0] = 0.0;
   xc[1] = 0.0;
@@ -219,8 +219,8 @@ TEST_F(BeadOnAWireTest, ConstraintFunctionEval) {
 TEST_F(BeadOnAWireTest, ConstraintDotFunctionEval) {
   // Put the bead directly onto the wire and make its velocity such that
   // it is not instantaneously leaving the wire.
-  systems::ContinuousState<double> &xc =
-      *context_abs_->get_mutable_continuous_state();
+  systems::ContinuousState<double>& xc =
+      context_abs_->get_mutable_continuous_state();
   const double s = 1.0;
   xc[0] = std::cos(s);
   xc[1] = std::sin(s);

--- a/drake/examples/bouncing_ball/ball-inl.h
+++ b/drake/examples/bouncing_ball/ball-inl.h
@@ -24,7 +24,7 @@ template <typename T>
 void Ball<T>::CopyStateOut(const systems::Context<T>& context,
                            systems::BasicVector<T>* output) const {
   output->get_mutable_value() =
-      context.get_continuous_state()->CopyToVector();
+      context.get_continuous_state().CopyToVector();
 }
 
 template <typename T>
@@ -36,12 +36,10 @@ void Ball<T>::DoCalcTimeDerivatives(
 
   // Obtain the structure we need to write into.
   DRAKE_ASSERT(derivatives != nullptr);
-  systems::VectorBase<T>* const new_derivatives =
-      derivatives->get_mutable_vector();
-  DRAKE_ASSERT(new_derivatives != nullptr);
+  systems::VectorBase<T>& new_derivatives = derivatives->get_mutable_vector();
 
-  new_derivatives->SetAtIndex(0, state.GetAtIndex(1));
-  new_derivatives->SetAtIndex(1, T(get_gravitational_acceleration()));
+  new_derivatives.SetAtIndex(0, state.GetAtIndex(1));
+  new_derivatives.SetAtIndex(1, T(get_gravitational_acceleration()));
 }
 
 template <typename T>
@@ -50,7 +48,7 @@ void Ball<T>::SetDefaultState(const systems::Context<T>&,
   DRAKE_DEMAND(state != nullptr);
   Vector2<T> x0;
   x0 << 10.0, 0.0;  // initial state values.
-  state->get_mutable_continuous_state()->SetFromVector(x0);
+  state->get_mutable_continuous_state().SetFromVector(x0);
 }
 
 }  // namespace bouncing_ball

--- a/drake/examples/bouncing_ball/bouncing_ball-inl.h
+++ b/drake/examples/bouncing_ball/bouncing_ball-inl.h
@@ -41,12 +41,12 @@ void BouncingBall<T>::PerformReset(systems::Context<T>* context) const {
   DRAKE_ASSERT_VOID(systems::System<T>::CheckValidContext(*context));
 
   // Define a pointer to the continuous state in the context.
-  const auto result = context->get_mutable_continuous_state_vector();
+  auto& result = context->get_mutable_continuous_state_vector();
 
   // Perform the reset: map the position to itself and negate the
   // velocity and attenuate by the coefficient of restitution.
-  auto state = context->get_mutable_continuous_state_vector();
-  result->SetAtIndex(1, -1.0 * this->restitution_coef_ * state->GetAtIndex(1));
+  auto& state = context->get_mutable_continuous_state_vector();
+  result.SetAtIndex(1, -1.0 * this->restitution_coef_ * state.GetAtIndex(1));
 }
 
 template <typename T>
@@ -107,12 +107,12 @@ void BouncingBall<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* next_state) const {
-  systems::VectorBase<T>* next_cstate =
-      next_state->get_mutable_continuous_state()->get_mutable_vector();
+  systems::VectorBase<T>& next_cstate =
+      next_state->get_mutable_continuous_state().get_mutable_vector();
 
   // Get present state.
   const systems::VectorBase<T>& cstate =
-      context.get_continuous_state()->get_vector();
+      context.get_continuous_state().get_vector();
 
   // Copy the present state to the new one.
   next_state->CopyFrom(context.get_state());
@@ -121,8 +121,8 @@ void BouncingBall<T>::DoCalcUnrestrictedUpdate(
   DRAKE_DEMAND(cstate.GetAtIndex(1) <= 0.0);
 
   // Update the velocity.
-  next_cstate->SetAtIndex(1,
-                          cstate.GetAtIndex(1) * this->restitution_coef_ * -1.);
+  next_cstate.SetAtIndex(1,
+                         cstate.GetAtIndex(1) * this->restitution_coef_ * -1.);
 }
 
 }  // namespace bouncing_ball

--- a/drake/examples/bouncing_ball/test/ball_test.cc
+++ b/drake/examples/bouncing_ball/test/ball_test.cc
@@ -17,16 +17,16 @@ class BallTest : public ::testing::Test {
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 
-  systems::VectorBase<double>* continuous_state() {
+  systems::VectorBase<double>& continuous_state() {
     return context_->get_mutable_continuous_state_vector();
   }
 
   const systems::VectorBase<double>& generalized_position() {
-    return context_->get_continuous_state()->get_generalized_position();
+    return context_->get_continuous_state().get_generalized_position();
   }
 
   const systems::VectorBase<double>& generalized_velocity() {
-    return context_->get_continuous_state()->get_generalized_velocity();
+    return context_->get_continuous_state().get_generalized_velocity();
   }
 
   std::unique_ptr<systems::System<double>> dut_;  //< The device under test.
@@ -53,8 +53,8 @@ TEST_F(BallTest, Output) {
   EXPECT_EQ(0.0, result->GetAtIndex(1));
 
   // New state just propagates through.
-  continuous_state()->SetAtIndex(0, 1.0);
-  continuous_state()->SetAtIndex(1, 2.0);
+  continuous_state().SetAtIndex(0, 1.0);
+  continuous_state().SetAtIndex(1, 2.0);
   dut_->CalcOutput(*context_, output_.get());
   EXPECT_EQ(1.0, result->GetAtIndex(0));
   EXPECT_EQ(2.0, result->GetAtIndex(1));
@@ -62,18 +62,18 @@ TEST_F(BallTest, Output) {
 
 TEST_F(BallTest, Derivatives) {
   // Grab a pointer to where the EvalTimeDerivatives results will be saved.
-  const auto result = derivatives_->get_mutable_vector();
+  const auto& result = derivatives_->get_mutable_vector();
 
   // Evaluate time derivatives.
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
-  EXPECT_EQ(0.0, result->GetAtIndex(0));
-  EXPECT_EQ(-9.81, result->GetAtIndex(1));
+  EXPECT_EQ(0.0, result.GetAtIndex(0));
+  EXPECT_EQ(-9.81, result.GetAtIndex(1));
 
   // Test at non-zero velocity.
-  continuous_state()->SetAtIndex(1, 5.3);
+  continuous_state().SetAtIndex(1, 5.3);
   dut_->CalcTimeDerivatives(*context_, derivatives_.get());
-  EXPECT_EQ(5.3, result->GetAtIndex(0));
-  EXPECT_EQ(-9.81, result->GetAtIndex(1));
+  EXPECT_EQ(5.3, result.GetAtIndex(0));
+  EXPECT_EQ(-9.81, result.GetAtIndex(1));
 }
 
 TEST_F(BallTest, Accessors) {

--- a/drake/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/drake/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -75,7 +75,7 @@ class BouncingBallTest : public ::testing::Test {
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 
-  systems::VectorBase<double>* continuous_state() {
+  systems::VectorBase<double>& continuous_state() {
     return context_->get_mutable_continuous_state_vector();
   }
 
@@ -91,20 +91,20 @@ TEST_F(BouncingBallTest, Guard) {
 
   // Evaluate at a state where the ball is rising.
   // The guard should be positive, meaning a mode transition cannot be made.
-  continuous_state()->SetAtIndex(0, 1.7);
-  continuous_state()->SetAtIndex(1, 2.3);
+  continuous_state().SetAtIndex(0, 1.7);
+  continuous_state().SetAtIndex(1, 2.3);
   EXPECT_EQ(2.3, dut_->EvalGuard(*context_));
 
   // Evaluate at a state where the ball is falling.
   // The guard should be positive, meaning a mode transition cannot be made.
-  continuous_state()->SetAtIndex(0, 1.7);
-  continuous_state()->SetAtIndex(1, -2.0);
+  continuous_state().SetAtIndex(0, 1.7);
+  continuous_state().SetAtIndex(1, -2.0);
   EXPECT_EQ(1.7, dut_->EvalGuard(*context_));
 
   // Evaluate at the moment of impact, where the ball is falling.
   // The guard is non-positive, so a mode transition is possible.
-  continuous_state()->SetAtIndex(0, 0.0);
-  continuous_state()->SetAtIndex(1, -3.7);
+  continuous_state().SetAtIndex(0, 0.0);
+  continuous_state().SetAtIndex(1, -3.7);
   EXPECT_EQ(0.0, dut_->EvalGuard(*context_));
 }
 
@@ -119,8 +119,8 @@ TEST_F(BouncingBallTest, Reset) {
   EXPECT_EQ(0.0, result->GetAtIndex(1));
 
   // Perform a reset at the moment of impact.
-  continuous_state()->SetAtIndex(0, 0.0);
-  continuous_state()->SetAtIndex(1, -5.7);
+  continuous_state().SetAtIndex(0, 0.0);
+  continuous_state().SetAtIndex(1, -5.7);
   dut_->PerformReset(context_.get());
   dut_->CalcOutput(*context_, output_.get());
   EXPECT_EQ(0.0, result->GetAtIndex(0));
@@ -136,21 +136,21 @@ TEST_F(BouncingBallTest, Simulate) {
   // Prepare to integrate.
   drake::systems::Simulator<double> simulator(*dut_, std::move(context_));
   simulator.reset_integrator<systems::RungeKutta3Integrator<double>>(*dut_,
-                                              simulator.get_mutable_context());
+      &simulator.get_mutable_context());
   simulator.get_mutable_integrator()->set_fixed_step_mode(true);
   simulator.get_mutable_integrator()->set_requested_minimum_step_size(1e-3);
   simulator.get_mutable_integrator()->set_maximum_step_size(1e-3);
   simulator.Initialize();
 
   // Set the initial state for the bouncing ball.
-  systems::VectorBase<double>* xc = simulator.get_mutable_context()->
+  systems::VectorBase<double>& xc = simulator.get_mutable_context().
       get_mutable_continuous_state_vector();
-  xc->SetAtIndex(0, x0);
-  xc->SetAtIndex(1, v0);
+  xc.SetAtIndex(0, x0);
+  xc.SetAtIndex(1, v0);
 
   // Integrate.
   simulator.StepTo(t_final);
-  EXPECT_EQ(simulator.get_mutable_context()->get_time(), t_final);
+  EXPECT_EQ(simulator.get_mutable_context().get_time(), t_final);
 
   // Check against closed form solution for the bouncing ball. We anticipate
   // some small integration error.
@@ -159,15 +159,15 @@ TEST_F(BouncingBallTest, Simulate) {
   std::tie(height, velocity) = CalcClosedFormHeightAndVelocity(
                                     dut_->get_gravitational_acceleration(),
                                     dut_->get_restitution_coef(), x0, t_final);
-  EXPECT_NEAR(xc->GetAtIndex(0), height, tol);
-  EXPECT_NEAR(xc->GetAtIndex(1), velocity, tol);
+  EXPECT_NEAR(xc.GetAtIndex(0), height, tol);
+  EXPECT_NEAR(xc.GetAtIndex(1), velocity, tol);
 
   // Try again in variable step mode.
-  simulator.get_mutable_context()->set_time(0.0);
-  xc->SetAtIndex(0, x0);
-  xc->SetAtIndex(1, v0);
+  simulator.get_mutable_context().set_time(0.0);
+  xc.SetAtIndex(0, x0);
+  xc.SetAtIndex(1, v0);
   simulator.reset_integrator<systems::RungeKutta3Integrator<double>>(*dut_,
-                                              simulator.get_mutable_context());
+      &simulator.get_mutable_context());
   simulator.get_mutable_integrator()->set_fixed_step_mode(false);
   simulator.get_mutable_integrator()->set_requested_minimum_step_size(1e-8);
   simulator.get_mutable_integrator()->set_maximum_step_size(1e-2);
@@ -176,12 +176,12 @@ TEST_F(BouncingBallTest, Simulate) {
 
   // Integrate.
   simulator.StepTo(t_final);
-  EXPECT_EQ(simulator.get_mutable_context()->get_time(), t_final);
+  EXPECT_EQ(simulator.get_mutable_context().get_time(), t_final);
   std::tie(height, velocity) = CalcClosedFormHeightAndVelocity(
                                     dut_->get_gravitational_acceleration(),
                                     dut_->get_restitution_coef(), x0, t_final);
-  EXPECT_NEAR(xc->GetAtIndex(0), height, tol);
-  EXPECT_NEAR(xc->GetAtIndex(1), velocity, tol);
+  EXPECT_NEAR(xc.GetAtIndex(0), height, tol);
+  EXPECT_NEAR(xc.GetAtIndex(1), velocity, tol);
 }
 
 }  // namespace

--- a/drake/examples/contact_model/bowling_ball.cc
+++ b/drake/examples/contact_model/bowling_ball.cc
@@ -124,12 +124,13 @@ int main() {
 
   // Create simulator.
   auto simulator = std::make_unique<Simulator<double>>(*diagram);
-  auto context = simulator->get_mutable_context();
+  Context<double>& context = simulator->get_mutable_context();
   simulator->reset_integrator<RungeKutta2Integrator<double>>(*diagram,
                                                              FLAGS_timestep,
-                                                             context);
+                                                             &context);
   // Set initial state.
-  auto& plant_context = diagram->GetMutableSubsystemContext(plant, context);
+  Context<double>& plant_context =
+      diagram->GetMutableSubsystemContext(plant, &context);
 
   // 1 floating quat joint = |xyz|, |q|, |w|, |xyzdot| = 3 + 4 + 3 + 3.
   const int kStateSize = 13 * (1 + FLAGS_pin_count);

--- a/drake/examples/contact_model/rigid_gripper.cc
+++ b/drake/examples/contact_model/rigid_gripper.cc
@@ -124,9 +124,9 @@ int main() {
   const std::unique_ptr<systems::Diagram<double>> model = builder.Build();
   systems::Simulator<double> simulator(*model);
 
-  auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
 
-  simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, context);
+  simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, &context);
   simulator.get_mutable_integrator()->request_initial_step_size_target(1e-4);
   simulator.get_mutable_integrator()->set_target_accuracy(FLAGS_accuracy);
   std::cout << "Variable-step integrator accuracy: " << FLAGS_accuracy << "\n";
@@ -139,7 +139,7 @@ int main() {
   int step_count =
       static_cast<int>(std::ceil(FLAGS_sim_duration / kPrintPeriod));
   for (int i = 1; i <= step_count; ++i) {
-    double t = context->get_time();
+    double t = context.get_time();
     std::cout << "time: " << t << "\n";
     simulator.StepTo(i * kPrintPeriod);
   }

--- a/drake/examples/contact_model/sliding_bricks.cc
+++ b/drake/examples/contact_model/sliding_bricks.cc
@@ -119,12 +119,13 @@ int main() {
 
   // Create simulator.
   auto simulator = std::make_unique<Simulator<double>>(*diagram);
-  auto context = simulator->get_mutable_context();
+  Context<double>& context = simulator->get_mutable_context();
   simulator->reset_integrator<RungeKutta2Integrator<double>>(*diagram,
                                                              FLAGS_timestep,
-                                                             context);
+                                                             &context);
   // Set initial state.
-  auto& plant_context = diagram->GetMutableSubsystemContext(plant, context);
+  Context<double>& plant_context =
+      diagram->GetMutableSubsystemContext(plant, &context);
   // 6 1-dof joints * 2 = 6 * (x, ẋ) * 2
   const int kStateSize = 24;
   DRAKE_DEMAND(plant_context.get_continuous_state_vector().size() ==

--- a/drake/examples/cubic_polynomial/region_of_attraction.cc
+++ b/drake/examples/cubic_polynomial/region_of_attraction.cc
@@ -60,7 +60,7 @@ void ComputeRegionOfAttraction() {
   const Variable& x = xvec(0);
 
   // Extract the polynomial dynamics.
-  context->get_mutable_continuous_state_vector()->SetAtIndex(0, x);
+  context->get_mutable_continuous_state_vector().SetAtIndex(0, x);
   system.CalcTimeDerivatives(*context, derivatives.get());
 
   // Define the Lyapunov function.

--- a/drake/examples/geometry_world/bouncing_ball_plant.cc
+++ b/drake/examples/geometry_world/bouncing_ball_plant.cc
@@ -49,9 +49,9 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
   using std::max;
 
   const BouncingBallVector<T>& state = get_state(context);
-  BouncingBallVector<T>* derivative_vector = get_mutable_state(derivatives);
+  BouncingBallVector<T>& derivative_vector = get_mutable_state(derivatives);
 
-  derivative_vector->set_z(state.zdot());
+  derivative_vector.set_z(state.zdot());
 
   const T& x = -state.z();        // Penetration depth, > 0 at penetration.
   const T& xdot = -state.zdot();  // Penetration rate, > 0 implies increasing
@@ -59,7 +59,7 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
 
   const T fN = max(0.0, k_ * x * (1.0 - d_ * xdot));
 
-  derivative_vector->set_zdot((- m_ * g_ + fN) / m_);
+  derivative_vector.set_zdot((- m_ * g_ + fN) / m_);
 }
 
 template class BouncingBallPlant<double>;

--- a/drake/examples/geometry_world/bouncing_ball_plant.h
+++ b/drake/examples/geometry_world/bouncing_ball_plant.h
@@ -30,11 +30,11 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
   const systems::OutputPort<T>& get_state_output_port() const;
 
   void set_z(MyContext* context, const T& z) const {
-    get_mutable_state(context)->set_z(z);
+    get_mutable_state(context).set_z(z);
   }
 
   void set_zdot(MyContext* context, const T& zdot) const {
-    get_mutable_state(context)->set_zdot(zdot);
+    get_mutable_state(context).set_zdot(zdot);
   }
 
   /** Mass in kg. */
@@ -62,9 +62,9 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
     return dynamic_cast<const BouncingBallVector<T>&>(cstate.get_vector());
   }
 
-  static BouncingBallVector<T>* get_mutable_state(
+  static BouncingBallVector<T>& get_mutable_state(
       MyContinuousState* cstate) {
-    return dynamic_cast<BouncingBallVector<T>*>(cstate->get_mutable_vector());
+    return dynamic_cast<BouncingBallVector<T>&>(cstate->get_mutable_vector());
   }
 
   BouncingBallVector<T>* get_mutable_state_output(MyOutput *output) const {
@@ -73,11 +73,11 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
   }
 
   static const BouncingBallVector<T>& get_state(const MyContext& context) {
-    return get_state(*context.get_continuous_state());
+    return get_state(context.get_continuous_state());
   }
 
-  static BouncingBallVector<T>* get_mutable_state(MyContext* context) {
-    return get_mutable_state(context->get_mutable_continuous_state());
+  static BouncingBallVector<T>& get_mutable_state(MyContext* context) {
+    return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
   const Vector2<T> init_position_;

--- a/drake/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/drake/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -22,7 +22,7 @@ int do_main() {
                              double z, double zdot) {
     systems::Context<double>& ball_context =
         diagram->GetMutableSubsystemContext(*system,
-            simulator.get_mutable_context());
+            &simulator.get_mutable_context());
     system->set_z(&ball_context, z);
     system->set_zdot(&ball_context, zdot);
   };

--- a/drake/examples/geometry_world/solar_system.cc
+++ b/drake/examples/geometry_world/solar_system.cc
@@ -66,7 +66,7 @@ template <typename T>
 void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
                      systems::State<T>* state) const {
   DRAKE_DEMAND(state != nullptr);
-  ContinuousState<T>* xc = state->get_mutable_continuous_state();
+  ContinuousState<T>& xc = state->get_mutable_continuous_state();
   VectorX<T> initial_state;
   initial_state.resize(kBodyCount * 2);
   // clang-format off
@@ -79,11 +79,11 @@ void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
                    2 * M_PI / 6,    // Mars revolution lasts 6 seconds.
                    2 * M_PI / 1.1;  // phobos revolution lasts 1.1 seconds.
   // clang-format on
-  DRAKE_DEMAND(xc->size() == initial_state.size());
-  xc->SetFromVector(initial_state);
-  DiscreteValues<T>* xd = state->get_mutable_discrete_state();
-  for (int i = 0; i < xd->num_groups(); i++) {
-    BasicVector<T>& s = xd->get_mutable_vector(i);
+  DRAKE_DEMAND(xc.size() == initial_state.size());
+  xc.SetFromVector(initial_state);
+  DiscreteValues<T>& xd = state->get_mutable_discrete_state();
+  for (int i = 0; i < xd.num_groups(); i++) {
+    BasicVector<T>& s = xd.get_mutable_vector(i);
     s.SetFromVector(VectorX<T>::Zero(s.size()));
   }
 }
@@ -280,9 +280,9 @@ template <typename T>
 void SolarSystem<T>::DoCalcTimeDerivatives(
     const MyContext& context, MyContinuousState* derivatives) const {
   const BasicVector<T>& state = get_state(context);
-  BasicVector<T>* derivative_vector = get_mutable_state(derivatives);
-  derivative_vector->SetZero();
-  derivative_vector->get_mutable_value().head(kBodyCount) =
+  BasicVector<T>& derivative_vector = get_mutable_state(derivatives);
+  derivative_vector.SetZero();
+  derivative_vector.get_mutable_value().head(kBodyCount) =
       state.get_value().tail(kBodyCount);
 }
 

--- a/drake/examples/geometry_world/solar_system.h
+++ b/drake/examples/geometry_world/solar_system.h
@@ -132,12 +132,12 @@ class SolarSystem : public systems::LeafSystem<T> {
     return dynamic_cast<const systems::BasicVector<T>&>(cstate.get_vector());
   }
 
-  static systems::BasicVector<T>* get_mutable_state(MyContinuousState* cstate) {
-    return dynamic_cast<systems::BasicVector<T>*>(cstate->get_mutable_vector());
+  static systems::BasicVector<T>& get_mutable_state(MyContinuousState* cstate) {
+    return dynamic_cast<systems::BasicVector<T>&>(cstate->get_mutable_vector());
   }
 
   static const systems::BasicVector<T>& get_state(const MyContext& context) {
-    return get_state(*context.get_continuous_state());
+    return get_state(context.get_continuous_state());
   }
 
   // Geometry source identifier for this system to interact with geometry system

--- a/drake/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
+++ b/drake/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
@@ -111,7 +111,7 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     // Initializes.
     auto& plan_eval_context =
         diagram_->GetMutableSubsystemContext(*plan_eval, context_.get());
-    plan_eval->Initialize(robot_status, plan_eval_context.get_mutable_state());
+    plan_eval->Initialize(robot_status, &plan_eval_context.get_mutable_state());
 
     // Computes results.
     auto events = diagram_->AllocateCompositeEventCollection();
@@ -120,7 +120,7 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
     std::unique_ptr<systems::State<double>> state = context_->CloneState();
     diagram_->CalcUnrestrictedUpdate(
         *context_, events->get_unrestricted_update_events(), state.get());
-    context_->get_mutable_state()->CopyFrom(*state);
+    context_->get_mutable_state().CopyFrom(*state);
     diagram_->CalcOutput(*context_, output_.get());
   }
 

--- a/drake/examples/humanoid_controller/valkyrie_balancing_demo.cc
+++ b/drake/examples/humanoid_controller/valkyrie_balancing_demo.cc
@@ -42,7 +42,7 @@ void controller_loop() {
   const systems::AbstractValue& first_msg = loop.WaitForMessage();
   double msg_time =
       loop.get_message_to_time_converter().GetTimeInSeconds(first_msg);
-  loop.get_mutable_context()->set_time(msg_time);
+  loop.get_mutable_context().set_time(msg_time);
 
   // Decodes the message into q and v.
   const bot_core::robot_state_t& raw_msg =
@@ -65,8 +65,8 @@ void controller_loop() {
   // Sets plan eval's desired to the measured state.
   systems::Context<double>& plan_eval_context =
       valkyrie_controller.GetMutableSubsystemContext(
-          *plan_eval, loop.get_mutable_context());
-  plan_eval->Initialize(robot_status, plan_eval_context.get_mutable_state());
+          *plan_eval, &loop.get_mutable_context());
+  plan_eval->Initialize(robot_status, &plan_eval_context.get_mutable_state());
 
   // Starts the loop.
   loop.RunToSecondsAssumingInitialized();

--- a/drake/examples/kinova_jaco_arm/run_passive_jaco_demo.cc
+++ b/drake/examples/kinova_jaco_arm/run_passive_jaco_demo.cc
@@ -76,12 +76,12 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
 
   Context<double>& jaco_context = diagram->GetMutableSubsystemContext(
-      *plant, simulator.get_mutable_context());
+      *plant, &simulator.get_mutable_context());
 
   // Sets (arbitrary) initial conditions.
   // See the @file docblock in jaco_common.h for joint index descriptions.
-  VectorBase<double>* x0 = jaco_context.get_mutable_continuous_state_vector();
-  x0->SetAtIndex(1, 0.5);  // shoulder fore/aft angle [rad]
+  VectorBase<double>& x0 = jaco_context.get_mutable_continuous_state_vector();
+  x0.SetAtIndex(1, 0.5);  // shoulder fore/aft angle [rad]
 
   simulator.Initialize();
 
@@ -91,9 +91,9 @@ int DoMain() {
 
   // Ensures the simulation was successful.
   const Context<double>& context = simulator.get_context();
-  const ContinuousState<double>* state = context.get_continuous_state();
-  const VectorBase<double>& position_vector = state->get_generalized_position();
-  const VectorBase<double>& velocity_vector = state->get_generalized_velocity();
+  const ContinuousState<double>& state = context.get_continuous_state();
+  const VectorBase<double>& position_vector = state.get_generalized_position();
+  const VectorBase<double>& velocity_vector = state.get_generalized_velocity();
 
   const int num_q = position_vector.size();
   const int num_v = velocity_vector.size();

--- a/drake/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
+++ b/drake/examples/kinova_jaco_arm/run_setpose_jaco_demo.cc
@@ -95,14 +95,14 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
 
   systems::Context<double>& jaco_context = diagram->GetMutableSubsystemContext(
-      *plant, simulator.get_mutable_context());
+      *plant, &simulator.get_mutable_context());
 
   // Sets some (arbitrary) initial conditions.
   // See the @file docblock in jaco_common.h for joint index descriptions.
-  systems::VectorBase<double>* x0 =
+  systems::VectorBase<double>& x0 =
       jaco_context.get_mutable_continuous_state_vector();
-  x0->SetAtIndex(1, -1.57);  // shoulder fore/aft
-  x0->SetAtIndex(2, -1.57);  // elbow fore/aft
+  x0.SetAtIndex(1, -1.57);  // shoulder fore/aft
+  x0.SetAtIndex(2, -1.57);  // elbow fore/aft
 
   simulator.Initialize();
   simulator.set_target_realtime_rate(1);

--- a/drake/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
+++ b/drake/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
@@ -44,9 +44,9 @@ GTEST_TEST(JacoLcmTest, JacoCommandPassthroughTest) {
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
-  update->SetFrom(*context->get_mutable_discrete_state());
+  update->SetFrom(context->get_mutable_discrete_state());
   diagram->CalcDiscreteVariableUpdates(*context, update.get());
-  context->get_mutable_discrete_state()->CopyFrom(*update);
+  context->get_mutable_discrete_state().CopyFrom(*update);
   diagram->CalcOutput(*context, output.get());
 
   lcmt_jaco_command command_out =
@@ -114,9 +114,9 @@ GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       diagram->AllocateDiscreteVariables();
-  update->SetFrom(*context->get_mutable_discrete_state());
+  update->SetFrom(context->get_mutable_discrete_state());
   diagram->CalcDiscreteVariableUpdates(*context, update.get());
-  context->get_mutable_discrete_state()->CopyFrom(*update);
+  context->get_mutable_discrete_state().CopyFrom(*update);
   diagram->CalcOutput(*context, output.get());
 
   lcmt_jaco_status status_out =

--- a/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -296,7 +296,7 @@ int DoMain() {
   Simulator<double> simulator(*sys);
 
   simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
-      *sys, 1e-3, simulator.get_mutable_context());
+      *sys, 1e-3, &simulator.get_mutable_context());
 
   // TODO(rcory): Explore other integration schemes here.
 //  simulator.reset_integrator<systems::ImplicitEulerIntegrator<double>>(

--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
@@ -307,16 +307,16 @@ int DoMain(void) {
   simulator.Initialize();
   simulator.set_target_realtime_rate(FLAGS_realtime_rate);
   simulator.reset_integrator<RungeKutta2Integrator<double>>(*sys,
-      FLAGS_dt, simulator.get_mutable_context());
+      FLAGS_dt, &simulator.get_mutable_context());
   simulator.get_mutable_integrator()->set_maximum_step_size(FLAGS_dt);
   simulator.get_mutable_integrator()->set_fixed_step_mode(true);
 
   auto& plan_source_context = sys->GetMutableSubsystemContext(
-      *iiwa_trajectory_generator, simulator.get_mutable_context());
+      *iiwa_trajectory_generator, &simulator.get_mutable_context());
   iiwa_trajectory_generator->Initialize(
       plan_source_context.get_time(),
       Eigen::VectorXd::Zero(7),
-      plan_source_context.get_mutable_state());
+      &plan_source_context.get_mutable_state());
 
   // Step the simulator in some small increment.  Between steps, check
   // to see if the state machine thinks we're done, and if so that the

--- a/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -129,15 +129,15 @@ int DoMain() {
   for (int i = 0; i < kNumJoints; i++)
     q0[i] = first_status.joint_position_measured[i];
 
-  systems::Context<double>* diagram_context = loop.get_mutable_context();
+  systems::Context<double>& diagram_context = loop.get_mutable_context();
   systems::Context<double>& status_sub_context =
-      diagram->GetMutableSubsystemContext(*status_sub, diagram_context);
+      diagram->GetMutableSubsystemContext(*status_sub, &diagram_context);
   status_sub->SetDefaultContext(&status_sub_context);
 
   // Explicit initialization.
-  diagram_context->set_time(msg_time);
+  diagram_context.set_time(msg_time);
   auto& plan_interpolator_context =
-      diagram->GetMutableSubsystemContext(*plan_interpolator, diagram_context);
+      diagram->GetMutableSubsystemContext(*plan_interpolator, &diagram_context);
   plan_interpolator->Initialize(msg_time, q0, &plan_interpolator_context);
 
   loop.RunToSecondsAssumingInitialized();

--- a/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -169,7 +169,7 @@ int DoMain() {
 
   command_receiver->set_initial_position(
       &sys->GetMutableSubsystemContext(*command_receiver,
-                                       simulator.get_mutable_context()),
+                                       &simulator.get_mutable_context()),
       VectorX<double>::Zero(tree.get_num_positions()));
 
   // Simulate for a very long time.

--- a/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
+++ b/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
@@ -61,7 +61,7 @@ void LcmPlanInterpolator::Initialize(double plan_start_time,
                                      systems::Context<double>* context) const {
   robot_plan_interpolator_->Initialize(
       plan_start_time, q0,
-      this->GetMutableSubsystemContext(*robot_plan_interpolator_, context)
+      &this->GetMutableSubsystemContext(*robot_plan_interpolator_, context)
           .get_mutable_state());
 }
 

--- a/drake/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
+++ b/drake/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
@@ -57,7 +57,7 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       dut.AllocateDiscreteVariables();
-  update->SetFrom(*context->get_mutable_discrete_state());
+  update->SetFrom(context->get_mutable_discrete_state());
   dut.CalcDiscreteVariableUpdates(*context, update.get());
   context->set_discrete_state(std::move(update));
 
@@ -135,7 +135,7 @@ GTEST_TEST(IiwaLcmTest, IiwaStatusReceiverTest) {
 
   std::unique_ptr<systems::DiscreteValues<double>> update =
       dut.AllocateDiscreteVariables();
-  update->SetFrom(*context->get_mutable_discrete_state());
+  update->SetFrom(context->get_mutable_discrete_state());
   dut.CalcDiscreteVariableUpdates(*context, update.get());
   context->set_discrete_state(std::move(update));
 

--- a/drake/examples/particles/particle.cc
+++ b/drake/examples/particles/particle.cc
@@ -34,15 +34,15 @@ void Particle<T>::DoCalcTimeDerivatives(
   const systems::VectorBase<T>& continuous_state_vector =
     context.get_continuous_state_vector();
   // Obtain the structure we need to write into.
-  systems::VectorBase<T>* const derivatives_vector =
+  systems::VectorBase<T>& derivatives_vector =
     derivatives->get_mutable_vector();
   // Get current input acceleration value.
   const systems::BasicVector<T>* input_vector =
       this->EvalVectorInput(context, 0);
   // Set the derivatives. The first one is
   // velocity and the second one is acceleration.
-  derivatives_vector->SetAtIndex(0, continuous_state_vector.GetAtIndex(1));
-  derivatives_vector->SetAtIndex(1, input_vector->GetAtIndex(0));
+  derivatives_vector.SetAtIndex(0, continuous_state_vector.GetAtIndex(1));
+  derivatives_vector.SetAtIndex(1, input_vector->GetAtIndex(0));
 }
 
 template class Particle<double>;

--- a/drake/examples/particles/test/particle_test.cc
+++ b/drake/examples/particles/test/particle_test.cc
@@ -45,11 +45,11 @@ TYPED_TEST_CASE_P(ParticleTest);
 /// state (position and velocity).
 TYPED_TEST_P(ParticleTest, OutputTest) {
   // Initialize state.
-  systems::VectorBase<TypeParam>* continuous_state_vector =
+  systems::VectorBase<TypeParam>& continuous_state_vector =
     this->context_->get_mutable_continuous_state_vector();
-  continuous_state_vector->SetAtIndex(
+  continuous_state_vector.SetAtIndex(
       0, static_cast<TypeParam>(10.0));  // x0 = 10 m.
-  continuous_state_vector->SetAtIndex(
+  continuous_state_vector.SetAtIndex(
       1, static_cast<TypeParam>(1.0));  // x1 = 1 m/s.
   // Compute outputs.
   this->dut_->CalcOutput(*this->context_, this->output_.get());
@@ -74,11 +74,11 @@ TYPED_TEST_P(ParticleTest, DerivativesTest) {
   input->SetAtIndex(0, static_cast<TypeParam>(1.0));  // u0 = 1 m/s^2
   this->context_->FixInputPort(0, std::move(input));
   // Set state.
-  systems::VectorBase<TypeParam>* continuous_state_vector =
+  systems::VectorBase<TypeParam>& continuous_state_vector =
     this->context_->get_mutable_continuous_state_vector();
-  continuous_state_vector->SetAtIndex(
+  continuous_state_vector.SetAtIndex(
       0, static_cast<TypeParam>(0.0));  // x0 = 0 m
-  continuous_state_vector->SetAtIndex(
+  continuous_state_vector.SetAtIndex(
       1, static_cast<TypeParam>(2.0));  // x1 = 2 m/s
   // Compute derivatives.
   this->dut_->CalcTimeDerivatives(*this->context_, this->derivatives_.get());

--- a/drake/examples/particles/uniformly_accelerated_particle.cc
+++ b/drake/examples/particles/uniformly_accelerated_particle.cc
@@ -114,10 +114,10 @@ UniformlyAcceleratedParticle<T>::CreateContext(
   // Allocate context.
   auto context = this->AllocateContext();
   // Set continuous state.
-  systems::VectorBase<T>* cstate =
+  systems::VectorBase<T>& cstate =
     context->get_mutable_continuous_state_vector();
-  cstate->SetAtIndex(0, position);
-  cstate->SetAtIndex(1, velocity);
+  cstate.SetAtIndex(0, position);
+  cstate.SetAtIndex(1, velocity);
   return context;
 }
 

--- a/drake/examples/pendulum/energy_shaping_simulation.cc
+++ b/drake/examples/pendulum/energy_shaping_simulation.cc
@@ -87,17 +87,17 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& pendulum_context =
       diagram->GetMutableSubsystemContext(*pendulum,
-                                          simulator.get_mutable_context());
-  auto state = pendulum->get_mutable_state(&pendulum_context);
+                                          &simulator.get_mutable_context());
+  auto& state = pendulum->get_mutable_state(&pendulum_context);
 
   // Desired energy is the total energy when the pendulum is at the upright.
-  state->set_theta(M_PI);
-  state->set_thetadot(0.0);
+  state.set_theta(M_PI);
+  state.set_thetadot(0.0);
   const double desired_energy = pendulum->CalcTotalEnergy(pendulum_context);
 
   // Set initial conditions (near the bottom).
-  state->set_theta(0.1);
-  state->set_thetadot(0.2);
+  state.set_theta(0.1);
+  state.set_thetadot(0.2);
   const double initial_energy = pendulum->CalcTotalEnergy(pendulum_context);
 
   // Run the simulation.

--- a/drake/examples/pendulum/lqr_simulation.cc
+++ b/drake/examples/pendulum/lqr_simulation.cc
@@ -42,9 +42,9 @@ int DoMain() {
 
   // Prepare to linearize around the vertical equilibrium point (with tau=0)
   auto pendulum_context = pendulum->CreateDefaultContext();
-  auto desired_state = pendulum->get_mutable_state(pendulum_context.get());
-  desired_state->set_theta(M_PI);
-  desired_state->set_thetadot(0);
+  auto& desired_state = pendulum->get_mutable_state(pendulum_context.get());
+  desired_state.set_theta(M_PI);
+  desired_state.set_thetadot(0);
   auto input = std::make_unique<PendulumInput<double>>();
   input->set_tau(0.0);
   pendulum_context->FixInputPort(0, std::move(input));
@@ -73,18 +73,18 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& sim_pendulum_context =
       diagram->GetMutableSubsystemContext(*pendulum,
-                                          simulator.get_mutable_context());
-  auto state = pendulum->get_mutable_state(&sim_pendulum_context);
-  state->set_theta(M_PI + 0.1);
-  state->set_thetadot(0.2);
+                                          &simulator.get_mutable_context());
+  auto& state = pendulum->get_mutable_state(&sim_pendulum_context);
+  state.set_theta(M_PI + 0.1);
+  state.set_thetadot(0.2);
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.Initialize();
   simulator.StepTo(10);
 
   // Adds a numerical test to make sure we're stabilizing the fixed point.
-  DRAKE_DEMAND(is_approx_equal_abstol(state->get_value(),
-                                      desired_state->get_value(), 1e-3));
+  DRAKE_DEMAND(is_approx_equal_abstol(state.get_value(),
+                                      desired_state.get_value(), 1e-3));
 
   return 0;
 }

--- a/drake/examples/pendulum/passive_simulation.cc
+++ b/drake/examples/pendulum/passive_simulation.cc
@@ -47,10 +47,10 @@ int DoMain() {
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& pendulum_context =
       diagram->GetMutableSubsystemContext(*pendulum,
-                                          simulator.get_mutable_context());
-  PendulumState<double>* state = pendulum->get_mutable_state(&pendulum_context);
-  state->set_theta(1.);
-  state->set_thetadot(0.);
+                                          &simulator.get_mutable_context());
+  PendulumState<double>& state = pendulum->get_mutable_state(&pendulum_context);
+  state.set_theta(1.);
+  state.set_thetadot(0.);
 
   const double initial_energy = pendulum->CalcTotalEnergy(pendulum_context);
 

--- a/drake/examples/pendulum/pendulum_plant.cc
+++ b/drake/examples/pendulum/pendulum_plant.cc
@@ -66,10 +66,10 @@ void PendulumPlant<T>::DoCalcTimeDerivatives(
     systems::ContinuousState<T>* derivatives) const {
   const PendulumState<T>& state = get_state(context);
   const PendulumParams<T>& params = get_parameters(context);
-  PendulumState<T>* derivative_vector = get_mutable_state(derivatives);
+  PendulumState<T>& derivative_vector = get_mutable_state(derivatives);
 
-  derivative_vector->set_theta(state.thetadot());
-  derivative_vector->set_thetadot(
+  derivative_vector.set_theta(state.thetadot());
+  derivative_vector.set_thetadot(
       (get_tau(context) -
        params.mass() * params.gravity() * params.length() * sin(state.theta()) -
        params.damping() * state.thetadot()) /

--- a/drake/examples/pendulum/pendulum_plant.h
+++ b/drake/examples/pendulum/pendulum_plant.h
@@ -56,16 +56,16 @@ class PendulumPlant : public systems::LeafSystem<T> {
   }
 
   static const PendulumState<T>& get_state(const systems::Context<T>& context) {
-    return get_state(*context.get_continuous_state());
+    return get_state(context.get_continuous_state());
   }
 
-  static PendulumState<T>* get_mutable_state(
+  static PendulumState<T>& get_mutable_state(
       systems::ContinuousState<T>* cstate) {
-    return dynamic_cast<PendulumState<T>*>(cstate->get_mutable_vector());
+    return dynamic_cast<PendulumState<T>&>(cstate->get_mutable_vector());
   }
 
-  static PendulumState<T>* get_mutable_state(systems::Context<T>* context) {
-    return get_mutable_state(context->get_mutable_continuous_state());
+  static PendulumState<T>& get_mutable_state(systems::Context<T>* context) {
+    return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
   static PendulumState<T>* get_mutable_output(

--- a/drake/examples/pendulum/print_symbolic_dynamics.cc
+++ b/drake/examples/pendulum/print_symbolic_dynamics.cc
@@ -17,9 +17,9 @@ int DoMain() {
   auto context = system.CreateDefaultContext();
   context->FixInputPort(
       0, Vector1<symbolic::Expression>::Constant(symbolic::Variable("tau")));
-  context->get_mutable_continuous_state_vector()->SetAtIndex(
+  context->get_mutable_continuous_state_vector().SetAtIndex(
       0, symbolic::Variable("theta"));
-  context->get_mutable_continuous_state_vector()->SetAtIndex(
+  context->get_mutable_continuous_state_vector().SetAtIndex(
       1, symbolic::Variable("thetadot"));
 
   auto derivatives = system.AllocateTimeDerivatives();

--- a/drake/examples/pendulum/test/pendulum_plant_test.cc
+++ b/drake/examples/pendulum/test/pendulum_plant_test.cc
@@ -14,7 +14,7 @@ GTEST_TEST(PendulumPlantTest, ToAutoDiff) {
   PendulumPlant<double> plant;
   auto context = plant.CreateDefaultContext();
   // Pretend the state has evolved due to simulation.
-  auto& xc = *context->get_mutable_continuous_state_vector();
+  auto& xc = context->get_mutable_continuous_state_vector();
   xc[0] = 42.0;  // position
   xc[1] = 76.0;  // velocity
 
@@ -26,7 +26,7 @@ GTEST_TEST(PendulumPlantTest, ToAutoDiff) {
   // Construct a new context based on autodiff.
   auto ad_context = ad_plant->CreateDefaultContext();
   ad_context->SetTimeStateAndParametersFrom(*context);
-  auto& ad_xc = *ad_context->get_mutable_continuous_state_vector();
+  auto& ad_xc = ad_context->get_mutable_continuous_state_vector();
   EXPECT_EQ(42.0, ad_xc[0].value());
   EXPECT_EQ(0, ad_xc[0].derivatives().size());
   EXPECT_EQ(76.0, ad_xc[1].value());
@@ -48,7 +48,7 @@ GTEST_TEST(PendulumPlantTest, CalcTotalEnergy) {
   EXPECT_TRUE(params);
 
   auto* state = dynamic_cast<PendulumState<double>*>(
-      context->get_mutable_continuous_state_vector());
+      &context->get_mutable_continuous_state_vector());
   EXPECT_TRUE(state);
 
   const double kTol = 1e-6;

--- a/drake/examples/pendulum/test/urdf_dynamics_test.cc
+++ b/drake/examples/pendulum/test/urdf_dynamics_test.cc
@@ -38,8 +38,8 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
     x = Eigen::Vector2d::Random();
     u = Vector1d::Random();
 
-    context_rbp->get_mutable_continuous_state_vector()->SetFromVector(x);
-    context_p->get_mutable_continuous_state_vector()->SetFromVector(x);
+    context_rbp->get_mutable_continuous_state_vector().SetFromVector(x);
+    context_p->get_mutable_continuous_state_vector().SetFromVector(x);
 
     u_rbp.GetMutableVectorData<double>()->SetFromVector(u);
     u_p.GetMutableVectorData<double>()->SetFromVector(u);

--- a/drake/examples/pr2/pr2_passive_simulation.cc
+++ b/drake/examples/pr2/pr2_passive_simulation.cc
@@ -81,10 +81,10 @@ int DoMain() {
 
   // Reset the integrator with parameters that support stable gripping, given
   // the contact parameters.
-  auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
   const double max_step_size = 1e-4;
   simulator.reset_integrator<systems::SemiExplicitEulerIntegrator<double>>(
-      *diagram, max_step_size, context);
+      *diagram, max_step_size, &context);
 
   // Set the initial joint positions to be something more interesting. Note that
   // the joint position order is the same as the order you get when you read the
@@ -95,7 +95,7 @@ int DoMain() {
       0.2, 0.2, 0.2, 0.2;
 
   for (int index = 0; index < num_actuators; index++) {
-    plant_->set_position(simulator.get_mutable_context(), index,
+    plant_->set_position(&simulator.get_mutable_context(), index,
                          initial_joint_positions[index]);
   }
 

--- a/drake/examples/qp_inverse_dynamics/manipulator_joint_space_controller.cc
+++ b/drake/examples/qp_inverse_dynamics/manipulator_joint_space_controller.cc
@@ -101,9 +101,9 @@ void ManipulatorJointSpaceController::Initialize(
     systems::Context<double>* context) {
   systems::Context<double>& plan_eval_context =
       GetMutableSubsystemContext(*plan_eval_, context);
-  systems::State<double>* plan_eval_state =
+  systems::State<double>& plan_eval_state =
       plan_eval_context.get_mutable_state();
-  plan_eval_->Initialize(plan_eval_state);
+  plan_eval_->Initialize(&plan_eval_state);
 }
 
 }  // namespace qp_inverse_dynamics

--- a/drake/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.h
+++ b/drake/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.h
@@ -55,8 +55,8 @@ class ManipulatorMoveJointPlanEvalSystem
    * Initializes the plan and gains. Must be called before execution.
    */
   void Initialize(systems::Context<double>* context) {
-    systems::State<double>* servo_state = context->get_mutable_state();
-    Initialize(servo_state);
+    systems::State<double>& servo_state = context->get_mutable_state();
+    Initialize(&servo_state);
   }
 
   /**

--- a/drake/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
+++ b/drake/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
@@ -134,13 +134,13 @@ class ManipulatorJointSpaceControllerTest : public ::testing::Test {
     // ManipulatorJointSpaceController.
     diagram_->CalcUnrestrictedUpdate(
         *context_, events->get_unrestricted_update_events(), state.get());
-    context_->get_mutable_state()->CopyFrom(*state);
+    context_->get_mutable_state().CopyFrom(*state);
 
     // Generates QpOuput from the inverse dynamics block within
     // ManipulatorJointSpaceController.
     diagram_->CalcUnrestrictedUpdate(
          *context_, events->get_unrestricted_update_events(), state.get());
-    context_->get_mutable_state()->CopyFrom(*state);
+    context_->get_mutable_state().CopyFrom(*state);
 
     // Gets output.
     diagram_->CalcOutput(*context_, output_.get());

--- a/drake/examples/quadrotor/quadrotor_plant.h
+++ b/drake/examples/quadrotor/quadrotor_plant.h
@@ -33,7 +33,7 @@ class QuadrotorPlant final : public systems::LeafSystem<T> {
   int get_num_states() const { return kStateDimension; }
 
   void set_state(systems::Context<T>* context, const VectorX<T>& x) const {
-    context->get_mutable_continuous_state_vector()->SetFromVector(x);
+    context->get_mutable_continuous_state_vector().SetFromVector(x);
   }
 
   double m() const { return m_; }

--- a/drake/examples/quadrotor/run_quadrotor_dynamics.cc
+++ b/drake/examples/quadrotor/run_quadrotor_dynamics.cc
@@ -103,7 +103,7 @@ int do_main(int argc, char* argv[]) {
   // Same as the nominal step size, since we're using a fixed step integrator.
   const double max_step_size = 1e-3;
   simulator.reset_integrator<systems::RungeKutta2Integrator<double>>(
-      model, max_step_size, simulator.get_mutable_context());
+      model, max_step_size, &simulator.get_mutable_context());
   simulator.Initialize();
   simulator.StepTo(FLAGS_duration);
   return 0;

--- a/drake/examples/quadrotor/run_quadrotor_lqr.cc
+++ b/drake/examples/quadrotor/run_quadrotor_lqr.cc
@@ -76,8 +76,8 @@ int do_main() {
     x0 = VectorX<double>::Random(12);
 
     simulator.get_mutable_context()
-        ->get_mutable_continuous_state_vector()
-        ->SetFromVector(x0);
+        .get_mutable_continuous_state_vector()
+        .SetFromVector(x0);
 
     simulator.Initialize();
     simulator.set_target_realtime_rate(FLAGS_simulation_real_time_rate);
@@ -85,8 +85,8 @@ int do_main() {
 
     // Goal state verification.
     const Context<double>& context = simulator.get_context();
-    const ContinuousState<double>* state = context.get_continuous_state();
-    const VectorX<double>& position_vector = state->CopyToVector();
+    const ContinuousState<double>& state = context.get_continuous_state();
+    const VectorX<double>& position_vector = state.CopyToVector();
 
     if (!is_approx_equal_abstol(
         position_vector, kNominalState, 1e-4)) {

--- a/drake/examples/rod2d/rod2d.h
+++ b/drake/examples/rod2d/rod2d.h
@@ -255,7 +255,7 @@ class Rod2D : public systems::LeafSystem<T> {
   /// the rod, measured counter-clockwise with respect to the x-axis.
   Vector3<T> GetRodConfig(const systems::Context<T>& context) const {
     return context.get_state().
-        get_continuous_state()->get_generalized_position().CopyToVector();
+        get_continuous_state().get_generalized_position().CopyToVector();
   }
 
   /// Gets the generalized velocity of the rod, given a Context. The first
@@ -264,7 +264,7 @@ class Rod2D : public systems::LeafSystem<T> {
   /// the rod.
   Vector3<T> GetRodVelocity(const systems::Context<T>& context) const {
     return context.get_state().
-        get_continuous_state()->get_generalized_velocity().CopyToVector();
+        get_continuous_state().get_generalized_velocity().CopyToVector();
   }
 
   /// Models impact using an inelastic impact model with friction.

--- a/drake/examples/rod2d/rod2d_sim.cc
+++ b/drake/examples/rod2d/rod2d_sim.cc
@@ -133,13 +133,13 @@ int main(int argc, char* argv[]) {
   // Set up the integrator.
   Simulator<double> simulator(*diagram, std::move(context));
   if (FLAGS_simulation_type == "compliant") {
-    auto mut_context = simulator.get_mutable_context();
+    Context<double>& mut_context = simulator.get_mutable_context();
     simulator.reset_integrator<ImplicitEulerIntegrator<double>>(*diagram,
-                                                                mut_context);
+                                                                &mut_context);
   } else {
-    auto mut_context = simulator.get_mutable_context();
+    Context<double>& mut_context = simulator.get_mutable_context();
     simulator.reset_integrator<RungeKutta3Integrator<double>>(*diagram,
-                                                              mut_context);
+                                                              &mut_context);
   }
   simulator.get_mutable_integrator()->set_target_accuracy(FLAGS_accuracy);
   simulator.get_mutable_integrator()->set_maximum_step_size(FLAGS_dt);

--- a/drake/examples/rod2d/test/rod2d_test.cc
+++ b/drake/examples/rod2d/test/rod2d_test.cc
@@ -61,7 +61,7 @@ class Rod2DDAETest : public ::testing::Test {
     return context_->CloneState();
   }
 
-  VectorBase<double> *continuous_state() {
+  VectorBase<double>& continuous_state() {
     return context_->get_mutable_continuous_state_vector();
   }
 
@@ -77,7 +77,7 @@ class Rod2DDAETest : public ::testing::Test {
     const double half_len = dut_->get_rod_half_length();
     const double r22 = std::sqrt(2) / 2;
     ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+        context_->get_mutable_continuous_state();
     xc[0] = -half_len * r22;
     xc[1] = half_len * r22;
     xc[2] = 3 * M_PI / 4.0;
@@ -86,23 +86,23 @@ class Rod2DDAETest : public ::testing::Test {
     xc[5] = 0.0;
 
     // Indicate that the rod is in the single contact sliding mode.
-    AbstractValues* abs_state =
-        context_->get_mutable_state()->get_mutable_abstract_state();
-    abs_state->get_mutable_value(0)
+    AbstractValues& abs_state =
+        context_->get_mutable_state().get_mutable_abstract_state();
+    abs_state.get_mutable_value(0)
         .template GetMutableValue<Rod2D<double>::Mode>() =
         Rod2D<double>::kSlidingSingleContact;
 
     // Determine the point of contact.
     const double theta = xc[2];
     const int k = (std::sin(theta) > 0) ? -1 : 1;
-    abs_state->get_mutable_value(1).template GetMutableValue<int>() = k;
+    abs_state.get_mutable_value(1).template GetMutableValue<int>() = k;
   }
 
   // Sets the rod to a state that corresponds to ballistic motion.
   void SetBallisticState() {
     const double half_len = dut_->get_rod_half_length();
     ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+        context_->get_mutable_continuous_state();
     xc[0] = 0.0;
     xc[1] = 10 * half_len;
     xc[2] = M_PI_2;
@@ -111,9 +111,9 @@ class Rod2DDAETest : public ::testing::Test {
     xc[5] = 3.0;
 
     // Set the mode to ballistic.
-    AbstractValues* abs_state =
-        context_->get_mutable_state()->get_mutable_abstract_state();
-    abs_state->get_mutable_value(0)
+    AbstractValues& abs_state =
+        context_->get_mutable_state().get_mutable_abstract_state();
+    abs_state.get_mutable_value(0)
         .template GetMutableValue<Rod2D<double>::Mode>() =
         Rod2D<double>::kBallisticMotion;
 
@@ -123,8 +123,7 @@ class Rod2DDAETest : public ::testing::Test {
   // Sets the rod to an interpenetrating configuration without modifying the
   // velocity or any mode variables.
   void SetInterpenetratingConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;    // com horizontal position
     xc[1] = -1.0;   // com vertical position
@@ -134,8 +133,7 @@ class Rod2DDAETest : public ::testing::Test {
   // Sets the rod to a resting horizontal configuration without modifying the
   // mode variables.
   void SetRestingHorizontalConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;     // com horizontal position
     xc[1] = 0.0;     // com vertical position
@@ -146,8 +144,7 @@ class Rod2DDAETest : public ::testing::Test {
   // Sets the rod to a resting vertical configuration without modifying the
   // mode variables.
   void SetRestingVerticalConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[0] = 0.0;                             // com horizontal position
     xc[1] = dut_->get_rod_half_length();     // com vertical position
     xc[2] = M_PI_2;                          // rod rotation
@@ -160,21 +157,20 @@ class Rod2DDAETest : public ::testing::Test {
     // but with the vertical component of velocity set such that the state
     // corresponds to an impact.
     SetSecondInitialConfig();
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[4] = -1.0;    // com horizontal velocity
 
     // Indicate that the rod is in the single contact sliding mode.
-    AbstractValues* abs_state =
-        context_->get_mutable_state()->get_mutable_abstract_state();
-    abs_state->get_mutable_value(0)
+    AbstractValues& abs_state =
+        context_->get_mutable_state().get_mutable_abstract_state();
+    abs_state.get_mutable_value(0)
         .template GetMutableValue<Rod2D<double>::Mode>() =
         Rod2D<double>::kSlidingSingleContact;
 
     // Determine the point of contact.
     const double theta = xc[2];
     const int k = (std::sin(theta) > 0) ? -1 : 1;
-    abs_state->get_mutable_value(1).template GetMutableValue<int>() = k;
+    abs_state.get_mutable_value(1).template GetMutableValue<int>() = k;
   }
 
   // Computes rigid impact data.
@@ -214,8 +210,8 @@ class Rod2DDAETest : public ::testing::Test {
     contact_solver_.ComputeGeneralizedVelocityChange(data, cf, &delta_v);
 
     // Update the velocity part of the state.
-    context_->get_mutable_continuous_state()->get_mutable_generalized_velocity()
-        ->SetFromVector(data.solve_inertia(data.Mv) + delta_v);
+    context_->get_mutable_continuous_state().get_mutable_generalized_velocity()
+        .SetFromVector(data.solve_inertia(data.Mv) + delta_v);
   }
 
   // Gets the number of generalized coordinates for the rod.
@@ -290,7 +286,7 @@ class Rod2DDAETest : public ::testing::Test {
 
 // Checks that the output port represents the state.
 TEST_F(Rod2DDAETest, Output) {
-  const ContinuousState<double>& xc = *context_->get_continuous_state();
+  const ContinuousState<double>& xc = context_->get_continuous_state();
   std::unique_ptr<SystemOutput<double>> output =
       dut_->AllocateOutput(*context_);
   dut_->CalcOutput(*context_, output.get());
@@ -330,8 +326,7 @@ TEST_F(Rod2DDAETest, ImpactWorks) {
   // Cause the initial state to be impacting, with center of mass directly
   // over the point of contact.
   const double half_len = dut_->get_rod_half_length();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[0] = 0.0;
   xc[1] = half_len;
   xc[2] = M_PI_2;
@@ -376,7 +371,7 @@ TEST_F(Rod2DDAETest, ConsistentDerivativesBallistic) {
   // ballistic system.
   const double tol = std::numeric_limits<double>::epsilon();
   const double g = dut_->get_gravitational_acceleration();
-  const ContinuousState<double>& xc = *context_->get_continuous_state();
+  const ContinuousState<double>& xc = context_->get_continuous_state();
   EXPECT_NEAR((*derivatives_)[0], xc[3], tol);  // qdot = v ...
   EXPECT_NEAR((*derivatives_)[1], xc[4], tol);  // ... for this ...
   EXPECT_NEAR((*derivatives_)[2], xc[5], tol);  // ... system.
@@ -395,8 +390,7 @@ TEST_F(Rod2DDAETest, ConsistentDerivativesContacting) {
   // Set the initial state to sustained contact with zero tangential velocity
   // at the point of contact.
   const double half_len = dut_->get_rod_half_length();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[0] = 0.0;
   xc[1] = half_len;
   xc[2] = M_PI_2;
@@ -458,8 +452,7 @@ TEST_F(Rod2DDAETest, DerivativesContactingAndSticking) {
   // Set the initial state to sustained contact with zero tangential velocity
   // at the point of contact and the rod being straight up.
   const double half_len = dut_->get_rod_half_length();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[0] = 0.0;
   xc[1] = half_len;
   xc[2] = M_PI_2;
@@ -548,12 +541,12 @@ TEST_F(Rod2DDAETest, ImpactNoChange) {
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Get the continuous state.
-  const VectorX<double> xc_old = context_->get_continuous_state()->
+  const VectorX<double> xc_old = context_->get_continuous_state().
       get_vector().CopyToVector();
 
   // Model the impact and get the continuous state out.
   ModelImpact();
-  const VectorX<double> xc = context_->get_continuous_state()->
+  const VectorX<double> xc = context_->get_continuous_state().
       get_vector().CopyToVector();
 
   // Verify the continuous state did not change.
@@ -586,7 +579,7 @@ TEST_F(Rod2DDAETest, InfFrictionImpactThenNoImpact) {
   // Handle the impact and copy the result to the context.
   std::unique_ptr<State<double>> new_state = CloneState();
   dut_->HandleImpact(*context_, new_state.get());
-  context_->get_mutable_state()->SetFrom(*new_state);
+  context_->get_mutable_state().SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Verify that the state is now in a sticking mode.
@@ -595,9 +588,9 @@ TEST_F(Rod2DDAETest, InfFrictionImpactThenNoImpact) {
 
   // Do one more impact- there should now be no change.
   dut_->HandleImpact(*context_, new_state.get());
-  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state().get_vector().
                                   CopyToVector(),
-                              context_->get_continuous_state()->get_vector().
+                              context_->get_continuous_state().get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
@@ -622,7 +615,7 @@ TEST_F(Rod2DDAETest, NoFrictionImpactThenNoImpact) {
   // Handle the impact and copy the result to the context.
   std::unique_ptr<State<double>> new_state = CloneState();
   dut_->HandleImpact(*context_, new_state.get());
-  context_->get_mutable_state()->SetFrom(*new_state);
+  context_->get_mutable_state().SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Verify that the state is still in a sliding mode.
@@ -632,9 +625,9 @@ TEST_F(Rod2DDAETest, NoFrictionImpactThenNoImpact) {
   // Do one more impact- there should now be no change.
   // Verify that there is no further change from this second impact.
   dut_->HandleImpact(*context_, new_state.get());
-  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state().get_vector().
                                   CopyToVector(),
-                              context_->get_continuous_state()->get_vector().
+                              context_->get_continuous_state().get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
@@ -648,8 +641,7 @@ TEST_F(Rod2DDAETest, NoFrictionImpactThenNoImpact) {
 TEST_F(Rod2DDAETest, NoSliding) {
   const double half_len = dut_->get_rod_half_length();
   const double r22 = std::sqrt(2) / 2;
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
 
   // Set the coefficient of friction to zero (triggering the case on the
   // edge of the friction cone).
@@ -681,8 +673,7 @@ TEST_F(Rod2DDAETest, NoSliding) {
 
 // Test multiple (two-point) contact configurations.
 TEST_F(Rod2DDAETest, MultiPoint) {
-  ContinuousState<double> &xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
 
   // Set the rod to a horizontal, two-contact configuration.
   xc[0] = 0;
@@ -752,12 +743,12 @@ TEST_F(Rod2DDAETest, ImpactNoChange2) {
   SetSecondInitialConfig();
 
   // Get the continuous state.
-  const VectorX<double> xc_old = context_->get_continuous_state()->
+  const VectorX<double> xc_old = context_->get_continuous_state().
     get_vector().CopyToVector();
 
   // Model the impact and get the continuous state out.
   ModelImpact();
-  const VectorX<double> xc = context_->get_continuous_state()->
+  const VectorX<double> xc = context_->get_continuous_state().
     get_vector().CopyToVector();
 
   // Verify the continuous state did not change.
@@ -781,7 +772,7 @@ TEST_F(Rod2DDAETest, InfFrictionImpactThenNoImpact2) {
 
   // Handle the impact and copy the result to the context.
   dut_->HandleImpact(*context_, new_state.get());
-  context_->get_mutable_state()->SetFrom(*new_state);
+  context_->get_mutable_state().SetFrom(*new_state);
 
   // Verify the state no longer corresponds to an impact.
   EXPECT_FALSE(dut_->IsImpacting(*context_));
@@ -792,9 +783,9 @@ TEST_F(Rod2DDAETest, InfFrictionImpactThenNoImpact2) {
 
   // Do one more impact- there should now be no change.
   dut_->HandleImpact(*context_, new_state.get());
-  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state().get_vector().
                                   CopyToVector(),
-                              context_->get_continuous_state()->get_vector().
+                              context_->get_continuous_state().get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
@@ -823,14 +814,14 @@ TEST_F(Rod2DDAETest, NoFrictionImpactThenNoImpact2) {
 
   // Handle the impact and copy the result to the context.
   dut_->HandleImpact(*context_, new_state.get());
-  context_->get_mutable_state()->SetFrom(*new_state);
+  context_->get_mutable_state().SetFrom(*new_state);
   EXPECT_FALSE(dut_->IsImpacting(*context_));
 
   // Do one more impact- there should now be no change.
   dut_->HandleImpact(*context_, new_state.get());
-  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state()->get_vector().
+  EXPECT_TRUE(CompareMatrices(new_state->get_continuous_state().get_vector().
                                   CopyToVector(),
-                              context_->get_continuous_state()->get_vector().
+                              context_->get_continuous_state().get_vector().
                                   CopyToVector(),
                               std::numeric_limits<double>::epsilon(),
                               MatrixCompareType::absolute));
@@ -847,8 +838,7 @@ TEST_F(Rod2DDAETest, BallisticNoImpact) {
 
   // Move the rod upward vertically so that it is no longer impacting and
   // set the mode to ballistic motion.
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[1] += 10.0;
   context_->template get_mutable_abstract_state<Rod2D<double>::Mode>(0) =
       Rod2D<double>::kBallisticMotion;
@@ -925,7 +915,7 @@ TEST_F(Rod2DDAETest, OtherEndpointDistWitness) {
 TEST_F(Rod2DDAETest, SeparationWitness) {
   // Set the rod to an upward configuration so that accelerations are simple
   // to predict.
-  ContinuousState<double>& xc = *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
 
   // Configuration has the rod on its side. Vertical velocity is still zero.
   xc[0] = 0.0;
@@ -965,8 +955,7 @@ TEST_F(Rod2DDAETest, StickingSlidingWitness) {
   // Put the rod into an upright configuration with no tangent velocity and
   // some horizontal force.
   const double half_len = dut_->get_rod_half_length();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[0] = 0.0;       // com horizontal position
   xc[1] = half_len;  // com vertical position
   xc[2] = M_PI_2;    // rod rotation
@@ -1024,8 +1013,7 @@ TEST_F(Rod2DDAETest, RigidContactProblemDataHorizontalResting) {
 TEST_F(Rod2DDAETest, RigidContactProblemDataHorizontalSliding) {
   // Set the rod to a sliding horizontal configuration.
   SetRestingHorizontalConfig();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[3] = 1.0;  // horizontal velocity of the rod center-of-mass.
 
   // Compute the problem data.
@@ -1065,8 +1053,7 @@ TEST_F(Rod2DDAETest, RigidContactProblemDataVerticalResting) {
 TEST_F(Rod2DDAETest, RigidContactProblemDataVerticalSliding) {
   // Set the rod to a sliding vertical configuration.
   SetRestingVerticalConfig();
-  ContinuousState<double>& xc =
-      *context_->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[3] = 1.0;
 
   // Compute the problem data.
@@ -1205,13 +1192,13 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSliding) {
   // based approach.
   std::unique_ptr<ContinuousState<double>> f = pdae.AllocateTimeDerivatives();
   pdae.CalcTimeDerivatives(*context_pdae, f.get());
-  auto xc = context_pdae->get_mutable_continuous_state_vector();
-  xc->SetAtIndex(3, xc->GetAtIndex(3) + dt * ((*f)[3]));
-  xc->SetAtIndex(4, xc->GetAtIndex(4) + dt * ((*f)[4]));
-  xc->SetAtIndex(5, xc->GetAtIndex(5) + dt * ((*f)[5]));
-  xc->SetAtIndex(0, xc->GetAtIndex(0) + dt * xc->GetAtIndex(3));
-  xc->SetAtIndex(1, xc->GetAtIndex(1) + dt * xc->GetAtIndex(4));
-  xc->SetAtIndex(2, xc->GetAtIndex(2) + dt * xc->GetAtIndex(5));
+  auto& xc = context_pdae->get_mutable_continuous_state_vector();
+  xc.SetAtIndex(3, xc.GetAtIndex(3) + dt * ((*f)[3]));
+  xc.SetAtIndex(4, xc.GetAtIndex(4) + dt * ((*f)[4]));
+  xc.SetAtIndex(5, xc.GetAtIndex(5) + dt * ((*f)[5]));
+  xc.SetAtIndex(0, xc.GetAtIndex(0) + dt * xc.GetAtIndex(3));
+  xc.SetAtIndex(1, xc.GetAtIndex(1) + dt * xc.GetAtIndex(4));
+  xc.SetAtIndex(2, xc.GetAtIndex(2) + dt * xc.GetAtIndex(5));
 
   // See whether the states are equal.
   const Context<double>& context_ts_new = simulator_ts.get_context();
@@ -1219,12 +1206,12 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSliding) {
 
   // Check that the solution is nearly identical.
   const double tol = std::numeric_limits<double>::epsilon() * 10;
-  EXPECT_NEAR(xc->GetAtIndex(0), xd[0], tol);
-  EXPECT_NEAR(xc->GetAtIndex(1), xd[1], tol);
-  EXPECT_NEAR(xc->GetAtIndex(2), xd[2], tol);
-  EXPECT_NEAR(xc->GetAtIndex(3), xd[3], tol);
-  EXPECT_NEAR(xc->GetAtIndex(4), xd[4], tol);
-  EXPECT_NEAR(xc->GetAtIndex(5), xd[5], tol);
+  EXPECT_NEAR(xc.GetAtIndex(0), xd[0], tol);
+  EXPECT_NEAR(xc.GetAtIndex(1), xd[1], tol);
+  EXPECT_NEAR(xc.GetAtIndex(2), xd[2], tol);
+  EXPECT_NEAR(xc.GetAtIndex(3), xd[3], tol);
+  EXPECT_NEAR(xc.GetAtIndex(4), xd[4], tol);
+  EXPECT_NEAR(xc.GetAtIndex(5), xd[5], tol);
 
   // TODO(edrumwri): Introduce more extensive tests that cross-validate the
   // time-stepping based approach against the piecewise DAE-based approach for
@@ -1256,8 +1243,7 @@ GTEST_TEST(Rod2DCrossValidationTest, OneStepSolutionSticking) {
 
   // This configuration has no sliding velocity.
   const double half_len = pdae.get_rod_half_length();
-  ContinuousState<double>& xc =
-      *context_pdae->get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_pdae->get_mutable_continuous_state();
   auto xd = context_ts->get_mutable_discrete_state(0).get_mutable_value();
   xc[0] = xd[0] = 0.0;
   xc[1] = xd[1] = half_len;
@@ -1344,7 +1330,7 @@ class Rod2DCompliantTest : public ::testing::Test {
 
   // Return the state x,y,θ,xdot,ydot,θdot as a Vector6.
   Vector6d get_state() const {
-    const ContinuousState<double>& xc = *context_->get_continuous_state();
+    const ContinuousState<double>& xc = context_->get_continuous_state();
     return Vector6d(xc.CopyToVector());
   }
 
@@ -1356,15 +1342,13 @@ class Rod2DCompliantTest : public ::testing::Test {
 
   // Sets the planar pose in the context.
   void set_pose(double x, double y, double theta) {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[0] = x; xc[1] = y; xc[2] = theta;
   }
 
   // Sets the planar velocity in the context.
   void set_velocity(double xdot, double ydot, double thetadot) {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[3] = xdot; xc[4] = ydot; xc[5] = thetadot;
   }
 
@@ -1514,7 +1498,7 @@ GTEST_TEST(Rod2DCrossValidationTest, Outputs) {
   x_pdae[0] = 0;
   x_pdae[1] = pdae.get_rod_half_length();
   x_pdae[2] = M_PI_2;
-  context_pdae->get_mutable_continuous_state()->SetFromVector(x_pdae);
+  context_pdae->get_mutable_continuous_state().SetFromVector(x_pdae);
   pdae.CalcOutput(*context_pdae, output_pdae.get());
 
   // Rotation by theta is converted to rotation around +y by theta + π/2.

--- a/drake/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/drake/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -220,7 +220,7 @@ GTEST_TEST(SchunkWsgLiftTest, BoxLiftTest) {
   // surprisingly complicated.
   systems::Context<double>& plant_context =
       model->GetMutableSubsystemContext(
-          *plant, simulator.get_mutable_context());
+          *plant, &simulator.get_mutable_context());
   Eigen::VectorXd plant_initial_state =
       Eigen::VectorXd::Zero(plant->get_num_states());
   plant_initial_state.head(plant->get_num_positions())
@@ -242,9 +242,9 @@ GTEST_TEST(SchunkWsgLiftTest, BoxLiftTest) {
   plant_initial_state(5) = 0.009759;
   plant->set_state_vector(&plant_context, plant_initial_state);
 
-  auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
 
-  simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, context);
+  simulator.reset_integrator<RungeKutta3Integrator<double>>(*model, &context);
   simulator.get_mutable_integrator()->request_initial_step_size_target(1e-4);
   simulator.get_mutable_integrator()->set_target_accuracy(1e-3);
 

--- a/drake/examples/simple_continuous_time_system.cc
+++ b/drake/examples/simple_continuous_time_system.cc
@@ -51,7 +51,7 @@ int main() {
 
   // Set the initial conditions x(0).
   drake::systems::ContinuousState<double>& state =
-      *simulator.get_mutable_context()->get_mutable_continuous_state();
+      simulator.get_mutable_context().get_mutable_continuous_state();
   state[0] = 0.9;
 
   // Simulate for 10 seconds.

--- a/drake/examples/simple_discrete_time_system.cc
+++ b/drake/examples/simple_discrete_time_system.cc
@@ -51,7 +51,7 @@ int main() {
 
   // Set the initial conditions x(0).
   drake::systems::DiscreteValues<double>& state =
-      *simulator.get_mutable_context()->get_mutable_discrete_state();
+      simulator.get_mutable_context().get_mutable_discrete_state();
   state[0] = 0.99;
 
   // Simulate for 10 seconds.

--- a/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
+++ b/drake/examples/simple_mixed_continuous_and_discrete_time_system.cc
@@ -43,7 +43,7 @@ class SimpleMixedContinuousTimeDiscreteTimeSystem
       drake::systems::ContinuousState<double>* derivatives) const override {
     const double x = context.get_continuous_state_vector().GetAtIndex(0);
     const double xdot = -x + std::pow(x, 3.0);
-    derivatives->get_mutable_vector()->SetAtIndex(0, xdot);
+    derivatives->get_mutable_vector().SetAtIndex(0, xdot);
   }
 
   // y = x
@@ -67,10 +67,10 @@ int main() {
 
   // Set the initial conditions x(0).
   drake::systems::DiscreteValues<double>& xd =
-      *simulator.get_mutable_context()->get_mutable_discrete_state();
+      simulator.get_mutable_context().get_mutable_discrete_state();
   xd[0] = 0.99;
   drake::systems::ContinuousState<double>& xc =
-      *simulator.get_mutable_context()->get_mutable_continuous_state();
+      simulator.get_mutable_context().get_mutable_continuous_state();
   xc[0] = 0.9;
 
   // Simulate for 10 seconds.

--- a/drake/examples/valkyrie/test/valkyrie_simulation_test.cc
+++ b/drake/examples/valkyrie/test/valkyrie_simulation_test.cc
@@ -20,17 +20,18 @@ GTEST_TEST(ValkyrieSimulationTest, TestIfRuns) {
 
   // Create simulator.
   systems::Simulator<double> simulator(diagram);
-  auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
 
   // Integrator set arbitrarily. The time step was selected by tuning for the
   // largest value that appears to give stable results.
   simulator.reset_integrator<systems::SemiExplicitEulerIntegrator<double>>(
-      diagram, 3e-4, context);
+      diagram, 3e-4, &context);
   simulator.set_publish_every_time_step(false);
 
   // Set initial state.
   auto plant = diagram.get_mutable_plant();
-  auto& plant_context = diagram.GetMutableSubsystemContext(*plant, context);
+  systems::Context<double>& plant_context =
+      diagram.GetMutableSubsystemContext(*plant, &context);
 
   // TODO(tkoolen): make it easy to specify a different initial configuration.
   VectorX<double> initial_state = RPYValkyrieFixedPointState();

--- a/drake/examples/valkyrie/valkyrie_simulation.cc
+++ b/drake/examples/valkyrie/valkyrie_simulation.cc
@@ -20,17 +20,18 @@ int main() {
 
   // Create simulator.
   systems::Simulator<double> simulator(diagram);
-  auto context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
 
   // Integrator set arbitrarily. The time step was selected by tuning for the
   // largest value that appears to give stable results.
   simulator.reset_integrator<systems::SemiExplicitEulerIntegrator<double>>(
-      diagram, 3e-4, context);
+      diagram, 3e-4, &context);
   simulator.set_publish_every_time_step(false);
 
   // Set initial state.
   auto plant = diagram.get_mutable_plant();
-  auto& plant_context = diagram.GetMutableSubsystemContext(*plant, context);
+  systems::Context<double>& plant_context =
+      diagram.GetMutableSubsystemContext(*plant, &context);
 
   // TODO(tkoolen): make it easy to specify a different initial configuration.
   VectorX<double> initial_state = RPYValkyrieFixedPointState();

--- a/drake/examples/van_der_pol/plot_limit_cycle.cc
+++ b/drake/examples/van_der_pol/plot_limit_cycle.cc
@@ -32,10 +32,11 @@ void DoMain() {
   // TODO(russt): Use trajectory optimization to compute the cycle for arbitrary
   // μ.
   const Eigen::Vector2d initial_state(-0.1144, 2.0578);
-  auto vdp_state =
-      diagram->GetMutableSubsystemContext(*vdp, simulator.get_mutable_context())
+  systems::VectorBase<double>& vdp_state =
+      diagram
+          ->GetMutableSubsystemContext(*vdp, &simulator.get_mutable_context())
           .get_mutable_continuous_state_vector();
-  vdp_state->SetFromVector(initial_state);
+  vdp_state.SetFromVector(initial_state);
 
   // Simulate for the (experimentally acquired) period of the cycle for μ=1.
   simulator.StepTo(6.667);
@@ -52,7 +53,7 @@ void DoMain() {
   // TODO(russt): Tighten this tolerance after I generalize the code to support
   // arbitrary μ.
   DRAKE_DEMAND(
-      is_approx_equal_abstol(vdp_state->CopyToVector(), initial_state, 1e-2));
+      is_approx_equal_abstol(vdp_state.CopyToVector(), initial_state, 1e-2));
 }
 
 }  // namespace

--- a/drake/examples/van_der_pol/van_der_pol.cc
+++ b/drake/examples/van_der_pol/van_der_pol.cc
@@ -39,16 +39,16 @@ void VanDerPolOscillator<T>::DoCalcTimeDerivatives(
     const systems::Context<T>& context,
     systems::ContinuousState<T>* derivatives) const {
   const T q =
-      context.get_continuous_state()->get_generalized_position().GetAtIndex(0);
+      context.get_continuous_state().get_generalized_position().GetAtIndex(0);
   const T qdot =
-      context.get_continuous_state()->get_generalized_velocity().GetAtIndex(0);
+      context.get_continuous_state().get_generalized_velocity().GetAtIndex(0);
   const T mu = context.get_numeric_parameter(0).GetAtIndex(0);
 
   using std::pow;
   const T qddot = -mu * (q * q - 1) * qdot - q;
 
-  derivatives->get_mutable_generalized_position()->SetAtIndex(0, qdot);
-  derivatives->get_mutable_generalized_velocity()->SetAtIndex(0, qddot);
+  derivatives->get_mutable_generalized_position().SetAtIndex(0, qdot);
+  derivatives->get_mutable_generalized_velocity().SetAtIndex(0, qddot);
 }
 
 template <typename T>
@@ -56,7 +56,7 @@ void VanDerPolOscillator<T>::CopyPositionToOutput(
     const systems::Context<T>& context, systems::BasicVector<T>* output) const {
   output->SetAtIndex(
       0,
-      context.get_continuous_state()->get_generalized_position().GetAtIndex(0));
+      context.get_continuous_state().get_generalized_position().GetAtIndex(0));
 }
 
 template <typename T>

--- a/drake/geometry/geometry_context.cc
+++ b/drake/geometry/geometry_context.cc
@@ -11,7 +11,7 @@ GeometryContext<T>::GeometryContext(int geometry_state_index)
 template <typename T>
 GeometryState<T>& GeometryContext<T>::get_mutable_geometry_state() {
   return this->get_mutable_state()
-      ->template get_mutable_abstract_state<GeometryState<T>>(
+      .template get_mutable_abstract_state<GeometryState<T>>(
           geometry_state_index_);
 }
 

--- a/drake/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/drake/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -37,7 +37,7 @@ class OptitrackPoseTest : public ::testing::Test {
     input->SetValue(input_frame);
     context_->FixInputPort(0 /* input port ID*/, std::move(input));
 
-    dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+    dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
     dut_->CalcOutput(*context_, output_.get());
     auto output_value = output_->get_data(0);
 

--- a/drake/manipulation/perception/test/pose_smoother_test.cc
+++ b/drake/manipulation/perception/test/pose_smoother_test.cc
@@ -57,7 +57,7 @@ class PoseSmootherTest : public ::testing::Test {
     context_->FixInputPort(0 /* input port ID*/, std::move(input));
     context_->set_time(input_time);
 
-    dut_->CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+    dut_->CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
     dut_->CalcOutput(*context_, output_.get());
 
     auto output_pose_value =

--- a/drake/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/drake/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -110,9 +110,9 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   context->FixInputPort(dut.get_plan_input_port().get_index(),
                         systems::AbstractValue::Make(plan));
   dut.Initialize(0, Eigen::VectorXd::Zero(kNumJoints),
-                 context->get_mutable_state());
+                 &context->get_mutable_state());
 
-  dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
 
   // Test we're running the plan through time by watching the
   // positions, velocities, and acceleration change.
@@ -151,7 +151,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
 
   for (const TrajectoryTestCase& kase : cases) {
     context->set_time(kase.time);
-    dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+    dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double position =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -177,7 +177,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
       interp_type == InterpolatorType::ZeroOrderHold ||
       interp_type == InterpolatorType::Pchip) {
     context->set_time(t.back() + 0.01);
-    dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+    dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     const double velocity =
         output->get_vector_data(dut.get_state_output_port().get_index())
@@ -194,7 +194,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   // Check that sending an empty plan causes us to continue to output
   // the same commanded position.
   context->set_time(1);
-  dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   double position =
       output->get_vector_data(dut.get_state_output_port().get_index())
@@ -206,7 +206,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   plan.plan.clear();
   context->FixInputPort(dut.get_plan_input_port().get_index(),
                         systems::AbstractValue::Make(plan));
-  dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   position = output->get_vector_data(
       dut.get_state_output_port().get_index())->GetAtIndex(0);

--- a/drake/manipulation/util/test/frame_pose_tracker_test.cc
+++ b/drake/manipulation/util/test/frame_pose_tracker_test.cc
@@ -74,7 +74,7 @@ class FramePoseTrackerTest : public ::testing::Test {
         dut.get_kinematics_input_port_index() /* input port ID*/,
         std::move(input));
 
-    dut.CalcUnrestrictedUpdate(*context_, context_->get_mutable_state());
+    dut.CalcUnrestrictedUpdate(*context_, &context_->get_mutable_state());
     dut.CalcOutput(*context_, output_.get());
     auto output_value =
         output_->get_data(dut.get_pose_bundle_output_port_index());

--- a/drake/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/drake/manipulation/util/test/sim_diagram_builder_test.cc
@@ -113,9 +113,9 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
 
   // Simulates.
   systems::Simulator<double> simulator(*diagram);
-  systems::Context<double>* context = simulator.get_mutable_context();
+  systems::Context<double>& context = simulator.get_mutable_context();
   systems::Context<double>& plant_context =
-      diagram->GetMutableSubsystemContext(*plant, context);
+      diagram->GetMutableSubsystemContext(*plant, &context);
   VectorX<double> state0(2 * kNumPos * iiwa_info.size());
   for (size_t i = 0; i < iiwa_info.size(); ++i) {
     state0.segment<kNumPos>(i * kNumPos) = state_d.head<kNumPos>();

--- a/drake/multibody/benchmarks/free_body/test/rigid_body_plant_free_body_test.cc
+++ b/drake/multibody/benchmarks/free_body/test/rigid_body_plant_free_body_test.cc
@@ -259,7 +259,7 @@ void  TestDrakeSolutionForSpecificInitialValue(
                    torque_free_cylinder_solution.get_w_NB_B_initial(),
                    torque_free_cylinder_solution.get_v_NBcm_B_initial();
   systems::VectorBase<double>& state_drake =
-      *(context->get_mutable_continuous_state_vector());
+      context->get_mutable_continuous_state_vector();
   state_drake.SetFromVector(state_initial);
 
   // Ensure the time stored by context is set to 0.0 (initial value).

--- a/drake/multibody/constraint/test/constraint_solver_test.cc
+++ b/drake/multibody/constraint/test/constraint_solver_test.cc
@@ -103,8 +103,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // Sets the rod to a resting horizontal configuration without modifying the
   // rod's mode variables.
   void SetRodToRestingHorizontalConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;     // com horizontal position
     xc[1] = 0.0;     // com vertical position
@@ -115,8 +114,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // Sets the rod to an upward moving horizontal configuration without modifying
   // the rod's mode variables.
   void SetRodToUpwardMovingHorizontalConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;     // com horizontal position
     xc[1] = 0.0;     // com vertical position
@@ -130,8 +128,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // configured to lie upon its side and without modifying the rod's mode
   // variables.
   void SetRodToSlidingImpactingHorizontalConfig(bool sliding_to_right) {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;                          // com horizontal position
     xc[1] = 0.0;                          // com vertical position
@@ -144,8 +141,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // Sets the rod to a sliding velocity with the rod configured to impact
   // vertically and without modifying the rod's mode variables.
   void SetRodToSlidingImpactingVerticalConfig(bool sliding_to_right) {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     // Configuration has the rod on its side.
     xc[0] = 0.0;                          // com horizontal position
     xc[1] = 0.0;                          // com vertical position
@@ -158,8 +154,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // Sets the rod to a resting vertical configuration without modifying the
   // mode variables.
   void SetRodToRestingVerticalConfig() {
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[0] = 0.0;                             // com horizontal position
     xc[1] = rod_->get_rod_half_length();     // com vertical position
     xc[2] = M_PI_2;                          // rod rotation
@@ -812,7 +807,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
         SetRodToSlidingImpactingHorizontalConfig(sliding_to_right);
 
         // Get the vertical velocity of the rod.
-        const double vert_vel = context_->get_continuous_state()->
+        const double vert_vel = context_->get_continuous_state().
             CopyToVector()[4];
 
         // Compute the problem data.
@@ -933,7 +928,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
         SetRodToSlidingImpactingHorizontalConfig(sliding_to_right);
 
         // Get the vertical velocity of the rod.
-        const double vert_vel = context_->get_continuous_state()->
+        const double vert_vel = context_->get_continuous_state().
             CopyToVector()[4];
 
         // Compute the impact problem data.
@@ -1026,8 +1021,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
       // Set the state of the rod to resting on its side w/ horizontal velocity.
       SetRodToRestingHorizontalConfig();
     }
-    ContinuousState<double>& xc = *context_->
-        get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[3] = (sliding_to_right) ? 1 : -1;
 
     // Get the gravitational acceleration.
@@ -1110,8 +1104,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
   // using a bilateral constraint as well.
   void SlidingPlusBilateral(bool sliding_to_right) {
       SetRodToRestingVerticalConfig();
-    ContinuousState<double>& xc = *context_->
-        get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     xc[3] = (sliding_to_right) ? 1 : -1;
 
     // Set the coefficient of friction. A nonzero coefficient of friction should
@@ -1258,8 +1251,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
     EXPECT_EQ(cf.size(), num_contacts * 2 + num_bilateral_eqns);
 
     // Get the pre-impact vertical momentum.
-    ContinuousState<double>& xc =
-        *context_->get_mutable_continuous_state();
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
     const double mv = rod_->get_rod_mass() * xc[4];
 
     // Verify that the normal contact impulses exactly oppose the pre-impact
@@ -1412,8 +1404,7 @@ TEST_P(Constraint2DSolverTest, OnePointPlusLimit) {
   // Set the state of the rod to vertically-at-rest and sliding to the left.
   // Set the state of the rod to resting on its side with horizontal velocity.
   SetRodToRestingHorizontalConfig();
-  ContinuousState<double>& xc = *context_->
-    get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[3] = 1.0;
 
   // Set the coefficient of friction to somewhat small (to limit sliding force)
@@ -1786,8 +1777,7 @@ TEST_P(Constraint2DSolverTest, TwoPointAsLimit) {
 TEST_P(Constraint2DSolverTest, TwoPointImpactAsLimit) {
   // Set the state of the rod to impacting on its side.
   SetRodToSlidingImpactingHorizontalConfig(true /* moving to the right */);
-  ContinuousState<double>& xc = *context_->
-      get_mutable_continuous_state();
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   const double vert_vel = xc[4];
 
   // First, construct the velocity-level problem data as normal to set

--- a/drake/multibody/dev/test/quadrotor_test.cc
+++ b/drake/multibody/dev/test/quadrotor_test.cc
@@ -93,7 +93,7 @@ GTEST_TEST(QuadrotorTest, Equality) {
 
   // Make them use the same "integrator".
   continuous_sim.reset_integrator<systems::SemiExplicitEulerIntegrator<double>>(
-      continuous_model, step_size, continuous_sim.get_mutable_context());
+      continuous_model, step_size, &continuous_sim.get_mutable_context());
 
   // Initialize the simulators.
   continuous_sim.Initialize();
@@ -106,13 +106,13 @@ GTEST_TEST(QuadrotorTest, Equality) {
   for (int i = 0; i < kQuadrotorStateDim; ++i)
     x0[i] = i + 1;
   auto& continuous_context = continuous_model.GetMutableSubsystemContext(
-    continuous_plant, continuous_sim.get_mutable_context());
-  continuous_context.get_mutable_continuous_state()->SetFromVector(x0);
+    continuous_plant, &continuous_sim.get_mutable_context());
+  continuous_context.get_mutable_continuous_state().SetFromVector(x0);
 
   // Set the initial conditions for the discrete plant.
   Context<double>& discrete_context = discrete_model.GetMutableSubsystemContext(
-      discrete_plant, discrete_sim.get_mutable_context());
-  discrete_context.get_mutable_discrete_state()->get_mutable_vector().
+      discrete_plant, &discrete_sim.get_mutable_context());
+  discrete_context.get_mutable_discrete_state().get_mutable_vector().
       SetFromVector(x0);
 
   // Step both forward by one step into the future.
@@ -124,7 +124,7 @@ GTEST_TEST(QuadrotorTest, Equality) {
   auto& continuous_state = continuous_sim.get_context().
       get_continuous_state_vector();
   auto& discrete_state = *discrete_sim.get_context().
-      get_discrete_state()->get_data().front();
+      get_discrete_state().get_data().front();
   const double tol = 1e3 * std::numeric_limits<double>::epsilon();
   ASSERT_EQ(continuous_state.size(), discrete_state.size());
   for (int i = 0; i < discrete_state.size(); ++i)

--- a/drake/multibody/multibody_tree/multibody_tree_context.h
+++ b/drake/multibody/multibody_tree/multibody_tree_context.h
@@ -70,12 +70,12 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
 
   /// Returns the size of the generalized positions vector.
   int get_num_positions() const {
-    return this->get_continuous_state()->get_generalized_position().size();
+    return this->get_continuous_state().get_generalized_position().size();
   }
 
   /// Returns the size of the generalized velocities vector.
   int get_num_velocities() const {
-    return this->get_continuous_state()->get_generalized_velocity().size();
+    return this->get_continuous_state().get_generalized_velocity().size();
   }
 
   /// Returns an Eigen expression of the vector of generalized positions.
@@ -111,7 +111,7 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
     // PR #6049 gets merged.
     Eigen::VectorBlock<const VectorX<T>> xc =
         dynamic_cast<const systems::BasicVector<T>&>(
-            this->get_continuous_state()->get_vector()).get_value();
+            this->get_continuous_state().get_vector()).get_value();
     // xc.nestedExpression() resolves to "VectorX<T>&" since the continuous
     // state is a BasicVector.
     // If we do return xc.segment() directly, we would instead get a
@@ -129,8 +129,8 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
     // TODO(amcastro-tri): make use of VectorBase::get_contiguous_vector() once
     // PR #6049 gets merged.
     Eigen::VectorBlock<VectorX<T>> xc =
-        dynamic_cast<systems::BasicVector<T>*>(
-            this->get_mutable_continuous_state()->get_mutable_vector())->
+        dynamic_cast<systems::BasicVector<T>&>(
+            this->get_mutable_continuous_state().get_mutable_vector()).
             get_mutable_value();
     // xc.nestedExpression() resolves to "VectorX<T>&" since the continuous
     // state is a BasicVector.
@@ -150,7 +150,7 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
     // PR #6049 gets merged.
     Eigen::VectorBlock<const VectorX<T>> xc =
         dynamic_cast<const systems::BasicVector<T>&>(
-            this->get_continuous_state()->get_vector()).get_value();
+            this->get_continuous_state().get_vector()).get_value();
     // xc.nestedExpression() resolves to "const VectorX<T>&" since the
     // continuous state is a BasicVector.
     // If we do return xc.segment() directly, we would instead get a
@@ -168,8 +168,8 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
     // TODO(amcastro-tri): make use of VectorBase::get_contiguous_vector() once
     // PR #6049 gets merged.
     Eigen::VectorBlock<VectorX<T>> xc =
-        dynamic_cast<systems::BasicVector<T>*>(
-            this->get_mutable_continuous_state()->get_mutable_vector())->
+        dynamic_cast<systems::BasicVector<T>&>(
+            this->get_mutable_continuous_state().get_mutable_vector()).
             get_mutable_value();
     // xc.nestedExpression() resolves to "VectorX<T>&" since the continuous
     // state is a BasicVector.

--- a/drake/multibody/rigid_body_plant/drake_visualizer.h
+++ b/drake/multibody/rigid_body_plant/drake_visualizer.h
@@ -126,7 +126,7 @@ class DrakeVisualizer : public LeafSystem<double> {
   // Set the default to "initialization phase has not been completed."
   void SetDefaultState(const Context<double>&, State<double>* state)
       const override {
-    set_is_load_message_sent(state->get_mutable_discrete_state(), false);
+    set_is_load_message_sent(&state->get_mutable_discrete_state(), false);
   }
 
   // If initialization has not been completed, schedule a DiscreteStateUpdate

--- a/drake/multibody/rigid_body_plant/kinematics_results.cc
+++ b/drake/multibody/rigid_body_plant/kinematics_results.cc
@@ -84,7 +84,7 @@ void KinematicsResults<T>::UpdateFromContext(const Context<T>& context) {
   const int nv = tree_->get_num_velocities();
 
   VectorX<T> x;
-  if (context.get_state().get_continuous_state()->size() > 0) {
+  if (context.get_state().get_continuous_state().size() > 0) {
     // TODO(amcastro-tri): provide nicer accessor to an Eigen representation for
     // LeafSystems.
     x = dynamic_cast<const BasicVector<T>&>(

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -269,8 +269,8 @@ void RigidBodyPlant<T>::set_position(Context<T>* context, int position_index,
                                                        position);
   } else {
     context->get_mutable_continuous_state()
-        ->get_mutable_generalized_position()
-        ->SetAtIndex(position_index, position);
+        .get_mutable_generalized_position()
+        .SetAtIndex(position_index, position);
   }
 }
 
@@ -283,8 +283,8 @@ void RigidBodyPlant<T>::set_velocity(Context<T>* context, int velocity_index,
         get_num_positions() + velocity_index, velocity);
   } else {
     context->get_mutable_continuous_state()
-        ->get_mutable_generalized_velocity()
-        ->SetAtIndex(velocity_index, velocity);
+        .get_mutable_generalized_velocity()
+        .SetAtIndex(velocity_index, velocity);
   }
 }
 
@@ -292,7 +292,7 @@ template <typename T>
 void RigidBodyPlant<T>::set_state_vector(
     Context<T>* context, const Eigen::Ref<const VectorX<T>> x) const {
   DRAKE_ASSERT(context != nullptr);
-  set_state_vector(context->get_mutable_state(), x);
+  set_state_vector(&context->get_mutable_state(), x);
 }
 
 template <typename T>
@@ -301,10 +301,10 @@ void RigidBodyPlant<T>::set_state_vector(
   DRAKE_ASSERT(state != nullptr);
   DRAKE_ASSERT(x.size() == get_num_states());
   if (is_state_discrete()) {
-    auto* xd = state->get_mutable_discrete_state();
-    xd->get_mutable_vector(0).SetFromVector(x);
+    auto& xd = state->get_mutable_discrete_state();
+    xd.get_mutable_vector(0).SetFromVector(x);
   } else {
-    state->get_mutable_continuous_state()->SetFromVector(x);
+    state->get_mutable_continuous_state().SetFromVector(x);
   }
 }
 
@@ -396,7 +396,7 @@ void RigidBodyPlant<T>::CopyStateToOutput(const Context<T>& context,
   // mere pointers to state variables (or cache lines).
   const VectorX<T> state_vector =
       (is_state_discrete()) ? context.get_discrete_state(0).CopyToVector()
-                            : context.get_continuous_state()->CopyToVector();
+                            : context.get_continuous_state().CopyToVector();
 
   state_output_vector->get_mutable_value() = state_vector;
 }
@@ -409,7 +409,7 @@ void RigidBodyPlant<T>::CalcInstanceOutput(
   // TODO(sherm1) Should reference state rather than copy it here.
   const VectorX<T> state_vector =
       (is_state_discrete()) ? context.get_discrete_state(0).CopyToVector()
-                            : context.get_continuous_state()->CopyToVector();
+                            : context.get_continuous_state().CopyToVector();
 
   auto values = instance_output->get_mutable_value();
   const auto& instance_positions = position_map_[instance_id];

--- a/drake/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/drake/multibody/rigid_body_plant/rigid_body_plant.h
@@ -220,17 +220,16 @@ class RigidBodyPlant : public LeafSystem<T> {
     if (is_state_discrete()) {
       // Extract a reference to the discrete state from the context.
       BasicVector<T>& xd =
-          state->get_mutable_discrete_state()->get_mutable_vector(0);
+          state->get_mutable_discrete_state().get_mutable_vector(0);
 
       // Write the zero configuration into the discrete state.
       xd.SetFromVector(x0);
     } else {
-      // Extract a pointer to continuous state from the context.
-      ContinuousState<T>* xc = state->get_mutable_continuous_state();
-      DRAKE_DEMAND(xc != nullptr);
+      // Extract a reference to continuous state from the context.
+      ContinuousState<T>& xc = state->get_mutable_continuous_state();
 
       // Write the zero configuration into the continuous state.
-      xc->SetFromVector(x0);
+      xc.SetFromVector(x0);
     }
   }
 

--- a/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/drake/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -50,10 +50,10 @@ class ContactFormulaTest : public ::testing::Test {
     const int port_index = plant_->contact_results_output_port().get_index();
 
     // Set Sphere 2's velocity.
-    auto velocities = context_->get_mutable_state()
-                          ->get_mutable_continuous_state()
-                          ->get_mutable_generalized_velocity();
-    ASSERT_EQ(velocities->size(), 12);  // Two quaternion floating joints.
+    auto& velocities = context_->get_mutable_state()
+                           .get_mutable_continuous_state()
+                           .get_mutable_generalized_velocity();
+    ASSERT_EQ(velocities.size(), 12);  // Two quaternion floating joints.
     Vector6d v_WS2 = get_v_WS2();
     VectorXd target_velocities;
     target_velocities.resize(12);
@@ -61,7 +61,7 @@ class ContactFormulaTest : public ::testing::Test {
         0, 0, 0,                       // sphere 1 linear velocity
         v_WS2[0], v_WS2[1], v_WS2[2],  // sphere 2 angular velocity
         v_WS2[3], v_WS2[4], v_WS2[5];  // sphere 2 linear velocity
-    velocities->SetFromVector(target_velocities);
+    velocities.SetFromVector(target_velocities);
 
     SetContactParameters();
     plant_->set_normal_contact_parameters(stiffness_, dissipation_);

--- a/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/drake/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -457,8 +457,8 @@ void PublishLoadRobotModelMessageHelper(
     const DrakeVisualizer& dut, Context<double>* context) {
   std::unique_ptr<State<double>> tmp_state = context->CloneState();
   dut.CalcDiscreteVariableUpdates(*context,
-      tmp_state->get_mutable_discrete_state());
-  context->get_mutable_state()->CopyFrom(*tmp_state);
+      &tmp_state->get_mutable_discrete_state());
+  context->get_mutable_state().CopyFrom(*tmp_state);
 }
 
 // Tests the basic functionality of the DrakeVisualizer.
@@ -512,12 +512,12 @@ GTEST_TEST(DrakeVisualizerTests, TestPublishPeriod) {
   // Prepares to integrate.
   drake::systems::Simulator<double> simulator(dut, std::move(context));
   simulator.set_publish_every_time_step(false);
-  PublishLoadRobotModelMessageHelper(dut, simulator.get_mutable_context());
+  PublishLoadRobotModelMessageHelper(dut, &simulator.get_mutable_context());
   simulator.Initialize();
 
   for (double time = 0; time < 4; time += 0.01) {
     simulator.StepTo(time);
-    EXPECT_NEAR(simulator.get_mutable_context()->get_time(), time, 1e-10);
+    EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
     // Note that the expected time is in milliseconds.
     const double expected_time =
         std::floor(time / kPublishPeriod) * kPublishPeriod * 1000;

--- a/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/drake/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -143,9 +143,9 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
     for (double pitch = 0; pitch <= M_PI_2; pitch += kAngleInc) {
       for (double yaw = 0; yaw <= M_PI_2; yaw += kAngleInc) {
         // Get the mutable state.
-        VectorBase<double>* xc = context->get_mutable_state()
-                                     ->get_mutable_continuous_state()
-                                     ->get_mutable_generalized_position();
+        VectorBase<double>& xc = context->get_mutable_state()
+                                     .get_mutable_continuous_state()
+                                     .get_mutable_generalized_position();
 
         // Update the orientation.
         const Quaterniond q = Eigen::AngleAxisd(roll, Vector3d::UnitZ()) *
@@ -154,10 +154,10 @@ GTEST_TEST(RigidBodyPlantTest, MapVelocityToConfigurationDerivativesAndBack) {
 
         // Verify normalization.
         DRAKE_ASSERT(std::abs(q.norm() - 1.0) < 1e-15);
-        xc->SetAtIndex(3, q.w());
-        xc->SetAtIndex(4, q.x());
-        xc->SetAtIndex(5, q.y());
-        xc->SetAtIndex(6, q.z());
+        xc.SetAtIndex(3, q.w());
+        xc.SetAtIndex(4, q.x());
+        xc.SetAtIndex(5, q.y());
+        xc.SetAtIndex(6, q.z());
 
         // Transform the generalized velocities to time derivative of
         // generalized coordinates.
@@ -248,11 +248,11 @@ TEST_P(KukaArmTest, StateHasTheRightSizes) {
   // Only check these if the state is continuous.
   if (!kuka_plant_->is_state_discrete()) {
     const VectorBase<double>& xc =
-        context_->get_continuous_state()->get_generalized_position();
+        context_->get_continuous_state().get_generalized_position();
     const VectorBase<double>& vc =
-        context_->get_continuous_state()->get_generalized_velocity();
+        context_->get_continuous_state().get_generalized_velocity();
     const VectorBase<double>& zc =
-        context_->get_continuous_state()->get_misc_continuous_state();
+        context_->get_continuous_state().get_misc_continuous_state();
 
     EXPECT_EQ(kNumPositions_, xc.size());
     EXPECT_EQ(kNumVelocities_, vc.size());
@@ -446,8 +446,8 @@ double GetPrismaticJointLimitAccel(double position, double applied_force) {
 
   auto context = plant.CreateDefaultContext();
   context->get_mutable_continuous_state()
-      ->get_mutable_generalized_position()
-      ->SetAtIndex(0, position);
+      .get_mutable_generalized_position()
+      .SetAtIndex(0, position);
 
   // Apply a constant force on the input.
   Vector1d input;
@@ -546,7 +546,7 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   // but as discrete state.
   EXPECT_TRUE(continuous_context->has_only_continuous_state());
   EXPECT_TRUE(time_stepping_context->has_only_discrete_state());
-  EXPECT_EQ(continuous_context->get_continuous_state()->size(),
+  EXPECT_EQ(continuous_context->get_continuous_state().size(),
             time_stepping_context->get_discrete_state(0).size());
 
   // Check that the dynamics of the time-stepping model match the
@@ -557,15 +557,15 @@ GTEST_TEST(rigid_body_plant_test, BasicTimeSteppingTest) {
   time_stepping_plant.CalcDiscreteVariableUpdates(
       *time_stepping_context, updates.get());
 
-  const VectorXd x = continuous_context->get_continuous_state()->CopyToVector();
+  const VectorXd x = continuous_context->get_continuous_state().CopyToVector();
   EXPECT_TRUE(CompareMatrices(
       x, time_stepping_context->get_discrete_state(0).CopyToVector()));
 
   const VectorXd q = continuous_context->get_continuous_state()
-                         ->get_generalized_position()
+                         .get_generalized_position()
                          .CopyToVector();
   const VectorXd v = continuous_context->get_continuous_state()
-                         ->get_generalized_velocity()
+                         .get_generalized_velocity()
                          .CopyToVector();
 
   const VectorXd vn =

--- a/drake/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
+++ b/drake/multibody/test/rigid_body_tree/rigid_body_tree_clone_test.cc
@@ -121,12 +121,11 @@ class TestRbtCloneDiagram : public Diagram<double> {
   void SetInitialState(Context<double>* context, double q, double v) {
     Context<double>& plant_context =
         GetMutableSubsystemContext(*plant_, context);
-    ContinuousState<double>* plant_state =
+    ContinuousState<double>& plant_state =
         plant_context.get_mutable_continuous_state();
-    DRAKE_DEMAND(plant_state != nullptr);
-    DRAKE_DEMAND(plant_state->size() == 2);
-    (*plant_state)[0] = q;
-    (*plant_state)[1] = v;
+    DRAKE_DEMAND(plant_state.size() == 2);
+    plant_state[0] = q;
+    plant_state[1] = v;
   }
 
   const SignalLogger<double>& get_logger() const { return *logger_; }
@@ -154,13 +153,13 @@ TEST_F(RigidBodyTreeCloneTest, PendulumDynamicsTest) {
   unique_ptr<Context<double>> original_context =
       original_diagram.AllocateContext();
   original_diagram.SetDefaultState(
-      *original_context, original_context->get_mutable_state());
+      *original_context, &original_context->get_mutable_state());
   original_diagram.SetInitialState(original_context.get(), 1.57, 0);
 
   unique_ptr<Context<double>> cloned_context =
       cloned_diagram.AllocateContext();
   cloned_diagram.SetDefaultState(
-      *cloned_context, cloned_context->get_mutable_state());
+      *cloned_context, &cloned_context->get_mutable_state());
   cloned_diagram.SetInitialState(cloned_context.get(), 1.57, 0);
 
   // Instantiates the simulators.
@@ -187,10 +186,10 @@ TEST_F(RigidBodyTreeCloneTest, PendulumDynamicsTest) {
   const double integrator_step_size = swing_period / 100;
   original_simulator.reset_integrator<ExplicitEulerIntegrator<double>>(
       original_diagram, integrator_step_size,
-      original_simulator.get_mutable_context());
+      &original_simulator.get_mutable_context());
   cloned_simulator.reset_integrator<ExplicitEulerIntegrator<double>>(
       cloned_diagram, integrator_step_size,
-      cloned_simulator.get_mutable_context());
+      &cloned_simulator.get_mutable_context());
 
   original_simulator.Initialize();
   cloned_simulator.Initialize();

--- a/drake/systems/analysis/explicit_euler_integrator.h
+++ b/drake/systems/analysis/explicit_euler_integrator.h
@@ -64,7 +64,7 @@ template <class T>
 bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
-  VectorBase<T>* xc = context->get_mutable_continuous_state_vector();
+  VectorBase<T>& xc = context->get_mutable_continuous_state_vector();
 
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
@@ -73,7 +73,7 @@ bool ExplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Compute derivative and update configuration and velocity.
   // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))
   const auto& xcdot = derivs_->get_vector();
-  xc->PlusEqScaled(dt, xcdot);  // xc += dt * xcdot
+  xc.PlusEqScaled(dt, xcdot);  // xc += dt * xcdot
   context->set_time(context->get_time() + dt);
 
   // This integrator always succeeds at taking the step.

--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -91,7 +91,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::ComputeAutoDiffJacobian(
                context.get_time());
   // Create AutoDiff versions of the state vector.
   typedef AutoDiffXd Scalar;
-  VectorX<Scalar> a_xtplus = context.get_continuous_state()->CopyToVector();
+  VectorX<Scalar> a_xtplus = context.get_continuous_state().CopyToVector();
 
   // Set the size of the derivatives and prepare for Jacobian calculation.
   const int n_state_dim = a_xtplus.size();
@@ -112,7 +112,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::ComputeAutoDiffJacobian(
   adiff_system->FixInputPortsFrom(system, context, adiff_context.get());
 
   // Set the continuous state in the context.
-  adiff_context->get_mutable_continuous_state()->get_mutable_vector()->
+  adiff_context->get_mutable_continuous_state().get_mutable_vector().
       SetFromVector(a_xtplus);
 
   // Evaluate the derivatives at that state.
@@ -447,7 +447,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
   // at t+dt.
   const T tf = context->get_time() + dt;
   context->set_time(tf);
-  context->get_mutable_continuous_state()->SetFromVector(*xtplus);
+  context->get_mutable_continuous_state().SetFromVector(*xtplus);
 
   // Evaluate the residual error using the current x(t+h) as x⁰(t+h):
   // g(x⁰(t+h)) = x⁰(t+h) - x(t) - h f(t+h,x⁰(t+h)), where h = dt;
@@ -484,7 +484,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     VectorX<T> dx = Solve(goutput);
 
     // Get the infinity norm of the weighted update vector.
-    dx_state_->get_mutable_vector()->SetFromVector(dx);
+    dx_state_->get_mutable_vector().SetFromVector(dx);
     T dx_norm = this->CalcStateChangeNorm(*dx_state_);
 
     // Update the state vector.
@@ -497,7 +497,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     // equivalent to last_dx_norm, making theta = 1, and eta = infinity. Thus,
     // convergence would never be identified.
     if (dx_norm < 10 * std::numeric_limits<double>::epsilon()) {
-      context->get_mutable_continuous_state()->SetFromVector(*xtplus);
+      context->get_mutable_continuous_state().SetFromVector(*xtplus);
       last_call_failed_ = false;
       return true;
     }
@@ -527,7 +527,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
       if (eta * dx_norm < k_dot_tol) {
         SPDLOG_DEBUG(drake::log(), "Newton-Raphson converged; η = {}, h = {}",
                      eta, dt);
-        context->get_mutable_continuous_state()->SetFromVector(*xtplus);
+        context->get_mutable_continuous_state().SetFromVector(*xtplus);
         last_call_failed_ = false;
         return true;
       }
@@ -537,7 +537,7 @@ bool ImplicitEulerIntegrator<T>::StepAbstract(const T& dt,
     last_dx_norm = dx_norm;
 
     // Update the state in the context and compute g(xⁱ⁺¹).
-    context->get_mutable_continuous_state()->SetFromVector(*xtplus);
+    context->get_mutable_continuous_state().SetFromVector(*xtplus);
     goutput = g();
   }
 
@@ -573,7 +573,7 @@ bool ImplicitEulerIntegrator<T>::StepImplicitEuler(const T& dt) {
   // Set g for the implicit Euler method.
   std::function<VectorX<T>()> g =
       [&xt0, dt, context, this]() {
-        return (context->get_continuous_state()->CopyToVector() - xt0 -
+        return (context->get_continuous_state().CopyToVector() - xt0 -
             dt*CalcTimeDerivativesUsingContext()).eval();
       };
 
@@ -617,7 +617,7 @@ bool ImplicitEulerIntegrator<T>::StepImplicitTrapezoid(const T& dt,
   // evaluate it at the current x(t+h).
   std::function<VectorX<T>()> g =
       [&xt0, dt, &dx0, context, this]() {
-        return (context->get_continuous_state()->CopyToVector() - xt0 -
+        return (context->get_continuous_state().CopyToVector() - xt0 -
             dt/2*(dx0 + CalcTimeDerivativesUsingContext().eval())).eval();
       };
 
@@ -667,7 +667,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::CalcJacobian(const T& t,
 
   // Update the time and state.
   context->set_time(t);
-  context->get_mutable_continuous_state_vector()->SetFromVector(x);
+  context->get_mutable_continuous_state_vector().SetFromVector(x);
   num_jacobian_evaluations_++;
 
   // Get the current number of ODE evaluations.
@@ -677,18 +677,18 @@ MatrixX<T> ImplicitEulerIntegrator<T>::CalcJacobian(const T& t,
   const System<T>& system = this->get_system();
 
   // Get the mutable continuous state.
-  ContinuousState<T>* continuous_state = context->
+  ContinuousState<T>& continuous_state = context->
       get_mutable_continuous_state();
 
   // TODO(edrumwri): Give the caller the option to provide their own Jacobian.
   MatrixX<T> J;
   switch (jacobian_scheme_) {
     case JacobianComputationScheme::kForwardDifference:
-      J = ComputeForwardDiffJacobian(system, *context, continuous_state);
+      J = ComputeForwardDiffJacobian(system, *context, &continuous_state);
       break;
 
     case JacobianComputationScheme::kCentralDifference:
-      J = ComputeCentralDiffJacobian(system, *context, continuous_state);
+      J = ComputeCentralDiffJacobian(system, *context, &continuous_state);
       break;
 
     case JacobianComputationScheme::kAutomatic:
@@ -707,7 +707,7 @@ MatrixX<T> ImplicitEulerIntegrator<T>::CalcJacobian(const T& t,
 
   // Reset the time and state.
   context->set_time(t_current);
-  continuous_state->SetFromVector(x_current);
+  continuous_state.SetFromVector(x_current);
 
   return J;
 }
@@ -756,7 +756,7 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& dt,
 
   // Reset the state.
   context->set_time(t0);
-  context->get_mutable_continuous_state()->SetFromVector(xt0);
+  context->get_mutable_continuous_state().SetFromVector(xt0);
 
   // The error estimation process uses the implicit trapezoid method, which
   // is defined as:
@@ -783,7 +783,7 @@ bool ImplicitEulerIntegrator<T>::AttemptStepPaired(const T& dt,
     //                 instead as *the* solution, rather than the implicit
     //                 Euler. Refer to [Lambert, 1991], Ch 6.
     context->set_time(t0 + dt);
-    context->get_mutable_continuous_state()->SetFromVector(*xtplus_ie);
+    context->get_mutable_continuous_state().SetFromVector(*xtplus_ie);
     return true;
   } else {
     SPDLOG_DEBUG(drake::log(), "Implicit trapezoid approach FAILED with a step"
@@ -803,7 +803,7 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
   // Save the current time and state.
   Context<T>* context = this->get_mutable_context();
   const T t0 = context->get_time();
-  const VectorX<T> xt0 = context->get_continuous_state()->CopyToVector();
+  const VectorX<T> xt0 = context->get_continuous_state().CopyToVector();
 
   SPDLOG_DEBUG(drake::log(), "IE DoStep(h={}) t={}", dt, t0);
 
@@ -845,7 +845,7 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
     xtplus_ie = xt0 + dt*derivs_->CopyToVector();
 
     // Do one half step.
-    context->get_mutable_continuous_state()->SetFromVector(
+    context->get_mutable_continuous_state().SetFromVector(
         xt0 + half_dt*derivs_->CopyToVector());
     context->set_time(t0 + half_dt);
 
@@ -853,7 +853,7 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
     const VectorX<T> xtpoint5 = context->get_continuous_state_vector().
         CopyToVector();
     this->CalcTimeDerivatives(*context, derivs_.get());
-    context->get_mutable_continuous_state()->SetFromVector(
+    context->get_mutable_continuous_state().SetFromVector(
         xtpoint5 + half_dt*derivs_->CopyToVector());
     context->set_time(t0 + dt);
 
@@ -863,7 +863,7 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
     // Set the "trapezoid" state to be the result of taking two explicit Euler
     // half steps. since the code below the if/then/else block
     // simply subtracts the two results to obtain the error estimate.
-    xtplus_itr = context->get_continuous_state()->CopyToVector();
+    xtplus_itr = context->get_continuous_state().CopyToVector();
   } else {
     // Try taking the requested step.
     bool success = AttemptStepPaired(dt, &xtplus_ie, &xtplus_itr);
@@ -871,19 +871,19 @@ bool ImplicitEulerIntegrator<T>::DoStep(const T& dt) {
     // If the step was not successful, reset the time and state.
     if (!success) {
       context->set_time(t0);
-      context->get_mutable_continuous_state()->SetFromVector(xt0);
+      context->get_mutable_continuous_state().SetFromVector(xt0);
       return false;
     }
   }
 
   // Reset the error estimate.
-  err_est_vec_.setZero(context->get_continuous_state()->size());
+  err_est_vec_.setZero(context->get_continuous_state().size());
 
   // Compute and update the error estimate.
   err_est_vec_ += xtplus_ie - xtplus_itr;
 
   // Update the caller-accessible error estimate.
-  this->get_mutable_error_estimate()->get_mutable_vector()->
+  this->get_mutable_error_estimate()->get_mutable_vector().
       SetFromVector(err_est_vec_);
 
   return true;

--- a/drake/systems/analysis/integrator_base.h
+++ b/drake/systems/analysis/integrator_base.h
@@ -467,8 +467,8 @@ class IntegratorBase {
       err_est_ = system_.AllocateTimeDerivatives();
 
       const auto& xc = context_->get_state().get_continuous_state();
-      const int gv_size = xc->get_generalized_velocity().size();
-      const int misc_size = xc->get_misc_continuous_state().size();
+      const int gv_size = xc.get_generalized_velocity().size();
+      const int misc_size = xc.get_misc_continuous_state().size();
       if (qbar_weight_.size() != gv_size) qbar_weight_.setOnes(gv_size);
       if (z_weight_.size() != misc_size) z_weight_.setOnes(misc_size);
 
@@ -1407,9 +1407,9 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
   // revert time and state.
   const Context<T>& context = get_context();
   const T current_time = context.get_time();
-  VectorBase<T>* xc =
+  VectorBase<T>& xc =
       get_mutable_context()->get_mutable_continuous_state_vector();
-  xc0_save_ = xc->CopyToVector();
+  xc0_save_ = xc.CopyToVector();
 
   // Set the step size to attempt.
   T step_size_to_attempt = get_ideal_next_step_size();
@@ -1510,7 +1510,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
 
       // Reset the time, state, and time derivative at t0.
       get_mutable_context()->set_time(current_time);
-      xc->SetFromVector(xc0_save_);
+      xc.SetFromVector(xc0_save_);
     }
   } while (!step_succeeded);
 
@@ -1767,7 +1767,7 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::IntegrateAtMost(
 
   // If there is no continuous state, there will be no need to limit the
   // integration step size.
-  if (get_context().get_continuous_state()->size() == 0) {
+  if (get_context().get_continuous_state().size() == 0) {
     Context<T>* context = get_mutable_context();
     context->set_time(context->get_time() + dt);
     return candidate_result;

--- a/drake/systems/analysis/runge_kutta2_integrator.h
+++ b/drake/systems/analysis/runge_kutta2_integrator.h
@@ -60,7 +60,7 @@ template <class T>
 bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
   // Find the continuous state xc within the Context, just once.
   auto context = IntegratorBase<T>::get_mutable_context();
-  VectorBase<T>* xc = context->get_mutable_continuous_state_vector();
+  VectorBase<T>& xc = context->get_mutable_continuous_state_vector();
 
   // TODO(sherm1) This should be calculating into the cache so that
   // Publish() doesn't have to recalculate if it wants to output derivatives.
@@ -69,7 +69,7 @@ bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
   // First stage is an explicit Euler step:
   // xc(t+h) = xc(t) + dt * xcdot(t, xc(t), u(t))
   const auto& xcdot0 = derivs0_->get_vector();
-  xc->PlusEqScaled(dt, xcdot0);  // xc += dt * xcdot0
+  xc.PlusEqScaled(dt, xcdot0);  // xc += dt * xcdot0
   T t = IntegratorBase<T>::get_context().get_time() + dt;
   IntegratorBase<T>::get_mutable_context()->set_time(t);
 
@@ -78,8 +78,8 @@ bool RungeKutta2Integrator<T>::DoStep(const T& dt) {
   const auto& xcdot1 = derivs1_->get_vector();
 
   // TODO(sherm1) Use better operators when available.
-  xc->PlusEqScaled(dt / 2, xcdot1);
-  xc->PlusEqScaled(-dt / 2, xcdot0);
+  xc.PlusEqScaled(dt / 2, xcdot1);
+  xc.PlusEqScaled(-dt / 2, xcdot0);
 
   // RK2 always succeeds at taking the step.
   return true;

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -54,9 +54,9 @@ bool RungeKutta3Integrator<T>::DoStep(const T& dt) {
   using std::abs;
 
   // Find the continuous state xc within the Context, just once.
-  VectorBase<T>* xc = this->get_mutable_context()
+  VectorBase<T>& xc = this->get_mutable_context()
                           ->get_mutable_continuous_state_vector();
-  const VectorX<T> xt0 = xc->CopyToVector();
+  const VectorX<T> xt0 = xc.CopyToVector();
 
   // Setup ta and tb.
   T ta = this->get_context().get_time();
@@ -71,35 +71,35 @@ bool RungeKutta3Integrator<T>::DoStep(const T& dt) {
 
   // Compute the first intermediate state and derivative (at t=0.5, x(0.5)).
   this->get_mutable_context()->set_time(ta + dt * 0.5);
-  xc->PlusEqScaled(dt * 0.5, xcdot0);
+  xc.PlusEqScaled(dt * 0.5, xcdot0);
   this->CalcTimeDerivatives(context, derivs1_.get());
   const auto& xcdot1 = derivs1_->get_vector();
 
   // Compute the second intermediate state and derivative (at t=1, x(1)).
   this->get_mutable_context()->set_time(tb);
-  xc->SetFromVector(xt0);
-  xc->PlusEqScaled({{-dt, xcdot0}, {dt * 2, xcdot1}});
+  xc.SetFromVector(xt0);
+  xc.PlusEqScaled({{-dt, xcdot0}, {dt * 2, xcdot1}});
   this->CalcTimeDerivatives(context, derivs2_.get());
   const auto& xcdot2 = derivs2_->get_vector();
 
   // calculate the state at dt.
   const double kOneSixth = 1.0 / 6.0;
-  xc->SetFromVector(xt0);
-  xc->PlusEqScaled({{dt * kOneSixth, xcdot0},
+  xc.SetFromVector(xt0);
+  xc.PlusEqScaled({{dt * kOneSixth, xcdot0},
                     {4.0 * dt * kOneSixth, xcdot1},
                     {dt * kOneSixth, xcdot2}});
 
   // If the state of the system has changed, the error estimate will no
   // longer be sized correctly. Verify that the error estimate is the
   // correct size.
-  DRAKE_DEMAND(this->get_error_estimate()->size() == xc->size());
+  DRAKE_DEMAND(this->get_error_estimate()->size() == xc.size());
 
   // Calculate the error estimate using an Eigen vector then copy it to the
   // continuous state vector, where the various state components can be
   // analyzed.
   err_est_vec_ = -xt0;
   xcdot0.ScaleAndAddToVector(-dt, err_est_vec_);
-  xc->ScaleAndAddToVector(1.0, err_est_vec_);
+  xc.ScaleAndAddToVector(1.0, err_est_vec_);
   err_est_vec_ = err_est_vec_.cwiseAbs();
   this->get_mutable_error_estimate()->SetFromVector(err_est_vec_);
 

--- a/drake/systems/analysis/test/discontinuous_spring_mass_damper_system.h
+++ b/drake/systems/analysis/test/discontinuous_spring_mass_damper_system.h
@@ -56,7 +56,7 @@ class DiscontinuousSpringMassDamperSystem final
   void DoCalcTimeDerivatives(const Context <T>& context,
                              ContinuousState <T>* derivatives) const override {
     // Get the current state of the spring.
-    const ContinuousState<T>& state = *context.get_continuous_state();
+    const ContinuousState<T>& state = context.get_continuous_state();
 
     // First element of the derivative is spring velocity.
     const T v = state[1];

--- a/drake/systems/analysis/test/explicit_error_controlled_integrator_test.h
+++ b/drake/systems/analysis/test/explicit_error_controlled_integrator_test.h
@@ -151,7 +151,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, BulletProofSetup) {
 
   // Get the final position.
   const double x_final =
-      this->context->get_continuous_state()->get_vector().GetAtIndex(0);
+      this->context->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Check the solution. We're not really looking for accuracy here, just
   // want to make sure that the value is finite.
@@ -246,7 +246,7 @@ TYPED_TEST_P(ExplicitErrorControlledIntegratorTest, SpringMassStepEC) {
 
   // Get the final position.
   const double x_final =
-      this->context->get_continuous_state()->get_vector().GetAtIndex(0);
+      this->context->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Store the number of integration steps.
   int fixed_steps = this->integrator->get_num_steps_taken();

--- a/drake/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -167,7 +167,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
 
   // Get the final position.
   const double x_final =
-      context->get_continuous_state()->get_vector().GetAtIndex(0);
+      context->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Check the solution.
   EXPECT_NEAR(c1 * std::cos(omega * t) + c2 * std::sin(omega * t), x_final,

--- a/drake/systems/analysis/test/implicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/implicit_euler_integrator_test.cc
@@ -35,8 +35,8 @@ class StationarySystem final : public LeafSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override {
     // State does not evolve.
-    derivatives->get_mutable_vector()->SetAtIndex(0, 0.0);
-    derivatives->get_mutable_vector()->SetAtIndex(1, 0.0);
+    derivatives->get_mutable_vector().SetAtIndex(0, 0.0);
+    derivatives->get_mutable_vector().SetAtIndex(1, 0.0);
   }
 };
 
@@ -48,10 +48,10 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Stationary) {
   std::unique_ptr<Context<double>> context = stationary->CreateDefaultContext();
 
   // Set the initial condition for the stationary system.
-  VectorBase<double>* state = context->get_mutable_continuous_state()->
+  VectorBase<double>& state = context->get_mutable_continuous_state().
       get_mutable_vector();
-  state->SetAtIndex(0, 0.0);
-  state->SetAtIndex(1, 0.0);
+  state.SetAtIndex(0, 0.0);
+  state.SetAtIndex(1, 0.0);
 
   // Create the integrator.
   ImplicitEulerIntegrator<double> integrator(*stationary, context.get());
@@ -64,8 +64,8 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Stationary) {
   integrator.IntegrateWithMultipleSteps(1.0);
 
   // Verify the solution.
-  EXPECT_NEAR(state->GetAtIndex(0), 0, std::numeric_limits<double>::epsilon());
-  EXPECT_NEAR(state->GetAtIndex(1), 0, std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(state.GetAtIndex(0), 0, std::numeric_limits<double>::epsilon());
+  EXPECT_NEAR(state.GetAtIndex(1), 0, std::numeric_limits<double>::epsilon());
 }
 
 // Tests the implicit integrator on Robertson's stiff chemical reaction
@@ -78,11 +78,11 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Robertson) {
   std::unique_ptr<Context<double>> context = robertson->CreateDefaultContext();
 
   // Set the initial conditions for Robertson's system.
-  VectorBase<double>* state = context->get_mutable_continuous_state()->
+  VectorBase<double>& state = context->get_mutable_continuous_state().
                                 get_mutable_vector();
-  state->SetAtIndex(0, 1);
-  state->SetAtIndex(1, 0);
-  state->SetAtIndex(2, 0);
+  state.SetAtIndex(0, 1);
+  state.SetAtIndex(1, 0);
+  state.SetAtIndex(2, 0);
 
   const double t_final = robertson->get_end_time();
   const double tol = 5e-5;
@@ -108,9 +108,9 @@ GTEST_TEST(ImplicitEulerIntegratorTest, Robertson) {
 
   // Verify the solution.
   const Eigen::Vector3d sol = robertson->GetSolution(t_final);
-  EXPECT_NEAR(state->GetAtIndex(0), sol(0), tol);
-  EXPECT_NEAR(state->GetAtIndex(1), sol(1), tol);
-  EXPECT_NEAR(state->GetAtIndex(2), sol(2), tol);
+  EXPECT_NEAR(state.GetAtIndex(0), sol(0), tol);
+  EXPECT_NEAR(state.GetAtIndex(1), sol(1), tol);
+  EXPECT_NEAR(state.GetAtIndex(2), sol(2), tol);
 }
 
 class ImplicitIntegratorTest : public ::testing::TestWithParam<bool> {
@@ -331,8 +331,8 @@ TEST_P(ImplicitIntegratorTest, DoubleSpringMassDamper) {
 
   // Get the solution at the target time.
   const double t_final = 1.0;
-  stiff_double_system_->GetSolution(*dspring_context_, t_final,
-                                    state_copy->get_mutable_continuous_state());
+  stiff_double_system_->GetSolution(
+      *dspring_context_, t_final, &state_copy->get_mutable_continuous_state());
 
   // Take all the defaults.
   integrator.Initialize();
@@ -341,9 +341,9 @@ TEST_P(ImplicitIntegratorTest, DoubleSpringMassDamper) {
   integrator.IntegrateWithMultipleSteps(t_final);
 
   // Check the solution.
-  const VectorX<double> nsol = dspring_context_->get_continuous_state()->
+  const VectorX<double> nsol = dspring_context_->get_continuous_state().
       get_generalized_position().CopyToVector();
-  const VectorX<double> sol = state_copy->get_continuous_state()->
+  const VectorX<double> sol = state_copy->get_continuous_state().
       get_generalized_position().CopyToVector();
 
   for (int i = 0; i < nsol.size(); ++i)
@@ -388,7 +388,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassDamperStiff) {
   EXPECT_NEAR(context_->get_time(), t_final, ttol);
 
   // Get the final position and velocity.
-  const VectorBase<double>& xc_final = context_->get_continuous_state()->
+  const VectorBase<double>& xc_final = context_->get_continuous_state().
       get_vector();
   double x_final = xc_final.GetAtIndex(0);
   double v_final = xc_final.GetAtIndex(1);
@@ -489,7 +489,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStep) {
 
   // Get the final position.
   double x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Compute the true solution at t_final.
   double x_final_true, v_final_true;
@@ -518,7 +518,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStep) {
 
   // Check results again.
   x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
   EXPECT_NEAR(x_final_true, x_final, 5e-3);
   EXPECT_NEAR(context_->get_time(), t_final, ttol);
 
@@ -540,7 +540,7 @@ TEST_P(ImplicitIntegratorTest, SpringMassStep) {
 
   // Check results again.
   x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
   EXPECT_NEAR(x_final_true, x_final, 5e-3);
   EXPECT_NEAR(context_->get_time(), t_final, ttol);
 
@@ -619,7 +619,7 @@ TEST_P(ImplicitIntegratorTest, ErrorEstimation) {
 
       // Get the final position of the spring.
       const double x_final =
-          context_->get_continuous_state()->get_vector().GetAtIndex(0);
+          context_->get_continuous_state().get_vector().GetAtIndex(0);
 
       // Get the true position.
       double x_final_true, v_final_true;
@@ -730,7 +730,7 @@ TEST_P(ImplicitIntegratorTest, DiscontinuousSpringMassDamper) {
 
   // Get the final position.
   double x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Verify that solution and integrator statistics are valid and reset the
   // statistics.
@@ -752,7 +752,7 @@ TEST_P(ImplicitIntegratorTest, DiscontinuousSpringMassDamper) {
 
   // Check the solution and the time again, and reset the statistics again.
   x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
   EXPECT_NEAR(context_->get_time(), t_final, ttol);
   EXPECT_NEAR(0.0, x_final, sol_tol);
   CheckGeneralStatsValidity(&integrator);
@@ -772,7 +772,7 @@ TEST_P(ImplicitIntegratorTest, DiscontinuousSpringMassDamper) {
 
   // Check the solution and the time again.
   x_final =
-      context_->get_continuous_state()->get_vector().GetAtIndex(0);
+      context_->get_continuous_state().get_vector().GetAtIndex(0);
   EXPECT_NEAR(context_->get_time(), t_final, ttol);
   EXPECT_NEAR(0.0, x_final, sol_tol);
   CheckGeneralStatsValidity(&integrator);

--- a/drake/systems/analysis/test/logistic_system.h
+++ b/drake/systems/analysis/test/logistic_system.h
@@ -35,7 +35,7 @@ class LogisticWitness : public systems::WitnessFunction<T> {
 
   // The witness function is simply the state value itself.
   T DoEvaluate(const Context<T>& context) const override {
-    return (*context.get_continuous_state())[0];
+    return context.get_continuous_state()[0];
   }
 };
 
@@ -68,7 +68,7 @@ class LogisticSystem : public LeafSystem<T> {
     const T& t = context.get_time();
 
     // Get state.
-    const T& x = (*context.get_continuous_state())[0];
+    const T& x = context.get_continuous_state()[0];
 
     // Compute the derivative.
     (*continuous_state)[0] = alpha_ * (1 - pow(x/k_, nu_)) * t;

--- a/drake/systems/analysis/test/my_spring_mass_system.h
+++ b/drake/systems/analysis/test/my_spring_mass_system.h
@@ -28,16 +28,6 @@ class MySpringMassSystem : public SpringMassSystem<T> {
 
   int get_update_count() const { return update_count_; }
 
-  /** There are no discrete variables in this system, but it does use
-   * a discrete update with zero variables. In other words, this function
-   * is a kludge until discrete variables are automatically allocated in
-   * a system.
-   */
-  std::unique_ptr<DiscreteValues<T>> AllocateDiscreteVariables()
-      const override {
-    return std::make_unique<DiscreteValues<T>>();
-  }
-
  private:
   // Publish t q u to standard output.
   void DoPublish(const Context<T>&,

--- a/drake/systems/analysis/test/robertson_system.h
+++ b/drake/systems/analysis/test/robertson_system.h
@@ -38,9 +38,9 @@ class RobertsonSystem : public LeafSystem<T> {
     T y3_prime = 3e7 * y2 * y2;
 
     // Set the derivatives.
-    deriv->get_mutable_vector()->SetAtIndex(0, y1_prime);
-    deriv->get_mutable_vector()->SetAtIndex(1, y2_prime);
-    deriv->get_mutable_vector()->SetAtIndex(2, y3_prime);
+    deriv->get_mutable_vector().SetAtIndex(0, y1_prime);
+    deriv->get_mutable_vector().SetAtIndex(1, y2_prime);
+    deriv->get_mutable_vector().SetAtIndex(2, y3_prime);
   }
 
   /// Gets the end time for integration.

--- a/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/drake/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -82,7 +82,7 @@ GTEST_TEST(RK3RK2IntegratorTest, RigidBody) {
 
   // Re-integrate with RK3
   context->set_time(0.);
-  plant.SetDefaultState(*context, context->get_mutable_state());
+  plant.SetDefaultState(*context, &context->get_mutable_state());
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
   // Reset the non-identity position and orientation.

--- a/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
+++ b/drake/systems/analysis/test/semi_explicit_euler_integrator_test.cc
@@ -80,7 +80,7 @@ GTEST_TEST(IntegratorTest, RigidBody) {
   auto context = plant.CreateDefaultContext();
 
   // Set free_body to have zero translation, zero rotation, and zero velocity.
-  plant.SetDefaultState(*context, context->get_mutable_state());
+  plant.SetDefaultState(*context, &context->get_mutable_state());
 
   Eigen::Vector3d v0(1, 2, 3);    // Linear velocity in body's frame.
   Eigen::Vector3d w0(-4, 5, 6);  // Angular velocity in body's frame.
@@ -111,7 +111,7 @@ GTEST_TEST(IntegratorTest, RigidBody) {
 
   // Re-integrate with semi-explicit Euler.
   context->set_time(0.);
-  plant.SetDefaultState(*context, context->get_mutable_state());
+  plant.SetDefaultState(*context, &context->get_mutable_state());
   for (int i=0; i< plant.get_num_velocities(); ++i)
     plant.set_velocity(context.get(), i, generalized_velocities[i]);
   SemiExplicitEulerIntegrator<double> see(plant, small_dt, context.get());
@@ -181,7 +181,7 @@ GTEST_TEST(IntegratorTest, SpringMassStep) {
 
   // Get the final position.
   const double x_final =
-      context->get_continuous_state()->get_vector().GetAtIndex(0);
+      context->get_continuous_state().get_vector().GetAtIndex(0);
 
   // Check the solution.
   EXPECT_NEAR(c1 * std::cos(kOmega * t) + c2 * std::sin(kOmega * t), x_final,

--- a/drake/systems/analysis/test/simulator_test.cc
+++ b/drake/systems/analysis/test/simulator_test.cc
@@ -101,9 +101,9 @@ GTEST_TEST(SimulatorTest, NoContinuousStateYieldsSingleStep) {
   // time step.
   const double dt = 1e-3;
   Simulator<double> simulator(system);
-  Context<double>* context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
   simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
-      context);
+      &context);
   simulator.StepTo(final_time);
 
   EXPECT_EQ(simulator.get_num_steps_taken(), 1);
@@ -128,12 +128,12 @@ GTEST_TEST(SimulatorTest, DiagramWitness) {
   const double dt = 1;
   Simulator<double> simulator(system);
   simulator.set_publish_at_initialization(false);
-  Context<double>* context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
   simulator.reset_integrator<RungeKutta2Integrator<double>>(system, dt,
-                                                            context);
+                                                            &context);
   simulator.set_publish_every_time_step(false);
 
-  context->set_time(0);
+  context.set_time(0);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -213,8 +213,8 @@ void DisableDefaultPublishing(Simulator<double>* s) {
 // function related tests.
 void InitFixedStepIntegratorForWitnessTesting(Simulator<double>* s, double dt) {
   const System<double>& system = s->get_system();
-  auto context = s->get_mutable_context();
-  s->reset_integrator<RungeKutta2Integrator<double>>(system, dt, context);
+  Context<double>& context = s->get_mutable_context();
+  s->reset_integrator<RungeKutta2Integrator<double>>(system, dt, &context);
   s->get_mutable_integrator()->set_fixed_step_mode(true);
   s->get_mutable_integrator()->set_maximum_step_size(dt);
   DisableDefaultPublishing(s);
@@ -224,8 +224,8 @@ void InitFixedStepIntegratorForWitnessTesting(Simulator<double>* s, double dt) {
 // function related tests.
 void InitVariableStepIntegratorForWitnessTesting(Simulator<double>* s) {
   const System<double>& system = s->get_system();
-  auto context = s->get_mutable_context();
-  s->reset_integrator<RungeKutta3Integrator<double>>(system, context);
+  Context<double>& context = s->get_mutable_context();
+  s->reset_integrator<RungeKutta3Integrator<double>>(system, &context);
   DisableDefaultPublishing(s);
 }
 
@@ -244,8 +244,8 @@ GTEST_TEST(SimulatorTest, FixedStepNoIsolation) {
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
 
-  Context<double>* context = simulator.get_mutable_context();
-  (*context->get_mutable_continuous_state())[0] = -1;
+  Context<double>& context = simulator.get_mutable_context();
+  context.get_mutable_continuous_state()[0] = -1;
   simulator.StepTo(dt);
 
   // Verify that no witness isolation is done.
@@ -275,11 +275,11 @@ GTEST_TEST(SimulatorTest, VariableStepIsolation) {
 
   Simulator<double> simulator(system);
   InitVariableStepIntegratorForWitnessTesting(&simulator);
-  Context<double>* context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
 
   // Set the initial accuracy in the context.
   double accuracy = 1.0;
-  context->set_accuracy(accuracy);
+  context.set_accuracy(accuracy);
 
   // Set the initial empty system evaluation.
   double eval = std::numeric_limits<double>::infinity();
@@ -297,7 +297,7 @@ GTEST_TEST(SimulatorTest, VariableStepIsolation) {
     // Increase the accuracy, which should shrink the isolation window when
     // next retrieved.
     accuracy *= 0.1;
-    context->set_accuracy(accuracy);
+    context.set_accuracy(accuracy);
   }
 }
 
@@ -318,16 +318,16 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
   const double dt = 10;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
 
   // Get the (one) witness function.
   std::vector<const WitnessFunction<double>*> witness;
-  system.GetWitnessFunctions(*context, &witness);
+  system.GetWitnessFunctions(context, &witness);
   DRAKE_DEMAND(witness.size() == 1);
 
   // Set the initial accuracy in the context.
   double accuracy = 1.0;
-  context->set_accuracy(accuracy);
+  context.set_accuracy(accuracy);
 
   // Set the initial empty system evaluation.
   double eval = std::numeric_limits<double>::infinity();
@@ -335,14 +335,14 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
   // Loop, decreasing accuracy as we go.
   while (accuracy > 1e-8) {
     // (Re)set the time and initial state.
-    context->set_time(0);
+    context.set_time(0);
 
     // Simulate to dt.
     simulator.StepTo(dt);
 
     // Evaluate the witness function.
-    context->set_time(publish_time);
-    double new_eval = witness.front()->Evaluate(*context);
+    context.set_time(publish_time);
+    double new_eval = witness.front()->Evaluate(context);
 
     // Verify that the new evaluation is closer to zero than the old one.
     EXPECT_LT(new_eval, eval);
@@ -350,7 +350,7 @@ GTEST_TEST(SimulatorTest, FixedStepIncreasingIsolationAccuracy) {
 
     // Increase the accuracy.
     accuracy *= 0.1;
-    context->set_accuracy(accuracy);
+    context.set_accuracy(accuracy);
   }
 }
 
@@ -389,18 +389,18 @@ GTEST_TEST(SimulatorTest, MultipleWitnesses) {
   Simulator<double> simulator(system);
   DisableDefaultPublishing(&simulator);
   simulator.reset_integrator<ImplicitEulerIntegrator<double>>(system,
-                                              simulator.get_mutable_context());
+                                              &simulator.get_mutable_context());
   simulator.get_mutable_integrator()->set_maximum_step_size(dt);
   simulator.get_mutable_integrator()->set_target_accuracy(0.1);
 
   // Set initial time and state.
-  Context<double>* context = simulator.get_mutable_context();
-  (*context->get_mutable_continuous_state())[0] = -1;
-  context->set_time(0);
+  Context<double>& context = simulator.get_mutable_context();
+  context.get_mutable_continuous_state()[0] = -1;
+  context.set_time(0);
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-10;
-  context->set_accuracy(tol);
+  context.set_accuracy(tol);
 
   // Simulate.
   simulator.StepTo(0.1);
@@ -455,7 +455,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesIdentical) {
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
-  simulator->get_mutable_context()->set_accuracy(tol);
+  simulator->get_mutable_context().set_accuracy(tol);
 
   // Simulate.
   simulator->StepTo(10);
@@ -494,7 +494,7 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesStaggered) {
 
   // Isolate witness functions to high accuracy.
   const double tol = 1e-12;
-  simulator.get_mutable_context()->set_accuracy(tol);
+  simulator.get_mutable_context().set_accuracy(tol);
 
   // Get the isolation interval tolerance.
   const optional<double> iso_tol = simulator.GetCurrentWitnessTimeIsolation();
@@ -527,8 +527,8 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegToZero) {
   const double dt = 1;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
-  context->set_time(0);
+  Context<double>& context = simulator.get_mutable_context();
+  context.set_time(0);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -551,8 +551,8 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleZeroToPos) {
   const double dt = 1;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
-  context->set_time(0);
+  Context<double>& context = simulator.get_mutable_context();
+  context.set_time(0);
   simulator.StepTo(1);
 
   // Verify that no publication is performed when stepping to 1.
@@ -574,8 +574,8 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimplePositiveToNegative) {
   const double dt = 1;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
-  context->set_time(0);
+  Context<double>& context = simulator.get_mutable_context();
+  context.set_time(0);
   simulator.StepTo(2);
 
   // Publication should not occur (witness function should initially evaluate
@@ -597,8 +597,8 @@ GTEST_TEST(SimulatorTest, WitnessTestCountSimpleNegativeToPositive) {
   const double dt = 1;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
-  context->set_time(-1);
+  Context<double>& context = simulator.get_mutable_context();
+  context.set_time(-1);
   simulator.StepTo(1);
 
   // Publication should occur at witness function crossing.
@@ -620,8 +620,8 @@ GTEST_TEST(SimulatorTest, WitnessTestCountChallenging) {
   const double dt = 1e-6;
   Simulator<double> simulator(system);
   InitFixedStepIntegratorForWitnessTesting(&simulator, dt);
-  Context<double>* context = simulator.get_mutable_context();
-  (*context->get_mutable_continuous_state())[0] = -1;
+  Context<double>& context = simulator.get_mutable_context();
+  context.get_mutable_continuous_state()[0] = -1;
   simulator.StepTo(1e-4);
 
   // Publication should occur only at witness function crossing.
@@ -661,12 +661,12 @@ GTEST_TEST(SimulatorTest, MiscAPI) {
   // Set the integrator default step size.
   const double dt = 1e-3;
 
-  // Create a context.
-  auto context = simulator.get_mutable_context();
+  // Get the context.
+  Context<double>& context = simulator.get_mutable_context();
 
   // Create the integrator.
   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
-                                                              context);
+                                                              &context);
 
   // Initialize the simulator first.
   simulator.Initialize();
@@ -680,20 +680,21 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   const double dt = 1e-3;
 
   // Get the context.
-  auto context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
 
   // Create the integrator.
   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
-                                                              context);
+                                                              &context);
 
   // Initialize the simulator first.
   simulator.Initialize();
 
   // Try some other context stuff.
-  simulator.get_mutable_context()->set_time(3.);
+  simulator.get_mutable_context().set_time(3.);
   EXPECT_EQ(simulator.get_context().get_time(), 3.);
+  EXPECT_TRUE(simulator.has_context());
   simulator.release_context();
-  EXPECT_TRUE(simulator.get_mutable_context() == nullptr);
+  EXPECT_FALSE(simulator.has_context());
   EXPECT_THROW(simulator.Initialize(), std::logic_error);
 
   // Create another context.
@@ -701,8 +702,9 @@ GTEST_TEST(SimulatorTest, ContextAccess) {
   ucontext->set_time(3.);
   simulator.reset_context(std::move(ucontext));
   EXPECT_EQ(simulator.get_context().get_time(), 3.);
+  EXPECT_TRUE(simulator.has_context());
   simulator.reset_context(nullptr);
-  EXPECT_TRUE(simulator.get_mutable_context() == nullptr);
+  EXPECT_FALSE(simulator.has_context());
 }
 
 // Try a purely continuous system with no sampling.
@@ -717,14 +719,14 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
   // Set initial condition using the Simulator's internal Context.
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
 
   // Get the context.
-  auto context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
 
   // Create the integrator.
   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
-                                                              context);
+                                                              &context);
 
   simulator.set_target_realtime_rate(0.5);
   // Set the integrator and initialize the simulator.
@@ -733,7 +735,7 @@ GTEST_TEST(SimulatorTest, SpringMassNoSample) {
   // Simulate for 1 second.
   simulator.StepTo(1.);
 
-  EXPECT_NEAR(context->get_time(), 1., 1e-8);
+  EXPECT_NEAR(context.get_time(), 1., 1e-8);
   EXPECT_EQ(simulator.get_num_steps_taken(), 1000);
   EXPECT_EQ(simulator.get_num_discrete_updates(), 0);
 
@@ -756,14 +758,14 @@ GTEST_TEST(SimulatorTest, ResetIntegratorTest) {
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
   // Set initial condition using the Simulator's internal Context.
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
 
   // Get the context.
-  auto context = simulator.get_mutable_context();
+  Context<double>& context = simulator.get_mutable_context();
 
   // Create the integrator.
   simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
-                                                              context);
+                                                              &context);
 
   // set the integrator and initialize the simulator
   simulator.Initialize();
@@ -773,12 +775,12 @@ GTEST_TEST(SimulatorTest, ResetIntegratorTest) {
 
   // Reset the integrator.
   simulator.reset_integrator<RungeKutta2Integrator<double>>(
-      simulator.get_system(), dt, simulator.get_mutable_context());
+      simulator.get_system(), dt, &simulator.get_mutable_context());
 
   // Simulate to 1 second..
   simulator.StepTo(1.);
 
-  EXPECT_NEAR(context->get_time(), 1., 1e-8);
+  EXPECT_NEAR(context.get_time(), 1., 1e-8);
 
   // Number of steps will have been reset.
   EXPECT_EQ(simulator.get_num_steps_taken(), 500);
@@ -793,13 +795,13 @@ GTEST_TEST(SimulatorTest, RealtimeRate) {
 
   simulator.set_target_realtime_rate(1.);  // No faster than 1X real time.
   simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
-  simulator.get_mutable_context()->set_time(0.);
+  simulator.get_mutable_context().set_time(0.);
   simulator.Initialize();
   simulator.StepTo(1.);  // Simulate for 1 simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 1.1);
 
   simulator.set_target_realtime_rate(5.);  // No faster than 5X real time.
-  simulator.get_mutable_context()->set_time(0.);
+  simulator.get_mutable_context().set_time(0.);
   simulator.Initialize();
   simulator.StepTo(1.);  // Simulate for 1 more simulated second.
   EXPECT_TRUE(simulator.get_actual_realtime_rate() <= 5.1);
@@ -812,7 +814,7 @@ GTEST_TEST(SimulatorTest, DisablePublishEveryTimestep) {
   Simulator<double> simulator(spring_mass);  // Use default Context.
   simulator.set_publish_every_time_step(false);
 
-  simulator.get_mutable_context()->set_time(0.);
+  simulator.get_mutable_context().set_time(0.);
   simulator.Initialize();
   // Publish should happen on initialization.
   EXPECT_EQ(1, simulator.get_num_publishes());
@@ -837,19 +839,14 @@ GTEST_TEST(SimulatorTest, SpringMass) {
   Simulator<double> simulator(spring_mass);  // Use default Context.
 
   // Get the context.
-  auto context = simulator.get_mutable_context();
-
-  // TODO(edrumwri): Remove this when discrete state has been created
-  // automatically.
-  // Create the discrete state.
-  context->set_discrete_state(std::make_unique<DiscreteValues<double>>());
+  Context<double>& context = simulator.get_mutable_context();
 
   // Set initial condition using the Simulator's internal context.
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
+  spring_mass.set_position(&context, 0.1);
 
   // Create the integrator and initialize it.
   auto integrator = simulator.reset_integrator<ExplicitEulerIntegrator<double>>(
-      spring_mass, dt, context);
+      spring_mass, dt, &context);
   integrator->Initialize();
 
   // Set the integrator and initialize the simulator.
@@ -930,7 +927,7 @@ GTEST_TEST(SimulatorTest, ExactUpdateTime) {
 
   // Set time to an exact floating point representation; we want t_upd to
   // be much smaller in magnitude than the time, hence the negative time.
-  simulator.get_mutable_context()->set_time(-1.0 / 1024);
+  simulator.get_mutable_context().set_time(-1.0 / 1024);
 
   // Capture the time at which an update is done using a callback function.
   std::vector<double> updates;
@@ -986,8 +983,8 @@ GTEST_TEST(SimulatorTest, ControlledSpringMass) {
   simulator.get_mutable_integrator()->set_maximum_step_size(0.001);
 
   // Sets initial condition using the Simulator's internal Context.
-  spring_mass.set_position(simulator.get_mutable_context(), x0);
-  spring_mass.set_velocity(simulator.get_mutable_context(), v0);
+  spring_mass.set_position(&simulator.get_mutable_context(), x0);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), v0);
 
   // Takes all the defaults for the simulator.
   simulator.Initialize();
@@ -1208,13 +1205,13 @@ GTEST_TEST(SimulatorTest, StretchedStep) {
 
   // Initialize a fixed step integrator and the simulator.
   simulator.reset_integrator<RungeKutta2Integrator<double>>(spring_mass,
-      directed_t_final, simulator.get_mutable_context());
+      directed_t_final, &simulator.get_mutable_context());
   simulator.Initialize();
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context()->set_time(0);
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
-  spring_mass.set_velocity(simulator.get_mutable_context(), 0);
+  simulator.get_mutable_context().set_time(0);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
   // Now step.
   simulator.StepTo(expected_t_final);
@@ -1244,13 +1241,13 @@ GTEST_TEST(SimulatorTest, NoStretchedStep) {
 
   // Initialize a fixed step integrator and the simulator.
   simulator.reset_integrator<RungeKutta2Integrator<double>>(spring_mass,
-      directed_t_final, simulator.get_mutable_context());
+      directed_t_final, &simulator.get_mutable_context());
   simulator.Initialize();
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context()->set_time(0);
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
-  spring_mass.set_velocity(simulator.get_mutable_context(), 0);
+  simulator.get_mutable_context().set_time(0);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
   // Now step.
   simulator.StepTo(event_t_final);
@@ -1272,8 +1269,8 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   Simulator<double> simulator(spring_mass);
 
   // Set initial condition using the Simulator's internal Context.
-  spring_mass.set_position(simulator.get_mutable_context(), 1.0);
-  spring_mass.set_velocity(simulator.get_mutable_context(), 0.1);
+  spring_mass.set_position(&simulator.get_mutable_context(), 1.0);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), 0.1);
 
   // Accuracy tolerances are extremely loose.
   const double accuracy = 1e-1;
@@ -1283,8 +1280,8 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   const double req_initial_step_size = 1e-2;
 
   // Initialize the error controlled integrator and the simulator.
-  simulator.reset_integrator<RungeKutta3Integrator<double>>(spring_mass,
-    simulator.get_mutable_context());
+  simulator.reset_integrator<RungeKutta3Integrator<double>>(
+      spring_mass, &simulator.get_mutable_context());
   IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
   integrator->request_initial_step_size_target(req_initial_step_size);
   integrator->set_target_accuracy(accuracy);
@@ -1298,7 +1295,7 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   integrator->IntegrateAtMost(inf, 1.0, 1.0);
 
   // Verify that the integrator has stepped before the event time.
-  EXPECT_LT(simulator.get_mutable_context()->get_time(), event_time);
+  EXPECT_LT(simulator.get_mutable_context().get_time(), event_time);
 
   // Get the ideal next step size and verify that it is not NaN.
   const double ideal_next_step_size = integrator->get_ideal_next_step_size();
@@ -1306,7 +1303,7 @@ GTEST_TEST(SimulatorTest, ArtificalLimitingStep) {
   // Set the time to right before an event, which should trigger artificial
   // limiting.
   const double desired_dt = req_initial_step_size * 1e-2;
-  simulator.get_mutable_context()->set_time(event_time - desired_dt);
+  simulator.get_mutable_context().set_time(event_time - desired_dt);
 
   // Step to the event time.
   integrator->IntegrateAtMost(inf, desired_dt, inf);
@@ -1343,7 +1340,7 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
 
   // Initialize the error controlled integrator and the simulator.
   simulator.reset_integrator<RungeKutta3Integrator<double>>(spring_mass,
-    simulator.get_mutable_context());
+      &simulator.get_mutable_context());
   IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
   integrator->set_requested_minimum_step_size(req_min_step_size);
   integrator->request_initial_step_size_target(directed_t_final);
@@ -1351,9 +1348,9 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   simulator.Initialize();
 
   // Set initial condition using the Simulator's internal Context.
-  simulator.get_mutable_context()->set_time(0);
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
-  spring_mass.set_velocity(simulator.get_mutable_context(), 0);
+  simulator.get_mutable_context().set_time(0);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
 
   // Activate exceptions on violating the minimum step size to verify that
   // error control is a limiting factor.
@@ -1361,9 +1358,9 @@ GTEST_TEST(SimulatorTest, StretchedStepPerfectStorm) {
   EXPECT_THROW(simulator.StepTo(expected_t_final), std::runtime_error);
 
   // Now disable exceptions on violating the minimum step size and step again.
-  simulator.get_mutable_context()->set_time(0);
-  spring_mass.set_position(simulator.get_mutable_context(), 0.1);
-  spring_mass.set_velocity(simulator.get_mutable_context(), 0);
+  simulator.get_mutable_context().set_time(0);
+  spring_mass.set_position(&simulator.get_mutable_context(), 0.1);
+  spring_mass.set_velocity(&simulator.get_mutable_context(), 0);
   integrator->set_throw_on_minimum_step_size_violation(false);
   simulator.StepTo(expected_t_final);
 
@@ -1419,7 +1416,7 @@ GTEST_TEST(SimulatorTest, PerStepAction) {
         const Context<double>& context,
         ContinuousState<double>* derivatives) const override {
       // Derivative will always be zero, making the system stationary.
-      derivatives->get_mutable_vector()->SetAtIndex(0, 0.0);
+      derivatives->get_mutable_vector().SetAtIndex(0, 0.0);
     }
 
     void DoCalcDiscreteVariableUpdates(

--- a/drake/systems/analysis/test/spring_mass_damper_system.h
+++ b/drake/systems/analysis/test/spring_mass_damper_system.h
@@ -116,7 +116,7 @@ class SpringMassDamperSystem : public SpringMassSystem<T> {
   void DoCalcTimeDerivatives(const Context <T>& context,
                              ContinuousState <T>* derivatives) const override {
     // Get the current state of the spring.
-    const ContinuousState<T>& state = *context.get_continuous_state();
+    const ContinuousState<T>& state = context.get_continuous_state();
 
     // First element of the derivative is spring velocity.
     const T xd = state[1];

--- a/drake/systems/analysis/test/stiff_double_mass_spring_system.h
+++ b/drake/systems/analysis/test/stiff_double_mass_spring_system.h
@@ -76,13 +76,13 @@ class StiffDoubleMassSpringSystem : public LeafSystem<T> {
   /// Gets the positions of the two point mass bodies.
   Vector2<T> get_position(const Context<T>& c) const {
     return
-        c.get_continuous_state()->get_generalized_position().CopyToVector();
+        c.get_continuous_state().get_generalized_position().CopyToVector();
   }
 
   /// Gets the velocity of the two point mass bodies.
   Vector2<T> get_velocity(const Context<T>& c) const {
     return
-        c.get_continuous_state()->get_generalized_velocity().CopyToVector();
+        c.get_continuous_state().get_generalized_velocity().CopyToVector();
   }
 
   /// Gets the mass for the bodies in the system.
@@ -91,7 +91,7 @@ class StiffDoubleMassSpringSystem : public LeafSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* deriv) const override {
     // Get velocity.
-    const VectorBase<T>& xd = context.get_continuous_state()->
+    const VectorBase<T>& xd = context.get_continuous_state().
         get_generalized_velocity();
 
     // Get the masses and spring and damping coefficients.
@@ -104,8 +104,8 @@ class StiffDoubleMassSpringSystem : public LeafSystem<T> {
     const Vector2<T> a = f.array() / mass.array();
 
     // Set the derivatives.
-    deriv->get_mutable_generalized_position()->SetFrom(xd);
-    deriv->get_mutable_generalized_velocity()->SetFromVector(a);
+    deriv->get_mutable_generalized_position().SetFrom(xd);
+    deriv->get_mutable_generalized_velocity().SetFromVector(a);
   }
 
   /// Gets the end time for integration.
@@ -121,9 +121,9 @@ class StiffDoubleMassSpringSystem : public LeafSystem<T> {
     x(1) = 1.5;
     xd.setZero();
 
-    state->get_mutable_continuous_state()->get_mutable_generalized_position()->
+    state->get_mutable_continuous_state().get_mutable_generalized_position().
         SetFromVector(x);
-    state->get_mutable_continuous_state()->get_mutable_generalized_velocity()->
+    state->get_mutable_continuous_state().get_mutable_generalized_velocity().
         SetFromVector(xd);
   }
 
@@ -150,23 +150,23 @@ class StiffDoubleMassSpringSystem : public LeafSystem<T> {
         (get_mass()(0) + get_mass()(1)));
 
     // Setup c1 and c2 for ODE constants.
-    const double c1 = context.get_continuous_state()->
+    const double c1 = context.get_continuous_state().
         get_generalized_position().GetAtIndex(0);
-    const double c2 = context.get_continuous_state()->
+    const double c2 = context.get_continuous_state().
         get_generalized_velocity().GetAtIndex(0) / omega;
 
     // Set the position and velocity of the first body using the ODE solution.
     const double x1_final = c1 * cos(omega * t) + c2 * sin(omega * t);
     const double v1_final = c1 * -sin(omega * t) * omega +
         c2 * +cos(omega * t) * omega;
-    state->get_mutable_generalized_position()->SetAtIndex(0, x1_final);
-    state->get_mutable_generalized_velocity()->SetAtIndex(0, v1_final);
+    state->get_mutable_generalized_position().SetAtIndex(0, x1_final);
+    state->get_mutable_generalized_velocity().SetAtIndex(0, v1_final);
 
     // The position of the second body should be offset exactly from the first.
-    state->get_mutable_generalized_position()->SetAtIndex(1, x1_final + offset);
+    state->get_mutable_generalized_position().SetAtIndex(1, x1_final + offset);
 
     // Velocity of the second body should be zero.
-    state->get_mutable_generalized_velocity()->SetAtIndex(1, 0);
+    state->get_mutable_generalized_velocity().SetAtIndex(1, 0);
   }
 };
 

--- a/drake/systems/controllers/linear_model_predictive_controller.cc
+++ b/drake/systems/controllers/linear_model_predictive_controller.cc
@@ -42,7 +42,7 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
   // group.
   const auto model_context = model_->CreateDefaultContext();
   DRAKE_DEMAND(model_context->get_num_discrete_state_groups() == 1);
-  DRAKE_DEMAND(model_context->get_continuous_state()->size() == 0);
+  DRAKE_DEMAND(model_context->get_continuous_state().size() == 0);
   DRAKE_DEMAND(model_context->get_num_abstract_state_groups() == 0);
   DRAKE_DEMAND(model_->get_num_input_ports() == 1);
   DRAKE_DEMAND(model_->get_num_output_ports() == 1);
@@ -103,7 +103,7 @@ VectorX<T> LinearModelPredictiveController<T>::SetupAndSolveQp(
                       input_error.transpose() * R_ * input_error);
 
   const VectorX<T> state_ref =
-      base_context.get_discrete_state()->get_vector().CopyToVector();
+      base_context.get_discrete_state().get_vector().CopyToVector();
   prog.AddLinearConstraint(prog.initial_state() == current_state - state_ref);
 
   DRAKE_DEMAND(prog.Solve() == solvers::SolutionResult::kSolutionFound);

--- a/drake/systems/controllers/linear_quadratic_regulator.cc
+++ b/drake/systems/controllers/linear_quadratic_regulator.cc
@@ -76,7 +76,7 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
 
   DRAKE_DEMAND(system.get_num_input_ports() == 1);
   const int num_inputs = system.get_input_port(0).size(),
-            num_states = context.get_continuous_state()->size();
+            num_states = context.get_continuous_state().size();
   DRAKE_DEMAND(num_states > 0);
   DRAKE_DEMAND(context.has_only_continuous_state());
   // TODO(russt): Confirm behavior if Q is not PSD.

--- a/drake/systems/controllers/pid_controller.cc
+++ b/drake/systems/controllers/pid_controller.cc
@@ -86,10 +86,10 @@ void PidController<T>::DoCalcTimeDerivatives(
       this->EvalEigenVectorInput(context, input_index_desired_state_);
 
   // The derivative of the continuous state is the instantaneous position error.
-  VectorBase<T>* const derivatives_vector = derivatives->get_mutable_vector();
+  VectorBase<T>& derivatives_vector = derivatives->get_mutable_vector();
   const VectorX<T> controlled_state_diff =
       state_d - (state_projection_.cast<T>() * state);
-  derivatives_vector->SetFromVector(
+  derivatives_vector.SetFromVector(
       controlled_state_diff.head(num_controlled_q_));
 }
 

--- a/drake/systems/controllers/pid_controller.h
+++ b/drake/systems/controllers/pid_controller.h
@@ -151,9 +151,9 @@ class PidController : public StateFeedbackControllerInterface<T>,
    */
   void set_integral_value(Context<T>* context,
                           const Eigen::Ref<const VectorX<T>>& value) const {
-    VectorBase<T>* state_vector =
+    VectorBase<T>& state_vector =
         context->get_mutable_continuous_state_vector();
-    state_vector->SetFromVector(value);
+    state_vector.SetFromVector(value);
   }
 
   /**

--- a/drake/systems/controllers/plan_eval/plan_eval_base_system.h
+++ b/drake/systems/controllers/plan_eval/plan_eval_base_system.h
@@ -107,7 +107,7 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
   Type& get_mutable_abstract_value(systems::State<double>* state,
                                    int index) const {
     return state->get_mutable_abstract_state()
-        ->get_mutable_value(index)
+        .get_mutable_value(index)
         .GetMutableValue<Type>();
   }
 
@@ -117,7 +117,7 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
   systems::controllers::qp_inverse_dynamics::QpInput& get_mutable_qp_input(
       systems::State<double>* state) const {
     return state->get_mutable_abstract_state()
-        ->get_mutable_value(abs_state_index_qp_input_)
+        .get_mutable_value(abs_state_index_qp_input_)
         .GetMutableValue<systems::controllers::qp_inverse_dynamics::QpInput>();
   }
 

--- a/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
+++ b/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
@@ -17,7 +17,7 @@ template <typename ValueType>
 ValueType& get_mutable_value(systems::State<double>* state, int index) {
   DRAKE_DEMAND(state);
   return state->get_mutable_abstract_state()
-      ->get_mutable_value(index)
+      .get_mutable_value(index)
       .GetMutableValue<ValueType>();
 }
 

--- a/drake/systems/controllers/test/inverse_dynamics_test.cc
+++ b/drake/systems/controllers/test/inverse_dynamics_test.cc
@@ -58,7 +58,7 @@ class InverseDynamicsTest : public ::testing::Test {
     }
 
     // Checks that no state variables are allocated in the context.
-    EXPECT_EQ(context_->get_continuous_state()->size(), 0);
+    EXPECT_EQ(context_->get_continuous_state().size(), 0);
 
     // Checks that the number of output ports in the Gravity Compensator system
     // and the SystemOutput are consistent.

--- a/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/drake/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -155,7 +155,7 @@ class TestMpcWithCubicSystem : public ::testing::Test {
 
     // Set the nominal state.
     BasicVector<double>& x =
-        context->get_mutable_discrete_state()->get_mutable_vector();
+        context->get_mutable_discrete_state().get_mutable_vector();
     x.SetFromVector(Eigen::Vector2d::Zero());  // Fixed point is zero.
 
     dut_.reset(new LinearModelPredictiveController<double>(
@@ -196,10 +196,10 @@ class TestMpcWithCubicSystem : public ::testing::Test {
 
     const auto& cubic_system = GetSystemByName("cubic_system", *diagram_);
     Context<double>& cubic_system_context =
-        diagram_->GetMutableSubsystemContext(cubic_system,
-                                             simulator_->get_mutable_context());
+        diagram_->GetMutableSubsystemContext(
+            cubic_system, &simulator_->get_mutable_context());
     BasicVector<double>& x0 =
-        cubic_system_context.get_mutable_discrete_state()->get_mutable_vector();
+        cubic_system_context.get_mutable_discrete_state().get_mutable_vector();
 
     // Set an initial condition near the fixed point.
     x0.SetFromVector(10. * Eigen::Vector2d::Ones());
@@ -232,7 +232,7 @@ TEST_F(TestMpcWithCubicSystem, TimeInvariantMpc) {
   // Result should be deadbeat; expect convergence to within a tiny tolerance in
   // one step.
   Eigen::Vector2d result =
-      simulator_->get_mutable_context()->get_discrete_state(0).get_value();
+      simulator_->get_mutable_context().get_discrete_state(0).get_value();
   EXPECT_TRUE(CompareMatrices(result, Eigen::Vector2d::Zero(), kTolerance));
 }
 

--- a/drake/systems/controllers/test/linear_quadratic_regulator_test.cc
+++ b/drake/systems/controllers/test/linear_quadratic_regulator_test.cc
@@ -88,7 +88,7 @@ void TestLQRAffineSystemAgainstKnownSolution(
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(m);
 
   context->FixInputPort(0, u0);
-  context->get_mutable_continuous_state()->SetFromVector(x0);
+  context->get_mutable_continuous_state().SetFromVector(x0);
   std::unique_ptr<AffineSystem<double>> lqr =
       LinearQuadraticRegulator(sys, *context, Q, R, N);
 

--- a/drake/systems/estimators/luenberger_observer.cc
+++ b/drake/systems/estimators/luenberger_observer.cc
@@ -36,16 +36,16 @@ LuenbergerObserver<T>::LuenbergerObserver(
   // Observer state is the (estimated) state of the observed system,
   // but the best we can do for now is to allocate a similarly-sized
   // BasicVector (see #6998).
-  const auto xc = observed_system_context_->get_continuous_state();
-  const int num_q = xc->get_generalized_position().size();
-  const int num_v = xc->get_generalized_velocity().size();
-  const int num_z = xc->get_misc_continuous_state().size();
+  const auto& xc = observed_system_context_->get_continuous_state();
+  const int num_q = xc.get_generalized_position().size();
+  const int num_v = xc.get_generalized_velocity().size();
+  const int num_z = xc.get_misc_continuous_state().size();
   this->DeclareContinuousState(num_q, num_v, num_z);
 
   // Output port is the (estimated) state of the observed system.
   // Note: Again, the derived type of the state vector is lost here, because xc
   // is only guaranteed to be a VectorBase, not a BasicVector.
-  this->DeclareVectorOutputPort(BasicVector<T>(xc->size()),
+  this->DeclareVectorOutputPort(BasicVector<T>(xc.size()),
                                 &LuenbergerObserver::CalcEstimatedState);
 
   // First input port is the output of the observed system.
@@ -53,7 +53,7 @@ LuenbergerObserver<T>::LuenbergerObserver(
   this->DeclareVectorInputPort(*observed_system_output_->get_vector_data(0));
 
   // Check the size of the gain matrix.
-  DRAKE_DEMAND(observer_gain_.rows() == xc->size());
+  DRAKE_DEMAND(observer_gain_.rows() == xc.size());
   DRAKE_DEMAND(observer_gain_.cols() ==
                observed_system_->get_output_port(0).size());
 
@@ -87,7 +87,7 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
         0, this->EvalVectorInput(context, 1)->CopyToVector());
   }
   // Set observed system state.
-  observed_system_context_->get_mutable_continuous_state_vector()->SetFrom(
+  observed_system_context_->get_mutable_continuous_state_vector().SetFrom(
       context.get_continuous_state_vector());
 
   // Evaluate the observed system.
@@ -101,10 +101,10 @@ void LuenbergerObserver<T>::DoCalcTimeDerivatives(
   auto yhat = observed_system_output_->GetMutableVectorData(0)->CopyToVector();
 
   // Add in the observed gain terms.
-  auto xdothat = observed_system_derivatives_->get_mutable_vector();
+  auto& xdothat = observed_system_derivatives_->get_mutable_vector();
 
   // xdothat = f(xhat,u) + L(y-yhat).
-  derivatives->SetFromVector(xdothat->CopyToVector() +
+  derivatives->SetFromVector(xdothat.CopyToVector() +
                              observer_gain_ * (y - yhat));
 }
 

--- a/drake/systems/estimators/test/kalman_filter_test.cc
+++ b/drake/systems/estimators/test/kalman_filter_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(TestKalman, DoubleIntegrator) {
   auto sys = std::make_unique<LinearSystem<double>>(A, B, C, D);
   auto context = sys->CreateDefaultContext();
   context->FixInputPort(0, Eigen::Matrix<double, 1, 1>::Zero());
-  context->get_mutable_continuous_state()->SetFromVector(
+  context->get_mutable_continuous_state().SetFromVector(
       Eigen::Vector2d::Zero());
   auto filter =
       SteadyStateKalmanFilter(std::move(sys), std::move(context), W, V);

--- a/drake/systems/estimators/test/luenberger_observer_test.cc
+++ b/drake/systems/estimators/test/luenberger_observer_test.cc
@@ -64,7 +64,7 @@ GTEST_TEST(LuenbergerObserverTest, ErrorDynamics) {
 
   context->FixInputPort(0, y);
   context->FixInputPort(1, u);
-  context->get_mutable_continuous_state_vector()->SetFromVector(xhat);
+  context->get_mutable_continuous_state_vector().SetFromVector(xhat);
 
   observer->CalcTimeDerivatives(*context, derivatives.get());
   observer->CalcOutput(*context, output.get());

--- a/drake/systems/framework/context.h
+++ b/drake/systems/framework/context.h
@@ -57,11 +57,11 @@ class Context {
   // Accessors and Mutators for State.
 
   virtual const State<T>& get_state() const = 0;
-  virtual State<T>* get_mutable_state() = 0;
+  virtual State<T>& get_mutable_state() = 0;
 
   /// Returns true if the Context has no state.
   bool is_stateless() const {
-    const int nxc = get_continuous_state()->size();
+    const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
     const int nxa = get_num_abstract_state_groups();
     return nxc == 0 && nxd == 0 && nxa == 0;
@@ -70,7 +70,7 @@ class Context {
   /// Returns true if the Context has continuous state, but no discrete or
   /// abstract state.
   bool has_only_continuous_state() const {
-    const int nxc = get_continuous_state()->size();
+    const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
     const int nxa = get_num_abstract_state_groups();
     return nxc > 0 && nxd == 0 && nxa == 0;
@@ -79,7 +79,7 @@ class Context {
   /// Returns true if the Context has discrete state, but no continuous or
   /// abstract state.
   bool has_only_discrete_state() const {
-    const int nxc = get_continuous_state()->size();
+    const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
     const int nxa = get_num_abstract_state_groups();
     return nxd > 0 && nxc == 0 && nxa == 0;
@@ -90,7 +90,7 @@ class Context {
   /// @throws std::runtime_error if the system contains any abstract state.
   int get_num_total_states() const {
     DRAKE_THROW_UNLESS(get_num_abstract_state_groups() == 0);
-    int count = get_continuous_state()->size();
+    int count = get_continuous_state().size();
     for (int i = 0; i < get_num_discrete_state_groups(); i++)
       count += get_discrete_state(i).size();
     return count;
@@ -98,109 +98,109 @@ class Context {
 
   /// Sets the continuous state to @p xc, deleting whatever was there before.
   void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
-    get_mutable_state()->set_continuous_state(std::move(xc));
+    get_mutable_state().set_continuous_state(std::move(xc));
   }
 
-  /// Returns a mutable pointer to the continuous component of the state,
+  /// Returns a mutable reference to the continuous component of the state,
   /// which may be of size zero.
-  ContinuousState<T>* get_mutable_continuous_state() {
-    return get_mutable_state()->get_mutable_continuous_state();
+  ContinuousState<T>& get_mutable_continuous_state() {
+    return get_mutable_state().get_mutable_continuous_state();
   }
 
-  /// Returns a mutable pointer to the continuous state, devoid of second-order
-  /// structure. The vector may be of size zero.
-  VectorBase<T>* get_mutable_continuous_state_vector() {
-    return get_mutable_continuous_state()->get_mutable_vector();
+  /// Returns a mutable reference to the continuous state vector, devoid
+  /// of second-order structure. The vector may be of size zero.
+  VectorBase<T>& get_mutable_continuous_state_vector() {
+    return get_mutable_continuous_state().get_mutable_vector();
   }
 
-  /// Returns a const pointer to the continuous component of the state,
+  /// Returns a const reference to the continuous component of the state,
   /// which may be of size zero.
-  const ContinuousState<T>* get_continuous_state() const {
+  const ContinuousState<T>& get_continuous_state() const {
     return get_state().get_continuous_state();
   }
 
   /// Returns a reference to the continuous state vector, devoid of second-order
   /// structure. The vector may be of size zero.
   const VectorBase<T>& get_continuous_state_vector() const {
-    return get_continuous_state()->get_vector();
+    return get_continuous_state().get_vector();
   }
 
   /// Returns the number of elements in the discrete state.
   int get_num_discrete_state_groups() const {
-    return get_state().get_discrete_state()->num_groups();
+    return get_state().get_discrete_state().num_groups();
   }
 
-  const DiscreteValues<T>* get_discrete_state() const {
+  const DiscreteValues<T>& get_discrete_state() const {
     return get_state().get_discrete_state();
   }
 
   /// Returns a reference to the discrete state vector. The vector may be of
   /// size zero.
   const BasicVector<T>& get_discrete_state_vector() const {
-    return get_discrete_state()->get_vector();
+    return get_discrete_state().get_vector();
   }
 
   /// Returns a mutable pointer to the discrete component of the state,
   /// which may be of size zero.
-  DiscreteValues<T>* get_mutable_discrete_state() {
-    return get_mutable_state()->get_mutable_discrete_state();
+  DiscreteValues<T>& get_mutable_discrete_state() {
+    return get_mutable_state().get_mutable_discrete_state();
   }
 
   /// Returns a mutable pointer to element @p index of the discrete state.
   /// Asserts if @p index doesn't exist.
   BasicVector<T>& get_mutable_discrete_state(int index) {
-    DiscreteValues<T>* xd = get_mutable_discrete_state();
-    return xd->get_mutable_vector(index);
+    DiscreteValues<T>& xd = get_mutable_discrete_state();
+    return xd.get_mutable_vector(index);
   }
 
   /// Sets the discrete state to @p xd, deleting whatever was there before.
   void set_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
-    get_mutable_state()->set_discrete_state(std::move(xd));
+    get_mutable_state().set_discrete_state(std::move(xd));
   }
 
   /// Returns a const pointer to the discrete component of the
   /// state at @p index.  Asserts if @p index doesn't exist.
   const BasicVector<T>& get_discrete_state(int index) const {
-    const DiscreteValues<T>* xd = get_state().get_discrete_state();
-    return xd->get_vector(index);
+    const DiscreteValues<T>& xd = get_state().get_discrete_state();
+    return xd.get_vector(index);
   }
 
   /// Returns the number of elements in the abstract state.
   int get_num_abstract_state_groups() const {
-    return get_state().get_abstract_state()->size();
+    return get_state().get_abstract_state().size();
   }
 
-  /// Returns a pointer to the abstract component of the state, which
+  /// Returns a const reference to the abstract component of the state, which
   /// may be of size zero.
-  const AbstractValues* get_abstract_state() const {
+  const AbstractValues& get_abstract_state() const {
     return get_state().get_abstract_state();
   }
 
-  /// Returns a mutable pointer to the abstract component of the state,
+  /// Returns a mutable reference to the abstract component of the state,
   /// which may be of size zero.
-  AbstractValues* get_mutable_abstract_state() {
-    return get_mutable_state()->get_mutable_abstract_state();
+  AbstractValues& get_mutable_abstract_state() {
+    return get_mutable_state().get_mutable_abstract_state();
   }
 
   /// Returns a mutable pointer to element @p index of the abstract state.
   /// Asserts if @p index doesn't exist.
   template <typename U>
   U& get_mutable_abstract_state(int index) {
-    AbstractValues* xa = get_mutable_abstract_state();
-    return xa->get_mutable_value(index).GetMutableValue<U>();
+    AbstractValues& xa = get_mutable_abstract_state();
+    return xa.get_mutable_value(index).GetMutableValue<U>();
   }
 
   /// Sets the abstract state to @p xa, deleting whatever was there before.
   void set_abstract_state(std::unique_ptr<AbstractValues> xa) {
-    get_mutable_state()->set_abstract_state(std::move(xa));
+    get_mutable_state().set_abstract_state(std::move(xa));
   }
 
   /// Returns a const reference to the abstract component of the
   /// state at @p index.  Asserts if @p index doesn't exist.
   template <typename U>
   const U& get_abstract_state(int index) const {
-    const AbstractValues* xa = get_state().get_abstract_state();
-    return xa->get_value(index).GetValue<U>();
+    const AbstractValues& xa = get_state().get_abstract_state();
+    return xa.get_value(index).GetValue<U>();
   }
 
   // =========================================================================
@@ -428,7 +428,7 @@ class Context {
   void SetTimeStateAndParametersFrom(const Context<double>& source) {
     set_time(T(source.get_time()));
     set_accuracy(source.get_accuracy());
-    get_mutable_state()->SetFrom(source.get_state());
+    get_mutable_state().SetFrom(source.get_state());
     get_mutable_parameters().SetFrom(source.get_parameters());
   }
 

--- a/drake/systems/framework/continuous_state.h
+++ b/drake/systems/framework/continuous_state.h
@@ -101,46 +101,52 @@ class ContinuousState {
   T& operator[](std::size_t idx) { return (*state_)[idx]; }
   const T& operator[](std::size_t idx) const { return (*state_)[idx]; }
 
-  /// Returns the entire continuous state vector.
-  const VectorBase<T>& get_vector() const { return *state_; }
+  /// Returns a reference to the entire continuous state vector.
+  const VectorBase<T>& get_vector() const {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
 
-  /// Returns a mutable pointer to the entire continuous state vector, which
-  /// is never nullptr.
-  VectorBase<T>* get_mutable_vector() { return state_.get(); }
+  /// Returns a mutable reference to the entire continuous state vector.
+  VectorBase<T>& get_mutable_vector() {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_.get();
+  }
 
-  /// Returns the subset of the state vector that is generalized position `q`.
+  /// Returns a const reference to the subset of the state vector that is
+  /// generalized position `q`. May be zero length.
   const VectorBase<T>& get_generalized_position() const {
     return *generalized_position_;
   }
 
-  /// Returns a mutable pointer to the subset of the state vector that is
-  /// generalized position `q`.
-  VectorBase<T>* get_mutable_generalized_position() {
-    return generalized_position_.get();
+  /// Returns a mutable reference to the subset of the state vector that is
+  /// generalized position `q`. May be zero length.
+  VectorBase<T>& get_mutable_generalized_position() {
+    return *generalized_position_.get();
   }
 
-  /// Returns the subset of the continuous state vector that is generalized
-  /// velocity `v`.
+  /// Returns a const reference to the subset of the continuous state vector
+  /// that is generalized velocity `v`. May be zero length.
   const VectorBase<T>& get_generalized_velocity() const {
     return *generalized_velocity_;
   }
 
-  /// Returns a mutable pointer to the subset of the continuous state vector
-  /// that is generalized velocity `v`.
-  VectorBase<T>* get_mutable_generalized_velocity() {
-    return generalized_velocity_.get();
+  /// Returns a mutable reference to the subset of the continuous state vector
+  /// that is generalized velocity `v`. May be zero length.
+  VectorBase<T>& get_mutable_generalized_velocity() {
+    return *generalized_velocity_.get();
   }
 
-  /// Returns the subset of the continuous state vector that is other
-  /// continuous state `z`.
+  /// Returns a const reference to the subset of the continuous state vector
+  /// that is other continuous state `z`. May be zero length.
   const VectorBase<T>& get_misc_continuous_state() const {
     return *misc_continuous_state_;
   }
 
-  /// Returns a mutable pointer to the subset of the continuous state vector
-  /// that is other continuous state `z`.
-  VectorBase<T>* get_mutable_misc_continuous_state() {
-    return misc_continuous_state_.get();
+  /// Returns a mutable reference to the subset of the continuous state vector
+  /// that is other continuous state `z`. May be zero length.
+  VectorBase<T>& get_mutable_misc_continuous_state() {
+    return *misc_continuous_state_.get();
   }
 
 
@@ -160,7 +166,7 @@ class ContinuousState {
   /// Sets the entire continuous state vector from an Eigen expression.
   void SetFromVector(const Eigen::Ref<const VectorX<T>>& value) {
     DRAKE_ASSERT(value.size() == state_->size());
-    this->get_mutable_vector()->SetFromVector(value);
+    this->get_mutable_vector().SetFromVector(value);
   }
 
   /// Returns a copy of the entire continuous state vector into an Eigen vector.

--- a/drake/systems/framework/diagram.h
+++ b/drake/systems/framework/diagram.h
@@ -585,7 +585,7 @@ class Diagram : public System<T>,
   State<T>& GetMutableSubsystemState(const System<T>& subsystem,
                                      Context<T>* context) const {
     Context<T>& subcontext = GetMutableSubsystemContext(subsystem, context);
-    return *subcontext.get_mutable_state();
+    return subcontext.get_mutable_state();
   }
 
   /// Retrieves the state for a particular subsystem from the @p state for the
@@ -927,10 +927,9 @@ class Diagram : public System<T>,
     // Check that the dimensions of the continuous state in the context match
     // the dimensions of the provided generalized velocity and configuration
     // derivatives.
-    const ContinuousState<T>* xc = context.get_continuous_state();
-    DRAKE_DEMAND(xc != nullptr);
-    const int nq = xc->get_generalized_position().size();
-    const int nv = xc->get_generalized_velocity().size();
+    const ContinuousState<T>& xc = context.get_continuous_state();
+    const int nq = xc.get_generalized_position().size();
+    const int nv = xc.get_generalized_velocity().size();
     DRAKE_DEMAND(nq == qdot->size());
     DRAKE_DEMAND(nv == generalized_velocity.size());
 
@@ -946,17 +945,15 @@ class Diagram : public System<T>,
     for (int i = 0; i < num_subsystems(); ++i) {
       // Find the continuous state of subsystem i.
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
-      const ContinuousState<T>* sub_xc = subcontext.get_continuous_state();
-      // If subsystem i is stateless, skip it.
-      if (sub_xc == nullptr) continue;
+      const ContinuousState<T>& sub_xc = subcontext.get_continuous_state();
 
       // Select the chunk of generalized_velocity belonging to subsystem i.
-      const int num_v = sub_xc->get_generalized_velocity().size();
+      const int num_v = sub_xc.get_generalized_velocity().size();
       const Eigen::Ref<const VectorX<T>>& v_slice =
           generalized_velocity.segment(v_index, num_v);
 
       // Select the chunk of qdot belonging to subsystem i.
-      const int num_q = sub_xc->get_generalized_position().size();
+      const int num_q = sub_xc.get_generalized_position().size();
       Subvector<T> dq_slice(qdot, q_index, num_q);
 
       // Delegate the actual mapping to subsystem i itself.
@@ -977,10 +974,9 @@ class Diagram : public System<T>,
     // Check that the dimensions of the continuous state in the context match
     // the dimensions of the provided generalized velocity and configuration
     // derivatives.
-    const ContinuousState<T>* xc = context.get_continuous_state();
-    DRAKE_DEMAND(xc != nullptr);
-    const int nq = xc->get_generalized_position().size();
-    const int nv = xc->get_generalized_velocity().size();
+    const ContinuousState<T>& xc = context.get_continuous_state();
+    const int nq = xc.get_generalized_position().size();
+    const int nv = xc.get_generalized_velocity().size();
     DRAKE_DEMAND(nq == qdot.size());
     DRAKE_DEMAND(nv == generalized_velocity->size());
 
@@ -996,17 +992,15 @@ class Diagram : public System<T>,
     for (int i = 0; i < num_subsystems(); ++i) {
       // Find the continuous state of subsystem i.
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
-      const ContinuousState<T>* sub_xc = subcontext.get_continuous_state();
-      // If subsystem i is stateless, skip it.
-      if (sub_xc == nullptr) continue;
+      const ContinuousState<T>& sub_xc = subcontext.get_continuous_state();
 
       // Select the chunk of qdot belonging to subsystem i.
-      const int num_q = sub_xc->get_generalized_position().size();
+      const int num_q = sub_xc.get_generalized_position().size();
       const Eigen::Ref<const VectorX<T>>& dq_slice =
           qdot.segment(q_index, num_q);
 
       // Select the chunk of generalized_velocity belonging to subsystem i.
-      const int num_v = sub_xc->get_generalized_velocity().size();
+      const int num_v = sub_xc.get_generalized_velocity().size();
       Subvector<T> v_slice(generalized_velocity, v_index, num_v);
 
       // Delegate the actual mapping to subsystem i itself.

--- a/drake/systems/framework/diagram_context.h
+++ b/drake/systems/framework/diagram_context.h
@@ -71,15 +71,15 @@ class DiagramState : public State<T> {
     std::vector<AbstractValue*> sub_xas;
     for (State<T>* substate : substates_) {
       // Continuous
-      sub_xcs.push_back(substate->get_mutable_continuous_state());
+      sub_xcs.push_back(&substate->get_mutable_continuous_state());
       // Discrete
       const std::vector<BasicVector<T>*>& xd_data =
-          substate->get_mutable_discrete_state()->get_data();
+          substate->get_mutable_discrete_state().get_data();
       sub_xds.insert(sub_xds.end(), xd_data.begin(), xd_data.end());
       // Abstract
-      AbstractValues* xa = substate->get_mutable_abstract_state();
-      for (int i_xa = 0; i_xa < xa->size(); ++i_xa) {
-        sub_xas.push_back(&xa->get_mutable_value(i_xa));
+      AbstractValues& xa = substate->get_mutable_abstract_state();
+      for (int i_xa = 0; i_xa < xa.size(); ++i_xa) {
+        sub_xas.push_back(&xa.get_mutable_value(i_xa));
       }
     }
 
@@ -196,7 +196,7 @@ class DiagramContext : public Context<T> {
     auto state = std::make_unique<DiagramState<T>>(num_subsystems());
     for (int i = 0; i < num_subsystems(); ++i) {
       Context<T>* context = contexts_[i].get();
-      state->set_substate(i, context->get_mutable_state());
+      state->set_substate(i, &context->get_mutable_state());
     }
     state->Finalize();
     state_ = std::move(state);
@@ -283,8 +283,15 @@ class DiagramContext : public Context<T> {
     // TODO(david-german-tri): Set invalidation callbacks.
   }
 
-  const State<T>& get_state() const override { return *state_; }
-  State<T>* get_mutable_state() override { return state_.get(); }
+  const State<T>& get_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  State<T>& get_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
 
   const Parameters<T>& get_parameters() const final {
     return *parameters_;

--- a/drake/systems/framework/diagram_continuous_state.h
+++ b/drake/systems/framework/diagram_continuous_state.h
@@ -57,29 +57,29 @@ class DiagramContinuousState : public ContinuousState<T> {
   // substate in @p substates, as indicated by @p selector.
   static std::unique_ptr<VectorBase<T>> Span(
       const std::vector<ContinuousState<T>*>& substates,
-      std::function<VectorBase<T>*(ContinuousState<T>*)> selector) {
+      std::function<VectorBase<T>&(ContinuousState<T>*)> selector) {
     std::vector<VectorBase<T>*> sub_xs;
     for (const auto& substate : substates) {
       DRAKE_DEMAND(substate != nullptr);
-      sub_xs.push_back(selector(substate));
+      sub_xs.push_back(&selector(substate));
     }
     return std::make_unique<Supervector<T>>(sub_xs);
   }
 
   // Returns the entire state vector in @p xc.
-  static VectorBase<T>* x_selector(ContinuousState<T>* xc) {
+  static VectorBase<T>& x_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_vector();
   }
   // Returns the generalized position vector in @p xc.
-  static VectorBase<T>* q_selector(ContinuousState<T>* xc) {
+  static VectorBase<T>& q_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_generalized_position();
   }
   // Returns the generalized velocity vector in @p xc.
-  static VectorBase<T>* v_selector(ContinuousState<T>* xc) {
+  static VectorBase<T>& v_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_generalized_velocity();
   }
   // Returns the misc continuous state vector in @p xc.
-  static VectorBase<T>* z_selector(ContinuousState<T>* xc) {
+  static VectorBase<T>& z_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_misc_continuous_state();
   }
 

--- a/drake/systems/framework/leaf_system.h
+++ b/drake/systems/framework/leaf_system.h
@@ -141,7 +141,7 @@ class LeafSystem : public System<T> {
     detail::CheckBasicVectorInvariants(dynamic_cast<const BasicVector<T>*>(xc));
     // -- The discrete state must all be valid BasicVectors.
     for (const BasicVector<T>* group :
-         context->get_state().get_discrete_state()->get_data()) {
+         context->get_state().get_discrete_state().get_data()) {
       detail::CheckBasicVectorInvariants(group);
     }
     // -- The numeric parameters must all be valid BasicVectors.
@@ -166,15 +166,15 @@ class LeafSystem : public System<T> {
                        State<T>* state) const override {
     unused(context);
     DRAKE_DEMAND(state != nullptr);
-    ContinuousState<T>* xc = state->get_mutable_continuous_state();
+    ContinuousState<T>& xc = state->get_mutable_continuous_state();
     if (model_continuous_state_vector_ != nullptr) {
-      xc->SetFromVector(model_continuous_state_vector_->get_value());
+      xc.SetFromVector(model_continuous_state_vector_->get_value());
     } else {
-      xc->SetFromVector(VectorX<T>::Zero(xc->size()));
+      xc.SetFromVector(VectorX<T>::Zero(xc.size()));
     }
-    DiscreteValues<T>* xd = state->get_mutable_discrete_state();
-    for (int i = 0; i < xd->num_groups(); i++) {
-      BasicVector<T>& s = xd->get_mutable_vector(i);
+    DiscreteValues<T>& xd = state->get_mutable_discrete_state();
+    for (int i = 0; i < xd.num_groups(); i++) {
+      BasicVector<T>& s = xd.get_mutable_vector(i);
       s.SetFromVector(VectorX<T>::Zero(s.size()));
     }
   }
@@ -691,9 +691,8 @@ class LeafSystem : public System<T> {
     MaybeDeclareVectorBaseInequalityConstraint(
         "continuous state", model_vector,
         [](const Context<T>& context) -> const VectorBase<T>& {
-          const ContinuousState<T>* state = context.get_continuous_state();
-          DRAKE_DEMAND(state != nullptr);
-          return state->get_vector();
+          const ContinuousState<T>& state = context.get_continuous_state();
+          return state.get_vector();
         });
   }
 
@@ -1254,7 +1253,7 @@ class LeafSystem : public System<T> {
         dynamic_cast<const LeafEventCollection<DiscreteUpdateEvent<T>>&>(
             events);
     // TODO(siyuan): should have a API level CopyFrom for DiscreteValues.
-    discrete_state->CopyFrom(*context.get_discrete_state());
+    discrete_state->CopyFrom(context.get_discrete_state());
     // Only call DoCalcDiscreteVariableUpdates if there are discrete update
     // events.
     DRAKE_DEMAND(leaf_events.HasEvents());

--- a/drake/systems/framework/state.h
+++ b/drake/systems/framework/state.h
@@ -40,12 +40,14 @@ class State {
     continuous_state_ = std::move(xc);
   }
 
-  const ContinuousState<T>* get_continuous_state() const {
-    return continuous_state_.get();
+  const ContinuousState<T>& get_continuous_state() const {
+    DRAKE_ASSERT(continuous_state_ != nullptr);
+    return *continuous_state_.get();
   }
 
-  ContinuousState<T>* get_mutable_continuous_state() {
-    return continuous_state_.get();
+  ContinuousState<T>& get_mutable_continuous_state() {
+    DRAKE_ASSERT(continuous_state_ != nullptr);
+    return *continuous_state_.get();
   }
 
   void set_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
@@ -53,12 +55,14 @@ class State {
     discrete_state_ = std::move(xd);
   }
 
-  const DiscreteValues<T>* get_discrete_state() const {
-    return discrete_state_.get();
+  const DiscreteValues<T>& get_discrete_state() const {
+    DRAKE_ASSERT(discrete_state_ != nullptr);
+    return *discrete_state_.get();
   }
 
-  DiscreteValues<T>* get_mutable_discrete_state() {
-    return discrete_state_.get();
+  DiscreteValues<T>& get_mutable_discrete_state() {
+    DRAKE_ASSERT(discrete_state_ != nullptr);
+    return *discrete_state_.get();
   }
 
   void set_abstract_state(std::unique_ptr<AbstractValues> xa) {
@@ -66,42 +70,46 @@ class State {
     abstract_state_ = std::move(xa);
   }
 
-  const AbstractValues* get_abstract_state() const {
-    return abstract_state_.get();
+  const AbstractValues& get_abstract_state() const {
+    DRAKE_ASSERT(abstract_state_ != nullptr);
+    return *abstract_state_.get();
   }
 
-  AbstractValues* get_mutable_abstract_state() { return abstract_state_.get(); }
+  AbstractValues& get_mutable_abstract_state() {
+    DRAKE_ASSERT(abstract_state_ != nullptr);
+    return *abstract_state_.get();
+  }
 
   /// Returns a const pointer to the abstract component of the
   /// state at @p index.  Asserts if @p index doesn't exist.
   template <typename U>
   const U& get_abstract_state(int index) const {
-    const AbstractValues* xa = get_abstract_state();
-    return xa->get_value(index).GetValue<U>();
+    const AbstractValues& xa = get_abstract_state();
+    return xa.get_value(index).GetValue<U>();
   }
 
   /// Returns a mutable pointer to element @p index of the abstract state.
   /// Asserts if @p index doesn't exist.
   template <typename U>
   U& get_mutable_abstract_state(int index) {
-    AbstractValues* xa = get_mutable_abstract_state();
-    return xa->get_mutable_value(index).GetMutableValue<U>();
+    AbstractValues& xa = get_mutable_abstract_state();
+    return xa.get_mutable_value(index).GetMutableValue<U>();
   }
 
   /// Copies the values from another State of the same scalar type into this
   /// State.
   void CopyFrom(const State<T>& other) {
-    continuous_state_->CopyFrom(*other.get_continuous_state());
-    discrete_state_->CopyFrom(*other.get_discrete_state());
-    abstract_state_->CopyFrom(*other.get_abstract_state());
+    continuous_state_->CopyFrom(other.get_continuous_state());
+    discrete_state_->CopyFrom(other.get_discrete_state());
+    abstract_state_->CopyFrom(other.get_abstract_state());
   }
 
   /// Initializes this state (regardless of scalar type) from a State<double>.
   /// All scalar types in Drake must support initialization from doubles.
   void SetFrom(const State<double>& other) {
-    continuous_state_->SetFrom(*other.get_continuous_state());
-    discrete_state_->SetFrom(*other.get_discrete_state());
-    abstract_state_->CopyFrom(*other.get_abstract_state());
+    continuous_state_->SetFrom(other.get_continuous_state());
+    discrete_state_->SetFrom(other.get_discrete_state());
+    abstract_state_->CopyFrom(other.get_abstract_state());
   }
 
  private:

--- a/drake/systems/framework/system.h
+++ b/drake/systems/framework/system.h
@@ -176,13 +176,13 @@ class System {
   void SetDefaultContext(Context<T>* context) const {
     // Set the default state, checking that the number of state variables does
     // not change.
-    const int n_xc = context->get_continuous_state()->size();
+    const int n_xc = context->get_continuous_state().size();
     const int n_xd = context->get_num_discrete_state_groups();
     const int n_xa = context->get_num_abstract_state_groups();
 
-    SetDefaultState(*context, context->get_mutable_state());
+    SetDefaultState(*context, &context->get_mutable_state());
 
-    DRAKE_DEMAND(n_xc == context->get_continuous_state()->size());
+    DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
     DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
     DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
 
@@ -233,13 +233,13 @@ class System {
   void SetRandomContext(Context<T>* context, RandomGenerator* generator) const {
     // Set the default state, checking that the number of state variables does
     // not change.
-    const int n_xc = context->get_continuous_state()->size();
+    const int n_xc = context->get_continuous_state().size();
     const int n_xd = context->get_num_discrete_state_groups();
     const int n_xa = context->get_num_abstract_state_groups();
 
-    SetRandomState(*context, context->get_mutable_state(), generator);
+    SetRandomState(*context, &context->get_mutable_state(), generator);
 
-    DRAKE_DEMAND(n_xc == context->get_continuous_state()->size());
+    DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
     DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
     DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
 
@@ -495,7 +495,7 @@ class System {
     DRAKE_ASSERT(J.rows() == get_num_constraint_equations(context));
     DRAKE_ASSERT(
         J.cols() ==
-        context.get_continuous_state()->get_generalized_velocity().size());
+        context.get_continuous_state().get_generalized_velocity().size());
     return DoCalcVelocityChangeFromConstraintImpulses(context, J, lambda);
   }
 
@@ -586,9 +586,9 @@ class System {
       const EventCollection<UnrestrictedUpdateEvent<T>>& events,
       State<T>* state) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
-    const int continuous_state_dim = state->get_continuous_state()->size();
-    const int discrete_state_dim = state->get_discrete_state()->num_groups();
-    const int abstract_state_dim = state->get_abstract_state()->size();
+    const int continuous_state_dim = state->get_continuous_state().size();
+    const int discrete_state_dim = state->get_discrete_state().num_groups();
+    const int abstract_state_dim = state->get_abstract_state().size();
 
     // Copy current state to the passed-in state, as specified in the
     // documentation for DoCalcUnrestrictedUpdate().
@@ -596,9 +596,9 @@ class System {
 
     DispatchUnrestrictedUpdateHandler(context, events, state);
 
-    if (continuous_state_dim != state->get_continuous_state()->size() ||
-        discrete_state_dim != state->get_discrete_state()->num_groups() ||
-        abstract_state_dim != state->get_abstract_state()->size())
+    if (continuous_state_dim != state->get_continuous_state().size() ||
+        discrete_state_dim != state->get_discrete_state().num_groups() ||
+        abstract_state_dim != state->get_abstract_state().size())
       throw std::logic_error(
           "State variable dimensions cannot be changed "
           "in CalcUnrestrictedUpdate().");
@@ -1072,8 +1072,7 @@ class System {
 
   /// Returns a copy of the continuous state vector `xc` into an Eigen vector.
   VectorX<T> CopyContinuousStateVector(const Context<T>& context) const {
-    DRAKE_ASSERT(context.get_continuous_state() != nullptr);
-    return context.get_continuous_state()->CopyToVector();
+    return context.get_continuous_state().CopyToVector();
   }
 
   /// Declares that `parent` is the immediately enclosing Diagram. The
@@ -1759,7 +1758,7 @@ class System {
       const Eigen::VectorXd& lambda) const {
     unused(J, lambda);
     DRAKE_DEMAND(get_num_constraint_equations(context) == 0);
-    const auto& gv = context.get_continuous_state()->get_generalized_velocity();
+    const auto& gv = context.get_continuous_state().get_generalized_velocity();
     return Eigen::VectorXd::Zero(gv.size());
   }
 

--- a/drake/systems/framework/system_symbolic_inspector.cc
+++ b/drake/systems/framework/system_symbolic_inspector.cc
@@ -16,7 +16,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
     const System<symbolic::Expression>& system)
     : context_(system.CreateDefaultContext()),
       input_variables_(system.get_num_input_ports()),
-      continuous_state_variables_(context_->get_continuous_state()->size()),
+      continuous_state_variables_(context_->get_continuous_state().size()),
       discrete_state_variables_(context_->get_num_discrete_state_groups()),
       numeric_parameters_(context_->num_numeric_parameters()),
       output_(system.AllocateOutput(*context_)),
@@ -50,7 +50,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
   }
 
   // Time derivatives.
-  if (context_->get_continuous_state()->size() > 0) {
+  if (context_->get_continuous_state().size() > 0) {
     system.CalcTimeDerivatives(*context_, derivatives_.get());
   }
 
@@ -99,7 +99,7 @@ void SystemSymbolicInspector::InitializeContinuousState() {
   // Set each element i in the continuous state to a symbolic expression whose
   // value is the variable "xci".
   VectorBase<symbolic::Expression>& xc =
-      *context_->get_mutable_continuous_state_vector();
+      context_->get_mutable_continuous_state_vector();
   for (int i = 0; i < xc.size(); ++i) {
     std::ostringstream name;
     name << "xc" << i;
@@ -111,7 +111,7 @@ void SystemSymbolicInspector::InitializeContinuousState() {
 void SystemSymbolicInspector::InitializeDiscreteState() {
   // For each discrete state vector i, set each element j to a symbolic
   // expression whose value is the variable "xdi_j".
-  auto& xd = *context_->get_mutable_discrete_state();
+  auto& xd = context_->get_mutable_discrete_state();
   for (int i = 0; i < context_->get_num_discrete_state_groups(); ++i) {
     auto& xdi = xd.get_mutable_vector(i);
     discrete_state_variables_[i].resize(xdi.size());

--- a/drake/systems/framework/test/continuous_state_test.cc
+++ b/drake/systems/framework/test/continuous_state_test.cc
@@ -47,10 +47,10 @@ TEST_F(ContinuousStateTest, Access) {
 }
 
 TEST_F(ContinuousStateTest, Mutation) {
-  continuous_state_->get_mutable_generalized_position()->SetAtIndex(0, 5);
-  continuous_state_->get_mutable_generalized_position()->SetAtIndex(1, 6);
-  continuous_state_->get_mutable_generalized_velocity()->SetAtIndex(0, 7);
-  continuous_state_->get_mutable_misc_continuous_state()->SetAtIndex(0, 8);
+  continuous_state_->get_mutable_generalized_position().SetAtIndex(0, 5);
+  continuous_state_->get_mutable_generalized_position().SetAtIndex(1, 6);
+  continuous_state_->get_mutable_generalized_velocity().SetAtIndex(0, 7);
+  continuous_state_->get_mutable_misc_continuous_state().SetAtIndex(0, 8);
 
   EXPECT_EQ(5, continuous_state_->get_vector()[0]);
   EXPECT_EQ(6, continuous_state_->get_vector()[1]);
@@ -69,7 +69,7 @@ TEST_F(ContinuousStateTest, OutOfBoundsAccess) {
   EXPECT_THROW(continuous_state_->get_generalized_position().GetAtIndex(2),
                std::runtime_error);
   EXPECT_THROW(
-      continuous_state_->get_mutable_generalized_velocity()->SetAtIndex(1, 42),
+      continuous_state_->get_mutable_generalized_velocity().SetAtIndex(1, 42),
       std::runtime_error);
 }
 

--- a/drake/systems/framework/test/diagram_context_test.cc
+++ b/drake/systems/framework/test/diagram_context_test.cc
@@ -93,12 +93,12 @@ class DiagramContextTest : public ::testing::Test {
 
     context_->MakeState();
     context_->MakeParameters();
-    ContinuousState<double>* xc = context_->get_mutable_continuous_state();
-    xc->get_mutable_vector()->SetAtIndex(0, 42.0);
-    xc->get_mutable_vector()->SetAtIndex(1, 43.0);
+    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
+    xc.get_mutable_vector().SetAtIndex(0, 42.0);
+    xc.get_mutable_vector().SetAtIndex(1, 43.0);
 
-    DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
-    xd->get_mutable_vector(0).SetAtIndex(0, 44.0);
+    DiscreteValues<double>& xd = context_->get_mutable_discrete_state();
+    xd.get_mutable_vector(0).SetAtIndex(0, 44.0);
 
     context_->get_mutable_numeric_parameter(0).SetAtIndex(0, 76.0);
     context_->get_mutable_numeric_parameter(0).SetAtIndex(1, 77.0);
@@ -140,15 +140,15 @@ class DiagramContextTest : public ::testing::Test {
 // DiagramContextTest::SetUp.
 void VerifyClonedState(const State<double>& clone) {
   // - Continuous
-  const ContinuousState<double>* xc = clone.get_continuous_state();
-  EXPECT_EQ(42.0, xc->get_vector().GetAtIndex(0));
-  EXPECT_EQ(43.0, xc->get_vector().GetAtIndex(1));
+  const ContinuousState<double>& xc = clone.get_continuous_state();
+  EXPECT_EQ(42.0, xc.get_vector().GetAtIndex(0));
+  EXPECT_EQ(43.0, xc.get_vector().GetAtIndex(1));
   // - Discrete
-  const DiscreteValues<double>* xd = clone.get_discrete_state();
-  EXPECT_EQ(44.0, xd->get_vector(0).GetAtIndex(0));
+  const DiscreteValues<double>& xd = clone.get_discrete_state();
+  EXPECT_EQ(44.0, xd.get_vector(0).GetAtIndex(0));
   // - Abstract
-  const AbstractValues* xa = clone.get_abstract_state();
-  EXPECT_EQ(42, xa->get_value(0).GetValue<int>());
+  const AbstractValues& xa = clone.get_abstract_state();
+  EXPECT_EQ(42, xa.get_value(0).GetValue<int>());
 }
 
 // Verifies that the @p params are a clone of the params constructed in
@@ -188,47 +188,47 @@ TEST_F(DiagramContextTest, Time) {
 // transparently through to the constituent system contexts.
 TEST_F(DiagramContextTest, State) {
   // Each integrator has a single continuous state variable.
-  ContinuousState<double>* xc = context_->get_mutable_continuous_state();
-  EXPECT_EQ(2, xc->size());
-  EXPECT_EQ(0, xc->get_generalized_position().size());
-  EXPECT_EQ(0, xc->get_generalized_velocity().size());
-  EXPECT_EQ(2, xc->get_misc_continuous_state().size());
+  ContinuousState<double>& xc = context_->get_mutable_continuous_state();
+  EXPECT_EQ(2, xc.size());
+  EXPECT_EQ(0, xc.get_generalized_position().size());
+  EXPECT_EQ(0, xc.get_generalized_velocity().size());
+  EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 
   // The zero-order hold has a discrete state vector of length 1.
-  DiscreteValues<double>* xd = context_->get_mutable_discrete_state();
-  EXPECT_EQ(1, xd->num_groups());
-  EXPECT_EQ(1, xd->get_vector(0).size());
+  DiscreteValues<double>& xd = context_->get_mutable_discrete_state();
+  EXPECT_EQ(1, xd.num_groups());
+  EXPECT_EQ(1, xd.get_vector(0).size());
 
   // Changes to the diagram state write through to constituent system states.
   // - Continuous
-  ContinuousState<double>* integrator0_xc =
+  ContinuousState<double>& integrator0_xc =
       context_->GetMutableSubsystemContext(2).get_mutable_continuous_state();
-  ContinuousState<double>* integrator1_xc =
+  ContinuousState<double>& integrator1_xc =
       context_->GetMutableSubsystemContext(3).get_mutable_continuous_state();
-  EXPECT_EQ(42.0, integrator0_xc->get_vector().GetAtIndex(0));
-  EXPECT_EQ(43.0, integrator1_xc->get_vector().GetAtIndex(0));
+  EXPECT_EQ(42.0, integrator0_xc.get_vector().GetAtIndex(0));
+  EXPECT_EQ(43.0, integrator1_xc.get_vector().GetAtIndex(0));
   // - Discrete
-  DiscreteValues<double>* hold_xd =
+  DiscreteValues<double>& hold_xd =
       context_->GetMutableSubsystemContext(4).get_mutable_discrete_state();
-  EXPECT_EQ(44.0, hold_xd->get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(44.0, hold_xd.get_vector(0).GetAtIndex(0));
 
   // Changes to constituent system states appear in the diagram state.
   // - Continuous
-  integrator1_xc->get_mutable_vector()->SetAtIndex(0, 1000.0);
-  EXPECT_EQ(1000.0, xc->get_vector().GetAtIndex(1));
+  integrator1_xc.get_mutable_vector().SetAtIndex(0, 1000.0);
+  EXPECT_EQ(1000.0, xc.get_vector().GetAtIndex(1));
   // - Discrete
-  hold_xd->get_mutable_vector(0).SetAtIndex(0, 1001.0);
-  EXPECT_EQ(1001.0, xd->get_vector(0).GetAtIndex(0));
+  hold_xd.get_mutable_vector(0).SetAtIndex(0, 1001.0);
+  EXPECT_EQ(1001.0, xd.get_vector(0).GetAtIndex(0));
 }
 
 // Tests that the pointers to substates in the DiagramState are equal to the
 // substates in the subsystem contexts.
 TEST_F(DiagramContextTest, DiagramState) {
   auto diagram_state = dynamic_cast<DiagramState<double>*>(
-      context_->get_mutable_state());
+      &context_->get_mutable_state());
   ASSERT_NE(nullptr, diagram_state);
   for (int i = 0; i < kNumSystems; ++i) {
-    EXPECT_EQ(context_->GetMutableSubsystemContext(i).get_mutable_state(),
+    EXPECT_EQ(&context_->GetMutableSubsystemContext(i).get_mutable_state(),
               &diagram_state->get_mutable_substate(i));
   }
 }
@@ -268,9 +268,9 @@ TEST_F(DiagramContextTest, Clone) {
 
   // Verify that changes to the state do not write through to the original
   // context.
-  clone->get_mutable_continuous_state_vector()->SetAtIndex(0, 1024.0);
-  EXPECT_EQ(1024.0, (*clone->get_continuous_state())[0]);
-  EXPECT_EQ(42.0, (*context_->get_continuous_state())[0]);
+  clone->get_mutable_continuous_state_vector().SetAtIndex(0, 1024.0);
+  EXPECT_EQ(1024.0, clone->get_continuous_state()[0]);
+  EXPECT_EQ(42.0, context_->get_continuous_state()[0]);
 
   // Verify that the cloned input ports contain the same data,
   // but are different pointers.
@@ -292,9 +292,9 @@ TEST_F(DiagramContextTest, CloneState) {
   EXPECT_NE(nullptr, dynamic_cast<DiagramState<double>*>(state.get()));
   // Verify that changes to the state do not write through to the original
   // context.
-  (*state->get_mutable_continuous_state())[1] = 1024.0;
-  EXPECT_EQ(1024.0, (*state->get_continuous_state())[1]);
-  EXPECT_EQ(43.0, (*context_->get_continuous_state())[1]);
+  state->get_mutable_continuous_state()[1] = 1024.0;
+  EXPECT_EQ(1024.0, state->get_continuous_state()[1]);
+  EXPECT_EQ(43.0, context_->get_continuous_state()[1]);
 }
 
 // Verifies that accuracy is set properly.

--- a/drake/systems/framework/test/diagram_test.cc
+++ b/drake/systems/framework/test/diagram_test.cc
@@ -356,21 +356,19 @@ class DiagramTest : public ::testing::Test {
     input2_ = BasicVector<double>::Make({64, 128, 256});
 
     // Initialize the integrator states.
-    auto integrator0_xc = GetMutableContinuousState(integrator0());
-    ASSERT_TRUE(integrator0_xc != nullptr);
-    integrator0_xc->get_mutable_vector()->SetAtIndex(0, 3);
-    integrator0_xc->get_mutable_vector()->SetAtIndex(1, 9);
-    integrator0_xc->get_mutable_vector()->SetAtIndex(2, 27);
+    auto& integrator0_xc = GetMutableContinuousState(integrator0());
+    integrator0_xc.get_mutable_vector().SetAtIndex(0, 3);
+    integrator0_xc.get_mutable_vector().SetAtIndex(1, 9);
+    integrator0_xc.get_mutable_vector().SetAtIndex(2, 27);
 
-    auto integrator1_xc = GetMutableContinuousState(integrator1());
-    ASSERT_TRUE(integrator1_xc != nullptr);
-    integrator1_xc->get_mutable_vector()->SetAtIndex(0, 81);
-    integrator1_xc->get_mutable_vector()->SetAtIndex(1, 243);
-    integrator1_xc->get_mutable_vector()->SetAtIndex(2, 729);
+    auto& integrator1_xc = GetMutableContinuousState(integrator1());
+    integrator1_xc.get_mutable_vector().SetAtIndex(0, 81);
+    integrator1_xc.get_mutable_vector().SetAtIndex(1, 243);
+    integrator1_xc.get_mutable_vector().SetAtIndex(2, 729);
   }
 
   // Returns the continuous state of the given @p system.
-  ContinuousState<double>* GetMutableContinuousState(
+  ContinuousState<double>& GetMutableContinuousState(
       const System<double>* system) {
     return diagram_->GetMutableSubsystemState(*system, context_.get())
         .get_mutable_continuous_state();
@@ -522,11 +520,11 @@ TEST_F(DiagramTest, GetMutableSubsystemState) {
   State<double>& state_from_context = diagram_->GetMutableSubsystemState(
       *diagram_->integrator0(), context_.get());
   State<double>& state_from_state = diagram_->GetMutableSubsystemState(
-      *diagram_->integrator0(), context_->get_mutable_state());
+      *diagram_->integrator0(), &context_->get_mutable_state());
 
   EXPECT_EQ(&state_from_context, &state_from_state);
   const ContinuousState<double>& xc =
-      *state_from_context.get_continuous_state();
+      state_from_context.get_continuous_state();
   EXPECT_EQ(3, xc[0]);
   EXPECT_EQ(9, xc[1]);
   EXPECT_EQ(27, xc[2]);
@@ -769,22 +767,22 @@ class DiagramOfDiagramsTest : public ::testing::Test {
     State<double>& integrator0_x = subdiagram0_->GetMutableSubsystemState(
         *subdiagram0_->integrator0(), &d0_context);
     integrator0_x.get_mutable_continuous_state()
-        ->get_mutable_vector()->SetAtIndex(0, 3);
+        .get_mutable_vector().SetAtIndex(0, 3);
 
     State<double>& integrator1_x = subdiagram0_->GetMutableSubsystemState(
         *subdiagram0_->integrator1(), &d0_context);
     integrator1_x.get_mutable_continuous_state()
-        ->get_mutable_vector()->SetAtIndex(0, 9);
+        .get_mutable_vector().SetAtIndex(0, 9);
 
     State<double>& integrator2_x = subdiagram1_->GetMutableSubsystemState(
         *subdiagram1_->integrator0(), &d1_context);
     integrator2_x.get_mutable_continuous_state()
-        ->get_mutable_vector()->SetAtIndex(0, 27);
+        .get_mutable_vector().SetAtIndex(0, 27);
 
     State<double>& integrator3_x = subdiagram1_->GetMutableSubsystemState(
         *subdiagram1_->integrator1(), &d1_context);
     integrator3_x.get_mutable_continuous_state()
-        ->get_mutable_vector()->SetAtIndex(0, 81);
+        .get_mutable_vector().SetAtIndex(0, 81);
   }
 
   const int kSize = 1;
@@ -1189,7 +1187,7 @@ class SecondOrderStateSystem : public LeafSystem<double> {
 
   SecondOrderStateVector* x(Context<double>* context) const {
     return dynamic_cast<SecondOrderStateVector*>(
-        context->get_mutable_continuous_state_vector());
+        &context->get_mutable_continuous_state_vector());
   }
 
  protected:
@@ -1258,7 +1256,7 @@ GTEST_TEST(SecondOrderStateTest, MapVelocityToQDot) {
 
   BasicVector<double> qdot(2);
   const VectorBase<double>& v =
-      context->get_continuous_state()->get_generalized_velocity();
+      context->get_continuous_state().get_generalized_velocity();
   diagram.MapVelocityToQDot(*context, v, &qdot);
 
   // The order of these derivatives is defined to be the same as the order
@@ -1414,7 +1412,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   context_->set_time(9.0);
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
-  context_->get_mutable_discrete_state()->SetFrom(*updates);
+  context_->get_mutable_discrete_state().SetFrom(*updates);
   EXPECT_EQ(1001.0, ctx1.get_discrete_state(0).GetAtIndex(0));
   EXPECT_EQ(23.0, ctx2.get_discrete_state(0).GetAtIndex(0));
 
@@ -1430,7 +1428,7 @@ TEST_F(DiscreteStateTest, UpdateDiscreteVariables) {
   context_->set_time(12.0);
   diagram_.CalcDiscreteVariableUpdates(
       *context_, events->get_discrete_update_events(), updates.get());
-  context_->get_mutable_discrete_state()->SetFrom(*updates);
+  context_->get_mutable_discrete_state().SetFrom(*updates);
   EXPECT_EQ(17.0, ctx1.get_discrete_state(0).GetAtIndex(0));
   EXPECT_EQ(23.0, ctx2.get_discrete_state(0).GetAtIndex(0));
 }
@@ -1476,7 +1474,7 @@ class SystemWithAbstractState : public LeafSystem<double> {
       const std::vector<const UnrestrictedUpdateEvent<double>*>& events,
       State<double>* state) const override {
     double& state_num = state->get_mutable_abstract_state()
-                            ->get_mutable_value(0)
+                            .get_mutable_value(0)
                             .GetMutableValue<double>();
     state_num = id_ + context.get_time();
   }
@@ -1568,7 +1566,7 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
   EXPECT_EQ(get_sys1_abstract_data_as_double(), 1);
 
   // Swaps in the new state, and the abstract data for sys0 should be updated.
-  context_->get_mutable_state()->CopyFrom(*x_buf);
+  context_->get_mutable_state().CopyFrom(*x_buf);
   EXPECT_EQ(get_sys0_abstract_data_as_double(), (time + 0));
   EXPECT_EQ(get_sys1_abstract_data_as_double(), 1);
 
@@ -1587,7 +1585,7 @@ TEST_F(AbstractStateDiagramTest, CalcUnrestrictedUpdate) {
   diagram_.CalcUnrestrictedUpdate(
       *context_, events->get_unrestricted_update_events(), x_buf.get());
   // Both sys0 and sys1's abstract data should be updated.
-  context_->get_mutable_state()->CopyFrom(*x_buf);
+  context_->get_mutable_state().CopyFrom(*x_buf);
   EXPECT_EQ(get_sys0_abstract_data_as_double(), (time + 0));
   EXPECT_EQ(get_sys1_abstract_data_as_double(), (time + 1));
 }
@@ -1679,16 +1677,16 @@ TEST_F(NestedDiagramContextTest, GetSubsystemContext) {
 
   big_diagram_->GetMutableSubsystemContext(*integrator0_, big_context_.get())
       .get_mutable_continuous_state_vector()
-      ->SetAtIndex(0, 1);
+      .SetAtIndex(0, 1);
   big_diagram_->GetMutableSubsystemContext(*integrator1_, big_context_.get())
       .get_mutable_continuous_state_vector()
-      ->SetAtIndex(0, 2);
+      .SetAtIndex(0, 2);
   big_diagram_->GetMutableSubsystemContext(*integrator2_, big_context_.get())
       .get_mutable_continuous_state_vector()
-      ->SetAtIndex(0, 3);
+      .SetAtIndex(0, 3);
   big_diagram_->GetMutableSubsystemContext(*integrator3_, big_context_.get())
       .get_mutable_continuous_state_vector()
-      ->SetAtIndex(0, 4);
+      .SetAtIndex(0, 4);
 
   // Checks states.
   EXPECT_EQ(big_diagram_->GetSubsystemContext(*integrator0_, *big_context_)
@@ -1727,40 +1725,40 @@ TEST_F(NestedDiagramContextTest, GetSubsystemState) {
   EXPECT_EQ(big_output_->get_vector_data(2)->GetAtIndex(0), 0);
   EXPECT_EQ(big_output_->get_vector_data(3)->GetAtIndex(0), 0);
 
-  State<double>* big_state = big_context_->get_mutable_state();
+  State<double>& big_state = big_context_->get_mutable_state();
   big_diagram_
-      ->GetMutableSubsystemState(*integrator0_, big_state)
+      ->GetMutableSubsystemState(*integrator0_, &big_state)
       .get_mutable_continuous_state()
-      ->get_mutable_vector()
-      ->SetAtIndex(0, 1);
+      .get_mutable_vector()
+      .SetAtIndex(0, 1);
   big_diagram_
-      ->GetMutableSubsystemState(*integrator1_, big_state)
+      ->GetMutableSubsystemState(*integrator1_, &big_state)
       .get_mutable_continuous_state()
-      ->get_mutable_vector()
-      ->SetAtIndex(0, 2);
+      .get_mutable_vector()
+      .SetAtIndex(0, 2);
   big_diagram_
-      ->GetMutableSubsystemState(*integrator2_, big_state)
+      ->GetMutableSubsystemState(*integrator2_, &big_state)
       .get_mutable_continuous_state()
-      ->get_mutable_vector()
-      ->SetAtIndex(0, 3);
+      .get_mutable_vector()
+      .SetAtIndex(0, 3);
   big_diagram_
-      ->GetMutableSubsystemState(*integrator3_, big_state)
+      ->GetMutableSubsystemState(*integrator3_, &big_state)
       .get_mutable_continuous_state()
-      ->get_mutable_vector()
-      ->SetAtIndex(0, 4);
+      .get_mutable_vector()
+      .SetAtIndex(0, 4);
 
   // Checks state.
-  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator0_, *big_state)
-                .get_continuous_state()->get_vector()[0],
+  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator0_, big_state)
+                .get_continuous_state().get_vector()[0],
             1);
-  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator1_, *big_state)
-                .get_continuous_state()->get_vector()[0],
+  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator1_, big_state)
+                .get_continuous_state().get_vector()[0],
             2);
-  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator2_, *big_state)
-                .get_continuous_state()->get_vector()[0],
+  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator2_, big_state)
+                .get_continuous_state().get_vector()[0],
             3);
-  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator3_, *big_state)
-                .get_continuous_state()->get_vector()[0],
+  EXPECT_EQ(big_diagram_->GetSubsystemState(*integrator3_, big_state)
+                .get_continuous_state().get_vector()[0],
             4);
 
   // Checks output.
@@ -1825,7 +1823,7 @@ class PerStepActionTestSystem : public LeafSystem<double> {
  private:
   void SetDefaultState(const Context<double>& context,
                        State<double>* state) const override {
-    (*state->get_mutable_discrete_state())[0] = 0;
+    state->get_mutable_discrete_state()[0] = 0;
     state->get_mutable_abstract_state<std::string>(0) = "wow";
   }
 
@@ -1903,13 +1901,13 @@ GTEST_TEST(DiagramPerStepActionTest, TestEverything) {
   // Does unrestricted update first.
   diagram->CalcUnrestrictedUpdate(
       *context, events->get_unrestricted_update_events(), tmp_state.get());
-  context->get_mutable_state()->CopyFrom(*tmp_state);
+  context->get_mutable_state().CopyFrom(*tmp_state);
 
   // Does discrete updates second.
   diagram->CalcDiscreteVariableUpdates(*context,
                                        events->get_discrete_update_events(),
                                        tmp_discrete_state.get());
-  context->get_mutable_discrete_state()->SetFrom(*tmp_discrete_state);
+  context->get_mutable_discrete_state().SetFrom(*tmp_discrete_state);
 
   // Publishes last.
   diagram->Publish(*context, events->get_publish_events());
@@ -2101,12 +2099,12 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
   // Set sys1 context.
   diagram->GetMutableSubsystemContext(*sys1, context.get())
       .get_mutable_continuous_state_vector()
-      ->SetFromVector(Eigen::Vector2d(5.0, 7.0));
+      .SetFromVector(Eigen::Vector2d(5.0, 7.0));
 
   // Set sys2 context.
   diagram->GetMutableSubsystemContext(*sys2, context.get())
       .get_mutable_continuous_state_vector()
-      ->SetFromVector(Eigen::Vector2d(11.0, 12.0));
+      .SetFromVector(Eigen::Vector2d(11.0, 12.0));
 
   Eigen::VectorXd value;
   // Check system 1's x0 constraint.
@@ -2230,7 +2228,7 @@ class RandomContextTestSystem : public LeafSystem<double> {
                       RandomGenerator* generator) const override {
     std::normal_distribution<double> normal;
     for (int i = 0; i < context.get_continuous_state_vector().size(); i++) {
-      state->get_mutable_continuous_state()->get_mutable_vector()->SetAtIndex(
+      state->get_mutable_continuous_state().get_mutable_vector().SetAtIndex(
           i, normal(*generator));
     }
   }

--- a/drake/systems/framework/test/leaf_context_test.cc
+++ b/drake/systems/framework/test/leaf_context_test.cc
@@ -114,7 +114,7 @@ class LeafContextTest : public ::testing::Test {
 // LeafContextTest::SetUp.
 void VerifyClonedState(const State<double>& clone) {
   // Verify that the state was copied.
-  const ContinuousState<double>& xc = *clone.get_continuous_state();
+  const ContinuousState<double>& xc = clone.get_continuous_state();
   {
     VectorX<double> contents = xc.CopyToVector();
     VectorX<double> expected(kContinuousStateSize);
@@ -122,9 +122,9 @@ void VerifyClonedState(const State<double>& clone) {
     EXPECT_EQ(expected, contents);
   }
 
-  EXPECT_EQ(2, clone.get_discrete_state()->num_groups());
-  const BasicVector<double>& xd0 = clone.get_discrete_state()->get_vector(0);
-  const BasicVector<double>& xd1 = clone.get_discrete_state()->get_vector(1);
+  EXPECT_EQ(2, clone.get_discrete_state().num_groups());
+  const BasicVector<double>& xd0 = clone.get_discrete_state().get_vector(0);
+  const BasicVector<double>& xd1 = clone.get_discrete_state().get_vector(1);
   {
     VectorX<double> contents = xd0.CopyToVector();
     VectorX<double> expected(1);
@@ -139,8 +139,8 @@ void VerifyClonedState(const State<double>& clone) {
     EXPECT_EQ(expected, contents);
   }
 
-  EXPECT_EQ(1, clone.get_abstract_state()->size());
-  EXPECT_EQ(42, clone.get_abstract_state()->get_value(0).GetValue<int>());
+  EXPECT_EQ(1, clone.get_abstract_state().size());
+  EXPECT_EQ(42, clone.get_abstract_state().get_value(0).GetValue<int>());
   EXPECT_EQ(42, clone.get_abstract_state<int>(0));
 
   // Verify that the state type was preserved.
@@ -289,9 +289,9 @@ TEST_F(LeafContextTest, Clone) {
 
   // Verify that changes to the cloned state do not affect the original state.
   // -- Continuous
-  ContinuousState<double>* xc = clone->get_mutable_continuous_state();
-  xc->get_mutable_generalized_velocity()->SetAtIndex(1, 42.0);
-  EXPECT_EQ(42.0, (*xc)[3]);
+  ContinuousState<double>& xc = clone->get_mutable_continuous_state();
+  xc.get_mutable_generalized_velocity().SetAtIndex(1, 42.0);
+  EXPECT_EQ(42.0, xc[3]);
   EXPECT_EQ(5.0, context_.get_continuous_state_vector().GetAtIndex(3));
 
   // -- Discrete
@@ -303,7 +303,7 @@ TEST_F(LeafContextTest, Clone) {
   // -- Abstract (even though it's not owned in context_)
   clone->get_mutable_abstract_state<int>(0) = 2048;
   EXPECT_EQ(42, context_.get_abstract_state<int>(0));
-  EXPECT_EQ(42, context_.get_abstract_state()->get_value(0).GetValue<int>());
+  EXPECT_EQ(42, context_.get_abstract_state().get_value(0).GetValue<int>());
   EXPECT_EQ(2048, clone->get_abstract_state<int>(0));
 
   // Verify that the parameters were copied.
@@ -337,13 +337,13 @@ TEST_F(LeafContextTest, CloneState) {
 // Tests that the State can be copied from another State.
 TEST_F(LeafContextTest, CopyStateFrom) {
   std::unique_ptr<Context<double>> clone = context_.Clone();
-  (*clone->get_mutable_continuous_state())[0] = 81.0;
+  clone->get_mutable_continuous_state()[0] = 81.0;
   clone->get_mutable_discrete_state(0)[0] = 243.0;
   clone->get_mutable_abstract_state<int>(0) = 729;
 
-  context_.get_mutable_state()->CopyFrom(clone->get_state());
+  context_.get_mutable_state().CopyFrom(clone->get_state());
 
-  EXPECT_EQ(81.0, (*context_.get_continuous_state())[0]);
+  EXPECT_EQ(81.0, context_.get_continuous_state()[0]);
   EXPECT_EQ(243.0, context_.get_discrete_state(0)[0]);
   EXPECT_EQ(729, context_.get_abstract_state<int>(0));
 }
@@ -395,7 +395,7 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   // Verify that time was set.
   EXPECT_EQ(kTime, target.get_time());
   // Verify that state was set.
-  const ContinuousState<AutoDiffXd> &xc = *target.get_continuous_state();
+  const ContinuousState<AutoDiffXd>& xc = target.get_continuous_state();
   EXPECT_EQ(kGeneralizedPositionSize, xc.get_generalized_position().size());
   EXPECT_EQ(5.0, xc.get_generalized_velocity()[1].value());
   EXPECT_EQ(0, xc.get_generalized_velocity()[1].derivatives().size());

--- a/drake/systems/framework/test/leaf_system_test.cc
+++ b/drake/systems/framework/test/leaf_system_test.cc
@@ -329,11 +329,11 @@ TEST_F(LeafSystemTest, Parameters) {
 TEST_F(LeafSystemTest, DeclareVanillaMiscContinuousState) {
   system_.DeclareContinuousState(2);
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
-  const ContinuousState<double>* xc = context->get_continuous_state();
-  EXPECT_EQ(2, xc->size());
-  EXPECT_EQ(0, xc->get_generalized_position().size());
-  EXPECT_EQ(0, xc->get_generalized_velocity().size());
-  EXPECT_EQ(2, xc->get_misc_continuous_state().size());
+  const ContinuousState<double>& xc = context->get_continuous_state();
+  EXPECT_EQ(2, xc.size());
+  EXPECT_EQ(0, xc.get_generalized_position().size());
+  EXPECT_EQ(0, xc.get_generalized_velocity().size());
+  EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 }
 
 // Tests that the leaf system reserved the declared misc continuous state of
@@ -341,14 +341,14 @@ TEST_F(LeafSystemTest, DeclareVanillaMiscContinuousState) {
 TEST_F(LeafSystemTest, DeclareTypedMiscContinuousState) {
   system_.DeclareContinuousState(MyVector2d());
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
-  const ContinuousState<double>* xc = context->get_continuous_state();
+  const ContinuousState<double>& xc = context->get_continuous_state();
   // Check that type was preserved.
   EXPECT_NE(nullptr, dynamic_cast<MyVector2d*>(
-                         context->get_mutable_continuous_state_vector()));
-  EXPECT_EQ(2, xc->size());
-  EXPECT_EQ(0, xc->get_generalized_position().size());
-  EXPECT_EQ(0, xc->get_generalized_velocity().size());
-  EXPECT_EQ(2, xc->get_misc_continuous_state().size());
+                         &context->get_mutable_continuous_state_vector()));
+  EXPECT_EQ(2, xc.size());
+  EXPECT_EQ(0, xc.get_generalized_position().size());
+  EXPECT_EQ(0, xc.get_generalized_velocity().size());
+  EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 }
 
 // Tests that the leaf system reserved the declared continuous state with
@@ -356,11 +356,11 @@ TEST_F(LeafSystemTest, DeclareTypedMiscContinuousState) {
 TEST_F(LeafSystemTest, DeclareVanillaContinuousState) {
   system_.DeclareContinuousState(4, 3, 2);
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
-  const ContinuousState<double>* xc = context->get_continuous_state();
-  EXPECT_EQ(4 + 3 + 2, xc->size());
-  EXPECT_EQ(4, xc->get_generalized_position().size());
-  EXPECT_EQ(3, xc->get_generalized_velocity().size());
-  EXPECT_EQ(2, xc->get_misc_continuous_state().size());
+  const ContinuousState<double>& xc = context->get_continuous_state();
+  EXPECT_EQ(4 + 3 + 2, xc.size());
+  EXPECT_EQ(4, xc.get_generalized_position().size());
+  EXPECT_EQ(3, xc.get_generalized_velocity().size());
+  EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 }
 
 // Tests that the leaf system reserved the declared continuous state with
@@ -369,15 +369,15 @@ TEST_F(LeafSystemTest, DeclareTypedContinuousState) {
   using MyVector9d = MyVector<4 + 3 + 2, double>;
   system_.DeclareContinuousState(MyVector9d(), 4, 3, 2);
   std::unique_ptr<Context<double>> context = system_.CreateDefaultContext();
-  const ContinuousState<double>* xc = context->get_continuous_state();
+  const ContinuousState<double>& xc = context->get_continuous_state();
   // Check that type was preserved.
   EXPECT_NE(nullptr, dynamic_cast<MyVector9d*>(
-                         context->get_mutable_continuous_state_vector()));
+                         &context->get_mutable_continuous_state_vector()));
   // Check that dimensions were preserved.
-  EXPECT_EQ(4 + 3 + 2, xc->size());
-  EXPECT_EQ(4, xc->get_generalized_position().size());
-  EXPECT_EQ(3, xc->get_generalized_velocity().size());
-  EXPECT_EQ(2, xc->get_misc_continuous_state().size());
+  EXPECT_EQ(4 + 3 + 2, xc.size());
+  EXPECT_EQ(4, xc.get_generalized_position().size());
+  EXPECT_EQ(3, xc.get_generalized_velocity().size());
+  EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 }
 
 TEST_F(LeafSystemTest, DeclarePerStepEvents) {
@@ -1433,7 +1433,7 @@ GTEST_TEST(SystemConstraintTest, ClassMethodTest) {
   EXPECT_EQ(dut.get_num_constraints(), 2);
 
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_continuous_state_vector()->SetFromVector(
+  context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d(5.0, 7.0));
 
   EXPECT_EQ(dut.get_constraint(SystemConstraintIndex(0)).size(), 1);
@@ -1471,7 +1471,7 @@ GTEST_TEST(SystemConstraintTest, FunctionHandleTest) {
   EXPECT_EQ(dut.get_num_constraints(), 1);
 
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_continuous_state_vector()->SetFromVector(
+  context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d(5.0, 7.0));
 
   Eigen::VectorXd value;
@@ -1551,7 +1551,7 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   EXPECT_TRUE(CompareMatrices(value0, Vector1<double>::Constant(-10.0)));
 
   // `xc[0] >= 22.0` with `xc[0] == 2.0` produces `-20.0 >= 0.0`.
-  context->get_mutable_continuous_state_vector()->SetAtIndex(0, 2.0);
+  context->get_mutable_continuous_state_vector().SetAtIndex(0, 2.0);
   Eigen::VectorXd value1;
   constraint1.Calc(*context, &value1);
   EXPECT_TRUE(CompareMatrices(value1, Vector1<double>::Constant(-20.0)));
@@ -1584,7 +1584,7 @@ class RandomContextTestSystem : public LeafSystem<double> {
                       RandomGenerator* generator) const override {
     std::normal_distribution<double> normal;
     for (int i = 0; i < context.get_continuous_state_vector().size(); i++) {
-      state->get_mutable_continuous_state()->get_mutable_vector()->SetAtIndex(
+      state->get_mutable_continuous_state().get_mutable_vector().SetAtIndex(
           i, normal(*generator));
     }
   }

--- a/drake/systems/framework/test/output_port_test.cc
+++ b/drake/systems/framework/test/output_port_test.cc
@@ -191,7 +191,7 @@ class SystemWithNStates : public LeafSystem<double> {
  private:
   void ReturnNumContinuous(const Context<double>& context, int* nc) const {
     ASSERT_NE(nc, nullptr);
-    *nc = context.get_state().get_continuous_state()->size();
+    *nc = context.get_state().get_continuous_state().size();
   }
 };
 

--- a/drake/systems/framework/test/single_output_vector_source_test.cc
+++ b/drake/systems/framework/test/single_output_vector_source_test.cc
@@ -56,7 +56,7 @@ TEST_F(SingleOutputVectorSourceTest, OutputTest) {
 
 // Tests that the state is empty.
 TEST_F(SingleOutputVectorSourceTest, IsStateless) {
-  EXPECT_EQ(context_->get_continuous_state()->size(), 0);
+  EXPECT_EQ(context_->get_continuous_state().size(), 0);
 }
 
 }  // namespace

--- a/drake/systems/framework/test/system_constraint_test.cc
+++ b/drake/systems/framework/test/system_constraint_test.cc
@@ -38,12 +38,12 @@ GTEST_TEST(SystemConstraintTest, BasicTest) {
   // Test equality constraint.
   SystemConstraint<double> equality_constraint(
       calc, 1, SystemConstraintType::kEquality, "equality constraint");
-  context->get_mutable_continuous_state_vector()->SetAtIndex(1, 5.0);
+  context->get_mutable_continuous_state_vector().SetAtIndex(1, 5.0);
   equality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 5.0);
   EXPECT_FALSE(equality_constraint.CheckSatisfied(*context, tol));
 
-  context->get_mutable_continuous_state_vector()->SetAtIndex(1, 0.0);
+  context->get_mutable_continuous_state_vector().SetAtIndex(1, 0.0);
   equality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 0.0);
   EXPECT_TRUE(equality_constraint.CheckSatisfied(*context, tol));
@@ -54,14 +54,14 @@ GTEST_TEST(SystemConstraintTest, BasicTest) {
   // Test inequality constraint.
   SystemConstraint<double> inequality_constraint(
       calc2, 2, SystemConstraintType::kInequality, "inequality constraint");
-  context->get_mutable_continuous_state_vector()->SetAtIndex(0, 3.0);
-  context->get_mutable_continuous_state_vector()->SetAtIndex(1, 5.0);
+  context->get_mutable_continuous_state_vector().SetAtIndex(0, 3.0);
+  context->get_mutable_continuous_state_vector().SetAtIndex(1, 5.0);
   inequality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[0], 3.0);
   EXPECT_EQ(value[1], 5.0);
   EXPECT_TRUE(inequality_constraint.CheckSatisfied(*context, tol));
 
-  context->get_mutable_continuous_state_vector()->SetAtIndex(1, -0.5);
+  context->get_mutable_continuous_state_vector().SetAtIndex(1, -0.5);
   inequality_constraint.Calc(*context, &value);
   EXPECT_EQ(value[1], -0.5);
   EXPECT_FALSE(inequality_constraint.CheckSatisfied(*context, tol));

--- a/drake/systems/framework/test/system_scalar_conversion_doxygen_test.cc
+++ b/drake/systems/framework/test/system_scalar_conversion_doxygen_test.cc
@@ -20,7 +20,7 @@ GTEST_TEST(SystemScalarConversionDoxygen, PendulumPlantAutodiff) {
   auto context = plant->CreateDefaultContext();
   context->FixInputPort(0, Vector1d::Zero());  // tau
   auto* state = dynamic_cast<PendulumState<double>*>(
-      context->get_mutable_continuous_state_vector());
+      &context->get_mutable_continuous_state_vector());
   state->set_theta(0.1);
   state->set_thetadot(0.2);
   double energy = plant->CalcTotalEnergy(*context);
@@ -34,7 +34,7 @@ GTEST_TEST(SystemScalarConversionDoxygen, PendulumPlantAutodiff) {
 
   // Differentiate with respect to theta by setting dtheta/dtheta = 1.0.
   constexpr int kNumDerivatives = 1;
-  auto& xc = *autodiff_context->get_mutable_continuous_state_vector();
+  auto& xc = autodiff_context->get_mutable_continuous_state_vector();
   xc[PendulumStateIndices::kTheta].derivatives() =
       MatrixXd::Identity(kNumDerivatives, kNumDerivatives).col(0);
 

--- a/drake/systems/framework/test/vector_system_test.cc
+++ b/drake/systems/framework/test/vector_system_test.cc
@@ -245,7 +245,7 @@ TEST_F(VectorSystemTest, OutputContinuous) {
   auto& output_port = dut.get_output_port();
   std::unique_ptr<AbstractValue> output = output_port.Allocate(*context);
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
-  context->get_mutable_continuous_state_vector()->SetFromVector(
+  context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d::Ones());
   output_port.Calc(*context, output.get());
   EXPECT_EQ(dut.get_output_count(), 1);
@@ -303,7 +303,7 @@ TEST_F(VectorSystemTest, TimeDerivatives) {
   dut.DeclareContinuousState(TestVectorSystem::kSize);
   context = dut.CreateDefaultContext();
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
-  context->get_mutable_continuous_state_vector()->SetFromVector(
+  context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d::Ones());
   derivatives = dut.AllocateTimeDerivatives();
   dut.CalcTimeDerivatives(*context, derivatives.get());
@@ -377,7 +377,7 @@ class NoInputContinuousTimeSystem : public VectorSystem<double> {
 TEST_F(VectorSystemTest, NoInputContinuousTimeSystemTest) {
   NoInputContinuousTimeSystem dut;
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_continuous_state()->SetFromVector(Vector1d::Ones());
+  context->get_mutable_continuous_state().SetFromVector(Vector1d::Ones());
 
   // Ensure that time derivatives get calculated correctly.
   std::unique_ptr<ContinuousState<double>> derivatives =
@@ -416,7 +416,7 @@ class NoInputNoOutputDiscreteTimeSystem : public VectorSystem<double> {
 TEST_F(VectorSystemTest, NoInputNoOutputDiscreteTimeSystemTest) {
   NoInputNoOutputDiscreteTimeSystem dut;
   auto context = dut.CreateDefaultContext();
-  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(
+  context->get_mutable_discrete_state().get_mutable_vector().SetFromVector(
       Vector1d::Constant(2.0));
 
   auto discrete_updates = dut.AllocateDiscreteVariables();
@@ -540,7 +540,7 @@ TEST_F(VectorSystemTest, MissingMethodsDiscreteTimeSystemTest) {
   MissingMethodsDiscreteTimeSystem dut;
   auto context = dut.CreateDefaultContext();
 
-  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(
+  context->get_mutable_discrete_state().get_mutable_vector().SetFromVector(
       Vector1d::Constant(2.0));
   auto discrete_updates = dut.AllocateDiscreteVariables();
   EXPECT_THROW(

--- a/drake/systems/framework/vector_system.h
+++ b/drake/systems/framework/vector_system.h
@@ -65,7 +65,7 @@ class VectorSystem : public LeafSystem<T> {
 
     // At most one of either continuous xor discrete state.
     DRAKE_THROW_UNLESS(result->get_num_abstract_state_groups() == 0);
-    const int continuous_size = result->get_continuous_state()->size();
+    const int continuous_size = result->get_continuous_state().size();
     const int num_discrete_groups = result->get_num_discrete_state_groups();
     DRAKE_DEMAND(continuous_size >= 0);
     DRAKE_DEMAND(num_discrete_groups >= 0);
@@ -160,10 +160,9 @@ class VectorSystem : public LeafSystem<T> {
         dynamic_cast<const BasicVector<T>&>(state_vector).get_value();
 
     // Obtain the block form of xcdot.
-    VectorBase<T>* const derivatives_vector = derivatives->get_mutable_vector();
-    DRAKE_ASSERT(derivatives_vector != nullptr);
+    VectorBase<T>& derivatives_vector = derivatives->get_mutable_vector();
     Eigen::VectorBlock<VectorX<T>> derivatives_block =
-        dynamic_cast<BasicVector<T>&>(*derivatives_vector).get_mutable_value();
+        dynamic_cast<BasicVector<T>&>(derivatives_vector).get_mutable_value();
 
     // Delegate to subclass.
     DoCalcVectorTimeDerivatives(context, input_block, state_block,

--- a/drake/systems/lcm/lcm_driven_loop.cc
+++ b/drake/systems/lcm/lcm_driven_loop.cc
@@ -44,14 +44,14 @@ const AbstractValue& LcmDrivenLoop::WaitForMessage() {
   if (sub_events_->HasDiscreteUpdateEvents()) {
     driving_sub_.CalcDiscreteVariableUpdates(
         *sub_context_, sub_events_->get_discrete_update_events(),
-        sub_swap_state_->get_mutable_discrete_state());
+        &sub_swap_state_->get_mutable_discrete_state());
   } else if (sub_events_->HasUnrestrictedUpdateEvents()) {
     driving_sub_.CalcUnrestrictedUpdate(*sub_context_,
         sub_events_->get_unrestricted_update_events(), sub_swap_state_.get());
   } else {
     DRAKE_DEMAND(false);
   }
-  sub_context_->get_mutable_state()->CopyFrom(*sub_swap_state_);
+  sub_context_->get_mutable_state().CopyFrom(*sub_swap_state_);
 
   driving_sub_.CalcOutput(*sub_context_, sub_output_.get());
   return *(sub_output_->get_data(0));

--- a/drake/systems/lcm/lcm_driven_loop.h
+++ b/drake/systems/lcm/lcm_driven_loop.h
@@ -156,9 +156,9 @@ class LcmDrivenLoop {
   }
 
   /**
-   * Returns a mutable pointer to the context.
+   * Returns a mutable reference to the context.
    */
-  Context<double>* get_mutable_context() {
+  Context<double>& get_mutable_context() {
     return stepper_->get_mutable_context();
   }
 

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -86,10 +86,10 @@ void LcmSubscriberSystem::SetDefaultState(const Context<double>&,
                                           State<double>* state) const {
   if (translator_ != nullptr) {
     DRAKE_DEMAND(serializer_ == nullptr);
-    ProcessMessageAndStoreToDiscreteState(state->get_mutable_discrete_state());
+    ProcessMessageAndStoreToDiscreteState(&state->get_mutable_discrete_state());
   } else {
     DRAKE_DEMAND(translator_ == nullptr);
-    ProcessMessageAndStoreToAbstractState(state->get_mutable_abstract_state());
+    ProcessMessageAndStoreToAbstractState(&state->get_mutable_abstract_state());
   }
 }
 
@@ -275,7 +275,7 @@ void LcmSubscriberSystem::CalcSerializerOutputValue(
     const Context<double>& context, AbstractValue* output_value) const {
   DRAKE_DEMAND(serializer_.get() != nullptr);
   output_value->SetFrom(
-      context.get_abstract_state()->get_value(kStateIndexMessage));
+      context.get_abstract_state().get_value(kStateIndexMessage));
 }
 
 void LcmSubscriberSystem::HandleMessage(const std::string& channel,

--- a/drake/systems/lcm/lcm_subscriber_system.h
+++ b/drake/systems/lcm/lcm_subscriber_system.h
@@ -146,7 +146,7 @@ class LcmSubscriberSystem : public LeafSystem<double>,
       const Context<double>&,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
       State<double>* state) const override {
-    ProcessMessageAndStoreToAbstractState(state->get_mutable_abstract_state());
+    ProcessMessageAndStoreToAbstractState(&state->get_mutable_abstract_state());
   }
 
   std::unique_ptr<AbstractValues> AllocateAbstractState() const override;

--- a/drake/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/drake/systems/lcm/test/lcm_driven_loop_test.cc
@@ -108,7 +108,7 @@ GTEST_TEST(LcmDrivenLoopTest, TestLoop) {
   const AbstractValue& first_msg = dut.WaitForMessage();
   double msg_time =
       dut.get_message_to_time_converter().GetTimeInSeconds(first_msg);
-  dut.get_mutable_context()->set_time(msg_time);
+  dut.get_mutable_context().set_time(msg_time);
 
   // Starts the loop.
   dut.RunToSecondsAssumingInitialized(static_cast<double>(kEnd));

--- a/drake/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/drake/systems/lcm/test/lcm_publisher_system_test.cc
@@ -173,7 +173,7 @@ GTEST_TEST(LcmPublisherSystemTest, TestPublishPeriod) {
 
   for (double time = 0; time < 4; time += 0.01) {
     simulator.StepTo(time);
-    EXPECT_NEAR(simulator.get_mutable_context()->get_time(), time, 1e-10);
+    EXPECT_NEAR(simulator.get_mutable_context().get_time(), time, 1e-10);
     // Note that the expected time is in milliseconds.
     const double expected_time =
         std::floor(time / kPublishPeriod) * kPublishPeriod * 1000;

--- a/drake/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/drake/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -30,14 +30,14 @@ void EvalOutputHelper(const LcmSubscriberSystem& sub, Context<double>* context,
     if (event_info->HasDiscreteUpdateEvents()) {
       sub.CalcDiscreteVariableUpdates(
           *context, event_info->get_discrete_update_events(),
-          tmp_state->get_mutable_discrete_state());
+          &tmp_state->get_mutable_discrete_state());
     } else if (event_info->HasUnrestrictedUpdateEvents()) {
       sub.CalcUnrestrictedUpdate(*context,
           event_info->get_unrestricted_update_events(), tmp_state.get());
     } else {
       DRAKE_DEMAND(false);
     }
-    context->get_mutable_state()->CopyFrom(*tmp_state);
+    context->get_mutable_state().CopyFrom(*tmp_state);
   }
   sub.CalcOutput(*context, output);
 }

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -173,10 +173,10 @@ void SpringMassSystem<T>::DoCalcTimeDerivatives(
   // TODO(david-german-tri): Cache the output of this function.
   const SpringMassStateVector<T>& state = get_state(context);
 
-  SpringMassStateVector<T>* derivative_vector = get_mutable_state(derivatives);
+  SpringMassStateVector<T>& derivative_vector = get_mutable_state(derivatives);
 
   // The derivative of position is velocity.
-  derivative_vector->set_position(state.get_velocity());
+  derivative_vector.set_position(state.get_velocity());
 
   const T external_force = get_input_force(context);
 
@@ -184,12 +184,12 @@ void SpringMassSystem<T>::DoCalcTimeDerivatives(
   // f is the force applied to the body by the spring, and m is the mass of the
   // body.
   const T force_applied_to_body = EvalSpringForce(context) + external_force;
-  derivative_vector->set_velocity(force_applied_to_body / mass_kg_);
+  derivative_vector.set_velocity(force_applied_to_body / mass_kg_);
 
   // We are integrating conservative power to get the work done by conservative
   // force elements, that is, the net energy transferred between the spring and
   // the mass over time.
-  derivative_vector->set_conservative_work(
+  derivative_vector.set_conservative_work(
       this->CalcConservativePower(context));
 }
 

--- a/drake/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/drake/systems/plants/spring_mass_system/spring_mass_system.h
@@ -135,18 +135,18 @@ class SpringMassSystem : public LeafSystem<T> {
 
   /// Sets the position of the mass in the given Context.
   void set_position(Context<T>* context, const T& position) const {
-    get_mutable_state(context)->set_position(position);
+    get_mutable_state(context).set_position(position);
   }
 
   /// Sets the velocity of the mass in the given Context.
   void set_velocity(Context<T>* context, const T& velocity) const {
-    get_mutable_state(context)->set_velocity(velocity);
+    get_mutable_state(context).set_velocity(velocity);
   }
 
   /// Sets the initial value of the conservative power integral in the given
   /// Context.
   void set_conservative_work(Context<T>* context, const T& energy) const {
-    get_mutable_state(context)->set_conservative_work(energy);
+    get_mutable_state(context).set_conservative_work(energy);
   }
 
   /// Returns the force being applied by the spring to the mass in the given
@@ -261,18 +261,18 @@ class SpringMassSystem : public LeafSystem<T> {
     return dynamic_cast<const SpringMassStateVector<T>&>(cstate.get_vector());
   }
 
-  static SpringMassStateVector<T>* get_mutable_state(
+  static SpringMassStateVector<T>& get_mutable_state(
       ContinuousState<T>* cstate) {
-    return dynamic_cast<SpringMassStateVector<T>*>(
+    return dynamic_cast<SpringMassStateVector<T>&>(
         cstate->get_mutable_vector());
   }
 
   static const SpringMassStateVector<T>& get_state(const Context<T>& context) {
-    return get_state(*context.get_continuous_state());
+    return get_state(context.get_continuous_state());
   }
 
-  static SpringMassStateVector<T>* get_mutable_state(Context<T>* context) {
-    return get_mutable_state(context->get_mutable_continuous_state());
+  static SpringMassStateVector<T>& get_mutable_state(Context<T>* context) {
+    return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
   const double spring_constant_N_per_m_{};

--- a/drake/systems/primitives/affine_system.cc
+++ b/drake/systems/primitives/affine_system.cc
@@ -75,7 +75,7 @@ void TimeVaryingAffineSystem<T>::CalcOutputY(
     const VectorX<T>& x = (this->time_period() == 0.)
         ? dynamic_cast<const BasicVector<T>&>(
             context.get_continuous_state_vector()).get_value()
-        : context.get_discrete_state()->get_vector().get_value();
+        : context.get_discrete_state().get_vector().get_value();
     y += Ct * x;
   }
 
@@ -245,7 +245,7 @@ void AffineSystem<T>::CalcOutputY(const Context<T>& context,
   const VectorX<T>& x = (this->time_period() == 0.)
       ? dynamic_cast<const BasicVector<T>&>(
           context.get_continuous_state_vector()).get_value()
-      : context.get_discrete_state()->get_vector().get_value();
+      : context.get_discrete_state().get_vector().get_value();
 
   auto y = output_vector->get_mutable_value();
   y = C_ * x + y0_;

--- a/drake/systems/primitives/first_order_low_pass_filter.cc
+++ b/drake/systems/primitives/first_order_low_pass_filter.cc
@@ -53,10 +53,10 @@ FirstOrderLowPassFilter<T>::get_time_constants_vector() const {
 template <typename T>
 void FirstOrderLowPassFilter<T>::set_initial_output_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& z0) const {
-  VectorBase<T>* state_vector = context->get_mutable_continuous_state_vector();
+  VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
-  DRAKE_ASSERT(z0.rows() == state_vector->size() && z0.cols() == 1);
-  state_vector->SetFromVector(z0);
+  DRAKE_ASSERT(z0.rows() == state_vector.size() && z0.cols() == 1);
+  state_vector.SetFromVector(z0);
 }
 
 template <typename T>

--- a/drake/systems/primitives/integrator.cc
+++ b/drake/systems/primitives/integrator.cc
@@ -24,10 +24,10 @@ Integrator<T>::~Integrator() {}
 template <typename T>
 void Integrator<T>::set_integral_value(
     Context<T>* context, const Eigen::Ref<const VectorX<T>>& value) const {
-  VectorBase<T>* state_vector = context->get_mutable_continuous_state_vector();
+  VectorBase<T>& state_vector = context->get_mutable_continuous_state_vector();
   // Asserts that the input value is a column vector of the appropriate size.
-  DRAKE_ASSERT(value.rows() == state_vector->size() && value.cols() == 1);
-  state_vector->SetFromVector(value);
+  DRAKE_ASSERT(value.rows() == state_vector.size() && value.cols() == 1);
+  state_vector.SetFromVector(value);
 }
 
 template <typename T>

--- a/drake/systems/primitives/linear_system.cc
+++ b/drake/systems/primitives/linear_system.cc
@@ -136,7 +136,7 @@ MakeStateAndInputMatrices(
     Context<AutoDiffXd>* autodiff_context,
     WhichAction which_action) {
   if (autodiff_context->has_only_continuous_state()) {
-    autodiff_context->get_mutable_continuous_state_vector()->SetFromVector(
+    autodiff_context->get_mutable_continuous_state_vector().SetFromVector(
         autodiff_x0_vec);
     std::unique_ptr<ContinuousState<AutoDiffXd>> autodiff_xdot =
         autodiff_system.AllocateTimeDerivatives();
@@ -154,7 +154,7 @@ MakeStateAndInputMatrices(
                           math::autoDiffToValueMatrix(autodiff_xdot_vec));
   }
   auto& autodiff_x0 =
-      autodiff_context->get_mutable_discrete_state()->get_mutable_vector();
+      autodiff_context->get_mutable_discrete_state().get_mutable_vector();
   autodiff_x0.SetFromVector(autodiff_x0_vec);
   std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
       autodiff_system.AllocateDiscreteVariables();

--- a/drake/systems/primitives/random_source.h
+++ b/drake/systems/primitives/random_source.h
@@ -93,10 +93,10 @@ class RandomSource : public LeafSystem<double> {
       State<double>* state) const override {
     auto& random_state =
         state->template get_mutable_abstract_state<RandomState>(0);
-    auto* updates = state->get_mutable_discrete_state();
-    const int N = updates->size();
+    auto& updates = state->get_mutable_discrete_state();
+    const int N = updates.size();
     for (int i = 0; i < N; i++) {
-      (*updates)[i] = random_state.GetNextValue();
+      updates[i] = random_state.GetNextValue();
     }
   }
 

--- a/drake/systems/primitives/test/adder_test.cc
+++ b/drake/systems/primitives/test/adder_test.cc
@@ -68,7 +68,7 @@ TEST_F(AdderTest, AddTwoVectors) {
 
 // Tests that Adder allocates no state variables in the context_.
 TEST_F(AdderTest, AdderIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
 }
 
 // Asserts that adders have direct-feedthrough from all inputs to the output.

--- a/drake/systems/primitives/test/affine_system_test.cc
+++ b/drake/systems/primitives/test/affine_system_test.cc
@@ -23,7 +23,7 @@ class AffineSystemTest : public AffineLinearSystemTest {
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
     system_output_ = dut_->AllocateOutput(*context_);
-    state_ = context_->get_mutable_continuous_state();
+    state_ = &context_->get_mutable_continuous_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
     updates_ = dut_->AllocateDiscreteVariables();
   }
@@ -255,7 +255,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, EvalTest) {
 
   auto context = sys.CreateDefaultContext();
   context->set_time(t);
-  context->get_mutable_continuous_state_vector()->SetFromVector(x);
+  context->get_mutable_continuous_state_vector().SetFromVector(x);
   context->FixInputPort(0, BasicVector<double>::Make(42.0));
 
   auto derivs = sys.AllocateTimeDerivatives();
@@ -276,7 +276,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
 
   auto context = sys.CreateDefaultContext();
   context->set_time(t);
-  context->get_mutable_discrete_state()->get_mutable_vector().SetFromVector(x);
+  context->get_mutable_discrete_state().get_mutable_vector().SetFromVector(x);
   context->FixInputPort(0, BasicVector<double>::Make(42.0));
 
   auto updates = sys.AllocateDiscreteVariables();

--- a/drake/systems/primitives/test/constant_value_source_test.cc
+++ b/drake/systems/primitives/test/constant_value_source_test.cc
@@ -42,7 +42,7 @@ TEST_F(ConstantValueSourceTest, Output) {
 
 // Tests that ConstantValueSource allocates no state variables in the context_.
 TEST_F(ConstantValueSourceTest, ConstantValueSourceIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/demultiplexer_test.cc
+++ b/drake/systems/primitives/test/demultiplexer_test.cc
@@ -98,7 +98,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
 
 // Tests that Demultiplexer allocates no state variables in the context_.
 TEST_F(DemultiplexerTest, DemultiplexerIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
 }
 
 TEST_F(DemultiplexerTest, DirectFeedthrough) {

--- a/drake/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/drake/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -37,13 +37,13 @@ class FirstOrderLowPassFilterTest : public ::testing::Test {
     output_ = filter_->get_output_port().Allocate(*context_);
 
     // Sets the state to zero initially.
-    ContinuousState<double>* xc = continuous_state();
-    EXPECT_EQ(kSignalSize, xc->size());
-    EXPECT_EQ(kSignalSize, xc->get_misc_continuous_state().size());
-    xc->SetFromVector(Eigen::VectorXd::Zero(kSignalSize));
+    ContinuousState<double>& xc = continuous_state();
+    EXPECT_EQ(kSignalSize, xc.size());
+    EXPECT_EQ(kSignalSize, xc.get_misc_continuous_state().size());
+    xc.SetFromVector(Eigen::VectorXd::Zero(kSignalSize));
   }
 
-  ContinuousState<double>* continuous_state() {
+  ContinuousState<double>& continuous_state() {
     return context_->get_mutable_continuous_state();
   }
 
@@ -81,7 +81,7 @@ TEST_F(FirstOrderLowPassFilterTest, Output) {
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
   EXPECT_EQ(expected, output_vector.get_value());
 
-  continuous_state()->get_mutable_vector()->SetAtIndex(1, 42.0);
+  continuous_state().get_mutable_vector().SetAtIndex(1, 42.0);
   expected << 0.0, 42.0, 0.0;
   filter_->get_output_port().Calc(*context_, output_.get());
   EXPECT_EQ(expected, output_vector.get_value());
@@ -101,7 +101,7 @@ TEST_F(FirstOrderLowPassFilterTest, Derivatives) {
   filter_->CalcTimeDerivatives(*context_, derivatives_.get());
 
   // Current state.
-  Vector3<double> z = continuous_state()->get_vector().CopyToVector();
+  Vector3<double> z = continuous_state().get_vector().CopyToVector();
   EXPECT_EQ(z_expected, z);
 
   auto time_constants = filter_->get_time_constants_vector();

--- a/drake/systems/primitives/test/gain_test.cc
+++ b/drake/systems/primitives/test/gain_test.cc
@@ -24,7 +24,7 @@ void TestGainSystem(const Gain<T>& gain_system,
   auto context = gain_system.CreateDefaultContext();
 
   // Verifies that Gain allocates no state variables in the context.
-  EXPECT_EQ(0, context->get_continuous_state()->size());
+  EXPECT_EQ(0, context->get_continuous_state().size());
   auto output = gain_system.AllocateOutput(*context);
   auto input =
       make_unique<BasicVector<double>>(gain_system.get_gain_vector().size());

--- a/drake/systems/primitives/test/integrator_test.cc
+++ b/drake/systems/primitives/test/integrator_test.cc
@@ -26,13 +26,13 @@ class IntegratorTest : public ::testing::Test {
     output_ = integrator_->AllocateOutput(*context_);
 
     // Set the state to zero initially.
-    ContinuousState<double>* xc = continuous_state();
-    EXPECT_EQ(3, xc->size());
-    EXPECT_EQ(3, xc->get_misc_continuous_state().size());
-    xc->SetFromVector(Eigen::VectorXd::Zero(kLength));
+    ContinuousState<double>& xc = continuous_state();
+    EXPECT_EQ(3, xc.size());
+    EXPECT_EQ(3, xc.get_misc_continuous_state().size());
+    xc.SetFromVector(Eigen::VectorXd::Zero(kLength));
   }
 
-  ContinuousState<double>* continuous_state() {
+  ContinuousState<double>& continuous_state() {
     return context_->get_mutable_continuous_state();
   }
 
@@ -69,7 +69,7 @@ TEST_F(IntegratorTest, Output) {
   Eigen::Vector3d expected = Eigen::Vector3d::Zero();
   EXPECT_EQ(expected, output_port->get_value());
 
-  continuous_state()->get_mutable_vector()->SetAtIndex(1, 42.0);
+  continuous_state().get_mutable_vector().SetAtIndex(1, 42.0);
   expected << 0.0, 42.0, 0.0;
   integrator_->CalcOutput(*context_, output_.get());
   EXPECT_EQ(expected, output_port->get_value());
@@ -106,7 +106,7 @@ class SymbolicIntegratorTest : public IntegratorTest {
             symbolic::Variable("u1"),
             symbolic::Variable("u2")));
 
-    auto& xc = *symbolic_context_->get_mutable_continuous_state_vector();
+    auto& xc = symbolic_context_->get_mutable_continuous_state_vector();
     xc[0] = symbolic::Variable("x0");
     xc[1] = symbolic::Variable("x1");
     xc[2] = symbolic::Variable("x2");

--- a/drake/systems/primitives/test/linear_system_test.cc
+++ b/drake/systems/primitives/test/linear_system_test.cc
@@ -28,7 +28,7 @@ class LinearSystemTest : public AffineLinearSystemTest {
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
     system_output_ = dut_->AllocateOutput(*context_);
-    state_ = context_->get_mutable_continuous_state();
+    state_ = &context_->get_mutable_continuous_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 
@@ -185,7 +185,7 @@ TEST_F(TestLinearizeFromAffine, ContinuousAtEquilibrium) {
 
   // Set x0 to the actual equilibrium point.
   const Eigen::Vector3d x0 = A_.colPivHouseholderQr().solve(-B_ * u0_ - f0_);
-  context->get_mutable_continuous_state_vector()->SetFromVector(x0);
+  context->get_mutable_continuous_state_vector().SetFromVector(x0);
 
   auto linearized_system = Linearize(*continuous_system_, *context);
 
@@ -214,7 +214,7 @@ TEST_F(TestLinearizeFromAffine, ContinuousAtEquilibrium) {
 TEST_F(TestLinearizeFromAffine, ContinuousAtNonEquilibrium) {
   auto context = continuous_system_->CreateDefaultContext();
   context->FixInputPort(0, Vector1d::Constant(u0_));
-  context->get_mutable_continuous_state_vector()->SetFromVector(x0_);
+  context->get_mutable_continuous_state_vector().SetFromVector(x0_);
 
   // This Context is not an equilibrium point.
   EXPECT_THROW(Linearize(*continuous_system_, *context), std::runtime_error);
@@ -248,7 +248,7 @@ TEST_F(TestLinearizeFromAffine, DiscreteAtEquilibrium) {
   const Eigen::Vector3d x0 =
       (eye - A_).colPivHouseholderQr().solve(B_ * u0_ + f0_);
   systems::BasicVector<double>& xd =
-      context->get_mutable_discrete_state()->get_mutable_vector();
+      context->get_mutable_discrete_state().get_mutable_vector();
   xd.SetFromVector(x0);
 
   auto linearized_system = Linearize(*discrete_system_, *context);
@@ -280,7 +280,7 @@ TEST_F(TestLinearizeFromAffine, DiscreteAtNonEquilibrium) {
   auto context = discrete_system_->CreateDefaultContext();
   context->FixInputPort(0, Vector1d::Constant(u0_));
   systems::BasicVector<double>& xd =
-      context->get_mutable_discrete_state()->get_mutable_vector();
+      context->get_mutable_discrete_state().get_mutable_vector();
   xd.SetFromVector(x0_);
 
   // This Context is not an equilibrium point.
@@ -493,11 +493,11 @@ TEST_F(LinearSystemTest, LinearizeSystemWithParameters) {
   auto input = std::make_unique<examples::pendulum::PendulumInput<double>>();
   input->set_tau(0.0);
   context->FixInputPort(0, std::move(input));
-  examples::pendulum::PendulumState<double>* state =
-      dynamic_cast<examples::pendulum::PendulumState<double>*>(
+  examples::pendulum::PendulumState<double>& state =
+      dynamic_cast<examples::pendulum::PendulumState<double>&>(
           context->get_mutable_continuous_state_vector());
-  state->set_theta(0.0);
-  state->set_thetadot(0.0);
+  state.set_theta(0.0);
+  state.set_thetadot(0.0);
 
   std::unique_ptr<LinearSystem<double>> linearized_pendulum =
       Linearize(pendulum, *context);

--- a/drake/systems/primitives/test/multiplexer_test.cc
+++ b/drake/systems/primitives/test/multiplexer_test.cc
@@ -100,7 +100,7 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
 
 TEST_F(MultiplexerTest, IsStateless) {
   Reset({1});
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/pass_through_test.cc
+++ b/drake/systems/primitives/test/pass_through_test.cc
@@ -95,9 +95,9 @@ TEST_P(PassThroughTest, VectorThroughPassThroughSystem) {
 
 // Tests that PassThrough allocates no state variables in the context_.
 TEST_P(PassThroughTest, PassThroughIsStateless) {
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
-  EXPECT_EQ(0, context_->get_abstract_state()->size());
-  EXPECT_EQ(0, context_->get_discrete_state()->num_groups());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
+  EXPECT_EQ(0, context_->get_abstract_state().size());
+  EXPECT_EQ(0, context_->get_discrete_state().num_groups());
 }
 
 // Tests that PassThrough is direct feedthrough.

--- a/drake/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/drake/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -38,8 +38,8 @@ class PiecewisePolynomialAffineSystemTest
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
     system_output_ = dut_->AllocateOutput(*context_);
-    continuous_state_ = context_->get_mutable_continuous_state();
-    discrete_state_ = context_->get_mutable_discrete_state();
+    continuous_state_ = &context_->get_mutable_continuous_state();
+    discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
     updates_ = dut_->AllocateDiscreteVariables();
   }

--- a/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/drake/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -38,8 +38,8 @@ class PiecewisePolynomialLinearSystemTest
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
     system_output_ = dut_->AllocateOutput(*context_);
-    continuous_state_ = context_->get_mutable_continuous_state();
-    discrete_state_ = context_->get_mutable_discrete_state();
+    continuous_state_ = &context_->get_mutable_continuous_state();
+    discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
     updates_ = dut_->AllocateDiscreteVariables();
   }

--- a/drake/systems/primitives/test/random_source_test.cc
+++ b/drake/systems/primitives/test/random_source_test.cc
@@ -39,7 +39,7 @@ void CheckStatistics(
 
   systems::Simulator<double> simulator(*diagram);
   BasicVector<double>& state =
-      simulator.get_mutable_context()->get_mutable_discrete_state(0);
+      simulator.get_mutable_context().get_mutable_discrete_state(0);
   for (int i = 0; i < state.size(); i++) {
     state.SetAtIndex(i, 0.0);
   }

--- a/drake/systems/primitives/test/saturation_test.cc
+++ b/drake/systems/primitives/test/saturation_test.cc
@@ -20,7 +20,7 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
   const int port_size = saturation_system.get_size();
 
   // Verifies that Saturation allocates no state variables in the context.
-  EXPECT_EQ(context->get_continuous_state()->size(), 0);
+  EXPECT_EQ(context->get_continuous_state().size(), 0);
   auto output = saturation_system.AllocateOutput(*context);
   auto input = std::make_unique<BasicVector<T>>(port_size);
 

--- a/drake/systems/primitives/test/signal_logger_test.cc
+++ b/drake/systems/primitives/test/signal_logger_test.cc
@@ -36,8 +36,8 @@ GTEST_TEST(TestSignalLogger, LinearSystemTest) {
 
   // Simulate the simple system from x(0) = 1.0.
   systems::Simulator<double> simulator(*diagram);
-  systems::Context<double>* context = simulator.get_mutable_context();
-  context->get_mutable_continuous_state_vector()->SetAtIndex(0, 1.0);
+  systems::Context<double>& context = simulator.get_mutable_context();
+  context.get_mutable_continuous_state_vector().SetAtIndex(0, 1.0);
 
   // Make the integrator tolerance sufficiently tight for the test to pass.
   simulator.get_mutable_integrator()->set_target_accuracy(1e-4);

--- a/drake/systems/primitives/test/trajectory_source_test.cc
+++ b/drake/systems/primitives/test/trajectory_source_test.cc
@@ -75,7 +75,7 @@ TEST_F(TrajectorySourceTest, OutputTest) {
 // Tests that ConstantVectorSource allocates no state variables in the context_.
 TEST_F(TrajectorySourceTest, ConstantVectorSourceIsStateless) {
   Reset(PiecewisePolynomial<double>(MatrixXd::Constant(2, 1, 1.5)));
-  EXPECT_EQ(0, context_->get_continuous_state()->size());
+  EXPECT_EQ(0, context_->get_continuous_state().size());
 }
 
 }  // namespace

--- a/drake/systems/primitives/test/zero_order_hold_test.cc
+++ b/drake/systems/primitives/test/zero_order_hold_test.cc
@@ -188,9 +188,9 @@ TEST_P(ZeroOrderHoldTest, Update) {
     const BasicVector<double>& xd = update->get_vector(0);
     value = xd.CopyToVector();
   } else {
-    State<double>* state = context_->get_mutable_state();
-    hold_->CalcUnrestrictedUpdate(*context_, state);
-    value = state->get_abstract_state<SimpleAbstractType>(0).value();
+    State<double>& state = context_->get_mutable_state();
+    hold_->CalcUnrestrictedUpdate(*context_, &state);
+    value = state.get_abstract_state<SimpleAbstractType>(0).value();
   }
   EXPECT_EQ(input_value_, value);
 }

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -85,7 +85,7 @@ void ZeroOrderHold<T>::DoCalcAbstractOutput(const Context<T>& context,
   // Do not use `get_abstract_state<AbstractValue>` since it would cast
   // the value to `Value<AbstractValue>`, which is an invalid type by design.
   const AbstractValue& state_value =
-      context.template get_abstract_state()->get_value(0);
+      context.template get_abstract_state().get_value(0);
   output->SetFrom(state_value);
 }
 
@@ -99,7 +99,7 @@ void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
   // See `DoCalcAbstractOutput` for rationale regarding non-templated value
   // accessor.
   AbstractValue& state_value =
-      state->get_mutable_abstract_state()->get_mutable_value(0);
+      state->get_mutable_abstract_state().get_mutable_value(0);
   state_value.SetFrom(input_value);
 }
 

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_example.cc
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_example.cc
@@ -38,7 +38,7 @@ int exec(int argc, char* argv[]) {
   diagram.get_mutable_logger()->enable_log_to_console();
 
   unique_ptr<Context<double>> context = diagram.AllocateContext();
-  diagram.SetDefaultState(*context, context->get_mutable_state());
+  diagram.SetDefaultState(*context, &context->get_mutable_state());
 
   // Sets the initial state of the pendulum.
   diagram.SetInitialState(context.get(), FLAGS_initial_q, FLAGS_initial_v);

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.cc
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.cc
@@ -114,12 +114,11 @@ void AccelerometerExampleDiagram::SetInitialState(Context<double>* context,
     double q, double v) {
   Context<double>& plant_context =
       GetMutableSubsystemContext(*plant_, context);
-  ContinuousState<double>* plant_state =
+  ContinuousState<double>& plant_state =
       plant_context.get_mutable_continuous_state();
-  DRAKE_DEMAND(plant_state != nullptr);
-  DRAKE_DEMAND(plant_state->size() == 2);
-  (*plant_state)[0] = q;
-  (*plant_state)[1] = v;
+  DRAKE_DEMAND(plant_state.size() == 2);
+  plant_state[0] = q;
+  plant_state[1] = v;
 }
 
 }  // namespace sensors

--- a/drake/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/drake/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -148,7 +148,7 @@ GTEST_TEST(TestAccelerometer, TestSensorAttachedToSwingingPendulum) {
 
   // Prepares to integrate.
   unique_ptr<Context<double>> context = diagram.AllocateContext();
-  diagram.SetDefaultState(*context, context->get_mutable_state());
+  diagram.SetDefaultState(*context, &context->get_mutable_state());
   diagram.SetInitialState(context.get(), 1.57, 0);
 
   Simulator<double> simulator(diagram, std::move(context));

--- a/drake/systems/sensors/test/beam_model_test.cc
+++ b/drake/systems/sensors/test/beam_model_test.cc
@@ -100,7 +100,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
   for (int i = 0; i < simulator.get_context().get_num_discrete_state_groups();
        i++) {
     BasicVector<double>& state =
-        simulator.get_mutable_context()->get_mutable_discrete_state(0);
+        simulator.get_mutable_context().get_mutable_discrete_state(0);
     for (int j = 0; j < state.size(); j++) {
       state.SetAtIndex(j, 0.0);
     }
@@ -108,7 +108,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
 
   auto& params =
       beam_model->get_mutable_parameters(&diagram->GetMutableSubsystemContext(
-          *beam_model, simulator.get_mutable_context()));
+          *beam_model, &simulator.get_mutable_context()));
 
   // Set some testable beam model parameters.
   params.set_lambda_short(2.0);

--- a/drake/systems/sensors/test/optitrack_encoder_test.cc
+++ b/drake/systems/sensors/test/optitrack_encoder_test.cc
@@ -58,7 +58,7 @@ class OptitrackEncoderTest : public ::testing::Test {
         dut.get_pose_bundle_input_port_index() /* input port ID*/,
         std::move(input));
 
-    dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+    dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
     dut.CalcOutput(*context, output.get());
     auto output_value =
         output->get_data(dut.get_optitrack_output_port_index());

--- a/drake/systems/sensors/test/optitrack_sender_test.cc
+++ b/drake/systems/sensors/test/optitrack_sender_test.cc
@@ -45,7 +45,7 @@ GTEST_TEST(OptitrackSenderTest, OptitrackLCMSenderTest) {
   auto output = dut.AllocateOutput(*context);
   context->FixInputPort(0 /* input port ID*/, std::move(input));
 
-  dut.CalcUnrestrictedUpdate(*context, context->get_mutable_state());
+  dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());
   dut.CalcOutput(*context, output.get());
   auto output_value = output->get_data(0);
 

--- a/drake/systems/trajectory_optimization/direct_collocation.cc
+++ b/drake/systems/trajectory_optimization/direct_collocation.cc
@@ -36,7 +36,7 @@ class DirectCollocationConstraint : public solvers::Constraint {
         derivatives_(system_->AllocateTimeDerivatives()),
         num_states_(num_states),
         num_inputs_(num_inputs) {
-    DRAKE_DEMAND(num_states_ == context.get_continuous_state()->size());
+    DRAKE_DEMAND(num_states_ == context.get_continuous_state().size());
     DRAKE_DEMAND(num_inputs_ == (context.get_num_input_ports() > 0
                                      ? system.get_input_port(0).size()
                                      : 0));
@@ -66,7 +66,7 @@ class DirectCollocationConstraint : public solvers::Constraint {
       input_port_value_->GetMutableVectorData<AutoDiffXd>()->SetFromVector(
           input);
     }
-    context_->get_mutable_continuous_state()->SetFromVector(state);
+    context_->get_mutable_continuous_state().SetFromVector(state);
     system_->CalcTimeDerivatives(*context_, derivatives_.get());
     *xdot = derivatives_->CopyToVector();
   }
@@ -133,7 +133,7 @@ DirectCollocation::DirectCollocation(const System<double>* system,
                                      double minimum_timestep,
                                      double maximum_timestep)
     : MultipleShooting(system->get_num_total_inputs(),
-                       context.get_continuous_state()->size(), num_time_samples,
+                       context.get_continuous_state().size(), num_time_samples,
                        minimum_timestep, maximum_timestep),
       system_(system),
       context_(system_->CreateDefaultContext()),
@@ -208,7 +208,7 @@ PiecewisePolynomialTrajectory DirectCollocation::ReconstructStateTrajectory()
     states[i] = GetSolution(state(i));
     input_port_value_->GetMutableVectorData<double>()->SetFromVector(
         GetSolution(input(i)));
-    context_->get_mutable_continuous_state()->SetFromVector(states[i]);
+    context_->get_mutable_continuous_state().SetFromVector(states[i]);
     system_->CalcTimeDerivatives(*context_, continuous_state_.get());
     derivatives[i] = continuous_state_->CopyToVector();
   }


### PR DESCRIPTION
This is a followup to #7312. Here the various state-returning APIs are switched to return references consistently. Also, the Simulator now returns Context references consistently.

As before the System convention followed here is to prefer reference return values over pointer returns unless a nullptr return is meaningful. This eliminates unnecessary nullptr checks and makes better use of the style guide's `&output_param` convention. Changes are minor but ubiquitous.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7337)
<!-- Reviewable:end -->
