### PR TITLE
Disable pardiso support in OSQP

### DIFF
--- a/tools/workspace/osqp/package.BUILD.bazel
+++ b/tools/workspace/osqp/package.BUILD.bazel
@@ -24,7 +24,6 @@ cmake_configure_file(
         "CTRLC",
         "DFLOAT",
         "DLONG",
-        "ENABLE_MKL_PARDISO",
     ] + select({
         "@drake//tools/cc_toolchain:apple": [
             "IS_MAC",
@@ -40,10 +39,6 @@ cmake_configure_file(
 cc_binary(
     name = "libdrake_osqp.so",
     srcs = glob([
-        "lin_sys/*.c",
-        "lin_sys/*.h",
-        "lin_sys/direct/pardiso/*.c",
-        "lin_sys/direct/pardiso/*.h",
         "lin_sys/direct/suitesparse/*.c",
         "lin_sys/direct/suitesparse/*.h",
         "lin_sys/direct/suitesparse/amd/src/*.c",


### PR DESCRIPTION
OSQP's support for pardiso involves dlopen'ing a pardiso shared library; in general, Drake does not have access to such a thing, so this code had no practical effect.  However, it did have the downside of adding a dependency on dlopen, and worse not declaring `-ldl` as a build-time dependency.  Instead of adding `-ldl`, we choose to disable pardiso until such a time as we need it, and have CI support for pardiso.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8190)
<!-- Reviewable:end -->
