### PR TITLE
Use /usr/local/opt/python@2/bin/{python|pip}2.7 on macOS

### DIFF
--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -63,19 +63,18 @@ To check this:
 
 .. note::
 
-    If you are on Mac, you must ensure that you have Homebrew Python installed,
-    and are using ``python@2`` from Homebrew Python to execute these scripts.
-    You may do this by either explicitly using ``python2`` on the command line,
-    or follow the instructions from ``brew info python@2``::
+    If you are using macOS, you must ensure that you are using the
+    ``python2.7`` executable located at
+    ``/usr/local/opt/python@2/bin/python2.7`` to run these scripts. For
+    convenience, you may modify your ``PATH`` by adding the following to
+    ``~/.bash_profile`` ::
 
-        This formula installs a python2 executable to /usr/local/bin.
-        If you wish to have this formula's python executable in your PATH then
-        add the following to ~/.bash_profile:
-          export PATH="/usr/local/opt/python@2/libexec/bin:$PATH"
+        export PATH="/usr/local/opt/python@2/bin:$PATH"
 
     Once you have done this, if you would like to use ``jupyter`` then be sure
-    to install it via ``pip2 install jupyter`` (*not* via Homebrew) to ensure
-    that it uses the correct ``PYTHONPATH``.
+    to install it via ``pip2.7 install jupyter`` (*not*
+    ``brew install jupyter``) to ensure that it uses the correct
+    ``PYTHONPATH``.
 
     ..
         Developers: Ensure this is synchronized with the steps in

--- a/setup/mac/binary_distribution/install_prereqs.sh
+++ b/setup/mac/binary_distribution/install_prereqs.sh
@@ -21,4 +21,4 @@ if [[ ! -f /usr/include/expat.h || ! -f /usr/include/zlib.h ]]; then
   xcode-select --install
 fi
 
-/usr/local/opt/python@2/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"
+/usr/local/opt/python@2/bin/pip2.7 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"

--- a/setup/mac/source_distribution/install_prereqs.sh
+++ b/setup/mac/source_distribution/install_prereqs.sh
@@ -15,4 +15,4 @@ fi
 brew update
 brew bundle --file="${BASH_SOURCE%/*}/Brewfile"
 
-/usr/local/opt/python@2/bin/pip2 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"
+/usr/local/opt/python@2/bin/pip2.7 install --upgrade --requirement "${BASH_SOURCE%/*}/requirements.txt"

--- a/setup/mac/source_distribution/install_prereqs_user_environment.sh
+++ b/setup/mac/source_distribution/install_prereqs_user_environment.sh
@@ -11,13 +11,13 @@ set -euo pipefail
 # We require that Bazel uses the Python installed by Homebrew.
 # TODO(jamiesnape): Also support a .bazelrc located in the WORKSPACE.
 if [[ ! -f "${HOME}/.bazelrc" ]] || ! grep -q '^build --python_path=' "${HOME}/.bazelrc"; then
-  echo "We need to add 'build --python_path=/usr/local/opt/python@2/libexec/bin/python' to ~/.bazelrc."
+  echo "We need to add 'build --python_path=/usr/local/opt/python@2/bin/python2.7' to ~/.bazelrc."
   read -r -p 'Do you want to continue (y/N)? ' reply
   if [[ "${reply}" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
-    echo 'build --python_path=/usr/local/opt/python@2/libexec/bin/python' >> "${HOME}/.bazelrc"
+    echo 'build --python_path=/usr/local/opt/python@2/bin/python2.7' >> "${HOME}/.bazelrc"
   fi
 fi
 
-if [[ ! -f "${HOME}/.bazelrc" ]] || ! grep -q '^build --python_path=/usr/local/opt/python@2/libexec/bin/python$' "${HOME}/.bazelrc"; then
-  echo 'Using a python other than /usr/local/opt/python@2/libexec/bin/python is NOT supported' >&2
+if [[ ! -f "${HOME}/.bazelrc" ]] || ! grep -q '^build --python_path=/usr/local/opt/python@2/bin/python2.7$' "${HOME}/.bazelrc"; then
+  echo 'Using a python other than /usr/local/opt/python@2/bin/python2.7 is NOT supported' >&2
 fi


### PR DESCRIPTION
I am just going to say use `python2.7` and `pip2.7` to limit accidental invocations of `python3` and `pip3` and match our shebang lines.

Relates #8231.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8332)
<!-- Reviewable:end -->
