### PR TITLE
Support Bool<T> as conditionals in if_then_else and cond

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -27,6 +27,7 @@ drake_cc_library(
         ":cond",
         ":copyable_unique_ptr",
         ":double",
+        ":drake_bool",
         ":drake_path",
         ":dummy_value",
         ":essential",
@@ -64,7 +65,6 @@ drake_cc_library(
         "constants.h",
         "drake_assert.h",
         "drake_assertion_error.h",
-        "drake_bool.h",
         "drake_copyable.h",
         "drake_deprecated.h",
         "drake_optional.h",
@@ -88,6 +88,16 @@ drake_cc_library(
     hdrs = ["cond.h"],
     deps = [
         ":double",
+    ],
+)
+
+drake_cc_library(
+    name = "drake_bool",
+    hdrs = ["drake_bool.h"],
+    deps = [
+        ":autodiff",
+        ":cond",
+        ":essential",
     ],
 )
 
@@ -198,6 +208,7 @@ drake_cc_library(
     ],
     deps = [
         ":cond",
+        ":drake_bool",
         ":dummy_value",
         ":essential",
         ":extract_double",
@@ -481,8 +492,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "drake_bool_test",
     deps = [
-        ":autodiff",
-        ":essential",
+        ":drake_bool",
         ":symbolic",
         "//common/test_utilities:symbolic_test_util",
     ],

--- a/common/drake_bool.h
+++ b/common/drake_bool.h
@@ -2,6 +2,8 @@
 
 #include <type_traits>
 
+#include "drake/common/autodiff.h"
+#include "drake/common/cond.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
 
@@ -33,7 +35,6 @@ namespace drake {
 /// }
 /// @endcode
 ///
-/// TODO(soonho-tri): Make cond compatible with Bool.
 template <typename T>
 class Bool {
  public:
@@ -67,6 +68,25 @@ class Bool {
 template <typename T>
 bool ExtractBoolOrThrow(const Bool<T>& b) {
   return bool{b.value()};
+}
+
+/// Allows users to use `if_then_else` with a conditional of `Bool<T>` type in
+/// addition to `Bool<T>::value_type`.
+///
+/// Note that we need to have `#include "drake/common/autodiff.h"` atop this
+/// file because, in case of T = AutoDiffXd, this template function calls
+/// another template function defined in common/autodiff.h. See
+/// https://clang.llvm.org/compatibility.html#dep_lookup for more information.
+template <typename T>
+T if_then_else(const Bool<T>& b, const T& v_then, const T& v_else) {
+  return if_then_else(b.value(), v_then, v_else);
+}
+
+/// Allows users to use `cond` with conditionals of `Bool<T>` type in addition
+/// to `Bool<T>::value_type`.
+template <typename T, typename... Rest>
+T cond(const Bool<T>& b, const T& e_then, Rest... rest) {
+  return cond(b.value(), e_then, rest...);
 }
 
 namespace assert {

--- a/common/test/drake_bool_test.cc
+++ b/common/test/drake_bool_test.cc
@@ -12,15 +12,16 @@ namespace drake {
 
 using std::move;
 
+using symbolic::Environment;
 using symbolic::Expression;
 using symbolic::Formula;
 using symbolic::Variable;
+using symbolic::test::ExprEqual;
 using symbolic::test::FormulaEqual;
 
 // --------------------------------------------------------------
 // Test constructors and assignment operators using T = double case.
 // --------------------------------------------------------------
-
 class BoolTestDouble : public ::testing::Test {
  protected:
   Bool<double> b_true_{3.0 < 4.0};
@@ -78,6 +79,20 @@ TEST_F(BoolTestDouble, Value) {
   EXPECT_FALSE(b_false_.value());
 }
 
+TEST_F(BoolTestDouble, IfThenElse) {
+  const double v_true{if_then_else(b_true_, 1.0, 0.0)};
+  const double v_false{if_then_else(b_false_, 1.0, 0.0)};
+  EXPECT_EQ(v_true, 1);
+  EXPECT_EQ(v_false, 0);
+}
+
+TEST_F(BoolTestDouble, Cond) {
+  const double v_true{cond(b_true_, 1.0, 0.0)};
+  const double v_false{cond(b_false_, 1.0, 0.0)};
+  EXPECT_EQ(v_true, 1);
+  EXPECT_EQ(v_false, 0);
+}
+
 // -------------------
 // Case T = AutoDiffXd
 // -------------------
@@ -104,6 +119,20 @@ TEST_F(BoolTestAutoDiffXd, ExtractBoolOrThrow) {
 TEST_F(BoolTestAutoDiffXd, Value) {
   EXPECT_TRUE(b_true_.value());
   EXPECT_FALSE(b_false_.value());
+}
+
+TEST_F(BoolTestAutoDiffXd, IfThenElse) {
+  const AutoDiffXd v_true{if_then_else(b_true_, x_, y_)};
+  const AutoDiffXd v_false{if_then_else(b_false_, x_, y_)};
+  EXPECT_EQ(v_true, x_);
+  EXPECT_EQ(v_false, y_);
+}
+
+TEST_F(BoolTestAutoDiffXd, Cond) {
+  const AutoDiffXd v_true{cond(b_true_, x_, y_)};
+  const AutoDiffXd v_false{cond(b_false_, x_, y_)};
+  EXPECT_EQ(v_true, x_);
+  EXPECT_EQ(v_false, y_);
 }
 
 // -----------------------------
@@ -149,6 +178,40 @@ TEST_F(BoolTestSymbolic, Value) {
   EXPECT_PRED2(FormulaEqual, b_true_.value(), Formula::True());
   EXPECT_PRED2(FormulaEqual, b_false_.value(), Formula::False());
   EXPECT_PRED2(FormulaEqual, Bool<Expression>{x_ < y_}.value(), x_ < y_);
+}
+
+TEST_F(BoolTestSymbolic, IfThenElse) {
+  const Expression e{if_then_else(Bool<Expression>{x_ > y_}, +x_, -y_)};
+
+  Environment env;
+  env[x_] = 4.0;
+  env[y_] = 3.0;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), env[x_]);
+
+  env[x_] = 3.0;
+  env[y_] = 4.0;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), -env[y_]);
+}
+
+TEST_F(BoolTestSymbolic, Cond) {
+  // clang-format off
+  const Expression e{cond(x_ > 3.0, 3.0,
+                          x_ > 2.0, 2.0,
+                          x_ > 1.0, 1.0,
+                          0.0)};
+  // clang-format on
+  Environment env;
+  env[x_] = 3.5;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), 3.0);
+
+  env[x_] = 2.5;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), 2.0);
+
+  env[x_] = 1.5;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), 1.0);
+
+  env[x_] = 0.5;
+  EXPECT_PRED2(ExprEqual, e.Evaluate(env), 0.0);
 }
 
 }  // namespace drake


### PR DESCRIPTION
Close #8362 

Note that this PR also moves `:drake_bool` target from `:essential` to `:common` since it depends on `cond` and `autodiff` which are in `:common`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8408)
<!-- Reviewable:end -->
