### PR TITLE
Add missing pybind module to CMAKE_MODULE_PATH

### DIFF
--- a/tools/workspace/pybind11/pybind11-create-cps.py
+++ b/tools/workspace/pybind11/pybind11-create-cps.py
@@ -19,7 +19,10 @@ content = """
       "Compile-Features": ["c++11"]
     }
   },
-  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"]
+  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"],
+  "X-CMake-Variables-Init": {
+    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}"
+  }
 }
 """ % defs
 


### PR DESCRIPTION
pybind11 defines a [custom module](https://github.com/RobotLocomotion/pybind11/blob/ffcf754ae9e766632610975d22372a86a7b63014/tools/FindPythonLibsNew.cmake) for finding Python libraries.
Their CMake Config file adds it to the `CMAKE_MODULE_PATH` for visibility.
https://github.com/RobotLocomotion/pybind11/blob/ffcf754ae9e766632610975d22372a86a7b63014/tools/pybind11Config.cmake.in#L73-L74

This PR update the pcs configuration to do the same.
This is necessary for downstream packages to be able to `find_package(pybind11 REQUIRED)`.

Expected behavior:
CMake finds the module and populate the package's CMake variables accordingly.

Actual behavior:
```
CMake Error at /home/mikael/work/test_delphyne_pybind/install/lib/cmake/pybind11/pybind11Tools.cmake:16 (find_package):
  By not providing "FindPythonLibsNew.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "PythonLibsNew", but CMake did not find one.

  Could not find a package configuration file provided by "PythonLibsNew"
  with any of the following names:

    PythonLibsNewConfig.cmake
    pythonlibsnew-config.cmake

  Add the installation prefix of "PythonLibsNew" to CMAKE_PREFIX_PATH or set
  "PythonLibsNew_DIR" to a directory containing one of the above files.  If
  "PythonLibsNew" provides a separate development package or SDK, be sure it
  has been installed.
```

+@EricCousineau-TRI for feature review please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7641)
<!-- Reviewable:end -->
