### PR TITLE
pydrake: Add `pydrake_pybind`, with beginning documentation for conventions.

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -28,20 +28,18 @@ package(default_visibility = adjust_labels_for_drake_hoist([
     "//drake/bindings/pydrake:__subpackages__",
 ]))
 
-# N.B. Any common headers should be shared via a HEADER ONLY library.
-
-# Target Naming Conventions:
-# `*_py`
-#   A Python library (can be pure Python or pybind)
-#   Files: `*.py`, `*_py.cc`
-# `*_pybind`
-#   A C++ library for adding pybind-specific utilities to be consumed by C++.
-#   Files: `*_pybind.{h,cc}`
-
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
 PACKAGE_INFO = get_pybind_package_info(
     base_package = adjust_label_for_drake_hoist("//drake/bindings"),
+)
+
+drake_cc_library(
+    name = "pydrake_pybind",
+    hdrs = ["pydrake_pybind.h"],
+    # NOTE: We must violate IWYU and not list any Drake libraries in "deps"
+    # here because we do not want these dependencies violating ODR (at both
+    # development and install time).
 )
 
 drake_pybind_library(
@@ -57,12 +55,9 @@ drake_pybind_library(
     ],
 )
 
-# TODO(eric.cousineau): Ensure that this is not installed.
 drake_cc_library(
     name = "autodiff_types_pybind",
     hdrs = ["autodiff_types_pybind.h"],
-    # NOTE: We must violate IWYU and not list "autodiff" in "deps" here because
-    # we do not want these dependencies leaking in at install time.
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/autodiff_types_pybind.h
+++ b/bindings/pydrake/autodiff_types_pybind.h
@@ -3,12 +3,10 @@
 #include <Eigen/Core>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/autodiff.h"
 
+// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
+// `pybind11::detail`, so we should not place these in `drake::pydrake`.
+
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::AutoDiffXd);
-
-typedef Eigen::Matrix<drake::AutoDiffXd, Eigen::Dynamic, 1> VectorXAutoDiffXd;
-
-typedef Eigen::Matrix<drake::AutoDiffXd, 3, Eigen::Dynamic> Matrix3XAutoDiffXd;
-
-typedef Eigen::Matrix<drake::AutoDiffXd, 4, 4> Matrix44AutoDiffXd;

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -3,13 +3,13 @@
 #include <pybind11/stl.h>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
-
-namespace py = pybind11;
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 
 using std::sin;
 using std::cos;
 
-using drake::AutoDiffXd;
+namespace drake {
+namespace pydrake {
 
 /**
  * Force Eigen to evaluate an autodiff expression. We need this function
@@ -78,3 +78,6 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
       return eval(other / self);
     }, py::is_operator());
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/common_py.cc
+++ b/bindings/pydrake/common_py.cc
@@ -2,12 +2,14 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_assertion_error.h"
 #include "drake/common/drake_path.h"
 #include "drake/common/find_resource.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 // This function is defined in drake/common/drake_assert_and_throw.cc.
 extern "C" void drake_set_assertion_failure_to_throw_exception();
@@ -28,21 +30,21 @@ PYBIND11_MODULE(_common_py, m) {
   py::register_exception_translator([](std::exception_ptr p) {
       try {
         if (p) { std::rethrow_exception(p); }
-      } catch (const drake::detail::assertion_error& e) {
+      } catch (const detail::assertion_error& e) {
         PyErr_SetString(PyExc_SystemExit, e.what());
       }
     });
   // Convenient wrapper to add a resource search path.
-  m.def("AddResourceSearchPath", &drake::AddResourceSearchPath,
+  m.def("AddResourceSearchPath", &AddResourceSearchPath,
         "Adds a path in which to search for resource files. "
         "The path refers to the relative path within the Drake repository, ",
         py::arg("search_path"));
   // Convenient wrapper to get the list of resource search paths.
-  m.def("GetResourceSearchPaths", &drake::GetResourceSearchPaths,
+  m.def("GetResourceSearchPaths", &GetResourceSearchPaths,
         "Gets a copy of the list of paths set programmatically in which "
         "resource files are searched.");
   // Convenient wrapper for querying FindResource(resource_path).
-  m.def("FindResourceOrThrow", &drake::FindResourceOrThrow,
+  m.def("FindResourceOrThrow", &FindResourceOrThrow,
         "Attempts to locate a Drake resource named by the given path string. "
         "The path refers to the relative path within the Drake repository, "
         "e.g., drake/examples/pendulum/Pendulum.urdf. Raises an exception "
@@ -51,7 +53,7 @@ PYBIND11_MODULE(_common_py, m) {
   // Returns the fully-qualified path to the root of the `drake` source tree.
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  m.def("GetDrakePath", &drake::GetDrakePath,
+  m.def("GetDrakePath", &GetDrakePath,
         "Get Drake path");
   #pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   // These are meant to be called internally by pydrake; not by users.
@@ -61,3 +63,6 @@ PYBIND11_MODULE(_common_py, m) {
   m.def("trigger_an_assertion_failure", &trigger_an_assertion_failure,
         "Trigger a Drake C++ assertion failure");
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/examples/pendulum_py.cc
+++ b/bindings/pydrake/examples/pendulum_py.cc
@@ -1,17 +1,17 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
-
-namespace py = pybind11;
 
 using std::make_unique;
 using std::unique_ptr;
 using std::vector;
 
+namespace drake {
+namespace pydrake {
+
 PYBIND11_MODULE(pendulum, m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -27,3 +27,6 @@ PYBIND11_MODULE(pendulum, m) {
   py::class_<PendulumPlant<T>, LeafSystem<T>>(m, "PendulumPlant")
     .def(py::init<>());
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/parsers_py.cc
+++ b/bindings/pydrake/parsers_py.cc
@@ -1,8 +1,10 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/parsers/package_map.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(parsers, m) {
   using drake::parsers::PackageMap;
@@ -19,3 +21,6 @@ PYBIND11_MODULE(parsers, m) {
     .def("PopulateFromEnvironment", &PackageMap::PopulateFromEnvironment)
     .def("PopulateUpstreamToDrake", &PackageMap::PopulateUpstreamToDrake);
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+// N.B. Avoid including other headers, such as `pybind11/eigen.sh` or
+// `pybind11/functional.sh`, such that modules can opt-in to (and pay the cost
+// for) these binding capabilities.
+
+namespace drake {
+namespace pydrake {
+
+/**
+@page python_bindings Python Bindings
+
+Drake uses [pybind11](http://pybind11.readthedocs.io/en/stable/) for binding
+its C++ API to Python.
+
+At present, a fork of `pybind11` is used which permits bindings matrices with
+`dtype=object`, passing `unique_ptr` objects, and prevents aliasing for Python
+classes derived from `pybind11` classes.
+
+# Conventions
+
+## Target Conventions
+
+Target names should be of the following form:
+
+- `*_py`: A Python library (can be pure Python or pybind)
+  - File Names: `*.py`, `*_py.cc`
+
+- `*_pybind`: A C++ library for adding pybind-specific utilities to be consumed
+  by C++.
+  - File Names: `*_pybind.{h,cc}`
+
+File names should follow form with their respective target.
+
+### Bazel
+
+Given that `libdrake.so` relies on static linking for components,
+any common headers should be robust against ODR violations. This can
+be normally achieved by using header-only libraries.
+
+For upstream dependencies of these libraries, do NOT depend on the direct
+targets (e.g. `//common:essential`), because this will introduce runtime ODR
+violations for objects that have static storage (UID counters, etc.).
+
+Instead, you must temporarily violate IWYU because it will be satisfied by
+`drake_pybind_library`, which will incorporate `libdrake.so` and the transitive
+headers.
+
+If singletons are required (e.g. for `util/cpp_param_pybind`), consider storing
+the singleton values using Python.
+
+If you are developing bindings for a small portion of Drake and would like to
+avoid rebuilding a large number of components when testing, consider editing
+`//tools/install/libdrake:build_components.bzl` to reduce the number of
+components being built.
+
+## pybind Module Definitions
+
+- Any Drake pybind module should include this header file, `pydrake_pybind.h`.
+- `PYBIND_MODULE` should be used to define modules.
+- Modules should be defined within the namespace `drake::pydrake`.
+- The alias `namespace py = pybind11` is defined as `drake::pydrake::py`. Drake
+modules should not re-define this alias at global scope.
+- If a certain namespace is being bound (e.g. `drake::systems::sensors`), you
+may use `using namespace drake::systems::sensors` within functions or
+anonymous namespaces. Avoid `using namespace` directives otherwise.
+
+## Keep Alive Behavior
+
+`py::keep_alive` is used heavily throughout this code. For more
+information, please see [the pybind11 documentation](
+http://pybind11.readthedocs.io/en/stable/advanced/functions.html#keep-alive).
+
+Terse notes are added to method bindings to indicate the patient
+(object being kept alive by nurse) and the nurse (object keeping patient
+alive). To expand on them:
+- "Keep alive, ownership" implies that one argument is owned directly by
+one of the other arguments (`self` is included in those arguments, for
+`py::init<>` and class methods).
+- "Keep alive, reference" implies a reference that is lifetime-sensitive
+(something that is not necessarily owned by the other arguments).
+- "Keep alive, transitive" implies a transfer of ownership of owned
+objects from one container to another (e.g. transfering all `System`s
+from `DiagramBuilder` to `Diagram` when calling
+`DiagramBuilder.Build()`).
+
+# Interactive Debugging with Bazel
+
+If you would like to interactively debug binding code (using IPython for
+general Python behavior, or GDB for C++ behavior), debug C++ behavior from a
+Python binary, while using Bazel, you may expose Bazel's development
+environment variables by adding these lines to your Python script:
+
+    import subprocess
+    subprocess.Popen(
+        "export -p | sed 's# PWD=# OLD_PWD=#g' | tee /tmp/env.sh",
+        shell=True)
+
+Run your target once from Bazel, and then source the generated `/tmp/env.sh` in
+your terminal to gain access to the environment variables (e.g. `$PYTHONPATH`).
+
+## Example with GDB
+
+This is a brief recipe for debugging with GDB
+(note the usage of subshell `(...)` to keep the variables scoped):
+
+    (
+        target=//bindings/pydrake/systems:lifetime_test
+        target_bin=$(echo ${target} | sed -e 's#//##' -e 's#:#/#')
+        bazel run -c dbg ${target}
+        workspace=$(bazel info workspace)
+        name=$(basename ${workspace})
+        cd ${workspace}/bazel-${name}
+        source /tmp/env.sh
+        gdb --args python ${workspace}/bazel-bin/${target_bin}
+    )
+
+This allows you to use GDB from the terminal, while being able to inspect the
+sources in Bazel's symlink forests.
+
+If using CLion, consider using `gdbserver`.
+
+*/
+
+// TODO(eric.cousineau): Add API naming conventions (#7819).
+
+/// @defgroup Convenience aliases
+/// @{
+
+/// Shorthand alias to `pybind` for consistency.
+/// @note Downstream users should avoid `using namespace drake::pydrake`, as
+/// this may create ambiguous aliases (especially for GCC). Instead, consider
+/// an alias.
+namespace py = pybind11;
+
+/// Used when returning `T& or `const T&`, as pybind's default behavior is to
+/// copy lvalue references.
+const auto py_reference_internal =
+    py::return_value_policy::reference_internal;
+
+/// Used when returning references to objects that are internally owned by
+/// `self`. Implies both `py_reference` and `py::keep_alive<0, 1>`, which
+/// implies "Keep alive, reference: `return` keeps` self` alive".
+const auto py_reference = py::return_value_policy::reference;
+
+/// @}
+
+// TODO(eric.cousineau): pybind11 defaults to C++-like copies when dealing
+// with rvalues. We should wrap this into a drake-level binding, so that we
+// can default this to `py_reference` or `py_reference_internal.`
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/rbtree_py.cc
+++ b/bindings/pydrake/rbtree_py.cc
@@ -5,17 +5,18 @@
 #include <pybind11/stl.h>
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/parsers/package_map.h"
 #include "drake/multibody/parsers/sdf_parser.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(_rbtree_py, m) {
   m.doc() = "Bindings for the RigidBodyTree class";
 
-  using drake::AutoDiffXd;
   using drake::multibody::joints::FloatingBaseType;
   using drake::parsers::PackageMap;
   namespace sdf = drake::parsers::sdf;
@@ -97,12 +98,12 @@ PYBIND11_MODULE(_rbtree_py, m) {
       return tree.doKinematics(q, v);
     })
     .def("doKinematics", [](const RigidBodyTree<double>& tree,
-                            const VectorXAutoDiffXd& q) {
+                            const VectorX<AutoDiffXd>& q) {
       return tree.doKinematics(q);
     })
     .def("doKinematics", [](const RigidBodyTree<double>& tree,
-                            const VectorXAutoDiffXd& q,
-                            const VectorXAutoDiffXd& v) {
+                            const VectorX<AutoDiffXd>& q,
+                            const VectorX<AutoDiffXd>& v) {
       return tree.doKinematics(q, v);
     })
     .def("CalcBodyPoseInWorldFrame", [](const RigidBodyTree<double>& tree,
@@ -213,3 +214,6 @@ PYBIND11_MODULE(_rbtree_py, m) {
   m.def("AddModelInstancesFromSdfStringSearchingInRosPackages",
         &sdf::AddModelInstancesFromSdfStringSearchingInRosPackages);
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/gurobi_py.cc
+++ b/bindings/pydrake/solvers/gurobi_py.cc
@@ -1,8 +1,10 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/solvers/gurobi_solver.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(gurobi, m) {
   using drake::solvers::GurobiSolver;
@@ -16,3 +18,6 @@ PYBIND11_MODULE(gurobi, m) {
   py::class_<GurobiSolver>(m, "GurobiSolver", solverinterface)
     .def(py::init<>());
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/ik_py.cc
+++ b/bindings/pydrake/solvers/ik_py.cc
@@ -2,11 +2,13 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/multibody/ik_options.h"
 #include "drake/multibody/rigid_body_ik.h"
 #include "drake/multibody/rigid_body_tree.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(_ik_py, m) {
   m.doc() = "RigidBodyTree inverse kinematics";
@@ -261,3 +263,6 @@ PYBIND11_MODULE(_ik_py, m) {
     .def_readonly("info", &IKResults::info)
     .def_readonly("infeasible_constraints", &IKResults::infeasible_constraints);
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/ipopt_py.cc
+++ b/bindings/pydrake/solvers/ipopt_py.cc
@@ -1,8 +1,10 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/solvers/ipopt_solver.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(ipopt, m) {
   using drake::solvers::IpoptSolver;
@@ -16,3 +18,6 @@ PYBIND11_MODULE(ipopt, m) {
   py::class_<IpoptSolver>(m, "IpoptSolver", solverinterface)
     .def(py::init<>());
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -5,39 +5,42 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solver_type_converter.h"
 
-namespace py = pybind11;
 using std::string;
 
-using drake::solvers::Binding;
-using drake::solvers::BoundingBoxConstraint;
-using drake::solvers::Constraint;
-using drake::solvers::Cost;
-using drake::solvers::EvaluatorBase;
-using drake::solvers::LinearConstraint;
-using drake::solvers::LinearCost;
-using drake::solvers::LinearEqualityConstraint;
-using drake::solvers::MathematicalProgram;
-using drake::solvers::MathematicalProgramSolverInterface;
-using drake::solvers::MatrixXDecisionVariable;
-using drake::solvers::QuadraticCost;
-using drake::solvers::SolutionResult;
-using drake::solvers::SolverId;
-using drake::solvers::SolverType;
-using drake::solvers::SolverTypeConverter;
-using drake::solvers::VectorXDecisionVariable;
-using drake::symbolic::Expression;
-using drake::symbolic::Formula;
-using drake::symbolic::Variable;
+namespace drake {
+namespace pydrake {
+
+using solvers::Binding;
+using solvers::BoundingBoxConstraint;
+using solvers::Constraint;
+using solvers::Cost;
+using solvers::EvaluatorBase;
+using solvers::LinearConstraint;
+using solvers::LinearCost;
+using solvers::LinearEqualityConstraint;
+using solvers::MathematicalProgram;
+using solvers::MathematicalProgramSolverInterface;
+using solvers::MatrixXDecisionVariable;
+using solvers::QuadraticCost;
+using solvers::SolutionResult;
+using solvers::SolverId;
+using solvers::SolverType;
+using solvers::SolverTypeConverter;
+using solvers::VectorXDecisionVariable;
+using symbolic::Expression;
+using symbolic::Formula;
+using symbolic::Variable;
 
 namespace {
 // Unwrap an optional<T> for more idiomatic use in Python.  A nullopt in C++
 // becomes None in Python, and non-nullopt in C++ becomes T directly in Python.
 template <typename T>
-std::unique_ptr<T> deref_optional(const drake::optional<T>& value) {
+std::unique_ptr<T> deref_optional(const optional<T>& value) {
   return value ? std::make_unique<T>(*value) : nullptr;
 }
 
@@ -271,3 +274,6 @@ PYBIND11_MODULE(_mathematicalprogram_py, m) {
   RegisterBinding<LinearCost>(&m, &prog_cls, "LinearCost");
   RegisterBinding<QuadraticCost>(&m, &prog_cls, "QuadraticCost");
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/solvers/mosek_py.cc
+++ b/bindings/pydrake/solvers/mosek_py.cc
@@ -1,8 +1,10 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/solvers/mosek_solver.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(mosek, m) {
   using drake::solvers::MosekSolver;
@@ -16,3 +18,6 @@ PYBIND11_MODULE(mosek, m) {
   py::class_<MosekSolver>(m, "MosekSolver", solverinterface)
     .def(py::init<>());
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -2,9 +2,11 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(_symbolic_py, m) {
   using drake::symbolic::Variable;
@@ -249,3 +251,6 @@ PYBIND11_MODULE(_symbolic_py, m) {
           return !a;
     });
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/symbolic_types_pybind.h
+++ b/bindings/pydrake/symbolic_types_pybind.h
@@ -3,7 +3,11 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/common/symbolic.h"
+
+// The macro `PYBIND11_NUMPY_OBJECT_DTYPE` place symbols into the namespace
+// `pybind11::detail`, so we should not place these in `drake::pydrake`.
 
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Variable);
 PYBIND11_NUMPY_OBJECT_DTYPE(drake::symbolic::Expression);

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -1,16 +1,16 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/analysis/simulator.h"
 
-namespace py = pybind11;
-
 using std::unique_ptr;
+
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(analysis, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
-
-  auto py_iref = py::return_value_policy::reference_internal;
 
   m.doc() = "Bindings for the analysis portion of the Systems framework.";
 
@@ -27,9 +27,13 @@ PYBIND11_MODULE(analysis, m) {
          py::keep_alive<3, 1>())
     .def("Initialize", &Simulator<T>::Initialize)
     .def("StepTo", &Simulator<T>::StepTo)
-    .def("get_context", &Simulator<T>::get_context, py_iref)
-    .def("get_mutable_context", &Simulator<T>::get_mutable_context, py_iref)
+    .def("get_context", &Simulator<T>::get_context, py_reference_internal)
+    .def("get_mutable_context", &Simulator<T>::get_mutable_context,
+         py_reference_internal)
     .def("set_publish_every_time_step",
          &Simulator<T>::set_publish_every_time_step)
     .def("set_target_realtime_rate", &Simulator<T>::set_target_realtime_rate);
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -1,6 +1,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/constant_value_source.h"
 #include "drake/systems/primitives/constant_vector_source.h"
@@ -8,11 +9,10 @@
 #include "drake/systems/primitives/signal_logger.h"
 #include "drake/systems/primitives/zero_order_hold.h"
 
-namespace py = pybind11;
+namespace drake {
+namespace pydrake {
 
 PYBIND11_MODULE(primitives, m) {
-  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake;
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems;
 
@@ -42,3 +42,6 @@ PYBIND11_MODULE(primitives, m) {
 
   // TODO(eric.cousineau): Add more systems as needed.
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -24,9 +24,6 @@ using constant = std::integral_constant<T, Value>;
 template <typename T, T ... Values>
 using constant_pack = type_pack<type_pack<constant<T, Values>>...>;
 
-const auto py_reference = py::return_value_policy::reference;
-const auto py_reference_internal = py::return_value_policy::reference_internal;
-
 using Eigen::Map;
 using Eigen::Ref;
 

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -1,19 +1,21 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 
-namespace py = pybind11;
-
 using std::unique_ptr;
-using drake::VectorX;
-using drake::systems::BasicVector;
-using drake::systems::ConstantVectorSource;
+
+namespace drake {
+
+using systems::BasicVector;
+using systems::ConstantVectorSource;
+
+namespace pydrake {
+namespace {
 
 using T = double;
-
-namespace {
 
 // Informs listener when this class is deleted.
 class DeleteListenerSystem : public ConstantVectorSource<T> {
@@ -46,7 +48,7 @@ class DeleteListenerVector : public BasicVector<T> {
 
 PYBIND11_MODULE(test_util, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
-  using namespace drake::systems;
+  using namespace systems;
 
   // Import dependencies.
   py::module::import("pydrake.systems.framework");
@@ -68,3 +70,6 @@ PYBIND11_MODULE(test_util, m) {
     system->Publish(*context, *events);
   });
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/test/odr_test_module_py.cc
+++ b/bindings/pydrake/test/odr_test_module_py.cc
@@ -1,10 +1,13 @@
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
 
-namespace py = pybind11;
+namespace drake {
 
-using drake::symbolic::Variable;
+using symbolic::Variable;
+
+namespace pydrake {
 
 PYBIND11_MODULE(odr_test_module, m) {
   m.doc() = "Test ODR using Variable.";
@@ -13,3 +16,6 @@ PYBIND11_MODULE(odr_test_module, m) {
     return new Variable(name);
   });
 }
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -60,6 +60,7 @@ drake_cc_library(
     hdrs = ["cpp_param_pybind.h"],
     deps = [
         ":type_pack",
+        "//bindings/pydrake:pydrake_pybind",
         "@pybind11",
     ],
 )
@@ -87,6 +88,7 @@ drake_cc_library(
     hdrs = ["cpp_template_pybind.h"],
     deps = [
         ":cpp_param_pybind",
+        "//bindings/pydrake:pydrake_pybind",
         "@pybind11",
     ],
 )

--- a/bindings/pydrake/util/cpp_param_pybind.h
+++ b/bindings/pydrake/util/cpp_param_pybind.h
@@ -9,15 +9,11 @@
 
 #include <pybind11/pybind11.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/util/type_pack.h"
 
 namespace drake {
 namespace pydrake {
-
-// This alias is intended to be part of the public API, as it follows
-// `pybind11` conventions.
-namespace py = pybind11;
-
 namespace internal {
 
 // Gets singleton for type aliases from `cpp_param`.

--- a/bindings/pydrake/util/cpp_template_pybind.h
+++ b/bindings/pydrake/util/cpp_template_pybind.h
@@ -7,15 +7,13 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include "drake/bindings/pydrake/pydrake_pybind.h"
 // `GetPyTypes` is implemented specifically for `cpp_template`; to simplify
 // dependencies, this is included transitively.
 #include "drake/bindings/pydrake/util/cpp_param_pybind.h"
 
 namespace drake {
 namespace pydrake {
-
-namespace py = pybind11;
-
 namespace internal {
 
 // C++ interface for `pydrake.util.cpp_template.get_or_init`.

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -84,6 +84,7 @@ def drake_pybind_library(
         C++ dependencies.
         At present, these should be libraries that will not cause ODR
         conflicts (generally, header-only).
+        By default, this includes `pydrake_pybind`.
     @param cc_so_name (optional)
         Shared object name. By default, this is `_${name}`, so that the C++
         code can be then imported in a more controlled fashion in Python.
@@ -114,7 +115,9 @@ def drake_pybind_library(
     _drake_pybind_cc_binary(
         name = cc_so_name,
         srcs = cc_srcs,
-        deps = cc_deps,
+        deps = cc_deps + [
+            "//bindings/pydrake:pydrake_pybind",
+        ],
         testonly = testonly,
         visibility = visibility,
     )
@@ -217,6 +220,7 @@ def drake_pybind_cc_googletest(
         name = cc_name,
         srcs = cc_srcs,
         deps = cc_deps + [
+            "//bindings/pydrake:pydrake_pybind",
             "//tools/install/libdrake:drake_shared_library",
             "@pybind11",
         ],


### PR DESCRIPTION
This provides an alternative to #7818 (that I prefer much more), and provides a start to #7819.

\cc @jwnimmer-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7829)
<!-- Reviewable:end -->
