### PR TITLE
Revert "Switch to SNOPT 7.6.1 2018-01-20 release (#8263)"

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -140,7 +140,7 @@ The Drake Bazel build currently supports the following proprietary solvers:
 
  * Gurobi 7.5.2
  * MOSEK 7.1
- * SNOPT 7.6
+ * SNOPT 7.2
 
 .. _gurobi:
 
@@ -187,8 +187,8 @@ these tests.  If you will be developing with MOSEK regularly, you may wish
 to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
 See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 
-SNOPT
------
+SNOPT 7.2
+---------
 
 Drake provides two mechanisms to include the SNOPT sources.  One mechanism is
 to provide your own SNOPT source archive.  The other mechanism is via access to
@@ -198,8 +198,8 @@ Using your own source archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download the SNOPT sources from the distributor in ``.tar.gz`` format (e.g.,
-   named ``snopt7.6.tar.gz``).
-2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.6.tar.gz``
+   named ``snopt7.5-1.4.tar.gz``).
+2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.5-1.4.tar.gz``
 
 Using the RobotLocomotion git repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/multibody/test/test_ik.cc
+++ b/multibody/test/test_ik.cc
@@ -107,7 +107,7 @@ GTEST_TEST(testIK, iiwaIK) {
   inverseKin(model.get(), q0, q0, constraint_array.size(),
              constraint_array.data(), ikoptions, &q_sol, &info,
              &infeasible_constraint);
-  ASSERT_EQ(info, 1);
+  EXPECT_EQ(info, 1);
 
   // Check that our constrained joint is within where we tried to constrain it.
   EXPECT_GE(q_sol(joint_position_start_idx(0)), joint_lb(0));
@@ -117,7 +117,7 @@ GTEST_TEST(testIK, iiwaIK) {
   const KinematicsCache<double> cache = model->doKinematics(q_sol);
   EXPECT_TRUE(CompareMatrices(
       pos_end, model->relativeTransform(cache, 0, link_7_idx).translation(),
-      pos_tol + 2e-6, MatrixCompareType::absolute));
+      pos_tol + 1e-6, MatrixCompareType::absolute));
 }
 
 GTEST_TEST(testIK, iiwaIKInfeasible) {

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -82,7 +82,7 @@ def _impl(repo_ctx):
 snopt_repository = repository_rule(
     attrs = {
         "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
-        "commit": attr.string(default = "c17db3769e59d4a8d651631d5d79641cecca0504"),  # noqa
+        "commit": attr.string(default = "0f475624131c9ca4d5624e74c3f8273ccc926f9b"),  # noqa
         "use_drake_build_rules": attr.bool(default = True),
     },
     environ = ["SNOPT_PATH"],


### PR DESCRIPTION
This reverts commit 9fea3ae292860c0a84007a280f0fadd92288261e.

When running `snopt_solver_test` under asan, there is some kind of out-of-bounds access to global memory when using 7.6.1.