### PR TITLE
Use /usr/bin/env python2.7 in shebang for python scripts and add linting

### DIFF
--- a/common/test/cpplint_wrapper.py
+++ b/common/test/cpplint_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 
 """cpplint_wrapper.py -- Run cpplint.py using Drake's standard settings,
 summarizing its output for cleanliness, and providing a --fast option

--- a/doc/code_style_guide.rst
+++ b/doc/code_style_guide.rst
@@ -84,11 +84,12 @@ Additional Rules
   ``stderr``, but are otherwise ignored, and thus may escape notice.
 * Executable files should use the following "shebang" line::
 
-    #!/usr/bin/env python
+    #!/usr/bin/env python2.7
 
-  Rationale: ``/usr/bin/env`` enables a ``PATH`` search for python. On macOS
-  systems configured for Drake, this gives a better result than
-  ``/usr/bin/python``.
+  Rationale: ``/usr/bin/env`` enables a ``PATH`` search for the Python 2.7
+  executable. On macOS systems configured for Drake, this gives a better result
+  than ``/usr/bin/python`` (system Python 2.7) and ``/usr/local/bin/python`` or
+  ``/usr/bin/env python`` (Homebrew Python 3.x).
 
 .. _code-style-guide-matlab:
 

--- a/doc/doxygen.py
+++ b/doc/doxygen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """Command-line tool to generate Drake's Doxygen content.
 

--- a/tools/clion/bazel_wrapper
+++ b/tools/clion/bazel_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import os
 import re

--- a/tools/dev/add_cpplint.py
+++ b/tools/dev/add_cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 import re
 import sys, os
 import subprocess

--- a/tools/dev/check_missing_sources.sh
+++ b/tools/dev/check_missing_sources.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/tools/dynamic_analysis/kcov.sh
+++ b/tools/dynamic_analysis/kcov.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -vx
+#!/bin/bash
 
 
 me=$(python -c 'import os; print(os.path.realpath("'"$0"'"))')

--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -356,7 +356,7 @@ def _install_impl(ctx):
 
     # Generate install script.
     # TODO(mwoehlke-kitware): Figure out a better way to generate this and run
-    # it via Python than `#!/usr/bin/env python`?
+    # it via Python than `#!/usr/bin/env python2.7`?
     ctx.template_action(
         template = ctx.executable.install_script_template,
         output = ctx.outputs.executable,

--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import argparse
 import collections

--- a/tools/install/libdrake/build_components_refresh.py
+++ b/tools/install/libdrake/build_components_refresh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """This script creates build_components.bzl.new with new contents based on the
 current source tree.  It should be used to regularly update the version of

--- a/tools/lint/clang_format_includes.py
+++ b/tools/lint/clang_format_includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 """Rewrite the filenames given on the command line to obey formatting rules for
 #include statements.  The only changes this script will make are to relocate

--- a/tools/lint/drakelint.py
+++ b/tools/lint/drakelint.py
@@ -43,11 +43,14 @@ def _check_includes(filename):
 
 
 def _check_shebang(filename):
-    """Return 0 if the filename's executable bit is consistent with the presence of
-    a shebang line, and 1 otherwise."""
+    """Return 0 if the filename's executable bit is consistent with the
+    presence of a shebang line and the shebang line is in the whitelist of
+    acceptable shebang lines, and 1 otherwise.
+    """
     is_executable = os.access(filename, os.X_OK)
     with open(filename, 'r') as file:
-        has_shebang = file.readline().startswith("#!")
+        shebang = file.readline().rstrip("\n")
+        has_shebang = shebang.startswith("#!")
     if is_executable and not has_shebang:
         print("error: {} is executable but lacks a shebang".format(filename))
         print("note: fix via chmod a-x '{}'".format(filename))
@@ -55,6 +58,19 @@ def _check_shebang(filename):
     if has_shebang and not is_executable:
         print("error: {} has a shebang but is not executable".format(filename))
         print("note: fix by removing the first line of the file")
+        return 1
+    shebang_whitelist = {
+        "bash": "#!/bin/bash",
+        "directorPython": "#!/usr/bin/env directorPython",
+        "python": "#!/usr/bin/env python2.7"
+    }
+    if has_shebang and shebang not in shebang_whitelist.values():
+        print(("error: shebang '{}' in the file '{}' is not in the shebang "
+              "whitelist").format(shebang, filename))
+        for hint, replacement_shebang in shebang_whitelist.iteritems():
+            if hint in shebang:
+                print(("note: fix by replacing the shebang with "
+                      "'{}'").format(replacement_shebang))
         return 1
     return 0
 
@@ -68,7 +84,7 @@ def main():
     for filename in sys.argv[1:]:
         print("drakelint.py: Linting " + filename)
         total_errors += _check_invalid_line_endings(filename)
-        if filename.endswith(".py"):
+        if not filename.endswith((".cc", ".cpp", ".h")):
             # TODO(jwnimmer-tri) We should enable this check for C++ files
             # also, but that runs into some struggle with genfiles.
             total_errors += _check_shebang(filename)

--- a/tools/workspace/bullet/package-create-cps.py
+++ b/tools/workspace/bullet/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import sys
 

--- a/tools/workspace/cmake_configure_file.py
+++ b/tools/workspace/cmake_configure_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 """A re-implementation of CMake's configure_file substitution semantics.  This
 implementation is incomplete, and may not produce the same result as CMake in

--- a/tools/workspace/eigen/package-create-cps.py
+++ b/tools/workspace/eigen/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_defs
 

--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_version_defs
 

--- a/tools/workspace/ignition_math/package-create-cps.py
+++ b/tools/workspace/ignition_math/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_version_defs
 

--- a/tools/workspace/ignition_rndf/package-create-cps.py
+++ b/tools/workspace/ignition_rndf/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_version_defs, read_requires
 

--- a/tools/workspace/lcm/package-create-cps.py
+++ b/tools/workspace/lcm/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_defs
 

--- a/tools/workspace/optitrack_driver/optitrack_client
+++ b/tools/workspace/optitrack_driver/optitrack_client
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import os
 import sys

--- a/tools/workspace/spdlog/package-create-cps.py
+++ b/tools/workspace/spdlog/package-create-cps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from drake.tools.install.cpsutils import read_version_defs, read_requires
 


### PR DESCRIPTION
Toward #8231. Still not 100% of the fix, unfortunately. Local Mac users may need
```bash
export PATH=/usr/local/opt/python@2/libexec/bin:/usr/local/opt/python@2/bin:$PATH
```
(or maybe just the second path) for the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8290)
<!-- Reviewable:end -->
