### PR TITLE
Provide a diagnostic when a command fails

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -6,10 +6,18 @@ set -euo pipefail
 
 die () {
     echo "$@" 1>&2
+    trap : EXIT  # Disable line number reporting; the "$@" message is enough.
     exit 1
 }
 
+at_exit () {
+    echo "${me} has experienced an error on line ${LINENO}" \
+        "while running the command ${BASH_COMMAND}"
+}
+
 me="The Drake prerequisite set-up script"
+
+trap at_exit EXIT
 
 [[ "${EUID}" -eq 0 ]] || die "${me} must run as root. Please use sudo."
 
@@ -187,4 +195,5 @@ if [ -L /usr/lib/ccache/bazel ]; then
   apt purge ccache-bazel-wrapper
 fi
 
+trap : EXIT  # Disable exit reporting.
 echo "install_prereqs: success"


### PR DESCRIPTION
Without this, commands that fail sliently like the "curl | apt-key" pipe might leave the user thinking that everything passed.

Fixes #7724.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7768)
<!-- Reviewable:end -->
