### PR TITLE
framework_py: Add bindings for VectorSystem.

### DIFF
--- a/bindings/pydrake/common_py.cc
+++ b/bindings/pydrake/common_py.cc
@@ -30,7 +30,7 @@ PYBIND11_MODULE(_common_py, m) {
   py::register_exception_translator([](std::exception_ptr p) {
       try {
         if (p) { std::rethrow_exception(p); }
-      } catch (const detail::assertion_error& e) {
+      } catch (const drake::detail::assertion_error& e) {
         PyErr_SetString(PyExc_SystemExit, e.what());
       }
     });

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -47,6 +47,7 @@ drake_pybind_library(
     name = "framework_py",
     cc_deps = [
         "//bindings/pydrake/util:drake_optional_pybind",
+        "//bindings/pydrake/util:eigen_pybind",
     ],
     cc_so_name = "framework",
     cc_srcs = ["framework_py.cc"],

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -121,21 +121,34 @@ class TestCustom(unittest.TestCase):
             def __init__(self):
                 LeafSystem.__init__(self)
                 self.called_publish = False
+                self.called_discrete = False
                 # Ensure we have desired overloads.
                 self._DeclarePeriodicPublish(0.1)
                 self._DeclarePeriodicPublish(0.1, 0)
                 self._DeclarePeriodicPublish(period_sec=0.1, offset_sec=0.)
+                self._DeclarePeriodicDiscreteUpdate(
+                    period_sec=0.1, offset_sec=0.)
+                self._DeclareDiscreteState(1)
 
             def _DoPublish(self, context, events):
-                # Call base `DoPublish` to ensure that we do not get
-                # recursion.
+                # Call base method to ensure we do not get recursion.
                 LeafSystem._DoPublish(self, context, events)
                 self.called_publish = True
 
+            def _DoCalcDiscreteVariableUpdates(
+                    self, context, events, discrete_state):
+                # Call base method to ensure we do not get recursion.
+                LeafSystem._DoCalcDiscreteVariableUpdates(
+                    self, context, events, discrete_state)
+                self.called_discrete = True
+
         system = TrivialSystem()
         self.assertFalse(system.called_publish)
-        call_leaf_system_overrides(system)
+        self.assertFalse(system.called_discrete)
+        results = call_leaf_system_overrides(system)
         self.assertTrue(system.called_publish)
+        self.assertTrue(system.called_discrete)
+        self.assertEquals(results["discrete_next_t"], 0.1)
 
     def test_vector_system_overrides(self):
         dt = 0.5

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -15,13 +15,15 @@ from pydrake.systems.framework import (
     DiagramBuilder,
     LeafSystem,
     PortDataType,
+    VectorSystem,
     )
 from pydrake.systems.primitives import (
     ZeroOrderHold,
     )
 
 from pydrake.systems.test.test_util import (
-    call_overrides,
+    call_leaf_system_overrides,
+    call_vector_system_overrides,
     )
 
 
@@ -43,29 +45,56 @@ class CustomAdder(LeafSystem):
             sum += input_vector.get_value()
 
 
+class CustomVectorSystem(VectorSystem):
+    def __init__(self, is_discrete):
+        # VectorSystem only supports pure Continuous or pure Discrete.
+        # Dimensions:
+        #   1 Input, 2 States, 3 Outputs.
+        VectorSystem.__init__(self, 1, 3)
+        self._is_discrete = is_discrete
+        if self._is_discrete:
+            self._DeclareDiscreteState(2)
+        else:
+            self._DeclareContinuousState(2)
+        # Record calls for testing.
+        self.has_called = []
+
+    def _DoCalcVectorOutput(self, context, u, x, y):
+        y[:] = np.hstack([u, x])
+        self.has_called.append("output")
+
+    def _DoCalcVectorTimeDerivatives(self, context, u, x, x_dot):
+        x_dot[:] = x + u
+        self.has_called.append("continuous")
+
+    def _DoCalcVectorDiscreteVariableUpdates(self, context, u, x, x_n):
+        x_n[:] = x + 2*u
+        self.has_called.append("discrete")
+
+
 class TestCustom(unittest.TestCase):
-    def _create_system(self):
+    def _create_adder_system(self):
         system = CustomAdder(2, 3)
         return system
 
-    def _fix_inputs(self, context):
+    def _fix_adder_inputs(self, context):
         self.assertEquals(context.get_num_input_ports(), 2)
         context.FixInputPort(0, BasicVector([1, 2, 3]))
         context.FixInputPort(1, BasicVector([4, 5, 6]))
 
-    def test_execution(self):
-        system = self._create_system()
+    def test_adder_execution(self):
+        system = self._create_adder_system()
         context = system.CreateDefaultContext()
-        self._fix_inputs(context)
+        self._fix_adder_inputs(context)
         output = system.AllocateOutput(context)
         self.assertEquals(output.get_num_ports(), 1)
         system.CalcOutput(context, output)
         value = output.get_vector_data(0).get_value()
         self.assertTrue(np.allclose([5, 7, 9], value))
 
-    def test_simulation(self):
+    def test_adder_simulation(self):
         builder = DiagramBuilder()
-        adder = builder.AddSystem(self._create_system())
+        adder = builder.AddSystem(self._create_adder_system())
         adder.set_name("custom_adder")
         # Add ZOH so we can easily extract state.
         zoh = builder.AddSystem(ZeroOrderHold(0.1, 3))
@@ -76,7 +105,7 @@ class TestCustom(unittest.TestCase):
         builder.Connect(adder.get_output_port(0), zoh.get_input_port(0))
         diagram = builder.Build()
         context = diagram.CreateDefaultContext()
-        self._fix_inputs(context)
+        self._fix_adder_inputs(context)
 
         simulator = Simulator(diagram, context)
         simulator.Initialize()
@@ -86,7 +115,7 @@ class TestCustom(unittest.TestCase):
         value = state.get_discrete_state().get_data()[0].get_value()
         self.assertTrue(np.allclose([5, 7, 9], value))
 
-    def test_overrides(self):
+    def test_leaf_system_overrides(self):
 
         class TrivialSystem(LeafSystem):
             def __init__(self):
@@ -105,8 +134,68 @@ class TestCustom(unittest.TestCase):
 
         system = TrivialSystem()
         self.assertFalse(system.called_publish)
-        call_overrides(system)
+        call_leaf_system_overrides(system)
         self.assertTrue(system.called_publish)
+
+    def test_vector_system_overrides(self):
+        dt = 0.5
+        for is_discrete in [False, True]:
+            system = CustomVectorSystem(is_discrete)
+            context = system.CreateDefaultContext()
+
+            u = np.array([1.])
+            context.FixInputPort(0, BasicVector(u))
+
+            # Dispatch virtual calls from C++.
+            output = call_vector_system_overrides(
+                system, context, is_discrete, dt)
+
+            # Check call order.
+            update_type = is_discrete and "discrete" or "continuous"
+            assert system.has_called == [update_type, "output"]
+
+            # Check values.
+            state = context.get_state()
+            state_type = (
+                is_discrete and state.get_discrete_state()
+                or state.get_continuous_state())
+
+            x0 = [0., 0.]
+            x = state_type.get_vector().get_value()
+            c = is_discrete and 2 or 1*dt
+            x_expected = x0 + c*u
+            self.assertTrue(np.allclose(x, x_expected))
+
+            # Check output.
+            y_expected = np.hstack([u, x])
+            y = output.get_vector_data(0).get_value()
+            self.assertTrue(np.allclose(y, y_expected))
+
+    def test_state_api(self):
+
+        class TrivialSystem(LeafSystem):
+            def __init__(self, index):
+                LeafSystem.__init__(self)
+                num_q = 2
+                num_v = 1
+                num_z = 3
+                num_state = num_q + num_v + num_z
+                if index == 0:
+                    self._DeclareContinuousState(num_state_variables=num_state)
+                elif index == 1:
+                    self._DeclareContinuousState(
+                        num_q=num_q, num_v=num_v, num_z=num_z)
+                elif index == 2:
+                    self._DeclareContinuousState(BasicVector(num_state))
+                elif index == 3:
+                    self._DeclareContinuousState(
+                        BasicVector(num_state),
+                        num_q=num_q, num_v=num_v, num_z=num_z)
+
+        for index in range(4):
+            system = TrivialSystem(index)
+            context = system.CreateDefaultContext()
+            self.assertEquals(context.get_continuous_state_vector().size(), 6)
 
 
 if __name__ == '__main__':

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -107,12 +107,10 @@ class TestGeneral(unittest.TestCase):
         context.FixInputPort(2, input2)
 
         # Initialize integrator states.
-        def get_mutable_continuous_state(system):
-            return (diagram.GetMutableSubsystemState(system, context)
-                           .get_mutable_continuous_state())
-
-        integrator_xc = get_mutable_continuous_state(integrator)
-        integrator_xc.get_mutable_vector().SetFromVector([0, 1, 2])
+        integrator_xc = (
+            diagram.GetMutableSubsystemState(integrator, context)
+                   .get_mutable_continuous_state().get_vector())
+        integrator_xc.SetFromVector([0, 1, 2])
 
         simulator.Initialize()
 
@@ -132,8 +130,7 @@ class TestGeneral(unittest.TestCase):
         for i, context_i in enumerate(context_log):
             t = times[i]
             self.assertEqual(context_i.get_time(), t)
-            xc = (context_i.get_state().get_continuous_state()
-                           .get_vector().CopyToVector())
+            xc = context_i.get_continuous_state_vector().CopyToVector()
             xc_expected = (float(i) / (n - 1) * (xc_final - xc_initial) +
                            xc_initial)
             print("xc[t = {}] = {}".format(t, xc))

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -3,6 +3,7 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/vector_system.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 
 using std::unique_ptr;
@@ -62,12 +63,49 @@ PYBIND11_MODULE(test_util, m) {
     .def(py::init<std::function<void()>>());
 
   // Call overrides to ensure a custom Python class can override these methods.
-  m.def("call_overrides", [](const LeafSystem<T>* system) {
-    auto context = system->AllocateContext();
+
+  m.def("call_leaf_system_overrides", [](const LeafSystem<T>& system) {
+    auto context = system.AllocateContext();
     // Call `Publish` to test `DoPublish`.
     auto events =
         LeafEventCollection<PublishEvent<T>>::MakeForcedEventCollection();
-    system->Publish(*context, *events);
+    system.Publish(*context, *events);
+  });
+
+  auto clone_vector = [](const VectorBase<T>& vector) {
+    auto copy = std::make_unique<BasicVector<T>>(vector.size());
+    copy->SetFrom(vector);
+    return copy;
+  };
+
+  m.def("call_vector_system_overrides", [clone_vector](
+      const VectorSystem<T>& system, Context<T>* context,
+      bool is_discrete, double dt) {
+    // While this is not convention, update state first to ensure that our
+    // output incorporates it correctly, for testing purposes.
+    // TODO(eric.cousineau): Add (Continuous|Discrete)State::Clone().
+    if (is_discrete) {
+      auto& state = context->get_mutable_discrete_state();
+      DiscreteValues<T> state_copy(
+          clone_vector(state.get_vector()));
+      system.CalcDiscreteVariableUpdates(
+          *context, &state_copy);
+      state.SetFrom(state_copy);
+    } else {
+      auto& state = context->get_mutable_continuous_state();
+      ContinuousState<T> state_dot(
+          clone_vector(state.get_vector()),
+          state.get_generalized_position().size(),
+          state.get_generalized_velocity().size(),
+          state.get_misc_continuous_state().size());
+      system.CalcTimeDerivatives(*context, &state_dot);
+      state.SetFromVector(
+          state.CopyToVector() + dt * state_dot.CopyToVector());
+    }
+    // Calculate output.
+    auto output = system.AllocateOutput(*context);
+    system.CalcOutput(*context, output.get());
+    return output;
   });
 }
 

--- a/bindings/pydrake/systems/test/vector_test.py
+++ b/bindings/pydrake/systems/test/vector_test.py
@@ -11,30 +11,51 @@ from pydrake.systems.framework import (
     BasicVector,
     )
 
-# TODO(eric.cousineau): Add negative test cases for AutoDiffXd and Symbolic
-# once they are in the bindings.
+
+def pass_through(x):
+    return x
+
+
+# TODO(eric.cousineau): Add negative (or positive) test cases for AutoDiffXd
+# and Symbolic once they are in the bindings.
 
 
 class TestReference(unittest.TestCase):
     def test_basic_vector_double(self):
-        # Ensure that we can get vectors templated on double by reference.
-        init = [1., 2, 3]
-        value_data = BasicVector(init)
-        value = value_data.get_mutable_value()
-        # TODO(eric.cousineau): Determine if there is a way to extract the
-        # pointer referred to by the buffer (e.g. `value.data`).
-        value[:] += 1
-        expected = [2., 3, 4]
-        self.assertTrue(np.allclose(value, expected))
-        self.assertTrue(np.allclose(value_data.get_value(), expected))
-        self.assertTrue(np.allclose(value_data.get_mutable_value(), expected))
-        self.assertEqual(value_data.size(), 3)
-        expected = [5., 6, 7]
-        value_data.SetFromVector(expected)
-        self.assertTrue(np.allclose(value, expected))
-        self.assertTrue(np.allclose(value_data.get_value(), expected))
-        self.assertTrue(np.allclose(value_data.get_mutable_value(), expected))
-        self.assertEqual(value_data.size(), 3)
+        # Test constructing vectors of sizes [0, 1, 2], and ensure that we can
+        # construct from both lists and `np.array` objects with no ambiguity.
+        for n in [0, 1, 2]:
+            for wrap in [pass_through, np.array]:
+                # Ensure that we can get vectors templated on double by
+                # reference.
+                expected_init = wrap(map(float, range(n)))
+                expected_add = wrap([x + 1 for x in expected_init])
+                expected_set = wrap([x + 10 for x in expected_init])
+
+                value_data = BasicVector(expected_init)
+                value = value_data.get_mutable_value()
+                self.assertTrue(np.allclose(value, expected_init))
+
+                # Add value directly.
+                # TODO(eric.cousineau): Determine if there is a way to extract
+                # the pointer referred to by the buffer (e.g. `value.data`).
+                value[:] += 1
+                self.assertTrue(np.allclose(value, expected_add))
+                self.assertTrue(
+                    np.allclose(value_data.get_value(), expected_add))
+                self.assertTrue(
+                    np.allclose(value_data.get_mutable_value(), expected_add))
+
+                # Set value from `BasicVector`.
+                value_data.SetFromVector(expected_set)
+                self.assertTrue(np.allclose(value, expected_set))
+                self.assertTrue(
+                    np.allclose(value_data.get_value(), expected_set))
+                self.assertTrue(
+                    np.allclose(value_data.get_mutable_value(), expected_set))
+                # Ensure we can construct from size.
+                value_data = BasicVector(n)
+                self.assertEquals(value_data.size(), n)
 
 
 if __name__ == '__main__':

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -58,6 +58,12 @@ drake_py_library(
     imports = PACKAGE_INFO.py_imports,
 )
 
+drake_cc_library(
+    name = "eigen_pybind",
+    hdrs = ["eigen_pybind.h"],
+    deps = ["//bindings/pydrake:pydrake_pybind"],
+)
+
 # ODR does not matter, because the singleton will be stored in Python.
 drake_cc_library(
     name = "cpp_param_pybind",

--- a/bindings/pydrake/util/eigen_pybind.h
+++ b/bindings/pydrake/util/eigen_pybind.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <pybind11/eigen.h>
+
+namespace drake {
+namespace pydrake {
+
+/// Provides a mutable Ref<> for a pointer.
+/// Meant to be used for decorating methods passed to `pybind11` (e.g. virtual
+/// function dispatch).
+// TODO(eric.cousineau): Ensure that all C++ mutator call sites use `EigenPtr`.
+template <typename Derived>
+auto ToEigenRef(Eigen::VectorBlock<Derived>* derived) {
+  return Eigen::Ref<Derived>(*derived);
+}
+
+}  // namespace pydrake
+}  // namespace drake


### PR DESCRIPTION
Got some bugfixes in, but end-user use should be straightforward (when `T = double`).

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7880)
<!-- Reviewable:end -->
