### PR TITLE
Do not generate lcmtypes C libraries

### DIFF
--- a/tools/workspace/lcm/lcm.bzl
+++ b/tools/workspace/lcm/lcm.bzl
@@ -200,54 +200,6 @@ def lcm_cc_library(
     # We report the computed output filenames for use by calling code.
     return struct(hdrs = outs)
 
-def lcm_c_library(
-        name,
-        lcm_srcs,
-        lcm_package,
-        lcm_structs = None,
-        aggregate_hdr = "AUTO",
-        aggregate_hdr_strip_prefix = ["**/include/"],
-        includes = [],
-        **kwargs):
-    """Declares a cc_library on message C structs generated from ``*.lcm``
-    files.
-
-    The required ``lcm_srcs`` :obj:`list` parameter specifies the ``*.lcm``
-    source files. All ``lcm_srcs`` must reside in the same subdirectory.
-
-    The standard parameters (``lcm_srcs``, ``lcm_package``, ``lcm_structs``,
-    ``aggregate_hdr_strip_prefix``) are documented in :func:`lcm_cc_library`.
-    The ``aggregate_hdr`` parameter default value is ``AUTO``.
-    """
-    outs = _lcm_outs(lcm_srcs, lcm_package, lcm_structs, ".h")
-
-    _lcm_library_gen(
-        name = name + "_lcm_library_gen",
-        language = "c",
-        lcm_srcs = lcm_srcs,
-        lcm_package = lcm_package,
-        outs = outs.hdrs + outs.srcs)
-
-    hdrs = outs.hdrs
-    if aggregate_hdr:
-        hdrs += _lcm_aggregate_hdr(
-            lcm_package,
-            name,
-            aggregate_hdr,
-            outs.hdrs,
-            "h",
-            aggregate_hdr_strip_prefix)
-
-    deps = depset(kwargs.pop('deps', [])) | ["@lcm"]
-    includes = depset(includes) | ["."]
-    native.cc_library(
-        name = name,
-        srcs = outs.srcs,
-        hdrs = hdrs,
-        deps = deps,
-        includes = includes,
-        **kwargs)
-
 def lcm_py_library(
         name,
         lcm_srcs = None,

--- a/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
@@ -10,7 +10,6 @@ load(
 )
 load(
     "@drake//tools/workspace/lcm:lcm.bzl",
-    "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
     "lcm_py_library",
@@ -23,14 +22,6 @@ LCM_STRUCTS = [
     f.replace("lcmtypes/bot_core_", "").replace(".lcm", "")
     for f in LCM_SRCS
 ]
-
-lcm_c_library(
-    name = "lcmtypes_bot2_core_c",
-    includes = ["lcmtypes"],
-    lcm_package = "bot_core",
-    lcm_srcs = LCM_SRCS,
-    lcm_structs = LCM_STRUCTS,
-)
 
 lcm_cc_library(
     name = "lcmtypes_bot2_core",
@@ -75,7 +66,6 @@ install(
     workspace = CMAKE_PACKAGE,
     targets = [
         ":lcmtypes_bot2_core",
-        ":lcmtypes_bot2_core_c",
         ":lcmtypes_bot2_core_java",
         ":lcmtypes_bot2_core_py",
     ],

--- a/tools/workspace/lcmtypes_bot2_core/package.cps
+++ b/tools/workspace/lcmtypes_bot2_core/package.cps
@@ -11,12 +11,6 @@
   },
   "Default-Components": [":lcmtypes_bot2-core-cpp"],
   "Components": {
-    "lcmtypes_bot2-core": {
-      "Type": "dylib",
-      "Includes": ["@prefix@/include/lcmtypes"],
-      "Location": "@prefix@/lib/liblcmtypes_bot2_core_c.so",
-      "Requires": ["lcm:lcm-coretypes"]
-    },
     "lcmtypes_bot2-core-cpp": {
       "Type": "interface",
       "Includes": ["@prefix@/include/lcmtypes"],

--- a/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
@@ -10,21 +10,12 @@ load(
 )
 load(
     "@drake//tools/workspace/lcm:lcm.bzl",
-    "lcm_c_library",
     "lcm_cc_library",
     "lcm_java_library",
     "lcm_py_library",
 )
 
 LCM_SRCS = glob(["lcmtypes/*.lcm"])
-
-lcm_c_library(
-    name = "lcmtypes_robotlocomotion_c",
-    includes = ["lcmtypes"],
-    lcm_package = "robotlocomotion",
-    lcm_srcs = LCM_SRCS,
-    deps = ["@lcmtypes_bot2_core//:lcmtypes_bot2_core_c"],
-)
 
 lcm_cc_library(
     name = "lcmtypes_robotlocomotion",
@@ -66,7 +57,6 @@ install(
     workspace = CMAKE_PACKAGE,
     targets = [
         ":lcmtypes_robotlocomotion",
-        ":lcmtypes_robotlocomotion_c",
         ":lcmtypes_robotlocomotion_java",
         ":lcmtypes_robotlocomotion_py",
     ],

--- a/tools/workspace/lcmtypes_robotlocomotion/package.cps
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.cps
@@ -15,15 +15,6 @@
   },
   "Default-Components": [":robotlocomotion-lcmtypes-cpp"],
   "Components": {
-    "robotlocomotion-lcmtypes": {
-      "Type": "dylib",
-      "Includes": ["@prefix@/include/lcmtypes"],
-      "Location": "@prefix@/lib/liblcmtypes_robotlocomotion_c.so",
-      "Requires": [
-        "bot2-core-lcmtypes:lcmtypes_bot2-core",
-        "lcm:lcm-coretypes"
-      ]
-    },
     "robotlocomotion-lcmtypes-cpp": {
       "Type": "interface",
       "Includes": ["@prefix@/include/lcmtypes"],


### PR DESCRIPTION
The generation of C libraries was added for the internal lcmtypes of libbot2, which are now all gone. The C libraries for the remaining lcmtypes were simply generated because we could, but they were never actually used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7808)
<!-- Reviewable:end -->
