### PR TITLE
Implements Eval() methods in MBP to avoid boilerplate

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -426,6 +426,14 @@ class MultibodyPlant final : public systems::LeafSystem<T> {
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;
 
+  // Helper method to Eval() position kinematics cached in the context.
+  const PositionKinematicsCache<T>& EvalPositionKinematics(
+      const systems::Context<T>& context) const;
+
+  // Helper method to Eval() velocity kinematics cached in the context.
+  const VelocityKinematicsCache<T>& EvalVelocityKinematics(
+      const systems::Context<T>& context) const;
+
   // The entire multibody model.
   std::unique_ptr<drake::multibody::MultibodyTree<T>> model_;
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -426,6 +426,9 @@ class MultibodyPlant final : public systems::LeafSystem<T> {
       const systems::Context<T>& context,
       systems::ContinuousState<T>* derivatives) const override;
 
+  // Helper method to declare cache entries to be allocated in the context.
+  void DeclareCacheEntries();
+
   // Helper method to Eval() position kinematics cached in the context.
   const PositionKinematicsCache<T>& EvalPositionKinematics(
       const systems::Context<T>& context) const;
@@ -442,6 +445,11 @@ class MultibodyPlant final : public systems::LeafSystem<T> {
 
   // Map used to find joint indexes by their joint name.
   std::unordered_map<std::string, JointIndex> joint_name_to_index_;
+
+  // Temporary solution for fake cache entries to help statbilize the API.
+  // TODO(amcastro-tri): Remove these when caching lands.
+  std::unique_ptr<PositionKinematicsCache<T>> pc_;
+  std::unique_ptr<VelocityKinematicsCache<T>> vc_;
 };
 
 }  // namespace multibody_plant


### PR DESCRIPTION
To avoid boilerplate code like this:
```
TODO(my name!): Eval() this from context.
PositionKinematics<T> pc(model_->topology());
model_->CalcPositionKinematics(context, &pc);
```
all over the place, I introduce `Eval()` methods that place the boilerplate in a singe central location.
Per suggestion [here](https://reviewable.io/reviews/robotlocomotion/drake/7947#-L4OY0liwjNpp-j4SYnD).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7973)
<!-- Reviewable:end -->
