### PR TITLE
Increase acrobot_run_passive_test size to medium.

### DIFF
--- a/examples/acrobot/BUILD.bazel
+++ b/examples/acrobot/BUILD.bazel
@@ -107,6 +107,7 @@ drake_cc_binary(
     add_test_rule = 1,
     data = [":models"],
     test_rule_args = ["-realtime_factor=0.0"],
+    test_rule_size = "medium",
     deps = [
         ":acrobot_plant",
         "//drake/common:find_resource",


### PR DESCRIPTION
Attempts to resolve the following failures:

- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/267/
- https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/263/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7853)
<!-- Reviewable:end -->
