### PR TITLE
Pin Mac's lxml to 4.1.1

### DIFF
--- a/setup/mac/binary_distribution/requirements.txt
+++ b/setup/mac/binary_distribution/requirements.txt
@@ -1,3 +1,3 @@
-lxml
+lxml==4.1.1
 pip
 PyYAML


### PR DESCRIPTION
Failing builds:
[1](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-sierra-unprovisioned-clang-bazel-nightly-release/248/), [2](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-sierra-unprovisioned-clang-cmake-nightly-release/32/)

[Reported Bug](https://bugs.launchpad.net/lxml/+bug/1727864)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8367)
<!-- Reviewable:end -->
