### PR TITLE
cpp_template: Add Python mechanisms to pave way for C++ template binding.

### DIFF
--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -53,21 +53,6 @@ drake_py_library(
     imports = PACKAGE_INFO.py_imports,
 )
 
-PYBIND_LIBRARIES = []
-
-PY_LIBRARIES = [
-    ":cpp_param_py",
-    ":module_py",
-    ":module_shim_py",
-]
-
-# Package target.
-drake_py_library(
-    name = "util",
-    imports = PACKAGE_INFO.py_imports,
-    deps = PYBIND_LIBRARIES + PY_LIBRARIES,
-)
-
 # ODR does not matter, because the singleton will be stored in Python.
 drake_cc_library(
     name = "cpp_param_pybind",
@@ -85,6 +70,31 @@ drake_py_library(
     deps = [
         ":module_py",
     ],
+)
+
+drake_py_library(
+    name = "cpp_template_py",
+    srcs = ["cpp_template.py"],
+    deps = [
+        ":cpp_param_py",
+        ":module_py",
+    ],
+)
+
+PYBIND_LIBRARIES = []
+
+PY_LIBRARIES = [
+    ":cpp_param_py",
+    ":cpp_template_py",
+    ":module_py",
+    ":module_shim_py",
+]
+
+# Package target.
+drake_py_library(
+    name = "util",
+    imports = PACKAGE_INFO.py_imports,
+    deps = PYBIND_LIBRARIES + PY_LIBRARIES,
 )
 
 install(
@@ -132,6 +142,13 @@ drake_pybind_cc_googletest(
     name = "cpp_param_pybind_test",
     cc_deps = [":cpp_param_pybind"],
     py_deps = [":cpp_param_py"],
+)
+
+drake_py_test(
+    name = "cpp_template_test",
+    deps = [
+        ":cpp_template_py",
+    ],
 )
 
 add_lint_tests()

--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -1,0 +1,211 @@
+"""Provides containers for tracking instantiations of C++ templates. """
+
+import inspect
+from types import MethodType
+
+from pydrake.util.cpp_param import get_param_names, get_param_canonical
+
+
+def _get_module_name_from_stack(frame=2):
+    # Infers module name from call stack.
+    return inspect.getmodule(inspect.stack()[frame][0]).__name__
+
+
+def get_or_init(scope, name, template_cls, *args, **kwargs):
+    """Gets an existing template from a scope if it exists; otherwise, it will
+    be created and registered.
+
+    If `scope` does not have the attribute `name`, then it will be created as
+    `template_cls(name, *args, **kwargs)`.
+    (`module_name=...` is also set, but should not be important).
+
+    @param scope
+        Scope that contains the template object (this may not necessarily be
+        the scope of the instantiation).
+    @param name
+        Name of the template object.
+    @param template_cls
+        Class (either `TemplateBase` or a derivative).
+    @param args, kwargs
+        Passed to the template class's constructor.
+    @returns The existing (or newly created) template object.
+    """
+    template = getattr(scope, name, None)
+    if template is None:
+        if isinstance(scope, type):
+            module_name = scope.__module__
+        else:
+            module_name = scope.__name__
+        template = template_cls(name, *args, module_name=module_name, **kwargs)
+        setattr(scope, name, template)
+    return template
+
+
+class TemplateBase(object):
+    """Provides a mechanism to map parameters (types or literals) to
+    instantiations, following C++ mechanics.
+    """
+    def __init__(self, name, allow_default=True, module_name=None):
+        """
+        @param name
+            Name of the template object.
+        @param allow_default
+            (optional) Allow a default value (None) to resolve to the
+            parameters of the instantiation that was first added.
+        @param module_name
+            Parent module for the template object.
+        """
+        self.name = name
+        self.param_list = []
+        self._allow_default = allow_default
+        self._instantiation_map = {}
+        if module_name is None:
+            module_name = _get_module_name_from_stack()
+        self._module_name = module_name
+
+    def __getitem__(self, param):
+        """Gets concrete class associate with the given arguments.
+
+        Can be one of the following forms:
+            template[param0]
+            template[param0, param1, ...]
+            template[(param0, param1, ...)]
+            template[[param0, param1, ...]]
+            template[None]   (first instantiation, if `allow_default` is True)
+        """
+        return self.get_instantiation(param)[0]
+
+    def get_instantiation(self, param=None, throw_error=True):
+        """Gets the instantiation for the given parameters.
+
+        @param param
+            Can be None, a single parameter, or a tuple/list of parameters.
+        @returns (instantiation, param), where `param` is the resolved
+        set of parameters.
+        """
+        param = self._param_resolve(param)
+        instantiation = self._instantiation_map.get(param)
+        if instantiation is None and throw_error:
+            raise RuntimeError("Invalid instantiation: {}".format(
+                self._instantiation_name(param)))
+        return (instantiation, param)
+
+    def add_instantiation(self, param, instantiation):
+        """Adds a unique instantiation. """
+        assert instantiation is not None
+        # Ensure that we do not already have this tuple.
+        param = get_param_canonical(self._param_resolve(param))
+        if param in self._instantiation_map:
+            raise RuntimeError(
+                "Parameter instantiation already registered: {}".format(param))
+        # Register it.
+        self.param_list.append(param)
+        self._instantiation_map[param] = instantiation
+        self._on_add(param, instantiation)
+        return param
+
+    def add_instantiations(self, instantiation_func, param_list):
+        """Adds a set of instantiations given a function of the form
+        `instantiation_func(param)`, for a given set of parmeters
+        `param_list`.
+        """
+        for param in param_list:
+            self.add_instantiation(param, instantiation_func(param))
+
+    def get_param_set(self, instantiation):
+        """Returns all parameters for a given `instantiation`.
+
+        @returns A set of instantiations. """
+        param_list = []
+        for param, check in self._instantiation_map.iteritems():
+            if check == instantiation:
+                param_list.append(param)
+        return set(param_list)
+
+    def _param_resolve(self, param):
+        # Resolves to canonical parameters, including default case.
+        if param is None:
+            assert self._allow_default
+            assert len(self.param_list) > 0
+            param = self.param_list[0]
+        elif not isinstance(param, tuple):
+            if not isinstance(param, list):
+                # Assume scalar.
+                param = (param,)
+            else:
+                param = tuple(param)
+        return get_param_canonical(param)
+
+    def _instantiation_name(self, param):
+        names = get_param_names(self._param_resolve(param))
+        return '{}[{}]'.format(self.name, ', '.join(names))
+
+    def _full_name(self):
+        return "{}.{}".format(self._module_name, self.name)
+
+    def __str__(self):
+        cls_name = type(self).__name__
+        return "<{} {}>".format(cls_name, self._full_name())
+
+    def _on_add(self, param, instantiation):
+        # To be overridden by child classes.
+        pass
+
+
+class TemplateClass(TemplateBase):
+    """Extension of `TemplateBase` for classes. """
+    def __init__(self, name, override_name=True, **kwargs):
+        TemplateBase.__init__(self, name, **kwargs)
+        self._override_name = override_name
+
+    def _on_add(self, param, cls):
+        # Update class name for easier debugging.
+        if self._override_name:
+            cls.__name__ = self._instantiation_name(param)
+
+
+class TemplateFunction(TemplateBase):
+    """Extension of `TemplateBase` for functions. """
+    pass
+
+
+class TemplateMethod(TemplateBase):
+    """Extension of `TemplateBase` for class methods. """
+    def __init__(self, name, cls, **kwargs):
+        TemplateBase.__init__(self, name, **kwargs)
+        self._cls = cls
+
+    def __get__(self, obj, objtype):
+        """Provides descriptor accessor. """
+        if obj is None:
+            return self
+        else:
+            return TemplateMethod._Bound(self, obj)
+
+    def __set__(self, obj, value):
+        raise RuntimeError("Read-only property")
+
+    def __str__(self):
+        return '<unbound TemplateMethod {}>'.format(self._full_name())
+
+    def _full_name(self):
+        return '{}.{}'.format(self._cls.__name__, self.name)
+
+    class _Bound(object):
+        def __init__(self, template, obj):
+            self._tpl = template
+            self._obj = obj
+
+        def __getitem__(self, param):
+            unbound = self._tpl[param]
+            bound = MethodType(unbound, self._obj, self._tpl._cls)
+            return bound
+
+        def __str__(self):
+            return '<bound TemplateMethod {} of {}>'.format(
+                self._tpl._full_name(), self._obj)
+
+
+def is_instantiation_of(obj, template):
+    """Determines of an object is registered as an instantiation. """
+    return obj in template._instantiation_map.values()

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -1,0 +1,149 @@
+from __future__ import absolute_import, print_function
+
+import unittest
+from types import ModuleType
+
+import pydrake.util.cpp_template as m
+
+
+class DummyA(object):
+    pass
+
+
+class DummyB(object):
+    pass
+
+
+def dummy_a():
+    return 1
+
+
+def dummy_b():
+    return 2
+
+
+class DummyC(object):
+    def dummy_c(self):
+        return (self, 3)
+
+    def dummy_d(self):
+        return (self, 4)
+
+
+class DummyD(object):
+    pass
+
+
+class TestCppTemplate(unittest.TestCase):
+    def test_base(self):
+        template = m.TemplateBase("BaseTpl")
+        self.assertEquals(str(template), "<TemplateBase __main__.BaseTpl>")
+
+        # Single arguments.
+        template.add_instantiation(int, 1)
+        self.assertEquals(template[int], 1)
+        self.assertEquals(template.get_instantiation(int), (1, (int,)))
+        self.assertEquals(template.get_param_set(1), {(int,)})
+        self.assertTrue(m.is_instantiation_of(1, template))
+        self.assertFalse(m.is_instantiation_of(10, template))
+        # Duplicate parameters.
+        self.assertRaises(
+            RuntimeError, lambda: template.add_instantiation(int, 4))
+
+        # Invalid parameters.
+        self.assertRaises(RuntimeError, lambda: template[float])
+        # New instantiation.
+        template.add_instantiation(float, 2)
+        self.assertEquals(template[float], 2)
+
+        # Default instantiation.
+        self.assertEquals(template[None], 1)
+        self.assertEquals(template.get_instantiation(), (1, (int,)))
+
+        # Multiple arguments.
+        template.add_instantiation((int, int), 3)
+        self.assertEquals(template[int, int], 3)
+        # Duplicate instantiation.
+        template.add_instantiation((float, float), 1)
+        self.assertEquals(template.get_param_set(1), {(int,), (float, float)})
+        # Nested getitem indices.
+        self.assertEquals(template[(int, int)], 3)
+        self.assertEquals(template[[int, int]], 3)
+
+        # List instantiation.
+        def instantiation_func(param):
+            return 100 + len(param)
+        dummy_a = (str,) * 5
+        dummy_b = (str,) * 10
+        template.add_instantiations(instantiation_func, [dummy_a, dummy_b])
+        self.assertEquals(template[dummy_a], 105)
+        self.assertEquals(template[dummy_b], 110)
+
+    def test_class(self):
+        template = m.TemplateClass("ClassTpl")
+
+        template.add_instantiation(int, DummyA)
+        template.add_instantiation(float, DummyB)
+
+        self.assertEquals(template[int], DummyA)
+        self.assertEquals(str(DummyA), "<class '__main__.ClassTpl[int]'>")
+        self.assertEquals(template[float], DummyB)
+        self.assertEquals(str(DummyB), "<class '__main__.ClassTpl[float]'>")
+
+    def test_function(self):
+        template = m.TemplateFunction("func")
+
+        template.add_instantiation(int, dummy_a)
+        template.add_instantiation(float, dummy_b)
+
+        self.assertEquals(template[int](), 1)
+        self.assertEquals(template[float](), 2)
+        self.assertEquals(str(template), "<TemplateFunction __main__.func>")
+
+    def test_method(self):
+        DummyC.method = m.TemplateMethod("method", DummyC)
+        DummyC.method.add_instantiation(int, DummyC.dummy_c)
+        DummyC.method.add_instantiation(float, DummyC.dummy_d)
+
+        self.assertEquals(str(DummyC.method),
+                          "<unbound TemplateMethod DummyC.method>")
+        self.assertEquals(DummyC.method[int], DummyC.dummy_c)
+        self.assertEquals(str(DummyC.method[int]),
+                          "<unbound method DummyC.dummy_c>")
+
+        obj = DummyC()
+        self.assertTrue(
+            str(obj.method).startswith(
+                "<bound TemplateMethod DummyC.method of "))
+        self.assertTrue(
+            str(obj.method[int]).startswith(
+                "<bound method DummyC.dummy_c of "))
+        self.assertEquals(obj.method[int](), (obj, 3))
+        self.assertEquals(DummyC.method[int](obj), (obj, 3))
+        self.assertEquals(obj.method[float](), (obj, 4))
+        self.assertEquals(DummyC.method[float](obj), (obj, 4))
+
+    def test_get_or_init(self):
+        m_test = ModuleType("test_module")
+
+        def get_tpl_cls():
+            return m.get_or_init(m_test, "ClassTpl", m.TemplateClass)
+
+        tpl_1 = get_tpl_cls()
+        self.assertEquals(str(tpl_1), "<TemplateClass test_module.ClassTpl>")
+        self.assertTrue(m_test.ClassTpl is tpl_1)
+        tpl_2 = get_tpl_cls()
+        self.assertTrue(tpl_1 is tpl_2)
+
+        def get_tpl_method():
+            return m.get_or_init(DummyD, "method", m.TemplateMethod, DummyD)
+
+        tpl_1 = get_tpl_method()
+        self.assertTrue(tpl_1 is DummyD.method)
+        self.assertEquals(str(tpl_1), "<unbound TemplateMethod DummyD.method>")
+        tpl_2 = get_tpl_method()
+        self.assertTrue(tpl_1 is tpl_2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to exposing templates in #7660.

Final PR is to combine with #7732 and incorporate C++ glue:
https://github.com/EricCousineau-TRI/repro/blob/fa4e6a0/python/bindings/pymodule/tpl/cpp_template.h#L45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7757)
<!-- Reviewable:end -->
