### PR TITLE
Add reset_on_copy adapter

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -39,6 +39,7 @@ drake_cc_library(
         ":number_traits",
         ":polynomial",
         ":reinit_after_move",
+        ":reset_on_copy",
         ":scoped_singleton",
         ":sorted_vectors_have_intersection",
         ":symbolic",
@@ -330,6 +331,11 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "reset_on_copy",
+    hdrs = ["reset_on_copy.h"],
+)
+
+drake_cc_library(
     name = "sorted_vectors_have_intersection",
     hdrs = ["sorted_vectors_have_intersection.h"],
     deps = [
@@ -474,6 +480,13 @@ drake_cc_googletest(
     name = "reinit_after_move_test",
     deps = [
         ":reinit_after_move",
+    ],
+)
+
+drake_cc_googletest(
+    name = "reset_on_copy_test",
+    deps = [
+        ":reset_on_copy",
     ],
 )
 

--- a/common/reinit_after_move.h
+++ b/common/reinit_after_move.h
@@ -43,6 +43,10 @@ namespace drake {
 /// @tparam T must support CopyConstructible, CopyAssignable, MoveConstructible,
 /// and MoveAssignable and must not throw exceptions during construction or
 /// assignment.
+/// @see reset_on_copy
+
+// TODO(sherm1) Rename this "reset_after_move".
+// TODO(sherm1) Upgrade this to match reset_on_copy (e.g. noexcept).
 template <typename T>
 class reinit_after_move {
  public:
@@ -58,7 +62,7 @@ class reinit_after_move {
 
   /// @name Implements CopyConstructible, CopyAssignable, MoveConstructible,
   /// MoveAssignable.
-  /** @{ */
+  //@{
   reinit_after_move(const reinit_after_move&) = default;
   reinit_after_move& operator=(const reinit_after_move&) = default;
   reinit_after_move(reinit_after_move&& other) {
@@ -72,14 +76,30 @@ class reinit_after_move {
     }
     return *this;
   }
-  /** @} */
+  //@}
 
-  /// @name Implicit conversion operators to make reinit_after_move<T> to act
+  /// @name Implicit conversion operators to make reinit_after_move<T> act
   /// as the wrapped type.
-  /** @{ */
+  //@{
   operator T&() { return value_; }
   operator const T&() const { return value_; }
-  /** @} */
+  //@}
+
+  /// @name Dereference operators if T is a pointer type.
+  /// If type T is a pointer, these exist and return the pointed-to object.
+  /// For non-pointer types these methods are not instantiated.
+  //@{
+  template <typename T1 = T>
+  std::enable_if_t<std::is_pointer<T1>::value, T> operator->() const {
+    return value_;
+  }
+  template <typename T1 = T>
+  std::enable_if_t<std::is_pointer<T1>::value,
+                   std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+  operator*() const {
+    return *value_;
+  }
+  //@}
 
  private:
   T value_{};

--- a/common/reset_on_copy.h
+++ b/common/reset_on_copy.h
@@ -16,10 +16,11 @@ namespace drake {
 /// Only types T that satisfy `std::is_scalar<T>` are currently
 /// permitted: integral and floating point types, enums, and pointers.
 /// Value initialization means the initialization performed when a variable is
-/// constructed with an empty initializer. Numeric types are set to zero and
-/// pointer types are set to nullptr.
+/// constructed with an empty initializer `{}`. For the restricted set of types
+/// we support, that just means that numeric types are set to zero and pointer
+/// types are set to nullptr. Also, all the methods here are noexcept due to the
+/// `std::is_scalar<T>` restriction.
 /// See http://en.cppreference.com/w/cpp/language/value_initialization.
-/// All the methods here are noexcept under the `std::is_scalar<T>` restriction.
 ///
 /// Background:
 ///

--- a/common/reset_on_copy.h
+++ b/common/reset_on_copy.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+namespace drake {
+
+/// Type wrapper that performs value-initialization on copy construction or
+/// assignment.
+///
+/// Rather than copying the source supplied for copy construction or copy
+/// assignment, this wrapper instead value-initializes the destination object.
+/// Move assignment and construction preserve contents in the destination as
+/// usual, but reset the source to its value-initialized value.
+///
+/// Only types T that satisfy `std::is_scalar<T>` are currently
+/// permitted: integral and floating point types, enums, and pointers.
+/// Value initialization means the initialization performed when a variable is
+/// constructed with an empty initializer. Numeric types are set to zero and
+/// pointer types are set to nullptr.
+/// See http://en.cppreference.com/w/cpp/language/value_initialization.
+/// All the methods here are noexcept under the `std::is_scalar<T>` restriction.
+///
+/// Background:
+///
+/// It is preferable to use default copy construction for classes whenever
+/// possible because it avoids difficult-to-maintain enumeration of member
+/// fields in bespoke copy constructors. The presence of fields that must be
+/// reset to zero in the copy (counters, for example) prevents use of default
+/// copy construction. Similarly, pointers that would be invalid in the copy
+/// need to be set to null to avoid stale references. By wrapping those
+/// problematic data members in this adapter, default copy construction can
+/// continue to be used, with all data members copied properly except the
+/// designated ones, which are value-initialized instead. The resetting of the
+/// source on move doesn't change semantics since the condition of the source
+/// after a move is generally undefined. It is instead opportunistic good
+/// hygiene for early detection of bugs, taking advantage of the fact that we
+/// know type T can be value-initialized. See reinit_after_move for more
+/// discussion.
+///
+/// Example:
+///
+/// <pre>
+/// class Foo {
+///  public:
+///   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Foo)
+///   Foo() = default;
+///
+///  private:
+///   std::vector<int> items_;
+///   reset_on_copy<int> use_count_;
+/// };
+/// </pre>
+///
+/// When copying from `Foo`, the new object will contain a copy of `items_`
+/// but `use_count_` will be zero.  If `Foo` had not used the
+/// `reset_on_copy` wrapper, `use_count_` would have been copied also,
+/// which we're assuming is not the desired behavior here.
+///
+/// @warning Even if you initialize a %reset_on_copy member to a non-zero value
+/// using an initializer like `reset_on_copy<int> some_member_{5}` it will be
+/// _reset_ to zero, not _reinitialized_ to 5 when copied.
+///
+/// @note Enum types T are permitted, but be aware that they will be reset to
+/// zero, regardless of whether 0 is one of the specified enumeration values.
+///
+/// @tparam T must satisfy `std::is_scalar<T>`.
+/// @see reinit_after_move
+
+// NOTE(sherm1) to future implementers: if you decide to extend this adapter for
+// use with class types, be sure to think carefully about the semantics of copy
+// and move and how to explain that to users. Be aware that for class types T,
+// the implementation of `T{}` (the default constructor, which may have been
+// user-supplied) won't necessarily reset T's members to zero, nor even
+// necessarily value-initialize T's members. Also, the "noexcept" reasoning
+// below is more than we need with the std::is_scalar<T> restriction, but is
+// strictly necessary for class types if you want std::vector to choose move
+// construction (content-preserving) over copy construction (resetting).
+template <typename T>
+class reset_on_copy {
+ public:
+  static_assert(std::is_scalar<T>::value,
+                "reset_on_copy<T> is permitted only for integral, "
+                "floating point, and pointer types T.");
+
+  /// Constructs a reset_on_copy<T> with a value-initialized wrapped value.
+  reset_on_copy() noexcept(std::is_nothrow_default_constructible<T>::value) {}
+
+  /// Constructs a %reset_on_copy<T> with a copy of the given value. This is
+  /// an implicit conversion, so that %reset_on_copy<T> behaves more like
+  /// the unwrapped type.
+  // NOLINTNEXTLINE(runtime/explicit)
+  reset_on_copy(const T& value) noexcept(
+      std::is_nothrow_copy_constructible<T>::value)
+      : value_(value) {}
+
+  /// Constructs a %reset_on_copy<T> with the given wrapped value, by move
+  /// construction if possible. This is an implicit conversion, so that
+  /// %reset_on_copy<T> behaves more like the unwrapped type.
+  // NOLINTNEXTLINE(runtime/explicit)
+  reset_on_copy(T&& value) noexcept(
+      std::is_nothrow_move_constructible<T>::value)
+      : value_(std::move(value)) {}
+
+  /// @name Implements copy/move construction and assignment.
+  /// These make %reset_on_copy objects CopyConstructible, CopyAssignable,
+  /// MoveConstructible, and MoveAssignable.
+  //@{
+
+  /// Copy constructor just value-initializes instead; the source is ignored.
+  reset_on_copy(const reset_on_copy&) noexcept(
+      std::is_nothrow_default_constructible<T>::value) {}
+
+  /// Copy assignment just destructs the contained value and then
+  /// value-initializes it, _except_ for self-assignment which does nothing.
+  /// The source argument is otherwise ignored.
+  reset_on_copy& operator=(const reset_on_copy& source) noexcept(
+      std::is_nothrow_destructible<T>::value&&
+          std::is_nothrow_default_constructible<T>::value) {
+    if (this != &source) destruct_and_reset_value();
+    return *this;
+  }
+
+  /// Move construction uses T's move constructor, then destructs and
+  /// value initializes the source.
+  reset_on_copy(reset_on_copy&& source) noexcept(
+      std::is_nothrow_move_constructible<T>::value &&
+          std::is_nothrow_destructible<T>::value &&
+          std::is_nothrow_default_constructible<T>::value)
+      : value_(std::move(source.value_)) {
+    source.destruct_and_reset_value();
+  }
+
+  /// Move assignment uses T's move assignment, then destructs and value
+  /// initializes the source, _except_ for self-assignment which does nothing.
+  /// The source argument is otherwise ignored.
+  reset_on_copy& operator=(reset_on_copy&& source) noexcept(
+      std::is_nothrow_move_assignable<T>::value &&
+          std::is_nothrow_destructible<T>::value &&
+          std::is_nothrow_default_constructible<T>::value) {
+    if (this != &source) {
+      value_ = std::move(source);
+      source.destruct_and_reset_value();
+    }
+    return *this;
+  }
+  //@}
+
+  /// @name Implicit conversion operators to make reset_on_copy<T> act
+  /// as the wrapped type.
+  //@{
+  operator T&() noexcept { return value_; }
+  operator const T&() const noexcept { return value_; }
+  //@}
+
+  /// @name Dereference operators if T is a pointer type.
+  /// If type T is a pointer, these exist and return the pointed-to object.
+  /// For non-pointer types these methods are not instantiated.
+  //@{
+  template <typename T1 = T>
+  std::enable_if_t<std::is_pointer<T1>::value, T> operator->() const noexcept {
+    return value_;
+  }
+
+  template <typename T1 = T>
+  std::enable_if_t<std::is_pointer<T1>::value,
+                   std::add_lvalue_reference_t<std::remove_pointer_t<T>>>
+  operator*() const noexcept {
+    return *value_;
+  }
+  //@}
+
+ private:
+  // Invokes T's destructor if there is one, then value-initializes. Note that
+  // the noexcept code above assumes exactly this implementation. Don't change
+  // this to `value_ = T{}` which would introduce an additional dependence on
+  // the behavior of T's copy assignment operator.
+  void destruct_and_reset_value() {
+    value_.~T();  // Invokes destructor if there is one.
+    new (&value_) T{};  // Placement new; no heap activity.
+  }
+
+  T value_{};
+};
+
+}  // namespace drake

--- a/common/test/reinit_after_move_test.cc
+++ b/common/test/reinit_after_move_test.cc
@@ -46,6 +46,42 @@ GTEST_TEST(DefaultValueTest, Access) {
   EXPECT_EQ(ForceInt(x_value_ref), 2);
 }
 
+// For the next test.
+struct Thing {
+  int i{};
+};
+
+// Check that the dereferencing operators *ptr and ptr-> work for pointer types.
+GTEST_TEST(DefaultValueTest, Pointers) {
+  int i = 5;
+  reinit_after_move<int*> i_ptr{&i};
+  reinit_after_move<const int*> i_cptr{&i};
+
+  EXPECT_EQ(*i_ptr, 5);
+  EXPECT_EQ(*i_cptr, 5);
+  *i_ptr = 6;
+  EXPECT_EQ(*i_ptr, 6);
+  EXPECT_EQ(*i_cptr, 6);
+
+  reinit_after_move<int*> i_ptr2(std::move(i_ptr));
+  reinit_after_move<const int*> i_cptr2(std::move(i_cptr));
+  EXPECT_EQ(i_ptr2, &i);
+  EXPECT_EQ(i_cptr2, &i);
+  EXPECT_EQ(i_ptr, nullptr);
+  EXPECT_EQ(i_cptr, nullptr);
+
+  Thing thing;
+  reinit_after_move<Thing*> thing_ptr{&thing};
+  reinit_after_move<const Thing*> thing_cptr{&thing};
+
+  // Make sure there's no cloning happening.
+  EXPECT_EQ(&*thing_ptr, &thing);
+
+  thing_ptr->i = 10;
+  EXPECT_EQ(thing_ptr->i, 10);
+  EXPECT_EQ((*thing_ptr).i, 10);
+}
+
 GTEST_TEST(DefaultValueTest, Copy) {
   reinit_after_move<int> x{1};
   EXPECT_EQ(x, 1);

--- a/common/test/reset_on_copy_test.cc
+++ b/common/test/reset_on_copy_test.cc
@@ -1,0 +1,224 @@
+#include "drake/common/reset_on_copy.h"
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace {
+
+// A function that helps force an implicit conversion operator to int; without
+// it, EXPECT_EQ is underspecified whether we are unwrapping the first argument
+// or converting the second.
+int ForceInt(int value) {
+  return value;
+}
+
+// The example from the documentation, fleshed out a little.
+class Foo {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Foo)
+  Foo() : items_{1, 2, 3}, use_count_{25} {}
+  const std::vector<int>& items() const { return items_; }
+  int use_count() const { return use_count_; }
+
+ private:
+  std::vector<int> items_;
+  reset_on_copy<int> use_count_;
+};
+
+GTEST_TEST(ResetOnCopyTest, Constructor) {
+  EXPECT_EQ(reset_on_copy<int>(), 0);
+  EXPECT_EQ(reset_on_copy<int>(1), 1);
+}
+
+GTEST_TEST(ResetOnCopyTest, Nothrow) {
+  // Default constructor.
+  EXPECT_TRUE(noexcept(reset_on_copy<int>()));
+  EXPECT_TRUE(noexcept(reset_on_copy<Foo*>()));
+
+  // Initialize-from-lvalue constructor.
+  int i{};
+  Foo foo{};
+  Foo* foo_ptr{};
+  EXPECT_TRUE(noexcept(reset_on_copy<int>{i}));
+  EXPECT_TRUE(noexcept(reset_on_copy<Foo*>{foo_ptr}));
+
+  // Initialize-from-rvalue constructor.
+  EXPECT_TRUE(noexcept(reset_on_copy<int>{5}));
+  EXPECT_TRUE(noexcept(reset_on_copy<Foo*>{&foo}));
+
+  // Copy constructor & assignment (source must be lvalue).
+  reset_on_copy<int> r_int, r_int2;
+  reset_on_copy<Foo*> r_foo_ptr, r_foo_ptr2;
+  EXPECT_TRUE(noexcept(reset_on_copy<int>{r_int}));
+  EXPECT_TRUE(noexcept(reset_on_copy<Foo*>{r_foo_ptr}));
+  EXPECT_TRUE(noexcept(r_int = r_int2));
+  EXPECT_TRUE(noexcept(r_foo_ptr = r_foo_ptr2));
+
+  // Move constructor & assignment.
+  EXPECT_TRUE(noexcept(reset_on_copy<int>{std::move(r_int)}));
+  EXPECT_TRUE(noexcept(reset_on_copy<Foo*>{std::move(r_foo_ptr)}));
+  EXPECT_TRUE(noexcept(r_int = std::move(r_int2)));
+  EXPECT_TRUE(noexcept(r_foo_ptr = std::move(r_foo_ptr2)));
+}
+
+GTEST_TEST(ResetOnCopyTest, Access) {
+  // Assignment from a RHS of int (versus reset_on_copy<int>).
+  reset_on_copy<int> x;
+  x = 1;
+
+  // Conversion operator, non-const value.
+  EXPECT_EQ(x, 1);
+  EXPECT_EQ(ForceInt(x), 1);
+
+  // Conversion operator, const.
+  const reset_on_copy<int>& x_cref = x;
+  EXPECT_EQ(x_cref, 1);
+  EXPECT_EQ(ForceInt(x_cref), 1);
+
+  // Conversion operator, non-const reference.
+  int& x_value_ref = x;
+  EXPECT_EQ(x_value_ref, 1);
+  EXPECT_EQ(ForceInt(x_value_ref), 1);
+
+  // All values work okay.
+  x = 2;
+  EXPECT_EQ(x, 2);
+  EXPECT_EQ(ForceInt(x), 2);
+  EXPECT_EQ(x_cref, 2);
+  EXPECT_EQ(ForceInt(x_cref), 2);
+  EXPECT_EQ(x_value_ref, 2);
+  EXPECT_EQ(ForceInt(x_value_ref), 2);
+}
+
+GTEST_TEST(ResetOnCopyTest, Pointers) {
+  int i = 5;
+  reset_on_copy<int*> i_ptr{&i};
+  reset_on_copy<const int*> i_cptr{&i};
+
+  EXPECT_EQ(*i_ptr, 5);
+  EXPECT_EQ(*i_cptr, 5);
+  *i_ptr = 6;
+  EXPECT_EQ(*i_ptr, 6);
+  EXPECT_EQ(*i_cptr, 6);
+
+  reset_on_copy<int*> i_ptr2(i_ptr);
+  reset_on_copy<const int*> i_cptr2(i_cptr);
+  EXPECT_EQ(i_ptr2, nullptr);
+  EXPECT_EQ(i_cptr2, nullptr);
+
+  Foo my_foo;
+  reset_on_copy<Foo*> my_foo_ptr{&my_foo};
+  EXPECT_EQ(my_foo_ptr, &my_foo);
+
+  // Make sure there's no cloning happening.
+  EXPECT_EQ(&*my_foo_ptr, &my_foo);
+
+  EXPECT_EQ(my_foo_ptr->use_count(), 25);
+  EXPECT_EQ((*my_foo_ptr).use_count(), 25);
+
+  // Moving should preserve the pointer and nuke the old one.
+  reset_on_copy<Foo*> moved{std::move(my_foo_ptr)};
+  EXPECT_EQ(moved, &my_foo);
+  EXPECT_EQ(my_foo_ptr, nullptr);
+}
+
+// Copy construction and assignment should ignore the source and
+// value-initialize the destinatation, except for self-assign which should
+// do nothing.
+GTEST_TEST(ResetOnCopyTest, Copy) {
+  reset_on_copy<int> x{1};
+  EXPECT_EQ(x, 1);
+
+  // Copy-construction (from non-const reference) and lack of aliasing.
+  reset_on_copy<int> y{x};
+  EXPECT_EQ(x, 1);
+  EXPECT_EQ(y, 0);
+
+  // Copy-construction (from const reference) and lack of aliasing.
+  const reset_on_copy<int>& x_cref = x;
+  reset_on_copy<int> z{x_cref};
+  x = 3;
+  EXPECT_EQ(x, 3);
+  EXPECT_EQ(z, 0);
+
+  // Copy-assignment and lack of aliasing.
+  reset_on_copy<int> w{22};
+  EXPECT_EQ(w, 22);
+  w = x;
+  EXPECT_EQ(x, 3);
+  EXPECT_EQ(w, 0);  // reset, not reinitialized to 22!
+  w = 4;
+  EXPECT_EQ(x, 3);
+  EXPECT_EQ(w, 4);
+
+  // Self copy assignment preserves value.
+  w = w;
+  EXPECT_EQ(w, 4);
+
+  // Make sure the example works.
+  Foo source;
+  Foo copy(source);
+
+  EXPECT_EQ(source.items().size(), 3);
+  EXPECT_EQ(copy.items().size(), 3);
+  for (size_t i=0; i < 3; ++i) {
+    EXPECT_EQ(source.items()[i], i + 1);
+    EXPECT_EQ(copy.items()[i], i + 1);
+  }
+  EXPECT_EQ(source.use_count(), 25);
+  EXPECT_EQ(copy.use_count(), 0);
+}
+
+// We need to indirect self-move-assign through this function; doing it
+// directly in the test code generates a compiler warning.
+void MoveAssign(reset_on_copy<int>* target, reset_on_copy<int>* donor) {
+  *target = std::move(*donor);
+}
+
+// Move construction and assignment should preserve the current value in the
+// destination, and reset the source to be value-initialized. However,
+// self-move assign should do nothing.
+GTEST_TEST(ResetOnCopyTest, Move) {
+  reset_on_copy<int> x{1};
+  EXPECT_EQ(x, 1);
+
+  // Move-construction and lack of aliasing.
+  reset_on_copy<int> y{std::move(x)};
+  EXPECT_EQ(x, 0);
+  EXPECT_EQ(y, 1);
+  x = 2;
+  EXPECT_EQ(x, 2);
+  EXPECT_EQ(y, 1);
+
+  // Second move-construction and lack of aliasing.
+  reset_on_copy<int> z{std::move(x)};
+  EXPECT_EQ(x, 0);
+  EXPECT_EQ(y, 1);
+  EXPECT_EQ(z, 2);
+
+  // Move-assignment and lack of aliasing.
+  reset_on_copy<int> w{22};
+  EXPECT_EQ(w, 22);
+  x = 3;
+  w = std::move(x);
+  EXPECT_EQ(x, 0);
+  EXPECT_EQ(y, 1);
+  EXPECT_EQ(z, 2);
+  EXPECT_EQ(w, 3);
+  x = 4;
+  EXPECT_EQ(x, 4);
+  EXPECT_EQ(y, 1);
+  EXPECT_EQ(z, 2);
+  EXPECT_EQ(w, 3);
+
+  // Self-assignment during move.
+  MoveAssign(&w, &w);
+  EXPECT_EQ(w, 3);
+}
+
+}  // namespace
+}  // namespace drake

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -74,6 +74,7 @@ LIBDRAKE_COMPONENTS = [
     "//common:number_traits",
     "//common:polynomial",
     "//common:reinit_after_move",
+    "//common:reset_on_copy",
     "//common:scoped_singleton",
     "//common:sorted_vectors_have_intersection",
     "//common:symbolic",


### PR DESCRIPTION
Adds `reset_on_copy<T>` adapter for data members that need to be reset after copy construction, typically counters and pointers that would be stale after a copy. This allows easy-to-maintain default copy constructors to be used more often. I'm using this in caching but expect it to be generally useful.

The code is modeled on `reinit_after_move<T>` (thanks, Jeremy).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8208)
<!-- Reviewable:end -->
