### PR TITLE
Update SHA256 of sdformat archive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -433,7 +433,7 @@ bitbucket_archive(
     name = "sdformat",
     repository = "osrf/sdformat",
     commit = "bac3dfb42cc7",
-    sha256 = "b10a3ac68ed46f8d5780ddc687e6c89c71cb4c1e4e65449197f8aac76be903d8",  # noqa
+    sha256 = "212211eddd9fa010b4b61a2dae87cd84a66a8b78ed302612d214b7388f9bc198",  # noqa
     strip_prefix = "osrf-sdformat-bac3dfb42cc7",
     build_file = "tools/workspace/sdformat/sdformat.BUILD.bazel",
 )


### PR DESCRIPTION
I guess Bitbucket updated their version of Mercurial or related utilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7649)
<!-- Reviewable:end -->
