### PR TITLE
[Multilane] Provides lane-to-lane methods to create Connections from the Builder

### DIFF
--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -48,6 +48,38 @@ const Connection* Builder::Connect(const std::string& id, int num_lanes,
   return connections_.back().get();
 }
 
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double left_shoulder, double right_shoulder,
+                                   int start_lane_index, const Endpoint& start,
+                                   double length, int end_lane_index,
+                                   const EndpointZ& z_end, double r_ref,
+                                   int lane_ref_index) {
+  DRAKE_DEMAND(start_lane_index < num_lanes && start_lane_index >= 0);
+  DRAKE_DEMAND(end_lane_index < num_lanes && end_lane_index >= 0);
+  DRAKE_DEMAND(lane_ref_index < num_lanes && lane_ref_index >= 0);
+  // Creates the connection.
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, start_lane_index, z_end, end_lane_index, num_lanes, r_ref,
+      lane_ref_index, lane_width_, left_shoulder, right_shoulder, length));
+  return connections_.back().get();
+}
+
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double left_shoulder, double right_shoulder,
+                                   int start_lane_index, const Endpoint& start,
+                                   const ArcOffset& arc, int end_lane_index,
+                                   const EndpointZ& z_end, double r_ref,
+                                   int lane_ref_index) {
+  DRAKE_DEMAND(start_lane_index < num_lanes && start_lane_index >= 0);
+  DRAKE_DEMAND(end_lane_index < num_lanes && end_lane_index >= 0);
+  DRAKE_DEMAND(lane_ref_index < num_lanes && lane_ref_index >= 0);
+  // Creates the connection.
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, start_lane_index, z_end, end_lane_index, num_lanes, r_ref,
+      lane_ref_index, lane_width_, left_shoulder, right_shoulder, arc));
+  return connections_.back().get();
+}
+
 void Builder::SetDefaultBranch(const Connection* in, int in_lane_index,
                                const api::LaneEnd::Which in_end,
                                const Connection* out, int out_lane_index,

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -98,6 +98,48 @@ class Builder {
                             const Endpoint& start, const ArcOffset& arc,
                             const EndpointZ& z_end);
 
+  /// Creates a line Connection whose ID is `id` and has `num_lanes` lanes.
+  ///
+  /// `length` specifies the length of the reference curve which will be located
+  /// at `r_ref` lateral distance from `lane_ref_index` lane.
+  ///
+  /// Connection's `start_lane_index` lane will start at `start` and
+  /// connection's `end_lane_index` lane will end with `z_end` EndpointZ.
+  ///
+  /// `start_lane_index`, `end_lane_index`, `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra lateral distances added to
+  /// the extents of the Segment after the first and last Lanes positions are
+  /// determined.
+  const Connection* Connect(const std::string& id, int num_lanes,
+                            double left_shoulder, double right_shoulder,
+                            int start_lane_index, const Endpoint& start,
+                            double length, int end_lane_index,
+                            const EndpointZ& z_end, double r_ref,
+                            int lane_ref_index);
+
+  /// Creates an arc Connection whose ID is `id` and has `num_lanes` lanes.
+  ///
+  /// `arc` specifies the shape of the reference curve which will be located
+  /// at `r_ref` lateral distance from `lane_ref_index` lane.
+  ///
+  /// Connection's `start_lane_index` lane will start at `start` and
+  /// connection's `end_lane_index` lane will end with `z_end` EndpointZ.
+  ///
+  /// `start_lane_index`, `end_lane_index`, `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra lateral distances added to
+  /// the extents of the Segment after the first and last Lanes positions are
+  /// determined.
+  const Connection* Connect(const std::string& id, int num_lanes,
+                            double left_shoulder, double right_shoulder,
+                            int start_lane_index, const Endpoint& start,
+                            const ArcOffset& arc, int end_lane_index,
+                            const EndpointZ& z_end, double r_ref,
+                            int lane_ref_index);
+
   /// Sets the default branch for one end of a connection.
   ///
   /// The default branch for the `in_end` of connection `in` at Lane

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -186,6 +186,8 @@ class Connection {
 
   /// Constructs a line-segment connection.
   ///
+  /// Connection's ID is `id`.
+  ///
   /// Segment's reference curve begins at `start` and extends on the plane
   /// z=0 `line_length` distance with `start.xy().heading()` heading angle.
   /// `end_z` will be used to build elevation and superelevation information of
@@ -208,6 +210,8 @@ class Connection {
 
   /// Constructs an arc-segment connection.
   ///
+  /// Connection's ID is `id`.
+  ///
   /// Segment's reference curve begins at `start` and extends on the plane z=0
   /// with `arc_offset.radius()` and angle span of `arc_offset.d_theta()`.
   /// `end_z` will be used to build elevation and superelevation information of
@@ -228,6 +232,67 @@ class Connection {
   Connection(const std::string& id, const Endpoint& start,
              const EndpointZ& end_z, int num_lanes, double r0,
              double lane_width, double left_shoulder, double right_shoulder,
+             const ArcOffset& arc_offset);
+
+  /// Constructs a line-segment connection.
+  ///
+  /// Connection's ID is `id`.
+  ///
+  /// Segment's reference curve begins at `r_ref` lateral distance from the
+  /// `lane_ref_index` lane and extends on the plane z=0 `line_length` distance
+  /// with `start.xy().heading()` heading angle. `start_lane_index` lane will
+  /// begin at `start`. `end_z` is the end EndpointZ information of
+  /// `end_lane_index` lane. Both start and end lane information is used to
+  /// compute the reference curve by translating coordinates and elevation and
+  /// superelevation information of the road.
+  ///
+  /// `line_length` must be non negative.
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// Each lane's width will be `lane_width`, which should be greater or equal
+  /// to zero.
+  ///
+  /// `start_lane_index`, `end_lane_index` and `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, int start_lane_index,
+             const EndpointZ& end_z, int end_lane_index, int num_lanes,
+             double r_ref, int lane_ref_index, double lane_width,
+             double left_shoulder, double right_shoulder, double line_length);
+
+  /// Constructs an arc-segment connection.
+  ///
+  /// Connection's ID is `id`.
+  ///
+  /// Segment's reference curve begins at `r_ref` lateral distance from the
+  /// `lane_ref_index` lane and extends on the plane z=0 with
+  /// `arc_offset.radius()` and angle span of `arc_offset.d_theta()`.
+  /// `start_lane_index` lane will begin at `start`. `end_z` is the end
+  /// EndpointZ information of `end_lane_index` lane. Both start and end lane
+  /// information is used to compute the reference curve by translating
+  /// coordinates and elevation and superelevation information of the road.
+  ///
+  /// `arc_offset.radius()` must be positive. `arc_offset.d_theta()` > 0
+  /// indicates a counterclockwise arc from `start` with initial heading angle
+  /// `start.heading()`.
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// Each lane's width will be `lane_width`, which should be greater or equal
+  /// to zero.
+  ///
+  /// `start_lane_index`, `end_lane_index` and `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, int start_lane_index,
+             const EndpointZ& end_z, int end_lane_index, int num_lanes,
+             double r_ref, int lane_ref_index, double lane_width,
+             double left_shoulder, double right_shoulder,
              const ArcOffset& arc_offset);
 
   /// Returns the geometric type of the path.
@@ -305,7 +370,7 @@ class Connection {
  private:
   const Type type_{};
   const std::string id_;
-  const Endpoint start_{};
+  Endpoint start_{};
   Endpoint end_{};
   const int num_lanes_{};
   const double r0_{};
@@ -316,13 +381,13 @@ class Connection {
   const double r_max_{};
   std::unique_ptr<RoadCurve> road_curve_;
   // Bits specific to type_ == kLine:
-  double line_length_{};
+  const double line_length_{};
   // Bits specific to type_ == kArc:
-  double radius_{};
-  double d_theta_{};
-  double theta0_{};
-  double cx_{};
-  double cy_{};
+  const double radius_{};
+  const double d_theta_{};
+  const double theta0_{};
+  const double cx_{};
+  const double cy_{};
 };
 
 /// A group of Connections.

--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -247,17 +247,8 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   }
 };
 
-// Holds Lane IDs for each Lane, both at the start and end of the Lane.
-struct BranchPointLaneIds {
-  std::vector<std::string> start_a_side;
-  std::vector<std::string> start_b_side;
-  std::vector<std::string> finish_a_side;
-  std::vector<std::string> finish_b_side;
-};
-
 class MultilaneBuilderPrimitivesTest : public ::testing::Test {
  protected:
-  const double kR0{10.};
   const double kLaneWidth{4.};
   const double kLeftShoulder{2.};
   const double kRightShoulder{2.};
@@ -268,108 +259,248 @@ class MultilaneBuilderPrimitivesTest : public ::testing::Test {
   const EndpointZ kLowFlatZ{0., 0., 0., 0.};
   const double kStartHeading{-M_PI / 4.};
   const Endpoint start{{0., 0., kStartHeading}, kLowFlatZ};
+  const Vector3<double> kStartRVersor{std::cos(kStartHeading + M_PI / 2.),
+                                      std::sin(kStartHeading + M_PI / 2.), 0.};
+
+  void TestRoadGeometryEntities(const api::RoadGeometry& rg,
+                                const std::string& name) const {
+    EXPECT_EQ(rg.id(), api::RoadGeometryId(name));
+    EXPECT_EQ(rg.num_junctions(), 1);
+    EXPECT_NE(rg.junction(0), nullptr);
+    EXPECT_EQ(rg.junction(0)->id(), api::JunctionId("j:c0"));
+    EXPECT_EQ(rg.junction(0)->num_segments(), 1);
+    EXPECT_NE(rg.junction(0)->segment(0), nullptr);
+    EXPECT_EQ(rg.junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
+    EXPECT_EQ(rg.junction(0)->segment(0)->num_lanes(), kNumLanes);
+    // Checks Lane's ID.
+    for (int i = 0; i < kNumLanes; i++) {
+      const api::Lane* lane = rg.junction(0)->segment(0)->lane(i);
+      EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
+      // Checks lane start and end BranchPoint.
+      const api::BranchPoint* const start_bp =
+          lane->GetBranchPoint(api::LaneEnd::kStart);
+      EXPECT_EQ(start_bp->GetASide()->size(), 1);
+      EXPECT_EQ(start_bp->GetASide()->get(0).lane, lane);
+      EXPECT_EQ(start_bp->GetBSide()->size(), 0);
+      const api::BranchPoint* const end_bp =
+          lane->GetBranchPoint(api::LaneEnd::kFinish);
+      EXPECT_EQ(end_bp->GetASide()->size(), 1);
+      EXPECT_EQ(end_bp->GetASide()->get(0).lane, lane);
+      EXPECT_EQ(end_bp->GetBSide()->size(), 0);
+    }
+    // Checks the number of branch points.
+    EXPECT_EQ(rg.num_branch_points(), 2 * kNumLanes);
+  }
+
+  void TestLaneEndGeoPositions(const api::RoadGeometry& rg, double r0,
+                               const Vector3<double>& start_reference_curve,
+                               const Vector3<double>& start_r_versor,
+                               const Vector3<double>& end_reference_curve,
+                               const Vector3<double>& end_r_versor) const {
+    for (int i = 0; i < kNumLanes; i++) {
+      const api::Lane* const lane = rg.junction(0)->segment(0)->lane(i);
+      // Checks lane start GeoPosition to verify that spacing is correctly
+      // applied.
+      const Vector3<double> lane_start_geo =
+          start_reference_curve +
+          (r0 + static_cast<double>(i) * kLaneWidth) * start_r_versor;
+      EXPECT_TRUE(api::test::IsGeoPositionClose(
+          lane->ToGeoPosition({0., 0., 0.}),
+          api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
+      // Checks lane end GeoPosition to verify that spacing is correctly
+      // applied.
+      const Vector3<double> lane_end_geo =
+          end_reference_curve +
+          (r0 + static_cast<double>(i) * kLaneWidth) * end_r_versor;
+      EXPECT_TRUE(api::test::IsGeoPositionClose(
+          lane->ToGeoPosition({lane->length(), 0., 0.}),
+          api::GeoPosition::FromXyz(lane_end_geo), kLinearTolerance));
+    }
+  }
 };
 
-// Checks that a multi-lane line segment is correctly created.
-TEST_F(MultilaneBuilderPrimitivesTest, MultilaneLineSegment) {
+// Checks that a multi-lane line segment is correctly created with both Builder
+// methods.
+TEST_F(MultilaneBuilderPrimitivesTest, LineSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
-  const double kLength = 50.;
+  const double kR0{10.};
+  const double kLength{50.};
   b.Connect("c0", kNumLanes, kR0, kLeftShoulder, kRightShoulder, start, kLength,
             kLowFlatZ);
+  const std::string kRoadGeometryName{"multilane-line-segment"};
   std::unique_ptr<const api::RoadGeometry> rg =
-      b.Build(api::RoadGeometryId{"multilane-line-segment"});
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
 
-  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-line-segment"));
-  EXPECT_EQ(rg->num_junctions(), 1);
-  EXPECT_NE(rg->junction(0), nullptr);
-  EXPECT_EQ(rg->junction(0)->id(), api::JunctionId("j:c0"));
-  EXPECT_EQ(rg->junction(0)->num_segments(), 1);
-  EXPECT_NE(rg->junction(0)->segment(0), nullptr);
-  EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
-  EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
 
-  const Vector3<double> r_versor(-std::sin(kStartHeading),
-                                 std::cos(kStartHeading), 0.);
   const Vector3<double> start_reference_curve(start.xy().x(), start.xy().y(),
                                               start.z().z());
-  for (int i = 0; i < kNumLanes; i++) {
-    const api::Lane* lane = rg->junction(0)->segment(0)->lane(i);
-    // Checks Lane's ID.
-    EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
-    // Checks lane start geo position to verify that spacing is correctly
-    // applied.
-    const Vector3<double> lane_start_geo =
-        start_reference_curve +
-        (kR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition({0., 0., 0.}),
-        api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
-    // Checks lane start and end BranchPoint.
-    const api::BranchPoint* const start_bp =
-        lane->GetBranchPoint(api::LaneEnd::kStart);
-    EXPECT_EQ(start_bp->GetASide()->size(), 1);
-    EXPECT_EQ(start_bp->GetASide()->get(0).lane, lane);
-    EXPECT_EQ(start_bp->GetBSide()->size(), 0);
-    const api::BranchPoint* const end_bp =
-        lane->GetBranchPoint(api::LaneEnd::kFinish);
-    EXPECT_EQ(end_bp->GetASide()->size(), 1);
-    EXPECT_EQ(end_bp->GetASide()->get(0).lane, lane);
-    EXPECT_EQ(end_bp->GetBSide()->size(), 0);
-  }
-  // Checks the number of branch points.
-  EXPECT_EQ(rg->num_branch_points(), 2 * kNumLanes);
+  const Vector3<double> end_reference_curve(
+      start.xy().x() + kLength * std::cos(kStartHeading),
+      start.xy().y() + kLength * std::sin(kStartHeading), start.z().z());
+
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, kStartRVersor);
+}
+
+TEST_F(MultilaneBuilderPrimitivesTest, LaneToLaneLineSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kLength{50.};
+  const int kStartLaneIndex{1};
+  const int kEndLaneIndex{0};
+  const double kRRef{0.5};
+  const double kRefLaneIndex{2};
+  const double kR0{kRRef - 2. * kLaneWidth};
+
+  b.Connect("c0", kNumLanes, kLeftShoulder, kRightShoulder, kStartLaneIndex,
+            start, kLength, kEndLaneIndex, kLowFlatZ, kRRef, kRefLaneIndex);
+
+  const std::string kRoadGeometryName{"multilane-line-segment"};
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
+
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
+
+  const Vector3<double> start_reference_curve(
+      start.xy().x() + (-kRRef + kLaneWidth) * kStartRVersor.x(),
+      start.xy().y() + (-kRRef + kLaneWidth) * kStartRVersor.y(),
+      start.z().z());
+  const Vector3<double> end_reference_curve(
+      start_reference_curve.x() + kLength * std::cos(kStartHeading),
+      start_reference_curve.y() + kLength * std::sin(kStartHeading),
+      start.z().z());
+
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, kStartRVersor);
 }
 
 // Checks that a multi-lane arc segment is correctly created.
-TEST_F(MultilaneBuilderPrimitivesTest, MultilaneArcSegment) {
+TEST_F(MultilaneBuilderPrimitivesTest, CounterclockwiseArcSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
-  const double kRadius = 30.;
-  const double kDTheta = 0.5 * M_PI;
+  const double kR0{10.};
+  const double kRadius{30.};
+  const double kDTheta{0.5 * M_PI};
   b.Connect("c0", kNumLanes, kR0, kLeftShoulder, kRightShoulder, start,
             ArcOffset(kRadius, kDTheta), kLowFlatZ);
+
+  const std::string kRoadGeometryName{"multilane-arc-segment"};
   std::unique_ptr<const api::RoadGeometry> rg =
-      b.Build(api::RoadGeometryId{"multilane-arc-segment"});
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
 
-  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-arc-segment"));
-  EXPECT_EQ(rg->num_junctions(), 1);
-  EXPECT_NE(rg->junction(0), nullptr);
-  EXPECT_EQ(rg->junction(0)->id(), api::JunctionId("j:c0"));
-  EXPECT_EQ(rg->junction(0)->num_segments(), 1);
-  EXPECT_NE(rg->junction(0)->segment(0), nullptr);
-  EXPECT_EQ(rg->junction(0)->segment(0)->id(), api::SegmentId("s:c0"));
-  EXPECT_EQ(rg->junction(0)->segment(0)->num_lanes(), kNumLanes);
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
 
-  const Vector3<double> r_versor(-std::sin(kStartHeading),
-                                 std::cos(kStartHeading), 0.);
   const Vector3<double> start_reference_curve(start.xy().x(), start.xy().y(),
-                                              start.z().z());
-  for (int i = 0; i < kNumLanes; i++) {
-    const api::Lane* const lane = rg->junction(0)->segment(0)->lane(i);
-    // Checks Lane's ID.
-    EXPECT_EQ(lane->id().string(), std::string("l:c0_") + std::to_string(i));
-    // Checks lane start geo position to verify that spacing is correctly
-    // applied.
-    const Vector3<double> lane_start_geo =
-        start_reference_curve +
-        (kR0 + static_cast<double>(i) * kLaneWidth) * r_versor;
-    EXPECT_TRUE(api::test::IsGeoPositionClose(
-        lane->ToGeoPosition({0., 0., 0.}),
-        api::GeoPosition::FromXyz(lane_start_geo), kLinearTolerance));
-    // Checks lane start and end BranchPoint.
-    const api::BranchPoint* const start_bp =
-        lane->GetBranchPoint(api::LaneEnd::kStart);
-    EXPECT_EQ(start_bp->GetASide()->size(), 1);
-    EXPECT_EQ(start_bp->GetASide()->get(0).lane, lane);
-    EXPECT_EQ(start_bp->GetBSide()->size(), 0);
-    const api::BranchPoint* const end_bp =
-        lane->GetBranchPoint(api::LaneEnd::kFinish);
-    EXPECT_EQ(end_bp->GetASide()->size(), 1);
-    EXPECT_EQ(end_bp->GetASide()->get(0).lane, lane);
-    EXPECT_EQ(end_bp->GetBSide()->size(), 0);
-  }
-  // Checks the number of branch points.
-  EXPECT_EQ(rg->num_branch_points(), 2 * kNumLanes);
+                                              kLowFlatZ.z());
+  const Vector3<double> end_r_versor(
+      std::cos(kStartHeading + kDTheta + M_PI / 2.),
+      std::sin(kStartHeading + kDTheta + M_PI / 2.), 0.);
+  const Vector3<double> end_reference_curve(kRadius * std::sqrt(2.), 0.,
+                                            kLowFlatZ.z());
+
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, end_r_versor);
 }
+
+TEST_F(MultilaneBuilderPrimitivesTest, LaneToLaneCounterclockwiseArcSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kRadius{30.};
+  const double kDTheta{0.5 * M_PI};
+  const int kStartLaneIndex{1};
+  const int kEndLaneIndex{0};
+  const double kRRef{0.5};
+  const double kRefLaneIndex{2};
+  const double kR0{kRRef - 2. * kLaneWidth};
+
+  b.Connect("c0", kNumLanes, kLeftShoulder, kRightShoulder, kStartLaneIndex,
+            start, ArcOffset(kRadius, kDTheta), kEndLaneIndex, kLowFlatZ, kRRef,
+            kRefLaneIndex);
+
+  const std::string kRoadGeometryName{"multilane-arc-segment"};
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
+
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
+
+  const Vector3<double> start_reference_curve(
+      start.xy().x() + (kLaneWidth - kRRef) * kStartRVersor.x(),
+      start.xy().y() + (kLaneWidth - kRRef) * kStartRVersor.y(), kLowFlatZ.z());
+  const Vector3<double> end_r_versor(
+      std::cos(kStartHeading + kDTheta + M_PI / 2.),
+      std::sin(kStartHeading + kDTheta + M_PI / 2.), 0.);
+  const Vector3<double> end_reference_curve(
+      start_reference_curve.x() + kRadius * std::sqrt(2.),
+      start_reference_curve.y(), kLowFlatZ.z());
+
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, end_r_versor);
+}
+
+TEST_F(MultilaneBuilderPrimitivesTest, ClockwiseArcSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kR0{10.};
+  const double kRadius{30.};
+  const double kDTheta{-0.5 * M_PI};
+  b.Connect("c0", kNumLanes, kR0, kLeftShoulder, kRightShoulder, start,
+            ArcOffset(kRadius, kDTheta), kLowFlatZ);
+
+  const std::string kRoadGeometryName{"multilane-arc-segment"};
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
+
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
+
+  const Vector3<double> start_reference_curve(start.xy().x(), start.xy().y(),
+                                              kLowFlatZ.z());
+  const Vector3<double> end_r_versor(
+      std::cos(kStartHeading + kDTheta + M_PI / 2.),
+      std::sin(kStartHeading + kDTheta + M_PI / 2.), 0.);
+  const Vector3<double> end_reference_curve(0., -kRadius * std::sqrt(2.),
+                                            kLowFlatZ.z());
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, end_r_versor);
+}
+
+TEST_F(MultilaneBuilderPrimitivesTest, LaneToLaneClockwiseArcSegment) {
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  const double kRadius{30.};
+  const double kDTheta{-0.5 * M_PI};
+  const int kStartLaneIndex{1};
+  const int kEndLaneIndex{0};
+  const double kRRef{0.5};
+  const double kRefLaneIndex{2};
+  const double kR0{kRRef - 2. * kLaneWidth};
+
+  b.Connect("c0", kNumLanes, kLeftShoulder, kRightShoulder, kStartLaneIndex,
+            start, ArcOffset(kRadius, kDTheta), kEndLaneIndex, kLowFlatZ, kRRef,
+            kRefLaneIndex);
+
+  const std::string kRoadGeometryName{"multilane-arc-segment"};
+  std::unique_ptr<const api::RoadGeometry> rg =
+      b.Build(api::RoadGeometryId{kRoadGeometryName});
+
+  TestRoadGeometryEntities(*rg, kRoadGeometryName);
+
+  const Vector3<double> start_reference_curve(
+      start.xy().x() + (kLaneWidth - kRRef) * kStartRVersor.x(),
+      start.xy().y() + (kLaneWidth - kRRef) * kStartRVersor.y(), kLowFlatZ.z());
+  const Vector3<double> end_r_versor(
+      std::cos(kStartHeading + kDTheta + M_PI / 2.),
+      std::sin(kStartHeading + kDTheta + M_PI / 2.), 0.);
+  const Vector3<double> end_reference_curve(
+      start_reference_curve.x(),
+      start_reference_curve.y() - kRadius * std::sqrt(2.), kLowFlatZ.z());
+
+  TestLaneEndGeoPositions(*rg, kR0, start_reference_curve, kStartRVersor,
+                          end_reference_curve, end_r_versor);
+}
+
+// Holds Lane IDs for each Lane, both at the start and end of the Lane.
+struct BranchPointLaneIds {
+  std::vector<std::string> start_a_side;
+  std::vector<std::string> start_b_side;
+  std::vector<std::string> finish_a_side;
+  std::vector<std::string> finish_b_side;
+};
 
 // Checks that Junctions, Segments, Lanes and BranchPoints are correctly made
 // after creating the following RoadGeometry.
@@ -380,7 +511,7 @@ TEST_F(MultilaneBuilderPrimitivesTest, MultilaneArcSegment) {
 // <pre>
 //
 //                                0 1
-//                        d       x x
+//                        d       h x
 //                                | | c5
 //                                | |
 //                                | |
@@ -405,7 +536,9 @@ TEST_F(MultilaneBuilderPrimitivesTest, MultilaneArcSegment) {
 //                              x x x
 //                              0 1 2
 // </pre>
-GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
+
+class MultilaneBuilderCrossTest : public ::testing::Test {
+ protected:
   const double kLaneWidth{4.};
   const double kLeftShoulder{1.};
   const double kRightShoulder{1.};
@@ -415,42 +548,6 @@ GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
   const int kTwoLanes{2};
   const int kThreeLanes{3};
   const EndpointZ kLowFlatZ{0., 0., 0., 0.};
-
-  const Endpoint endpoint_a{{0., 0., 0.}, kLowFlatZ};
-  const Endpoint endpoint_b{{50., 0., 0.}, kLowFlatZ};
-  const Endpoint endpoint_c{{70., 0., 0.}, kLowFlatZ};
-  const Endpoint endpoint_d{{50., 50., -M_PI / 2.}, kLowFlatZ};
-  const Endpoint endpoint_e{{50., 14., -M_PI / 2.}, kLowFlatZ};
-  const Endpoint endpoint_f{{60., 14., -M_PI / 2.}, kLowFlatZ};
-  const Endpoint endpoint_g{{50., -6., -M_PI / 2.}, kLowFlatZ};
-
-  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
-  // Creates connections.
-  b.Connect("c1", kThreeLanes, 0, kLeftShoulder, kRightShoulder, endpoint_a,
-            50., kLowFlatZ);
-  auto c2 = b.Connect("c2", kTwoLanes, 4., kLeftShoulder, kRightShoulder,
-                      endpoint_b, 20., kLowFlatZ);
-  b.Connect("c3", kTwoLanes, 4., kLeftShoulder, kRightShoulder, endpoint_c, 30.,
-            kLowFlatZ);
-  auto c4 = b.Connect("c4", kThreeLanes, 0., kLeftShoulder, kRightShoulder,
-                      endpoint_b, ArcOffset(6., -M_PI / 2.), kLowFlatZ);
-  b.Connect("c5", kTwoLanes, 10., kLeftShoulder, kRightShoulder, endpoint_d,
-            36., kLowFlatZ);
-  auto c6 = b.Connect("c6", kTwoLanes, 0., kLeftShoulder, kRightShoulder,
-                      endpoint_f, ArcOffset(10., M_PI / 2.), kLowFlatZ);
-  auto c7 = b.Connect("c7", kTwoLanes, 10., kLeftShoulder, kRightShoulder,
-                      endpoint_e, 20., kLowFlatZ);
-  b.Connect("c8", kThreeLanes, 6., kLeftShoulder, kRightShoulder, endpoint_g,
-            44., kLowFlatZ);
-  // Creates the crossing junction.
-  std::vector<const Connection*> connections{c2, c4, c6, c7};
-  b.MakeGroup("cross", connections);
-
-  std::unique_ptr<const api::RoadGeometry> rg =
-      b.Build(api::RoadGeometryId{"multilane-arc-segment"});
-
-  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-arc-segment"));
-
   // Junction ID --> Segment IDs.
   const std::map<std::string, std::vector<std::string>> junction_truth_map{
       {"j:c1", {"s:c1"}},
@@ -499,65 +596,152 @@ GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
       {"l:c8_1", {{"l:c4_1", "l:c7_0"}, {"l:c8_1"}, {"l:c8_1"}, {}}},
       {"l:c8_2", {{"l:c4_2", "l:c7_1"}, {"l:c8_2"}, {"l:c8_2"}, {}}}};
 
-  EXPECT_EQ(rg->num_junctions(), junction_truth_map.size());
-  for (int i = 0; i < rg->num_junctions(); i++) {
-    // Checks each Junction.
-    const api::Junction* const junction = rg->junction(i);
-    EXPECT_NE(junction_truth_map.find(junction->id().string()),
-              junction_truth_map.end());
-    const std::vector<std::string>& segment_ids =
-        junction_truth_map.at(junction->id().string());
-    EXPECT_EQ(segment_ids.size(), junction->num_segments());
-    for (int j = 0; j < junction->num_segments(); j++) {
-      // Checks each Segment.
-      const api::Segment* const segment = junction->segment(j);
-      EXPECT_EQ(segment->id().string(), segment_ids[j]);
-      EXPECT_NE(segment_truth_map.find(segment->id().string()),
-                segment_truth_map.end());
-      const std::vector<std::string>& lane_ids =
-          segment_truth_map.at(segment->id().string());
-      EXPECT_EQ(segment->num_lanes(), lane_ids.size());
-      for (int k = 0; k < segment->num_lanes(); k++) {
-        // Checks each Lane.
-        const api::Lane* const lane = segment->lane(k);
-        EXPECT_NE(lane_truth_map.find(lane->id().string()),
-                  lane_truth_map.end());
-        const BranchPointLaneIds& bp_lane_ids =
-            lane_truth_map.at(lane->id().string());
-        const api::BranchPoint* const start_bp =
-            lane->GetBranchPoint(api::LaneEnd::kStart);
-        EXPECT_EQ(start_bp->GetASide()->size(),
-                  bp_lane_ids.start_a_side.size());
-        for (int lane_index = 0; lane_index < start_bp->GetASide()->size();
-             lane_index++) {
-          EXPECT_EQ(start_bp->GetASide()->get(lane_index).lane->id().string(),
-                    bp_lane_ids.start_a_side[lane_index]);
-        }
-        EXPECT_EQ(start_bp->GetBSide()->size(),
-                  bp_lane_ids.start_b_side.size());
-        for (int lane_index = 0; lane_index < start_bp->GetBSide()->size();
-             lane_index++) {
-          EXPECT_EQ(start_bp->GetBSide()->get(lane_index).lane->id().string(),
-                    bp_lane_ids.start_b_side[lane_index]);
-        }
-        const api::BranchPoint* const end_bp =
-            lane->GetBranchPoint(api::LaneEnd::kFinish);
-        EXPECT_EQ(end_bp->GetASide()->size(), bp_lane_ids.finish_a_side.size());
-        for (int lane_index = 0; lane_index < end_bp->GetASide()->size();
-             lane_index++) {
-          EXPECT_EQ(end_bp->GetASide()->get(lane_index).lane->id().string(),
-                    bp_lane_ids.finish_a_side[lane_index]);
-        }
-        EXPECT_EQ(end_bp->GetBSide()->size(), bp_lane_ids.finish_b_side.size());
-        for (int lane_index = 0; lane_index < end_bp->GetBSide()->size();
-             lane_index++) {
-          EXPECT_EQ(end_bp->GetBSide()->get(lane_index).lane->id().string(),
-                    bp_lane_ids.finish_b_side[lane_index]);
+  void TestRoadGeometry(std::unique_ptr<const api::RoadGeometry> rg) const {
+    EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-cross"));
+
+    EXPECT_EQ(rg->num_junctions(), junction_truth_map.size());
+    for (int i = 0; i < rg->num_junctions(); i++) {
+      // Checks each Junction.
+      const api::Junction* const junction = rg->junction(i);
+      EXPECT_NE(junction_truth_map.find(junction->id().string()),
+                junction_truth_map.end());
+      const std::vector<std::string>& segment_ids =
+          junction_truth_map.at(junction->id().string());
+      EXPECT_EQ(segment_ids.size(), junction->num_segments());
+      for (int j = 0; j < junction->num_segments(); j++) {
+        // Checks each Segment.
+        const api::Segment* const segment = junction->segment(j);
+        EXPECT_EQ(segment->id().string(), segment_ids[j]);
+        EXPECT_NE(segment_truth_map.find(segment->id().string()),
+                  segment_truth_map.end());
+        const std::vector<std::string>& lane_ids =
+            segment_truth_map.at(segment->id().string());
+        EXPECT_EQ(segment->num_lanes(), lane_ids.size());
+        for (int k = 0; k < segment->num_lanes(); k++) {
+          // Checks each Lane.
+          const api::Lane* const lane = segment->lane(k);
+          EXPECT_NE(lane_truth_map.find(lane->id().string()),
+                    lane_truth_map.end());
+          const BranchPointLaneIds& bp_lane_ids =
+              lane_truth_map.at(lane->id().string());
+          const api::BranchPoint* const start_bp =
+              lane->GetBranchPoint(api::LaneEnd::kStart);
+          EXPECT_EQ(start_bp->GetASide()->size(),
+                    bp_lane_ids.start_a_side.size());
+          for (int lane_index = 0; lane_index < start_bp->GetASide()->size();
+               lane_index++) {
+            EXPECT_EQ(start_bp->GetASide()->get(lane_index).lane->id().string(),
+                      bp_lane_ids.start_a_side[lane_index]);
+          }
+          EXPECT_EQ(start_bp->GetBSide()->size(),
+                    bp_lane_ids.start_b_side.size());
+          for (int lane_index = 0; lane_index < start_bp->GetBSide()->size();
+               lane_index++) {
+            EXPECT_EQ(start_bp->GetBSide()->get(lane_index).lane->id().string(),
+                      bp_lane_ids.start_b_side[lane_index]);
+          }
+          const api::BranchPoint* const end_bp =
+              lane->GetBranchPoint(api::LaneEnd::kFinish);
+          EXPECT_EQ(end_bp->GetASide()->size(),
+                    bp_lane_ids.finish_a_side.size());
+          for (int lane_index = 0; lane_index < end_bp->GetASide()->size();
+               lane_index++) {
+            EXPECT_EQ(end_bp->GetASide()->get(lane_index).lane->id().string(),
+                      bp_lane_ids.finish_a_side[lane_index]);
+          }
+          EXPECT_EQ(end_bp->GetBSide()->size(),
+                    bp_lane_ids.finish_b_side.size());
+          for (int lane_index = 0; lane_index < end_bp->GetBSide()->size();
+               lane_index++) {
+            EXPECT_EQ(end_bp->GetBSide()->get(lane_index).lane->id().string(),
+                      bp_lane_ids.finish_b_side[lane_index]);
+          }
         }
       }
     }
+    EXPECT_EQ(rg->num_branch_points(), 20);
   }
-  EXPECT_EQ(rg->num_branch_points(), 20);
+};
+
+// Constructs the RoadGeometry using the RoadCurve related API. Afterwards,
+// checks created entities.
+TEST_F(MultilaneBuilderCrossTest, ReferenceCurveMultilaneCross) {
+  const Endpoint endpoint_a{{0., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_b{{50., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_c{{70., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_d{{50., 50., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_e{{50., 14., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_f{{60., 14., -M_PI / 2.}, kLowFlatZ};
+  const Endpoint endpoint_g{{50., -6., -M_PI / 2.}, kLowFlatZ};
+
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  // Creates connections.
+  b.Connect("c1", kThreeLanes, 0, kLeftShoulder, kRightShoulder, endpoint_a,
+            50., kLowFlatZ);
+  auto c2 = b.Connect("c2", kTwoLanes, 4., kLeftShoulder, kRightShoulder,
+                      endpoint_b, 20., kLowFlatZ);
+  b.Connect("c3", kTwoLanes, 4., kLeftShoulder, kRightShoulder, endpoint_c, 30.,
+            kLowFlatZ);
+  auto c4 = b.Connect("c4", kThreeLanes, 0., kLeftShoulder, kRightShoulder,
+                      endpoint_b, ArcOffset(6., -M_PI / 2.), kLowFlatZ);
+  b.Connect("c5", kTwoLanes, 10., kLeftShoulder, kRightShoulder, endpoint_d,
+            36., kLowFlatZ);
+  auto c6 = b.Connect("c6", kTwoLanes, 0., kLeftShoulder, kRightShoulder,
+                      endpoint_f, ArcOffset(10., M_PI / 2.), kLowFlatZ);
+  auto c7 = b.Connect("c7", kTwoLanes, 10., kLeftShoulder, kRightShoulder,
+                      endpoint_e, 20., kLowFlatZ);
+  b.Connect("c8", kThreeLanes, 6., kLeftShoulder, kRightShoulder, endpoint_g,
+            44., kLowFlatZ);
+  // Creates the crossing junction.
+  std::vector<const Connection*> connections{c2, c4, c6, c7};
+  b.MakeGroup("cross", connections);
+
+  TestRoadGeometry(b.Build(api::RoadGeometryId{"multilane-cross"}));
+}
+
+// Constructs the RoadGeometry using the LaneToLane related API. Afterwards,
+// checks created entities.
+TEST_F(MultilaneBuilderCrossTest, LaneToLaneMultilaneCross) {
+  const Endpoint endpoint_a{{0., 0., 0.}, kLowFlatZ};
+  const Endpoint endpoint_h{{60., 50., -M_PI / 2.}, kLowFlatZ};
+  const int kFirstLaneId{0};
+  const int kSecondLaneId{1};
+  const int kThirdLaneId{2};
+  const double kRRef{0.5};
+
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+  // Creates connections.
+  auto c1 =
+      b.Connect("c1", kThreeLanes, kLeftShoulder, kRightShoulder, kFirstLaneId,
+                endpoint_a, 50., kFirstLaneId, kLowFlatZ, kRRef, kFirstLaneId);
+  auto c2 = b.Connect("c2", kTwoLanes, kLeftShoulder, kRightShoulder,
+                      kFirstLaneId, c1->LaneEnd(kSecondLaneId), 20.,
+                      kSecondLaneId, kLowFlatZ, kRRef, kSecondLaneId);
+  b.Connect("c3", kTwoLanes, kLeftShoulder, kRightShoulder, kSecondLaneId,
+            c2->LaneEnd(kSecondLaneId), 30., kFirstLaneId, kLowFlatZ, kRRef,
+            kFirstLaneId);
+  auto c4 =
+      b.Connect("c4", kThreeLanes, kLeftShoulder, kRightShoulder, kSecondLaneId,
+                c1->LaneEnd(kSecondLaneId), ArcOffset(9.5, -M_PI / 2.),
+                kFirstLaneId, kLowFlatZ, kRRef, kSecondLaneId);
+  auto c5 =
+      b.Connect("c5", kTwoLanes, kLeftShoulder, kRightShoulder, kFirstLaneId,
+                endpoint_h, 36., kFirstLaneId, kLowFlatZ, kRRef, kFirstLaneId);
+  auto c6 =
+      b.Connect("c6", kTwoLanes, kLeftShoulder, kRightShoulder, kFirstLaneId,
+                c5->LaneEnd(kFirstLaneId), ArcOffset(10.5, M_PI / 2.),
+                kFirstLaneId, kLowFlatZ, kRRef, kFirstLaneId);
+  auto c7 = b.Connect("c7", kTwoLanes, kLeftShoulder, kRightShoulder,
+                      kSecondLaneId, c6->LaneStart(kSecondLaneId), 20.,
+                      kSecondLaneId, kLowFlatZ, kRRef, kSecondLaneId);
+  b.Connect("c8", kThreeLanes, kLeftShoulder, kRightShoulder, kThirdLaneId,
+            c7->LaneEnd(kSecondLaneId), 44., kSecondLaneId, kLowFlatZ, kRRef,
+            kThirdLaneId);
+  // Creates the crossing junction.
+  std::vector<const Connection*> connections{c2, c4, c6, c7};
+  b.MakeGroup("cross", connections);
+
+  TestRoadGeometry(b.Build(api::RoadGeometryId{"multilane-cross"}));
 }
 
 }  // namespace multilane

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -80,7 +80,6 @@ GTEST_TEST(ArcOffsetTest, ParametrizedConstructor) {
 // Connection checks.
 class MultilaneConnectionTest : public ::testing::Test {
  protected:
-  const double kR0{2.};
   const int kNumLanes{3};
   const double kLeftShoulder{1.};
   const double kRightShoulder{1.5};
@@ -93,12 +92,13 @@ class MultilaneConnectionTest : public ::testing::Test {
   const double kVeryExact{1e-12};
 };
 
-TEST_F(MultilaneConnectionTest, ArcAccessors) {
+TEST_F(MultilaneConnectionTest, ReferenceCurveArcAccessors) {
   const std::string kId{"arc_connection"};
   const double kRadius{10. * std::sqrt(2.)};
   const double kDTheta{M_PI / 2.};
   const ArcOffset kArcOffset(kRadius, kDTheta);
   const Endpoint kEndEndpoint{{40., 30., kHeading + kDTheta}, kLowFlatZ};
+  const double kR0{2.};
 
   const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                        kLaneWidth, kLeftShoulder, kRightShoulder, kArcOffset);
@@ -126,11 +126,58 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
   EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
 }
 
-TEST_F(MultilaneConnectionTest, LineAccessors) {
+TEST_F(MultilaneConnectionTest, LaneToLaneArcAccessors) {
+  const std::string kId{"arc_connection"};
+  const int kStartLane{1};
+  const int kEndLane{2};
+  const double kRRef{0.5};
+  const int kLaneRef{2};
+  const double kRadius{10. * std::sqrt(2.)};
+  const double kDTheta{M_PI / 2.};
+  const double kTheta0{kHeading - M_PI / 2.};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
+
+  const Connection dut(kId, kStartEndpoint, kStartLane, kLowFlatZ, kEndLane,
+                       kNumLanes, kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                       kRightShoulder, kArcOffset);
+  EXPECT_EQ(dut.type(), Connection::Type::kArc);
+  EXPECT_EQ(dut.id(), kId);
+  EXPECT_TRUE(test::IsEndpointClose(
+      dut.start(),
+      {{kStartXy.x() + (kLaneWidth - kRRef) * std::cos(kHeading + M_PI / 2),
+        kStartXy.y() + (kLaneWidth - kRRef) * std::sin(kHeading + M_PI / 2),
+        kHeading},
+       kLowFlatZ},
+      kZeroTolerance));
+  EXPECT_TRUE(test::IsEndpointClose(
+      dut.end(),
+      {{kStartXy.x() + (kLaneWidth - kRRef) * std::cos(kHeading + M_PI / 2) +
+            kRadius * (std::cos(kTheta0 + kDTheta) - std::cos(kTheta0)),
+        kStartXy.y() + (kLaneWidth - kRRef) * std::sin(kHeading + M_PI / 2) +
+            kRadius * (std::sin(kTheta0 + kDTheta) - std::sin(kTheta0)),
+        kHeading + kDTheta},
+       kLowFlatZ},
+      kVeryExact));
+  EXPECT_EQ(dut.num_lanes(), kNumLanes);
+  EXPECT_EQ(dut.r0(), -2. * kLaneWidth + kRRef);
+  EXPECT_EQ(dut.lane_width(), kLaneWidth);
+  EXPECT_EQ(dut.left_shoulder(), kLeftShoulder);
+  EXPECT_EQ(dut.right_shoulder(), kRightShoulder);
+  EXPECT_EQ(dut.radius(), kRadius);
+  EXPECT_EQ(dut.d_theta(), kDTheta);
+  EXPECT_EQ(dut.r_min(), kRRef - 2.5 * kLaneWidth - kRightShoulder);
+  EXPECT_EQ(dut.r_max(), kRRef + 0.5 * kLaneWidth + kLeftShoulder);
+  EXPECT_EQ(dut.lane_offset(0), kRRef - 2. * kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(1), kRRef - kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(2), kRRef);
+}
+
+TEST_F(MultilaneConnectionTest, ReferenceCurveLineAccessors) {
   const std::string kId{"line_connection"};
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
-
   const double kLineLength{30. * std::sqrt(2.)};
+  const double kR0{2.};
+
   const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                        kLaneWidth, kLeftShoulder, kRightShoulder, kLineLength);
   EXPECT_EQ(dut.type(), Connection::Type::kLine);
@@ -156,6 +203,48 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
   EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
 }
 
+TEST_F(MultilaneConnectionTest, LaneToLaneLineAccessors) {
+  const std::string kId{"line_connection"};
+  const double kLineLength{30. * std::sqrt(2.)};
+  const int kStartLane{1};
+  const int kEndLane{2};
+  const double kRRef{0.5};
+  const int kLaneRef{2};
+
+  const Connection dut(kId, kStartEndpoint, kStartLane, kLowFlatZ, kEndLane,
+                       kNumLanes, kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                       kRightShoulder, kLineLength);
+  EXPECT_EQ(dut.type(), Connection::Type::kLine);
+  EXPECT_EQ(dut.id(), kId);
+  EXPECT_TRUE(test::IsEndpointClose(
+      dut.start(),
+      {{kStartXy.x() + (kLaneWidth - kRRef) * std::cos(kHeading + M_PI / 2.),
+        kStartXy.y() + (kLaneWidth - kRRef) * std::sin(kHeading + M_PI / 2.),
+        kHeading},
+       kLowFlatZ},
+      kVeryExact));
+  EXPECT_TRUE(test::IsEndpointClose(
+      dut.end(),
+      {{kStartXy.x() + kLineLength * std::cos(kHeading) +
+            (kLaneWidth - kRRef) * std::cos(kHeading + M_PI / 2.),
+        kStartXy.y() + kLineLength * std::sin(kHeading) +
+            (kLaneWidth - kRRef) * std::sin(kHeading + M_PI / 2.),
+        kHeading},
+       kLowFlatZ},
+      kVeryExact));
+  EXPECT_EQ(dut.num_lanes(), kNumLanes);
+  EXPECT_EQ(dut.r0(), -2. * kLaneWidth + kRRef);
+  EXPECT_EQ(dut.lane_width(), kLaneWidth);
+  EXPECT_EQ(dut.left_shoulder(), kLeftShoulder);
+  EXPECT_EQ(dut.right_shoulder(), kRightShoulder);
+  EXPECT_EQ(dut.line_length(), kLineLength);
+  EXPECT_EQ(dut.r_min(), -2.5 * kLaneWidth + kRRef - kRightShoulder);
+  EXPECT_EQ(dut.r_max(), 0.5 * kLaneWidth + kRRef + kLeftShoulder);
+  EXPECT_EQ(dut.lane_offset(0), kRRef - 2. * kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(1), kRRef - kLaneWidth);
+  EXPECT_EQ(dut.lane_offset(2), kRRef);
+}
+
 // Checks RoadCurve creation.
 //
 // Literals for elevation and superelevation polynomials below have been derived
@@ -170,12 +259,13 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
 // b = y_dot_0 / d_x
 // c = 3 * (y_1 - y_0) / d_x - 2 * y_dot_0 - y_dot_1
 // d = y_dot_0 + y_dot_1 - 2 * (y_1 - y_0)
-TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
+TEST_F(MultilaneConnectionTest, ReferenceCurveArcRoadCurveValidation) {
   const std::string kId{"arc_connection"};
   const double kRadius{10. * std::sqrt(2.)};
   const double kDTheta{M_PI / 2.};
   const ArcOffset kArcOffset(kRadius, kDTheta);
   const Endpoint kEndEndpoint{{40., 30., kHeading + kDTheta}, kLowFlatZ};
+  const double kR0{2.};
 
   const Connection flat_dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                             kLaneWidth, kLeftShoulder, kRightShoulder,
@@ -254,10 +344,114 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
               kVeryExact);
 }
 
-TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
+TEST_F(MultilaneConnectionTest, LaneToLaneArcRoadCurveValidation) {
+  const std::string kId{"arc_connection"};
+  const int kStartLane{1};
+  const int kEndLane{2};
+  const double kRadius{10. * std::sqrt(2.)};
+  const double kDTheta{M_PI / 2.};
+  const double kRRef{0.5};
+  const int kLaneRef{2};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
+
+  const Connection flat_dut(kId, kStartEndpoint, kStartLane, kLowFlatZ,
+                            kEndLane, kNumLanes, kRRef, kLaneRef, kLaneWidth,
+                            kLeftShoulder, kRightShoulder, kArcOffset);
+  std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
+  EXPECT_NE(dynamic_cast<ArcRoadCurve*>(road_curve.get()), nullptr);
+
+  // Checks start and end Endpoints of the road curve. x-y coordinates are
+  // computed using a simple Octave script like the following:
+  //
+  // start = [20 30];
+  // heading = -pi/4;
+  // start_r_versor = [cos(heading + pi/2) sin(heading + pi/2)];
+  // lane_width = 2;
+  // r_ref = 0.5;
+  // radius = 10 * sqrt(2);
+  // d_theta = pi/2;
+  // theta0 = heading - pi/2;
+  // road_curve_start = start + (lane_width - r_ref) .* start_r_versor;
+  // center = road_curve_start - radius .* [cos(theta0) sin(theta0)];
+  // road_curve_end = center + ...
+  //                  radius .* [cos(theta0 + d_theta) sin(theta0 + d_theta)];
+  const Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(),
+                      flat_dut.start().z().z()),
+      flat_origin, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(21.0606601717798, 31.0606601717798, kLowFlatZ.z()),
+      flat_origin, kVeryExact));
+  const Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(),
+                      flat_dut.end().z().z()),
+      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(41.0606601717798, 31.0606601717798, kLowFlatZ.z()),
+      flat_end, kVeryExact));
+
+  // Checks that elevation and superelevation polynomials are correctly built
+  // for the trivial case of a flat dut.
+  EXPECT_EQ(road_curve->elevation().a(), 0.);
+  EXPECT_EQ(road_curve->elevation().b(), 0.);
+  EXPECT_EQ(road_curve->elevation().c(), 0.);
+  EXPECT_EQ(road_curve->elevation().d(), 0.);
+  EXPECT_EQ(road_curve->superelevation().a(), 0.);
+  EXPECT_EQ(road_curve->superelevation().b(), 0.);
+  EXPECT_EQ(road_curve->superelevation().c(), 0.);
+  EXPECT_EQ(road_curve->superelevation().d(), 0.);
+
+  // Creates a new complex dut with cubic elevation and superelevation.
+  const EndpointZ kEndElevatedEndpointZ{5., 1., M_PI / 6., 1.};
+  const Connection complex_dut(kId, kStartEndpoint, kStartLane,
+                               kEndElevatedEndpointZ, kEndLane, kNumLanes,
+                               kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                               kRightShoulder, kArcOffset);
+  std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
+
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> complex_origin =
+      complex_road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(complex_dut.start().xy().x(),
+                                              complex_dut.start().xy().y(),
+                                              complex_dut.start().z().z()),
+                              complex_origin, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(21.0606601717798, 31.0606601717798, kLowFlatZ.z()),
+      complex_origin, kVeryExact));
+  const Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(),
+                      complex_dut.end().z().z()),
+      complex_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(41.0606601717798, 31.0606601717798,
+                      kEndElevatedEndpointZ.z() -
+                          kRRef * std::sin(kEndElevatedEndpointZ.theta())),
+      complex_end, kVeryExact));
+
+  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.327906002953272,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.541731128040585,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.898670700096556,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.922240926136107,
+              kVeryExact);
+}
+
+TEST_F(MultilaneConnectionTest, ReferenceCurveLineRoadCurveValidation) {
   const std::string kId{"line_connection"};
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
   const double kLineLength{30. * std::sqrt(2.)};
+  const double kR0{2.};
+
   const Connection flat_dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                             kLaneWidth, kLeftShoulder, kRightShoulder,
                             kLineLength);
@@ -337,6 +531,104 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
               kVeryExact);
 }
 
+TEST_F(MultilaneConnectionTest, LaneToLaneLineRoadCurveValidation) {
+  const std::string kId{"line_connection"};
+  const double kLineLength{30. * std::sqrt(2.)};
+  const int kStartLane{1};
+  const int kEndLane{2};
+  const double kRRef{0.5};
+  const int kLaneRef{2};
+
+  const Connection flat_dut(kId, kStartEndpoint, kStartLane, kLowFlatZ,
+                            kEndLane, kNumLanes, kRRef, kLaneRef, kLaneWidth,
+                            kLeftShoulder, kRightShoulder, kLineLength);
+  std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
+  EXPECT_NE(dynamic_cast<LineRoadCurve*>(road_curve.get()), nullptr);
+
+  // Checks start and end Endpoints of the road curve. x-y coordinates are
+  // computed using a simple Octave script like the following:
+  //
+  // start = [20 30];
+  // heading = -pi/4;
+  // s_versor = [cos(heading) sin(heading)];
+  // r_versor = [cos(heading + pi/2) sin(heading + pi/2)];
+  // lane_width = 2;
+  // r_ref = 0.5;
+  // length = 30 * sqrt(2);
+  // road_curve_start = start + (lane_width - r_ref) .* r_versor;
+  // road_curve_end = start + (lane_width - r_ref) .* r_versor + ...
+  //                  length .* s_versor;
+  const Vector3<double> flat_origin = road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.start().xy().x(), flat_dut.start().xy().y(),
+                      flat_dut.start().z().z()),
+      flat_origin, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(21.0606601717798, 31.0606601717798, kLowFlatZ.z()),
+      flat_origin, kVeryExact));
+  const Vector3<double> flat_end = road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(flat_dut.end().xy().x(), flat_dut.end().xy().y(),
+                      flat_dut.end().z().z()),
+      flat_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(51.06066017177983, 1.06066017177982, kLowFlatZ.z()),
+      flat_end, kVeryExact));
+
+  // Checks that elevation and superelevation polynomials are correctly built
+  // for the trivial case of a flat dut.
+  EXPECT_EQ(road_curve->elevation().a(), 0.);
+  EXPECT_EQ(road_curve->elevation().b(), 0.);
+  EXPECT_EQ(road_curve->elevation().c(), 0.);
+  EXPECT_EQ(road_curve->elevation().d(), 0.);
+  EXPECT_EQ(road_curve->superelevation().a(), 0.);
+  EXPECT_EQ(road_curve->superelevation().b(), 0.);
+  EXPECT_EQ(road_curve->superelevation().c(), 0.);
+  EXPECT_EQ(road_curve->superelevation().d(), 0.);
+
+  // Creates a new complex dut with cubic elevation and superelevation.
+  const EndpointZ kEndElevatedEndpointZ{5., 1., M_PI / 6., 1.};
+  const Connection complex_dut(kId, kStartEndpoint, kStartLane,
+                               kEndElevatedEndpointZ, kEndLane, kNumLanes,
+                               kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                               kRightShoulder, kLineLength);
+  std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
+
+  // Checks that the road curve starts and ends at given endpoints.
+  const Vector3<double> complex_origin =
+      complex_road_curve->W_of_prh(0., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(Vector3<double>(complex_dut.start().xy().x(),
+                                              complex_dut.start().xy().y(),
+                                              complex_dut.start().z().z()),
+                              complex_origin, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(21.0606601717798, 31.0606601717798, kLowFlatZ.z()),
+      complex_origin, kVeryExact));
+  const Vector3<double> complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(complex_dut.end().xy().x(), complex_dut.end().xy().y(),
+                      complex_dut.end().z().z()),
+      complex_end, kVeryExact));
+  EXPECT_TRUE(CompareMatrices(
+      Vector3<double>(51.06066017177983, 1.06066017177982,
+                      kEndElevatedEndpointZ.z() -
+                          kRRef * std::sin(kEndElevatedEndpointZ.theta())),
+      complex_end, kVeryExact));
+
+  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.664124278936390,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.776082852624260,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.962975975515347,
+              kVeryExact);
+  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.975317317010231,
+              kVeryExact);
+}
+
 // Lane Endpoints with different EndpointZ. Those are selected to cover
 // different combinations of elevation and superelevation polynomials.
 
@@ -404,13 +696,6 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
                        kLeftShoulder, kRightShoulder, kArcOffset);
   const double kTheta0{kHeading - M_PI / 2.};
 
-  // Wraps angles in [-π, π) range.
-  auto wrap = [](double theta) {
-    double theta_new = std::fmod(theta + M_PI, 2. * M_PI);
-    if (theta_new < 0.) theta_new += 2. * M_PI;
-    return theta_new - M_PI;
-  };
-
   for (int i = 0; i < num_lanes; i++) {
     // Start endpoints.
     const double start_radius =
@@ -418,10 +703,9 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
                   std::cos(start_z.theta());
     const Endpoint lane_start{
         {kCenterX + start_radius * std::cos(kTheta0),
-         kCenterY + start_radius * std::sin(kTheta0),
-         wrap(kTheta0 + M_PI / 2.)},
-        {start_z.z(), start_z.z_dot() * kRadius / start_radius,
-         start_z.theta(), start_z.theta_dot() * kRadius / start_radius}};
+         kCenterY + start_radius * std::sin(kTheta0), kHeading},
+        {start_z.z(), start_z.z_dot() * kRadius / start_radius, start_z.theta(),
+         start_z.theta_dot() * kRadius / start_radius}};
     EXPECT_TRUE(
         test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
     // End endpoints.
@@ -431,9 +715,9 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
     const Endpoint lane_end{
         {kCenterX + end_radius * std::cos(kTheta0 + kDTheta),
          kCenterY + end_radius * std::sin(kTheta0 + kDTheta),
-         wrap(kTheta0 + kDTheta + M_PI / 2.)},
-        {end_z.z(), end_z.z_dot() * kRadius / end_radius,
-         end_z.theta(), end_z.theta_dot() * kRadius / end_radius}};
+         kHeading + kDTheta},
+        {end_z.z(), end_z.z_dot() * kRadius / end_radius, end_z.theta(),
+         end_z.theta_dot() * kRadius / end_radius}};
     EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
   }
 }
@@ -460,6 +744,104 @@ TEST_P(MultilaneConnectionEndpointZTest, LineLaneEndpoints) {
         {kStartXy.x() - offset * kNormalDirection.x() + kDirection.x(),
          kStartXy.y() - offset * kNormalDirection.y() + kDirection.y(),
          kHeading}, end_z};
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+  }
+}
+
+TEST_P(MultilaneConnectionEndpointZTest, LineLaneToLaneEndpoints) {
+  const std::string kId{"line_connection"};
+  const double kLineLength{25. * std::sqrt(2.)};
+  const int kStartLane{num_lanes - 1};
+  const int kEndLane{0};
+  const int kLaneRef{0};
+  const double kRRef{r0};
+
+  const Connection dut(kId, start_endpoint, kStartLane, end_z, kEndLane,
+                       num_lanes, kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                       kRightShoulder, kLineLength);
+  const Vector2<double> kDirection{45. - kStartXy.x(), 5. - kStartXy.y()};
+  const Vector2<double> kNormalDirection =
+      Vector2<double>(kDirection.y(), -kDirection.x()).normalized();
+
+  for (int i = 0; i < num_lanes; i++) {
+    // Start endpoints.
+    const double start_offset = static_cast<double>(i - kStartLane) *
+                                kLaneWidth * std::cos(start_z.theta());
+    const Endpoint lane_start{
+        {kStartXy.x() - start_offset * kNormalDirection.x(),
+         kStartXy.y() - start_offset * kNormalDirection.y(), kHeading},
+        start_z};
+    EXPECT_TRUE(
+        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    // End endpoints.
+    const double end_offset = static_cast<double>(i - kStartLane) * kLaneWidth *
+                              std::cos(end_z.theta());
+    const Endpoint lane_end{
+        {kStartXy.x() - end_offset * kNormalDirection.x() + kDirection.x(),
+         kStartXy.y() - end_offset * kNormalDirection.y() + kDirection.y(),
+         kHeading},
+        end_z};
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+  }
+}
+
+TEST_P(MultilaneConnectionEndpointZTest, ArcLaneToLaneEndpoints) {
+  const std::string kId{"arc_connection"};
+  const int kStartLane{num_lanes - 1};
+  const int kEndLane{0};
+  const double kRadius{10. * std::sqrt(2.)};
+  const double kDTheta{M_PI / 2.};
+  const ArcOffset kArcOffset(kRadius, kDTheta);
+  const int kLaneRef{0};
+  const double kRRef{r0};
+  const Connection dut(kId, start_endpoint, kStartLane, end_z, kEndLane,
+                       num_lanes, kRRef, kLaneRef, kLaneWidth, kLeftShoulder,
+                       kRightShoulder, kArcOffset);
+  const double kTheta0{kHeading - M_PI / 2.};
+
+  auto compute_radius = [ kRadius, lane_width = kLaneWidth, kRRef ](
+      int lane_index, double angle) {
+    return kRadius -
+           (kRRef + static_cast<double>(lane_index) * lane_width) *
+               std::cos(angle);
+  };
+  const double center_x =
+      kStartXy.x() -
+      compute_radius(kStartLane, start_z.theta()) * std::cos(kTheta0);
+  const double center_y =
+      kStartXy.y() -
+      compute_radius(kStartLane, start_z.theta()) * std::sin(kTheta0);
+
+  // Computes start and end EndpointZ derivative terms. Those will be used to
+  // compute EndpointZ derivatives at lane start and end Endpoints.
+  const double start_lane_radius = compute_radius(kStartLane, start_z.theta());
+  const double end_lane_radius = compute_radius(kEndLane, end_z.theta());
+  const double reference_start_z_dot =
+      start_z.z_dot() * start_lane_radius / kRadius;
+  const double reference_start_theta_dot =
+      start_z.theta_dot() * start_lane_radius / kRadius;
+  const double reference_end_z_dot = end_z.z_dot() * end_lane_radius / kRadius;
+  const double reference_end_theta_dot =
+      end_z.theta_dot() * end_lane_radius / kRadius;
+
+  for (int i = 0; i < num_lanes; i++) {
+    // Start endpoints.
+    const double start_radius = compute_radius(i, start_z.theta());
+    const Endpoint lane_start{
+        {center_x + start_radius * std::cos(kTheta0),
+         center_y + start_radius * std::sin(kTheta0), kHeading},
+        {start_z.z(), reference_start_z_dot * kRadius / start_radius,
+         start_z.theta(), reference_start_theta_dot * kRadius / start_radius}};
+    EXPECT_TRUE(
+        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    // End endpoints.
+    const double end_radius = compute_radius(i, end_z.theta());
+    const Endpoint lane_end{
+        {center_x + end_radius * std::cos(kTheta0 + kDTheta),
+         center_y + end_radius * std::sin(kTheta0 + kDTheta),
+         kHeading + kDTheta},
+        {end_z.z(), reference_end_z_dot * kRadius / end_radius, end_z.theta(),
+         reference_end_theta_dot * kRadius / end_radius}};
     EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
   }
 }


### PR DESCRIPTION
As part of issue #7194, and parent issue #4934, this PR includes:

- New constructors to `Connection` class so as to derive reference curve from different lane information (`Endpoint` and `EndpointZ`).
- `Builder` provides new methods to construct Arc and Line `Connections` from other connections.
- Modifies `Builder` tests to create the same `RoadGeometry` with both reference curve and lane-to-lane API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7471)
<!-- Reviewable:end -->
