### PR TITLE
Fold together gurobi and mosek test_tags declarations

### DIFF
--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -2,8 +2,7 @@
 
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags", "mosek_test_tags")
 load(
     "//tools/skylark:pybind.bzl",
     "drake_pybind_library",

--- a/examples/cubic_polynomial/BUILD.bazel
+++ b/examples/cubic_polynomial/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("//tools:drake.bzl", "drake_cc_binary")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
+load("//tools/skylark:test_tags.bzl", "mosek_test_tags")
 
 drake_cc_binary(
     name = "region_of_attraction",

--- a/examples/humanoid_controller/BUILD.bazel
+++ b/examples/humanoid_controller/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/qp_inverse_dynamics/BUILD.bazel
+++ b/examples/qp_inverse_dynamics/BUILD.bazel
@@ -1,7 +1,7 @@
 # -*- python -*-
 
 load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 

--- a/multibody/dev/BUILD.bazel
+++ b/multibody/dev/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 drake_cc_library(

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -6,9 +6,8 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags", "mosek_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
 load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 
 package(default_visibility = ["//visibility:public"])

--- a/systems/controllers/plan_eval/BUILD.bazel
+++ b/systems/controllers/plan_eval/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "drake_cc_googletest",
     "drake_cc_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])

--- a/systems/controllers/qp_inverse_dynamics/BUILD.bazel
+++ b/systems/controllers/qp_inverse_dynamics/BUILD.bazel
@@ -6,7 +6,7 @@ load(
     "@drake//tools/skylark:drake_proto.bzl",
     "drake_cc_proto_library",
 )
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")
+load("//tools/skylark:test_tags.bzl", "gurobi_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/systems/estimators/dev/BUILD.bazel
+++ b/systems/estimators/dev/BUILD.bazel
@@ -5,7 +5,7 @@ load(
     "drake_cc_test",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")
+load("//tools/skylark:test_tags.bzl", "mosek_test_tags")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -28,8 +28,8 @@ test --test_env=DISPLAY
 # -- linux64 directory in the Gurobi 7.0.2 release.
 #
 # -- To run tests where Gurobi is used, ensure that you include
-# -- "gurobi_test_tags()" from //tools:gurobi.bzl. If Gurobi is optional, set
-# -- gurobi_required=False.
+# -- "gurobi_test_tags()" from //tools/skylark:test_tags.bzl.
+# -- If Gurobi is optional, set gurobi_required=False.
 build:gurobi --define=WITH_GUROBI=ON
 # -- By default, Gurobi looks for the license file in the homedir.
 test:gurobi --test_env=HOME
@@ -41,8 +41,8 @@ test:gurobi --test_env=GRB_LICENSE_FILE
 # -- $HOME/mosek/mosek.lic.
 #
 # -- To run tests where MOSEK is used, ensure that you include
-# -- "mosek_test_tags()" from //tools:mosek.bzl. If MOSEK is optional, set
-# -- mosek_required=False.
+# -- "mosek_test_tags()" from //tools/skylark:test_tags.bzl.
+# -- If MOSEK is optional, set mosek_required=False.
 build:mosek --define=WITH_MOSEK=ON
 # -- MOSEK looks for its license file at $HOME/mosek/mosek.lic
 test:mosek --test_env=HOME

--- a/tools/gurobi.bzl
+++ b/tools/gurobi.bzl
@@ -1,9 +1,0 @@
-# -*- python -*-
-
-# This file is a compatibility shim, to ease porting to our new filename.
-# TODO(jwnimmer-tri) This is a compatibility shim; remove this file on or
-# around 2017-11-01.
-print("warning: tools/gurobi.bzl is deprecated; " +
-      "use tools/workspace/gurobi/gurobi.bzl.")
-
-load("//tools/workspace/gurobi:gurobi.bzl", "gurobi_test_tags")

--- a/tools/mosek.bzl
+++ b/tools/mosek.bzl
@@ -1,9 +1,0 @@
-# -*- python -*-
-
-# This file is a compatibility shim, to ease porting to our new filename.
-# TODO(jwnimmer-tri) This is a compatibility shim; remove this file on or
-# around 2017-11-01.
-print("warning: tools/mosek.bzl is deprecated; " +
-      "use tools/workspace/mosek/mosek.bzl.")
-
-load("//tools/workspace/mosek:mosek.bzl", "mosek_test_tags")

--- a/tools/skylark/test_tags.bzl
+++ b/tools/skylark/test_tags.bzl
@@ -1,0 +1,47 @@
+# -*- mode: python -*-
+
+# These macros are intended to be used when declaring tests that either may-use
+# or must-use either Gurobi or Mosek commercial solvers.  These labels both
+# account for any license-server specific needs (such as network access or rate
+# control), as well as provide a marker so that //tools/bazel.rc can
+# selectively enable tests based on the developer's chosen configuration.
+
+def gurobi_test_tags(gurobi_required = True):
+    """Returns the test tags necessary for properly running Gurobi tests.
+
+    By default, sets gurobi_required=True, which will require that the supplied
+    tag filters include "gurobi".
+
+    Gurobi checks a license file, and may need to contact a license server to
+    check out a license. Therefore, tests that use Gurobi must have the tag
+    "local", because they are non-hermetic. For the moment, we also require
+    the tag "exclusive", to rate-limit license servers with a small number of
+    licenses.
+    """
+    # TODO(david-german-tri): Find a better fix for the license server problem.
+    nominal_tags = [
+        "exclusive",
+        "local",
+    ]
+    if gurobi_required:
+        return nominal_tags + ["gurobi"]
+    else:
+        return nominal_tags
+
+def mosek_test_tags(mosek_required = True):
+    """Returns the test tags necessary for properly running mosek tests.
+
+    By default, sets mosek_required=True, which will require that the supplied
+    tag filters include "mosek".
+
+    MOSEK checks a license file, and may need to contact a license server to
+    check out a license. Therefore, tests that use MOSEK must have the tag
+    "local", because they are non-hermetic.
+    """
+    nominal_tags = [
+        "local",
+    ]
+    if mosek_required:
+        return nominal_tags + ["mosek"]
+    else:
+        return nominal_tags

--- a/tools/workspace/gurobi/gurobi.bzl
+++ b/tools/workspace/gurobi/gurobi.bzl
@@ -102,25 +102,3 @@ gurobi_repository = repository_rule(
     local = True,
     implementation = _gurobi_impl,
 )
-
-def gurobi_test_tags(gurobi_required = True):
-    """Returns the test tags necessary for properly running Gurobi tests.
-
-    By default, sets gurobi_required=True, which will require that the supplied
-    tag filters include "gurobi".
-
-    Gurobi checks a license file, and may need to contact a license server to
-    check out a license. Therefore, tests that use Gurobi must have the tag
-    "local", because they are non-hermetic. For the moment, we also require
-    the tag "exclusive", to rate-limit license servers with a small number of
-    licenses.
-    """
-    # TODO(david-german-tri): Find a better fix for the license server problem.
-    nominal_tags = [
-        "exclusive",
-        "local",
-    ]
-    if gurobi_required:
-        return nominal_tags + ["gurobi"]
-    else:
-        return nominal_tags

--- a/tools/workspace/mosek/mosek.bzl
+++ b/tools/workspace/mosek/mosek.bzl
@@ -129,21 +129,3 @@ install(
     repository_ctx.file("BUILD", content = file_content, executable = False)
 
 mosek_repository = repository_rule(implementation = _impl)
-
-def mosek_test_tags(mosek_required = True):
-    """Returns the test tags necessary for properly running mosek tests.
-
-    By default, sets mosek_required=True, which will require that the supplied
-    tag filters include "mosek".
-
-    MOSEK checks a license file, and may need to contact a license server to
-    check out a license. Therefore, tests that use MOSEK must have the tag
-    "local", because they are non-hermetic.
-    """
-    nominal_tags = [
-        "local",
-    ]
-    if mosek_required:
-        return nominal_tags + ["mosek"]
-    else:
-        return nominal_tags


### PR DESCRIPTION
These functions shouldn't really be part of the workspace code; that code about declaring the repository, while these functions are about suite labeling within Drake's test declarations.  This way is also slightly less verbose, and provides a central place to document some of the oddities.

Relates #7259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7727)
<!-- Reviewable:end -->
