### PR TITLE
Ignition library pkg-config files

### DIFF
--- a/tools/workspace/ignition_math/package-create-cps.py
+++ b/tools/workspace/ignition_math/package-create-cps.py
@@ -24,7 +24,8 @@ content = """
     "IGNITION-MATH_INCLUDE_DIRS": "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/include",
     "IGNITION-MATH_LINK_DIRS": "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib",
     "IGNITION-MATH_LIBRARY_DIRS": "${${CMAKE_FIND_PACKAGE_NAME}_IMPORT_PREFIX}/lib",
-    "IGNITION-MATH_LIBRARIES": "ignition_math"
+    "IGNITION-MATH_LIBRARIES": "ignition_math",
+    "ignition-math4_PKGCONFIG_ENTRY": "ignition-math4"
   }
 }
 """ % defs

--- a/tools/workspace/ignition_math/package.BUILD.bazel
+++ b/tools/workspace/ignition_math/package.BUILD.bazel
@@ -178,12 +178,34 @@ cmake_config(
 # Creates rule :install_cmake_config.
 install_cmake_config(package = CMAKE_PACKAGE)
 
+generate_file(
+    name = "ign_math_pkgconfig",
+    out = "ignition-math%d.pc" % (PROJECT_MAJOR),
+    content = """
+prefix=${pcfiledir}/../..
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Ignition math
+Description: A set of math classes for robot applications
+Version: %d.%d.%d
+Requires:
+Requires.private:
+Libs: -L${libdir} -lignition_math
+Libs.private: -ldl
+CFlags: -I${includedir}  -std=c++14
+    """ % (PROJECT_MAJOR, PROJECT_MINOR, PROJECT_PATCH),
+    visibility = ["//visibility:private"],
+)
+
 install(
     name = "install",
     workspace = CMAKE_PACKAGE,
     targets = [":libignition_math.so"],
     hdrs = public_headers,
     hdr_strip_prefix = ["include"],
+    data = [":ign_math_pkgconfig"],
+    data_dest = "lib/pkgconfig",
     docs = [
         "COPYING",
         "LICENSE",

--- a/tools/workspace/ignition_rndf/package-create-cps.py
+++ b/tools/workspace/ignition_rndf/package-create-cps.py
@@ -29,6 +29,9 @@ content = """
       "Includes": [ "@prefix@/include" ],
       "Requires": [ "ignition-math4:ignition-math4" ]
     }
+  },
+  "X-CMake-Variables": {
+    "ignition-rndf0_PKGCONFIG_ENTRY": "ignition-rndf0"
   }
 }
 """ % defs

--- a/tools/workspace/ignition_rndf/package.BUILD.bazel
+++ b/tools/workspace/ignition_rndf/package.BUILD.bazel
@@ -157,12 +157,34 @@ cmake_config(
 # Creates rule :install_cmake_config.
 install_cmake_config(package = CMAKE_PACKAGE)
 
+generate_file(
+    name = "ign_rndf_pkgconfig",
+    out = "ignition-rndf%d.pc" % (PROJECT_MAJOR),
+    content = """
+prefix=${pcfiledir}/../..
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Ignition rndf
+Description: A set of rndf classes for robot applications
+Version: %d.%d.%d
+Requires: ignition-math4
+Requires.private:
+Libs: -L${libdir} -lignition_rndf
+Libs.private: -ldl
+CFlags: -I${includedir}
+    """ % (PROJECT_MAJOR, PROJECT_MINOR, PROJECT_PATCH),
+    visibility = ["//visibility:private"],
+)
+
 install(
     name = "install",
     workspace = CMAKE_PACKAGE,
     targets = [":libignition_rndf.so"],
     hdrs = public_headers,
     hdr_strip_prefix = ["include"],
+    data = [":ign_rndf_pkgconfig"],
+    data_dest = "lib/pkgconfig",
     docs = [
         "COPYING",
         "LICENSE",


### PR DESCRIPTION
Downstream users of the ignition libraries (math and rndf) expect that those libraries provide a pkg-config file in addition to their cmake file.  While downstream users can work fine without it, they spit out warnings during cmake configuration time.  This PR generates and install pkg-config files for both ignition-math and ignition-rndf, silencing warnings from downstream consumers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7824)
<!-- Reviewable:end -->
