### PR TITLE
Adds Eigen versions of the Cubic polynomial generation methods.  

### DIFF
--- a/bindings/pydrake/systems/test/trajectory_optimization_test.py
+++ b/bindings/pydrake/systems/test/trajectory_optimization_test.py
@@ -40,7 +40,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         dircol.AddDurationBounds(.3*21, 0.4*21)
         dircol.AddFinalCost(2*x.dot(x))
 
-        initial_u = PiecewisePolynomial.ZeroOrderHold([0, .3*21], [[0], [0]])
+        initial_u = PiecewisePolynomial.ZeroOrderHold([0, .3*21],
+                                                      np.zeros((1, 2)))
         initial_x = PiecewisePolynomial()
         dircol.SetInitialTrajectory(initial_u, initial_x)
 
@@ -81,7 +82,8 @@ class TestTrajectoryOptimization(unittest.TestCase):
         dirtran.AddConstraintToAllKnotPoints(u[0] == 0)
         dirtran.AddFinalCost(2*x.dot(x))
 
-        initial_u = PiecewisePolynomial.ZeroOrderHold([0, .3*21], [[0], [0]])
+        initial_u = PiecewisePolynomial.ZeroOrderHold([0, .3*21],
+                                                      np.zeros((1, 2)))
         initial_x = PiecewisePolynomial()
         dirtran.SetInitialTrajectory(initial_u, initial_x)
 

--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -20,7 +20,7 @@ class TestTrajectories(unittest.TestCase):
         np.testing.assert_equal(x, pp.value(11.))
 
     def test_zero_order_hold(self):
-        x = [[1., 2.], [3., 4.], [5., 6.]]
+        x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.ZeroOrderHold([0., 1., 2.], x)
         np.testing.assert_equal(np.array([[1.], [2.]]), pp.value(.5))
         self.assertEqual(pp.get_number_of_segments(), 2)
@@ -33,14 +33,14 @@ class TestTrajectories(unittest.TestCase):
         self.assertEqual(pp.get_segment_times(), [0., 1., 2.])
 
     def test_first_order_hold(self):
-        x = [[1., 2.], [3., 4.], [5., 6.]]
+        x = np.array([[1., 2.], [3., 4.], [5., 6.]]).transpose()
         pp = PiecewisePolynomial.FirstOrderHold([0., 1., 2.], x)
         np.testing.assert_equal(np.array([[2.], [3.]]), pp.value(.5))
 
     def test_cubic(self):
         t = [0., 1., 2.]
-        x = [[1., 2.], [3., 4.], [5., 6.]]
+        x = np.diag((4., 5., 6.))
         # Just test the spelling for these.
-        pp = PiecewisePolynomial.Cubic(t, x)
-        pp2 = PiecewisePolynomial.Cubic(t, x, x)
-        pp3 = PiecewisePolynomial.Cubic(t, x, [0., 0.], [0., 0.])
+        pp1 = PiecewisePolynomial.Cubic(t, x)
+        pp2 = PiecewisePolynomial.Cubic(t, x, np.identity(3))
+        pp3 = PiecewisePolynomial.Cubic(t, x, [0., 0., 0.], [0., 0., 0.])

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -33,34 +33,37 @@ PYBIND11_MODULE(trajectories, m) {
       m, "PiecewisePolynomial")
       .def(py::init<>())
       .def(py::init<const Eigen::Ref<const MatrixX<T>>&>())
-      .def_static("ZeroOrderHold", &PiecewisePolynomial<T>::ZeroOrderHold)
-      .def_static("FirstOrderHold", &PiecewisePolynomial<T>::FirstOrderHold)
-      .def_static("Pchip", &PiecewisePolynomial<T>::Pchip)
-      .def_static(
-          "Cubic",
-          py::overload_cast<
-              const std::vector<double>&,
-              const std::vector<PiecewisePolynomial<T>::CoefficientMatrix>&,
-              const PiecewisePolynomial<T>::CoefficientMatrix&,
-              const PiecewisePolynomial<T>::CoefficientMatrix&>(
-              &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"), py::arg("knot_dot_start"),
-          py::arg("knot_dot_end"))
-      .def_static(
-          "Cubic",
-          py::overload_cast<
-              const std::vector<double>&,
-              const std::vector<PiecewisePolynomial<T>::CoefficientMatrix>&,
-              const std::vector<PiecewisePolynomial<T>::CoefficientMatrix>&>(
-              &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"))
-      .def_static(
-          "Cubic",
-          py::overload_cast<
-              const std::vector<double>&,
-              const std::vector<PiecewisePolynomial<T>::CoefficientMatrix>&>(
-              &PiecewisePolynomial<T>::Cubic),
-          py::arg("breaks"), py::arg("knots"))
+      .def_static("ZeroOrderHold",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&>(
+                      &PiecewisePolynomial<T>::ZeroOrderHold))
+      .def_static("FirstOrderHold",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&>(
+                      &PiecewisePolynomial<T>::FirstOrderHold))
+      .def_static("Pchip",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&, bool>(
+                      &PiecewisePolynomial<T>::Pchip))
+      .def_static("Cubic",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&,
+                                    const Eigen::Ref<const VectorX<T>>&,
+                                    const Eigen::Ref<const VectorX<T>>&>(
+                      &PiecewisePolynomial<T>::Cubic),
+                  py::arg("breaks"), py::arg("knots"),
+                  py::arg("knot_dot_start"), py::arg("knot_dot_end"))
+      .def_static("Cubic",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&,
+                                    const Eigen::Ref<const MatrixX<T>>&>(
+                      &PiecewisePolynomial<T>::Cubic),
+                  py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"))
+      .def_static("Cubic",
+                  py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const MatrixX<T>>&>(
+                      &PiecewisePolynomial<T>::Cubic),
+                  py::arg("breaks"), py::arg("knots"))
       .def("value", &PiecewisePolynomial<T>::value)
       .def("rows", &PiecewisePolynomial<T>::rows)
       .def("cols", &PiecewisePolynomial<T>::cols);

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -50,8 +50,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(PiecewisePolynomial)
 
   typedef Polynomial<T> PolynomialType;
-  typedef drake::MatrixX<PolynomialType> PolynomialMatrix;
-  typedef drake::MatrixX<T> CoefficientMatrix;
+  typedef MatrixX<PolynomialType> PolynomialMatrix;
+  typedef MatrixX<T> CoefficientMatrix;
   typedef Eigen::Ref<CoefficientMatrix> CoefficientMatrixRef;
 
   // default constructor; just leaves segment_times and polynomials empty
@@ -94,6 +94,17 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const std::vector<CoefficientMatrix>& knots);
 
   /**
+   * Eigen version of ZeroOrderHold(breaks, knots) where each column of knots
+   * is used as a knot point, and
+   *   knots.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> ZeroOrderHold(breaks, knots)
+   */
+  static PiecewisePolynomial<T> ZeroOrderHold(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots);
+
+  /**
    * Constructs a piecewise linear PiecewisePolynomial.
    *
    * @throws std::runtime_error if
@@ -102,12 +113,20 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *    `knots` has inconsistent dimensions,
    *    `breaks` has length smaller than 2.
    */
-  // TODO(russt): Improve Eigen support.  Should have a version that
-  // accepts Eigen vectors instead of std::vector, and the
-  // CoefficientMatrix can be generalized to an Eigen::Ref.
   static PiecewisePolynomial<T> FirstOrderHold(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& knots);
+
+  /**
+   * Eigen version of FirstOrderHold(breaks, knots) where each column of knots
+   * is used as a knot point, and
+   *   knots.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> FirstOrderHold(breaks, knots)
+   */
+  static PiecewisePolynomial<T> FirstOrderHold(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots);
 
   /**
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
@@ -151,6 +170,20 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       bool zero_end_point_derivatives = false);
 
   /**
+   * Eigen version of Pchip(breaks, knots, zero_end_point_derivatives)
+   * where each column of knots is used as a knot point, and
+   *   knots.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> Pchip(breaks, knots,
+   * zero_end_point_derivatives)
+   */
+  static PiecewisePolynomial<T> Pchip(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots,
+      bool zero_end_point_derivatives = false);
+
+
+  /**
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
    * The PiecewisePolynomial is constructed such that the interior segments
    * have the same value, first and second derivatives at `breaks`.
@@ -172,6 +205,20 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const CoefficientMatrix& knot_dot_end);
 
   /**
+   * Eigen version of Cubic(breaks, knots, knots_dot_start, knots_dot_end)
+   * where each column of knots is used as a knot point, and
+   *   knots.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> Cubic(breaks, knots, knots_dot_start,
+   *   knots_dot_end)
+   */
+  static PiecewisePolynomial<T> Cubic(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots,
+      const Eigen::Ref<const VectorX<T>>& knots_dot_start,
+      const Eigen::Ref<const VectorX<T>>& knots_dot_end);
+
+  /**
    * Constructs a third order PiecewisePolynomial from `breaks`, `knots` and
    * `knots`dot.
    * Each segment is fully specified by @knots and @knot_dot at both ends.
@@ -189,6 +236,18 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& knots,
       const std::vector<CoefficientMatrix>& knots_dot);
+
+  /**
+   * Eigen version of Cubic(breaks, knots, knots_dot) where each column of knots
+   * and knots_dot are used as the knot point/derivative.
+   *   knots.cols() == knots_dot.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> Cubic(breaks, knots, knots_dot)
+   */
+  static PiecewisePolynomial<T> Cubic(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots,
+      const Eigen::Ref<const MatrixX<T>>& knots_dot);
 
   /**
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
@@ -214,6 +273,17 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& knots);
+
+  /**
+   * Eigen version of Cubic(breaks, knots) where each column of knots is used
+   * as a knot point and  knots.cols() == breaks.size().
+   *
+   * @overloads PiecewisePolynomial<T> Cubic(breaks, knots)
+   */
+  static PiecewisePolynomial<T> Cubic(
+      const Eigen::Ref<const Eigen::VectorXd>& breaks,
+      const Eigen::Ref<const MatrixX<T>>& knots);
+
 
   /// Takes the derivative of this PiecewisePolynomial.
   /**
@@ -382,7 +452,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   static int SetupCubicSplineInteriorCoeffsLinearSystem(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& knots, int row, int col,
-      drake::MatrixX<T>* A, drake::VectorX<T>* b);
+      MatrixX<T>* A, VectorX<T>* b);
 
   // Computes the first derivative at the end point using a non-centered,
   // shape-preserving three-point formulae.


### PR DESCRIPTION
This is much easier to use from python, as the std::vector method would convert a 2d array into a std::vector<MatrixX<double>> with a single element and matrix coefficients, but I almost always wanted the vector coefficient version of the spline.  I've replaced the bindings to use the Eigen versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8380)
<!-- Reviewable:end -->
