### PR TITLE
Fix Wdeprecated warnings (common/trajectories)

### DIFF
--- a/common/trajectories/exponential_plus_piecewise_polynomial.h
+++ b/common/trajectories/exponential_plus_piecewise_polynomial.h
@@ -6,6 +6,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
@@ -15,22 +16,14 @@ namespace trajectories {
 /**
  * y(t) = K * exp(A * (t - t_j)) * alpha.col(j) + piecewise_polynomial_part(t)
  */
-
 template <typename T>
-class ExponentialPlusPiecewisePolynomial
+class ExponentialPlusPiecewisePolynomial final
     : public PiecewiseTrajectory<T> {
  public:
-  typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
-      MatrixX;
+  // We are final, so this is okay.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ExponentialPlusPiecewisePolynomial)
 
- private:
-  MatrixX K_;
-  MatrixX A_;
-  MatrixX alpha_;
-  PiecewisePolynomial<T> piecewise_polynomial_part_;
-
- public:
-  ExponentialPlusPiecewisePolynomial();
+  ExponentialPlusPiecewisePolynomial() = default;
 
   template <typename DerivedK, typename DerivedA, typename DerivedAlpha>
   ExponentialPlusPiecewisePolynomial(
@@ -57,13 +50,11 @@ class ExponentialPlusPiecewisePolynomial
   ExponentialPlusPiecewisePolynomial(
       const PiecewisePolynomial<T>& piecewise_polynomial_part);
 
-  virtual ~ExponentialPlusPiecewisePolynomial() {}
+  ~ExponentialPlusPiecewisePolynomial() override = default;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 
-  // TODO(tkoolen): fix return type (handle complex etc.)
-  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> value(
-      double t) const override;
+  MatrixX<T> value(double t) const override;
 
   ExponentialPlusPiecewisePolynomial derivative(int derivative_order = 1) const;
 
@@ -77,6 +68,12 @@ class ExponentialPlusPiecewisePolynomial
   Eigen::Index cols() const override;
 
   void shiftRight(double offset);
+
+ private:
+  MatrixX<T> K_;
+  MatrixX<T> A_;
+  MatrixX<T> alpha_;
+  PiecewisePolynomial<T> piecewise_polynomial_part_;
 };
 
 }  // namespace trajectories

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -44,13 +44,8 @@ PiecewisePolynomial<T>::PiecewisePolynomial(
 }
 
 template <typename T>
-PiecewisePolynomial<T>::PiecewisePolynomial() : PiecewiseTrajectory<T>() {
-  // empty
-}
-
-template <typename T>
 std::unique_ptr<Trajectory<T>> PiecewisePolynomial<T>::Clone() const {
-  return std::make_unique<PiecewisePolynomial<T>>(polynomials_, this->breaks());
+  return std::make_unique<PiecewisePolynomial<T>>(*this);
 }
 
 template <typename T>

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -46,18 +46,16 @@ namespace trajectories {
 template <typename T>
 class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
  public:
+  // We are final, so this is okay.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePolynomial)
+
   typedef Polynomial<T> PolynomialType;
   typedef drake::MatrixX<PolynomialType> PolynomialMatrix;
   typedef drake::MatrixX<T> CoefficientMatrix;
   typedef Eigen::Ref<CoefficientMatrix> CoefficientMatrixRef;
 
- public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePolynomial)
-
-  virtual ~PiecewisePolynomial() {}
-
   // default constructor; just leaves segment_times and polynomials empty
-  PiecewisePolynomial();
+  PiecewisePolynomial() = default;
 
   // single segment and/or constant value constructor
   template <typename Derived>
@@ -74,6 +72,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   // Scalar constructor
   PiecewisePolynomial(std::vector<PolynomialType> const& polynomials,
                       std::vector<double> const& breaks);
+
+  ~PiecewisePolynomial() override = default;
 
   std::unique_ptr<Trajectory<T>> Clone() const override;
 

--- a/common/trajectories/piecewise_quaternion.h
+++ b/common/trajectories/piecewise_quaternion.h
@@ -4,9 +4,7 @@
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
-#include "drake/common/eigen_stl_types.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/common/trajectories/piecewise_trajectory.h"
 
 namespace drake {
@@ -36,40 +34,41 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseQuaternionSlerp)
 
-  PiecewiseQuaternionSlerp() {}
+  /**
+   * Builds an empty PiecewiseQuaternionSlerp.
+   */
+  PiecewiseQuaternionSlerp() = default;
 
-  /*
+  /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throw if breaks and quaternions have different length,
+   * @throws std::logic_error if breaks and quaternions have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
       const std::vector<double>& breaks,
-      const eigen_aligned_std_vector<Quaternion<T>>& quaternions);
+      const std::vector<Quaternion<T>>& quaternions);
 
-  /*
+  /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throw if breaks and rot_matrices have different length,
+   * @throws std::logic_error if breaks and rot_matrices have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
       const std::vector<double>& breaks,
-      const eigen_aligned_std_vector<Matrix3<T>>& rot_matrices);
+      const std::vector<Matrix3<T>>& rot_matrices);
 
-  /*
+  /**
    * Builds a PiecewiseQuaternionSlerp.
-   * @throw if breaks and ang_axes have different length,
+   * @throws std::logic_error if breaks and ang_axes have different length,
    * or breaks have length < 2.
    */
   PiecewiseQuaternionSlerp(
       const std::vector<double>& breaks,
-      const eigen_aligned_std_vector<AngleAxis<T>>& ang_axes);
+      const std::vector<AngleAxis<T>>& ang_axes);
 
-  std::unique_ptr<Trajectory<T>> Clone() const override {
-    return std::make_unique<PiecewiseQuaternionSlerp>(this->breaks(),
-                                                      quaternions_);
-  };
+  ~PiecewiseQuaternionSlerp() override = default;
 
+  std::unique_ptr<Trajectory<T>> Clone() const override;
 
   Eigen::Index rows() const override { return 4; }
 
@@ -97,7 +96,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    */
   // TODO(russt): Implement this if/when someone needs it!
   std::unique_ptr<Trajectory<T>> MakeDerivative(
-  int derivative_order = 1) const override;
+      int derivative_order = 1) const override;
 
   /**
    * Interpolates angular acceleration.
@@ -115,8 +114,7 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    *
    * @return the internal knot points.
    */
-  const eigen_aligned_std_vector<Quaternion<T>> &get_quaternion_knots()
-  const {
+  const std::vector<Quaternion<T>>& get_quaternion_knots() const {
     return quaternions_;
   }
 
@@ -125,14 +123,14 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
    * @p tol seconds, and the angle difference between the corresponding
    * quaternion knot points are within @p tol.
    */
-  bool is_approx(const PiecewiseQuaternionSlerp<T> &other,
-                 const T &tol) const;
+  bool is_approx(const PiecewiseQuaternionSlerp<T>& other,
+                 const T& tol) const;
 
  private:
   // Initialize quaternions_ and computes angular velocity for each segment.
   void Initialize(
-      const std::vector<double> &breaks,
-      const eigen_aligned_std_vector<Quaternion<T>> &quaternions);
+      const std::vector<double>& breaks,
+      const std::vector<Quaternion<T>>& quaternions);
 
   // Computes angular velocity for each segment.
   void ComputeAngularVelocities();
@@ -140,8 +138,8 @@ class PiecewiseQuaternionSlerp final : public PiecewiseTrajectory<T> {
   // Computes the interpolation time within each segment. Result is in [0, 1].
   double ComputeInterpTime(int segment_index, double time) const;
 
-  eigen_aligned_std_vector<Quaternion<T>> quaternions_;
-  eigen_aligned_std_vector<Vector3<T>> angular_velocities_;
+  std::vector<Quaternion<T>> quaternions_;
+  std::vector<Vector3<T>> angular_velocities_;
 };
 
 }  // namespace trajectories

--- a/common/trajectories/piecewise_trajectory.cc
+++ b/common/trajectories/piecewise_trajectory.cc
@@ -21,16 +21,6 @@ PiecewiseTrajectory<T>::PiecewiseTrajectory(std::vector<double> const& breaks)
 }
 
 template <typename T>
-PiecewiseTrajectory<T>::PiecewiseTrajectory() : Trajectory<T>() {
-  // empty
-}
-
-template <typename T>
-PiecewiseTrajectory<T>::~PiecewiseTrajectory() {
-  // empty
-}
-
-template <typename T>
 bool PiecewiseTrajectory<T>::is_time_in_range(double time) const {
   return (time >= start_time() && time <= end_time());
 }

--- a/common/trajectories/piecewise_trajectory.h
+++ b/common/trajectories/piecewise_trajectory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <random>
 #include <vector>
 
@@ -19,15 +20,10 @@ namespace trajectories {
 template <typename T>
 class PiecewiseTrajectory : public Trajectory<T> {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseTrajectory)
-
   /// Minimum delta quantity used for comparing time.
   static constexpr double kEpsilonTime = 1e-10;
 
-  /// @p breaks increments must be greater or equal to kEpsilonTime.
-  explicit PiecewiseTrajectory(std::vector<double> const& breaks);
-
-  virtual ~PiecewiseTrajectory();
+  ~PiecewiseTrajectory() override = default;
 
   int get_number_of_segments() const;
 
@@ -57,10 +53,15 @@ class PiecewiseTrajectory : public Trajectory<T> {
       int num_segments, std::default_random_engine &generator);
 
  protected:
-  bool SegmentTimesEqual(const PiecewiseTrajectory &b,
-                         double tol = kEpsilonTime) const;
+  // Final subclasses are allowed to make copy/move/assign public.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewiseTrajectory)
+  PiecewiseTrajectory() = default;
 
-  PiecewiseTrajectory();
+  /// @p breaks increments must be greater or equal to kEpsilonTime.
+  explicit PiecewiseTrajectory(const std::vector<double>& breaks);
+
+  bool SegmentTimesEqual(const PiecewiseTrajectory& b,
+                         double tol = kEpsilonTime) const;
 
   const std::vector<double>& breaks() const { return breaks_; }
   std::vector<double>& get_mutable_breaks() { return breaks_; }

--- a/common/trajectories/test/exponential_plus_piecewise_polynomial_test.cc
+++ b/common/trajectories/test/exponential_plus_piecewise_polynomial_test.cc
@@ -16,31 +16,27 @@ namespace trajectories {
 
 namespace {
 
-template <typename CoefficientType>
+template <typename T>
 void testSimpleCase() {
-  typedef ExponentialPlusPiecewisePolynomial<CoefficientType>
-      ExponentialPlusPiecewisePolynomialType;
-  typedef typename ExponentialPlusPiecewisePolynomialType::MatrixX MatrixX;
-
   int num_coefficients = 5;
   int num_segments = 1;
 
-  MatrixX K = MatrixX::Random(1, 1);
-  MatrixX A = MatrixX::Random(1, 1);
-  MatrixX alpha = MatrixX::Random(1, 1);
+  MatrixX<T> K = MatrixX<T>::Random(1, 1);
+  MatrixX<T> A = MatrixX<T>::Random(1, 1);
+  MatrixX<T> alpha = MatrixX<T>::Random(1, 1);
 
   default_random_engine generator;
   auto segment_times =
       PiecewiseTrajectory<double>::RandomSegmentTimes(num_segments, generator);
-  auto polynomial_part = test::MakeRandomPiecewisePolynomial<CoefficientType>(
+  auto polynomial_part = test::MakeRandomPiecewisePolynomial<T>(
       1, 1, num_coefficients, segment_times);
 
-  ExponentialPlusPiecewisePolynomial<CoefficientType> expPlusPp(
+  ExponentialPlusPiecewisePolynomial<T> expPlusPp(
       K, A, alpha, polynomial_part);
-  ExponentialPlusPiecewisePolynomial<CoefficientType> derivative =
+  ExponentialPlusPiecewisePolynomial<T> derivative =
       expPlusPp.derivative();
 
-  uniform_real_distribution<CoefficientType> uniform(expPlusPp.start_time(),
+  uniform_real_distribution<T> uniform(expPlusPp.start_time(),
                                                      expPlusPp.end_time());
   double t = uniform(generator);
   auto check =

--- a/common/trajectories/test/piecewise_quaternion_test.cc
+++ b/common/trajectories/test/piecewise_quaternion_test.cc
@@ -34,7 +34,7 @@ Quaternion<double> EulerIntegrateQuaternion(const Quaternion<Scalar>& q0,
 // Checks q[n].dot(q[n-1]) >= 0
 template <typename Scalar>
 bool CheckClosest(
-    const eigen_aligned_std_vector<Quaternion<Scalar>>& quaternions) {
+    const std::vector<Quaternion<Scalar>>& quaternions) {
   if (quaternions.size() <= 1) return true;
   for (size_t i = 1; i < quaternions.size(); ++i) {
     if (quaternions[i].dot(quaternions[i - 1]) < 0) return false;
@@ -72,10 +72,10 @@ bool CheckSlerpInterpolation(const PiecewiseQuaternionSlerp<Scalar>& spline,
 
 // Generates a vector of random orientation using randomized axis angles.
 template <typename Scalar>
-eigen_aligned_std_vector<Quaternion<Scalar>> GenerateRandomQuaternions(
+std::vector<Quaternion<Scalar>> GenerateRandomQuaternions(
     int size, std::default_random_engine* generator) {
   DRAKE_DEMAND(size >= 0);
-  eigen_aligned_std_vector<Quaternion<Scalar>> ret(size);
+  std::vector<Quaternion<Scalar>> ret(size);
   std::uniform_real_distribution<double> uniform(-10, 10);
   for (int i = 0; i < size; ++i) {
     ret[i] = Quaternion<Scalar>(AngleAxis<Scalar>(
@@ -94,7 +94,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
   int N = 10000;
   std::vector<double> time =
       PiecewiseTrajectory<double>::RandomSegmentTimes(N - 1, generator);
-  eigen_aligned_std_vector<Quaternion<double>> quat =
+  std::vector<Quaternion<double>> quat =
       GenerateRandomQuaternions<double>(N, &generator);
 
   PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
@@ -114,13 +114,13 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
   std::vector<double> time = {0, 1.6, 2.32};
   std::vector<double> ang = {1, 2.4 - 2 * M_PI, 5.3};
   Vector3<double> axis = Vector3<double>(1, 2, 3).normalized();
-  eigen_aligned_std_vector<Quaternion<double>> quat(ang.size());
+  std::vector<Quaternion<double>> quat(ang.size());
   for (size_t i = 0; i < ang.size(); ++i) {
     quat[i] = Quaternion<double>(AngleAxis<double>(ang[i], axis));
   }
 
   PiecewiseQuaternionSlerp<double> rot_spline(time, quat);
-  const eigen_aligned_std_vector<Quaternion<double>>& internal_quat =
+  const std::vector<Quaternion<double>>& internal_quat =
       rot_spline.get_quaternion_knots();
 
   EXPECT_TRUE(CheckClosest(internal_quat));
@@ -147,7 +147,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
   std::vector<double> time = {0, 1.6};
   std::vector<double> ang = {-1.3, -1.3 + 2 * M_PI};
   Vector3<double> axis = Vector3<double>(1, 2, 3).normalized();
-  eigen_aligned_std_vector<Quaternion<double>> quat(ang.size());
+  std::vector<Quaternion<double>> quat(ang.size());
   for (size_t i = 0; i < ang.size(); ++i) {
     quat[i] = Quaternion<double>(AngleAxis<double>(ang[i], axis));
   }
@@ -155,7 +155,7 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp,
 
   double t = 0.3 * time[0] + 0.7 * time[1];
 
-  const eigen_aligned_std_vector<Quaternion<double>>& internal_quats =
+  const std::vector<Quaternion<double>>& internal_quats =
       rot_spline.get_quaternion_knots();
   EXPECT_TRUE(CompareMatrices(
       rot_spline.orientation(t).coeffs(),
@@ -171,14 +171,14 @@ GTEST_TEST(TestPiecewiseQuaternionSlerp, TestIsApprox) {
   std::vector<double> time = {0, 1.6};
   std::vector<double> ang = {-1.3, 1};
   Vector3<double> axis = Vector3<double>(1, 2, 3).normalized();
-  eigen_aligned_std_vector<Quaternion<double>> quat(ang.size());
+  std::vector<Quaternion<double>> quat(ang.size());
   for (size_t i = 0; i < ang.size(); ++i) {
     quat[i] = Quaternion<double>(AngleAxis<double>(ang[i], axis));
   }
   PiecewiseQuaternionSlerp<double> traj0(time, quat);
 
   // -q represents the same orientation, so it should result in equality.
-  eigen_aligned_std_vector<Quaternion<double>> quat_neg = quat;
+  std::vector<Quaternion<double>> quat_neg = quat;
   for (size_t i = 0; i < ang.size(); ++i) {
     quat_neg[i].coeffs() *= -1;
   }

--- a/common/trajectories/trajectory.h
+++ b/common/trajectories/trajectory.h
@@ -4,6 +4,7 @@
 
 #include <Eigen/Core>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 
 namespace drake {
@@ -18,13 +19,9 @@ namespace trajectories {
 template <typename T>
 class Trajectory {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
-
-  Trajectory() {}
-  virtual ~Trajectory() {}
+  virtual ~Trajectory() = default;
 
   /**
-   *
    * @return A deep copy of this Trajectory.
    */
   virtual std::unique_ptr<Trajectory<T>> Clone() const = 0;
@@ -58,6 +55,11 @@ class Trajectory {
   virtual double start_time() const = 0;
 
   virtual double end_time() const = 0;
+
+ protected:
+  // Final subclasses are allowed to make copy/move/assign public.
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
+  Trajectory() = default;
 };
 
 }  // namespace trajectories

--- a/manipulation/util/test/trajectory_utils_test.cc
+++ b/manipulation/util/test/trajectory_utils_test.cc
@@ -103,7 +103,7 @@ class PiecewiseCartesianTrajectoryTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::vector<double> times = {1, 2};
-    eigen_aligned_std_vector<AngleAxis<double>> rot_knots(times.size());
+    std::vector<AngleAxis<double>> rot_knots(times.size());
     std::vector<MatrixX<double>> pos_knots(times.size(), MatrixX<double>(3, 1));
 
     rot_knots[0] = AngleAxis<double>(0.3, Vector3<double>::UnitX());
@@ -222,7 +222,7 @@ TEST_F(PiecewiseCartesianTrajectoryTest, TestConstructor) {
 // Tests is_approx().
 TEST_F(PiecewiseCartesianTrajectoryTest, TestIsApprox) {
   std::vector<double> times = {1, 2, 3};
-  eigen_aligned_std_vector<AngleAxis<double>> rot_knots(times.size());
+  std::vector<AngleAxis<double>> rot_knots(times.size());
   std::vector<MatrixX<double>> pos_knots(times.size(), MatrixX<double>(3, 1));
   pos_knots[0] << -3, 1, 0;
   pos_knots[1] << -2, -1, 5;

--- a/manipulation/util/trajectory_utils.h
+++ b/manipulation/util/trajectory_utils.h
@@ -137,7 +137,7 @@ class PiecewiseCartesianTrajectory {
       const std::vector<T>& times, const std::vector<Isometry3<T>>& poses,
       const Vector3<T>& vel0, const Vector3<T>& vel1) {
     std::vector<MatrixX<T>> pos_knots(poses.size());
-    eigen_aligned_std_vector<Matrix3<T>> rot_knots(poses.size());
+    std::vector<Matrix3<T>> rot_knots(poses.size());
     for (size_t i = 0; i < poses.size(); ++i) {
       pos_knots[i] = poses[i].translation();
       rot_knots[i] = poses[i].linear();


### PR DESCRIPTION
When using clang, `Wdeprecated` warns about deprecated implicitly-defined copy constructors (happens most often due to user-defined destructor):
http://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor

This patch explicitly defines the copy, move, and assignment semantics and visibility of the virtual class hierarchy used by the trajectory classes.  Thus, the warning is silenced and the code is safer.

This also changes all `Clone()` implementations to use the copy constructor (and be defined in the .cc file for consistency), instead of listing out member fields by hand.

We clean up some related items while we're here:
- Move private members to end of class.
- Order ctor/dtor/clone class declaration per cppguide.
- Use `= default` for all defaulted ctors and dtors consistently.
- Use `drake::MatrixX` spelling consistently.
- Use west-const and ref-with-typename more consistently.
- Repair a few doxygen nits.

We stop using `eigen_aligned_std_vector`, because it serves no purpose on our supported platforms.  Best to get this API change in as this class is already being refactored, before other code starts to use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8330)
<!-- Reviewable:end -->
