### PR TITLE
Fix warnings about redefinition of _FORTIFY_SOURCE on macOS

### DIFF
--- a/tools/cc_toolchain/CROSSTOOL
+++ b/tools/cc_toolchain/CROSSTOOL
@@ -295,6 +295,7 @@ toolchain {
   tool_path { name: "objdump" path: "/usr/bin/objdump" }
   tool_path { name: "strip" path: "/usr/bin/strip" }
   needsPic: false
+  compiler_flag: "-U_FORTIFY_SOURCE"
   compiler_flag: "-D_FORTIFY_SOURCE=1"
   compiler_flag: "-fstack-protector"
   compiler_flag: "-fcolor-diagnostics"
@@ -317,6 +318,7 @@ toolchain {
     mode: OPT
     compiler_flag: "-g0"
     compiler_flag: "-O2"
+    compiler_flag: "-U_FORTIFY_SOURCE"
     compiler_flag: "-D_FORTIFY_SOURCE=1"
     compiler_flag: "-DNDEBUG"
     compiler_flag: "-ffunction-sections"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8183)
<!-- Reviewable:end -->
