### PR TITLE
pydrake/util: Remove defective use of namespace aliases in headers.

### DIFF
--- a/bindings/pydrake/util/cpp_param_pybind.h
+++ b/bindings/pydrake/util/cpp_param_pybind.h
@@ -13,32 +13,27 @@
 
 namespace drake {
 namespace pydrake {
-
-// This alias is intended to be part of the public API, as it follows
-// `pybind11` conventions.
-namespace py = pybind11;
-
 namespace internal {
 
 // Gets singleton for type aliases from `cpp_param`.
-py::object GetParamAliases();
+pybind11::object GetParamAliases();
 
 // Gets Python type object given `std::type_info`.
 // @throws std::runtime_error if type is neither aliased nor registered in
 // `pybind11`.
-py::object GetPyParamScalarImpl(const std::type_info& tinfo);
+pybind11::object GetPyParamScalarImpl(const std::type_info& tinfo);
 
 // Gets Python type for a C++ type (base case).
 template <typename T>
-inline py::object GetPyParamScalarImpl(type_pack<T> = {}) {
+inline pybind11::object GetPyParamScalarImpl(type_pack<T> = {}) {
   return GetPyParamScalarImpl(typeid(T));
 }
 
 // Gets Python literal for a C++ literal (specialization).
 template <typename T, T Value>
-inline py::object GetPyParamScalarImpl(
+inline pybind11::object GetPyParamScalarImpl(
     type_pack<std::integral_constant<T, Value>> = {}) {
-  return py::cast(Value);
+  return pybind11::cast(Value);
 }
 
 }  // namespace internal
@@ -48,8 +43,9 @@ inline py::object GetPyParamScalarImpl(
 /// @throws std::runtime_error on the first type it encounters that is neither
 /// aliased nor registered in `pybind11`.
 template <typename ... Ts>
-inline py::tuple GetPyParam(type_pack<Ts...> = {}) {
-  return py::make_tuple(internal::GetPyParamScalarImpl(type_pack<Ts>{})...);
+inline pybind11::tuple GetPyParam(type_pack<Ts...> = {}) {
+  return pybind11::make_tuple(
+      internal::GetPyParamScalarImpl(type_pack<Ts>{})...);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/util/cpp_template_pybind.h
+++ b/bindings/pydrake/util/cpp_template_pybind.h
@@ -13,35 +13,33 @@
 
 namespace drake {
 namespace pydrake {
-
-namespace py = pybind11;
-
 namespace internal {
 
 // C++ interface for `pydrake.util.cpp_template.get_or_init`.
 // Please see that function for common parameters.
 // @param template_cls_name Name of the template class in `cpp_template`,
 // resolves to class to be passed as `template_cls`.
-inline py::object GetOrInitTemplate(
-    py::handle scope, const std::string& name,
+inline pybind11::object GetOrInitTemplate(
+    pybind11::handle scope, const std::string& name,
     const std::string& template_cls_name,
-    py::tuple args = py::tuple(), py::dict kwargs = py::dict()) {
+    pybind11::tuple args = pybind11::tuple(),
+    pybind11::dict kwargs = pybind11::dict()) {
   const char module_name[] = "pydrake.util.cpp_template";
-  py::handle m = py::module::import(module_name);
+  pybind11::handle m = pybind11::module::import(module_name);
   return m.attr("get_or_init")(
       scope, name, m.attr(template_cls_name.c_str()), *args, **kwargs);
 }
 
 // Adds instantiation to a Python template.
 inline void AddInstantiation(
-    py::handle py_template, py::handle obj, py::tuple param) {
+    pybind11::handle py_template, pybind11::handle obj, pybind11::tuple param) {
   py_template.attr("add_instantiation")(param, obj);
 }
 
 // Gets name for a given instantiation.
 inline std::string GetInstantiationName(
-    py::handle py_template, py::tuple param) {
-  return py::cast<std::string>(
+    pybind11::handle py_template, pybind11::tuple param) {
+  return pybind11::cast<std::string>(
     py_template.attr("_instantiation_name")(param));
 }
 
@@ -62,13 +60,13 @@ std::string TemporaryClassName(
 /// @param py_class Class instantiation to be added.
 /// @note The class name should be *unique*. If you would like automatic unique
 /// names, consider constructing the class binding as
-/// `py::class_<Class, ...>(m, TemporaryClassName<Class>().c_str())`.
+/// `pybind11::class_<Class, ...>(m, TemporaryClassName<Class>().c_str())`.
 /// @param param Parameters for the instantiation.
-inline py::object AddTemplateClass(
-    py::handle scope, const std::string& name,
-    py::handle py_class, py::tuple param,
+inline pybind11::object AddTemplateClass(
+    pybind11::handle scope, const std::string& name,
+    pybind11::handle py_class, pybind11::tuple param,
     const std::string& default_instantiation_name = "") {
-  py::object py_template =
+  pybind11::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateClass");
   internal::AddInstantiation(py_template, py_class, param);
   return py_template;
@@ -80,15 +78,16 @@ inline py::object AddTemplateClass(
 /// @param func Function to be added.
 /// @param param Parameters for the instantiation.
 template <typename Func>
-py::object AddTemplateFunction(
-    py::handle scope, const std::string& name, Func&& func,
-    py::tuple param) {
-  // TODO(eric.cousineau): Use `py::sibling` if overloads are needed.
-  py::object py_template =
+pybind11::object AddTemplateFunction(
+    pybind11::handle scope, const std::string& name, Func&& func,
+    pybind11::tuple param) {
+  // TODO(eric.cousineau): Use `pybind11::sibling` if overloads are needed.
+  pybind11::object py_template =
       internal::GetOrInitTemplate(scope, name, "TemplateFunction");
-  py::object py_func = py::cpp_function(
+  pybind11::object py_func = pybind11::cpp_function(
         std::forward<Func>(func),
-        py::name(internal::GetInstantiationName(py_template, param).c_str()));
+        pybind11::name(
+            internal::GetInstantiationName(py_template, param).c_str()));
   internal::AddInstantiation(py_template, py_func, param);
   return py_template;
 }
@@ -99,16 +98,17 @@ py::object AddTemplateFunction(
 /// @param method Method to be added.
 /// @param param Parameters for the instantiation.
 template <typename Method>
-py::object AddTemplateMethod(
-    py::handle scope, const std::string& name, Method&& method,
-    py::tuple param) {
-  py::object py_template =
+pybind11::object AddTemplateMethod(
+    pybind11::handle scope, const std::string& name, Method&& method,
+    pybind11::tuple param) {
+  pybind11::object py_template =
       internal::GetOrInitTemplate(
-          scope, name, "TemplateMethod", py::make_tuple(scope));
-  py::object py_func = py::cpp_function(
+          scope, name, "TemplateMethod", pybind11::make_tuple(scope));
+  pybind11::object py_func = pybind11::cpp_function(
       std::forward<Method>(method),
-      py::name(internal::GetInstantiationName(py_template, param).c_str()),
-      py::is_method(scope));
+      pybind11::name(
+          internal::GetInstantiationName(py_template, param).c_str()),
+      pybind11::is_method(scope));
   internal::AddInstantiation(py_template, py_func, param);
   return py_template;
 }

--- a/bindings/pydrake/util/test/cpp_param_pybind_test.cc
+++ b/bindings/pydrake/util/test/cpp_param_pybind_test.cc
@@ -11,6 +11,8 @@
 #include <pybind11/eval.h>
 #include <pybind11/pybind11.h>
 
+namespace py = pybind11;
+
 using std::string;
 
 namespace drake {

--- a/bindings/pydrake/util/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/util/test/cpp_template_pybind_test.cc
@@ -14,6 +14,8 @@
 
 #include "drake/common/nice_type_name.h"
 
+namespace py = pybind11;
+
 using std::string;
 using std::vector;
 


### PR DESCRIPTION
Per discussion: https://github.com/RobotLocomotion/drake/pull/7811#issuecomment-359124965

Because GCC (tested on versions 5 and 6) does not permit ambiguous aliases (even if the aliases refer to the same entity), remove `namespace py = pybind11` in reused `*_pybind.h` utility files.

NOTE: I would have thought that C++11+ would have introduced something to overcome this, something like "yes, given my order of import, I really want to use this variant in my scope", given that we're still using legacy preprocessors... but alas, no. Will still look into this, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7818)
<!-- Reviewable:end -->
