### PR TITLE
Make Element be explicit about using the global-namespace RigidBody

### DIFF
--- a/multibody/collision/element.cc
+++ b/multibody/collision/element.cc
@@ -22,13 +22,13 @@ Element::Element(const DrakeShapes::Geometry& geometry_in,
 }
 
 Element::Element(const Isometry3d& T_element_to_link,
-                 const RigidBody<double>* body)
+                 const ::RigidBody<double>* body)
     : DrakeShapes::Element(T_element_to_link), body_(body) {
 }
 
 Element::Element(const DrakeShapes::Geometry& geometry_in,
                  const Isometry3d& T_element_to_link,
-                 const RigidBody<double>* body)
+                 const ::RigidBody<double>* body)
     : DrakeShapes::Element(geometry_in, T_element_to_link), body_(body) {
 }
 
@@ -41,9 +41,9 @@ ElementId Element::getId() const {
   return reinterpret_cast<ElementId>(this);
 }
 
-const RigidBody<double>* Element::get_body() const { return body_; }
+const ::RigidBody<double>* Element::get_body() const { return body_; }
 
-void Element::set_body(const RigidBody<double> *body) { body_ = body; }
+void Element::set_body(const ::RigidBody<double> *body) { body_ = body; }
 
 bool Element::CanCollideWith(const Element* other) const {
   // Determines if the elements filter each other via filter *groups*. The

--- a/multibody/collision/element.h
+++ b/multibody/collision/element.h
@@ -63,7 +63,7 @@ class Element : public DrakeShapes::Element {
    * @param[in] body                    The associated rigid body.
    */
   Element(const Eigen::Isometry3d& T_element_to_local,
-          const RigidBody<double>* body);
+          const ::RigidBody<double>* body);
 
   /**
    * Full constructor.
@@ -73,7 +73,7 @@ class Element : public DrakeShapes::Element {
    */
   Element(const DrakeShapes::Geometry& geometry,
           const Eigen::Isometry3d& T_element_to_local,
-          const RigidBody<double>* body);
+          const ::RigidBody<double>* body);
 
   ~Element() override {}
 
@@ -129,10 +129,10 @@ class Element : public DrakeShapes::Element {
   /** Returns a pointer to the `RigidBody` to which this `Element`
    *  is attached.
    */
-  const RigidBody<double>* get_body() const;
+  const ::RigidBody<double>* get_body() const;
 
   /** Sets the `RigidBody` this collision element is attached to. */
-  void set_body(const RigidBody<double> *body);
+  void set_body(const ::RigidBody<double> *body);
 
   /** Sets the collision filter state of the element: the groups to which this
    * element belongs and the groups that it should ignore.
@@ -171,7 +171,7 @@ class Element : public DrakeShapes::Element {
   void operator=(Element&&) = delete;
 
   bool is_anchored_{false};
-  const RigidBody<double>* body_{};
+  const ::RigidBody<double>* body_{};
 
   // Collision cliques are defined as a set of collision elements that do not
   // collide.


### PR DESCRIPTION
@siyuanfeng-tri reported confusion between `::RigidBody` and `drake::multibody::RigidBody` when using the new MultibodyTree. This is an attempt to fix that by being explicit.

If this works, fixes #8428.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8431)
<!-- Reviewable:end -->
