### PR TITLE
Add runtime dependencies of libibex-dev

### DIFF
--- a/setup/ubuntu/16.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/16.04/binary_distribution/packages.txt
@@ -1,3 +1,5 @@
+coinor-libclp1
+coinor-libcoinutils3v5
 coinor-libipopt1v5
 libblas3
 libboost-all-dev


### PR DESCRIPTION
These previously to #8218 came from `apt install libibex-dev`'s `Depends:` line, and still come indirectly from `source_distribution/package.txt`, but in binary releases are otherwise missing.

These lines match [tools/workspace/dreal/package-ubuntu.BUILD.bazel#L49-L50](https://github.com/RobotLocomotion/drake/blob/master/tools/workspace/dreal/package-ubuntu.BUILD.bazel#L49-L50).

Do not merge until:
- [x] Unprovisioned builds pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8237)
<!-- Reviewable:end -->
