### PR TITLE
Force correct spelling for our lcmtypes includes

### DIFF
--- a/drake/lcmtypes/BUILD.bazel
+++ b/drake/lcmtypes/BUILD.bazel
@@ -4,6 +4,10 @@ package(default_visibility = ["//visibility:public"])
 
 load("@drake//tools/install:install.bzl", "install")
 load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_transitive_installed_hdrs_filegroup",
+)
+load(
     "@drake//tools/skylark:drake_java.bzl",
     "drake_java_binary",
 )
@@ -345,21 +349,39 @@ drake_java_binary(
     ],
 )
 
+drake_transitive_installed_hdrs_filegroup(
+    name = "drake_lcmtypes_headers",
+    deps = DRAKE_LCMTYPES,
+)
+
+# The drake-lcmtypes-cpp library is distinct from (but required by) the drake
+# library; refer to `tools/install/libdrake/drake.cps` for library structure.
+# Therefore, we install Drake's lcmtypes C++ headers to a different directory
+# than the drake library's include path; this ensures that downstream code is
+# using the correct include paths for the libraries they need.  The path to
+# `include/drake_lcmtypes` is provided to downstream code via `drake.cps` and
+# its generated cmake config `lib/cmake/drake/drake-config.cmake.
+install(
+    name = "install_cc_headers",
+    hdrs = [":drake_lcmtypes_headers"],
+    hdr_dest = "include/drake_lcmtypes",
+    visibility = ["//visibility:private"],
+)
+
 install(
     name = "install",
-    targets = DRAKE_LCMTYPES + [
+    targets = [
         ":drake-lcm-spy-launcher",
         ":drake-lcm-spy",
         ":lcmtypes_drake_java",
         ":lcmtypes_py",
     ],
-    hdr_dest = "include/drake/lcmtypes",
-    guess_hdrs = "PACKAGE",
     rename = {
         "share/java/liblcmtypes_drake_java.jar": "lcmtypes_drake.jar",
         "bin/drake-lcm-spy-launcher.sh": "drake-lcm-spy",
     },
     deps = [
+        ":install_cc_headers",
         "//tools/workspace/optitrack_driver:install",
         "@lcmtypes_robotlocomotion//:install",
         "@libbot//:install_bot2_core",

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -124,7 +124,7 @@
     },
     "drake-lcmtypes-cpp": {
       "Type": "interface",
-      "Includes": ["@prefix@/include/drake/lcmtypes"],
+      "Includes": ["@prefix@/include/drake_lcmtypes"],
       "Requires": ["lcm:lcm-coretypes"]
     },
     "drake-lcmtypes-java": {

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -127,6 +127,12 @@ def installed_headers_for_drake_deps(deps):
     """Filters `deps` to find drake labels (i.e., discard third_party labels),
     and then maps `installed_headers_for_dep()` over that list of drake deps.
 
+    (Absolute paths to Drake's lcmtypes headers are also filtered out, because
+    LCM headers follow a different #include convention, and so are installed
+    separately.  Refer to drake/lcmtypes/BUILD.bazel for details.  Note that
+    within-package paths are left unchanged, so that this macro can still be
+    used within Drake's lcmtypes folder.)
+
     This is useful for computing the deps of a `drake_installed_headers()` rule
     from the deps of a `cc_library()` rule.
     """
@@ -136,7 +142,10 @@ def installed_headers_for_drake_deps(deps):
         return []
     return [
         installed_headers_for_dep(x)
-        for x in deps if not x.startswith("@")
+        for x in deps if (
+            not x.startswith("@") and
+            not x.startswith("//drake/lcmtypes:")
+        )
     ]
 
 # A provider to collect Drake metadata about C++ rules.  For background, see

--- a/tools/skylark/drake_lcm.bzl
+++ b/tools/skylark/drake_lcm.bzl
@@ -16,12 +16,23 @@ def drake_lcm_cc_library(
         name,
         deps = [],
         tags = [],
+        strip_include_prefix = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations."""
+    # Drake's *.lcm files all live in our //drake/lcmtypes package.  Per LCM
+    # upstream convention, the include directory for generated code should
+    # always look like "my_lcm_package/my_lcm_struct.h", but by default Bazel
+    # would provide "drake/lcmtypes/my_lcm_package/my_lcm_struct.h" as an
+    # allowed spelling.  Here, we override that to enforce that Drake's include
+    # statements use the standard formulation.  (We allow callers to override
+    # our enforcement though, such as for special-case testing.)
+    if strip_include_prefix == None:
+        strip_include_prefix = "/" + native.package_name()
     detail = lcm_cc_library(
         name = name,
         deps = deps,
         tags = tags + ["nolint"],
+        strip_include_prefix = strip_include_prefix,
         **kwargs)
     drake_installed_headers(
         name = name + ".installed_headers",

--- a/tools/vector_gen/BUILD.bazel
+++ b/tools/vector_gen/BUILD.bazel
@@ -67,7 +67,7 @@ drake_lcm_cc_library(
     includes = ["test"],
     lcm_package = "drake",
     lcm_srcs = ["test/lcmt_sample_t.lcm"],
-    strip_include_prefix = "/" + native.package_name() + "/test",
+    strip_include_prefix = "/tools/vector_gen/test",
 )
 
 # From sample.named_vector, create gen/sample_translator.{h,cc}.


### PR DESCRIPTION
Relates #6996.

Drake's `*.lcm` files all live in our `//drake/lcmtypes` package.  However, per LCM upstream convention, the include directory for generated code should always look like `"my_lcm_package/my_lcm_struct.h"`.  By default, Bazel would provide `"drake/lcmtypes/my_lcm_package/my_lcm_struct.h"` as the desired spelling.  Here, we override that to force Drake's include statements to use the standard formulation.

This reapplies the portion of c35cc64 (#7381) that was reverted in 7cd00fc (#7395), with substantial modifications that ensure the installed image is correct.

This depends on #7458.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7462)
<!-- Reviewable:end -->
