### PR TITLE
Disable dreal_solver_test under LSan due to memory leak in IBEX

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -769,6 +769,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "dreal_solver_test",
     tags = [
+        # Disable under LSan due to memory leak in IBEX.
+        "no_lsan",
         # For most of floating-point operations, Valgrind only supports the
         # IEEE default mode (round to nearest) while dReal uses to +infinity
         # and to -infinity rounding modes intensively to maintain conservative


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8022)
<!-- Reviewable:end -->
