### PR TITLE
Fix Wshadow warnings from GCC (systems)

### DIFF
--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -13,6 +13,12 @@ namespace drake {
 namespace systems {
 namespace controllers {
 
+DynamicProgrammingOptions::PeriodicBoundaryCondition::PeriodicBoundaryCondition(
+    int state_index_in, double low_in, double high_in)
+    : state_index(state_index_in), low(low_in), high(high_in) {
+  DRAKE_DEMAND(low_in < high_in);
+}
+
 std::pair<std::unique_ptr<BarycentricMeshSystem<double>>, Eigen::RowVectorXd>
 FittedValueIteration(
     Simulator<double>* simulator,

--- a/systems/controllers/dynamic_programming.h
+++ b/systems/controllers/dynamic_programming.h
@@ -28,10 +28,7 @@ struct DynamicProgrammingOptions {
   /// ensure that all values are in the range [low, high).  The classic example
   /// is for angles that are wrapped around at 2π.
   struct PeriodicBoundaryCondition {
-    PeriodicBoundaryCondition(int state_index, double low, double high) :
-      state_index(state_index), low(low), high(high) {
-      DRAKE_DEMAND(low < high);
-    }
+    PeriodicBoundaryCondition(int state_index, double low, double high);
     int state_index{-1};
     double low{0.};
     double high{2.*M_PI};

--- a/systems/primitives/time_varying_data.cc
+++ b/systems/primitives/time_varying_data.cc
@@ -1,4 +1,82 @@
 #include "drake/systems/primitives/time_varying_data.h"
 
-// For now, this is an empty .cc file that only serves to confirm that
-// our .h file is a stand-alone header.
+namespace drake {
+namespace systems {
+
+// We use out-of-line definitions to rename the arguments without shadowing.
+
+TimeVaryingData::TimeVaryingData(const std::vector<Eigen::MatrixXd>& Ain,
+                                 const std::vector<Eigen::MatrixXd>& Bin,
+                                 const std::vector<Eigen::MatrixXd>& f0in,
+                                 const std::vector<Eigen::MatrixXd>& Cin,
+                                 const std::vector<Eigen::MatrixXd>& Din,
+                                 const std::vector<Eigen::MatrixXd>& y0in,
+                                 double time_period)
+    : TimeVaryingData(
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(Ain.size(), time_period), Ain),
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(Bin.size(), time_period), Bin),
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(f0in.size(), time_period), f0in),
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(Cin.size(), time_period), Cin),
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(Din.size(), time_period), Din),
+          PiecewisePolynomial<double>::FirstOrderHold(
+              internal::vector_iota(y0in.size(), time_period), y0in)) {
+  DRAKE_DEMAND(time_period > 0.);
+}
+
+TimeVaryingData::TimeVaryingData(const PiecewisePolynomial<double>& Ain,
+                                 const PiecewisePolynomial<double>& Bin,
+                                 const PiecewisePolynomial<double>& f0in,
+                                 const PiecewisePolynomial<double>& Cin,
+                                 const PiecewisePolynomial<double>& Din,
+                                 const PiecewisePolynomial<double>& y0in)
+    : A(PiecewisePolynomialTrajectory(Ain)),
+      B(PiecewisePolynomialTrajectory(Bin)),
+      f0(PiecewisePolynomialTrajectory(f0in)),
+      C(PiecewisePolynomialTrajectory(Cin)),
+      D(PiecewisePolynomialTrajectory(Din)),
+      y0(PiecewisePolynomialTrajectory(y0in)) {
+  DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+               B.get_piecewise_polynomial().getNumberOfSegments());
+  DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+               C.get_piecewise_polynomial().getNumberOfSegments());
+  DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
+               D.get_piecewise_polynomial().getNumberOfSegments());
+  DRAKE_DEMAND(A.rows() == A.cols());
+  DRAKE_DEMAND(B.rows() == A.cols());
+  DRAKE_DEMAND(C.cols() == A.cols());
+  DRAKE_DEMAND(D.rows() == C.rows());
+  DRAKE_DEMAND(D.cols() == B.cols());
+
+  DRAKE_DEMAND(f0.get_piecewise_polynomial().getNumberOfSegments() ==
+               A.get_piecewise_polynomial().getNumberOfSegments());
+  DRAKE_DEMAND(f0.rows() == A.cols());
+  DRAKE_DEMAND(y0.get_piecewise_polynomial().getNumberOfSegments() ==
+               A.get_piecewise_polynomial().getNumberOfSegments());
+  DRAKE_DEMAND(y0.rows() == C.rows());
+}
+
+LinearTimeVaryingData::LinearTimeVaryingData(
+    const std::vector<Eigen::MatrixXd>& Ain,
+    const std::vector<Eigen::MatrixXd>& Bin,
+    const std::vector<Eigen::MatrixXd>& Cin,
+    const std::vector<Eigen::MatrixXd>& Din, double time_period)
+    : TimeVaryingData(
+          Ain, Bin, internal::eigen_vector_zeros(Ain.size(), Ain[0].rows()),
+          Cin, Din, internal::eigen_vector_zeros(Cin.size(), Cin[0].rows()),
+          time_period) {}
+
+LinearTimeVaryingData::LinearTimeVaryingData(
+    const PiecewisePolynomial<double>& Ain,
+    const PiecewisePolynomial<double>& Bin,
+    const PiecewisePolynomial<double>& Cin,
+    const PiecewisePolynomial<double>& Din)
+    : TimeVaryingData(Ain, Bin, internal::MakeZeroedPiecewisePolynomial(Ain),
+                      Cin, Din, internal::MakeZeroedPiecewisePolynomial(Cin)) {}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/time_varying_data.h
+++ b/systems/primitives/time_varying_data.h
@@ -67,60 +67,20 @@ struct TimeVaryingData {
   ///
   /// @param time_period The time period from which to construct the time
   /// vector.  time_period must be greater than zero.
-  TimeVaryingData(const std::vector<Eigen::MatrixXd>& Ain,
-                  const std::vector<Eigen::MatrixXd>& Bin,
-                  const std::vector<Eigen::MatrixXd>& f0in,
-                  const std::vector<Eigen::MatrixXd>& Cin,
-                  const std::vector<Eigen::MatrixXd>& Din,
-                  const std::vector<Eigen::MatrixXd>& y0in, double time_period)
-      : TimeVaryingData(
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(Ain.size(), time_period), Ain),
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(Bin.size(), time_period), Bin),
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(f0in.size(), time_period), f0in),
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(Cin.size(), time_period), Cin),
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(Din.size(), time_period), Din),
-            PiecewisePolynomial<double>::FirstOrderHold(
-                internal::vector_iota(y0in.size(), time_period), y0in)) {
-    DRAKE_DEMAND(time_period > 0.);
-  }
+  TimeVaryingData(const std::vector<Eigen::MatrixXd>& A,
+                  const std::vector<Eigen::MatrixXd>& B,
+                  const std::vector<Eigen::MatrixXd>& f0,
+                  const std::vector<Eigen::MatrixXd>& C,
+                  const std::vector<Eigen::MatrixXd>& D,
+                  const std::vector<Eigen::MatrixXd>& y0, double time_period);
 
   /// Fully-parameterized constructor of PiecewisePolynomials.
-  TimeVaryingData(const PiecewisePolynomial<double>& Ain,
-                  const PiecewisePolynomial<double>& Bin,
-                  const PiecewisePolynomial<double>& f0in,
-                  const PiecewisePolynomial<double>& Cin,
-                  const PiecewisePolynomial<double>& Din,
-                  const PiecewisePolynomial<double>& y0in)
-      : A(PiecewisePolynomialTrajectory(Ain)),
-        B(PiecewisePolynomialTrajectory(Bin)),
-        f0(PiecewisePolynomialTrajectory(f0in)),
-        C(PiecewisePolynomialTrajectory(Cin)),
-        D(PiecewisePolynomialTrajectory(Din)),
-        y0(PiecewisePolynomialTrajectory(y0in)) {
-    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
-                 B.get_piecewise_polynomial().getNumberOfSegments());
-    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
-                 C.get_piecewise_polynomial().getNumberOfSegments());
-    DRAKE_DEMAND(A.get_piecewise_polynomial().getNumberOfSegments() ==
-                 D.get_piecewise_polynomial().getNumberOfSegments());
-    DRAKE_DEMAND(A.rows() == A.cols());
-    DRAKE_DEMAND(B.rows() == A.cols());
-    DRAKE_DEMAND(C.cols() == A.cols());
-    DRAKE_DEMAND(D.rows() == C.rows());
-    DRAKE_DEMAND(D.cols() == B.cols());
-
-    DRAKE_DEMAND(f0.get_piecewise_polynomial().getNumberOfSegments() ==
-                 A.get_piecewise_polynomial().getNumberOfSegments());
-    DRAKE_DEMAND(f0.rows() == A.cols());
-    DRAKE_DEMAND(y0.get_piecewise_polynomial().getNumberOfSegments() ==
-                 A.get_piecewise_polynomial().getNumberOfSegments());
-    DRAKE_DEMAND(y0.rows() == C.rows());
-  }
+  TimeVaryingData(const PiecewisePolynomial<double>& A,
+                  const PiecewisePolynomial<double>& B,
+                  const PiecewisePolynomial<double>& f0,
+                  const PiecewisePolynomial<double>& C,
+                  const PiecewisePolynomial<double>& D,
+                  const PiecewisePolynomial<double>& y0);
 
   PiecewisePolynomialTrajectory A{PiecewisePolynomial<double>()};
   PiecewisePolynomialTrajectory B{PiecewisePolynomial<double>()};
@@ -157,18 +117,13 @@ struct LinearTimeVaryingData : TimeVaryingData {
                         const std::vector<Eigen::MatrixXd>& B,
                         const std::vector<Eigen::MatrixXd>& C,
                         const std::vector<Eigen::MatrixXd>& D,
-                        double time_period)
-      : TimeVaryingData(
-            A, B, internal::eigen_vector_zeros(A.size(), A[0].rows()), C, D,
-            internal::eigen_vector_zeros(C.size(), C[0].rows()), time_period) {}
+                        double time_period);
 
   /// Fully-parameterized constructor of PiecewisePolynomials.
   LinearTimeVaryingData(const PiecewisePolynomial<double>& A,
                         const PiecewisePolynomial<double>& B,
                         const PiecewisePolynomial<double>& C,
-                        const PiecewisePolynomial<double>& D)
-      : TimeVaryingData(A, B, internal::MakeZeroedPiecewisePolynomial(A), C, D,
-                        internal::MakeZeroedPiecewisePolynomial(C)) {}
+                        const PiecewisePolynomial<double>& D);
 };
 
 }  // namespace systems


### PR DESCRIPTION
This removes potential confusion between member fields and local variables.  We are careful to leave the Doxygen spellings alone (not infected with -in suffixes).

For DynamicProgrammingOptions, we bury a its constructor into the cc file, since its constructor is unlikely to be performance-critical.

For TimeVaryingData stuff, we out-of-line the constructor definitions, which lets us use different names for declaration vs definition, but does not affect compiler inlining operations.

Relates #8259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8279)
<!-- Reviewable:end -->
