### PR TITLE
Call SetSolverId only in MathematicalProgramSolverInterface

### DIFF
--- a/solvers/equality_constrained_qp_solver.cc
+++ b/solvers/equality_constrained_qp_solver.cc
@@ -265,7 +265,8 @@ SolutionResult EqualityConstrainedQPSolver::Solve(
     }
   }
   prog.SetOptimalCost(optimal_cost);
-  prog.SetSolverId(id());
+
+  SetSolverIdInsideMathematicalProgram(&prog);
   // Make sure solver_result is set.
   DRAKE_DEMAND(!!solver_result);
   return *solver_result;

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -832,7 +832,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
     }
   }
 
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
 
   GRBfreemodel(model);
   GRBfreeenv(env);

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -386,8 +386,6 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
                                  IpoptCalculatedQuantities* ip_cq) {
     unused(z_L, z_U, m, g, lambda, ip_data, ip_cq);
 
-    problem_->SetSolverId(IpoptSolver::id());
-
     switch (status) {
       case Ipopt::SUCCESS: {
         result_ = SolutionResult::kSolutionFound;
@@ -539,6 +537,7 @@ SolutionResult IpoptSolver::Solve(MathematicalProgram& prog) const {
   Ipopt::SmartPtr<IpoptSolver_NLP> nlp = new IpoptSolver_NLP(&prog);
   status = app->OptimizeTNLP(nlp);
 
+  SetSolverIdInsideMathematicalProgram(&prog);
   return nlp->result();
 }
 

--- a/solvers/linear_system_solver.cc
+++ b/solvers/linear_system_solver.cc
@@ -51,7 +51,8 @@ SolutionResult LinearSystemSolver::Solve(MathematicalProgram& prog) const {
       Aeq.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(beq);
   prog.SetDecisionVariableValues(least_square_sol);
 
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
+
   if (beq.isApprox(Aeq * least_square_sol)) {
     prog.SetOptimalCost(0.);
     return SolutionResult::kSolutionFound;

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2115,8 +2115,19 @@ class MathematicalProgram {
 
   /**
    * Sets the ID of the solver that was used to solve this program.
+   * @Note This method is only meant to be called by the solver, as a child
+   * class of MathematicalProgramSolverInterface. If you want to solve the 
+   * program using a specific solver, do
+   * \code{cc}
+   * solver.Solve(program);
+   * \endcode
+   *
+   * We use passkey idiom to restrict that this function can only be called
+   * inside MathematicalProgramSolverInterface. Notice that SetSolverIdKey
+   * has a private constructor, and it is a friend of
+   * MathematicalProgramSolverInterface.
    */
-  void SetSolverId(SolverId solver_id) { solver_id_ = solver_id; }
+  void SetSolverId(const SetSolverIdKey& key) { solver_id_ = key.solver_id(); }
 
   /**
    * Returns the ID of the solver that was used to solve this program.

--- a/solvers/mathematical_program_solver_interface.cc
+++ b/solvers/mathematical_program_solver_interface.cc
@@ -1,3 +1,13 @@
 #include "drake/solvers/mathematical_program_solver_interface.h"
 
-// This is an empty file, to make sure the header parses on its own.
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+void MathematicalProgramSolverInterface::SetSolverIdInsideMathematicalProgram(
+    MathematicalProgram* prog) const {
+  SetSolverIdKey key(solver_id());
+  prog->SetSolverId(key);
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/mathematical_program_solver_interface.h
+++ b/solvers/mathematical_program_solver_interface.h
@@ -43,6 +43,31 @@ class MathematicalProgramSolverInterface {
 
   /// Returns the identifier of this solver.
   virtual SolverId solver_id() const = 0;
+
+  /// Sets the solver ID inside MathematicalProgram
+  void SetSolverIdInsideMathematicalProgram(MathematicalProgram* prog) const;
+};
+
+/**
+ * This class is used for calling MathematicalProgram::SetSolverId(...).
+ * It has private constuctor, and is a friend of
+ * MathematicalProgramSolverInterface, so only
+ * MathematicalProgramSolverInterface can call
+ * MathematicalProgram::SetSolverId()
+ */
+class SetSolverIdKey {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SetSolverIdKey)
+
+  SolverId solver_id() const { return solver_id_; }
+ private:
+  explicit SetSolverIdKey(const SolverId& id) : solver_id_(id) {}
+
+  SetSolverIdKey() = delete;
+
+  friend MathematicalProgramSolverInterface;
+
+  const SolverId solver_id_;
 };
 
 }  // namespace solvers

--- a/solvers/moby_lcp_solver.cc
+++ b/solvers/moby_lcp_solver.cc
@@ -215,7 +215,7 @@ SolutionResult MobyLCPSolver<T>::Solve(MathematicalProgram& prog) const {
   // internally.
 
   // We don't actually indicate different results.
-  prog.SetSolverId(MobyLcpSolverId::id());
+  SetSolverIdInsideMathematicalProgram(&prog);
 
   for (const auto& binding : bindings) {
     Eigen::VectorXd constraint_solution(binding.GetNumElements());

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -777,7 +777,8 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
     }
   }
 
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
+
   if (rescode != MSK_RES_OK) {
     result = SolutionResult::kUnknownError;
   }

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -477,7 +477,7 @@ SolutionResult NloptSolver::Solve(MathematicalProgram& prog) const {
   }
 
   prog.SetOptimalCost(minf);
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
   return result;
 }
 

--- a/solvers/osqp_solver.cc
+++ b/solvers/osqp_solver.cc
@@ -299,7 +299,7 @@ SolutionResult OsqpSolver::Solve(MathematicalProgram& prog) const {
   c_free(data);
   c_free(settings);
 
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
   return solution_result;
 }
 }  // namespace solvers

--- a/solvers/scs_solver.cc
+++ b/solvers/scs_solver.cc
@@ -641,7 +641,7 @@ SolutionResult ScsSolver::Solve(MathematicalProgram& prog) const {
   scs_free_data(scs_problem_data, cone);
   scs_free_sol(scs_sol);
 
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
   return sol_result;
 }
 }  // namespace solvers

--- a/solvers/snopt_solver.cc
+++ b/solvers/snopt_solver.cc
@@ -754,7 +754,7 @@ SolutionResult SnoptSolver::Solve(MathematicalProgram& prog) const {
   }
   prog.SetDecisionVariableValues(sol);
   prog.SetOptimalCost(*F);
-  prog.SetSolverId(id());
+  SetSolverIdInsideMathematicalProgram(&prog);
 
   // todo: extract the other useful quantities, too.
 


### PR DESCRIPTION
Some users were confused by `MathematicalProgram::SetSolverId(...)`, regarding it as specifying which solver to be used, for solving the optimization program; while this function should only be called inside `MathematicalProgramSolverInterface`, after solving the optimization program.

This PR uses the [passkey idiom](https://www.spiria.com/en/blog/desktop-software/passkey-idiom-and-better-friendship-c), that restrict the access to `SetSolverId` to `MathematicalProgramSolverInterface`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8193)
<!-- Reviewable:end -->
