### PR TITLE
Expose penetration query through GeometrySystem API

### DIFF
--- a/examples/geometry_world/BUILD.bazel
+++ b/examples/geometry_world/BUILD.bazel
@@ -23,6 +23,8 @@ drake_cc_library(
     hdrs = ["bouncing_ball_plant.h"],
     deps = [
         ":bouncing_ball_vector",
+        "//geometry:geometry_ids",
+        "//geometry:geometry_system",
         "//systems/framework:leaf_system",
     ],
 )
@@ -32,11 +34,14 @@ drake_cc_binary(
     srcs = ["bouncing_ball_run_dynamics.cc"],
     deps = [
         ":bouncing_ball_plant",
+        "//geometry:geometry_system",
+        "//geometry:geometry_visualization",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/lcm",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
+        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/examples/geometry_world/bouncing_ball_plant.cc
+++ b/examples/geometry_world/bouncing_ball_plant.cc
@@ -2,35 +2,89 @@
 
 #include <algorithm>
 
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/frame_id_vector.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
+#include "drake/geometry/shape_specification.h"
+
 namespace drake {
 namespace examples {
+namespace geometry_world {
 namespace bouncing_ball {
 
+using geometry::FrameIdVector;
+using geometry::FramePoseVector;
+using geometry::GeometryFrame;
+using geometry::GeometryInstance;
+using geometry::GeometrySystem;
+using geometry::PenetrationAsPointPair;
+using geometry::SourceId;
+using geometry::Sphere;
 using systems::Context;
 using systems::Value;
 using std::make_unique;
 
 template <typename T>
-BouncingBallPlant<T>::BouncingBallPlant(const Vector2<T>& init_position)
-    : init_position_(init_position) {
+BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
+                                        GeometrySystem<T>* geometry_system,
+                                        const Vector2<double>& p_WB)
+    : source_id_(source_id), p_WB_(p_WB) {
+  DRAKE_DEMAND(geometry_system != nullptr);
+
+  geometry_query_port_ = this->DeclareAbstractInputPort().get_index();
   state_port_ =
       this->DeclareVectorOutputPort(BouncingBallVector<T>(),
                                     &BouncingBallPlant::CopyStateToOutput)
           .get_index();
+  geometry_id_port_ =
+      this->DeclareAbstractOutputPort(&BouncingBallPlant::AllocateFrameIdOutput,
+                                      &BouncingBallPlant::CalcFrameIdOutput)
+          .get_index();
+  geometry_pose_port_ = this->DeclareAbstractOutputPort(
+                                &BouncingBallPlant::AllocateFramePoseOutput,
+                                &BouncingBallPlant::CalcFramePoseOutput)
+                            .get_index();
 
-    this->DeclareContinuousState(
-      BouncingBallVector<T>(),
-      1 /* num_q */, 1 /* num_v */, 0 /* num_z */);
+  this->DeclareContinuousState(BouncingBallVector<T>(), 1 /* num_q */,
+                               1 /* num_v */, 0 /* num_z */);
   static_assert(BouncingBallVectorIndices::kNumCoordinates == 1 + 1, "");
+
+  ball_frame_id_ = geometry_system->RegisterFrame(
+      source_id, GeometryFrame("ball_frame",
+                               Isometry3<double>::Identity()));
+  ball_id_ = geometry_system->RegisterGeometry(
+      source_id, ball_frame_id_,
+      make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/
+                                    make_unique<Sphere>(diameter_ / 2.0)));
 }
 
 template <typename T>
 BouncingBallPlant<T>::~BouncingBallPlant() {}
 
 template <typename T>
+const systems::InputPortDescriptor<T>&
+BouncingBallPlant<T>::get_geometry_query_input_port() const {
+  return systems::System<T>::get_input_port(geometry_query_port_);
+}
+
+template <typename T>
 const systems::OutputPort<T>&
 BouncingBallPlant<T>::get_state_output_port() const {
   return systems::System<T>::get_output_port(state_port_);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+BouncingBallPlant<T>::get_geometry_id_output_port() const {
+  return systems::System<T>::get_output_port(geometry_id_port_);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+BouncingBallPlant<T>::get_geometry_pose_output_port() const {
+  return systems::System<T>::get_output_port(geometry_pose_port_);
 }
 
 // Updates the state output port.
@@ -39,6 +93,38 @@ void BouncingBallPlant<T>::CopyStateToOutput(
     const Context<T>& context,
     BouncingBallVector<T>* state_output_vector) const {
   state_output_vector->set_value(get_state(context).get_value());
+}
+
+template <typename T>
+FramePoseVector<T> BouncingBallPlant<T>::AllocateFramePoseOutput(
+    const Context<T>&) const {
+  FramePoseVector<T> poses(source_id_);
+  poses.mutable_vector().push_back(Isometry3<T>::Identity());
+  return poses;
+}
+
+template <typename T>
+void BouncingBallPlant<T>::CalcFramePoseOutput(
+    const Context<T>& context, FramePoseVector<T>* poses) const {
+  const BouncingBallVector<T>& state = get_state(context);
+  DRAKE_ASSERT(poses->vector().size() == 1);
+  // This assumes *no* rotation, we only need to update the translation.
+  poses->mutable_vector()[0].translation() << p_WB_(0),
+      p_WB_(1), state.z();
+  poses->mutable_vector()[0].linear() << Matrix3<T>::Identity();
+}
+
+template <typename T>
+FrameIdVector BouncingBallPlant<T>::AllocateFrameIdOutput(
+    const systems::Context<T>&) const {
+  return FrameIdVector(source_id_,
+                       std::vector<geometry::FrameId>{ball_frame_id_});
+}
+
+template <typename T>
+void BouncingBallPlant<T>::CalcFrameIdOutput(const systems::Context<T>& context,
+                                             FrameIdVector* frame_ids) const {
+  *frame_ids = AllocateFrameIdOutput(context);
 }
 
 // Compute the actual physics.
@@ -51,19 +137,34 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
   const BouncingBallVector<T>& state = get_state(context);
   BouncingBallVector<T>& derivative_vector = get_mutable_state(derivatives);
 
+  const geometry::QueryObject<T>& query_object =
+      this->EvalAbstractInput(context, geometry_query_port_)
+          ->template GetValue<geometry::QueryObject<T>>();
+
+  std::vector<PenetrationAsPointPair<T>> penetrations =
+      query_object.ComputePointPairPenetration();
+  T fC = 0;  // the contact force
+  if (penetrations.size() > 0) {
+    for (const auto& penetration : penetrations) {
+      if (penetration.id_A == ball_id_ || penetration.id_B == ball_id_) {
+        // Penetration depth, > 0 during penetration.
+        const T& x = penetration.depth;
+        // Penetration rate, > 0 implies increasing penetration.
+        const T& xdot = -state.zdot();
+
+        fC = k_ * x * (1.0 + d_ * xdot);
+      }
+    }
+  }
   derivative_vector.set_z(state.zdot());
+  const T fN = max(0.0, fC);
 
-  const T& x = -state.z();        // Penetration depth, > 0 at penetration.
-  const T& xdot = -state.zdot();  // Penetration rate, > 0 implies increasing
-                                  // penetration.
-
-  const T fN = max(0.0, k_ * x * (1.0 - d_ * xdot));
-
-  derivative_vector.set_zdot((- m_ * g_ + fN) / m_);
+  derivative_vector.set_zdot((-m_ * g_ + fN) / m_);
 }
 
 template class BouncingBallPlant<double>;
 
 }  // namespace bouncing_ball
+}  // namespace geometry_world
 }  // namespace examples
 }  // namespace drake

--- a/examples/geometry_world/bouncing_ball_plant.h
+++ b/examples/geometry_world/bouncing_ball_plant.h
@@ -1,14 +1,22 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "drake/common/drake_copyable.h"
 #include "drake/examples/geometry_world/gen/bouncing_ball_vector.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_system.h"
+#include "drake/geometry/query_object.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace examples {
+namespace geometry_world {
 namespace bouncing_ball {
 
 /** A model of a bouncing ball with Hunt-Crossley compliant contact model.
+ The model supports 1D motion in a 3D world.
 
  @tparam T The vector element type, which must be a valid Eigen scalar.
 
@@ -19,82 +27,134 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BouncingBallPlant)
 
-  explicit BouncingBallPlant(const Vector2<T>& init_position);
+  /** Constructor
+   @param source_id             The source id for this plant to interact with
+                                GeoemtrySystem.
+   @param geometry_system       Pointer to the geometry system instance on which
+                                this plant's geometry will be registered. It
+                                must be the same system the source id was
+                                extracted from.
+   @param p_WB                  The 2D, projected position vector of the ball
+                                onto the ground plane relative to the world.
+   */
+  BouncingBallPlant(geometry::SourceId source_id,
+                    geometry::GeometrySystem<T>* geometry_system,
+                    const Vector2<double>& p_WB);
   ~BouncingBallPlant() override;
 
-  using MyContext = systems::Context<T>;
-  using MyContinuousState = systems::ContinuousState<T>;
-  using MyOutput = systems::SystemOutput<T>;
-
+  const systems::InputPortDescriptor<T>& get_geometry_query_input_port() const;
   /** Returns the port to output state. */
   const systems::OutputPort<T>& get_state_output_port() const;
+  const systems::OutputPort<T>& get_geometry_id_output_port() const;
+  const systems::OutputPort<T>& get_geometry_pose_output_port() const;
 
-  void set_z(MyContext* context, const T& z) const {
+  void set_z(systems::Context<T>* context, const T& z) const {
     get_mutable_state(context).set_z(z);
   }
 
-  void set_zdot(MyContext* context, const T& zdot) const {
+  void set_zdot(systems::Context<T>* context, const T& zdot) const {
     get_mutable_state(context).set_zdot(zdot);
   }
 
   /** Mass in kg. */
-  T m() const { return m_; }
+  double m() const { return m_; }
 
-  /** Stiffness constant. */
-  T k() const {return k_; }
+  /** Stiffness constant in N/m */
+  double k() const { return k_; }
 
-  /** Hunt-Crossley's dissipation factor. */
-  T d() const {return d_; }
+  /** Hunt-Crossley's dissipation factor in s/m. */
+  double d() const { return d_; }
 
   /** Gravity in m/s^2. */
-  T g() const { return g_; }
+  double g() const { return g_; }
+
+ protected:
+  // The single input (geometry query) only impacts time derivatives and does
+  // not affect any output port. So, there are no direct feedthroughs.
+  optional<bool> DoHasDirectFeedthrough(int input_port, int) const override {
+    // This prevents addition of new input ports without revisiting this method.
+    DRAKE_THROW_UNLESS(input_port == geometry_query_port_);
+    return false;
+  }
 
  private:
   // Callback for writing the state vector to an output.
-  void CopyStateToOutput(const MyContext& context,
+  void CopyStateToOutput(const systems::Context<T>& context,
                          BouncingBallVector<T>* state_output_vector) const;
 
-  void DoCalcTimeDerivatives(const MyContext& context,
-                             MyContinuousState* derivatives) const override;
+  // Allocate the frame pose set output port value.
+  geometry::FramePoseVector<T> AllocateFramePoseOutput(
+      const systems::Context<T>& context) const;
+
+  // Calculate the frame pose set output port value.
+  void CalcFramePoseOutput(const systems::Context<T>& context,
+                           geometry::FramePoseVector<T>* poses) const;
+
+  // Allocate the id output.
+  geometry::FrameIdVector AllocateFrameIdOutput(
+      const systems::Context<T>& context) const;
+
+  // Calculate the id output.
+  void CalcFrameIdOutput(const systems::Context<T>& context,
+                         geometry::FrameIdVector* frame_ids) const;
+
+  void DoCalcTimeDerivatives(
+      const systems::Context<T>& context,
+      systems::ContinuousState<T>* derivatives) const override;
 
   static const BouncingBallVector<T>& get_state(
-      const MyContinuousState& cstate) {
+      const systems::ContinuousState<T>& cstate) {
     return dynamic_cast<const BouncingBallVector<T>&>(cstate.get_vector());
   }
 
   static BouncingBallVector<T>& get_mutable_state(
-      MyContinuousState* cstate) {
+      systems::ContinuousState<T>* cstate) {
     return dynamic_cast<BouncingBallVector<T>&>(cstate->get_mutable_vector());
   }
 
-  BouncingBallVector<T>* get_mutable_state_output(MyOutput *output) const {
+  BouncingBallVector<T>* get_mutable_state_output(
+      systems::SystemOutput<T>* output) const {
     return dynamic_cast<BouncingBallVector<T>*>(
         output->GetMutableVectorData(state_port_));
   }
 
-  static const BouncingBallVector<T>& get_state(const MyContext& context) {
+  static const BouncingBallVector<T>& get_state(
+      const systems::Context<T>& context) {
     return get_state(context.get_continuous_state());
   }
 
-  static BouncingBallVector<T>& get_mutable_state(MyContext* context) {
+  static BouncingBallVector<T>& get_mutable_state(
+      systems::Context<T>* context) {
     return get_mutable_state(&context->get_mutable_continuous_state());
   }
 
-  const Vector2<T> init_position_;
+  // This plant's source id in GeometrySystem.
+  geometry::SourceId source_id_;
+  // The projected position of the ball onto the ground plane. I.e., it's
+  // "where the ball bounces".
+  const Vector2<double> p_WB_;
+  // The id for the ball's frame.
+  geometry::FrameId ball_frame_id_;
+  // The id for the ball's geometry.
+  geometry::GeometryId ball_id_;
 
-  int state_port_;
+  int geometry_id_port_{-1};
+  int geometry_pose_port_{-1};
+  int state_port_{-1};
+  int geometry_query_port_{-1};
 
-  const double diameter_{0.1};  // Ball diameter, just for visualization.
-  const double m_{0.1};   // kg
-  const double g_{9.81};  // m/s^2
+  const double diameter_{0.1};  // Ball diameter, just for visualization (m).
+  const double m_{0.1};         // kg
+  const double g_{9.81};        // m/s^2
   // Stiffness constant [N/m]. Calculated so that under its own weight the ball
   // penetrates the plane by 1 mm when the contact force and gravitational
   // force are in equilibrium.
-  const double k_{m_* g_ / 0.001};
+  const double k_{m_ * g_ / 0.001};
   // Hunt-Crossley's dissipation factor.
   const double d_{0.0};  // s/m
 };
 
 }  // namespace bouncing_ball
+}  // namespace geometry_world
 }  // namespace examples
 }  // namespace drake

--- a/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -1,34 +1,110 @@
+#include <memory>
+#include <utility>
+
 #include "drake/examples/geometry_world/bouncing_ball_plant.h"
+#include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_system.h"
+#include "drake/geometry/geometry_visualization.h"
+#include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/lcm/serializer.h"
+#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
+namespace geometry_world {
 namespace bouncing_ball {
 namespace {
 
+using geometry::GeometryInstance;
+using geometry::GeometrySystem;
+using geometry::HalfSpace;
+using geometry::SourceId;
+using lcm::DrakeLcm;
 using systems::InputPortDescriptor;
+using systems::rendering::PoseBundleToDrawMessage;
+using systems::lcm::LcmPublisherSystem;
+using systems::lcm::Serializer;
+using std::make_unique;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
-  auto bouncing_ball = builder.AddSystem<BouncingBallPlant>(
-      Vector2<double>(0.25, 0.25));
-  bouncing_ball->set_name("BouncingBall1");
+  auto geometry_system = builder.AddSystem<GeometrySystem<double>>();
+  geometry_system->set_name("geometry_system");
 
+  // Create two bouncing balls --> two plants. Put the balls at positions
+  // mirrored over the origin (<0.25, 0.25> and <-0.25, -0.25>, respectively).
+  // See below for setting the initial *height*.
+  SourceId ball_source_id1 = geometry_system->RegisterSource("ball1");
+  auto bouncing_ball1 = builder.AddSystem<BouncingBallPlant>(
+      ball_source_id1, geometry_system, Vector2<double>(0.25, 0.25));
+  bouncing_ball1->set_name("BouncingBall1");
+
+  SourceId ball_source_id2 = geometry_system->RegisterSource("ball2");
+  auto bouncing_ball2 = builder.AddSystem<BouncingBallPlant>(
+      ball_source_id2, geometry_system, Vector2<double>(-0.25, -0.25));
+  bouncing_ball2->set_name("BouncingBall2");
+
+  SourceId global_source = geometry_system->RegisterSource("anchored");
+  // Add a "ground" halfspace. Define the pose of the half space (H) in the
+  // world from its normal (Hz_W) and a point on the plane (p_WH). In this case,
+  // X_WH will be the identity.
+  Vector3<double> Hz_W(0, 0, 1);
+  Vector3<double> p_WH(0, 0, 0);
+  geometry_system->RegisterAnchoredGeometry(
+      global_source,
+      make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
+                                    make_unique<HalfSpace>()));
+  DrakeLcm lcm;
+  PoseBundleToDrawMessage* converter =
+      builder.template AddSystem<PoseBundleToDrawMessage>();
+  LcmPublisherSystem* publisher =
+      builder.template AddSystem<LcmPublisherSystem>(
+          "DRAKE_VIEWER_DRAW",
+          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
+  publisher->set_publish_period(1 / 60.0);
+
+  builder.Connect(bouncing_ball1->get_geometry_id_output_port(),
+                  geometry_system->get_source_frame_id_port(ball_source_id1));
+  builder.Connect(bouncing_ball1->get_geometry_pose_output_port(),
+                  geometry_system->get_source_pose_port(ball_source_id1));
+  builder.Connect(geometry_system->get_query_output_port(),
+                  bouncing_ball1->get_geometry_query_input_port());
+
+  builder.Connect(bouncing_ball2->get_geometry_id_output_port(),
+                  geometry_system->get_source_frame_id_port(ball_source_id2));
+  builder.Connect(bouncing_ball2->get_geometry_pose_output_port(),
+                  geometry_system->get_source_pose_port(ball_source_id2));
+  builder.Connect(geometry_system->get_query_output_port(),
+                  bouncing_ball2->get_geometry_query_input_port());
+
+  builder.Connect(geometry_system->get_pose_bundle_output_port(),
+                  converter->get_input_port(0));
+  builder.Connect(*converter, *publisher);
+
+  // Last thing before building the diagram; dispatch the message to load
+  // geometry.
+  geometry::DispatchLoadMessage(*geometry_system);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);
-  auto init_ball = [&](BouncingBallPlant<double>* system,
-                             double z, double zdot) {
+  auto init_ball = [&](BouncingBallPlant<double>* system, double z,
+                       double zdot) {
     systems::Context<double>& ball_context =
         diagram->GetMutableSubsystemContext(*system,
-            &simulator.get_mutable_context());
+                                            &simulator.get_mutable_context());
     system->set_z(&ball_context, z);
     system->set_zdot(&ball_context, zdot);
   };
-  init_ball(bouncing_ball, 0.3, 0.);
+  init_ball(bouncing_ball1, 0.3, 0.);
+  init_ball(bouncing_ball2, 0.3, 0.3);
 
   simulator.get_mutable_integrator()->set_maximum_step_size(0.002);
+  simulator.set_target_realtime_rate(1.f);
   simulator.Initialize();
   simulator.StepTo(10);
 
@@ -37,9 +113,10 @@ int do_main() {
 
 }  // namespace
 }  // namespace bouncing_ball
+}  // namespace geometry_world
 }  // namespace examples
 }  // namespace drake
 
 int main() {
-  return drake::examples::bouncing_ball::do_main();
+  return drake::examples::geometry_world::bouncing_ball::do_main();
 }

--- a/examples/geometry_world/bouncing_ball_vector.named_vector
+++ b/examples/geometry_world/bouncing_ball_vector.named_vector
@@ -1,4 +1,4 @@
-namespace: "drake::examples::bouncing_ball"
+namespace: "drake::examples::geometry_world::bouncing_ball"
 
 element {
     name: "z"

--- a/geometry/geometry_system.cc
+++ b/geometry/geometry_system.cc
@@ -330,9 +330,7 @@ void GeometrySystem<T>::FullPoseUpdate(
     }
   }
 
-  // TODO(SeanCurtis-TRI): Propagate changes to the geometry engine.
-  // Again, this will change significantly when caching becomes available.
-
+  mutable_state.FinalizePoseUpdate();
   // TODO(SeanCurtis-TRI): Add velocity as appropriate.
 }
 

--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -534,6 +534,7 @@ ProximityEngine<T>::ProximityEngine(const ProximityEngine<T>& other)
 template <typename T>
 ProximityEngine<T>& ProximityEngine<T>::operator=(
     const ProximityEngine<T>& other) {
+  if (this == &other) return *this;
   if (impl_) delete impl_;
   impl_ = new ProximityEngine<T>::Impl(*other.impl_);
   return *this;
@@ -548,6 +549,7 @@ ProximityEngine<T>::ProximityEngine(ProximityEngine<T>&& other) noexcept
 template <typename T>
 ProximityEngine<T>& ProximityEngine<T>::operator=(
     ProximityEngine<T>&& other) noexcept {
+  if (this == &other) return *this;
   if (impl_) delete impl_;
   impl_ = std::move(other.impl_);
   other.impl_ = new ProximityEngine<T>::Impl();
@@ -581,7 +583,7 @@ int ProximityEngine<T>::num_anchored() const {
 }
 
 template <typename T>
-std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiff()
+std::unique_ptr<ProximityEngine<AutoDiffXd>> ProximityEngine<T>::ToAutoDiffXd()
     const {
   return unique_ptr<ProximityEngine<AutoDiffXd>>(
       new ProximityEngine<AutoDiffXd>(impl_->ToAutoDiff().release()));

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -62,7 +62,7 @@ class ProximityEngine {
   /** Returns an independent copy of this engine templated on the AutoDiffXd
    scalar type. If the engine is already an AutoDiffXd engine, it is equivalent
    to using the copy constructor to create a duplicate on the heap. */
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ToAutoDiff() const;
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ToAutoDiffXd() const;
 
   /** @name Topology management */
   //@{

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -31,6 +31,17 @@ FrameId QueryObject<T>::GetFrameId(GeometryId geometry_id) const {
   return context_->get_geometry_state().GetFrameId(geometry_id);
 }
 
+template <typename T>
+std::vector<PenetrationAsPointPair<double>>
+QueryObject<T>::ComputePointPairPenetration() const {
+  ThrowIfDefault();
+
+  // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
+  system_->FullPoseUpdate(*context_);
+  const GeometryState<T>& state = context_->get_geometry_state();
+  return state.ComputePointPairPenetration();
+}
+
 }  // namespace geometry
 }  // namespace drake
 

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "drake/geometry/geometry_context.h"
+#include "drake/geometry/query_results/penetration_as_point_pair.h"
 
 namespace drake {
 namespace geometry {
@@ -84,6 +85,39 @@ class QueryObject {
 
   //@}
 
+  //----------------------------------------------------------------------------
+  /** @name                Collision Queries
+
+   These queries detect _collisions_ between geometry. Two geometries collide
+   if they overlap each other and are not explicitly excluded through
+   @ref collision_filter_concepts "collision filtering". These algorithms find
+   those colliding cases, characterize them, and report the essential
+   characteristics of that collision.  */
+  //@{
+
+  /** Computes the penetrations across all pairs of geometries in the world.
+   Only reports results for _penetrating_ geometries; if two geometries are
+   separated, there will be no result for that pair. Pairs of _anchored_
+   geometry are also not reported. The penetration between two geometries is
+   characterized as a point pair (see PenetrationAsPointPair).
+
+   <!--
+   This method is affected by collision filtering; element pairs that
+   have been filtered will not produce contacts, even if their collision
+   geometry is penetrating.
+   TODO(SeanCurtis-TRI): This isn't true yet.
+
+   NOTE: This is currently declared as double because we haven't exposed FCL's
+   templated functionality yet. When that happens, double -> T.
+   -->
+
+   @returns A vector populated with all detected penetrations characterized as
+            point pairs. */
+  std::vector<PenetrationAsPointPair<double>> ComputePointPairPenetration()
+      const;
+
+  //@}
+
  private:
   // GeometrySystem is the only class that can instantiate QueryObjects.
   friend class GeometrySystem<T>;
@@ -116,7 +150,7 @@ class QueryObject {
   //
   // Several issues:
   //  1. Leads to a clunky API (passing self and context into *every* query).
-  //  2. The index value would be insufficient if the GeoemtrySystem were buried
+  //  2. The index value would be insufficient if the GeometrySystem were buried
   //     in a diagram with its query object port exported in the diagram.
   // This is documented for future consideration, and should not necessarily be
   // interpreted as a guaranteed task.
@@ -126,8 +160,8 @@ class QueryObject {
   // on the current context (fully-dependent on context). These pointers must
   // be null for "baked" contexts (e.g., the result of copying a "live"
   // context).
-  const GeometryContext<T>* context_{};
-  const GeometrySystem<T>* system_{};
+  const GeometryContext<T>* context_{nullptr};
+  const GeometrySystem<T>* system_{nullptr};
 };
 
 }  // namespace geometry

--- a/geometry/query_results/penetration_as_point_pair.h
+++ b/geometry/query_results/penetration_as_point_pair.h
@@ -13,7 +13,11 @@ namespace geometry {
  geometry (in the normal direction). For convenience, the penetration depth
  is provided and is equal to:
 
-     depth = ‖ (p_WCa - p_WCb) ⋅ nhat_BA_W ‖₂.
+     depth = `(p_WCb - p_WCa) ⋅ nhat_BA_W`
+
+ (`depth` is strictly positive when there is penetration and otherwise not
+ defined.)
+
  @tparam T The underlying scalar type. Must be a valid Eigen scalar. */
 template <typename T>
 struct PenetrationAsPointPair {

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -123,19 +123,21 @@ class HalfSpace final : public Shape {
 
   HalfSpace();
 
-  /** Given a plane `normal_F` and a position vector to a point on the plane
-   `p_FP`, both expressed in frame F, creates the transform `X_FC` from the
-   half-space's canonical space to frame F.
-   @param normal_F  A vector perpendicular to the half-space's plane boundary
-                    expressed in frame F. It must be a non-zero vector but need
-                    not be unit length.
-   @param r_FP      A point lying on the half-space's plane boundary measured
+  /** Creates the pose of a canonical half space in frame F.
+   The half space's normal is aligned to the positive z-axis of its canonical
+   frame C. Given the measure of that axis in frame F (Cz_F) and a position
+   vector to a point on the plane expressed in the same frame, `p_FC`, creates
+   the pose of the half space in frame F: `X_FC`.
+   @param Cz_F      The positive z-axis of the canonical frame expressed in
+                    frame F. It must be a non-zero vector but need not be unit
+                    length.
+   @param p_FC      A point lying on the half-space's boundary measured
                     and expressed in frame F.
    @retval `X_FC`   The pose of the canonical half-space in frame F.
    @throws std::logic_error if the normal is _close_ to a zero-vector (e.g.,
                             ‖normal_F‖₂ < ε). */
-  static Isometry3<double> MakePose(const Vector3<double>& normal_F,
-                                    const Vector3<double>& r_FP);
+  static Isometry3<double> MakePose(const Vector3<double>& Cz_F,
+                                    const Vector3<double>& p_FC);
 };
 
 // TODO(SeanCurtis-TRI): Update documentation when the level of support for

--- a/geometry/test/proximity_engine_test.cc
+++ b/geometry/test/proximity_engine_test.cc
@@ -306,8 +306,9 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndAnchored) {
   ProximityEngine<double> copy_engine(engine_);
   ExpectPenetration(origin_id, dynamic_id, &copy_engine);
 
-  // Test AutoDiff converted engine
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine = engine_.ToAutoDiff();
+  // Test AutoDiffXd converted engine
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
+      engine_.ToAutoDiffXd();
   ExpectPenetration(origin_id, dynamic_id, ad_engine.get());
 }
 
@@ -339,8 +340,9 @@ TEST_F(SimplePenetrationTest, PenetrationDynamicAndDynamicSingleSource) {
   ProximityEngine<double> copy_engine(engine_);
   ExpectPenetration(origin_id, collide_id, &copy_engine);
 
-  // Test AutoDiff converted engine
-  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine = engine_.ToAutoDiff();
+  // Test AutoDiffXd converted engine
+  std::unique_ptr<ProximityEngine<AutoDiffXd>> ad_engine =
+      engine_.ToAutoDiffXd();
   ExpectPenetration(origin_id, collide_id, ad_engine.get());
 }
 

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -100,6 +100,7 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   // Enumerate *all* queries to confirm they throw the proper exception.
   EXPECT_DEFAULT_ERROR(default_object->GetFrameId(GeometryId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object->GetSourceName(SourceId::get_new_id()));
+  EXPECT_DEFAULT_ERROR(default_object->ComputePointPairPenetration());
 
 #undef EXPECT_DEFAULT_ERROR
 }


### PR DESCRIPTION
1. Add the penetration query to the QueryObject (and the underlying pass
   through on GeometryState).
2. Exercise the functionality in the bouncing ball demo
   - add a second ball
   - Change dynamics to use penetration detection.
3. Incidental cosmetic changes including:
   - clang formatting
   - Swapping for `DRAKE_DEFINE_CLASS_TEMPLATE...` stuff

Changes
```
Category            added  modified  removed  
----------------------------------------------
code                203    23        5        
comments            52     4         8        
blank               35     0         3        
----------------------------------------------
TOTAL               290    27        16 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7988)
<!-- Reviewable:end -->
