### PR TITLE
Re-enable tests for QuasistaticSystem

### DIFF
--- a/manipulation/dev/BUILD.bazel
+++ b/manipulation/dev/BUILD.bazel
@@ -49,7 +49,7 @@ drake_cc_library(
 drake_cc_googletest(
     name = "rod2d_time_stepping",
     data = [":models"],
-    tags = gurobi_test_tags() + ["manual"],
+    tags = gurobi_test_tags(),
     deps = [
         ":quasistatic_system",
         "//drake/common",

--- a/manipulation/dev/quasistatic_system.cc
+++ b/manipulation/dev/quasistatic_system.cc
@@ -482,8 +482,8 @@ void QuasistaticSystem<Scalar>::DoCalcWnWfJnJfPhi(
   Jf_half.resize(nc * 2, nq_tree);
 
   MatrixX<Scalar> Jv = J * tree_->GetVelocityToQDotMapping(cache);
-  DRAKE_ASSERT(Jv.cols() == 3 * nc);
-  DRAKE_ASSERT(Jv.rows() == nv_tree);
+  DRAKE_ASSERT(Jv.cols() == nv_tree);
+  DRAKE_ASSERT(Jv.rows() == 3 * nc);
 
   int idx_first = 0;
   int idx_tangent = 0;
@@ -727,7 +727,7 @@ void QuasistaticSystem<Scalar>::MinimizeKineticEnergy(
     }
   }
 
-  prog_QP.AddQuadraticCost(H, VectorXd::Zero(nu_, 0), delta_qu_QP);
+  prog_QP.AddQuadraticCost(H, VectorXd::Zero(nu_), delta_qu_QP);
 
   // solve QP
   prog_QP.SetSolverOption(solvers::GurobiSolver::id(), "OutputFlag", 0);


### PR DESCRIPTION
Tests in PR #8042 were disabled due to assertion failures, which are fixed in this PR. 
Related issue: #8211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8423)
<!-- Reviewable:end -->
