### PR TITLE
Port util.py away from the find_resource sentinel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ package(
 
 exports_files([
     "CPPLINT.cfg",
+    ".bazelproject",
     ".clang-format",
     ".drake-resource-sentinel",
 ])

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -21,7 +21,7 @@ drake_py_library(
 drake_py_library(
     name = "util",
     srcs = ["util.py"],
-    data = ["//:.drake-resource-sentinel"],
+    data = ["//:.bazelproject"],
     visibility = ["//visibility:private"],
 )
 

--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -19,7 +19,7 @@ class UtilTest(unittest.TestCase):
 
         # Sanity-check relpaths.
         self.assertGreater(len(relpaths), 1000)
-        self.assertTrue('.drake-resource-sentinel' in relpaths)
+        self.assertTrue('.bazelproject' in relpaths)
         self.assertTrue('setup/ubuntu/16.04/install_prereqs.sh' in relpaths)
         THIRD_PARTY_SOURCES_ALLOWED_TO_BE_FOUND = [
             "third_party/BUILD.bazel",

--- a/tools/lint/util.py
+++ b/tools/lint/util.py
@@ -16,7 +16,7 @@ def find_all_sources():
     """
     # Our outermost `myprogram.runfiles` directory will contain a file named
     # MANIFEST.  Because this py_library declares a `data=[]` dependency on
-    # Drake's top-level sentinel file, the manifest will cite the original
+    # Drake's top-level .bazelproject file, the manifest will cite the original
     # location of that file, which we can abuse to find the absolute path to
     # the root of the source tree.
     workspace_root = None
@@ -29,13 +29,13 @@ def find_all_sources():
         with open(manifest, "r") as infile:
             lines = infile.readlines()
         for one_line in lines:
-            if not one_line.startswith("drake/.drake-resource-sentinel"):
+            if not one_line.startswith("drake/.bazelproject"):
                 continue
             _, source_sentinel = one_line.split(" ")
             workspace_root = os.path.dirname(source_sentinel)
             break
     if not workspace_root:
-        raise RuntimeError("Cannot find .drake-resource-sentinel in MANIFEST")
+        raise RuntimeError("Cannot find .bazelproject in MANIFEST")
     # Make sure we found the right place.
     workspace_file = os.path.join(workspace_root, "WORKSPACE")
     if not os.path.exists(workspace_file):


### PR DESCRIPTION
Relates #6996.

Instead, use a more-appropriate top-level file `.bazelproject`, better in tune with the purpose of this tool.  (The find_resource sentinel is undergoing a shuffle due to 6996.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7448)
<!-- Reviewable:end -->
