### PR TITLE
linearize certain input/output ports

### DIFF
--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -77,9 +77,14 @@ PYBIND11_MODULE(primitives, m) {
            py::arg("time_period") = 0.0);
 
   m.def("Linearize", &Linearize, py::arg("system"), py::arg("context"),
+        py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
+        py::arg("output_port_index") = systems::kUseFirstOutputIfItExists,
         py::arg("equilibrium_check_tolerance") = 1e-6);
 
-  m.def("FirstOrderTaylorApproximation", &FirstOrderTaylorApproximation);
+  m.def("FirstOrderTaylorApproximation", &FirstOrderTaylorApproximation,
+        py::arg("system"), py::arg("context"),
+        py::arg("input_port_index") = systems::kUseFirstInputIfItExists,
+        py::arg("output_port_index") = systems::kUseFirstOutputIfItExists);
 
   m.def("ControllabilityMatrix", &ControllabilityMatrix);
 
@@ -92,8 +97,8 @@ PYBIND11_MODULE(primitives, m) {
         py::arg("threshold") = nullopt);
 
   py::class_<PassThrough<T>, LeafSystem<T>>(m, "PassThrough")
-    .def(py::init<int>())
-    .def(py::init<const AbstractValue&>());
+      .def(py::init<int>())
+      .def(py::init<const AbstractValue&>());
 
   py::class_<SignalLogger<T>, LeafSystem<T>>(m, "SignalLogger")
       .def(py::init<int>())

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -106,7 +106,7 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual(system.time_period(), .1)
 
         context.FixInputPort(0, BasicVector([0]))
-        linearized = Linearize(system, context, 1e-6)
+        linearized = Linearize(system, context)
         self.assertTrue((linearized.A() == A).all())
         taylor = FirstOrderTaylorApproximation(system, context)
         self.assertTrue((taylor.y0() == y0).all())

--- a/systems/controllers/linear_quadratic_regulator.cc
+++ b/systems/controllers/linear_quadratic_regulator.cc
@@ -81,7 +81,9 @@ std::unique_ptr<systems::AffineSystem<double>> LinearQuadraticRegulator(
   DRAKE_DEMAND(context.has_only_continuous_state());
   // TODO(russt): Confirm behavior if Q is not PSD.
 
-  auto linear_system = Linearize(system, context);
+  // Use first input and no outputs (the output dynamics are irrelevant for
+  // LQR design).
+  auto linear_system = Linearize(system, context, 0, kNoOutput);
 
   LinearQuadraticRegulatorResult lqr_result =
       LinearQuadraticRegulator(linear_system->A(), linear_system->B(), Q, R, N);

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -681,11 +681,8 @@ class System {
   /// determine whether a system's dynamics are at least partially governed by
   /// difference equations and (2) to obtain the difference equation update
   /// times.
-  /// @param[out] periodic_attr Contains the periodic trigger attributes
-  ///             on return of `true` from this function; the value will be
-  ///             unchanged on return value `false`. Function aborts if null.
-  /// @returns `true` if there exists a unique periodic attribute that triggers
-  ///          one or more discrete update events and `false` otherwise.
+  /// @returns optional<PeriodicAttribute> Contains the periodic trigger
+  /// attributes if the unique periodic attribute exists, otherwise `nullopt`.
   optional<typename Event<T>::PeriodicAttribute>
       GetUniquePeriodicDiscreteUpdateAttribute() const {
     optional<typename Event<T>::PeriodicAttribute> saved_attr;

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -18,11 +18,6 @@
 
 namespace drake {
 namespace systems {
-namespace {
-
-enum class WhichAction { DoLinearize, DoThrow };
-
-}  // namespace
 
 using std::make_unique;
 using std::unique_ptr;
@@ -33,15 +28,14 @@ LinearSystem<T>::LinearSystem(const Eigen::Ref<const Eigen::MatrixXd>& A,
                               const Eigen::Ref<const Eigen::MatrixXd>& C,
                               const Eigen::Ref<const Eigen::MatrixXd>& D,
                               double time_period)
-    : LinearSystem<T>(
-          SystemTypeTag<systems::LinearSystem>{},
-          A, B, C, D, time_period) {}
+    : LinearSystem<T>(SystemTypeTag<systems::LinearSystem>{}, A, B, C, D,
+                      time_period) {}
 
 template <typename T>
 template <typename U>
 LinearSystem<T>::LinearSystem(const LinearSystem<U>& other)
-    : LinearSystem<T>(
-          other.A(), other.B(), other.C(), other.D(), other.time_period()) {}
+    : LinearSystem<T>(other.A(), other.B(), other.C(), other.D(),
+                      other.time_period()) {}
 
 template <typename T>
 LinearSystem<T>::LinearSystem(SystemScalarConverter converter,
@@ -50,10 +44,9 @@ LinearSystem<T>::LinearSystem(SystemScalarConverter converter,
                               const Eigen::Ref<const Eigen::MatrixXd>& C,
                               const Eigen::Ref<const Eigen::MatrixXd>& D,
                               double time_period)
-    : AffineSystem<T>(
-          std::move(converter),
-          A, B, Eigen::VectorXd::Zero(A.rows()), C, D,
-          Eigen::VectorXd::Zero(C.rows()), time_period) {}
+    : AffineSystem<T>(std::move(converter), A, B,
+                      Eigen::VectorXd::Zero(A.rows()), C, D,
+                      Eigen::VectorXd::Zero(C.rows()), time_period) {}
 
 template <typename T>
 unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(
@@ -90,95 +83,12 @@ unique_ptr<LinearSystem<T>> LinearSystem<T>::MakeLinearSystem(
 
 namespace {
 
-// If the system has discrete states, checks that the sole registered event for
-// the system is periodic, and returns the time_period. A time_period of zero is
-// returned if the system has continuous states.
-double GetTimePeriodIfDiscreteUpdatesArePeriodic(
-    const System<double>& system, const Context<double>& context) {
-  if (!context.has_only_discrete_state()) return 0.;
-
-  std::unique_ptr<CompositeEventCollection<double>> event_info =
-      system.AllocateCompositeEventCollection();
-  const double time_period =
-      system.CalcNextUpdateTime(context, event_info.get()) - context.get_time();
-
-  // Verify that the system has only one discrete, periodic update event.
-  // TODO(jadecastro) Upon resolution of #6878, clean up this implementation and
-  // weed out all illegal systems having a combination of event handlers.
-  DRAKE_THROW_UNLESS(event_info->HasDiscreteUpdateEvents());
-  const auto leaf_info =
-      dynamic_cast<const LeafCompositeEventCollection<double>*>(
-          event_info.get());
-  DRAKE_DEMAND(leaf_info != nullptr);
-  auto discrete_events = leaf_info->get_discrete_update_events().get_events();
-  DRAKE_THROW_UNLESS(discrete_events.size() == 1);
-  DRAKE_THROW_UNLESS(discrete_events.front()->get_trigger_type() ==
-                     Event<double>::TriggerType::kPeriodic);
-  return time_period;
-}
-
-void ThrowNonEquilibrium() {
-  throw std::runtime_error(
-      "The nominal operating point (x0,u0) is not an equilibrium point of "
-      "the system.  Without additional information, a time-invariant "
-      "linearization of this system is not well defined.");
-}
-
-// Builds the A and B matrices of the system's discrete/continuous state
-// equation.  Returns a pair consisting of the concatenated matrix [A, B], along
-// with the value of the state equation f(x0,u0) (note that this is *not* the
-// affine term f0).
-std::pair<Eigen::MatrixXd, Eigen::VectorXd>
-MakeStateAndInputMatrices(
-    const VectorX<AutoDiffXd>& autodiff_x0_vec,
-    double equilibrium_check_tolerance,
-    const System<AutoDiffXd>& autodiff_system,
-    Context<AutoDiffXd>* autodiff_context,
-    WhichAction which_action) {
-  if (autodiff_context->has_only_continuous_state()) {
-    autodiff_context->get_mutable_continuous_state_vector().SetFromVector(
-        autodiff_x0_vec);
-    std::unique_ptr<ContinuousState<AutoDiffXd>> autodiff_xdot =
-        autodiff_system.AllocateTimeDerivatives();
-    autodiff_system.CalcTimeDerivatives(*autodiff_context, autodiff_xdot.get());
-    auto autodiff_xdot_vec = autodiff_xdot->CopyToVector();
-
-    if (!math::autoDiffToValueMatrix(autodiff_xdot_vec)
-             .isZero(equilibrium_check_tolerance)) {
-      if (which_action == WhichAction::DoThrow) {
-        // Ensure that xdot0 = f(x0,u0) == 0 if we require an equilibrium point.
-        ThrowNonEquilibrium();
-      }
-    }
-    return std::make_pair(math::autoDiffToGradientMatrix(autodiff_xdot_vec),
-                          math::autoDiffToValueMatrix(autodiff_xdot_vec));
-  }
-  auto& autodiff_x0 =
-      autodiff_context->get_mutable_discrete_state().get_mutable_vector();
-  autodiff_x0.SetFromVector(autodiff_x0_vec);
-  std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
-      autodiff_system.AllocateDiscreteVariables();
-  autodiff_system.CalcDiscreteVariableUpdates(*autodiff_context,
-                                              autodiff_x1.get());
-  auto autodiff_x1_vec = autodiff_x1->get_vector().CopyToVector();
-
-  if (!(math::autoDiffToValueMatrix(autodiff_x1_vec) -
-        math::autoDiffToValueMatrix(autodiff_x0_vec))
-           .isZero(equilibrium_check_tolerance)) {
-    if (which_action == WhichAction::DoThrow) {
-      // Ensure that x1 = f(x0,u0) == x0 if we require an equilibrium point.
-      ThrowNonEquilibrium();
-    }
-  }
-  return std::make_pair(math::autoDiffToGradientMatrix(autodiff_x1_vec),
-                        math::autoDiffToValueMatrix(autodiff_x1_vec));
-}
-
+// Helper function allows reuse for both FirstOrderTaylorApproximation and
+// Linearize.
 std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
-    const System<double>& system,
-    const Context<double>& context,
-    double equilibrium_check_tolerance,
-    WhichAction which_action) {
+    const System<double>& system, const Context<double>& context,
+    int input_port_index, int output_port_index,
+    optional<double> equilibrium_check_tolerance = nullopt) {
   DRAKE_ASSERT_VOID(system.CheckValidContext(context));
 
   const bool has_only_discrete_states_contained_in_one_group =
@@ -187,20 +97,13 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   DRAKE_DEMAND(context.is_stateless() || context.has_only_continuous_state() ||
                has_only_discrete_states_contained_in_one_group);
 
-  const double time_period =
-      GetTimePeriodIfDiscreteUpdatesArePeriodic(system, context);
-  // N.B. Placement here allows us to fail fast if non-periodic updates are
-  // detected.
-
-  DRAKE_DEMAND(system.get_num_input_ports() <= 1);
-  DRAKE_DEMAND(system.get_num_output_ports() <= 1);
-
-  const int num_inputs = (system.get_num_input_ports() > 0)
-                             ? system.get_input_port(0).size()
-                             : 0,
-            num_outputs = (system.get_num_output_ports() > 0)
-                              ? system.get_output_port(0).size()
-                              : 0;
+  double time_period = 0.0;
+  if (has_only_discrete_states_contained_in_one_group) {
+    optional<Event<double>::PeriodicAttribute> periodic_attr =
+        system.GetUniquePeriodicDiscreteUpdateAttribute();
+    DRAKE_THROW_UNLESS(static_cast<bool>(periodic_attr));
+    time_period = periodic_attr->period_sec;
+  }
 
   // Create an autodiff version of the system.
   std::unique_ptr<System<AutoDiffXd>> autodiff_system =
@@ -211,74 +114,175 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
       autodiff_system->CreateDefaultContext();
   autodiff_context->SetTimeStateAndParametersFrom(context);
 
+  const InputPortDescriptor<AutoDiffXd>* input_port = nullptr;
+  // By default, use the first input / output ports (if they exist).
+  if (input_port_index == kUseFirstInputIfItExists) {
+    if (system.get_num_input_ports() > 0) {
+      input_port = &(autodiff_system->get_input_port(0));
+    }
+  } else if (input_port_index >= 0 &&
+             input_port_index < system.get_num_input_ports()) {
+    input_port = &(autodiff_system->get_input_port(input_port_index));
+  } else if (input_port_index != kNoInput) {
+    DRAKE_ABORT_MSG("Invalid input_port_index specified.");
+  }
+  const OutputPort<AutoDiffXd>* output_port = nullptr;
+  // By default, use the first input / output ports (if they exist).
+  if (output_port_index == kUseFirstOutputIfItExists) {
+    if (system.get_num_output_ports() > 0) {
+      output_port = &(autodiff_system->get_output_port(0));
+    }
+  } else if (output_port_index >= 0 &&
+             output_port_index < system.get_num_output_ports()) {
+    output_port = &(autodiff_system->get_output_port(output_port_index));
+  } else if (output_port_index != kNoOutput) {
+    DRAKE_ABORT_MSG("Invalid output_port_index specified.");
+  }
+
+  const int num_inputs = input_port ? input_port->size() : 0;
+  const int num_outputs = output_port ? output_port->size() : 0;
+
   const Eigen::VectorXd x0 =
-      (context.has_only_continuous_state())
-          ? context.get_continuous_state_vector().CopyToVector()
-          : context.get_discrete_state(0).get_value();
+      context.is_stateless()
+          ? Eigen::VectorXd::Zero(0)
+          : ((context.has_only_continuous_state())
+                 ? context.get_continuous_state_vector().CopyToVector()
+                 : context.get_discrete_state(0).get_value());
   const int num_states = x0.size();
 
+  // Must have some values for all of the inputs.
+  for (int index = 0; index < system.get_num_input_ports(); index++) {
+    Eigen::VectorXd u = system.EvalEigenVectorInput(context, index);
+    autodiff_context->FixInputPort(index, u.cast<AutoDiffXd>());
+  }
+
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(num_inputs);
-  if (num_inputs > 0) {
-    u0 = system.EvalEigenVectorInput(context, 0);
+  if (input_port) {
+    u0 = system.EvalEigenVectorInput(context, input_port->get_index());
   }
 
   auto autodiff_args = math::initializeAutoDiffTuple(x0, u0);
-  if (num_inputs > 0) {
+  if (input_port) {
     auto input_vector = std::make_unique<BasicVector<AutoDiffXd>>(num_inputs);
     input_vector->SetFromVector(std::get<1>(autodiff_args));
-    autodiff_context->FixInputPort(0, std::move(input_vector));
+    autodiff_context->FixInputPort(input_port->get_index(),
+                                   std::move(input_vector));
   }
 
-  Eigen::MatrixXd AB;
-  Eigen::VectorXd f_at_basepoint;
-  std::tie(AB, f_at_basepoint) = MakeStateAndInputMatrices(
-      std::get<0>(autodiff_args), equilibrium_check_tolerance, *autodiff_system,
-      autodiff_context.get(), which_action);
-  const Eigen::MatrixXd& A = AB.leftCols(num_states);
-  const Eigen::MatrixXd& B = AB.rightCols(num_inputs);
-  const Eigen::VectorXd& f0 = f_at_basepoint - A * x0 - B * u0;
+  Eigen::MatrixXd A(num_states, num_states), B(num_states, num_inputs);
+  Eigen::VectorXd f0(num_states);
+  if (num_states > 0) {
+    if (autodiff_context->has_only_continuous_state()) {
+      autodiff_context->get_mutable_continuous_state_vector().SetFromVector(
+          std::get<0>(autodiff_args));
+      std::unique_ptr<ContinuousState<AutoDiffXd>> autodiff_xdot =
+          autodiff_system->AllocateTimeDerivatives();
+      autodiff_system->CalcTimeDerivatives(*autodiff_context,
+                                           autodiff_xdot.get());
+      auto autodiff_xdot_vec = autodiff_xdot->CopyToVector();
+
+      const Eigen::MatrixXd AB =
+          math::autoDiffToGradientMatrix(autodiff_xdot_vec);
+      A = AB.leftCols(num_states);
+      B = AB.rightCols(num_inputs);
+
+      const Eigen::VectorXd xdot0 =
+          math::autoDiffToValueMatrix(autodiff_xdot_vec);
+
+      if (equilibrium_check_tolerance &&
+          !xdot0.isZero(*equilibrium_check_tolerance)) {
+        throw std::runtime_error(
+            "The nominal operating point (x0,u0) is not an equilibrium point "
+            "of "
+            "the system.  Without additional information, a time-invariant "
+            "linearization of this system is not well defined.");
+      }
+
+      f0 = xdot0 - A * x0 - B * u0;
+    } else {
+      DRAKE_ASSERT(has_only_discrete_states_contained_in_one_group);
+      auto& autodiff_x0 =
+          autodiff_context->get_mutable_discrete_state().get_mutable_vector();
+      autodiff_x0.SetFromVector(std::get<0>(autodiff_args));
+      std::unique_ptr<DiscreteValues<AutoDiffXd>> autodiff_x1 =
+          autodiff_system->AllocateDiscreteVariables();
+      autodiff_system->CalcDiscreteVariableUpdates(*autodiff_context,
+                                                   autodiff_x1.get());
+      auto autodiff_x1_vec = autodiff_x1->get_vector().CopyToVector();
+
+      const Eigen::MatrixXd AB =
+          math::autoDiffToGradientMatrix(autodiff_x1_vec);
+      A = AB.leftCols(num_states);
+      B = AB.rightCols(num_inputs);
+
+      const Eigen::VectorXd x1 = math::autoDiffToValueMatrix(autodiff_x1_vec);
+
+      if (equilibrium_check_tolerance &&
+          !(x1 - x0).isZero(*equilibrium_check_tolerance)) {
+        throw std::runtime_error(
+            "The nominal operating point (x0,u0) is not an equilibrium point "
+            "of the system.  Without additional information, a time-invariant "
+            "linearization of this system is not well defined.");
+      }
+
+      f0 = x1 - A * x0 - B * u0;
+    }
+  } else {
+    DRAKE_ASSERT(num_states == 0);
+    A = Eigen::MatrixXd(0, 0);
+    B = Eigen::MatrixXd(0, num_inputs);
+    f0 = Eigen::VectorXd(0);
+  }
 
   Eigen::MatrixXd C = Eigen::MatrixXd::Zero(num_outputs, num_states);
   Eigen::MatrixXd D = Eigen::MatrixXd::Zero(num_outputs, num_inputs);
-
   Eigen::VectorXd y0 = Eigen::VectorXd::Zero(num_outputs);
-  if (num_outputs > 0) {
-    std::unique_ptr<SystemOutput<AutoDiffXd>> autodiff_y0 =
-        autodiff_system->AllocateOutput(*autodiff_context);
-    autodiff_system->CalcOutput(*autodiff_context, autodiff_y0.get());
-    auto autodiff_y0_vec = autodiff_y0->get_vector_data(0)->CopyToVector();
 
-    Eigen::MatrixXd CD = math::autoDiffToGradientMatrix(autodiff_y0_vec);
+  if (output_port) {
+    std::unique_ptr<AbstractValue> autodiff_y0 =
+        output_port->Allocate(*autodiff_context);
+    output_port->Calc(*autodiff_context, autodiff_y0.get());
+
+    auto autodiff_y0_vec =
+        autodiff_y0->GetValue<BasicVector<AutoDiffXd>>().CopyToVector();
+
+    const Eigen::MatrixXd CD = math::autoDiffToGradientMatrix(autodiff_y0_vec);
     C = CD.leftCols(num_states);
     D = CD.rightCols(num_inputs);
 
-    const Eigen::VectorXd& y_at_basepoint =
-        math::autoDiffToValueMatrix(autodiff_y0_vec);
-    y0 = y_at_basepoint - C * x0 - D * u0;
+    const Eigen::VectorXd y = math::autoDiffToValueMatrix(autodiff_y0_vec);
+
+    // Note: No tolerance check needed here.  We have defined that the output
+    // for the system produced by Linearize is in the coordinates (y-y0).
+
+    y0 = y - C * x0 - D * u0;
   }
 
-  return std::make_unique<AffineSystem<double>>(
-      A, B, f0, C, D, y0, time_period);
+  return std::make_unique<AffineSystem<double>>(A, B, f0, C, D, y0,
+                                                time_period);
 }
 
 }  // namespace
 
 std::unique_ptr<LinearSystem<double>> Linearize(
     const System<double>& system, const Context<double>& context,
+    int input_port_index, int output_port_index,
     double equilibrium_check_tolerance) {
   std::unique_ptr<AffineSystem<double>> affine =
-      DoFirstOrderTaylorApproximation(
-          system, context, equilibrium_check_tolerance, WhichAction::DoThrow);
-  return std::make_unique<LinearSystem<double>>(
-      affine->A(), affine->B(), affine->C(), affine->D(),
-      affine->time_period());
+      DoFirstOrderTaylorApproximation(system, context, input_port_index,
+                                      output_port_index,
+                                      equilibrium_check_tolerance);
+
+  return std::make_unique<LinearSystem<double>>(affine->A(), affine->B(),
+                                                affine->C(), affine->D(),
+                                                affine->time_period());
 }
 
 std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
-    const System<double>& system, const Context<double>& context) {
-  return DoFirstOrderTaylorApproximation(
-      system, context, 0. /* equilibrium tolerance (not used) */,
-      WhichAction::DoLinearize);
+    const System<double>& system, const Context<double>& context,
+    int input_port_index, int output_port_index) {
+  return DoFirstOrderTaylorApproximation(system, context, input_port_index,
+                                         output_port_index);
 }
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
@@ -297,8 +301,8 @@ Eigen::MatrixXd ControllabilityMatrix(const LinearSystem<double>& sys) {
 }
 
 /// Returns true iff the controllability matrix is full row rank.
-bool IsControllable(const LinearSystem<double>& sys, optional<double>
-    threshold) {
+bool IsControllable(const LinearSystem<double>& sys,
+                    optional<double> threshold) {
   const auto R = ControllabilityMatrix(sys);
   Eigen::ColPivHouseholderQR<Eigen::MatrixXd> lu_decomp(R);
   if (threshold) {

--- a/systems/primitives/linear_system.h
+++ b/systems/primitives/linear_system.h
@@ -88,8 +88,7 @@ class LinearSystem : public AffineSystem<T> {
                const Eigen::Ref<const Eigen::MatrixXd>& A,
                const Eigen::Ref<const Eigen::MatrixXd>& B,
                const Eigen::Ref<const Eigen::MatrixXd>& C,
-               const Eigen::Ref<const Eigen::MatrixXd>& D,
-               double time_period);
+               const Eigen::Ref<const Eigen::MatrixXd>& D, double time_period);
 };
 
 /// Base class for a discrete or continuous linear time-varying (LTV) system.
@@ -132,11 +131,10 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
   /// @param num_inputs size of the system's input vector
   /// @param num_outputs size of the system's output vector
   /// @param time_period discrete update period, or 0.0 to use continuous time
-  TimeVaryingLinearSystem(SystemScalarConverter converter,
-                          int num_states, int num_inputs, int num_outputs,
-                          double time_period) : TimeVaryingAffineSystem<T>(
-          std::move(converter), num_states, num_inputs, num_outputs,
-          time_period) {}
+  TimeVaryingLinearSystem(SystemScalarConverter converter, int num_states,
+                          int num_inputs, int num_outputs, double time_period)
+      : TimeVaryingAffineSystem<T>(std::move(converter), num_states, num_inputs,
+                                   num_outputs, time_period) {}
 
  private:
   // N.B. A linear system is simply a restricted form of an affine system with
@@ -149,20 +147,43 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
   }
 };
 
+/// @defgroup Additional options for input/output port specification.
+/// @{
+// TODO(russt): Move these to a more central location if they are useful in
+// other related methods.
+const int kNoInput = -1;
+const int kUseFirstInputIfItExists = -2;
+
+const int kNoOutput = -3;
+const int kUseFirstOutputIfItExists = -4;
+/// @}
+
 /// Takes the first-order Taylor expansion of a System around a nominal
 /// operating point (defined by the Context).
+///
+/// This method currently supports linearizing around at most a single vector
+/// input port and at most a single vector output port.  For systems with
+/// more ports, use @p input_port_index and @p output_port_index to select
+/// the input for the newly constructed system.  Any additional input ports
+/// will be treated as constants (fixed at the value specified in @p context).
 ///
 /// @param system The system or subsystem to linearize.
 /// @param context Defines the nominal operating point about which the system
 /// should be linearized.  See note below.
+/// @param input_port_index A valid input port index for @p system or kNoInput
+/// or (default) kUseFirstInputIfItExists.
+/// @param output_port_index A valid output port index for @p system or
+/// kNoOutput or (default) kUseFirstOutputIfItExists.
 /// @param equilibrium_check_tolerance Specifies the tolerance on ensuring that
 /// the derivative vector isZero at the nominal operating point.  @default 1e-6.
 /// @returns A LinearSystem that approximates the original system in the
 /// vicinity of the operating point.  See note below.
 /// @throws std::runtime_error if the system the operating point is not an
 /// equilibrium point of the system (within the specified tolerance)
+/// @throws std::runtime_error if the system if the system is not (only)
+/// continuous or (only) discrete time with a single periodic update.
 ///
-/// Note: The inputs in the Context must be connected, either to the
+/// Note: All inputs in the Context must be connected, either to the
 /// output of some upstream System within a Diagram (e.g., if system is a
 /// reference to a subsystem in a Diagram), or to a constant value using, e.g.
 ///   context->FixInputPort(0,default_input);
@@ -177,6 +198,8 @@ class TimeVaryingLinearSystem : public TimeVaryingAffineSystem<T> {
 ///
 std::unique_ptr<LinearSystem<double>> Linearize(
     const System<double>& system, const Context<double>& context,
+    int input_port_index = kUseFirstInputIfItExists,
+    int output_port_index = kUseFirstOutputIfItExists,
     double equilibrium_check_tolerance = 1e-6);
 
 /// A first-order Taylor series approximation to a @p system in the neighborhood
@@ -197,18 +220,34 @@ std::unique_ptr<LinearSystem<double>> Linearize(
 /// where @f$ f0 = \dot{x0} - A x0 - B u0 @f$ (CT) and
 /// @f$ f0 = x0[n+1] - A x[n] - B u[n] @f$ (DT).
 ///
+/// This method currently supports approximating around at most a single vector
+/// input port and at most a single vector output port.  For systems with
+/// more ports, use @p input_port_index and @p output_port_index to select
+/// the input for the newly constructed system.  Any additional input ports
+/// will be treated as constants (fixed at the value specified in @p context).
+///
 /// @param system The system or subsystem to linearize.
 /// @param context Defines the nominal operating point about which the system
 /// should be linearized.
+/// @param input_port_index A valid input port index for @p system or kNoInput
+/// or (default) kUseFirstInputIfItExists.
+/// @param output_port_index A valid output port index for @p system or
+/// kNoOutput or (default) kUseFirstOutputIfItExists.
 /// @returns An AffineSystem at this linearization point.
+/// @throws std::runtime_error if the system if the system is not (only)
+/// continuous or (only) discrete time with a single periodic update.
 ///
 /// Note that x, u and y are in the same coordinate system as the original
 /// @p system, since the terms involving x0, u0 reside in f0.
 ///
 /// @ingroup primitive_systems
 ///
+// Note: The TypeSafeIndices (InputPortIndex and OutputPortIndex) didn't let
+// me handle the additional options without a lot of boilerplate.
 std::unique_ptr<AffineSystem<double>> FirstOrderTaylorApproximation(
-    const System<double>& system, const Context<double>& context);
+    const System<double>& system, const Context<double>& context,
+    int input_port_index = kUseFirstInputIfItExists,
+    int output_port_index = kUseFirstOutputIfItExists);
 
 /// Returns the controllability matrix:  R = [B, AB, ..., A^{n-1}B].
 /// @ingroup control_systems


### PR DESCRIPTION
generalize (and cleanup) linearize methods to support using a subset of the total available input/output ports
also adds support for linearizing systems with no state (which admittedly we haven't needed yet).

this is needed in order to linearize the rigid body plant, since RBP has lots of outputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8165)
<!-- Reviewable:end -->
