### PR TITLE
Provide ExtractDoubleOrThrow for symbolic::Expression

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -195,6 +195,7 @@ drake_cc_library(
         ":cond",
         ":dummy_value",
         ":essential",
+        ":extract_double",
         ":hash",
         ":number_traits",
         ":polynomial",

--- a/common/extract_double.h
+++ b/common/extract_double.h
@@ -10,17 +10,17 @@ namespace drake {
 /// Converts a ScalarType value to a double, failing at runtime (not compile
 /// time) if the type cannot be converted to a double.
 ///
-/// This function is useful for writing ScalarType-generic code that (1) is
-/// only intended to be used on numeric types, (2) can reasonably discard any
-/// supplemental scalar data, e.g., the derivatives of an AutoDiffScalar, and
-/// (3) is reasonable to fail at runtime if called with a non-numeric
-/// ScalarType.
+/// This function is useful for writing ScalarType-generic code that (1) can
+/// reasonably discard any supplemental scalar data, e.g., the derivatives of an
+/// AutoDiffScalar, and (2) is reasonable to fail at runtime if the extraction
+/// fails.
 ///
-/// The default implementation throws an exception.  ScalarTypes that are
-/// numeric must overload this method to provide an appropriate extraction.
-/// An overload for `double` is already provided.
+/// The default implementation throws an exception.  ScalarTypes that can hold a
+/// numeric value must overload this method to provide an appropriate
+/// extraction.  An overload for `double` is already provided.
 ///
 /// See autodiff_overloads.h to use this with Eigen's AutoDiffScalar.
+/// See symbolic_expression.h to use this with symbolic::Expression.
 /// See number_traits.h for specifying which ScalarTypes are numeric.
 template <typename T>
 double ExtractDoubleOrThrow(const T& scalar) {

--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -877,4 +877,9 @@ MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
   return Jacobian(f, vector<Variable>(vars.data(), vars.data() + vars.size()));
 }
 }  // namespace symbolic
+
+double ExtractDoubleOrThrow(const symbolic::Expression& e) {
+  return e.Evaluate();
+}
+
 }  // namespace drake

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -24,6 +24,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/dummy_value.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/extract_double.h"
 #include "drake/common/hash.h"
 #include "drake/common/number_traits.h"
 #include "drake/common/polynomial.h"
@@ -768,6 +769,13 @@ template <>
 struct is_numeric<symbolic::Expression> {
   static constexpr bool value = false;
 };
+
+/// Returns the symbolic expression's value() as a double.
+///
+/// @throws If it is not possible to evaluate the symbolic expression with an
+/// empty environment.
+double ExtractDoubleOrThrow(const symbolic::Expression& e);
+
 }  // namespace drake
 
 namespace std {

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -1849,6 +1849,20 @@ TEST_F(SymbolicExpressionTest, MemcpyKeepsExpressionIntact) {
     EXPECT_TRUE(IsMemcpyMovable(expr));
   }
 }
+
+TEST_F(SymbolicExpressionTest, ExtractDoubleTest) {
+  const Expression e1{10.0};
+  EXPECT_EQ(ExtractDoubleOrThrow(e1), 10.0);
+
+  // 'x_' can't be converted to a double value.
+  const Expression e2{x_};
+  EXPECT_THROW(ExtractDoubleOrThrow(e2), std::exception);
+
+  // 2x - 7 -2x + 2 => -5
+  const Expression e3{2 * x_ - 7 - 2 * x_ + 2};
+  EXPECT_EQ(ExtractDoubleOrThrow(e3), -5);
+}
+
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
I found we need this to make more systems compatible with `T = symbolic::Expression`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7604)
<!-- Reviewable:end -->
