### PR TITLE
pydrake: Use transitive `py::keep_alive` to aid in REPL-friendly behavior.

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -17,8 +17,14 @@ PYBIND11_MODULE(analysis, m) {
   using T = double;
 
   py::class_<Simulator<T>>(m, "Simulator")
-    .def(py::init<const System<T>&>())
-    .def(py::init<const System<T>&, unique_ptr<Context<T>>>())
+    .def(py::init<const System<T>&>(),
+         // Keep alive, reference: `self` keeps `System` alive.
+         py::keep_alive<1, 2>())
+    .def(py::init<const System<T>&, unique_ptr<Context<T>>>(),
+         // Keep alive, reference: `self` keeps `System` alive.
+         py::keep_alive<1, 2>(),
+         // Keep alive, ownership: `Context` keeps `self` alive.
+         py::keep_alive<3, 1>())
     .def("Initialize", &Simulator<T>::Initialize)
     .def("StepTo", &Simulator<T>::StepTo)
     .def("get_context", &Simulator<T>::get_context, py_iref)

--- a/bindings/pydrake/systems/test/lifetime_test.py
+++ b/bindings/pydrake/systems/test/lifetime_test.py
@@ -58,9 +58,16 @@ class TestLifetime(unittest.TestCase):
         self.assertFalse(info.deleted)
         # Delete the diagram. Should be dead.
         del diagram
-        # WARNING
-        self.assertTrue(info.deleted)
+        # Using `py::keep_alive`, `system` will keep `builder` alive after
+        # `.AddSystem` is called, and `builder` will keep `diagram` alive after
+        # `.Build` is called.
+        # Transitively, `system` will keep `builder` alive (as its old owner)
+        # and `diagram` (as its new owner, which is kept alive by `builder`).
+        self.assertFalse(info.deleted)
         self.assertTrue(system is not None)
+        del system
+        # Upon removing this reference, everything should be cleared up.
+        self.assertTrue(info.deleted)
 
     def test_ownership_multiple_containers(self):
         info = Info()
@@ -84,6 +91,13 @@ class TestLifetime(unittest.TestCase):
         # Simulator does not own the system.
         self.assertFalse(info.deleted)
         self.assertTrue(system is not None)
+        # Now ensure that having a system be alive will keep
+        # the system alive (using `py::keep_alive`).
+        simulator = Simulator(system)
+        del system
+        self.assertFalse(info.deleted)
+        del simulator
+        self.assertTrue(info.deleted)
 
     def test_ownership_vector(self):
         system = Adder(1, 1)
@@ -92,9 +106,14 @@ class TestLifetime(unittest.TestCase):
         vector = DeleteListenerVector(info.record_deletion)
         context.FixInputPort(0, vector)
         del context
-        # WARNING
-        self.assertTrue(info.deleted)
+        # Same as above applications, using `py::keep_alive`.
+        self.assertFalse(info.deleted)
         self.assertTrue(vector is not None)
+        # Ensure that we do not get segfault behavior when accessing / mutating
+        # the values.
+        self.assertTrue(np.allclose(vector.get_value(), [0.]))
+        vector.get_mutable_value()[:] = [10.]
+        self.assertTrue(np.allclose(vector.get_value(), [10.]))
 
 
 assert __name__ == '__main__'


### PR DESCRIPTION
Relates #7660.
Per discussions in Platform Reviewer's meeting and after.

\cc @jwnimmer-tri @sammy-tri @ggould-tri @rdeits 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7742)
<!-- Reviewable:end -->
