### PR TITLE
Work around issue with FindBoost in CMake 3.5

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -139,6 +139,7 @@
     "drake_RESOURCE_ROOT": "${CMAKE_CURRENT_LIST_DIR}/../../../share/drake"
   },
   "X-CMake-Variables-Init": {
+    "_Boost_IMPORTED_TARGETS": 1,
     "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR}/modules;${CMAKE_MODULE_PATH}"
   }
 }


### PR DESCRIPTION
Imported target Boost::boost is not created when no components are specified. Fixed by Kitware/CMake@2c1b720.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7692)
<!-- Reviewable:end -->
