### PR TITLE
pybind11: Install headers and CMake config

### DIFF
--- a/tools/workspace/pybind11/BUILD.bazel
+++ b/tools/workspace/pybind11/BUILD.bazel
@@ -2,4 +2,9 @@
 
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+exports_files(
+    ["package-create-cps.py"],
+    visibility = ["@pybind11//:__pkg__"],
+)
+
 add_lint_tests()

--- a/tools/workspace/pybind11/package-create-cps.py
+++ b/tools/workspace/pybind11/package-create-cps.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from drake.tools.install.cpsutils import read_defs
+
+defs = read_defs("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
+
+content = """
+{
+  "Cps-Version": "0.8.0",
+  "Name": "pybind11",
+  "Description": "Seamless operability between C++11 and Python",
+  "License": "BSD-3-Clause",
+  "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
+  "Default-Components": [":module"],
+  "Components": {
+    "module": {
+      "Type": "interface",
+      "Includes": ["@prefix@/include"],
+      "Compile-Features": ["c++11"]
+    }
+  },
+  "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"],
+  "X-CMake-Variables-Init": {
+    "CMAKE_MODULE_PATH": "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}"
+  }
+}
+""" % defs
+
+print(content[1:])

--- a/tools/workspace/pybind11/package-create-cps.py
+++ b/tools/workspace/pybind11/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from drake.tools.install.cpsutils import read_defs
 
@@ -15,7 +15,7 @@ content = """
   "Components": {
     "module": {
       "Type": "interface",
-      "Includes": ["@prefix@/include"],
+      "Includes": ["@prefix@/include/pybind11"],
       "Compile-Features": ["c++11"]
     }
   },

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -69,6 +69,7 @@ install_files(
 install(
     name = "install",
     targets = [":pybind11"],
+    hdr_dest = "include/pybind11",
     hdr_strip_prefix = ["include"],
     guess_hdrs = "PACKAGE",
     docs = ["LICENSE"],

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -2,8 +2,12 @@
 
 load(
     "@drake//tools/install:install.bzl",
+    "cmake_config",
     "install",
+    "install_cmake_config",
+    "install_files",
 )
+load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -43,7 +47,35 @@ cc_library(
     ],
 )
 
+cmake_config(
+    package = "pybind11",
+    script = "@drake//tools/workspace/pybind11:package-create-cps.py",
+    version_file = "include/pybind11/detail/common.h",
+)
+
+# Creates rule :install_cmake_config.
+install_cmake_config(package = "pybind11")
+
+install_files(
+    name = "install_extra_cmake",
+    dest = "lib/cmake/pybind11",
+    files = [
+        "tools/FindPythonLibsNew.cmake",
+        "tools/pybind11Tools.cmake",
+    ],
+    strip_prefix = ["**/"],
+)
+
 install(
     name = "install",
+    targets = [":pybind11"],
+    hdr_strip_prefix = ["include"],
+    guess_hdrs = "PACKAGE",
     docs = ["LICENSE"],
+    deps = [
+        ":install_cmake_config",
+        ":install_extra_cmake",
+    ],
 )
+
+python_lint()


### PR DESCRIPTION
This reverts commit be30e9d026f4e42e9cfbc70b6ddcc8ee46ae1754, reversing
changes made to 82bf3c8a02678f553c746bdbbe0f8e5a345841b7.

Per discussion with @stonier and @jamiesnape, and confirming with @clalancette, this seems like a better route for easier downstream consumption, (especially since we may expose some developer APIs for leveraging `pydrake`'s `pybind` utility components, and these utilities are required for binding Drake-derived components).

Relates #7856

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8264)
<!-- Reviewable:end -->
