### PR TITLE
Deprecate LCM System's index'd port accessor

### DIFF
--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -449,7 +449,7 @@ void AutomotiveSimulator<T>::AddPublisher(const MaliputRailcar<T>& system,
       std::to_string(vehicle_number) + "_MALIPUT_RAILCAR_STATE";
   auto publisher =  builder_->template AddSystem<LcmPublisherSystem>(
       channel, translator, lcm_.get());
-  builder_->Connect(system.state_output(), publisher->get_input_port(0));
+  builder_->Connect(system.state_output(), publisher->get_input_port());
 }
 
 template <typename T>
@@ -462,7 +462,7 @@ void AutomotiveSimulator<T>::AddPublisher(const SimpleCar<T>& system,
       std::to_string(vehicle_number) + "_SIMPLE_CAR_STATE";
   auto publisher = builder_->template AddSystem<LcmPublisherSystem>(
       channel, translator, lcm_.get());
-  builder_->Connect(system.state_output(), publisher->get_input_port(0));
+  builder_->Connect(system.state_output(), publisher->get_input_port());
 }
 
 template <typename T>
@@ -475,7 +475,7 @@ void AutomotiveSimulator<T>::AddPublisher(const TrajectoryCar<T>& system,
       std::to_string(vehicle_number) + "_SIMPLE_CAR_STATE";
   auto publisher = builder_->template AddSystem<LcmPublisherSystem>(
       channel, translator, lcm_.get());
-  builder_->Connect(system.raw_pose_output(), publisher->get_input_port(0));
+  builder_->Connect(system.raw_pose_output(), publisher->get_input_port());
 }
 
 template <typename T>
@@ -554,7 +554,7 @@ void AutomotiveSimulator<T>::Build() {
                                                    lcm_.get()));
     builder_->Connect(
         bundle_to_draw_->get_output_port(0),
-        lcm_publisher_->get_input_port(0));
+        lcm_publisher_->get_input_port());
   }
   pose_bundle_output_port_ =
       builder_->ExportOutput(aggregator_->get_output_port(0));

--- a/automotive/car_sim_lcm_common.cc
+++ b/automotive/car_sim_lcm_common.cc
@@ -213,7 +213,7 @@ std::unique_ptr<systems::Diagram<double>> CreateCarSimLcmDiagram(
   //
   MatrixX<double> matrix_gain(
       controller->get_input_port(1).size(),
-      command_subscriber->get_output_port(0).size());
+      command_subscriber->get_output_port().size());
   matrix_gain <<
       1,                 0,
       0,                 0,
@@ -223,7 +223,7 @@ std::unique_ptr<systems::Diagram<double>> CreateCarSimLcmDiagram(
       0, 1. / kWheelRadius;
   DRAKE_ASSERT(matrix_gain.rows() == controller->get_input_port(1).size());
   DRAKE_ASSERT(matrix_gain.cols() ==
-      command_subscriber->get_output_port(0).size());
+      command_subscriber->get_output_port().size());
 
   // TODO(liang.fok): Consider replacing the the MatrixGain system below with a
   // custom system that converts the user's commands to the vehicle's actuator's
@@ -247,7 +247,7 @@ std::unique_ptr<systems::Diagram<double>> CreateCarSimLcmDiagram(
                   controller->get_control_input_port());
 
   // Connects the system that converts from user commands to actuator commands.
-  builder.Connect(command_subscriber->get_output_port(0),
+  builder.Connect(command_subscriber->get_output_port(),
                   user_to_actuator_cmd_sys->get_input_port());
 
   // Connects the controller, which includes the plant being controlled.

--- a/examples/acrobot/acrobot_plant_w_lcm.cc
+++ b/examples/acrobot/acrobot_plant_w_lcm.cc
@@ -62,7 +62,7 @@ int DoMain() {
   auto command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<lcmt_acrobot_u>(channel_u, &lcm));
   auto command_receiver = builder.AddSystem<AcrobotCommandReceiver>();
-  builder.Connect(command_sub->get_output_port(0),
+  builder.Connect(command_sub->get_output_port(),
                   command_receiver->get_input_port(0));
 
   // Creates state sender and publisher.
@@ -70,7 +70,7 @@ int DoMain() {
       systems::lcm::LcmPublisherSystem::Make<lcmt_acrobot_x>(channel_x, &lcm));
   auto state_sender = builder.AddSystem<AcrobotStateSender>();
   builder.Connect(state_sender->get_output_port(0),
-                  state_pub->get_input_port(0));
+                  state_pub->get_input_port());
 
   // Connects plant to command receiver and state sender.
   builder.Connect(command_receiver->get_output_port(0),

--- a/examples/acrobot/acrobot_spong_controller_w_lcm.cc
+++ b/examples/acrobot/acrobot_spong_controller_w_lcm.cc
@@ -37,7 +37,7 @@ int DoMain() {
   auto state_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<lcmt_acrobot_x>(channel_x, &lcm));
   auto state_receiver = builder.AddSystem<AcrobotStateReceiver>();
-  builder.Connect(state_sub->get_output_port(0),
+  builder.Connect(state_sub->get_output_port(),
                   state_receiver->get_input_port(0));
 
   // Create command sender.
@@ -45,7 +45,7 @@ int DoMain() {
       systems::lcm::LcmPublisherSystem::Make<lcmt_acrobot_u>(channel_u, &lcm));
   auto command_sender = builder.AddSystem<AcrobotCommandSender>();
   builder.Connect(command_sender->get_output_port(0),
-                  command_pub->get_input_port(0));
+                  command_pub->get_input_port());
 
   auto controller = builder.AddSystem<AcrobotSpongController>();
   builder.Connect(controller->get_output_port(0),

--- a/examples/contact_model/rigid_gripper.cc
+++ b/examples/contact_model/rigid_gripper.cc
@@ -137,7 +137,7 @@ int main() {
   builder.Connect(plant->contact_results_output_port(),
                   contact_viz.get_input_port(0));
   builder.Connect(contact_viz.get_output_port(0),
-                  contact_results_publisher.get_input_port(0));
+                  contact_results_publisher.get_input_port());
 
   // Set up the model and simulator and set their starting state.
   const std::unique_ptr<systems::Diagram<double>> model = builder.Build();

--- a/examples/humanoid_controller/humanoid_controller.h
+++ b/examples/humanoid_controller/humanoid_controller.h
@@ -71,12 +71,12 @@ class HumanoidController : public systems::Diagram<double> {
             "ROBOT_COMMAND", lcm));
 
     // lcm -> rs
-    builder.Connect(robot_state_subscriber_->get_output_port(0),
+    builder.Connect(robot_state_subscriber_->get_output_port(),
                     msg_to_humanoid_status->get_input_port());
     // rs + plan -> qp_input
     builder.Connect(msg_to_humanoid_status->get_output_port(),
                     plan_eval_->get_input_port_kinematic_state());
-    builder.Connect(plan_subscriber->get_output_port(0),
+    builder.Connect(plan_subscriber->get_output_port(),
                     plan_eval_->get_input_port_manip_plan_msg());
     // rs + qp_input -> qp_output
     builder.Connect(msg_to_humanoid_status->get_output_port(),
@@ -88,7 +88,7 @@ class HumanoidController : public systems::Diagram<double> {
                     joint_con->get_input_port_qp_output());
     // atlas_command_t -> lcm
     builder.Connect(joint_con->get_output_port_atlas_command(),
-                    atlas_command_publisher->get_input_port(0));
+                    atlas_command_publisher->get_input_port());
 
     builder.BuildInto(this);
   }

--- a/examples/kinova_jaco_arm/jaco_controller.cc
+++ b/examples/kinova_jaco_arm/jaco_controller.cc
@@ -61,7 +61,7 @@ int DoMain() {
       (!FLAGS_urdf.empty() ? FLAGS_urdf : FindResourceOrThrow(kIiwaUrdf));
   auto plan_source = builder.AddSystem<RobotPlanInterpolator>(urdf);
 
-  builder.Connect(plan_sub->get_output_port(0),
+  builder.Connect(plan_sub->get_output_port(),
                   plan_source->get_plan_input_port());
 
   const int num_joints = FLAGS_num_joints;
@@ -77,7 +77,7 @@ int DoMain() {
   auto status_receiver = builder.AddSystem<JacoStatusReceiver>(
       num_joints, num_fingers);
 
-  builder.Connect(status_sub->get_output_port(0),
+  builder.Connect(status_sub->get_output_port(),
                   status_receiver->get_input_port(0));
   builder.Connect(status_receiver->get_output_port(0),
                   plan_source->get_state_input_port());
@@ -143,7 +143,7 @@ int DoMain() {
   builder.Connect(command_mux->get_output_port(0),
                   command_sender->get_input_port(0));
   builder.Connect(command_sender->get_output_port(0),
-                  command_pub->get_input_port(0));
+                  command_pub->get_input_port());
 
   auto diagram = builder.Build();
 

--- a/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/iiwa_box_simulation.cc
@@ -237,7 +237,7 @@ int DoMain() {
   builder.Connect(optitrack_encoder->get_optitrack_output_port(),
                   optitrack_sender->get_optitrack_input_port());
   builder.Connect(optitrack_sender->get_lcm_output_port(),
-                  optitrack_pub->get_input_port(0));
+                  optitrack_pub->get_input_port());
 
   // TODO(rcory): Do we need this accel source?
   auto iiwa_zero_acceleration_source =
@@ -245,7 +245,7 @@ int DoMain() {
           Eigen::VectorXd::Zero(14));
   iiwa_zero_acceleration_source->set_name("zero_acceleration");
 
-  builder.Connect(iiwa_command_sub->get_output_port(0),
+  builder.Connect(iiwa_command_sub->get_output_port(),
                   iiwa_command_receiver->get_input_port(0));
 
   builder.Connect(iiwa_command_receiver->get_output_port(0),
@@ -264,7 +264,7 @@ int DoMain() {
                   iiwa_status_sender->get_commanded_torque_input_port());
 
   builder.Connect(iiwa_status_sender->get_output_port(0),
-                  iiwa_status_pub->get_input_port(0));
+                  iiwa_status_pub->get_input_port());
 
   auto iiwa_state_pub = builder.AddSystem(
       systems::lcm::LcmPublisherSystem::Make<bot_core::robot_state_t>(
@@ -273,7 +273,7 @@ int DoMain() {
   iiwa_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   builder.Connect(model->get_output_port_iiwa_robot_state_msg(),
-                  iiwa_state_pub->get_input_port(0));
+                  iiwa_state_pub->get_input_port());
   iiwa_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   auto box_state_pub = builder.AddSystem(
@@ -283,7 +283,7 @@ int DoMain() {
   box_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   builder.Connect(model->get_output_port_box_robot_state_msg(),
-                  box_state_pub->get_input_port(0));
+                  box_state_pub->get_input_port());
   box_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
 
@@ -302,7 +302,7 @@ int DoMain() {
     builder.Connect(model->get_output_port_contact_results(),
                     contact_viz->get_input_port(0));
     builder.Connect(contact_viz->get_output_port(0),
-                    contact_results_publisher->get_input_port(0));
+                    contact_results_publisher->get_input_port());
     contact_results_publisher->set_publish_period(.01);
   }
 

--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
@@ -70,7 +70,7 @@ int DoMain(void) {
       systems::lcm::LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
           "CONTACT_RESULTS", &lcm));
   builder.Connect(plant->get_output_port_contact_results(),
-                  contact_results_publisher->get_input_port(0));
+                  contact_results_publisher->get_input_port());
   contact_results_publisher->set_publish_period(kIiwaLcmStatusPeriod);
 
   // Add visualizer.

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_planner.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_planner.cc
@@ -83,18 +83,18 @@ int DoMain(void) {
   wsg_command_pub->set_publish_period(planner_configuration.period_sec);
 
   // Connect subscribers to planner input ports.
-  builder.Connect(wsg_status_sub->get_output_port(0),
+  builder.Connect(wsg_status_sub->get_output_port(),
                   planner->get_input_port_wsg_status());
-  builder.Connect(iiwa_status_sub->get_output_port(0),
+  builder.Connect(iiwa_status_sub->get_output_port(),
                   planner->get_input_port_iiwa_status());
-  builder.Connect(optitrack_sub->get_output_port(0),
+  builder.Connect(optitrack_sub->get_output_port(),
                   planner->get_input_port_optitrack_message());
 
   // Connect publishers to planner output ports.
   builder.Connect(planner->get_output_port_iiwa_plan(),
-                  iiwa_plan_pub->get_input_port(0));
+                  iiwa_plan_pub->get_input_port());
   builder.Connect(planner->get_output_port_wsg_command(),
-                  wsg_command_pub->get_input_port(0));
+                  wsg_command_pub->get_input_port());
 
   // Build the diagram.
   auto sys = builder.Build();

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_pick_and_place_simulator.cc
@@ -81,7 +81,7 @@ int DoMain(void) {
   builder.Connect(plant->get_output_port_contact_results(),
                   contact_viz->get_input_port(0));
   builder.Connect(contact_viz->get_output_port(0),
-                  contact_results_publisher->get_input_port(0));
+                  contact_results_publisher->get_input_port());
   contact_results_publisher->set_publish_period(kIiwaLcmStatusPeriod);
 
   // Publish the mock Optitrack data over LCM.
@@ -90,7 +90,7 @@ int DoMain(void) {
           "OPTITRACK_FRAMES", &lcm));
   optitrack_pub->set_publish_period(kIiwaLcmStatusPeriod);
   builder.Connect(plant->get_output_port_optitrack_frame(),
-                  optitrack_pub->get_input_port(0));
+                  optitrack_pub->get_input_port());
 
   // Add LCM subscribers/publishers for the iiwa arms.
   const int num_iiwa{plant->num_iiwa()};
@@ -102,7 +102,7 @@ int DoMain(void) {
         systems::lcm::LcmSubscriberSystem::Make<lcmt_iiwa_command>(
             "IIWA_COMMAND" + suffix, &lcm));
     iiwa_command_sub->set_name("iiwa_command_subscriber" + suffix);
-    builder.Connect(iiwa_command_sub->get_output_port(0),
+    builder.Connect(iiwa_command_sub->get_output_port(),
                     plant->get_input_port_iiwa_command(i));
 
     auto iiwa_status_pub = builder.AddSystem(
@@ -111,7 +111,7 @@ int DoMain(void) {
     iiwa_status_pub->set_name("iiwa_status_publisher" + suffix);
     iiwa_status_pub->set_publish_period(kIiwaLcmStatusPeriod);
     builder.Connect(plant->get_output_port_iiwa_status(i),
-                    iiwa_status_pub->get_input_port(0));
+                    iiwa_status_pub->get_input_port());
   }
 
   // Add LCM subscribers/publishers for the Schunk grippers.
@@ -124,13 +124,13 @@ int DoMain(void) {
         systems::lcm::LcmPublisherSystem::Make<lcmt_schunk_wsg_status>(
             "SCHUNK_WSG_STATUS" + suffix, &lcm));
     builder.Connect(plant->get_output_port_wsg_status(i),
-                    wsg_status_pub->get_input_port(0));
+                    wsg_status_pub->get_input_port());
     wsg_status_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
     auto wsg_command_sub = builder.AddSystem(
         systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
             "SCHUNK_WSG_COMMAND" + suffix, &lcm));
-    builder.Connect(wsg_command_sub->get_output_port(0),
+    builder.Connect(wsg_command_sub->get_output_port(),
                     plant->get_input_port_wsg_command(i));
   }
 

--- a/examples/kuka_iiwa_arm/iiwa_controller.cc
+++ b/examples/kuka_iiwa_arm/iiwa_controller.cc
@@ -101,14 +101,14 @@ int DoMain() {
   command_pub->set_name("command_pub");
 
   // Connect subscribers to input ports.
-  builder.Connect(plan_sub->get_output_port(0),
+  builder.Connect(plan_sub->get_output_port(),
                   plan_interpolator->get_input_port_iiwa_plan());
-  builder.Connect(status_sub->get_output_port(0),
+  builder.Connect(status_sub->get_output_port(),
                   plan_interpolator->get_input_port_iiwa_status());
 
   // Connect publisher to output port.
   builder.Connect(plan_interpolator->get_output_port_iiwa_command(),
-                  command_pub->get_input_port(0));
+                  command_pub->get_input_port());
 
   auto diagram = builder.Build();
 

--- a/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
+++ b/examples/kuka_iiwa_arm/iiwa_wsg_simulation.cc
@@ -185,7 +185,7 @@ int DoMain() {
           Eigen::VectorXd::Zero(7));
   iiwa_zero_acceleration_source->set_name("zero_acceleration");
 
-  builder.Connect(iiwa_command_sub->get_output_port(0),
+  builder.Connect(iiwa_command_sub->get_output_port(),
                   iiwa_command_receiver->get_input_port(0));
   builder.Connect(iiwa_command_receiver->get_output_port(0),
                   model->get_input_port_iiwa_state_command());
@@ -205,7 +205,7 @@ int DoMain() {
   builder.Connect(external_torque_converter->get_output_port(0),
                   iiwa_status_sender->get_external_torque_input_port());
   builder.Connect(iiwa_status_sender->get_output_port(0),
-                  iiwa_status_pub->get_input_port(0));
+                  iiwa_status_pub->get_input_port());
 
   auto wsg_command_sub = builder.AddSystem(
       systems::lcm::LcmSubscriberSystem::Make<lcmt_schunk_wsg_command>(
@@ -227,7 +227,7 @@ int DoMain() {
       manipulation::schunk_wsg::kSchunkWsgVelocityIndex);
   wsg_status_sender->set_name("wsg_status_sender");
 
-  builder.Connect(wsg_command_sub->get_output_port(0),
+  builder.Connect(wsg_command_sub->get_output_port(),
                   wsg_controller->get_command_input_port());
   builder.Connect(wsg_controller->get_output_port(0),
                   model->get_input_port_wsg_command());
@@ -246,7 +246,7 @@ int DoMain() {
   iiwa_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   builder.Connect(model->get_output_port_iiwa_robot_state_msg(),
-                  iiwa_state_pub->get_input_port(0));
+                  iiwa_state_pub->get_input_port());
   iiwa_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   auto box_state_pub = builder.AddSystem(
@@ -256,7 +256,7 @@ int DoMain() {
   box_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   builder.Connect(model->get_output_port_object_robot_state_msg(),
-                  box_state_pub->get_input_port(0));
+                  box_state_pub->get_input_port());
   box_state_pub->set_publish_period(kIiwaLcmStatusPeriod);
 
   auto sys = builder.Build();

--- a/examples/kuka_iiwa_arm/kuka_simulation.cc
+++ b/examples/kuka_iiwa_arm/kuka_simulation.cc
@@ -124,7 +124,7 @@ int DoMain() {
   auto status_sender = base_builder->AddSystem<IiwaStatusSender>(num_joints);
   status_sender->set_name("status_sender");
 
-  base_builder->Connect(command_sub->get_output_port(0),
+  base_builder->Connect(command_sub->get_output_port(),
                         command_receiver->get_input_port(0));
   base_builder->Connect(command_receiver->get_output_port(0),
                         controller->get_input_port_desired_state());
@@ -141,7 +141,7 @@ int DoMain() {
   base_builder->Connect(external_torque_converter->get_output_port(0),
                         status_sender->get_external_torque_input_port());
   base_builder->Connect(status_sender->get_output_port(0),
-                        status_pub->get_input_port(0));
+                        status_pub->get_input_port());
 
   if (FLAGS_visualize_frames) {
     // TODO(sam.creasey) This try/catch block is here because even

--- a/examples/schunk_wsg/schunk_wsg_simulation.cc
+++ b/examples/schunk_wsg/schunk_wsg_simulation.cc
@@ -76,7 +76,7 @@ int DoMain() {
       manipulation::schunk_wsg::kSchunkWsgVelocityIndex);
   status_sender->set_name("status_sender");
 
-  builder.Connect(command_sub->get_output_port(0),
+  builder.Connect(command_sub->get_output_port(),
                   wsg_controller->get_command_input_port());
   builder.Connect(wsg_controller->get_output_port(0),
                   plant->actuator_command_input_port());

--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -101,7 +101,7 @@ class Sinusoid : public systems::LeafSystem<double> {
 class SchunkWsgLiftTest : public ::testing::TestWithParam<bool> {
  protected:
 
-  // Finds the single end-effector from a RigidBodyTree and returns it. Aborts 
+  // Finds the single end-effector from a RigidBodyTree and returns it. Aborts
   // if there is more than one end-effector or more than one base link.
   RigidBody<double>* FindEndEffector(RigidBodyTree<double>* tree) {
     // There should only be one base body.
@@ -224,7 +224,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
   // trajectory or sinusoid) consist of an output and the time derivative of
   // that output. The PID controller requires the positional desireds to be
   // grouped together and the velocity desireds to also be grouped together;
-  // the control diagram uses demultiplexers and multiplexers for this purpose. 
+  // the control diagram uses demultiplexers and multiplexers for this purpose.
 
   // Build a trajectory and PID controller for the lifting joint.
   const auto& input_port =
@@ -232,7 +232,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
   const auto& output_port =
       plant->model_instance_state_output_port(lifter_instance_id);
 
-  // Get the number of controllers. 
+  // Get the number of controllers.
   const int num_PID_controllers = plant->get_num_actuators() - 1;
 
   // Constants chosen arbitrarily.
@@ -365,7 +365,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
   builder.Connect(plant->contact_results_output_port(),
                   contact_viz.get_input_port(0));
   builder.Connect(contact_viz.get_output_port(0),
-                  contact_results_publisher.get_input_port(0));
+                  contact_results_publisher.get_input_port());
 
   const int plant_output_port = builder.ExportOutput(plant->get_output_port(0));
 
@@ -410,7 +410,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
 
   // Note: the RK2 is used instead of the RK3 here because error control
   // with our current models is yielding much slower running times without
-  // discernible improvements in accuracy. 
+  // discernible improvements in accuracy.
   const double dt = 1e-4;
   simulator.reset_integrator<RungeKutta2Integrator<double>>(
       *model, dt, &context);

--- a/examples/valkyrie/valkyrie_pd_ff_controller.cc
+++ b/examples/valkyrie/valkyrie_pd_ff_controller.cc
@@ -174,7 +174,7 @@ void run_valkyrie_pd_ff_controller() {
           "ROBOT_COMMAND", &lcm));
 
   // lcm sub -> state decoder
-  builder.Connect(robot_state_subscriber.get_output_port(0),
+  builder.Connect(robot_state_subscriber.get_output_port(),
                   state_decoder->get_input_port(0));
 
   // state decoder -> controller
@@ -183,7 +183,7 @@ void run_valkyrie_pd_ff_controller() {
 
   // controller -> lcm pub
   builder.Connect(controller->get_output_port_atlas_command(),
-                  atlas_command_publisher.get_input_port(0));
+                  atlas_command_publisher.get_input_port());
 
   std::unique_ptr<Diagram<double>> diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();

--- a/examples/valkyrie/valkyrie_simulator.h
+++ b/examples/valkyrie/valkyrie_simulator.h
@@ -214,7 +214,7 @@ class ValkyrieSimulationDiagram : public systems::Diagram<double> {
     builder.Connect(plant_->contact_results_output_port(),
                     contact_viz.get_input_port(0));
     builder.Connect(contact_viz.get_output_port(0),
-                    contact_results_publisher.get_input_port(0));
+                    contact_results_publisher.get_input_port());
 
     // Robot state encoder to robot state publisher.
     builder.Connect(robot_state_encoder, robot_state_publisher);

--- a/manipulation/sensors/xtion.cc
+++ b/manipulation/sensors/xtion.cc
@@ -111,7 +111,7 @@ void Xtion::BuildDiagram(lcm::DrakeLcm* lcm, bool add_lcm_publisher,
     image_lcm_pub->set_publish_period(period_);
 
     builder.Connect(image_to_lcm_message->image_array_t_msg_output_port(),
-                    image_lcm_pub->get_input_port(0));
+                    image_lcm_pub->get_input_port());
   }
 
   if (add_frame_visualizer) {

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_throw.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/lcm/lcm_and_vector_base_translator.h"
@@ -129,6 +131,21 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * @pre this system is using a vector-valued port (not abstract-valued).
    */
   const LcmAndVectorBaseTranslator& get_translator() const;
+
+  /// Returns the sole input port.
+  const InputPortDescriptor<double>& get_input_port() const {
+    DRAKE_THROW_UNLESS(this->get_num_input_ports() == 1);
+    return LeafSystem<double>::get_input_port(0);
+  }
+
+  DRAKE_DEPRECATED("Don't use the indexed overload; use the no-arg overload.")
+  const InputPortDescriptor<double>& get_input_port(int index) const {
+    DRAKE_THROW_UNLESS(index == 0);
+    return get_input_port();
+  }
+
+  // This system has no output ports.
+  void get_output_port(int) = delete;
 
  private:
   // All constructors delegate to here.

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_throw.h"
 #include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -125,6 +127,21 @@ class LcmSubscriberSystem : public LeafSystem<double>,
    * @pre this system is using a vector-valued port (not abstract-valued).
    */
   const LcmAndVectorBaseTranslator& get_translator() const;
+
+  /// Returns the sole output port.
+  const OutputPort<double>& get_output_port() const {
+    DRAKE_THROW_UNLESS(this->get_num_output_ports() == 1);
+    return LeafSystem<double>::get_output_port(0);
+  }
+
+  DRAKE_DEPRECATED("Don't use the indexed overload; use the no-arg overload.")
+  const OutputPort<double>& get_output_port(int index) const {
+    DRAKE_THROW_UNLESS(index == 0);
+    return get_output_port();
+  }
+
+  // This system has no input ports.
+  void get_input_port(int) = delete;
 
   /**
    * Blocks the caller until @p old_message_count is different from the

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -145,9 +145,9 @@ void CheckLog() {
   auto printer0 = builder.AddSystem<DummySys>();
   auto printer1 = builder.AddSystem<DummySys>();
   auto printer2 = builder.AddSystem<DummySys>();
-  builder.Connect(sub0->get_output_port(0), printer0->get_input_port(0));
-  builder.Connect(sub1->get_output_port(0), printer1->get_input_port(0));
-  builder.Connect(sub2->get_output_port(0), printer2->get_input_port(0));
+  builder.Connect(sub0->get_output_port(), printer0->get_input_port(0));
+  builder.Connect(sub1->get_output_port(), printer1->get_input_port(0));
+  builder.Connect(sub2->get_output_port(), printer2->get_input_port(0));
 
   auto diagram = builder.Build();
 

--- a/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -182,11 +182,11 @@ int main() {
 
   builder.Connect(
       image_to_lcm_image_array->image_array_t_msg_output_port(),
-      image_array_lcm_publisher->get_input_port(0));
+      image_array_lcm_publisher->get_input_port());
 
   builder.Connect(
       rgbd_camera->camera_base_pose_output_port(),
-      pose_lcm_publisher->get_input_port(0));
+      pose_lcm_publisher->get_input_port());
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();

--- a/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.cc
+++ b/systems/sensors/test/accelerometer_test/accelerometer_example_diagram.cc
@@ -81,7 +81,7 @@ AccelerometerExampleDiagram::AccelerometerExampleDiagram(
           VectorX<double>::Zero(plant_->actuator_command_input_port().size()));
   constant_zero_source->set_name("zero");
 
-  builder_.Connect(lcm_subscriber_->get_output_port(0),
+  builder_.Connect(lcm_subscriber_->get_output_port(),
                    xdot_hack_->get_input_port());
   builder_.Connect(xdot_hack_->get_output_port(),
                    accelerometer_->get_plant_state_derivative_input_port());


### PR DESCRIPTION
We add a simple `get_input_port()` and `get_output_port()` and deprecate the overload that required uses to pass in zero all the time.

Fixes #7621.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7949)
<!-- Reviewable:end -->
