### PR TITLE
Use PatchELF instead of chrpath to fix up libdrake.so RPATH

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -97,6 +97,7 @@ lldb-4.0
 make
 mesa-common-dev
 openjdk-8-jdk
+patchelf
 patchutils
 pkg-config
 protobuf-compiler

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -214,6 +214,12 @@ toolchain {
   linker_flag: "-fuse-ld=gold"
   linker_flag: "-B/usr/bin"
   linker_flag: "-B/usr/bin"
+  # On Linux, we need to disable "new" dtags in the linker so that we use
+  # RPATH instead of RUNPATH.  When doing runtime linking, RPATH is checked
+  # *before* LD_LIBRARY_PATH, which is important to avoid using the MATLAB
+  # versions of certain libraries (protobuf).
+  linker_flag: "-Wl,--disable-new-dtags"
+  linker_flag: "-Wl,-rpath=XXXXXXXXXXXXXXXXXXXXXXXXX"
   needsPic: true
   objcopy_embed_flag: "-I"
   objcopy_embed_flag: "binary"

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -181,15 +181,6 @@ def linux_fix_rpaths(dst_full):
     # MATLAB that are added to the LD_LIBRARY_PATH.
     rpath.add('/usr/lib/x86_64-linux-gnu/')
 
-    # Work around https://github.com/NixOS/patchelf/issues/94. The version
-    # of patchelf distributed with Ubuntu 16.04 also does not have the
-    # --remove-rpath option, so use chrpath instead.
-    check_output(
-        ["chrpath",
-         "--delete",
-         dst_full]
-    )
-
     # Replace build tree RPATH with computed install tree RPATH. Build tree
     # RPATH are automatically removed by this call. RPATH will contain the
     # necessary relative paths to find the libraries that are needed. RPATH

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -152,19 +152,6 @@ def macos_fix_rpaths(basename, dst_full):
 
 
 def linux_fix_rpaths(dst_full):
-    # Check that file has an rpath or a runpath tag
-    try:
-        check_output(["chrpath", "-l", dst_full])
-    except OSError as ex:
-        if ex.errno == 2 and ex.strerror == "No such file or directory":
-            print("`chrpath` not found. Please run install_prereqs.sh.")
-        raise ex
-    except CalledProcessError as ex:
-        if ex.returncode == 2 and \
-                ex.output.strip().endswith('no rpath or runpath tag found.'):
-            # Cannot be modified with `chrpath`, so we skip it.
-            return
-        raise ex
     # Check if file dependencies are found and not in install prefix.
     # The found libraries outside of the install prefix are system
     # libraries and we do not worry about these. We only make sure that
@@ -189,18 +176,31 @@ def linux_fix_rpaths(dst_full):
             os.path.relpath(libs[soname][0], lib_dirname)
         )
         rpath.add('$ORIGIN' + '/' + diff_path)
+
+    # Ensure that system libraries get loaded instead of those bundled with
+    # MATLAB that are added to the LD_LIBRARY_PATH.
+    rpath.add('/usr/lib/x86_64-linux-gnu/')
+
+    # Work around https://github.com/NixOS/patchelf/issues/94. The version
+    # of patchelf distributed with Ubuntu 16.04 also does not have the
+    # --remove-rpath option, so use chrpath instead.
+    check_output(
+        ["chrpath",
+         "--delete",
+         dst_full]
+    )
+
     # Replace build tree RPATH with computed install tree RPATH. Build tree
     # RPATH are automatically removed by this call. RPATH will contain the
     # necessary relative paths to find the libraries that are needed. RPATH
     # will typically be set to `$ORIGIN` or `$ORIGIN/../../..` .
-    if rpath:
-        str_rpath = ":".join(x for x in rpath)
-        check_output(
-            ['chrpath',
-             "-r", str_rpath,
-             dst_full]
-        )
-
+    str_rpath = ":".join(x for x in rpath)
+    check_output(
+        ["patchelf",
+         "--force-rpath",  # We need to override LD_LIBRARY_PATH.
+         "--set-rpath", str_rpath,
+         dst_full]
+    )
 
 def create_java_launcher(filename, classpath, main_class):
     # In list-only mode, just display the filename, don't do any real work.


### PR DESCRIPTION
We need to set `RPATH` instead of `RUNPATH` so that `libdrake.so` does not use versions of libraries in `LD_LIBRARY_PATH`, which is set by MATLAB. This is not possible with `chrpath`, so we use PatchELF (and `chrpath` to work around https://github.com/NixOS/patchelf/issues/94).

Blocks #7323. FYI @clalancette.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7569)
<!-- Reviewable:end -->
