### PR TITLE
Add LcmPlanInterpolator and update iiwa_controller.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/BUILD.bazel
@@ -59,6 +59,21 @@ drake_cc_library(
     ],
 )
 
+drake_cc_library(
+    name = "lcm_plan_interpolator",
+    srcs = ["lcm_plan_interpolator.cc"],
+    hdrs = [
+        "lcm_plan_interpolator.h",
+    ],
+    deps = [
+        ":iiwa_common",
+        ":iiwa_lcm",
+        "//drake/manipulation/planner:robot_plan_interpolator",
+        "//drake/systems/framework:diagram_builder",
+        "//drake/systems/primitives:demultiplexer",
+    ],
+)
+
 drake_cc_binary(
     name = "iiwa_controller",
     srcs = ["iiwa_controller.cc"],
@@ -68,18 +83,12 @@ drake_cc_binary(
     ],
     deps = [
         ":iiwa_common",
-        ":iiwa_lcm",
-        "//drake/common:find_resource",
+        ":lcm_plan_interpolator",
         "//drake/common:text_logging_gflags",
         "//drake/lcm",
-        "//drake/manipulation/planner:robot_plan_interpolator",
-        "//drake/systems/analysis:simulator",
         "//drake/systems/lcm",
         "//drake/systems/lcm:lcm_driven_loop",
-        "//drake/systems/primitives:demultiplexer",
         "@com_github_gflags_gflags//:gflags",
-        "@lcmtypes_bot2_core",
-        "@lcmtypes_robotlocomotion",
     ],
 )
 

--- a/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -10,11 +10,10 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/text_logging_gflags.h"
-#include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
+#include "drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.h"
 #include "drake/lcm/drake_lcm.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
-#include "drake/manipulation/planner/robot_plan_interpolator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram.h"
@@ -29,6 +28,12 @@ using robotlocomotion::robot_plan_t;
 DEFINE_string(urdf, "", "Name of urdf to load");
 DEFINE_string(interp_type, "cubic",
               "Robot plan interpolation type. Can be {zoh, foh, cubic, pchip}");
+DEFINE_string(lcm_status_channel, "IIWA_STATUS",
+              "Channel on which to listen for lcmt_iiwa_status messages.");
+DEFINE_string(lcm_command_channel, "IIWA_COMMAND",
+              "Channel on which to publish lcmt_iiwa_command messages.");
+DEFINE_string(lcm_plan_channel, "COMMITTED_ROBOT_PLAN",
+              "Channel on which to listen for robot_plan_t messages.");
 
 namespace drake {
 namespace examples {
@@ -37,84 +42,74 @@ namespace {
 using manipulation::planner::RobotPlanInterpolator;
 using manipulation::planner::InterpolatorType;
 
-const char* const kIiwaUrdf =
+const char kIiwaUrdf[] =
     "drake/manipulation/models/iiwa_description/urdf/"
     "iiwa14_polytope_collision.urdf";
-const char* const kLcmStatusChannel = "IIWA_STATUS";
-const char* const kLcmCommandChannel = "IIWA_COMMAND";
-const char* const kLcmPlanChannel = "COMMITTED_ROBOT_PLAN";
 
 // Create a system which has an integrator on the interpolated
 // reference position for received plans.
 int DoMain() {
+  const std::string kLcmStatusChannel = FLAGS_lcm_status_channel;
+  const std::string kLcmCommandChannel = FLAGS_lcm_command_channel;
+  const std::string kLcmPlanChannel = FLAGS_lcm_plan_channel;
   lcm::DrakeLcm lcm;
   systems::DiagramBuilder<double> builder;
+
+  drake::log()->debug("Status channel: {}", kLcmStatusChannel);
+  drake::log()->debug("Command channel: {}", kLcmCommandChannel);
+  drake::log()->debug("Plan channel: {}", kLcmPlanChannel);
+
+  const std::string urdf =
+      (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kIiwaUrdf));
+
+  // Sets the robot plan interpolation type.
+  std::string interp_str(FLAGS_interp_type);
+  std::transform(interp_str.begin(), interp_str.end(),
+                 interp_str.begin(), ::tolower);
+  InterpolatorType interpolator_type{};
+  if (interp_str == "zoh") {
+    interpolator_type = InterpolatorType::ZeroOrderHold;
+  } else if (interp_str == "foh") {
+    interpolator_type = InterpolatorType::FirstOrderHold;
+  } else if (interp_str == "cubic") {
+    interpolator_type = InterpolatorType::Cubic;
+  } else if (interp_str == "pchip") {
+    interpolator_type = InterpolatorType::Pchip;
+  } else {
+    DRAKE_ABORT_MSG(
+        "Robot plan interpolation type not recognized. "
+        "Use the gflag --helpshort to display "
+        "flag options for interpolator type.");
+  }
+  auto plan_interpolator =
+      builder.AddSystem<LcmPlanInterpolator>(urdf, interpolator_type);
+  const int kNumJoints = plan_interpolator->num_joints();
 
   auto plan_sub =
       builder.AddSystem(systems::lcm::LcmSubscriberSystem::Make<robot_plan_t>(
           kLcmPlanChannel, &lcm));
   plan_sub->set_name("plan_sub");
 
-  const std::string urdf =
-      (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kIiwaUrdf));
-
-  // Sets the robot plan interpolation type.
-  RobotPlanInterpolator* plan_source;
-  std::string interp_str(FLAGS_interp_type);
-  std::transform(interp_str.begin(), interp_str.end(),
-                 interp_str.begin(), ::tolower);
-  if (interp_str == "zoh") {
-    plan_source = builder.AddSystem<RobotPlanInterpolator>(
-        urdf, InterpolatorType::ZeroOrderHold);
-  } else if (interp_str == "foh") {
-    plan_source = builder.AddSystem<RobotPlanInterpolator>(
-        urdf, InterpolatorType::FirstOrderHold);
-  } else if (interp_str == "cubic") {
-    plan_source = builder.AddSystem<RobotPlanInterpolator>(
-        urdf, InterpolatorType::Cubic);
-  } else if (interp_str == "pchip") {
-    plan_source = builder.AddSystem<RobotPlanInterpolator>(
-        urdf, InterpolatorType::Pchip);
-  } else {
-    DRAKE_ABORT_MSG("Robot plan interpolation type not recognized. "
-                    "Use the gflag --helpshort to display "
-                    "flag options for interpolator type.");
-  }
-  plan_source->set_name("plan_source");
-  const int num_joints = plan_source->tree().get_num_positions();
-
   auto status_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_status>(
           kLcmStatusChannel, &lcm));
   status_sub->set_name("status_sub");
-
-  auto status_receiver = builder.AddSystem<IiwaStatusReceiver>(num_joints);
-  status_receiver->set_name("status_receiver");
-
-  auto target_demux =
-      builder.AddSystem<systems::Demultiplexer>(num_joints * 2, num_joints);
-  target_demux->set_name("target_demux");
 
   auto command_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<lcmt_iiwa_command>(
           kLcmCommandChannel, &lcm));
   command_pub->set_name("command_pub");
 
-  auto command_sender = builder.AddSystem<IiwaCommandSender>(num_joints);
-  command_sender->set_name("command_sender");
-
+  // Connect subscribers to input ports.
   builder.Connect(plan_sub->get_output_port(0),
-                  plan_source->get_plan_input_port());
+                  plan_interpolator->get_input_port_iiwa_plan());
   builder.Connect(status_sub->get_output_port(0),
-                  status_receiver->get_input_port(0));
-  builder.Connect(status_receiver->get_measured_position_output_port(),
-                  plan_source->get_state_input_port());
-  builder.Connect(plan_source->get_output_port(0),
-                  target_demux->get_input_port(0));
-  builder.Connect(target_demux->get_output_port(0),
-                  command_sender->get_input_port(0));
-  builder.Connect(command_sender->get_output_port(0),
+                  plan_interpolator->get_input_port_iiwa_status());
+
+  // Connect publisher to output port.
+  builder.Connect(plan_interpolator->get_output_port_iiwa_command(),
                   command_pub->get_input_port(0));
+
   auto diagram = builder.Build();
 
   drake::log()->info("controller started");
@@ -129,9 +124,9 @@ int DoMain() {
   double msg_time =
       loop.get_message_to_time_converter().GetTimeInSeconds(first_msg);
   const lcmt_iiwa_status& first_status = first_msg.GetValue<lcmt_iiwa_status>();
-  VectorX<double> q0(num_joints);
-  DRAKE_DEMAND(num_joints == first_status.num_joints);
-  for (int i = 0; i < num_joints; i++)
+  VectorX<double> q0(kNumJoints);
+  DRAKE_DEMAND(kNumJoints == first_status.num_joints);
+  for (int i = 0; i < kNumJoints; i++)
     q0[i] = first_status.joint_position_measured[i];
 
   systems::Context<double>* diagram_context = loop.get_mutable_context();
@@ -141,10 +136,9 @@ int DoMain() {
 
   // Explicit initialization.
   diagram_context->set_time(msg_time);
-  auto& plan_source_context =
-      diagram->GetMutableSubsystemContext(*plan_source, diagram_context);
-  plan_source->Initialize(msg_time, q0,
-                          plan_source_context.get_mutable_state());
+  auto& plan_interpolator_context =
+      diagram->GetMutableSubsystemContext(*plan_interpolator, diagram_context);
+  plan_interpolator->Initialize(msg_time, q0, &plan_interpolator_context);
 
   loop.RunToSecondsAssumingInitialized();
   return 0;
@@ -157,5 +151,6 @@ int DoMain() {
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  drake::logging::HandleSpdlogGflags();
   return drake::examples::kuka_iiwa_arm::DoMain();
 }

--- a/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
+++ b/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.cc
@@ -1,0 +1,70 @@
+#include "drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.h"
+
+#include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/demultiplexer.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+
+using manipulation::planner::InterpolatorType;
+using manipulation::planner::RobotPlanInterpolator;
+using systems::DiagramBuilder;
+
+LcmPlanInterpolator::LcmPlanInterpolator(const std::string& model_path,
+                                         InterpolatorType interpolator_type) {
+  DiagramBuilder<double> builder;
+
+  // Add plan interpolation block.
+  robot_plan_interpolator_ =
+      builder.AddSystem<RobotPlanInterpolator>(model_path, interpolator_type);
+  num_joints_ = robot_plan_interpolator_->tree().get_num_positions();
+
+  // Add block to convert iiwa status to position + velocity vector.
+  auto status_receiver = builder.AddSystem<IiwaStatusReceiver>(num_joints_);
+
+  // Add a demux block to pull out the positions from the position + velocity
+  // vector
+  auto target_demux =
+      builder.AddSystem<systems::Demultiplexer>(num_joints_ * 2, num_joints_);
+  target_demux->set_name("target_demux");
+
+  // Add a block to convert the desired position vector to iiwa command.
+  auto command_sender = builder.AddSystem<IiwaCommandSender>(num_joints_);
+  command_sender->set_name("command_sender");
+
+  // Export the inputs.
+  input_port_iiwa_plan_ =
+      builder.ExportInput(robot_plan_interpolator_->get_plan_input_port());
+  input_port_iiwa_status_ =
+      builder.ExportInput(status_receiver->get_input_port(0));
+
+  // Export the output.
+  output_port_iiwa_command_ =
+      builder.ExportOutput(command_sender->get_output_port(0));
+
+  // Connect the subsystems.
+  builder.Connect(status_receiver->get_measured_position_output_port(),
+                  robot_plan_interpolator_->get_state_input_port());
+  builder.Connect(robot_plan_interpolator_->get_output_port(0),
+                  target_demux->get_input_port(0));
+  builder.Connect(target_demux->get_output_port(0),
+                  command_sender->get_input_port(0));
+
+  // Build the system.
+  builder.BuildInto(this);
+}
+
+void LcmPlanInterpolator::Initialize(double plan_start_time,
+                                     const VectorX<double>& q0,
+                                     systems::Context<double>* context) const {
+  robot_plan_interpolator_->Initialize(
+      plan_start_time, q0,
+      this->GetMutableSubsystemContext(*robot_plan_interpolator_, context)
+          .get_mutable_state());
+}
+
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
+++ b/drake/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#include "drake/manipulation/planner/robot_plan_interpolator.h"
+#include "drake/systems/framework/diagram.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+class LcmPlanInterpolator : public systems::Diagram<double> {
+ public:
+  LcmPlanInterpolator(
+      const std::string& model_path,
+      manipulation::planner::InterpolatorType interpolator_type);
+
+  const systems::InputPortDescriptor<double>& get_input_port_iiwa_status()
+      const {
+    return get_input_port(input_port_iiwa_status_);
+  }
+
+  const systems::InputPortDescriptor<double>& get_input_port_iiwa_plan() const {
+    return get_input_port(input_port_iiwa_plan_);
+  }
+
+  const systems::OutputPort<double>& get_output_port_iiwa_command() const {
+    return get_output_port(output_port_iiwa_command_);
+  }
+
+  /**
+   * Makes a plan to hold at the measured joint configuration @p q0 starting at
+   * @p plan_start_time. This function needs to be explicitly called before any
+   * simulation. Otherwise this aborts in CalcOutput().
+   */
+  void Initialize(double plan_start_time, const VectorX<double>& q0,
+                  systems::Context<double>* context) const;
+
+  int num_joints() const { return num_joints_; }
+
+ private:
+  // Input ports.
+  int input_port_iiwa_status_{-1};
+  int input_port_iiwa_plan_{-1};
+
+  // Ouptut ports.
+  int output_port_iiwa_command_{-1};
+
+  manipulation::planner::RobotPlanInterpolator* robot_plan_interpolator_{};
+  int num_joints_{};
+};
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
This PR moves the `PiecewisePolynomial` to `robot_plan_t` conversion out of `iiwa_controller`, so that that executable consists only of LCM pub/sub blocks and a single worker block. In subsequent PRs, this allows the `lcm_plan_interpolator` to be directly connected to other blocks with LCM message ports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7338)
<!-- Reviewable:end -->
