### PR TITLE
Generalized constraint force evaluator

### DIFF
--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -3394,6 +3394,9 @@ RigidBodyTree<double>::positionConstraints<double>(
 template MatrixXd
 RigidBodyTree<double>::positionConstraintsJacobian<double>(
     KinematicsCache<double> const&, bool) const;
+template Matrix<AutoDiffXd, Eigen::Dynamic, Eigen::Dynamic>
+RigidBodyTree<double>::positionConstraintsJacobian<AutoDiffXd>(
+    KinematicsCache<AutoDiffXd> const&, bool) const;
 
 // Explicit template instantiations for positionConstraintsJacDotTimesV.
 template VectorXd

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -23,6 +23,7 @@ drake_cc_library(
     hdrs = ["position_constraint_force_evaluator.h"],
     deps = [
         ":generalized_constraint_force_evaluator",
+        "//math:autodiff",
         "//multibody:kinematics_cache_helper",
     ],
 )
@@ -33,6 +34,7 @@ drake_cc_library(
     hdrs = ["joint_limit_constraint_force_evaluator.h"],
     deps = [
         ":generalized_constraint_force_evaluator",
+        "//math:autodiff",
     ],
 )
 

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -12,7 +12,6 @@ drake_cc_library(
     deps = [
         "//common:essential",
         "//math:autodiff",
-        "//multibody:kinematics_cache_helper",
         "//multibody:rigid_body_tree",
         "//solvers:evaluator_base",
     ],
@@ -24,6 +23,7 @@ drake_cc_library(
     hdrs = ["position_constraint_force_evaluator.h"],
     deps = [
         ":generalized_constraint_force_evaluator",
+        "//multibody:kinematics_cache_helper",
     ],
 )
 

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -19,6 +19,24 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "position_constraint_force_evaluator",
+    srcs = ["position_constraint_force_evaluator.cc"],
+    hdrs = ["position_constraint_force_evaluator.h"],
+    deps = [
+        ":generalized_constraint_force_evaluator",
+    ],
+)
+
+drake_cc_library(
+    name = "joint_limit_constraint_force_evaluator",
+    srcs = ["joint_limit_constraint_force_evaluator.cc"],
+    hdrs = ["joint_limit_constraint_force_evaluator.h"],
+    deps = [
+        ":generalized_constraint_force_evaluator",
+    ],
+)
+
+drake_cc_library(
     name = "multiple_shooting",
     srcs = ["multiple_shooting.cc"],
     hdrs = ["multiple_shooting.h"],
@@ -98,17 +116,39 @@ drake_cc_googletest(
     ],
 )
 
-drake_cc_googletest(
-    name = "generalized_constraint_force_evaluator_test",
+drake_cc_library(
+    name = "generalized_constraint_force_evaluator_test_util",
+    testonly = 1,
+    srcs = [
+        "test/generalized_constraint_force_evaluator_test_util.cc",
+    ],
+    hdrs = ["test/generalized_constraint_force_evaluator_test_util.h"],
     data = [
         "//examples/simple_four_bar:models",
     ],
     deps = [
-        ":generalized_constraint_force_evaluator",
         "//common:find_resource",
+        "//multibody/parsers",
+    ],
+)
+
+drake_cc_googletest(
+    name = "position_constraint_force_evaluator_test",
+    deps = [
+        ":generalized_constraint_force_evaluator_test_util",
+        ":position_constraint_force_evaluator",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:autodiff",
-        "//multibody/parsers",
+    ],
+)
+
+drake_cc_googletest(
+    name = "joint_limit_constraint_force_evaluator_test",
+    deps = [
+        ":generalized_constraint_force_evaluator_test_util",
+        ":joint_limit_constraint_force_evaluator",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
     ],
 )
 

--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -6,6 +6,19 @@ load("//tools/lint:lint.bzl", "add_lint_tests")
 package(default_visibility = ["//visibility:public"])
 
 drake_cc_library(
+    name = "generalized_constraint_force_evaluator",
+    srcs = ["generalized_constraint_force_evaluator.cc"],
+    hdrs = ["generalized_constraint_force_evaluator.h"],
+    deps = [
+        "//common:essential",
+        "//math:autodiff",
+        "//multibody:kinematics_cache_helper",
+        "//multibody:rigid_body_tree",
+        "//solvers:evaluator_base",
+    ],
+)
+
+drake_cc_library(
     name = "multiple_shooting",
     srcs = ["multiple_shooting.cc"],
     hdrs = ["multiple_shooting.h"],
@@ -82,6 +95,20 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/trajectories:piecewise_polynomial",
         "//systems/primitives:piecewise_polynomial_linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "generalized_constraint_force_evaluator_test",
+    data = [
+        "//examples/simple_four_bar:models",
+    ],
+    deps = [
+        ":generalized_constraint_force_evaluator",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:autodiff",
+        "//multibody/parsers",
     ],
 )
 

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
@@ -31,39 +31,6 @@ void GeneralizedConstraintForceEvaluator::DoEval(
   const auto J = EvalConstraintJacobian(x);
   y = J.transpose() * lambda;
 }
-
-PositionConstraintForceEvaluator::PositionConstraintForceEvaluator(
-    const RigidBodyTree<double>& tree,
-    std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
-        kinematics_cache_helper)
-    : GeneralizedConstraintForceEvaluator(
-          tree, tree.get_num_positions() + tree.getNumPositionConstraints(),
-          tree.getNumPositionConstraints()),
-      kinematics_cache_helper_(kinematics_cache_helper) {}
-
-MatrixX<AutoDiffXd> PositionConstraintForceEvaluator::EvalConstraintJacobian(
-    const Eigen::Ref<const AutoDiffVecXd>& x) const {
-  const auto& q = x.head(tree()->get_num_positions());
-  auto kinsol = kinematics_cache_helper_->UpdateKinematics(q, tree());
-  return tree()->positionConstraintsJacobian(kinsol);
-}
-
-JointLimitConstraintForceEvaluator::JointLimitConstraintForceEvaluator(
-    const RigidBodyTree<double>& tree, int joint_velocity_index)
-    : GeneralizedConstraintForceEvaluator(tree, 2, 2),
-      joint_velocity_index_(joint_velocity_index) {}
-
-MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
-    const Eigen::Ref<const AutoDiffVecXd>& x) const {
-  // x is unused here, since the Jacobian is a constant, that does not depends
-  // on x.
-  unused(x);
-  Eigen::Matrix2Xd J(2, tree()->get_num_velocities());
-  J.setZero();
-  J(LowerLimitForceIndexInLambda(), joint_velocity_index_) = 1;
-  J(UpperLimitForceIndexInLambda(), joint_velocity_index_) = -1;
-  return J.cast<AutoDiffXd>();
-}
 }  // namespace trajectory_optimization
 }  // namespace systems
 }  // namespace drake

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
@@ -1,0 +1,69 @@
+#include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
+
+#include "drake/math/autodiff.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+using plants::KinematicsCacheWithVHelper;
+
+// This evaluator computes the generalized constraint force Jᵀλ.
+GeneralizedConstraintForceEvaluator::GeneralizedConstraintForceEvaluator(
+    const RigidBodyTree<double>& tree, int num_vars, int lambda_size)
+    : EvaluatorBase(tree.get_num_velocities(), num_vars,
+                    "generalized constraint force"),
+      tree_{&tree},
+      lambda_size_(lambda_size) {}
+
+void GeneralizedConstraintForceEvaluator::DoEval(
+    const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
+  AutoDiffVecXd y_t;
+  Eval(math::initializeAutoDiff(x), y_t);
+  y = math::autoDiffToValueMatrix(y_t);
+}
+
+void GeneralizedConstraintForceEvaluator::DoEval(
+    const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd& y) const {
+  // x contains non-λ and λ
+  DRAKE_ASSERT(x.rows() == num_vars());
+  const auto lambda = GetLambdaFromEvalInputVector(x);
+
+  const auto J = EvalConstraintJacobian(x);
+  y = J.transpose() * lambda;
+}
+
+PositionConstraintForceEvaluator::PositionConstraintForceEvaluator(
+    const RigidBodyTree<double>& tree,
+    std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+        kinematics_cache_helper)
+    : GeneralizedConstraintForceEvaluator(
+          tree, tree.get_num_positions() + tree.getNumPositionConstraints(),
+          tree.getNumPositionConstraints()),
+      kinematics_cache_helper_(kinematics_cache_helper) {}
+
+MatrixX<AutoDiffXd> PositionConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  const auto& q = x.head(tree()->get_num_positions());
+  auto kinsol = kinematics_cache_helper_->UpdateKinematics(q, tree());
+  return tree()->positionConstraintsJacobian(kinsol);
+}
+
+JointLimitConstraintForceEvaluator::JointLimitConstraintForceEvaluator(
+    const RigidBodyTree<double>& tree, int joint_velocity_index)
+    : GeneralizedConstraintForceEvaluator(tree, 2, 2),
+      joint_velocity_index_(joint_velocity_index) {}
+
+MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  // x is unused here, since the Jacobian is a constant, that does not depends
+  // on x.
+  unused(x);
+  Eigen::Matrix2Xd J(2, tree()->get_num_velocities());
+  J.setZero();
+  J(LowerLimitForceIndexInLambda(), joint_velocity_index_) = 1;
+  J(UpperLimitForceIndexInLambda(), joint_velocity_index_) = -1;
+  return J.cast<AutoDiffXd>();
+}
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
@@ -16,19 +16,12 @@ GeneralizedConstraintForceEvaluator::GeneralizedConstraintForceEvaluator(
 
 void GeneralizedConstraintForceEvaluator::DoEval(
     const Eigen::Ref<const Eigen::VectorXd>& x, Eigen::VectorXd& y) const {
-  AutoDiffVecXd y_t;
-  Eval(math::initializeAutoDiff(x), y_t);
-  y = math::autoDiffToValueMatrix(y_t);
+  DoEvalGeneric(x, &y);
 }
 
 void GeneralizedConstraintForceEvaluator::DoEval(
     const Eigen::Ref<const AutoDiffVecXd>& x, AutoDiffVecXd& y) const {
-  // x contains non-λ and λ
-  DRAKE_ASSERT(x.rows() == num_vars());
-  const auto lambda = GetLambdaFromEvalInputVector(x);
-
-  const auto J = EvalConstraintJacobian(x);
-  y = J.transpose() * lambda;
+  DoEvalGeneric(x, &y);
 }
 }  // namespace trajectory_optimization
 }  // namespace systems

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.cc
@@ -5,7 +5,6 @@
 namespace drake {
 namespace systems {
 namespace trajectory_optimization {
-using plants::KinematicsCacheWithVHelper;
 
 // This evaluator computes the generalized constraint force Jᵀλ.
 GeneralizedConstraintForceEvaluator::GeneralizedConstraintForceEvaluator(

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/multibody/kinematics_cache_helper.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/solvers/evaluator_base.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+/** This evaluator computes the generalized constraint force Jᵀλ.
+ * where the Jacobian J can depend on generalized position q and/or other
+ * variables.
+ */
+class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
+ public:
+  /**
+   * Constructor.
+   * @param tree Note @p tree is aliased for the lifetime of of this object.
+   * @param num_vars Number of variables, including λ.
+   * @param lambda_size λ is a lambda_size x 1 vector.
+   */
+  GeneralizedConstraintForceEvaluator(const RigidBodyTree<double>& tree,
+                                      int num_vars, int lambda_size);
+
+  /** Getter for the size of non_lambda part in the evaluator variables. */
+  int non_lambda_size() const { return num_vars() - lambda_size_; }
+
+  /** Getter for lambda_size. */
+  int lambda_size() const { return lambda_size_; }
+
+  /** Getter for the tree. */
+  const RigidBodyTree<double>* tree() const { return tree_; }
+
+  /**
+   * Compose the input `x` to the Eval function, given λ and the part of x
+   * that is not in λ.
+   * This is a helper function, so that the user does not need to remember which
+   * part of x corresponds to λ, and which part corresponds to non-λ.
+   */
+  template <typename DerivedNonLambda, typename DerivedLambda>
+  typename std::enable_if<
+      is_eigen_vector_of<DerivedNonLambda,
+                         typename DerivedLambda::Scalar>::value &&
+          is_eigen_vector<DerivedLambda>::value,
+      Eigen::Matrix<typename DerivedLambda::Scalar, Eigen::Dynamic, 1>>::type
+  ComposeEvalInputVector(const Eigen::MatrixBase<DerivedNonLambda>& non_lambda,
+                         const Eigen::MatrixBase<DerivedLambda>& lambda) const {
+    using Scalar = typename DerivedLambda::Scalar;
+    DRAKE_ASSERT(non_lambda.rows() == num_vars() - lambda_size_);
+    DRAKE_ASSERT(lambda.rows() == lambda_size_);
+    typename Eigen::Matrix<Scalar, Eigen::Dynamic, 1> x(num_vars());
+    x << non_lambda, lambda;
+    return x;
+  }
+
+  /** Get the non-lambda part from the eval input vector. */
+  template <typename Derived>
+  auto GetLambdaFromEvalInputVector(const Eigen::MatrixBase<Derived>& x) const {
+    return x.tail(lambda_size_);
+  }
+
+  /** Get the lambda part from the eval input vector. */
+  template <typename Derived>
+  auto GetNonLambdaFromEvalInputVector(
+      const Eigen::MatrixBase<Derived>& x) const {
+    return x.head(num_vars() - lambda_size_);
+  }
+
+ protected:
+  void DoEval(const Eigen::Ref<const Eigen::VectorXd>& x,
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              Eigen::VectorXd& y) const override;
+
+  void DoEval(const Eigen::Ref<const AutoDiffVecXd>& x,
+              // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
+              AutoDiffVecXd& y) const override;
+  //
+  // Computes the Jacobian J so as to evaluate the generalized constraint force
+  // Jᵀλ.
+  virtual MatrixX<AutoDiffXd> EvalConstraintJacobian(
+      const Eigen::Ref<const AutoDiffVecXd>& x) const = 0;
+
+ private:
+  const RigidBodyTree<double>* tree_;
+  const int lambda_size_;
+};
+
+/**
+ * Evaluates the generalized constraint force from
+ * RigidBodyTree::positionConstraint.
+ * Loop joint constraint is a position constraint.
+ */
+class PositionConstraintForceEvaluator
+    : public GeneralizedConstraintForceEvaluator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionConstraintForceEvaluator)
+
+  /**
+   * @param kinematics_cache_helper. The helper class to update the kinematics
+   * cache. The kinematics cache is useful when computing the Jacobian of the
+   * position constraint.
+   */
+  PositionConstraintForceEvaluator(
+      const RigidBodyTree<double>& tree,
+      std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+          kinematics_cache_helper);
+
+ protected:
+  MatrixX<AutoDiffXd> EvalConstraintJacobian(
+      const Eigen::Ref<const AutoDiffVecXd>& q) const override;
+
+ private:
+  mutable std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+      kinematics_cache_helper_;
+};
+
+/**
+ * Evaluates the joint limit constraint force.
+ * For a single joint (revolute or prismatic), whose index in the velocity
+ * vector is i, its joint limit force has the form
+ * [0, 0, ..., 0, -λᵤ+λₗ, 0, ... ,0], that only the i'th entry is non-zero.
+ * where λᵤ / λₗ are the joint limit force from upper / lower limit
+ * respectively. We assume that both λᵤ and λₗ are non-negative.
+ */
+class JointLimitConstraintForceEvaluator
+    : public GeneralizedConstraintForceEvaluator {
+ public:
+  JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,
+                                     int joint_velocity_index);
+
+  /**
+   * The constraint force λ contains both the joint upper limit force λᵤ, and
+   * the joint lower limit force λₗ. The following two method returns the
+   * indices of λᵤ / λₗ in λ.
+   */
+  static constexpr int UpperLimitForceIndexInLambda() { return 0; }
+  static constexpr int LowerLimitForceIndexInLambda() { return 1; }
+
+ protected:
+  MatrixX<AutoDiffXd> EvalConstraintJacobian(
+      const Eigen::Ref<const AutoDiffVecXd>& x) const override;
+
+ private:
+  const int joint_velocity_index_;
+};
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -87,65 +87,6 @@ class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
   const RigidBodyTree<double>* tree_;
   const int lambda_size_;
 };
-
-/**
- * Evaluates the generalized constraint force from
- * RigidBodyTree::positionConstraint.
- * Loop joint constraint is a position constraint.
- */
-class PositionConstraintForceEvaluator
-    : public GeneralizedConstraintForceEvaluator {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionConstraintForceEvaluator)
-
-  /**
-   * @param kinematics_cache_helper. The helper class to update the kinematics
-   * cache. The kinematics cache is useful when computing the Jacobian of the
-   * position constraint.
-   */
-  PositionConstraintForceEvaluator(
-      const RigidBodyTree<double>& tree,
-      std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
-          kinematics_cache_helper);
-
- protected:
-  MatrixX<AutoDiffXd> EvalConstraintJacobian(
-      const Eigen::Ref<const AutoDiffVecXd>& q) const override;
-
- private:
-  mutable std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
-      kinematics_cache_helper_;
-};
-
-/**
- * Evaluates the joint limit constraint force.
- * For a single joint (revolute or prismatic), whose index in the velocity
- * vector is i, its joint limit force has the form
- * [0, 0, ..., 0, -λᵤ+λₗ, 0, ... ,0], that only the i'th entry is non-zero.
- * where λᵤ / λₗ are the joint limit force from upper / lower limit
- * respectively. We assume that both λᵤ and λₗ are non-negative.
- */
-class JointLimitConstraintForceEvaluator
-    : public GeneralizedConstraintForceEvaluator {
- public:
-  JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,
-                                     int joint_velocity_index);
-
-  /**
-   * The constraint force λ contains both the joint upper limit force λᵤ, and
-   * the joint lower limit force λₗ. The following two method returns the
-   * indices of λᵤ / λₗ in λ.
-   */
-  static constexpr int UpperLimitForceIndexInLambda() { return 0; }
-  static constexpr int LowerLimitForceIndexInLambda() { return 1; }
-
- protected:
-  MatrixX<AutoDiffXd> EvalConstraintJacobian(
-      const Eigen::Ref<const AutoDiffVecXd>& x) const override;
-
- private:
-  const int joint_velocity_index_;
-};
 }  // namespace trajectory_optimization
 }  // namespace systems
 }  // namespace drake

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -25,7 +25,7 @@ class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
    * So the size of the output vector is always Nᵥ. To evaluate Jᵀλ, it may or
    * may not depend on variables such as contact force λ, generalized position
    * q, or some additional variables, so the size of the input variable to this
-   * evalautor should be specified by the user.
+   * evaluator should be specified by the user.
    */
   GeneralizedConstraintForceEvaluator(const RigidBodyTree<double>& tree,
                                       int num_vars, int lambda_size);
@@ -100,13 +100,15 @@ class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
     *y = J.transpose() * lambda;
   }
 
-  // Computes the Jacobian J so as to evaluate the generalized constraint force
-  // Jᵀλ. The Jacobian J is of size Nv x n_λ.
+  // Derived class implementation should compute the Jacobian J 
+  // that can be used to evaluate the generalized constraint force
+  // Jᵀλ. J must be size Nv x n_λ. 
   virtual Eigen::MatrixXd EvalConstraintJacobian(
       const Eigen::Ref<const Eigen::VectorXd>& x) const = 0;
 
-  // Computes the Jacobian J so as to evaluate the generalized constraint force
-  // Jᵀλ. The Jacobian J is of size Nv x n_λ.
+  // Derived class implementation should compute the Jacobian J 
+  // that can be used to evaluate the generalized constraint force
+  // Jᵀλ. J must be size Nv x n_λ. 
   virtual MatrixX<AutoDiffXd> EvalConstraintJacobian(
       const Eigen::Ref<const AutoDiffVecXd>& x) const = 0;
 

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -100,15 +100,15 @@ class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
     *y = J.transpose() * lambda;
   }
 
-  // Derived class implementation should compute the Jacobian J 
+  // Derived class implementation should compute the Jacobian J
   // that can be used to evaluate the generalized constraint force
-  // Jᵀλ. J must be size Nv x n_λ. 
+  // Jᵀλ. J must be size Nv x n_λ.
   virtual Eigen::MatrixXd EvalConstraintJacobian(
       const Eigen::Ref<const Eigen::VectorXd>& x) const = 0;
 
-  // Derived class implementation should compute the Jacobian J 
+  // Derived class implementation should compute the Jacobian J
   // that can be used to evaluate the generalized constraint force
-  // Jᵀλ. J must be size Nv x n_λ. 
+  // Jᵀλ. J must be size Nv x n_λ.
   virtual MatrixX<AutoDiffXd> EvalConstraintJacobian(
       const Eigen::Ref<const AutoDiffVecXd>& x) const = 0;
 

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -24,6 +24,8 @@ class GeneralizedConstraintForceEvaluator : public solvers::EvaluatorBase {
   GeneralizedConstraintForceEvaluator(const RigidBodyTree<double>& tree,
                                       int num_vars, int lambda_size);
 
+  ~GeneralizedConstraintForceEvaluator() override {}
+
   /** Getter for the size of non_lambda part in the evaluator variables. */
   int non_lambda_size() const { return num_vars() - lambda_size_; }
 

--- a/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/generalized_constraint_force_evaluator.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/multibody/kinematics_cache_helper.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/solvers/evaluator_base.h"
 

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h"
 
+#include "drake/math/autodiff.h"
+
 namespace drake {
 namespace systems {
 namespace trajectory_optimization {
@@ -8,8 +10,8 @@ JointLimitConstraintForceEvaluator::JointLimitConstraintForceEvaluator(
     : GeneralizedConstraintForceEvaluator(tree, 2, 2),
       joint_velocity_index_(joint_velocity_index) {}
 
-MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
-    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+Eigen::MatrixXd JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const Eigen::VectorXd>& x) const {
   // x is unused here, since the Jacobian is a constant, that does not depends
   // on x.
   unused(x);
@@ -17,7 +19,13 @@ MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
   J.setZero();
   J(LowerLimitForceIndexInLambda(), joint_velocity_index_) = 1;
   J(UpperLimitForceIndexInLambda(), joint_velocity_index_) = -1;
-  return J.cast<AutoDiffXd>();
+  return J;
+}
+
+MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  return EvalConstraintJacobian(math::autoDiffToValueMatrix(x))
+      .cast<AutoDiffXd>();
 }
 }  // namespace trajectory_optimization
 }  // namespace systems

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.cc
@@ -1,0 +1,24 @@
+#include "drake/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+JointLimitConstraintForceEvaluator::JointLimitConstraintForceEvaluator(
+    const RigidBodyTree<double>& tree, int joint_velocity_index)
+    : GeneralizedConstraintForceEvaluator(tree, 2, 2),
+      joint_velocity_index_(joint_velocity_index) {}
+
+MatrixX<AutoDiffXd> JointLimitConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  // x is unused here, since the Jacobian is a constant, that does not depends
+  // on x.
+  unused(x);
+  Eigen::Matrix2Xd J(2, tree()->get_num_velocities());
+  J.setZero();
+  J(LowerLimitForceIndexInLambda(), joint_velocity_index_) = 1;
+  J(UpperLimitForceIndexInLambda(), joint_velocity_index_) = -1;
+  return J.cast<AutoDiffXd>();
+}
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
@@ -16,6 +16,11 @@ namespace trajectory_optimization {
 class JointLimitConstraintForceEvaluator
     : public GeneralizedConstraintForceEvaluator {
  public:
+  /** Constructor.
+   * @param tree The tree on which the joint limit force is evaluated.
+   * @param joint_velocity_index The joint whose velocity index equals to 
+   * joint_velocity_index has joint limit force.
+   */
   JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,
                                      int joint_velocity_index);
 
@@ -30,6 +35,9 @@ class JointLimitConstraintForceEvaluator
   static constexpr int LowerLimitForceIndexInLambda() { return 1; }
 
  protected:
+  Eigen::MatrixXd EvalConstraintJacobian(
+      const Eigen::Ref<const Eigen::VectorXd>& x) const override;
+
   MatrixX<AutoDiffXd> EvalConstraintJacobian(
       const Eigen::Ref<const AutoDiffVecXd>& x) const override;
 

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
@@ -18,7 +18,7 @@ class JointLimitConstraintForceEvaluator
  public:
   /** Constructor.
    * @param tree The tree on which the joint limit force is evaluated.
-   * @param joint_velocity_index The joint whose velocity index equals to 
+   * @param joint_velocity_index The joint whose velocity index equals to
    * joint_velocity_index has joint limit force.
    */
   JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+/**
+ * Evaluates the joint limit constraint force.
+ * For a single joint (revolute or prismatic), whose index in the velocity
+ * vector is i, its joint limit force has the form
+ * [0, 0, ..., 0, -λᵤ+λₗ, 0, ... ,0], that only the i'th entry is non-zero.
+ * where λᵤ / λₗ are the joint limit force from upper / lower limit
+ * respectively. We assume that both λᵤ and λₗ are non-negative.
+ */
+class JointLimitConstraintForceEvaluator
+    : public GeneralizedConstraintForceEvaluator {
+ public:
+  JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,
+                                     int joint_velocity_index);
+
+  /**
+   * The constraint force λ contains both the joint upper limit force λᵤ, and
+   * the joint lower limit force λₗ. The following two method returns the
+   * indices of λᵤ / λₗ in λ.
+   */
+  static constexpr int UpperLimitForceIndexInLambda() { return 0; }
+  static constexpr int LowerLimitForceIndexInLambda() { return 1; }
+
+ protected:
+  MatrixX<AutoDiffXd> EvalConstraintJacobian(
+      const Eigen::Ref<const AutoDiffVecXd>& x) const override;
+
+ private:
+  const int joint_velocity_index_;
+};
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h
@@ -19,6 +19,8 @@ class JointLimitConstraintForceEvaluator
   JointLimitConstraintForceEvaluator(const RigidBodyTree<double>& tree,
                                      int joint_velocity_index);
 
+  ~JointLimitConstraintForceEvaluator() override {}
+
   /**
    * The constraint force λ contains both the joint upper limit force λᵤ, and
    * the joint lower limit force λₗ. The following two method returns the

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.cc
@@ -3,6 +3,8 @@
 namespace drake {
 namespace systems {
 namespace trajectory_optimization {
+using plants::KinematicsCacheWithVHelper;
+
 PositionConstraintForceEvaluator::PositionConstraintForceEvaluator(
     const RigidBodyTree<double>& tree,
     std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/trajectory_optimization/position_constraint_force_evaluator.h"
 
+#include "drake/math/autodiff.h"
+
 namespace drake {
 namespace systems {
 namespace trajectory_optimization {
@@ -13,6 +15,12 @@ PositionConstraintForceEvaluator::PositionConstraintForceEvaluator(
           tree, tree.get_num_positions() + tree.getNumPositionConstraints(),
           tree.getNumPositionConstraints()),
       kinematics_cache_helper_(kinematics_cache_helper) {}
+
+Eigen::MatrixXd PositionConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const Eigen::VectorXd>& x) const {
+  return math::autoDiffToValueMatrix(
+      EvalConstraintJacobian(math::initializeAutoDiff(x)));
+}
 
 MatrixX<AutoDiffXd> PositionConstraintForceEvaluator::EvalConstraintJacobian(
     const Eigen::Ref<const AutoDiffVecXd>& x) const {

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.cc
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.cc
@@ -1,0 +1,23 @@
+#include "drake/systems/trajectory_optimization/position_constraint_force_evaluator.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+PositionConstraintForceEvaluator::PositionConstraintForceEvaluator(
+    const RigidBodyTree<double>& tree,
+    std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+        kinematics_cache_helper)
+    : GeneralizedConstraintForceEvaluator(
+          tree, tree.get_num_positions() + tree.getNumPositionConstraints(),
+          tree.getNumPositionConstraints()),
+      kinematics_cache_helper_(kinematics_cache_helper) {}
+
+MatrixX<AutoDiffXd> PositionConstraintForceEvaluator::EvalConstraintJacobian(
+    const Eigen::Ref<const AutoDiffVecXd>& x) const {
+  const auto& q = x.head(tree()->get_num_positions());
+  auto kinsol = kinematics_cache_helper_->UpdateKinematics(q, tree());
+  return tree()->positionConstraintsJacobian(kinsol);
+}
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "drake/multibody/kinematics_cache_helper.h"
 #include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
 
 namespace drake {

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.h
@@ -28,6 +28,8 @@ class PositionConstraintForceEvaluator
       std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
           kinematics_cache_helper);
 
+  ~PositionConstraintForceEvaluator() override{};
+
  protected:
   MatrixX<AutoDiffXd> EvalConstraintJacobian(
       const Eigen::Ref<const AutoDiffVecXd>& q) const override;

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+/**
+ * Evaluates the generalized constraint force from
+ * RigidBodyTree::positionConstraint.
+ * Loop joint constraint is a position constraint.
+ */
+class PositionConstraintForceEvaluator
+    : public GeneralizedConstraintForceEvaluator {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionConstraintForceEvaluator)
+
+  /**
+   * @param kinematics_cache_helper. The helper class to update the kinematics
+   * cache. The kinematics cache is useful when computing the Jacobian of the
+   * position constraint.
+   */
+  PositionConstraintForceEvaluator(
+      const RigidBodyTree<double>& tree,
+      std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+          kinematics_cache_helper);
+
+ protected:
+  MatrixX<AutoDiffXd> EvalConstraintJacobian(
+      const Eigen::Ref<const AutoDiffVecXd>& q) const override;
+
+ private:
+  mutable std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
+      kinematics_cache_helper_;
+};
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/position_constraint_force_evaluator.h
+++ b/systems/trajectory_optimization/position_constraint_force_evaluator.h
@@ -10,15 +10,16 @@ namespace systems {
 namespace trajectory_optimization {
 /**
  * Evaluates the generalized constraint force from
- * RigidBodyTree::positionConstraint.
- * Loop joint constraint is a position constraint.
+ * RigidBodyTree::positionConstraint. For example, loop joint constraint is a
+ * position constraint.
  */
 class PositionConstraintForceEvaluator
     : public GeneralizedConstraintForceEvaluator {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(PositionConstraintForceEvaluator)
 
-  /**
+  /** Constructor.
+   * @param tree The tree on which the position constraint force is evaluated.
    * @param kinematics_cache_helper. The helper class to update the kinematics
    * cache. The kinematics cache is useful when computing the Jacobian of the
    * position constraint.
@@ -28,9 +29,16 @@ class PositionConstraintForceEvaluator
       std::shared_ptr<plants::KinematicsCacheHelper<AutoDiffXd>>
           kinematics_cache_helper);
 
-  ~PositionConstraintForceEvaluator() override{};
+  ~PositionConstraintForceEvaluator() override {}
+
+  /** The size of the generalized position vector to evaluate the position
+   * constraint Jacobian. */
+  int generalized_positions_size() const { return non_lambda_size(); }
 
  protected:
+  Eigen::MatrixXd EvalConstraintJacobian(
+      const Eigen::Ref<const Eigen::VectorXd>& q) const override;
+
   MatrixX<AutoDiffXd> EvalConstraintJacobian(
       const Eigen::Ref<const AutoDiffVecXd>& q) const override;
 

--- a/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test.cc
+++ b/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test.cc
@@ -1,0 +1,95 @@
+#include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+namespace {
+// Construct a RigidBodyTree containing a four bar linkage.
+std::unique_ptr<RigidBodyTree<double>> ConstructFourBarTree() {
+  RigidBodyTree<double>* tree = new RigidBodyTree<double>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+      FindResourceOrThrow("drake/examples/simple_four_bar/FourBar.urdf"),
+      multibody::joints::kFixed, tree);
+  DRAKE_DEMAND(tree->get_num_actuators() != 0);
+  return std::unique_ptr<RigidBodyTree<double>>(tree);
+}
+
+GTEST_TEST(GeneralizedConstraintForceEvaluatorTest, TestEval) {
+  // Test the Eval function of GeneralizedConstraintForceEvaluator.
+  auto tree = ConstructFourBarTree();
+
+  auto cache_helper =
+      std::make_shared<plants::KinematicsCacheHelper<AutoDiffXd>>(*tree);
+
+  PositionConstraintForceEvaluator evaluator(*tree, cache_helper);
+
+  EXPECT_EQ(evaluator.lambda_size(), tree->getNumPositionConstraints());
+  EXPECT_EQ(evaluator.non_lambda_size(), tree->get_num_positions());
+
+  // Set q to some arbitrary number.
+  const Eigen::VectorXd q =
+      Eigen::VectorXd::LinSpaced(tree->get_num_positions(), 1, 5);
+  // Set lambda to some arbitrary number.
+  const Eigen::VectorXd lambda =
+      Eigen::VectorXd::LinSpaced(evaluator.lambda_size(), -3, 3);
+
+  // Test ComposeEvalInputVector
+  const Eigen::VectorXd x = evaluator.ComposeEvalInputVector(q, lambda);
+  EXPECT_TRUE(CompareMatrices(evaluator.GetLambdaFromEvalInputVector(x), lambda,
+                              1E-15));
+  EXPECT_TRUE(
+      CompareMatrices(evaluator.GetNonLambdaFromEvalInputVector(x), q, 1E-15));
+
+  // Test Eval
+  const auto tx = math::initializeAutoDiff(x);
+  AutoDiffVecXd ty;
+  evaluator.Eval(tx, ty);
+  EXPECT_EQ(ty.rows(), tree->get_num_velocities());
+  KinematicsCache<double> kinsol = tree->CreateKinematicsCache();
+  kinsol.initialize(q);
+  tree->doKinematics(kinsol);
+  const auto J = tree->positionConstraintsJacobian(kinsol);
+  const Eigen::VectorXd y_expected = J.transpose() * lambda;
+  EXPECT_TRUE(CompareMatrices(math::autoDiffToValueMatrix(ty), y_expected,
+                              1E-10, MatrixCompareType::absolute));
+}
+
+GTEST_TEST(JointLimitConstraintForceEvaluatorTest, TestEval) {
+  auto tree = ConstructFourBarTree();
+
+  // Pretend that the four bar has a joint limit at joint 0.
+  JointLimitConstraintForceEvaluator evaluator(*tree, 0);
+  EXPECT_EQ(evaluator.lambda_size(), 2);
+
+  // Doesn't need a non-lambda part to evaluate the Jacobian.
+  const Eigen::VectorXd non_lambda(0);
+  // Set lambda to some arbitrary number.
+  const Eigen::VectorXd lambda =
+      Eigen::VectorXd::LinSpaced(evaluator.lambda_size(), -3, 3);
+  const Eigen::VectorXd x =
+      evaluator.ComposeEvalInputVector(non_lambda, lambda);
+  const auto tx = math::initializeAutoDiff(x);
+  AutoDiffVecXd ty;
+  evaluator.Eval(tx, ty);
+
+  Eigen::VectorXd y_expected =
+      Eigen::VectorXd::Zero(tree->get_num_velocities());
+  y_expected(0) =
+      lambda(
+          JointLimitConstraintForceEvaluator::LowerLimitForceIndexInLambda()) -
+      lambda(
+          JointLimitConstraintForceEvaluator::UpperLimitForceIndexInLambda());
+  EXPECT_TRUE(CompareMatrices(math::autoDiffToValueMatrix(ty), y_expected,
+                              1E-10, MatrixCompareType::absolute));
+}
+}  // namespace
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.cc
+++ b/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.cc
@@ -1,0 +1,20 @@
+#include "drake/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.h"
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+// Construct a RigidBodyTree containing a four bar linkage.
+std::unique_ptr<RigidBodyTree<double>> ConstructFourBarTree() {
+  RigidBodyTree<double>* tree = new RigidBodyTree<double>();
+  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
+      FindResourceOrThrow("drake/examples/simple_four_bar/FourBar.urdf"),
+      multibody::joints::kFixed, tree);
+  DRAKE_DEMAND(tree->get_num_actuators() != 0);
+  return std::unique_ptr<RigidBodyTree<double>>(tree);
+}
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.h
+++ b/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+/** Construct a RigidBodyTree containing a four bar linkage. */
+std::unique_ptr<RigidBodyTree<double>> ConstructFourBarTree();
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/test/joint_limit_constraint_force_evaluator_test.cc
+++ b/systems/trajectory_optimization/test/joint_limit_constraint_force_evaluator_test.cc
@@ -1,0 +1,44 @@
+#include "drake/systems/trajectory_optimization/joint_limit_constraint_force_evaluator.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/math/autodiff.h"
+#include "drake/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.h"
+
+namespace drake {
+namespace systems {
+namespace trajectory_optimization {
+namespace {
+GTEST_TEST(JointLimitConstraintForceEvaluatorTest, TestEval) {
+  auto tree = ConstructFourBarTree();
+
+  // Pretend that the four bar has a joint limit at joint 0.
+  JointLimitConstraintForceEvaluator evaluator(*tree, 0);
+  EXPECT_EQ(evaluator.lambda_size(), 2);
+
+  // Doesn't need a non-lambda part to evaluate the Jacobian.
+  const Eigen::VectorXd non_lambda(0);
+  // Set lambda to some arbitrary number.
+  const Eigen::VectorXd lambda =
+      Eigen::VectorXd::LinSpaced(evaluator.lambda_size(), -3, 3);
+  const Eigen::VectorXd x =
+      evaluator.ComposeEvalInputVector(non_lambda, lambda);
+  const auto tx = math::initializeAutoDiff(x);
+  AutoDiffVecXd ty;
+  evaluator.Eval(tx, ty);
+
+  Eigen::VectorXd y_expected =
+      Eigen::VectorXd::Zero(tree->get_num_velocities());
+  y_expected(0) =
+      lambda(
+          JointLimitConstraintForceEvaluator::LowerLimitForceIndexInLambda()) -
+      lambda(
+          JointLimitConstraintForceEvaluator::UpperLimitForceIndexInLambda());
+  EXPECT_TRUE(CompareMatrices(math::autoDiffToValueMatrix(ty), y_expected,
+                              1E-10, MatrixCompareType::absolute));
+}
+}  // namespace
+}  // namespace trajectory_optimization
+}  // namespace systems
+}  // namespace drake

--- a/systems/trajectory_optimization/test/position_constraint_force_evaluator_test.cc
+++ b/systems/trajectory_optimization/test/position_constraint_force_evaluator_test.cc
@@ -1,27 +1,16 @@
-#include "drake/systems/trajectory_optimization/generalized_constraint_force_evaluator.h"
+#include "drake/systems/trajectory_optimization/position_constraint_force_evaluator.h"
 
 #include <gtest/gtest.h>
 
-#include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
-#include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/systems/trajectory_optimization/test/generalized_constraint_force_evaluator_test_util.h"
 
 namespace drake {
 namespace systems {
 namespace trajectory_optimization {
 namespace {
-// Construct a RigidBodyTree containing a four bar linkage.
-std::unique_ptr<RigidBodyTree<double>> ConstructFourBarTree() {
-  RigidBodyTree<double>* tree = new RigidBodyTree<double>();
-  parsers::urdf::AddModelInstanceFromUrdfFileToWorld(
-      FindResourceOrThrow("drake/examples/simple_four_bar/FourBar.urdf"),
-      multibody::joints::kFixed, tree);
-  DRAKE_DEMAND(tree->get_num_actuators() != 0);
-  return std::unique_ptr<RigidBodyTree<double>>(tree);
-}
-
-GTEST_TEST(GeneralizedConstraintForceEvaluatorTest, TestEval) {
+GTEST_TEST(PositionConstraintForceEvaluatorTest, TestEval) {
   // Test the Eval function of GeneralizedConstraintForceEvaluator.
   auto tree = ConstructFourBarTree();
 
@@ -57,35 +46,6 @@ GTEST_TEST(GeneralizedConstraintForceEvaluatorTest, TestEval) {
   tree->doKinematics(kinsol);
   const auto J = tree->positionConstraintsJacobian(kinsol);
   const Eigen::VectorXd y_expected = J.transpose() * lambda;
-  EXPECT_TRUE(CompareMatrices(math::autoDiffToValueMatrix(ty), y_expected,
-                              1E-10, MatrixCompareType::absolute));
-}
-
-GTEST_TEST(JointLimitConstraintForceEvaluatorTest, TestEval) {
-  auto tree = ConstructFourBarTree();
-
-  // Pretend that the four bar has a joint limit at joint 0.
-  JointLimitConstraintForceEvaluator evaluator(*tree, 0);
-  EXPECT_EQ(evaluator.lambda_size(), 2);
-
-  // Doesn't need a non-lambda part to evaluate the Jacobian.
-  const Eigen::VectorXd non_lambda(0);
-  // Set lambda to some arbitrary number.
-  const Eigen::VectorXd lambda =
-      Eigen::VectorXd::LinSpaced(evaluator.lambda_size(), -3, 3);
-  const Eigen::VectorXd x =
-      evaluator.ComposeEvalInputVector(non_lambda, lambda);
-  const auto tx = math::initializeAutoDiff(x);
-  AutoDiffVecXd ty;
-  evaluator.Eval(tx, ty);
-
-  Eigen::VectorXd y_expected =
-      Eigen::VectorXd::Zero(tree->get_num_velocities());
-  y_expected(0) =
-      lambda(
-          JointLimitConstraintForceEvaluator::LowerLimitForceIndexInLambda()) -
-      lambda(
-          JointLimitConstraintForceEvaluator::UpperLimitForceIndexInLambda());
   EXPECT_TRUE(CompareMatrices(math::autoDiffToValueMatrix(ty), y_expected,
                               1E-10, MatrixCompareType::absolute));
 }

--- a/systems/trajectory_optimization/test/position_constraint_force_evaluator_test.cc
+++ b/systems/trajectory_optimization/test/position_constraint_force_evaluator_test.cc
@@ -20,7 +20,7 @@ GTEST_TEST(PositionConstraintForceEvaluatorTest, TestEval) {
   PositionConstraintForceEvaluator evaluator(*tree, cache_helper);
 
   EXPECT_EQ(evaluator.lambda_size(), tree->getNumPositionConstraints());
-  EXPECT_EQ(evaluator.non_lambda_size(), tree->get_num_positions());
+  EXPECT_EQ(evaluator.generalized_positions_size(), tree->get_num_positions());
 
   // Set q to some arbitrary number.
   const Eigen::VectorXd q =


### PR DESCRIPTION
This evaluator is going to be used in quasi-static trajectory optimization.

@avalenzu , here I want to evaluate the generalized constraint force Jᵀλ. For generality I assumed the Jacobian `J` can be a function of both `q` and `v`. But in all of the cases that I can think of, the Jacobian `J` is just a function of `q`, independent of `v`. Do you think `J` should only be a function of `q` as well? If so, this evaluator can be a lot easier to compute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8037)
<!-- Reviewable:end -->
