### PR TITLE
Fix //drake label names in many packages

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,6 @@
 
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -15,7 +14,6 @@ exports_files([
     "CPPLINT.cfg",
     ".bazelproject",
     ".clang-format",
-    # TODO(jwnimmer-tri) This won't appear until #6996 merges.
     ".drake-find_resource-sentinel",
 ])
 
@@ -45,18 +43,18 @@ py_library(
 install(
     name = "install",
     docs = ["LICENSE.TXT"],
-    deps = adjust_labels_for_drake_hoist([
-        "//drake/automotive/models:install_data",
-        "//drake/bindings/pydrake:install",
-        "//drake/common:install",
-        "//drake/common/proto:install",
-        "//drake/examples:install",
-        "//drake/lcmtypes:install",
-        "//drake/manipulation/models:install_data",
+    deps = [
+        "//automotive/models:install_data",
+        "//bindings/pydrake:install",
+        "//common:install",
+        "//common/proto:install",
+        "//examples:install",
+        "//lcmtypes:install",
+        "//manipulation/models:install_data",
         "//setup:install",
         "//tools/install/libdrake:install",
         "//tools/workspace:install_external_packages",
-    ]),
+    ],
 )
 
 add_lint_tests()

--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -52,7 +52,7 @@ drake_cc_vector_gen_translator_library(
     srcs = _LCM_ENABLED_NAMED_VECTORS,
     deps = [
         ":generated_vectors",
-        "//drake/lcmtypes:automotive",
+        "//lcmtypes:automotive",
     ],
 )
 
@@ -62,8 +62,8 @@ drake_cc_library(
     hdrs = ["bicycle_car.h"],
     deps = [
         ":generated_vectors",
-        "//drake/common:symbolic",
-        "//drake/systems/framework:leaf_system",
+        "//common:symbolic",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -73,8 +73,8 @@ drake_cc_library(
     hdrs = ["box_car_vis.h"],
     deps = [
         ":car_vis",
-        "//drake/multibody/shapes",
-        "//drake/systems/rendering:drake_visualizer_client",
+        "//multibody/shapes",
+        "//systems/rendering:drake_visualizer_client",
     ],
 )
 
@@ -83,8 +83,8 @@ drake_cc_library(
     srcs = ["car_vis.cc"],
     hdrs = ["car_vis.h"],
     deps = [
-        "//drake/lcmtypes:viewer",
-        "//drake/systems/rendering:pose_bundle",
+        "//lcmtypes:viewer",
+        "//systems/rendering:pose_bundle",
     ],
 )
 
@@ -96,10 +96,10 @@ drake_cc_library(
         ":box_car_vis",
         ":car_vis",
         ":generated_vectors",
-        "//drake/lcmtypes:viewer",
-        "//drake/systems/framework",
-        "//drake/systems/rendering:drake_visualizer_client",
-        "//drake/systems/rendering:pose_aggregator",
+        "//lcmtypes:viewer",
+        "//systems/framework",
+        "//systems/rendering:drake_visualizer_client",
+        "//systems/rendering:pose_aggregator",
     ],
 )
 
@@ -111,9 +111,9 @@ drake_cc_library(
     deps = [
         ":curve2",
         ":trajectory_car",
-        "//drake/automotive/maliput/api",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common:symbolic",
+        "//automotive/maliput/api",
+        "//automotive/maliput/dragway",
+        "//common:symbolic",
     ],
 )
 
@@ -123,8 +123,8 @@ drake_cc_library(
     hdrs = ["curve2.h"],
     deps = [
         ":generated_vectors",
-        "//drake/common:autodiff",
-        "//drake/common:autodiffxd_make_coherent",
+        "//common:autodiff",
+        "//common:autodiffxd_make_coherent",
     ],
 )
 
@@ -137,11 +137,11 @@ drake_cc_library(
         ":generated_vectors",
         ":idm_planner",
         ":pose_selector",
-        "//drake/automotive/maliput/api",
-        "//drake/common:default_scalars",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:pose_bundle",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//common:default_scalars",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:pose_bundle",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -151,8 +151,8 @@ drake_cc_library(
     hdrs = ["idm_planner.h"],
     deps = [
         ":generated_vectors",
-        "//drake/common:default_scalars",
-        "//drake/common:extract_double",
+        "//common:default_scalars",
+        "//common:extract_double",
     ],
 )
 
@@ -161,7 +161,7 @@ drake_cc_library(
     srcs = ["lane_direction.cc"],
     hdrs = ["lane_direction.h"],
     deps = [
-        "//drake/automotive/maliput/api",
+        "//automotive/maliput/api",
     ],
 )
 
@@ -173,11 +173,11 @@ drake_cc_library(
         ":calc_smooth_acceleration",
         ":generated_vectors",
         ":lane_direction",
-        "//drake/automotive/maliput/api",
-        "//drake/math:geometric_transform",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:frame_velocity",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//math:geometric_transform",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:frame_velocity",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -192,12 +192,12 @@ drake_cc_library(
         ":lane_direction",
         ":pose_selector",
         ":road_odometry",
-        "//drake/automotive/maliput/api",
-        "//drake/common:cond",
-        "//drake/math:saturate",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:pose_bundle",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//common:cond",
+        "//math:saturate",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:pose_bundle",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -206,8 +206,8 @@ drake_cc_library(
     srcs = ["monolane_onramp_merge.cc"],
     hdrs = ["monolane_onramp_merge.h"],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/automotive/maliput/monolane",
+        "//automotive/maliput/api",
+        "//automotive/maliput/monolane",
     ],
 )
 
@@ -219,11 +219,11 @@ drake_cc_library(
     deps = [
         ":lane_direction",
         ":road_odometry",
-        "//drake/automotive/maliput/api",
-        "//drake/common:autodiffxd_make_coherent",
-        "//drake/common:extract_double",
-        "//drake/systems/rendering:pose_bundle",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//common:autodiffxd_make_coherent",
+        "//common:extract_double",
+        "//systems/rendering:pose_bundle",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -231,16 +231,16 @@ drake_cc_library(
     name = "prius_vis",
     srcs = ["prius_vis.cc"],
     hdrs = ["prius_vis.h"],
-    data = ["//drake/automotive/models:prod_models"],
+    data = ["//automotive/models:prod_models"],
     deps = [
         ":car_vis",
-        "//drake/common:find_resource",
-        "//drake/lcmtypes:viewer",
-        "//drake/multibody/joints",
-        "//drake/multibody/parsers",
-        "//drake/multibody/rigid_body_plant:create_load_robot_message",
-        "//drake/systems/rendering:pose_bundle",
-        "//drake/systems/rendering:pose_vector",
+        "//common:find_resource",
+        "//lcmtypes:viewer",
+        "//multibody/joints",
+        "//multibody/parsers",
+        "//multibody/rigid_body_plant:create_load_robot_message",
+        "//systems/rendering:pose_bundle",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -251,10 +251,10 @@ drake_cc_library(
     deps = [
         ":generated_vectors",
         ":lane_direction",
-        "//drake/automotive/maliput/api",
-        "//drake/common:symbolic",
-        "//drake/math:saturate",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//common:symbolic",
+        "//math:saturate",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -266,8 +266,8 @@ drake_cc_library(
         ":generated_vectors",
         ":lane_direction",
         ":pure_pursuit",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:pose_vector",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -276,8 +276,8 @@ drake_cc_library(
     srcs = ["road_odometry.cc"],
     hdrs = ["road_odometry.h"],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/systems/rendering:frame_velocity",
+        "//automotive/maliput/api",
+        "//systems/rendering:frame_velocity",
     ],
 )
 
@@ -289,12 +289,12 @@ drake_cc_library(
     deps = [
         ":lane_direction",
         ":monolane_onramp_merge",
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common:unused",
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/common/trajectories/qp_spline:spline_generation",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common:unused",
+        "//common/trajectories:piecewise_polynomial",
+        "//common/trajectories/qp_spline:spline_generation",
+        "//math:saturate",
     ],
 )
 
@@ -307,13 +307,13 @@ drake_cc_library(
     deps = [
         ":calc_smooth_acceleration",
         ":generated_vectors",
-        "//drake/common:cond",
-        "//drake/common:double",
-        "//drake/common:symbolic",
-        "//drake/math:saturate",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:frame_velocity",
-        "//drake/systems/rendering:pose_vector",
+        "//common:cond",
+        "//common:double",
+        "//common:symbolic",
+        "//math:saturate",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:frame_velocity",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -322,7 +322,7 @@ drake_cc_library(
     srcs = ["simple_powertrain.cc"],
     hdrs = ["simple_powertrain.h"],
     deps = [
-        "//drake/systems/primitives:linear_system",
+        "//systems/primitives:linear_system",
     ],
 )
 
@@ -333,12 +333,12 @@ drake_cc_library(
     visibility = [],
     deps = [
         ":pose_selector",
-        "//drake/automotive/maliput/api",
-        "//drake/common:autodiff",
-        "//drake/common:default_scalars",
-        "//drake/common:symbolic",
-        "//drake/systems/rendering:frame_velocity",
-        "//drake/systems/rendering:pose_vector",
+        "//automotive/maliput/api",
+        "//common:autodiff",
+        "//common:default_scalars",
+        "//common:symbolic",
+        "//systems/rendering:frame_velocity",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -348,8 +348,8 @@ drake_cc_library(
     hdrs = ["calc_smooth_acceleration.h"],
     visibility = [],
     deps = [
-        "//drake/common:autodiff",
-        "//drake/common:symbolic",
+        "//common:autodiff",
+        "//common:symbolic",
     ],
 )
 
@@ -361,11 +361,11 @@ drake_cc_library(
         ":calc_smooth_acceleration",
         ":curve2",
         ":generated_vectors",
-        "//drake/common:autodiff",
-        "//drake/common:extract_double",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:frame_velocity",
-        "//drake/systems/rendering:pose_vector",
+        "//common:autodiff",
+        "//common:extract_double",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:frame_velocity",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -385,18 +385,18 @@ drake_cc_library(
         ":pure_pursuit_controller",
         ":simple_car",
         ":trajectory_car",
-        "//drake/automotive/maliput/api",
-        "//drake/automotive/maliput/utility",
-        "//drake/lcm",
-        "//drake/multibody/parsers",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/systems/analysis",
-        "//drake/systems/lcm",
-        "//drake/systems/lcm:lcmt_drake_signal_translator",
-        "//drake/systems/primitives:constant_value_source",
-        "//drake/systems/primitives:multiplexer",
-        "//drake/systems/rendering:pose_aggregator",
-        "//drake/systems/rendering:pose_bundle_to_draw_message",
+        "//automotive/maliput/api",
+        "//automotive/maliput/utility",
+        "//lcm",
+        "//multibody/parsers",
+        "//multibody/rigid_body_plant:drake_visualizer",
+        "//systems/analysis",
+        "//systems/lcm",
+        "//systems/lcm:lcmt_drake_signal_translator",
+        "//systems/primitives:constant_value_source",
+        "//systems/primitives:multiplexer",
+        "//systems/rendering:pose_aggregator",
+        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 
@@ -406,15 +406,15 @@ drake_cc_binary(
         "automotive_demo.cc",
     ],
     data = [
-        "//drake/automotive/models:prod_models",
+        "//automotive/models:prod_models",
     ],
     deps = [
         ":automotive_simulator",
         ":create_trajectory_params",
         ":monolane_onramp_merge",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common:text_logging_gflags",
-        "//drake/lcm",
+        "//automotive/maliput/dragway",
+        "//common:text_logging_gflags",
+        "//lcm",
     ],
 )
 
@@ -427,18 +427,18 @@ drake_cc_binary(
     ],
     add_test_rule = 1,
     data = [
-        "//drake/automotive/models:prod_models",
+        "//automotive/models:prod_models",
     ],
     test_rule_args = ["--simulation_sec=0.01"],
     # Flaky because LCM self-test can fail (PR #7311)
     test_rule_flaky = 1,
     deps = [
         ":automotive_simulator",
-        "//drake/common:find_resource",
-        "//drake/common:text_logging_gflags",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/systems/controllers:pid_controlled_system",
+        "//common:find_resource",
+        "//common:text_logging_gflags",
+        "//multibody:rigid_body_tree_construction",
+        "//multibody/rigid_body_plant",
+        "//systems/controllers:pid_controlled_system",
     ],
 )
 
@@ -446,7 +446,7 @@ drake_py_binary(
     name = "steering_command_driver",
     srcs = ["steering_command_driver.py"],
     deps = [
-        "//drake/lcmtypes:lcmtypes_py",
+        "//lcmtypes:lcmtypes_py",
         "@lcm//:lcm-python",
     ],
 )
@@ -455,7 +455,7 @@ drake_java_binary(
     name = "lcm-spy",
     main_class = "lcm.spy.Spy",
     runtime_deps = [
-        "//drake/lcmtypes:lcmtypes_drake_java",
+        "//lcmtypes:lcmtypes_drake_java",
     ],
 )
 
@@ -483,31 +483,31 @@ drake_cc_library(
     hdrs = ["test/autodiff_test_utilities.h"],
     visibility = ["//visibility:private"],
     deps = [
-        "//drake/common:autodiff",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common:autodiff",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "automotive_simulator_test",
-    data = ["//drake/automotive/models:prod_models"],
+    data = ["//automotive/models:prod_models"],
     # Flaky because LCM self-test can fail (PR #7311)
     flaky = 1,
     local = 1,
     deps = [
-        "//drake/automotive:automotive_simulator",
-        "//drake/automotive:create_trajectory_params",
-        "//drake/automotive/maliput/dragway",
-        "//drake/lcm:mock",
+        "//automotive:automotive_simulator",
+        "//automotive:create_trajectory_params",
+        "//automotive/maliput/dragway",
+        "//lcm:mock",
     ],
 )
 
 drake_cc_googletest(
     name = "bicycle_car_test",
     deps = [
-        "//drake/automotive:bicycle_car",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/framework/test_utilities",
+        "//automotive:bicycle_car",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework/test_utilities",
     ],
 )
 
@@ -515,8 +515,8 @@ drake_cc_googletest(
     name = "box_car_vis_test",
     deps = [
         ":box_car_vis",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/rendering:pose_vector",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/rendering:pose_vector",
     ],
 )
 
@@ -524,27 +524,27 @@ drake_cc_googletest(
     name = "car_vis_applicator_test",
     deps = [
         ":car_vis_applicator",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
 drake_cc_googletest(
     name = "curve2_test",
     deps = [
-        "//drake/automotive:curve2",
+        "//automotive:curve2",
     ],
 )
 
 drake_cc_googletest(
     name = "maliput_railcar_test",
     deps = [
-        "//drake/automotive:maliput_railcar",
-        "//drake/automotive/maliput/api",
-        "//drake/automotive/maliput/dragway",
-        "//drake/automotive/maliput/monolane",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//automotive:maliput_railcar",
+        "//automotive/maliput/api",
+        "//automotive/maliput/dragway",
+        "//automotive/maliput/monolane",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -552,56 +552,56 @@ drake_cc_googletest(
     name = "monolane_onramp_merge_test",
     deps = [
         ":monolane_onramp_merge",
-        "//drake/automotive/maliput/utility",
+        "//automotive/maliput/utility",
     ],
 )
 
 drake_cc_googletest(
     name = "simple_car_test",
     deps = [
-        "//drake/automotive:simple_car",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/framework/test_utilities",
+        "//automotive:simple_car",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework/test_utilities",
     ],
 )
 
 drake_cc_googletest(
     name = "idm_controller_test",
     deps = [
-        "//drake/automotive:idm_controller",
-        "//drake/automotive:monolane_onramp_merge",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/framework/test_utilities:scalar_conversion",
+        "//automotive:idm_controller",
+        "//automotive:monolane_onramp_merge",
+        "//automotive/maliput/dragway",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework/test_utilities:scalar_conversion",
     ],
 )
 
 drake_cc_googletest(
     name = "idm_planner_test",
     deps = [
-        "//drake/automotive:autodiff_test_utilities",
-        "//drake/automotive:idm_planner",
-        "//drake/common:extract_double",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive:autodiff_test_utilities",
+        "//automotive:idm_planner",
+        "//common:extract_double",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "mobil_planner_test",
     deps = [
-        "//drake/automotive:mobil_planner",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive:mobil_planner",
+        "//automotive/maliput/dragway",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "pose_selector_test",
     deps = [
-        "//drake/automotive:pose_selector",
-        "//drake/automotive/maliput/dragway",
-        "//drake/automotive/maliput/monolane:builder",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive:pose_selector",
+        "//automotive/maliput/dragway",
+        "//automotive/maliput/monolane:builder",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -609,8 +609,8 @@ drake_cc_googletest(
     name = "prius_vis_test",
     deps = [
         ":prius_vis",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -618,65 +618,65 @@ drake_cc_googletest(
     name = "road_path_test",
     deps = [
         ":road_path",
-        "//drake/automotive/maliput/dragway",
-        "//drake/automotive/maliput/monolane",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/dragway",
+        "//automotive/maliput/monolane",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "pure_pursuit_test",
     deps = [
-        "//drake/automotive:pure_pursuit",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive:pure_pursuit",
+        "//automotive/maliput/dragway",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "pure_pursuit_controller_test",
     deps = [
-        "//drake/automotive:pure_pursuit_controller",
-        "//drake/automotive/maliput/dragway",
-        "//drake/systems/framework/test_utilities",
+        "//automotive:pure_pursuit_controller",
+        "//automotive/maliput/dragway",
+        "//systems/framework/test_utilities",
     ],
 )
 
 drake_cc_googletest(
     name = "simple_powertrain_test",
     deps = [
-        "//drake/automotive:simple_powertrain",
-        "//drake/systems/framework/test_utilities",
+        "//automotive:simple_powertrain",
+        "//systems/framework/test_utilities",
     ],
 )
 
 drake_cc_googletest(
     name = "calc_smooth_acceleration_test",
     deps = [
-        "//drake/automotive:calc_smooth_acceleration",
-        "//drake/common:essential",
+        "//automotive:calc_smooth_acceleration",
+        "//common:essential",
     ],
 )
 
 drake_cc_googletest(
     name = "calc_ongoing_road_position_test",
     deps = [
-        "//drake/automotive:calc_ongoing_road_position",
-        "//drake/automotive:monolane_onramp_merge",
-        "//drake/automotive/maliput/dragway",
-        "//drake/common:essential",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive:calc_ongoing_road_position",
+        "//automotive:monolane_onramp_merge",
+        "//automotive/maliput/dragway",
+        "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "trajectory_car_test",
     deps = [
-        "//drake/automotive:autodiff_test_utilities",
-        "//drake/automotive:trajectory_car",
-        "//drake/common:extract_double",
-        "//drake/systems/analysis:simulator",
-        "//drake/systems/framework/test_utilities",
+        "//automotive:autodiff_test_utilities",
+        "//automotive:trajectory_car",
+        "//common:extract_double",
+        "//systems/analysis:simulator",
+        "//systems/framework/test_utilities",
     ],
 )
 
@@ -689,9 +689,9 @@ drake_cc_googletest(
     tags = ["snopt"],
     deps = [
         ":simple_car",
-        "//drake/common/proto:call_matlab",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/trajectory_optimization:direct_collocation",
+        "//common/proto:call_matlab",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/trajectory_optimization:direct_collocation",
     ],
 )
 

--- a/automotive/dev/BUILD.bazel
+++ b/automotive/dev/BUILD.bazel
@@ -18,7 +18,7 @@ drake_cc_library(
         "traffic_light.h",
     ],
     deps = [
-        "//drake/systems/framework",
+        "//systems/framework",
     ],
 )
 

--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -22,9 +22,9 @@ drake_cc_library(
         "type_specific_identifier.h",
     ],
     deps = [
-        "//drake/common:default_scalars",
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
+        "//common:default_scalars",
+        "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 
@@ -34,7 +34,7 @@ drake_cc_googletest(
     name = "lane_data_test",
     deps = [
         ":api",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/automotive/maliput/api/test_utilities/BUILD.bazel
+++ b/automotive/maliput/api/test_utilities/BUILD.bazel
@@ -20,9 +20,9 @@ drake_cc_library(
     srcs = ["maliput_types_compare.cc"],
     hdrs = ["maliput_types_compare.h"],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//math:geometric_transform",
         "@gtest//:without_main",
     ],
 )

--- a/automotive/maliput/dragway/BUILD.bazel
+++ b/automotive/maliput/dragway/BUILD.bazel
@@ -27,10 +27,10 @@ drake_cc_library(
         "segment.h",
     ],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common:unused",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common:unused",
+        "//math:saturate",
     ],
 )
 
@@ -39,9 +39,9 @@ drake_cc_binary(
     srcs = ["dragway_to_urdf.cc"],
     deps = [
         ":dragway",
-        "//drake/automotive/maliput/utility",
-        "//drake/common:essential",
-        "//drake/common:text_logging_gflags",
+        "//automotive/maliput/utility",
+        "//common:essential",
+        "//common:text_logging_gflags",
         "@gflags",
         "@spruce",
     ],
@@ -56,8 +56,8 @@ drake_cc_googletest(
     srcs = ["test/dragway_test.cc"],
     deps = [
         ":dragway",
-        "//drake/automotive/maliput/api/test_utilities",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/api/test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/automotive/maliput/monolane/BUILD.bazel
+++ b/automotive/maliput/monolane/BUILD.bazel
@@ -46,11 +46,11 @@ drake_cc_library(
         "segment.h",
     ],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common:unused",
-        "//drake/math:geometric_transform",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common:unused",
+        "//math:geometric_transform",
+        "//math:saturate",
     ],
 )
 
@@ -103,8 +103,8 @@ drake_cc_googletest(
     srcs = ["test/monolane_lanes_test.cc"],
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/api/test_utilities",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/api/test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -114,7 +114,7 @@ drake_cc_googletest(
     srcs = ["test/monolane_road_geometry_test.cc"],
     deps = [
         ":builder",
-        "//drake/automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 
@@ -124,7 +124,7 @@ drake_cc_binary(
     srcs = ["test/yaml_load.cc"],
     deps = [
         ":loader",
-        "//drake/common:text_logging_gflags",
+        "//common:text_logging_gflags",
     ],
 )
 

--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -49,11 +49,11 @@ drake_cc_library(
         "segment.h",
     ],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common:unused",
-        "//drake/math:geometric_transform",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common:unused",
+        "//math:geometric_transform",
+        "//math:saturate",
     ],
 )
 
@@ -98,7 +98,7 @@ drake_cc_googletest(
     srcs = ["test/multilane_arc_road_curve_test.cc"],
     deps = [
         ":lanes",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -108,8 +108,8 @@ drake_cc_googletest(
     srcs = ["test/multilane_builder_test.cc"],
     deps = [
         ":builder",
-        "//drake/automotive/maliput/api/test_utilities",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/api/test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -119,8 +119,8 @@ drake_cc_googletest(
     srcs = ["test/multilane_connection_test.cc"],
     deps = [
         ":builder",
-        "//drake/automotive/maliput/multilane/test_utilities",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/multilane/test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -130,8 +130,8 @@ drake_cc_googletest(
     srcs = ["test/multilane_lanes_test.cc"],
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/api/test_utilities",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/api/test_utilities",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -141,7 +141,7 @@ drake_cc_googletest(
     srcs = ["test/multilane_line_road_curve_test.cc"],
     deps = [
         ":lanes",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -151,7 +151,7 @@ drake_cc_googletest(
     srcs = ["test/multilane_loader_test.cc"],
     deps = [
         ":loader",
-        "//drake/automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 
@@ -161,7 +161,7 @@ drake_cc_googletest(
     srcs = ["test/multilane_road_geometry_test.cc"],
     deps = [
         ":builder",
-        "//drake/automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 
@@ -171,8 +171,8 @@ drake_cc_googletest(
     srcs = ["test/multilane_segments_test.cc"],
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/api/test_utilities:maliput_types_compare",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//automotive/maliput/api/test_utilities:maliput_types_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -182,7 +182,7 @@ drake_cc_binary(
     srcs = ["test/yaml_load.cc"],
     deps = [
         ":loader",
-        "//drake/common:text_logging_gflags",
+        "//common:text_logging_gflags",
     ],
 )
 

--- a/automotive/maliput/multilane/test_utilities/BUILD.bazel
+++ b/automotive/maliput/multilane/test_utilities/BUILD.bazel
@@ -21,9 +21,9 @@ drake_cc_library(
     srcs = ["multilane_types_compare.cc"],
     hdrs = ["multilane_types_compare.h"],
     deps = [
-        "//drake/automotive/maliput/multilane",
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
+        "//automotive/maliput/multilane",
+        "//common:essential",
+        "//math:geometric_transform",
         "@gtest//:without_main",
     ],
 )

--- a/automotive/maliput/rndf/BUILD.bazel
+++ b/automotive/maliput/rndf/BUILD.bazel
@@ -32,8 +32,8 @@ drake_cc_library(
     deps = [
         ":builder",
         ":lanes",
-        "//drake/automotive/maliput/api",
-        "//drake/common",
+        "//automotive/maliput/api",
+        "//common",
         "@ignition_math",
         "@ignition_rndf",
     ],
@@ -53,11 +53,11 @@ drake_cc_library(
     ],
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/math:geometric_transform",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common/trajectories:piecewise_polynomial",
+        "//math:geometric_transform",
+        "//math:saturate",
         "@ignition_math",
         "@ignition_rndf",
     ],
@@ -84,11 +84,11 @@ drake_cc_library(
         "spline_lane.h",
     ],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/common:essential",
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/math:geometric_transform",
-        "//drake/math:saturate",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common/trajectories:piecewise_polynomial",
+        "//math:geometric_transform",
+        "//math:saturate",
         "@ignition_math",
     ],
 )
@@ -110,7 +110,7 @@ drake_cc_binary(
     test_rule_size = "small",
     deps = [
         ":loader",
-        "//drake/common:text_logging_gflags",
+        "//common:text_logging_gflags",
     ],
 )
 
@@ -118,7 +118,7 @@ drake_cc_googletest(
     name = "connection_test",
     deps = [
         ":builder",
-        "//drake/automotive/maliput/rndf/test_utilities",
+        "//automotive/maliput/rndf/test_utilities",
         "@ignition_math",
         "@ignition_rndf",
     ],
@@ -128,7 +128,7 @@ drake_cc_googletest(
     name = "directed_waypoint_test",
     deps = [
         ":builder",
-        "//drake/automotive/maliput/rndf/test_utilities",
+        "//automotive/maliput/rndf/test_utilities",
         "@ignition_math",
         "@ignition_rndf",
     ],
@@ -138,7 +138,7 @@ drake_cc_googletest(
     name = "builder_test",
     deps = [
         ":builder",
-        "//drake/automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 
@@ -156,9 +156,9 @@ drake_cc_googletest(
     ],
     deps = [
         ":loader",
-        "//drake/automotive/maliput/api",
-        "//drake/automotive/maliput/api/test_utilities",
-        "//drake/common:find_resource",
+        "//automotive/maliput/api",
+        "//automotive/maliput/api/test_utilities",
+        "//common:find_resource",
     ],
 )
 
@@ -194,7 +194,7 @@ drake_cc_googletest(
     name = "spline_lane_test",
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 
@@ -202,7 +202,7 @@ drake_cc_googletest(
     name = "spline_helpers_test",
     deps = [
         ":lanes",
-        "//drake/automotive/maliput/rndf/test_utilities",
+        "//automotive/maliput/rndf/test_utilities",
     ],
 )
 

--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -11,7 +11,6 @@ load(
     "drake_py_test",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_label_for_drake_hoist")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,8 +25,8 @@ drake_cc_library(
         "generate_urdf.h",
     ],
     deps = [
-        "//drake/automotive/maliput/api",
-        "//drake/math:geometric_transform",
+        "//automotive/maliput/api",
+        "//math:geometric_transform",
         "@fmt",
     ],
 )
@@ -37,16 +36,14 @@ drake_cc_binary(
     srcs = ["yaml_to_obj.cc"],
     deps = [
         ":utility",
-        "//drake/automotive/maliput/monolane",
-        "//drake/common:text_logging_gflags",
+        "//automotive/maliput/monolane",
+        "//common:text_logging_gflags",
     ],
 )
 
 alias(
     name = "t_intersection.rndf",
-    actual = adjust_label_for_drake_hoist(
-        "//drake/automotive/maliput/rndf:test/maps/t_intersection.rndf",
-    ),
+    actual = "//automotive/maliput/rndf:test/maps/t_intersection.rndf",
 )
 
 drake_cc_binary(
@@ -65,8 +62,8 @@ drake_cc_binary(
     test_rule_size = "small",
     deps = [
         ":utility",
-        "//drake/automotive/maliput/rndf",
-        "//drake/common:text_logging_gflags",
+        "//automotive/maliput/rndf",
+        "//common:text_logging_gflags",
     ],
 )
 
@@ -85,8 +82,8 @@ drake_cc_googletest(
     ],
     deps = [
         ":utility",
-        "//drake/automotive/maliput/monolane",
-        "//drake/common",
+        "//automotive/maliput/monolane",
+        "//common",
         "@spruce",
     ],
 )
@@ -95,7 +92,7 @@ drake_cc_googletest(
     name = "generate_urdf_test",
     deps = [
         ":utility",
-        "//drake/automotive/maliput/monolane",
+        "//automotive/maliput/monolane",
         "@spruce",
     ],
 )
@@ -107,7 +104,7 @@ drake_py_test(
     args = ["$(location :yaml_to_obj)"],
     data = [
         ":yaml_to_obj",
-        "//drake/automotive/maliput/monolane:yamls",
+        "//automotive/maliput/monolane:yamls",
     ],
 )
 

--- a/automotive/models/BUILD.bazel
+++ b/automotive/models/BUILD.bazel
@@ -2,15 +2,12 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 load("//tools/install:install_data.bzl", "install_data")
-load("//tools/skylark:6996.bzl", "adjust_label_for_drake_hoist")
 
 package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "yaml_to_obj",
-    actual = adjust_label_for_drake_hoist(
-        "//drake/automotive/maliput/utility:yaml_to_obj",
-    ),
+    actual = "//automotive/maliput/utility:yaml_to_obj",
 )
 
 genrule(

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -13,7 +13,6 @@ load(
 )
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_label_for_drake_hoist")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -203,7 +202,7 @@ drake_cc_library(
         ":hash",
         ":number_traits",
         ":polynomial",
-        "//drake/math:matrix_util",
+        "//math:matrix_util",
     ],
 )
 
@@ -232,9 +231,7 @@ drake_cc_library(
 
 # Miscellaneous utilities.
 
-DRAKE_RESOURCE_SENTINEL = adjust_label_for_drake_hoist(
-    "//drake:.drake-find_resource-sentinel",
-)
+DRAKE_RESOURCE_SENTINEL = "//:.drake-find_resource-sentinel"
 
 drake_cc_library(
     name = "is_less_than_comparable",
@@ -469,7 +466,7 @@ drake_cc_googletest(
         ":autodiff",
         ":essential",
         ":extract_double",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -576,7 +573,7 @@ drake_cc_googletest(
     name = "copyable_unique_ptr_test",
     deps = [
         ":copyable_unique_ptr",
-        "//drake/common/test_utilities:is_dynamic_castable",
+        "//common/test_utilities:is_dynamic_castable",
     ],
 )
 
@@ -692,7 +689,7 @@ drake_cc_googletest(
     name = "autodiffxd_make_coherent_test",
     deps = [
         ":autodiffxd_make_coherent",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -701,7 +698,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -725,8 +722,8 @@ drake_cc_googletest(
     name = "polynomial_test",
     deps = [
         ":essential",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:random_polynomial_matrix",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:random_polynomial_matrix",
     ],
 )
 
@@ -760,7 +757,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -769,8 +766,8 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:is_memcpy_movable",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:is_memcpy_movable",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -779,7 +776,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -788,7 +785,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -797,7 +794,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -806,7 +803,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -815,8 +812,8 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -834,7 +831,7 @@ drake_cc_googletest(
     size = "medium",
     deps = [
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -843,7 +840,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -852,7 +849,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -861,7 +858,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -870,8 +867,8 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:is_memcpy_movable",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:is_memcpy_movable",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -880,7 +877,7 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -889,8 +886,8 @@ drake_cc_googletest(
     deps = [
         ":essential",
         ":symbolic",
-        "//drake/common/test_utilities:is_memcpy_movable",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:is_memcpy_movable",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -975,7 +972,7 @@ drake_py_test(
     data = [
         "test/resource_tool_test_data.txt",
         ":resource_tool",
-        "//drake/examples/pendulum:models",
+        "//examples/pendulum:models",
     ],
 )
 

--- a/common/proto/BUILD.bazel
+++ b/common/proto/BUILD.bazel
@@ -12,7 +12,6 @@ load(
 )
 load("@drake//tools/install:install.bzl", "install")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "HAS_MOVED_6996")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,7 +35,7 @@ drake_cc_library(
     hdrs = ["call_matlab.h"],
     deps = [
         ":matlab_rpc",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -55,7 +54,7 @@ drake_cc_library(
     hdrs = ["call_python.h"],
     deps = [
         ":call_matlab",
-        "//drake/common:copyable_unique_ptr",
+        "//common:copyable_unique_ptr",
     ],
 )
 
@@ -77,7 +76,7 @@ py_binary(
         # TODO(jwnimmer-tri) We should use a project-wide solution so that
         # Drake's import paths are consistent without having to use weird
         # spellings such as this one.
-        "@drake//common/proto:call_python_client" if HAS_MOVED_6996 else ":call_python_client",  # noqa
+        "@drake//common/proto:call_python_client",
     ],
 )
 
@@ -143,7 +142,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":protobuf",
-        "//drake/common",
+        "//common",
     ],
 )
 

--- a/common/test_utilities/BUILD.bazel
+++ b/common/test_utilities/BUILD.bazel
@@ -36,7 +36,7 @@ drake_cc_library(
     hdrs = ["eigen_geometry_compare.h"],
     deps = [
         ":eigen_matrix_compare",
-        "//drake/common:essential",
+        "//common:essential",
         "@gtest//:without_main",
     ],
 )
@@ -46,7 +46,7 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["eigen_matrix_compare.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
         "@gtest//:without_main",
     ],
 )
@@ -56,7 +56,7 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["is_dynamic_castable.h"],
     deps = [
-        "//drake/common:nice_type_name",
+        "//common:nice_type_name",
     ],
 )
 
@@ -77,7 +77,7 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["random_polynomial_matrix.h"],
     deps = [
-        "//drake/common:polynomial",
+        "//common:polynomial",
     ],
 )
 
@@ -86,7 +86,7 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["symbolic_test_util.h"],
     deps = [
-        "//drake/common:symbolic",
+        "//common:symbolic",
     ],
 )
 
@@ -97,7 +97,7 @@ drake_cc_library(
     testonly = 1,
     srcs = ["drake_cc_googletest_main.cc"],
     deps = [
-        "//drake/common:text_logging_gflags",
+        "//common:text_logging_gflags",
         "@gtest//:without_main",
     ],
 )
@@ -106,7 +106,7 @@ drake_cc_googletest(
     name = "eigen_matrix_compare_test",
     deps = [
         ":eigen_matrix_compare",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 

--- a/common/trajectories/BUILD.bazel
+++ b/common/trajectories/BUILD.bazel
@@ -10,7 +10,7 @@ drake_cc_library(
     name = "trajectory",
     hdrs = ["trajectory.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -19,7 +19,7 @@ drake_cc_library(
     srcs = ["piecewise_function.cc"],
     hdrs = ["piecewise_function.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -37,8 +37,8 @@ drake_cc_library(
     ],
     deps = [
         ":piecewise_function",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
+        "//common:essential",
+        "//common:polynomial",
     ],
 )
 
@@ -49,7 +49,7 @@ drake_cc_library(
     deps = [
         ":piecewise_polynomial",
         ":trajectory",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -59,8 +59,8 @@ drake_cc_library(
     hdrs = ["piecewise_quaternion.h"],
     deps = [
         ":piecewise_function",
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
+        "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 
@@ -71,7 +71,7 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["test/random_piecewise_polynomial.h"],
     deps = [
-        "//drake/common/test_utilities:random_polynomial_matrix",
+        "//common/test_utilities:random_polynomial_matrix",
     ],
 )
 
@@ -89,7 +89,7 @@ drake_cc_googletest(
     srcs = ["test/piecewise_polynomial_generation_test.cc"],
     deps = [
         ":piecewise_polynomial",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -98,7 +98,7 @@ drake_cc_googletest(
     deps = [
         ":piecewise_polynomial",
         ":random_piecewise_polynomial",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -107,7 +107,7 @@ drake_cc_googletest(
     deps = [
         ":piecewise_polynomial",
         ":random_piecewise_polynomial",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -116,7 +116,7 @@ drake_cc_googletest(
     deps = [
         ":piecewise_polynomial_trajectory",
         ":random_piecewise_polynomial",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -124,8 +124,8 @@ drake_cc_googletest(
     name = "piecewise_quaternion_test",
     deps = [
         ":piecewise_quaternion",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/util",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//util",
     ],
 )
 

--- a/common/trajectories/qp_spline/BUILD.bazel
+++ b/common/trajectories/qp_spline/BUILD.bazel
@@ -10,7 +10,7 @@ drake_cc_library(
     srcs = ["continuity_constraint.cc"],
     hdrs = ["continuity_constraint.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -20,7 +20,7 @@ drake_cc_library(
     hdrs = ["spline_generation.h"],
     deps = [
         ":spline_information",
-        "//drake/common/trajectories:piecewise_polynomial",
+        "//common/trajectories:piecewise_polynomial",
     ],
 )
 
@@ -31,7 +31,7 @@ drake_cc_library(
     deps = [
         ":continuity_constraint",
         ":value_constraint",
-        "//drake/common/trajectories:piecewise_polynomial",
+        "//common/trajectories:piecewise_polynomial",
     ],
 )
 
@@ -40,7 +40,7 @@ drake_cc_library(
     srcs = ["value_constraint.cc"],
     hdrs = ["value_constraint.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -21,9 +21,9 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_index",
         ":shape_specification",
-        "//drake/common",
-        "//drake/common:default_scalars",
-        "//drake/geometry/query_results:penetration_as_point_pair",
+        "//common",
+        "//common:default_scalars",
+        "//geometry/query_results:penetration_as_point_pair",
         "@fcl",
     ],
 )
@@ -40,8 +40,8 @@ drake_cc_library(
     ],
     deps = [
         ":geometry_ids",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
+        "//common:autodiff",
+        "//common:essential",
     ],
 )
 
@@ -51,7 +51,7 @@ drake_cc_library(
     hdrs = ["geometry_context.h"],
     deps = [
         ":geometry_state",
-        "//drake/systems/framework:leaf_context",
+        "//systems/framework:leaf_context",
     ],
 )
 
@@ -61,7 +61,7 @@ drake_cc_library(
     hdrs = ["geometry_frame.h"],
     deps = [
         ":geometry_ids",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -76,7 +76,7 @@ drake_cc_library(
     name = "geometry_index",
     srcs = [],
     hdrs = ["geometry_index.h"],
-    deps = ["//drake/common:type_safe_index"],
+    deps = ["//common:type_safe_index"],
 )
 
 drake_cc_library(
@@ -86,8 +86,8 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":shape_specification",
-        "//drake/common:copyable_unique_ptr",
-        "//drake/common:essential",
+        "//common:copyable_unique_ptr",
+        "//common:essential",
     ],
 )
 
@@ -120,10 +120,10 @@ drake_cc_library(
     deps = [
         ":geometry_context",
         ":geometry_state",
-        "//drake/common:essential",
-        "//drake/geometry/query_results:penetration_as_point_pair",
-        "//drake/systems/framework",
-        "//drake/systems/rendering:pose_bundle",
+        "//common:essential",
+        "//geometry/query_results:penetration_as_point_pair",
+        "//systems/framework",
+        "//systems/rendering:pose_bundle",
     ],
 )
 
@@ -134,9 +134,9 @@ drake_cc_library(
     deps = [
         ":geometry_state",
         ":geometry_system",
-        "//drake/lcm",
-        "//drake/lcmtypes:viewer",
-        "//drake/math:geometric_transform",
+        "//lcm",
+        "//lcmtypes:viewer",
+        "//math:geometric_transform",
     ],
 )
 
@@ -147,7 +147,7 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":geometry_index",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -159,8 +159,8 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_index",
         ":shape_specification",
-        "//drake/common:copyable_unique_ptr",
-        "//drake/common:essential",
+        "//common:copyable_unique_ptr",
+        "//common:essential",
     ],
 )
 
@@ -168,14 +168,14 @@ drake_cc_library(
     name = "identifier",
     srcs = [],
     hdrs = ["identifier.h"],
-    deps = ["//drake/common:essential"],
+    deps = ["//common:essential"],
 )
 
 drake_cc_library(
     name = "shape_specification",
     srcs = ["shape_specification.cc"],
     hdrs = ["shape_specification.h"],
-    deps = ["//drake/common:essential"],
+    deps = ["//common:essential"],
 )
 
 # -----------------------------------------------------
@@ -184,7 +184,7 @@ drake_cc_googletest(
     name = "proximity_engine_test",
     deps = [
         ":proximity_engine",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -192,7 +192,7 @@ drake_cc_googletest(
     name = "frame_id_vector_test",
     deps = [
         ":frame_kinematics",
-        "//drake/geometry/test_utilities",
+        "//geometry/test_utilities",
     ],
 )
 
@@ -200,7 +200,7 @@ drake_cc_googletest(
     name = "frame_kinematics_vector_test",
     deps = [
         ":frame_kinematics",
-        "//drake/common/test_utilities",
+        "//common/test_utilities",
     ],
 )
 
@@ -208,7 +208,7 @@ drake_cc_googletest(
     name = "geometry_frame_test",
     deps = [
         ":geometry_frame",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -221,8 +221,8 @@ drake_cc_googletest(
     name = "geometry_state_test",
     deps = [
         ":geometry_state",
-        "//drake/common/test_utilities",
-        "//drake/geometry/test_utilities",
+        "//common/test_utilities",
+        "//geometry/test_utilities",
     ],
 )
 
@@ -231,7 +231,7 @@ drake_cc_googletest(
     deps = [
         ":geometry_system",
         ":geometry_visualization",
-        "//drake/geometry/test_utilities",
+        "//geometry/test_utilities",
     ],
 )
 
@@ -244,7 +244,7 @@ drake_cc_googletest(
     name = "query_object_test",
     deps = [
         ":geometry_system",
-        "//drake/geometry/test_utilities",
+        "//geometry/test_utilities",
     ],
 )
 
@@ -252,7 +252,7 @@ drake_cc_googletest(
     name = "shape_specification_test",
     deps = [
         ":shape_specification",
-        "//drake/common/test_utilities",
+        "//common/test_utilities",
     ],
 )
 

--- a/geometry/query_results/BUILD.bazel
+++ b/geometry/query_results/BUILD.bazel
@@ -14,8 +14,8 @@ drake_cc_library(
     srcs = [],
     hdrs = ["penetration_as_point_pair.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/geometry:geometry_ids",
+        "//common:essential",
+        "//geometry:geometry_ids",
     ],
 )
 

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -13,7 +13,7 @@ drake_cc_library(
         "drake_lcm_message_handler_interface.h",
     ],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -38,7 +38,7 @@ drake_cc_library(
     ],
     deps = [
         ":interface",
-        "//drake/common:essential",
+        "//common:essential",
         "@lcm",
     ],
 )
@@ -53,7 +53,7 @@ drake_cc_library(
     ],
     deps = [
         ":interface",
-        "//drake/common:essential",
+        "//common:essential",
         "@lcm",
     ],
 )
@@ -64,8 +64,8 @@ drake_cc_library(
     srcs = ["lcmt_drake_signal_utils.cc"],
     hdrs = ["lcmt_drake_signal_utils.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/lcmtypes:drake_signal",
+        "//common:essential",
+        "//lcmtypes:drake_signal",
     ],
 )
 
@@ -75,8 +75,8 @@ drake_cc_library(
         "translator_base.h",
     ],
     deps = [
-        "//drake/common:essential",
-        "//drake/common:unused",
+        "//common:essential",
+        "//common:unused",
     ],
 )
 

--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -26,7 +26,6 @@ load(
     "drake_vector_gen_lcm_sources",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 
 drake_lcm_cc_library(
     name = "acrobot",
@@ -236,12 +235,12 @@ _AUTOMOTIVE_LCM_SRCS = [
 # Generate *.lcm sources from *.named_vector files.
 drake_vector_gen_lcm_sources(
     name = "automotive_sources",
-    srcs = adjust_labels_for_drake_hoist([
-        "//drake/automotive:{}.named_vector".format(
+    srcs = [
+        "//automotive:{}.named_vector".format(
             x[len("lcmt_"):-len("_t.lcm")],
         )
         for x in _AUTOMOTIVE_LCM_SRCS
-    ]),
+    ],
 )
 
 # Generate C++ sources and a library from *.lcm sources.

--- a/manipulation/models/BUILD.bazel
+++ b/manipulation/models/BUILD.bazel
@@ -1,18 +1,17 @@
 # -*- python -*-
 
 load("@drake//tools/install:install.bzl", "install")
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 install(
     name = "install_data",
     visibility = ["//visibility:public"],
-    deps = adjust_labels_for_drake_hoist([
-        "//drake/manipulation/models/iiwa_description:install_data",
-        "//drake/manipulation/models/jaco_description:install_data",
-        "//drake/manipulation/models/wsg_50_description:install_data",
-        "//drake/manipulation/models/xtion_description:install_data",
-    ]),
+    deps = [
+        "//manipulation/models/iiwa_description:install_data",
+        "//manipulation/models/jaco_description:install_data",
+        "//manipulation/models/wsg_50_description:install_data",
+        "//manipulation/models/xtion_description:install_data",
+    ],
 )
 
 add_lint_tests()

--- a/manipulation/models/iiwa_description/BUILD.bazel
+++ b/manipulation/models/iiwa_description/BUILD.bazel
@@ -21,8 +21,8 @@ drake_cc_googletest(
     data = [":models"],
     local = 1,
     deps = [
-        "//drake/common:find_resource",
-        "//drake/multibody/parsers",
+        "//common:find_resource",
+        "//multibody/parsers",
     ],
 )
 

--- a/manipulation/models/jaco_description/BUILD.bazel
+++ b/manipulation/models/jaco_description/BUILD.bazel
@@ -18,8 +18,8 @@ drake_cc_googletest(
     srcs = ["urdf/test/jaco_arm_test.cc"],
     data = [":models"],
     deps = [
-        "//drake/common:find_resource",
-        "//drake/multibody/parsers",
+        "//common:find_resource",
+        "//multibody/parsers",
     ],
 )
 

--- a/manipulation/models/wsg_50_description/BUILD.bazel
+++ b/manipulation/models/wsg_50_description/BUILD.bazel
@@ -19,8 +19,8 @@ drake_cc_googletest(
     data = [":models"],
     local = 1,
     deps = [
-        "//drake/common:find_resource",
-        "//drake/multibody/parsers",
+        "//common:find_resource",
+        "//multibody/parsers",
     ],
 )
 

--- a/manipulation/perception/BUILD.bazel
+++ b/manipulation/perception/BUILD.bazel
@@ -16,8 +16,8 @@ drake_cc_library(
     hdrs = ["optitrack_pose_extractor.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "//drake/math:geometric_transform",
-        "//drake/systems/framework",
+        "//math:geometric_transform",
+        "//systems/framework",
         "@optitrack_driver//lcmtypes:optitrack_lcmtypes",
     ],
 )
@@ -27,9 +27,9 @@ drake_cc_library(
     srcs = ["pose_smoother.cc"],
     hdrs = ["pose_smoother.h"],
     deps = [
-        "//drake/manipulation/util:moving_average_filter",
-        "//drake/math:geometric_transform",
-        "//drake/systems/framework:leaf_system",
+        "//manipulation/util:moving_average_filter",
+        "//math:geometric_transform",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -37,8 +37,8 @@ drake_cc_googletest(
     name = "optitrack_pose_extractor_test",
     deps = [
         ":optitrack_pose_extractor",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/systems/framework",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework",
     ],
 )
 
@@ -46,10 +46,10 @@ drake_cc_googletest(
     name = "pose_smoother_test",
     deps = [
         ":pose_smoother",
-        "//drake/common/test_utilities:eigen_geometry_compare",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/manipulation/util:moving_average_filter",
-        "//drake/systems/framework",
+        "//common/test_utilities:eigen_geometry_compare",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//manipulation/util:moving_average_filter",
+        "//systems/framework",
     ],
 )
 

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -16,10 +16,10 @@ drake_cc_library(
     srcs = ["constraint_relaxing_ik.cc"],
     hdrs = ["constraint_relaxing_ik.h"],
     deps = [
-        "//drake/common/trajectories:piecewise_polynomial_trajectory",
-        "//drake/multibody:inverse_kinematics",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
+        "//common/trajectories:piecewise_polynomial_trajectory",
+        "//multibody:inverse_kinematics",
+        "//multibody:rigid_body_tree",
+        "//multibody/parsers",
     ],
 )
 
@@ -28,9 +28,9 @@ drake_cc_library(
     srcs = ["differential_inverse_kinematics.cc"],
     hdrs = ["differential_inverse_kinematics.h"],
     deps = [
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
-        "//drake/solvers:mathematical_program",
+        "//multibody:rigid_body_tree",
+        "//multibody/parsers",
+        "//solvers:mathematical_program",
     ],
 )
 
@@ -39,10 +39,10 @@ drake_cc_library(
     srcs = ["robot_plan_interpolator.cc"],
     hdrs = ["robot_plan_interpolator.h"],
     deps = [
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
-        "//drake/systems/framework:leaf_system",
+        "//common/trajectories:piecewise_polynomial",
+        "//multibody:rigid_body_tree",
+        "//multibody/parsers",
+        "//systems/framework:leaf_system",
         "@lcmtypes_bot2_core",
         "@lcmtypes_robotlocomotion",
     ],
@@ -55,7 +55,7 @@ drake_cc_googletest(
     size = "medium",
     srcs = ["test/constraint_relaxing_ik_test.cc"],
     data = [
-        "//drake/manipulation/models/iiwa_description:models",
+        "//manipulation/models/iiwa_description:models",
     ],
     # TODO(sam.creasey) This test currently times out on Mac with
     # IPOPT.  Once IPOPT is tuned to provide better/faster IK results
@@ -64,7 +64,7 @@ drake_cc_googletest(
     tags = ["snopt"],
     deps = [
         ":constraint_relaxing_ik",
-        "//drake/common:find_resource",
+        "//common:find_resource",
     ],
 )
 
@@ -72,7 +72,7 @@ drake_cc_googletest(
     name = "differential_inverse_kinematics_test",
     size = "medium",
     data = [
-        "//drake/manipulation/models/iiwa_description:models",
+        "//manipulation/models/iiwa_description:models",
     ],
     # TODO(siyuan.feng) This needs to be switched over to a accurate open
     # source QP sovler when we have one. Snopt is chosen here because it
@@ -82,22 +82,22 @@ drake_cc_googletest(
     ],
     deps = [
         ":differential_inverse_kinematics",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/examples/kuka_iiwa_arm:iiwa_common",
-        "//drake/manipulation/util:world_sim_tree_builder",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//examples/kuka_iiwa_arm:iiwa_common",
+        "//manipulation/util:world_sim_tree_builder",
     ],
 )
 
 drake_cc_googletest(
     name = "robot_plan_interpolator_test",
     data = [
-        "//drake/examples/kuka_iiwa_arm:models",
-        "//drake/manipulation/models/iiwa_description:models",
+        "//examples/kuka_iiwa_arm:models",
+        "//manipulation/models/iiwa_description:models",
     ],
     deps = [
         ":robot_plan_interpolator",
-        "//drake/common:find_resource",
-        "//drake/systems/framework",
+        "//common:find_resource",
+        "//systems/framework",
         "@lcmtypes_bot2_core",
         "@lcmtypes_robotlocomotion",
     ],

--- a/manipulation/schunk_wsg/BUILD.bazel
+++ b/manipulation/schunk_wsg/BUILD.bazel
@@ -19,7 +19,7 @@ drake_cc_library(
     name = "schunk_wsg_constants",
     hdrs = ["schunk_wsg_constants.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -35,10 +35,10 @@ drake_cc_library(
     hdrs = ["schunk_wsg_lcm.h"],
     deps = [
         ":schunk_wsg_trajectory_generator_state_vector",
-        "//drake/common/trajectories:piecewise_polynomial_trajectory",
-        "//drake/common/trajectories:trajectory",
-        "//drake/lcmtypes:schunk",
-        "//drake/systems/framework:leaf_system",
+        "//common/trajectories:piecewise_polynomial_trajectory",
+        "//common/trajectories:trajectory",
+        "//lcmtypes:schunk",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -49,13 +49,13 @@ drake_cc_library(
     deps = [
         ":schunk_wsg_constants",
         ":schunk_wsg_lcm",
-        "//drake/common:essential",
-        "//drake/systems/controllers:pid_controller",
-        "//drake/systems/framework:diagram",
-        "//drake/systems/framework:diagram_builder",
-        "//drake/systems/primitives:gain",
-        "//drake/systems/primitives:pass_through",
-        "//drake/systems/primitives:saturation",
+        "//common:essential",
+        "//systems/controllers:pid_controller",
+        "//systems/framework:diagram",
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:gain",
+        "//systems/primitives:pass_through",
+        "//systems/primitives:saturation",
     ],
 )
 
@@ -64,14 +64,14 @@ drake_cc_library(
 drake_cc_googletest(
     name = "schunk_wsg_constants_test",
     data = [
-        "//drake/manipulation/models/wsg_50_description:models",
+        "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":schunk_wsg_constants",
-        "//drake/common:find_resource",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody:rigid_body_tree",
+        "//multibody/parsers",
     ],
 )
 
@@ -80,18 +80,18 @@ drake_cc_googletest(
     deps = [
         ":schunk_wsg_constants",
         ":schunk_wsg_controller",
-        "//drake/systems/analysis:simulator",
+        "//systems/analysis:simulator",
     ],
 )
 
 drake_cc_googletest(
     name = "schunk_wsg_lcm_test",
     data = [
-        "//drake/manipulation/models/wsg_50_description:models",
+        "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":schunk_wsg_lcm",
-        "//drake/systems/analysis:simulator",
+        "//systems/analysis:simulator",
     ],
 )
 

--- a/manipulation/sensors/BUILD.bazel
+++ b/manipulation/sensors/BUILD.bazel
@@ -1,10 +1,12 @@
+# -*- python -*-
+
 load("//tools:drake.bzl", "drake_cc_library")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
 # This is tested by usage in:
-# //drake/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place
+# //examples/kuka_iiwa_arm/dev/monolithic_pick_and_place
 #   :monolithic_pick_and_place_demo.
 # TODO(eric.cousineau): Add a test here once #5227 is resolved.
 drake_cc_library(
@@ -12,19 +14,19 @@ drake_cc_library(
     srcs = ["xtion.cc"],
     hdrs = ["xtion.h"],
     data = [
-        "//drake/manipulation/models/xtion_description:models",
+        "//manipulation/models/xtion_description:models",
     ],
     deps = [
-        "//drake/common",
-        "//drake/lcm",
-        "//drake/manipulation/util:world_sim_tree_builder",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/multibody/rigid_body_plant:frame_visualizer",
-        "//drake/systems/framework:diagram_builder",
-        "//drake/systems/primitives:pass_through",
-        "//drake/systems/primitives:zero_order_hold",
-        "//drake/systems/sensors:image_to_lcm_image_array_t",
-        "//drake/systems/sensors:rgbd_camera",
+        "//common",
+        "//lcm",
+        "//manipulation/util:world_sim_tree_builder",
+        "//multibody/rigid_body_plant",
+        "//multibody/rigid_body_plant:frame_visualizer",
+        "//systems/framework:diagram_builder",
+        "//systems/primitives:pass_through",
+        "//systems/primitives:zero_order_hold",
+        "//systems/sensors:image_to_lcm_image_array_t",
+        "//systems/sensors:rgbd_camera",
     ],
 )
 

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -15,11 +15,11 @@ drake_cc_library(
     srcs = ["world_sim_tree_builder.cc"],
     hdrs = ["world_sim_tree_builder.h"],
     deps = [
-        "//drake/common:find_resource",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/multibody/parsers",
-        "//drake/multibody/rigid_body_plant:compliant_contact_model",
+        "//common:find_resource",
+        "//multibody:rigid_body_tree",
+        "//multibody:rigid_body_tree_construction",
+        "//multibody/parsers",
+        "//multibody/rigid_body_plant:compliant_contact_model",
     ],
 )
 
@@ -28,9 +28,9 @@ drake_cc_library(
     srcs = ["robot_state_msg_translator.cc"],
     hdrs = ["robot_state_msg_translator.h"],
     deps = [
-        "//drake/multibody:rigid_body_tree",
-        "//drake/util",
-        "//drake/util:lcm_util",
+        "//multibody:rigid_body_tree",
+        "//util",
+        "//util:lcm_util",
         "@lcmtypes_bot2_core",
     ],
 )
@@ -40,10 +40,10 @@ drake_cc_library(
     srcs = ["sim_diagram_builder.cc"],
     hdrs = ["sim_diagram_builder.h"],
     deps = [
-        "//drake/multibody/rigid_body_plant",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/systems/controllers:state_feedback_controller_interface",
-        "//drake/systems/framework",
+        "//multibody/rigid_body_plant",
+        "//multibody/rigid_body_plant:drake_visualizer",
+        "//systems/controllers:state_feedback_controller_interface",
+        "//systems/framework",
     ],
 )
 
@@ -52,13 +52,13 @@ drake_cc_library(
     srcs = ["simple_tree_visualizer.cc"],
     hdrs = ["simple_tree_visualizer.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/lcm",
-        "//drake/lcmtypes:viewer",
-        "//drake/multibody/rigid_body_plant:create_load_robot_message",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/systems/framework",
-        "//drake/systems/rendering:drake_visualizer_client",
+        "//common:essential",
+        "//lcm",
+        "//lcmtypes:viewer",
+        "//multibody/rigid_body_plant:create_load_robot_message",
+        "//multibody/rigid_body_plant:drake_visualizer",
+        "//systems/framework",
+        "//systems/rendering:drake_visualizer_client",
     ],
 )
 
@@ -71,9 +71,9 @@ drake_cc_library(
         "trajectory_utils.h",
     ],
     deps = [
-        "//drake/common/trajectories:piecewise_polynomial",
-        "//drake/common/trajectories:piecewise_quaternion",
-        "//drake/math:geometric_transform",
+        "//common/trajectories:piecewise_polynomial",
+        "//common/trajectories:piecewise_quaternion",
+        "//math:geometric_transform",
     ],
 )
 
@@ -82,16 +82,16 @@ drake_cc_binary(
     srcs = ["simple_tree_visualizer_demo.cc"],
     add_test_rule = 1,
     data = [
-        "//drake/manipulation/models/iiwa_description:models",
+        "//manipulation/models/iiwa_description:models",
     ],
     test_rule_args = ["--num_configurations=1"],
     deps = [
         ":simple_tree_visualizer",
-        "//drake/common:essential",
-        "//drake/common:find_resource",
-        "//drake/lcm",
-        "//drake/multibody/parsers",
-        "//drake/systems/framework",
+        "//common:essential",
+        "//common:find_resource",
+        "//lcm",
+        "//multibody/parsers",
+        "//systems/framework",
         "@gflags",
     ],
 )
@@ -101,7 +101,7 @@ drake_cc_library(
     name = "moving_average_filter",
     srcs = ["moving_average_filter.cc"],
     hdrs = ["moving_average_filter.h"],
-    deps = ["//drake/common:essential"],
+    deps = ["//common:essential"],
 )
 
 drake_cc_library(
@@ -109,12 +109,12 @@ drake_cc_library(
     srcs = ["frame_pose_tracker.cc"],
     hdrs = ["frame_pose_tracker.h"],
     deps = [
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/multibody_tree/math:spatial_velocity",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/systems/framework:leaf_system",
-        "//drake/systems/rendering:frame_velocity",
-        "//drake/systems/rendering:pose_bundle",
+        "//multibody:rigid_body_tree",
+        "//multibody/multibody_tree/math:spatial_velocity",
+        "//multibody/rigid_body_plant",
+        "//systems/framework:leaf_system",
+        "//systems/rendering:frame_velocity",
+        "//systems/rendering:pose_bundle",
     ],
 )
 
@@ -125,17 +125,17 @@ drake_cc_googletest(
     # TODO(siyuan): we should eventually move the models for test outside of
     # /examples.
     data = [
-        "//drake/examples/valkyrie:models",
-        "//drake/manipulation/models/iiwa_description:models",
-        "//drake/manipulation/models/wsg_50_description:models",
+        "//examples/valkyrie:models",
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":robot_state_msg_translator",
-        "//drake/common:find_resource",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/multibody/parsers",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+        "//multibody:rigid_body_tree_construction",
+        "//multibody/parsers",
     ],
 )
 
@@ -143,7 +143,7 @@ drake_cc_googletest(
     name = "trajectory_utils_test",
     deps = [
         ":trajectory_utils",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -152,43 +152,43 @@ drake_cc_googletest(
     srcs = ["test/moving_average_filter_test.cc"],
     deps = [
         ":moving_average_filter",
-        "//drake/common:essential",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
 drake_cc_googletest(
     name = "sim_diagram_builder_test",
     data = [
-        "//drake/examples/kuka_iiwa_arm:models",
-        "//drake/manipulation/models/iiwa_description:models",
-        "//drake/manipulation/models/wsg_50_description:models",
+        "//examples/kuka_iiwa_arm:models",
+        "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":sim_diagram_builder",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/lcm",
-        "//drake/manipulation/util:world_sim_tree_builder",
-        "//drake/multibody/rigid_body_plant",
-        "//drake/systems/analysis",
-        "//drake/systems/controllers:inverse_dynamics_controller",
-        "//drake/systems/controllers:pid_controller",
-        "//drake/systems/framework",
-        "//drake/systems/primitives:constant_vector_source",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//lcm",
+        "//manipulation/util:world_sim_tree_builder",
+        "//multibody/rigid_body_plant",
+        "//systems/analysis",
+        "//systems/controllers:inverse_dynamics_controller",
+        "//systems/controllers:pid_controller",
+        "//systems/framework",
+        "//systems/primitives:constant_vector_source",
     ],
 )
 
 drake_cc_googletest(
     name = "frame_pose_tracker_test",
-    data = ["//drake/manipulation/models/iiwa_description:models"],
+    data = ["//manipulation/models/iiwa_description:models"],
     deps = [
         ":frame_pose_tracker",
-        "//drake/common:find_resource",
-        "//drake/common/test_utilities:eigen_geometry_compare",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody/parsers",
-        "//drake/systems/framework",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_geometry_compare",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody:rigid_body_tree",
+        "//multibody/parsers",
+        "//systems/framework",
     ],
 )
 

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -10,9 +10,9 @@ drake_cc_library(
     srcs = ["autodiff.cc"],
     hdrs = ["autodiff.h"],
     deps = [
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:unused",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:unused",
     ],
 )
 
@@ -21,8 +21,8 @@ drake_cc_library(
     srcs = ["continuous_algebraic_riccati_equation.cc"],
     hdrs = ["continuous_algebraic_riccati_equation.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/common:is_approx_equal_abstol",
+        "//common:essential",
+        "//common:is_approx_equal_abstol",
     ],
 )
 
@@ -32,8 +32,8 @@ drake_cc_library(
     hdrs = ["discrete_algebraic_riccati_equation.h"],
     deps = [
         ":autodiff",
-        "//drake/common:essential",
-        "//drake/common:is_approx_equal_abstol",
+        "//common:essential",
+        "//common:is_approx_equal_abstol",
     ],
 )
 
@@ -57,8 +57,8 @@ drake_cc_library(
         "rotation_matrix.h",
     ],
     deps = [
-        "//drake/common:essential",
-        "//drake/common:is_approx_equal_abstol",
+        "//common:essential",
+        "//common:is_approx_equal_abstol",
     ],
 )
 
@@ -67,7 +67,7 @@ drake_cc_library(
     srcs = ["orthonormal_basis.cc"],
     hdrs = ["orthonormal_basis.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -79,7 +79,7 @@ drake_cc_library(
         "cross_product.h",
     ],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -101,7 +101,7 @@ drake_cc_library(
     deps = [
         ":autodiff",
         ":vector3_util",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -110,8 +110,8 @@ drake_cc_library(
     srcs = ["matrix_util.cc"],
     hdrs = ["matrix_util.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/common:number_traits",
+        "//common:essential",
+        "//common:number_traits",
     ],
 )
 
@@ -120,7 +120,7 @@ drake_cc_library(
     srcs = ["eigen_sparse_triplet.cc"],
     hdrs = ["eigen_sparse_triplet.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -137,7 +137,7 @@ drake_cc_library(
     hdrs = ["expmap.h"],
     deps = [
         ":gradient",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -146,7 +146,7 @@ drake_cc_library(
     srcs = ["gray_code.cc"],
     hdrs = ["gray_code.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
         "@eigen",
     ],
 )
@@ -156,8 +156,8 @@ drake_cc_library(
     srcs = ["jacobian.cc"],
     hdrs = ["jacobian.h"],
     deps = [
-        "//drake/common:autodiff",
-        "//drake/common:essential",
+        "//common:autodiff",
+        "//common:essential",
     ],
 )
 
@@ -166,7 +166,7 @@ drake_cc_library(
     srcs = ["quadratic_form.cc"],
     hdrs = ["quadratic_form.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
         "@eigen",
     ],
 )
@@ -176,10 +176,10 @@ drake_cc_library(
     srcs = [],
     hdrs = ["saturate.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
         # TODO(jwnimmer-tri) Remove once cond() no longer requires it.
-        "//drake/common:autodiff",
-        "//drake/common:cond",
+        "//common:autodiff",
+        "//common:cond",
     ],
 )
 
@@ -190,7 +190,7 @@ drake_cc_googletest(
     deps = [
         ":autodiff",
         ":gradient",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -198,7 +198,7 @@ drake_cc_googletest(
     name = "continuous_algebraic_riccati_equation_test",
     deps = [
         ":continuous_algebraic_riccati_equation",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -206,7 +206,7 @@ drake_cc_googletest(
     name = "cross_product_test",
     deps = [
         ":vector3_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -214,7 +214,7 @@ drake_cc_googletest(
     name = "convert_time_derivative_test",
     deps = [
         ":vector3_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -222,7 +222,7 @@ drake_cc_googletest(
     name = "discrete_algebraic_riccati_equation_test",
     deps = [
         ":discrete_algebraic_riccati_equation",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -230,7 +230,7 @@ drake_cc_googletest(
     name = "evenly_distributed_pts_on_sphere_test",
     deps = [
         ":evenly_distributed_pts_on_sphere",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -238,7 +238,7 @@ drake_cc_googletest(
     name = "expmap_test",
     deps = [
         ":expmap",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -246,7 +246,7 @@ drake_cc_googletest(
     name = "eigen_sparse_triplet_test",
     deps = [
         ":eigen_sparse_triplet",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -255,7 +255,7 @@ drake_cc_googletest(
     deps = [
         ":gradient",
         ":jacobian",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -263,7 +263,7 @@ drake_cc_googletest(
     name = "gradient_util_test",
     deps = [
         ":gradient",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -271,7 +271,7 @@ drake_cc_googletest(
     name = "gray_code_test",
     deps = [
         ":gray_code",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -279,8 +279,8 @@ drake_cc_googletest(
     name = "matrix_util_test",
     deps = [
         ":matrix_util",
-        "//drake/common:symbolic",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common:symbolic",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -288,7 +288,7 @@ drake_cc_googletest(
     name = "normalize_vector_test",
     deps = [
         ":gradient",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -296,7 +296,7 @@ drake_cc_googletest(
     name = "orthonormal_basis_test",
     deps = [
         ":orthonormal_basis",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -304,7 +304,7 @@ drake_cc_googletest(
     name = "quadratic_form_test",
     deps = [
         ":quadratic_form",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -312,8 +312,8 @@ drake_cc_googletest(
     name = "quaternion_test",
     deps = [
         ":geometric_transform",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:autodiff",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
     ],
 )
 
@@ -321,7 +321,7 @@ drake_cc_googletest(
     name = "rotation_matrix_test",
     deps = [
         ":geometric_transform",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -330,7 +330,7 @@ drake_cc_googletest(
     deps = [
         ":geometric_transform",
         ":gradient",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -338,8 +338,8 @@ drake_cc_googletest(
     name = "saturate_test",
     deps = [
         ":saturate",
-        "//drake/common:autodiff",
-        "//drake/common:symbolic",
+        "//common:autodiff",
+        "//common:symbolic",
     ],
 )
 

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -14,7 +14,7 @@ drake_cc_library(
     srcs = ["point_cloud_flags.cc"],
     hdrs = ["point_cloud_flags.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -24,7 +24,7 @@ drake_cc_library(
     hdrs = ["point_cloud.h"],
     deps = [
         ":point_cloud_flags",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -41,7 +41,7 @@ drake_cc_googletest(
     srcs = ["test/point_cloud_test.cc"],
     deps = [
         ":point_cloud",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/perception/dev/BUILD.bazel
+++ b/perception/dev/BUILD.bazel
@@ -17,7 +17,7 @@ drake_cc_library(
         "neural_network.h",
     ],
     deps = [
-        "//drake/systems/framework",
+        "//systems/framework",
     ],
 )
 
@@ -31,7 +31,7 @@ drake_cc_library(
     ],
     deps = [
         ":neural_network",
-        "//drake/systems/framework",
+        "//systems/framework",
     ],
 )
 
@@ -42,7 +42,7 @@ drake_cc_googletest(
     srcs = ["test/feedforward_neural_network_test.cc"],
     deps = [
         ":feedforward_neural_network",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/perception/estimators/dev/BUILD.bazel
+++ b/perception/estimators/dev/BUILD.bazel
@@ -15,8 +15,8 @@ drake_cc_library(
     srcs = ["pose_closed_form.cc"],
     hdrs = ["pose_closed_form.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
+        "//common:essential",
+        "//math:geometric_transform",
     ],
 )
 
@@ -25,7 +25,7 @@ drake_cc_library(
     srcs = ["scene.cc"],
     hdrs = ["scene.h"],
     deps = [
-        "//drake/multibody:rigid_body_tree",
+        "//multibody:rigid_body_tree",
     ],
 )
 
@@ -35,7 +35,7 @@ drake_cc_library(
     hdrs = ["articulated_icp.h"],
     deps = [
         ":scene",
-        "//drake/solvers:cost",
+        "//solvers:cost",
     ],
 )
 
@@ -58,12 +58,12 @@ drake_cc_library(
     hdrs = ["test/test_util.h"],
     data = [":test_models"],
     deps = [
-        "//drake/common",
-        "//drake/common/test_utilities:eigen_geometry_compare",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/lcm",
-        "//drake/lcmtypes:viewer",
-        "//drake/math:geometric_transform",
+        "//common",
+        "//common/test_utilities:eigen_geometry_compare",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//lcm",
+        "//lcmtypes:viewer",
+        "//math:geometric_transform",
         "@gtest//:without_main",
         "@lcmtypes_bot2_core",
         "@vtk//:vtkFiltersGeneral",
@@ -76,7 +76,7 @@ drake_cc_googletest(
     deps = [
         ":pose_closed_form",
         ":test_util",
-        "//drake/common/test_utilities:eigen_geometry_compare",
+        "//common/test_utilities:eigen_geometry_compare",
     ],
 )
 
@@ -88,15 +88,15 @@ drake_cc_googletest(
     deps = [
         ":articulated_icp",
         ":test_util",
-        "//drake/common:find_resource",
-        "//drake/lcmtypes:viewer",
-        "//drake/math:geometric_transform",
-        "//drake/multibody:rigid_body_tree",
-        "//drake/multibody:rigid_body_tree_construction",
-        "//drake/multibody/parsers",
-        "//drake/multibody/rigid_body_plant:create_load_robot_message",
-        "//drake/multibody/rigid_body_plant:drake_visualizer",
-        "//drake/solvers:mathematical_program",
+        "//common:find_resource",
+        "//lcmtypes:viewer",
+        "//math:geometric_transform",
+        "//multibody:rigid_body_tree",
+        "//multibody:rigid_body_tree_construction",
+        "//multibody/parsers",
+        "//multibody/rigid_body_plant:create_load_robot_message",
+        "//multibody/rigid_body_plant:drake_visualizer",
+        "//solvers:mathematical_program",
     ],
 )
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -8,7 +8,6 @@ load(
 )
 load("//tools/skylark:test_tags.bzl", "gurobi_test_tags", "mosek_test_tags")
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,10 +26,10 @@ drake_cc_library(
     hdrs = ["evaluator_base.h"],
     deps = [
         ":function",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
-        "//drake/math:matrix_util",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:polynomial",
+        "//math:matrix_util",
     ],
 )
 
@@ -40,10 +39,10 @@ drake_cc_library(
     hdrs = ["constraint.h"],
     deps = [
         ":evaluator_base",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
-        "//drake/math:matrix_util",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:polynomial",
+        "//math:matrix_util",
     ],
 )
 
@@ -53,10 +52,10 @@ drake_cc_library(
     hdrs = ["cost.h"],
     deps = [
         ":evaluator_base",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
-        "//drake/math:matrix_util",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:polynomial",
+        "//math:matrix_util",
     ],
 )
 
@@ -66,11 +65,11 @@ drake_cc_library(
     hdrs = ["symbolic_extraction.h"],
     deps = [
         ":decision_variable",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:number_traits",
-        "//drake/common:polynomial",
-        "//drake/common:symbolic",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:number_traits",
+        "//common:polynomial",
+        "//common:symbolic",
     ],
 )
 
@@ -82,10 +81,10 @@ drake_cc_library(
         ":binding",
         ":constraint",
         ":symbolic_extraction",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
-        "//drake/common:symbolic",
-        "//drake/math:quadratic_form",
+        "//common:essential",
+        "//common:polynomial",
+        "//common:symbolic",
+        "//math:quadratic_form",
     ],
 )
 
@@ -97,10 +96,10 @@ drake_cc_library(
         ":binding",
         ":cost",
         ":symbolic_extraction",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
-        "//drake/common:symbolic",
-        "//drake/common:unused",
+        "//common:essential",
+        "//common:polynomial",
+        "//common:symbolic",
+        "//common:unused",
     ],
 )
 
@@ -109,7 +108,7 @@ drake_cc_library(
     srcs = ["decision_variable.cc"],
     hdrs = ["decision_variable.h"],
     deps = [
-        "//drake/common:symbolic",
+        "//common:symbolic",
     ],
 )
 
@@ -118,7 +117,7 @@ drake_cc_library(
     srcs = [],
     hdrs = ["function.h"],
     deps = [
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -132,8 +131,8 @@ drake_cc_library(
     srcs = ["solver_id.cc"],
     hdrs = ["solver_id.h"],
     deps = [
-        "//drake/common:essential",
-        "//drake/common:reinit_after_move",
+        "//common:essential",
+        "//common:reinit_after_move",
     ],
 )
 
@@ -142,8 +141,8 @@ drake_cc_library(
     srcs = ["indeterminate.cc"],
     hdrs = ["indeterminate.h"],
     deps = [
-        "//drake/common:symbolic",
-        "//drake/solvers:decision_variable",
+        "//common:symbolic",
+        "//solvers:decision_variable",
     ],
 )
 
@@ -164,7 +163,7 @@ drake_cc_library(
         ":snopt_solver",
         ":solver_id",
         ":solver_type",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -193,11 +192,11 @@ drake_cc_library(
         ":snopt_solver",
         ":solver_id",
         ":symbolic_extraction",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:number_traits",
-        "//drake/common:polynomial",
-        "//drake/common:symbolic",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:number_traits",
+        "//common:polynomial",
+        "//common:symbolic",
     ],
 )
 
@@ -207,7 +206,7 @@ drake_cc_library(
     hdrs = ["non_convex_optimization_util.h"],
     deps = [
         ":mathematical_program",
-        "//drake/math:quadratic_form",
+        "//math:quadratic_form",
     ],
 )
 
@@ -217,8 +216,8 @@ drake_cc_library(
     hdrs = ["bilinear_product_util.h"],
     deps = [
         ":decision_variable",
-        "//drake/common:essential",
-        "//drake/common:symbolic",
+        "//common:essential",
+        "//common:symbolic",
     ],
 )
 
@@ -237,9 +236,9 @@ drake_cc_library(
     hdrs = ["system_identification.h"],
     deps = [
         ":mathematical_program",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:polynomial",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:polynomial",
     ],
 )
 
@@ -256,7 +255,7 @@ drake_cc_library(
         ":bilinear_product_util",
         ":mathematical_program",
         ":mixed_integer_optimization_util",
-        "//drake/math:gradient",
+        "//math:gradient",
     ],
 )
 
@@ -271,7 +270,7 @@ drake_cc_library(
     ],
     deps = [
         ":rotation_constraint",
-        "//drake/common/proto:call_matlab",
+        "//common/proto:call_matlab",
     ],
 )
 
@@ -310,7 +309,7 @@ drake_cc_googletest(
     name = "indeterminate_test",
     deps = [
         ":indeterminate",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -334,7 +333,7 @@ drake_cc_library(
         ":mathematical_program",
         ":mathematical_program_test_util",
         ":solver_type_converter",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
         "@gtest//:without_main",
     ],
 )
@@ -366,7 +365,7 @@ drake_cc_library(
     hdrs = ["test/second_order_cone_program_examples.h"],
     deps = [
         ":mathematical_program_test_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -377,7 +376,7 @@ drake_cc_library(
     hdrs = ["test/semidefinite_program_examples.h"],
     deps = [
         ":mathematical_program_test_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -406,10 +405,10 @@ drake_cc_library(
         ":function",
         ":indeterminate",
         ":solver_id",
-        "//drake/common:autodiff",
-        "//drake/common:essential",
-        "//drake/common:number_traits",
-        "//drake/common:polynomial",
+        "//common:autodiff",
+        "//common:essential",
+        "//common:number_traits",
+        "//common:polynomial",
     ],
 )
 
@@ -421,7 +420,7 @@ drake_cc_library(
     hdrs = ["equality_constrained_qp_solver.h"],
     deps = [
         ":mathematical_program_api",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -431,7 +430,7 @@ drake_cc_library(
     hdrs = ["linear_system_solver.h"],
     deps = [
         ":mathematical_program_api",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -441,7 +440,7 @@ drake_cc_library(
     hdrs = ["moby_lcp_solver.h"],
     deps = [
         ":mathematical_program_api",
-        "//drake/common:essential",
+        "//common:essential",
     ],
 )
 
@@ -455,7 +454,7 @@ drake_cc_library(
     hdrs = ["dreal_solver.h"],
     deps = [
         ":mathematical_program_api",
-        "//drake/common:essential",
+        "//common:essential",
         "@dreal",
     ],
 )
@@ -479,11 +478,11 @@ drake_cc_library(
     }),
     hdrs = ["gurobi_solver.h"],
     deps = select({
-        "//tools:with_gurobi": adjust_labels_for_drake_hoist([
+        "//tools:with_gurobi": [
             ":mathematical_program_api",
-            "//drake/math:eigen_sparse_triplet",
+            "//math:eigen_sparse_triplet",
             "@gurobi",
-        ]),
+        ],
         "//conditions:default": [
             ":mathematical_program_api",
         ],
@@ -507,11 +506,11 @@ drake_cc_library(
     }),
     hdrs = ["mosek_solver.h"],
     deps = select({
-        "//tools:with_mosek": adjust_labels_for_drake_hoist([
+        "//tools:with_mosek": [
             ":mathematical_program_api",
-            "//drake/common:scoped_singleton",
+            "//common:scoped_singleton",
             "@mosek",
-        ]),
+        ],
         "//conditions:default": [
             ":mathematical_program_api",
         ],
@@ -546,11 +545,11 @@ drake_cc_library(
     # snopt_wrapper.cc could still have full `-pedantic` checks enabled.)
     copts = ["-fpermissive"],
     deps = select({
-        "//tools:with_snopt": adjust_labels_for_drake_hoist([
+        "//tools:with_snopt": [
             ":mathematical_program_api",
-            "//drake/math:autodiff",
+            "//math:autodiff",
             "@snopt//:snopt_c",
-        ]),
+        ],
         "//conditions:default": [
             ":mathematical_program_api",
         ],
@@ -571,12 +570,12 @@ drake_cc_library(
     }),
     hdrs = ["ipopt_solver.h"],
     deps = select({
-        "//conditions:default": adjust_labels_for_drake_hoist([
+        "//conditions:default": [
             "@ipopt",
             ":mathematical_program_api",
-            "//drake/common:unused",
-            "//drake/math:autodiff",
-        ]),
+            "//common:unused",
+            "//math:autodiff",
+        ],
         "//tools:no_ipopt": [
             ":mathematical_program_api",
         ],
@@ -597,11 +596,11 @@ drake_cc_library(
     }),
     hdrs = ["nlopt_solver.h"],
     deps = select({
-        "//conditions:default": adjust_labels_for_drake_hoist([
+        "//conditions:default": [
             ":mathematical_program_api",
-            "//drake/math:autodiff",
+            "//math:autodiff",
             "@nlopt",
-        ]),
+        ],
         "//tools:no_nlopt": [
             ":mathematical_program_api",
         ],
@@ -622,12 +621,12 @@ drake_cc_library(
     }),
     hdrs = ["scs_solver.h"],
     deps = select({
-        "//conditions:default": adjust_labels_for_drake_hoist([
+        "//conditions:default": [
             ":mathematical_program_api",
-            "//drake/common:essential",
-            "//drake/math:eigen_sparse_triplet",
+            "//common:essential",
+            "//math:eigen_sparse_triplet",
             "@scs//:scsdir",
-        ]),
+        ],
         "//tools:no_scs": [
             ":mathematical_program_api",
         ],
@@ -665,7 +664,7 @@ drake_cc_library(
     hdrs = ["mixed_integer_optimization_util.h"],
     deps = [
         ":mathematical_program",
-        "//drake/math:gray_code",
+        "//math:gray_code",
     ],
 )
 
@@ -674,7 +673,7 @@ drake_cc_googletest(
     name = "bilinear_product_util_test",
     deps = [
         ":bilinear_product_util",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -686,7 +685,7 @@ drake_cc_googletest(
     deps = [
         ":binding",
         ":constraint",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -694,9 +693,9 @@ drake_cc_googletest(
     name = "evaluator_base_test",
     deps = [
         ":evaluator_base",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:is_dynamic_castable",
-        "//drake/math:gradient",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:is_dynamic_castable",
+        "//math:gradient",
     ],
 )
 
@@ -704,8 +703,8 @@ drake_cc_googletest(
     name = "constraint_test",
     deps = [
         ":constraint",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:gradient",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:gradient",
     ],
 )
 
@@ -716,9 +715,9 @@ drake_cc_googletest(
         ":cost",
         ":create_cost",
         ":generic_trivial_cost",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:is_dynamic_castable",
-        "//drake/math:gradient",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:is_dynamic_castable",
+        "//math:gradient",
     ],
 )
 
@@ -726,8 +725,8 @@ drake_cc_googletest(
     name = "symbolic_extraction_test",
     deps = [
         ":symbolic_extraction",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -743,7 +742,7 @@ drake_cc_googletest(
     name = "create_constraint_test",
     deps = [
         ":create_constraint",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -751,7 +750,7 @@ drake_cc_googletest(
     name = "decision_variable_test",
     deps = [
         ":mathematical_program",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -763,7 +762,7 @@ drake_cc_googletest(
     deps = [
         ":mathematical_program",
         ":mathematical_program_test_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -797,7 +796,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":quadratic_program_examples",
         ":second_order_cone_program_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -820,7 +819,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":optimization_examples",
         ":quadratic_program_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -831,7 +830,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":mathematical_program",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -844,7 +843,7 @@ drake_cc_googletest(
         ":mathematical_program",
         ":mathematical_program_test_util",
         ":optimization_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -858,10 +857,10 @@ drake_cc_googletest(
         ":generic_trivial_cost",
         ":mathematical_program",
         ":mathematical_program_test_util",
-        "//drake/common:symbolic",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:is_dynamic_castable",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common:symbolic",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:is_dynamic_castable",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -878,7 +877,7 @@ drake_cc_googletest(
         ":add_solver_util",
         ":mathematical_program",
         ":mathematical_program_test_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -886,7 +885,7 @@ drake_cc_googletest(
     name = "moby_lcp_solver_test",
     deps = [
         ":mathematical_program",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -918,7 +917,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":optimization_examples",
         ":quadratic_program_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -931,8 +930,8 @@ drake_cc_googletest(
     deps = [
         ":decision_variable",
         ":non_convex_optimization_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:symbolic_test_util",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:symbolic_test_util",
     ],
 )
 
@@ -945,8 +944,8 @@ drake_cc_googletest(
         ":mathematical_program",
         ":mathematical_program_test_util",
         ":optimization_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:is_dynamic_castable",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:is_dynamic_castable",
     ],
 )
 
@@ -965,8 +964,8 @@ drake_cc_googletest(
         ":gurobi_solver",
         ":mathematical_program",
         ":rotation_constraint",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -976,8 +975,8 @@ drake_cc_googletest(
     deps = [
         ":mathematical_program",
         ":rotation_constraint",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/math:geometric_transform",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
     ],
 )
 
@@ -988,7 +987,7 @@ drake_cc_binary(
     deps = [
         ":mathematical_program",
         ":rotation_constraint",
-        "//drake/common/proto:call_matlab",
+        "//common/proto:call_matlab",
     ],
 )
 
@@ -1005,7 +1004,7 @@ drake_cc_googletest(
         ":gurobi_solver",
         ":mathematical_program",
         ":rotation_constraint",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -1035,7 +1034,7 @@ drake_cc_googletest(
         ":mathematical_program_test_util",
         ":optimization_examples",
         ":quadratic_program_examples",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -1068,7 +1067,7 @@ drake_cc_googletest(
     size = "large",
     deps = [
         ":system_identification",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -1087,7 +1086,7 @@ drake_cc_googletest(
     deps = [
         ":gurobi_solver",
         ":mixed_integer_optimization_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -8,8 +8,6 @@ exports_files(
     ["com_github_bazelbuild_bazel/tools/cpp/osx_cc_wrapper.sh"],
     visibility = [
         "//common:__pkg__",
-        # TODO(6996) Remove the next line once #6996 is fully merged.
-        "//drake/common:__pkg__",
         "//tools/cc_toolchain:__pkg__",
     ],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,6 @@
 # -*- python -*-
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load("//tools/skylark:6996.bzl", "adjust_labels_for_drake_hoist")
 load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -9,18 +8,18 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "drake_visualizer.impl",
     srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
-    data = adjust_labels_for_drake_hoist([
-        "//drake/examples:prod_models",
+    data = [
+        "//examples:prod_models",
         "@drake_visualizer",
-    ]),
+    ],
     main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
     visibility = ["//visibility:private"],
     # Python libraries to import.
-    deps = adjust_labels_for_drake_hoist([
-        "//drake/bindings/pydrake",
-        "//drake/lcmtypes:lcmtypes_py",
+    deps = [
+        "//bindings/pydrake",
+        "//lcmtypes:lcmtypes_py",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
-    ]),
+    ],
 )
 
 drake_runfiles_binary(

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -13,15 +13,8 @@ load(
     "drake_transitive_installed_hdrs_filegroup",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_labels_for_drake_hoist",
-    "HAS_MOVED_6996",
-)
 load(":build_components.bzl", "LIBDRAKE_COMPONENTS")
 load("//tools:drake.bzl", "drake_cc_binary")
-
-LIBDRAKE_COMPONENTS = adjust_labels_for_drake_hoist(LIBDRAKE_COMPONENTS)
 
 cmake_config(
     cps_file_name = "drake.cps",
@@ -57,7 +50,7 @@ install(
     name = "install",
     targets = ["libdrake.so"],
     hdrs = [":libdrake_headers"],
-    hdr_dest = "include/drake" if HAS_MOVED_6996 else "include",
+    hdr_dest = "include/drake",
     allowed_externals = ["//:LICENSE.TXT"],  # Root for our #include paths.
     deps = [
         ":install_cmake_config",
@@ -90,8 +83,8 @@ cc_library(
     visibility = [],
     deps = [
         # TODO(jwnimmer-tri) This duplicates the list of VTK libraries needed
-        # by //drake/sensors.  We should find a way for ":drake_shared_library"
-        # to be declared without having to repeat this list here.
+        # by //sensors.  We should find a way for ":drake_shared_library" to be
+        # declared without having to repeat this list here.
         "@vtk//:vtkCommonCore",
         "@vtk//:vtkCommonDataModel",
         "@vtk//:vtkCommonTransforms",
@@ -113,12 +106,12 @@ cc_library(
 cc_library(
     name = "drake_shared_library",
     hdrs = [":libdrake_headers"],
-    include_prefix = "drake" if HAS_MOVED_6996 else None,
-    strip_include_prefix = "/" if HAS_MOVED_6996 else None,
-    visibility = adjust_labels_for_drake_hoist([
-        "//drake/bindings/pydrake:__subpackages__",
-        "//drake/examples:__subpackages__",
-    ]),
+    include_prefix = "drake",
+    strip_include_prefix = "/",
+    visibility = [
+        "//bindings/pydrake:__subpackages__",
+        "//examples:__subpackages__",
+    ],
     deps = [
         ":gurobi_deps",
         ":mosek_deps",

--- a/tools/vector_gen/BUILD.bazel
+++ b/tools/vector_gen/BUILD.bazel
@@ -85,8 +85,8 @@ drake_cc_googletest(
     name = "sample_test",
     deps = [
         ":sample",
-        "//drake/common:autodiff",
-        "//drake/common:symbolic",
+        "//common:autodiff",
+        "//common:symbolic",
     ],
 )
 
@@ -94,7 +94,7 @@ drake_cc_googletest(
     name = "sample_translator_test",
     deps = [
         ":sample_translator",
-        "//drake/common/test_utilities",
+        "//common/test_utilities",
     ],
 )
 

--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -520,11 +520,9 @@ def generate_code(
         # name after "external" will vary depending on what name the workspace
         # gave us, so we can't hard-code it to "drake".)
         cxx_include_path = "/".join(cxx_include_path.split("/")[2:])
-    # TODO(#6996) Do this unconditionally once #6996 shuffle is finished.
-    if not cxx_include_path.startswith("drake/"):
-        # TODO(jwnimmer-tri) For use outside of Drake, this include_prefix
-        # should probably be configurable, instead of hard-coded here.
-        cxx_include_path = "drake/" + cxx_include_path
+    # TODO(jwnimmer-tri) For use outside of Drake, this include_prefix should
+    # probably be configurable, instead of hard-coded here.
+    cxx_include_path = "drake/" + cxx_include_path
     snake, _ = os.path.splitext(os.path.basename(named_vector_filename))
     screaming_snake = snake.upper()
     camel = "".join([x.capitalize() for x in snake.split("_")])

--- a/tools/vector_gen/vector_gen.bzl
+++ b/tools/vector_gen/vector_gen.bzl
@@ -117,8 +117,8 @@ def drake_cc_vector_gen_library(
         srcs = outs.srcs,
         hdrs = outs.hdrs,
         deps = deps + [
-            "//drake/systems/framework:vector",
-            "//drake/common:essential",
+            "//systems/framework:vector",
+            "//common:essential",
         ],
         **kwargs)
 
@@ -145,8 +145,8 @@ def drake_cc_vector_gen_translator_library(
         srcs = outs.srcs,
         hdrs = outs.hdrs,
         deps = deps + [
-            "//drake/common:essential",
-            "//drake/systems/lcm:translator",
+            "//common:essential",
+            "//systems/lcm:translator",
         ],
         **kwargs)
 

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -15,9 +15,9 @@ drake_cc_library(
         "drakeUtil.h",
     ],
     deps = [
-        "//drake/common:essential",
-        "//drake/math:geometric_transform",
-        "//drake/math:gradient",
+        "//common:essential",
+        "//math:geometric_transform",
+        "//math:gradient",
     ],
 )
 
@@ -27,7 +27,7 @@ drake_cc_library(
     hdrs = ["lcmUtil.h"],
     deps = [
         ":util",
-        "//drake/math:geometric_transform",
+        "//math:geometric_transform",
         "@eigen",
         "@lcmtypes_bot2_core",
     ],
@@ -40,7 +40,7 @@ drake_cc_googletest(
     srcs = ["test/testDrakeGeometryUtil.cpp"],
     deps = [
         ":util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 
@@ -49,9 +49,9 @@ drake_cc_googletest(
     srcs = ["test/testLCMUtil.cpp"],
     deps = [
         ":lcm_util",
-        "//drake/common/test_utilities:eigen_matrix_compare",
-        "//drake/common/test_utilities:random_polynomial_matrix",
-        "//drake/common/trajectories:random_piecewise_polynomial",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:random_polynomial_matrix",
+        "//common/trajectories:random_piecewise_polynomial",
     ],
 )
 


### PR DESCRIPTION
This converts perhaps half of the tree to the new spelling.  This doesn't cover `systems` or `examples` to avoid other possibly active PRs there at the moment, and to keep this PR size under control.  Future plan is to PR those folders and then deprecate the auto-adjustment with warnings, then later on remove the auto-adjustment entirely.

Relates #6996.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8004)
<!-- Reviewable:end -->
