### PR TITLE
Normalize quaternion from optitrack (it is passed in float precision)

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -77,7 +77,7 @@ drake_cc_googletest(
     # parallel, subject to the availability of resources. There are 31 test
     # points in this test. To count the number of tests in the googletest
     # target "foo_test" run
-    #   $ ./bazel-bin/path/to/foo_test --gtest_list_test | grep "  \w" | wc -l
+    #   $ ./bazel-bin/path/to/foo_test --gtest_list_tests | grep "  \w" | wc -l
     shard_count = 31,
     # TODO(sam.creasey) The "snopt" tag is required because IPOPT doesn't find
     # a reasonable solution for one of the steps in this demo.  We should see

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -24,6 +24,9 @@ Isometry3<double> ExtractOptitrackPose(
   // Eigen's W-X-Y-Z ordering.
   auto& q_xyzw = body.quat;
   Eigen::Quaterniond q_wxyz(q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]);
+  // Quaternion arrived in float (single) precision so is not sufficiently
+  // normalized for use in double precision.
+  q_wxyz.normalize();
   // Pose of rigid body frame `B` in Optitrack frame `O`.
   Isometry3<double> X_OB;
   X_OB.linear() = q_wxyz.toRotationMatrix();


### PR DESCRIPTION
Paul @mitiguy's new fussy rotation matrix code barfed on a non-orthogonal rotation in monolithic_pick_and_place_system_test run in Debug (which is too expensive to do in CI). @avalenzu tracked it to the Optitrack pose message which provides the pose in float precision.

This PR is a quick fix that simply makes sure the passed-in quaternion is normalize prior to converting it to a rotation matrix. I verified on my local machine (after a very long run) that this allows it to execute to completion in Debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8483)
<!-- Reviewable:end -->
