### PR TITLE
rendering_py: Add PoseVector. Enable by-value casting for geometric arguments.

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -28,9 +28,9 @@ from .forwarddiff import *
 from .symbolic import *
 
 # Submodules.
-# - Do not inclue `examples`.
+# - `examples` does not offer public Drake symbols.
 from .multibody.all import *
 from .solvers.all import *
 from .systems.all import *
-# - Do not include `third_party`.
-# - Do not include `util`.
+# - `third_party` does not offer public Drake symbols.
+from .util.all import *

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -107,6 +107,21 @@ drake_pybind_library(
     ],
 )
 
+drake_pybind_library(
+    name = "rendering_py",
+    cc_deps = [
+        "//bindings/pydrake/util:eigen_geometry_pybind",
+    ],
+    cc_so_name = "rendering",
+    cc_srcs = ["rendering_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [
+        ":framework_py",
+        ":module_py",
+        "//bindings/pydrake/util:eigen_geometry_py",
+    ],
+)
+
 drake_py_library(
     name = "drawing_py",
     srcs = ["drawing.py"],
@@ -118,6 +133,7 @@ PY_LIBRARIES_WITH_INSTALL = [
     ":analysis_py",
     ":framework_py",
     ":primitives_py",
+    ":rendering_py",
     ":sensors_py",
 ]
 
@@ -220,6 +236,14 @@ drake_py_test(
     size = "small",
     deps = [
         ":sensors_py",
+    ],
+)
+
+drake_py_test(
+    name = "rendering_test",
+    size = "small",
+    deps = [
+        ":rendering_py",
     ],
 )
 

--- a/bindings/pydrake/systems/all.py
+++ b/bindings/pydrake/systems/all.py
@@ -1,6 +1,7 @@
 from .analysis import *
 from .framework import *
 from .primitives import *
+from .rendering import *
 from .sensors import *
 
 try:

--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -45,6 +45,7 @@ using systems::DiscreteUpdateEvent;
 using systems::DiscreteValues;
 
 using pysystems::AddValueInstantiation;
+using pysystems::DefClone;
 
 class PySystem : public py::wrapper<System<T>> {
  public:
@@ -434,7 +435,9 @@ PYBIND11_MODULE(framework, m) {
     .def("size", &VectorBase<T>::size);
 
   // TODO(eric.cousineau): Make a helper function for the Eigen::Ref<> patterns.
-  py::class_<BasicVector<T>, VectorBase<T>>(m, "BasicVector")
+  py::class_<BasicVector<T>, VectorBase<T>> basic_vector(m, "BasicVector");
+  DefClone(&basic_vector);
+  basic_vector
     // N.B. Place `init<VectorX<T>>` `init<int>` so that we do not implicitly
     // convert scalar-size `np.array` objects to `int` (since this is normally
     // permitted).
@@ -467,12 +470,8 @@ PYBIND11_MODULE(framework, m) {
   };
 
   py::class_<AbstractValue> abstract_value(m, "AbstractValue");
+  DefClone(&abstract_value);
   abstract_value
-    .def("Clone", &AbstractValue::Clone)
-    .def("__copy__", &AbstractValue::Clone)
-    .def("__deepcopy__", [](const AbstractValue* self, py::dict /* memo */) {
-      return self->Clone();
-    })
     // Only bind the exception variant, `SetFromOrThrow`, for use in Python.
     // Otherwise, a user could encounter undefind behavior via `SetFrom`.
     .def("SetFrom", &AbstractValue::SetFromOrThrow)

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -1,0 +1,38 @@
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/util/eigen_geometry_pybind.h"
+#include "drake/systems/rendering/pose_vector.h"
+
+namespace drake {
+namespace pydrake {
+
+PYBIND11_MODULE(rendering, m) {
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems;
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems::rendering;
+
+  m.doc() = "Bindings for the rendering portion of the Systems framework.";
+
+  py::module::import("pydrake.systems.framework");
+
+  using T = double;
+
+  py::class_<PoseVector<T>, BasicVector<T>> pose_vector(m, "PoseVector");
+  pose_vector
+    .def(py::init())
+    .def("get_isometry", &PoseVector<T>::get_isometry)
+    .def("get_translation", &PoseVector<T>::get_translation)
+    .def("set_translation", &PoseVector<T>::set_translation)
+    .def("get_rotation", &PoseVector<T>::get_rotation)
+    .def("set_rotation", &PoseVector<T>::set_rotation);
+
+  pose_vector.attr("kSize") = int{PoseVector<T>::kSize};
+
+  // TODO(eric.cousineau): Add more systems as needed.
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/systems/systems_pybind.h
+++ b/bindings/pydrake/systems/systems_pybind.h
@@ -15,6 +15,19 @@ namespace drake {
 namespace pydrake {
 namespace pysystems {
 
+/// Binds `Clone` and Pythonic `__copy__` and `__deepcopy__` for a class.
+template <typename PyClass>
+void DefClone(PyClass* ppy_class) {
+  using Class = typename PyClass::type;
+  PyClass& py_class = *ppy_class;
+  py_class
+    .def("Clone", &Class::Clone)
+    .def("__copy__", &Class::Clone)
+    .def("__deepcopy__", [](const Class* self, py::dict /* memo */) {
+      return self->Clone();
+    });
+}
+
 /// Defines an instantiation of `pydrake.systems.framework.Value[...]`. This is
 /// only meant to bind `Value<T>` (or specializations thereof).
 /// @prereq `T` must have already been exposed to `pybind11`.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 

--- a/bindings/pydrake/systems/test/lifetime_test.py
+++ b/bindings/pydrake/systems/test/lifetime_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 """
 @file

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from pydrake.systems.rendering import (
+    PoseVector,
+)
+
+import copy
+import unittest
+import numpy as np
+
+from pydrake.systems.framework import (
+    BasicVector,
+)
+from pydrake.util.eigen_geometry import (
+    Isometry3,
+    Quaternion,
+)
+
+
+def normalized(x):
+    return x / np.linalg.norm(x)
+
+
+class TestRendering(unittest.TestCase):
+    def test_pose_vector(self):
+        value = PoseVector()
+        self.assertTrue(isinstance(value, BasicVector))
+        self.assertTrue(isinstance(copy.copy(value), PoseVector))
+        self.assertTrue(isinstance(value.Clone(), PoseVector))
+        self.assertEquals(value.size(), PoseVector.kSize)
+        # - Accessors.
+        self.assertTrue(isinstance(
+            value.get_isometry(), Isometry3))
+        self.assertTrue(isinstance(
+            value.get_rotation(), Quaternion))
+        self.assertTrue(isinstance(
+            value.get_translation(), np.ndarray))
+        # - - Value.
+        self.assertTrue(np.allclose(
+            value.get_isometry().matrix(), np.eye(4, 4)))
+        # - Mutators.
+        p = [0, 1, 2]
+        q = Quaternion(wxyz=normalized([0.1, 0.3, 0.7, 0.9]))
+        X_expected = Isometry3(q, p)
+        value.set_translation(p)
+        value.set_rotation(q)
+        self.assertTrue(np.allclose(
+            value.get_isometry().matrix(), X_expected.matrix()))
+        # - Ensure ordering is ((px, py, pz), (qw, qx, qy, qz))
+        vector_expected = np.hstack((p, q.wxyz()))
+        vector_actual = value.get_value()
+        self.assertTrue(np.allclose(vector_actual, vector_expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -62,6 +62,15 @@ class TestValue(unittest.TestCase):
                 # Ensure we can construct from size.
                 value_data = BasicVector(n)
                 self.assertEquals(value_data.size(), n)
+                # Ensure we can clone.
+                value_copies = [
+                    value_data.Clone(),
+                    copy.copy(value_data),
+                    copy.deepcopy(value_data),
+                ]
+                for value_copy in value_copies:
+                    self.assertTrue(value_copy is not value_data)
+                    self.assertEquals(value_data.size(), n)
 
     def test_abstract_value_copyable(self):
         expected = "Hello world"

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function
 

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -82,6 +82,8 @@ class TestAll(unittest.TestCase):
             "Simulator",
             # - primitives
             "Adder",
+            # - rendering
+            "PoseVector",
             # - sensors
             "Image",
             # util

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -33,7 +33,10 @@ class TestAll(unittest.TestCase):
         simulator = pydrake.systems.analysis.Simulator(
             pydrake.multibody.rigid_body_plant.RigidBodyPlant(tree))
 
-    def test_symbols(self):
+    def test_symbols_subset(self):
+        """Tests a subset of symbols provided by `drake.all`. At least one
+        symbol per submodule should be included.
+        """
         import pydrake.all
 
         # Subset of symbols.
@@ -50,21 +53,46 @@ class TestAll(unittest.TestCase):
             "Variable",
             "Expression",
             # multibody
+            # - parsers
             "PackageMap",
+            # - rigid_body_plant
             "RigidBodyPlant",
+            # - rigid_body_tree
             "RigidBodyTree",
+            # - shapes
+            # TODO(eric.cousineau): Avoid collision with `collision.Element`.
+            # Import modules, since these names are generic.
+            "Element",
             # solvers
+            # - gurobi
+            "GurobiSolver",
+            # - ik
+            "IKResults",
+            # - ipopt
+            "IpoptSolver",
+            # - mathematicalprogram
             "MathematicalProgram",
-            "LinearConstraint",
+            # - mosek
+            "MosekSolver",
             # systems
+            # - framework
             "BasicVector",
             "LeafSystem",
+            # - analysis
             "Simulator",
+            # - primitives
+            "Adder",
+            # - sensors
+            "Image",
+            # util
+            "Isometry3",
+            "Quaternion",
         )
         # Ensure each symbol is exposed as globals from the above import
         # statement.
         for expected_symbol in expected_symbols:
-            self.assertTrue(expected_symbol in pydrake.all.__dict__)
+            self.assertTrue(
+                expected_symbol in pydrake.all.__dict__, expected_symbol)
 
 
 if __name__ == '__main__':

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 load(
     "//tools/skylark:pybind.bzl",
     "drake_pybind_cc_googletest",
+    "drake_pybind_library",
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
@@ -62,6 +63,21 @@ drake_cc_library(
     name = "eigen_pybind",
     hdrs = ["eigen_pybind.h"],
     deps = ["//bindings/pydrake:pydrake_pybind"],
+)
+
+drake_cc_library(
+    name = "eigen_geometry_pybind",
+    hdrs = ["eigen_geometry_pybind.h"],
+    deps = ["//bindings/pydrake:pydrake_pybind"],
+)
+
+drake_pybind_library(
+    name = "eigen_geometry_py",
+    cc_deps = [":eigen_geometry_pybind"],
+    cc_so_name = "eigen_geometry",
+    cc_srcs = ["eigen_geometry_py.cc"],
+    package_info = PACKAGE_INFO,
+    py_deps = [":module_py"],
 )
 
 # ODR does not matter, because the singleton will be stored in Python.
@@ -118,7 +134,9 @@ drake_cc_library(
     hdrs = ["drake_optional_pybind.h"],
 )
 
-PY_LIBRARIES_WITH_INSTALL = []
+PY_LIBRARIES_WITH_INSTALL = [
+    ":eigen_geometry_py",
+]
 
 PY_LIBRARIES = [
     ":cpp_const_py",
@@ -128,16 +146,23 @@ PY_LIBRARIES = [
     ":module_shim_py",
 ]
 
-# Package target.
+# Symbol roll-up (for user ease).
+drake_py_library(
+    name = "all_py",
+    srcs = ["all.py"],
+    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+)
+
+# Package roll-up (for Bazel dependencies).
 drake_py_library(
     name = "util",
     imports = PACKAGE_INFO.py_imports,
-    deps = PY_LIBRARIES_WITH_INSTALL + PY_LIBRARIES,
+    deps = [":all_py"],
 )
 
 install(
     name = "install",
-    targets = PY_LIBRARIES,
+    targets = PY_LIBRARIES + [":all_py"],
     py_dest = PACKAGE_INFO.py_dest,
     deps = get_drake_py_installs(PY_LIBRARIES_WITH_INSTALL),
 )
@@ -210,6 +235,24 @@ drake_pybind_cc_googletest(
         "//common:nice_type_name",
     ],
     py_deps = [":cpp_template_py"],
+)
+
+drake_pybind_library(
+    name = "eigen_geometry_test_util_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = [":eigen_geometry_pybind"],
+    cc_so_name = "test/eigen_geometry_test_util",
+    cc_srcs = ["test/eigen_geometry_test_util_py.cc"],
+    package_info = PACKAGE_INFO,
+)
+
+drake_py_test(
+    name = "eigen_geometry_test",
+    deps = [
+        ":eigen_geometry_py",
+        ":eigen_geometry_test_util_py",
+    ],
 )
 
 add_lint_tests()

--- a/bindings/pydrake/util/all.py
+++ b/bindings/pydrake/util/all.py
@@ -1,0 +1,5 @@
+# - `cpp_const` does not offer public Drake symbols.
+# - `cpp_param` does not offer public Drake symbols.
+# - `cpp_template` does not offer public Drake symbols.
+from .eigen_geometry import *
+# - `module_shim` does not offer public Drake symbols.

--- a/bindings/pydrake/util/eigen_geometry_py.cc
+++ b/bindings/pydrake/util/eigen_geometry_py.cc
@@ -1,0 +1,216 @@
+#include <cmath>
+
+#include <pybind11/pybind11.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/util/eigen_geometry_pybind.h"
+#include "drake/common/drake_assertion_error.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+using std::fabs;
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+// TODO(eric.cousineau): There is validation from Python to C++, but no
+// validation in the other direction. Consider intercepting this.
+
+// TODO(eric.cousineau): Add operator overloads.
+
+// TODO(eric.cousineau): Disable tolerance checks for the symbolic case.
+
+// N.B. This could potentially interfere with another library's bindings of
+// Eigen types. If/when this happens, this should be addressed for both these
+// and AutoDiff types.
+
+// N.B. Use a loose tolerance, so that we don't have to be super strict with
+// C++.
+const double kCheckTolerance = 1e-5;
+
+template <typename T>
+void CheckRotMat(const Matrix3<T>& R) {
+  // See `ExpectRotMat`.
+  const T identity_error =
+      (R * R.transpose() - Eigen::Matrix<T, 3, 3>::Identity())
+      .array().abs().maxCoeff();
+  DRAKE_THROW_UNLESS(
+      identity_error < kCheckTolerance &&
+      "Rotation matrix is not orthonormal");
+  const T det_error = fabs(R.determinant() - 1);
+  DRAKE_THROW_UNLESS(
+    det_error < kCheckTolerance &&
+    "Rotation matrix violates right-hand rule");
+}
+
+template <typename T>
+void CheckIsometry(const Isometry3<T>& X) {
+  CheckRotMat<T>(X.linear());
+  Eigen::Matrix<T, 1, 4> bottom_expected;
+  bottom_expected << 0, 0, 0, 1;
+  const T bottom_error =
+      (X.matrix().bottomRows(1) - bottom_expected).array().abs().maxCoeff();
+  DRAKE_THROW_UNLESS(
+      bottom_error < kCheckTolerance &&
+      "Homogeneous matrix is improperly scaled.");
+}
+
+template <typename T>
+void CheckQuaternion(const Eigen::Quaternion<T>& q) {
+  const T norm_error = fabs(q.coeffs().norm() - 1);
+  DRAKE_THROW_UNLESS(
+      norm_error < kCheckTolerance &&
+      "Quaternion is not normalized");
+}
+
+}  // namespace
+
+PYBIND11_MODULE(eigen_geometry, m) {
+  m.doc() = "Bindings for Eigen geometric types.";
+
+  using T = double;
+
+  // Do not return references to matrices (e.g. `Eigen::Ref<>`) so that we have
+  // tighter control over validation.
+
+  // Isometry3d.
+  // @note `linear` implies rotation, and `affine` implies translation.
+  {
+    using Class = Isometry3<T>;
+    py::class_<Class> py_class(m, "Isometry3");
+    py_class
+      .def(py::init([]() {
+        return Class::Identity();
+      }))
+      .def_static("Identity", []() {
+        return Class::Identity();
+      })
+      .def(py::init([](const Matrix4<T>& matrix) {
+        Class out(matrix);
+        CheckIsometry(out);
+        return out;
+      }), py::arg("matrix"))
+      .def(py::init([](
+          const Matrix3<T>& rotation,
+          const Vector3<T>& translation) {
+        CheckRotMat(rotation);
+        Class out = Class::Identity();
+        out.linear() = rotation;
+        out.translation() = translation;
+        return out;
+      }), py::arg("rotation"), py::arg("translation"))
+      .def(py::init([](
+          const Eigen::Quaternion<T>& q,
+          const Vector3<T>& translation) {
+        CheckQuaternion(q);
+        Class out = Class::Identity();
+        out.linear() = q.toRotationMatrix();
+        out.translation() = translation;
+        return out;
+      }), py::arg("quaternion"), py::arg("translation"))
+      .def("matrix", [](const Class* self) -> Matrix4<T> {
+        return self->matrix();
+      })
+      .def("set_matrix", [](Class* self, const Matrix4<T>& matrix) {
+        Class update(matrix);
+        CheckIsometry(update);
+        *self = update;
+      })
+      .def("translation", [](const Class* self) -> Vector3<T> {
+        return self->translation();
+      })
+      .def("set_translation", [](Class* self, const Vector3<T>& translation) {
+        self->translation() = translation;
+      })
+      .def("rotation", [](const Class* self) -> Matrix3<T> {
+        return self->linear();
+      })
+      .def("set_rotation", [](Class* self, const Matrix3<T>& rotation) {
+        CheckRotMat(rotation);
+        self->linear() = rotation;
+      })
+      .def("quaternion", [](const Class* self) {
+        return Eigen::Quaternion<T>(self->linear());
+      })
+      .def("set_quaternion", [](Class* self, const Eigen::Quaternion<T>& q) {
+        CheckQuaternion(q);
+        self->linear() = q.toRotationMatrix();
+      })
+      .def("__str__", [](py::object self) {
+        return py::str(self.attr("matrix")());
+      });
+  }
+
+  // Quaternion.
+  // Since the Eigen API for Quaternion is insufficiently explicit, we will
+  // deviate some from the API to maintain clarity.
+  // TODO(eric.cousineau): Should this not be restricted to a unit quaternion?
+  {
+    using Class = Eigen::Quaternion<T>;
+    py::class_<Class> py_class(m, "Quaternion");
+    py_class.attr("__doc__") =
+        "Provides a unit quaternion binding of Eigen::Quaternion<>.";
+    py::object py_class_obj = py_class;
+    py_class
+      .def(py::init([]() {
+        return Class::Identity();
+      }))
+      .def_static("Identity", []() {
+        return Class::Identity();
+      })
+      .def(py::init([](const Vector4<T>& wxyz) {
+        Class out(wxyz(0), wxyz(1), wxyz(2), wxyz(3));
+        CheckQuaternion(out);
+        return out;
+      }), py::arg("wxyz"))
+      .def(py::init([](T w, T x, T y, T z) {
+        Class out(w, x, y, z);
+        CheckQuaternion(out);
+        return out;
+      }), py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
+      .def(py::init([](const Matrix3<T>& rotation) {
+        Class out(rotation);
+        CheckQuaternion(out);
+        return out;
+      }), py::arg("rotation"))
+      .def("w", [](const Class* self) { return self->w(); })
+      .def("x", [](const Class* self) { return self->x(); })
+      .def("y", [](const Class* self) { return self->y(); })
+      .def("z", [](const Class* self) { return self->z(); })
+      .def("xyz", [](const Class* self) { return self->vec(); })
+      .def("wxyz", [](Class* self) {
+        Vector4<T> wxyz;
+        wxyz << self->w(), self->vec();
+        return wxyz;
+      })
+      .def("set_wxyz", [](Class* self, const Vector4<T>& wxyz) {
+        Class update;
+        update.w() = wxyz(0);
+        update.vec() = wxyz.tail(3);
+        CheckQuaternion(update);
+        *self = update;
+      }, py::arg("wxyz"))
+      .def("set_wxyz", [](Class* self, T w, T x, T y, T z) {
+        Class update(w, x, y, z);
+        CheckQuaternion(update);
+        *self = update;
+      }, py::arg("w"), py::arg("x"), py::arg("y"), py::arg("z"))
+      .def("rotation", [](const Class* self) {
+        return self->toRotationMatrix();
+      })
+      .def("set_rotation", [](Class* self, const Matrix3<T>& rotation) {
+        Class update(rotation);
+        CheckQuaternion(update);
+        *self = update;
+      })
+      .def("__str__", [py_class_obj](const Class* self) {
+        return py::str("{}(w={}, x={}, y={}, z={})").format(
+            py_class_obj.attr("__name__"),
+            self->w(), self->x(), self->y(), self->z());
+      });
+  }
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/util/eigen_geometry_pybind.h
+++ b/bindings/pydrake/util/eigen_geometry_pybind.h
@@ -1,0 +1,115 @@
+#pragma once
+
+/// @file
+/// Provides pybind11 `type_caster`s for Eigen geometric types.
+/// N.B. This uses some of pybind's coding conventions.
+///
+/// See http://pybind11.readthedocs.io/en/stable/advanced/cast/custom.html for
+/// more details on custom type casters.
+
+#include <string>
+#include <utility>
+
+#include <Eigen/Dense>
+#include <pybind11/eigen.h>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace pydrake {
+namespace detail {
+
+// Implements a `type_caster<>` specialization used to convert types using a
+// specific wrapping policy.
+// @tparam Wrapper
+//  Struct which must provide `Type`, `WrappedType`, `unwrap`, and `wrap`.
+// @tparam copy_only
+//  This may only pass between C++ and Python as copies, not references.
+// See `eigen_wrapper_*` structs below for more details.
+template <typename Wrapper>
+struct type_caster_wrapped {
+  using Type = typename Wrapper::Type;
+  using WrappedType = typename Wrapper::WrappedType;
+  using WrappedTypeCaster = py::detail::type_caster<WrappedType>;
+
+  // Python to C++.
+  bool load(py::handle src, bool converter) {
+    WrappedTypeCaster caster;
+    if (!caster.load(src, converter)) {
+      return false;
+    }
+    value_ = Wrapper::unwrap(caster.operator WrappedType&());
+    loaded_ = true;
+    return true;
+  }
+
+  // See `pybind11/eigen.h`, `type_caster<>` implementations.
+  // N.B. Do not use `PYBIND11_TYPE_CASTER(...)` so we can avoid casting
+  // garbage values.
+  operator Type&() {
+    DRAKE_DEMAND(loaded_);
+    return value_;
+  }
+  template <typename T> using cast_op_type =
+      py::detail::movable_cast_op_type<T>;
+  static constexpr auto name = WrappedTypeCaster::props::descriptor;
+
+  // C++ to Python.
+  template <typename TType>
+  static py::handle cast(TType&& src, py::return_value_policy policy,
+      py::handle parent) {
+    if (policy == py::return_value_policy::reference ||
+        policy == py::return_value_policy::reference_internal) {
+      // N.B. We must declare a local `static constexpr` here to prevent
+      // linking errors. This does not appear achievable with
+      // `constexpr char[]`, so we use `py::detail::descr`.
+      // See `pybind11/pybind11.h`, `cpp_function::initialize(...)` for an
+      // example.
+      static constexpr auto original_name = Wrapper::original_name;
+      throw py::cast_error(
+          std::string("Can only pass ") + original_name.text +
+          " by value.");
+    }
+    return WrappedTypeCaster::cast(
+        Wrapper::wrap(std::forward<TType>(src)), policy, parent);
+  }
+
+ private:
+  bool loaded_{false};
+  Type value_;
+};
+
+// Wrapper for Eigen::Translation<>, to be used as first parameter to
+// `type_caster_wrapped`.
+// Since there are not many special operations for a translation vector, we
+// shall return it as a nominal vector.
+template <typename T, int Dim>
+struct wrapper_eigen_translation {
+  using Type = Eigen::Translation<T, Dim>;
+  using WrappedType = Eigen::Matrix<T, Dim, 1>;
+  static constexpr auto original_name = py::detail::_("Eigen::Translation<>");
+  static Type unwrap(const WrappedType& arg_wrapped) {
+    return Type(arg_wrapped);
+  }
+  static WrappedType wrap(const Type& arg) {
+    return arg.vector();
+  }
+};
+
+// N.B. Since `Isometry3<>` and `Eigen::Quaternion<>` have more
+// complicated structures, they are registered as types in `eigen_geometry_py`.
+
+}  // namespace detail
+}  // namespace pydrake
+}  // namespace drake
+
+namespace pybind11 {
+namespace detail {
+
+template <typename T, int Dim>
+struct type_caster<Eigen::Translation<T, Dim>>
+    : public drake::pydrake::detail::type_caster_wrapped<
+        drake::pydrake::detail::wrapper_eigen_translation<T, Dim>> {};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/bindings/pydrake/util/test/eigen_geometry_test.py
+++ b/bindings/pydrake/util/test/eigen_geometry_test.py
@@ -1,0 +1,117 @@
+import pydrake.util.eigen_geometry as mut
+
+import numpy as np
+import unittest
+
+import pydrake.util.test.eigen_geometry_test_util as test_util
+
+
+def normalize(x):
+    return x / np.linalg.norm(x)
+
+
+class TestEigenGeometry(unittest.TestCase):
+    def test_quaternion(self):
+        # Simple API.
+        q_identity = mut.Quaternion()
+        self.assertTrue(np.allclose(q_identity.wxyz(), [1, 0, 0, 0]))
+        self.assertTrue(np.allclose(
+            q_identity.wxyz(), mut.Quaternion.Identity().wxyz()))
+        self.assertEquals(
+            str(q_identity), "Quaternion(w=1.0, x=0.0, y=0.0, z=0.0)")
+        # Test ordering.
+        q_wxyz = normalize([0.1, 0.3, 0.7, 0.9])
+        q = mut.Quaternion(w=q_wxyz[0], x=q_wxyz[1], y=q_wxyz[2], z=q_wxyz[3])
+        # - Accessors.
+        self.assertEquals(q.w(), q_wxyz[0])
+        self.assertEquals(q.x(), q_wxyz[1])
+        self.assertEquals(q.y(), q_wxyz[2])
+        self.assertEquals(q.z(), q_wxyz[3])
+        self.assertTrue(np.allclose(q.xyz(), q_wxyz[1:]))
+        self.assertTrue(np.allclose(q.wxyz(), q_wxyz))
+        # - Mutators.
+        q_wxyz_new = q_wxyz[::-1]
+        self.assertFalse(np.allclose(q_wxyz, q_wxyz_new))
+        q.set_wxyz(wxyz=q_wxyz_new)
+        self.assertTrue(np.allclose(q.wxyz(), q_wxyz_new))
+        q.set_wxyz(
+            w=q_wxyz_new[0], x=q_wxyz_new[1], y=q_wxyz_new[2], z=q_wxyz_new[3])
+        self.assertTrue(np.allclose(q.wxyz(), q_wxyz_new))
+        # Alternative constructors.
+        q_other = mut.Quaternion(wxyz=q_wxyz)
+        self.assertTrue(np.allclose(q_other.wxyz(), q_wxyz))
+        R = np.array([
+            [0, 0, 1],
+            [1, 0, 0],
+            [0, 1, 0]])
+        q_wxyz_expected = np.array([0.5, 0.5, 0.5, 0.5])
+        q_other = mut.Quaternion(q_wxyz_expected)
+        self.assertTrue(np.allclose(q_other.rotation(), R))
+        R_I = np.eye(3, 3)
+        q_other.set_rotation(R_I)
+        self.assertTrue(np.allclose(q_other.wxyz(), q_identity.wxyz()))
+        # Bad values.
+        q = mut.Quaternion.Identity()
+        # - wxyz
+        q_wxyz_bad = [1., 2, 3, 4]
+        with self.assertRaises(RuntimeError):
+            q.set_wxyz(q_wxyz_bad)
+        self.assertTrue(np.allclose(q.wxyz(), [1, 0, 0, 0]))
+        # - Rotation.
+        R_bad = np.copy(R)
+        R_bad[0, 0] = 10
+        with self.assertRaises(RuntimeError):
+            q_other.set_rotation(R_bad)
+        self.assertTrue(np.allclose(q_other.rotation(), R_I))
+
+        # Test `type_caster`s.
+        value = test_util.create_quaternion()
+        self.assertTrue(isinstance(value, mut.Quaternion))
+        test_util.check_quaternion(value)
+
+    def test_transform(self):
+        transform = mut.Isometry3()
+        X = np.eye(4, 4)
+        self.assertTrue(np.allclose(transform.matrix(), X))
+        self.assertEquals(str(transform), str(X))
+        R = np.array([
+            [0., 1, 0],
+            [-1, 0, 0],
+            [0, 0, 1]])
+        p = np.array([1., 2, 3])
+        X = np.vstack((np.hstack((R, p.reshape((-1, 1)))), [0, 0, 0, 1]))
+        transform = mut.Isometry3(rotation=R, translation=p)
+        self.assertTrue(np.allclose(transform.matrix(), X))
+        self.assertTrue(np.allclose(transform.translation(), p))
+        transform.set_translation(-p)
+        self.assertTrue(np.allclose(transform.translation(), -p))
+        self.assertTrue(np.allclose(transform.rotation(), R))
+        transform.set_rotation(R.T)
+        self.assertTrue(np.allclose(transform.rotation(), R.T))
+        # - Check transactions for bad values.
+        transform = mut.Isometry3(rotation=R, translation=p)
+        R_bad = np.copy(R)
+        R_bad[0, 0] = 10.
+        with self.assertRaises(RuntimeError):
+            transform.set_rotation(R_bad)
+        self.assertTrue(np.allclose(R, transform.rotation()))
+        X_bad = np.copy(X)
+        X_bad[:3, :3] = R_bad
+        with self.assertRaises(RuntimeError):
+            transform.set_matrix(X_bad)
+        self.assertTrue(np.allclose(X, transform.matrix()))
+
+        # Test `type_caster`s.
+        value = test_util.create_isometry()
+        self.assertTrue(isinstance(value, mut.Isometry3))
+        test_util.check_isometry(value)
+
+    def test_translation(self):
+        # Test `type_caster`s.
+        value = test_util.create_translation()
+        self.assertEquals(value.shape, (3,))
+        test_util.check_translation(value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pydrake/util/test/eigen_geometry_test_util_py.cc
+++ b/bindings/pydrake/util/test/eigen_geometry_test_util_py.cc
@@ -1,0 +1,56 @@
+#include <Eigen/Dense>
+#include <pybind11/pybind11.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/util/eigen_geometry_pybind.h"
+#include "drake/common/drake_throw.h"
+#include "drake/common/eigen_types.h"
+
+using Eigen::Isometry3d;
+using Eigen::Quaterniond;
+using Eigen::Translation3d;
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+const double kTolerance = 1e-8;
+
+}  // namespace
+
+PYBIND11_MODULE(eigen_geometry_test_util, m) {
+  m.doc() = "Bindings for Eigen geometric types.";
+
+  using T = double;
+
+  m.def("create_isometry", []() {
+    return Isometry3<T>::Identity();
+  });
+  m.def("check_isometry", [](const Isometry3d& X) {
+    const T error =
+        (X.matrix() - Isometry3<T>::Identity().matrix())
+        .array().abs().maxCoeff();
+    DRAKE_THROW_UNLESS(error < kTolerance);
+  });
+
+  m.def("create_translation", []() {
+    return Translation3<T>(Vector3<T>::Zero());
+  });
+  m.def("check_translation", [](const Translation3<T>& p) {
+    const T error = p.vector().array().abs().maxCoeff();
+    DRAKE_THROW_UNLESS(error < kTolerance);
+  });
+
+  m.def("create_quaternion", []() {
+    return Quaternion<T>::Identity();
+  });
+  m.def("check_quaternion", [](const Quaternion<T>& q) {
+    const T error =
+        (q.coeffs() - Quaternion<T>::Identity().coeffs())
+        .array().abs().maxCoeff();
+    DRAKE_THROW_UNLESS(error < kTolerance);
+  });
+}
+
+}  // namespace pydrake
+}  // namespace drake


### PR DESCRIPTION
Provides `Pose` as a prereq for #7918.

\cc @jadecastro 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7948)
<!-- Reviewable:end -->
