### PR TITLE
Change SNOPT to use in-tree build file

### DIFF
--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -12,6 +12,11 @@ cc_library(
     ],
     linkopts = ["-lm"],
     # Link statically so that Fortran MAIN__ resolution works on gcc.
+    # It's also important to link statically because Drake's binary releases
+    # are allowed to redistribute SNOPT only if SNOPT is not distributed as a
+    # stand-alone package -- that users cannot use the SNOPT code separately,
+    # but rather only through Drake's interfaces.  A shared library of SNOPT
+    # would not meet those criteria.
     linkstatic = 1,
     # By convention, SNOPT header #includes are not fully qualified.
     strip_include_prefix = "csrc",

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -1,28 +1,12 @@
 # -*- python -*-
 
-# Copied from RobotLocomotion/snopt/BUILD.
-
-package(default_visibility = ["//visibility:public"])
-
-alias(
-    name = "snopt_c",
-    actual = "//csrc:snopt_c",
-)
-
-alias(
-    name = "snopt_cpp",
-    actual = "//cppsrc:snopt_cpp",
-)
-
-# Copied from RobotLocomotion/snopt/csrc/BUILD.
-
 cc_library(
     name = "snopt_c",
     srcs = glob(
-        ["*.c"],
-        exclude = ["dummy.c"],
+        ["csrc/*.c"],
+        exclude = ["csrc/dummy.c"],
     ),
-    hdrs = glob(["*.hh"]),
+    hdrs = glob(["csrc/*.hh"]),
     copts = [
         "-w",
     ],
@@ -30,18 +14,21 @@ cc_library(
     # Link statically so that Fortran MAIN__ resolution works on gcc.
     linkstatic = 1,
     # By convention, SNOPT header #includes are not fully qualified.
-    strip_include_prefix = "/csrc",
+    strip_include_prefix = "csrc",
     visibility = ["//visibility:public"],
-    deps = ["//libf2c"],
+    deps = [":libf2c"],
     # Always link the entirety of SNOPT.
     alwayslink = 1,
 )
 
-# Copied from RobotLocomotion/snopt/libf2c/BUILD.
+# Different revisions of SNOPT have this folder in different places.
+# TODO(jwnimmer-tri) Use a different value here, depending on what's needed for
+# a specific version of snopt.
+_LIBF2C = "libf2c/"
 
 cc_binary(
     name = "arithchk",
-    srcs = ["arithchk.c"],
+    srcs = [_LIBF2C + "arithchk.c"],
     copts = [
         "-w",
         "-DNO_FPINIT",
@@ -52,59 +39,59 @@ cc_binary(
 genrule(
     name = "arith",
     srcs = [],
-    outs = ["arith.h"],
+    outs = [_LIBF2C + "arith.h"],
     cmd = "$(location :arithchk) > $(@)",
     tools = [":arithchk"],
 )
 
 genrule(
     name = "f2c",
-    srcs = ["f2c.h0"],
-    outs = ["f2c.h"],
+    srcs = [_LIBF2C + "f2c.h0"],
+    outs = [_LIBF2C + "f2c.h"],
     cmd = "cp $< $(@)",
 )
 
 genrule(
     name = "sysdep1",
-    srcs = ["sysdep1.h0"],
-    outs = ["sysdep1.h"],
+    srcs = [_LIBF2C + "sysdep1.h0"],
+    outs = [_LIBF2C + "sysdep1.h"],
     cmd = "cp $< $(@)",
 )
 
 genrule(
     name = "signal1",
-    srcs = ["signal1.h0"],
-    outs = ["signal1.h"],
+    srcs = [_LIBF2C + "signal1.h0"],
+    outs = [_LIBF2C + "signal1.h"],
     cmd = "cp $< $(@)",
 )
 
 genrule(
     name = "math",
-    srcs = ["math.h0"],
-    outs = ["f2math.h"],
+    srcs = [_LIBF2C + "math.h0"],
+    outs = [_LIBF2C + "f2math.h"],
     cmd = "cp $< $(@)",
 )
 
 filegroup(
     name = "generated_headers",
     srcs = [
-        "arith.h",
-        "f2c.h",
-        "f2math.h",
-        "signal1.h",
-        "sysdep1.h",
+        _LIBF2C + "arith.h",
+        _LIBF2C + "f2c.h",
+        _LIBF2C + "f2math.h",
+        _LIBF2C + "signal1.h",
+        _LIBF2C + "sysdep1.h",
     ],
 )
 
 filegroup(
     name = "generated_public_headers",
-    srcs = ["f2c.h"],
+    srcs = [_LIBF2C + "f2c.h"],
 )
 
 # Replace main.c, which causes tests that link to SNOPT to erroneously pass.
 genrule(
     name = "main_",
-    outs = ["main_.c"],
+    outs = [_LIBF2C + "main_.c"],
     cmd = "echo \"int xargc; char **xargv;\" > $(@)",
 )
 
@@ -112,17 +99,17 @@ cc_library(
     name = "libf2c",
     srcs = [":main_"] + glob(
         [
-            "*.c",
-            "*.h",
+            _LIBF2C + "*.c",
+            _LIBF2C + "*.h",
         ],
         # Exclude optional sources and generator tools from the glob.
         exclude = [
-            "main.c",
-            "pow_qq.c",
-            "qbitbits.c",
-            "qbitshft.c",
-            "*64*.c",
-            "arithchk.c",
+            _LIBF2C + "main.c",
+            _LIBF2C + "pow_qq.c",
+            _LIBF2C + "qbitbits.c",
+            _LIBF2C + "qbitshft.c",
+            _LIBF2C + "*64*.c",
+            _LIBF2C + "arithchk.c",
         ],
     ),
     hdrs = [":generated_headers"],
@@ -133,6 +120,6 @@ cc_library(
     # Link statically so that Fortran MAIN__ resolution works on gcc.
     linkstatic = 1,
     # By convention, SNOPT header #includes are not fully qualified.
-    strip_include_prefix = "/libf2c",
+    strip_include_prefix = _LIBF2C,
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -1,0 +1,138 @@
+# -*- python -*-
+
+# Copied from RobotLocomotion/snopt/BUILD.
+
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "snopt_c",
+    actual = "//csrc:snopt_c",
+)
+
+alias(
+    name = "snopt_cpp",
+    actual = "//cppsrc:snopt_cpp",
+)
+
+# Copied from RobotLocomotion/snopt/csrc/BUILD.
+
+cc_library(
+    name = "snopt_c",
+    srcs = glob(
+        ["*.c"],
+        exclude = ["dummy.c"],
+    ),
+    hdrs = glob(["*.hh"]),
+    copts = [
+        "-w",
+    ],
+    linkopts = ["-lm"],
+    # Link statically so that Fortran MAIN__ resolution works on gcc.
+    linkstatic = 1,
+    # By convention, SNOPT header #includes are not fully qualified.
+    strip_include_prefix = "/csrc",
+    visibility = ["//visibility:public"],
+    deps = ["//libf2c"],
+    # Always link the entirety of SNOPT.
+    alwayslink = 1,
+)
+
+# Copied from RobotLocomotion/snopt/libf2c/BUILD.
+
+cc_binary(
+    name = "arithchk",
+    srcs = ["arithchk.c"],
+    copts = [
+        "-w",
+        "-DNO_FPINIT",
+    ],
+    linkopts = ["-lm"],
+)
+
+genrule(
+    name = "arith",
+    srcs = [],
+    outs = ["arith.h"],
+    cmd = "$(location :arithchk) > $(@)",
+    tools = [":arithchk"],
+)
+
+genrule(
+    name = "f2c",
+    srcs = ["f2c.h0"],
+    outs = ["f2c.h"],
+    cmd = "cp $< $(@)",
+)
+
+genrule(
+    name = "sysdep1",
+    srcs = ["sysdep1.h0"],
+    outs = ["sysdep1.h"],
+    cmd = "cp $< $(@)",
+)
+
+genrule(
+    name = "signal1",
+    srcs = ["signal1.h0"],
+    outs = ["signal1.h"],
+    cmd = "cp $< $(@)",
+)
+
+genrule(
+    name = "math",
+    srcs = ["math.h0"],
+    outs = ["f2math.h"],
+    cmd = "cp $< $(@)",
+)
+
+filegroup(
+    name = "generated_headers",
+    srcs = [
+        "arith.h",
+        "f2c.h",
+        "f2math.h",
+        "signal1.h",
+        "sysdep1.h",
+    ],
+)
+
+filegroup(
+    name = "generated_public_headers",
+    srcs = ["f2c.h"],
+)
+
+# Replace main.c, which causes tests that link to SNOPT to erroneously pass.
+genrule(
+    name = "main_",
+    outs = ["main_.c"],
+    cmd = "echo \"int xargc; char **xargv;\" > $(@)",
+)
+
+cc_library(
+    name = "libf2c",
+    srcs = [":main_"] + glob(
+        [
+            "*.c",
+            "*.h",
+        ],
+        # Exclude optional sources and generator tools from the glob.
+        exclude = [
+            "main.c",
+            "pow_qq.c",
+            "qbitbits.c",
+            "qbitshft.c",
+            "*64*.c",
+            "arithchk.c",
+        ],
+    ),
+    hdrs = [":generated_headers"],
+    copts = [
+        "-DSkip_f2c_Undefs",
+        "-w",
+    ],
+    # Link statically so that Fortran MAIN__ resolution works on gcc.
+    linkstatic = 1,
+    # By convention, SNOPT header #includes are not fully qualified.
+    strip_include_prefix = "/libf2c",
+    visibility = ["//visibility:public"],
+)

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -1,14 +1,60 @@
 # -*- python -*-
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@drake//tools/workspace:pypi.bzl", "pypi_archive")
+def _run_git(repo_ctx, *args):
+    # Runs the git operation named in *args.  We use "--git-dir" to prevent git
+    # from looking in parent directories to find the repository.  We only ever
+    # want it to look where we've told it.
+    result = repo_ctx.execute(["git", "--git-dir=.git"] + list(args))
+    if result.return_code:
+        fail('Repository rule @{} error {} during git operation: {}'.format(
+            repo_ctx.name,
+            result.return_code,
+            repr(result.stdout + result.stderr),
+        ))
 
-def snopt_repository(name):
-    # We directly declare a git_repository because the snopt source code
-    # requires authentication, and our github_archive does not (yet, easily)
-    # support that.
-    git_repository(
-        name = name,
-        remote = "git@github.com:RobotLocomotion/snopt.git",
-        commit = "0f475624131c9ca4d5624e74c3f8273ccc926f9b",
+def _git_clone(
+        repo_ctx,
+        remote = None,
+        commit = None):
+    # Clones a git repository named by the given remote and reset it to the
+    # given commit.
+    #
+    # The clone is placed into "." (which is the workspace being populated by
+    # whatever repository_rule calls this function).  This function assumes
+    # that "." is empty, which that's already been established by Bazel before
+    # it invokes the repository_rule.
+    #
+    # On any error, terminates via fail() and does not return.
+    #
+    # We would prefer to load `@bazel_tools//tools/build_defs/repo:git.bzl` and
+    # use its `git_repository` rule, but there is no flavor of that rule that
+    # allows us to pass in the repo_ctx from our own repository_rule.
+    (commit and remote) or fail("Missing commit or remote")
+    _run_git(repo_ctx, "clone", remote, ".")
+    _run_git(repo_ctx, "reset", "--hard", commit)
+
+def _impl(repo_ctx):
+    # Download the snopt sources from an access-controlled git repository.
+    # We'll use git operations directly (and not the github_archive helper)
+    # because github_archive does not (yet, easily) support authentication.
+    #
+    # TODO(#7240) Allow additional configuration to allow Drake developers and
+    # users to choose archives other than git to provide the SNOPT source code.
+    # This is why the current implementation here uses a repository_rule,
+    # instead of simply calling Bazel's built-in new_git_repository.  Once we
+    # need that additional configuration, we'll no longer be able to re-use
+    # Bazel's git helpers.
+    _git_clone(
+        repo_ctx,
+        remote = repo_ctx.attr.remote,
+        commit = repo_ctx.attr.commit,
     )
+
+snopt_repository = repository_rule(
+    attrs = {
+        "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
+        "commit": attr.string(default = "0f475624131c9ca4d5624e74c3f8273ccc926f9b"),  # noqa
+    },
+    local = False,
+    implementation = _impl,
+)

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -49,11 +49,27 @@ def _impl(repo_ctx):
         remote = repo_ctx.attr.remote,
         commit = repo_ctx.attr.commit,
     )
+    if repo_ctx.attr.use_drake_build_rules:
+        # Disable any files that came from the upstream snopt source archive.
+        result = repo_ctx.execute(["bash", "-c", """
+            set -ex
+            find . -name BUILD -print0 -o -name BUILD.bazel -print0 |
+                xargs -t -n1 -0 -I{} \
+                mv {} {}.upstream-ignored
+        """])
+        if result.return_code:
+            fail("Error {} during {}".format(
+                result.return_code, result.stdout + result.stderr))
+        # Link Drake's BUILD file into the snopt workspace.
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/snopt:package.BUILD.bazel"),
+            "BUILD")
 
 snopt_repository = repository_rule(
     attrs = {
         "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
         "commit": attr.string(default = "0f475624131c9ca4d5624e74c3f8273ccc926f9b"),  # noqa
+        "use_drake_build_rules": attr.bool(default = True),
     },
     local = False,
     implementation = _impl,


### PR DESCRIPTION
There are actually four commits here:
1. Switch snopt to custom git rules, instead of Bazel's git wrapper

    In the future we want to support non-git sources for SNOPT (and in particular, sources with no BUILD files); by having our own direct implementation of the repository rule, it is easier to mix and match the pieces we need.  (Plus, Bazel's implementation is actually pretty lame.)

2. Import BUILD rules from RobotLocomotion/snopt

    Copied from https://github.com/RobotLocomotion/snopt as of commit `0f475624131c9ca4d5624e74c3f8273ccc926f9b`.

    Co-authored-by: David German <...>
    Co-authored-by: Jamie Snape <...>

   This is a straight copy (though cat'ing them into one file) from our existing `BUILD` rules from the RL/snopt repository.

3. Rework the copied BUILD files into one; use it by default.

    This means that the RL/snopt repository's `BUILD` files are now dead code as far as Drake is concerned.

 4. Add some more comments.

The overall effect should be an entirely non-functional change, but prepares us to:
- Use SNOPT from sources other than git (#7240), such as when a user has their own source archive already but doesn't have RobotLocomotion credentials.  (The source archive doesn't have a `BUILD` file of course, so Drake needs to have a `package.BUILD.bazel` in-tree.)
- Inter-operate with other releases of SNOPT (#245, #1647, #4611) by amending our `package.BUILD.bazel` file to detect and configure itself based on the provided snopt.

The full branch with future work is at https://github.com/jwnimmer-tri/drake/commits/snopt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7932)
<!-- Reviewable:end -->
