### PR TITLE
Add polynomial::EvaluatePartial

### DIFF
--- a/common/symbolic_monomial.cc
+++ b/common/symbolic_monomial.cc
@@ -149,7 +149,7 @@ double Monomial::Evaluate(const Environment& env) const {
                     });
 }
 
-pair<double, Monomial> Monomial::Substitute(const Environment& env) const {
+pair<double, Monomial> Monomial::EvaluatePartial(const Environment& env) const {
   double coeff{1.0};
   map<Variable, int> new_powers;
   for (const auto& p : powers_) {

--- a/common/symbolic_monomial.h
+++ b/common/symbolic_monomial.h
@@ -67,21 +67,20 @@ class Monomial {
    */
   double Evaluate(const Environment& env) const;
 
-  /** Substitutes using a given environment @p env. The substitution result is
-   * of type pair<double, Monomial>. The first component (: double) represents
-   * the coefficient part while the second component represents the remaining
-   * parts of the Monomial which was not substituted. Note that users are
-   * allowed to provide a partial environment.
+  /** Partially evaluates using a given environment @p env. The evaluation
+   * result is of type pair<double, Monomial>. The first component (: double)
+   * represents the coefficient part while the second component represents the
+   * remaining parts of the Monomial which was not evaluated.
    *
-   * Example 1. Substitution with a fully-specified environment
-   *     (x^3*y^2).Substitute({{x, 2}, {y, 3}})
-   *   = (2^3 * 3^2 = 8 * 9 = 72, Monomial{} = 1).
+   * Example 1. Evaluate with a fully-specified environment
+   *     (x³*y²).EvaluatePartial({{x, 2}, {y, 3}})
+   *   = (2³ * 3² = 8 * 9 = 72, Monomial{} = 1).
    *
-   * Example 1. Substitution with a partial environment
-   *     (x^3*y^2).Substitute({{x, 2}})
-   *   = (2^3 = 8, y^2).
+   * Example 2. Evaluate with a partial environment
+   *     (x³*y²).EvaluatePartial({{x, 2}})
+   *   = (2³ = 8, y²).
    */
-  std::pair<double, Monomial> Substitute(const Environment& env) const;
+  std::pair<double, Monomial> EvaluatePartial(const Environment& env) const;
 
   /** Returns a symbolic expression representing this monomial. */
   Expression ToExpression() const;

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -105,6 +105,17 @@ class Polynomial {
   /// assignment is not provided by @p env.
   double Evaluate(const Environment& env) const;
 
+  /// Partially evaluates this polynomial using an environment @p env.
+  ///
+  /// @throws std::runtime_error if NaN is detected during evaluation.
+  Polynomial EvaluatePartial(const Environment& env) const;
+
+  /// Partially evaluates this polynomial by substituting @p var with @p c.
+  ///
+  /// @throws std::runtime_error if NaN is detected at any point during
+  /// evaluation.
+  Polynomial EvaluatePartial(const Variable& var, double c) const;
+
   /// Adds @p coeff * @p m to this polynomial.
   Polynomial& AddProduct(const Expression& coeff, const Monomial& m);
 

--- a/common/test/symbolic_monomial_test.cc
+++ b/common/test/symbolic_monomial_test.cc
@@ -90,28 +90,26 @@ class MonomialTest : public ::testing::Test {
     return result1 == result2;
   }
 
-  // Checks if Monomial::Substitute corresponds to Expression::Substitute.
+  // Checks if Monomial::EvaluatePartial corresponds to Expression's
+  // EvaluatePartial.
   //
   //                            ToExpression
   //                   Monomial ------------> Expression
   //                      ||                      ||
-  // Monomial::Substitute ||                      || Expression::Substitute
+  //      EvaluatePartial ||                      || EvaluatePartial
   //                      ||                      ||
   //                      \/                      \/
   //          double * Monomial (e2)   ==   Expression (e1)
   //
   // In one direction (left-to-right), first we convert a Monomial to an
-  // Expression using Monomial::ToExpression and call Expression::Substitution
-  // to have an Expression (e1). In another direction (top-to-bottom), we call
-  // Monomial::Substitution which returns a pair of double (coefficient part)
-  // and Monomial. We obtain e2 by multiplying the two. Then, we check if e1 and
-  // e2 are structurally equal.
-  bool CheckSubstitute(const Monomial& m, const Environment& env) {
-    const Substitution subst{ExtractSubst(env)};
-
-    const Expression e1{m.ToExpression().Substitute(subst)};
-
-    const pair<double, Monomial> subst_result{m.Substitute(env)};
+  // Expression using Monomial::ToExpression and call
+  // Expression::EvaluatePartial to have an Expression (e1). In another
+  // direction (top-to-bottom), we call Monomial::EvaluatePartial which returns
+  // a pair of double (coefficient part) and Monomial. We obtain e2 by
+  // multiplying the two. Then, we check if e1 and e2 are structurally equal.
+  bool CheckEvaluatePartial(const Monomial& m, const Environment& env) {
+    const Expression e1{m.ToExpression().EvaluatePartial(env)};
+    const pair<double, Monomial> subst_result{m.EvaluatePartial(env)};
     const Expression e2{subst_result.first *
                         subst_result.second.ToExpression()};
 
@@ -585,7 +583,7 @@ TEST_F(MonomialTest, EvaluateException) {
   EXPECT_THROW(m.Evaluate(env), runtime_error);
 }
 
-TEST_F(MonomialTest, Substitute) {
+TEST_F(MonomialTest, EvaluatePartial) {
   const vector<Environment> environments{
       {{var_x_, 2.0}},
       {{var_y_, 3.0}},
@@ -597,7 +595,7 @@ TEST_F(MonomialTest, Substitute) {
   };
   for (const Monomial m : monomials_) {
     for (const Environment env : environments) {
-      EXPECT_TRUE(CheckSubstitute(m, env));
+      EXPECT_TRUE(CheckEvaluatePartial(m, env));
     }
   }
 }

--- a/common/test/symbolic_polynomial_test.cc
+++ b/common/test/symbolic_polynomial_test.cc
@@ -719,6 +719,47 @@ TEST_F(SymbolicPolynomialTest, Evaluate) {
   }};
   EXPECT_THROW(p.Evaluate(partial_env), runtime_error);
 }
+
+TEST_F(SymbolicPolynomialTest, PartialEvaluate1) {
+  // p1 = a*x² + b*x + c
+  // p2 = p1[x ↦ 3.0] = 3²a + 3b + c.
+  const Polynomial p1{a_ * x_ * x_ + b_ * x_ + c_, var_xyz_};
+  const Polynomial p2{a_ * 3.0 * 3.0 + b_ * 3.0 + c_, var_xyz_};
+  const Environment env{{{var_x_, 3.0}}};
+  EXPECT_PRED2(PolyEqual, p1.EvaluatePartial(env), p2);
+  EXPECT_PRED2(PolyEqual, p1.EvaluatePartial(var_x_, 3.0), p2);
+}
+
+TEST_F(SymbolicPolynomialTest, PartialEvaluate2) {
+  // p1 = a*xy² - a*xy + c
+  // p2 = p1[y ↦ 2.0] = (4a - 2a)*x + c = 2ax + c
+  const Polynomial p1{a_ * x_ * y_ * y_ - a_ * x_ * y_ + c_, var_xyz_};
+  const Polynomial p2{2 * a_ * x_ + c_, var_xyz_};
+  const Environment env{{{var_y_, 2.0}}};
+  EXPECT_PRED2(PolyEqual, p1.EvaluatePartial(env), p2);
+  EXPECT_PRED2(PolyEqual, p1.EvaluatePartial(var_y_, 2.0), p2);
+}
+
+TEST_F(SymbolicPolynomialTest, PartialEvaluate3) {
+  // p1 = a*x² + b*x + c
+  // p2 = p1[a ↦ 2.0, x ↦ 3.0] = 2*3² + 3b + c
+  //                           = 18 + 3b + c
+  const Polynomial p1{a_ * x_ * x_ + b_ * x_ + c_, var_xyz_};
+  const Polynomial p2{18 + 3 * b_ + c_, var_xyz_};
+  const Environment env{{{var_a_, 2.0}, {var_x_, 3.0}}};
+  EXPECT_PRED2(PolyEqual, p1.EvaluatePartial(env), p2);
+}
+
+TEST_F(SymbolicPolynomialTest, PartialEvaluate4) {
+  // p = (a + c / b + c)*x² + b*x + c
+  //
+  // Partially evaluating p with [a ↦ 0, b ↦ 0, c ↦ 0] throws `runtime_error`
+  // because of the divide-by-zero
+  const Polynomial p{((a_ + c_) / (b_ + c_)) * x_ * x_ + b_ * x_ + c_,
+                     var_xyz_};
+  const Environment env{{{var_a_, 0.0}, {var_b_, 0.0}, {var_c_, 0.0}}};
+  EXPECT_THROW(p.EvaluatePartial(env), runtime_error);
+}
 }  // namespace
 }  // namespace symbolic
 }  // namespace drake


### PR DESCRIPTION
Closes #7771 

 - The first commit renames `Monomial::Substitute` to `Monomial::EvaluatePartial` to be consistent with other symbolic classes.
 - The second commit provides `polynomial::EvaluatePartial`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7780)
<!-- Reviewable:end -->
