### PR TITLE
Use --strict_system_includes for bazel

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -9,6 +9,7 @@ build -c opt
 # Default build options.
 build --force_pic
 build --strip=never
+build --strict_system_includes
 
 # Default test options.
 test --test_output=errors


### PR DESCRIPTION
This is helpful / required for caching to be safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8223)
<!-- Reviewable:end -->
