### PR TITLE
Update documentation to clarify forward declarations on copyable_unique_ptr

### DIFF
--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -127,7 +127,14 @@ using is_copyable_unique_ptr_compatible =
    - The `Base` class's Clone() implementation does not invoke the `Derived`
    class's implementation of a suitable virtual method.
 
- @internal For future developers:
+ @warning One important difference between unique_ptr and %copyable_unique_ptr
+ is that a unique_ptr can be declared on a forward-declared class type. The
+ %copyable_unique_ptr _cannot_. The class must be fully defined so that the
+ %copyable_unique_ptr is able to determine if the type meets the requirements
+ (i.e., public copy constructible or cloneable).
+
+ <!--
+ For future developers:
    - the copyability of a base class does *not* imply anything about the
    copyability of a derived class. In other words, `copyable_unique_ptr<Base>`
    can be compilable while `copyable_unique_ptr<Derived>` is not.
@@ -135,6 +142,7 @@ using is_copyable_unique_ptr_compatible =
    this copies "correctly" (such that the copy contains an instance of
    `Derived`), this does _not_ imply that `copyable_unique_ptr<Derived>` is
    compilable.
+ -->
 
  @see is_copyable_unique_ptr_compatible
  @tparam T   The type of the contained object, which *must* be


### PR DESCRIPTION
1. Clarify usage of copyable_unique_ptr with forward declared classes
   (you can't).
2. Cleaned up use of the @internal which was causing the template parameter
   documentation to be omitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7992)
<!-- Reviewable:end -->
