### PR TITLE
Force line breaks in lcm_vector_gen initializer_list

### DIFF
--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -88,9 +88,9 @@ INDICES_END = """
 INDICIES_NAMES_ACCESSOR_IMPL_START = """
 const std::vector<std::string>& %(camel)sIndices::GetCoordinateNames() {
   static const never_destroyed<std::vector<std::string>> coordinates(
-      std::vector<std::string> {
+      std::vector<std::string>{
 """
-INDICES_NAMES_ACCESSOR_IMPL_MID = """    \"%(name)s\","""
+INDICES_NAMES_ACCESSOR_IMPL_MID = """    \"%(name)s\",  // BR"""
 INDICES_NAMES_ACCESSOR_IMPL_END = """  });
   return coordinates.access();
 }"""

--- a/tools/vector_gen/test/goal/sample.cc
+++ b/tools/vector_gen/test/goal/sample.cc
@@ -15,7 +15,9 @@ const int SampleIndices::kAbsone;
 const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
   static const never_destroyed<std::vector<std::string>> coordinates(
       std::vector<std::string>{
-          "x", "two_word", "absone",
+          "x",         // BR
+          "two_word",  // BR
+          "absone",    // BR
       });
   return coordinates.access();
 }


### PR DESCRIPTION
This makes Ubuntu clang-format and homebrew clang-format agree on how the initializer_list values should be line-wrapped.  Prior to this, Ubuntu wanted the list on one line, but homebrew as of the 2017-11-14 tag wanted it on three lines.

Example failure: https://drake-jenkins.csail.mit.edu/view/Unprovisioned/job/mac-sierra-unprovisioned-clang-bazel-nightly-release/139/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7561)
<!-- Reviewable:end -->
