### PR TITLE
Use dreal and ibex from workspace (not apt) on Ubuntu

### DIFF
--- a/setup/ubuntu/16.04/binary_distribution/install_prereqs.sh
+++ b/setup/ubuntu/16.04/binary_distribution/install_prereqs.sh
@@ -15,7 +15,6 @@ apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 apt-transport-https
 ca-certificates
 lsb-release
-wget
 EOF
 )
 
@@ -24,10 +23,39 @@ if [[ "$(lsb_release -sc)" != 'xenial' ]]; then
   exit 2
 fi
 
-wget -O - https://drake-apt.csail.mit.edu/drake.pub.gpg | apt-key add
-echo 'deb [arch=amd64] https://drake-apt.csail.mit.edu xenial main' > /etc/apt/sources.list.d/drake.list
+# TODO(jwnimmer-tri) Remove this cleanup step sometime after 2018-09-01.
+# This script used to install some custom packages directly; here, we'll set
+# them to `auto` mode so that Ubuntu will suggest to remove them if nothing
+# else is using them.
+mark_auto() {
+  package="$1"
+  shift
 
-apt update
+  installed=$(dpkg-query --showformat='${Version}\n' --show "${package}" 2>/dev/null || true)
+  if [[ -z "${installed}" ]]; then
+    return
+  fi
+
+  for version in "$@"; do
+    if [[ "${version}" == "${installed}" ]]; then
+      apt-mark auto "${package}"
+      return
+    fi
+  done
+}
+mark_auto \
+  dreal \
+  4.17.12.2 \
+  4.17.12.3 \
+  4.18.01.3 \
+  4.18.02.2 \
+  4.18.02.4
+mark_auto \
+  libibex-dev \
+  2.6.3 \
+  2.6.5.20180123154310.gitf618c7b296182f90a84d54936d144b87df0747b9~16.04 \
+  2.6.5.20180211084215.gitd1419538b4d818ed1cf21a01896bc5eaae5d1d57~16.04
+
 apt install --no-install-recommends $(tr '\n' ' ' <<EOF
 build-essential
 cmake

--- a/setup/ubuntu/16.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/16.04/binary_distribution/packages.txt
@@ -1,5 +1,4 @@
 coinor-libipopt1v5
-dreal=4.18.02.4
 libblas3
 libboost-all-dev
 libexpat1
@@ -7,7 +6,6 @@ libgflags-dev
 libgl1-mesa-glx
 libglib2.0-0
 libhdf5-10
-libibex-dev=2.6.5.20180211084215.gitd1419538b4d818ed1cf21a01896bc5eaae5d1d57~16.04
 libjpeg8
 libjsoncpp1
 liblapack3

--- a/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
+++ b/setup/ubuntu/16.04/source_distribution/install_prereqs.sh
@@ -13,6 +13,15 @@ if [[ "${EUID}" -ne 0 ]]; then
   exit 1
 fi
 
+apt install --no-install-recommends $(tr '\n' ' ' <<EOF
+wget
+EOF
+)
+
+wget -O - https://drake-apt.csail.mit.edu/drake.pub.gpg | apt-key add
+echo 'deb [arch=amd64] https://drake-apt.csail.mit.edu xenial main' > /etc/apt/sources.list.d/drake.list
+
+apt update
 apt install --no-install-recommends $(cat "${BASH_SOURCE%/*}/packages.txt" | tr '\n' ' ')
 
 dpkg_install_from_wget() {

--- a/tools/workspace/BUILD.bazel
+++ b/tools/workspace/BUILD.bazel
@@ -38,6 +38,7 @@ _DRAKE_EXTERNAL_PACKAGE_INSTALLS = ["@%s//:install" % p for p in [
     "tinyobjloader",
     "vtk",
 ]] + ["//tools/workspace/%s:install" % p for p in [
+    "dreal",
     "net_sf_jchart2d",
     "find_protobuf_cmake",
     "optitrack_driver",

--- a/tools/workspace/deb.bzl
+++ b/tools/workspace/deb.bzl
@@ -1,0 +1,94 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/workspace:execute.bzl",
+    "execute_and_return",
+)
+
+def setup_new_deb_archive(repo_ctx):
+    """Behaves like new_deb_archive, except that (1) this is a macro instead of a
+    rule and (2) this macro returns an error status instead of fail()ing.  The
+    return value is a struct with a field `error` that will be None on success
+    or else a detailed message on any failure.
+    """
+    name = repo_ctx.attr.name
+    filenames = repo_ctx.attr.filenames
+    mirrors = repo_ctx.attr.mirrors
+    sha256s = repo_ctx.attr.sha256s
+    build_file = repo_ctx.attr.build_file
+
+    # Download and unpack all of the debs.
+    for i in range(len(filenames)):
+        filename = filenames[i]
+        if i == len(sha256s):
+            sha256s = sha256s + [""]
+        sha256 = sha256s[i]
+        if not sha256:
+            # We do not permit an empty checksum; empty means "don't care".
+            sha256 = "0" * 64
+        repo_ctx.download(
+            url = [mirror + "/" + filename for mirror in mirrors],
+            output = filename,
+            sha256 = sha256,
+        )
+        result = execute_and_return(
+            repo_ctx,
+            ["dpkg-deb", "-x", filename, "."])
+        if result.error:
+            return result
+
+    # Add in the build file.
+    repo_ctx.symlink(build_file, "BUILD.bazel")
+
+    # Success.
+    return struct(error = None)
+
+def _impl(repo_ctx):
+    result = setup_new_deb_archive(repo_ctx)
+    if result.error != None:
+        fail("Unable to complete setup for @{} repository: {}".
+             format(repo_ctx.name, result.error))
+
+new_deb_archive = repository_rule(
+    attrs = {
+        "filenames": attr.string_list(
+            doc = """
+            Base filenames of the debs, e.g., ["libfoo-dev_123_amd64.deb"].
+            When multiple files are listed, they will all be extracted atop
+            each other (within our sandbox), as is typical for Debian install.
+            """,
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "mirrors": attr.string_list(
+            doc = """
+            List of URLs to download from, without the filename portion, e.g.,
+            ["https://example.com/archives"].
+            """,
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "sha256s": attr.string_list(
+            doc = """
+            Checksums of the files.  When unsure, you may set it to an empty
+            string or list; the checksum error will offer a suggestion.  The
+            sha256s and filenames are matched ordering (i.e., parallel lists).
+            """,
+        ),
+        "build_file": attr.label(
+            doc = """
+            Label for BUILD.bazel file to add into the repository.  This should
+            contain the rules that expose the archive contents for consumers.
+            The *.deb file contents will appear at ".", so paths are like,
+            e.g., `hdrs = glob(["usr/include/foo/**/*.h"]),`.
+            """,
+            mandatory = True,
+            single_file = True,
+            allow_files = True,
+        ),
+    },
+    implementation = _impl,
+)
+
+"""A repository rule that downloads and unpacks one or more *.deb files.
+"""

--- a/tools/workspace/dreal/BUILD.bazel
+++ b/tools/workspace/dreal/BUILD.bazel
@@ -1,8 +1,26 @@
 # -*- python -*-
 
-# This file exists to make our directory into a Bazel package, so that our
-# neighboring *.bzl file can be loaded elsewhere.
-
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "linux",
+    values = {"cpu": "k8"},
+)
+
+# Only Ubuntu needs an installation rule; on macOS, we are using dReal from
+# homebrew, so Drake's installation script doesn't need to do anything extra.
+install(
+    name = "install",
+    deps = select({
+        ":linux": ["@dreal//:install"],
+        "@//conditions:default": [],
+    }),
+)
 
 add_lint_tests()

--- a/tools/workspace/dreal/package-ubuntu.BUILD.bazel
+++ b/tools/workspace/dreal/package-ubuntu.BUILD.bazel
@@ -1,0 +1,82 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/install:install.bzl",
+    "install",
+)
+load(
+    "@drake//tools/workspace/dreal:versions.bzl",
+    "DREAL_VERSION",
+    "IBEX_VERSION",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+_DREAL_BASE = "opt/dreal/{}/".format(DREAL_VERSION)
+
+_IBEX_BASE = "opt/libibex/{}/".format(IBEX_VERSION)
+
+_DREAL_HDRS_GLOB = glob([_DREAL_BASE + "include/dreal/**"]) or fail("Missing dreal hdrs")  # noqa
+
+_IBEX_HDRS_GLOB = glob([_IBEX_BASE + "include/ibex/**"]) or fail("Missing ibex hdrs")  # noqa
+
+cc_library(
+    name = "dreal",
+    srcs = [_DREAL_BASE + "lib/libdrake_dreal.so"],
+    hdrs = _DREAL_HDRS_GLOB,
+    includes = [
+        _DREAL_BASE + "include",
+    ],
+    # The deps= here are transcribed from the contents of the *.pc file.
+    deps = [
+        ":ibex",
+        "@nlopt",
+    ],
+)
+
+cc_library(
+    name = "ibex",
+    srcs = [_IBEX_BASE + "lib/libdrake_ibex.so"],
+    hdrs = [_IBEX_BASE + "include/ibex.h"] + _IBEX_HDRS_GLOB,
+    # The includes= here are transcribed from the contents of the *.pc file.
+    includes = [
+        _IBEX_BASE + "include",
+        _IBEX_BASE + "include/ibex",
+        _IBEX_BASE + "include/ibex/3rd",
+    ],
+    # The linkopts= here are transcribed from the contents of the *.pc file.
+    linkopts = [
+        "-lClp",
+        "-lCoinUtils",
+        "-lbz2",
+        "-lm",
+    ],
+    # The deps= here are transcribed from the contents of the *.pc file.
+    deps = [
+        "@blas",
+        "@lapack",
+        "@zlib",
+    ],
+)
+
+install(
+    name = "install",
+    data_strip_prefix = [
+        _DREAL_BASE,
+        _IBEX_BASE,
+    ],
+    # The *.pc files don't have the correct ${prefix} anymore, so its probably
+    # best to omit them.  (Nothing else in Drake installs *.pc files, either.)
+    # The binaries won't work either, given our renamed libraries.
+    data = glob(
+        include = [
+            _DREAL_BASE + "**",
+            _IBEX_BASE + "**",
+        ],
+        exclude = [
+            "**/bin/**",
+            "**/*.pc",
+        ],
+    ),
+    data_dest = "",
+)

--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -1,29 +1,104 @@
 # -*- mode: python -*-
 
 load(
+    "@drake//tools/workspace:deb.bzl",
+    "setup_new_deb_archive",
+)
+load(
+    "@drake//tools/workspace:execute.bzl",
+    "execute_or_fail",
+)
+load(
+    "@drake//tools/workspace:os.bzl",
+    "determine_os",
+)
+load(
     "@drake//tools/workspace:pkg_config.bzl",
-    "pkg_config_repository",
+    "setup_pkg_config_repository",
+)
+load(
+    ":versions.bzl",
+    "DREAL_VERSION",
+    "IBEX_VERSION",
 )
 
-def dreal_repository(
-        name,
-        modname = "dreal",
-        # Since dReal and its dependency IBEX are installed under
-        # `/opt/<package_name>/<version_number>/`, it is necessary to keep the
-        # following versions in sync with the ones in
-        # `setup/ubuntu/16.04/binary_distribution/packages.txt` file.
-        pkg_config_paths = [
-            "/opt/dreal/4.18.02.4/lib/pkgconfig",
-            "/opt/libibex/2.6.5/share/pkgconfig",
-            "/usr/local/opt/clp/lib/pkgconfig",
-            "/usr/local/opt/coinutils/lib/pkgconfig",
-            "/usr/local/opt/dreal/lib/pkgconfig",
-            "/usr/local/opt/ibex@2.6.5/share/pkgconfig",
-            "/usr/local/opt/nlopt/lib/pkgconfig",
-        ],
-        **kwargs):
-    pkg_config_repository(
-        name = name,
-        modname = modname,
-        pkg_config_paths = pkg_config_paths,
-        **kwargs)
+def _rename_so(repo_ctx, directory, old_name):
+    # Rename directory/old_name to be -ldrake_foo instead of -lfoo.
+    old_name[:3] == "lib" or fail("Bad library name " + old_name)
+    execute_or_fail(repo_ctx, [
+        "mv",
+        directory + "/lib" + old_name[3:],
+        directory + "/libdrake_" + old_name[3:],
+    ])
+
+def _impl(repo_ctx):
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_macos:
+        result = setup_pkg_config_repository(repo_ctx)
+    else:
+        result = setup_new_deb_archive(repo_ctx)
+        # Avoid using upstream library names for our custom build.
+        _rename_so(
+            repo_ctx,
+            "opt/libibex/{}/lib".format(IBEX_VERSION),
+            "libibex.so",
+        )
+        _rename_so(
+            repo_ctx,
+            "opt/dreal/{}/lib".format(DREAL_VERSION),
+            "libdreal.so",
+        )
+        # Our BUILD file declares this dependency with the revised spelling.
+        execute_or_fail(repo_ctx, [
+            "patchelf", "--remove-needed", "libibex.so",
+            "opt/dreal/{}/lib/libdrake_dreal.so".format(DREAL_VERSION),
+        ])
+    if result.error != None:
+        fail("Unable to complete setup for @{} repository: {}".
+             format(repo_ctx.name, result.error))
+
+dreal_repository = repository_rule(
+    attrs = {
+        "modname": attr.string(default = "dreal"),
+        # This attribute is only used for macOS.  It is documented in the
+        # pkg_config_repository rule.
+        "pkg_config_paths": attr.string_list(
+            default = [
+                "/usr/local/opt/clp/lib/pkgconfig",
+                "/usr/local/opt/coinutils/lib/pkgconfig",
+                "/usr/local/opt/dreal/lib/pkgconfig",
+                "/usr/local/opt/ibex@{}/share/pkgconfig".format(IBEX_VERSION),
+                "/usr/local/opt/nlopt/lib/pkgconfig",
+            ],
+        ),
+        # All of the below attributes are only used for Ubuntu.  They are
+        # documented in the new_deb_archive rule.
+        "mirrors": attr.string_list(
+            default = [
+                "https://drake-apt.csail.mit.edu/pool/main",
+            ],
+        ),
+        "filenames": attr.string_list(
+            default = [
+                "d/dreal/dreal_{}_amd64.deb".format(DREAL_VERSION),
+                "libi/libibex-dev/libibex-dev_{}.20180211084215.gitd1419538b4d818ed1cf21a01896bc5eaae5d1d57~16.04_amd64.deb".format(IBEX_VERSION),  # noqa
+            ],
+        ),
+        "sha256s": attr.string_list(
+            default = [
+                "53e530a7df9efe1afe5222e025a4339b9a33508f1b4f4434f7bd7763d44a6c11",  # noqa
+                "1285a64aa5c7ddbefa650232dbd5b309414fce94fd25b160689336f20672494b",  # noqa
+            ],
+        ),
+        "build_file": attr.label(
+            default = "@drake//tools/workspace/dreal:package-ubuntu.BUILD.bazel",  # noqa
+        ),
+    },
+    implementation = _impl,
+)
+
+"""Provides a library target for @dreal//:dreal.  On macOS, uses homebrew; on
+Ubuntu, downloads *.deb files and unpacks them into the workspace.
+"""

--- a/tools/workspace/dreal/versions.bzl
+++ b/tools/workspace/dreal/versions.bzl
@@ -1,0 +1,5 @@
+# -*- mode: python -*-
+
+DREAL_VERSION = "4.18.02.4"
+
+IBEX_VERSION = "2.6.5"

--- a/tools/workspace/execute.bzl
+++ b/tools/workspace/execute.bzl
@@ -1,0 +1,33 @@
+# -*- python -*-
+
+def execute_and_return(repo_ctx, command):
+    """Runs the `command` (list) and returns a status value.  The return value
+    is a struct with a field `error` that will be None on success or else a
+    detailed message on command failure.
+    """
+    if "/" in command[0]:
+        program = command[0]
+    else:
+        program = repo_ctx.which(command[0])
+        if not program:
+            error = "Could not find a program named '{}'".format(
+                command[0])
+            return struct(error = error)
+    exec_result = repo_ctx.execute([program] + command[1:])
+    if exec_result.return_code == 0:
+        error = None
+    else:
+        error = "Failure running " + (
+            " ".join(["'{}'".format(x) for x in command]))
+        if exec_result.stdout:
+            error += "\n" + exec_result.stdout
+        if exec_result.stderr:
+            error += "\n" + exec_result.stderr
+    return struct(error = error)
+
+def execute_or_fail(repo_ctx, command):
+    """Runs the `command` (list) and immediately fails on any error."""
+    result = execute_and_return(repo_ctx, command)
+    if result.error:
+        fail("Unable to complete setup for @{} repository: {}".format(
+            repo_ctx.name, result.error))


### PR DESCRIPTION
Previously discussed in #7330 but we couldn't get it working right away, so we were using the apt site in the meantime.

When downstream projects want to bump around which commit they are using, its a pain to have to touch anything to do with apt packages.  Having Bazel fetch what's needed is an ergonomics improvement.

In the future, this PR might also enable us to remove the Drake apt source from our developer setup instructions.

Do not merge until:
- [x] Ubuntu unprovisioned builds pass
- [x] macOS (non-unprovisioned) builds pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8218)
<!-- Reviewable:end -->
