### PR TITLE
Remove the rename of liblcm-java.jar to lcm.jar.

### DIFF
--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -267,9 +267,6 @@ install(
         "COPYING",
         "NEWS",
     ],
-    rename = {
-        "share/java/liblcm-java.jar": "lcm.jar",
-    },
     deps = [
         ":install_cmake_config",
         ":install_extra_cmake",


### PR DESCRIPTION
The problem is that lcm.jar is not a proper rule, and hence the
rule in drake-lcm-spy that generates the launcher doesn't put
"lcm.jar" in the list of classes.  This ends up making drake-lcm-spy
fail to launch, since it can't find the main class.  Just remove
the rename, since it doesn't seem to be a problem to do that.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7750)
<!-- Reviewable:end -->
