### PR TITLE
Cleanup drake.cps

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -46,6 +46,10 @@
       "Hints": ["@prefix@/lib/cmake/lcm"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
+    "optitrack": {
+      "Hints": ["@prefix@/lib/cmake/optitrack"],
+      "X-CMake-Find-Args": ["CONFIG"]
+    },
     "protobuf": {
       "Version": "3.1.0",
       "Hints": ["@prefix@/lib/cmake/protobuf"],
@@ -83,10 +87,6 @@
       "Version": "0.5.5",
       "Hints": ["@prefix@/lib/cmake/yaml-cpp"],
       "X-CMake-Find-Args": ["CONFIG"]
-    },
-    "ZLIB": {
-      "Version": "1.2.5",
-      "X-CMake-Find-Args": ["MODULE"]
     }
   },
   "Default-Components": [":drake"],
@@ -98,12 +98,12 @@
         "@prefix@/include"
       ],
       "Compile-Features": ["c++14"],
-      "Link-Flags": ["-lnlopt", "-ltinyxml2"],
+      "Link-Flags": ["-ltinyxml2"],
       "Link-Requires": [
         "fmt:fmt",
         "scs:scsdir",
         "SDFormat:sdformat",
-        "ZLIB:ZLIB"
+        "tinyobjloader:tinyobjloader"
       ],
       "Requires": [
         ":drake-lcmtypes-cpp",
@@ -114,6 +114,7 @@
         "ignition-math3:ignition-math3",
         "ignition-rndf0:ignition-rndf0",
         "lcm:lcm",
+        "optitrack:lcmtypes_optitrack-cpp",
         "protobuf:protobuf",
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",


### PR DESCRIPTION
Per the list in #7451, some entries can be cleaned up from `drake.cps` since they are both private and correctly linked into `libdrake.so`. Equally, `optitrack` is used by a public header and so should appear in `drake.cps`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7454)
<!-- Reviewable:end -->
