### PR TITLE
Change characteristic "area" to "radius"

### DIFF
--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -58,8 +58,8 @@ DEFINE_double(ud, 0.2, "The dynamic coefficient of friction");
 DEFINE_double(v_tol, 0.01,
               "The maximum slipping speed allowed during stiction (m/s)");
 DEFINE_double(dissipation, 2, "The contact model's dissipation (s/m)");
-DEFINE_double(contact_area, 1e-3,
-              "The characteristic scale of contact area (m^2)");
+DEFINE_double(contact_radius, 1e-3,
+              "The characteristic scale of radius (m) of the contact area");
 DEFINE_double(sim_duration, 3, "The simulation duration (s)");
 DEFINE_int32(pin_count, 10, "The number of pins -- in the range [0, 10]");
 DEFINE_bool(playback, true, "If true, loops playback of simulation");
@@ -82,7 +82,7 @@ int main() {
   cout << "\tstatic friction:  " << FLAGS_us << "\n";
   cout << "\tdynamic friction: " << FLAGS_ud << "\n";
   cout << "\tslip threshold:   " << FLAGS_v_tol << "\n";
-  cout << "\tContact area:     " << FLAGS_contact_area << "\n";
+  cout << "\tContact radius:   " << FLAGS_contact_radius << "\n";
   cout << "\tdissipation:      " << FLAGS_dissipation << "\n";
   cout << "\tpin count:        " << FLAGS_pin_count << "\n";
 
@@ -121,7 +121,7 @@ int main() {
       .set_friction(FLAGS_us, FLAGS_ud);
   plant.set_default_compliant_material(default_material);
   CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = FLAGS_contact_area;
+  model_parameters.characteristic_radius = FLAGS_contact_radius;
   model_parameters.v_stiction_tolerance = FLAGS_v_tol;
   plant.set_contact_model_parameters(model_parameters);
 

--- a/examples/contact_model/rigid_gripper.cc
+++ b/examples/contact_model/rigid_gripper.cc
@@ -43,8 +43,8 @@ DEFINE_double(youngs_modulus, 1e8, "The contact material Young's modulus (Pa)");
 DEFINE_double(dissipation, 2.0, "The contact material dissipation (s/m)");
 DEFINE_double(v_stiction_tolerance, 0.01,
               "The maximum slipping speed allowed during stiction (m/s)");
-DEFINE_double(contact_area, 1e-4,
-              "The characteristic scale of contact area (m^2)");
+DEFINE_double(contact_radius, 1e-4,
+              "The characteristic scale of radius (m) of the contact area");
 DEFINE_double(sim_duration, 5, "Amount of time to simulate (s)");
 DEFINE_bool(playback, true,
             "If true, simulation begins looping playback when complete");
@@ -113,7 +113,7 @@ int main() {
       .set_friction(FLAGS_us, FLAGS_ud);
   plant->set_default_compliant_material(default_material);
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = FLAGS_contact_area;
+  model_parameters.characteristic_radius = FLAGS_contact_radius;
   model_parameters.v_stiction_tolerance = FLAGS_v_stiction_tolerance;
   plant->set_contact_model_parameters(model_parameters);
 

--- a/examples/contact_model/sliding_bricks.cc
+++ b/examples/contact_model/sliding_bricks.cc
@@ -45,8 +45,8 @@ DEFINE_double(ud, 0.5, "The dynamic coefficient of friction");
 DEFINE_double(v_tol, 0.01,
               "The maximum slipping speed allowed during stiction (m/s)");
 DEFINE_double(dissipation, 1.0, "The contact model's dissipation (s/m)");
-DEFINE_double(contact_area, 1e-3,
-              "The characteristic scale of contact area (m^2)");
+DEFINE_double(contact_radius, 1e-3,
+              "The characteristic scale of radius (m) of the contact area");
 DEFINE_double(sim_duration, 3, "The simulation duration (s)");
 DEFINE_bool(playback, true,
             "If true, enters looping playback after sim finished");
@@ -73,7 +73,7 @@ int main() {
   std::cout << "\tStatic friction:  " << FLAGS_us << "\n";
   std::cout << "\tDynamic friction: " << FLAGS_ud << "\n";
   std::cout << "\tSlip Threshold:   " << FLAGS_v_tol << "\n";
-  std::cout << "\tContact area:     " << FLAGS_contact_area << "\n";
+  std::cout << "\tContact radius    " << FLAGS_contact_radius << "\n";
   std::cout << "\tDissipation:      " << FLAGS_dissipation << "\n";
 
   DiagramBuilder<double> builder;
@@ -102,7 +102,7 @@ int main() {
       .set_friction(FLAGS_us, FLAGS_ud);
   plant.set_default_compliant_material(default_material);
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = FLAGS_contact_area;
+  model_parameters.characteristic_radius = FLAGS_contact_radius;
   model_parameters.v_stiction_tolerance = FLAGS_v_tol;
   plant.set_contact_model_parameters(model_parameters);
 

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -48,8 +48,8 @@ DEFINE_double(dissipation, 5, "Contact Dissipation (s/m)");
 DEFINE_double(static_friction, 0.5, "Static Friction");
 DEFINE_double(dynamic_friction, 0.2, "Dynamic Friction");
 DEFINE_double(v_stiction_tol, 0.01, "v Stiction Tol (m/s)");
-DEFINE_double(contact_area, 2e-4,
-              "The characteristic scale of contact area (m^2)");
+DEFINE_double(contact_radius, 2e-4,
+              "The characteristic scale of radius (m) of the contact area");
 DEFINE_bool(use_visualizer, true, "Use Drake Visualizer?");
 
 namespace drake {
@@ -158,7 +158,7 @@ int DoMain() {
       .set_friction(FLAGS_static_friction, FLAGS_dynamic_friction);
   model_ptr->set_default_compliant_material(default_material);
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = FLAGS_contact_area;
+  model_parameters.characteristic_radius = FLAGS_contact_radius;
   model_parameters.v_stiction_tolerance = FLAGS_v_stiction_tol;
   model_ptr->set_contact_model_parameters(model_parameters);
 

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration.proto
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration.proto
@@ -85,9 +85,9 @@ message CompliantModelParameters {
     // Stiction velocity tolerance (m/s)
     // DEFAULT: 0.01
     optional double v_stiction_tolerance = 1;
-    // Characteristic area (m^2)
+    // Characteristic radius (m)
     // DEFAULT: 2e-4
-    optional double characteristic_area = 2;
+    optional double characteristic_radius = 2;
 }
 
 // Next ID: 3

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_configuration_parsing.cc
@@ -119,11 +119,11 @@ void ExtractCompliantParameters(
     pick_and_place::SimulatedPlantConfiguration* plant_configuration) {
   if (configuration.has_compliant_model_parameters()) {
     const auto& proto_parameters = configuration.compliant_model_parameters();
-    if (proto_parameters.characteristic_area() > 0) {
-      plant_configuration->contact_model_parameters.characteristic_area =
-          proto_parameters.characteristic_area();
-    } else if (proto_parameters.characteristic_area() < 0) {
-      throw std::runtime_error("'characteristic_area' must be positive");
+    if (proto_parameters.characteristic_radius() > 0) {
+      plant_configuration->contact_model_parameters.characteristic_radius =
+          proto_parameters.characteristic_radius();
+    } else if (proto_parameters.characteristic_radius() < 0) {
+      throw std::runtime_error("'characteristic_radius' must be positive");
     }
     if (proto_parameters.v_stiction_tolerance() > 0) {
       plant_configuration->contact_model_parameters.v_stiction_tolerance =

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/test/pick_and_place_configuration_parsing_test.cc
@@ -148,8 +148,8 @@ void ValidateSimulatedPlantConfiguration(
       plant_configuration.contact_model_parameters;
   const systems::CompliantContactModelParameters expected_parameters =
       expected_plant_configuration.contact_model_parameters;
-  EXPECT_EQ(test_parameters.characteristic_area,
-            expected_parameters.characteristic_area);
+  EXPECT_EQ(test_parameters.characteristic_radius,
+            expected_parameters.characteristic_radius);
   EXPECT_EQ(test_parameters.v_stiction_tolerance,
             expected_parameters.v_stiction_tolerance);
 
@@ -290,8 +290,8 @@ GTEST_TEST(ConfigurationParsingCompliantParameterTests, AllDefaults) {
   const auto& parsed_parameters = parsed_configuration.contact_model_parameters;
   EXPECT_EQ(parsed_parameters.v_stiction_tolerance,
             default_parameters.v_stiction_tolerance);
-  EXPECT_EQ(parsed_parameters.characteristic_area,
-            default_parameters.characteristic_area);
+  EXPECT_EQ(parsed_parameters.characteristic_radius,
+            default_parameters.characteristic_radius);
 
   const auto& parsed_material = parsed_configuration.default_contact_material;
   EXPECT_TRUE(parsed_material.youngs_modulus_is_default());
@@ -316,7 +316,7 @@ GTEST_TEST(ConfigurationParsingCompliantParameterTests, BadValues) {
       "compliant_model_parameters { v_stiction_tolerance: -1 }"),
                std::runtime_error);
   EXPECT_THROW(ParseSimulatedPlantConfigurationStringOrThrow(
-      "compliant_model_parameters { characteristic_area: -1 }"),
+      "compliant_model_parameters { characteristic_radius: -1 }"),
                std::runtime_error);
 
   // Special friction logic -- only one defined and u_d > u_s.
@@ -338,7 +338,7 @@ GTEST_TEST(ConfigurationParsingCompliantParameterTests, ConfiguredValues) {
       R"_(
 compliant_model_parameters {
   v_stiction_tolerance: 1e-3
-  characteristic_area: 1e-1
+  characteristic_radius: 1e-1
 }
 
 default_compliant_material {
@@ -353,7 +353,7 @@ default_compliant_material {
 
   const auto& parsed_parameters = parsed_configuration.contact_model_parameters;
   EXPECT_EQ(parsed_parameters.v_stiction_tolerance, 1e-3);
-  EXPECT_EQ(parsed_parameters.characteristic_area, 1e-1);
+  EXPECT_EQ(parsed_parameters.characteristic_radius, 1e-1);
 
   const auto& parsed_material = parsed_configuration.default_contact_material;
   EXPECT_FALSE(parsed_material.youngs_modulus_is_default());

--- a/examples/pr2/pr2_passive_simulation.cc
+++ b/examples/pr2/pr2_passive_simulation.cc
@@ -76,9 +76,9 @@ int DoMain() {
   plant_->set_default_compliant_material(default_material);
 
   const double kStictionSlipTolerance = 1e-3;  // m/s
-  const double kContactArea = 2e-4;  // m^2
+  const double kContactRadius = 2e-4;  // m
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = kContactArea;
+  model_parameters.characteristic_radius = kContactRadius;
   model_parameters.v_stiction_tolerance = kStictionSlipTolerance;
   plant_->set_contact_model_parameters(model_parameters);
 

--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -202,9 +202,9 @@ GTEST_TEST(SchunkWsgLiftTest, BoxLiftTest) {
   plant->set_default_compliant_material(default_material);
 
   const double kVStictionTolerance = 0.01;  // m/s
-  const double kContactArea = 2e-4;  // m^2
+  const double kContactRadius = 2e-4;  // m
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = kContactArea;
+  model_parameters.characteristic_radius = kContactRadius;
   model_parameters.v_stiction_tolerance = kVStictionTolerance;
   plant->set_contact_model_parameters(model_parameters);
 

--- a/examples/valkyrie/valkyrie_simulator.h
+++ b/examples/valkyrie/valkyrie_simulator.h
@@ -66,9 +66,9 @@ class ValkyrieSimulationDiagram : public systems::Diagram<double> {
     plant_->set_default_compliant_material(default_material);
 
     const double kStictionSlipTolerance = 0.01;  // m/s
-    const double kContactArea = 2e-3;  // m^2
+    const double kContactRadius = 2e-3;  // m
     systems::CompliantContactModelParameters model_parameters;
-    model_parameters.characteristic_area = kContactArea;
+    model_parameters.characteristic_radius = kContactRadius;
     model_parameters.v_stiction_tolerance = kStictionSlipTolerance;
     plant_->set_contact_model_parameters(model_parameters);
 

--- a/manipulation/util/world_sim_tree_builder.cc
+++ b/manipulation/util/world_sim_tree_builder.cc
@@ -41,7 +41,7 @@ WorldSimTreeBuilder<T>::WorldSimTreeBuilder() {
   //     Young's modulus values produces an effective Young's modulus half as
   //     large.
   contact_model_parameters_.v_stiction_tolerance = 0.01;  // m/s
-  contact_model_parameters_.characteristic_area = 1.0;  // m^2
+  contact_model_parameters_.characteristic_radius = 1.0;  // m^2
   default_contact_material_.set_youngs_modulus(20000);  // Pa
   default_contact_material_.set_dissipation(2);  // s/m
   default_contact_material_.set_friction(0.9, 0.5);

--- a/multibody/rigid_body_plant/compliant_contact_model.cc
+++ b/multibody/rigid_body_plant/compliant_contact_model.cc
@@ -24,9 +24,9 @@ template <typename T>
 void CompliantContactModel<T>::set_model_parameters(
     const CompliantContactModelParameters& values) {
   DRAKE_DEMAND(values.v_stiction_tolerance > 0 &&
-      values.characteristic_area > 0);
+      values.characteristic_radius > 0);
   inv_v_stiction_tolerance_ = 1.0 / values.v_stiction_tolerance;
-  characteristic_area_ = values.characteristic_area;
+  characteristic_radius_ = values.characteristic_radius;
 }
 
 template <typename T>
@@ -124,7 +124,7 @@ VectorX<T> CompliantContactModel<T>::ComputeContactForce(
       const T x = T(-pair.distance);
       const T x_dot = -v_CBcAc_C(2);
 
-      const T fK = parameters.youngs_modulus() * x * characteristic_area_;
+      const T fK = parameters.youngs_modulus() * x * characteristic_radius_;
       const T fD = fK * parameters.dissipation() * x_dot;
       const T fN = fK + fD;
       if (fN <= 0) continue;

--- a/multibody/rigid_body_plant/compliant_contact_model.h
+++ b/multibody/rigid_body_plant/compliant_contact_model.h
@@ -13,7 +13,7 @@ namespace systems {
 /// See @ref drake_contacts for details.
 struct CompliantContactModelParameters {
   double v_stiction_tolerance{1e-2};      // 1 cm/s (in m/s).
-  double characteristic_area{2e-4};       // Two square-cm (in m²).
+  double characteristic_radius{2e-4};     // 0.2 mm (in m).
 };
 
 /// This class encapsulates the compliant contact model force computations as
@@ -93,8 +93,8 @@ class CompliantContactModel {
   // optimize for the division.
   double inv_v_stiction_tolerance_{
       1.0 / CompliantContactModelParameters().v_stiction_tolerance};
-  double characteristic_area_{
-      CompliantContactModelParameters().characteristic_area};
+  double characteristic_radius_{
+      CompliantContactModelParameters().characteristic_radius};
 
   // The default compliant material properties for *this* model instance.
   // By default, it uses all hard-coded values.

--- a/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
+++ b/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
@@ -55,7 +55,7 @@ class CompliantContactModelTest : public ContactResultTestCommon {
     compliant_contact_model_->set_default_material(material);
     CompliantContactModelParameters contact_parameters;
     contact_parameters.v_stiction_tolerance = kVStictionTolerance;
-    contact_parameters.characteristic_area = kContactArea;
+    contact_parameters.characteristic_radius = kContactRadius;
     compliant_contact_model_->set_model_parameters(contact_parameters);
 
     // The state to test is the default state of the tree (0 velocities

--- a/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -51,7 +51,7 @@ class ContactResultTest : public ContactResultTestCommon {
     plant_->set_default_compliant_material(MakeDefaultMaterial());
 
     systems::CompliantContactModelParameters model_parameters;
-    model_parameters.characteristic_area = kContactArea;
+    model_parameters.characteristic_radius = kContactRadius;
     model_parameters.v_stiction_tolerance = kVStictionTolerance;
     plant_->set_contact_model_parameters(model_parameters);
 

--- a/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -75,7 +75,7 @@ class ContactFormulaTest : public ::testing::Test {
     plant_->set_default_compliant_material(default_material);
 
     systems::CompliantContactModelParameters model_parameters;
-    model_parameters.characteristic_area = contact_area_;
+    model_parameters.characteristic_radius = contact_radius_;
     model_parameters.v_stiction_tolerance = v_stiction_tolerance_;
     plant_->set_contact_model_parameters(model_parameters);
 
@@ -142,7 +142,7 @@ class ContactFormulaTest : public ::testing::Test {
   const double static_friction_ = 0.7;
   const double dynamic_friction_ = 0.5;
   const double v_stiction_tolerance_ = 0.01;  // m/s
-  const double contact_area_ = 2;  // m^2
+  const double contact_radius_ = 2;  // m
   const double dissipation_ = 0.5;  // s/m
 
   // dummy_precision is a very tight threshold for these tests. It is well

--- a/multibody/rigid_body_plant/test/contact_result_test_common.h
+++ b/multibody/rigid_body_plant/test/contact_result_test_common.h
@@ -70,7 +70,7 @@ class ContactResultTestCommon : public ::testing::Test {
   const double kContactStaticFriction = kStaticFriction;
   const double kConstantDynamicFriction = kDynamicFriction;
   const double kVStictionTolerance = 0.01;  // m/s
-  const double kContactArea = 1.0;  // m^2
+  const double kContactRadius = 1.0;  // m
 
   // Places two spheres on the x-y plane mirrored across the x_anchor_ from
   // each other such there is 2 * `distance` units gap between them.  Negative

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -109,7 +109,7 @@ GTEST_TEST(DiagramBuilderTest, CycleButNoLoopPortLevel) {
   // +----------------+
   //
   // The input feeds through to the echo output, but it is the constant output
-  // that is connected to input. So, the system has direct feeedthrough, the
+  // that is connected to input. So, the system has direct feedthrough, the
   // diagram has a cycle at the *system* level, but there is no algebraic loop.
 
   auto echo = builder.AddSystem<ConstAndEcho>();

--- a/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -106,7 +106,7 @@ int main() {
   plant->set_default_compliant_material(default_material);
 
   systems::CompliantContactModelParameters model_parameters;
-  model_parameters.characteristic_area = 2e-4;  // m^2
+  model_parameters.characteristic_radius = 2e-4;  // m
   model_parameters.v_stiction_tolerance = 0.01;  // m/s
   plant->set_contact_model_parameters(model_parameters);
 


### PR DESCRIPTION
Bad dimensional analysis snuck through PRs. This updates the *discussion*
of the model parameter. It changes the incorrect "area" to be a characteristic "radius".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7568)
<!-- Reviewable:end -->
