### PR TITLE
kuka_plan_runner can find resources when installed

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
-from os.path import dirname, join, pardir, realpath
+from os.path import abspath
 from platform import python_version_tuple
 from sys import stderr
 
@@ -9,31 +9,11 @@ from . import common
 from .util import ModuleShim
 
 
-def _init_path():
-    # Adding searchable path as inferred by pydrake. This assumes that the
-    # python module has not been moved outside of the installation directory
-    # (in which the data has also been installed).
-    path = dirname(__file__)
-    version = ".".join(python_version_tuple()[:2])
-    # In the install tree. pydrake Python module is in
-    # `lib/python2.7/site-packages/pydrake/` whereas the data is installed in
-    # `share/drake`. From the current file location, the data is 4 directories
-    # up. If pydrake is not in the expected directory, `path` is not added to
-    # the resource search path.
-    if path.endswith("lib/python" + version + "/site-packages/pydrake"):
-        common.AddResourceSearchPath(
-            realpath(join(path,
-                          pardir, pardir, pardir, pardir,
-                          "share/drake"))
-        )
-
-
 def getDrakePath():
     # Compatibility alias.
-    return common.GetDrakePath()
+    return abspath(common.GetDrakePath())
 
 
-_init_path()
 __all__ = ['common', 'getDrakePath']
 
 

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -233,11 +233,22 @@ DRAKE_RESOURCE_SENTINEL = adjust_label_for_drake_hoist(
 
 drake_cc_library(
     name = "find_resource",
-    srcs = ["find_resource.cc"],
-    hdrs = ["find_resource.h"],
+    srcs = [
+        "find_loaded_library.cc",
+        "find_resource.cc",
+    ],
+    hdrs = [
+        "find_loaded_library.h",
+        "find_resource.h",
+    ],
     data = [
         DRAKE_RESOURCE_SENTINEL,
     ],
+    # for libdrake.so path on linux
+    linkopts = select({
+        "//tools/cc_toolchain:linux": ["-ldl"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":essential",
         "@spruce",
@@ -589,6 +600,13 @@ drake_cc_googletest(
     data = [
         "test/find_resource_test_data.txt",
     ],
+    deps = [
+        ":find_resource",
+    ],
+)
+
+drake_cc_googletest(
+    name = "find_loaded_library_test",
     deps = [
         ":find_resource",
     ],

--- a/common/find_loaded_library.cc
+++ b/common/find_loaded_library.cc
@@ -1,0 +1,102 @@
+#include "drake/common/find_loaded_library.h"
+
+#ifdef __APPLE__
+#include <dlfcn.h>
+
+#include <mach-o/dyld.h>
+#include <mach-o/dyld_images.h>
+#else  // Not __APPLE__
+#include <libgen.h>
+#include <string.h>
+
+#include <link.h>
+#endif
+
+using std::string;
+
+namespace drake {
+
+#ifdef __APPLE__
+
+// This code has been adapted from:
+// https://stackoverflow.com/questions/4309117/determining-programmatically-what-modules-are-loaded-in-another-process-os-x/23229148#23229148
+
+namespace {
+// Reads memory from MacOS specific structures into an `unsigned char*`.
+unsigned char * ReadProcessMemory(mach_vm_address_t addr,
+                                  mach_msg_type_number_t* size) {
+  vm_offset_t readMem;
+
+  kern_return_t kr = vm_read(mach_task_self(), addr, *size,
+                             &readMem, size);
+  if (kr != KERN_SUCCESS) {
+    return NULL;
+  }
+  return (reinterpret_cast<unsigned char *>(readMem));
+}
+}  // namespace
+// Gets the list of all the dynamic libraries that have been loaded. Finds
+// `library_name` in the list, and returns its directory path appended
+// with relative directory to find resource files in drake install tree.
+// This function is specific to MacOS
+optional<string> LoadedLibraryPath(const string& library_name) {
+  task_dyld_info dyld_info;
+  mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+  // Getinformation from current process.
+  if (task_info(mach_task_self(), TASK_DYLD_INFO,
+    reinterpret_cast<task_info_t>(&dyld_info), &count) == KERN_SUCCESS) {
+    // Recover list of dynamic libraries.
+    mach_msg_type_number_t size = sizeof(dyld_all_image_infos);
+    unsigned char* data =
+      ReadProcessMemory(dyld_info.all_image_info_addr, &size);
+    if (!data) {
+      return nullopt;
+    }
+    dyld_all_image_infos* infos =
+      reinterpret_cast<dyld_all_image_infos *>(data);
+
+    // Recover number of dynamic libraries in list.
+    mach_msg_type_number_t size2 =
+      sizeof(dyld_image_info) * infos->infoArrayCount;
+    unsigned char* info_addr = ReadProcessMemory(
+        reinterpret_cast<mach_vm_address_t>(infos->infoArray), &size2);
+    if (!info_addr) {
+      return nullopt;
+    }
+    dyld_image_info* info =
+      reinterpret_cast<dyld_image_info*>(info_addr);
+
+    // Loop over the dynamic libraries until `library_name` is found.
+    for (uint32_t i=0; i < infos->infoArrayCount; i++) {
+      const char * pos_slash = strrchr(info[i].imageFilePath, '/');
+      if (!strcmp(pos_slash + 1, library_name.c_str())) {
+        return string(info[i].imageFilePath,
+          pos_slash - info[i].imageFilePath);
+      }
+    }
+  }
+  return nullopt;
+}
+#else  // Not __APPLE__
+
+// Gets the list of all the shared objects that have been loaded. Finds
+// `library_name` in the list, and returns its directory path appended
+// with relative directory to find resource files in drake install tree.
+// This function is specific to Linux.
+optional<string> LoadedLibraryPath(const std::string& library_name) {
+  optional<string> binary_dirname;
+  void* handle = dlopen(NULL, RTLD_NOW);
+  link_map *map;
+  dlinfo(handle, RTLD_DI_LINKMAP, &map);
+  // Loop over loaded shared objects until `library_name` is found.
+  while (map) {
+    if (!strcmp(basename(map->l_name), library_name.c_str())) {
+      binary_dirname = string(dirname(map->l_name));
+      break;
+    }
+    map = map->l_next;
+  }
+  return binary_dirname;
+}
+#endif
+}  // namespace drake

--- a/common/find_loaded_library.h
+++ b/common/find_loaded_library.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+
+/// This function returns the full path of the library with the name
+/// `library_name` if that library was loaded in the current running
+/// process. Otherwise it returns an empty optional.
+optional<std::string> LoadedLibraryPath(const std::string& library_name);
+
+
+}  // namespace drake

--- a/common/test/find_loaded_library_test.cc
+++ b/common/test/find_loaded_library_test.cc
@@ -1,0 +1,23 @@
+#include "drake/common/find_loaded_library.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using std::string;
+
+namespace drake {
+namespace {
+
+GTEST_TEST(FindLibraryTest, Library) {
+  // Test wether or not `LoadedLibraryPath()` can find the path to a library
+  // loaded by the process.
+  optional<string> library_path =
+    LoadedLibraryPath("libexternal_Scom_Ugithub_Ugflags_Ugflags_Slibgflags.so");
+  EXPECT_TRUE(library_path);
+  library_path = LoadedLibraryPath("lib_not_real.so");
+  EXPECT_FALSE(library_path);
+}
+
+}  // namespace
+}  // namespace drake

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "drake_cc_library",
     "drake_cc_binary",
     "drake_cc_googletest",
+    "drake_example_cc_binary",
 )
 load("//tools/install:install_data.bzl", "install", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
@@ -79,7 +80,7 @@ drake_cc_library(
     ],
 )
 
-drake_cc_binary(
+drake_example_cc_binary(
     name = "iiwa_controller",
     srcs = ["iiwa_controller.cc"],
     data = [
@@ -89,15 +90,11 @@ drake_cc_binary(
     deps = [
         ":iiwa_common",
         ":lcm_plan_interpolator",
-        "//drake/common:text_logging_gflags",
-        "//drake/lcm",
-        "//drake/systems/lcm",
-        "//drake/systems/lcm:lcm_driven_loop",
         "@com_github_gflags_gflags//:gflags",
     ],
 )
 
-drake_cc_binary(
+drake_example_cc_binary(
     name = "iiwa_wsg_simulation",
     srcs = ["iiwa_wsg_simulation.cc"],
     add_test_rule = 1,
@@ -113,25 +110,12 @@ drake_cc_binary(
         ":iiwa_common",
         ":iiwa_lcm",
         ":oracular_state_estimator",
-        "//drake/common:text_logging_gflags",
         "//drake/examples/kuka_iiwa_arm/iiwa_world:iiwa_wsg_diagram_factory",
-        "//drake/lcm",
-        "//drake/manipulation/schunk_wsg:schunk_wsg_constants",
-        "//drake/manipulation/schunk_wsg:schunk_wsg_controller",
-        "//drake/manipulation/schunk_wsg:schunk_wsg_lcm",
-        "//drake/manipulation/util:world_sim_tree_builder",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/systems/analysis",
-        "//drake/systems/controllers:inverse_dynamics_controller",
-        "//drake/systems/controllers:pid_controller",
-        "//drake/systems/primitives:constant_vector_source",
-        "//drake/systems/primitives:matrix_gain",
-        "//drake/util:lcm_util",
         "@com_github_gflags_gflags//:gflags",
     ],
 )
 
-drake_cc_binary(
+drake_example_cc_binary(
     name = "kuka_simulation",
     srcs = ["kuka_simulation.cc"],
     add_test_rule = 1,
@@ -145,21 +129,11 @@ drake_cc_binary(
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
-        "//drake/common:find_resource",
-        "//drake/common:text_logging_gflags",
-        "//drake/lcm",
-        "//drake/manipulation/util:sim_diagram_builder",
-        "//drake/manipulation/util:world_sim_tree_builder",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/multibody/rigid_body_plant:frame_visualizer",
-        "//drake/systems/analysis:simulator",
-        "//drake/systems/controllers:inverse_dynamics_controller",
-        "//drake/systems/primitives:constant_vector_source",
         "@com_github_gflags_gflags//:gflags",
     ],
 )
 
-drake_cc_binary(
+drake_example_cc_binary(
     name = "kuka_plan_runner",
     srcs = ["kuka_plan_runner.cc"],
     data = [
@@ -169,7 +143,6 @@ drake_cc_binary(
     deps = [
         ":iiwa_common",
         ":iiwa_lcm",
-        "//drake/common:find_resource",
         "@lcmtypes_bot2_core",
         "@lcmtypes_robotlocomotion",
     ],

--- a/tools/drake.bzl
+++ b/tools/drake.bzl
@@ -8,4 +8,5 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
     "drake_cc_test",
+    "drake_example_cc_binary",
 )

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -116,6 +116,7 @@ cc_library(
     strip_include_prefix = "/" if HAS_MOVED_6996 else None,
     visibility = adjust_labels_for_drake_hoist([
         "//drake/bindings/pydrake:__subpackages__",
+        "//drake/examples:__subpackages__",
     ]),
     deps = [
         ":gurobi_deps",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -513,3 +513,50 @@ def drake_cc_googletest(
         name = name,
         deps = deps,
         **kwargs)
+
+def drake_example_cc_binary(
+        srcs = [],
+        deps = [],
+        **kwargs):
+    """Creates a rule to declare a C++ binary using `libdrake.so`.
+
+    This rule is a wrapper around `drake_cc_binary()`. It adds `libdrake.so`
+    and `drake_lcmtypes_headers` as dependencies to the target.
+
+    This allows the creation of examples for drake that depend on `libdrake.so`
+    which let the process discover the location of drake resources at runtime
+    based on the location of `libdrake.so` which is loaded by the process.
+
+    This macro will fail-fast if there is ODR violation. This happens if this
+    macro adds dependendies (`deps` or `srcs`) that are already part of
+    libdrake.so or drake_lcmtypes_headers.
+    """
+    if not native.package_name().startswith("examples"):
+        fail("`drake_example_cc_binary()` macro should only be used in examples \
+            subdirectory.")
+    # This verifies that there is no ODR violation. Targets that are part of
+    # libdrake should not be included a second time. Only targets that are in
+    # //examples (historically //drake/examples) or in the workspace can be
+    # added as dependencies. By extension, this makes sure that
+    # //tools/install/libdrake:drake_shared_library is not added as a
+    # dependency a second time.
+    for dep in deps:
+        if not (dep.startswith('@') or
+                dep.startswith(':') or
+                dep.startswith('//examples') or
+                dep.startswith('//drake/examples')):
+            fail("Dependency used in `drake_example_cc_binary()` macro should\
+                not already be part of libdrake.so: %s" % dep)
+    # This makes sure that //tools/install/libdrake:libdrake.so and
+    # //lcmtypes:drake_lcmtypes_headers are not added to srcs a second time.
+    if ("//tools/install/libdrake:libdrake.so" in srcs or
+            "//lcmtypes:drake_lcmtypes_headers"in srcs):
+        fail("//tools/install/libdrake:libdrake.so and \
+            //lcmtypes:drake_lcmtypes_headers are already included in \
+            `drake_example_cc_binary()` macro")
+    drake_cc_binary(
+        srcs = srcs +
+        ["//tools/install/libdrake:libdrake.so",
+         "//lcmtypes:drake_lcmtypes_headers"],
+        deps = deps + ["//tools/install/libdrake:drake_shared_library"],
+        **kwargs)


### PR DESCRIPTION
kuka_plan_runner adds its own path to AddResourceSearchPath. Before this patch,
`FindResource()` was only using the environment variable or the current working
directory to find resources. No additional resource search path was set.

This is the easy solution and would have to be implemented in each executable. Another solution would be to add the current executable path in the resource search path as part of the process to find resources (in `find_resource.cc`). There is no cross-platform way of doing so without using `argv[0]`but one could use [this solution](https://stackoverflow.com/questions/22675457/what-is-the-equivalent-of-proc-self-exe-on-macintosh-os-x-mavericks) which implements a solution for Linux and MacOS. If Windows support was added to `drake`, one could use `GetModuleFileName`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7439)
<!-- Reviewable:end -->
