### PR TITLE
Fix PopulateUpstreamToDrake for checkout not named drake

### DIFF
--- a/multibody/parsers/package_map.cc
+++ b/multibody/parsers/package_map.cc
@@ -11,6 +11,7 @@
 #include <tinyxml2.h>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_path.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/text_logging.h"
 
@@ -83,7 +84,7 @@ string GetParentDirectory(const string& directory) {
 
 // Parses the package.xml file specified by package_xml_file. Finds and returns
 // the name of the package.
-std::string GetPackageName(const string& package_xml_file) {
+string GetPackageName(const string& package_xml_file) {
   DRAKE_DEMAND(!package_xml_file.empty());
   XMLDocument xml_doc;
   xml_doc.LoadFile(package_xml_file.data());
@@ -129,15 +130,15 @@ void PackageMap::AddPackageIfNew(const string& package_name,
   }
 }
 
-namespace {
-
-// This is the folder that PopulateUpstreamToDrake is documented to use.
-const char* const kDrakeFolderName = "drake";
-
-}  // namespace
-
-void PackageMap::PopulateUpstreamToDrakeHelper(const string& directory) {
+void PackageMap::PopulateUpstreamToDrakeHelper(
+    const string& directory,
+    const string& stop_at_directory) {
   DRAKE_DEMAND(!directory.empty());
+
+  // If we've reached the top, then stop searching.
+  if (directory.length() <= stop_at_directory.length()) {
+    return;
+  }
 
   // If there is a new package.xml file, then add it.
   if (HasPackageXmlFile(directory)) {
@@ -147,17 +148,9 @@ void PackageMap::PopulateUpstreamToDrakeHelper(const string& directory) {
     AddPackageIfNew(package_name, directory);
   }
 
-  // If we've reached .../drake, then stop searching.
-  const vector<string> path_elements = spruce::path(directory).split();
-  DRAKE_DEMAND(!path_elements.empty());
-  const string& final_path_element = path_elements.back();
-  DRAKE_DEMAND(!final_path_element.empty());
-  if (final_path_element == kDrakeFolderName) {
-    return;
-  }
-
   // Continue searching in our parent directory.
-  PopulateUpstreamToDrakeHelper(GetParentDirectory(directory));
+  PopulateUpstreamToDrakeHelper(
+      GetParentDirectory(directory), stop_at_directory);
 }
 
 void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
@@ -165,20 +158,26 @@ void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
 
   // Verify that the model_file names an URDF or SDF file.
   spruce::path spruce_path(model_file);
-  std::string extension = spruce_path.extension();
+  string extension = spruce_path.extension();
   std::transform(extension.begin(), extension.end(), extension.begin(),
                  ::tolower);
   DRAKE_DEMAND(extension == ".urdf" || extension == ".sdf");
+  const string model_dir = spruce_path.root();
 
-  // Bail out if the model file is not in .../drake.
-  const string path_sep("/");
-  const string required_substring = path_sep + kDrakeFolderName + path_sep;
-  if (model_file.find(required_substring) == string::npos) {
+  // Bail out if the model file is not part of Drake.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const string drake_path = GetDrakePath();
+#pragma GCC diagnostic pop
+  auto iter = std::mismatch(drake_path.begin(), drake_path.end(),
+                            model_dir.begin());
+  if (iter.first != drake_path.end()) {
+    // The drake_path was not a prefix of model_dir.
     return;
   }
 
   // Search the directory containing the model_file and "upstream".
-  PopulateUpstreamToDrakeHelper(spruce_path.root());
+  PopulateUpstreamToDrakeHelper(spruce_path.root(), drake_path);
 }
 
 void PackageMap::CrawlForPackages(const string& path) {

--- a/multibody/parsers/package_map.h
+++ b/multibody/parsers/package_map.h
@@ -78,9 +78,13 @@ class PackageMap {
       const std::string& path);
 
   // Recursively searches up the directory path searching for package.xml files.
+  // The @p directory must be a child of @p stop_at_directory.  Stops searching
+  // when the search directory is not longer than @p stop_at_directory.
   // Adds the packages defined by these package.xml files to this PackageMap.
   // This method is intended to be called by PopulateUpstreamToDrake().
-  void PopulateUpstreamToDrakeHelper(const std::string& directory);
+  void PopulateUpstreamToDrakeHelper(
+      const std::string& directory,
+      const std::string& stop_at_directory);
 
   // The key is the name of a ROS package and the value is the package's
   // directory.


### PR DESCRIPTION
The prior version relied on `"/drake/"` appearing in absolute pathnames to URDF files, then looked for `package.xml` files in the trip from the URDF down to drake's root.  This worked when all resources were in `drake-distro/drake`.  When we got rid of `drake-distro`, it still worked if your git clone was named `drake`, or if you were running a test in the bazel sandbox where the workspace is named `drake`.  If you were running from the command line, it would give up because it didn't know where Drake was.

The fix is to use `GetDrakePath` to establish the coordinate to search up until.  This still might fail if the URDF is from some foreign Drake tree, but `GetDrakePath` is finding the current tree (it won't add the foreign packages), but at least this is an improvement.

Fixes #7855.  Relates #6996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7864)
<!-- Reviewable:end -->
