### PR TITLE
Allow and prefer "import drake.stuff" in python

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,6 +34,14 @@ alias(
     actual = "@com_google_protobuf//:protobuf_python",
 )
 
+# Drake's top-level module; all drake_py_stuff rules add this to deps.
+# (We use py_library here because drake_py_library would be circular.)
+# This file should NOT be installed (see commits in __init__.py).
+py_library(
+    name = "module_py",
+    srcs = ["__init__.py"],
+)
+
 install(
     name = "install",
     docs = ["LICENSE.TXT"],

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,26 @@
+# It confusing to have both drake-the-workspace and drake-the-lcmtypes-package
+# on sys.path at the same time via Bazel's py_library(imports = ...).
+#
+# To prevent that confusion, and possibly also import errors, in our
+# //lcmtypes:lcmtypes_py rule we use add_current_package_to_imports = False,
+# and then here in drake-the-workspace's package initialization we use __path__
+# editing to fold the two directories into the same package.
+#
+# We need to do it on a best-effort basis, because not all of our py_binary
+# rules use lcmtypes -- sometimes the lcmtypes will be absent from runfiles.
+#
+# Note that this file should NOT be installed (`//:install` should not touch
+# it).  The `//lcmtypes`-supplied init file is the correct file to install.
+
+# First, probe whether we need the repair.
+_needs_lcmtypes_pathing = False
+try:
+    import drake.lcmtypes
+    _needs_lcmtypes_pathing = True
+except ImportError:
+    pass
+
+# Run the repair outside of try-except, so we'll yell if it fails.
+if _needs_lcmtypes_pathing:
+    __path__.append(drake.lcmtypes.__path__[0] + "/drake")
+    from drake.lcmtypes.drake import *

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -282,6 +282,7 @@ drake_lcm_cc_library(
 
 drake_lcm_py_library(
     name = "lcmtypes_py",
+    add_current_package_to_imports = False,  # Use //:module_py instead.
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]) + _AUTOMOTIVE_LCM_SRCS,
     deps = [

--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -11,8 +11,8 @@ import subprocess
 import sys
 from subprocess import Popen, PIPE, STDOUT
 
-from tools.lint.find_data import find_data
-from tools.lint.util import find_all_sources
+from drake.tools.lint.find_data import find_data
+from drake.tools.lint.util import find_all_sources
 
 # These match data=[] in our BUILD.bazel file.
 _BUILDIFIER = "external/buildifier/buildifier"

--- a/tools/lint/clang_format_includes.py
+++ b/tools/lint/clang_format_includes.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import sys
 
-from tools.lint.formatter import IncludeFormatter
+from drake.tools.lint.formatter import IncludeFormatter
 
 
 def main():

--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -1,6 +1,6 @@
 import sys
 
-from tools.lint.formatter import IncludeFormatter
+from drake.tools.lint.formatter import IncludeFormatter
 
 
 def _check_invalid_line_endings(filename):

--- a/tools/lint/formatter.py
+++ b/tools/lint/formatter.py
@@ -4,7 +4,7 @@
 import os
 from subprocess import Popen, PIPE, CalledProcessError
 
-import tools.lint.clang_format as clang_format_lib
+import drake.tools.lint.clang_format as clang_format_lib
 
 
 class FormatterBase(object):

--- a/tools/lint/test/find_data_test.py
+++ b/tools/lint/test/find_data_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from tools.lint.find_data import find_data
+from drake.tools.lint.find_data import find_data
 
 
 class FindDataTest(unittest.TestCase):

--- a/tools/lint/test/formatter_test.py
+++ b/tools/lint/test/formatter_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tools.lint.formatter import FormatterBase, IncludeFormatter
+from drake.tools.lint.formatter import FormatterBase, IncludeFormatter
 
 
 class TestFormatterBase(unittest.TestCase):

--- a/tools/lint/test/util_test.py
+++ b/tools/lint/test/util_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from tools.lint.util import find_all_sources
+from drake.tools.lint.util import find_all_sources
 
 
 class UtilTest(unittest.TestCase):

--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -10,6 +10,8 @@ def drake_py_library(
     """A wrapper to insert Drake-specific customizations."""
     deps = adjust_labels_for_drake_hoist(deps)
     data = adjust_labels_for_drake_hoist(data)
+    # Work around https://github.com/bazelbuild/bazel/issues/1567.
+    deps = (deps or []) + ["//:module_py"]
     native.py_library(
         name = name,
         deps = deps,
@@ -18,14 +20,18 @@ def drake_py_library(
 
 def drake_py_binary(
         name,
+        srcs = None,
         deps = None,
         data = None,
         **kwargs):
     """A wrapper to insert Drake-specific customizations."""
     deps = adjust_labels_for_drake_hoist(deps)
     data = adjust_labels_for_drake_hoist(data)
+    # Work around https://github.com/bazelbuild/bazel/issues/1567.
+    deps = (deps or []) + ["//:module_py"]
     native.py_binary(
         name = name,
+        srcs = srcs,
         deps = deps,
         data = data,
         **kwargs)
@@ -41,6 +47,8 @@ def drake_py_test(
         srcs = ["test/%s.py" % name]
     deps = adjust_labels_for_drake_hoist(deps)
     data = adjust_labels_for_drake_hoist(data)
+    # Work around https://github.com/bazelbuild/bazel/issues/1567.
+    deps = (deps or []) + ["//:module_py"]
     native.py_test(
         name = name,
         srcs = srcs,

--- a/tools/workspace/lcm/lcm.bzl
+++ b/tools/workspace/lcm/lcm.bzl
@@ -202,9 +202,11 @@ def lcm_cc_library(
 
 def lcm_py_library(
         name,
+        imports = None,
         lcm_srcs = None,
         lcm_package = None,
         lcm_structs = None,
+        add_current_package_to_imports = True,
         **kwargs):
     """Declares a py_library on message classes generated from `*.lcm` files.
 
@@ -214,6 +216,14 @@ def lcm_py_library(
     This library has an ${lcm_package}/__init__.py, which means that this macro
     should only be used once for a given lcm_package in a given subdirectory.
     (Bazel will fail-fast with a "duplicate file" error if this is violated.)
+
+    The add_current_package_to_imports argument controls whether or not this
+    library adds an `imports = ["."]` attribute so that `from ${lcm_package}
+    import ${lcm_src}` will work in Python code (as opposed to needing to
+    prefix import statements with the bazel package name).  It is True by
+    default, but can be set to False if a package needs its own manually-
+    written __init__.py handling, or if the current bazel package should
+    not be imported by default.
     """
     if not lcm_srcs:
         fail("lcm_srcs is required")
@@ -228,7 +238,8 @@ def lcm_py_library(
         lcm_package = lcm_package,
         outs = outs)
 
-    imports = depset(kwargs.pop('imports', [])) | ["."]
+    if add_current_package_to_imports:
+        imports = depset(imports or []) | ["."]
     native.py_library(
         name = name,
         srcs = outs,


### PR DESCRIPTION
This finally tips the scale on disambiguating drake-the-workspace from drake-the-lcmtypes in the python `sys.path`.  We have been fudging it with careful `deps=` values so far, but it really is annoying to debug.  By writing a custom `__init__.py`, we can fix it correctly forever.

For now, we just port `//tools/lint/...` to use the preferred spelling; in future PRs we can update the rest of the codebase.

This is a prerequisite of robustly exposing python targets in `drake_bazel_external`.  In some cases the `sys.path` for some runfiles arrangements was already correct without this, but after this it will always work.

Do not merge until:
- [x] a little macOS testing;
- [x] a visual inspection of changes to the installed image.

Relates bazelbuild/bazel#1567.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7848)
<!-- Reviewable:end -->
