### PR TITLE
Change DrakeLcmInterface callback to use std::function

### DIFF
--- a/examples/acrobot/test/acrobot_lcm_msg_generator.cc
+++ b/examples/acrobot/test/acrobot_lcm_msg_generator.cc
@@ -18,80 +18,44 @@ namespace {
 using std::chrono::milliseconds;
 using std::this_thread::sleep_for;
 
-/// Handles received LCM messages of type lcmt_acrobot_x.
-// copied from drake/lcm/test/drake_lcm_test.cc
-class MessageHandler : public lcm::DrakeLcmMessageHandlerInterface {
- public:
-  /// A constructor that initializes the memory for storing received LCM
-  /// messages.
-  MessageHandler() {
-    // Initializes the fields of received_message.
-    received_message_.theta1 = 0;
-    received_message_.theta2 = 0;
-    received_message_.theta1Dot = 0;
-    received_message_.theta2Dot = 0;
-    received_message_.timestamp = 0;
-  }
-
-  /// This is the callback method.
-  void HandleMessage(const std::string& channel, const void* message_buffer,
-                     int message_size) override {
-    channel_ = channel;
-    std::lock_guard<std::mutex> lock(message_mutex_);
-    received_message_.decode(message_buffer, 0, message_size);
-  }
-
-  /// Returns a copy of the most recently received message.
-  lcmt_acrobot_x GetReceivedMessage() {
-    lcmt_acrobot_x message_copy;
-    std::lock_guard<std::mutex> lock(message_mutex_);
-    message_copy = received_message_;
-    return message_copy;
-  }
-
-  /// Returns the channel on which the most recent message was received.
-  const std::string& get_receive_channel() { return channel_; }
-
- private:
-  std::string channel_{};
-  std::mutex message_mutex_;
-  lcmt_acrobot_x received_message_;
-};
-
 int DoMain() {
   drake::lcm::DrakeLcm lcm;
 
   const std::string channel_x = "acrobot_xhat";
   const std::string channel_u = "acrobot_u";
+
+  // Decode channel_x into msg_x.
+  std::mutex msg_x_mutex;  // Guards msg_x.
   lcmt_acrobot_x msg_x{};
-  lcmt_acrobot_u msg_u{};
+  lcm.Subscribe(channel_x, [&](const void* buffer, int size) {
+    std::lock_guard<std::mutex> lock(msg_x_mutex);
+    msg_x.decode(buffer, 0, size);
+  });
 
-  MessageHandler handler;
-  lcm.Subscribe(channel_x, &handler);
   lcm.StartReceiveThread();
-
-  int t = 0;
-  while (t < 1e5) {
-    // Publishes msg_x.
-    msg_x.theta1 = t * M_PI / 6;
-    msg_x.theta2 = t * M_PI / 6;
-    msg_x.theta1Dot = std::sin(msg_x.theta1);
-    msg_x.theta2Dot = std::cos(msg_x.theta2);
-    Publish(&lcm, channel_x, msg_x);
+  for (int i = 0; i < 1e5; ++i) {
+    // Publishes a dummy msg_x.
+    {
+      lcmt_acrobot_x dummy{};
+      dummy.theta1 = i * M_PI / 6;
+      dummy.theta2 = i * M_PI / 6;
+      dummy.theta1Dot = std::sin(dummy.theta1);
+      dummy.theta2Dot = std::cos(dummy.theta2);
+      Publish(&lcm, channel_x, dummy);
+    }
 
     // Publishes msg_u using received msg_x.
-    if (handler.get_receive_channel() == channel_x) {
-      // Gets the received message.
-      const lcmt_acrobot_x received_msg = handler.GetReceivedMessage();
-
-      // Calculates some output from received state.
-      msg_u.tau = received_msg.theta1 + received_msg.theta2;
-
-      // Publish msg_u.
-      Publish(&lcm, channel_u, msg_u);
+    {
+      std::lock_guard<std::mutex> lock(msg_x_mutex);
+      if (msg_x.timestamp > 0) {
+        // Calculates some output from received state.
+        lcmt_acrobot_u msg_u{};
+        msg_u.tau = msg_x.theta1 + msg_x.theta2;
+        Publish(&lcm, channel_u, msg_u);
+      }
     }
+
     sleep_for(milliseconds(500));
-    t++;
   }
 
   return 0;

--- a/lcm/drake_lcm.cc
+++ b/lcm/drake_lcm.cc
@@ -8,26 +8,18 @@
 
 namespace drake {
 namespace lcm {
+namespace {
 
-// This is the actual subscriber to an LCM channel. It simply extracts the
-// serialized LCM message and passes it to the `DrakeLcmMessageHandlerInterface`
-// object. A single type of subscriber is used to avoid DrakeLcm from being
-// templated on the subscriber type.
-class DrakeLcm::Subscriber {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Subscriber)
+void Callback(const ::lcm::ReceiveBuffer* buffer,
+              const std::string& /* channel */ ,
+              DrakeLcm::HandlerFunction* context) {
+  DRAKE_DEMAND(buffer != nullptr);
+  DRAKE_DEMAND(context != nullptr);
+  DrakeLcm::HandlerFunction& handler = *context;
+  handler(buffer->data, buffer->data_size);
+}
 
-  explicit Subscriber(DrakeLcmMessageHandlerInterface* drake_handler)
-      : drake_handler_(drake_handler) {}
-
-  void LcmCallback(const ::lcm::ReceiveBuffer* rbuf,
-                   const std::string& channel) {
-    drake_handler_->HandleMessage(channel, rbuf->data, rbuf->data_size);
-  }
-
- private:
-  DrakeLcmMessageHandlerInterface* const drake_handler_{};
-};
+}  // namespace
 
 DrakeLcm::DrakeLcm() {}
 
@@ -53,15 +45,23 @@ void DrakeLcm::Publish(const std::string& channel, const void* data,
   lcm_.publish(channel, data, data_size);
 }
 
+void DrakeLcm::Subscribe(const std::string& channel, HandlerFunction handler) {
+  DRAKE_THROW_UNLESS(!channel.empty());
+  handlers_.emplace_back(std::move(handler));
+  // The handlers_ is a std::list so that the context pointers remain stable.
+  HandlerFunction* const context = &handlers_.back();
+  lcm_.subscribeFunction(channel, &Callback, context)->setQueueCapacity(1);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 void DrakeLcm::Subscribe(const std::string& channel,
                          DrakeLcmMessageHandlerInterface* handler) {
-  DRAKE_THROW_UNLESS(!channel.empty());
-  auto subscriber = std::make_unique<Subscriber>(handler);
-  auto sub =
-      lcm_.subscribe(channel, &Subscriber::LcmCallback, subscriber.get());
-  sub->setQueueCapacity(1);
-  subscriptions_.push_back(std::move(subscriber));
+  Subscribe(channel, std::bind(
+      std::mem_fn(&DrakeLcmMessageHandlerInterface::HandleMessage), handler,
+      channel, std::placeholders::_1, std::placeholders::_2));
 }
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 }  // namespace lcm
 }  // namespace drake

--- a/lcm/drake_lcm.h
+++ b/lcm/drake_lcm.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <list>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "lcm/lcm-cpp.hpp"
 
@@ -66,14 +66,17 @@ class DrakeLcm : public DrakeLcmInterface {
   void Publish(const std::string& channel, const void* data,
                int data_size, optional<double> time_sec) override;
 
-  void Subscribe(const std::string& channel,
-                 DrakeLcmMessageHandlerInterface* handler) override;
+  void Subscribe(const std::string&, HandlerFunction) override;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  void Subscribe(const std::string&, DrakeLcmMessageHandlerInterface*) override;
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
  private:
-  class Subscriber;
   ::lcm::LCM lcm_;
   std::unique_ptr<LcmReceiveThread> receive_thread_{nullptr};
-  std::vector<std::unique_ptr<Subscriber>> subscriptions_;
+  std::list<HandlerFunction> handlers_;
 };
 
 }  // namespace lcm

--- a/lcm/drake_lcm_interface.h
+++ b/lcm/drake_lcm_interface.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <string>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/drake_throw.h"
 #include "drake/lcm/drake_lcm_message_handler_interface.h"
@@ -20,6 +22,14 @@ class DrakeLcmInterface {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeLcmInterface)
   virtual ~DrakeLcmInterface() = default;
+
+  /**
+   * A callback used by DrakeLcmInterface::Subscribe(), with arguments:
+   * - `message_buffer` A pointer to the byte vector that is the serial
+   *   representation of the LCM message.
+   * - `message_size` The size of `message_buffer`.
+   */
+  using HandlerFunction = std::function<void(const void*, int)>;
 
   /**
    * Publishes an LCM message on channel @p channel.
@@ -40,16 +50,21 @@ class DrakeLcmInterface {
 
   /**
    * Subscribes to an LCM channel without automatic message decoding. The
-   * callback method within @p handler will be invoked when a message arrives on
-   * channel @p channel.
+   * handler will be invoked when a message arrives on channel @p channel.
    *
-   * @param[in] channel The channel to subscribe to.
+   * @param channel The channel to subscribe to.
    * Must not be the empty string.
-   *
-   * @param[in] handler A class instance whose callback method will be invoked.
    */
+  virtual void Subscribe(const std::string& channel, HandlerFunction) = 0;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  /** A deprecated overload of Subscribe. */
+  // TODO(jwnimmer-tri) Remove this deprecated method on or about 2018-06-01.
+  DRAKE_DEPRECATED("Use the std::function overload instead")
   virtual void Subscribe(const std::string& channel,
-                         DrakeLcmMessageHandlerInterface* handler) = 0;
+                         DrakeLcmMessageHandlerInterface*) = 0;
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
  protected:
   DrakeLcmInterface() = default;

--- a/lcm/drake_lcm_log.h
+++ b/lcm/drake_lcm_log.h
@@ -71,8 +71,12 @@ class DrakeLcmLog : public DrakeLcmInterface {
    * @throws std::logic_error if this instance is not constructed in read-only
    * mode.
    */
-  void Subscribe(const std::string& channel,
-                 DrakeLcmMessageHandlerInterface* handler) override;
+  void Subscribe(const std::string& channel, HandlerFunction handler) override;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  void Subscribe(const std::string&, DrakeLcmMessageHandlerInterface*) override;
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   /**
    * Returns the time in seconds for the next logged message's occurrence time
@@ -127,8 +131,7 @@ class DrakeLcmLog : public DrakeLcmInterface {
 
   // This mutes guards access to all of the below member fields.
   mutable std::mutex mutex_;
-  std::map<std::string, std::vector<DrakeLcmMessageHandlerInterface*>>
-      subscriptions_;
+  std::multimap<std::string, DrakeLcmInterface::HandlerFunction> subscriptions_;
   std::unique_ptr<::lcm::LogFile> log_;
   const ::lcm::LogEvent* next_event_{nullptr};
 };

--- a/lcm/drake_lcm_message_handler_interface.h
+++ b/lcm/drake_lcm_message_handler_interface.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_deprecated.h"
 
 namespace drake {
 namespace lcm {
@@ -14,9 +15,14 @@ namespace lcm {
  *
  * @see DrakeLcmInterface::Subscribe().
  */
-class DrakeLcmMessageHandlerInterface {
+class
+DRAKE_DEPRECATED("Use the std::function subscription in DrakeLcmInterface instead")  // NOLINT
+DrakeLcmMessageHandlerInterface {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrakeLcmMessageHandlerInterface)
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
   DrakeLcmMessageHandlerInterface() = default;
   virtual ~DrakeLcmMessageHandlerInterface() = default;
 

--- a/lcm/drake_mock_lcm.h
+++ b/lcm/drake_mock_lcm.h
@@ -94,13 +94,13 @@ class DrakeMockLcm : public DrakeLcmInterface {
    */
   optional<double> get_last_publication_time(const std::string& channel) const;
 
-  /**
-   * Creates a subscription. Only one subscription per channel name is
-   * permitted. A std::runtime_error is thrown if more than one subscription to
-   * the same channel name is attempted.
-   */
-  void Subscribe(const std::string& channel,
-                 DrakeLcmMessageHandlerInterface* handler) override;
+  void Subscribe(const std::string&, HandlerFunction) override;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  void Subscribe(const std::string&,
+                 DrakeLcmMessageHandlerInterface*) override;
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
   /**
    * Fakes a callback. The callback is executed by the same thread as the one
@@ -127,7 +127,7 @@ class DrakeMockLcm : public DrakeLcmInterface {
   std::map<std::string, LastPublishedMessage> last_published_messages_;
 
   // Maps the channel name to the subscriber.
-  std::map<std::string, DrakeLcmMessageHandlerInterface*> subscriptions_;
+  std::multimap<std::string, HandlerFunction> subscriptions_;
 };
 
 }  // namespace lcm

--- a/lcm/test/drake_lcm_log_test.cc
+++ b/lcm/test/drake_lcm_log_test.cc
@@ -11,6 +11,12 @@ namespace drake {
 namespace lcm {
 namespace {
 
+// TODO(jwnimmer-tri) When the DrakeLcmMessageHandlerInterface class is
+// deleted, refactor this test to use the HandlerFunction interface.  For now,
+// since the DrakeLcmInterface code delegates to the HandlerFunction code, we
+// keep this all as-is so that all codepaths are covered by tests.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 template <typename MsgType>
 class TestHandler : public DrakeLcmMessageHandlerInterface {
  public:
@@ -30,6 +36,7 @@ class TestHandler : public DrakeLcmMessageHandlerInterface {
   const std::string name_;
   MsgType msg_{};
 };
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 // Generates a log file using the write-only interface, then plays it back
 // and check message content with a subscriber.

--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -132,6 +132,12 @@ TEST_F(DrakeLcmTest, PublishTest) {
   EXPECT_FALSE(dut.IsReceiveThreadRunning());
 }
 
+// TODO(jwnimmer-tri) When the DrakeLcmMessageHandlerInterface class is
+// deleted, refactor this test to use the HandlerFunction interface.  For now,
+// since the DrakeLcmInterface code delegates to the HandlerFunction code, we
+// keep this all as-is so that all codepaths are covered by tests.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Handles received LCM messages.
 class MessageHandler : public DrakeLcmMessageHandlerInterface {
  public:
@@ -175,6 +181,7 @@ class MessageHandler : public DrakeLcmMessageHandlerInterface {
   std::mutex message_mutex_;
   drake::lcmt_drake_signal received_message_;
 };
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 // Tests DrakeLcm's ability to subscribe to an LCM message.
 TEST_F(DrakeLcmTest, SubscribeTest) {

--- a/lcm/test/drake_mock_lcm_test.cc
+++ b/lcm/test/drake_mock_lcm_test.cc
@@ -84,6 +84,12 @@ GTEST_TEST(DrakeMockLcmTest, DecodeLastPublishedMessageAsTest) {
       channel_name), std::runtime_error);
 }
 
+// TODO(jwnimmer-tri) When the DrakeLcmMessageHandlerInterface class is
+// deleted, refactor this test to use the HandlerFunction interface.  For now,
+// since the DrakeLcmInterface code delegates to the HandlerFunction code, we
+// keep this all as-is so that all codepaths are covered by tests.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // Handles received LCM messages.
 class MockMessageHandler : public DrakeLcmMessageHandlerInterface {
  public:
@@ -115,6 +121,7 @@ class MockMessageHandler : public DrakeLcmMessageHandlerInterface {
   string channel_{};
   vector<uint8_t> buffer_;
 };
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
 
 // Tests DrakeMockLcm's ability to "subscribe" to an LCM channel.
 GTEST_TEST(DrakeMockLcmTest, SubscribeTest) {

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -43,8 +43,7 @@ namespace lcm {
  *
  * @ingroup message_passing
  */
-class LcmSubscriberSystem : public LeafSystem<double>,
-                            public drake::lcm::DrakeLcmMessageHandlerInterface {
+class LcmSubscriberSystem : public LeafSystem<double> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmSubscriberSystem)
 
@@ -208,10 +207,8 @@ class LcmSubscriberSystem : public LeafSystem<double>,
   void ProcessMessageAndStoreToAbstractState(
       AbstractValues* abstract_state) const;
 
-  // Callback entry point from LCM into this class. Also wakes up one thread
-  // block on notification_ if it's not nullptr.
-  void HandleMessage(const std::string& channel, const void* message_buffer,
-                     int message_size) override;
+  // Callback entry point from LCM into this class.
+  void HandleMessage(const void*, int);
 
   // This pair of methods is used for the output port when we're using a
   // translator.


### PR DESCRIPTION
This allows clients a wider variety of options for how to be called back when subscribing, and paves the way for adding sugar for various kinds of callbacks.

Relates #8256.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8460)
<!-- Reviewable:end -->
