### PR TITLE
Add an autodiff-enabled IDM-controlled lane follower to AutomotiveSimulator

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -104,6 +104,20 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "create_trajectory_params",
+    srcs = ["create_trajectory_params.cc"],
+    hdrs = ["create_trajectory_params.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":curve2",
+        ":trajectory_car",
+        "//drake/automotive/maliput/api",
+        "//drake/automotive/maliput/dragway",
+        "//drake/common:symbolic",
+    ],
+)
+
+drake_cc_library(
     name = "curve2",
     srcs = ["curve2.cc"],
     hdrs = ["curve2.h"],
@@ -364,6 +378,7 @@ drake_cc_library(
         "//drake/systems/analysis",
         "//drake/systems/lcm",
         "//drake/systems/lcm:lcmt_drake_signal_translator",
+        "//drake/systems/primitives:constant_value_source",
         "//drake/systems/primitives:multiplexer",
         "//drake/systems/rendering:pose_aggregator",
         "//drake/systems/rendering:pose_bundle_to_draw_message",
@@ -374,17 +389,17 @@ drake_cc_binary(
     name = "automotive_demo",
     srcs = [
         "automotive_demo.cc",
-        "create_trajectory_params.cc",
-        "create_trajectory_params.h",
     ],
     data = [
         "//drake/automotive/models:prod_models",
     ],
     deps = [
         ":automotive_simulator",
+        ":create_trajectory_params",
         ":monolane_onramp_merge",
         "//drake/automotive/maliput/dragway",
         "//drake/common:text_logging_gflags",
+        "//drake/lcm",
     ],
 )
 
@@ -466,6 +481,7 @@ drake_cc_googletest(
     local = 1,
     deps = [
         "//drake/automotive:automotive_simulator",
+        "//drake/automotive:create_trajectory_params",
         "//drake/automotive/maliput/dragway",
         "//drake/lcm:mock",
     ],

--- a/automotive/automotive_demo.cc
+++ b/automotive/automotive_demo.cc
@@ -12,6 +12,7 @@
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/monolane_onramp_merge.h"
 #include "drake/common/text_logging_gflags.h"
+#include "drake/lcm/drake_lcm.h"
 
 DEFINE_int32(num_simple_car, 0, "Number of SimpleCar vehicles. The cars are "
              "named \"0\", \"1\", \"2\", etc. If this option is provided, "
@@ -381,7 +382,8 @@ int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   logging::HandleSpdlogGflags();
   const RoadNetworkType road_network_type = DetermineRoadNetworkType();
-  auto simulator = std::make_unique<AutomotiveSimulator<double>>();
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
+      std::make_unique<lcm::DrakeLcm>());
   const maliput::api::RoadGeometry* road_geometry =
       AddTerrain(road_network_type, simulator.get());
   AddVehicles(road_network_type, road_geometry, simulator.get());

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -26,6 +26,7 @@
 #include "drake/systems/framework/system.h"
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/lcmt_drake_signal_translator.h"
+#include "drake/systems/primitives/constant_value_source.h"
 #include "drake/systems/primitives/multiplexer.h"
 
 namespace drake {
@@ -58,14 +59,16 @@ AutomotiveSimulator<T>::AutomotiveSimulator(
       builder_->template AddSystem<systems::rendering::PoseAggregator<T>>();
   aggregator_->set_name("pose_aggregator");
 
-  car_vis_applicator_ =
-      builder_->template AddSystem<CarVisApplicator<T>>();
-  car_vis_applicator_->set_name("car_vis_applicator");
+  if (lcm_) {
+    car_vis_applicator_ =
+        builder_->template AddSystem<CarVisApplicator<T>>();
+    car_vis_applicator_->set_name("car_vis_applicator");
 
-  bundle_to_draw_ =
-      builder_->template
-          AddSystem<systems::rendering::PoseBundleToDrawMessage>();
-  bundle_to_draw_->set_name("bundle_to_draw");
+    bundle_to_draw_ =
+        builder_->template
+        AddSystem<systems::rendering::PoseBundleToDrawMessage>();
+    bundle_to_draw_->set_name("bundle_to_draw");
+  }
 }
 
 template <typename T>
@@ -96,7 +99,9 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
   auto ports = aggregator_->AddSinglePoseAndVelocityInput(name, id);
   builder_->Connect(pose_output, ports.first);
   builder_->Connect(velocity_output, ports.second);
-  car_vis_applicator_->AddCarVis(std::make_unique<PriusVis<T>>(id, name));
+  if (lcm_) {
+    car_vis_applicator_->AddCarVis(std::make_unique<PriusVis<T>>(id, name));
+  }
 }
 
 // TODO(jwnimmer-tri): Modify the various vehicle model systems to be more
@@ -113,11 +118,6 @@ int AutomotiveSimulator<T>::AddPriusSimpleCar(
   CheckNameUniqueness(name);
   const int id = allocate_vehicle_number();
 
-  static const DrivingCommandTranslator driving_command_translator;
-  DRAKE_DEMAND(!channel_name.empty());
-  auto command_subscriber =
-      builder_->template AddSystem<systems::lcm::LcmSubscriberSystem>(
-          channel_name, driving_command_translator, lcm_.get());
   auto simple_car = builder_->template AddSystem<SimpleCar<T>>();
   simple_car->set_name(name);
   vehicles_[id] = simple_car;
@@ -126,9 +126,16 @@ int AutomotiveSimulator<T>::AddPriusSimpleCar(
   ConnectCarOutputsAndPriusVis(id, simple_car->pose_output(),
       simple_car->velocity_output());
 
-  builder_->Connect(*command_subscriber, *simple_car);
+  if (!channel_name.empty() && lcm_) {
+    static const DrivingCommandTranslator driving_command_translator;
+    auto command_subscriber =
+        builder_->template AddSystem<systems::lcm::LcmSubscriberSystem>(
+            channel_name, driving_command_translator, lcm_.get());
 
-  AddPublisher(*simple_car, id);
+    builder_->Connect(*command_subscriber, *simple_car);
+
+    AddPublisher(*simple_car, id);
+  }
   return id;
 }
 
@@ -191,7 +198,9 @@ int AutomotiveSimulator<T>::AddMobilControlledSimpleCar(
   ConnectCarOutputsAndPriusVis(id, simple_car->pose_output(),
                                simple_car->velocity_output());
 
-  AddPublisher(*simple_car, id);
+  if (lcm_) {
+    AddPublisher(*simple_car, id);
+  }
   return id;
 }
 
@@ -220,7 +229,76 @@ int AutomotiveSimulator<T>::AddPriusTrajectoryCar(
   ConnectCarOutputsAndPriusVis(id, trajectory_car->pose_output(),
       trajectory_car->velocity_output());
 
-  AddPublisher(*trajectory_car, id);
+  if (lcm_) {
+    AddPublisher(*trajectory_car, id);
+  }
+  return id;
+}
+
+template <typename T>
+int AutomotiveSimulator<T>::AddIdmControlledCar(
+    const std::string& name, bool initial_with_s,
+    const SimpleCarState<T>& initial_state,
+    const maliput::api::Lane* goal_lane) {
+  DRAKE_DEMAND(!has_started());
+  DRAKE_DEMAND(aggregator_ != nullptr);
+  DRAKE_THROW_UNLESS(goal_lane != nullptr);
+  DRAKE_THROW_UNLESS(FindLane(goal_lane->id().string()) != nullptr);
+  if (road_ == nullptr) {
+    throw std::runtime_error(
+        "AutomotiveSimulator::AddIdmControlledCar(): "
+        "RoadGeometry not set. Please call SetRoadGeometry() first before "
+        "calling this method.");
+  }
+
+  CheckNameUniqueness(name);
+  const int id = allocate_vehicle_number();
+
+  auto idm_controller = builder_->template AddSystem<IdmController<T>>(*road_);
+  idm_controller->set_name(name + "_idm_controller");
+
+  const LaneDirection lane_direction(goal_lane, initial_with_s);
+  auto lane_source =
+      builder_->template AddSystem<systems::ConstantValueSource<T>>(
+          systems::AbstractValue::Make<LaneDirection>(lane_direction));
+
+  auto simple_car = builder_->template AddSystem<SimpleCar<T>>();
+  simple_car->set_name(name + "_simple_car");
+  vehicles_[id] = simple_car;
+
+  simple_car_initial_states_[simple_car].set_value(initial_state.get_value());
+
+  auto pursuit = builder_->template AddSystem<PurePursuitController<T>>();
+  pursuit->set_name(name + "_pure_pursuit_controller");
+  auto mux = builder_->template AddSystem<systems::Multiplexer<T>>(
+      DrivingCommand<T>());
+  mux->set_name(name + "_mux");
+
+  // Wire up the simple car and pose aggregator to IdmController.
+  builder_->Connect(simple_car->pose_output(),
+                    idm_controller->ego_pose_input());
+  builder_->Connect(simple_car->velocity_output(),
+                    idm_controller->ego_velocity_input());
+  builder_->Connect(aggregator_->get_output_port(0),
+                    idm_controller->traffic_input());
+
+  // Wire up the lane source and simple car to PurePursuitController.
+  builder_->Connect(simple_car->pose_output(), pursuit->ego_pose_input());
+  builder_->Connect(lane_source->get_output_port(0), pursuit->lane_input());
+  // Build DrivingCommand via a mux of two scalar outputs (a BasicVector where
+  // row 0 = steering command, row 1 = acceleration command).
+  builder_->Connect(pursuit->steering_command_output(),
+                    mux->get_input_port(0));
+  builder_->Connect(idm_controller->acceleration_output(),
+                    mux->get_input_port(1));
+  builder_->Connect(mux->get_output_port(0), simple_car->get_input_port(0));
+
+  ConnectCarOutputsAndPriusVis(id, simple_car->pose_output(),
+                               simple_car->velocity_output());
+  if (lcm_) {
+    AddPublisher(*simple_car, id);
+  }
+
   return id;
 }
 
@@ -365,6 +443,7 @@ template <typename T>
 void AutomotiveSimulator<T>::AddPublisher(const MaliputRailcar<T>& system,
                                           int vehicle_number) {
   DRAKE_DEMAND(!has_started());
+  DRAKE_DEMAND(lcm_ != nullptr);
   static const MaliputRailcarStateTranslator translator;
   const std::string channel =
       std::to_string(vehicle_number) + "_MALIPUT_RAILCAR_STATE";
@@ -377,6 +456,7 @@ template <typename T>
 void AutomotiveSimulator<T>::AddPublisher(const SimpleCar<T>& system,
                                           int vehicle_number) {
   DRAKE_DEMAND(!has_started());
+  DRAKE_DEMAND(lcm_ != nullptr);
   static const SimpleCarStateTranslator translator;
   const std::string channel =
       std::to_string(vehicle_number) + "_SIMPLE_CAR_STATE";
@@ -389,6 +469,7 @@ template <typename T>
 void AutomotiveSimulator<T>::AddPublisher(const TrajectoryCar<T>& system,
                                           int vehicle_number) {
   DRAKE_DEMAND(!has_started());
+  DRAKE_DEMAND(lcm_ != nullptr);
   static const SimpleCarStateTranslator translator;
   const std::string channel =
       std::to_string(vehicle_number) + "_SIMPLE_CAR_STATE";
@@ -448,6 +529,7 @@ void AutomotiveSimulator<T>::TransmitLoadMessage() {
 template <typename T>
 void AutomotiveSimulator<T>::SendLoadRobotMessage(
     const lcmt_viewer_load_robot& message) {
+  DRAKE_DEMAND(lcm_ != nullptr);
   const int num_bytes = message.getEncodedSize();
   std::vector<uint8_t> message_bytes(num_bytes);
   const int num_bytes_encoded =
@@ -460,18 +542,20 @@ template <typename T>
 void AutomotiveSimulator<T>::Build() {
   DRAKE_DEMAND(diagram_ == nullptr);
 
-  builder_->Connect(
-      aggregator_->get_output_port(0),
-      car_vis_applicator_->get_car_poses_input_port());
-  builder_->Connect(
-      car_vis_applicator_->get_visual_geometry_poses_output_port(),
-      bundle_to_draw_->get_input_port(0));
-  lcm_publisher_ = builder_->AddSystem(
-      LcmPublisherSystem::Make<lcmt_viewer_draw>("DRAKE_VIEWER_DRAW",
-                                                 lcm_.get()));
-  builder_->Connect(
-      bundle_to_draw_->get_output_port(0),
-      lcm_publisher_->get_input_port(0));
+  if (lcm_) {
+    builder_->Connect(
+        aggregator_->get_output_port(0),
+        car_vis_applicator_->get_car_poses_input_port());
+    builder_->Connect(
+        car_vis_applicator_->get_visual_geometry_poses_output_port(),
+        bundle_to_draw_->get_input_port(0));
+    lcm_publisher_ = builder_->AddSystem(
+        LcmPublisherSystem::Make<lcmt_viewer_draw>("DRAKE_VIEWER_DRAW",
+                                                   lcm_.get()));
+    builder_->Connect(
+        bundle_to_draw_->get_output_port(0),
+        lcm_publisher_->get_input_port(0));
+  }
   pose_bundle_output_port_ =
       builder_->ExportOutput(aggregator_->get_output_port(0));
 
@@ -480,26 +564,40 @@ void AutomotiveSimulator<T>::Build() {
 }
 
 template <typename T>
-void AutomotiveSimulator<T>::Start(double target_realtime_rate) {
+void AutomotiveSimulator<T>::BuildAndInitialize(
+    std::unique_ptr<systems::Context<double>> initial_context) {
   DRAKE_DEMAND(!has_started());
   if (diagram_ == nullptr) {
     Build();
   }
-
-  TransmitLoadMessage();
-
   simulator_ = std::make_unique<systems::Simulator<T>>(*diagram_);
 
-  InitializeTrajectoryCars();
-  InitializeSimpleCars();
-  InitializeMaliputRailcars();
+  if (initial_context == nullptr) {
+    InitializeTrajectoryCars();
+    InitializeSimpleCars();
+    InitializeMaliputRailcars();
+  } else {
+    simulator_->reset_context(std::move(initial_context));
+  }
+}
 
-  lcm_->StartReceiveThread();
+template <typename T>
+void AutomotiveSimulator<T>::Start(
+    double target_realtime_rate,
+    std::unique_ptr<systems::Context<double>> initial_context) {
+  DRAKE_DEMAND(!has_started());
+
+  BuildAndInitialize(std::move(initial_context));
+
+  if (lcm_) {
+    TransmitLoadMessage();
+    lcm_->StartReceiveThread();
+  }
 
   simulator_->set_target_realtime_rate(target_realtime_rate);
   const double max_step_size = 0.01;
-  simulator_->template reset_integrator<RungeKutta2Integrator<T>>(*diagram_,
-      max_step_size, &simulator_->get_mutable_context());
+  simulator_->template reset_integrator<RungeKutta2Integrator<T>>(
+      *diagram_, max_step_size, &simulator_->get_mutable_context());
   simulator_->get_mutable_integrator()->set_fixed_step_mode(true);
   simulator_->Initialize();
 }
@@ -513,7 +611,7 @@ void AutomotiveSimulator<T>::InitializeTrajectoryCars() {
     systems::VectorBase<T>& context_state =
         diagram_->GetMutableSubsystemContext(*car,
                                              &simulator_->get_mutable_context())
-        .get_mutable_continuous_state().get_mutable_vector();
+        .get_mutable_continuous_state_vector();
     TrajectoryCarState<T>* const state =
         dynamic_cast<TrajectoryCarState<T>*>(&context_state);
     DRAKE_ASSERT(state);
@@ -530,7 +628,7 @@ void AutomotiveSimulator<T>::InitializeSimpleCars() {
     systems::VectorBase<T>& context_state =
         diagram_->GetMutableSubsystemContext(*car,
                                              &simulator_->get_mutable_context())
-        .get_mutable_continuous_state().get_mutable_vector();
+        .get_mutable_continuous_state_vector();
     SimpleCarState<T>* const state =
         dynamic_cast<SimpleCarState<T>*>(&context_state);
     DRAKE_ASSERT(state);
@@ -549,7 +647,7 @@ void AutomotiveSimulator<T>::InitializeMaliputRailcars() {
          *car, &simulator_->get_mutable_context());
 
     systems::VectorBase<T>& context_state =
-        context.get_mutable_continuous_state().get_mutable_vector();
+        context.get_mutable_continuous_state_vector();
     MaliputRailcarState<T>* const state =
         dynamic_cast<MaliputRailcarState<T>*>(&context_state);
     DRAKE_ASSERT(state);

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -300,6 +300,7 @@ drake_cc_googletest(
         ":constant_value_source",
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/systems/framework",
+        "//drake/systems/framework/test_utilities:scalar_conversion",
     ],
 )
 
@@ -391,7 +392,7 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/common/test_utilities:is_dynamic_castable",
         "//drake/systems/framework",
-        "//drake/systems/framework/test_utilities:my_vector",
+        "//drake/systems/framework/test_utilities",
     ],
 )
 

--- a/systems/primitives/constant_value_source-inl.h
+++ b/systems/primitives/constant_value_source-inl.h
@@ -18,7 +18,8 @@ namespace systems {
 template <typename T>
 ConstantValueSource<T>::ConstantValueSource(
     std::unique_ptr<AbstractValue> value)
-    : source_value_(std::move(value)) {
+    : LeafSystem<T>(SystemTypeTag<systems::ConstantValueSource>{}),
+      source_value_(std::move(value)) {
   // Use the "advanced" method to provide explicit non-member functors here
   // since we already have AbstractValues.
   this->DeclareAbstractOutputPort(
@@ -29,6 +30,11 @@ ConstantValueSource<T>::ConstantValueSource(
         output->SetFrom(*source_value_);
       });
 }
+
+template <typename T>
+template <typename U>
+ConstantValueSource<T>::ConstantValueSource(const ConstantValueSource<U>& other)
+    : ConstantValueSource<T>(other.source_value_->Clone()) {}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/primitives/constant_value_source.cc
+++ b/systems/primitives/constant_value_source.cc
@@ -1,10 +1,7 @@
 // NOLINTNEXTLINE(build/include) False positive on inl file.
 #include "drake/systems/primitives/constant_value_source-inl.h"
 
-namespace drake {
-namespace systems {
+#include "drake/common/default_scalars.h"
 
-template class ConstantValueSource<double>;
-
-}  // namespace systems
-}  // namespace drake
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::ConstantValueSource)

--- a/systems/primitives/constant_value_source.h
+++ b/systems/primitives/constant_value_source.h
@@ -28,7 +28,13 @@ class ConstantValueSource : public LeafSystem<T> {
   /// @p value The constant value to emit.
   explicit ConstantValueSource(std::unique_ptr<AbstractValue> value);
 
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit ConstantValueSource(const ConstantValueSource<U>&);
+
  private:
+  template <typename> friend class ConstantValueSource;
+
   // TODO(david-german-tri): move source_value_ to the system's parameters.
   const std::unique_ptr<AbstractValue> source_value_;
 };

--- a/systems/primitives/multiplexer.h
+++ b/systems/primitives/multiplexer.h
@@ -43,7 +43,16 @@ class Multiplexer : public LeafSystem<T> {
   /// `model_vector`.
   explicit Multiplexer(const systems::BasicVector<T>& model_vector);
 
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit Multiplexer(const Multiplexer<U>&);
+
  private:
+  template <typename> friend class Multiplexer;
+
+  Multiplexer(std::vector<int> input_sizes,
+              const systems::BasicVector<T>& model_vector);
+
   // This is the calculator for the output port.
   void CombineInputsToOutput(const Context<T>& context,
                              BasicVector<T>* output) const;

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/input_port_value.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 #include "drake/systems/framework/value.h"
 
 using Eigen::Matrix;
@@ -43,6 +44,15 @@ TEST_F(ConstantValueSourceTest, Output) {
 // Tests that ConstantValueSource allocates no state variables in the context_.
 TEST_F(ConstantValueSourceTest, ConstantValueSourceIsStateless) {
   EXPECT_EQ(0, context_->get_continuous_state().size());
+}
+
+// Tests conversion to different scalar types.
+TEST_F(ConstantValueSourceTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*source_));
+}
+
+TEST_F(ConstantValueSourceTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*source_));
 }
 
 }  // namespace

--- a/systems/primitives/test/multiplexer_test.cc
+++ b/systems/primitives/test/multiplexer_test.cc
@@ -4,10 +4,13 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/input_port_value.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 using std::make_unique;
 
@@ -101,6 +104,34 @@ TEST_F(MultiplexerTest, ModelVectorConstructor) {
 TEST_F(MultiplexerTest, IsStateless) {
   Reset({1});
   EXPECT_EQ(0, context_->get_continuous_state().size());
+}
+
+// Tests conversion to AutoDiffXd.
+TEST_F(MultiplexerTest, ToAutoDiff) {
+  Reset({1, 1, 1});
+  EXPECT_TRUE(is_autodiffxd_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(3, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(1, converted.get_input_port(2).size());
+    EXPECT_EQ(3, converted.get_output_port(0).size());
+  }));
+}
+
+// Tests conversion to symbolic::Expression.
+TEST_F(MultiplexerTest, ToSymbolic) {
+  Reset({1, 1, 1});
+  EXPECT_TRUE(is_symbolic_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(3, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(1, converted.get_input_port(2).size());
+    EXPECT_EQ(3, converted.get_output_port(0).size());
+  }));
 }
 
 }  // namespace


### PR DESCRIPTION
The diagram constructed within AddIdmControlledCar does IDM-based longitudinal control of a SimpleCar plant model and also lane-keeping using a PurePursuitController.  LCM (not autodiff-supported) may be disabled by way of a constructor argument to AutomotiveSimulator.

The diagrams were built with ConstantValueSource and Multiplexer, hence autodiff support was added for both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7551)
<!-- Reviewable:end -->
