### PR TITLE
Enable freetype in godotengine; bump to v3.0

### DIFF
--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -14,6 +14,7 @@ load("@drake//tools/workspace/eigen:repository.bzl", "eigen_repository")
 load("@drake//tools/workspace/expat:repository.bzl", "expat_repository")
 load("@drake//tools/workspace/fcl:repository.bzl", "fcl_repository")
 load("@drake//tools/workspace/fmt:repository.bzl", "fmt_repository")
+load("@drake//tools/workspace/freetype2:repository.bzl", "freetype2_repository")  # noqa
 load("@drake//tools/workspace/gflags:repository.bzl", "gflags_repository")
 load("@drake//tools/workspace/glew:repository.bzl", "glew_repository")
 load("@drake//tools/workspace/glib:repository.bzl", "glib_repository")
@@ -98,6 +99,8 @@ def add_default_repositories(excludes = []):
         fcl_repository(name = "fcl")
     if "fmt" not in excludes:
         fmt_repository(name = "fmt")
+    if "freetype2" not in excludes:
+        freetype2_repository(name = "freetype2")
     if "gflags" not in excludes:
         gflags_repository(name = "gflags")
     if "glew" not in excludes:

--- a/tools/workspace/freetype2/BUILD.bazel
+++ b/tools/workspace/freetype2/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/freetype2/repository.bzl
+++ b/tools/workspace/freetype2/repository.bzl
@@ -1,0 +1,9 @@
+# -*- mode: python -*-
+
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "pkg_config_repository",
+)
+
+def freetype2_repository(name, modname = "freetype2", **kwargs):
+    pkg_config_repository(name = name, modname = modname, **kwargs)

--- a/tools/workspace/godotengine/package.BUILD.bazel
+++ b/tools/workspace/godotengine/package.BUILD.bazel
@@ -132,6 +132,7 @@ cc_library(
         "-w",
     ],
     defines = [
+        "FREETYPE_ENABLED",
         "GLAD_ENABLED",
         "GLES_OVER_GL",
         "UNIX_ENABLED",
@@ -162,6 +163,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "generated_headers",
+        "@freetype2",
         "@libpng",
         "@zlib",
     ],

--- a/tools/workspace/godotengine/repository.bzl
+++ b/tools/workspace/godotengine/repository.bzl
@@ -6,7 +6,7 @@ def godotengine_repository(name):
     github_archive(
         name = name,
         repository = "godotengine/godot",
-        commit = "06dd10b3905a7d48beffe0523b785d513747f511",
-        sha256 = "bb305dc5cec41ef379174162c62f7056f91ba7798324a9466592c0a3420c3105",  # noqa
+        commit = "9bd402698cfa299b79b9144f8d7744c308a4e085",
+        sha256 = "cbec9b48d79b1fdc16a253f438fb06544a59baf71cf2c1f47c193817f2127a10",  # noqa
         build_file = "@drake//tools/workspace/godotengine:package.BUILD.bazel",
     )


### PR DESCRIPTION
Upstream Godot _looks_ like it supports turning off freetype at compile time, but in practice has various build errors if we do.  So, we'll turn on that feature when used in Drake, even though we'll probably never need fonts per se.  This lets us update to use Godot's 3.0 stable release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7964)
<!-- Reviewable:end -->
