### PR TITLE
Add clp on mac's install_prereqs.sh

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -41,6 +41,7 @@ clang-format
 cmake
 diffstat
 doxygen
+dreal-deps/coinor/clp
 glew
 glib
 graphviz


### PR DESCRIPTION
I found that we only have it on the Ubuntu-side:

https://github.com/RobotLocomotion/drake/blob/02cf2e76c5a900bc07c04f5860c3361ca814d014/setup/ubuntu/16.04/install_prereqs.sh#L53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7410)
<!-- Reviewable:end -->
