### PR TITLE
Put RGBD tests back to manual

### DIFF
--- a/drake/systems/sensors/BUILD.bazel
+++ b/drake/systems/sensors/BUILD.bazel
@@ -468,7 +468,7 @@ sh_test(
     args = [
         # TODO(eric.cousineau): Find skylark rule that can resolve
         # "test/models/sphere.sdf" to the path below.
-        "--sdf_dir=drake/systems/sensors/test/models",
+        "--sdf_dir=" + native.package_name() + "/test/models",
         "--duration=0.1",
     ],
     data = [

--- a/drake/systems/sensors/BUILD.bazel
+++ b/drake/systems/sensors/BUILD.bazel
@@ -426,7 +426,10 @@ drake_cc_googletest(
     local = 1,
     # Disable under LeakSanitizer and Valgrind Memcheck due to driver-related
     # leaks. For more information, see #7520.
+    # TODO(jwnimmer-tri) Marked manual because it opens windows on the
+    # developer's desktop.
     tags = [
+        "manual",
         "no_lsan",
         "no_memcheck",
     ],
@@ -450,7 +453,10 @@ drake_cc_googletest(
     local = 1,
     # Disable under LeakSanitizer and Valgrind Memcheck due to driver-related
     # leaks. For more information, see #7520.
+    # TODO(jwnimmer-tri) Marked manual because it opens windows on the
+    # developer's desktop.
     tags = [
+        "manual",
         "no_lsan",
         "no_memcheck",
     ],
@@ -476,7 +482,10 @@ sh_test(
     ],
     # Disable under LeakSanitizer and Valgrind Memcheck due to driver-related
     # leaks. For more information, see #7520.
+    # TODO(jwnimmer-tri) Marked manual because it opens windows on the
+    # developer's desktop.
     tags = [
+        "manual",
         "no_lsan",
         "no_memcheck",
     ],


### PR DESCRIPTION
Relates #6996.
- Make test path spelling insensitive to Drake package name.
- Put rgbd tests back to manual.  This partially reverts 1a5325f.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7572)
<!-- Reviewable:end -->
