### PR TITLE
Add SetModelInstancePositions() to RigidBodyPlant

### DIFF
--- a/examples/schunk_wsg/BUILD.bazel
+++ b/examples/schunk_wsg/BUILD.bazel
@@ -63,6 +63,7 @@ drake_cc_googletest(
         "//common/trajectories:piecewise_polynomial_trajectory",
         "//common/trajectories:trajectory",
         "//lcm",
+        "//manipulation/schunk_wsg:schunk_wsg_constants",
         "//multibody:rigid_body_tree",
         "//multibody:rigid_body_tree_construction",
         "//multibody/parsers",

--- a/manipulation/schunk_wsg/schunk_wsg_constants.h
+++ b/manipulation/schunk_wsg/schunk_wsg_constants.h
@@ -43,6 +43,23 @@ MatrixX<T> GetSchunkWsgFeedbackSelector() {
   return selector;
 }
 
+/**
+ * Returns the position vector corresponding to the open position of the
+ * gripper. This is more complicated than one might expect due to the linkage in
+ * our model of the gripper.
+ */
+template <typename T>
+VectorX<T> GetSchunkWsgOpenPosition() {
+  // clang-format off
+  return (VectorX<T>(kSchunkWsgNumPositions) <<
+      -0.0550667,
+       0.009759,
+       1.27982,
+       0.0550667,
+       0.009759) .finished();
+  // clang-format on
+}
+
 }  // namespace schunk_wsg
 }  // namespace manipulation
 }  // namespace drake

--- a/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -276,6 +276,30 @@ void RigidBodyPlant<T>::set_position(Context<T>* context, int position_index,
 }
 
 template <typename T>
+void RigidBodyPlant<T>::SetModelInstancePositions(
+    Context<T>* context, int model_instance_id,
+    const Eigen::Ref<const VectorX<T>> positions) const {
+  DRAKE_ASSERT(context != nullptr);
+  const int num_positions = positions.size();
+  std::vector<const RigidBody<T>*> model_instance_bodies =
+      this->get_rigid_body_tree().FindModelInstanceBodies(model_instance_id);
+  std::vector<int> position_indices;
+  position_indices.reserve(num_positions);
+  for (const RigidBody<T>* body : model_instance_bodies) {
+    const int joint_num_positions = body->getJoint().get_num_positions();
+    const int position_start_index = body->get_position_start_index();
+    for (int i = 0; i < joint_num_positions; ++i) {
+      position_indices.push_back(position_start_index + i);
+    }
+  }
+  DRAKE_THROW_UNLESS(static_cast<int>(position_indices.size()) ==
+                     num_positions);
+  for (int i = 0; i < num_positions; ++i) {
+    set_position(context, position_indices[i], positions(i));
+  }
+}
+
+template <typename T>
 void RigidBodyPlant<T>::set_velocity(Context<T>* context, int velocity_index,
                                      T velocity) const {
   DRAKE_ASSERT(context != nullptr);

--- a/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/multibody/rigid_body_plant/rigid_body_plant.h
@@ -195,6 +195,12 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// `position`.
   void set_position(Context<T>* context, int position_index, T position) const;
 
+  /// Sets the generalized coordinates of the model instance specified by
+  /// `model_instance_id` to the values in `position`.
+  void SetModelInstancePositions(
+      Context<T>* context, int model_instance_id,
+      const Eigen::Ref<const VectorX<T>> positions) const;
+
   /// Sets the generalized velocity `velocity_index` to the value
   /// `velocity`.
   void set_velocity(Context<T>* context, int velocity_index, T velocity) const;

--- a/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -325,9 +325,8 @@ TEST_P(KukaArmTest, EvalOutput) {
   // Sets the state to a non-zero value.
   VectorXd desired_angles(kNumPositions_);
   desired_angles << 0.5, 0.1, -0.1, 0.2, 0.3, -0.2, 0.15;
-  for (int i = 0; i < kNumPositions_; ++i) {
-    kuka_plant_->set_position(context_.get(), i, desired_angles[i]);
-  }
+  kuka_plant_->SetModelInstancePositions(context_.get(), kModelInstanceId,
+                                        desired_angles);
   VectorXd desired_state(kNumStates_);
   desired_state << desired_angles, VectorXd::Zero(kNumVelocities_);
   auto x = kuka_plant_->GetStateVector(*context_);


### PR DESCRIPTION
This PR consists of two curated commits, one which adds a `SetModelInstancePositions()` method to `RigidBodyPlant` and one which updates `schunk_wsg_lift_test.cc` to use that method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8053)
<!-- Reviewable:end -->
