### PR TITLE
De-duplicate cflags in pkg_config.bzl

### DIFF
--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -128,9 +128,13 @@ def setup_pkg_config_repository(repository_ctx):
     # We process in reserve order to keep our loop index unchanged by a pop.
     for cflag in cflags:
         if cflag.startswith("-I"):
-            absolute_includes += [cflag[2:]]
+            value = cflag[2:]
+            if value not in absolute_includes:
+                absolute_includes.append(value)
         elif cflag.startswith("-D"):
-            defines += [cflag[2:]]
+            value = cflag[2:]
+            if value not in defines:
+                defines.append(value)
         elif cflag in [
                 "-frounding-math",
                 "-ffloat-store",


### PR DESCRIPTION
In particular, duplicated `-Ifoo` flags would cause hard failure because we attempted to symlink all of them into the identical local name.

For example, `pkg-config --cflags Qt5Widgets` on Ubuntu 16.04 yields:
```
 -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets
 -I/usr/include/x86_64-linux-gnu/qt5
 -I/usr/include/x86_64-linux-gnu/qt5/QtGui
 -I/usr/include/x86_64-linux-gnu/qt5
 -I/usr/include/x86_64-linux-gnu/qt5/QtCore
 -I/usr/include/x86_64-linux-gnu/qt5
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8350)
<!-- Reviewable:end -->
