### PR TITLE
Make WorldSimTreeBuilder::StoreModel() use an absolute path

### DIFF
--- a/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_diagram_factory.cc
@@ -48,8 +48,8 @@ IiwaAndBoxPlantWithStateEstimator<T>::IiwaAndBoxPlantWithStateEstimator(
 
   auto single_arm = std::make_unique<RigidBodyTree<double>>();
   parsers::urdf::AddModelInstanceFromUrdfFile(
-      iiwa_info.model_path, multibody::joints::kFixed, iiwa_info.world_offset,
-      single_arm.get());
+      iiwa_info.absolute_model_path, multibody::joints::kFixed,
+      iiwa_info.world_offset, single_arm.get());
 
   DRAKE_DEMAND(single_arm->get_num_positions() % kIiwaArmNumJoints == 0);
   for (int offset = kIiwaArmNumJoints; offset < single_arm->get_num_positions();
@@ -98,7 +98,7 @@ IiwaAndBoxPlantWithStateEstimator<T>::IiwaAndBoxPlantWithStateEstimator(
   // Make a box RBT for the fake state estimator.
   object_ = std::make_unique<RigidBodyTree<T>>();
   parsers::urdf::AddModelInstanceFromUrdfFile(
-      box_info.model_path, multibody::joints::kQuaternion,
+      box_info.absolute_model_path, multibody::joints::kQuaternion,
       box_info.world_offset, object_.get());
   box_state_est_ =
       base_builder->template AddSystem<OracularStateEstimation<T>>(*object_);

--- a/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -79,7 +79,7 @@ std::unique_ptr<RigidBodyPlant<T>> BuildCombinedPlant(
     manipulation::util::ModelInstanceInfo<T> *box_instance) {
 
   const std::string iiwa_path =
-      (!FLAGS_urdf.empty() ? FLAGS_urdf : kIiwaUrdf);
+      (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kIiwaUrdf));
 
   auto tree_builder =
       std::make_unique<manipulation::util::WorldSimTreeBuilder<double>>();
@@ -87,15 +87,16 @@ std::unique_ptr<RigidBodyPlant<T>> BuildCombinedPlant(
   // Adds models to the simulation builder. Instances of these models can be
   // subsequently added to the world.
   tree_builder->StoreModel("iiwa", iiwa_path);
-  tree_builder->StoreModel("table",
-                           "drake/examples/kuka_iiwa_arm/models/table/"
-                           "extra_heavy_duty_table_surface_only_collision.sdf");
-  tree_builder->StoreModel(
+  tree_builder->StoreDrakeModel(
+      "table",
+      "drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf");
+  tree_builder->StoreDrakeModel(
       "large_table", "drake/examples/kuka_iiwa_arm/dev/box_rotation/models/"
       "large_extra_heavy_duty_table_surface_only_collision.sdf");
-  tree_builder->StoreModel("box",
-                           "drake/examples/kuka_iiwa_arm/dev/box_rotation/"""
-                           "models/box.urdf");
+  tree_builder->StoreDrakeModel(
+      "box",
+      "drake/examples/kuka_iiwa_arm/dev/box_rotation/models/box.urdf");
 
   // Build a world with three fixed tables.  A box is placed one on
   // table, and the iiwa arms are fixed to the other two tables.

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
@@ -50,12 +50,14 @@ std::unique_ptr<systems::RigidBodyPlant<double>> BuildCombinedPlant(
 
   // Add models to the simulation builder. Instances of these models can be
   // subsequently added to the world.
-  tree_builder->StoreModel("table",
-                           "drake/examples/kuka_iiwa_arm/models/table/"
-                           "extra_heavy_duty_table_surface_only_collision.sdf");
-  tree_builder->StoreModel("wsg",
-                           "drake/manipulation/models/wsg_50_description"
-                           "/sdf/schunk_wsg_50_ball_contact.sdf");
+  tree_builder->StoreDrakeModel(
+      "table",
+      "drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf");
+  tree_builder->StoreDrakeModel(
+      "wsg",
+      "drake/manipulation/models/wsg_50_description"
+      "/sdf/schunk_wsg_50_ball_contact.sdf");
 
   tree_builder->AddGround();
 
@@ -65,7 +67,7 @@ std::unique_ptr<systems::RigidBodyPlant<double>> BuildCombinedPlant(
                      static_cast<int>(configuration.robot_poses.size()));
   for (int i = 0; i < num_robots; ++i) {
     const std::string robot_tag{"robot_" + std::to_string(i)};
-    tree_builder->StoreModel(robot_tag, configuration.robot_models[i]);
+    tree_builder->StoreDrakeModel(robot_tag, configuration.robot_models[i]);
     // Add the arm.
     const Isometry3<double>& robot_base_pose{configuration.robot_poses[i]};
     int robot_base_id = tree_builder->AddFixedModelInstance(
@@ -98,7 +100,7 @@ std::unique_ptr<systems::RigidBodyPlant<double>> BuildCombinedPlant(
                      static_cast<int>(configuration.object_poses.size()));
   for (int i = 0; i < num_objects; ++i) {
     const std::string object_tag{"object_" + std::to_string(i)};
-    tree_builder->StoreModel(object_tag, configuration.object_models[i]);
+    tree_builder->StoreDrakeModel(object_tag, configuration.object_models[i]);
     int object_id = tree_builder->AddFloatingModelInstance(
         object_tag, configuration.object_poses[i].translation(),
         drake::math::rotmat2rpy(configuration.object_poses[i].linear()));
@@ -112,7 +114,7 @@ std::unique_ptr<systems::RigidBodyPlant<double>> BuildCombinedPlant(
                      static_cast<int>(configuration.table_poses.size()));
   for (int i = 0; i < num_tables; ++i) {
     const std::string table_tag{"table_" + std::to_string(i)};
-    tree_builder->StoreModel(table_tag, configuration.table_models[i]);
+    tree_builder->StoreDrakeModel(table_tag, configuration.table_models[i]);
     int table_id = tree_builder->AddFixedModelInstance(
         table_tag, configuration.table_poses[i].translation(),
         drake::math::rotmat2rpy(configuration.table_poses[i].linear()));

--- a/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
+++ b/drake/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
@@ -184,7 +184,7 @@ pick_and_place::PlannerConfiguration DoParsePlannerConfiguration(
 
   // Extract target dimensions
   WorldSimTreeBuilder<double> tree_builder;
-  tree_builder.StoreModel(
+  tree_builder.StoreDrakeModel(
       "target", GetPlanningModelPathOrThrow(
                     configuration,
                     configuration.object(planner_configuration.target_index)));

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
@@ -51,7 +51,7 @@ IiwaAndWsgPlantWithStateEstimator<T>::IiwaAndWsgPlantWithStateEstimator(
     // motions.
     auto single_arm = std::make_unique<RigidBodyTree<double>>();
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        iiwa_instances[i].model_path, multibody::joints::kFixed,
+        iiwa_instances[i].absolute_model_path, multibody::joints::kFixed,
         iiwa_instances[i].world_offset, single_arm.get());
 
     auto iiwa_controller = builder.template AddController<
@@ -113,7 +113,7 @@ IiwaAndWsgPlantWithStateEstimator<T>::IiwaAndWsgPlantWithStateEstimator(
     const std::string suffix{"_" + std::to_string(i)};
     objects_.emplace_back(new RigidBodyTree<T>);
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        object_instances[i].model_path, multibody::joints::kQuaternion,
+        object_instances[i].absolute_model_path, multibody::joints::kQuaternion,
         object_instances[i].world_offset, objects_.back().get());
     auto object_state_est =
         base_builder->template AddSystem<OracularStateEstimation<T>>(

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/multi_arm_with_gripper_demo.cc
@@ -24,10 +24,11 @@ std::unique_ptr<RigidBodyTree<double>> build_tree(
 
   // Adds models to the simulation builder. Instances of these models can be
   // subsequently added to the world.
-  tree_builder->StoreModel("iiwa",
-                           "drake/manipulation/models/iiwa_description/urdf/"
-                           "iiwa14_polytope_collision.urdf");
-  tree_builder->StoreModel(
+  tree_builder->StoreDrakeModel(
+      "iiwa",
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "iiwa14_polytope_collision.urdf");
+  tree_builder->StoreDrakeModel(
       "wsg",
       "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
 
@@ -102,7 +103,7 @@ void main() {
   for (const auto& info : iiwa_info) {
     auto single_arm = std::make_unique<RigidBodyTree<double>>();
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        info.model_path, multibody::joints::kFixed, info.world_offset,
+        info.absolute_model_path, multibody::joints::kFixed, info.world_offset,
         single_arm.get());
 
     auto controller = builder.AddController<

--- a/drake/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_world/test/iiwa_wsg_diagram_factory_test.cc
@@ -22,13 +22,15 @@ constexpr int kNumObjectVelocities = 6;
 class IiwaAndWsgPlantWithStateEstimatorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    tree_builder_.StoreModel("iiwa",
-                             "drake/manipulation/models/iiwa_description/urdf/"
-                             "iiwa14_polytope_collision.urdf");
-    tree_builder_.StoreModel("wsg",
-                             "drake/manipulation/models/wsg_50_description"
-                             "/sdf/schunk_wsg_50_ball_contact.sdf");
-    tree_builder_.StoreModel(
+    tree_builder_.StoreDrakeModel(
+        "iiwa",
+        "drake/manipulation/models/iiwa_description/urdf/"
+        "iiwa14_polytope_collision.urdf");
+    tree_builder_.StoreDrakeModel(
+        "wsg",
+        "drake/manipulation/models/wsg_50_description"
+        "/sdf/schunk_wsg_50_ball_contact.sdf");
+    tree_builder_.StoreDrakeModel(
         "object",
         "drake/examples/kuka_iiwa_arm/models/objects/simple_cuboid.urdf");
   }

--- a/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/drake/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -76,14 +76,16 @@ std::unique_ptr<RigidBodyPlant<T>> BuildCombinedPlant(
 
   // Adds models to the simulation builder. Instances of these models can be
   // subsequently added to the world.
-  tree_builder->StoreModel("iiwa", kIiwaUrdf);
-  tree_builder->StoreModel("table",
-                           "drake/examples/kuka_iiwa_arm/models/table/"
-                           "extra_heavy_duty_table_surface_only_collision.sdf");
-  tree_builder->StoreModel("box",
-                           "drake/examples/kuka_iiwa_arm/models/objects/"
-                           "block_for_pick_and_place.urdf");
-  tree_builder->StoreModel(
+  tree_builder->StoreDrakeModel("iiwa", kIiwaUrdf);
+  tree_builder->StoreDrakeModel(
+      "table",
+      "drake/examples/kuka_iiwa_arm/models/table/"
+      "extra_heavy_duty_table_surface_only_collision.sdf");
+  tree_builder->StoreDrakeModel(
+      "box",
+      "drake/examples/kuka_iiwa_arm/models/objects/"
+      "block_for_pick_and_place.urdf");
+  tree_builder->StoreDrakeModel(
       "wsg",
       "drake/manipulation/models/wsg_50_description"
       "/sdf/schunk_wsg_50_ball_contact.sdf");

--- a/drake/manipulation/sensors/xtion.cc
+++ b/drake/manipulation/sensors/xtion.cc
@@ -46,7 +46,7 @@ void Xtion::AddToTree(WorldSimTreeBuilder<double>* tree_builder,
   fixture_frame_ = fixture_frame;
   const std::string urdf_path =
       "drake/manipulation/models/xtion_description/urdf/xtion.urdf";
-  tree_builder->StoreModel(name_, urdf_path);
+  tree_builder->StoreDrakeModel(name_, urdf_path);
   int xtion_id = tree_builder->AddModelInstanceToFrame(
       name_, fixture_frame_, drake::multibody::joints::kFixed);
   sensor_frame_ =

--- a/drake/manipulation/util/BUILD.bazel
+++ b/drake/manipulation/util/BUILD.bazel
@@ -162,6 +162,7 @@ drake_cc_googletest(
     data = [
         "//drake/examples/kuka_iiwa_arm:models",
         "//drake/manipulation/models/iiwa_description:models",
+        "//drake/manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":sim_diagram_builder",

--- a/drake/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/drake/manipulation/util/test/sim_diagram_builder_test.cc
@@ -25,10 +25,11 @@ std::unique_ptr<RigidBodyTree<double>> build_tree(
 
   // Adds models to the simulation builder. Instances of these models can be
   // subsequently added to the world.
-  tree_builder->StoreModel("iiwa",
-                           "drake/manipulation/models/iiwa_description/urdf/"
-                           "iiwa14_polytope_collision.urdf");
-  tree_builder->StoreModel(
+  tree_builder->StoreDrakeModel(
+      "iiwa",
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "iiwa14_polytope_collision.urdf");
+  tree_builder->StoreDrakeModel(
       "wsg",
       "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
 
@@ -92,8 +93,8 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
   for (const auto& info : iiwa_info) {
     auto single_arm = std::make_unique<RigidBodyTree<double>>();
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        info.model_path, multibody::joints::kFixed, info.world_offset,
-        single_arm.get());
+        info.absolute_model_path, multibody::joints::kFixed,
+        info.world_offset, single_arm.get());
 
     auto controller = builder.template AddController<
         systems::controllers::InverseDynamicsController<double>>(

--- a/drake/manipulation/util/world_sim_tree_builder.cc
+++ b/drake/manipulation/util/world_sim_tree_builder.cc
@@ -94,18 +94,18 @@ int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
   DRAKE_DEMAND(extension == ".urdf" || extension == ".sdf");
   if (extension == ".urdf") {
     table = drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-        FindResourceOrThrow(model_map_[model_name]), floating_base_type,
+        model_map_[model_name], floating_base_type,
         weld_to_frame, rigid_body_tree_.get());
 
   } else if (extension == ".sdf") {
     table = drake::parsers::sdf::AddModelInstancesFromSdfFile(
-        FindResourceOrThrow(model_map_[model_name]), floating_base_type,
+        model_map_[model_name], floating_base_type,
         weld_to_frame, rigid_body_tree_.get());
   }
   const int model_instance_id = table.begin()->second;
 
   ModelInstanceInfo<T> info;
-  info.model_path = FindResourceOrThrow(model_map_[model_name]);
+  info.absolute_model_path = model_map_[model_name];
   info.instance_id = model_instance_id;
   info.world_offset = weld_to_frame;
   instance_id_to_model_info_[model_instance_id] = info;
@@ -119,11 +119,19 @@ void WorldSimTreeBuilder<T>::AddGround() {
 }
 
 template <typename T>
-void WorldSimTreeBuilder<T>::StoreModel(const std::string& model_name,
-                                        const std::string& model_path) {
+void WorldSimTreeBuilder<T>::StoreModel(
+    const std::string& model_name,
+    const std::string& absolute_model_path) {
   DRAKE_DEMAND(model_map_.find(model_name) == model_map_.end());
   model_map_.insert(
-      std::pair<std::string, std::string>(model_name, model_path));
+      std::pair<std::string, std::string>(model_name, absolute_model_path));
+}
+
+template <typename T>
+void WorldSimTreeBuilder<T>::StoreDrakeModel(
+    const std::string& model_name,
+    const std::string& model_path) {
+  StoreModel(model_name, FindResourceOrThrow(model_path));
 }
 
 template class WorldSimTreeBuilder<double>;

--- a/drake/manipulation/util/world_sim_tree_builder.h
+++ b/drake/manipulation/util/world_sim_tree_builder.h
@@ -13,7 +13,7 @@ namespace manipulation {
 namespace util {
 
 template<typename T> struct ModelInstanceInfo {
-  std::string model_path;
+  std::string absolute_model_path;
   int instance_id;
   std::shared_ptr<RigidBodyFrame<T>> world_offset;
 };
@@ -74,17 +74,23 @@ class WorldSimTreeBuilder {
   WorldSimTreeBuilder(const WorldSimTreeBuilder<T>& other) = delete;
   WorldSimTreeBuilder& operator=(const WorldSimTreeBuilder<T>& other) = delete;
 
-  /// Adds a model to the internal model database. Models are described by
-  /// @p model_name coupled with URDF/SDF paths in @p model_path. Instances
-  /// of these models can then be added to the world via the various
-  /// `AddFoo()` methods provided by this class. Note that @p model_name is
-  /// user-selectable but must be unique among all of the models that are
-  /// stored.
+  /// Adds a model to the internal model database. Models are
+  /// described by @p model_name coupled with URDF/SDF paths in @p
+  /// absolute_model_path. Instances of these models can then be added
+  /// to the world via the various `AddFoo()` methods provided by this
+  /// class. Note that @p model_name is user-selectable but must be
+  /// unique among all of the models that are stored.
   ///
   /// @see AddObjectToFrame
   /// @see AddFloatingObject
   /// @see AddFixedObject
-  void StoreModel(const std::string& model_name, const std::string& model_path);
+  void StoreModel(const std::string& model_name,
+                  const std::string& absolute_model_path);
+
+  /// Like StoreModel, but uses FindResourceOrThrow to search inside
+  /// the drake resource search path.
+  void StoreDrakeModel(const std::string& model_name,
+                       const std::string& model_path);
 
   /// Gets a unique pointer to the `RigidBodyTree` that was built.
   /// This method can only be called if it was not previously called.


### PR DESCRIPTION
Make WorldSimTreeBuilder::StoreModel() use an absolute path.

Add StoreDrakeModel() for cases where we actually want relative paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7566)
<!-- Reviewable:end -->
