### PR TITLE
Add variables to Drake's Eigen CMake config for PCL.

### DIFF
--- a/tools/workspace/eigen/eigen-create-cps.py
+++ b/tools/workspace/eigen/eigen-create-cps.py
@@ -17,6 +17,10 @@ content = """
       "Type": "interface",
       "Includes": [ "@prefix@/include/eigen3" ]
     }
+  },
+  "X-CMake-Variables": {
+    "EIGEN_FOUND": "ON",
+    "EIGEN_INCLUDE_DIRS": "${CMAKE_CURRENT_LIST_DIR}/../../../include/eigen3"
   }
 }
 """ % defs


### PR DESCRIPTION
For the benefit of PCL's particular CMake config [[1]] add variables to Eigen's
CMake config that PCLConfig.cmake will expect to find in order to make sure that
PCL uses Drake's Eigen rather than the system version in projects using Drake.

[1]: https://github.com/PointCloudLibrary/pcl/blob/438838d9c267d89f37f587ad4b9d241a38411eca/PCLConfig.cmake.in#L115-L124

FYI @stonier @jamiesnape who collaborated on this with me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7435)
<!-- Reviewable:end -->
