### PR TITLE
Fix lcm_vector_gen when used from other workspaces

### DIFF
--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -513,6 +513,12 @@ def generate_code(
         lcm_filename=None):
 
     cxx_include_path = os.path.dirname(named_vector_filename) + "/gen"
+    if cxx_include_path.startswith("external/"):
+        # Drake is being used from within a different workspace, so we have to
+        # strip the "external/drake/" from the named_vector_filename.  (The
+        # name after "external" will vary depending on what name the workspace
+        # gave us, so we can't hard-code it to "drake".)
+        cxx_include_path = "/".join(cxx_include_path.split("/")[2:])
     # TODO(#6996) Do this unconditionally once #6996 shuffle is finished.
     if not cxx_include_path.startswith("drake/"):
         # TODO(jwnimmer-tri) For use outside of Drake, this include_prefix


### PR DESCRIPTION
As of #7383 and #7340, Bazel-using projects that consumed `drake/automotive` would receive codegen errors.  This gets that feature working again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7532)
<!-- Reviewable:end -->
