### PR TITLE
Expose joint_limit_{min,max} in python RBT.

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -208,7 +208,9 @@ PYBIND11_MODULE(rigid_body_tree, m) {
          [](const RigidBodyTree<double>* self, const VectorX<double>& v) {
            return self->frictionTorques(v);
          })
-    .def_readonly("B", &RigidBodyTree<double>::B);
+    .def_readonly("B", &RigidBodyTree<double>::B)
+    .def_readonly("joint_limit_min", &RigidBodyTree<double>::joint_limit_min)
+    .def_readonly("joint_limit_max", &RigidBodyTree<double>::joint_limit_max);
 
   py::class_<KinematicsCache<double> >(m, "KinematicsCacheDouble");
   py::class_<KinematicsCache<AutoDiffXd> >(m, "KinematicsCacheAutoDiffXd");

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 import pydrake
+from pydrake.common import FindResourceOrThrow
 from pydrake.forwarddiff import jacobian
 from pydrake.multibody.parsers import PackageMap
 from pydrake.multibody.rigid_body_tree import (
@@ -19,8 +20,8 @@ class TestRigidBodyTree(unittest.TestCase):
     def test_kinematics_api(self):
         # TODO(eric.cousineau): Reduce these tests to only test API, and do
         # simple sanity checks on the numbers.
-        tree = RigidBodyTree(os.path.join(
-            pydrake.getDrakePath(), "examples/pendulum/Pendulum.urdf"))
+        tree = RigidBodyTree(FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf"))
         num_q = 7
         num_v = 7
         self.assertEqual(tree.number_of_positions(), num_q)
@@ -76,15 +77,15 @@ class TestRigidBodyTree(unittest.TestCase):
         self.assertTrue(np.allclose(T, T_expected))
 
     def test_flat_terrain(self):
-        tree = RigidBodyTree(os.path.join(
-            pydrake.getDrakePath(), "examples/pendulum/Pendulum.urdf"))
+        tree = RigidBodyTree(FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf"))
 
         # Test that AddFlatTerrainToWorld is spelled correctly.
         AddFlatTerrainToWorld(tree)
 
     def test_kinematics_com_api(self):
-        tree = RigidBodyTree(os.path.join(
-            pydrake.getDrakePath(), "examples/pendulum/Pendulum.urdf"))
+        tree = RigidBodyTree(FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf"))
         num_q = 7
         num_v = 7
         q = np.zeros(num_q)
@@ -109,8 +110,8 @@ class TestRigidBodyTree(unittest.TestCase):
         self.assertTrue(np.allclose(c, [0.0, 0.0, -0.5]))
 
     def test_dynamics_api(self):
-        urdf_path = os.path.join(
-            pydrake.getDrakePath(), "examples/pendulum/Pendulum.urdf")
+        urdf_path = FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf")
         tree = RigidBodyTree(
             urdf_path, floating_base_type=FloatingBaseType.kRollPitchYaw)
 
@@ -156,8 +157,8 @@ class TestRigidBodyTree(unittest.TestCase):
         # don't break the test), and split pure API testing of
         # VisualElement and Geometry over to shapes_test while keeping
         # RigidBodyTree and RigidBody visual element extraction here.
-        urdf_path = os.path.join(
-            pydrake.getDrakePath(), "examples/pendulum/Pendulum.urdf")
+        urdf_path = FindResourceOrThrow(
+            "drake/examples/pendulum/Pendulum.urdf")
 
         tree = RigidBodyTree(
             urdf_path,
@@ -206,11 +207,18 @@ class TestRigidBodyTree(unittest.TestCase):
     def test_atlas_parsing(self):
         # Sanity check on parsing.
         pm = PackageMap()
-        model = os.path.join(
-            pydrake.getDrakePath(), "examples", "atlas", "urdf",
-            "atlas_minimal_contact.urdf")
+        model = FindResourceOrThrow(
+            "drake/examples/atlas/urdf/atlas_minimal_contact.urdf")
         pm.PopulateUpstreamToDrake(model)
         tree = RigidBodyTree(
             model, package_map=pm,
             floating_base_type=FloatingBaseType.kRollPitchYaw)
         self.assertEqual(tree.get_num_actuators(), 30)
+        # Sanity checks joint limits
+        #  - Check sizes.
+        self.assertEqual(tree.joint_limit_min.size, tree.number_of_positions())
+        self.assertEqual(tree.joint_limit_max.size, tree.number_of_positions())
+        #  - Check extremal values against values taken from URDF-file. Ignore
+        #    the floating-base joints, as they are not present in the URDF.
+        self.assertAlmostEqual(np.min(tree.joint_limit_min[6:]), -3.011)
+        self.assertAlmostEqual(np.max(tree.joint_limit_max[6:]), 3.14159)


### PR DESCRIPTION
Also updates `rigid_body_tree_test.py` to use `FindResourceOrThrow`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8351)
<!-- Reviewable:end -->
