### PR TITLE
drake_visualizer: Add variant using actual pydrake

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,27 +5,55 @@ load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-py_binary(
-    name = "drake_visualizer.impl",
-    srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
+py_library(
+    name = "drake_visualizer_base",
     data = [
         "//examples:prod_models",
         "@drake_visualizer",
     ],
-    main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
     visibility = ["//visibility:private"],
     # Python libraries to import.
     deps = [
         "//lcmtypes:lcmtypes_py",
-        "//tools/workspace/drake_visualizer:stub_pydrake",
         "@drake_visualizer//:drake_visualizer_python_deps",
         "@optitrack_driver//lcmtypes:py_optitrack_lcmtypes",
+    ],
+)
+
+# `drake_visualizer` implementation, using stubbed pydrake.
+py_binary(
+    name = "drake_visualizer.impl",
+    srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
+    main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":drake_visualizer_base",
+        # N.B. `stub_pydrake` should ONLY be used by this target. Any other
+        # usages are defects.
+        "//tools/workspace/drake_visualizer:stub_pydrake",
     ],
 )
 
 drake_runfiles_binary(
     name = "drake_visualizer",
     target = ":drake_visualizer.impl",
+)
+
+# `drake_visualizer` implementation, using actual pydrake.
+py_binary(
+    name = "drake_visualizer_pydrake.impl",
+    srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
+    main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
+    visibility = ["//visibility:private"],
+    deps = [
+        ":drake_visualizer_base",
+        "//bindings/pydrake",
+    ],
+)
+
+drake_runfiles_binary(
+    name = "drake_visualizer_pydrake",
+    target = ":drake_visualizer_pydrake.impl",
 )
 
 # === config_setting rules ===

--- a/tools/workspace/drake_visualizer/BUILD.bazel
+++ b/tools/workspace/drake_visualizer/BUILD.bazel
@@ -14,10 +14,13 @@ exports_files(
 # (the only piece drake_visualizer needs).  Note that the installed version of
 # drake-visualizer *does* use the installed (full) version of pydrake -- this
 # is development-sandbox-only stub.
+# Unfortunately, we cannot constrain the visibility of this target to
+# `//tools:drake_visualizer.impl` because this creates a dependency cycle.
 py_library(
     name = "stub_pydrake",
     srcs = ["stub/pydrake/__init__.py"],
     visibility = ["//tools:__pkg__"],
+    imports = ["stub"],
 )
 
 add_lint_tests()

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -18,27 +18,16 @@ assert runfiles_dir, (
     "This must be called by a script generated using the " +
     "`drake_runfiles_binary` macro.")
 
-# Stub out pydrake (refer to our ./BUILD.bazel comments for rationale).
-#
-# We add it to PYTHONPATH within the script, rather than `imports = ["stub"]`
-# on the stub py_library, to avoid any other target accidentally pulling in the
-# stubbed pydrake onto its PYTHONPATH.  Only the visualizer, when launched via
-# this wrapper script, should employ the stub.
-stub_relpath = "tools/workspace/drake_visualizer/stub"
-if os.path.exists(os.path.join(runfiles_dir, "external/drake")):
-    # This is for bazel run @drake//tools:drake_visualizer.
-    prepend_path('PYTHONPATH', "external/drake/" + stub_relpath)
-else:
-    # This is for bazel run //tools:drake_visualizer.
-    prepend_path('PYTHONPATH', stub_relpath)
-
-# Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.  This
-# also placates the drake-visualizer logic that puts it into Director mode when
-# DRAKE_RESOURCE_ROOT is set (thus requiring more than just getDrakePath).
-try:
-    del os.environ["DRAKE_RESOURCE_ROOT"]
-except KeyError:
-    pass
+import pydrake
+if getattr(pydrake, '_is_stub', False):
+    # Don't use DRAKE_RESOURCE_ROOT; the stub getDrakePath should always win.
+    # This also placates the drake-visualizer logic that puts it into Director
+    # mode when DRAKE_RESOURCE_ROOT is set (thus requiring more than just
+    # getDrakePath).
+    try:
+        del os.environ["DRAKE_RESOURCE_ROOT"]
+    except KeyError:
+        pass
 
 # TODO(eric.cousineau): Remove these shims if we can teach Bazel how to handle
 # these on its own.

--- a/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
+++ b/tools/workspace/drake_visualizer/stub/pydrake/__init__.py
@@ -3,6 +3,9 @@
 import os
 
 
+_is_stub = True
+
+
 def getDrakePath():
     # Because //tools:drake_visualizer is a drake_runfiles_binary, the correct
     # answer to getDrakePath is always the runfiles root.  Nice!


### PR DESCRIPTION
Follow-up from #8080.

@jwnimmer-tri I'm not sure if I followed your earlier comment about the visibility of `stub_pydrake` and why we should try to inject things into the `PYTHONPATH`. 

In this PR, I've made the `drake_visualizer_pydrake` variant, splitting out the `py_library` + `py_binary`. Regarding the "accidental" inclusion of `stub_pydrake`, I think this is simply something that should be caught. Since it's only visible to `//tools:__pkg__`, it should be relatively easy to catch this defect.

Are there any other situations that you're thinking that these libraries might collide?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8084)
<!-- Reviewable:end -->
