### PR TITLE
make Eval methods in barycentricMesh inline 

### DIFF
--- a/common/eigen_types.h
+++ b/common/eigen_types.h
@@ -50,6 +50,27 @@ using VectorX = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
 template <typename Scalar>
 using VectorUpTo6 = Eigen::Matrix<Scalar, Eigen::Dynamic, 1, 0, 6, 1>;
 
+/// A row vector of size 2, templated on scalar type.
+template <typename Scalar>
+using RowVector2 = Eigen::Matrix<Scalar, 1, 2>;
+
+/// A row vector of size 3, templated on scalar type.
+template <typename Scalar>
+using RowVector3 = Eigen::Matrix<Scalar, 1, 3>;
+
+/// A row vector of size 4, templated on scalar type.
+template <typename Scalar>
+using RowVector4 = Eigen::Matrix<Scalar, 1, 4>;
+
+/// A row vector of size 6.
+template <typename Scalar>
+using RowVector6 = Eigen::Matrix<Scalar, 1, 6>;
+
+/// A row vector of any size, templated on scalar type.
+template <typename Scalar>
+using RowVectorX = Eigen::Matrix<Scalar, 1, Eigen::Dynamic>;
+
+
 /// A matrix of 2 rows and 2 columns, templated on scalar type.
 template <typename Scalar>
 using Matrix2 = Eigen::Matrix<Scalar, 2, 2>;

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -218,6 +218,7 @@ drake_cc_googletest(
     name = "barycentric_test",
     deps = [
         ":barycentric",
+        "//common:symbolic",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/math/barycentric.cc
+++ b/math/barycentric.cc
@@ -146,27 +146,14 @@ template <typename T>
 void BarycentricMesh<T>::Eval(const Eigen::Ref<const MatrixX<T>>& mesh_values,
                               const Eigen::Ref<const VectorX<T>>& input,
                               EigenPtr<VectorX<T>> output) const {
-  DRAKE_DEMAND(input.size() == get_input_size());
-  DRAKE_DEMAND(mesh_values.cols() == get_num_mesh_points());
-
-  Eigen::VectorXi mesh_indices(num_interpolants_);
-  VectorX<T> weights(num_interpolants_);
-
-  EvalBarycentricWeights(input, &mesh_indices, &weights);
-
-  *output = weights[0] * mesh_values.col(mesh_indices[0]);
-  for (int i = 1; i < num_interpolants_; i++) {
-    *output += weights[i] * mesh_values.col(mesh_indices[i]);
-  }
+  EvalWithMixedScalars<T>(mesh_values, input, output);
 }
 
 template <typename T>
 VectorX<T> BarycentricMesh<T>::Eval(
     const Eigen::Ref<const MatrixX<T>>& mesh_values,
     const Eigen::Ref<const VectorX<T>>& input) const {
-  VectorX<T> output(mesh_values.rows());
-  Eval(mesh_values, input, &output);
-  return output;
+  return EvalWithMixedScalars<T>(mesh_values, input);
 }
 
 template <typename T>

--- a/math/barycentric.h
+++ b/math/barycentric.h
@@ -7,6 +7,7 @@
 
 #include <Eigen/Dense>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
@@ -118,6 +119,41 @@ class BarycentricMesh {
   VectorX<T> Eval(const Eigen::Ref<const MatrixX<T>>& mesh_values,
                   const Eigen::Ref<const VectorX<T>>& input) const;
 
+  /// Performs Eval, but with the possibility of the values on the mesh
+  /// having a different scalar type than the values defining the mesh
+  /// (symbolic::Expression containing decision variables for an optimization
+  /// problem is an important example)
+  /// @tparam ValueT defines the scalar type of the mesh_values and the output.
+  /// @see Eval
+  template <typename ValueT = T>
+  void EvalWithMixedScalars(
+      const Eigen::Ref<const MatrixX<ValueT>>& mesh_values,
+      const Eigen::Ref<const VectorX<T>>& input,
+      EigenPtr<VectorX<ValueT>> output) const {
+    DRAKE_DEMAND(input.size() == get_input_size());
+    DRAKE_DEMAND(mesh_values.cols() == get_num_mesh_points());
+
+    Eigen::VectorXi mesh_indices(num_interpolants_);
+    VectorX<T> weights(num_interpolants_);
+
+    EvalBarycentricWeights(input, &mesh_indices, &weights);
+
+    *output = weights[0] * mesh_values.col(mesh_indices[0]);
+    for (int i = 1; i < num_interpolants_; i++) {
+      *output += weights[i] * mesh_values.col(mesh_indices[i]);
+    }
+  }
+
+  /// Returns the function evaluated at @p input.
+  template <typename ValueT = T>
+  VectorX<ValueT> EvalWithMixedScalars(
+      const Eigen::Ref<const MatrixX<ValueT>>& mesh_values,
+      const Eigen::Ref<const VectorX<T>>& input) const {
+    VectorX<ValueT> output(mesh_values.rows());
+    EvalWithMixedScalars<ValueT>(mesh_values, input, &output);
+    return output;
+  }
+
   /// Evaluates @p vector_func at all input mesh points and extracts the mesh
   /// value matrix that should be used to approximate the function with this
   /// barycentric interpolation.
@@ -131,8 +167,8 @@ class BarycentricMesh {
           vector_func) const;
 
  private:
-  MeshGrid input_grid_;  // Specifies the location of the mesh points in
-                         // the input space.
+  MeshGrid input_grid_;      // Specifies the location of the mesh points in
+                             // the input space.
   std::vector<int> stride_;  // The number of elements to skip to arrive at the
                              // next value (per input dimension)
   int num_interpolants_{1};  // The number of points used in any interpolation.

--- a/math/test/barycentric_test.cc
+++ b/math/test/barycentric_test.cc
@@ -8,6 +8,7 @@
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
 
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
@@ -128,6 +129,37 @@ GTEST_TEST(BarycentricTest, EvalTest) {
 
   // Test the alternative call signature.
   EXPECT_NEAR(bary.Eval(mesh, Vector2d{.25, .75})[0], 6.25, 1e-8);
+}
+
+GTEST_TEST(BarycentricTest, EvalSymbolicTest) {
+  BarycentricMesh<double> bary{{{0.0, 1.0},  // BR
+                                {0.0, 1.0}}};
+
+  using symbolic::Variable;
+  using symbolic::Expression;
+  Variable a{"a"}, b{"b"}, c{"c"}, d{"d"};
+  RowVector4<Expression> mesh;
+  mesh << a, b, c, d;
+
+  Vector1<Expression> value;
+  // Check grid points.
+  bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{0., 0.}, &value);
+  EXPECT_TRUE(value[0].EqualTo(a));
+  bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{1., 0.}, &value);
+  EXPECT_TRUE(value[0].EqualTo(b));
+  bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{0., 1.}, &value);
+  EXPECT_TRUE(value[0].EqualTo(c));
+  bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{1., 1.}, &value);
+  EXPECT_TRUE(value[0].EqualTo(d));
+
+  // Check the middle.
+  bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{.5, .5}, &value);
+  EXPECT_TRUE(value[0].EqualTo(.5 * a + .5 * d));
+
+  // Test the alternative call signature.
+  EXPECT_TRUE(
+      bary.EvalWithMixedScalars<Expression>(mesh, Vector2d{0., 0.})[0].EqualTo(
+          a));
 }
 
 GTEST_TEST(BarycentricTest, MultidimensionalOutput) {


### PR DESCRIPTION
and provide a template parameter for the mesh values / output.  this enables a very important
use case for dynamic programming (where i'm passing decision variables
through the mesh eval).

Note: I wish that I understood why none of the call sites could infer
the template parameter through the Eigen::Ref NOR succeed using the
default template parameter, which should have worked for every existing
call site)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8100)
<!-- Reviewable:end -->
