### PR TITLE
Use clang-format-4.0 on Ubuntu

### DIFF
--- a/doc/clion.rst
+++ b/doc/clion.rst
@@ -182,7 +182,7 @@ CLion such that the modification may not be immediately apparent. When in doubt,
 select away from the target file and back; this will cause the file to refresh
 and you can confirm that the file has been modified as expected.
 
-First, make sure you have installed ``clang-format``
+First, make sure you have installed ``clang-format-4.0``
 (see :doc:`code_style_tools`).
 
 Clang format selected file
@@ -193,7 +193,7 @@ following values for the fields:
 
   :Name: ``Clang Format Full File``
   :Description: ``Apply clang-format to the active file``
-  :Program: ``clang-format``
+  :Program: ``clang-format-4.0``
   :Parameters: ``-i $FileName$``
   :Working directory: ``$FileDir$``
 
@@ -207,7 +207,7 @@ following values for the fields:
 
   :Name: ``Clang Format Selected Lines``
   :Description: ``Apply clang-format to the selected lines``
-  :Program: ``clang-format``
+  :Program: ``clang-format-4.0``
   :Parameters: ``-lines $SelectionStartLine$:$SelectionEndLine$ -i $FileName$``
   :Working directory: ``$FileDir$``
 

--- a/doc/code_style_tools.rst
+++ b/doc/code_style_tools.rst
@@ -54,15 +54,12 @@ C/C++: Clang-Format
 
 The
 :ref:`Mandatory platform specific instructions <platform_specific_setup>`
-already install clang-format.  On Ubuntu, you may wish to create an alias
-(assuming ``$HOME/bin`` is already on your ``$PATH``)::
-
-    ln -s /usr/bin/clang-format-3.9 $HOME/bin/clang-format
+already install ``clang-format-4.0``.
 
 You can check whether you've installed it correctly by executing::
 
-    clang-format --help
+    clang-format-4.0 --help
 
 To run clang-format::
 
-    clang-format -i -style=file [file name]
+    clang-format-4.0 -i -style=file [file name]

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -33,7 +33,7 @@ while true; do
       # added, since it otherwise duplicates the commented deb-src line.
       add-apt-repository -s -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main"
       apt update
-      apt install --no-install-recommends clang-3.9 clang-format-3.9 lldb-3.9
+      apt install --no-install-recommends clang-3.9 lldb-3.9
       break
       ;;
     [Nn]*) break ;;

--- a/tools/lint/clang_format.py
+++ b/tools/lint/clang_format.py
@@ -9,7 +9,7 @@ def get_clang_format_path():
     if sys.platform == "darwin":
         path = "/usr/local/bin/clang-format"
     else:
-        path = "/usr/bin/clang-format-3.9"
+        path = "/usr/bin/clang-format-4.0"
     if os.path.isfile(path):
         return path
     raise RuntimeError("Could not find required clang-format at " + path)


### PR DESCRIPTION
Update build system linter path to use `clang-format-4.0`.
Update documentation to specify `clang-format-4.0`.
Remove `clang-format-3.9` from the install_prereqs list.

For reference, the `clang-format-4.0` package was added to `install_prereqs.sh` in #7457.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7477)
<!-- Reviewable:end -->
