### PR TITLE
lcmtypes: Ensure module has `__init__`.

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -282,6 +282,7 @@ drake_lcm_cc_library(
 drake_lcm_py_library(
     name = "lcmtypes_py",
     add_current_package_to_imports = False,  # Use //:module_py instead.
+    extra_srcs = ["__init__.py"],
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]) + _AUTOMOTIVE_LCM_SRCS,
     deps = [

--- a/lcmtypes/__init__.py
+++ b/lcmtypes/__init__.py
@@ -1,0 +1,1 @@
+# Empty Python module `__init__`, required to make this a module.

--- a/tools/workspace/lcm/lcm.bzl
+++ b/tools/workspace/lcm/lcm.bzl
@@ -207,6 +207,7 @@ def lcm_py_library(
         lcm_package = None,
         lcm_structs = None,
         add_current_package_to_imports = True,
+        extra_srcs = [],
         **kwargs):
     """Declares a py_library on message classes generated from `*.lcm` files.
 
@@ -223,7 +224,8 @@ def lcm_py_library(
     prefix import statements with the bazel package name).  It is True by
     default, but can be set to False if a package needs its own manually-
     written __init__.py handling, or if the current bazel package should
-    not be imported by default.
+    not be imported by default. Additional sources can be added via
+    `extra_srcs`.
     """
     if not lcm_srcs:
         fail("lcm_srcs is required")
@@ -242,7 +244,7 @@ def lcm_py_library(
         imports = depset(imports or []) | ["."]
     native.py_library(
         name = name,
-        srcs = outs,
+        srcs = outs + extra_srcs,
         imports = imports,
         **kwargs)
 


### PR DESCRIPTION
Closes #8012.

Since we want to avoid `add_current_package_to_imports` (which would have possibly generated an `__init__`, but cluttered PYTHONPATH), this provides a way to incorporate an `__init__.py`.

~An alternative would be to update `drake_lcm_py_library` to take an `extra_srcs` parameter. May do that right quick.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8013)
<!-- Reviewable:end -->
