### PR TITLE
prstat: Use merge-base rather than `upstream/master` directly.

### DIFF
--- a/tools/prstat
+++ b/tools/prstat
@@ -19,7 +19,7 @@ excludes="$excludes --exclude=*/dev/*"
 # generated code.  See https://github.com/Reviewable/Reviewable/wiki/FAQ.
 marker="GENERATED FILE ""DO NOT EDIT"
 toplevel=$(git rev-parse --show-toplevel)
-git_base_path=upstream/master
+git_base_path=$(git merge-base upstream/master HEAD)
 for relpath in $(git diff $git_base_path | lsdiff $excludes --strip=1); do
     if fgrep -s -q -e"$marker" $toplevel/$relpath; then
         excludes="$excludes --exclude=$relpath"


### PR DESCRIPTION
Quick mod for using `merge-base` so you don't incorporate changes after your fork into the stats.

Related to @SeanCurtis-TRI's https://github.com/SeanCurtis-TRI/git_cloc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7833)
<!-- Reviewable:end -->
