### PR TITLE
Fix FindLibraryTest by making it platform-dependent

### DIFF
--- a/common/test/find_loaded_library_test.cc
+++ b/common/test/find_loaded_library_test.cc
@@ -13,7 +13,12 @@ GTEST_TEST(FindLibraryTest, Library) {
   // Test wether or not `LoadedLibraryPath()` can find the path to a library
   // loaded by the process.
   optional<string> library_path =
+  // TODO(fbudin69500): Remove this platform-dependency.
+#ifdef __APPLE__
+    LoadedLibraryPath("libgflags.so");
+#else
     LoadedLibraryPath("libexternal_Scom_Ugithub_Ugflags_Ugflags_Slibgflags.so");
+#endif
   EXPECT_TRUE(library_path);
   library_path = LoadedLibraryPath("lib_not_real.so");
   EXPECT_FALSE(library_path);


### PR DESCRIPTION
The original code was added by https://github.com/RobotLocomotion/drake/pull/7439.
See https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/mac-sierra-clang-bazel-continuous-release/271/consoleText.

This PR merely changes the test to make CI happy. @fbudin69500, please check if the original test failure indicates an issue in `LoadedLibraryPath`.

/cc @jamiesnape, @sammy-tri, @jwnimmer-tri (reviewers of #7439)
/cc @ggould-tri (buildcop)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7632)
<!-- Reviewable:end -->
