### PR TITLE
Require the exact clang-format we want

### DIFF
--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -7,9 +7,9 @@ import sys
 
 def get_clang_format_path():
     if sys.platform == "darwin":
-        preferred = "/usr/local/bin/clang-format"
+        path = "/usr/local/bin/clang-format"
     else:
-        preferred = "/usr/bin/clang-format-3.9"
-    if os.path.isfile(preferred):
-        return preferred
-    return "clang-format"
+        path = "/usr/bin/clang-format-3.9"
+    if os.path.isfile(path):
+        return path
+    raise RuntimeError("Could not find required clang-format at " + path)


### PR DESCRIPTION
We don't want to search for this, we should only use Drake's mandated version.  Guessing paths only defers failures into later in the build and release cycle.

This is a follow-up to #7373, where the failure message was `OSError: [Errno 2] No such file or directory` with no additional detail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7413)
<!-- Reviewable:end -->
