### PR TITLE
Reduces simulation time for free_rotating_body_test

### DIFF
--- a/multibody/multibody_tree/test/free_rotating_body_test.cc
+++ b/multibody/multibody_tree/test/free_rotating_body_test.cc
@@ -29,7 +29,7 @@ GTEST_TEST(RollPitchYawTest, TimeDerivatives) {
   // The numerical tolerance accepted for these tests.
   const double kTolerance = 1.0e-5;
   const double kMaxDt = 0.1;
-  const double kEndTime = 10.0;
+  const double kEndTime = 5.0;
 
   // Initial position and translational velocity are zero; only rotations are
   // considered.


### PR DESCRIPTION
Reduces simulation time in unit test so that it doesn't time out. Simulation time is still long enough for the test purposes.