### PR TITLE
Use static library with hidden symbols for tinyobjloader

### DIFF
--- a/tools/workspace/tinyobjloader/package.BUILD.bazel
+++ b/tools/workspace/tinyobjloader/package.BUILD.bazel
@@ -9,27 +9,16 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-TINYOBJLOADER_HDRS = ["tiny_obj_loader.h"]
-
-TINYOBJLOADER_INCLUDES = ["."]
-
-cc_binary(
-    name = "libtinyobjloader.so",
-    srcs = ["tiny_obj_loader.cc"] + TINYOBJLOADER_HDRS,
-    includes = TINYOBJLOADER_INCLUDES,
-    linkshared = 1,
-    visibility = ["//visibility:private"],
-)
-
 cc_library(
     name = "tinyobjloader",
-    srcs = ["libtinyobjloader.so"],
-    hdrs = TINYOBJLOADER_HDRS,
-    includes = TINYOBJLOADER_INCLUDES,
+    srcs = ["tiny_obj_loader.cc"],
+    hdrs = ["tiny_obj_loader.h"],
+    copts = ["-fvisibility=hidden"],
+    includes = ["."],
+    linkstatic = 1,
 )
 
 install(
     name = "install",
-    targets = [":libtinyobjloader.so"],
     docs = ["LICENSE"],
 )


### PR DESCRIPTION
So we discussed this on #7773 and I looked into it in more detail and I will agree that this approach is better for this library and keeps `libdrake.so` clean (enough).  It is "tiny" by name after all, so it should be static.

I am also looking into exactly why we do not do this for octomap since to hide everything we do not need changes to upstream (lack of support for visibility is not a problem when hiding everything, as is also the case here), but that is a different issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7872)
<!-- Reviewable:end -->
