### PR TITLE
Add Werror=logical-op to GCC builds

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -25,6 +25,7 @@ GCC_FLAGS = CXX_FLAGS + [
     "-Werror=return-local-addr",
     "-Werror=non-virtual-dtor",
     "-Werror=unused-but-set-parameter",
+    "-Werror=logical-op",
     # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
     "-Wno-missing-field-initializers",
     # TODO(#2852) Turn on shadow checking for g++ once we use a version that


### PR DESCRIPTION
This is to keep pace with TRI's internal build warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7393)
<!-- Reviewable:end -->
