### PR TITLE
Remove mention of pylint

### DIFF
--- a/doc/code_style_guide.rst
+++ b/doc/code_style_guide.rst
@@ -46,13 +46,8 @@ incorporates `PEP 257 -- Docstring Conventions
 <https://www.python.org/dev/peps/pep-0257/>`_, Drake follows its
 recommendations as well.
 
-In addition, Drake recommends use of ``pylint`` for automatic error
-checking. See :ref:`tools for complying with coding style <code-style-tools>`
-for full guidance.
-
-Sadly ``pylint`` does not check all the conditions enumerated by
-PEP 8. Therefore, Drake recommends the use of ``pep8.py`` as well. See
-:ref:`tools for complying with coding style <code-style-tools>` for details.`
+See :ref:`tools for complying with coding style <code-style-tools>` for details
+about the automated style checks.
 
 .. _code-style-guide-python-clarifications:
 


### PR DESCRIPTION
We don't actually suggest or use pylint anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8020)
<!-- Reviewable:end -->
