### PR TITLE
Disable a test case that fails under valgrind

### DIFF
--- a/multibody/multibody_tree/test/floating_body_test.cc
+++ b/multibody/multibody_tree/test/floating_body_test.cc
@@ -24,7 +24,7 @@ using Eigen::Vector4d;
 using systems::Context;
 using systems::RungeKutta3Integrator;
 
-GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
+GTEST_TEST(QuaternionFloatingMobilizer, DISABLED_Simulation) {
   const double kEpsilon = std::numeric_limits<double>::epsilon();
   const double kAccuracy = 1.0e-5;  // The integrator's desired accuracy.
   // The numerical tolerance accepted for these tests.


### PR DESCRIPTION
In #8135 a few days ago we added a new unit test case; it fails 100% of the time under valgrind.  This disables the test until it can be repaired.

Issue #8177 tracks re-enabling the test case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8176)
<!-- Reviewable:end -->
