### PR TITLE
Detect dual infeasible for mosek.

### DIFF
--- a/multibody/inverse_kinematics_backend.cc
+++ b/multibody/inverse_kinematics_backend.cc
@@ -66,6 +66,9 @@ int GetIKSolverInfo(SolutionResult result) {
     case SolutionResult::kIterationLimit: {
       return 3;
     }
+    case SolutionResult::kDualInfeasible: {
+      return 100; // Not a real SNOPT error.
+    }
   }
 
   return -1;

--- a/multibody/inverse_kinematics_backend.cc
+++ b/multibody/inverse_kinematics_backend.cc
@@ -67,7 +67,7 @@ int GetIKSolverInfo(SolutionResult result) {
       return 3;
     }
     case SolutionResult::kDualInfeasible: {
-      return 100; // Not a real SNOPT error.
+      return 100;  // Not a real SNOPT error.
     }
   }
 

--- a/solvers/mathematical_program_solver_interface.h
+++ b/solvers/mathematical_program_solver_interface.h
@@ -11,13 +11,16 @@ namespace solvers {
 class MathematicalProgram;
 
 enum SolutionResult {
-  kSolutionFound = 0,
-  kInvalidInput = -1,
-  kInfeasibleConstraints = -2,
-  kUnbounded = -3,
-  kUnknownError = -4,
-  kInfeasible_Or_Unbounded = -5,
-  kIterationLimit = -6,
+  kSolutionFound = 0,           ///< Found the optimal solution.
+  kInvalidInput = -1,           ///< Invalid input.
+  kInfeasibleConstraints = -2,  ///< The primal is infeasible.
+  kUnbounded = -3,              ///< The primal is unbounded.
+  kUnknownError = -4,           ///< Unknown error.
+  kInfeasible_Or_Unbounded =
+      -5,                ///< The primal is either infeasible or unbounded.
+  kIterationLimit = -6,  ///< Reaches the iteration limits.
+  kDualInfeasible = -7,  ///< Dual problem is infeasible. In this case we cannot
+                         /// infer the status of the primal problem.
 };
 
 /// Interface used by implementations of individual solvers.

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -761,8 +761,10 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
           break;
         }
         case MSK_SOL_STA_DUAL_INFEAS_CER:
+        case MSK_SOL_STA_NEAR_DUAL_INFEAS_CER:
+          result = SolutionResult::kDualInfeasible;
+          break;
         case MSK_SOL_STA_PRIM_INFEAS_CER:
-        case MSK_SOL_STA_NEAR_DUAL_FEAS:
         case MSK_SOL_STA_NEAR_PRIM_INFEAS_CER: {
           result = SolutionResult::kInfeasibleConstraints;
           break;

--- a/solvers/test/linear_program_examples.cc
+++ b/solvers/test/linear_program_examples.cc
@@ -347,32 +347,32 @@ void LinearProgram3::CheckSolution(SolverType solver_type) const {
   ExpectSolutionCostAccurate(*prog(), cost_tol);
 }
 
-
 LinearProgramTest::LinearProgramTest() {
   auto cost_form = std::get<0>(GetParam());
   auto constraint_form = std::get<1>(GetParam());
   switch (std::get<2>(GetParam())) {
-    case LinearProblems::kLinearFeasibilityProgram : {
+    case LinearProblems::kLinearFeasibilityProgram: {
       prob_ = std::make_unique<LinearFeasibilityProgram>(constraint_form);
       break;
     }
-    case LinearProblems::kLinearProgram0 : {
+    case LinearProblems::kLinearProgram0: {
       prob_ = std::make_unique<LinearProgram0>(cost_form, constraint_form);
       break;
     }
-    case LinearProblems::kLinearProgram1 : {
+    case LinearProblems::kLinearProgram1: {
       prob_ = std::make_unique<LinearProgram1>(cost_form, constraint_form);
       break;
     }
-    case LinearProblems::kLinearProgram2 : {
+    case LinearProblems::kLinearProgram2: {
       prob_ = std::make_unique<LinearProgram2>(cost_form, constraint_form);
       break;
     }
-    case LinearProblems::kLinearProgram3 : {
+    case LinearProblems::kLinearProgram3: {
       prob_ = std::make_unique<LinearProgram3>(cost_form, constraint_form);
       break;
     }
-    default : throw std::runtime_error("Un-recognized linear problem.");
+    default:
+      throw std::runtime_error("Un-recognized linear problem.");
   }
 }
 
@@ -400,6 +400,15 @@ UnboundedLinearProgramTest0::UnboundedLinearProgramTest0()
   prog_->AddLinearConstraint(2 * x(0) + x(1) >= 4);
   prog_->AddLinearConstraint(x(0) >= 0);
   prog_->AddLinearConstraint(x(1) >= 2);
+}
+
+UnboundedLinearProgramTest1::UnboundedLinearProgramTest1()
+    : prog_(std::make_unique<MathematicalProgram>()) {
+  auto x = prog_->NewContinuousVariables<4>("x");
+  prog_->AddCost(x(0) + 2 * x(1) + 3 * x(2) + 2.5 * x(3) + 2);
+  prog_->AddLinearConstraint(x(0) + x(1) - x(2) + x(3) <= 3);
+  prog_->AddLinearConstraint(x(0) + 2 * x(1) - 2 * x(2) + 4 * x(3), 1, 3);
+  prog_->AddBoundingBoxConstraint(0, 1, VectorDecisionVariable<2>(x(0), x(2)));
 }
 }  // namespace test
 }  // namespace solvers

--- a/solvers/test/linear_program_examples.h
+++ b/solvers/test/linear_program_examples.h
@@ -186,6 +186,25 @@ class UnboundedLinearProgramTest0 : public ::testing::Test {
  protected:
   std::unique_ptr<MathematicalProgram> prog_;
 };
+
+/**
+ * An unbounded linear program.
+ * min x0 + 2*x1 + 3*x2 + 2.5*x3 + 2
+ * s.t x0 + x1 - x2 + x3 <= 3
+ *     1 <= x0 + 2 * x1 - 2 * x2 + 4 * x3 <= 3
+ *     0 <= x0, x2 <= 1
+ */
+class UnboundedLinearProgramTest1 : public ::testing::Test {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(UnboundedLinearProgramTest1)
+
+  UnboundedLinearProgramTest1();
+
+  ~UnboundedLinearProgramTest1() override {}
+
+ protected:
+  std::unique_ptr<MathematicalProgram> prog_;
+};
 }  // namespace test
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/mosek_solver_test.cc
+++ b/solvers/test/mosek_solver_test.cc
@@ -23,6 +23,24 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(linear_constraint_form()),
                        ::testing::ValuesIn(linear_problems())));
 
+TEST_F(UnboundedLinearProgramTest0, Test) {
+  MosekSolver solver;
+  if (solver.available()) {
+    const SolutionResult result = solver.Solve(*prog_);
+    // Mosek can only detect dual infeasibility, not primal unboundedness.
+    EXPECT_EQ(result, SolutionResult::kDualInfeasible);
+  }
+}
+
+TEST_F(UnboundedLinearProgramTest1, Test) {
+  MosekSolver solver;
+  if (solver.available()) {
+    const SolutionResult result = solver.Solve(*prog_);
+    // Mosek can only detect dual infeasibility, not primal unboundedness.
+    EXPECT_EQ(result, SolutionResult::kDualInfeasible);
+  }
+}
+
 TEST_P(QuadraticProgramTest, TestQP) {
   MosekSolver solver;
   prob()->RunProblem(&solver);


### PR DESCRIPTION
Mosek doesn't detect unbounded problem, instead it only detects dual infeasibility, which can mean that the primal is infeasibe/unbounded/has a solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7675)
<!-- Reviewable:end -->
