### PR TITLE
Avoid using local_repository for spruce; other misc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,8 +71,6 @@ gthread_repository(name = "gthread")
 
 load("//tools/workspace/libprotobuf:package.bzl", "libprotobuf_repository")
 
-# Load in the paths and flags to the system version of the protobuf runtime;
-# in contrast, the Bazel build rules are loaded as @com_google_protobuf.
 libprotobuf_repository(name = "libprotobuf")
 
 # Find the protoc binary on $PATH.
@@ -99,9 +97,7 @@ github_archive(
 
 load("//tools/workspace/gflags:package.bzl", "gflags_repository")
 
-gflags_repository(
-    name = "gflags",
-)
+gflags_repository(name = "gflags")
 
 github_archive(
     name = "styleguide",
@@ -288,7 +284,6 @@ git_repository(
     commit = "0f475624131c9ca4d5624e74c3f8273ccc926f9b",
 )
 
-# Python Libraries
 load("//tools/workspace:pypi.bzl", "pypi_archive")
 
 pypi_archive(
@@ -395,9 +390,6 @@ load("//tools/workspace/zlib:package.bzl", "zlib_repository")
 
 zlib_repository(name = "zlib")
 
-load(
-    "//tools/workspace/drake_visualizer:package.bzl",
-    "drake_visualizer_repository",
-)
+load("//tools/workspace/drake_visualizer:package.bzl", "drake_visualizer_repository")  # noqa
 
 drake_visualizer_repository(name = "drake_visualizer")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,11 +29,9 @@ github_archive(
     build_file = "@drake//tools/workspace/tinydir:package.BUILD.bazel",
 )
 
-new_local_repository(
-    name = "spruce",
-    build_file = "@drake//tools/workspace/spruce:package.BUILD.bazel",
-    path = __workspace_dir__ + "/third_party/josephdavisco_spruce",
-)
+load("//tools/workspace/spruce:package.bzl", "spruce_repository")
+
+spruce_repository(name = "spruce")
 
 github_archive(
     name = "stx",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,17 +83,11 @@ which(
 
 load("//tools/workspace/python:package.bzl", "python_repository")
 
-python_repository(
-    name = "python",
-    version = "2.7",
-)
+python_repository(name = "python")
 
 load("//tools/workspace/numpy:package.bzl", "numpy_repository")
 
-numpy_repository(
-    name = "numpy",
-    python_version = "2.7",
-)
+numpy_repository(name = "numpy")
 
 github_archive(
     name = "gtest",

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -29,4 +29,9 @@ exports_files(
     visibility = ["//tools/workspace/find_protobuf_cmake:__pkg__"],
 )
 
+exports_files(
+    glob(["josephdavisco_spruce/**"]),
+    visibility = ["@spruce//:__pkg__"],
+)
+
 add_lint_tests()

--- a/tools/workspace/libprotobuf/package.bzl
+++ b/tools/workspace/libprotobuf/package.bzl
@@ -5,5 +5,8 @@ load(
     "pkg_config_repository",
 )
 
+# Load in the paths and flags to the system version of the protobuf runtime;
+# in contrast, the Bazel build rules are loaded as @com_google_protobuf.
+
 def libprotobuf_repository(name, modname = "protobuf", **kwargs):
     pkg_config_repository(name = name, modname = modname, **kwargs)

--- a/tools/workspace/spruce/package.bzl
+++ b/tools/workspace/spruce/package.bzl
@@ -1,0 +1,21 @@
+# -*- python -*-
+
+def _impl(repository_ctx):
+    # Bring in the BUILD file.
+    repository_ctx.symlink(
+        Label("@drake//tools/workspace/spruce:package.BUILD.bazel"),
+        "BUILD.bazel")
+    # Bring in the source files from upstream.
+    repository_ctx.symlink(
+        Label("@drake//third_party:josephdavisco_spruce/LICENSE"),
+        "LICENSE")
+    repository_ctx.symlink(
+        Label("@drake//third_party:josephdavisco_spruce/spruce.cc"),
+        "spruce.cc")
+    repository_ctx.symlink(
+        Label("@drake//third_party:josephdavisco_spruce/spruce.hh"),
+        "spruce.hh")
+
+spruce_repository = repository_rule(
+    implementation = _impl,
+)


### PR DESCRIPTION
This PR is a little bit of a grab bag...

1. Avoid using `local_repository` for `@spruce`.  Using `new_local_repository` is a bit tricky to get right so we are trying to avoid it, thus its worth rewriting this to form a repository by just symlinking exactly what we need.

2. Remove redundant workspace defaults.  The python version is already defaulted within the `package.bzl` files, so we should not repeat it here.

3. Tidy up some comments and whitespace.  For consistency, don't wrap any lines; noqa them instead.

Relates #7259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7748)
<!-- Reviewable:end -->
