### PR TITLE
Exclude yaml_util.h header from install

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -40,6 +40,10 @@ install(
     targets = ["libdrake.so"],
     guess_hdrs = "WORKSPACE",
     guess_hdrs_exclude = [
+        # This is private visibility; we don't want to have a yaml dependency
+        # in our published headers.  TODO(jwnimmer-tri) Update the guess_hdrs
+        # logic to exclude non-public headers by default.
+        "drake/systems/controllers/yaml_util.h",
         # This is private visibility; we don't want to have a vtk dependency
         # in our published headers.  TODO(jwnimmer-tri) Update the guess_hdrs
         # logic to exclude non-public headers by default.


### PR DESCRIPTION
This is a cherry-pick of 9eb22d4ee913efb417bc71e328a47f12514f2a07 in part.  That commit was #7352 and reverted in #7403 for other reasons, but this portion is still correct and useful.

Relates #7451.

/CC @nuclearsandwich

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7453)
<!-- Reviewable:end -->
