### PR TITLE
Adds CacheEntry and SystemBase

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -34,6 +34,7 @@ drake_cc_library(
         ":single_output_vector_source",
         ":state",
         ":system",
+        ":system_base",
         ":system_constraint",
         ":system_scalar_converter",
         ":system_symbolic_inspector",
@@ -233,6 +234,33 @@ drake_cc_library(
         ":framework_common",
         "//common:default_scalars",
         "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "cache_entry",
+    srcs = [
+        "cache_entry.cc",
+    ],
+    hdrs = [
+        "cache_entry.h",
+    ],
+    deps = [
+        ":context_base",
+    ],
+)
+
+drake_cc_library(
+    name = "system_base",
+    srcs = [
+        "system_base.cc",
+    ],
+    hdrs = [
+        "system_base.h",
+    ],
+    deps = [
+        ":cache_entry",
+        ":context_base",
     ],
 )
 
@@ -503,6 +531,17 @@ drake_cc_googletest(
         ":cache_and_dependency_tracker",
         ":context_base",
         "//common:essential",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "cache_entry_test",
+    deps = [
+        ":cache_entry",
+        ":system_base",
+        "//common:essential",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities",
     ],
 )

--- a/systems/framework/cache.cc
+++ b/systems/framework/cache.cc
@@ -14,7 +14,7 @@ std::string CacheEntryValue::GetPathDescription() const {
 }
 
 void CacheEntryValue::ThrowIfBadCacheEntryValue(
-    const internal::SystemPathnameInterface* owning_subcontext) const {
+    const internal::ContextMessageInterface* owning_subcontext) const {
   if (owning_subcontext_ == nullptr) {
     // Can't use FormatName() here because that depends on us having an owning
     // context to talk to.
@@ -117,7 +117,7 @@ void Cache::SetAllEntriesOutOfDate() {
 }
 
 void Cache::RepairCachePointers(
-    const internal::SystemPathnameInterface* owning_subcontext) {
+    const internal::ContextMessageInterface* owning_subcontext) {
   DRAKE_DEMAND(owning_subcontext != nullptr);
   DRAKE_DEMAND(owning_subcontext_ == nullptr);
   owning_subcontext_ = owning_subcontext;

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -385,7 +385,7 @@ class CacheEntryValue {
   @throws std::logic_error for anything that goes wrong, with an appropriate
                            explanatory message. */
   // These invariants hold for all CacheEntryValues except the dummy one.
-  void ThrowIfBadCacheEntryValue(const internal::SystemPathnameInterface*
+  void ThrowIfBadCacheEntryValue(const internal::ContextMessageInterface*
                                      owning_subcontext = nullptr) const;
 
   /** (Advanced) Disables caching for just this cache entry value. When
@@ -452,7 +452,7 @@ class CacheEntryValue {
   // description identical to the CacheEntry for which this is the value.
   CacheEntryValue(CacheIndex index, DependencyTicket ticket,
                   std::string description,
-                  const internal::SystemPathnameInterface* owning_subcontext,
+                  const internal::ContextMessageInterface* owning_subcontext,
                   std::unique_ptr<AbstractValue> initial_value)
       : cache_index_(index),
         ticket_(ticket),
@@ -470,7 +470,7 @@ class CacheEntryValue {
 
   // This is the post-copy cleanup method.
   void set_owning_subcontext(
-      const internal::SystemPathnameInterface* owning_subcontext) {
+      const internal::ContextMessageInterface* owning_subcontext) {
     DRAKE_DEMAND(owning_subcontext != nullptr);
     DRAKE_DEMAND(owning_subcontext_ == nullptr);
     owning_subcontext_ = owning_subcontext;
@@ -569,7 +569,7 @@ class CacheEntryValue {
 
   // Pointer to the system name service of the owning subcontext. Used for
   // error messages.
-  reset_on_copy<const internal::SystemPathnameInterface*>
+  reset_on_copy<const internal::ContextMessageInterface*>
       owning_subcontext_;
 
   // The value, its serial number, and its validity. The value is copyable so
@@ -599,7 +599,7 @@ class Cache {
 
   /** Constructor creates an empty cache referencing the system pathname
   service of its owning subcontext. The supplied pointer must not be null. */
-  explicit Cache(const internal::SystemPathnameInterface* owning_subcontext)
+  explicit Cache(const internal::ContextMessageInterface* owning_subcontext)
       : owning_subcontext_(owning_subcontext) {
     DRAKE_DEMAND(owning_subcontext != nullptr);
   }
@@ -690,11 +690,11 @@ class Cache {
   // those pointers. The supplied pointer must not be null, and there must not
   // already be an owning subcontext set here.
   void RepairCachePointers(
-      const internal::SystemPathnameInterface* owning_subcontext);
+      const internal::ContextMessageInterface* owning_subcontext);
 
   // The system name service of the subcontext that owns this cache. This should
   // not be copied since it would still refer to the source subcontext.
-  reset_on_copy<const internal::SystemPathnameInterface*>
+  reset_on_copy<const internal::ContextMessageInterface*>
       owning_subcontext_;
 
   // All CacheEntryValue objects, indexed by CacheIndex.

--- a/systems/framework/cache_doxygen.h
+++ b/systems/framework/cache_doxygen.h
@@ -266,7 +266,7 @@ most-general method is:
       std::string                   description,
       CacheEntry::AllocCallback     alloc_function,
       CacheEntry::CalcCallback      calc_function,
-      std::vector<DependencyTicket> calc_prerequisites);
+      std::vector<DependencyTicket> prerequisites_of_calc_function);
 @endcode
 
 If no dependencies are listed the default is `{all_sources_ticket()}`. A cache

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -1,0 +1,81 @@
+#include "drake/systems/framework/cache_entry.h"
+
+#include <exception>
+#include <memory>
+#include <typeinfo>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/nice_type_name.h"
+
+namespace drake {
+namespace systems {
+
+CacheEntry::CacheEntry(
+    const internal::SystemMessageInterface* owning_subsystem, CacheIndex index,
+    DependencyTicket ticket, std::string description,
+    AllocCallback alloc_function, CalcCallback calc_function,
+    std::vector<DependencyTicket> prerequisites_of_calc)
+    : owning_subsystem_(owning_subsystem),
+      cache_index_(index),
+      ticket_(ticket),
+      description_(std::move(description)),
+      alloc_function_(std::move(alloc_function)),
+      calc_function_(std::move(calc_function)),
+      prerequisites_of_calc_(
+          std::move(prerequisites_of_calc)) {
+  DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
+  DRAKE_DEMAND(owning_subsystem && alloc_function_ && calc_function_);
+
+  if (prerequisites_of_calc_.empty()) {
+    throw std::logic_error(FormatName("CacheEntry") +
+        "Cannot create a CacheEntry with an empty prerequisites list. If the "
+        "Calc() function really has no dependencies, list 'nothing_ticket()' "
+        "as its sole prerequisite.");
+  }
+}
+
+std::unique_ptr<AbstractValue> CacheEntry::Allocate(
+    const ContextBase& context) const {
+  DRAKE_ASSERT_VOID(owning_subsystem_->ThrowIfContextNotCompatible(context));
+  std::unique_ptr<AbstractValue> value = alloc_function_(context);
+  if (value == nullptr) {
+    throw std::logic_error(FormatName("Allocate") +
+                           "allocator returned a nullptr.");
+  }
+  return value;
+}
+
+void CacheEntry::Calc(const ContextBase& context,
+                      AbstractValue* value) const {
+  DRAKE_DEMAND(value != nullptr);
+  DRAKE_ASSERT_VOID(owning_subsystem_->ThrowIfContextNotCompatible(context));
+  DRAKE_ASSERT_VOID(CheckValidAbstractValue(context, *value));
+
+  calc_function_(context, value);
+}
+
+void CacheEntry::CheckValidAbstractValue(const ContextBase& context,
+                                         const AbstractValue& proposed) const {
+  // TODO(sherm1) Consider whether we can depend on there already being an
+  //              object of this type in the context's CacheEntryValue so we
+  //              wouldn't have to allocate one here. If so could also store
+  //              a precomputed type_index there for further savings.
+  auto good_ptr = Allocate(context);  // Very expensive!
+  const AbstractValue& good = *good_ptr;
+  if (typeid(proposed) != typeid(good)) {
+    throw std::logic_error(FormatName("Calc") +
+                           "expected AbstractValue output type " +
+                           NiceTypeName::Get(good) + " but got " +
+                           NiceTypeName::Get(proposed) + ".");
+  }
+}
+
+std::string CacheEntry::FormatName(const char* api) const {
+  return "Subsystem '" + owning_subsystem_->GetSystemPathname() + "' (" +
+      NiceTypeName::RemoveNamespaces(owning_subsystem_->GetSystemType()) +
+      "): CacheEntry[" + std::to_string(cache_index_) + "](" +
+      description() + ")::" + api + "(): ";
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -1,0 +1,319 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/context_base.h"
+#include "drake/systems/framework/framework_common.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/** A %CacheEntry belongs to a System and represents the properties of one of
+that System's cached computations. %CacheEntry objects are assigned CacheIndex
+values in the order they are declared; these are unique within a single System
+and can be used for quick access to both the %CacheEntry and the corresponding
+CacheEntryValue in the System's Context.
+
+%CacheEntry objects are allocated automatically for known System computations
+like output ports and time derivatives, and may also be allocated by user code
+for other cached computations.
+
+A cache entry's value is always stored as an AbstractValue, which can hold a
+concrete value of any copyable type. However, once a value has been allocated
+using a particular concrete type, the type cannot be changed.
+
+%CacheEntry objects support four important operations:
+- Allocate() returns an object that can hold the cached value.
+- Calc() unconditionally computes the cached value.
+- Eval() returns a reference to the cached value, first updating with Calc()
+    if it was out of date.
+- GetKnownUpToDate() returns a reference to the current value that you are
+    certain must already be up to date.
+
+The allocation and calculation functions must be provided at the time a
+cache entry is declared. That is typically done in a System constructor, in
+a manner very similar to the declaration of output ports. */
+class CacheEntry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CacheEntry)
+
+  /** Signature of a function suitable for allocating an object that can hold
+  a value of a particular cache entry. The result is always returned as an
+  AbstractValue but must contain the correct concrete type. */
+  using AllocCallback =
+      std::function<std::unique_ptr<AbstractValue>(const ContextBase&)>;
+
+  /** Signature of a function suitable for calculating a value of a particular
+  cache entry, given a place to put the value. */
+  using CalcCallback = std::function<void(const ContextBase&, AbstractValue*)>;
+
+  /** (Advanced) Constructs a cache entry within a System and specifies the
+  resources it needs.
+
+  This method is intended only for use by the framework which provides much
+  nicer APIs for end users. See
+  @ref DeclareCacheEntry_documentation "DeclareCacheEntry" for the
+  user-facing API documentation.
+
+  The supplied allocator must return a suitable AbstractValue in which to
+  hold the result. The supplied calculator function must write to an
+  AbstractValue of the same underlying concrete type as is returned by the
+  allocator. The allocator function is not invoked here during construction of
+  the cache entry. Instead allocation is deferred until the allocator can be
+  provided with a complete Context, which cannot occur until the full Diagram
+  containing this subsystem has been completed. That way the initial type, size,
+  or value can Context-dependent. The supplied prerequisite tickets are
+  interpreted as belonging to the same subsystem that owns this %CacheEntry.
+
+  The list of prerequisites cannot be empty -- a cache entry that really has
+  no prerequisites must say so explicitly by providing a list containing only
+  `nothing_ticket()` as a prerequisite. The subsystem pointer must not be null,
+  and the cache index and ticket must be valid. The description is an arbitrary
+  string not interpreted in any way by Drake.
+
+  @throws std::logic_error if the prerequisite list is empty.
+
+  @see drake::systems::SystemBase::DeclareCacheEntry() */
+  // All the nontrivial parameters here are moved to the CacheEntry which is
+  // why they aren't references.
+  CacheEntry(const internal::SystemMessageInterface* owning_subsystem,
+             CacheIndex index, DependencyTicket ticket, std::string description,
+             AllocCallback alloc_function, CalcCallback calc_function,
+             std::vector<DependencyTicket> prerequisites_of_calc);
+
+  /** Returns a reference to the list of prerequisites needed by this cache
+  entry's Calc() function. These are all within the same subsystem that
+  owns this %CacheEntry. */
+  const std::vector<DependencyTicket>& prerequisites() const {
+    return prerequisites_of_calc_;
+  }
+
+  /** Invokes this cache entry's allocator function to allocate a concrete
+  object suitable for holding the value to be held in this cache entry, and
+  returns that as an AbstractValue. The returned object will never be null.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry.
+  @throws std::logic_error if the allocator function returned null. */
+  std::unique_ptr<AbstractValue> Allocate(const ContextBase& context) const;
+
+  /** Unconditionally computes the value this cache entry should have given a
+  particular context, into an already-allocated object.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry.
+  @pre `value` is non null and has exactly the same concrete type as that of
+       the object returned by this entry's Allocate() method. */
+  void Calc(const ContextBase& context, AbstractValue* value) const;
+
+  /** Returns a reference to the up-to-date value of this cache entry contained
+  in the given Context. This is the preferred way to obtain a cached value. If
+  the value is not already up to date with respect to its prerequisites, or if
+  caching is disabled for this entry, then this entry's Calc() method is used
+  first to update the value before the reference is returned. The Calc() method
+  may be arbitrarily expensive, but this method is constant time and _very_ fast
+  if the value is already up to date. If you are certain the value should be up
+  to date already, you may use the GetKnownUpToDate() method instead.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry.
+  @throws std::logic_error if the value doesn't actually have type V. */
+  template <typename ValueType>
+  const ValueType& Eval(const ContextBase& context) const {
+    const AbstractValue& abstract_value = EvalAbstract(context);
+    return ExtractValueOrThrow<ValueType>(abstract_value, __func__);
+  }
+
+  /** Returns a reference to the up-to-date abstract value of this cache entry
+  contained in the given Context. If the value is not already up to date with
+  respect to its prerequisites, or if caching is disabled for this entry, the
+  Calc() method above is used first to update the value before the reference is
+  returned. This method is constant time and _very_ fast if the value doesn't
+  need to be recomputed.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry. */
+  // Keep this method as small as possible to encourage inlining; it gets
+  // called *a lot*.
+  const AbstractValue& EvalAbstract(const ContextBase& context) const {
+    const CacheEntryValue& cache_value = get_cache_entry_value(context);
+    if (cache_value.needs_recomputation()) UpdateValue(context);
+    return cache_value.get_abstract_value();
+  }
+
+  /** Returns a reference to the _known up-to-date_ value of this cache entry
+  contained in the given Context. The purpose of this method is to avoid
+  unexpected recomputations in circumstances where you believe the value must
+  already be up to date. Unlike Eval(), this method will throw an exception
+  if the value is out of date; it will never attempt a recomputation. The
+  behavior here is unaffected if caching is disabled for this cache entry --
+  it looks only at the out_of_date flag which is still maintained when caching
+  is disabled. This method is constant time and _very_ fast if it succeeds.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry.
+  @throws std::logic_error if the value is out of date or if it does not
+                           actually have type `ValueType`. */
+  // Keep this method as small as possible to encourage inlining; it gets
+  // called *a lot*.
+  template <typename ValueType>
+  const ValueType& GetKnownUpToDate(const ContextBase& context) const {
+    const CacheEntryValue& cache_value = get_cache_entry_value(context);
+    if (cache_value.is_out_of_date()) ThrowOutOfDate(__func__);
+    return ExtractValueOrThrow<ValueType>(cache_value.get_abstract_value(),
+                                          __func__);
+  }
+
+  /** Returns a reference to the _known up-to-date_ abstract value of this cache
+  entry contained in the given Context. See GetKnownUpToDate() for more
+  information.
+  @pre `context` is a subcontext that is compatible with the subsystem that owns
+       this cache entry.
+  @throws std::logic_error if the value is not up to date. */
+  // Keep this method as small as possible to encourage inlining; it gets
+  // called *a lot*.
+  const AbstractValue& GetKnownUpToDateAbstract(
+      const ContextBase& context) const {
+    const CacheEntryValue& cache_value = get_cache_entry_value(context);
+    if (cache_value.is_out_of_date()) ThrowOutOfDate(__func__);
+    return cache_value.get_abstract_value();
+  }
+
+  /** Returns `true` if the current value of this cache entry is out of
+  date with respect to its prerequisites. If this returns `false` then the
+  Eval() method will not perform any computation when invoked, unless caching
+  has been disabled for this entry. If this returns `true` the
+  GetKnownUpToDate() methods will fail if invoked. */
+  bool is_out_of_date(const ContextBase& context) const {
+    return get_cache_entry_value(context).is_out_of_date();
+  }
+
+  /** (Debugging) Returns `true` if caching has been disabled for this cache
+  entry. That means Eval() will recalculate even if the entry is marked up
+  to date. */
+  bool is_cache_entry_disabled(const ContextBase& context) const {
+    return get_cache_entry_value(context).is_cache_entry_disabled();
+  }
+
+  /** (Debugging) Disables caching for this cache entry. Eval() will recompute
+  the cached value every time it is invoked, regardless of the state of the
+  out_of_date flag. That should have no effect on any computed results, other
+  than speed. See class documentation for ideas as to what might be wrong if you
+  see a change. Note that the `context` is `const` here; cache entry values
+  are mutable. */
+  void disable_caching(const ContextBase& context) const {
+    CacheEntryValue& value = get_mutable_cache_entry_value(context);
+    value.disable_caching();
+  }
+
+  /** (Debugging) Enables caching for this cache entry if it was previously
+  disabled. */
+  void enable_caching(const ContextBase& context) const {
+    CacheEntryValue& value = get_mutable_cache_entry_value(context);
+    value.enable_caching();
+  }
+
+  /** Return the human-readable description for this %CacheEntry. */
+  const std::string& description() const { return description_; }
+
+  /** (Advanced) Returns a const reference to the CacheEntryValue object that
+  corresponds to this %CacheEntry, from the supplied Context. The returned
+  object contains the current value and tracks whether it is up to date with
+  respect to its prerequisites. If you just need the value, use the Eval()
+  method rather than this one. This method is constant time and _very_ fast in
+  all circumstances. */
+  const CacheEntryValue& get_cache_entry_value(
+      const ContextBase& context) const {
+    return context.get_cache().get_cache_entry_value(cache_index_);
+  }
+
+  /** (Advanced) Returns a mutable reference to the CacheEntryValue object that
+  corresponds to this %CacheEntry, from the supplied Context. Note that
+  `context` is const; cache values are mutable. Don't call this method unless
+  you know what you're doing. This method is constant time and _very_ fast in
+  all circumstances. */
+  CacheEntryValue& get_mutable_cache_entry_value(
+      const ContextBase& context) const {
+    return context.get_mutable_cache().get_mutable_cache_entry_value(
+        cache_index_);
+  }
+
+  /** Returns the CacheIndex used to locate this %CacheEntry within the
+  containing System. */
+  CacheIndex cache_index() const { return cache_index_; }
+
+  /** Returns the DependencyTicket used to register dependencies on the value
+  of this %CacheEntry. This can also be used to locate the DependencyTracker
+  that manages dependencies at runtime for the associated CacheEntryValue in
+  a Context. */
+  DependencyTicket ticket() const { return ticket_; }
+
+ private:
+  // Unconditionally update the cache value, which has already been determined
+  // to be in need of recomputation (either because it is out of date or
+  // because caching was disabled).
+  void UpdateValue(const ContextBase& context) const {
+    // We can get a mutable cache entry value from a const context.
+    CacheEntryValue& mutable_cache_value =
+        get_mutable_cache_entry_value(context);
+    AbstractValue& value = mutable_cache_value.GetMutableAbstractValueOrThrow();
+    // If Calc() throws a recoverable exception, the cache remains out of date.
+    Calc(context, &value);
+    mutable_cache_value.mark_up_to_date();
+  }
+
+  // The value was unexpectedly out of date. Issue a helpful message.
+  void ThrowOutOfDate(const char* api) const {
+    throw std::logic_error(FormatName(api) + "value out of date.");
+  }
+
+  // The user told us the cache entry would have a particular concrete type
+  // but it doesn't.
+  template <typename ValueType>
+  void ThrowBadValueType(const char* api, const AbstractValue& abstract) const {
+    throw std::logic_error(FormatName(api) + "wrong value type <" +
+                           NiceTypeName::Get<ValueType>() +
+                           "> specified but actual type was <" +
+                           abstract.GetNiceTypeName() + ">.");
+  }
+
+  // Pull a value of a given type from an abstract value or issue a nice
+  // message if the type is not correct. Keep this small and inlineable.
+  template <typename ValueType>
+  const ValueType& ExtractValueOrThrow(const AbstractValue& abstract,
+                                       const char* api) const {
+    const ValueType* value = abstract.MaybeGetValue<ValueType>();
+    if (!value)
+      ThrowBadValueType<ValueType>(api, abstract);
+    return *value;
+  }
+
+  // Check that an AbstractValue provided to Calc() is suitable for this cache
+  // entry. (Very expensive; use in Debug only.)
+  void CheckValidAbstractValue(const ContextBase& context,
+                               const AbstractValue& proposed) const;
+
+  // Provides an identifying prefix for error messages.
+  std::string FormatName(const char* api) const;
+
+  const internal::SystemMessageInterface* const owning_subsystem_;
+  const CacheIndex cache_index_;
+  const DependencyTicket ticket_;
+
+  // A human-readable description of this cache entry. Not interpreted by code
+  // but useful for error messages.
+  const std::string description_;
+
+  const AllocCallback alloc_function_;
+  const CalcCallback calc_function_;
+
+  // The list of prerequisites for the calc_function. Whenever one of these
+  // changes, the cache value must be recalculated. Note that all possible
+  // prerequisites are internal to the containing subsystem, so the ticket
+  // alone is a unique specification of a prerequisite.
+  const std::vector<DependencyTicket> prerequisites_of_calc_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -24,7 +24,7 @@ Context objects. There is a one-to-one correspondence between subsystems and
 subcontexts. Within a given System (Context), its child subsystems (subcontexts)
 are indexed using a SubsystemIndex; there is no separate SubcontextIndex since
 the numbering must be identical. */
-class ContextBase : public internal::SystemPathnameInterface {
+class ContextBase : public internal::ContextMessageInterface {
  public:
   /** @name  Does not allow move or assignment; copy is protected. */
   /** @{ */
@@ -38,7 +38,7 @@ class ContextBase : public internal::SystemPathnameInterface {
   /** Creates an identical copy of the concrete context object. */
   std::unique_ptr<ContextBase> Clone() const;
 
-  virtual ~ContextBase();
+  ~ContextBase() override;
 
   /** (Debugging) Disables caching recursively for this context
   and all its subcontexts. Disabling forces every `Eval()` method to perform a
@@ -75,7 +75,10 @@ class ContextBase : public internal::SystemPathnameInterface {
   /** (Debugging) Returns the local name of the subsystem for which this is the
   Context. See GetSystemPathname() if you want the full name. */
   // TODO(sherm1) Replace with the real name.
-  std::string GetSystemName() const final { return "dummy"; }
+  const std::string& GetSystemName() const final {
+    static const never_destroyed<std::string> name("dummy");
+    return name.access();
+  }
 
   /** (Debugging) Returns the full pathname of the subsystem for which this is
   the Context. See get_system_pathname() if you want to the full name. */

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -172,7 +172,7 @@ bool DependencyTracker::HasSubscriber(
 }
 
 void DependencyTracker::ThrowIfBadDependencyTracker(
-    const internal::SystemPathnameInterface* owning_subcontext,
+    const internal::ContextMessageInterface* owning_subcontext,
     const CacheEntryValue* cache_value) const {
   if (owning_subcontext_ == nullptr) {
     // Can't use FormatName() here because that depends on us having an owning
@@ -213,7 +213,7 @@ void DependencyTracker::ThrowIfBadDependencyTracker(
 void DependencyTracker::RepairTrackerPointers(
     const DependencyTracker& source,
     const DependencyTracker::PointerMap& tracker_map,
-    const internal::SystemPathnameInterface* owning_subcontext, Cache* cache) {
+    const internal::ContextMessageInterface* owning_subcontext, Cache* cache) {
   DRAKE_DEMAND(owning_subcontext != nullptr);
   DRAKE_DEMAND(cache != nullptr);
   owning_subcontext_ = owning_subcontext;
@@ -269,7 +269,7 @@ void DependencyGraph::AppendToTrackerPointerMap(
 void DependencyGraph::RepairTrackerPointers(
     const DependencyGraph& source,
     const DependencyTracker::PointerMap& tracker_map,
-    const internal::SystemPathnameInterface* owning_subcontext,
+    const internal::ContextMessageInterface* owning_subcontext,
     Cache* new_cache) {
   DRAKE_DEMAND(owning_subcontext != nullptr);
   owning_subcontext_ = owning_subcontext;

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -277,7 +277,7 @@ class DependencyTracker {
   @throws std::logic_error for anything that goes wrong, with an appropriate
                            explanatory message. */
   void ThrowIfBadDependencyTracker(
-      const internal::SystemPathnameInterface* owning_subcontext = nullptr,
+      const internal::ContextMessageInterface* owning_subcontext = nullptr,
       const CacheEntryValue* cache_value = nullptr) const;
   //@}
 
@@ -292,7 +292,7 @@ class DependencyTracker {
   // system pathname service of the owning subcontext must be supplied here and
   // be non-null.
   DependencyTracker(DependencyTicket ticket, std::string description,
-                    const internal::SystemPathnameInterface* owning_subcontext,
+                    const internal::ContextMessageInterface* owning_subcontext,
                     CacheEntryValue* cache_value)
       : ticket_(ticket),
         description_(std::move(description)),
@@ -329,7 +329,7 @@ class DependencyTracker {
   void RepairTrackerPointers(
       const DependencyTracker& source,
       const DependencyTracker::PointerMap& tracker_map,
-      const internal::SystemPathnameInterface* owning_subcontext, Cache* cache);
+      const internal::ContextMessageInterface* owning_subcontext, Cache* cache);
 
   // Notifies `this` DependencyTracker that one of its prerequisite values was
   // modified or made available for mutable access. All of our downstream
@@ -365,7 +365,7 @@ class DependencyTracker {
   const std::string description_;
 
   // Pointer to the system name service of the owning subcontext.
-  const internal::SystemPathnameInterface* owning_subcontext_{nullptr};
+  const internal::ContextMessageInterface* owning_subcontext_{nullptr};
 
   // Points to CacheEntryValue::dummy() if we're not told otherwise.
   CacheEntryValue* cache_value_{nullptr};
@@ -422,7 +422,7 @@ class DependencyGraph {
   /** Constructor creates an empty graph referencing the system pathname
   service of its owning subcontext. The supplied pointer must not be null. */
   explicit DependencyGraph(
-      const internal::SystemPathnameInterface* owning_subcontext)
+      const internal::ContextMessageInterface* owning_subcontext)
       : owning_subcontext_(owning_subcontext) {
     DRAKE_DEMAND(owning_subcontext != nullptr);
   }
@@ -531,12 +531,12 @@ class DependencyGraph {
   void RepairTrackerPointers(
       const DependencyGraph& source,
       const DependencyTracker::PointerMap& tracker_map,
-      const internal::SystemPathnameInterface* owning_subcontext,
+      const internal::ContextMessageInterface* owning_subcontext,
       Cache* new_cache);
 
  private:
   // The system name service of the subcontext that owns this subgraph.
-  const internal::SystemPathnameInterface* owning_subcontext_{};
+  const internal::ContextMessageInterface* owning_subcontext_{};
 
   // All value trackers, indexed by DependencyTicket.
   std::vector<std::unique_ptr<DependencyTracker>> graph_;

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -29,9 +29,6 @@ the corresponding CacheEntryValue in that System's Context. This is an index
 providing extremely fast constant-time access to both. */
 using CacheIndex = TypeSafeIndex<class CacheTag>;
 
-// TODO(sherm1) Reveal these when they are used.
-#ifndef DRAKE_DOXYGEN_CXX
-
 /** Serves as a local index for a child subsystem within a parent
 Diagram, or a child subcontext within a parent DiagramContext. A subsystem and
 its matching subcontext have the same %SubsystemIndex. Unique only
@@ -61,7 +58,6 @@ using NumericParameterIndex = TypeSafeIndex<class NumericParameterTag>;
 /** Serves as the local index for abstract parameters within a given System
 and its corresponding Context. */
 using AbstractParameterIndex = TypeSafeIndex<class AbstractParameterTag>;
-#endif
 
 /** All system ports are either vectors of Eigen scalars, or black-box
 AbstractValues which may contain any type. */
@@ -76,29 +72,64 @@ rather depends on what it is connected to (not yet implemented). */
 constexpr int kAutoSize = -1;
 
 #ifndef DRAKE_DOXYGEN_CXX
+class ContextBase;
 namespace internal {
 
-/** Any class that can provide a System name and (for Diagrams) a subsystem
-path name should implement this interface. This is used by System and Context
-so that contained objects can provide helpful error messages and log
-diagnostics that identify the offending object within a diagram. (Diagram
-Systems and their Contexts have identical substructure.) Providing
-this as a separate interface allows us to avoid circular dependencies between
-the containers and their contained objects. */
-class SystemPathnameInterface {
+/** SystemBase should implement this interface so that its contained objects
+can provide helpful error messages and log diagnostics that identify the
+offending object within a diagram. Providing this as a separate interface allows
+us to avoid mutual dependencies between the containers and their contained
+objects, which allows us to put the contained objects in their own Bazel
+libraries. */
+class SystemMessageInterface {
  public:
-  virtual ~SystemPathnameInterface() = default;
+  virtual ~SystemMessageInterface() = default;
 
   /** Returns the simple name of this subsystem, with no path separators. */
-  virtual std::string GetSystemName() const = 0;
+  virtual const std::string& GetSystemName() const = 0;
 
-  /** Returns the full path name of this subsystem, starting at the root
-  of the containing Diagram, with path name separators between segments. */
+  /** Generates and returns the full path name of this subsystem, starting at
+  the root of the containing Diagram, with path name separators between
+  segments. */
+  virtual std::string GetSystemPathname() const = 0;
+
+  /** Returns the concrete type of this subsystem. This should be the
+  namespace-decorated human-readable name as returned by NiceTypeName. */
+  virtual std::string GetSystemType() const = 0;
+
+  /** Throws an std::logic_error if the given Context is incompatible with
+  this System; does nothing if `this` object is not a System. This is
+  likely to be _very_ expensive and should generally be done only in Debug
+  builds, like this:
+  @code
+     DRAKE_ASSERT_VOID(ThrowIfContextNotCompatible(context));
+  @endcode */
+  virtual void ThrowIfContextNotCompatible(const ContextBase&) const = 0;
+
+ protected:
+  SystemMessageInterface() = default;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemMessageInterface);
+};
+
+/** ContextBase should implement this interface so that its contained objects
+can provide helpful error messages and log diagnostics that identify the
+offending object within a diagram. (Diagram Systems and their Contexts have
+identical substructure.) See SystemMessageInterface for motivation. */
+class ContextMessageInterface {
+ public:
+  virtual ~ContextMessageInterface() = default;
+
+  /** Returns the simple name of this subsystem, with no path separators. */
+  virtual const std::string& GetSystemName() const = 0;
+
+  /** Generates and returns the full path name of this subsystem, starting at
+  the root of the containing Diagram, with path name separators between
+  segments. */
   virtual std::string GetSystemPathname() const = 0;
 
  protected:
-  SystemPathnameInterface() = default;
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemPathnameInterface);
+  ContextMessageInterface() = default;
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContextMessageInterface);
 };
 
 /** These dependency ticket numbers are common to all systems and contexts so
@@ -116,11 +147,15 @@ enum BuiltInTicketNumbers {
   kXdTicket             =  7,
   kXaTicket             =  8,
   kXTicket              =  9,
-  kAllParametersTicket  = 10,
-  kAllInputPortsTicket  = 11,
-  kAllSourcesTicket     = 12,
-  kNextAvailableTicket  = kAllSourcesTicket+1
-  // TODO(sherm1) Add the rest of the built-in tickets here.
+  kConfigurationTicket  = 10,
+  kVelocityTicket       = 11,
+  kKinematicsTicket     = 12,
+  kAllParametersTicket  = 13,
+  kAllInputPortsTicket  = 14,
+  kAllSourcesTicket     = 15,
+  kXcdotTicket          = 16,
+  kXdhatTicket          = 17,
+  kNextAvailableTicket  = kXdhatTicket+1
 };
 
 }  // namespace internal

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -1,0 +1,71 @@
+#include "drake/systems/framework/system_base.h"
+
+namespace drake {
+namespace systems {
+
+SystemBase::~SystemBase() {}
+
+std::string SystemBase::GetSystemPathname() const {
+  // TODO(sherm1) Replace with the real pathname.
+  return "/dummy/system/pathname/" + GetSystemName();
+}
+
+const CacheEntry& SystemBase::DeclareCacheEntry(
+    std::string description, CacheEntry::AllocCallback alloc_function,
+    CacheEntry::CalcCallback calc_function,
+    std::vector<DependencyTicket> prerequisites_of_calc) {
+  // If the prerequisite list is empty the CacheEntry constructor will throw
+  // a logic error.
+  const CacheIndex index(num_cache_entries());
+  const DependencyTicket ticket(assign_next_dependency_ticket());
+  cache_entries_.emplace_back(std::make_unique<CacheEntry>(
+      this, index, ticket, std::move(description), std::move(alloc_function),
+      std::move(calc_function), std::move(prerequisites_of_calc)));
+  const CacheEntry& new_entry = *cache_entries_.back();
+  return new_entry;
+}
+
+std::unique_ptr<ContextBase> SystemBase::AllocateContext() const {
+  // Derived class creates the concrete Context object, which already contains
+  // all the well-known trackers (the ones with fixed tickets).
+  std::unique_ptr<ContextBase> context_ptr = DoMakeContext();
+  DRAKE_DEMAND(context_ptr != nullptr);
+  ContextBase& context = *context_ptr;
+
+  // TODO(sherm1) Set context system name from GetSystemName().
+
+  // TODO(sherm1) Add the independent-source trackers and wire them up
+  // appropriately. That includes input ports since their dependencies are
+  // external.
+
+  DependencyGraph& graph = context.get_mutable_dependency_graph();
+
+  // Create the Context cache containing a CacheEntryValue corresponding to
+  // each CacheEntry, add a DependencyTracker and subscribe it to its
+  // prerequisites as specified in the CacheEntry. Cache entries are
+  // necessarily ordered such that the first cache entry can depend only
+  // on the known source trackers created above, the second may depend on
+  // those plus the first, and so on. Circular dependencies are not permitted.
+  Cache& cache = context.get_mutable_cache();
+  for (CacheIndex index(0); index < num_cache_entries(); ++index) {
+    const CacheEntry& entry = get_cache_entry(index);
+    cache.CreateNewCacheEntryValue(entry.cache_index(), entry.ticket(),
+        entry.description(), entry.prerequisites(), &graph);
+  }
+
+  // TODO(sherm1) Create the output port trackers yᵢ here.
+
+  // TODO(sherm1) Move this to the AcquireContextResources phase.
+  // We now have a complete Context. We can allocate space for cache entry
+  // values using the allocators, which require a context.
+  for (CacheIndex index(0); index < num_cache_entries(); ++index) {
+    const CacheEntry& entry = get_cache_entry(index);
+    CacheEntryValue& cache_value = cache.get_mutable_cache_entry_value(index);
+    cache_value.SetInitialValue(entry.Allocate(context));
+  }
+
+  return context_ptr;
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1,0 +1,554 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/unused.h"
+#include "drake/systems/framework/cache_entry.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+/** Provides non-templatized functionality shared by the templatized System
+classes.
+
+Terminology: in general a Drake System is a tree structure composed of
+"subsystems", which are themselves System objects. The corresponding Context is
+a parallel tree structure composed of "subcontexts", which are themselves
+Context objects. There is a one-to-one correspondence between subsystems and
+subcontexts. Within a given System (Context), its child subsystems (subcontexts)
+are indexed using a SubsystemIndex; there is no separate SubcontextIndex since
+the numbering must be identical. */
+class SystemBase : public internal::SystemMessageInterface {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemBase)
+
+  ~SystemBase() override;
+
+  /** Sets the name of the system. Do not use the path delimiter character '/'
+  in the name. When creating a Diagram, names of sibling subsystems should be
+  unique. */
+  // TODO(sherm1) Enforce reasonable naming policies.
+  void set_name(const std::string& name) { name_ = name; }
+
+  /** Returns the name last supplied to set_name(), or a default name if
+  set_name() was never called. Systems with an empty name that are added to a
+  Diagram will have a default name automatically assigned. Systems created
+  by copying with a scalar type change have the same name as the source
+  system. */
+  const std::string& GetSystemName() const final { return name_; }
+
+  /** Generates and returns the full path name of this subsystem, starting from
+  the root System, with '/' delimiters between parent and child subsystems. */
+  std::string GetSystemPathname() const final;
+
+  /** Returns the most-derived type of this concrete System object as a
+  human-readable string suitable for use in error messages. */
+  std::string GetSystemType() const final { return NiceTypeName::Get(*this); }
+
+  /** Throws an exception with an appropriate message if the given `context` is
+  not compatible with this System. Restrictions may vary for different systems;
+  the error message should explain. This can be an expensive check so you may
+  want to limit it to Debug builds. */
+  void ThrowIfContextNotCompatible(const ContextBase& context) const final {
+    CheckValidContext(context);
+  }
+
+  /** Returns a Context suitable for use with this System. Context resources
+  are allocated based on resource requests that were made during System
+  construction. */
+  // TODO(sherm1) Split this into phases as needed for caching.
+  std::unique_ptr<ContextBase> AllocateContext() const;
+
+  /** Returns the number nc of cache entries currently allocated in this System.
+  These are indexed from 0 to nc-1. */
+  int num_cache_entries() const {
+    return static_cast<int>(cache_entries_.size());
+  }
+
+  /** Return a reference to a CacheEntry given its `index`. */
+  const CacheEntry& get_cache_entry(CacheIndex index) const {
+    DRAKE_ASSERT(0 <= index && index < num_cache_entries());
+    return *cache_entries_[index];
+  }
+
+  // TODO(sherm1) Consider whether to make DeclareCacheEntry methods protected.
+  //============================================================================
+  /** @name                    Declare cache entries
+  @anchor DeclareCacheEntry_documentation
+
+  Methods in this section are used by derived classes to declare cache entries
+  for their own internal computations. (Other cache entries are provided
+  automatically for well-known computations such as output ports and time
+  derivatives.) Cache entries may contain values of any type, however the type
+  for any particular cache entry is fixed after first allocation. Every cache
+  entry must have an _allocator_ function `Alloc()` and a _calculator_ function
+  `Calc()`. `Alloc()` returns an object suitable for holding a value of the
+  cache entry. `Calc()` uses the contents of a given Context to produce the
+  cache entry's value, which is placed in an object of the type returned by
+  `Alloc()`.
+
+  <h4>Prerequisites</h4>
+
+  Correct runtime caching behavior depends critically on understanding the
+  dependencies of the cache entry's `Calc()` function (we call those
+  "prerequisites"). If none of the prerequisites has changed since the last
+  time `Calc()` was invoked to set the cache entry's value, then we don't need
+  to perform a potentially expensive recalculation. On the other hand, if any
+  of the prerequisites has changed then the current value is invalid and must
+  not be used without first recomputing.
+
+  Currently it is not possible for Drake to infer prerequisites accurately and
+  automatically from inspection of the `Calc()` implementation. Therefore,
+  if you don't say otherwise, Drake will assume `Calc()` is dependent
+  on all value sources in the Context, including time, state, input ports,
+  parameters, and accuracy. That means the cache entry's value will be
+  considered invalid if _any_ of those sources has changed since the last time
+  the value was calculated. That is safe, but can result in more computation
+  than necessary. If you know that your `Calc()` method has fewer prerequisites,
+  you may say so by providing an explicit list in the `prerequisites_of_calc`
+  parameter. Every possible prerequisite has a DependencyTicket ("ticket"), and
+  the list should consist of tickets. For example, if your calculator depends
+  only on time (e.g. `Calc(context)` is `sin(context.get_time())`) then you
+  would specify `prerequisites_of_calc={time_ticket()}` here. See
+  @ref DependencyTicket_documentation "Dependency tickets" for a list of the
+  possible tickets and what they mean.
+
+  @warning It is critical that the prerequisite list you supply be accurate, or
+  at least conservative, for correct functioning of the caching system. Drake
+  cannot currently detect that a `Calc()` function accesses an undeclared
+  prerequisite. Even assuming you have correctly listed the prerequisites, you
+  should include a prominent comment in every `Calc()` implementation noting
+  that if the implementation is changed then the prerequisite list must be
+  updated correspondingly.
+
+  A technique you can use to ensure that prerequisites have been properly
+  specified is to make use of the Context's
+  @ref drake::systems::ContextBase::DisableCaching "DisableCaching()"
+  method, which causes cache values to be recalculated unconditionally. You
+  should get identical results with caching enabled or disabled, with speed
+  being the only difference.
+  @see drake::systems::ContextBase::DisableCaching()
+
+  <h4>Which signature to use?</h4>
+
+  Although the allocator and calculator functions ultimately satisfy generic
+  function signatures defined in CacheEntry, we provide a variety
+  of `DeclareCacheEntry()` signatures here for convenient specification,
+  with mapping to the generic form handled invisibly. In particular,
+  allocators are most easily defined by providing a model value that can be
+  used to construct an allocator that copies the model when a new value
+  object is needed. Alternatively a method can be provided that constructs
+  a value object when invoked (those methods are conventionally, but not
+  necessarily, named `MakeSomething()` where `Something` is replaced by the
+  cache entry value type).
+
+  Because cache entry values are ultimately stored in AbstractValue objects,
+  the underlying types must be suitable. That means the type must be copy
+  constructible or cloneable. For methods below that are not given an explicit
+  model value or construction ("make") method, the underlying type must also be
+  default constructible.
+  @see drake::systems::Value for more about abstract values. */
+  //@{
+
+  /** Declares a new %CacheEntry in this System using the least-restrictive
+  definitions for the associated functions. Prefer one of the more-convenient
+  signatures below if you can. The new cache entry is assigned a unique
+  CacheIndex and DependencyTicket, which can be obtained from the returned
+  %CacheEntry. The function signatures here are:
+  @code
+    std::unique_ptr<AbstractValue> Alloc(const ContextBase&);
+    void Calc(const ContextBase&, AbstractValue*);
+  @endcode
+  where the AbstractValue objects must resolve to the same concrete type.
+
+  @param[in] description
+    A human-readable description of this cache entry, most useful for debugging
+    and documentation. Not interpreted in any way by Drake; it is retained
+    by the cache entry and used to generate the description for the
+    corresponding CacheEntryValue in the Context.
+  @param[in] alloc_function
+    Given a Context, returns a heap-allocated AbstractValue object suitable for
+    holding a value for this cache entry.
+  @param[in] calc_function
+    Provides the computation that maps from a given Context to the current
+    value that this cache entry should have, and writes that value to a given
+    object of the type returned by `alloc_function`.
+  @param[in] prerequisites_of_calc
+    Provides the DependencyTicket list containing a ticket for _every_ Context
+    value on which `calc_function` may depend when it computes its result.
+    Defaults to `{all_sources_ticket()}` if unspecified. If the cache value
+    is truly independent of the Context (rare!) say so explicitly by providing
+    the list `{nothing_ticket()}`; an explicitly empty list `{}` is forbidden.
+  @returns a const reference to the newly-created %CacheEntry.
+  @throws std::logic_error if given an explicitly empty prerequisite list. */
+  const CacheEntry& DeclareCacheEntry(
+      std::string description, CacheEntry::AllocCallback alloc_function,
+      CacheEntry::CalcCallback calc_function,
+      std::vector<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()});
+
+  /** Declares a cache entry by specifying member functions to use both for the
+  allocator and calculator. The signatures are: @code
+    ValueType MySystem::MakeValueType(const MyContext&) const;
+    void MySystem::CalcCacheValue(const MyContext&, ValueType*) const;
+  @endcode
+  where `MySystem` is a class derived from `SystemBase`, `MyContext` is a class
+  derived from `ContextBase`, and `ValueType` is any concrete type such that
+  `Value<ValueType>` is permitted. (The method names are arbitrary.) Template
+  arguments will be deduced and do not need to be specified. See the first
+  DeclareCacheEntry() signature above for more information about the parameters
+  and behavior.
+  @see drake::systems::Value */
+  template <class MySystem, class MyContext, typename ValueType>
+  const CacheEntry& DeclareCacheEntry(
+      std::string description,
+      ValueType (MySystem::*make)(const MyContext&) const,
+      void (MySystem::*calc)(const MyContext&, ValueType*) const,
+      std::vector<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()});
+
+  /** Declares a cache entry by specifying a model value of concrete type
+  `ValueType` and a calculator function that is a class member function (method)
+  with signature: @code
+    void MySystem::CalcCacheValue(const MyContext&, ValueType*) const;
+  @endcode
+  where `MySystem` is a class derived from `SystemBase`, `MyContext` is a class
+  derived from `ContextBase`, and `ValueType` is any concrete type such that
+  `Value<ValueType>` is permitted. (The method names are arbitrary.) Template
+  arguments will be deduced and do not need to be specified.
+  See the first DeclareCacheEntry() signature above for more information about
+  the parameters and behavior.
+  @see drake::systems::Value */
+  template <class MySystem, class MyContext, typename ValueType>
+  const CacheEntry& DeclareCacheEntry(
+      std::string description, const ValueType& model_value,
+      void (MySystem::*calc)(const MyContext&, ValueType*) const,
+      std::vector<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()});
+
+  /** Declares a cache entry by specifying only a calculator function that is a
+  class member function (method) with signature:
+  @code
+    void MySystem::CalcCacheValue(const MyContext&, ValueType*) const;
+  @endcode
+  where `MySystem` is a class derived from `SystemBase` and `MyContext` is a
+  class derived from `ContextBase`. `ValueType` is a concrete type such that
+  (a) `Value<ValueType>` is permitted, and (b) `ValueType` is default
+  constructible. That allows us to create a model value using
+  `Value<ValueType>{}` (value initialized so numerical types will be zeroed in
+  the model). (The method name is arbitrary.) Template arguments will be
+  deduced and do not need to be specified. See the first DeclareCacheEntry()
+  signature above for more information about the parameters and behavior.
+
+  @note The default constructor will be called once immediately to create a
+  model value, and subsequent allocations will just copy the model value without
+  invoking the constructor again. If you want the constructor invoked again at
+  each allocation (not common), use one of the other signatures to explicitly
+  provide a method for the allocator to call; that method can then invoke
+  the `ValueType` default constructor each time it is called.
+  @see drake::systems::Value */
+  template <class MySystem, class MyContext, typename ValueType>
+  const CacheEntry& DeclareCacheEntry(
+      std::string description,
+      void (MySystem::*calc)(const MyContext&, ValueType*) const,
+      std::vector<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()});
+  //@}
+
+  /** Checks whether the given context is valid for this System and throws
+  an exception with a helpful message if not. This is *very* expensive and
+  should generally be done only in Debug builds, like this:
+  @code
+     DRAKE_ASSERT_VOID(CheckValidContext(context));
+  @endcode */
+  void CheckValidContext(const ContextBase& context) const {
+    // TODO(sherm1) Add base class checks.
+
+    // Let derived classes have their say.
+    DoCheckValidContext(context);
+  }
+
+  //============================================================================
+  /** @name                     Dependency tickets
+  @anchor DependencyTicket_documentation
+
+  Use these tickets to declare well-known sources as prerequisites of a
+  downstream computation such as an output port, derivative, update, or cache
+  entry. The ticket numbers for these sources are the same for all subsystems.
+  For time and accuracy they refer to the same global resource; otherwise they
+  refer to the specified sources within the referencing subsystem.
+
+  A dependency ticket for a more specific resource (a particular input or
+  output port, a discrete variable group, abstract state variable, a parameter,
+  or a cache entry) is allocated and stored with the resource when it is
+  declared. Usually the tickets are obtained directly from the resource but
+  you can recover them with methods here knowing only the resource index. */
+  //@{
+
+  /** Returns a ticket indicating dependence on every possible independent
+  source value, including time, state, input ports, parameters, and the accuracy
+  setting (but not cache entries). This is the default dependency for
+  computations that have not specified anything more refined. */
+  static DependencyTicket all_sources_ticket() {
+    return DependencyTicket(internal::kAllSourcesTicket);
+  }
+
+  /** Returns a ticket indicating that a computation does not depend on *any*
+  source value; that is, it is a constant. If this appears in a prerequisite
+  list, it must be the only entry. */
+  static DependencyTicket nothing_ticket() {
+    return DependencyTicket(internal::kNothingTicket);
+  }
+
+  /** Returns a ticket indicating dependence on time. This is the same ticket
+  for all subsystems and refers to the same time value. */
+  static DependencyTicket time_ticket() {
+    return DependencyTicket(internal::kTimeTicket);
+  }
+
+  /** Returns a ticket indicating dependence on the accuracy setting in the
+  Context. This is the same ticket for all subsystems and refers to the same
+  accuracy value. */
+  static DependencyTicket accuracy_ticket() {
+    return DependencyTicket(internal::kAccuracyTicket);
+  }
+
+  /** Returns a ticket indicating that a computation depends on configuration
+  state variables q. */
+  static DependencyTicket q_ticket() {
+    return DependencyTicket(internal::kQTicket);
+  }
+
+  /** Returns a ticket indicating dependence on velocity state variables v. This
+  does _not_ also indicate a dependence on configuration variables q -- you must
+  list that explicitly or use kinematics_ticket() instead. */
+  static DependencyTicket v_ticket() {
+    return DependencyTicket(internal::kVTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the miscellaneous
+  continuous state variables z. */
+  static DependencyTicket z_ticket() {
+    return DependencyTicket(internal::kZTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the continuous
+  state variables q, v, or z. */
+  static DependencyTicket xc_ticket() {
+    return DependencyTicket(internal::kXcTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the numerical
+  discrete state variables, in any discrete variable group. */
+  static DependencyTicket xd_ticket() {
+    return DependencyTicket(internal::kXdTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the abstract
+  state variables in the current Context. */
+  static DependencyTicket xa_ticket() {
+    return DependencyTicket(internal::kXaTicket);
+  }
+
+  /** Returns a ticket indicating dependence on _all_ state variables x in this
+  subsystem, including continuous variables xc, discrete (numeric) variables xd,
+  and abstract state variables xa. This does not imply dependence on time,
+  parameters, or inputs; those must be specified separately. If you mean to
+  express dependence on all possible value sources, use all_sources_ticket()
+  instead. */
+  static DependencyTicket all_state_ticket() {
+    return DependencyTicket(internal::kXTicket);
+  }
+
+  /** Returns a ticket for the cache entry that holds time derivatives of
+  the continuous variables. */
+  static DependencyTicket xcdot_ticket() {
+    return DependencyTicket(internal::kXcdotTicket);
+  }
+
+  /** Returns a ticket for the cache entry that holds the discrete state
+  update for the numerical discrete variables in the state. */
+  static DependencyTicket xdhat_ticket() {
+    return DependencyTicket(internal::kXdhatTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all the configuration
+  variables for this System. By default this is set to the continuous
+  second-order state variables q, but configuration may be represented
+  differently in some systems (discrete ones, for example), in which case this
+  ticket should have been set to depend on that representation. */
+  static DependencyTicket configuration_ticket() {
+    return DependencyTicket(internal::kConfigurationTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the velocity variables
+  for this System. By default this is set to the continuous state variables v,
+  but velocity may be represented differently in some systems (discrete ones,
+  for example), in which case this ticket should have been set to depend on that
+  representation. */
+  static DependencyTicket velocity_ticket() {
+    return DependencyTicket(internal::kVelocityTicket);
+  }
+
+  /** Returns a ticket indicating dependence on all of the configuration
+  and velocity state variables of this System. This ticket depends on the
+  configuration_ticket and the velocity_ticket.
+  @see configuration_ticket(), velocity_ticket() */
+  static DependencyTicket kinematics_ticket() {
+    return DependencyTicket(internal::kKinematicsTicket);
+  }
+
+  /** Returns a ticket indicating dependence on _all_ parameters p in this
+  subsystem, including numeric parameters pn, and abstract parameters pa. */
+  static DependencyTicket all_parameters_ticket() {
+    return DependencyTicket(internal::kAllParametersTicket);
+  }
+
+  /** Returns a ticket indicating dependence on _all_ input ports u of this
+  subsystem. */
+  static DependencyTicket all_input_ports_ticket() {
+    return DependencyTicket(internal::kAllInputPortsTicket);
+  }
+
+  /** Returns a ticket indicating dependence on a particular cache entry. */
+  DependencyTicket cache_entry_ticket(CacheIndex index) {
+    DRAKE_DEMAND(0 <= index && index < num_cache_entries());
+    return cache_entries_[index]->ticket();
+  }
+  //@}
+
+ protected:
+  SystemBase() = default;
+
+  /** Derived class implementations should allocate a suitable
+  default-constructed Context, with default-constructed subcontexts for
+  diagrams. The base class allocates trackers for known resources and
+  intra-subcontext dependencies. No inter-subcontext dependencies should be
+  made in this step. */
+  virtual std::unique_ptr<ContextBase> DoMakeContext() const = 0;
+
+  /** Derived classes must implement this to verify that the supplied
+  context is suitable, and throw an exception if not. */
+  virtual void DoCheckValidContext(const ContextBase&) const = 0;
+
+ private:
+  // Assigns the next unused dependency ticket number, unique only within a
+  // particular subsystem. Each call to this method increments the
+  // ticket number.
+  DependencyTicket assign_next_dependency_ticket() {
+    return next_available_ticket_++;
+  }
+
+  // Ports and cache entries hold their own DependencyTickets. Note that the
+  // addresses of the elements are stable even if the std::vectors are resized.
+
+  // Indexed by CacheIndex.
+  std::vector<std::unique_ptr<CacheEntry>> cache_entries_;
+  // TODO(sherm1) Add input and output ports here.
+
+  // States and parameters don't hold their own tickets so we track them here.
+  // TODO(sherm1) Add state & parameter trackers here.
+
+  // Initialize to the first ticket number available after all the well-known
+  // ones. This gets incremented as tickets are handed out for the optional
+  // entities above.
+  DependencyTicket next_available_ticket_{internal::kNextAvailableTicket};
+
+  // Name of this subsystem.
+  std::string name_;
+};
+
+// Implementations of templatized DeclareCacheEntry() methods.
+
+// Takes make() and calc() member functions.
+template <class MySystem, class MyContext, typename ValueType>
+const CacheEntry& SystemBase::DeclareCacheEntry(
+    std::string description,
+    ValueType (MySystem::*make)(const MyContext&) const,
+    void (MySystem::*calc)(const MyContext&, ValueType*) const,
+    std::vector<DependencyTicket> prerequisites_of_calc) {
+  static_assert(std::is_base_of<SystemBase, MySystem>::value,
+                "Expected to be invoked from a SystemBase-derived System.");
+  static_assert(std::is_base_of<ContextBase, MyContext>::value,
+                "Expected to be invoked with a ContextBase-derived Context.");
+  auto this_ptr = dynamic_cast<const MySystem*>(this);
+  DRAKE_DEMAND(this_ptr != nullptr);
+  auto alloc_callback = [this_ptr, make](const ContextBase& context) {
+    const auto& typed_context = dynamic_cast<const MyContext&>(context);
+    return AbstractValue::Make((this_ptr->*make)(typed_context));
+  };
+  auto calc_callback = [this_ptr, calc](const ContextBase& context,
+                                        AbstractValue* result) {
+    const auto& typed_context = dynamic_cast<const MyContext&>(context);
+    ValueType& typed_result = result->GetMutableValue<ValueType>();
+    (this_ptr->*calc)(typed_context, &typed_result);
+  };
+  // Invoke the general signature above.
+  auto& entry = DeclareCacheEntry(
+      std::move(description), std::move(alloc_callback),
+      std::move(calc_callback), std::move(prerequisites_of_calc));
+  return entry;
+}
+
+// Takes an initial value and calc() member function.
+template <class MySystem, class MyContext, typename ValueType>
+const CacheEntry& SystemBase::DeclareCacheEntry(
+    std::string description, const ValueType& model_value,
+    void (MySystem::*calc)(const MyContext&, ValueType*) const,
+    std::vector<DependencyTicket> prerequisites_of_calc) {
+  static_assert(std::is_base_of<SystemBase, MySystem>::value,
+                "Expected to be invoked from a SystemBase-derived System.");
+  static_assert(std::is_base_of<ContextBase, MyContext>::value,
+                "Expected to be invoked with a ContextBase-derived Context.");
+  auto this_ptr = dynamic_cast<const MySystem*>(this);
+  DRAKE_DEMAND(this_ptr != nullptr);
+  // The given model value may have *either* a copy constructor or a Clone()
+  // method, since it just has to be suitable for containing in an
+  // AbstractValue. We need to create a functor that is copy constructible,
+  // so need to wrap the model value to give it a copy constructor. Drake's
+  // copyable_unique_ptr does just that, so is suitable for capture by the
+  // allocator functor here.
+  copyable_unique_ptr<AbstractValue> owned_model(
+      new Value<ValueType>(model_value));
+  auto alloc_callback = [model = std::move(owned_model)](const ContextBase&) {
+    return model->Clone();
+  };
+  auto calc_callback = [this_ptr, calc](const ContextBase& context,
+                                        AbstractValue* result) {
+    const auto& typed_context = dynamic_cast<const MyContext&>(context);
+    ValueType& typed_result = result->GetMutableValue<ValueType>();
+    (this_ptr->*calc)(typed_context, &typed_result);
+  };
+  auto& entry = DeclareCacheEntry(
+      std::move(description), std::move(alloc_callback),
+      std::move(calc_callback), std::move(prerequisites_of_calc));
+  return entry;
+}
+
+// Takes just a calc() member function, value-initializes entry.
+template <class MySystem, class MyContext, typename ValueType>
+const CacheEntry& SystemBase::DeclareCacheEntry(
+    std::string description,
+    void (MySystem::*calc)(const MyContext&, ValueType*) const,
+    std::vector<DependencyTicket> prerequisites_of_calc) {
+  static_assert(std::is_base_of<SystemBase, MySystem>::value,
+                "Expected to be invoked from a SystemBase-derived System.");
+  static_assert(std::is_base_of<ContextBase, MyContext>::value,
+                "Expected to be invoked with a ContextBase-derived Context.");
+  static_assert(
+      std::is_default_constructible<ValueType>::value,
+      "SystemBase::DeclareCacheEntry(calc): the calc-only overload of "
+      "this method requires that the output type has a default constructor");
+  // Invokes the above model-value method. Note that value initialization {}
+  // is required here.
+  return DeclareCacheEntry(std::move(description), ValueType{}, calc,
+                           std::move(prerequisites_of_calc));
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -1,0 +1,614 @@
+#include "drake/systems/framework/cache.h"
+
+// Tests the System (const) side of caching, which consists of a CacheEntry
+// objects that can be provided automatically or defined by users. When a
+// Context is created, each CacheEntry in a System is provided with a
+// CacheEntryValue in its corresponding Context.
+//
+// Here we test that the DeclareCacheEntry() API works correctly, that
+// the resulting CacheEntry objects behave properly, and that they are
+// assigned appropriate CacheEntryValue objects in the Context. A lot of
+// the testing here is to make sure dependencies are being properly handled.
+// The Context side tests are provided in cache_test.cc; we are testing the
+// System side here.
+
+#include <memory>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/common/text_logging.h"
+#include "drake/systems/framework/system_base.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+#include "drake/systems/framework/test_utilities/pack_value.h"
+#include "drake/systems/framework/value.h"
+
+using std::string;
+using Eigen::Vector3d;
+
+namespace drake {
+namespace systems {
+namespace {
+
+// Free functions suitable for defining cache entries.
+auto Alloc3 = [](const ContextBase&) { return AbstractValue::Make<int>(3); };
+auto Calc99 = [](const ContextBase&, AbstractValue* result) {
+  result->SetValue(99);
+};
+
+// This one is fatally flawed since null is not allowed.
+auto AllocNull = [](const ContextBase&) {
+  return std::unique_ptr<AbstractValue>();
+};
+
+// This is so we can use the contained cache & dependency graph objects.
+class MyContextBase : public ContextBase {
+ public:
+  MyContextBase() = default;
+  MyContextBase(const MyContextBase&) = default;
+
+ private:
+  std::unique_ptr<ContextBase> DoCloneWithoutPointers() const final {
+    return std::unique_ptr<ContextBase>(new MyContextBase(*this));
+  }
+};
+
+// Dependency chains for cache entries here:
+//
+//   +-----------+    +--------------+
+//   |   time    +--->| string_entry +-----------+
+//   +-+---------+    +--------------+           |
+//     |                                         |
+//     |  +------+                        +------v-------+
+//     |  |  xc  +------------------------> vector_entry +
+//     |  +--+---+                        +--------------+
+//     |     |
+//   +-v-----v---+    +--------------+    +--------------+
+//   |all_sources+--->|    entry0    +---->    entry1    +
+//   +-----------+    +------+-------+    +------+-------+
+//                           |                   |
+//                           |            +------v-------+
+//                           +------------>    entry2    +
+//                                        +--------------+
+//
+// Note that this diagram depicts DependencyTracker ("tracker") objects, not
+// cache entries. The boxes labeled "entry" correspond to cache entries; time,
+// xc, and all_sources are other dependency trackers that do not correspond to
+// any cache entries.
+//
+// The dependencies for all_sources are set up automatically during
+// Context construction; the others are set explicitly here.
+//
+// Value types:
+//   int: entry0,1,2
+//   string: string_entry
+//   MyVector3: vector_entry
+class MySystemBase final : public SystemBase {
+ public:
+  // Use at least one of each of the four DeclareCacheEntry() variants.
+  MySystemBase()
+        // 1. Use the most general method, taking free functions. Unspecified
+        //    prerequisites should default to all_sources_ticket().
+      : entry0_(DeclareCacheEntry("entry0", Alloc3, Calc99)),
+        // 2. Use the method that takes two member functions.
+        entry1_(DeclareCacheEntry("entry1", &MySystemBase::MakeInt1,
+                                  &MySystemBase::CalcInt98,
+                                  {entry0_.ticket()})),
+        // 3a. Use the method that takes a model value and member calculator.
+        entry2_(DeclareCacheEntry("entry2", 2, &MySystemBase::CalcInt98,
+                                  {entry0_.ticket(), entry1_.ticket()})),
+        // 4. Use the method that takes just a member calculator
+        // (value-initializes the cache entry).
+        string_entry_(DeclareCacheEntry("string thing",
+                                        &MySystemBase::CalcString,
+                                        {time_ticket()})),
+        // 3b. Also a model value and member calculator.
+        vector_entry_(
+            DeclareCacheEntry("vector thing", MyVector3d(Vector3d(1., 2., 3.)),
+                              &MySystemBase::CalcMyVector3,
+                              {xc_ticket(), string_entry_.ticket()})) {
+    set_name("cache_entry_test_system");
+    EXPECT_EQ(num_cache_entries(), 5);
+    EXPECT_EQ(GetSystemName(), "cache_entry_test_system");
+  }
+
+  const CacheEntry& entry0() const { return entry0_; }
+  const CacheEntry& entry1() const { return entry1_; }
+  const CacheEntry& entry2() const { return entry2_; }
+  const CacheEntry& string_entry() const { return string_entry_; }
+  const CacheEntry& vector_entry() const { return vector_entry_; }
+
+  // For use as an allocator.
+  int MakeInt1(const MyContextBase&) const { return 1; }
+  // For use as a cache entry calculator.
+  void CalcInt98(const MyContextBase& my_context, int* out) const {
+    *out = 98;
+  }
+  void CalcString(const MyContextBase& my_context, string* out) const {
+    *out = "calculated_result";
+  }
+  void CalcMyVector3(const MyContextBase& my_context, MyVector3d* out) const {
+    out->set_value(Vector3d(3., 2., 1.));
+  }
+
+ private:
+  std::unique_ptr<ContextBase> DoMakeContext() const override {
+    return std::make_unique<MyContextBase>();
+  }
+
+  void DoCheckValidContext(const ContextBase&) const override {}
+
+  const CacheEntry& entry0_;
+  const CacheEntry& entry1_;
+  const CacheEntry& entry2_;
+  const CacheEntry& string_entry_;
+  const CacheEntry& vector_entry_;
+};
+
+// An allocator is not permitted to return null. That should be caught when
+// we allocate a Context.
+GTEST_TEST(CacheEntryAllocTest, BadAllocGetsCaught) {
+  MySystemBase system;
+  system.DeclareCacheEntry("bad alloc entry", AllocNull, Calc99,
+                           {system.nothing_ticket()});
+  // Error messages should include the System name and type, cache entry
+  // description, and the specific message. The first three are boilerplate so
+  // we'll just check once here; everywhere else we'll just check for the
+  // right message.
+  DRAKE_EXPECT_THROWS_MESSAGE(system.AllocateContext(), std::logic_error,
+                              ".*cache_entry_test_system"
+                              ".*MySystemBase"
+                              ".*bad alloc entry"
+                              ".*allocator returned a nullptr.*");
+}
+
+// Leaving out prerequisites altogether defaults to all sources and is fine
+// (that default is tested for entry0 in SetUp() below). Explicitly specifying
+// an empty list is forbidden -- the proper syntax for saying there are no
+// dependencies is `{nothing_ticket()}`.
+GTEST_TEST(CacheEntryAllocTest, EmptyPrerequisiteListForbidden) {
+  MySystemBase system;
+  EXPECT_NO_THROW(
+      system.DeclareCacheEntry("default prerequisites", Alloc3, Calc99));
+  EXPECT_NO_THROW(system.DeclareCacheEntry("no prerequisites", Alloc3, Calc99,
+                                           {system.nothing_ticket()}));
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      system.DeclareCacheEntry("empty prerequisites", Alloc3, Calc99, {}),
+      std::logic_error,
+      ".*[Cc]annot create.*empty prerequisites.*nothing_ticket.*");
+}
+
+// Allocate a System and Context and provide some convenience methods.
+class CacheEntryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    index0_ = entry0().cache_index();
+    index1_ = entry1().cache_index();
+    index2_ = entry2().cache_index();
+    string_index_ = string_entry().cache_index();
+    vector_index_ = vector_entry().cache_index();
+
+    // We left prerequisites unspecified for entry0 -- should have defaulted
+    // to all_sources.
+    const DependencyTracker& entry0_tracker = tracker(entry0().cache_index());
+    EXPECT_EQ(entry0_tracker.prerequisites().size(), 1);
+    EXPECT_EQ(entry0_tracker.prerequisites()[0],
+              &context_.get_tracker(system_.all_sources_ticket()));
+
+    EXPECT_TRUE(entry0().is_out_of_date(context_));
+    EXPECT_TRUE(entry1().is_out_of_date(context_));
+    EXPECT_TRUE(entry2().is_out_of_date(context_));
+    EXPECT_TRUE(string_entry().is_out_of_date(context_));
+    EXPECT_TRUE(vector_entry().is_out_of_date(context_));
+
+    // Set the initial values and mark them up to date.
+    // Make the initial values up to date.
+    cache_value(index0_).mark_up_to_date();
+    cache_value(index1_).mark_up_to_date();
+    cache_value(index2_).mark_up_to_date();
+    cache_value(string_index_).mark_up_to_date();
+
+    EXPECT_EQ(entry0().GetKnownUpToDate<int>(context_), 3);
+    EXPECT_EQ(entry1().GetKnownUpToDate<int>(context_), 1);
+    EXPECT_EQ(entry2().GetKnownUpToDate<int>(context_), 2);
+    // String should have been value-initialized.
+    EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "");
+    // Let's change its initial value. Can't when it's up to date.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        cache_value(string_index_).SetValueOrThrow<string>("initial"),
+        std::logic_error,
+        ".*SetValueOrThrow().*current value.*already up to date.*");
+    cache_value(string_index_).mark_out_of_date();
+    cache_value(string_index_).SetValueOrThrow<string>("initial");
+    EXPECT_EQ(cache_value(string_index_).GetValueOrThrow<string>(), "initial");
+    EXPECT_FALSE(string_entry().is_out_of_date(context_));
+
+    // vector_entry still invalid so we can only peek.
+    DRAKE_EXPECT_THROWS_MESSAGE(
+        vector_entry().GetKnownUpToDate<MyVector3d>(context_), std::logic_error,
+        ".*GetKnownUpToDate().*value out of date.*");
+    EXPECT_EQ(
+        cache_value(vector_index_).PeekValueOrThrow<MyVector3d>().get_value(),
+        Vector3d(1., 2., 3.));
+
+    cache_value(vector_index_).set_value(MyVector3d(Vector3d(99., 98., 97.)));
+
+    // Everything should be up to date to start out.
+    EXPECT_FALSE(entry0().is_out_of_date(context_));
+    EXPECT_FALSE(entry1().is_out_of_date(context_));
+    EXPECT_FALSE(entry2().is_out_of_date(context_));
+    EXPECT_FALSE(string_entry().is_out_of_date(context_));
+    EXPECT_FALSE(vector_entry().is_out_of_date(context_));
+  }
+
+  const CacheEntry& entry0() const { return system_.entry0(); }
+  const CacheEntry& entry1() const { return system_.entry1(); }
+  const CacheEntry& entry2() const { return system_.entry2(); }
+  const CacheEntry& string_entry() const { return system_.string_entry(); }
+  const CacheEntry& vector_entry() const { return system_.vector_entry(); }
+
+  const DependencyTracker& tracker(CacheIndex index) {
+    return tracker(cache_value(index).ticket());
+  }
+  void invalidate(CacheIndex index) {
+    static int64_t next_change_event = 1;
+    const int64_t event = next_change_event++;
+    cache_value(index).mark_out_of_date();
+    tracker(index).NoteValueChange(event);
+  }
+
+  const DependencyGraph& graph() {
+    return context_.get_mutable_dependency_graph();
+  }
+  const DependencyTracker& tracker(DependencyTicket dticket) {
+    return graph().get_tracker(dticket);
+  }
+
+  // Create a System and a Context to match.
+  MySystemBase system_;
+  std::unique_ptr<ContextBase> context_base_ = system_.AllocateContext();
+  MyContextBase& context_ = dynamic_cast<MyContextBase&>(*context_base_);
+  CacheIndex index0_, index1_, index2_;
+  CacheIndex string_index_, vector_index_;
+
+ private:
+  CacheEntryValue& cache_value(CacheIndex index) {
+    return context_.get_mutable_cache().get_mutable_cache_entry_value(index);
+  }
+};
+
+// Test that the GetKnownUpToDate/Calc/Eval() methods work.
+TEST_F(CacheEntryTest, ValueMethodsWork) {
+  CacheEntryValue& value0 = entry0().get_mutable_cache_entry_value(context_);
+  int64_t expected_serial_num = value0.serial_number();
+  EXPECT_EQ(entry0().GetKnownUpToDate<int>(context_), 3);
+  EXPECT_EQ(value0.serial_number(), expected_serial_num);  // No change.
+  EXPECT_EQ(entry0().Eval<int>(context_), 3);  // Up to date; shouldn't update.
+  EXPECT_EQ(value0.serial_number(), expected_serial_num);  // No change.
+  value0.mark_out_of_date();
+  DRAKE_EXPECT_THROWS_MESSAGE(entry0().GetKnownUpToDate<int>(context_),
+                              std::logic_error,
+                              ".*GetKnownUpToDate().*value out of date.*");
+  EXPECT_EQ(entry0().Eval<int>(context_), 99);  // Should update now.
+  ++expected_serial_num;
+  EXPECT_EQ(value0.serial_number(), expected_serial_num);  // Increased.
+
+  // EvalAbstract() should retrieve the same object as Eval() did.
+  const AbstractValue& abstract_value_eval = entry0().EvalAbstract(context_);
+  EXPECT_EQ(value0.serial_number(), expected_serial_num);  // No change.
+  EXPECT_EQ(abstract_value_eval.GetValueOrThrow<int>(), 99);
+
+  // GetKnownUpToDateAbstract() should return the same object as EvalAbstract().
+  const AbstractValue& abstract_value_get =
+      entry0().GetKnownUpToDateAbstract(context_);
+  EXPECT_EQ(&abstract_value_get, &abstract_value_eval);
+  EXPECT_EQ(value0.serial_number(), expected_serial_num);  // No change.
+
+  CacheEntryValue& string_value =
+      string_entry().get_mutable_cache_entry_value(context_);
+  expected_serial_num = string_value.serial_number();
+  EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "initial");
+  EXPECT_EQ(string_value.serial_number(), expected_serial_num);  // No change.
+
+  // Check that the Calc() method produces output but doesn't change the
+  // stored value.
+  std::unique_ptr<AbstractValue> out = AbstractValue::Make<string>("something");
+  string_entry().Calc(context_, &*out);
+  EXPECT_EQ(out->GetValue<string>(), "calculated_result");
+  EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "initial");
+  EXPECT_EQ(string_value.serial_number(), expected_serial_num);  // No change.
+
+// In Debug we have an expensive check that the output type provided to
+// Calc() has the right concrete type. Make sure it works.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  auto bad_out = AbstractValue::Make<double>(3.14);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      string_entry().Calc(context_, &*bad_out), std::logic_error,
+      ".*Calc().*expected.*type.*string.*but got.*double.*");
+#endif
+
+  // The value is currently marked up to date, so Eval does nothing.
+  const string& result = string_entry().Eval<string>(context_);
+  EXPECT_EQ(result, "initial");
+  // Force out-of-date.
+  string_value.mark_out_of_date();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      string_entry().GetKnownUpToDateAbstract(context_), std::logic_error,
+      ".*GetKnownUpToDateAbstract().*value out of date.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(string_entry().GetKnownUpToDate<string>(context_),
+                              std::logic_error,
+                              ".*GetKnownUpToDate().*value out of date.*");
+  string_entry().Eval<string>(context_);
+  ++expected_serial_num;
+  EXPECT_FALSE(string_entry().is_out_of_date(context_));
+  EXPECT_NO_THROW(string_entry().GetKnownUpToDate<string>(context_));
+  EXPECT_EQ(string_value.serial_number(), expected_serial_num);  // Updated.
+
+  // The result reference was updated by the Eval().
+  EXPECT_EQ(result, "calculated_result");
+  // GetKnownUpToDate() returns the same reference.
+  EXPECT_EQ(&string_entry().GetKnownUpToDate<string>(context_), &result);
+
+  // This is the wrong value type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      string_entry().GetKnownUpToDate<int>(context_), std::logic_error,
+      ".*GetKnownUpToDate().*wrong value type.*int.*actual type.*string.*");
+}
+
+// Check that a chain of dependent cache entries gets invalidated properly.
+// See Diagram above for expected dependencies.
+TEST_F(CacheEntryTest, InvalidationWorks) {
+  // Everything starts out up to date. This should invalidate everything.
+  context_.get_tracker(system_.time_ticket()).NoteValueChange(99);
+  EXPECT_TRUE(entry0().is_out_of_date(context_));
+  EXPECT_TRUE(entry1().is_out_of_date(context_));
+  EXPECT_TRUE(entry2().is_out_of_date(context_));
+  EXPECT_TRUE(string_entry().is_out_of_date(context_));
+  EXPECT_TRUE(vector_entry().is_out_of_date(context_));
+}
+
+// Make sure the debugging routine that invalidates everything works.
+TEST_F(CacheEntryTest, InvalidateAllWorks) {
+  // Everything starts out up to date. This should invalidate everything.
+  context_.SetAllCacheEntriesOutOfDate();
+  EXPECT_TRUE(entry0().is_out_of_date(context_));
+  EXPECT_TRUE(entry1().is_out_of_date(context_));
+  EXPECT_TRUE(entry2().is_out_of_date(context_));
+  EXPECT_TRUE(string_entry().is_out_of_date(context_));
+  EXPECT_TRUE(vector_entry().is_out_of_date(context_));
+}
+
+// Make sure the debugging routine to disable the cache works, and is
+// independent of the out_of_date flags.
+TEST_F(CacheEntryTest, DisableCacheWorks) {
+  CacheEntryValue& int_val = entry1().get_mutable_cache_entry_value(context_);
+  CacheEntryValue& str_val =
+      string_entry().get_mutable_cache_entry_value(context_);
+  CacheEntryValue& vec_val =
+      vector_entry().get_mutable_cache_entry_value(context_);
+
+  // Everything starts out up to date. Memorize serial numbers.
+  int64_t ser_int = int_val.serial_number();
+  int64_t ser_str = str_val.serial_number();
+  int64_t ser_vec = vec_val.serial_number();
+
+  EXPECT_FALSE(int_val.needs_recomputation());
+  EXPECT_FALSE(str_val.needs_recomputation());
+  EXPECT_FALSE(vec_val.needs_recomputation());
+
+  // Eval() shouldn't have to recalculate since caching is enabled.
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  vector_entry().EvalAbstract(context_);
+
+  EXPECT_EQ(int_val.serial_number(), ser_int);  // No change to serial numbers.
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+  EXPECT_EQ(vec_val.serial_number(), ser_vec);
+
+  context_.DisableCaching();
+  // Up-to-date shouldn't be affected, but now we need recomputation.
+  EXPECT_FALSE(int_val.is_out_of_date());
+  EXPECT_FALSE(str_val.is_out_of_date());
+  EXPECT_FALSE(vec_val.is_out_of_date());
+  EXPECT_TRUE(int_val.needs_recomputation());
+  EXPECT_TRUE(str_val.needs_recomputation());
+  EXPECT_TRUE(vec_val.needs_recomputation());
+
+  // Eval() should recalculate even though up-to_date is true.
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  vector_entry().EvalAbstract(context_);
+  ++ser_int; ++ser_str; ++ser_vec;
+
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+  EXPECT_EQ(vec_val.serial_number(), ser_vec);
+
+  // Flags are still supposed to be functioning while caching is disabled,
+  // even though they are mostly ignored. (The GetKnownUpToDate() methods
+  // depends on them.)
+  int_val.mark_out_of_date();
+  str_val.mark_out_of_date();
+  vec_val.mark_out_of_date();
+
+  // Eval() should recalculate and mark entries up to date.
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  vector_entry().EvalAbstract(context_);
+  ++ser_int; ++ser_str; ++ser_vec;
+
+  EXPECT_FALSE(int_val.is_out_of_date());
+  EXPECT_FALSE(str_val.is_out_of_date());
+  EXPECT_FALSE(vec_val.is_out_of_date());
+
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+  EXPECT_EQ(vec_val.serial_number(), ser_vec);
+
+  // GetKnownUpToDate() should work even though caching is disabled, since the
+  // entries are marked up to date.
+  EXPECT_NO_THROW(entry1().GetKnownUpToDate<int>(context_));
+  EXPECT_NO_THROW(string_entry().GetKnownUpToDate<string>(context_));
+  EXPECT_NO_THROW(vector_entry().GetKnownUpToDate<MyVector3d>(context_));
+
+  // Now re-enable caching and verify that it works.
+  EXPECT_TRUE(entry1().is_cache_entry_disabled(context_));
+  EXPECT_TRUE(string_entry().is_cache_entry_disabled(context_));
+  context_.EnableCaching();
+  EXPECT_FALSE(entry1().is_cache_entry_disabled(context_));
+  EXPECT_FALSE(string_entry().is_cache_entry_disabled(context_));
+
+  // These are still up to date since enable/disable is independent. So
+  // these Eval's should be no-ops.
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+
+  // Verify that we can disable/enable a single entry.
+  string_entry().disable_caching(context_);
+
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  ++ser_str;  // Only disabled entry needs recalculation.
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+
+  // Enable and verify that no computation is required for either entry.
+  string_entry().enable_caching(context_);
+  entry1().EvalAbstract(context_);
+  string_entry().EvalAbstract(context_);
+  EXPECT_EQ(int_val.serial_number(), ser_int);
+  EXPECT_EQ(str_val.serial_number(), ser_str);
+}
+
+// Test that the vector-valued cache entry works and preserved the underlying
+// concrete type.
+TEST_F(CacheEntryTest, VectorCacheEntryWorks) {
+  auto& entry = system_.get_cache_entry(vector_index_);
+  auto& entry_value = entry.get_mutable_cache_entry_value(context_);
+  EXPECT_FALSE(entry_value.is_out_of_date());  // We set it during construction.
+  const MyVector3d& contents = entry_value.get_value<MyVector3d>();
+  Vector3d eigen_contents = contents.get_value();
+  EXPECT_EQ(eigen_contents, Vector3d(99., 98., 97.));
+
+  // Force Eval to recalculate by pretending we modified a z, which should
+  // invalidate this xc-dependent cache entry.
+  // Note: the change_event number just has to be unique from any others used
+  // on this context, doesn't have to be this particular value!
+  context_.get_mutable_tracker(system_.z_ticket()).NoteValueChange(1001);
+  EXPECT_TRUE(entry_value.is_out_of_date());
+  const MyVector3d& contents2 = entry.Eval<MyVector3d>(context_);
+  EXPECT_FALSE(entry_value.is_out_of_date());
+  Vector3d eigen_contents2 = contents2.get_value();
+  EXPECT_EQ(eigen_contents2, Vector3d(3., 2., 1.));
+  // The contents object should still be the same one.
+  EXPECT_EQ(&contents2, &contents);
+}
+
+// Test that we can swap in a new value if it has the right type, and that
+// the swapped-in value is invalid immediately after swapping. In Debug,
+// test that we throw if the swapped-in value is null or has the
+// wrong type.
+TEST_F(CacheEntryTest, CanSwapValue) {
+  auto& entry_value = string_entry().get_mutable_cache_entry_value(context_);
+  EXPECT_FALSE(entry_value.is_out_of_date());  // Set to "initial".
+  EXPECT_EQ(entry_value.get_value<string>(), "initial");
+  auto new_value = AbstractValue::Make<string>("new value");
+  entry_value.swap_value(&new_value);
+  EXPECT_EQ(new_value->GetValue<string>(), "initial");
+  EXPECT_TRUE(entry_value.is_out_of_date());
+  entry_value.mark_up_to_date();
+  EXPECT_EQ(entry_value.get_value<string>(), "new value");
+  EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_), "new value");
+
+// In Debug builds, try a bad swap and expect it to be caught.
+#ifdef DRAKE_ASSERT_IS_ARMED
+  std::unique_ptr<AbstractValue> empty_ptr;
+  DRAKE_EXPECT_THROWS_MESSAGE(entry_value.swap_value(&empty_ptr),
+                              std::logic_error,
+                              ".*swap_value().*value.*empty.*");
+  auto bad_value = AbstractValue::Make<int>(29);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      entry_value.swap_value(&bad_value), std::logic_error,
+      ".*swap_value().*value.*wrong concrete type.*int.*[Ee]xpected.*string.*");
+#endif
+}
+
+TEST_F(CacheEntryTest, InvalidationIsRecursive) {
+  invalidate(index1_);  // Invalidate entry1.
+  EXPECT_EQ(3, entry0().GetKnownUpToDate<int>(context_));
+  EXPECT_TRUE(entry1().is_out_of_date(context_));
+  EXPECT_TRUE(entry2().is_out_of_date(context_));
+
+  // Shouldn't have leaked into independent entries.
+  EXPECT_FALSE(string_entry().is_out_of_date(context_));
+  EXPECT_FALSE(vector_entry().is_out_of_date(context_));
+}
+
+TEST_F(CacheEntryTest, Copy) {
+  // Create a clone of the cache and dependency graph.
+  auto clone_context_ptr = context_.Clone();
+  MyContextBase& clone_context =
+      dynamic_cast<MyContextBase&>(*clone_context_ptr);
+
+  // The copy should have the same values.
+  EXPECT_EQ(entry0().GetKnownUpToDate<int>(context_),
+            entry0().GetKnownUpToDate<int>(clone_context));
+  EXPECT_EQ(entry1().GetKnownUpToDate<int>(context_),
+            entry1().GetKnownUpToDate<int>(clone_context));
+  EXPECT_EQ(entry2().GetKnownUpToDate<int>(context_),
+            entry2().GetKnownUpToDate<int>(clone_context));
+  EXPECT_EQ(string_entry().GetKnownUpToDate<string>(context_),
+            string_entry().GetKnownUpToDate<string>(clone_context));
+  EXPECT_EQ(
+      vector_entry().GetKnownUpToDate<MyVector3d>(context_).get_value(),
+      vector_entry().GetKnownUpToDate<MyVector3d>(clone_context).get_value());
+
+  // Changes to the copy should not affect the original.
+  EXPECT_EQ(entry2().GetKnownUpToDate<int>(context_), 2);
+  entry2().get_mutable_cache_entry_value(clone_context).mark_out_of_date();
+  EXPECT_EQ(entry2().Eval<int>(clone_context), 98);
+  EXPECT_EQ(entry2().GetKnownUpToDate<int>(context_), 2);
+
+  // This should invalidate everything in the original cache, but nothing
+  // in the copy.
+  // Note: the change_event number just has to be unique from any others used
+  // on this context, doesn't have to be this particular value!
+  context_.get_tracker(system_.time_ticket()).NoteValueChange(10);
+  EXPECT_TRUE(string_entry().is_out_of_date(context_));
+  EXPECT_FALSE(string_entry().is_out_of_date(clone_context));
+  EXPECT_TRUE(vector_entry().is_out_of_date(context_));
+  EXPECT_FALSE(vector_entry().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry0().is_out_of_date(context_));
+  EXPECT_FALSE(entry0().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry1().is_out_of_date(context_));
+  EXPECT_FALSE(entry1().is_out_of_date(clone_context));
+  EXPECT_TRUE(entry2().is_out_of_date(context_));
+  EXPECT_FALSE(entry2().is_out_of_date(clone_context));
+
+  // Bring everything in source context up to date.
+  entry0().EvalAbstract(context_); entry1().EvalAbstract(context_);
+  entry2().EvalAbstract(context_); string_entry().EvalAbstract(context_);
+  vector_entry().EvalAbstract(context_);
+
+  // Pretend entry0 was modified in the copy. Should invalidate the copy's
+  // entry1 & 2, but leave source untouched.
+  entry0().get_mutable_cache_entry_value(clone_context).mark_out_of_date();
+  clone_context.get_tracker(entry0().ticket()).NoteValueChange(11);
+  EXPECT_TRUE(entry0().is_out_of_date(clone_context));
+  EXPECT_FALSE(entry0().is_out_of_date(context_));
+  EXPECT_TRUE(entry1().is_out_of_date(clone_context));
+  EXPECT_FALSE(entry1().is_out_of_date(context_));
+  EXPECT_TRUE(entry2().is_out_of_date(clone_context));
+  EXPECT_FALSE(entry2().is_out_of_date(context_));
+
+  // These aren't downstream of entry0().
+  EXPECT_FALSE(string_entry().is_out_of_date(clone_context));
+  EXPECT_FALSE(vector_entry().is_out_of_date(clone_context));
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This is the next big chunk of caching code from PR #7668. Previous PRs #8050 and #8227 added Context-side caching classes ContextBase, DependencyTracker, and CacheEntryValue; this one adds the corresponding System-side classes SystemBase and CacheEntry.

For the big picture, please see the [caching system design notes](http://drake.mit.edu/doxygen_cxx/group__cache__design__notes.html).

This is an oversize PR though more than half the code is the unit tests and there are lots of comments. Here are the stats:
```
Category            added  modified  removed  
----------------------------------------------
code                885    8         2        
comments            600    8         2        
blank               214    0         0        
----------------------------------------------
TOTAL               1699   16        4        
```
I am hoping this can be reviewed in one piece since it is entirely about the CacheEntry object, which is a substantial piece of new functionality. Please let me know if you think there is a reasonable way to chop it up. One way would be to defer the unit tests to later, though they can be helpful in understanding how the code is intended to work.

SystemBase includes the DeclareCacheEntry API variants intended to be used in System constructors. Reviewers may want to start at the top of cache_entry_test.cc where these are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8372)
<!-- Reviewable:end -->
