### PR TITLE
Install apt-transport-http in install_prereqs_binary_distribution.sh

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -64,7 +64,7 @@ libnetcdf-cxx-legacy-dev
 libnetcdf-dev
 libnlopt-dev
 libogg-dev
-libpng-dev
+libpng12-dev
 libqt5opengl5-dev
 libqt5x11extras5-dev
 libtheora-dev

--- a/setup/ubuntu/16.04/install_prereqs_binary_distribution.sh
+++ b/setup/ubuntu/16.04/install_prereqs_binary_distribution.sh
@@ -11,7 +11,7 @@ if [[ "${EUID}" -ne 0 ]]; then
 fi
 
 apt update
-apt install --no-install-recommends wget
+apt install --no-install-recommends apt-transport-https wget
 
 wget -O - https://drake-apt.csail.mit.edu/drake.pub.gpg | apt-key add
 echo 'deb [arch=amd64] https://drake-apt.csail.mit.edu xenial main' > /etc/apt/sources.list.d/drake.list


### PR DESCRIPTION
Potentially you could have
```
E: The method driver /usr/lib/apt/methods/https could not be found.
N: Is the package apt-transport-https installed?
E: Failed to fetch https://drake-apt.csail.mit.edu/dists/xenial/InRelease  
E: Some index files failed to download. They have been ignored, or old ones used instead.
```
You would need an unusually minimal install, but it is a possibility nonetheless.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7959)
<!-- Reviewable:end -->
