### PR TITLE
pydrake.{autodiff, solvers.ik}: Change old-style placement constructors to new-style constructors

### DIFF
--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -27,12 +27,7 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
   m.doc() = "Bindings for Eigen AutoDiff Scalars";
 
   py::class_<AutoDiffXd>(m, "AutoDiffXd")
-    .def("__init__",
-         [](AutoDiffXd& self,
-            double value,
-            const Eigen::VectorXd& derivatives) {
-           new (&self) AutoDiffXd(value, derivatives);
-         })
+    .def(py::init<const double&, const Eigen::VectorXd&>())
     .def("value", [](const AutoDiffXd& self) {
       return self.value();
     })

--- a/bindings/pydrake/solvers/ik_py.cc
+++ b/bindings/pydrake/solvers/ik_py.cc
@@ -183,14 +183,9 @@ PYBIND11_MODULE(_ik_py, m) {
 
   py::class_<QuasiStaticConstraint, RigidBodyConstraint>(
     m, "QuasiStaticConstraint")
-    .def("__init__",
-         [](QuasiStaticConstraint& instance,
-            RigidBodyTree<double>* model,
-            const Eigen::Vector2d& tspan) {
-            new (&instance) QuasiStaticConstraint(model, tspan);
-          },
-          py::arg("model"),
-          py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan)
+    .def(py::init<RigidBodyTree<double>*, const Eigen::Vector2d&>(),
+        py::arg("model"),
+        py::arg("tspan") = DrakeRigidBodyConstraint::default_tspan)
     .def(py::init<RigidBodyTree<double>*,
                   const Eigen::Vector2d&,
                   const std::set<int>& >())
@@ -203,7 +198,7 @@ PYBIND11_MODULE(_ik_py, m) {
                  &QuasiStaticConstraint::addContact));
 
   py::class_<IKoptions>(m, "IKoptions")
-    .def(py::init<RigidBodyTree<double> *>())
+    .def(py::init<RigidBodyTree<double>*>())
     .def("setQ", &IKoptions::setQ)
     .def("getQ", &IKoptions::getQ)
     .def("setQa", &IKoptions::setQa)

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -1,10 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
 import unittest
+import warnings
 
 
 class TestAll(unittest.TestCase):
     # N.B. Synchronize code snippests with `doc/python_bindings.rst`.
+    def test_no_import_warnings(self):
+        """Ensures that we have no warnings (primarily from `pybind11`) when
+        importing `pydrake.all`."""
+        # Ensure that we haven't imported anything from `pydrake`.
+        self.assertTrue("pydrake" not in sys.modules)
+        # - While this may be redundant, let's do it for good measure.
+        self.assertTrue("pydrake.all" not in sys.modules)
+        # Enable *all* warnings, and ensure that we don't trigger them.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", Warning)
+            import pydrake.all
+            self.assertEquals(len(w), 0)
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow


### PR DESCRIPTION
Closes #8386

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8387)
<!-- Reviewable:end -->
