### PR TITLE
Adds the FclEngine to geometry world to handle geometry queries

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -10,6 +10,24 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "proximity_engine",
+    srcs = [
+        "proximity_engine.cc",
+    ],
+    hdrs = [
+        "proximity_engine.h",
+    ],
+    deps = [
+        ":geometry_ids",
+        ":geometry_index",
+        ":shape_specification",
+        "//drake/common",
+        "//drake/common:default_scalars",
+        "@fcl",
+    ],
+)
+
+drake_cc_library(
     name = "frame_kinematics",
     srcs = [
         "frame_id_vector.cc",
@@ -84,6 +102,7 @@ drake_cc_library(
         ":geometry_instance",
         ":internal_frame",
         ":internal_geometry",
+        ":proximity_engine",
     ],
 )
 
@@ -159,6 +178,14 @@ drake_cc_library(
 )
 
 # -----------------------------------------------------
+
+drake_cc_googletest(
+    name = "proximity_engine_test",
+    deps = [
+        ":proximity_engine",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
 
 drake_cc_googletest(
     name = "frame_id_vector_test",

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -1,0 +1,488 @@
+#include "drake/geometry/proximity_engine.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+
+#include <fcl/fcl.h>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+using Eigen::Vector3d;
+using std::make_shared;
+using std::make_unique;
+using std::move;
+using std::shared_ptr;
+using std::unique_ptr;
+
+namespace {
+
+// TODO(SeanCurtis-TRI): Swap all Isometry3 for Transforms.
+
+// ADL-reliant helper functions for converting Isometry<T> to Isometry<double>.
+const Isometry3<double>& convert(const Isometry3<double>& transform) {
+  return transform;
+}
+
+template <class VectorType>
+Isometry3<double> convert(
+    const Isometry3<Eigen::AutoDiffScalar<VectorType>>& transform) {
+  Isometry3<double> result;
+  for (int r = 0; r < 4; ++r) {
+    for (int c = 0; c < 4; ++c) {
+      result.matrix()(r, c) = ExtractDoubleOrThrow(transform.matrix()(r, c));
+    }
+  }
+  return result;
+}
+
+// Utilities/functions for working with the encoding of collision object index
+// and mobility type in the fcl::CollisionObject user data field.
+class EncodedData {
+ public:
+  EncodedData(int index, bool is_dynamic)
+      : data_(static_cast<uintptr_t>(index)) {
+    if (is_dynamic) set_dynamic();
+    // NOTE: data is encoded as anchored by default. So, an action only needs to
+    // be taken in the dynamic case.
+  }
+
+  explicit EncodedData(const fcl::CollisionObject<double>& fcl_object)
+      : data_(reinterpret_cast<uintptr_t>(fcl_object.getUserData())) {}
+
+  // Sets the encoded data to be dynamic.
+  void set_dynamic() { data_ |= kIsDynamicMask; }
+
+  // Sets the encoded data to be anchored.
+  void set_anchored() { data_ &= ~kIsDynamicMask; }
+
+  // Stores the encoded data in the collision object's user data.
+  void store_in(fcl::CollisionObject<double>* object) {
+    object->setUserData(reinterpret_cast<void*>(data_));
+  }
+
+  // Reports true if the given fcl_object's user data is encoded as dynamic.
+  // False if anchored.
+  bool is_dynamic() const { return (data_ & kIsDynamicMask) != 0; }
+
+  // Reports the stored index.
+  int index() const { return static_cast<int>(data_ & ~kIsDynamicMask); }
+
+  // Given an fcl object and maps from index to id of both dynamic and anchored
+  // geometry, returns the geometry id for the given fcl object.
+  GeometryId id(const std::vector<GeometryId>& dynamic_map,
+                const std::vector<GeometryId>& anchored_map) const {
+    const uintptr_t i = index();
+    return is_dynamic() ? dynamic_map[i] : anchored_map[i];
+  }
+
+ private:
+  // Fcl Collision objects allow for user data. We're storing *two* pieces of
+  // information: the engine index of the corresponding geometry and the
+  // _mobility_ type (i.e., dynamic vs anchored). We do this by mangling bits.
+  // Because user data is a void*, we can read it like a uintptr_t. The highest
+  // bit will represent dynamic (1) or anchored (0).The remaining lower order
+  // bits store the index.
+
+  // Note: This sets a mask to be 1000...0 based on the size of a pointer.
+  // C++ guarantees that uintptr_t can hold a pointer and cast to a pointer,
+  // but it doesn't guarantee it's the *same size* as a pointer. So, we set
+  // the mask value based on pointer size.
+  static const uintptr_t kIsDynamicMask = uintptr_t{1}
+                                          << (sizeof(void*) * 8 - 1);
+
+  // The encoded data - index and mobility type.
+  // We're using an unsigned value here because:
+  //   - Bitmasking games are typically more intuitive with unsigned values
+  //     (think of bit shifting as an example here).
+  //   - This unsigned integer doesn't bleed out into the API at all.
+  uintptr_t data_{};
+};
+
+// Returns a copy of the given fcl collision geometry; throws an exception for
+// unsupported collision geometry types. This supplements the *missing* cloning
+// functionality in FCL. Issue has been submitted to FCL:
+// https://github.com/flexible-collision-library/fcl/issues/246
+shared_ptr<fcl::ShapeBased> CopyShapeOrThrow(
+    const fcl::CollisionGeometryd& geometry) {
+  // NOTE: Returns a shared pointer because of the FCL API in assigning
+  // collision geometry to collision objects.
+  switch (geometry.getNodeType()) {
+    case fcl::GEOM_SPHERE: {
+      const auto& sphere = dynamic_cast<const fcl::Sphered&>(geometry);
+      return make_shared<fcl::Sphered>(sphere.radius);
+    }
+    case fcl::GEOM_CYLINDER: {
+      const auto& cylinder = dynamic_cast<const fcl::Cylinderd&>(geometry);
+      return make_shared<fcl::Cylinderd>(cylinder.radius, cylinder.lz);
+    }
+    case fcl::GEOM_HALFSPACE:
+      // All half spaces are defined exactly the same.
+      return make_shared<fcl::Halfspaced>(0, 0, 1, 0);
+    case fcl::GEOM_BOX:
+    case fcl::GEOM_ELLIPSOID:
+    case fcl::GEOM_CAPSULE:
+    case fcl::GEOM_CONE:
+    case fcl::GEOM_CONVEX:
+    case fcl::GEOM_PLANE:
+    case fcl::GEOM_TRIANGLE:
+      throw std::logic_error(
+          "Trying to copy fcl::CollisionGeometry of unsupported GEOM_* type");
+    default:
+      throw std::logic_error(
+          "Trying to copy fcl::CollisionGeometry of non GEOM_* type");
+  }
+}
+
+// Helper function that creates a *deep* copy of the given collision object.
+unique_ptr<fcl::CollisionObjectd> CopyFclObjectOrThrow(
+    const fcl::CollisionObjectd& object) {
+  shared_ptr<fcl::ShapeBased> geometry_copy =
+      CopyShapeOrThrow(*object.collisionGeometry());
+  auto copy = make_unique<fcl::CollisionObjectd>(geometry_copy);
+  copy->setUserData(object.getUserData());
+  copy->setTransform(object.getTransform());
+  return copy;
+}
+
+// Helper function that creates a deep copy of a vector of collision objects.
+// Assumes the input vector has already been cleared. The `copy_map` parameter
+// serves as a mapping from each source object to its corresponding copy. Used
+// to facilitate copying broadphase culling data structures (see
+// ProximityEngine::operator=()).
+void CopyFclObjectsOrThrow(
+    const std::vector<unique_ptr<fcl::CollisionObjectd>>& source_objects,
+    std::vector<unique_ptr<fcl::CollisionObjectd>>* target_objects,
+    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>*
+        copy_map) {
+  DRAKE_ASSERT(target_objects->size() == 0);
+  target_objects->reserve(source_objects.size());
+  for (const unique_ptr<fcl::CollisionObjectd>& source_object :
+       source_objects) {
+    target_objects->emplace_back(CopyFclObjectOrThrow(*source_object));
+    copy_map->insert({source_object.get(), target_objects->back().get()});
+  }
+}
+
+// Builds into the target AABB tree manager based on the reference "other"
+// manager and the lookup table from other's collision objects to the target's
+// collision objects (the map populated by CopyFclObjectsOrThrow()).
+void BuildTreeFromReference(
+    const fcl::DynamicAABBTreeCollisionManager<double>& other,
+    const std::unordered_map<const fcl::CollisionObjectd*,
+                             fcl::CollisionObjectd*>& copy_map,
+    fcl::DynamicAABBTreeCollisionManager<double>* target) {
+  std::vector<fcl::CollisionObjectd*> other_objects;
+  other.getObjects(other_objects);
+  for (auto* other_object : other_objects) {
+    target->registerObject(copy_map.at(other_object));
+  }
+}
+
+}  // namespace
+
+// The implementation class for the fcl engine. Each of these functions
+// mirrors a method on the ProximityEngine (unless otherwise indicated.
+// See ProximityEngine for documentation.
+template <typename T>
+class ProximityEngine<T>::Impl : public ShapeReifier {
+ public:
+  Impl() = default;
+
+  Impl(const Impl& other) {
+    dynamic_tree_.clear();
+    dynamic_objects_.clear();
+    anchored_tree_.clear();
+    anchored_objects_.clear();
+
+    // Copy all of the geometry to ensure that the engine index values stay
+    // aligned.
+    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>
+        object_map;
+    CopyFclObjectsOrThrow(other.anchored_objects_, &anchored_objects_,
+                          &object_map);
+    CopyFclObjectsOrThrow(other.dynamic_objects_, &dynamic_objects_,
+                          &object_map);
+
+    // Build new AABB trees from the input AABB trees.
+    BuildTreeFromReference(other.dynamic_tree_, object_map, &dynamic_tree_);
+    BuildTreeFromReference(other.anchored_tree_, object_map, &anchored_tree_);
+  }
+
+  // Only the copy constructor is used to facilitate copying of the parent
+  // ProximityEngine class.
+  Impl& operator=(const Impl&) = delete;
+  Impl(Impl&& other) = delete;
+  Impl& operator=(Impl&&) = delete;
+
+  std::unique_ptr<ProximityEngine<AutoDiffXd>::Impl> ToAutoDiff() const {
+    auto engine = make_unique<ProximityEngine<AutoDiffXd>::Impl>();
+
+    // TODO(SeanCurtis-TRI): When AutoDiff is fully supported in the internal
+    // types, modify this map to the appropriate scalar and modify consuming
+    // functions accordingly.
+    // Copy all of the geometry to ensure that the engine index values stay
+    // aligned.
+    std::unordered_map<const fcl::CollisionObjectd*, fcl::CollisionObjectd*>
+        object_map;
+    CopyFclObjectsOrThrow(anchored_objects_, &engine->anchored_objects_,
+                          &object_map);
+    CopyFclObjectsOrThrow(dynamic_objects_, &engine->dynamic_objects_,
+                          &object_map);
+
+    // Build new AABB trees from the input AABB trees.
+    BuildTreeFromReference(dynamic_tree_, object_map, &engine->dynamic_tree_);
+    BuildTreeFromReference(anchored_tree_, object_map, &engine->anchored_tree_);
+
+    return engine;
+  }
+
+  GeometryIndex AddDynamicGeometry(const Shape& shape) {
+    // The collision object gets instantiated in the reification process and
+    // placed in this unique pointer.
+    std::unique_ptr<fcl::CollisionObject<double>> fcl_object;
+    shape.Reify(this, &fcl_object);
+    dynamic_tree_.registerObject(fcl_object.get());
+    GeometryIndex index(static_cast<int>(dynamic_objects_.size()));
+    EncodedData(index, true /* is dynamic */).store_in(fcl_object.get());
+    dynamic_objects_.emplace_back(std::move(fcl_object));
+
+    return index;
+  }
+
+  AnchoredGeometryIndex AddAnchoredGeometry(const Shape& shape,
+                                            const Isometry3<double>& X_WG) {
+    // The collision object gets instantiated in the reification process and
+    // placed in this unique pointer.
+    std::unique_ptr<fcl::CollisionObject<double>> fcl_object;
+    shape.Reify(this, &fcl_object);
+    fcl_object->setTransform(X_WG);
+    anchored_tree_.registerObject(fcl_object.get());
+    AnchoredGeometryIndex index(static_cast<int>(anchored_objects_.size()));
+    EncodedData(index, false /* is dynamic */).store_in(fcl_object.get());
+    anchored_objects_.emplace_back(std::move(fcl_object));
+
+    return index;
+  }
+
+  int num_geometries() const {
+    return static_cast<int>(dynamic_objects_.size() + anchored_objects_.size());
+  }
+
+  int num_dynamic() const { return static_cast<int>(dynamic_objects_.size()); }
+
+  int num_anchored() const {
+    return static_cast<int>(anchored_objects_.size());
+  }
+
+  // TODO(SeanCurtis-TRI): I could do things here differently a number of ways:
+  //  1. I could make this move semantics (or swap semantics).
+  //  2. I could simply have a method that returns a mutable reference to such
+  //    a vector and the caller sets values there directly.
+  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG) {
+    DRAKE_DEMAND(X_WG.size() == dynamic_objects_.size());
+    for (size_t i = 0; i < X_WG.size(); ++i) {
+      dynamic_objects_[i]->setTransform(convert(X_WG[i]));
+    }
+    dynamic_tree_.update();
+  }
+
+  // Implementation of ShapeReifier interface
+
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override {
+    // Note: Using `shared_ptr` because of FCL API requirements.
+    auto fcl_sphere = make_shared<fcl::Sphered>(sphere.get_radius());
+    TakeShapeOwnership(fcl_sphere, user_data);
+  }
+
+  void ImplementGeometry(const Cylinder& cylinder, void* user_data) override {
+    // Note: Using `shared_ptr` because of FCL API requirements.
+    auto fcl_cylinder = make_shared<fcl::Cylinderd>(cylinder.get_radius(),
+                                                    cylinder.get_length());
+    TakeShapeOwnership(fcl_cylinder, user_data);
+  }
+
+  void ImplementGeometry(const HalfSpace&,
+                         void* user_data) override {
+    // Note: Using `shared_ptr` because of FCL API requirements.
+    auto fcl_half_space = make_shared<fcl::Halfspaced>(0, 0, 1, 0);
+    TakeShapeOwnership(fcl_half_space, user_data);
+  }
+
+  // Testing utilities
+
+  bool IsDeepCopy(const Impl& other) const {
+    if (this != &other) {
+      // Function for validating that two objects are different objects with
+      // "identical" data. The test isn't exhaustive (for example, the
+      // parameters of the particular geometric shape are not compared--instead,
+      // we compare the AABBs).
+      auto ValidateObject = [](const fcl::CollisionObject<double>& test,
+                               const fcl::CollisionObject<double>& ref) {
+        return test.getUserData() == ref.getUserData() &&
+            &test != &ref &&
+            test.getNodeType() == ref.getNodeType() &&
+            test.getObjectType() == ref.getObjectType() &&
+            test.getAABB().center() == ref.getAABB().center() &&
+            test.getAABB().width(), ref.getAABB().width() &&
+            test.getAABB().height(), ref.getAABB().height() &&
+            test.getAABB().depth(), ref.getAABB().depth();
+      };
+      bool is_copy = true;
+      is_copy = is_copy &&
+          this->dynamic_objects_.size() == other.dynamic_objects_.size();
+      is_copy = is_copy &&
+          this->anchored_objects_.size() == other.anchored_objects_.size();
+      if (is_copy) {
+        for (size_t i = 0; i < this->dynamic_objects_.size(); ++i) {
+          const fcl::CollisionObject<double>& test_object =
+              *this->dynamic_objects_.at(i);
+          const fcl::CollisionObject<double>& ref_object =
+              *other.dynamic_objects_.at(i);
+          is_copy = is_copy && ValidateObject(test_object, ref_object);
+        }
+        for (size_t i = 0; i < this->anchored_objects_.size(); ++i) {
+          const fcl::CollisionObject<double>& test_object =
+              *this->anchored_objects_.at(i);
+          const fcl::CollisionObject<double>& ref_object =
+              *other.anchored_objects_.at(i);
+          is_copy = is_copy && ValidateObject(test_object, ref_object);
+        }
+      }
+      return is_copy;
+    }
+
+    return false;
+  }
+
+ private:
+  // Engine on one scalar can see the members of other engines.
+  friend class ProximityEngineTester;
+  template <typename> friend class ProximityEngine;
+
+  // TODO(SeanCurtis-TRI): Convert these to scalar type T when I know how to
+  // transmogrify them. Otherwise, while the engine can be transmogrified, the
+  // results on an <AutoDiffXd> type will still be double.
+
+  // Helper method called by the various ImplementGeometry overrides to
+  // facilitate the logistics of creating shapes from specifications. `data`
+  // is a unique_ptr of an fcl CollisionObject that should be instantiated
+  // with the given shape.
+  void TakeShapeOwnership(const std::shared_ptr<fcl::ShapeBased>& shape,
+                          void* data) {
+    DRAKE_ASSERT(data != nullptr);
+    std::unique_ptr<fcl::CollisionObject<double>>& fcl_object_ptr =
+        *reinterpret_cast<std::unique_ptr<fcl::CollisionObject<double>>*>(data);
+    fcl_object_ptr = make_unique<fcl::CollisionObject<double>>(shape);
+  }
+
+  // The BVH of all dynamic geometries; this depends on *all* inputs.
+  // TODO(SeanCurtis-TRI): Ultimately, this should probably be a cache entry.
+  fcl::DynamicAABBTreeCollisionManager<double> dynamic_tree_;
+
+  // All of the *dynamic* collision elements (spanning all sources). Their
+  // GeometryIndex maps to their position in *this* vector.
+  // TODO(SeanCurtis-TRI): Cluster the geometries on source such that each
+  // source owns a _contiguous_ block of engine indices.
+  std::vector<std::unique_ptr<fcl::CollisionObject<double>>> dynamic_objects_;
+
+  // The tree containing all of the anchored geometry.
+  fcl::DynamicAABBTreeCollisionManager<double> anchored_tree_;
+
+  // All of the *anchored* collision elements (spanning *all* sources). Their
+  // AnchoredGeometryIndex maps to their position in *this* vector.
+  std::vector<std::unique_ptr<fcl::CollisionObject<double>>> anchored_objects_;
+};
+
+template <typename T>
+ProximityEngine<T>::ProximityEngine() : impl_(new Impl()) {}
+
+template <typename T>
+ProximityEngine<T>::~ProximityEngine() { delete impl_; }
+
+template <typename T>
+ProximityEngine<T>::ProximityEngine(ProximityEngine<T>::Impl* impl)
+    : impl_(impl) {}
+
+template <typename T>
+ProximityEngine<T>::ProximityEngine(const ProximityEngine<T>& other)
+    : impl_(new ProximityEngine<T>::Impl(*other.impl_)) {}
+
+template <typename T>
+ProximityEngine<T>& ProximityEngine<T>::operator=(
+    const ProximityEngine<T>& other) {
+  if (impl_) delete impl_;
+  impl_ = new ProximityEngine<T>::Impl(*other.impl_);
+  return *this;
+}
+
+template <typename T>
+ProximityEngine<T>::ProximityEngine(ProximityEngine<T>&& other) noexcept
+    : impl_(std::move(other.impl_)) {
+  other.impl_ = new ProximityEngine<T>::Impl();
+}
+
+template <typename T>
+ProximityEngine<T>& ProximityEngine<T>::operator=(
+    ProximityEngine<T>&& other) noexcept {
+  if (impl_) delete impl_;
+  impl_ = std::move(other.impl_);
+  other.impl_ = new ProximityEngine<T>::Impl();
+  return *this;
+}
+
+template <typename T>
+GeometryIndex ProximityEngine<T>::AddDynamicGeometry(const Shape& shape) {
+  return impl_->AddDynamicGeometry(shape);
+}
+
+template <typename T>
+AnchoredGeometryIndex ProximityEngine<T>::AddAnchoredGeometry(
+    const Shape& shape, const Isometry3<double>& X_WG) {
+  return impl_->AddAnchoredGeometry(shape, X_WG);
+}
+
+template <typename T>
+int ProximityEngine<T>::num_geometries() const {
+  return impl_->num_geometries();
+}
+
+template <typename T>
+int ProximityEngine<T>::num_dynamic() const {
+  return impl_->num_dynamic();
+}
+
+template <typename T>
+int ProximityEngine<T>::num_anchored() const {
+  return impl_->num_anchored();
+}
+
+template <typename T>
+std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiff()
+    const {
+  return unique_ptr<ProximityEngine<AutoDiffXd>>(
+      new ProximityEngine<AutoDiffXd>(impl_->ToAutoDiff().release()));
+}
+
+template <typename T>
+void ProximityEngine<T>::UpdateWorldPoses(
+    const std::vector<Isometry3<T>>& X_WG) {
+  impl_->UpdateWorldPoses(X_WG);
+}
+// Testing utilities
+
+template <typename T>
+bool ProximityEngine<T>::IsDeepCopy(const ProximityEngine<T>& other) const {
+  return impl_->IsDeepCopy(*other.impl_);
+}
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::geometry::internal::ProximityEngine)

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/drake_optional.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_index.h"
+#include "drake/geometry/shape_specification.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T> class GeometryState;
+
+namespace internal {
+
+// TODO(SeanCurtis-TRI): Swap Isometry3 for the new Transform class.
+
+/** The underlying engine for performing geometric _proximity_ queries.
+ It owns the geometry instances and, once it has been provided with the poses
+ of the geometry, it provides geometric queries on that geometry.
+
+ Proximity queries span a range of types, including:
+
+   - penetration
+   - distance
+   - ray-intersection
+
+ @tparam T The scalar type. Must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+ - double
+ - AutoDiffXd
+
+ They are already available to link against in the containing library.
+ No other values for T are currently supported.
+
+ @internal Historically, this replaces the DrakeCollision::Model class.  */
+template <typename T>
+class ProximityEngine {
+ public:
+  ProximityEngine();
+  ~ProximityEngine();
+
+  /** Construct a deep copy of the provided `other` engine. */
+  ProximityEngine(const ProximityEngine& other);
+
+  /** Set `this` engine to be a deep copy of the `other` engine. */
+  ProximityEngine& operator=(const ProximityEngine& other);
+
+  /** Construct an engine by moving the data of a source engine. The source
+   engine will be returned to its default-initialized state. */
+  ProximityEngine(ProximityEngine&& other) noexcept;
+
+  /** Move assign a source engine to this engine. The source
+   engine will be returned to its default-initialized state. */
+  ProximityEngine& operator=(ProximityEngine&& other) noexcept;
+
+  /** Returns an independent copy of this engine templated on the AutoDiffXd
+   scalar type. If the engine is already an AutoDiffXd engine, it is equivalent
+   to using the copy constructor to create a duplicate on the heap. */
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ToAutoDiff() const;
+
+  /** @name Topology management */
+  //@{
+
+  /** Adds the given `shape` to the engine's dynamic geometry.  */
+  GeometryIndex AddDynamicGeometry(const Shape& shape);
+
+  /** Adds the given `shape` to the engine's anchored geometry at the fixed
+   pose given by `X_WG` (in the world frame W).  */
+  AnchoredGeometryIndex AddAnchoredGeometry(const Shape& shape,
+                                            const Isometry3<double>& X_WG);
+
+  /** Reports the _total_ number of geometries in the engine -- dynamic and
+   anchored (spanning all sources).  */
+  int num_geometries() const;
+
+  /** Reports the number of _dynamic_ geometries (spanning all sources). */
+  int num_dynamic() const;
+
+  /** Reports the number of _anchored_ geometries (spanning all sources). */
+  int num_anchored() const;
+
+  //@}
+
+  /** Updates the poses for all of the dynamic geometries in the engine. It
+   is an invariant that _every_ registered dynamic geometry, across _all_
+   geometry sources, has a _unique_ index that lies in the range
+   [0, num_dynamic() - 1]. Therefore, `X_WG` should have size equal to
+   num_dynamics() and any other length will cause program failure. The iᵗʰ entry
+   contains the pose for the geometry whose GeometryIndex value is `i`.
+   @param X_WG     The poses of each geometry `G` measured and expressed in the
+                   world frame `W`. */
+  // TODO(SeanCurtis-TRI): I could do things here differently a number of ways:
+  //  1. I could make this move semantics (or swap semantics).
+  //  2. I could simply have a method that returns a mutable reference to such
+  //    a vector and the caller sets values there directly.
+  void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG);
+
+ private:
+  ////////////////////////////////////////////////////////////////////////////
+
+  // Testing utilities:
+  // These functions facilitate *limited* introspection into the engine state.
+  // This enables unit tests to make assertions about pre- and post-operation
+  // state.
+
+  // Reports true if other is detectably a deep copy of this engine.
+  bool IsDeepCopy(const ProximityEngine<T>& other) const;
+
+  ////////////////////////////////////////////////////////////////////////////
+
+  // TODO(SeanCurtis-TRI): Pimpl + template implementation has proven
+  // problematic. This gets around it but it isn't a reliable long-term
+  // solution. Figure out how to make this work with unique_ptr or
+  // copyable unique_ptr
+  //
+  // The implementation details.
+  class Impl;
+  Impl* impl_{};
+
+  // Private constructor to use for scalar conversion.
+  explicit ProximityEngine(Impl* impl);
+
+  // Engine on one scalar can see the members of other engines.
+  template <typename> friend class ProximityEngine;
+
+  // Facilitate testing.
+  friend class ProximityEngineTester;
+};
+
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -1,0 +1,117 @@
+#include "drake/geometry/proximity_engine.h"
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+
+namespace drake {
+namespace geometry {
+namespace internal {
+
+class ProximityEngineTester {
+ public:
+  ProximityEngineTester() = delete;
+
+  template <typename T>
+  static bool IsDeepCopy(const ProximityEngine<T>& test_engine,
+                         const ProximityEngine<T>& ref_engine) {
+    return ref_engine.IsDeepCopy(test_engine);
+  }
+};
+
+namespace {
+
+using Eigen::Translation3d;
+using std::move;
+
+// Test simple addition of dynamic geometry.
+GTEST_TEST(ProximityEngineTests, AddDynamicGeometry) {
+  ProximityEngine<double> engine;
+  Sphere sphere{0.5};
+  GeometryIndex index = engine.AddDynamicGeometry(sphere);
+  EXPECT_EQ(index, 0);
+  EXPECT_EQ(engine.num_geometries(), 1);
+  EXPECT_EQ(engine.num_anchored(), 0);
+  EXPECT_EQ(engine.num_dynamic(), 1);
+}
+
+// Tests simple addition of anchored geometry.
+GTEST_TEST(ProximityEngineTests, AddAchoredGeometry) {
+  ProximityEngine<double> engine;
+  Sphere sphere{0.5};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex index = engine.AddAnchoredGeometry(sphere, pose);
+  EXPECT_EQ(index, 0);
+  EXPECT_EQ(engine.num_geometries(), 1);
+  EXPECT_EQ(engine.num_anchored(), 1);
+  EXPECT_EQ(engine.num_dynamic(), 0);
+}
+
+// Tests addition of both dynamic and anchored geometry.
+GTEST_TEST(ProximityEngineTests, AddMixedGeometry) {
+  ProximityEngine<double> engine;
+  Sphere sphere{0.5};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex a_index = engine.AddAnchoredGeometry(sphere, pose);
+  EXPECT_EQ(a_index, 0);
+  GeometryIndex g_index = engine.AddDynamicGeometry(sphere);
+  EXPECT_EQ(g_index, 0);
+  EXPECT_EQ(engine.num_geometries(), 2);
+  EXPECT_EQ(engine.num_anchored(), 1);
+  EXPECT_EQ(engine.num_dynamic(), 1);
+}
+
+// Tests the copy semantics of the ProximityEngine -- the copy is a complete,
+// deep copy.
+GTEST_TEST(ProximityEngineTests, CopySemantics) {
+  ProximityEngine<double> ref_engine;
+  Sphere sphere{0.5};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex a_index = ref_engine.AddAnchoredGeometry(sphere, pose);
+  EXPECT_EQ(a_index, 0);
+  GeometryIndex g_index = ref_engine.AddDynamicGeometry(sphere);
+  EXPECT_EQ(g_index, 0);
+
+  ProximityEngine<double> copy_construct(ref_engine);
+  ProximityEngineTester::IsDeepCopy(copy_construct, ref_engine);
+
+  ProximityEngine<double> copy_assign;
+  copy_assign = ref_engine;
+  ProximityEngineTester::IsDeepCopy(copy_assign, ref_engine);
+}
+
+// Tests the move semantics of the ProximityEngine -- the source is restored to
+// default state.
+GTEST_TEST(ProximityEngineTests, MoveSemantics) {
+  ProximityEngine<double> engine;
+  Sphere sphere{0.5};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex a_index = engine.AddAnchoredGeometry(sphere, pose);
+  EXPECT_EQ(a_index, 0);
+  GeometryIndex g_index = engine.AddDynamicGeometry(sphere);
+  EXPECT_EQ(g_index, 0);
+
+  ProximityEngine<double> move_construct(move(engine));
+  EXPECT_EQ(move_construct.num_geometries(), 2);
+  EXPECT_EQ(move_construct.num_anchored(), 1);
+  EXPECT_EQ(move_construct.num_dynamic(), 1);
+  EXPECT_EQ(engine.num_geometries(), 0);
+  EXPECT_EQ(engine.num_anchored(), 0);
+  EXPECT_EQ(engine.num_dynamic(), 0);
+
+  ProximityEngine<double> move_assign;
+  move_assign = move(move_construct);
+  EXPECT_EQ(move_assign.num_geometries(), 2);
+  EXPECT_EQ(move_assign.num_anchored(), 1);
+  EXPECT_EQ(move_assign.num_dynamic(), 1);
+  EXPECT_EQ(move_construct.num_geometries(), 0);
+  EXPECT_EQ(move_construct.num_anchored(), 0);
+  EXPECT_EQ(move_construct.num_dynamic(), 0);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace geometry
+}  // namespace drake


### PR DESCRIPTION
Defines the collision engine for geometry world. Implements the engine using FCL with a subset of
the shapes (sphere, cylinder, halfspace). 

This includes:
- copy & move semantics
- Autodiff compatibility and "conversion"
- Shape storage and update

Does *not* include:
- Penetration query
- Removal of geometry from engine
- Connection to GeometrySystem/State

The missing parts will be introduced in a further 2-3 PRs.

```
Category            added  modified  removed  
----------------------------------------------
code                377    0         0        
comments            107    0         0        
blank               95     0         0        
----------------------------------------------
TOTAL               579    0         0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7652)
<!-- Reviewable:end -->
