### PR TITLE
Annotate packages with their licenses

### DIFF
--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(
     ["com_github_bazelbuild_bazel/tools/cpp/osx_cc_wrapper.sh"],
+    licenses = ["notice"],  # Apache-2.0
     visibility = [
         "//common:__pkg__",
         "//tools/cc_toolchain:__pkg__",
@@ -14,21 +15,19 @@ exports_files(
 
 exports_files(
     ["net_sf_jchart2d/LICENSE"],
+    licenses = ["restricted"],  # LGPL-3.0+
     visibility = ["//tools/workspace/net_sf_jchart2d:__pkg__"],
 )
 
 exports_files(
-    ["com_github_robotlocomotion_libbot2/LICENSE.ldpc"],
-    visibility = ["@libbot//:__pkg__"],
-)
-
-exports_files(
     glob(["com_kitware_gitlab_cmake_cmake/**"]),
+    licenses = ["notice"],  # BSD-3-Clause
     visibility = ["//tools/workspace/find_protobuf_cmake:__pkg__"],
 )
 
 exports_files(
     glob(["josephdavisco_spruce/**"]),
+    licenses = ["notice"],  # BSD-3-Clause
     visibility = ["@spruce//:__pkg__"],
 )
 
@@ -37,11 +36,13 @@ exports_files(
         "com_github_google_protobuf/LICENSE",
         "com_github_google_protobuf/protobuf.bzl",
     ],
+    licenses = ["notice"],  # BSD-3-Clause
     visibility = ["@com_google_protobuf//:__pkg__"],
 )
 
 exports_files(
     ["com_github_google_protobuf/protobuf-ubsan-fixup.h"],
+    licenses = ["notice"],  # BSD-3-Clause
     visibility = ["//common/proto:__pkg__"],
 )
 
@@ -51,6 +52,7 @@ exports_files(
         "__init__.py",
         "wrappers.py",
     ]],
+    licenses = ["notice"],  # BSD-2-Clause
     visibility = ["//bindings/pydrake/third_party:__pkg__"],
 )
 

--- a/tools/lint/buildifier-tables.json
+++ b/tools/lint/buildifier-tables.json
@@ -42,6 +42,7 @@
     "new_local_repository.path":                300,
     "new_local_repository.build_file_content":  360,
 
+    "pkg_config_repository.licenses":         100,
     "pkg_config_repository.atleast_version":  200,
     "pkg_config_repository.static":           201,
     "pkg_config_repository.pkg_config_paths": 202,

--- a/tools/workspace/blas/repository.bzl
+++ b/tools/workspace/blas/repository.bzl
@@ -5,5 +5,13 @@ load(
     "pkg_config_repository",
 )
 
-def blas_repository(name, modname = "blas", **kwargs):
-    pkg_config_repository(name = name, modname = modname, **kwargs)
+def blas_repository(
+        name,
+        licenses = ["notice"],  # BSD-3-Clause
+        modname = "blas",
+        **kwargs):
+    pkg_config_repository(
+        name = name,
+        licenses = licenses,
+        modname = modname,
+        **kwargs)

--- a/tools/workspace/boost/repository.bzl
+++ b/tools/workspace/boost/repository.bzl
@@ -41,7 +41,10 @@ def _impl(repository_ctx):
 
     repository_ctx.symlink("{}/include/boost".format(prefix), "boost")
 
-    file_content = """
+    file_content = """# -*- python -*-
+
+licenses(["notice"])  # BSL-1.0
+
 cc_library(
     name = "boost_headers",
     hdrs = glob({}),

--- a/tools/workspace/buildifier/repository.bzl
+++ b/tools/workspace/buildifier/repository.bzl
@@ -49,7 +49,10 @@ def _impl(repository_ctx):
 
     repository_ctx.download(urls, output, sha256, executable = True)
 
-    content = """
+    content = """# -*- python -*-
+
+licenses(["notice"])  # Apache-2.0
+
 exports_files(
     ["buildifier"],
 )

--- a/tools/workspace/bullet/package.BUILD.bazel
+++ b/tools/workspace/bullet/package.BUILD.bazel
@@ -8,6 +8,12 @@ load(
 )
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
+licenses(["notice"])  # Zlib AND (BSD-3-Clause OR LGPL-2.1+ OR Zlib)
+
+# Gimpact, which is used by BulletCollision offers a choice of three licenses,
+# and we choose Zlib to match the license of the rest of Bullet. Hence, the
+# license type only includes "notice" and not "restricted."
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(

--- a/tools/workspace/ccd/package.BUILD.bazel
+++ b/tools/workspace/ccd/package.BUILD.bazel
@@ -9,6 +9,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/com_google_protobuf/package.BUILD.bazel
+++ b/tools/workspace/com_google_protobuf/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/com_jidesoft_jide_oss/repository.bzl
+++ b/tools/workspace/com_jidesoft_jide_oss/repository.bzl
@@ -7,7 +7,7 @@ def com_jidesoft_jide_oss_repository(
         mirrors = None):
     java_import_external(
         name = name,
-        licenses = [],
+        licenses = ["restricted"],  # GPL-2.0 WITH Classpath-exception-2.0
         jar_urls = [
             x.format(fulljar = "com/jidesoft/jide-oss/2.9.7/jide-oss-2.9.7.jar")  # noqa
             for x in mirrors.get("maven")

--- a/tools/workspace/commons_io/repository.bzl
+++ b/tools/workspace/commons_io/repository.bzl
@@ -7,7 +7,7 @@ def commons_io_repository(
         mirrors = None):
     java_import_external(
         name = name,
-        licenses = [],
+        licenses = ["notice"],  # Apache-2.0
         jar_urls = [
             x.format(fulljar = "commons-io/commons-io/1.3.1/commons-io-1.3.1.jar")  # noqa
             for x in mirrors.get("maven")

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -64,6 +64,23 @@ def _impl(repository_ctx):
 
     file_content = """# -*- python -*-
 
+licenses([
+    "notice",  # Apache-2.0 AND BSD-3-Clause AND Python-2.0
+    "reciprocal",  # MPL-2.0
+    "restricted",  # LGPL-2.1 AND LGPL-2.1+
+    "unencumbered",  # Public-Domain
+])
+
+# drake-visualizer has the following non-system dependencies in addition to
+# those declared in deps:
+#   ctkPythonConsole: Apache-2.0
+#   Eigen: BSD-3-Clause AND MPL-2.0 AND Public-Domain
+#   LCM: BSD-3-Clause AND LGPL-2.1 AND LGPL-2.1+
+#   Python: Python-2.0
+#   PythonQt: LGPL-2.1
+#   QtPropertyBrowser: LGPL-2.1
+# TODO(jamiesnape): Enumerate system dependencies.
+
 py_library(
     name = "drake_visualizer_python_deps",
     deps = [

--- a/tools/workspace/dreal/package-ubuntu.BUILD.bazel
+++ b/tools/workspace/dreal/package-ubuntu.BUILD.bazel
@@ -10,6 +10,8 @@ load(
     "IBEX_VERSION",
 )
 
+licenses(["notice"])  # Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 _DREAL_BASE = "opt/dreal/{}/".format(DREAL_VERSION)
@@ -34,6 +36,11 @@ cc_library(
     ],
 )
 
+# IBEX has the following dependencies in addition to those declared in deps:
+#   Clp: EPL-1
+#   CoinUtils: EPL-1
+#   bzip2: bzip2-1.0.6
+
 cc_library(
     name = "ibex",
     srcs = [_IBEX_BASE + "lib/libdrake_ibex.so"],
@@ -43,6 +50,11 @@ cc_library(
         _IBEX_BASE + "include",
         _IBEX_BASE + "include/ibex",
         _IBEX_BASE + "include/ibex/3rd",
+    ],
+    licenses = [
+        "notice",  # bzip2-1.0.6
+        "reciprocal",  # EPL-1
+        "restricted",  # LGPL-3.0
     ],
     # The linkopts= here are transcribed from the contents of the *.pc file.
     linkopts = [

--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -64,6 +64,7 @@ def _impl(repo_ctx):
              format(repo_ctx.name, result.error))
 
 dreal_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
     attrs = {
         "modname": attr.string(default = "dreal"),
         # This attribute is only used for macOS.  It is documented in the

--- a/tools/workspace/eigen/package.BUILD.bazel
+++ b/tools/workspace/eigen/package.BUILD.bazel
@@ -8,6 +8,12 @@ load(
 )
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
+licenses([
+    "notice",  # BSD-3-Clause
+    "reciprocal",  # MPL-2.0
+    "unencumbered",  # Public-Domain
+])
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/expat/repository.bzl
+++ b/tools/workspace/expat/repository.bzl
@@ -40,7 +40,10 @@ def _impl(repository_ctx):
         repository_ctx.symlink("/usr/include/expat_external.h",
                                "include/expat_external.h")
 
-        file_content = """
+        file_content = """# -*- python -*-
+
+licenses(["notice"])  # MIT
+
 cc_library(
     name = "expat",
     hdrs = [
@@ -62,6 +65,7 @@ cc_library(
             fail(error)
 
 expat_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
     attrs = {
         "modname": attr.string(default = "expat"),
     },

--- a/tools/workspace/fcl/package.BUILD.bazel
+++ b/tools/workspace/fcl/package.BUILD.bazel
@@ -17,6 +17,8 @@ load(
     "drake_generate_include_header",
 )
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/fmt/package.BUILD.bazel
+++ b/tools/workspace/fmt/package.BUILD.bazel
@@ -7,6 +7,8 @@ load(
     "install_cmake_config",
 )
 
+licenses(["notice"])  # BSD-2-Clause
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/freetype2/repository.bzl
+++ b/tools/workspace/freetype2/repository.bzl
@@ -5,5 +5,16 @@ load(
     "pkg_config_repository",
 )
 
-def freetype2_repository(name, modname = "freetype2", **kwargs):
-    pkg_config_repository(name = name, modname = modname, **kwargs)
+def freetype2_repository(
+        name,
+        licenses = ["notice"],  # BSD-2-Clause AND BSD-3-Clause AND
+                                # (FTL OR GPL-2.0+)
+        modname = "freetype2",
+        pkg_config_paths = ["/usr/local/opt/freetype/lib/pkgconfig"],
+        **kwargs):
+    pkg_config_repository(
+        name = name,
+        licenses = licenses,
+        modname = modname,
+        pkg_config_paths = pkg_config_paths,
+        **kwargs)

--- a/tools/workspace/gflags/repository.bzl
+++ b/tools/workspace/gflags/repository.bzl
@@ -38,7 +38,10 @@ def _impl(repository_ctx):
     if os_result.ubuntu_release == "16.04":
         repository_ctx.symlink("/usr/include/gflags", "include/gflags")
 
-        file_content = """
+        file_content = """# -*- python -*-
+
+licenses(["notice"])  # BSD-3-Clause
+
 cc_library(
     name = "gflags",
     hdrs = [
@@ -62,6 +65,7 @@ cc_library(
             fail(error)
 
 gflags_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
     attrs = {
         "modname": attr.string(default = "gflags"),
         "pkg_config_paths": attr.string_list(

--- a/tools/workspace/glew/repository.bzl
+++ b/tools/workspace/glew/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def glew_repository(
         name,
+        licenses = ["notice"],  # BSD-3-Clause AND MIT
         modname = "glew",
         pkg_config_paths = ["/usr/local/opt/glew/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/glib/repository.bzl
+++ b/tools/workspace/glib/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def glib_repository(
         name,
+        licenses = ["restricted"],  # LGPL-2.0+
         modname = "glib-2.0",
         pkg_config_paths = ["/usr/local/opt/glib/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/godotengine/package.BUILD.bazel
+++ b/tools/workspace/godotengine/package.BUILD.bazel
@@ -1,5 +1,10 @@
 # -*- python -*-
 
+licenses([
+    "notice",  # Apache-2.0 AND BSD-3-Clause AND ISC AND MIT AND Zlib
+    "unencumbered",  # Public-Domain
+])
+
 # Compile a tool that knows how to emit the version*.gen.h files.
 py_binary(
     name = "update_version",
@@ -87,7 +92,10 @@ cc_library(
     ],
 )
 
-# The packages that we want.  Use "/**" to also glob their subpackages.
+# The packages that we want.  Use "/**" to also glob their subpackages.  When
+# adding new third-party packages to this list, verify that the licenses()
+# function call at the top of this file and the inline comments next to it are
+# still accurate.
 _PACKAGES = [
     "core/**",
     "drivers",

--- a/tools/workspace/gtest/package.BUILD.bazel
+++ b/tools/workspace/gtest/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["notice"])  # BSD-3-Clause
+
 config_setting(
     name = "linux",
     values = {"cpu": "k8"},

--- a/tools/workspace/gurobi/repository.bzl
+++ b/tools/workspace/gurobi/repository.bzl
@@ -48,6 +48,8 @@ def _gurobi_impl(repository_ctx):
 
     file_content = """# -*- python -*-
 
+licenses(["by_exception_only"])  # Gurobi
+
 package(default_visibility = ["//visibility:public"])
 
 GUROBI_HDRS = glob([

--- a/tools/workspace/ignition_math/package.BUILD.bazel
+++ b/tools/workspace/ignition_math/package.BUILD.bazel
@@ -20,6 +20,8 @@ load(
 )
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
+licenses(["notice"])  # Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(

--- a/tools/workspace/ignition_rndf/package.BUILD.bazel
+++ b/tools/workspace/ignition_rndf/package.BUILD.bazel
@@ -20,6 +20,8 @@ load(
 )
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
+licenses(["notice"])  # Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(

--- a/tools/workspace/ipopt/repository.bzl
+++ b/tools/workspace/ipopt/repository.bzl
@@ -7,11 +7,16 @@ load(
 
 def ipopt_repository(
         name,
+        licenses = [
+            "reciprocal",  # CPL-1.0
+            "unencumbered",  # Public-Domain
+        ],
         modname = "ipopt",
         pkg_config_paths = ["/usr/local/opt/ipopt/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/json/package.BUILD.bazel
+++ b/tools/workspace/json/package.BUILD.bazel
@@ -5,6 +5,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # MIT
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/lapack/repository.bzl
+++ b/tools/workspace/lapack/repository.bzl
@@ -5,5 +5,13 @@ load(
     "pkg_config_repository",
 )
 
-def lapack_repository(name, modname = "lapack", **kwargs):
-    pkg_config_repository(name = name, modname = modname, **kwargs)
+def lapack_repository(
+        name,
+        licenses = ["notice"],  # BSD-3-Clause
+        modname = "lapack",
+        **kwargs):
+    pkg_config_repository(
+        name = name,
+        licenses = licenses,
+        modname = modname,
+        **kwargs)

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -17,6 +17,11 @@ load(
 )
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
+licenses([
+    "notice",  # BSD-3-Clause
+    "restricted",  # LGPL-2.1 AND LGPL-2.1+
+])
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(

--- a/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_bot2_core/package.BUILD.bazel
@@ -1,7 +1,5 @@
 # -*- python -*-
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@drake//tools/install:install.bzl",
     "cmake_config",
@@ -14,6 +12,13 @@ load(
     "lcm_java_library",
     "lcm_py_library",
 )
+
+licenses([
+    "none",
+    "notice",  # BSD-3-Clause
+])
+
+package(default_visibility = ["//visibility:public"])
 
 LCM_SRCS = glob(["lcmtypes/*.lcm"])
 

--- a/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
+++ b/tools/workspace/lcmtypes_robotlocomotion/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 load(

--- a/tools/workspace/liblz4/repository.bzl
+++ b/tools/workspace/liblz4/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def liblz4_repository(
         name,
+        licenses = ["notice"],  # BSD-2-Clause
         modname = "liblz4",
         pkg_config_paths = ["/usr/local/opt/lz4/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/libpng/repository.bzl
+++ b/tools/workspace/libpng/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def libpng_repository(
         name,
+        licenses = ["notice"],  # Libpng
         modname = "libpng",
         pkg_config_paths = ["/usr/local/opt/libpng/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/libprotobuf/repository.bzl
+++ b/tools/workspace/libprotobuf/repository.bzl
@@ -10,11 +10,13 @@ load(
 
 def libprotobuf_repository(
         name,
+        licenses = ["notice"],  # BSD-3-Clause
         modname = "protobuf",
         pkg_config_paths = ["/usr/local/opt/protobuf/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/mosek/repository.bzl
+++ b/tools/workspace/mosek/repository.bzl
@@ -100,6 +100,11 @@ def _impl(repository_ctx):
 
 load("@drake//tools/install:install.bzl", "install", "install_files")
 
+licenses([
+    "by_exception_only",  # MOSEK
+    "notice",  # fplib AND Zlib
+])
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/net_sf_jchart2d/repository.bzl
+++ b/tools/workspace/net_sf_jchart2d/repository.bzl
@@ -9,7 +9,7 @@ def net_sf_jchart2d_repository(
     # licenses in tools/third_party/jchart2d/LICENSE are still applicable.
     java_import_external(
         name = name,
-        licenses = [],
+        licenses = ["restricted"],  # LGPL-3.0+
         jar_urls = [
             x.format(fulljar = "net/sf/jchart2d/jchart2d/3.3.2/jchart2d-3.3.2.jar")  # noqa
             for x in mirrors.get("maven")

--- a/tools/workspace/nlopt/repository.bzl
+++ b/tools/workspace/nlopt/repository.bzl
@@ -7,11 +7,16 @@ load(
 
 def nlopt_repository(
         name,
+        licenses = [
+            "notice",  # BSD-3-Clause AND MIT
+            "restricted",  # LGPL-2.1+
+        ],
         modname = "nlopt",
         pkg_config_paths = ["/usr/local/opt/nlopt/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/numpy/repository.bzl
+++ b/tools/workspace/numpy/repository.bzl
@@ -50,7 +50,13 @@ def _impl(repository_ctx):
     destination = repository_ctx.path("include")
     repository_ctx.symlink(source, destination)
 
-    file_content = """
+    file_content = """# -*- python -*-
+
+licenses([
+    "notice",  # BSD-2-Clause AND BSD-3-Clause AND MIT AND Python-2.0
+    "unencumbered",  # Public-Domain
+])
+
 cc_library(
     name = "numpy",
     hdrs = glob(["include/**"]),

--- a/tools/workspace/octomap/package.BUILD.bazel
+++ b/tools/workspace/octomap/package.BUILD.bazel
@@ -5,6 +5,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 # Lets other packages inspect the CMake code, e.g., for the version number.

--- a/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
+++ b/tools/workspace/org_apache_xmlgraphics_commons/repository.bzl
@@ -7,7 +7,7 @@ def org_apache_xmlgraphics_commons_repository(
         mirrors = None):
     java_import_external(
         name = name,
-        licenses = [],
+        licenses = ["notice"],  # Apache-2.0
         jar_urls = [
             x.format(fulljar = "org/apache/xmlgraphics/xmlgraphics-commons/1.3.1/xmlgraphics-commons-1.3.1.jar")  # noqa
             for x in mirrors.get("maven")

--- a/tools/workspace/osqp/package.BUILD.bazel
+++ b/tools/workspace/osqp/package.BUILD.bazel
@@ -9,6 +9,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # Apache-2.0
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/pkg_config.BUILD.tpl
+++ b/tools/workspace/pkg_config.BUILD.tpl
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(%{licenses})
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -169,6 +169,8 @@ def setup_pkg_config_repository(repository_ctx):
 
     # Write out the BUILD file.
     substitutions = {
+        "%{licenses}": repr(
+            getattr(repository_ctx.attr, "licenses", [])),
         "%{name}": repr(
             repository_ctx.name),
         "%{srcs}": repr(
@@ -200,7 +202,11 @@ def _impl(repository_ctx):
              format(repository_ctx.name, result.error))
 
 pkg_config_repository = repository_rule(
+    # TODO(jamiesnape): Make licenses mandatory.
+    # TODO(jamiesnape): Use of this rule may cause additional transitive
+    # dependencies to be linked and their licenses must also be enumerated.
     attrs = {
+        "licenses": attr.string_list(),
         "modname": attr.string(mandatory = True),
         "atleast_version": attr.string(),
         "static": attr.bool(default = _DEFAULT_STATIC),
@@ -250,6 +256,10 @@ Example:
 
 Args:
     name: A unique name for this rule.
+    licenses: Licenses of the library. Valid license types include restricted,
+              reciprocal, notice, permissive, and unencumbered. See
+              https://docs.bazel.build/versions/master/be/functions.html#licenses_args
+              for more information.
     modname: The library name as known to pkg-config.
     atleast_version: (Optional) The --atleast-version to pkg-config.
     static: (Optional) Add linkopts for static linking to the library target.

--- a/tools/workspace/pybind11/package.BUILD.bazel
+++ b/tools/workspace/pybind11/package.BUILD.bazel
@@ -9,6 +9,8 @@ load(
 )
 load("@drake//tools/lint:python_lint.bzl", "python_lint")
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/pycodestyle/package.BUILD.bazel
+++ b/tools/workspace/pycodestyle/package.BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@drake//tools/workspace:generate_file.bzl", "generate_file")
 
+licenses(["notice"])  # MIT
+
 package(default_visibility = ["//visibility:public"])
 
 # Downstream users of python modules expect to say 'import pycodestyle'.

--- a/tools/workspace/pycps/package.BUILD.bazel
+++ b/tools/workspace/pycps/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["restricted"])  # LGPL-3.0+
+
 genrule(
     name = "copy_cps2cmake",
     srcs = ["cps2cmake"],

--- a/tools/workspace/python/repository.bzl
+++ b/tools/workspace/python/repository.bzl
@@ -91,6 +91,8 @@ def _impl(repository_ctx):
 
     file_content = """# -*- python -*-
 
+licenses(["notice"])  # Python-2.0
+
 cc_library(
     name = "python_headers",
     hdrs = glob(["include/**"]),

--- a/tools/workspace/scs/package.BUILD.bazel
+++ b/tools/workspace/scs/package.BUILD.bazel
@@ -2,6 +2,11 @@
 
 load("@drake//tools/install:install.bzl", "install")
 
+licenses([
+    "notice",  # MIT
+    "restricted",  # LGPL-2.1+
+])
+
 package(default_visibility = ["//visibility:public"])
 
 config_setting(

--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -17,6 +17,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # Apache-2.0 AND BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/semantic_version/package.BUILD.bazel
+++ b/tools/workspace/semantic_version/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["notice"])  # BSD-2-Clause
+
 py_library(
     name = "semantic_version",
     srcs = glob(["*.py"]),

--- a/tools/workspace/snopt/package.BUILD.bazel
+++ b/tools/workspace/snopt/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["by_exception_only"])  # SNOPT
+
 # In some versions of SNOPT, this header provides the function declarations to
 # control SNOPT's logging.  In other versions, those declarations instead
 # appear directly in cexamples/snopt.h and this file is absent.  We'll sense

--- a/tools/workspace/spdlog/package.BUILD.bazel
+++ b/tools/workspace/spdlog/package.BUILD.bazel
@@ -7,6 +7,8 @@ load(
     "install_cmake_config",
 )
 
+licenses(["notice"])  # BSD-2-Clause AND MIT
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/spruce/package.BUILD.bazel
+++ b/tools/workspace/spruce/package.BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@drake//tools/install:install.bzl", "install")
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/stx/package.BUILD.bazel
+++ b/tools/workspace/stx/package.BUILD.bazel
@@ -7,6 +7,8 @@ load(
     "install_cmake_config",
 )
 
+licenses(["notice"])  # BSD-3-Clause AND BSL-1.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/styleguide/package.BUILD.bazel
+++ b/tools/workspace/styleguide/package.BUILD.bazel
@@ -1,5 +1,7 @@
 # -*- python -*-
 
+licenses(["notice"])  # BSD-3-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 # We can't set name="cpplint" here because that's the directory name so the

--- a/tools/workspace/tinydir/package.BUILD.bazel
+++ b/tools/workspace/tinydir/package.BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@drake//tools/install:install.bzl", "install")
 
+licenses(["notice"])  # BSD-2-Clause
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/workspace/tinyobjloader/package.BUILD.bazel
+++ b/tools/workspace/tinyobjloader/package.BUILD.bazel
@@ -5,6 +5,8 @@ load(
     "install",
 )
 
+licenses(["notice"])  # MIT
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/tools/workspace/tinyxml/repository.bzl
+++ b/tools/workspace/tinyxml/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def tinyxml_repository(
         name,
+        licenses = ["notice"],  # Zlib
         modname = "tinyxml",
         pkg_config_paths = ["/usr/local/opt/tinyxml/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/tinyxml2/repository.bzl
+++ b/tools/workspace/tinyxml2/repository.bzl
@@ -7,11 +7,13 @@ load(
 
 def tinyxml2_repository(
         name,
+        licenses = ["notice"],  # Zlib
         modname = "tinyxml2",
         pkg_config_paths = ["/usr/local/opt/tinyxml2/lib/pkgconfig"],
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         pkg_config_paths = pkg_config_paths,
         **kwargs)

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -126,7 +126,14 @@ def _impl(repository_ctx):
     else:
         fail("Operating system is NOT supported", attr = os_result)
 
-    file_content = "# -*- python -*-"
+    file_content = """# -*- python -*-
+
+licenses([
+    "notice",  # BSD-3-Clause AND MIT
+    "reciprocal",  # GL2PS
+    "unencumbered",  # Public-Domain
+])
+"""
 
     # Note that we only create library targets for enough of VTK to support
     # those used directly or indirectly by Drake.

--- a/tools/workspace/yaml_cpp/repository.bzl
+++ b/tools/workspace/yaml_cpp/repository.bzl
@@ -7,6 +7,7 @@ load(
 
 def yaml_cpp_repository(
         name,
+        licenses = ["notice"],  # X11
         modname = "yaml-cpp",
         atleast_version = "0.5.2",
         extra_deps = ["@boost//:boost_headers"],
@@ -14,6 +15,7 @@ def yaml_cpp_repository(
         **kwargs):
     pkg_config_repository(
         name = name,
+        licenses = licenses,
         modname = modname,
         atleast_version = atleast_version,
         extra_deps = extra_deps,

--- a/tools/workspace/zlib/repository.bzl
+++ b/tools/workspace/zlib/repository.bzl
@@ -39,7 +39,10 @@ def _impl(repository_ctx):
         repository_ctx.symlink("/usr/include/zlib.h", "include/zlib.h")
         repository_ctx.symlink("/usr/include/zconf.h", "include/zconf.h")
 
-        file_content = """
+        file_content = """# -*- python -*-
+
+licenses(["notice"])  # Zlib
+
 cc_library(
     name = "zlib",
     hdrs = [
@@ -61,6 +64,7 @@ cc_library(
             fail(error)
 
 zlib_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
     attrs = {
         "modname": attr.string(default = "zlib"),
     },


### PR DESCRIPTION
This is toward distilling the information into #4045 into something that we can programmatically enforce. Of course, really every `BUILD` file in Drake also needs annotating, but this is a start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8447)
<!-- Reviewable:end -->