### PR TITLE
pybind: Add `get_pybind_package_info` for non-pybind Python libraries.

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -15,9 +15,13 @@ load(
     "//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_pybind_installs",
-    "get_pybind_library_dest",
+    "get_pybind_package_info",
 )
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
+load(
+    "//tools/skylark:6996.bzl",
+    "adjust_label_for_drake_hoist",
+    "adjust_labels_for_drake_hoist",
+)
 
 package(default_visibility = adjust_labels_for_drake_hoist([
     "//drake/bindings/pydrake:__subpackages__",
@@ -33,17 +37,24 @@ package(default_visibility = adjust_labels_for_drake_hoist([
 #   A C++ library for adding pybind-specific utilities to be consumed by C++.
 #   Files: `*_pybind.{h,cc}`
 
+# This determines how `PYTHONPATH` is configured, and how to install the
+# bindings.
+PACKAGE_INFO = get_pybind_package_info(
+    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
+)
+
 # This is a pure-python, standalone library.
 # Keep this away from `common_py` to simplify test dependencies.
 drake_py_library(
     name = "util_py",
     srcs = ["util.py"],
-    imports = [".."],
+    imports = PACKAGE_INFO.py_imports,
 )
 
 drake_pybind_library(
     name = "common_py",
     cc_srcs = ["common_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":util_py",
     ],
@@ -67,6 +78,7 @@ drake_pybind_library(
         ":autodiff_types_pybind",
     ],
     cc_srcs = ["autodiffutils_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":common_py",
     ],
@@ -82,6 +94,7 @@ drake_pybind_library(
         ":autodiff_types_pybind",
     ],
     cc_srcs = ["rbtree_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":autodiffutils_py",
         ":common_py",
@@ -94,6 +107,7 @@ drake_pybind_library(
     name = "parsers_py",
     cc_so_name = "parsers",
     cc_srcs = ["parsers_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":common_py",
     ],
@@ -111,6 +125,7 @@ drake_pybind_library(
         ":symbolic_types_pybind",
     ],
     cc_srcs = ["symbolic_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":common_py",
     ],
@@ -134,7 +149,7 @@ PY_LIBRARIES = [
 install(
     name = "install",
     targets = PY_LIBRARIES,
-    py_dest = get_pybind_library_dest(),
+    py_dest = PACKAGE_INFO.py_dest,
     visibility = ["//visibility:public"],
     deps = get_drake_pybind_installs(PYBIND_LIBRARIES),
 )
@@ -155,6 +170,7 @@ drake_pybind_library(
     ],
     cc_so_name = "test/odr_test_module",
     cc_srcs = ["test/odr_test_module_py.cc"],
+    package_info = PACKAGE_INFO,
 )
 
 drake_py_test(

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -8,22 +8,33 @@ load(
     "//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_pybind_installs",
-    "get_pybind_library_dest",
+    "get_pybind_package_info",
 )
 load(
     "//tools/skylark:drake_py.bzl",
     "drake_py_library",
     "drake_py_test",
 )
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
+load(
+    "//tools/skylark:6996.bzl",
+    "adjust_label_for_drake_hoist",
+    "adjust_labels_for_drake_hoist",
+)
 
 package(default_visibility = adjust_labels_for_drake_hoist([
     "//drake/bindings/pydrake:__subpackages__",
 ]))
 
+# This determines how `PYTHONPATH` is configured, and how to install the
+# bindings.
+PACKAGE_INFO = get_pybind_package_info(
+    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
+)
+
 drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
+    imports = PACKAGE_INFO.py_imports,
     deps = [
         "//drake/bindings/pydrake:common_py",
     ],
@@ -32,6 +43,7 @@ drake_py_library(
 drake_pybind_library(
     name = "ik_py",
     cc_srcs = ["ik_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         "//drake/bindings/pydrake:rbtree_py",
     ],
@@ -46,6 +58,7 @@ drake_pybind_library(
         "//drake/bindings/pydrake:symbolic_types_pybind",
     ],
     cc_srcs = ["mathematicalprogram_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         "//drake/bindings/pydrake:symbolic_py",
     ],
@@ -56,6 +69,7 @@ drake_pybind_library(
     name = "gurobi_py",
     cc_so_name = "gurobi",
     cc_srcs = ["gurobi_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
 )
 
@@ -63,6 +77,7 @@ drake_pybind_library(
     name = "ipopt_py",
     cc_so_name = "ipopt",
     cc_srcs = ["ipopt_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
 )
 
@@ -70,6 +85,7 @@ drake_pybind_library(
     name = "mosek_py",
     cc_so_name = "mosek",
     cc_srcs = ["mosek_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [":mathematicalprogram_py"],
 )
 
@@ -93,7 +109,7 @@ drake_py_library(
 install(
     name = "install",
     targets = PY_LIBRARIES,
-    py_dest = get_pybind_library_dest(),
+    py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_pybind_installs(PYBIND_LIBRARIES),
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "//tools/skylark:pybind.bzl",
     "drake_pybind_library",
     "get_drake_pybind_installs",
-    "get_pybind_library_dest",
+    "get_pybind_package_info",
 )
 load(
     "//tools/skylark:drake_py.bzl",
@@ -14,11 +14,21 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
+load(
+    "//tools/skylark:6996.bzl",
+    "adjust_label_for_drake_hoist",
+    "adjust_labels_for_drake_hoist",
+)
 
 package(default_visibility = adjust_labels_for_drake_hoist([
     "//drake/bindings/pydrake:__subpackages__",
 ]))
+
+# This determines how `PYTHONPATH` is configured, and how to install the
+# bindings.
+PACKAGE_INFO = get_pybind_package_info(
+    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
+)
 
 # @note Symbols are NOT imported directly into
 # `__init__.py` to simplify dependency management, meaning that
@@ -27,6 +37,7 @@ package(default_visibility = adjust_labels_for_drake_hoist([
 drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
+    imports = PACKAGE_INFO.py_imports,
     deps = [
         "//drake/bindings/pydrake:common_py",
     ],
@@ -36,6 +47,7 @@ drake_pybind_library(
     name = "framework_py",
     cc_so_name = "framework",
     cc_srcs = ["framework_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":module_py",
     ],
@@ -45,6 +57,7 @@ drake_pybind_library(
     name = "primitives_py",
     cc_so_name = "primitives",
     cc_srcs = ["primitives_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":framework_py",
         ":module_py",
@@ -55,6 +68,7 @@ drake_pybind_library(
     name = "analysis_py",
     cc_so_name = "analysis",
     cc_srcs = ["analysis_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":framework_py",
         ":module_py",
@@ -64,9 +78,8 @@ drake_pybind_library(
 drake_py_library(
     name = "drawing_py",
     srcs = ["drawing.py"],
+    imports = PACKAGE_INFO.py_imports,
     deps = [":module_py"],
-    # TODO(eric.cousineau): Expose information to allow `imports = ...` to be
-    # defined, rather than rely on `module_py`.
 )
 
 drake_py_library(
@@ -93,13 +106,14 @@ PY_LIBRARIES = [
 
 drake_py_library(
     name = "systems",
+    imports = PACKAGE_INFO.py_imports,
     deps = PYBIND_LIBRARIES + PY_LIBRARIES,
 )
 
 install(
     name = "install",
     targets = PY_LIBRARIES,
-    py_dest = get_pybind_library_dest(),
+    py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_pybind_installs(PYBIND_LIBRARIES),
 )
 
@@ -131,6 +145,7 @@ drake_pybind_library(
     add_install = False,
     cc_so_name = "test/lifetime_test_util",
     cc_srcs = ["test/lifetime_test_util_py.cc"],
+    package_info = PACKAGE_INFO,
     py_deps = [
         ":primitives_py",
     ],

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -14,13 +14,6 @@ load("//tools/skylark:6996.bzl", "adjust_label_for_drake_hoist")
 
 _PY_VERSION = "2.7"
 
-# This is the base package to determine which paths should be imported, and
-# where the Python components should be installed.
-#
-# TODO(jwnimmer-tri) Either make this path configurable, or else move this file
-# (pybind.bzl) back into the bindings folder directly.
-_BASE_PACKAGE = adjust_label_for_drake_hoist("//drake/bindings")[2:]
-
 # TODO(eric.cousineau): Consider making a `PybindProvider`, to sort
 # out dependencies, sources, etc, and simplify installation
 # dependencies.
@@ -74,6 +67,7 @@ def drake_pybind_library(
         cc_deps = [],
         copts = [],
         cc_so_name = None,
+        package_info = None,
         py_srcs = [],
         py_deps = [],
         py_imports = [],
@@ -86,19 +80,27 @@ def drake_pybind_library(
         C++ source files.
     @param cc_deps (optional)
         C++ dependencies.
-        At present, these should be header only, as they will violate ODR
-        with statically-linked libraries.
+        At present, these should be libraries that will not cause ODR
+        conflicts (generally, header-only).
     @param cc_so_name (optional)
         Shared object name. By default, this is `_${name}`, so that the C++
         code can be then imported in a more controlled fashion in Python.
         If overridden, this could be the public interface exposed to the user.
-    @param py_srcs
+    @param package_info
+        This should be the result of `get_pybind_package_info` called from the
+        current package. This dictates how `PYTHONPATH` is configured, and
+        where the modules will be installed.
+    @param py_srcs (optional)
         Python sources.
-    @param py_deps
+    @param py_deps (optional)
         Python dependencies.
-    @param py_imports
+    @param py_imports (optional)
         Additional Python import directories.
+    @param add_install (optional)
+        Add install targets.
     """
+    if package_info == None:
+        fail("`package_info` must be supplied.")
     py_name = name
     if not cc_so_name:
         cc_so_name = "_" + name
@@ -114,31 +116,26 @@ def drake_pybind_library(
         testonly = testonly,
         visibility = visibility,
     )
-    # Get current package's information.
-    library_info = _get_child_library_info()
-    py_base_rel_path, py_library_install = (
-        library_info.rel_path, library_info.sub_package)
     # Add Python library.
     drake_py_library(
         name = py_name,
         data = [cc_so_name],
         srcs = py_srcs,
         deps = py_deps,
-        imports = [py_base_rel_path] + py_imports,
+        imports = package_info.py_imports + py_imports,
         testonly = testonly,
         visibility = visibility,
     )
     # Add installation target for C++ and C++ bits.
     if add_install:
-        py_dest = get_pybind_library_dest(py_library_install)
         install(
             name = install_name,
             targets = [
                 py_name,
                 cc_so_name,
             ],
-            py_dest = py_dest,
-            library_dest = py_dest,
+            py_dest = package_info.py_dest,
+            library_dest = package_info.py_dest,
             visibility = visibility,
         )
 
@@ -158,26 +155,45 @@ def _get_install(target):
         # Assume that the package has an ":install" target.
         return target + ":install"
 
-def get_pybind_library_dest(py_library_install = None):
-    """Gets Python installation destination for a given package."""
-    if py_library_install == None:
-        py_library_install = _get_child_library_info().sub_package
-    return "lib/python{}/site-packages/{}".format(_PY_VERSION,
-                                                  py_library_install)
+def get_pybind_package_info(base_package, sub_package = None):
+    """Gets a package's path relative to a base package, and the sub-package
+    name (for installation).
 
-def _get_child_library_info(package = None, base_package = _BASE_PACKAGE):
-    # Gets a package's path relative to a base package, and the sub-package
-    # name (for installation).
-    # @return struct(rel_path, sub_package)
-    if package == None:
-        package = native.package_name()
+    @param base_package
+        Base package, which should be on `PYTHONPATH`.
+    @param sub_package
+        Package of interest. If `None`, will resolve to the calling package.
+    @return struct(
+        py_imports,  # Directories to add to `PYTHONPATH` with `py_library`.
+        py_dest)  # Installation directory for use with `install()`.
+    """
+    # Use relative package path, as `py_library` does not like absolute package
+    # paths.
+    package_info = _get_package_info(base_package, sub_package)
+    return struct(
+        py_imports = [package_info.base_path_rel],
+        py_dest = "lib/python{}/site-packages/{}".format(
+            _PY_VERSION, package_info.sub_path_rel))
+
+def _get_package_info(base_package, sub_package = None):
+    # TODO(eric.cousineau): Move this to `python.bzl` or somewhere more
+    # general?
+    base_package = base_package.lstrip('//')
+    if sub_package == None:
+        sub_package = native.package_name()
+    else:
+        sub_package = sub_package.lstrip('//')
     base_package_pre = base_package + "/"
-    if not package.startswith(base_package_pre):
-        fail("Invalid package '{}' (not a child of '{}')"
-             .format(package, base_package))
-    sub_package = package[len(base_package_pre):]
+    if not sub_package.startswith(base_package_pre):
+        fail("Invalid sub_package '{}' (not a child of '{}')"
+             .format(sub_package, base_package))
+    sub_path_rel = sub_package[len(base_package_pre):]
     # Count the number of pieces.
-    num_pieces = len(sub_package.split("/"))
+    num_pieces = len(sub_path_rel.split("/"))
     # Make the number of parent directories.
-    rel_path = "/".join([".."] * num_pieces)
-    return struct(rel_path = rel_path, sub_package = sub_package)
+    base_path_rel = "/".join([".."] * num_pieces)
+    return struct(
+        # Base package's path relative to sub-package's path.
+        base_path_rel = base_path_rel,
+        # Sub-package's path relative to base package's path.
+        sub_path_rel = sub_path_rel)


### PR DESCRIPTION
This generalizes `pybind.bzl` logic, while still being convenient for `pydrake` (given that `drake`-specific logic is still present in the file).

The purpose of this is to address Jeremy's TODO, and make it more convenient to add Python-only libraries, which before this PR did not readily have access to both the base package path and installation path in the same structure (even though this information is tightly coupled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7690)
<!-- Reviewable:end -->

  