### PR TITLE
Use static_cast to turn void* into uint8_t*

### DIFF
--- a/drake/lcm/drake_mock_lcm.cc
+++ b/drake/lcm/drake_mock_lcm.cc
@@ -31,7 +31,7 @@ void DrakeMockLcm::Publish(const std::string& channel, const void* data,
 
   DRAKE_DEMAND(saved_message);
 
-  const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data);
+  const uint8_t* bytes = static_cast<const uint8_t*>(data);
   saved_message->data = std::vector<uint8_t>(&bytes[0], &bytes[data_size]);
 
   if (enable_loop_back_) {

--- a/drake/systems/lcm/lcm_subscriber_system.cc
+++ b/drake/systems/lcm/lcm_subscriber_system.cc
@@ -285,7 +285,7 @@ void LcmSubscriberSystem::HandleMessage(const std::string& channel,
 
   if (channel == channel_) {
     const uint8_t* const rbuf_begin =
-        reinterpret_cast<const uint8_t*>(message_buffer);
+        static_cast<const uint8_t*>(message_buffer);
     const uint8_t* const rbuf_end = rbuf_begin + message_size;
     std::lock_guard<std::mutex> lock(received_message_mutex_);
     received_message_.clear();


### PR DESCRIPTION
For turning raw `void*` buffers into bytes storage, the correct C++ mechanism is to use `static_cast`, not `reinterpret_cast`.

Noticed manually when working on #7407.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7414)
<!-- Reviewable:end -->
