### PR TITLE
Provide macros for trace/debug logging that don't evaluate arguments

### DIFF
--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -15,9 +15,7 @@ class Streamable {
   }
 };
 
-// Call each API function and macro to ensure that all of them compile; the
-// cmake script will cause this to be compiled in both spdlog and non-spdlog
-// modes.
+// Call each API function and macro to ensure that all of them compile.
 GTEST_TEST(TextLoggingTest, SmokeTest) {
   Streamable obj;
   drake::log()->trace("drake::log()->trace test: {} {}", "OK", obj);

--- a/common/test/text_logging_test.cc
+++ b/common/test/text_logging_test.cc
@@ -28,6 +28,10 @@ GTEST_TEST(TextLoggingTest, SmokeTest) {
   drake::log()->critical("drake::log()->critical test: {} {}", "OK", obj);
   SPDLOG_TRACE(drake::log(), "SPDLOG_TRACE macro test: {}, {}", "OK", obj);
   SPDLOG_DEBUG(drake::log(), "SPDLOG_DEBUG macro test: {}, {}", "OK", obj);
+  DRAKE_SPDLOG_TRACE(drake::log(), "DRAKE_SPDLOG_TRACE macro test: {}, {}",
+                     "OK", obj);
+  DRAKE_SPDLOG_DEBUG(drake::log(), "DRAKE_SPDLOG_DEBUG macro test: {}, {}",
+                     "OK", obj);
 }
 
 // Abuse gtest internals to verify that logging actually prints.
@@ -37,6 +41,47 @@ GTEST_TEST(TextLoggingTest, CaptureOutputTest) {
   drake::log()->info("sentinel string");
   std::string output = testing::internal::GetCapturedStderr();
   EXPECT_TRUE(output.find("sentinel string") != std::string::npos);
+}
+#endif
+
+// Verify that DRAKE_SPDLOG macros succeed in avoiding evaluation of
+// their arguments. (The plain SPDLOG ones currently evaluate unconditionally
+// when expanded but we won't check that here since it could change.)
+#ifdef HAVE_SPDLOG
+GTEST_TEST(TextLoggingTest, DrakeMacrosDontEvaluateArguments) {
+  int tracearg = 0, debugarg = 0;
+  drake::log()->set_level(spdlog::level::off);
+
+  // Shouldn't increment argument whether the macro expanded or not, since
+  // logging is off.
+  DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
+  DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
+  EXPECT_EQ(tracearg, 0);
+  EXPECT_EQ(debugarg, 0);
+
+  drake::log()->set_level(spdlog::level::trace);
+  // Should increment arg only if the macro expanded.
+  DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
+  DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
+  #ifndef NDEBUG
+    EXPECT_EQ(tracearg, 1);
+    EXPECT_EQ(debugarg, 1);
+  #else
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, 0);
+  #endif
+
+  drake::log()->set_level(spdlog::level::debug);
+  // Only DEBUG should increment arg since trace is not enabled.
+  DRAKE_SPDLOG_TRACE(drake::log(), "tracearg={}", ++tracearg);
+  DRAKE_SPDLOG_DEBUG(drake::log(), "debugarg={}", ++debugarg);
+  #ifndef NDEBUG
+    EXPECT_EQ(tracearg, 1);
+    EXPECT_EQ(debugarg, 2);
+  #else
+    EXPECT_EQ(tracearg, 0);
+    EXPECT_EQ(debugarg, 0);
+  #endif
 }
 #endif
 


### PR DESCRIPTION
Our awesome logging tool spdlog provides macros SPDLOG_TRACE and SPDLOG_DEBUG so we can include tracing and debugging output at zero cost when NDEBUG is defined (typically in Release builds). In case NDEBUG is _undefined_ (meaning assertions etc. are enabled), these macros are expanded and evaluate their arguments _regardless_ of whether trace or debug logging is actually enabled. If the arguments are expensive to evaluate, and the macros are present in performance-sensitive inner loops, this can be painfully slow.

This PR adds alternative macros DRAKE_SPDLOG_TRACE and DRAKE_SPDLOG_DEBUG that:
- evaporate if NDEBUG is defined, otherwise
- check the log level before evaluating their arguments.

(See [discussion](https://reviewable.io/reviews/robotlocomotion/drake/8050#-L5MNznTPOK9IWnKrGmw) in review of #8050.)

Probably this should be how the original macros behave. I filed [an issue](https://github.com/gabime/spdlog/issues/638) at spdlog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8087)
<!-- Reviewable:end -->
