### PR TITLE
Use shared library for fmt

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -979,12 +979,7 @@ drake_py_test(
 drake_py_test(
     name = "resource_tool_installed_test",
     srcs = ["test/resource_tool_installed_test.py"],
-    args = [
-        "$(location :install)",
-    ],
-    data = [
-        ":install",
-    ],
+    deps = ["//tools/install:install_test_helper"],
 )
 
 # TODO(jwnimmer-tri) These tests are currently missing...

--- a/common/test/resource_tool_installed_test.py
+++ b/common/test/resource_tool_installed_test.py
@@ -2,38 +2,23 @@
 """
 
 import os
-import shutil
 import subprocess
-import sys
 import unittest
-
-
-# Set on command-line to the location of common/install.
-_install_exe = None
+import install_test_helper
 
 
 class TestResourceTool(unittest.TestCase):
     def test_install_and_run(self):
         # Install into a temporary directory.
-        os.mkdir("tmp")
-        subprocess.check_call(
-            [_install_exe,
-             os.path.abspath("tmp"),
-             ])
+        result = install_test_helper.install("tmp", ["libexec"])
+        self.assertEqual(None, result)
 
         # Create a resource in the temporary directory.
         os.makedirs("tmp/share/drake/common/test")
         with open("tmp/share/drake/common/test/tmp_resource", "w") as f:
             f.write("tmp_resource")
 
-        # Remove the un-installed copy, so we _know_ it won't be used.
-        content_test_folder = os.listdir(os.getcwd())
-        content_test_folder.remove("tmp")
-        for element in content_test_folder:
-            if os.path.isdir(element):
-                shutil.rmtree(element)
-            else:
-                os.remove(element)
+        # Verify un-installed copy was removed, so we _know_ it won't be used.
         self.assertEqual(os.listdir(os.getcwd()), ["tmp"])
 
         # Cross-check the resource root environment variable name.
@@ -73,5 +58,4 @@ class TestResourceTool(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    _install_exe = sys.argv.pop(1)
     unittest.main()

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -118,6 +118,7 @@ cc_library(
         ":vtk_deps",
         "@bullet//:BulletCollision",
         "@dreal",
+        "@fmt",
         "@ignition_math",
         "@ignition_rndf",
         "@lcm",

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -21,11 +21,6 @@
       "Hints": ["@prefix@/lib/cmake/eigen3"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "fmt": {
-      "Version": "3.0.1",
-      "Hints": ["@prefix@/lib/cmake/fmt"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "ignition-math4": {
       "Version": "4.0.0",
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -11,11 +11,23 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+FMT_HDRS = glob(["fmt/*.h"])
+
+FMT_INCLUDES = ["."]
+
+cc_binary(
+    name = "libfmt.so",
+    srcs = glob(["fmt/*.cc"]) + FMT_HDRS,
+    includes = FMT_INCLUDES,
+    linkshared = 1,
+    visibility = ["//visibility:private"],
+)
+
 cc_library(
     name = "fmt",
-    srcs = glob(["fmt/*.cc"]),
-    hdrs = glob(["fmt/*.h"]),
-    includes = ["."],
+    srcs = ["libfmt.so"],
+    hdrs = FMT_HDRS,
+    includes = FMT_INCLUDES,
 )
 
 CMAKE_PACKAGE = "fmt"
@@ -31,7 +43,8 @@ install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
-    targets = [":fmt"],
+    targets = [":libfmt.so"],
+    hdrs = FMT_HDRS,
     hdr_dest = "include/" + CMAKE_PACKAGE,
     guess_hdrs = "PACKAGE",
     docs = ["LICENSE.rst"],


### PR DESCRIPTION
Note here, `fmt` is used by `spdlog` and indirectly by `drake`.

`resource_tool_installed_test` had to be refactored otherwise `libfmt.so` on which `resource_tool` relies would not be installed. Conflicts with #7774.
<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7807)
<!-- Reviewable:end -->
