### PR TITLE
Fix //drake labels names in bindings/pydrake/...

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -18,21 +18,14 @@ load(
     "get_drake_py_installs",
     "get_pybind_package_info",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info(base_package = "//bindings")
 
 drake_cc_library(
     name = "pydrake_pybind",
@@ -107,17 +100,17 @@ drake_pybind_library(
     py_srcs = ["symbolic.py"],
 )
 
-PY_LIBRARIES_WITH_INSTALL = adjust_labels_for_drake_hoist([
+PY_LIBRARIES_WITH_INSTALL = [
     ":autodiffutils_py",
     ":common_py",
     ":symbolic_py",
-    "//drake/bindings/pydrake/examples",
-    "//drake/bindings/pydrake/multibody",
-    "//drake/bindings/pydrake/solvers",
-    "//drake/bindings/pydrake/systems",
-    "//drake/bindings/pydrake/third_party",
-    "//drake/bindings/pydrake/util",
-])
+    "//bindings/pydrake/examples",
+    "//bindings/pydrake/multibody",
+    "//bindings/pydrake/solvers",
+    "//bindings/pydrake/systems",
+    "//bindings/pydrake/third_party",
+    "//bindings/pydrake/util",
+]
 
 PY_LIBRARIES = [
     ":backwards_compatibility_py",
@@ -189,7 +182,7 @@ drake_py_test(
     name = "common_test",
     size = "small",
     srcs = ["test/common_test.py"],
-    data = ["//drake/examples/atlas:models"],
+    data = ["//examples/atlas:models"],
     main = "test/common_test.py",
     deps = [":common_py"],
 )

--- a/bindings/pydrake/examples/BUILD.bazel
+++ b/bindings/pydrake/examples/BUILD.bazel
@@ -14,21 +14,14 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info("//bindings")
 
 # @note Symbols are NOT imported directly into
 # `__init__.py` to simplify dependency management, meaning that
@@ -39,14 +32,14 @@ drake_py_library(
     srcs = ["__init__.py"],
     imports = PACKAGE_INFO.py_imports,
     deps = [
-        "//drake/bindings/pydrake:common_py",
+        "//bindings/pydrake:common_py",
     ],
 )
 
 drake_pybind_library(
     name = "pendulum_py",
     cc_deps = [
-        "//drake/examples/pendulum:pendulum_plant",
+        "//examples/pendulum:pendulum_plant",
     ],
     cc_so_name = "pendulum",
     cc_srcs = ["pendulum_py.cc"],
@@ -82,7 +75,7 @@ drake_py_test(
     size = "small",
     deps = [
         ":pendulum_py",
-        "//drake/bindings/pydrake/systems",
+        "//bindings/pydrake/systems",
     ],
 )
 

--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -13,21 +13,14 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info("//bindings")
 
 drake_py_library(
     name = "module_py",
@@ -139,8 +132,8 @@ drake_py_test(
     name = "rigid_body_tree_test",
     size = "small",
     data = [
-        "//drake/examples/atlas:models",
-        "//drake/examples/pendulum:models",
+        "//examples/atlas:models",
+        "//examples/pendulum:models",
     ],
     deps = [":rigid_body_tree_py"],
 )
@@ -149,9 +142,9 @@ drake_py_test(
     name = "parsers_test",
     size = "small",
     data = [
-        "//drake/examples/acrobot:models",
-        "//drake/examples/atlas:models",
-        "//drake/examples/pr2:models",
+        "//examples/acrobot:models",
+        "//examples/atlas:models",
+        "//examples/pr2:models",
     ],
     deps = [
         ":parsers_py",

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -14,28 +14,21 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info("//bindings")
 
 drake_py_library(
     name = "module_py",
     srcs = ["__init__.py"],
     imports = PACKAGE_INFO.py_imports,
     deps = [
-        "//drake/bindings/pydrake:common_py",
+        "//bindings/pydrake:common_py",
     ],
 )
 
@@ -45,7 +38,7 @@ drake_pybind_library(
     cc_srcs = ["ik_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
-        "//drake/bindings/pydrake/multibody:rigid_body_tree_py",
+        "//bindings/pydrake/multibody:rigid_body_tree_py",
     ],
     py_srcs = ["ik.py"],
 )
@@ -55,13 +48,13 @@ drake_pybind_library(
 drake_pybind_library(
     name = "mathematicalprogram_py",
     cc_deps = [
-        "//drake/bindings/pydrake:symbolic_types_pybind",
-        "//drake/bindings/pydrake/util:drake_optional_pybind",
+        "//bindings/pydrake:symbolic_types_pybind",
+        "//bindings/pydrake/util:drake_optional_pybind",
     ],
     cc_srcs = ["mathematicalprogram_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
-        "//drake/bindings/pydrake:symbolic_py",
+        "//bindings/pydrake:symbolic_py",
     ],
     py_srcs = ["mathematicalprogram.py"],
 )
@@ -165,7 +158,7 @@ drake_py_test(
     name = "pr2_ik_test",
     size = "small",
     srcs = ["test/pr2_ik_test.py"],
-    data = ["//drake/examples/pr2:models"],
+    data = ["//examples/pr2:models"],
     main = "test/pr2_ik_test.py",
     tags = ["snopt"],
     deps = [":ik_py"],
@@ -175,7 +168,7 @@ drake_py_test(
     name = "rbt_ik_test",
     size = "small",
     srcs = ["test/rbt_ik_test.py"],
-    data = ["//drake/examples/pendulum:models"],
+    data = ["//examples/pendulum:models"],
     main = "test/rbt_ik_test.py",
     tags = ["snopt"],
     deps = [":ik_py"],

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -18,21 +18,14 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info(base_package = "//bindings")
 
 # @note Symbols are NOT imported directly into
 # `__init__.py` to simplify dependency management, meaning that

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -19,21 +19,14 @@ load(
     "drake_py_library",
     "drake_py_test",
 )
-load(
-    "//tools/skylark:6996.bzl",
-    "adjust_label_for_drake_hoist",
-    "adjust_labels_for_drake_hoist",
-)
 
-package(default_visibility = adjust_labels_for_drake_hoist([
-    "//drake/bindings/pydrake:__subpackages__",
-]))
+package(default_visibility = [
+    "//bindings/pydrake:__subpackages__",
+])
 
 # This determines how `PYTHONPATH` is configured, and how to install the
 # bindings.
-PACKAGE_INFO = get_pybind_package_info(
-    base_package = adjust_label_for_drake_hoist("//drake/bindings"),
-)
+PACKAGE_INFO = get_pybind_package_info("//bindings")
 
 drake_cc_library(
     name = "type_pack",


### PR DESCRIPTION
Relates #6996.

I am PR'ing these changes in chunks.  The plan is that once everything is converted, we'll add a deprecation warning to the 6996.bzl before finally removing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8018)
<!-- Reviewable:end -->
