### PR TITLE
compliant contact model supports autodiff

### DIFF
--- a/math/autodiff.h
+++ b/math/autodiff.h
@@ -36,17 +36,19 @@ typename AutoDiffToValueMatrix<Derived>::type autoDiffToValueMatrix(
   return ret;
 }
 
-/** `B = discardGradient(A)` enables casting from a matrix of AutoDiffScalars
+/** `B = DiscardGradient(A)` enables casting from a matrix of AutoDiffScalars
  * to AutoDiffScalar::Scalar type, explicitly throwing away any gradient
  * information. For a matrix of type, e.g. `MatrixX<AutoDiffXd> A`, the
  * comparable operation
  *   `B = A.cast<double>()`
- * should (and does) fail to compile.  Use discardGradient(A) if you want to
+ * should (and does) fail to compile.  Use `DiscardGradient(A)` if you want to
  * force the cast (and explicitly declare that information is lost).
  *
  * This method is overloaded to permit the user to call it for double types and
  * AutoDiffScalar types (to avoid the calling function having to handle the
  * two cases differently).
+ *
+ * @see DiscardZeroGradient
  */
 template <typename Derived>
 typename std::enable_if<
@@ -62,9 +64,7 @@ DiscardGradient(const Eigen::MatrixBase<Derived>& auto_diff_matrix) {
 template <typename Derived>
 typename std::enable_if<
     std::is_same<typename Derived::Scalar, double>::value,
-    Eigen::Matrix<typename Derived::Scalar, Derived::RowsAtCompileTime,
-                  Derived::ColsAtCompileTime, 0, Derived::MaxRowsAtCompileTime,
-                  Derived::MaxColsAtCompileTime>>::type
+    const Eigen::MatrixBase<Derived>&>::type
 DiscardGradient(const Eigen::MatrixBase<Derived>& matrix) {
   return matrix;
 }
@@ -83,11 +83,13 @@ DiscardGradient(const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>&
 /// @see DiscardGradient().
 template <typename _Scalar, int _Dim, int _Mode, int _Options>
 typename std::enable_if<std::is_same<_Scalar, double>::value,
-                        Eigen::Transform<_Scalar, _Dim, _Mode, _Options>>::type
+                        const Eigen::Transform<_Scalar, _Dim, _Mode,
+    _Options>&>::type
 DiscardGradient(
     const Eigen::Transform<_Scalar, _Dim, _Mode, _Options>& transform) {
   return transform;
 }
+
 
 /** \brief Initialize a single autodiff matrix given the corresponding value
  *matrix.

--- a/math/test/autodiff_test.cc
+++ b/math/test/autodiff_test.cc
@@ -10,6 +10,9 @@
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::AutoDiffScalar;
 
 namespace drake {
 namespace math {
@@ -86,7 +89,7 @@ TEST_F(AutodiffTest, ToGradientMatrix) {
       << gradients;
 }
 
-GTEST_TEST(DiscardGradientTest, discardGradient) {
+GTEST_TEST(AdditionalAutodiffTest, DiscardGradient) {
   // Test the double case:
   Eigen::Matrix2d test = Eigen::Matrix2d::Identity();
   EXPECT_TRUE(CompareMatrices(DiscardGradient(test), test));
@@ -95,7 +98,7 @@ GTEST_TEST(DiscardGradientTest, discardGradient) {
   EXPECT_TRUE(CompareMatrices(DiscardGradient(test2), test2));
 
   // Test the AutoDiff case
-  Eigen::Matrix<AutoDiffXd, 3, 1> test3 = test2;
+  Vector3<AutoDiffXd> test3 = test2;
   // Note:  Neither of these would compile:
   //   Eigen::Vector3d test3out = test3;
   //   Eigen::Vector3d test3out = test3.cast<double>();
@@ -119,6 +122,82 @@ GTEST_TEST(DiscardGradientTest, discardGradient) {
   EXPECT_TRUE(CompareMatrices(test6b.rotation(), Eigen::Matrix3d::Identity()));
   EXPECT_TRUE(
       CompareMatrices(test6b.translation(), Eigen::Vector3d{3., 2., 1.}));
+}
+
+GTEST_TEST(AdditionalAutodiffTest, DiscardZeroGradient) {
+  // Test the double case:
+  Eigen::Matrix2d test = Eigen::Matrix2d::Identity();
+  EXPECT_NO_THROW(DiscardZeroGradient(test));
+  EXPECT_TRUE(CompareMatrices(DiscardZeroGradient(test), test));
+
+  Eigen::MatrixXd test2 = Eigen::Vector3d{1., 2., 3.};
+  EXPECT_NO_THROW(DiscardZeroGradient(test2));
+  EXPECT_TRUE(CompareMatrices(DiscardZeroGradient(test2), test2));
+  // Check that the returned value is a reference to the original data.
+  EXPECT_EQ(&DiscardZeroGradient(test2), &test2);
+
+  // Test the AutoDiff case
+  Eigen::Matrix<AutoDiffXd, 3, 1> test3 = test2;
+  EXPECT_NO_THROW(DiscardZeroGradient(test3));
+  // Note:  Neither of these would compile:
+  //   Eigen::Vector3d test3out = test3;
+  //   Eigen::Vector3d test3out = test3.cast<double>();
+  // (so even compiling is a success).
+  Eigen::Vector3d test3out = DiscardZeroGradient(test3);
+  EXPECT_TRUE(CompareMatrices(test3out, test2));
+  test3 =
+      initializeAutoDiffGivenGradientMatrix(test2, Eigen::MatrixXd::Zero(3, 2));
+  EXPECT_TRUE(CompareMatrices(DiscardZeroGradient(test3), test2));
+  test3 =
+      initializeAutoDiffGivenGradientMatrix(test2, Eigen::MatrixXd::Ones(3, 2));
+  EXPECT_THROW(DiscardZeroGradient(test3), std::runtime_error);
+  EXPECT_NO_THROW(DiscardZeroGradient(test3, 2.));
+
+  VectorX<AutoDiffUpTo73d> test4 = VectorX<AutoDiffUpTo73d>::Ones(4);
+  EXPECT_NO_THROW(DiscardZeroGradient(test4));
+  Eigen::Vector4d test4b = DiscardZeroGradient(test4);
+  EXPECT_TRUE(CompareMatrices(test4b, Eigen::Vector4d::Ones()));
+
+  Eigen::Isometry3d test5 = Eigen::Isometry3d::Identity();
+  EXPECT_NO_THROW(DiscardZeroGradient(test5));
+  EXPECT_TRUE(
+      CompareMatrices(DiscardZeroGradient(test5).linear(), test5.linear()));
+  EXPECT_TRUE(CompareMatrices(DiscardZeroGradient(test5).translation(),
+                              test5.translation()));
+  // Check that the returned value is a reference to the original data.
+  EXPECT_EQ(&DiscardZeroGradient(test5), &test5);
+
+  Isometry3<AutoDiffXd> test6 = Isometry3<AutoDiffXd>::Identity();
+  test6.translate(Vector3<AutoDiffXd>{3., 2., 1.});
+  EXPECT_NO_THROW(DiscardZeroGradient(test5));
+  Eigen::Isometry3d test6b = DiscardZeroGradient(test6);
+  EXPECT_TRUE(CompareMatrices(test6b.linear(), Eigen::Matrix3d::Identity()));
+  EXPECT_TRUE(
+      CompareMatrices(test6b.translation(), Eigen::Vector3d{3., 2., 1.}));
+  test6.linear()(0, 0).derivatives() = Vector3d{1., 2., 3.};
+
+  EXPECT_THROW(DiscardZeroGradient(test6), std::runtime_error);
+}
+
+// Make sure that casting to autodiff always results in zero gradients.
+GTEST_TEST(AdditionalAutodiffTest, CastToAutoDiff) {
+  Vector2<AutoDiffXd> dynamic = Vector2d::Ones().cast<AutoDiffXd>();
+  const auto dynamic_gradients = autoDiffToGradientMatrix(dynamic);
+  EXPECT_EQ(dynamic_gradients.rows(), 2);
+  EXPECT_EQ(dynamic_gradients.cols(), 0);
+
+  Vector2<AutoDiffUpTo73d> dynamic_max =
+      Vector2d::Ones().cast<AutoDiffUpTo73d>();
+  const auto dynamic_max_gradients = autoDiffToGradientMatrix(dynamic_max);
+  EXPECT_EQ(dynamic_max_gradients.rows(), 2);
+  EXPECT_EQ(dynamic_max_gradients.cols(), 0);
+
+  Vector2<AutoDiffScalar<Vector3d>> fixed =
+      Vector2d::Ones().cast<AutoDiffScalar<Vector3d>>();
+  const auto fixed_gradients = autoDiffToGradientMatrix(fixed);
+  EXPECT_EQ(fixed_gradients.rows(), 2);
+  EXPECT_EQ(fixed_gradients.cols(), 3);
+  EXPECT_TRUE(fixed_gradients.isZero(0.));
 }
 
 }  // namespace

--- a/multibody/rigid_body_plant/compliant_contact_model.cc
+++ b/multibody/rigid_body_plant/compliant_contact_model.cc
@@ -4,6 +4,8 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/default_scalars.h"
+#include "drake/math/autodiff.h"
 #include "drake/math/orthonormal_basis.h"
 #include "drake/multibody/collision/element.h"
 #include "drake/multibody/rigid_body_plant/compliant_material.h"
@@ -38,8 +40,8 @@ void CompliantContactModel<T>::set_model_parameters(
 
 template <typename T>
 VectorX<T> CompliantContactModel<T>::ComputeContactForce(
-    const RigidBodyTree<T>& tree,
-    const KinematicsCache<T>& kinsol, ContactResults<T>* contacts) const {
+    const RigidBodyTree<double>& tree, const KinematicsCache<T>& kinsol,
+    ContactResults<T>* contacts) const {
   using std::sqrt;
 
   // TODO(amcastro-tri): get rid of this const_cast.
@@ -47,9 +49,9 @@ VectorX<T> CompliantContactModel<T>::ComputeContactForce(
   // when updating the collision element poses.
   // TODO(naveenoid) : This method call limits the template instanziation of
   // this class currently to T = double only.
-  std::vector<drake::multibody::collision::PointPair<double>> pairs =
-      const_cast<RigidBodyTree<T>*>(&tree)->ComputeMaximumDepthCollisionPoints(
-          kinsol, true);
+  std::vector<drake::multibody::collision::PointPair<T>> pairs =
+      const_cast<RigidBodyTree<double>*>(&tree)
+          ->ComputeMaximumDepthCollisionPoints(kinsol, true, false);
 
   VectorX<T> contact_force(kinsol.getV().rows(), 1);
   contact_force.setZero();
@@ -57,6 +59,18 @@ VectorX<T> CompliantContactModel<T>::ComputeContactForce(
   //  as a zero-force contact.
   for (const auto& pair : pairs) {
     if (pair.distance < 0.0) {  // There is contact.
+      if (!std::is_same<T, double>::value) {
+        // TODO(russt): Consider handling some important special
+        // cases.  For instance, if a point contact on a robot is
+        // colliding with a static object in the world, then there
+        // should be no lost gradient information (the gradients with
+        // respect to the point on the robot are zero, and the forces
+        // on the static object will have no effect).
+        throw std::runtime_error(
+            "Contact occurred.  Gradient information "
+            "would have been inaccurate.");
+      }
+
       CompliantMaterial parameters;
       const double s_a =
           CalcContactParameters(*pair.elementA, *pair.elementB, &parameters);
@@ -261,8 +275,9 @@ double CompliantContactModel<T>::CalcContactParameters(
   return s_a;
 }
 
-// Explicit instantiates on the most common scalar types
-template class CompliantContactModel<double>;
-
 }  // namespace systems
 }  // namespace drake
+
+// Explicitly instantiates on the most common scalar types.
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::systems::CompliantContactModel)

--- a/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -1253,7 +1253,7 @@ void RigidBodyPlant<T>::DoMapQDotToVelocity(
   // TODO(amcastro-tri): Remove .eval() below once RigidBodyTree is fully
   // templatized.
   generalized_velocity->SetFromVector(
-      tree_->transformQDotToVelocity(kinsol, qdot));
+    tree_->transformQDotToVelocity(kinsol, qdot.eval()));
 }
 
 template <typename T>

--- a/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
+++ b/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
@@ -5,6 +5,7 @@
 #include <Eigen/Geometry>
 #include <gtest/gtest.h>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/multibody/joints/quaternion_floating_joint.h"
 #include "drake/multibody/rigid_body_plant/compliant_material.h"
@@ -44,45 +45,48 @@ namespace {
 
 // Base class for testing the CompliantContactModel logic for contact force
 // computations.
-class CompliantContactModelTest : public ContactResultTestCommon {
+template <typename T>
+class CompliantContactModelTest : public ContactResultTestCommon<T> {
  protected:
-  const ContactResults<double>& RunTest(double distance) override {
-    unique_tree_ = GenerateTestTree(distance);
+  const ContactResults<T>& RunTest(double distance) override {
+    unique_tree_ = this->GenerateTestTree(distance);
     // Populate the CompliantContactModel.
-    compliant_contact_model_ =
-        make_unique<CompliantContactModel<double>>();
-    CompliantMaterial material = MakeDefaultMaterial();
+    compliant_contact_model_ = make_unique<CompliantContactModel<T>>();
+    CompliantMaterial material = this->MakeDefaultMaterial();
     compliant_contact_model_->set_default_material(material);
     CompliantContactModelParameters contact_parameters;
-    contact_parameters.v_stiction_tolerance = kVStictionTolerance;
-    contact_parameters.characteristic_radius = kContactRadius;
+    contact_parameters.v_stiction_tolerance = this->kVStictionTolerance;
+    contact_parameters.characteristic_radius = this->kContactRadius;
     compliant_contact_model_->set_model_parameters(contact_parameters);
 
     // The state to test is the default state of the tree (0 velocities
     // and default configuration positions of the tree)
 
-    VectorX<double> q0 = VectorX<double>::Zero(
-        unique_tree_->get_num_positions());
+    VectorX<T> q0 = VectorX<T>::Zero(unique_tree_->get_num_positions());
 
-    VectorXd v0 = VectorXd::Zero(unique_tree_->get_num_velocities());
+    VectorX<T> v0 = VectorX<T>::Zero(unique_tree_->get_num_velocities());
 
     q0 = unique_tree_->getZeroConfiguration();
     auto kinsol = unique_tree_->doKinematics(q0, v0);
 
     compliant_contact_model_->ComputeContactForce(*unique_tree_.get(), kinsol,
-                                                  &contact_results_);
-    return contact_results_;
+                                                  &(this->contact_results_));
+    return this->contact_results_;
   }
 
   // Instances owned by the test class.
-  unique_ptr<CompliantContactModel<double>> compliant_contact_model_{};
+  unique_ptr<CompliantContactModel<T>> compliant_contact_model_{};
   // Holds the unique pointer to the tree.
   unique_ptr<RigidBodyTree<double>> unique_tree_{};
 };
 
+using CompliantContactModelTestDouble = CompliantContactModelTest<double>;
+using CompliantContactModelTestAutoDiffXd =
+    CompliantContactModelTest<AutoDiffXd>;
+
 // Confirms a contact result for two non-colliding spheres -- expects no
 // reported collisions.
-TEST_F(CompliantContactModelTest, ModelNoCollision) {
+TEST_F(CompliantContactModelTestDouble, ModelNoCollision) {
   auto& contact_results = RunTest(0.1);
   ASSERT_EQ(contact_results.get_num_contacts(), 0);
 }
@@ -90,14 +94,14 @@ TEST_F(CompliantContactModelTest, ModelNoCollision) {
 // Confirms a contact result for two touching spheres -- expects no reported
 // collisions. For now, osculation is not considered a "contact" for reporting
 // purposes. If the definition changes, this will likewise change.
-TEST_F(CompliantContactModelTest, ModelTouching) {
+TEST_F(CompliantContactModelTestDouble, ModelTouching) {
   auto& contact_results = RunTest(0.0);
   ASSERT_EQ(contact_results.get_num_contacts(), 0);
 }
 
 // Confirms a contact result for two colliding spheres with identical contact
 // material and zero relative velocity.
-TEST_F(CompliantContactModelTest, ModelSingleCollision) {
+TEST_F(CompliantContactModelTestDouble, ModelSingleCollision) {
   const double offset = 0.1;
   auto& contact_results = RunTest(-offset);
   ASSERT_EQ(contact_results.get_num_contacts(), 1);
@@ -147,10 +151,19 @@ TEST_F(CompliantContactModelTest, ModelSingleCollision) {
       CompareMatrices(detail_force.get_application_point(), expected_point));
 }
 
+// Test that the autodiff module throws when collision information is discarded
+// (due to the collision model not supporting AutoDiffXd yet).
+TEST_F(CompliantContactModelTestAutoDiffXd, AutoDiffTest) {
+  EXPECT_NO_THROW(RunTest(0.1));
+  EXPECT_NO_THROW(RunTest(0.0));
+  EXPECT_THROW(RunTest(-0.1), std::runtime_error);
+}
+
 // This class introduces heterogeneous compliant material parameters. It does
 // so by wrapping the tree generation and directly setting element contact
 // parameters.
-class CompliantHeterogeneousModelTest : public CompliantContactModelTest {
+class CompliantHeterogeneousModelTest
+    : public CompliantContactModelTest<double> {
  protected:
   void DoGenerateTestTree(RigidBodyTree<double>*) override {
     EXPECT_EQ(body1_->get_num_collision_elements(), 1);

--- a/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -41,7 +41,7 @@ namespace {
 
 // Base class for testing the RigidBodyPlant's logic for populating its
 // output port for collision response data.
-class ContactResultTest : public ContactResultTestCommon {
+class ContactResultTest : public ContactResultTestCommon<double> {
  protected:
   // Runs the test on the RigidBodyPlant.
   const ContactResults<double>& RunTest(double distance) {

--- a/multibody/rigid_body_plant/test/contact_result_test_common.h
+++ b/multibody/rigid_body_plant/test/contact_result_test_common.h
@@ -29,6 +29,7 @@ template <typename DerivedA, typename DerivedB>
 // Base class for testing the CompliantContactModel class as well as the
 // RigidBodyPlant's logic for populating its output port for collision response
 // data.
+template <typename T>
 class ContactResultTestCommon : public ::testing::Test {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultTestCommon)
@@ -114,7 +115,7 @@ class ContactResultTestCommon : public ::testing::Test {
   }
 
   // Abstract method to be implemented by child classes.
-  virtual const ContactResults<double>& RunTest(double distance) = 0;
+  virtual const ContactResults<T>& RunTest(double distance) = 0;
 
   // These pointers are merely reference pointers; the underlying instances
   //  are owned by objects which, ultimately, are owned by the test class.
@@ -125,7 +126,7 @@ class ContactResultTestCommon : public ::testing::Test {
   //  x-axis from this point.
   double x_anchor_{};
 
-  ContactResults<double> contact_results_{};
+  ContactResults<T> contact_results_{};
 };
 
 }  // namespace test

--- a/multibody/rigid_body_tree.h
+++ b/multibody/rigid_body_tree.h
@@ -932,11 +932,33 @@ class RigidBodyTree {
     }
   }
 
+  /**
+   * Updates the collision elements registered with the collision detection 
+   * engine.  Note: If U is not a double then the transforms from kinematics
+   * cache will be forcefully cast to doubles (discarding any gradient
+   * information).  Callers that set @p throw_if_missing_gradient to
+   * `false` are responsible for ensuring that future code is secure despite all
+   * gradients with respect to the collision engine being arbitrarily set to
+   * zero.
+   * @see ComputeMaximumDepthCollisionPoints for an example.
+   *
+   * @throws std::runtime_error based on the criteria of DiscardZeroGradient() 
+   * only if @p throws_if_missing_gradient is true.
+   */
+  template <typename U>
   void updateCollisionElements(
       const RigidBody<T>& body,
-      const Eigen::Transform<double, 3, Eigen::Isometry>& transform_to_world);
+      const Eigen::Transform<U, 3, Eigen::Isometry>& transform_to_world,
+      bool throw_if_missing_gradient = true);
 
-  void updateDynamicCollisionElements(const KinematicsCache<double>& kin_cache);
+  /**
+   * @see updateCollisionElements 
+   * @throws std::runtime_error based on the criteria of DiscardZeroGradient() 
+   * only if @p throws_if_missing_gradient is true.
+   */
+  template <typename U>
+  void updateDynamicCollisionElements(const KinematicsCache<U>& kin_cache,
+                                      bool throw_if_missing_gradient = true);
 
   /**
    * Gets the contact points defined by a body's collision elements.
@@ -1113,12 +1135,17 @@ class RigidBodyTree {
    surface of each body is stored in the PointPair structure in the frame of the
    corresponding body.
 
-   @param use_margins[in] If `true` the model uses the representation with
+   @param[in] use_margins If `true` the model uses the representation with
    margins. If `false`, the representation without margins is used instead.
+
+   @throws std::runtime_error based on the criteria of DiscardZeroGradient() 
+   only if @p throws_if_missing_gradient is true.
    **/
-  std::vector<drake::multibody::collision::PointPair<double>>
-  ComputeMaximumDepthCollisionPoints(const KinematicsCache<double>& cache,
-                                     bool use_margins = true);
+  template <typename U>
+  std::vector<drake::multibody::collision::PointPair<U>>
+  ComputeMaximumDepthCollisionPoints(const KinematicsCache<U>& cache,
+                                     bool use_margins = true, bool
+                                     throw_if_missing_gradient = true);
 
   virtual bool collidingPointsCheckOnly(
       const KinematicsCache<double>& cache,

--- a/multibody/rigid_body_tree_contact.cc
+++ b/multibody/rigid_body_tree_contact.cc
@@ -170,7 +170,8 @@ void RigidBodyTree<T>::accumulateContactJacobian(
   const size_t numCB = cindB.size();
   const size_t offset = 3 * numCA;
 
-  auto J_tmp = transformPointsJacobian(cache, bodyPoints, bodyInd, 0, true);
+  auto J_tmp = transformPointsJacobian(
+      cache, bodyPoints.template cast<Scalar>().eval(), bodyInd, 0, true);
 
   // add contributions from points in xA
   for (size_t x = 0; x < numCA; x++) {

--- a/multibody/test/benchmark_rigid_body_tree.cc
+++ b/multibody/test/benchmark_rigid_body_tree.cc
@@ -69,8 +69,9 @@ void Scenario1(const RigidBodyTree<double>& model,
     cache.initialize(q);
     model.doKinematics(cache, false);
     for (const auto& pair : body_fixed_points) {
-      auto J = model.transformPointsJacobian(cache, pair.second, pair.first, 0,
-                                             false);
+      auto J = model.transformPointsJacobian(cache, pair.second.cast<Scalar>
+                                                 ().eval(),
+                                             pair.first, 0, false);
       if (uniform(generator) < 1e-15) {
         // print with some probability to avoid optimizing away
         printMatrix<decltype(J)::RowsAtCompileTime,


### PR DESCRIPTION
rigid_body_tree collision checks support autodiff, but throw if the gradient information is insufficient

this is the interesting one, which handles gradient information loss into/out of the collision engine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8175)
<!-- Reviewable:end -->
