### PR TITLE
Update CLion to work with Drake rename

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,3 +14,8 @@ add_default_repositories()
 load("@drake//tools/external_data/test:external_data_workspace_test.bzl", "add_external_data_test_repositories")  # noqa
 
 add_external_data_test_repositories(__workspace_dir__)
+
+# Add some special heuristic logic for using CLion with Drake.
+load("//tools/clion:repository.bzl", "drake_clion_environment")
+
+drake_clion_environment()

--- a/doc/clion.rst
+++ b/doc/clion.rst
@@ -51,6 +51,14 @@ Installing CLion
    30-day trial version of CLion. Either try it out as is, or get a free
    academic license `here <https://www.jetbrains.com/shop/eform/students>`_.
 
+The most recent versions that we have tested for compatibility are:
+  - CLion 2017.2.3
+  - Bazel 0.9.0
+  - "CLion with Bazel" plug-in 2018.01.02.0.1
+
+Note that as of this writing, CLion 2017.3.2 is not compatible.  For more
+details, see https://github.com/bazelbuild/intellij/issues/175.
+  
 Upgrading CLion
 ---------------
 
@@ -72,11 +80,19 @@ in ``~/ClionProjects/project-name``).
 Installing the Bazel Plugin
 ---------------------------
 
-To use Bazel in CLion, you must install a plugin supplied by Google. The plugin
-requires CLion 2016.3 or later.  To install the plugin, open
-``File > Settings``, select ``Plugins``, and press the ``Browse repositories``
-button.  Locate and install the ``CLion with Bazel`` plugin. You will be
-prompted to restart CLion.
+To use Bazel in CLion, you must install a plugin supplied by Google.  To
+install the plugin, open ``File > Settings``, select ``Plugins``, and press the
+``Browse repositories`` button.  Locate and install the ``CLion with Bazel``
+plugin. You will be prompted to restart CLion.
+
+To use Drake with CLion, your Drake checkout should ideally be named ``drake``;
+if it isn't, navigation features like "Jump to Definition" will have confusing
+results.
+
+Open ``Settings >> Bazel Settings``.  For ``Bazel binary location`` select the
+path to ``drake/tools/clion/bazel_wrapper`` from any recent Drake source tree
+(it doesn't have to match the current project open in CLion).
+
 
 Setting up Drake in CLion
 -------------------------
@@ -85,17 +101,15 @@ specified in the WORKSPACE file.
 
 1. ``File > Import Bazel Project``
 2. Select Workspace: Use an existing Bazel workspace, and provide the path to
-   your ``drake-distro`` directory.
-3. (Sometimes) Select Bazel Executable: If prompted, specify the path to your
-   Bazel executable. The default is probably correct.
-4. Select Project View: choose "Import from workspace", and
-   select the file ``drake-distro/.bazelproject``
-5. Project View: Pick a ``project data directory`` of your choice for the
-   CLion project files. It must not be a subdirectory of ``drake-distro``.
-6. (Advanced) Project View: If you only wish to develop a subset of Drake,
+   your ``drake`` directory.
+3. Select Project View: choose "Import from workspace", and
+   select the file ``drake/.bazelproject``
+4. Project View: Pick a ``project data directory`` of your choice for the
+   CLion project files. It must not be a subdirectory of ``drake``.
+5. (Advanced) Project View: If you only wish to develop a subset of Drake,
    you can specify only those files and targets in the project view file.
    Most users should leave it as-is.
-7. Click "Finish".  CLion will begin ingesting the Drake source, building
+6. Click "Finish".  CLion will begin ingesting the Drake source, building
    symbols, and compiling Drake. This will take several minutes.
 
 Building and Running Targets
@@ -109,7 +123,7 @@ To build or run a specific target go to ``Run > Edit Configurations``. Click
 options. The ``Target expression`` specifies the actual code (library, binary,
 and/or test) that you want to run. To learn more about target expressions, see
 `the Bazel manual
-<https://bazel.build/versions/master/docs/bazel-user-manual.html#target-patterns>`
+<https://docs.bazel.build/versions/master/user-manual.html#target-patterns>`
 _. Once you've created a configuration, you can launch it from the ``Run`` menu.
 
 To run a specific target in the debugger, create a configuration as above,
@@ -127,13 +141,13 @@ Git Integration
 
 CLion provides a user interface for Git, which you can enable in the ``VCS``
 menu.  It automatically detects all Git roots within the workspace. This will
-include ``bazel-drake-distro``, which is a Bazel-internal detail. Bazel edits
+include ``bazel-drake``, which is a Bazel-internal detail. Bazel edits
 the contents of that directory for its own purposes, and those changes will
 spuriously appear in the CLion UI as changes that need to be committed. To make
-CLion ignore ``bazel-drake-distro``, enable Git integration under the ``VCS``
+CLion ignore ``bazel-drake``, enable Git integration under the ``VCS``
 tab, then go to ``File > Settings``. Select the ``Version Control`` menu item
 directly (not one of the subtopics displayed when that item is expanded). You
-will see a list of all the Git root directories. Look for ``bazel-drake-distro``
+will see a list of all the Git root directories. Look for ``bazel-drake``
 on that list and select it. On the right hand side are ``+`` and ``-`` buttons;
 click ``-`` to remove the spurious root directory. After that you should be
 able to go to ``VCS > Commit Changes`` and there should be no changes seen.

--- a/tools/clion/BUILD.bazel
+++ b/tools/clion/BUILD.bazel
@@ -1,0 +1,5 @@
+# -*- python -*-
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/clion/aspect.bzl
+++ b/tools/clion/aspect.bzl
@@ -1,0 +1,58 @@
+# -*- python -*-
+
+# Load the relevant upstream methods.
+load(
+    "@intellij_aspect//:intellij_info_impl.bzl",
+    "make_intellij_info_aspect",
+    "intellij_info_aspect_impl",
+)
+load(
+    "@intellij_aspect//:intellij_info_bundled.bzl",
+    "tool_label",
+)
+
+# Load the magic.
+load(
+    "@drake_clion_environment//:path.bzl",
+    "additional_transitive_quote_include_directory",
+)
+
+# This is part of the `semantics` hooks provided by intellij_aspect's aspect.
+# We use it to rewrite the transitive_quote_include_directory to contain an
+# entry for Drake that avoids the virtual_headers symlink farm.
+#
+# For reference, ~/.CLion2017.2/config/plugins/clwb/intellij_info_impl.bzl is
+# the code that ends up calling this function -- read its source to understand
+# the data types that we are manipulating here.
+def _extra_ide_info(target, ctx, ide_info, ide_info_file, output_groups):
+    # N.B. All of our return statements here should return False, which means
+    # "I was not the primary semantics for this target".  The intellij_aspect's
+    # code is always the primary semantics, we're just (potentially) frobbing
+    # its results.
+    if not additional_transitive_quote_include_directory:
+        # No Drake path needs to be inserted.
+        return False
+    c_ide_info = ide_info.get("c_ide_info", None)
+    if c_ide_info == None:
+        # Not a C / C++ target.
+        return False
+    includes = getattr(c_ide_info, "transitive_quote_include_directory", None)
+    if includes == None:
+        # No includes exist, so we don't need to override them.
+        return False
+    # Place Drake's parent directory on CLion's include path.
+    includes.insert(0, additional_transitive_quote_include_directory)
+    return False
+
+# Define the relevant semantics (see intellij_info_bundled.bzl).
+semantics = struct(
+    extra_ide_info = _extra_ide_info,
+    tool_label = tool_label,
+)
+
+# Curry our semantics argument into the aspect rule's implementation function.
+def _aspect_impl(target, ctx):
+    return intellij_info_aspect_impl(target, ctx, semantics)
+
+# This is the command-line entry point.
+intellij_info_aspect = make_intellij_info_aspect(_aspect_impl, semantics)

--- a/tools/clion/bazel_wrapper
+++ b/tools/clion/bazel_wrapper
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+# TODO(jwnimmer-tri) At some point, a Drake Developer who is a CLion user will
+# probably want to use the "CLion with Bazel" plug-in on a Bazel project that
+# does not involve Drake at all.  In that case, because the plug-in's path to
+# bazel is a global setting in CLion, this script would still be used and then
+# would fail to find `@drake`.  It would be nice to automatically sense whether
+# or not we should be substituting the aspect path, so that the user doesn't
+# have to reconfigure the path to bazel when they switch projects.
+
+if __name__ == "__main__":
+    # Copy args for modification.
+    args = sys.argv[1:]
+
+    # If this magic argument is found, replace it with our hooks instead.
+    old_magic = "--aspects=@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect"  # noqa
+    new_magic = "--aspects=@drake//tools/clion:aspect.bzl%intellij_info_aspect"
+    if old_magic in args:
+        args[args.index(old_magic)] = new_magic
+
+    # Delegate to bazel.
+    os.execvp("bazel", ["bazel"] + args)

--- a/tools/clion/repository.bzl
+++ b/tools/clion/repository.bzl
@@ -1,0 +1,43 @@
+# -*- python -*-
+
+"""Declares a repository that names the parent directory of the Drake
+workspace.  This repository contains no rules; just a single file named
+`path.bzl` which has a variable `additional_transitive_quote_include_directory`
+with Drake's parent directory name.  This path is used by `aspect.bzl` in this
+package (@drake//tools/clion).  This rule only makes sense when used directly
+from Drake's WORKSPACE file, not from any other project; thus, it does not live
+under //tools/workspace like most other repository rules.
+"""
+
+def _impl(repository_ctx):
+    # Find the top-level folder of Drake's source code.
+    dotfile_path = repository_ctx.path(Label("@drake//:.bazelproject"))
+    drake_workspace = dotfile_path.realpath.dirname
+
+    # Compute an include path that makes '#include "drake/foo.h" work.
+    if drake_workspace.basename == "drake":
+        drake_workspace_parent = str(drake_workspace.dirname)
+    else:
+        print("Cannot fix CLion paths; your checkout is not named 'drake'")
+        drake_workspace_parent = ""
+
+    # Write out the path to a bzl constant.
+    bzl_content = [
+        'additional_transitive_quote_include_directory = "{}"'.format(
+            drake_workspace_parent),
+    ]
+    repository_ctx.file(
+        "BUILD.bazel",
+        content = "\n",
+        executable = False)
+    repository_ctx.file(
+        "path.bzl",
+        content = "".join(bzl_content),
+        executable = False)
+
+def drake_clion_environment():
+    rule = repository_rule(
+        implementation = _impl,
+        local = True,
+    )
+    rule(name = "drake_clion_environment")


### PR DESCRIPTION
This modernizes the CLion instructions to use the newest possible versions of the tools, and adds a `bazel_wrapper` script for CLion that repairs the IDE's include paths (but does not affect the sandbox or build; just the IDE aspect).

This fixes the most acute trouble of #7586.  Some follow-up work might still be needed, but this at least removes the need for the current hacky work-around posted there.

Do not merge until:
- [x] macOS testing;
- [x] manual testing by user(s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7843)
<!-- Reviewable:end -->
