### PR TITLE
automotive/models: silence speed_bump genrule output

### DIFF
--- a/drake/automotive/models/BUILD.bazel
+++ b/drake/automotive/models/BUILD.bazel
@@ -19,6 +19,7 @@ genrule(
     ],
     cmd = " ".join([
         "$(location :yaml_to_obj)",
+        "--spdlog_level warn",
         "--yaml_file '$<'",
         "--obj_dir $(@D)/speed_bump",
         "--obj_file speed_bump",

--- a/drake/common/text_logging_gflags.h
+++ b/drake/common/text_logging_gflags.h
@@ -11,7 +11,7 @@
 // Declare the --spdlog_level gflags option.
 DEFINE_string(spdlog_level, "unchanged",
               "sets the spdlog output threshold; "
-              "possible values are 'unchanged', 'trace', 'debug'");
+              "possible values are 'unchanged', 'trace', 'debug', 'warn'");
 
 namespace drake {
 namespace logging {


### PR DESCRIPTION
text_logging_gflags: Add missing option to help string.  The help was broken as of ebc8f25.

automotive/models: silence speed_bump genrule output.  This was fixed in ebc8f25 but erroneously reverted by c8f439a.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7553)
<!-- Reviewable:end -->
