### PR TITLE
Give lyapunov_test a longer timeout for valgrind

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -144,6 +144,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "lyapunov_test",
+    # Test size increased to not timeout when run with Valgrind.
+    size = "medium",
     deps = [
         ":lyapunov",
         "//examples/pendulum:pendulum_plant",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8286)
<!-- Reviewable:end -->
