### PR TITLE
call_python: Ensure SIGINT is installed (since `exec` does not work the same on Mac).

### DIFF
--- a/common/proto/call_python_client.py
+++ b/common/proto/call_python_client.py
@@ -8,6 +8,7 @@ import signal
 import stat
 import sys
 from threading import Thread
+import time
 import traceback
 
 import numpy as np
@@ -155,6 +156,14 @@ def _merge_dicts(*args):
     return out
 
 
+def _fix_pyplot(plt):
+    # This patches matplotlib/matplotlib#9412 by injecting `time` into the
+    # module (#7597).
+    cur = plt.__dict__
+    if 'time' not in cur:
+        cur['time'] = time
+
+
 def default_globals():
     """Creates default globals for code that the client side can execute.
 
@@ -175,6 +184,7 @@ def default_globals():
 
     # TODO(eric.cousineau): Where better to put this?
     matplotlib.interactive(True)
+    _fix_pyplot(plt)
 
     def disp(value):
         """Alias for print."""

--- a/common/proto/test/call_python_full_test.sh
+++ b/common/proto/test/call_python_full_test.sh
@@ -112,9 +112,7 @@ threading-no_loop() {
 sub-tests threading-no_loop
 
 threading-loop() {
-    # Use `exec` so that we inherit SIGINT (Ctrl+C) handlers.
-    # @ref https://stackoverflow.com/a/44538799/7829525
-    exec ${py_client_cli} ${py_flags} &
+    ${py_client_cli} ${py_flags} &
     pid=$!
     rm -f ${done_file}
     ${cc_bin} ${cc_bin_flags} ${cc_flags}


### PR DESCRIPTION
Python does not seem to install the `SIGINT` handler on Mac under a bash script, even if run using `exec` in `bash`.

This resolves this on the Python side.

(NOTE: Some of the other CI failures have another error: `ERROR: global name 'time' is not defined`. However, at present, I cannot reproduce this on our local Mac machines.)

\cc @soonho-tri @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7597)
<!-- Reviewable:end -->
