### PR TITLE
add a tip about installing jupyter on mac

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -73,6 +73,8 @@ To check this:
         add the following to ~/.bash_profile:
           export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
+    Once you have done this, if you would like to use ``jupyter`` then be sure to install it via ``pip install jupyter`` (*not* via Homebrew) to ensure that it uses the correct Python interpreter. 
+    
     ..
         Developers: Ensure this is synchronized with the steps in
         ``install_prereqs_user_environment.sh``.


### PR DESCRIPTION
wasted some time on this one.  
```
brew remove jupyter
pip install jupyter
```
resolved all of my woes.  

this adds an app note to the python page.