### PR TITLE
pydrake: Add roll-up of symbols which still allows decoupled testing.

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -121,12 +121,6 @@ drake_pybind_library(
     py_srcs = ["symbolic.py"],
 )
 
-# Alias sub-package.
-alias(
-    name = "util_py",
-    actual = "//bindings/pydrake/util",
-)
-
 PY_LIBRARIES_WITH_INSTALL = adjust_labels_for_drake_hoist([
     ":autodiffutils_py",
     ":common_py",
@@ -143,18 +137,32 @@ PY_LIBRARIES_WITH_INSTALL = adjust_labels_for_drake_hoist([
 
 PY_LIBRARIES = []
 
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+)
+
+# Package roll-up (for Bazel dependencies).
+drake_py_library(
+    name = "pydrake",
+    visibility = ["//visibility:public"],
+    deps = [":all_py"],
+)
+
 install(
     name = "install",
-    targets = PY_LIBRARIES,
+    targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     visibility = ["//visibility:public"],
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )
 
-drake_py_library(
-    name = "pydrake",
-    visibility = ["//visibility:public"],
-    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+drake_py_test(
+    name = "all_test",
+    data = ["//examples/pendulum:models"],
+    deps = [":all_py"],
 )
 
 # Test ODR (One Definition Rule).

--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -1,0 +1,37 @@
+"""
+Provides a roll-up of all user-visible symbols in `pydrake`.
+
+Things to note:
+*   The `.all` modules in `pydrake` are intended as convenient end-user
+shortcut for interactive or tutorial use.
+*   Code within pydrake itself should not use the all shortcut, but rather
+import only exactly what is needed.
+*   The downside of importing an `.all` module is (a) pulling in additional
+dependencies and (b) the potential to lose a symbol if there is a conflict
+(e.g. something like `pydrake.multibody.shapes.Element` vs
+`pydrake.multibody.collision.Element` (which does not exist yet)).
+
+N.B. Import order matters! If there is a name conflict, the last one imported
+wins.
+
+To see example usages, please see `doc/python_bindings.rst`.
+
+"""
+
+from __future__ import absolute_import
+
+# This module.
+from . import getDrakePath
+from .autodiffutils import *
+from .common import *
+from .parsers import *
+from .rbtree import *
+from .symbolic import *
+
+# Submodules.
+# - Do not inclue `examples`.
+from .multibody.all import *
+from .solvers.all import *
+from .systems.all import *
+# - Do not include `third_party`.
+# - Do not include `util`.

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -60,33 +60,29 @@ drake_pybind_library(
     ],
 )
 
-drake_py_library(
-    name = "all_py",
-    deps = [
-        ":rigid_body_plant_py",
-        ":shapes_py",
-    ],
-)
-
 PY_LIBRARIES_WITH_INSTALL = [
     ":rigid_body_plant_py",
     ":shapes_py",
 ]
 
-PY_LIBRARIES = [
-    ":all_py",
-    ":module_py",
-]
+PY_LIBRARIES = []
 
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+)
+
+# Package roll-up (for Bazel dependencies).
 drake_py_library(
     name = "multibody",
-    imports = PACKAGE_INFO.py_imports,
-    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+    deps = [":all_py"],
 )
 
 install(
     name = "install",
-    targets = PY_LIBRARIES,
+    targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )

--- a/bindings/pydrake/multibody/all.py
+++ b/bindings/pydrake/multibody/all.py
@@ -1,7 +1,2 @@
 from .rigid_body_plant import *
 from .shapes import *
-
-try:
-    from .drawing import *
-except ImportError:
-    pass

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -101,14 +101,22 @@ PY_LIBRARIES = [
     ":module_py",
 ]
 
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+)
+
+# Package roll-up (for Bazel dependencies).
 drake_py_library(
     name = "solvers",
-    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+    deps = [":all_py"],
 )
 
 install(
     name = "install",
-    targets = PY_LIBRARIES,
+    targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )

--- a/bindings/pydrake/solvers/all.py
+++ b/bindings/pydrake/solvers/all.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+# TODO(eric.cousineau): Move `ik` to `multibody`.
+from .ik import *
+from .mathematicalprogram import *
+# TODO(eric.cousineau): Merge these into `mathematicalprogram`.
+from .gurobi import *
+from .ipopt import *
+from .mosek import *

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -100,17 +100,6 @@ drake_py_library(
     deps = [":module_py"],
 )
 
-drake_py_library(
-    name = "all_py",
-    deps = [
-        ":analysis_py",
-        ":drawing_py",
-        ":framework_py",
-        ":primitives_py",
-        ":sensors_py",
-    ],
-)
-
 PY_LIBRARIES_WITH_INSTALL = [
     ":analysis_py",
     ":framework_py",
@@ -119,20 +108,26 @@ PY_LIBRARIES_WITH_INSTALL = [
 ]
 
 PY_LIBRARIES = [
-    ":all_py",
     ":drawing_py",
     ":module_py",
 ]
 
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+)
+
+# Package roll-up (for Bazel dependencies).
 drake_py_library(
     name = "systems",
-    imports = PACKAGE_INFO.py_imports,
-    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+    deps = [":all_py"],
 )
 
 install(
     name = "install",
-    targets = PY_LIBRARIES,
+    targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from pydrake.all import *
+
+
+class TestAll(unittest.TestCase):
+    def test_symbols(self):
+        # Subset of symbols.
+        expected_symbols = (
+            # autodiffutils
+            "AutoDiffXd",
+            # common
+            "AddResourceSearchPath",
+            # parsers
+            "PackageMap",
+            # rbtree
+            "RigidBodyTree",
+            # symbolic
+            "Variable",
+            "Expression",
+            # multibody
+            "RigidBodyPlant",
+            # solvers
+            "MathematicalProgram",
+            "LinearConstraint",
+            # systems
+            "BasicVector",
+            "LeafSystem",
+            "Simulator",
+        )
+        # Ensure each symbol is exposed as globals from the above import
+        # statement.
+        for expected_symbol in expected_symbols:
+            self.assertTrue(expected_symbol in globals())
+
+    def test_usage_all(self):
+        # N.B. Synchronize this with `doc/python_bindings.rst`.
+        tree = RigidBodyTree(
+            FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+        simulator = Simulator(RigidBodyPlant(tree))
+
+    def test_usage_no_all(self):
+
+        def isolated(self):
+            # Ensure we have no globals leaking in.
+            self.assertEquals(len(globals()), 0)
+
+            # N.B. Synchronize this with `doc/python_bindings.rst`.
+            from pydrake.common import FindResourceOrThrow
+            from pydrake.multibody.rigid_body_plant import RigidBodyPlant
+            from pydrake.rbtree import RigidBodyTree
+            from pydrake.systems.analysis import Simulator
+
+            tree = RigidBodyTree(
+                FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+            simulator = Simulator(RigidBodyPlant(tree))
+
+            return simulator
+
+        # Evaluate without access to current globals.
+        # TODO(eric.cousineau): Use `mock.patch.dict` when available.
+        # Unfortunately, `isolated.__globals__` references current globals, so
+        # we must restore them. `eval(expr, globals)` does not override the
+        # scoped globals of the function (as it should be).
+        # `isolated.__globals__` is a read-only property as well.
+        old_globals = dict(isolated.__globals__)
+        isolated.__globals__.clear()
+        simulator = isolated(self)
+        isolated.__globals__.update(old_globals)
+        self.assertTrue(isinstance(simulator, Simulator))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -90,3 +90,39 @@ What's Available from Python
 The most up-to-date demonstrations of what can be done using ``pydrake`` are
 the ``pydrake`` unit tests themselves. You can see all of them inside the
 ``drake/bindings/python/pydrake/test`` folder in the Drake source code.
+
+There are multiple levels of modules available from ``pydrake``. If you are
+experimenting with ``pydrake`` in a REPL environment (such as IPython  or
+Jupyter), consider importing from ``pydrake.all`` to reduce the number of
+import staments.
+
+..
+    Developers: Ensure this is synchronized with
+    ``//bindings/pydrake:all_test``, specifically the test cases
+    ``test_usage_all`` and ``test_usage_no_all``.
+
+As an example, the following code uses ``pydrake.all``:
+
+.. code-block:: python
+
+    from pydrake.all import *
+
+    tree = RigidBodyTree(
+        FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+    simulator = Simulator(RigidBodyPlant(tree))
+
+While this code does not:
+
+.. code-block:: python
+
+    from pydrake.common import FindResourceOrThrow
+    from pydrake.multibody.rigid_body_plant import RigidBodyPlant
+    from pydrake.rbtree import RigidBodyTree
+    from pydrake.systems.analysis import Simulator
+
+    tree = RigidBodyTree(
+        FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+    simulator = Simulator(RigidBodyPlant(tree))
+
+For guidance on when to use ``pydrake.all`` when developing, please see
+``help(pydrake.all)``.


### PR DESCRIPTION
\cc @gizatt @peteflorence 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7911)
<!-- Reviewable:end -->
