### PR TITLE
Change SolutionResult to a enum class

### DIFF
--- a/solvers/mathematical_program_solver_interface.cc
+++ b/solvers/mathematical_program_solver_interface.cc
@@ -23,7 +23,7 @@ std::string to_string(SolutionResult solution_result) {
   }
   // The following lines should not be reached, we add this line due to a defect
   // in the compiler.
-  return "Should not reach here";
+  throw std::runtime_error("Should not reach here");
 }
 
 std::ostream& operator<<(std::ostream& os, SolutionResult solution_result) {

--- a/solvers/mathematical_program_solver_interface.cc
+++ b/solvers/mathematical_program_solver_interface.cc
@@ -1,3 +1,34 @@
 #include "drake/solvers/mathematical_program_solver_interface.h"
 
-// This is an empty file, to make sure the header parses on its own.
+namespace drake {
+namespace solvers {
+std::string to_string(SolutionResult solution_result) {
+  switch (solution_result) {
+    case SolutionResult::kSolutionFound:
+      return "SolutionFound";
+    case SolutionResult::kInvalidInput:
+      return "InvalidInput";
+    case SolutionResult::kInfeasibleConstraints:
+      return "InfeasibleConstraints";
+    case SolutionResult::kUnbounded:
+      return "Unbounded";
+    case SolutionResult::kInfeasible_Or_Unbounded:
+      return "Infeasible_Or_Unbounded";
+    case SolutionResult::kIterationLimit:
+      return "IterationLimit";
+    case SolutionResult::kUnknownError:
+      return "UnknownError";
+    case SolutionResult::kDualInfeasible:
+      return "DualInfeasible";
+  }
+  // The following lines should not be reached, we add this line due to a defect
+  // in the compiler.
+  return "Should not reach here";
+}
+
+std::ostream& operator<<(std::ostream& os, SolutionResult solution_result) {
+  os << to_string(solution_result);
+  return os;
+}
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/mathematical_program_solver_interface.h
+++ b/solvers/mathematical_program_solver_interface.h
@@ -26,6 +26,9 @@ enum SolutionResult {
                          /// infer the status of the primal problem.
 };
 
+std::string to_string(SolutionResult solution_result);
+std::ostream& operator<<(std::ostream& os, SolutionResult solution_result);
+
 /**
  * This class is used by implementations of the class
  * MathematicalProgramSolverInterface to report their results to the

--- a/solvers/system_identification.cc
+++ b/solvers/system_identification.cc
@@ -310,9 +310,10 @@ SystemIdentification<T>::EstimateParameters(
 
   // Solve the problem and copy out the result.
   SolutionResult solution_result = problem.Solve();
-  if (solution_result != kSolutionFound) {
-    throw std::runtime_error("Solution failed: " +
-                             std::to_string(solution_result));
+  if (solution_result != SolutionResult::kSolutionFound) {
+    std::ostringstream oss;
+    oss << "Solution failed: " << solution_result;
+    throw std::runtime_error(oss.str());
   }
   PartialEvalType estimates;
   for (int i = 0; i < num_to_estimate; i++) {

--- a/systems/analysis/lyapunov.cc
+++ b/systems/analysis/lyapunov.cc
@@ -108,7 +108,7 @@ Eigen::VectorXd SampleBasedLyapunovAnalysis(
   const solvers::SolutionResult result = prog.Solve();
   if (result != solvers::SolutionResult::kSolutionFound) {
     drake::log()->error("No solution found.  SolutionResult = " +
-                        std::to_string(result));
+                        to_string(result));
   }
   drake::log()->info("Done solving program.");
 

--- a/systems/controllers/dynamic_programming.cc
+++ b/systems/controllers/dynamic_programming.cc
@@ -247,7 +247,7 @@ Eigen::VectorXd LinearProgrammingApproximateDynamicProgramming(
   const solvers::SolutionResult result = prog.Solve();
   if (result != solvers::SolutionResult::kSolutionFound) {
     drake::log()->error("No solution found.  SolutionResult = " +
-                        std::to_string(result));
+                        to_string(result));
   }
   drake::log()->info("Done solving linear program.");
 


### PR DESCRIPTION
With `SolutionResult` being an enum class, and the reloaded operator <<, now the error message is more meaning. For example, now the terminal prints out the string for the solution result
![screenshot from 2018-03-16 08-39-23](https://user-images.githubusercontent.com/6314000/37532658-dd6075a6-28fc-11e8-8059-0a3de324e4a6.png)
 
while previously it only prints out the number
![screenshot from 2018-03-16 09-35-23](https://user-images.githubusercontent.com/6314000/37532838-6f8ff5dc-28fd-11e8-8412-bec2ddbe0b91.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8390)
<!-- Reviewable:end -->
