### PR TITLE
In vector_gen, don't call clang-format on stdin

### DIFF
--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -629,16 +629,17 @@ def generate_code(
                                                       field['doc']), 1)
             put(lcm, LCMTYPE_POSTAMBLE % context, 1)
 
-    # Run clang-format over all C++ files.  Instead copying the clang-format
-    # settings file into place (which is problematic when writing to
-    # bazel-genfiles), we pass its contents on the command line instead.
-    with open(find_data(".clang-format"), "r") as f:
-        yaml_data = yaml.load(f, Loader=yaml.Loader)
-        style = str(yaml_data)
-        # For some reason, clang-format really wants lowercase for booleans.
-        style = style.replace("False", "false").replace("True", "true")
-    subprocess.check_call([
-        get_clang_format_path(), "--style=" + style, "-i"] + cxx_names)
+    if cxx_names:
+        # Run clang-format over all C++ files.  Inserting a .clang-format
+        # settings file is problematic when formatting within bazel-genfiles,
+        # so instead we pass its contents on the command line.
+        with open(find_data(".clang-format"), "r") as f:
+            yaml_data = yaml.load(f, Loader=yaml.Loader)
+            style = str(yaml_data)
+            # For some reason, clang-format really wants lowercase booleans.
+            style = style.replace("False", "false").replace("True", "true")
+        subprocess.check_call(
+            [get_clang_format_path(), "--style=" + style, "-i"] + cxx_names)
 
 
 def generate_all_code(srcs, outs):


### PR DESCRIPTION
By asking for "inplace" but not listing any files, `clang-format` is sad.  In this case on macOS, it prints an annoying warning.

Fixes #7803.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7806)
<!-- Reviewable:end -->
