### PR TITLE
Avoid hard-coded resource paths

### DIFF
--- a/drake/common/proto/BUILD.bazel
+++ b/drake/common/proto/BUILD.bazel
@@ -56,6 +56,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":protobuf",
+        "//drake/common",
     ],
 )
 

--- a/drake/common/proto/test/protobuf_test.cc
+++ b/drake/common/proto/test/protobuf_test.cc
@@ -5,12 +5,15 @@
 #include <gtest/gtest.h>
 #include "google/protobuf/io/coded_stream.h"
 
+#include "drake/common/find_resource.h"
+
 namespace drake {
 namespace {
 
 GTEST_TEST(ProtobufUtilsTest, MakeFileInputStreamSucceeds) {
-  auto istream = MakeFileInputStreamOrThrow(
-      "drake/common/proto/test/test_string.txt");
+  const std::string absolute_path =
+      FindResourceOrThrow("drake/common/proto/test/test_string.txt");
+  auto istream = MakeFileInputStreamOrThrow(absolute_path);
   google::protobuf::io::CodedInputStream coded_stream(istream.get());
   std::string expected("test string");
   std::string contents;

--- a/drake/multibody/parsers/BUILD.bazel
+++ b/drake/multibody/parsers/BUILD.bazel
@@ -51,7 +51,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "parser_common_test",
     srcs = ["test/parser_common_test/parser_common_test.cc"],
-    data = ["test/parser_common_test/test_file.txt"],
     deps = [
         ":parsers",
     ],

--- a/drake/multibody/parsers/test/package_map_test/package_map_test.cc
+++ b/drake/multibody/parsers/test/package_map_test/package_map_test.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <gtest/gtest.h>
+#include <spruce.hh>
 
 #include "drake/common/find_resource.h"
 
@@ -37,9 +38,11 @@ void VerifyMatch(const PackageMap& package_map,
 
 // Tests that the PackageMap can be manually populated.
 GTEST_TEST(PackageMapTest, TestManualPopulation) {
+  spruce::dir::mkdir(spruce::path("package_foo"));
+  spruce::dir::mkdir(spruce::path("package_bar"));
   map<string, string> expected_packages = {
-    {"package_foo", "drake/multibody/parsers"},
-    {"my_package", "drake/multibody"}
+    {"package_foo", "package_foo"},
+    {"my_package", "package_bar"}
   };
 
   PackageMap package_map;
@@ -118,9 +121,11 @@ GTEST_TEST(PackageMapTest, TestPopulateUpstreamToDrake) {
 
 // Tests that PackageMap's streaming to-string operator works.
 GTEST_TEST(PackageMapTest, TestStreamingToString) {
+  spruce::dir::mkdir(spruce::path("package_foo"));
+  spruce::dir::mkdir(spruce::path("package_bar"));
   map<string, string> expected_packages = {
-    {"package_foo", "drake/multibody/parsers"},
-    {"my_package", "drake/multibody"}
+    {"package_foo", "package_foo"},
+    {"my_package", "package_bar"}
   };
 
   PackageMap package_map;

--- a/drake/multibody/parsers/test/parser_common_test/parser_common_test.cc
+++ b/drake/multibody/parsers/test/parser_common_test/parser_common_test.cc
@@ -1,5 +1,6 @@
 #include "drake/multibody/parsers/parser_common.h"
 
+#include <fstream>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -14,8 +15,10 @@ namespace {
 // Verifies that GetFullPath() promotes a relative path to an absolute path,
 // and leaves already-absolute paths alone.
 GTEST_TEST(ParserCommonTest, TestGetFullPath_Relative) {
-  const string relative_path =
-      "drake/multibody/parsers/test/parser_common_test/test_file.txt";
+  const string relative_path = "test_file.txt";
+  std::ofstream ostr(relative_path);
+  ASSERT_TRUE(ostr.is_open());
+  ostr.close();
 
   // Relative path -> absolute path.
   string full_path;

--- a/drake/multibody/parsers/test/parser_common_test/test_file.txt
+++ b/drake/multibody/parsers/test/parser_common_test/test_file.txt
@@ -1,2 +1,0 @@
-This file is intentially left empty. It is used by parser_common_test.cc for
-testing purposes.

--- a/drake/perception/estimators/dev/BUILD.bazel
+++ b/drake/perception/estimators/dev/BUILD.bazel
@@ -58,7 +58,7 @@ drake_cc_library(
     hdrs = ["test/test_util.h"],
     data = [":test_models"],
     deps = [
-        "//drake/common:essential",
+        "//drake/common",
         "//drake/common/test_utilities:eigen_geometry_compare",
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/lcm",

--- a/drake/perception/estimators/dev/test/test_util.cc
+++ b/drake/perception/estimators/dev/test/test_util.cc
@@ -5,6 +5,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkXMLPolyDataReader.h>
 
+#include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_geometry_compare.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/lcmt_viewer_draw.hpp"
@@ -221,7 +222,8 @@ void GetObjectTestSetup(ObjectTestType type, ObjectTestSetup *setup) {
       const double distance_tolerance = 0.05;
       Matrix3Xd points_Wm;
       LoadVTPPointCloud(
-          "drake/perception/estimators/dev/test/blue_funnel_meas.vtp",
+          FindResourceOrThrow(
+              "drake/perception/estimators/dev/test/blue_funnel_meas.vtp"),
           &points_Wm, distance_tolerance);
       setup->points_B = X_WmB.inverse() * points_Wm;
       break;


### PR DESCRIPTION
Relates #6996.

We shouldn't hard-code data file paths -- we should either use `FindResource` for declared data, or we can also just create temporary data on the fly when we need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7476)
<!-- Reviewable:end -->
