### PR TITLE
Decreases simulation time for MBT acrobot smoke test.

### DIFF
--- a/examples/multibody/acrobot/BUILD.bazel
+++ b/examples/multibody/acrobot/BUILD.bazel
@@ -44,7 +44,10 @@ drake_cc_binary(
     name = "passive_simulation",
     srcs = ["passive_simulation.cc"],
     add_test_rule = 1,
-    test_rule_args = ["--target_realtime_rate=0.0"],
+    test_rule_args = [
+        "--simulation_time=0.1",
+        "--target_realtime_rate=0.0",
+    ],
     deps = [
         ":acrobot_plant",
         "//drake/common:text_logging_gflags",

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -33,6 +33,9 @@ DEFINE_string(integration_scheme, "runge_kutta3",
               "Integration scheme to be used. Available options are:"
               "'runge_kutta3','implicit_euler','semi_explicit_euler'");
 
+DEFINE_double(simulation_time, 10.0,
+              "Desired duration of the simulation in seconds.");
+
 using geometry::GeometrySystem;
 using geometry::SourceId;
 using lcm::DrakeLcm;
@@ -50,7 +53,7 @@ int do_main() {
       *builder.AddSystem<GeometrySystem>();
   geometry_system.set_name("geometry_system");
 
-  const double simulation_time = 10.0;
+  const double simulation_time = FLAGS_simulation_time;
 
   // Make the desired maximum time step a fraction of the simulation time.
   const double max_time_step = simulation_time / 1000.0;


### PR DESCRIPTION
Decreases the simulation time for the MBT acrobot smoke test.
Timeout failures were found out by @kunimatsu-tri:
 - https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/267/
 - https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/263/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7863)
<!-- Reviewable:end -->
