### PR TITLE
Restrict fixed input ports to use the FixInputPort() API

### DIFF
--- a/automotive/maliput_railcar.h
+++ b/automotive/maliput_railcar.h
@@ -105,7 +105,7 @@ class MaliputRailcar : public systems::LeafSystem<T> {
   /// Sets `railcar_state` to contain the default state for MaliputRailcar.
   static void SetDefaultState(MaliputRailcarState<T>* railcar_state);
 
-  /// Returns a mutable pointer to the parameters in the given @p context.
+  /// Returns a mutable reference to the parameters in the given @p context.
   MaliputRailcarParams<T>& get_mutable_parameters(
       systems::Context<T>* context) const;
 

--- a/automotive/simple_car.cc
+++ b/automotive/simple_car.cc
@@ -48,11 +48,9 @@ const DrivingCommand<T>& get_input(const SimpleCar<T>* simple_car,
 // Obtain our parameters from a context.
 template <typename T>
 const SimpleCarParams<T>& get_params(const systems::Context<T>& context) {
-  const SimpleCarParams<T>* const params =
-      dynamic_cast<const SimpleCarParams<T>*>(
-          &context.get_numeric_parameter(0));
-  DRAKE_DEMAND(params);
-  return *params;
+  const SimpleCarParams<T>& params =
+      dynamic_cast<const SimpleCarParams<T>&>(context.get_numeric_parameter(0));
+  return params;
 }
 
 }  // namespace

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -26,11 +26,8 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgTrajectoryGeneratorTest) {
   lcmt_schunk_wsg_command initial_command{};
   initial_command.target_position_mm = 100;
   initial_command.force = 40;
-  std::unique_ptr<systems::FreestandingInputPortValue> input_command =
-      std::make_unique<systems::FreestandingInputPortValue>(
-          std::make_unique<systems::Value<lcmt_schunk_wsg_command>>(
-              initial_command));
-  context->SetInputPortValue(0, std::move(input_command));
+  context->FixInputPort(0,
+      systems::AbstractValue::Make<lcmt_schunk_wsg_command>(initial_command));
   context->FixInputPort(1, Eigen::VectorXd::Zero(1));
 
   // Step a little bit. We should be commanding a point on the

--- a/multibody/multibody_doxygen.h
+++ b/multibody/multibody_doxygen.h
@@ -234,7 +234,7 @@ When we speak of the "location" or "pose" of a body, we really mean the location
 of the body frame origin Bo or pose of the body frame B, respectively.
 Body properties such
 as inertia and geometry are given with respect to the body frame. We denote
-a body's center of mass point as @f$B_{cm}@f$ (`Bcm`); it's location on the body
+a body's center of mass point as @f$B_{cm}@f$ (`Bcm`); its location on the body
 is specified by a position vector from Bo to Bcm. For a rigid body, any frames
 attached to it are fixed with respect to the body frame. For a flexible body,
 deformations are measured with respect to the body frame.

--- a/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -477,10 +477,7 @@ GTEST_TEST(DrakeVisualizerTests, BasicTest) {
       tree->get_num_positions() + tree->get_num_velocities();
   auto input_data = make_unique<BasicVector<double>>(vector_size);
   input_data->set_value(Eigen::VectorXd::Zero(vector_size));
-
-  context->SetInputPortValue(
-      0, std::make_unique<systems::FreestandingInputPortValue>(
-             std::move(input_data)));
+  context->FixInputPort(0, std::move(input_data));
 
   // Publishes the `RigidBodyTree` visualization messages.
   PublishLoadRobotModelMessageHelper(dut, *context);

--- a/multibody/rigid_body_plant/test/frame_visualizer_test.cc
+++ b/multibody/rigid_body_plant/test/frame_visualizer_test.cc
@@ -46,9 +46,7 @@ GTEST_TEST(FrameVisualizerTests, TestMessageGeneration) {
   auto input_data = std::make_unique<systems::BasicVector<double>>(vector_size);
   VectorX<double> x = VectorX<double>::Zero(vector_size);
   input_data->set_value(x);
-  context->SetInputPortValue(
-      0, std::make_unique<systems::FreestandingInputPortValue>(
-             std::move(input_data)));
+  context->FixInputPort(0, std::move(input_data));
   dut.Publish(*context);
 
   KinematicsCache<double> cache = tree.CreateKinematicsCache();

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -206,46 +206,39 @@ class Context {
   // =========================================================================
   // Accessors and Mutators for Input.
 
-  /// Connects the input port at @p index to the value source @p port_value.
-  /// Disconnects whatever value source was previously there, and deregisters
-  /// it from the output port on which it depends.  In some Context
-  /// implementations, may require a recursive search through a tree of
-  /// subcontexts. Asserts if @p index is out of range.
-  virtual void SetInputPortValue(
-      int index, std::unique_ptr<InputPortValue> port_value) = 0;
-
   /// Returns the number of input ports.
   virtual int get_num_input_ports() const = 0;
 
   /// Connects the input port at @p index to a FreestandingInputPortValue with
-  /// the given vector @p value. Asserts if @p index is out of range.
-  void FixInputPort(int index, std::unique_ptr<BasicVector<T>> value) {
-    SetInputPortValue(
-        index, std::make_unique<FreestandingInputPortValue>(std::move(value)));
-  }
-
-  /// Connects the input port at @p index to a FreestandingInputPortValue with
   /// the given abstract @p value. Asserts if @p index is out of range.
-  void FixInputPort(int index, std::unique_ptr<AbstractValue> value) {
-    SetInputPortValue(
-        index, std::make_unique<FreestandingInputPortValue>(std::move(value)));
-  }
-
-  /// Connects the input port at @p index to a FreestandingInputPortValue with
-  /// the given vector @p value. Asserts if @p index is out of range.
   /// Returns a reference to the allocated FreestandingInputPortValue that will
   /// remain valid until this input port's value source is replaced or the
-  /// context is destroyed. You may use that reference to modify the input
+  /// %Context is destroyed. You may use that reference to modify the input
   /// port's value using the appropriate FreestandingInputPortValue method,
   /// which will ensure that invalidation notifications are delivered.
   FreestandingInputPortValue& FixInputPort(
+      int index, std::unique_ptr<AbstractValue> value) {
+    auto free_value_ptr =
+        std::make_unique<FreestandingInputPortValue>(std::move(value));
+    FreestandingInputPortValue& free_value = *free_value_ptr;
+    SetInputPortValue(index, std::move(free_value_ptr));
+    return free_value;
+  }
+
+  /// Connects the input port at @p index to a FreestandingInputPortValue with
+  /// the given vector @p vec. Otherwise same as above method.
+  FreestandingInputPortValue& FixInputPort(
+      int index, std::unique_ptr<BasicVector<T>> vec) {
+    return FixInputPort(
+        index, std::make_unique<Value<BasicVector<T>>>(std::move(vec)));
+  }
+
+  /// Same as above method but starts with an Eigen vector whose contents are
+  /// used to initialize a BasicVector in the FreestandingInputPortValue.
+  FreestandingInputPortValue& FixInputPort(
       int index, const Eigen::Ref<const VectorX<T>>& data) {
     auto vec = std::make_unique<BasicVector<T>>(data);
-    auto freestanding =
-        std::make_unique<FreestandingInputPortValue>(std::move(vec));
-    FreestandingInputPortValue& freestanding_ref = *freestanding;
-    SetInputPortValue(index, std::move(freestanding));
-    return freestanding_ref;
+    return FixInputPort(index, std::move(vec));
   }
 
   /// Evaluates and returns the value of the input port identified by
@@ -489,12 +482,24 @@ class Context {
   /// Asserts if @p index is out of range.
   virtual const InputPortValue* GetInputPortValue(int index) const = 0;
 
-  /// Returns the InputPortValue at the given @p index from the given
-  /// @p context. Returns nullptr if the given port has never been set with
-  /// SetInputPortValue(). Asserts if @p index is out of range.
+  /// Allows derived classes to invoke the protected method on subcontexts.
   static const InputPortValue* GetInputPortValue(const Context<T>& context,
                                                  int index) {
     return context.GetInputPortValue(index);
+  }
+
+  /// Connects the input port at @p index to the value source @p port_value.
+  /// Disconnects whatever value source was previously there, and deregisters
+  /// it from the output port on which it depends.  In some Context
+  /// implementations, may require a recursive search through a tree of
+  /// subcontexts. Asserts if @p index is out of range.
+  virtual void SetInputPortValue(
+      int index, std::unique_ptr<InputPortValue> port_value) = 0;
+
+  /// Allows derived classes to invoke the protected method on subcontexts.
+  static void SetInputPortValue(Context<T>* context, int index,
+                                std::unique_ptr<InputPortValue> port_value) {
+    context->SetInputPortValue(index, std::move(port_value));
   }
 
  private:

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -490,10 +490,10 @@ class Context {
   }
 
   /// Connects the input port at @p index to the value source @p port_value.
-  /// Disconnects whatever value source was previously there, and unregisters
+  /// Disconnects whatever value source was previously there, and de-registers
   /// it from the output port on which it depends.  In some Context
   /// implementations, may require a recursive search through a tree of
-  /// subcontexts. Aborts if @p index is out of range.
+  /// subcontexts. Implementations must abort if @p index is out of range.
   virtual void SetInputPortValue(
       int index, std::unique_ptr<InputPortValue> port_value) = 0;
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -210,12 +210,13 @@ class Context {
   virtual int get_num_input_ports() const = 0;
 
   /// Connects the input port at @p index to a FreestandingInputPortValue with
-  /// the given abstract @p value. Asserts if @p index is out of range.
-  /// Returns a reference to the allocated FreestandingInputPortValue that will
-  /// remain valid until this input port's value source is replaced or the
-  /// %Context is destroyed. You may use that reference to modify the input
-  /// port's value using the appropriate FreestandingInputPortValue method,
-  /// which will ensure that invalidation notifications are delivered.
+  /// the given abstract @p value. Aborts if @p index is out of range.
+  /// Returns a reference to the allocated FreestandingInputPortValue. The
+  /// reference will remain valid until this input port's value source is
+  /// replaced or the %Context is destroyed. You may use that reference to
+  /// modify the input port's value using the appropriate
+  /// FreestandingInputPortValue method, which will ensure that invalidation
+  /// notifications are delivered.
   FreestandingInputPortValue& FixInputPort(
       int index, std::unique_ptr<AbstractValue> value) {
     auto free_value_ptr =
@@ -489,10 +490,10 @@ class Context {
   }
 
   /// Connects the input port at @p index to the value source @p port_value.
-  /// Disconnects whatever value source was previously there, and deregisters
+  /// Disconnects whatever value source was previously there, and unregisters
   /// it from the output port on which it depends.  In some Context
   /// implementations, may require a recursive search through a tree of
-  /// subcontexts. Asserts if @p index is out of range.
+  /// subcontexts. Aborts if @p index is out of range.
   virtual void SetInputPortValue(
       int index, std::unique_ptr<InputPortValue> port_value) = 0;
 

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -365,8 +365,8 @@ class DiagramContext : public Context<T> {
   }
 
   void SetInputPortValue(int index,
-                         std::unique_ptr<InputPortValue> port) override {
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
+                         std::unique_ptr<InputPortValue> port) final {
+    DRAKE_DEMAND(index >= 0 && index < get_num_input_ports());
     const PortIdentifier& id = input_ids_[index];
     SystemIndex system_index = id.first;
     PortIndex port_index = id.second;

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -181,7 +181,8 @@ class DiagramContext : public Context<T> {
     // Construct and install the destination port.
     auto input_port =
         std::make_unique<DependentInputPortValue>(output_port_value);
-    dest_context.SetInputPortValue(dest_port_index, std::move(input_port));
+    Context<T>::SetInputPortValue(&dest_context, dest_port_index,
+                                  std::move(input_port));
 
     // Remember the graph structure. We need it in DoClone().
     dependency_graph_[dest] = src;
@@ -270,17 +271,6 @@ class DiagramContext : public Context<T> {
 
   int get_num_input_ports() const override {
     return static_cast<int>(input_ids_.size());
-  }
-
-  void SetInputPortValue(int index,
-                         std::unique_ptr<InputPortValue> port) override {
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
-    const PortIdentifier& id = input_ids_[index];
-    SystemIndex system_index = id.first;
-    PortIndex port_index = id.second;
-    GetMutableSubsystemContext(system_index)
-        .SetInputPortValue(port_index, std::move(port));
-    // TODO(david-german-tri): Set invalidation callbacks.
   }
 
   const State<T>& get_state() const final {
@@ -372,6 +362,16 @@ class DiagramContext : public Context<T> {
   int num_subsystems() const {
     DRAKE_ASSERT(contexts_.size() == outputs_.size());
     return static_cast<int>(contexts_.size());
+  }
+
+  void SetInputPortValue(int index,
+                         std::unique_ptr<InputPortValue> port) override {
+    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
+    const PortIdentifier& id = input_ids_[index];
+    SystemIndex system_index = id.first;
+    PortIndex port_index = id.second;
+    Context<T>::SetInputPortValue(&GetMutableSubsystemContext(system_index),
+                                  port_index, std::move(port));
   }
 
   std::vector<PortIdentifier> input_ids_;

--- a/systems/framework/input_port_value.h
+++ b/systems/framework/input_port_value.h
@@ -119,31 +119,9 @@ class FreestandingInputPortValue : public InputPortValue {
   // FreestandingInputPortValue objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreestandingInputPortValue)
 
-  /// Constructs a vector-valued %FreestandingInputPortValue.
-  /// Takes ownership of @p vec.
-  ///
-  /// @tparam T The type of the vector data. Must be a valid Eigen scalar.
-  /// @tparam V The type of @p vec itself. Must implement BasicVector<T>.
-  template <template <typename T> class V, typename T>
-  explicit FreestandingInputPortValue(std::unique_ptr<V<T>> vec)
-      : output_port_value_(std::move(vec)) {
-    output_port_value_.add_dependent(this);
-  }
-
   /// Constructs an abstract-valued %FreestandingInputPortValue from a value
-  /// of unknown type. Takes ownership of @p data.
+  /// of arbitrary type. Takes ownership of @p data.
   explicit FreestandingInputPortValue(std::unique_ptr<AbstractValue> data);
-
-  /// Constructs an abstract-valued %FreestandingInputPortValue from a value
-  /// of currently-known type. This will become a type-erased AbstractValue
-  /// here but a knowledgeable caller can recover the original typed object
-  /// using `dynamic_cast`. Takes ownership of @p data.
-  ///
-  /// @tparam T The type of the data.
-  template <typename T>
-  explicit FreestandingInputPortValue(std::unique_ptr<Value<T>> data)
-      : FreestandingInputPortValue(
-            std::unique_ptr<AbstractValue>(data.release())) {}
 
   ~FreestandingInputPortValue() override;
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -183,9 +183,8 @@ class LeafContext : public Context<T> {
 
  private:
   void SetInputPortValue(int index,
-                         std::unique_ptr<InputPortValue> port) override {
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
-    // TODO(david-german-tri): Set invalidation callbacks.
+                         std::unique_ptr<InputPortValue> port) final {
+    DRAKE_DEMAND(index >= 0 && index < get_num_input_ports());
     input_values_[index] = std::move(port);
   }
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -38,13 +38,6 @@ class LeafContext : public Context<T> {
         parameters_(std::make_unique<Parameters<T>>()) {}
   ~LeafContext() override {}
 
-  void SetInputPortValue(int index,
-                         std::unique_ptr<InputPortValue> port) override {
-    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
-    // TODO(david-german-tri): Set invalidation callbacks.
-    input_values_[index] = std::move(port);
-  }
-
   /// Removes all the input ports, and deregisters them from the output ports
   /// on which they depend.
   void ClearInputPorts() { input_values_.clear(); }
@@ -151,7 +144,7 @@ class LeafContext : public Context<T> {
         clone->input_values_.emplace_back(nullptr);
       } else {
         clone->input_values_.emplace_back(new FreestandingInputPortValue(
-            port->template get_vector_data<T>()->Clone()));
+            port->template get_abstract_data()->Clone()));
       }
     }
 
@@ -189,6 +182,13 @@ class LeafContext : public Context<T> {
   }
 
  private:
+  void SetInputPortValue(int index,
+                         std::unique_ptr<InputPortValue> port) override {
+    DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
+    // TODO(david-german-tri): Set invalidation callbacks.
+    input_values_[index] = std::move(port);
+  }
+
   // The external inputs to the System.
   std::vector<std::unique_ptr<InputPortValue>> input_values_;
 

--- a/systems/framework/test/input_port_value_test.cc
+++ b/systems/framework/test/input_port_value_test.cc
@@ -15,7 +15,8 @@ class FreestandingInputPortVectorTest : public ::testing::Test {
   void SetUp() override {
     std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(2));
     vec->get_mutable_value() << 5, 6;
-    port_value_.reset(new FreestandingInputPortValue(std::move(vec)));
+    port_value_.reset(new FreestandingInputPortValue(
+        std::make_unique<Value<BasicVector<double>>>(std::move(vec))));
     port_value_->set_invalidation_callback(
         std::bind(&FreestandingInputPortVectorTest::Invalidate, this));
   }

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -571,15 +571,13 @@ class SystemIOTest : public ::testing::Test {
     // make string input
     std::unique_ptr<Value<std::string>> str_input =
         std::make_unique<Value<std::string>>("input");
-    context_->SetInputPortValue(
-        0, std::make_unique<FreestandingInputPortValue>(std::move(str_input)));
+    context_->FixInputPort(0, std::move(str_input));
 
     // make vector input
     std::unique_ptr<BasicVector<double>> vec_input =
         std::make_unique<BasicVector<double>>(1);
     vec_input->SetAtIndex(0, 2);
-    context_->SetInputPortValue(
-        1, std::make_unique<FreestandingInputPortValue>(std::move(vec_input)));
+    context_->FixInputPort(1, std::move(vec_input));
   }
 
   ValueIOTestSystem<double> test_sys_;

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -138,9 +138,8 @@ GTEST_TEST(LcmPublisherSystemTest, SerializerTest) {
   const lcmt_drake_signal sample_data{
     2, { 1.0, 2.0, }, { "x", "y", }, 12345,
   };
-  context->SetInputPortValue(
-      kPortNumber, make_unique<FreestandingInputPortValue>(
-          make_unique<Value<lcmt_drake_signal>>(sample_data)));
+  context->FixInputPort(kPortNumber,
+                        make_unique<Value<lcmt_drake_signal>>(sample_data));
 
   // Verifies that a correct message is published.
   dut->Publish(*context.get());

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -226,9 +226,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   if (num_inputs > 0) {
     auto input_vector = std::make_unique<BasicVector<AutoDiffXd>>(num_inputs);
     input_vector->SetFromVector(std::get<1>(autodiff_args));
-    autodiff_context->SetInputPortValue(
-        0,
-        std::make_unique<FreestandingInputPortValue>(std::move(input_vector)));
+    autodiff_context->FixInputPort(0, std::move(input_vector));
   }
 
   Eigen::MatrixXd AB;

--- a/systems/trajectory_optimization/direct_collocation.cc
+++ b/systems/trajectory_optimization/direct_collocation.cc
@@ -50,10 +50,8 @@ class DirectCollocationConstraint : public solvers::Constraint {
 
     if (context.get_num_input_ports() > 0) {
       // Allocate the input port and keep an alias around.
-      input_port_value_ = new FreestandingInputPortValue(
-          system_->AllocateInputVector(system_->get_input_port(0)));
-      std::unique_ptr<InputPortValue> input_port_value(input_port_value_);
-      context_->SetInputPortValue(0, std::move(input_port_value));
+      input_port_value_ = &context_->FixInputPort(
+          0, system_->AllocateInputVector(system_->get_input_port(0)));
     }
   }
 
@@ -144,10 +142,8 @@ DirectCollocation::DirectCollocation(const System<double>* system,
 
   if (context_->get_num_input_ports() > 0) {
     // Allocate the input port and keep an alias around.
-    input_port_value_ = new FreestandingInputPortValue(
-        system->AllocateInputVector(system->get_input_port(0)));
-    std::unique_ptr<InputPortValue> input_port_value(input_port_value_);
-    context_->SetInputPortValue(0, std::move(input_port_value));
+    input_port_value_ = &context_->FixInputPort(
+        0, system_->AllocateInputVector(system_->get_input_port(0)));
   }
 
   // Add the dynamic constraints.

--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -252,10 +252,8 @@ void DirectTranscription::AddAutodiffDynamicConstraints(
 
   if (context_->get_num_input_ports() > 0) {
     // Allocate the input port and keep an alias around.
-    input_port_value_ = new FreestandingInputPortValue(
-        system_->AllocateInputVector(system_->get_input_port(0)));
-    std::unique_ptr<InputPortValue> input_port_value(input_port_value_);
-    context_->SetInputPortValue(0, std::move(input_port_value));
+    input_port_value_ = &context_->FixInputPort(
+        0, system_->AllocateInputVector(system_->get_input_port(0)));
   }
 
   // For N-1 timesteps, add a constraint which depends on the knot


### PR DESCRIPTION
This contains a few minor changes needed by the caching code (as seen in #7668). The main change here is to direct all fixed input port setting through the Context::FixInputPort API, and to hide the SetInputPortValue() method which was previously public. There are also a few minor cosmetic changes in a few files -- my goal is to chip away at the changed files in #7668 to attempt to carve it into reviewable chunks. The Python binding fixes are copied from @EricCousineau-TRI's magic in #7668.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7686)
<!-- Reviewable:end -->

  
  