### PR TITLE
[WIP] Enable caching in Drake.

### DIFF
--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
@@ -28,8 +28,6 @@ void QpOutputTranslatorSystem::CalcActuationTorques(
   // Output:
   auto out_vector = output->get_mutable_value();
 
-  // TODO(sherm1) This computation should be cached so it will be evaluated
-  // when first requested and then available for re-use.
   out_vector = robot_.B.transpose() * qp_output->dof_torques();
 
   DRAKE_ASSERT(out_vector.size() == robot_.get_num_actuators());

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
@@ -54,7 +54,6 @@ class QpOutputTranslatorSystem : public systems::LeafSystem<double> {
    * selection matrix that maps the actuator indices to the generalized
    * coordinate indices.
    */
-  // TODO(sherm1) This should be cached so it doesn't need to be recomputed.
   void CalcActuationTorques(const systems::Context<double>& context,
                             systems::BasicVector<double>* output) const;
 

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -327,15 +327,14 @@ drake_cc_library(
     srcs = ["leaf_context.cc"],
     hdrs = ["leaf_context.h"],
     deps = [
-        ":cache_and_dependency_tracker",
         ":context",
-        ":parameters",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
     ],
 )
 
+# TODO(sherm1) This should be "input_port".
 drake_cc_library(
     name = "input_port_descriptor",
     srcs = [
@@ -604,7 +603,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "cache_test",
     deps = [
-        ":cache_and_dependency_tracker",
         ":context_base",
         "//common:essential",
         "//systems/framework/test_utilities",

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -111,6 +111,9 @@ void ContextBase::SetFixedInputPortValue(
   detail::ContextBaseFixedInputAttorney::set_owning_subcontext(
       port_value.get(), this);
   input_port_values_[index] = std::move(port_value);
+
+  // Invalidate anyone who cares about this input port.
+  port_tracker.NoteValueChange(start_new_change_event());
 }
 
 // Set up trackers for independent sources: time, accuracy, state, parameters,

--- a/systems/framework/fixed_input_port_value.cc
+++ b/systems/framework/fixed_input_port_value.cc
@@ -1,10 +1,16 @@
 #include "drake/systems/framework/fixed_input_port_value.h"
 
+#include "drake/systems/framework/context_base.h"
+
 namespace drake {
 namespace systems {
 
 AbstractValue* FixedInputPortValue::GetMutableData() {
-  // TODO(sherm1) Change event tracking goes here.
+  DRAKE_DEMAND(owning_subcontext_ != nullptr);
+  ContextBase& context = *owning_subcontext_;
+  const DependencyTracker& tracker = context.get_tracker(ticket_);
+  const int64_t change_event = context.start_new_change_event();
+  tracker.NoteValueChange(change_event);
   ++serial_number_;
   return value_.get_mutable();
 }

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -16,11 +16,12 @@
 namespace drake {
 namespace systems {
 
-/// %LeafContext contains all prerequisite data necessary to uniquely determine
-/// the results of computations performed by the associated LeafSystem.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
+/** %LeafContext contains all prerequisite data necessary to uniquely determine
+the results of computations performed by the associated LeafSystem.
+@see Context for more information.
+
+@tparam T The mathematical type of the context, which must be a valid Eigen
+          scalar. */
 template <typename T>
 class LeafContext : public Context<T> {
  public:
@@ -35,16 +36,6 @@ class LeafContext : public Context<T> {
   LeafContext()
       : state_(std::make_unique<State<T>>()) {}
   ~LeafContext() override {}
-
-  const State<T>& get_state() const final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  State<T>& get_mutable_state() final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_.get();
-  }
 
 #ifndef DRAKE_DOXYGEN_CXX
   // Temporarily promoting these to public so that LeafSystem and testing code
@@ -90,8 +81,8 @@ class LeafContext : public Context<T> {
         xc_vector.Clone(), num_q, num_v, num_z));
 
     // Make deep copies of the discrete and abstract states.
-    clone->set_discrete_state(get_state().get_discrete_state().Clone());
-    clone->set_abstract_state(get_state().get_abstract_state().Clone());
+    clone->set_discrete_state(state_->get_discrete_state().Clone());
+    clone->set_abstract_state(state_->get_abstract_state().Clone());
 
     return clone;
   }
@@ -100,6 +91,16 @@ class LeafContext : public Context<T> {
   friend class LeafContextTest;
   using ContextBase::AddInputPort;    // For LeafContextTest.
   using ContextBase::AddOutputPort;
+
+  const State<T>& do_access_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  State<T>& do_access_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_.get();
+  }
 
   // The state values (x) for this LeafContext; this is never null.
   std::unique_ptr<State<T>> state_;

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -84,12 +84,7 @@ class LeafOutputPort final : public OutputPort<T> {
   }
 
   // Invokes the cache entry's Eval() function.
-  // TODO(sherm1) Caching is intentionally disabled here. Enable when
-  // invalidation wiring is connected up.
   const AbstractValue& DoEval(const Context<T>& context) const final {
-    CacheEntryValue& cache_value =
-        cache_entry().get_mutable_cache_entry_value(context);
-    cache_value.mark_out_of_date();  // Force re-evaluation.
     return cache_entry().EvalAbstract(context);
   }
 

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -80,9 +80,7 @@ class OutputPort : public OutputPortBase {
   already up to date with respect to its prerequisites, this port's Calc()
   method is used first to update the value before the reference is returned. The
   Calc() method may be arbitrarily expensive, but Eval() is constant time and
-  _very_ fast if the value is already up to date.
-  @warning Caching is currently disabled -- Calc() will be invoked. */
-  // TODO(sherm1) Remove the above warning asap. See LeafOutputPort::DoEval().
+  _very_ fast if the value is already up to date. */
   template <typename ValueType>
   const ValueType& Eval(const Context<T>& context) const {
     const AbstractValue& abstract_value = EvalAbstract(context);
@@ -126,9 +124,7 @@ class OutputPort : public OutputPortBase {
   /** Returns a reference to the value of this output port contained in the
   given Context. If that value is not up to date with respect to its
   prerequisites, the Calc() method above is used first to update the value
-  before the reference is returned.
-  @warning Caching is currently disabled -- Calc() will be invoked. */
-  // TODO(sherm1) Remove the above warning asap. See LeafOutputPort::DoEval().
+  before the reference is returned. */
   const AbstractValue& EvalAbstract(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(
         get_system_base().ThrowIfContextNotCompatible(context));

--- a/systems/framework/system_symbolic_inspector.h
+++ b/systems/framework/system_symbolic_inspector.h
@@ -113,7 +113,7 @@ class SystemSymbolicInspector {
   /// @param i The discrete state group number.
   Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
       int i) const {
-    DRAKE_DEMAND(i >= 0 && i < static_cast<int>(discrete_updates_->size()));
+    DRAKE_DEMAND(i >= 0 && i < context_->get_num_discrete_state_groups());
     return discrete_updates_->get_vector(i).get_value();
   }
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1034,6 +1034,25 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   EXPECT_EQ(1249, output_->get_vector_data(0)->get_value().x());
   EXPECT_EQ(2489, output_->get_vector_data(1)->get_value().x());
   EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
+
+  // Check that invalidation flows through input ports properly. We'll change
+  // the fixed input value for input port 0 from 8 to 10. That should cause
+  // everything to get recalculated.
+  // The outputs of subsystem0_ are now:
+  //   output0 = 10 + 64 + 512 = 586
+  //   output1 = output0 + 10 + 64 = 660
+  //   output2 = 9 (state of integrator1_)
+
+  // So, the outputs of subsystem1_, and thus of the whole diagram, are:
+  //   output0 = 586 + 660 + 9 = 1255
+  //   output1 = output0 + 586 + 660 = 2501
+  //   output2 = 81 (state of integrator1_)
+  auto value10 = BasicVector<double>::Make({10});
+  context_->FixInputPort(0, std::move(value10));
+  diagram_->CalcOutput(*context_, output_.get());
+  EXPECT_EQ(1255, output_->get_vector_data(0)->get_value().x());
+  EXPECT_EQ(2501, output_->get_vector_data(1)->get_value().x());
+  EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
 }
 
 TEST_F(DiagramOfDiagramsTest, DirectFeedthrough) {

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -59,6 +59,12 @@ class FixedInputPortTest : public ::testing::Test {
     free_tracker0_ = &context_.get_tracker(free_ticket0);
     free_tracker1_ = &context_.get_tracker(free_ticket1);
 
+    // Record the initial notification statistics so we can see if they
+    // change properly.
+    sent0_ = free_tracker0_->num_notifications_sent();
+    sent1_ = free_tracker1_->num_notifications_sent();
+    rcvd0_ = tracker0_->num_notifications_received();
+    rcvd1_ = tracker1_->num_notifications_received();
     serial0_ = port0_value_->serial_number();
     serial1_ = port1_value_->serial_number();
   }
@@ -73,6 +79,8 @@ class FixedInputPortTest : public ::testing::Test {
   const DependencyTracker* free_tracker0_{};
   const DependencyTracker* free_tracker1_{};
 
+  int64_t sent0_{-1}, sent1_{-1};
+  int64_t rcvd0_{-1}, rcvd1_{-1};
   int64_t serial0_{-1}, serial1_{-1};
 };
 
@@ -171,9 +179,13 @@ TEST_F(FixedInputPortTest, Clone) {
 TEST_F(FixedInputPortTest, Access) {
   EXPECT_EQ(Vector2<double>(5, 6),
             port0_value_->get_vector_value<double>().get_value());
+  EXPECT_EQ(free_tracker0_->num_notifications_sent(), sent0_);
+  EXPECT_EQ(tracker0_->num_notifications_received(), rcvd0_);
   EXPECT_EQ(port0_value_->serial_number(), serial0_);
 
   EXPECT_EQ("foo", port1_value_->get_value().GetValue<std::string>());
+  EXPECT_EQ(free_tracker1_->num_notifications_sent(), sent1_);
+  EXPECT_EQ(tracker1_->num_notifications_received(), rcvd1_);
   EXPECT_EQ(port1_value_->serial_number(), serial1_);
 }
 
@@ -187,7 +199,8 @@ TEST_F(FixedInputPortTest, Mutation) {
   EXPECT_EQ(Vector2<double>(7, 8),
             port0_value_->get_vector_value<double>().get_value());
   // Check that notifications were sent and serial number bumped.
-  // TODO(sherm1) Check notifications.
+  EXPECT_EQ(free_tracker0_->num_notifications_sent(), sent0_ + 1);
+  EXPECT_EQ(tracker0_->num_notifications_received(), rcvd0_ + 1);
   EXPECT_EQ(port0_value_->serial_number(), serial0_ + 1);
 
   // Change the abstract port's value.
@@ -195,7 +208,8 @@ TEST_F(FixedInputPortTest, Mutation) {
   // Check that the contents changed.
   EXPECT_EQ("bar", port1_value_->get_value().GetValue<std::string>());
   // Check that notifications were sent and serial number bumped.
-  // TODO(sherm1) Check notifications.
+  EXPECT_EQ(free_tracker1_->num_notifications_sent(), sent1_ + 1);
+  EXPECT_EQ(tracker1_->num_notifications_received(), rcvd1_ + 1);
   EXPECT_EQ(port1_value_->serial_number(), serial1_ + 1);
 }
 

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -36,9 +36,13 @@ class ConstantValueSourceTest : public ::testing::Test {
 TEST_F(ConstantValueSourceTest, Output) {
   ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
 
+  // Check Calc() method.
   source_->get_output_port(0).Calc(*context_, output_.get());
-
   EXPECT_EQ("foo", output_->GetValue<std::string>());
+
+  // Check Eval() method.
+  auto& cached_value = source_->get_output_port(0).Eval<std::string>(*context_);
+  EXPECT_EQ("foo", cached_value);
 }
 
 // Tests that ConstantValueSource allocates no state variables in the context_.

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -415,6 +415,7 @@ filegroup(
 
 drake_cc_googletest(
     name = "rgbd_camera_test",
+    srcs = ["test/rgbd_camera_test.cc"],
     data = [
         ":test_models",
     ],

--- a/systems/sensors/depth_sensor.cc
+++ b/systems/sensors/depth_sensor.cc
@@ -54,10 +54,11 @@ DepthSensor::DepthSensor(const std::string& name,
   }
   DRAKE_DEMAND(specification_.min_range() <= specification_.max_range() &&
                "min_range must be less than or equal to max_range");
-  input_port_index_ =
-      DeclareInputPort(kVectorValued,
-                       tree.get_num_positions() + tree.get_num_velocities())
-          .get_index();
+
+  const auto& input_port = DeclareInputPort(kVectorValued,
+                       tree.get_num_positions() + tree.get_num_velocities());
+  input_port_index_ = input_port.get_index();
+
   depth_output_port_index_ =
       DeclareVectorOutputPort(DepthSensorOutput<double>(specification_),
                               &DepthSensor::CalcDepthOutput)
@@ -66,7 +67,27 @@ DepthSensor::DepthSensor(const std::string& name,
       DeclareVectorOutputPort(PoseVector<double>(),
                               &DepthSensor::CalcPoseOutput)
           .get_index();
+
+  // Kinematics cache here depends only on the input port, specifically just
+  // the q's (but the port has v's also).
+  kinematics_cache_entry_ = &DeclareCacheEntry(
+      "kinematics cache", &DepthSensor::AllocateKinematicsCache,
+      &DepthSensor::CalcKinematics, {input_port.ticket()});
+
   PrecomputeRaycastEndpoints();
+}
+
+KinematicsCache<double> DepthSensor::AllocateKinematicsCache() const {
+  return tree_.CreateKinematicsCache();
+}
+
+void DepthSensor::CalcKinematics(
+    const Context<double>& context,
+    KinematicsCache<double>* kinematics_cache) const {
+  VectorXd u = this->EvalEigenVectorInput(context, input_port_index_);
+  auto q = u.head(tree_.get_num_positions());
+  kinematics_cache->initialize(q);
+  tree_.doKinematics(*kinematics_cache);
 }
 
 void DepthSensor::PrecomputeRaycastEndpoints() {
@@ -128,14 +149,11 @@ const OutputPort<double>& DepthSensor::get_pose_output_port() const {
   return System<double>::get_output_port(pose_output_port_index_);
 }
 
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcDepthOutput(
     const Context<double>& context,
     DepthSensorOutput<double>* data_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const int frame_index = frame_.get_frame_index();
 
@@ -187,13 +205,10 @@ void DepthSensor::ApplyLimits(VectorX<double>* distances) const {
 }
 
 // Evaluates the output port containing X_WS.
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcPoseOutput(const Context<double>& context,
                                  PoseVector<double>* pose_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const drake::Isometry3<double> X_WS =
       tree_.CalcFramePoseInWorldFrame(kinematics_cache, frame_);

--- a/systems/sensors/depth_sensor.h
+++ b/systems/sensors/depth_sensor.h
@@ -166,6 +166,14 @@ class DepthSensor : public systems::LeafSystem<double> {
   void CalcPoseOutput(const Context<double>& context,
                       rendering::PoseVector<double>* pose_output) const;
 
+  // Allocator for our CacheEntry. Returns a KinematicsCache suitable for
+  // the RigidBodyTree we're using.
+  KinematicsCache<double> AllocateKinematicsCache() const;
+
+  // Calculator for the CacheEntry. Updates the KinematicsCache to reflect
+  // the current q's at the input port.
+  void CalcKinematics(const Context<double>& context,
+                      KinematicsCache<double>*) const;
 
   // The depth sensor will cast a ray with its start point at (0,0,0) in the
   // sensor's base frame (as defined by get_frame()). Its end, also in the
@@ -189,6 +197,7 @@ class DepthSensor : public systems::LeafSystem<double> {
   int input_port_index_{};
   int depth_output_port_index_{};
   int pose_output_port_index_{};
+  const CacheEntry* kinematics_cache_entry_{};
 
   // A cache of where a depth measurement ray endpoint would be if the maximum
   // range were achieved. This is cached to avoid repeated allocation and


### PR DESCRIPTION
This is the final PR for enabling operation of the Drake caching system, following on from #9067. This adds 
- notifications when Context source quantities are modified, so that dependent output port and cache entry computations are invalidated,
- cache entries for built-in computations involving power, energy, and time derivatives,
- modifications to depth_sensor as an example of using a cache entry to avoid recalculation of kinematics.

After this lands, output ports will be automatically cached with assumed dependencies on any source value changes (time, accuracy, parameters, states, input ports). This benefits any Systems that have output port "fan out" to multiple clients. In general, however, obtaining speedups requires using `Eval()` methods rather than `Calc()` methods, creating explicit cache entries, and specifying limited prerequisite tickets rather than the default "all sources".

I will add more unit tests but I think this is ready for design/feature review.

Resolves #4364.
```
Category            added  modified  removed  
----------------------------------------------
code                407    46        44       
comments            148    47        30       
blank               75     0         0        
----------------------------------------------
TOTAL               630    93        74       
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7668)
<!-- Reviewable:end -->
