### PR TITLE
World sim builder add model with transformation

### DIFF
--- a/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/manipulation/util/test/sim_diagram_builder_test.cc
@@ -49,7 +49,8 @@ std::unique_ptr<RigidBodyTree<double>> build_tree(
   for (int i = 0; i < num_wsg; ++i) {
     // Adds a wsg gripper
     int id = tree_builder->AddModelInstanceToFrame(
-        "wsg", tree_builder->tree().findFrame("iiwa_frame_ee",
+        "wsg",
+        tree_builder->tree().findFrame("iiwa_frame_ee",
                                        iiwa->at(i).instance_id),
         drake::multibody::joints::kFixed);
     wsg->push_back(tree_builder->get_model_info_for_instance(id));
@@ -93,8 +94,8 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
   for (const auto& info : iiwa_info) {
     auto single_arm = std::make_unique<RigidBodyTree<double>>();
     parsers::urdf::AddModelInstanceFromUrdfFile(
-        info.absolute_model_path, multibody::joints::kFixed,
-        info.world_offset, single_arm.get());
+        info.absolute_model_path, multibody::joints::kFixed, info.world_offset,
+        single_arm.get());
 
     auto controller = builder.template AddController<
         systems::controllers::InverseDynamicsController<double>>(
@@ -193,6 +194,64 @@ GTEST_TEST(SimDiagramBuilderTest, TestAddVisualizerWithoutPlant) {
   SimDiagramBuilder<double> builder;
   drake::lcm::DrakeLcm lcm;
   EXPECT_DEATH(builder.AddVisualizer(&lcm), ".*");
+}
+
+// Tests that if we have two IIWA arms in the diagram, and we add a schunk
+// gripper to one of the arm, then the other arm should not have the gripper.
+GTEST_TEST(SimDiagramBuilderTest, TestAddingOneSchunkToTwoArms) {
+  auto tree_builder = std::make_unique<WorldSimTreeBuilder<double>>();
+
+  // Adds models to the simulation builder. Instances of these models can be
+  // subsequently added to the world.
+  tree_builder->StoreDrakeModel(
+      "iiwa",
+      "drake/manipulation/models/iiwa_description/urdf/"
+      "iiwa14_polytope_collision.urdf");
+  tree_builder->StoreDrakeModel(
+      "wsg",
+      "drake/manipulation/models/wsg_50_description/sdf/schunk_wsg_50.sdf");
+
+  std::vector<ModelInstanceInfo<double>> iiwa;
+  std::vector<ModelInstanceInfo<double>> wsg;
+
+  const int num_iiwa = 2;
+  const int num_wsg = 1;
+  DRAKE_ASSERT(num_iiwa >= num_wsg);
+
+  for (int i = 0; i < num_iiwa; ++i) {
+    // Adds an iiwa arm
+    int id =
+        tree_builder->AddFixedModelInstance("iiwa", Vector3<double>(i, 0, 0));
+    iiwa.push_back(tree_builder->get_model_info_for_instance(id));
+  }
+
+  const Eigen::Isometry3d transform_schunk_to_iiwa_link_ee =
+      Eigen::Translation3d(Eigen::Vector3d(0.09, 0, 0)) *
+      Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d::UnitZ()) *
+      Eigen::AngleAxisd(22.0 / 180 * M_PI, Eigen::Vector3d::UnitY()) *
+      Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitX());
+  for (int i = 0; i < num_wsg; ++i) {
+    // Adds a wsg gripper
+    // The transformation from schunk to iiwa ee link has roll-pitch-yaw angle
+    // [180, 22, 90], with translation[0.09, 0, 0].
+    int id = tree_builder->AddModelInstanceToFrame(
+        "wsg", "iiwa_link_ee", "frame_schunk_to_iiwa_link_ee",
+        transform_schunk_to_iiwa_link_ee, drake::multibody::joints::kFixed,
+        iiwa.at(i).instance_id);
+    wsg.push_back(tree_builder->get_model_info_for_instance(id));
+  }
+
+  for (int i = 0; i < num_wsg; ++i) {
+    auto schunk_frame = tree_builder->tree().findFrame(
+        "frame_schunk_to_iiwa_link_ee", iiwa.at(i).instance_id);
+    EXPECT_TRUE(CompareMatrices(schunk_frame->get_transform_to_body().matrix(),
+              transform_schunk_to_iiwa_link_ee.matrix()));
+  }
+  for (int i = num_wsg; i < num_iiwa; ++i) {
+    EXPECT_THROW(tree_builder->tree().findFrame("frame_schunk_to_iiwa_link_ee",
+                                                iiwa.at(i).instance_id),
+                 std::logic_error);
+  }
 }
 
 }  // namespace

--- a/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/manipulation/util/test/sim_diagram_builder_test.cc
@@ -235,9 +235,9 @@ GTEST_TEST(SimDiagramBuilderTest, TestAddingOneSchunkToTwoArms) {
     // The transformation from schunk to iiwa ee link has roll-pitch-yaw angle
     // [180, 22, 90], with translation[0.09, 0, 0].
     int id = tree_builder->AddModelInstanceToFrame(
-        "wsg", "iiwa_link_ee", "frame_schunk_to_iiwa_link_ee",
-        transform_schunk_to_iiwa_link_ee, drake::multibody::joints::kFixed,
-        iiwa.at(i).instance_id);
+        "wsg", "iiwa_link_ee", iiwa.at(i).instance_id,
+        "frame_schunk_to_iiwa_link_ee", transform_schunk_to_iiwa_link_ee,
+        drake::multibody::joints::kFixed);
     wsg.push_back(tree_builder->get_model_info_for_instance(id));
   }
 
@@ -245,7 +245,7 @@ GTEST_TEST(SimDiagramBuilderTest, TestAddingOneSchunkToTwoArms) {
     auto schunk_frame = tree_builder->tree().findFrame(
         "frame_schunk_to_iiwa_link_ee", iiwa.at(i).instance_id);
     EXPECT_TRUE(CompareMatrices(schunk_frame->get_transform_to_body().matrix(),
-              transform_schunk_to_iiwa_link_ee.matrix()));
+                                transform_schunk_to_iiwa_link_ee.matrix()));
   }
   for (int i = num_wsg; i < num_iiwa; ++i) {
     EXPECT_THROW(tree_builder->tree().findFrame("frame_schunk_to_iiwa_link_ee",

--- a/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/manipulation/util/test/sim_diagram_builder_test.cc
@@ -236,8 +236,8 @@ GTEST_TEST(SimDiagramBuilderTest, TestAddingOneSchunkToTwoArms) {
     // The transformation from schunk to iiwa ee link has roll-pitch-yaw angle
     // [180, 22, 90], with translation[0.09, 0, 0].
     int id = tree_builder->AddModelInstanceToFrame(
-        "wsg", "iiwa_link_ee", iiwa.at(i).instance_id,
-        "frame_schunk_to_iiwa_link_ee", X_ES, drake::multibody::joints::kFixed);
+        "wsg", "iiwa_link_ee", iiwa.at(i).instance_id, "iiwa_link_ee_S", X_ES,
+        drake::multibody::joints::kFixed);
     wsg.push_back(tree_builder->get_model_info_for_instance(id));
   }
 

--- a/manipulation/util/world_sim_tree_builder.cc
+++ b/manipulation/util/world_sim_tree_builder.cc
@@ -77,8 +77,19 @@ int WorldSimTreeBuilder<T>::AddFloatingModelInstance(const string& model_name,
 
 template <typename T>
 int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
-    const string& model_name,
-    std::shared_ptr<RigidBodyFrame<T>> weld_to_frame,
+    const string& model_name, const string& weld_to_body_name,
+    const string& frame_name, const Eigen::Isometry3d& transform_frame_to_body,
+    const drake::multibody::joints::FloatingBaseType floating_base_type) {
+  // Create a new frame.
+  auto  weld_to_frame = std::make_shared<RigidBodyFrame<T>>(
+      frame_name, rigid_body_tree_->get_mutable_body(rigid_body_tree_->FindBodyIndex(weld_to_body_name)), transform_frame_to_body);
+  rigid_body_tree_->addFrame(weld_to_frame);
+  return AddModelInstanceToFrame(model_name, weld_to_frame, floating_base_type);
+}
+
+template <typename T>
+int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
+    const string& model_name, std::shared_ptr<RigidBodyFrame<T>> weld_to_frame,
     const drake::multibody::joints::FloatingBaseType floating_base_type) {
   DRAKE_DEMAND(!built_);
 

--- a/manipulation/util/world_sim_tree_builder.cc
+++ b/manipulation/util/world_sim_tree_builder.cc
@@ -77,14 +77,14 @@ int WorldSimTreeBuilder<T>::AddFloatingModelInstance(const string& model_name,
 template <typename T>
 int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
     const string& model_name, const string& weld_to_body_name,
+    const int weld_to_body_model_instance_id,
     const string& frame_name, const Eigen::Isometry3d& transform_frame_to_body,
-    const drake::multibody::joints::FloatingBaseType floating_base_type,
-    int model_instance_id) {
+    const drake::multibody::joints::FloatingBaseType floating_base_type) {
   // Create a new frame.
   auto weld_to_frame = std::make_shared<RigidBodyFrame<T>>(
       frame_name,
       rigid_body_tree_->get_mutable_body(rigid_body_tree_->FindBodyIndex(
-          weld_to_body_name, model_instance_id)),
+          weld_to_body_name, weld_to_body_model_instance_id)),
       transform_frame_to_body);
   rigid_body_tree_->addFrame(weld_to_frame);
   return AddModelInstanceToFrame(model_name, weld_to_frame, floating_base_type);

--- a/manipulation/util/world_sim_tree_builder.cc
+++ b/manipulation/util/world_sim_tree_builder.cc
@@ -42,8 +42,8 @@ WorldSimTreeBuilder<T>::WorldSimTreeBuilder() {
   //     large.
   contact_model_parameters_.v_stiction_tolerance = 0.01;  // m/s
   contact_model_parameters_.characteristic_radius = 1.0;  // m^2
-  default_contact_material_.set_youngs_modulus(20000);  // Pa
-  default_contact_material_.set_dissipation(2);  // s/m
+  default_contact_material_.set_youngs_modulus(20000);    // Pa
+  default_contact_material_.set_dissipation(2);           // s/m
   default_contact_material_.set_friction(0.9, 0.5);
 }
 
@@ -71,18 +71,21 @@ int WorldSimTreeBuilder<T>::AddFloatingModelInstance(const string& model_name,
   auto weld_to_frame = allocate_shared<RigidBodyFrame<T>>(
       aligned_allocator<RigidBodyFrame<T>>(), "world", nullptr, xyz, rpy);
 
-  return AddModelInstanceToFrame(model_name, weld_to_frame,
-                                 kQuaternion);
+  return AddModelInstanceToFrame(model_name, weld_to_frame, kQuaternion);
 }
 
 template <typename T>
 int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
     const string& model_name, const string& weld_to_body_name,
     const string& frame_name, const Eigen::Isometry3d& transform_frame_to_body,
-    const drake::multibody::joints::FloatingBaseType floating_base_type) {
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    int model_instance_id) {
   // Create a new frame.
-  auto  weld_to_frame = std::make_shared<RigidBodyFrame<T>>(
-      frame_name, rigid_body_tree_->get_mutable_body(rigid_body_tree_->FindBodyIndex(weld_to_body_name)), transform_frame_to_body);
+  auto weld_to_frame = std::make_shared<RigidBodyFrame<T>>(
+      frame_name,
+      rigid_body_tree_->get_mutable_body(rigid_body_tree_->FindBodyIndex(
+          weld_to_body_name, model_instance_id)),
+      transform_frame_to_body);
   rigid_body_tree_->addFrame(weld_to_frame);
   return AddModelInstanceToFrame(model_name, weld_to_frame, floating_base_type);
 }
@@ -105,13 +108,13 @@ int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
   DRAKE_DEMAND(extension == ".urdf" || extension == ".sdf");
   if (extension == ".urdf") {
     table = drake::parsers::urdf::AddModelInstanceFromUrdfFile(
-        model_map_[model_name], floating_base_type,
-        weld_to_frame, rigid_body_tree_.get());
+        model_map_[model_name], floating_base_type, weld_to_frame,
+        rigid_body_tree_.get());
 
   } else if (extension == ".sdf") {
     table = drake::parsers::sdf::AddModelInstancesFromSdfFile(
-        model_map_[model_name], floating_base_type,
-        weld_to_frame, rigid_body_tree_.get());
+        model_map_[model_name], floating_base_type, weld_to_frame,
+        rigid_body_tree_.get());
   }
   const int model_instance_id = table.begin()->second;
 
@@ -131,17 +134,15 @@ void WorldSimTreeBuilder<T>::AddGround() {
 
 template <typename T>
 void WorldSimTreeBuilder<T>::StoreModel(
-    const std::string& model_name,
-    const std::string& absolute_model_path) {
+    const std::string& model_name, const std::string& absolute_model_path) {
   DRAKE_DEMAND(model_map_.find(model_name) == model_map_.end());
   model_map_.insert(
       std::pair<std::string, std::string>(model_name, absolute_model_path));
 }
 
 template <typename T>
-void WorldSimTreeBuilder<T>::StoreDrakeModel(
-    const std::string& model_name,
-    const std::string& model_path) {
+void WorldSimTreeBuilder<T>::StoreDrakeModel(const std::string& model_name,
+                                             const std::string& model_path) {
   StoreModel(model_name, FindResourceOrThrow(model_path));
 }
 

--- a/manipulation/util/world_sim_tree_builder.cc
+++ b/manipulation/util/world_sim_tree_builder.cc
@@ -78,14 +78,13 @@ template <typename T>
 int WorldSimTreeBuilder<T>::AddModelInstanceToFrame(
     const string& model_name, const string& weld_to_body_name,
     const int weld_to_body_model_instance_id,
-    const string& frame_name, const Eigen::Isometry3d& transform_frame_to_body,
+    const string& frame_name, const Eigen::Isometry3d& X_BF,
     const drake::multibody::joints::FloatingBaseType floating_base_type) {
   // Create a new frame.
   auto weld_to_frame = std::make_shared<RigidBodyFrame<T>>(
       frame_name,
       rigid_body_tree_->get_mutable_body(rigid_body_tree_->FindBodyIndex(
-          weld_to_body_name, weld_to_body_model_instance_id)),
-      transform_frame_to_body);
+          weld_to_body_name, weld_to_body_model_instance_id)), X_BF);
   rigid_body_tree_->addFrame(weld_to_frame);
   return AddModelInstanceToFrame(model_name, weld_to_frame, floating_base_type);
 }

--- a/manipulation/util/world_sim_tree_builder.h
+++ b/manipulation/util/world_sim_tree_builder.h
@@ -69,22 +69,31 @@ class WorldSimTreeBuilder {
           drake::multibody::joints::kFixed);
 
   /// Adds a model instance specified by its model name, @p model_name, to the
-  /// `RigidBodyTree` being built. The model instance is connected to
-  /// a new frame constructed within this function. This new frame will be
-  /// welded to a body of name @p weld_to_body_name, with a transformation to
-  /// this body as @p transform frame_to_body. The new frame is named @p
-  /// frame_name. The model instance is connected to the body using a joint of
-  /// type @p floating_base_type. The model name must have been previously
+  /// `RigidBodyTree` being built. The model instance is welded to
+  /// a new frame `F` constructed within this function. This new frame `F` is
+  /// fixed on a body of name @p weld_to_body_name, with a transformation to
+  /// this body as @p X_BF, where `B` is the body frame. The new frame is named
+  /// @p frame_name. The model instance is connected to the body using a joint
+  /// of type @p floating_base_type. The model name must have been previously
   /// loaded via a call to StoreModel().
   /// The function will search for the body with name @p weld_to_body_name, on
   /// the model with ID @p weld_to_body_model_instance_id.
+  /// @param model_name The model with this name will be added to the tree.
+  /// @param weld_to_body_name The added model will be welded to a body with
+  /// this name.
+  /// @param weld_to_body_model_instance_id The added model will be welded to
+  /// a body with this model instance ID.
+  /// @param frame_name The name of the newly added frame.
+  /// @param X_BF The pose of the newly added frame `F` in the added body
+  /// frame `B`.
+  /// @param floating_base_type The type of the joint to weld the added model
+  /// to the frame `F` on the body `B`.
   ///
   /// @return model_instance_id of the object that is added.
   int AddModelInstanceToFrame(
       const std::string& model_name, const std::string& weld_to_body_name,
-      int weld_to_body_model_instance_id,
-      const std::string& frame_name,
-      const Eigen::Isometry3d& transform_frame_to_body,
+      int weld_to_body_model_instance_id, const std::string& frame_name,
+      const Eigen::Isometry3d& X_BF,
       const drake::multibody::joints::FloatingBaseType floating_base_type);
 
   /// Adds a flat terrain to the simulation.

--- a/manipulation/util/world_sim_tree_builder.h
+++ b/manipulation/util/world_sim_tree_builder.h
@@ -69,7 +69,7 @@ class WorldSimTreeBuilder {
           drake::multibody::joints::kFixed);
 
   /// Adds a model instance specified by its model name, @p model_name, to the
-  /// `RigidBodyTree` being built. The model instance is connected to the
+  /// `RigidBodyTree` being built. The model instance is connected to
   /// a new frame constructed within this function. This new frame will be
   /// welded to a body of name @p weld_to_body_name, with a transformation to
   /// this body as @p transform frame_to_body. The new frame is named @p
@@ -77,15 +77,15 @@ class WorldSimTreeBuilder {
   /// type @p floating_base_type. The model name must have been previously
   /// loaded via a call to StoreModel().
   /// The function will search for the body with name @p weld_to_body_name, on
-  /// the model with @p model_instance_id.
+  /// the model with ID @p weld_to_body_model_instance_id.
   ///
   /// @return model_instance_id of the object that is added.
   int AddModelInstanceToFrame(
       const std::string& model_name, const std::string& weld_to_body_name,
+      int weld_to_body_model_instance_id,
       const std::string& frame_name,
       const Eigen::Isometry3d& transform_frame_to_body,
-      const drake::multibody::joints::FloatingBaseType floating_base_type,
-      int model_instance_id);
+      const drake::multibody::joints::FloatingBaseType floating_base_type);
 
   /// Adds a flat terrain to the simulation.
   void AddGround();

--- a/manipulation/util/world_sim_tree_builder.h
+++ b/manipulation/util/world_sim_tree_builder.h
@@ -67,6 +67,22 @@ class WorldSimTreeBuilder {
       const drake::multibody::joints::FloatingBaseType floating_base_type =
           drake::multibody::joints::kFixed);
 
+  /// Adds a model instance specified by its model name, @p model_name, to the
+  /// `RigidBodyTree` being built. The model instance is connected to the 
+  /// a new frame constructed within this function. This new frame will be
+  /// welded to a body of name @p weld_to_body_name, with a transformation to 
+  /// this body as @p transform frame_to_body. The new frame is named @p
+  /// frame_name. The model instance is connected to the body using a joint of
+  /// type @p floating_base_type. The model name must have been previously 
+  /// loaded via a call to StoreModel().
+  /// 
+  /// @return model_instance_id of the object that is added.
+  int AddModelInstanceToFrame(
+      const std::string& model_name,const std::string& weld_to_body_name,
+      const std::string& frame_name,
+      const Eigen::Isometry3d& transform_frame_to_body,
+      const drake::multibody::joints::FloatingBaseType floating_base_type);
+
   /// Adds a flat terrain to the simulation.
   void AddGround();
 

--- a/manipulation/util/world_sim_tree_builder.h
+++ b/manipulation/util/world_sim_tree_builder.h
@@ -12,7 +12,8 @@ namespace drake {
 namespace manipulation {
 namespace util {
 
-template<typename T> struct ModelInstanceInfo {
+template <typename T>
+struct ModelInstanceInfo {
   std::string absolute_model_path;
   int instance_id;
   std::shared_ptr<RigidBodyFrame<T>> world_offset;
@@ -68,20 +69,23 @@ class WorldSimTreeBuilder {
           drake::multibody::joints::kFixed);
 
   /// Adds a model instance specified by its model name, @p model_name, to the
-  /// `RigidBodyTree` being built. The model instance is connected to the 
+  /// `RigidBodyTree` being built. The model instance is connected to the
   /// a new frame constructed within this function. This new frame will be
-  /// welded to a body of name @p weld_to_body_name, with a transformation to 
+  /// welded to a body of name @p weld_to_body_name, with a transformation to
   /// this body as @p transform frame_to_body. The new frame is named @p
   /// frame_name. The model instance is connected to the body using a joint of
-  /// type @p floating_base_type. The model name must have been previously 
+  /// type @p floating_base_type. The model name must have been previously
   /// loaded via a call to StoreModel().
-  /// 
+  /// The function will search for the body with name @p weld_to_body_name, on
+  /// the model with @p model_instance_id.
+  ///
   /// @return model_instance_id of the object that is added.
   int AddModelInstanceToFrame(
-      const std::string& model_name,const std::string& weld_to_body_name,
+      const std::string& model_name, const std::string& weld_to_body_name,
       const std::string& frame_name,
       const Eigen::Isometry3d& transform_frame_to_body,
-      const drake::multibody::joints::FloatingBaseType floating_base_type);
+      const drake::multibody::joints::FloatingBaseType floating_base_type,
+      int model_instance_id);
 
   /// Adds a flat terrain to the simulation.
   void AddGround();
@@ -139,7 +143,6 @@ class WorldSimTreeBuilder {
   systems::CompliantMaterial default_contact_material() const {
     return default_contact_material_;
   }
-
 
  private:
   std::unique_ptr<RigidBodyTree<T>> rigid_body_tree_{


### PR DESCRIPTION
This is used when I simulate the cup flipping example, that the mounting transform for our Schunk gripper is different from the iiwa_ee_frame defined in the URDF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7928)
<!-- Reviewable:end -->
