### PR TITLE
Fix MathematicalProgram linking problems

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1112,6 +1112,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "solver_type_converter_test",
     deps = [
+        ":mathematical_program",
         ":solver_type_converter",
     ],
 )

--- a/solvers/mathematical_program.cc
+++ b/solvers/mathematical_program.cc
@@ -134,7 +134,44 @@ MathematicalProgram::MathematicalProgram()
       osqp_solver_(new OsqpSolver()),
       scs_solver_(new ScsSolver()) {}
 
-MathematicalProgram::~MathematicalProgram() = default;
+std::unique_ptr<MathematicalProgram> MathematicalProgram::Clone() const {
+  // The constructor of MathematicalProgram will construct each solver. It
+  // also sets x_values_ and x_initial_guess_ to default values.
+  auto new_prog = std::make_unique<MathematicalProgram>();
+  // Add variables and indeterminates
+  // AddDecisionVariables and AddIndeterminates also set
+  // decision_variable_index_ and indeterminate_index_ properly.
+  new_prog->AddDecisionVariables(decision_variables_);
+  new_prog->AddIndeterminates(indeterminates_);
+  // Add costs
+  new_prog->generic_costs_ = generic_costs_;
+  new_prog->quadratic_costs_ = quadratic_costs_;
+  new_prog->linear_costs_ = linear_costs_;
+
+  // Add constraints
+  new_prog->generic_constraints_ = generic_constraints_;
+  new_prog->linear_constraints_ = linear_constraints_;
+  new_prog->linear_equality_constraints_ = linear_equality_constraints_;
+  new_prog->bbox_constraints_ = bbox_constraints_;
+  new_prog->lorentz_cone_constraint_ = lorentz_cone_constraint_;
+  new_prog->rotated_lorentz_cone_constraint_ =
+      rotated_lorentz_cone_constraint_;
+  new_prog->positive_semidefinite_constraint_ =
+      positive_semidefinite_constraint_;
+  new_prog->linear_matrix_inequality_constraint_ =
+      linear_matrix_inequality_constraint_;
+  new_prog->linear_complementarity_constraints_ =
+      linear_complementarity_constraints_;
+
+  new_prog->x_initial_guess_ = x_initial_guess_;
+  new_prog->solver_id_ = solver_id_;
+  new_prog->solver_options_double_ = solver_options_double_;
+  new_prog->solver_options_int_ = solver_options_int_;
+  new_prog->solver_options_str_ = solver_options_str_;
+
+  new_prog->required_capabilities_ = required_capabilities_;
+  return new_prog;
+}
 
 MatrixXDecisionVariable MathematicalProgram::NewVariables(
     VarType type, int rows, int cols, bool is_symmetric,

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -323,49 +323,8 @@ class MathematicalProgram {
    * However, the clone's x values will be initialized to NaN, and all internal
    * solvers will be freshly constructed.
    * @retval new_prog. The newly constructed mathematical program.
-   * TODO(hongkai.dai): I put the definition of this function in the header
-   * file, so that the target mathematical_program_api has the definition of
-   * this virtual function. We should make MathematicalProgramSolverInterface
-   * independent of MathematicalProgram.
    */
-  virtual std::unique_ptr<MathematicalProgram> Clone() const {
-    // The constructor of MathematicalProgram will construct each solver. It
-    // also sets x_values_ and x_initial_guess_ to default values.
-    auto new_prog = std::make_unique<MathematicalProgram>();
-    // Add variables and indeterminates
-    // AddDecisionVariables and AddIndeterminates also set
-    // decision_variable_index_ and indeterminate_index_ properly.
-    new_prog->AddDecisionVariables(decision_variables_);
-    new_prog->AddIndeterminates(indeterminates_);
-    // Add costs
-    new_prog->generic_costs_ = generic_costs_;
-    new_prog->quadratic_costs_ = quadratic_costs_;
-    new_prog->linear_costs_ = linear_costs_;
-
-    // Add constraints
-    new_prog->generic_constraints_ = generic_constraints_;
-    new_prog->linear_constraints_ = linear_constraints_;
-    new_prog->linear_equality_constraints_ = linear_equality_constraints_;
-    new_prog->bbox_constraints_ = bbox_constraints_;
-    new_prog->lorentz_cone_constraint_ = lorentz_cone_constraint_;
-    new_prog->rotated_lorentz_cone_constraint_ =
-        rotated_lorentz_cone_constraint_;
-    new_prog->positive_semidefinite_constraint_ =
-        positive_semidefinite_constraint_;
-    new_prog->linear_matrix_inequality_constraint_ =
-        linear_matrix_inequality_constraint_;
-    new_prog->linear_complementarity_constraints_ =
-        linear_complementarity_constraints_;
-
-    new_prog->x_initial_guess_ = x_initial_guess_;
-    new_prog->solver_id_ = solver_id_;
-    new_prog->solver_options_double_ = solver_options_double_;
-    new_prog->solver_options_int_ = solver_options_int_;
-    new_prog->solver_options_str_ = solver_options_str_;
-
-    new_prog->required_capabilities_ = required_capabilities_;
-    return new_prog;
-  }
+  std::unique_ptr<MathematicalProgram> Clone() const;
 
   /**
    * Adds continuous variables, appending them to an internal vector of any

--- a/solvers/mathematical_program_api.cc
+++ b/solvers/mathematical_program_api.cc
@@ -6,7 +6,11 @@
 #include <stdexcept>
 
 // This file contains the portions of mathematical_program.h's implementation
-// that are called by MathematicalProgramSolverInterface implementations.
+// that are referred to by MathematicalProgramSolverInterface implementations.
+//
+// The MathematicalProgram destructor is listed here because the typeinfo for
+// MathematicalProgram might be needed by ...SolverInterface implementations,
+// not because they would usually destroy MathematicalProgram objects.
 
 namespace drake {
 namespace solvers {
@@ -15,6 +19,8 @@ using std::ostringstream;
 using std::runtime_error;
 
 using symbolic::Variable;
+
+MathematicalProgram::~MathematicalProgram() = default;
 
 int MathematicalProgram::FindDecisionVariableIndex(const Variable& var) const {
   auto it = decision_variable_index_.find(var.get_id());


### PR DESCRIPTION
Move MathematicalProgram typeinfo into the base library.  This resolves linking errors when using --config ubsan.  (See [one such failure](https://drake-jenkins.csail.mit.edu/view/Production/job/linux-xenial-clang-bazel-nightly-memcheck-ubsan-everything/221/) from last night.)

Make MathematicalProgram::Clone non-virtual and move its definition into the cc file.  This resolves linking errors when using `-c dbg`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8416)
<!-- Reviewable:end -->
