### PR TITLE
Hoist up installed resource sentinel to match data

### DIFF
--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -21,7 +21,7 @@ class TestCommonInstall(unittest.TestCase):
         tool_env[env_python_path] = os.path.abspath(
             os.path.join(tmp_folder, "lib", "python2.7", "site-packages")
         )
-        data_folder = os.path.join(tmp_folder, "share", "drake", "drake")
+        data_folder = os.path.join(tmp_folder, "share", "drake")
         # Call python2 to force using python brew install. Calling python
         # system would result in a crash since pydrake was built against
         # brew python. On Linux this will still work and force using
@@ -33,6 +33,7 @@ class TestCommonInstall(unittest.TestCase):
              "-c", "import pydrake; print(pydrake.getDrakePath());\
              import pydrake; print(pydrake.getDrakePath())"
              ],
+            cwd='/',  # Defeat the "search in parent folders" heuristic.
             env=tool_env,
             ).strip()
         found_install_path = (data_folder in output_path)

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -418,11 +418,10 @@ install(
     name = "install",
     targets = [":resource_tool"],
     # TODO(jwnimmer-tri) The install rule should offer more specific options
-    # for putting programs into libexec and including the workspace and/or
-    # package name in the installed path.  For now, we'll just specify it
-    # manually.
-    runtime_dest = "libexec/drake/drake/common",
-    data_dest = "share/drake/drake",
+    # for programs not in bin/, and including the workspace and/or package name
+    # in the installed path.  For now, we'll just specify it manually.
+    runtime_dest = "share/drake/common",
+    data_dest = "share/drake",
     guess_data = "WORKSPACE",
     allowed_externals = [DRAKE_RESOURCE_SENTINEL],
 )

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -114,7 +114,7 @@ optional<std::string> getenv_optional(const char* const name) {
 optional<std::string>  GetCandidateDirFromLibdrake() {
   optional<std::string> libdrake_dir = LoadedLibraryPath("libdrake.so");
   if (libdrake_dir) {
-    libdrake_dir = libdrake_dir.value() + "/../share/drake/drake";
+    libdrake_dir = libdrake_dir.value() + "/../share/drake";
   }
   return libdrake_dir;
 }

--- a/common/test/resource_tool_installed_test.py
+++ b/common/test/resource_tool_installed_test.py
@@ -22,8 +22,8 @@ class TestResourceTool(unittest.TestCase):
              ])
 
         # Create a resource in the temporary directory.
-        os.makedirs("tmp/share/drake/drake/common/test")
-        with open("tmp/share/drake/drake/common/test/tmp_resource", "w") as f:
+        os.makedirs("tmp/share/drake/common/test")
+        with open("tmp/share/drake/common/test/tmp_resource", "w") as f:
             f.write("tmp_resource")
 
         # Remove the un-installed copy, so we _know_ it won't be used.
@@ -38,7 +38,7 @@ class TestResourceTool(unittest.TestCase):
 
         # Cross-check the resource root environment variable name.
         env_name = "DRAKE_RESOURCE_ROOT"
-        resource_tool = "tmp/libexec/drake/drake/common/resource_tool"
+        resource_tool = "tmp/share/drake/common/resource_tool"
         output_name = subprocess.check_output(
             [resource_tool,
              "--print_resource_root_environment_variable_name",
@@ -48,7 +48,7 @@ class TestResourceTool(unittest.TestCase):
 
         # Use the installed resource_tool to find a resource.
         tool_env = dict(os.environ)
-        tool_env[env_name] = "tmp/share/drake"
+        tool_env[env_name] = "tmp/share"
         absolute_path = subprocess.check_output(
             [resource_tool,
              "--print_resource_path",
@@ -65,7 +65,7 @@ class TestResourceTool(unittest.TestCase):
              "--print_resource_path",
              "drake/common/test/tmp_resource",
              "--add_resource_search_path",
-             "tmp/share/drake",
+             "tmp/share",
              ],
             ).strip()
         with open(absolute_path, 'r') as data:

--- a/examples/kuka_iiwa_arm/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/BUILD.bazel
@@ -7,6 +7,10 @@ load(
     "drake_cc_googletest",
     "drake_example_cc_binary",
 )
+load(
+    "//tools/skylark:drake_py.bzl",
+    "drake_py_test",
+)
 load("//tools/install:install_data.bzl", "install", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load(
@@ -272,6 +276,21 @@ install(
     deps = adjust_labels_for_drake_hoist([
         "//drake/examples/kuka_iiwa_arm/models:install_data",
     ]),
+)
+
+# Run the installed flavor of the kuka simulation, to make sure it can locate
+# its resources, etc.  TODO(jwnimmer-tri) Refactor installed-test phrasing to
+# be more compact, convenient, and efficient such as #7774 proposes.
+drake_py_test(
+    name = "kuka_simulation_installed_test",
+    size = "small",
+    timeout = "long",
+    srcs = ["test/kuka_simulation_installed_test.py"],
+    data = ["//:install"],
+    main = "test/kuka_simulation_installed_test.py",
+    deps = [
+        "//tools/install:install_test_helper",
+    ],
 )
 
 add_lint_tests()

--- a/examples/kuka_iiwa_arm/test/kuka_simulation_installed_test.py
+++ b/examples/kuka_iiwa_arm/test/kuka_simulation_installed_test.py
@@ -1,0 +1,30 @@
+
+import os
+import shutil
+import subprocess
+import unittest
+import sys
+import install_test_helper
+
+
+class TestKukaSimulation(unittest.TestCase):
+    def test(self):
+        # Install into the tmpdir that Bazel has created for us.
+        tmpdir = os.environ["TEST_TMPDIR"]
+        self.assertTrue(os.path.exists(tmpdir))
+        install_dir = os.path.join(tmpdir, "install")
+        result = install_test_helper.install(install_dir, rmdir_cwd=False)
+        self.assertEqual(None, result)
+
+        # Make sure the simulation can run without error.  We set cwd="/" to
+        # defeat the "search in parent folders" heuristic, so that the "use
+        # libdrake.so relative paths" must be successful.
+        simulation = os.path.join(
+            install_dir,
+            "share/drake/examples/kuka_iiwa_arm/kuka_simulation")
+        self.assertTrue(os.path.exists(simulation), "Can't find " + simulation)
+        subprocess.check_call([simulation, "--simulation_sec=0.01"], cwd="/")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/install/install_data.bzl
+++ b/tools/install/install_data.bzl
@@ -21,9 +21,9 @@ def install_data(
     install directory is also created. The corresponding install directory is
     generated based on the current folder which is prepended with
     "share/drake/":
-    The file `drake/drake/examples/acrobot/Acrobot_no_collision.urdf` will be
+    The file `drake/examples/acrobot/Acrobot_no_collision.urdf` will be
     installed in:
-    {install_dir}/share/drake/drake/examples/acrobot/Acrobot_no_collision.urdf
+    {install_dir}/share/drake/examples/acrobot/Acrobot_no_collision.urdf
     Test files (files contained in a `test` subfolder or named `*test*`) are
     not installed.
 

--- a/tools/install/install_test_helper.py
+++ b/tools/install/install_test_helper.py
@@ -5,7 +5,8 @@ import shutil
 import subprocess
 
 
-def install(installation_folder="tmp", installed_subfolders=[]):
+def install(installation_folder="tmp", installed_subfolders=[],
+            rmdir_cwd=True):
     """Install into a temporary directory.
 
     Runs install script to install target in the specified temporary
@@ -26,6 +27,9 @@ def install(installation_folder="tmp", installed_subfolders=[]):
     for f in installed_subfolders:
         if f not in content_install_folder:
             return str(f) + " not found in " + str(content_install_folder)
+    # Skip the "remove Bazel build artifacts" when asked.
+    if not rmdir_cwd:
+        return None
     # Remove Bazel build artifacts, and ensure that we only have install
     # artifacts.
     content_test_folder = os.listdir(os.getcwd())


### PR DESCRIPTION
This is a fix for "most of the installed demo's don't actually work".  Relates #6996.

---

Now that the resources have been moved one directory up in drake's install folder, we need to also move the resource sentinel.

Since we also have to change the installed location of `resource_tool` (it had a double `drake/drake` in it), we take the opportunity to relocate it under `share/` to be alongside the other installed binaries.

As a smoke test of the move, add a regression test of `kuka_simulation` to prove that it works once installed.  We'll plan a rephrase of the "test of the install" logic soon, but for now this fixes a big problem, and proves at works for at least one example program.

Co-authored-by: Francois Budin <francois.budin@kitware.com>

---

This PR starts from the initial draft of #7774 by @fbudin69500 and amends it with a tiny bit of clean up, and adds the `kuka_simulation_installed_test` code.  The plan is to merge this first to stop the bleeding, and then iterate on #7774 so that tests are easier to write and more performant, so that then we can more thoroughly test the entire install.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7887)
<!-- Reviewable:end -->
