### PR TITLE
Change Ubuntu default to clang-4.0 

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -77,13 +77,17 @@ supported for CMake builds using the "Unix Makefiles" generator.
 | Operating System            | Build System   | C/C++ Compiler  | Java       | MATLAB (Optional) | Python |
 +=============================+================+=================+============+===================+========+
 +-----------------------------+----------------+-----------------+------------+-------------------+--------+
-| Ubuntu 16.04 LTS ("Xenial") | | Bazel 0.6.1  | | Clang 3.9     | OpenJDK 8  | R2017a            | 2.7.11 |
-|                             | | CMake 3.5.1  | | GCC 5.4       |            |                   |        |
+| Ubuntu 16.04 LTS ("Xenial") | | Bazel 0.6.1  | | Clang 4.0     | OpenJDK 8  | R2017a            | 2.7.11 |
+|                             | | CMake 3.5.1  | | Clang 3.9     |            |                   |        |
+|                             | |              | | GCC 5.4       |            |                   |        |
 +-----------------------------+----------------+-----------------+------------+                   +--------+
 | macOS 10.12 ("Sierra")      | | Bazel 0.6.1  | Apple Clang 9.0 | Oracle 1.8 |                   | 2.7.14 |
 +-----------------------------+ | CMake 3.10.0 |                 |            +-------------------+        |
 | macOS 10.13 ("High Sierra") |                |                 |            | R2017b            |        |
 +-----------------------------+----------------+-----------------+------------+-------------------+--------+
+
+On Ubuntu 16.04, the combination of CMake + Clang 4.0 is not yet supported,
+and the combination of Bazel + Clang 3.9 is deprecated.
 
 macOS 10.13 ("High Sierra") MATLAB support is experimental and untested in continuous
 integration.

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -20,7 +20,7 @@ default_toolchain {
 # We use Clang on Ubuntu by default. To use gcc, specify --compiler=gcc-5.
 default_toolchain {
   cpu: "k8"
-  toolchain_identifier: "clang-3.9-linux"
+  toolchain_identifier: "clang-4.0-linux"
 }
 
 # GCC 6.x on Linux


### PR DESCRIPTION
This is based atop #7457 but also sets the default to clang-4.0, so that we can test it in CI.  We expect several pre-merge builds to fail until #7457 merges and CI images are updated.

Note that to switch the `-clang-cmake` builds to 4.0, a `drake-ci` PR will also have to happen.  However, I suspect that will run up against bazelbuild/bazel#3977.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7459)
<!-- Reviewable:end -->
