### PR TITLE
Added lcm:mock to libdrake

### DIFF
--- a/drake/lcm/BUILD.bazel
+++ b/drake/lcm/BUILD.bazel
@@ -18,7 +18,6 @@ drake_cc_library(
 
 drake_cc_library(
     name = "mock",
-    testonly = 1,
     srcs = ["drake_mock_lcm.cc"],
     hdrs = ["drake_mock_lcm.h"],
     deps = [

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -98,6 +98,7 @@ LIBDRAKE_COMPONENTS = [
     "//drake/lcm:interface",
     "//drake/lcm:lcm",
     "//drake/lcm:lcm_log",
+    "//drake/lcm:mock",
     "//drake/lcm:translator_base",
     "//drake/manipulation/planner:constraint_relaxing_ik",
     "//drake/manipulation/planner:robot_plan_interpolator",


### PR DESCRIPTION
As part of an external project in which we are making use of `libdrake`, we found that it'd be really nice to have lcm mocks handy for testing. This PR adds the following changes:
- Adds the `lcm:mock` library into `libdrake`.
- Removes the `testonly = 1` rule to enable `libdrake` to depend on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7515)
<!-- Reviewable:end -->
