### PR TITLE
Remove drake_visualizer's dependency on pydrake

### DIFF
--- a/lcmtypes/BUILD.bazel
+++ b/lcmtypes/BUILD.bazel
@@ -286,6 +286,7 @@ drake_lcm_py_library(
     lcm_package = "drake",
     lcm_srcs = glob(["*.lcm"]) + _AUTOMOTIVE_LCM_SRCS,
     deps = [
+        "//:module_py",
         "@lcmtypes_bot2_core//:lcmtypes_bot2_core_py",
     ],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -16,8 +16,8 @@ py_binary(
     visibility = ["//visibility:private"],
     # Python libraries to import.
     deps = [
-        "//bindings/pydrake",
         "//lcmtypes:lcmtypes_py",
+        "//tools/workspace/drake_visualizer:stub_pydrake",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
     ],

--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -7,4 +7,17 @@ exports_files(
     visibility = ["//tools:__pkg__"],
 )
 
+# When developing within Drake, we don't want //tools:drake_visualizer to
+# depend on the entire pydrake library, because that adds a dependency on a
+# whole bunch of C++ code that is irrelevant for the visualizer.  So, here we
+# provide a small stub version of pydrake with only getDrakePath implemented
+# (the only piece drake_visualizer needs).  Note that the installed version of
+# drake-visualizer *does* use the installed (full) version of pydrake -- this
+# is development-sandbox-only stub.
+py_library(
+    name = "stub_pydrake",
+    srcs = ["stub/pydrake/__init__.py"],
+    visibility = ["//tools:__pkg__"],
+)
+
 add_lint_tests()

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -18,6 +18,28 @@ assert runfiles_dir, (
     "This must be called by a script generated using the " +
     "`drake_runfiles_binary` macro.")
 
+# Stub out pydrake (refer to our ./BUILD.bazel comments for rationale).
+#
+# We add it to PYTHONPATH within the script, rather than `imports = ["stub"]`
+# on the stub py_library, to avoid any other target accidentally pulling in the
+# stubbed pydrake onto its PYTHONPATH.  Only the visualizer, when launched via
+# this wrapper script, should employ the stub.
+stub_relpath = "tools/workspace/drake_visualizer/stub"
+if os.path.exists(os.path.join(runfiles_dir, "external/drake")):
+    # This is for bazel run @drake//tools:drake_visualizer.
+    prepend_path('PYTHONPATH', "external/drake/" + stub_relpath)
+else:
+    # This is for bazel run //tools:drake_visualizer.
+    prepend_path('PYTHONPATH', stub_relpath)
+
+# Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.  This
+# also placates the drake-visualizer logic that puts it into Director mode when
+# DRAKE_RESOURCE_ROOT is set (thus requiring more than just getDrakePath).
+try:
+    del os.environ["DRAKE_RESOURCE_ROOT"]
+except KeyError:
+    pass
+
 # TODO(eric.cousineau): Remove these shims if we can teach Bazel how to handle
 # these on its own.
 if sys.platform.startswith("linux"):

--- a/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
+++ b/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
@@ -1,0 +1,9 @@
+# Refer to ../../BUILD.bazel comments for rationale.
+
+import os
+
+
+def getDrakePath():
+    # Because //tools:drake_visualizer is a drake_runfiles_binary, the correct
+    # answer to getDrakePath is always the runfiles root.  Nice!
+    return os.environ["DRAKE_BAZEL_RUNFILES"]


### PR DESCRIPTION
Fixes #8010.

I've tested this locally using:
- the `examples/vakyrie/README.md` instructions;
- the first example from `automotive/README.md` instructions;
- the Anzu demo instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8080)
<!-- Reviewable:end -->
