### PR TITLE
Disable call_python_full_test due to multiple CI failures

### DIFF
--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -114,7 +114,10 @@ sh_test(
     # lsan; however, when the binary fails, it simply aborts without
     # diagnostic information. When this is resolved, these tags should be
     # removed.
+    # TODO(jamiesnape): Tagged "manual" because fails with latest Matplotlib
+    # (~2.1.1) on macOS (and possibly other platforms).
     tags = [
+        "manual",
         "no_asan",
         "no_lsan",
     ],


### PR DESCRIPTION
Disabling due to failures with very latest Matplotlib on all Mac builds and intermittent failures on Linux TSan jobs.

FYI @EricCousineau-TRI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7670)
<!-- Reviewable:end -->
