### PR TITLE
Add a separate target kinematics_cache_helper

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -58,6 +58,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "kinematics_cache_helper",
+    srcs = [
+        "kinematics_cache_helper.cc",
+    ],
+    hdrs = [
+        "kinematics_cache_helper.h",
+    ],
+    deps = [
+        ":rigid_body_tree",
+    ],
+)
+
+drake_cc_library(
     name = "inverse_kinematics",
     srcs = [
         "constraint_wrappers.cc",
@@ -78,6 +91,7 @@ drake_cc_library(
     ],
     deps = [
         ":approximate_ik",
+        ":kinematics_cache_helper",
         ":rigid_body_constraint",
         ":rigid_body_tree",
         "//drake/common:unused",

--- a/multibody/constraint_wrappers.cc
+++ b/multibody/constraint_wrappers.cc
@@ -4,25 +4,6 @@ namespace drake {
 namespace systems {
 namespace plants {
 
-template <typename T>
-KinematicsCacheHelper<T>::KinematicsCacheHelper(
-    const std::vector<std::unique_ptr<RigidBody<T>>>& bodies)
-    : kinsol_(RigidBodyTree<T>::CreateKinematicsCacheFromBodiesVector(bodies)) {
-}
-
-template <typename Scalar>
-KinematicsCache<Scalar>& KinematicsCacheHelper<Scalar>::UpdateKinematics(
-    const Eigen::Ref<const Eigen::VectorXd>& q,
-    const RigidBodyTree<double>* tree) {
-  if ((q.size() != last_q_.size()) || (q != last_q_) || (tree != last_tree_)) {
-    last_q_ = q;
-    last_tree_ = tree;
-    kinsol_.initialize(q);
-    tree->doKinematics(kinsol_);
-  }
-  return kinsol_;
-}
-
 SingleTimeKinematicConstraintWrapper::SingleTimeKinematicConstraintWrapper(
     const SingleTimeKinematicConstraint* rigid_body_constraint,
     KinematicsCacheHelper<double>* kin_helper)
@@ -100,8 +81,6 @@ void QuasiStaticConstraintWrapper::DoEval(
       y, (dy * drake::math::autoDiffToGradientMatrix(tq)).eval(), ty);
 }
 
-// Explicitly instantiates on the most common scalar types.
-template class KinematicsCacheHelper<double>;
 
 }  // namespace plants
 }  // namespace systems

--- a/multibody/constraint_wrappers.h
+++ b/multibody/constraint_wrappers.h
@@ -10,6 +10,7 @@
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/gradient.h"
 #include "drake/multibody/kinematics_cache.h"
+#include "drake/multibody/kinematics_cache_helper.h"
 #include "drake/multibody/rigid_body_constraint.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/solvers/mathematical_program.h"
@@ -17,25 +18,6 @@
 namespace drake {
 namespace systems {
 namespace plants {
-
-/// Helper class to avoid recalculating a kinematics cache which is
-/// going to be used repeatedly by multiple other classes.
-template <typename Scalar>
-class KinematicsCacheHelper {
- public:
-  explicit KinematicsCacheHelper(
-      const std::vector<std::unique_ptr<RigidBody<Scalar>>>& bodies);
-
-  KinematicsCache<Scalar>& UpdateKinematics(
-      const Eigen::Ref<const Eigen::VectorXd>& q,
-      const RigidBodyTree<double>* tree);
-
- private:
-  Eigen::VectorXd last_q_;
-  const RigidBodyTree<double>* last_tree_;
-  KinematicsCache<Scalar> kinsol_;
-};
-
 class SingleTimeKinematicConstraintWrapper : public drake::solvers::Constraint {
  public:
   /// All pointers are aliased for the lifetime of the wrapper.

--- a/multibody/inverse_kinematics_backend.cc
+++ b/multibody/inverse_kinematics_backend.cc
@@ -213,7 +213,7 @@ void inverseKinBackend(RigidBodyTree<double>* model, const int nT,
         "nq x nT");
   }
 
-  KinematicsCacheHelper<double> kin_helper(model->bodies);
+  KinematicsCacheHelper<double> kin_helper(*model);
 
   // TODO(sam.creasey) I really don't like rebuilding the
   // MathematicalProgram for every timestep, but it's not possible to

--- a/multibody/inverse_kinematics_trajectory_backend.cc
+++ b/multibody/inverse_kinematics_trajectory_backend.cc
@@ -440,7 +440,7 @@ void inverseKinTrajBackend(RigidBodyTree<double>* model, const int nT,
   // speed boost?  It could be more if there are no inbetween sample
   // times (which effectively cache internally by doing all of the
   // constraints for the same time inbetween sample at once).
-  KinematicsCacheHelper<double> kin_helper(model->bodies);
+  KinematicsCacheHelper<double> kin_helper(*model);
 
   // Add all of our single time and quasi static constraints.
   int qstart_idx = 0;

--- a/multibody/kinematics_cache_helper.cc
+++ b/multibody/kinematics_cache_helper.cc
@@ -1,0 +1,34 @@
+#include "drake/multibody/kinematics_cache_helper.h"
+
+#include "drake/common/autodiff.h"
+
+namespace drake {
+namespace systems {
+namespace plants {
+template <typename Scalar>
+KinematicsCacheHelper<Scalar>::KinematicsCacheHelper(
+    const RigidBodyTree<double>& tree)
+    : last_tree_{nullptr},
+      kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
+      last_q_.resize(0);
+}
+
+template <typename Scalar>
+KinematicsCache<Scalar>& KinematicsCacheHelper<Scalar>::UpdateKinematics(
+    const Eigen::Ref<const VectorX<Scalar>>& q,
+    const RigidBodyTree<double>* tree) {
+  if ((q.size() != last_q_.size()) || (q != last_q_) || (last_tree_ != tree)) {
+    last_q_ = q;
+    last_tree_ = tree;
+    kinsol_.initialize(q);
+    tree->doKinematics(kinsol_);
+  }
+  return kinsol_;
+}
+
+// Explicitly instantiates on the most common scalar types.
+template class KinematicsCacheHelper<double>;
+template class KinematicsCacheHelper<AutoDiffXd>;
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake

--- a/multibody/kinematics_cache_helper.cc
+++ b/multibody/kinematics_cache_helper.cc
@@ -37,6 +37,9 @@ KinematicsCacheWithVHelper<Scalar>::KinematicsCacheWithVHelper(
 template <typename Scalar>
 KinematicsCache<Scalar>& KinematicsCacheWithVHelper<Scalar>::UpdateKinematics(
     const Eigen::Ref<const VectorX<Scalar>>& q) {
+  if (last_v_.rows() == 0) {
+    throw std::runtime_error("last_v_ is not set yet.");
+  }
   return UpdateKinematics(q, last_v_);
 }
 

--- a/multibody/kinematics_cache_helper.cc
+++ b/multibody/kinematics_cache_helper.cc
@@ -9,7 +9,7 @@ template <typename Scalar>
 KinematicsCacheHelper<Scalar>::KinematicsCacheHelper(
     const RigidBodyTree<double>& tree)
     : last_tree_{nullptr},
-      kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
+      kinematics_cache_(tree.CreateKinematicsCacheWithType<Scalar>()) {
   last_q_.resize(0);
 }
 
@@ -20,27 +20,19 @@ KinematicsCache<Scalar>& KinematicsCacheHelper<Scalar>::UpdateKinematics(
   if ((q.size() != last_q_.size()) || (q != last_q_) || (last_tree_ != tree)) {
     last_q_ = q;
     last_tree_ = tree;
-    kinsol_.initialize(q);
-    tree->doKinematics(kinsol_);
+    kinematics_cache_.initialize(q);
+    tree->doKinematics(kinematics_cache_);
   }
-  return kinsol_;
+  return kinematics_cache_;
 }
 
 template <typename Scalar>
 KinematicsCacheWithVHelper<Scalar>::KinematicsCacheWithVHelper(
     const RigidBodyTree<double>& tree)
-    : tree_{&tree}, kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
+    : tree_{&tree},
+      kinematics_cache_(tree.CreateKinematicsCacheWithType<Scalar>()) {
   last_q_.resize(0);
   last_v_.resize(0);
-}
-
-template <typename Scalar>
-KinematicsCache<Scalar>& KinematicsCacheWithVHelper<Scalar>::UpdateKinematics(
-    const Eigen::Ref<const VectorX<Scalar>>& q) {
-  if (last_v_.rows() == 0) {
-    throw std::runtime_error("last_v_ is not set yet.");
-  }
-  return UpdateKinematics(q, last_v_);
 }
 
 template <typename Scalar>
@@ -51,10 +43,10 @@ KinematicsCache<Scalar>& KinematicsCacheWithVHelper<Scalar>::UpdateKinematics(
       v.size() != last_v_.size() || v != last_v_) {
     last_q_ = q;
     last_v_ = v;
-    kinsol_.initialize(q, v);
-    tree_->doKinematics(kinsol_, true);  // compute Jdotv
+    kinematics_cache_.initialize(q, v);
+    tree_->doKinematics(kinematics_cache_, true);  // compute Jdotv
   }
-  return kinsol_;
+  return kinematics_cache_;
 }
 
 // Explicitly instantiates on the most common scalar types.

--- a/multibody/kinematics_cache_helper.cc
+++ b/multibody/kinematics_cache_helper.cc
@@ -10,7 +10,7 @@ KinematicsCacheHelper<Scalar>::KinematicsCacheHelper(
     const RigidBodyTree<double>& tree)
     : last_tree_{nullptr},
       kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
-      last_q_.resize(0);
+  last_q_.resize(0);
 }
 
 template <typename Scalar>
@@ -26,9 +26,40 @@ KinematicsCache<Scalar>& KinematicsCacheHelper<Scalar>::UpdateKinematics(
   return kinsol_;
 }
 
+template <typename Scalar>
+KinematicsCacheWithVHelper<Scalar>::KinematicsCacheWithVHelper(
+    const RigidBodyTree<double>& tree)
+    : tree_{&tree}, kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
+  last_q_.resize(0);
+  last_v_.resize(0);
+}
+
+template <typename Scalar>
+KinematicsCache<Scalar>& KinematicsCacheWithVHelper<Scalar>::UpdateKinematics(
+    const Eigen::Ref<const VectorX<Scalar>>& q) {
+  return UpdateKinematics(q, last_v_);
+}
+
+template <typename Scalar>
+KinematicsCache<Scalar>& KinematicsCacheWithVHelper<Scalar>::UpdateKinematics(
+    const Eigen::Ref<const VectorX<Scalar>>& q,
+    const Eigen::Ref<const VectorX<Scalar>>& v) {
+  if (q.size() != last_q_.size() || q != last_q_ ||
+      v.size() != last_v_.size() || v != last_v_) {
+    last_q_ = q;
+    last_v_ = v;
+    kinsol_.initialize(q, v);
+    tree_->doKinematics(kinsol_, true);  // compute Jdotv
+  }
+  return kinsol_;
+}
+
 // Explicitly instantiates on the most common scalar types.
 template class KinematicsCacheHelper<double>;
 template class KinematicsCacheHelper<AutoDiffXd>;
+
+template class KinematicsCacheWithVHelper<double>;
+template class KinematicsCacheWithVHelper<AutoDiffXd>;
 }  // namespace plants
 }  // namespace systems
 }  // namespace drake

--- a/multibody/kinematics_cache_helper.h
+++ b/multibody/kinematics_cache_helper.h
@@ -45,6 +45,24 @@ class KinematicsCacheWithVHelper {
    */
   explicit KinematicsCacheWithVHelper(const RigidBodyTree<double>& tree);
 
+  /**
+   * Only updates the position q, but leave velocity v unchanged as the last
+   * velocity passed in.
+   * @throw a runtime_error if last_v_ is unset.
+   * Note that by updating only q, KinematicsCacheWithVHelper behaves similarly
+   * to KinematicsCachHelper, without updating v. The reason we provide this
+   * functionality is that it is possible that we might need to evaluate
+   * some kinematic result both with and without v, for example in manipulator
+   * equation
+   * Mv̇+c = Bu + Jᵀλ
+   * The coriolis term c requires kinematics information with both q and v,
+   * while the Jacobian J might only need the position q. To avoid providing
+   * two helpers for this evaluator, one with v and one without, we can choose
+   * to provide a single helper with both q and v, and update only q when
+   * computing the Jacobian J. This trick avoids the redundant computation for
+   * calling doKinematics for twice, if we were to use two kinematics cache
+   * helpers, one with v and the other without.
+   */
   KinematicsCache<Scalar>& UpdateKinematics(
       const Eigen::Ref<const VectorX<Scalar>>& q);
 

--- a/multibody/kinematics_cache_helper.h
+++ b/multibody/kinematics_cache_helper.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace systems {
+namespace plants {
+/// Helper class to avoid recalculating a kinematics cache which is
+/// going to be used repeatedly by multiple other classes.
+template <typename Scalar>
+class KinematicsCacheHelper {
+ public:
+  explicit KinematicsCacheHelper(const RigidBodyTree<double>& tree);
+
+  KinematicsCache<Scalar>& UpdateKinematics(
+      const Eigen::Ref<const VectorX<Scalar>>& q,
+      const RigidBodyTree<double>* tree);
+
+ private:
+  VectorX<Scalar> last_q_;
+  const RigidBodyTree<double>* last_tree_;
+  KinematicsCache<Scalar> kinsol_;
+};
+
+/**
+ * Stores and updates the kinematics cache for the rigid body tree. 
+ */
+template <typename Scalar>
+class KinematicsCacheWithVHelper {
+ public:
+  explicit KinematicsCacheWithVHelper(const RigidBodyTree<double>& tree)
+      : tree_{&tree}, kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
+    last_q_.resize(0);
+    last_v_.resize(0);
+  }
+
+  KinematicsCache<Scalar>& UpdateKinematics(
+      const Eigen::Ref<const VectorX<Scalar>>& q) {
+    if (q.size() != last_q_.size() || q != last_q_) {
+      last_q_ = q;
+      kinsol_.initialize(q, last_v_);
+      tree_->doKinematics(kinsol_, true);  // compute Jdotv
+    }
+    return kinsol_;
+  }
+
+ private:
+  const RigidBodyTree<double>* tree_;
+  VectorX<Scalar> last_q_;
+  VectorX<Scalar> last_v_;
+  KinematicsCache<Scalar> kinsol_;
+};
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake
+

--- a/multibody/kinematics_cache_helper.h
+++ b/multibody/kinematics_cache_helper.h
@@ -13,6 +13,11 @@ namespace plants {
 template <typename Scalar>
 class KinematicsCacheHelper {
  public:
+  /**
+   * Construct a cache for a tree.
+   * @param tree tree is aliased and needs to live for the lifetime of the
+   * object.
+   */
   explicit KinematicsCacheHelper(const RigidBodyTree<double>& tree);
 
   KinematicsCache<Scalar>& UpdateKinematics(
@@ -26,26 +31,26 @@ class KinematicsCacheHelper {
 };
 
 /**
- * Stores and updates the kinematics cache for the rigid body tree. 
+ * Stores and updates the kinematics cache for the rigid body tree.
  */
 template <typename Scalar>
 class KinematicsCacheWithVHelper {
  public:
-  explicit KinematicsCacheWithVHelper(const RigidBodyTree<double>& tree)
-      : tree_{&tree}, kinsol_(tree.CreateKinematicsCacheWithType<Scalar>()) {
-    last_q_.resize(0);
-    last_v_.resize(0);
-  }
+  /**
+   * Construct a cache for a tree.
+   * The kinematics information includes the pose and spatial velocity, w.r.t
+   * q, v. And Jdotv is computed.
+   * @param tree tree is aliased and needs to live for the lifetime of the
+   * object.
+   */
+  explicit KinematicsCacheWithVHelper(const RigidBodyTree<double>& tree);
 
   KinematicsCache<Scalar>& UpdateKinematics(
-      const Eigen::Ref<const VectorX<Scalar>>& q) {
-    if (q.size() != last_q_.size() || q != last_q_) {
-      last_q_ = q;
-      kinsol_.initialize(q, last_v_);
-      tree_->doKinematics(kinsol_, true);  // compute Jdotv
-    }
-    return kinsol_;
-  }
+      const Eigen::Ref<const VectorX<Scalar>>& q);
+
+  KinematicsCache<Scalar>& UpdateKinematics(
+      const Eigen::Ref<const VectorX<Scalar>>& q,
+      const Eigen::Ref<const VectorX<Scalar>>& v);
 
  private:
   const RigidBodyTree<double>* tree_;
@@ -56,4 +61,3 @@ class KinematicsCacheWithVHelper {
 }  // namespace plants
 }  // namespace systems
 }  // namespace drake
-

--- a/multibody/kinematics_cache_helper.h
+++ b/multibody/kinematics_cache_helper.h
@@ -27,7 +27,7 @@ class KinematicsCacheHelper {
  private:
   VectorX<Scalar> last_q_;
   const RigidBodyTree<double>* last_tree_;
-  KinematicsCache<Scalar> kinsol_;
+  KinematicsCache<Scalar> kinematics_cache_;
 };
 
 /**
@@ -45,27 +45,6 @@ class KinematicsCacheWithVHelper {
    */
   explicit KinematicsCacheWithVHelper(const RigidBodyTree<double>& tree);
 
-  /**
-   * Only updates the position q, but leave velocity v unchanged as the last
-   * velocity passed in.
-   * @throw a runtime_error if last_v_ is unset.
-   * Note that by updating only q, KinematicsCacheWithVHelper behaves similarly
-   * to KinematicsCachHelper, without updating v. The reason we provide this
-   * functionality is that it is possible that we might need to evaluate
-   * some kinematic result both with and without v, for example in manipulator
-   * equation
-   * Mv̇+c = Bu + Jᵀλ
-   * The coriolis term c requires kinematics information with both q and v,
-   * while the Jacobian J might only need the position q. To avoid providing
-   * two helpers for this evaluator, one with v and one without, we can choose
-   * to provide a single helper with both q and v, and update only q when
-   * computing the Jacobian J. This trick avoids the redundant computation for
-   * calling doKinematics for twice, if we were to use two kinematics cache
-   * helpers, one with v and the other without.
-   */
-  KinematicsCache<Scalar>& UpdateKinematics(
-      const Eigen::Ref<const VectorX<Scalar>>& q);
-
   KinematicsCache<Scalar>& UpdateKinematics(
       const Eigen::Ref<const VectorX<Scalar>>& q,
       const Eigen::Ref<const VectorX<Scalar>>& v);
@@ -74,7 +53,7 @@ class KinematicsCacheWithVHelper {
   const RigidBodyTree<double>* tree_;
   VectorX<Scalar> last_q_;
   VectorX<Scalar> last_v_;
-  KinematicsCache<Scalar> kinsol_;
+  KinematicsCache<Scalar> kinematics_cache_;
 };
 }  // namespace plants
 }  // namespace systems


### PR DESCRIPTION
I find I need `KinematicsCacheHelper` in trajectory optimization. In this PR, I did three things
1. Move `KinematicsCacheHelper` to a separate file, and build it to a standalone target.
2. Instantiate `KinematicsCacheHelper` with `AutoDiffXd`. This is because in trajectory optimization, we need to compute the gradient of Jᵀλ w.r.t q. Thus we need to compute the Jacobian `J ` using `AutoDiffXd`.
3. Add another class `KinematicsCacheWithVHelper`, which compute a `KinematicsCache` with both position `q` and velocity `v`. This is used when we compute the gradient of the dynamics, for example, the gradient of the mass matrix or the Coriolis force.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7978)
<!-- Reviewable:end -->
