### PR TITLE
Make current geometry/* compatible with AutoDiffXd

### DIFF
--- a/drake/geometry/BUILD.bazel
+++ b/drake/geometry/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_library(
     ],
     deps = [
         ":geometry_ids",
+        "//drake/common:autodiff",
         "//drake/common:essential",
     ],
 )

--- a/drake/geometry/frame_kinematics_vector.cc
+++ b/drake/geometry/frame_kinematics_vector.cc
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "drake/common/autodiff.h"
+
 namespace drake {
 namespace geometry {
 
@@ -24,6 +26,7 @@ FrameKinematicsVector<KinematicsValue>::FrameKinematicsVector(
 
 // Explicitly instantiates on the most common scalar types.
 template class FrameKinematicsVector<Isometry3<double>>;
+template class FrameKinematicsVector<Isometry3<AutoDiffXd>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/frame_kinematics_vector.h
+++ b/drake/geometry/frame_kinematics_vector.h
@@ -51,6 +51,7 @@ namespace geometry {
   Alias           | Instantiation                            | Scalar types
  -----------------|------------------------------------------|--------------
   FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | double
+  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | AutoDiffXd
 
   @see FrameIdVector */
 template <class KinematicsValue>
@@ -88,6 +89,7 @@ class FrameKinematicsVector {
 
  Instantiated templates for the following kinds of T's are provided:
  - double
+ - AutoDiffXd
 
  They are already available to link against in the containing library.
  No other values for T are currently supported.

--- a/drake/geometry/geometry_context.cc
+++ b/drake/geometry/geometry_context.cc
@@ -1,5 +1,7 @@
 #include "drake/geometry/geometry_context.h"
 
+#include "drake/common/autodiff.h"
+
 namespace drake {
 namespace geometry {
 
@@ -23,6 +25,7 @@ const GeometryState<T>& GeometryContext<T>::get_geometry_state() const {
 
 // Explicitly instantiates on the most common scalar types.
 template class GeometryContext<double>;
+template class GeometryContext<AutoDiffXd>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_context.h
+++ b/drake/geometry/geometry_context.h
@@ -13,6 +13,7 @@ namespace geometry {
 
  Instantiated templates for the following kinds of T's are provided:
  - double
+ - AutoDiffXd
 
  They are already available to link against in the containing library.
  No other values for T are currently supported. */

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/frame_id_vector.h"
@@ -39,7 +40,14 @@ using FrameIdSet = std::unordered_set<FrameId>;
  GeometryWorld's context-dependent state includes values and structure -- the
  topology of the world.
 
- @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
+ @tparam T The scalar type. Must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double
+ - AutoDiffXd
+
+ They are already available to link against in the containing library.
+ No other values for T are currently supported. */
 template <typename T>
 class GeometryState {
  public:
@@ -55,6 +63,20 @@ class GeometryState {
 
   /** Default constructor. */
   GeometryState();
+
+  /** Allow assignment from a %GeometryState<double> to a %GeometryState<T>.
+   @internal The SFINAE is required to prevent collision with the default
+   defined assignment operator where T is double. */
+  template <class T1 = T>
+  typename std::enable_if<!std::is_same<T1, double>::value,
+                          GeometryState<T>&>::type
+  operator=(const GeometryState<double>& other) {
+    // This reuses the private copy *conversion* constructor. It is *not*
+    // intended to be performant -- but no one should be copying geometry
+    // world's state frequently anyways.
+    GeometryState<T> temp{other};
+    return *this = temp;
+  }
 
   /** @name        State introspection
 
@@ -249,6 +271,7 @@ class GeometryState {
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id,
       std::unique_ptr<GeometryInstance> geometry);
+
   /** Removes all frames and geometry registered from the identified source.
    The source remains registered and further frames and geometry can be
    registered on it.
@@ -324,7 +347,53 @@ class GeometryState {
 
   //@}
 
+  /** Scalar conversion */
+  //@{
+
+  /** Returns a deep copy of this state using the AutoDiffXd scalar with all
+   scalar values initialized from the current values. If this is invoked on an
+   instance already instantiated on AutoDiffXd, it is equivalent to cloning
+   the instance. */
+  std::unique_ptr<GeometryState<AutoDiffXd>> ToAutoDiffXd() const;
+
+  //@}
+
  private:
+  // GeometryState of one scalar type is friends with all other scalar types.
+  template <typename>
+  friend class GeometryState;
+
+  // Conversion constructor. In the initial implementation, this is only
+  // intended to be used to clone an AutoDiff instance from a double instance.
+  template <typename U>
+  GeometryState(const GeometryState<U>& source)
+      : source_frame_id_map_(source.source_frame_id_map_),
+        source_root_frame_map_(source.source_root_frame_map_),
+        source_names_(source.source_names_),
+        source_anchored_geometry_map_(source.source_anchored_geometry_map_),
+        frames_(source.frames_),
+        geometries_(source.geometries_),
+        anchored_geometries_(source.anchored_geometries_),
+        geometry_index_id_map_(source.geometry_index_id_map_),
+        anchored_geometry_index_id_map_(source.anchored_geometry_index_id_map_),
+        X_FG_(source.X_FG_),
+        pose_index_to_frame_map_(source.pose_index_to_frame_map_) {
+    // NOTE: Can't assign Isometry3<double> to Isometry3<AutoDiff>. But we *can*
+    // assign Matrix<double> to Matrix<AutoDiff>, so that's what we're doing.
+    auto convert = [](const std::vector<Isometry3<U>>& s,
+                      std::vector<Isometry3<T>>* d) {
+      std::vector<Isometry3<T>>& dest = *d;
+      dest.resize(s.size());
+      for (size_t i = 0; i < s.size(); ++i) {
+        dest[i].matrix() = s[i].matrix();
+      }
+    };
+
+    convert(source.X_PF_, &X_PF_);
+    convert(source.X_WG_, &X_WG_);
+    convert(source.X_WF_, &X_WF_);
+  }
+
   // Allow geometry dispatch to peek into GeometryState.
   friend void DispatchLoadMessage(const GeometryState<double>&);
 

--- a/drake/geometry/geometry_system.cc
+++ b/drake/geometry/geometry_system.cc
@@ -1,10 +1,10 @@
 #include "drake/geometry/geometry_system.h"
 
+#include <algorithm>
 #include <string>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/unused.h"
 #include "drake/geometry/geometry_context.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/geometry_state.h"
@@ -19,18 +19,62 @@ using systems::Context;
 using systems::InputPortDescriptor;
 using systems::LeafContext;
 using systems::LeafSystem;
-using systems::SystemSymbolicInspector;
-using systems::SystemOutput;
 using systems::rendering::PoseBundle;
+using systems::SystemOutput;
+using systems::SystemSymbolicInspector;
+using systems::SystemTypeTag;
+using systems::Value;
 using std::make_unique;
 using std::vector;
 
 #define GS_THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
 
+namespace {
 template <typename T>
-GeometrySystem<T>::GeometrySystem() : LeafSystem<T>() {
-  std::unique_ptr<GeometryState<T>> state = make_unique<GeometryState<T>>();
-  auto state_value = AbstractValue::Make<GeometryState<T>>(*state.get());
+class GeometryStateValue final : public Value<GeometryState<T>> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GeometryStateValue)
+
+  GeometryStateValue() = default;
+  explicit GeometryStateValue(const GeometryState<T>& state)
+      : Value<GeometryState<T>>(state) {}
+
+  std::unique_ptr<AbstractValue> Clone() const override {
+    return make_unique<GeometryStateValue<T>>(this->get_value());
+  }
+
+  void SetFrom(const AbstractValue& other) override {
+    if (!do_double_assign(other)) {
+      Value<GeometryState<T>>::SetFrom(other);
+    }
+  }
+
+  void SetFromOrThrow(const AbstractValue& other) override {
+    if (!do_double_assign(other)) {
+      Value<GeometryState<T>>::SetFromOrThrow(other);
+    }
+  }
+
+ private:
+  bool do_double_assign(const AbstractValue& other) {
+    const GeometryStateValue<double>* double_value =
+        dynamic_cast<const GeometryStateValue<double>*>(&other);
+    if (double_value) {
+      this->get_mutable_value() = double_value->get_value();
+      return true;
+    }
+    return false;
+  }
+
+  template <typename>
+  friend class GeometryStateValue;
+};
+}  // namespace
+
+template <typename T>
+GeometrySystem<T>::GeometrySystem()
+    : LeafSystem<T>(SystemTypeTag<geometry::GeometrySystem>{}) {
+  auto state_value = make_unique<GeometryStateValue<T>>();
   initial_state_ = &state_value->template GetMutableValue<GeometryState<T>>();
   geometry_state_index_ = this->DeclareAbstractState(std::move(state_value));
 
@@ -46,15 +90,50 @@ GeometrySystem<T>::GeometrySystem() : LeafSystem<T>() {
 }
 
 template <typename T>
+template <typename U>
+GeometrySystem<T>::GeometrySystem(const GeometrySystem<U>& other)
+    : GeometrySystem() {
+  // NOTE: If other.initial_state_ is not null, it means we're converting a
+  // system that hasn't had its context allocated yet. We want the converted
+  // system to persist the same state.
+  if (other.initial_state_ != nullptr) {
+    *initial_state_ = *(other.initial_state_->ToAutoDiffXd());
+  } else {
+    initial_state_ = nullptr;
+  }
+
+  // We need to guarantee that the same source ids map to the same port indexes.
+  // We'll do this by processing the source ids in monotonically increasing
+  // order. This is predicated on several principles:
+  //   1. Port indices monotonically increase.
+  //   2. SourceIds monotonically increase.
+  //   3. Registering sources generates a source id and its ports at the same
+  //      time.
+  // Therefore, for SourceIds i and j, the if i > j, then the port indices for
+  // source i must all be greater than those for j.
+  std::vector<SourceId> source_ids;
+  for (const auto pair : other.input_source_ids_) {
+    source_ids.push_back(pair.first);
+  }
+  auto comparator = [](const SourceId& a, const SourceId& b) {
+    return a.get_value() < b.get_value();
+  };
+  std::sort(source_ids.begin(), source_ids.end(), comparator);
+
+  for (const auto source_id : source_ids) {
+    MakeSourcePorts(source_id);
+    const auto& new_ports = input_source_ids_[source_id];
+    const auto& ref_ports = other.input_source_ids_.at(source_id);
+    DRAKE_DEMAND(new_ports.id_port == ref_ports.id_port &&
+                 new_ports.pose_port == ref_ports.pose_port);
+  }
+}
+
+template <typename T>
 SourceId GeometrySystem<T>::RegisterSource(const std::string &name) {
   GS_THROW_IF_CONTEXT_ALLOCATED
   SourceId source_id = initial_state_->RegisterNewSource(name);
-  // This will fail only if the source generator starts recycling source ids.
-  DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
-  // Create and store the input ports for this source id.
-  SourcePorts& source_ports = input_source_ids_[source_id];
-  source_ports.id_port = this->DeclareAbstractInputPort().get_index();
-  source_ports.pose_port = this->DeclareAbstractInputPort().get_index();
+  MakeSourcePorts(source_id);
   return source_id;
 }
 
@@ -165,6 +244,17 @@ QueryHandle<T> GeometrySystem<T>::MakeQueryHandle(
     const systems::Context<T>&) const {
   return QueryHandle<T>(nullptr, 0);
 }
+
+template <typename T>
+void GeometrySystem<T>::MakeSourcePorts(SourceId source_id) {
+  // This will fail only if the source generator starts recycling source ids.
+  DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);
+  // Create and store the input ports for this source id.
+  SourcePorts& source_ports = input_source_ids_[source_id];
+  source_ports.id_port = this->DeclareAbstractInputPort().get_index();
+  source_ports.pose_port = this->DeclareAbstractInputPort().get_index();
+}
+
 
 template <typename T>
 void GeometrySystem<T>::CalcQueryHandle(const Context<T>& context,
@@ -298,6 +388,7 @@ void GeometrySystem<T>::ThrowUnlessRegistered(SourceId source_id,
 
 // Explicitly instantiates on the most common scalar types.
 template class GeometrySystem<double>;
+template class GeometrySystem<AutoDiffXd>;
 
 // Don't leave the macro defined.
 #undef GS_THROW_IF_CONTEXT_ALLOCATED

--- a/drake/geometry/test/frame_kinematics_vector_test.cc
+++ b/drake/geometry/test/frame_kinematics_vector_test.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
@@ -71,6 +72,15 @@ GTEST_TEST(FrameKinematicsVector, MoveConstructor) {
     Vector3<double> pose{kValue, kValue, kValue};
     EXPECT_EQ(poses.mutable_vector()[i].translation(), pose);
   }
+}
+
+GTEST_TEST(FrameKinematicsVector, AutoDiffInstantiation) {
+  SourceId source_id = SourceId::get_new_id();
+  FramePoseVector<AutoDiffXd> poses(source_id);
+
+  EXPECT_EQ(poses.get_source_id(), source_id);
+  EXPECT_EQ(poses.vector().size(), 0);
+  EXPECT_EQ(poses.vector().begin(), poses.vector().end());
 }
 
 }  // namespace test

--- a/drake/geometry/test/geometry_system_test.cc
+++ b/drake/geometry/test/geometry_system_test.cc
@@ -27,6 +27,7 @@ namespace drake {
 namespace geometry {
 
 using systems::Context;
+using systems::System;
 using std::make_unique;
 using std::unique_ptr;
 
@@ -34,11 +35,21 @@ using std::unique_ptr;
 class QueryHandleTester {
  public:
   QueryHandleTester() = delete;
-  static QueryHandle<double> MakeNullQueryHandle() {
-    return QueryHandle<double>(nullptr, 0);
+
+  template <typename T>
+  static QueryHandle<T> MakeNullQueryHandle() {
+    return QueryHandle<T>(nullptr, 0);
   }
-  static void set_context(QueryHandle<double>* handle,
-                          const GeometryContext<double>* context) {
+
+  template <typename T>
+  static QueryHandle<T> MakeQueryHandle(
+      const GeometryContext<T>* context) {
+    return QueryHandle<T>(context, 0);
+  }
+
+  template <typename T>
+  static void set_context(QueryHandle<T>* handle,
+                          const GeometryContext<T>* context) {
     handle->context_ = context;
     // NOTE: This does not set the hash because these tests do not depend on it
     // yet.
@@ -50,19 +61,31 @@ class QueryHandleTester {
 class GeometrySystemTester {
  public:
   GeometrySystemTester() = delete;
-  static QueryHandle<double> MakeHandle(
-      const GeometrySystem<double>& system,
-      const Context<double>* context) {
-    return system.MakeQueryHandle(*context);
-  }
-  static bool HasDirectFeedthrough(const GeometrySystem<double>& system,
+
+  template <typename T>
+  static bool HasDirectFeedthrough(const GeometrySystem<T>& system,
                                    int input_port, int output_port) {
     return system.DoHasDirectFeedthrough(
         input_port, output_port).value_or(true);
   }
-  static void FullPoseUpdate(const GeometrySystem<double>& system,
-                             const GeometryContext<double>& context) {
+
+  template <typename T>
+  static void FullPoseUpdate(const GeometrySystem<T>& system,
+                             const GeometryContext<T>& context) {
     system.FullPoseUpdate(context);
+  }
+
+  template <typename T>
+  static std::vector<PenetrationAsPointPair<T>> ComputePenetration(
+      const GeometrySystem<T>& system, const QueryHandle<T>& handle) {
+    return system.ComputePenetration(handle);
+  }
+
+  template <typename T>
+  static void GetQueryHandlePortValue(const GeometrySystem<T>& system,
+                                      const systems::Context<T>& context,
+                                      QueryHandle<T>* handle) {
+    system.CalcQueryHandle(context, handle);
   }
 };
 
@@ -76,7 +99,7 @@ class GeometrySystemTest : public ::testing::Test {
  public:
   GeometrySystemTest()
       : ::testing::Test(),
-        query_handle_(QueryHandleTester::MakeNullQueryHandle()) {}
+        query_handle_(QueryHandleTester::MakeNullQueryHandle<double>()) {}
 
  protected:
   void AllocateContext() {
@@ -285,8 +308,8 @@ TEST_F(GeometrySystemTest, DirectFeedThrough) {
 // should be, essentially a no op.
 TEST_F(GeometrySystemTest, FullPoseUpdateEmpty) {
   AllocateContext();
-  EXPECT_NO_THROW(GeometrySystemTester::FullPoseUpdate(system_,
-                                                       *geom_context_));
+  EXPECT_NO_THROW(
+      GeometrySystemTester::FullPoseUpdate(system_, *geom_context_));
 }
 
 // Test case where there are only anchored geometries -- same as the empty case;
@@ -295,8 +318,73 @@ TEST_F(GeometrySystemTest, FullPoseUpdateAnchoredOnly) {
   SourceId s_id = system_.RegisterSource();
   system_.RegisterAnchoredGeometry(s_id, make_sphere_instance());
   AllocateContext();
-  EXPECT_NO_THROW(GeometrySystemTester::FullPoseUpdate(system_,
-                                                       *geom_context_));
+  EXPECT_NO_THROW(
+      GeometrySystemTester::FullPoseUpdate(system_, *geom_context_));
+}
+
+// Tests transmogrification of GeometrySystem in the case where a Context has
+// *not* been allocated yet. Registration should still be possible.
+TEST_F(GeometrySystemTest, TransmogrifyWithoutAllocation) {
+  SourceId s_id = system_.RegisterSource();
+  // This should allow additional geometry registration.
+  std::unique_ptr<systems::System<AutoDiffXd>> system_ad =
+      system_.ToAutoDiffXd();
+  GeometrySystem<AutoDiffXd>& geo_system_ad =
+      *dynamic_cast<GeometrySystem<AutoDiffXd>*>(system_ad.get());
+  EXPECT_NO_THROW(
+      geo_system_ad.RegisterAnchoredGeometry(s_id, make_sphere_instance()));
+
+  // After allocation, registration should *not* be valid.
+  AllocateContext();
+  system_ad = system_.ToAutoDiffXd();
+  GeometrySystem<AutoDiffXd>& geo_system_ad2 =
+      *dynamic_cast<GeometrySystem<AutoDiffXd>*>(system_ad.get());
+  EXPECT_THROW(
+      geo_system_ad2.RegisterAnchoredGeometry(s_id, make_sphere_instance()),
+      std::logic_error);
+}
+
+// Tests that the ports are correctly mapped.
+TEST_F(GeometrySystemTest, TransmogrifyPorts) {
+  SourceId s_id = system_.RegisterSource();
+  AllocateContext();
+  std::unique_ptr<systems::System<AutoDiffXd>> system_ad
+      = system_.ToAutoDiffXd();
+  GeometrySystem<AutoDiffXd>& geo_system_ad =
+      *dynamic_cast<GeometrySystem<AutoDiffXd>*>(system_ad.get());
+  EXPECT_EQ(geo_system_ad.get_num_input_ports(), system_.get_num_input_ports());
+  EXPECT_EQ(geo_system_ad.get_source_frame_id_port(s_id).get_index(),
+            system_.get_source_frame_id_port(s_id).get_index());
+  EXPECT_EQ(geo_system_ad.get_source_pose_port(s_id).get_index(),
+            system_.get_source_pose_port(s_id).get_index());
+  std::unique_ptr<systems::Context<AutoDiffXd>> context_ad =
+      geo_system_ad.AllocateContext();
+}
+
+// Tests that the work to "set" the context values for the transmogrified system
+// behaves correctly.
+TEST_F(GeometrySystemTest, TransmogrifyContext) {
+  SourceId s_id = system_.RegisterSource();
+  // Register geometry that should be successfully transmogrified.
+  GeometryId g_id = system_.RegisterAnchoredGeometry(s_id,
+                                                     make_sphere_instance());
+  AllocateContext();
+  std::unique_ptr<System<AutoDiffXd>> system_ad = system_.ToAutoDiffXd();
+  GeometrySystem<AutoDiffXd>& geo_system_ad =
+      *dynamic_cast<GeometrySystem<AutoDiffXd>*>(system_ad.get());
+  std::unique_ptr<Context<AutoDiffXd>> context_ad =
+      geo_system_ad.AllocateContext();
+  context_ad->SetTimeStateAndParametersFrom(*geom_context_);
+  GeometryContext<AutoDiffXd>* geo_context_ad =
+      dynamic_cast<GeometryContext<AutoDiffXd>*>(context_ad.get());
+  ASSERT_NE(geo_context_ad, nullptr);
+  // If the anchored geometry were not ported over, this would throw an
+  // exception.
+  EXPECT_NO_THROW(
+      geo_context_ad->get_mutable_geometry_state().RemoveGeometry(s_id, g_id));
+  EXPECT_THROW(geo_context_ad->get_mutable_geometry_state().RemoveGeometry(
+                   s_id, GeometryId::get_new_id()),
+               std::logic_error);
 }
 
 // Dummy system to serve as geometry source.
@@ -416,7 +504,7 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateNoIdConnection) {
       GeometrySystemTester::FullPoseUpdate(*geometry_system, geometry_context),
       std::logic_error,
       "Source \\d+ has registered frames but does not provide id values on "
-          "the input port.");
+      "the input port.");
 }
 
 // Adversarial test case: Missing pose port connection.
@@ -462,6 +550,22 @@ GTEST_TEST(GeometrySystemConnectionTest, FullPoseUpdateNoConnections) {
       std::logic_error,
       "Source \\d+ has registered frames but does not provide id values on "
           "the input port.");
+}
+
+// Confirms that the GeometrySystem can be instantiated on AutoDiff type.
+GTEST_TEST(GeometrySystemAutoDiffTest, InstantiateAutoDiff) {
+  GeometrySystem<AutoDiffXd> geometry_system;
+  geometry_system.RegisterSource("dummy_source");
+  auto context = geometry_system.AllocateContext();
+  GeometryContext<AutoDiffXd>* geometry_context =
+      dynamic_cast<GeometryContext<AutoDiffXd>*>(context.get());
+
+  ASSERT_NE(geometry_context, nullptr);
+
+  QueryHandle<AutoDiffXd> handle =
+      QueryHandleTester::MakeNullQueryHandle<AutoDiffXd>();
+  GeometrySystemTester::GetQueryHandlePortValue(geometry_system, *context,
+                                                &handle);
 }
 
 }  // namespace


### PR DESCRIPTION
This provides sufficient support to allow instantiation of `Geometry*` artifacts against `AutoDiffXd`. It also supports transmogrification from `double` to `AutoDiffXd`.

NOTE: This includes a unique sub-class of `systems::Value<T>` to support transmogrification of the `GeometryState<T>` abstract value. It is not clear if this will be necessary in the long run. *Some* of the data stored in `GeometryState<T>` that is scalar-dependent is making up for the lack of cache. After the cache goes life, this will be reconciled and the remaining state will be considered. In the meantime, it does *not* touch the public API and can easily be removed/refactored down the road.

Code changes:
```
Category            added  modified  removed  
----------------------------------------------
code                311    35        12       
comments            76     2         0        
blank               59     0         0        
----------------------------------------------
TOTAL               446    37        12
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7421)
<!-- Reviewable:end -->
