### PR TITLE
Re-disable monolithic_p&p_system_test in debug mode.

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -65,6 +65,13 @@ drake_cc_binary(
 drake_cc_googletest(
     name = "monolithic_pick_and_place_system_test",
     size = "medium",
+    # TODO(avalenzu) The gtest_filter argument below is required because the
+    # test currently times out when compiled in debug mode. We should try to
+    # split this test up such that this exclusion is no longer necessary.
+    args = select({
+        "//tools/cc_toolchain:debug": ["--gtest_filter=-*"],
+        "//conditions:default": [],
+    }),
     # Setting shard_count allows the test runner to split up the test-points in
     # this test into shard_count separate pieces which will be exectuted in
     # parallel, subject to the availability of resources. There are 31 test


### PR DESCRIPTION
This test still times out in debug builds, even with sharding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7620)
<!-- Reviewable:end -->
