### PR TITLE
wrap_function: Allow general function wrapping to facilitate consistent pybind workflows.

### DIFF
--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -39,6 +39,11 @@ drake_cc_library(
     hdrs = ["type_pack.h"],
 )
 
+drake_cc_library(
+    name = "wrap_function",
+    hdrs = ["wrap_function.h"],
+)
+
 # This is a pure-python, standalone library SET.
 # Keep this away from `common_py` to simplify test dependencies.
 drake_py_library(
@@ -119,6 +124,13 @@ drake_cc_googletest(
     deps = [
         ":type_pack",
         "//common:nice_type_name",
+    ],
+)
+
+drake_cc_googletest(
+    name = "wrap_function_test",
+    deps = [
+        ":wrap_function",
     ],
 )
 

--- a/bindings/pydrake/util/test/wrap_function_test.cc
+++ b/bindings/pydrake/util/test/wrap_function_test.cc
@@ -1,0 +1,360 @@
+#include "drake/bindings/pydrake/util/wrap_function.h"
+
+#include <functional>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+// @note Some of these statements violate style guide. That is intended, as
+// this should test references for use in `pybind`.
+
+namespace drake {
+namespace pydrake {
+
+// N.B. Anonymous namespace not used as it makes failure messages
+// (static_assert) harder to interpret.
+
+// Will keep argument / return types the same, but homogenize method signatures.
+template <typename Func>
+auto WrapIdentity(Func&& func) {
+  return WrapFunction<wrap_arg_default>(std::forward<Func>(func));
+}
+
+// Functions with primitive values (int) as return, with 0-1 arugments and/or
+// parameters.
+void Void() {}
+void IntToVoid(int) {}
+int ReturnInt() { return 1; }
+int IntToInt(int value) { return value; }
+
+GTEST_TEST(WrapFunction, FunctionPointer) {
+  int value{0};
+  WrapIdentity(Void)();
+  WrapIdentity(&Void)();  // Test pointer style.
+  WrapIdentity(IntToVoid)(value);
+  EXPECT_EQ(WrapIdentity(ReturnInt)(), 1);
+  EXPECT_EQ(WrapIdentity(IntToInt)(value), value);
+}
+
+// Lambdas / basic functors.
+GTEST_TEST(WrapFunction, Lambda) {
+  int value{0};
+  auto func_1_lambda = [](int value) {};
+  WrapIdentity(func_1_lambda)(value);
+
+  std::function<void(int)> func_1_func = func_1_lambda;
+  WrapIdentity(func_1_func)(value);
+}
+
+// Class methods.
+class MyClass {
+ public:
+  static int MethodStatic(int value) { return value; }
+  int MethodMutable(int value) { return value + value_; }
+  int MethodConst(int value) const { return value * value_; }
+
+ private:
+  int value_{10};
+};
+
+GTEST_TEST(WrapFunction, Methods) {
+  int value = 2;
+
+  MyClass c;
+  const MyClass& c_const{c};
+
+  // Wrapped signature: Unchanged.
+  EXPECT_EQ(WrapIdentity(&MyClass::MethodStatic)(value), 2);
+  // Wrapped signature: int (MyClass*, int)
+  auto method_mutable = WrapIdentity(&MyClass::MethodMutable);
+  EXPECT_EQ(method_mutable(&c, value), 12);
+  // method_mutable(&c_const, value);  // Should fail.
+  // Wrapped signature: int (const MyClass*, int)
+  EXPECT_EQ(WrapIdentity(&MyClass::MethodConst)(&c_const, value), 20);
+}
+
+// Move-only arguments.
+struct MoveOnlyValue {
+  MoveOnlyValue() = default;
+  MoveOnlyValue(const MoveOnlyValue&) = delete;
+  MoveOnlyValue& operator=(const MoveOnlyValue&) = delete;
+  MoveOnlyValue(MoveOnlyValue&&) = default;
+  MoveOnlyValue& operator=(MoveOnlyValue&&) = default;
+  int value{};
+};
+
+void ArgMoveOnly(MoveOnlyValue arg) {
+  EXPECT_EQ(arg.value, 1);
+}
+
+const int& ArgMoveOnlyConst(const MoveOnlyValue& arg) {
+  return arg.value;
+}
+
+int& ArgMoveOnlyMutable(MoveOnlyValue& arg) {  // NOLINT
+  arg.value += 1;
+  return arg.value;
+}
+
+GTEST_TEST(WrapFunction, ArgMoveOnly) {
+  WrapIdentity(ArgMoveOnly)(MoveOnlyValue{1});
+  MoveOnlyValue v{10};
+
+  const int& out_const = WrapIdentity(ArgMoveOnlyConst)(v);
+  v.value += 10;
+  EXPECT_EQ(out_const, 20);
+
+  int& out_mutable = WrapIdentity(ArgMoveOnlyMutable)(v);
+  EXPECT_EQ(out_mutable, 21);
+  out_mutable += 1;
+  EXPECT_EQ(v.value, 22);
+}
+
+// Provides a functor which can be default constructed and moved only.
+struct MoveOnlyFunctor {
+  MoveOnlyFunctor(const MoveOnlyFunctor&) = delete;
+  MoveOnlyFunctor& operator=(const MoveOnlyFunctor&) = delete;
+  MoveOnlyFunctor(MoveOnlyFunctor&&) = default;
+  MoveOnlyFunctor& operator=(MoveOnlyFunctor&&) = default;
+  // N.B. Per documentation, cannot overload operator(), as it's ambiguous when
+  // attempting to infer arguments.
+  void operator()(int& value) const {  // NOLINT
+    value += 1;
+  }
+};
+
+GTEST_TEST(WrapFunction, MoveOnlyFunctor) {
+  int value = 0;
+  auto wrapped = WrapIdentity(MoveOnlyFunctor{});
+  wrapped(value);
+  EXPECT_EQ(value, 1);
+}
+
+struct ConstFunctor {
+  void operator()(int& value) const { value += 1; }  // NOLINT
+};
+
+GTEST_TEST(WrapFunction, ConstFunctor) {
+  int value = 0;
+  const ConstFunctor functor{};
+  auto wrapped = WrapIdentity(functor);
+  wrapped(value);
+  EXPECT_EQ(value, 1);
+}
+
+// Test a slightly complicated conversion mechanism.
+
+// Wraps `const T&` or `const T*`.
+template <typename T>
+struct const_ptr {
+  static_assert(!std::is_const<T>::value, "Bad (redundant) inference");
+  const T* value{};
+};
+
+// Wraps `T&` or `T*` (where `T` is non-const).
+template <typename T>
+struct ptr {
+  // Ensure that this is not being used in lieu of `const_ptr` (ensure that
+  // our specializiation delegates correctly).
+  static_assert(
+      !std::is_const<T>::value, "Should be using `const_ptr`");
+  T* value{};
+};
+
+// Base case: Pass though.
+template <typename T, typename = void>
+struct wrap_change : public wrap_arg_default<T> {};
+
+template <typename T>
+using wrap_change_t =
+    detail::wrap_function_impl<wrap_change>::wrap_type_t<T>;
+
+// Wraps any `const T*` with `const_ptr`, except for `int`.
+// SFINAE. Could be achieved with specialization, but using to uphold SFINAE
+// contract provided by `WrapFunction`.
+template <typename T>
+struct wrap_change<const T*, std::enable_if_t<!std::is_same<T, int>::value>> {
+  static const_ptr<T> wrap(const T* arg) {
+    return {arg};
+  }
+
+  static const T* unwrap(const_ptr<T> arg_wrapped) {
+    return arg_wrapped.value;
+  }
+};
+
+// Wraps any `const T&` with `const_ptr`, except for `int`.
+// Leverage `const T&` logic, such that we'd get the default template when
+// SFINAE prevents matching.
+template <typename T>
+struct wrap_change<const T&> : public wrap_change<const T*> {
+  using Base = wrap_change<const T*>;
+  using Wrapped = wrap_change_t<const T*>;
+
+  static Wrapped wrap(const T& arg) { return Base::wrap(&arg); }
+
+  static const T& unwrap(Wrapped arg_wrapped) {
+    return *Base::unwrap(arg_wrapped);
+  }
+};
+
+// Wraps any mutable `T*` with `ptr`.
+// N.B. Prevent `const T*` from binding here, since it may be rejected from
+// SFINAE.
+template <typename T>
+struct wrap_change<T*, std::enable_if_t<!std::is_const<T>::value>> {
+  static ptr<T> wrap(T* arg) { return {arg}; }
+  static T* unwrap(ptr<T> arg_wrapped) { return arg_wrapped.value; }
+};
+
+// Wraps any mutable `T&` with `ptr`.
+template <typename T>
+struct wrap_change<T&> {
+  static ptr<T> wrap(T& arg) { return {&arg}; }  // NOLINT
+  static T& unwrap(ptr<T> arg_wrapped) { return *arg_wrapped.value; }
+};
+
+// Test case to exercise `WrapFunction`.
+// Mappings:
+//   `T*`         -> `ptr<T>` (always)
+//   `T&`         -> `ptr<T>` (always).
+//   `const T*`   -> `const_ptr<T>`, if `T` is not `int`.
+//   `const int*` -> `const int*`
+//   `const T&`   -> `const_ptr<T>`, if `T` is not `int`.
+//   `const int&` -> `const int*`
+template <typename Func>
+auto WrapChange(Func&& func) {
+  return WrapFunction<wrap_change>(std::forward<Func>(func));
+}
+
+// Compares types, generating a static_assert that should have a helpful
+// context of which types do not match.
+template <typename Actual, typename Expected>
+void check_type() {
+  // Use this function to inspect types when failure is encountered.
+  static_assert(std::is_same<Actual, Expected>::value, "Mismatch");
+}
+
+// Checks signature of a generic functor.
+template <typename ReturnExpected, typename... ArgsExpected>
+struct check_signature {
+  template <typename FuncActual>
+  static void run(const FuncActual& func) {
+    run_impl(detail::infer_function_info(func));
+  }
+
+  template <typename ReturnActual, typename... ArgsActual, typename FuncActual>
+  static void run_impl(
+      const detail::function_info<
+          FuncActual, ReturnActual, ArgsActual...>& info) {
+    check_type<ReturnActual, ReturnExpected>();
+    using Dummy = int[];
+    (void)Dummy{(check_type<ArgsActual, ArgsExpected>(), 0)...};
+  }
+};
+
+GTEST_TEST(WrapFunction, ChangeTypeCheck) {
+  // Codify rules above.
+  // Use arbitrary T that is not constrained by the rules.
+  using T = double;
+
+  check_type<wrap_change_t<T*>, ptr<T>>();
+  check_type<wrap_change_t<int*>, ptr<int>>();
+
+  check_type<wrap_change_t<T&>, ptr<T>>();
+  check_type<wrap_change_t<int&>, ptr<int>>();
+
+  check_type<wrap_change_t<const T*>, const_ptr<T>>();
+  check_type<wrap_change_t<const int*>, const int*>();
+
+  check_type<wrap_change_t<const T&>, const_ptr<T>>();
+  check_type<wrap_change_t<const int&>, const int*>();
+}
+
+int* ChangeBasic(const int& a, const double& b, int* x, double* y) {
+  *x += a;
+  *y += b;
+  return x;
+}
+
+GTEST_TEST(WrapFunction, ChangeBasic) {
+  int a = 1;
+  double b = 2.;
+  int x = 3;
+  double y = 4.;
+
+  ptr<int> out = WrapChange(ChangeBasic)(
+      &a, const_ptr<double>{&b},
+      ptr<int>{&x}, ptr<double>{&y});
+
+  EXPECT_EQ(x, 4);
+  EXPECT_EQ(y, 6.);
+  EXPECT_EQ(&x, out.value);
+}
+
+class MyClassChange {
+ public:
+  double* ChangeComprehensive(
+      // double (general case)
+      double,
+      double*, double&,
+      const double*, const double&,
+      // int (special case)
+      int,
+      int*, int&,
+      const int*, const int&) {
+    return nullptr;
+  }
+};
+
+GTEST_TEST(WrapFunction, ChangeComprehensive) {
+  auto wrapped = WrapChange(&MyClassChange::ChangeComprehensive);
+  using check_expected =
+      check_signature<
+          // Return.
+          ptr<double>,
+          // self
+          ptr<MyClassChange>,
+          // double (general case)
+          double,
+          ptr<double>, ptr<double>,
+          const_ptr<double>, const_ptr<double>,
+          // int (special case)
+          int, ptr<int>, ptr<int>,
+          const int*, const int*>;
+  check_expected::run(wrapped);
+}
+
+using Callback = std::function<const double&(MyClassChange*, const int&)>;
+using CallbackWrapped =
+    std::function<const_ptr<double>(ptr<MyClassChange>, const int*)>;
+
+Callback ChangeCallback(const Callback&) { throw std::runtime_error("Dummy"); }
+
+GTEST_TEST(WrapFunction, ChangeCallback) {
+  auto wrapped = WrapChange(ChangeCallback);
+  using check_expected =
+      check_signature<
+          // Return.
+          CallbackWrapped,
+          // Arguments.
+          CallbackWrapped>;
+  check_expected::run(wrapped);
+}
+
+void ChangeCallbackNested(
+    const std::function<Callback(const Callback&)>&) {}
+
+GTEST_TEST(WrapFunction, ChangeCallbackNested) {
+  auto wrapped = WrapChange(ChangeCallbackNested);
+  using check_expected =
+      check_signature<
+          // Return.
+          void,
+          // Nested callback, wrapped.
+          std::function<CallbackWrapped(CallbackWrapped)>>;
+  check_expected::run(wrapped);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/util/wrap_function.h
+++ b/bindings/pydrake/util/wrap_function.h
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace drake {
+namespace pydrake {
+namespace detail {
+
+// Collects both a functor object and its signature for ease of inference.
+template <typename Func, typename Return, typename ... Args>
+struct function_info {
+  // TODO(eric.cousineau): Ensure that this permits copy elision when combined
+  // with `std::forward<Func>(func)`, while still behaving well with primitive
+  // types.
+  std::decay_t<Func> func;
+};
+
+// Factory method for `function_info<>`, to be used by `infer_function_info`.
+template <typename Return, typename ... Args, typename Func>
+auto make_function_info(Func&& func, Return (*infer)(Args...) = nullptr) {
+  (void)infer;
+  return function_info<Func, Return, Args...>{std::forward<Func>(func)};
+}
+
+// SFINAE for functors.
+// N.B. This *only* distinguished between function / method pointers and
+// lambda objects. It does *not* distinguish among other types.
+template <typename Func, typename T = void>
+using enable_if_lambda_t =
+    std::enable_if_t<!std::is_function<std::decay_t<Func>>::value, T>;
+
+// Infers `function_info<>` from a function pointer.
+template <typename Return, typename ... Args>
+auto infer_function_info(Return (*func)(Args...)) {
+  return make_function_info<Return, Args...>(func);
+}
+
+// Infers `function_info<>` from a mutable method pointer.
+template <typename Return, typename Class, typename ... Args>
+auto infer_function_info(Return (Class::*method)(Args...)) {
+  auto func = [method](Class* self, Args... args) {
+    return (self->*method)(std::forward<Args>(args)...);
+  };
+  return make_function_info<Return, Class*, Args...>(func);
+}
+
+// Infers `function_info<>` from a const method pointer.
+template <typename Return, typename Class, typename ... Args>
+auto infer_function_info(Return (Class::*method)(Args...) const) {
+  auto func = [method](const Class* self, Args... args) {
+    return (self->*method)(std::forward<Args>(args)...);
+  };
+  return make_function_info<Return, const Class*, Args...>(func);
+}
+
+// Helpers for general functor objects.
+struct functor_helpers {
+  // Removes class from mutable method pointer for inferring signature
+  // of functor.
+  template <typename Class, typename Return, typename ... Args>
+  static auto remove_class_from_ptr(Return (Class::*)(Args...)) {
+    using Ptr = Return (*)(Args...);
+    return Ptr{};
+  }
+
+  // Removes class from const method pointer for inferring signature of functor.
+  template <typename Class, typename Return, typename ... Args>
+  static auto remove_class_from_ptr(Return (Class::*)(Args...) const) {
+    using Ptr = Return (*)(Args...);
+    return Ptr{};
+  }
+
+  // Infers funtion pointer from functor.
+  // @pre `Func` must have only *one* overload of `operator()`.
+  template <typename Func>
+  static auto infer_function_ptr() {
+    return remove_class_from_ptr(&Func::operator());
+  }
+};
+
+// Infers `function_info<>` from a generic functor.
+template <typename Func, typename = detail::enable_if_lambda_t<Func>>
+auto infer_function_info(Func&& func) {
+  return make_function_info(
+      std::forward<Func>(func),
+      functor_helpers::infer_function_ptr<std::decay_t<Func>>());
+}
+
+// Implementation for wrapping a function by scanning and replacing arguments
+// based on their types.
+template <template <typename...> class wrap_arg_policy>
+struct wrap_function_impl {
+  // By default `wrap_arg` is the same as `wrap_arg_policy`. However, below we
+  // specialize it for the case when `T` is of the form `std::function<F>`.
+  // N.B. This must precede `wrap_type`.
+  template <typename T>
+  struct wrap_arg : public wrap_arg_policy<T> {};
+
+  // Provides wrapped argument type.
+  // Uses `Extra` to specialize within class scope to intercept `void`.
+  template <typename T, typename Extra>
+  struct wrap_type {
+    using type = decltype(wrap_arg<T>::wrap(std::declval<T>()));
+  };
+
+  // Intercept `void`, since `declval<void>()` is invalid.
+  template <typename Extra>
+  struct wrap_type<void, Extra> {
+    using type = void;
+  };
+
+  // Convenience helper type.
+  template <typename T>
+  using wrap_type_t = typename wrap_type<T, void>::type;
+
+  // Determines which overload should be used, since we cannot wrap a `void`
+  // type using `wrap_arg<void>::wrap()`.
+  template <typename Return>
+  static constexpr bool enable_wrap_output =
+      !std::is_same<Return, void>::value;
+
+  // Specialization for callbacks of the form `std::function<>`.
+  // @note We could generalize this using SFINAE for functors of any form, but
+  // that complicates the details for a relatively low ROI.
+  template <typename Return, typename ... Args>
+  struct wrap_arg<const std::function<Return(Args...)>&> {
+    // Define types explicit, since `auto` is not easily usable as a return type
+    // (compilers struggle with inference).
+    using Func = std::function<Return(Args...)>;
+    using WrappedFunc =
+        std::function<wrap_type_t<Return> (wrap_type_t<Args>...)>;
+
+    static WrappedFunc wrap(const Func& func) {
+      return wrap_function_impl::run(infer_function_info(func));
+    }
+
+    // Unwraps a `WrappedFunc`, also unwrapping the return value.
+    // @note We use `Defer` so that we can use SFINAE without a disptach method.
+    template <typename Defer = Return>
+    static Func unwrap(
+        const WrappedFunc& func_wrapped,
+        std::enable_if_t<enable_wrap_output<Defer>, void*> = {}) {
+      return [func_wrapped](Args... args) -> Return {
+        return wrap_arg<Return>::unwrap(
+            func_wrapped(wrap_arg<Args>::wrap(std::forward<Args>(args))...));
+      };
+    }
+
+    // Specialization / overload of above, but not wrapping the return value.
+    template <typename Defer = Return>
+    static Func unwrap(
+        const WrappedFunc& func_wrapped,
+        std::enable_if_t<!enable_wrap_output<Defer>, void*> = {}) {
+      return [func_wrapped](Args... args) {
+        func_wrapped(wrap_arg<Args>::wrap(std::forward<Args>(args))...);
+      };
+    }
+  };
+
+  // Ensure that we also wrap `std::function<>` returned by value.
+  template <typename Signature>
+  struct wrap_arg<std::function<Signature>>
+      : public wrap_arg<const std::function<Signature>&> {};
+
+  // Wraps function arguments and the return value.
+  // Generally used when `Return` is non-void.
+  template <typename Func, typename Return, typename ... Args>
+  static auto run(function_info<Func, Return, Args...>&& info,
+      std::enable_if_t<enable_wrap_output<Return>, void*> = {}) {
+    // N.B. Since we do not use the `mutable` keyword with this lambda,
+    // any functors passed in *must* provide `operator()(...) const`.
+    auto func_wrapped =
+        [func_f = std::forward<Func>(info.func)]
+        (wrap_type_t<Args>... args_wrapped) -> wrap_type_t<Return> {
+      return wrap_arg<Return>::wrap(
+          func_f(wrap_arg<Args>::unwrap(
+                  std::forward<wrap_type_t<Args>>(args_wrapped))...));
+    };
+    return func_wrapped;
+  }
+
+  // Wraps function arguments, but not the return value.
+  // Generally used when `Return` is void.
+  template <typename Func, typename Return, typename ... Args>
+  static auto run(function_info<Func, Return, Args...>&& info,
+      std::enable_if_t<!enable_wrap_output<Return>, void*> = {}) {
+    auto func_wrapped =
+        [func_f = std::forward<Func>(info.func)]
+        (wrap_type_t<Args>... args_wrapped) -> Return {
+      return func_f(wrap_arg<Args>::unwrap(
+              std::forward<wrap_type_t<Args>>(args_wrapped))...);
+    };
+    return func_wrapped;
+  }
+};
+
+}  // namespace detail
+
+/// Wraps the types used in a function signature to produce a new function with
+/// wrapped arguments and return value (if non-void). The wrapping is based on
+/// `wrap_arg_policy`.
+/// Any types that are of the form `std::function<F>` will be recursively
+/// wrapped, such that callbacks will be of a wrapped form (arguments and
+/// return types wrapped). The original form of the callbacks will still be
+/// called in the wrapped callback.
+/// @tparam wrap_arg_policy
+///   User-supplied argument wrapper, that must supply the static functions
+///   `wrap(Arg arg) -> Wrapped` and `unwrap(Wrapped wrapped) -> Arg`.
+///   `Arg arg` is the original argument, and `Wrapped wrapped` is the wrapped
+///   / transformed argument type.
+///   N.B. This template template parameter uses a parameter pack to allow
+///   for SFINAE. If passing a `using` template alias, ensure that the alias
+///   template template parameter uses a parameter pack of the *exact* same
+///   form.
+/// @param func
+///   Functor to be wrapped. Returns a function with wrapped arugments and
+///   return type. If functor is a method pointer, it will return a function of
+///   the form `Return ([const] Class* self, ...)`.
+/// @return Wrapped function lambda.
+///   N.B. Construct a `std::function<>` from this if you encounter inference
+///   issues downstream of this method.
+template <template <typename...> class wrap_arg_policy, typename Func>
+auto WrapFunction(Func&& func) {
+  // TODO(eric.cousineau): Create an overload with `type_pack<Args...>` to
+  // handle overloads, to disambiguate when necessary.
+  return detail::wrap_function_impl<wrap_arg_policy>::run(
+      detail::infer_function_info(std::forward<Func>(func)));
+}
+
+/// Default case for argument wrapping, with pure pass-through. Consider
+/// inheriting from this for base cases.
+/// N.B. `Wrapped` is not necessary, but is used for demonstration purposes.
+template <typename T>
+struct wrap_arg_default {
+  using Wrapped = T;
+  static Wrapped wrap(T arg) { return std::forward<T&&>(arg); }
+  static T unwrap(Wrapped arg_wrapped) {
+    return std::forward<Wrapped&&>(arg_wrapped);
+  }
+  // N.B. `T` rather than `T&&` is used as arguments here as it behaves well
+  // with primitve types, such as `int`.
+};
+
+}  // namespace pydrake
+}  // namespace drake


### PR DESCRIPTION
This implements functionality to enable a potential solution for #7793, and to provide workarounds for https://github.com/pybind/pybind11/issues/1241 (callbacks and virtual function overrides - #7838).

The prototype for `const`-proxying, connected with `pybind`is here:
[cpp_const_pybind.h](https://github.com/EricCousineau-TRI/repro/blob/242807deabbb71801a8bf73f193292c7adeb2e42/python/bindings/pymodule/const/cpp_const_pybind.h)
[cpp_const_pybind_test.py](https://github.com/EricCousineau-TRI/repro/blob/242807deabbb71801a8bf73f193292c7adeb2e42/python/bindings/pymodule/const/test/cpp_const_pybind_test.py)

This is a tad hefty with both functionality and the unittest, but I feel the unittest explains usage most easily.
If desired, I can remove the nested callback tests and save that for a follow-up PR.

NOTE: I found `clang-tidy` to be a little too picky.
I want to ensure that this is tested for mutable rvalue references, and there was no way to disable this for the entire file, from within the file.
Additionally, its desired for `std::function<>` signatures is weird - it doesn't want spaces?

Because of these, and because I feel like `NOLINTNEXTLINE(...) <explanation>` is verbose and clutters the code, I've used `NOLINT`.

```
$ drake_cloc.py 
Computing difference between $(git merge-base master HEAD) (f3a7a38) and 'HEAD' (f3f8915).

Category            added  modified  removed  
----------------------------------------------
code                379    0         0        
comments            123    0         0        
blank               91     0         0        
----------------------------------------------
TOTAL               593    0         0    
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7841)
<!-- Reviewable:end -->
