### PR TITLE
Add Boost::boost to drake.cps and SDFormat.cps

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -7,6 +7,10 @@
   "Name": "drake",
   "Website": "http://drake.mit.edu/",
   "Requires": {
+    "Boost": {
+      "Version": "1.58",
+      "X-CMake-Find-Args": ["MODULE"]
+    },
     "bot2-core-lcmtypes": {
       "Hints": ["@prefix@/lib/cmake/bot2-core-lcmtypes"],
       "X-CMake-Find-Args": ["CONFIG"]
@@ -103,6 +107,7 @@
       ],
       "Requires": [
         ":drake-lcmtypes-cpp",
+        "Boost:boost",
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",
         "Bullet:BulletCollision",
         "Eigen3:Eigen",

--- a/tools/workspace/sdformat/sdformat-create-cps.py
+++ b/tools/workspace/sdformat/sdformat-create-cps.py
@@ -14,10 +14,14 @@ content = """
   "License": "Apache-2.0",
   "Version": "%(MAJOR_VERSION)s.%(MINOR_VERSION)s.%(PATCH_VERSION)s",
   "Requires": {
+    "Boost": {
+      "Version": "1.58",
+      "X-CMake-Find-Args": ["MODULE"]
+    },
     "ignition-math3": {
       "Version": "%(ignition-math3_VERSION)s",
       "Hints": ["@prefix@/lib/cmake/ignition-math3"],
-      "X-CMake-Find-Args": [ "CONFIG" ]
+      "X-CMake-Find-Args": ["CONFIG"]
     }
   },
   "Default-Components": [ ":sdformat" ],
@@ -25,13 +29,15 @@ content = """
     "sdformat": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libsdformat.so",
-      "Includes": [ "@prefix@/include" ],
-      "Link-Flags": [ "-ltinyxml" ],
-      "Requires": [ "ignition-math3:ignition-math3" ]
+      "Includes": ["@prefix@/include"],
+      "Link-Flags": ["-ltinyxml"],
+      "Requires": [
+        "Boost:boost",
+        "ignition-math3:ignition-math3"
+      ]
     }
   }
 }
 """ % defs
-
 
 print(content[1:])


### PR DESCRIPTION
Note that `Boost::boost` is just the boost headers. This is added to `drake.cps` for the benefit of the system version of yaml-cpp (#7602) that has a broken pkg-config file (https://github.com/RobotLocomotion/drake/pull/7602#issuecomment-353093726).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7650)
<!-- Reviewable:end -->
