### PR TITLE
rgbd_render: Add RenderingConfig::kDefaultShowWindow, use this for testing as well.

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -478,11 +478,8 @@ sh_test(
     name = "rgbd_camera_publish_lcm_test",
     srcs = ["rgbd_camera_publish_lcm_example"],
     args = [
-        # TODO(eric.cousineau): Find skylark rule that can resolve
-        # "test/models/sphere.sdf" to the path below.
         "--sdf_dir=" + native.package_name() + "/test/models",
         "--duration=0.1",
-        "--show_window=false",
     ],
     data = [
         ":test_models",

--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -128,7 +128,7 @@ class RgbdCamera final : public LeafSystem<double> {
              double z_near = 0.5,
              double z_far = 5.0,
              double fov_y = M_PI_4,
-             bool show_window = true);
+             bool show_window = RenderingConfig::kDefaultShowWindow);
 
   /// A constructor for %RgbdCamera that defines `B` using a RigidBodyFrame.
   /// The pose of %RgbdCamera is fixed to a user-defined frame and will be
@@ -167,7 +167,7 @@ class RgbdCamera final : public LeafSystem<double> {
              double z_near = 0.5,
              double z_far = 5.0,
              double fov_y = M_PI_4,
-             bool show_window = true);
+             bool show_window = RenderingConfig::kDefaultShowWindow);
 
   ~RgbdCamera() = default;
 

--- a/systems/sensors/rgbd_camera_publish_lcm_example.cc
+++ b/systems/sensors/rgbd_camera_publish_lcm_example.cc
@@ -49,7 +49,7 @@ bool ValidateDir(const char* flagname, const std::string& dir) {
 DEFINE_bool(lookup, true,
             "If true, RgbdCamera faces a direction normal to the "
             "terrain plane.");
-DEFINE_bool(show_window, true,
+DEFINE_bool(show_window, RenderingConfig::kDefaultShowWindow,
             "If true, RgbdCamera opens windows for displaying rendering "
             "context.");
 DEFINE_double(duration, 5., "Total duration of the simulation in secondes.");

--- a/systems/sensors/rgbd_renderer.h
+++ b/systems/sensors/rgbd_renderer.h
@@ -17,6 +17,8 @@ namespace sensors {
 
 /// Common configurations of rendering systems.
 struct RenderingConfig {
+  // TODO(eric.cousineau): Define all default values be defined here to
+  // minimize duplication.
   /// The width of the image to be rendered in pixels.
   const int width;
   /// The height of the image to be rendered in pixels.
@@ -34,7 +36,9 @@ struct RenderingConfig {
   /// A flag for showing visible windows for RGB and label images.  If this is
   /// false, offscreen rendering is executed. This is useful for debugging
   /// purposes.
-  const bool show_window;
+  const bool show_window{kDefaultShowWindow};
+  /// Default value for `show_window`.
+  static constexpr bool kDefaultShowWindow{false};
 };
 
 

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -42,7 +42,7 @@ namespace {
 // Linux and Mac OSX.
 constexpr double kTolerance = 1e-12;
 constexpr double kFovY = M_PI_4;
-constexpr bool kShowWindow = false;
+constexpr bool kShowWindow = RenderingConfig::kDefaultShowWindow;
 constexpr double kDepthRangeNear = 0.5;
 constexpr double kDepthRangeFar = 5.;
 constexpr int kWidth = 640;

--- a/systems/sensors/test/rgbd_renderer_test_util.h
+++ b/systems/sensors/test/rgbd_renderer_test_util.h
@@ -104,7 +104,7 @@ class RgbdRendererTest : public ::testing::Test {
   const double kZNear = 0.5;
   const double kZFar = 5.;
   const double kFovY = M_PI_4;
-  const bool kShowWindow = false;
+  const bool kShowWindow = RenderingConfig::kDefaultShowWindow;
 
   // The following tolerance is used due to a precision difference between
   // Ubuntu Linux and Mac OSX.


### PR DESCRIPTION
Closes #7935.
Relates #7908.

This sets `show_window` to `false` by default (my preference, if it wouldn't cause segfaults on my machine), and synchronizes tests to use the same default. For machines wanting to change this, they just change this single flag.

\cc @jamiesnape @rpoyner-tri

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8006)
<!-- Reviewable:end -->
