### PR TITLE
Bnb solve by rounding

### DIFF
--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -373,7 +373,7 @@ SolutionResult MixedIntegerBranchAndBound::Solve() {
   // solution can be specified after the constructor call.
   if (root_->solution_result() == SolutionResult::kSolutionFound &&
       !root_->optimal_solution_is_integral()) {
-    SearchIntegralSolution(*root_);
+    SearchIntegralSolutionByRounding(*root_);
   }
   MixedIntegerBranchAndBoundNode* branching_node = PickBranchingNode();
   while (branching_node) {
@@ -580,39 +580,6 @@ double BestLowerBoundInSubTree(
                ? left_best_lower_bound
                : right_best_lower_bound;
   }
-}
-}  // namespace
-
-MixedIntegerBranchAndBoundNode*
-MixedIntegerBranchAndBound::PickMinLowerBoundNode() const {
-  return PickMinLowerBoundNodeInSubTree(*this, *root_);
-}
-
-MixedIntegerBranchAndBoundNode* MixedIntegerBranchAndBound::PickDepthFirstNode()
-    const {
-  // The deepest node has the largest number of fixed binary variables.
-  return PickDepthFirstNodeInSubTree(*this, *root_);
-}
-
-const symbolic::Variable* MixedIntegerBranchAndBound::PickBranchingVariable(
-    const MixedIntegerBranchAndBoundNode& node) const {
-  switch (variable_selection_method_) {
-    case VariableSelectionMethod::kMostAmbivalent:
-      return PickMostAmbivalentAsBranchingVariable(node);
-    case VariableSelectionMethod::kLeastAmbivalent:
-      return PickLeastAmbivalentAsBranchingVariable(node);
-    case VariableSelectionMethod::kUserDefined:
-      if (variable_selection_userfun_ != nullptr) {
-        return variable_selection_userfun_(node);
-      }
-      throw std::runtime_error(
-          "The user defined function cannot be null. Call "
-          "SetUserDefinedVariableSelectionFunction to provide the user-defined "
-          "function for selecting the branching variable.");
-  }
-  // It is impossible to reach this DRAKE_ABORT(), but gcc throws the error
-  // Werror=return-type, if we do not have it here.
-  DRAKE_ABORT();
 }
 
 const symbolic::Variable* PickMostOrLeastAmbivalentAsBranchingVariable(

--- a/solvers/branch_and_bound.cc
+++ b/solvers/branch_and_bound.cc
@@ -64,9 +64,6 @@ MixedIntegerBranchAndBoundNode::MixedIntegerBranchAndBoundNode(
       solution_result_{SolutionResult::kUnknownError},
       optimal_solution_is_integral_{OptimalSolutionIsIntegral::kUnknown},
       solver_id_{solver_id} {
-  std::unique_ptr<MathematicalProgramSolverInterface> solver =
-      MakeSolver(solver_id);
-  DRAKE_ASSERT(solver.get());
   // Check if there are still binary variables.
   DRAKE_ASSERT(!MathProgHasBinaryVariables(*prog_));
   // Set Gurobi DualReductions to 0, to differentiate infeasible from unbounded.
@@ -760,8 +757,7 @@ void MixedIntegerBranchAndBound::SearchIntegralSolutionByRounding(
     for (const auto& remaining_binary_variable :
          node.remaining_binary_variables()) {
       // Notice that roundoff_integer_val is of type double here. This is
-      // because AddBoundingBoxConstraint(...) requires the bounds of type
-      // double.
+      // because AddBoundingBoxConstraint(...) requires bounds of type double.
       const double roundoff_integer_val =
           std::round(node.prog()->GetSolution(remaining_binary_variable));
       new_prog->AddBoundingBoxConstraint(roundoff_integer_val,

--- a/solvers/branch_and_bound.h
+++ b/solvers/branch_and_bound.h
@@ -265,23 +265,6 @@ class MixedIntegerBranchAndBound {
   };
 
   /**
-   * In each node, after the optimization problem is solved, the user can
-   * call some callback method. For example, the user can try to find an
-   * integral solution based on the solution to the optimization problem
-   * in the node.
-   */
-  enum class NodeCallbackMethod {
-    kDoNothing,                         ///< No callback. This is the default.
-    kSearchIntegralSolutionByRounding,  ///< If the optimal solution to the
-                                        ///< problem in this node is not
-                                        ///< integral, then round off the
-                                        ///< fractional solutions to either 0 or
-                                        ///< 1, and then solve the remaining
-                                        ///< continuous variables.
-    kUserDefined,                       ///< User defined call back
-  };
-
-  /**
    * The function signature for the user defined method to pick a branching node
    * or a branching variable.
    */
@@ -491,19 +474,20 @@ class MixedIntegerBranchAndBound {
     variable_selection_userfun_ = fun;
   }
 
-  /**
-   * The user can choose the method for the call back for each node, after the 
-   * node is created, and the optimization problem in the node is solved.
-   * @param node_callback_method The option to call back in each node. If the
-   * option is NodeCallbackMethod::kUserDfined, the the user should provide
-   * the callback function through SetUserDefinedNodeCallbackFunction(...).
+  /** Set the flag to true if the user wants to search an integral solution
+   * in each node, after the optimization problem in that node is solved.
+   * The program can search for an integral solution based on the solution to
+   * the optimization program in the node, by rounding the binary variables
+   * to the nearest integer value, and solve for the continuous variables.
+   * If a solution is obtained in this new program, then this solution is
+   * an integral solution to the mixed-integer program.
    */
-  void SetNodeCallbackMethod(NodeCallbackMethod node_callback_method) {
-    node_callback_method_ = node_callback_method;
+  void SetSearchIntegralSolutionByRounding(bool flag) {
+    search_integral_solution_by_rounding_ = flag;
   }
 
   /**
-   * Set the user defined callback function in each node. This function is 
+   * The user can set a defined callback function in each node. This function is 
    * called after the optimization is solved in each node, if the user has 
    * called SetNodeCallbackMethod(NodeCallbackMethod::kUserDefined).
    */
@@ -683,7 +667,7 @@ class MixedIntegerBranchAndBound {
   NodeSelectionMethod node_selection_method_ =
       NodeSelectionMethod::kMinLowerBound;
 
-  NodeCallbackMethod node_callback_method_ = NodeCallbackMethod::kDoNothing;
+  bool search_integral_solution_by_rounding_ = false;
 
   // The user defined function to pick a branching variable. Default is null.
   VariableSelectFun variable_selection_userfun_ = nullptr;

--- a/solvers/branch_and_bound.h
+++ b/solvers/branch_and_bound.h
@@ -488,8 +488,7 @@ class MixedIntegerBranchAndBound {
 
   /**
    * The user can set a defined callback function in each node. This function is 
-   * called after the optimization is solved in each node, if the user has 
-   * called SetNodeCallbackMethod(NodeCallbackMethod::kUserDefined).
+   * called after the optimization is solved in each node.
    */
   void SetUserDefinedNodeCallbackFunction(NodeCallbackFun fun) {
     node_callback_userfun_ = fun;
@@ -614,8 +613,7 @@ class MixedIntegerBranchAndBound {
    * satisfied:
    * 1. The optimization problem in this node is feasible.
    * 2. The optimal solution to the problem in this node is not integral.
-   * 3. node_callback_method =
-   * NodeCallbackMethod::kSearchIntegralSolutionByRounding
+   * 3. The user called SetSearchIntegralSolutionByRounding(true);
    * @note This method will change the data field such as solutions_ and/or
    * best_upper_bound_, if an integral solution is found.
    */

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -185,7 +185,7 @@ void CheckNodeSolution(const MixedIntegerBranchAndBoundNode& node,
                               MatrixCompareType::absolute));
   EXPECT_NEAR(node.prog()->GetOptimalCost(), optimal_cost, tol);
 }
-/*
+
 GTEST_TEST(MixedIntegerBranchAndBoundNodeTest, TestConstructRoot1) {
   // Test constructing root node for prog 1.
   auto prog = ConstructMathematicalProgram1();
@@ -1120,7 +1120,7 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, TestMultipleIntegralSolution2) {
       CheckAllIntegralSolution(bnb, xy, integral_solutions, tol);
     }
   }
-} */
+} 
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
   // Test the node callback to search an integral solution by rounding the
@@ -1149,12 +1149,9 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
   // by rounding. The branch-and-bound should terminate at the root node, as
   // it should find the optimal integral solution at the root.
   MixedIntegerBranchAndBound bnb(*prog, GurobiSolver::id());
-  bnb.SetNodeCallbackMethod(MixedIntegerBranchAndBound::NodeCallbackMethod::kSearchIntegralSolutionByRounding);
+  bnb.SetSearchIntegralSolutionByRounding(true);
   const SolutionResult result = bnb.Solve();
   EXPECT_EQ(result, SolutionResult::kSolutionFound);
-  // The branch-and-bound terminates at the root node, thus the root node is
-  // a leaf node.
-  EXPECT_TRUE(bnb.root()->IsLeaf());
 }
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding3) {

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -42,6 +42,8 @@ class MixedIntegerBranchAndBoundTester {
     return bnb_->BranchAndUpdate(node, branching_variable);
   }
 
+  MixedIntegerBranchAndBoundNode* mutable_root() { return bnb_->root_.get(); }
+
   void SearchIntegralSolutionByRounding(
       const MixedIntegerBranchAndBoundNode& node) {
     bnb_->SearchIntegralSolutionByRounding(node);

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -42,7 +42,10 @@ class MixedIntegerBranchAndBoundTester {
     return bnb_->BranchAndUpdate(node, branching_variable);
   }
 
-  MixedIntegerBranchAndBoundNode* mutable_root() { return bnb_->root_.get(); }
+  void SearchIntegralSolutionByRounding(
+      const MixedIntegerBranchAndBoundNode& node) {
+    bnb_->SearchIntegralSolutionByRounding(node);
+  }
 
  private:
   std::unique_ptr<MixedIntegerBranchAndBound> bnb_;
@@ -182,7 +185,7 @@ void CheckNodeSolution(const MixedIntegerBranchAndBoundNode& node,
                               MatrixCompareType::absolute));
   EXPECT_NEAR(node.prog()->GetOptimalCost(), optimal_cost, tol);
 }
-
+/*
 GTEST_TEST(MixedIntegerBranchAndBoundNodeTest, TestConstructRoot1) {
   // Test constructing root node for prog 1.
   auto prog = ConstructMathematicalProgram1();
@@ -1117,6 +1120,71 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, TestMultipleIntegralSolution2) {
       CheckAllIntegralSolution(bnb, xy, integral_solutions, tol);
     }
   }
+} */
+
+GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
+  // Test the node callback to search an integral solution by rounding the
+  // fractional solution to binary values, and solve the continuous variables.
+  // Test on prog2.
+  auto prog = ConstructMathematicalProgram2();
+  VectorDecisionVariable<5> x = prog->decision_variables();
+  MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
+  // The solution to the root node is (0.7, 1, 1, 1.4, 0), with optimal cost
+  // -4.9. We will add the constraint x₀ = 1, x₂ = 1, x₄ = 0, and then solve the
+  // continuous variables.
+  // The optimal solution to this new program is (1, 1/3, 1, 1, 0), with cost
+  // -13 / 3. This is also the optimal solution to the MIP prog2.
+  dut.SearchIntegralSolutionByRounding(*(dut.bnb()->root()));
+  const double tol{1E-5};
+  EXPECT_NEAR(dut.bnb()->best_upper_bound(), -13.0 / 3, tol);
+  // The best lower bound is unchanged after solving the new program with fixed
+  // binary variables.
+  EXPECT_NEAR(dut.bnb()->best_lower_bound(), -4.9, tol);
+  Eigen::Matrix<double, 5, 1> x_expected;
+  x_expected << 1, 1.0 / 3, 1, 1, 0;
+  EXPECT_TRUE(CompareMatrices(dut.bnb()->GetSolution(x), x_expected, tol,
+                              MatrixCompareType::absolute));
+
+  // Now test to solve the mip with the callback to search for integral solution
+  // by rounding. The branch-and-bound should terminate at the root node, as
+  // it should find the optimal integral solution at the root.
+  MixedIntegerBranchAndBound bnb(*prog, GurobiSolver::id());
+  bnb.SetNodeCallbackMethod(MixedIntegerBranchAndBound::NodeCallbackMethod::kSearchIntegralSolutionByRounding);
+  const SolutionResult result = bnb.Solve();
+  EXPECT_EQ(result, SolutionResult::kSolutionFound);
+  // The branch-and-bound terminates at the root node, thus the root node is
+  // a leaf node.
+  EXPECT_TRUE(bnb.root()->IsLeaf());
+}
+
+GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding3) {
+  // Test the node callback to search an integral solution by rounding the
+  // fractional solution to binary values, and solve the continuous variables.
+  // Test on prog3.
+  auto prog = ConstructMathematicalProgram3();
+  MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
+  // The solution to the root node is unbounded. If we fix the binary variables
+  // and search for the continuous variables, the new program is still unbounded.
+  dut.SearchIntegralSolutionByRounding(*(dut.bnb()->root()));
+  EXPECT_EQ(dut.bnb()->best_upper_bound(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(dut.bnb()->best_lower_bound(), -std::numeric_limits<double>::infinity());
+}
+
+GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding4) {
+  // Test the node callback to search an integral solution by rounding the
+  // fractional solution to binary values, and solve the continuous variables.
+  // Test on prog4.
+  auto prog = ConstructMathematicalProgram4();
+  MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
+  // The optimal solution to the root node is (1/3, 1/3, 1/3, 2/3, 1/3), with 
+  // optimal cost 4/3. We will add the constraint y₀ = 1, y₁ = 0, and solve for
+  // the continuous variable x. The new problem is infeasible.
+  dut.SearchIntegralSolutionByRounding(*(dut.bnb()->root()));
+  const double tol{1E-5};
+  EXPECT_EQ(dut.bnb()->best_upper_bound(), std::numeric_limits<double>::infinity());
+  // This best lower bound is unchanged, after we search for the integral
+  // solution, since the new program is infeasible.
+  EXPECT_NEAR(dut.bnb()->best_lower_bound(), 4.0 / 3, tol);
 }
 
 MixedIntegerBranchAndBoundNode* LeftMostNodeInSubTree(

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -1122,7 +1122,7 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, TestMultipleIntegralSolution2) {
       CheckAllIntegralSolution(bnb, xy, integral_solutions, tol);
     }
   }
-} 
+}
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
   // Test the node callback to search an integral solution by rounding the
@@ -1163,10 +1163,13 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding3) {
   auto prog = ConstructMathematicalProgram3();
   MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
   // The solution to the root node is unbounded. If we fix the binary variables
-  // and search for the continuous variables, the new program is still unbounded.
+  // and search for the continuous variables, the new program is still
+  // unbounded.
   dut.SearchIntegralSolutionByRounding(*(dut.bnb()->root()));
-  EXPECT_EQ(dut.bnb()->best_upper_bound(), std::numeric_limits<double>::infinity());
-  EXPECT_EQ(dut.bnb()->best_lower_bound(), -std::numeric_limits<double>::infinity());
+  EXPECT_EQ(dut.bnb()->best_upper_bound(),
+            std::numeric_limits<double>::infinity());
+  EXPECT_EQ(dut.bnb()->best_lower_bound(),
+            -std::numeric_limits<double>::infinity());
 }
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding4) {
@@ -1175,12 +1178,13 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding4) {
   // Test on prog4.
   auto prog = ConstructMathematicalProgram4();
   MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
-  // The optimal solution to the root node is (1/3, 1/3, 1/3, 2/3, 1/3), with 
+  // The optimal solution to the root node is (1/3, 1/3, 1/3, 2/3, 1/3), with
   // optimal cost 4/3. We will add the constraint y₀ = 1, y₁ = 0, and solve for
   // the continuous variable x. The new problem is infeasible.
   dut.SearchIntegralSolutionByRounding(*(dut.bnb()->root()));
   const double tol{1E-5};
-  EXPECT_EQ(dut.bnb()->best_upper_bound(), std::numeric_limits<double>::infinity());
+  EXPECT_EQ(dut.bnb()->best_upper_bound(),
+            std::numeric_limits<double>::infinity());
   // This best lower bound is unchanged, after we search for the integral
   // solution, since the new program is infeasible.
   EXPECT_NEAR(dut.bnb()->best_lower_bound(), 4.0 / 3, tol);

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -1147,9 +1147,9 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
   EXPECT_TRUE(CompareMatrices(dut.bnb()->GetSolution(x), x_expected, tol,
                               MatrixCompareType::absolute));
 
-  // Now test to solve the mip with the callback to search for integral solution
-  // by rounding. The branch-and-bound should terminate at the root node, as
-  // it should find the optimal integral solution at the root.
+  // Now test to solve the mip with searching for integral solution by rounding.
+  // The branch-and-bound should terminate at the root node, as it should find
+  // the optimal integral solution at the root.
   MixedIntegerBranchAndBound bnb(*prog, GurobiSolver::id());
   bnb.SetSearchIntegralSolutionByRounding(true);
   const SolutionResult result = bnb.Solve();

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -1125,8 +1125,8 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, TestMultipleIntegralSolution2) {
 }
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
-  // Test the node callback to search an integral solution by rounding the
-  // fractional solution to binary values, and solve the continuous variables.
+  // Test searching an integral solution by rounding the fractional solution to
+  // binary values, and solve the continuous variables.
   // Test on prog2.
   auto prog = ConstructMathematicalProgram2();
   VectorDecisionVariable<5> x = prog->decision_variables();
@@ -1157,8 +1157,8 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding2) {
 }
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding3) {
-  // Test the node callback to search an integral solution by rounding the
-  // fractional solution to binary values, and solve the continuous variables.
+  // Test searching an integral solution by rounding the fractional solution to
+  // binary values, and solve the continuous variables.
   // Test on prog3.
   auto prog = ConstructMathematicalProgram3();
   MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
@@ -1173,8 +1173,8 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding3) {
 }
 
 GTEST_TEST(MixedIntegerBranchAndBoundTest, SearchIntegralSolutionByRounding4) {
-  // Test the node callback to search an integral solution by rounding the
-  // fractional solution to binary values, and solve the continuous variables.
+  // Test searching an integral solution by rounding the fractional solution to
+  // binary values, and solve the continuous variables.
   // Test on prog4.
   auto prog = ConstructMathematicalProgram4();
   MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
@@ -1250,6 +1250,30 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest,
       dut.bnb()->IsLeafNodeFathomed(*(dut.bnb()->root()->right_child())));
   // The left-most un-fathomed node is root->left.
   EXPECT_EQ(dut.PickBranchingNode(), dut.bnb()->root()->left_child());
+}
+
+GTEST_TEST(MixedIntegerBranchAndBoundTest, NodeCallbackTest) {
+  // Test node callback function.
+  // In this trivial test, we just count how many nodes has been explored.
+
+  int num_visited_nodes = 1;
+  auto call_back_fun = [&num_visited_nodes](
+      const MixedIntegerBranchAndBoundNode& node,
+      MixedIntegerBranchAndBound* bnb) { ++num_visited_nodes; };
+  auto prog = ConstructMathematicalProgram2();
+  MixedIntegerBranchAndBoundTester dut(*prog, GurobiSolver::id());
+  dut.bnb()->SetUserDefinedNodeCallbackFunction(call_back_fun);
+
+  // Initially, only the root node has been visited.
+  EXPECT_EQ(num_visited_nodes, 1);
+
+  VectorDecisionVariable<5> x = dut.bnb()->root()->prog()->decision_variables();
+  // Every branch increments the number of visited nodes by 2.
+  dut.BranchAndUpdate(dut.mutable_root(), x(0));
+  EXPECT_EQ(num_visited_nodes, 3);
+
+  dut.BranchAndUpdate(dut.mutable_root(), x(2));
+  EXPECT_EQ(num_visited_nodes, 5);
 }
 }  // namespace
 }  // namespace solvers


### PR DESCRIPTION
In each node of the branch-and-bound tree, if the optimization hasn't found an integral solution yet, the user could choose to search for an integral solution, by fixing the remaining binary variables to the closest binary values in the solution, and search the continuous variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8063)
<!-- Reviewable:end -->
