### PR TITLE
Change "@stx//:install" headers from "include/stx/stx/*" to "include/stx/*"

### DIFF
--- a/tools/workspace/stx/stx.BUILD.bazel
+++ b/tools/workspace/stx/stx.BUILD.bazel
@@ -27,7 +27,7 @@ install_cmake_config(
 install(
     name = "install",
     targets = [":stx"],
-    hdr_dest = "include/stx",
+    hdr_dest = "include",
     guess_hdrs = "PACKAGE",
     docs = [
         "LICENSE",


### PR DESCRIPTION
@avalenzu ran into an issue when building against one of the released binaries on his machine, where a downstream project, including `${install_prefix}/include`, could not find `stx/optional.hpp` (since his compilation setup did not meet the requirements to use `std::optional`).

The root cause was simply the file getting installed too many levels deep. This fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7385)
<!-- Reviewable:end -->
