### PR TITLE
pydrake math: Permit convenience overloads for math functions (autodiff, symbolic). Fix autodiff operator overloads

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -255,6 +255,16 @@ drake_py_unittest(
 )
 
 drake_py_unittest(
+    name = "math_overloads_test",
+    size = "small",
+    deps = [
+        ":autodiffutils_py",
+        ":math_py",
+        ":symbolic_py",
+    ],
+)
+
+drake_py_unittest(
     name = "symbolic_test",
     size = "small",
     deps = [":symbolic_py"],

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -63,6 +63,7 @@ drake_pybind_library(
     package_info = PACKAGE_INFO,
     py_deps = [
         ":common_py",
+        ":math_py",
     ],
     py_srcs = [
         "autodiffutils.py",

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -123,12 +123,14 @@ drake_pybind_library(
     name = "symbolic_py",
     cc_deps = [
         ":symbolic_types_pybind",
+        "//bindings/pydrake/util:wrap_pybind",
         "@fmt",
     ],
     cc_srcs = ["symbolic_py.cc"],
     package_info = PACKAGE_INFO,
     py_deps = [
         ":common_py",
+        ":math_py",
     ],
     py_srcs = ["symbolic.py"],
 )

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -33,6 +33,7 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
       return py::str("<AutoDiffXd {} nderiv={}>").format(
           self.value(), self.derivatives().size());
     })
+    // Arithmetic
     .def(py::self + py::self)
     .def(py::self + double())
     .def(double() + py::self)
@@ -45,6 +46,20 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
     .def(py::self / py::self)
     .def(py::self / double())
     .def(double() / py::self)
+    // Logical comparison
+    .def(py::self == py::self)
+    .def(py::self == double())
+    .def(py::self != py::self)
+    .def(py::self != double())
+    .def(py::self < py::self)
+    .def(py::self < double())
+    .def(py::self <= py::self)
+    .def(py::self <= double())
+    .def(py::self > py::self)
+    .def(py::self > double())
+    .def(py::self >= py::self)
+    .def(py::self >= double())
+    // Additional math
     .def("__pow__",
          [](const AutoDiffXd& base, int exponent) {
            return pow(base, exponent);

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -53,9 +53,20 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
     // Add overloads for `sin` and `cos`.
     auto math = py::module::import("pydrake.math");
     math
+      .def("log", [](const AutoDiffXd& x) { return log(x); })
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
-      .def("cos", [](const AutoDiffXd& x) { return cos(x); });
-    // Re-define for backwards compatibility.
+      .def("cos", [](const AutoDiffXd& x) { return cos(x); })
+      .def("tan", [](const AutoDiffXd& x) { return tan(x); })
+      .def("asin", [](const AutoDiffXd& x) { return asin(x); })
+      .def("acos", [](const AutoDiffXd& x) { return acos(x); })
+      .def("atan2",
+           [](const AutoDiffXd& y, const AutoDiffXd& x) {
+             return atan2(y, x);
+           }, py::arg("y"), py::arg("x"))
+      .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
+      .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
+      .def("tanh", [](const AutoDiffXd& x) { return tanh(x); });
+    // Re-define a subset for backwards compatibility.
     autodiff
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
       .def("cos", [](const AutoDiffXd& x) { return cos(x); });

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -25,6 +25,14 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
     .def("derivatives", [](const AutoDiffXd& self) {
       return self.derivatives();
     })
+    .def("__str__", [](const AutoDiffXd& self) {
+      return py::str("AD{{{}, nderiv={}}}").format(
+          self.value(), self.derivatives().size());
+    })
+    .def("__repr__", [](const AutoDiffXd& self) {
+      return py::str("<AutoDiffXd {} nderiv={}>").format(
+          self.value(), self.derivatives().size());
+    })
     .def(py::self + py::self)
     .def(py::self + double())
     .def(double() + py::self)

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -59,6 +59,7 @@ PYBIND11_MODULE(math, m) {
   // when modules are loaded. However, there should not be ambiguous implicit
   // conversions between autodiff and symbolic, and double overloads should
   // always occur first, so it shouldn't be a problem.
+  // See `math_overloads_test`, which tests this specifically.
   m
       .def("log", [](double x) { return log(x); })
       .def("abs", [](double x) { return fabs(x); })

--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "pybind11/eigen.h"
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
@@ -47,6 +49,37 @@ PYBIND11_MODULE(math, m) {
                                           const Eigen::Ref<const VectorX<T>>&>(
                        &BarycentricMesh<T>::Eval))
       .def("MeshValuesFrom", &BarycentricMesh<T>::MeshValuesFrom);
+
+  // General math overloads.
+  // N.B. Additional overloads will be added for autodiff, symbolic, etc, by
+  // those respective modules.
+  // TODO(eric.cousineau): If possible, delegate these to NumPy UFuncs, either
+  // using __array_ufunc__ or user dtypes.
+  // N.B. The ordering in which the overloads are resolved will change based on
+  // when modules are loaded. However, there should not be ambiguous implicit
+  // conversions between autodiff and symbolic, and double overloads should
+  // always occur first, so it shouldn't be a problem.
+  m
+      .def("log", [](double x) { return log(x); })
+      .def("abs", [](double x) { return fabs(x); })
+      .def("exp", [](double x) { return exp(x); })
+      .def("sqrt", [](double x) { return sqrt(x); })
+      .def("pow", [](double x, double y) { return pow(x, y); })
+      .def("sin", [](double x) { return sin(x); })
+      .def("cos", [](double x) { return cos(x); })
+      .def("tan", [](double x) { return tan(x); })
+      .def("asin", [](double x) { return asin(x); })
+      .def("acos", [](double x) { return acos(x); })
+      .def("atan", [](double x) { return atan(x); })
+      .def("atan2", [](double y, double x) { return atan2(y, x); },
+           py::arg("y"), py::arg("x"))
+      .def("sinh", [](double x) { return sinh(x); })
+      .def("cosh", [](double x) { return cosh(x); })
+      .def("tanh", [](double x) { return tanh(x); })
+      .def("min", [](double x, double y) { return fmin(x, y); })
+      .def("max", [](double x, double y) { return fmax(x, y); })
+      .def("ceil", [](double x) { return ceil(x); })
+      .def("floor", [](double x) { return floor(x); });
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -10,6 +10,7 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
+#include "drake/bindings/pydrake/util/wrap_pybind.h"
 
 namespace drake {
 namespace pydrake {
@@ -146,6 +147,7 @@ PYBIND11_MODULE(_symbolic_py, m) {
            })
       .def("to_string", &Expression::to_string)
       .def("Expand", &Expression::Expand)
+      .def("Evaluate", [](const Expression& self) { return self.Evaluate(); })
       // Addition
       .def(py::self + py::self)
       .def(py::self + Variable())
@@ -223,7 +225,10 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def("Differentiate", &Expression::Differentiate)
       .def("Jacobian", &Expression::Jacobian);
 
-  m.def("log", &symbolic::log)
+  // TODO(eric.cousineau): Consider deprecating these methods?
+  auto math = py::module::import("pydrake.math");
+  MirrorDef(math, m)
+      .def("log", &symbolic::log)
       .def("abs", &symbolic::abs)
       .def("exp", &symbolic::exp)
       .def("sqrt", &symbolic::sqrt)
@@ -242,8 +247,9 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def("min", &symbolic::min)
       .def("max", &symbolic::max)
       .def("ceil", &symbolic::ceil)
-      .def("floor", &symbolic::floor)
-      .def("if_then_else", &symbolic::if_then_else);
+      .def("floor", &symbolic::floor);
+
+  m.def("if_then_else", &symbolic::if_then_else);
 
   m.def("Jacobian", [](const Eigen::Ref<const VectorX<Expression>>& f,
                        const Eigen::Ref<const VectorX<Variable>>& vars) {

--- a/bindings/pydrake/test/all_test.py
+++ b/bindings/pydrake/test/all_test.py
@@ -18,7 +18,7 @@ class TestAll(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", Warning)
             import pydrake.all
-            self.assertEquals(len(w), 0)
+            self.assertEquals(len(w), 0, "\n".join(map(str, w)))
 
     def test_usage_no_all(self):
         from pydrake.common import FindResourceOrThrow

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -27,10 +27,20 @@ class TestAutoDiffXd(unittest.TestCase):
             (actual.derivatives() == expected.derivatives()).all(),
             (actual.derivatives(), expected.derivatives()))
 
+    def _check_logical(self, func, a, b, expect):
+        # Test overloads which have the same return values for:
+        # - f(AutoDiffXd, AutoDiffXd)
+        # - f(AutoDiffXd, float)
+        # - f(float, AutoDiffXd)
+        self.assertEquals(func(a, b), expect)
+        self.assertEquals(func(a, b.value()), expect)
+        self.assertEquals(func(a.value(), b), expect)
+
     def test_scalar_math(self):
         a = AD(1, [1., 0])
         self._compare_scalar(a, a)
         b = AD(2, [0, 1.])
+        # Arithmetic
         self._compare_scalar(a + b, AD(3, [1, 1]))
         self._compare_scalar(a + 1, AD(2, [1, 0]))
         self._compare_scalar(1 + a, AD(2, [1, 0]))
@@ -43,6 +53,15 @@ class TestAutoDiffXd(unittest.TestCase):
         self._compare_scalar(a / b, AD(1./2, [1./2, -1./4]))
         self._compare_scalar(a / 2, AD(0.5, [0.5, 0]))
         self._compare_scalar(2 / a, AD(2, [-2, 0]))
+        # Logical
+        af = a.value()
+        self._check_logical(lambda x, y: x == y, a, a, True)
+        self._check_logical(lambda x, y: x != y, a, a, False)
+        self._check_logical(lambda x, y: x < y, a, b, True)
+        self._check_logical(lambda x, y: x <= y, a, b, True)
+        self._check_logical(lambda x, y: x > y, a, b, False)
+        self._check_logical(lambda x, y: x >= y, a, b, False)
+        # Additional math
         self._compare_scalar(a**2, AD(1, [2., 0]))
         # Test autodiff overloads.
         # See `math_overloads_test` for more comprehensive checks.

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -43,6 +43,7 @@ class TestAutoDiffXd(unittest.TestCase):
         self._compare_scalar(2 / a, AD(2, [-2, 0]))
         self._compare_scalar(a**2, AD(1, [2., 0]))
         # Test autodiff overloads.
+        # See `math_overloads_test` for more comprehensive checks.
         c = AD(0, [1., 0])
         self._compare_scalar(sin(c), AD(0, [1, 0]))
         self._compare_scalar(cos(c), AD(1, [0, 0]))

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -7,7 +7,7 @@ from pydrake.autodiffutils import AutoDiffXd
 
 import unittest
 import numpy as np
-from pydrake.math import sin, cos
+import pydrake.math as drake_math
 
 # Use convenience abbreviation.
 AD = AutoDiffXd
@@ -23,7 +23,9 @@ class TestAutoDiffXd(unittest.TestCase):
 
     def _compare_scalar(self, actual, expected):
         self.assertAlmostEquals(actual.value(), expected.value())
-        self.assertTrue((actual.derivatives() == expected.derivatives()).all())
+        self.assertTrue(
+            (actual.derivatives() == expected.derivatives()).all(),
+            (actual.derivatives(), expected.derivatives()))
 
     def test_scalar_math(self):
         a = AD(1, [1., 0])
@@ -45,5 +47,13 @@ class TestAutoDiffXd(unittest.TestCase):
         # Test autodiff overloads.
         # See `math_overloads_test` for more comprehensive checks.
         c = AD(0, [1., 0])
-        self._compare_scalar(sin(c), AD(0, [1, 0]))
-        self._compare_scalar(cos(c), AD(1, [0, 0]))
+        d = AD(1, [0, 1.])
+        self._compare_scalar(drake_math.sin(c), AD(0, [1, 0]))
+        self._compare_scalar(drake_math.cos(c), AD(1, [0, 0]))
+        self._compare_scalar(drake_math.tan(c), AD(0, [1, 0]))
+        self._compare_scalar(drake_math.asin(c), AD(0, [1, 0]))
+        self._compare_scalar(drake_math.acos(c), AD(np.pi / 2, [-1, 0]))
+        self._compare_scalar(drake_math.atan2(c, d), AD(0, [1, 0]))
+        self._compare_scalar(drake_math.sinh(c), AD(0, [1, 0]))
+        self._compare_scalar(drake_math.cosh(c), AD(1, [0, 0]))
+        self._compare_scalar(drake_math.tanh(c), AD(0, [1, 0]))

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -14,6 +14,13 @@ AD = AutoDiffXd
 
 
 class TestAutoDiffXd(unittest.TestCase):
+    def test_api(self):
+        a = AD(1, [1., 0])
+        self.assertEquals(a.value(), 1.)
+        self.assertTrue((a.derivatives() == [1., 0]).all())
+        self.assertEquals(str(a), "AD{1.0, nderiv=2}")
+        self.assertEquals(repr(a), "<AutoDiffXd 1.0 nderiv=2>")
+
     def _compare_scalar(self, actual, expected):
         self.assertAlmostEquals(actual.value(), expected.value())
         self.assertTrue((actual.derivatives() == expected.derivatives()).all())

--- a/bindings/pydrake/test/math_overloads_test.py
+++ b/bindings/pydrake/test/math_overloads_test.py
@@ -1,0 +1,204 @@
+from __future__ import print_function
+
+import math
+import subprocess
+import sys
+import unittest
+
+# N.B. Do not import modules here, as we want to test the order in which
+# they're imported (if they're imported at all).
+
+# Change this to inspect output.
+verbose = False
+
+
+def debug_print(*args):
+    # Prints only if `verbose` is true.
+    if verbose:
+        print(*args)
+
+
+def qualname(obj):
+    return "{}.{}".format(obj.__module__, obj.__name__)
+
+
+class Overloads(object):
+    # Provides interface for testing function overloads for a given type, `T`.
+    def supports(self, func):
+        # Determines if `func` is supported by this overload.
+        raise NotImplemented
+
+    def to_float(self, y_T):
+        # Converts `y_T` (a value of type `T`) to a float.
+        raise NotImplemented
+
+    def to_type(self, y_float):
+        # Converts `y_float` (a float value) to a value of type `T`.
+        raise NotImplemented
+
+
+class FloatOverloads(Overloads):
+    # Imports `math` and provides support for testing `float` overloads.
+    def __init__(self):
+        from pydrake import math as drake_math
+        self.m = drake_math
+        self.T = float
+
+    def supports(self, func):
+        return True
+
+    def to_float(self, y_T):
+        return y_T
+
+    def to_type(self, y_float):
+        return y_float
+
+
+class AutoDiffOverloads(Overloads):
+    # Imports `pydrake.autodiffutils` and provides support for testing its
+    # overloads.
+    def __init__(self):
+        from pydrake import autodiffutils
+        self.m = autodiffutils
+        self.T = self.m.AutoDiffXd
+
+    def supports(self, func):
+        backwards_compat = [
+            "cos", "sin",
+        ]
+        supported = backwards_compat
+        if func.__name__ in backwards_compat:
+            # Check backwards compatibility.
+            assert hasattr(self.T, func.__name__)
+        return func.__name__ in supported
+
+    def to_float(self, y_T):
+        return y_T.value()
+
+    def to_type(self, y_float):
+        return self.T(y_float, [])
+
+
+class SymbolicOverloads(Overloads):
+    # Imports `pydrake.symbolic` and provides support for testing its
+    # overloads.
+    def __init__(self):
+        from pydrake import symbolic
+        self.m = symbolic
+        self.T = self.m.Expression
+
+    def supports(self, func):
+        backwards_compat = [
+            "log", "abs", "exp", "sqrt",
+            "sin", "cos", "tan", "asin", "acos", "atan",
+            "sinh", "cosh", "tanh", "ceil", "floor",
+            "min", "max", "pow", "atan2",
+        ]
+        supported = backwards_compat
+        if func.__name__ in backwards_compat:
+            # Check backwards compatibility.
+            assert hasattr(self.m, func.__name__)
+        return func.__name__ in supported
+
+    def to_float(self, y_T):
+        return y_T.Evaluate()
+
+    def to_type(self, y_float):
+        return self.T(y_float)
+
+
+class TestMathOverloads(unittest.TestCase):
+    """Tests overloads of math functions, specifically ensuring that we will be
+    robust against import order."""
+
+    def _check_overload(self, overload):
+        # TODO(eric.cousineau): Consider comparing against `numpy` ufunc
+        # methods.
+        import pydrake.math as drake_math
+        unary = [
+            (drake_math.log, math.log),
+            (drake_math.abs, math.fabs),
+            (drake_math.exp, math.exp),
+            (drake_math.sqrt, math.sqrt),
+            (drake_math.sin, math.sin),
+            (drake_math.cos, math.cos),
+            (drake_math.tan, math.tan),
+            (drake_math.asin, math.asin),
+            (drake_math.acos, math.acos),
+            (drake_math.atan, math.atan),
+            (drake_math.sinh, math.sinh),
+            (drake_math.cosh, math.cosh),
+            (drake_math.tanh, math.tanh),
+            (drake_math.ceil, math.ceil),
+            (drake_math.floor, math.floor),
+        ]
+        binary = [
+            (drake_math.min, min),
+            (drake_math.max, max),
+            (drake_math.pow, pow),
+            (drake_math.atan2, math.atan2),
+        ]
+
+        # Arbitrary values to test overloads with.
+        args_float_all = [0.1, 0.2]
+
+        def check_eval(functions, nargs):
+            # Generate arguments.
+            args_float = args_float_all[:nargs]
+            args_T = map(overload.to_type, args_float)
+            # Check each supported function.
+            for f_drake, f_builtin in functions:
+                if not overload.supports(f_drake):
+                    continue
+                debug_print(
+                    "- Functions: ", qualname(f_drake), qualname(f_builtin))
+                y_builtin = f_builtin(*args_float)
+                y_float = f_drake(*args_float)
+                debug_print(" - - Float Eval:", repr(y_builtin), repr(y_float))
+                self.assertEquals(y_float, y_builtin)
+                self.assertIsInstance(y_float, float)
+                # Test method current overload, and ensure value is accurate.
+                y_T = f_drake(*args_T)
+                y_T_float = overload.to_float(y_T)
+                debug_print(" - - Overload Eval:", repr(y_T), repr(y_T_float))
+                self.assertIsInstance(y_T, overload.T)
+                # - Ensure the translated value is accurate.
+                self.assertEquals(y_T_float, y_float)
+
+        debug_print("\n\nOverload: ", qualname(type(overload)))
+        float_overload = FloatOverloads()
+        # Check each number of arguments.
+        debug_print("Unary:")
+        check_eval(unary, 1)
+        debug_print("Binary:")
+        check_eval(binary, 2)
+
+    def _check_overloads(self, order):
+        for overload_cls in order:
+            self._check_overload(overload_cls())
+
+    def test_overloads(self):
+        # Each of these orders implies the relevant module is imported in this
+        # test, in the order specified. This is done to guarantee that the
+        # cross-module overloading does not affect functionality.
+        orders = [
+            (FloatOverloads,),
+            (SymbolicOverloads,),
+            (AutoDiffOverloads,),
+            (AutoDiffOverloads, SymbolicOverloads),
+            (SymbolicOverloads, AutoDiffOverloads),
+        ]
+        # At present, the `pybind11` modules appear not to be destroyed, even
+        # when we try to completely dergister them and garbage collect.
+        # To keep this test self-contained, we will just reinvoke this test
+        # with the desired order so we can control which modules get imported.
+        if len(sys.argv) == 1:
+            # We have arrived here from a direct call. Call the specified
+            # ordering.
+            for i in range(len(orders)):
+                args = [sys.executable, sys.argv[0], str(i)]
+                subprocess.check_call(args)
+        else:
+            self.assertEquals(len(sys.argv), 2)
+            i = int(sys.argv[1])
+            self._check_overloads(orders[i])

--- a/bindings/pydrake/test/math_overloads_test.py
+++ b/bindings/pydrake/test/math_overloads_test.py
@@ -66,7 +66,11 @@ class AutoDiffOverloads(Overloads):
         backwards_compat = [
             "cos", "sin",
         ]
-        supported = backwards_compat
+        supported = backwards_compat + [
+            "log",
+            "tan", "asin", "acos", "atan2",
+            "sinh", "cosh", "tanh",
+        ]
         if func.__name__ in backwards_compat:
             # Check backwards compatibility.
             assert hasattr(self.T, func.__name__)

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-import unittest
+import pydrake.math as mut
 from pydrake.math import (BarycentricMesh, wrap_to)
+
+import unittest
 import numpy as np
+
+import math
 
 
 class TestBarycentricMesh(unittest.TestCase):
@@ -58,3 +62,38 @@ class TestBarycentricMesh(unittest.TestCase):
 
     def test_wrap_to(self):
         self.assertEquals(wrap_to(1.5, 0., 1.), .5)
+
+    def test_math(self):
+        # Compare against `math` functions.
+        # TODO(eric.cousineau): Consider removing this and only rely on
+        # `math_overloads_test`, which already tests this.
+        unary = [
+            (mut.log, math.log),
+            (mut.abs, math.fabs),
+            (mut.exp, math.exp),
+            (mut.sqrt, math.sqrt),
+            (mut.sin, math.sin),
+            (mut.cos, math.cos),
+            (mut.tan, math.tan),
+            (mut.asin, math.asin),
+            (mut.acos, math.acos),
+            (mut.atan, math.atan),
+            (mut.sinh, math.sinh),
+            (mut.cosh, math.cosh),
+            (mut.tanh, math.tanh),
+            (mut.ceil, math.ceil),
+            (mut.floor, math.floor),
+        ]
+        binary = [
+            (mut.min, min),
+            (mut.max, max),
+            (mut.pow, math.pow),
+            (mut.atan2, math.atan2),
+        ]
+
+        a = 0.1
+        b = 0.2
+        for f_core, f_cpp in unary:
+            self.assertEquals(f_core(a), f_cpp(a), (f_core, f_cpp))
+        for f_core, f_cpp in binary:
+            self.assertEquals(f_core(a, b), f_cpp(a, b))

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -429,6 +429,9 @@ class TestSymbolicExpression(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(repr(e_x), '<Expression "x">')
 
+    # See `math_overloads_test` for more comprehensive checks on math
+    # functions.
+
 
 class TestSymbolicFormula(unittest.TestCase):
     def test_get_free_variables(self):

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -5,6 +5,8 @@ import unittest
 import numpy as np
 import pydrake.symbolic as sym
 
+# TODO(eric.cousineau): Replace usages of `sym` math functions with the
+# overloads from `pydrake.math`.
 
 # Define global variables to make the tests less verbose.
 x = sym.Variable("x")

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -43,6 +43,12 @@ drake_cc_library(
     hdrs = ["wrap_function.h"],
 )
 
+drake_cc_library(
+    name = "wrap_pybind",
+    hdrs = ["wrap_pybind.h"],
+    deps = [":wrap_function"],
+)
+
 # This is a pure-python, standalone library SET.
 # Keep this away from `common_py` to simplify test dependencies.
 drake_py_library(

--- a/bindings/pydrake/util/wrap_pybind.h
+++ b/bindings/pydrake/util/wrap_pybind.h
@@ -1,0 +1,47 @@
+/// @file
+/// Defines convenience utilities to wrap pybind11 methods and classes.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "pybind11/pybind11.h"
+
+namespace drake {
+namespace pydrake {
+
+// Defines a function in module `m`, and mirrors to module `mirror` for
+// backwards compatibility. Throws an error if any mirrored methods already
+// exist and do not match the original value.
+class MirrorDef {
+ public:
+  MirrorDef(py::module m, py::module mirror)
+      : m_(m), mirror_(mirror) {}
+
+  template <typename... Args>
+  MirrorDef& def(const char* name, Args&&... args) {
+    m_.def(name, std::forward<Args>(args)...);
+    do_mirror(name);
+    return *this;
+  }
+
+ private:
+  void do_mirror(const char* name) {
+    py::object value = m_.attr(name);
+    // Ensure we won't shadow anything in the mirror; if an attribute of this
+    // name exists and is not exactly the same, throw an error.
+    py::object mirror_value = py::getattr(mirror_, name, py::none());
+    if (!mirror_value.is_none() && !mirror_value.is(value))
+      throw py::cast_error(py::str(
+          "Mirroring: '{}' from {} already exists in {} and will be shadowed")
+              .format(name, m_, mirror_).cast<std::string>());
+    mirror_.attr(name) = value;
+  }
+
+  py::module m_;
+  py::module mirror_;
+};
+
+}  // namespace pydrake
+}  // namespace drake


### PR DESCRIPTION
Closes #8388 

Steps / options:
- ~Upstream changes~
  - ~Teach `pybind` operator `.def` methods to wrap functions, or~
  - ~Just make an external `def_op` for wrapping (maybe simplest?). A tiny slice of https://github.com/RobotLocomotion/pybind11/pull/12 would help.~ This ended up not really needing `eval`, most likely how `py::self` resolves the values.
- [x] Finish this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8389)
<!-- Reviewable:end -->
