### PR TITLE
Stop assigning names to systems which are no better than GetMemoryObjectName

### DIFF
--- a/drake/manipulation/perception/optitrack_pose_extractor.cc
+++ b/drake/manipulation/perception/optitrack_pose_extractor.cc
@@ -26,7 +26,6 @@ OptitrackPoseExtractor::OptitrackPoseExtractor(
                   &OptitrackPoseExtractor::OutputMeasuredPose)
               .get_index()},
       X_WO_(X_WO) {
-  this->set_name("Optitrack pose extractor");
   DeclareAbstractState(
       systems::AbstractValue::Make<Isometry3<double>>(
           Isometry3<double>::Identity()));

--- a/drake/manipulation/perception/pose_smoother.cc
+++ b/drake/manipulation/perception/pose_smoother.cc
@@ -107,7 +107,6 @@ PoseSmoother::PoseSmoother(double desired_max_linear_velocity,
       max_linear_velocity_(desired_max_linear_velocity),
       max_angular_velocity_(desired_max_angular_velocity),
       is_filter_enabled_(filter_window_size > 1) {
-  this->set_name("Pose Smoother");
   this->DeclareAbstractState(
       systems::AbstractValue::Make<InternalState>(
           InternalState(filter_window_size)));

--- a/drake/manipulation/planner/robot_plan_interpolator.cc
+++ b/drake/manipulation/planner/robot_plan_interpolator.cc
@@ -50,7 +50,6 @@ RobotPlanInterpolator::RobotPlanInterpolator(
     double update_interval)
     : plan_input_port_(this->DeclareAbstractInputPort().get_index()),
       interp_type_(interp_type) {
-  this->set_name("RobotPlanInterpolator");
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
       model_path, multibody::joints::kFixed, &tree_);
   // TODO(sam.creasey) This implementation doesn't know how to

--- a/drake/manipulation/schunk_wsg/schunk_wsg_controller.cc
+++ b/drake/manipulation/schunk_wsg/schunk_wsg_controller.cc
@@ -64,7 +64,6 @@ SchunkWsgController::SchunkWsgController() {
                   saturation->get_min_value_port());
   builder.ExportOutput(saturation->get_output_port());
   builder.BuildInto(this);
-  set_name("SchunkWsgController");
 }
 
 }  // namespace schunk_wsg

--- a/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/drake/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -29,7 +29,6 @@ SchunkWsgTrajectoryGenerator::SchunkWsgTrajectoryGenerator(
           this->DeclareVectorOutputPort(
               BasicVector<double>(1),
               &SchunkWsgTrajectoryGenerator::OutputForce).get_index()) {
-  this->set_name("SchunkWsgTrajectoryGenerator");
   this->DeclareAbstractInputPort();
   this->DeclareInputPort(systems::kVectorValued, input_size);
   // The update period below matches the polling rate from
@@ -182,7 +181,6 @@ SchunkWsgStatusSender::
 SchunkWsgStatusSender(int input_size,
                       int position_index, int velocity_index)
     : position_index_(position_index), velocity_index_(velocity_index) {
-  this->set_name("SchunkWsgStatusSender");
   this->DeclareInputPort(systems::kVectorValued, input_size);
   this->DeclareAbstractOutputPort(&SchunkWsgStatusSender::OutputStatus);
 }

--- a/drake/manipulation/util/sim_diagram_builder.cc
+++ b/drake/manipulation/util/sim_diagram_builder.cc
@@ -14,8 +14,6 @@ systems::DrakeVisualizer* SimDiagramBuilder<T>::AddVisualizer(
 
   visualizer_ = builder_.template AddSystem<systems::DrakeVisualizer>(
       plant_->get_rigid_body_tree(), lcm);
-  visualizer_->set_name("visualizer");
-
   return visualizer_;
 }
 
@@ -25,7 +23,6 @@ systems::RigidBodyPlant<T>* SimDiagramBuilder<T>::AddPlant(
   DRAKE_DEMAND(plant_ == nullptr);
   plant_ =
       builder_.template AddSystem<systems::RigidBodyPlant<T>>(std::move(plant));
-  plant_->set_name("plant");
   return plant_;
 }
 

--- a/drake/systems/controllers/inverse_dynamics_controller.cc
+++ b/drake/systems/controllers/inverse_dynamics_controller.cc
@@ -19,7 +19,6 @@ void InverseDynamicsController<T>::SetUp(const VectorX<double>& kp,
                                          const VectorX<double>& ki,
                                          const VectorX<double>& kd) {
   DiagramBuilder<T> builder;
-  this->set_name("InverseDynamicsController");
 
   const RigidBodyTree<T>& robot = *robot_for_control_;
   DRAKE_DEMAND(robot.get_num_positions() == kp.size());
@@ -43,20 +42,16 @@ void InverseDynamicsController<T>::SetUp(const VectorX<double>& kp,
 
   // Adds a PID.
   pid_ = builder.template AddSystem<PidController<T>>(kp, ki, kd);
-  pid_->set_name("pid");
 
   // Adds inverse dynamics.
   auto inverse_dynamics =
       builder.template AddSystem<InverseDynamics<T>>(robot, false);
-  inverse_dynamics->set_name("inverse_dynamics");
 
   // Redirects estimated state input into PID and inverse dynamics.
   auto pass_through = builder.template AddSystem<PassThrough<T>>(2 * dim);
-  pass_through->set_name("passthrough");
 
   // Adds a adder to do PID's acceleration + reference acceleration.
   auto adder = builder.template AddSystem<Adder<T>>(2, dim);
-  adder->set_name("adder");
 
   // Connects estimated state to PID.
   builder.Connect(pass_through->get_output_port(),
@@ -86,7 +81,6 @@ void InverseDynamicsController<T>::SetUp(const VectorX<double>& kp,
     auto zero_feedforward_acceleration =
         builder.template AddSystem<ConstantVectorSource<T>>(
             VectorX<T>::Zero(robot.get_num_velocities()));
-    zero_feedforward_acceleration->set_name("zero");
     builder.Connect(zero_feedforward_acceleration->get_output_port(),
                     adder->get_input_port(1));
   } else {

--- a/drake/systems/controllers/pid_controlled_system.cc
+++ b/drake/systems/controllers/pid_controlled_system.cc
@@ -58,10 +58,6 @@ void PidControlledSystem<T>::Initialize(
     const Eigen::VectorXd& Ki, const Eigen::VectorXd& Kd) {
   DRAKE_DEMAND(plant != nullptr);
 
-  if (plant->get_name().empty()) {
-    plant->set_name("plant");
-  }
-
   DiagramBuilder<T> builder;
   plant_ = builder.template AddSystem(std::move(plant));
   DRAKE_ASSERT(plant_->get_num_input_ports() >= 1);
@@ -88,17 +84,13 @@ PidControlledSystem<T>::ConnectController(
   auto controller = builder->template AddSystem<PidController<T>>(
       feedback_selector,
       Kp, Ki, Kd);
-  controller->set_name("pid_controller");
 
   auto plant_input_adder =
       builder->template AddSystem<Adder<T>>(2, plant_input.size());
-  plant_input_adder->set_name("input_adder");
 
   builder->Connect(plant_output, controller->get_input_port_estimated_state());
-
   builder->Connect(controller->get_output_port_control(),
                    plant_input_adder->get_input_port(0));
-
   builder->Connect(plant_input_adder->get_output_port(), plant_input);
 
   return ConnectResult{
@@ -130,8 +122,6 @@ PidControlledSystem<T>::ConnectControllerWithInputSaturation(
     DiagramBuilder<T>* builder) {
   auto saturation = builder->template AddSystem<Saturation<T>>(
       min_plant_input, max_plant_input);
-  saturation->set_name("saturation");
-
   builder->Connect(saturation->get_output_port(), plant_input);
 
   return

--- a/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
+++ b/drake/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
@@ -36,8 +36,6 @@ QpInverseDynamicsSystem::QpInverseDynamicsSystem(
       DeclareAbstractOutputPort(lcmt_inverse_dynamics_debug_info(),
                                 &QpInverseDynamicsSystem::CopyOutDebugInfo)
           .get_index();
-
-  set_name("QpInverseDynamicsSystem");
   DeclarePeriodicUnrestrictedUpdate(control_dt_, 0);
 
   abs_state_index_qp_output_ = DeclareAbstractState(


### PR DESCRIPTION
This came about because two instances of the resulting systems couldn't live in the same diagram.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7470)
<!-- Reviewable:end -->
