### PR TITLE
Add Python binding for RigidBody.get_center_of_mass()

### DIFF
--- a/bindings/pydrake/rbtree_py.cc
+++ b/bindings/pydrake/rbtree_py.cc
@@ -192,7 +192,8 @@ PYBIND11_MODULE(_rbtree_py, m) {
 
   py::class_<RigidBody<double> >(m, "RigidBody")
     .def("get_name", &RigidBody<double>::get_name)
-    .def("get_body_index", &RigidBody<double>::get_body_index);
+    .def("get_body_index", &RigidBody<double>::get_body_index)
+    .def("get_center_of_mass", &RigidBody<double>::get_center_of_mass);
 
   py::class_<RigidBodyFrame<double>,
              std::shared_ptr<RigidBodyFrame<double> > >(m, "RigidBodyFrame")

--- a/bindings/pydrake/test/rbt_com_test.py
+++ b/bindings/pydrake/test/rbt_com_test.py
@@ -18,6 +18,17 @@ class TestRBTCoM(unittest.TestCase):
 
         self.assertTrue(np.allclose(c.flat, [0.0, 0.0, -0.2425], atol=1e-4))
 
+    def testCoMBody(self):
+        r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(),
+                                         "examples/pendulum/Pendulum.urdf"))
+
+        kinsol = r.doKinematics(np.zeros((7, 1)), np.zeros((7, 1)))
+
+        arm_com = r.FindBody("arm_com")
+        c = arm_com.get_center_of_mass()
+
+        self.assertTrue(np.allclose(c.flat, [0.0, 0.0, -0.5], atol=1e-4))
+
     def testCoMJacobian(self):
         r = pydrake.rbtree.RigidBodyTree(os.path.join(pydrake.getDrakePath(),
                                          "examples/pendulum/Pendulum.urdf"))


### PR DESCRIPTION
@EricCousineau-TRI (though I wouldn't be surprised if you already have this in a staged PR...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7795)
<!-- Reviewable:end -->
