### PR TITLE
Add SNOPT 7.5 support while retaining RLG support

### DIFF
--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -12,20 +12,46 @@
 #include "drake/math/autodiff.h"
 #include "drake/solvers/mathematical_program.h"
 
+// TODO(#7984) The SNOPT includes we use below are from an older f2c-based
+// implementation.  SNOPT has since switched to wrapping using F90 per the
+// publicly-available `snopt-interface` headers.  We should consider using that
+// header instead, which would remove a bunch of the odd #include and #define
+// statements from the below.
+
+// Put SNOPT's and F2C's typedefs into their own namespace.
+namespace snopt {
+extern "C" {
+
+// Include F2C's typedefs but revert its leaky defines.
+#include <f2c.h>
+#undef qbit_clear
+#undef qbit_set
+#undef TRUE_
+#undef FALSE_
+#undef Extern
+#undef VOID
+#undef abs
+#undef dabs
+#undef min
+#undef max
+#undef dmin
+#undef dmax
+#undef bit_test
+#undef bit_clear
+#undef bit_set
+
+// Include SNOPT's function declarations.
+#include <cexamples/snopt.h>
+#ifdef SNOPT_HAS_SNFILEWRAPPER
+#include <cexamples/snfilewrapper.h>
+#endif
+
+}  // extern C
+}  // namespace snopt
+
 // TODO(jwnimmer-tri) Eventually resolve these warnings.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-
-namespace snopt {
-// Needs to include snopt.hh BEFORE snfilewrapper.hh, otherwise compiler does
-// not work.
-// clang-format wants to switch the order of this inclusion, which causes
-// compiler failure.
-// clang-format off
-#include "snopt.hh"
-#include "snfilewrapper.hh"
-// clang-format on
-}
 
 // todo(sammy-tri) :  implement sparsity inside each cost/constraint
 // todo(sammy-tri) :  handle snopt options
@@ -152,19 +178,23 @@ struct SNOPTRun {
   snopt::integer iPrint = -1;
   snopt::integer iSumm = -1;
 
-  snopt::integer snSeti(std::string const& opt, snopt::integer val) {
+  // The `opt` is non-const, because snopt wants a non-const char*.
+  snopt::integer snSeti(std::string opt, snopt::integer val) {
+    DRAKE_DEMAND(!opt.empty());
     snopt::integer opt_len = static_cast<snopt::integer>(opt.length());
     snopt::integer err = 0;
-    snopt::snseti_(opt.c_str(), &val, &iPrint, &iSumm, &err, D.cw.data(),
+    snopt::snseti_(&opt[0], &val, &iPrint, &iSumm, &err, D.cw.data(),
                    &D.lencw, D.iw.data(), &D.leniw, D.rw.data(), &D.lenrw,
                    opt_len, 8 * D.lencw);
     return err;
   }
 
-  snopt::integer snSetr(std::string const& opt, snopt::doublereal val) {
+  // The `opt` is non-const, because snopt wants a non-const char*.
+  snopt::integer snSetr(std::string opt, snopt::doublereal val) {
+    DRAKE_DEMAND(!opt.empty());
     snopt::integer opt_len = static_cast<snopt::integer>(opt.length());
     snopt::integer err = 0;
-    snopt::snsetr_(opt.c_str(), &val, &iPrint, &iSumm, &err, D.cw.data(),
+    snopt::snsetr_(&opt[0], &val, &iPrint, &iSumm, &err, D.cw.data(),
                    &D.lencw, D.iw.data(), &D.leniw, D.rw.data(), &D.lenrw,
                    opt_len, 8 * D.lencw);
     return err;
@@ -701,7 +731,8 @@ SolutionResult SnoptSolver::Solve(MathematicalProgram& prog) const {
 
   snopt::integer info;
   snopt::snopta_(
-      &Cold, &nF, &nx, &nxname, &nFname, &ObjAdd, &ObjRow, Prob, snopt_userfun,
+      &Cold, &nF, &nx, &nxname, &nFname, &ObjAdd, &ObjRow, Prob,
+      reinterpret_cast<snopt::U_fp>(&snopt_userfun),
       iAfun, jAvar, &lenA, &lenA, A, iGfun, jGvar, &lenG, &lenG, xlow, xupp,
       xnames, Flow, Fupp, Fnames, x, xstate, xmul, F, Fstate, Fmul, &info,
       &mincw, &miniw, &minrw, &nS, &nInf, &sInf,

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -5,6 +5,14 @@ config_setting(
     values = {"compilation_mode": "dbg"},
 )
 
+# In some versions of SNOPT, this header provides the function declarations to
+# control SNOPT's logging.  In other versions, those declarations instead
+# appear directly in cexamples/snopt.h and this file is absent.  We'll sense
+# whether it's present, and define SNOPT_HAS_SNFILEWRAPPER only if so.
+_MAYBE_SNFILEWRAPPER = glob([
+    "cexamples/snfilewrapper.h",
+])
+
 # Drake's binary releases are allowed to redistribute SNOPT only if SNOPT is
 # not redistributed as a stand-alone package -- users must not use the SNOPT
 # code on its own, but rather only through Drake's interfaces.  To that end,
@@ -16,12 +24,18 @@ cc_library(
         ["csrc/*.c"],
         exclude = ["csrc/dummy.c"],
     ),
-    hdrs = glob(["csrc/*.hh"]),
+    hdrs = [
+        "cexamples/snopt.h",
+    ] + _MAYBE_SNFILEWRAPPER,
     copts = [
         "-w",
         # Hide symbols per note (2) above.
         "-fvisibility=hidden",
     ],
+    defines = [
+        "SNOPT_HAS_SNFILEWRAPPER",
+    ] if _MAYBE_SNFILEWRAPPER else [],
+    includes = ["."],
     linkopts = [
         "-lm",
     ] + select({
@@ -31,18 +45,19 @@ cc_library(
     }),
     # Link statically per note (1) above.
     linkstatic = 1,
-    # By convention, SNOPT header #includes are not fully qualified.
-    strip_include_prefix = "csrc",
     visibility = ["//visibility:public"],
     deps = [":libf2c"],
     # Always link the entirety of SNOPT.
     alwayslink = 1,
 )
 
-# Different revisions of SNOPT have this folder in different places.
-# TODO(jwnimmer-tri) Use a different value here, depending on what's needed for
-# a specific version of snopt.
-_LIBF2C = "libf2c/"
+# Different revisions of SNOPT have the libf2c folder in different places.
+# Find a well-known f2c header and strip off the filename to leave, e.g.,
+# "libf2c/" as the path constant that we want.  First one wins.
+_LIBF2C = (glob([
+    "libf2c/ctype.h",
+    "f2c/libf2c/ctype.h",
+]) or fail("Could not find ctype.h"))[0][:-len("ctype.h")]
 
 cc_binary(
     name = "arithchk",
@@ -83,22 +98,30 @@ genrule(
     cmd = "cp $< $(@)",
 )
 
-genrule(
-    name = "math",
-    srcs = [_LIBF2C + "math.h0"],
-    outs = [_LIBF2C + "f2math.h"],
-    cmd = "cp $< $(@)",
-)
+# Some libf2c's need math.h0 copied to f2math.h, but others don't.  Check if we
+# have the input file that would need a rename.
+_MAYBE_MATH_H0 = glob([_LIBF2C + "math.h0"])
+
+# If we had the input file, this is the output.  Otherwise, this is empty.
+_MAYBE_F2MATH_H = [_LIBF2C + "f2math.h"] if _MAYBE_MATH_H0 else []
+
+# Copy the file only if needed.
+if _MAYBE_F2MATH_H:
+    genrule(
+        name = "math",
+        srcs = _MAYBE_MATH_H0,
+        outs = _MAYBE_F2MATH_H,
+        cmd = "cp $< $(@)",
+    )
 
 filegroup(
     name = "generated_headers",
     srcs = [
         _LIBF2C + "arith.h",
         _LIBF2C + "f2c.h",
-        _LIBF2C + "f2math.h",
         _LIBF2C + "signal1.h",
         _LIBF2C + "sysdep1.h",
-    ],
+    ] + _MAYBE_F2MATH_H,
 )
 
 filegroup(


### PR DESCRIPTION
This PR amends the BUILD rules and C++ code to allow for SNOPT 7.5.  If an external workspace were to call our rule with a different git remote and commit that pointed at SNOPT 7.5, this would build and pass `snopt_solver_test` cases.

Relates to #1647 but does not fix it yet, since the default is still SNOPT 7.2.

Do not merge until:
- [x] tested on macOS.
- [x] agreed testing plan (or at least forecast) for SNOPT 7.5 in CI.
  - Discussed in #1647.
  - I have manually tested the `package.BUILD.bazel` in this PR against SNOPT 7.5, using the archive selector prototyped at https://github.com/jwnimmer-tri/drake/tree/snopt, running `test //solvers:snopt_solver_test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7975)
<!-- Reviewable:end -->
