### PR TITLE
Cosmetic changes from caching branch

### DIFF
--- a/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
@@ -86,11 +86,11 @@ TEST_F(SpringMassSystemTest, EvalTimeDerivatives) {
   ASSERT_EQ(2, derivatives->get_misc_continuous_state().size());
 
   // The derivatives of plant.
-  const ContinuousState<double>* plant_xcdot =
+  const ContinuousState<double>& plant_xcdot =
       model_->GetSubsystemDerivatives(*derivatives, &model_->get_plant());
 
   // Position derivative.
-  EXPECT_EQ(v0, plant_xcdot->get_vector().GetAtIndex(0));
+  EXPECT_EQ(v0, plant_xcdot.get_vector().GetAtIndex(0));
 
   // Acceleration.
   const double error = x0 - kTargetPosition;
@@ -98,11 +98,11 @@ TEST_F(SpringMassSystemTest, EvalTimeDerivatives) {
   const double pid_actuation =
       kProportionalConstant * error +  kDerivativeConstant * error_rate;
   EXPECT_EQ((-kSpring * x0 - pid_actuation) / kMass,
-            plant_xcdot->get_vector().GetAtIndex(1));
+            plant_xcdot.get_vector().GetAtIndex(1));
 
   // Power.
   EXPECT_EQ(model_->get_plant().EvalConservativePower(*plant_context_),
-            plant_xcdot->get_vector().GetAtIndex(2));
+            plant_xcdot.get_vector().GetAtIndex(2));
 }
 
 TEST_F(SpringMassSystemTest, DirectFeedthrough) {

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -106,7 +106,7 @@ class DiagramOutputPort : public OutputPort<T> {
   }
 
   const OutputPort<T>* const source_output_port_;
-  const int subsystem_index_;
+  const SubsystemIndex subsystem_index_;
 };
 
 //==============================================================================
@@ -234,7 +234,8 @@ class Diagram : public System<T>,
   // Diagram objects are neither copyable nor moveable.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Diagram)
 
-  typedef typename std::pair<const System<T>*, int> PortIdentifier;
+  using InputPortLocator = std::pair<const System<T>*, InputPortIndex>;
+  using OutputPortLocator = std::pair<const System<T>*, OutputPortIndex>;
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
@@ -255,8 +256,8 @@ class Diagram : public System<T>,
 
   std::multimap<int, int> GetDirectFeedthroughs() const final {
     std::multimap<int, int> pairs;
-    for (int u = 0; u < this->get_num_input_ports(); ++u) {
-      for (int v = 0; v < this->get_num_output_ports(); ++v) {
+    for (InputPortIndex u(0); u < this->get_num_input_ports(); ++u) {
+      for (OutputPortIndex v(0); v < this->get_num_output_ports(); ++v) {
         if (DoHasDirectFeedthrough(u, v)) {
           pairs.emplace(u, v);
         }
@@ -272,7 +273,7 @@ class Diagram : public System<T>,
     const int num_systems = num_subsystems();
     std::vector<std::unique_ptr<CompositeEventCollection<T>>> subevents(
         num_systems);
-    for (int i = 0; i < num_systems; ++i) {
+    for (SubsystemIndex i(0); i < num_systems; ++i) {
       subevents[i] = registered_systems_[i]->AllocateCompositeEventCollection();
     }
 
@@ -286,7 +287,7 @@ class Diagram : public System<T>,
     auto context = std::make_unique<DiagramContext<T>>(num_systems);
 
     // Add each constituent system to the Context.
-    for (int i = 0; i < num_systems; ++i) {
+    for (SubsystemIndex i(0); i < num_systems; ++i) {
       const System<T>* const sys = registered_systems_[i].get();
       auto subcontext = sys->AllocateContext();
       auto suboutput = sys->AllocateOutput(*subcontext);
@@ -294,15 +295,15 @@ class Diagram : public System<T>,
     }
 
     // Wire up the Diagram-internal inputs and outputs.
-    for (const auto& connection : dependency_graph_) {
-      const PortIdentifier& src = connection.second;
-      const PortIdentifier& dest = connection.first;
+    for (const auto& connection : connection_map_) {
+      const OutputPortLocator& src = connection.second;
+      const InputPortLocator& dest = connection.first;
       context->Connect(ConvertToContextPortIdentifier(src),
                        ConvertToContextPortIdentifier(dest));
     }
 
     // Declare the Diagram-external inputs.
-    for (const PortIdentifier& id : input_port_ids_) {
+    for (const InputPortLocator& id : input_port_ids_) {
       context->ExportInput(ConvertToContextPortIdentifier(id));
     }
 
@@ -320,7 +321,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(diagram_state != nullptr);
 
     // Set default state of each constituent system.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
       auto& substate = diagram_state->get_mutable_substate(i);
       registered_systems_[i]->SetDefaultState(subcontext, &substate);
@@ -336,7 +337,7 @@ class Diagram : public System<T>,
     int abstract_parameter_offset = 0;
 
     // Set default parameters of each constituent system.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
 
       if (!subcontext.num_numeric_parameters() &&
@@ -385,7 +386,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(diagram_state != nullptr);
 
     // Set state of each constituent system.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
       auto& substate = diagram_state->get_mutable_substate(i);
       registered_systems_[i]->SetRandomState(subcontext, &substate, generator);
@@ -401,7 +402,7 @@ class Diagram : public System<T>,
     int abstract_parameter_offset = 0;
 
     // Set parameters of each constituent system.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       auto& subcontext = diagram_context->GetSubsystemContext(i);
 
       if (!subcontext.num_numeric_parameters() &&
@@ -510,7 +511,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(num_subsystems() == n);
 
     // Evaluate the derivatives of each constituent system.
-    for (int i = 0; i < n; ++i) {
+    for (SubsystemIndex i(0); i < n; ++i) {
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       ContinuousState<T>& subderivatives =
           diagram_derivatives->get_mutable_substate(i);
@@ -520,16 +521,16 @@ class Diagram : public System<T>,
 
   /// Retrieves the state derivatives for a particular subsystem from the
   /// derivatives for the entire diagram. Aborts if @p subsystem is not
-  /// actually a subsystem of this diagram. Returns nullptr if @p subsystem
-  /// is stateless.
-  const ContinuousState<T>* GetSubsystemDerivatives(
+  /// actually a subsystem of this diagram. Returns a 0-length ContinuousState
+  /// if @p subsystem has none.
+  const ContinuousState<T>& GetSubsystemDerivatives(
       const ContinuousState<T>& derivatives, const System<T>* subsystem) const {
     DRAKE_DEMAND(subsystem != nullptr);
     auto diagram_derivatives =
         dynamic_cast<const DiagramContinuousState<T>*>(&derivatives);
     DRAKE_DEMAND(diagram_derivatives != nullptr);
-    const int i = GetSystemIndexOrAbort(subsystem);
-    return &diagram_derivatives->get_substate(i);
+    const SubsystemIndex i = GetSystemIndexOrAbort(subsystem);
+    return diagram_derivatives->get_substate(i);
   }
 
   /// Returns a constant reference to the subcontext that corresponds to the
@@ -666,10 +667,10 @@ class Diagram : public System<T>,
       subsystem->GetGraphvizFragment(dot);
     }
     // -- Add the connections as edges.
-    for (const auto& edge : dependency_graph_) {
-      const PortIdentifier& src = edge.second;
+    for (const auto& edge : connection_map_) {
+      const OutputPortLocator& src = edge.second;
       const System<T>* src_sys = src.first;
-      const PortIdentifier& dest = edge.first;
+      const InputPortLocator& dest = edge.first;
       const System<T>* dest_sys = dest.first;
       src_sys->GetGraphvizOutputPortToken(src_sys->get_output_port(src.second),
                                           dot);
@@ -730,7 +731,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(context != nullptr);
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(context);
     DRAKE_DEMAND(diagram_context != nullptr);
-    const PortIdentifier id{descriptor.get_system(), descriptor.get_index()};
+    const InputPortLocator id{descriptor.get_system(), descriptor.get_index()};
 
     // Find if this input port is exported.
     const auto external_it =
@@ -738,8 +739,8 @@ class Diagram : public System<T>,
     const bool is_exported = (external_it != input_port_ids_.end());
 
     // Find if this input port is connected to an output port.
-    const auto upstream_it = dependency_graph_.find(id);
-    const bool is_connected = (upstream_it != dependency_graph_.end());
+    const auto upstream_it = connection_map_.find(id);
+    const bool is_connected = (upstream_it != connection_map_.end());
 
     DRAKE_DEMAND(is_exported ^ is_connected);
 
@@ -752,14 +753,14 @@ class Diagram : public System<T>,
       // The upstream output port exists in this Diagram; evaluate it.
       // TODO(david-german-tri): Add online algebraic loop detection here.
       DRAKE_ASSERT(is_connected);
-      const PortIdentifier& prerequisite = upstream_it->second;
+      const OutputPortLocator& prerequisite = upstream_it->second;
       this->EvaluateOutputPort(*diagram_context, prerequisite);
     }
   }
 
   /// Returns the index of the given @p sys in this diagram, or aborts if @p sys
   /// is not a member of the diagram.
-  int GetSystemIndexOrAbort(const System<T>* sys) const {
+  SubsystemIndex GetSystemIndexOrAbort(const System<T>* sys) const {
     auto it = system_index_map_.find(sys);
     DRAKE_DEMAND(it != system_index_map_.end());
     return it->second;
@@ -850,7 +851,7 @@ class Diagram : public System<T>,
     auto diagram_context = dynamic_cast<const DiagramContext<T>*>(&context);
     DRAKE_DEMAND(diagram_context != nullptr);
 
-    int index = 0;  // The subsystem index.
+    SubsystemIndex index(0);
 
     for (const auto& system : registered_systems_) {
       DRAKE_ASSERT(index == GetSystemIndexOrAbort(system.get()));
@@ -985,7 +986,7 @@ class Diagram : public System<T>,
     // concatenated in order.
     int v_index = 0;  // The next index to read in generalized_velocity.
     int q_index = 0;  // The next index to write in qdot.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       // Find the continuous state of subsystem i.
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       const ContinuousState<T>& sub_xc = subcontext.get_continuous_state();
@@ -1032,7 +1033,7 @@ class Diagram : public System<T>,
     // concatenated in order.
     int q_index = 0;  // The next index to read in qdot.
     int v_index = 0;  // The next index to write in generalized_velocity.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       // Find the continuous state of subsystem i.
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       const ContinuousState<T>& sub_xc = subcontext.get_continuous_state();
@@ -1067,9 +1068,9 @@ class Diagram : public System<T>,
   BasicVector<T>* DoAllocateInputVector(
       const InputPortDescriptor<T>& descriptor) const override {
     // Ask the subsystem to perform the allocation.
-    const PortIdentifier& id = input_port_ids_[descriptor.get_index()];
+    const InputPortLocator& id = input_port_ids_[descriptor.get_index()];
     const System<T>* subsystem = id.first;
-    const int subindex = id.second;
+    const InputPortIndex subindex = id.second;
     return subsystem->AllocateInputVector(subsystem->get_input_port(subindex))
         .release();
   }
@@ -1077,9 +1078,9 @@ class Diagram : public System<T>,
   AbstractValue* DoAllocateInputAbstract(
       const InputPortDescriptor<T>& descriptor) const override {
     // Ask the subsystem to perform the allocation.
-    const PortIdentifier& id = input_port_ids_[descriptor.get_index()];
+    const InputPortLocator& id = input_port_ids_[descriptor.get_index()];
     const System<T>* subsystem = id.first;
-    const int subindex = id.second;
+    const InputPortIndex subindex = id.second;
     return subsystem->AllocateInputAbstract(subsystem->get_input_port(subindex))
         .release();
   }
@@ -1093,21 +1094,21 @@ class Diagram : public System<T>,
     DRAKE_ASSERT(output_port >= 0);
     DRAKE_ASSERT(output_port < this->get_num_output_ports());
 
-    const PortIdentifier& target_input_id = input_port_ids_[input_port];
+    const InputPortLocator& target_input_id = input_port_ids_[input_port];
 
     // Search the graph for a direct-feedthrough connection from the output_port
     // back to the input_port. Maintain a set of the output port identifiers
     // that are known to have a direct-feedthrough path to the output_port.
-    std::set<PortIdentifier> active_set;
+    std::set<OutputPortLocator> active_set;
     active_set.insert(output_port_ids_[output_port]);
     while (!active_set.empty()) {
-      const PortIdentifier current_output_id = *active_set.begin();
+      const OutputPortLocator current_output_id = *active_set.begin();
       size_t removed_count = active_set.erase(current_output_id);
       DRAKE_ASSERT(removed_count == 1);
       const System<T>* sys = current_output_id.first;
-      for (int i = 0; i < sys->get_num_input_ports(); ++i) {
+      for (InputPortIndex i(0); i < sys->get_num_input_ports(); ++i) {
         if (sys->HasDirectFeedthrough(i, current_output_id.second)) {
-          const PortIdentifier curr_input_id(sys, i);
+          const InputPortLocator curr_input_id(sys, i);
           if (curr_input_id == target_input_id) {
             // We've found a direct-feedthrough path to the input_port.
             return true;
@@ -1115,9 +1116,9 @@ class Diagram : public System<T>,
             // We've found an intermediate input port has a direct-feedthrough
             // path to the output_port. Add the upstream output port (if there
             // is one) to the active set.
-            auto it = dependency_graph_.find(curr_input_id);
-            if (it != dependency_graph_.end()) {
-              const PortIdentifier& upstream_output = it->second;
+            auto it = connection_map_.find(curr_input_id);
+            if (it != connection_map_.end()) {
+              const OutputPortLocator& upstream_output = it->second;
               active_set.insert(upstream_output);
             }
           }
@@ -1137,7 +1138,7 @@ class Diagram : public System<T>,
   allocater_func) const {
     const int num_systems = num_subsystems();
     auto ret = std::make_unique<DiagramEventCollection<EventType>>(num_systems);
-    for (int i = 0; i < num_systems; ++i) {
+    for (SubsystemIndex i(0); i < num_systems; ++i) {
       std::unique_ptr<EventCollection<EventType>> subevent_collection =
           allocater_func(registered_systems_[i].get());
       ret->set_and_own_subevent_collection(i, std::move(subevent_collection));
@@ -1157,7 +1158,7 @@ class Diagram : public System<T>,
         dynamic_cast<const DiagramEventCollection<PublishEvent<T>>&>(
             event_info);
 
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const EventCollection<PublishEvent<T>>& subinfo =
           info.get_subevent_collection(i);
 
@@ -1194,7 +1195,7 @@ class Diagram : public System<T>,
         dynamic_cast<const DiagramEventCollection<DiscreteUpdateEvent<T>>&>(
             event_info);
 
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const EventCollection<DiscreteUpdateEvent<T>>& subinfo =
           info.get_subevent_collection(i);
 
@@ -1229,7 +1230,7 @@ class Diagram : public System<T>,
         dynamic_cast<const DiagramEventCollection<UnrestrictedUpdateEvent<T>>&>(
             event_info);
 
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const EventCollection<UnrestrictedUpdateEvent<T>>& subinfo =
           info.get_subevent_collection(i);
 
@@ -1243,32 +1244,33 @@ class Diagram : public System<T>,
     }
   }
 
-  /// Tries to recursively find @p target_system's BaseStuff
-  /// (context / state / etc). nullptr is returned if @p target_system is not
-  /// a subsystem of this diagram. This template function should only be used
-  /// to reduce code repetition for DoGetMutableTargetSystemContext(),
-  /// DoGetTargetSystemContext(), DoGetMutableTargetSystemState(), and
-  /// DoGetTargetSystemState().
-  /// @param target_system The sub system of interest.
-  /// @param my_stuff BaseStuff that's associated with this diagram.
-  /// @param recursive_getter A member function of System that returns sub
-  /// context or state. Should be one of the four functions listed above.
-  /// @param get_child_stuff A member function of DiagramContext or DiagramState
-  /// that returns context or state given the index of the subsystem.
-  ///
-  /// @tparam BaseStuff Can be Context<T>, const Context<T>, State<T> and
-  /// const State<T>.
-  /// @tparam DerivedStuff Can be DiagramContext<T>,
-  /// const DiagramContext<T>, DiagramState<T> and const DiagramState<T>.
-  ///
-  /// @pre @p target_system cannot be `this`. The caller should check for this
-  /// edge case.
+  // Tries to recursively find @p target_system's BaseStuff
+  // (context / state / etc). nullptr is returned if @p target_system is not
+  // a subsystem of this diagram. This template function should only be used
+  // to reduce code repetition for DoGetMutableTargetSystemContext(),
+  // DoGetTargetSystemContext(), DoGetMutableTargetSystemState(), and
+  // DoGetTargetSystemState().
+  // @param target_system The subsystem of interest.
+  // @param my_stuff BaseStuff that's associated with this diagram.
+  // @param recursive_getter A member function of System that returns sub
+  // context or state. Should be one of the four functions listed above.
+  // @param get_child_stuff A member function of DiagramContext or DiagramState
+  // that returns context or state given the index of the subsystem.
+  //
+  // @tparam BaseStuff Can be Context<T>, const Context<T>, State<T> and
+  // const State<T>.
+  // @tparam DerivedStuff Can be DiagramContext<T>,
+  // const DiagramContext<T>, DiagramState<T> and const DiagramState<T>.
+  //
+  // @pre @p target_system cannot be `this`. The caller should check for this
+  // edge case.
   template <typename BaseStuff, typename DerivedStuff>
   BaseStuff* GetSubsystemStuff(
       const System<T>& target_system, BaseStuff* my_stuff,
       std::function<BaseStuff* (const System<T>*, const System<T>&, BaseStuff*)>
           recursive_getter,
-      std::function<BaseStuff& (DerivedStuff*, int)> get_child_stuff) const {
+      std::function<BaseStuff&(DerivedStuff*, SubsystemIndex)> get_child_stuff)
+      const {
     static_assert(
         std::is_same<BaseStuff,
                      typename std::remove_pointer<BaseStuff>::type>::value,
@@ -1282,10 +1284,9 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(&target_system != this);
     DerivedStuff& my_stuff_as_derived = dynamic_cast<DerivedStuff&>(*my_stuff);
 
-    int index = 0;
+    SubsystemIndex index(0);
     for (const auto& child : registered_systems_) {
-      BaseStuff& child_stuff =
-          get_child_stuff(&my_stuff_as_derived, index);
+      BaseStuff& child_stuff = get_child_stuff(&my_stuff_as_derived, index);
 
       BaseStuff* const target_stuff =
           recursive_getter(child.get(), target_system, &child_stuff);
@@ -1293,16 +1294,16 @@ class Diagram : public System<T>,
       if (target_stuff != nullptr) {
         return target_stuff;
       }
-      index++;
+      ++index;
     }
 
     return nullptr;
   }
 
-  /// Uses this Diagram<T> to manufacture a Diagram<NewType>::Blueprint,
-  /// using system scalar conversion.
-  ///
-  /// @tparam NewType The scalar type to which to convert.
+  // Uses this Diagram<T> to manufacture a Diagram<NewType>::Blueprint,
+  // using system scalar conversion.
+  //
+  // @tparam NewType The scalar type to which to convert.
   template <typename NewType>
   std::unique_ptr<typename Diagram<NewType>::Blueprint> ConvertScalarType()
       const {
@@ -1324,31 +1325,31 @@ class Diagram : public System<T>,
     // Set up the blueprint.
     auto blueprint = std::make_unique<typename Diagram<NewType>::Blueprint>();
     // Make all the inputs and outputs.
-    for (const PortIdentifier& id : input_port_ids_) {
+    for (const InputPortLocator& id : input_port_ids_) {
       const System<NewType>* new_system = old_to_new_map[id.first];
-      const int port = id.second;
+      const InputPortIndex port = id.second;
       blueprint->input_port_ids.emplace_back(new_system, port);
     }
-    for (const PortIdentifier& id : output_port_ids_) {
+    for (const OutputPortLocator& id : output_port_ids_) {
       const System<NewType>* new_system = old_to_new_map[id.first];
-      const int port = id.second;
+      const OutputPortIndex port = id.second;
       blueprint->output_port_ids.emplace_back(new_system, port);
     }
     // Make all the connections.
-    for (const auto& edge : dependency_graph_) {
-      const PortIdentifier& old_dest = edge.first;
+    for (const auto& edge : connection_map_) {
+      const InputPortLocator& old_dest = edge.first;
       const System<NewType>* const dest_system = old_to_new_map[old_dest.first];
-      const int dest_port = old_dest.second;
-      const typename Diagram<NewType>::PortIdentifier new_dest{dest_system,
-                                                               dest_port};
+      const InputPortIndex dest_port = old_dest.second;
+      const typename Diagram<NewType>::InputPortLocator new_dest{dest_system,
+                                                                 dest_port};
 
-      const PortIdentifier& old_src = edge.second;
+      const OutputPortLocator& old_src = edge.second;
       const System<NewType>* const src_system = old_to_new_map[old_src.first];
-      const int src_port = old_src.second;
-      const typename Diagram<NewType>::PortIdentifier new_src{src_system,
-                                                              src_port};
+      const OutputPortIndex src_port = old_src.second;
+      const typename Diagram<NewType>::OutputPortLocator new_src{src_system,
+                                                                 src_port};
 
-      blueprint->dependency_graph[new_dest] = new_src;
+      blueprint->connection_map[new_dest] = new_src;
     }
     // Move the new systems into the blueprint.
     blueprint->systems = std::move(new_systems);
@@ -1386,7 +1387,7 @@ class Diagram : public System<T>,
 
     // Iterate over the subsystems, and harvest the most imminent updates.
     std::vector<T1> times(num_subsystems());
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const Context<T1>& subcontext = diagram_context->GetSubsystemContext(i);
       CompositeEventCollection<T1>& subinfo =
           info->get_mutable_subevent_collection(i);
@@ -1401,7 +1402,7 @@ class Diagram : public System<T>,
 
     // For all the subsystems whose next update time is bigger than *time,
     // clear their event collections.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       if (times[i] > *time)
         info->get_mutable_subevent_collection(i).Clear();
     }
@@ -1433,7 +1434,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(diagram_context != nullptr);
     DRAKE_DEMAND(info != nullptr);
 
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       CompositeEventCollection<T>& subinfo =
           info->get_mutable_subevent_collection(i);
@@ -1450,7 +1451,7 @@ class Diagram : public System<T>,
     DRAKE_DEMAND(diagram_context != nullptr);
     DRAKE_DEMAND(info != nullptr);
 
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const Context<T>& subcontext = diagram_context->GetSubsystemContext(i);
       CompositeEventCollection<T>& subinfo =
           info->get_mutable_subevent_collection(i);
@@ -1462,13 +1463,13 @@ class Diagram : public System<T>,
   // A structural outline of a Diagram, produced by DiagramBuilder.
   struct Blueprint {
     // The ordered subsystem ports that are inputs to the entire diagram.
-    std::vector<PortIdentifier> input_port_ids;
+    std::vector<InputPortLocator> input_port_ids;
     // The ordered subsystem ports that are outputs of the entire diagram.
-    std::vector<PortIdentifier> output_port_ids;
+    std::vector<OutputPortLocator> output_port_ids;
     // A map from the input ports of constituent systems to the output ports
     // on which they depend. This graph is possibly cyclic, but must not
     // contain an algebraic loop.
-    std::map<PortIdentifier, PortIdentifier> dependency_graph;
+    std::map<InputPortLocator, OutputPortLocator> connection_map;
     // All of the systems to be included in the diagram.
     std::vector<std::unique_ptr<System<T>>> systems;
   };
@@ -1487,22 +1488,22 @@ class Diagram : public System<T>,
     // We must not already own any subsystems.
     DRAKE_DEMAND(registered_systems_.empty());
 
-    // Copy the data from the blueprint into private member variables.
-    dependency_graph_ = std::move(blueprint->dependency_graph);
+    // Move the data from the blueprint into private member variables.
+    connection_map_ = std::move(blueprint->connection_map);
     input_port_ids_ = std::move(blueprint->input_port_ids);
     output_port_ids_ = std::move(blueprint->output_port_ids);
     registered_systems_ = std::move(blueprint->systems);
 
     // Generate a map from the System pointer to its index in the registered
     // order.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       system_index_map_[registered_systems_[i].get()] = i;
       registered_systems_[i]->set_parent(this);
     }
 
     // Generate constraints for the diagram from the constraints on the
     // subsystems.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subsystems(); ++i) {
       const auto sys = registered_systems_[i].get();
       for (SystemConstraintIndex j(0); j < sys->get_num_constraints(); ++j) {
         const auto c = &(sys->get_constraint(j));
@@ -1518,16 +1519,16 @@ class Diagram : public System<T>,
 
     // Every system must appear exactly once.
     DRAKE_DEMAND(registered_systems_.size() == system_index_map_.size());
-    // Every port named in the dependency_graph_ must actually exist.
+    // Every port named in the connection_map_ must actually exist.
     DRAKE_ASSERT(PortsAreValid());
     // Every subsystem must have a unique name.
     DRAKE_THROW_UNLESS(NamesAreUniqueAndNonEmpty());
 
     // Add the inputs to the Diagram topology, and check their invariants.
-    for (const PortIdentifier& id : input_port_ids_) {
+    for (const InputPortLocator& id : input_port_ids_) {
       ExportInput(id);
     }
-    for (const PortIdentifier& id : output_port_ids_) {
+    for (const OutputPortLocator& id : output_port_ids_) {
       ExportOutput(id);
     }
 
@@ -1552,7 +1553,7 @@ class Diagram : public System<T>,
   }
 
   // Exposes the given port as an input of the Diagram.
-  void ExportInput(const PortIdentifier& port) {
+  void ExportInput(const InputPortLocator& port) {
     const System<T>* const sys = port.first;
     const int port_index = port.second;
     // Fail quickly if this system is not part of the diagram.
@@ -1566,7 +1567,7 @@ class Diagram : public System<T>,
   }
 
   // Exposes the given subsystem output port as an output of the Diagram.
-  void ExportOutput(const PortIdentifier& port) {
+  void ExportOutput(const OutputPortLocator& port) {
     const System<T>* const sys = port.first;
     const int port_index = port.second;
     const auto& source_output_port = sys->get_output_port(port_index);
@@ -1585,11 +1586,11 @@ class Diagram : public System<T>,
   // output ports the Diagram exposes, and N is the number of intermediate
   // output ports the Diagram contains.
   void EvaluateOutputPort(const DiagramContext<T>& context,
-                          const PortIdentifier& id) const {
+                          const OutputPortLocator& id) const {
     const System<T>* const system = id.first;
     const OutputPortIndex port_index(id.second);
     const OutputPort<T>& port = system->get_output_port(port_index);
-    const int i = GetSystemIndexOrAbort(system);
+    const SubsystemIndex i = GetSystemIndexOrAbort(system);
     SPDLOG_TRACE(log(), "Evaluating output for subsystem {}, port {}",
                  system->GetPath(), port_index);
     const Context<T>& subsystem_context = context.GetSubsystemContext(i);
@@ -1598,15 +1599,27 @@ class Diagram : public System<T>,
     port.Calc(subsystem_context, port_output);
   }
 
-  // Converts a PortIdentifier to a DiagramContext::PortIdentifier.
-  // The DiagramContext::PortIdentifier contains the index of the System in the
+  // Converts an InputPortLocator to a DiagramContext::InputPortIdentifier.
+  // The DiagramContext::InputPortIdentifier contains the index of the System in
   // the diagram, instead of an actual pointer to the System.
-  typename DiagramContext<T>::PortIdentifier ConvertToContextPortIdentifier(
-      const PortIdentifier& id) const {
-    typename DiagramContext<T>::PortIdentifier output;
-    output.first = GetSystemIndexOrAbort(id.first);
-    output.second = id.second;
-    return output;
+  // TODO(sherm1) Should just use the (SystemIndex,PortIndex) form everywhere.
+  typename DiagramContext<T>::InputPortIdentifier
+  ConvertToContextPortIdentifier(const InputPortLocator& locator) const {
+    typename DiagramContext<T>::InputPortIdentifier identifier;
+    identifier.first = GetSystemIndexOrAbort(locator.first);
+    identifier.second = locator.second;
+    return identifier;
+  }
+
+  // Converts an OutputPortLocator to a DiagramContext::OutputPortIdentifier.
+  // The DiagramContext::OutputPortIdentifier contains the index of the System
+  // in the diagram, instead of an actual pointer to the System.
+  typename DiagramContext<T>::OutputPortIdentifier
+  ConvertToContextPortIdentifier(const OutputPortLocator& locator) const {
+    typename DiagramContext<T>::OutputPortIdentifier identifier;
+    identifier.first = GetSystemIndexOrAbort(locator.first);
+    identifier.second = locator.second;
+    return identifier;
   }
 
   // Sets up the OutputPortValue pointers in @p output to point to the subsystem
@@ -1618,12 +1631,12 @@ class Diagram : public System<T>,
     const int num_ports = static_cast<int>(output_port_ids_.size());
     DRAKE_DEMAND(output->get_num_ports() == num_ports);
 
-    for (int i = 0; i < num_ports; ++i) {
-      const PortIdentifier& id = output_port_ids_[i];
+    for (OutputPortIndex i(0); i < num_ports; ++i) {
+      const OutputPortLocator& id = output_port_ids_[i];
       // For each configured output port ID, obtain from the DiagramContext the
       // actual OutputPortValue that supplies its value.
-      const int sys_index = GetSystemIndexOrAbort(id.first);
-      const int port_index = id.second;
+      const SubsystemIndex sys_index = GetSystemIndexOrAbort(id.first);
+      const OutputPortIndex port_index = id.second;
       SystemOutput<T>* subsystem_output = context.GetSubsystemOutput(sys_index);
       OutputPortValue* output_port_value =
           subsystem_output->get_mutable_port_value(port_index);
@@ -1633,11 +1646,11 @@ class Diagram : public System<T>,
     }
   }
 
-  // Returns true if every port mentioned in the dependency_graph_ exists.
+  // Returns true if every port mentioned in the connection map exists.
   bool PortsAreValid() const {
-    for (const auto& entry : dependency_graph_) {
-      const PortIdentifier& dest = entry.first;
-      const PortIdentifier& src = entry.second;
+    for (const auto& entry : connection_map_) {
+      const InputPortLocator& dest = entry.first;
+      const OutputPortLocator& src = entry.second;
       if (dest.second < 0 || dest.second >= dest.first->get_num_input_ports()) {
         return false;
       }
@@ -1677,19 +1690,20 @@ class Diagram : public System<T>,
   }
 
   // A map from the input ports of constituent systems, to the output ports of
-  // the systems on which they depend.
-  std::map<PortIdentifier, PortIdentifier> dependency_graph_;
+  // the systems from which they get their values.
+  std::map<InputPortLocator, OutputPortLocator> connection_map_;
 
   // The Systems in this Diagram, which are owned by this Diagram, in the order
-  // they were registered.
+  // they were registered. Index by SubsystemIndex.
   std::vector<std::unique_ptr<System<T>>> registered_systems_;
 
   // Map to quickly satisify "What is the subsytem index of the child system?"
-  std::map<const System<T>*, int> system_index_map_;
+  std::map<const System<T>*, SubsystemIndex> system_index_map_;
 
-  // The ordered inputs and outputs of this Diagram.
-  std::vector<PortIdentifier> input_port_ids_;
-  std::vector<PortIdentifier> output_port_ids_;
+  // The ordered inputs and outputs of this Diagram. Index by InputPortIndex
+  // and OutputPortIndex.
+  std::vector<InputPortLocator> input_port_ids_;
+  std::vector<OutputPortLocator> output_port_ids_;
 
   // For all T, Diagram<T> considers DiagramBuilder<T> a friend, so that the
   // builder can set the internal state correctly.

--- a/systems/framework/diagram_builder.h
+++ b/systems/framework/diagram_builder.h
@@ -128,12 +128,12 @@ class DiagramBuilder {
   void Connect(const OutputPort<T>& src,
                const InputPortDescriptor<T>& dest) {
     DRAKE_DEMAND(src.size() == dest.size());
-    PortIdentifier dest_id{dest.get_system(), dest.get_index()};
-    PortIdentifier src_id{&src.get_system(), src.get_index()};
+    InputPortLocator dest_id{dest.get_system(), dest.get_index()};
+    OutputPortLocator src_id{&src.get_system(), src.get_index()};
     ThrowIfInputAlreadyWired(dest_id);
     ThrowIfSystemNotRegistered(&src.get_system());
     ThrowIfSystemNotRegistered(dest.get_system());
-    dependency_graph_[dest_id] = src_id;
+    connection_map_[dest_id] = src_id;
   }
 
   /// Declares that sole input port on the @p dest system is connected to sole
@@ -159,11 +159,11 @@ class DiagramBuilder {
   /// Declares that the given @p input port of a constituent system is an input
   /// to the entire Diagram.
   /// @return The index of the exported input port of the entire diagram.
-  int ExportInput(const InputPortDescriptor<T>& input) {
-    PortIdentifier id{input.get_system(), input.get_index()};
+  InputPortIndex ExportInput(const InputPortDescriptor<T>& input) {
+    InputPortLocator id{input.get_system(), input.get_index()};
     ThrowIfInputAlreadyWired(id);
     ThrowIfSystemNotRegistered(input.get_system());
-    int return_id = static_cast<int>(input_port_ids_.size());
+    InputPortIndex return_id(input_port_ids_.size());
     input_port_ids_.push_back(id);
     diagram_input_set_.insert(id);
     return return_id;
@@ -172,11 +172,11 @@ class DiagramBuilder {
   /// Declares that the given @p output port of a constituent system is an
   /// output of the entire diagram.
   /// @return The index of the exported output port of the entire diagram.
-  int ExportOutput(const OutputPort<T>& output) {
+  OutputPortIndex ExportOutput(const OutputPort<T>& output) {
     ThrowIfSystemNotRegistered(&output.get_system());
-    int return_id = static_cast<int>(output_port_ids_.size());
+    OutputPortIndex return_id(output_port_ids_.size());
     output_port_ids_.push_back(
-        PortIdentifier{&output.get_system(), output.get_index()});
+        OutputPortLocator{&output.get_system(), output.get_index()});
     return return_id;
   }
 
@@ -199,10 +199,18 @@ class DiagramBuilder {
   }
 
  private:
-  typedef typename Diagram<T>::PortIdentifier PortIdentifier;
+  using InputPortLocator = typename Diagram<T>::InputPortLocator;
+  using OutputPortLocator = typename Diagram<T>::OutputPortLocator;
 
-  void ThrowIfInputAlreadyWired(const PortIdentifier& id) const {
-    if (dependency_graph_.find(id) != dependency_graph_.end() ||
+  // This generic port identifier is used only for cycle detection below
+  // because the algorithm treats both input & output ports as nodes.
+  using PortIdentifier = std::pair<const System<T>*, int>;
+
+  // Throws if the given input port (belonging to a child subsystem) has
+  // already been connected to an output port, or exported to be an input
+  // port of the whole diagram.
+  void ThrowIfInputAlreadyWired(const InputPortLocator& id) const {
+    if (connection_map_.find(id) != connection_map_.end() ||
         diagram_input_set_.find(id) != diagram_input_set_.end()) {
       throw std::logic_error("Input port is already wired.");
     }
@@ -278,11 +286,13 @@ class DiagramBuilder {
 
     // Populate the node set from the connections (and define the edges implied
     // by those connections).
-    for (const auto& connection : dependency_graph_) {
+    for (const auto& connection : connection_map_) {
       // Dependency graph is a mapping from the destination of the connection
       // to what it *depends on* (the source).
-      const PortIdentifier& src = connection.second;
-      const PortIdentifier& dest = connection.first;
+      const PortIdentifier src(connection.second.first,
+                               connection.second.second);
+      const PortIdentifier dest(connection.first.first,
+                                connection.first.second);
       PortIdentifier encoded_src{src.first, output_to_key(src.second)};
       nodes.insert(encoded_src);
       nodes.insert(dest);
@@ -349,22 +359,22 @@ class DiagramBuilder {
     auto blueprint = std::make_unique<typename Diagram<T>::Blueprint>();
     blueprint->input_port_ids = input_port_ids_;
     blueprint->output_port_ids = output_port_ids_;
-    blueprint->dependency_graph = dependency_graph_;
+    blueprint->connection_map = connection_map_;
     blueprint->systems = std::move(registered_systems_);
 
     return blueprint;
   }
 
   // The ordered inputs and outputs of the Diagram to be built.
-  std::vector<PortIdentifier> input_port_ids_;
-  std::vector<PortIdentifier> output_port_ids_;
+  std::vector<InputPortLocator> input_port_ids_;
+  std::vector<OutputPortLocator> output_port_ids_;
 
   // For fast membership queries: has this input port already been declared?
-  std::set<PortIdentifier> diagram_input_set_;
+  std::set<InputPortLocator> diagram_input_set_;
 
   // A map from the input ports of constituent systems, to the output ports of
-  // the systems on which they depend.
-  std::map<PortIdentifier, PortIdentifier> dependency_graph_;
+  // the systems from which they get their values.
+  std::map<InputPortLocator, OutputPortLocator> connection_map_;
 
   // A mirror on the systems in the diagram. Should have the same values as
   // registered_systems_. Used for fast membership queries.

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -119,24 +119,27 @@ class DiagramContext : public Context<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramContext)
 
-  typedef int SystemIndex;
-  typedef int PortIndex;
-  typedef std::pair<SystemIndex, PortIndex> PortIdentifier;
+  /// Identifies a child subsystem's input port.
+  using InputPortIdentifier = std::pair<SubsystemIndex, InputPortIndex>;
+  /// Identifies a child subsystem's output port.
+  using OutputPortIdentifier = std::pair<SubsystemIndex, OutputPortIndex>;
 
-  /// Constructs a DiagramContext with the given @p num_subsystems, which is
-  /// final: you cannot resize a DiagramContext after construction.
-  explicit DiagramContext(int num_subsystems)
-      : outputs_(num_subsystems), contexts_(num_subsystems),
-        state_(std::make_unique<DiagramState<T>>(num_subsystems)) {}
+  /// Constructs a DiagramContext with the given @p num_subcontexts, which is
+  /// final: you cannot resize a DiagramContext after construction. The
+  /// number and ordering of subcontexts is identical to the number and
+  /// ordering of subsystems in the corresponding Diagram.
+  explicit DiagramContext(int num_subcontexts)
+      : outputs_(num_subcontexts), contexts_(num_subcontexts),
+        state_(std::make_unique<DiagramState<T>>(num_subcontexts)) {}
 
   /// Declares a new subsystem in the DiagramContext. Subsystems are identified
   /// by number. If the subsystem has already been declared, aborts.
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void AddSystem(SystemIndex index, std::unique_ptr<Context<T>> context,
+  void AddSystem(SubsystemIndex index, std::unique_ptr<Context<T>> context,
                  std::unique_ptr<SystemOutput<T>> output) {
-    DRAKE_DEMAND(index >= 0 && index < num_subsystems());
+    DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(contexts_[index] == nullptr);
     DRAKE_DEMAND(outputs_[index] == nullptr);
     context->set_parent(this);
@@ -150,8 +153,8 @@ class DiagramContext : public Context<T> {
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void ExportInput(const PortIdentifier& id) {
-    const SystemIndex system_index = id.first;
+  void ExportInput(const InputPortIdentifier& id) {
+    const SubsystemIndex system_index = id.first;
     DRAKE_DEMAND(contexts_[system_index] != nullptr);
     input_ids_.emplace_back(id);
   }
@@ -161,10 +164,11 @@ class DiagramContext : public Context<T> {
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void Connect(const PortIdentifier& src, const PortIdentifier& dest) {
+  void Connect(const OutputPortIdentifier& src,
+               const InputPortIdentifier& dest) {
     // Identify and validate the source port.
-    SystemIndex src_system_index = src.first;
-    PortIndex src_port_index = src.second;
+    SubsystemIndex src_system_index = src.first;
+    OutputPortIndex src_port_index = src.second;
     SystemOutput<T>* src_ports = GetSubsystemOutput(src_system_index);
     DRAKE_DEMAND(src_port_index >= 0);
     DRAKE_DEMAND(src_port_index < src_ports->get_num_ports());
@@ -172,8 +176,8 @@ class DiagramContext : public Context<T> {
         src_ports->get_mutable_port_value(src_port_index);
 
     // Identify and validate the destination port.
-    SystemIndex dest_system_index = dest.first;
-    PortIndex dest_port_index = dest.second;
+    SubsystemIndex dest_system_index = dest.first;
+    InputPortIndex dest_port_index = dest.second;
     Context<T>& dest_context = GetMutableSubsystemContext(dest_system_index);
     DRAKE_DEMAND(dest_port_index >= 0);
     DRAKE_DEMAND(dest_port_index < dest_context.get_num_input_ports());
@@ -184,8 +188,8 @@ class DiagramContext : public Context<T> {
     Context<T>::SetInputPortValue(&dest_context, dest_port_index,
                                   std::move(input_port));
 
-    // Remember the graph structure. We need it in DoClone().
-    dependency_graph_[dest] = src;
+    // Remember the input/output port connectivity. We need it in DoClone().
+    connection_map_[dest] = src;
   }
 
   /// Generates the state vector for the entire diagram by wrapping the states
@@ -194,8 +198,8 @@ class DiagramContext : public Context<T> {
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
   void MakeState() {
-    auto state = std::make_unique<DiagramState<T>>(num_subsystems());
-    for (int i = 0; i < num_subsystems(); ++i) {
+    auto state = std::make_unique<DiagramState<T>>(num_subcontexts());
+    for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
       Context<T>* context = contexts_[i].get();
       state->set_substate(i, &context->get_mutable_state());
     }
@@ -233,8 +237,8 @@ class DiagramContext : public Context<T> {
   /// Returns the output structure for a given constituent system at @p index.
   /// Aborts if @p index is out of bounds, or if no system has been added to the
   /// DiagramContext at that index.
-  SystemOutput<T>* GetSubsystemOutput(SystemIndex index) const {
-    DRAKE_DEMAND(index >= 0 && index < num_subsystems());
+  SystemOutput<T>* GetSubsystemOutput(SubsystemIndex index) const {
+    DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(outputs_[index] != nullptr);
     return outputs_[index].get();
   }
@@ -243,8 +247,8 @@ class DiagramContext : public Context<T> {
   /// Aborts if @p index is out of bounds, or if no system has been added to the
   /// DiagramContext at that index.
   /// TODO(david-german-tri): Rename to get_subsystem_context.
-  const Context<T>& GetSubsystemContext(SystemIndex index) const {
-    DRAKE_DEMAND(index >= 0 && index < num_subsystems());
+  const Context<T>& GetSubsystemContext(SubsystemIndex index) const {
+    DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(contexts_[index] != nullptr);
     return *contexts_[index].get();
   }
@@ -253,8 +257,8 @@ class DiagramContext : public Context<T> {
   /// Aborts if @p index is out of bounds, or if no system has been added to the
   /// DiagramContext at that index.
   /// TODO(david-german-tri): Rename to get_mutable_subsystem_context.
-  Context<T>& GetMutableSubsystemContext(SystemIndex index) {
-    DRAKE_DEMAND(index >= 0 && index < num_subsystems());
+  Context<T>& GetMutableSubsystemContext(SubsystemIndex index) {
+    DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(contexts_[index] != nullptr);
     return *contexts_[index].get();
   }
@@ -295,10 +299,10 @@ class DiagramContext : public Context<T> {
   /// The caller owns the returned memory.
   DiagramContext<T>* DoClone() const override {
     DRAKE_ASSERT(contexts_.size() == outputs_.size());
-    DiagramContext<T>* clone = new DiagramContext(num_subsystems());
+    DiagramContext<T>* clone = new DiagramContext(num_subcontexts());
 
     // Clone all the subsystem contexts and outputs.
-    for (int i = 0; i < num_subsystems(); ++i) {
+    for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
       DRAKE_DEMAND(contexts_[i] != nullptr);
       DRAKE_DEMAND(outputs_[i] != nullptr);
       // When a leaf context is cloned, it will clone the data that currently
@@ -316,14 +320,14 @@ class DiagramContext : public Context<T> {
     // still have FreestandingInputPortValues at the inputs to the Diagram
     // itself, but all of the intermediate nodes will have
     // DependentInputPortValues.
-    for (const auto& connection : dependency_graph_) {
-      const PortIdentifier& src = connection.second;
-      const PortIdentifier& dest = connection.first;
+    for (const auto& connection : connection_map_) {
+      const OutputPortIdentifier& src = connection.second;
+      const InputPortIdentifier& dest = connection.first;
       clone->Connect(src, dest);
     }
 
     // Clone the external input structure.
-    for (const PortIdentifier& id : input_ids_) {
+    for (const InputPortIdentifier& id : input_ids_) {
       clone->ExportInput(id);
     }
 
@@ -336,9 +340,9 @@ class DiagramContext : public Context<T> {
 
   /// The caller owns the returned memory.
   State<T>* DoCloneState() const override {
-    DiagramState<T>* clone = new DiagramState<T>(num_subsystems());
+    DiagramState<T>* clone = new DiagramState<T>(num_subcontexts());
 
-    for (int i = 0; i < num_subsystems(); i++) {
+    for (SubsystemIndex i(0); i < num_subcontexts(); i++) {
       Context<T>* context = contexts_[i].get();
       clone->set_and_own_substate(i, context->CloneState());
     }
@@ -351,15 +355,15 @@ class DiagramContext : public Context<T> {
   /// to the subsystem whose input was exposed at that index.
   const InputPortValue* GetInputPortValue(int index) const override {
     DRAKE_ASSERT(index >= 0 && index < get_num_input_ports());
-    const PortIdentifier& id = input_ids_[index];
-    SystemIndex system_index = id.first;
-    PortIndex port_index = id.second;
+    const InputPortIdentifier& id = input_ids_[index];
+    const SubsystemIndex system_index = id.first;
+    const InputPortIndex port_index = id.second;
     return Context<T>::GetInputPortValue(GetSubsystemContext(system_index),
                                          port_index);
   }
 
  private:
-  int num_subsystems() const {
+  int num_subcontexts() const {
     DRAKE_ASSERT(contexts_.size() == outputs_.size());
     return static_cast<int>(contexts_.size());
   }
@@ -367,25 +371,25 @@ class DiagramContext : public Context<T> {
   void SetInputPortValue(int index,
                          std::unique_ptr<InputPortValue> port) final {
     DRAKE_DEMAND(index >= 0 && index < get_num_input_ports());
-    const PortIdentifier& id = input_ids_[index];
-    SystemIndex system_index = id.first;
-    PortIndex port_index = id.second;
+    const InputPortIdentifier& id = input_ids_[index];
+    SubsystemIndex system_index = id.first;
+    InputPortIndex port_index = id.second;
     Context<T>::SetInputPortValue(&GetMutableSubsystemContext(system_index),
                                   port_index, std::move(port));
   }
 
-  std::vector<PortIdentifier> input_ids_;
+  std::vector<InputPortIdentifier> input_ids_;
 
-  // The outputs are stored in SystemIndex order, and outputs_ is equal in
+  // The outputs are stored in SubsystemIndex order, and outputs_ is equal in
   // length to the number of subsystems specified at construction time.
   std::vector<std::unique_ptr<SystemOutput<T>>> outputs_;
-  // The contexts are stored in SystemIndex order, and contexts_ is equal in
+  // The contexts are stored in SubsystemIndex order, and contexts_ is equal in
   // length to the number of subsystems specified at construction time.
   std::vector<std::unique_ptr<Context<T>>> contexts_;
 
   // A map from the input ports of constituent systems, to the output ports of
-  // the systems on which they depend.
-  std::map<PortIdentifier, PortIdentifier> dependency_graph_;
+  // the systems from which they get their values.
+  std::map<InputPortIdentifier, OutputPortIdentifier> connection_map_;
 
   // The internal state of the Diagram, which includes all its subsystem states.
   std::unique_ptr<DiagramState<T>> state_;

--- a/systems/framework/input_port_descriptor.h
+++ b/systems/framework/input_port_descriptor.h
@@ -29,7 +29,7 @@ class InputPortDescriptor {
   /// @param random_type Input ports may optionally be labeled as random, if the
   ///                    port is intended to model a random-source "noise" or
   ///                    "disturbance" input.
-  InputPortDescriptor(const System<T>* system, int index,
+  InputPortDescriptor(const System<T>* system, InputPortIndex index,
                       PortDataType data_type, int size,
                       const optional<RandomDistribution>& random_type)
       : system_(system),
@@ -67,7 +67,7 @@ class InputPortDescriptor {
   /// @}
 
   const System<T>* get_system() const { return system_; }
-  int get_index() const { return index_; }
+  InputPortIndex get_index() const { return index_; }
   PortDataType get_data_type() const { return data_type_; }
   int size() const { return size_; }
   bool is_random() const { return static_cast<bool>(random_type_); }
@@ -75,7 +75,7 @@ class InputPortDescriptor {
 
  private:
   const System<T>* const system_;
-  const int index_;
+  const InputPortIndex index_;
   const PortDataType data_type_;
   const int size_;
   const optional<RandomDistribution> random_type_;

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1474,7 +1474,7 @@ class System {
   const InputPortDescriptor<T>& DeclareInputPort(
       PortDataType type, int size,
       optional<RandomDistribution> random_type = nullopt) {
-    int port_index = get_num_input_ports();
+    const InputPortIndex port_index(get_num_input_ports());
     input_ports_.push_back(std::make_unique<InputPortDescriptor<T>>(
         this, port_index, type, size, random_type));
     return *input_ports_.back();

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -76,17 +76,19 @@ class DiagramContextTest : public ::testing::Test {
     context_ = std::make_unique<DiagramContext<double>>(kNumSystems);
     context_->set_time(kTime);
 
-    AddSystem(*adder0_, 0);
-    AddSystem(*adder1_, 1);
-    AddSystem(*integrator0_, 2);
-    AddSystem(*integrator1_, 3);
-    AddSystem(*hold_, 4);
-    AddSystem(*abstract_state_system_, 5);
-    AddSystem(*system_with_numeric_parameters_, 6);
-    AddSystem(*system_with_abstract_parameters_, 7);
+    AddSystem(*adder0_, SubsystemIndex(0));
+    AddSystem(*adder1_, SubsystemIndex(1));
+    AddSystem(*integrator0_, SubsystemIndex(2));
+    AddSystem(*integrator1_, SubsystemIndex(3));
+    AddSystem(*hold_, SubsystemIndex(4));
+    AddSystem(*abstract_state_system_, SubsystemIndex(5));
+    AddSystem(*system_with_numeric_parameters_, SubsystemIndex(6));
+    AddSystem(*system_with_abstract_parameters_, SubsystemIndex(7));
 
-    context_->ExportInput({0 /* adder0_ */, 1 /* port 1 */});
-    context_->ExportInput({1 /* adder1_ */, 0 /* port 0 */});
+    context_->ExportInput(
+        {SubsystemIndex(0) /* adder0_ */, InputPortIndex(1) /* port 1 */});
+    context_->ExportInput(
+        {SubsystemIndex(1) /* adder1_ */, InputPortIndex(0) /* port 0 */});
 
     context_->MakeState();
     context_->MakeParameters();
@@ -101,7 +103,7 @@ class DiagramContextTest : public ::testing::Test {
     context_->get_mutable_numeric_parameter(0).SetAtIndex(1, 77.0);
   }
 
-  void AddSystem(const System<double>& sys, int index) {
+  void AddSystem(const System<double>& sys, SubsystemIndex index) {
     auto subcontext = sys.CreateDefaultContext();
     auto suboutput = sys.AllocateOutput(*subcontext);
     context_->AddSystem(index, std::move(subcontext), std::move(suboutput));
@@ -116,8 +118,8 @@ class DiagramContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0,
-                                           nullopt);
+    InputPortDescriptor<double> descriptor(nullptr, InputPortIndex(index),
+                                           kVectorValued, 0, nullopt);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 
@@ -161,7 +163,7 @@ void VerifyClonedParameters(const Parameters<double>& params) {
 // Tests that subsystems have outputs and contexts in the DiagramContext.
 TEST_F(DiagramContextTest, RetrieveConstituents) {
   // All of the subsystems should be leaf Systems.
-  for (int i = 0; i < kNumSystems; ++i) {
+  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
     auto context = dynamic_cast<const LeafContext<double>*>(
         &context_->GetSubsystemContext(i));
     EXPECT_TRUE(context != nullptr);
@@ -176,7 +178,7 @@ TEST_F(DiagramContextTest, RetrieveConstituents) {
 TEST_F(DiagramContextTest, Time) {
   context_->set_time(42.0);
   EXPECT_EQ(42.0, context_->get_time());
-  for (int i = 0; i < kNumSystems; ++i) {
+  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
     EXPECT_EQ(42.0, context_->GetSubsystemContext(i).get_time());
   }
 }
@@ -199,14 +201,17 @@ TEST_F(DiagramContextTest, State) {
   // Changes to the diagram state write through to constituent system states.
   // - Continuous
   ContinuousState<double>& integrator0_xc =
-      context_->GetMutableSubsystemContext(2).get_mutable_continuous_state();
+      context_->GetMutableSubsystemContext(SubsystemIndex(2))
+          .get_mutable_continuous_state();
   ContinuousState<double>& integrator1_xc =
-      context_->GetMutableSubsystemContext(3).get_mutable_continuous_state();
+      context_->GetMutableSubsystemContext(SubsystemIndex(3))
+          .get_mutable_continuous_state();
   EXPECT_EQ(42.0, integrator0_xc.get_vector().GetAtIndex(0));
   EXPECT_EQ(43.0, integrator1_xc.get_vector().GetAtIndex(0));
   // - Discrete
   DiscreteValues<double>& hold_xd =
-      context_->GetMutableSubsystemContext(4).get_mutable_discrete_state();
+      context_->GetMutableSubsystemContext(SubsystemIndex(4))
+          .get_mutable_discrete_state();
   EXPECT_EQ(44.0, hold_xd.get_vector(0).GetAtIndex(0));
 
   // Changes to constituent system states appear in the diagram state.
@@ -224,7 +229,7 @@ TEST_F(DiagramContextTest, DiagramState) {
   auto diagram_state = dynamic_cast<DiagramState<double>*>(
       &context_->get_mutable_state());
   ASSERT_NE(nullptr, diagram_state);
-  for (int i = 0; i < kNumSystems; ++i) {
+  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
     EXPECT_EQ(&context_->GetMutableSubsystemContext(i).get_mutable_state(),
               &diagram_state->get_mutable_substate(i));
   }
@@ -233,8 +238,9 @@ TEST_F(DiagramContextTest, DiagramState) {
 // Tests that no exception is thrown when connecting a valid source
 // and destination port.
 TEST_F(DiagramContextTest, ConnectValid) {
-  EXPECT_NO_THROW(context_->Connect({0 /* adder0_ */, 0 /* port 0 */},
-                                    {1 /* adder1_ */, 1 /* port 1 */}));
+  EXPECT_NO_THROW(
+      context_->Connect({SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
+                        {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)}));
 }
 
 // Tests that input ports can be assigned to the DiagramContext and then
@@ -247,8 +253,8 @@ TEST_F(DiagramContextTest, SetAndGetInputPorts) {
 }
 
 TEST_F(DiagramContextTest, Clone) {
-  context_->Connect({0 /* adder0_ */, 0 /* port 0 */},
-                    {1 /* adder1_ */, 1 /* port 1 */});
+  context_->Connect({SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
+                    {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)});
   AttachInputPorts();
 
   std::unique_ptr<DiagramContext<double>> clone(

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -267,14 +267,49 @@ GTEST_TEST(EmptySystemDiagramTest, CheckPeriodicTriggerDiscreteUpdate) {
   }
 }
 
-/// ExampleDiagram has the following structure:
-/// adder0_: (input0_ + input1_) -> A
-/// adder1_: (A + input2_)       -> B, output 0
-/// adder2_: (A + B)             -> output 1
-/// integrator1_: A              -> C
-/// integrator2_: C              -> output 2
-/// It also uses an StatelessSystem to verify Diagram's ability to retrieve
-/// witness functions from its subsystems.
+/* ExampleDiagram has the following structure:
+adder0_: (input0_ + input1_) -> A
+adder1_: (A + input2_)       -> B, output 0
+adder2_: (A + B)             -> output 1
+integrator1_: A              -> C
+integrator2_: C              -> output 2
+It also uses an StatelessSystem to verify Diagram's ability to retrieve
+witness functions from its subsystems.
+
+             +----------------------------------------------------------+
+             |                                                          |
+             |  +--------+                       +------------------------->
+1, 2, 4  +------>        |                       |                   B  | y0
+          u0 |  | Adder0 | A  +-----------+      |                      |
+             |  |        +-+--> u0        |      |                      |
+8, 16, 32+------>        | |  |           |      |                      |
+          u1 |  +--------+ |  | Adder1    |  B   |       +-----------+  |
+             |             |  |           +------+-------> u1        |  |
+64, 128, 256 |             |  |           | 73,146,292   |           |  |
+         +--------------------> u1        |              | Adder2    |  |
+          u2 |             |  +-----------+              |           +----->
+             |             |                 A           |           |  | y1
+             |             +-----------------------------> u0        |  |
+             |             |     9, 18, 36               +-----------+  |  82
+             |             |                                            | 164
+             |             |                                            | 328
+             |             |                                            |
+             |             |  +------------+             +-----------+  |
+             |             |  |            |             |           |  |
+             |           A |  |            |     C       |           |  |
+             |             +--> Integ0     +-------------> Integ1    +----->
+             |                |            |             |           |  | y2
+             |                |  3, 9, 27  |             |81,243,729 |  |
+             |                +------------+             +-----------+  |
+             |                                                          |
+             |  +----------------+            +-------------------+     |
+             |  |                |            |    ConstantVector |     |
+             |  |  Stateless     |            |    or             |     |
+             |  |                |            |    DoubleOnly     |     |
+             |  +----------------+            +-------------------+     |
+             |                                                          |
+             +----------------------------------------------------------|
+*/
 class ExampleDiagram : public Diagram<double> {
  public:
   explicit ExampleDiagram(
@@ -551,20 +586,18 @@ TEST_F(DiagramTest, CalcTimeDerivatives) {
   ASSERT_EQ(6, derivatives->get_misc_continuous_state().size());
 
   // The derivative of the first integrator is A.
-  const ContinuousState<double>* integrator0_xcdot =
+  const ContinuousState<double>& integrator0_xcdot =
       diagram_->GetSubsystemDerivatives(*derivatives, integrator0());
-  ASSERT_TRUE(integrator0_xcdot != nullptr);
-  EXPECT_EQ(1 + 8, integrator0_xcdot->get_vector().GetAtIndex(0));
-  EXPECT_EQ(2 + 16, integrator0_xcdot->get_vector().GetAtIndex(1));
-  EXPECT_EQ(4 + 32, integrator0_xcdot->get_vector().GetAtIndex(2));
+  EXPECT_EQ(1 + 8, integrator0_xcdot.get_vector().GetAtIndex(0));
+  EXPECT_EQ(2 + 16, integrator0_xcdot.get_vector().GetAtIndex(1));
+  EXPECT_EQ(4 + 32, integrator0_xcdot.get_vector().GetAtIndex(2));
 
   // The derivative of the second integrator is the state of the first.
-  const ContinuousState<double>* integrator1_xcdot =
+  const ContinuousState<double>& integrator1_xcdot =
       diagram_->GetSubsystemDerivatives(*derivatives, integrator1());
-  ASSERT_TRUE(integrator1_xcdot != nullptr);
-  EXPECT_EQ(3, integrator1_xcdot->get_vector().GetAtIndex(0));
-  EXPECT_EQ(9, integrator1_xcdot->get_vector().GetAtIndex(1));
-  EXPECT_EQ(27, integrator1_xcdot->get_vector().GetAtIndex(2));
+  EXPECT_EQ(3, integrator1_xcdot.get_vector().GetAtIndex(0));
+  EXPECT_EQ(9, integrator1_xcdot.get_vector().GetAtIndex(1));
+  EXPECT_EQ(27, integrator1_xcdot.get_vector().GetAtIndex(2));
 }
 
 // Tests the AllocateInput logic.
@@ -723,7 +756,7 @@ TEST_F(DiagramTest, DerivativesOfStatelessSystemAreEmpty) {
   std::unique_ptr<ContinuousState<double>> derivatives =
       diagram_->AllocateTimeDerivatives();
   EXPECT_EQ(0,
-            diagram_->GetSubsystemDerivatives(*derivatives, adder0())->size());
+            diagram_->GetSubsystemDerivatives(*derivatives, adder0()).size());
 }
 
 class DiagramOfDiagramsTest : public ::testing::Test {
@@ -819,7 +852,7 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   //   output1 = output0 + 8 + 64 = 656
   //   output2 = 9 (state of integrator1_)
 
-  // So, the outputs of subsytem1_, and thus of the whole diagram, are:
+  // So, the outputs of subsystem1_, and thus of the whole diagram, are:
   //   output0 = 584 + 656 + 9 = 1249
   //   output1 = output0 + 584 + 656 = 2489
   //   output2 = 81 (state of integrator1_)

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -83,17 +83,17 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const BasicVector<double>* ReadVectorInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kVectorValued, 0,
-                                           nullopt);
+    InputPortDescriptor<double> descriptor(nullptr, InputPortIndex(index),
+                                           kVectorValued, 0, nullopt);
     return context.EvalVectorInput(nullptr, descriptor);
   }
 
   // Mocks up a descriptor sufficient to read a FreestandingInputPortValue
   // connected to @p context at @p index.
-  static const std::string* ReadStringInputPort(
-      const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0,
-                                           nullopt);
+  static const std::string* ReadStringInputPort(const Context<double>& context,
+                                                int index) {
+    InputPortDescriptor<double> descriptor(nullptr, InputPortIndex(index),
+                                           kAbstractValued, 0, nullopt);
     return context.EvalInputValue<std::string>(nullptr, descriptor);
   }
 
@@ -101,8 +101,8 @@ class LeafContextTest : public ::testing::Test {
   // connected to @p context at @p index.
   static const AbstractValue* ReadAbstractInputPort(
       const Context<double>& context, int index) {
-    InputPortDescriptor<double> descriptor(nullptr, index, kAbstractValued, 0,
-                                           nullopt);
+    InputPortDescriptor<double> descriptor(nullptr, InputPortIndex(index),
+                                           kAbstractValued, 0, nullopt);
     return context.EvalAbstractInput(nullptr, descriptor);
   }
 

--- a/systems/primitives/random_source.cc
+++ b/systems/primitives/random_source.cc
@@ -31,10 +31,10 @@ int AddRandomInputs(double sampling_interval_sec,
         continue;
       }
 
-      typedef typename Diagram<double>::PortIdentifier PortIdentifier;
+      typedef typename Diagram<double>::InputPortLocator InputPortLocator;
       // Check if the input is already wired up.
-      PortIdentifier id{port.get_system(), port.get_index()};
-      if (builder->dependency_graph_.count(id) > 0 ||
+      InputPortLocator id{port.get_system(), port.get_index()};
+      if (builder->connection_map_.count(id) > 0 ||
           builder->diagram_input_set_.count(id) > 0) {
         continue;
       }


### PR DESCRIPTION
This PR contains an assortment of cosmetic changes from the caching branch #7668 so that these won't be in the way when reviewing substantive changes.

Most of the changes here make use of TypeSafeIndex types to distinguish the many types of `int` from one another. A few names "dependency_graph" are changed to "connection_map" (meaning 
output port -> input port relations) since those have a distinct meaning from the context's DependencyGraph object. One method that was returning a pointer now returns a reference (GetSubsystemDerivatives()). I added one lovely piece of ascii art to a test case.

These are Framework-internal changes and do not affect the end user API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8462)
<!-- Reviewable:end -->
