### PR TITLE
Add point penetration query to ProximityEngine

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_library(
         ":shape_specification",
         "//drake/common",
         "//drake/common:default_scalars",
+        "//drake/geometry/query_results:penetration_as_point_pair",
         "@fcl",
     ],
 )

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -103,6 +103,95 @@ class EncodedData {
   uintptr_t data_{};
 };
 
+// Struct for use in SingleCollisionCallback(). Contains the collision request
+// and accumulates results in a drake::multibody::collision::PointPair vector.
+struct CollisionData {
+  CollisionData(const std::vector<GeometryId>* dynamic_map_in,
+                const std::vector<GeometryId>* anchored_map_in)
+      : dynamic_map(*dynamic_map_in), anchored_map(*anchored_map_in) {}
+  // Maps so the penetration call back can map from engine index to geometry id.
+  const std::vector<GeometryId>& dynamic_map;
+  const std::vector<GeometryId>& anchored_map;
+
+  // Collision request
+  fcl::CollisionRequestd request;
+
+  // Vector of distance results
+  std::vector<PenetrationAsPointPair<double>>* contacts{};
+};
+
+// Callback function for FCL's collide() function for retrieving a *single*
+// contact.
+bool SingleCollisionCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
+                             fcl::CollisionObjectd* fcl_object_B_ptr,
+                             void* callback_data) {
+  // NOTE: Although this function *takes* non-const pointers to satisfy the
+  // fcl api, it should not exploit the non-constness to modify the collision
+  // objects. We insure this by immediately assigning to a const version and
+  // not directly using the provided parameters.
+  const fcl::CollisionObjectd& fcl_object_A = *fcl_object_A_ptr;
+  const fcl::CollisionObjectd& fcl_object_B = *fcl_object_B_ptr;
+
+  // TODO(SeanCurtis-TRI): Introduce collision filtering here.
+  const bool is_filtered = false;
+
+  if (!is_filtered) {
+    // Unpack the callback data
+    auto& collision_data = *static_cast<CollisionData*>(callback_data);
+    const fcl::CollisionRequestd& request = collision_data.request;
+    const std::vector<GeometryId> dynamic_map = collision_data.dynamic_map;
+    const std::vector<GeometryId> anchored_map = collision_data.anchored_map;
+
+    // This callback only works for a single contact, this confirms a request
+    // hasn't been made for more contacts.
+    DRAKE_ASSERT(request.num_max_contacts == 1);
+    fcl::CollisionResultd result;
+
+    // Perform nearphase collision detection
+    fcl::collide(&fcl_object_A, &fcl_object_B, request, result);
+
+    // Process the contact points
+    if (result.isCollision()) {
+      // NOTE: This assumes that the request is configured to use a single
+      // contact.
+      const fcl::Contactd& contact = result.getContact(0);
+      //  By convention, Drake requires the contact normal to point out of B and
+      //  into A. FCL uses the opposite convention.
+      Vector3d drake_normal = -contact.normal;
+
+      // Signed distance is negative when penetration depth is positive.
+      double depth = contact.penetration_depth;
+
+      // FCL returns a single contact point, but PenetrationAsPointPair expects
+      // two, one on the surface of body A (Ac) and one on the surface of body B
+      // (Bc). Choose points along the line defined by the contact point and
+      // normal, equidistant to the contact point. Recall that signed_distance
+      // is strictly non-positive, so signed_distance * drake_normal points out
+      // of A and into B.
+      const Vector3d p_WAc{contact.pos - 0.5 * depth * drake_normal};
+      const Vector3d p_WBc{contact.pos + 0.5 * depth * drake_normal};
+
+      PenetrationAsPointPair<double> penetration;
+      penetration.depth = depth;
+      // The engine doesn't know geometry ids; it returns engine indices. The
+      // caller must map engine indices to geometry ids.
+      penetration.id_A =
+          EncodedData(fcl_object_A).id(dynamic_map, anchored_map);
+      penetration.id_B =
+          EncodedData(fcl_object_B).id(dynamic_map, anchored_map);
+      penetration.p_WCa = p_WAc;
+      penetration.p_WCb = p_WBc;
+      penetration.nhat_BA_W = drake_normal;
+      collision_data.contacts->emplace_back(std::move(penetration));
+    }
+  }
+
+  // Returning true would tell the broadphase manager to terminate early. Since
+  // we want to find all the collisions present in the model's current
+  // configuration, we return false.
+  return false;
+}
+
 // Returns a copy of the given fcl collision geometry; throws an exception for
 // unsupported collision geometry types. This supplements the *missing* cloning
 // functionality in FCL. Issue has been submitted to FCL:
@@ -313,6 +402,28 @@ class ProximityEngine<T>::Impl : public ShapeReifier {
     TakeShapeOwnership(fcl_half_space, user_data);
   }
 
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration(
+      const std::vector<GeometryId>& dynamic_map,
+      const std::vector<GeometryId>& anchored_map) const {
+    std::vector<PenetrationAsPointPair<double>> contacts;
+    CollisionData collision_data{&dynamic_map, &anchored_map};
+    collision_data.contacts = &contacts;
+    collision_data.request.num_max_contacts = 1;
+    collision_data.request.enable_contact = true;
+    dynamic_tree_.collide(&collision_data, SingleCollisionCallback);
+    // NOTE: The interface to DynamicAABBTreeCollisionManager::collide
+    // requires the input collision manager pointer to be *non* const.
+    // As of 02/06/2018, it appears the only opportunity for modification
+    // of the AABB tree (and its contents) occurs in the callback provided.
+    // See the definition of SingleCollisionCallback above to see that no
+    // modification takes place.
+    dynamic_tree_.collide(
+        const_cast<fcl::DynamicAABBTreeCollisionManager<double>*>(
+            &anchored_tree_),
+        &collision_data, SingleCollisionCallback);
+    return contacts;
+  }
+
   // Testing utilities
 
   bool IsDeepCopy(const Impl& other) const {
@@ -473,6 +584,15 @@ void ProximityEngine<T>::UpdateWorldPoses(
     const std::vector<Isometry3<T>>& X_WG) {
   impl_->UpdateWorldPoses(X_WG);
 }
+
+template <typename T>
+std::vector<PenetrationAsPointPair<double>>
+ProximityEngine<T>::ComputePointPairPenetration(
+    const std::vector<GeometryId>& dynamic_map,
+    const std::vector<GeometryId>& anchored_map) const {
+  return impl_->ComputePointPairPenetration(dynamic_map, anchored_map);
+}
+
 // Testing utilities
 
 template <typename T>

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -7,6 +7,7 @@
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -99,6 +100,48 @@ class ProximityEngine {
   //  2. I could simply have a method that returns a mutable reference to such
   //    a vector and the caller sets values there directly.
   void UpdateWorldPoses(const std::vector<Isometry3<T>>& X_WG);
+
+
+  //----------------------------------------------------------------------------
+  /** @name                Collision Queries
+
+   These queries detect _collisions_ between geometry. Two geometries collide
+   if they overlap each other and are not explicitly excluded through
+   @ref collision_filter_concepts "collision filtering". These algorithms find
+   those colliding cases, characterize them, and report the essential
+   characteristics of that collision.  */
+
+  //@{
+
+  // NOTE: This maps to Model::ComputeMaximumDepthCollisionPoints().
+  /** Computes the penetrations across all pairs of geometries in the world.
+   Only reports results for _penetrating_ geometries; if two geometries are
+   separated, there will be no result for that pair.
+
+   The penetrations are characterized by pairs of points (providing some measure
+   of the penetration "depth" of the two objects -- but _not_ the overlapping
+   volume.
+
+   @cond
+   // TODO(SeanCurtis-TRI): Once collision filtering is supported, pull this
+   // *out* of the cond tag.
+   This method is affected by collision filtering; geometry pairs that
+   have been filtered will not produce contacts, even if their collision
+   geometry is penetrating.
+   @endcond
+
+   @param[in]   dynamic_map   A map from geometry _index_ to the corresponding
+                              global geometry identifier for dynamic geometries.
+   @param[in]   anchored_map  A map from geometry _index_ to the corresponding
+                              global geometry identifier for anchored
+                              geometries.
+   @returns A vector populated with all detected penetrations characterized as
+            point pairs. */
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration(
+      const std::vector<GeometryId>& dynamic_map,
+      const std::vector<GeometryId>& anchored_map) const;
+
+  //@}
 
  private:
   ////////////////////////////////////////////////////////////////////////////

--- a/geometry/query_results/penetration_as_point_pair.h
+++ b/geometry/query_results/penetration_as_point_pair.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
 
@@ -12,10 +13,13 @@ namespace geometry {
  geometry (in the normal direction). For convenience, the penetration depth
  is provided and is equal to:
 
-     depth = ‖ (p_WCa - p_WCb) ⋅ nhat_AB_W ‖₂.
+     depth = ‖ (p_WCa - p_WCb) ⋅ nhat_BA_W ‖₂.
  @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
 template <typename T>
 struct PenetrationAsPointPair {
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PenetrationAsPointPair)
+  PenetrationAsPointPair() = default;
+
   /** The id of the first geometry in the contact. */
   GeometryId id_A;
   /** The id of the second geometry in the contact. */
@@ -27,8 +31,9 @@ struct PenetrationAsPointPair {
    the world frame. */
   Vector3<T> p_WCb;
   /** The unit-length normal which defines the penetration direction, pointing
-   from geometry A to geometry B, measured and expressed in the world frame. */
-  Vector3<T> nhat_AB_W;
+   from geometry B into geometry A, measured and expressed in the world frame.
+   It _approximates_ the normal to the plane on which the contact patch lies. */
+  Vector3<T> nhat_BA_W;
   /** The penetration depth. */
   T depth{-1.0};
 };

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -111,6 +111,239 @@ GTEST_TEST(ProximityEngineTests, MoveSemantics) {
   EXPECT_EQ(move_construct.num_dynamic(), 0);
 }
 
+
+// Penetration tests
+
+// A scene with no geometry reports no penetrations.
+GTEST_TEST(ProximityEngineTests, PenetrationOnEmptyScene) {
+  ProximityEngine<double> engine;
+  std::vector<GeometryId> empty_map;
+
+  auto results = engine.ComputePointPairPenetration(empty_map, empty_map);
+  EXPECT_EQ(results.size(), 0);
+}
+
+// A scene with a single anchored geometry reports no penetrations.
+GTEST_TEST(ProximityEngineTests, PenetrationSingleAnchored) {
+  ProximityEngine<double> engine;
+  std::vector<GeometryId> dynamic_map;
+  std::vector<GeometryId> anchored_map;
+
+  Sphere sphere{0.5};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex index = engine.AddAnchoredGeometry(sphere, pose);
+  anchored_map.push_back(GeometryId::get_new_id());
+  EXPECT_EQ(index, 0);
+  auto results = engine.ComputePointPairPenetration(dynamic_map, anchored_map);
+  EXPECT_EQ(results.size(), 0);
+}
+
+// Tests that anchored geometry aren't collided against each other -- even if
+// they actually *are* in penetration.
+GTEST_TEST(ProximityEngineTests, PenetrationMultipleAnchored) {
+  ProximityEngine<double> engine;
+  std::vector<GeometryId> dynamic_map;
+  std::vector<GeometryId> anchored_map;
+
+  const double radius = 0.5;
+  Sphere sphere{radius};
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex index1 = engine.AddAnchoredGeometry(sphere, pose);
+  anchored_map.push_back(GeometryId::get_new_id());
+  EXPECT_EQ(index1, 0);
+  pose.translation() << 1.8 * radius, 0, 0;
+  AnchoredGeometryIndex index2 = engine.AddAnchoredGeometry(sphere, pose);
+  anchored_map.push_back(GeometryId::get_new_id());
+  EXPECT_EQ(index2, 1);
+  auto results = engine.ComputePointPairPenetration(dynamic_map, anchored_map);
+  EXPECT_EQ(results.size(), 0);
+}
+
+// These tests validate collisions between spheres. This does *not* test against
+// other geometry types because we assume FCL works. This merely confirms that
+// the ProximityEngine functions provide the correct mapping.
+
+// Common class for evaluating a simple penetration case between two spheres.
+// The variations are in sphere *ownership* (see below).
+class SimplePenetrationTest : public ::testing::Test {
+ protected:
+  // Moves the dynamic sphere to either a penetrating or non-penetrating
+  // position. The sphere is indicated by its engine `index` which belongs to
+  // the given `source_id`. If `is_colliding` is true, the sphere is placed in
+  // a colliding configuration.
+  //
+  // Non-colliding state
+  //       y           x = free_x_
+  //        │          │
+  //       *│*         o o
+  //    *   │   *   o       o
+  //   *    │    * o         o
+  // ──*────┼────*─o─────────o───────── x
+  //   *    │    * o         o
+  //    *   │   *   o       o
+  //       *│*         o o
+  //
+  // Colliding state
+  //       y       x = colliding_x_
+  //        │      │
+  //       *│*    o o
+  //    *   │  o*      o
+  //   *    │ o  *      o
+  // ──*────┼─o──*──────o────────────── x
+  //   *    │ o  *      o
+  //    *   │  o*      o
+  //       *│*    o o
+  void MoveDynamicSphere(int index, bool is_colliding,
+                         ProximityEngine<double>* engine = nullptr) {
+    engine = engine == nullptr ? &engine_ : engine;
+    std::vector<Isometry3<double>> poses(engine->num_dynamic(),
+                                         Isometry3<double>::Identity());
+    const double x_pos = is_colliding ? colliding_x_ : free_x_;
+    poses[index] = Isometry3<double>(Translation3d{x_pos, 0, 0});
+    engine->UpdateWorldPoses(poses);
+  }
+
+  // Compute penetration and confirm that a single penetration with the expected
+  // properties was found. Provide the engine indices of the sphere located at
+  // the origin and the sphere positioned to be in collision.
+  template <typename T>
+  void ExpectPenetration(GeometryId origin_sphere, GeometryId colliding_sphere,
+                         ProximityEngine<T>* engine) {
+    std::vector<PenetrationAsPointPair<double>> results =
+        engine->ComputePointPairPenetration(dynamic_map_, anchored_map_);
+    EXPECT_EQ(results.size(), 1);
+    const PenetrationAsPointPair<double> penetration = results[0];
+
+    // There are no guarantees as to the ordering of which element is A and
+    // which is B. This test enforces an order for validation.
+
+    // First confirm membership
+    EXPECT_TRUE((penetration.id_A == origin_sphere &&
+                 penetration.id_B == colliding_sphere) ||
+                (penetration.id_A == colliding_sphere &&
+                 penetration.id_B == origin_sphere));
+
+    // Assume A => origin_sphere and b => colliding_sphere
+    // NOTE: In this current version, penetration is only reported in double.
+    PenetrationAsPointPair<double> expected;
+    expected.id_A = origin_sphere;  // located at origin
+    expected.id_B = colliding_sphere;  // located at [1.5R, 0, 0]
+    expected.depth = 2 * radius_ - colliding_x_;
+    expected.p_WCa = Vector3<double>{radius_, 0, 0};
+    expected.p_WCb = Vector3<double>{colliding_x_ - radius_, 0, 0};
+    expected.nhat_BA_W = -Vector3<double>::UnitX();
+
+    // Reverse if previous order assumption is false
+    if (penetration.id_A == colliding_sphere) {
+      Vector3<double> temp;
+      // Swap the indices
+      expected.id_A = colliding_sphere;
+      expected.id_B = origin_sphere;
+      // Swap the points
+      temp = expected.p_WCa;
+      expected.p_WCa = expected.p_WCb;
+      expected.p_WCb = temp;
+      // Reverse the normal
+      expected.nhat_BA_W = -expected.nhat_BA_W;
+      // Penetration depth is same either way; do nothing.
+    }
+
+    EXPECT_EQ(penetration.id_A, expected.id_A);
+    EXPECT_EQ(penetration.id_B, expected.id_B);
+    EXPECT_EQ(penetration.depth, expected.depth);
+    EXPECT_TRUE(CompareMatrices(penetration.p_WCa, expected.p_WCa, 1e-13,
+                                MatrixCompareType::absolute));
+    EXPECT_TRUE(CompareMatrices(penetration.p_WCb, expected.p_WCb, 1e-13,
+                                MatrixCompareType::absolute));
+    EXPECT_TRUE(CompareMatrices(penetration.nhat_BA_W, expected.nhat_BA_W,
+                                1e-13, MatrixCompareType::absolute));
+  }
+
+  // Compute penetration and confirm that none were found.
+  void ExpectNoPenetration(ProximityEngine<double>* engine = nullptr) {
+    engine = engine == nullptr ? &engine_ : engine;
+    std::vector<PenetrationAsPointPair<double>> results =
+        engine->ComputePointPairPenetration(dynamic_map_, anchored_map_);
+    EXPECT_EQ(results.size(), 0);
+  }
+
+  ProximityEngine<double> engine_;
+  std::vector<GeometryId> dynamic_map_;
+  std::vector<GeometryId> anchored_map_;
+  const double radius_{0.5};
+  const Sphere sphere_{radius_};
+  const double free_x_{2.5 * radius_};
+  const double colliding_x_{1.5 * radius_};
+};
+
+// Tests collision between dynamic and anchored sphere. One case colliding, one
+// case *not* colliding.
+TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
+  // Set up anchored geometry
+  Isometry3<double> pose = Isometry3<double>::Identity();
+  AnchoredGeometryIndex anchored_index =
+      engine_.AddAnchoredGeometry(sphere_, pose);
+  GeometryId origin_id = GeometryId::get_new_id();
+  anchored_map_.push_back(origin_id);
+  EXPECT_EQ(anchored_index, 0);
+
+  // Set up dynamic geometry
+  GeometryIndex dynamic_index = engine_.AddDynamicGeometry(sphere_);
+  GeometryId dynamic_id = GeometryId::get_new_id();
+  dynamic_map_.push_back(dynamic_id);
+  EXPECT_EQ(dynamic_index, 0);
+  EXPECT_EQ(engine_.num_geometries(), 2);
+
+  // Non-colliding case
+  MoveDynamicSphere(dynamic_index, false /* not colliding */);
+  ExpectNoPenetration();
+
+  // Colliding case
+  MoveDynamicSphere(dynamic_index, true /* colliding */);
+  ExpectPenetration(origin_id, dynamic_id, &engine_);
+
+  // Test colliding case on copy.
+  ProximityEngine<double> copy_engine(engine_);
+  ExpectPenetration(origin_id, dynamic_id, &copy_engine);
+
+  // Test AutoDiff converted engine
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine = engine_.ToAutoDiff();
+  ExpectPenetration(origin_id, dynamic_id, ad_engine.get());
+}
+
+// Performs the same collision test between two dynamic spheres which belong to
+// the same source
+TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
+  GeometryIndex origin_index = engine_.AddDynamicGeometry(sphere_);
+  GeometryId origin_id = GeometryId::get_new_id();
+  dynamic_map_.push_back(origin_id);
+  EXPECT_EQ(origin_index, 0);
+  std::vector<Isometry3<double>> poses{Isometry3<double>::Identity()};
+  engine_.UpdateWorldPoses(poses);
+
+  GeometryIndex collide_index = engine_.AddDynamicGeometry(sphere_);
+  GeometryId collide_id = GeometryId::get_new_id();
+  dynamic_map_.push_back(collide_id);
+  EXPECT_EQ(collide_index, 1);
+  EXPECT_EQ(engine_.num_geometries(), 2);
+
+  // Non-colliding case
+  MoveDynamicSphere(collide_index, false /* not colliding */);
+  ExpectNoPenetration();
+
+  // Colliding case
+  MoveDynamicSphere(collide_index, true /* colliding */);
+  ExpectPenetration(origin_id, collide_id, &engine_);
+
+  // Test colliding case on copy.
+  ProximityEngine<double> copy_engine(engine_);
+  ExpectPenetration(origin_id, collide_id, &copy_engine);
+
+  // Test AutoDiff converted engine
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine = engine_.ToAutoDiff();
+  ExpectPenetration(origin_id, collide_id, ad_engine.get());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace geometry


### PR DESCRIPTION
This adds the ability to make penetration queries to ProximityEngine. The penetrations are characterized as point-pairs.

```
Category            added  modified  removed  
----------------------------------------------
code                211    1         0        
comments            132    2         0        
blank               56     0         0        
----------------------------------------------
TOTAL               399    3         0 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7962)
<!-- Reviewable:end -->
