### PR TITLE
Use wrapper script to call sphinx-build command

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -8,6 +8,11 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
+drake_py_binary(
+    name = "sphinx_build",
+    srcs = ["sphinx_build.py"],
+)
+
 genrule(
     name = "sphinx",
     srcs = glob([
@@ -20,7 +25,7 @@ genrule(
     outs = ["sphinx.zip"],
     cmd = " ".join([
         # Run sphinx-build.
-        "sphinx-build -b html",  # HTML output.
+        "$(location :sphinx_build) -b html",  # HTML output.
         "-a -E -d $(@D)/.doctrees/",  # Don't use caching.
         "-W -N -q",  # Turn warnings into errors; else be quiet.
         "$$(dirname $(location conf.py))",  # Source dir.
@@ -35,6 +40,7 @@ genrule(
     # Some (currently disabled) Sphinx extentions try to reach out to the
     # network; we should fail-fast if someone tries to turn them on.
     tags = ["block-network"],
+    tools = [":sphinx_build"],
 )
 
 drake_py_binary(

--- a/doc/sphinx_build.py
+++ b/doc/sphinx_build.py
@@ -1,0 +1,7 @@
+import sys
+
+from sphinx.cmd.build import main
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This allows `--experimental_strict_action_env` to be used. On macOS, `sphinx-build` is not in the stripped down `PATH`, but `sphinx` is in the `PYTHONPATH`. Regardless of `--experimental_strict_action_env`, this also allows `pip install --user Sphinx` to be used on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8375)
<!-- Reviewable:end -->
