### PR TITLE
Bump lcm install  test size to large

### DIFF
--- a/tools/workspace/lcm/BUILD.bazel
+++ b/tools/workspace/lcm/BUILD.bazel
@@ -16,7 +16,7 @@ exports_files(
 # run as part of all the drake tests to have access to //:install
 drake_py_test(
     name = "install_test",
-    size = "medium",
+    size = "large",
     srcs = ["test/install_test.py"],
     main = "test/install_test.py",
     deps = ["//tools/install:install_test_helper"],


### PR DESCRIPTION
lcm install test was timing out on
linux-xenial-clang-bazel-continuous-everything-debug:

//tools/workspace/lcm:install_test TIMEOUT in 301.4s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7613)
<!-- Reviewable:end -->
