### PR TITLE
Avoid DRAKE_DEMAND failure on CheckStructuralEquality

### DIFF
--- a/drake/common/symbolic_formula_cell.cc
+++ b/drake/common/symbolic_formula_cell.cc
@@ -571,7 +571,8 @@ bool FormulaPositiveSemidefinite::EqualTo(const FormulaCell& f) const {
   DRAKE_ASSERT(get_kind() == f.get_kind());
   const FormulaPositiveSemidefinite& f_psd{
       static_cast<const FormulaPositiveSemidefinite&>(f)};
-  return CheckStructuralEquality(m_, f_psd.m_);
+  return (m_.rows() == f_psd.m_.rows()) && (m_.cols() == f_psd.m_.cols()) &&
+      CheckStructuralEquality(m_, f_psd.m_);
 }
 
 bool FormulaPositiveSemidefinite::Less(const FormulaCell& f) const {


### PR DESCRIPTION
This failure is improbable (but not impossible) for a user to hit, because
it requires a 64-bit hash collision in Formula::EqualTo, for two objects
that are both PSD formulas but have differing sizes.

(This was discovered while working on a hash_append spike test, that
removed the hash code short-circuit on equality checking.)

No unit test is added here, because we have to break some abstraction
barriers to tickle the error.  If we ever remove the hash short-circuit,
then the current unit tests already found the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7350)
<!-- Reviewable:end -->
