### PR TITLE
Revert "Use yaml_cpp from Ubuntu Xenial."

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -261,10 +261,12 @@ github_archive(
     build_file = "tools/workspace/tinyobjloader/tinyobjloader.BUILD.bazel",
 )
 
-pkg_config_package(
+github_archive(
     name = "yaml_cpp",
-    atleast_version = "0.5.2",
-    modname = "yaml-cpp",
+    repository = "jbeder/yaml-cpp",
+    commit = "85af926ddc5f3c8fb438001743e65ec3a039ceec",
+    sha256 = "907fb42a502e1448a73959f9a648771b070d6d8513f16d74149f775fc56550ef",  # noqa
+    build_file = "tools/workspace/yaml_cpp/yaml_cpp.BUILD.bazel",
 )
 
 load("//tools/workspace/buildifier:buildifier.bzl", "buildifier_repository")

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -39,12 +39,6 @@ install(
     name = "install",
     targets = ["libdrake.so"],
     guess_hdrs = "WORKSPACE",
-    guess_hdrs_exclude = [
-        # This is private visibility; we don't want to have a yaml dependency
-        # in our published headers.  TODO(jwnimmer-tri) Update the guess_hdrs
-        # logic to exclude non-public headers by default.
-        "drake/systems/controllers/yaml_util.h",
-    ],
     allowed_externals = ["//:LICENSE.TXT"],  # Root for our #include paths.
     deps = [
         ":install_cmake_config",

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -82,6 +82,11 @@
       ],
       "X-CMake-Find-Args": ["CONFIG"]
     },
+    "yaml-cpp": {
+      "Version": "0.5.5",
+      "Hints": ["@prefix@/lib/cmake/yaml-cpp"],
+      "X-CMake-Find-Args": ["CONFIG"]
+    },
     "ZLIB": {
       "Version": "1.2.5",
       "X-CMake-Find-Args": ["MODULE"]
@@ -96,11 +101,7 @@
         "@prefix@/include"
       ],
       "Compile-Features": ["c++14"],
-      "Link-Flags": [
-        "-lnlopt",
-        "-ltinyxml2",
-        "-lyaml-cpp"
-      ],
+      "Link-Flags": ["-lnlopt", "-ltinyxml2"],
       "Link-Requires": [
         "fmt:fmt",
         "SDFormat:sdformat",
@@ -127,7 +128,8 @@
         "protobuf:protobuf",
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",
-        "stx:stx"
+        "stx:stx",
+        "yaml-cpp:yaml-cpp"
       ]
     },
     "drake-lcmtypes-cpp": {

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -36,6 +36,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "tinydir",
     "tinyobjloader",
     "vtk",
+    "yaml_cpp",
 ]] + ["//tools/workspace/%s:install" % p for p in [
     "gflags",
     "jchart2d",

--- a/tools/workspace/yaml_cpp/BUILD.bazel
+++ b/tools/workspace/yaml_cpp/BUILD.bazel
@@ -1,0 +1,10 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+exports_files(
+    ["yaml_cpp-create-cps.py"],
+    visibility = ["@yaml_cpp//:__pkg__"],
+)
+
+add_lint_tests()

--- a/tools/workspace/yaml_cpp/yaml_cpp-create-cps.py
+++ b/tools/workspace/yaml_cpp/yaml_cpp-create-cps.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from drake.tools.install.cpsutils import read_defs
+
+defs = read_defs("set\(YAML_CPP_(VERSION_.*)\s+\"([0-9]+)\"")
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "yaml-cpp",
+  "Description": "A YAML parser and emitter in C++",
+  "License": "MIT",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_MINOR)s",
+  "Default-Components": [ ":yaml-cpp" ],
+  "Components": {
+    "yaml-cpp": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libyaml_cpp.so",
+      "Includes": [ "@prefix@/include" ]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/workspace/yaml_cpp/yaml_cpp.BUILD.bazel
+++ b/tools/workspace/yaml_cpp/yaml_cpp.BUILD.bazel
@@ -1,0 +1,46 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "cmake_config",
+    "install",
+    "install_cmake_config",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+public_headers = glob([
+    "include/**/*.h",
+])
+
+cc_library(
+    name = "yaml_cpp",
+    srcs = glob([
+        "src/**/*.cpp",
+        "src/**/*.h",
+    ]),
+    hdrs = public_headers,
+    includes = ["include"],
+)
+
+CMAKE_PACKAGE = "yaml-cpp"
+
+cmake_config(
+    package = CMAKE_PACKAGE,
+    script = "@drake//tools/workspace/yaml_cpp:yaml_cpp-create-cps.py",
+    version_file = "CMakeLists.txt",
+)
+
+# Creates rule :install_cmake_config.
+install_cmake_config(package = CMAKE_PACKAGE)
+
+install(
+    name = "install",
+    workspace = CMAKE_PACKAGE,
+    targets = [":yaml_cpp"],
+    hdrs = public_headers,
+    hdr_dest = "include",
+    hdr_strip_prefix = ["include"],
+    docs = ["LICENSE"],
+    deps = [":install_cmake_config"],
+)


### PR DESCRIPTION
Reverts RobotLocomotion/drake#7352

@nuclearsandwich your PR seems to have broken these builds on CI (https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/):

`mac-elcapitan-clang-cmake-continuous-release`
`mac-sierra-clang-cmake-continuous-release`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7403)
<!-- Reviewable:end -->
