### PR TITLE
Add dReal in install_prereqs.sh

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -41,7 +41,7 @@ clang-format
 cmake
 diffstat
 doxygen
-dreal-deps/coinor/clp
+dreal/dreal/dreal
 glew
 glib
 graphviz

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -47,6 +47,7 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 
 bash-completion
 binutils
+bison
 chrpath
 clang-4.0
 clang-format-4.0
@@ -56,6 +57,7 @@ coinor-libclp-dev
 coinor-libipopt-dev
 diffstat
 doxygen
+flex
 g++
 g++-5
 g++-5-multilib
@@ -127,6 +129,31 @@ else
 fi
 
 rm /tmp/bazel_0.6.1-linux-x86_64.deb
+
+# Install IBEX, a dReal dependency.  See
+# https://launchpad.net/~dreal/+archive/ubuntu/dreal
+# for more information. To rebuild IBEX, add the PPA `ppa:dreal/dreal` and then
+# run `apt source libibex-dev` to get the sources.
+wget -O /tmp/libibex-dev_2.6.3_amd64.deb \
+     https://launchpad.net/~dreal/+archive/ubuntu/dreal/+files/libibex-dev_2.6.3.20171215122721.git2275df8f465a9db6a42d497ca322011ff2c6f8f7~16.04_amd64.deb
+if echo "7d76c4450921b83971006f01b3259c75cddc178bc7f4f8766f996df7763ed2b5 /tmp/libibex-dev_2.6.3_amd64.deb" | sha256sum -c -; then
+  dpkg -i /tmp/libibex-dev_2.6.3_amd64.deb
+else
+  die "The IBEX deb does not have the expected SHA256.  Not installing IBEX."
+fi
+rm /tmp/libibex-dev_2.6.3_amd64.deb
+
+# Install dReal. See
+# https://github.com/dreal/dreal4/blob/master/README.md#build-debian-package for
+# build instructions.
+wget -O /tmp/dreal_4.17.12.2_amd64.deb \
+     https://dl.bintray.com/dreal/dreal/dreal_4.17.12.2_amd64.deb
+if echo "9347492e47a518ff78991e15fe9de0cff0200573091385e42940cdbf1fcf77a5 /tmp/dreal_4.17.12.2_amd64.deb" | sha256sum -c -; then
+  dpkg -i /tmp/dreal_4.17.12.2_amd64.deb
+else
+  die "The dReal deb does not have the expected SHA256.  Not installing dReal."
+fi
+rm /tmp/dreal_4.17.12.2_amd64.deb
 
 # Remove deb that we used to generate and install, but no longer need.
 if [ -L /usr/lib/ccache/bazel ]; then


### PR DESCRIPTION
Adding dReal and IBEX (dReal's dependency) in `install_prereqs.sh` so that we can use it via `pkg-config`.

Previously, we wanted to use it via consuming `.deb` (in Ubuntu) and  homebrew bottles (in OSX) (see https://github.com/RobotLocomotion/drake/issues/7387). I made some progress in https://github.com/soonho-tri/drake/tree/add-dreal but found more hurdles as implementing its install logic. I do not want to spend more time on it now. I'd rather specify dReal as a system package for now (via `pkg-config`) and focus on its use cases in V&V.

Esp, [IBEX](https://github.com/ibex-team/ibex-lib) is an LGPL package and I do not expect it to be changed frequently (or we need to use the bleeding edge). So it should be better to use it as a system package.

/cc @stonier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7600)
<!-- Reviewable:end -->
