### PR TITLE
Prepare some misc items for package renames

### DIFF
--- a/drake/automotive/models/BUILD.bazel
+++ b/drake/automotive/models/BUILD.bazel
@@ -5,6 +5,11 @@ load("//tools/install:install_data.bzl", "install_data")
 
 package(default_visibility = ["//visibility:public"])
 
+alias(
+    name = "yaml_to_obj",
+    actual = "//drake/automotive/maliput/utility:yaml_to_obj",
+)
+
 genrule(
     name = "speed_bump_genrule",
     srcs = ["speed_bump/speed_bump.yaml"],
@@ -13,12 +18,12 @@ genrule(
         "speed_bump/speed_bump.mtl",
     ],
     cmd = " ".join([
-        "$(location //drake/automotive/maliput/utility:yaml_to_obj)",
+        "$(location :yaml_to_obj)",
         "--yaml_file '$<'",
         "--obj_dir $(@D)/speed_bump",
         "--obj_file speed_bump",
     ]),
-    tools = ["//drake/automotive/maliput/utility:yaml_to_obj"],
+    tools = [":yaml_to_obj"],
 )
 
 install_data(

--- a/drake/common/BUILD.bazel
+++ b/drake/common/BUILD.bazel
@@ -892,6 +892,9 @@ drake_py_test(
 drake_py_test(
     name = "resource_tool_installed_test",
     srcs = ["test/resource_tool_installed_test.py"],
+    args = [
+        "$(location :install)",
+    ],
     data = [
         ":install",
     ],

--- a/drake/common/test/resource_tool_installed_test.py
+++ b/drake/common/test/resource_tool_installed_test.py
@@ -1,9 +1,15 @@
 """Performs tests for resource_tool as used _after_ installation.
 """
 
-import subprocess
 import os
+import shutil
+import subprocess
+import sys
 import unittest
+
+
+# Set on command-line to the location of common/install.
+_install_exe = None
 
 
 class TestResourceTool(unittest.TestCase):
@@ -11,7 +17,7 @@ class TestResourceTool(unittest.TestCase):
         # Install into a temporary directory.
         os.mkdir("tmp")
         subprocess.check_call(
-            ["drake/common/install",
+            [_install_exe,
              os.path.abspath("tmp"),
              ])
 
@@ -21,18 +27,14 @@ class TestResourceTool(unittest.TestCase):
             f.write("tmp_resource")
 
         # Remove the un-installed copy, so we _know_ it won't be used.
-        os.remove("drake/.drake-find_resource-sentinel")
-        os.remove("drake/__init__.py")
-        os.remove("drake/common/__init__.py")
-        os.remove("drake/common/install")
-        os.remove("drake/common/resource_tool")
-        os.remove("drake/common/resource_tool_installed_test")
-        os.remove("drake/common/test/__init__.py")
-        os.remove("drake/common/test/resource_tool_installed_test.py")
-        os.rmdir("drake/common/test")
-        os.rmdir("drake/common")
-        os.rmdir("drake")
-        self.assertEqual(os.listdir("."), ["tmp"])
+        content_test_folder = os.listdir(os.getcwd())
+        content_test_folder.remove("tmp")
+        for element in content_test_folder:
+            if os.path.isdir(element):
+                shutil.rmtree(element)
+            else:
+                os.remove(element)
+        self.assertEqual(os.listdir(os.getcwd()), ["tmp"])
 
         # Cross-check the resource root environment variable name.
         env_name = "DRAKE_RESOURCE_ROOT"
@@ -71,4 +73,5 @@ class TestResourceTool(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    _install_exe = sys.argv.pop(1)
     unittest.main()

--- a/drake/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/BUILD.bazel
@@ -200,6 +200,11 @@ drake_cc_googletest(
     ],
 )
 
+alias(
+    name = "dual_iiwa14_polytope_collision.urdf",
+    actual = "//drake/manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf",  # noqa
+)
+
 # Test that kuka_simulation can load the dual arm urdf
 sh_test(
     name = "dual_kuka_simulation_test",
@@ -208,12 +213,12 @@ sh_test(
     args = [
         "$(location :kuka_simulation)",
         "--urdf",
-        "$(location //drake/manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf)",  # noqa
+        "$(location :dual_iiwa14_polytope_collision.urdf)",
         "--simulation_sec=0.01",
         "--novisualize_frames",
     ],
     data = [
-        "//drake/manipulation/models/iiwa_description:urdf/dual_iiwa14_polytope_collision.urdf",  # noqa
+        ":dual_iiwa14_polytope_collision.urdf",
     ],
     # Flaky because LCM self-test can fail (PR #7311)
     flaky = 1,


### PR DESCRIPTION
Relates #6996.

This uses spellings that are more amenable to changing the absolute package paths, by using preferring `:name` labels, and passing paths to data on the command-line, instead of hard-coding them.

Prior similar PRs are #7468 and #7446.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7497)
<!-- Reviewable:end -->
