### PR TITLE
Set an appropriate mac default for clang-format

### DIFF
--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -2,10 +2,14 @@
 """
 
 import os
+import sys
 
 
 def get_clang_format_path():
-    preferred = "/usr/bin/clang-format-3.9"
+    if sys.platform == "darwin":
+        preferred = "/usr/local/bin/clang-format"
+    else:
+        preferred = "/usr/bin/clang-format-3.9"
     if os.path.isfile(preferred):
         return preferred
     return "clang-format"


### PR DESCRIPTION
Repairs Macintosh-specific build failures from #7340.  Relates #6996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7373)
<!-- Reviewable:end -->
