### PR TITLE
pydrake: Add internal instructions for installing via Bazel.

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -122,6 +122,26 @@ sources in Bazel's symlink forests.
 
 If using CLion, consider using `gdbserver`.
 
+# Installing Python Bindings from Bazel
+
+We suggest that you use the CMake workflow for installing the Python bindings
+as it should be more stable w.r.t. the rest of your system:
+http://drake.mit.edu/python_bindings.html
+
+However, if you need to test this without CMake in the loop, you may install
+all of Drake (including the Python bindings) using the target `//:install`.
+As an example:
+
+    mkdir build_install
+    bazel run //:install -- ~+/build_install
+
+N.B. Ensure that you use the correcet `--config` flags; if you do not want your
+`~/.bazelrc` flags leaking in, considuer using `bazel --bazelrc=/dev/null`.
+
+You may then start using the bindings by exposing these artifacts to Python:
+
+    export PYTHONPATH=${PWD}/build_install/lib/python2.7/site-packages:${PYTHONPATH}
+
 */
 
 // TODO(eric.cousineau): Add API naming conventions (#7819).


### PR DESCRIPTION
Closes #7519 (following from [this comment](https://github.com/RobotLocomotion/drake/issues/7519#issuecomment-349646032))

This is the internal version of #7598.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7891)
<!-- Reviewable:end -->
