### PR TITLE
Tidy up some automotive dependencies

### DIFF
--- a/drake/automotive/BUILD.bazel
+++ b/drake/automotive/BUILD.bazel
@@ -45,7 +45,7 @@ drake_cc_library(
         "gen/trajectory_car_state.h",
     ],
     deps = [
-        "//drake/systems/framework",
+        "//drake/systems/framework:vector",
     ],
 )
 
@@ -68,7 +68,6 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         "//drake/lcmtypes:automotive",
-        "//drake/systems/framework",
         "//drake/systems/lcm:translator",
     ],
 )
@@ -80,6 +79,7 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         "//drake/common:symbolic",
+        "//drake/systems/framework:leaf_system",
     ],
 )
 
@@ -139,6 +139,7 @@ drake_cc_library(
         ":pose_selector",
         ":road_odometry",
         "//drake/automotive/maliput/api",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -173,6 +174,7 @@ drake_cc_library(
         ":lane_direction",
         "//drake/automotive/maliput/api",
         "//drake/math:geometric_transform",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:frame_velocity",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -192,6 +194,7 @@ drake_cc_library(
         "//drake/common:cond",
         "//drake/common:symbolic",
         "//drake/math:saturate",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -261,6 +264,7 @@ drake_cc_library(
         ":generated_vectors",
         ":lane_direction",
         ":pure_pursuit",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:pose_vector",
     ],
 )
@@ -305,6 +309,7 @@ drake_cc_library(
         "//drake/common:double",
         "//drake/common:symbolic",
         "//drake/math:saturate",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:frame_velocity",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -340,6 +345,7 @@ drake_cc_library(
         ":generated_vectors",
         "//drake/common:autodiff",
         "//drake/common:extract_double",
+        "//drake/systems/framework:leaf_system",
         "//drake/systems/rendering:frame_velocity",
         "//drake/systems/rendering:pose_vector",
     ],


### PR DESCRIPTION
Relates #6996.

This will matter more acutely once `lcm_vector_gen` moves into the build system, and no longer links in the entire `:framework` library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7349)
<!-- Reviewable:end -->
