### PR TITLE
Fail fast when using an empty LCM channel name

### DIFF
--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace lcm {
@@ -45,11 +46,13 @@ void DrakeLcm::StopReceiveThread() {
 
 void DrakeLcm::Publish(const std::string& channel, const void* data,
                        int data_size, double) {
+  DRAKE_THROW_UNLESS(!channel.empty());
   lcm_.publish(channel, data, data_size);
 }
 
 void DrakeLcm::Subscribe(const std::string& channel,
                          DrakeLcmMessageHandlerInterface* handler) {
+  DRAKE_THROW_UNLESS(!channel.empty());
   auto subscriber = std::make_unique<Subscriber>(handler);
   auto sub =
       lcm_.subscribe(channel, &Subscriber::LcmCallback, subscriber.get());

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -43,6 +43,7 @@ class DrakeLcmInterface {
    * Publishes an LCM message on channel @p channel.
    *
    * @param[in] channel The channel on which to publish the message.
+   * Must not be the empty string.
    *
    * @param[in] data A buffer containing the serialized bytes of the message to
    * publish.
@@ -61,6 +62,7 @@ class DrakeLcmInterface {
    * channel @p channel.
    *
    * @param[in] channel The channel to subscribe to.
+   * Must not be the empty string.
    *
    * @param[in] handler A class instance whose callback method will be invoked.
    */

--- a/lcm/drake_mock_lcm.cc
+++ b/lcm/drake_mock_lcm.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
 
 namespace drake {
@@ -11,17 +12,18 @@ namespace lcm {
 DrakeMockLcm::DrakeMockLcm() {}
 
 void DrakeMockLcm::StartReceiveThread() {
-  DRAKE_DEMAND(!receive_thread_started_);
+  DRAKE_THROW_UNLESS(!receive_thread_started_);
   receive_thread_started_ = true;
 }
 
 void DrakeMockLcm::StopReceiveThread() {
-  DRAKE_DEMAND(receive_thread_started_);
+  DRAKE_THROW_UNLESS(receive_thread_started_);
   receive_thread_started_ = false;
 }
 
 void DrakeMockLcm::Publish(const std::string& channel, const void* data,
                            int data_size, double) {
+  DRAKE_THROW_UNLESS(!channel.empty());
   if (last_published_messages_.find(channel) ==
       last_published_messages_.end()) {
     last_published_messages_[channel] = LastPublishedMessage();
@@ -57,6 +59,7 @@ const std::vector<uint8_t>& DrakeMockLcm::get_last_published_message(
 
 void DrakeMockLcm::Subscribe(const std::string& channel,
                              DrakeLcmMessageHandlerInterface* handler) {
+  DRAKE_THROW_UNLESS(!channel.empty());
   if (subscriptions_.find(channel) == subscriptions_.end()) {
     subscriptions_[channel] = handler;
   } else {

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -213,6 +214,16 @@ TEST_F(DrakeLcmTest, SubscribeTest) {
 
   dut.StopReceiveThread();
   EXPECT_TRUE(done);
+}
+
+TEST_F(DrakeLcmTest, EmptyChannelTest) {
+  DrakeLcm dut;
+
+  MessageHandler handler;
+  EXPECT_THROW(dut.Subscribe("", &handler), std::exception);
+
+  const uint8_t buffer{};
+  EXPECT_THROW(dut.Publish("", &buffer, 1), std::exception);
 }
 
 }  // namespace

--- a/lcm/test/drake_mock_lcm_test.cc
+++ b/lcm/test/drake_mock_lcm_test.cc
@@ -229,6 +229,16 @@ GTEST_TEST(DrakeMockLcmTest, WithoutLoopbackTest) {
   EXPECT_NE(kMessageSize, handler.get_buffer_size());
 }
 
+GTEST_TEST(DrakeMockLcmTest, EmptyChannelTest) {
+  DrakeMockLcm dut;
+
+  MockMessageHandler handler;
+  EXPECT_THROW(dut.Subscribe("", &handler), std::exception);
+
+  const uint8_t buffer{};
+  EXPECT_THROW(dut.Publish("", &buffer, 1), std::exception);
+}
+
 }  // namespace
 }  // namespace lcm
 }  // namespace drake


### PR DESCRIPTION
Even though liblcm allows empty channel names, it doesn't seem useful to support that in our interface wrapper.  Most likely, an empty channel name is a sign of user error, and we should fail fast in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8281)
<!-- Reviewable:end -->
