### PR TITLE
Don't link gflags into libdrake.so

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
     ],
     # Intentionally excluded items:
     # - text_logging_gflags
+    # - text_logging_gflags_h
 )
 
 # A library of things that EVERYONE should want and MUST EAT.
@@ -326,6 +327,15 @@ drake_cc_library(
         ":essential",
         "@com_github_gflags_gflags//:gflags",
     ],
+)
+
+# Compared to the above rule, this removes the deps attribute; we don't want to
+# link against gflags for libdrake.so, we just want to publish this header for
+# callers who have their own gflags to link against.
+drake_cc_library(
+    name = "text_logging_gflags_h",
+    hdrs = ["text_logging_gflags.h"],
+    visibility = ["//tools/install/libdrake:__pkg__"],
 )
 
 drake_cc_library(

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -78,7 +78,7 @@ LIBDRAKE_COMPONENTS = [
     "//drake/common:sorted_vectors_have_intersection",
     "//drake/common:symbolic",
     "//drake/common:symbolic_decompose",
-    "//drake/common:text_logging_gflags",
+    "//drake/common:text_logging_gflags_h",
     "//drake/common:type_safe_index",
     "//drake/common:unused",
     "//drake/geometry/query_results:penetration_as_point_pair",


### PR DESCRIPTION
It was not by design (it was broken) that we were linking to gflags; somehow, only macOS in debug mode noticed.

This closes #7637 -- the revert will not be needed if this merges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7639)
<!-- Reviewable:end -->
