### PR TITLE
Change the linear term variable in non-convex quadratic constraint

### DIFF
--- a/drake/solvers/non_convex_optimization_util.cc
+++ b/drake/solvers/non_convex_optimization_util.cc
@@ -54,13 +54,14 @@ std::tuple<Binding<LinearConstraint>,
            std::vector<Binding<RotatedLorentzConeConstraint>>,
            VectorXDecisionVariable>
 AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const VectorXDecisionVariable> &x,
-    const Eigen::Ref<const Eigen::MatrixXd> &Q1,
-    const Eigen::Ref<const Eigen::MatrixXd> &Q2,
-    const Eigen::Ref<const Eigen::VectorXd> &p, double lower_bound,
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q1,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q2,
+    const Eigen::Ref<const Eigen::VectorXd>& p,
+    const Eigen::Ref<const VectorXDecisionVariable>& y, double lower_bound,
     double upper_bound,
-    const Eigen::Ref<const Eigen::VectorXd> &linearization_point,
+    const Eigen::Ref<const Eigen::VectorXd>& linearization_point,
     double trust_region_gap) {
   const auto& x0 = linearization_point;
   if (Q1.rows() != Q1.cols()) {
@@ -69,8 +70,8 @@ AddRelaxNonConvexQuadraticConstraintInTrustRegion(
   if (Q2.rows() != Q2.cols()) {
     throw std::runtime_error("Q2 should be a square matrix.");
   }
-  if (Q1.rows() != Q2.rows() || Q1.rows() != p.rows() ||
-      Q1.rows() != x0.rows() || Q1.rows() != x.rows()) {
+  if (Q1.rows() != Q2.rows() || Q1.rows() != x0.rows() ||
+      Q1.rows() != x.rows() || p.rows() != y.rows()) {
     throw std::runtime_error(
         "The dimensions of the inputs are not consistent.");
   }
@@ -117,7 +118,7 @@ AddRelaxNonConvexQuadraticConstraintInTrustRegion(
     Eigen::Vector2d linear_ub(std::numeric_limits<double>::infinity(),
                               upper_bound);
     Vector2<symbolic::Expression> linear_expr(2 * x0.dot(nonzero_Q * x) - z(0),
-                                              p.dot(x) + z_coeff * z(0));
+                                              p.dot(y) + z_coeff * z(0));
     Binding<LinearConstraint> linear_constraint = prog->AddConstraint(
         internal::ParseLinearConstraint(linear_expr, linear_lb, linear_ub));
     std::vector<Binding<RotatedLorentzConeConstraint>> lorentz_cones{
@@ -128,7 +129,7 @@ AddRelaxNonConvexQuadraticConstraintInTrustRegion(
   // Neither Q1 nor Q2 is zero.
   auto z = prog->NewContinuousVariables<2>("z");
   Vector3<symbolic::Expression> linear_expressions;
-  linear_expressions << z(0) - z(1) + p.dot(x), z(0) - 2 * x0.dot(Q1 * x),
+  linear_expressions << z(0) - z(1) + p.dot(y), z(0) - 2 * x0.dot(Q1 * x),
       z(1) - 2 * x0.dot(Q2 * x);
   const Eigen::Vector3d linear_lb(lower_bound,
                                   -std::numeric_limits<double>::infinity(),

--- a/drake/solvers/non_convex_optimization_util.cc
+++ b/drake/solvers/non_convex_optimization_util.cc
@@ -58,8 +58,9 @@ AddRelaxNonConvexQuadraticConstraintInTrustRegion(
     const Eigen::Ref<const VectorXDecisionVariable>& x,
     const Eigen::Ref<const Eigen::MatrixXd>& Q1,
     const Eigen::Ref<const Eigen::MatrixXd>& Q2,
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
     const Eigen::Ref<const Eigen::VectorXd>& p,
-    const Eigen::Ref<const VectorXDecisionVariable>& y, double lower_bound,
+    double lower_bound,
     double upper_bound,
     const Eigen::Ref<const Eigen::VectorXd>& linearization_point,
     double trust_region_gap) {

--- a/drake/solvers/non_convex_optimization_util.h
+++ b/drake/solvers/non_convex_optimization_util.h
@@ -128,8 +128,8 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  * constraint.
  * @param Q1 A positive semidefinite matrix.
  * @param Q2 A positive semidefinite matrix.
- * @param p A vector, the linear coefficients in the quadratic form.
- * @param y A vector, the variables in the linear term in the quadratic form.
+ * @param p A vector, the linear coefficients of the quadratic form.
+ * @param y A vector, the variables in the linear term of the quadratic form.
  * @param linearization_point The vector `x₀` in the documentation above.
  * @param lower_bound The left-hand side of the original non-convex constraint.
  * @param upper_bound The right-hand side of the original non-convex constraint.

--- a/drake/solvers/non_convex_optimization_util.h
+++ b/drake/solvers/non_convex_optimization_util.h
@@ -44,13 +44,14 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
 
 /**
  * For a non-convex quadratic constraint
- *   lb ≤ xᵀQ₁x - xᵀQ₂x + pᵀx ≤ ub
- * where Q₁, Q₂ are both positive semidefinite matrices, we relax this
- * constraint by several convex constraints. The steps are
+ *   lb ≤ xᵀQ₁x - xᵀQ₂x + pᵀy ≤ ub
+ * where Q₁, Q₂ are both positive semidefinite matrices. `y` is a vector that
+ * can overlap with `x`. We relax this non-convex constraint by several convex
+ * constraints. The steps are
  * 1. Introduce two new variables z₁, z₂, to replace xᵀQ₁x and xᵀQ₂x
  *    respectively. The constraint becomes
  *    <pre>
- *      lb ≤ z₁ - z₂ + pᵀx ≤ ub              (1)
+ *      lb ≤ z₁ - z₂ + pᵀy ≤ ub              (1)
  *    </pre>
  * 2. Ideally, we would like to enforce z₁ = xᵀQ₁x and z₂ = xᵀQ₂x through convex
  *    constraints. To this end, we first bound z₁ and z₂ from below, as
@@ -99,23 +100,23 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  *
  * The special cases are when Q₁ = 0 or Q₂ = 0.
  * 1. When Q₁ = 0, the original constraint becomes
- *    lb ≤ -xᵀQ₂x + pᵀx ≤ ub
+ *    lb ≤ -xᵀQ₂x + pᵀy ≤ ub
  *    If ub = +∞, then the original constraint is the convex rotated Lorentz
- *    cone constraint xᵀQ₂x ≤ pᵀx - lb. The user should not call this function
+ *    cone constraint xᵀQ₂x ≤ pᵀy - lb. The user should not call this function
  *    to relax this convex constraint.
  *    @throws std::runtime_error if Q₁ = 0 and ub = +∞.
  *    If ub < +∞, then we introduce a new variable z, with the constraints
- *    lb ≤ -z + pᵀx ≤ ub
+ *    lb ≤ -z + pᵀy ≤ ub
  *    z ≥ xᵀQ₂x
  *    z ≤ 2 x₀ᵀQ₂(x - x₀) + x₀ᵀQ₂x₀ + d
  * 2. When Q₂ = 0, the constraint becomes
- *    lb ≤ xᵀQ₁x + pᵀx ≤ ub
+ *    lb ≤ xᵀQ₁x + pᵀy ≤ ub
  *    If lb = -∞, then the original constraint is the convex rotated Lorentz
- *    cone constraint xᵀQ₁x ≤ ub - pᵀx. The user should not call this function
+ *    cone constraint xᵀQ₁x ≤ ub - pᵀy. The user should not call this function
  *    to relax this convex constraint.
  *    @throws std::runtime_error if Q₂ = 0 and lb = -∞.
  *    If lb > -∞, then we introduce a new variable z, with the constraints
- *    lb ≤ z + pᵀx ≤ ub
+ *    lb ≤ z + pᵀy ≤ ub
  *    z ≥ xᵀQ₁x
  *    z ≤ 2 x₀ᵀQ₁(x - x₀) + x₀ᵀQ₁x₀ + d
  * 3. If both Q₁ and Q₂ are zero, then the original constraint is a convex
@@ -128,6 +129,7 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  * @param Q1 A positive semidefinite matrix.
  * @param Q2 A positive semidefinite matrix.
  * @param p A vector, the linear coefficients in the quadratic form.
+ * @param y A vector, the variables in the linear term in the quadratic form.
  * @param linearization_point The vector `x₀` in the documentation above.
  * @param lower_bound The left-hand side of the original non-convex constraint.
  * @param upper_bound The right-hand side of the original non-convex constraint.
@@ -142,21 +144,23 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  * z is the newly added variable.
  * @pre 1. Q1, Q2 are positive semidefinite.
  *      2. d is positive.
- *      3. Q1, Q2, p, x, x₀ are all of the consistent size.
- *      4. lower_bound ≤ upper_bound.
+ *      3. Q1, Q2, x, x₀ are all of the consistent size.
+ *      4. p and y are of the consistent size.
+ *      5. lower_bound ≤ upper_bound.
  *      @throws std::runtime_error when the precondition is not satisfied.
  */
 std::tuple<Binding<LinearConstraint>,
            std::vector<Binding<RotatedLorentzConeConstraint>>,
            VectorXDecisionVariable>
 AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const VectorXDecisionVariable> &x,
-    const Eigen::Ref<const Eigen::MatrixXd> &Q1,
-    const Eigen::Ref<const Eigen::MatrixXd> &Q2,
-    const Eigen::Ref<const Eigen::VectorXd> &p, double lower_bound,
+    MathematicalProgram* prog,
+    const Eigen::Ref<const VectorXDecisionVariable>& x,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q1,
+    const Eigen::Ref<const Eigen::MatrixXd>& Q2,
+    const Eigen::Ref<const Eigen::VectorXd>& p,
+    const Eigen::Ref<const VectorXDecisionVariable>& y, double lower_bound,
     double upper_bound,
-    const Eigen::Ref<const Eigen::VectorXd> &linearization_point,
+    const Eigen::Ref<const Eigen::VectorXd>& linearization_point,
     double trust_region_gap);
 }  // namespace solvers
 }  // namespace drake

--- a/drake/solvers/non_convex_optimization_util.h
+++ b/drake/solvers/non_convex_optimization_util.h
@@ -157,8 +157,8 @@ AddRelaxNonConvexQuadraticConstraintInTrustRegion(
     const Eigen::Ref<const VectorXDecisionVariable>& x,
     const Eigen::Ref<const Eigen::MatrixXd>& Q1,
     const Eigen::Ref<const Eigen::MatrixXd>& Q2,
-    const Eigen::Ref<const Eigen::VectorXd>& p,
-    const Eigen::Ref<const VectorXDecisionVariable>& y, double lower_bound,
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
+    const Eigen::Ref<const Eigen::VectorXd>& p, double lower_bound,
     double upper_bound,
     const Eigen::Ref<const Eigen::VectorXd>& linearization_point,
     double trust_region_gap);

--- a/drake/solvers/non_convex_optimization_util.h
+++ b/drake/solvers/non_convex_optimization_util.h
@@ -128,8 +128,8 @@ std::pair<Eigen::MatrixXd, Eigen::MatrixXd> DecomposeNonConvexQuadraticForm(
  * constraint.
  * @param Q1 A positive semidefinite matrix.
  * @param Q2 A positive semidefinite matrix.
- * @param p A vector, the linear coefficients of the quadratic form.
  * @param y A vector, the variables in the linear term of the quadratic form.
+ * @param p A vector, the linear coefficients of the quadratic form.
  * @param linearization_point The vector `x₀` in the documentation above.
  * @param lower_bound The left-hand side of the original non-convex constraint.
  * @param upper_bound The right-hand side of the original non-convex constraint.

--- a/drake/solvers/test/non_convex_optimization_util_test.cc
+++ b/drake/solvers/test/non_convex_optimization_util_test.cc
@@ -183,8 +183,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, Test1) {
       &prog_, x_, Q1, Q2, p, x_, lower_bound, upper_bound, linearization_point,
       trust_region_gap);
 
-  // The variables y in the linear term is not the same as the variables in the
-  // quadratic term x.
+  // Check the case in which the variable y in the linear term are not the same
+  // as the variable x in the quadratic term.
   auto x_prime = prog_.NewContinuousVariables<2>();
   const Eigen::Vector3d p_prime(3, 2, 1);
   VectorDecisionVariable<3> y{x_(0), x_prime(0), x_prime(1)};
@@ -296,8 +296,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem1) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem2) {
-  // The variables y in the linear term is not the same as the variables x in
-  // the quadratic term.
+  // Check the case in which the variable y in the linear term are not the same
+  // as the variable x in the quadratic term.
   Eigen::Matrix2d Q1, Q2;
   Q1 << 1, 0, 0, 2;
   Q2 << 2, 0.1, 0.1, 1;
@@ -451,8 +451,8 @@ void SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
       symbolic::Polynomial(x.dot(Q * x)), poly_tol));
 
   auto cost = prog->AddLinearCost(x.cast<symbolic::Expression>().sum());
-  const double z_coeff = Q1_is_zero ? -1 : 1;
-  const double Q_coeff = Q1_is_zero ? -1 : 1;
+  const double z_sign = Q1_is_zero ? -1 : 1;
+  const double Q_sign = Q1_is_zero ? -1 : 1;
   for (int i = 0; i < c.cols(); ++i) {
     cost.constraint()->UpdateCoefficients(c.col(i).transpose());
     auto result = prog->Solve();
@@ -461,12 +461,12 @@ void SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
     const Eigen::Vector2d x_sol = prog->GetSolution(x);
     const Eigen::VectorXd y_sol = prog->GetSolution(y);
     const double tol{1E-5};
-    EXPECT_GE(z_coeff * z_sol + p.dot(y_sol), lb - tol);
-    EXPECT_LE(z_coeff * z_sol + p.dot(y_sol), ub + tol);
+    EXPECT_GE(z_sign * z_sol + p.dot(y_sol), lb - tol);
+    EXPECT_LE(z_sign * z_sol + p.dot(y_sol), ub + tol);
     EXPECT_LE(z_sol,
               2 * x0.dot(Q * x_sol) - x0.dot(Q * x0) + trust_region_gap + tol);
     EXPECT_GE(z_sol, x_sol.dot(Q * x_sol) - tol);
-    const double original_constraint_val{x_sol.dot(Q_coeff * Q * x_sol) +
+    const double original_constraint_val{x_sol.dot(Q_sign * Q * x_sol) +
                                          p.dot(y_sol)};
     EXPECT_GE(original_constraint_val, lb - trust_region_gap - tol);
     EXPECT_LE(original_constraint_val, ub + trust_region_gap + tol);
@@ -512,8 +512,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test2) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test3) {
-  // The variable y in the linear term is not the same as the variable x in the
-  // quadratic term.
+  // Check the case in which the variable y in the linear term is not the same
+  // as the variable x in the quadratic term.
   // -1 <= -x(0)² - 4x(1)² - 2x(0)x(1) + 2x(1) + 3z(0) + 2z(1) <= 4
   // -1 <= z(0) <= 1
   // -1 <= z(1) <= 1
@@ -566,8 +566,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test2) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test3) {
-  // The variable y in the linear term is not the same as the variable x in the
-  // quadratic term.
+  // Check the case in which the variable y in the linear term are not the same
+  // as the variable x in the quadratic term.
   // -1 <= x(0)² + 3x(1)² + x(0)x(1) + 2x(0) + 4x(1) + 3y(0) <= 4
   // -1 <= y(0) <= 1
   Eigen::Matrix2d Q;

--- a/drake/solvers/test/non_convex_optimization_util_test.cc
+++ b/drake/solvers/test/non_convex_optimization_util_test.cc
@@ -85,7 +85,7 @@ void CheckRelaxNonConvexQuadraticConstraintInTrustRegion(
     double trust_region_gap) {
   const auto& x0 = linearization_point;
   const auto result = AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-      prog, x, Q1, Q2, p, y, lower_bound, upper_bound, linearization_point,
+      prog, x, Q1, Q2, y, p, lower_bound, upper_bound, linearization_point,
       trust_region_gap);
   Binding<LinearConstraint> linear_constraint = std::get<0>(result);
   EXPECT_EQ(std::get<1>(result).size(), 2);
@@ -199,21 +199,19 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, TestRuntimeError) {
   Eigen::Matrix2d positive_Q;
   positive_Q << 1, 0.2, 0.2, 1;
   // Q1 not being positive semidefinite.
-  EXPECT_THROW(
-      AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          &prog_, x_, non_positive_Q, positive_Q, Eigen::Vector2d(1, 0), x_, -1,
-          0.1, Eigen::Vector2d(1, 2), 1),
-      std::runtime_error);
+  EXPECT_THROW(AddRelaxNonConvexQuadraticConstraintInTrustRegion(
+                   &prog_, x_, non_positive_Q, positive_Q, x_,
+                   Eigen::Vector2d(1, 0), -1, 0.1, Eigen::Vector2d(1, 2), 1),
+               std::runtime_error);
   // Q2 not being positive semidefinite.
-  EXPECT_THROW(
-      AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          &prog_, x_, positive_Q, non_positive_Q, Eigen::Vector2d(1, 0), x_, -1,
-          0.1, Eigen::Vector2d(1, 2), 1),
-      std::runtime_error);
+  EXPECT_THROW(AddRelaxNonConvexQuadraticConstraintInTrustRegion(
+                   &prog_, x_, positive_Q, non_positive_Q, x_,
+                   Eigen::Vector2d(1, 0), -1, 0.1, Eigen::Vector2d(1, 2), 1),
+               std::runtime_error);
   // Negative trust region gap.
   EXPECT_THROW(AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-                   &prog_, x_, positive_Q, positive_Q, Eigen::Vector2d(1, 0),
-                   x_, -1, 0.1, Eigen::Vector2d(1, 2), -0.1),
+                   &prog_, x_, positive_Q, positive_Q, x_,
+                   Eigen::Vector2d(1, 0), -1, 0.1, Eigen::Vector2d(1, 2), -0.1),
                std::runtime_error);
 }
 
@@ -222,13 +220,13 @@ void SolveRelaxNonConvexQuadraticConstraintInTrustRegion(
     const Eigen::Ref<const VectorXDecisionVariable>& x,
     const Eigen::Ref<const Eigen::MatrixXd>& Q1,
     const Eigen::Ref<const Eigen::MatrixXd>& Q2,
-    const Eigen::Ref<const Eigen::VectorXd>& p,
-    const Eigen::Ref<const VectorXDecisionVariable>& y, double lower_bound,
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
+    const Eigen::Ref<const Eigen::VectorXd>& p, double lower_bound,
     double upper_bound, const Eigen::Ref<const Eigen::VectorXd>& x0,
     double trust_region_gap, const Eigen::Ref<const Eigen::MatrixXd>& c) {
   const auto relaxed_constraints =
       AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          prog, x, Q1, Q2, p, y, lower_bound, upper_bound, x0,
+          prog, x, Q1, Q2, y, p, lower_bound, upper_bound, x0,
           trust_region_gap);
   VectorDecisionVariable<2> z = std::get<2>(relaxed_constraints);
 
@@ -278,7 +276,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem0) {
   const double ub{2};
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Q1, Q2, Eigen::Vector2d::Zero(), x_, lb, ub,
+      &prog_, x_, Q1, Q2, x_, Eigen::Vector2d::Zero(), lb, ub,
       Eigen::Vector2d(2, 1), trust_region_gap, c);
 }
 
@@ -291,7 +289,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem1) {
   const double ub{2};
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Q1, Q2, Eigen::Vector2d(1, 3), x_, lb, ub,
+      &prog_, x_, Q1, Q2, x_, Eigen::Vector2d(1, 3), lb, ub,
       Eigen::Vector2d(2, 1), trust_region_gap, c);
 }
 
@@ -309,7 +307,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem2) {
   VectorDecisionVariable<3> y{x_(0), x_prime(0), x_prime(1)};
   prog_.AddBoundingBoxConstraint(-1, 1, x_prime);
   SolveRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Q1, Q2, Eigen::Vector3d(1, 2, 3), y, lb, ub,
+      &prog_, x_, Q1, Q2, y, Eigen::Vector3d(1, 2, 3), lb, ub,
       Eigen::Vector2d(2, 1), trust_region_gap, c);
 }
 
@@ -323,7 +321,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion,
   const Eigen::Matrix2d Q1 = Eigen::Vector2d(1, 0).asDiagonal();
   const Eigen::Matrix2d Q2 = Eigen::Vector2d(0, 1).asDiagonal();
   AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Q1, Q2, Eigen::Vector2d::Zero(), x_, 1, 1,
+      &prog_, x_, Q1, Q2, x_, Eigen::Vector2d::Zero(), 1, 1,
       Eigen::Vector2d(1, 0), 0.1);
 
   auto result = prog_.Solve();
@@ -346,7 +344,7 @@ GTEST_TEST(TestRelaxNonConvexQuadraticConstraintInTrustRegionInfeasible,
   Eigen::Matrix2d Q2 = Eigen::Vector2d(0, 2).asDiagonal();
   const auto relaxed_constraint =
       AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          &prog1, x1, Q1, Q2, Eigen::Vector2d::Zero(), x1, 1, 1,
+          &prog1, x1, Q1, Q2, x1, Eigen::Vector2d::Zero(), 1, 1,
           Eigen::Vector2d(-5, -3), 0.1);
 
   auto result = prog1.Solve();
@@ -360,7 +358,7 @@ GTEST_TEST(TestRelaxNonConvexQuadraticConstraintInTrustRegionInfeasible,
   prog2.AddLinearConstraint(x2(0) >= x2(1) + 2);
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog2, x2, Q1, Q2, Eigen::Vector2d::Zero(), x2, 1, 1,
+      &prog2, x2, Q1, Q2, x2, Eigen::Vector2d::Zero(), 1, 1,
       Eigen::Vector2d(7, -5), 1.5, c);
 }
 
@@ -369,26 +367,26 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Q2) {
   // Both Q1 and Q2 are 0
   EXPECT_THROW(AddRelaxNonConvexQuadraticConstraintInTrustRegion(
                    &prog_, x_, Eigen::Matrix2d::Zero(), Eigen::Matrix2d::Zero(),
-                   Eigen::Vector2d(1, 2), x_, 1, 2, Eigen::Vector2d(2, 1), 1),
+                   x_, Eigen::Vector2d(1, 2), 1, 2, Eigen::Vector2d(2, 1), 1),
                std::runtime_error);
   // Q1 is zero and upper_bound is infinity.
   EXPECT_THROW(
       AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          &prog_, x_, Eigen::Matrix2d::Zero(), Eigen::Matrix2d::Identity(),
-          Eigen::Vector2d(1, 2), x_, 1, std::numeric_limits<double>::infinity(),
+          &prog_, x_, Eigen::Matrix2d::Zero(), Eigen::Matrix2d::Identity(), x_,
+          Eigen::Vector2d(1, 2), 1, std::numeric_limits<double>::infinity(),
           Eigen::Vector2d(2, 1), 1),
       std::runtime_error);
   // Q2 is zero and lower_bound is -infinity.
   EXPECT_THROW(
       AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          &prog_, x_, Eigen::Matrix2d::Identity(), Eigen::Matrix2d::Zero(),
-          Eigen::Vector2d(1, 2), x_, -std::numeric_limits<double>::infinity(),
-          1, Eigen::Vector2d(2, 1), 1),
+          &prog_, x_, Eigen::Matrix2d::Identity(), Eigen::Matrix2d::Zero(), x_,
+          Eigen::Vector2d(1, 2), -std::numeric_limits<double>::infinity(), 1,
+          Eigen::Vector2d(2, 1), 1),
       std::runtime_error);
   // lower_bound is larger than upper_bound
   EXPECT_THROW(AddRelaxNonConvexQuadraticConstraintInTrustRegion(
                    &prog_, x_, Eigen::Matrix2d::Identity(),
-                   0.1 * Eigen::Matrix2d::Identity(), Eigen::Vector2d(1, 2), x_,
+                   0.1 * Eigen::Matrix2d::Identity(), x_, Eigen::Vector2d(1, 2),
                    2, 1, Eigen::Vector2d(2, 1), 1),
                std::runtime_error);
 }
@@ -397,8 +395,8 @@ void SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
     MathematicalProgram* prog,
     const Eigen::Ref<const VectorXDecisionVariable>& x,
     const Eigen::Ref<const Eigen::MatrixXd>& Q,
-    const Eigen::Ref<const Eigen::VectorXd>& p,
-    const Eigen::Ref<const VectorXDecisionVariable>& y, double lb, double ub,
+    const Eigen::Ref<const VectorXDecisionVariable>& y,
+    const Eigen::Ref<const Eigen::VectorXd>& p, double lb, double ub,
     const Eigen::Ref<const Eigen::VectorXd>& x0, double trust_region_gap,
     bool Q1_is_zero, const Eigen::Ref<const Eigen::MatrixXd>& c) {
   Eigen::MatrixXd Q1, Q2;
@@ -411,7 +409,7 @@ void SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
   }
   const auto relaxed_constraints =
       AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-          prog, x, Q1, Q2, p, y, lb, ub, x0, trust_region_gap);
+          prog, x, Q1, Q2, y, p, lb, ub, x0, trust_region_gap);
   const Binding<LinearConstraint> linear_constraint =
       std::get<0>(relaxed_constraints);
   EXPECT_EQ(std::get<1>(relaxed_constraints).size(), 1);
@@ -479,7 +477,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test0) {
   Q << 1, 0.5, 0.5, 1;
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector2d(2, 0), x_,
+      &prog_, x_, Q, x_, Eigen::Vector2d(2, 0),
       -std::numeric_limits<double>::infinity(), 1, Eigen::Vector2d(1, 2), 1,
       true, c);
 }
@@ -490,7 +488,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test1) {
   Q << 1, 1, 1, 4;
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector2d(3, 2), x_, -1, 4, Eigen::Vector2d(1, 0), 1,
+      &prog_, x_, Q, x_, Eigen::Vector2d(3, 2), -1, 4, Eigen::Vector2d(1, 0), 1,
       true, c);
 }
 
@@ -503,7 +501,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test2) {
   prog_.AddLinearConstraint(x_(0) + x_(1) >= 10);
 
   AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Eigen::Matrix2d::Zero(), Q2, Eigen::Vector2d::Zero(), x_, -4,
+      &prog_, x_, Eigen::Matrix2d::Zero(), Q2, x_, Eigen::Vector2d::Zero(), -4,
       -1, Eigen::Vector2d(0, 1), 1);
 
   auto result = prog_.Solve();
@@ -524,7 +522,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test3) {
   VectorDecisionVariable<3> y(x_(1), z(0), z(1));
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector3d(2, 3, 2), y, -1, 4, Eigen::Vector2d(1, 0),
+      &prog_, x_, Q, y, Eigen::Vector3d(2, 3, 2), -1, 4, Eigen::Vector2d(1, 0),
       1, true, c);
 }
 
@@ -534,7 +532,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test0) {
   Q << 1, 0.5, 0.5, 1;
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector2d(1, 0), x_, 1, 4, Eigen::Vector2d(1, -1),
+      &prog_, x_, Q, x_, Eigen::Vector2d(1, 0), 1, 4, Eigen::Vector2d(1, -1),
       0.5, false, c);
 }
 
@@ -544,7 +542,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test1) {
   Q << 1, 0.5, 0.5, 3;
   const auto c = GenerateCostDirection();
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector2d(2, 4), x_, 1, 4, Eigen::Vector2d(1, -1),
+      &prog_, x_, Q, x_, Eigen::Vector2d(2, 4), 1, 4, Eigen::Vector2d(1, -1),
       0.5, false, c);
 }
 
@@ -557,7 +555,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test2) {
   prog_.AddLinearConstraint(x_(0) + x_(1) >= 10);
 
   AddRelaxNonConvexQuadraticConstraintInTrustRegion(
-      &prog_, x_, Q1, Eigen::Matrix2d::Zero(), Eigen::Vector2d::Zero(), x_, 1,
+      &prog_, x_, Q1, Eigen::Matrix2d::Zero(), x_, Eigen::Vector2d::Zero(), 1,
       4, Eigen::Vector2d(0, 1), 1);
 
   auto result = prog_.Solve();
@@ -576,7 +574,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test3) {
   auto x_prime = prog_.NewContinuousVariables<1>();
   const VectorDecisionVariable<3> y(x_(0), x_(1), x_prime(0));
   SolveRelaxNonConvexQuadraticConstraintInTrustRegionWithZeroQ1orQ2(
-      &prog_, x_, Q, Eigen::Vector3d(2, 4, 3), y, 1, 4, Eigen::Vector2d(1, -1),
+      &prog_, x_, Q, y, Eigen::Vector3d(2, 4, 3), 1, 4, Eigen::Vector2d(1, -1),
       0.5, false, c);
 }
 }  // namespace

--- a/drake/solvers/test/non_convex_optimization_util_test.cc
+++ b/drake/solvers/test/non_convex_optimization_util_test.cc
@@ -183,7 +183,7 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, Test1) {
       &prog_, x_, Q1, Q2, p, x_, lower_bound, upper_bound, linearization_point,
       trust_region_gap);
 
-  // Check the case in which the variable y in the linear term are not the same
+  // Check the case in which the variable y in the linear term is not the same
   // as the variable x in the quadratic term.
   auto x_prime = prog_.NewContinuousVariables<2>();
   const Eigen::Vector3d p_prime(3, 2, 1);
@@ -296,8 +296,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem1) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, SolveProblem2) {
-  // Check the case in which the variable y in the linear term are not the same
-  // as the variable x in the quadratic term.
+  // The variable y in the linear term is not the same as the variable x in the
+  // quadratic term.
   Eigen::Matrix2d Q1, Q2;
   Q1 << 1, 0, 0, 2;
   Q2 << 2, 0.1, 0.1, 1;
@@ -512,8 +512,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test2) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ1Test3) {
-  // Check the case in which the variable y in the linear term is not the same
-  // as the variable x in the quadratic term.
+  // The variable y in the linear term is not the same as the variable x in the
+  // quadratic term.
   // -1 <= -x(0)² - 4x(1)² - 2x(0)x(1) + 2x(1) + 3z(0) + 2z(1) <= 4
   // -1 <= z(0) <= 1
   // -1 <= z(1) <= 1
@@ -566,8 +566,8 @@ TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test2) {
 }
 
 TEST_F(TestRelaxNonConvexQuadraticConstraintInTrustRegion, ZeroQ2Test3) {
-  // Check the case in which the variable y in the linear term are not the same
-  // as the variable x in the quadratic term.
+  // The variable y in the linear term is not the same as the variable x in the
+  // quadratic term.
   // -1 <= x(0)² + 3x(1)² + x(0)x(1) + 2x(0) + 4x(1) + 3y(0) <= 4
   // -1 <= y(0) <= 1
   Eigen::Matrix2d Q;


### PR DESCRIPTION
Now the variables in the linear term can be different from the variables in the quadratic term. Namely we support this type of constraint
```
lb <= x'Q1x - x'Q2x + p'y <= ub
```
The advantage of allowing `y` to be different from `x`, is that we only need to linearize the constraint about `x`, instead of about the union of `x` and `y`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7400)
<!-- Reviewable:end -->
