### PR TITLE
Fix shebang linting to use @drake for tools

### DIFF
--- a/tools/lint/python_lint.bzl
+++ b/tools/lint/python_lint.bzl
@@ -26,10 +26,10 @@ def _python_lint(name_prefix, files, ignore):
     native.py_test(
         name = name_prefix + "_drakelint",
         size = "small",
-        srcs = ["//tools/lint:drakelint"],
+        srcs = ["@drake//tools/lint:drakelint"],
         data = files,
         args = locations,
-        main = "//tools/lint:drakelint.py",
+        main = "@drake//tools/lint:drakelint.py",
         tags = ["drakelint", "lint"]
     )
 


### PR DESCRIPTION
This amends #8088 so that it doesn't break downstream projects that reuse the python linters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8139)
<!-- Reviewable:end -->
