### PR TITLE
Remove the no-longer-valid "drake" portion of the documented path

### DIFF
--- a/common/drake_path.h
+++ b/common/drake_path.h
@@ -14,7 +14,7 @@ std::string GetDrakePath();
 
 /// Returns the fully-qualified path to the first folder containing Drake
 /// resources as located by FindResource, or nullopt if none is found.  For
-/// example `${result}/drake/examples/pendulum/Pendulum.urdf` would be the path
+/// example `${result}/examples/pendulum/Pendulum.urdf` would be the path
 /// to the Pendulum example's URDF resource.
 optional<std::string> MaybeGetDrakePath();
 


### PR DESCRIPTION
The documentation has evolved into a lie. This corrects it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/7993)
<!-- Reviewable:end -->
