### PR TITLE
Increase kcov timeouts

### DIFF
--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -12,8 +12,8 @@ test:kcov --nocache_test_results
 # These increased timeouts were set through experimentation. Because kcov runs
 # in a separate process from the main program, the OS has to context-switch
 # between the processes every time a line is hit, slowing down execution
-# significantly.
-test:kcov --test_timeout=120,600,1800,7200
+# significantly. Timeouts are 3.5x default values.
+test:kcov --test_timeout=210,1050,3150,12600
 
 ### Kcov everything build. ###
 build:kcov_everything --define=WITH_GUROBI=ON
@@ -30,7 +30,7 @@ test:kcov_everything --local_test_jobs=1
 test:kcov_everything --test_tag_filters=-cpplint,-pycodestyle,-no_kcov
 test:kcov_everything --nocache_test_results
 # See timeout note above.
-test:kcov_everything --test_timeout=120,600,1800,7200
+test:kcov_everything --test_timeout=210,1050,3150,12600
 
 ### ASan build. ###
 build:asan --copt -g


### PR DESCRIPTION
A few tests are timing out in the **gcc-everything** configuration, see https://drake-cdash.csail.mit.edu/index.php?project=Drake&showfilters=1&filtercount=2&showfilters=1&filtercombine=and&field1=label&compare1=61&value1=jenkins-linux-xenial-gcc-bazel-experimental-coverage-everything-debug-3&field2=buildstarttime&compare2=84&value2=now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8464)
<!-- Reviewable:end -->
