### PR TITLE
Provides lane-to-lane methods to create Connections for Multilane. #7194

### DIFF
--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -48,6 +48,38 @@ const Connection* Builder::Connect(const std::string& id, int num_lanes,
   return connections_.back().get();
 }
 
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double left_shoulder, double right_shoulder,
+                                   int start_lane_index, const Endpoint& start,
+                                   double length, int end_lane_index,
+                                   const EndpointZ& z_end, double r_ref,
+                                   int lane_ref_index) {
+  DRAKE_DEMAND(start_lane_index < num_lanes && start_lane_index >= 0);
+  DRAKE_DEMAND(end_lane_index < num_lanes && end_lane_index >= 0);
+  DRAKE_DEMAND(lane_ref_index < num_lanes && lane_ref_index >= 0);
+  // Creates the connection.
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, start_lane_index, z_end, end_lane_index, num_lanes, r_ref,
+      lane_ref_index, lane_width_, left_shoulder, right_shoulder, length));
+  return connections_.back().get();
+}
+
+const Connection* Builder::Connect(const std::string& id, int num_lanes,
+                                   double left_shoulder, double right_shoulder,
+                                   int start_lane_index, const Endpoint& start,
+                                   const ArcOffset& arc, int end_lane_index,
+                                   const EndpointZ& z_end, double r_ref,
+                                   int lane_ref_index) {
+  DRAKE_DEMAND(start_lane_index < num_lanes && start_lane_index >= 0);
+  DRAKE_DEMAND(end_lane_index < num_lanes && end_lane_index >= 0);
+  DRAKE_DEMAND(lane_ref_index < num_lanes && lane_ref_index >= 0);
+  // Creates the connection.
+  connections_.push_back(std::make_unique<Connection>(
+      id, start, start_lane_index, z_end, end_lane_index, num_lanes, r_ref,
+      lane_ref_index, lane_width_, left_shoulder, right_shoulder, arc));
+  return connections_.back().get();
+}
+
 void Builder::SetDefaultBranch(const Connection* in, int in_lane_index,
                                const api::LaneEnd::Which in_end,
                                const Connection* out, int out_lane_index,

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -98,6 +98,48 @@ class Builder {
                             const Endpoint& start, const ArcOffset& arc,
                             const EndpointZ& z_end);
 
+  /// Creates a line Connection whose ID is `id` and has `num_lanes` lanes.
+  ///
+  /// `length` specifies the length of the reference curve which will be located
+  /// at `r_ref` lateral distance from `lane_ref_index` lane.
+  ///
+  /// Connection's `start_lane_index` lane will start at `start` and
+  /// connection's `end_lane_index` lane will end with `z_end` EndpointZ.
+  ///
+  /// `start_lane_index`, `end_lane_index`, `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra lateral distances added to
+  /// the extents of the Segment after the first and last Lanes positions are
+  /// determined.
+  const Connection* Connect(const std::string& id, int num_lanes,
+                            double left_shoulder, double right_shoulder,
+                            int start_lane_index, const Endpoint& start,
+                            double length, int end_lane_index,
+                            const EndpointZ& z_end, double r_ref,
+                            int lane_ref_index);
+
+  /// Creates an arc Connection whose ID is `id` and has `num_lanes` lanes.
+  ///
+  /// `arc` specifies the shape of the reference curve which will be located
+  /// at `r_ref` lateral distance from `lane_ref_index` lane.
+  ///
+  /// Connection's `start_lane_index` lane will start at `start` and
+  /// connection's `end_lane_index` lane will end with `z_end` EndpointZ.
+  ///
+  /// `start_lane_index`, `end_lane_index`, `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra lateral distances added to
+  /// the extents of the Segment after the first and last Lanes positions are
+  /// determined.
+  const Connection* Connect(const std::string& id, int num_lanes,
+                            double left_shoulder, double right_shoulder,
+                            int start_lane_index, const Endpoint& start,
+                            const ArcOffset& arc, int end_lane_index,
+                            const EndpointZ& z_end, double r_ref,
+                            int lane_ref_index);
+
   /// Sets the default branch for one end of a connection.
   ///
   /// The default branch for the `in_end` of connection `in` at Lane

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -186,6 +186,8 @@ class Connection {
 
   /// Constructs a line-segment connection.
   ///
+  /// Connection's ID is `id`.
+  ///
   /// Segment's reference curve begins at `start` and extends on the plane
   /// z=0 `line_length` distance with `start.xy().heading()` heading angle.
   /// `end_z` will be used to build elevation and superelevation information of
@@ -208,6 +210,8 @@ class Connection {
 
   /// Constructs an arc-segment connection.
   ///
+  /// Connection's ID is `id`.
+  ///
   /// Segment's reference curve begins at `start` and extends on the plane z=0
   /// with `arc_offset.radius()` and angle span of `arc_offset.d_theta()`.
   /// `end_z` will be used to build elevation and superelevation information of
@@ -228,6 +232,67 @@ class Connection {
   Connection(const std::string& id, const Endpoint& start,
              const EndpointZ& end_z, int num_lanes, double r0,
              double lane_width, double left_shoulder, double right_shoulder,
+             const ArcOffset& arc_offset);
+
+  /// Constructs a line-segment connection.
+  ///
+  /// Connection's ID is `id`.
+  ///
+  /// Segment's reference curve begins at `r_ref` lateral distance from the
+  /// `lane_ref_index` lane and extends on the plane z=0 `line_length` distance
+  /// with `start.xy().heading()` heading angle. `start_lane_index` lane will
+  /// begin at `start`. `end_z` is the end EndpointZ information of
+  /// `end_lane_index` lane. Both start and end lane information is used to
+  /// compute the reference curve by translating coordinates and elevation and
+  /// superelevation information of the road.
+  ///
+  /// `line_length` must be non negative.
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// Each lane's width will be `lane_width`, which should be greater or equal
+  /// to zero.
+  ///
+  /// `start_lane_index`, `end_lane_index` and `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, int start_lane_index,
+             const EndpointZ& end_z, int end_lane_index, int num_lanes,
+             double r_ref, int lane_ref_index, double lane_width,
+             double left_shoulder, double right_shoulder, double line_length);
+
+  /// Constructs an arc-segment connection.
+  ///
+  /// Connection's ID is `id`.
+  ///
+  /// Segment's reference curve begins at `r_ref` lateral distance from the
+  /// `lane_ref_index` lane and extends on the plane z=0 with
+  /// `arc_offset.radius()` and angle span of `arc_offset.d_theta()`.
+  /// `start_lane_index` lane will begin at `start`. `end_z` is the end
+  /// EndpointZ information of `end_lane_index` lane. Both start and end lane
+  /// information is used to compute the reference curve by translating
+  /// coordinates and elevation and superelevation information of the road.
+  ///
+  /// `arc_offset.radius()` must be positive. `arc_offset.d_theta()` > 0
+  /// indicates a counterclockwise arc from `start` with initial heading angle
+  /// `start.heading()`.
+  ///
+  /// Segments will contain `num_lanes` lanes, which must be greater than zero.
+  /// Each lane's width will be `lane_width`, which should be greater or equal
+  /// to zero.
+  ///
+  /// `start_lane_index`, `end_lane_index` and `lane_ref_index` must be smaller
+  /// than `num_lanes` and non negative.
+  ///
+  /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
+  /// and left side of the first and last lanes of the Segment. They will be
+  /// added to Segment's bounds and must be greater or equal to zero.
+  Connection(const std::string& id, const Endpoint& start, int start_lane_index,
+             const EndpointZ& end_z, int end_lane_index, int num_lanes,
+             double r_ref, int lane_ref_index, double lane_width,
+             double left_shoulder, double right_shoulder,
              const ArcOffset& arc_offset);
 
   /// Returns the geometric type of the path.
@@ -305,7 +370,7 @@ class Connection {
  private:
   const Type type_{};
   const std::string id_;
-  const Endpoint start_{};
+  Endpoint start_{};
   Endpoint end_{};
   const int num_lanes_{};
   const double r0_{};
@@ -316,13 +381,13 @@ class Connection {
   const double r_max_{};
   std::unique_ptr<RoadCurve> road_curve_;
   // Bits specific to type_ == kLine:
-  double line_length_{};
+  const double line_length_{};
   // Bits specific to type_ == kArc:
-  double radius_{};
-  double d_theta_{};
-  double theta0_{};
-  double cx_{};
-  double cy_{};
+  const double radius_{};
+  const double d_theta_{};
+  const double theta0_{};
+  const double cx_{};
+  const double cy_{};
 };
 
 /// A group of Connections.


### PR DESCRIPTION
As part of issue #7194, and parent issue #4934, this PR includes:

- New constructors to `Connection` class so as to derive reference curve from different lane information (`Endpoint` and `EndpointZ`).
- `Builder` provides new methods to construct Arc and Line `Connections` from other connections.
- Modifies `Builder` tests to create the same `RoadGeometry` with both reference curve and lane-to-lane API.
- Improved test coverage to the Builder API.

This code was previously PRed to Drake and history can be found in #7471.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8077)
<!-- Reviewable:end -->
