### PR TITLE
Revert "Use yaml-cpp@0.6 from robotlocomotion/director Homebrew tap"

### DIFF
--- a/setup/mac/install_prereqs_binary_distribution.sh
+++ b/setup/mac/install_prereqs_binary_distribution.sh
@@ -50,7 +50,7 @@ scipy
 tinyxml
 tinyxml2
 vtk@8.0
-yaml-cpp@0.6
+yaml-cpp
 EOF
 )
 

--- a/tools/workspace/yaml_cpp/repository.bzl
+++ b/tools/workspace/yaml_cpp/repository.bzl
@@ -5,19 +5,15 @@ load(
     "pkg_config_repository",
 )
 
-# TODO(jamiesnape): Remove extra_deps on macOS since latest yaml-cpp does not
-# require boost.
 def yaml_cpp_repository(
         name,
         modname = "yaml-cpp",
         atleast_version = "0.5.2",
         extra_deps = ["@boost//:boost_headers"],
-        pkg_config_paths = ["/usr/local/opt/yaml-cpp@0.6/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
         modname = modname,
         atleast_version = atleast_version,
         extra_deps = extra_deps,
-        pkg_config_paths = pkg_config_paths,
         **kwargs)


### PR DESCRIPTION
Reverts RobotLocomotion/drake#7925. See https://github.com/Homebrew/homebrew-core/commit/a58dea295ba28c175b49b28ca906ed3a273597e7 and https://github.com/Homebrew/homebrew-core/commit/7cc51fc09f591a98db846f93459952af64d657b2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7939)
<!-- Reviewable:end -->
