### PR TITLE
drake-lcm-spy install rule need to know all renamed targets

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -379,11 +379,24 @@ install(
     deps = [
         ":install_cc_headers",
         "//tools/workspace/optitrack_driver:install",
+        "@lcm//:install",
+        "@lcmtypes_bot2_core//:install",
         "@lcmtypes_robotlocomotion//:install",
     ],
 )
 
 # === test/ ===
+
+# `//:install` is run in this test to verify that once installed
+# drake-lcm-spy still works. Cannot be run on its own, needs to be
+# run as part of all the drake tests to have access to //:install
+drake_py_test(
+    name = "drake-lcm-spy_install_test",
+    size = "large",
+    srcs = ["test/drake-lcm-spy_install_test.py"],
+    main = "test/drake-lcm-spy_install_test.py",
+    deps = ["//tools/install:install_test_helper"],
+)
 
 drake_py_test(
     name = "polynomial_matrix_test",

--- a/lcmtypes/test/drake-lcm-spy_install_test.py
+++ b/lcmtypes/test/drake-lcm-spy_install_test.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import unittest
+import install_test_helper
+
+
+class TestCommonInstall(unittest.TestCase):
+    def testInstall(self):
+        tmp_folder = "tmp"
+        result = install_test_helper.install(tmp_folder,
+                                             ['bin', 'lib', 'share'])
+        self.assertEqual(None, result)
+        executable_folder = os.path.join(tmp_folder, "bin")
+        try:
+            subprocess.check_output(
+                [os.path.join(executable_folder, "drake-lcm-spy"), "--help"],
+                stderr=subprocess.STDOUT
+                )
+            # If the process doesn't fail, we cannot test the string
+            # returned in the exception output. Since this should not
+            # happen, we fail here. If lcm is updated to return 0 when
+            # "--help" is called, this test will fail and will need to be
+            # updated.
+            self.fail(
+                "drake-lcm-spy execution passed instead of failing. Update test"  # noqa
+                )
+        except subprocess.CalledProcessError as e:
+            self.assertIn("usage: lcm-spy [options]", e.output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -248,7 +248,7 @@ for jar_file in %s; do
   fi
 done
 
-java %s
+java %s "$@"
 """ % (strclasspath, main_class)
         launcher_file.write(content)
     os.chmod(filename, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH |


### PR DESCRIPTION
When creating a java launcher, the install rule needs to know all the install
rules that it depends on that rename jars. Because of commit 6eca6e7 (libbot
removal), drake-lcm-spy was unaware of the fact that `liblcm-java.jar` and
`liblcmtypes_bot2-core-java.jar` were being renamed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7760)
<!-- Reviewable:end -->
