### PR TITLE
Python bindings for a few simulator/integrator controls

### DIFF
--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -24,10 +24,14 @@ PYBIND11_MODULE(analysis, m) {
     .def("get_target_accuracy", &IntegratorBase<T>::get_target_accuracy)
     .def("set_maximum_step_size", &IntegratorBase<T>::set_maximum_step_size)
     .def("get_maximum_step_size", &IntegratorBase<T>::get_maximum_step_size)
-    .def("set_requested_minimum_step_size", &IntegratorBase<T>::set_requested_minimum_step_size)
-    .def("get_requested_minimum_step_size", &IntegratorBase<T>::get_requested_minimum_step_size)
-    .def("set_throw_on_minimum_step_size_violation", &IntegratorBase<T>::set_throw_on_minimum_step_size_violation)
-    .def("get_throw_on_minimum_step_size_violation", &IntegratorBase<T>::get_throw_on_minimum_step_size_violation);
+    .def("set_requested_minimum_step_size",
+         &IntegratorBase<T>::set_requested_minimum_step_size)
+    .def("get_requested_minimum_step_size",
+         &IntegratorBase<T>::get_requested_minimum_step_size)
+    .def("set_throw_on_minimum_step_size_violation",
+         &IntegratorBase<T>::set_throw_on_minimum_step_size_violation)
+    .def("get_throw_on_minimum_step_size_violation",
+         &IntegratorBase<T>::get_throw_on_minimum_step_size_violation);
 
   py::class_<Simulator<T>>(m, "Simulator")
     .def(py::init<const System<T>&>(),
@@ -45,11 +49,10 @@ PYBIND11_MODULE(analysis, m) {
     .def("get_mutable_context", &Simulator<T>::get_mutable_context,
          py_reference_internal)
     .def("get_mutable_integrator", &Simulator<T>::get_mutable_integrator,
-        py_reference_internal)
+         py_reference_internal)
     .def("set_publish_every_time_step",
          &Simulator<T>::set_publish_every_time_step)
     .def("set_target_realtime_rate", &Simulator<T>::set_target_realtime_rate);
-
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -46,9 +46,9 @@ PYBIND11_MODULE(analysis, m) {
     .def("StepTo", &Simulator<T>::StepTo)
     .def("get_context", &Simulator<T>::get_context, py_reference_internal)
     .def("get_integrator", &Simulator<T>::get_integrator, py_reference_internal)
-    .def("get_mutable_context", &Simulator<T>::get_mutable_context,
-         py_reference_internal)
     .def("get_mutable_integrator", &Simulator<T>::get_mutable_integrator,
+         py_reference_internal)
+    .def("get_mutable_context", &Simulator<T>::get_mutable_context,
          py_reference_internal)
     .def("set_publish_every_time_step",
          &Simulator<T>::set_publish_every_time_step)

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -1,6 +1,7 @@
 #include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/simulator.h"
 
 using std::unique_ptr;
@@ -16,6 +17,18 @@ PYBIND11_MODULE(analysis, m) {
 
   using T = double;
 
+  py::class_<IntegratorBase<T>>(m, "IntegratorBase")
+    .def("set_fixed_step_mode", &IntegratorBase<T>::set_fixed_step_mode)
+    .def("get_fixed_step_mode", &IntegratorBase<T>::get_fixed_step_mode)
+    .def("set_target_accuracy", &IntegratorBase<T>::set_target_accuracy)
+    .def("get_target_accuracy", &IntegratorBase<T>::get_target_accuracy)
+    .def("set_maximum_step_size", &IntegratorBase<T>::set_maximum_step_size)
+    .def("get_maximum_step_size", &IntegratorBase<T>::get_maximum_step_size)
+    .def("set_requested_minimum_step_size", &IntegratorBase<T>::set_requested_minimum_step_size)
+    .def("get_requested_minimum_step_size", &IntegratorBase<T>::get_requested_minimum_step_size)
+    .def("set_throw_on_minimum_step_size_violation", &IntegratorBase<T>::set_throw_on_minimum_step_size_violation)
+    .def("get_throw_on_minimum_step_size_violation", &IntegratorBase<T>::get_throw_on_minimum_step_size_violation);
+
   py::class_<Simulator<T>>(m, "Simulator")
     .def(py::init<const System<T>&>(),
          // Keep alive, reference: `self` keeps `System` alive.
@@ -28,11 +41,15 @@ PYBIND11_MODULE(analysis, m) {
     .def("Initialize", &Simulator<T>::Initialize)
     .def("StepTo", &Simulator<T>::StepTo)
     .def("get_context", &Simulator<T>::get_context, py_reference_internal)
+    .def("get_integrator", &Simulator<T>::get_integrator, py_reference_internal)
     .def("get_mutable_context", &Simulator<T>::get_mutable_context,
          py_reference_internal)
+    .def("get_mutable_integrator", &Simulator<T>::get_mutable_integrator,
+        py_reference_internal)
     .def("set_publish_every_time_step",
          &Simulator<T>::set_publish_every_time_step)
     .def("set_target_realtime_rate", &Simulator<T>::set_target_realtime_rate);
+
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -141,6 +141,38 @@ class TestGeneral(unittest.TestCase):
             print("xc[t = {}] = {}".format(t, xc))
             self.assertTrue(np.allclose(xc, xc_expected))
 
+    def test_simulator_integrator_manipulation(self):
+        system = ConstantVectorSource([1])
+
+        # Create simulator with basic constructor.
+        simulator = Simulator(system)
+        simulator.Initialize()
+        simulator.set_target_realtime_rate(0)
+
+        integrator = simulator.get_mutable_integrator()
+
+        target_accuracy = 1E-6
+        integrator.set_target_accuracy(target_accuracy)
+        self.assertEqual(integrator.get_target_accuracy(), target_accuracy)
+
+        maximum_step_size = 0.2
+        integrator.set_maximum_step_size(maximum_step_size)
+        self.assertEqual(integrator.get_maximum_step_size(), maximum_step_size)
+
+        minimum_step_size = 2E-2
+        integrator.set_requested_minimum_step_size(minimum_step_size)
+        self.assertEqual(integrator.get_requested_minimum_step_size(),
+                         minimum_step_size)
+
+        integrator.set_throw_on_minimum_step_size_violation(True)
+        self.assertTrue(integrator.get_throw_on_minimum_step_size_violation())
+
+        integrator.set_fixed_step_mode(True)
+        self.assertTrue(integrator.get_fixed_step_mode())
+
+        const_integrator = simulator.get_integrator()
+        self.assertRaises(const_integrator.set_fixed_step_mode(True))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -171,7 +171,6 @@ class TestGeneral(unittest.TestCase):
         self.assertTrue(integrator.get_fixed_step_mode())
 
         const_integrator = simulator.get_integrator()
-        self.assertRaises(const_integrator.set_fixed_step_mode(True))
 
 
 if __name__ == '__main__':

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -171,6 +171,7 @@ class TestGeneral(unittest.TestCase):
         self.assertTrue(integrator.get_fixed_step_mode())
 
         const_integrator = simulator.get_integrator()
+        self.assertTrue(const_integrator is integrator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Exposes a little more control of the simulator in Python -- e.g., encouraging longer timesteps or fixed step mode to speed up simulations when accuracy isn't critical.

@EricCousineau-TRI, would you mind taking a look once I see that this works with CI?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8226)
<!-- Reviewable:end -->
