### PR TITLE
Path length numerical estimation support for Multilane

### DIFF
--- a/automotive/maliput/api/test_utilities/maliput_types_compare.cc
+++ b/automotive/maliput/api/test_utilities/maliput_types_compare.cc
@@ -119,7 +119,7 @@ namespace test {
     error_message = error_message
                    + "Rotations are different at pitch angle. "
                    + "rot1.pitch(): " + std::to_string(rot1.pitch()) + " vs. "
-                   + "rot2.pitch(): " + std::to_string(rot1.pitch())
+                   + "rot2.pitch(): " + std::to_string(rot2.pitch())
                    + ", diff = " + std::to_string(delta) + ", tolerance = "
                    + std::to_string(tolerance) + "\n";
   }
@@ -128,7 +128,7 @@ namespace test {
     fails = true;
     error_message = error_message
                    + "Rotations are different at yaw angle. "
-                   + "rot1.yaw(): " + std::to_string(rot2.yaw()) + " vs. "
+                   + "rot1.yaw(): " + std::to_string(rot1.yaw()) + " vs. "
                    + "rot2.yaw(): " + std::to_string(rot2.yaw()) + ", diff = "
                    + std::to_string(delta) + ", tolerance = "
                    + std::to_string(tolerance) + "\n";

--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -53,6 +53,8 @@ drake_cc_library(
         "//common:unused",
         "//math:geometric_transform",
         "//math:saturate",
+        "//systems/analysis:antiderivative_function",
+        "//systems/analysis:scalar_initial_value_problem",
     ],
 )
 
@@ -148,6 +150,17 @@ drake_cc_googletest(
         ":loader",
         "//automotive/maliput/api/test_utilities",
         "//automotive/maliput/multilane/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multilane_road_curve_accuracy_test",
+    srcs = ["test/multilane_road_curve_accuracy_test.cc"],
+    deps = [
+        ":builder",
+        "//automotive/maliput/api/test_utilities",
+        ("//automotive/maliput/multilane/test_utilities:" +
+         "multilane_brute_force_integral"),
     ],
 )
 

--- a/automotive/maliput/multilane/arc_road_curve.cc
+++ b/automotive/maliput/multilane/arc_road_curve.cc
@@ -10,32 +10,20 @@ namespace drake {
 namespace maliput {
 namespace multilane {
 
-double ArcRoadCurve::p_from_s(double s, double r) const {
-  // TODO(@maddog-tri) We should take care of the superelevation() scale that
-  //                   will modify curve's path length.
-  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
-               superelevation().b() == 0. && superelevation().c() == 0. &&
-               superelevation().d() == 0.));
+double ArcRoadCurve::FastCalcPFromS(double s, double r) const {
   const double effective_radius = offset_radius(r);
-  DRAKE_THROW_UNLESS(effective_radius > 0.0);
   const double elevation_domain = effective_radius / radius_;
   return s / (p_scale() * std::sqrt(elevation_domain * elevation_domain +
                                     elevation().fake_gprime(1.) *
-                                        elevation().fake_gprime(1.)));
+                                    elevation().fake_gprime(1.)));
 }
 
-double ArcRoadCurve::s_from_p(double p, double r) const {
-  // TODO(@maddog-tri) We should take care of the superelevation() scale that
-  //                   will modify curve's path length.
-  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
-               superelevation().b() == 0. && superelevation().c() == 0. &&
-               superelevation().d() == 0.));
+double ArcRoadCurve::FastCalcSFromP(double p, double r) const {
   const double effective_radius = offset_radius(r);
-  DRAKE_THROW_UNLESS(effective_radius > 0.0);
   const double elevation_domain = effective_radius / radius_;
   return p * p_scale() * std::sqrt(elevation_domain * elevation_domain +
                                    elevation().fake_gprime(p) *
-                                       elevation().fake_gprime(p));
+                                   elevation().fake_gprime(p));
 }
 
 namespace {

--- a/automotive/maliput/multilane/arc_road_curve.h
+++ b/automotive/maliput/multilane/arc_road_curve.h
@@ -32,28 +32,33 @@ class ArcRoadCurve : public RoadCurve {
   /// @param superelevation CubicPolynomial object that represents the
   /// superelevation polynomial. See RoadCurve class constructor for more
   /// details.
-  /// @throws std::runtime_error When `radius` is not positive.
-  explicit ArcRoadCurve(const Vector2<double>& center, double radius,
-                        double theta0, double d_theta,
-                        const CubicPolynomial& elevation,
-                        const CubicPolynomial& superelevation)
-      : RoadCurve(elevation, superelevation),
-        center_(center),
-        radius_(radius),
-        theta0_(theta0),
-        d_theta_(d_theta) {
+  /// @param linear_tolerance The linear tolerance, in meters, for all
+  /// computations. See RoadCurve class constructor for more details.
+  /// @param scale_length The minimum spatial period of variation in the curve,
+  /// in meters. See RoadCurve class constructor for more details.
+  /// @param computation_policy Policy to guide all computations. If geared
+  /// towards speed, computations will make use of analytical expressions even
+  /// if not actually correct for the curve as specified.
+  /// @throw std::runtime_error if @p radius is not a positive number.
+  explicit ArcRoadCurve(
+      const Vector2<double>& center, double radius,
+      double theta0, double d_theta,
+      const CubicPolynomial& elevation,
+      const CubicPolynomial& superelevation,
+      double linear_tolerance = 0.01, double scale_length = 1.0,
+      const ComputationPolicy computation_policy =
+            ComputationPolicy::kPreferAccuracy)
+      : RoadCurve(linear_tolerance, scale_length,
+                  elevation, superelevation,
+                  computation_policy),
+        center_(center), radius_(radius), theta0_(theta0), d_theta_(d_theta) {
+    // TODO(hidmic): Remove default values in trailing arguments, which were
+    // added in the first place to defer the need to propagate changes upwards
+    // in the class hierarchy.
     DRAKE_THROW_UNLESS(radius > 0.0);
   }
 
   ~ArcRoadCurve() override = default;
-
-  /// @throws std::runtime_error When `r` makes the effective radius to be
-  /// negative or zero.
-  double p_from_s(double s, double r) const override;
-
-  /// @throws std::runtime_error When `r` makes the effective radius to be
-  /// negative or zero.
-  double s_from_p(double p, double r) const override;
 
   Vector2<double> xy_of_p(double p) const override {
     // The result will be computed with the following function:
@@ -111,19 +116,27 @@ class ArcRoadCurve : public RoadCurve {
                const api::HBounds& height_bounds) const override;
 
  private:
-  // Computes the absolute position along reference arc as an angle in
-  // range [theta0_, (theta0 + d_theta_)],
-  // as a function of parameter @p p (in domain [0, 1]).
-  double theta_of_p(double p) const { return theta0_ + (p * d_theta_); }
+  double FastCalcPFromS(double s, double r) const override;
+
+  double FastCalcSFromP(double p, double r) const override;
+
+  double CalcMinimumRadiusAtOffset(double r) const override {
+    return offset_radius(r);
+  }
 
   // Computes the radius of the reference arc offset at a distance @p r.
-  // Uses d_theta_'s sign (see ArcRoadCurve() for more details)  to add or
+  // Uses d_theta_'s sign (see ArcRoadCurve() for more details) to add or
   // or subtract @p r distance.
   // @param r Lateral offset of the reference curve over the z=0 plane.
   // @return The reference arc offset radius.
   double offset_radius(double r) const {
     return radius_ - std::copysign(1., d_theta_) * r;
   }
+
+  // Computes the absolute position along reference arc as an angle in
+  // range [theta0_, (theta0 + d_theta_)],
+  // as a function of parameter @p p (in domain [0, 1]).
+  double theta_of_p(double p) const { return theta0_ + (p * d_theta_); }
 
   // Center of rotation in z=0 plane, world coordinates, for the arc reference
   // curve.

--- a/automotive/maliput/multilane/cubic_polynomial.h
+++ b/automotive/maliput/multilane/cubic_polynomial.h
@@ -15,6 +15,7 @@ class CubicPolynomial {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CubicPolynomial)
 
   /// Default constructor, all zero coefficients.
+
   CubicPolynomial() : CubicPolynomial(0., 0., 0., 0.) {}
 
   /// Constructs a cubic polynomial given all four coefficients.
@@ -35,6 +36,20 @@ class CubicPolynomial {
 
   // Returns the d coefficient.
   double d() const { return d_; }
+
+  /// Returns the order of the polynomial, based on
+  /// its nonzero coefficients.
+  int order() const {
+    if (d_ != 0.0) return 3;
+    if (c_ != 0.0) return 2;
+    if (b_ != 0.0) return 1;
+    return 0;
+  }
+
+  /// Checks whether the polynomial is _exactly_ zero.
+  bool is_zero() const {
+    return (a_ == 0.0 && b_ == 0.0 && c_ == 0.0 && d_ == 0.0);
+  }
 
   /// Evaluates the polynomial f at @p p.
   double f_p(double p) const {

--- a/automotive/maliput/multilane/line_road_curve.cc
+++ b/automotive/maliput/multilane/line_road_curve.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/maliput/multilane/line_road_curve.h"
 
+#include "drake/common/unused.h"
 #include "drake/math/saturate.h"
 
 namespace drake {
@@ -8,22 +9,12 @@ namespace multilane {
 
 const double LineRoadCurve::kMinimumNorm = 1e-12;
 
-double LineRoadCurve::p_from_s(double s, double r) const {
-  // TODO(@maddog-tri) We should take care of the superelevation() scale that
-  //                   will modify curve's path length.
-  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
-               superelevation().b() == 0. && superelevation().c() == 0. &&
-               superelevation().d() == 0.));
+double LineRoadCurve::FastCalcPFromS(double s, double r) const {
   unused(r);
   return elevation().p_s(s / p_scale());
 }
 
-double LineRoadCurve::s_from_p(double p, double r) const {
-  // TODO(@maddog-tri) We should take care of the superelevation() scale that
-  //                   will modify curve's path length.
-  DRAKE_DEMAND(r == 0. || (superelevation().a() == 0. &&
-               superelevation().b() == 0. && superelevation().c() == 0. &&
-               superelevation().d() == 0.));
+double LineRoadCurve::FastCalcSFromP(double p, double r) const {
   unused(r);
   return p_scale() * elevation().s_p(p);
 }

--- a/automotive/maliput/multilane/line_road_curve.h
+++ b/automotive/maliput/multilane/line_road_curve.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 #include <utility>
 
 #include "drake/automotive/maliput/api/lane_data.h"
@@ -30,21 +31,31 @@ class LineRoadCurve : public RoadCurve {
   /// @param superelevation CubicPolynomial object that represents the
   /// superelevation polynomial. See RoadCurve class constructor for more
   /// details.
-  explicit LineRoadCurve(const Vector2<double>& xy0, const Vector2<double>& dxy,
-                         const CubicPolynomial& elevation,
-                         const CubicPolynomial& superelevation)
-      : RoadCurve(elevation, superelevation),
-        p0_(xy0),
-        dp_(dxy),
-        heading_(std::atan2(dxy.y(), dxy.x())) {
+  /// @param linear_tolerance The linear tolerance, in meters, for all
+  /// computations. See RoadCurve class constructor for more details.
+  /// @param scale_length The minimum spatial period of variation in the curve,
+  /// in meters. See RoadCurve class constructor for more details.
+  /// @param computation_policy Policy to guide all computations. If geared
+  /// towards speed, computations will make use of analytical expressions even
+  /// if not actually correct for the curve as specified.
+  explicit LineRoadCurve(
+      const Vector2<double>& xy0, const Vector2<double>& dxy,
+      const CubicPolynomial& elevation,
+      const CubicPolynomial& superelevation,
+      double linear_tolerance = 0.01, double scale_length = 1.0,
+      const ComputationPolicy computation_policy =
+         ComputationPolicy::kPreferAccuracy)
+      : RoadCurve(linear_tolerance, scale_length,
+                  elevation, superelevation,
+                  computation_policy),
+        p0_(xy0), dp_(dxy), heading_(std::atan2(dxy.y(), dxy.x())) {
+    // TODO(hidmic): Remove default values in trailing arguments, which were
+    // added in the first place to defer the need to propagate changes upwards
+    // in the class hierarchy.
     DRAKE_DEMAND(dxy.norm() > kMinimumNorm);
   }
 
   ~LineRoadCurve() override = default;
-
-  double p_from_s(double s, double r) const override;
-
-  double s_from_p(double p, double r) const override;
 
   Vector2<double> xy_of_p(double p) const override { return p0_ + p * dp_; }
 
@@ -80,6 +91,15 @@ class LineRoadCurve : public RoadCurve {
   }
 
  private:
+  double FastCalcPFromS(double s, double r) const override;
+
+  double FastCalcSFromP(double p, double r) const override;
+
+  double CalcMinimumRadiusAtOffset(double r) const override {
+    unused(r);
+    return std::numeric_limits<double>::infinity();
+  }
+
   // The first point in world coordinates over the z=0 plane of the reference
   // curve.
   const Vector2<double> p0_{};

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -1,8 +1,191 @@
 #include "drake/automotive/maliput/multilane/road_curve.h"
 
+#include "drake/common/drake_assert.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/analysis/integrator_base.h"
+
 namespace drake {
 namespace maliput {
 namespace multilane {
+
+namespace {
+
+// Arc length derivative function ds/dp = f(p; [r, h]) for numerical resolution
+// of the s(p) mapping as an antiderivative computation (i.e. quadrature).
+struct ArcLengthDerivativeFunction {
+  // Constructs the arc length derivative function for the given @p road_curve.
+  explicit ArcLengthDerivativeFunction(const RoadCurve* road_curve)
+      : road_curve_(road_curve) {}
+
+  // Computes the arc length derivative for the RoadCurve specified
+  // at construction.
+  //
+  // @param p The parameterization value to evaluate the derivative at.
+  // @param k The parameter vector, containing r and h coordinates respectively.
+  // @return The arc length derivative value at the specified point.
+  // @pre The given parameter vector @p k is bi-dimensional (holding r and h
+  //      coordinates only).
+  // @throw std::logic_error if preconditions are not met.
+  double operator()(const double& p, const VectorX<double>& k) const {
+    if (k.size() != 2) {
+      throw std::logic_error("Arc length derivative expects only r and"
+                             " h coordinates as parameters, respectively.");
+    }
+    return road_curve_->W_prime_of_prh(
+        p, k(0), k(1), road_curve_->Rabg_of_p(p),
+        road_curve_->elevation().f_dot_p(p)).norm();
+  }
+
+ private:
+  // Associated RoadCurve instance.
+  const RoadCurve* road_curve_;
+};
+
+// Inverse arc length ODE function dp/ds = f(s, p; [r, h]) for numerical
+// resolution of the p(s) mapping as an scalar initial value problem for
+// a given RoadCurve.
+struct InverseArcLengthODEFunction {
+  // Constructs an inverse arc length ODE for the given @p road_curve.
+  explicit InverseArcLengthODEFunction(const RoadCurve* road_curve)
+      : road_curve_(road_curve) {}
+
+  // Computes the inverse arc length derivative for the RoadCurve specified
+  // at construction.
+  //
+  // @param s The arc length to evaluate the derivative at.
+  // @param p The parameterization value to evaluate the derivative at.
+  // @param k The parameter vector, containing r and h coordinates respectively.
+  // @return The inverse arc length derivative value at the specified point.
+  // @pre The given parameter vector @p k is bi-dimensional (holding r and h
+  //      coordinates only).
+  // @throw std::logic_error if preconditions are not met.
+  double operator()(const double& s, const double& p,
+                    const VectorX<double>& k) {
+    unused(s);
+    if (k.size() != 2) {
+      throw std::logic_error("Inverse arc length ODE expects only r and"
+                             " h coordinates as parameters, respectively.");
+    }
+    return 1.0 / road_curve_->W_prime_of_prh(
+        p, k(0), k(1), road_curve_->Rabg_of_p(p),
+        road_curve_->elevation().f_dot_p(p)).norm();
+  }
+
+ private:
+  // Associated RoadCurve instance.
+  const RoadCurve* road_curve_;
+};
+
+
+}  // namespace
+
+RoadCurve::RoadCurve(double linear_tolerance, double scale_length,
+                     const CubicPolynomial& elevation,
+                     const CubicPolynomial& superelevation,
+                     const ComputationPolicy computation_policy)
+    : scale_length_(scale_length),
+      linear_tolerance_(linear_tolerance),
+      elevation_(elevation),
+      superelevation_(superelevation),
+      computation_policy_(computation_policy) {
+  // Enforces preconditions.
+  DRAKE_THROW_UNLESS(scale_length > 0.);
+  DRAKE_THROW_UNLESS(linear_tolerance > 0.);
+  // Sets default parameter value at the beginning of the
+  // curve to 0 by default.
+  const double initial_p_value = 0.0;
+  // Sets default arc length at the beginning of the curve
+  // to 0 by default.
+  const double initial_s_value = 0.0;
+  // Sets default r and h coordinates to 0 by default.
+  const VectorX<double> default_parameters = VectorX<double>::Zero(2);
+
+  // Instantiates s(p) and p(s) mappings with default values.
+  const systems::AntiderivativeFunction<double>::SpecifiedValues
+      s_from_p_func_values(initial_p_value, default_parameters);
+  s_from_p_func_ = std::make_unique<systems::AntiderivativeFunction<double>>(
+      ArcLengthDerivativeFunction(this), s_from_p_func_values);
+
+  const systems::ScalarInitialValueProblem<double>::SpecifiedValues
+      p_from_s_ivp_values(initial_s_value, initial_p_value, default_parameters);
+  p_from_s_ivp_ = std::make_unique<systems::ScalarInitialValueProblem<double>>(
+      InverseArcLengthODEFunction(this), p_from_s_ivp_values);
+
+  // Relative tolerance in path length is roughly bounded by e/L, where e is
+  // the linear tolerance and L is the scale length. This can be seen by
+  // considering straight path one scale length (or spatial period) long, and
+  // then another path, whose deviation from the first is a sine function with
+  // the same period and amplitude equal to the specified tolerance. The
+  // difference in path length is bounded by 4e and the relative error is thus
+  // bounded by 4e/L.
+  const double relative_tolerance = linear_tolerance_ / scale_length_;
+
+  // Sets `s_from_p`'s integration accuracy and step sizes. Said steps
+  // should not be too large, because that could make accuracy control
+  // fail, nor too small to avoid wasting cycles. The nature of the
+  // problem at hand varies with the parameterization of the RoadCurve,
+  // and so will optimal step sizes (in terms of their efficiency vs.
+  // accuracy balance). However, for the time being, the following
+  // constants (considering 0.0 <= p <= 1.0) work well as a heuristic
+  // approximation to appropriate step sizes.
+  systems::IntegratorBase<double>* s_from_p_integrator =
+      s_from_p_func_->get_mutable_integrator();
+  s_from_p_integrator->request_initial_step_size_target(0.1);
+  s_from_p_integrator->set_maximum_step_size(1.0);
+  s_from_p_integrator->set_target_accuracy(relative_tolerance);
+
+  // Sets `p_from_s`'s integration accuracy and step sizes. Said steps
+  // should not be too large, because that could make accuracy control
+  // fail, nor too small to avoid wasting cycles. The nature of the
+  // problem at hand varies with the shape of the RoadCurve, and so will
+  // optimal step sizes (in terms of their efficiency vs. accuracy balance).
+  // However, for the time being, the following proportions of the scale
+  // length work well as a heuristic approximation to appropriate step sizes.
+  systems::IntegratorBase<double>* p_from_s_integrator =
+      p_from_s_ivp_->get_mutable_integrator();
+  p_from_s_integrator->request_initial_step_size_target(0.1 * scale_length);
+  p_from_s_integrator->set_maximum_step_size(scale_length);
+  p_from_s_integrator->set_target_accuracy(relative_tolerance);
+}
+
+bool RoadCurve::AreFastComputationsAccurate(double r) const {
+  // When superelevation() has no influence on the curve's
+  // geometry and elevation() is at most linear along the curve,
+  // known analytical expressions are accurate.
+  return ((r == 0.0 || superelevation().is_zero())
+          && elevation().order() <= 1);
+}
+
+double RoadCurve::CalcSFromP(double p, double r) const {
+  DRAKE_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
+  if (computation_policy() == ComputationPolicy::kPreferAccuracy
+      && !AreFastComputationsAccurate(r)) {
+    // Populates parameter vector with (r, h) coordinate values.
+    systems::AntiderivativeFunction<double>::SpecifiedValues values;
+    values.k = (VectorX<double>(2) << r, 0.0).finished();
+    return s_from_p_func_->Evaluate(p, values);
+  }
+  return FastCalcSFromP(p, r);
+}
+
+double RoadCurve::CalcPFromS(double s, double r) const {
+  DRAKE_THROW_UNLESS(CalcMinimumRadiusAtOffset(r) > 0.0);
+  if (computation_policy() == ComputationPolicy::kPreferAccuracy
+      && !AreFastComputationsAccurate(r)) {
+    // Populates parameter vector with (r, h) coordinate values.
+    systems::ScalarInitialValueProblem<double>::SpecifiedValues values;
+    values.k = (VectorX<double>(2) << r, 0.0).finished();
+    return p_from_s_ivp_->Solve(s, values);
+  }
+  return FastCalcPFromS(s, r);
+}
+
+double RoadCurve::CalcGPrimeAsUsedForCalcSFromP(double p) const {
+  if (computation_policy() == ComputationPolicy::kPreferSpeed) {
+    return elevation().fake_gprime(p);
+  }
+  return elevation().f_dot_p(p);
+}
 
 Vector3<double> RoadCurve::W_of_prh(double p, double r, double h) const {
   // Calculates z (elevation) of (p,0,0).

--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -40,7 +40,7 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
   const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
   // Checks the length.
   EXPECT_NEAR(dut.p_scale(), kDTheta * kRadius, kVeryExact);
-  EXPECT_NEAR(dut.s_from_p(1., kNoOffset), kDTheta * kRadius, kVeryExact);
+  EXPECT_NEAR(dut.CalcSFromP(1., kNoOffset), kDTheta * kRadius, kVeryExact);
   // Checks the evaluation of xy at different values over the reference curve.
   EXPECT_TRUE(CompareMatrices(
       dut.xy_of_p(0.0), kCenter + Vector2<double>(kRadius * std::cos(kTheta0),
@@ -209,20 +209,20 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
   EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kRadius * kDTheta);
   // Checks that functions throw when lateral offset is exceeded.
-  EXPECT_THROW(flat_dut.p_from_s(0., kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.p_from_s(0., 2.0 * kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.s_from_p(0., kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.s_from_p(0., 2.0 * kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.CalcPFromS(0., kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.CalcPFromS(0., 2.0 * kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.CalcSFromP(0., kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.CalcSFromP(0., 2.0 * kRadius), std::runtime_error);
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.p_from_s(p * (kRadius - r) * kDTheta, r), p);
+      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(p * (kRadius - r) * kDTheta, r), p);
     }
   }
   // Evaluates the path length integral for different offset values.
   for (double r : r_vector) {
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.s_from_p(p, r), p * (kRadius - r) * kDTheta);
+      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), p * (kRadius - r) * kDTheta);
     }
   }
 
@@ -238,8 +238,8 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
     for (double p : p_vector) {
       const double s = p * kRadius * kDTheta *
           std::sqrt(std::pow((kRadius - r) / kRadius, 2.) + slope * slope);
-      EXPECT_DOUBLE_EQ(elevated_dut.p_from_s(s , r), p);
-      EXPECT_DOUBLE_EQ(elevated_dut.s_from_p(p, r), s);
+      EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s , r), p);
+      EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
     }
   }
 }

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -106,13 +106,13 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.p_from_s(p * kDirection.norm(), r), p);
+      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(p * kDirection.norm(), r), p);
     }
   }
   // Evaluates the path length integral for different offset values.
   for (double r : r_vector) {
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.s_from_p(p, r), p * kDirection.norm());
+      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), p * kDirection.norm());
     }
   }
 
@@ -126,8 +126,8 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   for (double r : r_vector) {
     for (double p : p_vector) {
       const double s = p * kDirection.norm() * std::sqrt(1. + slope * slope);
-      EXPECT_DOUBLE_EQ(elevated_dut.p_from_s(s, r), p);
-      EXPECT_DOUBLE_EQ(elevated_dut.s_from_p(p, r), s);
+      EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s, r), p);
+      EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
     }
   }
 }

--- a/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
@@ -1,0 +1,173 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/multilane/road_curve.h"
+/* clang-format on */
+
+#include <memory>
+#include <ostream>
+#include <tuple>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/multilane/arc_road_curve.h"
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
+#include "drake/automotive/maliput/multilane/line_road_curve.h"
+#include "drake/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+// Convenience stream operator overload for CubicPolynomial instances.
+// @note MUST be outside the anonymous namespace to be found by the
+// compiler.
+std::ostream& operator<<(std::ostream& o, const CubicPolynomial& p) {
+  return o << p.a() << " + " << p.b() << " p + "
+           << p.c() << " p^2 + " << p.d() << " p^3";
+}
+
+namespace {
+
+// Checks brute force integral computations against known
+// path length arc road curves.
+GTEST_TEST(BruteForceIntegralTest, ArcRoadCurvePathLength) {
+  const double kAccuracy{1e-12};
+
+  const double kRadius{10.0};
+  const double kTheta0{M_PI / 4.0};
+  const double kTheta1{3.0 * M_PI / 4.0};
+  const double kDTheta{kTheta1 - kTheta0};
+  const Vector2<double> kCenter{10.0, 10.0};
+  const CubicPolynomial zp(0., 0., 0., 0.);
+  const double kP0{0.};
+  const double kP1{1.};
+  const double kR{0.};
+  const double kH{0.};
+
+  const ArcRoadCurve rc(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+
+  // A k = 0 order approximation uses a single segment, as n = 2^k,
+  // where n is the segment count.
+  double maximum_step = 0;
+  const double path_length_zero_order_approx =
+      test::BruteForcePathLengthIntegral(
+          rc, kP0, kP1, kR, kH, 0, &maximum_step);
+  const double path_length_zero_order = std::sin(M_PI / 4.) * kRadius * 2.;
+  EXPECT_NEAR(path_length_zero_order_approx, path_length_zero_order, kAccuracy);
+  EXPECT_NEAR(maximum_step, path_length_zero_order, kAccuracy);
+
+  int k_order_hint = 0;
+  const double tolerance = .01 * rc.CalcSFromP(1., 0.);
+  const double path_length_adaptive_approx =
+      test::AdaptiveBruteForcePathLengthIntegral(
+          rc, kP0, kP1, kR, kH, tolerance, &k_order_hint);
+  EXPECT_NEAR(path_length_adaptive_approx, kRadius * M_PI / 2., tolerance);
+}
+
+// A test fixture for RoadCurve computation accuracy tests.
+class RoadCurveAccuracyTest
+    : public ::testing::TestWithParam<std::shared_ptr<RoadCurve>> {};
+
+// Checks that path length computations are within tolerance.
+TEST_P(RoadCurveAccuracyTest, PathLengthAccuracy) {
+  const double kMinimumP = 0.;
+  const double kMaximumP = 1.;
+  const double kPStep = 0.2;
+
+  const double kMinimumR = -5.0;
+  const double kMaximumR = 5.0;
+  const double kRStep = 2.5;
+
+  const double kH = 0.0;
+
+  std::shared_ptr<RoadCurve> road_curve = GetParam();
+  const double kTolerance = road_curve->linear_tolerance()
+                            / road_curve->scale_length();
+  for (double r = kMinimumR; r <= kMaximumR; r += kRStep) {
+    int k_order = 0;
+    for (double p = kMinimumP; p <= kMaximumP; p += kPStep) {
+      const double k_order_s_approximation =
+          test::AdaptiveBruteForcePathLengthIntegral(
+              *road_curve, kMinimumP, p, r, kH,
+              road_curve->linear_tolerance(), &k_order);
+      const double relative_error =
+          (k_order_s_approximation != 0.0) ?
+          (road_curve->CalcSFromP(p, r) - k_order_s_approximation) /
+          k_order_s_approximation : road_curve->CalcSFromP(p, r);
+      EXPECT_LE(relative_error, kTolerance)
+          << "Path length estimation with a tolerance of "
+          << road_curve->linear_tolerance() << " m failed"
+          << " at p = " << p << ", r = " << r << "m, h = " << kH
+          << "m with " << road_curve->elevation() << " for elevation and "
+          << road_curve->superelevation() << " for superelevation";
+    }
+  }
+}
+
+// Returns an exhaustive combination of CubicPolynomial instances for testing.
+std::vector<CubicPolynomial> GetCubicPolynomials() {
+  return {
+    {0.0, 0.0, 0.0, 0.0},
+    {1.0, 0.0, 0.0, 0.0},
+    {0.0, 1.0, 0.0, 0.0},
+    {1.0, 1.0, 0.0, 0.0},
+    {0.0, 0.0, 1.0, 0.0},
+    {1.0, 0.0, 1.0, 0.0},
+    {0.0, 1.0, 1.0, 0.0},
+    {1.0, 1.0, 1.0, 0.0},
+    {0.0, 0.0, 0.0, 1.0},
+    {1.0, 0.0, 0.0, 1.0},
+    {0.0, 1.0, 0.0, 1.0},
+    {1.0, 1.0, 0.0, 1.0},
+    {0.0, 0.0, 1.0, 1.0},
+    {1.0, 0.0, 1.0, 1.0},
+    {0.0, 1.0, 1.0, 1.0},
+    {1.0, 1.0, 1.0, 1.0}};
+}
+
+// Returns a collection of LineRoadCurve instances for testing.
+std::vector<std::shared_ptr<RoadCurve>> GetLineRoadCurves() {
+  const Vector2<double> kStart{0., 0.};
+  const Vector2<double> kEnd{10., -8.};
+
+  std::vector<std::shared_ptr<RoadCurve>> road_curves;
+  for (const auto& elevation_polynomial : GetCubicPolynomials()) {
+    for (const auto& superelevation_polynomial : GetCubicPolynomials()) {
+      road_curves.push_back(std::make_shared<LineRoadCurve>(
+          kStart, kEnd - kStart, elevation_polynomial,
+          superelevation_polynomial));
+    }
+  }
+  return road_curves;
+}
+
+// Returns a collection of ArcRoadCurve instances for testing.
+std::vector<std::shared_ptr<RoadCurve>> GetArcRoadCurves() {
+  const Vector2<double> kCenter{0., 0.};
+  const double kRadius{10.0};
+  const double kTheta0{M_PI / 6.};
+  const double kDTheta{M_PI / 2.};
+
+  std::vector<std::shared_ptr<RoadCurve>> road_curves;
+  for (const auto& elevation_polynomial : GetCubicPolynomials()) {
+    for (const auto& superelevation_polynomial : GetCubicPolynomials()) {
+      road_curves.push_back(std::make_shared<ArcRoadCurve>(
+        kCenter, kRadius, kTheta0, kDTheta,
+        elevation_polynomial, superelevation_polynomial));
+    }
+  }
+  return road_curves;
+}
+
+INSTANTIATE_TEST_CASE_P(ExhaustiveLineRoadCurveAccuracyTest,
+                        RoadCurveAccuracyTest,
+                        ::testing::ValuesIn(GetLineRoadCurves()));
+
+INSTANTIATE_TEST_CASE_P(ExhaustiveArcRoadCurveAccuracyTest,
+                        RoadCurveAccuracyTest,
+                        ::testing::ValuesIn(GetArcRoadCurves()));
+
+}  // namespace
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/multilane/test_utilities/BUILD.bazel
+++ b/automotive/maliput/multilane/test_utilities/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
     deps = [
+        ":multilane_brute_force_integral",
         ":multilane_types_compare",
     ],
 )
@@ -29,6 +30,17 @@ drake_cc_library(
         "//common:essential",
         "//math:geometric_transform",
         "@gtest//:without_main",
+    ],
+)
+
+drake_cc_library(
+    name = "multilane_brute_force_integral",
+    testonly = 1,
+    srcs = ["multilane_brute_force_integral.cc"],
+    hdrs = ["multilane_brute_force_integral.h"],
+    deps = [
+        "//automotive/maliput/multilane:lanes",
+        "//common:essential",
     ],
 )
 

--- a/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.cc
@@ -1,0 +1,91 @@
+#include "drake/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+namespace test {
+
+double BruteForcePathLengthIntegral(const RoadCurve& rc, double p_0, double p_1,
+                                    double r, double h, int k_order,
+                                    double* maximum_step) {
+  DRAKE_THROW_UNLESS(0. <= p_0);
+  DRAKE_THROW_UNLESS(p_0 <= p_1);
+  DRAKE_THROW_UNLESS(p_1 <= 1.);
+  DRAKE_THROW_UNLESS(k_order >= 0);
+  double length = 0.0;
+  const double d_p = (p_1 - p_0);
+  const int iterations = std::pow(2, k_order);
+  if (maximum_step != nullptr) {
+    *maximum_step = -std::numeric_limits<double>::infinity();
+  }
+  // Splits the [p_0, p_1] interval in 2^k intervals, computes the positions
+  // in the global frame for each interval boundary and sums up the path lengths
+  // of the segments in the global frame that correspond to each one of those
+  // intervals.
+  Vector3<double> geo_position_at_prev_p = rc.W_of_prh(p_0, r, h);
+  for (int i = 1; i <= iterations; ++i) {
+    const double p = p_0 + d_p * static_cast<double>(i) / iterations;
+    const Vector3<double> geo_position_at_p = rc.W_of_prh(p, r, h);
+    const double ith_step_length = (
+        geo_position_at_p - geo_position_at_prev_p).norm();
+    if (maximum_step != nullptr) {
+      // Keep track of the maximum step taken.
+      *maximum_step = std::max(*maximum_step, ith_step_length);
+    }
+    length += ith_step_length;
+    geo_position_at_prev_p = geo_position_at_p;
+  }
+  return length;
+}
+
+double AdaptiveBruteForcePathLengthIntegral(
+    const RoadCurve& rc, double p_0, double p_1, double r,
+    double h, double tolerance, int* k_order_hint) {
+  DRAKE_THROW_UNLESS(tolerance > 0.);
+  const double kInfinity = std::numeric_limits<double>::infinity();
+  // Zero initializes the current k order unless a hint was provided.
+  int k_order = k_order_hint != nullptr ? *k_order_hint : 0;
+  double k_order_maximum_step = kInfinity;
+  // Computes the k-order path length approximation.
+  double k_order_path_length = BruteForcePathLengthIntegral(
+      rc, p_0, p_1, r, h, k_order, &k_order_maximum_step);
+  // Estimates the error of a k-order approximation, increasing k
+  // until said error falls within the specified tolerance.
+  while (true) {
+    double k_plus_1_order_maximum_step = kInfinity;
+    // Computes the k+1-order path length approximation.
+    const double k_plus_1_order_path_length =
+        BruteForcePathLengthIntegral(rc, p_0, p_1, r, h, k_order + 1,
+                                     &k_plus_1_order_maximum_step);
+    // Estimates the error of the k-order path length approximation
+    // by comparing it with the k+1-order one.
+    const double k_order_error = std::abs(
+        k_plus_1_order_path_length - k_order_path_length);
+    // Not only the estimated error must be within tolerance but
+    // also the maximum step taken by the k-order approximation
+    // must be within a scale length to ensure it is valid (see
+    // AdaptiveBruteForcePathLengthIntegral() function documentation).
+    if (k_order_maximum_step < rc.scale_length() && k_order_error < tolerance) {
+      break;
+    }
+    k_order_path_length = k_plus_1_order_path_length;
+    k_order_maximum_step = k_plus_1_order_maximum_step;
+    k_order += 1;
+  }
+  // Update k-order hint with actual k-order required to achieve
+  // the desired accuracy.
+  if (k_order_hint != nullptr) *k_order_hint = k_order;
+  return k_order_path_length;
+}
+
+}  // namespace test
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h
+++ b/automotive/maliput/multilane/test_utilities/multilane_brute_force_integral.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <tuple>
+
+#include "drake/automotive/maliput/multilane/road_curve.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+namespace test {
+
+// Approximates a path length lower bound for the given @p road_curve
+// from @p p_0 to @p p_1, for constant @p r and @p h offsets, by
+// computing the same integral for a 2^@p k_order linear approximation.
+//
+// @param road_curve The RoadCurve to compute path length for.
+// @param p_0 The lower integration bound for the p coordinate.
+// @param p_1 The upper integration bound for the p coordinate.
+// @param r The r coordinate offset.
+// @param h The h coordinate offset.
+// @param k_order Order k of the linear approximation, i.e. 2^k segments
+//                are used in the approximation.
+// @param maximum_step A mutable reference that, if given (can be nullptr), is
+//                     set to the maximum step length used in the computation.
+// @pre Given upper integration bound @p p_1 is less than or equal to 1.
+// @pre Given upper integration bound @p p_1 is greater than or equal to
+//      the given lower integration bound @p p_0.
+// @pre Given lower integration bound @p p_0 is greater than or equal to 0.
+// @pre Given @p k_order for the linear approximation is a non-negative number.
+// @throw std::runtime_error if preconditions are not met.
+double BruteForcePathLengthIntegral(const RoadCurve& road_curve,
+                                    double p_0, double p_1, double r,
+                                    double h, int k_order,
+                                    double* maximum_step);
+
+// Approximates the path length of a given @p road_curve from @p p_0 to @p p_1,
+// for constant @p r and @p h offsets, to within specified @p tolerance.
+//
+// To ensure the error falls within @p tolerance, a path length lower bound
+// is used (see BruteForcePathLengthIntegral()). If the curve is split in pieces
+// no longer than the scale length of the curve, assuming the curve is well
+// behaved, each one of the pieces can roughly be approximated as a constant
+// curvature arc of radius R, subtending an angle θ. Then, let E(k) be the kth
+// order approximation computed as the length of the chord that connects the arc
+// endpoints, E(k+1) be the (k+1)th order approximation computed as the sum
+// of the lengths of the resulting chords after an arc bisection and E(∞) be the
+// true path length. It can be shown that: E(∞) - E(k+1) <= E(k+1) - E(k).
+//
+// TODO(hidmic): Compute a path length upper bound to ensure the approximation
+// is within tolerance.
+//
+// @param road_curve The RoadCurve to compute path length for.
+// @param p_0 The lower integration bound for the p coordinate.
+// @param p_1 The upper integration bound for the p coordinate.
+// @param r The r coordinate offset.
+// @param h The h coordinate offset.
+// @param tolerance The tolerance for the approximation, in the absolute error
+//                  sense.
+// @param k_order_hint A mutable reference to the order k of the linear
+//                     approximation that, if given (can be nullptr) it's used
+//                     as hint on call and it's updated to the actually required
+//                     order necessary to achieve the specified tolerance on
+//                     return.
+// @pre Given upper integration bound @p p_1 is less than or equal to 1.
+// @pre Given upper integration bound @p p_1 is greater than or equal to
+//      the given lower integration bound @p p_0.
+// @pre Given lower integration bound @p p_0 is greater than or equal to 0.
+// @pre Given tolerance is a positive real number.
+// @pre If given, the order suggested by @p k_order_hint is a non-negative
+//      number.
+// @throw std::runtime_error if preconditions are not met.
+double AdaptiveBruteForcePathLengthIntegral(
+    const RoadCurve& rc, double p_0, double p_1,
+    double r, double h, double tolerance,
+    int* k_order_hint);
+
+}  // namespace test
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This pull request enables the estimation, up to a given accuracy, of the path length of Multilane's `RoadCurve` geometries for which no closed form solution exists. To do this, it leverages Drake's integration mechanisms.

Integrator's accuracy settings relate to the `RoadCurve`s scale length `L` (e.g. its minimum spatial period) and linear tolerance `e`, both quantities fixed by the implementation for the time being. Enabling proper parameterization on road construction will be the topic of the next PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7594)
<!-- Reviewable:end -->
