### PR TITLE
Re-enable dreal_solver_test

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -178,9 +178,9 @@ dpkg_install_from_wget \
 # https://github.com/dreal/dreal4/blob/master/README.md#build-debian-package for
 # build instructions.
 dpkg_install_from_wget \
-  dreal 4.17.12.2 \
-  https://dl.bintray.com/dreal/dreal/dreal_4.17.12.2_amd64.deb \
-  9347492e47a518ff78991e15fe9de0cff0200573091385e42940cdbf1fcf77a5
+  dreal 4.17.12.3 \
+  https://dl.bintray.com/dreal/dreal/dreal_4.17.12.3_amd64.deb \
+  72e878e2af14b1509b8d3a2943d7e7c824babfa755f4928cc3618e1fe85695c9
 
 # Remove deb that we used to generate and install, but no longer need.
 if [ -L /usr/lib/ccache/bazel ]; then

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -758,14 +758,22 @@ drake_cc_googletest(
     ],
 )
 
-# TODO(soonho-tri): Enable this test after checking lsan/tsan/asan results.
-#                   See https://github.com/RobotLocomotion/drake/pull/7647
-# drake_cc_googletest(
-#     name = "dreal_solver_test",
-#     deps = [
-#         ":dreal_solver",
-#     ],
-# )
+drake_cc_googletest(
+    name = "dreal_solver_test",
+    tags = [
+        # For most of floating-point operations, Valgrind only supports the
+        # IEEE default mode (round to nearest) while dReal uses to +infinity
+        # and to -infinity rounding modes intensively to maintain conservative
+        # interval approximations. This causes some of the assertions to fail
+        # in the test. So we disable memcheck for this test. See
+        # http://valgrind.org/docs/manual/manual-core.html#manual-core.limits
+        # for more information.
+        "no_memcheck",
+    ],
+    deps = [
+        ":dreal_solver",
+    ],
+)
 
 drake_cc_googletest(
     name = "gurobi_solver_test",


### PR DESCRIPTION
The first commit updates dReal to `4.17.12.3` which fixes the problem reported in #7647. The second commit re-enables `dreal_solver_test`.

To test this PR, please run the followings to make sure that we don't have errors from clang-sanitizers:

```bash
sudo ./setup/ubuntu/16.04/install_prereqs.sh
bazel test //solvers:dreal_solver_test --compilation_mode=dbg --compiler=gcc-5 --config=tsan
bazel test //solvers:dreal_solver_test --compilation_mode=dbg --compiler=gcc-5 --config=lsan
bazel test //solvers:dreal_solver_test --compilation_mode=dbg --config=asan
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7655)
<!-- Reviewable:end -->
