### PR TITLE
Use shared libraries for Bullet

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -107,9 +107,8 @@ cc_library(
 # required *.so's that are WORKSPACE downloads (such as VTK, Gurobi, etc).
 #
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
-# *.so files (Gurobi, LCM, Mosek, SCS, TinyXML2, VTK) for us, without us having
-# to know up-front here which dependencies are coming from the WORKSPACE in the
-# form of *.so.
+# *.so files for us, without us having to know up-front here which dependencies
+# are coming from the WORKSPACE in the form of *.so.
 cc_library(
     name = "drake_shared_library",
     hdrs = [":libdrake_headers"],
@@ -122,6 +121,7 @@ cc_library(
         ":gurobi_deps",
         ":mosek_deps",
         ":vtk_deps",
+        "@bullet//:BulletCollision",
         "@lcm",
         "@scs//:scsdir",
         "@tinyxml2",

--- a/tools/workspace/bullet/bullet-create-cps.py
+++ b/tools/workspace/bullet/bullet-create-cps.py
@@ -12,12 +12,12 @@ content = """
   "Cps-Version": "0.8.0",
   "Name": "Bullet",
   "Description": "Real-time collision detection and multi-physics simulation",
-  "License": "Zlib",
-  "Version": "%s",
-  "Default-Components": [
-    ":BulletCollision",
-    ":BulletDynamics"
+  "License": [
+    "LGPL-2.1+",
+    "Zlib"
   ],
+  "Version": "%s",
+  "Default-Components": [":BulletCollision"],
   "Components": {
     "BulletCollision": {
       "Type": "dylib",
@@ -25,30 +25,11 @@ content = """
       "Includes": ["@prefix@/include/bullet"],
       "Requires": [":LinearMath"]
     },
-    "BulletDynamics": {
-      "Type": "dylib",
-      "Location": "@prefix@/lib/libBulletDynamics.so",
-      "Includes": ["@prefix@/include/bullet"],
-      "Requires": [
-        ":BulletCollision",
-        ":LinearMath"
-      ]
-    },
     "LinearMath": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libLinearMath.so",
       "Definitions": ["BT_USE_DOUBLE_PRECISION"],
       "Includes": ["@prefix@/include/bullet"]
-    },
-    "BulletSoftBody": {
-      "Type": "dylib",
-      "Location": "@prefix@/lib/libBulletSoftBody.so",
-      "Includes": ["@prefix@/include/bullet"],
-      "Requires": [
-        ":BulletCollision",
-        ":BulletDynamics",
-        ":LinearMath"
-      ]
     }
   }
 }

--- a/tools/workspace/bullet/bullet.BUILD.bazel
+++ b/tools/workspace/bullet/bullet.BUILD.bazel
@@ -16,53 +16,53 @@ BULLET_COPTS = ["-Wno-all"]
 
 BULLET_INCLUDES = ["src"]
 
+LINEAR_MATH_HDRS = glob(["src/LinearMath/**/*.h"])
+
 # Keep defines in sync with Components.LinearMath.Definitions in
 # bullet-create-cps.py.
-cc_library(
-    name = "LinearMath",
-    srcs = glob(["src/LinearMath/**/*.cpp"]),
-    hdrs = glob(["src/LinearMath/**/*.h"]),
+LINEAR_MATH_DEFINES = ["BT_USE_DOUBLE_PRECISION"]
+
+cc_binary(
+    name = "libLinearMath.so",
+    srcs = glob(["src/LinearMath/**/*.cpp"]) + LINEAR_MATH_HDRS,
     copts = BULLET_COPTS,
-    defines = ["BT_USE_DOUBLE_PRECISION"],
+    defines = LINEAR_MATH_DEFINES,
     includes = BULLET_INCLUDES,
+    linkshared = 1,
+    visibility = ["//visibility:private"],
 )
 
 cc_library(
-    name = "BulletCollision",
-    srcs = glob(["src/BulletCollision/**/*.cpp"]),
-    hdrs = glob(["src/BulletCollision/**/*.h"]) + [
-        "src/btBulletCollisionCommon.h",
-    ],
+    name = "LinearMath",
+    srcs = ["libLinearMath.so"],
+    hdrs = LINEAR_MATH_HDRS,
+    copts = BULLET_COPTS,
+    defines = LINEAR_MATH_DEFINES,
+    includes = BULLET_INCLUDES,
+)
+
+BULLET_COLLISION_HDRS = glob(["src/BulletCollision/**/*.h"]) + [
+    "src/btBulletCollisionCommon.h",
+]
+
+# BulletCollision contains LGPL code so only build shared library.
+cc_binary(
+    name = "libBulletCollision.so",
+    srcs = glob(["src/BulletCollision/**/*.cpp"]) + BULLET_COLLISION_HDRS,
     copts = BULLET_COPTS,
     includes = BULLET_INCLUDES,
+    linkshared = 1,
+    visibility = ["//visibility:private"],
     deps = [":LinearMath"],
 )
 
 cc_library(
-    name = "BulletDynamics",
-    srcs = glob(["src/BulletDynamics/**/*.cpp"]),
-    hdrs = glob(["src/BulletDynamics/**/*.h"]) + [
-        "src/btBulletDynamicsCommon.h",
-    ],
+    name = "BulletCollision",
+    srcs = ["libBulletCollision.so"],
+    hdrs = BULLET_COLLISION_HDRS,
     copts = BULLET_COPTS,
     includes = BULLET_INCLUDES,
-    deps = [
-        ":BulletCollision",
-        ":LinearMath",
-    ],
-)
-
-cc_library(
-    name = "BulletSoftBody",
-    srcs = glob(["src/BulletSoftBody/**/*.cpp"]),
-    hdrs = glob(["src/BulletSoftBody/**/*.h"]),
-    copts = BULLET_COPTS,
-    includes = BULLET_INCLUDES,
-    deps = [
-        ":BulletCollision",
-        ":BulletDynamics",
-        ":LinearMath",
-    ],
+    deps = [":LinearMath"],
 )
 
 cmake_config(
@@ -76,10 +76,8 @@ install_cmake_config(package = "Bullet")
 install(
     name = "install",
     targets = [
-        ":BulletCollision",
-        ":BulletDynamics",
-        ":BulletSoftBody",
-        ":LinearMath",
+        ":libBulletCollision.so",
+        ":libLinearMath.so",
     ],
     hdr_dest = "include/bullet",
     hdr_strip_prefix = BULLET_INCLUDES,


### PR DESCRIPTION
BulletCollision actually contains some LGPL code, so it should be built as a shared library only. Also, we are moving away from building code that Drake does not use, so no longer build extra Bullet libraries, which are not even used by Director or Spartan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7582)
<!-- Reviewable:end -->
