### PR TITLE
[WIP] Create `unique_ptr_tracked` to opt-in for REPL-friendly destruction behvaior

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -267,9 +267,9 @@ github_archive(
 
 github_archive(
     name = "pybind11",
-    repository = "RobotLocomotion/pybind11",
-    commit = "48999b69bde29cdf8d616d4fbd3d6ab1c561027d",
-    sha256 = "2ea18adfb608948cab1b5978081dc8c318ed47573ccd66f1603a37fbdbfc56da",  # noqa
+    repository = "EricCousineau-TRI/pybind11",
+    commit = "9c05432ac1a59cd858dc77704905d2dcc2487ec1",
+    sha256 = "1ea18adfb608948cab1b5978081dc8c318ed47573ccd66f1603a37fbdbfc56da",  # noqa
     build_file = "tools/workspace/pybind11/pybind11.BUILD.bazel",
 )
 

--- a/common/test/unique_ptr_tracked_test.cc
+++ b/common/test/unique_ptr_tracked_test.cc
@@ -1,0 +1,73 @@
+#include "drake/common/unique_ptr_tracked.h"
+
+#include <gtest/gtest.h>
+
+using std::unique_ptr;
+
+namespace drake {
+
+int num_alive = 0;
+
+struct Value {
+  Value() {
+    num_alive++;
+  }
+  ~Value() {
+    num_alive--;
+  }
+  Value(const Value&) = delete;
+  Value(Value&&) = delete;
+};
+
+using internal::on_delete;
+using internal::PtrErased;
+
+class UniquePtrTracked : public ::testing::Test {
+ public:
+  void SetUp() virtual {
+    ASSERT_FALSE(on_delete);
+  }
+  void TearDown() virtual {
+    on_delete = DeleteCallback{};
+  }
+};
+
+TEST_F(UniquePtrTracked, TestNominal) {
+  // Ensure that nominal behavior is guaranteed without a callback installed.
+  unique_ptr<Value> ptr;
+  EXPECT_EQ(num_alive, 1);
+  ptr.reset();
+  EXPECT_EQ(num_alive, 0);
+}
+
+TEST_F(UniquePtrTracked, TestWithCallback) {
+  // Test nominal behavior.
+  PtrErased ptr_last;
+  on_delete = [&ptr_last](PtrErased ptr) {
+    // Just store the last value.
+    ptr_last = ptr;
+    return false;
+  };
+
+  unique_ptr<Value> ptr(new Value());
+  Value* raw = ptr.get();
+  EXPECT_EQ(num_alive, 1);
+  {
+    unique_ptr_tracked<Value> ptr_tracked = std::move(ptr);
+    // Test moving back and forth.
+    unique_ptr<Value> ptr_2 = std::move(ptr_tracked);
+    ptr_tracked = std::move(ptr_2);
+    ptr = std::move(ptr_tracked);
+  }
+  // Lifetime should not have ended.
+  ASSERT_FALSE(ptr_last);
+  {
+    // The lifetime should end here.
+    unique_ptr_tracked<Value> ptr_tracked_2;
+    ptr_tracked_2 = std::move(ptr);
+  }
+  EXPECT_EQ(num_alive, 0);
+  EXPECT_EQ(raw, ptr_last.ptr());
+}
+
+}  // namespace drake

--- a/common/unique_ptr_tracked.cc
+++ b/common/unique_ptr_tracked.cc
@@ -1,0 +1,11 @@
+#include "drake/common/unique_ptr_tracked.h"
+
+#include "drake/common/never_destroyed.h"
+
+namespace drake {
+namespace internal {
+
+never_destroyed<DeleteCallback> on_delete;
+
+}  // namespace internal
+}  // namespace drake

--- a/common/unique_ptr_tracked.h
+++ b/common/unique_ptr_tracked.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <typeindex>
+#include <typeinfo>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace internal {
+
+class PtrErased {
+ public:
+  struct type_hasher {
+    using type = const std::type_info*;
+    template <typename T>
+    static type hash() { return &typeid(T); }
+  };
+
+  PtrErased(const PtrErased&) = default;
+
+  template <typename T>
+  PtrErased(T* ptr)
+    : ptr_(ptr), type_(type_hasher::hash<T>()) {}
+
+  operator bool() const { return ptr_ != nullptr; }
+  void* ptr() const { return ptr_; }
+  type_hasher::type type_hash() const { return type_; }
+ private:
+  void* ptr_{};
+  type_hasher::type type_{};
+};
+
+using DeleteCallback = std::function<bool (PtrErased)>;
+extern DeleteCallback on_delete;
+
+/// Yar.
+template <typename T>
+class TrackedDeleter {
+ public:
+  TrackedDeleter() = default;
+  // Allow interfacting with trivial deleters.
+  template <typename Deleter>
+  TrackedDeleter(Deleter&&) {}
+  template <typename Deleter>
+  TrackedDeleter& operator=(Deleter&&) {
+    return *this;
+  }
+  template <typename Deleter>
+  operator Deleter() {
+    return Deleter{};
+  }
+  // Only called when `ptr` is non-null.
+  void operator()(T* ptr) {
+    bool is_deleted = on_delete && on_delete(ptr);
+    if (!is_deleted)
+      delete ptr;
+  }
+};
+
+}  // namespace internal
+
+/// Used for C++ and Python.
+template <typename T>
+using unique_ptr_tracked = unique_ptr<T, internal::TrackedDeleter<T>>;
+
+}  // namespace drake


### PR DESCRIPTION
This is a rough sketch to show a potential solution.

This may most likely be abandoned in favor of:
* Using `py::keep_alive` behavior, assuming that memory will not be an issue.
* Using `shared_ptr` instead of `unique_ptr`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7715)
<!-- Reviewable:end -->

  