### PR TITLE
Edit xtion_description package.xml to have a full catkin-compat version

### DIFF
--- a/drake/manipulation/models/xtion_description/package.xml
+++ b/drake/manipulation/models/xtion_description/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>xtion_description</name>
-  <version>1.0</version>
+  <version>1.0.0</version>
   <description>
     This package contains the URDF of the Xtion PRO Live camera.
   </description>


### PR DESCRIPTION
As specified [here](http://wiki.ros.org/catkin/package.xml), package.xml versions need to be composed of 3 dot-separated integers. Catkin barfs (and, especially unhelpfully, doesn't even say what package caused the problem) otherwise.

+@EricCousineau-TRI Can I get a quick review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7493)
<!-- Reviewable:end -->
