### PR TITLE
Don't re-lint the add_test_rule test binary

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -443,6 +443,7 @@ def drake_cc_binary(
             flaky = test_rule_flaky,
             linkstatic = linkstatic,
             args = test_rule_args,
+            tags = kwargs.pop("tags", []) + ["nolint"],
             **kwargs)
 
 def drake_cc_test(


### PR DESCRIPTION
The original cc_binary will handle the linting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8461)
<!-- Reviewable:end -->
