### PR TITLE
pydrake.all: Do not promote using `from x import *` in documentation.

### DIFF
--- a/bindings/pydrake/all.py
+++ b/bindings/pydrake/all.py
@@ -1,5 +1,5 @@
 """
-Provides a roll-up of all user-visible symbols in `pydrake`.
+Provides a roll-up of all user-visible modules and symbols in `pydrake`.
 
 Things to note:
 *   The `.all` modules in `pydrake` are intended as convenient end-user

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -2,11 +2,40 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
-from pydrake.all import *
-
 
 class TestAll(unittest.TestCase):
+    # N.B. Synchronize code snippests with `doc/python_bindings.rst`.
+
+    def test_usage_no_all(self):
+        from pydrake.common import FindResourceOrThrow
+        from pydrake.multibody.rigid_body_plant import RigidBodyPlant
+        from pydrake.multibody.rigid_body_tree import RigidBodyTree
+        from pydrake.systems.analysis import Simulator
+
+        tree = RigidBodyTree(
+            FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+        simulator = Simulator(RigidBodyPlant(tree))
+
+    def test_usage_all(self):
+        from pydrake.all import (
+            FindResourceOrThrow, RigidBodyPlant, RigidBodyTree, Simulator)
+
+        tree = RigidBodyTree(
+            FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+        simulator = Simulator(RigidBodyPlant(tree))
+
+    def test_usage_all_explicit(self):
+        import pydrake.all
+
+        tree = pydrake.multibody.rigid_body_tree.RigidBodyTree(
+            pydrake.common.FindResourceOrThrow(
+                "drake/examples/pendulum/Pendulum.urdf"))
+        simulator = pydrake.systems.analysis.Simulator(
+            pydrake.multibody.rigid_body_plant.RigidBodyPlant(tree))
+
     def test_symbols(self):
+        import pydrake.all
+
         # Subset of symbols.
         expected_symbols = (
             # autodiffutils
@@ -35,43 +64,7 @@ class TestAll(unittest.TestCase):
         # Ensure each symbol is exposed as globals from the above import
         # statement.
         for expected_symbol in expected_symbols:
-            self.assertTrue(expected_symbol in globals())
-
-    def test_usage_all(self):
-        # N.B. Synchronize this with `doc/python_bindings.rst`.
-        tree = RigidBodyTree(
-            FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
-        simulator = Simulator(RigidBodyPlant(tree))
-
-    def test_usage_no_all(self):
-
-        def isolated(self):
-            # Ensure we have no globals leaking in.
-            self.assertEquals(len(globals()), 0)
-
-            # N.B. Synchronize this with `doc/python_bindings.rst`.
-            from pydrake.common import FindResourceOrThrow
-            from pydrake.multibody.rigid_body_plant import RigidBodyPlant
-            from pydrake.multibody.rigid_body_tree import RigidBodyTree
-            from pydrake.systems.analysis import Simulator
-
-            tree = RigidBodyTree(
-                FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
-            simulator = Simulator(RigidBodyPlant(tree))
-
-            return simulator
-
-        # Evaluate without access to current globals.
-        # TODO(eric.cousineau): Use `mock.patch.dict` when available.
-        # Unfortunately, `isolated.__globals__` references current globals, so
-        # we must restore them. `eval(expr, globals)` does not override the
-        # scoped globals of the function (as it should be).
-        # `isolated.__globals__` is a read-only property as well.
-        old_globals = dict(isolated.__globals__)
-        isolated.__globals__.clear()
-        simulator = isolated(self)
-        isolated.__globals__.update(old_globals)
-        self.assertTrue(isinstance(simulator, Simulator))
+            self.assertTrue(expected_symbol in pydrake.all.__dict__)
 
 
 if __name__ == '__main__':

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -91,27 +91,11 @@ The most up-to-date demonstrations of what can be done using ``pydrake`` are
 the ``pydrake`` unit tests themselves. You can see all of them inside the
 ``drake/bindings/python/pydrake/test`` folder in the Drake source code.
 
-There are multiple levels of modules available from ``pydrake``. If you are
-experimenting with ``pydrake`` in a REPL environment (such as IPython  or
-Jupyter), consider importing from ``pydrake.all`` to reduce the number of
-import staments.
+Here's an example snippet of code from ``pydrake``:
 
 ..
-    Developers: Ensure this is synchronized with
-    ``//bindings/pydrake:all_test``, specifically the test cases
-    ``test_usage_all`` and ``test_usage_no_all``.
-
-As an example, the following code uses ``pydrake.all``:
-
-.. code-block:: python
-
-    from pydrake.all import *
-
-    tree = RigidBodyTree(
-        FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
-    simulator = Simulator(RigidBodyPlant(tree))
-
-While this code does not:
+    Developers: Ensure these snippets are synchronized with
+    ``//bindings/pydrake:all_test``
 
 .. code-block:: python
 
@@ -124,5 +108,35 @@ While this code does not:
         FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
     simulator = Simulator(RigidBodyPlant(tree))
 
-For guidance on when to use ``pydrake.all`` when developing, please see
-``help(pydrake.all)``.
+If you are prototyping code in a REPL environment (such as IPython / Jupyter)
+and to reduce the number of import statements, consider using ``pydrake.all`` to
+import a subset of symbols from a flattened namespace or import all modules
+automatically. If you are writing non-prototype code, avoid using
+``pydrake.all``; for more details, see ``help(pydrake.all)``.
+
+In all cases, try to avoid using ``from pydrake.all import *``, as it may
+introduce symbol collisions that are difficiult to debug.
+
+An example of importing symbols directly from ``pydrake.all``:
+
+.. code-block:: python
+
+    from pydrake.all import (
+        FindResourceOrThrow, RigidBodyPlant, RigidBodyTree, Simulator)
+
+    tree = RigidBodyTree(
+        FindResourceOrThrow("drake/examples/pendulum/Pendulum.urdf"))
+    simulator = Simulator(RigidBodyPlant(tree))
+
+An alternative is to use ``pydrake.all`` to import all modules, but then
+explicity refer to each symbol:
+
+.. code-block:: python
+
+    import pydrake.all
+
+    tree = pydrake.multibody.rigid_body_tree.RigidBodyTree(
+        pydrake.common.FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf"))
+    simulator = pydrake.systems.analysis.Simulator(
+        pydrake.multibody.rigid_body_plant.RigidBodyPlant(tree))


### PR DESCRIPTION
Per [discussion here](https://github.com/RussTedrake/underactuated/pull/58#issuecomment-363252363).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7963)
<!-- Reviewable:end -->
