### PR TITLE
Correct test timeouts with ASan

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -70,7 +70,7 @@ test:asan_everything --test_env=ASAN_SYMBOLIZER_PATH
 test:asan_everything --test_lang_filters=-sh,-py
 # Typical slowdown introduced by AddressSanitizer is 2x.
 # See https://clang.llvm.org/docs/AddressSanitizer.html
-test:asan_everything--test_timeout=120,600,1800,7200
+test:asan_everything --test_timeout=120,600,1800,7200
 
 ### LSan build. ###
 build:lsan --copt -g


### PR DESCRIPTION
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-asan-everything/

~This is in order to know the time it takes to run `global_inverse_kinematics_test`, and possibly increasing its size.~
We only know that its lower bound is ~ 315 s.

@jamiesnape pointed out that we intend the timeout to be 600 seconds and that we'd missed a space which was causing unintended timeouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8366)
<!-- Reviewable:end -->
