### PR TITLE
Use quoted includes for lcm and external lcmtypes

### DIFF
--- a/examples/kuka_iiwa_arm/dev/box_rotation/box_rotation_demo.cc
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/box_rotation_demo.cc
@@ -9,7 +9,7 @@
 #include <string>
 
 #include <gflags/gflags.h>
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/find_resource.h"
 #include "drake/examples/kuka_iiwa_arm/iiwa_common.h"

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_demo.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/pick_and_place_demo.cc
@@ -7,8 +7,8 @@
 #include <list>
 #include <memory>
 
-#include <lcm/lcm-cpp.hpp>
 #include "bot_core/robot_state_t.hpp"
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"

--- a/examples/kuka_iiwa_arm/kuka_plan_runner.cc
+++ b/examples/kuka_iiwa_arm/kuka_plan_runner.cc
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <memory>
 
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 #include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/drake_assert.h"

--- a/examples/kuka_iiwa_arm/move_iiwa_ee.cc
+++ b/examples/kuka_iiwa_arm/move_iiwa_ee.cc
@@ -7,7 +7,7 @@
 /// during, and after the commanded motion.
 
 #include <gflags/gflags.h>
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 #include "robotlocomotion/robot_plan_t.hpp"
 
 #include "drake/common/drake_assert.h"

--- a/lcm/lcm_receive_thread.h
+++ b/lcm/lcm_receive_thread.h
@@ -3,7 +3,7 @@
 #include <atomic>
 #include <thread>
 
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_copyable.h"
 

--- a/multibody/rigid_body_plant/viewer_draw_translator.cc
+++ b/multibody/rigid_body_plant/viewer_draw_translator.cc
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/basic_vector.h"

--- a/perception/estimators/dev/test/test_util.h
+++ b/perception/estimators/dev/test/test_util.h
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <bot_core/pointcloud_t.hpp>
 #include <gtest/gtest.h>
+#include "bot_core/pointcloud_t.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/lcm/drake_lcm.h"

--- a/systems/controllers/InstantaneousQPController.cpp
+++ b/systems/controllers/InstantaneousQPController.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/eigen_types.h"

--- a/systems/estimators/dev/pose_estimation_test.cc
+++ b/systems/estimators/dev/pose_estimation_test.cc
@@ -1,10 +1,8 @@
 #include <random>
 #include <stdexcept>
 
-#include <lcm/lcm-cpp.hpp>
-// TODO(russt): Figure out why do I need the lcmtypes here.  Inconsistent with
-// https://github.com/mwoehlke-kitware/bot_core_lcmtypes/pull/1#issuecomment-269343143
-#include <lcmtypes/bot_core/pointcloud_t.hpp>
+#include "bot_core/pointcloud_t.hpp"
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"

--- a/systems/lcm/lcmt_drake_signal_translator.cc
+++ b/systems/lcm/lcmt_drake_signal_translator.cc
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <vector>
 
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/drake_assert.h"
 #include "drake/lcmt_drake_signal.hpp"

--- a/systems/lcm/test/lcm_driven_loop_test.cc
+++ b/systems/lcm/test/lcm_driven_loop_test.cc
@@ -1,7 +1,7 @@
 #include "drake/systems/lcm/lcm_driven_loop.h"
 
 #include <gtest/gtest.h>
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/lcm/drake_lcm.h"

--- a/systems/robotInterfaces/QPLocomotionPlan.h
+++ b/systems/robotInterfaces/QPLocomotionPlan.h
@@ -6,7 +6,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <lcm/lcm-cpp.hpp>
+#include "lcm/lcm-cpp.hpp"
 
 #include "drake/common/trajectories/exponential_plus_piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"


### PR DESCRIPTION
This was the other hotspot for system conflicts, if I recall correctly from Slack.

Toward #8155.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8151)
<!-- Reviewable:end -->
