### PR TITLE
Partially revert "Use a single correct spelling for lcmtypes includes"

### DIFF
--- a/tools/skylark/drake_lcm.bzl
+++ b/tools/skylark/drake_lcm.bzl
@@ -10,21 +10,11 @@ load(
 def drake_lcm_cc_library(
         name,
         tags = [],
-        strip_include_prefix = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations."""
-    # Drake's *.lcm files all live in our //drake/lcmtypes package.  However,
-    # per LCM upstream convention, the include directory for generated code
-    # should always look like "my_lcm_package/my_lcm_struct.h".  By default,
-    # Bazel would provide "drake/lcmtypes/my_lcm_package/my_lcm_struct.h" as
-    # the desired spelling.  Here, we override that to force Drake's include
-    # statements to use the standard formulation.
-    if not strip_include_prefix:
-        strip_include_prefix = "/" + native.package_name()
     lcm_cc_library(
         name = name,
         tags = tags + ["nolint"],
-        strip_include_prefix = strip_include_prefix,
         **kwargs)
 
 def drake_lcm_java_library(


### PR DESCRIPTION
This reverts one file from #7381.  This reverts the bzl change, but not the *.cc path fixups.  The bzl change broke the installed header paths with "virtual_includes".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7395)
<!-- Reviewable:end -->
