### PR TITLE
Implements a workaround for using contact visualization with drake_visualizer

### DIFF
--- a/multibody/rigid_body_plant/visualization/contact_viz.py
+++ b/multibody/rigid_body_plant/visualization/contact_viz.py
@@ -27,9 +27,6 @@ class ContactVisualizer(object):
             'CONTACT_RESULTS',
             messageClass=lcmdrakemsg.lcmt_contact_results_for_viz,
             callback=self.handle_message)
-        # Limits the rate of message handling, since redrawing is done in the
-        # message handler.
-        self._sub.setSpeedLimit(30)
         print self._name + " subscriber added."
 
     def remove_subscriber(self):
@@ -52,6 +49,10 @@ class ContactVisualizer(object):
             self.remove_subscriber()
 
     def handle_message(self, msg):
+        # Limits the rate of message handling, since redrawing is done in the
+        # message handler.
+        self._sub.setSpeedLimit(30)
+
         # Removes the folder completely.
         om.removeFromObjectModel(om.findObjectByName(self._folder_name))
 


### PR DESCRIPTION
Implements a workaround for using contact visualization with drake's pre-compiled drake_visualizer, which needs to be updated per #7851.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8195)
<!-- Reviewable:end -->
