### PR TITLE
Move the resource sentinel file down one folder

### DIFF
--- a/.drake-resource-sentinel
+++ b/.drake-resource-sentinel
@@ -1,1 +1,0 @@
-This file is used as a sentinel to anchor the implementation of GetDrakePath.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,6 @@ exports_files([
     "CPPLINT.cfg",
     ".bazelproject",
     ".clang-format",
-    ".drake-resource-sentinel",
 ])
 
 alias(

--- a/drake/.drake-find_resource-sentinel
+++ b/drake/.drake-find_resource-sentinel
@@ -1,0 +1,1 @@
+This file is used as a sentinel to anchor the implementation of FindResource.

--- a/drake/BUILD.bazel
+++ b/drake/BUILD.bazel
@@ -7,4 +7,8 @@ package(default_visibility = ["//visibility:public"])
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+exports_files([
+    ".drake-find_resource-sentinel",
+])
+
 add_lint_tests()

--- a/drake/common/BUILD.bazel
+++ b/drake/common/BUILD.bazel
@@ -226,7 +226,7 @@ drake_cc_library(
 
 # Miscellaneous utilities.
 
-DRAKE_RESOURCE_SENTINEL = "//:.drake-resource-sentinel"
+DRAKE_RESOURCE_SENTINEL = "//drake:.drake-find_resource-sentinel"
 
 drake_cc_library(
     name = "find_resource",
@@ -369,7 +369,7 @@ install(
     # package name in the installed path.  For now, we'll just specify it
     # manually.
     runtime_dest = "libexec/drake/drake/common",
-    data_dest = "share/drake",
+    data_dest = "share/drake/drake",
     guess_data = "WORKSPACE",
     allowed_externals = [DRAKE_RESOURCE_SENTINEL],
 )

--- a/drake/common/drake_path.cc
+++ b/drake/common/drake_path.cc
@@ -9,15 +9,14 @@ namespace drake {
 
 std::string GetDrakePath() {
   // Find something that represents where Drake resources live.  This will be
-  // "/path/to/.drake-resource-sentinel" where "/path/to/" names the root of
-  // Drake's git source tree (or perhaps an installed version of the same).
-  const auto& find_result = FindResource(".drake-resource-sentinel");
+  // "/path/to/drake/.drake-find_resource-sentinel" where "/path/to/" names the
+  // root of Drake's git source tree (or perhaps an installed version of same).
+  const auto& find_result = FindResource("drake/.drake-find_resource-sentinel");
   spruce::path sentinel_path = find_result.get_absolute_path_or_throw();
 
-  // Rewrite to be the "/path/to/drake" that names the "drake" folder within
-  // the git source tree (or perhaps an installed version of the same).
+  // Take the dirname of sentinel_path; that will name the "drake" folder
+  // within the git source tree (or perhaps an installed version of same).
   spruce::path result = sentinel_path.root();
-  result.append("drake");
   if (!result.isDir()) {
     throw std::runtime_error("GetDrakePath: proposed result " +
                              result.getStr() + " is not a directory");

--- a/drake/common/find_resource.cc
+++ b/drake/common/find_resource.cc
@@ -125,12 +125,10 @@ optional<string> file_exists(
   return file_query.getStr();
 }
 
-constexpr const char* const kSentinelName = ".drake-resource-sentinel";
-
 optional<string> check_candidate_dir(const spruce::path& candidate_dir) {
   // If we found the sentinel, we win.
   spruce::path candidate_file = candidate_dir;
-  candidate_file.append(kSentinelName);
+  candidate_file.append("drake/.drake-find_resource-sentinel");
   if (candidate_file.isFile()) {
     return candidate_dir.getStr();
   }
@@ -193,21 +191,16 @@ Result FindResource(string resource_path) {
   // to drake::FindResource to start with "drake" is redundant, but preserves
   // compatibility with the original semantics of this function; if we want to
   // offer a function that takes paths without "drake", we can use a new name.
-  // In the checks below, note that we also special-case the top-level sentinel
-  // file (which does not start with "drake/"), since GetDrakePath needs to be
-  // able to find it.
   if (!is_relative_path(resource_path)) {
     return Result::make_error(
         std::move(resource_path),
         "resource_path is not a relative path");
   }
-  if (resource_path != kSentinelName) {
-    const std::string prefix("drake/");
-    if (resource_path.compare(0, prefix.size(), prefix) != 0) {
-      return Result::make_error(
-          std::move(resource_path),
-          "resource_path does not start with " + prefix);
-    }
+  const std::string prefix("drake/");
+  if (resource_path.compare(0, prefix.size(), prefix) != 0) {
+    return Result::make_error(
+        std::move(resource_path),
+        "resource_path does not start with " + prefix);
   }
 
   // Collect a list of (priority-ordered) directories to check.

--- a/drake/common/test/find_resource_test.cc
+++ b/drake/common/test/find_resource_test.cc
@@ -69,7 +69,7 @@ GTEST_TEST(FindResourceTest, AlternativeDirectory) {
   const std::string candidate_filename = "drake/candidate.ext";
   spruce::dir::mkdir(test_directory);
   spruce::dir::mkdir(test_directory + "/drake");
-  Touch(test_directory + "/.drake-resource-sentinel");
+  Touch(test_directory + "/drake/.drake-find_resource-sentinel");
   Touch(test_directory + "/" + candidate_filename);
   AddResourceSearchPath(test_directory);
   EXPECT_TRUE(!GetResourceSearchPaths().empty());

--- a/drake/common/test/resource_tool_installed_test.py
+++ b/drake/common/test/resource_tool_installed_test.py
@@ -21,7 +21,7 @@ class TestResourceTool(unittest.TestCase):
             f.write("tmp_resource")
 
         # Remove the un-installed copy, so we _know_ it won't be used.
-        os.remove(".drake-resource-sentinel")
+        os.remove("drake/.drake-find_resource-sentinel")
         os.remove("drake/__init__.py")
         os.remove("drake/common/__init__.py")
         os.remove("drake/common/install")


### PR DESCRIPTION
Relates #6996.

This changes the internal mechanisms of `FindResource` and its sugars but does not affect users at all.  The actual data files still end up in the same places; the `relative_path` args to `FindResource` are unchanged; the `GetDrakePath` result is unchanged.

The shift is in order to enable #6996, which will move the entire contents of `drake-distro/drake` up a level, thus moving the new sentinel back down to the repository root.

Depends on #7450.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7460)
<!-- Reviewable:end -->
