### PR TITLE
Don't define CTRLC when building osqp

### DIFF
--- a/tools/workspace/osqp/package.BUILD.bazel
+++ b/tools/workspace/osqp/package.BUILD.bazel
@@ -21,7 +21,6 @@ cmake_configure_file(
     defines = [
         "PRINTING",
         "PROFILING",
-        "CTRLC",
         "DFLOAT",
         "DLONG",
     ] + select({


### PR DESCRIPTION
It causes osqp to register a SIGINT handler inside osqp_solve.  This
can be confusing to downstream consumers who don't expect the solver
to mess with the process's signal state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8251)
<!-- Reviewable:end -->
