### PR TITLE
Promote deprecation warnings to errors

### DIFF
--- a/common/proto/call_python.h
+++ b/common/proto/call_python.h
@@ -127,19 +127,31 @@ template <typename Policy>
 class PythonAccessor : public internal::PythonApi<PythonAccessor<Policy>> {
  public:
   using KeyType = typename Policy::KeyType;
+
+  // Given a variable (and key), makes a PythonAccessor.
   PythonAccessor(PythonRemoteVariable obj, const KeyType& key)
       : obj_(obj), key_(key) {}
 
+  // Copying a PythonAccessor aliases the original remote variable (reference
+  // semantics), it does not create a new remote variable.
+  PythonAccessor(const PythonAccessor&) = default;
+
+  // Implicitly converts to a PythonRemoteVariable.
   operator PythonRemoteVariable() const { return value(); }
 
+  // Assigning from another PythonAccessor delegates to set_value from that
+  // `value`'s underlying PythonRemoteVariable.
   PythonRemoteVariable operator=(const PythonAccessor& value) {
     return set_value(value);
   }
 
+  // Assigning from another PythonRemoteVariable delegates to set_value from it.
   PythonRemoteVariable operator=(const PythonRemoteVariable& value) {
     return set_value(value);
   }
 
+  // Assigning from some literal value creates a new PythonRemoveVariable to
+  // bind the value.
   template <typename T>
   PythonRemoteVariable operator=(const T& value) {
     return set_value(NewPythonVariable(value));

--- a/common/trajectories/exponential_plus_piecewise_polynomial.cc
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.cc
@@ -32,8 +32,7 @@ ExponentialPlusPiecewisePolynomial<T>::
 template <typename T>
 std::unique_ptr<Trajectory<T>> ExponentialPlusPiecewisePolynomial<T>::Clone()
     const {
-  return std::make_unique<ExponentialPlusPiecewisePolynomial<T>>(
-      K_, A_, alpha_, piecewise_polynomial_part_);
+  return std::make_unique<ExponentialPlusPiecewisePolynomial<T>>(*this);
 }
 
 template <typename T>

--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -6,6 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
@@ -17,7 +18,7 @@ namespace trajectories {
  */
 
 template <typename T>
-class ExponentialPlusPiecewisePolynomial
+class ExponentialPlusPiecewisePolynomial final
     : public PiecewiseTrajectory<T> {
  public:
   typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
@@ -30,6 +31,9 @@ class ExponentialPlusPiecewisePolynomial
   PiecewisePolynomial<T> piecewise_polynomial_part_;
 
  public:
+  // We are final, so this is okay.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ExponentialPlusPiecewisePolynomial)
+
   ExponentialPlusPiecewisePolynomial();
 
   template <typename DerivedK, typename DerivedA, typename DerivedAlpha>
@@ -57,7 +61,7 @@ class ExponentialPlusPiecewisePolynomial
   ExponentialPlusPiecewisePolynomial(
       const PiecewisePolynomial<T>& piecewise_polynomial_part);
 
-  virtual ~ExponentialPlusPiecewisePolynomial() {}
+  ~ExponentialPlusPiecewisePolynomial() override = default;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -50,7 +50,7 @@ PiecewisePolynomial<T>::PiecewisePolynomial() : PiecewiseTrajectory<T>() {
 
 template <typename T>
 std::unique_ptr<Trajectory<T>> PiecewisePolynomial<T>::Clone() const {
-  return std::make_unique<PiecewisePolynomial<T>>(polynomials_, this->breaks());
+  return std::make_unique<PiecewisePolynomial<T>>(*this);
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -46,15 +46,13 @@ namespace trajectories {
 template <typename T>
 class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
  public:
+  // We are final, so this is okay.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePolynomial)
+
   typedef Polynomial<T> PolynomialType;
   typedef drake::MatrixX<PolynomialType> PolynomialMatrix;
   typedef drake::MatrixX<T> CoefficientMatrix;
   typedef Eigen::Ref<CoefficientMatrix> CoefficientMatrixRef;
-
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePolynomial)
-
-  virtual ~PiecewisePolynomial() {}
 
   // default constructor; just leaves segment_times and polynomials empty
   PiecewisePolynomial();
@@ -74,6 +72,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // Scalar constructor
   PiecewisePolynomial(std::vector<PolynomialType> const& polynomials,
                       std::vector<double> const& breaks);
+
+  ~PiecewisePolynomial() override = default;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -19,15 +20,15 @@ namespace trajectories {
 template <typename T>
 class PiecewiseTrajectory : public Trajectory<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseTrajectory)
-
   /// Minimum delta quantity used for comparing time.
   static constexpr double kEpsilonTime = 1e-10;
 
   /// @p breaks increments must be greater or equal to kEpsilonTime.
   explicit PiecewiseTrajectory(std::vector<double> const& breaks);
 
-  virtual ~PiecewiseTrajectory();
+  ~PiecewiseTrajectory() override;
+
+  // N.B. No Clone() override here because we are an abstract class.
 
   int get_number_of_segments() const;
 
@@ -57,6 +58,9 @@ class PiecewiseTrajectory : public Trajectory<T> {
       int num_segments, std::default_random_engine &generator);
 
  protected:
+  // Final subclasses are allowed to make copy/move/assign public.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseTrajectory)
+
   bool SegmentTimesEqual(const PiecewiseTrajectory &b,
                          double tol = kEpsilonTime) const;
 

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -18,10 +19,7 @@ namespace trajectories {
 template <typename T>
 class Trajectory {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
-
-  Trajectory() {}
-  virtual ~Trajectory() {}
+  virtual ~Trajectory() = default;
 
   /**
    *
@@ -58,6 +56,11 @@ class Trajectory {
   virtual double start_time() const = 0;
 
   virtual double end_time() const = 0;
+
+ protected:
+  // Final subclasses are allowed to make copy/move/assign public.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
+  Trajectory() = default;
 };
 
 }  // namespace trajectories

--- a/matlab/cmake/flags.cmake
+++ b/matlab/cmake/flags.cmake
@@ -7,6 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated
+    -Werror=deprecated-declarations
     -Werror=ignored-qualifiers
     -Werror=inconsistent-missing-override
     -Werror=non-virtual-dtor
@@ -19,6 +21,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang OR CMAKE_CXX_COMPILER_ID STREQUAL C
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CXX_FLAGS
     -Werror=all
+    -Werror=deprecated
+    -Werror=deprecated-declarations
     -Werror=extra
     -Werror=ignored-qualifiers
     -Werror=logical-op

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -13,6 +13,8 @@ load(
 # building with any compiler.
 CXX_FLAGS = [
     "-Werror=all",
+    "-Werror=deprecated",
+    "-Werror=deprecated-declarations",
     "-Werror=ignored-qualifiers",
     "-Werror=overloaded-virtual",
     "-Werror=old-style-cast",


### PR DESCRIPTION
Inspired by #8204, but this PR turns on _C++ language_ deprecation warnings, not API deprecation warnings (those are handled by #8259).

Do not merge until:
- [ ] freshly rebased to avoid cross-merge-vs-jenkins pitfalls;
- [ ] macOS builds pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8288)
<!-- Reviewable:end -->
