### PR TITLE
Make DiagramContinuousState and DiagramDiscreteValues cloneable.

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_library(
         ":diagram_builder",
         ":diagram_context",
         ":diagram_continuous_state",
+        ":diagram_discrete_values",
         ":discrete_values",
         ":event_collection",
         ":framework_common",
@@ -97,6 +98,7 @@ drake_cc_library(
     srcs = ["abstract_values.cc"],
     hdrs = ["abstract_values.h"],
     deps = [
+        ":framework_common",
         ":value",
         "//common:autodiff",
         "//common:essential",
@@ -108,6 +110,7 @@ drake_cc_library(
     srcs = ["continuous_state.cc"],
     hdrs = ["continuous_state.h"],
     deps = [
+        ":framework_common",
         ":vector",
         "//common:autodiff",
         "//common:default_scalars",
@@ -120,6 +123,7 @@ drake_cc_library(
     srcs = ["discrete_values.cc"],
     hdrs = ["discrete_values.h"],
     deps = [
+        ":framework_common",
         ":value",
         ":vector",
         "//common:autodiff",
@@ -424,7 +428,18 @@ drake_cc_library(
     srcs = ["diagram_continuous_state.cc"],
     hdrs = ["diagram_continuous_state.h"],
     deps = [
-        ":state",
+        ":continuous_state",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "diagram_discrete_values",
+    srcs = ["diagram_discrete_values.cc"],
+    hdrs = ["diagram_discrete_values.h"],
+    deps = [
+        ":discrete_values",
         "//common:default_scalars",
         "//common:essential",
     ],
@@ -437,6 +452,7 @@ drake_cc_library(
     deps = [
         ":context",
         ":diagram_continuous_state",
+        ":diagram_discrete_values",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
@@ -550,7 +566,9 @@ drake_cc_googletest(
     name = "continuous_state_test",
     deps = [
         ":continuous_state",
+        ":diagram_continuous_state",
         "//common:essential",
+        "//systems/framework/test_utilities:my_vector",
     ],
 )
 
@@ -603,8 +621,11 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "discrete_values_test",
     deps = [
+        ":diagram_discrete_values",
         ":discrete_values",
         "//common:essential",
+        "//common/test_utilities:is_dynamic_castable",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -125,29 +125,32 @@ class Context {
     return get_continuous_state().get_vector();
   }
 
-  /// Returns the number of elements in the discrete state.
+  /// Returns the number of vectors (groups) in the discrete state.
   int get_num_discrete_state_groups() const {
     return get_state().get_discrete_state().num_groups();
   }
 
+  /// Returns a reference to the entire discrete state, which may consist of
+  /// multiple discrete state vectors (groups).
   const DiscreteValues<T>& get_discrete_state() const {
     return get_state().get_discrete_state();
   }
 
-  /// Returns a reference to the discrete state vector. The vector may be of
-  /// size zero.
+  /// Returns a reference to the _only_ discrete state vector. The vector may be
+  /// of size zero. Fails if there is more than one discrete state group.
   const BasicVector<T>& get_discrete_state_vector() const {
     return get_discrete_state().get_vector();
   }
 
-  /// Returns a mutable pointer to the discrete component of the state,
+  /// Returns a mutable reference to the discrete component of the state,
   /// which may be of size zero.
   DiscreteValues<T>& get_mutable_discrete_state() {
     return get_mutable_state().get_mutable_discrete_state();
   }
 
-  /// Returns a mutable pointer to element @p index of the discrete state.
-  /// Asserts if @p index doesn't exist.
+  /// Returns a mutable reference to group (vector) @p index of the discrete
+  /// state.
+  /// @pre @p index must identify an existing group.
   BasicVector<T>& get_mutable_discrete_state(int index) {
     DiscreteValues<T>& xd = get_mutable_discrete_state();
     return xd.get_mutable_vector(index);
@@ -158,8 +161,9 @@ class Context {
     get_mutable_state().set_discrete_state(std::move(xd));
   }
 
-  /// Returns a const pointer to the discrete component of the
-  /// state at @p index.  Asserts if @p index doesn't exist.
+  /// Returns a const reference to group (vector) @p index of the discrete
+  /// state.
+  /// @pre @p index must identify an existing group.
   const BasicVector<T>& get_discrete_state(int index) const {
     const DiscreteValues<T>& xd = get_state().get_discrete_state();
     return xd.get_vector(index);
@@ -182,8 +186,8 @@ class Context {
     return get_mutable_state().get_mutable_abstract_state();
   }
 
-  /// Returns a mutable pointer to element @p index of the abstract state.
-  /// Asserts if @p index doesn't exist.
+  /// Returns a mutable reference to element @p index of the abstract state.
+  /// @pre @p index must identify an existing element.
   template <typename U>
   U& get_mutable_abstract_state(int index) {
     AbstractValues& xa = get_mutable_abstract_state();
@@ -196,7 +200,8 @@ class Context {
   }
 
   /// Returns a const reference to the abstract component of the
-  /// state at @p index.  Asserts if @p index doesn't exist.
+  /// state at @p index.
+  /// @pre @p index must identify an existing element.
   template <typename U>
   const U& get_abstract_state(int index) const {
     const AbstractValues& xa = get_state().get_abstract_state();
@@ -335,13 +340,13 @@ class Context {
     return get_parameters().num_numeric_parameters();
   }
 
-  /// Returns a const pointer to the vector-valued parameter at @p index.
+  /// Returns a const reference to the vector-valued parameter at @p index.
   /// Asserts if @p index doesn't exist.
   const BasicVector<T>& get_numeric_parameter(int index) const {
     return get_parameters().get_numeric_parameter(index);
   }
 
-  /// Returns a mutable pointer to element @p index of the vector-valued
+  /// Returns a mutable reference to element @p index of the vector-valued
   /// parameters. Asserts if @p index doesn't exist.
   BasicVector<T>& get_mutable_numeric_parameter(int index) {
     return get_mutable_parameters().get_mutable_numeric_parameter(index);

--- a/systems/framework/continuous_state.h
+++ b/systems/framework/continuous_state.h
@@ -16,20 +16,35 @@
 namespace drake {
 namespace systems {
 
-/// %ContinuousState is a container for all the continuous state
-/// variables `xc`. Continuous state variables are those whose values are
-/// defined by differential equations, so we expect there to be a well-defined
-/// time derivative `xcdot` ≜ `d/dt xc`.
+/// %ContinuousState is a view of, and optionally a container for, all the
+/// continuous state variables `xc` of a Drake System. Continuous state
+/// variables are those whose values are defined by differential equations,
+/// so we expect there to be a well-defined time derivative `xcdot` ≜ `d/dt xc`.
 ///
 /// The contents of `xc` are conceptually partitioned into three groups:
-/// <pre>
-///          |------- xc ------|
-/// (index 0)|--q--|--v--|--z--|(index %xc.size() - 1)
+/// - `q` is generalized position
+/// - `v` is generalized velocity
+/// - `z` is other continuous state
 ///
-/// Where q is generalized position
-///       v is generalized velocity
-///       z is other continuous state
-/// </pre>
+/// For a Drake LeafSystem these partitions are stored contiguously in memory
+/// in this sequence: xc=[q v z]. But because a Drake System may be a Diagram
+/// composed from subsystems, each with its own continuous state variables
+/// ("substates"), the composite continuous state will not generally be stored
+/// in contiguous memory. In that case the most we can say is that xc={q,v,z},
+/// that is, it consists of all the q's, v's, and z's, in some order.
+///
+/// Nevertheless, this %ContinuousState class provides a vector
+/// view of the data that groups together all the q partitions, v
+/// partitions, and z partitions. For example, if there are three subsystems
+/// (possibly Diagrams) whose continuous state variables are respectively
+/// xc₁={q₁,v₁,z₁}, xc₂={q₂,v₂,z₂}, and xc₃={q₃,v₃,z₃} the composite xc includes
+/// all the partitions in an undefined order. However, composite q, v, and z
+/// appear ordered as q=[q₁ q₂ q₃], v=[v₁ v₂ v₃], z=[z₁ z₂ z₃]. Note that the
+/// element ordering of the composite xc is _not_ a concatenation of the
+/// composite subgroups. Do not index elements of the full state xc unless you
+/// know it is the continuous state of a LeafSystem (a LeafSystem looking at its
+/// own Context can depend on that).
+///
 /// Any of the groups may be empty. However, groups q and v must be either both
 /// present or both empty, because the time derivative `qdot` of the
 /// second-order state variables `q` must be computable using a linear mapping
@@ -39,11 +54,29 @@ namespace systems {
 /// partitions interpreted as `qdot`, `vdot`, and `zdot`. We use identical
 /// %ContinuousState objects for both.
 ///
+/// <h4>Memory ownership</h4>
+/// When a %ContinuousState represents the state of a LeafSystem, it always
+/// owns the memory that is used for the state variables and is responsible
+/// for destruction. For a Diagram, %ContinuousState can instead be a _view_
+/// of the underlying LeafSystem substates, so that modifying the Diagram's
+/// continuous state affects the LeafSystems appropriately. In that case, the
+/// memory is owned by the underlying LeafSystems. However, when a
+/// %ContinuousState object of any structure is cloned, the resulting object
+/// _always_ owns all its underlying memory, which is initialized with a copy
+/// of the original state variable values but is otherwise independent. The
+/// cloned object retains the structure and ordering of the elements and does
+/// not guarantee contiguous storage.
+/// @see DiagramContinuousState for more information.
+///
 /// @tparam T A mathematical type compatible with Eigen's Scalar.
+// TODO(sherm1) The ordering of the composite xc is useless and prevents us
+//              from describing every xc as a sequence [q v z]. Consider
+//              reimplementing so that xc=[q₁q₂ v₁v₂ z₁z₂].
 template <typename T>
 class ContinuousState {
  public:
-  // ContinuousState is not copyable or moveable.
+  // ContinuousState is not copyable or moveable, but can be cloned with some
+  // caveats.
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContinuousState)
 
   /// Constructs a ContinuousState for a system that does not have second-order
@@ -95,8 +128,30 @@ class ContinuousState {
 
   virtual ~ContinuousState() {}
 
-  /// Returns the size of the entire continuous state vector.
+  /// Creates a deep copy of this object with the same substructure but with all
+  /// data owned by the copy. That is, if the original was a Diagram continuous
+  /// state that merely referenced substates, the clone will not include any
+  /// references to the original substates and is thus decoupled from the
+  /// Context containing the original. The concrete type of the BasicVector
+  /// underlying each leaf ContinuousState is preserved. See the class comments
+  /// above for more information.
+  std::unique_ptr<ContinuousState<T>> Clone() const {
+    return std::unique_ptr<ContinuousState<T>>(DoClone());
+  }
+
+  /// Returns the size of the entire continuous state vector, which is
+  /// necessarily `num_q + num_v + num_z`.
   int size() const { return get_vector().size(); }
+
+  /// Returns the number of generalized positions q in this state vector.
+  int num_q() const { return get_generalized_position().size(); }
+
+  /// Returns the number of generalized velocities v in this state vector.
+  int num_v() const { return get_generalized_velocity().size(); }
+
+  /// Returns the number of miscellaneous continuous state variables z
+  /// in this state vector.
+  int num_z() const { return get_misc_continuous_state().size(); }
 
   T& operator[](std::size_t idx) { return (*state_)[idx]; }
   const T& operator[](std::size_t idx) const { return (*state_)[idx]; }
@@ -149,7 +204,6 @@ class ContinuousState {
     return *misc_continuous_state_.get();
   }
 
-
   /// Copies the values from another ContinuousState of the same scalar type
   /// into this State.
   void CopyFrom(const ContinuousState<T>& other) {
@@ -193,35 +247,42 @@ class ContinuousState {
     DRAKE_ASSERT_VOID(DemandInvariants());
   }
 
+  /// DiagramContinuousState must override this to maintain the necessary
+  /// internal substructure, and to perform a deep copy so that the result
+  /// owns all its own data. The default implementation here requires that the
+  /// full state is a BasicVector (that is, this is a leaf continuous state).
+  /// The BasicVector is cloned to preserve its concrete type and contents,
+  /// then the q, v, z Subvectors are created referencing it.
+  virtual std::unique_ptr<ContinuousState> DoClone() const {
+    auto state = dynamic_cast<const BasicVector<T>*>(state_.get());
+    DRAKE_DEMAND(state != nullptr);
+    return std::make_unique<ContinuousState>(state->Clone(), num_q(), num_v(),
+                                             num_z());
+  }
+
  private:
   template <typename U>
   void SetFromGeneric(const ContinuousState<U>& other) {
     DRAKE_DEMAND(size() == other.size());
-    DRAKE_DEMAND(get_generalized_position().size() ==
-        other.get_generalized_position().size());
-    DRAKE_DEMAND(get_generalized_velocity().size() ==
-        other.get_generalized_velocity().size());
-    DRAKE_DEMAND(get_misc_continuous_state().size() ==
-        other.get_misc_continuous_state().size());
+    DRAKE_DEMAND(num_q() == other.num_q());
+    DRAKE_DEMAND(num_v() == other.num_v());
+    DRAKE_DEMAND(num_z() == other.num_z());
     SetFromVector(other.CopyToVector().template cast<T>());
   }
 
   // Demand that the representation invariants hold.
   void DemandInvariants() const {
     // Nothing is nullptr.
-    DRAKE_DEMAND(!!generalized_position_);
-    DRAKE_DEMAND(!!generalized_velocity_);
-    DRAKE_DEMAND(!!misc_continuous_state_);
+    DRAKE_DEMAND(generalized_position_ != nullptr);
+    DRAKE_DEMAND(generalized_velocity_ != nullptr);
+    DRAKE_DEMAND(misc_continuous_state_ != nullptr);
 
     // The sizes are consistent.
-    const int num_q = generalized_position_->size();
-    const int num_v = generalized_velocity_->size();
-    const int num_z = misc_continuous_state_->size();
-    const int num_total = (num_q + num_v + num_z);
-    DRAKE_DEMAND(num_q >= 0);
-    DRAKE_DEMAND(num_v >= 0);
-    DRAKE_DEMAND(num_z >= 0);
-    DRAKE_DEMAND(num_v <= num_q);
+    DRAKE_DEMAND(num_q() >= 0);
+    DRAKE_DEMAND(num_v() >= 0);
+    DRAKE_DEMAND(num_z() >= 0);
+    DRAKE_DEMAND(num_v() <= num_q());
+    const int num_total = (num_q() + num_v() + num_z());
     DRAKE_DEMAND(state_->size() == num_total);
 
     // The storage addresses of `state_` elements contain no duplicates.
@@ -237,17 +298,17 @@ class ContinuousState {
     // Therefore, the `state_` vector and (q, v, z) vectors form views into the
     // same unique underlying data, just with different indexing.
     std::unordered_set<const T*> qvz_element_pointers;
-    for (int i = 0; i < num_q; ++i) {
+    for (int i = 0; i < num_q(); ++i) {
       const T* element = &(generalized_position_->GetAtIndex(i));
       qvz_element_pointers.emplace(element);
       DRAKE_DEMAND(state_element_pointers.count(element) == 1);
     }
-    for (int i = 0; i < num_v; ++i) {
+    for (int i = 0; i < num_v(); ++i) {
       const T* element = &(generalized_velocity_->GetAtIndex(i));
       qvz_element_pointers.emplace(element);
       DRAKE_DEMAND(state_element_pointers.count(element) == 1);
     }
-    for (int i = 0; i < num_z; ++i) {
+    for (int i = 0; i < num_z(); ++i) {
       const T* element = &(misc_continuous_state_->GetAtIndex(i));
       qvz_element_pointers.emplace(element);
       DRAKE_DEMAND(state_element_pointers.count(element) == 1);

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -9,10 +9,4 @@ DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::internal::DiagramOutput)
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::internal::DiagramTimeDerivatives)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::internal::DiagramDiscreteVariables)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Diagram)

--- a/systems/framework/diagram_continuous_state.h
+++ b/systems/framework/diagram_continuous_state.h
@@ -6,17 +6,29 @@
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/supervector.h"
 
 namespace drake {
 namespace systems {
 
-/// DiagramContinuousState is a ContinuousState consisting of Supervectors
-/// over a set of constituent ContinuousStates.
+/// %DiagramContinuousState is a ContinuousState consisting of Supervectors
+/// xc, q, v, z over the corresponding entries in a set of referenced
+/// ContinuousState objects, which may or may not be owned by this
+/// %DiagramContinuousState. This is done recursively since any of the
+/// referenced ContinuousState objects could themselves be
+/// %DiagramContinuousState objects. The actual numerical data is always
+/// contained in the leaf ContinuousState objects at the bottom of the tree.
+///
+/// This object is used both for a Diagram's actual continuous state variables
+/// xc (with partitions q, v, z) and for the time derivatives xdot (qdot, vdot,
+/// zdot). Cloning a %DiagramContinuousState results in an object with identical
+/// structure, but which owns the referenced ContinuousState objects, regardless
+/// of whether the original had ownership.
 ///
 /// @tparam T The type of the output data. Must be a valid Eigen scalar.
 template <typename T>
-class DiagramContinuousState : public ContinuousState<T> {
+class DiagramContinuousState final: public ContinuousState<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramContinuousState)
 
@@ -24,37 +36,68 @@ class DiagramContinuousState : public ContinuousState<T> {
   /// which are not owned by this object and must outlive it.
   ///
   /// The DiagramContinuousState vector xc = [q v z] will have the same
-  /// ordering as the @p substates parameter, which should be the order of
-  /// the Diagram itself. This fact is an implementation detail that should
-  /// only be of interest to framework authors. Everyone else can just use
-  /// Diagram<T>::GetMutableSubsystemState.
+  /// ordering as the `substates` parameter, which should be the order of
+  /// the Diagram itself. That is, the substates should be indexed by
+  /// SubsystemIndex in the same order as the subsystems are. */
   explicit DiagramContinuousState(std::vector<ContinuousState<T>*> substates)
       : ContinuousState<T>(
             Span(substates, x_selector), Span(substates, q_selector),
             Span(substates, v_selector), Span(substates, z_selector)),
-        substates_(std::move(substates)) {}
+        substates_(std::move(substates)) {
+    DRAKE_ASSERT(internal::IsNonNull(substates_));
+  }
+
+  /// Constructs a ContinuousState that is composed (recursively) of other
+  /// ContinuousState objects, ownership of which is transferred here.
+  explicit DiagramContinuousState(
+      std::vector<std::unique_ptr<ContinuousState<T>>> substates)
+      : DiagramContinuousState<T>(internal::Unpack(substates)) {
+      owned_substates_ = std::move(substates);
+    DRAKE_ASSERT(internal::IsNonNull(owned_substates_));
+  }
 
   ~DiagramContinuousState() override {}
 
-  int get_num_substates() const { return static_cast<int>(substates_.size()); }
+  /// Creates a deep copy of this %DiagramContinuousState, with the same
+  /// substructure but with new, owned data. Intentionally shadows the
+  /// ContinuousState::Clone() method but with a more-specific return type so
+  /// you don't have to downcast.
+  std::unique_ptr<DiagramContinuousState> Clone() const {
+    // Note that DoClone() below cannot be overridden so we can count on the
+    // concrete type being DiagramContinuousState.
+    return std::unique_ptr<DiagramContinuousState>(
+        static_cast<DiagramContinuousState*>(DoClone().release()));
+  }
 
-  /// Returns the continuous state at the given @p index. Aborts if @p index is
+  int num_substates() const { return static_cast<int>(substates_.size()); }
+
+  /// Returns the continuous state at the given `index`. Aborts if `index` is
   /// out-of-bounds.
   const ContinuousState<T>& get_substate(int index) const {
-    DRAKE_DEMAND(index >= 0 && index < get_num_substates());
+    DRAKE_DEMAND(0 <= index && index < num_substates());
+    DRAKE_DEMAND(substates_[index] != nullptr);
     return *substates_[index];
   }
 
-  /// Returns the continuous state at the given @p index. Aborts if @p index is
+  /// Returns the continuous state at the given `index`. Aborts if `index` is
   /// out-of-bounds.
   ContinuousState<T>& get_mutable_substate(int index) {
-    DRAKE_DEMAND(index >= 0 && index < get_num_substates());
-    return *substates_[index];
+    return const_cast<ContinuousState<T>&>(get_substate(index));
   }
 
  private:
+  // This completely replaces the base class default DoClone() so must
+  // take care of the base class members as well as the local ones.
+  // The returned concrete object is a DiagramContinuousState<T>.
+  std::unique_ptr<ContinuousState<T>> DoClone() const final {
+    std::vector<std::unique_ptr<ContinuousState<T>>> owned_states;
+    // Make deep copies regardless of whether they were owned.
+    for (auto state : substates_) owned_states.push_back(state->Clone());
+    return std::make_unique<DiagramContinuousState>(std::move(owned_states));
+  }
+
   // Returns a Supervector over the x, q, v, or z components of each
-  // substate in @p substates, as indicated by @p selector.
+  // substate in `substates`, as indicated by `selector`.
   static std::unique_ptr<VectorBase<T>> Span(
       const std::vector<ContinuousState<T>*>& substates,
       std::function<VectorBase<T>&(ContinuousState<T>*)> selector) {
@@ -66,24 +109,31 @@ class DiagramContinuousState : public ContinuousState<T> {
     return std::make_unique<Supervector<T>>(sub_xs);
   }
 
-  // Returns the entire state vector in @p xc.
+  // Returns the entire state vector in `xc`.
   static VectorBase<T>& x_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_vector();
   }
-  // Returns the generalized position vector in @p xc.
+  // Returns the generalized position vector in `xc`.
   static VectorBase<T>& q_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_generalized_position();
   }
-  // Returns the generalized velocity vector in @p xc.
+  // Returns the generalized velocity vector in `xc`.
   static VectorBase<T>& v_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_generalized_velocity();
   }
-  // Returns the misc continuous state vector in @p xc.
+  // Returns the misc continuous state vector in `xc`.
   static VectorBase<T>& z_selector(ContinuousState<T>* xc) {
     return xc->get_mutable_misc_continuous_state();
   }
 
+  // Pointers to the underlying ContinuousStates that provide the actual
+  // values. If these are owned, the pointers are equal to the pointers in
+  // owned_substates_.
   std::vector<ContinuousState<T>*> substates_;
+  // Owned pointers to ContinuousState objects that hold the actual values.
+  // The only purpose of these pointers is to maintain ownership. They may be
+  // populated at construction time, and are never accessed thereafter.
+  std::vector<std::unique_ptr<ContinuousState<T>>> owned_substates_;
 };
 
 }  // namespace systems

--- a/systems/framework/diagram_discrete_values.cc
+++ b/systems/framework/diagram_discrete_values.cc
@@ -1,0 +1,6 @@
+#include "drake/systems/framework/diagram_discrete_values.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramDiscreteValues)

--- a/systems/framework/diagram_discrete_values.h
+++ b/systems/framework/diagram_discrete_values.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/discrete_values.h"
+#include "drake/systems/framework/framework_common.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/// DiagramDiscreteValues is a DiscreteValues container comprised recursively of
+/// a sequence of child DiscreteValues objects. The API allows this to be
+/// treated as though it were a single DiscreteValues object whose groups are
+/// the concatenation of the groups in each child.
+///
+/// The child objects may be owned or not. When this is used to aggregate
+/// LeafSystem discrete values in a Diagram, the child objects are not owned.
+/// When this is cloned, deep copies are made that are owned here.
+template <typename T>
+class DiagramDiscreteValues final: public DiscreteValues<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramDiscreteValues)
+
+  /// Constructs a DiagramDiscreteValues object that is composed of other
+  /// DiscreteValues, which are not owned by this object and must outlive it.
+  ///
+  /// The DiagramDiscreteValues vector xd = [xd₁ xd₂ ...] where each of the xdᵢ
+  /// is an array of BasicVector objects. These will have the same
+  /// ordering as the @p subdiscretes parameter, which should be the order of
+  /// the Diagram itself. That is, the substates should be indexed by
+  /// SubsystemIndex in the same order as the subsystems are.
+  explicit DiagramDiscreteValues(std::vector<DiscreteValues<T>*> subdiscretes)
+      : DiscreteValues<T>(Flatten(subdiscretes)),
+        subdiscretes_(std::move(subdiscretes)) {
+    DRAKE_ASSERT(internal::IsNonNull(subdiscretes_));
+  }
+
+  /// Constructs a DiagramDiscreteValues object that is composed (recursively)
+  /// of other DiscreteValues objects, ownership of which is transferred here.
+  explicit DiagramDiscreteValues(
+      std::vector<std::unique_ptr<DiscreteValues<T>>> owned_subdiscretes)
+      : DiagramDiscreteValues<T>(internal::Unpack(owned_subdiscretes)) {
+    owned_subdiscretes_ = std::move(owned_subdiscretes);
+    DRAKE_ASSERT(internal::IsNonNull(owned_subdiscretes_));
+  }
+
+  /// Destructor deletes any owned DiscreteValues objects but does nothing if
+  /// the referenced DiscreteValues objects are unowned.
+  ~DiagramDiscreteValues() override {}
+
+  /// Creates a deep copy of this %DiagramDiscreteValues object, with the same
+  /// substructure but with new, owned data. Intentionally shadows the
+  /// DiscreteValues::Clone() method but with a more-specific return type so
+  /// you don't have to downcast.
+  std::unique_ptr<DiagramDiscreteValues> Clone() const {
+    // Note that DoClone() below cannot be overridden so we can count on the
+    // concrete type being DiagramDiscreteValues.
+    return std::unique_ptr<DiagramDiscreteValues>(
+        static_cast<DiagramDiscreteValues*>(DoClone().release()));
+  }
+
+  /// Returns the number of DiscreteValues objects referenced by this
+  /// %DiagramDiscreteValues object, necessarily the same as the number of
+  /// subcontexts in the containing DiagramContext.
+  int num_subdiscretes() const {
+    return static_cast<int>(subdiscretes_.size());
+  }
+
+  /// Returns a const reference to one of the referenced DiscreteValues
+  /// objects which may or may not be owned locally.
+  const DiscreteValues<T>& get_subdiscrete(SubsystemIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_subdiscretes());
+    DRAKE_DEMAND(subdiscretes_[index] != nullptr);
+    return *subdiscretes_[index];
+  }
+
+  /// Returns a mutable reference to one of the referenced DiscreteValues
+  /// objects which may or may not be owned locally.
+  DiscreteValues<T>& get_mutable_subdiscrete(SubsystemIndex index) {
+    return const_cast<DiscreteValues<T>&>(get_subdiscrete(index));
+  }
+
+ private:
+  // This completely replaces the base class default DoClone() so must
+  // take care of the base class members as well as the local ones. That's done
+  // by invoking a constructor that delegates to the base.
+  // The returned concrete object is a DiagramDiscreteValues<T>.
+  std::unique_ptr<DiscreteValues<T>> DoClone() const final {
+    std::vector<std::unique_ptr<DiscreteValues<T>>> owned_subdiscretes;
+    // Make deep copies regardless of whether they were owned.
+    for (auto discrete : subdiscretes_)
+      owned_subdiscretes.push_back(discrete->Clone());
+    return std::make_unique<DiagramDiscreteValues>(
+        std::move(owned_subdiscretes));
+  }
+
+  // Given a vector of DiscreteValues pointers, each potentially containing
+  // multiple BasicVectors, return a longer vector of pointers to all the
+  // contained BasicVectors, unpacked in order. Because each of the referenced
+  // DiscreteValues has been similarly unpacked, the result is a complete, flat
+  // list of all the leaf BasicVectors below `this` DiagramDiscreteValues.
+  std::vector<BasicVector<T>*> Flatten(
+      const std::vector<DiscreteValues<T>*>& in) const {
+    std::vector<BasicVector<T>*> out;
+    for (const DiscreteValues<T>* xd : in) {
+      const std::vector<BasicVector<T>*>& xd_data = xd->get_data();
+      out.insert(out.end(), xd_data.begin(), xd_data.end());
+    }
+    return out;
+  }
+
+  // Pointers to the underlying DiscreteValues objects that provide the actual
+  // values. If these are owned, the pointers are equal to the pointers in
+  // owned_subdiscretes_.
+  std::vector<DiscreteValues<T>*> subdiscretes_;
+
+  // Owned pointers to DiscreteValues objects that hold the actual values.
+  // The only purpose of these pointers is to maintain ownership. They may be
+  // populated at construction time, and are never accessed thereafter.
+  std::vector<std::unique_ptr<DiscreteValues<T>>> owned_subdiscretes_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/discrete_values.cc
+++ b/systems/framework/discrete_values.cc
@@ -4,3 +4,4 @@
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::DiscreteValues)
+

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -158,6 +158,35 @@ enum BuiltInTicketNumbers {
   kNextAvailableTicket  = kXdhatTicket+1
 };
 
+// These are some utility methods that are reused within the framework.
+
+// Returns a vector of raw pointers that correspond placewise with the
+// unique_ptrs in the vector `in`.
+template<typename U>
+std::vector<U*> Unpack(const std::vector<std::unique_ptr<U>>& in) {
+  std::vector<U*> out(in.size());
+  std::transform(in.begin(), in.end(), out.begin(),
+                 [](const std::unique_ptr<U>& p) { return p.get(); });
+  return out;
+}
+
+// Checks a vector of pointer-like objects to make sure no entries are null,
+// return false otherwise. Use this as a Debug-only check:
+// @code{.cpp}
+//   std::vector<Thing*> things;
+//   std::vector<std::unique_ptr<Thing> owned_things;
+//   DRAKE_ASSERT(internal::IsNonNull(things));
+//   DRAKE_ASSERT(internal::IsNonNull(owned_things);
+// @endcode
+// This function can be applied to an std::vector of any type T that can be
+// meaningfully compared to `nullptr`.
+template <typename PtrType>
+bool IsNonNull(const std::vector<PtrType>& pointers) {
+  for (const PtrType& p : pointers)
+    if (p == nullptr) return false;
+  return true;
+}
+
 }  // namespace internal
 #endif
 

--- a/systems/framework/test/continuous_state_test.cc
+++ b/systems/framework/test/continuous_state_test.cc
@@ -1,3 +1,6 @@
+// This test covers ContinuousState (used directly by LeafContexts) and its
+// derived class DiagramContinuousState (for DiagramContexts).
+
 #include "drake/systems/framework/continuous_state.h"
 
 #include <memory>
@@ -6,11 +9,21 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/diagram_continuous_state.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/vector_base.h"
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using Eigen::VectorXd;
 
 namespace drake {
 namespace systems {
 namespace {
+
+typedef Eigen::Matrix<double, 5, 1> Vector5d;
+typedef Eigen::Matrix<double, 6, 1> Vector6d;
 
 constexpr int kPositionLength = 2;
 constexpr int kVelocityLength = 1;
@@ -20,6 +33,8 @@ constexpr int kLength = kPositionLength + kVelocityLength + kMiscLength;
 std::unique_ptr<VectorBase<double>> MakeSomeVector() {
   return BasicVector<double>::Make({1, 2, 3, 4});
 }
+
+// Tests for ContinuousState.
 
 class ContinuousStateTest : public ::testing::Test {
  protected:
@@ -102,6 +117,227 @@ TEST_F(ContinuousStateTest, CopyFrom) {
   EXPECT_EQ(2, next_state[1]);
   EXPECT_EQ(3, next_state[2]);
   EXPECT_EQ(4, next_state[3]);
+}
+
+// This is testing the default implementation of Clone() for when a
+// ContinuousState is used as a concrete object. A DiagramContinuousState has
+// to do more but that is not tested here.
+TEST_F(ContinuousStateTest, Clone) {
+  auto clone_ptr = continuous_state_->Clone();
+  const ContinuousState<double>& clone = *clone_ptr;
+
+  EXPECT_EQ(1, clone[0]);
+  EXPECT_EQ(2, clone[1]);
+  EXPECT_EQ(3, clone[2]);
+  EXPECT_EQ(4, clone[3]);
+
+  // Make sure underlying BasicVector type, and 2nd-order structure,
+  // is preserved in the clone.
+  ContinuousState<double> state(MyVector<3, double>::Make(1.25, 1.5, 1.75),
+                                2, 1, 0);
+  clone_ptr = state.Clone();
+  const ContinuousState<double>& clone2 = *clone_ptr;
+  EXPECT_EQ(clone2[0], 1.25);
+  EXPECT_EQ(clone2[1], 1.5);
+  EXPECT_EQ(clone2[2], 1.75);
+  EXPECT_EQ(clone2.num_q(), 2);
+  EXPECT_EQ(clone2.num_v(), 1);
+  EXPECT_EQ(clone2.num_z(), 0);
+  EXPECT_EQ(clone2.get_generalized_position()[0], 1.25);
+  EXPECT_EQ(clone2.get_generalized_position()[1], 1.5);
+  EXPECT_EQ(clone2.get_generalized_velocity()[0], 1.75);
+
+  auto vector = dynamic_cast<const MyVector<3, double>*>(&clone2.get_vector());
+  ASSERT_NE(vector, nullptr);
+  EXPECT_EQ((*vector)[0], 1.25);
+  EXPECT_EQ((*vector)[1], 1.5);
+  EXPECT_EQ((*vector)[2], 1.75);
+}
+
+// Tests for DiagramContinousState.
+
+class DiagramContinuousStateTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    state0_.reset(
+        new ContinuousState<double>(MyVector3d::Make(1, 2, 3), 1, 1, 1));
+    state1_.reset(new ContinuousState<double>(
+        BasicVector<double>::Make(4, 5, 6, 7, 8), 2, 1, 2));
+    state2_.reset(new ContinuousState<double>(
+        BasicVector<double>::Make(10, 11), 0, 0, 2));
+    state3_.reset(new ContinuousState<double>(
+        BasicVector<double>::Make(-1, -2, -3, -4), 2, 1, 1));
+
+    // Expected contents, with expected number of q/v/z variables.
+    // unowned 3q 2v 5z
+    //   state0 q v z           1       2     3
+    //   state1 2q v 2z         4,5     6     7,8
+    //   state2 2z                            10,11
+    unowned_.reset(new DiagramContinuousState<double>(
+        {&*state0_, &*state1_, &*state2_}));
+
+    // root_unowned 5q 3v 6z
+    //   state3 2q v z         -1,-2    -3    -4
+    //   unowned 3q 2v 5z      1,4,5    2,6   3,7,8,10,11
+    //     state0
+    //     state1
+    //     state2
+    root_unowned_.reset(
+        new DiagramContinuousState<double>({&*state3_, &*unowned_}));
+
+    std::vector<std::unique_ptr<ContinuousState<double>>> copies;
+    copies.emplace_back(state3_->Clone());
+    copies.emplace_back(unowned_->Clone());
+    copies.emplace_back(state1_->Clone());
+
+    // root_owned 7q 4v 8z
+    //   state3 (copy) 2q v z         -1,-2    -3     -4
+    //   unowned (copy) 3q 2v 5z      1,4,5    2,6    3,7,8,10,11
+    //     state0 (copy)
+    //     state1 (copy)
+    //     state2 (copy)
+    //   state1 (copy) 2q v 2z        4,5       6     7,8
+    root_owned_.reset(new DiagramContinuousState<double>(std::move(copies)));
+  }
+
+  std::unique_ptr<ContinuousState<double>> state0_, state1_, state2_, state3_;
+  // These are created using the "unowned" constructor.
+  std::unique_ptr<DiagramContinuousState<double>> unowned_, root_unowned_;
+  // This is created using the "owned" constructor.
+  std::unique_ptr<DiagramContinuousState<double>> root_owned_;
+};
+
+// See above for number of substates and their identities.
+TEST_F(DiagramContinuousStateTest, Substates) {
+  EXPECT_EQ(unowned_->num_substates(), 3);
+  EXPECT_EQ(root_unowned_->num_substates(), 2);
+  EXPECT_EQ(root_owned_->num_substates(), 3);
+
+  EXPECT_EQ(&unowned_->get_substate(0), &*state0_);
+  EXPECT_EQ(&unowned_->get_substate(1), &*state1_);
+  EXPECT_EQ(&unowned_->get_substate(2), &*state2_);
+
+  EXPECT_EQ(&root_unowned_->get_substate(0), &*state3_);
+  EXPECT_EQ(&root_unowned_->get_substate(1), &*unowned_);
+
+  // The root_owned substates must be copies.
+  EXPECT_NE(&root_owned_->get_substate(0), &*state3_);
+  EXPECT_NE(&root_owned_->get_substate(1), &*unowned_);
+  EXPECT_NE(&root_owned_->get_substate(2), &*state1_);
+
+  // Just make sure get_mutable_substate() exists and works.
+  EXPECT_EQ(&unowned_->get_mutable_substate(1), &*state1_);
+}
+
+// See above for expected dimensions.
+TEST_F(DiagramContinuousStateTest, Counts) {
+  EXPECT_EQ(unowned_->size(), 10);
+  EXPECT_EQ(unowned_->num_q(), 3);
+  EXPECT_EQ(unowned_->num_v(), 2);
+  EXPECT_EQ(unowned_->num_z(), 5);
+
+  EXPECT_EQ(root_unowned_->size(), 14);
+  EXPECT_EQ(root_unowned_->num_q(), 5);
+  EXPECT_EQ(root_unowned_->num_v(), 3);
+  EXPECT_EQ(root_unowned_->num_z(), 6);
+
+  EXPECT_EQ(root_owned_->size(), 19);
+  EXPECT_EQ(root_owned_->num_q(), 7);
+  EXPECT_EQ(root_owned_->num_v(), 4);
+  EXPECT_EQ(root_owned_->num_z(), 8);
+}
+
+// See above for expected values.
+TEST_F(DiagramContinuousStateTest, Values) {
+  // Asking for the whole value x treats all substates as whole values xi
+  // so the ordering is x={x0,x1,x2, ...} which means the q's v's and z's
+  // are all mixed together rather than grouped.
+  const VectorXd unowned_value = unowned_->CopyToVector();
+  VectorXd unowned_expected(10);
+  unowned_expected << 1,      2,   3,       // state0
+                      4, 5,   6,   7, 8,    // state1
+                                   10, 11;  // state2
+  EXPECT_EQ(unowned_value, unowned_expected);
+
+  // Asking for individual partitions groups like variables together.
+  const VectorXd unowned_q =
+      unowned_->get_generalized_position().CopyToVector();
+  const VectorXd unowned_v =
+      unowned_->get_generalized_velocity().CopyToVector();
+  const VectorXd unowned_z =
+      unowned_->get_misc_continuous_state().CopyToVector();
+
+  EXPECT_EQ(unowned_q, Vector3d(1, 4, 5));
+  EXPECT_EQ(unowned_v, Vector2d(2, 6));
+  Vector5d unowned_z_expected;
+  unowned_z_expected << 3, 7, 8, 10, 11;
+  EXPECT_EQ(unowned_z, unowned_z_expected);
+
+  const VectorXd root_unowned_value = root_unowned_->CopyToVector();
+  VectorXd root_unowned_expected(14);
+  root_unowned_expected << -1, -2, -3, -4,                   // state3
+                            1, 2, 3, 4, 5, 6, 7, 8, 10, 11;  // unowned
+  EXPECT_EQ(root_unowned_value, root_unowned_expected);
+
+  const VectorXd root_unowned_q =
+      root_unowned_->get_generalized_position().CopyToVector();
+  const VectorXd root_unowned_v =
+      root_unowned_->get_generalized_velocity().CopyToVector();
+  const VectorXd root_unowned_z =
+      root_unowned_->get_misc_continuous_state().CopyToVector();
+
+  Vector5d root_unowned_q_expected;
+  root_unowned_q_expected << -1, -2, 1, 4, 5;
+  EXPECT_EQ(root_unowned_q, root_unowned_q_expected);
+  EXPECT_EQ(root_unowned_v, Vector3d(-3, 2, 6));
+
+  Vector6d root_unowned_z_expected;
+  root_unowned_z_expected << -4, 3, 7, 8, 10, 11;
+  EXPECT_EQ(root_unowned_z, root_unowned_z_expected);
+
+  const VectorXd root_owned_value = root_owned_->CopyToVector();
+  VectorXd root_owned_expected(19);
+  root_owned_expected << -1, -2, -3, -4,                   // state3
+                          1, 2, 3, 4, 5, 6, 7, 8, 10, 11,  // unowned
+                          4, 5, 6, 7, 8;                   // state1
+  EXPECT_EQ(root_owned_value, root_owned_expected);
+
+  const VectorXd root_owned_q =
+      root_owned_->get_generalized_position().CopyToVector();
+  const VectorXd root_owned_v =
+      root_owned_->get_generalized_velocity().CopyToVector();
+  const VectorXd root_owned_z =
+      root_owned_->get_misc_continuous_state().CopyToVector();
+
+  VectorXd root_owned_q_expected(7);
+  root_owned_q_expected << -1, -2, 1, 4, 5, 4, 5;
+  EXPECT_EQ(root_owned_q, root_owned_q_expected);
+  EXPECT_EQ(root_owned_v, Vector4d(-3, 2, 6, 6));
+  VectorXd root_owned_z_expected(8);
+  root_owned_z_expected << -4, 3, 7, 8, 10, 11, 7, 8;
+  EXPECT_EQ(root_owned_z, root_owned_z_expected);
+}
+
+// Check that Clone() results in new memory being allocated by modifying that
+// memory and observing that it doesn't change the original. We'll assume that
+// means the new DiagramContinuousState has ownership. (We're not checking for
+// memory leaks here -- that's for Valgrind.)
+TEST_F(DiagramContinuousStateTest, Clone) {
+  // unowned is singly-nested, root_unowned is doubly-nested.
+  auto clone_of_unowned = unowned_->Clone();
+  auto clone_of_root_unowned = root_unowned_->Clone();
+
+  // Show that values got copied.
+  for (int i=0; i < unowned_->size(); ++i)
+    EXPECT_EQ((*clone_of_unowned)[i], (*unowned_)[i]);
+  for (int i=0; i < root_unowned_->size(); ++i)
+    EXPECT_EQ((*clone_of_root_unowned)[i], (*root_unowned_)[i]);
+
+  (*state0_)[1] = 99;  // Should affect unowned but not the clones (was 2).
+  EXPECT_EQ((*unowned_)[1], 99);
+  EXPECT_EQ((*clone_of_unowned)[1], 2);
+  EXPECT_EQ((*root_unowned_)[5], 99);
+  EXPECT_EQ((*clone_of_root_unowned)[5], 2);
 }
 
 }  // namespace

--- a/systems/framework/test/discrete_values_test.cc
+++ b/systems/framework/test/discrete_values_test.cc
@@ -1,3 +1,6 @@
+// This test covers DiscreteValues (used directly by LeafContexts) and its
+// derived class DiagramDiscreteValues (for DiagramContexts).
+
 #include "drake/systems/framework/discrete_values.h"
 
 #include <memory>
@@ -6,7 +9,14 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/diagram_discrete_values.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
+
+using Eigen::Vector2d;
+using Eigen::Vector3d;
+using Eigen::VectorXd;
 
 namespace drake {
 namespace systems {
@@ -15,29 +25,34 @@ namespace {
 class DiscreteValuesTest : public ::testing::Test {
  public:
   DiscreteValuesTest() {
-    data_.push_back(BasicVector<double>::Make({1.0, 1.0}));
-    data_.push_back(BasicVector<double>::Make({2.0, 3.0}));
+    data_.push_back(std::make_unique<BasicVector<double>>(v00_));
+    data_.push_back(std::make_unique<MyVector2d>(v01_));
+    data1_.push_back(std::make_unique<BasicVector<double>>(v10_));
+    data1_.push_back(std::make_unique<MyVector3d>(v11_));
+    data1_.push_back(std::make_unique<MyVector2d>(v12_));
   }
 
  protected:
+  const VectorXd v00_ = Vector2d{1., 1.},
+                 v01_ = Vector2d{2., 3.},
+                 v10_ = Vector3d{9., 10., 11.},
+                 v11_ = Vector3d{-1.25, -2.5, -3.75},
+                 v12_ = Vector2d{5., 6.};
   std::vector<std::unique_ptr<BasicVector<double>>> data_;
+  std::vector<std::unique_ptr<BasicVector<double>>> data1_;
 };
 
 TEST_F(DiscreteValuesTest, OwnedState) {
   DiscreteValues<double> xd(std::move(data_));
-  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_vector(1).GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_vector(1).GetAtIndex(1));
+  EXPECT_EQ(xd.get_vector(0).get_value(), v00_);
+  EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
 }
 
 TEST_F(DiscreteValuesTest, UnownedState) {
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
-  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(0));
-  EXPECT_EQ(1.0, xd.get_vector(0).GetAtIndex(1));
-  EXPECT_EQ(2.0, xd.get_vector(1).GetAtIndex(0));
-  EXPECT_EQ(3.0, xd.get_vector(1).GetAtIndex(1));
+  EXPECT_EQ(xd.get_vector(0).get_value(), v00_);
+  EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
 }
 
 TEST_F(DiscreteValuesTest, NoNullsAllowed) {
@@ -50,14 +65,29 @@ TEST_F(DiscreteValuesTest, NoNullsAllowed) {
   EXPECT_THROW(DiscreteValues<double>(std::move(data_)), std::logic_error);
 }
 
+// Clone should be deep, even for unowned data.
 TEST_F(DiscreteValuesTest, Clone) {
+  // Create a DiscreteValues object with unowned contents.
   DiscreteValues<double> xd(
       std::vector<BasicVector<double>*>{data_[0].get(), data_[1].get()});
   std::unique_ptr<DiscreteValues<double>> clone = xd.Clone();
-  EXPECT_EQ(1.0, clone->get_vector(0).GetAtIndex(0));
-  EXPECT_EQ(1.0, clone->get_vector(0).GetAtIndex(1));
-  EXPECT_EQ(2.0, clone->get_vector(1).GetAtIndex(0));
-  EXPECT_EQ(3.0, clone->get_vector(1).GetAtIndex(1));
+
+  // First check that the clone has the original values.
+  EXPECT_EQ(clone->get_vector(0).get_value(), v00_);
+  EXPECT_EQ(clone->get_vector(1).get_value(), v01_);
+
+  // Set the clone's new values.
+  Eigen::Vector2d new0(9., 10.), new1(1.25, 2.5);
+  clone->get_mutable_vector(0).set_value(new0);
+  clone->get_mutable_vector(1).set_value(new1);
+
+  // Check that the clone changed correctly.
+  EXPECT_EQ(clone->get_vector(0).get_value(), new0);
+  EXPECT_EQ(clone->get_vector(1).get_value(), new1);
+
+  // Check that the original remains unchanged.
+  EXPECT_EQ(xd.get_vector(0).get_value(), v00_);
+  EXPECT_EQ(xd.get_vector(1).get_value(), v01_);
 }
 
 TEST_F(DiscreteValuesTest, SetFrom) {
@@ -84,6 +114,86 @@ GTEST_TEST(DiscreteValuesSingleGroupTest, ConvenienceSugar) {
   EXPECT_EQ(100.0, xd.get_vector().GetAtIndex(0));
   xd.get_mutable_vector().SetAtIndex(1, 1000.0);
   EXPECT_EQ(1000.0, xd[1]);
+}
+
+// For DiagramDiscreteValues we want to check that we can build a tree of
+// unowned DiscreteValues but then Clone() produces an identical tree of
+// owned DiscreteValues, with underlying BasicVector types preserved.
+// Below b=basic vector, m=myvector.
+TEST_F(DiscreteValuesTest, DiagramDiscreteValues) {
+  DiscreteValues<double> dv0(std::move(data_));   // 2 groups size (b2,m2)
+  DiscreteValues<double> dv1(std::move(data1_));  // 3 groups size (b3,m3,m2)
+  auto dv2ptr = dv0.Clone(), dv3ptr = dv1.Clone();
+  DiscreteValues<double>& dv2 = *dv2ptr;  // 2 groups size (b2,m2)
+  DiscreteValues<double>& dv3 = *dv3ptr;  // 3 groups size (b3,m3,m2)
+  EXPECT_EQ(dv0.num_groups(), 2);
+  EXPECT_EQ(dv1.num_groups(), 3);
+  EXPECT_EQ(dv2.num_groups(), 2);
+  EXPECT_EQ(dv3.num_groups(), 3);
+
+  //                     root
+  //                    ╱    ╲       Flattened: root=10 groups
+  //                  dv3   ddv1                ddv1=7 groups
+  //                       ╱  |  ╲
+  //                     dv0 dv1 dv2
+  std::vector<DiscreteValues<double>*> unowned1{&dv0, &dv1, &dv2};
+  DiagramDiscreteValues<double> ddv1(unowned1);
+  std::vector<DiscreteValues<double>*> unowned2{&dv3, &ddv1};
+  DiagramDiscreteValues<double> root(unowned2);
+
+  EXPECT_EQ(ddv1.num_subdiscretes(), 3);
+  EXPECT_EQ(ddv1.num_groups(), 7);
+  EXPECT_EQ(ddv1.get_vector(0).size(), 2);  // dv0[0]
+  EXPECT_EQ(ddv1.get_vector(3).size(), 3);  // dv1[1]
+  EXPECT_EQ(ddv1.get_vector(6).size(), 2);  // dv2[1]
+  EXPECT_EQ(root.num_subdiscretes(), 2);
+  EXPECT_EQ(root.num_groups(), 10);
+  EXPECT_EQ(root.get_subdiscrete(SubsystemIndex(0)).num_groups(), 3);
+  EXPECT_EQ(root.get_subdiscrete(SubsystemIndex(1)).num_groups(), 7);
+  EXPECT_EQ(root.get_vector(1).size(), 3);  // dv3[1]
+  EXPECT_EQ(root.get_vector(3).size(), 2);  // dv0[0]
+  EXPECT_EQ(root.get_vector(6).size(), 3);  // dv1[1]
+  EXPECT_EQ(root.get_vector(9).size(), 2);  // dv2[1]
+
+  // Check some of the vector types.
+  EXPECT_FALSE(is_dynamic_castable<MyVector3d>(&root.get_vector(0)));  // dv3[0]
+  EXPECT_TRUE(is_dynamic_castable<MyVector3d>(&root.get_vector(1)));   // dv3[1]
+  EXPECT_TRUE(is_dynamic_castable<MyVector2d>(&root.get_vector(2)));   // dv3[2]
+  EXPECT_TRUE(is_dynamic_castable<MyVector3d>(&root.get_vector(6)));   // dv1[1]
+
+  // This is the shadowed Clone() method that preserves the concrete type.
+  auto root2_ptr = root.Clone();
+  DiagramDiscreteValues<double>& root2 = *root2_ptr;
+  // Should have same structure.
+  EXPECT_EQ(root2.num_subdiscretes(), root.num_subdiscretes());
+  EXPECT_EQ(root2.num_groups(), root.num_groups());
+  EXPECT_EQ(root2.get_subdiscrete(SubsystemIndex(0)).num_groups(),
+            root.get_subdiscrete(SubsystemIndex(0)).num_groups());
+  EXPECT_EQ(root2.get_subdiscrete(SubsystemIndex(1)).num_groups(),
+            root.get_subdiscrete(SubsystemIndex(1)).num_groups());
+  // But different owned BasicVectors, with the same values.
+  for (int i = 0; i < root.num_groups(); ++i) {
+    EXPECT_NE(&root.get_vector(i), &root2.get_vector(i));
+    EXPECT_EQ(root2.get_vector(i).get_value(), root.get_vector(i).get_value());
+  }
+
+  // Check that the underlying vector types were preserved by Clone().
+  EXPECT_FALSE(
+      is_dynamic_castable<MyVector3d>(&root2.get_vector(0)));          // dv3[0]
+  EXPECT_TRUE(is_dynamic_castable<MyVector3d>(&root2.get_vector(1)));  // dv3[1]
+  EXPECT_TRUE(is_dynamic_castable<MyVector2d>(&root2.get_vector(2)));  // dv3[2]
+  EXPECT_TRUE(is_dynamic_castable<MyVector3d>(&root2.get_vector(6)));  // dv1[1]
+
+  // To make sure we didn't go too far with ownership, check that writing
+  // through root2 changes what is seen by its subdiscretes.
+  EXPECT_EQ(root2.get_vector(6).get_value()[1], -2.5);
+  const DiscreteValues<double>& root2_ddv1 =
+      root2.get_subdiscrete(SubsystemIndex(1));
+  EXPECT_EQ(root2_ddv1.get_vector(3).get_value()[1], -2.5);
+  root2.get_mutable_vector(6).get_mutable_value()[1] = 19.;
+  EXPECT_EQ(root2.get_vector(6).get_value()[1], 19.);
+  EXPECT_EQ(root2_ddv1.get_vector(3).get_value()[1], 19.);
+  EXPECT_EQ(ddv1.get_vector(3).get_value()[1], -2.5);  // sanity check
 }
 
 }  // namespace

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -277,6 +277,7 @@ LIBDRAKE_COMPONENTS = [
     "//systems/framework:diagram_builder",
     "//systems/framework:diagram_context",
     "//systems/framework:diagram_continuous_state",
+    "//systems/framework:diagram_discrete_values",
     "//systems/framework:discrete_values",
     "//systems/framework:event_collection",
     "//systems/framework:framework",


### PR DESCRIPTION
Another caching lemma. This PR makes DiagramContinuousState and DiagramDiscreteValues cloneable and adds a bunch of unit tests that are more than half the code. (DiagramContinuousState apparently didn't have any direct unit tests.) 

Eliminates unneeded DiagramTimeDerivatives class and moves DiagramDiscreteValues out of internal:: to make it parallel to DiagramContinuousState. A couple of utility methods move to framework_common internal:: to avoid duplicating them. Fixed some comments.

This code comes from the caching branch (#7668).

```
Category            added  modified  removed  
----------------------------------------------
code                356    40        71       
comments            175    29        15       
blank               78     0         14       
----------------------------------------------
TOTAL               609    69        100      
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8496)
<!-- Reviewable:end -->
