### PR TITLE
Change Ubuntu default to clang-4.0

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -77,13 +77,17 @@ supported for CMake builds using the "Unix Makefiles" generator.
 | Operating System            | Build System   | C/C++ Compiler  | Java       | MATLAB (Optional) | Python |
 +=============================+================+=================+============+===================+========+
 +-----------------------------+----------------+-----------------+------------+-------------------+--------+
-| Ubuntu 16.04 LTS ("Xenial") | | Bazel 0.6.1  | | Clang 3.9     | OpenJDK 8  | R2017a            | 2.7.11 |
-|                             | | CMake 3.5.1  | | GCC 5.4       |            |                   |        |
+| Ubuntu 16.04 LTS ("Xenial") | | Bazel 0.6.1  | | Clang 4.0     | OpenJDK 8  | R2017a            | 2.7.11 |
+|                             | | CMake 3.5.1  | | Clang 3.9     |            |                   |        |
+|                             | |              | | GCC 5.4       |            |                   |        |
 +-----------------------------+----------------+-----------------+------------+                   +--------+
 | macOS 10.12 ("Sierra")      | | Bazel 0.6.1  | Apple Clang 9.0 | Oracle 1.8 |                   | 2.7.14 |
 +-----------------------------+ | CMake 3.10.0 |                 |            +-------------------+        |
 | macOS 10.13 ("High Sierra") |                |                 |            | R2017b            |        |
 +-----------------------------+----------------+-----------------+------------+-------------------+--------+
+
+On Ubuntu 16.04, the combination of CMake + Clang 4.0 is not yet supported,
+and the combination of Bazel + Clang 3.9 is deprecated.
 
 macOS 10.13 ("High Sierra") MATLAB support is experimental and untested in continuous
 integration.

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -20,7 +20,7 @@ default_toolchain {
 # We use Clang on Ubuntu by default. To use gcc, specify --compiler=gcc-5.
 default_toolchain {
   cpu: "k8"
-  toolchain_identifier: "clang-3.9-linux"
+  toolchain_identifier: "clang-4.0-linux"
 }
 
 # GCC 6.x on Linux

--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -28,3 +28,4 @@ race:g_static_rec_mutex_lock
 
 # data race in libgurobi70.so.  Gurobi has not been instrumented with TSan.
 called_from_lib:libgurobi.so
+called_from_lib:libgurobi70.so


### PR DESCRIPTION
This re-applies a311f30da90e7d02bfc5e0c9d408d49408718a6b (from #7459) with modifications to update the `tsan.supp` to also recognize a new name for the Gurobi shared library that results, probably via invoking the linker in gold mode now by default.  This undoes the revert from #7472.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7475)
<!-- Reviewable:end -->
