### PR TITLE
Use shared library for SDFormat

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -129,6 +129,7 @@ cc_library(
         "@lcm",
         "@libprotobuf",
         "@scs//:scsdir",
+        "@sdformat",
         "@tinyobjloader",
         "@tinyxml2",
     ],

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -53,11 +53,6 @@
       "Hints": ["@prefix@/lib/cmake/robotlocomotion-lcmtypes"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "SDFormat": {
-      "Version": "6.0.0",
-      "Hints": ["@prefix@/lib/cmake/sdformat"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "spdlog": {
       "Version": "1.0.0",
       "Hints": ["@prefix@/lib/cmake/spdlog"],
@@ -76,10 +71,7 @@
       "Includes": ["@prefix@/include"],
       "Compile-Features": ["c++14"],
       "Link-Flags": ["-ltinyxml2"],
-      "Link-Requires": [
-        "fmt:fmt",
-        "SDFormat:sdformat"
-      ],
+      "Link-Requires": ["fmt:fmt"],
       "Requires": [
         ":drake-lcmtypes-cpp",
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",

--- a/tools/workspace/sdformat/package-create-cps.py
+++ b/tools/workspace/sdformat/package-create-cps.py
@@ -21,16 +21,15 @@ content = """
     "ignition-math4": {
       "Version": "%(ignition-math4_VERSION)s",
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],
-      "X-CMake-Find-Args": [ "CONFIG" ]
+      "X-CMake-Find-Args": ["CONFIG"]
     }
   },
-  "Default-Components": [ ":sdformat" ],
+  "Default-Components": [":sdformat"],
   "Components": {
     "sdformat": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libsdformat.so",
       "Includes": ["@prefix@/include"],
-      "Link-Flags": ["-ltinyxml"],
       "Requires": [
         "Boost:boost",
         "ignition-math4:ignition-math4"

--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -37,7 +37,7 @@ cmake_configure_file(
     visibility = ["//visibility:private"],
 )
 
-public_headers = [
+SDFORMAT_MOST_PUBLIC_HDRS = [
     "include/sdf/Assert.hh",
     "include/sdf/Console.hh",
     "include/sdf/Element.hh",
@@ -57,24 +57,36 @@ public_headers = [
 drake_generate_include_header(
     name = "sdfhh_genrule",
     out = "include/sdf/sdf.hh",
-    hdrs = public_headers + [":config"],
+    hdrs = SDFORMAT_MOST_PUBLIC_HDRS + [":config"],
     visibility = ["//visibility:private"],
 )
+
+SDFORMAT_ALL_PUBLIC_HDRS = SDFORMAT_MOST_PUBLIC_HDRS + [
+    "include/sdf/sdf.hh",  # from genrule above
+    "include/sdf/sdf_config.h",  # from cmake_configure_file above
+]
+
+SDFORMAT_PUBLIC_INCLUDES = ["include"]
+
+SDFORMAT_DATA = glob(["sdf/1.6/*.sdf"])
+
+SDFORMAT_PUBLIC_DEPS = [
+    "@boost//:boost_headers",
+    "@ignition_math",
+]
 
 # Generates the library exported to users.  The explicitly listed srcs= matches
 # upstream's explicitly listed sources plus private headers.  The explicitly
 # listed hdrs= matches upstream's public headers.
-cc_library(
-    name = "sdformat",
-    srcs = [
+cc_binary(
+    name = "libsdformat.so",
+    srcs = SDFORMAT_ALL_PUBLIC_HDRS + [
         "include/sdf/Converter.hh",
         "include/sdf/ExceptionPrivate.hh",
         "include/sdf/SDFExtension.hh",
         "include/sdf/SDFImplPrivate.hh",
         "include/sdf/parser_private.hh",
         "include/sdf/parser_urdf.hh",
-        "include/sdf/sdf.hh",  # from genrule above
-        "include/sdf/sdf_config.h",  # from cmake_configure_file above
         "src/Console.cc",
         "src/Converter.cc",
         "src/Element.cc",
@@ -113,21 +125,25 @@ cc_library(
         "src/urdf/urdf_world/types.h",
         "src/urdf/urdf_world/world.h",
     ],
-    hdrs = public_headers,
     copts = ["-w"],
-    data = glob(["sdf/1.6/*.sdf"]),
-    includes = [
-        "include",
+    data = SDFORMAT_DATA,
+    includes = SDFORMAT_PUBLIC_INCLUDES + [
         # We use the vendored version of urdfdom embedded in sdformat; we need
         # this include path to find it.
         "src/urdf",
     ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@boost//:boost_headers",
-        "@ignition_math",
-        "@tinyxml",
-    ],
+    linkshared = 1,
+    visibility = ["//visibility:private"],
+    deps = SDFORMAT_PUBLIC_DEPS + ["@tinyxml"],
+)
+
+cc_library(
+    name = "sdformat",
+    srcs = ["libsdformat.so"],
+    hdrs = SDFORMAT_ALL_PUBLIC_HDRS,
+    data = SDFORMAT_DATA,
+    includes = SDFORMAT_PUBLIC_INCLUDES,
+    deps = SDFORMAT_PUBLIC_DEPS,
 )
 
 cmake_config(
@@ -142,11 +158,8 @@ install_cmake_config(package = "SDFormat")
 
 install(
     name = "install",
-    targets = [":sdformat"],
-    hdrs = public_headers + [
-        ":sdfhh_genrule",
-        ":config",
-    ],
+    targets = [":libsdformat.so"],
+    hdrs = SDFORMAT_ALL_PUBLIC_HDRS,
     hdr_strip_prefix = ["include"],
     docs = [
         "COPYING",


### PR DESCRIPTION
Of note, this fixes `libsdformat.so` so that `tinyxml` is correctly linked to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7828)
<!-- Reviewable:end -->
