### PR TITLE
Remove drake-distro from example READMEs

### DIFF
--- a/examples/valkyrie/BUILD.bazel
+++ b/examples/valkyrie/BUILD.bazel
@@ -55,10 +55,12 @@ drake_cc_library(
     ],
 )
 
-drake_cc_library(
+drake_cc_binary(
     name = "valkyrie_pd_ff_controller",
-    srcs = ["valkyrie_pd_ff_controller.cc"],
-    hdrs = ["valkyrie_pd_ff_controller.h"],
+    srcs = [
+        "valkyrie_pd_ff_controller.cc",
+        "valkyrie_pd_ff_controller.h",
+    ],
     data = [":models"],
     deps = [
         ":robot_state_decoder",

--- a/examples/valkyrie/README.md
+++ b/examples/valkyrie/README.md
@@ -9,18 +9,21 @@ buildcop cannot trivially resolve them, a GitHub issue will be assigned to
 the Valkyrie team. If the issue is not resolved within 24 hours, the author
 or buildcop may disable the offending targets.
 
+To compile this example
+  $ cd drake
+  $ bazel build //tools:drake_visualizer //examples/valkyrie/...
 
 To run the visualizer:
-  $ cd drake-distro
-  $ ./build/install/bin/drake-visualizer
+  $ cd drake
+  $ bazel-bin/tools/drake_visualizer &
 
 To run the pd + feedforward controller:
-  $ cd drake-distro
-  $ ./build/drake/examples/valkyrie/valkyrie_pd_ff_controller
+  $ cd drake
+  $ bazel-bin/examples/valkyrie/valkyrie_pd_ff_controller &
 
 To run the simulation:
-  $ cd drake-distro
-  $ ./build/drake/examples/valkyrie/valkyrie_simulation
+  $ cd drake
+  $ bazel-bin/examples/valkyrie/valkyrie_simulation &
 
 The visualizer needs to be started before the simulator.
 The controller and simulator are not synchronized in any way, and they both

--- a/multibody/rigid_body_plant/images/README.md
+++ b/multibody/rigid_body_plant/images/README.md
@@ -4,7 +4,7 @@
 
 The simplest way to create a .png from the .svg file is to use Inkscape.
 
-To install: `sudo apt-get install inkscape`
+To install: `sudo apt install inkscape`
 
 The following steps will re-create the png:
 
@@ -26,8 +26,8 @@ These python scripts use Python 2.X, matplotlib, and numpy to generate the
 
 Acquiring the dependencies in Ubuntu:
 
-- `sudo apt-get install python-matplotlib`
-- `sudo apt-get install python-numpy`
+- `sudo apt install python-matplotlib`
+- `sudo apt install python-numpy`
 
 To create the image:
 

--- a/multibody/rigid_body_plant/images/README.md
+++ b/multibody/rigid_body_plant/images/README.md
@@ -15,7 +15,7 @@ The following steps will re-create the png:
    2. In "Export area", select "Drawing"
    3. In "Bitmap size", set "pixels at" to 100.0 dpi
    4. Click [Browse|Export As] and direct it to the
-   `$DRAKE_DISTRO$/drake/multibody/rigid_body_plant/images` directory.
+   `drake/multibody/rigid_body_plant/images` directory.
    5. Use the same file name as the .svg file (e.g., image.svg --> image.png).
    6. Click the "Export" button.
 
@@ -31,7 +31,7 @@ Acquiring the dependencies in Ubuntu:
 
 To create the image:
 
-1. `cd $DRAKE_DISTRO$/drake/multibody/rigid_body_plant/images`
+1. `cd drake/multibody/rigid_body_plant/images`
 2. `python file_name.py`
 
 This will create the image `file_name.png`.

--- a/multibody/rigid_body_plant/visualization/README
+++ b/multibody/rigid_body_plant/visualization/README
@@ -1,9 +1,11 @@
 To run drake-visualizer with the contact force visualization:
 
-$ cd drake-distro
-$ ./build/install/bin/drake-visualizer --script ./drake/multibody/rigid_body_plant/visualization/contact_viz.py
+$ cd drake
+$ bazel build //tools:drake_visualizer
+$ bazel-bin/tools/drake_visualizer --script ./multibody/rigid_body_plant/visualization/contact_viz.py
 
 To run drake-visualizer with the simulation and real time factor display:
 
-$ cd drake-distro
-$ ./build/install/bin/drake-visualizer --script ./drake/multibody/rigid_body_plant/visualization/show_time.py
+$ cd drake
+$ bazel build //tools:drake_visualizer
+$ bazel-bin/tools/drake_visualizer --script ./multibody/rigid_body_plant/visualization/show_time.py

--- a/systems/sensors/test/accelerometer_test/README.md
+++ b/systems/sensors/test/accelerometer_test/README.md
@@ -1,14 +1,8 @@
 To run a demo of an accelerometer attached to a pendulum:
 
-# When building Drake using CMake
-
-    cd drake-distro
-    ./build/install/bin/drake-visualizer &
-    ./build/drake/systems/sensors/test/accelerometer_test/accelerometer_example --initial_q=1.57 --initial_v=0
-
 # When building Drake using Bazel
 
-    cd drake-distro
+    cd drake
     bazel build //tools:drake_visualizer
     bazel-bin/tools/drake_visualizer &
-    bazel run -- //drake/systems/sensors:accelerometer_example --initial_q=1.57 --initial_v=0
+    bazel run -- //systems/sensors:accelerometer_example --initial_q=1.57 --initial_v=0


### PR DESCRIPTION
This also makes `valkyrie_pd_ff_controller` executable again -- we'd been compiling it as a library ever since we switched to Bazel.  As it turns out, its a main program split into header + cc.

Relates #6996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7886)
<!-- Reviewable:end -->
