### PR TITLE
Add (off by default) support for Clang 4.0 on Ubuntu

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -48,6 +48,8 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 bash-completion
 binutils
 chrpath
+clang-4.0
+clang-format-4.0
 cmake
 cmake-curses-gui
 coinor-libclp-dev
@@ -91,6 +93,7 @@ libtool
 libxml2-dev
 libxt-dev
 libyaml-cpp-dev
+lldb-4.0
 make
 mesa-common-dev
 openjdk-8-jdk

--- a/tools/cc_toolchain/BUILD
+++ b/tools/cc_toolchain/BUILD
@@ -27,6 +27,7 @@ cc_toolchain_suite(
     toolchains = {
         "darwin|compiler": "cc_toolchain_apple",
         "k8|clang-3.9": "cc_toolchain_linux",
+        "k8|clang-4.0": "cc_toolchain_linux",
         "k8|gcc-5": "cc_toolchain_linux",
         "k8|gcc-6": "cc_toolchain_linux",
     },

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -183,6 +183,78 @@ toolchain {
   linking_mode_flags { mode: DYNAMIC }
 }
 
+# Clang 4.0 on Linux
+toolchain {
+  toolchain_identifier: "clang-4.0-linux"
+  abi_libc_version: "local"
+  abi_version: "local"
+  builtin_sysroot: ""
+  compiler: "clang-4.0"
+  compiler_flag: "-U_FORTIFY_SOURCE"
+  compiler_flag: "-fstack-protector"
+  compiler_flag: "-Wall"
+  compiler_flag: "-B/usr/bin"
+  compiler_flag: "-B/usr/bin"
+  compiler_flag: "-fcolor-diagnostics"
+  compiler_flag: "-fno-omit-frame-pointer"
+  cxx_builtin_include_directory: "/usr/include/c++/5.4.0"
+  cxx_builtin_include_directory: "/usr/include/x86_64-linux-gnu/c++/5.4.0"
+  cxx_builtin_include_directory: "/usr/include/c++/5.4.0/backward"
+  cxx_builtin_include_directory: "/usr/local/include"
+  cxx_builtin_include_directory: "/usr/include/clang/4.0.0/include"
+  cxx_builtin_include_directory: "/usr/include/x86_64-linux-gnu"
+  cxx_builtin_include_directory: "/usr/include"
+  cxx_flag: "-std=c++0x"
+  host_system_name: "local"
+  linker_flag: "-lstdc++"
+  linker_flag: "-lm"
+  linker_flag: "-fuse-ld=gold"
+  linker_flag: "-B/usr/bin"
+  linker_flag: "-B/usr/bin"
+  needsPic: true
+  objcopy_embed_flag: "-I"
+  objcopy_embed_flag: "binary"
+  supports_fission: false
+  supports_gold_linker: true
+  supports_incremental_linker: false
+  supports_interface_shared_objects: false
+  supports_normalizing_ar: false
+  supports_start_end_lib: true
+  target_cpu: "k8"
+  target_libc: "local"
+  target_system_name: "local"
+  unfiltered_cxx_flag: "-Wno-builtin-macro-redefined"
+  unfiltered_cxx_flag: "-D__DATE__=\"redacted\""
+  unfiltered_cxx_flag: "-D__TIMESTAMP__=\"redacted\""
+  unfiltered_cxx_flag: "-D__TIME__=\"redacted\""
+  tool_path {name: "ar" path: "/usr/bin/ar" }
+  tool_path {name: "cpp" path: "/usr/bin/cpp" }
+  tool_path {name: "dwp" path: "/usr/bin/dwp" }
+  tool_path {name: "gcc" path: "/usr/bin/clang-4.0" }
+  tool_path {name: "gcov" path: "/usr/bin/gcov" }
+  tool_path {name: "ld" path: "/usr/bin/ld" }
+  tool_path {name: "nm" path: "/usr/bin/nm" }
+  tool_path {name: "objcopy" path: "/usr/bin/objcopy" }
+  tool_path {name: "objdump" path: "/usr/bin/objdump" }
+  tool_path {name: "strip" path: "/usr/bin/strip" }
+
+  compilation_mode_flags {
+    mode: DBG
+    compiler_flag: "-g"
+  }
+  compilation_mode_flags {
+    mode: OPT
+    compiler_flag: "-g0"
+    compiler_flag: "-O2"
+    compiler_flag: "-D_FORTIFY_SOURCE=1"
+    compiler_flag: "-DNDEBUG"
+    compiler_flag: "-ffunction-sections"
+    compiler_flag: "-fdata-sections"
+    linker_flag: "-Wl,--gc-sections"
+  }
+  linking_mode_flags { mode: DYNAMIC }
+}
+
 # Clang 3.9 on Linux
 toolchain {
   toolchain_identifier: "clang-3.9-linux"

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -191,6 +191,7 @@ toolchain {
   builtin_sysroot: ""
   compiler: "clang-4.0"
   compiler_flag: "-U_FORTIFY_SOURCE"
+  compiler_flag: "-D_FORTIFY_SOURCE=1"
   compiler_flag: "-fstack-protector"
   compiler_flag: "-Wall"
   compiler_flag: "-B/usr/bin"
@@ -204,7 +205,9 @@ toolchain {
   cxx_builtin_include_directory: "/usr/include/clang/4.0.0/include"
   cxx_builtin_include_directory: "/usr/include/x86_64-linux-gnu"
   cxx_builtin_include_directory: "/usr/include"
-  cxx_flag: "-std=c++0x"
+  # Next line is a Drake fix for https://github.com/bazelbuild/bazel/issues/3977.
+  cxx_builtin_include_directory: "/usr/lib/llvm-4.0/lib/clang/4.0.0/include"
+  cxx_flag: "-std=c++1y" # Modified for Drake.
   host_system_name: "local"
   linker_flag: "-lstdc++"
   linker_flag: "-lm"
@@ -246,7 +249,6 @@ toolchain {
     mode: OPT
     compiler_flag: "-g0"
     compiler_flag: "-O2"
-    compiler_flag: "-D_FORTIFY_SOURCE=1"
     compiler_flag: "-DNDEBUG"
     compiler_flag: "-ffunction-sections"
     compiler_flag: "-fdata-sections"


### PR DESCRIPTION
As of #7456, the macOS flavors that we support align with clang 4.0 more than clang 3.9.  We should probably bump Ubuntu to match.  This is a first step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7457)
<!-- Reviewable:end -->
