### PR TITLE
Support friend copyable_unique_ptr to provide access to private methods

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -586,6 +586,7 @@ drake_cc_googletest(
     name = "copyable_unique_ptr_test",
     deps = [
         ":copyable_unique_ptr",
+        "//common:unused",
         "//common/test_utilities:is_dynamic_castable",
     ],
 )

--- a/common/copyable_unique_ptr.h
+++ b/common/copyable_unique_ptr.h
@@ -16,71 +16,26 @@ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 #include <utility>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/is_cloneable.h"
 
 namespace drake {
-
-/** @cond */
-
-namespace copyable_unique_ptr_detail {
-
-// This uses SFINAE to classify a particular class as "copyable". There are two
-// overloads of the `is_copyable_unique_ptr_compatible_helper` struct: one is
-// the default implementation and the other relies on the SFINAE and copyable
-// test.
-//
-// The default overload reports that a class is _not_ copyable. Only if the
-// class being queried passes the copyable test, will the second overload get
-// created. It defines value to be true. The second overload is a more specific
-// match to the helper invocation, so, if it exists, it will be instantiated by
-// preference and report a true value.
-
-template <typename V, class>
-struct is_copyable_unique_ptr_compatible_helper : std::false_type {};
-
-// This is the specific overload. The copyable condition is that it is
-// "cloneable" or has a copy constructor.
-template <typename V>
-struct is_copyable_unique_ptr_compatible_helper<
-    V, typename std::enable_if<is_cloneable<V>::value ||
-        std::is_copy_constructible<V>::value>::type>
-    : std::true_type {};
-
-
-}  // namespace copyable_unique_ptr_detail
-/** @endcond */
-
-/**
- Test for determining if an arbitrary class is compatible with the
- copyable_unique_ptr. For a class to be compatible with the copy_unique_ptr,
- it must be copy constructible or "cloneable" (see @ref is_cloneable_doc
- "is_cloneable"). Usage:
-
- @code
- is_copyable_unique_ptr_compatible<TestClass>::value
- @endcode
-
- Evaluates to true if compatible, false otherwise. This can be used in run-time
- test, `static_assert`s, and in SFINAE voodoo.
-
- @see copyable_unique_ptr
- @see is_cloneable
- */
-template <typename T>
-using is_copyable_unique_ptr_compatible =
-    copyable_unique_ptr_detail::is_copyable_unique_ptr_compatible_helper<T,
-                                                                         void>;
 
 /** A smart pointer with deep copy semantics.
 
  This is _similar_ to `std::unique_ptr` in that it does not permit shared
  ownership of the contained object. However, unlike `std::unique_ptr`,
  %copyable_unique_ptr supports copy and assignment operations, by insisting that
- the contained object be "copyable".
- To be copyable, the class must have either a public copy constructor, or it
- must be "cloneable" (see @ref is_cloneable_doc "is_cloneable" for definition).
- A class can be tested for compatibility using the
- @ref is_copyable_unique_ptr_compatible struct.
+ the contained object be "copyable". To be copyable, the class must have either
+ an accessible copy constructor, or it must have an accessible clone method
+ with signature @code
+   std::unique_ptr<Foo> Clone() const;
+ @endcode
+ where Foo is the type of the managed object. By "accessible" we mean either
+ that the copy constructor or clone method is public, or
+ `friend copyable_unique_ptr<Foo>;` appears in Foo's class declaration.
+
+ <!-- Developer note: if you change or extend the definition of an acceptable
+      clone method here, be sure to consider whether drake::is_cloneable should
+      be changed as well. -->
 
  Generally, the API is modeled as closely as possible on the C++ standard
  `std::unique_ptr` API and %copyable_unique_ptr<T> is interoperable with
@@ -91,9 +46,9 @@ using is_copyable_unique_ptr_compatible =
    between writable and const access, the get() method is modified to return
    only a const pointer, with get_mutable() added to return a writable pointer.
 
- This class is entirely inline and has no computational or
- space overhead except when copying is required; it contains just a single
- pointer and does no reference counting.
+ This class is entirely inline and has no computational or space overhead except
+ when copying is required; it contains just a single pointer and does no
+ reference counting.
 
  __Usage__
 
@@ -144,19 +99,12 @@ using is_copyable_unique_ptr_compatible =
    compilable.
  -->
 
- @see is_copyable_unique_ptr_compatible
- @tparam T   The type of the contained object, which *must* be
-             @ref is_copyable_unique_ptr_compatible "compatibly copyable". May
-             be an abstract or concrete type.
+ @tparam T   The type of the contained object, which *must* be copyable as
+             defined above. May be an abstract or concrete type.
  */
 // TODO(SeanCurtis-TRI): Consider extending this to add the Deleter as well.
 template <typename T>
 class copyable_unique_ptr : public std::unique_ptr<T> {
-  static_assert(is_copyable_unique_ptr_compatible<T>::value,
-                "copyable_unique_ptr can only be used with a 'copyable' class"
-                    ", requiring either a public copy constructor or a valid "
-                    "clone method of the form: `unique_ptr<T> Clone() const`.");
-
  public:
   /** @name                    Constructors **/
   /**@{*/
@@ -343,13 +291,72 @@ class copyable_unique_ptr : public std::unique_ptr<T> {
   T* get_mutable() noexcept { return std::unique_ptr<T>::get(); }
 
   /**@}*/
-
  private:
+  // The can_copy() and can_clone() methods must be defined within the
+  // copyable_unique_ptr class so that they have the same method access as
+  // the class does. That way we can use them to determine whether
+  // copyable_unique_ptr can get access. That precludes using helper classes
+  // like drake::is_cloneable because those may have different access due to an
+  // explicit friend declaration giving copyable_unique_ptr<Foo> access to Foo's
+  // private business. The static_assert below ensures that at least one of
+  // these must return true.
+
+  // SFINAE magic explanation. We're combining several tricks here:
+  // (1) "..." as a parameter type is a last choice; an exact type match is
+  //     preferred in overload resolution.
+  // (2) Use a dummy template parameter U that is always just T but defers
+  //     instantiation so that substitution failure is not fatal.
+  // (3) We construct a non-evaluated copy constructor and Clone method in
+  //     templatized methods to prevent instantiation if the needed method
+  //     doesn't exist or isn't accessible. If instantiation is successful,
+  //     we produce an exact-match method that trumps the "..."-using method.
+  // (4) Make these constexpr so they can be used in static_assert.
+
+  // True iff type T provides a copy constructor that is accessible from
+  // %copyable_unique_ptr<T>. Invoke with `can_copy(1)`; the argument is used
+  // to select the right method. Note that if both `can_copy()` and
+  // `can_clone()` return true, we will prefer the copy constructor over the
+  // Clone() method.
+  static constexpr bool can_copy(...) { return false; }
+
+  // If this instantiates successfully it will be the preferred method called
+  // when an integer argument is provided.
+  template <typename U = T>
+  static constexpr std::enable_if_t<
+      std::is_same<decltype(U(std::declval<const U&>())), U>::value,
+      bool>
+  can_copy(int) {
+    return true;
+  }
+
+  // True iff type T provides a `Clone()` method with the appropriate
+  // signature (see class documentation) that is accessible from
+  // %copyable_unique_ptr<T>. Invoke with `can_clone(1)`; the argument is used
+  // to select the right method.
+  static constexpr bool can_clone(...) { return false; }
+
+  // If this instantiates successfully it will be the preferred method called
+  // when an integer argument is provide.
+  template <typename U = T>
+  static constexpr std::enable_if_t<
+      std::is_same<decltype(std::declval<const U>().Clone()),
+                   std::unique_ptr<std::remove_const_t<U>>>::value,
+      bool>
+  can_clone(int) {
+    return true;
+  }
+
+  static_assert(
+      can_copy(1) || can_clone(1),
+      "copyable_unique_ptr<T> can only be used with a 'copyable' class T, "
+      "requiring either a copy constructor or a Clone method of the form "
+      "'unique_ptr<T> Clone() const', accessible to copyable_unique_ptr<T>. "
+      "You may need to friend copyable_unique_ptr<T>.");
+
   // Selects Clone iff there is no copy constructor and the Clone method is of
   // the expected form.
-  template <typename U>
-  static typename std::enable_if<
-      !std::is_copy_constructible<U>::value && is_cloneable<T>::value, U*>::type
+  template <typename U = T>
+  static typename std::enable_if<!can_copy(1) && can_clone(1), U*>::type
   CopyOrNullHelper(const U* ptr, int) {
     return ptr->Clone().release();
   }

--- a/common/is_cloneable.h
+++ b/common/is_cloneable.h
@@ -51,11 +51,16 @@ struct is_cloneable_helper<
 
  __Definition of "cloneability"__
 
- To be cloneable, the class `Foo` must have a public method of the form:
-
+ To be cloneable, the class `Foo` must have a _public_ method of the form:
  @code
  unique_ptr<Foo> Foo::Clone() const;
  @endcode
+ Note that "friend" access for the %is_cloneable-using class is not sufficient.
+ The `Foo::Clone()` method must actually be public.
+
+ <!-- Developer note: if you change or extend the definition of an acceptable
+      clone method here, be sure to consider whether
+      copyable_unique_ptr::can_clone() should be changed as well. -->
 
  The pointer contained in the returned `unique_ptr` must point to a
  heap-allocated deep copy of the _concrete_ object. This test can confirm the

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -6,7 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/is_cloneable.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
+#include "drake/common/unused.h"
 
 namespace drake {
 namespace  {
@@ -72,7 +74,6 @@ struct CopyOnly : Base {
 // Confirms that a class with only a public copy constructor is considered
 // copyable and copies appropriately.
 GTEST_TEST(CopyableUniquePtrTest, CopyOnlySuccess) {
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CopyOnly>::value);
   cup<CopyOnly> ptr(new CopyOnly(1));
   EXPECT_EQ(ptr->origin, Origin::CONSTRUCT);
   cup<CopyOnly> copy(ptr);
@@ -80,6 +81,55 @@ GTEST_TEST(CopyableUniquePtrTest, CopyOnlySuccess) {
   EXPECT_EQ(copy->value, ptr->value);
   ++copy->value;
   EXPECT_NE(copy->value, ptr->value);
+}
+
+// This class has a private copy constructor but declares copyable_unique_ptr
+// to be a friend so it should still be copyable.
+class FriendsWithBenefitsCopy {
+ public:
+  explicit FriendsWithBenefitsCopy(int value) : value_(value) {}
+  int value() const {return value_;}
+
+ private:
+  friend class copyable_unique_ptr<FriendsWithBenefitsCopy>;
+  FriendsWithBenefitsCopy(const FriendsWithBenefitsCopy&) = default;
+
+  int value_{0};
+};
+
+// This class has no copy constructor and a private Clone() method but declares
+// copyable_unique_ptr to be a friend so it should still be copyable.
+class FriendsWithBenefitsClone {
+ public:
+  explicit FriendsWithBenefitsClone(int value) : value_(value) {}
+  int value() const {return value_;}
+  FriendsWithBenefitsClone(const FriendsWithBenefitsClone&) = delete;
+
+ private:
+  friend class copyable_unique_ptr<FriendsWithBenefitsClone>;
+  std::unique_ptr<FriendsWithBenefitsClone> Clone() const {
+    return std::make_unique<FriendsWithBenefitsClone>(value_);
+  }
+
+  int value_{0};
+};
+
+// Check that a friend declaration works to get copyable_unique_ptr access
+// to the needed copy constructor or Clone() method.
+GTEST_TEST(CopyableUniquePtrTest, FriendsWithBenefits) {
+  copyable_unique_ptr<FriendsWithBenefitsCopy> fwb(
+      new FriendsWithBenefitsCopy(10));
+  EXPECT_EQ(fwb->value(), 10);
+
+  copyable_unique_ptr<FriendsWithBenefitsCopy> fwb2(fwb);
+  EXPECT_EQ(fwb2->value(), 10);
+
+  copyable_unique_ptr<FriendsWithBenefitsClone> fwbc(
+      new FriendsWithBenefitsClone(20));
+  EXPECT_EQ(fwbc->value(), 20);
+
+  copyable_unique_ptr<FriendsWithBenefitsClone> fwbc2(fwbc);
+  EXPECT_EQ(fwbc2->value(), 20);
 }
 
 // A fully copyable class (has both copy constructor and Clone). Confirms that
@@ -95,7 +145,6 @@ struct FullyCopyable : Base {
 
 // Confirms that the copy constructor is preferred when both exist.
 GTEST_TEST(CopyableUniquePtrTest, FullyCopyableSuccess) {
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<FullyCopyable>::value);
   cup<FullyCopyable> ptr(new FullyCopyable(1));
   EXPECT_EQ(ptr->origin, Origin::CONSTRUCT);
   cup<FullyCopyable> copy(ptr);
@@ -121,7 +170,6 @@ struct CloneOnly : Base {
 // Confirms that a class that has a proper implementation of Clone, but no
 // copy constructor clones itself.
 GTEST_TEST(CopyableUniquePtrTest, CloneOnlySuccess) {
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CloneOnly>::value);
   cup<CloneOnly> ptr(new CloneOnly(1));
   EXPECT_EQ(ptr->origin, Origin::CONSTRUCT);
   cup<CloneOnly> copy(ptr);
@@ -201,33 +249,39 @@ struct CopyChild : public FullyCopyable {
 // the base class has *only* a Clone method and no copy constructor. Just
 // because the base class is copyable does not imply the child is copyable.
 GTEST_TEST(CopyableUniquePtrTest, PolymorphicCopyability) {
+  // FYI is_cloneable and is_copy_constructible look only for public methods
+  // which is a more stringent condition that copyable_unique_ptr enforces.
+  // Below we'll verify that the presence of an appropriate public method *does*
+  // enable us to use copyable_unique_ptr, by creating one of the appropriate
+  // type and then marking it "unused" to avoid warnings. If this test compiles
+  // then we succeeded.
+
   // Case 1) Child with *only* Clone method.
   EXPECT_TRUE(is_cloneable<CloneOnlyChildWithClone>::value);
   EXPECT_FALSE(std::is_copy_constructible<CloneOnlyChildWithClone>::value);
-  EXPECT_TRUE(
-      is_copyable_unique_ptr_compatible<CloneOnlyChildWithClone>::value);
+  copyable_unique_ptr<CloneOnlyChildWithClone> ptr_1;
 
   // Case 2) Child with *only* Copy method but virtual DoClone().
   EXPECT_FALSE(is_cloneable<CloneOnlyChildWithCopyVClone>::value);
   EXPECT_TRUE(std::is_copy_constructible<CloneOnlyChildWithCopyVClone>::value);
-  EXPECT_TRUE(
-      is_copyable_unique_ptr_compatible<CloneOnlyChildWithCopyVClone>::value);
+  copyable_unique_ptr<CloneOnlyChildWithCopyVClone> ptr_2;
 
   // Case 3) Child with *only* Copy method.
   EXPECT_FALSE(is_cloneable<CloneOnlyChildWithCopy>::value);
   EXPECT_TRUE(std::is_copy_constructible<CloneOnlyChildWithCopy>::value);
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CloneOnlyChildWithCopy>::value);
+  copyable_unique_ptr<CloneOnlyChildWithCopy> ptr_3;
 
   // Case 4) Child with no copy and no clone.
   EXPECT_FALSE(is_cloneable<CloneOnlyChildUncopyable>::value);
   EXPECT_FALSE(std::is_copy_constructible<CloneOnlyChildUncopyable>::value);
-  EXPECT_FALSE(
-      is_copyable_unique_ptr_compatible<CloneOnlyChildUncopyable>::value);
+  // Can't make a cloneable_unique_ptr<CloneOnlyChildUncopyable>.
 
   // Case 5) Child with copy, derived from base with copy.
   EXPECT_FALSE(is_cloneable<CopyChild>::value);
   EXPECT_TRUE(std::is_copy_constructible<CopyChild>::value);
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CopyChild>::value);
+  copyable_unique_ptr<CopyChild> ptr_4;
+
+  unused(ptr_1, ptr_2, ptr_3, ptr_4);
 }
 
 // Utility test for the CopyTypeSlicing test. It is templated on the sub-class
@@ -301,22 +355,18 @@ GTEST_TEST(CopyableUniquePtrTest, CopyableAsExpected) {
   // Case 1) True || True --> True
   EXPECT_TRUE(is_cloneable<FullyCopyable>::value);
   EXPECT_TRUE(std::is_copy_constructible<FullyCopyable>::value);
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<FullyCopyable>::value);
 
   // Case 2) True || False --> True
   EXPECT_TRUE(is_cloneable<CloneOnly>::value);
   EXPECT_FALSE(std::is_copy_constructible<CloneOnly>::value);
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CloneOnly>::value);
 
   // Case 3) False || True --> True
   EXPECT_FALSE(is_cloneable<CopyOnly>::value);
   EXPECT_TRUE(std::is_copy_constructible<CopyOnly>::value);
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<CopyOnly>::value);
 
   // Case 4) False || False --> False
   EXPECT_FALSE(is_cloneable<Base>::value);
   EXPECT_FALSE(std::is_copy_constructible<Base>::value);
-  EXPECT_FALSE(is_copyable_unique_ptr_compatible<Base>::value);
 }
 
 // ------------------------ Constructor Tests ------------------------------

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -16,7 +16,12 @@ using std::move;
 
 // Confirms that the instance is copyable.
 GTEST_TEST(GeometryInstanceTest, IsCopyable) {
-  EXPECT_TRUE(is_copyable_unique_ptr_compatible<GeometryInstance>::value);
+  // Verify that this is copyable as defined by copyable_unique_ptr. We don't
+  // have a runtime check available but this will fail to compile if the class
+  // is not copyable.
+  copyable_unique_ptr<GeometryInstance> geo(make_unique<GeometryInstance>
+      (Isometry3<double>(), make_unique<Sphere>(1)));
+  EXPECT_TRUE(geo->id().is_valid());
 }
 
 GTEST_TEST(GeometryInstanceTest, IdCopies) {


### PR DESCRIPTION
`copyable_unique_ptr<Foo>` depends on access to Foo's copy constructor or Clone() method. When those methods exist but must be private, we would like to be able to write `friend copyable_unique_ptr<Foo>;` in Foo's class declaration so that `copyable_unique_ptr` can invoke the appropriate method on our behalf. Currently that does not work because the SFINAE magic uses helper classes which still can't access the private methods. This PR switches the magic to use functions directly in `copyable_unique_ptr` so that they inherit the same access abilities so can be used to find non-public, but accessible, methods. That makes `friend copyable_unique_ptr<Foo>;` work as expected.

(Note that the built-in `std::is_copy_constructible<Foo>` returns true only if the copy constructor is public.)

Relates to [this comment](https://reviewable.io/reviews/robotlocomotion/drake/8227#-L6qxLBaEMLv8jzEKjqh) in #8227. (cc: @jwnimmer-tri)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8262)
<!-- Reviewable:end -->
