### PR TITLE
Add hash_append and use it everywhere

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,8 +97,8 @@ github_archive(
 github_archive(
     name = "styleguide",
     repository = "RobotLocomotion/styleguide",
-    commit = "8d38c5909a5ab38824d7f4566b3f3c6ae4557826",
-    sha256 = "09baa2280a63b9d2efe5c07d08f4674339b5b2a0424f71c429c33ac1783a4cd8",  # noqa
+    commit = "5777e74b82e46f29ffbf41ffed0209d9d5f2ccb5",
+    sha256 = "434789debb7a81872302af5958a0b25bf5e3cafb7e666ed7a4218938bd8cc874",  # noqa
     build_file = "tools/workspace/styleguide/styleguide.BUILD.bazel",  # noqa
 )
 

--- a/automotive/maliput/api/test/type_specific_identifier_test.cc
+++ b/automotive/maliput/api/test/type_specific_identifier_test.cc
@@ -59,16 +59,6 @@ GTEST_TEST(TypeSpecificIdentifierTest, CopyingAndAssignment) {
 }
 
 
-GTEST_TEST(TypeSpecificIdentifierTest, HashProhibitionExceptionCanary) {
-  // Since our specialization of std::hash is only allowed because we promised
-  // to call only std::hash<std::string>, attempt to catch a violation of
-  // that promise.
-  const std::string kSomeString("some string");
-  const CId dut(kSomeString);
-  EXPECT_EQ(std::hash<CId>()(dut), std::hash<std::string>()(kSomeString));
-}
-
-
 // Test usage with ordered/unordered sets.
 template <typename T>
 class TypeSpecificIdentifierSetTest : public ::testing::Test {};

--- a/automotive/maliput/api/type_specific_identifier.h
+++ b/automotive/maliput/api/type_specific_identifier.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_throw.h"
+#include "drake/common/hash.h"
 
 namespace drake {
 namespace maliput {
@@ -64,6 +65,14 @@ class TypeSpecificIdentifier {
     return !(*this == rhs);
   }
 
+  /// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const TypeSpecificIdentifier& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.string_);
+  }
+
  private:
   std::string string_;
 };
@@ -77,24 +86,8 @@ namespace std {
 
 /// Specialization of std::hash for TypeSpecificIdentifier<T>
 template <typename T>
-struct hash<drake::maliput::api::TypeSpecificIdentifier<T>> {
-  typedef std::size_t result_type;
-  typedef drake::maliput::api::TypeSpecificIdentifier<T> argument_type;
-
-  result_type operator()(const argument_type& id) const {
-    // NB: Per the GSG, our current style guide strictly prohibits
-    // creating new specializations of std::hash on the grounds that
-    // it is in general difficult to do that correctly.  However,
-    // since this implementation is merely a wrapper around
-    // std::string with stricter type checking and since it merely
-    // invokes a C++ standard hash approved by the style guide, it has
-    // been granted an exception.  If this implementation changes, the
-    // exception must be reevaluated.  Conversely, if the (arguably
-    // maladaptive) prohibition is removed from our style guide, this
-    // notice can go away.
-    return hash<string>{}(id.string());
-  }
-};
+struct hash<drake::maliput::api::TypeSpecificIdentifier<T>>
+    : public drake::DefaultHash {};
 
 /// Specialization of std::less for TypeSpecificIdentifier<T> providing a
 /// strict weak ordering over TypeSpecificIdentifier<T> suitable for use with

--- a/automotive/maliput/utility/generate_obj.cc
+++ b/automotive/maliput/utility/generate_obj.cc
@@ -18,6 +18,7 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/hash.h"
 
 namespace drake {
 namespace maliput {
@@ -68,14 +69,7 @@ class UniqueIndexer {
 class GeoVertex {
  public:
   // A hasher operation suitable for std::unordered_map.
-  struct Hash {
-    size_t operator()(const GeoVertex& gv) const {
-      const size_t hx(std::hash<double>()(gv.v().x()));
-      const size_t hy(std::hash<double>()(gv.v().y()));
-      const size_t hz(std::hash<double>()(gv.v().z()));
-      return hx ^ (hy << 1) ^ (hz << 2);
-    }
-  };
+  using Hash = drake::DefaultHash;
 
   // An equivalence operation suitable for std::unordered_map.
   struct Equiv {
@@ -90,6 +84,16 @@ class GeoVertex {
 
   const api::GeoPosition& v() const { return v_; }
 
+  /// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const GeoVertex& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.v_.x());
+    hash_append(hasher, item.v_.y());
+    hash_append(hasher, item.v_.z());
+  }
+
  private:
   api::GeoPosition v_;
 };
@@ -99,14 +103,7 @@ class GeoVertex {
 class GeoNormal {
  public:
   // A hasher operation suitable for std::unordered_map.
-  struct Hash {
-    size_t operator()(const GeoNormal& gn) const {
-      const size_t hx(std::hash<double>()(gn.n().x()));
-      const size_t hy(std::hash<double>()(gn.n().y()));
-      const size_t hz(std::hash<double>()(gn.n().z()));
-      return hx ^ (hy << 1) ^ (hz << 2);
-    }
-  };
+  using Hash = drake::DefaultHash;
 
   // An equivalence operation suitable for std::unordered_map.
   struct Equiv {
@@ -120,6 +117,16 @@ class GeoNormal {
   explicit GeoNormal(const api::GeoPosition& n) : n_(n) {}
 
   const api::GeoPosition& n() const { return n_; }
+
+  /// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const GeoNormal& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.n_.x());
+    hash_append(hasher, item.n_.y());
+    hash_append(hasher, item.n_.z());
+  }
 
  private:
   api::GeoPosition n_;

--- a/common/doxygen_cxx.h
+++ b/common/doxygen_cxx.h
@@ -1,0 +1,3 @@
+/// @defgroup cxx C++ support features
+/// @{
+/// @}

--- a/common/hash.h
+++ b/common/hash.h
@@ -1,77 +1,245 @@
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 #include <functional>
 #include <iostream>
 #include <map>
 #include <set>
+#include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+/// @defgroup hash_append hash_append generic hashing
+/// @{
+/// @ingroup cxx
+/// @brief Drake uses the hash_append pattern as described by N3980.
+///
+/// For a full treatment of the hash_append pattern, refer to:
+/// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3980.html
+///
+/// <h3>Providing hash_append support within a class</h3>
+///
+/// Drake types may implement a `hash_append` function.
+/// The function appends every hash-relevant member field into the hasher:
+/// @code
+/// class MyValue {
+///  public:
+///   ...
+///   /// Implements the @ref hash_append concept.
+///   template <class HashAlgorithm>
+///   friend void hash_append(
+///       HashAlgorithm& hasher, const MyValue& item) noexcept {
+///     using drake::hash_append;
+///     hash_append(hasher, item.my_data_);
+///   }
+///   ...
+///  private:
+///   std::string my_data_;
+/// };
+/// @endcode
+///
+/// Checklist for reviewing a `hash_append` implementation:
+/// - The function cites `@ref hash_append` in its Doxygen comment.
+/// - The function is marked `noexcept`.
+///
+/// <h3>Using hashable types</h3>
+///
+/// Types that implement this pattern may be used in unordered collections:
+/// @code
+/// std::unordered_set<MyValue, drake::DefaultHash> foo;
+/// @endcode
+///
+/// Some Drake types may also choose to specialize `std::hash<MyValue>` to use
+/// `DefaultHash`, so that the second template argument to `std::unordered_set`
+/// can be omitted.  For example, Drake's `symbolic::Expression` header says:
+/// @code
+/// namespace std {
+/// struct hash<drake::symbolic::Expression> : public drake::DefaultHash {};
+/// }  // namespace std
+/// @endcode
+/// so that users are able to simply write:
+/// @code
+/// std::unordered_set<drake::symbolic::Expression> foo;
+/// @endcode
+///
+/// @}
+
 namespace drake {
 
-/** Combines a given hash value @p seed and a hash of parameter @p v. */
-template <class T>
-size_t hash_combine(size_t seed, const T& v);
-
-template <class T, class... Rest>
-size_t hash_combine(size_t seed, const T& v, Rest... rest) {
-  return hash_combine(hash_combine(seed, v), rest...);
+/// Provides @ref hash_append for integral constants.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_integral<T>::value>
+hash_append(
+    HashAlgorithm& hasher, const T& item) noexcept {
+  hasher(std::addressof(item), sizeof(item));
 }
 
-/** Computes the combined hash value of the elements of an iterator range. */
-template <typename It>
-size_t hash_range(It first, It last) {
-  size_t seed{};
-  for (; first != last; ++first) {
-    seed = hash_combine(seed, *first);
-  }
-  return seed;
+/// Provides @ref hash_append for enumerations.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_enum<T>::value>
+hash_append(
+    HashAlgorithm& hasher, const T& item) noexcept {
+  hasher(std::addressof(item), sizeof(item));
 }
 
-/** Computes the hash value of @p v using std::hash. */
-template <class T>
-struct hash_value {
-  size_t operator()(const T& v) { return std::hash<T>{}(v); }
-};
-
-/** Computes the hash value of a pair @p p. */
-template <class T1, class T2>
-struct hash_value<std::pair<T1, T2>> {
-  size_t operator()(const std::pair<T1, T2>& p) {
-    return hash_combine(0, p.first, p.second);
+/// Provides @ref hash_append for floating point values.
+template <class HashAlgorithm, class T>
+std::enable_if_t<std::is_floating_point<T>::value>
+hash_append(
+    HashAlgorithm& hasher, const T& item) noexcept {
+  // Hashing a NaN makes no sense, since they cannot compare as equal.
+  DRAKE_ASSERT(!std::isnan(item));
+  // +0.0 and -0.0 are equal, so must hash identically.
+  if (item == 0.0) {
+    const T zero{0.0};
+    hasher(std::addressof(zero), sizeof(zero));
+  } else {
+    hasher(std::addressof(item), sizeof(item));
   }
-};
-
-/** Computes the hash value of a vector @p vec. */
-template <class T>
-struct hash_value<std::vector<T>> {
-  size_t operator()(const std::vector<T>& vec) {
-    return hash_range(vec.begin(), vec.end());
-  }
-};
-
-/** Computes the hash value of a set @p s. */
-template <class T>
-struct hash_value<std::set<T>> {
-  size_t operator()(const std::set<T>& s) {
-    return hash_range(s.begin(), s.end());
-  }
-};
-
-/** Computes the hash value of a map @p map. */
-template <class T1, class T2>
-struct hash_value<std::map<T1, T2>> {
-  size_t operator()(const std::map<T1, T2>& map) {
-    return hash_range(map.begin(), map.end());
-  }
-};
-
-/** Combines two hash values into one. The following code is public domain
- *  according to http://www.burtleburtle.net/bob/hash/doobs.html. */
-template <class T>
-inline size_t hash_combine(size_t seed, const T& v) {
-  seed ^= hash_value<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  return seed;
 }
+
+/// Provides @ref hash_append for std::string.
+/// (Technically, any string based on `CharT = char`.)
+template <class HashAlgorithm, class Traits, class Allocator>
+void hash_append(
+    HashAlgorithm& hasher,
+    const std::basic_string<char, Traits, Allocator>& item) noexcept {
+  using drake::hash_append;
+  hasher(item.data(), item.size());
+  // All collection types must send their size, after their contents.
+  // See the #hash_append_vector anchor in N3980.
+  hash_append(hasher, item.size());
+}
+
+/// Provides @ref hash_append for std::pair.
+template <class HashAlgorithm, class T1, class T2>
+void hash_append(
+    HashAlgorithm& hasher, const std::pair<T1, T2>& item) noexcept {
+  using drake::hash_append;
+  hash_append(hasher, item.first);
+  hash_append(hasher, item.second);
+}
+
+/// Provides @ref hash_append for a range, as given by two iterators.
+template <class HashAlgorithm, class Iter>
+void hash_append_range(
+    // NOLINTNEXTLINE(runtime/references) Per hash_append convention.
+    HashAlgorithm& hasher, Iter begin, Iter end) noexcept {
+  using drake::hash_append;
+  size_t count{0};
+  for (Iter iter = begin; iter != end; ++iter, ++count) {
+    hash_append(hasher, *iter);
+  }
+  // All collection types must send their size, after their contents.
+  // See the #hash_append_vector anchor in N3980.
+  hash_append(hasher, count);
+}
+
+/// Provides @ref hash_append for std::map.
+///
+/// Note that there is no `hash_append` overload for `std::unordered_map`, and
+/// such an overload must never appear.  See n3980.html#unordered for details.
+template <
+  class HashAlgorithm,
+  class T1,
+  class T2,
+  class Compare,
+  class Allocator>
+void hash_append(
+    HashAlgorithm& hasher,
+    const std::map<T1, T2, Compare, Allocator>& item) noexcept {
+  return hash_append_range(hasher, item.begin(), item.end());
+};
+
+/// Provides @ref hash_append for std::set.
+///
+/// Note that there is no `hash_append` overload for `std::unordered_set`, and
+/// such an overload must never appear.  See n3980.html#unordered for details.
+template <
+  class HashAlgorithm,
+  class Key,
+  class Compare,
+  class Allocator>
+void hash_append(
+    HashAlgorithm& hasher,
+    const std::set<Key, Compare, Allocator>& item) noexcept {
+  return hash_append_range(hasher, item.begin(), item.end());
+};
+
+/// A hashing functor, somewhat like `std::hash`.  Given an item of type @p T,
+/// applies @ref hash_append to it, directing the bytes to append into the
+/// given @p HashAlgorithm, and then finally returning the algorithm's result.
+template <class HashAlgorithm>
+struct uhash {
+  using result_type = typename HashAlgorithm::result_type;
+
+  template <class T>
+  result_type operator()(const T& item) const noexcept {
+    HashAlgorithm hasher;
+    using drake::hash_append;
+    hash_append(hasher, item);
+    return static_cast<result_type>(hasher);
+  }
+};
+
+namespace detail {
+/// The FNV1a hash algorithm, used for @ref hash_append.
+/// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+class FNV1aHasher {
+ public:
+  using result_type = size_t;
+
+  void operator()(const void* data, size_t length) noexcept {
+    const uint8_t* const begin = static_cast<const uint8_t*>(data);
+    const uint8_t* const end = begin + length;
+    for (const uint8_t* iter = begin; iter < end; ++iter) {
+      hash_ = (hash_ ^ *iter) * 1099511628211u;
+    }
+  }
+
+  explicit operator size_t() noexcept {
+    return hash_;
+  }
+
+ private:
+  static_assert(sizeof(result_type) == (64 / 8), "We require a 64-bit size_t");
+  result_type hash_{0xcbf29ce484222325u};
+};
+}  // namespace detail
+
+/// The default HashAlgorithm concept implementation across Drake.  This is
+/// guaranteed to have a result_type of size_t to be compatible with std::hash.
+using DefaultHasher = detail::FNV1aHasher;
+
+/// The default hashing functor, akin to std::hash.
+using DefaultHash = drake::uhash<DefaultHasher>;
+
+/// An adapter that forwards the HashAlgorithm::operator(data, length) function
+/// concept into a runtime-provided std::function of the same signature.  This
+/// is useful for passing a concrete HashAlgorithm implementation through into
+/// non-templated code, such as with an Impl or Cell pattern.
+struct DelegatingHasher {
+  /// A std::function whose signature matches HashAlgorithm::operator().
+  using Func = std::function<void(const void*, size_t)>;
+
+  /// Create a delegating hasher that calls the given @p func.
+  explicit DelegatingHasher(Func func) : func_(std::move(func)) {
+    // In order for operator() to be noexcept, it must have a non-empty func_.
+    DRAKE_THROW_UNLESS(static_cast<bool>(func_));
+  }
+
+  /// Append [data, data + length) bytes into the wrapped algorithm.
+  void operator()(const void* data, size_t length) noexcept {
+    func_(data, length);
+  }
+
+ private:
+  const Func func_;
+};
+
 }  // namespace drake

--- a/common/symbolic_environment.h
+++ b/common/symbolic_environment.h
@@ -59,9 +59,7 @@ class Environment {
 
   typedef Variable key_type;
   typedef double mapped_type;
-  typedef
-      typename std::unordered_map<key_type, mapped_type, hash_value<key_type>>
-          map;
+  typedef typename std::unordered_map<key_type, mapped_type> map;
   /** std::pair<key_type, mapped_type> */
   typedef typename map::value_type value_type;
   typedef typename map::iterator iterator;

--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <Eigen/Core>
@@ -76,9 +77,11 @@ ExpressionKind Expression::get_kind() const {
   DRAKE_ASSERT(ptr_ != nullptr);
   return ptr_->get_kind();
 }
-size_t Expression::get_hash() const {
-  DRAKE_ASSERT(ptr_ != nullptr);
-  return ptr_->get_hash();
+
+void Expression::HashAppend(DelegatingHasher* hasher) const {
+  using drake::hash_append;
+  hash_append(*hasher, get_kind());
+  ptr_->HashAppendDetail(hasher);
 }
 
 Expression Expression::Zero() {
@@ -121,11 +124,7 @@ bool Expression::EqualTo(const Expression& e) const {
   if (get_kind() != e.get_kind()) {
     return false;
   }
-  if (get_hash() != e.get_hash()) {
-    return false;
-  }
-  // Same kind/hash, but it could be the result of hash collision,
-  // check structural equality.
+  // Check structural equality.
   return ptr_->EqualTo(*(e.ptr_));
 }
 

--- a/common/symbolic_formula.cc
+++ b/common/symbolic_formula.cc
@@ -34,9 +34,10 @@ FormulaKind Formula::get_kind() const {
   return ptr_->get_kind();
 }
 
-size_t Formula::get_hash() const {
-  DRAKE_ASSERT(ptr_ != nullptr);
-  return ptr_->get_hash();
+void Formula::HashAppend(DelegatingHasher* hasher) const {
+  using drake::hash_append;
+  hash_append(*hasher, get_kind());
+  ptr_->HashAppendDetail(hasher);
 }
 
 Variables Formula::GetFreeVariables() const {
@@ -52,9 +53,6 @@ bool Formula::EqualTo(const Formula& f) const {
     return true;
   }
   if (get_kind() != f.get_kind()) {
-    return false;
-  }
-  if (get_hash() != f.get_hash()) {
     return false;
   }
   // Same kind/hash, but it could be the result of hash collision,

--- a/common/symbolic_monomial.cc
+++ b/common/symbolic_monomial.cc
@@ -115,14 +115,6 @@ int Monomial::degree(const Variable& v) const {
   }
 }
 
-size_t Monomial::GetHash() const {
-  // To get a hash value for a Monomial, we re-use the hash value for
-  // powers_. This is suitable because powers_ is the only independent
-  // data-member of Monomial class while another data-member, total_degree_ is
-  // determined by a given powers_.
-  return hash_value<map<Variable, int>>{}(powers_);
-}
-
 Variables Monomial::GetVariables() const {
   Variables vars{};
   for (const pair<Variable, int> p : powers_) {

--- a/common/symbolic_monomial.h
+++ b/common/symbolic_monomial.h
@@ -53,9 +53,6 @@ class Monomial {
   /** Returns the total degree of this Monomial. */
   int total_degree() const { return total_degree_; }
 
-  /** Returns hash value. */
-  size_t GetHash() const;
-
   /** Returns the set of variables in this monomial. */
   Variables GetVariables() const;
 
@@ -105,6 +102,16 @@ class Monomial {
    */
   Monomial& pow_in_place(int p);
 
+  /** Implements the @ref hash_append concept. */
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const Monomial& item) noexcept {
+    using drake::hash_append;
+    // We do not send total_degree_ to the hasher, because it is already fully
+    // represented by powers_ -- it is just a cached tally of the exponents.
+    hash_append(hasher, item.powers_);
+  }
+
  private:
   int total_degree_{0};
   std::map<Variable, int> powers_;
@@ -121,14 +128,14 @@ Monomial operator*(Monomial m1, const Monomial& m2);
  */
 Monomial pow(Monomial m, int p);
 }  // namespace symbolic
-
-/** Computes the hash value of a Monomial. */
-template <>
-struct hash_value<symbolic::Monomial> {
-  size_t operator()(const symbolic::Monomial& m) const { return m.GetHash(); }
-};
-
 }  // namespace drake
+
+namespace std {
+/* Provides std::hash<drake::symbolic::Monomial>. */
+template <>
+struct hash<drake::symbolic::Monomial>
+    : public drake::DefaultHash {};
+}  // namespace std
 
 #if !defined(DRAKE_DOXYGEN_CXX)
 namespace Eigen {

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -11,7 +11,6 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/hash.h"
 #include "drake/common/symbolic.h"
 
 namespace drake {
@@ -29,8 +28,7 @@ namespace symbolic {
 /// we need this information to perform arithmetic operations over Polynomials.
 class Polynomial {
  public:
-  using MapType =
-      std::unordered_map<Monomial, Expression, hash_value<Monomial>>;
+  using MapType = std::unordered_map<Monomial, Expression>;
 
   /// Constructs a zero polynomial.
   Polynomial() = default;

--- a/common/symbolic_variables.cc
+++ b/common/symbolic_variables.cc
@@ -32,10 +32,6 @@ Variables::Variables(initializer_list<Variable> init) : vars_(init) {}
 Variables::Variables(const Eigen::Ref<const VectorX<Variable>>& init)
     : vars_{init.data(), init.data() + init.size()} {}
 
-size_t Variables::get_hash() const {
-  return hash_value<set<Variable>>{}(vars_);
-}
-
 string Variables::to_string() const {
   ostringstream oss;
   oss << *this;

--- a/common/symbolic_variables.h
+++ b/common/symbolic_variables.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/hash.h"
 #include "drake/common/symbolic.h"
 
 namespace drake {
@@ -47,9 +48,6 @@ class Variables {
   /** Constructs from an Eigen vector of variables. */
   explicit Variables(const Eigen::Ref<const VectorX<Variable>>& init);
 
-  /** Returns hash value. */
-  size_t get_hash() const;
-
   /** Returns the number of elements. */
   size_type size() const { return vars_.size(); }
 
@@ -58,6 +56,14 @@ class Variables {
 
   /** Returns string representation of Variables. */
   std::string to_string() const;
+
+  /** Implements the @ref hash_append concept. */
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const Variables& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.vars_);
+  }
 
   /** Returns an iterator to the beginning. */
   iterator begin() { return vars_.begin(); }
@@ -164,13 +170,10 @@ Variables operator-(Variables vars, const Variable& var);
 Variables intersect(const Variables& vars1, const Variables& vars2);
 
 }  // namespace symbolic
-
-/** Computes the hash value of a symbolic variables. */
-template <>
-struct hash_value<symbolic::Variables> {
-  size_t operator()(const symbolic::Variables& vars) const {
-    return vars.get_hash();
-  }
-};
-
 }  // namespace drake
+
+namespace std {
+/* Provides std::hash<drake::symbolic::Variables>. */
+template <> struct hash<drake::symbolic::Variables>
+    : public drake::DefaultHash {};
+}  // namespace std

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -44,6 +44,11 @@ using test::ExprLess;
 using test::ExprNotEqual;
 using test::ExprNotLess;
 
+template <typename T>
+size_t get_std_hash(const T& item) {
+  return std::hash<T>{}(item);
+}
+
 // Checks if a given 'expressions' is ordered by Expression::Less.
 void CheckOrdering(const vector<Expression>& expressions) {
   for (size_t i{0}; i < expressions.size(); ++i) {
@@ -832,9 +837,9 @@ TEST_F(SymbolicExpressionTest, StaticConstant) {
 TEST_F(SymbolicExpressionTest, Hash) {
   Expression x{var_x_};
   const Expression x_prime(x);
-  EXPECT_EQ(x.get_hash(), x_prime.get_hash());
+  EXPECT_EQ(get_std_hash(x), get_std_hash(x_prime));
   x++;
-  EXPECT_NE(x.get_hash(), x_prime.get_hash());
+  EXPECT_NE(get_std_hash(x), get_std_hash(x_prime));
 }
 
 TEST_F(SymbolicExpressionTest, HashBinary) {
@@ -852,7 +857,7 @@ TEST_F(SymbolicExpressionTest, HashBinary) {
   unordered_set<size_t> hash_set;
   const vector<Expression> exprs{e1, e2, e3, e4, e5, e6, e7, e8};
   for (auto const& e : exprs) {
-    hash_set.insert(e.get_hash());
+    hash_set.insert(get_std_hash(e));
   }
   EXPECT_EQ(hash_set.size(), exprs.size());
 }
@@ -880,7 +885,7 @@ TEST_F(SymbolicExpressionTest, HashUnary) {
   const vector<Expression> exprs{e0, e1, e2,  e3,  e4,  e5,  e6, e7,
                                  e8, e9, e10, e11, e12, e13, e14};
   for (auto const& e : exprs) {
-    hash_set.insert(e.get_hash());
+    hash_set.insert(get_std_hash(e));
   }
   EXPECT_EQ(hash_set.size(), exprs.size());
 }
@@ -1198,7 +1203,7 @@ TEST_F(SymbolicExpressionTest, Div4) {
 // This test checks whether symbolic::Expression is compatible with
 // std::unordered_set.
 GTEST_TEST(ExpressionTest, CompatibleWithUnorderedSet) {
-  unordered_set<Expression, hash_value<Expression>> uset;
+  unordered_set<Expression> uset;
   uset.emplace(Expression{Variable{"a"}});
   uset.emplace(Expression{Variable{"b"}});
 }
@@ -1206,7 +1211,7 @@ GTEST_TEST(ExpressionTest, CompatibleWithUnorderedSet) {
 // This test checks whether symbolic::Expression is compatible with
 // std::unordered_map.
 GTEST_TEST(ExpressionTest, CompatibleWithUnorderedMap) {
-  unordered_map<Expression, Expression, hash_value<Expression>> umap;
+  unordered_map<Expression, Expression> umap;
   umap.emplace(Expression{Variable{"a"}}, Expression{Variable{"b"}});
 }
 

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -1220,7 +1220,7 @@ TEST_F(SymbolicFormulaTest, DrakeAssert) {
 // This test checks whether symbolic::Formula is compatible with
 // std::unordered_set.
 GTEST_TEST(FormulaTest, CompatibleWithUnorderedSet) {
-  unordered_set<Formula, hash_value<Formula>> uset;
+  unordered_set<Formula> uset;
   uset.emplace(Formula::True());
   uset.emplace(Formula::True());
   uset.emplace(Formula::False());
@@ -1230,7 +1230,7 @@ GTEST_TEST(FormulaTest, CompatibleWithUnorderedSet) {
 // This test checks whether symbolic::Formula is compatible with
 // std::unordered_map.
 GTEST_TEST(FormulaTest, CompatibleWithUnorderedMap) {
-  unordered_map<Formula, Formula, hash_value<Formula>> umap;
+  unordered_map<Formula, Formula> umap;
   umap.emplace(Formula::True(), Formula::False());
   umap.emplace(Formula::False(), Formula::True());
 }

--- a/common/test/symbolic_monomial_test.cc
+++ b/common/test/symbolic_monomial_test.cc
@@ -401,7 +401,7 @@ TEST_F(MonomialTest, MonomialBasis_x_y_z_w_3) {
 // This test shows that we can have a std::unordered_map whose key is of
 // Monomial.
 TEST_F(MonomialTest, UnorderedMapOfMonomial) {
-  unordered_map<Monomial, double, hash_value<Monomial>> monomial_to_coeff_map;
+  unordered_map<Monomial, double> monomial_to_coeff_map;
   Monomial x_3{var_x_, 3};
   Monomial y_5{var_y_, 5};
   // Add 2 * x^3

--- a/common/test/symbolic_variable_test.cc
+++ b/common/test/symbolic_variable_test.cc
@@ -30,6 +30,11 @@ using test::VarLess;
 using test::VarNotEqual;
 using test::VarNotLess;
 
+template <typename T>
+size_t get_std_hash(const T& item) {
+  return std::hash<T>{}(item);
+}
+
 // Provides common variables that are used by the following tests.
 class VariableTest : public ::testing::Test {
  protected:
@@ -64,13 +69,13 @@ TEST_F(VariableTest, GetName) {
 TEST_F(VariableTest, MoveCopyPreserveId) {
   Variable x{"x"};
   const size_t x_id{x.get_id()};
-  const size_t x_hash{x.get_hash()};
+  const size_t x_hash{get_std_hash(x)};
   const Variable x_copied{x};
   const Variable x_moved{move(x)};
   EXPECT_EQ(x_id, x_copied.get_id());
-  EXPECT_EQ(x_hash, x_copied.get_hash());
+  EXPECT_EQ(x_hash, get_std_hash(x_copied));
   EXPECT_EQ(x_id, x_moved.get_id());
-  EXPECT_EQ(x_hash, x_moved.get_hash());
+  EXPECT_EQ(x_hash, get_std_hash(x_moved));
 }
 
 TEST_F(VariableTest, Less) {
@@ -138,14 +143,14 @@ TEST_F(VariableTest, EqualityCheck) {
 
 // This test checks whether Variable is compatible with std::unordered_set.
 TEST_F(VariableTest, CompatibleWithUnorderedSet) {
-  unordered_set<Variable, hash_value<Variable>> uset;
+  unordered_set<Variable> uset;
   uset.emplace(x_);
   uset.emplace(y_);
 }
 
 // This test checks whether Variable is compatible with std::unordered_map.
 TEST_F(VariableTest, CompatibleWithUnorderedMap) {
-  unordered_map<Variable, Variable, hash_value<Variable>> umap;
+  unordered_map<Variable, Variable> umap;
   umap.emplace(x_, y_);
 }
 

--- a/common/test/symbolic_variables_test.cc
+++ b/common/test/symbolic_variables_test.cc
@@ -7,6 +7,11 @@ namespace drake {
 namespace symbolic {
 namespace {
 
+template <typename T>
+size_t get_std_hash(const T& item) {
+  return std::hash<T>{}(item);
+}
+
 // Provides common variables that are used by the following tests.
 class VariablesTest : public ::testing::Test {
  protected:
@@ -37,7 +42,7 @@ TEST_F(VariablesTest, ConstructFromVariableVector) {
 TEST_F(VariablesTest, HashEq) {
   const Variables vars1{x_, y_, z_};
   const Variables vars2{z_, y_, x_};
-  EXPECT_EQ(vars1.get_hash(), vars2.get_hash());
+  EXPECT_EQ(get_std_hash(vars1), get_std_hash(vars2));
   EXPECT_EQ(vars1, vars2);
 }
 

--- a/systems/framework/system_scalar_converter.cc
+++ b/systems/framework/system_scalar_converter.cc
@@ -14,7 +14,11 @@ SystemScalarConverter::Key::Key(
     : pair<type_index, type_index>(t_info, u_info) {}
 
 size_t SystemScalarConverter::KeyHasher::operator()(const Key& key) const {
-  return hash_combine(size_t{}, key.first, key.second);
+  drake::DefaultHasher hasher;
+  using drake::hash_append;
+  hash_append(hasher, std::hash<std::type_index>{}(key.first));
+  hash_append(hasher, std::hash<std::type_index>{}(key.second));
+  return static_cast<size_t>(hasher);
 }
 
 SystemScalarConverter::SystemScalarConverter() = default;

--- a/systems/sensors/color_palette.h
+++ b/systems/sensors/color_palette.h
@@ -6,6 +6,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
 
 namespace drake {
 namespace systems {
@@ -23,7 +24,30 @@ struct Color {
   bool operator==(const Color<T>& other) const {
     return this->r == other.r && this->g == other.g && this->b == other.b;
   }
+
+  /// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher, const Color& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.r);
+    hash_append(hasher, item.g);
+    hash_append(hasher, item.b);
+  }
 };
+
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake
+
+namespace std {
+template <typename T>
+struct hash<drake::systems::sensors::Color<T>>
+    : public drake::DefaultHash {};
+}  // namespace std
+
+namespace drake {
+namespace systems {
+namespace sensors {
 
 /// Defines a color based on its three primary additive colors: red, green, and
 /// blue. Each of these primary additive colors are in the range of [0, 255].
@@ -32,13 +56,6 @@ using ColorI = Color<int>;
 /// Defines a color based on its three primary additive colors: red, green, and
 /// blue. Each of these primary additive colors are in the range of [0, 1].
 using ColorD = Color<double>;
-
-// Defines a hash function for unordered_map that takes Color as the key.
-struct ColorHash {
-  std::size_t operator()(const ColorI& key) const {
-    return std::hash<int>{}((key.r * 256 + key.g) * 256 + key.b);
-  }
-};
 
 /// Creates and holds a palette of colors for visualizing different objects in a
 /// scene (the intent is for a different color to be applied to each identified
@@ -153,7 +170,7 @@ class ColorPalette {
   const ColorI kTerrainColor{255, 229, 204};
   const ColorI kSkyColor{204, 229, 255};
   std::vector<ColorI> colors_;
-  std::unordered_map<ColorI, int, ColorHash> color_id_map_;
+  std::unordered_map<ColorI, int> color_id_map_;
 };
 
 }  // namespace sensors


### PR DESCRIPTION
Relates #6937.  Closes #7190.

This provides an implementation of object hashing (for use with the `std::unordered_foo` containers) based on Howard Hinnant's excellent work in [N3980](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3980.html), proposed for standardization.

The corresponding styleguide change is RobotLocomotion/styleguide#3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7357)
<!-- Reviewable:end -->
