### PR TITLE
Make DrakeVisualizer aware of automotive models by default

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -9,6 +9,7 @@ py_binary(
     name = "drake_visualizer.impl",
     srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
     data = [
+        "//automotive/models:prod_models",
         "//examples:prod_models",
         "@drake_visualizer",
     ],


### PR DESCRIPTION
This preserves the ability to call DrakeVisualizer as a separate process (e.g. with Python, etc.) as was possible pre-#8080.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8216)
<!-- Reviewable:end -->
