### PR TITLE
Do no use compiler wrappers on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,15 @@ list(INSERT CMAKE_MODULE_PATH 0 "${PROJECT_SOURCE_DIR}/cmake/modules")
 include(CTest)
 
 configure_file(CTestCustom.cmake.in CTestCustom.cmake @ONLY)
-foreach(LANG C CXX)
-  set(COMPILER ${CMAKE_${LANG}_COMPILER})
-  configure_file(tools/cc_toolchain/wrapper.sh.in ${CMAKE_CURRENT_BINARY_DIR}/${LANG}_wrapper.sh @ONLY)
-endforeach()
+if(NOT APPLE)
+  foreach(LANG C CXX)
+    set(COMPILER ${CMAKE_${LANG}_COMPILER})
+    configure_file(tools/cc_toolchain/wrapper.sh.in ${CMAKE_CURRENT_BINARY_DIR}/${LANG}_wrapper.sh @ONLY)
+  endforeach()
+  set(BAZEL_ENV "CC=${CMAKE_CURRENT_BINARY_DIR}/C_wrapper.sh" "CXX=${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh")
+else()
+  set(BAZEL_ENV "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}")
+endif()
 
 if(CYGWIN OR NOT UNIX)
   message(FATAL_ERROR "Cygwin and non-Unix platforms are NOT supported")
@@ -47,8 +52,6 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
 else()
   set(BAZEL_COMPILATION_MODE opt)
 endif()
-
-set(BAZEL_ENV "CC=${CMAKE_CURRENT_BINARY_DIR}/C_wrapper.sh" "CXX=${CMAKE_CURRENT_BINARY_DIR}/CXX_wrapper.sh")
 
 set(BAZEL_ARGS
   --compilation_mode=${BAZEL_COMPILATION_MODE}

--- a/tools/cc_toolchain/wrapper.sh.in
+++ b/tools/cc_toolchain/wrapper.sh.in
@@ -16,24 +16,24 @@ if [[ "$*" ==  *"-E"* ]] &&
 then
     $_COMPILER "$@" 2>&1 >/dev/null | while IFS= read line ; do
     # Prints include directory in stderr, and if it is a symlink, gets the link
-    # path and print it to stderr too. We cannot use `readlink -f` because
-    # MacOS `readlink` does not have this flag. Using Python instead.
+    # path and print it to stderr too. Since this is only run on Linux, we can
+    # use `readlink -f`.
     line_escape=$(echo "$line" |sed "s/'/\\\\'/g")
-    python -c "$(echo "
-        import os
-        import sys
-        import re
-        line = '$line_escape'
-        sys.stderr.write(line + '\n')
-        if re.match('^[ ]*/usr/.*', line):
-            filename = line.lstrip()
-            nbspaces = len(line) - len(filename)
-            if os.path.islink(filename):
-                path = os.path.join(os.path.dirname(filename), os.readlink(filename))
-                path = os.path.abspath(path)
-                sys.stderr.write(' ' * nbspaces + path + '\n')
-        " | sed 's/        //')"
-    done
+    echo "$line" >&2
+    line_trim=$(echo $line | sed -e 's/^[[:space:]]*//')
+    # Only run `readlink` on include directories.
+    if [[  "$line_trim" == /usr/* ]] ; then
+       line_link=$(readlink -f "$line_trim")
+       # If it is actually a link, then print the real path.
+       if [[ $line_trim != $line_link ]]; then
+         # Escape slashes to be able to use the string in `sed`
+         line_link=$(echo $line_link | sed -e 's/\//\\\//g')
+         # Adds the same number of space at the beginning of the line
+         # as there was in the original string.
+         echo "$line" | sed -e "s/\/usr.*/$line_link/" >&2
+       fi
+     fi
+   done
 else
 # Otherwise, just run the compiler normally.
   $_COMPILER "$@"


### PR DESCRIPTION
Bazel already uses wrappers on MacOS which are setup with bazel's CROSSTOOL.
With the current wrappers, on MacOS, bazel ends up sometimes using the
wrappers and sometimes not using them, depending if it calls `cc_wrapper.sh`
which does call drake's compiler wrapper, or `wrapped_clang` which doesn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7840)
<!-- Reviewable:end -->
