### PR TITLE
Fix uninitialized value in rgbd_camera.cc

### DIFF
--- a/drake/systems/sensors/rgbd_camera.cc
+++ b/drake/systems/sensors/rgbd_camera.cc
@@ -92,7 +92,7 @@ RgbdCamera::RgbdCamera(const std::string& name,
       camera_fixed_(false),
       color_camera_info_(kImageWidth, kImageHeight, fov_y),
       depth_camera_info_(kImageWidth, kImageHeight, fov_y),
-      renderer_(new RgbdRenderer(Eigen::Isometry3d(),
+      renderer_(new RgbdRenderer(Eigen::Isometry3d::Identity(),
                                  kImageWidth, kImageHeight,
                                  z_near, z_far,
                                  fov_y, show_window)) {


### PR DESCRIPTION
Came up when I was trying to fix #7520 on running with Valgrind.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7541)
<!-- Reviewable:end -->
