### PR TITLE
 Update osx toolchain to match C/C++ part of latest upstream toolchain

### DIFF
--- a/tools/cc_toolchain/BUILD
+++ b/tools/cc_toolchain/BUILD
@@ -48,7 +48,7 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
-# A compiler wrapper script that adjusts linker paths on OS X.
+# A compiler wrapper script that adjusts linker paths on macOS.
 filegroup(
     name = "osx_cc_wrapper",
     srcs = [
@@ -59,8 +59,15 @@ filegroup(
 )
 
 filegroup(
+    name = "osx_ar_wrapper",
+    srcs = ["osx_ar_wrapper.sh"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
     name = "apple_toolchain_deps",
     srcs = [
+        ":osx_ar_wrapper",
         ":osx_cc_wrapper",
         ":universal_toolchain_deps",
     ],

--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -3,7 +3,7 @@
 #
 # To extract the Bazel auto-generated toolchain stanza for a given platform:
 # - Run bazel build --crosstool_top=//external:cc_toolchain ...
-# - Inspect ./bazel-drake-distro/external/local_config_cc/CROSSTOOL
+# - Inspect ./bazel-drake/external/local_config_cc/CROSSTOOL
 # - Find the default_toolchain stanza for the cpu (k8 on Linux, darwin on OS X)
 # - Find the toolchain stanza with a target_cpu and toolchain_identifer that
 #   match the default_toolchain values.
@@ -14,6 +14,11 @@ default_target_cpu: "same_as_host"
 
 default_toolchain {
   cpu: "darwin"
+  toolchain_identifier: "osx"
+}
+
+default_toolchain {
+  cpu: "darwin_x86_64"
   toolchain_identifier: "osx"
 }
 
@@ -330,101 +335,933 @@ toolchain {
   linking_mode_flags { mode: DYNAMIC }
 }
 
-# Clang on OS X
+# Clang on macOS. To update, extract the C/C++ parts (https://git.io/vNCSg) of
+# the configured version of CROSSTOOL.tpl (https://git.io/vNCSb) which is
+# created in external/local_config_cc/CROSSTOOL for a local build.
+# TODO(jamiesnape): Write a script to extract the necessary fields
+# automatically.
 toolchain {
   toolchain_identifier: "osx"
-  abi_version: "local"
-  abi_libc_version: "local"
-  builtin_sysroot: ""
-  compiler: "compiler"
-  host_system_name: "local"
-  needsPic: true
-  target_libc: "macosx"
-  target_cpu: "darwin"
-  target_system_name: "local"
-
-  cxx_flag: "-std=c++1y"
-  linker_flag: "-lstdc++"
-  linker_flag: "-undefined"
-  linker_flag: "dynamic_lookup"
-  linker_flag: "-headerpad_max_install_names"
-  ar_flag: "-static"
-  ar_flag: "-s"
-  ar_flag: "-o"
   cxx_builtin_include_directory: "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
-  cxx_builtin_include_directory: "/Library/Developer/CommandLineTools"
   cxx_builtin_include_directory: "/usr/local/include"
   cxx_builtin_include_directory: "/usr/include"
   cxx_builtin_include_directory: "/System/Library/Frameworks"
   cxx_builtin_include_directory: "/Library/Frameworks"
+  cxx_builtin_include_directory: "/Applications/Xcode.app/Contents/Developer"
+  cxx_builtin_include_directory: "/Library/Developer/CommandLineTools"
+  host_system_name: "local"
+  target_system_name: "local"
+  target_cpu: "darwin"
+  target_libc: "local"
+  compiler: "compiler"
+  abi_version: "local"
+  abi_libc_version: "local"
+  tool_path { name: "ar" path: "osx_ar_wrapper.sh" }
+  tool_path { name: "compat-ld" path: "/usr/bin/ld" }
+  tool_path { name: "cpp" path: "/usr/bin/cpp" }
+  tool_path { name: "dwp" path: "/usr/bin/dwp" }
+  tool_path { name: "gcc" path: "osx_cc_wrapper.sh" }
+  tool_path { name: "gcov" path: "/usr/bin/gcov" }
+  tool_path { name: "ld" path: "/usr/bin/ld" }
+  tool_path { name: "nm" path: "/usr/bin/nm" }
+  tool_path { name: "objcopy" path: "/usr/bin/objcopy" }
+  tool_path { name: "objdump" path: "/usr/bin/objdump" }
+  tool_path { name: "strip" path: "/usr/bin/strip" }
+  needsPic: false
+  compiler_flag: "-D_FORTIFY_SOURCE=1"
+  compiler_flag: "-fstack-protector"
+  compiler_flag: "-fcolor-diagnostics"
+  compiler_flag: "-Wall"
+  compiler_flag: "-Wthread-safety"
+  compiler_flag: "-Wself-assign"
+  compiler_flag: "-fno-omit-frame-pointer"
+  cxx_flag: "-std=c++14"
+  linker_flag: "-headerpad_max_install_names"
+  linker_flag: "-lc++"
+  linker_flag: "-no-canonical-prefixes"
   objcopy_embed_flag: "-I"
   objcopy_embed_flag: "binary"
-
-  # Anticipated future default.
+  compilation_mode_flags {
+    mode: FASTBUILD
+    compiler_flag: "-O0"
+    compiler_flag: "-DDEBUG"
+  }
+  compilation_mode_flags {
+    mode: OPT
+    compiler_flag: "-g0"
+    compiler_flag: "-O2"
+    compiler_flag: "-D_FORTIFY_SOURCE=1"
+    compiler_flag: "-DNDEBUG"
+    compiler_flag: "-ffunction-sections"
+    compiler_flag: "-fdata-sections"
+  }
+  compilation_mode_flags {
+    mode: DBG
+    compiler_flag: "-g"
+  }
+  linking_mode_flags {
+    mode: DYNAMIC
+    linker_flag: "-undefined"
+    linker_flag: "dynamic_lookup"
+  }
+  builtin_sysroot: ""
   unfiltered_cxx_flag: "-no-canonical-prefixes"
-
-  # Make C++ compilation deterministic. Use linkstamping instead of these
-  # compiler symbols.
   unfiltered_cxx_flag: "-Wno-builtin-macro-redefined"
   unfiltered_cxx_flag: "-D__DATE__=\"redacted\""
   unfiltered_cxx_flag: "-D__TIMESTAMP__=\"redacted\""
   unfiltered_cxx_flag: "-D__TIME__=\"redacted\""
-
-  # Security hardening on by default.
-  # Conservative choice; -D_FORTIFY_SOURCE=2 may be unsafe in some cases.
-  compiler_flag: "-D_FORTIFY_SOURCE=1"
-  compiler_flag: "-fstack-protector"
-
-  # Enable coloring even if there's no attached terminal. Bazel removes the
-  # escape sequences if --nocolor is specified.
-  compiler_flag: "-fcolor-diagnostics"
-
-  # All warnings are enabled. Maybe enable -Werror as well?
-  compiler_flag: "-Wall"
-  # Enable a few more warnings that aren't part of -Wall.
-  compiler_flag: "-Wthread-safety"
-  compiler_flag: "-Wself-assign"
-
-  # Keep stack frames for debugging, even in opt mode.
-  compiler_flag: "-fno-omit-frame-pointer"
-
-  # Anticipated future default.
-  linker_flag: "-no-canonical-prefixes"
-
-  tool_path {name: "ld" path: "/usr/bin/ld" }
-  tool_path {name: "cpp" path: "/usr/bin/cpp" }
-  tool_path {name: "dwp" path: "/usr/bin/dwp" }
-  tool_path {name: "gcov" path: "/usr/bin/gcov" }
-  tool_path {name: "nm" path: "/usr/bin/nm" }
-  tool_path {name: "objcopy" path: "/usr/bin/objcopy" }
-  tool_path {name: "objdump" path: "/usr/bin/objdump" }
-  tool_path {name: "strip" path: "/usr/bin/strip" }
-  tool_path {name: "gcc" path: "osx_cc_wrapper.sh" }
-  tool_path {name: "ar" path: "/usr/bin/libtool" }
-
-  compilation_mode_flags {
-    mode: DBG
-    # Enable debug symbols.
-    compiler_flag: "-g"
+  default_python_version: "python2.7"
+  feature { name: "fastbuild" }
+  feature { name: "no_legacy_features" }
+  feature { name: "opt" }
+  feature { name: "dbg" }
+  feature { name: "has_configured_linker_path" }
+  feature {
+    name: "legacy_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "lto-backend"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "%{legacy_compile_flags}"
+        iterate_over: "legacy_compile_flags"
+      }
+      expand_if_all_available: "legacy_compile_flags"
+    }
   }
-  compilation_mode_flags {
-    mode: OPT
-    # No debug symbols.
-    # Maybe we should enable https://gcc.gnu.org/wiki/DebugFission for opt or even generally?
-    # However, that can't happen here, as it requires special handling in Bazel.
-    compiler_flag: "-g0"
-
-    # Conservative choice for -O
-    # -O3 can increase binary size and even slow down the resulting binaries.
-    # Profile first and / or use FDO if you need better performance than this.
-    compiler_flag: "-O2"
-
-    # Disable assertions
-    compiler_flag: "-DNDEBUG"
-
-    # Removal of unused code and data at link time (can this increase binary size in some cases?).
-    compiler_flag: "-ffunction-sections"
-    compiler_flag: "-fdata-sections"
+  feature {
+    name: "strip_debug_symbols"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-interface-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "-Wl,-S"
+        expand_if_all_available: "strip_debug_symbols"
+      }
+    }
   }
-  linking_mode_flags { mode: DYNAMIC }
+  feature {
+    name: "symbol_counts"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      flag_group { flag: "-Wl,--print-symbol-counts=%{symbol_counts_output}" }
+      expand_if_all_available: "symbol_counts_output"
+    }
+  }
+  feature {
+    name: "shared_flag"
+    flag_set {
+      action: "c++-link-dynamic-library"
+      flag_group { flag: "-shared" }
+    }
+  }
+  feature {
+    name: "linkstamps"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      flag_group {
+        flag: "%{linkstamp_paths}"
+        iterate_over: "linkstamp_paths"
+      }
+      expand_if_all_available: "linkstamp_paths"
+    }
+  }
+  feature {
+    name: "output_execpath_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      flag_group {
+        flag: "-o"
+        flag: "%{output_execpath}"
+      }
+      expand_if_all_available: "output_execpath"
+    }
+  }
+  feature {
+    name: "global_whole_archive_open"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group { flag: "-Wl,-all_load" }
+      expand_if_all_available: "global_whole_archive"
+    }
+  }
+  feature {
+    name: "archiver_flags"
+    flag_set {
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "rcs"
+        flag: "%{output_execpath}"
+      }
+      expand_if_all_available: "output_execpath"
+    }
+  }
+  feature {
+    name: "runtime_root_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}"
+        iterate_over: "runtime_library_search_directories"
+      }
+      expand_if_all_available: "runtime_library_search_directories"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "%{runtime_root_flags}"
+        iterate_over: "runtime_root_flags"
+      }
+      expand_if_all_available: "runtime_root_flags"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "%{runtime_root_entries}"
+        iterate_over: "runtime_root_entries"
+      }
+      expand_if_all_available: "runtime_root_entries"
+    }
+  }
+  feature {
+    name: "input_param_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "-L%{library_search_directories}"
+        iterate_over: "library_search_directories"
+      }
+      expand_if_all_available: "library_search_directories"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "%{libopts}"
+        iterate_over: "libopts"
+      }
+      expand_if_all_available: "libopts"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "-Wl,-force_load,%{whole_archive_linker_params}"
+        iterate_over: "whole_archive_linker_params"
+      }
+      expand_if_all_available: "whole_archive_linker_params"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag: "%{linker_input_params}"
+        iterate_over: "linker_input_params"
+      }
+      expand_if_all_available: "linker_input_params"
+    }
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group {
+        flag_group {
+          flag: "-Wl,--start-lib"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.object_files}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.object_files}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          iterate_over: "libraries_to_link.object_files"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag: "-Wl,--end-lib"
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "object_file"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "interface_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "static_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "-l%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,-l%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "dynamic_library"
+          }
+        }
+        flag_group {
+          flag_group {
+            flag: "-l:%{libraries_to_link.name}"
+            expand_if_false: "libraries_to_link.is_whole_archive"
+          }
+          flag_group {
+            flag: "-Wl,-force_load,-l:%{libraries_to_link.name}"
+            expand_if_true: "libraries_to_link.is_whole_archive"
+          }
+          expand_if_equal {
+            variable: "libraries_to_link.type"
+            value: "versioned_dynamic_library"
+          }
+        }
+        iterate_over: "libraries_to_link"
+      }
+      expand_if_all_available: "libraries_to_link"
+    }
+  }
+  feature {
+    name: "force_pic_flags"
+    flag_set {
+      action: "c++-link-executable"
+      flag_group { flag: "-Wl,-pie" }
+      expand_if_all_available: "force_pic"
+    }
+  }
+  feature {
+    name: "pch"
+    flag_set {
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-include"
+        flag: "%{pch_file}"
+      }
+    }
+  }
+  feature {
+    name: "includes"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "linkstamp-compile"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-include"
+        flag: "%{includes}"
+        iterate_over: "includes"
+        expand_if_all_available: "includes"
+      }
+    }
+    enabled: true
+  }
+  feature {
+    name: "include_paths"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "linkstamp-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-iquote"
+        flag: "%{quote_include_paths}"
+        iterate_over: "quote_include_paths"
+      }
+      flag_group {
+        flag: "-I%{include_paths}"
+        iterate_over: "include_paths"
+      }
+      flag_group {
+        flag: "-isystem"
+        flag: "%{system_include_paths}"
+        iterate_over: "system_include_paths"
+      }
+    }
+  }
+  feature {
+    name: "sysroot"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c++-header-preprocessing"
+      action: "c++-header-parsing"
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "linkstamp-compile"
+      action: "lto-backend"
+      flag_group { flag: "--sysroot=%{sysroot}" }
+      expand_if_all_available: "sysroot"
+    }
+  }
+  feature {
+    name: "dependency_file"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      action: "c++-header-preprocessing"
+      action: "c++-header-parsing"
+      flag_group {
+        flag: "-MD"
+        flag: "-MF"
+        flag: "%{dependency_file}"
+      }
+      expand_if_all_available: "dependency_file"
+    }
+  }
+  feature {
+    name: "random_seed"
+    flag_set {
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "c++-module-compile"
+      flag_group { flag: "-frandom-seed=%{output_file}" }
+    }
+  }
+  feature {
+    name: "pic"
+    flag_set {
+      action: "assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "c++-module-compile"
+      action: "linkstamp-compile"
+      action: "preprocess-assemble"
+      flag_group { flag: "-fPIC" }
+      expand_if_all_available: "pic"
+    }
+  }
+  feature {
+    name: "per_object_debug_info"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-codegen"
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "lto-backend"
+      flag_group { flag: "-gsplit-dwarf" }
+      expand_if_all_available: "per_object_debug_info_file"
+    }
+  }
+  feature {
+    name: "preprocessor_defines"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "linkstamp-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-D%{preprocessor_defines}"
+        iterate_over: "preprocessor_defines"
+      }
+    }
+  }
+  feature {
+    name: "fdo_instrument"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-link-interface-dynamic-library"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-executable"
+      flag_group {
+        flag: "-fprofile-generate=%{fdo_instrument_path}"
+        flag: "-fno-data-sections"
+      }
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "fdo_optimize"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-fprofile-use=%{fdo_profile_path}"
+        flag: "-Wno-profile-instr-unprofiled"
+        flag: "-Wno-profile-instr-out-of-date"
+        flag: "-fprofile-correction"
+      }
+      expand_if_all_available: "fdo_profile_path"
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "autofdo"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group {
+        flag: "-fauto-profile=%{fdo_profile_path}"
+        flag: "-fprofile-correction"
+      }
+      expand_if_all_available: "fdo_profile_path"
+    }
+    provides: "profile"
+  }
+  feature {
+    name: "lipo"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      flag_group { flag: "-fripa" }
+    }
+    requires { feature: "autofdo" }
+    requires { feature: "fdo_optimize" }
+    requires { feature: "fdo_instrument" }
+  }
+  feature { name: "coverage" }
+  feature {
+    name: "llvm_coverage_map_format"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "-fprofile-instr-generate"
+        flag: "-fcoverage-mapping"
+        flag: "-g"
+      }
+    }
+    flag_set {
+      action: "c++-link-interface-dynamic-library"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-executable"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group { flag: "-fprofile-instr-generate" }
+    }
+    requires { feature: "coverage" }
+    provides: "profile"
+  }
+  feature {
+    name: "gcc_coverage_map_format"
+    flag_set {
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        expand_if_all_available: "gcov_gcno_file"
+        flag: "-fprofile-arcs"
+        flag: "-ftest-coverage"
+        flag: "-g"
+      }
+    }
+    flag_set {
+      action: "c++-link-interface-dynamic-library"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-executable"
+      flag_group { flag: "-lgcov" }
+    }
+    requires { feature: "coverage" }
+    provides: "profile"
+  }
+  feature {
+    name: "legacy_link_flags"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "%{legacy_link_flags}"
+        iterate_over: "legacy_link_flags"
+      }
+      expand_if_all_available: "legacy_link_flags"
+    }
+  }
+  feature {
+    name: "dead_strip"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "objc-executable"
+      action: "objc++-executable"
+      flag_group {
+        flag: "--dead_strip"
+        flag: "--no_dead_strip_inits_and_terms"
+      }
+    }
+    requires { feature: "opt" }
+  }
+  feature { name: "cpp_linker_flags" }
+  feature { name: "unfiltered_cxx_flags" }
+  feature {
+    name: "user_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "linkstamp-compile"
+      action: "lto-backend"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "%{user_compile_flags}"
+        iterate_over: "user_compile_flags"
+      }
+      expand_if_all_available: "user_compile_flags"
+    }
+  }
+  feature {
+    name: "unfiltered_compile_flags"
+    flag_set {
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "linkstamp-compile"
+      action: "lto-backend"
+      action: "objc-compile"
+      action: "objc++-compile"
+      flag_group {
+        flag: "%{unfiltered_compile_flags}"
+        iterate_over: "unfiltered_compile_flags"
+      }
+      expand_if_all_available: "unfiltered_compile_flags"
+    }
+  }
+  feature {
+    name: "linker_param_file"
+    flag_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      flag_group { flag: "-Wl,@%{linker_param_file}" }
+      expand_if_all_available: "linker_param_file"
+    }
+    flag_set {
+      action: "c++-link-static-library"
+      action: "c++-link-alwayslink-static-library"
+      action: "c++-link-pic-static-library"
+      action: "c++-link-alwayslink-pic-static-library"
+      flag_group { flag: "@%{linker_param_file}" }
+      expand_if_all_available: "linker_param_file"
+    }
+  }
+  action_config {
+    config_name: "strip"
+    action_name: "strip"
+    tool { tool_path: "/usr/bin/strip" }
+    flag_set {
+      flag_group {
+        flag: "-S"
+        flag: "-o"
+        flag: "%{output_file}"
+      }
+      flag_group {
+        flag: "%{stripopts}"
+        iterate_over: "stripopts"
+      }
+      flag_group { flag: "%{input_file}" }
+    }
+  }
+  action_config {
+    config_name: "c-compile"
+    action_name: "c-compile"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "c++-compile"
+    action_name: "c++-compile"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "linkstamp-compile"
+    action_name: "linkstamp-compile"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "c++-module-compile"
+    action_name: "c++-module-compile"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "c++-header-parsing"
+    action_name: "c++-header-parsing"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "c++-header-preprocessing"
+    action_name: "c++-header-preprocessing"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "assemble"
+    action_name: "assemble"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "preprocess-assemble"
+    action_name: "preprocess-assemble"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "preprocessor_defines"
+    implies: "legacy_compile_flags"
+    implies: "user_compile_flags"
+    implies: "sysroot"
+    implies: "unfiltered_compile_flags"
+  }
+  action_config {
+    config_name: "c++-link-executable"
+    action_name: "c++-link-executable"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "symbol_counts"
+    implies: "linkstamps"
+    implies: "output_execpath_flags"
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "input_param_flags"
+    implies: "force_pic_flags"
+    implies: "legacy_link_flags"
+    implies: "strip_debug_symbols"
+    implies: "linker_param_file"
+    implies: "sysroot"
+  }
+  action_config {
+    config_name: "c++-link-dynamic-library"
+    action_name: "c++-link-dynamic-library"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "has_configured_linker_path"
+    implies: "symbol_counts"
+    implies: "shared_flag"
+    implies: "linkstamps"
+    implies: "output_execpath_flags"
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "input_param_flags"
+    implies: "legacy_link_flags"
+    implies: "strip_debug_symbols"
+    implies: "linker_param_file"
+    implies: "sysroot"
+  }
+  action_config {
+    config_name: "c++-link-static-library"
+    action_name: "c++-link-static-library"
+    tool { tool_path: "osx_ar_wrapper.sh" }
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "archiver_flags"
+    implies: "input_param_flags"
+    implies: "linker_param_file"
+  }
+  action_config {
+    config_name: "c++-link-alwayslink-static-library"
+    action_name: "c++-link-alwayslink-static-library"
+    tool { tool_path: "osx_ar_wrapper.sh" }
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "archiver_flags"
+    implies: "input_param_flags"
+    implies: "linker_param_file"
+  }
+  action_config {
+    config_name: "c++-link-pic-static-library"
+    action_name: "c++-link-pic-static-library"
+    tool { tool_path: "osx_ar_wrapper.sh" }
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "archiver_flags"
+    implies: "input_param_flags"
+    implies: "linker_param_file"
+  }
+  action_config {
+    config_name: "c++-link-alwayslink-pic-static-library"
+    action_name: "c++-link-alwayslink-pic-static-library"
+    tool { tool_path: "osx_ar_wrapper.sh" }
+    implies: "global_whole_archive_open"
+    implies: "runtime_root_flags"
+    implies: "archiver_flags"
+    implies: "input_param_flags"
+    implies: "linker_param_file"
+  }
+  action_config {
+    config_name: "c++-link-interface-dynamic-library"
+    action_name: "c++-link-interface-dynamic-library"
+    tool { tool_path: "osx_cc_wrapper.sh" }
+    implies: "strip_debug_symbols"
+  }
+  cc_target_os: "apple"
 }

--- a/tools/cc_toolchain/osx_ar_wrapper.sh
+++ b/tools/cc_toolchain/osx_ar_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Ensure zero timestamping for hermetic results.
+export ZERO_AR_DATE=1
+/usr/bin/ar "$@"


### PR DESCRIPTION
Relates in part to https://github.com/RobotLocomotion/drake-shambhala/issues/78. Also significantly improves #5183.

The amount of code in the new `CROSSTOOL` really does illustrate the difficulty of using a custom toolchain while they update the format of the `CROSSTOOL` file in upstream bazel. Basically, the current situation is that some of the build settings use the legacy format and some use the new feature/action-based format. Bazel does attempt to generate various parts of the new format from the old, but it is not perfect on macOS. Hence, our macOS toolchain was both out-of-date and internally inconsistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7761)
<!-- Reviewable:end -->
