### PR TITLE
Configure C and CXX compiler wrapper to compile project without using…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/modules")
 include(CTest)
 
 configure_file(CTestCustom.cmake.in CTestCustom.cmake @ONLY)
+foreach(LANG C CXX)
+  set(COMPILER ${CMAKE_${LANG}_COMPILER})
+  configure_file(tools/cc_toolchain/wrapper.sh.in ${CMAKE_CURRENT_BINARY_DIR}/${LANG}_wrapper.sh @ONLY)
+endforeach()
 
 if(CYGWIN OR NOT UNIX)
   message(FATAL_ERROR "Cygwin and non-Unix platforms are NOT supported")
@@ -44,7 +48,7 @@ else()
   set(BAZEL_COMPILATION_MODE opt)
 endif()
 
-set(BAZEL_ENV "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}")
+set(BAZEL_ENV "CC=${CMAKE_CURRENT_BINARY_DIR}/C_wrapper.sh" "CXX=${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh")
 
 set(BAZEL_ARGS
   --compilation_mode=${BAZEL_COMPILATION_MODE}

--- a/tools/cc_toolchain/wrapper.sh.in
+++ b/tools/cc_toolchain/wrapper.sh.in
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Real compiler path. Configured by CMake
+_COMPILER=@COMPILER@
+# If bazel is configuring the project and trying to get the list of system
+# include directories, we also compute the real path (canonical path) of the
+# include directories that are symlinks. We keep both original and canonical
+# paths just in case. The flags used in this step are visible in bazel source
+# code [1].
+# [1] https://github.com/bazelbuild/bazel/blob/ceaed51/tools/cpp/unix_cc_configure.bzl#L149-L168
+if [[ "$*" ==  *"-E"* ]] &&
+    [[ "$*" == *"-xc++"* ]] &&
+    [[ "$*" == *"-"* ]] &&
+    [[ "$*" == *"-v"* ]]
+then
+    $_COMPILER "$@" 2>&1 >/dev/null | while IFS= read line ; do
+    # Prints include directory in stderr, and if it is a symlink, gets the link
+    # path and print it to stderr too. We cannot use `readlink -f` because
+    # MacOS `readlink` does not have this flag. Using Python instead.
+    line_escape=$(echo "$line" |sed "s/'/\\\\'/g")
+    python -c "$(echo "
+        import os
+        import sys
+        import re
+        line = '$line_escape'
+        sys.stderr.write(line + '\n')
+        if re.match('^[ ]*/usr/.*', line):
+            filename = line.lstrip()
+            nbspaces = len(line) - len(filename)
+            if os.path.islink(filename):
+                path = os.path.join(os.path.dirname(filename), os.readlink(filename))
+                path = os.path.abspath(path)
+                sys.stderr.write(' ' * nbspaces + path + '\n')
+        " | sed 's/        //')"
+    done
+else
+# Otherwise, just run the compiler normally.
+  $_COMPILER "$@"
+fi


### PR DESCRIPTION
… CROSSTOOL

The compiler wrappers are configured with CMake. This allows to compile drake
with CMake with clang 4 and 5. Without this wrapper, it is required to use
the CROSSTOOL file to manually specify `cxx_builtin_include_directory` since
there is a bug, either in clang or in bazel, that results in comparing
symlink directory names to canonical directory names and fails even though
the directories are technically the same (string comparison failing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7729)
<!-- Reviewable:end -->
