### PR TITLE
Make tree compilation *optional* when parsing sdf/urdf files

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -21,6 +21,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
   using drake::multibody::joints::FloatingBaseType;
   using drake::parsers::PackageMap;
   namespace sdf = drake::parsers::sdf;
+  using std::shared_ptr;
 
   py::module::import("pydrake.multibody.parsers");
   py::module::import("pydrake.multibody.shapes");
@@ -220,7 +221,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
     .def("get_visual_elements", &RigidBody<double>::get_visual_elements);
 
   py::class_<RigidBodyFrame<double>,
-             std::shared_ptr<RigidBodyFrame<double> > >(m, "RigidBodyFrame")
+             shared_ptr<RigidBodyFrame<double> > >(m, "RigidBodyFrame")
     .def(
         py::init<
             const std::string&,
@@ -241,16 +242,24 @@ PYBIND11_MODULE(rigid_body_tree, m) {
     .def("get_frame_index", &RigidBodyFrame<double>::get_frame_index);
 
   m.def("AddModelInstanceFromUrdfStringSearchingInRosPackages",
-        &drake::parsers::urdf::\
-          AddModelInstanceFromUrdfStringSearchingInRosPackages);
+        py::overload_cast<const std::string&, const PackageMap&,
+                          const std::string&, const FloatingBaseType,
+                          shared_ptr<RigidBodyFrame<double>>,
+                          RigidBodyTree<double>*>(
+            &parsers::urdf::
+                AddModelInstanceFromUrdfStringSearchingInRosPackages));
   m.def("AddModelInstancesFromSdfString",
-        &sdf::AddModelInstancesFromSdfString);
+        py::overload_cast<const std::string&, const FloatingBaseType,
+                          shared_ptr<RigidBodyFrame<double>>,
+                          RigidBodyTree<double>*>(
+            &sdf::AddModelInstancesFromSdfString));
   m.def("AddModelInstancesFromSdfStringSearchingInRosPackages",
-        &sdf::AddModelInstancesFromSdfStringSearchingInRosPackages),
-  m.def("AddFlatTerrainToWorld",
-        &drake::multibody::AddFlatTerrainToWorld,
-        py::arg("tree"),
-        py::arg("box_size") = 1000,
+        py::overload_cast<
+            const std::string&, const PackageMap&, const FloatingBaseType,
+            shared_ptr<RigidBodyFrame<double>>, RigidBodyTree<double>*>(
+            &sdf::AddModelInstancesFromSdfStringSearchingInRosPackages)),
+  m.def("AddFlatTerrainToWorld", &multibody::AddFlatTerrainToWorld,
+        py::arg("tree"), py::arg("box_size") = 1000,
         py::arg("box_depth") = 10);
 }
 

--- a/multibody/collision/test/collision_filter_group_test.cc
+++ b/multibody/collision/test/collision_filter_group_test.cc
@@ -460,45 +460,91 @@ GTEST_TEST(CollisionFilterGroupRBT, CollisionElementSetFilters) {
 
 //---------------------------------------------------------------------------
 
-// These tests read the files `filter_groups_in_file.[sdf|urdf]`. Each file
-// represents an identical tree with built in collisions where all collisions
-// have been filtered out by different filter specification idioms. The
-// test confirms that no collisions are reported.
-
-// Utility function for running the same test on equivalent urdf and sdf files.
-void ExpectNoCollisions(const std::string extension) {
+// Utility function for loading an sdf|urdf file, performing *optional*
+// pre-compile activities, configuring it to the "zero" configuration, perform
+// collision detection, and assert the expected number of collisions.
+//
+// This supports tests where the file is parsed and compiled as well as tests
+// where compilation is deferred.
+//
+// Note: The pre_compile function does *not* need to compile the tree.
+void ExpectNCollisions(
+    const std::string& file_name, const std::string& extension,
+    int collision_count,
+    std::function<void(RigidBodyTree<double>*)> pre_compile = {}) {
+  // If there is pre-compile work to do, parse without compilation.
+  bool do_compile = !pre_compile;
   RigidBodyTree<double> tree;
-  const std::string file_name = "drake/multibody/collision/test/"
-      "filter_groups_in_file.";
   if (extension == "urdf") {
     AddModelInstanceFromUrdfFileToWorld(
         FindResourceOrThrow(file_name + extension),
-        drake::multibody::joints::kRollPitchYaw, &tree);
+        drake::multibody::joints::kRollPitchYaw, do_compile, &tree);
   } else if (extension == "sdf") {
     AddModelInstancesFromSdfFileToWorld(
         FindResourceOrThrow(file_name + extension),
-        drake::multibody::joints::kRollPitchYaw, &tree);
+        drake::multibody::joints::kRollPitchYaw, do_compile, &tree);
   }  else {
     GTEST_FAIL() << "Unexpected model extension: " << extension;
   }
-  Eigen::Matrix<double, 16, 1> state;
-  state << 0, 0, 0, 0, 0, 0, 0, 0,  // x_0, rpy_0, joint12, joint23
-      0, 0, 0, 0, 0, 0, 0, 0;  // x_dot_0, omega_0, joint12_dot, joint23_dot
 
-  VectorXd q = state.topRows(8);
-  VectorXd v = state.bottomRows(8);
+  if (pre_compile) {
+    pre_compile(&tree);
+    tree.compile();
+  }
+
+  // Simply initialize everything to the "zero" position.
+  const int q_size = tree.get_num_positions();
+  const int v_size = tree.get_num_velocities();
+  VectorXd q = VectorXd::Zero(q_size);
+  VectorXd v = VectorXd::Zero(v_size);
   auto kinematics_cache = tree.doKinematics(q, v);
   std::vector<PointPair<double>> pairs =
       tree.ComputeMaximumDepthCollisionPoints(kinematics_cache, false);
-  EXPECT_EQ(pairs.size(), 0u);
+  EXPECT_EQ(pairs.size(), collision_count)
+            << "Failure for " << file_name << extension;
 }
 
+// These tests read the files `filter_groups_in_file.[sdf|urdf]`. Each file
+// represents an identical tree with built-in collisions where all collisions
+// have been filtered out by different filter specification idioms. The
+// test confirms that no collisions are reported.
 GTEST_TEST(CollisionFilterGroupDefinition, TestCollisionFilterGroupSpecUrdf) {
-  ExpectNoCollisions("urdf");
+  const std::string file_name = "drake/multibody/collision/test/"
+      "filter_groups_in_file.";
+  ExpectNCollisions(file_name, "urdf", 0);
 }
 
 GTEST_TEST(CollisionFilterGroupDefinition, TestCollisionFilterGroupSpecSdf) {
-  ExpectNoCollisions("sdf");
+  const std::string file_name = "drake/multibody/collision/test/"
+      "filter_groups_in_file.";
+  ExpectNCollisions(file_name, "sdf", 0);
+}
+
+// This confirms that default use of parsing a urdf/sdf leaves the tree in a
+// state that prevents modification of collision filter groups for the parsed
+// bodies.
+GTEST_TEST(CollisionFilterGroupDefinition, PostParseFailure) {
+  const std::string file_name = "drake/multibody/collision/test/"
+      "no_filter_groups.";
+  // Confirm collisions without filter groups.
+  ExpectNCollisions(file_name, "urdf", 1);
+  ExpectNCollisions(file_name, "sdf", 1);
+
+  auto configure_groups = [](RigidBodyTree<double>* tree) {
+    const std::string group_name = "self_group";
+    tree->DefineCollisionFilterGroup(group_name);
+    tree->AddCollisionFilterGroupMember(group_name, "sphereA", 0);
+    tree->AddCollisionFilterGroupMember(group_name, "sphereB", 0);
+    tree->AddCollisionFilterIgnoreTarget(group_name, group_name);
+  };
+  ExpectNCollisions(file_name, "urdf", 0, configure_groups);
+  ExpectNCollisions(file_name, "sdf", 0, configure_groups);
+}
+
+GTEST_TEST(CollisionFilterGroupDefinition, MultiModelSdfFilters) {
+  const std::string file_name = "drake/multibody/collision/test/"
+      "multi_model_groups.";
+  ExpectNCollisions(file_name, "sdf", 0);
 }
 
 }  // namespace

--- a/multibody/collision/test/filter_groups_in_file.sdf
+++ b/multibody/collision/test/filter_groups_in_file.sdf
@@ -4,7 +4,10 @@
      See the URDF for documentation on the purpose/structure of this file. -->
     <model name="sphere_chain">
         <link name="sphereA">
-            <collision>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideA">
                 <geometry>
                     <sphere>
                         <radius>1</radius>
@@ -13,7 +16,10 @@
             </collision>
         </link>
         <link name="sphereB">
-            <collision>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideB">
                 <geometry>
                     <sphere>
                         <radius>1</radius>
@@ -22,7 +28,10 @@
             </collision>
         </link>
         <link name="sphereC">
-            <collision>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideC">
                 <geometry>
                     <sphere>
                         <radius>1</radius>
@@ -31,7 +40,10 @@
             </collision>
         </link>
         <link name="sphereD">
-            <collision>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideD">
                 <geometry>
                     <sphere>
                         <radius>1</radius>

--- a/multibody/collision/test/filter_groups_in_file.urdf
+++ b/multibody/collision/test/filter_groups_in_file.urdf
@@ -18,8 +18,14 @@
         There is also an SDF version of this file: filter_groups_in_file.sdf.
         Both files should specify the same links, joints, and collision filter
         groups.
+
+        NOTE: Inertia values are introduced to prevent the parser from welding
+        links.
     -->
  <link name="sphereA">
+   <inertial>
+     <mass value="1"/>
+   </inertial>
    <collision>
      <geometry>
        <sphere radius="1" />
@@ -28,6 +34,9 @@
   </link>
 
   <link name="sphereB">
+    <inertial>
+        <mass value="1"/>
+    </inertial>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
@@ -37,6 +46,9 @@
   </link>
 
   <link name="sphereC">
+    <inertial>
+        <mass value="1"/>
+    </inertial>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
@@ -46,6 +58,9 @@
   </link>
 
   <link name="sphereD">
+    <inertial>
+        <mass value="1"/>
+    </inertial>
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>

--- a/multibody/collision/test/multi_model_groups.sdf
+++ b/multibody/collision/test/multi_model_groups.sdf
@@ -1,0 +1,47 @@
+<?xml version='1.0' ?>
+<sdf version='1.6'>
+    <!-- A simple scenario in which the sdf introduces *two* different models.
+         In this case, two spheres located at the origin. Each model places the
+         single body into a collision filter group and one model's group ignores
+         the other model's groups. This should lead to *no* collisions.
+
+         NOTE: This file is directly referenced in the
+         collision_filter_doxygen.h documentation. If this file changes, confirm
+         that the purpose it serves in the documentation hasn't been broken.
+    -->
+    <model name='modelA'>
+        <link name='sphereA'>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideA">
+                <geometry>
+                    <sphere>
+                        <radius>1</radius>
+                    </sphere>
+                </geometry>
+            </collision>
+        </link>
+        <collision_filter_group name="groupA">
+            <member link="sphereA"/>
+            <ignored_collision_filter_group collision_filter_group="groupB"/>
+        </collision_filter_group>
+    </model>
+    <model name="modelB">
+        <link name='sphereB'>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideB">
+                <geometry>
+                    <sphere>
+                        <radius>1</radius>
+                    </sphere>
+                </geometry>
+            </collision>
+        </link>
+        <collision_filter_group name="groupB">
+            <member link="sphereB"/>
+        </collision_filter_group>
+    </model>
+</sdf>

--- a/multibody/collision/test/no_filter_groups.sdf
+++ b/multibody/collision/test/no_filter_groups.sdf
@@ -1,0 +1,34 @@
+<?xml version='1.0' ?>
+<sdf version='1.6'>
+    <!-- NOTE: This should parallel no_filter_groups.urdf
+         See the URDF for documentation on the purpose/structure of this file.
+    -->
+    <model name='overlapping_spheres'>
+        <link name='sphereA'>
+            <pose>-0.9 0 0 0 0 0</pose>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideA">
+                <geometry>
+                    <sphere>
+                        <radius>1</radius>
+                    </sphere>
+                </geometry>
+            </collision>
+        </link>
+        <link name='sphereB'>
+            <pose>0.9 0 0 0 0 0</pose>
+            <inertial>
+                <mass>1.</mass>
+            </inertial>
+            <collision name="collideB">
+                <geometry>
+                    <sphere>
+                        <radius>1</radius>
+                    </sphere>
+                </geometry>
+            </collision>
+        </link>
+    </model>
+</sdf>

--- a/multibody/collision/test/no_filter_groups.urdf
+++ b/multibody/collision/test/no_filter_groups.urdf
@@ -1,0 +1,36 @@
+<robot name="overlapping_spheres">
+    <!--
+        Two simple colliding spheres. Their centers lie on the x-axis on
+        opposite sides of the y-z plane. Both spheres enclose the origin at a
+        depth of 0.1. The net penetration depth between the spheres is 0.2.
+
+        There is also an SDF version of this file: no_filter_groups.sdf.
+        Both files should specify the same links and geometry.
+
+        NOTE: Inertia values are introduced to prevent the parser from welding
+        links.
+    -->
+    <link name="sphereA">
+        <inertial>
+            <mass value="1"/>
+        </inertial>
+        <collision>
+            <origin xyz="-0.9 0 0" />
+            <geometry>
+                <sphere radius="1" />
+            </geometry>
+        </collision>
+    </link>
+
+    <link name="sphereB">
+        <inertial>
+            <mass value="1"/>
+        </inertial>
+        <collision>
+            <origin xyz="0.9 0 0" />
+            <geometry>
+                <sphere radius="1" />
+            </geometry>
+        </collision>
+    </link>
+</robot>

--- a/multibody/parsers/sdf_parser.cc
+++ b/multibody/parsers/sdf_parser.cc
@@ -814,7 +814,7 @@ ModelInstanceIdTable ParseSdf(XMLDocument* xml_doc,
     const PackageMap& package_map, const string& root_dir,
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
-    RigidBodyTree<double>* model) {
+    bool do_compile, RigidBodyTree<double>* model) {
   XMLElement* node = xml_doc->FirstChildElement("sdf");
   if (!node) {
     throw std::runtime_error(
@@ -845,7 +845,7 @@ ModelInstanceIdTable ParseSdf(XMLDocument* xml_doc,
                weld_to_frame, &model_instance_id_table);
   }
 
-  model->compile();
+  if (do_compile) model->compile();
 
   return model_instance_id_table;
 }
@@ -855,12 +855,20 @@ ModelInstanceIdTable ParseSdf(XMLDocument* xml_doc,
 ModelInstanceIdTable AddModelInstancesFromSdfFileToWorld(
     const string& filename, const FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfFileToWorld(filename, floating_base_type, true,
+                                             tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfFileToWorld(
+    const string& filename, const FloatingBaseType floating_base_type,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const string full_path_filename = GetFullPath(filename);
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(full_path_filename);
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(full_path_filename,
-      package_map, floating_base_type, nullptr /* weld_to_frame */, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      full_path_filename, package_map, floating_base_type,
+      nullptr /* weld_to_frame */, do_compile, tree);
 }
 
 ModelInstanceIdTable
@@ -868,21 +876,39 @@ AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
     const string& filename, const PackageMap& package_map,
     const FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
+      filename, package_map, floating_base_type, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
+    const string& filename, const PackageMap& package_map,
+    const FloatingBaseType floating_base_type, bool do_compile,
+    RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(filename,
-      package_map, floating_base_type, nullptr /* weld_to_frame */, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, nullptr /* weld_to_frame */,
+      do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfFile(
     const string& filename, const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfFile(filename, floating_base_type,
+                                      weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfFile(
+    const string& filename, const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame, bool do_compile,
+    RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const string full_path_filename = GetFullPath(filename);
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(full_path_filename);
-  return AddModelInstancesFromSdfFileSearchingInRosPackages(full_path_filename,
-      package_map, floating_base_type, weld_to_frame, tree);
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      full_path_filename, package_map, floating_base_type, weld_to_frame,
+      do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
@@ -890,14 +916,23 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
+    const string& filename, const PackageMap& package_map,
+    const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
 
   XMLDocument xml_doc;
   xml_doc.LoadFile(filename.data());
   if (xml_doc.ErrorID()) {
     throw std::runtime_error(string(__FILE__) + ": " + __func__ +
-                             ": ERROR: Failed to parse XML in file " +
-                             filename + "\n" + xml_doc.ErrorName() + ".");
+        ": ERROR: Failed to parse XML in file " +
+        filename + "\n" + xml_doc.ErrorName() + ".");
   }
 
   string root_dir = ".";
@@ -907,17 +942,26 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
   }
 
   return ParseSdf(&xml_doc, package_map, root_dir, floating_base_type,
-           weld_to_frame, tree);
+                  weld_to_frame, do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfString(
     const string& sdf_string, const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfString(sdf_string, floating_base_type,
+                                        weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfString(
+    const string& sdf_string, const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame, bool do_compile,
+    RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const PackageMap package_map;
-  return AddModelInstancesFromSdfStringSearchingInRosPackages(sdf_string,
-      package_map, floating_base_type, weld_to_frame, tree);
+  return AddModelInstancesFromSdfStringSearchingInRosPackages(
+      sdf_string, package_map, floating_base_type, weld_to_frame, do_compile,
+      tree);
 }
 
 ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
@@ -925,6 +969,15 @@ ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstancesFromSdfStringSearchingInRosPackages(
+      sdf_string, package_map, floating_base_type, weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
+    const string& sdf_string, const PackageMap& package_map,
+    const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
 
   XMLDocument xml_doc;
@@ -938,7 +991,7 @@ ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
   string root_dir = ".";
 
   return ParseSdf(&xml_doc, package_map, root_dir, floating_base_type,
-      weld_to_frame, tree);
+      weld_to_frame, do_compile, tree);
 }
 
 }  // namespace sdf

--- a/multibody/parsers/sdf_parser.h
+++ b/multibody/parsers/sdf_parser.h
@@ -26,6 +26,12 @@ namespace sdf {
  * meet these requirements should instead use
  * AddModelInstancesFromSdfFileToWorldSearchingInRosPackages().
  *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
+ *
  * @param[in] filename The name of the SDF file containing the model to be
  * added.
  *
@@ -44,6 +50,12 @@ AddModelInstancesFromSdfFileToWorld(
     const drake::multibody::joints::FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable
+AddModelInstancesFromSdfFileToWorld(
+    const std::string& filename,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * Adds the model or models defined within an SDF file to a rigid body tree.
  * One instance of each model is added. The models in the SDF are assumed to be
@@ -55,6 +67,12 @@ AddModelInstancesFromSdfFileToWorld(
  * `package://`, or if the package can be found by crawling up the directory
  * tree, the SDF could instead be loaded using
  * AddModelInstancesFromSdfFileToWorld().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] filename The name of the SDF file containing the model to be
  * added.
@@ -77,6 +95,12 @@ AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
     const drake::multibody::joints::FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable
+AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
+    const std::string& filename, const PackageMap& package_map,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * Adds the model or models defined within an SDF file to a rigid body tree.
  * One instance of each model is added.
@@ -87,6 +111,12 @@ AddModelInstancesFromSdfFileToWorldSearchingInRosPackages(
  * @p filename. SDF files that contain `package://` references to do not
  * meet these requirements should instead use
  * AddModelInstancesFromSdfFileSearchingInRosPackages().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] filename The name of the SDF file containing the model to be
  * added.
@@ -108,6 +138,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfFile(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstancesFromSdfFile(
+    const std::string& filename,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * Adds the model or models defined within an SDF file to @p tree. One instance
  * of each model is added.
@@ -118,6 +154,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfFile(
  * `package://`, or if the package can be found by crawling up the directory
  * tree, the SDF could instead be loaded using
  * AddModelInstancesFromSdfFile().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] filename The name of the SDF file containing the model to be
  * added.
@@ -142,6 +184,11 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
+    const std::string& filename, const PackageMap& package_map,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
 
 /**
  * Adds the model or models defined within an SDF description to @p tree. One
@@ -153,6 +200,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfFileSearchingInRosPackages(
  * @p filename. SDF files that contain `package://` references to do not
  * meet these requirements should instead use
  * AddModelInstancesFromSdfStringSearchingInRosPackages().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] sdf_string The SDF description of one or more models.
  *
@@ -173,6 +226,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfString(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstancesFromSdfString(
+    const std::string& sdf_string,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * Adds the model or models defined within an SDF description to @p tree. One
  * instance of each model is added.
@@ -183,6 +242,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfString(
  * `package://`, or if the package can be found by crawling up the directory
  * tree, the SDF could instead be loaded using
  * AddModelInstancesFromSdfFile().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] sdf_string The SDF description of one or more models.
  *
@@ -205,6 +270,12 @@ ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
     const drake::multibody::joints::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
+
+ModelInstanceIdTable AddModelInstancesFromSdfStringSearchingInRosPackages(
+    const std::string& sdf_string, const PackageMap& package_map,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
 
 }  // namespace sdf
 }  // namespace parsers

--- a/multibody/parsers/urdf_parser.cc
+++ b/multibody/parsers/urdf_parser.cc
@@ -1099,7 +1099,7 @@ ModelInstanceIdTable ParseUrdf(XMLDocument* xml_doc,
     const PackageMap& package_map, const string& root_dir,
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
-    RigidBodyTree<double>* tree) {
+    bool do_compile, RigidBodyTree<double>* tree) {
   XMLElement* node = xml_doc->FirstChildElement("robot");
   if (!node) {
     throw std::runtime_error(string(__FILE__) + ": " + __func__ + ": ERROR: "
@@ -1109,7 +1109,7 @@ ModelInstanceIdTable ParseUrdf(XMLDocument* xml_doc,
   ModelInstanceIdTable model_instance_id_table = ParseModel(
       tree, node, package_map, root_dir, floating_base_type, weld_to_frame);
 
-  tree->compile();
+  if (do_compile) tree->compile();
 
   return model_instance_id_table;
 }
@@ -1118,10 +1118,16 @@ ModelInstanceIdTable ParseUrdf(XMLDocument* xml_doc,
 
 ModelInstanceIdTable AddModelInstanceFromUrdfStringWithRpyJointToWorld(
     const string& urdf_string, RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfStringWithRpyJointToWorld(urdf_string, true,
+                                                           tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfStringWithRpyJointToWorld(
+    const string& urdf_string, bool do_compile, RigidBodyTree<double>* tree) {
   const PackageMap package_map;
   return
       AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
-          urdf_string, package_map, tree);
+          urdf_string, package_map, do_compile, tree);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to Release 1.0.
@@ -1134,10 +1140,19 @@ ModelInstanceIdTable
 AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
     const string& urdf_string, const PackageMap& package_map,
     RigidBodyTree<double>* tree) {
+  return
+      AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
+          urdf_string, package_map, true, tree);
+}
+
+ModelInstanceIdTable
+AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
+    const string& urdf_string, const PackageMap& package_map,
+    bool do_compile, RigidBodyTree<double>* tree) {
   const string root_dir = ".";
   return AddModelInstanceFromUrdfStringSearchingInRosPackages(
       urdf_string, package_map, root_dir, kRollPitchYaw,
-      nullptr /* weld_to_frame */, tree);
+      nullptr /* weld_to_frame */, do_compile, tree);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to Release 1.0.
@@ -1166,10 +1181,19 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfString(
+      urdf_string, root_dir, floating_base_type, weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfString(
+    const string& urdf_string, const string& root_dir,
+    const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   const PackageMap package_map;
   return AddModelInstanceFromUrdfStringSearchingInRosPackages(
       urdf_string, package_map, root_dir, floating_base_type,
-      weld_to_frame, tree);
+      weld_to_frame, do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(
@@ -1177,21 +1201,36 @@ ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(
     const string& root_dir, const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfStringSearchingInRosPackages(
+      urdf_string, package_map, root_dir, floating_base_type, weld_to_frame,
+      true, tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(
+    const string& urdf_string, const PackageMap& package_map,
+    const string& root_dir, const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   XMLDocument xml_doc;
   xml_doc.Parse(urdf_string.c_str());
   return ParseUrdf(&xml_doc, package_map, root_dir, floating_base_type,
-                   weld_to_frame, tree);
+                   weld_to_frame, do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstanceFromUrdfFileWithRpyJointToWorld(
     const string& filename, RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfFileWithRpyJointToWorld(filename, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileWithRpyJointToWorld(
+    const string& filename, bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const string full_path_filename = GetFullPath(filename);
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(full_path_filename);
   return AddModelInstanceFromUrdfFileSearchingInRosPackages(
       full_path_filename, package_map, kRollPitchYaw,
-      nullptr /* weld_to_frame */, tree);
+      nullptr /* weld_to_frame */, do_compile, tree);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to Release 1.0.
@@ -1203,13 +1242,20 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(const string& filename,
 ModelInstanceIdTable AddModelInstanceFromUrdfFileToWorld(
     const string& filename, const FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfFileToWorld(filename, floating_base_type, true,
+                                             tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileToWorld(
+    const string& filename, const FloatingBaseType floating_base_type,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const string full_path_filename = GetFullPath(filename);
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(full_path_filename);
   return AddModelInstanceFromUrdfFileSearchingInRosPackages(
       full_path_filename, package_map, floating_base_type,
-      nullptr /*weld_to_frame*/, tree);
+      nullptr /*weld_to_frame*/, do_compile, tree);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to Release 1.0.
@@ -1224,12 +1270,21 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(
     const string& filename, const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfFile(filename, floating_base_type,
+                                      weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFile(
+    const string& filename, const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
   const string full_path_filename = GetFullPath(filename);
   PackageMap package_map;
   package_map.PopulateUpstreamToDrake(full_path_filename);
   return AddModelInstanceFromUrdfFileSearchingInRosPackages(
-      full_path_filename, package_map, floating_base_type, weld_to_frame, tree);
+      full_path_filename, package_map, floating_base_type, weld_to_frame,
+      do_compile, tree);
 }
 
 ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
@@ -1237,6 +1292,15 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
     const FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree) {
+  return AddModelInstanceFromUrdfFileSearchingInRosPackages(
+      filename, package_map, floating_base_type, weld_to_frame, true, tree);
+}
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
+    const string& filename, const PackageMap& package_map,
+    const FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree) {
   DRAKE_DEMAND(tree && "You must provide a valid RigidBodyTree pointer.");
 
   // Opens the URDF file and feeds it into the XML parser.
@@ -1256,7 +1320,7 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
   }
 
   return ParseUrdf(&xml_doc, package_map, root_dir, floating_base_type,
-                   weld_to_frame, tree);
+                   weld_to_frame, do_compile, tree);
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to Release 1.0.

--- a/multibody/parsers/urdf_parser.h
+++ b/multibody/parsers/urdf_parser.h
@@ -62,6 +62,12 @@ std::shared_ptr<RigidBodyFrame<double>> MakeRigidBodyFrameFromUrdfNode(
  * `package://` should instead use
  * AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages().
  *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
+ *
  * @param[in] urdf_string The URDF string of the model. This is the actual
  * URDF text (i.e., it is not the name of a file that contains the URDF text).
  * A new model instance is created based on this URDF text and added to
@@ -75,6 +81,10 @@ std::shared_ptr<RigidBodyFrame<double>> MakeRigidBodyFrameFromUrdfNode(
  */
 ModelInstanceIdTable AddModelInstanceFromUrdfStringWithRpyJointToWorld(
     const std::string& urdf_string, RigidBodyTree<double>* tree);
+
+ModelInstanceIdTable AddModelInstanceFromUrdfStringWithRpyJointToWorld(
+    const std::string& urdf_string, bool do_compile,
+    RigidBodyTree<double>* tree);
 
 DRAKE_DEPRECATED(
   "Please use AddModelInstanceFromUrdfStringWithRpyJointToWorld().")
@@ -95,6 +105,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
  * modeling resources using `package://`. If the model in the URDF does not use
  * `package://`, the URDF could instead be loaded using
  * AddModelInstanceFromUrdfStringWithRpyJointToWorld().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] urdf_string The URDF string of the model. This is the actual
  * URDF text (i.e., it is not the name of a file that contains the URDF text).
@@ -117,6 +133,11 @@ AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
     const std::string& urdf_string, const PackageMap& package_map,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable
+AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages(
+    const std::string& urdf_string, const PackageMap& package_map,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 DRAKE_DEPRECATED("Please use AddModelInstanceFromUrdfStringWithRpyJointToWorldSearchingInRosPackages().")  // NOLINT(whitespace/line_length)
 ModelInstanceIdTable AddModelInstanceFromUrdfString(
     const std::string& urdf_string, const PackageMap& package_map,
@@ -135,6 +156,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
  * reference modeling resources like mesh files. URDF models that contain
  * `package://` should instead use
  * AddModelInstanceFromUrdfStringSearchingInRosPackages().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] urdf_string The URDF string of the model. This is the actual
  * URDF text (i.e., it is not the name of a file that contains the URDF text).
@@ -160,6 +187,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstanceFromUrdfString(
+    const std::string& urdf_string, const std::string& root_dir,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * This method is the same as AddModelInstanceFromUrdfString() except it has an
  * additional parameter called @p package_map. Parameter @p package_map
@@ -173,6 +206,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
  * modeling resources using `package://`. If the model in the URDF does not use
  * `package://`, the URDF could instead be loaded using
  * AddModelInstanceFromUrdfString().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] urdf_string The URDF string of the model. This is the actual
  * URDF text (i.e., it is not the name of a file that contains the URDF text).
@@ -205,6 +244,13 @@ ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstanceFromUrdfStringSearchingInRosPackages(
+    const std::string& urdf_string, const PackageMap& package_map,
+    const std::string& root_dir,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 DRAKE_DEPRECATED("Please use AddModelInstanceFromUrdfStringSearchingInRosPackages().")  // NOLINT(whitespace/line_length)
 ModelInstanceIdTable AddModelInstanceFromUrdfString(
     const std::string& urdf_string, const PackageMap& package_map,
@@ -228,6 +274,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
  * meet these requirements should instead use
  * AddModelInstanceFromUrdfFileSearchingInRosPackages().
  *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
+ *
  * @param[in] urdf_filename The name of the file containing the URDF model.
  *
  * @param[out] tree The `RigidBodyTree` to which to add the model instance.
@@ -238,6 +290,10 @@ ModelInstanceIdTable AddModelInstanceFromUrdfString(
  */
 ModelInstanceIdTable AddModelInstanceFromUrdfFileWithRpyJointToWorld(
     const std::string& urdf_filename, RigidBodyTree<double>* tree);
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileWithRpyJointToWorld(
+    const std::string& urdf_filename, bool do_compile,
+    RigidBodyTree<double>* tree);
 
 DRAKE_DEPRECATED("Please use AddModelInstanceFromUrdfFileWithRpyJointToWorld().")  // NOLINT(whitespace/line_length)
 ModelInstanceIdTable AddModelInstanceFromUrdfFile(
@@ -258,6 +314,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(
  * meet these requirements should instead use
  * AddModelInstanceFromUrdfFileSearchingInRosPackages().
  *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
+ *
  * @param[in] urdf_filename The name of the file containing a URDF
  * description of the model. An instance of this model will be added to
  * @p tree.
@@ -276,6 +338,11 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFileToWorld(
     const std::string& urdf_filename,
     const drake::multibody::joints::FloatingBaseType floating_base_type,
     RigidBodyTree<double>* tree);
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileToWorld(
+    const std::string& urdf_filename,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    bool do_compile, RigidBodyTree<double>* tree);
 
 DRAKE_DEPRECATED("Please use AddModelInstanceFromUrdfFileToWorld().")
 ModelInstanceIdTable AddModelInstanceFromUrdfFile(
@@ -299,6 +366,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(
  * meet these requirements should instead use
  * AddModelInstanceFromUrdfFileSearchingInRosPackages().
  *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
+ *
  * @param[in] urdf_filename The name of the file containing the URDF model.
  * A new instance of this model is created and added to @p tree.
  *
@@ -321,6 +394,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
 
+ModelInstanceIdTable AddModelInstanceFromUrdfFile(
+    const std::string& urdf_filename,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
+
 /**
  * This method is the same as AddModelInstanceFromUrdfFile() except it has an
  * additional parameter called @p package_map. Parameter @p package_map
@@ -334,6 +413,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFile(
  * modeling resources using `package://`. If the model in the URDF does not use
  * `package://`, the URDF could instead be loaded using
  * AddModelInstanceFromUrdfFile().
+ *
+ * There are two versions: one in which the tree is automatically "compiled"
+ * after a successful parse and one in which compilation depends on an input
+ * parameter, `do_compile`. If `do_compile` is false, it is the responsibility
+ * of the caller to ensure RigdBodyTree::compile() is invoked appropriately
+ * subsequent to the successful parse.
  *
  * @param[in] urdf_filename The name of the file containing the URDF model.
  * An instance of this model will be added to @p tree.
@@ -359,6 +444,12 @@ ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
     const drake::multibody::joints::FloatingBaseType floating_base_type,
     std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
     RigidBodyTree<double>* tree);
+
+ModelInstanceIdTable AddModelInstanceFromUrdfFileSearchingInRosPackages(
+    const std::string& urdf_filename, const PackageMap& package_map,
+    const drake::multibody::joints::FloatingBaseType floating_base_type,
+    std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+    bool do_compile, RigidBodyTree<double>* tree);
 
 DRAKE_DEPRECATED("Please use AddModelInstanceFromUrdfFileSearchingInRosPackages().")  // NOLINT(whitespace/line_length)
 ModelInstanceIdTable AddModelInstanceFromUrdfFile(


### PR DESCRIPTION
This enables being able to programmatically modify collision filter groups
of parsed files. It does this by providing an optional flag that defers
tree compilation (which used to be a defacto step in parsing).

1. URDF and SDF parsers are updated to propagate the flags.
2. Testing is provided to confirm behavior.
3. Incidental corrections to providing collision filter group support in
   sdf parsing.
   a. The doxygen module on the subject has been updated.
   b. SDF specific semantics have been documented and tested.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8297)
<!-- Reviewable:end -->
