### PR TITLE
[WIP] Spike test using shared libraries rather than static linking

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -316,6 +316,8 @@ drake_cc_library(
 drake_cc_library(
     name = "text_logging_gflags",
     hdrs = ["text_logging_gflags.h"],
+    linkshared = 0,
+    linkstatic = 1,
     # TODO(jwnimmer-tri) Ideally, gflags BUILD would do this for us.  Figure
     # out what's going on.  Definitely don't let "-pthread" get copy-pasta'd
     # throughout our code.

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 load("@drake//tools/install:install.bzl", "install")
 load(
     "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
     "drake_transitive_installed_hdrs_filegroup",
 )
 load(
@@ -345,9 +346,14 @@ drake_java_binary(
     ],
 )
 
-drake_transitive_installed_hdrs_filegroup(
+drake_cc_library(
     name = "drake_lcmtypes_headers",
     deps = DRAKE_LCMTYPES,
+)
+
+drake_transitive_installed_hdrs_filegroup(
+    name = "drake_lcmtypes_install_artifacts",
+    deps = [":drake_lcmtypes_headers"],
 )
 
 # The drake-lcmtypes-cpp library is distinct from (but required by) the drake
@@ -359,7 +365,7 @@ drake_transitive_installed_hdrs_filegroup(
 # its generated cmake config `lib/cmake/drake/drake-config.cmake.
 install(
     name = "install_cc_headers",
-    hdrs = [":drake_lcmtypes_headers"],
+    targets = [":drake_lcmtypes_install_artifacts"],
     hdr_dest = "include/drake_lcmtypes",
     visibility = ["//visibility:private"],
 )

--- a/multibody/collision/BUILD.bazel
+++ b/multibody/collision/BUILD.bazel
@@ -76,6 +76,10 @@ drake_cc_library(
         "//drake/common:unused",
         "@fcl",
     ],
+    # For FCL and its upstream dependencies.
+    # This is the ONLY place these should EVER be linked in; otherwise, FCL
+    # and its upstream dependencies must become shared libraries.
+    linkstatic = 1,
 )
 
 # By default, supply a bullet-only model.  As we gain more collision library

--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -1,6 +1,7 @@
 # -*- python -*-
 
 load("@drake//tools/skylark:drake_java.bzl", "MainClassInfo")
+load("@drake//tools/skylark:drake_cc.bzl", "DrakeCc")
 load(
     "@drake//tools/skylark:pathutils.bzl",
     "dirname",
@@ -328,6 +329,24 @@ def _install_impl(ctx):
                 rename,
                 t
             )
+        elif DrakeCc in t:
+            tx = t[DrakeCc]
+            # Headers:
+            hdrs = [struct(files = tx.transitive_hdrs)]
+            actions += _install_actions(
+                ctx,
+                hdrs,
+                ctx.attr.hdr_dest,
+                strip_prefixes = ctx.attr.hdr_strip_prefix,
+                rename = rename)
+            # Solib (library):
+            solibs = [struct(files = tx.transitive_solibs)]
+            actions += _install_actions(
+                ctx,
+                solibs,
+                ctx.attr.library_dest,
+                strip_prefixes = ctx.attr.library_strip_prefix,
+                rename = rename)
         elif hasattr(t, "files_to_run") and t.files_to_run.executable:
             # Executable scripts copied from source directory.
             actions += _install_runtime_actions(ctx, t)

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -19,7 +19,7 @@ load(
     "HAS_MOVED_6996",
 )
 load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
-load("//tools:drake.bzl", "drake_cc_binary")
+load("//tools:drake.bzl", "drake_cc_library")
 
 LIBDRAKE_COMPONENTS = adjust_labels_for_drake_hoist(LIBDRAKE_COMPONENTS)
 
@@ -37,26 +37,28 @@ install_cmake_config(
 # LIBDRAKE_COMPONENTS and all the Drake externals. We use linkstatic=1 so
 # that the binary package will not contain any references to shared libraries
 # inside the build tree.
-drake_cc_binary(
-    name = "libdrake.so",
-    linkshared = 1,
-    linkstatic = 1,
+drake_cc_library(
+    name = "drake",
+    solib_name = "libdrake.so",
     deps = LIBDRAKE_COMPONENTS,
+    visibility = ["//visibility:public"],
 )
 
 # Gather all of libdrake.so's dependent headers.
 drake_transitive_installed_hdrs_filegroup(
-    name = "libdrake_headers",
+    name = "drake_install_artifacts",
     visibility = [],
-    deps = LIBDRAKE_COMPONENTS,
+    deps = [":drake"],
 )
 
 # Install libdrake.so along with all transitive headers in the same workspace
 # (i.e. in Drake itself; not externals).
 install(
     name = "install",
-    targets = ["libdrake.so"],
-    hdrs = [":libdrake_headers"],
+    targets = [
+        ":drake_install_artifacts",
+    ],
+    library_dest = "lib",
     hdr_dest = "include/drake" if HAS_MOVED_6996 else "include",
     allowed_externals = ["//:LICENSE.TXT"],  # Root for our #include paths.
     deps = [
@@ -110,26 +112,9 @@ cc_library(
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
 # *.so files for us, without us having to know up-front here which dependencies
 # are coming from the WORKSPACE in the form of *.so.
-cc_library(
+alias(
     name = "drake_shared_library",
-    hdrs = [":libdrake_headers"],
-    include_prefix = "drake" if HAS_MOVED_6996 else None,
-    strip_include_prefix = "/" if HAS_MOVED_6996 else None,
-    visibility = adjust_labels_for_drake_hoist([
-        "//drake/bindings/pydrake:__subpackages__",
-        "//drake/examples:__subpackages__",
-    ]),
-    deps = [
-        ":gurobi_deps",
-        ":mosek_deps",
-        ":vtk_deps",
-        "@bullet//:BulletCollision",
-        "@ignition_math",
-        "@lcm",
-        "@libprotobuf",
-        "@scs//:scsdir",
-        "@tinyxml2",
-    ],
+    actual = "drake",
 )
 
 add_lint_tests()

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -45,7 +45,7 @@ def _drake_pybind_cc_binary(
         ] + copts,
         # This is how you tell Bazel to create a shared library.
         linkshared = 1,
-        linkstatic = 1,
+        linkstatic = 0,
         # For all pydrake_foo.so, always link to Drake and pybind11.
         deps = [
             # Even though "libdrake.so" appears in srcs above, we have to list

--- a/tools/workspace/ccd/package.BUILD.bazel
+++ b/tools/workspace/ccd/package.BUILD.bazel
@@ -56,6 +56,7 @@ cc_library(
     defines = ["CCD_STATIC_DEFINE"],
     includes = ["src"],
     linkstatic = 1,
+    # See notes in `fcl` regarding privacy and limited linking.
 )
 
 install(

--- a/tools/workspace/fcl/package.BUILD.bazel
+++ b/tools/workspace/fcl/package.BUILD.bazel
@@ -73,6 +73,9 @@ cc_library(
         "@eigen",
         "@octomap",
     ],
+    # Only ONE Drake solib should *ever* consume this.
+    # Otherwise, this must become a shared library, and we must rethink
+    # visibility. We cannot use visibility, however, to control this.
 )
 
 install(

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -6,12 +6,17 @@ load(
     "install",
     "install_cmake_config",
 )
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+    "cc_solib_library_artifacts",
+)
 
 package(
     default_visibility = ["//visibility:public"],
 )
 
-cc_library(
+cc_solib_library(
     name = "fmt",
     srcs = glob(["fmt/*.cc"]),
     hdrs = glob(["fmt/*.h"]),
@@ -28,7 +33,7 @@ install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
 
 install(
     name = "install",
-    targets = [":fmt"],
+    targets = cc_solib_library_artifacts("fmt"),
     hdr_dest = "include/fmt",
     hdr_strip_prefix = ["fmt"],
     guess_hdrs = "PACKAGE",

--- a/tools/workspace/gtest/package.BUILD.bazel
+++ b/tools/workspace/gtest/package.BUILD.bazel
@@ -1,12 +1,18 @@
 # -*- python -*-
 
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+)
+
 config_setting(
     name = "linux",
     values = {"cpu": "k8"},
 )
 
-cc_library(
+cc_solib_library(
     name = "without_main",
+    solib_name = "libgtest_without_main.so",
     testonly = 1,
     srcs = glob(
         [

--- a/tools/workspace/ignition_rndf/package.BUILD.bazel
+++ b/tools/workspace/ignition_rndf/package.BUILD.bazel
@@ -13,6 +13,11 @@ load(
     "install",
     "install_cmake_config",
 )
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+    "cc_solib_library_artifacts",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -49,7 +54,7 @@ drake_generate_include_header(
     visibility = ["//visibility:private"],
 )
 
-cc_library(
+cc_solib_library(
     name = "ignition_rndf",
     srcs = glob(
         ["src/*.cc"],
@@ -79,11 +84,7 @@ install_cmake_config(package = CMAKE_PACKAGE)
 install(
     name = "install",
     workspace = CMAKE_PACKAGE,
-    targets = [":ignition_rndf"],
-    hdrs = public_headers + [
-        ":config",
-        ":rndfhh_genrule",
-    ],
+    targets = cc_solib_library_artifacts("ignition_rndf"),
     hdr_strip_prefix = ["include"],
     docs = [
         "COPYING",

--- a/tools/workspace/octomap/package.BUILD.bazel
+++ b/tools/workspace/octomap/package.BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
         "octomap/include/octomap/math/*.h*",
     ]),
     includes = ["octomap/include"],
+    linkstatic = 1,
 )
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
@@ -47,6 +48,7 @@ cc_library(
     includes = ["octomap/include"],
     linkstatic = 1,
     deps = [":octomath"],
+    # See notes in `fcl` regarding privacy and limited linking.
 )
 
 install(

--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -14,6 +14,11 @@ load(
     "install",
     "install_cmake_config",
 )
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+    "cc_solib_library_artifacts",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -64,7 +69,7 @@ drake_generate_include_header(
 # Generates the library exported to users.  The explicitly listed srcs= matches
 # upstream's explicitly listed sources plus private headers.  The explicitly
 # listed hdrs= matches upstream's public headers.
-cc_library(
+cc_solib_library(
     name = "sdformat",
     srcs = [
         "include/sdf/Converter.hh",
@@ -142,11 +147,7 @@ install_cmake_config(package = "SDFormat")
 
 install(
     name = "install",
-    targets = [":sdformat"],
-    hdrs = public_headers + [
-        ":sdfhh_genrule",
-        ":config",
-    ],
+    targets = cc_solib_library_artifacts("sdformat"),
     hdr_strip_prefix = ["include"],
     docs = [
         "COPYING",

--- a/tools/workspace/spruce/package.BUILD.bazel
+++ b/tools/workspace/spruce/package.BUILD.bazel
@@ -1,11 +1,19 @@
 # -*- python -*-
 
 load("@drake//tools/install:install.bzl", "install")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+    "cc_solib_library_artifacts",
+)
 
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
+# Because this is referenced in multiple places, this *must* be a shared
+# library.
+cc_solib_library(
     name = "spruce",
+    solib_name = "libdrake-spruce.so",
     srcs = ["spruce.cc"],
     hdrs = ["spruce.hh"],
     includes = ["."],
@@ -15,5 +23,6 @@ cc_library(
 # need to install its license file.
 install(
     name = "install",
+    targets = cc_solib_library_artifacts("spruce", private=True),
     docs = ["LICENSE"],
 )

--- a/tools/workspace/tinyobjloader/package.BUILD.bazel
+++ b/tools/workspace/tinyobjloader/package.BUILD.bazel
@@ -6,12 +6,17 @@ load(
     "install",
     "install_cmake_config",
 )
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "cc_solib_library",
+    "cc_solib_library_artifacts",
+)
 
 package(
     default_visibility = ["//visibility:public"],
 )
 
-cc_library(
+cc_solib_library(
     name = "tinyobjloader",
     srcs = [
         "tiny_obj_loader.cc",
@@ -34,9 +39,8 @@ install_cmake_config(package = "tinyobjloader")
 
 install(
     name = "install",
-    targets = [":tinyobjloader"],
+    targets = cc_solib_library_artifacts("tinyobjloader"),
     hdr_dest = "include/tinyobjloader",
-    guess_hdrs = "PACKAGE",
     docs = ["LICENSE"],
     deps = [":install_cmake_config"],
 )


### PR DESCRIPTION
Relates #7294 / #6760:

This is a (semi-)quick test of having Drake use shared libraries, rather than rely on static linking, trying to skip waiting on bazelbuild/bazel#492, using one of the suggested workarounds.

Pros:
* Smaller files
    * On `master`, doing an install in debug mode yields `libdrake.so` of about 1.6GB (per Francois's findings)
    * With this branch, `libdrake.so` is about 2MB.
* Feels cleaner-ish

Cons:
* Fighting against Bazel:
    * `linkshared` causes any upstream libraries that have *any* bit of object code to be linked as Bazel-mangled shared objects. This sucks when working with externals, because I had to either have to shim them using (a) the workaround from 492, or (b) create a "barrier" library to intercept the 
    * `linkstatic` seems to be catered to how a library is consumed, rather than produced. Maybe there's a better balance of `linkstatic` and `linkshared` that I missed.
* Speed when loading:
     * It took quite a while to try and import `pydrake` after installing.
     * Not sure what the load time for GDB would be.

I tested the installed libraries with the following command:
```
cd drake
mkdir -p build/install
bazel --bazelrc=/dev/null run //:install -- ~+/build/install
find build/install/lib -name 'libdrake*.so' | xargs -n 1 -P8 ldd | grep 'not found' | sort -u
# ^ Race conditions for `-P8` shouldn't matter too much
```

When running `bazel --bazelrc=/dev/null test //...`, all but 15 tests pass:
* All python tests (missing `libdrake-automotive-maliput-dragway-dragway.so` - could be fixed quickly?)
* Some linting
* `rgbd_camera_test` - Same things as what's in the FAQ, I believe.

I wouldn't say this is anywhere near ready for prime time, but an initial attempt.

\cc @jwnimmer-tri @jamiesnape @fbudin69500 @stonier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7616)
<!-- Reviewable:end -->
