### PR TITLE
Fix misnamed method get_num_abstract_state_groups() -> _abstract_states()

### DIFF
--- a/automotive/idm_controller.cc
+++ b/automotive/idm_controller.cc
@@ -104,7 +104,7 @@ void IdmController<T>::CalcAcceleration(
   // Obtain the state if we've allocated it.
   RoadPosition ego_rp;
   if (context.template get_state().get_abstract_state().size() != 0) {
-    DRAKE_ASSERT(context.get_num_abstract_state_groups() == 1);
+    DRAKE_ASSERT(context.get_num_abstract_states() == 1);
     ego_rp = context.template get_abstract_state<RoadPosition>(0);
   }
 
@@ -164,7 +164,7 @@ void IdmController<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
-  DRAKE_ASSERT(context.get_num_abstract_state_groups() == 1);
+  DRAKE_ASSERT(context.get_num_abstract_states() == 1);
 
   // Obtain the input and state data.
   const PoseVector<T>* const ego_pose =

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -120,7 +120,7 @@ void MobilPlanner<T>::CalcLaneDirection(const systems::Context<T>& context,
   // Obtain the state if we've allocated it.
   RoadPosition ego_rp;
   if (context.template get_state().get_abstract_state().size() != 0) {
-    DRAKE_ASSERT(context.get_num_abstract_state_groups() == 1);
+    DRAKE_ASSERT(context.get_num_abstract_states() == 1);
     ego_rp = context.template get_abstract_state<RoadPosition>(0);
   }
 
@@ -302,7 +302,7 @@ void MobilPlanner<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
-  DRAKE_ASSERT(context.get_num_abstract_state_groups() == 1);
+  DRAKE_ASSERT(context.get_num_abstract_states() == 1);
 
   // Obtain the input and state data.
   const PoseVector<T>* const ego_pose =

--- a/automotive/test/idm_controller_test.cc
+++ b/automotive/test/idm_controller_test.cc
@@ -138,7 +138,7 @@ TEST_P(IdmControllerTest, Topology) {
 // state are correctly made.
 TEST_P(IdmControllerTest, UnrestrictedUpdate) {
   if (cache_or_search_ == RoadPositionStrategy::kCache) {
-    EXPECT_EQ(1, context_->get_num_abstract_state_groups());
+    EXPECT_EQ(1, context_->get_num_abstract_states());
 
     SetDefaultPoses(10. /* ego_speed */, 0. /* s_offset */, -5. /* rel_sdot */);
 

--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -210,7 +210,7 @@ TEST_P(MobilPlannerTest, UnrestrictedUpdate) {
   InitializeMobilPlanner(true /* initial_with_s */);
 
   if (cache_or_search_ == RoadPositionStrategy::kCache) {
-    EXPECT_EQ(1, context_->get_num_abstract_state_groups());
+    EXPECT_EQ(1, context_->get_num_abstract_states());
 
     // Arrange the ego car in the right lane with a traffic car placed
     // arbitrarily.

--- a/systems/controllers/linear_model_predictive_controller.cc
+++ b/systems/controllers/linear_model_predictive_controller.cc
@@ -43,7 +43,7 @@ LinearModelPredictiveController<T>::LinearModelPredictiveController(
   const auto model_context = model_->CreateDefaultContext();
   DRAKE_DEMAND(model_context->get_num_discrete_state_groups() == 1);
   DRAKE_DEMAND(model_context->get_continuous_state().size() == 0);
-  DRAKE_DEMAND(model_context->get_num_abstract_state_groups() == 0);
+  DRAKE_DEMAND(model_context->get_num_abstract_states() == 0);
   DRAKE_DEMAND(model_->get_num_input_ports() == 1);
   DRAKE_DEMAND(model_->get_num_output_ports() == 1);
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -63,7 +63,7 @@ class Context {
   bool is_stateless() const {
     const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_state_groups();
+    const int nxa = get_num_abstract_states();
     return nxc == 0 && nxd == 0 && nxa == 0;
   }
 
@@ -72,7 +72,7 @@ class Context {
   bool has_only_continuous_state() const {
     const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_state_groups();
+    const int nxa = get_num_abstract_states();
     return nxc > 0 && nxd == 0 && nxa == 0;
   }
 
@@ -81,7 +81,7 @@ class Context {
   bool has_only_discrete_state() const {
     const int nxc = get_continuous_state().size();
     const int nxd = get_num_discrete_state_groups();
-    const int nxa = get_num_abstract_state_groups();
+    const int nxa = get_num_abstract_states();
     return nxd > 0 && nxc == 0 && nxa == 0;
   }
 
@@ -89,7 +89,7 @@ class Context {
   /// were muxed).
   /// @throws std::runtime_error if the system contains any abstract state.
   int get_num_total_states() const {
-    DRAKE_THROW_UNLESS(get_num_abstract_state_groups() == 0);
+    DRAKE_THROW_UNLESS(get_num_abstract_states() == 0);
     int count = get_continuous_state().size();
     for (int i = 0; i < get_num_discrete_state_groups(); i++)
       count += get_discrete_state(i).size();
@@ -166,7 +166,7 @@ class Context {
   }
 
   /// Returns the number of elements in the abstract state.
-  int get_num_abstract_state_groups() const {
+  int get_num_abstract_states() const {
     return get_state().get_abstract_state().size();
   }
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -179,13 +179,13 @@ class System {
     // not change.
     const int n_xc = context->get_continuous_state().size();
     const int n_xd = context->get_num_discrete_state_groups();
-    const int n_xa = context->get_num_abstract_state_groups();
+    const int n_xa = context->get_num_abstract_states();
 
     SetDefaultState(*context, &context->get_mutable_state());
 
     DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
     DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
-    DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
+    DRAKE_DEMAND(n_xa == context->get_num_abstract_states());
 
     // Set the default parameters, checking that the number of parameters does
     // not change.
@@ -236,13 +236,13 @@ class System {
     // not change.
     const int n_xc = context->get_continuous_state().size();
     const int n_xd = context->get_num_discrete_state_groups();
-    const int n_xa = context->get_num_abstract_state_groups();
+    const int n_xa = context->get_num_abstract_states();
 
     SetRandomState(*context, &context->get_mutable_state(), generator);
 
     DRAKE_DEMAND(n_xc == context->get_continuous_state().size());
     DRAKE_DEMAND(n_xd == context->get_num_discrete_state_groups());
-    DRAKE_DEMAND(n_xa == context->get_num_abstract_state_groups());
+    DRAKE_DEMAND(n_xa == context->get_num_abstract_states());
 
     // Set the default parameters, checking that the number of parameters does
     // not change.

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -152,7 +152,7 @@ bool SystemSymbolicInspector::IsAbstract(
 
   // If there is any abstract state or parameters, we cannot do sparsity
   // analysis of this Context.
-  if (context.get_num_abstract_state_groups() > 0) {
+  if (context.get_num_abstract_states() > 0) {
     return true;
   }
   if (context.num_abstract_parameters() > 0) {

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -175,8 +175,8 @@ TEST_F(LeafContextTest, GetNumDiscreteStateGroups) {
   EXPECT_EQ(2, context_.get_num_discrete_state_groups());
 }
 
-TEST_F(LeafContextTest, GetNumAbstractStateGroups) {
-  EXPECT_EQ(1, context_.get_num_abstract_state_groups());
+TEST_F(LeafContextTest, GetNumAbstractStates) {
+  EXPECT_EQ(1, context_.get_num_abstract_states());
 }
 
 TEST_F(LeafContextTest, IsStateless) {

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -64,7 +64,7 @@ class VectorSystem : public LeafSystem<T> {
     DRAKE_DEMAND(result->get_num_input_ports() <= 1);
 
     // At most one of either continuous xor discrete state.
-    DRAKE_THROW_UNLESS(result->get_num_abstract_state_groups() == 0);
+    DRAKE_THROW_UNLESS(result->get_num_abstract_states() == 0);
     const int continuous_size = result->get_continuous_state().size();
     const int num_discrete_groups = result->get_num_discrete_state_groups();
     DRAKE_DEMAND(continuous_size >= 0);
@@ -128,7 +128,7 @@ class VectorSystem : public LeafSystem<T> {
   Eigen::VectorBlock<const VectorX<T>> GetVectorState(
       const Context<T>& context) const {
     // Obtain the block form of xc or xd.
-    DRAKE_ASSERT(context.get_num_abstract_state_groups() == 0);
+    DRAKE_ASSERT(context.get_num_abstract_states() == 0);
     const BasicVector<T>* state_vector{};
     if (context.get_num_discrete_state_groups() == 0) {
       const VectorBase<T>& vector_base = context.get_continuous_state_vector();


### PR DESCRIPTION
The Context API method `get_num_abstract_state_groups()` was a copy-pasta error from discrete state groups. Abstract states don't come in groups.

This PR renames the method to `get_num_abstract_states()`.

Q: should I deprecate the old method or is it OK to nuke it entirely as I've done here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7985)
<!-- Reviewable:end -->
