### PR TITLE
handles a TODO in direct transcription to call GetUniquePeriodicDiscreteUpdateAttribute

### DIFF
--- a/systems/trajectory_optimization/direct_transcription.cc
+++ b/systems/trajectory_optimization/direct_transcription.cc
@@ -97,15 +97,22 @@ class DiscreteTimeSystemConstraint : public solvers::Constraint {
   AutoDiffXd evaluation_time_{0};
 };
 
+double get_period(const System<double>* system) {
+  optional<PeriodicEventData> periodic_data =
+      system->GetUniquePeriodicDiscreteUpdateAttribute();
+  DRAKE_DEMAND(periodic_data.has_value());
+  DRAKE_DEMAND(periodic_data->offset_sec() == 0.0);
+  return periodic_data->period_sec();
+}
+
 }  // end namespace
 
 DirectTranscription::DirectTranscription(const System<double>* system,
                                          const Context<double>& context,
                                          int num_time_samples)
-    : MultipleShooting(system->get_num_total_inputs(),
-                       context.get_num_total_states(), num_time_samples,
-                       0.1),  // TODO(russt): Replace this with the actual
-                              // sample time of the discrete update (#6878).
+    : MultipleShooting(
+          system->get_num_total_inputs(), context.get_num_total_states(),
+          num_time_samples, get_period(system)),
       discrete_time_system_(true) {
   // Note: this constructor is for discrete-time systems.  For continuous-time
   // systems, you must use a different constructor that specifies the timesteps.
@@ -278,11 +285,7 @@ void DirectTranscription::ConstrainEqualInputAtFinalTwoTimesteps() {
 
 void DirectTranscription::ValidateSystem(const System<double>& system,
                                          const Context<double>& context) {
-  DRAKE_THROW_UNLESS(context.has_only_discrete_state());
-
-  // TODO(russt): Check that the system has ONLY simple periodic updates
-  // (#6878).
-
+  DRAKE_DEMAND(context.has_only_discrete_state());
   DRAKE_DEMAND(context.get_num_discrete_state_groups() == 1);
   DRAKE_DEMAND(num_states() == context.get_discrete_state(0).size());
   DRAKE_DEMAND(system.get_num_input_ports() <= 1);

--- a/systems/trajectory_optimization/direct_transcription.h
+++ b/systems/trajectory_optimization/direct_transcription.h
@@ -37,7 +37,6 @@ class DirectTranscription : public MultipleShooting {
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
   /// @param num_time_samples The number of knot points in the trajectory.
-  /// @throws std::runtime_error If the system is not discrete time (only).
   DirectTranscription(const System<double>* system,
                       const Context<double>& context, int num_time_samples);
 
@@ -53,8 +52,6 @@ class DirectTranscription : public MultipleShooting {
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
   /// @param num_time_samples The number of knot points in the trajectory.
-  /// @throws std::runtime_error If the system is not discrete time (only).
-
   DirectTranscription(const LinearSystem<double>* system,
                       const Context<double>& context, int num_time_samples);
 
@@ -70,7 +67,6 @@ class DirectTranscription : public MultipleShooting {
   ///    context after calling this method will NOT impact the trajectory
   ///    optimization.
   /// @param num_time_samples The number of knot points in the trajectory.
-  /// @throws std::runtime_error If the system is not discrete time (only).
   DirectTranscription(const TimeVaryingLinearSystem<double>* system,
                       const Context<double>& context, int num_time_samples);
 

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -20,18 +20,6 @@ namespace {
 using symbolic::Variable;
 using symbolic::Expression;
 
-GTEST_TEST(DirectTranscriptionTest, DiscreteTimeConstructorThrows) {
-  // Construct a trivial continuous time system.
-  const Eigen::Matrix2d A = Eigen::Matrix2d::Identity();
-  const Eigen::Matrix<double, 2, 0> B;
-  const Eigen::Matrix<double, 0, 2> C;
-  const Eigen::Matrix<double, 0, 0> D;
-  LinearSystem<double> system(A, B, C, D);
-
-  const auto context = system.CreateDefaultContext();
-  EXPECT_THROW(DirectTranscription(&system, *context, 3), std::runtime_error);
-}
-
 namespace {
 
 template <typename T>


### PR DESCRIPTION
now that it exists.
changes a DRAKE_THROW_UNLESS to DRAKE_DEMAND, because the API was oddly inconsistent on the way it was throwing on just the one case.
+ minor cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8335)
<!-- Reviewable:end -->
