### PR TITLE
Rename drake_visualizer.impl to drake_visualizer_py for downstream projects to access

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -5,8 +5,10 @@ load("//tools/skylark:drake_runfiles_binary.bzl", "drake_runfiles_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO(eric.cousineau): Consider using a `./run`-like script for this, rather
+# than `drake_runfiles_binary`. Then this can be renamed to `drake_visualizer`.
 py_binary(
-    name = "drake_visualizer.impl",
+    name = "drake_visualizer_py",
     srcs = ["//tools/workspace/drake_visualizer:drake_visualizer.py"],
     data = [
         "//automotive/models:prod_models",
@@ -14,7 +16,6 @@ py_binary(
         "@drake_visualizer",
     ],
     main = "//tools/workspace/drake_visualizer:drake_visualizer.py",
-    visibility = ["//visibility:private"],
     # Python libraries to import.
     deps = [
         "//lcmtypes:lcmtypes_py",
@@ -26,7 +27,7 @@ py_binary(
 
 drake_runfiles_binary(
     name = "drake_visualizer",
-    target = ":drake_visualizer.impl",
+    target = ":drake_visualizer_py",
 )
 
 # === config_setting rules ===


### PR DESCRIPTION
Ran into a case where I wanted to tack on a few more Python libraries in Anzu, and the easiest way was to incorporate this without `drake_runfiles_binary` getting in the way.

Specifically, I ported Sammy's `big_optitrack_visualizer` to a (reusable) module, put this on the Python path, and then included `show_optitrack` as an application-specific incantation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8314)
<!-- Reviewable:end -->
