### PR TITLE
call_python: Ensure that the tests accommodate SIGPIPE failures on C++ side.

### DIFF
--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -110,17 +110,6 @@ sh_test(
     # Certain versions of Mac don't like this script using `ps`. For this
     # reason, make the test run locally.
     local = 1,
-    # TODO(eric.cousineau): The `call_python_test` binary is flaky with asan /
-    # lsan; however, when the binary fails, it simply aborts without
-    # diagnostic information. When this is resolved, these tags should be
-    # removed.
-    # TODO(jamiesnape): Tagged "manual" because fails with latest Matplotlib
-    # (~2.1.1) on macOS (and possibly other platforms).
-    tags = [
-        "manual",
-        "no_asan",
-        "no_lsan",
-    ],
 )
 
 drake_cc_googletest(


### PR DESCRIPTION
The failures on CI were most likely due to load -- the C++ server would die due to a SIGPIPE signal if the Python client exited before it was done. This is reproducible on both Mac and Ubuntu, but encountered more often on Mac due to resource limitations.
This should fix the issues addressed by #7670 and #7664.

\cc @jamiesnape @m-chaturvedi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7672)
<!-- Reviewable:end -->
