### PR TITLE
Add tag "no_ubsan" to all tests which use protobuf.

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -41,8 +41,8 @@ drake_cc_binary(
     ],
     # TODO(m-chaturvedi) TSan fails with a data race in LCM for this test. See
     # #7524.
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
-    # in later versions of Protobuf is described here:
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
+    # workaround in later versions of Protobuf is described here:
     # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
     # In the future we should add a codegen action to edit the generated file
     # include block to add a fixup header with the workaround at the end.

--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -41,8 +41,14 @@ drake_cc_binary(
     ],
     # TODO(m-chaturvedi) TSan fails with a data race in LCM for this test. See
     # #7524.
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
+    # in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
     tags = [
         "no_tsan",
+        "no_ubsan",
     ],
     test_rule_args = ["--quick"],
     # Flaky because LCM self-test can fail (PR #7311)

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
@@ -193,6 +193,14 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/examples/kuka_iiwa_arm/dev/pick_and_place:pick_and_place_configuration_parsing",  # noqa
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
+    # in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
 )
 
 add_lint_tests()

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
@@ -189,17 +189,17 @@ drake_cc_googletest(
         "//drake/examples/kuka_iiwa_arm:models",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    deps = [
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/examples/kuka_iiwa_arm/dev/pick_and_place:pick_and_place_configuration_parsing",  # noqa
-    ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
-    # in later versions of Protobuf is described here:
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
+    # workaround in later versions of Protobuf is described here:
     # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
     # In the future we should add a codegen action to edit the generated file
     # include block to add a fixup header with the workaround at the end.
     tags = [
         "no_ubsan",
+    ],
+    deps = [
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/examples/kuka_iiwa_arm/dev/pick_and_place:pick_and_place_configuration_parsing",  # noqa
     ],
 )
 

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -595,6 +595,14 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/multibody/parsers",
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
+    # in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
 )
 
 # This test is empty unless Gurobi is enabled.

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -589,19 +589,19 @@ drake_cc_googletest(
         "test/test.alias_groups",
         "//drake/multibody:test_models",
     ],
-    deps = [
-        ":rigid_body_tree_alias_groups",
-        "//drake/common:find_resource",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/multibody/parsers",
-    ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
-    # in later versions of Protobuf is described here:
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
+    # workaround in later versions of Protobuf is described here:
     # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
     # In the future we should add a codegen action to edit the generated file
     # include block to add a fixup header with the workaround at the end.
     tags = [
         "no_ubsan",
+    ],
+    deps = [
+        ":rigid_body_tree_alias_groups",
+        "//drake/common:find_resource",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/multibody/parsers",
     ],
 )
 

--- a/systems/controllers/plan_eval/BUILD.bazel
+++ b/systems/controllers/plan_eval/BUILD.bazel
@@ -62,6 +62,14 @@ drake_cc_googletest(
         "//drake/systems/controllers/qp_inverse_dynamics:test/iiwa.alias_groups",  # noqa
         "//drake/systems/controllers/qp_inverse_dynamics:test/iiwa.id_controller_config",  # noqa
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
+    # workaround in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
     deps = [
         ":generic_plan",
         ":test_common",
@@ -69,14 +77,6 @@ drake_cc_googletest(
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody/parsers",
-    ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
-    # in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
     ],
 )
 

--- a/systems/controllers/plan_eval/BUILD.bazel
+++ b/systems/controllers/plan_eval/BUILD.bazel
@@ -70,6 +70,14 @@ drake_cc_googletest(
         "//drake/multibody:rigid_body_tree",
         "//drake/multibody/parsers",
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
+    # in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
 )
 
 add_lint_tests()

--- a/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -157,6 +157,14 @@ drake_cc_googletest(
         "//drake/multibody:rigid_body_tree_alias_groups",
         "//drake/multibody/parsers",
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
+    # in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
 )
 
 drake_cc_googletest(

--- a/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -150,20 +150,20 @@ drake_cc_googletest(
         "test/params.id_controller_config",
         "//drake/examples/valkyrie:models",
     ],
+    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
+    # workaround in later versions of Protobuf is described here:
+    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
+    # In the future we should add a codegen action to edit the generated file
+    # include block to add a fixup header with the workaround at the end.
+    tags = [
+        "no_ubsan",
+    ],
     deps = [
         ":param_parser",
         "//drake/common:find_resource",
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/multibody:rigid_body_tree_alias_groups",
         "//drake/multibody/parsers",
-    ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the workaround
-    # in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
     ],
 )
 


### PR DESCRIPTION
This is due to a bug in Protobuf 2.6; it is described in
more detail in the TODO comment in the code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7636)
<!-- Reviewable:end -->
