### PR TITLE
Multilane's Builder API refactor in favor of fluent API

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -109,6 +109,7 @@ drake_cc_googletest(
     deps = [
         ":builder",
         "//automotive/maliput/api/test_utilities",
+        "//automotive/maliput/multilane/test_utilities",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -16,6 +16,14 @@ namespace drake {
 namespace maliput {
 namespace multilane {
 
+std::ostream& operator<<(std::ostream& out, const LaneLayout& lane_layout) {
+  return out << "(left_shoulder: " << lane_layout.left_shoulder()
+             << ", right_shoulder: " << lane_layout.right_shoulder()
+             << ", num_lanes: " << lane_layout.num_lanes()
+             << ", ref_lane: " << lane_layout.ref_lane()
+             << ", ref_r0: " << lane_layout.ref_r0() << ")";
+}
+
 Builder::Builder(double lane_width, const api::HBounds& elevation_bounds,
                  double linear_tolerance, double angular_tolerance)
     : lane_width_(lane_width),
@@ -27,24 +35,37 @@ Builder::Builder(double lane_width, const api::HBounds& elevation_bounds,
   DRAKE_DEMAND(angular_tolerance_ >= 0.);
 }
 
-const Connection* Builder::Connect(const std::string& id, int num_lanes,
-                                   double r0, double left_shoulder,
-                                   double right_shoulder, const Endpoint& start,
-                                   double length, const EndpointZ& z_end) {
-  connections_.push_back(
-      std::make_unique<Connection>(id, start, z_end, num_lanes, r0, lane_width_,
-                                   left_shoulder, right_shoulder, length));
+const Connection* Builder::Connect(const std::string& id,
+                                   const LaneLayout& lane_layout,
+                                   const StartReference::Spec& start_spec,
+                                   const LineOffset& line_offset,
+                                   const EndReference::Spec& end_spec) {
+  // TODO(agalbachicar)    Once the API supports referencing to lanes, this
+  //                       should be used to call the appropriate Builder
+  //                       methods, r_ref will refer to any lane and will not be
+  //                       r0.
+  DRAKE_DEMAND(lane_layout.ref_lane() == 0);
+  connections_.push_back(std::make_unique<Connection>(
+      id, start_spec.endpoint(), end_spec.endpoint_z(), lane_layout.num_lanes(),
+      lane_layout.ref_r0(), lane_width_, lane_layout.left_shoulder(),
+      lane_layout.right_shoulder(), line_offset.length()));
   return connections_.back().get();
 }
 
-const Connection* Builder::Connect(const std::string& id, int num_lanes,
-                                   double r0, double left_shoulder,
-                                   double right_shoulder, const Endpoint& start,
-                                   const ArcOffset& arc,
-                                   const EndpointZ& z_end) {
-  connections_.push_back(
-      std::make_unique<Connection>(id, start, z_end, num_lanes, r0, lane_width_,
-                                   left_shoulder, right_shoulder, arc));
+const Connection* Builder::Connect(const std::string& id,
+                                   const LaneLayout& lane_layout,
+                                   const StartReference::Spec& start_spec,
+                                   const ArcOffset& arc_offset,
+                                   const EndReference::Spec& end_spec) {
+  // TODO(agalbachicar)    Once the API supports referencing to lanes, this
+  //                       should be used to call the appropriate Builder
+  //                       methods, r_ref will refer to any lane and will not be
+  //                       r0.
+  DRAKE_DEMAND(lane_layout.ref_lane() == 0);
+  connections_.push_back(std::make_unique<Connection>(
+      id, start_spec.endpoint(), end_spec.endpoint_z(), lane_layout.num_lanes(),
+      lane_layout.ref_r0(), lane_width_, lane_layout.left_shoulder(),
+      lane_layout.right_shoulder(), arc_offset));
   return connections_.back().get();
 }
 

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -19,6 +19,164 @@ namespace multilane {
 
 class RoadGeometry;
 
+/// Defines the direction of an Endpoint or EndpointZ.
+enum class Direction { kForward, kReverse };
+
+/// Provides methods to build an StartReference::Spec.
+class StartReference {
+ public:
+  /// Defines how a Connection's reference curve starts.
+  ///
+  /// Objects of this class should be created using StartReference::at()
+  /// methods.
+  class Spec {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Spec)
+
+    const Endpoint& endpoint() const { return endpoint_; }
+
+   private:
+    // Allows StartReference factory to build objects of this class.
+    friend class StartReference;
+
+    // Constructs a Spec that specifies with `endpoint` how a Connection's
+    // reference curve starts.
+    explicit Spec(const Endpoint& endpoint) : endpoint_(endpoint) {}
+
+    // Describes the connection's reference curve start-point.
+    Endpoint endpoint_{};
+  };
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(StartReference)
+
+  StartReference() = default;
+
+  /// Builds a Spec at `endpoint` with `direction` direction. When
+  /// `direction` == `Direction::kReverse`, `endpoint` is reversed.
+  Spec at(const Endpoint& endpoint, Direction direction) const {
+    return direction == Direction::kForward ? Spec(endpoint)
+                                            : Spec(endpoint.reverse());
+  }
+
+  /// Builds a Spec at `connection`'s `end` side with `direction` direction.
+  /// When `direction` == `Direction::kReverse`, `endpoint` is reversed.
+  Spec at(const Connection& connection, api::LaneEnd::Which end,
+          Direction direction) const {
+    const Endpoint endpoint = end == api::LaneEnd::Which::kStart
+                                  ? connection.start()
+                                  : connection.end();
+    return direction == Direction::kForward ? Spec(endpoint)
+                                            : Spec(endpoint.reverse());
+  }
+};
+
+/// Provides methods to build an EndReference::Spec.
+class EndReference {
+ public:
+  /// Defines how a Connection's reference curve ends.
+  ///
+  /// Objects of this class should be created using EndReference::z_at()
+  /// methods.
+  class Spec {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Spec)
+
+    const EndpointZ& endpoint_z() const { return endpoint_z_; }
+
+   private:
+    // Allows EndReference factory to build objects of this class.
+    friend class EndReference;
+
+    /// Constructs a Spec at that specifies with `endpoint_z` how a
+    /// Connection's reference curve ends.
+    explicit Spec(const EndpointZ& endpoint_z) : endpoint_z_(endpoint_z) {}
+
+    // Describes the connection's reference curve end-point.
+    EndpointZ endpoint_z_;
+  };
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(EndReference)
+
+  EndReference() = default;
+
+  /// Builds a Spec at `connection`'s `end` side with `direction` direction.
+  /// When `direction` == `Direction::kReverse`, `end`-side endpoint's
+  /// EndpointZ is reversed.
+  Spec z_at(const Connection& connection, api::LaneEnd::Which end,
+            Direction direction) const {
+    const EndpointZ endpoint_z = end == api::LaneEnd::Which::kStart
+                                     ? connection.start().z()
+                                     : connection.end().z();
+    return direction == Direction::kForward ? Spec(endpoint_z)
+                                            : Spec(endpoint_z.reverse());
+  }
+
+  /// Builds an Spec at `endpoint_z` with `direction` direction.
+  /// When `direction` == `Direction::kReverse`, `endpoint_z` is reversed.
+  Spec z_at(const EndpointZ& endpoint_z, Direction direction) const {
+    return direction == Direction::kForward ? Spec(endpoint_z)
+                                            : Spec(endpoint_z.reverse());
+  }
+};
+
+/// Wraps all the lane-related specifications in a Connection.
+class LaneLayout {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LaneLayout)
+
+  /// Constructs a the lane layout of a connection.
+  ///
+  /// Lane reference paths (which are offsets of parent Segment reference curve)
+  /// are centered within the Lane. Lane spacing will be road geometry fixed
+  /// lane's width. Segment extents will be derived from the composition of
+  /// `left_shoulder` and `right_shoulder` shoulders, number of lanes and lane
+  /// spacing. `ref_lane` lane's centerline will be placed at `ref_r0` distance
+  /// from connection's reference curve.
+  ///
+  /// `left_shoulder` and `right_shoulder` must be nonnegative.
+  /// `num_lanes` must be positive and `ref_lane` must be nonnegative and
+  /// smaller than `num_lanes`.
+  LaneLayout(double left_shoulder, double right_shoulder, int num_lanes,
+             int ref_lane, double ref_r0)
+      : left_shoulder_(left_shoulder),
+        right_shoulder_(right_shoulder),
+        num_lanes_(num_lanes),
+        ref_lane_(ref_lane),
+        ref_r0_(ref_r0) {
+    DRAKE_DEMAND(left_shoulder_ >= 0.);
+    DRAKE_DEMAND(right_shoulder_ >= 0.);
+    DRAKE_DEMAND(num_lanes_ > 0);
+    DRAKE_DEMAND(ref_lane_ >= 0 && ref_lane_ < num_lanes_);
+  }
+
+  double left_shoulder() const { return left_shoulder_; }
+
+  double right_shoulder() const { return right_shoulder_; }
+
+  int num_lanes() const { return num_lanes_; }
+
+  int ref_lane() const { return ref_lane_; }
+
+  double ref_r0() const { return ref_r0_; }
+
+ private:
+  // Extra space added to the right of the first lane.
+  double left_shoulder_{};
+  // Extra space added to the left of the last lane.
+  double right_shoulder_{};
+  // Number of lanes.
+  int num_lanes_{};
+  // Index of the lane from which `ref_r0_` is defined.
+  int ref_lane_{};
+  // Distance from `ref_lane_` lane's centerline to reference curve.
+  double ref_r0_{};
+};
+
+/// Streams a string representation of `lane_layout` into `out`. Returns `out`.
+/// This method is provided for the purposes of debugging or text-logging.
+/// It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const LaneLayout& lane_layout);
+
 /// Defines a builder interface for multilane. It is used for testing purposes
 /// only, and derived code should instantiate Builder objects.
 class BuilderBase {
@@ -41,32 +199,38 @@ class BuilderBase {
   /// Gets `angular_tolerance` value.
   virtual double get_angular_tolerance() const = 0;
 
-  /// Connects `start` to an end-point linearly displaced from `start`.
-  /// `length` specifies the length of displacement (in the direction of the
-  /// heading of `start`). `z_end` specifies the elevation characteristics at
-  /// the end-point.
-  /// `r0` is the distance from the reference curve to the first Lane
-  /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
-  /// distances added to the extents of the Segment after the first and last
-  /// Lanes positions are determined.
-  virtual const Connection* Connect(const std::string& id, int num_lanes,
-                                    double r0, double left_shoulder,
-                                    double right_shoulder,
-                                    const Endpoint& start, double length,
-                                    const EndpointZ& z_end) = 0;
+  /// Connects `start_spec`'s Endpoint to an end-point linearly displaced from
+  /// `start_spec`'s Endpoint.
+  ///
+  /// `line_offset` specifies the length of displacement (in the direction of
+  /// the heading of `start_spec`'s Endpoint). `end_spec` specifies the
+  /// elevation characteristics at the end-point.
+  /// `lane_layout` defines the number of lanes, their width, extra shoulder
+  /// asphalt extensions and placing with respect to connection's reference
+  /// curve.
+  virtual const Connection* Connect(const std::string& id,
+                                    const LaneLayout& lane_layout,
+                                    const StartReference::Spec& start_spec,
+                                    const LineOffset& line_offset,
+                                    const EndReference::Spec& end_spec) = 0;
 
-  /// Connects `start` to an end-point displaced from `start` via an arc.
-  /// `arc` specifies the shape of the arc. `z_end` specifies the elevation
-  /// characteristics at the end-point.
+  /// Connects `start_spec`'s Endpoint to an end-point displaced from
+  /// `start_spec`'s Endpoint via an arc.
+  ///
+  /// `arc_offset` specifies the shape of the arc. `end_spec` specifies the
+  /// elevation characteristics at the end-point.
   /// `r0` is the distance from the reference curve to the first Lane
   /// centerline. `left_shoulder` and `right_shoulder` are extra lateral
   /// distances added to the extents of the Segment after the first and last
   /// Lanes positions are determined.
-  virtual const Connection* Connect(const std::string& id, int num_lanes,
-                                    double r0, double left_shoulder,
-                                    double right_shoulder,
-                                    const Endpoint& start, const ArcOffset& arc,
-                                    const EndpointZ& z_end) = 0;
+  /// `lane_layout` defines the number of lanes, their width, extra shoulder
+  /// asphalt extensions and placing with respect to connection's reference
+  /// curve.
+  virtual const Connection* Connect(const std::string& id,
+                                    const LaneLayout& lane_layout,
+                                    const StartReference::Spec& start_spec,
+                                    const ArcOffset& arc_offset,
+                                    const EndReference::Spec& end_spec) = 0;
 
   /// Sets the default branch for one end of a connection.
   ///
@@ -132,8 +296,8 @@ class BuilderFactoryBase {
 /// components into a valid RoadGeometry.  In the Builder model, an Endpoint
 /// specifies a point in world coordinates (along with a direction, slope,
 /// and superelevation parameters).  A Connection is a path from an explicit
-/// start Endpoint to an end Endpoint calculated via a linear or arc
-/// displacement (ArcOffset).  A Group is a collection of Connections.
+/// start Endpoint to an end Endpoint calculated via a linear (LineOffset) or
+/// arc displacement (ArcOffset).  A Group is a collection of Connections.
 ///
 /// Builder::Build() constructs a RoadGeometry. Each Connection yields a
 /// Segment bearing multiple Lanes. Each Group yields a Junction containing
@@ -183,15 +347,17 @@ class Builder : public BuilderBase {
   /// Gets `angular_tolerance` value.
   double get_angular_tolerance() const override { return angular_tolerance_; }
 
-  const Connection* Connect(const std::string& id, int num_lanes, double r0,
-                            double left_shoulder, double right_shoulder,
-                            const Endpoint& start, double length,
-                            const EndpointZ& z_end) override;
+  const Connection* Connect(const std::string& id,
+                            const LaneLayout& lane_layout,
+                            const StartReference::Spec& start_spec,
+                            const LineOffset& line_offset,
+                            const EndReference::Spec& end_spec) override;
 
-  const Connection* Connect(const std::string& id, int num_lanes, double r0,
-                            double left_shoulder, double right_shoulder,
-                            const Endpoint& start, const ArcOffset& arc,
-                            const EndpointZ& z_end) override;
+  const Connection* Connect(const std::string& id,
+                            const LaneLayout& lane_layout,
+                            const StartReference::Spec& start_spec,
+                            const ArcOffset& arc_offset,
+                            const EndReference::Spec& end_spec) override;
 
   void SetDefaultBranch(const Connection* in, int in_lane_index,
                         const api::LaneEnd::Which in_end, const Connection* out,

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -23,6 +23,10 @@ std::ostream& operator<<(std::ostream& out, const Endpoint& endpoint) {
   return out << "(xy: " << endpoint.xy() << ", z: " << endpoint.z() << ")";
 }
 
+std::ostream& operator<<(std::ostream& out, const LineOffset& line_offset) {
+  return out << "(length: " << line_offset.length() << ")";
+}
+
 std::ostream& operator<<(std::ostream& out, const ArcOffset& arc_offset) {
   return out << "(r: " << arc_offset.radius()
              << ", d_theta: " << arc_offset.d_theta() << ")";

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -139,6 +139,29 @@ class Endpoint {
 /// text-logging. It is not intended for serialization.
 std::ostream& operator<<(std::ostream& out, const Endpoint& endpoint);
 
+/// Specification for path offset along a line.
+///  * length: length of the line, which must be nonnegative.
+class LineOffset {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(LineOffset)
+
+  LineOffset() = default;
+
+  explicit LineOffset(double length) : length_(length) {
+    DRAKE_DEMAND(length_ >= 0.);
+  }
+
+  double length() const { return length_; }
+
+ private:
+  double length_{};
+};
+
+/// Streams a string representation of `line_offset` into `out`. Returns `out`.
+/// This method is provided for the purposes of debugging or text-logging.
+/// It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const LineOffset& line_offset);
+
 /// Specification for path offset along a circular arc.
 ///  * radius: radius of the arc, which must be positive
 ///  * d_theta:  angle of arc segment (Δθ)

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -65,6 +65,17 @@ GTEST_TEST(EndpointZTest, Reverse) {
       dut.reverse(), {1., -2., -M_PI / 4., M_PI / 2.}, kZeroTolerance));
 }
 
+// LineOffset checks.
+GTEST_TEST(LineOffsetTest, DefaultConstructor) {
+  const LineOffset dut{};
+  EXPECT_EQ(dut.length(), 0.);
+}
+
+GTEST_TEST(LineOffsetTest, ParametrizedConstructor) {
+  const LineOffset dut{123.456};
+  EXPECT_EQ(dut.length(), 123.456);
+}
+
 // ArcOffset checks.
 GTEST_TEST(ArcOffsetTest, DefaultConstructor) {
   const ArcOffset dut{};

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -178,6 +178,38 @@ namespace test {
          << angular_tolerance;
 }
 
+Matcher<const api::HBounds&> Matches(const api::HBounds& elevation_bounds,
+                                     double tolerance) {
+  return MakeMatcher(new HBoundsMatcher(elevation_bounds, tolerance));
+}
+
+Matcher<const ArcOffset&> Matches(const ArcOffset& arc_offset,
+                                  double linear_tolerance,
+                                  double angular_tolerance) {
+  return MakeMatcher(
+      new ArcOffsetMatcher(arc_offset, linear_tolerance, angular_tolerance));
+}
+
+Matcher<const LineOffset&> Matches(const LineOffset& line_offset,
+                                   double tolerance) {
+  return MakeMatcher(new LineOffsetMatcher(line_offset, tolerance));
+}
+
+Matcher<const LaneLayout&> Matches(const LaneLayout& lane_layout,
+                                   double tolerance) {
+  return MakeMatcher(new LaneLayoutMatcher(lane_layout, tolerance));
+}
+
+Matcher<const StartReference::Spec&> Matches(
+    const StartReference::Spec& start_reference, double tolerance) {
+  return MakeMatcher(new StartReferenceSpecMatcher(start_reference, tolerance));
+}
+
+Matcher<const EndReference::Spec&> Matches(
+    const EndReference::Spec& end_reference, double tolerance) {
+  return MakeMatcher(new EndReferenceSpecMatcher(end_reference, tolerance));
+}
+
 }  // namespace test
 }  // namespace multilane
 }  // namespace maliput


### PR DESCRIPTION
Previous discussion can be found : 
 - Original PR #7471 
 - [New API proposal](https://github.com/RobotLocomotion/drake/pull/8077#issuecomment-366335658).

----------
In this PR:

- Provides [Start/End]ReferenceSpec to wrap Endpoint information.
- All lane related attributes in Connect methods were moved to LaneLayout.
- Fluent API to construct Spec types that will feed Connect methods.
- Updates previous tests to comply with the new API.
- Refactors loader tests with new builder API.
- Refactors loader test matchers.

--------

A follow up PR will include:

- `EndpoinZ.theta_dot_` will be moved to `drake::optional<double>` to correctly apply continuity constraints.
- Provide / fix tests for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8302)
<!-- Reviewable:end -->
