### PR TITLE
Add notes on downstream testing locally.

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -58,6 +58,7 @@ Testing
     :maxdepth: 1
 
     unit_testing_instructions
+    downstream_testing
 
 .. See :doc:`unit_testing_instructions`
 

--- a/doc/downstream_testing.rst
+++ b/doc/downstream_testing.rst
@@ -1,0 +1,34 @@
+******************************************
+Downstream Testing (Drake as a Dependency)
+******************************************
+
+Introduction
+============
+
+To ensure that Drake enables downstream consumption, there are downstream tests
+that show basic usage of Drake as a dependency. Those tests are located in
+the `Drake Shambhala <https://github.com/RobotLocomotion/drake-shambhala>`_
+repository.
+
+Continuous Integration
+======================
+
+Please see the Drake Shambhala `Continuous Integration
+<https://github.com/RobotLocomotion/drake-shambhala#continuous-integration>`_
+section.
+
+Local Testing
+=============
+
+For CMake, see the
+`drake_cmake_installed
+<https://github.com/RobotLocomotion/drake-shambhala/tree/master/drake_cmake_installed#developer-testing>`_
+example.
+
+For Bazel, see the
+`drake_bazel_external <https://github.com/RobotLocomotion/drake-shambhala/tree/master/drake_bazel_external>`_
+example, and note the comment in
+`WORKSPACE <https://github.com/RobotLocomotion/drake-shambhala/blob/master/drake_bazel_external/WORKSPACE>`_
+which mentions using something like
+`local_repository <https://docs.bazel.build/versions/master/be/workspace.html#local_repository>`_
+to consume a local checkout of Drake.


### PR DESCRIPTION
Since Drake Shambhala is part of the Build Cop's responsibilities, I would like to ensure that the repository is explicitly linked to in the documentation, with instructions specific to testing a local Drake build (without the need for `sudo` into `/opt`) for developers that may be making changes to the downstream interface.

\cc @stonier

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7737)
<!-- Reviewable:end -->
