### PR TITLE
Move thread launching into automotive_demo's main

### DIFF
--- a/automotive/automotive_demo.cc
+++ b/automotive/automotive_demo.cc
@@ -11,6 +11,7 @@
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/monolane_onramp_merge.h"
+#include "drake/common/drake_assert.h"
 #include "drake/common/text_logging_gflags.h"
 #include "drake/lcm/drake_lcm.h"
 
@@ -387,11 +388,13 @@ int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   logging::HandleSpdlogGflags();
   const RoadNetworkType road_network_type = DetermineRoadNetworkType();
-  auto simulator = std::make_unique<AutomotiveSimulator<double>>(
-      std::make_unique<lcm::DrakeLcm>());
+  auto simulator = std::make_unique<AutomotiveSimulator<double>>();
+  auto* lcm = dynamic_cast<drake::lcm::DrakeLcm*>(simulator->get_lcm());
+  DRAKE_DEMAND(lcm != nullptr);  // The simulator promises this should be OK.
   const maliput::api::RoadGeometry* road_geometry =
       AddTerrain(road_network_type, simulator.get());
   AddVehicles(road_network_type, road_geometry, simulator.get());
+  lcm->StartReceiveThread();
   simulator->Start(FLAGS_target_realtime_rate);
   simulator->StepBy(FLAGS_simulation_sec);
   return 0;

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -605,7 +605,6 @@ void AutomotiveSimulator<T>::Start(
 
   if (lcm_) {
     TransmitLoadMessage();
-    lcm_->StartReceiveThread();
   }
 
   simulator_->set_target_realtime_rate(target_realtime_rate);

--- a/automotive/test/automotive_simulator_test.cc
+++ b/automotive/test/automotive_simulator_test.cc
@@ -58,6 +58,8 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCar) {
   // Set up a basic simulation with just a Prius SimpleCar.
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
+
   const int id = simulator->AddPriusSimpleCar("Foo", kCommandChannelName);
   EXPECT_EQ(id, 0);
 
@@ -129,6 +131,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCar) {
 GTEST_TEST(AutomotiveSimulatorTest, TestPriusSimpleCarInitialState) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
   const double kX{10};
   const double kY{5.5};
   const double kHeading{M_PI_2};
@@ -161,6 +164,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestMobilControlledSimpleCar) {
   // Set up a basic simulation with a MOBIL- and IDM-controlled SimpleCar.
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
   lcm::DrakeMockLcm* lcm =
       dynamic_cast<lcm::DrakeMockLcm*>(simulator->get_lcm());
   ASSERT_NE(lcm, nullptr);
@@ -235,6 +239,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestPriusTrajectoryCar) {
   // stationary. They both follow a straight 100 m long line.
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
   const int id1 = simulator->AddPriusTrajectoryCar("alice", curve, 1.0, 0.0);
   const int id2 = simulator->AddPriusTrajectoryCar("bob", curve, 0.0, 0.0);
   EXPECT_EQ(id1, 0);
@@ -428,6 +433,7 @@ std::unique_ptr<AutomotiveSimulator<double>> MakeWithIdmCarAndDecoy(
 GTEST_TEST(AutomotiveSimulatorTest, TestIdmControlledSimpleCar) {
   auto simulator =
       MakeWithIdmCarAndDecoy(std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
 
   // Finish all initialization, so that we can test the post-init state.
   simulator->Start();
@@ -489,6 +495,7 @@ double GetPosition(const lcmt_viewer_draw& message, double y) {
 GTEST_TEST(AutomotiveSimulatorTest, TestMaliputRailcar) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
   lcm::DrakeMockLcm* lcm =
       dynamic_cast<lcm::DrakeMockLcm*>(simulator->get_lcm());
   ASSERT_NE(lcm, nullptr);
@@ -590,6 +597,7 @@ bool ContainsWorld(const lcmt_viewer_load_robot& message) {
 GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
 
   simulator->AddPriusSimpleCar("Model1", "Channel1");
   simulator->AddPriusSimpleCar("Model2", "Channel2");
@@ -636,6 +644,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestLcmOutput) {
 GTEST_TEST(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
 
   EXPECT_NO_THROW(simulator->AddPriusSimpleCar("Model1", "Channel1"));
   EXPECT_THROW(simulator->AddPriusSimpleCar("Model1", "foo"),
@@ -685,6 +694,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestDuplicateVehicleNameException) {
 GTEST_TEST(AutomotiveSimulatorTest, TestIdmControllerUniqueName) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
 
   const MaliputRailcarParams<double> params;
   const maliput::api::RoadGeometry* road = simulator->SetRoadGeometry(
@@ -713,6 +723,7 @@ GTEST_TEST(AutomotiveSimulatorTest, TestIdmControllerUniqueName) {
 GTEST_TEST(AutomotiveSimulatorTest, TestRailcarVelocityOutput) {
   auto simulator = std::make_unique<AutomotiveSimulator<double>>(
       std::make_unique<lcm::DrakeMockLcm>());
+  simulator->get_lcm()->StartReceiveThread();
 
   const MaliputRailcarParams<double> params;
   const maliput::api::RoadGeometry* road =


### PR DESCRIPTION
Threads are an application integration concern, not a library concern.  This enables us (in a future PR) to remove thread control virtual methods from the base `DrakeLcmInterface`.

The [full feature branch is here](https://github.com/jwnimmer-tri/drake/tree/lcm-thread-nointerface) for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8415)
<!-- Reviewable:end -->
