### PR TITLE
pydrake autodiff, symbolic: Add initial tests for scalar and vectorized math

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -58,6 +58,7 @@ drake_pybind_library(
     name = "autodiffutils_py",
     cc_deps = [
         ":autodiff_types_pybind",
+        "//bindings/pydrake/util:wrap_pybind",
     ],
     cc_srcs = ["autodiffutils_py.cc"],
     package_info = PACKAGE_INFO,

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -207,7 +207,10 @@ drake_py_library(
 
 drake_py_unittest(
     name = "autodiffutils_test",
-    deps = [":autodiffutils_py"],
+    deps = [
+        ":algebra_test_util_py",
+        ":autodiffutils_py",
+    ],
 )
 
 # Test ODR (One Definition Rule).

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -277,7 +277,10 @@ drake_py_unittest(
 drake_py_unittest(
     name = "symbolic_test",
     size = "small",
-    deps = [":symbolic_py"],
+    deps = [
+        ":algebra_test_util_py",
+        ":symbolic_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -199,6 +199,12 @@ drake_py_unittest(
     deps = [":all_py"],
 )
 
+drake_py_library(
+    name = "algebra_test_util_py",
+    testonly = 1,
+    srcs = ["test/algebra_test_util.py"],
+)
+
 drake_py_unittest(
     name = "autodiffutils_test",
     deps = [":autodiffutils_py"],

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -5,6 +5,7 @@
 
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/util/wrap_pybind.h"
 
 using Eigen::AutoDiffScalar;
 using std::sin;
@@ -67,7 +68,7 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
 
     // Add overloads for `sin` and `cos`.
     auto math = py::module::import("pydrake.math");
-    math
+    MirrorDef<py::module, decltype(autodiff)>(&math, &autodiff)
       .def("log", [](const AutoDiffXd& x) { return log(x); })
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
       .def("cos", [](const AutoDiffXd& x) { return cos(x); })
@@ -77,14 +78,14 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
       .def("atan2",
            [](const AutoDiffXd& y, const AutoDiffXd& x) {
              return atan2(y, x);
-           }, py::arg("y"), py::arg("x"))
+           })
       .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
       .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
       .def("tanh", [](const AutoDiffXd& x) { return tanh(x); });
-    // Re-define a subset for backwards compatibility.
-    autodiff
-      .def("sin", [](const AutoDiffXd& x) { return sin(x); })
-      .def("cos", [](const AutoDiffXd& x) { return cos(x); });
+    // Mirror for numpy.
+    autodiff.attr("arcsin") = autodiff.attr("asin");
+    autodiff.attr("arccos") = autodiff.attr("acos");
+    autodiff.attr("arctan2") = autodiff.attr("atan2");
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -35,6 +35,7 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
           self.value(), self.derivatives().size());
     })
     // Arithmetic
+    .def(-py::self)
     .def(py::self + py::self)
     .def(py::self + double())
     .def(double() + py::self)
@@ -64,24 +65,38 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
     .def("__pow__",
          [](const AutoDiffXd& base, int exponent) {
            return pow(base, exponent);
-         }, py::is_operator());
+         }, py::is_operator())
+    .def("__abs__", [](const AutoDiffXd& x) { return abs(x); });
 
-    // Add overloads for `sin` and `cos`.
+    // Add overloads for `math` functions.
     auto math = py::module::import("pydrake.math");
     MirrorDef<py::module, decltype(autodiff)>(&math, &autodiff)
       .def("log", [](const AutoDiffXd& x) { return log(x); })
+      .def("abs", [](const AutoDiffXd& x) { return abs(x); })
+      .def("exp", [](const AutoDiffXd& x) { return exp(x); })
+      .def("sqrt", [](const AutoDiffXd& x) { return sqrt(x); })
+      .def("pow", [](const AutoDiffXd& x, int y) {
+                      return pow(x, y);
+                    })
       .def("sin", [](const AutoDiffXd& x) { return sin(x); })
       .def("cos", [](const AutoDiffXd& x) { return cos(x); })
       .def("tan", [](const AutoDiffXd& x) { return tan(x); })
       .def("asin", [](const AutoDiffXd& x) { return asin(x); })
       .def("acos", [](const AutoDiffXd& x) { return acos(x); })
-      .def("atan2",
-           [](const AutoDiffXd& y, const AutoDiffXd& x) {
-             return atan2(y, x);
-           })
+      .def("atan2", [](const AutoDiffXd& y, const AutoDiffXd& x) {
+                      return atan2(y, x);
+                    })
       .def("sinh", [](const AutoDiffXd& x) { return sinh(x); })
       .def("cosh", [](const AutoDiffXd& x) { return cosh(x); })
-      .def("tanh", [](const AutoDiffXd& x) { return tanh(x); });
+      .def("tanh", [](const AutoDiffXd& x) { return tanh(x); })
+      .def("min", [](const AutoDiffXd& x, const AutoDiffXd& y) {
+                    return min(x, y);
+                  })
+      .def("max", [](const AutoDiffXd& x, const AutoDiffXd& y) {
+                    return max(x, y);
+                  })
+      .def("ceil", [](const AutoDiffXd& x) { return ceil(x); })
+      .def("floor", [](const AutoDiffXd& x) { return floor(x); });
     // Mirror for numpy.
     autodiff.attr("arcsin") = autodiff.attr("asin");
     autodiff.attr("arccos") = autodiff.attr("acos");

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -227,7 +227,7 @@ PYBIND11_MODULE(_symbolic_py, m) {
 
   // TODO(eric.cousineau): Consider deprecating these methods?
   auto math = py::module::import("pydrake.math");
-  MirrorDef(math, m)
+  MirrorDef<py::module, py::module>(&math, &m)
       .def("log", &symbolic::log)
       .def("abs", &symbolic::abs)
       .def("exp", &symbolic::exp)

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -37,6 +37,10 @@ PYBIND11_MODULE(_symbolic_py, m) {
            })
       .def("__hash__",
            [](const Variable& self) { return std::hash<Variable>{}(self); })
+      .def("__copy__",
+           [](const Variable& self) -> Variable {
+             return self;
+           })
       // Addition.
       .def(py::self + py::self)
       .def(py::self + double())
@@ -145,6 +149,10 @@ PYBIND11_MODULE(_symbolic_py, m) {
            [](const Expression& self) {
              return fmt::format("<Expression \"{}\">", self.to_string());
            })
+      .def("__copy__",
+           [](const Expression& self) -> Expression {
+             return self;
+           })
       .def("to_string", &Expression::to_string)
       .def("Expand", &Expression::Expand)
       .def("Evaluate", [](const Expression& self) { return self.Evaluate(); })
@@ -223,7 +231,27 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def(py::self != Variable())
       .def(py::self != double())
       .def("Differentiate", &Expression::Differentiate)
-      .def("Jacobian", &Expression::Jacobian);
+      .def("Jacobian", &Expression::Jacobian)
+      // TODO(eric.cousineau): Figure out how to consolidate with the below
+      // methods.
+      .def("log", &symbolic::log)
+      .def("__abs__", &symbolic::abs)
+      .def("exp", &symbolic::exp)
+      .def("sqrt", &symbolic::sqrt)
+      // TODO(eric.cousineau): Move `__pow__` here.
+      .def("sin", &symbolic::sin)
+      .def("cos", &symbolic::cos)
+      .def("tan", &symbolic::tan)
+      .def("arcsin", &symbolic::asin)
+      .def("arccos", &symbolic::acos)
+      .def("arctan2", &symbolic::atan2)
+      .def("sinh", &symbolic::sinh)
+      .def("cosh", &symbolic::cosh)
+      .def("tanh", &symbolic::tanh)
+      .def("min", &symbolic::min)
+      .def("max", &symbolic::max)
+      .def("ceil", &symbolic::ceil)
+      .def("floor", &symbolic::floor);
 
   // TODO(eric.cousineau): Consider deprecating these methods?
   auto math = py::module::import("pydrake.math");

--- a/bindings/pydrake/test/algebra_test_util.py
+++ b/bindings/pydrake/test/algebra_test_util.py
@@ -1,0 +1,111 @@
+"""
+Provides utilities to test different algebra.
+"""
+
+import numpy as np
+import pydrake.math as drake_math
+
+
+class BaseAlgebra(object):
+    # Base class for defining scalar or vectorized (array) algebra and math.
+    # Checks on custom types that have numeric relations to `float`.
+    # Note that linear algebra itself is not "pluggable" for these operations,
+    # so care should be taken when defining it.
+    def __init__(self, check_value_impl, scalar_to_float):
+        # Derived classes should define extra math functions.
+        self._check_value_impl = check_value_impl
+        self._scalar_to_float = scalar_to_float
+        pass
+
+    def to_algebra(self, scalar):
+        # Morphs a scalar to the given algebra (e.g. a scalar or array).
+        raise NotImplemented
+
+    def algebra_to_float(self, value):
+        # Casts from an algebra of `T` to the same algebra but of type `float`.
+        raise NotImplemented
+
+    def check_value(self, actual, expected_scalar):
+        # Checks if `actual` is equal to `expected_scalar`, which is
+        # broadcasting to match `actual`s shape.
+        expected = self.to_algebra(expected_scalar)
+        self._check_value_impl(actual, expected)
+
+    def check_logical(self, func, a, b, expected_scalar):
+        # Checks logical operations, morphing `expected_scalar` to match
+        # `actual`s algebra, and checking that `a` and `b` (of type `T`)
+        # have compatible logical operators when the left or right operatnds
+        # are `float`s. Specifically, tests:
+        # - f(T, T)
+        # - f(T, float)
+        # - f(float, T)
+        expected = self.to_algebra(expected_scalar)
+        self._check_value_impl(func(a, b), expected)
+        af = self.algebra_to_float(a)
+        bf = self.algebra_to_float(b)
+        self._check_value_impl(func(a, bf), expected)
+        self._check_value_impl(func(af, b), expected)
+
+
+class ScalarAlgebra(BaseAlgebra):
+    # Scalar algebra.
+    def __init__(self, check_value_impl, scalar_to_float):
+        BaseAlgebra.__init__(self, check_value_impl, scalar_to_float)
+        # Math functions:
+        self.log = drake_math.log
+        self.abs = drake_math.abs
+        self.exp = drake_math.exp
+        self.sqrt = drake_math.sqrt
+        self.pow = drake_math.pow
+        self.sin = drake_math.sin
+        self.cos = drake_math.cos
+        self.tan = drake_math.tan
+        self.arcsin = drake_math.asin
+        self.arccos = drake_math.acos
+        self.arctan2 = drake_math.atan2
+        self.sinh = drake_math.sinh
+        self.cosh = drake_math.cosh
+        self.tanh = drake_math.tanh
+        self.min = drake_math.min
+        self.max = drake_math.max
+        self.ceil = drake_math.ceil
+        self.floor = drake_math.floor
+
+    def to_algebra(self, scalar):
+        return scalar
+
+    def algebra_to_float(self, value):
+        return self._scalar_to_float(value)
+
+
+class VectorizedAlgebra(BaseAlgebra):
+    # Vectorized (array) algebra.
+    def __init__(self, check_value_impl, scalar_to_float):
+        BaseAlgebra.__init__(self, check_value_impl, scalar_to_float)
+        # Math functions:
+        self.log = np.log
+        self.abs = np.abs
+        self.exp = np.exp
+        self.sqrt = np.sqrt
+        self.pow = np.power
+        self.sin = np.sin
+        self.cos = np.cos
+        self.tan = np.tan
+        self.arcsin = np.arcsin
+        self.arccos = np.arccos
+        self.arctan2 = np.arctan2
+        self.sinh = np.sinh
+        self.cosh = np.cosh
+        self.tanh = np.tanh
+        self.min = np.fmin  # N.B. Do not use `np.min`
+        self.max = np.fmax
+        self.ceil = np.ceil
+        self.floor = np.floor
+
+    def to_algebra(self, scalar):
+        return np.array([scalar, scalar])
+
+    def algebra_to_float(self, value):
+        value_f = np.array([self._scalar_to_float(x) for x in value.flat])
+        value_f.reshape(value.shape)
+        return value_f

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -9,70 +9,141 @@ import unittest
 import numpy as np
 import pydrake.math as drake_math
 
+from pydrake.test.algebra_test_util import ScalarAlgebra, VectorizedAlgebra
+
 # Use convenience abbreviation.
 AD = AutoDiffXd
 
 
 class TestAutoDiffXd(unittest.TestCase):
-    def test_api(self):
+    def _check_scalar(self, actual, expected):
+        if isinstance(actual, bool):
+            self.assertTrue(isinstance(expected, bool))
+            self.assertEquals(actual, expected)
+        elif isinstance(actual, float):
+            self.assertTrue(isinstance(expected, float))
+            self.assertEquals(actual, expected)
+        else:
+            self.assertAlmostEquals(actual.value(), expected.value())
+            self.assertTrue(
+                (actual.derivatives() == expected.derivatives()).all(),
+                (actual.derivatives(), expected.derivatives()))
+
+    def _check_array(self, actual, expected):
+        expected = np.array(expected)
+        self.assertEquals(actual.dtype, expected.dtype)
+        self.assertEquals(actual.shape, expected.shape)
+        if actual.dtype == object:
+            for a, b in zip(actual.flat, expected.flat):
+                self._check_scalar(a, b)
+        else:
+            self.assertTrue((actual == expected).all())
+
+    def test_scalar_api(self):
         a = AD(1, [1., 0])
         self.assertEquals(a.value(), 1.)
         self.assertTrue((a.derivatives() == [1., 0]).all())
         self.assertEquals(str(a), "AD{1.0, nderiv=2}")
         self.assertEquals(repr(a), "<AutoDiffXd 1.0 nderiv=2>")
+        self._check_scalar(a, a)
 
-    def _compare_scalar(self, actual, expected):
-        self.assertAlmostEquals(actual.value(), expected.value())
-        self.assertTrue(
-            (actual.derivatives() == expected.derivatives()).all(),
-            (actual.derivatives(), expected.derivatives()))
-
-    def _check_logical(self, func, a, b, expect):
-        # Test overloads which have the same return values for:
-        # - f(AutoDiffXd, AutoDiffXd)
-        # - f(AutoDiffXd, float)
-        # - f(float, AutoDiffXd)
-        self.assertEquals(func(a, b), expect)
-        self.assertEquals(func(a, b.value()), expect)
-        self.assertEquals(func(a.value(), b), expect)
-
-    def test_scalar_math(self):
+    def test_array_api(self):
         a = AD(1, [1., 0])
-        self._compare_scalar(a, a)
         b = AD(2, [0, 1.])
+        x = np.array([a, b])
+        self.assertEquals(x.dtype, object)
+        # Idempotent check.
+        self._check_array(x, x)
+        # Conversion.
+        with self.assertRaises(TypeError):
+            # Avoid implicit coercion, as this will imply information loss.
+            xf = np.zeros(2, dtype=np.float)
+            xf[:] = x
+        with self.assertRaises(TypeError):
+            # We could define `__float__` to allow this, but then that will
+            # enable implicit coercion, which we should avoid.
+            xf = x.astype(dtype=np.float)
+        # Presently, does not convert.
+        x = np.zeros((3, 3), dtype=AD)
+        self.assertFalse(isinstance(x[0, 0], AD))
+        x = np.eye(3).astype(AD)
+        self.assertFalse(isinstance(x[0, 0], AD))
+
+    def _check_algebra(self, algebra):
+        a_scalar = AD(1, [1., 0])
+        b_scalar = AD(2, [0, 1.])
+        c_scalar = AD(0, [1., 0])
+        d_scalar = AD(1, [0, 1.])
+        a, b, c, d = map(
+            algebra.to_algebra, (a_scalar, b_scalar, c_scalar, d_scalar))
+
         # Arithmetic
-        self._compare_scalar(a + b, AD(3, [1, 1]))
-        self._compare_scalar(a + 1, AD(2, [1, 0]))
-        self._compare_scalar(1 + a, AD(2, [1, 0]))
-        self._compare_scalar(a - b, AD(-1, [1, -1]))
-        self._compare_scalar(a - 1, AD(0, [1, 0]))
-        self._compare_scalar(1 - a, AD(0, [-1, 0]))
-        self._compare_scalar(a * b, AD(2, [2, 1]))
-        self._compare_scalar(a * 2, AD(2, [2, 0]))
-        self._compare_scalar(2 * a, AD(2, [2, 0]))
-        self._compare_scalar(a / b, AD(1./2, [1./2, -1./4]))
-        self._compare_scalar(a / 2, AD(0.5, [0.5, 0]))
-        self._compare_scalar(2 / a, AD(2, [-2, 0]))
+        algebra.check_value(-a, AD(-1, [-1., 0]))
+        algebra.check_value(a + b, AD(3, [1, 1]))
+        algebra.check_value(a + 1, AD(2, [1, 0]))
+        algebra.check_value(1 + a, AD(2, [1, 0]))
+        algebra.check_value(a - b, AD(-1, [1, -1]))
+        algebra.check_value(a - 1, AD(0, [1, 0]))
+        algebra.check_value(1 - a, AD(0, [-1, 0]))
+        algebra.check_value(a * b, AD(2, [2, 1]))
+        algebra.check_value(a * 2, AD(2, [2, 0]))
+        algebra.check_value(2 * a, AD(2, [2, 0]))
+        algebra.check_value(a / b, AD(1./2, [1./2, -1./4]))
+        algebra.check_value(a / 2, AD(0.5, [0.5, 0]))
+        algebra.check_value(2 / a, AD(2, [-2, 0]))
         # Logical
-        af = a.value()
-        self._check_logical(lambda x, y: x == y, a, a, True)
-        self._check_logical(lambda x, y: x != y, a, a, False)
-        self._check_logical(lambda x, y: x < y, a, b, True)
-        self._check_logical(lambda x, y: x <= y, a, b, True)
-        self._check_logical(lambda x, y: x > y, a, b, False)
-        self._check_logical(lambda x, y: x >= y, a, b, False)
+        algebra.check_logical(lambda x, y: x == y, a, a, True)
+        algebra.check_logical(lambda x, y: x != y, a, a, False)
+        algebra.check_logical(lambda x, y: x < y, a, b, True)
+        algebra.check_logical(lambda x, y: x <= y, a, b, True)
+        algebra.check_logical(lambda x, y: x > y, a, b, False)
+        algebra.check_logical(lambda x, y: x >= y, a, b, False)
         # Additional math
-        self._compare_scalar(a**2, AD(1, [2., 0]))
-        # Test autodiff overloads.
-        # See `math_overloads_test` for more comprehensive checks.
-        c = AD(0, [1., 0])
-        d = AD(1, [0, 1.])
-        self._compare_scalar(drake_math.sin(c), AD(0, [1, 0]))
-        self._compare_scalar(drake_math.cos(c), AD(1, [0, 0]))
-        self._compare_scalar(drake_math.tan(c), AD(0, [1, 0]))
-        self._compare_scalar(drake_math.asin(c), AD(0, [1, 0]))
-        self._compare_scalar(drake_math.acos(c), AD(np.pi / 2, [-1, 0]))
-        self._compare_scalar(drake_math.atan2(c, d), AD(0, [1, 0]))
-        self._compare_scalar(drake_math.sinh(c), AD(0, [1, 0]))
-        self._compare_scalar(drake_math.cosh(c), AD(1, [0, 0]))
-        self._compare_scalar(drake_math.tanh(c), AD(0, [1, 0]))
+        # - See `math_overloads_test` for scalar overloads.
+        algebra.check_value(a**2, AD(1, [2., 0]))
+        algebra.check_value(algebra.log(a), AD(0, [1., 0]))
+        algebra.check_value(algebra.abs(-a), AD(1, [1., 0]))
+        algebra.check_value(algebra.exp(a), AD(np.e, [np.e, 0]))
+        algebra.check_value(algebra.sqrt(a), AD(1, [0.5, 0]))
+        algebra.check_value(algebra.pow(a, 2), AD(1, [2., 0]))
+        algebra.check_value(algebra.sin(c), AD(0, [1, 0]))
+        algebra.check_value(algebra.cos(c), AD(1, [0, 0]))
+        algebra.check_value(algebra.tan(c), AD(0, [1, 0]))
+        algebra.check_value(algebra.arcsin(c), AD(0, [1, 0]))
+        algebra.check_value(algebra.arccos(c), AD(np.pi / 2, [-1, 0]))
+        algebra.check_value(algebra.arctan2(c, d), AD(0, [1, 0]))
+        algebra.check_value(algebra.sinh(c), AD(0, [1, 0]))
+        algebra.check_value(algebra.cosh(c), AD(1, [0, 0]))
+        algebra.check_value(algebra.tanh(c), AD(0, [1, 0]))
+        algebra.check_value(algebra.min(a, b), a_scalar)
+        algebra.check_value(algebra.max(a, b), b_scalar)
+        # Because `ceil` and `floor` return `double`, we have to special case
+        # this comparison since the matrix is `dtype=object`, even though the
+        # elements are all doubles. We must cast it to float.
+        # N.B. This would be fixed if we registered a UFunc for these
+        # methods, so NumPy would have already returned a `float` array.
+        ceil_a = algebra.ceil(a)
+        floor_a = algebra.floor(a)
+        if isinstance(algebra, VectorizedAlgebra):
+            self.assertEquals(ceil_a.dtype, object)
+            self.assertIsInstance(ceil_a[0], float)
+            ceil_a = ceil_a.astype(float)
+            floor_a = floor_a.astype(float)
+        algebra.check_value(ceil_a, a_scalar.value())
+        algebra.check_value(floor_a, a_scalar.value())
+        # Return value so it can be inspected.
+        return a
+
+    def test_scalar_algebra(self):
+        a = self._check_algebra(
+            ScalarAlgebra(
+                self._check_scalar, scalar_to_float=lambda x: x.value()))
+        self.assertEquals(type(a), AD)
+
+    def test_array_algebra(self):
+        a = self._check_algebra(
+            VectorizedAlgebra(
+                self._check_array,
+                scalar_to_float=lambda x: x.value()))
+        self.assertEquals(type(a), np.ndarray)
+        self.assertEquals(a.shape, (2,))

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function
 import unittest
 import numpy as np
 import pydrake.symbolic as sym
+from pydrake.test.algebra_test_util import ScalarAlgebra, VectorizedAlgebra
+from copy import copy
 
 # TODO(eric.cousineau): Replace usages of `sym` math functions with the
 # overloads from `pydrake.math`.
@@ -109,6 +111,28 @@ class TestSymbolicVariable(unittest.TestCase):
                          "((y = 2) and (x >= 1) and (x <= 2))")
         self.assertEqual(str(sym.logical_or(x >= 1, x <= 2, y == 2)),
                          "((y = 2) or (x >= 1) or (x <= 2))")
+
+    def test_functions_with_variable(self):
+        self.assertEqual(str(sym.abs(x)), "abs(x)")
+        self.assertEqual(str(sym.exp(x)), "exp(x)")
+        self.assertEqual(str(sym.sqrt(x)), "sqrt(x)")
+        self.assertEqual(str(sym.pow(x, y)), "pow(x, y)")
+        self.assertEqual(str(sym.sin(x)), "sin(x)")
+        self.assertEqual(str(sym.cos(x)), "cos(x)")
+        self.assertEqual(str(sym.tan(x)), "tan(x)")
+        self.assertEqual(str(sym.asin(x)), "asin(x)")
+        self.assertEqual(str(sym.acos(x)), "acos(x)")
+        self.assertEqual(str(sym.atan(x)), "atan(x)")
+        self.assertEqual(str(sym.atan2(x, y)), "atan2(x, y)")
+        self.assertEqual(str(sym.sinh(x)), "sinh(x)")
+        self.assertEqual(str(sym.cosh(x)), "cosh(x)")
+        self.assertEqual(str(sym.tanh(x)), "tanh(x)")
+        self.assertEqual(str(sym.min(x, y)), "min(x, y)")
+        self.assertEqual(str(sym.max(x, y)), "max(x, y)")
+        self.assertEqual(str(sym.ceil(x)), "ceil(x)")
+        self.assertEqual(str(sym.floor(x)), "floor(x)")
+        self.assertEqual(str(sym.if_then_else(x > y, x, y)),
+                         "(if (x > y) then x else y)")
 
 
 class TestSymbolicVariables(unittest.TestCase):
@@ -221,75 +245,150 @@ class TestSymbolicVariables(unittest.TestCase):
 
 
 class TestSymbolicExpression(unittest.TestCase):
-    def test_addition(self):
-        self.assertEqual(str(e_x + e_y), "(x + y)")
-        self.assertEqual(str(e_x + y), "(x + y)")
-        self.assertEqual(str(e_x + 1), "(1 + x)")
-        self.assertEqual(str(x + e_y), "(x + y)")
-        self.assertEqual(str(1 + e_x), "(1 + x)")
+    def _check_scalar(self, actual, expected):
+        self.assertIsInstance(actual, sym.Expression)
+        # Chain conversion to ensure equivalent treatment.
+        if isinstance(expected, float) or isinstance(expected, int):
+            expected = sym.Expression(expected)
+        if isinstance(expected, sym.Expression):
+            expected = str(expected)
+        self.assertIsInstance(expected, str)
+        self.assertEqual(str(actual), expected)
 
-    def test_addition_assign(self):
-        e = x
-        e += e_y
-        self.assertEqual(e, x + y)
-        e += z
-        self.assertEqual(e, x + y + z)
+    def _check_array(self, actual, expected):
+        self.assertEqual(actual.shape, expected.shape)
+        for a, b in zip(actual.flat, expected.flat):
+            self._check_scalar(a, b)
+
+    def _check_algebra(self, algebra):
+        xv = algebra.to_algebra(x)
+        yv = algebra.to_algebra(y)
+        zv = algebra.to_algebra(z)
+        wv = algebra.to_algebra(w)
+        av = algebra.to_algebra(a)
+        bv = algebra.to_algebra(b)
+        cv = algebra.to_algebra(c)
+        e_xv = algebra.to_algebra(e_x)
+        e_yv = algebra.to_algebra(e_y)
+
+        # Addition.
+        algebra.check_value(e_xv + e_yv, "(x + y)")
+        algebra.check_value(e_xv + yv, "(x + y)")
+        algebra.check_value(e_xv + 1, "(1 + x)")
+        algebra.check_value(xv + e_yv, "(x + y)")
+        algebra.check_value(1 + e_xv, "(1 + x)")
+
+        # - In place.
+        e = copy(xv)
+        e += e_yv
+        algebra.check_value(e, "(x + y)")
+        e += zv
+        algebra.check_value(e, "(x + y + z)")
         e += 1
-        self.assertEqual(e, x + y + z + 1)
+        algebra.check_value(e, "(1 + x + y + z)")
 
-    def test_subtract(self):
-        self.assertEqual(str(e_x - e_y), "(x - y)")
-        self.assertEqual(str(e_x - y), "(x - y)")
-        self.assertEqual(str(e_x - 1), "(-1 + x)")
-        self.assertEqual(str(x - e_y), "(x - y)")
-        self.assertEqual(str(1 - e_x), "(1 - x)")
+        # Subtraction.
+        algebra.check_value((e_xv - e_yv), "(x - y)")
+        algebra.check_value((e_xv - yv), "(x - y)")
+        algebra.check_value((e_xv - 1), "(-1 + x)")
+        algebra.check_value((xv - e_yv), "(x - y)")
+        algebra.check_value((1 - e_xv), "(1 - x)")
 
-    def test_subtract_assign(self):
-        e = x
-        e -= e_y
-        self.assertEqual(e, x - y)
-        e -= z
-        self.assertEqual(e, x - y - z)
+        # - In place.
+        e = copy(xv)
+        e -= e_yv
+        algebra.check_value(e, (x - y))
+        e -= zv
+        algebra.check_value(e, (x - y - z))
         e -= 1
-        self.assertEqual(e, x - y - z - 1)
+        algebra.check_value(e, (x - y - z - 1))
 
-    def test_multiplication(self):
-        self.assertEqual(str(e_x * e_y), "(x * y)")
-        self.assertEqual(str(e_x * y), "(x * y)")
-        self.assertEqual(str(e_x * 1), "x")
-        self.assertEqual(str(x * e_y), "(x * y)")
-        self.assertEqual(str(1 * e_x), "x")
+        # Multiplication.
+        algebra.check_value((e_xv * e_yv), "(x * y)")
+        algebra.check_value((e_xv * yv), "(x * y)")
+        algebra.check_value((e_xv * 1), "x")
+        algebra.check_value((xv * e_yv), "(x * y)")
+        algebra.check_value((1 * e_xv), "x")
 
-    def test_multiplication_assign(self):
-        e = x
-        e *= e_y
-        self.assertEqual(e, x * y)
-        e *= z
-        self.assertEqual(e, x * y * z)
+        # - In place.
+        e = copy(xv)
+        e *= e_yv
+        algebra.check_value(e, "(x * y)")
+        e *= zv
+        algebra.check_value(e, "(x * y * z)")
         e *= 1
-        self.assertEqual(e, x * y * z)
+        algebra.check_value(e, "(x * y * z)")
 
-    def test_division(self):
-        self.assertEqual(str(e_x / e_y), "(x / y)")
-        self.assertEqual(str(e_x / y), "(x / y)")
-        self.assertEqual(str(e_x / 1), "x")
-        self.assertEqual(str(x / e_y), "(x / y)")
-        self.assertEqual(str(1 / e_x), "(1 / x)")
+        # Division
+        algebra.check_value((e_xv / e_yv), (x / y))
+        algebra.check_value((e_xv / yv), (x / y))
+        algebra.check_value((e_xv / 1), "x")
+        algebra.check_value((xv / e_yv), (x / y))
+        algebra.check_value((1 / e_xv), (1 / x))
 
-    def test_division_assign(self):
-        e = x
-        e /= e_y
-        self.assertEqual(e, x / y)
-        e /= z
-        self.assertEqual(e, x / y / z)
+        # - In place.
+        e = copy(xv)
+        e /= e_yv
+        algebra.check_value(e, (x / y))
+        e /= zv
+        algebra.check_value(e, (x / y / z))
         e /= 1
-        self.assertEqual(e, x / y / z)
+        algebra.check_value(e, ((x / y) / z))
 
-    def test_unary_operators(self):
-        self.assertEqual(str(+e_x), "x")
-        self.assertEqual(str(-e_x), "(-1 * x)")
+        # Unary
+        algebra.check_value((+e_xv), "x")
+        algebra.check_value((-e_xv), "(-1 * x)")
+
+        # Math functions.
+        algebra.check_value((algebra.abs(e_xv)), "abs(x)")
+        algebra.check_value((algebra.exp(e_xv)), "exp(x)")
+        algebra.check_value((algebra.sqrt(e_xv)), "sqrt(x)")
+        algebra.check_value((algebra.pow(e_xv, e_yv)), "pow(x, y)")
+        algebra.check_value((algebra.sin(e_xv)), "sin(x)")
+        algebra.check_value((algebra.cos(e_xv)), "cos(x)")
+        algebra.check_value((algebra.tan(e_xv)), "tan(x)")
+        algebra.check_value((algebra.arcsin(e_xv)), "asin(x)")
+        algebra.check_value((algebra.arccos(e_xv)), "acos(x)")
+        algebra.check_value((algebra.arctan2(e_xv, e_yv)), "atan2(x, y)")
+        algebra.check_value((algebra.sinh(e_xv)), "sinh(x)")
+        algebra.check_value((algebra.cosh(e_xv)), "cosh(x)")
+        algebra.check_value((algebra.tanh(e_xv)), "tanh(x)")
+        algebra.check_value((algebra.ceil(e_xv)), "ceil(x)")
+        algebra.check_value((algebra.floor(e_xv)), "floor(x)")
+
+        if isinstance(algebra, ScalarAlgebra):
+            # TODO(eric.cousineau): Uncomment these lines if we can teach numpy
+            # that reduction is not just selection.
+            algebra.check_value((algebra.min(e_xv, e_yv)), "min(x, y)")
+            algebra.check_value((algebra.max(e_xv, e_yv)), "max(x, y)")
+            # TODO(eric.cousineau): Add broadcasting functions for these
+            # operations.
+            algebra.check_value((sym.atan(e_xv)), "atan(x)")
+            algebra.check_value((sym.if_then_else(e_xv > e_yv, e_xv, e_yv)),
+                                "(if (x > y) then x else y)")
+
+        return xv, e_xv
+
+    def test_scalar_algebra(self):
+        xv, e_xv = self._check_algebra(
+            ScalarAlgebra(
+                self._check_scalar, scalar_to_float=lambda x: x.Evaluate()))
+        self.assertIsInstance(xv, sym.Variable)
+        self.assertIsInstance(e_xv, sym.Expression)
+
+    def test_array_algebra(self):
+        xv, e_xv = self._check_algebra(
+            VectorizedAlgebra(
+                self._check_array,
+                scalar_to_float=lambda x: x.Evaluate()))
+        self.assertEquals(xv.shape, (2,))
+        self.assertIsInstance(xv[0], sym.Variable)
+        self.assertEquals(e_xv.shape, (2,))
+        self.assertIsInstance(e_xv[0], sym.Expression)
 
     def test_relational_operators(self):
+        # TODO(eric.cousineau): Use `VectorizedAlgebra` overloads once #8315 is
+        # resolved.
         # Expression rop Expression
         self.assertEqual(str(e_x < e_y), "(x < y)")
         self.assertEqual(str(e_x <= e_y), "(x <= y)")
@@ -330,76 +429,55 @@ class TestSymbolicExpression(unittest.TestCase):
         self.assertEqual(str(1 == e_y), "(y = 1)")
         self.assertEqual(str(1 != e_y), "(y != 1)")
 
+    def test_relation_operators_array_8135(self):
+        # Indication of #8135.
+        e_xv = np.array([e_x, e_x])
+        e_yv = np.array([e_y, e_y])
+        # N.B. In some versions of NumPy, `!=` for dtype=object implies ID
+        # comparison (e.g. `is`).
+        value = (e_xv == e_yv)
+        # Ideally, this would be an array of formulas.
+        self.assertEqual(value.dtype, bool)
+        self.assertFalse(isinstance(value[0], sym.Formula))
+        self.assertTrue(value.all())
+
     def test_functions_with_float(self):
+        # TODO(eric.cousineau): Use concrete values once vectorized methods are
+        # supported.
         v_x = 1.0
         v_y = 1.0
-        self.assertEqual(sym.abs(v_x), np.abs(v_x))
-        self.assertEqual(sym.exp(v_x), np.exp(v_x))
-        self.assertEqual(sym.sqrt(v_x), np.sqrt(v_x))
-        self.assertEqual(sym.pow(v_x, v_y), v_x ** v_y)
-        self.assertEqual(sym.sin(v_x), np.sin(v_x))
-        self.assertEqual(sym.cos(v_x), np.cos(v_x))
-        self.assertEqual(sym.tan(v_x), np.tan(v_x))
-        self.assertEqual(sym.asin(v_x), np.arcsin(v_x))
-        self.assertEqual(sym.acos(v_x), np.arccos(v_x))
-        self.assertEqual(sym.atan(v_x), np.arctan(v_x))
-        self.assertEqual(sym.atan2(v_x, v_y), np.arctan2(v_x, v_y))
-        self.assertEqual(sym.sinh(v_x), np.sinh(v_x))
-        self.assertEqual(sym.cosh(v_x), np.cosh(v_x))
-        self.assertEqual(sym.tanh(v_x), np.tanh(v_x))
-        self.assertEqual(sym.min(v_x, v_y), min(v_x, v_y))
-        self.assertEqual(sym.max(v_x, v_y), max(v_x, v_y))
-        self.assertEqual(sym.ceil(v_x), np.ceil(v_x))
-        self.assertEqual(sym.floor(v_x), np.floor(v_x))
-        self.assertEqual(
+        # WARNING: If these math functions have `float` overloads that return
+        # `float`, then `assertEqual`-like tests are meaningful (current state,
+        # and before `math` overloads were introduced).
+        # If these math functions implicitly cast `float` to `Expression`, then
+        # `assertEqual` tests are meaningless, as it tests `__nonzero__` for
+        # `Formula`, which will always be True.
+        self.assertEqual(sym.abs(v_x), 0.5*np.abs(v_x))
+        self.assertNotEqual(str(sym.abs(v_x)), str(0.5*np.abs(v_x)))
+        self._check_scalar(sym.abs(v_x), np.abs(v_x))
+        self._check_scalar(sym.abs(v_x), np.abs(v_x))
+        self._check_scalar(sym.exp(v_x), np.exp(v_x))
+        self._check_scalar(sym.sqrt(v_x), np.sqrt(v_x))
+        self._check_scalar(sym.pow(v_x, v_y), v_x ** v_y)
+        self._check_scalar(sym.sin(v_x), np.sin(v_x))
+        self._check_scalar(sym.cos(v_x), np.cos(v_x))
+        self._check_scalar(sym.tan(v_x), np.tan(v_x))
+        self._check_scalar(sym.asin(v_x), np.arcsin(v_x))
+        self._check_scalar(sym.acos(v_x), np.arccos(v_x))
+        self._check_scalar(sym.atan(v_x), np.arctan(v_x))
+        self._check_scalar(sym.atan2(v_x, v_y), np.arctan2(v_x, v_y))
+        self._check_scalar(sym.sinh(v_x), np.sinh(v_x))
+        self._check_scalar(sym.cosh(v_x), np.cosh(v_x))
+        self._check_scalar(sym.tanh(v_x), np.tanh(v_x))
+        self._check_scalar(sym.min(v_x, v_y), min(v_x, v_y))
+        self._check_scalar(sym.max(v_x, v_y), max(v_x, v_y))
+        self._check_scalar(sym.ceil(v_x), np.ceil(v_x))
+        self._check_scalar(sym.floor(v_x), np.floor(v_x))
+        self._check_scalar(
           sym.if_then_else(
             sym.Expression(v_x) > sym.Expression(v_y),
             v_x, v_y),
           v_x if v_x > v_y else v_y)
-
-    def test_functions_with_variable(self):
-        self.assertEqual(str(sym.abs(x)), "abs(x)")
-        self.assertEqual(str(sym.exp(x)), "exp(x)")
-        self.assertEqual(str(sym.sqrt(x)), "sqrt(x)")
-        self.assertEqual(str(sym.pow(x, y)), "pow(x, y)")
-        self.assertEqual(str(sym.sin(x)), "sin(x)")
-        self.assertEqual(str(sym.cos(x)), "cos(x)")
-        self.assertEqual(str(sym.tan(x)), "tan(x)")
-        self.assertEqual(str(sym.asin(x)), "asin(x)")
-        self.assertEqual(str(sym.acos(x)), "acos(x)")
-        self.assertEqual(str(sym.atan(x)), "atan(x)")
-        self.assertEqual(str(sym.atan2(x, y)), "atan2(x, y)")
-        self.assertEqual(str(sym.sinh(x)), "sinh(x)")
-        self.assertEqual(str(sym.cosh(x)), "cosh(x)")
-        self.assertEqual(str(sym.tanh(x)), "tanh(x)")
-        self.assertEqual(str(sym.min(x, y)), "min(x, y)")
-        self.assertEqual(str(sym.max(x, y)), "max(x, y)")
-        self.assertEqual(str(sym.ceil(x)), "ceil(x)")
-        self.assertEqual(str(sym.floor(x)), "floor(x)")
-        self.assertEqual(str(sym.if_then_else(x > y, x, y)),
-                         "(if (x > y) then x else y)")
-
-    def test_functions_with_expression(self):
-        self.assertEqual(str(sym.abs(e_x)), "abs(x)")
-        self.assertEqual(str(sym.exp(e_x)), "exp(x)")
-        self.assertEqual(str(sym.sqrt(e_x)), "sqrt(x)")
-        self.assertEqual(str(sym.pow(e_x, e_y)), "pow(x, y)")
-        self.assertEqual(str(sym.sin(e_x)), "sin(x)")
-        self.assertEqual(str(sym.cos(e_x)), "cos(x)")
-        self.assertEqual(str(sym.tan(e_x)), "tan(x)")
-        self.assertEqual(str(sym.asin(e_x)), "asin(x)")
-        self.assertEqual(str(sym.acos(e_x)), "acos(x)")
-        self.assertEqual(str(sym.atan(e_x)), "atan(x)")
-        self.assertEqual(str(sym.atan2(e_x, e_y)), "atan2(x, y)")
-        self.assertEqual(str(sym.sinh(e_x)), "sinh(x)")
-        self.assertEqual(str(sym.cosh(e_x)), "cosh(x)")
-        self.assertEqual(str(sym.tanh(e_x)), "tanh(x)")
-        self.assertEqual(str(sym.min(e_x, e_y)), "min(x, y)")
-        self.assertEqual(str(sym.max(e_x, e_y)), "max(x, y)")
-        self.assertEqual(str(sym.ceil(e_x)), "ceil(x)")
-        self.assertEqual(str(sym.floor(e_x)), "floor(x)")
-        self.assertEqual(str(sym.if_then_else(e_x > e_y, e_x, e_y)),
-                         "(if (x > y) then x else y)")
 
     def test_non_method_jacobian(self):
         # Jacobian([x * cos(y), x * sin(y), x ** 2], [x, y]) returns
@@ -409,22 +487,22 @@ class TestSymbolicExpression(unittest.TestCase):
         #    |sin(y)    x * cos(y)|
         #    | 2 * x             0|
         J = sym.Jacobian([x * sym.cos(y), x * sym.sin(y), x ** 2], [x, y])
-        self.assertEqual(J[0, 0], sym.cos(y))
-        self.assertEqual(J[1, 0], sym.sin(y))
-        self.assertEqual(J[2, 0], 2 * x)
-        self.assertEqual(J[0, 1], - x * sym.sin(y))
-        self.assertEqual(J[1, 1], x * sym.cos(y))
-        self.assertEqual(J[2, 1], 0)
+        self._check_scalar(J[0, 0], sym.cos(y))
+        self._check_scalar(J[1, 0], sym.sin(y))
+        self._check_scalar(J[2, 0], 2 * x)
+        self._check_scalar(J[0, 1], - x * sym.sin(y))
+        self._check_scalar(J[1, 1], x * sym.cos(y))
+        self._check_scalar(J[2, 1], 0)
 
     def test_method_jacobian(self):
         # (x * cos(y)).Jacobian([x, y]) returns [cos(y), -x * sin(y)].
         J = (x * sym.cos(y)).Jacobian([x, y])
-        self.assertEqual(J[0], sym.cos(y))
-        self.assertEqual(J[1], -x * sym.sin(y))
+        self._check_scalar(J[0], sym.cos(y))
+        self._check_scalar(J[1], -x * sym.sin(y))
 
     def test_differentiate(self):
         e = x * x
-        self.assertEqual(e.Differentiate(x), 2 * x)
+        self._check_scalar(e.Differentiate(x), 2 * x)
 
     def test_repr(self):
         self.assertEqual(repr(e_x), '<Expression "x">')

--- a/bindings/pydrake/util/wrap_pybind.h
+++ b/bindings/pydrake/util/wrap_pybind.h
@@ -11,36 +11,29 @@
 namespace drake {
 namespace pydrake {
 
-// Defines a function in module `m`, and mirrors to module `mirror` for
-// backwards compatibility. Throws an error if any mirrored methods already
-// exist and do not match the original value.
+/// Defines a function in object `a` and mirrors `def` calls to object `b`.
+///
+/// @tparam A Type of object `a`
+/// @tparam B Type of object `b`
+template <typename A, typename B>
 class MirrorDef {
  public:
-  MirrorDef(py::module m, py::module mirror)
-      : m_(m), mirror_(mirror) {}
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MirrorDef);
 
+  MirrorDef(A* a, B* b)
+      : a_(a), b_(b) {}
+
+  /// Calls `def` for both `a` and `b`.
   template <typename... Args>
   MirrorDef& def(const char* name, Args&&... args) {
-    m_.def(name, std::forward<Args>(args)...);
-    do_mirror(name);
+    a_->def(name, std::forward<Args>(args)...);
+    b_->def(name, std::forward<Args>(args)...);
     return *this;
   }
 
  private:
-  void do_mirror(const char* name) {
-    py::object value = m_.attr(name);
-    // Ensure we won't shadow anything in the mirror; if an attribute of this
-    // name exists and is not exactly the same, throw an error.
-    py::object mirror_value = py::getattr(mirror_, name, py::none());
-    if (!mirror_value.is_none() && !mirror_value.is(value))
-      throw py::cast_error(py::str(
-          "Mirroring: '{}' from {} already exists in {} and will be shadowed")
-              .format(name, m_, mirror_).cast<std::string>());
-    mirror_.attr(name) = value;
-  }
-
-  py::module m_;
-  py::module mirror_;
+  A* const a_{};
+  B* const b_{};
 };
 
 }  // namespace pydrake

--- a/common/test/autodiff_overloads_test.cc
+++ b/common/test/autodiff_overloads_test.cc
@@ -16,6 +16,50 @@ namespace drake {
 namespace common {
 namespace {
 
+// Test nominal behavior of `AutoDiff`, checking implicit and explicit casting.
+GTEST_TEST(AutodiffOverloadsTest, Casting) {
+  VectorXd dx(3);
+  dx << 0, 1, 2;
+  VectorXd dx0(3);
+  dx0.setZero();
+
+  // No derivatives supplied.
+  AutoDiffXd x(1);
+  EXPECT_EQ(x.value(), 1);
+  EXPECT_EQ(x.derivatives().size(), 0);
+  // Persists.
+  x = 2;
+  EXPECT_EQ(x.value(), 2);
+  EXPECT_EQ(x.derivatives().size(), 0);
+  // Update derivative.
+  x.derivatives() = dx;
+  EXPECT_EQ(x.value(), 2);
+  EXPECT_EQ(x.derivatives(), dx);
+  // Implicitly castable, resets derivatives to zero.
+  x = 10;
+  EXPECT_EQ(x.value(), 10);
+  EXPECT_EQ(x.derivatives(), dx0);
+  // Resets derivative size.
+  x = AutoDiffXd(10);
+  EXPECT_EQ(x.value(), 10);
+  EXPECT_EQ(x.derivatives().size(), 0);
+
+  // Only explicitly castable to double.
+  double xs = x.value();
+  EXPECT_EQ(xs, 10);
+
+  // Can mix zero-size derivatives: interpreted as constants.
+  x = AutoDiffXd(2, dx);
+  AutoDiffXd y(3);
+  AutoDiffXd z = x * y;
+  EXPECT_EQ(z.value(), 6);
+  EXPECT_EQ(z.derivatives().size(), 3);
+
+  // The following causes failure, because of mixed derivative size.
+  // y.derivatives() = VectorXd::Zero(2);
+  // EXPECT_EQ((x * y).value(), 10);
+}
+
 // Tests ExtractDoubleOrThrow on autodiff.
 GTEST_TEST(AutodiffOverloadsTest, ExtractDouble) {
   // On autodiff.


### PR DESCRIPTION
Relates #8116 and #8315 

The purpose of this PR is to (a) ~lock down~ elucidate behavior with NumPy arrays and (b) provide a basis for seeing how the solution to #8315 will affect the behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8427)
<!-- Reviewable:end -->
