### PR TITLE
Declare yaml-cpp as a private dependency in drake.cps

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -103,7 +103,8 @@
       "Link-Requires": [
         "fmt:fmt",
         "SDFormat:sdformat",
-        "tinyobjloader:tinyobjloader"
+        "tinyobjloader:tinyobjloader",
+        "yaml-cpp:yaml-cpp"
       ],
       "Requires": [
         ":drake-lcmtypes-cpp",
@@ -119,8 +120,7 @@
         "protobuf:libprotobuf",
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",
-        "stx:stx",
-        "yaml-cpp:yaml-cpp"
+        "stx:stx"
       ]
     },
     "drake-common-text-logging-gflags": {


### PR DESCRIPTION
After #7453 no headers that use yaml-cpp are installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7676)
<!-- Reviewable:end -->
