### PR TITLE
pydrake: Work around bazelbuild/bazel#4594

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -3,6 +3,21 @@ from os.path import abspath
 from platform import python_version_tuple
 from sys import stderr
 
+# When importing `pydrake` as an external under Bazel, Bazel will use a shared
+# library whose relative RPATHs are incorrect for `libdrake.so`, and thus will
+# fail to load; this issue is captured in bazelbuild/bazel#4594. As a
+# workaround, we can use this spelling to load a properly-linked version of
+# `libdrake.so`. Once this is loaded, all of the Python C-extension libraries
+# that depend on it (and its dependencies) will load properly.
+# Please note that this workaround is only important when running under the
+# Bazel runfiles tree. Installed `pydrake` should not have this issue.
+# N.B. This will actually import a second copy of `pydrake` in the path below;
+# however, we should be able to ignore this as users should not be using it.
+try:
+    import external.drake.bindings.pydrake
+except ImportError:
+    pass
+
 # We specifically load `common` prior to loading any other pydrake modules,
 # in order to get assertion configuration done as early as possible.
 from . import common


### PR DESCRIPTION
~I would like to start using this in a downstream project in Bazel, so this is a dirty but functional WIP workaround for https://github.com/bazelbuild/bazel/issues/4594~

@jwnimmer-tri found a much more elegant solution to this, which leverages the fact that certain versions of the shared libraries are linked properly. I have updated this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8240)
<!-- Reviewable:end -->
