### PR TITLE
Update maliput API to use optional<LaneEnd> for default branches

### DIFF
--- a/drake/automotive/maliput/api/branch_point.h
+++ b/drake/automotive/maliput/api/branch_point.h
@@ -6,6 +6,7 @@
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -99,12 +100,10 @@ class BranchPoint {
   /// a turn).
   ///
   /// If @p end has no default-branch at this BranchPoint, the return
-  /// value will be nullptr.
+  /// value will be nullopt.
   ///
   /// @pre @p end must be connected to the BranchPoint.
-  // TODO(maddog@tri.global)  The return type yearns to be
-  //                          const boost::optional<LaneEnd>&.
-  std::unique_ptr<LaneEnd> GetDefaultBranch(const LaneEnd& end) const {
+  optional<LaneEnd> GetDefaultBranch(const LaneEnd& end) const {
     return DoGetDefaultBranch(end);
   }
 
@@ -132,7 +131,7 @@ class BranchPoint {
   virtual const LaneEndSet* DoGetOngoingBranches(
       const LaneEnd& end) const = 0;
 
-  virtual std::unique_ptr<LaneEnd> DoGetDefaultBranch(
+  virtual optional<LaneEnd> DoGetDefaultBranch(
       const LaneEnd& end) const = 0;
 
   virtual const LaneEndSet* DoGetASide() const = 0;

--- a/drake/automotive/maliput/api/lane.h
+++ b/drake/automotive/maliput/api/lane.h
@@ -7,6 +7,7 @@
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/autodiff.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -224,13 +225,9 @@ class Lane {
     return DoGetOngoingBranches(which_end);
   }
 
-  /// Returns the default ongoing LaneEnd connected at @p which_end.
-  ///
-  /// @returns nullptr if no default branch has been established
-  ///          at @p which_end.
-  // TODO(maddog@tri.global)  The return type yearns to be
-  //                          const boost::optional<LaneEnd>&.
-  std::unique_ptr<LaneEnd> GetDefaultBranch(
+  /// Returns the default ongoing LaneEnd connected at @p which_end,
+  /// or nullopt if no default branch has been established at @p which_end.
+  optional<LaneEnd> GetDefaultBranch(
       const LaneEnd::Which which_end) const {
     return DoGetDefaultBranch(which_end);
   }
@@ -282,7 +279,7 @@ class Lane {
   virtual const LaneEndSet* DoGetOngoingBranches(
       const LaneEnd::Which which_end) const = 0;
 
-  virtual std::unique_ptr<LaneEnd> DoGetDefaultBranch(
+  virtual optional<LaneEnd> DoGetDefaultBranch(
       const LaneEnd::Which which_end) const = 0;
 
   // AutoDiffXd overload of DoToGeoPosition().

--- a/drake/automotive/maliput/dragway/branch_point.cc
+++ b/drake/automotive/maliput/dragway/branch_point.cc
@@ -37,7 +37,7 @@ const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
   }
 }
 
-std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+optional<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
     const api::LaneEnd& end) const {
   // The result should be an ongoing branch for the given input. Thus, a Start
   // input should yield a Finish output (since start connects to finish) and
@@ -45,9 +45,9 @@ std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
   //
   // Since there is only one LaneEnd per side, return it as the default.
   if (end.end == api::LaneEnd::kStart) {
-    return std::make_unique<api::LaneEnd>(finish_side_lane_end_set_.get(0));
+    return finish_side_lane_end_set_.get(0);
   } else {
-    return std::make_unique<api::LaneEnd>(start_side_lane_end_set_.get(0));
+    return start_side_lane_end_set_.get(0);
   }
 }
 

--- a/drake/automotive/maliput/dragway/branch_point.h
+++ b/drake/automotive/maliput/dragway/branch_point.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -69,7 +70,7 @@ class BranchPoint final : public api::BranchPoint {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd& end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd& end) const override;
 
   const api::LaneEndSet* DoGetASide() const override;

--- a/drake/automotive/maliput/dragway/lane.cc
+++ b/drake/automotive/maliput/dragway/lane.cc
@@ -67,7 +67,7 @@ const api::LaneEndSet* Lane::DoGetOngoingBranches(
   return branch_point_->GetOngoingBranches({this, which_end});
 }
 
-std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
+optional<api::LaneEnd> Lane::DoGetDefaultBranch(
     api::LaneEnd::Which which_end) const {
   return branch_point_->GetDefaultBranch({this, which_end});
 }

--- a/drake/automotive/maliput/dragway/lane.h
+++ b/drake/automotive/maliput/dragway/lane.h
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/lane.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_autodiff_types.h"
 
 namespace drake {
@@ -139,7 +140,7 @@ class Lane final : public api::Lane {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd::Which which_end) const final;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd::Which which_end) const final;
 
   double do_length() const final { return length_; }

--- a/drake/automotive/maliput/dragway/test/dragway_test.cc
+++ b/drake/automotive/maliput/dragway/test/dragway_test.cc
@@ -258,15 +258,15 @@ class MaliputDragwayLaneTest : public ::testing::Test {
 
     // Verifies correctness of the default branches.
     {
-      std::unique_ptr<api::LaneEnd> default_start_lane_end =
+      optional<api::LaneEnd> default_start_lane_end =
           lane->GetDefaultBranch(api::LaneEnd::kStart);
-      EXPECT_NE(default_start_lane_end.get(), nullptr);
+      EXPECT_TRUE(default_start_lane_end);
       EXPECT_EQ(default_start_lane_end->end, api::LaneEnd::kFinish);
       EXPECT_EQ(default_start_lane_end->lane, lane);
 
-      std::unique_ptr<api::LaneEnd> default_finish_lane_end =
+      optional<api::LaneEnd> default_finish_lane_end =
           lane->GetDefaultBranch(api::LaneEnd::kFinish);
-      EXPECT_NE(default_finish_lane_end.get(), nullptr);
+      EXPECT_TRUE(default_finish_lane_end);
       EXPECT_EQ(default_finish_lane_end->end, api::LaneEnd::kStart);
       EXPECT_EQ(default_finish_lane_end->lane, lane);
     }

--- a/drake/automotive/maliput/monolane/branch_point.cc
+++ b/drake/automotive/maliput/monolane/branch_point.cc
@@ -24,11 +24,11 @@ const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
   return ongoing_branches_.at(end);
 }
 
-std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+optional<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
     const api::LaneEnd& end) const {
   auto default_it = defaults_.find(end);
-  if (default_it == defaults_.end()) { return nullptr; }
-  return std::make_unique<api::LaneEnd>(default_it->second);
+  if (default_it == defaults_.end()) { return nullopt; }
+  return default_it->second;
 }
 
 const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {

--- a/drake/automotive/maliput/monolane/branch_point.h
+++ b/drake/automotive/maliput/monolane/branch_point.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -72,7 +73,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd& end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd& end) const override;
 
   const api::LaneEndSet* DoGetASide() const override { return &a_side_; }

--- a/drake/automotive/maliput/monolane/lane.cc
+++ b/drake/automotive/maliput/monolane/lane.cc
@@ -28,7 +28,7 @@ const api::LaneEndSet* Lane::DoGetOngoingBranches(
   return GetBranchPoint(which_end)->GetOngoingBranches({this, which_end});
 }
 
-std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
+optional<api::LaneEnd> Lane::DoGetDefaultBranch(
     api::LaneEnd::Which which_end) const {
   return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
 }

--- a/drake/automotive/maliput/monolane/lane.h
+++ b/drake/automotive/maliput/monolane/lane.h
@@ -9,6 +9,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -231,7 +232,7 @@ class Lane : public api::Lane {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd::Which which_end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd::Which which_end) const override;
 
   double do_length() const override;

--- a/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
+++ b/drake/automotive/maliput/monolane/test/monolane_builder_test.cc
@@ -212,7 +212,7 @@ GTEST_TEST(MonolaneBuilderTest, QuadRing) {
                 api::LaneId("l:left1"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kFinish);
-      EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish).get(), nullptr);
+      EXPECT_FALSE(lane->GetDefaultBranch(api::LaneEnd::kFinish));
     } else {
       GTEST_FAIL();
     }

--- a/drake/automotive/maliput/multilane/branch_point.cc
+++ b/drake/automotive/maliput/multilane/branch_point.cc
@@ -24,11 +24,11 @@ const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
   return ongoing_branches_.at(end);
 }
 
-std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+optional<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
     const api::LaneEnd& end) const {
   auto default_it = defaults_.find(end);
-  if (default_it == defaults_.end()) { return nullptr; }
-  return std::make_unique<api::LaneEnd>(default_it->second);
+  if (default_it == defaults_.end()) { return nullopt; }
+  return default_it->second;
 }
 
 const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {

--- a/drake/automotive/maliput/multilane/branch_point.h
+++ b/drake/automotive/maliput/multilane/branch_point.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -72,7 +73,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd& end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd& end) const override;
 
   const api::LaneEndSet* DoGetASide() const override { return &a_side_; }

--- a/drake/automotive/maliput/multilane/lane.cc
+++ b/drake/automotive/maliput/multilane/lane.cc
@@ -30,7 +30,7 @@ const api::LaneEndSet* Lane::DoGetOngoingBranches(
   return GetBranchPoint(which_end)->GetOngoingBranches({this, which_end});
 }
 
-std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
+optional<api::LaneEnd> Lane::DoGetDefaultBranch(
     api::LaneEnd::Which which_end) const {
   return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
 }

--- a/drake/automotive/maliput/multilane/lane.h
+++ b/drake/automotive/maliput/multilane/lane.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/automotive/maliput/multilane/road_curve.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/unused.h"
 
@@ -119,7 +120,7 @@ class Lane : public api::Lane {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd::Which which_end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd::Which which_end) const override;
 
   double do_length() const override;

--- a/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -240,7 +240,7 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
                 api::LaneId("l:left1_0"));
       EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kStart)->end,
                 api::LaneEnd::kFinish);
-      EXPECT_EQ(lane->GetDefaultBranch(api::LaneEnd::kFinish).get(), nullptr);
+      EXPECT_FALSE(lane->GetDefaultBranch(api::LaneEnd::kFinish));
     } else {
       GTEST_FAIL();
     }

--- a/drake/automotive/maliput/rndf/branch_point.cc
+++ b/drake/automotive/maliput/rndf/branch_point.cc
@@ -24,13 +24,13 @@ const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
   return ongoing_branches_.at(end);
 }
 
-std::unique_ptr<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+optional<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
     const api::LaneEnd& end) const {
   auto default_it = defaults_.find(end);
   if (default_it == defaults_.end()) {
-    return nullptr;
+    return nullopt;
   }
-  return std::make_unique<api::LaneEnd>(default_it->second);
+  return default_it->second;
 }
 
 const api::LaneEnd& BranchPoint::AddABranch(const api::LaneEnd& lane_end) {

--- a/drake/automotive/maliput/rndf/branch_point.h
+++ b/drake/automotive/maliput/rndf/branch_point.h
@@ -8,6 +8,7 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -72,7 +73,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd& end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd& end) const override;
 
   const api::LaneEndSet* DoGetASide() const override { return &a_side_; }

--- a/drake/automotive/maliput/rndf/lane.cc
+++ b/drake/automotive/maliput/rndf/lane.cc
@@ -31,7 +31,7 @@ const api::LaneEndSet* Lane::DoGetOngoingBranches(
   return GetBranchPoint(which_end)->GetOngoingBranches({this, which_end});
 }
 
-std::unique_ptr<api::LaneEnd> Lane::DoGetDefaultBranch(
+optional<api::LaneEnd> Lane::DoGetDefaultBranch(
     api::LaneEnd::Which which_end) const {
   return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
 }

--- a/drake/automotive/maliput/rndf/lane.h
+++ b/drake/automotive/maliput/rndf/lane.h
@@ -7,6 +7,7 @@
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/automotive/maliput/rndf/branch_point.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 namespace maliput {
@@ -87,7 +88,7 @@ class Lane : public api::Lane {
   const api::LaneEndSet* DoGetOngoingBranches(
       const api::LaneEnd::Which which_end) const override;
 
-  std::unique_ptr<api::LaneEnd> DoGetDefaultBranch(
+  optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd::Which which_end) const override;
 
   const api::LaneId id_;

--- a/drake/automotive/maliput_railcar.cc
+++ b/drake/automotive/maliput_railcar.cc
@@ -422,34 +422,34 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
         next_state->template get_mutable_abstract_state<LaneDirection>(0);
     // TODO(liang.fok) Generalize the following to support the selection of
     // non-default branches or non-zero ongoing branches. See #5702.
-    std::unique_ptr<LaneEnd> next_branch;
+    optional<LaneEnd> next_branch;
     if (current_with_s) {
       next_branch = current_lane_direction.lane->GetDefaultBranch(
           LaneEnd::kFinish);
-      if (next_branch == nullptr) {
+      if (!next_branch) {
         const maliput::api::LaneEndSet* ongoing_lanes =
             current_lane_direction.lane->GetOngoingBranches(LaneEnd::kFinish);
         if (ongoing_lanes != nullptr) {
           if (ongoing_lanes->size() > 0) {
-            next_branch = std::make_unique<LaneEnd>(ongoing_lanes->get(0));
+            next_branch = ongoing_lanes->get(0);
           }
         }
       }
     } else {
       next_branch = current_lane_direction.lane->GetDefaultBranch(
           LaneEnd::kStart);
-      if (next_branch == nullptr) {
+      if (!next_branch) {
         const maliput::api::LaneEndSet* ongoing_lanes =
             current_lane_direction.lane->GetOngoingBranches(LaneEnd::kStart);
         if (ongoing_lanes != nullptr) {
           if (ongoing_lanes->size() > 0) {
-            next_branch = std::make_unique<LaneEnd>(ongoing_lanes->get(0));
+            next_branch = ongoing_lanes->get(0);
           }
         }
       }
     }
 
-    if (next_branch == nullptr) {
+    if (!next_branch) {
       DRAKE_ABORT_MSG("MaliputRailcar::DoCalcUnrestrictedUpdate: ERROR: "
           "Vehicle should switch lanes but no default or ongoing branch "
           "exists.");

--- a/drake/automotive/pose_selector.cc
+++ b/drake/automotive/pose_selector.cc
@@ -199,14 +199,14 @@ bool PoseSelector<T>::IsWithinLane(const LanePositionT<T>& lane_position,
 }
 
 template <typename T>
-std::unique_ptr<LaneEnd> PoseSelector<T>::GetDefaultOngoingLane(
+optional<LaneEnd> PoseSelector<T>::GetDefaultOngoingLane(
     LaneDirection* lane_direction) {
   const Lane* const lane{lane_direction->lane};
   const bool with_s{lane_direction->with_s};
-  std::unique_ptr<LaneEnd> branch =
+  optional<LaneEnd> branch =
       (with_s) ? lane->GetDefaultBranch(LaneEnd::kFinish)
                : lane->GetDefaultBranch(LaneEnd::kStart);
-  if (branch == nullptr) {
+  if (!branch) {
     lane_direction->lane = nullptr;
     lane_direction->with_s = true;
     return branch;

--- a/drake/automotive/pose_selector.h
+++ b/drake/automotive/pose_selector.h
@@ -12,6 +12,7 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/road_odometry.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/systems/rendering/pose_bundle.h"
 #include "drake/systems/rendering/pose_vector.h"
 
@@ -138,9 +139,9 @@ class PoseSelector {
  private:
   // Given a @p lane_direction, returns its default branch and updates @p
   // lane_direction to match the `lane` and `with_s` of that branch.  If there
-  // is no default branch, returns `nullptr` and sets `lane_direction->lane` to
+  // is no default branch, returns `nullopt` and sets `lane_direction->lane` to
   // `nullptr`.
-  static std::unique_ptr<maliput::api::LaneEnd> GetDefaultOngoingLane(
+  static optional<maliput::api::LaneEnd> GetDefaultOngoingLane(
       LaneDirection* lane_direction);
 
   // Returns a RoadOdometry that contains an infinite `s` position, zero `r` and

--- a/drake/automotive/test/maliput_railcar_test.cc
+++ b/drake/automotive/test/maliput_railcar_test.cc
@@ -262,9 +262,9 @@ class MaliputRailcarTest : public ::testing::Test {
     // Verifies that the end of the straight lane is connected to:
     //  - the start of the curved lane if it is not flipped.
     //  - the end of the curved lane if it is flipped.
-    std::unique_ptr<LaneEnd> straight_lane_end =
+    optional<LaneEnd> straight_lane_end =
         straight_lane->GetDefaultBranch(LaneEnd::kFinish);
-    ASSERT_NE(straight_lane_end, nullptr);
+    ASSERT_TRUE(straight_lane_end);
     EXPECT_EQ(straight_lane_end->end,
               flip_curve_lane ? LaneEnd::kFinish : LaneEnd::kStart);
     EXPECT_EQ(straight_lane_end->lane, curved_lane);
@@ -943,20 +943,20 @@ TEST_F(MaliputRailcarTest, TestTwoLaneStretchOfRoad) {
 
     // Verifies that the end of the straight lane is connected to the start of
     // the curved lane if it is not flipped.
-    std::unique_ptr<LaneEnd> straight_lane_start =
+    optional<LaneEnd> straight_lane_start =
         straight_lane->GetDefaultBranch(LaneEnd::kStart);
-    std::unique_ptr<LaneEnd> straight_lane_finish =
+    optional<LaneEnd> straight_lane_finish =
         straight_lane->GetDefaultBranch(LaneEnd::kFinish);
-    std::unique_ptr<LaneEnd> curved_lane_start =
+    optional<LaneEnd> curved_lane_start =
         curved_lane->GetDefaultBranch(LaneEnd::kStart);
-    std::unique_ptr<LaneEnd> curved_lane_finish =
+    optional<LaneEnd> curved_lane_finish =
         curved_lane->GetDefaultBranch(LaneEnd::kFinish);
-    EXPECT_EQ(straight_lane_start, nullptr);
-    ASSERT_NE(straight_lane_finish, nullptr);
+    EXPECT_FALSE(straight_lane_start);
+    ASSERT_TRUE(straight_lane_finish);
     EXPECT_EQ(straight_lane_finish->lane, curved_lane);
     EXPECT_EQ(straight_lane_finish->end, LaneEnd::kStart);
-    ASSERT_NE(curved_lane_start, nullptr);
-    EXPECT_EQ(curved_lane_finish, nullptr);
+    ASSERT_TRUE(curved_lane_start);
+    EXPECT_FALSE(curved_lane_finish);
     EXPECT_EQ(curved_lane_start->lane, straight_lane);
     EXPECT_EQ(curved_lane_start->end, LaneEnd::kFinish);
 
@@ -969,12 +969,12 @@ TEST_F(MaliputRailcarTest, TestTwoLaneStretchOfRoad) {
     straight_lane_finish = straight_lane->GetDefaultBranch(LaneEnd::kFinish);
     curved_lane_start = curved_lane->GetDefaultBranch(LaneEnd::kStart);
     curved_lane_finish = curved_lane->GetDefaultBranch(LaneEnd::kFinish);
-    EXPECT_EQ(straight_lane_start, nullptr);
-    ASSERT_NE(straight_lane_finish, nullptr);
+    EXPECT_FALSE(straight_lane_start);
+    ASSERT_TRUE(straight_lane_finish);
     EXPECT_EQ(straight_lane_finish->lane, curved_lane);
     EXPECT_EQ(straight_lane_finish->end, LaneEnd::kFinish);
-    ASSERT_NE(curved_lane_finish, nullptr);
-    EXPECT_EQ(curved_lane_start, nullptr);
+    ASSERT_TRUE(curved_lane_finish);
+    EXPECT_FALSE(curved_lane_start);
     EXPECT_EQ(curved_lane_finish->lane, straight_lane);
     EXPECT_EQ(curved_lane_finish->end, LaneEnd::kFinish);
 }

--- a/drake/automotive/test/monolane_onramp_merge_test.cc
+++ b/drake/automotive/test/monolane_onramp_merge_test.cc
@@ -52,9 +52,9 @@ GTEST_TEST(MonolaneOnrampMergeTest, TestDefaultAndNonDefaultAttributes) {
   EXPECT_EQ(api::LaneId("l:post0"), lane_beyond_onramp1->id());
 
   // Verify that the default branch of `onramp1` is `post0`.
-  std::unique_ptr<api::LaneEnd> onramp1_default_lane_end =
+  optional<api::LaneEnd> onramp1_default_lane_end =
       lane_onramp1->GetDefaultBranch(api::LaneEnd::kStart);
-  EXPECT_NE(onramp1_default_lane_end.get(), nullptr);
+  EXPECT_TRUE(onramp1_default_lane_end);
   EXPECT_EQ(api::LaneId("l:post0"), onramp1_default_lane_end->lane->id());
 
   // Verify that there's only one ongoing branch from `pre0`, and that it is
@@ -68,9 +68,9 @@ GTEST_TEST(MonolaneOnrampMergeTest, TestDefaultAndNonDefaultAttributes) {
   EXPECT_EQ(api::LaneId("l:post0"), lane_beyond_pre0->id());
 
   // Verify that the default branch of `pre0` is `post0`.
-  std::unique_ptr<api::LaneEnd> pre0_default_lane_end =
+  optional<api::LaneEnd> pre0_default_lane_end =
       lane_pre0->GetDefaultBranch(api::LaneEnd::kStart);
-  EXPECT_NE(pre0_default_lane_end.get(), nullptr);
+  EXPECT_TRUE(pre0_default_lane_end);
   EXPECT_EQ(api::LaneId("l:post0"), pre0_default_lane_end->lane->id());
 
   // Initialize non-default road characteristics.


### PR DESCRIPTION
...now that drake::optional<> exists, instead of the unique_ptr<> kludge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7443)
<!-- Reviewable:end -->
