### PR TITLE
Mark GradedReverseLexOrder::operator() const

### DIFF
--- a/common/symbolic_monomial_util.h
+++ b/common/symbolic_monomial_util.h
@@ -50,7 +50,7 @@ namespace symbolic {
 template <typename VariableOrder>
 struct GradedReverseLexOrder {
   /** Returns true if m1 > m2 under the Graded reverse lexicographic order. */
-  bool operator()(const Monomial& m1, const Monomial& m2) {
+  bool operator()(const Monomial& m1, const Monomial& m2) const {
     const int d1{m1.total_degree()};
     const int d2{m2.total_degree()};
     if (d1 > d2) {


### PR DESCRIPTION
Apple clang (Apple LLVM version 9.1.0 (clang-902.0.39.1)) shipped with XCode 9.3
generated the following error. This PR fixes the problem.

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tree:1819:22: error: the specified comparator type does not provide a const call operator [-Werror,-Wuser-defined-warnings]
                     __trigger_diagnostics()), "");
                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tree:876:70: note: in instantiation of member function 'std::__1::__tree<drake::symbolic::Monomial, drake::symbolic::GradedReverseLexOrder<std::__1::less<drake::symbolic::Variable> >, std::__1::allocator<drake::symbolic::Monomial> >::~__tree' requested here
    template <class, class, class> friend class _LIBCPP_TEMPLATE_VIS set;
                                                                     ^
common/symbolic_monomial_util.cc:9:20: note: in instantiation of function template specialization 'drake::symbolic::internal::ComputeMonomialBasis<-1>' requested here
  return internal::ComputeMonomialBasis<Eigen::Dynamic>(vars, degree);
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tree:970:7: note: from 'diagnose_if' attribute on '__trigger_diagnostics':
      _LIBCPP_DIAGNOSE_WARNING(!__invokable<_Compare const&, _Tp const&, _Tp const&>::value,
      ^                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__config:1095:20: note: expanded from macro '_LIBCPP_DIAGNOSE_WARNING'
    __attribute__((diagnose_if(__VA_ARGS__, "warning")))
                   ^           ~~~~~~~~~~~
1 error generated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8479)
<!-- Reviewable:end -->
