### PR TITLE
Disable PowEmptyExponentDerivative

### DIFF
--- a/drake/common/test/autodiff_overloads_test.cc
+++ b/drake/common/test/autodiff_overloads_test.cc
@@ -118,7 +118,8 @@ GTEST_TEST(AutodiffOverloadsTest, Pow) {
 
 // Tests that pow(AutoDiffScalar, AutoDiffScalar) computes sane derivatives for
 // base^exponent at the corner case base = 0, exponent.derivatives() = {0}.
-GTEST_TEST(AutodiffOverloadsTest, PowEmptyExponentDerivative) {
+// TODO(jadecastro) Re-enable this test case once Mac is fixed.
+GTEST_TEST(AutodiffOverloadsTest, DISABLED_PowEmptyExponentDerivative) {
   Eigen::AutoDiffScalar<Vector1d> x;
   x.value() = 0.;
   x.derivatives() = Eigen::VectorXd::Unit(1, 0);


### PR DESCRIPTION
It should be re-enabled once the Mac Sierra problem is fixed.

Closes #7424.  Relates to #7366.

If this PR merges, we should open an issue to re-enable the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7425)
<!-- Reviewable:end -->
