### PR TITLE
Check gripper position in WsgAction.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/pick_and_place/action.h
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/action.h
@@ -143,10 +143,18 @@ class WsgAction : public Action {
   }
 
   /**
-   * Returns true if the gripper stopped moving, and it is at least 0.5 seconds
-   * after an Open / Close command was last issued.
+   * Returns true if the following criteria are satisfied:
+   *  - The gripper speed is less than the final speed threshold.
+   *  - 0.5 s have elapsed since the last Open/Close command was issued.
+   *  - The gripper position is greater than (for an Open command) or less than
+   *    (for a Close command) the open position threshold.
    */
   bool ActionFinished(const WorldState& est_state) const override;
+
+ private:
+  enum { kOpen, kClose } last_command_{kOpen};
+  static constexpr double kFinalSpeedThreshold = 1e-2;  // m/s
+  static constexpr double kOpenPositionThreshold = .095;   // m
 };
 
 }  // namespace pick_and_place


### PR DESCRIPTION
Now if the WSG fails to respond to a command, the `WsgAction` will recognize that it is not finished. Thanks to @sammy-tri for the patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7392)
<!-- Reviewable:end -->
