### PR TITLE
Add /usr/local/include to Bazel header path during CMake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,13 @@ set(BAZEL_ARGS
   --host_cxxopt=${CMAKE_CXX14_STANDARD_COMPILE_OPTION}
 )
 
+if(APPLE)
+  list(APPEND BAZEL_ARGS
+    --cxxopt=-isystem/usr/local/include
+    --host_cxxopt=-isystem/usr/local/include
+  )
+endif()
+
 if(CMAKE_VERBOSE_MAKEFILE)
   list(APPEND BAZEL_ARGS --subcommands)
 endif()


### PR DESCRIPTION
Closes #7403.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7404)
<!-- Reviewable:end -->
