### PR TITLE
Avoid using local_repository for com_google_protobuf

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ install(
         "//drake/automotive/models:install_data",
         "//drake/bindings/pydrake:install",
         "//drake/common:install",
+        "//drake/common/proto:install",
         "//drake/examples:install",
         "//drake/lcmtypes:install",
         "//drake/manipulation/models:install_data",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,17 +41,9 @@ github_archive(
     build_file = "@drake//tools/workspace/stx:package.BUILD.bazel",
 )
 
-# This local repository imports the protobuf build rules for Bazel (based on
-# the upstream protobuf.bzl build rules); in constrast, the protobuf runtime is
-# loaded as @libprotobuf.
-local_repository(
-    name = "com_google_protobuf",
-    # TODO(clalancette) Per https://github.com/RobotLocomotion/drake/pull/7361
-    # this should use an absolute path (so this should be prepended by
-    # __workspace_dir__).  However, in a clean build, this did not work.  We
-    # should investigate that and fix it.
-    path = "third_party/com_github_google_protobuf",
-)
+load("//tools/workspace/com_google_protobuf:package.bzl", "com_google_protobuf_repository")  # noqa
+
+com_google_protobuf_repository(name = "com_google_protobuf")
 
 load("//tools/workspace/ibex:package.bzl", "ibex_repository")
 

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "drake_cc_proto_library",
     "drake_py_proto_library",
 )
+load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/skylark:6996.bzl", "HAS_MOVED_6996")
 
@@ -78,6 +79,26 @@ py_binary(
         # spellings such as this one.
         "@drake//common/proto:call_python_client" if HAS_MOVED_6996 else ":call_python_client",  # noqa
     ],
+)
+
+_UBSAN_H = "//third_party:com_github_google_protobuf/protobuf-ubsan-fixup.h"
+
+# This library is used by //tools/skylark:drake_proto.bzl.  Developers should
+# never need to mention it directly.  The source code is placed in third_party
+# because it is forked from protobuf upstream, and thus copyright by Google.
+cc_library(
+    name = "protobuf_ubsan_fixup",
+    hdrs = [_UBSAN_H],
+    include_prefix = "drake/common/proto",
+    strip_include_prefix = "/third_party/com_github_google_protobuf",
+)
+
+install(
+    name = "install",
+    hdrs = [_UBSAN_H],
+    hdr_dest = "include/drake/common/proto",
+    hdr_strip_prefix = ["com_github_google_protobuf"],
+    allowed_externals = [_UBSAN_H],
 )
 
 # === test/ ===

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -34,4 +34,17 @@ exports_files(
     visibility = ["@spruce//:__pkg__"],
 )
 
+exports_files(
+    [
+        "com_github_google_protobuf/LICENSE",
+        "com_github_google_protobuf/protobuf.bzl",
+    ],
+    visibility = ["@com_google_protobuf//:__pkg__"],
+)
+
+exports_files(
+    ["com_github_google_protobuf/protobuf-ubsan-fixup.h"],
+    visibility = ["//common/proto:__pkg__"],
+)
+
 add_lint_tests()

--- a/third_party/com_github_google_protobuf/README.md
+++ b/third_party/com_github_google_protobuf/README.md
@@ -3,9 +3,7 @@ https://github.com/google/protobuf, originally downloaded from commit
 4fc93044a5de018527ec027dbee6a882012e0d9d.  The following lists which files are
 copyrighted by whom:
 
-BUILD.bazel - Drake project
 LICENSE - Google, protobuf project
 protobuf-ubsan-fixup.h - Google, protobuf project
 protobuf.bzl - Google, protobuf project
 README.md - Drake project
-WORKSPACE - Drake project

--- a/third_party/com_github_google_protobuf/WORKSPACE
+++ b/third_party/com_github_google_protobuf/WORKSPACE
@@ -1,6 +1,0 @@
-# -*- python -*-
-
-# This file marks a workspace root for the Bazel build system. see
-# http://bazel.io/ .
-
-workspace(name = "com_google_protobuf")

--- a/third_party/com_github_google_protobuf/protobuf-ubsan-fixup.h
+++ b/third_party/com_github_google_protobuf/protobuf-ubsan-fixup.h
@@ -1,6 +1,36 @@
 #ifndef PROTOBUF_UBSAN_FIXUP_H
 #define PROTOBUF_UBSAN_FIXUP_H
 
+/*
+Copyright 2014, Google Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 // This code is pulled from upstream Protobuf:
 // https://github.com/google/protobuf/blob/4fc9304/src/google/protobuf/generated_message_util.h#L80
 // This is necessary because Protobuf 2.6 (which Drake is currently using from

--- a/tools/skylark/drake_proto.bzl
+++ b/tools/skylark/drake_proto.bzl
@@ -37,7 +37,7 @@ def drake_cc_proto_library(
         name = name + "_ubsan_fixup",
         srcs = pb_srcs,
         outs = pb_ubsan_fixups,
-        cmd = "for src in $(SRCS) ; do awk '/#include <google\/protobuf\/generated_message_reflection.h>/{print;print \"#include \\\"protobuf-ubsan-fixup.h\\\"\";next}1' $$src > $${src%??????}_ubsan_fixup.pb.cc ; done",  # noqa
+        cmd = "for src in $(SRCS) ; do awk '/#include <google\/protobuf\/generated_message_reflection.h>/{print;print \"#include \\\"drake/common/proto/protobuf-ubsan-fixup.h\\\"\";next}1' $$src > $${src%??????}_ubsan_fixup.pb.cc ; done",  # noqa
     )
     # Compile the cc file using standard include paths.
     native.cc_library(
@@ -47,7 +47,7 @@ def drake_cc_proto_library(
         tags = tags + ["nolint"],
         deps = [
             "@com_google_protobuf//:protobuf",
-            "@com_google_protobuf//:protobuf_fixup_ubsan",
+            "@drake//common/proto:protobuf_ubsan_fixup",
         ],
         **kwargs)
     # Provide a library with drake-modified include paths, depending on the

--- a/tools/workspace/com_google_protobuf/BUILD.bazel
+++ b/tools/workspace/com_google_protobuf/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/com_google_protobuf/package.BUILD.bazel
+++ b/tools/workspace/com_google_protobuf/package.BUILD.bazel
@@ -4,6 +4,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+# Provide a recent version of the protobuf skylark code from upstream.
 exports_files(["protobuf.bzl"])
 
 # The protobuf.bzl looks here to find which protoc to use.
@@ -25,9 +26,4 @@ alias(
 py_library(
     name = "protobuf_python",
     # No srcs here, so we'll use the system default.
-)
-
-cc_library(
-    name = "protobuf_fixup_ubsan",
-    hdrs = ["protobuf-ubsan-fixup.h"],
 )

--- a/tools/workspace/com_google_protobuf/package.bzl
+++ b/tools/workspace/com_google_protobuf/package.bzl
@@ -1,0 +1,25 @@
+# -*- mode: python -*-
+
+# This rule imports the protobuf skylark code (the upstream protobuf.bzl) under
+# the name @com_google_protobuf, as is conventional.  Within that repository,
+# we then use a custom BUILD.bazel file to provide the well-known labels
+# ":protoc", ":protobuf", and ":protobuf_python" as aliases to the operating
+# system's default installation of protobuf, for improved compatibility across
+# Drake's ecosystem.
+
+def _impl(repository_ctx):
+    # Bring in our hand-written BUILD file for @com_google_protobuf.
+    repository_ctx.symlink(
+        Label("@drake//tools/workspace/com_google_protobuf:package.BUILD.bazel"),  # noqa
+        "BUILD.bazel")
+    # Bring in two vendored files from upstream.
+    repository_ctx.symlink(
+        Label("@drake//third_party:com_github_google_protobuf/protobuf.bzl"),
+        "protobuf.bzl")
+    repository_ctx.symlink(
+        Label("@drake//third_party:com_github_google_protobuf/LICENSE"),
+        "LICENSE")
+
+com_google_protobuf_repository = repository_rule(
+    implementation = _impl,
+)


### PR DESCRIPTION
Avoid using local_repository for `@com_google_protobuf`.

Also properly install the ubsan fixup.

Also move the ubsan fixup `cc_library` out of the `@com_google_protobuf` repository.  If a downstream Bazel user of Drake were to choose to use modern `@com_google_protobuf` (not Drake's vendored copy) then this label would go missing and `drake_proto.bzl` would have errors.  Instead, we build and install this header as part of Drake.

Builds on #7323 and #7644.

Relates #7259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7745)
<!-- Reviewable:end -->
