### PR TITLE
favor symbolic::Expression over symbolic::Polynomial... 

### DIFF
--- a/examples/cubic_polynomial/region_of_attraction.cc
+++ b/examples/cubic_polynomial/region_of_attraction.cc
@@ -23,6 +23,7 @@ using std::endl;
 using symbolic::Expression;
 using symbolic::Polynomial;
 using symbolic::Variable;
+using symbolic::Variables;
 
 /// Cubic Polynomial System:
 ///   ẋ = -x + x³
@@ -56,31 +57,28 @@ void ComputeRegionOfAttraction() {
 
   // Setup the optimization problem.
   solvers::MathematicalProgram prog;
-  const VectorX<Variable> xvec{prog.NewIndeterminates<1>("x")};
-  const Variable& x = xvec(0);
+  const VectorX<Variable> xvar{prog.NewIndeterminates<1>("x")};
+  const VectorX<Expression> x = xvar.cast<Expression>();
 
   // Extract the polynomial dynamics.
-  context->get_mutable_continuous_state_vector().SetAtIndex(0, x);
+  context->get_mutable_continuous_state_vector().SetFromVector(x);
   system.CalcTimeDerivatives(*context, derivatives.get());
 
   // Define the Lyapunov function.
-  const Polynomial V{x * x};
+  const Expression V = x.dot(x);
 
-  // TODO(soonho): Remove the explicit cast to Polynomial below.
-  const Polynomial Vdot{V.Jacobian(xvec).coeff(0) *
-                        Polynomial((*derivatives)[0])};
+  const Expression Vdot = (Jacobian(Vector1<Expression>(V), xvar) *
+                         derivatives->CopyToVector())[0];
 
   // Maximize ρ s.t. V̇ ≥ 0 ∧ x ≠ 0 ⇒ V ≥ ρ,
   // implemented as (V(x) - ρ)x² - λ(x)V̇(x) is SOS;
   //                 λ(x) is SOS.
   const Variable rho{prog.NewContinuousVariables<1>("rho").coeff(0)};
-  const Polynomial rho_poly{rho, {} /* no indeterminate */};
+  const Expression lambda{
+      prog.NewSosPolynomial(Variables(xvar), 4).first.ToExpression()};
 
-  const Polynomial lambda{prog.NewSosPolynomial({x}, 4).first};
-
-  // TODO(soonho): Remove the explicit cast to Polynomial below.
-  prog.AddSosConstraint((V - rho_poly) * Polynomial(x * x) - lambda * Vdot);
-  prog.AddCost(-rho);
+  prog.AddSosConstraint((V - rho) * x.dot(x) - lambda * Vdot);
+  prog.AddLinearCost(-rho);
   const solvers::SolutionResult result{prog.Solve()};
   DRAKE_DEMAND(result == solvers::SolutionResult::kSolutionFound);
 


### PR DESCRIPTION
which avoids many of the explicit casts to Polynomial that were ugly previously.  Still wishing for less casting between VectorX<Variable> and VectorX<Expression>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8285)
<!-- Reviewable:end -->
