### PR TITLE
Add godotengine as an external

### DIFF
--- a/systems/sensors/godot_renderer/dev/BUILD.bazel
+++ b/systems/sensors/godot_renderer/dev/BUILD.bazel
@@ -1,0 +1,31 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+    "drake_cc_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "maybe_godotengine",
+    deps = select({
+        "//conditions:default": ["@godotengine"],
+        "//tools/cc_toolchain:apple": [],
+    }),
+)
+
+drake_cc_binary(
+    name = "dummy",
+    srcs = select({
+        "//conditions:default": ["dummy_ubuntu.cc"],
+        "//tools/cc_toolchain:apple": ["dummy_macos.cc"],
+    }),
+    deps = [
+        ":maybe_godotengine",
+    ],
+)
+
+add_lint_tests()

--- a/systems/sensors/godot_renderer/dev/README.md
+++ b/systems/sensors/godot_renderer/dev/README.md
@@ -1,0 +1,3 @@
+We are in the process of adding renering-based simulation tools to Drake using
+the https://godotengine.org/ software.  For the moment, macOS is not supported,
+but it will be added before we're done.

--- a/systems/sensors/godot_renderer/dev/dummy_macos.cc
+++ b/systems/sensors/godot_renderer/dev/dummy_macos.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 1;
+}

--- a/systems/sensors/godot_renderer/dev/dummy_ubuntu.cc
+++ b/systems/sensors/godot_renderer/dev/dummy_ubuntu.cc
@@ -1,0 +1,33 @@
+#include <core/register_core_types.h>
+#include <drivers/gles3/rasterizer_gles3.h>
+#include <drivers/register_driver_types.h>
+#include <drivers/unix/dir_access_unix.h>
+#include <drivers/unix/file_access_unix.h>
+#include <os/thread_dummy.h>
+#include <servers/visual/visual_server_raster.h>
+
+// This is some small sample code that uses a few things from Godot, to show
+// that we can link without errors.  Once we have more real code using Godot,
+// we should remove this dummy program.  (Note that this program more or less
+// always segfaults at the moment.)
+int main() {
+  RID_OwnerBase::init_rid();
+  ThreadDummy::make_default();
+  SemaphoreDummy::make_default();
+  MutexDummy::make_default();
+  FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
+  FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_USERDATA);
+  FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_FILESYSTEM);
+  DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_RESOURCES);
+  DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
+  DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
+  ClassDB::init();
+  register_core_types();
+  register_core_driver_types();
+  RasterizerGLES3::register_config();
+  RasterizerGLES3::make_current();
+  auto visual_server = memnew(VisualServerRaster);
+  visual_server->init();
+
+  return 0;
+}

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -17,6 +17,7 @@ load("@drake//tools/workspace/fmt:repository.bzl", "fmt_repository")
 load("@drake//tools/workspace/gflags:repository.bzl", "gflags_repository")
 load("@drake//tools/workspace/glew:repository.bzl", "glew_repository")
 load("@drake//tools/workspace/glib:repository.bzl", "glib_repository")
+load("@drake//tools/workspace/godotengine:repository.bzl", "godotengine_repository")  # noqa
 load("@drake//tools/workspace/gtest:repository.bzl", "gtest_repository")
 load("@drake//tools/workspace/gthread:repository.bzl", "gthread_repository")
 load("@drake//tools/workspace/gurobi:repository.bzl", "gurobi_repository")
@@ -102,6 +103,8 @@ def add_default_repositories(excludes = []):
         glew_repository(name = "glew")
     if "glib" not in excludes:
         glib_repository(name = "glib")
+    if "godotengine" not in excludes:
+        godotengine_repository(name = "godotengine")
     if "gtest" not in excludes:
         gtest_repository(name = "gtest")
     if "gthread" not in excludes:

--- a/tools/workspace/godotengine/BUILD.bazel
+++ b/tools/workspace/godotengine/BUILD.bazel
@@ -1,0 +1,10 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+exports_files(
+    glob(["*.py"]),
+    visibility = ["@godotengine//:__pkg__"],
+)
+
+add_lint_tests(python_lint_extra_srcs = glob(["*.py"]))

--- a/tools/workspace/godotengine/main_build_gles3_headers.py
+++ b/tools/workspace/godotengine/main_build_gles3_headers.py
@@ -1,0 +1,38 @@
+# This is a tool used by our package.BUILD.bazel file in a genrule().
+
+import os
+import shutil
+import sys
+
+# Load godotengine's SCons implementation of this feature.
+# See https://github.com/godotengine/godot/blob/master/methods.py.
+from methods import build_gles3_headers
+
+# From our BUILD rule, the first argument is an *.h that build_gles3_headers
+# needs to read in.  Since the path is hard-coded in build_gles3_headers, we
+# can discard it here.
+_ = sys.argv.pop(1)
+
+# The rest of our arguments are the *.glsl sources, and the *.gen.h outputs.
+srcs_and_outs = sys.argv[1:]
+assert (len(srcs_and_outs) % 2) == 0
+num_srcs = len(srcs_and_outs) // 2
+srcs = srcs_and_outs[:num_srcs]
+outs = srcs_and_outs[num_srcs:]
+
+# Turn the path "external/godotengine/drivers/gles3/shaders/blend_shape.glsl"
+# into just the base "external/godotengine".
+suffix = "/drivers/gles3/shaders/blend_shape.glsl"
+assert srcs[0].endswith(suffix)
+base = srcs[0][:-len(suffix)]
+
+# Call the upstream method, from the directory that it expects to see.
+paths = [os.path.relpath(src, base) for src in srcs]
+old_cwd = os.getcwd()
+os.chdir(base)
+build_gles3_headers(None, paths, None)
+os.chdir(old_cwd)
+
+# Move its outputs back into genfiles.
+for src, out in zip(srcs, outs):
+    shutil.move(src + ".gen.h", out)

--- a/tools/workspace/godotengine/main_make_binders.py
+++ b/tools/workspace/godotengine/main_make_binders.py
@@ -1,0 +1,13 @@
+# This is a tool used by our package.BUILD.bazel file in a genrule().
+
+import collections
+import sys
+
+# Load godotengine's SCons implementation of this feature.
+from core import make_binders
+
+# Call the upstream method; its first argument needs to quack like
+# "a list of things that each have a .path attribute".
+Target = collections.namedtuple("Target", ["path"])
+targets = [Target(path=x) for x in sys.argv[1:]]
+make_binders.run(targets, None, None)

--- a/tools/workspace/godotengine/main_update_version.py
+++ b/tools/workspace/godotengine/main_update_version.py
@@ -1,0 +1,21 @@
+# This is a tool used by our package.BUILD.bazel file in a genrule().
+
+import os
+import sys
+
+# Load godotengine's SCons implementation of this feature.
+# See https://github.com/godotengine/godot/blob/master/methods.py.
+from methods import update_version
+
+# Turn the path "genfiles/external/godotengine/core/version_generated.gen.h"
+# into just the base "genfiles/external/godotengine".
+outs = sys.argv[1:]
+suffix = "/core/version_generated.gen.h"
+assert outs[0].endswith(suffix)
+base = outs[0][:-len(suffix)]
+
+# Call the upstream method, from the directory that it expects to see.
+os.chdir(base)
+if not os.path.isdir("core"):
+    os.mkdir("core")
+update_version()

--- a/tools/workspace/godotengine/package.BUILD.bazel
+++ b/tools/workspace/godotengine/package.BUILD.bazel
@@ -1,0 +1,168 @@
+# -*- python -*-
+
+# Compile a tool that knows how to emit the version*.gen.h files.
+py_binary(
+    name = "update_version",
+    srcs = [
+        "compat.py",
+        "methods.py",
+        "version.py",
+        "@drake//tools/workspace/godotengine:main_update_version.py",
+    ],
+    main = "@drake//tools/workspace/godotengine:main_update_version.py",
+)
+
+# Run the tool that knows how to emit the version*.gen.h files.
+genrule(
+    name = "update_version_genrule",
+    outs = [
+        "core/version_generated.gen.h",
+        "core/version_hash.gen.h",
+    ],
+    cmd = "$(location :update_version) $(OUTS)",
+    tools = [":update_version"],
+)
+
+# Compile a tool that knows how to emit method_bind*.gen.inc files.
+py_binary(
+    name = "make_binders",
+    srcs = [
+        "core/make_binders.py",
+        "@drake//tools/workspace/godotengine:main_make_binders.py",
+    ],
+    main = "@drake//tools/workspace/godotengine:main_make_binders.py",
+)
+
+# Run the tool that knows how to emit method_bind*.gen.inc files.
+genrule(
+    name = "make_binders_genrule",
+    outs = [
+        "core/method_bind.gen.inc",
+        "core/method_bind_ext.gen.inc",
+    ],
+    cmd = "$(location :make_binders) $(OUTS)",
+    tools = [":make_binders"],
+)
+
+# Upstream's GLSL files.
+_GLSLS = glob(["drivers/gles3/shaders/*.glsl"])
+
+# The header files that will be generated.
+_GLSLS_GEN_H = [x + ".gen.h" for x in _GLSLS]
+
+# Compile a tool that knows how to emit *.glsl.gen.h files.
+py_binary(
+    name = "build_gles3_headers",
+    srcs = [
+        "compat.py",
+        "methods.py",
+        "@drake//tools/workspace/godotengine:main_build_gles3_headers.py",
+    ],
+    main = "@drake//tools/workspace/godotengine:main_build_gles3_headers.py",
+)
+
+# Run the tool that knows how to emit *.glsl.gen.h files.
+genrule(
+    name = "build_gles3_headers_genrule",
+    srcs = ["drivers/gles3/shader_gles3.h"] + _GLSLS,
+    outs = _GLSLS_GEN_H,
+    cmd = "$(location :build_gles3_headers) $(SRCS) $(OUTS)",
+    tools = [":build_gles3_headers"],
+)
+
+# Make the generated files #include-able.
+cc_library(
+    name = "generated_headers",
+    hdrs = [
+        "core/version_generated.gen.h",
+        "core/version_hash.gen.h",
+    ] + _GLSLS_GEN_H,
+    includes = [
+        ".",
+        "core",
+    ],
+    textual_hdrs = [
+        "core/method_bind.gen.inc",
+        "core/method_bind_ext.gen.inc",
+    ],
+)
+
+# The packages that we want.  Use "/**" to also glob their subpackages.
+_PACKAGES = [
+    "core/**",
+    "drivers",
+    "drivers/gl_context",
+    "drivers/gles3",
+    "drivers/png",
+    "scene/**",
+    "servers/**",
+    "thirdparty/glad/**",
+    "thirdparty/minizip/**",
+    "thirdparty/misc/**",
+    "thirdparty/zstd/**",
+]
+
+# Compile a library with everything from Godot that we need.
+cc_library(
+    name = "godotengine",
+    srcs = glob([
+        x + "/*.cpp"
+        for x in _PACKAGES
+    ] + [
+        x + "/*.c"
+        for x in _PACKAGES
+    ] + [
+        "drivers/unix/dir_access_unix.cpp",
+        "drivers/unix/file_access_unix.cpp",
+        "editor/**/*.h",
+        "platform/**/*.h",
+        "platform/**/globals/global_defaults.cpp",
+    ]),
+    hdrs = glob([
+        x + "/*.h"
+        for x in _PACKAGES
+    ] + [
+        x + "/*.inc"
+        for x in _PACKAGES
+    ] + [
+        "drivers/unix/**/*.h",
+    ]),
+    copts = [
+        "-Wno-c++11-narrowing",
+        "-w",
+    ],
+    defines = [
+        "GLAD_ENABLED",
+        "GLES_OVER_GL",
+        "UNIX_ENABLED",
+        "ZSTD_STATIC_LINKING_ONLY",
+    ],
+    includes = [
+        ".",
+        "core",
+        "core/bind",
+        "core/helper",
+        "core/io",
+        "core/math",
+        "core/os",
+        "drivers",
+        "drivers/gles3",
+        "platform/x11",
+        "thirdparty/glad",
+        "thirdparty/zstd",
+        "thirdparty/zstd/common",
+    ],
+    linkopts = select({
+        "@drake//tools/cc_toolchain:linux": ["-ldl"],
+        "//conditions:default": [],
+    }),
+    textual_hdrs = glob([
+        "**/*.xpm",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "generated_headers",
+        "@libpng",
+        "@zlib",
+    ],
+)

--- a/tools/workspace/godotengine/repository.bzl
+++ b/tools/workspace/godotengine/repository.bzl
@@ -1,0 +1,12 @@
+# -*- python -*-
+
+load("@drake//tools/workspace:github.bzl", "github_archive")
+
+def godotengine_repository(name):
+    github_archive(
+        name = name,
+        repository = "godotengine/godot",
+        commit = "06dd10b3905a7d48beffe0523b785d513747f511",
+        sha256 = "bb305dc5cec41ef379174162c62f7056f91ba7798324a9466592c0a3420c3105",  # noqa
+        build_file = "@drake//tools/workspace/godotengine:package.BUILD.bazel",
+    )


### PR DESCRIPTION
This also has a dummy main program to demonstrate that the library builds, and has somewhat reasonable link flags.

This uses a slightly older commit that godot master (because master is broken for our platform).  We can PR fixes for that upstream and then bump to their master.

Do not merge until:
- [x] tested on macOS builds.
- [x] retested after rebased onto latest master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7817)
<!-- Reviewable:end -->
