### PR TITLE
Disable sh_test in sanitizer configs

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -674,13 +674,6 @@ sh_test(
         "--dry-run",
     ],
     data = [":demo"],
-    tags = [
-        # TODO(jwnimmer-tri) Apparently the liblcm.so is broken when compiled
-        # with sanitizers that have a runtime support library.
-        "no_asan",
-        "no_tsan",
-        "no_ubsan",
-    ],
 )
 
 add_lint_tests()

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -490,12 +490,6 @@ sh_test(
     # Mitigates driver-related issues when running under `bazel test`. For more
     # information, see #7004.
     local = 1,
-    # Disable under LeakSanitizer and Valgrind Memcheck due to driver-related
-    # leaks. For more information, see #7520.
-    tags = [
-        "no_lsan",
-        "no_memcheck",
-    ],
 )
 
 drake_cc_googletest(

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -44,7 +44,7 @@ test:asan --test_env=LSAN_OPTIONS
 test:asan --test_env=ASAN_SYMBOLIZER_PATH
 # LSan is run with ASan by default
 test:asan --test_tag_filters=-gurobi,-mosek,-snopt,-no_asan,-no_lsan
-test:asan --test_lang_filters=-py
+test:asan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 test:asan --test_timeout=120,600,1800,7200
@@ -67,7 +67,7 @@ test:asan_everything --run_under=//tools/dynamic_analysis:asan
 test:asan_everything --test_env=ASAN_OPTIONS
 test:asan_everything --test_env=LSAN_OPTIONS
 test:asan_everything --test_env=ASAN_SYMBOLIZER_PATH
-test:asan_everything --test_lang_filters=-py
+test:asan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
 test:asan_everything--test_timeout=120,600,1800,7200
@@ -82,7 +82,7 @@ test:lsan --run_under=//tools/dynamic_analysis:lsan
 test:lsan --test_env=LSAN_OPTIONS
 test:lsan --test_env=LSAN_SYMBOLIZER_PATH
 test:lsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_lsan
-test:lsan --test_lang_filters=-py
+test:lsan --test_lang_filters=-sh,-py
 
 ### LSan everything build. ###
 build:lsan_everything --define=WITH_GUROBI=ON
@@ -100,7 +100,7 @@ test:lsan_everything --test_tag_filters=-no_lsan
 test:lsan_everything --run_under=//tools/dynamic_analysis:lsan
 test:lsan_everything --test_env=LSAN_OPTIONS
 test:lsan_everything --test_env=LSAN_SYMBOLIZER_PATH
-test:lsan_everything --test_lang_filters=-py
+test:lsan_everything --test_lang_filters=-sh,-py
 
 ### MSan build. ###
 build:msan --copt -g
@@ -111,7 +111,7 @@ build:msan --copt -fno-omit-frame-pointer
 build:msan --linkopt -fsanitize=memory
 test:msan --run_under=//tools/dynamic_analysis:msan
 test:msan --test_tag_filters=-gurobi,-mosek,-snopt,-no_msan
-test:msan --test_lang_filters=-py
+test:msan --test_lang_filters=-sh,-py
 test:msan --test_env=MSAN_OPTIONS
 test:msan --test_env=MSAN_SYMBOLIZER_PATH
 # Typical slowdown introduced by MemorySanitizer is 3x.
@@ -133,7 +133,7 @@ test:msan_everything --test_env=GRB_LICENSE_FILE
 test:msan_everything --test_env=HOME
 test:msan_everything --test_tag_filters=-no_msan
 test:msan_everything --run_under=//tools/dynamic_analysis:msan
-test:msan_everything --test_lang_filters=-py
+test:msan_everything --test_lang_filters=-sh,-py
 test:msan_everything --test_env=MSAN_OPTIONS
 test:msan_everything --test_env=MSAN_SYMBOLIZER_PATH
 # Typical slowdown introduced by MemorySanitizer is 3x.
@@ -155,7 +155,7 @@ build:tsan --linkopt -fsanitize=thread
 test:tsan --run_under=//tools/dynamic_analysis:tsan
 test:tsan --test_env=TSAN_OPTIONS
 test:tsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_tsan
-test:tsan --test_lang_filters=-py
+test:tsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 test:tsan --test_timeout=300,1500,5400,18000
@@ -181,7 +181,7 @@ test:tsan_everything --test_env=HOME
 test:tsan_everything --test_tag_filters=-no_tsan
 test:tsan_everything --run_under=//tools/dynamic_analysis:tsan
 test:tsan_everything --test_env=TSAN_OPTIONS
-test:tsan_everything --test_lang_filters=-py
+test:tsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by ThreadSanitizer is about 5x-15x
 # See https://clang.llvm.org/docs/ThreadSanitizer.html
 test:tsan_everything --test_timeout=300,1500,5400,18000
@@ -199,7 +199,7 @@ build:ubsan --linkopt /usr/lib/llvm-4.0/lib/clang/4.0.0/lib/linux/libclang_rt.ub
 test:ubsan --run_under=//tools/dynamic_analysis:ubsan
 test:ubsan --test_env=UBSAN_OPTIONS
 test:ubsan --test_tag_filters=-gurobi,-mosek,-snopt,-no_ubsan
-test:ubsan --test_lang_filters=-py
+test:ubsan --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
 test:ubsan --test_timeout=120,600,1800,7200
@@ -222,7 +222,7 @@ test:ubsan_everything --test_env=HOME
 test:ubsan_everything --test_tag_filters=-no_ubsan
 test:ubsan_everything --run_under=//tools/dynamic_analysis:ubsan
 test:ubsan_everything --test_env=UBSAN_OPTIONS
-test:ubsan_everything --test_lang_filters=-py
+test:ubsan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by UBSan is 1.2x, increasing timeouts to 2x.
 # See https://developer.apple.com/documentation/code_diagnostics/undefined_behavior_sanitizer
 test:ubsan_everything --test_timeout=120,600,1800,7200


### PR DESCRIPTION
For the same reasons in b3ff7d2 (#6077) that we disabled `py_test` in these configurations, we should also disable `sh_test` -- because `sh_test` are just as likely to call Python code as they are C++ code, and we don't want to work on suppressions or linker details for these cases.

Remove `sh_test` explicit tags made redundant by `test_lang_filters`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7897)
<!-- Reviewable:end -->
