### PR TITLE
Modify diagram builder error message on algebraic loops

### DIFF
--- a/drake/systems/framework/test/diagram_builder_test.cc
+++ b/drake/systems/framework/test/diagram_builder_test.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 
+#include <regex>
+
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
@@ -13,6 +15,16 @@
 namespace drake {
 namespace systems {
 namespace {
+
+#define EXPECT_ERROR_MESSAGE(expression, exception, reg_exp) \
+try { \
+  expression; \
+  GTEST_NONFATAL_FAILURE_("\t" #expression " failed to throw " #exception); \
+} catch (const exception& err) { \
+  auto matcher = [](const char* s, const std::string& re) { \
+    return std::regex_match(s, std::regex(re.c_str())); }; \
+  EXPECT_PRED2(matcher, err.what(), reg_exp); \
+}
 
 // Tests ::empty().
 GTEST_TEST(DiagramBuilderTest, Empty) {
@@ -69,10 +81,14 @@ class ConstAndEcho final : public LeafSystem<T> {
 GTEST_TEST(DiagramBuilderTest, AlgebraicLoop) {
   DiagramBuilder<double> builder;
   auto adder = builder.AddSystem<Adder>(1 /* inputs */, 1 /* size */);
-  adder->set_name("adder");
+  const std::string name{"adder"};
+  adder->set_name(name);
   // Connect the output port to the input port.
   builder.Connect(adder->get_output_port(), adder->get_input_port(0));
-  EXPECT_THROW(builder.Build(), std::logic_error);
+  EXPECT_ERROR_MESSAGE(builder.Build(), std::runtime_error,
+                       "Algebraic loop detected in DiagramBuilder:\n"
+                       "\\s+" + name + ":Out\\(0\\).*\n."
+                       "\\s*" + name + ":In\\(0\\)");
 }
 
 // Tests that a cycle which is not an algebraic loop is recognized as valid.
@@ -123,9 +139,13 @@ GTEST_TEST(DiagramBuilderTest, CycleAtLoopPortLevel) {
   // diagram has a cycle at the *system* level, but there is no algebraic loop.
 
   auto echo = builder.AddSystem<ConstAndEcho>();
-  echo->set_name("echo");
+  const std::string name{"echo"};
+  echo->set_name(name);
   builder.Connect(echo->get_echo_output_port(), echo->get_vec_input_port());
-  EXPECT_THROW(builder.Build(), std::logic_error);
+  EXPECT_ERROR_MESSAGE(builder.Build(), std::runtime_error,
+                       "Algebraic loop detected in DiagramBuilder:\n"
+                           "\\s+" + name + ":Out\\(0\\).*\n."
+                           "\\s*" + name + ":In\\(0\\)");
 }
 
 // Tests that a cycle which is not an algebraic loop is recognized as valid.


### PR DESCRIPTION
Changes the error message broadcast when detecting an algebraic loop. The loop is now described.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7564)
<!-- Reviewable:end -->
