### PR TITLE
Add no_tsan  flag to pick_and_place_state_machine_test.

### DIFF
--- a/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD.bazel
+++ b/drake/examples/kuka_iiwa_arm/pick_and_place/BUILD.bazel
@@ -56,10 +56,13 @@ drake_cc_googletest(
     data = [
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    # TODO(eric.cousineau): Remove this tag once #3128 or the IK redux lands.
+    # TODO(eric.cousineau): Remove these tags once #3128 or the IK redux lands.
     # On some CI machines without SNOPT, system IPOPT is used, and exceeds time
-    # limits under memcheck with -c dbg.
-    tags = ["no_memcheck"],
+    # limits under memcheck with -c dbg as well as under tsan.
+    tags = [
+        "no_memcheck",
+        "no_tsan",
+    ],
     deps = [
         ":pick_and_place",
         "//drake/common:find_resource",


### PR DESCRIPTION
Addresses [CI failure](https://drake-jenkins.csail.mit.edu/view/Continuous/job/linux-xenial-clang-bazel-continuous-memcheck-tsan/574/console) in which `pick_and_place_state_machine_test` timed out under tsan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7548)
<!-- Reviewable:end -->
