### PR TITLE
Specify to use JDK 8 (not the latest JDK 9)

### DIFF
--- a/doc/mac.rst
+++ b/doc/mac.rst
@@ -6,7 +6,7 @@ We assume that you have already installed:
 
 * Xcode 8.2.1 or above (from the `Mac App Store <https://itunes.apple.com/us/app/xcode/id497799835>`_)
   and the Command Line Tools for Xcode (``xcode-select --install``)
-* `Java SE Development Kit 8 or above <http://www.oracle.com/technetwork/java/javase/downloads/>`_
+* `Java SE Development Kit 8 <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_
 
 Prerequisite setup is automated. Simply run::
 


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/3410

/cc @pangtao22 who had this issue recently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7415)
<!-- Reviewable:end -->
