### PR TITLE
Disable TSan for call_python_test

### DIFF
--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -111,12 +111,13 @@ sh_test(
     # reason, make the test run locally.
     local = 1,
     # TODO(eric.cousineau): The `call_python_test` binary is flaky with asan /
-    # lsan; however, when the binary fails, it simply aborts without
+    # lsan / tsan; however, when the binary fails, it simply aborts without
     # diagnostic information. When this is resolved, these tags should be
     # removed.
     tags = [
         "no_asan",
         "no_lsan",
+        "no_tsan",
     ],
 )
 

--- a/common/proto/test/call_python_full_test.sh
+++ b/common/proto/test/call_python_full_test.sh
@@ -84,12 +84,14 @@ py-check() {
     # executable itself).
     if [[ ${py_fail} -eq 0 ]]; then
         # Should succeed.
-        "$@" || py-error
+        if ! "$@"; then
+            py-error
+        fi
     else
         # Should fail.
-        # TODO(eric.cousineau): File / find bug in Bash for this; this behaves
-        # differently depending on how this is placed in a function.
-        { "$@" && should-fail; } || :
+        if "$@"; then
+            should-fail
+        fi
     fi
 }
 


### PR DESCRIPTION
Failing builds:
Nightly: [1](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-tsan/175/console), [2](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-memcheck-tsan-everything/171/console), [3](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-gcc-bazel-nightly-memcheck-tsan-snopt/149/)

Continuous: [1](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-memcheck-tsan-everything/619/console)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7664)
<!-- Reviewable:end -->
