### PR TITLE
Reduce monolithic_pick_and_place_demo simulation time when --quick is specified

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/monolithic_pick_and_place_demo.cc
@@ -99,8 +99,9 @@ int DoMain(void) {
 
   // Step the simulator in some small increment.  Between steps, check
   // to see if the state machine thinks we're done, and if so that the
-  // object is near the target.
-  const double simulation_step = 0.1;
+  // object is near the target.  If --quick is set, use a smaller
+  // increment to keep the test from taking too long in valgrind.
+  const double simulation_step = FLAGS_quick ? 0.01 : 0.1;
   bool done{false};
   while (!done) {
     simulator.StepTo(simulator.get_context().get_time() + simulation_step);


### PR DESCRIPTION
This test had been timing out in the Jenkins nightly lately.  I'm
concerned something else has happened which is making the test take
longer, but it's not failing reliably and I wasn't able to come up
with a good metric to bisect on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8265)
<!-- Reviewable:end -->
