### PR TITLE
Adding torque sensing supporting robot_bridge

### DIFF
--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_library(
         "//drake/lcmtypes:iiwa",
         "//drake/multibody:inverse_kinematics",
         "//drake/multibody:rigid_body_tree",
+        "//drake/multibody/rigid_body_plant:contact_results",
         "//drake/systems/framework:leaf_system",
     ],
 )
@@ -194,9 +195,13 @@ alias(
 
 drake_cc_googletest(
     name = "iiwa_lcm_test",
+    data = [
+        "//drake/manipulation/models/iiwa_description:models",
+    ],
     deps = [
         ":iiwa_lcm",
         "//drake/common/test_utilities:eigen_matrix_compare",
+        "//drake/manipulation/util:world_sim_tree_builder",
         "//drake/systems/framework",
     ],
 )

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -261,7 +261,7 @@ int DoMain() {
                   iiwa_status_sender->get_command_input_port());
 
   builder.Connect(model->get_output_port_computed_torque(),
-                  iiwa_status_sender->get_torque_commanded_input_port());
+                  iiwa_status_sender->get_commanded_torque_input_port());
 
   builder.Connect(iiwa_status_sender->get_output_port(0),
                   iiwa_status_pub->get_input_port(0));

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.cc
@@ -271,7 +271,7 @@ LcmPlant::LcmPlant(
     builder.Connect(iiwa_command_receiver->get_output_port(0),
                     iiwa_status_sender->get_command_input_port());
     builder.Connect(iiwa_and_wsg_plant_->get_output_port_computed_torque(),
-                    iiwa_status_sender->get_torque_commanded_input_port());
+                    iiwa_status_sender->get_commanded_torque_input_port());
 
     // Export iiwa status output port.
     output_port_iiwa_status_.push_back(

--- a/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -1,10 +1,13 @@
 #include "drake/examples/kuka_iiwa_arm/iiwa_lcm.h"
 
+#include <algorithm>
+#include <utility>
 #include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/lcmt_iiwa_command.hpp"
 #include "drake/lcmt_iiwa_status.hpp"
+#include "drake/multibody/rigid_body_plant/contact_results.h"
 
 namespace drake {
 namespace examples {
@@ -25,20 +28,27 @@ const double kIiwaLcmStatusPeriod = 0.005;
 IiwaCommandReceiver::IiwaCommandReceiver(int num_joints)
     : num_joints_(num_joints) {
   this->DeclareAbstractInputPort();
-  this->DeclareVectorOutputPort(systems::BasicVector<double>(num_joints_ * 2),
-                                &IiwaCommandReceiver::OutputCommand);
+  this->DeclareVectorOutputPort(
+      systems::BasicVector<double>(num_joints_ * 2),
+      [this](const Context<double>& c, BasicVector<double>* o) {
+        this->CopyStateToOutput(c, 0, num_joints_ * 2, o);
+      });
+  this->DeclareVectorOutputPort(
+      systems::BasicVector<double>(num_joints_),
+      [this](const Context<double>& c, BasicVector<double>* o) {
+        this->CopyStateToOutput(c, num_joints_ * 2, num_joints_, o);
+      });
   this->DeclarePeriodicDiscreteUpdate(kIiwaLcmStatusPeriod);
-  this->DeclareDiscreteState(num_joints_ * 2);
+  // State + torque
+  this->DeclareDiscreteState(num_joints_ * 3);
 }
 
 void IiwaCommandReceiver::set_initial_position(
-    Context<double>* context,
-    const Eigen::Ref<const VectorX<double>> x) const {
-  auto state_value =
-      context->get_mutable_discrete_state(0).get_mutable_value();
+    Context<double>* context, const Eigen::Ref<const VectorX<double>> x) const {
+  auto state_value = context->get_mutable_discrete_state(0).get_mutable_value();
   DRAKE_ASSERT(x.size() == num_joints_);
+  state_value.setZero();
   state_value.head(num_joints_) = x;
-  state_value.tail(num_joints_) = VectorX<double>::Zero(num_joints_);
 }
 
 void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
@@ -48,10 +58,9 @@ void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
   const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
   DRAKE_ASSERT(input != nullptr);
   const auto& command = input->GetValue<lcmt_iiwa_command>();
-  // TODO(sam.creasey) Support torque control.
-  DRAKE_ASSERT(command.num_torques == 0);
 
-
+  BasicVector<double>& state = discrete_state->get_mutable_vector(0);
+  auto state_value = state.get_mutable_value();
   // If we're using a default constructed message (haven't received
   // a command yet), keep using the initial state.
   if (command.num_joints != 0) {
@@ -61,34 +70,43 @@ void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
       new_positions(i) = command.joint_position[i];
     }
 
-    BasicVector<double>& state = discrete_state->get_mutable_vector(0);
-    auto state_value = state.get_mutable_value();
-    state_value.tail(num_joints_) =
+    state_value.segment(num_joints_, num_joints_) =
         (new_positions - state_value.head(num_joints_)) / kIiwaLcmStatusPeriod;
     state_value.head(num_joints_) = new_positions;
   }
+
+  // If the message does not contain torque commands, set torque command to
+  // zeros.
+  if (command.num_torques == 0) {
+    state_value.tail(num_joints_).setZero();
+  } else {
+    DRAKE_DEMAND(command.num_torques == num_joints_);
+    for (int i = 0; i < num_joints_; i++)
+      state_value[2 * num_joints_ + i] = command.joint_torque[i];
+  }
 }
 
-void IiwaCommandReceiver::OutputCommand(const Context<double>& context,
-                                        BasicVector<double>* output) const {
-  Eigen::VectorBlock<VectorX<double>> output_vec =
-      output->get_mutable_value();
-  output_vec = context.get_discrete_state(0).get_value();
+void IiwaCommandReceiver::CopyStateToOutput(const Context<double>& context,
+                                            int start_idx, int length,
+                                            BasicVector<double>* output) const {
+  Eigen::VectorBlock<VectorX<double>> output_vec = output->get_mutable_value();
+  output_vec =
+      context.get_discrete_state(0).get_value().segment(start_idx, length);
 }
 
 IiwaCommandSender::IiwaCommandSender(int num_joints)
     : num_joints_(num_joints),
       position_input_port_(
-          this->DeclareInputPort(
-              systems::kVectorValued, num_joints_).get_index()),
+          this->DeclareInputPort(systems::kVectorValued, num_joints_)
+              .get_index()),
       torque_input_port_(
-          this->DeclareInputPort(
-              systems::kVectorValued, num_joints_).get_index()) {
+          this->DeclareInputPort(systems::kVectorValued, num_joints_)
+              .get_index()) {
   this->DeclareAbstractOutputPort(&IiwaCommandSender::OutputCommand);
 }
 
-void IiwaCommandSender::OutputCommand(
-    const Context<double>& context, lcmt_iiwa_command* output) const {
+void IiwaCommandSender::OutputCommand(const Context<double>& context,
+                                      lcmt_iiwa_command* output) const {
   lcmt_iiwa_command& command = *output;
 
   command.utime = context.get_time() * 1e6;
@@ -162,8 +180,8 @@ void IiwaStatusReceiver::DoCalcDiscreteVariableUpdates(
   }
 }
 
-void IiwaStatusReceiver::OutputMeasuredPosition(const Context<double>& context,
-                                       BasicVector<double>* output) const {
+void IiwaStatusReceiver::OutputMeasuredPosition(
+    const Context<double>& context, BasicVector<double>* output) const {
   const auto state_value = context.get_discrete_state(0).get_value();
 
   Eigen::VectorBlock<VectorX<double>> measured_position_output =
@@ -180,11 +198,18 @@ void IiwaStatusReceiver::OutputCommandedPosition(
   commanded_position_output = state_value.tail(num_joints_);
 }
 
-IiwaStatusSender::IiwaStatusSender(int num_joints)
-    : num_joints_(num_joints) {
+IiwaStatusSender::IiwaStatusSender(int num_joints) : num_joints_(num_joints) {
+  // Commanded state.
   this->DeclareInputPort(systems::kVectorValued, num_joints_ * 2);
+  // Measured state.
   this->DeclareInputPort(systems::kVectorValued, num_joints_ * 2);
+  // Commanded torque.
   this->DeclareInputPort(systems::kVectorValued, num_joints_);
+  // Measured torque.
+  this->DeclareInputPort(systems::kVectorValued, num_joints_);
+  // Measured external torque.
+  this->DeclareInputPort(systems::kVectorValued, num_joints_);
+
   this->DeclareAbstractOutputPort(&IiwaStatusSender::MakeOutputStatus,
                                   &IiwaStatusSender::OutputStatus);
 }
@@ -202,29 +227,108 @@ lcmt_iiwa_status IiwaStatusSender::MakeOutputStatus() const {
   return msg;
 }
 
-void IiwaStatusSender::OutputStatus(
-    const Context<double>& context, lcmt_iiwa_status* output) const {
+void IiwaStatusSender::OutputStatus(const Context<double>& context,
+                                    lcmt_iiwa_status* output) const {
   lcmt_iiwa_status& status = *output;
 
   status.utime = context.get_time() * 1e6;
   const systems::BasicVector<double>* command =
       this->EvalVectorInput(context, 0);
-  const systems::BasicVector<double>* state =
-      this->EvalVectorInput(context, 1);
+  const systems::BasicVector<double>* state = this->EvalVectorInput(context, 1);
   const systems::BasicVector<double>* commanded_torque =
       this->EvalVectorInput(context, 2);
+  const systems::BasicVector<double>* measured_torque =
+      this->EvalVectorInput(context, 3);
+  const systems::BasicVector<double>* external_torque =
+      this->EvalVectorInput(context, 4);
+
   for (int i = 0; i < num_joints_; ++i) {
     status.joint_position_measured[i] = state->GetAtIndex(i);
     status.joint_velocity_estimated[i] = state->GetAtIndex(i + num_joints_);
     status.joint_position_commanded[i] = command->GetAtIndex(i);
     status.joint_torque_commanded[i] = commanded_torque->GetAtIndex(i);
-    // TODO(rcory) Update joint_torque_measured to report actual measured torque
-    // once RigidBodyPlant supports it. For now, assume
-    // joint_torque_measured == joint_torque_commanded.
-    status.joint_torque_measured[i] = commanded_torque->GetAtIndex(i);
+
+    if (external_torque) {
+      status.joint_torque_external[i] = external_torque->GetAtIndex(i);
+    }
+    if (measured_torque) {
+      status.joint_torque_measured[i] = measured_torque->GetAtIndex(i);
+    } else {
+      // TODO(rcory) Update joint_torque_measured to report actual measured
+      // torque once RigidBodyPlant supports it. For now, assume
+      // joint_torque_measured == joint_torque_commanded.
+      status.joint_torque_measured[i] = commanded_torque->GetAtIndex(i);
+    }
   }
 }
 
+IiwaContactResultsToExternalTorque::IiwaContactResultsToExternalTorque(
+    const RigidBodyTree<double>& tree,
+    const std::vector<int>& model_instance_ids)
+    : num_joints_{tree.get_num_velocities()} {
+  int length = 0;
+  velocity_map_.resize(tree.get_num_model_instances(),
+                       std::pair<int, int>(-1, -1));
+
+  for (const auto& body : tree.bodies) {
+    if (!body->has_parent_body()) {
+      continue;
+    }
+
+    const int instance_id = body->get_model_instance_id();
+    const int velocity_start_index = body->get_velocity_start_index();
+    const int num_velocities = body->getJoint().get_num_velocities();
+
+    if (std::find(model_instance_ids.begin(), model_instance_ids.end(),
+                  instance_id) == model_instance_ids.end()) {
+      continue;
+    }
+
+    if (num_velocities) {
+      if (velocity_map_[instance_id].first == -1) {
+        velocity_map_[instance_id] =
+            std::pair<int, int>(velocity_start_index, num_velocities);
+      } else {
+        std::pair<int, int> map_entry = velocity_map_[instance_id];
+        DRAKE_DEMAND(velocity_start_index ==
+                     map_entry.first + map_entry.second);
+        map_entry.second += num_velocities;
+        velocity_map_[instance_id] = map_entry;
+      }
+      length += num_velocities;
+    }
+  }
+
+  this->DeclareAbstractInputPort();
+
+  this->DeclareVectorOutputPort(
+      systems::BasicVector<double>(length),
+      &IiwaContactResultsToExternalTorque::OutputExternalTorque);
+}
+
+void IiwaContactResultsToExternalTorque::OutputExternalTorque(
+    const systems::Context<double>& context,
+    systems::BasicVector<double>* output) const {
+  const systems::ContactResults<double>* contact_results =
+      this->EvalInputValue<systems::ContactResults<double>>(context, 0);
+
+  int start = 0;
+  const VectorX<double>& generalized_force =
+      contact_results->get_generalized_contact_force();
+  DRAKE_DEMAND(generalized_force.size() == num_joints_);
+
+  for (const auto& entry : velocity_map_) {
+    const int v_idx = entry.first;
+    const int v_length = entry.second;
+    if (v_idx == -1) continue;
+
+    for (int idx = 0; idx < v_length; idx++) {
+      output->SetAtIndex(start + idx, generalized_force[v_idx + idx]);
+    }
+    start += v_length;
+  }
+  DRAKE_DEMAND(start == output->size());
+}
 
 }  // namespace kuka_iiwa_arm
 }  // namespace examples

--- a/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
+++ b/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.cc
@@ -80,6 +80,10 @@ IiwaAndWsgPlantWithStateEstimator<T>::IiwaAndWsgPlantWithStateEstimator(
     // Export the inverse dynamics controller computed torque output
     output_port_iiwa_torque_.push_back(
         base_builder->ExportOutput(iiwa_controller->get_output_port_control()));
+    // Export iiwa's measured joint torque.
+    output_port_iiwa_measured_torque_.push_back(
+        plant_->model_instance_torque_output_port(
+            iiwa_instances[i].instance_id).get_index());
 
     // Sets up the WSG gripper part.
     const auto& wsg_input_port =
@@ -93,6 +97,10 @@ IiwaAndWsgPlantWithStateEstimator<T>::IiwaAndWsgPlantWithStateEstimator(
         base_builder->ExportInput(wsg_input_port));
     output_port_wsg_state_.push_back(
         base_builder->ExportOutput(wsg_output_port));
+    // Export wsg's measured joint torque.
+    output_port_wsg_measured_torque_.push_back(
+        plant_->model_instance_torque_output_port(
+            wsg_instances[i].instance_id).get_index());
 
     // Sets up a "state estimator" for iiwa that generates
     // bot_core::robot_state_t messages.

--- a/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.h
+++ b/examples/kuka_iiwa_arm/iiwa_world/iiwa_wsg_diagram_factory.h
@@ -136,6 +136,16 @@ class IiwaAndWsgPlantWithStateEstimator : public systems::Diagram<T> {
     return this->get_output_port(output_port_iiwa_torque_.at(index));
   }
 
+  const systems::OutputPort<T>& get_output_port_iiwa_measured_torque(
+      int index = 0) const {
+    return this->get_output_port(output_port_iiwa_measured_torque_.at(index));
+  }
+
+  const systems::OutputPort<T>& get_output_port_wsg_measured_torque(
+      int index = 0) const {
+    return this->get_output_port(output_port_wsg_measured_torque_.at(index));
+  }
+
  private:
   std::vector<std::unique_ptr<RigidBodyTree<T>>> objects_;
   systems::RigidBodyPlant<T>* plant_{nullptr};
@@ -148,6 +158,8 @@ class IiwaAndWsgPlantWithStateEstimator : public systems::Diagram<T> {
   std::vector<int> output_port_iiwa_torque_;
   std::vector<int> output_port_iiwa_robot_state_t_;
   std::vector<int> output_port_object_robot_state_t_;
+  std::vector<int> output_port_iiwa_measured_torque_;
+  std::vector<int> output_port_wsg_measured_torque_;
   int output_port_plant_state_{-1};
   int output_port_contact_results_{-1};
   int output_port_kinematics_results_{-1};

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -173,6 +173,11 @@ int DoMain() {
   auto iiwa_status_sender = builder.AddSystem<IiwaStatusSender>();
   iiwa_status_sender->set_name("iiwa_status_sender");
 
+  std::vector<int> instance_ids = {iiwa_instance.instance_id};
+  auto external_torque_converter =
+      builder.AddSystem<IiwaContactResultsToExternalTorque>(
+          tree, instance_ids);
+
   // TODO(siyuan): Connect this to kuka_planner runner once it generates
   // reference acceleration.
   auto iiwa_zero_acceleration_source =
@@ -192,7 +197,13 @@ int DoMain() {
   builder.Connect(iiwa_command_receiver->get_output_port(0),
                   iiwa_status_sender->get_command_input_port());
   builder.Connect(model->get_output_port_computed_torque(),
-                  iiwa_status_sender->get_torque_commanded_input_port());
+                  iiwa_status_sender->get_commanded_torque_input_port());
+  builder.Connect(model->get_output_port_iiwa_measured_torque(),
+                  iiwa_status_sender->get_measured_torque_input_port());
+  builder.Connect(model->get_output_port_contact_results(),
+                  external_torque_converter->get_input_port(0));
+  builder.Connect(external_torque_converter->get_output_port(0),
+                  iiwa_status_sender->get_external_torque_input_port());
   builder.Connect(iiwa_status_sender->get_output_port(0),
                   iiwa_status_pub->get_input_port(0));
 

--- a/multibody/rigid_body_plant/compliant_contact_model.cc
+++ b/multibody/rigid_body_plant/compliant_contact_model.cc
@@ -182,6 +182,9 @@ VectorX<T> CompliantContactModel<T>::ComputeContactForce(
       }
     }
   }
+  if (contacts != nullptr) {
+    contacts->set_generalized_contact_force(contact_force);
+  }
   return contact_force;
 }
 

--- a/multibody/rigid_body_plant/contact_results.h
+++ b/multibody/rigid_body_plant/contact_results.h
@@ -14,8 +14,10 @@ template <typename T>
 class RigidBodyPlant;
 
 /**
- A class containg the contact results (contact points and response spatial
- forces for each colliding pair of collision elements).
+ A class containing the contact results (contact points and response spatial
+ forces for each colliding pair of collision elements) as well as the sum of
+ all JᵀF for all contact, where J is the contact point Jacobian, and F is
+ the contact force.
 
  @tparam T      The scalar type. It must be a valid Eigen scalar.
 
@@ -47,8 +49,25 @@ class ContactResults {
   ContactInfo<T>& AddContact(drake::multibody::collision::ElementId element_a,
                              drake::multibody::collision::ElementId element_b);
 
+  /**
+   * Stores the contact forces as a force in the generalized coordinate.
+   * @param f = J^T * contact_force, where J is the stacked contact Jacobian,
+   * and contact_force is the stacked contact forces.
+   */
+  void set_generalized_contact_force(const VectorX<T>& f) {
+    generalized_contact_force_ = f;
+  }
+
+  /**
+   * Returns the stored generalized force that represents the contact forces.
+   */
+  const VectorX<T>& get_generalized_contact_force() const {
+    return generalized_contact_force_;
+  }
+
  private:
   std::vector<ContactInfo<T>> contacts_;
+  VectorX<T> generalized_contact_force_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
Add "measured" torque output ports to RBP, currently implemented as mere copy from inputs. 
Add J^T * F to ContactResults. 
Add IiwaContactResultsToExternalTorque, which maps the J^T * F term in ContactResults to a vector of the correct dimension, which is then feed into IiwaStatusSender's joint_torque_external term. 
robot_bridge on the other end of LCM pipeline consumes joint_torque_external.

Minimizing impacts to current setups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7822)
<!-- Reviewable:end -->
