### PR TITLE
Do not install SCS headers

### DIFF
--- a/tools/workspace/scs/scs.BUILD.bazel
+++ b/tools/workspace/scs/scs.BUILD.bazel
@@ -60,9 +60,6 @@ cc_library(
 install(
     name = "install",
     targets = [":libscsdir.so"],
-    hdrs = SCS_HDRS,
-    hdr_dest = "include/scs",
-    hdr_strip_prefix = ["include"],
     docs = [
         "LICENSE.txt",
         "linsys/direct/external/AMD_README.txt",


### PR DESCRIPTION
SCS is a purely private dependency of `libdrake.so` so the headers should not be installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7720)
<!-- Reviewable:end -->
