### PR TITLE
Specialization of std::hash for TypeSafeIndex.

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -370,6 +370,7 @@ drake_cc_library(
     hdrs = ["type_safe_index.h"],
     deps = [
         ":essential",
+        ":hash",
         ":nice_type_name",
     ],
 )

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -3,6 +3,7 @@
 #include <limits>
 #include <regex>
 #include <sstream>
+#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -492,16 +493,16 @@ GTEST_TEST(TypeSafeIndex, ConstructorAvailability) {
 // Confirms that type safe indexes are configured to serve as key and/or values
 // within std::unordered_map
 GTEST_TEST(TypeSafeIndex, CompatibleWithUnorderedMap) {
-  std::unordered_map<BIndex, AIndex> indexes;
+  std::unordered_map<AIndex, std::string> indexes;
   AIndex a1(1), a2(2), a3(3);
-  BIndex b1(0), b2(2), b3(6);
-  indexes.emplace(b1, a1);
-  indexes.emplace(b2, a2);
-  EXPECT_EQ(indexes.find(b3), indexes.end());
-  EXPECT_NE(indexes.find(b2), indexes.end());
-  EXPECT_NE(indexes.find(b1), indexes.end());
-  indexes[b3] = a3;
-  EXPECT_NE(indexes.find(b3), indexes.end());
+  std::string s1("hello"), s2("unordered"), s3("map");
+  indexes.emplace(a1, s1);
+  indexes.emplace(a2, s2);
+  EXPECT_EQ(indexes.find(a3), indexes.end());
+  EXPECT_NE(indexes.find(a2), indexes.end());
+  EXPECT_NE(indexes.find(a1), indexes.end());
+  indexes[a3] = s3;
+  EXPECT_NE(indexes.find(a3), indexes.end());
 }
 
 // Confirms that type safe indexes are configured to serve as values

--- a/common/test/type_safe_index_test.cc
+++ b/common/test/type_safe_index_test.cc
@@ -4,6 +4,8 @@
 #include <regex>
 #include <sstream>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -485,6 +487,35 @@ GTEST_TEST(TypeSafeIndex, ConstructorAvailability) {
   EXPECT_TRUE((has_constructor<AIndex, int>()));
   EXPECT_TRUE((has_constructor<AIndex, size_t>()));
   EXPECT_TRUE((has_constructor<AIndex, int64_t>()));
+}
+
+// Confirms that type safe indexes are configured to serve as key and/or values
+// within std::unordered_map
+GTEST_TEST(TypeSafeIndex, CompatibleWithUnorderedMap) {
+  std::unordered_map<BIndex, AIndex> indexes;
+  AIndex a1(1), a2(2), a3(3);
+  BIndex b1(0), b2(2), b3(6);
+  indexes.emplace(b1, a1);
+  indexes.emplace(b2, a2);
+  EXPECT_EQ(indexes.find(b3), indexes.end());
+  EXPECT_NE(indexes.find(b2), indexes.end());
+  EXPECT_NE(indexes.find(b1), indexes.end());
+  indexes[b3] = a3;
+  EXPECT_NE(indexes.find(b3), indexes.end());
+}
+
+// Confirms that type safe indexes are configured to serve as values
+// within std::unordered_set
+GTEST_TEST(TypeSafeIndex, CompatibleWithUnorderedSet) {
+  std::unordered_set<AIndex> indexes;
+  AIndex a1(1), a2(2), a3(3);
+
+  indexes.emplace(a1);
+  indexes.insert(a2);
+  EXPECT_EQ(indexes.size(), 2);
+  EXPECT_EQ(indexes.find(a3), indexes.end());
+  EXPECT_NE(indexes.find(a1), indexes.end());
+  EXPECT_NE(indexes.find(a2), indexes.end());
 }
 
 }  // namespace

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/hash.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {
@@ -446,3 +447,13 @@ class TypeSafeIndex {
 };
 
 }  // namespace drake
+
+namespace std {
+/// Specialization of std::hash for drake::TypeSafeIndex<Tag>.
+template <typename Tag>
+struct hash<drake::TypeSafeIndex<Tag>> {
+  size_t operator()(const drake::TypeSafeIndex<Tag>& index) const {
+    return hash<int64_t>()(index);
+  }
+};
+}  // namespace std

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <functional>
 #include <limits>
 #include <string>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/hash.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {
@@ -453,7 +453,7 @@ namespace std {
 template <typename Tag>
 struct hash<drake::TypeSafeIndex<Tag>> {
   size_t operator()(const drake::TypeSafeIndex<Tag>& index) const {
-    return hash<int64_t>()(index);
+    return std::hash<int>()(index);
   }
 };
 }  // namespace std

--- a/geometry/identifier.h
+++ b/geometry/identifier.h
@@ -215,7 +215,7 @@ namespace std {
 template <typename Tag>
 struct hash<drake::geometry::Identifier<Tag>> {
   size_t operator()(const drake::geometry::Identifier<Tag>& id) const {
-    return hash<int64_t>()(id.get_value());
+    return std::hash<int64_t>()(id.get_value());
   }
 };
 


### PR DESCRIPTION
I'm in need of using these with STL unordered maps in future PR's. 

Note: I tried using `drake::DefaultHash` like so:
```c++
namespace std {
template <typename Tag>
struct hash<drake::TypeSafeIndex<Tag>> : public drake::DefaultHash {}
}  // namespace std
```
but that did not work for me (meaning it would not compile with an STL error message hell).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7839)
<!-- Reviewable:end -->
