### PR TITLE
call_python: Address additional CI failures for Mac.

### DIFF
--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -111,6 +111,9 @@ sh_test(
         ":call_python_client_cli",
         ":call_python_test",
     ],
+    # Certain versions of Mac don't like this script using `ps`. For this
+    # reason, make the test run locally.
+    local = 1,
 )
 
 drake_cc_googletest(

--- a/common/proto/call_python.cc
+++ b/common/proto/call_python.cc
@@ -1,5 +1,7 @@
 #include "drake/common/proto/call_python.h"
 
+#include <memory>
+
 #include "drake/common/proto/matlab_rpc.pb.h"
 
 namespace drake {
@@ -23,10 +25,35 @@ void ToMatlabArray(const PythonRemoteVariable& var, MatlabArray* matlab_array) {
   matlab_array->set_data(&uid, num_bytes);
 }
 
+namespace {
+
+const char kFilenameDefault[] = "/tmp/python_rpc";
+
+auto GetPythonOutputStream(const std::string* filename = nullptr) {
+  static std::unique_ptr<google::protobuf::io::FileOutputStream> raw_output;
+  if (!raw_output) {
+    // If we do not yet have a file, create it.
+    raw_output =
+        internal::CreateOutputStream(filename ? *filename : kFilenameDefault);
+  } else {
+    // If we already have a file, ensure that this does not come from
+    // `CallPythonInit`.
+    if (filename) {
+      throw std::runtime_error(
+          "`CallPython` or `CallPythonInit` has already been called");
+    }
+  }
+  return raw_output.get();
+}
+
+}  // namespace
+
+void CallPythonInit(const std::string& filename) {
+  GetPythonOutputStream(&filename);
+}
+
 void internal::PublishCallPython(const MatlabRPC& message) {
-  // TODO(eric.cousineau): Provide option for setting the filename.
-  static auto raw_output = CreateOutputStream("/tmp/python_rpc");
-  PublishCall(raw_output.get(), message);
+  PublishCall(GetPythonOutputStream(), message);
 }
 
 }  // namespace common

--- a/common/proto/call_python.h
+++ b/common/proto/call_python.h
@@ -183,6 +183,12 @@ void PublishCallPython(const MatlabRPC& msg);
 
 }  // namespace internal
 
+/// Initializes `CallPython` for a given file.
+/// If this function is not called, then the file defaults to `/tmp/python_rpc`.
+/// @throws std::runtime_error If either this function or `CallPython` have
+/// already been called.
+void CallPythonInit(const std::string& filename);
+
 /// Calls a Python client with a given function and arguments, returning
 /// a handle to the result.
 template <typename... Types>

--- a/common/proto/test/call_python_full_test.sh
+++ b/common/proto/test/call_python_full_test.sh
@@ -20,8 +20,8 @@ cc_bin=${1}
 py_client_cli=${2}
 # TODO(eric.cousineau): Use `tempfile` once we can choose which file C++
 # uses.
-filename=/tmp/python_rpc
-done_file=/tmp/python_rpc_done
+filename=$(tempfile)
+done_file=${filename}_done
 
 py-error() {
     echo "ERROR: Python client did not exit successfully."
@@ -74,13 +74,13 @@ do-setup() {
     py_fail=${1}
     py_stop_on_error=${2}
 
-    cc_flags=
+    cc_flags="--file=${filename} --done_file=${done_file}"
     if [[ ${py_fail} -eq 1 ]]; then
-        cc_flags='--with_error'
+        cc_flags="${cc_flags} --with_error"
     fi
-    py_flags=
+    py_flags="--file=${filename}"
     if [[ ${py_stop_on_error} -eq 1 ]]; then
-        py_flags='--stop_on_error'
+        py_flags="${py_flags} --stop_on_error"
     fi
 
     rm -f ${filename}

--- a/common/proto/test/call_python_test.cc
+++ b/common/proto/test/call_python_test.cc
@@ -6,6 +6,14 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+DEFINE_string(file, "/tmp/python_rpc",
+              "File written to by this binary, read by client.");
+// This file signals to `call_python_full_test.sh` that a full execution has
+// been completed. This is useful for the `threading-loop` case, where we want
+// send a Ctrl+C interrupt only when finished.
+DEFINE_string(done_file, "/tmp/python_rpc_done",
+              "Signifies last Python command has been executed.");
+// Ensure that we test error behavior.
 DEFINE_bool(with_error, false, "Inject an error towards the end.");
 
 // TODO(eric.cousineau): Instrument client to verify output (and make this a
@@ -14,17 +22,13 @@ DEFINE_bool(with_error, false, "Inject an error towards the end.");
 namespace drake {
 namespace common {
 
-// This file signals to `call_python_full_test.sh` that a full execution has
-// been completed. This is useful for the `threading-loop` case, where we want
-// send a Ctrl+C interrupt only when finished.
-constexpr char kDoneFile[] = "/tmp/python_rpc_done";
-
 GTEST_TEST(TestCallPython, Start) {
+  CallPythonInit(FLAGS_file);
   // Tell client to expect a finishing signal.
   CallPython("execution_check.start");
   // Ensure that we remove `kDoneFile` so that we are not stopped in the middle
   // of execution.
-  CallPython("setvar", "done_file", kDoneFile);
+  CallPython("setvar", "done_file", FLAGS_done_file);
   CallPython("exec", "if os.path.exists(done_file): os.remove(done_file)");
 }
 


### PR DESCRIPTION
From this [CI failure](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-highsierra-clang-bazel-continuous-release/119/):
```
11:27:39 /Users/highsierra/workspace/mac-highsierra-clang-bazel-continuous-release/_bazel_highsierra/60e64b78a9d018d15bc884c4dac35977/bazel-sandbox/2876804359639914104/execroot/drake/bazel-out/osx-opt/bin/common/proto/call_python_full_test.runfiles/drake/common/proto/call_python_full_test: line 130: /bin/ps: Operation not permitted
11:27:39 Terminated: 15
```

Certain Mac platforms do not like `sh_test`s trying to access `ps`. Jamie's suggestion was to use `local = 1` for now.
As an alternative, `ps`, `kill`, and other `binutils` could be incorporated as tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7612)
<!-- Reviewable:end -->
