### PR TITLE
Adds low-level Cache components to ContextBase

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -201,6 +201,7 @@ drake_cc_library(
         ":framework_common",
         ":value",
         "//drake/common:copyable_unique_ptr",
+        "//drake/common:reset_on_copy",
         "//drake/common:unused",
     ],
 )
@@ -500,6 +501,7 @@ drake_cc_googletest(
     name = "cache_test",
     deps = [
         ":cache_and_dependency_tracker",
+        ":context_base",
         "//drake/common:essential",
         "//drake/systems/framework/test_utilities",
     ],

--- a/systems/framework/cache.cc
+++ b/systems/framework/cache.cc
@@ -1,12 +1,65 @@
-// TODO(sherm1) Re-review this file in its entirety when the cache stubs are
-// replaced with real code in a subsequent PR.
-
 #include "drake/systems/framework/cache.h"
+
+#include <typeindex>
+#include <typeinfo>
 
 #include "drake/systems/framework/dependency_tracker.h"
 
 namespace drake {
 namespace systems {
+
+std::string CacheEntryValue::GetPathDescription() const {
+  DRAKE_DEMAND(owning_subcontext_!= nullptr);
+  return owning_subcontext_->GetSystemPathname() + ":" + description();
+}
+
+void CacheEntryValue::ThrowIfBadCacheEntryValue(
+    const internal::SystemPathnameInterface* owning_subcontext) const {
+  if (owning_subcontext_ == nullptr) {
+    // Can't use FormatName() here because that depends on us having an owning
+    // context to talk to.
+    throw std::logic_error("CacheEntryValue(" + description() + ")::" +
+                           __func__ + "(): entry has no owning subcontext.");
+  }
+  if (owning_subcontext && owning_subcontext_ != owning_subcontext) {
+    throw std::logic_error(FormatName(__func__) + "wrong owning subcontext.");
+  }
+  if ((flags_ & ~(kValueIsOutOfDate | kCacheEntryIsDisabled)) != 0) {
+    throw std::logic_error(FormatName(__func__) +
+                           "flags value is out of range.");
+  }
+  if (serial_number() < 0) {
+    throw std::logic_error(FormatName(__func__) + "serial number is negative.");
+  }
+  if (!(cache_index_.is_valid() && ticket_.is_valid())) {
+    throw std::logic_error(FormatName(__func__) +
+                           "cache index or dependency ticket invalid.");
+  }
+}
+
+void CacheEntryValue::ThrowIfBadOtherValue(
+    const char* api,
+    const std::unique_ptr<AbstractValue>* other_value_ptr) const {
+  if (other_value_ptr == nullptr)
+    throw std::logic_error(FormatName(api) + "null other_value pointer.");
+
+  auto& other_value = *other_value_ptr;
+  if (other_value == nullptr)
+    throw std::logic_error(FormatName(api) + "other_value is empty.");
+
+  DRAKE_DEMAND(value_ != nullptr);  // Should have been checked already.
+
+  // Extract these outside typeid() to avoid warnings.
+  const AbstractValue& abstract_value = *value_;
+  const AbstractValue& other_abstract_value = *other_value;
+  if (std::type_index(typeid(abstract_value)) !=
+      std::type_index(typeid(other_abstract_value))) {
+    throw std::logic_error(FormatName(api) +
+                           "other_value has wrong concrete type " +
+                           NiceTypeName::Get(*other_value) + ". Expected " +
+                           NiceTypeName::Get(*value_) + ".");
+  }
+}
 
 CacheEntryValue& Cache::CreateNewCacheEntryValue(
     CacheIndex index, DependencyTicket ticket,
@@ -17,15 +70,17 @@ CacheEntryValue& Cache::CreateNewCacheEntryValue(
   DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
 
   // Make sure there is a place for this cache entry in the cache.
-  if (index >= num_entries())
+  if (index >= cache_size())
     store_.resize(index + 1);
 
   // Create the new cache entry value and install it into this Cache. Note that
   // indirection here means the CacheEntryValue object's address is stable
   // even when store_ is resized.
   DRAKE_DEMAND(store_[index] == nullptr);
-  store_[index] = std::make_unique<CacheEntryValue>(
-      index, ticket, description, nullptr /* no value yet */);
+  // Can't use make_unique because constructor is private.
+  store_[index] = std::unique_ptr<CacheEntryValue>(
+      new CacheEntryValue(index, ticket, description, owning_subcontext_,
+                          nullptr /* no value yet */));
   CacheEntryValue& value = *store_[index];
 
   // Allocate a DependencyTracker for this cache entry. Note that a pointer
@@ -43,6 +98,31 @@ CacheEntryValue& Cache::CreateNewCacheEntryValue(
     tracker.SubscribeToPrerequisite(&prereq_tracker);
   }
   return value;
+}
+
+void Cache::DisableCaching() {
+  for (auto& entry : store_)
+    if (entry) entry->disable_caching();
+}
+
+
+void Cache::EnableCaching() {
+  for (auto& entry : store_)
+    if (entry) entry->enable_caching();
+}
+
+void Cache::SetAllEntriesOutOfDate() {
+  for (auto& entry : store_)
+    if (entry) entry->mark_out_of_date();
+}
+
+void Cache::RepairCachePointers(
+    const internal::SystemPathnameInterface* owning_subcontext) {
+  DRAKE_DEMAND(owning_subcontext != nullptr);
+  DRAKE_DEMAND(owning_subcontext_ == nullptr);
+  owning_subcontext_ = owning_subcontext;
+  for (auto& entry : store_)
+    if (entry) entry->set_owning_subcontext(owning_subcontext);
 }
 
 }  // namespace systems

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -4,18 +4,17 @@
 Declares CacheEntryValue and Cache, which is the container for cache entry
 values. */
 
-// TODO(sherm1) Re-review this file in its entirety when the cache stubs are
-// replaced with real code in a subsequent PR.
-
+#include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_copyable.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/reset_on_copy.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/value.h"
 
@@ -24,111 +23,683 @@ namespace systems {
 
 class DependencyGraph;
 
-// TODO(sherm1) Stubbed for testing DependencyTracker; do not review.
+//==============================================================================
+//                             CACHE ENTRY VALUE
+//==============================================================================
+/** This is the representation in the Context for the value of one of a System's
+CacheEntry objects. It consists of a single type-erased value, a serial number,
+an `out_of_date` flag, and a DependencyTracker ticket. Details:
+- "Out of date" means that some prerequisite of this cache entry's computation
+  has been changed in the current Context since the stored value was last
+  computed, and thus must be recomputed prior to use. On the other hand, if the
+  entry is _not_ out of date, then it is "up to date" meaning that if you were
+  to recompute it using the current Context values you would get the identical
+  result (so don't bother!).
+- The "serial number" is an integer that is incremented whenever the value is
+  modified, or made available for mutable access. You can use it to recognize
+  that you are looking at the same value as you saw at some earlier time. It is
+  also useful for performance studies since it is a count of how many times this
+  value was recomputed. Note that marking the value "out of date" is _not_ a
+  modification; that does not change the serial number. The serial number is
+  maintained internally and cannot be user-modified.
+- The DependencyTicket ("ticket") stored here identifies the DependencyTracker
+  ("tracker") associated with this cache entry. The tracker maintains lists of
+  all upstream prerequisites and downstream dependents of the value stored here,
+  and also has a pointer to this %CacheEntryValue that it uses for invalidation.
+  Upstream modifications cause the tracker to set the `out_of_date` flag here,
+  and mark all downstream dependents out of date also. The tracker lives in
+  the same subcontext that owns the Cache that owns this %CacheEntryValue.
 
-// These are stubs for the two classes that comprise the cache:
-// - CacheEntryValue representing a single cache entry and storing its
-//                   abtract value and "up-to-date" indicator.
-// - Cache the container for CacheEntryValues
-//
-// Note that a Cache is local to a particular Context; that is, when there is
-// a diagram, each Context within it has its own Cache object.
-#ifndef DRAKE_DOXYGEN_CXX  // Hide from Doxygen for now.
+We sometimes use the terms "invalid" and "invalidate" as synonyms for "out of
+date" and "mark out of date".
+
+For debugging purposes, caching may be disabled for an entire Context or for
+particular cache entry values. This is independent of the `out_of_date` flag
+described above, which is still expected to be operational when caching is
+disabled. However, when caching is disabled the Eval() methods will recompute
+the contained value even if it is not marked out of date. That should have no
+effect other than to slow computation; if results change, something is wrong.
+There could be a problem with the specification of dependencies, a bug in user
+code such as improper retention of a stale reference, or a bug in the caching
+system. */
 class CacheEntryValue {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(CacheEntryValue)
+  /** @name  Does not allow move or assignment; copy constructor is private. */
+  /** @{ */
+  CacheEntryValue(CacheEntryValue&&) = delete;
+  void operator=(const CacheEntryValue&) = delete;
+  void operator=(CacheEntryValue&&) = delete;
+  /** @} */
 
-  CacheEntryValue(CacheIndex index, DependencyTicket ticket,
-                  std::string description,
-                  std::unique_ptr<AbstractValue> initial_value)
-      : description_(std::move(description)),
-        cache_index_(index),
-        value_(std::move(initial_value)),
-        ticket_(ticket) {
-    DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
-    // OK if value is null here.
-  }
+  /** Destructs the cache value, but does not issue any notifications to
+  downstream dependents. */
+  ~CacheEntryValue() = default;
 
+  /** Defines the concrete value type by providing an initial AbstractValue
+  object containing an object of the appropriate concrete type. This value
+  is marked out of date. It is an error to call this if there is already
+  a value here; use has_value() if you want to check first. Also, the given
+  initial value may not be null. The serial number is set to 1. No out-of-date
+  notifications are sent to downstream dependents.
+  @throws std::logic_error if the given value is null or if there is already a
+                           value, or if this %CacheEntryValue is malformed in
+                           some detectable way. */
   void SetInitialValue(std::unique_ptr<AbstractValue> init_value) {
+    if (init_value == nullptr) {
+      throw std::logic_error(FormatName(__func__) +
+                             "initial value may not be null.");
+    }
+    ThrowIfValuePresent(__func__);
     value_ = std::move(init_value);
-    set_is_up_to_date(false);
+    serial_number_ = 1;
+    mark_out_of_date();
+    ThrowIfBadCacheEntryValue();  // Sanity check.
   }
 
+  /** @name      Safe methods for value access and modification
+  These are the recommended methods for accessing and modifying the cache entry
+  value. They unconditionally check all the relevant preconditions to catch
+  usage errors. In particular, access is prevented when the value is out of
+  date, and modification is permitted only when (a) the value is _already_ out
+  of date (typically because a prerequisite changed), or (b) caching is
+  disabled for this entry. For performance-sensitive code, you may need to use
+  the parallel set of methods below that check preconditions only in Debug
+  builds, but be sure you are gaining significant performance before giving up
+  on Release-build validation. */
+  //@{
+
+  /** Returns a const reference to the contained abstract value, which must
+  not be out of date with respect to any of its prerequisites. It is
+  an error to call this if there is no stored value object, or if the value is
+  out of date.
+  @throws std::logic_error if there is no value or it is out of date.
+  @see get_abstract_value() */
+  const AbstractValue& GetAbstractValueOrThrow() const {
+    return GetAbstractValueOrThrowHelper(__func__);
+  }
+
+  /** Returns a const reference to the contained value of known type V. It is
+  an error to call this if there is no stored value, or the value is out of
+  date, or the value doesn't actually have type V.
+  @throws std::logic_error if there is no stored value, or if it is out of
+                           date, or it doesn't actually have type V.
+  @see get_value() */
+  template <typename V>
+  const V& GetValueOrThrow() const {
+    return GetValueOrThrowHelper<V>(__func__);
+  }
+
+  /** Assigns a new value to a cache entry and marks it up to date.
+  The cache entry must already contain a value object of type V to which the
+  new value is assigned, and that value must currently be marked out of date.
+  The supplied new value _must_ have been calculated using the current values
+  in the owning Context, and we assume that here although this method cannot
+  check that assumption. Consequently, this method clears the `out_of_date`
+  flag. No out-of-date notifications are issued by this method; we assume
+  downstream dependents were marked out of date at the time this value went out
+  of date. The serial number is incremented.
+
+  This method is the safest and most convenient way to assign a new value.
+  However it requires that a new value be computed and then copied into the
+  cache entry, which is fine for small types V but may be too expensive for
+  large ones. You can alternatively obtain a mutable reference to the value
+  already contained in the cache entry and update it in place via
+  GetMutableValueOrThrow().
+  @throws std::logic_error if there is no value, or the value is already up
+                           to date, of it doesn't actually have type V.
+  @see set_value(), GetMutableValueOrThrow() */
+  template <typename V>
+  void SetValueOrThrow(const V& new_value) {
+    SetValueOrThrowHelper<V>(__func__, new_value);
+    ++serial_number_;
+    mark_up_to_date();
+  }
+
+  /** (Advanced) Returns a mutable reference to the contained value after
+  incrementing the serial number. This is for the purpose of performing an
+  update or extended computation in place. If possible, use the safer and more
+  straightforward method SetValueOrThrow() rather than this method. Mutable
+  access is only permitted if the value is already marked out of date (meaning
+  that all downstream dependents have already been notified). It is an error to
+  call this if there is no stored value, or it is already up to date. Since this
+  is intended for relatively expensive computations, these preconditions are
+  checked even in Release builds. If you have a small, fast computation to
+  perform, use set_value() instead. If your computation completes successfully,
+  you must mark the entry up to date yourself using mark_up_to_date() if you
+  want anyone to be able to use the new value.
+  @throws std::logic_error if there is no value, or if the value is already
+                           up to date.
+  @see SetValueOrThrow(), set_value(), mark_up_to_date() */
+  AbstractValue& GetMutableAbstractValueOrThrow() {
+    return GetMutableAbstractValueOrThrowHelper(__func__);
+  }
+
+  /** (Advanced) Convenience method that returns a mutable reference to the
+  contained value downcast to its known concrete type. Throws an exception if
+  the contained value does not have the indicated concrete type. Note that you
+  must call mark_up_to_date() after modifying the value through the returned
+  reference. See GetMutableAbstractValueOrThrow() above for more information.
+  @throws std::logic_error if there is no value, or if the value is already
+                           up to date, of it doesn't actually have type V.
+  @see SetValueOrThrow(), set_value(), mark_up_to_date()
+  @tparam V The known actual value type. */
+  template <typename V>
+  V& GetMutableValueOrThrow() {
+    AbstractValue& value = GetMutableAbstractValueOrThrowHelper(__func__);
+    return value.GetMutableValueOrThrow<V>();
+  }
+
+  /** (Advanced) Returns a reference to the contained value _without_ checking
+  whether the value is out of date. This can be used to check type and size
+  information but should not be used to look at the value unless you _really_
+  know what you're doing.
+  @throws std::logic_error if there is no contained value. */
+  const AbstractValue& PeekAbstractValueOrThrow() const {
+    ThrowIfNoValuePresent(__func__);
+    return *value_;
+  }
+
+  /** (Advanced) Convenience method that provides access to the contained value
+  downcast to its known concrete type, _without_ checking whether the value is
+  out of date. This can be used to check type and size information but should
+  not be used to look at the value unless you _really_ know what you're doing.
+  @throws std::logic_error if there is no contained value, or if the contained
+                           value does not actually have type V.
+  @tparam V The known actual value type. */
+  template <typename V>
+  const V& PeekValueOrThrow() const {
+    ThrowIfNoValuePresent(__func__);
+    return value_->GetMutableValueOrThrow<V>();
+  }
+  //@}
+
+  /** @name    Fast-but-dangerous methods for highest performance
+  These methods check for errors only in Debug builds, but plunge
+  blindly onward in Release builds so that they will execute as fast as
+  possible. You should use them only in places where performance requirements
+  preclude Release-build checks. The best way to determine that is to time the
+  code using the always-checked methods vs. these ones. If that's not practical,
+  use these only when the containing code is in a very high-rate loop, and
+  is a substantial fraction of the total code being executed there. */
+  //@{
+
+  /** Returns a const reference to the contained abstract value, which must
+  not be out of date with respect to any of its prerequisites. It is an error
+  to call this if there is no stored value, or it is out of date. Because this
+  is used in performance-critical contexts, these requirements will be
+  checked only in Debug builds. If you are not in a performance-critical
+  situation (and you probably are not!), use GetAbstractValueOrThrow()
+  instead. */
+  const AbstractValue& get_abstract_value() const {
+#ifdef DRAKE_ASSERT_IS_ARMED
+    return GetAbstractValueOrThrowHelper(__func__);
+#else
+    return *value_;
+#endif
+  }
+
+  /** Returns a const reference to the contained value of known type V. It is
+  an error to call this if there is no stored value, or the value is out of
+  date, or the value doesn't actually have type V. Because this is expected to
+  be used in performance-critical, inner-loop circumstances, these requirements
+  will be checked only in Debug builds. If you are not in a performance-critical
+  situation (and you probably are not!), use `GetValueOrThrow<V>`() instead.
+  @tparam V The known actual value type. */
+  template <typename V>
+  const V& get_value() const {
+#ifdef DRAKE_ASSERT_IS_ARMED
+    return GetValueOrThrowHelper<V>(__func__);
+#else
+    return value_->GetValue<V>();
+#endif
+  }
+
+  /** Assigns a new value to a cache entry and marks it up to date.
+  The cache value must already have a value object of type V to which the
+  new value is assigned, and that value must not already be up to date.
+  The new value is assumed to be up to date with its prerequisites, so the
+  `out_of_date` flag is cleared. No out-of-date notifications are issued by this
+  method; we assume downstream dependents were marked out of date at the time
+  this value went out of date. The serial number is incremented. If you are not
+  in a performance-critical situation (and you probably are not!), use
+  `SetValueOrThrow<V>()` instead.
+  @tparam V The known actual value type. */
   template <typename V>
   void set_value(const V& new_value) {
+#ifdef DRAKE_ASSERT_IS_ARMED
+    SetValueOrThrowHelper<V>(__func__, new_value);
+#else
     value_->SetValue<V>(new_value);
-    set_is_up_to_date(true);
+#endif
+    ++serial_number_;
+    mark_up_to_date();
   }
 
-  bool is_up_to_date() const { return is_up_to_date_flag_; }
+  /** (Advanced) Swaps ownership of the stored value object with the given
+  one. The value is marked out of date and the serial number is incremented.
+  This is useful for discrete updates of abstract state variables that contain
+  large objects. Both values must be non-null and of the same concrete type but
+  we won't check for errors except in Debug builds. */
+  void swap_value(std::unique_ptr<AbstractValue>* other_value) {
+    DRAKE_ASSERT_VOID(ThrowIfNoValuePresent(__func__));
+    DRAKE_ASSERT_VOID(ThrowIfBadOtherValue(__func__, other_value));
+    value_.swap(*other_value);
+    ++serial_number_;
+    mark_out_of_date();
+  }
+  //@}
 
+  /** @name                  Dependency management
+  Methods here deal with management of the `out_of_date` flag and determining
+  whether the contained value must be recomputed before use. */
+  //@{
+
+  /** Returns `true` if the current value is out of date with respect to any of
+  its prerequisites. This refers only to the `out_of_date` flag and is
+  independent of whether caching is enabled or disabled. Don't call this if
+  there is no value here; use has_value() if you aren't sure.
+  @see needs_recomputation() */
+  bool is_out_of_date() const {
+    DRAKE_ASSERT_VOID(ThrowIfNoValuePresent(__func__));
+    return (flags_ & kValueIsOutOfDate) != 0;
+  }
+
+  /** Returns `true` if either (a) the value is out of date, or (b) caching
+  is disabled for this entry. This is a _very_ fast inline method intended
+  to be called every time a cache value is obtained with Eval(). This is
+  equivalent to `is_out_of_date() || is_entry_disabled()` but faster.  Don't
+  call this if there is no value here; use has_value() if you aren't sure.*/
+  bool needs_recomputation() const {
+    DRAKE_ASSERT_VOID(ThrowIfNoValuePresent(__func__));
+    return flags_ != kReadyToUse;
+  }
+
+  /** (Advanced) Marks the cache entry value as up to date with respect to
+  its prerequisites, with no other effects. That is, this method clears the
+  `out_of_date` flag. In particular, this method does not
+  modify the value, does not change the serial number, and does not notify
+  downstream dependents of anything. This is a very dangerous method since it
+  enables access to the value but can't independently determine whether it is
+  really up to date. You should not call it unless you really know what you're
+  doing, or have a death wish. Do not call this method if there is no stored
+  value object; use has_value() if you aren't sure. This is intended
+  to be very fast so doesn't check for a value object except in Debug builds. */
+  void mark_up_to_date() {
+    DRAKE_ASSERT_VOID(ThrowIfNoValuePresent(__func__));
+    flags_ &= ~kValueIsOutOfDate;
+  }
+
+  /** (Advanced) Marks the cache entry value as _out-of-date_ with respect to
+  its prerequisites, with no other effects. In particular, it does not modify
+  the value, does not change the serial number, and does not notify downstream
+  dependents. You should not call this method unless you know that dependent
+  notification has already been taken care of. There are no error conditions;
+  even an empty cache entry can be marked out of date. */
+  void mark_out_of_date() {
+    flags_ |= kValueIsOutOfDate;
+  }
+
+  /** Returns the serial number of the contained value. This counts up every
+  time the contained value changes, or whenever mutable access is granted. */
+  int64_t serial_number() const { return serial_number_; }
+  //@}
+
+  /** @name                 Bookkeeping methods
+  Miscellaneous methods of limited use to most users. */
+  //@{
+
+  /** Returns the human-readable description for this %CacheEntryValue. */
+  const std::string& description() const { return description_; }
+
+  /** Returns the description, preceded by the full pathname of the subsystem
+  associated with the owning subcontext. */
+  std::string GetPathDescription() const;
+
+  /** Returns `true` if this %CacheEntryValue currently contains a value object
+  at all, regardless of whether it is up to date. There will be no value object
+  after default construction, prior to SetInitialValue(). */
+  bool has_value() const { return value_ != nullptr; }
+
+  /** Returns the CacheIndex used to locate this %CacheEntryValue within its
+  containing subcontext. */
   CacheIndex cache_index() const { return cache_index_; }
 
+  /** Returns the DependencyTicket used to locate the DependencyTracker that
+  manages dependencies for this %CacheEntryValue. The ticket refers to a
+  tracker that is owned by the same subcontext that owns this
+  %CacheEntryValue. */
   DependencyTicket ticket() const { return ticket_; }
+  //@}
 
-  void set_is_up_to_date(bool up_to_date) { is_up_to_date_flag_ = up_to_date; }
+  /** @name            Testing/debugging utilities
+  These are used for disabling and re-enabling caching to determine correctness
+  and effectiveness of caching. Usually all cache entries are disabled or
+  enabled together using higher-level methods that invoke these ones, but you
+  can disable just a single entry if necessary. */
+  //@{
 
-  /** Returns a mutable reference to an unused cache entry value object, which
-  has no valid CacheIndex or DependencyTicket and has a meaningless value. The
-  reference is to a singleton %CacheEntryValue and will always return the same
-  address. You may invoke set_is_up_to_date() harmlessly on this object, but may
-  not depend on its contents in any way as they may change unexpectedly. The
-  intention is that this object is used as a common throw-away destination for
-  non-cache DependencyTracker invalidations so that invalidation can be done
-  unconditionally, and to the same memory location, for speed. */
+  /** Throws an std::logic_error if there is something clearly wrong with this
+  %CacheEntryValue object. If the owning subcontext is known, provide a pointer
+  to it here and we'll check that this cache entry agrees. In addition we check
+  for other internal inconsistencies.
+  @throws std::logic_error for anything that goes wrong, with an appropriate
+                           explanatory message. */
+  // These invariants hold for all CacheEntryValues except the dummy one.
+  void ThrowIfBadCacheEntryValue(const internal::SystemPathnameInterface*
+                                     owning_subcontext = nullptr) const;
+
+  /** (Advanced) Disables caching for just this cache entry value. When
+  disabled, the corresponding entry's Eval() method will unconditionally invoke
+  Calc() to recompute the value, regardless of the setting of the `out_of_date`
+  flag. The `disabled` flag is independent of the `out_of_date` flag, which
+  will continue to be managed even if caching is disabled. */
+  void disable_caching() {
+    flags_ |= kCacheEntryIsDisabled;
+  }
+
+  /** (Advanced) Enables caching for this cache entry value if it was previously
+  disabled. When enabled (the default condition) the corresponding entry's
+  Eval() method will check the `out_of_date` flag and invoke Calc() only if the
+  entry is marked out of date. */
+  void enable_caching() {
+    flags_ &= ~kCacheEntryIsDisabled;
+  }
+
+  /** (Advanced) Returns `true` if caching is disabled for this cache entry.
+  This is independent of the `out_of_date` flag. */
+  bool is_cache_entry_disabled() const {
+    return (flags_ & kCacheEntryIsDisabled) != 0;
+  }
+  //@}
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // (Internal use only) Returns a mutable reference to an unused cache entry
+  // value object, which has no valid CacheIndex or DependencyTicket and has a
+  // meaningless value. The reference is to a singleton %CacheEntryValue and
+  // will always return the same address. You may invoke mark_up_to_date()
+  // harmlessly on this object, but may not depend on its contents in any way as
+  // they may change unexpectedly. The intention is that this object is used as
+  // a common throw-away destination for non-cache DependencyTracker
+  // invalidations so that invalidation can be done unconditionally, and to the
+  // same memory location, for speed.
   static CacheEntryValue& dummy() {
     static never_destroyed<CacheEntryValue> dummy;
     return dummy.access();
   }
+#endif
 
  private:
-  // Allow never_destroyed to invoke the private constructor on our behalf.
+  // So Cache and no one else can construct and copy CacheEntryValues.
+  friend class Cache;
+
+  // Allow these adapters access to our private constructors on our behalf.
+  // TODO(sherm1) These friend declarations allow us to hide constructors we
+  //   don't want users to call. But there is still a loophole in that a user
+  //   could create objects of these types and get access indirectly. Consider
+  //   whether that is a real problem that needs to be solved and if so fix it.
   friend class never_destroyed<CacheEntryValue>;
+  friend class copyable_unique_ptr<CacheEntryValue>;
 
   // Default constructor can only be used privately to construct an empty
   // CacheEntryValue with description "DUMMY" and a meaningless value.
   CacheEntryValue()
       : description_("DUMMY"), value_(AbstractValue::Make<int>(0)) {}
 
-  std::string description_;
+  // Creates a new cache value with the given human-readable description and
+  // (optionally) an abstract value that defines the right concrete type for
+  // this value. The given cache index and dependency ticket must be valid and
+  // are recorded here. Unless you have a good reason to do otherwise, make the
+  // description identical to the CacheEntry for which this is the value.
+  CacheEntryValue(CacheIndex index, DependencyTicket ticket,
+                  std::string description,
+                  const internal::SystemPathnameInterface* owning_subcontext,
+                  std::unique_ptr<AbstractValue> initial_value)
+      : cache_index_(index),
+        ticket_(ticket),
+        description_(std::move(description)),
+        owning_subcontext_(owning_subcontext),
+        value_(std::move(initial_value)) {
+    DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
+    DRAKE_DEMAND(owning_subcontext != nullptr);
+    // OK if initial_value is null here.
+  }
+
+  // Copy constructor is private because it requires post-copy cleanup via
+  // set_owning_subcontext().
+  CacheEntryValue(const CacheEntryValue&) = default;
+
+  // This is the post-copy cleanup method.
+  void set_owning_subcontext(
+      const internal::SystemPathnameInterface* owning_subcontext) {
+    DRAKE_DEMAND(owning_subcontext != nullptr);
+    DRAKE_DEMAND(owning_subcontext_ == nullptr);
+    owning_subcontext_ = owning_subcontext;
+  }
+
+  // Fully-checked method with API name to use in error messages.
+  const AbstractValue& GetAbstractValueOrThrowHelper(const char* api) const {
+    ThrowIfNoValuePresent(api);
+    ThrowIfOutOfDate(api);  // Must *not* be out of date!
+    return *value_;
+  }
+
+  // Note that serial number is incremented here since caller will be stomping
+  // on this value.
+  AbstractValue& GetMutableAbstractValueOrThrowHelper(const char* api) {
+    ThrowIfNoValuePresent(api);
+    ThrowIfAlreadyComputed(api);  // *Must* be out of date!
+    ++serial_number_;
+    return *value_;
+  }
+
+  // Adds a check on the concrete value type also.
+  template <typename T>
+  const T& GetValueOrThrowHelper(const char* api) const {
+    return GetAbstractValueOrThrowHelper(api).GetValueOrThrow<T>();
+  }
+
+  // Fully-checked method with API name to use in error messages.
+  template <typename T>
+  void SetValueOrThrowHelper(const char* api, const T& new_value) const {
+    ThrowIfNoValuePresent(api);
+    ThrowIfAlreadyComputed(api);
+    return value_->SetValueOrThrow<T>(new_value);
+  }
+
+  void ThrowIfNoValuePresent(const char* api) const {
+    if (!has_value())
+      throw std::logic_error(FormatName(api) + "no value is present.");
+  }
+
+  void ThrowIfValuePresent(const char* api) const {
+    if (has_value()) {
+      throw std::logic_error(FormatName(api) +
+          "there is already a value object in this CacheEntryValue.");
+    }
+  }
+
+  // Throws if "other" doesn't have the same concrete type as this value.
+  // Don't call this unless you've already verified that there is a value.
+  void ThrowIfBadOtherValue(
+      const char* api,
+      const std::unique_ptr<AbstractValue>* other_value_ptr) const;
+
+  // This means literally that the out-of-date bit is set; it does not look
+  // at whether caching is disabled.
+  void ThrowIfOutOfDate(const char* api) const {
+    if (is_out_of_date()) {
+      throw std::logic_error(FormatName(api) +
+                             "the current value is out of date.");
+    }
+  }
+
+  // This checks that there is *some* reason to recompute -- either out-of-date
+  // or caching is disabled.
+  void ThrowIfAlreadyComputed(const char* api) const {
+    if (!needs_recomputation()) {
+      throw std::logic_error(FormatName(api) +
+          "the current value is already up to date.");
+    }
+  }
+
+  // Provides an identifying prefix for error messages.
+  std::string FormatName(const char* api) const {
+    return "CacheEntryValue(" + GetPathDescription() + ")::" + api + "(): ";
+  }
+
+  // The sense of these flag bits is chosen so that Eval() can check in a single
+  // instruction whether it must recalculate. Only if flags==0 (kReadyToUse) can
+  // we reuse the existing value. See needs_recomputation() above.
+  enum Flags : int {
+    kReadyToUse           = 0b00,
+    kValueIsOutOfDate     = 0b01,
+    kCacheEntryIsDisabled = 0b10
+  };
+
+  // The index for this CacheEntryValue within its containing subcontext.
   CacheIndex cache_index_;
-  copyable_unique_ptr<AbstractValue> value_;
-  bool is_up_to_date_flag_{false};
+
+  // The ticket for this cache entry's managing DependencyTracker in the
+  // containing subcontext.
   DependencyTicket ticket_;
+
+  // A human-readable description of this cache entry. Not interpreted by code
+  // but useful for error messages.
+  std::string description_;
+
+  // Pointer to the system name service of the owning subcontext. Used for
+  // error messages.
+  reset_on_copy<const internal::SystemPathnameInterface*>
+      owning_subcontext_;
+
+  // The value, its serial number, and its validity. The value is copyable so
+  // that we can use a default copy constructor. The serial number is
+  // 0 on construction but is always >= 1 once we get an initial value.
+  copyable_unique_ptr<AbstractValue> value_;
+  int64_t serial_number_{0};
+  int flags_{kValueIsOutOfDate};
 };
 
-// TODO(sherm1) Stubbed for DependencyTracker/Graph review; don't review.
+//==============================================================================
+//                                  CACHE
+//==============================================================================
+/** Stores all the CacheEntryValue objects owned by a particular Context,
+organized to allow fast access using a CacheIndex as an index. Memory addresses
+of CacheEntryValue objects are stable once allocated, but CacheIndex numbers are
+stable even after a Context has been copied so should be preferred as a means
+for identifying particular cache entries. */
 class Cache {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Cache)
+  /** @name  Does not allow move or assignment; copy constructor is private. */
+  //@{
+  Cache(Cache&&) = delete;
+  void operator=(const Cache&) = delete;
+  void operator=(Cache&&) = delete;
+  //@}
 
-  Cache() = default;
+  /** Constructor creates an empty cache referencing the system pathname
+  service of its owning subcontext. The supplied pointer must not be null. */
+  explicit Cache(const internal::SystemPathnameInterface* owning_subcontext)
+      : owning_subcontext_(owning_subcontext) {
+    DRAKE_DEMAND(owning_subcontext != nullptr);
+  }
 
-  // Allocates a new CacheEntryValue and corresponding DependencyTracker using
-  // the given CacheIndex and DependencyTicket number. The CacheEntryValue
-  // object is owned by this Cache and the returned reference remains valid
-  // if other cache entry values are created. The created DependencyTracker
-  // object is owned by the given DependencyGraph, which must be owned by
-  // the same Context that owns this Cache. The graph must already contain
-  // trackers for the indicated prerequisites. The new tracker will retain a
-  // pointer to the created CacheEntryValue for invalidation purposes.
+  /** Destruction deletes all cache entries and their contained values; no
+  dependency notifications are issued. */
+  ~Cache() = default;
+
+  /** Allocates a new CacheEntryValue and corresponding DependencyTracker using
+  the given CacheIndex and DependencyTicket number. The CacheEntryValue
+  object is owned by this Cache and the returned reference remains valid
+  if other cache entry values are created. The created DependencyTracker
+  object is owned by the given DependencyGraph, which must be owned by
+  the same Context that owns this Cache. The graph must already contain
+  trackers for the indicated prerequisites. The new tracker will retain a
+  pointer to the created CacheEntryValue for invalidation purposes. */
   CacheEntryValue& CreateNewCacheEntryValue(
       CacheIndex index, DependencyTicket ticket,
       const std::string& description,
       const std::vector<DependencyTicket>& prerequisites,
       DependencyGraph* graph);
 
-  int num_entries() const { return static_cast<int>(store_.size()); }
+  /** Returns true if there is a CacheEntryValue in this cache that has the
+  given index. */
+  bool has_cache_entry_value(CacheIndex index) const {
+    DRAKE_DEMAND(index.is_valid());
+    if (index >= cache_size()) return false;
+    return store_[index] != nullptr;
+  }
 
-  CacheEntryValue& get_mutable_cache_entry_value(CacheIndex index) {
-    CacheEntryValue& cache_value = *store_[index];
+  /** Returns the current size of the Cache container, providing for CacheIndex
+  values from `0..cache_size()-1`. Note that it is possible to have empty slots
+  in the cache. Use has_cache_entry_value() to determine if there is a cache
+  entry associated with a particular index. */
+  int cache_size() const { return static_cast<int>(store_.size()); }
+
+  /** Returns a const CacheEntryValue given an index. This is very fast.
+  Behavior is undefined if the index is out of range [0..cache_size()-1] or
+  if there is no CacheEntryValue with that index. Use has_cache_entry_value()
+  first if you aren't sure. */
+  const CacheEntryValue& get_cache_entry_value(CacheIndex index) const {
+    DRAKE_ASSERT(has_cache_entry_value(index));
+    const CacheEntryValue& cache_value = *store_[index];
+    DRAKE_ASSERT(cache_value.cache_index() == index);
     return cache_value;
   }
 
+  /** Returns a mutable CacheEntryValue given an index. This is very fast.
+  Behavior is undefined if the index is out of range [0..cache_size()-1] or
+  if there is no CacheEntryValue with that index. Use has_cache_entry_value()
+  first if you aren't sure.  */
+  CacheEntryValue& get_mutable_cache_entry_value(CacheIndex index) {
+    return const_cast<CacheEntryValue&>(get_cache_entry_value(index));
+  }
+
+  /** (Advanced) Disables caching for all the entries in this %Cache. Note that
+  this is done by setting individual `is_disabled` flags in the entries, so it
+  can be changed on a per-entry basis later. This has no effect on the
+  `out_of_date` flags. */
+  void DisableCaching();
+
+  /** (Advanced) Re-enables caching for all entries in this %Cache if any were
+  previously disabled. Note that this is done by clearing individual
+  `is_disabled` flags in the entries, so it overrides any disabling that may
+  have been done to individual entries. This has no effect on the `out_of_date`
+  flags so subsequent Eval() calls might not initiate recomputation. Use
+  SetAllEntriesOutOfDate() if you want to force recomputation. */
+  void EnableCaching();
+
+  /** (Advanced) Mark every entry in this cache as "out of date". This forces
+  the next Eval() request for an entry to perform a recalculation. After that
+  normal caching behavior resumes. */
+  void SetAllEntriesOutOfDate();
+
  private:
+  // So ContextBase and no one else can copy a Cache.
+  friend class ContextBase;
+
+  // Copy constructor duplicates the source %Cache object, with identical
+  // contents but with the "owning subcontext" back pointers set to null. Those
+  // must be set properly using RepairCachePointers() once the new subcontext is
+  // available. This should only be invoked by ContextBase code as part of
+  // copying an entire Context tree.
+  Cache(const Cache& source) = default;
+
+  // Assumes `this` %Cache is a recent copy that does not yet have its pointers
+  // to the system name-providing service of the new owning Context, and sets
+  // those pointers. The supplied pointer must not be null, and there must not
+  // already be an owning subcontext set here.
+  void RepairCachePointers(
+      const internal::SystemPathnameInterface* owning_subcontext);
+
+  // The system name service of the subcontext that owns this cache. This should
+  // not be copied since it would still refer to the source subcontext.
+  reset_on_copy<const internal::SystemPathnameInterface*>
+      owning_subcontext_;
+
+  // All CacheEntryValue objects, indexed by CacheIndex.
   std::vector<copyable_unique_ptr<CacheEntryValue>> store_;
 };
-#endif  // Hiding from Doxygen.
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -26,6 +26,21 @@ std::unique_ptr<ContextBase> ContextBase::Clone() const {
 
 ContextBase::~ContextBase() {}
 
+void ContextBase::DisableCaching() const {
+  cache_.DisableCaching();
+  // TODO(sherm1) Recursive disabling of descendents goes here.
+}
+
+void ContextBase::EnableCaching() const {
+  cache_.EnableCaching();
+  // TODO(sherm1) Recursive enabling of descendents goes here.
+}
+
+void ContextBase::SetAllCacheEntriesOutOfDate() const {
+  cache_.SetAllEntriesOutOfDate();
+  // TODO(sherm1) Recursive update of descendents goes here.
+}
+
 std::string ContextBase::GetSystemPathname() const {
   // TODO(sherm1) Replace with the real pathname.
   return "/dummy/system/pathname";
@@ -34,17 +49,97 @@ std::string ContextBase::GetSystemPathname() const {
 // Set up trackers for independent sources: time, accuracy, state, parameters,
 // and input ports.
 void ContextBase::CreateBuiltInTrackers() {
-  DependencyGraph& trackers = graph_;
+  DependencyGraph& graph = graph_;
   // This is the dummy "tracker" used for constants and anything else that has
   // no dependencies on any Context source. Ignoring return value.
-  trackers.CreateNewDependencyTracker(
+  graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kNothingTicket), "nothing");
 
-  // Allocate time tracker. Ignoring return value.
-  trackers.CreateNewDependencyTracker(
+  // Allocate trackers for time, accuracy, q, v, z.
+  auto& time_tracker = graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kTimeTicket), "t");
+  auto& accuracy_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kAccuracyTicket), "accuracy");
+  auto& q_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kQTicket), "q");
+  auto& v_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kVTicket), "v");
+  auto& z_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kZTicket), "z");
 
-  // TODO(sherm1) Add the rest of the built-in tickets here.
+  // Continuous state xc depends on q, v, and z.
+  auto& xc_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kXcTicket), "xc");
+  xc_tracker.SubscribeToPrerequisite(&q_tracker);
+  xc_tracker.SubscribeToPrerequisite(&v_tracker);
+  xc_tracker.SubscribeToPrerequisite(&z_tracker);
+
+  // Allocate the "all discrete variables" xd tracker. The associated System is
+  // responsible for allocating the individual discrete variable group xdᵢ
+  // trackers and subscribing this one to each of those.
+  auto& xd_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kXdTicket), "xd");
+
+  // Allocate the "all abstract variables" xa tracker. The associated System is
+  // responsible for allocating the individual abstract variable xaᵢ
+  // trackers and subscribing this one to each of those.
+  auto& xa_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kXaTicket), "xa");
+
+  // The complete state x={xc,xd,xa}.
+  auto& x_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kXTicket), "x");
+  x_tracker.SubscribeToPrerequisite(&xc_tracker);
+  x_tracker.SubscribeToPrerequisite(&xd_tracker);
+  x_tracker.SubscribeToPrerequisite(&xa_tracker);
+
+  // Allocate the "all parameters" p tracker. The associated System is
+  // responsible for allocating the individual numeric parameter pnᵢ and
+  // abstract paraemter paᵢ trackers and subscribing this one to each of those.
+  auto& p_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kAllParametersTicket), "p");
+
+  // Allocate the "all input ports" u tracker. The associated System is
+  // responsible for allocating the individual input port uᵢ
+  // trackers and subscribing this one to each of those.
+  auto& u_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kAllInputPortsTicket), "u");
+
+  // Allocate the "all sources" tracker. The complete list of known sources
+  // is t,a,x,p,u. Note that cache entries are not included. Under normal
+  // operation that doesn't matter because cache entries are invalidated only
+  // when one of these source values changes. Any computation that has
+  // declared "all sources" dependence will also have been invalidated for the
+  // same reason so doesn't need to explicitly list cache entries.
+  auto& all_sources_tracker = graph.CreateNewDependencyTracker(
+      DependencyTicket(internal::kAllSourcesTicket), "all sources");
+  all_sources_tracker.SubscribeToPrerequisite(&time_tracker);
+  all_sources_tracker.SubscribeToPrerequisite(&accuracy_tracker);
+  all_sources_tracker.SubscribeToPrerequisite(&x_tracker);
+  all_sources_tracker.SubscribeToPrerequisite(&p_tracker);
+  all_sources_tracker.SubscribeToPrerequisite(&u_tracker);
+
+  // TODO(sherm1) Add the rest of the built-in trackers here.
+}
+
+void ContextBase::BuildTrackerPointerMap(
+    const ContextBase& clone,
+    DependencyTracker::PointerMap* tracker_map) const {
+  // First map the pointers local to this context.
+  graph_.AppendToTrackerPointerMap(clone.get_dependency_graph(),
+                                   &(*tracker_map));
+  // TODO(sherm1) Recursive update of descendents goes here.
+}
+
+void ContextBase::FixTrackerPointers(
+    const ContextBase& source,
+    const DependencyTracker::PointerMap& tracker_map) {
+  // First repair pointers local to this context.
+  graph_.RepairTrackerPointers(source.get_dependency_graph(), tracker_map, this,
+                               &cache_);
+  // Cache and only needs its back pointers set to this.
+  cache_.RepairCachePointers(this);
+  // TODO(sherm1) Recursive update of descendents goes here.
 }
 
 }  // namespace systems

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -60,8 +60,8 @@ void DependencyTracker::NotePrerequisiteChange(
     return;
   }
   last_change_event_ = change_event;
-  // Update associated value if any.
-  cache_value_->set_is_up_to_date(false);
+  // Invalidate associated cache entry value if any.
+  cache_value_->mark_out_of_date();
   // Follow up with downstream subscribers.
   NotifySubscribers(change_event, depth);
 }
@@ -171,6 +171,45 @@ bool DependencyTracker::HasSubscriber(
   return Contains(&subscriber, subscribers_);
 }
 
+void DependencyTracker::ThrowIfBadDependencyTracker(
+    const internal::SystemPathnameInterface* owning_subcontext,
+    const CacheEntryValue* cache_value) const {
+  if (owning_subcontext_ == nullptr) {
+    // Can't use FormatName() here because that depends on us having an owning
+    // context to talk to.
+    throw std::logic_error("DependencyTracker(" + description() + ")::" +
+        __func__ +
+        "(): tracker has no owning subcontext.");
+  }
+  if (owning_subcontext && owning_subcontext_ != owning_subcontext) {
+    throw std::logic_error(FormatName(__func__) + "wrong owning subcontext.");
+  }
+  if (cache_value_ == nullptr) {
+    throw std::logic_error(
+        FormatName(__func__) +
+            "no associated cache entry value (should at least be a dummy).");
+  }
+  if (cache_value && cache_value_ != cache_value) {
+    throw std::logic_error(FormatName(__func__) +
+        "wrong associated cache entry value.");
+  }
+  if (!ticket_.is_valid()) {
+    throw std::logic_error(FormatName(__func__) +
+        "dependency ticket invalid.");
+  }
+  if (last_change_event_ < -1) {
+    throw std::logic_error(FormatName(__func__) +
+        "last change event has an absurd value.");
+  }
+  if (num_value_change_notifications_received_ < 0 ||
+      num_prerequisite_notifications_received_ < 0 ||
+      num_ignored_notifications_ < 0 ||
+      num_downstream_notifications_sent_ < 0) {
+    throw std::logic_error(FormatName(__func__) +
+        "a counter has a negative value.");
+  }
+}
+
 void DependencyTracker::RepairTrackerPointers(
     const DependencyTracker& source,
     const DependencyTracker::PointerMap& tracker_map,
@@ -208,6 +247,9 @@ void DependencyTracker::RepairTrackerPointers(
     DRAKE_DEMAND(map_entry != tracker_map.end());
     prerequisites_[i] = map_entry->second;
   }
+
+  // This should never happen, but ...
+  ThrowIfBadDependencyTracker();
 }
 
 void DependencyGraph::AppendToTrackerPointerMap(

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -263,6 +263,24 @@ class DependencyTracker {
   }
   //@}
 
+  /** @name                Testing/debugging utilities
+  Methods used in test cases or for debugging. */
+  //@{
+
+  /** Throws an std::logic_error if there is something clearly wrong with this
+  %DependencyTracker object. If the owning subcontext is known, provide a
+  pointer to it here and we'll check that this tracker agrees. If you know which
+  cache entry is supposed to be associated with this tracker, supply a pointer
+  to that and we'll check it (trackers that are not associated with a real cache
+  entry are still associated with the CacheEntryValue::dummy()). In addition we
+  check for other internal inconsistencies.
+  @throws std::logic_error for anything that goes wrong, with an appropriate
+                           explanatory message. */
+  void ThrowIfBadDependencyTracker(
+      const internal::SystemPathnameInterface* owning_subcontext = nullptr,
+      const CacheEntryValue* cache_value = nullptr) const;
+  //@}
+
  private:
   friend class DependencyGraph;
 
@@ -306,7 +324,8 @@ class DependencyTracker {
   // Assumes `this` tracker is a recent clone containing no pointers, sets
   // the pointers here to addresses corresponding to those in the source
   // tracker, with the help of the given map. It is a fatal error if any needed
-  // pointer is not present in the map.
+  // pointer is not present in the map. Performs a sanity check that the
+  // resulting tracker looks reasonable.
   void RepairTrackerPointers(
       const DependencyTracker& source,
       const DependencyTracker::PointerMap& tracker_map,
@@ -333,6 +352,11 @@ class DependencyTracker {
   std::string GetSystemPathname() const {
     DRAKE_DEMAND(owning_subcontext_!= nullptr);
     return owning_subcontext_->GetSystemPathname();
+  }
+
+  // Provides an identifying prefix for error messages.
+  std::string FormatName(const char* api) const {
+    return "DependencyTracker(" + GetPathDescription() + ")::" + api + "(): ";
   }
 
   // This tracker's index within its owning DependencyGraph.

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -104,8 +104,19 @@ entries are allocated beginning with kNextAvailableTicket defined below. */
 enum BuiltInTicketNumbers {
   kNothingTicket        =  0,
   kTimeTicket           =  1,
-  // TODO(sherm1) Add in the rest of the built-in tickets here.
-  kNextAvailableTicket  = kTimeTicket + 1
+  kAccuracyTicket       =  2,
+  kQTicket              =  3,
+  kVTicket              =  4,
+  kZTicket              =  5,
+  kXcTicket             =  6,
+  kXdTicket             =  7,
+  kXaTicket             =  8,
+  kXTicket              =  9,
+  kAllParametersTicket  = 10,
+  kAllInputPortsTicket  = 11,
+  kAllSourcesTicket     = 12,
+  kNextAvailableTicket  = kAllSourcesTicket+1
+  // TODO(sherm1) Add the rest of the built-in tickets here.
 };
 
 }  // namespace internal

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -106,7 +106,6 @@ class LeafContext : public Context<T> {
     // Make deep copies of everything else using the default copy constructors.
     *clone->get_mutable_step_info() = this->get_step_info();
     clone->set_accuracy(this->get_accuracy());
-    clone->cache_ = this->cache_;
     return clone;
   }
 
@@ -151,11 +150,6 @@ class LeafContext : public Context<T> {
 
   // The parameters of the system.
   std::unique_ptr<Parameters<T>> parameters_;
-
-  // The cache. The System may insert arbitrary key-value pairs, and configure
-  // invalidation on a per-entry basis.
-  // TODO(sherm1) This is non-functional here. Fix that!
-  mutable Cache cache_;
 };
 
 }  // namespace systems

--- a/systems/framework/test/cache_test.cc
+++ b/systems/framework/test/cache_test.cc
@@ -1,18 +1,570 @@
 #include "drake/systems/framework/cache.h"
 
+// Tests the Context (runtime) side of caching, which consists of a
+// Cache object containing CacheEntryValue objects, each intended to correspond
+// to one of a System's CacheEntry objects. User interaction with the cache is
+// normally through the CacheEntry objects; we're not attempting to test
+// CacheEntry here. Consequently we have to create cache entry values by
+// hand here which is clunky.
+
 #include <memory>
 #include <stdexcept>
 
 #include <gtest/gtest.h>
 
+#include "drake/systems/framework/context_base.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
 #include "drake/systems/framework/value.h"
+
+using std::string;
+using Eigen::Vector3d;
 
 namespace drake {
 namespace systems {
 namespace {
 
-// TODO(sherm1) Cache tests go here.
+// This is so we can use the contained cache & dependency graph objects, and
+// so we can use the ContextBase cloning infrastructure to clone the cache.
+class MyContextBase final : public ContextBase {
+ public:
+  MyContextBase() = default;
+  MyContextBase(const MyContextBase&) = default;
+
+ private:
+  std::unique_ptr<ContextBase> DoCloneWithoutPointers() const final {
+    return std::make_unique<MyContextBase>(*this);
+  }
+};
+
+// Dependency chains for cache entries here:
+//
+//   +-----------+    +--------------+
+//   |   time    +--->| string_entry +-----------+
+//   +-+---------+    +--------------+           |
+//     |                                         |
+//     |  +------+                        +------v-------+
+//     |  |  xc  +------------------------> vector_entry +
+//     |  +--+---+                        +--------------+
+//     |     |
+//   +-v-----v---+    +--------------+    +--------------+
+//   |all sources+--->|    entry0    +---->    entry1    +
+//   +-----------+    +------+-------+    +------+-------+
+//                           |                   |
+//                           |            +------v-------+
+//                           +------------>    entry2    +
+//                                        +--------------+
+//
+// The dependencies for all_sources are set up automatically during
+// Context construction; the others are set explicitly here.
+//
+// Value types:
+//   int: entry0,1,2
+//   string: string_entry
+//   MyVector3: vector_entry
+class CacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Manually dole out tickets and cache indexes.
+
+    index0_ = next_cache_index_++;
+    cache().CreateNewCacheEntryValue(index0_, next_ticket_++, "entry0",
+                                     {all_sources_ticket_}, &graph());
+    cache_value(index0_).SetInitialValue(PackValue(0));
+
+    index1_ = next_cache_index_++;
+    cache().CreateNewCacheEntryValue(index1_, next_ticket_++, "entry1",
+                                     {cache_value(index0_).ticket()},
+                                     &graph());
+    cache_value(index1_).SetInitialValue(PackValue(1));
+
+    index2_ = next_cache_index_++;
+    cache().CreateNewCacheEntryValue(
+        index2_, next_ticket_++, "entry2",
+        {cache_value(index0_).ticket(), cache_value(index1_).ticket()},
+        &graph());
+    cache_value(index2_).SetInitialValue(PackValue(2));
+
+    // Make the initial values up to date.
+    cache_value(index0_).mark_up_to_date();
+    cache_value(index1_).mark_up_to_date();
+    cache_value(index2_).mark_up_to_date();
+
+    string_index_ = next_cache_index_++;
+    cache().CreateNewCacheEntryValue(string_index_, next_ticket_++,
+                                     "string thing", {time_ticket_},
+                                     &graph());
+    cache_value(string_index_)
+        .SetInitialValue(AbstractValue::Make<string>("initial"));
+    EXPECT_TRUE(cache_value(string_index_).is_out_of_date());
+    cache_value(string_index_).mark_up_to_date();
+
+    vector_index_ = next_cache_index_++;
+    cache().CreateNewCacheEntryValue(
+        vector_index_, next_ticket_++, "vector thing",
+        {xc_ticket_, cache_value(string_index_).ticket()}, &graph());
+    const MyVector3d my_vec(Vector3d(0, 0, 0));
+    cache_value(vector_index_)
+        .SetInitialValue(AbstractValue::Make<MyVector3d>(my_vec));
+    EXPECT_TRUE(cache_value(vector_index_).is_out_of_date());
+    // set_value() should mark this up to date as a side effect.
+    cache_value(vector_index_).set_value(MyVector3d(Vector3d(99., 98., 97.)));
+
+    // Everything should be up to date to start out.
+    EXPECT_FALSE(cache_value(index0_).is_out_of_date());
+    EXPECT_FALSE(cache_value(index1_).is_out_of_date());
+    EXPECT_FALSE(cache_value(index2_).is_out_of_date());
+    EXPECT_FALSE(cache_value(string_index_).is_out_of_date());
+    EXPECT_FALSE(cache_value(vector_index_).is_out_of_date());
+  }
+
+  // Some sugar methods to shorten the calls. These default to the local Context
+  // but work with a given Context if needed.
+
+  CacheEntryValue& cache_value(CacheIndex index, Cache* cache_ptr = nullptr) {
+    if (!cache_ptr) cache_ptr = &cache();
+    return cache_ptr->get_mutable_cache_entry_value(index);
+  }
+
+  DependencyTracker& tracker(CacheIndex index,
+                             ContextBase* context_ptr = nullptr) {
+    if (!context_ptr) context_ptr = &context_;
+    return tracker(
+        cache_value(index, &context_ptr->get_mutable_cache()).ticket(),
+        &*context_ptr);
+  }
+
+  Cache& cache(ContextBase* context_ptr = nullptr) {
+    if (!context_ptr) context_ptr = &context_;
+    return context_ptr->get_mutable_cache();
+  }
+
+  DependencyGraph& graph(ContextBase* context_ptr = nullptr) {
+    if (!context_ptr) context_ptr = &context_;
+    return context_ptr->get_mutable_dependency_graph();
+  }
+
+  DependencyTracker& tracker(DependencyTicket ticket,
+                             ContextBase* context_ptr = nullptr) {
+    if (!context_ptr) context_ptr = &context_;
+    return graph(&*context_ptr).get_mutable_tracker(ticket);
+  }
+
+  std::unique_ptr<MyContextBase> context_ptr_ =
+      std::make_unique<MyContextBase>();
+  MyContextBase& context_ = *context_ptr_;
+  CacheIndex index0_, index1_, index2_;
+  CacheIndex string_index_, vector_index_;
+
+  const DependencyTicket nothing_ticket_{internal::kNothingTicket};
+  const DependencyTicket time_ticket_{internal::kTimeTicket};
+  const DependencyTicket z_ticket_{internal::kZTicket};
+  const DependencyTicket xc_ticket_{internal::kXcTicket};
+  const DependencyTicket all_sources_ticket_{internal::kAllSourcesTicket};
+  DependencyTicket next_ticket_{internal::kNextAvailableTicket};
+
+  CacheIndex next_cache_index_{cache().cache_size()};
+};
+
+// Check that SetInitialValue works and fails properly.
+TEST_F(CacheTest, SetInitialValueWorks) {
+  // Check that a value got set properly. (Others are checked below.)
+  EXPECT_EQ(cache_value(index2_).GetValueOrThrow<int>(), 2);
+
+  // Check that trying to provide another initial value fails.
+  EXPECT_THROW(cache_value(index2_).SetInitialValue(PackValue(5)),
+               std::logic_error);
+  EXPECT_EQ(cache_value(index2_).GetValueOrThrow<int>(), 2);  // No change.
+
+  // Check that an initial null value isn't allowed.
+  CacheIndex index(next_cache_index_++);
+  CacheEntryValue& value = cache().CreateNewCacheEntryValue(
+      index, next_ticket_++, "null value", {nothing_ticket_}, &graph());
+  EXPECT_FALSE(value.has_value());
+  EXPECT_THROW(
+      cache_value(index).SetInitialValue(std::unique_ptr<AbstractValue>()),
+      std::logic_error);
+  EXPECT_FALSE(value.has_value());  // No change.
+}
+
+// Check that a chain of dependent cache entries gets invalidated properly.
+// More extensive testing of dependency tracking is in the unit test for
+// dependency trackers.
+TEST_F(CacheTest, InvalidationWorks) {
+  // Everything starts out up to date. This should invalidate everything.
+  tracker(time_ticket_).NoteValueChange(99);
+  EXPECT_TRUE(cache_value(index0_).is_out_of_date());
+  EXPECT_TRUE(cache_value(index1_).is_out_of_date());
+  EXPECT_TRUE(cache_value(index2_).is_out_of_date());
+  EXPECT_TRUE(cache_value(string_index_).is_out_of_date());
+  EXPECT_TRUE(cache_value(vector_index_).is_out_of_date());
+}
+
+// Make sure the debugging routine that invalidates everything works.
+TEST_F(CacheTest, InvalidateAllWorks) {
+  // Everything starts out up to date. This should invalidate everything.
+  context_.SetAllCacheEntriesOutOfDate();
+  EXPECT_TRUE(cache_value(index0_).is_out_of_date());
+  EXPECT_TRUE(cache_value(index1_).is_out_of_date());
+  EXPECT_TRUE(cache_value(index2_).is_out_of_date());
+  EXPECT_TRUE(cache_value(string_index_).is_out_of_date());
+  EXPECT_TRUE(cache_value(vector_index_).is_out_of_date());
+}
+
+// Make sure the debugging routines to disable and re-enable caching work, and
+// are independent of the out of date flags.
+TEST_F(CacheTest, DisableCachingWorks) {
+  CacheEntryValue& int_val = cache_value(index1_);
+  CacheEntryValue& str_val = cache_value(string_index_);
+  CacheEntryValue& vec_val = cache_value(vector_index_);
+
+  // Everything starts out up to date. Memorize serial numbers.
+  int64_t ser_int = int_val.serial_number();
+  int64_t ser_str = str_val.serial_number();
+  int64_t ser_vec = vec_val.serial_number();
+
+  EXPECT_FALSE(int_val.needs_recomputation());
+  EXPECT_FALSE(str_val.needs_recomputation());
+  EXPECT_FALSE(vec_val.needs_recomputation());
+
+  context_.DisableCaching();
+  EXPECT_TRUE(int_val.is_cache_entry_disabled());  // Just check one.
+
+  // The out_of_date flag shouldn't be affected, but now we need recomputation.
+  EXPECT_FALSE(int_val.is_out_of_date());
+  EXPECT_FALSE(str_val.is_out_of_date());
+  EXPECT_FALSE(vec_val.is_out_of_date());
+  EXPECT_TRUE(int_val.needs_recomputation());
+  EXPECT_TRUE(str_val.needs_recomputation());
+  EXPECT_TRUE(vec_val.needs_recomputation());
+
+  // Flags are still supposed to be functioning while caching is disabled,
+  // even though they are mostly ignored. (The Get() method still depends
+  // on them.)
+  int_val.mark_out_of_date();
+  str_val.mark_out_of_date();
+  vec_val.mark_out_of_date();
+
+  // Eval() should recalculate and mark entries up to date..
+  int_val.SetValueOrThrow(101);
+  str_val.SetValueOrThrow(string("hello there"));
+  cache_value(vector_index_).SetValueOrThrow(MyVector3d(Vector3d(4., 5., 6.)));
+
+  EXPECT_FALSE(int_val.is_out_of_date());
+  EXPECT_FALSE(str_val.is_out_of_date());
+  EXPECT_FALSE(vec_val.is_out_of_date());
+
+  ++ser_int; ++ser_str; ++ser_vec;
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+  EXPECT_EQ(vec_val.serial_number(), ser_vec);
+
+  EXPECT_EQ(int_val.get_value<int>(), 101);
+  EXPECT_EQ(str_val.get_value<string>(), "hello there");
+  EXPECT_EQ(vec_val.get_value<MyVector3d>().get_value(),
+            Vector3d(4., 5., 6.));
+
+  // Should still need recomputation even though we just did it.
+  EXPECT_TRUE(int_val.needs_recomputation());
+  EXPECT_TRUE(str_val.needs_recomputation());
+  EXPECT_TRUE(vec_val.needs_recomputation());
+
+  // Now re-enable caching and verify that it works.
+  context_.EnableCaching();
+  EXPECT_FALSE(int_val.is_cache_entry_disabled());  // Just check one.
+
+  // Since the out_of_date flag was still functioning with caching disabled,
+  // we don't need to recompute now.
+  EXPECT_FALSE(int_val.needs_recomputation());
+  EXPECT_FALSE(str_val.needs_recomputation());
+  EXPECT_FALSE(vec_val.needs_recomputation());
+
+  // And we can still grab the previously-computed values.
+  EXPECT_EQ(int_val.get_value<int>(), 101);
+  EXPECT_EQ(str_val.get_value<string>(), "hello there");
+  EXPECT_EQ(vec_val.get_value<MyVector3d>().get_value(),
+            Vector3d(4., 5., 6.));
+
+  // Blanket forced recomputation should work though.
+  context_.SetAllCacheEntriesOutOfDate();
+  EXPECT_TRUE(int_val.needs_recomputation());
+  EXPECT_TRUE(str_val.needs_recomputation());
+  EXPECT_TRUE(vec_val.needs_recomputation());
+  EXPECT_TRUE(int_val.is_out_of_date());
+  EXPECT_TRUE(str_val.is_out_of_date());
+  EXPECT_TRUE(vec_val.is_out_of_date());
+}
+
+// Test that the vector-valued cache entry works and preserved the underlying
+// concrete type.
+TEST_F(CacheTest, VectorCacheEntryWorks) {
+  CacheEntryValue& entry_value = cache_value(vector_index_);
+  // Entry was marked up to date during construction.
+  EXPECT_FALSE(entry_value.is_out_of_date());
+  const MyVector3d& contents = entry_value.get_value<MyVector3d>();
+  Vector3d eigen_contents = contents.get_value();
+  EXPECT_EQ(eigen_contents, Vector3d(99., 98., 97.));
+
+  // Invalidate by pretending we modified a z, which should
+  // invalidate this xc-dependent cache entry.
+  tracker(z_ticket_).NoteValueChange(1001);
+  EXPECT_TRUE(entry_value.is_out_of_date());
+  entry_value.set_value(MyVector3d(Vector3d(3., 2., 1.)));
+  EXPECT_FALSE(entry_value.is_out_of_date());
+  const MyVector3d& contents2 = entry_value.get_value<MyVector3d>();
+  Vector3d eigen_contents2 = contents2.get_value();
+  EXPECT_EQ(eigen_contents2, Vector3d(3., 2., 1.));
+
+  // TODO(sherm1) Value<MyVector3d> treats the vector as non-assignable so
+  // we can't insist here that &contents2 == &contents.
+}
+
+// Test that we can swap in a new value if it has the right type, and that
+// the swapped-in value is invalid immediately after swapping. In Debug,
+// test that we throw if the swapped-in value is null or has the
+// wrong type.
+TEST_F(CacheTest, CanSwapValue) {
+  CacheEntryValue& entry_value = cache_value(string_index_);
+  EXPECT_FALSE(entry_value.is_out_of_date());  // Set to "initial".
+  EXPECT_EQ(entry_value.get_value<string>(), "initial");
+  auto new_value = AbstractValue::Make<string>("new value");
+  entry_value.swap_value(&new_value);
+  EXPECT_EQ(new_value->GetValue<string>(), "initial");
+  EXPECT_TRUE(entry_value.is_out_of_date());
+  entry_value.mark_up_to_date();
+  EXPECT_EQ(entry_value.get_value<string>(), "new value");
+
+// In Debug builds, try a bad swap and expect it to be caught.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  std::unique_ptr<AbstractValue> empty_ptr;
+  EXPECT_THROW(entry_value.swap_value(&empty_ptr), std::logic_error);
+  auto bad_value = AbstractValue::Make<int>(29);
+  EXPECT_THROW(entry_value.swap_value(&bad_value), std::logic_error);
+#endif
+}
+
+TEST_F(CacheTest, InvalidationIsRecursive) {
+  cache_value(index1_).mark_out_of_date();
+  tracker(index1_).NoteValueChange(100);  // Arbitrary unique change event.
+
+  EXPECT_EQ(0, cache_value(index0_).get_value<int>());
+  EXPECT_EQ(0, cache_value(index0_).GetValueOrThrow<int>());
+  EXPECT_TRUE(cache_value(index1_).is_out_of_date());
+  EXPECT_TRUE(cache_value(index2_).is_out_of_date());
+}
+
+TEST_F(CacheTest, Clone) {
+  // Make up a cache index that is guaranteed to leave a gap to make sure
+  // we test handling of missing entries properly.
+  next_cache_index_ += 3;
+  CacheIndex last_index(next_cache_index_++);
+  cache().CreateNewCacheEntryValue(last_index, next_ticket_++,
+                                   "last entry", {nothing_ticket_},
+                                   &graph());
+  cache_value(last_index).SetInitialValue(PackValue(42));
+  EXPECT_TRUE(cache_value(last_index).is_out_of_date());
+  cache_value(last_index).mark_up_to_date();
+
+  // Create a clone of the cache and dependency graph.
+  auto clone_context_ptr = context_.Clone();
+  MyContextBase& clone_context =
+      dynamic_cast<MyContextBase&>(*clone_context_ptr);
+  Cache& clone_cache = cache(&clone_context);
+
+  // Now study the copied cache to see if it got copied correctly.
+
+  // The copy should have the same size as the original, including empty slots.
+  // Can't go on if this fails so ASSERT.
+  ASSERT_EQ(clone_cache.cache_size(), cache().cache_size());
+  for (CacheIndex index(0); index < cache().cache_size(); ++index) {
+    EXPECT_EQ(cache().has_cache_entry_value(index),
+              clone_cache.has_cache_entry_value(index));
+    if (!cache().has_cache_entry_value(index)) continue;
+
+    const CacheEntryValue& value = cache().get_cache_entry_value(index);
+    const CacheEntryValue& clone_value =
+        clone_cache.get_cache_entry_value(index);
+    EXPECT_NE(&clone_value, &value);
+
+    // Test that the new cache entry is valid and is owned by the new context.
+    // This is also a unit test for ThrowIfBadCacheEntryValue().
+    EXPECT_NO_THROW(value.ThrowIfBadCacheEntryValue(&context_));
+    EXPECT_NO_THROW(clone_value.ThrowIfBadCacheEntryValue(&clone_context));
+    EXPECT_THROW(clone_value.ThrowIfBadCacheEntryValue(&context_),
+                 std::logic_error);
+
+    EXPECT_EQ(clone_value.description(), value.description());
+    EXPECT_EQ(clone_value.has_value(), value.has_value());
+    EXPECT_EQ(clone_value.cache_index(), value.cache_index());
+    EXPECT_EQ(clone_value.ticket(), value.ticket());
+    EXPECT_EQ(clone_value.serial_number(), value.serial_number());
+
+    // If there is a value, the clone_cache should not have the same memory
+    // address.
+    if (value.has_value()) {
+      EXPECT_NE(&clone_value.get_abstract_value(),
+                &value.get_abstract_value());
+    }
+
+    // Make sure the tracker got copied and that the new one refers to the
+    // new cache entry, not the old one. OTOH the ticket should be unchanged.
+    const DependencyTracker& value_tracker = tracker(value.ticket());
+    const DependencyTracker& clone_value_tracker =
+        tracker(value.ticket(), &clone_context);
+    EXPECT_NO_THROW(
+        value_tracker.ThrowIfBadDependencyTracker(&context_, &value));
+    EXPECT_NO_THROW(clone_value_tracker.ThrowIfBadDependencyTracker(
+        &clone_context, &clone_value));
+    EXPECT_EQ(value_tracker.ticket(), value.ticket());
+    EXPECT_EQ(clone_value_tracker.ticket(), value.ticket());
+  }
+
+  // The clone_cache should have the same values.
+  EXPECT_EQ(cache_value(index0_, &clone_cache).GetValueOrThrow<int>(),
+            cache_value(index0_).GetValueOrThrow<int>());
+  EXPECT_EQ(cache_value(index1_, &clone_cache).GetValueOrThrow<int>(),
+            cache_value(index1_).GetValueOrThrow<int>());
+  EXPECT_EQ(cache_value(index2_, &clone_cache).GetValueOrThrow<int>(),
+            cache_value(index2_).GetValueOrThrow<int>());
+  EXPECT_EQ(cache_value(string_index_, &clone_cache).GetValueOrThrow<string>(),
+            cache_value(string_index_).GetValueOrThrow<string>());
+  EXPECT_EQ(cache_value(vector_index_,
+                        &clone_cache).GetValueOrThrow<MyVector3d>()
+                .get_value(),
+            cache_value(vector_index_).GetValueOrThrow<MyVector3d>()
+                .get_value());
+  EXPECT_EQ(cache_value(last_index, &clone_cache).GetValueOrThrow<int>(),
+            cache_value(last_index).GetValueOrThrow<int>());
+
+  // Changes to the clone_cache should not affect the original.
+  cache_value(index2_, &clone_cache).mark_out_of_date();  // Invalidate.
+  cache_value(index2_,
+              &clone_cache).set_value<int>(99);  // Set new value & validate.
+  EXPECT_EQ(cache_value(index2_, &clone_cache).get_value<int>(), 99);
+  EXPECT_EQ(cache_value(index2_).get_value<int>(), 2);
+
+  // This should invalidate everything in the original cache, but nothing
+  // in the clone_cache. Just check one entry as representative.
+  tracker(time_ticket_).NoteValueChange(10);
+  EXPECT_TRUE(cache_value(string_index_).is_out_of_date());
+  EXPECT_FALSE(cache_value(string_index_, &clone_cache).is_out_of_date());
+
+  // Try an invalidation in the clone_cache to make sure the dependency graph is
+  // operational there.
+  tracker(xc_ticket_, &clone_context).NoteValueChange(10);
+  EXPECT_FALSE(cache_value(string_index_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(vector_index_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(index0_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(index1_, &clone_cache).is_out_of_date());
+  EXPECT_TRUE(cache_value(index2_, &clone_cache).is_out_of_date());
+}
+
+// Test that the Get(), Set(), GetMutable() and Peek() methods work and catch
+// errors appropriately. (This test is at the end because it throws so many
+// exceptions that it is hard to run through in the debugger.)
+TEST_F(CacheTest, ValueMethodsWork) {
+  CacheIndex index(next_cache_index_++);
+  cache().CreateNewCacheEntryValue(index, next_ticket_++,
+                                   "get test", {nothing_ticket_},
+                                   &graph());
+  CacheEntryValue& value = cache_value(index);
+  EXPECT_EQ(value.cache_index(), index);
+  EXPECT_EQ(value.ticket(), next_ticket_-1);
+  EXPECT_EQ(value.description(), "get test");
+
+  auto swap_with_me = AbstractValue::Make<int>(29);
+
+  // There is currently no value stored in the new entry. All "throw" methods
+  // should fail, and fast methods should fail in Debug builds.
+
+  EXPECT_THROW(value.GetAbstractValueOrThrow(), std::logic_error);
+  EXPECT_THROW(value.GetValueOrThrow<int>(), std::logic_error);
+  EXPECT_THROW(value.SetValueOrThrow<int>(5), std::logic_error);
+  EXPECT_THROW(value.GetMutableAbstractValueOrThrow(), std::logic_error);
+  EXPECT_THROW(value.GetMutableValueOrThrow<int>(), std::logic_error);
+  EXPECT_THROW(value.PeekAbstractValueOrThrow(), std::logic_error);
+  EXPECT_THROW(value.PeekValueOrThrow<int>(), std::logic_error);
+
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(value.get_abstract_value(), std::logic_error);
+  EXPECT_THROW(value.get_value<int>(), std::logic_error);
+  EXPECT_THROW(value.set_value<int>(5), std::logic_error);
+  EXPECT_THROW(value.is_out_of_date(), std::logic_error);
+  EXPECT_THROW(value.needs_recomputation(), std::logic_error);
+  EXPECT_THROW(value.mark_up_to_date(), std::logic_error);
+  EXPECT_THROW(value.swap_value(&swap_with_me), std::logic_error);
+#endif
+
+  // Now provide an initial value (not yet up to date).
+  value.SetInitialValue(PackValue(42));
+  // Nope, only allowed once.
+  EXPECT_THROW(value.SetInitialValue(PackValue(42)), std::logic_error);
+
+  EXPECT_TRUE(value.is_out_of_date());  // Initial value is not up to date.
+  // "Get" methods should fail, "GetMutable" and "Peek" succeed.
+  EXPECT_THROW(value.GetValueOrThrow<int>(), std::logic_error);
+  EXPECT_THROW(value.GetAbstractValueOrThrow(), std::logic_error);
+  EXPECT_NO_THROW(value.GetMutableValueOrThrow<int>());
+  EXPECT_NO_THROW(value.GetMutableAbstractValueOrThrow());
+  EXPECT_NO_THROW(value.PeekValueOrThrow<int>());
+  EXPECT_NO_THROW(value.PeekAbstractValueOrThrow());
+
+  // The fast "get" methods must check for up to date in Debug builds.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(value.get_value<int>(), std::logic_error);
+  EXPECT_THROW(value.get_abstract_value(), std::logic_error);
+#endif
+
+  // Swap doesn't care about up to date or not, but always marks the swapped-in
+  // value out of date.
+  value.swap_value(&swap_with_me);
+  EXPECT_TRUE(value.is_out_of_date());  // Still out of date.
+  EXPECT_EQ(value.PeekValueOrThrow<int>(), 29);
+  EXPECT_EQ(swap_with_me->GetValueOrThrow<int>(), 42);
+
+  value.GetMutableValueOrThrow<int>() = 43;
+  EXPECT_EQ(value.PeekValueOrThrow<int>(), 43);
+  value.SetValueOrThrow<int>(44);  // Check non-throw functioning.
+  EXPECT_EQ(value.PeekValueOrThrow<int>(), 44);
+
+  // Next, mark this up to date and check behavior. Now "Get" and "Peek"
+  // methods should succeed but "GetMutable" and "Set" methods should fail.
+  value.mark_up_to_date();
+
+  EXPECT_NO_THROW(value.get_abstract_value());
+  EXPECT_NO_THROW(value.get_value<int>());
+  EXPECT_NO_THROW(value.GetValueOrThrow<int>());
+  EXPECT_NO_THROW(value.GetAbstractValueOrThrow());
+  EXPECT_NO_THROW(value.PeekValueOrThrow<int>());
+  EXPECT_NO_THROW(value.PeekAbstractValueOrThrow());
+  EXPECT_THROW(value.GetMutableValueOrThrow<int>(), std::logic_error);
+  EXPECT_THROW(value.GetMutableAbstractValueOrThrow(), std::logic_error);
+  EXPECT_THROW(value.SetValueOrThrow<int>(5), std::logic_error);
+
+  // The fast "set" method must check for up to date in Debug builds.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(value.set_value<int>(5), std::logic_error);
+#endif
+
+  // And "swap" still doesn't care about up to date on entry.
+  value.swap_value(&swap_with_me);
+  EXPECT_TRUE(value.is_out_of_date());  // Should have changed.
+  EXPECT_EQ(value.PeekValueOrThrow<int>(), 42);
+  EXPECT_EQ(swap_with_me->GetValueOrThrow<int>(), 44);
+  value.mark_up_to_date();
+
+  // Get the same value as concrete or abstract type.
+  EXPECT_EQ(42, value.get_value<int>());
+  const AbstractValue& abstract_value =
+      cache().get_cache_entry_value(index).GetAbstractValueOrThrow();
+  EXPECT_EQ(42, UnpackIntValue(abstract_value));
+
+  CacheEntryValue& string_value = cache_value(string_index_);
+  EXPECT_EQ(string_value.GetValueOrThrow<string>(), "initial");
+
+  // This is the wrong value type.
+  EXPECT_THROW(string_value.GetValueOrThrow<int>(), std::logic_error);
+}
 
 }  // namespace
 }  // namespace systems

--- a/systems/framework/test/dependency_tracker_test.cc
+++ b/systems/framework/test/dependency_tracker_test.cc
@@ -28,13 +28,13 @@ namespace systems {
 namespace {
 
 // See above for why this is here.
-class MyContextBase : public ContextBase {
+class MyContextBase final : public ContextBase {
  public:
   MyContextBase() {}
   MyContextBase(const MyContextBase&) = default;
  private:
   std::unique_ptr<ContextBase> DoCloneWithoutPointers() const final {
-    return std::unique_ptr<ContextBase>(new MyContextBase(*this));
+    return std::make_unique<MyContextBase>(*this);
   }
 };
 
@@ -47,13 +47,114 @@ struct Stats {
 };
 
 void ExpectStatsMatch(const DependencyTracker* tracker, const Stats& expected) {
-  EXPECT_EQ(tracker->num_ignored_notifications(), expected.ignored);
-  EXPECT_EQ(tracker->num_notifications_sent(), expected.sent);
-  EXPECT_EQ(tracker->num_value_change_events(), expected.value_change);
-  EXPECT_EQ(tracker->num_prerequisite_change_events(), expected.prereq_change);
+  EXPECT_EQ(tracker->num_ignored_notifications(), expected.ignored)
+      << tracker->description();
+  EXPECT_EQ(tracker->num_notifications_sent(), expected.sent)
+      << tracker->description();
+  EXPECT_EQ(tracker->num_value_change_events(), expected.value_change)
+      << tracker->description();
+  EXPECT_EQ(tracker->num_prerequisite_change_events(), expected.prereq_change)
+      << tracker->description();
   EXPECT_EQ(tracker->num_notifications_received(),
             tracker->num_value_change_events() +
-                tracker->num_prerequisite_change_events());
+                tracker->num_prerequisite_change_events())
+      << tracker->description();
+}
+
+// Test that the built-in trackers exist and are wired up correctly. See
+// framework_common.h for the built-in tracker ticket numbers and make sure
+// they are all tested here. User-friendly access to tickets is provided by
+// SystemBase methods; we have to construct them manually here.
+GTEST_TEST(DependencyTracker, BuiltInTrackers) {
+  MyContextBase context, context2;
+
+  // Make sure each tracker knows its own ticket and looks reasonable. This is
+  // also a unit test for ThrowIfBadDependencyTracker().
+  for (int ticket_int = 0; ticket_int < internal::kNextAvailableTicket;
+       ++ticket_int) {
+    const DependencyTicket ticket(ticket_int);
+    auto& tracker = context.get_tracker(ticket);
+    EXPECT_EQ(tracker.ticket(), ticket);
+    EXPECT_NO_THROW(tracker.ThrowIfBadDependencyTracker(
+        &context, &CacheEntryValue::dummy()));
+    EXPECT_THROW(tracker.ThrowIfBadDependencyTracker(&context2),
+                 std::logic_error);
+  }
+
+  // Now check that each built-in tracker has the expected prerequisites and
+  // dependents.
+  using DT = DependencyTicket;  // Reduce clutter.
+  auto& nothing = context.get_tracker(DT(internal::kNothingTicket));
+  auto& time = context.get_tracker(DT(internal::kTimeTicket));
+  auto& accuracy = context.get_tracker(DT(internal::kAccuracyTicket));
+  auto& q = context.get_tracker(DT(internal::kQTicket));
+  auto& v = context.get_tracker(DT(internal::kVTicket));
+  auto& z = context.get_tracker(DT(internal::kZTicket));
+  auto& xc = context.get_tracker(DT(internal::kXcTicket));
+  auto& xd = context.get_tracker(DT(internal::kXdTicket));
+  auto& xa = context.get_tracker(DT(internal::kXaTicket));
+  auto& x = context.get_tracker(DT(internal::kXTicket));
+  auto& p = context.get_tracker(DT(internal::kAllParametersTicket));
+  auto& u = context.get_tracker(DT(internal::kAllInputPortsTicket));
+  auto& all_sources = context.get_tracker(DT(internal::kAllSourcesTicket));
+
+  // "nothing" has no prerequisites or subscribers.
+  EXPECT_EQ(nothing.prerequisites().size(), 0);
+  EXPECT_EQ(nothing.subscribers().size(), 0);
+
+  // time and accuracy are independent but all_sources subscribes.
+  EXPECT_EQ(time.prerequisites().size(), 0);
+  ASSERT_EQ(time.subscribers().size(), 1);
+  EXPECT_EQ(time.subscribers()[0], &all_sources);
+  EXPECT_EQ(accuracy.prerequisites().size(), 0);
+  ASSERT_EQ(accuracy.subscribers().size(), 1);
+  EXPECT_EQ(accuracy.subscribers()[0], &all_sources);
+
+  // q, v, z are independent but continuous variables xc subscribes.
+  EXPECT_EQ(q.prerequisites().size(), 0);
+  ASSERT_EQ(q.subscribers().size(), 1);
+  EXPECT_EQ(q.subscribers()[0], &xc);
+  EXPECT_EQ(v.prerequisites().size(), 0);
+  ASSERT_EQ(v.subscribers().size(), 1);
+  EXPECT_EQ(v.subscribers()[0], &xc);
+  EXPECT_EQ(z.prerequisites().size(), 0);
+  ASSERT_EQ(z.subscribers().size(), 1);
+  EXPECT_EQ(z.subscribers()[0], &xc);
+
+  // xc depends on q, v, and z and x subscribes.
+  ASSERT_EQ(xc.prerequisites().size(), 3);
+  EXPECT_EQ(xc.prerequisites()[0], &q);
+  EXPECT_EQ(xc.prerequisites()[1], &v);
+  EXPECT_EQ(xc.prerequisites()[2], &z);
+  ASSERT_EQ(xc.subscribers().size(), 1);
+  EXPECT_EQ(xc.subscribers()[0], &x);
+
+  // No discrete variables so xd is independent; x subscribes.
+  EXPECT_EQ(xd.prerequisites().size(), 0);
+  ASSERT_EQ(xd.subscribers().size(), 1);
+  EXPECT_EQ(xd.subscribers()[0], &x);
+
+  // No abstract variables so xa is independent; x subscribes.
+  EXPECT_EQ(xa.prerequisites().size(), 0);
+  ASSERT_EQ(xa.subscribers().size(), 1);
+  EXPECT_EQ(xa.subscribers()[0], &x);
+
+  // No parameters or inputs so p,u independent; all_sources subscribes.
+  EXPECT_EQ(p.prerequisites().size(), 0);
+  ASSERT_EQ(p.subscribers().size(), 1);
+  EXPECT_EQ(p.subscribers()[0], &all_sources);
+  EXPECT_EQ(u.prerequisites().size(), 0);
+  ASSERT_EQ(u.subscribers().size(), 1);
+  EXPECT_EQ(u.subscribers()[0], &all_sources);
+
+  // All sources depends on time, accuracy, x, p, u; no subscribers.
+  ASSERT_EQ(all_sources.prerequisites().size(), 5);
+  EXPECT_EQ(all_sources.prerequisites()[0], &time);
+  EXPECT_EQ(all_sources.prerequisites()[1], &accuracy);
+  EXPECT_EQ(all_sources.prerequisites()[2], &x);
+  EXPECT_EQ(all_sources.prerequisites()[3], &p);
+  EXPECT_EQ(all_sources.prerequisites()[4], &u);
+  EXPECT_EQ(all_sources.subscribers().size(), 0);
 }
 
 // Normally the dependency trackers are allocated automatically by the
@@ -70,10 +171,12 @@ void ExpectStatsMatch(const DependencyTracker* tracker, const Stats& expected) {
 //                          |                              +-->           |
 //     +-----------+        +--------------------------------->  entry0   |
 //     |  time     +------------------------------------------>           |
-//     +-----------+                                          +-----------+
+//     |           +---> others                               +-----------+
+//     +-----------+
 //
 // entry0 is a cache entry so we expect invalidation; the others are just
-// trackers with no associated values.
+// trackers with no associated values. Time is a built-in tracker and may
+// have other subscribers besides what we added here.
 class HandBuiltDependencies : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -98,7 +201,7 @@ class HandBuiltDependencies : public ::testing::Test {
     downstream2_->SubscribeToPrerequisite(middle1_);
 
     Cache& cache = context_.get_mutable_cache();
-    const CacheIndex index(cache.num_entries());
+    const CacheIndex index(cache.cache_size());
     entry0_ = &cache.CreateNewCacheEntryValue(
         index, next_ticket++, "entry0",
         {time_ticket_, middle1_->ticket(), downstream2_->ticket()}, &graph);
@@ -179,11 +282,11 @@ TEST_F(HandBuiltDependencies, Unsubscribe) {
 TEST_F(HandBuiltDependencies, Notify) {
   // Just-allocated cache entries are not up to date. We're not using the
   // cache entry API here -- just playing with the underlying "up to date" flag.
-  EXPECT_FALSE(entry0_->is_up_to_date());
+  EXPECT_TRUE(entry0_->is_out_of_date());
 
   // set_value() sets the up-to-date flag.
   entry0_->set_value(1125);
-  EXPECT_TRUE(entry0_->is_up_to_date());
+  EXPECT_FALSE(entry0_->is_out_of_date());
 
   // Refer to diagram above to decipher the expected stats below.
 
@@ -193,7 +296,7 @@ TEST_F(HandBuiltDependencies, Notify) {
   // The cache entry does not depend on downstream1.
   downstream1_->NoteValueChange(1LL);
   down1_stats_.value_change++;  // No dependents.
-  EXPECT_TRUE(entry0_->is_up_to_date());
+  EXPECT_FALSE(entry0_->is_out_of_date());
   ExpectAllStatsMatch();
 
   // A repeated notification (same change event) should be ignored.
@@ -205,13 +308,13 @@ TEST_F(HandBuiltDependencies, Notify) {
   // The cache entry depends directly on time.
   time_tracker_->NoteValueChange(2LL);
   tt_stats_.value_change++;
-  tt_stats_.sent++;  // entry0
+  tt_stats_.sent += time_tracker_->num_subscribers();  // entry0, others
   entry0_stats_.prereq_change++;
-  EXPECT_FALSE(entry0_->is_up_to_date());
+  EXPECT_TRUE(entry0_->is_out_of_date());
   ExpectAllStatsMatch();
 
-  entry0_->set_is_up_to_date(true);
-  EXPECT_TRUE(entry0_->is_up_to_date());
+  entry0_->mark_up_to_date();
+  EXPECT_FALSE(entry0_->is_out_of_date());
 
   upstream1_->NoteValueChange(3LL);
   up1_stats_.value_change++;
@@ -224,7 +327,7 @@ TEST_F(HandBuiltDependencies, Notify) {
   down2_stats_.sent++;  // entry0
   entry0_stats_.prereq_change += 2;
   entry0_stats_.ignored++;
-  EXPECT_FALSE(entry0_->is_up_to_date());
+  EXPECT_TRUE(entry0_->is_out_of_date());
   ExpectAllStatsMatch();
 }
 
@@ -313,9 +416,9 @@ TEST_F(HandBuiltDependencies, Clone) {
   ExpectStatsMatch(&down2, down2_stats);
   ExpectStatsMatch(&e0_tracker, entry0_stats);
 
-  EXPECT_FALSE(clone_entry0.is_up_to_date());
+  EXPECT_TRUE(clone_entry0.is_out_of_date());
   clone_entry0.set_value(101);
-  EXPECT_TRUE(clone_entry0.is_up_to_date());
+  EXPECT_FALSE(clone_entry0.is_out_of_date());
 
   // Upstream2 is prerequisite to middle1 which is prerequisite to down1,2 and
   // the cache entry, and down2 gets the cache entry again so should be


### PR DESCRIPTION
This is the next big chunk of caching code from #7668. This builds on #8050 (DependencyTrackers) to add the Context side of the Cache. This replaces the Cache and CacheEntryValue classes that were stubbed in #8050 with their complete implementations. These are properly wired up to DependencyTrackers in ContextBase, but are still disconnected from the operational System and Context classes. There is just enough here to allow independent testing of Cache and CacheEntryValue functionality, with much new code and documentation in cache.h,cc and tests in test/cache_test.cc. The rest of the changes (primarily to context_base.h,cc) are just to support the cache tests. However, all the code here is real code from #7668 and should be reviewed; I didn't add any mock infrastructure.

This is a large PR (650 loc + comments; about half unit tests) but I think it is a logical subunit of caching that makes sense to review in one PR.

```
Category            added  modified  removed  
----------------------------------------------
code                648    38        20       
comments            382    28        10       
blank               134    0         1        
----------------------------------------------
TOTAL               1164   66        31       
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8227)
<!-- Reviewable:end -->
