### PR TITLE
Removes value_or(999) hacks previously necessary for OS X builds to succeed.

### DIFF
--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -442,11 +442,9 @@ GTEST_TEST(SimulatorTest, MultipleWitnessesIdentical) {
     EXPECT_EQ(w1, w2);
 
     // Verify that they are triggering.
-    // NOTE: value_or(999) necessary to work around Mac OS X bug where value()
-    // function is declared but not defined.
     optional<double> iso_time = simulator->GetCurrentWitnessTimeIsolation();
     EXPECT_TRUE(iso_time);
-    EXPECT_LT(std::abs(w1), iso_time.value_or(999));
+    EXPECT_LT(std::abs(w1), iso_time.value());
 
     // Indicate that the method has been called.
     published = true;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -306,7 +306,7 @@ TEST_F(DiagramContextTest, Accuracy) {
   const double unity = 1.0;
   context_->set_accuracy(unity);
   std::unique_ptr<Context<double>> clone = context_->Clone();
-  EXPECT_EQ(clone->get_accuracy().value_or(999), unity);
+  EXPECT_EQ(clone->get_accuracy().value(), unity);
 }
 
 }  // namespace

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -419,7 +419,7 @@ TEST_F(LeafContextTest, Accuracy) {
   const double unity = 1.0;
   context_.set_accuracy(unity);
   std::unique_ptr<Context<double>> clone = context_.Clone();
-  EXPECT_EQ(clone->get_accuracy().value_or(999), unity);
+  EXPECT_EQ(clone->get_accuracy().value(), unity);
 }
 
 }  // namespace systems


### PR DESCRIPTION
Addresses issue #6277.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7661)
<!-- Reviewable:end -->
