### PR TITLE
Modifies multilane's Loader tests using gmock.

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -152,6 +152,7 @@ drake_cc_googletest(
     deps = [
         ":loader",
         "//automotive/maliput/api/test_utilities",
+        "//automotive/maliput/multilane/test_utilities",
     ],
 )
 

--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -233,7 +233,6 @@ std::unique_ptr<const api::RoadGeometry> Builder::Build(
   return std::move(road_geometry);
 }
 
-
 }  // namespace multilane
 }  // namespace maliput
 }  // namespace drake

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <tuple>
-#include <unordered_set>
 #include <vector>
 
 #include "drake/automotive/maliput/api/lane_data.h"
@@ -17,7 +16,104 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
+
 class RoadGeometry;
+
+/// Defines a builder interface for multilane. It is used for testing purposes
+/// only, and derived code should instantiate Builder objects.
+class BuilderBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BuilderBase)
+
+  BuilderBase() = default;
+
+  virtual ~BuilderBase() = default;
+
+  /// Gets `lane_width` value.
+  virtual double get_lane_width() const = 0;
+
+  /// Gets `elevation_bounds` value.
+  virtual const api::HBounds& get_elevation_bounds() const = 0;
+
+  /// Gets `linear_tolerance` value.
+  virtual double get_linear_tolerance() const = 0;
+
+  /// Gets `angular_tolerance` value.
+  virtual double get_angular_tolerance() const = 0;
+
+  /// Connects `start` to an end-point linearly displaced from `start`.
+  /// `length` specifies the length of displacement (in the direction of the
+  /// heading of `start`). `z_end` specifies the elevation characteristics at
+  /// the end-point.
+  /// `r0` is the distance from the reference curve to the first Lane
+  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
+  /// distances added to the extents of the Segment after the first and last
+  /// Lanes positions are determined.
+  virtual const Connection* Connect(const std::string& id, int num_lanes,
+                                    double r0, double left_shoulder,
+                                    double right_shoulder,
+                                    const Endpoint& start, double length,
+                                    const EndpointZ& z_end) = 0;
+
+  /// Connects `start` to an end-point displaced from `start` via an arc.
+  /// `arc` specifies the shape of the arc. `z_end` specifies the elevation
+  /// characteristics at the end-point.
+  /// `r0` is the distance from the reference curve to the first Lane
+  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
+  /// distances added to the extents of the Segment after the first and last
+  /// Lanes positions are determined.
+  virtual const Connection* Connect(const std::string& id, int num_lanes,
+                                    double r0, double left_shoulder,
+                                    double right_shoulder,
+                                    const Endpoint& start, const ArcOffset& arc,
+                                    const EndpointZ& z_end) = 0;
+
+  /// Sets the default branch for one end of a connection.
+  ///
+  /// The default branch for the `in_end` of connection `in` at Lane
+  /// `in_lane_index`will set to be `out_end` of connection `out` at Lane
+  /// `out_lane_index`. The specified connections must actually be joined at the
+  /// specified ends (i.e., the Endpoint's for those ends must be coincident and
+  /// (anti)parallel within the tolerances for the Builder).
+  virtual void SetDefaultBranch(const Connection* in, int in_lane_index,
+                                api::LaneEnd::Which in_end,
+                                const Connection* out, int out_lane_index,
+                                api::LaneEnd::Which out_end) = 0;
+
+  /// Creates a new empty connection group with ID string `id`.
+  virtual Group* MakeGroup(const std::string& id) = 0;
+
+  /// Creates a new connection group with ID `id`, populated with the
+  /// given `connections`.
+  virtual Group* MakeGroup(
+      const std::string& id,
+      const std::vector<const Connection*>& connections) = 0;
+
+  /// Produces a RoadGeometry, with the ID `id`.
+  virtual std::unique_ptr<const api::RoadGeometry> Build(
+      const api::RoadGeometryId& id) const = 0;
+};
+
+/// Factory interface to construct BuilderBase instances.
+///
+/// Defined for testing purposes, and production code must use BuilderFactory
+/// objects.
+class BuilderFactoryBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BuilderFactoryBase)
+
+  BuilderFactoryBase() = default;
+
+  virtual ~BuilderFactoryBase() = default;
+
+  /// Creates a BuilderBase instance.
+  ///
+  /// `lane_width`, `elevation_bounds`, `linear_tolerance` and
+  /// `angular_tolerance` are BuilderBase properties.
+  virtual std::unique_ptr<BuilderBase> Make(
+      double lane_width, const api::HBounds& elevation_bounds,
+      double linear_tolerance, double angular_tolerance) const = 0;
+};
 
 /// Convenient builder class which makes it easy to construct a multilane road
 /// network.
@@ -55,7 +151,7 @@ class RoadGeometry;
 ///
 /// Note: 'lane_index' is the index in the Segment, and 'branch_point_index' is
 /// is the index in the RoadGeometry.
-class Builder {
+class Builder : public BuilderBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Builder)
 
@@ -73,53 +169,42 @@ class Builder {
   Builder(double lane_width, const api::HBounds& elevation_bounds,
           double linear_tolerance, double angular_tolerance);
 
-  /// Connects `start` to an end-point linearly displaced from `start`.
-  /// `length` specifies the length of displacement (in the direction of the
-  /// heading of `start`). `z_end` specifies the elevation characteristics at
-  /// the end-point.
-  /// `r0` is the distance from the reference curve to the first Lane
-  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
-  /// distances added to the extents of the Segment after the first and last
-  /// Lanes positions are determined.
+  /// Gets `lane_width` value.
+  double get_lane_width() const override { return lane_width_; }
+
+  /// Gets `elevation_bounds` value.
+  const api::HBounds& get_elevation_bounds() const override {
+    return elevation_bounds_;
+  }
+
+  /// Gets `linear_tolerance` value.
+  double get_linear_tolerance() const override { return linear_tolerance_; }
+
+  /// Gets `angular_tolerance` value.
+  double get_angular_tolerance() const override { return angular_tolerance_; }
+
   const Connection* Connect(const std::string& id, int num_lanes, double r0,
                             double left_shoulder, double right_shoulder,
                             const Endpoint& start, double length,
-                            const EndpointZ& z_end);
+                            const EndpointZ& z_end) override;
 
-  /// Connects `start` to an end-point displaced from `start` via an arc.
-  /// `arc` specifies the shape of the arc. `z_end` specifies the elevation
-  /// characteristics at the end-point.
-  /// `r0` is the distance from the reference curve to the first Lane
-  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
-  /// distances added to the extents of the Segment after the first and last
-  /// Lanes positions are determined.
   const Connection* Connect(const std::string& id, int num_lanes, double r0,
                             double left_shoulder, double right_shoulder,
                             const Endpoint& start, const ArcOffset& arc,
-                            const EndpointZ& z_end);
+                            const EndpointZ& z_end) override;
 
-  /// Sets the default branch for one end of a connection.
-  ///
-  /// The default branch for the `in_end` of connection `in` at Lane
-  /// `in_lane_index`will set to be `out_end` of connection `out` at Lane
-  /// `out_lane_index`. The specified connections must actually be joined at the
-  /// specified ends (i.e., the Endpoint's for those ends must be coincident and
-  /// (anti)parallel within the tolerances for the Builder).
   void SetDefaultBranch(const Connection* in, int in_lane_index,
                         const api::LaneEnd::Which in_end, const Connection* out,
-                        int out_lane_index, const api::LaneEnd::Which out_end);
+                        int out_lane_index,
+                        const api::LaneEnd::Which out_end) override;
 
-  /// Creates a new empty connection group with ID string `id`.
-  Group* MakeGroup(const std::string& id);
+  Group* MakeGroup(const std::string& id) override;
 
-  /// Creates a new connection group with ID `id`, populated with the
-  /// given `connections`.
   Group* MakeGroup(const std::string& id,
-                   const std::vector<const Connection*>& connections);
+                   const std::vector<const Connection*>& connections) override;
 
-  /// Produces a RoadGeometry, with the ID `id`.
   std::unique_ptr<const api::RoadGeometry> Build(
-      const api::RoadGeometryId& id) const;
+      const api::RoadGeometryId& id) const override;
 
  private:
   // EndpointFuzzyOrder is an arbitrary strict complete ordering of Endpoints
@@ -210,13 +295,29 @@ class Builder {
       RoadGeometry* rg,
       std::map<Endpoint, BranchPoint*, EndpointFuzzyOrder>* bp_map) const;
 
-  const double lane_width_{};
-  const api::HBounds elevation_bounds_;
-  const double linear_tolerance_{};
-  const double angular_tolerance_{};
+  double lane_width_{};
+  api::HBounds elevation_bounds_;
+  double linear_tolerance_{};
+  double angular_tolerance_{};
   std::vector<std::unique_ptr<Connection>> connections_;
   std::vector<DefaultBranch> default_branches_;
   std::vector<std::unique_ptr<Group>> groups_;
+};
+
+/// Implements a BuilderFactoryBase to construct Builder objects.
+class BuilderFactory : public BuilderFactoryBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BuilderFactory)
+
+  BuilderFactory() = default;
+
+  std::unique_ptr<BuilderBase> Make(double lane_width,
+                                    const api::HBounds& elevation_bounds,
+                                    double linear_tolerance,
+                                    double angular_tolerance) const override {
+    return std::make_unique<Builder>(lane_width, elevation_bounds,
+                                     linear_tolerance, angular_tolerance);
+  }
 };
 
 }  // namespace multilane

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -23,6 +23,11 @@ std::ostream& operator<<(std::ostream& out, const Endpoint& endpoint) {
   return out << "(xy: " << endpoint.xy() << ", z: " << endpoint.z() << ")";
 }
 
+std::ostream& operator<<(std::ostream& out, const ArcOffset& arc_offset) {
+  return out << "(r: " << arc_offset.radius()
+             << ", d_theta: " << arc_offset.d_theta() << ")";
+}
+
 Connection::Connection(const std::string& id, const Endpoint& start,
                        const EndpointZ& end_z, int num_lanes, double r0,
                        double lane_width, double left_shoulder,

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -165,6 +165,11 @@ class ArcOffset {
   double d_theta_{};
 };
 
+/// Streams a string representation of `arc_offset` into `out`. Returns `out`.
+/// This method is provided for the purposes of debugging or text-logging.
+/// It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const ArcOffset& arc_offset);
+
 /// Representation of a reference path connecting two endpoints.
 ///
 /// Upon building the RoadGeometry, a Connection yields a Segment

--- a/automotive/maliput/multilane/loader.h
+++ b/automotive/maliput/multilane/loader.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "drake/automotive/maliput/multilane/builder.h"
+
 namespace drake {
 namespace maliput {
 
@@ -15,11 +17,12 @@ namespace multilane {
 /// @file
 /// Loader for serialized multilane road networks.
 ///
-/// The serialization is a fairly straightforward mapping of the Builder
+/// The serialization is a fairly straightforward mapping of the BuilderBase
 /// interface onto YAML. See (TBD) for more detail of the format.
 ///
 /// The basic idea is, however:
-///  - general parameters (i.e., as supplied to Builder constructor)
+///  - general parameters (i.e., lane_width, elevation bounds, linear and
+///    angular tolerance)
 ///  - a collection of named 'points', which are specifications of explicitly
 ///    named Endpoints
 ///  - a collection of named 'connections', whose start Endpoints are specified
@@ -35,11 +38,22 @@ namespace multilane {
 /// must bottom out in explicitly-named Endpoints.
 // TODO(maddog@tri.global)  Describe complete format somewhere.
 
-/// Loads the input string as a maliput_multilane_builder document.
-std::unique_ptr<const api::RoadGeometry> Load(const std::string& input);
+/// Loads the `input` string as a maliput_multilane_builder document using the
+/// provided `builder_factory`.
+///
+/// Application code must use a BuilderFactory reference. It is provided so that
+/// the Builder to be created can be mocked and code can be tested.
+std::unique_ptr<const api::RoadGeometry> Load(
+    const BuilderFactoryBase& builder_factory, const std::string& input);
 
-/// Loads the named file as a maliput_multilane_builder document.
-std::unique_ptr<const api::RoadGeometry> LoadFile(const std::string& filename);
+/// Loads the named file as a maliput_multilane_builder document using the
+/// provided `builder_factory`.
+///
+///
+/// Application code must use a BuilderFactory reference. It is provided so that
+/// the Builder to be created can be mocked and code can be tested.
+std::unique_ptr<const api::RoadGeometry> LoadFile(
+    const BuilderFactoryBase& builder_factory, const std::string& filename);
 
 }  // namespace multilane
 }  // namespace maliput

--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -22,6 +22,20 @@ namespace {
 //                   road surface is continuous, off the centerline, at the
 //                   branch-point where two connections connect
 
+GTEST_TEST(MultilaneBuilderTest, ParameterConstructor) {
+  const double kLaneWidth = 4.;
+  const api::HBounds kElevationBounds(0., 5.);
+  const double kLinearTolerance = 0.01;
+  const double kAngularTolerance = 0.01 * M_PI;
+  Builder builder(kLaneWidth, kElevationBounds, kLinearTolerance,
+                  kAngularTolerance);
+  EXPECT_EQ(builder.get_lane_width(), kLaneWidth);
+  EXPECT_TRUE(api::test::IsHBoundsClose(builder.get_elevation_bounds(),
+                                        kElevationBounds, 0.));
+  EXPECT_EQ(builder.get_linear_tolerance(), kLinearTolerance);
+  EXPECT_EQ(builder.get_angular_tolerance(), kAngularTolerance);
+}
+
 GTEST_TEST(MultilaneBuilderTest, Fig8) {
   const double kLaneWidth = 4.;
   const double kLeftShoulder = 2.;

--- a/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
@@ -21,7 +21,7 @@ using api::RBounds;
 using api::HBounds;
 using multilane::ArcOffset;
 
-const double kVeryExact = 1e-11;
+const double kVeryExact{1e-11};
 const double kWidth{2.};  // Lane and drivable width.
 const double kHeight{5.};  // Elevation bound.
 
@@ -54,9 +54,9 @@ const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
 
 GTEST_TEST(MultilaneLanesTest, DoToRoadPosition) {
   // Define a serpentine road with multiple segments and branches.
-  std::unique_ptr<multilane::Builder> rb(new multilane::Builder(
+  auto rb = multilane::BuilderFactory().Make(
       2. * kWidth, HBounds(0., kHeight), 0.01, /* linear tolerance */
-      0.01 * M_PI /* angular tolerance */));
+      0.01 * M_PI /* angular tolerance */);
 
   // Initialize the road from the origin.
   const multilane::EndpointXy kOriginXy{0., 0., 0.};
@@ -228,9 +228,9 @@ GTEST_TEST(MultilaneLanesTest, HintWithDisconnectedLanes) {
   // ongoing lanes.  This tests the pathological case when a `hint` is provided
   // in a topologically isolated lane, so the code returns the default road
   // position given by the hint.
-  std::unique_ptr<multilane::Builder> rb(new multilane::Builder(
+  auto rb = multilane::BuilderFactory().Make(
       2. * kWidth, HBounds(0., kHeight), 0.01, /* linear tolerance */
-      0.01 * M_PI /* angular tolerance */));
+      0.01 * M_PI /* angular tolerance */);
 
   // Initialize the road from the origin.
   const multilane::EndpointXy kOriginXy0{0., 0., 0.};
@@ -297,8 +297,8 @@ GTEST_TEST(MultilaneLanesTest, MultipleLineLaneSegmentWithoutHint) {
   const double kLinearTolerance{kVeryExact};
   const double kAngularTolerance{0.01 * M_PI};
 
-  auto builder = std::make_unique<Builder>(kLaneWidth, kElevationBounds,
-                                           kLinearTolerance, kAngularTolerance);
+  auto builder = multilane::BuilderFactory().Make(
+      kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
 
   // Initialize the road from the origin.
   const EndpointZ kFlatZ{0., 0., 0., 0.};

--- a/automotive/maliput/multilane/test/yaml_load.cc
+++ b/automotive/maliput/multilane/test/yaml_load.cc
@@ -8,6 +8,7 @@
 #include <gflags/gflags.h>
 
 #include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/multilane/builder.h"
 #include "drake/automotive/maliput/multilane/loader.h"
 #include "drake/common/text_logging.h"
 
@@ -24,7 +25,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   drake::log()->info("Loading '{}'.", FLAGS_yaml_file);
-  auto rg = multilane::LoadFile(FLAGS_yaml_file);
+  auto rg = multilane::LoadFile(multilane::BuilderFactory(), FLAGS_yaml_file);
   const std::vector<std::string> failures = rg->CheckInvariants();
 
   if (!failures.empty()) {

--- a/automotive/maliput/multilane/test_utilities/BUILD.bazel
+++ b/automotive/maliput/multilane/test_utilities/BUILD.bazel
@@ -21,6 +21,7 @@ drake_cc_library(
     srcs = ["multilane_types_compare.cc"],
     hdrs = ["multilane_types_compare.h"],
     deps = [
+        "//automotive/maliput/api/test_utilities",
         "//automotive/maliput/multilane",
         "//common:essential",
         "//math:geometric_transform",

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -140,6 +140,44 @@ namespace test {
          << p2 << "\ntolerance = " << tolerance;
 }
 
+::testing::AssertionResult IsArcOffsetClose(const ArcOffset& arc_offset1,
+                                            const ArcOffset& arc_offset2,
+                                            double linear_tolerance,
+                                            double angular_tolerance) {
+  bool fails = false;
+  std::string error_message{};
+  double delta = std::abs(arc_offset1.radius() - arc_offset2.radius());
+  if (delta > linear_tolerance) {
+    fails = true;
+    error_message =
+        error_message + "ArcOffset are different at radius. " +
+        "arc_offset1.radius(): " + std::to_string(arc_offset1.radius()) +
+        " vs. arc_offset2.radius(): " + std::to_string(arc_offset2.radius()) +
+        ", diff = " + std::to_string(delta) +
+        ", tolerance = " + std::to_string(linear_tolerance) + "\n";
+  }
+  delta = std::abs(arc_offset1.d_theta() - arc_offset2.d_theta());
+  if (delta > angular_tolerance) {
+    fails = true;
+    error_message =
+        error_message + "EndpointZ are different at d_theta. " +
+        "arc_offset1.d_theta(): " + std::to_string(arc_offset1.d_theta()) +
+        " vs.  arc_offset2.d_theta(): " +
+        std::to_string(arc_offset2.d_theta()) +
+        ", diff = " + std::to_string(delta) +
+        ", tolerance = " + std::to_string(angular_tolerance) + "\n";
+  }
+  if (fails) {
+    return ::testing::AssertionFailure() << error_message;
+  }
+  return ::testing::AssertionSuccess()
+         << "arc_offset1 =\n"
+         << arc_offset1 << "\nis approximately equal to arc_offset2 =\n"
+         << arc_offset2 << "\nwith linear tolerance = " << linear_tolerance
+         << "\nand angular tolerance =\n"
+         << angular_tolerance;
+}
+
 }  // namespace test
 }  // namespace multilane
 }  // namespace maliput

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
@@ -1,13 +1,18 @@
 #pragma once
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
+#include "drake/automotive/maliput/multilane/connection.h"
 
 namespace drake {
 namespace maliput {
 namespace multilane {
 namespace test {
+
+using ::testing::MatcherInterface;
+using ::testing::MatchResultListener;
 
 // Compares equality within @p tolerance deviation of two EndpointXy objects.
 // @param xy1 An EndpointXy object to compare.
@@ -56,6 +61,113 @@ namespace test {
 ::testing::AssertionResult IsEndpointClose(const Endpoint& pos1,
                                            const Endpoint& pos2,
                                            double tolerance);
+
+// Compares equality within @p linear_tolerance and @p angular_tolerance
+// deviations of two ArcOffset objects.
+// @param arc_offset1 An ArcOffset object to compare.
+// @param arc_offset2 An ArcOffset object to compare.
+// @param linear_tolerance An allowable absolute linear deviation for
+// ArcOffset's radius.
+// @param angular_tolerance An allowable absolute angle deviation for
+// ArcOffset's d_theta.
+// @return ::testing::AssertionFailure() When ArcOffset objects are different.
+// @return ::testing::AssertionSuccess() When ArcOffset objects are within
+// @p linear_tolerance and @p angular_tolerance deviations.
+::testing::AssertionResult IsArcOffsetClose(const ArcOffset& arc_offset1,
+                                            const ArcOffset& arc_offset2,
+                                            double linear_tolerance,
+                                            double angular_tolerance);
+
+/// Wraps api::HBounds comparison into a MatcherInterface.
+class HBoundsMatcher : public MatcherInterface<const api::HBounds&> {
+ public:
+  HBoundsMatcher(const api::HBounds& elevation_bounds, double tolerance)
+      : elevation_bounds_(elevation_bounds), tolerance_(tolerance) {}
+
+  bool MatchAndExplain(const api::HBounds& other,
+                       MatchResultListener*) const override {
+    return api::test::IsHBoundsClose(elevation_bounds_, other, tolerance_);
+  }
+
+  void DescribeTo(std::ostream* os) const override {
+    *os << "is within tolerance [" << tolerance_ << "] of elevation_bounds: ["
+        << elevation_bounds_.min() << ", " << elevation_bounds_.max() << "].";
+  }
+
+ private:
+  const api::HBounds elevation_bounds_;
+  const double tolerance_{};
+};
+
+/// Wraps Endpoint comparison into a MatcherInterface.
+class EndpointMatcher : public MatcherInterface<const Endpoint&> {
+ public:
+  EndpointMatcher(const Endpoint& endpoint, double tolerance)
+      : endpoint_(endpoint), tolerance_(tolerance) {}
+
+  bool MatchAndExplain(const Endpoint& other,
+                       MatchResultListener*) const override {
+    return IsEndpointClose(endpoint_, other, tolerance_);
+  }
+
+  void DescribeTo(std::ostream* os) const override  {
+    *os << "is within tolerance [" << tolerance_ << "] of endpoint: ["
+        << endpoint_ << "].";
+  }
+
+ private:
+  const Endpoint endpoint_;
+  const double tolerance_{};
+};
+
+/// Wraps EndpointZ comparison into a MatcherInterface.
+class EndpointZMatcher : public MatcherInterface<const EndpointZ&> {
+ public:
+  EndpointZMatcher(const EndpointZ& endpoint_z, double tolerance)
+      : endpoint_z_(endpoint_z), tolerance_(tolerance) {}
+
+  bool MatchAndExplain(const EndpointZ& other,
+                       MatchResultListener*) const override {
+    return IsEndpointZClose(endpoint_z_, other, tolerance_);
+  }
+
+  void DescribeTo(std::ostream* os) const override {
+    *os << "is within tolerance [" << tolerance_ << "] of endpoint_z: ["
+        << endpoint_z_ << "].";
+  }
+
+ private:
+  const EndpointZ endpoint_z_;
+  const double tolerance_{};
+};
+
+/// Wraps an ArcOffset comparison into a MatcherInterface.
+class ArcOffsetMatcher : public MatcherInterface<const ArcOffset&> {
+ public:
+  ArcOffsetMatcher(const ArcOffset& arc_offset, double linear_tolerance,
+                   double angular_tolerance)
+      : arc_offset_(arc_offset),
+        linear_tolerance_(linear_tolerance),
+        angular_tolerance_(angular_tolerance) {}
+
+  bool MatchAndExplain(const ArcOffset& other,
+                       MatchResultListener*) const override {
+    return IsArcOffsetClose(arc_offset_, other, linear_tolerance_,
+                            angular_tolerance_);
+  }
+
+  void DescribeTo(std::ostream* os) const override {
+    *os << "is within linear and angular tolerance: [" << linear_tolerance_
+        << ", " << angular_tolerance_ << "] of arc_offset: ["
+        << arc_offset_.radius() << ", " << arc_offset_.d_theta() << "].";
+  }
+
+ private:
+  const ArcOffset arc_offset_;
+  const double linear_tolerance_{};
+  const double angular_tolerance_{};
+};
+
 }  // namespace test
 }  // namespace multilane
 }  // namespace maliput


### PR DESCRIPTION
Based on comments in #7626:
 
- Creates a `BuilderBase` interface for Builders.
- Modifies Loader API to receive a `BuilderBase` pointer instead of creating it.
- Modifies Loader tests using gmock.
- Adds custom `Matchers` for tests.

This PR relates to #4934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8071)
<!-- Reviewable:end -->
