### PR TITLE
Fix Wshadow warnings from GCC (automotive)

### DIFF
--- a/automotive/maliput/multilane/road_geometry.cc
+++ b/automotive/maliput/multilane/road_geometry.cc
@@ -46,13 +46,11 @@ void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
       lane->ToLanePosition(geo_position, &new_nearest_position, &new_distance);
 
   // Replaces return values.
-  auto replace_values = [lane, road_position, distance, nearest_position](
-      double new_distance, const api::LanePosition& lane_position,
-      const api::GeoPosition& new_nearest_pos) {
+  auto replace_values = [&]() {
     *distance = new_distance;
     *road_position = api::RoadPosition{lane, lane_position};
     if (nearest_position != nullptr) {
-      *nearest_position = new_nearest_pos;
+      *nearest_position = new_nearest_position;
     }
   };
 
@@ -64,7 +62,7 @@ void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
   }
   if (delta < -linear_tolerance) {
     // It is a better match.
-    replace_values(new_distance, lane_position, new_nearest_position);
+    replace_values();
     return;
   }
   // They are almost equal so it is worth checking the lane bounds.
@@ -75,12 +73,12 @@ void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
       lane_position.r() < lane_bounds.max()) {
     // Given that `geo_position` is inside the lane_bounds and there is no
     // overlapping of lane_bounds, the road_position is returned.
-    replace_values(new_distance, lane_position, new_nearest_position);
+    replace_values();
   } else {
     // Compares the r coordinate and updates the closest_road_position if it
     // is a better match.
     if (std::abs(lane_position.r()) < std::abs(road_position->pos.r())) {
-      replace_values(new_distance, lane_position, new_nearest_position);
+      replace_values();
     }
   }
 }

--- a/automotive/maliput/multilane/road_geometry.cc
+++ b/automotive/maliput/multilane/road_geometry.cc
@@ -31,11 +31,11 @@ namespace {
 // `road_position` must not be nullptr.
 // `distance` must not be nullptr.
 void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
-                                  double linear_tolerance,
+                                  const double linear_tolerance,
                                   const api::Lane* const lane,
-                                  api::RoadPosition* road_position,
-                                  double* distance,
-                                  api::GeoPosition* nearest_position) {
+                                  api::RoadPosition* const road_position,
+                                  double* const distance,
+                                  api::GeoPosition* const nearest_position) {
   DRAKE_DEMAND(lane != nullptr);
   DRAKE_DEMAND(road_position != nullptr);
   DRAKE_DEMAND(distance != nullptr);

--- a/automotive/maliput/multilane/test/multilane_loader_test.cc
+++ b/automotive/maliput/multilane/test/multilane_loader_test.cc
@@ -387,9 +387,9 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
   EXPECT_NE(rg, nullptr);
 
   // Finds a lane in a RoadGeometry by its id.
-  auto find_lane = [](const api::RoadGeometry& rg, const std::string& id) {
-    for (int i = 0; i < rg.num_junctions(); ++i) {
-      const api::Junction* junction = rg.junction(i);
+  auto find_lane = [&rg](const std::string& id) {
+    for (int i = 0; i < rg->num_junctions(); ++i) {
+      const api::Junction* junction = rg->junction(i);
       for (int j = 0; j < junction->num_segments(); ++j) {
         const api::Segment* segment = junction->segment(j);
         for (int k = 0; k < segment->num_lanes(); ++k) {
@@ -404,7 +404,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks zero elevated linear lane elevation polynomial.
   const multilane::Lane* flat_planar_linear_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s1_1"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s1_1"));
   EXPECT_NE(flat_planar_linear_dut, nullptr);
   EXPECT_NEAR(flat_planar_linear_dut->elevation().a(), 0., kVeryExact);
   EXPECT_NEAR(flat_planar_linear_dut->elevation().b(), 0., kVeryExact);
@@ -413,7 +413,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks zero elevated arc lane elevation polynomial.
   const multilane::Lane* flat_planar_arc_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s5_1"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s5_1"));
   EXPECT_NE(flat_planar_arc_dut, nullptr);
   EXPECT_NEAR(flat_planar_arc_dut->elevation().a(), 0., kVeryExact);
   EXPECT_NEAR(flat_planar_arc_dut->elevation().b(), 0., kVeryExact);
@@ -422,7 +422,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks elevated planar linear lane elevation polynomial.
   const multilane::Lane* elevated_planar_linear_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s12_0"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s12_0"));
   EXPECT_NE(elevated_planar_linear_dut, nullptr);
   EXPECT_NEAR(elevated_planar_linear_dut->elevation().a(), 1. / 3., kVeryExact);
   EXPECT_NEAR(elevated_planar_linear_dut->elevation().b(), 0., kVeryExact);
@@ -431,7 +431,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks elevated planar arc lane elevation polynomial.
   const multilane::Lane* elevated_planar_arc_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s10_0"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s10_0"));
   EXPECT_NE(elevated_planar_arc_dut, nullptr);
   EXPECT_NEAR(
       elevated_planar_arc_dut->elevation().a(), 0.318309886183791, kVeryExact);
@@ -441,7 +441,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks elevated planar linear lane elevation polynomial.
   const multilane::Lane* complex_linear_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s13_0"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s13_0"));
   EXPECT_NE(complex_linear_dut, nullptr);
   EXPECT_NEAR(
       complex_linear_dut->elevation().a(), 0.666666666666667, kVeryExact);
@@ -452,7 +452,7 @@ TEST_F(MultilaneLoaderMultipleSegmentCircuitTest, LaneElevationPolynomials) {
 
   // Checks elevated planar arc lane elevation polynomial.
   const multilane::Lane* complex_arc_dut =
-      dynamic_cast<const multilane::Lane*>(find_lane(*rg, "l:s11_0"));
+      dynamic_cast<const multilane::Lane*>(find_lane("l:s11_0"));
   EXPECT_NE(complex_arc_dut, nullptr);
   EXPECT_NEAR(complex_arc_dut->elevation().a(), 0.318309886183791, kVeryExact);
   EXPECT_NEAR(complex_arc_dut->elevation().b(), 0., kVeryExact);


### PR DESCRIPTION
Shadowing by-value variables that are not const within a function into a nested lambda is asking for trouble.

This will become a compiler error once we turn on Werror=shadow.

Relates #8259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8276)
<!-- Reviewable:end -->
