### PR TITLE
Fix -inl.h related header include order

### DIFF
--- a/drake/examples/bead_on_a_wire/bead_on_a_wire-inl.h
+++ b/drake/examples/bead_on_a_wire/bead_on_a_wire-inl.h
@@ -5,10 +5,13 @@
 // Most users should only include that file, not this one.
 // For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
+#include "drake/examples/bead_on_a_wire/bead_on_a_wire.h"
+/* clang-format on */
+
 #include <limits>
 
 #include "drake/common/drake_assert.h"
-#include "drake/examples/bead_on_a_wire/bead_on_a_wire.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {

--- a/drake/examples/bouncing_ball/ball-inl.h
+++ b/drake/examples/bouncing_ball/ball-inl.h
@@ -5,7 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/examples/bouncing_ball/ball.h"
+/* clang-format on */
 
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/drake/examples/bouncing_ball/bouncing_ball-inl.h
+++ b/drake/examples/bouncing_ball/bouncing_ball-inl.h
@@ -5,7 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/examples/bouncing_ball/bouncing_ball.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <limits>

--- a/drake/examples/rod2d/rod2d-inl.h
+++ b/drake/examples/rod2d/rod2d-inl.h
@@ -5,7 +5,9 @@
 // Most users should only include that file, not this one.
 // For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/examples/rod2d/rod2d.h"
+/* clang-format on */
 
 #include <algorithm>
 #include <limits>

--- a/drake/multibody/kinematics_cache-inl.h
+++ b/drake/multibody/kinematics_cache-inl.h
@@ -5,7 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/multibody/kinematics_cache.h"
+/* clang-format on */
 
 #include <string>
 #include <vector>

--- a/drake/systems/analysis/implicit_euler_integrator-inl.h
+++ b/drake/systems/analysis/implicit_euler_integrator-inl.h
@@ -5,6 +5,10 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
+#include "drake/systems/analysis/implicit_euler_integrator.h"
+/* clang-format on */
+
 #include <algorithm>
 #include <limits>
 #include <memory>
@@ -12,7 +16,6 @@
 
 #include "drake/common/text_logging.h"
 #include "drake/math/autodiff.h"
-#include "drake/systems/analysis/implicit_euler_integrator.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/analysis/runge_kutta3_integrator-inl.h
+++ b/drake/systems/analysis/runge_kutta3_integrator-inl.h
@@ -5,9 +5,11 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
-#include <utility>
-
+/* clang-format off to disable clang-format-includes */
 #include "drake/systems/analysis/runge_kutta3_integrator.h"
+/* clang-format on */
+
+#include <utility>
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/constant_value_source-inl.h
+++ b/drake/systems/primitives/constant_value_source-inl.h
@@ -5,7 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/systems/primitives/constant_value_source.h"
+/* clang-format on */
 
 #include <memory>
 #include <utility>

--- a/drake/systems/primitives/gain-inl.h
+++ b/drake/systems/primitives/gain-inl.h
@@ -5,7 +5,9 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
 #include "drake/systems/primitives/gain.h"
+/* clang-format on */
 
 #include <sstream>
 

--- a/drake/systems/primitives/pass_through-inl.h
+++ b/drake/systems/primitives/pass_through-inl.h
@@ -5,10 +5,12 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
+#include "drake/systems/primitives/pass_through.h"
+/* clang-format on */
+
 #include <memory>
 #include <utility>
-
-#include "drake/systems/primitives/pass_through.h"
 
 namespace drake {
 namespace systems {

--- a/drake/systems/primitives/zero_order_hold-inl.h
+++ b/drake/systems/primitives/zero_order_hold-inl.h
@@ -5,11 +5,13 @@
 /// Most users should only include that file, not this one.
 /// For background, see http://drake.mit.edu/cxx_inl.html.
 
+/* clang-format off to disable clang-format-includes */
+#include "drake/systems/primitives/zero_order_hold.h"
+/* clang-format on */
+
 #include <memory>
 #include <utility>
 #include <vector>
-
-#include "drake/systems/primitives/zero_order_hold.h"
 
 namespace drake {
 namespace systems {


### PR DESCRIPTION
Relates #6996.

When a component uses the `-inl.h` pattern, the related header include in its `.cc` file is the `-inl.h` file.  Therefore, the related header include in the `-inl.h` file must be the related `.h` file, so that we prove the `.h` file parses on its own.

As it stands on master now, `clang-format-includes` allows both locations without complaint, but after 6996 would by default force the headers down into the group 5 mix; thus, we have to put suppressions in every `-inl.h` file to allow this positioning.

If the `-inl.h` pattern accumulates, we can look into patching the tool to allow (and require) this ordering without annotations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7479)
<!-- Reviewable:end -->
