### PR TITLE
Eliminate all documentation references to "GeometryWorld"

### DIFF
--- a/geometry/frame_id_vector.h
+++ b/geometry/frame_id_vector.h
@@ -19,7 +19,7 @@ namespace geometry {
 
 /** Represents an _ordered_ set of frame identifiers. Instances of this class
  work in conjunction with instances of FramePoseVector and FrameVelocityVector
- to communicate frame kinematics to GeometryWorld and GeometrySystem. Considered
+ to communicate frame kinematics to GeometrySystem. Considered
  together, they represent a "struct-of-arrays" paradigm. The iᵗʰ value in the
  %FrameIdVector is the frame identifier whose position is specified by
  the iᵗʰ value in the corresponding FramePoseVector (and analogously for the
@@ -28,12 +28,12 @@ namespace geometry {
  The geometry source can use arbitrary logic to define the _order_ of the ids.
  However, all frames registered by the source must be included. Omitting a
  registered frame id is considered an error (and will cause an exception
- when GeometryWorld/GeometrySystem evaluates the data.
+ when GeometrySystem evaluates the data.
 
  @internal In future iterations, this will be relaxed to allow only
  communicating kinematics for frames that have _changed_. But in the initial
  version, this requirement is in place for pedagogical purposes to help users
- use GeometryWorld/GeometrySystem correctly. */
+ use GeometrySystem correctly. */
 class FrameIdVector {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(FrameIdVector)

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -82,7 +82,7 @@ class FrameKinematicsVector {
   SourceId source_id_;
 };
 
-/** Class for communicating ordered _pose_ information to GeometryWorld/
+/** Class for communicating ordered _pose_ information to
  GeometrySystem for registered frames.
 
  @tparam T The scalar type. Must be a valid Eigen scalar.

--- a/geometry/geometry_context.h
+++ b/geometry/geometry_context.h
@@ -7,7 +7,7 @@
 namespace drake {
 namespace geometry {
 
-/** The custom leaf context type for GeometrySystem and GeometryWorld.
+/** The custom leaf context type for GeometrySystem.
 
  @tparam T The scalar type. Must be a valid Eigen scalar.
 

--- a/geometry/geometry_frame.h
+++ b/geometry/geometry_frame.h
@@ -9,11 +9,11 @@
 namespace drake {
 namespace geometry {
 
-/** This simple class carries the definition of a frame used by GeometryWorld.
- To register moving frames with GeometryWorld (see
- GeometryWorld::RegisterFrame), a geometry source (see
- GeometryWorld::RegisterNewSource) instantiates a frame and passes ownership
- over to GeometryWorld.
+/** This simple class carries the definition of a frame used in the
+ GeometrySystem. To register moving frames with GeometrySystem (see
+ GeometrySystem::RegisterFrame()), a geometry source (see
+ GeometrySystem::RegisterSource()) instantiates a frame and passes ownership
+ over to GeometrySystem.
 
  A frame is defined by three pieces of information:
     - the name, which must be unique within a single geometry source,
@@ -27,7 +27,7 @@ namespace geometry {
  instance id defined by the RigidBodyTree and used again in automotive to
  serve as unique car identifiers.
 
- @see GeometryWorld */
+ @see GeometrySystem */
 class GeometryFrame {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryFrame)

--- a/geometry/geometry_ids.h
+++ b/geometry/geometry_ids.h
@@ -5,13 +5,13 @@
 namespace drake {
 namespace geometry {
 
-/** Type used to identify geometry sources in GeometryWorld. */
+/** Type used to identify geometry sources in GeometrySystem. */
 using SourceId = Identifier<class SourceTag>;
 
-/** Type used to identify geometry frames in GeometryWorld .*/
+/** Type used to identify geometry frames in GeometrySystem .*/
 using FrameId = Identifier<class FrameTag>;
 
-/** Type used to identify geometry instances in GeometryWorld. */
+/** Type used to identify geometry instances in GeometrySystem. */
 using GeometryId = Identifier<class GeometryTag>;
 
 }  // namespace geometry

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -80,11 +80,11 @@ using FrameIdSet = std::unordered_set<FrameId>;
 //@}
 
 /**
- The context-dependent state of GeometryWorld. This serves as an AbstractValue
- in the context. GeometryWorld's time-dependent state includes more than just
+ The context-dependent state of GeometrySystem. This serves as an AbstractValue
+ in the context. GeometrySystem's time-dependent state includes more than just
  values; objects can be added to or removed from the world over time. Therefore,
- GeometryWorld's context-dependent state includes values and structure -- the
- topology of the world.
+ GeometrySystem's context-dependent state includes values (the poses) and
+ structure (the topology of the world).
 
  @tparam T The scalar type. Must be a valid Eigen scalar.
 

--- a/geometry/geometry_system.h
+++ b/geometry/geometry_system.h
@@ -226,10 +226,9 @@ class GeometrySystem final : public systems::LeafSystem<T> {
    provided. */
   //@{
 
-  /** Registers a new source to the geometry system (see GeometryWorld for the
-   discussion of "geometry source"). The caller must save the returned SourceId;
-   it is the token by which all other operations on the geometry world are
-   conducted.
+  /** Registers a new source to the geometry system. The caller must save the
+   returned SourceId; it is the token by which all other operations on the
+   geometry world are conducted.
 
    This source id can be used to register arbitrary _anchored_ geometry. But if
    dynamic geometry is registered (via RegisterGeometry/RegisterFrame), then

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -16,9 +16,8 @@ namespace internal {
  data, and then includes topology data.
 
  It is not intended to be used outside of the geometry library. To instantiate
- frames in GeometryWorld, use the drake::geometry::GeometryFrame class in
- conjunction with the GeometryWorld::RegisterFrame() methods.
- */
+ frames in GeometrySystem, use the drake::geometry::GeometryFrame class in
+ conjunction with the GeometrySystem::RegisterFrame() methods. */
 class InternalFrame {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalFrame)

--- a/geometry/shape_specification.h
+++ b/geometry/shape_specification.h
@@ -11,7 +11,7 @@
 
 /** @file
  Provides the classes through which geometric shapes are introduced into
- GeometryWorld. This includes the specific classes which specify shapes as well
+ GeometrySystem. This includes the specific classes which specify shapes as well
  as an interface for _processing_ those specifications.
  */
 

--- a/multibody/collision/collision_filter_doxygen.h
+++ b/multibody/collision/collision_filter_doxygen.h
@@ -51,7 +51,7 @@ are @ref collision_filter_mapping "related but complementary".
 Before looking at the details of the collision filter mechanisms, there are a
 few key principles to make note of.
 
- <!-- TODO(SeanCurtis-TRI): Change this with the advent of GeometryWorld to
+ <!-- TODO(SeanCurtis-TRI): Change this with the advent of GeometrySystem to
  reflect current state -->
 \section collision_elements Collision Elements
 

--- a/multibody/rigid_body.h
+++ b/multibody/rigid_body.h
@@ -213,8 +213,8 @@ class RigidBody {
 
   // TODO(SeanCurtis-TRI): This shouldn't be called publicly. Collision elements
   // have to be processed in the context of the rigid body tree.  Long term,
-  // this will be displaced into GeometryWorld.  Short term, just don't call it.
-  // If you need to add a collision element to a body, add it through
+  // this will be displaced into GeometrySystem.  Short term, just don't call
+  // it. If you need to add a collision element to a body, add it through
   // RigidBodyTree::addCollisionElement.
   /**
    * Adds the given collision @p element to the body with the given group name.

--- a/perception/estimators/dev/scene.h
+++ b/perception/estimators/dev/scene.h
@@ -19,7 +19,7 @@ typedef int FrameIndex;
  * structure), the world frame, and the camera frame. This is used to for
  * posing things such as an ICP formulation.
  */
-// TODO(eric.cousineau): Replace with GeometryWorld when it becomes available
+// TODO(eric.cousineau): Replace with GeometrySystem when it becomes available
 // Presently, RigidBodyTree<> can function as a (dense) scene graph of sorts.
 class Scene {
  public:

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -16,7 +16,7 @@ namespace rendering {
 namespace pose_aggregator_detail { struct InputRecord; }
 
 // TODO(david-german-tri, SeanCurtis-TRI): Evolve PoseAggregator into
-// GeometrySystem after GeometryWorld becomes available.
+// GeometrySystem as it becomes available.
 
 // TODO(david-german-tri): Rename PoseAggregator to KinematicsAggregator, since
 // it includes both poses and velocities now.

--- a/systems/rendering/pose_bundle.h
+++ b/systems/rendering/pose_bundle.h
@@ -17,7 +17,7 @@ namespace systems {
 namespace rendering {
 
 // TODO(david-german-tri, SeanCurtis-TRI): Subsume this functionality into
-// GeometryWorld/GeometrySystem when they become available.
+// GeometrySystem when it becomes available.
 
 // TODO(david-german-tri): Consider renaming this to FrameKinematicsBundle,
 // since it contains both poses and velocities.

--- a/systems/sensors/depth_sensor.cc
+++ b/systems/sensors/depth_sensor.cc
@@ -158,8 +158,8 @@ void DepthSensor::CalcDepthOutput(
 
   VectorX<double> distances(get_num_depth_readings());
 
-  // TODO(liang.fok) Remove the need for const_cast once GeometryWorld and
-  // GeometryQuery are introduced. See:
+  // TODO(liang.fok) Remove the need for const_cast once GeometrySystem is
+  // ready. See:
   // https://github.com/RobotLocomotion/drake/issues/4592#issuecomment-269491752
   const_cast<RigidBodyTree<double>&>(tree_).collisionRaycast(
       kinematics_cache, origin, raycast_endpoints_world, distances);

--- a/systems/sensors/rgbd_renderer.h
+++ b/systems/sensors/rgbd_renderer.h
@@ -174,7 +174,7 @@ class RgbdRenderer {
 
   /// The color palette for sky, terrain colors and ground truth label rendering
   /// TODO(thduynguyen, SeanCurtis-TRI): This is a world's property (colors for
-  /// each object/segment) hence should be moved to GeometryWorld. That would
+  /// each object/segment) hence should be moved to GeometrSystem. That would
   /// also answer the question whether this heavy object should be a singleton.
   ColorPalette color_palette_;
 };

--- a/systems/sensors/rgbd_renderer_vtk.cc
+++ b/systems/sensors/rgbd_renderer_vtk.cc
@@ -42,9 +42,9 @@
 // ModuleInitVtkRenderingOpenGL2.
 VTK_AUTOINIT_DECLARE(vtkRenderingOpenGL2)
 
-// TODO(kunimatsu-tri) Refactor RgbdRenderer with GeometryWorld when it's ready,
-// so that other VTK dependent sensor simulators can share the world without
-// duplicating it.
+// TODO(kunimatsu-tri) Refactor RgbdRenderer with GeometrySystem when it's
+// ready, so that other VTK dependent sensor simulators can share the world
+// without duplicating it.
 
 namespace drake {
 namespace systems {


### PR DESCRIPTION
Originally intended to be a separate class, it has now been eliminated.
Make sure there aren't any vestiges alluding to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8082)
<!-- Reviewable:end -->
