### PR TITLE
Disable 'schunk_wsg_lift_test' for coverage builds

### DIFF
--- a/examples/schunk_wsg/BUILD.bazel
+++ b/examples/schunk_wsg/BUILD.bazel
@@ -57,6 +57,9 @@ drake_cc_googletest(
     ],
     # This test is prohibitively slow with --compilation_mode=dbg.
     disable_in_compilation_mode_dbg = True,
+    # TODO(betsymcphail): Re-enable this test when it no longer
+    # causes timeouts in kcov.
+    tags = ["no_kcov"],
     deps = [
         "//common:essential",
         "//common:find_resource",


### PR DESCRIPTION
Examples of failing tests:
https://drake-cdash.csail.mit.edu/index.php?project=Drake&date=2018-03-12&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=clang-bazel-nightly-coverage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8342)
<!-- Reviewable:end -->
