### PR TITLE
Enable confluent branch checking within PoseSelector

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -598,6 +598,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "pose_selector_test",
     deps = [
+        "//automotive:monolane_onramp_merge",
         "//automotive:pose_selector",
         "//automotive/maliput/dragway",
         "//automotive/maliput/monolane:builder",

--- a/automotive/automotive_demo.cc
+++ b/automotive/automotive_demo.cc
@@ -151,7 +151,8 @@ void AddMaliputRailcar(int num_cars, bool idm_controlled, int initial_s_offset,
     if (idm_controlled) {
       simulator->AddIdmControlledPriusMaliputRailcar(
           "IdmControlledMaliputRailcar" + std::to_string(i),
-          LaneDirection(lane), RoadPositionStrategy::kExhaustiveSearch,
+          LaneDirection(lane), ScanStrategy::kPath,
+          RoadPositionStrategy::kExhaustiveSearch,
           0. /* time period (unused) */, params, state);
     } else {
       simulator->AddPriusMaliputRailcar("MaliputRailcar" + std::to_string(i),
@@ -239,7 +240,8 @@ void AddVehicles(RoadNetworkType road_network_type,
       state.set_x(x_offset);
       state.set_y(y_offset);
       simulator->AddMobilControlledSimpleCar(
-          name, true /* with_s */, RoadPositionStrategy::kExhaustiveSearch,
+          name, true /* with_s */, ScanStrategy::kPath,
+          RoadPositionStrategy::kExhaustiveSearch,
           0. /* time period (unused) */, state);
     }
 

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -141,7 +141,7 @@ int AutomotiveSimulator<T>::AddPriusSimpleCar(
 
 template <typename T>
 int AutomotiveSimulator<T>::AddMobilControlledSimpleCar(
-    const std::string& name, bool initial_with_s,
+    const std::string& name, bool initial_with_s, ScanStrategy path_or_branches,
     RoadPositionStrategy road_position_strategy, double period_sec,
     const SimpleCarState<T>& initial_state) {
   DRAKE_DEMAND(!has_started());
@@ -160,8 +160,10 @@ int AutomotiveSimulator<T>::AddMobilControlledSimpleCar(
                                                     road_position_strategy,
                                                     period_sec);
   mobil_planner->set_name(name + "_mobil_planner");
-  auto idm_controller = builder_->template AddSystem<IdmController<T>>(
-      *road_, road_position_strategy, period_sec);
+  auto idm_controller =
+      builder_->template AddSystem<IdmController<T>>(*road_, path_or_branches,
+                                                     road_position_strategy,
+                                                     period_sec);
   idm_controller->set_name(name + "_idm_controller");
 
   auto simple_car = builder_->template AddSystem<SimpleCar<T>>();
@@ -243,7 +245,7 @@ template <typename T>
 int AutomotiveSimulator<T>::AddIdmControlledCar(
     const std::string& name, bool initial_with_s,
     const SimpleCarState<T>& initial_state,
-    const maliput::api::Lane* goal_lane,
+    const maliput::api::Lane* goal_lane, ScanStrategy path_or_branches,
     RoadPositionStrategy road_position_strategy, double period_sec) {
   DRAKE_DEMAND(!has_started());
   DRAKE_DEMAND(aggregator_ != nullptr);
@@ -259,8 +261,10 @@ int AutomotiveSimulator<T>::AddIdmControlledCar(
   CheckNameUniqueness(name);
   const int id = allocate_vehicle_number();
 
-  auto idm_controller = builder_->template AddSystem<IdmController<T>>(
-      *road_, road_position_strategy, period_sec);
+  auto idm_controller =
+      builder_->template AddSystem<IdmController<T>>(*road_, path_or_branches,
+                                                     road_position_strategy,
+                                                     period_sec);
   idm_controller->set_name(name + "_idm_controller");
 
   const LaneDirection lane_direction(goal_lane, initial_with_s);
@@ -349,7 +353,9 @@ int AutomotiveSimulator<T>::AddPriusMaliputRailcar(
 
 template <typename T>
 int AutomotiveSimulator<T>::AddIdmControlledPriusMaliputRailcar(
-    const std::string& name, const LaneDirection& initial_lane_direction,
+    const std::string& name,
+    const LaneDirection& initial_lane_direction,
+    ScanStrategy path_or_branches,
     RoadPositionStrategy road_position_strategy, double period_sec,
     const MaliputRailcarParams<T>& params,
     const MaliputRailcarState<T>& initial_state) {
@@ -359,7 +365,7 @@ int AutomotiveSimulator<T>::AddIdmControlledPriusMaliputRailcar(
       dynamic_cast<const MaliputRailcar<T>*>(vehicles_.at(id));
   DRAKE_DEMAND(railcar != nullptr);
   auto controller =
-      builder_->template AddSystem<IdmController<T>>(*road_,
+      builder_->template AddSystem<IdmController<T>>(*road_, path_or_branches,
                                                      road_position_strategy,
                                                      period_sec);
   controller->set_name(name + "_IdmController");

--- a/automotive/automotive_simulator.h
+++ b/automotive/automotive_simulator.h
@@ -99,6 +99,10 @@ class AutomotiveSimulator {
   /// @param initial_with_s Initial travel direction in the lane. (See
   /// MobilPlanner documentation.)
   ///
+  /// @param path_or_branches If ScanStrategy::kBranches, performs IDM
+  /// computations using vehicles detected in confluent branches; if
+  /// ScanStrategy::kPath, limits to vehicles on the default path.
+  ///
   /// @param road_position_strategy Determines whether or not to memorize
   /// RoadPosition. See `calc_ongoing_road_position.h`.
   ///
@@ -110,6 +114,7 @@ class AutomotiveSimulator {
   /// @return The ID of the car that was just added to the simulation.
   int AddMobilControlledSimpleCar(
       const std::string& name, bool initial_with_s,
+      ScanStrategy path_or_branches,
       RoadPositionStrategy road_position_strategy, double period_sec,
       const SimpleCarState<T>& initial_state = SimpleCarState<T>());
 
@@ -151,6 +156,10 @@ class AutomotiveSimulator {
   /// a member of the road supplied via SetRoadGeometry(), a std::runtime_error
   /// will be thrown.
   ///
+  /// @param path_or_branches If ScanStrategy::kBranches, performs IDM
+  /// computations using vehicles detected in confluent branches; if
+  /// ScanStrategy::kPath, limits to vehicles on the default path.
+  ///
   /// @param road_position_strategy Determines whether or not to memorize
   /// RoadPosition. See `calc_ongoing_road_position.h`.
   ///
@@ -162,6 +171,7 @@ class AutomotiveSimulator {
                           bool initial_with_s,
                           const SimpleCarState<T>& initial_state,
                           const maliput::api::Lane* goal_lane,
+                          ScanStrategy path_or_branches,
                           RoadPositionStrategy road_position_strategy,
                           double period_sec);
 
@@ -208,6 +218,10 @@ class AutomotiveSimulator {
   /// maliput::api::RoadGeometry that is added via SetRoadGeometry(). Otherwise
   /// a std::runtime_error will be thrown.
   ///
+  /// @param path_or_branches If ScanStrategy::kBranches, performs IDM
+  /// computations using vehicles detected in confluent branches; if
+  /// ScanStrategy::kPath, limits to vehicles on the default path.
+  ///
   /// @param road_position_strategy Determines whether or not to memorize
   /// RoadPosition. See `calc_ongoing_road_position.h`.
   ///
@@ -223,6 +237,7 @@ class AutomotiveSimulator {
   /// @return The ID of the car that was just added to the simulation.
   int AddIdmControlledPriusMaliputRailcar(
       const std::string& name, const LaneDirection& initial_lane_direction,
+      ScanStrategy path_or_branches,
       RoadPositionStrategy road_position_strategy, double period_sec,
       const MaliputRailcarParams<T>& params = MaliputRailcarParams<T>(),
       const MaliputRailcarState<T>& initial_state = MaliputRailcarState<T>());

--- a/automotive/idm_controller.h
+++ b/automotive/idm_controller.h
@@ -10,6 +10,7 @@
 #include "drake/automotive/idm_planner.h"
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/pose_selector.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/rendering/pose_bundle.h"
@@ -54,20 +55,26 @@ class IdmController : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdmController)
 
-  /// Constructor.
+  /// Default constructor.
   /// @param road The pre-defined RoadGeometry.
+  /// @param path_or_branches If ScanStrategy::kBranches, performs IDM
+  /// computations using vehicles detected in confluent branches; if
+  /// ScanStrategy::kPath, limits to vehicles on the default path.  See
+  /// documentation for PoseSelector::FindSingleClosestPose().
   /// @param road_position_strategy Determines whether or not to cache
   /// RoadPosition. See `calc_ongoing_road_position.h`.
   /// @param period_sec The update period to use if road_position_strategy ==
   /// RoadPositionStrategy::kCache.
   IdmController(const maliput::api::RoadGeometry& road,
+                ScanStrategy path_or_branches,
                 RoadPositionStrategy road_position_strategy,
                 double period_sec);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit IdmController(const IdmController<U>& other)
-      : IdmController<T>(other.road_, other.road_position_strategy_,
+      : IdmController<T>(other.road_, other.path_or_branches_,
+                         other.road_position_strategy_,
                          other.period_sec_) {}
 
   ~IdmController() override;
@@ -112,6 +119,7 @@ class IdmController : public systems::LeafSystem<T> {
                         systems::BasicVector<T>* accel_output) const;
 
   const maliput::api::RoadGeometry& road_;
+  const ScanStrategy path_or_branches_{};
   const RoadPositionStrategy road_position_strategy_{};
   const double period_sec_{};
 

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -183,7 +183,7 @@ const std::pair<T, T> MobilPlanner<T>::ComputeIncentives(
   DRAKE_DEMAND(ego_closest_pose.odometry.lane != nullptr);
   const ClosestPoses current_closest_poses = PoseSelector<T>::FindClosestPair(
       ego_closest_pose.odometry.lane, ego_pose, traffic_poses,
-      idm_params.scan_ahead_distance());
+      idm_params.scan_ahead_distance(), ScanStrategy::kPath);
   // Construct ClosestPose containers for the leading, trailing, and ego car.
   const ClosestPose<T>& leading_closest_pose =
       current_closest_poses.at(AheadOrBehind::kAhead);
@@ -202,7 +202,8 @@ const std::pair<T, T> MobilPlanner<T>::ComputeIncentives(
   // Compute the incentive for the left lane.
   if (lanes.first != nullptr) {
     const ClosestPoses left_closest_poses = PoseSelector<T>::FindClosestPair(
-        lanes.first, ego_pose, traffic_poses, idm_params.scan_ahead_distance());
+        lanes.first, ego_pose, traffic_poses, idm_params.scan_ahead_distance(),
+        ScanStrategy::kPath);
     ComputeIncentiveOutOfLane(idm_params, mobil_params, left_closest_poses,
                               ego_closest_pose, ego_acceleration,
                               trailing_delta_accel_this, &incentives.first);
@@ -211,7 +212,8 @@ const std::pair<T, T> MobilPlanner<T>::ComputeIncentives(
   if (lanes.second != nullptr) {
     const ClosestPoses right_closest_poses =
         PoseSelector<T>::FindClosestPair(lanes.second, ego_pose, traffic_poses,
-                                         idm_params.scan_ahead_distance());
+                                         idm_params.scan_ahead_distance(),
+                                         ScanStrategy::kPath);
     ComputeIncentiveOutOfLane(idm_params, mobil_params, right_closest_poses,
                               ego_closest_pose, ego_acceleration,
                               trailing_delta_accel_this, &incentives.second);

--- a/automotive/pose_selector.cc
+++ b/automotive/pose_selector.cc
@@ -1,41 +1,233 @@
 #include "drake/automotive/pose_selector.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/segment.h"
 #include "drake/common/autodiffxd_make_coherent.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/extract_double.h"
 
 namespace drake {
 namespace automotive {
 
+using maliput::api::GeoPosition;
 using maliput::api::GeoPositionT;
 using maliput::api::Lane;
 using maliput::api::LaneEnd;
+using maliput::api::LaneEndSet;
 using maliput::api::LanePosition;
 using maliput::api::LanePositionT;
+using maliput::api::RoadGeometry;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseBundle;
 using systems::rendering::PoseVector;
 
+namespace {
+
+// Returns `true` if and only if @p lane_position is within the longitudinal
+// (s), driveable (r) and elevation (h) bounds of the specified @p lane
+// (i.e. within `linear_tolerance()` of `lane->driveable_bounds()` and
+// `lane->elevation_bounds()`).
 template <typename T>
-std::map<AheadOrBehind, const ClosestPose<T>> PoseSelector<T>::FindClosestPair(
-    const Lane* lane, const PoseVector<T>& ego_pose,
-    const PoseBundle<T>& traffic_poses, const T& scan_distance) {
-  std::map<AheadOrBehind, const ClosestPose<T>> result;
-  for (auto side : {AheadOrBehind::kAhead, AheadOrBehind::kBehind}) {
-    result.insert(std::make_pair(
-        side, FindSingleClosestPose(lane, ego_pose, traffic_poses,
-                                    scan_distance, side)));
+bool IsWithinDriveable(const LanePositionT<T>& lane_position,
+                       const Lane* lane) {
+  const double tol =
+      lane->segment()->junction()->road_geometry()->linear_tolerance();
+  if (lane_position.s() < -tol || lane_position.s() > lane->length() + tol) {
+    return false;
   }
-  return result;
+  const maliput::api::RBounds r_bounds =
+      lane->driveable_bounds(ExtractDoubleOrThrow(lane_position.s()));
+  if (lane_position.r() < r_bounds.min() - tol ||
+      lane_position.r() > r_bounds.max() + tol) {
+    return false;
+  }
+  const maliput::api::HBounds h_bounds =
+      lane->elevation_bounds(ExtractDoubleOrThrow(lane_position.s()),
+                             ExtractDoubleOrThrow(lane_position.r()));
+  return (lane_position.h() >= h_bounds.min() - tol &&
+          lane_position.h() <= h_bounds.max() + tol);
 }
 
+// Returns `true` if and only if @p geo_position is within the longitudinal (s),
+// lateral (r) and elevation (h) bounds of the specified @p lane (i.e. within
+// `linear_tolerance()` of `lane->lane_bounds()` and
+// `lane->elevation_bounds()`).
 template <typename T>
-ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
+bool IsWithinLane(const GeoPositionT<T>& geo_position, const Lane* lane) {
+  const double tol =
+      lane->segment()->junction()->road_geometry()->linear_tolerance();
+  T distance{};
+  const LanePositionT<T> pos =
+      lane->ToLanePositionT<T>(geo_position, nullptr, &distance);
+  const maliput::api::RBounds r_bounds =
+      lane->lane_bounds(ExtractDoubleOrThrow(pos.s()));
+  return (distance < tol && pos.r() >= r_bounds.min() - tol &&
+          pos.r() <= r_bounds.max() + tol);
+}
+
+// Returns `true` if and only if @p lane_position is within `linear_tolerance()`
+// of the driveable bounds of @p lane and, in addition, `r` is within its lane
+// bounds.
+template <typename T>
+bool IsWithinLane(const LanePositionT<T>& lane_position, const Lane* lane) {
+  const double tol =
+      lane->segment()->junction()->road_geometry()->linear_tolerance();
+  if (IsWithinDriveable(lane_position, lane)) {
+    const maliput::api::RBounds r_bounds =
+        lane->lane_bounds(ExtractDoubleOrThrow(lane_position.s()));
+    if (lane_position.r() >= r_bounds.min() - tol ||
+        lane_position.r() <= r_bounds.max() + tol) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Given a @p lane_direction, returns the LaneEnd corresponding to the
+// exit-point of an ongoing lane and updates @p lane_direction to match the
+// `lane` and `with_s` of that branch.  If the LaneEnd corresponds to a default
+// branch at that end, then it is returned.  If there is no default branch, the
+// ongoing LaneEnd with index = 0 is selected.  Otherwise, returns `nullopt` and
+// sets `lane_direction->lane` to `nullptr`.
+optional<LaneEnd> GetDefaultOrFirstOngoingLane(LaneDirection* lane_direction) {
+  const Lane* const lane{lane_direction->lane};
+  const bool with_s{lane_direction->with_s};
+  optional<LaneEnd> branch =
+      lane->GetDefaultBranch((with_s) ? LaneEnd::kFinish : LaneEnd::kStart);
+  if (!branch) {
+    const LaneEndSet* branches =
+        lane->GetOngoingBranches((with_s) ? LaneEnd::kFinish : LaneEnd::kStart);
+    if (branches->size() == 0) {
+      lane_direction->lane = nullptr;
+      lane_direction->with_s = true;
+      return nullopt;
+    }
+    branch = branches->get(0);
+  }
+  lane_direction->lane = branch->lane;
+  lane_direction->with_s = (branch->end == LaneEnd::kStart) ? true : false;
+  // The LaneEnd of the found successor lane corresponds to the traversal end;
+  // need to reverse this to get the opposite end (i.e. the one connected to the
+  // branch point).
+  branch->end =
+      (branch->end == LaneEnd::kStart) ? LaneEnd::kFinish : LaneEnd::kStart;
+  return branch;
+}
+
+// Given a @p lane_direction, returns the LaneEnd corresponding to
+// lane_direction.with_s.
+LaneEnd GetTargetLaneEnd(const LaneDirection& lane_direction) {
+  const Lane* const lane{lane_direction.lane};
+  const bool with_s{lane_direction.with_s};
+  return LaneEnd{lane, (with_s) ? LaneEnd::kFinish : LaneEnd::kStart};
+}
+
+// Constructs LaneDirection structure based on a vehicle's current @p lane, @p
+// lane_position, @p rotation (in global coordinates), and the @p side of the
+// car (ahead or behind) that traffic is being observed.  Note that
+// `LaneDirection::with_s` in the return argument is interpreted as the
+// direction along which targets are being observed (regardless of the ego car's
+// orientation): it is true if cars are being observed along the `s`-direction
+// and is false otherwise.
+template <typename T>
+LaneDirection CalcLaneDirection(
+    const Lane* lane, const LanePositionT<T>& lane_position,
+    const Eigen::Quaternion<T>& rotation, AheadOrBehind side) {
+  // Get the vehicle's heading with respect to the current lane; use it to
+  // determine if the vehicle is facing with or against the lane's canonical
+  // direction.
+  const LanePosition lane_pos =
+      LanePosition(ExtractDoubleOrThrow(lane_position.s()),
+                   ExtractDoubleOrThrow(lane_position.r()),
+                   ExtractDoubleOrThrow(lane_position.h()));
+  const Eigen::Quaternion<T> lane_rotation =
+      lane->GetOrientation(lane_pos).quat();
+  // The dot product of two quaternions is the cosine of half the angle between
+  // the two rotations.  Given two quaternions q₀, q₁ and letting θ be the angle
+  // difference between them, then -π/2 ≤ θ ≤ π/2 iff q₀.q₁ ≥ √2/2.
+  const bool with_s = (side == AheadOrBehind::kAhead)
+                          ? lane_rotation.dot(rotation) >= sqrt(2.) / 2.
+                          : lane_rotation.dot(rotation) < sqrt(2.) / 2.;
+  return LaneDirection(lane, with_s);
+}
+
+// Returns a RoadOdometry that contains an infinite `s` position, zero `r` and
+// `h` positions, and zero velocities. If @p lane_direction contains `with_s ==
+// true`, a RoadOdometry containing an s-position at positive infinity is
+// returned; otherwise a negative-infinite position is returned.  For T ==
+// AutoDiffXd, the derivatives of the returned RoadOdometry are made to be
+// coherent with respect to @p pose.
+template <typename T>
+RoadOdometry<T> MakeInfiniteOdometry(
+    const LaneDirection& lane_direction, const PoseVector<T>& pose) {
+  T infinite_position = (lane_direction.with_s)
+                            ? std::numeric_limits<T>::infinity()
+                            : -std::numeric_limits<T>::infinity();
+  T zero(0.);
+  autodiffxd_make_coherent(pose.get_isometry().translation().x(), &zero);
+  autodiffxd_make_coherent(pose.get_isometry().translation().x(),
+                           &infinite_position);
+  const LanePositionT<T> lane_position(infinite_position, zero, zero);
+  FrameVelocity<T> frame_velocity;
+  auto velocity = frame_velocity.get_mutable_value();
+  for (int i{0}; i < frame_velocity.kSize; ++i) {
+    autodiffxd_make_coherent(pose.get_isometry().translation().x(),
+                             &velocity(i));
+  }
+  // TODO(jadecastro) Consider moving the above autodiffxd_make_coherent() step
+  // to BasicVector().
+  return {lane_direction.lane, lane_position, frame_velocity};
+}
+
+// Returns positive infinity. For T = AutoDiffXd, the derivatives of the the
+// return value are made to be coherent with respect to @p pose.
+template <typename T>
+T MakeInfiniteDistance(const PoseVector<T>& pose) {
+  T infinite_distance = std::numeric_limits<T>::infinity();
+  autodiffxd_make_coherent(pose.get_isometry().translation().x(),
+                           &infinite_distance);
+  return infinite_distance;
+}
+
+// Returns the distance (along the `s`-coordinate) from an end of a lane to a @p
+// lane_position in that lane, where the end is determined by the `with_s` of
+// the provided `lane_direction`.  Both `lane` and `with_s` are specified in @p
+// lane_direction.  Throws if any element of @p lane_position is not within the
+// respective bounds of `lane_direction.lane`.
+template <typename T>
+T CalcLaneProgress(const LaneDirection& lane_direction,
+                   const LanePositionT<T>& lane_position) {
+  DRAKE_DEMAND(IsWithinDriveable(lane_position, lane_direction.lane));
+  if (lane_direction.with_s) {
+    return lane_position.s();
+  } else {
+    return T(lane_direction.lane->length()) - lane_position.s();
+  }
+}
+
+// Helper that makes a GeoPosition from the provided Isometry3.
+template <typename T>
+GeoPosition MakeGeoPosition(const Isometry3<T>& isometry) {
+  return {ExtractDoubleOrThrow(isometry.translation().x()),
+          ExtractDoubleOrThrow(isometry.translation().y()),
+          ExtractDoubleOrThrow(isometry.translation().z())};
+}
+
+// Returns the closest pose to the ego car along the default path given a
+// `lane`, the ego vehicle's pose `ego_pose`, a PoseBundle of `traffic_poses`,
+// the AheadOrBehind specifier `side`.  The return value is the same as
+// PoseSelector<T>::FindSingleClosestPose().
+template <typename T>
+ClosestPose<T> FindSingleClosestInDefaultPath(
     const Lane* lane, const PoseVector<T>& ego_pose,
     const PoseBundle<T>& traffic_poses, const T& scan_distance,
     const AheadOrBehind side) {
@@ -48,14 +240,15 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
   const LanePositionT<T> ego_lane_position =
       lane->ToLanePositionT<T>(ego_geo_position, nullptr, nullptr);
   LaneDirection lane_direction =
-      CalcLaneDirection(lane, ego_lane_position, ego_pose.get_rotation(), side);
+      CalcLaneDirection<T>(lane, ego_lane_position, ego_pose.get_rotation(),
+                           side);
 
   ClosestPose<T> result;
-  result.odometry = MakeInfiniteOdometry(lane_direction, ego_pose);
-  result.distance = MakeInfiniteDistance(ego_pose);
+  result.odometry = MakeInfiniteOdometry<T>(lane_direction, ego_pose);
+  result.distance = MakeInfiniteDistance<T>(ego_pose);
   const ClosestPose<T> default_result = result;
 
-  const T ego_s = CalcLaneProgress(lane_direction, ego_lane_position);
+  const T ego_s = CalcLaneProgress<T>(lane_direction, ego_lane_position);
   T distance_scanned = T(-ego_s);  // N.B. ego_s is negated to recover the
                                    // remaining distance to the end of the lane
                                    // when `distance_scanned` is incremented by
@@ -66,6 +259,7 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
   // looking for traffic cars.
   while (distance_scanned < scan_distance) {
     T distance_increment{0.};
+
     for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
       const Isometry3<T> traffic_isometry = traffic_poses.get_pose(i);
       const GeoPositionT<T> traffic_geo_position =
@@ -78,7 +272,7 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
           lane_direction.lane->ToLanePositionT<T>(traffic_geo_position, nullptr,
                                                   nullptr);
       const T traffic_s =
-          CalcLaneProgress(lane_direction, traffic_lane_position);
+          CalcLaneProgress<T>(lane_direction, traffic_lane_position);
 
       const T s_delta = traffic_s - ego_s;
       // Ignore traffic cars that are not in the desired direction (ahead or
@@ -117,12 +311,233 @@ ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
     distance_scanned += T(lane_direction.lane->length());
 
     // Obtain the next lane_direction in the scanned sequence.
-    GetDefaultOngoingLane(&lane_direction);
+    GetDefaultOrFirstOngoingLane(&lane_direction);
     if (lane_direction.lane == nullptr) {
       return result;
     }
   }
   return default_result;
+}
+
+// Returns true if `lane0` has an equal identifier as `lane1`, and false
+// otherwise.  The result is trivially false if either is nullptr.
+bool IsEqual(const Lane* lane0, const Lane* lane1) {
+  if (!lane0 || !lane1) return false;
+  return lane0->id() == lane1->id();
+}
+
+// Returns the closest pose to the ego car given a `lane`, the ego vehicle's
+// pose `ego_pose`, a PoseBundle of `traffic_poses`, the AheadOrBehind specifier
+// `side`, and a set of `branches` to be checked.  The return value is the same
+// as PoseSelector<T>::FindSingleClosestPose().
+template <typename T>
+ClosestPose<T> FindSingleClosestInBranches(
+    const Lane* ego_lane, const PoseVector<T>& ego_pose,
+    const PoseBundle<T>& traffic_poses, const T& scan_distance,
+    const AheadOrBehind side,
+    const std::vector<typename PoseSelector<T>::LaneEndDistance>& branches) {
+  using std::abs;
+  using std::min;
+
+  // Set the default ClosestPose at infinity.
+  DRAKE_DEMAND(ego_lane != nullptr);  // The ego car must be in a lane.
+  const GeoPositionT<T> ego_geo_position =
+      GeoPositionT<T>::FromXyz(ego_pose.get_isometry().translation());
+  const LanePositionT<T> ego_lane_position =
+      ego_lane->template ToLanePositionT<T>(ego_geo_position, nullptr, nullptr);
+  LaneDirection ego_lane_direction =
+      CalcLaneDirection<T>(ego_lane, ego_lane_position, ego_pose.get_rotation(),
+                           side);
+  ClosestPose<T> result;
+  result.odometry = MakeInfiniteOdometry<T>(ego_lane_direction, ego_pose);
+  result.distance = MakeInfiniteDistance<T>(ego_pose);
+
+  for (int i = 0; i < traffic_poses.get_num_poses(); ++i) {
+    const Isometry3<T> traffic_isometry = traffic_poses.get_pose(i);
+    const Lane* const traffic_lane =
+        ego_lane->segment()->junction()->road_geometry()->ToRoadPosition(
+            MakeGeoPosition<T>(traffic_isometry), nullptr, nullptr,
+            nullptr).lane;
+    // TODO(jadecastro) Supply a valid hint.
+    if (traffic_lane == nullptr) continue;
+
+    /// TODO(jadecastro) RoadGeometry::ToRoadPositionT() doesn't yet exist, so
+    /// for now, just call Lane::ToLanePositionT.
+    const LanePositionT<T> lane_position =
+        traffic_lane->ToLanePositionT<T>(
+            GeoPositionT<T>::FromXyz(traffic_isometry.translation()), nullptr,
+            nullptr);
+
+    // Get this traffic vehicle's velocity and travel direction in the lane it
+    // is occupying.
+    const T lane_sigma_v = PoseSelector<T>::GetSigmaVelocity(
+        {traffic_lane, lane_position, traffic_poses.get_velocity(i)});
+
+    const LaneDirection traffic_ld = CalcLaneDirection<T>(
+        traffic_lane, lane_position,
+        Eigen::Quaternion<T>(traffic_isometry.rotation()),
+        AheadOrBehind::kAhead);
+    const T traffic_s = CalcLaneProgress<T>(traffic_ld, lane_position);
+
+    // Determine if any of the traffic cars eventually lead to a branch within a
+    // speed- and branch-dependent influence distance horizon.
+    for (auto branch_distance : branches) {
+      LaneDirection lane_direction(traffic_ld);
+      optional<LaneEnd> lane_end = GetTargetLaneEnd(lane_direction);
+      DRAKE_ASSERT(lane_end != nullopt);
+
+      T distance_scanned = T(-traffic_s);
+
+      T ego_distance_to_this_branch{};
+      LaneEnd branch;
+      std::tie(ego_distance_to_this_branch, branch) = branch_distance;
+
+      // The distance ahead needed to scan for intersection is assumed equal to
+      // the distance scanned in the ego vehicle's lane times the ratio of
+      // s-velocity of the traffic car to that of the ego car.  Cars much slower
+      // than the ego car are thus phased out closer to the branch-point, while
+      // those that are faster remain in scope further away from the
+      // branch-point.
+      //
+      // TODO(jadecastro) Use the actual velocity from the ego car, ensuring
+      // that distance_to_scan is negative if the ego is moving away from the
+      // branch point.
+      const T distance_to_scan = min(scan_distance,
+                                     abs(lane_sigma_v / T(kEgoSigmaVelocity)) *
+                                     ego_distance_to_this_branch);
+
+      T effective_headway = MakeInfiniteDistance<T>(ego_pose);
+      while (distance_scanned < distance_to_scan) {
+        const Lane* trial_lane = lane_end->lane;
+        if (trial_lane == nullptr) break;
+
+        // If this vehicle is in the trial_lane, then use it to compute the
+        // effective headway distance to the ego vehicle.  Otherwise continue
+        // down its path looking for the lane connected to a branch up to
+        // distance_to_scan.
+        if (IsEqual(trial_lane, branch.lane) && (lane_end->end == branch.end)) {
+          const T distance_to_lane_end =
+              distance_scanned + T(trial_lane->length());
+          // "Effective headway" is the distance between the traffic vehicle and
+          // the ego vehicle, compared relative to their positions with respect
+          // to their shared branch point.
+          effective_headway =
+              ego_distance_to_this_branch - distance_to_lane_end;
+        }
+        if (0. < effective_headway && effective_headway < result.distance) {
+          result.distance = effective_headway;
+          result.odometry = RoadOdometry<T>(traffic_lane, lane_position,
+                                            traffic_poses.get_velocity(i));
+          break;
+        }
+        lane_end = GetDefaultOrFirstOngoingLane(&lane_direction);
+        if (lane_end == nullopt) break;
+        // Increment distance_scanned.
+        distance_scanned += T(trial_lane->length());
+      }
+    }
+  }
+  return result;
+}
+
+// Returns a LaneEndSet consisting of all LaneEnds attached to the provided lane
+// (specified in `lane_direction`) corresponding to all branches connected to
+// the end of the lane that is reached when traveling in the `with_s` direction
+// specified within `lane_direction`.  The return value contains a null pointer
+// if no default branch is found.
+const LaneEndSet* GetIncomingLaneEnds(
+    const LaneDirection& lane_direction) {
+  const Lane* lane{lane_direction.lane};
+  const bool with_s{lane_direction.with_s};
+  return lane->GetConfluentBranches(
+      (with_s) ? LaneEnd::kFinish : LaneEnd::kStart);
+}
+
+// Returns the vector of branches along the sequence of default road segments in
+// a `road`, up to a given `scan_distance` in the ego vehicle's current lane,
+// given its PoseVector `ego_pose` and AheadOrBehind `side`. A vector of
+// LaneEndDistance is returned, whose elements are pairs where the first entry
+// is the distance along the s-coordinate from the ego vehicle to the branch and
+// second entry is the LaneEnd describing the branch.
+template <typename T>
+std::vector<typename PoseSelector<T>::LaneEndDistance> FindConfluentBranches(
+    const Lane* lane, const PoseVector<T>& ego_pose, const T& scan_distance,
+    const AheadOrBehind side) {
+  DRAKE_DEMAND(lane != nullptr);  // The ego car must be in a lane.
+  const GeoPositionT<T> ego_geo_position =
+      GeoPositionT<T>::FromXyz(ego_pose.get_isometry().translation());
+  const LanePositionT<T> ego_lane_position =
+      lane->ToLanePositionT<T>(ego_geo_position, nullptr, nullptr);
+  LaneDirection lane_direction =
+      CalcLaneDirection<T>(lane, ego_lane_position, ego_pose.get_rotation(),
+                           side);
+
+  const T ego_s = CalcLaneProgress<T>(lane_direction, ego_lane_position);
+  T distance_scanned = T(-ego_s);
+
+  // Obtain any branches starting from the ego vehicle's lane, moving along its
+  // direction of travel by an amount equal to scan_distance.
+  std::vector<typename PoseSelector<T>::LaneEndDistance> branches;
+
+  while (distance_scanned < scan_distance) {
+    // Increment distance_scanned and collect all non-trivial branches as we go.
+    distance_scanned += T(lane_direction.lane->length());
+    const LaneEndSet* ends = GetIncomingLaneEnds(lane_direction);
+    if (lane_direction.lane != nullptr && ends->size() > 1) {
+      for (int i = 0; i < ends->size(); ++i) {
+        // Store, from the complete list, the LaneEnds that do not belong to the
+        // main path (lane sequence containing the ego vehicle).
+        if (!IsEqual(lane_direction.lane, ends->get(i).lane)) {
+          branches.emplace_back(std::make_pair(distance_scanned, ends->get(i)));
+        }
+      }
+    }
+    GetDefaultOrFirstOngoingLane(&lane_direction);
+    if (lane_direction.lane == nullptr) break;
+  }
+  return branches;
+}
+
+}  // namespace
+
+template <typename T>
+std::map<AheadOrBehind, const ClosestPose<T>> PoseSelector<T>::FindClosestPair(
+    const Lane* lane, const PoseVector<T>& ego_pose,
+    const PoseBundle<T>& traffic_poses, const T& scan_distance,
+    ScanStrategy path_or_branches) {
+  std::map<AheadOrBehind, const ClosestPose<T>> result;
+  for (auto side : {AheadOrBehind::kAhead, AheadOrBehind::kBehind}) {
+    result.insert(std::make_pair(
+        side, FindSingleClosestPose(lane, ego_pose, traffic_poses,
+                                    scan_distance, side, path_or_branches)));
+  }
+  return result;
+}
+
+template <typename T>
+ClosestPose<T> PoseSelector<T>::FindSingleClosestPose(
+    const Lane* lane, const PoseVector<T>& ego_pose,
+    const PoseBundle<T>& traffic_poses, const T& scan_distance,
+    const AheadOrBehind side, ScanStrategy path_or_branches) {
+  // Find any leading traffic cars along the same default path as the ego
+  // vehicle.
+  const ClosestPose<T> result_in_path = FindSingleClosestInDefaultPath(
+      lane, ego_pose, traffic_poses, scan_distance, side);
+  if (path_or_branches == ScanStrategy::kPath) return result_in_path;
+
+  const std::vector<LaneEndDistance> branches =
+      FindConfluentBranches(lane, ego_pose, scan_distance, side);
+  if (branches.size() == 0) return result_in_path;
+
+  // Find any leading traffic cars in lanes leading into the ego vehicle's
+  // default path.
+  const ClosestPose<T> result_in_branch = FindSingleClosestInBranches(
+      lane, ego_pose, traffic_poses, scan_distance, side, branches);
+
+  if (result_in_path.distance <= result_in_branch.distance) {
+    return result_in_path;
+  }
+  return result_in_branch;
 }
 
 template <typename T>
@@ -139,132 +554,9 @@ T PoseSelector<T>::GetSigmaVelocity(const RoadOdometry<T>& road_odometry) {
       road_odometry.vel.get_velocity();
   const Vector3<T>& vel = road_odometry_velocity.translational();
   return vel(0) * std::cos(rot.yaw()) + vel(1) * std::sin(rot.yaw());
-}
-
-template <typename T>
-bool PoseSelector<T>::IsWithinDriveable(const LanePositionT<T>& lane_position,
-                                        const Lane* lane) {
-  if (lane_position.s() < 0. || lane_position.s() > lane->length()) {
-    return false;
-  }
-  const maliput::api::RBounds r_bounds =
-      lane->driveable_bounds(ExtractDoubleOrThrow(lane_position.s()));
-  if (lane_position.r() < r_bounds.min() ||
-      lane_position.r() > r_bounds.max()) {
-    return false;
-  }
-  const maliput::api::HBounds h_bounds =
-      lane->elevation_bounds(ExtractDoubleOrThrow(lane_position.s()),
-                             ExtractDoubleOrThrow(lane_position.r()));
-  return (lane_position.h() >= h_bounds.min() &&
-          lane_position.h() <= h_bounds.max());
-}
-
-template <typename T>
-bool PoseSelector<T>::IsWithinLane(const GeoPositionT<T>& geo_position,
-                                   const Lane* lane) {
-  T distance{};
-  const LanePositionT<T> pos =
-      lane->ToLanePositionT<T>(geo_position, nullptr, &distance);
-  const maliput::api::RBounds r_bounds =
-      lane->lane_bounds(ExtractDoubleOrThrow(pos.s()));
-  return (distance == 0. && pos.r() >= r_bounds.min() &&
-          pos.r() <= r_bounds.max());
-}
-
-template <typename T>
-bool PoseSelector<T>::IsWithinLane(const LanePositionT<T>& lane_position,
-                                   const Lane* lane) {
-  if (IsWithinDriveable(lane_position, lane)) {
-    const maliput::api::RBounds r_bounds =
-        lane->lane_bounds(ExtractDoubleOrThrow(lane_position.s()));
-    if (lane_position.r() >= r_bounds.min() ||
-        lane_position.r() <= r_bounds.max()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-template <typename T>
-optional<LaneEnd> PoseSelector<T>::GetDefaultOngoingLane(
-    LaneDirection* lane_direction) {
-  const Lane* const lane{lane_direction->lane};
-  const bool with_s{lane_direction->with_s};
-  optional<LaneEnd> branch =
-      (with_s) ? lane->GetDefaultBranch(LaneEnd::kFinish)
-               : lane->GetDefaultBranch(LaneEnd::kStart);
-  if (!branch) {
-    lane_direction->lane = nullptr;
-    lane_direction->with_s = true;
-    return branch;
-  }
-  lane_direction->lane = branch->lane;
-  lane_direction->with_s = (branch->end == LaneEnd::kStart) ? true : false;
-  return branch;
-}
-
-template <typename T>
-RoadOdometry<T> PoseSelector<T>::MakeInfiniteOdometry(
-    const LaneDirection& lane_direction, const PoseVector<T>& ego_pose) {
-  T infinite_position = (lane_direction.with_s)
-                            ? std::numeric_limits<T>::infinity()
-                            : -std::numeric_limits<T>::infinity();
-  T zero(0.);
-  autodiffxd_make_coherent(ego_pose.get_isometry().translation().x(), &zero);
-  autodiffxd_make_coherent(ego_pose.get_isometry().translation().x(),
-                           &infinite_position);
-  const LanePositionT<T> lane_position(infinite_position, zero, zero);
-  FrameVelocity<T> frame_velocity;
-  auto velocity = frame_velocity.get_mutable_value();
-  for (int i{0}; i < frame_velocity.kSize; ++i) {
-    autodiffxd_make_coherent(ego_pose.get_isometry().translation().x(),
-                             &velocity(i));
-  }
-  // TODO(jadecastro) Consider moving the above autodiffxd_make_coherent() step
-  // to BasicVector().
-  return {lane_direction.lane, lane_position, frame_velocity};
-}
-
-template <typename T>
-T PoseSelector<T>::MakeInfiniteDistance(const PoseVector<T>& ego_pose) {
-  T infinite_distance = std::numeric_limits<T>::infinity();
-  autodiffxd_make_coherent(ego_pose.get_isometry().translation().x(),
-                           &infinite_distance);
-  return infinite_distance;
-}
-
-template <typename T>
-T PoseSelector<T>::CalcLaneProgress(const LaneDirection& lane_direction,
-                                    const LanePositionT<T>& lane_position) {
-  DRAKE_DEMAND(IsWithinDriveable(lane_position, lane_direction.lane));
-  if (lane_direction.with_s) {
-    return lane_position.s();
-  } else {
-    return T(lane_direction.lane->length()) - lane_position.s();
-  }
-}
-
-template <typename T>
-LaneDirection PoseSelector<T>::CalcLaneDirection(
-    const Lane* lane, const LanePositionT<T>& lane_position,
-    const Eigen::Quaternion<T>& rotation, AheadOrBehind side) {
-  // Get the vehicle's heading with respect to the current lane; use it to
-  // determine if the vehicle is facing with or against the lane's canonical
-  // direction.
-  const LanePosition lane_pos =
-      LanePosition(ExtractDoubleOrThrow(lane_position.s()),
-                   ExtractDoubleOrThrow(lane_position.r()),
-                   ExtractDoubleOrThrow(lane_position.h()));
-  const Eigen::Quaternion<T> lane_rotation =
-      lane->GetOrientation(lane_pos).quat();
-  // The dot product of two quaternions is the cosine of half the angle between
-  // the two rotations.  Given two quaternions q₀, q₁ and letting θ be the angle
-  // difference between them, then -π/2 ≤ θ ≤ π/2 iff q₀.q₁ ≥ √2/2.
-  const bool with_s = (side == AheadOrBehind::kAhead)
-                          ? lane_rotation.dot(rotation) >= sqrt(2.) / 2.
-                          : lane_rotation.dot(rotation) < sqrt(2.) / 2.;
-  return LaneDirection(lane, with_s);
+  // TODO(jadecastro) Replace above with the dot product of vel dotted with the
+  // unit vector of the s coordinate, i.e.
+  // (cos β * cos γ, cos β * sin γ, -sin β), where β is pitch and γ is yaw.
 }
 
 }  // namespace automotive

--- a/automotive/pose_selector.h
+++ b/automotive/pose_selector.h
@@ -19,6 +19,10 @@
 namespace drake {
 namespace automotive {
 
+// Assumed ego velocity, used in determining how far ahead to search for traffic
+// cars.
+static constexpr double kEgoSigmaVelocity{1.};
+
 /// ClosestPose bundles together the RoadOdometry of a particular target along
 /// with its distance measure relative to the ego vehicle.  Its intended use is
 /// as the return argument for PoseSelector member functions.
@@ -40,6 +44,10 @@ struct ClosestPose {
 /// current orientation with respect to its lane.
 enum class AheadOrBehind { kAhead = 0, kBehind = 1 };
 
+/// Specifies whether to check ongoing lanes or both ongoing lanes and confluent
+/// branches for traffic.
+enum class ScanStrategy { kBranches, kPath };
+
 /// PoseSelector is a class that provides the relevant pose or poses with
 /// respect to a given ego vehicle driving within a given maliput road geometry.
 ///
@@ -53,24 +61,36 @@ enum class AheadOrBehind { kAhead = 0, kBehind = 1 };
 template <typename T>
 class PoseSelector {
  public:
+  typedef typename std::pair<const T, const maliput::api::LaneEnd>
+  LaneEndDistance;
+
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PoseSelector)
 
   PoseSelector() = delete;
 
-  /// Returns the leading and trailing vehicles in a given @p lane that are
-  /// closest to an ego vehicle (within @p lane or another lane) as measured
-  /// along the `s`-coordinate of the ego vehicle's lane.  The ego vehicle must
-  /// be within the `driveable_bounds` of @p lane (i.e. the road is contiguous
-  /// with @p lane along the `r`-direction).  This function is used, for
-  /// instance, as logic for lane-change planners (e.g. MOBIL).  The ego car's
-  /// pose (@p ego_pose) and the poses of the traffic cars (@p traffic_poses)
-  /// are provided.  The parameter @p scan_distance determines the distance
-  /// along the sequence of lanes to scan before declaring that no traffic car
-  /// is ahead (resp. behind) the ego car.  If no leading/trailing vehicles are
-  /// seen within @p traffic_lane, `s`-positions are taken to be at infinite
-  /// distances away from the ego car.  Traffic vehicles having exactly the same
-  /// s-position as the ego vehicle but situated in a different (parallel) lane
-  /// are taken to be behind the ego vehicle.
+  /// Returns the leading and trailing vehicles in a given @p lane or @p road
+  /// that are closest to an ego vehicle along its path, as measured along the
+  /// `s`-coordinate of the ego vehicle's lane.  If @p path_or_branches is
+  /// ScanStrategy::kPath, only poses in the same path as the ego (ahead or
+  /// behind) are tracked; if ScanStrategy::kBranches, poses in lanes that
+  /// eventually merge (converge to the same branch point that is on the default
+  /// path of @p lane) are considered in addition to those along the ego car's
+  /// default path.
+  ///
+  /// Users should take heed to the fact that ScanStrategy::kBranches does _not_
+  /// assess the relationship between traffic and ego vehicle velocity when
+  /// selecting poses.  Thus, cars with in the same lane as the ego but with
+  /// negative net-velocity (approaching the ego car, from the ego's
+  /// point-of-view) could be ignored in favor of a car in a branch with
+  /// positive net-velocity.
+  ///
+  /// The ego vehicle must be within the `driveable_bounds` of @p lane (i.e. the
+  /// road is contiguous with @p lane along the `r`-direction).  This function
+  /// is used, for instance, as logic for lane-change planners (e.g. MOBIL).
+  /// The ego car's pose (@p ego_pose) and the poses of the traffic cars (@p
+  /// traffic_poses) are provided.  The parameter @p scan_distance determines
+  /// the distance along the sequence of lanes to scan before declaring that no
+  /// traffic car is ahead (resp. behind) the ego car.
   ///
   /// @return A map of AheadOrBehind values to vehicle ClosestPoses (containing
   /// RoadOdometries and closest relative distances).  Relative distances are
@@ -79,7 +99,15 @@ class PoseSelector {
   /// (resp. behind) the ego vehicle, the respective RoadPosition within
   /// ClosestPoses will contain an `s`-value of positive (resp. negative)
   /// infinity.  Any traffic poses that are redunant with `ego_pose` (i.e. have
-  /// the same RoadPosition as the ego car) are discarded.
+  /// the same RoadPosition as the ego car and thus the same `s` and `r` value)
+  /// are discarded.  If no leading/trailing vehicles are seen within
+  /// scan-distance of the ego car, `s`-positions are taken to be at infinite
+  /// distances away from the ego car.  Note also that traffic vehicles having
+  /// exactly the same `s`-position as the ego vehicle but with different
+  /// `r`-value or are directly perpendicular in a Lane::to_left(),
+  /// Lane::to_right() lane are taken to be *behind* the ego vehicle.  Note that
+  /// this implementation is greatly simplified by considering poses as points
+  /// (i.e. vehicle geometries are ignored).
   ///
   /// The RoadGeometry from which @p lane is drawn is required to have default
   /// branches set for all branches in the road network.
@@ -87,23 +115,27 @@ class PoseSelector {
       const maliput::api::Lane* lane,
       const systems::rendering::PoseVector<T>& ego_pose,
       const systems::rendering::PoseBundle<T>& traffic_poses,
-      const T& scan_distance);
+      const T& scan_distance, ScanStrategy path_or_branches);
 
   /// Same as PoseSelector::FindClosestPair() except that it returns a single
   /// ClosestPose for either the vehicle ahead (AheadOrBehind::kAhead) or behind
   /// (AheadOrBehind::kBehind).
   ///
+  /// Cars in other lanes are only tracked if they are in confluent lanes to a
+  /// given branch point within the `scan_distance`; i.e. cars in two
+  /// side-by-side lanes that never enter a branch point will not be selected.
+  /// This assumes that the ego car has knowledge of the traffic cars' default
+  /// lane.
+  ///
   /// Note that when no car is detected in front of the ego car, the returned
   /// RoadOdometry within ClosestPose will contain an `s`-value of
   /// `std::numeric_limits<double>::infinity()`.
-  //
-  // TODO(jadecastro): Generalize this function to find and locate cars that are
-  // in lanes that eventually merge with the ego car's default ongoing lane.
   static ClosestPose<T> FindSingleClosestPose(
       const maliput::api::Lane* lane,
       const systems::rendering::PoseVector<T>& ego_pose,
       const systems::rendering::PoseBundle<T>& traffic_poses,
-      const T& scan_distance, const AheadOrBehind side);
+      const T& scan_distance, const AheadOrBehind side,
+      ScanStrategy path_or_branches);
 
   /// Extracts the vehicle's `s`-direction velocity based on its RoadOdometry @p
   /// road_odometry in the Lane coordinate frame.  Assumes the road has zero
@@ -117,68 +149,6 @@ class PoseSelector {
   // TODO(jadecastro) Enable AutoDiffXd for
   // maliput::api::Lane::GetOrientation().
   static T GetSigmaVelocity(const RoadOdometry<T>& road_odometry);
-
-  /// Returns `true` if and only if @p lane_position is within the longitudinal
-  /// (s), driveable (r) and elevation (h) bounds of the specified @p lane
-  /// (i.e. within `lane->driveable_bounds()` and `lane->elevation_bounds()`).
-  static bool IsWithinDriveable(
-      const maliput::api::LanePositionT<T>& lane_position,
-      const maliput::api::Lane* lane);
-
-  /// Returns `true` if and only if @p geo_position is within the longitudinal
-  /// (s), lateral (r) and elevation (h) bounds of the specified @p lane
-  /// (i.e. within `lane->lane_bounds()` and `lane->elevation_bounds()`).
-  static bool IsWithinLane(const maliput::api::GeoPositionT<T>& geo_position,
-                           const maliput::api::Lane* lane);
-
-  /// Returns `true` if and only if @p lane_position is within the driveable
-  /// bounds of @p lane and, in addition, `r` is within its lane bounds.
-  static bool IsWithinLane(const maliput::api::LanePositionT<T>& lane_position,
-                           const maliput::api::Lane* lane);
-
- private:
-  // Given a @p lane_direction, returns its default branch and updates @p
-  // lane_direction to match the `lane` and `with_s` of that branch.  If there
-  // is no default branch, returns `nullopt` and sets `lane_direction->lane` to
-  // `nullptr`.
-  static optional<maliput::api::LaneEnd> GetDefaultOngoingLane(
-      LaneDirection* lane_direction);
-
-  // Returns a RoadOdometry that contains an infinite `s` position, zero `r` and
-  // `h` positions, and zero velocities. If @p lane_direction contains `with_s
-  // == True`, a RoadOdometry containing an s-position at positive infinity is
-  // returned; otherwise a negative-infinite position is returned.  For T =
-  // AutoDiffXd, the derivatives of the returned RoadOdometry are made to be
-  // coherent with respect to @p ego_pose.
-  static RoadOdometry<T> MakeInfiniteOdometry(
-      const LaneDirection& lane_direction,
-      const systems::rendering::PoseVector<T>& ego_pose);
-
-  // Returns positive infinity. For T = AutoDiffXd, the derivatives of the
-  // the return value are made to be coherent with respect to @p ego_pose.
-  static T MakeInfiniteDistance(
-      const systems::rendering::PoseVector<T>& ego_pose);
-
-  // Returns the distance (along the `s`-coordinate) from an end of a lane to a
-  // @p lane_position in that lane, where the end is determined by the `with_s`
-  // of the provided `lane_direction`.  Both `lane` and `with_s` are specified
-  // in @p lane_direction.  Throws if any element of @p lane_position is not
-  // within the respective bounds of `lane_direction.lane`.
-  static T CalcLaneProgress(
-      const LaneDirection& lane_direction,
-      const maliput::api::LanePositionT<T>& lane_position);
-
-  // Constructs a LaneDirection structure based on a vehicle's current @p lane,
-  // @p lane_position, @p rotation (in global coordinates), and the @p side of
-  // the car (ahead or behind) that traffic is being observed.  Note that
-  // `LaneDirection::with_s` in the return argument is interpreted as the
-  // direction along which targets are being observed (regardless of the ego
-  // car's orientation): it is true if cars are being observed along the
-  // `s`-direction and is false otherwise.
-  static LaneDirection CalcLaneDirection(
-      const maliput::api::Lane* lane,
-      const maliput::api::LanePositionT<T>& lane_position,
-      const Eigen::Quaternion<T>& rotation, AheadOrBehind side);
 };
 
 }  // namespace automotive

--- a/automotive/test/automotive_simulator_test.cc
+++ b/automotive/test/automotive_simulator_test.cc
@@ -185,9 +185,11 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   simple_car_state.set_x(2);
   simple_car_state.set_y(-2);
   simple_car_state.set_velocity(10);
-  const int id_mobil = simulator->AddMobilControlledSimpleCar(
-      "mobil", true /* with_s */, RoadPositionStrategy::kExhaustiveSearch,
-      0. /* time period (unused) */, simple_car_state);
+  const int id_mobil =
+      simulator->AddMobilControlledSimpleCar(
+          "mobil", true /* with_s */, ScanStrategy::kPath,
+          RoadPositionStrategy::kExhaustiveSearch,
+          0. /* time period (unused) */, simple_car_state);
   EXPECT_EQ(id_mobil, 0);
 
   MaliputRailcarState<double> decoy_state;
@@ -397,12 +399,13 @@ std::unique_ptr<AutomotiveSimulator<double>> MakeWithIdmCarAndDecoy(
   // Expect to throw when given a nullptr Lane.
   EXPECT_THROW(simulator->AddIdmControlledCar(
       "idm_car", true /* with_s */, initial_state, nullptr,
-      RoadPositionStrategy::kExhaustiveSearch, 0. /* time period (unused) */),
-               std::runtime_error);
+      ScanStrategy::kPath, RoadPositionStrategy::kExhaustiveSearch,
+      0. /* time period (unused) */), std::runtime_error);
 
   int id_idm_car{};
   EXPECT_NO_THROW(id_idm_car = simulator->AddIdmControlledCar(
       "idm_car", true /* with_s */, initial_state, goal_lane,
+      ScanStrategy::kPath,
       RoadPositionStrategy::kExhaustiveSearch, 0. /* time period (unused) */));
   EXPECT_EQ(id_idm_car, 0);
 
@@ -693,11 +696,13 @@ GTEST_TEST(AutomotiveSimulatorTest, TestIdmControllerUniqueName) {
           std::numeric_limits<double>::epsilon() /* angular_tolerance */));
   simulator->AddIdmControlledPriusMaliputRailcar(
       "Alice", LaneDirection(road->junction(0)->segment(0)->lane(0)),
-      RoadPositionStrategy::kExhaustiveSearch, 0. /* time period (unused) */,
+      ScanStrategy::kPath, RoadPositionStrategy::kExhaustiveSearch,
+      0. /* time period (unused) */,
       params, MaliputRailcarState<double>() /* initial state */);
   simulator->AddIdmControlledPriusMaliputRailcar(
       "Bob", LaneDirection(road->junction(0)->segment(0)->lane(0)),
-      RoadPositionStrategy::kExhaustiveSearch, 0. /* time period (unused) */,
+      ScanStrategy::kPath, RoadPositionStrategy::kExhaustiveSearch,
+      0. /* time period (unused) */,
       params, MaliputRailcarState<double>() /* initial state */);
 
   EXPECT_NO_THROW(simulator->Start());
@@ -726,8 +731,9 @@ GTEST_TEST(AutomotiveSimulatorTest, TestRailcarVelocityOutput) {
       alice_initial_state);
   const int bob_id = simulator->AddIdmControlledPriusMaliputRailcar("Bob",
       LaneDirection(road->junction(0)->segment(0)->lane(0)),
-      RoadPositionStrategy::kExhaustiveSearch, 0. /* time period (unused) */,
-      params, MaliputRailcarState<double>() /* initial state */);
+      ScanStrategy::kPath, RoadPositionStrategy::kExhaustiveSearch,
+      0. /* time period (unused) */, params,
+      MaliputRailcarState<double>() /* initial state */);
 
   EXPECT_NO_THROW(simulator->Start());
 

--- a/automotive/test/pose_selector_test.cc
+++ b/automotive/test/pose_selector_test.cc
@@ -6,6 +6,8 @@
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/maliput/monolane/builder.h"
+#include "drake/automotive/maliput/monolane/road_geometry.h"
+#include "drake/automotive/monolane_onramp_merge.h"
 #include "drake/common/extract_double.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/roll_pitch_yaw_using_quaternion.h"
@@ -15,15 +17,25 @@ namespace automotive {
 namespace {
 
 using maliput::api::GeoPosition;
+using maliput::api::HBounds;
+using maliput::api::Lane;
 using maliput::api::LaneEnd;
+using maliput::api::LanePosition;
+using maliput::api::RBounds;
 using maliput::api::RoadPosition;
+using maliput::api::Rotation;
+using maliput::monolane::ArcOffset;
 using maliput::monolane::Builder;
 using maliput::monolane::Connection;
 using maliput::monolane::Endpoint;
+using maliput::monolane::EndpointXy;
+using maliput::monolane::EndpointZ;
 using math::RollPitchYawToQuaternion;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 using systems::rendering::PoseBundle;
+
+constexpr double infty = std::numeric_limits<double>::infinity();
 
 // Constants for Dragway tests.
 constexpr double kDragwayLaneLength{100.};
@@ -51,6 +63,17 @@ constexpr double kRoadSegmentLength{15.};
 
 // Specifies zero elevation/super-elevation.
 const maliput::monolane::EndpointZ kEndZ{0., 0., 0., 0.};
+
+static const Lane* GetLaneByLaneId(
+    const maliput::api::RoadGeometry& road, const std::string& lane_id) {
+  for (int i = 0; i < road.num_junctions(); ++i) {
+    const Lane* lane = road.junction(i)->segment(0)->lane(0);
+    if (lane->id().string() == lane_id) {
+      return lane;
+    }
+  }
+  throw std::runtime_error("No matching junction name in the road network");
+}
 
 class PoseSelectorDragwayTest : public ::testing::Test {
  protected:
@@ -108,7 +131,7 @@ static void SetDefaultDragwayPoses(PoseVector<T>* ego_pose,
                           Isometry3<T>(translation_far_behind));
 }
 
-static void SetDefaultDragwayPoseDerivatives(
+static void SetDefaultDerivatives(
     PoseVector<AutoDiffXd>* ego_pose, PoseBundle<AutoDiffXd>* traffic_poses) {
   Eigen::Translation<AutoDiffXd, 3> ego_translation =
       ego_pose->get_translation();
@@ -160,8 +183,8 @@ static void SetPoses(const T& s_offset, const T& r_offset,
 
 // Returns the lane in the road associated with the provided pose.
 template <typename T>
-const maliput::api::Lane* get_lane(const PoseVector<T>& pose,
-                                   const maliput::api::RoadGeometry& road) {
+const Lane* get_lane(const PoseVector<T>& pose,
+                     const maliput::api::RoadGeometry& road) {
   const GeoPosition geo_position{
       ExtractDoubleOrThrow(pose.get_translation().x()),
       ExtractDoubleOrThrow(pose.get_translation().y()),
@@ -184,7 +207,8 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
                                               ego_pose, traffic_poses,
-                                              scan_ahead_distance);
+                                              scan_ahead_distance,
+                                              ScanStrategy::kPath);
 
     // Verifies that the ego car and traffic cars are on the road and that the
     // correct leading and trailing cars are identified.
@@ -202,7 +226,7 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
   const ClosestPose<double>& closest_pose =
       PoseSelector<double>::FindSingleClosestPose(
           get_lane(ego_pose, *road_), ego_pose, traffic_poses,
-          scan_ahead_distance, AheadOrBehind::kAhead);
+          scan_ahead_distance, AheadOrBehind::kAhead, ScanStrategy::kPath);
   EXPECT_EQ(kJustAheadSPosition, closest_pose.odometry.pos.s());
   EXPECT_EQ(kJustAheadSPosition - kEgoSPosition, closest_pose.distance);
   {
@@ -210,17 +234,14 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(
             get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            scan_ahead_distance);
+            scan_ahead_distance, ScanStrategy::kPath);
 
     // Expect to see no cars in the left lane.
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
-    EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(-infty,
               closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).distance);
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kBehind).distance);
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kBehind).distance);
   }
 
   // Bump the "just ahead" car into the lane to the left.
@@ -232,7 +253,8 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
                                               ego_pose, traffic_poses,
-                                              scan_ahead_distance);
+                                              scan_ahead_distance,
+                                              ScanStrategy::kPath);
 
     // Expect the "far ahead" car to be identified and with the correct speed.
     EXPECT_EQ(kFarAheadSPosition,
@@ -263,13 +285,12 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
                                               ego_pose, traffic_poses,
-                                              scan_ahead_distance);
+                                              scan_ahead_distance,
+                                              ScanStrategy::kPath);
 
     // Looking forward, we expect there to be no car in sight.
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).distance);
     for (int i = 0; i < 6; ++i) {
       EXPECT_EQ(0., closest_poses.at(AheadOrBehind::kAhead).odometry.vel[i]);
       // N.B. Defaults to zero velocity.
@@ -281,17 +302,48 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragway) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(
             get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            scan_ahead_distance);
+            scan_ahead_distance, ScanStrategy::kPath);
 
     // Expect there to be no car behind on the immediate left and the "just
     // ahead" car to be leading.
     EXPECT_EQ(kJustAheadSPosition,
               closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
-    EXPECT_EQ(-std::numeric_limits<double>::infinity(),
+    EXPECT_EQ(-infty,
               closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
     EXPECT_EQ(kJustAheadSPosition - kEgoSPosition,
               closest_poses.at(AheadOrBehind::kAhead).distance);
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kBehind).distance);
+  }
+}
+
+// Verifies the result when using the analogous branch checking functions.
+TEST_F(PoseSelectorDragwayTest, TwoLaneDragwayCheckBranches) {
+  MakeDragway(2 /* num lanes */, kDragwayLaneLength);
+
+  PoseVector<double> ego_pose;
+  PoseBundle<double> traffic_poses(kNumDragwayTrafficCars);
+
+  // Define the default poses.
+  SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
+
+  // Choose a scan-ahead distance shorter than the lane length.
+  const double scan_ahead_distance = kDragwayLaneLength / 2.;
+  {
+    const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+        PoseSelector<double>::FindClosestPair(
+            get_lane(ego_pose, *road_), ego_pose, traffic_poses,
+            scan_ahead_distance, ScanStrategy::kBranches);
+
+    // Verifies that the ego car and traffic cars are on the road and that the
+    // correct leading and trailing cars are identified within the path of the
+    // ego.
+    EXPECT_EQ(kJustAheadSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(kJustBehindSPosition,
+              closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
+    EXPECT_EQ(kJustAheadSPosition - kEgoSPosition,
+              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(kEgoSPosition - kJustBehindSPosition,
               closest_poses.at(AheadOrBehind::kBehind).distance);
   }
 }
@@ -304,7 +356,7 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragwayAutoDiff) {
 
   // Define the default poses.
   SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
-  SetDefaultDragwayPoseDerivatives(&ego_pose, &traffic_poses);
+  SetDefaultDerivatives(&ego_pose, &traffic_poses);
 
   // Choose a scan-ahead distance shorter than the lane length.
   const AutoDiffXd scan_ahead_distance(kDragwayLaneLength / 2.);
@@ -312,7 +364,8 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragwayAutoDiff) {
     const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
         PoseSelector<AutoDiffXd>::FindClosestPair(get_lane(ego_pose, *road_),
                                                   ego_pose, traffic_poses,
-                                                  scan_ahead_distance);
+                                                  scan_ahead_distance,
+                                                  ScanStrategy::kPath);
 
     // Verifies that the correct leading and trailing cars are identified, and
     // that their derivatives are correct.
@@ -358,7 +411,7 @@ TEST_F(PoseSelectorDragwayTest, TwoLaneDragwayAutoDiff) {
     const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
         PoseSelector<AutoDiffXd>::FindClosestPair(
             get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            scan_ahead_distance);
+            scan_ahead_distance, ScanStrategy::kPath);
 
     // Expect there to be no car behind on the immediate left and the "just
     // ahead" car to be leading.
@@ -418,7 +471,8 @@ TEST_F(PoseSelectorDragwayTest, EgoOrientation) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(get_lane(ego_pose, *road_),
                                               ego_pose, traffic_poses,
-                                              scan_ahead_distance);
+                                              scan_ahead_distance,
+                                              ScanStrategy::kPath);
 
     // Expect the correct result independent of the ego vehicle's orientation.
     const bool is_with_s = yaw > -M_PI / 2. && yaw < M_PI / 2.;
@@ -455,13 +509,11 @@ TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoad) {
   const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
       PoseSelector<double>::FindClosestPair(
           get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-          scan_ahead_distance);
+          scan_ahead_distance, ScanStrategy::kPath);
 
   // Expect infinite distances.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kAhead).distance);
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kBehind).distance);
+  EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).distance);
+  EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kBehind).distance);
 }
 
 TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoadAutoDiff) {
@@ -475,7 +527,7 @@ TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoadAutoDiff) {
 
   // Define the default poses.
   SetDefaultDragwayPoses(&ego_pose, &traffic_poses);
-  SetDefaultDragwayPoseDerivatives(&ego_pose, &traffic_poses);
+  SetDefaultDerivatives(&ego_pose, &traffic_poses);
 
   // Choose a scan-ahead distance greater than the lane length.
   const AutoDiffXd scan_ahead_distance(kShortLaneLength + 10.);
@@ -487,14 +539,12 @@ TEST_F(PoseSelectorDragwayTest, NoCarsOnShortRoadAutoDiff) {
   const std::map<AheadOrBehind, const ClosestPose<AutoDiffXd>> closest_poses =
       PoseSelector<AutoDiffXd>::FindClosestPair(
           get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-          scan_ahead_distance);
+          scan_ahead_distance, ScanStrategy::kPath);
 
   // Expect distances to have infinite value and zero derivatives in both the
   // ahead and behind directions.
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kAhead).distance);
-  EXPECT_EQ(std::numeric_limits<double>::infinity(),
-            closest_poses.at(AheadOrBehind::kBehind).distance);
+  EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).distance);
+  EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kBehind).distance);
   EXPECT_TRUE(CompareMatrices(
       Vector3<double>(0., 0., 0.),
       closest_poses.at(AheadOrBehind::kAhead).distance.derivatives()));
@@ -522,7 +572,7 @@ TEST_F(PoseSelectorDragwayTest, IdenticalSValues) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(
             get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            1000. /* scan_ahead_distance */);
+            1000. /* scan_ahead_distance */, ScanStrategy::kPath);
 
     // Verifies that, if the cars are side-by-side, then the traffic car is
     // classified as a trailing car (and not the leading car).
@@ -546,13 +596,12 @@ TEST_F(PoseSelectorDragwayTest, IdenticalSValues) {
     const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
         PoseSelector<double>::FindClosestPair(
             get_lane(ego_pose, *road_)->to_left(), ego_pose, traffic_poses,
-            kDragwayLaneLength / 2. /* scan_ahead_distance */);
+            kDragwayLaneLength / 2. /* scan_ahead_distance */,
+            ScanStrategy::kPath);
 
     // Verifies that no traffic car is seen ahead.
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
-    EXPECT_EQ(std::numeric_limits<double>::infinity(),
-              closest_poses.at(AheadOrBehind::kAhead).distance);
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).odometry.pos.s());
+    EXPECT_EQ(infty, closest_poses.at(AheadOrBehind::kAhead).distance);
     EXPECT_EQ(kEgoSPosition,
               closest_poses.at(AheadOrBehind::kBehind).odometry.pos.s());
     EXPECT_EQ(0., closest_poses.at(AheadOrBehind::kBehind).distance);
@@ -571,7 +620,7 @@ TEST_F(PoseSelectorDragwayTest, TestGetSigmaVelocity) {
                std::runtime_error);
 
   // Set a valid lane.
-  const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
+  const Lane* lane = road_->junction(0)->segment(0)->lane(0);
   RoadPosition position(lane, maliput::api::LanePosition(0., 0., 0.));
 
   // Expect the s-velocity to be zero.
@@ -603,12 +652,9 @@ TEST_F(PoseSelectorDragwayTest, TestGetSigmaVelocity) {
 std::unique_ptr<const maliput::api::RoadGeometry> MakeThreeSegmentMonolaneRoad(
     bool is_opposing) {
   Builder builder(
-      maliput::api::RBounds(-std::abs(kEgoRPosition) - 2.,
-                            std::abs(kEgoRPosition) + 2.) /* lane_bounds */,
-      maliput::api::RBounds(
-          -std::abs(kEgoRPosition) - 2.,
-          std::abs(kEgoRPosition) + 2.) /* driveable_bounds */,
-      maliput::api::HBounds(0., 5.) /* elevation bounds */,
+      RBounds(-std::abs(kEgoRPosition) - 2., std::abs(kEgoRPosition) + 2.),
+      RBounds(-std::abs(kEgoRPosition) - 2., std::abs(kEgoRPosition) + 2.),
+      HBounds(0., 5.) /* elevation bounds */,
       0.01 /* linear tolerance */, 0.01 /* angular_tolerance */);
   const Connection* c0 = builder.Connect(
       "0_fwd" /* id */, Endpoint({0., 0., 0.}, kEndZ) /* start */,
@@ -674,7 +720,8 @@ GTEST_TEST(PoseSelectorTest, MultiSegmentRoad) {
       const ClosestPose<double> closest_pose_ahead =
           PoseSelector<double>::FindSingleClosestPose(
               get_lane(ego_pose, *road), ego_pose, traffic_poses,
-              scan_ahead_distance, AheadOrBehind::kAhead);
+              scan_ahead_distance, AheadOrBehind::kAhead,
+              ScanStrategy::kBranches);
 
       // Expect the detected distance to be the offset distance.
       EXPECT_EQ(s_offset, closest_pose_ahead.distance);
@@ -687,11 +734,302 @@ GTEST_TEST(PoseSelectorTest, MultiSegmentRoad) {
       const ClosestPose<double> closest_pose_behind =
           PoseSelector<double>::FindSingleClosestPose(
               get_lane(ego_pose, *road), ego_pose, traffic_poses,
-              scan_ahead_distance, AheadOrBehind::kBehind);
+              scan_ahead_distance, AheadOrBehind::kBehind, ScanStrategy::kPath);
 
       // Expect the detected distance to be the offset distance.
       EXPECT_EQ(s_offset, closest_pose_behind.distance);
     }
+  }
+}
+
+// Construct a monolane road with three confluent feeder lanes correponding to
+// three distinct branch points.
+std::unique_ptr<const maliput::api::RoadGeometry> BuildOnrampRoad() {
+  std::unique_ptr<Builder> rb(
+      new Builder(RBounds(-2., 2.) /* lane bounds */,
+                  RBounds(-4., 4.) /* driveable bounds */,
+                  HBounds(0., 5.) /* elevation bounds */,
+                  0.01 /* linear tolerance */, 0.01 /* angular_tolerance */));
+
+  // Initialize the road from the origin.
+  const EndpointXy kOriginXy{0., 0., 0.};
+  const EndpointZ kFlatZ{0., 0., 0., 0.};
+  const Endpoint kRoadOrigin{kOriginXy, kFlatZ};
+
+  const double kArcRadius = 25.;
+  const double kArcLength = 40.;
+  const auto& lane6 = rb->Connect(
+      "lane6", kRoadOrigin,
+      ArcOffset(kArcRadius, -kArcLength / kArcRadius), kFlatZ);
+  const auto& lane5 = rb->Connect(
+      "lane5", lane6->end(),
+      ArcOffset(kArcRadius, kArcLength / kArcRadius), kFlatZ);
+  const auto& lane4 = rb->Connect(
+      "lane4", lane5->end(),
+      ArcOffset(kArcRadius, -kArcLength / kArcRadius), kFlatZ);
+  const auto& lane3 = rb->Connect(
+      "lane3", lane4->end(),
+      ArcOffset(kArcRadius, kArcLength / kArcRadius), kFlatZ);
+  const auto& lane2 = rb->Connect(
+      "lane2", lane3->end(),
+      ArcOffset(kArcRadius, -kArcLength / kArcRadius), kFlatZ);
+  const auto& lane1 = rb->Connect(
+      "lane1", lane2->end(),
+      ArcOffset(kArcRadius, kArcLength / kArcRadius), kFlatZ);
+  const double& kLinearLength = 100.;
+  const auto& lane0 =
+      rb->Connect("lane0", lane1->end(), kLinearLength, kFlatZ);
+
+  // Construct the three branches (working backwards from each branch point).
+  const double& kBranchArcRadius = 35.;
+  const double& kBranchArcLength = 50.;
+  const double& kBranchLinearLength = 100.;
+  const auto& b0_lane1 = rb->Connect(
+      "b0_lane1", lane1->end(),
+      ArcOffset(kBranchArcRadius, kBranchArcLength / kBranchArcRadius), kFlatZ);
+  const auto& b0_lane0 =
+      rb->Connect("b0_lane0", b0_lane1->end(), kBranchLinearLength, kFlatZ);
+  const auto& b1_lane1 = rb->Connect(
+      "b1_lane1", lane3->end(),
+      ArcOffset(kBranchArcRadius, kBranchArcLength / kBranchArcRadius), kFlatZ);
+  const auto& b1_lane0 =
+      rb->Connect("b1_lane0", b1_lane1->end(), kBranchLinearLength, kFlatZ);
+  const auto& b2_lane1 = rb->Connect(
+      "b2_lane1", lane5->end(),
+      ArcOffset(kBranchArcRadius, kBranchArcLength / kBranchArcRadius), kFlatZ);
+  const auto& b2_lane0 =
+      rb->Connect("b2_lane0", b2_lane1->end(), kBranchLinearLength, kFlatZ);
+
+  // Manually specify the default branches for all junctions in the road.
+  rb->SetDefaultBranch(lane0, LaneEnd::kStart, lane1, LaneEnd::kFinish);
+  rb->SetDefaultBranch(lane1, LaneEnd::kStart, lane2, LaneEnd::kFinish);
+  rb->SetDefaultBranch(lane2, LaneEnd::kStart, lane3, LaneEnd::kFinish);
+  rb->SetDefaultBranch(lane3, LaneEnd::kStart, lane4, LaneEnd::kFinish);
+  rb->SetDefaultBranch(lane4, LaneEnd::kStart, lane5, LaneEnd::kFinish);
+  rb->SetDefaultBranch(lane5, LaneEnd::kStart, lane6, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b0_lane1, LaneEnd::kStart, lane1, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b0_lane0, LaneEnd::kStart, b0_lane1, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b1_lane1, LaneEnd::kStart, lane3, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b1_lane0, LaneEnd::kStart, b1_lane1, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b2_lane1, LaneEnd::kStart, lane5, LaneEnd::kFinish);
+  rb->SetDefaultBranch(b2_lane0, LaneEnd::kStart, b2_lane1, LaneEnd::kFinish);
+
+  return rb->Build(maliput::api::RoadGeometryId{"three_feeder_lanes"});
+}
+
+enum class LanePolarity { kWithS, kAgainstS };
+
+// Appends a traffic car's pose to the provided traffic_poses.
+static void AddToTrafficPosesAt(int index,
+                                const Lane* traffic_lane,
+                                double traffic_s_position,
+                                double traffic_speed,
+                                LanePolarity traffic_polarity,
+                                PoseBundle<double>* traffic_poses) {
+  Eigen::Isometry3d isometry = Eigen::Isometry3d::Identity();
+  const LanePosition srh{traffic_s_position, 0., 0.};
+  const GeoPosition traffic_xyz = traffic_lane->ToGeoPosition(srh);
+  const Eigen::Vector3d translation_ahead(
+      traffic_xyz.x(), traffic_xyz.y(), traffic_xyz.z());
+  isometry.translate(translation_ahead);
+
+  const Rotation traffic_rotation =
+      traffic_lane->GetOrientation(srh);
+  Vector3<double> rpy = traffic_rotation.rpy();
+  rpy.x() = (traffic_polarity == LanePolarity::kWithS) ? rpy.x() : -rpy.x();
+  rpy.y() = (traffic_polarity == LanePolarity::kWithS) ? rpy.y() : -rpy.y();
+  rpy.z() -= (traffic_polarity == LanePolarity::kWithS) ? 0. : M_PI;
+  isometry.rotate(RollPitchYawToQuaternion(rpy));
+
+  traffic_poses->set_pose(index, isometry);
+
+  FrameVelocity<double> velocity_ahead{};
+  velocity_ahead.get_mutable_value().head(3) =
+      Vector3<double>::Zero();  /* ω */
+  const Eigen::Matrix3d traffic_rotmat = math::rpy2rotmat(rpy);
+  velocity_ahead.get_mutable_value().tail(3) =
+      traffic_speed * traffic_rotmat.leftCols(1);  /* v */
+  traffic_poses->set_velocity(index, velocity_ahead);
+}
+
+static void SetDefaultOnrampPoses(const Lane* ego_lane,
+                                  const Lane* traffic_lane,
+                                  double traffic_speed,
+                                  double ego_speed,
+                                  PoseVector<double>* ego_pose,
+                                  FrameVelocity<double>* ego_velocity,
+                                  PoseBundle<double>* traffic_poses,
+                                  LanePolarity ego_polarity,
+                                  LanePolarity traffic_polarity) {
+  // Set the ego vehicle at s = 1. in the ego_lane.
+  const LanePosition srh_near_start{1., 0., 0.};
+  const GeoPosition ego_xyz = ego_lane->ToGeoPosition(srh_near_start);
+  ego_pose->set_translation(
+      Eigen::Translation3d(ego_xyz.x(), ego_xyz.y(), ego_xyz.z()));
+  const Rotation ego_rotation = ego_lane->GetOrientation(srh_near_start);
+  const double ego_roll = (ego_polarity == LanePolarity::kWithS) ?
+      ego_rotation.roll() : -ego_rotation.roll();
+  const double ego_pitch = (ego_polarity == LanePolarity::kWithS) ?
+      ego_rotation.pitch() : -ego_rotation.pitch();
+  const double ego_yaw =
+      ego_rotation.yaw() - ((ego_polarity == LanePolarity::kWithS) ? 0. : M_PI);
+  const Rotation new_rotation = Rotation::FromRpy(ego_roll, ego_pitch, ego_yaw);
+  ego_pose->set_rotation(RollPitchYawToQuaternion(new_rotation.rpy()));
+
+  const Eigen::Matrix3d ego_rotmat = math::rpy2rotmat(new_rotation.rpy());
+  drake::Vector6<double> velocity{};
+  velocity.head(3) = Vector3<double>::Zero();             /* ω */
+  velocity.tail(3) = ego_speed * ego_rotmat.leftCols(1);  /* v */
+  ego_velocity->set_velocity(multibody::SpatialVelocity<double>(velocity));
+
+  // Set the traffic car at s = Lane::length() - 1 in the traffic_lane.
+  AddToTrafficPosesAt(0, traffic_lane, traffic_lane->length() - 1.,
+                      traffic_speed, traffic_polarity, traffic_poses);
+}
+
+using Cases = std::map<LanePolarity, std::pair<AheadOrBehind, AheadOrBehind>>;
+
+void CheckOnrampPosesInBranches(const maliput::api::RoadGeometry& road,
+                                const PoseVector<double>& ego_pose,
+                                const PoseBundle<double>& traffic_poses,
+                                std::string expected_traffic_lane,
+                                double expected_s_position,
+                                double expected_distance,
+                                LanePolarity ego_polarity,
+                                const Cases& ego_cases) {
+  const GeoPosition ego_geo_position{ego_pose.get_translation().x(),
+        ego_pose.get_translation().y(),
+        ego_pose.get_translation().z()};
+  const RoadPosition& ego_position =
+      road.ToRoadPosition(ego_geo_position, nullptr, nullptr, nullptr);
+
+  ClosestPose<double> closest_pose_leading =
+      PoseSelector<double>::FindSingleClosestPose(
+          ego_position.lane, ego_pose, traffic_poses,
+          1000. /* scan_ahead_distance */, ego_cases.at(ego_polarity).first,
+          ScanStrategy::kBranches);
+
+  // Verifies that we are on the road and that the correct car was identified.
+  EXPECT_EQ(expected_traffic_lane,
+            closest_pose_leading.odometry.lane->id().string());
+  if (expected_distance == infty) {
+    EXPECT_EQ(-infty, closest_pose_leading.odometry.pos.s());
+    EXPECT_EQ(infty, closest_pose_leading.distance);
+  } else {
+    EXPECT_NEAR(expected_s_position, closest_pose_leading.odometry.pos.s(),
+                1e-6);
+    EXPECT_NEAR(expected_distance, closest_pose_leading.distance, 1e-6);
+  }
+
+  const std::map<AheadOrBehind, const ClosestPose<double>> closest_poses =
+      PoseSelector<double>::FindClosestPair(
+          ego_position.lane, ego_pose, traffic_poses,
+          1000. /* scan_ahead_distance */, ScanStrategy::kBranches);
+
+  // Verifies that the kAhead closest pose agrees with closest_pose_leading.
+  const AheadOrBehind ego_view_1 = ego_cases.at(ego_polarity).first;
+  EXPECT_EQ(closest_pose_leading.odometry.lane->id(),
+            closest_poses.at(ego_view_1).odometry.lane->id());
+  EXPECT_EQ(closest_pose_leading.odometry.pos.s(),
+            closest_poses.at(ego_view_1).odometry.pos.s());
+  EXPECT_EQ(closest_pose_leading.distance,
+            closest_poses.at(ego_view_1).distance);
+  // Verifies that the kBehind closest pose is infinity in the ego car's lane.
+  const AheadOrBehind ego_view_2 = ego_cases.at(ego_polarity).second;
+  EXPECT_EQ(ego_position.lane->id(),
+            closest_poses.at(ego_view_2).odometry.lane->id());
+  EXPECT_EQ(infty, closest_poses.at(ego_view_2).odometry.pos.s());
+  EXPECT_EQ(infty, closest_poses.at(ego_view_2).distance);
+
+  // TODO(jadecastro) Include tests at various velocities.
+}
+
+GTEST_TEST(PoseSelectorOnrampTest, CheckBranches) {
+  const auto road = BuildOnrampRoad();
+
+  PoseVector<double> ego_pose;
+  FrameVelocity<double> ego_velocity;
+  PoseBundle<double> traffic_poses(1);
+
+  struct TestCase {
+    std::string ego_lane;
+    std::string traffic_lane;
+    LanePolarity traffic_orientation;
+    double expected_distance;
+    std::string expected_traffic_lane;
+  };
+  const std::vector<TestCase> test_cases{
+    {"l:b0_lane0", "l:lane6", LanePolarity::kWithS, 252., "l:lane6"},
+    {"l:b0_lane0", "l:lane0", LanePolarity::kWithS, infty, "l:b0_lane0"},
+    {"l:b1_lane0", "l:lane2", LanePolarity::kAgainstS, 12., "l:lane2"},
+    {"l:b1_lane0", "l:lane2", LanePolarity::kWithS, infty, "l:b1_lane0"},
+    {"l:b2_lane0", "l:lane4", LanePolarity::kAgainstS, 12., "l:lane4"},
+    {"l:b2_lane0", "l:lane4", LanePolarity::kWithS, infty, "l:b2_lane0"},
+    {"l:lane0", "l:b0_lane0", LanePolarity::kAgainstS, infty, "l:lane0"},
+    {"l:lane0", "l:b1_lane0", LanePolarity::kAgainstS, infty, "l:lane0"},
+    {"l:lane0", "l:b1_lane1", LanePolarity::kAgainstS, 32., "l:b1_lane1"},
+    {"l:lane0", "l:b2_lane0", LanePolarity::kAgainstS, 12., "l:b2_lane0"},
+    {"l:lane0", "l:b2_lane1", LanePolarity::kAgainstS, 112., "l:b2_lane1"},
+    {"l:lane1", "l:b2_lane1", LanePolarity::kAgainstS, 72., "l:b2_lane1"},
+  };
+
+  // Define appropriate tests based on the ego car's LanePolarity.
+  Cases ego_cases;
+  ego_cases[LanePolarity::kWithS] =
+      std::make_pair(AheadOrBehind::kBehind, AheadOrBehind::kAhead);
+  ego_cases[LanePolarity::kAgainstS] =
+      std::make_pair(AheadOrBehind::kAhead, AheadOrBehind::kBehind);
+
+  for (const auto& it : test_cases) {
+    const Lane* traffic_lane = GetLaneByLaneId(*road, it.traffic_lane);
+    for (const auto ego_polarity :
+         {LanePolarity::kWithS, LanePolarity::kAgainstS}) {
+      SetDefaultOnrampPoses(GetLaneByLaneId(*road, it.ego_lane),
+                            traffic_lane, 10. /* traffic_speed */,
+                            10. /* ego_speed */, &ego_pose, &ego_velocity,
+                            &traffic_poses, ego_polarity,
+                            it.traffic_orientation);
+      // TODO(jadecastro) Include additional unit tests at varying ego/traffic
+      // speeds once the code accepts externally-defined ego velocities.
+      CheckOnrampPosesInBranches(*road, ego_pose, traffic_poses,
+                                 it.expected_traffic_lane,
+                                 traffic_lane->length() - 1.,
+                                     /* expected s-position */
+                                 it.expected_distance, ego_polarity, ego_cases);
+    }
+  }
+
+  // Checks that behavior is as expected when two traffic cars are introduced.
+  PoseBundle<double> two_traffic_poses(2);
+  const TestCase test_case = test_cases[2];  // Ego in b1_lane0, Traffic in
+                                             // lane2, facing kAgainstS.
+  const Lane* traffic_lane = GetLaneByLaneId(*road, test_case.traffic_lane);
+  for (const auto ego_polarity :
+    {LanePolarity::kWithS, LanePolarity::kAgainstS}) {
+    SetDefaultOnrampPoses(GetLaneByLaneId(*road, test_case.ego_lane),
+                          traffic_lane, 10. /* traffic speed */,
+                          10. /* ego_speed */, &ego_pose, &ego_velocity,
+                          &two_traffic_poses, ego_polarity,
+                          test_case.traffic_orientation);
+
+    // Add an additional car in b1_lane1, closer to the branch point than the
+    // ego, and further than 12 meters from the ego.
+    const Lane* other_traffic_lane = GetLaneByLaneId(*road, "l:b1_lane1");
+    AddToTrafficPosesAt(1, other_traffic_lane,
+                        10. /* other traffic s-position */,
+                        10. /* other traffic speed */,
+                        LanePolarity::kWithS, &two_traffic_poses);
+
+    // Expect the traffic car in the branch lane to be selected (it is further
+    // from the merge-point).
+    const Lane* expected_lane =
+        GetLaneByLaneId(*road, test_case.expected_traffic_lane);
+    CheckOnrampPosesInBranches(*road, ego_pose, two_traffic_poses,
+                               test_case.expected_traffic_lane,
+                               expected_lane->length() - 1.,
+                                   /* expected s-position */
+                               test_case.expected_distance, ego_polarity,
+                               ego_cases);
   }
 }
 


### PR DESCRIPTION
This enables an IDM-controlled car to check a confluent lane entering the car's path (up to a specified horizon), allowing multiple IDM-cars to safely enter a single branch point from more than one lane.  Cars in other lanes are only tracked if they are confluent lanes to a given branch point within the `scan_ahead_distance`; i.e. cars in two side-by-side lanes that never enter a branch point will not be considered by IDM.  It also assumes that the ego car has knowledge of the traffic cars' default lane (a reasonable assumption, given a short enough horizon).
- Adds a bool to the constructor of IdmController to enable/disable IDM control to search confluent lanes.
- Creates overloads to two functions in PoseSelector: `FindClosestPair()` and `FindSingleClosestPose()` to accept a RoadGeometry (instead of the usual Lane*) for enabling confluent lane search.
- Extends PoseSelector's lane sequencing (e.g. when determining the ego car's path in a RoadGeometry) to use the first ongoing lane (if one exists) in the event that no default branch had been specified in a given lane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7533)
<!-- Reviewable:end -->
