### PR TITLE
Enable more compiler errors

### DIFF
--- a/matlab/cmake/flags.cmake
+++ b/matlab/cmake/flags.cmake
@@ -30,6 +30,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     -Werror=old-style-cast
     -Werror=overloaded-virtual
     -Werror=return-local-addr
+    -Werror=shadow
     -Werror=unused-but-set-parameter
   )
 endif()

--- a/matlab/cmake/flags.cmake
+++ b/matlab/cmake/flags.cmake
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated
     -Werror=deprecated-declarations
     -Werror=ignored-qualifiers
     -Werror=inconsistent-missing-override
@@ -20,6 +21,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL C
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated
     -Werror=deprecated-declarations
     -Werror=extra
     -Werror=ignored-qualifiers

--- a/matlab/cmake/flags.cmake
+++ b/matlab/cmake/flags.cmake
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated-declarations
     -Werror=ignored-qualifiers
     -Werror=inconsistent-missing-override
     -Werror=non-virtual-dtor
@@ -19,6 +20,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL C
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated-declarations
     -Werror=extra
     -Werror=ignored-qualifiers
     -Werror=logical-op

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -13,6 +13,7 @@ load(
 # building with any compiler.
 CXX_FLAGS = [
     "-Werror=all",
+    "-Werror=deprecated",
     "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",
     "-Werror=old-style-cast",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -14,28 +14,28 @@ load(
 CXX_FLAGS = [
     "-Werror=all",
     "-Werror=ignored-qualifiers",
-    "-Werror=overloaded-virtual",
     "-Werror=old-style-cast",
+    "-Werror=overloaded-virtual",
 ]
 
 # The CLANG_FLAGS will be enabled for all C++ rules in the project when
 # building with clang.
 CLANG_FLAGS = CXX_FLAGS + [
-    "-Werror=shadow",
     "-Werror=inconsistent-missing-override",
-    "-Werror=sign-compare",
-    "-Werror=return-stack-address",
     "-Werror=non-virtual-dtor",
+    "-Werror=return-stack-address",
+    "-Werror=shadow",
+    "-Werror=sign-compare",
 ]
 
 # The GCC_FLAGS will be enabled for all C++ rules in the project when
 # building with gcc.
 GCC_FLAGS = CXX_FLAGS + [
     "-Werror=extra",
-    "-Werror=return-local-addr",
-    "-Werror=non-virtual-dtor",
-    "-Werror=unused-but-set-parameter",
     "-Werror=logical-op",
+    "-Werror=non-virtual-dtor",
+    "-Werror=return-local-addr",
+    "-Werror=unused-but-set-parameter",
     # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
     "-Wno-missing-field-initializers",
     # TODO(#2852) Turn on shadow checking for g++ once we use a version that

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -18,6 +18,7 @@ CXX_FLAGS = [
     "-Werror=ignored-qualifiers",
     "-Werror=old-style-cast",
     "-Werror=overloaded-virtual",
+    "-Werror=shadow",
 ]
 
 # The CLANG_FLAGS will be enabled for all C++ rules in the project when
@@ -26,7 +27,6 @@ CLANG_FLAGS = CXX_FLAGS + [
     "-Werror=inconsistent-missing-override",
     "-Werror=non-virtual-dtor",
     "-Werror=return-stack-address",
-    "-Werror=shadow",
     "-Werror=sign-compare",
 ]
 
@@ -40,8 +40,6 @@ GCC_FLAGS = CXX_FLAGS + [
     "-Werror=unused-but-set-parameter",
     # TODO(jwnimmer-tri) Fix these warnings and remove this suppression.
     "-Wno-missing-field-initializers",
-    # TODO(#2852) Turn on shadow checking for g++ once we use a version that
-    # fixes https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709
 ]
 
 # The GCC_CC_TEST_FLAGS will be enabled for all cc_test rules in the project

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -13,6 +13,7 @@ load(
 # building with any compiler.
 CXX_FLAGS = [
     "-Werror=all",
+    "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",
     "-Werror=old-style-cast",
     "-Werror=overloaded-virtual",


### PR DESCRIPTION
Summary of changes:
- Alpha-sort `CXX_FLAGS` lists
- Enable `-Werror=deprecated-declarations` (Closes #8204).
- Enable `-Werror=deprecated`.
- Enable `-Werror=shadow` for GCC (Relates #2852).

Do not merge until:
- [ ] freshly tested on Jenkins (no cross-merge PR breaks);
- [ ] macOS CI passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8259)
<!-- Reviewable:end -->
