### PR TITLE
drake_visualizer: Add Bazel test for CI

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -30,6 +30,16 @@ drake_runfiles_binary(
     target = ":drake_visualizer_py",
 )
 
+sh_test(
+    name = "drake_visualizer_test",
+    srcs = [":drake_visualizer"],
+    # This argument is not present in the output of `--help`, but does take
+    # effect. Unfortunately, this does create a graphical window.
+    args = ["--testing"],
+    # This may not work without `local` on Ubuntu.
+    tags = ["local"],
+)
+
 # === config_setting rules ===
 
 config_setting(


### PR DESCRIPTION
Closes #7050

Presently, I can only test this locally on my machine once I revert #7851. I'm guessing the `local` tag may not be necessary once #8322 is resolved.

@jwnimmer-tri This test does create a window at present. Is this time that we should add something like a `ci_only` tag (or maybe `shows_windows`), and have `drake-ci` ensure that it tests that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8324)
<!-- Reviewable:end -->
