### PR TITLE
Don't throw when opportunistically looking for URDF package paths

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -654,6 +654,7 @@ drake_cc_googletest(
         "test/find_resource_test_data.txt",
     ],
     deps = [
+        ":drake_path",
         ":find_resource",
     ],
 )

--- a/common/drake_path.cc
+++ b/common/drake_path.cc
@@ -2,27 +2,36 @@
 
 #include <spruce.hh>
 
-#include "drake/common/drake_throw.h"
 #include "drake/common/find_resource.h"
 
-namespace drake {
+// N.B. This code is unit tested in test/find_resource_test.cc.
 
-std::string GetDrakePath() {
+namespace drake {
+namespace {
+
+optional<std::string> MaybeGetDrakePathImpl(bool should_throw) {
   // Find something that represents where Drake resources live.  This will be
   // "/path/to/drake/.drake-find_resource-sentinel" where "/path/to/" names the
   // root of Drake's git source tree (or perhaps an installed version of same).
   const auto& find_result = FindResource("drake/.drake-find_resource-sentinel");
+  if (find_result.get_error_message() && !should_throw) {
+    return nullopt;
+  }
   spruce::path sentinel_path = find_result.get_absolute_path_or_throw();
 
-  // Take the dirname of sentinel_path; that will name the "drake" folder
-  // within the git source tree (or perhaps an installed version of same).
-  spruce::path result = sentinel_path.root();
-  if (!result.isDir()) {
-    throw std::runtime_error("GetDrakePath: proposed result " +
-                             result.getStr() + " is not a directory");
-  }
+  // Take the dirname of sentinel_path, so that we have a folder where looking
+  // up "drake/foo/bar.urdf" makes sense.
+  return sentinel_path.root();
+}
 
-  return result.getStr();
+}  // namespace
+
+optional<std::string> MaybeGetDrakePath() {
+  return MaybeGetDrakePathImpl(false);
+}
+
+std::string GetDrakePath() {
+  return *MaybeGetDrakePathImpl(true);
 }
 
 }  // namespace drake

--- a/common/drake_path.h
+++ b/common/drake_path.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_optional.h"
 
 namespace drake {
 
@@ -10,5 +11,11 @@ namespace drake {
 /// N.B: <em>not</em> the `drake-distro` source tree.
 DRAKE_DEPRECATED("Please use drake::FindResource() instead.")
 std::string GetDrakePath();
+
+/// Returns the fully-qualified path to the first folder containing Drake
+/// resources as located by FindResource, or nullopt if none is found.  For
+/// example `${result}/drake/examples/pendulum/Pendulum.urdf` would be the path
+/// to the Pendulum example's URDF resource.
+optional<std::string> MaybeGetDrakePath();
 
 }  // namespace drake

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <spruce.hh>
 
+#include "drake/common/drake_path.h"
+
 using std::string;
 
 namespace drake {
@@ -104,6 +106,13 @@ GTEST_TEST(FindResourceTest, FoundDeclaredData) {
 
   // Sugar works the same way.
   EXPECT_EQ(FindResourceOrThrow(relpath), absolute_path);
+}
+
+GTEST_TEST(GetDrakePathTest, BasicTest) {
+  // Just test that we find a path, without any exceptions.
+  const auto& result = MaybeGetDrakePath();
+  ASSERT_TRUE(result);
+  EXPECT_GT(result->length(), 5);
 }
 
 }  // namespace

--- a/multibody/parsers/package_map.cc
+++ b/multibody/parsers/package_map.cc
@@ -165,10 +165,11 @@ void PackageMap::PopulateUpstreamToDrake(const string& model_file) {
   const string model_dir = spruce_path.root();
 
   // Bail out if the model file is not part of Drake.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  const string drake_path = GetDrakePath();
-#pragma GCC diagnostic pop
+  const optional<string> maybe_drake_path = MaybeGetDrakePath();
+  if (!maybe_drake_path) {
+    return;
+  }
+  const string& drake_path = *maybe_drake_path;
   auto iter = std::mismatch(drake_path.begin(), drake_path.end(),
                             model_dir.begin());
   if (iter.first != drake_path.end()) {


### PR DESCRIPTION
This amends #7864 to be more gentle in cases where the user doesn't want Drake resources at all, but still wants to use RigidBodyTree.

I don't have any new tests here, because making `GetDrakePath` (really, FindResource) fail to resolve the path while in the test sandbox isn't yet supported.  I'm open to ideas on whether adding that is worth it.

Relates #7855.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7879)
<!-- Reviewable:end -->
