### PR TITLE
Remove occurrences of unused lambda capture 'this'

### DIFF
--- a/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -1129,7 +1129,7 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
 
   // Set the range-of-motion (L) Jacobian multiplication operator and the
   // transpose_mult() operation.
-  data.L_mult = [this, &limits](const VectorX<T>& w) -> VectorX<T> {
+  data.L_mult = [&limits](const VectorX<T>& w) -> VectorX<T> {
     VectorX<T> result(limits.size());
     for (int i = 0; static_cast<size_t>(i) < limits.size(); ++i) {
       const int index = limits[i].v_index;
@@ -1185,10 +1185,8 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
   data.kG = default_bilateral_erp *
       tree.positionConstraints(kinematics_cache) / dt;
   const auto G = tree.positionConstraintsJacobian(kinematics_cache, false);
-  data.G_mult = [this, &G](const VectorX<T>& w) -> VectorX<T> {
-    return G * w;
-  };
-  data.G_transpose_mult = [this, &G](const VectorX<T>& lambda) {
+  data.G_mult = [&G](const VectorX<T>& w) -> VectorX<T> { return G * w; };
+  data.G_transpose_mult = [&G](const VectorX<T>& lambda) {
     return G.transpose() * lambda;
   };
 

--- a/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
+++ b/multibody/rigid_body_plant/test/compliant_contact_model_test.cc
@@ -171,7 +171,7 @@ class CompliantHeterogeneousModelTest
     Element& element1 = **body1_->collision_elements_begin();
     Element& element2 = **body2_->collision_elements_begin();
 
-    auto set_params = [this](Element* element, int index) {
+    auto set_params = [](Element* element, int index) {
       CompliantMaterial material;
       material.set_youngs_modulus(kMaterialYoungsModulus[index]);
       element->set_compliant_material(material);


### PR DESCRIPTION
Detected by Apple clang (`clang-902.0.39.1`):

```
multibody/rigid_body_plant/rigid_body_plant.cc:1132:18: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
  data.L_mult = [this, &limits](const VectorX<T>& w) -> VectorX<T> {
                 ^
bazel-out/darwin-dbg/bin/multibody/rigid_body_plant/_virtual_includes/rigid_body_plant/drake/multibody/rigid_body_plant/rigid_body_plant.h:424:5: note: in instantiation of function template specialization 'drake::systems::RigidBodyPlant<double>::DoCalcDiscreteVariableUpdatesImpl<double>' requested here
    DoCalcDiscreteVariableUpdatesImpl(context, events, updates);
    ^
multibody/rigid_body_plant/rigid_body_plant.cc:1188:18: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
  data.G_mult = [this, &G](const VectorX<T>& w) -> VectorX<T> {
                 ^
multibody/rigid_body_plant/rigid_body_plant.cc:1191:28: error: lambda capture 'this' is not used [-Werror,-Wunused-lambda-capture]
  data.G_transpose_mult = [this, &G](const VectorX<T>& lambda) {
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8480)
<!-- Reviewable:end -->
