### PR TITLE
[Multilane] Fixes PR #7325.

### DIFF
--- a/drake/automotive/maliput/monolane/builder.h
+++ b/drake/automotive/maliput/monolane/builder.h
@@ -105,7 +105,7 @@ class EndpointZ {
 
   /// Returns an EndpointZ with reversed direction.
   EndpointZ reverse() const {
-    return EndpointZ(z_, -z_dot_, -theta_, -theta_dot_);
+    return EndpointZ(z_, -z_dot_, -theta_, theta_dot_);
   }
 
   double z() const { return z_; }

--- a/drake/automotive/maliput/multilane/builder.cc
+++ b/drake/automotive/maliput/multilane/builder.cc
@@ -36,10 +36,8 @@ const Connection* Builder::Connect(const std::string& id, int num_lanes,
                  start.xy().y() + (length * std::sin(start.xy().heading())),
                  start.xy().heading()),
       z_end);
-  const Connection::SegmentParameters segment_parameters {
-      num_lanes, r0, left_shoulder, right_shoulder};
-  connections_.push_back(std::make_unique<Connection>(id, start, end,
-                                                      segment_parameters));
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, end, num_lanes, r0, left_shoulder, right_shoulder));
   return connections_.back().get();
 }
 
@@ -52,19 +50,16 @@ const Connection* Builder::Connect(const std::string& id, int num_lanes,
   const double theta0 = alpha - std::copysign(M_PI / 2., arc.d_theta());
   const double theta1 = theta0 + arc.d_theta();
 
-  const Connection::ArcGeometry arc_geometry{
-      start.xy().x() - (arc.radius() * std::cos(theta0)),
-      start.xy().y() - (arc.radius() * std::sin(theta0)),
-      arc.radius(), arc.d_theta()};
-  const Endpoint end(EndpointXy(
-      arc_geometry.cx + (arc.radius() * std::cos(theta1)),
-      arc_geometry.cy + (arc.radius() * std::sin(theta1)),
-      alpha + arc.d_theta()),
-      z_end);
-  const Connection::SegmentParameters segment_parameters{
-      num_lanes, r0, left_shoulder, right_shoulder};
+  const double cx = start.xy().x() - (arc.radius() * std::cos(theta0));
+  const double cy = start.xy().y() - (arc.radius() * std::sin(theta0));
+  const Endpoint end(EndpointXy(cx + (arc.radius() * std::cos(theta1)),
+                                cy + (arc.radius() * std::sin(theta1)),
+                                alpha + arc.d_theta()),
+                     z_end);
+
   connections_.push_back(std::make_unique<Connection>(
-      id, start, end, segment_parameters, arc_geometry));
+      id, start, end, num_lanes, r0, left_shoulder, right_shoulder, cx, cy,
+      arc.radius(), arc.d_theta()));
   return connections_.back().get();
 }
 

--- a/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -16,6 +16,11 @@ namespace drake {
 namespace maliput {
 namespace multilane {
 
+// TODO(maddog-tri)  Test use of Endpoint::reverse() with non-zero theta and
+//                   theta_dot, checking that the orientation of the resulting
+//                   road surface is continuous, off the centerline, at the
+//                   branch-point where two connections connect
+
 GTEST_TEST(MultilaneBuilderTest, Fig8) {
   const double kLaneWidth = 4.;
   const double kLeftShoulder = 2.;

--- a/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -59,7 +59,7 @@ GTEST_TEST(EndpointZTest, Reverse) {
   const EndpointZ dut{1., 2., M_PI / 4., M_PI / 2.};
   const double kZeroTolerance{0.};
   EXPECT_TRUE(test::IsEndpointZClose(
-      dut.reverse(), {1., -2., M_PI / 4., -M_PI / 2.}, kZeroTolerance));
+      dut.reverse(), {1., -2., -M_PI / 4., M_PI / 2.}, kZeroTolerance));
 }
 
 // ArcOffset checks.
@@ -82,8 +82,6 @@ class MultilaneConnectionTest : public ::testing::Test {
   const int kNumLanes{3};
   const double kLeftShoulder{1.};
   const double kRightShoulder{1.5};
-  const Connection::SegmentParameters kSegmentParameters{
-      kNumLanes, kR0, kLeftShoulder, kRightShoulder};
   const EndpointZ kLowFlatZ{0., 0., 0., 0.};
   const double kHeading{-M_PI / 4.};
   const EndpointXy kStartXy{20., 30., kHeading};
@@ -99,8 +97,9 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
   const double kDTheta{M_PI / 2.};
   const Endpoint kEndEndpoint{{40., 30., kHeading + kDTheta}, kLowFlatZ};
 
-  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kSegmentParameters,
-                       {kCenterX, kCenterY, kRadius, kDTheta});
+  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kNumLanes, kR0,
+                       kLeftShoulder, kRightShoulder, kCenterX, kCenterY,
+                       kRadius, kDTheta);
   EXPECT_EQ(dut.type(), Connection::Type::kArc);
   EXPECT_EQ(dut.id(), kId);
   EXPECT_TRUE(
@@ -119,8 +118,8 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
 TEST_F(MultilaneConnectionTest, LineAccessors) {
   const std::string kId{"line_connection"};
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
-
-  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kSegmentParameters);
+  const Connection dut(kId, kStartEndpoint, kEndEndpoint, kNumLanes, kR0,
+                       kLeftShoulder, kRightShoulder);
   EXPECT_EQ(dut.type(), Connection::Type::kLine);
   EXPECT_EQ(dut.id(), kId);
   EXPECT_TRUE(

--- a/drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -9,10 +9,6 @@ namespace maliput {
 namespace multilane {
 namespace test {
 
-// Scale factor in meters used to convert back and forth from an angle deviation
-// to length deviation.
-const double kLengthScale{1.};
-
 ::testing::AssertionResult IsEndpointXyClose(const EndpointXy& xy1,
                                              const EndpointXy& xy2,
                                              double tolerance) {
@@ -38,16 +34,16 @@ const double kLengthScale{1.};
                     ", diff = " + std::to_string(delta) +
                     ", tolerance = " + std::to_string(tolerance) + "\n";
   }
-  const double delta_angle = std::abs(xy1.heading() - xy2.heading());
-  if ((delta_angle * kLengthScale) > tolerance) {
+  delta = std::abs(xy1.heading() - xy2.heading());
+  if (delta > tolerance) {
     fails = true;
     error_message = error_message +
                     "EndpointXys are different at heading angle. " +
                     "xy1.heading(): " + std::to_string(xy1.heading()) +
                     " vs.  xy2.heading(): " + std::to_string(xy2.heading()) +
-                    ", diff = " + std::to_string(delta_angle) +
+                    ", diff = " + std::to_string(delta) +
                     ", tolerance = " +
-                    std::to_string(tolerance / kLengthScale) + "\n";
+                    std::to_string(tolerance) + "\n";
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
@@ -83,16 +79,16 @@ const double kLengthScale{1.};
                     ", diff = " + std::to_string(delta) +
                     ", tolerance = " + std::to_string(tolerance) + "\n";
   }
-  const double delta_angle = std::abs(z1.theta() - z2.theta());
-  if ((delta_angle * kLengthScale) > tolerance) {
+  delta = std::abs(z1.theta() - z2.theta());
+  if (delta > tolerance) {
     fails = true;
     error_message = error_message +
                     "EndpointZ are different at theta angle. " +
                     "z1.theta(): " + std::to_string(z1.theta()) +
                     " vs.  z2.theta(): " + std::to_string(z2.theta()) +
-                    ", diff = " + std::to_string(delta_angle) +
+                    ", diff = " + std::to_string(delta) +
                     ", tolerance = " +
-                    std::to_string(tolerance / kLengthScale) + "\n";
+                    std::to_string(tolerance) + "\n";
   }
   delta = std::abs(z1.theta_dot() - z2.theta_dot());
   if (delta > tolerance) {

--- a/drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
+++ b/drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
@@ -10,39 +10,33 @@ namespace multilane {
 namespace test {
 
 // Compares equality within @p tolerance deviation of two EndpointXy objects.
-//
-// When comparing angles, angle difference in radians is multiplied by a scale
-// factor to convert it into a length and then compared against @p tolerance.
-//
 // @param xy1 An EndpointXy object to compare.
 // @param xy2 An EndpointXy object to compare.
 // @param tolerance An allowable absolute deviation for each EndpointXy's
-// coordinate. It must be expressed in the same unit as length coordinates of
-// EndpointXy.
+// coordinate.
 // @return ::testing::AssertionFailure() When EndpointXy objects are different.
 // @return ::testing::AssertionSuccess() When EndpointXy objects are within
 // the @p tolerance deviation.
+
+// TODO(agalbachicar)    Given that EndpointXy is composed of two lengths and
+//                       one angle, tolerance must be replaced into two distinct
+//                       values to match each magnitude.
 ::testing::AssertionResult IsEndpointXyClose(const EndpointXy& xy1,
                                              const EndpointXy& xy2,
                                              double tolerance);
 
 // Compares equality within @p tolerance deviation of two EndpointZ objects.
-//
-// When comparing angles, angle difference in radians is multiplied by a scale
-// factor to convert it into a length and then compared against @p tolerance.
-//
 // @param z1 An EndpointZ object to compare.
 // @param z2 An EndpointZ object to compare.
 // @param tolerance An allowable absolute deviation for each EndpointZ's
-// coordinate. It must be expressed in the same unit as length coordinates of
-// EndpointZ.
+// coordinate.
 // @return ::testing::AssertionFailure() When EndpointZ objects are different.
 // @return ::testing::AssertionSuccess() When EndpointZ objects are within
 // the @p tolerance deviation.
 
 // TODO(agalbachicar)    Given that EndpointZ is composed of different
-//                       magnitudes, tolerance must be replaced or scaled to
-//                       match each magnitude.
+//                       magnitudes, tolerance must be replaced into distinct
+//                       values to match each magnitude.
 ::testing::AssertionResult IsEndpointZClose(const EndpointZ& z1,
                                             const EndpointZ& z2,
                                             double tolerance);
@@ -51,15 +45,14 @@ namespace test {
 // @param pos1 An Endpoint object to compare.
 // @param pos2 An Endpoint object to compare.
 // @param tolerance An allowable absolute deviation for each Endpoint's
-// coordinate. It must be expressed in the same unit as length coordinates of
-// Endpoint.
+// coordinate.
 // @return ::testing::AssertionFailure() When Endpoint objects are different.
 // @return ::testing::AssertionSuccess() When Endpoint objects are within
 // the @p tolerance deviation.
 
 // TODO(agalbachicar)    Given that EndpointXy and EndpointZ are composed of
-//                       different magnitudes, tolerance must be replaced or
-//                       scaled to match each magnitude.
+//                       different magnitudes, tolerance must be replaced into
+//                       distinct values to match each magnitude.
 ::testing::AssertionResult IsEndpointClose(const Endpoint& pos1,
                                            const Endpoint& pos2,
                                            double tolerance);


### PR DESCRIPTION
After PR #7325 was merged, it is necessary to roll back some modifications made during the review of the PR. Here is a summary:

- `Connection`'s constructors retain their signature instead of constructing structures to group them.
- Tolerance magnitude conversion in GTest idioms to compare Endpoint types is reverted as well as the TODOs.
- `EndpointZ::reverse` is buggy. Not only  code is corrected but a new doc string on the method is introduced trying to avoid future confusions.
- `Group`'s doc strings with reference to ID uniqueness is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7380)
<!-- Reviewable:end -->
