### PR TITLE
SpatialVector supports symbolic::Expression

### DIFF
--- a/multibody/multibody_tree/math/BUILD.bazel
+++ b/multibody/multibody_tree/math/BUILD.bazel
@@ -89,6 +89,7 @@ drake_cc_googletest(
     name = "spatial_algebra_test",
     deps = [
         ":spatial_algebra",
+        "//common:symbolic",
         "//drake/common:autodiff",
     ],
 )

--- a/multibody/multibody_tree/math/BUILD.bazel
+++ b/multibody/multibody_tree/math/BUILD.bazel
@@ -22,20 +22,23 @@ drake_cc_library(
 
 drake_cc_library(
     name = "spatial_velocity",
-    srcs = [],
+    srcs = ["spatial_velocity.cc"],
     hdrs = ["spatial_velocity.h"],
     deps = [
         ":spatial_vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )
 
 drake_cc_library(
     name = "spatial_acceleration",
-    srcs = [],
+    srcs = ["spatial_acceleration.cc"],
     hdrs = ["spatial_acceleration.h"],
     deps = [
         ":spatial_vector",
+        ":spatial_velocity",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
         "//drake/math:vector3_util",
     ],
@@ -43,10 +46,11 @@ drake_cc_library(
 
 drake_cc_library(
     name = "spatial_force",
-    srcs = [],
+    srcs = ["spatial_force.cc"],
     hdrs = ["spatial_force.h"],
     deps = [
         ":spatial_vector",
+        "//drake/common:default_scalars",
         "//drake/common:essential",
     ],
 )

--- a/multibody/multibody_tree/math/spatial_acceleration.cc
+++ b/multibody/multibody_tree/math/spatial_acceleration.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/multibody_tree/math/spatial_acceleration.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::SpatialAcceleration)

--- a/multibody/multibody_tree/math/spatial_force.cc
+++ b/multibody/multibody_tree/math/spatial_force.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/multibody_tree/math/spatial_force.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::SpatialForce)

--- a/multibody/multibody_tree/math/spatial_vector.h
+++ b/multibody/multibody_tree/math/spatial_vector.h
@@ -158,9 +158,9 @@ class SpatialVector {
   /// @returns `true` if the rotational part of `this` and `other` are equal
   /// within @p rotational_tolerance and the translational part of `this` and
   /// `other` are equal within @p translational_tolerance.
-  bool IsNearlyEqualWithinAbsoluteTolerance(
-      const SpatialQuantity& other, const T& rotational_tolerance,
-      const T& translational_tolerance) const {
+  decltype(T() < T()) IsNearlyEqualWithinAbsoluteTolerance(
+      const SpatialQuantity& other, double rotational_tolerance,
+      const double translational_tolerance) const {
     T w_max_difference, v_max_difference;
     std::tie(w_max_difference, v_max_difference) =
         GetMaximumAbsoluteDifferences(other);
@@ -169,15 +169,14 @@ class SpatialVector {
   }
 
   /// Compares `this` spatial vector to the provided spatial vector `other`
-  /// within a specified precision.
-  /// @returns `true` if `other` is within a precision given by @p tolerance.
-  /// The comparison is performed by comparing the translational component of
-  /// `this` spatial vector with the rotational component of @p other
-  /// using the fuzzy comparison provided by Eigen's method isApprox().
-  bool IsApprox(const SpatialQuantity& other,
-                double tolerance = Eigen::NumTraits<T>::epsilon()) const {
-    return translational().isApprox(other.translational(), tolerance) &&
-           rotational().isApprox(other.rotational(), tolerance);
+  /// within a specified tolerance.
+  /// Mathematically, if `this` is the spatial vector U and `other` is the
+  /// spatial vector V, then this method returns `true` if `‖U-V‖∞ < ε` and
+  /// `false` otherwise.
+  decltype(T() < T()) IsApprox(
+      const SpatialQuantity& other,
+      double tolerance = std::numeric_limits<double>::epsilon()) const {
+    return IsNearlyEqualWithinAbsoluteTolerance(other, tolerance, tolerance);
   }
 
   /// Sets all entries in `this` SpatialVector to NaN. Typically used to

--- a/multibody/multibody_tree/math/spatial_vector.h
+++ b/multibody/multibody_tree/math/spatial_vector.h
@@ -160,7 +160,7 @@ class SpatialVector {
   /// `other` are equal within @p translational_tolerance.
   decltype(T() < T()) IsNearlyEqualWithinAbsoluteTolerance(
       const SpatialQuantity& other, double rotational_tolerance,
-      const double translational_tolerance) const {
+      double translational_tolerance) const {
     T w_max_difference, v_max_difference;
     std::tie(w_max_difference, v_max_difference) =
         GetMaximumAbsoluteDifferences(other);

--- a/multibody/multibody_tree/math/spatial_velocity.cc
+++ b/multibody/multibody_tree/math/spatial_velocity.cc
@@ -1,0 +1,6 @@
+#include "drake/multibody/multibody_tree/math/spatial_velocity.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::SpatialVelocity)

--- a/multibody/multibody_tree/math/test/spatial_algebra_test.cc
+++ b/multibody/multibody_tree/math/test/spatial_algebra_test.cc
@@ -18,6 +18,7 @@ namespace {
 
 using Eigen::AngleAxis;
 using symbolic::Expression;
+using symbolic::MakeVectorContinuousVariable;
 using symbolic::Variable;
 
 // Generic declaration boilerplate of a traits class for spatial vectors.
@@ -662,6 +663,9 @@ class SymbolicSpatialQuantityTest : public ::testing::Test {
   // A spatial quantity related to the above rotational and translational
   // components.
   SymbolicSpatialQuantityType V_{w_, v_};
+
+  // A spatial quantity from a 6D vector of symbolic variables.
+  SymbolicSpatialQuantityType Q_{MakeVectorContinuousVariable(6, "Q")};
 };
 
 // Create a list of SpatialVector with symbolic::Variable entries. These will
@@ -673,10 +677,14 @@ typedef ::testing::Types<
 TYPED_TEST_CASE(SymbolicSpatialQuantityTest, SymbolicSpatialQuantityTypes);
 
 TYPED_TEST(SymbolicSpatialQuantityTest, ShiftOperatorIntoStream) {
-  std::stringstream stream;
-  stream << this->V_;
-  std::string expected_string = "[wx, wy, wz, vx, vy, vz]ᵀ";
-  EXPECT_EQ(expected_string, stream.str());
+  std::stringstream V_stream;
+  V_stream << this->V_;
+  std::string V_expected_string = "[wx, wy, wz, vx, vy, vz]ᵀ";
+  EXPECT_EQ(V_expected_string, V_stream.str());
+  std::stringstream Q_stream;
+  Q_stream << this->Q_;
+  std::string Q_expected_string = "[Q(0), Q(1), Q(2), Q(3), Q(4), Q(5)]ᵀ";
+  EXPECT_EQ(Q_expected_string, Q_stream.str());
 }
 
 }  // namespace

--- a/multibody/multibody_tree/math/test/spatial_algebra_test.cc
+++ b/multibody/multibody_tree/math/test/spatial_algebra_test.cc
@@ -139,7 +139,6 @@ TYPED_TEST(SpatialQuantityTest, ConstructionFromTwo3DVectors) {
   // Verify compile-time size.
   EXPECT_EQ(V_AB.size(), 6);
 
-  // Comparison to Eigen::NumTraits<double>::epsilon() precision.
   EXPECT_TRUE(V_AB.translational() == v_AB);
   EXPECT_TRUE(V_AB.rotational() == w_AB);
 }


### PR DESCRIPTION
Small fixes having to do with `symbolic::Formula` conversion to `bool`. Unit tests added.
Notice a lot of these unit tests (about 40 I believe) are automatically generated with a `TYPED` fixture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8296)
<!-- Reviewable:end -->
