### PR TITLE
Rename virtual LeafSystem::DoMakeContext() to DoMakeLeafContext()

### DIFF
--- a/examples/multibody/acrobot/acrobot_plant.cc
+++ b/examples/multibody/acrobot/acrobot_plant.cc
@@ -311,7 +311,7 @@ void AcrobotPlant<T>::RegisterGeometry(
 
 template<typename T>
 std::unique_ptr<systems::LeafContext<T>>
-AcrobotPlant<T>::DoMakeContext() const {
+AcrobotPlant<T>::DoMakeLeafContext() const {
   return std::make_unique<MultibodyTreeContext<T>>(model_->get_topology());
 }
 

--- a/examples/multibody/acrobot/acrobot_plant.h
+++ b/examples/multibody/acrobot/acrobot_plant.h
@@ -159,7 +159,7 @@ class AcrobotPlant final : public systems::LeafSystem<T> {
 
   // This override gives System::AllocateContext() the chance to create a more
   // specialized context type, in this case, a MultibodyTreeContext.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,

--- a/examples/multibody/pendulum/pendulum_plant.cc
+++ b/examples/multibody/pendulum/pendulum_plant.cc
@@ -237,7 +237,7 @@ void PendulumPlant<T>::RegisterGeometry(
 
 template<typename T>
 std::unique_ptr<systems::LeafContext<T>>
-PendulumPlant<T>::DoMakeContext() const {
+PendulumPlant<T>::DoMakeLeafContext() const {
   return model_->CreateDefaultContext();
 }
 

--- a/examples/multibody/pendulum/pendulum_plant.h
+++ b/examples/multibody/pendulum/pendulum_plant.h
@@ -115,7 +115,7 @@ class PendulumPlant final : public systems::LeafSystem<T> {
 
   // Override of context construction so that we can delegate it to
   // MultibodyTree.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   void DoCalcTimeDerivatives(
       const systems::Context<T>& context,

--- a/geometry/geometry_system.cc
+++ b/geometry/geometry_system.cc
@@ -337,7 +337,7 @@ void GeometrySystem<T>::FullPoseUpdate(
 }
 
 template <typename T>
-std::unique_ptr<LeafContext<T>> GeometrySystem<T>::DoMakeContext() const {
+std::unique_ptr<LeafContext<T>> GeometrySystem<T>::DoMakeLeafContext() const {
   // Disallow further geometry source additions.
   initial_state_ = nullptr;
   DRAKE_ASSERT(geometry_state_index_ >= 0);

--- a/geometry/geometry_system.h
+++ b/geometry/geometry_system.h
@@ -434,7 +434,7 @@ class GeometrySystem final : public systems::LeafSystem<T> {
   //    - instantiating a GeometryContext instance (as opposed to LeafContext),
   //    - to detect allocation in support of the topology semantics described
   //      above.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   // Helper method for throwing an exception if a context has *ever* been
   // allocated by this system. The invoking method should pass it's name so

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -44,7 +44,7 @@ void MultibodyPlant<T>::Finalize() {
 
 template<typename T>
 std::unique_ptr<systems::LeafContext<T>>
-MultibodyPlant<T>::DoMakeContext() const {
+MultibodyPlant<T>::DoMakeLeafContext() const {
   DRAKE_THROW_UNLESS(is_finalized());
   return std::make_unique<MultibodyTreeContext<T>>(model_->get_topology());
 }

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -419,7 +419,7 @@ class MultibodyPlant final : public systems::LeafSystem<T> {
 
   // This override gives System::AllocateContext() the chance to create a more
   // specialized context type, in this case, a MultibodyTreeContext.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   // Implements the system dynamics according to this class's documentation.
   void DoCalcTimeDerivatives(

--- a/multibody/multibody_tree/test/free_rotating_body_plant.cc
+++ b/multibody/multibody_tree/test/free_rotating_body_plant.cc
@@ -54,7 +54,7 @@ FreeRotatingBodyPlant<T>::get_default_initial_angular_velocity() const {
 
 template<typename T>
 std::unique_ptr<systems::LeafContext<T>>
-FreeRotatingBodyPlant<T>::DoMakeContext() const {
+FreeRotatingBodyPlant<T>::DoMakeLeafContext() const {
   return model_.CreateDefaultContext();
 }
 

--- a/multibody/multibody_tree/test/free_rotating_body_plant.h
+++ b/multibody/multibody_tree/test/free_rotating_body_plant.h
@@ -75,7 +75,7 @@ class FreeRotatingBodyPlant final : public systems::LeafSystem<T> {
  private:
   // Override of context construction so that we can delegate it to
   // MultibodyTree.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeContext() const override;
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   void DoCalcTimeDerivatives(
       const systems::Context<T> &context,

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -118,7 +118,7 @@ class LeafSystem : public System<T> {
   /// @endcond
 
   std::unique_ptr<Context<T>> AllocateContext() const override {
-    std::unique_ptr<LeafContext<T>> context = DoMakeContext();
+    std::unique_ptr<LeafContext<T>> context = DoMakeLeafContext();
     // Reserve inputs that have already been declared.
     context->SetNumInputPorts(this->get_num_input_ports());
     // Reserve continuous state via delegation to subclass.
@@ -303,7 +303,7 @@ class LeafSystem : public System<T> {
   // classes do *not* add new data members. If that changes, e.g., with the
   // advent of the cache, this documentation should be changed to include the
   // initialization of the sub-class's *unique* data members.
-  virtual std::unique_ptr<LeafContext<T>> DoMakeContext() const {
+  virtual std::unique_ptr<LeafContext<T>> DoMakeLeafContext() const {
     return std::make_unique<LeafContext<T>>();
   }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1354,7 +1354,7 @@ class CustomContext : public LeafContext<T> {};
 template <typename T>
 class CustomContextSystem : public LeafSystem<T> {
  protected:
-  std::unique_ptr<LeafContext<T>> DoMakeContext() const override {
+  std::unique_ptr<LeafContext<T>> DoMakeLeafContext() const override {
     return std::make_unique<CustomContext<T>>();
   }
 };


### PR DESCRIPTION
Caching introduces some additional abstraction so that DoMakeContext() doesn't apply only to leaf contexts. The user-overrideable method needs a more specific name. I want to make this change first in this teeny PR because it will reduce the number of ancillary file changes in subsequent caching PRs.

This is a protected method and rarely overridden since the default implementation provides a generic LeafContext that is almost always all that's needed.

[Here](https://github.com/sherm1/drake/blob/caching/systems/framework/system_base.h#L649) is the more-general DoMakeContext() in the caching branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7986)
<!-- Reviewable:end -->
