### PR TITLE
Fix Wshadow warnings from GCC (shapes)

### DIFF
--- a/multibody/collision/element.cc
+++ b/multibody/collision/element.cc
@@ -16,9 +16,9 @@ Element::Element()
     : DrakeShapes::Element(Eigen::Isometry3d::Identity()), body_(nullptr) {
 }
 
-Element::Element(const DrakeShapes::Geometry& geometry,
-                 const Isometry3d& T_element_to_local)
-    : DrakeShapes::Element(geometry, T_element_to_local), body_(nullptr) {
+Element::Element(const DrakeShapes::Geometry& geometry_in,
+                 const Isometry3d& T_element_to_local_in)
+    : DrakeShapes::Element(geometry_in, T_element_to_local_in), body_(nullptr) {
 }
 
 Element::Element(const Isometry3d& T_element_to_link,
@@ -26,10 +26,10 @@ Element::Element(const Isometry3d& T_element_to_link,
     : DrakeShapes::Element(T_element_to_link), body_(body) {
 }
 
-Element::Element(const DrakeShapes::Geometry& geometry,
+Element::Element(const DrakeShapes::Geometry& geometry_in,
                  const Isometry3d& T_element_to_link,
                  const RigidBody<double>* body)
-    : DrakeShapes::Element(geometry, T_element_to_link), body_(body) {
+    : DrakeShapes::Element(geometry_in, T_element_to_link), body_(body) {
 }
 
 Element* Element::clone() const { return new Element(*this); }

--- a/multibody/shapes/geometry.cc
+++ b/multibody/shapes/geometry.cc
@@ -348,18 +348,20 @@ void Mesh::LoadObjFile(PointsVector* vertices, TrianglesVector* triangles,
   int maximum_index = 0;
 
   // Iterate over the shapes.
-  for (auto const& shape : shapes) {
+  for (const auto& one_shape : shapes) {
+    const tinyobj::mesh_t& mesh = one_shape.mesh;
     int index_offset = 0;
 
     // For each face in the shape.
     for (int face = 0;
-         face < static_cast<int>(shape.mesh.num_face_vertices.size()); ++face) {
-      const int vert_count = shape.mesh.num_face_vertices[face];
+         face < static_cast<int>(mesh.num_face_vertices.size());
+         ++face) {
+      const int vert_count = mesh.num_face_vertices[face];
 
       std::vector<int> indices;
       for (int vert = 0; vert < vert_count; ++vert) {
         // Store the vertex index.
-        int vertex_index = shape.mesh.indices[index_offset + vert].vertex_index;
+        int vertex_index = mesh.indices[index_offset + vert].vertex_index;
         maximum_index = std::max(maximum_index, vertex_index);
         indices.push_back(vertex_index);
       }

--- a/multibody/shapes/visual_element.cc
+++ b/multibody/shapes/visual_element.cc
@@ -1,11 +1,15 @@
 #include "drake/multibody/shapes/visual_element.h"
 
 namespace DrakeShapes {
-// VisualElement::VisualElement(unique_ptr<Geometry> geometry,
-// const Matrix4d& T_element_to_local,
-// const Vector4d& material)
-//: Element(move(geometry), T_element_to_local), material(material)
-//{}
+
+VisualElement::VisualElement(const Eigen::Isometry3d& T_element_to_local_in)
+    : Element(T_element_to_local_in),
+      material(Eigen::Vector4d(0.7, 0.7, 0.7, 1)) {}
+
+VisualElement::VisualElement(const Geometry& geometry_in,
+                             const Eigen::Isometry3d& T_element_to_local_in,
+                             const Eigen::Vector4d& material_in)
+    : Element(geometry_in, T_element_to_local_in), material(material_in) {}
 
 void VisualElement::setMaterial(const Eigen::Vector4d& material_in) {
   material = material_in;

--- a/multibody/shapes/visual_element.h
+++ b/multibody/shapes/visual_element.h
@@ -9,9 +9,7 @@ namespace DrakeShapes {
 
 class VisualElement : public Element {
  public:
-  explicit VisualElement(const Eigen::Isometry3d& T_element_to_local)
-      : Element(T_element_to_local),
-        material(Eigen::Vector4d(0.7, 0.7, 0.7, 1)) {}
+  explicit VisualElement(const Eigen::Isometry3d& T_element_to_local);
 
   /**
    * Constructs a geometry at a specified transform with
@@ -20,8 +18,7 @@ class VisualElement : public Element {
    */
   VisualElement(const Geometry& geometry,
                 const Eigen::Isometry3d& T_element_to_local,
-                const Eigen::Vector4d& material_in)
-      : Element(geometry, T_element_to_local), material(material_in) {}
+                const Eigen::Vector4d& material);
 
   virtual ~VisualElement() {}
 


### PR DESCRIPTION
This removes potential confusion between member fields and local variables, in classes where member fields lack their trailing underscore.

We are careful to leave the Doxygen spellings alone (not infected with -in suffixes) by burying constructor definitions into the cc files.

Relates #8259.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8284)
<!-- Reviewable:end -->
