### PR TITLE
Add version checks for Eigen for AutoDiff when using as installed library. Handle >=v3.3.3

### DIFF
--- a/drake/common/autodiff.h
+++ b/drake/common/autodiff.h
@@ -12,6 +12,9 @@
 #include <Eigen/Core>
 #include <unsupported/Eigen/AutoDiff>
 
+static_assert(EIGEN_VERSION_AT_LEAST(3, 3, 3),
+              "Drake requires Eigen >= v3.3.3.");
+
 // Do not alpha-sort the following block of hard-coded #includes, which is
 // protected by `clang-format on/off`.
 //

--- a/drake/common/eigen_autodiff_limits.h
+++ b/drake/common/eigen_autodiff_limits.h
@@ -6,12 +6,15 @@
 #endif
 
 #include <limits>
-// If you see a 'duplicate specialization' compiler error here, then Eigen must
-// have started providing this itself; conditionalize or remove Drake's own
-// specialization.
+
+// Eigen provides `numeric_limits<AutoDiffScalar<T>>` starting with v3.3.4.
+#if !EIGEN_VERSION_AT_LEAST(3, 3, 4)  // Eigen Version < v3.3.4
+
 namespace std {
 template <typename T>
-class numeric_limits<Eigen::AutoDiffScalar<T> >
-  : public numeric_limits<typename T::Scalar> {};
+class numeric_limits<Eigen::AutoDiffScalar<T>>
+    : public numeric_limits<typename T::Scalar> {};
 
 }  // namespace std
+
+#endif  // Eigen Version < v3.3.4


### PR DESCRIPTION
Per a suggestion from Sam Z, this provides a small sanity check for autodiff-related issues when using Drake as a CMake external, but inadvertently using a different Eigen version.

Tested this against [v3.3.2](https://github.com/EricCousineau-TRI/drake/commit/51a8540) (fails at `static_assert`) and [v3.3.4](https://github.com/EricCousineau-TRI/drake/commit/4be602e) (now works, rather than getting multiple definition errors).

NOTE: If the Eigen version is much newer than v3.3.3, then other compilation errors will most likely occur before the `static_assert` is encountered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7378)
<!-- Reviewable:end -->
