### PR TITLE
Add visualization material to geometry

### DIFF
--- a/examples/geometry_world/solar_system.cc
+++ b/examples/geometry_world/solar_system.cc
@@ -29,6 +29,7 @@ using geometry::GeometrySystem;
 using geometry::Mesh;
 using geometry::SourceId;
 using geometry::Sphere;
+using geometry::VisualMaterial;
 using systems::BasicVector;
 using systems::Context;
 using systems::ContinuousState;
@@ -107,7 +108,7 @@ void SolarSystem<T>::SetDefaultState(const systems::Context<T>&,
 // origin, and the top of the arm is positioned at the given height.
 template <class ParentId>
 void MakeArm(SourceId source_id, ParentId parent_id, double length,
-             double height, double radius,
+             double height, double radius, const VisualMaterial& material,
              GeometrySystem<double>* geometry_system) {
   Isometry3<double> arm_pose = Isometry3<double>::Identity();
   // tilt it horizontally
@@ -117,14 +118,14 @@ void MakeArm(SourceId source_id, ParentId parent_id, double length,
   geometry_system->RegisterGeometry(
       source_id, parent_id,
       make_unique<GeometryInstance>(
-          arm_pose, make_unique<Cylinder>(radius, length)));
+          arm_pose, make_unique<Cylinder>(radius, length), material));
 
   Isometry3<double> post_pose = Isometry3<double>::Identity();
   post_pose.translation() << length, 0, height/2;
   geometry_system->RegisterGeometry(
       source_id, parent_id,
       make_unique<GeometryInstance>(
-          post_pose, make_unique<Cylinder>(radius, height)));
+          post_pose, make_unique<Cylinder>(radius, height), material));
 }
 
 template <typename T>
@@ -133,6 +134,7 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   body_offset_.reserve(kBodyCount);
   axes_.reserve(kBodyCount);
 
+  VisualMaterial post_material{Vector4d(0.3, 0.15, 0.05, 1)};
   const double orrery_bottom = -1.5;
   const double pipe_radius = 0.05;
 
@@ -140,8 +142,9 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   // NOTE: we don't store the id of the sun geometry because we have no need
   // for subsequent access (the same is also true for dynamic geometries).
   geometry_system->RegisterAnchoredGeometry(
-      source_id_, make_unique<GeometryInstance>(Isometry3<double>::Identity(),
-                                                make_unique<Sphere>(1.f)));
+      source_id_, make_unique<GeometryInstance>(
+                      Isometry3<double>::Identity(), make_unique<Sphere>(1.f),
+                      VisualMaterial(Vector4d(1, 1, 0, 1))));
 
   // The fixed post on which Sun sits and around which all planets rotate.
   const double post_height = 1;
@@ -150,7 +153,8 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   geometry_system->RegisterAnchoredGeometry(
       source_id_, make_unique<GeometryInstance>(
                       post_pose,
-                      make_unique<Cylinder>(pipe_radius, post_height)));
+                      make_unique<Cylinder>(pipe_radius, post_height),
+                      post_material));
 
   // Allocate the "celestial bodies": two planets orbiting on different planes,
   // each with a moon.
@@ -173,10 +177,11 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
       Translation3<double>{kEarthOrbitRadius, 0, -kEarthBottom}};
   geometry_system->RegisterGeometry(
       source_id_, planet_id,
-      make_unique<GeometryInstance>(X_EGe, make_unique<Sphere>(0.25f)));
+      make_unique<GeometryInstance>(X_EGe, make_unique<Sphere>(0.25f),
+                                    VisualMaterial(Vector4d(0, 0, 1, 1))));
   // Earth's orrery arm.
   MakeArm(source_id_, planet_id, kEarthOrbitRadius, -kEarthBottom, pipe_radius,
-          geometry_system);
+          post_material, geometry_system);
 
   // Luna's frame L is at the center of Earth's geometry (Ge). So, X_EL = X_EGe.
   const Isometry3<double>& X_EL = X_EGe;
@@ -196,8 +201,9 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
       Vector3<double>(-1, 0.5, 0.5).normalized() * kLunaOrbitRadius;
   Isometry3<double> X_LGl{Translation3<double>{luna_position}};
   geometry_system->RegisterGeometry(
-      source_id_, luna_id,
-      make_unique<GeometryInstance>(X_LGl, make_unique<Sphere>(0.075f)));
+      source_id_, luna_id, make_unique<GeometryInstance>(
+                               X_LGl, make_unique<Sphere>(0.075f),
+                               VisualMaterial(Vector4d(0.5, 0.5, 0.35, 1))));
 
   // Mars's frame M lies directly *below* the sun (to account for the orrery
   // arm).
@@ -216,7 +222,8 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
       Translation3<double>{kMarsOrbitRadius, 0, -orrery_bottom}};
   GeometryId mars_geometry_id = geometry_system->RegisterGeometry(
       source_id_, planet_id,
-      make_unique<GeometryInstance>(X_MGm, make_unique<Sphere>(kMarsSize)));
+      make_unique<GeometryInstance>(X_MGm, make_unique<Sphere>(kMarsSize),
+                                    VisualMaterial(Vector4d(0.9, 0.1, 0, 1))));
 
   std::string rings_absolute_path =
       FindResourceOrThrow("drake/examples/geometry_world/planet_rings.obj");
@@ -225,11 +232,12 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   geometry_system->RegisterGeometry(
       source_id_, mars_geometry_id,
       make_unique<GeometryInstance>(
-          X_GmGr, make_unique<Mesh>(rings_absolute_path, kMarsSize)));
+          X_GmGr, make_unique<Mesh>(rings_absolute_path, kMarsSize),
+          VisualMaterial(Vector4d(0.45, 0.9, 0, 1))));
 
   // Mars's orrery arm.
   MakeArm(source_id_, planet_id, kMarsOrbitRadius, -orrery_bottom, pipe_radius,
-          geometry_system);
+          post_material, geometry_system);
 
   // Phobos's frame P is at the center of Mars's geometry (Gm).
   // So, X_MP = X_MGm. The normal of the plane is negated so it orbits in the
@@ -246,8 +254,9 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
   const double kPhobosOrbitRadius = 0.34;
   Isometry3<double> X_PGp{Translation3<double>{kPhobosOrbitRadius, 0, 0}};
   geometry_system->RegisterGeometry(
-      source_id_, phobos_id,
-      make_unique<GeometryInstance>(X_PGp, make_unique<Sphere>(0.06f)));
+      source_id_, phobos_id, make_unique<GeometryInstance>(
+                                 X_PGp, make_unique<Sphere>(0.06f),
+                                 VisualMaterial(Vector4d(0.65, 0.6, 0.8, 1))));
 
   DRAKE_DEMAND(static_cast<int>(body_ids_.size()) == kBodyCount);
 }

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -85,10 +85,18 @@ drake_cc_library(
     hdrs = ["geometry_instance.h"],
     deps = [
         ":geometry_ids",
+        ":geometry_material",
         ":shape_specification",
         "//common:copyable_unique_ptr",
         "//common:essential",
     ],
+)
+
+drake_cc_library(
+    name = "geometry_material",
+    srcs = ["visual_material.cc"],
+    hdrs = ["visual_material.h"],
+    deps = ["//common"],
 )
 
 drake_cc_library(
@@ -158,6 +166,7 @@ drake_cc_library(
     deps = [
         ":geometry_ids",
         ":geometry_index",
+        ":geometry_material",
         ":shape_specification",
         "//common:copyable_unique_ptr",
         "//common:essential",

--- a/geometry/geometry_instance.cc
+++ b/geometry/geometry_instance.cc
@@ -9,5 +9,13 @@ GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
                                    std::unique_ptr<Shape> shape)
     : id_(GeometryId::get_new_id()), X_PG_(X_PG), shape_(std::move(shape)) {}
 
+GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
+                                   std::unique_ptr<Shape> shape,
+                                   const VisualMaterial& vis_material)
+    : id_(GeometryId::get_new_id()),
+      X_PG_(X_PG),
+      shape_(std::move(shape)),
+      visual_material_(vis_material) {}
+
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -7,6 +7,7 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/visual_material.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -24,6 +25,13 @@ class GeometryInstance {
    @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
    @param shape  The underlying shape for this geometry instance. */
   GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape);
+
+  /** Constructor.
+   @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
+   @param shape  The underlying shape for this geometry instance.
+   @param vis_material The visual material to apply to this geometry. */
+  GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape,
+                   const VisualMaterial& vis_material);
 
   /** Returns the globally unique id for this geometry specification. Every
    instantiation of %GeometryInstance will contain a unique id value. The id
@@ -43,6 +51,8 @@ class GeometryInstance {
   /** Releases the shape from the instance. */
   std::unique_ptr<Shape> release_shape() { return std::move(shape_); }
 
+  const VisualMaterial& visual_material() const { return visual_material_; }
+
  private:
   // The *globally* unique identifier for this instance. It is functionally
   // const (i.e. defined in construction) but not marked const to allow for
@@ -54,6 +64,9 @@ class GeometryInstance {
 
   // The shape associated with this instance.
   copyable_unique_ptr<Shape> shape_;
+
+  // The "rendering" material -- e.g., OpenGl contexts and the like.
+  VisualMaterial visual_material_;
 };
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -268,7 +268,8 @@ GeometryId GeometryState<T>::RegisterGeometry(
   geometries_.emplace(
       geometry_id,
       InternalGeometry(geometry->release_shape(), frame_id, geometry_id,
-                       geometry->pose(), engine_index));
+                       geometry->pose(), engine_index,
+                       geometry->visual_material()));
   // TODO(SeanCurtis-TRI): Enforcing the invariant that the indexes are
   // compactly distributed. Is there a more robust way to do this?
   DRAKE_ASSERT(static_cast<int>(X_FG_.size()) == engine_index);
@@ -354,8 +355,9 @@ GeometryId GeometryState<T>::RegisterAnchoredGeometry(
   anchored_geometry_index_id_map_.push_back(geometry_id);
   anchored_geometries_.emplace(
       geometry_id,
-      InternalAnchoredGeometry(geometry->release_shape(), geometry_id,
-                               geometry->pose(), engine_index));
+      InternalAnchoredGeometry(
+          geometry->release_shape(), geometry_id, geometry->pose(),
+          engine_index, geometry->visual_material()));
   return geometry_id;
 }
 

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -129,8 +129,6 @@ void DispatchLoadMessage(const GeometryState<double>& state) {
   message.num_links = total_link_count;
   message.link.resize(total_link_count);
 
-  Eigen::Vector4d default_color(0.8, 0.8, 0.8, 1.0);
-
   int link_index = 0;
   // Load anchored geometry into the world frame.
   {
@@ -143,8 +141,10 @@ void DispatchLoadMessage(const GeometryState<double>& state) {
       for (const auto& pair : state.anchored_geometries_) {
         const InternalAnchoredGeometry& geometry = pair.second;
         const Shape& shape = geometry.get_shape();
+        const Eigen::Vector4d& color =
+            geometry.get_visual_material().diffuse();
         message.link[0].geom[geom_index] = MakeGeometryData(
-            shape, geometry.get_pose_in_parent(), default_color);
+            shape, geometry.get_pose_in_parent(), color);
         ++geom_index;
       }
       link_index = 1;
@@ -168,11 +168,13 @@ void DispatchLoadMessage(const GeometryState<double>& state) {
     int geom_index = 0;
     for (GeometryId geom_id : frame.get_child_geometries()) {
       const InternalGeometry& geometry = state.geometries_.at(geom_id);
-      GeometryIndex index = state.geometries_.at(geom_id).get_engine_index();
-      const Shape& shape = geometry.get_shape();
+      GeometryIndex index = geometry.get_engine_index();
       const Isometry3<double> X_FG = state.X_FG_.at(index);
+      const Shape& shape = geometry.get_shape();
+      const Eigen::Vector4d& color =
+          geometry.get_visual_material().diffuse();
       message.link[link_index].geom[geom_index] =
-          MakeGeometryData(shape, X_FG, default_color);
+          MakeGeometryData(shape, X_FG, color);
       ++geom_index;
     }
     ++link_index;

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -15,6 +15,16 @@ InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
       frame_id_(frame_id),
       engine_index_(engine_index),
       parent_id_(parent_id) {}
+InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
+                                   FrameId frame_id, GeometryId geometry_id,
+                                   const Isometry3<double>& X_PG,
+                                   GeometryIndex engine_index,
+                                   const VisualMaterial& vis_material,
+                                   const optional<GeometryId>& parent_id)
+    : InternalGeometryBase(std::move(shape), geometry_id, X_PG, vis_material),
+      frame_id_(frame_id),
+      engine_index_(engine_index),
+      parent_id_(parent_id) {}
 
 InternalAnchoredGeometry::InternalAnchoredGeometry() : InternalGeometryBase() {}
 
@@ -22,6 +32,13 @@ InternalAnchoredGeometry::InternalAnchoredGeometry(
     std::unique_ptr<Shape> shape, GeometryId geometry_id,
     const Isometry3<double>& X_WG, AnchoredGeometryIndex engine_index)
     : InternalGeometryBase(std::move(shape), geometry_id, X_WG),
+      engine_index_(engine_index) {}
+
+InternalAnchoredGeometry::InternalAnchoredGeometry(
+    std::unique_ptr<Shape> shape, GeometryId geometry_id,
+    const Isometry3<double>& X_WG, AnchoredGeometryIndex engine_index,
+    const VisualMaterial& vis_material)
+    : InternalGeometryBase(std::move(shape), geometry_id, X_WG, vis_material),
       engine_index_(engine_index) {}
 
 }  // namespace internal

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -10,6 +10,7 @@
 #include "drake/common/drake_optional.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
+#include "drake/geometry/visual_material.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -28,7 +29,7 @@ class InternalGeometryBase {
    be nullptr, and the pose will be uninitialized. */
   InternalGeometryBase() {}
 
-  /** Full constructor.
+  /** Default material, full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
    @param X_PG          The pose of the geometry G in the parent frame P. */
@@ -38,6 +39,19 @@ class InternalGeometryBase {
         id_(geometry_id),
         X_PG_(X_PG) {}
 
+  /** Full constructor.
+   @param shape         The shape specification for this instance.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param X_PG          The pose of the geometry G in the parent frame P.
+   @param engine_index  The position in the geometry engine of this geometry.
+   @param vis_material  The visual material for this geometry. */
+  InternalGeometryBase(std::unique_ptr<Shape> shape, GeometryId geometry_id,
+                       const Isometry3<double>& X_PG,
+                       const VisualMaterial& vis_material)
+      : shape_spec_(std::move(shape)),
+        id_(geometry_id),
+        X_PG_(X_PG),
+        visual_material_(vis_material) {}
   /** Compares two %InternalGeometryBase instances for "equality". Two internal
    geometries are considered equal if they have the same geometry identifier. */
   bool operator==(const InternalGeometryBase &other) const {
@@ -53,6 +67,7 @@ class InternalGeometryBase {
   const Shape& get_shape() const { return *shape_spec_; }
   GeometryId get_id() const { return id_; }
   const Isometry3<double>& get_pose_in_parent() const { return X_PG_; }
+  const VisualMaterial& get_visual_material() const { return visual_material_; }
 
  private:
   // The specification for this instance's shape.
@@ -64,6 +79,10 @@ class InternalGeometryBase {
   // The pose of this geometry in the parent frame. The parent may be a frame or
   // another registered geometry.
   Isometry3<double> X_PG_;
+  // TODO(SeanCurtis-TRI): Consider making this "optional" so that the values
+  // can be assigned at the frame level.
+  // The "rendering" material -- e.g., OpenGl contexts and the like.
+  VisualMaterial visual_material_;
 };
 
 /** This class represents the internal representation of registered _dynamic_
@@ -77,7 +96,7 @@ class InternalGeometry : public InternalGeometryBase {
    the state documented in InternalGeometryBase(). */
   InternalGeometry();
 
-  /** Full constructor.
+  /** Default material, full constructor.
    @param shape         The shape specification for this instance.
    @param frame_id      The identifier of the frame this belongs to.
    @param geometry_id   The identifier for _this_ geometry.
@@ -86,8 +105,23 @@ class InternalGeometry : public InternalGeometryBase {
    @param engine_index  The position in the geometry engine of this geometry.
    @param parent_id     The optional id of the parent geometry. */
   InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
-                   GeometryId geometry_id, const Isometry3<double>& X_PG,
-                   GeometryIndex engine_index,
+                   GeometryId geometry_id,
+                   const Isometry3<double>& X_PG, GeometryIndex engine_index,
+                   const optional<GeometryId>& parent_id = {});
+
+  /** Full constructor.
+   @param shape         The shape specification for this instance.
+   @param frame_id      The identifier of the frame this belongs to.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param X_PG          The pose of the geometry G in the parent frame P. The
+                        parent may be a frame, or another registered geometry.
+   @param engine_index  The position in the geometry engine of this geometry.
+   @param vis_material  The visual material for this geometry.
+   @param parent_id     The optional id of the parent geometry. */
+  InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
+                   GeometryId geometry_id,
+                   const Isometry3<double>& X_PG, GeometryIndex engine_index,
+                   const VisualMaterial& vis_material,
                    const optional<GeometryId>& parent_id = {});
 
   FrameId get_frame_id() const { return frame_id_; }
@@ -158,7 +192,7 @@ class InternalAnchoredGeometry : public InternalGeometryBase {
    InternalGeometryBase(). */
   InternalAnchoredGeometry();
 
-  /** Full constructor.
+  /** Default material, full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
    @param X_WG          The pose of the geometry G in the world frame W.
@@ -166,6 +200,17 @@ class InternalAnchoredGeometry : public InternalGeometryBase {
   InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
                            const Isometry3<double>& X_WG,
                            AnchoredGeometryIndex engine_index);
+
+  /** Full constructor.
+   @param shape         The shape specification for this instance.
+   @param geometry_id   The identifier for _this_ geometry.
+   @param X_WG          The pose of the geometry G in the world frame W.
+   @param engine_index  The position in the geometry engine of this geometry.
+   @param vis_material  The visual material for this geometry. */
+  InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
+                           const Isometry3<double>& X_WG,
+                           AnchoredGeometryIndex engine_index,
+                           const VisualMaterial& vis_material);
 
   AnchoredGeometryIndex get_engine_index() const { return engine_index_; }
   void set_engine_index(AnchoredGeometryIndex index) { engine_index_ = index; }

--- a/geometry/visual_material.cc
+++ b/geometry/visual_material.cc
@@ -1,0 +1,11 @@
+#include "drake/geometry/visual_material.h"
+
+namespace drake {
+namespace geometry {
+
+VisualMaterial::VisualMaterial() {}
+
+VisualMaterial::VisualMaterial(const Eigen::Vector4d& diffuse)
+    : diffuse_(diffuse) {}
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/visual_material.h
+++ b/geometry/visual_material.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace geometry {
+
+/** Definition of material for simple visualization. Default materials are a
+ light grey. */
+class VisualMaterial {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(VisualMaterial)
+
+  /** Constructs a material with the default grey color. */
+  VisualMaterial();
+
+  /** Constructs a material with the given diffuse color. */
+  explicit VisualMaterial(const Eigen::Vector4d& diffuse);
+
+  /** Returns the material's diffuse color. */
+  const Eigen::Vector4d diffuse() const { return diffuse_; }
+
+ private:
+  // Default light grey color -- if this default changes, update the class
+  // documentation.
+  Eigen::Vector4d diffuse_{0.9, 0.9, 0.9, 1.0};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/rigid_body_plant/BUILD.bazel
+++ b/multibody/rigid_body_plant/BUILD.bazel
@@ -83,6 +83,7 @@ drake_cc_library(
     hdrs = ["rigid_body_plant_bridge.h"],
     deps = [
         "//geometry:geometry_ids",
+        "//geometry:geometry_material",
         "//geometry:geometry_system",
         "//multibody:rigid_body_tree",
     ],

--- a/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -6,6 +6,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/visual_material.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"
 
@@ -22,6 +23,7 @@ using geometry::GeometrySystem;
 using geometry::Mesh;
 using geometry::Shape;
 using geometry::Sphere;
+using geometry::VisualMaterial;
 
 template <typename T>
 RigidBodyPlantBridge<T>::RigidBodyPlantBridge(
@@ -123,7 +125,8 @@ void RigidBodyPlantBridge<T>::RegisterTree(GeometrySystem<T>* geometry_system) {
           geometry_system->RegisterGeometry(
               source_id_, body_id,
               std::make_unique<GeometryInstance>(
-                  X_FG, std::move(shape)));
+                  X_FG, std::move(shape),
+                  VisualMaterial(visual_element.getMaterial())));
           DRAKE_DEMAND(shape == nullptr);
         }
       }


### PR DESCRIPTION
1. Adds a definition of a *visualization* material (used for simple viz)
2. Modifies declaration of GeometryInstance to include a material.
3. Modifies the solar system example to have colors.
4. Updates LCM generation to account for materials.
5. Updates the RigidBodyPlantBridge to extract visual materials from RBT and pass them onto GeometrySystem.

Colors can be seen in two examples:
`bazel run examples/geometry_world:solar_system_run_dynamics`
`bazel run examples/contact_model:bowling_ball`

Related to #8473

```
Category            added  modified  removed  
----------------------------------------------
code                90     24        2        
comments            36     2         0        
blank               19     0         1        
----------------------------------------------
TOTAL               145    26        3  
```