### PR TITLE
Changes CalcNextUpdateTime() to permit current time return.

### DIFF
--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -529,7 +529,7 @@ class IntegratorBase {
    *
    * @param publish_dt The step size, >= 0.0 (exception will be thrown
    *        if this is not the case) at which the next publish will occur.
-   * @param update_dt The step size, > 0.0 (exception will be thrown
+   * @param update_dt The step size, >= 0.0 (exception will be thrown
    *        if this is not the case) at which the next update will occur.
    * @param boundary_dt The step size, >= 0.0 (exception will be thrown
    *        if this is not the case) marking the end of the user-designated
@@ -1690,11 +1690,9 @@ typename IntegratorBase<T>::StepResult IntegratorBase<T>::IntegrateAtMost(
   // time.
   const T t0 = context_->get_time();
 
-  // Verify that update dt is positive.
-  if (update_dt <= 0.0)
-    throw std::logic_error("Update dt must be strictly positive.");
-
-  // Verify that other dt's are non-negative.
+  // Verify that dt's are non-negative.
+  if (update_dt < 0.0)
+    throw std::logic_error("Update dt is negative.");
   if (publish_dt < 0.0)
     throw std::logic_error("Publish dt is negative.");
   if (boundary_dt < 0.0)

--- a/systems/analysis/test/explicit_euler_integrator_test.cc
+++ b/systems/analysis/test/explicit_euler_integrator_test.cc
@@ -68,7 +68,7 @@ GTEST_TEST(IntegratorTest, InvalidDts) {
   integrator.Initialize();
 
   EXPECT_NO_THROW(integrator.IntegrateAtMost(dt, dt, dt));
-  EXPECT_THROW(integrator.IntegrateAtMost(dt, 0.0, dt), std::logic_error);
+  EXPECT_THROW(integrator.IntegrateAtMost(dt, -1, dt), std::logic_error);
   EXPECT_THROW(integrator.IntegrateAtMost(-1, dt, dt), std::logic_error);
   EXPECT_THROW(integrator.IntegrateAtMost(dt, dt, -1), std::logic_error);
 }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -330,6 +330,11 @@ class LeafSystem : public System<T> {
   /// Computes the next update time based on the configured periodic events, for
   /// scalar types that are arithmetic, or aborts for scalar types that are not
   /// arithmetic. Subclasses that require aperiodic events should override.
+  /// @post `*time` is set to a non-negative value, on return.
+  /// @warning Setting `*time` to zero can inadvertently cause simulations of
+  ///          systems derived from @LeafSystem to loop interminably. Such a
+  ///          loop will occur if, for example, the event(s) does not modify
+  ///          the state.
   void DoCalcNextUpdateTime(const Context<T>& context,
                             CompositeEventCollection<T>* events,
                             T* time) const override {

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -330,11 +330,13 @@ class LeafSystem : public System<T> {
   /// Computes the next update time based on the configured periodic events, for
   /// scalar types that are arithmetic, or aborts for scalar types that are not
   /// arithmetic. Subclasses that require aperiodic events should override.
-  /// @post `*time` is set to a non-negative value, on return.
-  /// @warning Setting `*time` to zero can inadvertently cause simulations of
-  ///          systems derived from @LeafSystem to loop interminably. Such a
-  ///          loop will occur if, for example, the event(s) does not modify
-  ///          the state.
+  /// @post `time` is set to a value greater than or equal to
+  ///       `context.get_time()` on return.
+  /// @warning If you override this method, think carefully before setting
+  ///          `time` to `context.get_time()` on return, which can inadvertently
+  ///          cause simulations of systems derived from %LeafSystem to loop
+  ///          interminably. Such a loop will occur if, for example, the
+  ///          event(s) does not modify the state.
   void DoCalcNextUpdateTime(const Context<T>& context,
                             CompositeEventCollection<T>* events,
                             T* time) const override {

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -161,9 +161,8 @@ void LcmSubscriberSystem::DoCalcNextUpdateTime(
     return;
   }
 
-  // Schedule an update event.
-  // TODO(siyuan): should be context.get_time() once #5725 is resolved.
-  *time = context.get_time() + 0.0001;
+  // Schedule an update event at the current time.
+  *time = context.get_time();
   if (translator_ == nullptr) {
     EventCollection<UnrestrictedUpdateEvent<double>>& uu_events =
         events->get_mutable_unrestricted_update_events();

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -121,10 +121,7 @@ void CheckLog(const std::vector<double>& expected_times,
 
     // msg.timestamp is generated with the shifted time.
     EXPECT_NEAR(msg.timestamp, expected_times[i] * 1e6, 1e-12);
-    // Note: this needs to match how we schedule event processing
-    // (DoCalcNextUpdateTime) in LcmSubscriberSystem.
-    // TODO(siyuan): fix this together with #5725.
-    EXPECT_NEAR(times[i], expected_times[i] + 0.0001, 1e-12);
+    EXPECT_NEAR(times[i], expected_times[i], 1e-12);
   }
 }
 


### PR DESCRIPTION
(This PR addresses longstanding issue #5725 and would be a replacement for #8465).

Specifically, CalcNextUpdateTime() was always required to return a strictly positive time in the future to allow the simulation to be able to progress. This design was intended such that the simulation would always progress forward in time. However, the subsequent design of the witness function system addressed the problem I anticipated implicitly by triggering events only when a zero crossing occurred (i.e., there *must* be a sign change of a witness function at both ends of a time interval for the witness function to be triggered). 

Note that it is now possible that a System can create an infinite loop by returning a next update time of zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8486)
<!-- Reviewable:end -->
