### PR TITLE
Fixes bad memory accesses in Multilane's Connection tests.

### DIFF
--- a/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/drake/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -3,6 +3,7 @@
 /* clang-format on */
 
 #include <cmath>
+#include <ostream>
 
 #include <gtest/gtest.h>
 
@@ -351,6 +352,20 @@ struct EndpointZTestParameters{
   double r0{};
   int num_lanes{};
 };
+
+// Stream insertion operator overload for EndpointZTestParameters
+// instances. Necessary for gtest printouts that would otherwise fail
+// at properly printing the struct's bytes (its default behavior when
+// no stream insertion operator overload is present) and trigger Valgrind
+// errors.
+std::ostream& operator<<(std::ostream& stream,
+                         const EndpointZTestParameters& endpoint_z_test_param) {
+  return stream << "EndpointZTestParameters( start_z: ("
+                << endpoint_z_test_param.start_z  << "), end_z: ("
+                << endpoint_z_test_param.end_z << "), r0: "
+                << endpoint_z_test_param.r0 << ", num_lanes: "
+                << endpoint_z_test_param.num_lanes << ")";
+}
 
 // Groups common test constants as well as each test case parameters.
 class MultilaneConnectionEndpointZTest


### PR DESCRIPTION
To prevent #7480 revert PR, this PR fixes bad memory access introduced in PR #7343.

To solve Valgrind issues, this PR introduces an overload of `operator<<` for `EndpointZTestParameters` structure. The fix is quite similar to the one introduced in #7180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7481)
<!-- Reviewable:end -->
