### PR TITLE
Fix Wdeprecated warnings in proto

### DIFF
--- a/common/proto/call_python.h
+++ b/common/proto/call_python.h
@@ -127,19 +127,31 @@ template <typename Policy>
 class PythonAccessor : public internal::PythonApi<PythonAccessor<Policy>> {
  public:
   using KeyType = typename Policy::KeyType;
+
+  // Given a variable (and key), makes a PythonAccessor.
   PythonAccessor(PythonRemoteVariable obj, const KeyType& key)
       : obj_(obj), key_(key) {}
 
+  // Copying a PythonAccessor aliases the original remote variable (reference
+  // semantics), it does not create a new remote variable.
+  PythonAccessor(const PythonAccessor&) = default;
+
+  // Implicitly converts to a PythonRemoteVariable.
   operator PythonRemoteVariable() const { return value(); }
 
+  // Assigning from another PythonAccessor delegates to set_value from that
+  // `value`'s underlying PythonRemoteVariable.
   PythonRemoteVariable operator=(const PythonAccessor& value) {
     return set_value(value);
   }
 
+  // Assigning from another PythonRemoteVariable delegates to set_value from it.
   PythonRemoteVariable operator=(const PythonRemoteVariable& value) {
     return set_value(value);
   }
 
+  // Assigning from some literal value creates a new PythonRemoveVariable to
+  // bind the value.
   template <typename T>
   PythonRemoteVariable operator=(const T& value) {
     return set_value(NewPythonVariable(value));


### PR DESCRIPTION
When using clang, Wdeprecated warns about deprecated implicitly-defined copy constructors (happens most often due to user-defined destructor, but in this case is due to the explicit assignment operator):
http://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor

This patch explicitly defines the desired copy constructor, silencing the warning in call_python.

We also document the public (but internal) methods in order to reason about why exposing the copy constructor is correct.

See #8288 for the entire feature branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8304)
<!-- Reviewable:end -->
