### PR TITLE
Calling `getDrakePath()` multiple times on Linux was failing

### DIFF
--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -26,9 +26,12 @@ class TestCommonInstall(unittest.TestCase):
         # system would result in a crash since pydrake was built against
         # brew python. On Linux this will still work and force using
         # python2 which should be a link to the actual executable.
+        # Calling `pydrake.getDrakePath()` twice verifies that there
+        # is no memory allocation issue in the C code.
         output_path = subprocess.check_output(
             ["python2",
-             "-c", "import pydrake; print(pydrake.getDrakePath())"
+             "-c", "import pydrake; print(pydrake.getDrakePath());\
+             import pydrake; print(pydrake.getDrakePath())"
              ],
             env=tool_env,
             ).strip()


### PR DESCRIPTION
When calling `getDrakePath()` on Linux, the functions `basename()`
and `dirname()` from <libgen.h>. These function can, and did, modify
the content of the C-string that was passed to them. This was creating
issues the second time the function `getDrakePath()` was called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7711)
<!-- Reviewable:end -->
