### PR TITLE
Add some include paths, libraries, and library paths to ignition-math.

### DIFF
--- a/tools/workspace/ignition_math/ignition_math-create-cps.py
+++ b/tools/workspace/ignition_math/ignition_math-create-cps.py
@@ -19,6 +19,11 @@ content = """
       "Location": "@prefix@/lib/libignition_math.so",
       "Includes": [ "@prefix@/include" ]
     }
+  },
+  "X-CMake-Variables": {
+    "IGNITION-MATH_INCLUDE_DIRS": "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include",
+    "IGNITION-MATH_LINK_DIRS": "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib",
+    "IGNITION-MATH_LIBRARIES": "ignition_math"
   }
 }
 """ % defs


### PR DESCRIPTION
The rest of the ignition ecosystem expects these variables
to be named differently than what CPS generates by default,
so use X-CMake-Variables to set them.  With this in place,
other pieces of the ignition ecosystem can successfully build
against and link against the version of ignition-math that
drake builds.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7552)
<!-- Reviewable:end -->
