### PR TITLE
Bind images in Python.

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -75,6 +75,21 @@ drake_pybind_library(
     ],
 )
 
+drake_pybind_library(
+    name = "sensors_py",
+    cc_deps = [
+        "//bindings/pydrake/util:cpp_template_pybind",
+    ],
+    cc_so_name = "sensors",
+    cc_srcs = ["sensors_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":framework_py",
+        ":module_py",
+        "//bindings/pydrake/util:cpp_template_py",
+    ],
+)
+
 drake_py_library(
     name = "drawing_py",
     srcs = ["drawing.py"],
@@ -89,6 +104,7 @@ drake_py_library(
         ":drawing_py",
         ":framework_py",
         ":primitives_py",
+        ":sensors_py",
     ],
 )
 
@@ -96,6 +112,7 @@ PYBIND_LIBRARIES = [
     ":analysis_py",
     ":framework_py",
     ":primitives_py",
+    ":sensors_py",
 ]
 
 PY_LIBRARIES = [
@@ -176,6 +193,14 @@ drake_py_test(
     size = "small",
     deps = [
         ":framework_py",
+    ],
+)
+
+drake_py_test(
+    name = "sensors_test",
+    size = "small",
+    deps = [
+        ":sensors_py",
     ],
 )
 

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -1,6 +1,7 @@
 from .analysis import *
 from .framework import *
 from .primitives import *
+from .sensors import *
 
 try:
     from .drawing import *

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -1,0 +1,163 @@
+#include <string>
+#include <vector>
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "drake/bindings/pydrake/util/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/util/type_pack.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/sensors/image.h"
+#include "drake/systems/sensors/pixel_types.h"
+
+using std::string;
+using std::vector;
+
+namespace drake {
+namespace pydrake {
+
+template <typename T, T Value>
+using constant = std::integral_constant<T, Value>;
+
+template <typename T, T ... Values>
+using constant_pack = type_pack<type_pack<constant<T, Values>>...>;
+
+const auto py_reference = py::return_value_policy::reference;
+const auto py_reference_internal = py::return_value_policy::reference_internal;
+
+using Eigen::Map;
+using Eigen::Ref;
+
+// TODO(eric.cousineau): Place in `pydrake_pybind.h`.
+template <typename T>
+py::object ToArray(T* ptr, int size, py::tuple shape) {
+  // Create flat array to be reshaped in numpy.
+  using Vector = VectorX<T>;
+  Map<Vector> data(ptr, size);
+  return py::cast(Ref<Vector>(data), py_reference).attr("reshape")(shape);
+}
+
+// `const` variant.
+template <typename T>
+py::object ToArray(const T* ptr, int size, py::tuple shape) {
+  // Create flat array to be reshaped in numpy.
+  using Vector = const VectorX<T>;
+  Map<Vector> data(ptr, size);
+  return py::cast(Ref<Vector>(data), py_reference).attr("reshape")(shape);
+}
+
+PYBIND11_MODULE(sensors, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::sensors;
+
+  m.doc() = "Bindings for the sensors portion of the Systems framework.";
+
+  // Expose only types that are used.
+  py::enum_<PixelFormat>(m, "PixelFormat")
+      .value("kRgba", PixelFormat::kRgba)
+      .value("kDepth", PixelFormat::kDepth)
+      .value("kLabel", PixelFormat::kLabel);
+
+  {
+    // Expose image types and their traits.
+    py::enum_<PixelType> pixel_type(m, "PixelType");
+    vector<string> enum_names = {
+        "kRgba8U",
+        "kDepth32F",
+        "kLabel16I",
+    };
+
+    using ParamList = constant_pack<PixelType,
+        PixelType::kRgba8U,
+        PixelType::kDepth32F,
+        PixelType::kLabel16I>;
+
+    // Simple constexpr for-loop.
+    int i = 0;
+    auto instantiation_visitor = [&](auto param) {
+      // Extract information from inferred parameter.
+      using Param = decltype(param);
+      static_assert(Param::size == 1, "Should have scalar type_pack");
+      constexpr PixelType Value = Param::template type_at<0>::value;
+
+      using ImageT = Image<Value>;
+      using ImageTraitsT = ImageTraits<Value>;
+      using T = typename ImageTraitsT::ChannelType;
+
+      // Add definition to enum, before requesting the Python parameter.
+      pixel_type.value(enum_names[i].c_str(), Value);
+      py::tuple py_param = GetPyParam(param);
+
+      // Add traits.
+      py::class_<ImageTraitsT> traits(
+          m, TemporaryClassName<ImageTraitsT>().c_str());
+      traits.attr("ChannelType") = GetPyParam<T>()[0];
+      traits.attr("kNumChannels") = int{ImageTraitsT::kNumChannels};
+      traits.attr("kPixelFormat") = PixelFormat{ImageTraitsT::kPixelFormat};
+      AddTemplateClass(m, "ImageTraits", traits, py_param);
+
+      // Shape for use with NumPy, OpenCV, etc. Using same shape as what is
+      // present in `show_images.py`.
+      auto get_shape = [](const ImageT* self) {
+        return py::make_tuple(
+            self->height(), self->width(), int{ImageTraitsT::kNumChannels});
+      };
+      auto get_data = [=](const ImageT* self) {
+        return ToArray(self->at(0, 0), self->size(), get_shape(self));
+      };
+      auto get_mutable_data = [=](ImageT* self) {
+        return ToArray(self->at(0, 0), self->size(), get_shape(self));
+      };
+      auto check_coord = [](const ImageT* self, int x, int y) {
+        // Since Image<>::at(...) uses DRAKE_ASSERT for performance reasons,
+        // rewrite the checks here using DRAKE_THROW_UNLESS so that it will not
+        // segfault in Python.
+        DRAKE_THROW_UNLESS(x >= 0 && x < self->width());
+        DRAKE_THROW_UNLESS(y >= 0 && y < self->height());
+      };
+
+      py::class_<ImageT> image(m, TemporaryClassName<ImageT>().c_str());
+      image
+          .def(py::init<int, int>())
+          .def(py::init<int, int, T>())
+          .def("width", &ImageT::width)
+          .def("height", &ImageT::height)
+          .def("size", &ImageT::size)
+          .def("resize", &ImageT::resize)
+          .def("at", [=](ImageT* self, int x, int y) {
+                check_coord(self, x, y);
+                Map<VectorX<T>> pixel(
+                    self->at(x, y), int{ImageTraitsT::kNumChannels});
+                return pixel;
+              }, py::arg("x"), py::arg("y"), py_reference_internal)
+          // Non-C++ properties. Make them Pythonic.
+          .def_property_readonly("shape", get_shape)
+          .def_property_readonly("data", get_data, py_reference_internal)
+          .def_property_readonly(
+              "mutable_data", get_mutable_data, py_reference_internal);
+      // Constants.
+      image.attr("Traits") = traits;
+      // - Do not duplicate aliases (e.g. `kNumChannels`) for now.
+      AddTemplateClass(m, "Image", image, py_param);
+      // Add type alias for instantiation.
+      m.attr(("Image" + enum_names[i].substr(1)).c_str()) = image;
+      // Ensure that iterate.
+      ++i;
+    };
+    type_visit(instantiation_visitor, ParamList{});
+  }
+
+  // Constants.
+  py::class_<InvalidDepth> invalid_depth(m, "InvalidDepth");
+  invalid_depth.attr("kTooFar") = InvalidDepth::kTooFar;
+  invalid_depth.attr("kTooClose") = InvalidDepth::kTooClose;
+
+  py::class_<Label> label(m, "Label");
+  label.attr("kNoBody") = Label::kNoBody;
+  label.attr("kFlatTerrain") = Label::kFlatTerrain;
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,0 +1,142 @@
+import numpy as np
+import unittest
+
+import pydrake.systems.sensors as m
+
+# Shorthand aliases, to reduce verbosity.
+pt = m.PixelType
+pf = m.PixelFormat
+
+# Available image / pixel types.
+pixel_types = [
+    pt.kRgba8U,
+    pt.kDepth32F,
+    pt.kLabel16I,
+]
+
+# Convenience aliases.
+image_type_aliases = [
+    m.ImageRgba8U,
+    m.ImageDepth32F,
+    m.ImageLabel16I,
+]
+
+
+class TestSensors(unittest.TestCase):
+    def test_image_traits(self):
+        # Test instantiations of ImageTraits<>.
+        t = m.ImageTraits[pt.kRgba8U]
+        self.assertEquals(t.kNumChannels, 4)
+        self.assertEquals(t.ChannelType, np.uint8)
+        self.assertEquals(t.kPixelFormat, pf.kRgba)
+
+        t = m.ImageTraits[pt.kDepth32F]
+        self.assertEquals(t.kNumChannels, 1)
+        self.assertEquals(t.ChannelType, np.float32)
+        self.assertEquals(t.kPixelFormat, pf.kDepth)
+
+        t = m.ImageTraits[pt.kLabel16I]
+        self.assertEquals(t.kNumChannels, 1)
+        self.assertEquals(t.ChannelType, np.int16)
+        self.assertEquals(t.kPixelFormat, pf.kLabel)
+
+    def test_image_types(self):
+        # Test instantiations of Image<>.
+        for pixel_type, image_type_alias in (
+                zip(pixel_types, image_type_aliases)):
+            ImageT = m.Image[pixel_type]
+            self.assertEquals(ImageT.Traits, m.ImageTraits[pixel_type])
+            self.assertEquals(ImageT, image_type_alias)
+
+            w = 640
+            h = 480
+            nc = ImageT.Traits.kNumChannels
+            image = ImageT(w, h)
+            self.assertEquals(image.width(), w)
+            self.assertEquals(image.height(), h)
+            self.assertEquals(image.size(), h * w * nc)
+            # N.B. Since `shape` is a custom-Python extension, it's defined as
+            # a property (not a function).
+            self.assertEquals(image.shape, (h, w, nc))
+            self.assertEquals(image.data.shape, image.shape)
+            self.assertEquals(image.data.dtype, ImageT.Traits.ChannelType)
+
+            w /= 2
+            h /= 2
+            # WARNING: Resizing an image with an existing reference to
+            # `image.data` will cause `image.data` + `image.mutable_data` to be
+            # invalid.
+            image.resize(w, h)
+            self.assertEquals(image.shape, (h, w, nc))
+
+    def test_image_data(self):
+        # Test data mapping.
+        for pixel_type in pixel_types:
+            # Use a trivial size for ease of debugging.
+            w = 8
+            h = 6
+            channel_default = 1
+            ImageT = m.Image[pixel_type]
+            image = ImageT(w, h, channel_default)
+            nc = ImageT.Traits.kNumChannels
+
+            # Test default initialization.
+            self.assertEquals(image.at(0, 0)[0], channel_default)
+            self.assertTrue(np.allclose(image.data, channel_default))
+
+            # Test pixel / channel mutation and access.
+            image.at(0, 0)[0] = 2
+            # - Also test named arguments.
+            self.assertEquals(image.at(x=0, y=0)[0], 2)
+
+            bad_coords = [
+                # Bad X
+                (-1, 0, 0),
+                (100, 0, 0),
+                # Bad Y
+                (0, -1, 0),
+                (0, 100, 0),
+                # Bad Channel
+                (0, 0, -100),
+                (0, 0, 100),
+            ]
+            for x, y, c in bad_coords:
+                try:
+                    image.at(x, y)[c]
+                    self.assertTrue(False)
+                except SystemExit:
+                    pass
+                except IndexError:
+                    pass
+
+            # Test numpy views, access and mutation.
+            image.mutable_data[:] = 3
+            self.assertEquals(image.at(0, 0)[0], 3)
+            self.assertTrue(np.allclose(image.data, 3))
+            self.assertTrue(np.allclose(image.mutable_data, 3))
+
+            # Ensure that each dimension of the image array is unique.
+            self.assertEquals(len(set(image.shape)), 3)
+            # Ensure indices match as expected. Fill each channel at each pixel
+            # with unique values, and ensure that pixel / channels map
+            # appropriately.
+            data = image.mutable_data
+            data[:] = np.arange(0, image.size()).reshape(image.shape)
+            for iw in range(w):
+                for ih in range(h):
+                    self.assertTrue(
+                        np.allclose(data[ih, iw, :], image.at(iw, ih)))
+
+    def test_constants(self):
+        # Simply ensure we can access the constants.
+        values = [
+            m.InvalidDepth.kTooFar,
+            m.InvalidDepth.kTooClose,
+            m.Label.kNoBody,
+            m.Label.kFlatTerrain,
+        ]
+        self.assertTrue(values)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pydrake/util/cpp_param.py
+++ b/bindings/pydrake/util/cpp_param.py
@@ -44,6 +44,8 @@ class _ParamAliases(object):
         self.register(float, [np.double, ctypes.c_double])
         self.register(np.float32, [ctypes.c_float])
         self.register(int, [np.int32, ctypes.c_int32])
+        self.register(np.uint8, [ctypes.c_uint8])
+        self.register(np.int16, [ctypes.c_int16])
         self.register(np.uint32, [ctypes.c_uint32])
         self.register(np.int64, [ctypes.c_int64])
 

--- a/bindings/pydrake/util/cpp_param_pybind.cc
+++ b/bindings/pydrake/util/cpp_param_pybind.cc
@@ -33,6 +33,8 @@ void RegisterCommon(py::module m, py::object param_aliases) {
   RegisterType<double>(m, param_aliases, "float");
   RegisterType<float>(m, param_aliases, "np.float32");
   RegisterType<int>(m, param_aliases, "int");
+  RegisterType<uint8_t>(m, param_aliases, "np.uint8");
+  RegisterType<int16_t>(m, param_aliases, "np.int16");
   RegisterType<uint32_t>(m, param_aliases, "np.uint32");
   RegisterType<int64_t>(m, param_aliases, "np.int64");
   // For supporting generic Python types.

--- a/bindings/pydrake/util/cpp_template_pybind.h
+++ b/bindings/pydrake/util/cpp_template_pybind.h
@@ -66,8 +66,7 @@ std::string TemporaryClassName(
 /// @param param Parameters for the instantiation.
 inline py::object AddTemplateClass(
     py::handle scope, const std::string& name,
-    py::handle py_class, py::tuple param,
-    const std::string& default_instantiation_name = "") {
+    py::handle py_class, py::tuple param) {
   py::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateClass");
   internal::AddInstantiation(py_template, py_class, param);


### PR DESCRIPTION
Sorry for the delay, first step for #7753.

This binds `Image<>` in Python for commonly used `PixelType`'s.
~(Currently non-functional, but starting somewhere :) )~

~Should use #7790 once it's merged.~

\cc @gizatt @kunimatsu-tri @ChristopherSweeney

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7811)
<!-- Reviewable:end -->
