### PR TITLE
Fix all problems with protobuf 2.6 and UBSan

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -41,14 +41,8 @@ drake_cc_binary(
     ],
     # TODO(m-chaturvedi) TSan fails with a data race in LCM for this test. See
     # #7524.
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
-    # workaround in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
     tags = [
         "no_tsan",
-        "no_ubsan",
     ],
     test_rule_args = ["--quick"],
     # Flaky because LCM self-test can fail (PR #7311)

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/BUILD.bazel
@@ -189,14 +189,6 @@ drake_cc_googletest(
         "//drake/examples/kuka_iiwa_arm:models",
         "//drake/manipulation/models/iiwa_description:models",
     ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
-    # workaround in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
-    ],
     deps = [
         "//drake/common/test_utilities:eigen_matrix_compare",
         "//drake/examples/kuka_iiwa_arm/dev/pick_and_place:pick_and_place_configuration_parsing",  # noqa

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -589,14 +589,6 @@ drake_cc_googletest(
         "test/test.alias_groups",
         "//drake/multibody:test_models",
     ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
-    # workaround in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
-    ],
     deps = [
         ":rigid_body_tree_alias_groups",
         "//drake/common:find_resource",

--- a/systems/controllers/plan_eval/BUILD.bazel
+++ b/systems/controllers/plan_eval/BUILD.bazel
@@ -62,14 +62,6 @@ drake_cc_googletest(
         "//drake/systems/controllers/qp_inverse_dynamics:test/iiwa.alias_groups",  # noqa
         "//drake/systems/controllers/qp_inverse_dynamics:test/iiwa.id_controller_config",  # noqa
     ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
-    # workaround in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
-    ],
     deps = [
         ":generic_plan",
         ":test_common",

--- a/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -150,14 +150,6 @@ drake_cc_googletest(
         "test/params.id_controller_config",
         "//drake/examples/valkyrie:models",
     ],
-    # TODO(clalancette) UBSan fails due to a bug in Protobuf 2.6 (the
-    # workaround in later versions of Protobuf is described here:
-    # https://github.com/google/protobuf/blob/master/src/google/protobuf/generated_message_util.h#L78
-    # In the future we should add a codegen action to edit the generated file
-    # include block to add a fixup header with the workaround at the end.
-    tags = [
-        "no_ubsan",
-    ],
     deps = [
         ":param_parser",
         "//drake/common:find_resource",

--- a/third_party/com_github_google_protobuf/BUILD.bazel
+++ b/third_party/com_github_google_protobuf/BUILD.bazel
@@ -26,3 +26,8 @@ py_library(
     name = "protobuf_python",
     # No srcs here, so we'll use the system default.
 )
+
+cc_library(
+    name = "protobuf_fixup_ubsan",
+    hdrs = ["protobuf-ubsan-fixup.h"],
+)

--- a/third_party/com_github_google_protobuf/README.md
+++ b/third_party/com_github_google_protobuf/README.md
@@ -5,6 +5,7 @@ copyrighted by whom:
 
 BUILD.bazel - Drake project
 LICENSE - Google, protobuf project
+protobuf-ubsan-fixup.h - Google, protobuf project
 protobuf.bzl - Google, protobuf project
 README.md - Drake project
 WORKSPACE - Drake project

--- a/third_party/com_github_google_protobuf/protobuf-ubsan-fixup.h
+++ b/third_party/com_github_google_protobuf/protobuf-ubsan-fixup.h
@@ -1,0 +1,47 @@
+#ifndef PROTOBUF_UBSAN_FIXUP_H
+#define PROTOBUF_UBSAN_FIXUP_H
+
+// This code is pulled from upstream Protobuf:
+// https://github.com/google/protobuf/blob/4fc9304/src/google/protobuf/generated_message_util.h#L80
+// This is necessary because Protobuf 2.6 (which Drake is currently using from
+// the system) won't test cleanly under UBSan.  The way this works is that
+// the drake_cc_proto_library() skylark function splices this header file into
+// any generated protobuf headers, so that
+// the GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET macros is redefined to
+// pass UBSan.  This can be removed if the system version of protobuf is moved
+// to a newer version.
+
+#ifdef GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET
+#undef GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET
+#endif
+
+// Returns the offset of the given field within the given aggregate type.
+// This is equivalent to the ANSI C offsetof() macro.  However, according
+// to the C++ standard, offsetof() only works on POD types, and GCC
+// enforces this requirement with a warning.  In practice, this rule is
+// unnecessarily strict; there is probably no compiler or platform on
+// which the offsets of the direct fields of a class are non-constant.
+// Fields inherited from superclasses *can* have non-constant offsets,
+// but that's not what this macro will be used for.
+#if defined(__clang__)
+// For Clang we use __builtin_offsetof() and suppress the warning,
+// to avoid Control Flow Integrity and UBSan vptr sanitizers from
+// crashing while trying to validate the invalid reinterpet_casts.
+#define GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TYPE, FIELD)  \
+  _Pragma("clang diagnostic push")                                   \
+  _Pragma("clang diagnostic ignored \"-Winvalid-offsetof\"")         \
+  __builtin_offsetof(TYPE, FIELD)                                    \
+  _Pragma("clang diagnostic pop")
+#else
+// Note that we calculate relative to the pointer value 16 here since if we
+// just use zero, GCC complains about dereferencing a NULL pointer.  We
+// choose 16 rather than some other number just in case the compiler would
+// be confused by an unaligned pointer.
+#define GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(TYPE, FIELD)  \
+  static_cast< ::google::protobuf::uint32>(                           \
+      reinterpret_cast<const char*>(                                 \
+          &reinterpret_cast<const TYPE*>(16)->FIELD) -               \
+      reinterpret_cast<const char*>(16))
+#endif
+
+#endif


### PR DESCRIPTION
This PR should fix up the current problems with UBSan on the build farm, and should also fix #7638 .  There are some explanations in the code, but the short of the problem is that in Protobuf 2.6 (which Drake is using from the system), there is a bug that makes UBSan always complain.  Upstream protobuf has fixes this with a change to the problematic macro in later releases.  Since this is a macro, we can actually splice in our own header file with the fix; the header file undefines the old macro, then redefines it as the fixed version.  Since UBSan should now work, this patch also removes the temporary "no_ubsan" tags that we added in #7636.

Note that I have only done some basic testing here.  I haven't tested on a "full" ubsan build (I just spot-checked a couple locally), and I haven't yet tested on macOS.  Nonetheless, I am opening this for visibility, while I kick off those CI jobs.

FYI @jwnimmer-tri @jamiesnape @m-chaturvedi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7644)
<!-- Reviewable:end -->
