### PR TITLE
Fix Wdeprecated warnings from GCC (systems/framework)

### DIFF
--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -95,6 +95,10 @@ class SystemPathnameInterface {
   /** Returns the full path name of this subsystem, starting at the root
   of the containing Diagram, with path name separators between segments. */
   virtual std::string GetSystemPathname() const = 0;
+
+ protected:
+  SystemPathnameInterface() = default;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemPathnameInterface);
 };
 
 /** These dependency ticket numbers are common to all systems and contexts so


### PR DESCRIPTION
When using clang, `-Wdeprecated` warns about deprecated implicitly-defined copy constructors (happens most often due to user-defined destructor): http://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor.

This patch explicitly declares the copy, move, and assignment operations on `SystemPathnameInterface` as `protected`, because we depend on them in order to reuse copy construction in `ContextBase` to implement `Clone`.

PR #8259 shows that with this patch, there are no `-Wdeprecated` errors on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8354)
<!-- Reviewable:end -->
