### PR TITLE
Add RemoveNamespaces method to NiceTypeName

### DIFF
--- a/common/nice_type_name.cc
+++ b/common/nice_type_name.cc
@@ -97,5 +97,19 @@ string drake::NiceTypeName::Canonicalize(const string& demangled) {
   return canonical;
 }
 
+string drake::NiceTypeName::RemoveNamespaces(const string& canonical) {
+  // Removes everything up to and including the last "::" that isn't part of a
+  // template argument. If the string ends with "::", returns the original
+  // string unprocessed. We are depending on the fact that namespaces can't be
+  // templatized to avoid bad behavior for template types where the template
+  // argument might include namespaces (those should not be touched).
+  static const never_destroyed<std::regex> regex{"^[^<>]*::"};
+
+  const std::string no_namespace =
+      std::regex_replace(canonical, regex.access(), "");
+
+  return no_namespace.empty() ? canonical : no_namespace;
+}
+
 }  // namespace drake
 

--- a/common/nice_type_name.h
+++ b/common/nice_type_name.h
@@ -81,6 +81,16 @@ class NiceTypeName {
   any platform. **/
   static std::string Canonicalize(const std::string& demangled_name);
 
+  /** Given a canonical type name that may include leading namespaces, attempts
+  to remove those namespaces. For example,
+  `drake::systems::MyThing<internal::type>` becomes `MyThing<internal::type>`.
+  If the last segment ends in `::`, the original string is returned unprocessed.
+  Note that this is just string processing -- a segment that looks like a
+  namespace textually will be treated as one, even if it is really a class. So
+  `drake::MyClass::Impl` will be reduced to `Impl` while
+  `drake::MyClass<T>::Impl` is reduced to `MyClass<T>::Impl`. */
+  static std::string RemoveNamespaces(const std::string& canonical_name);
+
  private:
   // No instances of this class should be created.
   NiceTypeName() = delete;

--- a/common/test/nice_type_name_test.cc
+++ b/common/test/nice_type_name_test.cc
@@ -182,5 +182,26 @@ GTEST_TEST(NiceTypeNameTest, Expressions) {
             NiceTypeName::Get(base_uptr));
 }
 
+GTEST_TEST(NiceTypeNameTest, RemoveNamespaces) {
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces("JustAPlainType"), "JustAPlainType");
+  EXPECT_EQ(
+      NiceTypeName::RemoveNamespaces("drake::nice_type_name_test::Derived"),
+      "Derived");
+  // Should ignore nested namespaces.
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces(
+                "std::vector<std::string,std::allocator<std::string>>"),
+            "vector<std::string,std::allocator<std::string>>");
+  // Should stop at the first templatized segment.
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces(
+                "drake::systems::sensors::RgbdRenderer<T>::Impl"),
+            "RgbdRenderer<T>::Impl");
+
+  // Check behavior in odd cases.
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces(""), "");
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces("::"), "::");
+  // No final type segment -- should leave unprocessed.
+  EXPECT_EQ(NiceTypeName::RemoveNamespaces("blah::blah2::"), "blah::blah2::");
+}
+
 }  // namespace
 }  // namespace drake


### PR DESCRIPTION
This teeny PR adds a method to NiceTypeName that strips off the namespaces from a full type name. I needed this for making nice error messages, where all the useful type information is in the last segment and the namespaces clutter the message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8370)
<!-- Reviewable:end -->
