### PR TITLE
Add static option to pkg_config_repository

### DIFF
--- a/tools/lint/buildifier-tables.json
+++ b/tools/lint/buildifier-tables.json
@@ -43,6 +43,7 @@
     "new_local_repository.build_file_content":  360,
 
     "pkg_config_repository.atleast_version": 200,
+    "pkg_config_repository.static":          201,
     "pkg_config_repository.extra_srcs":      300,
     "pkg_config_repository.extra_hdrs":      301,
     "pkg_config_repository.extra_copts":     302,

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -16,6 +16,12 @@ load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "linux",
+    values = {"cpu": "k8"},
+    visibility = ["//visibility:private"],
+)
+
 # Generate header to provide ABI export symbols for LCM.
 generate_export_header(
     out = "lcm/lcm_export.h",
@@ -86,6 +92,10 @@ cc_binary(
     ] + LCM_PUBLIC_HEADERS,
     copts = LCM_COPTS,
     includes = LCM_PUBLIC_HEADER_INCLUDES,
+    linkopts = select({
+        ":linux": ["-pthread"],  # For lcm_(mp)udpm.c.
+        "@//conditions:default": [],
+    }),
     linkshared = 1,
     visibility = [],
     deps = ["@glib"],


### PR DESCRIPTION
Fixes #7764.

This sets the default to `static = 0`, which seems to be the correct setting everywhere that we currently use the rule, but I can easily change that to the previous behavior if preferred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7770)
<!-- Reviewable:end -->
