### PR TITLE
Install python in install_prereqs_binary_distribution

### DIFF
--- a/setup/ubuntu/16.04/install_prereqs_binary_distribution.sh
+++ b/setup/ubuntu/16.04/install_prereqs_binary_distribution.sh
@@ -49,6 +49,7 @@ libxml2
 libxt6
 libyaml-cpp0.5v5
 openjdk-8-jre
+python
 python-lxml
 python-numpy
 python-scipy


### PR DESCRIPTION
Not sure how this got missed. It does obviously end up getting installed because of the various `python-*` packages, but we use python independently of those packages, so it should be listed explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7961)
<!-- Reviewable:end -->
