### PR TITLE
Revert "Enable AutoDiff on various automotive planner/controller systems"

### DIFF
--- a/drake/automotive/BUILD.bazel
+++ b/drake/automotive/BUILD.bazel
@@ -219,7 +219,6 @@ drake_cc_library(
         ":lane_direction",
         ":road_odometry",
         "//drake/automotive/maliput/api",
-        "//drake/common:extract_double",
         "//drake/systems/rendering:pose_bundle",
         "//drake/systems/rendering:pose_vector",
     ],
@@ -250,6 +249,7 @@ drake_cc_library(
         ":generated_vectors",
         ":lane_direction",
         "//drake/automotive/maliput/api",
+        "//drake/common:cond",
         "//drake/common:symbolic",
         "//drake/math:saturate",
         "//drake/systems/rendering:pose_vector",
@@ -563,7 +563,6 @@ drake_cc_googletest(
         "//drake/automotive:pose_selector",
         "//drake/automotive/maliput/dragway",
         "//drake/automotive/maliput/monolane:builder",
-        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -591,7 +590,6 @@ drake_cc_googletest(
     deps = [
         "//drake/automotive:pure_pursuit",
         "//drake/automotive/maliput/dragway",
-        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -600,7 +598,6 @@ drake_cc_googletest(
     deps = [
         "//drake/automotive:pure_pursuit_controller",
         "//drake/automotive/maliput/dragway",
-        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/drake/automotive/maliput/api/lane.cc
+++ b/drake/automotive/maliput/api/lane.cc
@@ -46,13 +46,11 @@ LanePositionT<AutoDiffXd> Lane::ToLanePositionT<AutoDiffXd>(
   // If the partial derivatives of result, nearest_point and distance are not of
   // the same dimension as those in geo_pos, pad them with zeros of the same
   // dismension as those in geo_pos.
-  Vector3<AutoDiffXd> srh = result.srh();
-  Eigen::internal::make_coherent(srh.x().derivatives(), deriv);
-  Eigen::internal::make_coherent(srh.y().derivatives(), deriv);
-  Eigen::internal::make_coherent(srh.z().derivatives(), deriv);
-  result.set_srh(srh);
+  Eigen::internal::make_coherent(result.s().derivatives(), deriv);
+  Eigen::internal::make_coherent(result.r().derivatives(), deriv);
+  Eigen::internal::make_coherent(result.h().derivatives(), deriv);
   if (nearest_point != nullptr) {
-    Vector3<AutoDiffXd> xyz = nearest_point->xyz();
+    const Vector3<AutoDiffXd>& xyz = nearest_point->xyz();
     Eigen::internal::make_coherent(xyz.x().derivatives(), deriv);
     Eigen::internal::make_coherent(xyz.y().derivatives(), deriv);
     Eigen::internal::make_coherent(xyz.z().derivatives(), deriv);

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -677,12 +677,9 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePositionAutoDiff) {
         api::GeoPositionT<AutoDiffXd> geo_position{
           x_autodiff, y_autodiff, z_autodiff};
 
-        // Compute LanePositionT with and without the I/O arguments.
         const api::LanePositionT<AutoDiffXd> lane_position =
             lane_->ToLanePositionT<AutoDiffXd>(geo_position,
                                                &nearest_position, &distance);
-        const api::LanePositionT<AutoDiffXd> lane_position_nullargs =
-            lane_->ToLanePositionT<AutoDiffXd>(geo_position, nullptr, nullptr);
 
         std::vector<Vector3<double>> positional_derivatives{
           Vector3<double>::Zero(),   // s
@@ -698,16 +695,19 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePositionAutoDiff) {
           // = 0 (Dragway's s-r-h axis has the same orientation as the x-y-z
           // axis).  Verify that the derivatives of nearest position are the
           // same as for geo_position.
-          for (int i{0}; i < 3; ++i) {
-            EXPECT_TRUE(CompareMatrices(positional_derivatives[i],
-                                        lane_position.srh()(i).derivatives()));
-            EXPECT_TRUE(CompareMatrices(
-                positional_derivatives[i],
-                lane_position_nullargs.srh()(i).derivatives()));
-            EXPECT_TRUE(CompareMatrices(
-                positional_derivatives[i],
-                nearest_position.xyz()(i).derivatives()));
-          }
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      lane_position.s().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      nearest_position.x().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[1],
+                                      lane_position.r().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[1],
+                                      nearest_position.y().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[2],
+                                      lane_position.h().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[2],
+                                      nearest_position.z().derivatives()));
+
           // Expect ∂/∂x(distance) = 0., as distance remains unchanged when
           // on the boundary or within the interior of the lane.
           EXPECT_TRUE(CompareMatrices(Vector3<double>::Zero(),
@@ -781,16 +781,10 @@ TEST_F(MaliputDragwayLaneTest, TestToLanePositionAutoDiff) {
           EXPECT_TRUE(CompareMatrices(
               distance_derivatives, distance.derivatives(),
               1e-15 /* account for small numerical errors */));
-          for (int i{0}; i < 3; ++i) {
-            EXPECT_TRUE(CompareMatrices(positional_derivatives[i],
-                                        lane_position.srh()(i).derivatives()));
-            EXPECT_TRUE(CompareMatrices(
-                positional_derivatives[i],
-                lane_position_nullargs.srh()(i).derivatives()));
-            EXPECT_TRUE(CompareMatrices(
-                positional_derivatives[i],
-                nearest_position.xyz()(i).derivatives()));
-          }
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      lane_position.s().derivatives()));
+          EXPECT_TRUE(CompareMatrices(positional_derivatives[0],
+                                      nearest_position.x().derivatives()));
         }
       }
     }

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -4,32 +4,17 @@
 #include <memory>
 #include <utility>
 
-#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/extract_double.h"
 
 namespace drake {
 namespace automotive {
 
-namespace internal {
-
-// Makes the derviatives of the recipient coherent with respect to those of the
-// donor variable.  See drake/common/autodiffxd.h for further information.
-
-// TODO(jadecastro) Move to a commonly-accessible location.
-static void make_coherent(const AutoDiffXd& donor, AutoDiffXd* recipient) {
-  Eigen::internal::make_coherent(recipient->derivatives(), donor.derivatives());
-}
-
-static void make_coherent(const double&, double*) {}
-
-}  // namespace internal
-
-using maliput::api::GeoPositionT;
+using maliput::api::GeoPosition;
 using maliput::api::Lane;
 using maliput::api::LaneEnd;
 using maliput::api::LanePosition;
-using maliput::api::LanePositionT;
+using maliput::api::RoadGeometry;
+using maliput::api::RoadPosition;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseBundle;
 using systems::rendering::PoseVector;
@@ -56,19 +41,19 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
 
   DRAKE_DEMAND(lane != nullptr);
 
-  const GeoPositionT<T> ego_geo_position =
-      GeoPositionT<T>::FromXyz(ego_pose.get_isometry().translation());
-  const LanePositionT<T> ego_lane_position =
-      lane->ToLanePositionT<T>(ego_geo_position, nullptr, nullptr);
-  LaneDirection lane_direction =
-      CalcLaneDirection(lane, ego_lane_position, ego_pose.get_rotation(), side);
+  const GeoPosition ego_geo_position =
+      GeoPosition::FromXyz(ego_pose.get_isometry().translation());
+  const LanePosition ego_lane_position =
+      lane->ToLanePosition(ego_geo_position, nullptr, nullptr);
+  LaneDirection lane_direction = CalcLaneDirection(
+      {lane, ego_lane_position}, ego_pose.get_rotation(), side);
 
   ClosestPose<T> result;
-  result.odometry = MakeInfiniteOdometry(lane_direction, ego_pose);
-  result.distance = MakeInfiniteDistance(ego_pose);
+  result.odometry = MakeInfiniteOdometry(lane_direction);
+  result.distance = std::numeric_limits<T>::infinity();
   const ClosestPose<T> default_result = result;
 
-  const T ego_s = CalcLaneProgress(lane_direction, ego_lane_position);
+  const double ego_s = CalcLaneProgress(lane_direction, ego_lane_position);
   T distance_scanned = T(-ego_s);  // N.B. ego_s is negated to recover the
                                    // remaining distance to the end of the lane
                                    // when `distance_scanned` is incremented by
@@ -81,19 +66,19 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
     T distance_increment{0.};
     for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
       const Isometry3<T> traffic_isometry = traffic_poses.get_pose(i);
-      const GeoPositionT<T> traffic_geo_position =
-          GeoPositionT<T>::FromXyz(traffic_isometry.translation());
+      const GeoPosition traffic_geo_position =
+          GeoPosition::FromXyz(traffic_isometry.translation());
 
       if (ego_geo_position == traffic_geo_position) continue;
       if (!IsWithinLane(traffic_geo_position, lane_direction.lane)) continue;
 
-      const LanePositionT<T> traffic_lane_position =
-          lane_direction.lane->ToLanePositionT<T>(traffic_geo_position, nullptr,
-                                                  nullptr);
-      const T traffic_s =
+      const LanePosition traffic_lane_position =
+          lane_direction.lane->ToLanePosition(traffic_geo_position, nullptr,
+                                              nullptr);
+      const double traffic_s =
           CalcLaneProgress(lane_direction, traffic_lane_position);
 
-      const T s_delta = traffic_s - ego_s;
+      const double s_delta = traffic_s - ego_s;
       // Ignore traffic cars that are not in the desired direction (ahead or
       // behind) of the ego car (with respect to the car's current direction).
       // Cars with identical s-values as the ego but shifted laterally are
@@ -106,20 +91,21 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
 
       // Ignore positions at the desired direction (ahead or behind) of the ego
       // car that are not closer than any other found so far.
-      const T s_solution_difference =
+      const double s_solution_difference =
           result.odometry.pos.s() - traffic_lane_position.s();
-      const T s_improvement =
+      const double s_improvement =
           (ego_with_s) ? s_solution_difference : -s_solution_difference;
       if (s_improvement < 0.) continue;
 
       // Update the result and incremental distance with the new candidate.
       result.odometry =
-          RoadOdometry<T>(lane_direction.lane, traffic_lane_position,
+          RoadOdometry<T>({lane_direction.lane, traffic_lane_position},
                           traffic_poses.get_velocity(i));
       distance_increment = traffic_s;
     }
 
-    if (abs(result.odometry.pos.s()) < std::numeric_limits<T>::infinity()) {
+    if (abs(result.odometry.pos.s()) <
+        std::numeric_limits<double>::infinity()) {
       // Figure out whether or not the result is within scan_distance.
       if (distance_scanned + distance_increment < scan_distance) {
         result.distance = distance_scanned + distance_increment;
@@ -131,9 +117,7 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
 
     // Obtain the next lane_direction in the scanned sequence.
     GetDefaultOngoingLane(&lane_direction);
-    if (lane_direction.lane == nullptr) {
-      return result;
-    }
+    if (lane_direction.lane == nullptr) return result;
   }
   return default_result;
 }
@@ -141,12 +125,8 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
 template <typename T>
 T PoseSelector<T>::GetSigmaVelocity(const RoadOdometry<T>& road_odometry) {
   DRAKE_DEMAND(IsWithinLane(road_odometry.pos, road_odometry.lane));
-  const LanePosition& lane_pos =
-      LanePosition(ExtractDoubleOrThrow(road_odometry.pos.s()),
-                   ExtractDoubleOrThrow(road_odometry.pos.r()),
-                   ExtractDoubleOrThrow(road_odometry.pos.h()));
   const maliput::api::Rotation rot =
-      road_odometry.lane->GetOrientation(lane_pos);
+      road_odometry.lane->GetOrientation(road_odometry.pos);
   multibody::SpatialVelocity<T> road_odometry_velocity =
       road_odometry.vel.get_velocity();
   const Vector3<T>& vel = road_odometry_velocity.translational();
@@ -154,42 +134,39 @@ T PoseSelector<T>::GetSigmaVelocity(const RoadOdometry<T>& road_odometry) {
 }
 
 template <typename T>
-bool PoseSelector<T>::IsWithinDriveable(const LanePositionT<T>& lane_position,
+bool PoseSelector<T>::IsWithinDriveable(const LanePosition& lane_position,
                                         const Lane* lane) {
   if (lane_position.s() < 0. || lane_position.s() > lane->length()) {
     return false;
   }
   const maliput::api::RBounds r_bounds =
-      lane->driveable_bounds(ExtractDoubleOrThrow(lane_position.s()));
+      lane->driveable_bounds(lane_position.s());
   if (lane_position.r() < r_bounds.min() ||
       lane_position.r() > r_bounds.max()) {
     return false;
   }
   const maliput::api::HBounds h_bounds =
-      lane->elevation_bounds(ExtractDoubleOrThrow(lane_position.s()),
-                             ExtractDoubleOrThrow(lane_position.r()));
+      lane->elevation_bounds(lane_position.s(), lane_position.r());
   return (lane_position.h() >= h_bounds.min() &&
           lane_position.h() <= h_bounds.max());
 }
 
 template <typename T>
-bool PoseSelector<T>::IsWithinLane(const GeoPositionT<T>& geo_position,
+bool PoseSelector<T>::IsWithinLane(const GeoPosition& geo_position,
                                    const Lane* lane) {
-  T distance{};
-  const LanePositionT<T> pos =
-      lane->ToLanePositionT<T>(geo_position, nullptr, &distance);
-  const maliput::api::RBounds r_bounds =
-      lane->lane_bounds(ExtractDoubleOrThrow(pos.s()));
+  double distance{};
+  const LanePosition pos =
+      lane->ToLanePosition(geo_position, nullptr, &distance);
+  const maliput::api::RBounds r_bounds = lane->lane_bounds(pos.s());
   return (distance == 0. && pos.r() >= r_bounds.min() &&
           pos.r() <= r_bounds.max());
 }
 
 template <typename T>
-bool PoseSelector<T>::IsWithinLane(const LanePositionT<T>& lane_position,
+bool PoseSelector<T>::IsWithinLane(const LanePosition& lane_position,
                                    const Lane* lane) {
   if (IsWithinDriveable(lane_position, lane)) {
-    const maliput::api::RBounds r_bounds =
-        lane->lane_bounds(ExtractDoubleOrThrow(lane_position.s()));
+    const maliput::api::RBounds r_bounds = lane->lane_bounds(lane_position.s());
     if (lane_position.r() >= r_bounds.min() ||
         lane_position.r() <= r_bounds.max()) {
       return true;
@@ -218,70 +195,46 @@ std::unique_ptr<LaneEnd> PoseSelector<T>::GetDefaultOngoingLane(
 
 template <typename T>
 RoadOdometry<T> PoseSelector<T>::MakeInfiniteOdometry(
-    const LaneDirection& lane_direction, const PoseVector<T>& ego_pose) {
-  T infinite_position = (lane_direction.with_s)
-                            ? std::numeric_limits<T>::infinity()
-                            : -std::numeric_limits<T>::infinity();
-  T zero(0.);
-  internal::make_coherent(ego_pose.get_isometry().translation().x(), &zero);
-  internal::make_coherent(ego_pose.get_isometry().translation().x(),
-                          &infinite_position);
-  const LanePositionT<T> lane_position(infinite_position, zero, zero);
-  FrameVelocity<T> frame_velocity;
-  auto velocity = frame_velocity.get_mutable_value();
-  for (int i{0}; i < frame_velocity.kSize; ++i) {
-    internal::make_coherent(ego_pose.get_isometry().translation().x(),
-                            &velocity(i));
-  }
-  // TODO(jadecastro) Consider moving the above make_coherent() step to
-  // BasicVector().
-  return {lane_direction.lane, lane_position, frame_velocity};
+    const LaneDirection& lane_direction) {
+  const double infinite_distance =
+      (lane_direction.with_s) ? std::numeric_limits<double>::infinity()
+                              : -std::numeric_limits<double>::infinity();
+  const RoadPosition default_road_position(lane_direction.lane,
+                                           {infinite_distance, 0., 0.});
+  return {default_road_position, FrameVelocity<T>()};
 }
 
 template <typename T>
-T PoseSelector<T>::MakeInfiniteDistance(const PoseVector<T>& ego_pose) {
-  T infinite_distance = std::numeric_limits<T>::infinity();
-  internal::make_coherent(ego_pose.get_isometry().translation().x(),
-                          &infinite_distance);
-  return infinite_distance;
-}
-
-template <typename T>
-T PoseSelector<T>::CalcLaneProgress(const LaneDirection& lane_direction,
-                                    const LanePositionT<T>& lane_position) {
+double PoseSelector<T>::CalcLaneProgress(const LaneDirection& lane_direction,
+                                           const LanePosition& lane_position) {
   DRAKE_DEMAND(IsWithinDriveable(lane_position, lane_direction.lane));
   if (lane_direction.with_s) {
     return lane_position.s();
   } else {
-    return T(lane_direction.lane->length()) - lane_position.s();
+    return lane_direction.lane->length() - lane_position.s();
   }
 }
 
 template <typename T>
 LaneDirection PoseSelector<T>::CalcLaneDirection(
-    const Lane* lane, const LanePositionT<T>& lane_position,
-    const Eigen::Quaternion<T>& rotation, AheadOrBehind side) {
+    const RoadPosition& road_position, const Eigen::Quaternion<T>& rotation,
+    AheadOrBehind side) {
   // Get the vehicle's heading with respect to the current lane; use it to
   // determine if the vehicle is facing with or against the lane's canonical
   // direction.
-  const LanePosition lane_pos =
-      LanePosition(ExtractDoubleOrThrow(lane_position.s()),
-                   ExtractDoubleOrThrow(lane_position.r()),
-                   ExtractDoubleOrThrow(lane_position.h()));
   const Eigen::Quaternion<T> lane_rotation =
-      lane->GetOrientation(lane_pos).quat();
+      road_position.lane->GetOrientation(road_position.pos).quat();
   // The dot product of two quaternions is the cosine of half the angle between
   // the two rotations.  Given two quaternions q₀, q₁ and letting θ be the angle
   // difference between them, then -π/2 ≤ θ ≤ π/2 iff q₀.q₁ ≥ √2/2.
   const bool with_s = (side == AheadOrBehind::kAhead)
                           ? lane_rotation.dot(rotation) >= sqrt(2.) / 2.
                           : lane_rotation.dot(rotation) < sqrt(2.) / 2.;
-  return LaneDirection(lane, with_s);
+  return LaneDirection(road_position.lane, with_s);
 }
+
+// These instantiations must match the API documentation in pose_selector.h.
+template class PoseSelector<double>;
 
 }  // namespace automotive
 }  // namespace drake
-
-// These instantiations must match the API documentation in pose_selector.h.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::automotive::PoseSelector)

--- a/drake/automotive/pose_selector.h
+++ b/drake/automotive/pose_selector.h
@@ -44,7 +44,6 @@ enum class AheadOrBehind { kAhead = 0, kBehind = 1 };
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
-/// - AutoDiffXd
 ///
 /// They are already available to link against in the containing library.
 ///
@@ -109,30 +108,24 @@ class PoseSelector {
   /// elevation and superelevation.  Throws if any element of
   /// `road_odometry.pos` is not within the respective bounds of
   /// `road_odometry.lane`.
-  ///
-  /// N.B. This function currently only provides exact derivatives for velocity
-  /// in the `s` direction when the road is straight (no yaw angle variations).
-  //
-  // TODO(jadecastro) Enable AutoDiffXd for
-  // maliput::api::Lane::GetOrientation().
   static T GetSigmaVelocity(const RoadOdometry<T>& road_odometry);
 
   /// Returns `true` if and only if @p lane_position is within the longitudinal
   /// (s), driveable (r) and elevation (h) bounds of the specified @p lane
   /// (i.e. within `lane->driveable_bounds()` and `lane->elevation_bounds()`).
   static bool IsWithinDriveable(
-      const maliput::api::LanePositionT<T>& lane_position,
+      const maliput::api::LanePosition& lane_position,
       const maliput::api::Lane* lane);
 
   /// Returns `true` if and only if @p geo_position is within the longitudinal
   /// (s), lateral (r) and elevation (h) bounds of the specified @p lane
   /// (i.e. within `lane->lane_bounds()` and `lane->elevation_bounds()`).
-  static bool IsWithinLane(const maliput::api::GeoPositionT<T>& geo_position,
+  static bool IsWithinLane(const maliput::api::GeoPosition& geo_position,
                            const maliput::api::Lane* lane);
 
   /// Returns `true` if and only if @p lane_position is within the driveable
   /// bounds of @p lane and, in addition, `r` is within its lane bounds.
-  static bool IsWithinLane(const maliput::api::LanePositionT<T>& lane_position,
+  static bool IsWithinLane(const maliput::api::LanePosition& lane_position,
                            const maliput::api::Lane* lane);
 
  private:
@@ -143,40 +136,30 @@ class PoseSelector {
   static std::unique_ptr<maliput::api::LaneEnd> GetDefaultOngoingLane(
       LaneDirection* lane_direction);
 
-  // Returns a RoadOdometry that contains an infinite `s` position, zero `r` and
-  // `h` positions, and zero velocities. If @p lane_direction contains `with_s
-  // == True`, a RoadOdometry containing an s-position at positive infinity is
-  // returned; otherwise a negative-infinite position is returned.  For T =
-  // AutoDiffXd, the derivatives of the returned RoadOdometry are made to be
-  // coherent with respect to @p ego_pose.
+  // Returns a RoadOdometry that contains infinite positions and zero `r`, `h`,
+  // and velocity values. If @p lane_direction contains `with_s == True`, a
+  // RoadOdometry containing an s-position at positive infinity is returned;
+  // otherwise a negative-intinite position is returned.
   static RoadOdometry<T> MakeInfiniteOdometry(
-      const LaneDirection& lane_direction,
-      const systems::rendering::PoseVector<T>& ego_pose);
-
-  // Returns positive infinity. For T = AutoDiffXd, the derivatives of the
-  // the return value are made to be coherent with respect to @p ego_pose.
-  static T MakeInfiniteDistance(
-      const systems::rendering::PoseVector<T>& ego_pose);
+      const LaneDirection& lane_direction);
 
   // Returns the distance (along the `s`-coordinate) from an end of a lane to a
   // @p lane_position in that lane, where the end is determined by the `with_s`
   // of the provided `lane_direction`.  Both `lane` and `with_s` are specified
   // in @p lane_direction.  Throws if any element of @p lane_position is not
   // within the respective bounds of `lane_direction.lane`.
-  static T CalcLaneProgress(
+  static double CalcLaneProgress(
       const LaneDirection& lane_direction,
-      const maliput::api::LanePositionT<T>& lane_position);
+      const maliput::api::LanePosition& lane_position);
 
-  // Constructs a LaneDirection structure based on a vehicle's current @p lane,
-  // @p lane_position, @p rotation (in global coordinates), and the @p side of
+  // Constructs a LaneDirection structure based on a vehicle's current @p
+  // road_position and @p rotation (in global coordinates), and the @p side of
   // the car (ahead or behind) that traffic is being observed.  Note that
-  // `LaneDirection::with_s` in the return argument is interpreted as the
-  // direction along which targets are being observed (regardless of the ego
-  // car's orientation): it is true if cars are being observed along the
-  // `s`-direction and is false otherwise.
+  // `LaneDirection::with_s` is interpreted as the direction along which targets
+  // are being observed (regardless of the ego car's orientation): it is true if
+  // cars are being observed along the `s`-direction and is false otherwise.
   static LaneDirection CalcLaneDirection(
-      const maliput::api::Lane* lane,
-      const maliput::api::LanePositionT<T>& lane_position,
+      const maliput::api::RoadPosition& road_position,
       const Eigen::Quaternion<T>& rotation, AheadOrBehind side);
 };
 

--- a/drake/automotive/pure_pursuit.cc
+++ b/drake/automotive/pure_pursuit.cc
@@ -5,7 +5,7 @@
 
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/common/autodiff.h"
-#include "drake/common/default_scalars.h"
+#include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/symbolic.h"
 #include "drake/math/saturate.h"
@@ -13,9 +13,9 @@
 namespace drake {
 namespace automotive {
 
-using maliput::api::GeoPositionT;
+using maliput::api::GeoPosition;
 using maliput::api::Lane;
-using maliput::api::LanePositionT;
+using maliput::api::LanePosition;
 using systems::rendering::PoseVector;
 
 template <typename T>
@@ -26,12 +26,12 @@ T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
   DRAKE_DEMAND(pp_params.IsValid());
   DRAKE_DEMAND(car_params.IsValid());
 
-  using std::atan2;
+  using std::atan;
   using std::cos;
   using std::pow;
   using std::sin;
 
-  const GeoPositionT<T> goal_position =
+  const GeoPosition goal_position =
       ComputeGoalPoint(pp_params.s_lookahead(), lane_direction, pose);
 
   const T x = pose.get_translation().translation().x();
@@ -40,35 +40,33 @@ T PurePursuit<T>::Evaluate(const PurePursuitParams<T>& pp_params,
 
   const T delta_r = -(goal_position.x() - x) * sin(heading) +
                     (goal_position.y() - y) * cos(heading);
-  const T curvature = 2. * delta_r / pow(pp_params.s_lookahead(), 2.);
+  const T curvature = 2 * delta_r / pow(pp_params.s_lookahead(), 2.);
 
   // Return the steering angle.
-  return atan2(car_params.wheelbase() * curvature, T(1.));
-  // N.B. atan2(*, 1) is used here in the absence of an atan() autodiff
-  // overload.
+  return atan(car_params.wheelbase() * curvature);
 }
 
 template <typename T>
-const GeoPositionT<T> PurePursuit<T>::ComputeGoalPoint(
+const GeoPosition PurePursuit<T>::ComputeGoalPoint(
     const T& s_lookahead, const LaneDirection& lane_direction,
     const PoseVector<T>& pose) {
   const Lane* const lane = lane_direction.lane;
   const bool with_s = lane_direction.with_s;
-  const LanePositionT<T> position =
-      lane->ToLanePositionT<T>({pose.get_isometry().translation().x(),
-                                pose.get_isometry().translation().y(),
-                                pose.get_isometry().translation().z()},
-                               nullptr, nullptr);
+  const LanePosition position =
+      lane->ToLanePosition(
+          GeoPosition::FromXyz(pose.get_isometry().translation()),
+          nullptr, nullptr);
   const T s_new =
-      with_s ? position.s() + s_lookahead : position.s() - s_lookahead;
-  const T s_goal = math::saturate(s_new, T(0.), T(lane->length()));
+      cond(with_s, position.s() + s_lookahead, position.s() - s_lookahead);
+  const T s_goal = math::saturate(s_new, 0., lane->length());
   // TODO(jadecastro): Add support for locating goal points in ongoing lanes.
-  return lane->ToGeoPositionT<T>({s_goal, 0. * position.r(), position.h()});
+  return lane->ToGeoPosition({s_goal, 0., position.h()});
 }
+
+// These instantiations must match the API documentation in pure_pursuit.h.
+// The only scalar type supported is double.
+// TODO(jadecastro): Enable AutoDiffXd support.
+template class PurePursuit<double>;
 
 }  // namespace automotive
 }  // namespace drake
-
-// These instantiations must match the API documentation in pure_pursuit.h.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::automotive::PurePursuit)

--- a/drake/automotive/pure_pursuit.h
+++ b/drake/automotive/pure_pursuit.h
@@ -22,7 +22,6 @@ namespace automotive {
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
-/// - AutoDiffXd
 ///
 /// They are already available to link against in the containing library.
 ///
@@ -56,7 +55,7 @@ class PurePursuit {
   /// Computes the goal point at a distance `s_lookahead` from the closest
   /// position on the curve in the intended direction of travel, and `with_s`
   /// and `pose` are the direction of travel and PoseVector for the ego vehicle.
-  static const maliput::api::GeoPositionT<T> ComputeGoalPoint(
+  static const maliput::api::GeoPosition ComputeGoalPoint(
       const T& s_lookahead, const LaneDirection& lane_direction,
       const systems::rendering::PoseVector<T>& pose);
 };

--- a/drake/automotive/pure_pursuit_controller.cc
+++ b/drake/automotive/pure_pursuit_controller.cc
@@ -3,7 +3,6 @@
 #include <cmath>
 
 #include "drake/automotive/pure_pursuit.h"
-#include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
 
 namespace drake {
@@ -18,9 +17,7 @@ static constexpr int kCarParamsIndex{1};
 
 template <typename T>
 PurePursuitController<T>::PurePursuitController()
-    : systems::LeafSystem<T>(
-          systems::SystemTypeTag<automotive::PurePursuitController>{}),
-      lane_index_{this->DeclareAbstractInputPort().get_index()},
+    : lane_index_{this->DeclareAbstractInputPort().get_index()},
       ego_pose_index_{
           this->DeclareInputPort(systems::kVectorValued, PoseVector<T>::kSize)
               .get_index()},
@@ -95,10 +92,9 @@ void PurePursuitController<T>::CalcSteeringCommand(
       PurePursuit<T>::Evaluate(pp_params, car_params, lane_direction, ego_pose);
 }
 
-}  // namespace automotive
-}  // namespace drake
-
 // These instantiations must match the API documentation in
 // pure_pursuit_controller.h.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
-    class ::drake::automotive::PurePursuitController)
+template class PurePursuitController<double>;
+
+}  // namespace automotive
+}  // namespace drake

--- a/drake/automotive/pure_pursuit_controller.h
+++ b/drake/automotive/pure_pursuit_controller.h
@@ -19,7 +19,6 @@ namespace automotive {
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
-/// - AutoDiffXd
 ///
 /// They are already available to link against in the containing library.
 ///
@@ -41,12 +40,6 @@ class PurePursuitController : public systems::LeafSystem<T> {
 
   /// Constructor.
   PurePursuitController();
-
-  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
-  template <typename U>
-  explicit PurePursuitController(const PurePursuitController<U>&)
-      : PurePursuitController<T>() {}
-
   ~PurePursuitController() override;
 
   /// Returns the port to the individual input/output ports.
@@ -56,7 +49,7 @@ class PurePursuitController : public systems::LeafSystem<T> {
 
  private:
   void OutputSteeringCommand(const systems::Context<T>& context,
-                             systems::BasicVector<T>* output) const;
+                            systems::BasicVector<T>* output) const;
 
   void CalcSteeringCommand(const PurePursuitParams<T>& pp_params,
                            const SimpleCarParams<T>& car_params,
@@ -71,14 +64,4 @@ class PurePursuitController : public systems::LeafSystem<T> {
 };
 
 }  // namespace automotive
-
-namespace systems {
-namespace scalar_conversion {
-// Disables symbolic support, because maliput's LanePositionT <-> GeoPositionT
-// conversion (used in pure_pursuit.cc) is not symbolic-supported.
-template <>
-struct Traits<automotive::PurePursuitController> : public NonSymbolicTraits {};
-}  // namespace scalar_conversion
-}  // namespace systems
-
 }  // namespace drake

--- a/drake/automotive/road_odometry.h
+++ b/drake/automotive/road_odometry.h
@@ -15,16 +15,11 @@ struct RoadOdometry {
   RoadOdometry() = default;
   /// Fully-parameterized constructor.
   RoadOdometry(const maliput::api::RoadPosition& road_position,
-               const systems::rendering::FrameVelocity<double>& frame_velocity)
-      : lane(road_position.lane), pos(road_position.pos), vel(frame_velocity) {}
-  /// Fully-parameterized constructor that is T-supported.
-  RoadOdometry(const maliput::api::Lane* lane,
-               const maliput::api::LanePositionT<T>& lane_position,
                const systems::rendering::FrameVelocity<T>& frame_velocity)
-      : lane(lane), pos(lane_position), vel(frame_velocity) {}
+      : lane(road_position.lane), pos(road_position.pos), vel(frame_velocity) {}
 
   const maliput::api::Lane* lane{};
-  maliput::api::LanePositionT<T> pos{};
+  maliput::api::LanePosition pos{};
   systems::rendering::FrameVelocity<T> vel{};
 };
 

--- a/drake/automotive/test/pose_selector_test.cc
+++ b/drake/automotive/test/pose_selector_test.cc
@@ -6,8 +6,6 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/maliput/monolane/builder.h"
-#include "drake/common/extract_double.h"
-#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/roll_pitch_yaw_using_quaternion.h"
 
 namespace drake {
@@ -67,9 +65,8 @@ class PoseSelectorDragwayTest : public ::testing::Test {
   std::unique_ptr<maliput::dragway::RoadGeometry> road_;
 };
 
-template <typename T>
-static void SetDefaultDragwayPoses(PoseVector<T>* ego_pose,
-                                   PoseBundle<T>* traffic_poses) {
+static void SetDefaultDragwayPoses(PoseVector<double>* ego_pose,
+                                   PoseBundle<double>* traffic_poses) {
   DRAKE_DEMAND(traffic_poses->get_num_poses() == kNumDragwayTrafficCars);
   DRAKE_DEMAND(kEgoSPosition > 0. && kDragwayLaneLength > kEgoSPosition);
   DRAKE_DEMAND(kJustAheadSPosition > kEgoSPosition &&
@@ -83,57 +80,39 @@ static void SetDefaultDragwayPoses(PoseVector<T>* ego_pose,
   //     Far Behind   Just Behind     Ego     Just Ahead   Far Ahead
   //   |------o------------o-----------o----------o------------o-------------|
   //  s=0     3            7           10         31           35           100
-  ego_pose->set_translation(Translation3<T>(
-      T(kEgoSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */));
+  ego_pose->set_translation(Eigen::Translation3d(
+      kEgoSPosition /* s */, kEgoRPosition /* r */, 0. /* h */));
 
-  const Translation3<T> translation_far_ahead(
-      T(kFarAheadSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */);
-  FrameVelocity<T> velocity_far_ahead{};
-  velocity_far_ahead.get_mutable_value() << T(0.) /* ωx */, T(0.) /* ωy */,
-      T(0.) /* ωz */, T(kTrafficXVelocity) /* vx */, T(0.) /* vy */,
-      T(0.) /* vz */;
-  const Translation3<T> translation_just_ahead(
-      T(kJustAheadSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */);
-  const Translation3<T> translation_just_behind(
-      T(kJustBehindSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */);
-  const Translation3<T> translation_far_behind(
-      T(kFarBehindSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */);
-  traffic_poses->set_pose(kFarAheadIndex, Isometry3<T>(translation_far_ahead));
+  const Eigen::Translation3d translation_far_ahead(
+      kFarAheadSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+  FrameVelocity<double> velocity_far_ahead{};
+  velocity_far_ahead.get_mutable_value() << 0. /* ωx */, 0. /* ωy */,
+      0. /* ωz */, kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
+  const Eigen::Translation3d translation_just_ahead(
+      kJustAheadSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+  const Eigen::Translation3d translation_just_behind(
+      kJustBehindSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+  const Eigen::Translation3d translation_far_behind(
+      kFarBehindSPosition /* s */, kEgoRPosition /* r */, 0. /* h */);
+  traffic_poses->set_pose(kFarAheadIndex,
+                          Eigen::Isometry3d(translation_far_ahead));
   traffic_poses->set_velocity(kFarAheadIndex, velocity_far_ahead);
   traffic_poses->set_pose(kJustAheadIndex,
-                          Isometry3<T>(translation_just_ahead));
+                          Eigen::Isometry3d(translation_just_ahead));
   traffic_poses->set_pose(kJustBehindIndex,
-                          Isometry3<T>(translation_just_behind));
+                          Eigen::Isometry3d(translation_just_behind));
   traffic_poses->set_pose(kFarBehindIndex,
-                          Isometry3<T>(translation_far_behind));
-}
-
-static void SetDefaultDragwayPoseDerivatives(
-    PoseVector<AutoDiffXd>* ego_pose, PoseBundle<AutoDiffXd>* traffic_poses) {
-  Eigen::Translation<AutoDiffXd, 3> ego_translation =
-      ego_pose->get_translation();
-  ego_translation.x().derivatives() = Eigen::Vector3d(1., 0., 0.);
-  ego_translation.y().derivatives() = Eigen::Vector3d(0., 1., 0.);
-  ego_translation.z().derivatives() = Eigen::Vector3d(0., 0., 1.);
-  ego_pose->set_translation(ego_translation);
-  for (int i{0}; i < traffic_poses->get_num_poses(); ++i) {
-    Isometry3<AutoDiffXd> position;
-    position.translation() = traffic_poses->get_pose(i).translation();
-    position.translation().x().derivatives() = Eigen::Vector3d(1., 0., 0.);
-    position.translation().y().derivatives() = Eigen::Vector3d(0., 1., 0.);
-    position.translation().z().derivatives() = Eigen::Vector3d(0., 0., 1.);
-    traffic_poses->set_pose(i, position);
-  }
+                          Eigen::Isometry3d(translation_far_behind));
 }
 
 // Sets the poses for one ego car and one traffic car, with the relative
 // positions of each determined by the given s_offset an r_offset values.  The
 // optional `yaw` argument determines the orientation of the ego car with
 // respect to the x-axis.
-template <typename T>
-static void SetPoses(const T& s_offset, const T& r_offset,
-                     PoseVector<T>* ego_pose, PoseBundle<T>* traffic_poses,
-                     const T& yaw = T(0.)) {
+static void SetPoses(double s_offset, double r_offset,
+                     PoseVector<double>* ego_pose,
+                     PoseBundle<double>* traffic_poses,
+                     double yaw = 0.) {
   DRAKE_DEMAND(traffic_poses->get_num_poses() == 1);
   DRAKE_DEMAND(kEgoSPosition > 0. && kDragwayLaneLength > kEgoSPosition);
   DRAKE_DEMAND(kJustAheadSPosition > kEgoSPosition &&
@@ -142,30 +121,27 @@ static void SetPoses(const T& s_offset, const T& r_offset,
                kJustBehindSPosition > 0.);
 
   // Create poses for one traffic car and one ego car.
-  ego_pose->set_translation(Translation3<T>(
-      T(kEgoSPosition) /* s */, T(kEgoRPosition) /* r */, T(0.) /* h */));
+  ego_pose->set_translation(Eigen::Translation3d(
+      kEgoSPosition /* s */, kEgoRPosition /* r */, 0. /* h */));
   ego_pose->set_rotation(
-      RollPitchYawToQuaternion(Vector3<T>{T(0.), T(0.), T(yaw)}));
+      RollPitchYawToQuaternion(Vector3<double>{0., 0., yaw}));
 
-  const Translation3<T> translation(T(kEgoSPosition) + s_offset /* s */,
-                                    T(kEgoRPosition) + r_offset /* r */,
-                                    T(0.) /* h */);
-  FrameVelocity<T> traffic_velocity{};
-  traffic_velocity.get_mutable_value() << T(0.) /* ωx */, T(0.) /* ωy */,
-      T(0.) /* ωz */, T(kTrafficXVelocity) /* vx */, T(0.) /* vy */,
-      T(0.) /* vz */;
-  traffic_poses->set_pose(0, Isometry3<T>(translation));
+  const Eigen::Translation3d translation(kEgoSPosition + s_offset /* s */,
+                                         kEgoRPosition + r_offset /* r */,
+                                         0. /* h */);
+  FrameVelocity<double> traffic_velocity{};
+  traffic_velocity.get_mutable_value() << 0. /* ωx */, 0. /* ωy */, 0. /* ωz */,
+      kTrafficXVelocity /* vx */, 0. /* vy */, 0. /* vz */;
+  traffic_poses->set_pose(0, Eigen::Isometry3d(translation));
   traffic_poses->set_velocity(0, traffic_velocity);
 }
 
 // Returns the lane in the road associated with the provided pose.
-template <typename T>
-const maliput::api::Lane* get_lane(const PoseVector<T>& pose,
+const maliput::api::Lane* get_lane(const PoseVector<double>& pose,
                                    const maliput::api::RoadGeometry& road) {
-  const GeoPosition geo_position{
-      ExtractDoubleOrThrow(pose.get_translation().x()),
-      ExtractDoubleOrThrow(pose.get_translation().y()),
-      ExtractDoubleOrThrow(pose.get_translation().z())};
+  const GeoPosition geo_position{pose.get_translation().x(),
+                                 pose.get_translation().y(),
+                                 pose.get_translation().z()};
   return road.ToRoadPosition(geo_position, nullptr, nullptr, nullptr).lane;
 }
 
@@ -296,106 +272,6 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
   }
 }
 
-TEST_F(PoseSelectorDragwayTest, TwoLaneDragwayAutoDiff) {
-  MakeDragway(2 /* num lanes */, kDragwayLaneLength);
-
-  PoseVector<AutoDiffXd> ego_pose;
-  PoseBundle<AutoDiffXd> traffic_poses(kNumDragwayTrafficCars);
-
-  // Define the default poses.
-  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
-  SetDefaultDragwayPoseDerivatives(&ego_pose, &traffic_poses);
-
-  // Choose a scan-ahead distance shorter than the lane length.
-  const AutoDiffXd scan_ahead_distance(kDragwayLaneLength / 2.);
-  {
-    const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
-        PoseSelector<AutoDiffXd>::FindClosestPair(get_lane(ego_pose, *road_),
-                                                  ego_pose, traffic_poses,
-                                                  scan_ahead_distance);
-
-    // Verifies that the correct leading and trailing cars are identified, and
-    // that their derivatives are correct.
-    const Vector3<AutoDiffXd> srh_ahead =
-        closest_poses.at(AheadOrBehind::kAhead).odometry.pos.srh();
-    EXPECT_EQ(kJustAheadSPosition, srh_ahead.x().value());
-    // Both the ahead and behind cars were found within scan_ahead_distance.
-    // Expect the x-y-z-axis derivatives for both to be the orthonormal basis
-    // aligned with the s-r-h axis.
-    const Matrix3<double> expected_derivatives = Matrix3<double>::Identity();
-    for (int i{0}; i < 3; ++i) {
-      EXPECT_TRUE(CompareMatrices(expected_derivatives.col(i),
-                                  srh_ahead(i).derivatives()));
-    }
-    const Vector3<AutoDiffXd> srh_behind =
-        closest_poses.at(AheadOrBehind::kBehind).odometry.pos.srh();
-    EXPECT_EQ(kJustBehindSPosition, srh_behind.x().value());
-    for (int i{0}; i < 3; ++i) {
-      EXPECT_TRUE(CompareMatrices(expected_derivatives.col(i),
-                                  srh_behind(i).derivatives()));
-    }
-    const AutoDiffXd dist_ahead =
-        closest_poses.at(AheadOrBehind::kAhead).distance;
-    EXPECT_EQ(kJustAheadSPosition - kEgoSPosition, dist_ahead);
-    // Distance is always invariant wrt. to x, y and z.
-    EXPECT_TRUE(
-        CompareMatrices(Vector3<double>(0., 0., 0.), dist_ahead.derivatives()));
-    const AutoDiffXd dist_behind =
-        closest_poses.at(AheadOrBehind::kBehind).distance;
-    EXPECT_EQ(kEgoSPosition - kJustBehindSPosition, dist_behind);
-    // Distance is always invariant wrt. to x, y and z.
-    EXPECT_TRUE(CompareMatrices(Vector3<double>(0., 0., 0.),
-                                dist_behind.derivatives()));
-  }
-
-  // Bump the "just ahead" car into the lane to the left.
-  Isometry3<AutoDiffXd> isometry_just_ahead =
-      traffic_poses.get_pose(kJustAheadIndex);
-  isometry_just_ahead.translation().y() += kDragwayLaneWidth;
-  traffic_poses.set_pose(kJustAheadIndex, isometry_just_ahead);
-  // Peer into the adjacent lane to the left.
-  {
-    const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
-        PoseSelector<AutoDiffXd>::FindClosestPair(
-            get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            scan_ahead_distance);
-
-    // Expect there to be no car behind on the immediate left and the "just
-    // ahead" car to be leading.
-    const Vector3<AutoDiffXd> srh_ahead =
-        closest_poses.at(AheadOrBehind::kAhead).odometry.pos.srh();
-    EXPECT_EQ(kJustAheadSPosition, srh_ahead.x().value());
-    // Expect the ahead car to have x-y-z-axis derivatives forming an
-    // orthonormal basis aligned with the s-r-h axis.  There is no car behind,
-    // so the derivatives should be all zeros.
-    const Matrix3<double> expected_derivatives = Matrix3<double>::Identity();
-    for (int i{0}; i < 3; ++i) {
-      EXPECT_TRUE(CompareMatrices(expected_derivatives.col(i),
-                                  srh_ahead(i).derivatives()));
-    }
-    const Vector3<AutoDiffXd> srh_behind =
-        closest_poses.at(AheadOrBehind::kBehind).odometry.pos.srh();
-    EXPECT_EQ(-std::numeric_limits<AutoDiffXd>::infinity(),
-              srh_behind.x().value());
-    for (int i{0}; i < 3; ++i) {
-      EXPECT_TRUE(CompareMatrices(Vector3<double>(0., 0., 0.),
-                                  srh_behind(i).derivatives()));
-    }
-    const AutoDiffXd dist_ahead =
-        closest_poses.at(AheadOrBehind::kAhead).distance;
-    EXPECT_EQ(kJustAheadSPosition - kEgoSPosition, dist_ahead);
-    // Distance is always invariant wrt. to x, y and z.
-    EXPECT_TRUE(
-        CompareMatrices(Vector3<double>(0., 0., 0.), dist_ahead.derivatives()));
-    const AutoDiffXd dist_behind =
-        closest_poses.at(AheadOrBehind::kBehind).distance;
-    EXPECT_EQ(std::numeric_limits<AutoDiffXd>::infinity(), dist_behind);
-    // Distance is always invariant wrt. to x, y and z.
-    EXPECT_TRUE(CompareMatrices(Vector3<double>(0., 0., 0.),
-                                dist_behind.derivatives()));
-  }
-}
-
 // Verifies that CalcLaneDirection returns the correct result when the ego
 // vehicle's orientation is altered.
 TEST_F(PoseSelectorDragwayTest, EgoOrientation) {
@@ -462,45 +338,6 @@ TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoad) {
             closest_poses.at(AheadOrBehind::kAhead).distance);
   EXPECT_EQ(std::numeric_limits<double>::infinity(),
             closest_poses.at(AheadOrBehind::kBehind).distance);
-}
-
-TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoadAutoDiff) {
-  // When no cars are found on a dragway whose length is less than the
-  // scan_distance, then infinite distances should be returned.
-  const double kShortLaneLength{40.};
-  MakeDragway(2 /* num lanes */, kShortLaneLength);
-
-  PoseVector<AutoDiffXd> ego_pose;
-  PoseBundle<AutoDiffXd> traffic_poses(kNumDragwayTrafficCars);
-
-  // Define the default poses.
-  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
-  SetDefaultDragwayPoseDerivatives(&ego_pose, &traffic_poses);
-
-  // Choose a scan-ahead distance greater than the lane length.
-  const AutoDiffXd scan_ahead_distance(kShortLaneLength + 10.);
-  EXPECT_GT(scan_ahead_distance,
-            kShortLaneLength - ego_pose.get_translation().x());
-  EXPECT_GT(scan_ahead_distance, ego_pose.get_translation().x());
-
-  // Scan for cars in the left lane, which should contain no cars.
-  const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
-      PoseSelector<AutoDiffXd>::FindClosestPair(
-          get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-          scan_ahead_distance);
-
-  // Expect distances to have infinite value and zero derivatives in both the
-  // ahead and behind directions.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kAhead).distance);
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kBehind).distance);
-  EXPECT_TRUE(CompareMatrices(
-      Vector3<double>(0., 0., 0.),
-      closest_poses.at(AheadOrBehind::kAhead).distance.derivatives()));
-  EXPECT_TRUE(CompareMatrices(
-      Vector3<double>(0., 0., 0.),
-      closest_poses.at(AheadOrBehind::kBehind).distance.derivatives()));
 }
 
 // Verifies the result when the s-positions of the ego and traffic vehicles have
@@ -687,10 +524,6 @@ GTEST_TEST(PoseSelectorTest, MultiSegmentRoad) {
     }
   }
 }
-
-// TODO(jadecastro) We cannot yet test against AutoDiff for multi-segment roads
-// because only the Dragway backend has AutoDiff implementations for
-// Lane::ToLanePosition() and Lane::ToGeoPosition().
 
 }  // namespace
 }  // namespace automotive

--- a/drake/automotive/test/pure_pursuit_controller_test.cc
+++ b/drake/automotive/test/pure_pursuit_controller_test.cc
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
-#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
 namespace automotive {
@@ -24,7 +23,8 @@ class PurePursuitControllerTest : public ::testing::Test {
     // Create a straight road with two lanes.
     road_.reset(new maliput::dragway::RoadGeometry(
         maliput::api::RoadGeometryId("Two-Lane Dragway"), 1 /* num_lanes */,
-        100 /* length */, kLaneWidth /* lane_width */, 0. /* shoulder_width */,
+        100 /* length */, kLaneWidth /* lane_width */,
+        0. /* shoulder_width */,
         5. /* maximum_height */,
         std::numeric_limits<double>::epsilon() /* linear_tolerance */,
         std::numeric_limits<double>::epsilon() /* angular_tolerance */));
@@ -81,22 +81,6 @@ TEST_F(PurePursuitControllerTest, Topology) {
       dut_->get_output_port(dut_->steering_command_output().get_index());
   EXPECT_EQ(systems::kVectorValued, command_output_port.get_data_type());
   EXPECT_EQ(1 /* steering angle output */, command_output_port.size());
-}
-
-TEST_F(PurePursuitControllerTest, ToAutoDiff) {
-  EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& other_dut) {
-    auto other_context = other_dut.CreateDefaultContext();
-    auto other_output = other_dut.AllocateOutput(*other_context);
-    auto other_derivatives = other_dut.AllocateTimeDerivatives();
-
-    other_context->FixInputPort(dut_->lane_input().get_index(),
-                                systems::AbstractValue::Make(*lane_direction_));
-    auto ego_pose = std::make_unique<PoseVector<AutoDiffXd>>();
-    other_context->FixInputPort(dut_->ego_pose_input().get_index(),
-                                std::move(ego_pose));
-
-    other_dut.CalcOutput(*other_context, other_output.get());
-  }));
 }
 
 TEST_F(PurePursuitControllerTest, Output) {

--- a/drake/automotive/test/pure_pursuit_test.cc
+++ b/drake/automotive/test/pure_pursuit_test.cc
@@ -3,7 +3,6 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
-#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace automotive {
@@ -16,27 +15,26 @@ class PurePursuitTest : public ::testing::Test {
   void SetUp() override {
     // Create a straight road with one lane.
     road_.reset(new maliput::dragway::RoadGeometry(
-        maliput::api::RoadGeometryId("Single-Lane Dragway"), 1 /* num_lanes */,
-        100 /* length */, 4. /* lane_width */, 0. /* shoulder_width */,
+        maliput::api::RoadGeometryId("Single-Lane Dragway"),
+        1 /* num_lanes */, 100 /* length */, 4. /* lane_width */,
+        0. /* shoulder_width */,
         5. /* maximum_height */,
         std::numeric_limits<double>::epsilon() /* linear_tolerance */,
         std::numeric_limits<double>::epsilon() /* angular_tolerance */));
   }
 
   const PurePursuitParams<double> pp_params_{};
-  const PurePursuitParams<AutoDiffXd> pp_params_ad_{};
   const SimpleCarParams<double> car_params_{};
-  const SimpleCarParams<AutoDiffXd> car_params_ad_{};
   std::unique_ptr<maliput::api::RoadGeometry> road_;
 };
 
 TEST_F(PurePursuitTest, Evaluate) {
+  systems::rendering::PoseVector<double> ego_pose;
   const maliput::api::Lane* const lane =
       road_->junction(0)->segment(0)->lane(0);
 
   // Set the ego car's pose to be all zeros, and facing parallel to the track in
-  // the positive-s direction.
-  systems::rendering::PoseVector<double> ego_pose;
+  // the positive-s direction..
   ego_pose.set_translation(
       Eigen::Translation3d(0. /* s */, 0. /* r */, 0. /* h */));
   ego_pose.set_rotation(Eigen::Quaternion<double>(0. /* w */, 0. /* x */,
@@ -97,61 +95,6 @@ TEST_F(PurePursuitTest, Evaluate) {
   // Expect the steering angle to be between zero and 90-degrees.
   EXPECT_GT(0., result);
   EXPECT_LT(-M_PI_2, result);
-}
-
-TEST_F(PurePursuitTest, EvaluateAutoDiff) {
-  const maliput::api::Lane* const lane =
-      road_->junction(0)->segment(0)->lane(0);
-
-  // Set the ego car's pose to be all zeros, and facing parallel to the track in
-  // the positive-s direction.
-  // Derivatives are set such that ∂s/∂s = 1, ∂r/∂s = 0., ∂h/∂s = 0, etc.
-  AutoDiffXd s(0., Vector3<double>(1., 0., 0.));
-  AutoDiffXd r(0., Vector3<double>(0., 1., 0.));
-  AutoDiffXd h(0., Vector3<double>(0., 0., 1.));
-  AutoDiffXd ad_zero(0., Vector3<double>(0., 0., 0.));
-  systems::rendering::PoseVector<AutoDiffXd> ego_pose;
-  ego_pose.set_translation(Translation3<AutoDiffXd>(s, r, h));
-  ego_pose.set_rotation(Eigen::Quaternion<AutoDiffXd>(
-      ad_zero /* w */, ad_zero /* x */, ad_zero /* y */, ad_zero /* z */));
-
-  AutoDiffXd result = PurePursuit<AutoDiffXd>::Evaluate(
-      pp_params_ad_, car_params_ad_, {lane, true /* with_s */}, ego_pose);
-
-  // Expect the steering angle to be zero and its derivative to be negatively
-  // related to changes in r, but insensitive to changes in s and h.
-  EXPECT_EQ(0., result.value());
-  EXPECT_EQ(0., result.derivatives()(0));  // ∂(steering_angle)/∂s
-  EXPECT_GT(0., result.derivatives()(1));  // ∂(steering_angle)/∂r
-  EXPECT_EQ(0., result.derivatives()(2));  // ∂(steering_angle)/∂h
-
-  // Set the ego car to the left of the centerline, and facing parallel to the
-  // track in the positive-s direction.
-  r.value() = 1.;
-  ego_pose.set_translation(Translation3<AutoDiffXd>(s, r, h));
-  result = PurePursuit<AutoDiffXd>::Evaluate(
-      pp_params_ad_, car_params_ad_, {lane, true /* with_s */}, ego_pose);
-
-  // Expect the steering angle to be negative and its derivative to be
-  // negatively related to changes in r, but insensitive to changes in s and h.
-  EXPECT_GT(0., result.value());
-  EXPECT_EQ(0., result.derivatives()(0));  // ∂(steering_angle)/∂s
-  EXPECT_GT(0., result.derivatives()(1));  // ∂(steering_angle)/∂r
-  EXPECT_EQ(0., result.derivatives()(2));  // ∂(steering_angle)/∂h
-
-  // Set the ego car to the right of the centerline, and facing parallel to the
-  // track in the positive-s direction.
-  r.value() = -1.;
-  ego_pose.set_translation(Translation3<AutoDiffXd>(s, r, h));
-  result = PurePursuit<AutoDiffXd>::Evaluate(
-      pp_params_ad_, car_params_ad_, {lane, true /* with_s */}, ego_pose);
-
-  // Expect the steering angle to be positive and its derivative to be
-  // negatively related to changes in r, but insensitive to changes in s and h.
-  EXPECT_LT(0., result.value());
-  EXPECT_EQ(0., result.derivatives()(0));  // ∂(steering_angle)/∂s
-  EXPECT_GT(0., result.derivatives()(1));  // ∂(steering_angle)/∂r
-  EXPECT_EQ(0., result.derivatives()(2));  // ∂(steering_angle)/∂h
 }
 
 TEST_F(PurePursuitTest, ComputeGoalPoint) {


### PR DESCRIPTION
Dear @jadecastro ,

The on-call build cop, @BetsyMcPhail, believes that your PR #7309  may have
broken one or more of Drake's continuous integration builds [1,2]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-elcapitan-clang-bazel-continuous-release/101/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [3].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Continuous Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/
[2] CI Nightly Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/
[3] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7353)
<!-- Reviewable:end -->
