### PR TITLE
Fix and/or cleanup install scripts

### DIFF
--- a/setup/mac/install_prereqs.sh
+++ b/setup/mac/install_prereqs.sh
@@ -23,7 +23,7 @@ if [[ ! -f /usr/include/expat.h || ! -f /usr/include/zlib.h ]]; then
   exit 3
 fi
 
-brew tap homebrew/science
+brew tap dreal/dreal
 brew tap robotlocomotion/director
 
 brew update
@@ -41,7 +41,7 @@ clang-format
 cmake
 diffstat
 doxygen
-dreal/dreal/dreal
+dreal
 gflags
 glew
 glib

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -48,7 +48,6 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 bash-completion
 binutils
 bison
-chrpath
 clang-4.0
 clang-format-4.0
 cmake
@@ -98,7 +97,6 @@ libxt-dev
 libyaml-cpp-dev
 lldb-4.0
 make
-mesa-common-dev
 openjdk-8-jdk
 patchelf
 patchutils


### PR DESCRIPTION
`chrpath` is no longer used, `mesa-common-dev` is an implicit dependency and explicitly installing can cause conflicts (especially on CI, see current failures), `homebrew/science` is gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7696)
<!-- Reviewable:end -->
