### PR TITLE
Cleanup/fix various installed targets and file locations

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -109,6 +109,6 @@
   },
   "X-CMake-Variables-Init": {
     "_Boost_IMPORTED_TARGETS": 1,
-    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR}/modules;${CMAKE_MODULE_PATH}"
+    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR}/modules/3.10;${CMAKE_MODULE_PATH}"
   }
 }

--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -80,7 +80,7 @@
         "ignition-math4:ignition-math4",
         "ignition-rndf0:ignition-rndf0",
         "lcm:lcm",
-        "optitrack:lcmtypes_optitrack-cpp",
+        "optitrack:optitrack-lcmtypes-cpp",
         "protobuf:libprotobuf",
         "robotlocomotion-lcmtypes:robotlocomotion-lcmtypes-cpp",
         "spdlog:spdlog",

--- a/tools/workspace/eigen/package-create-cps.py
+++ b/tools/workspace/eigen/package-create-cps.py
@@ -11,11 +11,11 @@ content = """
   "Description": "Lightweight C++ template library for vector and matrix math",
   "License": ["MPL-2.0", "LGPL-2.1+", "BSD-3-Clause"],
   "Version": "%(WORLD_VERSION)s.%(MAJOR_VERSION)s.%(MINOR_VERSION)s",
-  "Default-Components": [ ":Eigen" ],
+  "Default-Components": [":Eigen"],
   "Components": {
     "Eigen": {
       "Type": "interface",
-      "Includes": [ "@prefix@/include/eigen3" ]
+      "Includes": ["@prefix@/include/eigen3"]
     }
   },
   "X-CMake-Variables": {

--- a/tools/workspace/find_protobuf_cmake/BUILD.bazel
+++ b/tools/workspace/find_protobuf_cmake/BUILD.bazel
@@ -10,17 +10,17 @@ package(default_visibility = ["//visibility:public"])
 
 install_files(
     name = "install",
-    dest = "lib/cmake/drake/modules",
+    dest = "lib/cmake/drake/modules/3.10",
     files = [
         "//third_party:com_kitware_gitlab_cmake_cmake/3.10/Copyright.txt",
         "//third_party:com_kitware_gitlab_cmake_cmake/3.10/Modules/FindProtobuf.cmake",  # noqa
     ],
     strip_prefix = [
         # The first strip_prefix match wins; thus, we will end up with:
-        # - install to "lib/cmake/drake/modules/FindProtobuf.cmake"
+        # - install to "lib/cmake/drake/modules/3.10/FindProtobuf.cmake"
         "com_kitware_gitlab_cmake_cmake/3.10/Modules",
         # - install to "lib/cmake/drake/modules/3.10/Copyright.txt"
-        "com_kitware_gitlab_cmake_cmake",
+        "com_kitware_gitlab_cmake_cmake/3.10",
     ],
     allowed_externals = [
         "//third_party:com_kitware_gitlab_cmake_cmake/3.10/Copyright.txt",

--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -11,16 +11,16 @@ content = """
   "Description": "Small, safe and fast formatting library",
   "License": "BSD-2-Clause",
   "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
-  "Default-Components": [ ":fmt" ],
+  "Default-Components": [":fmt"],
   "Components": {
     "fmt-header-only": {
       "Type": "interface",
-      "Includes": [ "@prefix@/include" ]
+      "Includes": ["@prefix@/include/fmt"]
     },
     "fmt": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libfmt.so",
-      "Requires": [ ":fmt-header-only" ]
+      "Requires": [":fmt-header-only"]
     }
   }
 }

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -18,19 +18,21 @@ cc_library(
     includes = ["."],
 )
 
+CMAKE_PACKAGE = "fmt"
+
 cmake_config(
-    package = "fmt",
+    package = CMAKE_PACKAGE,
     script = "@drake//tools/workspace/fmt:package-create-cps.py",
     version_file = "CMakeLists.txt",
 )
 
-install_cmake_config(package = "fmt")  # Creates rule :install_cmake_config.
+# Creates rule :install_cmake_config.
+install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
     targets = [":fmt"],
-    hdr_dest = "include/fmt",
-    hdr_strip_prefix = ["fmt"],
+    hdr_dest = "include/" + CMAKE_PACKAGE,
     guess_hdrs = "PACKAGE",
     docs = ["LICENSE.rst"],
     deps = [":install_cmake_config"],

--- a/tools/workspace/ignition_math/package-create-cps.py
+++ b/tools/workspace/ignition_math/package-create-cps.py
@@ -12,12 +12,12 @@ content = """
   "Description": "Math classes and functions for robot applications",
   "License": "Apache-2.0",
   "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
-  "Default-Components": [ ":ignition-math4" ],
+  "Default-Components": [":ignition-math4"],
   "Components": {
     "ignition-math4": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libignition_math.so",
-      "Includes": [ "@prefix@/include" ]
+      "Includes": ["@prefix@/include/ignition-math4"]
     }
   },
   "X-CMake-Variables": {

--- a/tools/workspace/ignition_math/package.BUILD.bazel
+++ b/tools/workspace/ignition_math/package.BUILD.bazel
@@ -197,6 +197,7 @@ install(
     workspace = CMAKE_PACKAGE,
     targets = [":libignition_math.so"],
     hdrs = public_headers,
+    hdr_dest = "include/" + CMAKE_PACKAGE,
     hdr_strip_prefix = ["include"],
     docs = [
         "COPYING",

--- a/tools/workspace/ignition_rndf/package-create-cps.py
+++ b/tools/workspace/ignition_rndf/package-create-cps.py
@@ -18,16 +18,16 @@ content = """
     "ignition-math4": {
       "Version": "%(ignition-math4_VERSION)s",
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],
-      "X-CMake-Find-Args": [ "CONFIG" ]
+      "X-CMake-Find-Args": ["CONFIG"]
     }
   },
-  "Default-Components": [ ":ignition-rndf0" ],
+  "Default-Components": [":ignition-rndf0"],
   "Components": {
     "ignition-rndf0": {
       "Type": "dylib",
       "Location": "@prefix@/lib/libignition_rndf.so",
-      "Includes": [ "@prefix@/include" ],
-      "Requires": [ "ignition-math4:ignition-math4" ]
+      "Includes": ["@prefix@/include/ignition-rndf0"],
+      "Requires": ["ignition-math4:ignition-math4"]
     }
   }
 }

--- a/tools/workspace/ignition_rndf/package.BUILD.bazel
+++ b/tools/workspace/ignition_rndf/package.BUILD.bazel
@@ -176,6 +176,7 @@ install(
     workspace = CMAKE_PACKAGE,
     targets = [":libignition_rndf.so"],
     hdrs = public_headers,
+    hdr_dest = "include/" + CMAKE_PACKAGE,
     hdr_strip_prefix = ["include"],
     docs = [
         "COPYING",

--- a/tools/workspace/lcm/package-create-cps.py
+++ b/tools/workspace/lcm/package-create-cps.py
@@ -21,11 +21,11 @@ content = """
   "Components": {
     "lcm-coretypes": {
       "Type": "interface",
-      "Includes": ["@prefix@/include"]
+      "Includes": ["@prefix@/include/lcm"]
     },
     "lcm": {
       "Type": "dylib",
-      "Includes": ["@prefix@/include"],
+      "Includes": ["@prefix@/include/lcm"],
       "Location": "@prefix@/lib/liblcm.so",
       "Requires": [":lcm-coretypes"]
     },

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -265,13 +265,16 @@ drake_java_binary(
     ],
 )
 
+CMAKE_PACKAGE = "lcm"
+
 cmake_config(
-    package = "lcm",
+    package = CMAKE_PACKAGE,
     script = "@drake//tools/workspace/lcm:package-create-cps.py",
     version_file = "lcm/lcm_version.h",
 )
 
-install_cmake_config(package = "lcm")  # Creates rule :install_cmake_config.
+# Creates rule :install_cmake_config.
+install_cmake_config(package = CMAKE_PACKAGE)
 
 install_files(
     name = "install_extra_cmake",
@@ -305,6 +308,7 @@ install(
     ],
     py_strip_prefix = ["lcm-python"],
     hdrs = LCM_PUBLIC_HEADERS,
+    hdr_dest = "include/" + CMAKE_PACKAGE,
     docs = [
         "AUTHORS",
         "COPYING",

--- a/tools/workspace/optitrack_driver/BUILD.bazel
+++ b/tools/workspace/optitrack_driver/BUILD.bazel
@@ -45,7 +45,7 @@ install(
     java_strip_prefix = ["**/"],
     py_dest = "lib/python2.7/site-packages/optitrack",
     py_strip_prefix = ["**/"],
-    hdr_dest = "include/lcmtypes",
+    hdr_dest = "include",
     guess_hdrs = "PACKAGE",
     docs = OPTITRACK_LICENSE_DOCS,
     doc_strip_prefix = ["**/"],

--- a/tools/workspace/optitrack_driver/package.cps
+++ b/tools/workspace/optitrack_driver/package.cps
@@ -9,20 +9,20 @@
       "X-CMake-Find-Args": ["CONFIG"]
     }
   },
-  "Default-Components": [":lcmtypes_optitrack-cpp"],
+  "Default-Components": [":optitrack-lcmtypes-cpp"],
   "Components": {
-    "lcmtypes_optitrack-cpp": {
+    "optitrack-client": {
+      "Type": "exe",
+      "Location": "@prefix@/bin/optitrack_client"
+    },
+    "optitrack-lcmtypes-cpp": {
       "Type": "interface",
       "Includes": ["@prefix@/include/lcmtypes"]
     },
-    "lcmtypes_optitrack-java": {
+    "optitrack-lcmtypes-java": {
       "Type": "jar",
       "Location": "@prefix@/share/java/lcmtypes_optitrack.jar",
       "Requires": ["lcm:lcm-java"]
-    },
-    "optitrack_client": {
-      "Type": "exe",
-      "Location": "@prefix@/bin/optitrack_client"
     }
   }
 }

--- a/tools/workspace/spdlog/package-create-cps.py
+++ b/tools/workspace/spdlog/package-create-cps.py
@@ -18,16 +18,19 @@ content = """
     "fmt": {
       "Version": "%(fmt_VERSION)s",
       "Hints": ["@prefix@/lib/cmake/fmt"],
-      "X-CMake-Find-Args": [ "CONFIG" ]
+      "X-CMake-Find-Args": ["CONFIG"]
     }
   },
-  "Default-Components": [ ":spdlog" ],
+  "Default-Components": [":spdlog"],
   "Components": {
     "spdlog": {
       "Type": "interface",
-      "Includes": [ "@prefix@/include" ],
-      "Definitions": ["SPDLOG_FMT_EXTERNAL", "HAVE_SPDLOG"],
-      "Requires": [ "fmt:fmt" ]
+      "Includes": ["@prefix@/include/spdlog"],
+      "Definitions": [
+        "HAVE_SPDLOG",
+        "SPDLOG_FMT_EXTERNAL"
+      ],
+      "Requires": ["fmt:fmt"]
     }
   }
 }

--- a/tools/workspace/spdlog/package.BUILD.bazel
+++ b/tools/workspace/spdlog/package.BUILD.bazel
@@ -33,20 +33,23 @@ cc_library(
     deps = ["@fmt"],
 )
 
+CMAKE_PACKAGE = "spdlog"
+
 cmake_config(
-    package = "spdlog",
+    package = CMAKE_PACKAGE,
     script = "@drake//tools/workspace/spdlog:package-create-cps.py",
     version_file = "CMakeLists.txt",
     deps = ["@fmt//:cps"],
 )
 
-install_cmake_config(package = "spdlog")  # Creates rule :install_cmake_config.
+# Creates rule :install_cmake_config.
+install_cmake_config(package = CMAKE_PACKAGE)
 
 install(
     name = "install",
     targets = [":spdlog"],
-    hdr_dest = "include/spdlog",
-    hdr_strip_prefix = ["include/spdlog"],
+    hdr_dest = "include/" + CMAKE_PACKAGE,
+    hdr_strip_prefix = ["include"],
     guess_hdrs = "PACKAGE",
     docs = ["LICENSE"],
     deps = [":install_cmake_config"],

--- a/tools/workspace/stx/package.BUILD.bazel
+++ b/tools/workspace/stx/package.BUILD.bazel
@@ -27,7 +27,7 @@ install_cmake_config(
 install(
     name = "install",
     targets = [":stx"],
-    hdr_dest = "include/stx",
+    hdr_dest = "include/" + CMAKE_PACKAGE,
     hdr_strip_prefix = ["include"],
     guess_hdrs = "PACKAGE",
     docs = ["@drake//tools/workspace/stx:LICENSE"],


### PR DESCRIPTION
This cleans up some inconsistencies and minor breakages in the naming of CMake targets and installed locations of headers and CMake files. It should be mostly a no-op to end users of the installed packages, assuming that they are using `find_package` correctly and everywhere that they should be. The one exception is the optitrack lcmtypes, that were inconsistent with the drake and robotlocomotion lcmtypes. Users of those packages would need to change the targets that they use from `optitrack::lcmtypes_optitrack-{cpp|java}` to `optitrack::optitrack-lcmtypes-{cpp|java}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7919)
<!-- Reviewable:end -->
