### PR TITLE
 pydrake: Add all_install_test. 

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -165,6 +165,17 @@ drake_py_test(
     deps = [":all_py"],
 )
 
+drake_py_test(
+    name = "all_install_test",
+    size = "medium",
+    # Increase the timeout so that debug builds are successful.
+    timeout = "long",
+    data = ["//:install"],
+    deps = [
+        "//tools/install:install_test_helper",
+    ],
+)
+
 # Test ODR (One Definition Rule).
 drake_pybind_library(
     name = "odr_test_module_py",

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -215,11 +215,8 @@ drake_py_test(
     size = "medium",
     # Increase the timeout so that debug builds are successful.
     timeout = "long",
-    srcs = ["test/common_install_test.py"],
     data = ["//:install"],
-    main = "test/common_install_test.py",
     deps = [
-        ":pydrake",
         "//tools/install:install_test_helper",
     ],
 )

--- a/bindings/pydrake/test/all_install_test.py
+++ b/bindings/pydrake/test/all_install_test.py
@@ -1,0 +1,31 @@
+"""
+Ensures we can import `pydrake.all` from install.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+import install_test_helper
+
+
+class TestAllInstall(unittest.TestCase):
+    def test_install(self):
+        # Install into a temporary directory.
+        tmp_folder = "tmp"
+        result = install_test_helper.install(tmp_folder, ['lib'])
+        self.assertEqual(None, result)
+        # Override PYTHONPATH to only use the installed `pydrake` module.
+        env_python_path = "PYTHONPATH"
+        tool_env = dict(os.environ)
+        tool_env[env_python_path] = os.path.abspath(
+            os.path.join(tmp_folder, "lib", "python2.7", "site-packages")
+        )
+        # Ensure we can import all user-visible modules.
+        script = "import pydrake.all"
+        subprocess.check_call([sys.executable, "-c", script], env=tool_env)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pydrake/test/common_install_test.py
+++ b/bindings/pydrake/test/common_install_test.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import shutil
 import subprocess
 import unittest
 import sys
+
 import install_test_helper
 
 
@@ -15,21 +14,21 @@ class TestCommonInstall(unittest.TestCase):
         tmp_folder = "tmp"
         result = install_test_helper.install(tmp_folder, ['lib', 'share'])
         self.assertEqual(None, result)
-        # Set the correct PYTHONPATH to use the correct pydrake module.
+        # Override PYTHONPATH to only use the installed `pydrake` module.
         env_python_path = "PYTHONPATH"
         tool_env = dict(os.environ)
         tool_env[env_python_path] = os.path.abspath(
             os.path.join(tmp_folder, "lib", "python2.7", "site-packages")
         )
         data_folder = os.path.join(tmp_folder, "share", "drake")
-        # Call python2 to force using python brew install. Calling python
-        # system would result in a crash since pydrake was built against
-        # brew python. On Linux this will still work and force using
+        # Call the same Python binary. On Mac, calling the system `python`
+        # would result in a crash since pydrake was built against brew python.
+        # On Linux, this will still work and force using
         # python2 which should be a link to the actual executable.
         # Calling `pydrake.getDrakePath()` twice verifies that there
         # is no memory allocation issue in the C code.
         output_path = subprocess.check_output(
-            ["python2",
+            [sys.executable,
              "-c", "import pydrake; print(pydrake.getDrakePath());\
              import pydrake; print(pydrake.getDrakePath())"
              ],

--- a/tools/install/install_test_helper.py
+++ b/tools/install/install_test_helper.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import shutil
 import subprocess
@@ -16,6 +14,8 @@ def install(installation_folder="tmp", installed_subfolders=[],
     in installation directory, a string containing an error message is
     returned.
     """
+    assert "TEST_TMPDIR" in os.environ, (
+        "This may only be run from within `bazel test`")
     os.mkdir(installation_folder)
     # Install target and its dependencies in scratch space.
     subprocess.check_call(
@@ -33,7 +33,7 @@ def install(installation_folder="tmp", installed_subfolders=[],
     # Remove Bazel build artifacts, and ensure that we only have install
     # artifacts.
     content_test_folder = os.listdir(os.getcwd())
-    content_test_folder.remove('tmp')
+    content_test_folder.remove(installation_folder)
     for element in content_test_folder:
         if os.path.isdir(element):
             shutil.rmtree(element)


### PR DESCRIPTION
This also fixes a small bug in `install_test_helpers` (where it assumed the `installation_folder` was `tmp` in one piece of logic) and allows running install tests via `bazel run`.

I manually tested this before the merge of #7936 and confirmed that it failed (and thus should have caught that error).

This is another specific installation test incantation, probably to be superseded by the completion of testing in #7774?

\cc @fbudin69500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7938)
<!-- Reviewable:end -->
