### PR TITLE
Add compatibility with Bazel 0.8.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,17 +18,17 @@ exports_files([
 
 alias(
     name = "protoc",
-    actual = "@protobuf//:protoc",
+    actual = "@com_google_protobuf//:protoc",
 )
 
 alias(
     name = "protobuf",
-    actual = "@protobuf//:protobuf",
+    actual = "@com_google_protobuf//:protobuf",
 )
 
 alias(
     name = "protobuf_python",
-    actual = "@protobuf//:protobuf_python",
+    actual = "@com_google_protobuf//:protobuf_python",
 )
 
 install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -336,10 +336,10 @@ bind(
 # When updating the version of protobuf,
 # update tools/install/protobuf/protobuf.cps
 github_archive(
-    name = "protobuf",
+    name = "com_google_protobuf",
     repository = "google/protobuf",
-    commit = "v3.1.0",
-    sha256 = "fb2a314f4be897491bb2446697be693d489af645cb0e165a85e7e64e07eb134d",  # noqa
+    commit = "v3.5.0",
+    sha256 = "0cc6607e2daa675101e9b7398a436f09167dffb8ca0489b0307ff7260498c13c",  # noqa
 )
 
 pypi_archive(

--- a/drake/common/proto/BUILD.bazel
+++ b/drake/common/proto/BUILD.bazel
@@ -43,7 +43,7 @@ drake_cc_library(
     srcs = ["protobuf.cc"],
     hdrs = ["protobuf.h"],
     deps = [
-        "@protobuf",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -488,9 +488,10 @@ def drake_cc_googletest(
     be used only rarely, and the reason should always be documented.
     """
     if use_default_main:
-        deps += ["//drake/common/test_utilities:drake_cc_googletest_main"]
+        deps = deps + \
+            ["//drake/common/test_utilities:drake_cc_googletest_main"]
     else:
-        deps += ["@gtest//:without_main"]
+        deps = deps + ["@gtest//:without_main"]
     drake_cc_test(
         name = name,
         deps = deps,

--- a/tools/skylark/drake_proto.bzl
+++ b/tools/skylark/drake_proto.bzl
@@ -1,7 +1,7 @@
 # -*- python -*-
 
 load(
-    "@protobuf//:protobuf.bzl",
+    "@com_google_protobuf//:protobuf.bzl",
     "cc_proto_library",
     "py_proto_library",
 )

--- a/tools/workspace/protobuf/BUILD.bazel
+++ b/tools/workspace/protobuf/BUILD.bazel
@@ -162,18 +162,18 @@ excluded_headers = [
 install(
     name = "install",
     targets = [
-        "@protobuf//:protobuf",
-        "@protobuf//:protobuf_lite",
-        "@protobuf//:protoc_lib",
-        "@protobuf//:protoc",
+        "@com_google_protobuf//:protobuf",
+        "@com_google_protobuf//:protobuf_lite",
+        "@com_google_protobuf//:protoc_lib",
+        "@com_google_protobuf//:protoc",
     ],
-    hdrs = ["@protobuf//:well_known_protos"],
+    hdrs = ["@com_google_protobuf//:well_known_protos"],
     hdr_strip_prefix = ["src"],
     guess_hdrs = "PACKAGE",
     guess_hdrs_exclude = excluded_headers,
-    docs = ["@protobuf//:LICENSE"],
+    docs = ["@com_google_protobuf//:LICENSE"],
     doc_dest = "share/doc/protobuf",
-    allowed_externals = ["@protobuf//:protobuf"],
+    allowed_externals = ["@com_google_protobuf//:protobuf"],
     deps = [":install_cmake_config"],
 )
 

--- a/tools/workspace/protobuf/protobuf.cps
+++ b/tools/workspace/protobuf/protobuf.cps
@@ -3,7 +3,7 @@
   "Name": "protobuf",
   "Description": "Language-neutral, platform-neutral, extensible mechanism for serializing structured data",
   "License": "BSD-3-Clause",
-  "Version": "3.1.0",
+  "Version": "3.5.0",
   "Default-Components": [":protobuf"],
   "Components": {
     "protobuf": {


### PR DESCRIPTION
Protobuf version 3.5.0 matches that currently in Homebrew and therefore that will likely be used on macOS and is necessary on all platforms for Bazel version 0.8.0 compatibility until we move across to the system version of Protobuf in #7323.

Also fixes RobotLocomotion/drake-shambhala#68.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7530)
<!-- Reviewable:end -->