### PR TITLE
Allow joints to have a same value in upper/lower limits

### DIFF
--- a/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -1041,7 +1041,7 @@ void RigidBodyPlant<T>::DoCalcDiscreteVariableUpdates(
     if (joint.get_num_positions() == 1 && joint.get_num_velocities() == 1) {
       const T qmin = joint.getJointLimitMin()(0);
       const T qmax = joint.getJointLimitMax()(0);
-      DRAKE_DEMAND(qmin < qmax);
+      DRAKE_DEMAND(qmin <= qmax);
 
       // Get the current joint position and velocity.
       const T& qjoint = q(b->get_position_start_index());
@@ -1296,7 +1296,7 @@ T RigidBodyPlant<T>::JointLimitForce(const DrakeJoint& joint, const T& position,
                                      const T& velocity) {
   const T qmin = joint.getJointLimitMin()(0);
   const T qmax = joint.getJointLimitMax()(0);
-  DRAKE_DEMAND(qmin < qmax);
+  DRAKE_DEMAND(qmin <= qmax);
   const T joint_stiffness = joint.get_joint_limit_stiffness()(0);
   DRAKE_DEMAND(joint_stiffness >= 0);
   const T joint_dissipation = joint.get_joint_limit_dissipation()(0);


### PR DESCRIPTION
In URDF, a joint can have a same value in upper/lower position limits.
But RigidBodyPlant doesn't accept those configuratoins even URDF parser
successfully parsed a robot model. (This causes sudden termination without clear messages)

I'm not sure this is the correct way to fix this.
So I would appreciate if you could suggest better way to do this.
I tested several examples under this code and ensured it doesn't break simulations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8112)
<!-- Reviewable:end -->
