### PR TITLE
optitrack_pose_extractor: Improve error message. Add `GetPose` for non-systems queries

### DIFF
--- a/manipulation/perception/BUILD.bazel
+++ b/manipulation/perception/BUILD.bazel
@@ -26,6 +26,7 @@ drake_cc_library(
     name = "pose_smoother",
     srcs = ["pose_smoother.cc"],
     hdrs = ["pose_smoother.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//manipulation/util:moving_average_filter",
         "//math:geometric_transform",

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -3,7 +3,7 @@
 #include <utility>
 #include <vector>
 
-#include "optitrack/optitrack_frame_t.hpp"
+#include <fmt/format.h>
 
 #include "drake/common/text_logging.h"
 #include "drake/math/quaternion.h"
@@ -13,9 +13,51 @@
 namespace drake {
 namespace manipulation {
 namespace perception {
+
 using systems::Context;
 using systems::DiscreteValues;
 using systems::BasicVector;
+
+Isometry3<double> ExtractOptitrackPose(
+    const optitrack::optitrack_rigid_body_t& body) {
+  // The optitrack quaternion ordering is X-Y-Z-W and this needs fitting into
+  // Eigen's W-X-Y-Z ordering.
+  auto& q_xyzw = body.quat;
+  Eigen::Quaterniond q_wxyz(q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]);
+  // Pose of rigid body frame `B` in Optitrack frame `O`.
+  Isometry3<double> X_OB;
+  X_OB.linear() = q_wxyz.toRotationMatrix();
+  X_OB.translation() =
+      Eigen::Vector3d(body.xyz[0], body.xyz[1], body.xyz[2]);
+  X_OB.makeAffine();
+  return X_OB;
+}
+
+std::map<int, Isometry3<double>> ExtractOptitrackPoses(
+    const optitrack::optitrack_frame_t& frame) {
+  std::map<int, Isometry3<double>> poses;
+  for (auto& body : frame.rigid_bodies) {
+    poses[body.id] = ExtractOptitrackPose(body);
+  }
+  return poses;
+}
+
+optional<optitrack::optitrack_rigid_body_t> FindOptitrackBody(
+      const optitrack::optitrack_frame_t& message, int object_id) {
+  for (auto& body : message.rigid_bodies) {
+    if (body.id == object_id) return body;
+  }
+  return nullopt;
+}
+
+optional<int> FindOptitrackObjectId(
+    const optitrack::optitrack_data_descriptions_t& message,
+    const std::string& object_name) {
+  for (auto& desc : message.rigid_bodies) {
+    if (desc.name == object_name) return desc.id;
+  }
+  return nullopt;
+}
 
 OptitrackPoseExtractor::OptitrackPoseExtractor(
     int object_id, const Isometry3<double>& X_WO,
@@ -45,41 +87,13 @@ void OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
   // Update world state from inputs.
   const systems::AbstractValue* input = this->EvalAbstractInput(context, 0);
   DRAKE_ASSERT(input != nullptr);
-  const auto& pose_message = input->GetValue<optitrack::optitrack_frame_t>();
-
-  internal_state = Isometry3<double>::Identity();
-
-  std::vector<optitrack::optitrack_rigid_body_t> rigid_bodies =
-      pose_message.rigid_bodies;
-
-  // Lookup and verify if object exists and extract vector index.
-  bool body_exists = false;
-  size_t vector_index;
-  for (vector_index = 0; vector_index < rigid_bodies.size(); ++vector_index) {
-    if (rigid_bodies[vector_index].id == object_id_) {
-      body_exists = true;
-      break;
-    }
+  auto& message = input->GetValue<optitrack::optitrack_frame_t>();
+  auto body = FindOptitrackBody(message, object_id_);
+  if (!body.has_value()) {
+    throw std::runtime_error(fmt::format(
+        "optitrack: id {} not found", object_id_));
   }
-  DRAKE_THROW_UNLESS(body_exists);
-
-  // The optitrack quaternion ordering is X-Y-Z-W and this needs fitting into
-  // Eigen's W-X-Y-Z ordering.
-  Eigen::Quaterniond quaternion(
-      rigid_bodies[vector_index].quat[3], rigid_bodies[vector_index].quat[0],
-      rigid_bodies[vector_index].quat[1], rigid_bodies[vector_index].quat[2]);
-
-  // Transform from world frame W to rigid body frame B.
-  Isometry3<double> X_OB;
-  X_OB.linear() = quaternion.toRotationMatrix();
-  X_OB.translation() = Eigen::Vector3d(rigid_bodies[vector_index].xyz[0],
-                                       rigid_bodies[vector_index].xyz[1],
-                                       rigid_bodies[vector_index].xyz[2]);
-
-  X_OB.makeAffine();
-  Isometry3<double> X_WB = X_WO_ * X_OB;
-
-  internal_state = X_WB;
+  internal_state = X_WO_ * ExtractOptitrackPose(*body);
 }
 
 void OptitrackPoseExtractor::OutputMeasuredPose(

--- a/manipulation/perception/optitrack_pose_extractor.h
+++ b/manipulation/perception/optitrack_pose_extractor.h
@@ -1,14 +1,52 @@
 #pragma once
 
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "optitrack/optitrack_data_descriptions_t.hpp"
+#include "optitrack/optitrack_frame_t.hpp"
+
+#include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace manipulation {
 namespace perception {
+
+/**
+ * Gets the pose of an Optitrack rigid body.
+ * @returns X_OB, the pose of the body `B` in the optitrack frame `O`.
+ */
+Isometry3<double> ExtractOptitrackPose(
+    const optitrack::optitrack_rigid_body_t& message);
+
+/**
+ * Extracts poses of all objects from an Optitrack message.
+ * @returns Mapping from object ID to pose.
+ */
+std::map<int, Isometry3<double>> ExtractOptitrackPoses(
+    const optitrack::optitrack_frame_t& frame);
+
+/**
+ * Gets a rigid body from an optitrack frame message given an object ID.
+ * @param message Optitrack message.
+ * @param object_id ID to be searched for in the frame message.
+ * @returns Rigid body object, or `nullopt` if not found.
+ */
+optional<optitrack::optitrack_rigid_body_t> FindOptitrackBody(
+      const optitrack::optitrack_frame_t& message, int object_id);
+
+/**
+ * Gets the object ID from an Optitrack description message.
+ * @param message Description message.
+ * @returns Object ID if found, or `nullopt` if not found.
+ */
+optional<int> FindOptitrackObjectId(
+    const optitrack::optitrack_data_descriptions_t& message,
+    const std::string& object_name);
 
 /**
  * Extracts and provides an output of the pose of a desired object as an

--- a/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -16,6 +16,11 @@ namespace drake {
 namespace manipulation {
 namespace perception {
 
+// @note This tolerance is relatively loose (most likely) because the Optitrack
+// LCM message types use single- rather than double-precision floating point
+// types for quaternions.
+constexpr double kTolerance = 1e-6;
+
 class OptitrackPoseTest : public ::testing::Test {
  public:
   void Initialize(int object_id = 0,
@@ -51,7 +56,8 @@ class OptitrackPoseTest : public ::testing::Test {
 };
 
 TEST_F(OptitrackPoseTest, InvalidObjectTest) {
-  Initialize(2 /* object_id */);
+  const int object_id = 2;
+  Initialize(object_id);
   optitrack::optitrack_frame_t test_frame{};
   optitrack::optitrack_rigid_body_t default_body{};
   default_body.id = 0;
@@ -71,7 +77,8 @@ TEST_F(OptitrackPoseTest, InvalidObjectTest) {
 }
 
 TEST_F(OptitrackPoseTest, InvalidObjectIDTest) {
-  Initialize(1 /* object_id */);
+  const int object_id = 1;
+  Initialize(object_id);
   optitrack::optitrack_frame_t test_frame{};
   optitrack::optitrack_rigid_body_t default_body{};
   default_body.id = 0;
@@ -84,23 +91,29 @@ TEST_F(OptitrackPoseTest, InvalidObjectIDTest) {
 }
 
 TEST_F(OptitrackPoseTest, PoseComparisonTest) {
-  Initialize(0 /* object_id */);
+  const int object_id = 0;
+  Isometry3<double> X_WO;
+  X_WO.translation() << 1, 2, 3;
+  X_WO.linear() =
+      Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitX()).matrix();
+  X_WO.makeAffine();
+  Initialize(object_id, X_WO);
   optitrack::optitrack_frame_t test_frame{};
   optitrack::optitrack_rigid_body_t default_body{};
 
   // An arbitrarily chosen test pose is assigned to the default_body.
-  Isometry3<double> test_pose;
-  test_pose.translation() << 0.01, -5.0, 10.10;
-
-  test_pose.linear() =
+  Isometry3<double> X_OB_expected;
+  X_OB_expected.translation() << 0.01, -5.0, 10.10;
+  X_OB_expected.linear() =
       Eigen::AngleAxisd(0.75 * M_PI, Eigen::Vector3d::UnitX()) *
       Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitY()).matrix();
+  X_OB_expected.makeAffine();
 
-  default_body.xyz[0] = test_pose.translation()[0];
-  default_body.xyz[1] = test_pose.translation()[1];
-  default_body.xyz[2] = test_pose.translation()[2];
+  default_body.xyz[0] = X_OB_expected.translation()[0];
+  default_body.xyz[1] = X_OB_expected.translation()[1];
+  default_body.xyz[2] = X_OB_expected.translation()[2];
 
-  Eigen::Quaterniond test_pose_quaternion(test_pose.linear());
+  Eigen::Quaterniond test_pose_quaternion(X_OB_expected.linear());
   default_body.quat[0] = test_pose_quaternion.x();
   default_body.quat[1] = test_pose_quaternion.y();
   default_body.quat[2] = test_pose_quaternion.z();
@@ -109,64 +122,49 @@ TEST_F(OptitrackPoseTest, PoseComparisonTest) {
 
   test_frame.rigid_bodies.push_back(default_body);
 
-  Isometry3<double> extracted_pose;
-  EXPECT_NO_THROW(extracted_pose = UpdateStateCalcOutput(test_frame));
+  // Non-systems tests.
 
-  // Compare translation.
-  EXPECT_TRUE(CompareMatrices(extracted_pose.translation(),
-                              test_pose.translation(), 1e-3,
-                              MatrixCompareType::absolute));
+  // - `ExtractPose`.
+  Isometry3<double> X_OB_direct =
+      ExtractOptitrackPose(*FindOptitrackBody(test_frame, object_id));
+  EXPECT_TRUE(CompareMatrices(
+      X_OB_direct.matrix(), X_OB_expected.matrix(),
+      kTolerance, MatrixCompareType::absolute));
 
-  // Compare quaternions.
-  EXPECT_TRUE(CompareMatrices(extracted_pose.linear(), test_pose.linear(),
-                              1e-3, MatrixCompareType::absolute));
+  // - `ExtractOptitrackPoses`.
+  using Map = std::map<int, Isometry3<double>>;
+  const Map all_poses = ExtractOptitrackPoses(test_frame);
+  const Map all_poses_expected = {{0, X_OB_expected}};
+  EXPECT_EQ(all_poses.size(), all_poses_expected.size());
+  for (auto& pair : all_poses) {
+    Isometry3<double> X_OBi = pair.second;
+    Isometry3<double> X_OBi_expected = all_poses_expected.at(pair.first);
+    EXPECT_TRUE(CompareMatrices(
+        X_OBi.matrix(), X_OBi_expected.matrix(),
+        kTolerance, MatrixCompareType::absolute));
+  }
+
+  // - Negative test for `FindOptitrackBody`.
+  EXPECT_FALSE(FindOptitrackBody(test_frame, 999).has_value());
+
+  // Systems test.
+  const Isometry3<double> X_WB_expected = X_WO * X_OB_expected;
+  Isometry3<double> X_WB;
+  EXPECT_NO_THROW(X_WB = UpdateStateCalcOutput(test_frame));
+
+  // Compare.
+  EXPECT_TRUE(CompareMatrices(
+      X_WB.matrix(), X_WB_expected.matrix(),
+      kTolerance, MatrixCompareType::absolute));
 }
 
-TEST_F(OptitrackPoseTest, PoseInReferenceFrameTest) {
-  // Arbitrarily chosen Transform from Drake World frame to Optitrack Frame.
-  Isometry3<double> X_WOp;
-  X_WOp.translation() << 7, 10, -4.5;
-  X_WOp.linear() =
-      Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitX()).matrix();
-  Initialize(0 /* object_id */, X_WOp);
+TEST_F(OptitrackPoseTest, FindObject) {
+  optitrack::optitrack_data_descriptions_t message;
+  message.rigid_bodies = {{"test", 10}};
+  message.num_rigid_bodies = message.rigid_bodies.size();
 
-  optitrack::optitrack_frame_t test_frame{};
-  optitrack::optitrack_rigid_body_t default_body{};
-
-  // An arbitrarily chosen test pose is assigned to the default_body.
-  Isometry3<double> test_pose;
-  test_pose.translation() << 0.01, -5.0, 10.10;
-
-  test_pose.linear() =
-      Eigen::AngleAxisd(0.75 * M_PI, Eigen::Vector3d::UnitX()) *
-      Eigen::AngleAxisd(-0.75 * M_PI, Eigen::Vector3d::UnitY()).matrix();
-
-  default_body.xyz[0] = test_pose.translation()[0];
-  default_body.xyz[1] = test_pose.translation()[1];
-  default_body.xyz[2] = test_pose.translation()[2];
-
-  Eigen::Quaterniond test_pose_quaternion(test_pose.linear());
-  default_body.quat[0] = test_pose_quaternion.x();
-  default_body.quat[1] = test_pose_quaternion.y();
-  default_body.quat[2] = test_pose_quaternion.z();
-  default_body.quat[3] = test_pose_quaternion.w();
-  default_body.id = 0;
-
-  test_frame.rigid_bodies.push_back(default_body);
-
-  Isometry3<double> transformed_test_pose = X_WOp * test_pose;
-
-  Isometry3<double> extracted_pose;
-  EXPECT_NO_THROW(extracted_pose = UpdateStateCalcOutput(test_frame));
-
-  EXPECT_TRUE(CompareMatrices(extracted_pose.translation(),
-                              transformed_test_pose.translation(), 1e-3,
-                              MatrixCompareType::absolute));
-
-  // Compare quaternions.
-  EXPECT_TRUE(CompareMatrices(extracted_pose.linear(),
-                              transformed_test_pose.linear(), 1e-3,
-                              MatrixCompareType::absolute));
+  EXPECT_EQ(*FindOptitrackObjectId(message, "test"), 10);
+  EXPECT_FALSE(FindOptitrackObjectId(message, "blergh").has_value());
 }
 
 }  // namespace perception


### PR DESCRIPTION
When tinkering with the optitrack setup, I found I wanted to know the ID of the object that couldn't be found. This fixes that.

Additionally, in Anzu, the current implementation of one of our demos does a lot of LCM shindiggery to get Optitrack information. This adds `GetPose`, to consolidate that functionality (given that the object ID and `X_WO` is already contained within `OptitrackPoseExtrator`).

\cc @naveenoid on the visibility of `PoseSmoother`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8312)
<!-- Reviewable:end -->
