### PR TITLE
Do not pass -s to the linker on macOS

### DIFF
--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -1,8 +1,11 @@
 # -*- python -*-
 
 config_setting(
-    name = "debug",
-    values = {"compilation_mode": "dbg"},
+    name = "linux_opt",
+    values = {
+        "compilation_mode": "opt",
+        "cpu": "k8",
+    },
 )
 
 # In some versions of SNOPT, this header provides the function declarations to
@@ -39,9 +42,10 @@ cc_library(
     linkopts = [
         "-lm",
     ] + select({
-        ":debug": [],
-        # Strip symbols in release mode per note (3) above.
-        "//conditions:default": ["-s"],
+        # Strip symbols in release mode where supported by the linker per note
+        # (3) above. Symbols are stripped during install on macOS.
+        ":linux_opt": ["-s"],
+        "//conditions:default": [],
     }),
     # Link statically per note (1) above.
     linkstatic = 1,


### PR DESCRIPTION
Fixes #8131. The flag is obsolete and ignored and there is no alternative flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8133)
<!-- Reviewable:end -->