### PR TITLE
Remove some Wold-style-cast warnings

### DIFF
--- a/drake/common/polynomial.cc
+++ b/drake/common/polynomial.cc
@@ -81,7 +81,7 @@ template <typename CoefficientType>
 Polynomial<CoefficientType>::Polynomial(const string varname,
                                         const unsigned int num) {
   Monomial m;
-  m.coefficient = (CoefficientType)1;
+  m.coefficient = CoefficientType{1};
   Term t;
   t.var = VariableNameToId(varname, num);
   t.power = 1;
@@ -304,8 +304,8 @@ Polynomial<CoefficientType> Polynomial<CoefficientType>::Integral(
       t.power = 1;
       iter->terms.push_back(t);
     } else {
-      iter->coefficient /= (RealScalar)(iter->terms[0].power + 1);
-      iter->terms[0].power += (PowerType)1;
+      iter->coefficient /= static_cast<RealScalar>(iter->terms[0].power + 1);
+      iter->terms[0].power += PowerType{1};
     }
   }
   Monomial m;
@@ -343,7 +343,7 @@ Polynomial<CoefficientType>& Polynomial<CoefficientType>::operator-=(
     const Polynomial<CoefficientType>& other) {
   for (const auto& iter : other.monomials_) {
     monomials_.push_back(iter);
-    monomials_.back().coefficient *= (CoefficientType)(-1);
+    monomials_.back().coefficient *= CoefficientType{-1};
   }
   MakeMonomialsUnique();  // also sets is_univariate false if necessary
   return *this;
@@ -554,7 +554,7 @@ Polynomial<CoefficientType>::VariableNameToId(const string name,
   const VarType maxId = std::numeric_limits<VarType>::max() / 2 / kMaxNamePart;
   if (m > maxId) throw runtime_error("name exceeds max ID");
   if (m < 1) throw runtime_error("m must be >0");
-  return (VarType)2 * (name_part + kMaxNamePart * (m - 1));
+  return static_cast<VarType>(2) * (name_part + kMaxNamePart * (m - 1));
 }
 
 template <typename CoefficientType>

--- a/drake/common/polynomial.h
+++ b/drake/common/polynomial.h
@@ -52,7 +52,7 @@ class Polynomial {
 
   template <typename Rhs, typename Lhs>
   struct Product {
-    typedef decltype((Rhs)0 * (Lhs)0) type;
+    typedef decltype(static_cast<Rhs>(0) * static_cast<Lhs>(0)) type;
   };
 
   /// An individual variable raised to an integer power; e.g. x**2.
@@ -198,8 +198,8 @@ class Polynomial {
         value += iter->coefficient;
       else
         value += iter->coefficient *
-                  pow((ProductType) x,
-                      (PowerType) iter->terms[0].power);
+                  pow(static_cast<ProductType>(x),
+                      static_cast<PowerType>(iter->terms[0].power));
     }
     return value;
   }

--- a/drake/multibody/rigid_body_constraint.cc
+++ b/drake/multibody/rigid_body_constraint.cc
@@ -1778,8 +1778,8 @@ void WorldFixedOrientConstraint::bounds(const double* t, int n_breaks,
   if (num_valid_t >= 2) {
     lb.resize(1);
     ub.resize(1);
-    lb(0) = (double)num_valid_t;
-    ub(0) = (double)num_valid_t;
+    lb(0) = static_cast<double>(num_valid_t);
+    ub(0) = static_cast<double>(num_valid_t);
   } else {
     lb.resize(0);
     ub.resize(0);
@@ -1872,8 +1872,8 @@ void WorldFixedBodyPoseConstraint::bounds(const double* t, int n_breaks,
   if (num_valid_t >= 2) {
     lb.resize(2);
     ub.resize(2);
-    lb << 0.0, (double)num_valid_t;
-    ub << 0.0, (double)num_valid_t;
+    lb << 0.0, static_cast<double>(num_valid_t);
+    ub << 0.0, static_cast<double>(num_valid_t);
   } else {
     lb.resize(0);
     ub.resize(0);

--- a/drake/perception/dev/feedforward_neural_network.cc
+++ b/drake/perception/dev/feedforward_neural_network.cc
@@ -154,7 +154,7 @@ template <typename T>
 std::unique_ptr<MatrixX<T>> FeedforwardNeuralNetwork<T>::get_weight_matrix(
     int index, const Context<T>& context) const {
   DRAKE_THROW_UNLESS((0 <= index) &&
-                     ((vector<int>::size_type)index < weight_indices_.size()));
+                     (static_cast<size_t>(index) < weight_indices_.size()));
 
   const BasicVector<T>& encodedMatrix =
       this->template GetNumericParameter<BasicVector>(context,
@@ -168,7 +168,7 @@ template <typename T>
 std::unique_ptr<VectorX<T>> FeedforwardNeuralNetwork<T>::get_bias_vector(
     int index, const Context<T>& context) const {
   DRAKE_THROW_UNLESS((0 <= index) &&
-                     ((vector<int>::size_type)index < bias_indices_.size()));
+                     (static_cast<size_t>(index) < bias_indices_.size()));
 
   const BasicVector<T>& encoded_vector =
       this->template GetNumericParameter<BasicVector>(context,

--- a/drake/solvers/moby_lcp_solver.cc
+++ b/drake/solvers/moby_lcp_solver.cc
@@ -593,7 +593,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
   }
 
   const unsigned n = q.size();
-  const unsigned max_iter = std::min((unsigned)1000, 50 * n);
+  const unsigned max_iter = std::min(unsigned{1000}, 50 * n);
 
   if (M.rows() != n || M.cols() != n)
     throw std::logic_error("M's dimensions do not match that of q.");
@@ -1047,7 +1047,7 @@ bool MobyLCPSolver<T>::SolveLcpLemke(const Eigen::SparseMatrix<double>& M,
   }
 
   const unsigned n = q.size();
-  const unsigned max_iter = std::min((unsigned)1000, 50 * n);
+  const unsigned max_iter = std::min(unsigned{1000}, 50 * n);
 
   if (M.rows() != n || M.cols() != n)
     throw std::logic_error("M's dimensions do not match that of q.");


### PR DESCRIPTION
The goal is to turn on `-Werror=old-style-cast` project-wide, to keep pace with TRI's internal build warnings.  For now, this is just the simple fixes; we will also need lcm-proj/lcm#199 before we can enable this project-wide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7394)
<!-- Reviewable:end -->
