### PR TITLE
Updated default young's modulus parameters

### DIFF
--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -43,7 +43,8 @@
 DEFINE_string(urdf, "", "Name of urdf file to load");
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate (s)");
-DEFINE_double(youngs_modulus, 3e7, "Default material's Young's modulus (Pa)");
+// Set default Young's modulus to be that of aluminum.
+DEFINE_double(youngs_modulus, 6.9e10, "Default material Young's modulus (Pa)");
 DEFINE_double(dissipation, 5, "Contact Dissipation (s/m)");
 DEFINE_double(static_friction, 0.5, "Static Friction");
 DEFINE_double(dynamic_friction, 0.2, "Dynamic Friction");

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -43,8 +43,11 @@
 DEFINE_string(urdf, "", "Name of urdf file to load");
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "Number of seconds to simulate (s)");
-// Set default Young's modulus to be that of aluminum.
-DEFINE_double(youngs_modulus, 6.9e10, "Default material Young's modulus (Pa)");
+// Set default Young's modulus to be that of aluminum. This demo assumes the box
+// defines it's own Young's modulus in it's URDF, and does not use this default
+// value.
+DEFINE_double(youngs_modulus, 6.9e10,
+              "Default Young's modulus (Pa), set to be that of aluminum.");
 DEFINE_double(dissipation, 5, "Contact Dissipation (s/m)");
 DEFINE_double(static_friction, 0.5, "Static Friction");
 DEFINE_double(dynamic_friction, 0.2, "Dynamic Friction");

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_dual_box_rot.pmd
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_dual_box_rot.pmd
@@ -15,7 +15,7 @@ cmd "0.drake_visualizer" {
 }
 
 cmd "1.iiwa-sim" {
-        exec = "${DRAKE_WORKSPACE}/bazel-bin/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation --urdf examples/kuka_iiwa_arm/dev/box_rotation/models/${URDF} --contact_radius 2e-4 --youngs_modulus 3e7 --dissipation 5 --static_friction 0.5 --dynamic_friction 0.2 --v_stiction_tol 0.01 --use_visualizer=true";
+        exec = "${DRAKE_WORKSPACE}/bazel-bin/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation --urdf examples/kuka_iiwa_arm/dev/box_rotation/models/${URDF} --contact_radius 2e-4 --youngs_modulus 6.9e10 --dissipation 5 --static_friction 0.5 --dynamic_friction 0.2 --v_stiction_tol 0.01 --use_visualizer=true";
         host = "localhost";
 }
 

--- a/examples/kuka_iiwa_arm/dev/box_rotation/models/box.urdf
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/models/box.urdf
@@ -56,6 +56,12 @@
 		<geometry>
 			<box size="0.56 0.56 0.56"/>
 		</geometry>
+        <drake_compliance>
+            <youngs_modulus>3e7</youngs_modulus>
+            <dissipation>5</dissipation>
+            <static_friction>0.5</static_friction>
+            <dynamic_friction>0.2</dynamic_friction>
+        </drake_compliance>
   </collision>
 
         <!--collision box-->
@@ -71,6 +77,12 @@
     <geometry>
       <sphere radius="1e-3"/>
     </geometry>
+      <drake_compliance>
+          <youngs_modulus>3e7</youngs_modulus>
+          <dissipation>5</dissipation>
+          <static_friction>0.5</static_friction>
+          <dynamic_friction>0.2</dynamic_friction>
+      </drake_compliance>
   </collision>
 
         <visual>
@@ -84,6 +96,12 @@
     <geometry>
       <sphere radius="1e-3"/>
     </geometry>
+      <drake_compliance>
+          <youngs_modulus>3e7</youngs_modulus>
+          <dissipation>5</dissipation>
+          <static_friction>0.5</static_friction>
+          <dynamic_friction>0.2</dynamic_friction>
+      </drake_compliance>
   </collision>
 
 
@@ -99,6 +117,12 @@
     <geometry>
       <sphere radius="1e-3"/>
     </geometry>
+      <drake_compliance>
+          <youngs_modulus>3e7</youngs_modulus>
+          <dissipation>5</dissipation>
+          <static_friction>0.5</static_friction>
+          <dynamic_friction>0.2</dynamic_friction>
+      </drake_compliance>
   </collision>
 
   <visual>
@@ -112,6 +136,12 @@
     <geometry>
       <sphere radius="1e-3"/>
     </geometry>
+      <drake_compliance>
+          <youngs_modulus>3e7</youngs_modulus>
+          <dissipation>5</dissipation>
+          <static_friction>0.5</static_friction>
+          <dynamic_friction>0.2</dynamic_friction>
+      </drake_compliance>
   </collision>
 
 <!--separator-->
@@ -126,6 +156,12 @@
             <geometry>
                 <sphere radius="1e-3"/>
             </geometry>
+            <drake_compliance>
+                <youngs_modulus>3e7</youngs_modulus>
+                <dissipation>5</dissipation>
+                <static_friction>0.5</static_friction>
+                <dynamic_friction>0.2</dynamic_friction>
+            </drake_compliance>
         </collision>
 
         <visual>
@@ -139,6 +175,12 @@
             <geometry>
                 <sphere radius="1e-3"/>
             </geometry>
+            <drake_compliance>
+                <youngs_modulus>3e7</youngs_modulus>
+                <dissipation>5</dissipation>
+                <static_friction>0.5</static_friction>
+                <dynamic_friction>0.2</dynamic_friction>
+            </drake_compliance>
         </collision>
 
         <visual>
@@ -152,6 +194,12 @@
             <geometry>
                 <sphere radius="1e-3"/>
             </geometry>
+            <drake_compliance>
+                <youngs_modulus>3e7</youngs_modulus>
+                <dissipation>5</dissipation>
+                <static_friction>0.5</static_friction>
+                <dynamic_friction>0.2</dynamic_friction>
+            </drake_compliance>
         </collision>
 
         <visual>
@@ -165,6 +213,12 @@
             <geometry>
                 <sphere radius="1e-3"/>
             </geometry>
+            <drake_compliance>
+                <youngs_modulus>3e7</youngs_modulus>
+                <dissipation>5</dissipation>
+                <static_friction>0.5</static_friction>
+                <dynamic_friction>0.2</dynamic_friction>
+            </drake_compliance>
         </collision>
 
 	</link>


### PR DESCRIPTION
Updated default Young's modulus parameters to equal that of aluminum. Also set box.urdf material parameters to represent a compliant box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7651)
<!-- Reviewable:end -->
