### PR TITLE
MathematicalProgram reports optimal cost when the problem is infeasible or unbounded.

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -898,6 +898,21 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "nlopt_solver_test",
+    srcs = [
+        "test/nlopt_solver_test.cc",
+    ],
+    deps = [
+        ":linear_program_examples",
+        ":mathematical_program",
+        ":mathematical_program_test_util",
+        ":optimization_examples",
+        ":quadratic_program_examples",
+        "//drake/common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
     name = "non_convex_optimization_util_test",
     srcs = [
         "test/non_convex_optimization_util_test.cc",

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -247,12 +247,22 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
 
   prog.SetDecisionVariableValues(x);
   double optimal_cost{};
-  if (solver_result == SolutionResult::kSolutionFound) {
-    optimal_cost = 0.5 * x.dot(G * x) + c.dot(x) + constant_term;
-  } else if (solver_result == SolutionResult::kUnbounded) {
-    optimal_cost = -std::numeric_limits<double>::infinity();
-  } else {
-    optimal_cost = NAN;
+  switch (solver_result.value()) {
+    case SolutionResult::kSolutionFound: {
+      optimal_cost = 0.5 * x.dot(G * x) + c.dot(x) + constant_term;
+      break;
+                                         }
+    case SolutionResult::kUnbounded: {
+      optimal_cost = -std::numeric_limits<double>::infinity();
+      break;
+                                     }
+    case SolutionResult::kInfeasibleConstraints: {
+      optimal_cost = std::numeric_limits<double>::infinity();
+      break;
+    }
+    default: {
+               optimal_cost = NAN;
+             }
   }
   prog.SetOptimalCost(optimal_cost);
   prog.SetSolverId(id());

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -251,18 +251,18 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
     case SolutionResult::kSolutionFound: {
       optimal_cost = 0.5 * x.dot(G * x) + c.dot(x) + constant_term;
       break;
-                                         }
+    }
     case SolutionResult::kUnbounded: {
       optimal_cost = -std::numeric_limits<double>::infinity();
       break;
-                                     }
+    }
     case SolutionResult::kInfeasibleConstraints: {
       optimal_cost = std::numeric_limits<double>::infinity();
       break;
     }
     default: {
-               optimal_cost = NAN;
-             }
+      optimal_cost = NAN;
+    }
   }
   prog.SetOptimalCost(optimal_cost);
   prog.SetSolverId(id());

--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -253,11 +253,11 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
       break;
     }
     case SolutionResult::kUnbounded: {
-      optimal_cost = -std::numeric_limits<double>::infinity();
+      optimal_cost = MathematicalProgram::kUnboundedCost;
       break;
     }
     case SolutionResult::kInfeasibleConstraints: {
-      optimal_cost = std::numeric_limits<double>::infinity();
+      optimal_cost = MathematicalProgram::kGlobalInfeasibleCost;
       break;
     }
     default: {

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -779,12 +779,12 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
           break;
         }
         case GRB_UNBOUNDED: {
-          SetOptimalCost(-std::numeric_limits<double>::infinity());
+          prog.SetOptimalCost(-std::numeric_limits<double>::infinity());
           result = SolutionResult::kUnbounded;
           break;
         }
         case GRB_INFEASIBLE: {
-          SetOptimalCost(std::numeric_limits<double>::infinity());
+          prog.SetOptimalCost(std::numeric_limits<double>::infinity());
           result = SolutionResult::kInfeasibleConstraints;
           break;
         }

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -779,12 +779,12 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
           break;
         }
         case GRB_UNBOUNDED: {
-          prog.SetOptimalCost(-std::numeric_limits<double>::infinity());
+          prog.SetOptimalCost(MathematicalProgram::kUnboundedCost);
           result = SolutionResult::kUnbounded;
           break;
         }
         case GRB_INFEASIBLE: {
-          prog.SetOptimalCost(std::numeric_limits<double>::infinity());
+          prog.SetOptimalCost(MathematicalProgram::kGlobalInfeasibleCost);
           result = SolutionResult::kInfeasibleConstraints;
           break;
         }

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -779,10 +779,12 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
           break;
         }
         case GRB_UNBOUNDED: {
+          SetOptimalCost(-std::numeric_limits<double>::infinity());
           result = SolutionResult::kUnbounded;
           break;
         }
         case GRB_INFEASIBLE: {
+          SetOptimalCost(std::numeric_limits<double>::infinity());
           result = SolutionResult::kInfeasibleConstraints;
           break;
         }

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -399,7 +399,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
       }
       case Ipopt::DIVERGING_ITERATES: {
         result_ = SolutionResult::kUnbounded;
-        obj_value = -std::numeric_limits<double>::infinity();
+        obj_value = MathematicalProgram::kUnboundedCost;
         break;
       }
       case Ipopt::MAXITER_EXCEEDED: {

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -397,6 +397,11 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
         result_ = SolutionResult::kInfeasibleConstraints;
         break;
       }
+      case Ipopt::DIVERGING_ITERATES: {
+        result_ = SolutionResult::kUnbounded;
+        obj_value = -std::numeric_limits<double>::infinity();
+        break;
+      }
       case Ipopt::MAXITER_EXCEEDED: {
         result_ = SolutionResult::kIterationLimit;
         drake::log()->warn(

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -1,6 +1,7 @@
 #include "drake/solvers/linear_system_solver.h"
 
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -56,7 +56,7 @@ SolutionResult LinearSystemSolver::Solve(MathematicalProgram& prog) const {
     prog.SetOptimalCost(0.);
     return SolutionResult::kSolutionFound;
   } else {
-    prog.SetOptimalCost(std::numeric_limits<double>::infinity());
+    prog.SetOptimalCost(MathematicalProgram::kGlobalInfeasibleCost);
     return SolutionResult::kInfeasibleConstraints;
   }
 }

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -49,12 +49,13 @@ SolutionResult LinearSystemSolver::Solve(MathematicalProgram& prog) const {
   const Eigen::VectorXd least_square_sol =
       Aeq.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(beq);
   prog.SetDecisionVariableValues(least_square_sol);
-  prog.SetOptimalCost(0.);
 
   prog.SetSolverId(id());
   if (beq.isApprox(Aeq * least_square_sol)) {
+    prog.SetOptimalCost(0.);
     return SolutionResult::kSolutionFound;
   } else {
+    prog.SetOptimalCost(std::numeric_limits<double>::infinity());
     return SolutionResult::kInfeasibleConstraints;
   }
 }

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -112,8 +112,8 @@ enum {
 // to int so it is odr-used (see
 // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
 
-constexpr double MathematicalProgram::kGlobalInfeasibleCost; 
-constexpr double MathematicalProgram::kUnboundedCost; 
+constexpr double MathematicalProgram::kGlobalInfeasibleCost;
+constexpr double MathematicalProgram::kUnboundedCost;
 
 MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -112,10 +112,8 @@ enum {
 // to int so it is odr-used (see
 // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
 
-const double MathematicalProgram::kGlobalInfeasibleCost =
-    std::numeric_limits<double>::infinity();
-const double MathematicalProgram::kUnboundedCost =
-    -std::numeric_limits<double>::infinity();
+constexpr double MathematicalProgram::kGlobalInfeasibleCost; 
+constexpr double MathematicalProgram::kUnboundedCost; 
 
 MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -112,6 +112,11 @@ enum {
 // to int so it is odr-used (see
 // https://gcc.gnu.org/wiki/VerboseDiagnostics#missing_static_const_definition)
 
+const double MathematicalProgram::kGlobalInfeasibleCost =
+    std::numeric_limits<double>::infinity();
+const double MathematicalProgram::kUnboundedCost =
+    -std::numeric_limits<double>::infinity();
+
 MathematicalProgram::MathematicalProgram()
     : x_initial_guess_(
           static_cast<Eigen::Index>(INITIAL_VARIABLE_ALLOCATION_NUM)),
@@ -379,7 +384,7 @@ Binding<LinearConstraint> MathematicalProgram::AddConstraint(
     // TODO(eric.cousineau): This is a good assertion... But seems out of place,
     // possibly redundant w.r.t. the binding infrastructure.
     DRAKE_ASSERT(binding.constraint()->A().cols() ==
-        static_cast<int>(binding.GetNumElements()));
+                 static_cast<int>(binding.GetNumElements()));
     CheckBinding(binding);
     required_capabilities_ |= kLinearConstraint;
     linear_constraints_.push_back(binding);
@@ -398,7 +403,7 @@ Binding<LinearConstraint> MathematicalProgram::AddLinearConstraint(
 Binding<LinearEqualityConstraint> MathematicalProgram::AddConstraint(
     const Binding<LinearEqualityConstraint>& binding) {
   DRAKE_ASSERT(binding.constraint()->A().cols() ==
-      static_cast<int>(binding.GetNumElements()));
+               static_cast<int>(binding.GetNumElements()));
   CheckBinding(binding);
   required_capabilities_ |= kLinearEqualityConstraint;
   linear_equality_constraints_.push_back(binding);
@@ -433,7 +438,7 @@ Binding<BoundingBoxConstraint> MathematicalProgram::AddConstraint(
     const Binding<BoundingBoxConstraint>& binding) {
   CheckBinding(binding);
   DRAKE_ASSERT(binding.constraint()->num_constraints() ==
-      binding.GetNumElements());
+               binding.GetNumElements());
   required_capabilities_ |= kLinearConstraint;
   bbox_constraints_.push_back(binding);
   return bbox_constraints_.back();
@@ -582,7 +587,7 @@ Binding<LinearMatrixInequalityConstraint> MathematicalProgram::AddConstraint(
     const Binding<LinearMatrixInequalityConstraint>& binding) {
   CheckBinding(binding);
   DRAKE_ASSERT(static_cast<int>(binding.constraint()->F().size()) ==
-      static_cast<int>(binding.GetNumElements()) + 1);
+               static_cast<int>(binding.GetNumElements()) + 1);
   required_capabilities_ |= kPositiveSemidefiniteConstraint;
   linear_matrix_inequality_constraint_.push_back(binding);
   return linear_matrix_inequality_constraint_.back();
@@ -662,7 +667,7 @@ SolutionResult MathematicalProgram::Solve() {
              nlopt_solver_->available()) {
     return nlopt_solver_->Solve(*this);
   } else if (is_satisfied(required_capabilities_, kScsCapabilities) &&
-      scs_solver_->available()) {
+             scs_solver_->available()) {
     // Use SCS as the last resort. SCS uses ADMM method, which converges fast to
     // modest accuracy quite fast, but then slows down significantly if the user
     // wants high accuracy.

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -290,6 +290,11 @@ class MathematicalProgram {
 
   using VarType = symbolic::Variable::Type;
 
+  /// The optimal cost is +∞ when the problem is globally infeasible.
+  static const double kGlobalInfeasibleCost;
+  /// The optimal cost is -∞ when the problem is unbounded.
+  static const double kUnboundedCost;
+
   MathematicalProgram();
   virtual ~MathematicalProgram() {}
 
@@ -355,8 +360,8 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols>
-  NewContinuousVariables(int rows, int cols, const std::string& name) {
+  MatrixDecisionVariable<Rows, Cols> NewContinuousVariables(
+      int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =
@@ -425,8 +430,8 @@ class MathematicalProgram {
    * readability.
    */
   template <int Rows = Eigen::Dynamic, int Cols = Eigen::Dynamic>
-  MatrixDecisionVariable<Rows, Cols>
-  NewBinaryVariables(int rows, int cols, const std::string& name) {
+  MatrixDecisionVariable<Rows, Cols> NewBinaryVariables(
+      int rows, int cols, const std::string& name) {
     rows = Rows == Eigen::Dynamic ? rows : Rows;
     cols = Cols == Eigen::Dynamic ? cols : Cols;
     auto names =
@@ -1993,11 +1998,13 @@ class MathematicalProgram {
   optional<SolverId> GetSolverId() const { return solver_id_; }
 
   /**
-   * Getter for optimal cost at the solution. 
-   * If the solver finds an optimal solution, then we return the cost evaluated at this solution.
+   * Getter for optimal cost at the solution.
+   * If the solver finds an optimal solution, then we return the cost evaluated
+   * at this solution.
    * If the program is unbounded, then the optimal cost is -∞.
-   * If the program is globally infeasible, then the optimal cost is +∞ 
-   * If the program is locally infeasible, and the solver (e.g. SNOPT) finds some values for the decision variables, such as the solution with least constraint violation, then return the cost evaluated at that solution.
+   * If the program is globally infeasible, then the optimal cost is +∞.
+   * If the program is locally infeasible, then the solver (e.g. SNOPT) might
+   * return some finite value as the optimal cost.
    * Otherwise, the optimal cost is NaN.
    */
   double GetOptimalCost() const { return optimal_cost_; }

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -291,9 +291,11 @@ class MathematicalProgram {
   using VarType = symbolic::Variable::Type;
 
   /// The optimal cost is +∞ when the problem is globally infeasible.
-  static const double kGlobalInfeasibleCost;
+  static constexpr double kGlobalInfeasibleCost =
+    std::numeric_limits<double>::infinity();
   /// The optimal cost is -∞ when the problem is unbounded.
-  static const double kUnboundedCost;
+  static constexpr double kUnboundedCost =
+    -std::numeric_limits<double>::infinity();
 
   MathematicalProgram();
   virtual ~MathematicalProgram() {}

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -1993,8 +1993,12 @@ class MathematicalProgram {
   optional<SolverId> GetSolverId() const { return solver_id_; }
 
   /**
-   * Getter for optimal cost at the solution. Will return NaN if there has
-   * been no successful solution.
+   * Getter for optimal cost at the solution. 
+   * If the solver finds an optimal solution, then we return the cost evaluated at this solution.
+   * If the program is unbounded, then the optimal cost is -∞.
+   * If the program is globally infeasible, then the optimal cost is +∞ 
+   * If the program is locally infeasible, and the solver (e.g. SNOPT) finds some values for the decision variables, such as the solution with least constraint violation, then return the cost evaluated at that solution.
+   * Otherwise, the optimal cost is NaN.
    */
   double GetOptimalCost() const { return optimal_cost_; }
 

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -294,6 +294,38 @@ void WrapConstraint(const MathematicalProgram& prog, const Binding<C>& binding,
   }
 }
 
+template <typename Binding>
+bool IsVectorOfConstraintsSatisfiedAtSolution(
+    const MathematicalProgram& prog, const std::vector<Binding>& bindings,
+    double tol) {
+  for (const auto& binding : bindings) {
+    const Eigen::VectorXd constraint_val = prog.EvalBindingAtSolution(binding);
+    const int num_constraint = constraint_val.rows();
+    if (((constraint_val - binding.constraint()->lower_bound()).array() <
+         -Eigen::ArrayXd::Constant(num_constraint, tol))
+            .any() ||
+        ((constraint_val - binding.constraint()->upper_bound()).array() >
+         Eigen::ArrayXd::Constant(num_constraint, tol))
+            .any()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Check if all the constraints are satisfied.
+ * @param all_constraints_satisfied [in/out] If not all constraints were satisfied before we check `bindings`, then bypass this check. Otherwise check if `bindings` are satisfied.
+ */
+template <typename Binding>
+void CheckConstraintsSatisfied(const MathematicalProgram& prog,
+                               const std::vector<Binding>& bindings, double tol,
+                               bool* all_constraints_satisfied) {
+  if (*all_constraints_satisfied) {
+    *all_constraints_satisfied &=
+        IsVectorOfConstraintsSatisfiedAtSolution(prog, bindings, tol);
+  }
+}
 }  // anonymous namespace
 
 bool NloptSolver::available() const { return true; }
@@ -378,27 +410,87 @@ SolutionResult NloptSolver::Solve(MathematicalProgram& prog) const {
   SolutionResult result = SolutionResult::kSolutionFound;
 
   double minf = 0;
+  const double kUnboundedTol = -1E30;
   try {
     const nlopt::result nlopt_result = opt.optimize(x, minf);
-    unused(nlopt_result);
+    if (nlopt_result == nlopt::SUCCESS ||
+        nlopt_result == nlopt::STOPVAL_REACHED ||
+        nlopt_result == nlopt::XTOL_REACHED ||
+        nlopt_result == nlopt::FTOL_REACHED ||
+        nlopt_result == nlopt::MAXEVAL_REACHED ||
+        nlopt_result == nlopt::MAXTIME_REACHED) {
+      Eigen::VectorXd sol(x.size());
+      for (int i = 0; i < nx; i++) {
+        sol(i) = x[i];
+      }
+      prog.SetDecisionVariableValues(sol);
+    }
+    switch (nlopt_result) {
+      case nlopt::SUCCESS:
+      case nlopt::STOPVAL_REACHED: {
+        result = SolutionResult::kSolutionFound;
+        break;
+      }
+      case nlopt::FTOL_REACHED:
+      case nlopt::XTOL_REACHED: {
+        // Now check if the constraints are violated.
+        // TODO(hongkai.dai) Allow the user to set this tolerance.
+        const double constraint_tol = 1E-6;
+        bool all_constraints_satisfied = true;
+        CheckConstraintsSatisfied(prog, prog.generic_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        CheckConstraintsSatisfied(prog, prog.bounding_box_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        CheckConstraintsSatisfied(prog, prog.linear_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        CheckConstraintsSatisfied(prog, prog.linear_equality_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        CheckConstraintsSatisfied(prog, prog.lorentz_cone_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        CheckConstraintsSatisfied(prog, prog.rotated_lorentz_cone_constraints(),
+                                  constraint_tol, &all_constraints_satisfied);
+        if (!all_constraints_satisfied) {
+          result = SolutionResult::kInfeasibleConstraints;
+        }
+        break;
+      }
+      case nlopt::MAXTIME_REACHED:
+      case nlopt::MAXEVAL_REACHED: {
+        result = SolutionResult::kIterationLimit;
+        break;
+      }
+      case nlopt::INVALID_ARGS: {
+        result = SolutionResult::kInvalidInput;
+        break;
+      }
+      case nlopt::ROUNDOFF_LIMITED: {
+        if (minf < kUnboundedTol) {
+          result = SolutionResult::kUnbounded;
+          minf = -std::numeric_limits<double>::infinity();
+          break;
+        }
+        result = SolutionResult::kUnknownError;
+        break;
+      }
+      default: { result = SolutionResult::kUnknownError; }
+    }
   } catch (std::invalid_argument&) {
     result = SolutionResult::kInvalidInput;
   } catch (std::bad_alloc&) {
     result = SolutionResult::kUnknownError;
   } catch (nlopt::roundoff_limited) {
-    result = SolutionResult::kUnknownError;
+    if (minf < kUnboundedTol) {
+      result = SolutionResult::kUnbounded;
+      minf = -std::numeric_limits<double>::infinity();
+    } else {
+      result = SolutionResult::kUnknownError;
+    }
   } catch (nlopt::forced_stop) {
     result = SolutionResult::kUnknownError;
-  } catch (std::runtime_error&) {
+  } catch (std::runtime_error) {
     result = SolutionResult::kUnknownError;
   }
 
-  Eigen::VectorXd sol(x.size());
-  for (int i = 0; i < nx; i++) {
-    sol(i) = x[i];
-  }
-
-  prog.SetDecisionVariableValues(sol);
   prog.SetOptimalCost(minf);
   prog.SetSolverId(id());
   return result;

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -650,11 +650,11 @@ SolutionResult ScsSolver::Solve(MathematicalProgram& prog) const {
   } else if (scs_status == SCS_UNBOUNDED ||
              scs_status == SCS_UNBOUNDED_INACCURATE) {
     sol_result = SolutionResult::kUnbounded;
-    prog.SetOptimalCost(-std::numeric_limits<double>::infinity());
+    prog.SetOptimalCost(MathematicalProgram::kUnboundedCost);
   } else if (scs_status == SCS_INFEASIBLE ||
              scs_status == SCS_INFEASIBLE_INACCURATE) {
     sol_result = SolutionResult::kInfeasibleConstraints;
-    prog.SetOptimalCost(std::numeric_limits<double>::infinity());
+    prog.SetOptimalCost(MathematicalProgram::kGlobalInfeasibleCost);
   }
   if (scs_status != SCS_SOLVED) {
     drake::log()->info("SCS returns code {}, with message \"{}\".\n",

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -650,9 +650,11 @@ SolutionResult ScsSolver::Solve(MathematicalProgram& prog) const {
   } else if (scs_status == SCS_UNBOUNDED ||
              scs_status == SCS_UNBOUNDED_INACCURATE) {
     sol_result = SolutionResult::kUnbounded;
+    prog.SetOptimalCost(-std::numeric_limits<double>::infinity());
   } else if (scs_status == SCS_INFEASIBLE ||
              scs_status == SCS_INFEASIBLE_INACCURATE) {
     sol_result = SolutionResult::kInfeasibleConstraints;
+    prog.SetOptimalCost(std::numeric_limits<double>::infinity());
   }
   if (scs_status != SCS_SOLVED) {
     drake::log()->info("SCS returns code {}, with message \"{}\".\n",

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -498,8 +498,7 @@ void UpdateLinearConstraint(const MathematicalProgram& prog,
            ++it) {
         tripletList->emplace_back(
             *linear_constraint_index + it.row(),
-            prog.FindDecisionVariableIndex(binding.variables()(k)),
-            it.value());
+            prog.FindDecisionVariableIndex(binding.variables()(k)), it.value());
       }
     }
 
@@ -728,6 +727,9 @@ SolutionResult SnoptSolver::Solve(MathematicalProgram& prog) const {
     drake::log()->debug("Snopt returns code {}\n", info);
     if (info >= 11 && info <= 16) {
       return SolutionResult::kInfeasibleConstraints;
+    } else if (info >= 20 && info <= 22) {
+      prog.SetOptimalCost(MathematicalProgram::kUnboundedCost);
+      return SolutionResult::kUnbounded;
     } else if (info == 91) {
       return SolutionResult::kInvalidInput;
     }

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -144,6 +144,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
+  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
 }
 
 GTEST_TEST(testEqualityConstrainedQPSolver, testUnboundedQP) {
@@ -156,6 +157,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testUnboundedQP) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
+  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
 }
 
 GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeDefiniteHessianQP) {
@@ -167,6 +169,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeDefiniteHessianQP) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
+  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
 }
 
 // Test a QP with positive definite Hessian, but infeasible constraint.
@@ -184,6 +187,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
+  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
 }
 
 // Test a QP with indefinite Hessian, but unique minimum.
@@ -199,6 +203,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testIndefiniteHessian) {
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_TRUE(CompareMatrices(prog.GetSolution(x), Eigen::Vector2d(0, 1), 1E-12,
                               MatrixCompareType::absolute));
+  EXPECT_NEAR(prog.GetOptimalCost(), -1, 1E-12);
 }
 
 // Test a QP with positive semidefinite Hessian, but unbounded objective.
@@ -212,6 +217,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testPSDhessianUnbounded) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
+  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
 }
 
 // Test a QP with negative definite Hessian, but with a unique optimum.
@@ -228,6 +234,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUniqueOptimum) {
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
   EXPECT_TRUE(CompareMatrices(prog.GetSolution(x), Eigen::Vector2d(2.5, -0.5),
                               1E-12, MatrixCompareType::absolute));
+  EXPECT_NEAR(prog.GetOptimalCost(), -6.5, 1E-12);
 }
 
 // Test a QP with negative definite Hessian, and an unbounded objective.
@@ -241,6 +248,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUnbounded) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
+  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
 }
 
 // Test a QP with positive semidefinite Hessian (not strictly positive
@@ -258,6 +266,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testPSDHessianUniqueOptimal) {
   EXPECT_TRUE(CompareMatrices(prog.GetSolution(x),
                               Eigen::Vector2d(-1.0 / 4, 5.0 / 8), 1E-12,
                               MatrixCompareType::absolute));
+  EXPECT_NEAR(prog.GetOptimalCost(), 23.0 / 16.0, 1E-12);
 }
 
 // Test a QP with indefinite Hessian and infeasible constraints
@@ -274,6 +283,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testIndefiniteHessianInfeasible) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
+  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
 }
 
 // Test changing the feasibility tolerance.
@@ -295,6 +305,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testFeasibilityTolerance) {
                        1E-7);
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
+  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
 
   // Now increase the feasibility tolerance.
   double tol = 1E-6;
@@ -307,6 +318,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testFeasibilityTolerance) {
                                   x_val(0) + x_val(1));
   EXPECT_TRUE(CompareMatrices(cnstr_val, Eigen::Vector3d(1, -2, 1E-6), tol,
                               MatrixCompareType::absolute));
+  EXPECT_NEAR(prog.GetOptimalCost(), 3, 1E-6);
 }
 
 // min x'*x + x0 + x1 + 1

--- a/solvers/test/equality_constrained_qp_solver_test.cc
+++ b/solvers/test/equality_constrained_qp_solver_test.cc
@@ -144,7 +144,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
-  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kUnboundedCost);
 }
 
 GTEST_TEST(testEqualityConstrainedQPSolver, testUnboundedQP) {
@@ -157,7 +157,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testUnboundedQP) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
-  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kUnboundedCost);
 }
 
 GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeDefiniteHessianQP) {
@@ -169,7 +169,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeDefiniteHessianQP) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
-  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kUnboundedCost);
 }
 
 // Test a QP with positive definite Hessian, but infeasible constraint.
@@ -187,7 +187,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver,
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
-  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kGlobalInfeasibleCost);
 }
 
 // Test a QP with indefinite Hessian, but unique minimum.
@@ -217,7 +217,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testPSDhessianUnbounded) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
-  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kUnboundedCost);
 }
 
 // Test a QP with negative definite Hessian, but with a unique optimum.
@@ -248,7 +248,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testNegativeHessianUnbounded) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kUnbounded);
-  EXPECT_EQ(prog.GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kUnboundedCost);
 }
 
 // Test a QP with positive semidefinite Hessian (not strictly positive
@@ -283,7 +283,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testIndefiniteHessianInfeasible) {
   EqualityConstrainedQPSolver equality_qp_solver;
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
-  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kGlobalInfeasibleCost);
 }
 
 // Test changing the feasibility tolerance.
@@ -305,7 +305,7 @@ GTEST_TEST(testEqualityConstrainedQPSolver, testFeasibilityTolerance) {
                        1E-7);
   auto result = equality_qp_solver.Solve(prog);
   EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
-  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kGlobalInfeasibleCost);
 
   // Now increase the feasibility tolerance.
   double tol = 1E-6;

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -35,7 +35,8 @@ TEST_F(InfeasibleLinearProgramTest0, TestGurobiInfeasible) {
     prog_->SetSolverOption(GurobiSolver::id(), "DualReductions", 0);
     result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
-    EXPECT_TRUE(std::isnan(prog_->GetOptimalCost()));
+    EXPECT_TRUE(std::isinf(prog_->GetOptimalCost()));
+    EXPECT_GE(prog_->GetOptimalCost(), 0);
   }
 }
 
@@ -50,6 +51,8 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     prog_->SetSolverOption(GurobiSolver::id(), "DualReductions", 0);
     result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kUnbounded);
+    EXPECT_TRUE(std::isinf(prog_->GetOptimalCost()));
+    EXPECT_LE(prog_->GetOptimalCost(), 0);
   }
 }
 

--- a/solvers/test/gurobi_solver_test.cc
+++ b/solvers/test/gurobi_solver_test.cc
@@ -51,8 +51,7 @@ TEST_F(UnboundedLinearProgramTest0, TestGurobiUnbounded) {
     prog_->SetSolverOption(GurobiSolver::id(), "DualReductions", 0);
     result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kUnbounded);
-    EXPECT_TRUE(std::isinf(prog_->GetOptimalCost()));
-    EXPECT_LE(prog_->GetOptimalCost(), 0);
+    EXPECT_EQ(prog_->GetOptimalCost(), MathematicalProgram::kUnboundedCost);
   }
 }
 

--- a/solvers/test/ipopt_solver_test.cc
+++ b/solvers/test/ipopt_solver_test.cc
@@ -22,6 +22,31 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(linear_constraint_form()),
                        ::testing::ValuesIn(linear_problems())));
 
+TEST_F(InfeasibleLinearProgramTest0, TestIpopt) {
+  prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
+  IpoptSolver solver;
+  if (solver.available()) {
+    const auto solver_result = solver.Solve(*prog_);
+    EXPECT_EQ(solver_result, SolutionResult::kInfeasibleConstraints);
+    const Eigen::Vector2d x_val =
+        prog_->GetSolution(prog_->decision_variables());
+    EXPECT_NEAR(prog_->GetOptimalCost(), -x_val(0) - x_val(1), 1E-7);
+  }
+}
+
+TEST_F(UnboundedLinearProgramTest0, TestIpopt) {
+  prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
+  prog_->SetSolverOption(IpoptSolver::id(), "diverging_iterates_tol", 1E3);
+  prog_->SetSolverOption(IpoptSolver::id(), "max_iter", 1000);
+  IpoptSolver solver;
+  if (solver.available()) {
+    const auto solver_result = solver.Solve(*prog_);
+    EXPECT_EQ(solver_result, SolutionResult::kUnbounded);
+    EXPECT_EQ(prog_->GetOptimalCost(),
+              -std::numeric_limits<double>::infinity());
+  }
+}
+
 TEST_P(QuadraticProgramTest, TestQP) {
   IpoptSolver solver;
   prob()->RunProblem(&solver);

--- a/solvers/test/linear_system_solver_test.cc
+++ b/solvers/test/linear_system_solver_test.cc
@@ -48,7 +48,7 @@ GTEST_TEST(testLinearSystemSolver, InfeasibleProblem) {
   Eigen::Vector2d x_expected(12.0 / 27, 21.0 / 27);
   EXPECT_TRUE(CompareMatrices(prog.GetSolution(x), x_expected, 1E-12,
                               MatrixCompareType::absolute));
-  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(prog.GetOptimalCost(), MathematicalProgram::kGlobalInfeasibleCost);
 }
 
 /**

--- a/solvers/test/linear_system_solver_test.cc
+++ b/solvers/test/linear_system_solver_test.cc
@@ -48,6 +48,7 @@ GTEST_TEST(testLinearSystemSolver, InfeasibleProblem) {
   Eigen::Vector2d x_expected(12.0 / 27, 21.0 / 27);
   EXPECT_TRUE(CompareMatrices(prog.GetSolution(x), x_expected, 1E-12,
                               MatrixCompareType::absolute));
+  EXPECT_EQ(prog.GetOptimalCost(), std::numeric_limits<double>::infinity());
 }
 
 /**

--- a/solvers/test/nlopt_solver_test.cc
+++ b/solvers/test/nlopt_solver_test.cc
@@ -1,0 +1,32 @@
+#include "drake/solvers/nlopt_solver.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/test/linear_program_examples.h"
+#include "drake/solvers/test/mathematical_program_test_util.h"
+#include "drake/solvers/test/quadratic_program_examples.h"
+
+namespace drake {
+namespace solvers {
+namespace test {
+TEST_F(UnboundedLinearProgramTest0, TestNlopt) {
+  prog_->SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
+  NloptSolver solver;
+  if (solver.available()) {
+    const auto solver_result = solver.Solve(*prog_);
+    EXPECT_EQ(solver_result, SolutionResult::kUnbounded);
+    EXPECT_EQ(prog_->GetOptimalCost(),
+              -std::numeric_limits<double>::infinity());
+  }
+}
+
+GTEST_TEST(QPtest, TestUnitBallExample) {
+  NloptSolver solver;
+  if (solver.available()) {
+    TestQPonUnitBallExample(solver);
+  }
+}
+}  // namespace test
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -151,6 +151,25 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(linear_constraint_form()),
                        ::testing::ValuesIn(linear_problems())));
 
+TEST_F(InfeasibleLinearProgramTest0, TestInfeasible) {
+  ScsSolver solver;
+  if (solver.available()) {
+    SolutionResult result = solver.Solve(*prog_);
+    EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
+    EXPECT_EQ(prog_->GetOptimalCost(), std::numeric_limits<double>::infinity());
+  }
+}
+
+TEST_F(UnboundedLinearProgramTest0, TestUnbounded) {
+  ScsSolver solver;
+  if (solver.available()) {
+    SolutionResult result = solver.Solve(*prog_);
+    EXPECT_EQ(result, SolutionResult::kUnbounded);
+    EXPECT_EQ(prog_->GetOptimalCost(),
+              -std::numeric_limits<double>::infinity());
+  }
+}
+
 TEST_P(TestEllipsoidsSeparation, TestSOCP) {
   ScsSolver scs_solver;
   if (scs_solver.available()) {

--- a/solvers/test/scs_solver_test.cc
+++ b/solvers/test/scs_solver_test.cc
@@ -156,7 +156,8 @@ TEST_F(InfeasibleLinearProgramTest0, TestInfeasible) {
   if (solver.available()) {
     SolutionResult result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kInfeasibleConstraints);
-    EXPECT_EQ(prog_->GetOptimalCost(), std::numeric_limits<double>::infinity());
+    EXPECT_EQ(prog_->GetOptimalCost(),
+              MathematicalProgram::kGlobalInfeasibleCost);
   }
 }
 
@@ -165,8 +166,7 @@ TEST_F(UnboundedLinearProgramTest0, TestUnbounded) {
   if (solver.available()) {
     SolutionResult result = solver.Solve(*prog_);
     EXPECT_EQ(result, SolutionResult::kUnbounded);
-    EXPECT_EQ(prog_->GetOptimalCost(),
-              -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(prog_->GetOptimalCost(), MathematicalProgram::kUnboundedCost);
   }
 }
 

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -16,6 +16,27 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
+TEST_F(InfeasibleLinearProgramTest0, TestSnopt) {
+  prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
+  SnoptSolver solver;
+  if (solver.available()) {
+    const auto solver_result = solver.Solve(*prog_);
+    EXPECT_EQ(solver_result, SolutionResult::kInfeasibleConstraints);
+    const Eigen::Vector2d x_val = prog_->GetSolution(prog_->decision_variables());
+    EXPECT_EQ(prog_->GetOptimalCost(), -x_val(0) - x_val(1));
+  }
+}
+
+TEST_F(UnboundedLinearProgramTest0, TestSnopt) {
+  prog_->SetInitialGuessForAllVariables(Eigen::Vector2d::Zero());
+  SnoptSolver solver;
+  if (solver.available()) {
+    const auto solver_result = solver.Solve(*prog_);
+    EXPECT_EQ(solver_result, SolutionResult::kUnbounded);
+    EXPECT_EQ(prog_->GetOptimalCost(), -std::numeric_limits<double>::infinity());
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(
     SnoptTest, LinearProgramTest,
     ::testing::Combine(::testing::ValuesIn(linear_cost_form()),

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -28,9 +28,6 @@ TEST_F(InfeasibleLinearProgramTest0, TestSnopt) {
   if (solver.available()) {
     const auto solver_result = solver.Solve(*prog_);
     EXPECT_EQ(solver_result, SolutionResult::kInfeasibleConstraints);
-    const Eigen::Vector2d x_val =
-        prog_->GetSolution(prog_->decision_variables());
-    EXPECT_EQ(prog_->GetOptimalCost(), -x_val(0) - x_val(1));
   }
 }
 

--- a/solvers/test/snopt_solver_test.cc
+++ b/solvers/test/snopt_solver_test.cc
@@ -16,13 +16,20 @@ TEST_P(LinearProgramTest, TestLP) {
   prob()->RunProblem(&solver);
 }
 
+INSTANTIATE_TEST_CASE_P(
+    SnoptTest, LinearProgramTest,
+    ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
+                       ::testing::ValuesIn(linear_constraint_form()),
+                       ::testing::ValuesIn(linear_problems())));
+
 TEST_F(InfeasibleLinearProgramTest0, TestSnopt) {
   prog_->SetInitialGuessForAllVariables(Eigen::Vector2d(1, 2));
   SnoptSolver solver;
   if (solver.available()) {
     const auto solver_result = solver.Solve(*prog_);
     EXPECT_EQ(solver_result, SolutionResult::kInfeasibleConstraints);
-    const Eigen::Vector2d x_val = prog_->GetSolution(prog_->decision_variables());
+    const Eigen::Vector2d x_val =
+        prog_->GetSolution(prog_->decision_variables());
     EXPECT_EQ(prog_->GetOptimalCost(), -x_val(0) - x_val(1));
   }
 }
@@ -33,15 +40,10 @@ TEST_F(UnboundedLinearProgramTest0, TestSnopt) {
   if (solver.available()) {
     const auto solver_result = solver.Solve(*prog_);
     EXPECT_EQ(solver_result, SolutionResult::kUnbounded);
-    EXPECT_EQ(prog_->GetOptimalCost(), -std::numeric_limits<double>::infinity());
+    EXPECT_EQ(prog_->GetOptimalCost(),
+              -std::numeric_limits<double>::infinity());
   }
 }
-
-INSTANTIATE_TEST_CASE_P(
-    SnoptTest, LinearProgramTest,
-    ::testing::Combine(::testing::ValuesIn(linear_cost_form()),
-                       ::testing::ValuesIn(linear_constraint_form()),
-                       ::testing::ValuesIn(linear_problems())));
 
 TEST_P(QuadraticProgramTest, TestQP) {
   SnoptSolver solver;


### PR DESCRIPTION
Solves two issues in this PR.

1. When the problem is unbounded, then the optimal cost should be negative infinity; when the problem is globally infeasible, then the optimal cost should be positive infinity.
2. Solves #7687 , now NLopt can detect infeasibility and unboundedness. Ipopt can detect unboundedness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7688)
<!-- Reviewable:end -->
