### PR TITLE
Add ability to alter the mirrors used in workspace

### DIFF
--- a/tools/workspace/bitbucket.bzl
+++ b/tools/workspace/bitbucket.bzl
@@ -7,6 +7,7 @@ def bitbucket_archive(
         sha256 = None,
         strip_prefix = None,
         build_file = None,
+        mirrors = None,
         **kwargs):
     """A macro to be called in the WORKSPACE that adds an external from
     bitbucket using a workspace rule.
@@ -27,6 +28,11 @@ def bitbucket_archive(
 
     The optional build_file= is the BUILD file label to use for building this
     external.  When omitted, the BUILD file(s) within the archive will be used.
+
+    The required mirrors= is a dict from string to list-of-string with key
+    "bitbucket", where the list-of-strings are URLs to use, formatted using
+    {repository} and {commit} string substitutions.  The mirrors.bzl file
+    in this directory provides a reasonable default value.
     """
     if repository == None:
         fail("Missing repository=")
@@ -38,15 +44,13 @@ def bitbucket_archive(
         sha256 = "0" * 64
     if strip_prefix == None:
         fail("Missing strip_prefix=")
+    if mirrors == None:
+        fail("Missing mirrors=; see mirrors.bzl")
 
-    # Packages are mirrored from Bitbucket to CloudFront backed by an S3
-    # bucket.
-    mirrors = [
-        "https://bitbucket.org/%s/get/%s.tar.gz",
-        "https://drake-mirror.csail.mit.edu/bitbucket/%s/%s.tar.gz",
-        "https://s3.amazonaws.com/drake-mirror/bitbucket/%s/%s.tar.gz",
+    urls = [
+        x.format(repository = repository, commit = commit)
+        for x in mirrors.get("bitbucket")
     ]
-    urls = [mirror % (repository, commit) for mirror in mirrors]
 
     repository_split = repository.split("/")
     if len(repository_split) != 2:

--- a/tools/workspace/bullet/repository.bzl
+++ b/tools/workspace/bullet/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def bullet_repository(name):
+def bullet_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "bulletphysics/bullet3",
         commit = "2.86.1",
         sha256 = "c058b2e4321ba6adaa656976c1a138c07b18fc03b29f5b82880d5d8228fbf059",  # noqa
         build_file = "@drake//tools/workspace/bullet:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/ccd/repository.bzl
+++ b/tools/workspace/ccd/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def ccd_repository(name):
+def ccd_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "danfis/libccd",
         commit = "5677d384315d64c41a9e1dabe6a531f10ffbb7fb",
         sha256 = "3b37ef4555d087f7abb6aa59c3b5cecb96410ea10e95a086ef2771569fb6fdfb",  # noqa
         build_file = "@drake//tools/workspace/ccd:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/com_jidesoft_jide_oss/repository.bzl
+++ b/tools/workspace/com_jidesoft_jide_oss/repository.bzl
@@ -1,15 +1,16 @@
 # -*- mode: python -*-
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@drake//tools/workspace:maven.bzl", "MAVEN_BASE_URLS")
 
-def com_jidesoft_jide_oss_repository(name):
+def com_jidesoft_jide_oss_repository(
+        name,
+        mirrors = None):
     java_import_external(
         name = name,
         licenses = [],
         jar_urls = [
-            base + "com/jidesoft/jide-oss/2.9.7/jide-oss-2.9.7.jar"
-            for base in MAVEN_BASE_URLS
+            x.format(fulljar = "com/jidesoft/jide-oss/2.9.7/jide-oss-2.9.7.jar")  # noqa
+            for x in mirrors.get("maven")
         ],
         jar_sha256 = "a2edc2749cf482f6b2b1331f35f0383a1a11c19b1cf6d9a8cf7c69ce4cc8e04b",  # noqa
     )

--- a/tools/workspace/commons_io/repository.bzl
+++ b/tools/workspace/commons_io/repository.bzl
@@ -1,15 +1,16 @@
 # -*- mode: python -*-
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@drake//tools/workspace:maven.bzl", "MAVEN_BASE_URLS")
 
-def commons_io_repository(name):
+def commons_io_repository(
+        name,
+        mirrors = None):
     java_import_external(
         name = name,
         licenses = [],
         jar_urls = [
-            base + "commons-io/commons-io/1.3.1/commons-io-1.3.1.jar"
-            for base in MAVEN_BASE_URLS
+            x.format(fulljar = "commons-io/commons-io/1.3.1/commons-io-1.3.1.jar")  # noqa
+            for x in mirrors.get("maven")
         ],
         jar_sha256 = "3307319ddc221f1b23e8a1445aef10d2d2308e0ec46977b3f17cbb15c0ef335b",  # noqa
     )

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -1,5 +1,6 @@
 # -*- python -*-
 
+load("@drake//tools/workspace:mirrors.bzl", "DEFAULT_MIRRORS")
 load("@drake//tools/workspace/blas:repository.bzl", "blas_repository")
 load("@drake//tools/workspace/boost:repository.bzl", "boost_repository")
 load("@drake//tools/workspace/buildifier:repository.bzl", "buildifier_repository")  # noqa
@@ -61,7 +62,7 @@ load("@drake//tools/workspace/vtk:repository.bzl", "vtk_repository")
 load("@drake//tools/workspace/yaml_cpp:repository.bzl", "yaml_cpp_repository")
 load("@drake//tools/workspace/zlib:repository.bzl", "zlib_repository")
 
-def add_default_repositories(excludes = []):
+def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
     """Declares workspace repositories for all externals needed by drake (other
     than those built into Bazel, of course).  This is intended to be loaded and
     called from a WORKSPACE file.
@@ -76,29 +77,29 @@ def add_default_repositories(excludes = []):
     if "boost" not in excludes:
         boost_repository(name = "boost")
     if "buildifier" not in excludes:
-        buildifier_repository(name = "buildifier")
+        buildifier_repository(name = "buildifier", mirrors = mirrors)
     if "bullet" not in excludes:
-        bullet_repository(name = "bullet")
+        bullet_repository(name = "bullet", mirrors = mirrors)
     if "ccd" not in excludes:
-        ccd_repository(name = "ccd")
+        ccd_repository(name = "ccd", mirrors = mirrors)
     if "com_google_protobuf" not in excludes:
         com_google_protobuf_repository(name = "com_google_protobuf")
     if "com_jidesoft_jide_oss" not in excludes:
-        com_jidesoft_jide_oss_repository(name = "com_jidesoft_jide_oss")
+        com_jidesoft_jide_oss_repository(name = "com_jidesoft_jide_oss", mirrors = mirrors)  # noqa
     if "commons_io" not in excludes:
-        commons_io_repository(name = "commons_io")
+        commons_io_repository(name = "commons_io", mirrors = mirrors)
     if "drake_visualizer" not in excludes:
-        drake_visualizer_repository(name = "drake_visualizer")
+        drake_visualizer_repository(name = "drake_visualizer", mirrors = mirrors)  # noqa
     if "dreal" not in excludes:
         dreal_repository(name = "dreal")
     if "eigen" not in excludes:
-        eigen_repository(name = "eigen")
+        eigen_repository(name = "eigen", mirrors = mirrors)
     if "expat" not in excludes:
         expat_repository(name = "expat")
     if "fcl" not in excludes:
-        fcl_repository(name = "fcl")
+        fcl_repository(name = "fcl", mirrors = mirrors)
     if "fmt" not in excludes:
-        fmt_repository(name = "fmt")
+        fmt_repository(name = "fmt", mirrors = mirrors)
     if "freetype2" not in excludes:
         freetype2_repository(name = "freetype2")
     if "gflags" not in excludes:
@@ -108,27 +109,27 @@ def add_default_repositories(excludes = []):
     if "glib" not in excludes:
         glib_repository(name = "glib")
     if "godotengine" not in excludes:
-        godotengine_repository(name = "godotengine")
+        godotengine_repository(name = "godotengine", mirrors = mirrors)
     if "gtest" not in excludes:
-        gtest_repository(name = "gtest")
+        gtest_repository(name = "gtest", mirrors = mirrors)
     if "gthread" not in excludes:
         gthread_repository(name = "gthread")
     if "gurobi" not in excludes:
         gurobi_repository(name = "gurobi")
     if "ignition_math" not in excludes:
-        ignition_math_repository(name = "ignition_math")
+        ignition_math_repository(name = "ignition_math", mirrors = mirrors)
     if "ignition_rndf" not in excludes:
-        ignition_rndf_repository(name = "ignition_rndf")
+        ignition_rndf_repository(name = "ignition_rndf", mirrors = mirrors)
     if "ipopt" not in excludes:
         ipopt_repository(name = "ipopt")
     if "lapack" not in excludes:
         lapack_repository(name = "lapack")
     if "lcm" not in excludes:
-        lcm_repository(name = "lcm")
+        lcm_repository(name = "lcm", mirrors = mirrors)
     if "lcmtypes_bot2_core" not in excludes:
-        lcmtypes_bot2_core_repository(name = "lcmtypes_bot2_core")
+        lcmtypes_bot2_core_repository(name = "lcmtypes_bot2_core", mirrors = mirrors)  # noqa
     if "lcmtypes_robotlocomotion" not in excludes:
-        lcmtypes_robotlocomotion_repository(name = "lcmtypes_robotlocomotion")
+        lcmtypes_robotlocomotion_repository(name = "lcmtypes_robotlocomotion", mirrors = mirrors)  # noqa
     if "liblz4" not in excludes:
         liblz4_repository(name = "liblz4")
     if "libpng" not in excludes:
@@ -138,55 +139,55 @@ def add_default_repositories(excludes = []):
     if "mosek" not in excludes:
         mosek_repository(name = "mosek")
     if "net_sf_jchart2d" not in excludes:
-        net_sf_jchart2d_repository(name = "net_sf_jchart2d")
+        net_sf_jchart2d_repository(name = "net_sf_jchart2d", mirrors = mirrors)
     if "nlopt" not in excludes:
         nlopt_repository(name = "nlopt")
     if "numpy" not in excludes:
         numpy_repository(name = "numpy")
     if "octomap" not in excludes:
-        octomap_repository(name = "octomap")
+        octomap_repository(name = "octomap", mirrors = mirrors)
     if "optitrack_driver" not in excludes:
-        optitrack_driver_repository(name = "optitrack_driver")
+        optitrack_driver_repository(name = "optitrack_driver", mirrors = mirrors)  # noqa
     if "org_apache_xmlgraphics_commons" not in excludes:
-        org_apache_xmlgraphics_commons_repository(name = "org_apache_xmlgraphics_commons")  # noqa
+        org_apache_xmlgraphics_commons_repository(name = "org_apache_xmlgraphics_commons", mirrors = mirrors)  # noqa
     if "osqp" not in excludes:
-        osqp_repository(name = "osqp")
+        osqp_repository(name = "osqp", mirrors = mirrors)
     if "protoc" not in excludes:
         protoc_repository(name = "protoc")
     if "pybind11" not in excludes:
-        pybind11_repository(name = "pybind11")
+        pybind11_repository(name = "pybind11", mirrors = mirrors)
     if "pycodestyle" not in excludes:
-        pycodestyle_repository(name = "pycodestyle")
+        pycodestyle_repository(name = "pycodestyle", mirrors = mirrors)
     if "pycps" not in excludes:
-        pycps_repository(name = "pycps")
+        pycps_repository(name = "pycps", mirrors = mirrors)
     if "python" not in excludes:
         python_repository(name = "python")
     if "scs" not in excludes:
-        scs_repository(name = "scs")
+        scs_repository(name = "scs", mirrors = mirrors)
     if "sdformat" not in excludes:
-        sdformat_repository(name = "sdformat")
+        sdformat_repository(name = "sdformat", mirrors = mirrors)
     if "semantic_version" not in excludes:
-        semantic_version_repository(name = "semantic_version")
+        semantic_version_repository(name = "semantic_version", mirrors = mirrors)  # noqa
     if "snopt" not in excludes:
         snopt_repository(name = "snopt")
     if "spdlog" not in excludes:
-        spdlog_repository(name = "spdlog")
+        spdlog_repository(name = "spdlog", mirrors = mirrors)
     if "spruce" not in excludes:
         spruce_repository(name = "spruce")
     if "stx" not in excludes:
-        stx_repository(name = "stx")
+        stx_repository(name = "stx", mirrors = mirrors)
     if "styleguide" not in excludes:
-        styleguide_repository(name = "styleguide")
+        styleguide_repository(name = "styleguide", mirrors = mirrors)
     if "tinydir" not in excludes:
-        tinydir_repository(name = "tinydir")
+        tinydir_repository(name = "tinydir", mirrors = mirrors)
     if "tinyobjloader" not in excludes:
-        tinyobjloader_repository(name = "tinyobjloader")
+        tinyobjloader_repository(name = "tinyobjloader", mirrors = mirrors)
     if "tinyxml2" not in excludes:
         tinyxml2_repository(name = "tinyxml2")
     if "tinyxml" not in excludes:
         tinyxml_repository(name = "tinyxml")
     if "vtk" not in excludes:
-        vtk_repository(name = "vtk")
+        vtk_repository(name = "vtk", mirrors = mirrors)
     if "yaml_cpp" not in excludes:
         yaml_cpp_repository(name = "yaml_cpp")
     if "zlib" not in excludes:

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -53,8 +53,8 @@ def _impl(repository_ctx):
         fail("Operating system is NOT supported", attr = os_result)
 
     urls = [
-        "https://drake-packages.csail.mit.edu/director/{}".format(archive),
-        "https://s3.amazonaws.com/drake-packages/director/{}".format(archive),
+        x.format(archive = archive)
+        for x in repository_ctx.attr.mirrors.get("director")
     ]
     root_path = repository_ctx.path("")
 
@@ -102,4 +102,9 @@ install_files(
 
     repository_ctx.file("BUILD", content = file_content, executable = False)
 
-drake_visualizer_repository = repository_rule(implementation = _impl)
+drake_visualizer_repository = repository_rule(
+    attrs = {
+        "mirrors": attr.string_list_dict(),
+    },
+    implementation = _impl,
+)

--- a/tools/workspace/eigen/repository.bzl
+++ b/tools/workspace/eigen/repository.bzl
@@ -2,7 +2,9 @@
 
 load("@drake//tools/workspace:bitbucket.bzl", "bitbucket_archive")
 
-def eigen_repository(name):
+def eigen_repository(
+        name,
+        mirrors = None):
     bitbucket_archive(
         name = name,
         repository = "eigen/eigen",
@@ -11,4 +13,5 @@ def eigen_repository(name):
         sha256 = "94878cbfa27b0d0fbc64c00d4aafa137f678d5315ae62ba4aecddbd4269ae75f",  # noqa
         strip_prefix = "eigen-eigen-67e894c6cd8f",
         build_file = "@drake//tools/workspace/eigen:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/fcl/repository.bzl
+++ b/tools/workspace/fcl/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def fcl_repository(name):
+def fcl_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "flexible-collision-library/fcl",
         commit = "43048336c34a01156dc216e8534ffb2788675ddf",
         sha256 = "fd74916b92ed58e77c06097dc18f545462417daa8c96fa8ea2a5c81cd3205917",  # noqa
         build_file = "@drake//tools/workspace/fcl:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def fmt_repository(name):
+def fmt_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "fmtlib/fmt",
         commit = "3.0.1",
         sha256 = "dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad",  # noqa
         build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/godotengine/repository.bzl
+++ b/tools/workspace/godotengine/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def godotengine_repository(name):
+def godotengine_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "godotengine/godot",
         commit = "9bd402698cfa299b79b9144f8d7744c308a4e085",
         sha256 = "cbec9b48d79b1fdc16a253f438fb06544a59baf71cf2c1f47c193817f2127a10",  # noqa
         build_file = "@drake//tools/workspace/godotengine:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/gtest/repository.bzl
+++ b/tools/workspace/gtest/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def gtest_repository(name):
+def gtest_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "google/googletest",
         commit = "release-1.8.0",
         sha256 = "58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8",  # noqa
         build_file = "@drake//tools/workspace/gtest:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/ignition_math/repository.bzl
+++ b/tools/workspace/ignition_math/repository.bzl
@@ -2,7 +2,9 @@
 
 load("//tools/workspace:bitbucket.bzl", "bitbucket_archive")
 
-def ignition_math_repository(name):
+def ignition_math_repository(
+        name,
+        mirrors = None):
     commit = "568cf1457760"
     bitbucket_archive(
         name = name,
@@ -11,4 +13,5 @@ def ignition_math_repository(name):
         sha256 = "bd0cafb01cc219c5e12c6b049cae44cfa68bb39bdb52a3c79c37f2163d7d4967",  # noqa
         strip_prefix = "ignitionrobotics-ign-math-%s" % (commit),
         build_file = "@drake//tools/workspace/ignition_math:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/ignition_rndf/repository.bzl
+++ b/tools/workspace/ignition_rndf/repository.bzl
@@ -2,7 +2,9 @@
 
 load("//tools/workspace:bitbucket.bzl", "bitbucket_archive")
 
-def ignition_rndf_repository(name):
+def ignition_rndf_repository(
+        name,
+        mirrors = None):
     commit = "0e7c72e6f5f4"
     bitbucket_archive(
         name = name,
@@ -11,4 +13,5 @@ def ignition_rndf_repository(name):
         sha256 = "a90b8e2e53e284df7e2876e999c4232a03a260c5b6c0a553016ba0a9fab934ad",  # noqa
         strip_prefix = "ignitionrobotics-ign-rndf-%s" % (commit),
         build_file = "@drake//tools/workspace/ignition_rndf:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def lcm_repository(name):
+def lcm_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "lcm-proj/lcm",
         commit = "87866bd0dbb1f9d5a0f662a6f5caecf469fd42d2",
         sha256 = "fd0afaf29954c26a725626b7bd24e873e303e84bb62dfcc05162be3f5ae30cd1",  # noqa
         build_file = "@drake//tools/workspace/lcm:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/lcmtypes_bot2_core/repository.bzl
+++ b/tools/workspace/lcmtypes_bot2_core/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def lcmtypes_bot2_core_repository(name):
+def lcmtypes_bot2_core_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = "lcmtypes_bot2_core",
         repository = "openhumanoids/bot_core_lcmtypes",
         commit = "99676541398749c2aab4b5b2c38be77d268085cc",
         sha256 = "896fd3edf87c7dfaae378af12d52d233577cc495ae96b5076c48b5b9ca700b4a",  # noqa
         build_file = "@drake//tools/workspace/lcmtypes_bot2_core:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/lcmtypes_robotlocomotion/repository.bzl
+++ b/tools/workspace/lcmtypes_robotlocomotion/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def lcmtypes_robotlocomotion_repository(name):
+def lcmtypes_robotlocomotion_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = "lcmtypes_robotlocomotion",
         repository = "RobotLocomotion/lcmtypes",
         commit = "8aea7a94d53dea01bfceba5f3cbe8e8cc9fb0244",
         sha256 = "f23a143d7865ea4f6cd9aeb2211fe36e20712a39d439cf16fea2b11685f29b61",  # noqa
         build_file = "@drake//tools/workspace/lcmtypes_robotlocomotion:package.BUILD.bazel",  # noqa
-)
+        mirrors = mirrors,
+    )

--- a/tools/workspace/maven.bzl
+++ b/tools/workspace/maven.bzl
@@ -1,8 +1,0 @@
-# -*- python -*-
-
-# URL prefixes (including the "/") where maven jars can be found.
-MAVEN_BASE_URLS = [
-    "https://jcenter.bintray.com/",
-    "https://repo1.maven.org/maven2/",
-    "http://maven.ibiblio.org/maven2/",  # N.B. ibiblio doesn't offer https.
-]

--- a/tools/workspace/mirrors.bzl
+++ b/tools/workspace/mirrors.bzl
@@ -1,0 +1,56 @@
+# -*- mode: python -*-
+# vi: set ft=python :
+
+# This constant contains Drake's default lists of mirrors.  It is keyed by the
+# repository type using magic strings ("github", "bitbucket", etc.), and has
+# values of type list-of-string; each string is a pattern for a mirror URL.
+#
+# When calling a Drake workspace rule that requires a mirror= argument, this
+# constant is a reasonable default value.
+#
+# Each repository type has its own keyword string substitutions within its
+# pattern string; these will vary from one repository type to another; consult
+# the specific rules (e.g., github_archive()) for details.
+#
+# The first item in each list is the authoritative source (e.g., the upstream
+# server), if there is one.
+#
+# For Drake's defaults, Packages are mirrored from upstream (GitHub, Bitbucket,
+# PyPI, etc.) to CloudFront backed by an S3 bucket.
+#
+DEFAULT_MIRRORS = {
+    "bitbucket": [
+        "https://bitbucket.org/{repository}/get/{commit}.tar.gz",
+        "https://drake-mirror.csail.mit.edu/bitbucket/{repository}/{commit}.tar.gz",  # noqa
+        "https://s3.amazonaws.com/drake-mirror/bitbucket/{repository}/{commit}.tar.gz",  # noqa
+    ],
+    "buildifier": [
+        "https://github.com/bazelbuild/buildtools/releases/download/{version}/{filename}",  # noqa
+        "https://drake-mirror.csail.mit.edu/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
+        "https://s3.amazonaws.com/drake-mirror/github/bazelbuild/buildtools/releases/{version}/{filename}",  # noqa
+    ],
+    "director": [
+        "https://drake-packages.csail.mit.edu/director/{archive}",
+        "https://s3.amazonaws.com/drake-packages/director/{archive}",
+    ],
+    "github": [
+        "https://github.com/{repository}/archive/{commit}.tar.gz",
+        "https://drake-mirror.csail.mit.edu/github/{repository}/{commit}.tar.gz",  # noqa
+        "https://s3.amazonaws.com/drake-mirror/github/{repository}/{commit}.tar.gz",  # noqa
+    ],
+    "maven": [
+        "https://jcenter.bintray.com/{fulljar}",
+        "https://repo1.maven.org/maven2/{fulljar}",
+        # N.B. ibiblio doesn't offer https.
+        "http://maven.ibiblio.org/maven2/{fulljar}",
+    ],
+    "pypi": [
+        "https://files.pythonhosted.org/packages/source/{p}/{package}/{package}-{version}.tar.gz",  # noqa
+        "https://drake-mirror.csail.mit.edu/pypi/{package}/{package}-{version}.tar.gz",  # noqa
+        "https://s3.amazonaws.com/drake-mirror/pypi/{package}/{package}-{version}.tar.gz",  # noqa
+    ],
+    "vtk": [
+        "https://drake-packages.csail.mit.edu/vtk/{archive}",
+        "https://s3.amazonaws.com/drake-packages/vtk/{archive}",
+    ],
+}

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -36,6 +36,7 @@ def _impl(repository_ctx):
         fail("Operating system is NOT supported",
              attr = repository_ctx.os.name)
 
+    # TODO(jwnimmer-tri) Port to use mirrors.bzl.
     url = "http://download.mosek.com/stable/{}/mosektools{}.tar.bz2".format(
         mosek_major_version, mosek_platform)
     root_path = repository_ctx.path("")

--- a/tools/workspace/net_sf_jchart2d/repository.bzl
+++ b/tools/workspace/net_sf_jchart2d/repository.bzl
@@ -1,17 +1,18 @@
 # -*- mode: python -*-
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@drake//tools/workspace:maven.bzl", "MAVEN_BASE_URLS")
 
-def net_sf_jchart2d_repository(name):
+def net_sf_jchart2d_repository(
+        name,
+        mirrors = None):
     # In the unlikely event that you update the version here, verify that the
     # licenses in tools/third_party/jchart2d/LICENSE are still applicable.
     java_import_external(
         name = name,
         licenses = [],
         jar_urls = [
-            base + "net/sf/jchart2d/jchart2d/3.3.2/jchart2d-3.3.2.jar"
-            for base in MAVEN_BASE_URLS
+            x.format(fulljar = "net/sf/jchart2d/jchart2d/3.3.2/jchart2d-3.3.2.jar")  # noqa
+            for x in mirrors.get("maven")
         ],
         jar_sha256 = "41af674b1bb00d8b89a0649ddaa569df5750911b4e33f89b211ae82e411d16cc",  # noqa
     )

--- a/tools/workspace/octomap/repository.bzl
+++ b/tools/workspace/octomap/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def octomap_repository(name):
+def octomap_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "OctoMap/octomap",
         commit = "v1.8.1",
         sha256 = "8b18ef7693e87f1400b9a8bc41f86e3b28259ac98c0b458037232652380aa6af",  # noqa
         build_file = "@drake//tools/workspace/octomap:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/optitrack_driver/repository.bzl
+++ b/tools/workspace/optitrack_driver/repository.bzl
@@ -2,10 +2,13 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def optitrack_driver_repository(name):
+def optitrack_driver_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "RobotLocomotion/optitrack-driver",
         commit = "b0d633570966e08b8915dee0867747596839d06c",
         sha256 = "5f7f46273f36073dc15191fe37dc538b4b23eaeaae63de153abeaa61d1134ad6",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
+++ b/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
@@ -1,15 +1,16 @@
 # -*- mode: python -*-
 
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
-load("@drake//tools/workspace:maven.bzl", "MAVEN_BASE_URLS")
 
-def org_apache_xmlgraphics_commons_repository(name):
+def org_apache_xmlgraphics_commons_repository(
+        name,
+        mirrors = None):
     java_import_external(
         name = name,
         licenses = [],
         jar_urls = [
-            base + "org/apache/xmlgraphics/xmlgraphics-commons/1.3.1/xmlgraphics-commons-1.3.1.jar"  # noqa
-            for base in MAVEN_BASE_URLS
+            x.format(fulljar = "org/apache/xmlgraphics/xmlgraphics-commons/1.3.1/xmlgraphics-commons-1.3.1.jar")  # noqa
+            for x in mirrors.get("maven")
         ],
         jar_sha256 = "7ce0c924c84e2710c162ae1c98f5047d64f528268792aba642d4bae5e1de7181",  # noqa
     )

--- a/tools/workspace/osqp/repository.bzl
+++ b/tools/workspace/osqp/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def osqp_repository(name):
+def osqp_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "oxfordcontrol/osqp",
         commit = "bdc96b409a1e1660e46dadc7f6e5ff1f37d24b89",
         sha256 = "3bbed20b58eeb9c07be3f038dcfadd512f6f1cbbf52c8a55f0fe469ecfd327f6",  # noqa
         build_file = "@drake//tools/workspace/osqp:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/pybind11/repository.bzl
+++ b/tools/workspace/pybind11/repository.bzl
@@ -9,13 +9,16 @@ _COMMIT = "3dcfcb00a440e858211661d179a15904586fb45f"
 
 _SHA256 = "f7ac23089450042ad8cd39bb2b58c14f7aa395683e60d57789aaae1335b21bbb"
 
-def pybind11_repository(name):
+def pybind11_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = _REPOSITORY,
         commit = _COMMIT,
         sha256 = _SHA256,
         build_file = "@drake//tools/workspace/pybind11:package.BUILD.bazel",
+        mirrors = mirrors,
     )
 
 def generate_pybind11_version_py_file(name):

--- a/tools/workspace/pycodestyle/repository.bzl
+++ b/tools/workspace/pycodestyle/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def pycodestyle_repository(name):
+def pycodestyle_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "PyCQA/pycodestyle",
         commit = "2.3.1",
         sha256 = "e9fc1ca3fd85648f45c0d2e33591b608a17d8b9b78e22c5f898e831351bacb03",  # noqa
         build_file = "@drake//tools/workspace/pycodestyle:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/pycps/repository.bzl
+++ b/tools/workspace/pycps/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def pycps_repository(name):
+def pycps_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "mwoehlke/pycps",
         commit = "544c1ded81b926a05b3dedb06504bd17bc8d0a95",
         sha256 = "0b97cbaae107e5ddbe89073b6e42b679130f1eb81b913aa93da9e72e032a137b",  # noqa
         build_file = "@drake//tools/workspace/pycps:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/scs/repository.bzl
+++ b/tools/workspace/scs/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def scs_repository(name):
+def scs_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "cvxgrp/scs",
         commit = "v2.0.2",
         sha256 = "8725291dfe952a1f117f1f725906843db392fe8d29eebd8feb14b49f25fc669e",  # noqa
         build_file = "@drake//tools/workspace/scs:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -2,7 +2,9 @@
 
 load("//tools/workspace:bitbucket.bzl", "bitbucket_archive")
 
-def sdformat_repository(name):
+def sdformat_repository(
+        name,
+        mirrors = None):
     bitbucket_archive(
         name = name,
         repository = "osrf/sdformat",
@@ -10,4 +12,5 @@ def sdformat_repository(name):
         sha256 = "212211eddd9fa010b4b61a2dae87cd84a66a8b78ed302612d214b7388f9bc198",  # noqa
         strip_prefix = "osrf-sdformat-bac3dfb42cc7",
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/semantic_version/repository.bzl
+++ b/tools/workspace/semantic_version/repository.bzl
@@ -2,7 +2,9 @@
 
 load("@drake//tools/workspace:pypi.bzl", "pypi_archive")
 
-def semantic_version_repository(name):
+def semantic_version_repository(
+        name,
+        mirrors = None):
     pypi_archive(
         name = name,
         package = "semantic_version",
@@ -10,4 +12,5 @@ def semantic_version_repository(name):
         sha256 = "2a4328680073e9b243667b201119772aefc5fc63ae32398d6afafff07c4f54c0",  # noqa
         strip_prefix = "semantic_version",
         build_file = "@drake//tools/workspace/semantic_version:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def spdlog_repository(name):
+def spdlog_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "gabime/spdlog",
         commit = "v0.13.0",
         sha256 = "d798a6ca19165f0a18a43938859359269f5a07fd8e0eb83ab8674739c9e8f361",  # noqa
         build_file = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/stx/repository.bzl
+++ b/tools/workspace/stx/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def stx_repository(name):
+def stx_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "tcbrindle/cpp17_headers",
         commit = "5f4e44153d42335c68027ec8e2f84db070837a88",
         sha256 = "c42239a5ce1e74d8464b5a86d7b9257ab6576c2a1b06afa80e69a97c00f7f525",  # noqa
         build_file = "@drake//tools/workspace/stx:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/styleguide/repository.bzl
+++ b/tools/workspace/styleguide/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def styleguide_repository(name):
+def styleguide_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "RobotLocomotion/styleguide",
         commit = "f9fb031554d398431bc0efcb511102d41bbed089",
         sha256 = "1e40f4595406e208de8bde66bc3425e6c0dce4ea96254cc2c7e4105316df9a31",  # noqa
         build_file = "@drake//tools/workspace/styleguide:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/tinydir/repository.bzl
+++ b/tools/workspace/tinydir/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def tinydir_repository(name):
+def tinydir_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "cxong/tinydir",
         commit = "3aae9224376b5e1a23fd824f19d9501162620b53",
         sha256 = "fa7eec0baaa5f6c57df1a38b064ec3a4f098f477f0a64d97c646a4470ffdd3b6",  # noqa
         build_file = "@drake//tools/workspace/tinydir:package.BUILD.bazel",
+        mirrors = mirrors,
     )

--- a/tools/workspace/tinyobjloader/repository.bzl
+++ b/tools/workspace/tinyobjloader/repository.bzl
@@ -2,11 +2,14 @@
 
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
-def tinyobjloader_repository(name):
+def tinyobjloader_repository(
+        name,
+        mirrors = None):
     github_archive(
         name = name,
         repository = "syoyo/tinyobjloader",
         commit = "v1.0.6",
         sha256 = "19ee82cd201761954dd833de551edb570e33b320d6027e0d91455faf7cd4c341",  # noqa
         build_file = "@drake//tools/workspace/tinyobjloader:package.BUILD.bazel",  # noqa
+        mirrors = mirrors,
     )

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -8,8 +8,9 @@ unpacked. On macOS and OS X, VTK must be installed using Homebrew.
 
 Example:
     WORKSPACE:
+        load("@drake//tools/workspace:mirrors.bzl", "DEFAULT_MIRRORS")
         load("@drake//tools/workspace/vtk:repository.bzl", "vtk_repository")
-        vtk_repository(name = "foo")
+        vtk_repository(name = "foo", mirrors = DEFAULT_MIRRORS)
 
     BUILD:
         cc_library(
@@ -89,8 +90,8 @@ def _impl(repository_ctx):
             fail("Operating system is NOT supported", attr = os_result)
 
         urls = [
-            "https://drake-packages.csail.mit.edu/vtk/{}".format(archive),
-            "https://s3.amazonaws.com/drake-packages/vtk/{}".format(archive),
+            x.format(archive = archive)
+            for x in repository_ctx.attr.mirrors.get("vtk")
         ]
         root_path = repository_ctx.path("")
 
@@ -571,4 +572,9 @@ install_files(
 
     repository_ctx.file("BUILD", content = file_content, executable = False)
 
-vtk_repository = repository_rule(implementation = _impl)
+vtk_repository = repository_rule(
+    attrs = {
+        "mirrors": attr.string_list_dict(),
+    },
+    implementation = _impl,
+)


### PR DESCRIPTION
The `tools/workspace/default.bzl` gains a `mirrors` argument that allows changing which mirrors are used.  The argument is passed down to only the repositories that use mirrors; to ensure that's reliably achieved, all of the individual rules and repositories declare `mirrors = None` as an argument and fail if no value was supplied.  Only the `default.bzl` provides a default value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8196)
<!-- Reviewable:end -->
