### PR TITLE
[Dev-only] Add protobuf messages for pick-and-place config.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
@@ -3,8 +3,43 @@
 load(
     "//tools:drake.bzl",
     "drake_cc_binary",
+    "drake_cc_library",
+    "drake_cc_googletest",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load(
+    "@drake//tools/skylark:drake_proto.bzl",
+    "drake_cc_proto_library",
+)
+
+package(
+    default_visibility = ["//drake/examples/kuka_iiwa_arm/dev:__subpackages__"],  # noqa
+)
+
+drake_cc_proto_library(
+    name = "pick_and_place_configuration_proto",
+    srcs = [
+        "pick_and_place_configuration.proto",
+    ],
+)
+
+drake_cc_library(
+    name = "pick_and_place_configuration_parsing",
+    srcs = [
+        "pick_and_place_configuration_parsing.cc",
+    ],
+    hdrs = [
+        "pick_and_place_configuration_parsing.h",
+    ],
+    deps = [
+        ":pick_and_place_configuration_proto",
+        "//drake/common:find_resource",
+        "//drake/common/proto:protobuf",
+        "//drake/examples/kuka_iiwa_arm/pick_and_place:pick_and_place_configuration",  # noqa
+        "//drake/manipulation/util:world_sim_tree_builder",
+        "//drake/math:geometric_transform",
+    ],
+)
 
 drake_cc_binary(
     name = "pick_and_place_demo",
@@ -21,5 +56,18 @@ drake_cc_binary(
 )
 
 # === test/ ===
+
+drake_cc_googletest(
+    name = "pick_and_place_configuration_parsing_test",
+    data = [
+        ":configuration",
+        "//drake/examples/kuka_iiwa_arm:models",
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
+    deps = [
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/examples/kuka_iiwa_arm/dev/pick_and_place:pick_and_place_configuration_parsing",  # noqa
+    ],
+)
 
 add_lint_tests()

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/configuration/yellow_posts.pick_and_place_configuration
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/configuration/yellow_posts.pick_and_place_configuration
@@ -1,0 +1,136 @@
+model {
+  key: "cube"
+  value: {
+    simulation_model_path: "drake/examples/kuka_iiwa_arm/models/objects/simple_cuboid.urdf"
+  }
+}
+model {
+  key: "big_robot_toy"
+  value {
+    simulation_model_path: "drake/examples/kuka_iiwa_arm/models/objects/big_robot_toy.urdf"
+  }
+} 
+model {
+  key: "yellow_post"
+  value {
+    simulation_model_path: "drake/examples/kuka_iiwa_arm/models/objects/yellow_post.urdf"
+  }
+}
+model {
+  key: "extra_heavy_duty_table"
+  value: {
+    simulation_model_path: "drake/examples/kuka_iiwa_arm/models/table/extra_heavy_duty_table_surface_only_collision.sdf";
+  }
+}
+model {
+  key: "iiwa"
+  value: {
+    simulation_model_path: "drake/manipulation/models/iiwa_description/urdf/iiwa14_polytope_collision.urdf";
+  }
+}
+
+table {
+  name: "yellow_post"
+  optitrack_info {
+    id: 2
+    X_MF {
+      xyz: [0.0, 0.0, 1.02]
+    }
+  }
+  pose {
+    xyz: [0.0, 1.0, 0.0]
+  }
+}
+
+table {
+  name: "yellow_post"
+  optitrack_info {
+    id: 3
+    X_MF {
+      xyz: [0.0, 0.0, 1.02]
+    }
+  }
+  pose {
+    xyz: [0.80, 0.36, 0.0]
+  }
+}
+
+table {
+  name: "extra_heavy_duty_table"
+  optitrack_info {
+    id: 4
+    X_MF {
+      xyz: [0.0, 0.0, 0.7645]
+    }
+  }
+  pose {
+    xyz: [0.86, -0.36, -0.07]
+  }
+}
+
+table {
+  name: "yellow_post"
+  optitrack_info {
+    id: 5
+    X_MF {
+      xyz: [0.0, 0.0, 1.02]
+    }
+  }
+  pose {
+    xyz: [0.30, -0.9, 0.0]
+  }
+}
+
+table {
+  name: "yellow_post"
+  optitrack_info {
+    id: 6
+    X_MF {
+      xyz: [0.0, 0.0, 1.02]
+    }
+  }
+  pose {
+    xyz: [-0.1, -1.0, 0.0]
+  }
+}
+
+table {
+  name: "yellow_post"
+  optitrack_info {
+    id: 7
+    X_MF {
+      xyz: [0.0, 0.0, 1.02]
+    }
+  }
+  pose {
+    xyz: [-0.47, -0.8, 0.0]
+  }
+}
+
+robot {
+  name: "iiwa"
+  optitrack_info {
+    id: 1
+  }
+  pose {
+    xyz: [0.0, 0.0, 0.7645];
+  }
+}
+
+object {
+  name: "cube"
+  optitrack_info {
+    id: 8
+  }
+  pose {
+    xyz: [0.30, -0.9, 1.05]
+    rpy: [0.0, 0.0, 1.571]
+  }
+}
+
+task {
+  end_effector_name: "iiwa_link_ee"
+}
+
+stiffness: 3000
+dissipation: 5

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration.proto
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration.proto
@@ -1,0 +1,96 @@
+syntax = "proto3";
+
+package drake.examples.kuka_iiwa_arm.pick_and_place.proto;
+
+ // Note: The default values listed below assume that the messages are parsed
+ // using the functions in pick_and_place_configuration_parsing.h. Fields
+ // without a default value are required.
+
+// Next ID: 3
+message Pose {
+    // Position.
+    // DEFAULT: (0, 0, 0)
+    repeated double xyz = 1;
+    // Orientation in SpaceXYZ Euler angles.
+    // DEFAULT: (0, 0, 0)
+    repeated double rpy = 2;
+}
+
+ // OptitrackInfo is a message that contains the information required to track a
+ // model from an Optitrack frame.
+ //
+ // Next ID: 3
+message OptitrackInfo {
+    // The unique identifier assigned to this object by the motion-capture
+    // system.
+    int32 id = 1;
+    // Pose of the Optitrack frame relative to the model frame.
+    // The transform from the Optitrack rigid-body frame (F) to the model base
+    // frame (M).
+    // DEFAULT: Identity
+    Pose X_MF = 2;
+}
+
+// Next ID: 3
+message Model{
+    // Path to the model file for simulation (relative to DRAKE_RESOURCE_ROOT).
+    string simulation_model_path = 1;
+    // Path to the model file for planning (relative to DRAKE_RESOURCE_ROOT).
+    // DEFAULT: simulation_model_path
+    string planning_model_path = 2;
+}
+
+// Next ID: 4
+message ModelInstance {
+    // The name of the model. This should correspond to a key in the model
+    // field of the PickAndPlaceConfiguration message.
+    string name = 1;
+    // The Optitrack information for the model base.
+    OptitrackInfo optitrack_info = 2;
+    // The [initial] world-pose of the model base.
+    // DEFAULT: Identity
+    Pose pose = 3;
+}
+
+// Next ID: 4
+message PickAndPlaceTask {
+    // The index of the robot arm to be used for this task.
+    // DEFAULT: 0
+    int32 robot_index = 1;
+    // The index of the object to be used as the target for this task.
+    // DEFAULT: 0
+    int32 target_index = 2;
+    // The name of the end-effector body in the robot.
+    string end_effector_name = 3;
+}
+
+// Next ID: 11
+message PickAndPlaceConfiguration {
+    // Map of model names to Model messages
+    map<string, Model> model = 1;
+
+    repeated PickAndPlaceTask task = 2;
+
+    // The tables from/on which the target can be picked/placed.
+    repeated ModelInstance table = 3;
+    // The objects that can be picked and placed
+    repeated ModelInstance object = 4;
+    // The robots that pick and place
+    repeated ModelInstance robot = 5;
+
+    // Static friction coefficient
+    // DEFAULT: 0.9
+    double static_friction_coefficient = 6;
+    // Dynamic friction coefficient
+    // DEFAULT: 0.5
+    double dynamic_friction_coefficient = 7;
+    // Stiction velocity tolerance
+    // DEFAULT: 0.01
+    double v_stiction_tolerance = 8;
+    // Contact stiffness
+    // DEFAULT: 10000
+    double stiffness = 9;
+    // Contact dissipation
+    // DEFAULT: 2
+    double dissipation = 10;
+}

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
@@ -1,0 +1,292 @@
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.h"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include "google/protobuf/text_format.h"
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
+#include "drake/common/proto/protobuf.h"
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration.pb.h"
+#include "drake/manipulation/util/world_sim_tree_builder.h"
+#include "drake/math/roll_pitch_yaw.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place {
+
+using manipulation::util::WorldSimTreeBuilder;
+using math::rpy2rotmat;
+using pick_and_place::RobotBaseIndex;
+using pick_and_place::TargetIndex;
+
+namespace {
+proto::PickAndPlaceConfiguration ReadProtobufFileOrThrow(
+    const std::string& filename) {
+  auto istream =
+      drake::MakeFileInputStreamOrThrow(FindResourceOrThrow(filename));
+  proto::PickAndPlaceConfiguration configuration;
+  google::protobuf::TextFormat::Parse(istream.get(), &configuration);
+  return configuration;
+}
+
+Isometry3<double> ParsePose(const proto::Pose& pose) {
+  Isometry3<double> X{Isometry3<double>::Identity()};
+  if (!pose.xyz().empty()) {
+    DRAKE_THROW_UNLESS(pose.xyz_size() == 3);
+    X.translation() = Vector3<double>(pose.xyz(0), pose.xyz(1), pose.xyz(2));
+  }
+  if (!pose.rpy().empty()) {
+    DRAKE_THROW_UNLESS(pose.rpy_size() == 3);
+    X.linear() =
+        rpy2rotmat(Vector3<double>(pose.rpy(0), pose.rpy(1), pose.rpy(2)));
+  }
+  return X;
+}
+
+const proto::Model& GetModelOrThrow(
+    const proto::PickAndPlaceConfiguration& configuration,
+    const proto::ModelInstance& model_instance) {
+  return configuration.model().at(model_instance.name());
+}
+
+const std::string& GetSimulationModelPathOrThrow(
+    const proto::PickAndPlaceConfiguration& configuration,
+    const proto::ModelInstance& model_instance) {
+  return GetModelOrThrow(configuration, model_instance).simulation_model_path();
+}
+
+const std::string& GetPlanningModelPathOrThrow(
+    const proto::PickAndPlaceConfiguration& configuration,
+    const proto::ModelInstance& model_instance) {
+  const proto::Model& model = GetModelOrThrow(configuration, model_instance);
+  return (model.planning_model_path().empty()) ? model.simulation_model_path()
+                                               : model.planning_model_path();
+}
+
+void ExtractBasePosesForModels(
+    const google::protobuf::RepeatedPtrField<proto::ModelInstance>& models,
+    std::vector<Isometry3<double>>* poses) {
+  DRAKE_DEMAND(poses != nullptr);
+  std::transform(models.cbegin(), models.cend(), std::back_inserter(*poses),
+                 [](const proto::ModelInstance& model) -> Isometry3<double> {
+                   return ParsePose(model.pose());
+                 });
+}
+
+void ExtractOptitrackInfoForModels(
+    const google::protobuf::RepeatedPtrField<proto::ModelInstance>& models,
+    std::vector<pick_and_place::OptitrackInfo>* optitrack_info) {
+  DRAKE_DEMAND(optitrack_info != nullptr);
+  std::transform(
+      models.cbegin(), models.cend(), std::back_inserter(*optitrack_info),
+      [](const proto::ModelInstance& model) -> pick_and_place::OptitrackInfo {
+        return pick_and_place::OptitrackInfo(
+            {model.optitrack_info().id(),
+             ParsePose(model.optitrack_info().x_mf())});
+      });
+}
+
+void ExtractModelPathsForModels(
+    const proto::PickAndPlaceConfiguration& configuration,
+    const google::protobuf::RepeatedPtrField<proto::ModelInstance>& models,
+    std::vector<std::string>* model_paths) {
+  DRAKE_DEMAND(model_paths != nullptr);
+  std::transform(
+      models.cbegin(), models.cend(), std::back_inserter(*model_paths),
+      [&configuration](const proto::ModelInstance& table) -> std::string {
+        return GetSimulationModelPathOrThrow(configuration, table);
+      });
+}
+
+pick_and_place::PlannerConfiguration DoParsePlannerConfiguration(
+    const proto::PickAndPlaceConfiguration& configuration,
+    const std::string& end_effector_name,
+    pick_and_place::RobotBaseIndex robot_index,
+    pick_and_place::TargetIndex target_index) {
+  // Check that the robot base and target indices are valid.
+  DRAKE_THROW_UNLESS(robot_index < configuration.robot_size());
+  DRAKE_THROW_UNLESS(target_index < configuration.object_size());
+
+  pick_and_place::PlannerConfiguration planner_configuration;
+
+  // Set the robot and target indices
+  planner_configuration.robot_index = robot_index;
+  planner_configuration.target_index = target_index;
+
+  // Store model path and end-effector name.
+  planner_configuration.model_path = GetPlanningModelPathOrThrow(
+      configuration, configuration.robot(planner_configuration.robot_index));
+  planner_configuration.end_effector_name = end_effector_name;
+
+  // Extract number of tables
+  planner_configuration.num_tables = configuration.table_size();
+
+  // Extract target dimensions
+  WorldSimTreeBuilder<double> tree_builder;
+  tree_builder.StoreModel(
+      "target", GetPlanningModelPathOrThrow(
+                    configuration,
+                    configuration.object(planner_configuration.target_index)));
+  tree_builder.AddFixedModelInstance("target", Vector3<double>::Zero());
+  auto target = tree_builder.Build();
+  Vector3<double> min_corner{
+      Vector3<double>::Constant(std::numeric_limits<double>::infinity())};
+  Vector3<double> max_corner{-min_corner};
+  // The target dimensions for planning will be the side lengths of the
+  // axis-aligned bounding box for all VISUAL geometry of the target. Ideally,
+  // this would be the collision geometry, but RigidBody doesn't give const
+  // access to collision geometries.
+  for (const auto& visual_element :
+       target->get_body(target->FindBaseBodies()[0]).get_visual_elements()) {
+    Matrix3X<double> bounding_box_points;
+    visual_element.getGeometry().getBoundingBoxPoints(bounding_box_points);
+    const Isometry3<double> X_BV = visual_element.getLocalTransform();
+    max_corner =
+        max_corner.cwiseMax((X_BV * bounding_box_points).rowwise().maxCoeff());
+    min_corner =
+        min_corner.cwiseMin((X_BV * bounding_box_points).rowwise().minCoeff());
+  }
+  planner_configuration.target_dimensions = max_corner - min_corner;
+
+  return planner_configuration;
+}
+}  // namespace
+
+pick_and_place::PlannerConfiguration ParsePlannerConfigurationOrThrow(
+    const std::string& filename, TaskIndex task_index) {
+  // Read configuration file
+  const proto::PickAndPlaceConfiguration configuration{
+      ReadProtobufFileOrThrow(filename)};
+
+  // Check that the task index is valid.
+  DRAKE_THROW_UNLESS(task_index < configuration.task_size());
+  RobotBaseIndex robot_index(configuration.task(task_index).robot_index());
+  TargetIndex target_index(configuration.task(task_index).target_index());
+
+  return DoParsePlannerConfiguration(
+      configuration, configuration.task(task_index).end_effector_name(),
+      robot_index, target_index);
+}
+
+pick_and_place::PlannerConfiguration ParsePlannerConfigurationOrThrow(
+    const std::string& filename, const std::string& end_effector_name,
+    RobotBaseIndex robot_index, TargetIndex target_index) {
+  // Read configuration file
+  const proto::PickAndPlaceConfiguration configuration{
+      ReadProtobufFileOrThrow(filename)};
+
+  // Check that the robot and target indices are valid.
+  DRAKE_THROW_UNLESS(robot_index < configuration.robot_size());
+  DRAKE_THROW_UNLESS(target_index < configuration.object_size());
+
+  return DoParsePlannerConfiguration(configuration, end_effector_name,
+                                     robot_index, target_index);
+}
+
+std::vector<pick_and_place::PlannerConfiguration>
+ParsePlannerConfigurationsOrThrow(const std::string& filename) {
+  // Read configuration file
+  const proto::PickAndPlaceConfiguration configuration{
+      ReadProtobufFileOrThrow(filename)};
+
+  // Build the planner configuration vector.
+  std::vector<pick_and_place::PlannerConfiguration> planner_configurations;
+  std::transform(configuration.task().cbegin(), configuration.task().cend(),
+                 std::back_inserter(planner_configurations),
+                 [&configuration](const proto::PickAndPlaceTask& task)
+                     -> pick_and_place::PlannerConfiguration {
+                   return DoParsePlannerConfiguration(
+                       configuration, task.end_effector_name(),
+                       pick_and_place::RobotBaseIndex(task.robot_index()),
+                       pick_and_place::TargetIndex(task.target_index()));
+                 });
+  return planner_configurations;
+}
+
+pick_and_place::SimulatedPlantConfiguration
+ParseSimulatedPlantConfigurationOrThrow(const std::string& filename) {
+  pick_and_place::SimulatedPlantConfiguration plant_configuration;
+
+  // Read configuration file
+  const proto::PickAndPlaceConfiguration configuration{
+      ReadProtobufFileOrThrow(filename)};
+
+  // Extract robot model paths
+  ExtractModelPathsForModels(configuration, configuration.robot(),
+                             &plant_configuration.robot_models);
+
+  // Extract base positions
+  ExtractBasePosesForModels(configuration.robot(),
+                            &plant_configuration.robot_poses);
+
+  // Extract table model paths
+  ExtractModelPathsForModels(configuration, configuration.table(),
+                             &plant_configuration.table_models);
+
+  // Extract table poses
+  ExtractBasePosesForModels(configuration.table(),
+                            &plant_configuration.table_poses);
+
+  // Extract object model paths
+  ExtractModelPathsForModels(configuration, configuration.object(),
+                             &plant_configuration.object_models);
+
+  // Extract object poses
+  ExtractBasePosesForModels(configuration.object(),
+                            &plant_configuration.object_poses);
+
+  if (configuration.static_friction_coefficient() > 0) {
+    plant_configuration.static_friction_coef =
+        configuration.static_friction_coefficient();
+  }
+  if (configuration.dynamic_friction_coefficient() > 0) {
+    plant_configuration.dynamic_friction_coef =
+        configuration.dynamic_friction_coefficient();
+  }
+  if (configuration.v_stiction_tolerance() > 0) {
+    plant_configuration.v_stiction_tolerance =
+        configuration.v_stiction_tolerance();
+  }
+  if (configuration.stiffness() > 0) {
+    plant_configuration.stiffness = configuration.stiffness();
+  }
+  if (configuration.dissipation() > 0) {
+    plant_configuration.dissipation = configuration.dissipation();
+  }
+
+  return plant_configuration;
+}
+
+pick_and_place::OptitrackConfiguration ParseOptitrackConfigurationOrThrow(
+    const std::string& filename) {
+  pick_and_place::OptitrackConfiguration optitrack_configuration;
+
+  // Read configuration file
+  const proto::PickAndPlaceConfiguration configuration{
+      ReadProtobufFileOrThrow(filename)};
+
+  // Extract Optitrack info for tables
+  ExtractOptitrackInfoForModels(configuration.table(),
+                                &optitrack_configuration.table_optitrack_info);
+
+  // Extract Optitrack Ids for objects
+  ExtractOptitrackInfoForModels(configuration.object(),
+                                &optitrack_configuration.object_optitrack_info);
+
+  // Extract Optitrack Ids for robot bases
+  ExtractOptitrackInfoForModels(
+      configuration.robot(),
+      &optitrack_configuration.robot_base_optitrack_info);
+
+  return optitrack_configuration;
+}
+
+}  // namespace pick_and_place
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/type_safe_index.h"
+#include "drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place {
+
+using TaskIndex = TypeSafeIndex<class TaskTag>;
+
+pick_and_place::PlannerConfiguration ParsePlannerConfigurationOrThrow(
+    const std::string& filename, TaskIndex task_index = TaskIndex(0));
+
+pick_and_place::PlannerConfiguration ParsePlannerConfigurationOrThrow(
+    const std::string& filename,
+    const std::string& end_effector_name,
+    pick_and_place::RobotBaseIndex robot_base_index =
+        pick_and_place::RobotBaseIndex(0),
+    pick_and_place::TargetIndex target_index = pick_and_place::TargetIndex(0));
+
+std::vector<pick_and_place::PlannerConfiguration>
+ParsePlannerConfigurationsOrThrow(const std::string& filename);
+
+pick_and_place::SimulatedPlantConfiguration
+ParseSimulatedPlantConfigurationOrThrow(const std::string& filename);
+
+pick_and_place::OptitrackConfiguration ParseOptitrackConfigurationOrThrow(
+    const std::string& filename);
+
+}  // namespace pick_and_place
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
@@ -1,0 +1,272 @@
+#include "drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.h"
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration.h"
+#include "drake/math/roll_pitch_yaw.h"
+
+namespace drake {
+namespace examples {
+namespace kuka_iiwa_arm {
+namespace pick_and_place {
+namespace {
+
+using math::rpy2rotmat;
+using pick_and_place::PlannerConfiguration;
+using pick_and_place::SimulatedPlantConfiguration;
+using pick_and_place::OptitrackConfiguration;
+using pick_and_place::OptitrackInfo;
+using pick_and_place::RobotBaseIndex;
+using pick_and_place::TargetIndex;
+
+const char kIiwaPath[] =
+    "drake/manipulation/models/iiwa_description/urdf/"
+    "iiwa14_polytope_collision.urdf";
+const char kEndEffectorName[] = "iiwa_link_ee";
+const char kYellowPostPath[] =
+    "drake/examples/kuka_iiwa_arm/models/objects/yellow_post.urdf";
+const char kExtraHeavyDutyTablePath[] =
+    "drake/examples/kuka_iiwa_arm/models/table/"
+    "extra_heavy_duty_table_surface_only_collision.sdf";
+const char kCubePath[] =
+    "drake/examples/kuka_iiwa_arm/models/objects/simple_cuboid.urdf";
+const Vector3<double> kTargetDimensions{0.06, 0.06, 0.06};
+
+const std::vector<int> kTableOptitrackIds{2, 3, 4, 5, 6, 7};
+
+const std::vector<std::string> kTableModelPaths{
+    kYellowPostPath,           // position A
+    kYellowPostPath,           // position B
+    kExtraHeavyDutyTablePath,  // position C
+    kYellowPostPath,           // position D
+    kYellowPostPath,           // position E
+    kYellowPostPath,           // position F
+};
+
+const std::vector<Vector3<double>> kTablePositions{
+    {0.00, 1.00, 0.0},     // position A
+    {0.80, 0.36, 0.0},     // position B
+    {0.86, -0.36, -0.07},  // position C
+    {0.30, -0.9, 0.0},     // position D
+    {-0.1, -1.0, 0.0},     // position E
+    {-0.47, -0.8, 0.0},    // position F
+};
+
+const std::vector<double> kTableOptitrackFrameHeights{
+    1.02,    // position A
+    1.02,    // position B
+    0.7645,  // position C
+    1.02,    // position D
+    1.02,    // position E
+    1.02,    // position F
+};
+
+const std::vector<int> kObjectOptitrackIds{8};
+
+const std::vector<std::string> kObjectModelPaths{kCubePath};
+
+const std::vector<Vector3<double>> kObjectPositions{{0.30, -0.9, 1.05}};
+
+const std::vector<Vector3<double>> kObjectRpy{{0.0, 0.0, 1.571}};
+
+const char kConfigurationFile[] =
+    "drake/examples/kuka_iiwa_arm/dev/pick_and_place/configuration/"
+    "yellow_posts.pick_and_place_configuration";
+
+::testing::AssertionResult CompareIsometry3Vectors(
+    const std::vector<Isometry3<double>>& pose_vector,
+    const std::vector<Isometry3<double>>& expected_pose_vector) {
+  if (pose_vector.size() != expected_pose_vector.size()) {
+    return ::testing::AssertionFailure()
+           << "Size mismatch: " << pose_vector.size() << " vs. "
+           << expected_pose_vector.size();
+  }
+  for (int i = 0; i < static_cast<int>(pose_vector.size()); ++i) {
+    ::testing::AssertionResult result{CompareMatrices(
+        pose_vector[i].matrix(), expected_pose_vector[i].matrix())};
+    if (!result) {
+      return ::testing::AssertionFailure() << "Comparison failed at index " << i
+                                           << ". " << result.message();
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult CompareOptitrackInfoVectors(
+    const std::vector<OptitrackInfo>& optitrack_info_vector,
+    const std::vector<OptitrackInfo>& expected_optitrack_info_vector) {
+  if (optitrack_info_vector.size() != expected_optitrack_info_vector.size()) {
+    return ::testing::AssertionFailure()
+           << "Size mismatch: " << optitrack_info_vector.size() << " vs. "
+           << expected_optitrack_info_vector.size();
+  }
+  ::testing::AssertionResult result = ::testing::AssertionSuccess();
+  for (int i = 0; i < static_cast<int>(optitrack_info_vector.size()); ++i) {
+    result = CompareMatrices(optitrack_info_vector[i].X_MF.matrix(),
+                             expected_optitrack_info_vector[i].X_MF.matrix());
+    if (result &&
+        optitrack_info_vector[i].id != expected_optitrack_info_vector[i].id) {
+      result = ::testing::AssertionFailure()
+               << "Optitrack ids do not match: " << optitrack_info_vector[i].id
+               << " vs. " << expected_optitrack_info_vector[i].id;
+    }
+    if (!result) {
+      return ::testing::AssertionFailure() << "Comparison failed at index " << i
+                                           << ". " << result.message();
+    }
+  }
+  return ::testing::AssertionSuccess();
+}  // namespace
+
+void ValidateSimulatedPlantConfiguration(
+    const SimulatedPlantConfiguration& plant_configuration,
+    const SimulatedPlantConfiguration& expected_plant_configuration) {
+  EXPECT_TRUE(
+      CompareIsometry3Vectors(plant_configuration.robot_poses,
+                              expected_plant_configuration.robot_poses));
+  EXPECT_TRUE(
+      CompareIsometry3Vectors(plant_configuration.table_poses,
+                              expected_plant_configuration.table_poses));
+  EXPECT_TRUE(
+      CompareIsometry3Vectors(plant_configuration.object_poses,
+                              expected_plant_configuration.object_poses));
+  EXPECT_EQ(plant_configuration.robot_models,
+            expected_plant_configuration.robot_models);
+  EXPECT_EQ(plant_configuration.table_models,
+            expected_plant_configuration.table_models);
+  EXPECT_EQ(plant_configuration.object_models,
+            expected_plant_configuration.object_models);
+  EXPECT_EQ(plant_configuration.static_friction_coef,
+            expected_plant_configuration.static_friction_coef);
+  EXPECT_EQ(plant_configuration.dynamic_friction_coef,
+            expected_plant_configuration.dynamic_friction_coef);
+  EXPECT_EQ(plant_configuration.v_stiction_tolerance,
+            expected_plant_configuration.v_stiction_tolerance);
+  EXPECT_EQ(plant_configuration.stiffness,
+            expected_plant_configuration.stiffness);
+  EXPECT_EQ(plant_configuration.dissipation,
+            expected_plant_configuration.dissipation);
+}
+
+void ValidateOptitrackConfiguration(
+    const OptitrackConfiguration& configuration,
+    const OptitrackConfiguration& expected_configuration) {
+  EXPECT_TRUE(CompareOptitrackInfoVectors(
+      configuration.robot_base_optitrack_info,
+      expected_configuration.robot_base_optitrack_info));
+  EXPECT_TRUE(CompareOptitrackInfoVectors(
+      configuration.object_optitrack_info,
+      expected_configuration.object_optitrack_info));
+  EXPECT_TRUE(
+      CompareOptitrackInfoVectors(configuration.table_optitrack_info,
+                                  expected_configuration.table_optitrack_info));
+}
+
+void ValidatePlannerConfiguration(
+    const PlannerConfiguration& configuration,
+    const PlannerConfiguration& expected_configuration) {
+  EXPECT_EQ(configuration.model_path, expected_configuration.model_path);
+  EXPECT_EQ(configuration.end_effector_name,
+            expected_configuration.end_effector_name);
+  EXPECT_EQ(configuration.robot_index, expected_configuration.robot_index);
+  EXPECT_EQ(configuration.target_dimensions,
+            expected_configuration.target_dimensions);
+  EXPECT_EQ(configuration.period_sec, expected_configuration.period_sec);
+  EXPECT_EQ(configuration.num_tables, expected_configuration.num_tables);
+}
+
+class ConfigurationParsingTests : public ::testing::Test {
+ protected:
+  void SetUp() {
+    // Set robot parameters
+    optitrack_configuration_.robot_base_optitrack_info.emplace_back();
+    optitrack_configuration_.robot_base_optitrack_info.back().id = 1;
+    plant_configuration_.robot_poses.push_back(Isometry3<double>::Identity());
+    plant_configuration_.robot_poses.back().translation().z() = 0.7645;
+    plant_configuration_.robot_models.push_back(kIiwaPath);
+
+    // Set table parameters
+    const int num_tables = kTableModelPaths.size();
+    for (int i = 0; i < num_tables; ++i) {
+      optitrack_configuration_.table_optitrack_info.emplace_back();
+      optitrack_configuration_.table_optitrack_info.back().id =
+          kTableOptitrackIds[i];
+      optitrack_configuration_.table_optitrack_info.back()
+          .X_MF.translation()
+          .z() += kTableOptitrackFrameHeights[i];
+      plant_configuration_.table_models.push_back(kTableModelPaths[i]);
+      plant_configuration_.table_poses.emplace_back(
+          Isometry3<double>::Identity());
+      plant_configuration_.table_poses.back().translation() =
+          kTablePositions[i];
+    }
+
+    // Set object parameters
+    const int num_objects = kObjectModelPaths.size();
+    for (int i = 0; i < num_objects; ++i) {
+      optitrack_configuration_.object_optitrack_info.emplace_back();
+      optitrack_configuration_.object_optitrack_info.back().id =
+          kObjectOptitrackIds[i];
+      plant_configuration_.object_models.push_back(kObjectModelPaths[i]);
+      plant_configuration_.object_poses.push_back(
+          Isometry3<double>::Identity());
+      plant_configuration_.object_poses.back().translation() =
+          kObjectPositions[i];
+      plant_configuration_.object_poses.back().rotate(
+          AngleAxis<double>(kObjectRpy[i].z(), Vector3<double>::UnitZ()));
+    }
+
+    plant_configuration_.stiffness = 3e3;
+    plant_configuration_.dissipation = 5;
+
+    // Set planner parameters
+    planner_configuration_.model_path = kIiwaPath;
+    planner_configuration_.end_effector_name = kEndEffectorName;
+    planner_configuration_.target_dimensions = kTargetDimensions;
+    planner_configuration_.num_tables = 6;
+  }
+
+  SimulatedPlantConfiguration plant_configuration_;
+  pick_and_place::OptitrackConfiguration optitrack_configuration_;
+  pick_and_place::PlannerConfiguration planner_configuration_;
+};
+
+TEST_F(ConfigurationParsingTests, ParsePlannerConfigurationTaskIndex) {
+  PlannerConfiguration parsed_planner_configuration =
+      ParsePlannerConfigurationOrThrow(kConfigurationFile, TaskIndex(0));
+  ValidatePlannerConfiguration(parsed_planner_configuration,
+                               planner_configuration_);
+}
+
+TEST_F(ConfigurationParsingTests,
+       ParsePlannerConfigurationRobotAndTargetIndex) {
+  PlannerConfiguration parsed_planner_configuration =
+      ParsePlannerConfigurationOrThrow(kConfigurationFile, "iiwa_link_ee",
+                                       RobotBaseIndex(0), TargetIndex(0));
+  ValidatePlannerConfiguration(parsed_planner_configuration,
+                               planner_configuration_);
+}
+
+TEST_F(ConfigurationParsingTests, ParseSimulatedPlantConfiguration) {
+  SimulatedPlantConfiguration parsed_plant_configuration =
+      ParseSimulatedPlantConfigurationOrThrow(kConfigurationFile);
+  ValidateSimulatedPlantConfiguration(parsed_plant_configuration,
+                                      plant_configuration_);
+}
+
+TEST_F(ConfigurationParsingTests, ParseOptitrackConfiguration) {
+  OptitrackConfiguration parsed_optitrack_configuration =
+      ParseOptitrackConfigurationOrThrow(kConfigurationFile);
+  ValidateOptitrackConfiguration(parsed_optitrack_configuration,
+                                 optitrack_configuration_);
+}
+}  // namespace
+}  // namespace pick_and_place
+}  // namespace kuka_iiwa_arm
+}  // namespace examples
+}  // namespace drake


### PR DESCRIPTION
This PR provides functions that parse text-format protobuf files into the pick-and-place configuration structs added in #7437. These will be used in subsequent `dev`-only PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7466)
<!-- Reviewable:end -->
