### PR TITLE
Ignition cosmetic fixups

### DIFF
--- a/tools/workspace/ignition_math/package.BUILD.bazel
+++ b/tools/workspace/ignition_math/package.BUILD.bazel
@@ -52,7 +52,21 @@ generate_file(
     content = """
 #pragma once
 
+// IGN_DEPRECATED is defined by all ignition libraries, but the version below
+// is a simplified version.  When mixing the regular ignition libraries and
+// the drake compiled ignition libraries, the compiler throws a warning about
+// the macro being multiply defined.  We undefine it before redefining it here
+// to work around that issue.  Note that the IGNITION_MATH_VISIBLE macro
+// shouldn't be defined multiple times, but we undefine it just in case.
+
+#ifdef IGNITION_MATH_VISIBLE
+#undef IGNITION_MATH_VISIBLE
+#endif
 #define IGNITION_MATH_VISIBLE __attribute__ ((visibility("default")))
+
+#ifdef IGN_DEPRECATED
+#undef IGN_DEPRECATED
+#endif
 #define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
     """,
     visibility = ["//visibility:private"],

--- a/tools/workspace/ignition_rndf/package.BUILD.bazel
+++ b/tools/workspace/ignition_rndf/package.BUILD.bazel
@@ -62,7 +62,21 @@ generate_file(
     content = """
 #pragma once
 
+// IGN_DEPRECATED is defined by all ignition libraries, but the version below
+// is a simplified version.  When mixing the regular ignition libraries and
+// the drake compiled ignition libraries, the compiler throws a warning about
+// the macro being multiply defined.  We undefine it before redefining it here
+// to work around that issue.  Note that the IGNITION_RNDF_VISIBLE macro
+// shouldn't be defined multiple times, but we undefine it just in case.
+
+#ifdef IGNITION_RNDF_VISIBLE
+#undef IGNITION_RNDF_VISIBLE
+#endif
 #define IGNITION_RNDF_VISIBLE __attribute__ ((visibility("default")))
+
+#ifdef IGN_DEPRECATED
+#undef IGN_DEPRECATED
+#endif
 #define IGN_DEPRECATED(version) __attribute__ ((__deprecated__))
     """,
     visibility = ["//visibility:private"],


### PR DESCRIPTION
The current installation of the ignition libraries (math and rndf) work for downstream libraries, but cause a few warnings.  These fixups make it so that downstream projects can build without warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7815)
<!-- Reviewable:end -->
