### PR TITLE
Extract just DependencyTracker-related changes from caching

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -11,8 +11,9 @@ drake_cc_library(
     srcs = [],
     deps = [
         ":abstract_values",
-        ":cache",
+        ":cache_and_dependency_tracker",
         ":context",
+        ":context_base",
         ":continuous_state",
         ":diagram",
         ":diagram_builder",
@@ -27,6 +28,7 @@ drake_cc_library(
         ":leaf_context",
         ":leaf_output_port",
         ":leaf_system",
+        ":model_values",
         ":output_port_value",
         ":parameters",
         ":single_output_vector_source",
@@ -86,16 +88,6 @@ drake_cc_library(
         ":value",
         "//drake/common:essential",
         "//drake/common:nice_type_name",
-    ],
-)
-
-drake_cc_library(
-    name = "cache",
-    srcs = ["cache.cc"],
-    hdrs = ["cache.h"],
-    deps = [
-        ":value",
-        "//drake/common:essential",
     ],
 )
 
@@ -193,6 +185,41 @@ drake_cc_library(
     ],
 )
 
+# Cache and dependencies are coupled because dependency trackers need inline
+# access to cache entries in order to invalidate them very, very fast.
+drake_cc_library(
+    name = "cache_and_dependency_tracker",
+    srcs = [
+        "cache.cc",
+        "dependency_tracker.cc",
+    ],
+    hdrs = [
+        "cache.h",
+        "dependency_tracker.h",
+    ],
+    deps = [
+        ":framework_common",
+        ":value",
+        "//drake/common:copyable_unique_ptr",
+        "//drake/common:unused",
+    ],
+)
+
+drake_cc_library(
+    name = "context_base",
+    srcs = [
+        "context_base.cc",
+    ],
+    hdrs = [
+        "context_base.h",
+    ],
+    deps = [
+        ":cache_and_dependency_tracker",
+        "//drake/common:default_scalars",
+        "//drake/common:essential",
+    ],
+)
+
 drake_cc_library(
     name = "input_port_descriptor",
     srcs = [
@@ -262,7 +289,7 @@ drake_cc_library(
     srcs = ["leaf_context.cc"],
     hdrs = ["leaf_context.h"],
     deps = [
-        ":cache",
+        ":cache_and_dependency_tracker",
         ":context",
         ":parameters",
         ":vector",
@@ -284,7 +311,6 @@ drake_cc_library(
         "witness_function.h",
     ],
     deps = [
-        ":cache",
         ":context",
         ":event_collection",
         ":framework_common",
@@ -393,7 +419,6 @@ drake_cc_library(
     srcs = ["diagram.cc"],
     hdrs = ["diagram.h"],
     deps = [
-        ":cache",
         ":diagram_context",
         ":system",
         "//drake/common:default_scalars",
@@ -474,7 +499,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "cache_test",
     deps = [
-        ":cache",
+        ":cache_and_dependency_tracker",
         "//drake/common:essential",
         "//drake/systems/framework/test_utilities",
     ],
@@ -538,6 +563,14 @@ drake_cc_googletest(
     deps = [
         ":discrete_values",
         "//drake/common:essential",
+    ],
+)
+
+drake_cc_googletest(
+    name = "dependency_tracker_test",
+    deps = [
+        ":context_base",
+        "//drake/common",
     ],
 )
 

--- a/systems/framework/cache.cc
+++ b/systems/framework/cache.cc
@@ -1,10 +1,49 @@
+// TODO(sherm1) Re-review this file in its entirety when the cache stubs are
+// replaced with real code in a subsequent PR.
+
 #include "drake/systems/framework/cache.h"
 
-#include <memory>
-#include <utility>
+#include "drake/systems/framework/dependency_tracker.h"
 
 namespace drake {
 namespace systems {
+
+CacheEntryValue& Cache::CreateNewCacheEntryValue(
+    CacheIndex index, DependencyTicket ticket,
+    const std::string& description,
+    const std::vector<DependencyTicket>& prerequisites,
+    DependencyGraph* trackers) {
+  DRAKE_DEMAND(trackers != nullptr);
+  DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
+
+  // Make sure there is a place for this cache entry in the cache.
+  if (index >= num_entries())
+    store_.resize(index + 1);
+
+  // Create the new cache entry value and install it into this Cache. Note that
+  // indirection here means the CacheEntryValue object's address is stable
+  // even when store_ is resized.
+  DRAKE_DEMAND(store_[index] == nullptr);
+  store_[index] = std::make_unique<CacheEntryValue>(
+      index, ticket, description, nullptr /* no value yet */);
+  CacheEntryValue& value = *store_[index];
+
+  // Allocate a DependencyTracker for this cache entry. Note that a pointer
+  // to the new CacheEntryValue is retained so must have a lifetime matching
+  // the tracker. That requires that the Cache and DependencyGraph are contained
+  // in the same Context.
+  DependencyTracker& tracker = trackers->CreateNewDependencyTracker(
+      ticket,
+      "cache " + description,
+      &value);
+
+  // Subscribe to prerequisites (trackers must already exist).
+  for (auto prereq : prerequisites) {
+    auto& prereq_tracker = trackers->get_mutable_tracker(prereq);
+    tracker.SubscribeToPrerequisite(&prereq_tracker);
+  }
+  return value;
+}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -1,29 +1,134 @@
 #pragma once
 
-#include <cstddef>
-#include <map>
+/** @file
+Declares CacheEntryValue and Cache, which is the container for cache entry
+values. */
+
+// TODO(sherm1) Re-review this file in its entirety when the cache stubs are
+// replaced with real code in a subsequent PR.
+
 #include <memory>
-#include <set>
-#include <tuple>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/never_destroyed.h"
+#include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
 
-// TODO(sherm1) Will contain CacheEntryValue and Cache.
+class DependencyGraph;
 
+// TODO(sherm1) Stubbed for testing DependencyTracker; do not review.
+
+// These are stubs for the two classes that comprise the cache:
+// - CacheEntryValue representing a single cache entry and storing its
+//                   abtract value and "up-to-date" indicator.
+// - Cache the container for CacheEntryValues
+//
+// Note that a Cache is local to a particular Context; that is, when there is
+// a diagram, each Context within it has its own Cache object.
+#ifndef DRAKE_DOXYGEN_CXX  // Hide from Doxygen for now.
+class CacheEntryValue {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CacheEntryValue)
+
+  CacheEntryValue(CacheIndex index, DependencyTicket ticket,
+                  std::string description,
+                  std::unique_ptr<AbstractValue> initial_value)
+      : description_(std::move(description)),
+        cache_index_(index),
+        value_(std::move(initial_value)),
+        ticket_(ticket) {
+    DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
+    // OK if value is null here.
+  }
+
+  void SetInitialValue(std::unique_ptr<AbstractValue> init_value) {
+    value_ = std::move(init_value);
+    set_is_up_to_date(false);
+  }
+
+  template <typename V>
+  void set_value(const V& new_value) {
+    value_->SetValue<V>(new_value);
+    set_is_up_to_date(true);
+  }
+
+  bool is_up_to_date() const { return is_up_to_date_flag_; }
+
+  CacheIndex cache_index() const { return cache_index_; }
+
+  DependencyTicket ticket() const { return ticket_; }
+
+  void set_is_up_to_date(bool up_to_date) { is_up_to_date_flag_ = up_to_date; }
+
+  /** Returns a mutable reference to an unused cache entry value object, which
+  has no valid CacheIndex or DependencyTicket and has a meaningless value. The
+  reference is to a singleton %CacheEntryValue and will always return the same
+  address. You may invoke set_is_up_to_date() harmlessly on this object, but may
+  not depend on its contents in any way as they may change unexpectedly. The
+  intention is that this object is used as a common throw-away destination for
+  non-cache DependencyTracker invalidations so that invalidation can be done
+  unconditionally, and to the same memory location, for speed. */
+  static CacheEntryValue& dummy() {
+    static never_destroyed<CacheEntryValue> dummy;
+    return dummy.access();
+  }
+
+ private:
+  // Allow never_destroyed to invoke the private constructor on our behalf.
+  friend class never_destroyed<CacheEntryValue>;
+
+  // Default constructor can only be used privately to construct an empty
+  // CacheEntryValue with description "DUMMY" and a meaningless value.
+  CacheEntryValue()
+      : description_("DUMMY"), value_(AbstractValue::Make<int>(0)) {}
+
+  std::string description_;
+  CacheIndex cache_index_;
+  copyable_unique_ptr<AbstractValue> value_;
+  bool is_up_to_date_flag_{false};
+  DependencyTicket ticket_;
+};
+
+// TODO(sherm1) Stubbed for DependencyTracker/Graph review; don't review.
 class Cache {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cache)
 
   Cache() = default;
-  ~Cache() = default;
+
+  // Allocates a new CacheEntryValue and corresponding DependencyTracker using
+  // the given CacheIndex and DependencyTicket number. The CacheEntryValue
+  // object is owned by this Cache and the returned reference remains valid
+  // if other cache entry values are created. The created DependencyTracker
+  // object is owned by the given DependencyGraph, which must be owned by
+  // the same Context that owns this Cache. The graph must already contain
+  // trackers for the indicated prerequisites. The new tracker will retain a
+  // pointer to the created CacheEntryValue for invalidation purposes.
+  CacheEntryValue& CreateNewCacheEntryValue(
+      CacheIndex index, DependencyTicket ticket,
+      const std::string& description,
+      const std::vector<DependencyTicket>& prerequisites,
+      DependencyGraph* graph);
+
+  int num_entries() const { return static_cast<int>(store_.size()); }
+
+  CacheEntryValue& get_mutable_cache_entry_value(CacheIndex index) {
+    CacheEntryValue& cache_value = *store_[index];
+    return cache_value;
+  }
+
+ private:
+  std::vector<copyable_unique_ptr<CacheEntryValue>> store_;
 };
+#endif  // Hiding from Doxygen.
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -1,0 +1,51 @@
+#include "drake/systems/framework/context_base.h"
+
+#include <string>
+#include <typeinfo>
+
+namespace drake {
+namespace systems {
+
+std::unique_ptr<ContextBase> ContextBase::Clone() const {
+  std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers());
+
+  // Verify that the most-derived Context didn't forget to override
+  // CloneWithoutPointers().
+  const ContextBase& source = *this;  // Deref here to avoid typeid warning.
+  ContextBase& clone = *clone_ptr;
+  DRAKE_ASSERT(typeid(source) == typeid(clone));
+
+  // Create a complete mapping of tracker pointers.
+  DependencyTracker::PointerMap tracker_map;
+  BuildTrackerPointerMap(clone, &tracker_map);
+
+  // Then do a pointer fixup pass.
+  clone.FixTrackerPointers(source, tracker_map);
+  return clone_ptr;
+}
+
+ContextBase::~ContextBase() {}
+
+std::string ContextBase::GetSystemPathname() const {
+  // TODO(sherm1) Replace with the real pathname.
+  return "/dummy/system/pathname";
+}
+
+// Set up trackers for independent sources: time, accuracy, state, parameters,
+// and input ports.
+void ContextBase::CreateBuiltInTrackers() {
+  DependencyGraph& trackers = graph_;
+  // This is the dummy "tracker" used for constants and anything else that has
+  // no dependencies on any Context source. Ignoring return value.
+  trackers.CreateNewDependencyTracker(
+      DependencyTicket(internal::kNothingTicket), "nothing");
+
+  // Allocate time tracker. Ignoring return value.
+  trackers.CreateNewDependencyTracker(
+      DependencyTicket(internal::kTimeTicket), "t");
+
+  // TODO(sherm1) Add the rest of the built-in tickets here.
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "drake/systems/framework/cache.h"
+#include "drake/systems/framework/dependency_tracker.h"
+
+namespace drake {
+namespace systems {
+
+/** Provides non-templatized functionality shared by the templatized derived
+classes. That includes caching and dependency tracking, and management of
+local values for fixed input ports.
+
+Terminology: in general a Drake System is a tree structure composed of
+"subsystems", which are themselves System objects. The corresponding Context is
+a parallel tree structure composed of "subcontexts", which are themselves
+Context objects. There is a one-to-one correspondence between subsystems and
+subcontexts. Within a given System (Context), its child subsystems (subcontexts)
+are indexed using a SubsystemIndex; there is no separate SubcontextIndex since
+the numbering must be identical. */
+class ContextBase : public internal::SystemPathnameInterface {
+ public:
+  /** @name  Does not allow move or assignment; copy is protected. */
+  /** @{ */
+  // Copy constructor is used only to facilitate implementation of Clone()
+  // in derived classes.
+  ContextBase(ContextBase&&) = delete;
+  ContextBase& operator=(const ContextBase&) = delete;
+  ContextBase& operator=(ContextBase&&) = delete;
+  /** @} */
+
+  /** Creates an identical copy of the concrete context object. */
+  std::unique_ptr<ContextBase> Clone() const;
+
+  virtual ~ContextBase();
+
+  /** (Debugging) Returns the local name of the subsystem for which this is the
+  Context. See GetSystemPathname() if you want the full name. */
+  // TODO(sherm1) Replace with the real name.
+  std::string GetSystemName() const final { return "dummy"; }
+
+  /** (Debugging) Returns the full pathname of the subsystem for which this is
+  the Context. See get_system_pathname() if you want to the full name. */
+  std::string GetSystemPathname() const final;
+
+  /** Returns a const reference to this subcontext's cache. */
+  const Cache& get_cache() const {
+    return cache_;
+  }
+
+  /** (Advanced) Returns a mutable reference to this subcontext's cache. Note
+  that this method is const because the cache is always writable.
+  @warning Writing directly to the cache does not automatically propagate
+  invalidations to downstream dependents of a contained cache entry, because
+  invalidations would normally have been propagated when the cache entry itself
+  went out of date. Cache entries are updated automatically when needed via
+  their `Calc()` methods; most users should not bypass that mechanism by using
+  this method. */
+  Cache& get_mutable_cache() const {
+    return cache_;
+  }
+
+  /** Returns a const reference to a DependencyTracker in this subcontext.
+  Advanced users and internal code can use the returned reference to issue value
+  change notifications -- mutable access is not required for that purpose. */
+  const DependencyTracker& get_tracker(DependencyTicket ticket) const {
+    return graph_.get_tracker(ticket);
+  }
+
+  /** Returns a mutable reference to a DependencyTracker in this subcontext.
+  (You do not need mutable access just to issue value change notifications.) */
+  DependencyTracker& get_mutable_tracker(DependencyTicket ticket) {
+    return graph_.get_mutable_tracker(ticket);
+  }
+
+  /** Returns a const reference to the collection of value trackers within
+  this subcontext. Together these form the dependency subgraph for the values
+  in this subcontext, plus edges leading to neighboring trackers. */
+  const DependencyGraph& get_dependency_graph() const {
+    return graph_;
+  }
+
+  /** Returns a mutable reference to the dependency graph. */
+  DependencyGraph& get_mutable_dependency_graph() {
+    return graph_;
+  }
+
+ protected:
+  /** Default constructor creates an empty ContextBase but initializes all the
+  built-in dependency trackers that are the same in every System (like time,
+  q, all states, all inputs, etc.). We can't allocate trackers for individual
+  discrete & abstract states, parameters, or input ports since we don't yet
+  know how many there are. */
+  ContextBase() : graph_(this) {
+    CreateBuiltInTrackers();
+  }
+
+  /** Copy constructor takes care of base class data members, but _does not_ fix
+  up base class pointers. Derived classes must implement copy constructors that
+  delegate to this one for use in their DoCloneWithoutPointers()
+  implementations. The cache and dependency graph are copied, but any pointers
+  contained in the source are left null in the copy. */
+  ContextBase(const ContextBase& source)
+      : cache_(source.cache_), graph_(source.graph_) {
+    // Everything else is left default-initialized.
+  }
+
+  /** Clones a context but without any of its internal pointers. */
+  std::unique_ptr<ContextBase> CloneWithoutPointers() const {
+    return DoCloneWithoutPointers();
+  }
+
+  /** Derived classes must implement this so that it performs the complete
+  deep copy of the context, including all base class members but not fixing
+  up base class pointers. To do that, implement a protected copy constructor
+  that inherits from the base class copy constructor (which doesn't repair the
+  pointers), then implement DoCloneWithoutPointers() as
+  `return unique_ptr<ContextBase>(new DerivedType(*this));`. */
+  virtual std::unique_ptr<ContextBase> DoCloneWithoutPointers() const = 0;
+
+ private:
+  // Fills in the dependency graph with the built-in trackers that are common
+  // to every Context (and every System).
+  void CreateBuiltInTrackers();
+
+  // Given a new context `clone` with the same dependency graph as this one,
+  // create a mapping of all tracker memory addresses from `this` to `clone`.
+  // This must be done for the whole Context tree because pointers can point
+  // outside of their containing subcontext.
+  void BuildTrackerPointerMap(
+      const ContextBase& clone,
+      DependencyTracker::PointerMap* tracker_map) const {
+    // First map the pointers local to this context.
+    graph_.AppendToTrackerPointerMap(clone.get_dependency_graph(),
+                                     &(*tracker_map));
+    // TODO(sherm1) Recursive update of descendents goes here.
+  }
+
+  // Assuming `this` is a recently-cloned Context containing stale references
+  // to the source Context's trackers, repair those pointers using the given
+  // map.
+  void FixTrackerPointers(const ContextBase& source,
+                          const DependencyTracker::PointerMap& tracker_map) {
+    // First repair pointers local to this context.
+    graph_.RepairTrackerPointers(source.get_dependency_graph(),
+                                 tracker_map, this, &cache_);
+    // TODO(sherm1) Recursive update of descendents goes here.
+  }
+
+  // The cache of pre-computed values owned by this subcontext.
+  mutable Cache cache_;
+
+  // This is the dependency graph for values within this subcontext.
+  DependencyGraph graph_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -1,0 +1,243 @@
+#include "drake/systems/framework/dependency_tracker.h"
+
+#include <algorithm>
+
+#include "drake/common/unused.h"
+
+namespace drake {
+namespace systems {
+
+namespace {
+// For debugging use, provide an indent of 2*depth characters.
+std::string Indent(int depth) {
+  std::string s;
+  for (int i = 0; i < depth; ++i) s += "| ";
+  return s;
+}
+}  // namespace
+
+// Our associated value has initiated a change (e.g. the associated value is
+// time and someone advanced time). Short circuit if this is part of a change
+// event that we have already heard about. Otherwise, let the subscribers know
+// that things have changed. Update statistics.
+void DependencyTracker::NoteValueChange(int64_t change_event) const {
+  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' value change event {} ...",
+                     GetPathDescription(), change_event);
+  DRAKE_ASSERT(change_event > 0);
+
+  ++num_value_change_notifications_received_;
+  if (last_change_event_ == change_event) {
+    ++num_ignored_notifications_;
+    DRAKE_SPDLOG_DEBUG(log(),
+        "... ignoring repeated value change notification same change event.");
+    return;
+  }
+  last_change_event_ = change_event;
+  NotifySubscribers(change_event, 0);
+}
+
+// A prerequisite says it has changed. Short circuit if we've already heard
+// about this change event. Otherwise, invalidate the associated cache entry and
+// then pass on the bad news to our subscribers. Update statistics.
+void DependencyTracker::NotePrerequisiteChange(
+    int64_t change_event,
+    const DependencyTracker& prerequisite,
+    int depth) const {
+  unused(Indent);  // Avoid warning in non-Debug builds.
+  DRAKE_SPDLOG_DEBUG(
+      log(), "{}Tracker '{}': prerequisite '{}' changed (event {}) ...",
+      Indent(depth), GetPathDescription(), prerequisite.GetPathDescription(),
+      change_event);
+  DRAKE_ASSERT(change_event > 0);
+  DRAKE_ASSERT(HasPrerequisite(prerequisite));  // Expensive.
+
+  ++num_prerequisite_notifications_received_;
+  if (last_change_event_ == change_event) {
+    ++num_ignored_notifications_;
+    DRAKE_SPDLOG_DEBUG(log(),
+        "{}... ignoring repeated prereq change notification same change event.",
+        Indent(depth));
+    return;
+  }
+  last_change_event_ = change_event;
+  // Update associated value if any.
+  cache_value_->set_is_up_to_date(false);
+  // Follow up with downstream subscribers.
+  NotifySubscribers(change_event, depth);
+}
+
+void DependencyTracker::NotifySubscribers(int64_t change_event,
+                                          int depth) const {
+  DRAKE_SPDLOG_DEBUG(log(), "{}... {} downstream subscribers.{}", Indent(depth),
+                     num_subscribers(),
+                     num_subscribers() > 0 ? " Notifying:" : "");
+  DRAKE_ASSERT(change_event > 0);
+  DRAKE_ASSERT(depth >= 0);
+
+  for (const DependencyTracker* subscriber : subscribers_) {
+    DRAKE_ASSERT(subscriber != nullptr);
+    DRAKE_SPDLOG_DEBUG(log(), "{}->{}", Indent(depth),
+                       subscriber->GetPathDescription());
+    subscriber->NotePrerequisiteChange(change_event, *this, depth + 1);
+  }
+
+  num_downstream_notifications_sent_ += num_subscribers();
+}
+
+// Given a DependencyTracker that is supposed to be a prerequisite to this
+// one, subscribe to it. This is done only at Context allocation and copying
+// so we can afford Release-build checks and general mucking about to make
+// runtime execution fast.
+void DependencyTracker::SubscribeToPrerequisite(
+    DependencyTracker* prerequisite) {
+  DRAKE_DEMAND(prerequisite != nullptr);
+  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' subscribing to prerequisite '{}'",
+                     GetPathDescription(), prerequisite->GetPathDescription());
+
+  // Make sure we haven't already added this prerequisite.
+  DRAKE_ASSERT(!HasPrerequisite(*prerequisite));  // Expensive.
+  prerequisites_.push_back(prerequisite);
+
+  prerequisite->AddDownstreamSubscriber(*this);
+}
+
+void DependencyTracker::AddDownstreamSubscriber(
+    const DependencyTracker& subscriber) {
+  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' adding subscriber '{}'",
+                     GetPathDescription(), subscriber.GetPathDescription());
+  // Make sure we haven't already added this subscriber.
+  DRAKE_ASSERT(!HasSubscriber(subscriber));  // Expensive.
+  // Subscriber must have *already* recorded this prerequisite.
+  DRAKE_ASSERT(subscriber.HasPrerequisite(*this));  // Expensive.
+
+  subscribers_.push_back(&subscriber);
+}
+
+namespace {
+// Convenience function for linear search of a vector to see if it contains
+// a given value.
+template <typename T>
+bool Contains(const T& value, const std::vector<T>& to_search) {
+  return std::find(to_search.begin(), to_search.end(), value)
+      != to_search.end();
+}
+
+// Look for the given value and erase it. Fail if not found.
+template <typename T>
+void Remove(const T& value, std::vector<T>* to_search) {
+  auto found = std::find(to_search->begin(), to_search->end(), value);
+  DRAKE_DEMAND(found != to_search->end());
+  to_search->erase(found);
+}
+}  // namespace
+
+// Remove a subscription that we made earlier.
+void DependencyTracker::UnsubscribeFromPrerequisite(
+    DependencyTracker* prerequisite) {
+  DRAKE_DEMAND(prerequisite != nullptr);
+  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' unsubscribing from prerequisite '{}'",
+                     GetPathDescription(), prerequisite->GetPathDescription());
+
+  // Make sure we have already added this prerequisite.
+  DRAKE_ASSERT(HasPrerequisite(*prerequisite));  // Expensive.
+  Remove<const DependencyTracker*>(prerequisite, &prerequisites_);
+
+  prerequisite->RemoveDownstreamSubscriber(*this);
+}
+
+void DependencyTracker::RemoveDownstreamSubscriber(
+    const DependencyTracker& subscriber) {
+  DRAKE_SPDLOG_DEBUG(log(), "Tracker '{}' removing subscriber '{}'",
+                     GetPathDescription(), subscriber.GetPathDescription());
+  // Make sure we already added this subscriber.
+  DRAKE_ASSERT(HasSubscriber(subscriber));  // Expensive.
+  // Subscriber must have *already* removed this prerequisite.
+  DRAKE_ASSERT(!subscriber.HasPrerequisite(*this));  // Expensive.
+
+  Remove<const DependencyTracker*>(&subscriber, &subscribers_);
+}
+
+std::string DependencyTracker::GetPathDescription() const {
+  return GetSystemPathname() + ":" + description();
+}
+
+bool DependencyTracker::HasPrerequisite(
+    const DependencyTracker& prerequisite) const {
+  return Contains(&prerequisite, prerequisites_);
+}
+
+bool DependencyTracker::HasSubscriber(
+    const DependencyTracker& subscriber) const {
+  return Contains(&subscriber, subscribers_);
+}
+
+void DependencyTracker::RepairTrackerPointers(
+    const DependencyTracker& source,
+    const DependencyTracker::PointerMap& tracker_map,
+    const internal::SystemPathnameInterface* owning_subcontext, Cache* cache) {
+  DRAKE_DEMAND(owning_subcontext != nullptr);
+  DRAKE_DEMAND(cache != nullptr);
+  owning_subcontext_ = owning_subcontext;
+
+  // Set the cache entry pointer.
+  if (source.cache_value_ == &CacheEntryValue::dummy()) {
+    cache_value_ = &CacheEntryValue::dummy();
+  } else {
+    const CacheIndex source_index(source.cache_value_->cache_index());
+    cache_value_ = &cache->get_mutable_cache_entry_value(source_index);
+    DRAKE_SPDLOG_DEBUG(log(),
+        "Cloned tracker '{}' repairing cache entry {} invalidation to {:#x}.",
+        GetPathDescription(), source.cache_value_->cache_index(),
+        size_t(cache_value_));
+  }
+
+  // Set the subscriber pointers.
+  DRAKE_DEMAND(num_subscribers() == source.num_subscribers());
+  for (int i = 0; i < num_subscribers(); ++i) {
+    DRAKE_ASSERT(subscribers_[i] == nullptr);
+    auto map_entry = tracker_map.find(source.subscribers()[i]);
+    DRAKE_DEMAND(map_entry != tracker_map.end());
+    subscribers_[i] = map_entry->second;
+  }
+
+  // Set the prerequisite pointers.
+  DRAKE_DEMAND(num_prerequisites() == source.num_prerequisites());
+  for (int i = 0; i < num_prerequisites(); ++i) {
+    DRAKE_ASSERT(prerequisites_[i] == nullptr);
+    auto map_entry = tracker_map.find(source.prerequisites()[i]);
+    DRAKE_DEMAND(map_entry != tracker_map.end());
+    prerequisites_[i] = map_entry->second;
+  }
+}
+
+void DependencyGraph::AppendToTrackerPointerMap(
+    const DependencyGraph& clone,
+    DependencyTracker::PointerMap* tracker_map) const {
+  DRAKE_DEMAND(tracker_map != nullptr);
+  DRAKE_DEMAND(clone.trackers_size() == trackers_size());
+  for (DependencyTicket ticket(0); ticket < trackers_size(); ++ticket) {
+    if (!has_tracker(ticket))
+      continue;
+    const bool added = tracker_map->emplace(&get_tracker(ticket),
+                                            &clone.get_tracker(ticket)).second;
+    DRAKE_DEMAND(added);  // Shouldn't have been there.
+  }
+}
+
+void DependencyGraph::RepairTrackerPointers(
+    const DependencyGraph& source,
+    const DependencyTracker::PointerMap& tracker_map,
+    const internal::SystemPathnameInterface* owning_subcontext,
+    Cache* new_cache) {
+  DRAKE_DEMAND(owning_subcontext != nullptr);
+  owning_subcontext_ = owning_subcontext;
+  for (DependencyTicket ticket(0); ticket < trackers_size(); ++ticket) {
+    if (!has_tracker(ticket))
+      continue;
+    get_mutable_tracker(ticket).RepairTrackerPointers(
+        source.get_tracker(ticket), tracker_map, owning_subcontext, new_cache);
+  }
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -1,0 +1,522 @@
+#pragma once
+
+/** @file
+Declares DependencyTracker and DependencyGraph which is the container for
+trackers. */
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/text_logging.h"
+#include "drake/systems/framework/cache.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+class DependencyGraph;  // defined below
+
+//==============================================================================
+//                             DEPENDENCY TRACKER
+//==============================================================================
+/** Manages value interdependencies for a particular value or set of values in
+a Context.
+
+A %DependencyTracker ("tracker" for short) provides notifications of changes to
+the managed value to downstream subscribers, and may invalidate an associated
+cache entry. The "managed value" can be a source like time or state, or a cached
+computation. A particular tracker is selected using a DependencyTicket
+("ticket") which provides very fast access to the tracker. The ticket is used by
+both the System and Context as a way to identify dependencies, while trackers
+exist only in the Context.
+
+Each %DependencyTracker manages dependencies for a value, or group of related
+values, upon which some downstream computations may depend, and maintains lists
+of downstream dependents (subscribers) and upstream prerequisites. An optional
+CacheEntryValue may be registered with a tracker in which case the tracker will
+mark the cache value out of date when one of its prerequisites has changed.
+
+A single %DependencyTracker can represent interdependencies within its
+subcontext, and to and from other subcontexts within the same containing Context
+tree. Trackers are always owned by a DependencyGraph that is part of a
+particular subcontext, and should always be created through methods of
+DependencyGraph; don't construct them directly yourself.
+
+%DependencyTracker objects within a Context are nodes in a directed acylic graph
+formed by "is-prerequisite-of" edges leading from source values (like time,
+state, parameters, and input ports) to dependent cached computations and output
+ports. A %DependencyTracker maintains lists of both its downstream subscribers
+and its upstream prerequisites. The entries in both lists are pointers to other
+%DependencyTrackers. That requires special handling when cloning a Context,
+since the internal pointers to the %DependencyTracker objects in the source must
+be replaced by their corresponding pointers in the copy.
+
+%DependencyTrackers may simply group upstream values, without representing a
+new value or computation. For example, the three continuous state subgroups
+q, v, and z are each associated with their own %DependencyTracker. There is
+also a tracker that monitors changes to _any_ variable within the entire
+collection of continuous variables `xc≜{q,v,z}`; that tracker
+subscribes to the three individual trackers. Similarly, individual discrete
+variable groups dᵢ collectively determine the discrete state `xd≜{dᵢ}`,
+individual abstract state variables aᵢ determine the abstract state `xa≜{aᵢ}`,
+and the full state is `x≜{xc,xd,xa}`. Here is a graph showing
+time and state trackers and some hypothetical cache entry trackers.
+<pre>
+                   (q)--------➙(position kinematics)
+                      ➘
+                 (v)--➙(xc)---     (time)----➙(xc_dot)
+                 (z)--➚       ╲              ➚
+                               ➘            ╱
+                (d₀)--➙(xd)---➙(x)----------
+                (d₁)--➚        ➚
+                              ╱
+                (a₀)--➙(xa)---
+                (a₁)--➚
+</pre>
+The parenthesized nodes are %DependencyTrackers for the indicated values, and
+a directed edge `(a)->(b)` can be read as "a is-prerequisite-of b" or
+"a determines b". The graph also maintains reverse-direction edges (not shown).
+A reversed edge `(a)<-(b)` could be read as "b subscribes-to a" or
+"b depends-on a".)
+
+These grouped trackers simplify dependency specification for quantities that
+depend on many sources, which is very common. For example, they allow a user to
+express a dependence on "all the inputs" without actually having to
+know how many inputs there are, which might change over time. Grouped trackers
+also serve to reduce the total number of edges in the dependency graph,
+providing faster invalidation. For example, if there are 10 computations
+dependent on q, v, and z (which frequently change together) we would have 30
+edges. Introducing (xc) reduces that to 13 edges.
+
+Downstream computations may subscribe to any of the individual or grouped
+nodes. */
+
+// Implementation notes:
+// Invalidation operations occur very frequently at run time and must execute
+// very fast. To make invalidation an O(N) operation, it is essential to avoid
+// unnecessary repeated invalidations of the same subgraph during an
+// invalidation sweep. That is handled via a unique "change event"
+// serial number that is stored in a tracker when it is first invalidated.
+// Encountering a node with a matching change event number terminates that
+// branch of an invalidation sweep using that change event. Calling code can
+// improve performance further by grouping simultaneous changes (say time and
+// state) together into a single change event.
+//
+// Lots of things can go wrong so we maintain lots of redundant information here
+// and check it religiously in Debug builds, less so in Release builds.
+//
+// For maximum speed, DependencyTracker objects contain pointers to other
+// trackers within the same containing Context tree. That is, the referenced
+// trackers can be in any subcontext that shares the same root Context as the
+// subcontext that owns this tracker; they are not necessarily limited to
+// trackers within the same subcontext. There is also
+// a pointer to the containing Context's system pathname service for use in
+// logging and error messages. These pointers provide great performance but
+// make DependencyTrackers hard to clone because the pointers have to be set to
+// point to corresponding entries in the new copy.
+//
+// DependencyTrackers for cache entries have to invalidate the associated cache
+// value when notified of prerequisite changes. That simply sets a bool that is
+// maintained by the CacheEntryValue object. This is an inner loop activity
+// that must be done very efficiently. It is faster to invalidate with
+// unconditional, inline code than to have a runtime test or abstract interface
+// for cache invalidation. To permit that, we allocate a static dummy
+// CacheEntryValue here, make it available for all non-cache DependencyTrackers
+// to "invalidate", and require that the definition of the cache invalidation
+// method is visible here rather than use an abstract interface to it.
+
+class DependencyTracker {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DependencyTracker)
+
+  /** (Internal use only) */
+  using PointerMap = std::unordered_map<const DependencyTracker*,
+                                        const DependencyTracker*>;
+
+  /** Returns the human-readable description for this tracker. */
+  const std::string& description() const { return description_; }
+
+  /** Returns the description, preceded by the full pathname of the subsystem
+  associated with the owning subcontext. */
+  std::string GetPathDescription() const;
+
+  /** Returns the DependencyTicket for this %DependencyTracker in its containing
+  DependencyGraph. The ticket is unique within the containing subcontext. */
+  DependencyTicket ticket() const { return ticket_; }
+
+  /** Notifies `this` %DependencyTracker that its managed value was directly
+  modified or made available for mutable access. That is, this is the
+  _initiating_ event of a value modification. All of our downstream
+  subscribers are notified but the associated cache entry (if any) is _not_
+  invalidated (see below for why). A unique, positive `change_event` should
+  have been obtained from the owning Context and supplied here.
+
+  Why don't we invalidate the cache entry? Recall that this method is for
+  _initiating_ a change event, meaning that the quantity that this tracker
+  tracks is _initiating_ an invalidation sweep, as opposed to just reacting to
+  prerequisite changes. Normally cache entries become invalid because their
+  prerequisites change; they are not usually the first step in an invalidation
+  sweep. So it is unusual for NoteValueChange() to be called on a cache entry's
+  dependency tracker. But if it is called, that is likely to mean the cache
+  entry was just given a new value, and is therefore _valid_; invalidating it
+  now would be an error. */
+  void NoteValueChange(int64_t change_event) const;
+
+  /** @name              Prerequisites and subscribers
+  These methods deal with dependencies associated with this tracker. */
+  //@{
+
+  /** Subscribes `this` tracker to an upstream prerequisite's tracker. The
+  upstream tracker will keep a const pointer back to `this` tracker in its
+  subscriber list, and `this` tracker will keep a pointer to the prerequisite
+  tracker in its prerequisites list. */
+  void SubscribeToPrerequisite(DependencyTracker* prerequisite);
+
+  /** Unsubscribes `this` tracker from an upstream prerequisite tracker to
+  which we previously subscribed. Both the prerequisite list in `this` tracker
+  and the subscriber list in `prerequisite` are modified.
+  @pre The supplied pointer must not be null.
+  @pre This tracker must already be subscribed to the given `prerequisite`. */
+  void UnsubscribeFromPrerequisite(DependencyTracker* prerequisite);
+
+  /** Adds a downstream subscriber to `this` %DependencyTracker, which will keep
+  a pointer to the subscribing tracker. The subscriber will be notified whenever
+  this %DependencyTracker is notified of a value or prerequisite change.
+  @pre The subscriber has already recorded its dependency on this tracker in its
+       prerequisite list. */
+  void AddDownstreamSubscriber(const DependencyTracker& subscriber);
+
+  /** Removes a downstream subscriber from `this` %DependencyTracker.
+  @pre The subscriber has already removed the dependency on this tracker from
+       its prerequisite list. */
+  void RemoveDownstreamSubscriber(const DependencyTracker& subscriber);
+
+  /** Returns `true` if this tracker has already subscribed to `prerequisite`.
+  This is slow and should not be used in performance-sensitive code. */
+  bool HasPrerequisite(const DependencyTracker& prerequisite) const;
+
+  /** Returns `true` if `subscriber` is one of this tracker's subscribers.
+  This is slow and should not be used in performance-sensitive code. */
+  bool HasSubscriber(const DependencyTracker& subscriber) const;
+
+  /** Returns the total number of "depends-on" edges emanating from `this`
+  tracker, pointing to its upstream prerequisites. */
+  int num_prerequisites() const {
+    return static_cast<int>(prerequisites_.size());
+  }
+
+  /** Returns a reference to the prerequisite trackers. */
+  const std::vector<const DependencyTracker*>& prerequisites() const {
+    return prerequisites_;
+  }
+
+  /** Returns the total number of "is-prerequisite-of" edges emanating from
+  `this` tracker, pointing to its downstream subscribers. */
+  int num_subscribers() const { return static_cast<int>(subscribers_.size()); }
+
+  /** Returns a reference to the subscribing trackers. */
+  const std::vector<const DependencyTracker*>& subscribers() const {
+    return subscribers_;
+  }
+  //@}
+
+  /** @name                     Runtime statistics
+  These methods track runtime operations and are useful for debugging and for
+  performance analysis. **/
+  //@{
+
+  /** What is the total number of notifications received by this tracker?
+  This is the sum of managed-value change event notifications and prerequisite
+  change notifications received. */
+  int64_t num_notifications_received() const {
+    return num_value_change_events() + num_prerequisite_change_events();
+  }
+
+  /** How many times did we receive a repeat notification for the same change
+  event that we ignored? */
+  int64_t num_ignored_notifications() const {
+    return num_ignored_notifications_;
+  }
+
+  /** What is the total number of notifications sent to downstream subscribers
+  by this trackers? */
+  int64_t num_notifications_sent() const {
+    return num_downstream_notifications_sent_;
+  }
+
+  /** How many times was this tracker notified of a change event for a direct
+  change to a value it tracks? */
+  int64_t num_value_change_events() const {
+    return num_value_change_notifications_received_;
+  }
+
+  /** How many times was this tracker notified of a change to one of its value's
+  prerequisites? */
+  int64_t num_prerequisite_change_events() const {
+    return num_prerequisite_notifications_received_;
+  }
+  //@}
+
+ private:
+  friend class DependencyGraph;
+
+  // (Private because trackers should only be created by DependencyGraph.)
+  // Constructs a tracker with a given ticket number, a human-readable
+  // description and an optional CacheEntryValue object that should be marked
+  // out-of-date when a prerequisite changes. The description should be of the
+  // associated value only, like "input port 3"; don't include "tracker". The
+  // system pathname service of the owning subcontext must be supplied here and
+  // be non-null.
+  DependencyTracker(DependencyTicket ticket, std::string description,
+                    const internal::SystemPathnameInterface* owning_subcontext,
+                    CacheEntryValue* cache_value)
+      : ticket_(ticket),
+        description_(std::move(description)),
+        owning_subcontext_(owning_subcontext),
+        cache_value_(cache_value ? cache_value : &CacheEntryValue::dummy()) {
+    DRAKE_SPDLOG_DEBUG(
+        log(), "Tracker #{} '{}' constructed {} invalidation {:#x}{}.", ticket_,
+        description_, cache_value ? "with" : "without", size_t(cache_value),
+        cache_value
+        ? " cache entry " + std::to_string(cache_value->cache_index())
+        : "");
+  }
+
+  // Copies the current tracker but with all pointers set to null, and all
+  // counters reset to their default-constructed values (0 for statistics, an
+  // unmatchable value for the last change event).
+  std::unique_ptr<DependencyTracker> CloneWithoutPointers() const {
+    // Can't use make_unique here because constructor is private.
+    std::unique_ptr<DependencyTracker> clone(
+        new DependencyTracker(ticket(), description(), nullptr, nullptr));
+    // cache_value_ is set to dummy by default; must reset to null now so we
+    // can fix it up later.
+    clone->cache_value_ = nullptr;
+    clone->subscribers_.resize(num_subscribers(), nullptr);
+    clone->prerequisites_.resize(num_prerequisites(), nullptr);
+    return clone;
+  }
+
+  // Assumes `this` tracker is a recent clone containing no pointers, sets
+  // the pointers here to addresses corresponding to those in the source
+  // tracker, with the help of the given map. It is a fatal error if any needed
+  // pointer is not present in the map.
+  void RepairTrackerPointers(
+      const DependencyTracker& source,
+      const DependencyTracker::PointerMap& tracker_map,
+      const internal::SystemPathnameInterface* owning_subcontext, Cache* cache);
+
+  // Notifies `this` DependencyTracker that one of its prerequisite values was
+  // modified or made available for mutable access. All of our downstream
+  // subscribers are notified and the associated cache entry (if any) is
+  // invalidated. The unique `change_event` obtained by the initiating value
+  // modification should be passed through here. The particular upstream
+  // `prerequisite` reporting the change is provided here for enforcing
+  // invariants in Debug builds. `depth` measures the notification chain length
+  // and is useful for debugging and performance analysis. An initial caller
+  // should supply `depth`=0; it is incremented internally.
+  void NotePrerequisiteChange(int64_t change_event,
+                              const DependencyTracker& prerequisite,
+                              int depth) const;
+
+  // Notifies downstream subscribers that they are no longer valid. This may
+  // have been initiated by a change to our tracked value or an upstream
+  // prerequisite; downstream subscribers can't tell the difference.
+  void NotifySubscribers(int64_t change_event, int depth) const;
+
+  std::string GetSystemPathname() const {
+    DRAKE_DEMAND(owning_subcontext_!= nullptr);
+    return owning_subcontext_->GetSystemPathname();
+  }
+
+  // This tracker's index within its owning DependencyGraph.
+  const DependencyTicket ticket_;
+
+  const std::string description_;
+
+  // Pointer to the system name service of the owning subcontext.
+  const internal::SystemPathnameInterface* owning_subcontext_{nullptr};
+
+  // Points to CacheEntryValue::dummy() if we're not told otherwise.
+  CacheEntryValue* cache_value_{nullptr};
+
+  std::vector<const DependencyTracker*> subscribers_;
+  std::vector<const DependencyTracker*> prerequisites_;
+
+  // Used for short-circuiting repeated notifications. Does not otherwise change
+  // the result; hence mutable is OK. All legitimate change events must be
+  // greater than zero, so this will never match.
+  mutable int64_t last_change_event_{-1};
+
+  // Runtime statistics. Does not change behavior at all.
+  mutable int64_t num_value_change_notifications_received_{0};
+  mutable int64_t num_prerequisite_notifications_received_{0};
+  mutable int64_t num_ignored_notifications_{0};
+  mutable int64_t num_downstream_notifications_sent_{0};
+};
+
+//==============================================================================
+//                            DEPENDENCY GRAPH
+//==============================================================================
+/** Represents the portion of the complete dependency graph that is a subgraph
+centered on the owning subcontext, plus some edges leading to other subcontexts.
+DependencyTracker objects are the nodes of the graph, and maintain
+prerequisite/subscriber edges that interconnect these nodes, and may also
+connect to nodes contained in dependency graphs belonging to other subcontexts
+within the same complete context tree. Dependencies on the parent (containing
+DiagramContext) and children (contained subcontexts) typically arise from
+exported input and output ports, while sibling dependencies arise from
+output-to-input port connections.
+
+A %DependencyGraph creates and owns all the DependencyTracker objects for a
+particular subcontext, organized to allow fast access using a DependencyTicket
+as an index. Memory addresses of DependencyTracker objects are stable once
+allocated, but DependencyTicket numbers are stable even after a Context has been
+copied so should be preferred.
+
+Because DependencyTrackers contain pointers, copying a %DependencyGraph must
+always be done as part of copying an entire Context tree. There is a copy
+constructor here but it must be followed by a pointer-fixup step so is for
+internal use only. */
+class DependencyGraph {
+ public:
+  /** @name  Does not allow move or assignment; copy constructor limited.
+  The copy constructor does not copy internal pointers so requires special
+  handling. */
+  /** @{ */
+  DependencyGraph(DependencyGraph&&) = delete;
+  DependencyGraph& operator=(const DependencyGraph&) = delete;
+  DependencyGraph& operator=(DependencyGraph&&) = delete;
+  /** @} */
+
+  /** Constructor creates an empty graph referencing the system pathname
+  service of its owning subcontext. The supplied pointer must not be null. */
+  explicit DependencyGraph(
+      const internal::SystemPathnameInterface* owning_subcontext)
+      : owning_subcontext_(owning_subcontext) {
+    DRAKE_DEMAND(owning_subcontext != nullptr);
+  }
+
+  /** Deletes all DependencyTracker objects; no notifications are issued. */
+  ~DependencyGraph() = default;
+
+  /** Allocates a new DependencyTracker with an already-known ticket number, the
+  given description and an optional cache value to be invalidated. The new
+  tracker has no prerequisites or subscribers yet. This may leave gaps in the
+  node numbering. Use has_tracker() if you need to know whether there is a
+  tracker for a particular ticket. We promise that the returned
+  DependencyTracker's location in memory will remain unchanged once created in
+  a particular Context, even as more trackers are added. The DependencyTicket
+  retains its meaning even after cloning the Context, although of course the
+  tracker has a new address in the clone.
+  @pre The given ticket must be valid.
+  @pre No DependencyTracker is already using the given ticket. */
+  DependencyTracker& CreateNewDependencyTracker(
+      DependencyTicket known_ticket, std::string description,
+      CacheEntryValue* cache_value = nullptr) {
+    DRAKE_DEMAND(!has_tracker(known_ticket));
+    if (known_ticket >= trackers_size()) graph_.resize(known_ticket + 1);
+    // Can't use make_unique here because constructor is private.
+    graph_[known_ticket].reset(new DependencyTracker(
+        known_ticket, std::move(description), owning_subcontext_, cache_value));
+    return *graph_[known_ticket];
+  }
+
+  /** Assigns a new ticket number and then allocates a new DependencyTracker
+  that can be accessed with that ticket. You may obtain the assigned
+  ticket from the returned tracker. See the other signature for details. */
+  DependencyTracker& CreateNewDependencyTracker(
+      std::string description, CacheEntryValue* cache_value = nullptr) {
+    DependencyTicket ticket(trackers_size());
+    return CreateNewDependencyTracker(ticket, std::move(description),
+                                      cache_value);
+  }
+
+  /** Returns true if there is a DependencyTracker in this graph that has the
+  given ticket number. */
+  bool has_tracker(DependencyTicket ticket) const {
+    DRAKE_DEMAND(ticket.is_valid());
+    if (ticket >= trackers_size()) return false;
+    return graph_[ticket] != nullptr;
+  }
+
+  /** Returns the current size of the DependencyTracker container, providing
+  for DependencyTicket numbers from `0..trackers_size()-1`. Note that it is
+  possible to have empty slots in the container. Use has_tracker() to determine
+  if there is a tracker associated with a particular ticket. */
+  int trackers_size() const { return static_cast<int>(graph_.size()); }
+
+  /** Returns a const DependencyTracker given a ticket. This is very fast.
+  Behavior is undefined if the ticket is out of range [0..num_trackers()-1]. */
+  const DependencyTracker& get_tracker(DependencyTicket ticket) const {
+    DRAKE_ASSERT(has_tracker(ticket));
+    DependencyTracker& tracker = *graph_[ticket];
+    DRAKE_ASSERT(tracker.ticket() == ticket);
+    return tracker;
+  }
+
+  /** Returns a mutable DependencyTracker given a ticket. This is very fast.
+  Behavior is undefined if the ticket is out of range [0..num_trackers()-1]. */
+  DependencyTracker& get_mutable_tracker(DependencyTicket ticket) {
+    return const_cast<DependencyTracker&>(get_tracker(ticket));
+  }
+
+  /** (Internal use only) Copy constructor partially duplicates the source
+  %DependencyGraph object, with identical structure to the source but
+  with all internal pointers set to null, and all counters and statistics set
+  to their default-constructed values. Pointers must be set properly using
+  RepairTrackerPointers() once all the old-to-new pointer mappings have been
+  determined _for the whole Context_, not just the containing subcontext. This
+  should only be invoked by Context code as part of copying an entire Context
+  tree.
+  @see AppendToTrackerPointerMap(), RepairTrackerPointers() */
+  DependencyGraph(const DependencyGraph& source) {
+    graph_.reserve(source.trackers_size());
+    for (DependencyTicket ticket(0); ticket < source.trackers_size();
+         ++ticket) {
+      graph_.emplace_back(
+          source.has_tracker(ticket)
+              ? source.get_tracker(ticket).CloneWithoutPointers()
+              : nullptr);
+    }
+  }
+
+  /** (Internal use only) Create a mapping from the memory addresses of the
+  trackers contained here to the corresponding ones in `clone`, which must have
+  exactly the same number of trackers. The mapping is appended to the supplied
+  map, which must not be null. */
+  void AppendToTrackerPointerMap(
+      const DependencyGraph& clone,
+      DependencyTracker::PointerMap* tracker_map) const;
+
+  /** (Internal use only) Assumes `this` %DependencyGraph is a recent clone
+  whose trackers do not yet contain subscriber and prerequisite pointers and
+  sets the local pointers to point to the `source`-corresponding trackers in the
+  new owning context, the appropriate cache entry values in the new cache, and
+  to the system name providing service of the new owning Context for logging and
+  error reporting. The supplied map should map source pointers to their
+  corresponding trackers. It is a fatal error if any old pointer we encounter is
+  not present in the map; that would indicate a bug in the Context cloning
+  code. */
+  void RepairTrackerPointers(
+      const DependencyGraph& source,
+      const DependencyTracker::PointerMap& tracker_map,
+      const internal::SystemPathnameInterface* owning_subcontext,
+      Cache* new_cache);
+
+ private:
+  // The system name service of the subcontext that owns this subgraph.
+  const internal::SystemPathnameInterface* owning_subcontext_{};
+
+  // All value trackers, indexed by DependencyTicket.
+  std::vector<std::unique_ptr<DependencyTracker>> graph_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -16,7 +16,6 @@
 #include "drake/common/number_traits.h"
 #include "drake/common/symbolic.h"
 #include "drake/common/text_logging.h"
-#include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/diagram_context.h"
 #include "drake/systems/framework/discrete_values.h"
 #include "drake/systems/framework/state.h"

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
 #include "drake/common/type_safe_index.h"
 
 namespace drake {
@@ -10,8 +16,6 @@ namespace systems {
 // the same meaning in both class hierarchies. A System and its Context always
 // have parallel internal structure.
 
-// TODO(sherm1) Reveal these when they are used.
-#ifndef DRAKE_DOXYGEN_CXX
 /** Identifies a particular source value or computation for purposes of
 declaring and managing dependencies. Unique only within a given subsystem
 and its corresponding subcontext. */
@@ -24,6 +28,9 @@ using DependencyTicket = TypeSafeIndex<class DependencyTag>;
 the corresponding CacheEntryValue in that System's Context. This is an index
 providing extremely fast constant-time access to both. */
 using CacheIndex = TypeSafeIndex<class CacheTag>;
+
+// TODO(sherm1) Reveal these when they are used.
+#ifndef DRAKE_DOXYGEN_CXX
 
 /** Serves as a local index for a child subsystem within a parent
 Diagram, or a child subcontext within a parent DiagramContext. A subsystem and
@@ -67,6 +74,42 @@ typedef enum {
 rather depends on what it is connected to (not yet implemented). */
 // TODO(sherm1) Implement this.
 constexpr int kAutoSize = -1;
+
+#ifndef DRAKE_DOXYGEN_CXX
+namespace internal {
+
+/** Any class that can provide a System name and (for Diagrams) a subsystem
+path name should implement this interface. This is used by System and Context
+so that contained objects can provide helpful error messages and log
+diagnostics that identify the offending object within a diagram. (Diagram
+Systems and their Contexts have identical substructure.) Providing
+this as a separate interface allows us to avoid circular dependencies between
+the containers and their contained objects. */
+class SystemPathnameInterface {
+ public:
+  virtual ~SystemPathnameInterface() = default;
+
+  /** Returns the simple name of this subsystem, with no path separators. */
+  virtual std::string GetSystemName() const = 0;
+
+  /** Returns the full path name of this subsystem, starting at the root
+  of the containing Diagram, with path name separators between segments. */
+  virtual std::string GetSystemPathname() const = 0;
+};
+
+/** These dependency ticket numbers are common to all systems and contexts so
+are defined here. Actual ticket objects are created from these integers.
+Ticket numbers for conditionally-allocated objects like ports and cache
+entries are allocated beginning with kNextAvailableTicket defined below. */
+enum BuiltInTicketNumbers {
+  kNothingTicket        =  0,
+  kTimeTicket           =  1,
+  // TODO(sherm1) Add in the rest of the built-in tickets here.
+  kNextAvailableTicket  = kTimeTicket + 1
+};
+
+}  // namespace internal
+#endif
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -19,7 +19,6 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/unused.h"
-#include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/event_collection.h"
 #include "drake/systems/framework/input_port_descriptor.h"

--- a/systems/framework/test/dependency_tracker_test.cc
+++ b/systems/framework/test/dependency_tracker_test.cc
@@ -1,0 +1,344 @@
+#include "drake/systems/framework/dependency_tracker.h"
+
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "drake/systems/framework/context_base.h"
+
+// Tests the DependencyTracker and DependencyGraph classes. These are intimately
+// tied to the CacheEntryValue class in order to be able to invalidate
+// cache entries with inline code for speed. We're not testing CacheEntryValue
+// here but use it to check that DependencyTracker propagates invalidations
+// to cache entries correctly.
+//
+// Although DependencyTracker code has no direct dependence on higher-level
+// Context code, for this test we do require ContextBase so we can use the
+// DependencyGraph and Cache objects it contains, and so we can test the cloning
+// operation which requires several steps that ContextBase understands how to
+// exercise (cloning of a DependencyGraph is always initiated as part of
+// cloning a Context).
+
+namespace drake {
+namespace systems {
+namespace {
+
+// See above for why this is here.
+class MyContextBase : public ContextBase {
+ public:
+  MyContextBase() {}
+  MyContextBase(const MyContextBase&) = default;
+ private:
+  std::unique_ptr<ContextBase> DoCloneWithoutPointers() const final {
+    return std::unique_ptr<ContextBase>(new MyContextBase(*this));
+  }
+};
+
+// For testing that trackers did what we expected.
+struct Stats {
+  int64_t ignored{0};
+  int64_t sent{0};
+  int64_t value_change{0};
+  int64_t prereq_change{0};
+};
+
+void ExpectStatsMatch(const DependencyTracker* tracker, const Stats& expected) {
+  EXPECT_EQ(tracker->num_ignored_notifications(), expected.ignored);
+  EXPECT_EQ(tracker->num_notifications_sent(), expected.sent);
+  EXPECT_EQ(tracker->num_value_change_events(), expected.value_change);
+  EXPECT_EQ(tracker->num_prerequisite_change_events(), expected.prereq_change);
+  EXPECT_EQ(tracker->num_notifications_received(),
+            tracker->num_value_change_events() +
+                tracker->num_prerequisite_change_events());
+}
+
+// Normally the dependency trackers are allocated automatically by the
+// System framework. Here we try to use as little of the framework as possible
+// and cobble together the following dependency graph by hand:
+//
+//     +-----------+                    +---------------+
+//     | upstream1 +--------+-----------> downstream1   |
+//     +-----------+        |       +--->               |
+//                          |       |   +---------------+
+//     +-----------+   +----v----+  |   +---------------+
+//     | upstream2 +---> middle1 +--+---> downstream2   +--+
+//     +-----------+   +----+----+      +---------------+  |  +-----------+
+//                          |                              +-->           |
+//     +-----------+        +--------------------------------->  entry0   |
+//     |  time     +------------------------------------------>           |
+//     +-----------+                                          +-----------+
+//
+// entry0 is a cache entry so we expect invalidation; the others are just
+// trackers with no associated values.
+class HandBuiltDependencies : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    DependencyGraph& graph = context_.get_mutable_dependency_graph();
+
+    DependencyTicket next_ticket(internal::kNextAvailableTicket);
+
+    upstream1_ = &graph.CreateNewDependencyTracker(
+        next_ticket++, "upstream1");
+    upstream2_ = &graph.CreateNewDependencyTracker(
+        next_ticket++, "upstream2");
+    middle1_ = &graph.CreateNewDependencyTracker(
+        next_ticket++, "middle1");
+    downstream1_ = &graph.CreateNewDependencyTracker(
+        next_ticket++, "downstream1");
+    downstream2_ = &graph.CreateNewDependencyTracker(
+        next_ticket++, "downstream2");
+    middle1_->SubscribeToPrerequisite(upstream1_);
+    middle1_->SubscribeToPrerequisite(upstream2_);
+    downstream1_->SubscribeToPrerequisite(middle1_);
+    downstream1_->SubscribeToPrerequisite(upstream1_);
+    downstream2_->SubscribeToPrerequisite(middle1_);
+
+    Cache& cache = context_.get_mutable_cache();
+    const CacheIndex index(cache.num_entries());
+    entry0_ = &cache.CreateNewCacheEntryValue(
+        index, next_ticket++, "entry0",
+        {time_ticket_, middle1_->ticket(), downstream2_->ticket()}, &graph);
+    entry0_->SetInitialValue(AbstractValue::Make<int>(3));
+    entry0_tracker_ = &graph.get_mutable_tracker(entry0_->ticket());
+
+    // Retrieve time tracker.
+    time_tracker_ = &graph.get_mutable_tracker(time_ticket_);
+  }
+
+  void ExpectAllStatsMatch() const {
+    ExpectStatsMatch(time_tracker_, tt_stats_);
+    ExpectStatsMatch(upstream1_, up1_stats_);
+    ExpectStatsMatch(upstream2_, up2_stats_);
+    ExpectStatsMatch(middle1_, mid1_stats_);
+    ExpectStatsMatch(downstream1_, down1_stats_);
+    ExpectStatsMatch(downstream2_, down2_stats_);
+    ExpectStatsMatch(entry0_tracker_, entry0_stats_);
+  }
+
+  std::unique_ptr<MyContextBase> context_ptr_ =
+      std::make_unique<MyContextBase>();
+  ContextBase& context_ = *context_ptr_;
+  DependencyTracker* middle1_{};
+  DependencyTracker* upstream1_{};
+  DependencyTracker* upstream2_{};
+  DependencyTracker* downstream1_{};
+  DependencyTracker* downstream2_{};
+  CacheEntryValue* entry0_{};
+  DependencyTracker* entry0_tracker_{};
+
+  const DependencyTicket time_ticket_{internal::kTimeTicket};
+  DependencyTracker* time_tracker_{};
+
+  // Expected statistics for each of the above trackers; initially zero.
+  Stats tt_stats_, up1_stats_, up2_stats_, mid1_stats_, down1_stats_,
+      down2_stats_, entry0_stats_;
+};
+
+// Check that we can ask the graph for new dependency trackers, and that the
+// associated cache entry has the right value.
+TEST_F(HandBuiltDependencies, Construction) {
+  DependencyGraph& graph = context_.get_mutable_dependency_graph();
+
+  // Construct with a known ticket.
+  auto& tracker100 = graph.CreateNewDependencyTracker(
+      DependencyTicket(100), "tracker100");
+  EXPECT_EQ(tracker100.ticket(), 100);
+
+  // Construct with assigned ticket (should get the next one).
+  const int num_trackers = graph.trackers_size();
+  auto& tracker = graph.CreateNewDependencyTracker("tracker");
+  EXPECT_EQ(tracker.ticket(), num_trackers);
+}
+
+// Check that a dependency tracker can provide a human-readable name.
+TEST_F(HandBuiltDependencies, GetPathname) {
+  const std::string system_path = context_.GetSystemPathname();
+  const std::string mid1_description = middle1_->description();
+  EXPECT_EQ(middle1_->GetPathDescription(),
+    system_path + ":" + mid1_description);
+}
+
+// Check that we can unsubscribe from a previously-subscribed-to
+// prerequisite.
+TEST_F(HandBuiltDependencies, Unsubscribe) {
+  EXPECT_TRUE(middle1_->HasPrerequisite(*upstream1_));
+  EXPECT_TRUE(middle1_->HasPrerequisite(*upstream2_));
+
+  middle1_->UnsubscribeFromPrerequisite(upstream1_);
+  EXPECT_FALSE(middle1_->HasPrerequisite(*upstream1_));
+  EXPECT_TRUE(middle1_->HasPrerequisite(*upstream2_));
+}
+
+// Check that notifications and invalidation are propagated correctly, and that
+// short-circuiting keeps the number of notifications minimal when there are
+// multiple paths through the graph.
+TEST_F(HandBuiltDependencies, Notify) {
+  // Just-allocated cache entries are not up to date. We're not using the
+  // cache entry API here -- just playing with the underlying "up to date" flag.
+  EXPECT_FALSE(entry0_->is_up_to_date());
+
+  // set_value() sets the up-to-date flag.
+  entry0_->set_value(1125);
+  EXPECT_TRUE(entry0_->is_up_to_date());
+
+  // Refer to diagram above to decipher the expected stats below.
+
+  // Nobody should have been notified yet.
+  ExpectAllStatsMatch();
+
+  // The cache entry does not depend on downstream1.
+  downstream1_->NoteValueChange(1LL);
+  down1_stats_.value_change++;  // No dependents.
+  EXPECT_TRUE(entry0_->is_up_to_date());
+  ExpectAllStatsMatch();
+
+  // A repeated notification (same change event) should be ignored.
+  downstream1_->NoteValueChange(1LL);
+  down1_stats_.value_change++;
+  down1_stats_.ignored++;
+  ExpectAllStatsMatch();
+
+  // The cache entry depends directly on time.
+  time_tracker_->NoteValueChange(2LL);
+  tt_stats_.value_change++;
+  tt_stats_.sent++;  // entry0
+  entry0_stats_.prereq_change++;
+  EXPECT_FALSE(entry0_->is_up_to_date());
+  ExpectAllStatsMatch();
+
+  entry0_->set_is_up_to_date(true);
+  EXPECT_TRUE(entry0_->is_up_to_date());
+
+  upstream1_->NoteValueChange(3LL);
+  up1_stats_.value_change++;
+  up1_stats_.sent += 2;  // mid1, down1
+  mid1_stats_.prereq_change++;
+  mid1_stats_.sent += 3;  // down1, down2, entry0
+  down1_stats_.prereq_change += 2;
+  down1_stats_.ignored++;
+  down2_stats_.prereq_change++;
+  down2_stats_.sent++;  // entry0
+  entry0_stats_.prereq_change += 2;
+  entry0_stats_.ignored++;
+  EXPECT_FALSE(entry0_->is_up_to_date());
+  ExpectAllStatsMatch();
+}
+
+// Clone the dependency graph and make sure the clone works like the
+// original did, but on the new entities!
+TEST_F(HandBuiltDependencies, Clone) {
+  DependencyGraph& graph = context_.get_mutable_dependency_graph();
+
+  // Make up a ticket number that is guaranteed to leave a gap to make sure
+  // we test handling of missing trackers.
+  const DependencyTicket after_gap_ticket(graph.trackers_size() + 3);
+  const DependencyTracker& after_gap = graph.CreateNewDependencyTracker(
+      after_gap_ticket, "after_gap");
+
+  // Do some notifies in the old context so we can make sure all the stats
+  // get cleared for the clone. (Previous test ensured these are propagated.)
+  upstream1_->NoteValueChange(5LL);
+  upstream2_->NoteValueChange(6LL);
+  time_tracker_->NoteValueChange(7LL);
+
+  // Create a clone of the dependency graph and exercise the pointer fixup code.
+  auto clone_context = context_.Clone();
+
+  // Now study the cloned graph to see if it got fixed up correctly.
+  DependencyGraph& clone_graph = clone_context->get_mutable_dependency_graph();
+
+  EXPECT_EQ(clone_graph.trackers_size(), graph.trackers_size());
+  for (DependencyTicket ticket(0); ticket < graph.trackers_size(); ++ticket) {
+    EXPECT_EQ(graph.has_tracker(ticket), clone_graph.has_tracker(ticket));
+    if (!graph.has_tracker(ticket)) continue;
+
+    const auto& tracker = graph.get_tracker(ticket);
+    const auto& clone_tracker = clone_graph.get_tracker(ticket);
+    EXPECT_NE(&clone_tracker, &tracker);
+    EXPECT_EQ(clone_tracker.description(), tracker.description());
+    EXPECT_EQ(clone_tracker.num_subscribers(), tracker.num_subscribers());
+    EXPECT_EQ(clone_tracker.num_prerequisites(), tracker.num_prerequisites());
+    for (int i=0; i < tracker.num_subscribers(); ++i) {
+      const DependencyTracker* clone_subs = clone_tracker.subscribers()[i];
+      const DependencyTracker* subs = tracker.subscribers()[i];
+      EXPECT_NE(clone_subs, nullptr);
+      EXPECT_NE(clone_subs, subs);
+      EXPECT_EQ(clone_subs->ticket(), subs->ticket());
+      EXPECT_EQ(clone_subs->description(), subs->description());
+    }
+    for (int i=0; i < tracker.num_prerequisites(); ++i) {
+      const DependencyTracker* clone_pre = clone_tracker.prerequisites()[i];
+      const DependencyTracker* pre = tracker.prerequisites()[i];
+      EXPECT_NE(clone_pre, nullptr);
+      EXPECT_NE(clone_pre, pre);
+      EXPECT_EQ(clone_pre->ticket(), pre->ticket());
+      EXPECT_EQ(clone_pre->description(), pre->description());
+    }
+  }
+
+  // Dig up corresponding trackers & the cloned cache entry. The auto here
+  // is "DependencyTracker".
+  auto& time1 = clone_graph.get_mutable_tracker(time_ticket_);
+  auto& up1 = clone_graph.get_mutable_tracker(upstream1_->ticket());
+  auto& up2 = clone_graph.get_mutable_tracker(upstream2_->ticket());
+  auto& mid1 = clone_graph.get_mutable_tracker(middle1_->ticket());
+  auto& down1 = clone_graph.get_mutable_tracker(downstream1_->ticket());
+  auto& down2 = clone_graph.get_mutable_tracker(downstream2_->ticket());
+  auto& e0_tracker = clone_graph.get_mutable_tracker(entry0_->ticket());
+  auto& after_gap_clone = clone_graph.get_tracker(after_gap.ticket());
+
+  // Check that gaps in the tracker ticket numbering were preserved.
+  EXPECT_EQ(after_gap_clone.ticket(), after_gap_ticket);
+  EXPECT_FALSE(clone_graph.has_tracker(DependencyTicket(after_gap_ticket - 1)));
+
+  // Find the cloned cache entry corresponding to entry0_.
+  Cache& clone_cache = clone_context->get_mutable_cache();
+  CacheEntryValue& clone_entry0 =
+      clone_cache.get_mutable_cache_entry_value(entry0_->cache_index());
+
+  // Expected statistics for the cloned trackers; initially zero.
+  Stats tt_stats, up1_stats, up2_stats, mid1_stats, down1_stats,
+      down2_stats, entry0_stats;
+
+  // All stats should have been cleared in the clone.
+  ExpectStatsMatch(&time1, tt_stats);
+  ExpectStatsMatch(&up1, up1_stats);
+  ExpectStatsMatch(&up2, up2_stats);
+  ExpectStatsMatch(&mid1, mid1_stats);
+  ExpectStatsMatch(&down1, down1_stats);
+  ExpectStatsMatch(&down2, down2_stats);
+  ExpectStatsMatch(&e0_tracker, entry0_stats);
+
+  EXPECT_FALSE(clone_entry0.is_up_to_date());
+  clone_entry0.set_value(101);
+  EXPECT_TRUE(clone_entry0.is_up_to_date());
+
+  // Upstream2 is prerequisite to middle1 which is prerequisite to down1,2 and
+  // the cache entry, and down2 gets the cache entry again so should be
+  // ignored.
+  up2.NoteValueChange(1LL);
+  up2_stats.value_change++;
+  up2_stats.sent++;  // mid1
+  mid1_stats.prereq_change++;
+  mid1_stats.sent += 3;  // down1, down2, entry0
+  down1_stats.prereq_change++;
+  down2_stats.prereq_change++;
+  down2_stats.sent++;
+  entry0_stats.prereq_change += 2;
+  entry0_stats.ignored++;
+  ExpectStatsMatch(&time1, tt_stats);
+  ExpectStatsMatch(&up1, up1_stats);
+  ExpectStatsMatch(&up2, up2_stats);
+  ExpectStatsMatch(&mid1, mid1_stats);
+  ExpectStatsMatch(&down1, down1_stats);
+  ExpectStatsMatch(&down2, down2_stats);
+  ExpectStatsMatch(&e0_tracker, entry0_stats);
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -244,7 +244,7 @@ LIBDRAKE_COMPONENTS = [
     "//drake/systems/estimators:kalman_filter",
     "//drake/systems/estimators:luenberger_observer",
     "//drake/systems/framework:abstract_values",
-    "//drake/systems/framework:cache",
+    "//drake/systems/framework:cache_and_dependency_tracker",
     "//drake/systems/framework:context",
     "//drake/systems/framework:continuous_state",
     "//drake/systems/framework:diagram",


### PR DESCRIPTION
This is a second attempt to chop out the DependencyTracker submodule of the [caching system](http://drake.mit.edu/doxygen_cxx/group__cache__design__notes.html) so it can be reviewed independently.  This contains DependencyTracker ("tracker") which is an abstraction of the concept of "a computation that may have upstream prerequisites and may serve as a prerequisite for downstream computations". A tracker serves as a node in the DependencyGraph maintained by a Context.

The DependencyTracker code is somewhat intimate with the caching code, which is not included here. Instead there is a mocked stub of Cache and CacheEntryValue with just enough API for the DependencyTracker to do its job. Those will be replaced in a subsequent PR; please don't review them except to make sure they won't cause any trouble sitting there doing nothing.

I have also included a stripped-down (but not mocked) portion of the new ContextBase class. Later that will become the base class for `Context<T>`, but right now it is serving only to hold the cache and dependency graph and execute the tricky cloning code that has to fix up dependency tracker pointers. The code that is there should be reviewed, but much of it is missing or abbreviated now.

A subsequent PR will add in the System-side CacheEntry and the Context-side CacheEntryValue objects, which are also relatively independent utilities. After that will be the framework wiring to make use of these objects.

Relates #7668.

### Reviewing strategy

The code that is here has already been feature reviewed by @edrumwri when it was part of the now-closed PR #7697. Should require just a quick confirmation that it is still the same code (and all issues raised there should have been addressed). Platform review is still needed.

This is still a large PR but singularly focused so hopefully not too awful to review. Here are the stats:
```
Category            added  modified  removed  
----------------------------------------------
code                719    3         5        
comments            440    1         1        
blank               202    0         0        
----------------------------------------------
TOTAL               1361   4         6            
```
There are ~100 lines of ignorable stub code, so maybe 600 real lines, plus comments.

- If you haven't already, you may want to look over the [caching design notes (doxygen)](http://drake.mit.edu/doxygen_cxx/group__cache__design__notes.html) to get the overall picture.

- All the interesting code and most documentation is in `dependency_tracker.{h,cc}`, which contains both the DependencyTracker and DependencyGraph classes, and the unit tests in `dependency_tracker_test.cc`. The actual graph object is in ContextBase. There are two important aspects to review here:
    - The functioning of the dependency classes, and
    - Cloning of the dependency graph (which occurs when a Context is cloned).


The latter is tricky because the edges of the dependency graph are represented by pointers to trackers, and those pointers must be repaired to point to corresponding entities in a cloned Context.

- The ContextBase stub code deals almost exclusively with the pointer-fixup issue. That is also real code but truncated.

If you have questions about how this isolated code fits in to the full implementation, please ask me or take a look at the caching branch in #7668.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8050)
<!-- Reviewable:end -->
