### PR TITLE
Use drake_java_binary for automotive lcm-spy

### DIFF
--- a/drake/automotive/BUILD.bazel
+++ b/drake/automotive/BUILD.bazel
@@ -7,6 +7,10 @@ load(
     "drake_cc_binary",
 )
 load(
+    "@drake//tools/skylark:drake_java.bzl",
+    "drake_java_binary",
+)
+load(
     "@drake//tools/skylark:drake_py.bzl",
     "drake_py_binary",
 )
@@ -417,7 +421,7 @@ drake_py_binary(
     ],
 )
 
-java_binary(
+drake_java_binary(
     name = "lcm-spy",
     main_class = "lcm.spy.Spy",
     runtime_deps = [


### PR DESCRIPTION
Relates #6996.

This is both good hygiene, and also required for 6996 to work.

In general, we should always use Drake's wrappers for Bazel-native rules, so that we have a single seam to make any cross-cutting changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7431)
<!-- Reviewable:end -->
