### PR TITLE
Require that drake resources start with "drake/"

### DIFF
--- a/drake/common/find_resource.h
+++ b/drake/common/find_resource.h
@@ -86,7 +86,8 @@ std::vector<std::string> GetResourceSearchPaths();
 
 /// Attempts to locate a Drake resource named by the given @p resource_path.
 /// The @p resource_path refers to the relative path within the Drake
-/// repository, e.g., `drake/examples/pendulum/Pendulum.urdf`.
+/// repository, e.g., `drake/examples/pendulum/Pendulum.urdf`.  Paths that do
+/// not start with "drake/" will return a failed result.
 ///
 /// The search scans for the resource in the following places and in
 /// the following order: 1) in the DRAKE_RESOURCE_ROOT environment variable

--- a/drake/common/test/find_resource_test.cc
+++ b/drake/common/test/find_resource_test.cc
@@ -39,7 +39,7 @@ GTEST_TEST(FindResourceTest, NonRelativeRequest) {
 }
 
 GTEST_TEST(FindResourceTest, NotFound) {
-  const string relpath = "this file does not exist";
+  const string relpath = "drake/this_file_does_not_exist";
   const auto& result = FindResource(relpath);
   EXPECT_EQ(result.get_resource_path(), relpath);
 
@@ -66,8 +66,9 @@ GTEST_TEST(FindResourceTest, AlternativeDirectory) {
   // an empty file in a scratch directory with a sentinel file. Bazel tests are
   // run in a scratch directory, so we don't need to remove anything manually.
   const std::string test_directory = "find_resource_test_scratch";
-  const std::string candidate_filename = "candidate.ext";
+  const std::string candidate_filename = "drake/candidate.ext";
   spruce::dir::mkdir(test_directory);
+  spruce::dir::mkdir(test_directory + "/drake");
   Touch(test_directory + "/.drake-resource-sentinel");
   Touch(test_directory + "/" + candidate_filename);
   AddResourceSearchPath(test_directory);


### PR DESCRIPTION
Relates #6996.

This provides a more specific user diagnostic when the API is misused, and will also allow for #6996 to play games with paths more easily.

Depends on #7446.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7450)
<!-- Reviewable:end -->
