### PR TITLE
Add python bindings needed for caching branch

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -60,6 +60,7 @@ drake_pybind_library(
         ":systems_pybind",
         "//bindings/pydrake/util:drake_optional_pybind",
         "//bindings/pydrake/util:eigen_pybind",
+        "//bindings/pydrake/util:type_safe_index_pybind",
     ],
     cc_so_name = "framework",
     cc_srcs = ["framework_py.cc"],

--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
 #include "drake/bindings/pydrake/util/drake_optional_pybind.h"
 #include "drake/bindings/pydrake/util/eigen_pybind.h"
+#include "drake/bindings/pydrake/util/type_safe_index_pybind.h"
 #include "drake/systems/framework/abstract_values.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
@@ -242,6 +243,16 @@ PYBIND11_MODULE(framework, m) {
   py::enum_<PortDataType>(m, "PortDataType")
     .value("kVectorValued", kVectorValued)
     .value("kAbstractValued", kAbstractValued);
+
+  BindTypeSafeIndex<DependencyTicket>(m, "DependencyTicket");
+  BindTypeSafeIndex<CacheIndex>(m, "CacheIndex");
+  BindTypeSafeIndex<SubsystemIndex>(m, "SubsystemIndex");
+  BindTypeSafeIndex<InputPortIndex>(m, "InputPortIndex");
+  BindTypeSafeIndex<OutputPortIndex>(m, "OutputPortIndex");
+  BindTypeSafeIndex<DiscreteStateIndex>(m, "DiscreteStateIndex");
+  BindTypeSafeIndex<AbstractStateIndex>(m, "AbstractStateIndex");
+  BindTypeSafeIndex<NumericParameterIndex>(m, "NumericParameterIndex");
+  BindTypeSafeIndex<AbstractParameterIndex>(m, "AbstractParameterIndex");
 
   // TODO(eric.cousineau): Show constructor, but somehow make sure `pybind11`
   // knows this is abstract?

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -134,6 +134,11 @@ drake_cc_library(
     hdrs = ["drake_optional_pybind.h"],
 )
 
+drake_cc_library(
+    name = "type_safe_index_pybind",
+    hdrs = ["type_safe_index_pybind.h"],
+)
+
 PY_LIBRARIES_WITH_INSTALL = [
     ":eigen_geometry_py",
 ]
@@ -252,6 +257,14 @@ drake_py_test(
     deps = [
         ":eigen_geometry_py",
         ":eigen_geometry_test_util_py",
+    ],
+)
+
+drake_pybind_cc_googletest(
+    name = "type_safe_index_pybind_test",
+    cc_deps = [
+        ":type_safe_index_pybind",
+        "//common:nice_type_name",
     ],
 )
 

--- a/bindings/pydrake/util/test/type_safe_index_pybind_test.cc
+++ b/bindings/pydrake/util/test/type_safe_index_pybind_test.cc
@@ -1,0 +1,89 @@
+#include "drake/bindings/pydrake/util/type_safe_index_pybind.h"
+
+// @file
+// Tests the behavior of `type_safe_index_pybind.h`.
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <pybind11/embed.h>
+#include <pybind11/eval.h>
+#include <pybind11/pybind11.h>
+
+using std::string;
+using std::vector;
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+template <typename T>
+void CheckValue(const string& expr, const T& expected) {
+  EXPECT_EQ(py::eval(expr).cast<T>(), expected);
+}
+
+GTEST_TEST(TypeSafeIndexTest, CheckCasting) {
+  py::module m("__main__");
+
+  struct Tag {};
+  using Index = TypeSafeIndex<Tag>;
+  BindTypeSafeIndex<Index>(m, "Index");
+
+  m.def("pass_thru_int", [](int x) {
+    EXPECT_EQ(x, 10);
+    return x;
+  });
+  CheckValue("pass_thru_int(10)", 10);
+  CheckValue("pass_thru_int(Index(10))", 10);
+  // TypeSafeIndex<> is not implicitly constructible from an int.
+  py::object py_int = py::eval("10");
+  ASSERT_THROW(
+      py_int.cast<Index>(),
+      std::runtime_error);
+
+  m.def("pass_thru_index", [](Index x) {
+    EXPECT_EQ(x, 10);
+    return x;
+  });
+  // TypeSafeIndex<> is not implicitly constructible from an int.
+  // TODO(eric.cousineau): Consider relaxing this to *only* accept `int`s, and
+  // puke if another `TypeSafeIndex<U>` is encountered.
+  ASSERT_THROW(
+      py::eval("pass_thru_index(10)"),
+      std::runtime_error);
+  CheckValue("pass_thru_index(Index(10))", 10);
+  CheckValue("pass_thru_index(Index(10))", Index{10});
+
+  struct OtherTag {};
+  using OtherIndex = TypeSafeIndex<OtherTag>;
+  BindTypeSafeIndex<OtherIndex>(m, "OtherIndex");
+
+  ASSERT_THROW(
+      py::eval("pass_thru_index(OtherIndex(10))"),
+      std::runtime_error);
+  py::object py_index = py::eval("Index(10)");
+  ASSERT_THROW(
+      py_index.cast<OtherIndex>(),
+      std::runtime_error);
+
+  CheckValue("Index(10) == Index(10)", true);
+  CheckValue("Index(10) == 10", true);
+  CheckValue("10 == Index(10)", true);
+}
+
+int main(int argc, char** argv) {
+  // Reconstructing `scoped_interpreter` multiple times (e.g. via `SetUp()`)
+  // while *also* importing `numpy` wreaks havoc.
+  py::scoped_interpreter guard;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace
+}  // namespace pydrake
+}  // namespace drake
+
+int main(int argc, char** argv) {
+  return drake::pydrake::main(argc, argv);
+}

--- a/bindings/pydrake/util/type_safe_index_pybind.h
+++ b/bindings/pydrake/util/type_safe_index_pybind.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/common/type_safe_index.h"
+
+namespace drake {
+namespace pydrake {
+
+/// Binds a TypeSafeIndex instantiation.
+template <typename Type>
+auto BindTypeSafeIndex(py::module m, const std::string& name) {
+  py::class_<Type> cls(m, name.c_str());
+  cls
+    .def(py::init<int>())
+    .def("__int__", &Type::operator int)
+    .def("__eq__", [](const Type* self, const Type* other) {
+      return *self == *other;
+    }, py::is_operator())
+    .def("__eq__", [](const Type* self, int other) {
+      return *self == other;
+    }, py::is_operator())
+    // TODO(eric.cousineau): Add more operators.
+    .def("is_valid", &Type::is_valid);
+  return cls;
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/common/type_safe_index.h
+++ b/common/type_safe_index.h
@@ -160,7 +160,7 @@ class TypeSafeIndex {
 
   /// Disallow construction from another index type.
   template <typename U>
-  TypeSafeIndex( const TypeSafeIndex<U>& idx) = delete;
+  TypeSafeIndex(const TypeSafeIndex<U>& idx) = delete;
 
   TypeSafeIndex(const TypeSafeIndex&) = default;
 

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -10,14 +10,51 @@ namespace systems {
 // the same meaning in both class hierarchies. A System and its Context always
 // have parallel internal structure.
 
+// TODO(sherm1) Reveal these when they are used.
+#ifndef DRAKE_DOXYGEN_CXX
+/** Identifies a particular source value or computation for purposes of
+declaring and managing dependencies. Unique only within a given subsystem
+and its corresponding subcontext. */
+// This is presented as an ID to end users but is implemented internally as
+// a typed integer index for fast access into the std::vector of dependency
+// trackers. That's why it is named differently than the other "indexes".
+using DependencyTicket = TypeSafeIndex<class DependencyTag>;
+
+/** Serves as a unique identifier for a particular CacheEntry in a System and
+the corresponding CacheEntryValue in that System's Context. This is an index
+providing extremely fast constant-time access to both. */
+using CacheIndex = TypeSafeIndex<class CacheTag>;
+
 /** Serves as a local index for a child subsystem within a parent
 Diagram, or a child subcontext within a parent DiagramContext. A subsystem and
 its matching subcontext have the same %SubsystemIndex. Unique only
 within a given subsystem or subcontext. */
-// TODO(sherm1) Use this.
 using SubsystemIndex = TypeSafeIndex<class SubsystemIndexTag>;
 
-constexpr int kAutoSize = -1;
+/** Serves as the local index for the input ports of a given System. The
+indexes used by a subsystem and its corresponding subcontext are the same. */
+using InputPortIndex = TypeSafeIndex<class InputPortTag>;
+
+/** Serves as the local index for the output ports of a given System. The
+indexes used by a subsystem and its corresponding subcontext are the same. */
+using OutputPortIndex = TypeSafeIndex<class OutputPortTag>;
+
+/** Serves as the local index for discrete state groups within a given System
+and its corresponding Context. */
+using DiscreteStateIndex = TypeSafeIndex<class DiscreteStateTag>;
+
+/** Serves as the local index for abstract state variables within a given System
+and its corresponding Context. */
+using AbstractStateIndex = TypeSafeIndex<class AbstractStateTag>;
+
+/** Serves as the local index for numeric parameter groups within a given System
+and its corresponding Context. */
+using NumericParameterIndex = TypeSafeIndex<class NumericParameterTag>;
+
+/** Serves as the local index for abstract parameters within a given System
+and its corresponding Context. */
+using AbstractParameterIndex = TypeSafeIndex<class AbstractParameterTag>;
+#endif
 
 /** All system ports are either vectors of Eigen scalars, or black-box
 AbstractValues which may contain any type. */
@@ -25,6 +62,11 @@ typedef enum {
   kVectorValued = 0,
   kAbstractValued = 1,
 } PortDataType;
+
+/** Port type indicating a vector value whose size is not prespecified but
+rather depends on what it is connected to (not yet implemented). */
+// TODO(sherm1) Implement this.
+constexpr int kAutoSize = -1;
 
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
This PR just extracts the Python-related changes from the caching branch to reduce the number of not-caching-related files that get included with caching.

There are some new type safe index types defined in framework_common.h, and those need wrapping. Most are unused at this point, but are harmless and will be in use shortly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7987)
<!-- Reviewable:end -->
