### PR TITLE
Use the full include path for babyboot

### DIFF
--- a/drake/multibody/benchmarks/chaotic_babyboot/MG/MG_chaotic_babyboot_auto_generated.cc
+++ b/drake/multibody/benchmarks/chaotic_babyboot/MG/MG_chaotic_babyboot_auto_generated.cc
@@ -6,7 +6,7 @@
 // This copyright notice must appear in all copies and distributions.
 // MotionGenesis Professional Licensee: Toyota Research Institute.
 // -----------------------------------------------------------------------------
-#include "MG_chaotic_babyboot_auto_generated.h"
+#include "drake/multibody/benchmarks/chaotic_babyboot/MG/MG_chaotic_babyboot_auto_generated.h"
 
 #include <cmath>
 


### PR DESCRIPTION
Relates #6996.

Even though it is generated code, it is unreasonably difficult in the context of 6996 to support a relative include path here.

By contrast, the `MG_kuka_iiwa_robot_auto_generated.cc` file already uses the full include path, so this is not without precedent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7430)
<!-- Reviewable:end -->
