### PR TITLE
Use header-only fmt

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -21,11 +21,6 @@
       "Hints": ["@prefix@/lib/cmake/eigen3"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
-    "fmt": {
-      "Version": "3.0.1",
-      "Hints": ["@prefix@/lib/cmake/fmt"],
-      "X-CMake-Find-Args": ["CONFIG"]
-    },
     "ignition-math4": {
       "Version": "4.0.0",
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],
@@ -71,7 +66,6 @@
       "Includes": ["@prefix@/include"],
       "Compile-Features": ["c++14"],
       "Link-Flags": ["-ltinyxml2"],
-      "Link-Requires": ["fmt:fmt"],
       "Requires": [
         ":drake-lcmtypes-cpp",
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",

--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -15,12 +15,8 @@ content = """
   "Components": {
     "fmt-header-only": {
       "Type": "interface",
+      "Definitions": ["FMT_HEADER_ONLY=1"],
       "Includes": ["@prefix@/include/fmt"]
-    },
-    "fmt": {
-      "Type": "dylib",
-      "Location": "@prefix@/lib/libfmt.so",
-      "Requires": [":fmt-header-only"]
     }
   }
 }

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -13,8 +13,11 @@ package(
 
 cc_library(
     name = "fmt",
-    srcs = glob(["fmt/*.cc"]),
-    hdrs = glob(["fmt/*.h"]),
+    hdrs = glob([
+        "fmt/*.cc",
+        "fmt/*.h",
+    ]),
+    defines = ["FMT_HEADER_ONLY=1"],
     includes = ["."],
 )
 

--- a/tools/workspace/spdlog/package-create-cps.py
+++ b/tools/workspace/spdlog/package-create-cps.py
@@ -30,7 +30,7 @@ content = """
         "HAVE_SPDLOG",
         "SPDLOG_FMT_EXTERNAL"
       ],
-      "Requires": ["fmt:fmt"]
+      "Requires": ["fmt:fmt-header-only"]
     }
   }
 }


### PR DESCRIPTION
Supersedes #7807. We have to install the headers for use with spdlog anyway, and there is only a very small amount of compiled code, so using the header-only version with both spdlog and drake is much cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8044)
<!-- Reviewable:end -->
