### PR TITLE
sensors_py: Add RgbdCamera, RgbdCameraDiscrete, and CameraInfo

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -66,6 +66,7 @@ drake_pybind_library(
         ":parsers_py",
         ":shapes_py",
         "//bindings/pydrake:autodiffutils_py",
+        "//bindings/pydrake/util:eigen_geometry_py",
     ],
 )
 

--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -24,6 +24,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
 
   py::module::import("pydrake.multibody.parsers");
   py::module::import("pydrake.multibody.shapes");
+  py::module::import("pydrake.util.eigen_geometry");
 
   py::enum_<FloatingBaseType>(m, "FloatingBaseType")
     .value("kFixed", FloatingBaseType::kFixed)
@@ -220,10 +221,23 @@ PYBIND11_MODULE(rigid_body_tree, m) {
 
   py::class_<RigidBodyFrame<double>,
              std::shared_ptr<RigidBodyFrame<double> > >(m, "RigidBodyFrame")
-    .def(py::init<const std::string&,
-                  RigidBody<double>*,
-                  const Eigen::VectorXd&,
-                  const Eigen::VectorXd& >())
+    .def(
+        py::init<
+            const std::string&,
+            RigidBody<double>*,
+            const Eigen::VectorXd&,
+            const Eigen::VectorXd&>(),
+        py::arg("name"), py::arg("body"),
+        py::arg("xyz") = Eigen::Vector3d::Zero(),
+        py::arg("rpy") = Eigen::Vector3d::Zero())
+    .def(
+        py::init<
+            const std::string&,
+            RigidBody<double>*,
+            const Eigen::Isometry3d&>(),
+        py::arg("name"), py::arg("body"),
+        py::arg("transform_to_body"))
+    .def("get_name", &RigidBodyFrame<double>::get_name)
     .def("get_frame_index", &RigidBodyFrame<double>::get_frame_index);
 
   m.def("AddModelInstanceFromUrdfStringSearchingInRosPackages",

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -110,7 +110,9 @@ drake_pybind_library(
 drake_pybind_library(
     name = "sensors_py",
     cc_deps = [
+        "//bindings/pydrake/systems:systems_pybind",
         "//bindings/pydrake/util:cpp_template_pybind",
+        "//bindings/pydrake/util:eigen_pybind",
     ],
     cc_so_name = "sensors",
     cc_srcs = ["sensors_py.cc"],

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -112,6 +112,7 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake/systems:systems_pybind",
         "//bindings/pydrake/util:cpp_template_pybind",
+        "//bindings/pydrake/util:eigen_geometry_pybind",
         "//bindings/pydrake/util:eigen_pybind",
     ],
     cc_so_name = "sensors",
@@ -120,7 +121,9 @@ drake_pybind_library(
     py_deps = [
         ":framework_py",
         ":module_py",
+        "//bindings/pydrake/multibody:rigid_body_tree_py",
         "//bindings/pydrake/util:cpp_template_py",
+        "//bindings/pydrake/util:eigen_geometry_py",
     ],
 )
 
@@ -271,6 +274,9 @@ drake_py_unittest(
 drake_py_unittest(
     name = "sensors_test",
     size = "small",
+    data = [
+        "//systems/sensors:test_models",
+    ],
     deps = [
         ":sensors_py",
     ],

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -6,6 +6,7 @@
 #include "pybind11/stl.h"
 
 #include "drake/bindings/pydrake/util/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/util/eigen_pybind.h"
 #include "drake/bindings/pydrake/util/type_pack.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
@@ -25,25 +26,6 @@ template <typename T, T ... Values>
 using constant_pack = type_pack<type_pack<constant<T, Values>>...>;
 
 using Eigen::Map;
-using Eigen::Ref;
-
-// TODO(eric.cousineau): Place in `pydrake_pybind.h`.
-template <typename T>
-py::object ToArray(T* ptr, int size, py::tuple shape) {
-  // Create flat array to be reshaped in numpy.
-  using Vector = VectorX<T>;
-  Map<Vector> data(ptr, size);
-  return py::cast(Ref<Vector>(data), py_reference).attr("reshape")(shape);
-}
-
-// `const` variant.
-template <typename T>
-py::object ToArray(const T* ptr, int size, py::tuple shape) {
-  // Create flat array to be reshaped in numpy.
-  using Vector = const VectorX<T>;
-  Map<Vector> data(ptr, size);
-  return py::cast(Ref<Vector>(data), py_reference).attr("reshape")(shape);
-}
 
 PYBIND11_MODULE(sensors, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.

--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -5,15 +6,19 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+#include "drake/bindings/pydrake/systems/systems_pybind.h"
 #include "drake/bindings/pydrake/util/cpp_template_pybind.h"
+#include "drake/bindings/pydrake/util/eigen_geometry_pybind.h"
 #include "drake/bindings/pydrake/util/eigen_pybind.h"
 #include "drake/bindings/pydrake/util/type_pack.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/sensors/image.h"
 #include "drake/systems/sensors/pixel_types.h"
+#include "drake/systems/sensors/rgbd_camera.h"
 
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 namespace drake {
@@ -29,9 +34,14 @@ using Eigen::Map;
 
 PYBIND11_MODULE(sensors, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
+  using namespace drake::systems;
+  // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
   using namespace drake::systems::sensors;
 
   m.doc() = "Bindings for the sensors portion of the Systems framework.";
+
+  py::module::import("pydrake.systems.framework");
+  py::module::import("pydrake.util.eigen_geometry");
 
   // Expose only types that are used.
   py::enum_<PixelFormat>(m, "PixelFormat")
@@ -122,6 +132,8 @@ PYBIND11_MODULE(sensors, m) {
       AddTemplateClass(m, "Image", image, py_param);
       // Add type alias for instantiation.
       m.attr(("Image" + enum_names[i].substr(1)).c_str()) = image;
+      // Add abstract values.
+      pysystems::AddValueInstantiation<ImageT>(m);
       // Ensure that iterate.
       ++i;
     };
@@ -136,6 +148,84 @@ PYBIND11_MODULE(sensors, m) {
   py::class_<Label> label(m, "Label");
   label.attr("kNoBody") = Label::kNoBody;
   label.attr("kFlatTerrain") = Label::kFlatTerrain;
+
+  using T = double;
+
+  // Systems.
+  py::class_<CameraInfo>(m, "CameraInfo")
+    .def(py::init<int, int, double>(),
+         py::arg("width"), py::arg("height"),
+         py::arg("fov_y"))
+    .def(py::init<int, int, double, double, double, double>(),
+         py::arg("width"), py::arg("height"),
+         py::arg("focal_x"), py::arg("focal_y"),
+         py::arg("center_x"), py::arg("center_y"))
+    .def("width", &CameraInfo::width)
+    .def("height", &CameraInfo::height)
+    .def("focal_x", &CameraInfo::focal_x)
+    .def("focal_y", &CameraInfo::focal_y)
+    .def("center_x", &CameraInfo::center_x)
+    .def("center_y", &CameraInfo::center_y)
+    .def("intrinsic_matrix", &CameraInfo::intrinsic_matrix);
+
+  auto def_camera_ports = [](auto* ppy_class) {
+    auto& py_class = *ppy_class;
+    using PyClass = std::decay_t<decltype(py_class)>;
+    using Class = typename PyClass::type;
+    py_class
+      .def("state_input_port",
+           &Class::state_input_port, py_reference_internal)
+      .def("color_image_output_port",
+           &Class::color_image_output_port, py_reference_internal)
+      .def("depth_image_output_port",
+           &Class::depth_image_output_port, py_reference_internal)
+      .def("label_image_output_port",
+           &Class::label_image_output_port, py_reference_internal)
+      .def("camera_base_pose_output_port",
+           &Class::camera_base_pose_output_port, py_reference_internal);
+  };
+
+  // TODO(eric.cousineau): Use something like `RenderingConfig`, per (#8123).
+  py::class_<RgbdCamera, LeafSystem<T>> rgbd_camera(m, "RgbdCamera");
+  rgbd_camera
+    .def(
+      py::init<
+        string, const RigidBodyTree<T>&, const RigidBodyFrame<T>&,
+        double, double, double, bool>(),
+      py::arg("name"), py::arg("tree"), py::arg("frame"),
+      py::arg("z_near") = 0.5, py::arg("z_far") = 5.0,
+      py::arg("fov_y") = M_PI_4,
+      py::arg("show_window") = bool{RenderingConfig::kDefaultShowWindow},
+      // Keep alive, reference: `this` keeps  `RigidBodyTree` alive.
+      py::keep_alive<1, 3>())
+    .def("color_camera_info", &RgbdCamera::color_camera_info,
+         py_reference_internal)
+    .def("depth_camera_info", &RgbdCamera::depth_camera_info,
+         py_reference_internal)
+    .def("color_camera_optical_pose", &RgbdCamera::color_camera_optical_pose)
+    .def("depth_camera_optical_pose", &RgbdCamera::depth_camera_optical_pose)
+    .def("frame", &RgbdCamera::frame, py_reference_internal)
+    .def("tree", &RgbdCamera::tree, py_reference);
+  def_camera_ports(&rgbd_camera);
+
+  py::class_<RgbdCameraDiscrete, Diagram<T>> rgbd_camera_discrete(
+      m, "RgbdCameraDiscrete");
+  rgbd_camera_discrete
+    .def(
+      py::init<unique_ptr<RgbdCamera>, double, bool>(),
+      py::arg("camera"),
+      py::arg("period") = double{RgbdCameraDiscrete::kDefaultPeriod},
+      py::arg("render_label_image") = true,
+      // Keep alive, ownership: `RgbdCamera` keeps `this` alive.
+      py::keep_alive<2, 1>())
+    // N.B. Since `camera` is already connected, we do not need additional
+    // `keep_alive`s.
+    .def("camera", &RgbdCameraDiscrete::camera)
+    .def("mutable_camera", &RgbdCameraDiscrete::mutable_camera)
+    .def("period", &RgbdCameraDiscrete::period);
+  def_camera_ports(&rgbd_camera_discrete);
+  rgbd_camera_discrete.attr("kDefaultPeriod") =
+      double{RgbdCameraDiscrete::kDefaultPeriod};
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -1,11 +1,25 @@
+import pydrake.systems.sensors as mut
+
 import numpy as np
 import unittest
 
-import pydrake.systems.sensors as m
+from pydrake.common import FindResourceOrThrow
+from pydrake.multibody.rigid_body_tree import (
+    AddModelInstancesFromSdfString,
+    FloatingBaseType,
+    RigidBodyTree,
+    RigidBodyFrame,
+    )
+from pydrake.systems.framework import (
+    InputPortDescriptor,
+    OutputPort,
+    Value,
+    )
+from pydrake.util.eigen_geometry import Isometry3
 
 # Shorthand aliases, to reduce verbosity.
-pt = m.PixelType
-pf = m.PixelFormat
+pt = mut.PixelType
+pf = mut.PixelFormat
 
 # Available image / pixel types.
 pixel_types = [
@@ -16,26 +30,27 @@ pixel_types = [
 
 # Convenience aliases.
 image_type_aliases = [
-    m.ImageRgba8U,
-    m.ImageDepth32F,
-    m.ImageLabel16I,
+    mut.ImageRgba8U,
+    mut.ImageDepth32F,
+    mut.ImageLabel16I,
 ]
 
 
 class TestSensors(unittest.TestCase):
+
     def test_image_traits(self):
         # Test instantiations of ImageTraits<>.
-        t = m.ImageTraits[pt.kRgba8U]
+        t = mut.ImageTraits[pt.kRgba8U]
         self.assertEquals(t.kNumChannels, 4)
         self.assertEquals(t.ChannelType, np.uint8)
         self.assertEquals(t.kPixelFormat, pf.kRgba)
 
-        t = m.ImageTraits[pt.kDepth32F]
+        t = mut.ImageTraits[pt.kDepth32F]
         self.assertEquals(t.kNumChannels, 1)
         self.assertEquals(t.ChannelType, np.float32)
         self.assertEquals(t.kPixelFormat, pf.kDepth)
 
-        t = m.ImageTraits[pt.kLabel16I]
+        t = mut.ImageTraits[pt.kLabel16I]
         self.assertEquals(t.kNumChannels, 1)
         self.assertEquals(t.ChannelType, np.int16)
         self.assertEquals(t.kPixelFormat, pf.kLabel)
@@ -44,8 +59,8 @@ class TestSensors(unittest.TestCase):
         # Test instantiations of Image<>.
         for pixel_type, image_type_alias in (
                 zip(pixel_types, image_type_aliases)):
-            ImageT = m.Image[pixel_type]
-            self.assertEquals(ImageT.Traits, m.ImageTraits[pixel_type])
+            ImageT = mut.Image[pixel_type]
+            self.assertEquals(ImageT.Traits, mut.ImageTraits[pixel_type])
             self.assertEquals(ImageT, image_type_alias)
 
             w = 640
@@ -76,7 +91,7 @@ class TestSensors(unittest.TestCase):
             w = 8
             h = 6
             channel_default = 1
-            ImageT = m.Image[pixel_type]
+            ImageT = mut.Image[pixel_type]
             image = ImageT(w, h, channel_default)
             nc = ImageT.Traits.kNumChannels
 
@@ -130,9 +145,93 @@ class TestSensors(unittest.TestCase):
     def test_constants(self):
         # Simply ensure we can access the constants.
         values = [
-            m.InvalidDepth.kTooFar,
-            m.InvalidDepth.kTooClose,
-            m.Label.kNoBody,
-            m.Label.kFlatTerrain,
+            mut.InvalidDepth.kTooFar,
+            mut.InvalidDepth.kTooClose,
+            mut.Label.kNoBody,
+            mut.Label.kFlatTerrain,
         ]
         self.assertTrue(values)
+
+    def test_camera_info(self):
+        width = 640
+        height = 480
+        fov_y = np.pi / 4
+        focal_y = height / 2 / np.tan(fov_y / 2)
+        focal_x = focal_y
+        center_x = width / 2
+        center_y = height / 2
+        intrinsic_matrix = np.array([
+            [focal_x, 0, center_x],
+            [0, focal_y, center_y],
+            [0, 0, 1]])
+
+        infos = [
+            mut.CameraInfo(width=width, height=height, fov_y=fov_y),
+            mut.CameraInfo(
+                width=width, height=height, focal_x=focal_x, focal_y=focal_y,
+                center_x=center_x, center_y=center_y),
+        ]
+
+        for info in infos:
+            self.assertEquals(info.width(), width)
+            self.assertEquals(info.height(), height)
+            self.assertEquals(info.focal_x(), focal_x)
+            self.assertEquals(info.focal_y(), focal_y)
+            self.assertEquals(info.center_x(), center_x)
+            self.assertEquals(info.center_y(), center_y)
+            self.assertTrue(
+                (info.intrinsic_matrix() == intrinsic_matrix).all())
+
+    def _check_input(self, value):
+        self.assertIsInstance(value, InputPortDescriptor)
+
+    def _check_output(self, value):
+        self.assertIsInstance(value, OutputPort)
+
+    def _check_ports(self, system):
+        self._check_input(system.state_input_port())
+        self._check_output(system.color_image_output_port())
+        self._check_output(system.depth_image_output_port())
+        self._check_output(system.label_image_output_port())
+        self._check_output(system.camera_base_pose_output_port())
+
+    def test_rgbd_camera(self):
+        sdf_path = FindResourceOrThrow(
+            "drake/systems/sensors/test/models/nothing.sdf")
+        tree = RigidBodyTree()
+        with open(sdf_path) as f:
+            sdf_string = f.read()
+        AddModelInstancesFromSdfString(
+            sdf_string, FloatingBaseType.kFixed, None, tree)
+        frame = RigidBodyFrame("rgbd camera frame", tree.FindBody("link"))
+        tree.addFrame(frame)
+
+        camera = mut.RgbdCamera(
+            name="camera", tree=tree, frame=frame,
+            z_near=0.5, z_far=5.0,
+            fov_y=np.pi / 4, show_window=False)
+
+        self.assertIsInstance(camera.color_camera_info(), mut.CameraInfo)
+        self.assertIsInstance(camera.depth_camera_info(), mut.CameraInfo)
+        self.assertIsInstance(camera.color_camera_optical_pose(), Isometry3)
+        self.assertIsInstance(camera.depth_camera_optical_pose(), Isometry3)
+        self.assertTrue(camera.tree() is tree)
+        # N.B. `RgbdCamera` copies the input frame.
+        self.assertEquals(camera.frame().get_name(), frame.get_name())
+        self._check_ports(camera)
+
+        # Test discrete camera.
+        period = mut.RgbdCameraDiscrete.kDefaultPeriod
+        discrete = mut.RgbdCameraDiscrete(
+            camera=camera, period=period, render_label_image=True)
+        self.assertTrue(discrete.camera() is camera)
+        self.assertTrue(discrete.mutable_camera() is camera)
+        self.assertEquals(discrete.period(), period)
+        self._check_ports(discrete)
+
+        # That we can access the state as images.
+        context = discrete.CreateDefaultContext()
+        values = context.get_abstract_state()
+        self.assertIsInstance(values.get_value(0), Value[mut.ImageRgba8U])
+        self.assertIsInstance(values.get_value(1), Value[mut.ImageDepth32F])
+        self.assertIsInstance(values.get_value(2), Value[mut.ImageLabel16I])

--- a/bindings/pydrake/util/eigen_pybind.h
+++ b/bindings/pydrake/util/eigen_pybind.h
@@ -3,6 +3,8 @@
 #include <Eigen/Dense>
 #include "pybind11/eigen.h"
 
+#include "drake/common/eigen_types.h"
+
 namespace drake {
 namespace pydrake {
 
@@ -13,6 +15,26 @@ namespace pydrake {
 template <typename Derived>
 auto ToEigenRef(Eigen::VectorBlock<Derived>* derived) {
   return Eigen::Ref<Derived>(*derived);
+}
+
+/// Converts a raw array to a numpy array.
+template <typename T>
+py::object ToArray(T* ptr, int size, py::tuple shape) {
+  // Create flat array to be reshaped in numpy.
+  using Vector = VectorX<T>;
+  Eigen::Map<Vector> data(ptr, size);
+  return py::cast(
+      Eigen::Ref<Vector>(data), py_reference).attr("reshape")(shape);
+}
+
+/// Converts a raw array to a numpy array (`const` variant).
+template <typename T>
+py::object ToArray(const T* ptr, int size, py::tuple shape) {
+  // Create flat array to be reshaped in numpy.
+  using Vector = const VectorX<T>;
+  Eigen::Map<Vector> data(ptr, size);
+  return py::cast(
+      Eigen::Ref<Vector>(data), py_reference).attr("reshape")(shape);
 }
 
 }  // namespace pydrake

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -419,7 +419,6 @@ filegroup(
         "test/models/nothing.sdf",
         "test/models/sphere.sdf",
     ],
-    visibility = ["//visibility:private"],
 )
 
 drake_cc_googletest(


### PR DESCRIPTION
A step towards #7753

NOTE: I may end up seeing if I can squirrel in a `dev` shader API into `RgbdCamera`, rather than try to spend time splitting out classes, just to save time.
\cc @gizatt @ChristopherSweeney

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8235)
<!-- Reviewable:end -->
