### PR TITLE
Add unzip to source distribution install_prereqs script

### DIFF
--- a/setup/ubuntu/16.04/source_distribution/packages.txt
+++ b/setup/ubuntu/16.04/source_distribution/packages.txt
@@ -47,6 +47,7 @@ python-protobuf
 python-pygame
 python-sphinx
 python-tk
+unzip
 valgrind
 zip
 zlib1g-dev


### PR DESCRIPTION
Technically only CI needs this, but since we require `zip`, I am going to argue it is not too controversial to require `unzip`, and saves me having to document the requirement elsewhere. In addition, SNOPT seems to be most widely distributed as a zip-file, so this may well be needed in future anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8453)
<!-- Reviewable:end -->
