### PR TITLE
Remove deprecated CI forwarders for documentation

### DIFF
--- a/drake/BUILD.bazel
+++ b/drake/BUILD.bazel
@@ -1,17 +1,10 @@
 # -*- python -*-
 
+# This almost-empty file exists to keep the `/drake` folder as its own Bazel
+# package, because it has traditionally been used as such in the past.
+
 package(default_visibility = ["//visibility:public"])
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
-
-# TODO(6996) This file is a compatibility shim; remove this as soon as CI no
-# longer needs it.
-genrule(
-    name = "deprecated_doc",
-    srcs = ["//doc:sphinx.zip"],
-    outs = ["doc/sphinx.zip"],
-    cmd = "cp $(location //doc:sphinx.zip) '$@'",
-    visibility = [],
-)
 
 add_lint_tests()

--- a/drake/doc/doxygen.py
+++ b/drake/doc/doxygen.py
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# TODO(6996) This file is a compatibility shim; remove this as soon as CI no
-# longer needs it.
-echo "WARNING: drake/doc/doxygen.py is deprecated; use doc/doxygen.py" 1>&2
-exec $(dirname "$0")/../../doc/doxygen.py "$@"


### PR DESCRIPTION
Relates #6996.  This completes the rename started in #7273, now that RobotLocomotion/drake-ci#85 has merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7370)
<!-- Reviewable:end -->
