### PR TITLE
Raise an error for EvalEigenVectorInput on a disconnted input

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -399,12 +400,17 @@ class System {
   }
 
   /// Causes the vector-valued input port with the given `port_index` to become
-  /// up-to-date, delegating to our parent Diagram if necessary. Returns
-  /// the port's value as an %Eigen expression.
+  /// up-to-date, delegating to our parent Diagram if necessary. Returns the
+  /// port's value as an %Eigen expression. Throws an exception if the input
+  /// port is not connected.
   Eigen::VectorBlock<const VectorX<T>> EvalEigenVectorInput(
       const Context<T>& context, int port_index) const {
     const BasicVector<T>* input_vector = EvalVectorInput(context, port_index);
-    DRAKE_ASSERT(input_vector != nullptr);
+    if (input_vector == nullptr) {
+      throw std::logic_error(
+          "System " + get_name() + ": Port index " +
+          std::to_string(port_index) + " is not connected.");
+    }
     DRAKE_ASSERT(input_vector->size() == get_input_port(port_index).size());
     return input_vector->get_value();
   }

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -595,6 +595,15 @@ TEST_F(SystemIOTest, SystemValueIOTest) {
             std::string("inputoutput"));
   EXPECT_EQ(output_->get_vector_data(1)->get_value()(0), 4);
 
+  // Connected inputs ports can be evaluated.  (Port #1 was set to [2]).
+  const auto& block = test_sys_.EvalEigenVectorInput(*context_, 1);
+  ASSERT_EQ(block.size(), 1);
+  ASSERT_EQ(block[0], 2.0);
+
+  // Disconnected inputs are nullptr, or generate an exception (not assert).
+  EXPECT_EQ(test_sys_.EvalVectorInput(*context_, 2), nullptr);
+  EXPECT_THROW(test_sys_.EvalEigenVectorInput(*context_, 2), std::exception);
+
   // Test AllocateInput*
   // Second input is not (yet) a TestTypedVector, since I haven't called the
   // Allocate methods directly yet.


### PR DESCRIPTION
By default, we segfault (release) or assert (debug).  These are not helpful for users.

Fixes #7558.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7852)
<!-- Reviewable:end -->
