### PR TITLE
Add python-matplotlib to install prereqs.

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -64,6 +64,7 @@ EOF
 
 pip2 install --upgrade $(tr '\n' ' ' <<EOF
 lxml
+matplotlib
 pip
 pygame
 PyYAML

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -103,11 +103,13 @@ protobuf-compiler
 python-dev
 python-gtk2
 python-lxml
+python-matplotlib
 python-numpy
 python-protobuf
 python-pygame
 python-scipy
 python-sphinx
+python-tk
 python-yaml
 valgrind
 zip


### PR DESCRIPTION
This adds matplotlib to facilitate plotting via `call_python` in #7496.

These prerequisites have been tested in has been tested in:

* [linux-xenial-unprovisioned-clang-bazel-experimental](https://drake-jenkins.csail.mit.edu/view/Unprovisioned/job/linux-xenial-unprovisioned-clang-bazel-experimental/41/)
* [mac-highsierra-unprovisioned-clang-bazel-experimental](https://drake-jenkins.csail.mit.edu/view/Unprovisioned/job/mac-highsierra-unprovisioned-clang-bazel-experimental/6/)

Still testing [mac-sierra-unprovisioned-clang-bazel-experimental](https://drake-jenkins.csail.mit.edu/view/Unprovisioned/job/mac-sierra-unprovisioned-clang-bazel-experimental/31/) - there was an issue beforehand, may have been due to some download flakes?

*NOTE*: Due to limitations on CI, no plotting is actually done in the automated tests (`//drake/common/proto:call_python_full_test`). However, these dependencies are still imported when `//drake/common/proto:call_python_client_cli` is executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7509)
<!-- Reviewable:end -->
