### PR TITLE
Hide symbols from the octomap library

### DIFF
--- a/tools/workspace/octomap/package.BUILD.bazel
+++ b/tools/workspace/octomap/package.BUILD.bazel
@@ -44,9 +44,9 @@ cc_library(
     hdrs = glob([
         "octomap/include/octomap/*.h*",
     ]),
+    copts = ["-fvisibility=hidden"],
     includes = ["octomap/include"],
     linkstatic = 1,
-    copts = ["-fvisibility=hidden"],
     deps = [":octomath"],
 )
 

--- a/tools/workspace/octomap/package.BUILD.bazel
+++ b/tools/workspace/octomap/package.BUILD.bazel
@@ -46,6 +46,7 @@ cc_library(
     ]),
     includes = ["octomap/include"],
     linkstatic = 1,
+    copts = ["-fvisibility=hidden"],
     deps = [":octomath"],
 )
 


### PR DESCRIPTION
The suggestion comes from @jamiesnape and I did not find an existing use case that needs the octomap symbols to be exposed. It might be the case if any of the tests inside Drake would have used octomap directly but octomap is present because fcl uses it. Drake skips the installation of the headers so the third party software can not use it anyway. I think it is fine to hide it fully by now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8075)
<!-- Reviewable:end -->
