### PR TITLE
Upgrade to fmtlib 4.1.0

### DIFF
--- a/tools/workspace/fmt/package-create-cps.py
+++ b/tools/workspace/fmt/package-create-cps.py
@@ -2,7 +2,11 @@
 
 from drake.tools.install.cpsutils import read_version_defs
 
-defs = read_version_defs("set\(FMT_VERSION\s([0-9]+).([0-9]+).([0-9]+)")
+defs = read_version_defs("#define FMT_VERSION ([0-9]{1,2})([0-9]{2})([0-9]{2})$")
+
+# Skip leading zeros if any.
+assert len(defs) == 3
+defs = dict([(k, int(v)) for k, v in defs.iteritems()])
 
 content = """
 {

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -26,7 +26,7 @@ CMAKE_PACKAGE = "fmt"
 cmake_config(
     package = CMAKE_PACKAGE,
     script = "@drake//tools/workspace/fmt:package-create-cps.py",
-    version_file = "CMakeLists.txt",
+    version_file = "fmt/format.h",
 )
 
 # Creates rule :install_cmake_config.

--- a/tools/workspace/fmt/repository.bzl
+++ b/tools/workspace/fmt/repository.bzl
@@ -8,8 +8,8 @@ def fmt_repository(
     github_archive(
         name = name,
         repository = "fmtlib/fmt",
-        commit = "3.0.1",
-        sha256 = "dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad",  # noqa
+        commit = "4.1.0",
+        sha256 = "46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d",  # noqa
         build_file = "@drake//tools/workspace/fmt:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
This newer version contains fixes for some compiler warnings that we care about.

Upstream has moved their version declaration into the header file as the source of truth, so we update the cps script to snarf it from there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8295)
<!-- Reviewable:end -->
