### PR TITLE
call_python: Denote `call_python_full_test` as flaky as a stop-gap measure.

### DIFF
--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -107,6 +107,9 @@ sh_test(
         ":call_python_client_cli",
         ":call_python_test",
     ],
+    # TODO(eric.cousineau): Find the source of (more) sporadic CI failures, but
+    # after refactoring the script into Python.
+    flaky = 1,
     # Certain versions of Mac don't like this script using `ps`. For this
     # reason, make the test run locally.
     local = 1,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7735)
<!-- Reviewable:end -->
