### PR TITLE
Stop kuka plan runner

### DIFF
--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -103,15 +103,6 @@ class RobotPlanRunner {
           iiwa_command.joint_position[joint] = desired_next(joint);
         }
 
-        if (stop_plan_) {
-          // Stop the robot from continuing the current plan and
-          // reset plan_ until it receives another one.
-          std::cout << "Stopping current plan." << std::endl;
-          stop_plan_ = false;
-          plan_.reset();
-          continue;
-        }
-
         lcm_.publish(kLcmCommandChannel, &iiwa_command);
       }
     }
@@ -177,7 +168,7 @@ class RobotPlanRunner {
   void HandleStop(const lcm::ReceiveBuffer*, const std::string&,
                     const robotlocomotion::robot_plan_t*) {
     std::cout << "Received stop command. Discarding plan." << std::endl;
-    stop_plan_ = true;
+    plan_.reset();
   }
 
   lcm::LCM lcm_;
@@ -185,7 +176,6 @@ class RobotPlanRunner {
   int plan_number_{};
   std::unique_ptr<PiecewisePolynomialTrajectory> plan_;
   lcmt_iiwa_status iiwa_status_;
-  bool stop_plan_{false};
 };
 
 int do_main() {

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -106,7 +106,7 @@ class RobotPlanRunner {
         if (stop_plan_) {
           // Stop the robot from continuing the current plan and
           // reset plan_ until it receives another one.
-          std::cout << "Stopping." << std::endl;
+          std::cout << "Stopping current plan." << std::endl;
           stop_plan_ = false;
           plan_.reset();
           continue;
@@ -176,7 +176,7 @@ class RobotPlanRunner {
 
   void HandleStop(const lcm::ReceiveBuffer*, const std::string&,
                     const robotlocomotion::robot_plan_t*) {
-    std::cout << "Received stop command. Discarding plan" << std::endl;
+    std::cout << "Received stop command. Discarding plan." << std::endl;
     stop_plan_ = true;
   }
 


### PR DESCRIPTION
Additions to kuka_plan_runner.cc to support immediately stopping the current plan when an LCM stop message is received.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8072)
<!-- Reviewable:end -->
