### PR TITLE
drake_proto: Simplify ubsan fix implementation.

### DIFF
--- a/tools/skylark/BUILD.bazel
+++ b/tools/skylark/BUILD.bazel
@@ -4,6 +4,11 @@ package(default_visibility = ["//visibility:public"])
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+py_binary(
+    name = "drake_proto_ubsan_fix",
+    srcs = ["drake_proto_ubsan_fix.py"],
+)
+
 exports_files([
     "py_env_runner.py",
 ])

--- a/tools/skylark/drake_proto.bzl
+++ b/tools/skylark/drake_proto.bzl
@@ -7,8 +7,7 @@ load(
 )
 load(
     "@drake//tools/skylark:drake_cc.bzl",
-    "drake_installed_headers",
-    "installed_headers_for_drake_deps",
+    "drake_cc_library",
 )
 load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 
@@ -32,16 +31,19 @@ def drake_cc_proto_library(
         outs = pb_srcs + pb_hdrs,
         visibility = ["//visibility:public"],
     )
+    # Apply ubsan fixups.
     pb_ubsan_fixups = [x[:-len(".proto")] + "_ubsan_fixup.pb.cc" for x in srcs]
+    tool = "//tools/skylark:drake_proto_ubsan_fix"
     native.genrule(
         name = name + "_ubsan_fixup",
         srcs = pb_srcs,
         outs = pb_ubsan_fixups,
-        cmd = "for src in $(SRCS) ; do awk '/#include <google\/protobuf\/generated_message_reflection.h>/{print;print \"#include \\\"drake/common/proto/protobuf-ubsan-fixup.h\\\"\";next}1' $$src > $${src%??????}_ubsan_fixup.pb.cc ; done",  # noqa
+        tools = [tool],
+        cmd = "$(location {tool}) '$(SRCS)' '$(OUTS)'".format(tool = tool),
     )
-    # Compile the cc file using standard include paths.
-    native.cc_library(
-        name = name + "_genproto_compile",
+    # Compile the cc files.
+    drake_cc_library(
+        name = name,
         srcs = pb_ubsan_fixups,
         hdrs = pb_hdrs,
         tags = tags + ["nolint"],
@@ -50,31 +52,6 @@ def drake_cc_proto_library(
             "@drake//common/proto:protobuf_ubsan_fixup",
         ],
         **kwargs)
-    # Provide a library with drake-modified include paths, depending on the
-    # already-compiled object code.  (We can't compile the .cc file using the
-    # drake-modified include paths.)
-    if native.package_name().startswith("drake"):
-        strip_include_prefix = None
-        include_prefix = None
-    else:
-        # Require include paths like "drake/foo/bar.h", not "foo/bar.h".
-        strip_include_prefix = "/"
-        include_prefix = "drake"
-    native.cc_library(
-        name = name,
-        hdrs = pb_hdrs,
-        tags = tags + ["nolint"],
-        strip_include_prefix = strip_include_prefix,
-        include_prefix = include_prefix,
-        deps = [name + "_genproto_compile"],
-        **kwargs)
-    # Install the header file.
-    drake_installed_headers(
-        name = name + ".installed_headers",
-        hdrs = pb_hdrs,
-        deps = installed_headers_for_drake_deps(deps),
-        tags = ["nolint"],
-    )
 
 def drake_py_proto_library(
         name,

--- a/tools/skylark/drake_proto_ubsan_fix.py
+++ b/tools/skylark/drake_proto_ubsan_fix.py
@@ -1,0 +1,34 @@
+"""Applies fixes to protobuf-generated files to address ubsan errors. """
+
+import re
+import sys
+
+
+def fixup(src, out):
+    insert_after = '#include <google/protobuf/generated_message_reflection.h>'
+    insert_text = '\n#include "drake/common/proto/protobuf-ubsan-fixup.h"'
+
+    with open(src, 'r') as fsrc, open(out, 'w') as fout:
+        text = fsrc.read()
+        # Ensure local includes are prefixed with 'drake'.
+        text = re.sub(
+            r'^#include "',
+            r'#include "drake/',
+            text, flags=re.MULTILINE)
+        # Insert fixup header.
+        text = re.sub(
+            '(' + re.escape(insert_after) + ')',
+            r'\1' + insert_text,
+            text)
+        fout.write(text)
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 3
+    # Simplify argument parsing by taking all files separated by spaces.
+    srcs = sys.argv[1].split()
+    outs = sys.argv[2].split()
+    assert len(srcs) == len(outs), (
+        "Must supply outputs in the same order and number as outputs")
+    for src, out in zip(srcs, outs):
+        fixup(src, out)


### PR DESCRIPTION
Ran into this when prototyping on #7616.

This simplifies the `ubsan` fixups by ensuring that local includes are prefixed with `drake`, such that we can use `drake_cc_library` rather than duplicate the code.
I'm not terribly familiar with `awk`, and tried using `sed` with multiple scripts, but Mac's `sed -E` has awkward line escaping [shenanigans](http://nlfiedler.github.io/2010/12/05/newlines-in-sed-on-mac.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7782)
<!-- Reviewable:end -->
