### PR TITLE
Cleanup bindings for symbolic pydrake

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -237,18 +237,6 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
-    name = "symbolic_variables_test",
-    size = "small",
-    deps = [":symbolic_py"],
-)
-
-drake_py_unittest(
-    name = "symbolic_monomial_test",
-    size = "small",
-    deps = [":symbolic_py"],
-)
-
-drake_py_unittest(
     name = "backwards_compatability_test",
     deps = [
         ":backwards_compatibility_py",

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -30,188 +30,66 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def("__repr__", &Variable::to_string)
       .def("__hash__",
            [](const Variable& self) { return std::hash<Variable>{}(self); })
-      .def("__add__",
-           [](const Variable& self, const Variable& other) {
-             return Expression{self + other};
-           },
-           py::is_operator())
-      .def("__add__",
-           [](const Variable& self, double other) {
-             return Expression{self + other};
-           },
-           py::is_operator())
-      .def("__add__",
-           [](const Variable& self, const Expression& other) {
-             return Expression{self + other};
-           },
-           py::is_operator())
-      .def("__radd__",
-           [](const Variable& self, double other) {
-             return Expression{other + self};
-           },
-           py::is_operator())
-      .def("__sub__",
-           [](const Variable& self, const Variable& other) {
-             return Expression{self - other};
-           },
-           py::is_operator())
-      .def("__sub__",
-           [](const Variable& self, double other) {
-             return Expression{self - other};
-           },
-           py::is_operator())
-      .def("__sub__",
-           [](const Variable& self, const Expression& other) {
-             return Expression{self - other};
-           },
-           py::is_operator())
-      .def("__rsub__",
-           [](const Variable& self, double other) {
-             return Expression{other - self};
-           },
-           py::is_operator())
-      .def("__mul__",
-           [](const Variable& self, const Variable& other) {
-             return Expression{self * other};
-           },
-           py::is_operator())
-      .def("__mul__",
-           [](const Variable& self, double other) {
-             return Expression{self * other};
-           },
-           py::is_operator())
-      .def("__mul__",
-           [](const Variable& self, const Expression& other) {
-             return Expression{self * other};
-           },
-           py::is_operator())
-      .def("__mul__",
-           [](const Variable& self, const Monomial& other) {
-             return Monomial(self) * other;
-           },
-           py::is_operator())
-      .def("__rmul__",
-           [](const Variable& self, double other) {
-             return Expression{other * self};
-           },
-           py::is_operator())
-      .def("__truediv__",
-           [](const Variable& self, const Variable& other) {
-             return Expression{self / other};
-           },
-           py::is_operator())
-      .def("__truediv__",
-           [](const Variable& self, double other) {
-             return Expression{self / other};
-           },
-           py::is_operator())
-      .def("__truediv__",
-           [](const Variable& self, const Expression& other) {
-             return Expression{self / other};
-           },
-           py::is_operator())
-      .def("__rtruediv__",
-           [](const Variable& self, double other) {
-             return Expression{other / self};
-           },
-           py::is_operator())
+      // Addition.
+      .def(py::self + py::self)
+      .def(py::self + double())
+      .def(double() + py::self)
+      // Subtraction.
+      .def(py::self - py::self)
+      .def(py::self - double())
+      .def(double() - py::self)
+      // Multiplication.
+      .def(py::self * py::self)
+      .def(py::self * double())
+      .def(double() * py::self)
+      // Division.
+      .def(py::self / py::self)
+      .def(py::self / double())
+      .def(double() / py::self)
+      // Pow.
       .def("__pow__",
-           [](const Variable& self, int other) {
-             return Expression{pow(self, other)};
-           },
-           py::is_operator())
-      .def("__pow__",
-           [](const Variable& self, double other) {
-             return Expression{pow(self, other)};
-           },
+           [](const Variable& self, double other) { return pow(self, other); },
            py::is_operator())
       .def("__pow__",
            [](const Variable& self, const Variable& other) {
-             return Expression{pow(self, other)};
+             return pow(self, other);
            },
            py::is_operator())
       .def("__pow__",
            [](const Variable& self, const Expression& other) {
-             return Expression{pow(self, other)};
+             return pow(self, other);
            },
            py::is_operator())
-      .def("__neg__", [](const Variable& self) { return Expression{-self}; },
-           py::is_operator())
-      .def("__lt__",
-           [](const Variable& self, const Variable& other) {
-             return Formula{Expression(self) < Expression(other)};
-           },
-           py::is_operator())
-      .def("__lt__",
-           [](const Variable& self, double other) {
-             return Formula{Expression(self) < Expression(other)};
-           },
-           py::is_operator())
-      .def("__lt__",
-           [](const Variable& self, const Expression& other) {
-             return Formula{Expression(self) < other};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Variable& self, const Variable& other) {
-             return Formula{Expression(self) <= Expression(other)};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Variable& self, double other) {
-             return Formula{Expression(self) <= Expression(other)};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Variable& self, const Expression& other) {
-             return Formula{Expression(self) <= other};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Variable& self, const Variable& other) {
-             return Formula{Expression(self) > Expression(other)};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Variable& self, double other) {
-             return Formula{Expression(self) > Expression(other)};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Variable& self, const Expression& other) {
-             return Formula{Expression(self) > other};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Variable& self, const Variable& other) {
-             return Formula{Expression(self) >= Expression(other)};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Variable& self, double other) {
-             return Formula{Expression(self) >= Expression(other)};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Variable& self, const Expression& other) {
-             return Formula{Expression(self) >= other};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Variable& self, const Variable& other) {
-             return Formula{Expression(self) == Expression(other)};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Variable& self, double other) {
-             return Formula{Expression(self) == Expression(other)};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Variable& self, const Expression& other) {
-             return Formula{Expression(self) == other};
-           },
-           py::is_operator());
+      // Unary Plus.
+      .def(+py::self)
+      // Unary Minus.
+      .def(-py::self)
+      // LT(<).
+      // Note that for `double < Variable` case, the reflected op ('>' in this
+      // case) is called. For example, `1 < x` will return `x > 1`.
+      .def(py::self < Expression())
+      .def(py::self < py::self)
+      .def(py::self < double())
+      // LE(<=).
+      .def(py::self <= Expression())
+      .def(py::self <= py::self)
+      .def(py::self <= double())
+      // GT(>).
+      .def(py::self > Expression())
+      .def(py::self > py::self)
+      .def(py::self > double())
+      // GE(>=).
+      .def(py::self >= Expression())
+      .def(py::self >= py::self)
+      .def(py::self >= double())
+      // EQ(==).
+      .def(py::self == Expression())
+      .def(py::self == py::self)
+      .def(py::self == double())
+      // NE(!=).
+      .def(py::self != Expression())
+      .def(py::self != py::self)
+      .def(py::self != double());
 
   py::class_<Variables>(m, "Variables")
       .def(py::init<>())
@@ -252,116 +130,80 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def(py::init<const Variable&>())
       .def("__repr__", &Expression::to_string)
       .def("Expand", &Expression::Expand)
+      // Addition
       .def(py::self + py::self)
       .def(py::self + Variable())
       .def(py::self + double())
+      .def(Variable() + py::self)
       .def(double() + py::self)
+      .def(py::self += py::self)
+      .def(py::self += Variable())
+      .def(py::self += double())
+      // Subtraction.
       .def(py::self - py::self)
       .def(py::self - Variable())
       .def(py::self - double())
+      .def(Variable() - py::self)
       .def(double() - py::self)
+      .def(py::self -= py::self)
+      .def(py::self -= Variable())
+      .def(py::self -= double())
+      // Multiplication.
       .def(py::self * py::self)
       .def(py::self * Variable())
       .def(py::self * double())
+      .def(Variable() * py::self)
       .def(double() * py::self)
+      .def(py::self *= py::self)
+      .def(py::self *= Variable())
+      .def(py::self *= double())
+      // Division.
       .def(py::self / py::self)
       .def(py::self / Variable())
       .def(py::self / double())
+      .def(Variable() / py::self)
       .def(double() / py::self)
-      .def("__pow__",
-           [](const Expression& self, int other) { return pow(self, other); },
-           py::is_operator())
-      .def(
-          "__pow__",
-          [](const Expression& self, double other) { return pow(self, other); },
-          py::is_operator())
-      .def("__pow__",
-           [](const Expression& self, const Variable& other) {
-             return pow(self, other);
-           },
-           py::is_operator())
-      .def("__pow__",
-           [](const Expression& self, const Expression& other) {
-             return pow(self, other);
-           },
-           py::is_operator())
-      .def("__neg__", [](const Expression& self) { return -self; },
-           py::is_operator())
-      .def("__lt__",
-           [](const Expression& self, const Variable& other) {
-             return Formula{Expression(self) < Expression(other)};
-           },
-           py::is_operator())
-      .def("__lt__",
-           [](const Expression& self, const Expression& other) {
-             return Formula{Expression(self) < Expression(other)};
-           },
-           py::is_operator())
-      .def("__lt__",
-           [](const Expression& self, double other) {
-             return Formula{Expression(self) < Expression(other)};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Expression& self, const Variable& other) {
-             return Formula{Expression(self) <= Expression(other)};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Expression& self, const Expression& other) {
-             return Formula{Expression(self) <= Expression(other)};
-           },
-           py::is_operator())
-      .def("__le__",
-           [](const Expression& self, double other) {
-             return Formula{Expression(self) <= Expression(other)};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Expression& self, const Variable& other) {
-             return Formula{Expression(self) > Expression(other)};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Expression& self, const Expression& other) {
-             return Formula{Expression(self) > Expression(other)};
-           },
-           py::is_operator())
-      .def("__gt__",
-           [](const Expression& self, double other) {
-             return Formula{Expression(self) > Expression(other)};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Expression& self, const Variable& other) {
-             return Formula{Expression(self) >= Expression(other)};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Expression& self, const Expression& other) {
-             return Formula{Expression(self) >= Expression(other)};
-           },
-           py::is_operator())
-      .def("__ge__",
-           [](const Expression& self, double other) {
-             return Formula{Expression(self) >= Expression(other)};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Expression& self, const Variable& other) {
-             return Formula{Expression(self) == Expression(other)};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Expression& self, const Expression& other) {
-             return Formula{Expression(self) == Expression(other)};
-           },
-           py::is_operator())
-      .def("__eq__",
-           [](const Expression& self, double other) {
-             return Formula{Expression(self) == Expression(other)};
-           },
-           py::is_operator());
+      .def(py::self /= py::self)
+      .def(py::self /= Variable())
+      .def(py::self /= double())
+      // Pow.
+      .def("__pow__", [](const Expression& self,
+                         const double other) { return pow(self, other); })
+      .def("__pow__", [](const Expression& self,
+                         const Variable& other) { return pow(self, other); })
+      .def("__pow__", [](const Expression& self,
+                         const Expression& other) { return pow(self, other); })
+      // Unary Plus.
+      .def(+py::self)
+      // Unary Minus.
+      .def(-py::self)
+      // LT(<).
+      //
+      // Note that for `double < Expression` case, the reflected op ('>' in this
+      // case) is called. For example, `1 < x * y` will return `x * y > 1`.
+      .def(py::self < py::self)
+      .def(py::self < Variable())
+      .def(py::self < double())
+      // LE(<=).
+      .def(py::self <= py::self)
+      .def(py::self <= Variable())
+      .def(py::self <= double())
+      // GT(>).
+      .def(py::self > py::self)
+      .def(py::self > Variable())
+      .def(py::self > double())
+      // GE(>=).
+      .def(py::self >= py::self)
+      .def(py::self >= Variable())
+      .def(py::self >= double())
+      // EQ(==).
+      .def(py::self == py::self)
+      .def(py::self == Variable())
+      .def(py::self == double())
+      // NE(!=)
+      .def(py::self != py::self)
+      .def(py::self != Variable())
+      .def(py::self != double());
 
   m.def("log", &symbolic::log)
       .def("abs", &symbolic::abs)
@@ -414,12 +256,9 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def("degree", &Monomial::degree)
       .def("total_degree", &Monomial::total_degree)
       .def(py::self * py::self)
-      .def("__mul__",
-           [](const Monomial& self, const Variable& other) {
-             return self * Monomial(other);
-           },
-           py::is_operator())
+      .def(py::self *= py::self)
       .def(py::self == py::self)
+      .def(py::self != py::self)
       .def("__hash__",
            [](const Monomial& self) { return std::hash<Monomial>{}(self); })
       .def(py::self != py::self)
@@ -497,6 +336,8 @@ PYBIND11_MODULE(_symbolic_py, m) {
   py::implicitly_convertible<double, drake::symbolic::Expression>();
   py::implicitly_convertible<drake::symbolic::Variable,
                              drake::symbolic::Expression>();
+  py::implicitly_convertible<drake::symbolic::Monomial,
+                             drake::symbolic::Polynomial>();
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -10,9 +10,12 @@ import pydrake.symbolic as sym
 x = sym.Variable("x")
 y = sym.Variable("y")
 z = sym.Variable("z")
+w = sym.Variable("w")
 a = sym.Variable("a")
 b = sym.Variable("b")
 c = sym.Variable("c")
+e_x = sym.Expression(x)
+e_y = sym.Expression(y)
 
 
 class TestSymbolicVariables(unittest.TestCase):
@@ -84,6 +87,106 @@ class TestSymbolicVariables(unittest.TestCase):
                          "((y = 2) and (x >= 1) and (x <= 2))")
         self.assertEqual(str(sym.logical_or(x >= 1, x <= 2, y == 2)),
                          "((y = 2) or (x >= 1) or (x <= 2))")
+
+
+class TestSymbolicVariables(unittest.TestCase):
+    def test_default_constructor(self):
+        vars = sym.Variables()
+        self.assertEqual(vars.size(), 0)
+        self.assertTrue(vars.empty())
+
+    def test_constructor_list(self):
+        vars = sym.Variables([x, y, z])
+        self.assertEqual(vars.size(), 3)
+
+    def test_insert1(self):
+        vars = sym.Variables()
+        vars.insert(x)
+        self.assertEqual(vars.size(), 1)
+
+    def test_insert2(self):
+        vars = sym.Variables([x])
+        vars.insert(sym.Variables([y, z]))
+        self.assertEqual(vars.size(), 3)
+
+    def test_erase1(self):
+        vars = sym.Variables([x, y, z])
+        count = vars.erase(x)
+        self.assertEqual(count, 1)
+
+    def test_erase2(self):
+        vars1 = sym.Variables([x, y, z])
+        vars2 = sym.Variables([w, z])
+        count = vars1.erase(vars2)
+        self.assertEqual(count, 1)
+        self.assertEqual(vars1.size(), 2)
+
+    def test_include(self):
+        vars = sym.Variables([x, y, z])
+        self.assertTrue(vars.include(y))
+
+    def test_to_string(self):
+        vars = sym.Variables()
+        vars.insert(x)
+        vars.insert(y)
+        vars.insert(z)
+        self.assertEqual(vars.to_string(), "{x, y, z}")
+
+    def test_subset_properties(self):
+        vars1 = sym.Variables([x, y, z])
+        vars2 = sym.Variables([x, y])
+        self.assertFalse(vars1.IsSubsetOf(vars2))
+        self.assertFalse(vars1.IsStrictSubsetOf(vars2))
+        self.assertTrue(vars1.IsSupersetOf(vars2))
+        self.assertTrue(vars1.IsStrictSupersetOf(vars2))
+
+    def test_eq(self):
+        vars1 = sym.Variables([x, y, z])
+        vars2 = sym.Variables([x, y])
+        self.assertFalse(vars1 == vars2)
+
+    def test_lt(self):
+        vars1 = sym.Variables([x, y])
+        vars2 = sym.Variables([x, y, z])
+        self.assertTrue(vars1 < vars2)
+
+    def test_add(self):
+        vars1 = sym.Variables([x, y])
+        vars2 = sym.Variables([y, z])
+        vars3 = vars1 + vars2  # [x, y, z]
+        self.assertEqual(vars3.size(), 3)
+        vars4 = vars1 + z  # [x, y, z]
+        self.assertEqual(vars4.size(), 3)
+        vars5 = x + vars1  # [x, y]
+        self.assertEqual(vars5.size(), 2)
+
+    def test_add_assignment(self):
+        vars = sym.Variables([x])
+        vars += y
+        self.assertEqual(vars.size(), 2)
+        vars += sym.Variables([x, z])
+        self.assertEqual(vars.size(), 3)
+
+    def test_sub(self):
+        vars1 = sym.Variables([x, y])
+        vars2 = sym.Variables([y, z])
+        vars3 = vars1 - vars2  # [x]
+        self.assertEqual(vars3, sym.Variables([x]))
+        vars4 = vars1 - y  # [x]
+        self.assertEqual(vars4, sym.Variables([x]))
+
+    def test_sub_assignment(self):
+        vars = sym.Variables([x, y, z])
+        vars -= y  # = [x, z]
+        self.assertEqual(vars, sym.Variables([x, z]))
+        vars -= sym.Variables([x])  # = [z]
+        self.assertEqual(vars, sym.Variables([z]))
+
+    def test_intersect(self):
+        vars1 = sym.Variables([x, y, z])
+        vars2 = sym.Variables([y, w])
+        vars3 = sym.intersect(vars1, vars2)  # = [y]
+        self.assertEqual(vars3, sym.Variables([y]))
 
 
 class TestSymbolicExpression(unittest.TestCase):
@@ -174,6 +277,117 @@ class TestSymbolicExpression(unittest.TestCase):
         self.assertEqual(J[0, 1], - x * sym.sin(y))
         self.assertEqual(J[1, 1], x * sym.cos(y))
         self.assertEqual(J[2, 1], 0)
+
+
+class TestSymbolicMonomial(unittest.TestCase):
+    def test_constructor_variable(self):
+        m = sym.Monomial(x)  # m = x¹
+        self.assertEqual(m.degree(x), 1)
+        self.assertEqual(m.total_degree(), 1)
+
+    def test_constructor_variable_int(self):
+        m = sym.Monomial(x, 2)  # m = x²
+        self.assertEqual(m.degree(x), 2)
+        self.assertEqual(m.total_degree(), 2)
+
+    def test_constructor_map(self):
+        powers_in = {x: 2, y: 3, z: 4}
+        m = sym.Monomial(powers_in)
+        powers_out = m.get_powers()
+        self.assertEqual(powers_out[x], 2)
+        self.assertEqual(powers_out[y], 3)
+        self.assertEqual(powers_out[z], 4)
+
+    def test_comparison(self):
+        # m1 = m2 = x²
+        m1 = sym.Monomial(x, 2)
+        m2 = sym.Monomial(x, 2)
+        m3 = sym.Monomial(x, 1)
+        m4 = sym.Monomial(y, 2)
+        # Test operator==
+        self.assertTrue(m1 == m2)
+        self.assertFalse(m1 == m3)
+        self.assertFalse(m1 == m4)
+        self.assertFalse(m2 == m3)
+        self.assertFalse(m2 == m4)
+        self.assertFalse(m3 == m4)
+        # Test operator!=
+        self.assertFalse(m1 != m2)
+        self.assertTrue(m1 != m3)
+        self.assertTrue(m1 != m4)
+        self.assertTrue(m2 != m3)
+        self.assertTrue(m2 != m4)
+        self.assertTrue(m3 != m4)
+
+    def test_str(self):
+        m1 = sym.Monomial(x, 2)
+        self.assertEqual(str(m1), "x^2")
+        m2 = m1 * sym.Monomial(y)
+        self.assertEqual(str(m2), "x^2 * y")
+
+    def test_multiplication1(self):
+        m1 = sym.Monomial(x, 2)
+        m2 = sym.Monomial(y, 3)
+        m3 = m1 * m2
+        self.assertEqual(m3.degree(x), 2)
+        self.assertEqual(m3.degree(y), 3)
+
+    def test_multiplication2(self):
+        m1 = sym.Monomial(x, 2)
+        m2 = m1 * sym.Monomial(y)
+        m3 = sym.Monomial(y) * m1
+        self.assertEqual(m2.degree(x), 2)
+        self.assertEqual(m2.degree(y), 1)
+        self.assertEqual(m2, m3)
+
+    def test_multiplication_assignment1(self):
+        m = sym.Monomial(x, 2)
+        m *= sym.Monomial(y, 3)
+        self.assertEqual(m.degree(x), 2)
+        self.assertEqual(m.degree(y), 3)
+
+    def test_multiplication_assignment2(self):
+        m = sym.Monomial(x, 2)
+        m *= sym.Monomial(y)
+        self.assertEqual(m.degree(x), 2)
+        self.assertEqual(m.degree(y), 1)
+
+    def test_pow(self):
+        m1 = sym.Monomial(x, 2) * sym.Monomial(y)  # m1 = x²y
+        m2 = m1 ** 2                 # m2 = x⁴y²
+        self.assertEqual(m2.degree(x), 4)
+        self.assertEqual(m2.degree(y), 2)
+
+    def test_pow_in_place(self):
+        m1 = sym.Monomial(x, 2) * sym.Monomial(y)  # m1 = x²y
+        m2 = m1.pow_in_place(2)      # m1 = m2 = x⁴y²
+        self.assertEqual(m1.degree(x), 4)
+        self.assertEqual(m1.degree(y), 2)
+        self.assertEqual(m2.degree(x), 4)
+        self.assertEqual(m2.degree(y), 2)
+
+    def test_get_powers(self):
+        m = sym.Monomial(x, 2) * sym.Monomial(y)  # m = x²y
+        powers = m.get_powers()
+        self.assertEqual(powers[x], 2)
+        self.assertEqual(powers[y], 1)
+
+    def test_to_expression(self):
+        m = sym.Monomial(x, 3) * sym.Monomial(y)  # m = x³y
+        e = m.ToExpression()
+        self.assertEqual(str(e), "(pow(x, 3) * y)")
+
+    def test_get_variables(self):
+        m = sym.Monomial(x, 3) * sym.Monomial(y)  # m = x³y
+        vars = m.GetVariables()  # = [x, y]
+        self.assertEqual(vars.size(), 2)
+
+    def test_monomial_basis(self):
+        vars = sym.Variables([x, y, z])
+        basis1 = sym.MonomialBasis(vars, 3)
+        basis2 = sym.MonomialBasis([x, y, z], 3)
+        self.assertEqual(basis1.size, 20)
+        self.assertEqual(basis2.size, 20)
 
 
 class TestSymbolicPolynomial(unittest.TestCase):

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -18,61 +18,88 @@ e_x = sym.Expression(x)
 e_y = sym.Expression(y)
 
 
-class TestSymbolicVariables(unittest.TestCase):
-    def testOperators(self):
-        x = sym.Variable("x")
+class TestSymbolicVariable(unittest.TestCase):
+    def test_addition(self):
+        self.assertEqual(str(x + y), "(x + y)")
+        self.assertEqual(str(x + 1), "(1 + x)")
+        self.assertEqual(str(1 + x), "(1 + x)")
+
+    def test_subtraction(self):
+        self.assertEqual(str(x - y), "(x - y)")
+        self.assertEqual(str(x - 1), "(-1 + x)")
+        self.assertEqual(str(1 - x), "(1 - x)")
+
+    def test_multiplication(self):
+        self.assertEqual(str(x * y), "(x * y)")
+        self.assertEqual(str(x * 1), "x")
+        self.assertEqual(str(1 * x), "x")
+
+    def test_division(self):
+        self.assertEqual(str(x / y), "(x / y)")
+        self.assertEqual(str(x / 1), "x")
+        self.assertEqual(str(1 / x), "(1 / x)")
+
+    def test_unary_operators(self):
+        self.assertEqual(str(+x), "x")
+        self.assertEqual(str(-x), "(-1 * x)")
+
+    def test_relational_operators(self):
+        # Variable rop float
+        self.assertEqual(str(x >= 1), "(x >= 1)")
+        self.assertEqual(str(x > 1), "(x > 1)")
+        self.assertEqual(str(x <= 1), "(x <= 1)")
+        self.assertEqual(str(x < 1), "(x < 1)")
+        self.assertEqual(str(x == 1), "(x = 1)")
+        self.assertEqual(str(x != 1), "(x != 1)")
+
+        # float rop Variable
+        self.assertEqual(str(1 < y), "(y > 1)")
+        self.assertEqual(str(1 <= y), "(y >= 1)")
+        self.assertEqual(str(1 > y), "(y < 1)")
+        self.assertEqual(str(1 >= y), "(y <= 1)")
+        self.assertEqual(str(1 == y), "(y = 1)")
+        self.assertEqual(str(1 != y), "(y != 1)")
+
+        # Variable rop Variable
+        self.assertEqual(str(x < y), "(x < y)")
+        self.assertEqual(str(x <= y), "(x <= y)")
+        self.assertEqual(str(x > y), "(x > y)")
+        self.assertEqual(str(x >= y), "(x >= y)")
+        self.assertEqual(str(x == y), "(x = y)")
+        self.assertEqual(str(x != y), "(x != y)")
+
+    def test_repr(self):
         self.assertEqual(str(x), "x")
-
-        y = sym.Variable("y")
         self.assertEqual(str(y), "y")
-
         self.assertEqual(str(x + y), "(x + y)")
         self.assertEqual(str(x - y), "(x - y)")
         self.assertEqual(str(x * y), "(x * y)")
         self.assertEqual(str(x / y), "(x / y)")
         self.assertEqual(str((x + y) * x), "(x * (x + y))")
 
-    def testSimplify(self):
-        x = sym.Variable("x")
-        y = sym.Variable("y")
+    def test_simplify(self):
         self.assertEqual(str(0 * (x + y)), "0")
         self.assertEqual(str(x + y - x - y), "0")
         self.assertEqual(str(x / x - 1), "0")
         self.assertEqual(str(x / x), "1")
 
-    def testFormula(self):
-        x = sym.Variable("x")
-        y = sym.Variable("y")
-
-        self.assertEqual(str(x < y), "(x < y)")
-        self.assertEqual(str(x <= y), "(x <= y)")
-        self.assertEqual(str(x > y), "(x > y)")
-        self.assertEqual(str(x >= y), "(x >= y)")
-        self.assertEqual(str(x == y), "(x = y)")
-
-    def testExpand(self):
-        x = sym.Variable("x")
-        y = sym.Variable("y")
+    def test_expand(self):
         ex = 2 * (x + y)
         self.assertEqual(str(ex), "(2 * (x + y))")
         self.assertEqual(str(ex.Expand()), "(2 * x + 2 * y)")
 
-    def testPow(self):
-        x = sym.Variable("x")
+    def test_pow(self):
         self.assertEqual(str(x**2), "pow(x, 2)")
-        y = sym.Variable("y")
         self.assertEqual(str(x**y), "pow(x, y)")
         self.assertEqual(str((x + 1)**(y - 1)), "pow((1 + x), (-1 + y))")
 
-    def testNeg(self):
-        x = sym.Variable("x")
-        self.assertEqual(str(-x), "(-1 * x)")
+    def test_neg(self):
         self.assertEqual(str(-(x + 1)), "(-1 - x)")
 
-    def testLogical(self):
-        x = sym.Variable("x")
+    def test_logical(self):
         self.assertEqual(str(sym.logical_not(x == 0)),
                          "!((x = 0))")
+
         # Test single-operand logical statements
         self.assertEqual(str(sym.logical_and(x >= 1)), "(x >= 1)")
         self.assertEqual(str(sym.logical_or(x >= 1)), "(x >= 1)")
@@ -82,7 +109,6 @@ class TestSymbolicVariables(unittest.TestCase):
         self.assertEqual(str(sym.logical_or(x <= 1, x >= 2)),
                          "((x >= 2) or (x <= 1))")
         # Test multiple operand logical statements
-        y = sym.Variable("y")
         self.assertEqual(str(sym.logical_and(x >= 1, x <= 2, y == 2)),
                          "((y = 2) and (x >= 1) and (x <= 2))")
         self.assertEqual(str(sym.logical_or(x >= 1, x <= 2, y == 2)),
@@ -190,6 +216,115 @@ class TestSymbolicVariables(unittest.TestCase):
 
 
 class TestSymbolicExpression(unittest.TestCase):
+    def test_addition(self):
+        self.assertEqual(str(e_x + e_y), "(x + y)")
+        self.assertEqual(str(e_x + y), "(x + y)")
+        self.assertEqual(str(e_x + 1), "(1 + x)")
+        self.assertEqual(str(x + e_y), "(x + y)")
+        self.assertEqual(str(1 + e_x), "(1 + x)")
+
+    def test_addition_assign(self):
+        e = x
+        e += e_y
+        self.assertEqual(e, x + y)
+        e += z
+        self.assertEqual(e, x + y + z)
+        e += 1
+        self.assertEqual(e, x + y + z + 1)
+
+    def test_subtract(self):
+        self.assertEqual(str(e_x - e_y), "(x - y)")
+        self.assertEqual(str(e_x - y), "(x - y)")
+        self.assertEqual(str(e_x - 1), "(-1 + x)")
+        self.assertEqual(str(x - e_y), "(x - y)")
+        self.assertEqual(str(1 - e_x), "(1 - x)")
+
+    def test_subtract_assign(self):
+        e = x
+        e -= e_y
+        self.assertEqual(e, x - y)
+        e -= z
+        self.assertEqual(e, x - y - z)
+        e -= 1
+        self.assertEqual(e, x - y - z - 1)
+
+    def test_multiplication(self):
+        self.assertEqual(str(e_x * e_y), "(x * y)")
+        self.assertEqual(str(e_x * y), "(x * y)")
+        self.assertEqual(str(e_x * 1), "x")
+        self.assertEqual(str(x * e_y), "(x * y)")
+        self.assertEqual(str(1 * e_x), "x")
+
+    def test_multiplication_assign(self):
+        e = x
+        e *= e_y
+        self.assertEqual(e, x * y)
+        e *= z
+        self.assertEqual(e, x * y * z)
+        e *= 1
+        self.assertEqual(e, x * y * z)
+
+    def test_division(self):
+        self.assertEqual(str(e_x / e_y), "(x / y)")
+        self.assertEqual(str(e_x / y), "(x / y)")
+        self.assertEqual(str(e_x / 1), "x")
+        self.assertEqual(str(x / e_y), "(x / y)")
+        self.assertEqual(str(1 / e_x), "(1 / x)")
+
+    def test_division_assign(self):
+        e = x
+        e /= e_y
+        self.assertEqual(e, x / y)
+        e /= z
+        self.assertEqual(e, x / y / z)
+        e /= 1
+        self.assertEqual(e, x / y / z)
+
+    def test_unary_operators(self):
+        self.assertEqual(str(+e_x), "x")
+        self.assertEqual(str(-e_x), "(-1 * x)")
+
+    def test_relational_operators(self):
+        # Expression rop Expression
+        self.assertEqual(str(e_x < e_y), "(x < y)")
+        self.assertEqual(str(e_x <= e_y), "(x <= y)")
+        self.assertEqual(str(e_x > e_y), "(x > y)")
+        self.assertEqual(str(e_x >= e_y), "(x >= y)")
+        self.assertEqual(str(e_x == e_y), "(x = y)")
+        self.assertEqual(str(e_x != e_y), "(x != y)")
+
+        # Expression rop Variable
+        self.assertEqual(str(e_x < y), "(x < y)")
+        self.assertEqual(str(e_x <= y), "(x <= y)")
+        self.assertEqual(str(e_x > y), "(x > y)")
+        self.assertEqual(str(e_x >= y), "(x >= y)")
+        self.assertEqual(str(e_x == y), "(x = y)")
+        self.assertEqual(str(e_x != y), "(x != y)")
+
+        # Variable rop Expression
+        self.assertEqual(str(x < e_y), "(x < y)")
+        self.assertEqual(str(x <= e_y), "(x <= y)")
+        self.assertEqual(str(x > e_y), "(x > y)")
+        self.assertEqual(str(x >= e_y), "(x >= y)")
+        self.assertEqual(str(x == e_y), "(x = y)")
+        self.assertEqual(str(x != e_y), "(x != y)")
+
+        # Expression rop float
+        self.assertEqual(str(e_x < 1), "(x < 1)")
+        self.assertEqual(str(e_x <= 1), "(x <= 1)")
+        self.assertEqual(str(e_x > 1), "(x > 1)")
+        self.assertEqual(str(e_x >= 1), "(x >= 1)")
+        self.assertEqual(str(e_x == 1), "(x = 1)")
+        self.assertEqual(str(e_x != 1), "(x != 1)")
+
+        # float rop Expression
+        self.assertEqual(str(1 < e_y), "(y > 1)")
+        self.assertEqual(str(1 <= e_y), "(y >= 1)")
+        self.assertEqual(str(1 > e_y), "(y < 1)")
+        self.assertEqual(str(1 >= e_y), "(y <= 1)")
+        self.assertEqual(str(1 == e_y), "(y = 1)")
+        self.assertEqual(str(1 != e_y), "(y != 1)")
+
     def test_functions_with_float(self):
         v_x = 1.0
         v_y = 1.0
@@ -240,8 +375,6 @@ class TestSymbolicExpression(unittest.TestCase):
                          "(if (x > y) then x else y)")
 
     def test_functions_with_expression(self):
-        e_x = sym.Expression(x)
-        e_y = sym.Expression(y)
         self.assertEqual(str(sym.abs(e_x)), "abs(x)")
         self.assertEqual(str(sym.exp(e_x)), "exp(x)")
         self.assertEqual(str(sym.sqrt(e_x)), "sqrt(x)")


### PR DESCRIPTION
The first commit: No functional changes. Only merging symbolic_{monomial, variables}_test to `symbolic_test` in pydrake.

The added tests should provide complete test coverage.

Close #8187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8247)
<!-- Reviewable:end -->
