### PR TITLE
Add MATLAB fortran / quadmath / stdc++ symlink fixup to documentation

### DIFF
--- a/doc/matlab_bindings.rst
+++ b/doc/matlab_bindings.rst
@@ -29,6 +29,23 @@ Building the MATLAB Bindings
     cmake -DWITH_MATLAB=ON ../drake
     make
 
+Troubleshooting
+---------------
+
+On Ubuntu, you may encounter an error similar to the following::
+
+    /usr/local/MATLAB/R2017a/bin/glnxa64/../../sys/os/glnxa64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found.
+
+If so, modify your MATLAB installation as follows:
+
+.. code-block:: shell
+
+    cd /usr/local/MATLAB/R2017a/sys/os/glnxa64
+    sudo rm libgfortran.so.3 libquadmath.so.0 libstdc++.so.6
+    sudo ln -s /usr/lib/x86_64-linux-gnu/libgfortran.so.3 libgfortran.so.3
+    sudo ln -s /usr/lib/x86_64-linux-gnu/libstdc++.so.6 libstdc++.so.6
+    sudo ln -s /usr/lib/x86_64-linux-gnu/libquadmath.so.0 libquadmath.so.0
+
 Original MATLAB
 ===============
 


### PR DESCRIPTION
This has been (almost) common knowledge since https://github.com/RobotLocomotion/drake/issues/960, but has never actually been formally documented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7504)
<!-- Reviewable:end -->
