### PR TITLE
Fixes multilane's ToRoadPosition #8045

### DIFF
--- a/automotive/maliput/multilane/road_geometry.h
+++ b/automotive/maliput/multilane/road_geometry.h
@@ -49,9 +49,11 @@ class RoadGeometry : public api::RoadGeometry {
   const api::BranchPoint* do_branch_point(int index) const override;
 
   // Returns a RoadPosition for a lane containing the provided `geo_position`.
-  // If there is no containing lane, the position is returned for the lane
-  // closest to the centerline curve.  If `hint` is non-null, then the search is
-  // restricted to the `hint->lane` and lanes adjacent to `hint->lane`.
+  // Either if there is or not a containing lane, the position is returned for
+  // the lane whose centerline curve is closest to `geo_position`. In other
+  // words, for the lane whose LanePosition makes the r coordinate be the
+  // smallest. If `hint` is non-null, then the search is restricted to the
+  // `hint->lane` and lanes adjacent to `hint->lane`.
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_position,
       const api::RoadPosition* hint,

--- a/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
@@ -3,6 +3,9 @@
 /* clang-format on */
 
 #include <cmath>
+#include <map>
+#include <tuple>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -23,13 +26,30 @@ const double kWidth{2.};  // Lane and drivable width.
 const double kHeight{5.};  // Elevation bound.
 
 const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
-                                     const std::string& junction_id) {
+                                     const std::string& junction_id,
+                                     int segment_index, int lane_index) {
+  DRAKE_DEMAND(segment_index >= 0);
+  DRAKE_DEMAND(lane_index >= 0);
+
   for (int i = 0; i < rg.num_junctions(); ++i) {
     if (rg.junction(i)->id() == api::JunctionId(junction_id)) {
-      return rg.junction(i)->segment(0)->lane(0);
+      if (segment_index >= rg.junction(i)->num_segments()) {
+        throw std::runtime_error(
+            "Segment index is greater than available segment number.");
+      }
+      if (lane_index >= rg.junction(i)->segment(segment_index)->num_lanes()) {
+        throw std::runtime_error(
+            "Lane index is greater than available lane number.");
+      }
+      return rg.junction(i)->segment(segment_index)->lane(lane_index);
     }
   }
   throw std::runtime_error("No matching junction name in the road network");
+}
+
+const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
+                                     const std::string& junction_id) {
+  return GetLaneByJunctionId(rg, junction_id, 0, 0);
 }
 
 GTEST_TEST(MultilaneLanesTest, DoToRoadPosition) {
@@ -246,6 +266,137 @@ GTEST_TEST(MultilaneLanesTest, HintWithDisconnectedLanes) {
   EXPECT_EQ(actual_position.lane->id(), api::LaneId("l:lane1_0"));
   // lane1 does not contain the point.
   EXPECT_GT(distance, 0.);
+}
+
+// Tests different api::Geoposition in the following RoadGeometry without a
+// hint.
+//
+//        ^ +r, +y
+//        |
+//        |                 g
+//        ------------------------------------
+//        |                 f                |           Left shoulder
+//        ------------------------------------
+//        |                 e                |           l:2
+//        |                                  |
+//        ------------------------------------
+//        |                                  |           l:1
+//        |                 d                |
+//        ------------------c-----------------
+// (0,0,0)|__________________________________|_____> +s  l:0
+//        |                                  |       +x
+//        ------------------------------------
+//        |                 b                |           Right shoulder
+//        ------------------------------------
+//                          a
+//
+// Letters, such as `a`, `b`, etc. are the api::GeoPositions to test.
+GTEST_TEST(MultilaneLanesTest, MultipleLineLaneSegmentWithoutHint) {
+  const double kLaneWidth{2. * kWidth};
+  const HBounds kElevationBounds{0., kHeight};
+  const double kLinearTolerance{kVeryExact};
+  const double kAngularTolerance{0.01 * M_PI};
+
+  auto builder = std::make_unique<Builder>(kLaneWidth, kElevationBounds,
+                                           kLinearTolerance, kAngularTolerance);
+
+  // Initialize the road from the origin.
+  const EndpointZ kFlatZ{0., 0., 0., 0.};
+  const double kZeroZ{0.};
+  const Endpoint kRoadOrigin{{0., 0., 0.}, kFlatZ};
+  const double kLength{10.};
+  const double kHalfLength{0.5 * kLength};
+  const double kThreeLanes{3};
+  const double kZeroR0{0.};
+  const double kShoulder{1.0};
+
+  // Creates a simple 3-line-lane segment road.
+  builder->Connect("s0", kThreeLanes, kZeroR0, kShoulder, kShoulder,
+                   kRoadOrigin, kLength, kFlatZ);
+  std::unique_ptr<const api::RoadGeometry> rg =
+      builder->Build(api::RoadGeometryId{"multi-lane-line-segment"});
+
+  // Prepares the truth table to match different api::GeoPositions into
+  // api::RoadPositions.
+  const api::Lane* kFirstLane = GetLaneByJunctionId(*rg, "j:s0", 0, 0);
+  const api::Lane* kSecondLane = GetLaneByJunctionId(*rg, "j:s0", 0, 1);
+  const api::Lane* kThirdLane = GetLaneByJunctionId(*rg, "j:s0", 0, 2);
+
+  // <Geo point - Expected road pos - Nearest pos - Hint - Distance >
+  const std::vector<std::tuple<api::GeoPosition, api::RoadPosition,
+                               api::GeoPosition, api::RoadPosition, double>>
+      truth_vector{
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // a
+              {kHalfLength, -kLaneWidth, kZeroZ},
+              {kFirstLane, {kHalfLength, -0.75 * kLaneWidth, kZeroZ}},
+              {kHalfLength, -0.75 * kLaneWidth, kZeroZ}, {kFirstLane, {}},
+              0.25 * kLaneWidth),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // b
+              {kHalfLength, -0.625 * kLaneWidth, kZeroZ},
+              {kFirstLane, {kHalfLength, -0.625 * kLaneWidth, kZeroZ}},
+              {kHalfLength, -0.625 * kLaneWidth, kZeroZ}, {kFirstLane, {}}, 0.),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // c
+              {kHalfLength, 0.5 * kLaneWidth, kZeroZ},
+              {kSecondLane, {kHalfLength, -0.5 * kLaneWidth, kZeroZ}},
+              {kHalfLength, 0.5 * kLaneWidth, kZeroZ}, {kSecondLane, {}}, 0.),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // d
+              {kHalfLength, 0.775 * kLaneWidth, kZeroZ},
+              {kSecondLane, {kHalfLength, -0.225 * kLaneWidth, kZeroZ}},
+              {kHalfLength, 0.775 * kLaneWidth, kZeroZ}, {kSecondLane, {}}, 0.),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // e
+              {kHalfLength, 2.075 * kLaneWidth, kZeroZ},
+              {kThirdLane, {kHalfLength, 0.075 * kLaneWidth, kZeroZ}},
+              {kHalfLength, 2.075 * kLaneWidth, kZeroZ}, {kThirdLane, {}}, 0.),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // f
+              {kHalfLength, 2.625 * kLaneWidth, kZeroZ},
+              {kThirdLane, {kHalfLength, 0.625 * kLaneWidth, kZeroZ}},
+              {kHalfLength, 2.625 * kLaneWidth, kZeroZ}, {kThirdLane, {}}, 0.),
+          std::make_tuple<api::GeoPosition, api::RoadPosition, api::GeoPosition,
+                          api::RoadPosition, double>(  // g
+              {kHalfLength, 3. * kLaneWidth, kZeroZ},
+              {kThirdLane, {kHalfLength, 0.75 * kLaneWidth, kZeroZ}},
+              {kHalfLength, 2.75 * kLaneWidth, kZeroZ}, {kThirdLane, {}},
+              0.25 * kLaneWidth),
+      };
+
+  double distance{};
+  api::RoadPosition test_road_position{};
+  api::GeoPosition nearest_position{};
+  // Evaluates the truth table without a hint.
+  for (const auto truth_value : truth_vector) {
+    EXPECT_NO_THROW(test_road_position =
+                        rg->ToRoadPosition(std::get<0>(truth_value), nullptr,
+                                           &nearest_position, &distance));
+    EXPECT_EQ(test_road_position.lane->id(),
+              std::get<1>(truth_value).lane->id());
+    EXPECT_TRUE(api::test::IsLanePositionClose(test_road_position.pos,
+                                               std::get<1>(truth_value).pos,
+                                               kLinearTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        nearest_position, std::get<2>(truth_value), kLinearTolerance));
+    EXPECT_NEAR(distance, std::get<4>(truth_value), kLinearTolerance);
+  }
+
+  // Evaluates the truth table with a hint.
+  for (const auto truth_value : truth_vector) {
+    EXPECT_NO_THROW(test_road_position = rg->ToRoadPosition(
+                        std::get<0>(truth_value), &(std::get<3>(truth_value)),
+                        &nearest_position, &distance));
+    EXPECT_EQ(test_road_position.lane->id(),
+              std::get<1>(truth_value).lane->id());
+    EXPECT_TRUE(api::test::IsLanePositionClose(test_road_position.pos,
+                                               std::get<1>(truth_value).pos,
+                                               kLinearTolerance));
+    EXPECT_TRUE(api::test::IsGeoPositionClose(
+        nearest_position, std::get<2>(truth_value), kLinearTolerance));
+    EXPECT_NEAR(distance, std::get<4>(truth_value), kLinearTolerance);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
In this PR `multilane`'s version of `ToRoadPosition` has been modified to take into account:

- `linear_tolerance`: when two different `lanes` whose output `distance`s from `ToLanePosition` with the same `GeoPosition` are within `linear_tolerance`, the code now keeps on analyzing the r-coordinate.
- Even if `distance` is 0, the checks go over all the `lane`s of the `Segment` to check that there isn't any other `lane` with a smaller r-coordinate.

A test case has been created to evaluate it the changes and prior tests were remained (note that there was no multi-lane case before).

It fixes #8045 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8212)
<!-- Reviewable:end -->
