### PR TITLE
Move RoadPositionStrategy enum to a globally-visible location

### DIFF
--- a/automotive/calc_ongoing_road_position.h
+++ b/automotive/calc_ongoing_road_position.h
@@ -8,14 +8,6 @@
 namespace drake {
 namespace automotive {
 
-/// If kCache, configures the calling system (e.g. IdmController, MobilPlanner)
-/// to declare an abstract state that caches the last-computed RoadPosition.
-/// If kExhaustiveSearch, then the system will contain no abstract states.  Note
-/// that the kCache option is for performance speedup (at the expense of
-/// optimizer compatibility) by preventing a potentially sizeable computation
-/// within RoadGeometry::ToRoadPosition().
-enum class RoadPositionStrategy { kCache, kExhaustiveSearch };
-
 /// Given a PoseVector @p pose, find a car's current RoadGeometry via a search
 /// of immediate ongoing lanes, starting with the current one.  Uses the
 /// provided FrameVelocity @p velocity to determine which side of the lane

--- a/automotive/pose_selector.h
+++ b/automotive/pose_selector.h
@@ -44,6 +44,14 @@ enum class AheadOrBehind { kAhead = 0, kBehind = 1 };
 /// branches for traffic.
 enum class ScanStrategy { kBranches, kPath };
 
+/// If kCache, configures a planning system (e.g. IdmController, MobilPlanner)
+/// to declare an abstract state that caches the last-computed RoadPosition.  If
+/// kExhaustiveSearch, then the system will contain no abstract states.  Note
+/// that the kCache option is for performance speedup (at the expense of
+/// optimizer compatibility) by preventing a potentially sizeable computation
+/// within RoadGeometry::ToRoadPosition().
+enum class RoadPositionStrategy { kCache, kExhaustiveSearch };
+
 /// PoseSelector is a class that provides the relevant pose or poses with
 /// respect to a given ego vehicle driving within a given maliput road geometry.
 ///


### PR DESCRIPTION
`IdmController` and `MobilPlanner` currently cannot be constructed outside of `automotive`, since `calc_ongoing_road_position.h`'s visibility is scoped locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8129)
<!-- Reviewable:end -->
