### PR TITLE
Make PublishLoadRobot() public and bind it in pydrake

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -177,7 +177,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
              py::keep_alive<1, 3>())
         .def("set_publish_period", &Class::set_publish_period,
              py::arg("period"))
-        .def("ReplayCachedSimulation", &Class::ReplayCachedSimulation);
+        .def("ReplayCachedSimulation", &Class::ReplayCachedSimulation)
+        .def("PublishLoadRobot", &Class::PublishLoadRobot);
     // TODO(eric.cousineau): Bind `PlaybackTrajectory` when
     // `PiecewisePolynomial` has bindings.
   }

--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -187,3 +187,5 @@ class TestRigidBodyPlant(unittest.TestCase):
         context.set_time(0.01)
         viz.Publish(context)
         viz.ReplayCachedSimulation()
+        # - Check that PublishLoadRobot can be called.
+        viz.PublishLoadRobot()

--- a/multibody/rigid_body_plant/drake_visualizer.h
+++ b/multibody/rigid_body_plant/drake_visualizer.h
@@ -108,6 +108,11 @@ class DrakeVisualizer : public LeafSystem<double> {
   void PlaybackTrajectory(
       const trajectories::PiecewisePolynomial<double>& input_trajectory) const;
 
+  // Publishes a lcmt_viewer_load_robot message containing a description
+  // of what should be visualized. The message is intended to be received by the
+  // Drake Visualizer.
+  void PublishLoadRobot() const;
+
  private:
   // TODO(siyuan): Split DoPublish into individual callbacks for different
   // events. Since the desired behaviors for different triggers are exclusive.
@@ -117,11 +122,6 @@ class DrakeVisualizer : public LeafSystem<double> {
   void DoPublish(const systems::Context<double>& context,
                  const std::vector<const PublishEvent<double>*>& events)
                  const override;
-
-  // Publishes a lcmt_viewer_load_robot message containing a description
-  // of what should be visualized. The message is intended to be received by the
-  // Drake Visualizer.
-  void PublishLoadRobot() const;
 
   // A pointer to the LCM subsystem. It is through this object that LCM messages
   // are published.

--- a/multibody/rigid_body_plant/drake_visualizer.h
+++ b/multibody/rigid_body_plant/drake_visualizer.h
@@ -19,7 +19,7 @@ namespace systems {
 
 /**
  * This is a Drake System block that takes a RigidBodyTree and publishes LCM
- * messages that are intended for the DrakeVisualizer. It does this in two
+ * messages that are intended for drake-visualizer. It does this in two
  * phases: initialization and run-time. This system holds a DiscreteState in
  * its context that identifies whether the initialization phase has been
  * completed. It is initialized to false in SetDefaultState(). The
@@ -37,7 +37,7 @@ namespace systems {
  * "DRAKE_VIEWER_LOAD_ROBOT".
  *
  * During run-time, this system block takes the current state of the model and
- * tells Drake Visualizer how to visualize the model. For example, this includes
+ * tells drake-visualizer how to visualize the model. For example, this includes
  * the position and orientation of each rigid body. The LCM messages used during
  * this phase is `lcmt_viewer_draw` and the channel name is
  * "DRAKE_VIEWER_DRAW".
@@ -108,9 +108,12 @@ class DrakeVisualizer : public LeafSystem<double> {
   void PlaybackTrajectory(
       const trajectories::PiecewisePolynomial<double>& input_trajectory) const;
 
-  // Publishes a lcmt_viewer_load_robot message containing a description
-  // of what should be visualized. The message is intended to be received by the
-  // Drake Visualizer.
+  /**
+   * Publishes a lcmt_viewer_load_robot message containing a description
+   * of what should be visualized. The message is intended to be received by
+   * drake-visualizer. This method is automatically invoked when the
+   * DrakeVisualizer instance is analyzed by a systems::Simulator.
+   */
   void PublishLoadRobot() const;
 
  private:


### PR DESCRIPTION
This PR is a step towards supporting workflows that want to use DrakeVisualizer to visualize trajectories generated by planners or other non-simulation sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8400)
<!-- Reviewable:end -->
