### PR TITLE
Add scs external

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,6 +253,24 @@ github_archive(
     build_file = "tools/workspace/lcmtypes_robotlocomotion/lcmtypes_robotlocomotion.BUILD.bazel",  # noqa
 )
 
+pkg_config_package(
+    name = "blas",
+    modname = "blas",
+)
+
+pkg_config_package(
+    name = "lapack",
+    modname = "lapack",
+)
+
+github_archive(
+    name = "scs",
+    repository = "cvxgrp/scs",
+    commit = "v1.2.6",
+    sha256 = "b4bebb43a1257b6e88a5f97c855c0559d6c8a8c0548d3156fc5a28d82bb9533f",  # noqa
+    build_file = "tools/workspace/scs/scs.BUILD.bazel",
+)
+
 github_archive(
     name = "tinyobjloader",
     repository = "syoyo/tinyobjloader",

--- a/drake/solvers/BUILD.bazel
+++ b/drake/solvers/BUILD.bazel
@@ -188,6 +188,7 @@ drake_cc_library(
         ":moby_lcp_solver",
         ":mosek_solver",
         ":nlopt_solver",
+        ":scs_solver",
         ":snopt_solver",
         ":solver_id",
         ":symbolic_extraction",
@@ -570,6 +571,20 @@ drake_cc_library(
             ":mathematical_program_api",
         ],
     }),
+)
+
+drake_cc_library(
+    name = "scs_solver",
+    srcs = [
+        "no_scs.cc",
+        "scs_solver_common.cc",
+    ],
+    hdrs = ["scs_solver.h"],
+    deps = [
+        ":mathematical_program_api",
+        "//drake/common:essential",
+        "@scs//:scsdir",
+    ],
 )
 
 # This library is empty unless Gurobi is available.

--- a/drake/solvers/no_scs.cc
+++ b/drake/solvers/no_scs.cc
@@ -1,0 +1,21 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/solvers/scs_solver.h"
+/* clang-format on */
+
+#include <stdexcept>
+
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+
+bool ScsSolver::available() const { return false; }
+
+SolutionResult ScsSolver::Solve(MathematicalProgram&) const {
+  throw std::runtime_error(
+      "The SCS bindings were not compiled.  You'll need to use a different "
+      "solver.");
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/scs_solver.h
+++ b/drake/solvers/scs_solver.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/solvers/mathematical_program_solver_interface.h"
+
+namespace drake {
+namespace solvers {
+
+class ScsSolver : public MathematicalProgramSolverInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScsSolver)
+
+  ScsSolver() = default;
+  ~ScsSolver() override = default;
+
+  // This solver is implemented in various pieces depending on if
+  // SCS was available during compilation.
+  bool available() const override;
+
+  SolutionResult Solve(MathematicalProgram& prog) const override;
+
+  SolverId solver_id() const override;
+
+  /// @return same as MathematicalProgramSolverInterface::solver_id()
+  static SolverId id();
+};
+
+}  // namespace solvers
+}  // namespace drake

--- a/drake/solvers/scs_solver_common.cc
+++ b/drake/solvers/scs_solver_common.cc
@@ -1,0 +1,24 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/solvers/scs_solver.h"
+/* clang-format on */
+
+#include "drake/common/never_destroyed.h"
+
+// TODO(jamiesnape, hongkai-dai): Currently only the unavailable version of
+// this solver class is implemented; remove this comment when the available
+// version is implemented.
+
+namespace drake {
+namespace solvers {
+
+SolverId ScsSolver::solver_id() const {
+  return id();
+}
+
+SolverId ScsSolver::id() {
+  static const never_destroyed<SolverId> singleton{"SCS"};
+  return singleton.access();
+}
+
+}  // namespace solvers
+}  // namespace drake

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -96,9 +96,9 @@ cc_library(
 # required *.so's that are WORKSPACE downloads (such as VTK, Gurobi, etc).
 #
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
-# *.so files (Gurobi, Mosek, TinyXML2, VTK) for us, without us having to know
-# up-front here which dependencies are coming from the WORKSPACE in the form
-# of *.so.
+# *.so files (Gurobi, Mosek, SCS, TinyXML2, VTK) for us, without us having to
+# know up-front here which dependencies are coming from the WORKSPACE in the
+# form of *.so.
 cc_library(
     name = "drake_shared_library",
     visibility = ["//drake/bindings:__pkg__"],
@@ -107,6 +107,7 @@ cc_library(
         ":libdrake_headers",
         ":mosek_deps",
         ":vtk_deps",
+        "@scs//:scsdir",
         "@tinyxml2",
     ],
 )

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -55,6 +55,11 @@
       "Hints": ["@prefix@/lib/cmake/robotlocomotion-lcmtypes"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
+    "scs": {
+      "Version": "1.2.6",
+      "Hints": ["@prefix@/lib/cmake/scs"],
+      "X-CMake-Find-Args": ["CONFIG"]
+    },
     "SDFormat": {
       "Version": "6.0.0",
       "Hints": ["@prefix@/lib/cmake/sdformat"],
@@ -104,6 +109,7 @@
       "Link-Flags": ["-lnlopt", "-ltinyxml2"],
       "Link-Requires": [
         "fmt:fmt",
+        "scs:scsdir",
         "SDFormat:sdformat",
         "vtkCommonCore",
         "vtkCommonDataModel",

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -29,6 +29,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "libbot",
     "octomap",
     "pybind11",
+    "scs",
     "sdformat",
     "spdlog",
     "spruce",

--- a/tools/workspace/scs/BUILD.bazel
+++ b/tools/workspace/scs/BUILD.bazel
@@ -1,0 +1,10 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+exports_files(
+    ["scs-create-cps.py"],
+    visibility = ["@scs//:__pkg__"],
+)
+
+add_lint_tests()

--- a/tools/workspace/scs/scs-create-cps.py
+++ b/tools/workspace/scs/scs-create-cps.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from drake.tools.install.cpsutils import read_version_defs
+
+defs = read_version_defs("\W+\(\"([0-9]+).([0-9]+).([0-9]+)\"\)")
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "scs",
+  "Description": "Conic optimization via operator splitting.",
+  "License": [
+    "LGPL-2.1+",
+    "MIT"
+  ],
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Default-Components": [":scsdir"],
+  "Components": {
+    "scsdir": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libscsdir.so",
+      "Definitions": ["LAPACK_LIB_FOUND=1"],
+      "Includes": ["@prefix@/include/scs"]
+    },
+    "scsindir": {
+      "Type": "dylib",
+      "Location": "@prefix@/lib/libscsindir.so",
+      "Definitions": ["LAPACK_LIB_FOUND=1"],
+      "Includes": ["@prefix@/include/scs"]
+    }
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/workspace/scs/scs.BUILD.bazel
+++ b/tools/workspace/scs/scs.BUILD.bazel
@@ -1,0 +1,119 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "cmake_config",
+    "install",
+    "install_cmake_config",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "linux",
+    values = {"cpu": "k8"},
+    visibility = ["//visibility:private"],
+)
+
+# TODO(jamiesnape, hongkai-dai): We probably do not need both :scsdir and
+# :scsindir. They are unlikely to happily coexist in libdrake.so and currently
+# libdrake.so links only to :scsdir.
+
+SCS_HDRS = glob(["include/*.h"])
+
+# TODO(jamiesnape): Use system AMD and LDL instead of outdated versions in
+# linsys/direct/external. These are licensed under the LGPL so only build a
+# shared library for :scsdir.
+
+cc_binary(
+    name = "libscsdir.so",
+    srcs = SCS_HDRS + glob([
+        "linsys/*.c",
+        "linsys/*.h",
+        "linsys/direct/**/*.c",
+        "linsys/direct/**/*.h",
+        "src/*.c",
+    ]),
+    defines = ["LAPACK_LIB_FOUND=1"],
+    includes = ["include"],
+    linkopts = select({
+        ":darwin": ["-framework Accelerate"],
+        ":linux": ["-lrt"],
+        "@//conditions:default": [],
+    }),
+    linkshared = 1,
+    visibility = ["//visibility:private"],
+    deps = select({
+        ":linux": [
+            "@blas",
+            "@lapack",
+        ],
+        "@//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "scsdir",
+    srcs = [":libscsdir.so"],
+    hdrs = SCS_HDRS,
+    defines = ["LAPACK_LIB_FOUND=1"],
+    includes = ["include"],
+)
+
+cc_library(
+    name = "scsindir",
+    srcs = glob([
+        "linsys/*.c",
+        "linsys/*.h",
+        "linsys/indirect/*.c",
+        "linsys/indirect/*.h",
+        "src/*.c",
+    ]),
+    hdrs = SCS_HDRS,
+    defines = ["LAPACK_LIB_FOUND=1"],
+    includes = ["include"],
+    linkopts = select({
+        ":darwin": ["-framework Accelerate"],
+        ":linux": ["-lrt"],
+        "@//conditions:default": [],
+    }),
+    deps = select({
+        ":linux": [
+            "@blas",
+            "@lapack",
+        ],
+        "@//conditions:default": [],
+    }),
+)
+
+cmake_config(
+    package = "scs",
+    script = "@drake//tools/workspace/scs:scs-create-cps.py",
+    version_file = "include/constants.h",
+)
+
+install_cmake_config(package = "scs")
+
+install(
+    name = "install",
+    targets = [
+        ":libscsdir.so",
+        ":scsindir",
+    ],
+    hdrs = SCS_HDRS,
+    hdr_dest = "include/scs",
+    hdr_strip_prefix = ["include"],
+    docs = [
+        "LICENSE.txt",
+        "linsys/direct/external/AMD_README.txt",
+        "linsys/direct/external/LDL_README.txt",
+    ],
+    doc_strip_prefix = ["linsys/direct/external"],
+    deps = [":install_cmake_config"],
+)


### PR DESCRIPTION
Toward #3773. I strongly anticipate that we will choose one of `:scsdir` and `:scsindir` after initial testing (I do not think they will really coexist well in any case), so I have deliberately not factored out the commonality between them. Note that the direct linear system solver (used by `:scsdir`) contains LGPL v2.1+ code. FYI @hongkai-dai.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7419)
<!-- Reviewable:end -->