### PR TITLE
Use FindResource as needed in kuka_iiwa_arm examples

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/test/monolithic_pick_and_place_system_test.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/test/monolithic_pick_and_place_system_test.cc
@@ -116,7 +116,7 @@ class SingleMoveTests : public ::testing::TestWithParam<std::tuple<int, int>> {
     plant_configuration_.default_contact_material.set_dissipation(5);
 
     // Set planner parameters
-    planner_configuration_.model_path = kIiwaPath;
+    planner_configuration_.drake_relative_model_path = kIiwaPath;
     planner_configuration_.end_effector_name = kEndEffectorName;
     planner_configuration_.target_dimensions = kTargetDimensions;
     planner_configuration_.num_tables = 2;

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
@@ -173,8 +173,10 @@ pick_and_place::PlannerConfiguration DoParsePlannerConfiguration(
   planner_configuration.target_index = target_index;
 
   // Store model path and end-effector name.
-  planner_configuration.model_path = GetPlanningModelPathOrThrow(
-      configuration, configuration.robot(planner_configuration.robot_index));
+  planner_configuration.drake_relative_model_path =
+      GetPlanningModelPathOrThrow(
+          configuration,
+          configuration.robot(planner_configuration.robot_index));
   planner_configuration.end_effector_name = end_effector_name;
 
   // Extract number of tables

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_demo.cc
@@ -102,13 +102,13 @@ using manipulation::planner::ConstraintRelaxingIk;
 void RunPickAndPlaceDemo() {
   lcm::LCM lcm;
 
-  const std::string iiwa_path = FindResourceOrThrow(
+  const std::string iiwa_absolute_path = FindResourceOrThrow(
       "drake/manipulation/models/iiwa_description/urdf/"
       "iiwa14_primitive_collision.urdf");
   const std::string iiwa_end_effector_name = "iiwa_link_ee";
 
   // Makes a WorldState, and sets up LCM subscriptions.
-  WorldState env_state(iiwa_path, iiwa_end_effector_name);
+  WorldState env_state(iiwa_absolute_path, iiwa_end_effector_name);
   WorldStateSubscriber env_state_subscriber(&lcm, &env_state);
 
   // Spins until at least one message is received from every LCM channel.
@@ -119,7 +119,7 @@ void RunPickAndPlaceDemo() {
   // Makes a planner.
   const Isometry3<double>& iiwa_base = env_state.get_iiwa_base();
   ConstraintRelaxingIk planner(
-      iiwa_path, iiwa_end_effector_name, iiwa_base);
+      iiwa_absolute_path, iiwa_end_effector_name, iiwa_base);
   PickAndPlaceStateMachine::IiwaPublishCallback iiwa_callback =
       ([&](const robotlocomotion::robot_plan_t* plan) {
         lcm.publish("COMMITTED_ROBOT_PLAN", plan);
@@ -131,7 +131,7 @@ void RunPickAndPlaceDemo() {
       });
 
   PlannerConfiguration planner_configuration;
-  planner_configuration.model_path =
+  planner_configuration.drake_relative_model_path =
       "drake/manipulation/models/iiwa_description/urdf/"
       "iiwa14_polytope_collision.urdf";
   planner_configuration.end_effector_name = "iiwa_link_ee";

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
@@ -40,8 +40,11 @@ namespace pick_and_place {
 struct PickAndPlaceStateMachineSystem::InternalState {
   InternalState(const pick_and_place::PlannerConfiguration& configuration,
                 bool single_move)
-      : world_state(configuration.model_path, configuration.end_effector_name,
-                    configuration.num_tables, configuration.target_dimensions),
+      : world_state(
+            configuration.absolute_model_path(),
+            configuration.end_effector_name,
+            configuration.num_tables,
+            configuration.target_dimensions),
         state_machine(configuration, single_move),
         last_iiwa_plan(MakeDefaultIiwaPlan()),
         last_wsg_command(MakeDefaultWsgCommand()) {}
@@ -81,7 +84,8 @@ PickAndPlaceStateMachineSystem::PickAndPlaceStateMachineSystem(
   this->DeclarePeriodicUnrestrictedUpdate(configuration.period_sec, 0);
 
   parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      iiwa_model_path(), multibody::joints::kFixed, &iiwa_tree_);
+      configuration_.absolute_model_path(),
+      multibody::joints::kFixed, &iiwa_tree_);
 }
 
 std::unique_ptr<systems::AbstractValues>

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.h
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.h
@@ -129,10 +129,6 @@ class PickAndPlaceStateMachineSystem : public systems::LeafSystem<double> {
 
   int num_tables() const { return configuration_.num_tables; }
 
-  const std::string& iiwa_model_path() const {
-    return configuration_.model_path;
-  }
-
   const std::string& end_effector_name() const {
     return configuration_.end_effector_name;
   }

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
@@ -183,7 +183,8 @@ void ValidateOptitrackConfiguration(
 void ValidatePlannerConfiguration(
     const PlannerConfiguration& configuration,
     const PlannerConfiguration& expected_configuration) {
-  EXPECT_EQ(configuration.model_path, expected_configuration.model_path);
+  EXPECT_EQ(configuration.drake_relative_model_path,
+            expected_configuration.drake_relative_model_path);
   EXPECT_EQ(configuration.end_effector_name,
             expected_configuration.end_effector_name);
   EXPECT_EQ(configuration.robot_index, expected_configuration.robot_index);
@@ -238,7 +239,7 @@ class ConfigurationParsingTests : public ::testing::Test {
     plant_configuration_.default_contact_material.set_dissipation(5);
 
     // Set planner parameters
-    planner_configuration_.model_path = kIiwaPath;
+    planner_configuration_.drake_relative_model_path = kIiwaPath;
     planner_configuration_.end_effector_name = kEndEffectorName;
     planner_configuration_.target_dimensions = kTargetDimensions;
     planner_configuration_.num_tables = 6;

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration.h
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/find_resource.h"
 #include "drake/common/type_safe_index.h"
 #include "drake/multibody/rigid_body_plant/compliant_contact_model.h"
 #include "drake/multibody/rigid_body_plant/compliant_material.h"
@@ -29,7 +30,7 @@ struct OptitrackInfo {
 struct PlannerConfiguration {
   /// Path (relative to DRAKE_RESOURCE_ROOT) to the model file describing the
   /// robot arm.
-  std::string model_path;
+  std::string drake_relative_model_path;
   /// Name of the end-effector link on the robot arm.
   std::string end_effector_name;
   /// Type-safe index indicating for which robot arm in the scenario this
@@ -45,6 +46,11 @@ struct PlannerConfiguration {
   /// Number of tables for which the planner should expect to receive pose
   /// inputs.
   int num_tables{0};
+
+  /// Returns the absolute path for our @p drake_relative_model_path.
+  std::string absolute_model_path() const {
+    return FindResourceOrThrow(drake_relative_model_path);
+  }
 };
 
 /// Information required to set up a simulation of a pick-and-place scenario

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
@@ -258,7 +258,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
         X_Wend_effector_1_.translation()[2] += kPreGraspHeightOffset;
 
         // 2 seconds, no via points.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(
@@ -291,7 +291,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
 
         // 2 seconds, 3 via points. More via points to ensure the end
         // effector moves in more or less a straight line.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(
@@ -340,7 +340,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
         X_Wend_effector_1_.translation()[2] += kPreGraspHeightOffset;
 
         // 2 seconds, 3 via points.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(
@@ -375,7 +375,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
         X_Wend_effector_1_.translation()[2] += kPreGraspHeightOffset;
 
         // 2 seconds, no via points.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(
@@ -408,7 +408,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
         X_Wend_effector_1_.translation()[2] -= kPreGraspHeightOffset;
 
         // 2 seconds, 3 via points.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(
@@ -457,7 +457,7 @@ void PickAndPlaceStateMachine::Update(const WorldState& env_state,
         X_Wend_effector_1_.translation()[2] += kPreGraspHeightOffset;
 
         // 2 seconds, 5 via points.
-        ConstraintRelaxingIk planner{configuration_.model_path,
+        ConstraintRelaxingIk planner{configuration_.absolute_model_path(),
                                      configuration_.end_effector_name,
                                      Isometry3<double>::Identity()};
         bool res = PlanStraightLineMotion(

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/test/pick_and_place_state_machine_test.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/test/pick_and_place_state_machine_test.cc
@@ -32,7 +32,7 @@ struct TestStep {
 // does not loop.  The choice of the pick/place location is arbitrary.
 GTEST_TEST(PickAndPlaceStateMachineTest, StateMachineTest) {
   PlannerConfiguration planner_configuration;
-  planner_configuration.model_path = kIiwaUrdf;
+  planner_configuration.drake_relative_model_path = kIiwaUrdf;
   planner_configuration.end_effector_name = "iiwa_link_ee";
   planner_configuration.target_dimensions = {0.06, 0.06, 0.06};
   planner_configuration.num_tables = 2;

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.cc
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.cc
@@ -9,12 +9,14 @@ namespace examples {
 namespace kuka_iiwa_arm {
 namespace pick_and_place {
 
-WorldState::WorldState(const std::string& iiwa_model_path,
+WorldState::WorldState(const std::string& iiwa_model_absolute_path,
                        const std::string& end_effector_name, int num_tables,
                        const Vector3<double>& object_dimensions)
-    : iiwa_model_path_(iiwa_model_path),
+    : iiwa_model_absolute_path_(iiwa_model_absolute_path),
       end_effector_name_(end_effector_name),
       object_dimensions_(object_dimensions) {
+  DRAKE_THROW_UNLESS(iiwa_model_absolute_path.at(0) == '/');
+
   iiwa_time_ = -1;
   iiwa_base_ = Isometry3<double>::Identity();
   iiwa_end_effector_pose_ = Isometry3<double>::Identity();
@@ -45,7 +47,8 @@ void WorldState::HandleIiwaStatus(const lcmt_iiwa_status& iiwa_msg,
 
     auto mutable_iiwa = std::make_shared<RigidBodyTree<double>>();
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        iiwa_model_path_, multibody::joints::kFixed, base_frame,
+        iiwa_model_absolute_path_,
+        multibody::joints::kFixed, base_frame,
         mutable_iiwa.get());
     iiwa_ = mutable_iiwa;
     end_effector_ = iiwa_->FindBody(end_effector_name_);

--- a/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.h
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/world_state.h
@@ -29,16 +29,17 @@ class WorldState {
   /**
    * Constructs an WorldState object that holds the states that represent a pick
    * and place scenario.  A RigidBodyTree will be constructed internally based
-   * on @p iiwa_model_path (the location of its base will be set from the pose
-   * supplied in the first call to HandleIiwaStatus).  @p end_effector_name is
-   * the link name of the end effector in the model.
+   * on @p iiwa_model_absolute_path (the location of its base will be set from
+   * the pose supplied in the first call to HandleIiwaStatus).
+   * @p end_effector_name is the link name of the end effector in the model.
    *
    * No synchronization is attempted between the various states
    * (iiwa/wsg/obj), the accessors just return the most recently
    * received status.
    */
   WorldState(
-      const std::string& iiwa_model_path, const std::string& end_effector_name,
+      const std::string& iiwa_model_absolute_path,
+      const std::string& end_effector_name,
       int num_tables = 0,
       const Vector3<double>& object_dimensions = Vector3<double>::Zero());
 
@@ -93,7 +94,7 @@ class WorldState {
   // Also, we store the model as a shared_ptr to allow instances to be
   // (relatively) cheaply copied as part of a system's state.
   std::shared_ptr<const RigidBodyTree<double>> iiwa_;
-  std::string iiwa_model_path_;
+  std::string iiwa_model_absolute_path_;
   std::string end_effector_name_;
   const RigidBody<double>* end_effector_{nullptr};
 


### PR DESCRIPTION
Relates #6996.

(I'd originally tried to make these edits as part of #7497, but ended up backing them out after they become too confusing in that PR.)

Update variable names and comments to be super-clear about which paths are drake-relative resources, and which paths are already resolved to point to an absolute filesystem path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7539)
<!-- Reviewable:end -->
