### PR TITLE
Adding ids to GeometryFrame and GeometryInstance

### DIFF
--- a/drake/geometry/BUILD.bazel
+++ b/drake/geometry/BUILD.bazel
@@ -40,7 +40,10 @@ drake_cc_library(
     name = "geometry_frame",
     srcs = [],
     hdrs = ["geometry_frame.h"],
-    deps = ["//drake/common:essential"],
+    deps = [
+        ":geometry_ids",
+        "//drake/common:essential",
+    ],
 )
 
 drake_cc_library(
@@ -62,6 +65,7 @@ drake_cc_library(
     srcs = ["geometry_instance.cc"],
     hdrs = ["geometry_instance.h"],
     deps = [
+        ":geometry_ids",
         ":shape_specification",
         "//drake/common:copyable_unique_ptr",
         "//drake/common:essential",

--- a/drake/geometry/BUILD.bazel
+++ b/drake/geometry/BUILD.bazel
@@ -174,11 +174,16 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "geometry_instance_test",
+    name = "geometry_frame_test",
     deps = [
-        ":geometry_instance",
-        "//drake/common:copyable_unique_ptr",
+        ":geometry_frame",
+        "//drake/common:essential",
     ],
+)
+
+drake_cc_googletest(
+    name = "geometry_instance_test",
+    deps = [":geometry_instance"],
 )
 
 drake_cc_googletest(

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
 
 namespace drake {
 namespace geometry {
@@ -38,13 +39,30 @@ class GeometryFrame {
                             defaults to the common, 0 group. */
   GeometryFrame(const std::string& frame_name, const Isometry3<double>& X_PF,
                 int frame_group_id = 0)
-      : name_(frame_name), X_PF_(X_PF), frame_group_(frame_group_id) {}
+      : id_(FrameId::get_new_id()),
+        name_(frame_name),
+        X_PF_(X_PF),
+        frame_group_(frame_group_id) {}
 
-  const std::string& get_name() const { return name_; }
-  const Isometry3<double>& get_pose() const { return X_PF_; }
-  int get_frame_group() const { return frame_group_; }
+  /** Returns the globally unique id for this geometry specification. Every
+   instantiation of %FrameInstance will contain a unique id value. The id
+   value is preserved across copies. After successfully registering this
+   %FrameInstance, this id will serve as the identifier for the registered
+   representation as well. */
+  FrameId id() const { return id_; }
+
+  const std::string& name() const { return name_; }
+
+  const Isometry3<double>& pose() const { return X_PF_; }
+
+  int frame_group() const { return frame_group_; }
 
  private:
+  // The *globally* unique identifier for this instance. It is functionally
+  // const (i.e. defined in construction) but not marked const to allow for
+  // default copying/assigning.
+  FrameId id_{};
+
   // The name of the frame. Must be unique across frames from the same geometry
   // source.
   std::string name_;

--- a/drake/geometry/geometry_frame.h
+++ b/drake/geometry/geometry_frame.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
 namespace drake {

--- a/drake/geometry/geometry_instance.cc
+++ b/drake/geometry/geometry_instance.cc
@@ -7,7 +7,7 @@ namespace geometry {
 
 GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
                                    std::unique_ptr<Shape> shape)
-    : X_PG_(X_PG), shape_(std::move(shape)) {}
+    : id_(GeometryId::get_new_id()), X_PG_(X_PG), shape_(std::move(shape)) {}
 
 }  // namespace geometry
 }  // namespace drake

--- a/drake/geometry/geometry_instance.h
+++ b/drake/geometry/geometry_instance.h
@@ -6,6 +6,7 @@
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -24,14 +25,30 @@ class GeometryInstance {
    @param shape  The underlying shape for this geometry instance. */
   GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape);
 
-  const Isometry3<double>& get_pose() const { return X_PG_; }
+  /** Returns the globally unique id for this geometry specification. Every
+   instantiation of %GeometryInstance will contain a unique id value. The id
+   value is preserved across copies. After successfully registering this
+   %GeometryInstance, this id will serve as the identifier for the registered
+   representation as well. */
+  GeometryId id() const { return id_; }
+
+  const Isometry3<double>& pose() const { return X_PG_; }
   void set_pose(const Isometry3<double>& X_PG) { X_PG_ = X_PG; }
 
-  const Shape& get_shape() const { return *shape_; }
+  const Shape& shape() const {
+    DRAKE_DEMAND(shape_ != nullptr);
+    return *shape_;
+  }
+
   /** Releases the shape from the instance. */
   std::unique_ptr<Shape> release_shape() { return std::move(shape_); }
 
  private:
+  // The *globally* unique identifier for this instance. It is functionally
+  // const (i.e. defined in construction) but not marked const to allow for
+  // default copying/assigning.
+  GeometryId id_{};
+
   // The pose of the geometry relative to the parent frame it hangs on.
   Isometry3<double> X_PG_;
 

--- a/drake/geometry/geometry_state.cc
+++ b/drake/geometry/geometry_state.cc
@@ -199,7 +199,7 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id,
 template <typename T>
 FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                         const GeometryFrame& frame) {
-  FrameId frame_id = FrameId::get_new_id();
+  FrameId frame_id = frame.id();
 
   FrameIdSet& f_set = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
   if (parent_id != InternalFrame::get_world_frame_id()) {
@@ -213,14 +213,14 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
     source_root_frame_map_[source_id].insert(frame_id);
   }
   PoseIndex pose_index(X_PF_.size());
-  X_PF_.emplace_back(frame.get_pose());
+  X_PF_.emplace_back(frame.pose());
   X_WF_.emplace_back(Isometry3<double>::Identity());
   DRAKE_ASSERT(pose_index == static_cast<int>(pose_index_to_frame_map_.size()));
   pose_index_to_frame_map_.push_back(frame_id);
   f_set.insert(frame_id);
   frames_.emplace(
-      frame_id, InternalFrame(source_id, frame_id, frame.get_name(),
-                              frame.get_frame_group(), pose_index, parent_id));
+      frame_id, InternalFrame(source_id, frame_id, frame.name(),
+                              frame.frame_group(), pose_index, parent_id));
   return frame_id;
 }
 
@@ -240,7 +240,7 @@ GeometryId GeometryState<T>::RegisterGeometry(
         to_string(source_id) + ", but the frame doesn't belong to the source.";
   });
 
-  GeometryId geometry_id = GeometryId::get_new_id();
+  GeometryId geometry_id = geometry->id();
   geometry_index_id_map_.push_back(geometry_id);
 
   // TODO(SeanCurtis-TRI): Replace this stub engine index with a call to the
@@ -253,14 +253,14 @@ GeometryId GeometryState<T>::RegisterGeometry(
   geometries_.emplace(
       geometry_id,
       InternalGeometry(geometry->release_shape(), frame_id, geometry_id,
-                       geometry->get_pose(), engine_index));
+                       geometry->pose(), engine_index));
   // TODO(SeanCurtis-TRI): Enforcing the invariant that the indexes are
   // compactly distributed. Is there a more robust way to do this?
   DRAKE_ASSERT(static_cast<int>(X_FG_.size()) == engine_index);
   DRAKE_ASSERT(static_cast<int>(geometry_index_id_map_.size()) - 1 ==
                engine_index);
   X_WG_.push_back(Isometry3<T>::Identity());
-  X_FG_.emplace_back(geometry->get_pose());
+  X_FG_.emplace_back(geometry->pose());
   return geometry_id;
 }
 
@@ -320,7 +320,7 @@ GeometryId GeometryState<T>::RegisterAnchoredGeometry(
   }
   auto& set = GetMutableValueOrThrow(source_id, &source_anchored_geometry_map_);
 
-  GeometryId geometry_id = GeometryId::get_new_id();
+  GeometryId geometry_id = geometry->id();
   set.emplace(geometry_id);
 
   // TODO(SeanCurtis-TRI): Replace this stub engine index with a call to the
@@ -336,7 +336,7 @@ GeometryId GeometryState<T>::RegisterAnchoredGeometry(
   anchored_geometries_.emplace(
       geometry_id,
       InternalAnchoredGeometry(geometry->release_shape(), geometry_id,
-                               geometry->get_pose(), engine_index));
+                               geometry->pose(), engine_index));
   return geometry_id;
 }
 

--- a/drake/geometry/geometry_state.cc
+++ b/drake/geometry/geometry_state.cc
@@ -201,6 +201,12 @@ FrameId GeometryState<T>::RegisterFrame(SourceId source_id, FrameId parent_id,
                                         const GeometryFrame& frame) {
   FrameId frame_id = frame.id();
 
+  if (frames_.count(frame_id) > 0) {
+    throw std::logic_error(
+        "Registering frame with an id that has already been registered: " +
+            to_string(frame_id));
+  }
+
   FrameIdSet& f_set = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
   if (parent_id != InternalFrame::get_world_frame_id()) {
     FindOrThrow(parent_id, f_set, [parent_id, source_id]() {
@@ -233,14 +239,20 @@ GeometryId GeometryState<T>::RegisterGeometry(
         "Registering null geometry to frame " + to_string(frame_id) +
             ", on source " + to_string(source_id) + ".");
   }
+
+  GeometryId geometry_id = geometry->id();
+  if (geometries_.count(geometry_id) > 0) {
+    throw std::logic_error(
+        "Registering geometry with an id that has already been registered: " +
+            to_string(geometry_id));
+  }
+
   FrameIdSet& set = GetMutableValueOrThrow(source_id, &source_frame_id_map_);
 
   FindOrThrow(frame_id, set, [frame_id, source_id]() {
     return "Referenced frame " + to_string(frame_id) + " for source " +
         to_string(source_id) + ", but the frame doesn't belong to the source.";
   });
-
-  GeometryId geometry_id = geometry->id();
   geometry_index_id_map_.push_back(geometry_id);
 
   // TODO(SeanCurtis-TRI): Replace this stub engine index with a call to the
@@ -318,9 +330,17 @@ GeometryId GeometryState<T>::RegisterAnchoredGeometry(
         "Registering null anchored geometry on source "
         + to_string(source_id) + ".");
   }
-  auto& set = GetMutableValueOrThrow(source_id, &source_anchored_geometry_map_);
 
   GeometryId geometry_id = geometry->id();
+  if (anchored_geometries_.count(geometry_id) > 0) {
+    throw std::logic_error(
+        "Registering anchored geometry with an id that has already been "
+        "registered: " +
+        to_string(geometry_id));
+  }
+
+  auto& set = GetMutableValueOrThrow(source_id, &source_anchored_geometry_map_);
+
   set.emplace(geometry_id);
 
   // TODO(SeanCurtis-TRI): Replace this stub engine index with a call to the

--- a/drake/geometry/geometry_state.h
+++ b/drake/geometry/geometry_state.h
@@ -202,7 +202,8 @@ class GeometryState {
    @param frame        The frame to register.
    @returns  A newly allocated frame id.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source. */
+                             source, or `frame` has an id that has already
+                             been registered. */
   FrameId RegisterFrame(SourceId source_id, const GeometryFrame& frame);
 
   /** Registers a new frame for the given source as a child of a previously
@@ -212,9 +213,11 @@ class GeometryState {
    @param frame        The frame to register.
    @returns  A newly allocated frame id.
    @throws std::logic_error  1. If the `source_id` does _not_ map to a
-                             registered source, or
+                             registered source,
                              2. If the `parent_id` does _not_ map to a known
-                             frame or does not belong to the source. */
+                             frame or does not belong to the source, or
+                             3. `frame` has an id that has already been
+                             registered */
   FrameId RegisterFrame(SourceId source_id, FrameId parent_id,
                         const GeometryFrame& frame);
 
@@ -229,8 +232,9 @@ class GeometryState {
    @returns  A newly allocated geometry id.
    @throws std::logic_error  1. the `source_id` does _not_ map to a registered
                              source, or
-                             2. the `frame_id` doesn't belong to the source, or
-                             3. The `geometry` is equal to `nullptr`. */
+                             2. the `frame_id` doesn't belong to the source,
+                             3. The `geometry` is equal to `nullptr`, or
+                             4. `geometry` has a previously registered id. */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -250,8 +254,8 @@ class GeometryState {
    @throws std::logic_error 1. the `source_id` does _not_ map to a registered
                             source, or
                             2. the `geometry_id` doesn't belong to the source,
-                            or
-                            3. the `geometry` is equal to `nullptr`. */
+                            3. the `geometry` is equal to `nullptr`, or
+                            4. `geometry` has a previously registered id. */
   GeometryId RegisterGeometryWithParent(
       SourceId source_id, GeometryId geometry_id,
       std::unique_ptr<GeometryInstance> geometry);
@@ -267,7 +271,8 @@ class GeometryState {
                        ownership of the geometry.
    @returns  A newly allocated geometry id.
    @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source. */
+                             source, or
+                             `geometry` has a previously registered id. */
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id,
       std::unique_ptr<GeometryInstance> geometry);

--- a/drake/geometry/test/geometry_frame_test.cc
+++ b/drake/geometry/test/geometry_frame_test.cc
@@ -1,0 +1,30 @@
+#include "drake/geometry/geometry_frame.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace geometry {
+namespace {
+
+using std::make_unique;
+using std::move;
+
+GTEST_TEST(GeometryFrameTest, IdCopies) {
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  GeometryFrame frame_a{"frame_a", pose};
+  GeometryFrame frame_b{frame_a};
+  EXPECT_EQ(frame_a.id(), frame_b.id());
+
+  GeometryFrame frame_c{"frame_c", pose};
+  EXPECT_NE(frame_c.id(), frame_a.id());
+  frame_c = frame_a;
+  EXPECT_EQ(frame_c.id(), frame_a.id());
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/drake/geometry/test/geometry_instance_test.cc
+++ b/drake/geometry/test/geometry_instance_test.cc
@@ -1,16 +1,36 @@
 #include "drake/geometry/geometry_instance.h"
 
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/copyable_unique_ptr.h"
+#include "drake/geometry/shape_specification.h"
 
 namespace drake {
 namespace geometry {
 namespace {
 
+using std::make_unique;
+using std::move;
+
 // Confirms that the instance is copyable.
 GTEST_TEST(GeometryInstanceTest, IsCopyable) {
   EXPECT_TRUE(is_copyable_unique_ptr_compatible<GeometryInstance>::value);
+}
+
+GTEST_TEST(GeometryInstanceTest, IdCopies) {
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  auto shape = make_unique<Sphere>(1.0);
+  GeometryInstance geometry_a{pose, move(shape)};
+  GeometryInstance geometry_b(geometry_a);
+  EXPECT_EQ(geometry_a.id(), geometry_b.id());
+
+  shape = make_unique<Sphere>(2.0);
+  GeometryInstance geometry_c{pose, move(shape)};
+  EXPECT_NE(geometry_a.id(), geometry_c.id());
+  geometry_c = geometry_a;
+  EXPECT_EQ(geometry_a.id(), geometry_c.id());
 }
 
 }  // namespace

--- a/drake/geometry/test/geometry_state_test.cc
+++ b/drake/geometry/test/geometry_state_test.cc
@@ -525,6 +525,7 @@ TEST_F(GeometryStateTest, AddFrameToInvalidSource) {
 TEST_F(GeometryStateTest, AddFirstFrameToValidSource) {
   SourceId s_id = NewSource();
   FrameId fid = geometry_state_.RegisterFrame(s_id, *frame_.get());
+  EXPECT_EQ(fid, frame_->id());
   EXPECT_TRUE(geometry_state_.BelongsToSource(fid, s_id));
   const auto &frame_set = geometry_state_.GetFramesForSource(s_id);
   EXPECT_NE(frame_set.find(fid), frame_set.end());
@@ -539,6 +540,7 @@ TEST_F(GeometryStateTest, AddFirstFrameToValidSource) {
 TEST_F(GeometryStateTest, AddFrameToSourceWithFrames) {
   SourceId s_id = SetUpSingleSourceTree();
   FrameId fid = geometry_state_.RegisterFrame(s_id, *frame_);
+  EXPECT_EQ(fid, frame_->id());
   EXPECT_TRUE(geometry_state_.BelongsToSource(fid, s_id));
   const auto &frame_set = geometry_state_.GetFramesForSource(s_id);
   EXPECT_NE(frame_set.find(fid), frame_set.end());
@@ -555,6 +557,7 @@ TEST_F(GeometryStateTest, AddFrameToNewSourceWithFrames) {
   SourceId s_id = SetUpSingleSourceTree();
   SourceId new_s_id = geometry_state_.RegisterNewSource("new_source");
   FrameId fid = geometry_state_.RegisterFrame(new_s_id, *frame_.get());
+  EXPECT_EQ(fid, frame_->id());
   // Confirm addition.
   EXPECT_TRUE(geometry_state_.BelongsToSource(fid, new_s_id));
   {
@@ -574,6 +577,7 @@ TEST_F(GeometryStateTest, AddFrameToNewSourceWithFrames) {
 TEST_F(GeometryStateTest, AddFrameOnFrame) {
   SourceId s_id = SetUpSingleSourceTree();
   FrameId fid = geometry_state_.RegisterFrame(s_id, frames_[0], *frame_);
+  EXPECT_EQ(fid, frame_->id());
   EXPECT_EQ(geometry_state_.get_num_frames(), kFrameCount + 1);
   EXPECT_TRUE(geometry_state_.BelongsToSource(fid, s_id));
 
@@ -684,8 +688,10 @@ TEST_F(GeometryStateTest, RemoveFrameInvalid) {
 TEST_F(GeometryStateTest, RegisterGeometryGoodSource) {
   SourceId s_id = NewSource();
   FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_);
+  GeometryId expected_g_id = instance_->id();
   GeometryId g_id = geometry_state_.RegisterGeometry(s_id, f_id,
                                                      move(instance_));
+  EXPECT_EQ(g_id, expected_g_id);
   EXPECT_EQ(geometry_state_.GetFrameId(g_id), f_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
   Isometry3<double> X_FG = geometry_state_.GetPoseInFrame(g_id);
@@ -744,10 +750,12 @@ TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
   const FrameId frame_id = geometry_state_.GetFrameId(parent_id);
   auto instance =
       make_unique<GeometryInstance>(pose, unique_ptr<Shape>(new Sphere(1)));
+  GeometryId expected_g_id = instance->id();
   GeometryId g_id =
       geometry_state_.RegisterGeometryWithParent(s_id,
                                                  parent_id,
                                                  move(instance));
+  EXPECT_EQ(g_id, expected_g_id);
 
   // This relies on the gᵗʰ geometry having position [ g+1 0 0 ]ᵀ. The parent
   // geometry is at [parent_index + 1, 0, 0] and this is at [3, 2, 1]. They
@@ -772,7 +780,7 @@ TEST_F(GeometryStateTest, RegisterGeometryonValidGeometry) {
 }
 
 // Tests the response to the erroneous action of trying to hang a new geometry
-// on a non-existant geometry id.
+// on a non-existent geometry id.
 TEST_F(GeometryStateTest, RegisterGeometryonInvalidGeometry) {
   SourceId s_id = SetUpSingleSourceTree();
   Isometry3<double> pose = Isometry3<double>::Identity();
@@ -974,7 +982,9 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
   Isometry3<double> pose = Isometry3<double>::Identity();
   auto instance = make_unique<GeometryInstance>(
       pose, unique_ptr<Shape>(new Sphere(1)));
+  GeometryId expected_g_id = instance->id();
   auto g_id = geometry_state_.RegisterAnchoredGeometry(s_id, move(instance));
+  EXPECT_EQ(g_id, expected_g_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
 }
 

--- a/drake/geometry/test/geometry_state_test.cc
+++ b/drake/geometry/test/geometry_state_test.cc
@@ -594,6 +594,18 @@ TEST_F(GeometryStateTest, AddFrameOnFrame) {
   EXPECT_TRUE(parent.has_child(fid));
 }
 
+// Confirms that adding two frames with the same id causes an error.
+TEST_F(GeometryStateTest, AddFrameWithDuplicateId) {
+  SourceId s_id = NewSource();
+  FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_.get());
+  EXPECT_ERROR_MESSAGE(
+      geometry_state_.RegisterFrame(s_id, *frame_), std::logic_error,
+      "Registering frame with an id that has already been registered: \\d+");
+  EXPECT_ERROR_MESSAGE(
+      geometry_state_.RegisterFrame(s_id, f_id, *frame_), std::logic_error,
+      "Registering frame with an id that has already been registered: \\d+");
+}
+
 // Tests the valid removal of an existing frame (and its attached geometry).
 TEST_F(GeometryStateTest, RemoveFrame) {
   SourceId s_id = SetUpSingleSourceTree();
@@ -703,6 +715,18 @@ TEST_F(GeometryStateTest, RegisterGeometryGoodSource) {
   EXPECT_FALSE(geometry.get_parent_id());
 }
 
+// Confirms that registering two geometries with the same id causes failure.
+TEST_F(GeometryStateTest, RegisterDuplicateGeometry) {
+  SourceId s_id = NewSource();
+  FrameId f_id = geometry_state_.RegisterFrame(s_id, *frame_);
+  auto instance_copy = make_unique<GeometryInstance>(*instance_);
+  geometry_state_.RegisterGeometry(s_id, f_id, move(instance_));
+  EXPECT_ERROR_MESSAGE(
+      geometry_state_.RegisterGeometry(s_id, f_id, move(instance_copy)),
+      std::logic_error,
+      "Registering geometry with an id that has already been registered: \\d+");
+}
+
 // Tests registration of geometry on invalid source.
 TEST_F(GeometryStateTest, RegisterGeometryMissingSource) {
   SourceId s_id = SourceId::get_new_id();
@@ -713,7 +737,7 @@ TEST_F(GeometryStateTest, RegisterGeometryMissingSource) {
                        "Referenced geometry source \\d+ is not registered.");
 }
 
-// Tests registration of geometry on valid source and non-existant frame.
+// Tests registration of geometry on valid source and non-existent frame.
 TEST_F(GeometryStateTest, RegisterGeometryMissingFrame) {
   SourceId s_id = NewSource();
 
@@ -986,6 +1010,18 @@ TEST_F(GeometryStateTest, RegisterAnchoredGeometry) {
   auto g_id = geometry_state_.RegisterAnchoredGeometry(s_id, move(instance));
   EXPECT_EQ(g_id, expected_g_id);
   EXPECT_TRUE(geometry_state_.BelongsToSource(g_id, s_id));
+}
+
+// Confirms that registering two geometries with the same id causes failure.
+TEST_F(GeometryStateTest, RegisterDuplicateAnchoredGeometry) {
+  SourceId s_id = NewSource();
+  auto instance_copy = make_unique<GeometryInstance>(*instance_);
+  geometry_state_.RegisterAnchoredGeometry(s_id, move(instance_));
+  EXPECT_ERROR_MESSAGE(
+      geometry_state_.RegisterAnchoredGeometry(s_id, move(instance_copy)),
+      std::logic_error,
+      "Registering anchored geometry with an id that has already been "
+      "registered: \\d+");
 }
 
 // Tests the attempt to register anchored geometry on an invalid source.


### PR DESCRIPTION
This smooths the road in the future for asynchronous addition of frames/geometry. One system can generate them (know the final ids by querying the specification instances), and rely on those being the ids when the GeometrySystem realizes the specification.

1. Adding the ids to the instances themselves.
2. Ancillary, modifying the get_value() methods to simply be value().
3. GeometryState returns the id of the provided instance.
4. Test said functionality.

```
Category            added  modified  removed  
----------------------------------------------
code                22     10        0        
comments            6      1         0        
blank               4      0         0        
----------------------------------------------
TOTAL               32     11        0        
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7498)
<!-- Reviewable:end -->
