### PR TITLE
Enhance AbstractValue to allow nicer error messages for user misbehavior

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -73,6 +73,7 @@ drake_cc_library(
         "//drake/common:copyable_unique_ptr",
         "//drake/common:essential",
         "//drake/common:is_cloneable",
+        "//drake/common:nice_type_name",
     ],
 )
 

--- a/systems/framework/value.h
+++ b/systems/framework/value.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
@@ -9,6 +10,7 @@
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/is_cloneable.h"
+#include "drake/common/nice_type_name.h"
 
 namespace drake {
 namespace systems {
@@ -107,17 +109,24 @@ class AbstractValue {
   virtual std::unique_ptr<AbstractValue> Clone() const = 0;
 
   /// Copies or clones the value in @p other to this value.
-  /// In Debug builds, if the types don't match, std::bad_cast will be
-  /// thrown.  In Release builds, this is not guaranteed.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed.
   virtual void SetFrom(const AbstractValue& other) = 0;
 
-  /// Like SetFrom, but throws on mismatched types even in Release builds.
+  /// Like SetFrom, but throws std::logic_error on mismatched types even in
+  /// Release builds.
   virtual void SetFromOrThrow(const AbstractValue& other) = 0;
+
+  /// Returns a human-readable name for the underlying type T. This may be
+  /// slow but is useful for error messages.
+  virtual std::string GetNiceTypeName() const = 0;
 
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
-  /// In Debug builds, if the types don't match, std::bad_cast will be
-  /// thrown.  In Release builds, this is not guaranteed.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed.
   ///
   /// TODO(david-german-tri): Once this uses static_cast under the hood in
   /// Release builds, lower-case it.
@@ -126,25 +135,37 @@ class AbstractValue {
     return DownCastOrMaybeThrow<T>()->get_value();
   }
 
-  /// Like GetValue, but throws on mismatched types even in Release builds.
+  /// Like GetValue, but throws std::logic_error on mismatched types even in
+  /// Release builds.
   template <typename T>
   const T& GetValueOrThrow() const {
     return DownCastOrThrow<T>()->get_value();
   }
 
+  /// Like GetValue, but quietly returns nullptr on mismatched types,
+  /// even in Release builds.
+  /// @returns A pointer to the stored value if T is the right type,
+  ///          otherwise nullptr.
+  template <typename T>
+  const T* MaybeGetValue() const {
+    const Value<T>* value = dynamic_cast<const Value<T>*>(this);
+    if (value == nullptr) return nullptr;
+    return &value->get_value();
+  }
+
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
-  /// In Debug builds, if the types don't match, std::bad_cast will be
-  /// thrown.  In Release builds, this is not guaranteed.
-  /// Intentionally not const: holders of const references to the AbstractValue
-  /// should not be able to mutate the value it contains.
+  /// In Debug builds, if the types don't match, an std::logic_error will be
+  /// thrown with a helpful error message. In Release builds, this is not
+  /// guaranteed. Intentionally not const: holders of const references to the
+  /// AbstractValue should not be able to mutate the value it contains.
   template <typename T>
   T& GetMutableValue() {
     return DownCastMutableOrMaybeThrow<T>()->get_mutable_value();
   }
 
-  /// Like GetMutableValue, but throws on mismatched types even in Release
-  /// builds.
+  /// Like GetMutableValue, but throws std::logic_error on mismatched types even
+  /// in Release builds.
   template <typename T>
   T& GetMutableValueOrThrow() {
     return DownCastMutableOrThrow<T>()->get_mutable_value();
@@ -153,9 +174,9 @@ class AbstractValue {
   /// Sets the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
   /// @param value_to_set The value to be copied or cloned into this
-  /// AbstractValue.
-  /// In Debug builds, if the types don't match, std::bad_cast will be
-  /// thrown.  In Release builds, this is not guaranteed.
+  /// AbstractValue. In Debug builds, if the types don't match,
+  /// an std::logic_error will be thrown with a helpful error message. In
+  /// Release builds, this is not guaranteed.
   template <typename T>
   void SetValue(const T& value_to_set) {
     DownCastMutableOrMaybeThrow<T>()->set_value(value_to_set);
@@ -174,7 +195,7 @@ class AbstractValue {
   }
 
  private:
-  // Casts this to a Value<T>*.  Throws std::bad_cast if the cast fails.
+  // Casts this to a Value<T>*. Throws if the cast fails.
   template <typename T>
   Value<T>* DownCastMutableOrThrow() {
     // We cast away const in this private non-const method so that we can reuse
@@ -183,7 +204,7 @@ class AbstractValue {
     return const_cast<Value<T>*>(DownCastOrThrow<T>());
   }
 
-  // Casts this to a Value<T>*. In Debug builds, throws std::bad_cast if the
+  // Casts this to a Value<T>*. In Debug builds, throws if the
   // cast fails.
   template <typename T>
   Value<T>* DownCastMutableOrMaybeThrow() {
@@ -193,19 +214,20 @@ class AbstractValue {
     return const_cast<Value<T>*>(DownCastOrMaybeThrow<T>());
   }
 
-  // Casts this to a const Value<T>*. Throws std::bad_cast if the cast fails.
+  // Casts this to a const Value<T>*. Throws if the cast fails.
   template <typename T>
   const Value<T>* DownCastOrThrow() const {
     const Value<T>* value = dynamic_cast<const Value<T>*>(this);
     if (value == nullptr) {
-      // This exception is commonly thrown when the AbstractValue does not
-      // contain the concrete value type requested.
-      throw std::bad_cast();
+      throw std::logic_error(
+          "AbstractValue: a request to extract a value of type '" +
+          NiceTypeName::Get<T>() + "' failed because the actual type was '" +
+          GetNiceTypeName() + "'.");
     }
     return value;
   }
 
-  // Casts this to a const Value<T>*. In Debug builds, throws std::bad_cast if
+  // Casts this to a const Value<T>*. In Debug builds, throws if
   // the cast fails.
   template <typename T>
   const Value<T>* DownCastOrMaybeThrow() const {
@@ -318,6 +340,10 @@ class Value : public AbstractValue {
 
   void SetFromOrThrow(const AbstractValue& other) override {
     value_ = Traits::to_storage(other.GetValueOrThrow<T>());
+  }
+
+  std::string GetNiceTypeName() const override {
+    return NiceTypeName::Get<T>();
   }
 
   /// Returns a const reference to the stored value.


### PR DESCRIPTION
This is another very small caching-branch lemma. Cache entry values are stored as AbstractValue objects and users are expected to know the actual type when extracting, using helpful methods like `entry.Eval<int>()`. This PR adds a few methods to AbstractValue that allow for nicer error messages than just `bad_cast`. There are tests but no real usages here. [Here](https://github.com/sherm1/drake/blob/caching/systems/framework/cache_entry.h#L269) is an example of actual use in caching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8048)
<!-- Reviewable:end -->
