### PR TITLE
Fix Wshadow warnings from GCC (joints)

### DIFF
--- a/multibody/joints/drake_joint.cc
+++ b/multibody/joints/drake_joint.cc
@@ -8,21 +8,21 @@
 using Eigen::Isometry3d;
 using Eigen::VectorXd;
 
-DrakeJoint::DrakeJoint(const std::string& _name,
-                       const Isometry3d& _transform_to_parent_body,
-                       int _num_positions, int _num_velocities)
-    : name(_name),
-      joint_limit_min(VectorXd::Constant(
-          _num_positions, -std::numeric_limits<double>::infinity())),
-      joint_limit_max(VectorXd::Constant(
-          _num_positions, std::numeric_limits<double>::infinity())),
+DrakeJoint::DrakeJoint(const std::string& name,
+                       const Isometry3d& transform_to_parent_body,
+                       int num_positions, int num_velocities)
+    : name_(name),
+      joint_limit_min_(VectorXd::Constant(
+          num_positions, -std::numeric_limits<double>::infinity())),
+      joint_limit_max_(VectorXd::Constant(
+          num_positions, std::numeric_limits<double>::infinity())),
       joint_limit_stiffness_(VectorXd::Constant(
-          _num_positions, 150. /* Historic default from RigidBodyPlant. */)),
+          num_positions, 150. /* Historic default from RigidBodyPlant. */)),
       joint_limit_dissipation_(VectorXd::Constant(
-          _num_positions, 1. /* Arbitrary, reasonable default. */)),
-      transform_to_parent_body(_transform_to_parent_body),
-      num_positions(_num_positions),
-      num_velocities(_num_velocities) {
+          num_positions, 1. /* Arbitrary, reasonable default. */)),
+      transform_to_parent_body_(transform_to_parent_body),
+      num_positions_(num_positions),
+      num_velocities_(num_velocities) {
   DRAKE_ASSERT(num_positions <= MAX_NUM_POSITIONS);
   DRAKE_ASSERT(num_velocities <= MAX_NUM_VELOCITIES);
 }
@@ -38,14 +38,14 @@ std::unique_ptr<DrakeJoint> DrakeJoint::Clone() const {
 }
 
 const Isometry3d& DrakeJoint::get_transform_to_parent_body() const {
-  return transform_to_parent_body;
+  return transform_to_parent_body_;
 }
 
-int DrakeJoint::get_num_positions() const { return num_positions; }
+int DrakeJoint::get_num_positions() const { return num_positions_; }
 
-int DrakeJoint::get_num_velocities() const { return num_velocities; }
+int DrakeJoint::get_num_velocities() const { return num_velocities_; }
 
-const std::string& DrakeJoint::get_name() const { return name; }
+const std::string& DrakeJoint::get_name() const { return name_; }
 
 std::string DrakeJoint::get_velocity_name(int index) const {
   return get_position_name(index) + "dot";
@@ -77,11 +77,11 @@ std::string DrakeJoint::getVelocityName(int index) const {
 }
 
 const Eigen::VectorXd& DrakeJoint::getJointLimitMin() const {
-  return joint_limit_min;
+  return joint_limit_min_;
 }
 
 const Eigen::VectorXd& DrakeJoint::getJointLimitMax() const {
-  return joint_limit_max;
+  return joint_limit_max_;
 }
 
 const Eigen::VectorXd& DrakeJoint::get_joint_limit_stiffness() const {
@@ -94,8 +94,8 @@ const Eigen::VectorXd& DrakeJoint::get_joint_limit_dissipation() const {
 
 void DrakeJoint::InitializeClone(DrakeJoint* clone) const {
   DoInitializeClone(clone);
-  clone->joint_limit_min = joint_limit_min;
-  clone->joint_limit_max = joint_limit_max;
+  clone->joint_limit_min_ = joint_limit_min_;
+  clone->joint_limit_max_ = joint_limit_max_;
   clone->joint_limit_stiffness_ = joint_limit_stiffness_;
   clone->joint_limit_dissipation_ = joint_limit_dissipation_;
 }

--- a/multibody/joints/drake_joint.h
+++ b/multibody/joints/drake_joint.h
@@ -188,7 +188,7 @@ class DrakeJoint {
   /**
    * Returns `true` if this joint is a FixedJoint.
    */
-  bool is_fixed() const { return num_positions == 0; }
+  bool is_fixed() const { return num_positions_ == 0; }
 
   virtual Eigen::VectorXd zeroConfiguration() const = 0;
 
@@ -214,9 +214,9 @@ class DrakeJoint {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
  protected:
-  const std::string name;
-  Eigen::VectorXd joint_limit_min;
-  Eigen::VectorXd joint_limit_max;
+  const std::string name_;
+  Eigen::VectorXd joint_limit_min_;
+  Eigen::VectorXd joint_limit_max_;
   Eigen::VectorXd joint_limit_stiffness_;
   Eigen::VectorXd joint_limit_dissipation_;
 
@@ -232,7 +232,7 @@ class DrakeJoint {
   virtual void DoInitializeClone(DrakeJoint* clone) const = 0;
 
  private:
-  const Eigen::Isometry3d transform_to_parent_body;
-  const int num_positions{};
-  const int num_velocities{};
+  const Eigen::Isometry3d transform_to_parent_body_;
+  const int num_positions_;
+  const int num_velocities_;
 };

--- a/multibody/joints/fixed_axis_one_dof_joint.h
+++ b/multibody/joints/fixed_axis_one_dof_joint.h
@@ -125,8 +125,8 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
           "ERROR: joint_limit_min cannot be larger than joint_limit_max");
     }
 
-    DrakeJoint::joint_limit_min[0] = joint_limit_min;
-    DrakeJoint::joint_limit_max[0] = joint_limit_max;
+    DrakeJoint::joint_limit_min_[0] = joint_limit_min;
+    DrakeJoint::joint_limit_max_[0] = joint_limit_max;
   }
 
   void SetJointLimitDynamics(double joint_limit_stiffness,
@@ -142,32 +142,32 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
   Eigen::VectorXd randomConfiguration(
       std::default_random_engine& generator) const override {
     Eigen::VectorXd q(1);
-    if (std::isfinite(DrakeJoint::joint_limit_min.value()) &&
-        std::isfinite(DrakeJoint::joint_limit_max.value())) {
+    if (std::isfinite(DrakeJoint::joint_limit_min_.value()) &&
+        std::isfinite(DrakeJoint::joint_limit_max_.value())) {
       std::uniform_real_distribution<double> distribution(
-          DrakeJoint::joint_limit_min.value(),
-          DrakeJoint::joint_limit_max.value());
+          DrakeJoint::joint_limit_min_.value(),
+          DrakeJoint::joint_limit_max_.value());
       q[0] = distribution(generator);
     } else {
       std::normal_distribution<double> distribution;
       double stddev = 1.0;
       double joint_limit_offset = 1.0;
-      if (std::isfinite(DrakeJoint::joint_limit_min.value())) {
+      if (std::isfinite(DrakeJoint::joint_limit_min_.value())) {
         distribution = std::normal_distribution<double>(
-            DrakeJoint::joint_limit_min.value() + joint_limit_offset, stddev);
-      } else if (std::isfinite(DrakeJoint::joint_limit_max.value())) {
+            DrakeJoint::joint_limit_min_.value() + joint_limit_offset, stddev);
+      } else if (std::isfinite(DrakeJoint::joint_limit_max_.value())) {
         distribution = std::normal_distribution<double>(
-            DrakeJoint::joint_limit_max.value() - joint_limit_offset, stddev);
+            DrakeJoint::joint_limit_max_.value() - joint_limit_offset, stddev);
       } else {
         distribution = std::normal_distribution<double>();
       }
 
       q[0] = distribution(generator);
-      if (q[0] < DrakeJoint::joint_limit_min.value()) {
-        q[0] = DrakeJoint::joint_limit_min.value();
+      if (q[0] < DrakeJoint::joint_limit_min_.value()) {
+        q[0] = DrakeJoint::joint_limit_min_.value();
       }
-      if (q[0] > DrakeJoint::joint_limit_max.value()) {
-        q[0] = DrakeJoint::joint_limit_max.value();
+      if (q[0] > DrakeJoint::joint_limit_max_.value()) {
+        q[0] = DrakeJoint::joint_limit_max_.value();
       }
     }
     return q;
@@ -183,7 +183,7 @@ class FixedAxisOneDoFJoint : public DrakeJointImpl<Derived> {
 
   std::string get_position_name(int index) const override {
     if (index != 0) throw std::runtime_error("bad index");
-    return DrakeJoint::name;
+    return DrakeJoint::name_;
   }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.

--- a/multibody/joints/quaternion_ball_joint.cc
+++ b/multibody/joints/quaternion_ball_joint.cc
@@ -12,13 +12,13 @@ using Eigen::VectorXd;
 std::string QuaternionBallJoint::get_position_name(int index) const {
   switch (index) {
     case 0:
-      return name + "_qw";
+      return name_ + "_qw";
     case 1:
-      return name + "_qx";
+      return name_ + "_qx";
     case 2:
-      return name + "_qy";
+      return name_ + "_qy";
     case 3:
-      return name + "_qz";
+      return name_ + "_qz";
     default:
       throw std::runtime_error("bad index");
   }
@@ -27,11 +27,11 @@ std::string QuaternionBallJoint::get_position_name(int index) const {
 std::string QuaternionBallJoint::get_velocity_name(int index) const {
   switch (index) {
     case 0:
-      return name + "_wx";
+      return name_ + "_wx";
     case 1:
-      return name + "_wy";
+      return name_ + "_wy";
     case 2:
-      return name + "_wz";
+      return name_ + "_wz";
     default:
       throw std::runtime_error("bad index");
   }

--- a/multibody/joints/quaternion_floating_joint.cc
+++ b/multibody/joints/quaternion_floating_joint.cc
@@ -13,19 +13,19 @@ using std::normal_distribution;
 std::string QuaternionFloatingJoint::get_position_name(int index) const {
   switch (index) {
     case 0:
-      return name + "_x";
+      return name_ + "_x";
     case 1:
-      return name + "_y";
+      return name_ + "_y";
     case 2:
-      return name + "_z";
+      return name_ + "_z";
     case 3:
-      return name + "_qw";
+      return name_ + "_qw";
     case 4:
-      return name + "_qx";
+      return name_ + "_qx";
     case 5:
-      return name + "_qy";
+      return name_ + "_qy";
     case 6:
-      return name + "_qz";
+      return name_ + "_qz";
     default:
       throw std::runtime_error("bad index");
   }
@@ -34,17 +34,17 @@ std::string QuaternionFloatingJoint::get_position_name(int index) const {
 std::string QuaternionFloatingJoint::get_velocity_name(int index) const {
   switch (index) {
     case 0:
-      return name + "_wx";
+      return name_ + "_wx";
     case 1:
-      return name + "_wy";
+      return name_ + "_wy";
     case 2:
-      return name + "_wz";
+      return name_ + "_wz";
     case 3:
-      return name + "_vx";
+      return name_ + "_vx";
     case 4:
-      return name + "_vy";
+      return name_ + "_vy";
     case 5:
-      return name + "_vz";
+      return name_ + "_vz";
     default:
       throw std::runtime_error("bad index");
   }

--- a/multibody/joints/roll_pitch_yaw_floating_joint.cc
+++ b/multibody/joints/roll_pitch_yaw_floating_joint.cc
@@ -15,17 +15,17 @@ using Eigen::VectorXd;
 std::string RollPitchYawFloatingJoint::get_position_name(int index) const {
   switch (index) {
     case 0:
-      return name + "_x";
+      return name_ + "_x";
     case 1:
-      return name + "_y";
+      return name_ + "_y";
     case 2:
-      return name + "_z";
+      return name_ + "_z";
     case 3:
-      return name + "_roll";
+      return name_ + "_roll";
     case 4:
-      return name + "_pitch";
+      return name_ + "_pitch";
     case 5:
-      return name + "_yaw";
+      return name_ + "_yaw";
     default:
       throw std::runtime_error("bad index");
   }


### PR DESCRIPTION
The main change is naming member fields with the conventional trailing underscore, and then fixing constructor argument names to be regular snake_case.  This removes potential confusion between member fields and local variables within member methods of DrakeJoint and its subclasses.

Because the renamed member field was protected, its less likely that this will disturb downstream code, so I haven't bothered with deprecation warnings. Nothing in Spartan at least appears to have any DrakeJoint subclasses.

Relates #8259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8283)
<!-- Reviewable:end -->
