### PR TITLE
Remove vtk from drake.cps.

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -74,14 +74,6 @@
       "Hints": ["@prefix@/lib/cmake/tinyobjloader"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "VTK": {
-      "Version": "8.0.1",
-      "Hints": [
-        "@prefix@/lib/cmake/vtk-8.0",
-        "/usr/local/opt/vtk@8.0/lib/cmake/vtk-8.0"
-      ],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "yaml-cpp": {
       "Version": "0.5.5",
       "Hints": ["@prefix@/lib/cmake/yaml-cpp"],
@@ -105,15 +97,6 @@
       "Link-Requires": [
         "fmt:fmt",
         "SDFormat:sdformat",
-        "vtkCommonCore",
-        "vtkCommonDataModel",
-        "vtkCommonTransforms",
-        "vtkFiltersGeneral",
-        "vtkFiltersSources",
-        "vtkIOGeometry",
-        "vtkIOImage",
-        "vtkRenderingCore",
-        "vtkRenderingOpenGL2",
         "ZLIB:ZLIB"
       ],
       "Requires": [


### PR DESCRIPTION
Per the comments in https://github.com/RobotLocomotion/drake-shambhala/issues/38
VTK was listed in drake.cps to make sure that it is linked in the event
libdrake.so is not explicitly linking to it. But the config referenced [[1]]
does indeed explicitly link VTK.

Removing this resolves errors with https://github.com/stonier/drake_pcl finding
Drake's VTK CMake config rather than the system VTK and not linking correctly.

[1]: https://github.com/RobotLocomotion/drake/blob/bdf86c07394b310a1f07b4e024fa3b84aed43d99/tools/install/libdrake/BUILD.bazel#L109

FYI @jamiesnape @stonier who collaborated on this with me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7434)
<!-- Reviewable:end -->
