### PR TITLE
multibody_py: Ensure `__init__` is installed.

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -65,7 +65,9 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":shapes_py",
 ]
 
-PY_LIBRARIES = []
+PY_LIBRARIES = [
+    ":module_py",
+]
 
 # Symbol roll-up (for user ease).
 drake_py_library(


### PR DESCRIPTION
Missed this during review, sorry about that!

\cc @RussTedrake @gizatt

Will follow-up with a `pydrake:all_install_test`  following suite with Francois's install tests in #7774. (Will just do a quick version of it, though.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7936)
<!-- Reviewable:end -->
