### PR TITLE
clang-format-includes fails fast on DOS newlines

### DIFF
--- a/tools/lint/formatter.py
+++ b/tools/lint/formatter.py
@@ -43,6 +43,8 @@ class FormatterBase(object):
             self._original_lines = list(readlines)
         self._working_lines = list(self._original_lines)
         self._check_rep()
+        if any(["\r" in line for line in self._working_lines]):
+            raise Exception("DOS newlines are not supported")
 
     def _check_rep(self):
         assert self._filename

--- a/tools/lint/test/formatter_test.py
+++ b/tools/lint/test/formatter_test.py
@@ -58,6 +58,13 @@ class TestFormatterBase(unittest.TestCase):
         self.assertEqual(
             dut.get_non_format_ranges(), [[1, 2, 3], [6, 7, 8, 9]])
 
+    def test_dos(self):
+        original_lines = [
+            '#include "line0"\r\n',
+        ]
+        with self.assertRaisesRegexp(Exception, "DOS newline"):
+            FormatterBase("filename.cc", readlines=original_lines)
+
 
 class TestIncludeFormatter(unittest.TestCase):
 


### PR DESCRIPTION
Without this fix, the error message is delayed until very late in processing, with an obscure "changes were not just a shuffle".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7950)
<!-- Reviewable:end -->
