### PR TITLE
Set timeout = "long" for monolithic_p&p_system_test.

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -64,7 +64,7 @@ drake_cc_binary(
 
 drake_cc_googletest(
     name = "monolithic_pick_and_place_system_test",
-    size = "medium",
+    timeout = "long",
     # Setting shard_count allows the test runner to split up the test-points in
     # this test into shard_count separate pieces which will be exectuted in
     # parallel, subject to the availability of resources. There are 31 test


### PR DESCRIPTION
#7606 brought `monolithic_pick_and_place_system_test` under the timeout for `medium` tests in release builds, but not in debug builds. This PR sets the timeout to `long` rather than the test size to large because the other resource requirements of this test are unchanged - it just takes a long time to run simulations in debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7619)
<!-- Reviewable:end -->
