### PR TITLE
Connects System/Context to SystemBase/ContextBase

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -308,6 +308,7 @@ drake_cc_library(
     srcs = ["context.cc"],
     hdrs = ["context.h"],
     deps = [
+        ":context_base",
         ":input_port_evaluator_interface",
         ":input_port_value",
         ":parameters",
@@ -346,7 +347,7 @@ drake_cc_library(
     deps = [
         ":context",
         ":event_collection",
-        ":framework_common",
+        ":system_base",
         ":system_constraint",
         ":system_scalar_converter",
         ":value",

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -34,10 +34,8 @@ CacheEntry::CacheEntry(
   }
 }
 
-std::unique_ptr<AbstractValue> CacheEntry::Allocate(
-    const ContextBase& context) const {
-  DRAKE_ASSERT_VOID(owning_subsystem_->ThrowIfContextNotCompatible(context));
-  std::unique_ptr<AbstractValue> value = alloc_function_(context);
+std::unique_ptr<AbstractValue> CacheEntry::Allocate() const {
+  std::unique_ptr<AbstractValue> value = alloc_function_();
   if (value == nullptr) {
     throw std::logic_error(FormatName("Allocate") +
                            "allocator returned a nullptr.");
@@ -54,13 +52,13 @@ void CacheEntry::Calc(const ContextBase& context,
   calc_function_(context, value);
 }
 
-void CacheEntry::CheckValidAbstractValue(const ContextBase& context,
+void CacheEntry::CheckValidAbstractValue(const ContextBase&,
                                          const AbstractValue& proposed) const {
   // TODO(sherm1) Consider whether we can depend on there already being an
   //              object of this type in the context's CacheEntryValue so we
   //              wouldn't have to allocate one here. If so could also store
   //              a precomputed type_index there for further savings.
-  auto good_ptr = Allocate(context);  // Very expensive!
+  auto good_ptr = Allocate();  // Very expensive!
   const AbstractValue& good = *good_ptr;
   if (typeid(proposed) != typeid(good)) {
     throw std::logic_error(FormatName("Calc") +

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -47,7 +47,7 @@ class CacheEntry {
   a value of a particular cache entry. The result is always returned as an
   AbstractValue but must contain the correct concrete type. */
   using AllocCallback =
-      std::function<std::unique_ptr<AbstractValue>(const ContextBase&)>;
+      std::function<std::unique_ptr<AbstractValue>()>;
 
   /** Signature of a function suitable for calculating a value of a particular
   cache entry, given a place to put the value. */
@@ -97,10 +97,8 @@ class CacheEntry {
   /** Invokes this cache entry's allocator function to allocate a concrete
   object suitable for holding the value to be held in this cache entry, and
   returns that as an AbstractValue. The returned object will never be null.
-  @pre `context` is a subcontext that is compatible with the subsystem that owns
-       this cache entry.
   @throws std::logic_error if the allocator function returned null. */
-  std::unique_ptr<AbstractValue> Allocate(const ContextBase& context) const;
+  std::unique_ptr<AbstractValue> Allocate() const;
 
   /** Unconditionally computes the value this cache entry should have given a
   particular context, into an already-allocated object.

--- a/systems/framework/context.cc
+++ b/systems/framework/context.cc
@@ -2,6 +2,17 @@
 
 #include "drake/common/default_scalars.h"
 
+namespace drake {
+namespace systems {
+
+// The Vector2/3 instantiations here are for the benefit of some
+// older unit tests but are not otherwise advertised.
+template class Context<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
+template class Context<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
+
+}  // namespace systems
+}  // namespace drake
+
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     struct ::drake::systems::StepInfo)
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -3,9 +3,9 @@
 #include <memory>
 #include <utility>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/drake_throw.h"
+#include "drake/systems/framework/context_base.h"
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/input_port_value.h"
 #include "drake/systems/framework/parameters.h"
@@ -26,21 +26,39 @@ struct StepInfo {
   T time_sec{0.0};
 };
 
-/// Context is an abstract base class template that represents all
-/// the inputs to a System: time, state, and input vectors. The framework
-/// provides two concrete subclasses of Context: LeafContext (for
-/// leaf Systems) and DiagramContext (for composite Systems). Users are
-/// discouraged from creating additional subclasses.
+/// %Context is an abstract class template that represents all the typed values
+/// that are used in a System's computations: time, numeric-valued input ports,
+/// numerical state, and numerical parameters. There are also type-erased
+/// abstract state variables, abstract-valued input ports, abstract parameters,
+/// and a double accuracy setting. The framework provides two concrete
+/// subclasses of %Context: LeafContext (for leaf Systems) and DiagramContext
+/// (for composite System Diagrams). Users are forbidden to extend
+/// DiagramContext and are discouraged from subclassing LeafContext.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 template <typename T>
-class Context {
+class Context : public ContextBase {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Context)
+  /// @name  Does not allow copy, move, or assignment.
+  //@{
+  // Copy constructor is protected for use in implementing Clone().
+  Context(Context&&) = delete;
+  Context& operator=(const Context&) = delete;
+  Context& operator=(Context&&) = delete;
+  //@}
 
-  Context() = default;
-  virtual ~Context() = default;
+  /// Returns a deep copy of this Context.
+  // This is just an intentional shadowing of the base class method to return
+  // a more convenient type.
+  std::unique_ptr<Context<T>> Clone() const {
+    std::unique_ptr<ContextBase> clone_base(ContextBase::Clone());
+    DRAKE_DEMAND(dynamic_cast<Context<T>*>(clone_base.get()) != nullptr);
+    return std::unique_ptr<Context<T>>(
+        static_cast<Context<T>*>(clone_base.release()));
+  }
+
+  ~Context() override = default;
 
   // =========================================================================
   // Accessors and Mutators for Time.
@@ -409,16 +427,9 @@ class Context {
   // =========================================================================
   // Miscellaneous Public Methods
 
-  /// Returns a deep copy of this Context. The clone's input ports will
-  /// hold deep copies of the data that appears on this context's input ports
-  /// at the time the clone is created.
-  std::unique_ptr<Context<T>> Clone() const {
-    return std::unique_ptr<Context<T>>(DoClone());
-  }
-
   /// Returns a deep copy of this Context's State.
   std::unique_ptr<State<T>> CloneState() const {
-    return std::unique_ptr<State<T>>(DoCloneState());
+    return DoCloneState();
   }
 
   /// Initializes this context's time, state, and parameters from the real
@@ -468,11 +479,33 @@ class Context {
   }
 
  protected:
-  /// Contains the return-type-covariant implementation of Clone().
-  virtual Context<T>* DoClone() const = 0;
+  Context() = default;
 
-  /// Contains the return-type-covariant implementation of CloneState().
-  virtual State<T>* DoCloneState() const = 0;
+  /// Copy constructor takes care of base class and `Context<T>` data members.
+  /// Derived classes must implement copy constructors that delegate to this
+  /// one for use in their DoCloneWithoutPointers() implementations.
+  // Default implementation invokes the base class copy constructor and then
+  // the local member copy constructors.
+  Context(const Context<T>&) = default;
+
+  /// Clones a context but without any of its internal pointers.
+  // Structuring this as a static method permits a DiagramContext to invoke
+  // this protected functionality on its children.
+  // This is just an intentional shadowing of the base class method to return a
+  // more convenient type.
+  static std::unique_ptr<Context<T>> CloneWithoutPointers(
+      const Context<T>& source) {
+    std::unique_ptr<ContextBase> clone_base(
+        ContextBase::CloneWithoutPointers(source));
+    DRAKE_DEMAND(dynamic_cast<Context<T>*>(clone_base.get()) != nullptr);
+    std::unique_ptr<Context<T>> clone(
+        static_cast<Context<T>*>(clone_base.release()));
+    return clone;
+  }
+
+  /// Override to return the appropriate concrete State class to be returned
+  /// by CloneState().
+  virtual std::unique_ptr<State<T>> DoCloneState() const = 0;
 
   /// Returns a const reference to current time and step information.
   const StepInfo<T>& get_step_info() const { return step_info_; }
@@ -518,7 +551,7 @@ class Context {
   // The context of the enclosing Diagram, used in EvalInputPort.
   // This pointer MUST be treated as a black box. If you call any substantive
   // methods on it, you are probably making a mistake.
-  const Context<T>* parent_ = nullptr;
+  reset_on_copy<const Context<T>*> parent_;
 };
 
 }  // namespace systems

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -9,10 +9,10 @@ namespace drake {
 namespace systems {
 
 std::unique_ptr<ContextBase> ContextBase::Clone() const {
-  std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers());
+  std::unique_ptr<ContextBase> clone_ptr(CloneWithoutPointers(*this));
 
   // Verify that the most-derived Context didn't forget to override
-  // CloneWithoutPointers().
+  // DoCloneWithoutPointers().
   const ContextBase& source = *this;  // Deref here to avoid typeid warning.
   ContextBase& clone = *clone_ptr;
   DRAKE_ASSERT(typeid(source) == typeid(clone));

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -26,7 +26,7 @@ are indexed using a SubsystemIndex; there is no separate SubcontextIndex since
 the numbering must be identical. */
 class ContextBase : public internal::ContextMessageInterface {
  public:
-  /** @name  Does not allow move or assignment; copy is protected. */
+  /** @name     Does not allow copy, move, or assignment. */
   /** @{ */
   // Copy constructor is used only to facilitate implementation of Clone()
   // in derived classes.
@@ -143,9 +143,13 @@ class ContextBase : public internal::ContextMessageInterface {
   contained in the source are left null in the copy. */
   ContextBase(const ContextBase&) = default;
 
-  /** Clones a context but without any of its internal pointers. */
-  std::unique_ptr<ContextBase> CloneWithoutPointers() const {
-      return DoCloneWithoutPointers();
+  /** Clones a context but without copying any of its internal pointers; the
+  clone's pointers are set to null. */
+  // Structuring this as a static method allows DiagramContext to invoke this
+  // protected function on its children.
+  static std::unique_ptr<ContextBase> CloneWithoutPointers(
+      const ContextBase& source) {
+    return source.DoCloneWithoutPointers();
   }
 
   /** Derived classes must implement this so that it performs the complete

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -209,37 +209,6 @@ class Diagram : public System<T>,
         std::move(subevents));
   }
 
-  std::unique_ptr<Context<T>> AllocateContext() const override {
-    const int num_systems = num_subsystems();
-    // Reserve inputs as specified during Diagram initialization.
-    auto context = std::make_unique<DiagramContext<T>>(num_systems);
-
-    // Add each constituent system to the Context.
-    for (SubsystemIndex i(0); i < num_systems; ++i) {
-      const System<T>* const sys = registered_systems_[i].get();
-      auto subcontext = sys->AllocateContext();
-      auto suboutput = sys->AllocateOutput(*subcontext);
-      context->AddSystem(i, std::move(subcontext), std::move(suboutput));
-    }
-
-    // Wire up the Diagram-internal inputs and outputs.
-    for (const auto& connection : connection_map_) {
-      const OutputPortLocator& src = connection.second;
-      const InputPortLocator& dest = connection.first;
-      context->Connect(ConvertToContextPortIdentifier(src),
-                       ConvertToContextPortIdentifier(dest));
-    }
-
-    // Declare the Diagram-external inputs.
-    for (const InputPortLocator& id : input_port_ids_) {
-      context->ExportInput(ConvertToContextPortIdentifier(id));
-    }
-
-    context->MakeState();
-    context->MakeParameters();
-    return std::move(context);
-  }
-
   void SetDefaultState(const Context<T>& context,
                        State<T>* state) const override {
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
@@ -1014,6 +983,58 @@ class Diagram : public System<T>,
   }
 
  private:
+  std::unique_ptr<ContextBase> DoMakeContext() const final {
+    const int num_systems = num_subsystems();
+    // Reserve inputs as specified during Diagram initialization.
+    auto context = std::make_unique<DiagramContext<T>>(num_systems);
+
+    // Recursively construct each constituent system and its subsystems,
+    // then add to this diagram Context.
+    for (SubsystemIndex i(0); i < num_systems; ++i) {
+      const System<T>& sys = *registered_systems_[i];
+      std::unique_ptr<ContextBase> subcontext_base =
+          SystemBase::MakeContext(sys);
+      DRAKE_DEMAND(dynamic_cast<Context<T>*>(subcontext_base.get()) != nullptr);
+      std::unique_ptr<Context<T>> subcontext(
+          static_cast<Context<T>*>(subcontext_base.release()));
+      auto suboutput = sys.AllocateOutput(*subcontext);
+      context->AddSystem(i, std::move(subcontext), std::move(suboutput));
+    }
+
+    // TODO(sherm1) Move to separate interconnection phase.
+    // Wire up the Diagram-internal inputs and outputs.
+    for (const auto& connection : connection_map_) {
+      const OutputPortLocator& src = connection.second;
+      const InputPortLocator& dest = connection.first;
+      context->Connect(ConvertToContextPortIdentifier(src),
+                       ConvertToContextPortIdentifier(dest));
+    }
+
+    // Declare the Diagram-external inputs.
+    for (const InputPortLocator& id : input_port_ids_) {
+      context->ExportInput(ConvertToContextPortIdentifier(id));
+    }
+
+    // TODO(sherm1) Move to final resource allocation phase.
+    context->MakeState();
+    context->MakeParameters();
+
+    return context;
+  }
+
+  // Permits child Systems to take a look at the completed Context to see
+  // if they have any objections.
+  void DoValidateAllocatedContext(const ContextBase& context_base) const final {
+    auto& context = dynamic_cast<const DiagramContext<T>&>(context_base);
+
+    // Depth-first validation of Context to make sure restrictions are met.
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
+      const System<T>& sys = *registered_systems_[i];
+      const Context<T>& subcontext = context.GetSubsystemContext(i);
+      SystemBase::ValidateAllocatedContext(sys, subcontext);
+    }
+  }
+
   // Returns true if there might be direct feedthrough from the given
   // @p input_port of the Diagram to the given @p output_port of the Diagram.
   bool DoHasDirectFeedthrough(int input_port, int output_port) const {

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -289,10 +289,8 @@ class DiagramBuilder {
     for (const auto& connection : connection_map_) {
       // Dependency graph is a mapping from the destination of the connection
       // to what it *depends on* (the source).
-      const PortIdentifier src(connection.second.first,
-                               connection.second.second);
-      const PortIdentifier dest(connection.first.first,
-                                connection.first.second);
+      const PortIdentifier& src = connection.second;
+      const PortIdentifier& dest = connection.first;
       PortIdentifier encoded_src{src.first, output_to_key(src.second)};
       nodes.insert(encoded_src);
       nodes.insert(dest);

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -115,9 +115,15 @@ class DiagramState : public State<T> {
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
 template <typename T>
-class DiagramContext : public Context<T> {
+class DiagramContext final : public Context<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramContext)
+  /// @name  Does not allow copy, move, or assignment.
+  //@{
+  // Copy constructor is protected for use in implementing Clone().
+  DiagramContext(DiagramContext&&) = delete;
+  DiagramContext& operator=(const DiagramContext&) = delete;
+  DiagramContext& operator=(DiagramContext&&) = delete;
+  //@}
 
   /// Identifies a child subsystem's input port.
   using InputPortIdentifier = std::pair<SubsystemIndex, InputPortIndex>;
@@ -296,59 +302,46 @@ class DiagramContext : public Context<T> {
   }
 
  protected:
-  /// The caller owns the returned memory.
-  DiagramContext<T>* DoClone() const override {
-    DRAKE_ASSERT(contexts_.size() == outputs_.size());
-    DiagramContext<T>* clone = new DiagramContext(num_subcontexts());
-
+  /// Protected copy constructor takes care of the local data members and
+  /// all base class members, but doesn't update base class pointers so is
+  /// not a complete copy.
+  DiagramContext(const DiagramContext& source)
+      : Context<T>(source),
+        outputs_(source.num_subcontexts()),
+        contexts_(source.num_subcontexts()),
+        state_(std::make_unique<DiagramState<T>>(source.num_subcontexts())) {
     // Clone all the subsystem contexts and outputs.
-    for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
-      DRAKE_DEMAND(contexts_[i] != nullptr);
-      DRAKE_DEMAND(outputs_[i] != nullptr);
+    for (SubsystemIndex i(0); i < source.num_subcontexts(); ++i) {
+      DRAKE_DEMAND(source.contexts_[i] != nullptr);
+      DRAKE_DEMAND(source.outputs_[i] != nullptr);
       // When a leaf context is cloned, it will clone the data that currently
       // appears on each of its input ports into a FreestandingInputPortValue.
-      clone->AddSystem(i, contexts_[i]->Clone(), outputs_[i]->Clone());
+      AddSystem(i, Context<T>::CloneWithoutPointers(*source.contexts_[i]),
+                source.outputs_[i]->Clone());
     }
 
     // Build a superstate over the subsystem contexts.
-    clone->MakeState();
+    MakeState();
 
-    // Build a superparameters over the subsystem contexts.
-    clone->MakeParameters();
+    // Build superparameters over the subsystem contexts.
+    MakeParameters();
 
     // Clone the internal graph structure. After this is done, the clone will
     // still have FreestandingInputPortValues at the inputs to the Diagram
     // itself, but all of the intermediate nodes will have
     // DependentInputPortValues.
-    for (const auto& connection : connection_map_) {
+    for (const auto& connection : source.connection_map_) {
       const OutputPortIdentifier& src = connection.second;
       const InputPortIdentifier& dest = connection.first;
-      clone->Connect(src, dest);
+      Connect(src, dest);
     }
 
     // Clone the external input structure.
-    for (const InputPortIdentifier& id : input_ids_) {
-      clone->ExportInput(id);
+    for (const InputPortIdentifier& id : source.input_ids_) {
+      ExportInput(id);
     }
 
-    // Make deep copies of everything else using the default copy constructors.
-    clone->set_accuracy(this->get_accuracy());
-    *clone->get_mutable_step_info() = this->get_step_info();
-
-    return clone;
-  }
-
-  /// The caller owns the returned memory.
-  State<T>* DoCloneState() const override {
-    DiagramState<T>* clone = new DiagramState<T>(num_subcontexts());
-
-    for (SubsystemIndex i(0); i < num_subcontexts(); i++) {
-      Context<T>* context = contexts_[i].get();
-      clone->set_and_own_substate(i, context->CloneState());
-    }
-
-    clone->Finalize();
-    return clone;
+    // Everything else was handled by the Context<T> copy constructor.
   }
 
   /// Returns the input port at the given @p index, which of course belongs
@@ -363,6 +356,22 @@ class DiagramContext : public Context<T> {
   }
 
  private:
+  std::unique_ptr<ContextBase> DoCloneWithoutPointers() const final {
+    return std::unique_ptr<ContextBase>(new DiagramContext<T>(*this));
+  }
+
+  std::unique_ptr<State<T>> DoCloneState() const final {
+    auto clone = std::make_unique<DiagramState<T>>(num_subcontexts());
+
+    for (SubsystemIndex i(0); i < num_subcontexts(); i++) {
+      Context<T>* context = contexts_[i].get();
+      clone->set_and_own_substate(i, context->CloneState());
+    }
+
+    clone->Finalize();
+    return clone;
+  }
+
   int num_subcontexts() const {
     DRAKE_ASSERT(contexts_.size() == outputs_.size());
     return static_cast<int>(contexts_.size());

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/cache.h"
 #include "drake/systems/framework/context.h"
@@ -18,20 +17,21 @@
 namespace drake {
 namespace systems {
 
-/// %LeafContext is a container for all of the data necessary to uniquely
-/// determine the computations performed by a leaf System. Specifically, a
-/// %LeafContext contains and owns the State, and also contains (but does not
-/// own) pointers to the value sources for Inputs, as well as the simulation
-/// time and the cache.
+/// %LeafContext contains all prerequisite data necessary to uniquely determine
+/// the results of computations performed by the associated LeafSystem.
 ///
 /// @tparam T The mathematical type of the context, which must be a valid Eigen
 ///           scalar.
-// TODO(david-german-tri): Manage cache invalidation.
 template <typename T>
 class LeafContext : public Context<T> {
  public:
-  // LeafContext objects are neither copyable nor moveable.
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafContext)
+  /// @name  Does not allow copy, move, or assignment.
+  //@{
+  // Copy constructor is protected for use in implementing Clone().
+  LeafContext(LeafContext&&) = delete;
+  LeafContext& operator=(const LeafContext&) = delete;
+  LeafContext& operator=(LeafContext&&) = delete;
+  //@}
 
   LeafContext()
       : state_(std::make_unique<State<T>>()),
@@ -82,36 +82,38 @@ class LeafContext : public Context<T> {
   }
 
  protected:
-  /// The caller owns the returned memory.
-  Context<T>* DoClone() const override {
-    LeafContext<T>* clone = new LeafContext<T>();
-
+  /// Protected copy constructor takes care of the local data members and
+  /// all base class members, but doesn't update base class pointers so is
+  /// not a complete copy.
+  LeafContext(const LeafContext& source) : Context<T>(source) {
     // Make a deep copy of the state.
-    clone->state_ = this->CloneState();
+    state_ = source.CloneState();
 
     // Make deep copies of the parameters.
-    clone->set_parameters(parameters_->Clone());
+    set_parameters(source.parameters_->Clone());
 
     // Make deep copies of the inputs into FreestandingInputPortValues.
     // TODO(david-german-tri): Preserve version numbers as well.
-    for (const auto& port : this->input_values_) {
+    for (const auto& port : source.input_values_) {
       if (port == nullptr) {
-        clone->input_values_.emplace_back(nullptr);
+        input_values_.emplace_back(nullptr);
       } else {
-        clone->input_values_.emplace_back(new FreestandingInputPortValue(
+        input_values_.emplace_back(new FreestandingInputPortValue(
             port->get_abstract_data()->Clone()));
       }
     }
 
-    // Make deep copies of everything else using the default copy constructors.
-    *clone->get_mutable_step_info() = this->get_step_info();
-    clone->set_accuracy(this->get_accuracy());
-    return clone;
+    // Everything else was handled by the Context<T> copy constructor.
   }
 
-  /// The caller owns the returned memory.
-  State<T>* DoCloneState() const override {
-    State<T>* clone = new State<T>();
+  /// Derived classes should reimplement and replace this; don't recursively
+  /// invoke it.
+  std::unique_ptr<ContextBase> DoCloneWithoutPointers() const override {
+    return std::unique_ptr<ContextBase>(new LeafContext<T>(*this));
+  }
+
+  std::unique_ptr<State<T>> DoCloneState() const override {
+    auto clone = std::make_unique<State<T>>();
 
     // Make a deep copy of the continuous state using BasicVector::Clone().
     const ContinuousState<T>& xc = this->get_continuous_state();

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -93,6 +93,15 @@ class LeafSystem : public System<T> {
     return std::make_unique<LeafCompositeEventCollection<T>>();
   }
 
+  /// Shadows System<T>::AllocateContext to provide a more concrete return
+  /// type LeafContext<T>.
+  std::unique_ptr<LeafContext<T>> AllocateContext() const {
+    std::unique_ptr<Context<T>> context = System<T>::AllocateContext();
+    DRAKE_DEMAND(dynamic_cast<Context<T>*>(context.get()) != nullptr);
+    return std::unique_ptr<LeafContext<T>>(
+        static_cast<LeafContext<T>*>(context.release()));
+  }
+
   // =========================================================================
   // Implementations of System<T> methods.
 
@@ -117,7 +126,7 @@ class LeafSystem : public System<T> {
   }
   /// @endcond
 
-  std::unique_ptr<Context<T>> AllocateContext() const override {
+  std::unique_ptr<ContextBase> DoMakeContext() const final {
     std::unique_ptr<LeafContext<T>> context = DoMakeLeafContext();
     // Reserve inputs that have already been declared.
     context->SetNumInputPorts(this->get_num_input_ports());
@@ -129,35 +138,42 @@ class LeafSystem : public System<T> {
     // Reserve parameters via delegation to subclass.
     context->set_parameters(this->AllocateParameters());
 
-    // Enforce some requirements on the fully-assembled Context.
-    // -- The continuous state must be contiguous, i.e., a valid BasicVector.
-    //    (In general, a System's Context's continuous state can be any kind of
-    //    VectorBase including scatter-gather implementations like Supervector.
-    //    But for a LeafSystem with LeafContext, we only allow BasicVectors,
-    //    which are guaranteed to have a linear storage layout.)  If the xc is
-    //    not BasicVector, the dynamic_cast will yield nullptr, and the
-    //    invariant-checker will complain.
-    const VectorBase<T>* const xc = &context->get_continuous_state_vector();
-    detail::CheckBasicVectorInvariants(dynamic_cast<const BasicVector<T>*>(xc));
-    // -- The discrete state must all be valid BasicVectors.
-    for (const BasicVector<T>* group :
-         context->get_state().get_discrete_state().get_data()) {
-      detail::CheckBasicVectorInvariants(group);
-    }
-    // -- The numeric parameters must all be valid BasicVectors.
-    const int num_numeric_parameters = context->num_numeric_parameters();
-    for (int i = 0; i < num_numeric_parameters; ++i) {
-      const BasicVector<T>& group = context->get_numeric_parameter(i);
-      detail::CheckBasicVectorInvariants(&group);
-    }
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.
 
-    return std::move(context);
+    return context;
+  }
+
+  // Enforce some requirements on the fully-assembled Context.
+  // -- The continuous state must be contiguous, i.e., a valid BasicVector.
+  //    (In general, a System's Context's continuous state can be any kind of
+  //    VectorBase including scatter-gather implementations like Supervector.
+  //    But for a LeafSystem with LeafContext, we only allow BasicVectors,
+  //    which are guaranteed to have a linear storage layout.)  If the xc is
+  //    not BasicVector, the dynamic_cast will yield nullptr, and the
+  //    invariant-checker will complain.
+  void DoValidateAllocatedContext(const ContextBase& context_base) const final {
+    auto& context = dynamic_cast<const LeafContext<T>&>(context_base);
+    const VectorBase<T>* const xc = &context.get_continuous_state_vector();
+    detail::CheckBasicVectorInvariants(dynamic_cast<const BasicVector<T>*>(xc));
+    // -- The discrete state must all be valid BasicVectors.
+    for (const BasicVector<T>* group :
+        context.get_state().get_discrete_state().get_data()) {
+      detail::CheckBasicVectorInvariants(group);
+    }
+    // -- The numeric parameters must all be valid BasicVectors.
+    const int num_numeric_parameters = context.num_numeric_parameters();
+    for (int i = 0; i < num_numeric_parameters; ++i) {
+      const BasicVector<T>& group = context.get_numeric_parameter(i);
+      detail::CheckBasicVectorInvariants(&group);
+    }
+
+    // Allow derived LeafSystem to validate allocated Context.
+    DoValidateAllocatedLeafContext(context);
   }
 
   /// Default implementation: sets all continuous state to the model vector
-  /// given in DeclareContinousState (or zero if no model vector was given) and
+  /// given in DeclareContinuousState (or zero if no model vector was given) and
   /// discrete states to zero.  This method makes no attempt to set abstract
   /// state values.  Overrides must not change the number of state variables.
   // TODO(sherm/russt): Initialize the discrete state from the model vector
@@ -298,13 +314,19 @@ class LeafSystem : public System<T> {
   /// leaf systems with custom derived leaf system contexts should override this
   /// to provide a context of the appropriate type. The returned context should
   /// be "empty"; invoked by AllocateContext(), the caller will take the
-  /// responsibility to initialize the core LeafContext data.
-  // TODO(SeanCurtis-TRI): This currently assumes that derived LeafContext
-  // classes do *not* add new data members. If that changes, e.g., with the
-  // advent of the cache, this documentation should be changed to include the
-  // initialization of the sub-class's *unique* data members.
+  /// responsibility to initialize the core LeafContext data. The default
+  /// implementation provides a default-constructed `LeafContext<T>`.
   virtual std::unique_ptr<LeafContext<T>> DoMakeLeafContext() const {
     return std::make_unique<LeafContext<T>>();
+  }
+
+  /// Derived classes that impose restrictions on what resources are permitted
+  /// should check those restrictions by implementing this. For example, a
+  /// derived class might require a single input and single output. The default
+  /// implementation does nothing.
+  virtual void DoValidateAllocatedLeafContext(
+      const LeafContext<T>& context) const {
+    unused(context);
   }
 
   // =========================================================================
@@ -1607,25 +1629,25 @@ class LeafSystem : public System<T> {
   // Update or Publish events that need to be handled at system initialization.
   LeafCompositeEventCollection<T> initialization_events_;
 
-  // A model continuous state to be used in AllocateDefaultContext.
+  // A model continuous state to be used during Context allocation.
   std::unique_ptr<BasicVector<T>> model_continuous_state_vector_;
   int num_generalized_positions_{0};
   int num_generalized_velocities_{0};
   int num_misc_continuous_states_{0};
 
-  // A model discrete state to be used in AllocateDefaultContext.
+  // A model discrete state to be used during Context allocation.
   std::unique_ptr<BasicVector<T>> model_discrete_state_vector_;
 
-  // A model abstract state to be used in AllocateAbstractState.
+  // A model abstract state to be used during Context allocation.
   detail::ModelValues model_abstract_states_;
 
-  // Model inputs to be used in AllocateOutput{Vector,Abstract}.
+  // Model inputs to be used in AllocateInput{Vector,Abstract}.
   detail::ModelValues model_input_values_;
 
-  // Model numeric parameters to be used in AllocateParameters.
+  // Model numeric parameters to be used during Context allocation.
   detail::ModelValues model_numeric_parameters_;
 
-  // Model abstract parameters to be used in AllocateParameters.
+  // Model abstract parameters to be used during Context allocation.
   detail::ModelValues model_abstract_parameters_;
 };
 

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -39,13 +39,6 @@ class SingleOutputVectorSource : public LeafSystem<T> {
   // Don't use the indexed get_output_port when calling this system directly.
   void get_output_port(int) = delete;
 
-  // Confirms the single-output invariant when allocating the context.
-  std::unique_ptr<Context<T>> AllocateContext() const override {
-    DRAKE_DEMAND(this->get_num_input_ports() == 0);
-    DRAKE_DEMAND(this->get_num_output_ports() == 1);
-    return LeafSystem<T>::AllocateContext();
-  }
-
  protected:
   /// Creates a source with the given sole output port configuration.
   explicit SingleOutputVectorSource(int size)
@@ -67,6 +60,12 @@ class SingleOutputVectorSource : public LeafSystem<T> {
       Eigen::VectorBlock<VectorX<T>>* output) const = 0;
 
  private:
+  // Confirms the single-output invariant when allocating the context.
+  void DoValidateAllocatedLeafContext(const LeafContext<T>&) const final {
+    DRAKE_DEMAND(this->get_num_input_ports() == 0);
+    DRAKE_DEMAND(this->get_num_output_ports() == 1);
+  }
+
   // Converts the parameters to Eigen::VectorBlock form, then delegates to
   // DoCalcVectorOutput().
   void CalcVectorOutput(const Context<T>& context,

--- a/systems/framework/system.cc
+++ b/systems/framework/system.cc
@@ -4,6 +4,7 @@
 #include <ios>
 #include <regex>
 
+#include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 
 namespace drake {
@@ -28,6 +29,11 @@ std::string SystemImpl::GetMemoryObjectName(
   result << default_name << '@' << setfill('0') << setw(16) << hex << address;
   return result.str();
 }
+
+// The Vector2/3 instantiations here are for the benefit of some
+// older unit tests but are not otherwise advertised.
+template class System<Eigen::AutoDiffScalar<Eigen::Vector2d>>;
+template class System<Eigen::AutoDiffScalar<Eigen::Vector3d>>;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -26,6 +26,7 @@
 #include "drake/systems/framework/input_port_evaluator_interface.h"
 #include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/output_port_value.h"
+#include "drake/systems/framework/system_base.h"
 #include "drake/systems/framework/system_constraint.h"
 #include "drake/systems/framework/system_scalar_converter.h"
 #include "drake/systems/framework/witness_function.h"
@@ -33,7 +34,7 @@
 namespace drake {
 namespace systems {
 
-/** @cond */
+#if !defined(DRAKE_DOXYGEN_CXX)
 // Private helper class for System.
 class SystemImpl {
  public:
@@ -59,7 +60,7 @@ class SystemImpl {
     return system->system_scalar_converter_;
   }
 };
-/** @endcond */
+#endif  // DRAKE_DOXYGEN_CXX
 
 /// Defines the implementation of the stdc++ concept UniformRandomBitGenerator
 /// to be used by the Systems classes.  This is provided as a work-around to
@@ -69,28 +70,32 @@ class SystemImpl {
 // a templated class that exposes the required methods from the concept.
 typedef std::mt19937 RandomGenerator;
 
-/// A superclass template for systems that receive input, maintain state, and
-/// produce output of a given mathematical type T.
+/// Base class for all System functionality that is dependent on the templatized
+/// scalar type T for input, state, parameters, and outputs.
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 template <typename T>
-class System {
+class System : public SystemBase {
  public:
   // System objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(System)
 
-  virtual ~System() {}
+  ~System() override = default;
 
   //----------------------------------------------------------------------------
   /// @name           Resource allocation and initialization
   /// These methods are used to allocate and initialize Context resources.
   //@{
 
-  /// Allocates a context, initialized with the correct numbers of concrete
-  /// input ports and state variables for this System.  Since input port
-  /// pointers are not owned by the context, they should simply be initialized
-  /// to nullptr.
-  virtual std::unique_ptr<Context<T>> AllocateContext() const = 0;
+  /// Returns a Context<T> suitable for use with this System<T>.
+  // This is just an intentional shadowing of the base class method to return
+  // a more convenient type.
+  std::unique_ptr<Context<T>> AllocateContext() const {
+    std::unique_ptr<ContextBase> context_base(SystemBase::AllocateContext());
+    DRAKE_DEMAND(dynamic_cast<Context<T>*>(context_base.get()) != nullptr);
+    return std::unique_ptr<Context<T>>(
+        static_cast<Context<T>*>(context_base.release()));
+  }
 
   /// Allocates a CompositeEventCollection for this system. The allocated
   /// instance is used for registering events; for example, Simulator passes
@@ -1068,10 +1073,10 @@ class System {
 
     // Checks the validity of each output port.
     for (int i = 0; i < get_num_output_ports(); ++i) {
-      // TODO(amcastro-tri): add appropriate checks for kAbstractValued ports
-      // once abstract ports are implemented in 3164.
+      // TODO(sherm1): consider adding (very expensive) validation of the
+      // abstract ports also.
       if (get_output_port(i).get_data_type() == kVectorValued) {
-        const VectorBase<T>* output_vector = output->get_vector_data(i);
+        const BasicVector<T>* output_vector = output->get_vector_data(i);
         DRAKE_THROW_UNLESS(output_vector != nullptr);
         DRAKE_THROW_UNLESS(output_vector->size() == get_output_port(i).size());
       }
@@ -1083,8 +1088,9 @@ class System {
   ///
   /// @throw exception unless `context` is valid for this system.
   /// @tparam T1 the scalar type of the Context to check.
+  // TODO(sherm1) This method needs to be unit tested.
   template <typename T1 = T>
-  void CheckValidContext(const Context<T1>& context) const {
+  void CheckValidContextT(const Context<T1>& context) const {
     // Checks that the number of input ports in the context is consistent with
     // the number of ports declared by the System.
     DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
@@ -1296,10 +1302,10 @@ class System {
   void FixInputPortsFrom(const System<double>& other_system,
                          const Context<double>& other_context,
                          Context<T>* target_context) const {
-    DRAKE_ASSERT_VOID(CheckValidContext(other_context));
+    DRAKE_ASSERT_VOID(CheckValidContextT(other_context));
     DRAKE_ASSERT_VOID(CheckValidContext(*target_context));
     DRAKE_ASSERT_VOID(other_system.CheckValidContext(other_context));
-    DRAKE_ASSERT_VOID(other_system.CheckValidContext(*target_context));
+    DRAKE_ASSERT_VOID(other_system.CheckValidContextT(*target_context));
 
     for (int i = 0; i < get_num_input_ports(); ++i) {
       const auto& descriptor = get_input_port(i);
@@ -1539,19 +1545,18 @@ class System {
   //@{
 
   /// Override this if you have any continuous state variables `xc` in your
-  /// concrete %System to calculate their time derivatives.
-  /// The `derivatives` vector will correspond elementwise with the state
-  /// vector Context.state.continuous_state.get_state(). Thus, if the state in
-  /// the Context has second-order structure `xc=[q,v,z]`, that same structure
+  /// concrete %System to calculate their time derivatives. The `derivatives`
+  /// vector will correspond elementwise with the state vector
+  /// `Context.state.continuous_state.get_state()`. Thus, if the state in the
+  /// Context has second-order structure `xc=[q,v,z]`, that same structure
   /// applies to the derivatives.
   ///
   /// This method is called only from the public non-virtual
-  /// CalcTimeDerivatives() which will already have error-checked
-  /// the parameters so you don't have to.
-  /// In particular, implementations may assume that the given Context is valid
-  /// for this %System; that the `derivatives` pointer is non-null, and that
-  /// the referenced object has the same constituent structure as was
-  /// produced by AllocateTimeDerivatives().
+  /// CalcTimeDerivatives() which will already have error-checked the parameters
+  /// so you don't have to. In particular, implementations may assume that the
+  /// given Context is valid for this %System; that the `derivatives` pointer is
+  /// non-null, and that the referenced object has the same constituent
+  /// structure as was produced by AllocateTimeDerivatives().
   ///
   /// The default implementation does nothing if the `derivatives` vector is
   /// size zero and aborts otherwise.
@@ -1876,6 +1881,13 @@ class System {
   // Attorney-Client idiom to expose a subset of private elements of System.
   // Refer to SystemImpl comments for details.
   friend class SystemImpl;
+
+  // SystemBase override checks a Context of same type T.
+  void DoCheckValidContext(const ContextBase& context_base) const final {
+    const Context<T>* context = dynamic_cast<const Context<T>*>(&context_base);
+    DRAKE_THROW_UNLESS(context != nullptr);
+    CheckValidContextT(*context);
+  }
 
   std::string name_;
   // input_ports_ and output_ports_ are vectors of unique_ptr so that references

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -25,7 +25,7 @@ const CacheEntry& SystemBase::DeclareCacheEntry(
   return new_entry;
 }
 
-std::unique_ptr<ContextBase> SystemBase::AllocateContext() const {
+std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
   // Derived class creates the concrete Context object, which already contains
   // all the well-known trackers (the ones with fixed tickets).
   std::unique_ptr<ContextBase> context_ptr = DoMakeContext();
@@ -50,7 +50,8 @@ std::unique_ptr<ContextBase> SystemBase::AllocateContext() const {
   for (CacheIndex index(0); index < num_cache_entries(); ++index) {
     const CacheEntry& entry = get_cache_entry(index);
     cache.CreateNewCacheEntryValue(entry.cache_index(), entry.ticket(),
-        entry.description(), entry.prerequisites(), &graph);
+                                   entry.description(), entry.prerequisites(),
+                                   &graph);
   }
 
   // TODO(sherm1) Create the output port trackers yᵢ here.
@@ -61,7 +62,7 @@ std::unique_ptr<ContextBase> SystemBase::AllocateContext() const {
   for (CacheIndex index(0); index < num_cache_entries(); ++index) {
     const CacheEntry& entry = get_cache_entry(index);
     CacheEntryValue& cache_value = cache.get_mutable_cache_entry_value(index);
-    cache_value.SetInitialValue(entry.Allocate(context));
+    cache_value.SetInitialValue(entry.Allocate());
   }
 
   return context_ptr;

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -1,4 +1,4 @@
-#include "drake/systems/framework/cache.h"
+#include "drake/systems/framework/cache_entry.h"
 
 // Tests the System (const) side of caching, which consists of a CacheEntry
 // objects that can be provided automatically or defined by users. When a
@@ -32,13 +32,13 @@ namespace systems {
 namespace {
 
 // Free functions suitable for defining cache entries.
-auto Alloc3 = [](const ContextBase&) { return AbstractValue::Make<int>(3); };
+auto Alloc3 = []() { return AbstractValue::Make<int>(3); };
 auto Calc99 = [](const ContextBase&, AbstractValue* result) {
   result->SetValue(99);
 };
 
 // This one is fatally flawed since null is not allowed.
-auto AllocNull = [](const ContextBase&) {
+auto AllocNull = []() {
   return std::unique_ptr<AbstractValue>();
 };
 
@@ -120,7 +120,7 @@ class MySystemBase final : public SystemBase {
   const CacheEntry& vector_entry() const { return vector_entry_; }
 
   // For use as an allocator.
-  int MakeInt1(const MyContextBase&) const { return 1; }
+  int MakeInt1() const { return 1; }
   // For use as a cache entry calculator.
   void CalcInt98(const MyContextBase& my_context, int* out) const {
     *out = 98;
@@ -133,11 +133,13 @@ class MySystemBase final : public SystemBase {
   }
 
  private:
-  std::unique_ptr<ContextBase> DoMakeContext() const override {
+  std::unique_ptr<ContextBase> DoMakeContext() const final {
     return std::make_unique<MyContextBase>();
   }
 
-  void DoCheckValidContext(const ContextBase&) const override {}
+  void DoValidateAllocatedContext(const ContextBase& context) const final {}
+
+  void DoCheckValidContext(const ContextBase&) const final {}
 
   const CacheEntry& entry0_;
   const CacheEntry& entry1_;

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -44,10 +44,6 @@ class TestSystem : public System<double> {
     return nullptr;
   }
 
-  std::unique_ptr<Context<double>> AllocateContext() const override {
-    return nullptr;
-  }
-
   std::unique_ptr<CompositeEventCollection<double>>
   AllocateCompositeEventCollection() const override {
     return std::make_unique<LeafCompositeEventCollection<double>>();
@@ -212,6 +208,12 @@ class TestSystem : public System<double> {
   }
 
  private:
+  std::unique_ptr<ContextBase> DoMakeContext() const final {
+    return std::make_unique<LeafContext<double>>();
+  }
+
+  void DoValidateAllocatedContext(const ContextBase&) const final {}
+
   mutable int publish_count_ = 0;
   mutable int update_count_ = 0;
   mutable std::vector<int> published_numbers_;
@@ -465,11 +467,13 @@ class ValueIOTestSystem : public System<T> {
     return nullptr;
   }
 
-  std::unique_ptr<Context<T>> AllocateContext() const override {
+  std::unique_ptr<ContextBase> DoMakeContext() const final {
     std::unique_ptr<LeafContext<T>> context(new LeafContext<T>);
     context->SetNumInputPorts(this->get_num_input_ports());
     return std::move(context);
   }
+
+  void DoValidateAllocatedContext(const ContextBase& context) const final {}
 
   std::unique_ptr<CompositeEventCollection<T>>
   AllocateCompositeEventCollection() const override {


### PR DESCRIPTION
This PR just wires up the existing System framework classes to the new base classes introduced from the caching branch in PRs #8050, #8227, and #8372. Construction and cloning of the Context are the main issues addressed here. There are no functionality changes here and no new unit tests -- there are good tests of construction and cloning in system_test, diagram_test, {leaf,diagram}{_context}_test.

I will be moving a lot of type-agnostic functionality into the SystemBase and ContextBase classes and this PR makes it possible for me to do that without structural changes. The use of default & inherited copy constructors for cloning means I can add members freely to the ContextBase without having to get permission from the derived classes!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8420)
<!-- Reviewable:end -->
