### PR TITLE
Add mutable getters for the two MobilPlanner Parameters groups

### DIFF
--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -28,14 +28,6 @@ using systems::rendering::PoseVector;
 
 namespace automotive {
 
-namespace {
-
-static constexpr int kIdmParamsIndex{0};
-static constexpr int kMobilParamsIndex{1};
-static constexpr double kDefaultLargeAccel{1e6};  // m/s^2
-
-}  // namespace
-
 template <typename T>
 MobilPlanner<T>::MobilPlanner(const RoadGeometry& road, bool initial_with_s)
     : road_(road),

--- a/automotive/mobil_planner.h
+++ b/automotive/mobil_planner.h
@@ -102,6 +102,21 @@ class MobilPlanner : public systems::LeafSystem<T> {
   const systems::OutputPort<T>& lane_output() const;
   /// @}
 
+  /// Getters to mutable named-vector references associated with MobilPlanner's
+  /// Parameters groups.
+  /// @{
+  inline IdmPlannerParameters<T>& get_mutable_idm_params(
+      systems::Context<T>* context) const {
+    return this->template GetMutableNumericParameter<IdmPlannerParameters>(
+        context, kIdmParamsIndex);
+  }
+  inline MobilPlannerParameters<T>& get_mutable_mobil_params(
+      systems::Context<T>* context) const {
+    return this->template GetMutableNumericParameter<MobilPlannerParameters>(
+        context, kMobilParamsIndex);
+  }
+  /// @}
+
  private:
   void CalcLaneDirection(const systems::Context<T>& context,
                          LaneDirection* lane_direction) const;
@@ -148,6 +163,10 @@ class MobilPlanner : public systems::LeafSystem<T> {
   const T EvaluateIdm(const IdmPlannerParameters<T>& idm_params,
                       const ClosestPose<T>& trailing_closest_pose,
                       const ClosestPose<T>& leading_closest_pose) const;
+
+  static constexpr int kIdmParamsIndex{0};
+  static constexpr int kMobilParamsIndex{1};
+  static constexpr double kDefaultLargeAccel{1e6};  // m/s^2
 
   const maliput::api::RoadGeometry& road_;
   const bool with_s_{true};

--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -174,6 +174,28 @@ TEST_F(MobilPlannerTest, Topology) {
   EXPECT_EQ(systems::kAbstractValued, lane_output_port.get_data_type());
 }
 
+// Tests that the parameters index getters access the correct parameter groups.
+TEST_F(MobilPlannerTest, MutableParameterAccessors) {
+  InitializeDragway(2 /* num_lanes */);
+  InitializeMobilPlanner(true /* initial_with_s */);
+
+  ASSERT_EQ(2, context_->num_numeric_parameters());
+  const auto mobil = dynamic_cast<const MobilPlanner<double>*>(dut_.get());
+
+  auto& mobil_params = mobil->get_mutable_mobil_params(context_.get());
+  EXPECT_EQ(MobilPlannerParametersIndices::kNumCoordinates,
+            mobil_params.size());
+  EXPECT_TRUE(MobilPlannerParametersIndices::GetCoordinateNames() ==
+              mobil_params.GetCoordinateNames());
+  mobil_params[0] = 42.;
+
+  auto& idm_params = mobil->get_mutable_idm_params(context_.get());
+  EXPECT_EQ(IdmPlannerParametersIndices::kNumCoordinates, idm_params.size());
+  EXPECT_TRUE(IdmPlannerParametersIndices::GetCoordinateNames() ==
+              idm_params.GetCoordinateNames());
+  idm_params[0] = 42.;
+}
+
 // Tests the incentive of the ego car to change lanes when tailgating a car
 // close ahead.
 TEST_F(MobilPlannerTest, IncentiveWhileTailgating) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7716)
<!-- Reviewable:end -->
