### PR TITLE
Unifies unnamed namespaces for rndf and multilane tests.

### DIFF
--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -11,6 +11,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 class MultilaneArcRoadCurveTest : public ::testing::Test {
  protected:
@@ -650,6 +651,7 @@ TEST_F(MultilaneArcRoadCurveTest, Orientation) {
   }
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -15,6 +15,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 // TODO(maddog-tri)  Test use of Endpoint::reverse() with non-zero theta and
 //                   theta_dot, checking that the orientation of the resulting
@@ -560,6 +561,7 @@ GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
   EXPECT_EQ(rg->num_branch_points(), 20);
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -16,6 +16,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 // EndpointXy checks.
 GTEST_TEST(EndpointXyTest, DefaultConstructor) {
@@ -487,6 +488,7 @@ INSTANTIATE_TEST_CASE_P(EndpointZ, MultilaneConnectionEndpointZTest,
                                             EndpointZ(5., 1., M_PI / 6., 1.),
                                             0., 1)));
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_lanes_test.cc
+++ b/automotive/maliput/multilane/test/multilane_lanes_test.cc
@@ -19,6 +19,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 const double kLinearTolerance = 1e-6;
 const double kAngularTolerance = 1e-6;
@@ -503,7 +504,6 @@ TEST_P(MultilaneLanesParamTest, FlatArcLane) {
 }
 
 
-namespace {
 api::LanePosition IntegrateTrivially(const api::Lane* lane,
                                      const api::LanePosition& lp_initial,
                                      const api::IsoLaneVelocity& velocity,
@@ -518,7 +518,6 @@ api::LanePosition IntegrateTrivially(const api::Lane* lane,
   }
   return lp_current;
 }
-}  // namespace
 
 
 TEST_P(MultilaneLanesParamTest, HillIntegration) {
@@ -1007,6 +1006,7 @@ TEST_F(MultilaneMultipleLanesTest, MultipleArcLanes) {
   }
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -13,6 +13,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 class MultilaneLineRoadCurveTest : public ::testing::Test {
  protected:
@@ -404,6 +405,7 @@ TEST_F(MultilaneLineRoadCurveTest, Orientation) {
   }
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
@@ -12,6 +12,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 using api::RBounds;
 using api::HBounds;
@@ -247,6 +248,7 @@ GTEST_TEST(MultilaneLanesTest, HintWithDisconnectedLanes) {
   EXPECT_GT(distance, 0.);
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/test/multilane_segments_test.cc
+++ b/automotive/maliput/multilane/test/multilane_segments_test.cc
@@ -16,6 +16,7 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+namespace {
 
 const double kLinearTolerance = 1e-6;
 const double kAngularTolerance = 1e-6;
@@ -70,6 +71,7 @@ GTEST_TEST(MultilaneSegmentsTest, MultipleLanes) {
                                         kZeroTolerance));
 }
 
+}  // namespace
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/connection_test.cc
+++ b/automotive/maliput/rndf/test/connection_test.cc
@@ -12,6 +12,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // Checks Connection's constructor constraints that may throw exceptions.
 GTEST_TEST(RNDFBuilderTest, ConnectionConstructorTest) {
@@ -130,6 +131,7 @@ GTEST_TEST(RNDFBuilderTest, ConnectionWaypointTest) {
   EXPECT_EQ(connection.waypoints()[4].id().Z(), id_at_the_end.Z());
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/directed_waypoint_test.cc
+++ b/automotive/maliput/rndf/test/directed_waypoint_test.cc
@@ -12,6 +12,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // Checks the DirectedWaypoint's default constructor and the getters.
 GTEST_TEST(RNDFBuilderTest, DirectedWaypointDefaultConstructorTest) {
@@ -110,6 +111,7 @@ GTEST_TEST(RNDFBuilderTest, DirectedWaypointBoundingBoxTest) {
       kZeroTolerance));
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/ignition_rndf_test.cc
+++ b/automotive/maliput/rndf/test/ignition_rndf_test.cc
@@ -4,6 +4,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // Exercise the Bazel infrastructure and ensure that Ignition RNDF can be
 // built and linked.
@@ -12,6 +13,7 @@ GTEST_TEST(IgnitionRNDFTest, Test) {
   EXPECT_FALSE(rndfLoader.Valid());
 };
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/junction_test.cc
+++ b/automotive/maliput/rndf/test/junction_test.cc
@@ -13,6 +13,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
@@ -50,6 +51,7 @@ GTEST_TEST(RNDFJunctionTest, SegmentTest) {
   EXPECT_THROW(junction->segment(2), std::runtime_error);
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/road_geometry_test.cc
+++ b/automotive/maliput/rndf/test/road_geometry_test.cc
@@ -13,6 +13,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
@@ -66,6 +67,7 @@ GTEST_TEST(RNDFRoadGeometryTest, GettersTest) {
   EXPECT_EQ(rg.angular_tolerance(), kAngularTolerance);
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/segment_test.cc
+++ b/automotive/maliput/rndf/test/segment_test.cc
@@ -11,6 +11,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
@@ -50,6 +51,7 @@ GTEST_TEST(RNDFSegmentTest, MetadataLane) {
   EXPECT_THROW(s1->lane(3), std::runtime_error);
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/spline_helpers_test.cc
+++ b/automotive/maliput/rndf/test/spline_helpers_test.cc
@@ -15,6 +15,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // We use this tolerance to match the interpolated positions given by the path
 // length interpolator wrappers.
@@ -530,6 +531,7 @@ GTEST_TEST(RNDFCreatePChipBasedSplineTest, CaseExceptions) {
   EXPECT_THROW(CreatePChipBasedSpline(points), std::runtime_error);
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/rndf/test/spline_lane_test.cc
+++ b/automotive/maliput/rndf/test/spline_lane_test.cc
@@ -22,6 +22,7 @@
 namespace drake {
 namespace maliput {
 namespace rndf {
+namespace {
 
 // Angular tolerance will be used to match the angle values from the orientation
 // matrices.
@@ -377,6 +378,7 @@ GTEST_TEST(RNDFSplineLanesTest, TwoFlatLineLanesBoundChecks) {
                                         kVeryExact));
 }
 
+}  // namespace
 }  // namespace rndf
 }  // namespace maliput
 }  // namespace drake


### PR DESCRIPTION
Based on this [comment](https://github.com/RobotLocomotion/drake/pull/7626#issuecomment-363089202), this PR unifies and corrects the use of test namespaces for `rndf` and `mulitlane` inside `maliput`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7955)
<!-- Reviewable:end -->
