### PR TITLE
 framework_py: Add test of using AbstractValue's in input ports, fix overload error for unique_ptr in pybind

### DIFF
--- a/bindings/pydrake/systems/framework_py.cc
+++ b/bindings/pydrake/systems/framework_py.cc
@@ -283,7 +283,16 @@ PYBIND11_MODULE(framework, m) {
         "EvalVectorInput",
         [](const System<T>* self, const Context<T>& arg1, int arg2) {
           return self->EvalVectorInput(arg1, arg2);
-        }, py_reference_internal)
+        }, py_reference,
+        // Keep alive, ownership: `return` keeps `Context` alive.
+        py::keep_alive<0, 2>())
+    .def(
+        "EvalAbstractInput",
+        [](const System<T>* self, const Context<T>& arg1, int arg2) {
+          return self->EvalAbstractInput(arg1, arg2);
+        }, py_reference,
+        // Keep alive, ownership: `return` keeps `Context` alive.
+        py::keep_alive<0, 2>())
     .def("CalcOutput", &System<T>::CalcOutput)
     // Sugar.
     .def(
@@ -352,8 +361,15 @@ PYBIND11_MODULE(framework, m) {
     .def("get_num_input_ports", &Context<T>::get_num_input_ports)
     .def("FixInputPort",
          py::overload_cast<int, unique_ptr<BasicVector<T>>>(
-             &Context<T>::FixInputPort), py_reference_internal,
+             &Context<T>::FixInputPort),
+         py_reference_internal,
          // Keep alive, ownership: `BasicVector` keeps `self` alive.
+         py::keep_alive<3, 1>())
+    .def("FixInputPort",
+         py::overload_cast<int, unique_ptr<AbstractValue>>(
+             &Context<T>::FixInputPort),
+         py_reference_internal,
+         // Keep alive, ownership: `AbstractValue` keeps `self` alive.
          py::keep_alive<3, 1>())
     .def("get_time", &Context<T>::get_time)
     .def("set_time", &Context<T>::set_time)
@@ -437,8 +453,12 @@ PYBIND11_MODULE(framework, m) {
   py::class_<OutputPort<T>>(m, "OutputPort")
     .def("size", &OutputPort<T>::size);
 
-  py::class_<SystemOutput<T>>(m, "SystemOutput")
+  py::class_<SystemOutput<T>> system_output(m, "SystemOutput");
+  DefClone(&system_output);
+  system_output
     .def("get_num_ports", &SystemOutput<T>::get_num_ports)
+    .def("get_data", &SystemOutput<T>::get_data,
+         py_reference_internal)
     .def("get_vector_data", &SystemOutput<T>::get_vector_data,
          py_reference_internal);
 

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -10,6 +10,7 @@
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/primitives/integrator.h"
 #include "drake/systems/primitives/linear_system.h"
+#include "drake/systems/primitives/pass_through.h"
 #include "drake/systems/primitives/signal_logger.h"
 #include "drake/systems/primitives/zero_order_hold.h"
 
@@ -89,6 +90,10 @@ PYBIND11_MODULE(primitives, m) {
 
   m.def("IsObservable", &IsObservable, py::arg("sys"),
         py::arg("threshold") = nullopt);
+
+  py::class_<PassThrough<T>, LeafSystem<T>>(m, "PassThrough")
+    .def(py::init<int>())
+    .def(py::init<const AbstractValue&>());
 
   py::class_<SignalLogger<T>, LeafSystem<T>>(m, "SignalLogger")
       .def(py::init<int>())

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -87,6 +87,9 @@ class TestValue(unittest.TestCase):
     def test_abstract_value_move_only(self):
         obj = MoveOnlyType(10)
         # This *always* clones `obj`.
+        self.assertEquals(
+            str(Value[MoveOnlyType]),
+            "<class 'pydrake.systems.framework.Value[MoveOnlyType]'>")
         value = Value[MoveOnlyType](obj)
         self.assertTrue(value.get_value() is not obj)
         self.assertEquals(value.get_value().x(), 10)

--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -154,14 +154,17 @@ class TemplateBase(object):
 
 class TemplateClass(TemplateBase):
     """Extension of `TemplateBase` for classes. """
-    def __init__(self, name, override_name=True, **kwargs):
-        TemplateBase.__init__(self, name, **kwargs)
-        self._override_name = override_name
+    def __init__(self, name, override_meta=True, module_name=None, **kwargs):
+        if module_name is None:
+            module_name = _get_module_name_from_stack()
+        TemplateBase.__init__(self, name, module_name=module_name, **kwargs)
+        self._override_meta = override_meta
 
     def _on_add(self, param, cls):
         # Update class name for easier debugging.
-        if self._override_name:
+        if self._override_meta:
             cls.__name__ = self._instantiation_name(param)
+            cls.__module__ = self._module_name
 
 
 class TemplateFunction(TemplateBase):
@@ -171,8 +174,10 @@ class TemplateFunction(TemplateBase):
 
 class TemplateMethod(TemplateBase):
     """Extension of `TemplateBase` for class methods. """
-    def __init__(self, name, cls, **kwargs):
-        TemplateBase.__init__(self, name, **kwargs)
+    def __init__(self, name, cls, module_name=None, **kwargs):
+        if module_name is None:
+            module_name = _get_module_name_from_stack()
+        TemplateBase.__init__(self, name, module_name=module_name, **kwargs)
         self._cls = cls
 
     def __get__(self, obj, objtype):

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -81,6 +81,7 @@ class TestCppTemplate(unittest.TestCase):
 
     def test_class(self):
         template = m.TemplateClass("ClassTpl")
+        self.assertEquals(str(template), "<TemplateClass __main__.ClassTpl>")
 
         template.add_instantiation(int, DummyA)
         template.add_instantiation(float, DummyB)

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -6,7 +6,7 @@ def pybind11_repository(name):
     github_archive(
         name = name,
         repository = "RobotLocomotion/pybind11",
-        commit = "e19086472c664078b0ba77432001a89f97784c8d",
-        sha256 = "62f1ae603f896e810339a23ed8695e6273d0936c6d77bd150cade67b76b06373",  # noqa
+        commit = "060f8eb02c72c793967ccdaa6da10d6aba3055db",
+        sha256 = "5a250d01cb4ace5d7e15bdd5b71c4e8f041bc7965677384903aeb77898953602",  # noqa
         build_file = "@drake//tools/workspace/pybind11:package.BUILD.bazel",
     )


### PR DESCRIPTION
Closes #8074

Address part of `AbstractValue` point in #7660. (Just need to follow-up with unrestricted updates.)

When I was first prototyping accepting `unique_ptr` as arguments in `pybind`, I introduced a bug where *any* registered pybind type would match with *any* other pybind type. This is fixed via https://github.com/RobotLocomotion/pybind11/pull/10
(I ultimately made this a possibility when supporting anti-slicing stuff for `shared_ptr`, but just hadn't incorporated it until now...)

This also fixes a minor issue with `cpp_template` - any instantiations may have had the wrong module name used because `inspect` was not called with the right frame count. That has now been fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8094)
<!-- Reviewable:end -->
