### PR TITLE
[Multilane] Adds start and end Endpoint computation to Connections

### DIFF
--- a/drake/automotive/maliput/multilane/BUILD.bazel
+++ b/drake/automotive/maliput/multilane/BUILD.bazel
@@ -120,6 +120,7 @@ drake_cc_googletest(
     deps = [
         ":builder",
         "//drake/automotive/maliput/multilane/test_utilities",
+        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/drake/automotive/maliput/multilane/connection.cc
+++ b/drake/automotive/maliput/multilane/connection.cc
@@ -1,5 +1,7 @@
 #include "drake/automotive/maliput/multilane/connection.h"
 
+#include "drake/automotive/maliput/multilane/arc_road_curve.h"
+#include "drake/automotive/maliput/multilane/line_road_curve.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -19,6 +21,222 @@ std::ostream& operator<<(std::ostream& out, const EndpointZ& endpoint_z) {
 
 std::ostream& operator<<(std::ostream& out, const Endpoint& endpoint) {
   return out << "(xy: " << endpoint.xy() << ", z: " << endpoint.z() << ")";
+}
+
+Connection::Connection(const std::string& id, const Endpoint& start,
+                       const EndpointZ& end_z, int num_lanes, double r0,
+                       double lane_width, double left_shoulder,
+                       double right_shoulder, double line_length)
+    : type_(kLine),
+      id_(id),
+      start_(start),
+      num_lanes_(num_lanes),
+      r0_(r0),
+      lane_width_(lane_width),
+      left_shoulder_(left_shoulder),
+      right_shoulder_(right_shoulder),
+      r_min_(r0 - lane_width / 2. - right_shoulder),
+      r_max_(r0 + lane_width * (static_cast<double>(num_lanes - 1) + 0.5) +
+             left_shoulder),
+      line_length_(line_length) {
+  DRAKE_DEMAND(num_lanes_ > 0);
+  DRAKE_DEMAND(lane_width_ >= 0);
+  DRAKE_DEMAND(left_shoulder_ >= 0);
+  DRAKE_DEMAND(right_shoulder_ >= 0);
+  DRAKE_DEMAND(r_max_ >= r_min_);
+  DRAKE_DEMAND(line_length_ > 0.);
+  // Computes end Endpoint and RoadCurve.
+  end_ = Endpoint(
+      {start_.xy().x() + line_length_ * std::cos(start_.xy().heading()),
+       start_.xy().y() + line_length_ * std::sin(start_.xy().heading()),
+       start_.xy().heading()},
+      end_z);
+  road_curve_ = CreateRoadCurve();
+  // TODO(agalbachicar)  Modify Connection API to provide support for HBounds
+  //                     once RoadCurve's children are capable of computing
+  //                     singularities with it.
+  DRAKE_DEMAND(road_curve_->IsValid(r_min_, r_max_, {0., 0.}));
+}
+
+Connection::Connection(const std::string& id, const Endpoint& start,
+                       const EndpointZ& end_z, int num_lanes, double r0,
+                       double lane_width, double left_shoulder,
+                       double right_shoulder, const ArcOffset& arc_offset)
+    : type_(kArc),
+      id_(id),
+      start_(start),
+      num_lanes_(num_lanes),
+      r0_(r0),
+      lane_width_(lane_width),
+      left_shoulder_(left_shoulder),
+      right_shoulder_(right_shoulder),
+      r_min_(r0 - lane_width / 2. - right_shoulder),
+      r_max_(r0 + lane_width * (static_cast<double>(num_lanes - 1) + 0.5) +
+             left_shoulder),
+      radius_(arc_offset.radius()),
+      d_theta_(arc_offset.d_theta()) {
+  DRAKE_DEMAND(num_lanes_ > 0);
+  DRAKE_DEMAND(lane_width_ >= 0);
+  DRAKE_DEMAND(left_shoulder_ >= 0);
+  DRAKE_DEMAND(right_shoulder_ >= 0);
+  DRAKE_DEMAND(r_max_ >= r_min_);
+  DRAKE_DEMAND(radius_ > 0);
+  // Fills arc related parameters, computes end Endpoint and creates the
+  // RoadCurve.
+  theta0_ = start_.xy().heading() - std::copysign(M_PI / 2., d_theta_);
+  cx_ = start.xy().x() - (radius_ * std::cos(theta0_));
+  cy_ = start.xy().y() - (radius_ * std::sin(theta0_));
+  const double theta1 = theta0_ + d_theta_;
+  end_ = Endpoint(
+      {cx_ + radius_ * std::cos(theta1), cy_ + radius_ * std::sin(theta1),
+       start_.xy().heading() + d_theta_},
+      end_z);
+  road_curve_ = CreateRoadCurve();
+  // TODO(agalbachicar)  Modify Connection API to provide support for HBounds
+  //                     once RoadCurve's children are capable of computing
+  //                     singularities with it.
+  DRAKE_DEMAND(road_curve_->IsValid(r_min_, r_max_, {0., 0.}));
+}
+
+Endpoint Connection::LaneStart(int lane_index) const {
+  DRAKE_DEMAND(lane_index >= 0 && lane_index < num_lanes_);
+  const double r = lane_offset(lane_index);
+  const Vector3<double> position = road_curve_->W_of_prh(0., r, 0.);
+  const Rot3 rotation = road_curve_->Orientation(0., r, 0.);
+  // Let t be the arc-length xy projection of the lane centerline and t_of_p be
+  // a linear function of p (given that p <--> s is a linear relation too).
+  // Given z_dot = ∂z/∂t, chain rule can be applied so:
+  //
+  // z_dot = ∂z/∂p * ∂p/∂t.
+  //
+  // The same applies to theta_dot.
+
+  // Computes w_prime to obtain ∂z/∂p.
+  const Vector3<double> w_prime =
+      road_curve_->W_prime_of_prh(0., r, 0., road_curve_->Rabg_of_p(0.),
+                                  road_curve_->elevation().f_dot_p(0.));
+  // Computes ∂p/∂t based on Connection geometry type.
+
+  // TODO(maddog-tri)  A (second-order?) contribution of theta_dot to ∂p/∂t is
+  //                   being ignored.
+  const double cos_superelevation =
+      std::cos(road_curve_->superelevation().f_p(0.));
+  const double planar_length = type_ == kLine ?
+      line_length_ :
+      std::abs(d_theta_ * (radius_ - std::copysign(1., d_theta_) * r *
+                           cos_superelevation));
+  // Given that ∂p/∂t = 1 / planar_length.
+  const double z_dot = w_prime.z() / planar_length;
+  // theta_dot is derivative with respect to t, but the reference curve t
+  // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
+  // coordinate and t_i the arc-length xy projection for lane_index lane.
+  const double theta_dot = type_ == kLine ?
+      start_.z().theta_dot() :
+      start_.z().theta_dot() * std::abs(d_theta_ * radius_) / planar_length;
+  return Endpoint({position[0], position[1], rotation.yaw()},
+                  {position[2], z_dot, start_.z().theta(), theta_dot});
+}
+
+Endpoint Connection::LaneEnd(int lane_index) const {
+  DRAKE_DEMAND(lane_index >= 0 && lane_index < num_lanes_);
+  const double r = lane_offset(lane_index);
+  const Vector3<double> position = road_curve_->W_of_prh(1., r, 0.);
+  const Rot3 rotation = road_curve_->Orientation(1., r, 0.);
+  // Let t be the arc-length xy projection of the lane centerline and t_of_p be
+  // a linear function of p (given that p <--> s is a linear relation too).
+  // Given z_dot = ∂z/∂t, chain rule can be applied so:
+  //
+  // z_dot = ∂z/∂p * ∂p/∂t.
+  //
+  // The same applies to theta_dot.
+
+  // Computes w_prime to obtain ∂z/∂p.
+  const Vector3<double> w_prime =
+      road_curve_->W_prime_of_prh(1., r, 0., road_curve_->Rabg_of_p(1.),
+                                  road_curve_->elevation().f_dot_p(1.));
+  // Computes ∂p/∂t based on Connection geometry type.
+
+  // TODO(maddog-tri)  A (second-order?) contribution of theta_dot to ∂p/∂t is
+  //                   being ignored.
+  const double cos_superelevation =
+      std::cos(road_curve_->superelevation().f_p(1.));
+  const double planar_length = type_ == kLine ?
+      line_length_ :
+      std::abs(d_theta_ * (radius_ - std::copysign(1., d_theta_) * r *
+                           cos_superelevation));
+  // Given that ∂p/∂t = 1 / planar_length.
+  const double z_dot = w_prime.z() / planar_length;
+  // theta_dot is derivative with respect to t, but the reference curve t
+  // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
+  // coordinate and t_i the arc-length xy projection for lane_index lane.
+  const double theta_dot = type_ == kLine ?
+      end_.z().theta_dot() :
+      end_.z().theta_dot() * std::abs(d_theta_ * radius_) / planar_length;
+  return Endpoint({position[0], position[1], rotation.yaw()},
+                  {position[2], z_dot, end_.z().theta(), theta_dot});
+}
+
+namespace {
+// Construct a CubicPolynomial such that:
+//    f(0) = Y0 / dX           f'(0) = Ydot0
+//    f(1) = (Y0 + dY) / dX    f'(1) = Ydot1
+//
+// This is equivalent to taking a cubic polynomial g such that:
+//    g(0) = Y0          g'(0) = Ydot0
+//    g(dX) = Y0 + dY    g'(1) = Ydot1
+// and isotropically scaling it (scale both axes) by a factor of 1/dX
+CubicPolynomial MakeCubic(double dX, double Y0, double dY,
+                          double Ydot0, double Ydot1) {
+  return CubicPolynomial(Y0 / dX,
+                         Ydot0,
+                         (3. * dY / dX) - (2. * Ydot0) - Ydot1,
+                         Ydot0 + Ydot1 - (2. * dY / dX));
+}
+}  // namespace
+
+std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
+  switch (type_) {
+    case Connection::kLine: {
+      const Vector2<double> xy0(start_.xy().x(), start_.xy().y());
+      const Vector2<double> dxy(end_.xy().x() - start_.xy().x(),
+                                end_.xy().y() - start_.xy().y());
+      const CubicPolynomial elevation(MakeCubic(
+          dxy.norm(),
+          start_.z().z(),
+          end_.z().z() - start_.z().z(),
+          start_.z().z_dot(),
+          end_.z().z_dot()));
+      const CubicPolynomial superelevation(MakeCubic(
+          dxy.norm(),
+          start_.z().theta(),
+          end_.z().theta() - start_.z().theta(),
+          start_.z().theta_dot(),
+          end_.z().theta_dot()));
+      return
+        std::make_unique<LineRoadCurve>(xy0, dxy, elevation, superelevation);
+    };
+    case Connection::kArc: {
+      const Vector2<double> center(cx_, cy_);
+      const double arc_length = radius_ * std::abs(d_theta_);
+      const CubicPolynomial elevation(MakeCubic(
+          arc_length,
+          start_.z().z(),
+          end_.z().z() - start_.z().z(),
+          start_.z().z_dot(),
+          end_.z().z_dot()));
+      const CubicPolynomial superelevation(MakeCubic(
+          arc_length,
+          start_.z().theta(),
+          end_.z().theta() - start_.z().theta(),
+          start_.z().theta_dot(),
+          end_.z().theta_dot()));
+      return std::make_unique<ArcRoadCurve>(
+          center, radius_, theta0_, d_theta_, elevation, superelevation);
+    };
+    default: {
+      DRAKE_ABORT();
+    }
+  }
 }
 
 }  // namespace multilane

--- a/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -10,6 +10,7 @@
 #include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/automotive/maliput/multilane/line_road_curve.h"
 #include "drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace maliput {
@@ -82,24 +83,24 @@ class MultilaneConnectionTest : public ::testing::Test {
   const int kNumLanes{3};
   const double kLeftShoulder{1.};
   const double kRightShoulder{1.5};
+  const double kLaneWidth{2.};
   const EndpointZ kLowFlatZ{0., 0., 0., 0.};
   const double kHeading{-M_PI / 4.};
   const EndpointXy kStartXy{20., 30., kHeading};
   const Endpoint kStartEndpoint{kStartXy, kLowFlatZ};
   const double kZeroTolerance{0.};
+  const double kVeryExact{1e-12};
 };
 
 TEST_F(MultilaneConnectionTest, ArcAccessors) {
   const std::string kId{"arc_connection"};
-  const double kCenterX{30.};
-  const double kCenterY{40.};
   const double kRadius{10. * std::sqrt(2.)};
   const double kDTheta{M_PI / 2.};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
   const Endpoint kEndEndpoint{{40., 30., kHeading + kDTheta}, kLowFlatZ};
 
-  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kNumLanes, kR0,
-                       kLeftShoulder, kRightShoulder, kCenterX, kCenterY,
-                       kRadius, kDTheta);
+  const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
+                       kLaneWidth, kLeftShoulder, kRightShoulder, kArcOffset);
   EXPECT_EQ(dut.type(), Connection::Type::kArc);
   EXPECT_EQ(dut.id(), kId);
   EXPECT_TRUE(
@@ -107,19 +108,30 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
   EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kZeroTolerance));
   EXPECT_EQ(dut.num_lanes(), kNumLanes);
   EXPECT_EQ(dut.r0(), kR0);
+  EXPECT_EQ(dut.lane_width(), kLaneWidth);
   EXPECT_EQ(dut.left_shoulder(), kLeftShoulder);
   EXPECT_EQ(dut.right_shoulder(), kRightShoulder);
-  EXPECT_EQ(dut.cx(), kCenterX);
-  EXPECT_EQ(dut.cy(), kCenterY);
   EXPECT_EQ(dut.radius(), kRadius);
   EXPECT_EQ(dut.d_theta(), kDTheta);
+  EXPECT_EQ(dut.r_min(), kR0 - kLaneWidth / 2. - kRightShoulder);
+  EXPECT_EQ(dut.r_max(),
+            kR0 + kLaneWidth * (static_cast<double>(kNumLanes - 1) + .5) +
+                kLeftShoulder);
+  EXPECT_TRUE(
+      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
+  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kVeryExact));
+  EXPECT_EQ(dut.lane_offset(0), kR0);
+  EXPECT_EQ(dut.lane_offset(1), kR0 + kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
 }
 
 TEST_F(MultilaneConnectionTest, LineAccessors) {
   const std::string kId{"line_connection"};
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
-  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kNumLanes, kR0,
-                       kLeftShoulder, kRightShoulder);
+
+  const double kLineLength{30. * std::sqrt(2.)};
+  const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
+                       kLaneWidth, kLeftShoulder, kRightShoulder, kLineLength);
   EXPECT_EQ(dut.type(), Connection::Type::kLine);
   EXPECT_EQ(dut.id(), kId);
   EXPECT_TRUE(
@@ -127,9 +139,338 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
   EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kZeroTolerance));
   EXPECT_EQ(dut.num_lanes(), kNumLanes);
   EXPECT_EQ(dut.r0(), kR0);
+  EXPECT_EQ(dut.lane_width(), kLaneWidth);
   EXPECT_EQ(dut.left_shoulder(), kLeftShoulder);
   EXPECT_EQ(dut.right_shoulder(), kRightShoulder);
+  EXPECT_EQ(dut.line_length(), kLineLength);
+  EXPECT_EQ(dut.r_min(), kR0 - kLaneWidth / 2. - kRightShoulder);
+  EXPECT_EQ(dut.r_max(),
+            kR0 + kLaneWidth * (static_cast<double>(kNumLanes - 1) + .5) +
+                kLeftShoulder);
+  EXPECT_TRUE(
+      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
+  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kVeryExact));
+  EXPECT_EQ(dut.lane_offset(0), kR0);
+  EXPECT_EQ(dut.lane_offset(1), kR0 + kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
 }
+
+// Checks RoadCurve creation.
+//
+// Literals for elevation and superelevation polynomials below have been derived
+// in Octave running the following code snippet. Variables with '0' suffix refer
+// to start EndpointZ and with '1' suffix refer to end EndpointZ. Replace 'y'
+// variables by 'z' related ones and by 'theta' to compute elevation and
+// superelevation polynomial coefficients respectively.
+//
+// % Sets the value of the planar length.
+// d_x = 10. * sqrt(2.) * pi / 2.;
+// a = y_0 / d_x
+// b = y_dot_0 / d_x
+// c = 3 * (y_1 - y_0) / d_x - 2 * y_dot_0 - y_dot_1
+// d = y_dot_0 + y_dot_1 - 2 * (y_1 - y_0)
+TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
+  const std::string kId{"arc_connection"};
+  const double kRadius{10. * std::sqrt(2.)};
+  const double kDTheta{M_PI / 2.};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
+  const Endpoint kEndEndpoint{{40., 30., kHeading + kDTheta}, kLowFlatZ};
+
+  const Connection flat_dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
+                            kLaneWidth, kLeftShoulder, kRightShoulder,
+                            kArcOffset);
+  std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
+  EXPECT_NE(dynamic_cast<ArcRoadCurve*>(road_curve.get()), nullptr);
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(),
+                      flat_dut.start().z().z()),
+      flat_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(),
+                      kStartEndpoint.z().z()),
+      flat_origin, kZeroTolerance));
+  const Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(),
+                      flat_dut.end().z().z()),
+      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(),
+                      kEndEndpoint.z().z()),
+      flat_end, kVeryExact));
+  // Checks that elevation and superelevation polynomials are correctly built
+  // for the trivial case of a flat dut.
+  EXPECT_EQ(road_curve->elevation().a(), 0.);
+  EXPECT_EQ(road_curve->elevation().b(), 0.);
+  EXPECT_EQ(road_curve->elevation().c(), 0.);
+  EXPECT_EQ(road_curve->elevation().d(), 0.);
+  EXPECT_EQ(road_curve->superelevation().a(), 0.);
+  EXPECT_EQ(road_curve->superelevation().b(), 0.);
+  EXPECT_EQ(road_curve->superelevation().c(), 0.);
+  EXPECT_EQ(road_curve->superelevation().d(), 0.);
+
+  // Creates a new complex dut with cubic elevation and superelevation.
+  const Endpoint kEndElevatedEndpoint{{40., 30., kHeading + kDTheta},
+                                      {5., 1., M_PI / 6., 1.}};
+  const Connection complex_dut(kId, kStartEndpoint, kEndElevatedEndpoint.z(),
+                               kNumLanes, kR0, kLaneWidth, kLeftShoulder,
+                               kRightShoulder, kArcOffset);
+  std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> complex_origin =
+      complex_road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(complex_dut.start().xy().x(),
+                                              complex_dut.start().xy().y(),
+                                              complex_dut.start().z().z()),
+                              complex_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(),
+                      kStartEndpoint.z().z()),
+      complex_origin, kZeroTolerance));
+  const Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(),
+                      complex_dut.end().z().z()),
+      complex_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(kEndElevatedEndpoint.xy().x(),
+                                              kEndElevatedEndpoint.xy().y(),
+                                              kEndElevatedEndpoint.z().z()),
+                              complex_end, kVeryExact));
+
+  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.32476276288217043,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.549841841921447,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.9292893218813453,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.9528595479208968,
+              kVeryExact);
+}
+
+TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
+  const std::string kId{"line_connection"};
+  const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
+  const double kLineLength{30. * std::sqrt(2.)};
+  const Connection flat_dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
+                            kLaneWidth, kLeftShoulder, kRightShoulder,
+                            kLineLength);
+  std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
+  EXPECT_NE(dynamic_cast<LineRoadCurve*>(road_curve.get()), nullptr);
+
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(),
+                      flat_dut.start().z().z()),
+      flat_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(),
+                      kStartEndpoint.z().z()),
+      flat_origin, kZeroTolerance));
+  const Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(),
+                      flat_dut.end().z().z()),
+      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(),
+                      kEndEndpoint.z().z()),
+      flat_end, kVeryExact));
+  // Checks that elevation and superelevation polynomials are correctly built
+  // for the trivial case of a flat dut.
+  EXPECT_EQ(road_curve->elevation().a(), 0.);
+  EXPECT_EQ(road_curve->elevation().b(), 0.);
+  EXPECT_EQ(road_curve->elevation().c(), 0.);
+  EXPECT_EQ(road_curve->elevation().d(), 0.);
+  EXPECT_EQ(road_curve->superelevation().a(), 0.);
+  EXPECT_EQ(road_curve->superelevation().b(), 0.);
+  EXPECT_EQ(road_curve->superelevation().c(), 0.);
+  EXPECT_EQ(road_curve->superelevation().d(), 0.);
+
+  // Creates a new complex dut with cubic elevation and superelevation.
+  const Endpoint kEndElevatedEndpoint{{50., 0., kHeading},
+                                      {5., 1., M_PI / 6., 1.}};
+  const Connection complex_dut(kId, kStartEndpoint, kEndElevatedEndpoint.z(),
+                               kNumLanes, kR0, kLaneWidth, kLeftShoulder,
+                               kRightShoulder, kLineLength);
+  std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
+
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> complex_origin =
+      complex_road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(complex_dut.start().xy().x(),
+                                              complex_dut.start().xy().y(),
+                                              complex_dut.start().z().z()),
+                              complex_origin, kZeroTolerance));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(),
+                      kStartEndpoint.z().z()),
+      complex_origin, kZeroTolerance));
+  const Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(),
+                      complex_dut.end().z().z()),
+      complex_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(kEndElevatedEndpoint.xy().x(),
+                                              kEndElevatedEndpoint.xy().y(),
+                                              kEndElevatedEndpoint.z().z()),
+                              complex_end, kVeryExact));
+
+  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.646446609406726,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.764297739604484,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.962975975515347,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.975317317010231,
+              kVeryExact);
+}
+
+// Lane Endpoints with different EndpointZ. Those are selected to cover
+// different combinations of elevation and superelevation polynomials.
+
+// Groups test parameters.
+struct EndpointZTestParameters{
+  EndpointZTestParameters() = default;
+  EndpointZTestParameters(const EndpointZ& _start_z, const EndpointZ& _end_z,
+                          double _r0, int _num_lanes)
+      : start_z(_start_z), end_z(_end_z), r0(_r0), num_lanes(_num_lanes) {}
+
+  EndpointZ start_z{};
+  EndpointZ end_z{};
+  double r0{};
+  int num_lanes{};
+};
+
+// Groups common test constants as well as each test case parameters.
+class MultilaneConnectionEndpointZTest
+    : public ::testing::TestWithParam<EndpointZTestParameters> {
+ protected:
+  void SetUp() override {
+    const EndpointZTestParameters parameters = this->GetParam();
+    start_z = parameters.start_z;
+    end_z = parameters.end_z;
+    r0 = parameters.r0;
+    num_lanes = parameters.num_lanes;
+    start_endpoint = {kStartXy, start_z};
+  }
+
+  const double kLeftShoulder{1.};
+  const double kRightShoulder{1.5};
+  const double kLaneWidth{2.};
+  const double kHeading{-M_PI / 4.};
+  const EndpointXy kStartXy{20., 30., kHeading};
+  EndpointZ start_z{};
+  EndpointZ end_z{};
+  double r0{};
+  int num_lanes{};
+  Endpoint start_endpoint{};
+  const double kVeryExact{1e-12};
+};
+
+TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
+  const std::string kId{"arc_connection"};
+  const double kCenterX{30.};
+  const double kCenterY{40.};
+  const double kRadius{10. * std::sqrt(2.)};
+  const double kDTheta{M_PI / 2.};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
+  const Connection dut(kId, start_endpoint, end_z, num_lanes, r0, kLaneWidth,
+                       kLeftShoulder, kRightShoulder, kArcOffset);
+  const double kTheta0{kHeading - M_PI / 2.};
+
+  // Wraps angles in [-π, π) range.
+  auto wrap = [](double theta) {
+    double theta_new = std::fmod(theta + M_PI, 2. * M_PI);
+    if (theta_new < 0.) theta_new += 2. * M_PI;
+    return theta_new - M_PI;
+  };
+
+  for (int i = 0; i < num_lanes; i++) {
+    // Start endpoints.
+    const double start_radius =
+        kRadius - (r0 + static_cast<double>(i) * kLaneWidth) *
+                  std::cos(start_z.theta());
+    const Endpoint lane_start{
+        {kCenterX + start_radius * std::cos(kTheta0),
+         kCenterY + start_radius * std::sin(kTheta0),
+         wrap(kTheta0 + M_PI / 2.)},
+        {start_z.z(), start_z.z_dot() * kRadius / start_radius,
+         start_z.theta(), start_z.theta_dot() * kRadius / start_radius}};
+    EXPECT_TRUE(
+        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    // End endpoints.
+    const double end_radius =
+        kRadius - (r0 + static_cast<double>(i) * kLaneWidth) *
+                  std::cos(end_z.theta());
+    const Endpoint lane_end{
+        {kCenterX + end_radius * std::cos(kTheta0 + kDTheta),
+         kCenterY + end_radius * std::sin(kTheta0 + kDTheta),
+         wrap(kTheta0 + kDTheta + M_PI / 2.)},
+        {end_z.z(), end_z.z_dot() * kRadius / end_radius,
+         end_z.theta(), end_z.theta_dot() * kRadius / end_radius}};
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+  }
+}
+
+TEST_P(MultilaneConnectionEndpointZTest, LineLaneEndpoints) {
+  const std::string kId{"line_connection"};
+  const double kLineLength{25. * std::sqrt(2.)};
+  const Connection dut(kId, start_endpoint, end_z, num_lanes, r0, kLaneWidth,
+                       kLeftShoulder, kRightShoulder, kLineLength);
+  const Vector2<double> kDirection{45. - kStartXy.x(), 5. - kStartXy.y()};
+  const Vector2<double> kNormalDirection =
+      Vector2<double>(kDirection.y(), -kDirection.x()).normalized();
+
+  for (int i = 0; i < num_lanes; i++) {
+    // Start endpoints.
+    const double offset = r0 + static_cast<double>(i) * kLaneWidth;
+    const Endpoint lane_start{
+        {kStartXy.x() - offset * kNormalDirection.x(),
+         kStartXy.y() - offset * kNormalDirection.y(), kHeading}, start_z};
+    EXPECT_TRUE(
+        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    // End endpoints.
+    const Endpoint lane_end{
+        {kStartXy.x() - offset * kNormalDirection.x() + kDirection.x(),
+         kStartXy.y() - offset * kNormalDirection.y() + kDirection.y(),
+         kHeading}, end_z};
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(EndpointZ, MultilaneConnectionEndpointZTest,
+    testing::Values(EndpointZTestParameters(EndpointZ(0., 0., 0., 0.),
+                                            EndpointZ(0., 0., 0., 0.),
+                                            0., 1),
+                    EndpointZTestParameters(EndpointZ(0., 0., 0., 0.),
+                                            EndpointZ(0., 0., 0., 0.),
+                                            2., 3),
+                    EndpointZTestParameters(EndpointZ(1., 0., 0., 0.),
+                                            EndpointZ(1., 0., 0., 0.),
+                                            2., 3),
+                    EndpointZTestParameters(EndpointZ(1., 1., 0., 0.),
+                                            EndpointZ(5., 1., 0., 0.),
+                                            2., 3),
+                    EndpointZTestParameters(EndpointZ(0., 0., M_PI / 6., 0.),
+                                            EndpointZ(0., 0., M_PI / 6., 0.),
+                                            0., 1),
+                    EndpointZTestParameters(EndpointZ(1., 1., M_PI / 6., 0.),
+                                            EndpointZ(5., 1., M_PI / 6., 0.),
+                                            0., 1),
+                    EndpointZTestParameters(EndpointZ(1., 1., M_PI / 3., 1.),
+                                            EndpointZ(5., 1., M_PI / 6., 1.),
+                                            0., 1)));
 
 }  // namespace multilane
 }  // namespace maliput


### PR DESCRIPTION
This PR is a follow up of #7325 as part of issue #7194. It adds methods to `Connection` class to compute lane `Endpoint`s among other refactors. 

To sum up,  this PR includes:

- `Connection` constructor signatures are modified and do not need the end `Endpoint` anymore. Just end `EndpointZ` is needed. By doing this, we avoid the possibility of building a `Connection` that does not connect _start_ and _end_ `Endpoints`.
- `Connection`s build a `RoadCurve` at construction time and provide an API to construct a new one as requested.
- `Connection` will be in charge of building the elevation and superelevation polynomials for its `RoadCurve`. Tests are also included to check the creation.
- `Lane`-centerline offset computation is moved to `Connection` class.
- Provides `Connection::LaneStart()` and `Connection::LaneEnd()` methods to allow query lane _start_ and _end_ `Endpoint`s.
- Provides several test conditions with different geometries in order to validate new methods.
- Modifies `Builder`'s implementation to support previous changes.

Future PRs will modify loader methods and YAML format description as #4934 explains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7343)
<!-- Reviewable:end -->
