### PR TITLE
Specify axis of revolution in unit inertia factory for solid cylinder

### DIFF
--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -134,12 +134,10 @@ drake_cc_library(
 
 drake_cc_library(
     name = "unit_inertia",
-    testonly = 1,
     srcs = ["unit_inertia.cc"],
     hdrs = ["unit_inertia.h"],
     deps = [
         ":rotational_inertia",
-        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -134,10 +134,12 @@ drake_cc_library(
 
 drake_cc_library(
     name = "unit_inertia",
+    testonly = 1,
     srcs = ["unit_inertia.cc"],
     hdrs = ["unit_inertia.h"],
     deps = [
         ":rotational_inertia",
+        "//drake/common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -184,10 +184,27 @@ GTEST_TEST(UnitInertia, SolidCylinder) {
   const double L = 1.5;
   const double I_perp = (3.0 * r * r + L * L) / 12.0;
   const double I_axial = r * r / 2.0;
-  const UnitInertia<double> G_expected(I_perp, I_perp, I_axial);
-  UnitInertia<double> G = UnitInertia<double>::SolidCylinder(r, L);
-  EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
-      G_expected.CopyToFullMatrix3(), kEpsilon));
+  const UnitInertia<double> Gz_expected(I_perp, I_perp, I_axial);
+  // Compute the unit of inertia for a cylinder oriented along the z-axis
+  // (the default).
+  UnitInertia<double> Gz =
+      UnitInertia<double>::SolidCylinder(r, L);
+  EXPECT_TRUE(Gz.CopyToFullMatrix3().isApprox(
+      Gz_expected.CopyToFullMatrix3(), kEpsilon));
+
+  // Compute the unit of inertia for a cylinder oriented along the x-axis.
+  const UnitInertia<double> Gx =
+      UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitX());
+  const UnitInertia<double> Gx_expected(I_axial, I_perp, I_perp);
+  EXPECT_TRUE(Gx.CopyToFullMatrix3().isApprox(
+      Gx_expected.CopyToFullMatrix3(), kEpsilon));
+
+  // Compute the unit of inertia for a cylinder oriented along the y-axis.
+  const UnitInertia<double> Gy =
+      UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitY());
+  const UnitInertia<double> Gy_expected(I_perp, I_axial, I_perp);
+  EXPECT_TRUE(Gy.CopyToFullMatrix3().isApprox(
+      Gy_expected.CopyToFullMatrix3(), kEpsilon));
 }
 
 // Tests the static method to obtain the unit inertia of a solid cylinder

--- a/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -6,7 +6,6 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/math/autodiff.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/multibody/multibody_tree/rotational_inertia.h"

--- a/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -186,28 +186,28 @@ GTEST_TEST(UnitInertia, SolidCylinder) {
   const double I_perp = (3.0 * r * r + L * L) / 12.0;
   const double I_axial = r * r / 2.0;
   const UnitInertia<double> Gz_expected(I_perp, I_perp, I_axial);
-  // Compute the unit of inertia for a cylinder oriented along the z-axis
+  // Compute the unit inertia for a cylinder oriented along the z-axis
   // (the default).
   UnitInertia<double> Gz =
       UnitInertia<double>::SolidCylinder(r, L);
   EXPECT_TRUE(Gz.CopyToFullMatrix3().isApprox(
       Gz_expected.CopyToFullMatrix3(), kEpsilon));
 
-  // Compute the unit of inertia for a cylinder oriented along the x-axis.
+  // Compute the unit inertia for a cylinder oriented along the x-axis.
   const UnitInertia<double> Gx =
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitX());
   const UnitInertia<double> Gx_expected(I_axial, I_perp, I_perp);
   EXPECT_TRUE(Gx.CopyToFullMatrix3().isApprox(
       Gx_expected.CopyToFullMatrix3(), kEpsilon));
 
-  // Compute the unit of inertia for a cylinder oriented along the y-axis.
+  // Compute the unit inertia for a cylinder oriented along the y-axis.
   const UnitInertia<double> Gy =
       UnitInertia<double>::SolidCylinder(r, L, Vector3d::UnitY());
   const UnitInertia<double> Gy_expected(I_perp, I_axial, I_perp);
   EXPECT_TRUE(Gy.CopyToFullMatrix3().isApprox(
       Gy_expected.CopyToFullMatrix3(), kEpsilon));
 
-  // Compute the unit of inertia for a cylinder oriented along a non-unit,
+  // Compute the unit inertia for a cylinder oriented along a non-unit,
   // non-axial vector.
   const Vector3d v(1.0, 2.0, 3.0);
   const UnitInertia<double> Gv =

--- a/multibody/multibody_tree/unit_inertia.h
+++ b/multibody/multibody_tree/unit_inertia.h
@@ -299,9 +299,9 @@ class UnitInertia : public RotationalInertia<T> {
     DRAKE_THROW_UNLESS(r >= 0);
     DRAKE_THROW_UNLESS(L >= 0);
     DRAKE_THROW_UNLESS(b_E.norm() > std::numeric_limits<double>::epsilon());
-    const T Iz = r * r / T(2);
-    const T Ix = (T(3) * r * r + L * L) / T(12);
-    return AxiallySymmetric(Iz, Ix, b_E);
+    const T J = r * r / T(2);
+    const T K = (T(3) * r * r + L * L) / T(12);
+    return AxiallySymmetric(J, K, b_E);
   }
 
   /// Computes the unit inertia for a unit-mass cylinder of uniform density

--- a/multibody/multibody_tree/unit_inertia.h
+++ b/multibody/multibody_tree/unit_inertia.h
@@ -271,14 +271,37 @@ class UnitInertia : public RotationalInertia<T> {
     return SolidBox(L, L, L);
   }
 
-  /// Computes the unit inertia for a unit-mass cylinder of uniform density
-  /// oriented along the z-axis computed about its center.
-  /// @param[in] r The radius of the cylinder.
-  /// @param[in] L The length of the cylinder.
-  static UnitInertia<T> SolidCylinder(const T& r, const T& L) {
+  /// Computes the unit inertia for a unit-mass cylinder B, of uniform density,
+  /// having its axis of revolution along input vector `b_E`. The resulting unit
+  /// inertia is computed about the cylinder's center of mass `Bcm` and is
+  /// expressed in the same frame E as the input axis of revolution `b_E`.
+  ///
+  /// @param[in] r The radius of the cylinder, it must be non-negative.
+  /// @param[in] L The length of the cylinder, it must be non-negative.
+  /// @param[in] b_E
+  ///   Vector defining the axis of revolution of the cylinder, expressed in a
+  ///   frame E. `b_E` can have a norm different from one; however, it will be
+  ///   normalized before using it. Therefore its norm is ignored and only its
+  ///   direction is used. It defaults to `Vector3<T>::UnitZ()`.
+  /// @retval G_Bcm_E
+  ///   The unit inertia for a solid cylinder B, of uniform density, with axis
+  ///   of revolution along `b_E`, computed about the cylinder's center of mass
+  ///   `Bcm`, and expressed in the same frame E as the input axis of rotation
+  ///   `b_E`.
+  ///
+  /// @throws std::runtime_error
+  ///   - Radius r is negative.
+  ///   - Length L is negative.
+  ///   - `b_E` is the zero vector. That is if `‖b_E‖₂ ≤ ε`, where ε is the
+  ///     machine epsilon.
+  static UnitInertia<T> SolidCylinder(
+      const T& r, const T& L, const Vector3<T>& b_E = Vector3<T>::UnitZ()) {
+    DRAKE_THROW_UNLESS(r >= 0);
+    DRAKE_THROW_UNLESS(L >= 0);
+    DRAKE_THROW_UNLESS(b_E.norm() > std::numeric_limits<double>::epsilon());
     const T Iz = r * r / T(2);
     const T Ix = (T(3) * r * r + L * L) / T(12);
-    return UnitInertia(Ix, Ix, Iz);
+    return AxiallySymmetric(Iz, Ix, b_E);
   }
 
   /// Computes the unit inertia for a unit-mass cylinder of uniform density
@@ -308,7 +331,7 @@ class UnitInertia : public RotationalInertia<T> {
   /// where `Id` is the identity matrix and ⊗ denotes the tensor product
   /// operator. See Mitiguy, P., 2016. Advanced Dynamics & Motion Simulation.
   ///
-  /// This method aborts if:
+  /// @throws std::runtime_error
   ///   - J is negative. J can be zero.
   ///   - K is negative. K can be zero.
   ///   - J ≤ 2 * K, this corresponds to the triangle inequality, see
@@ -333,11 +356,11 @@ class UnitInertia : public RotationalInertia<T> {
   ///   expressed in the same frame E as the input unit vector `b_E`.
   static UnitInertia<T> AxiallySymmetric(
       const T& J, const T& K, const Vector3<T>& b_E) {
-    DRAKE_DEMAND(J >= 0.0);
-    DRAKE_DEMAND(K >= 0.0);
+    DRAKE_THROW_UNLESS(J >= 0.0);
+    DRAKE_THROW_UNLESS(K >= 0.0);
     // The triangle inequalities for this case reduce to J <= 2*K:
-    DRAKE_DEMAND(J <= 2.0 * K);
-    DRAKE_DEMAND(b_E.norm() > std::numeric_limits<double>::epsilon());
+    DRAKE_THROW_UNLESS(J <= 2.0 * K);
+    DRAKE_THROW_UNLESS(b_E.norm() > std::numeric_limits<double>::epsilon());
     // Normalize b_E before using it. Only direction matters:
     Vector3<T> bhat_E = b_E.normalized();
     Matrix3<T> G_matrix =


### PR DESCRIPTION
Improves `UnitInertia::SolidCylinder()` by allowing to specify the axis of revolution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8040)
<!-- Reviewable:end -->
