### PR TITLE
Add manipulation/util/model_tree directory.

### DIFF
--- a/manipulation/util/model_tree/BUILD.bazel
+++ b/manipulation/util/model_tree/BUILD.bazel
@@ -1,0 +1,38 @@
+# -*- python -*-
+
+load(
+    "//tools:drake.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_library(
+    name = "model_tree_node",
+    srcs = [
+        "model_tree_node.cc",
+    ],
+    hdrs = [
+        "model_tree_node.h",
+    ],
+    deps = [
+        "//common:copyable_unique_ptr",
+        "//common:essential",
+        "//math:geometric_transform",
+        "//multibody/joints",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "model_tree_node_test",
+    deps = [
+        ":model_tree_node",
+        "//common/test_utilities:expect_throws_message",
+    ],
+)
+
+add_lint_tests()

--- a/manipulation/util/model_tree/model_tree_node.cc
+++ b/manipulation/util/model_tree/model_tree_node.cc
@@ -1,0 +1,163 @@
+#include "drake/manipulation/util/model_tree/model_tree_node.h"
+
+#include <set>
+
+#include "drake/common/text_logging.h"
+
+using drake::nullopt;
+using drake::optional;
+using drake::multibody::joints::FloatingBaseType;
+
+namespace drake {
+namespace manipulation {
+namespace util {
+namespace model_tree {
+
+bool operator==(const PredecessorInfo& info_0, const PredecessorInfo& info_1) {
+  drake::log()->trace(
+      "info_0.model_instance_name == "
+      "info_1.model_instance_name: "
+      "{}\n"
+      "        info_0.model_instance_name: {}\n"
+      "        info_1.model_instance_name: {}",
+      info_0.model_instance_name == info_1.model_instance_name,
+      info_0.model_instance_name, info_1.model_instance_name);
+  drake::log()->trace(
+      "info_0.body_or_frame_name == "
+      "info_1.body_or_frame_name: "
+      "{}\n"
+      "        info_0.body_or_frame_name: {}\n"
+      "        info_1.body_or_frame_name: {}",
+      info_0.body_or_frame_name == info_1.body_or_frame_name,
+      info_0.body_or_frame_name, info_1.body_or_frame_name);
+  return (info_0.model_instance_name == info_1.model_instance_name) &&
+         (info_0.body_or_frame_name == info_1.body_or_frame_name) &&
+         (info_0.is_frame == info_1.is_frame);
+}
+
+bool operator==(const ModelFile& file_0, const ModelFile& file_1) {
+  drake::log()->trace(
+      "file_0.absolute_path == file_1.absolute_path: {}\n"
+      "        file_0.absolute_path: {}\n"
+      "        file_1.absolute_path: {}",
+      file_0.absolute_path == file_1.absolute_path, file_0.absolute_path,
+      file_1.absolute_path);
+  drake::log()->trace(
+      "file_0.type == file_1.type: {}\n"
+      "        file_0.type: {}\n"
+      "        file_1.type: {}",
+      file_0.type == file_1.type, static_cast<int>(file_0.type),
+      static_cast<int>(file_1.type));
+  return (file_0.absolute_path == file_1.absolute_path) &&
+         (file_0.type == file_1.type);
+}
+
+bool ModelTreeNode::operator==(const ModelTreeNode& other) const {
+  drake::log()->trace(
+      "name_ == other.name_: {}\n"
+      "        name:       {}\n"
+      "        other.name: {}",
+      name_ == other.name_, name_, other.name_);
+  drake::log()->trace(
+      "parent_name_ == other.parent_name_: {}\n"
+      "        parent_name:       {}\n"
+      "        other.parent_name: {}",
+      parent_name_ == other.parent_name_, parent_name_, other.parent_name_);
+  drake::log()->trace("model_file_ == other.model_file_: {}",
+                      model_file_ == other.model_file_);
+  drake::log()->trace("predecessor_info_ == other.predecessor_info_: {}",
+                      predecessor_info_ == other.predecessor_info_);
+  drake::log()->trace(
+      "parent_predecessor_info_ == other.parent_predecessor_info_: {}",
+      parent_predecessor_info_ == other.parent_predecessor_info_);
+  drake::log()->trace(
+      "X_PB.IsNearlyEqualTo(info_1.X_PB, 0.0): {}\n"
+      "X_PB:\n"
+      "{}\n"
+      "other.X_PB:\n"
+      "{}\n",
+      X_PB().IsNearlyEqualTo(other.X_PB(), 0.0), X_PB().GetAsMatrix4(),
+      other.X_PB().GetAsMatrix4());
+  drake::log()->trace("base_joint_type == other.base_joint_type_: {}",
+                      base_joint_type_ == other.base_joint_type_);
+  return (name_ == other.name_) && (model_file_ == other.model_file_) &&
+         (parent_name_ == other.parent_name_) &&
+         (predecessor_info_ == other.predecessor_info_) &&
+         (parent_predecessor_info_ == other.parent_predecessor_info_) &&
+         X_PB_.IsNearlyEqualTo(other.X_PB_, 0.0) &&
+         (base_joint_type_ == other.base_joint_type_) &&
+         (children_ == other.children_);
+}
+
+ModelTreeNode::ModelTreeNode(
+    const std::string& node_name, const drake::optional<ModelFile>& model_file,
+    const drake::optional<PredecessorInfo>& node_predecessor_info,
+    const drake::math::Transform<double>& X_PB,
+    FloatingBaseType base_joint_type,
+    const std::vector<ModelTreeNode>& children)
+    : name_(node_name),
+      model_file_(model_file),
+      predecessor_info_(node_predecessor_info),
+      X_PB_(X_PB),
+      base_joint_type_(base_joint_type),
+      children_(children) {
+  std::set<std::string> child_names;
+  for (auto& child : children_) {
+    if (!child_names.insert(child.name_).second) {
+      throw std::runtime_error("Duplicate child node name: " + child.name_);
+    }
+  }
+  UpdateChildren();
+}
+
+bool ModelTreeNode::is_predecessor_parent_base_frame() const {
+  return !predecessor_info_;
+}
+
+std::string ModelTreeNode::ParentNamePrefix() const {
+  if (parent_name_.empty()) {
+    return "";
+  }
+  return parent_name_ + "/";
+}
+
+std::string ModelTreeNode::name() const { return ParentNamePrefix() + name_; }
+
+optional<PredecessorInfo> ModelTreeNode::predecessor_info() const {
+  if (is_predecessor_parent_base_frame()) {
+    return parent_predecessor_info_;
+  }
+  return PredecessorInfo(
+      ParentNamePrefix() + predecessor_info_->model_instance_name,
+      predecessor_info_->body_or_frame_name, predecessor_info_->is_frame);
+}
+
+drake::math::Transform<double> ModelTreeNode::X_PB() const {
+  if (is_predecessor_parent_base_frame()) {
+    return parent_X_PB_ * X_PB_;
+  }
+  return X_PB_;
+}
+
+FloatingBaseType ModelTreeNode::base_joint_type() const {
+  if (is_predecessor_parent_base_frame() &&
+      base_joint_type_ == FloatingBaseType::kFixed) {
+    return parent_base_joint_type_;
+  }
+  return base_joint_type_;
+}
+
+void ModelTreeNode::UpdateChildren() {
+  for (ModelTreeNode& child : children_) {
+    child.parent_name_ = name();
+    child.parent_predecessor_info_ = predecessor_info();
+    child.parent_X_PB_ = X_PB();
+    child.parent_base_joint_type_ = base_joint_type();
+    child.UpdateChildren();
+  }
+}
+
+}  // namespace model_tree
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/util/model_tree/model_tree_node.h
+++ b/manipulation/util/model_tree/model_tree_node.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+#include "drake/math/transform.h"
+#include "drake/multibody/joints/floating_base_types.h"
+
+namespace drake {
+namespace manipulation {
+namespace util {
+namespace model_tree {
+
+/** Describes how a model tree node is attached to the tree.
+ */
+// TODO(avalenzu): Add a FindBodyOrFrame() method to RigidBodyTree and get rid
+// of this nonsense.
+struct PredecessorInfo {
+  PredecessorInfo(const std::string& model_instance_name_in,
+                  const std::string& body_or_frame_name_in,
+                  bool is_frame_in)
+      : model_instance_name(model_instance_name_in),
+        body_or_frame_name(body_or_frame_name_in),
+        is_frame(is_frame_in) {}
+  std::string model_instance_name{};
+  std::string body_or_frame_name{};
+  bool is_frame{false};
+};
+
+/** Enumerates supported model file types.
+ */
+enum class ModelFileType { kUrdf, kSdf };
+
+/** Describes a model file
+ */
+struct ModelFile {
+  ModelFile(const std::string& absolute_path_in, ModelFileType type_in)
+      : absolute_path(absolute_path_in), type(type_in) {}
+  std::string absolute_path{};
+  ModelFileType type{};
+};
+
+bool operator==(const PredecessorInfo& info_0, const PredecessorInfo& info_1);
+
+bool operator==(const ModelFile& file_0, const ModelFile& file_1);
+
+/** Represents a node in a model tree.
+ */
+class ModelTreeNode {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ModelTreeNode);
+
+  /** Constructs a ModelTreeNode with the given parameters.
+   * @param node_name Identifying name of this node.
+   * @param model_file Describes the model file specified by this node. Pass
+   *        drake::nullopt if the node does not specify a model file.
+   * @param node_predecessor_info Describes the predecessor of this node (the
+   *        body or frame to which this node's base is attached). Pass
+   *        drake::nullopt to indicate that this node's base is attached to the
+   *        base of this node's parent node. Otherwise, pass a PredecessorInfo
+   *        instance describing a body or frame in one of this node's siblings.
+   * @param X_PB Pose of this node's Base frame relative to its Predecessor.
+   * @param base_joint_type Joint type of the joint between this node's base and
+   *        its predecessor.
+   * @param children Nodes to be copied and added as children of this node. Each
+   *        node in `children` must have a unique `name()`.
+   * @throws std::runtime_error if any elements of `children` have the same
+   *         name.
+   */
+  ModelTreeNode(const std::string& node_name,
+                const drake::optional<ModelFile>& model_file,
+                const drake::optional<PredecessorInfo>& node_predecessor_info,
+                const drake::math::Transform<double>& X_PB,
+                drake::multibody::joints::FloatingBaseType base_joint_type,
+                const std::vector<ModelTreeNode>& children);
+
+  /** Fully qualified name of this node. For child nodes, the format of this
+   * name is: `root_name/.../parent_name/node_name`
+   */
+  std::string name() const;
+
+  /** Information on the model file specified by this node. Returns
+   * drake::nullopt if this node does not specify a model file.
+   */
+  drake::optional<ModelFile> model_file() const { return model_file_; }
+
+  /** Fully qualified information on the predecessor of this node's base frame.
+   * Returns drake::nullopt if the predecessor is the world frame.
+   *
+   * Note that for child nodes, this will differ from the
+   * `node_predecessor_info` passed to the constructor. If drake::nullopt was
+   * passed to the constructor, this method will return the result of calling
+   * predecessor_info() on the node's parent. If a PredecessorInfo instance
+   * was passed to the constructor, the fully qualified name of the parent will
+   * be prepended to the `model_instance_name`.  */
+  drake::optional<PredecessorInfo> predecessor_info() const;
+
+  /** Pose of this node's Base frame relative to its Predecessor.
+   */
+  drake::math::Transform<double> X_PB() const;
+
+  /** Joint type for the joint connecting the base frame to its predecessor.
+   *
+   * Note that for child nodes, this may differ from the `base_joint_type`
+   * passed to the constructor. If drake::nullopt and FloatingBaseType::kFixed
+   * were passed to the constructor for `node_predecessor_info` and
+   * `base_joint_type` respectively, then this method will return the result of
+   * calling base_joint_type() on this node's parent.
+   */
+  drake::multibody::joints::FloatingBaseType base_joint_type() const;
+
+  /** Children of this node.
+   */
+  const std::vector<ModelTreeNode>& children() const { return children_; }
+
+  bool operator==(const ModelTreeNode& other) const;
+
+  bool operator!=(const ModelTreeNode& other) const {
+    return !operator==(other);
+  }
+
+ private:
+  std::string ParentNamePrefix() const;
+  void UpdateChildren();
+  bool is_predecessor_parent_base_frame() const;
+
+  std::string name_{};
+  drake::optional<ModelFile> model_file_{};
+  // Identifying information for the predecessor frame.
+  drake::optional<PredecessorInfo> predecessor_info_{};
+  // Pose of Base frame relative to Predecessor.
+  drake::math::Transform<double> X_PB_{};
+  // Joint type to be used to connect the base frame to the predecessor frame.
+  drake::multibody::joints::FloatingBaseType base_joint_type_{};
+  std::vector<ModelTreeNode> children_{};
+  // Values copied from the parent of this node (if any) during a call to the
+  // parent's UpdateChildren() method.
+  std::string parent_name_{};
+  drake::optional<PredecessorInfo> parent_predecessor_info_{};
+  drake::math::Transform<double> parent_X_PB_{};
+  drake::multibody::joints::FloatingBaseType parent_base_joint_type_{};
+};
+
+typedef ModelTreeNode ModelTree;
+
+}  // namespace model_tree
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake

--- a/manipulation/util/model_tree/test/model_tree_node_test.cc
+++ b/manipulation/util/model_tree/test/model_tree_node_test.cc
@@ -1,0 +1,199 @@
+#include "drake/manipulation/util/model_tree/model_tree_node.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_optional.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/multibody/joints/floating_base_types.h"
+
+using drake::nullopt;
+using drake::math::RotationMatrix;
+using drake::math::Transform;
+using drake::multibody::joints::FloatingBaseType;
+
+namespace drake {
+namespace manipulation {
+namespace util {
+namespace model_tree {
+namespace {
+
+constexpr char kModelName[] = "my_model";
+constexpr char kModelPath[] = "my/model/path";
+constexpr ModelFileType kModelFileType = ModelFileType::kUrdf;
+constexpr char kParentName[] = "my_parent";
+constexpr char kParentBodyName[] = "my_predecessor_body";
+constexpr FloatingBaseType kBaseJointType = FloatingBaseType::kQuaternion;
+
+Transform<double> MakeTransform() {
+  return {RotationMatrix<double>::MakeSpaceXYZRotation({1., 2., 3.}),
+          {1., 2., 3}};
+}
+
+std::vector<ModelTreeNode> MakeModelTreeNodes() {
+  std::vector<ModelTreeNode> nodes{};
+  std::string model_name = "node_with_predecessor_info";
+  PredecessorInfo predecessor_info{kModelName, "my_model_body_0", false};
+  ModelFile model_file{"/path/to/" + model_name, kModelFileType};
+  nodes.emplace_back(model_name, model_file, predecessor_info, MakeTransform(),
+                     FloatingBaseType::kFixed, std::vector<ModelTreeNode>());
+  model_name = "node_without_predecessor_info";
+  nodes.emplace_back(model_name, model_file, nullopt, MakeTransform(),
+                     FloatingBaseType::kFixed, std::vector<ModelTreeNode>());
+  return nodes;
+}
+
+class ModelTreeNodeTest : public ::testing::Test {
+ public:
+  ModelTreeNodeTest()
+      : model_(kModelName, ModelFile(kModelPath, kModelFileType),
+               PredecessorInfo(kParentName, kParentBodyName, false),
+               MakeTransform(), kBaseJointType, MakeModelTreeNodes()) {}
+
+ protected:
+  ModelTreeNode model_;
+};
+
+GTEST_TEST(ModelTreeNodeNegativeTests, DuplicateChildNamesTest) {
+  std::vector<ModelTreeNode> nodes_with_duplicated_names{
+      2, MakeModelTreeNodes()[0]};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      ModelTreeNode(kModelName, {}, {}, {}, kBaseJointType,
+                    nodes_with_duplicated_names),
+      std::runtime_error,
+      "Duplicate child node name: " + nodes_with_duplicated_names[0].name());
+}
+
+TEST_F(ModelTreeNodeTest, ConstructorTest) {
+  EXPECT_EQ(model_.name(), kModelName);
+  EXPECT_EQ(model_.model_file(), ModelFile(kModelPath, kModelFileType));
+  EXPECT_EQ(model_.predecessor_info(),
+            PredecessorInfo(kParentName, kParentBodyName, false));
+  EXPECT_TRUE(model_.X_PB().IsNearlyEqualTo(MakeTransform(), 0.0));
+  EXPECT_EQ(model_.base_joint_type(), kBaseJointType);
+
+  // Check the relationship between "free" nodes and the ones stored in
+  // model_. These should not match because the ones stored in model_ have a
+  // parent now.
+  std::vector<ModelTreeNode> free_nodes = MakeModelTreeNodes();
+  EXPECT_NE(model_.children(), free_nodes);
+  ASSERT_EQ(model_.children().size(), free_nodes.size());
+  ASSERT_EQ(free_nodes.size(), 2);
+  for (int i = 0; i < static_cast<int>(model_.children().size()); ++i) {
+    EXPECT_EQ(model_.children()[i].name(),
+              model_.name() + "/" + free_nodes[i].name());
+    EXPECT_EQ(model_.children()[i].model_file(), free_nodes[i].model_file());
+  }
+
+  // Check the child constructed with predecessor info.
+  ASSERT_TRUE(free_nodes[0].predecessor_info());
+  ASSERT_TRUE(model_.children()[0].predecessor_info());
+  PredecessorInfo expected_predecessor_info = *free_nodes[0].predecessor_info();
+  expected_predecessor_info.model_instance_name =
+      model_.name() + "/" + expected_predecessor_info.model_instance_name;
+  EXPECT_EQ(*model_.children()[0].predecessor_info(),
+            expected_predecessor_info);
+  EXPECT_TRUE(
+      model_.children()[0].X_PB().IsNearlyEqualTo(free_nodes[0].X_PB(), 0.0));
+  EXPECT_EQ(model_.children()[0].base_joint_type(),
+            free_nodes[0].base_joint_type());
+
+  // Check the child constructed without predecessor info.
+  ASSERT_FALSE(free_nodes[1].predecessor_info());
+  ASSERT_TRUE(model_.children()[1].predecessor_info());
+  expected_predecessor_info = *model_.predecessor_info();
+  EXPECT_EQ(*model_.children()[1].predecessor_info(),
+            expected_predecessor_info);
+  EXPECT_TRUE(model_.children()[1].X_PB().IsNearlyEqualTo(
+      model_.X_PB() * free_nodes[1].X_PB(), 0.0));
+  EXPECT_EQ(model_.children()[1].base_joint_type(), model_.base_joint_type());
+}
+
+TEST_F(ModelTreeNodeTest, OperatorEqualsTest) {
+  // Add parent.
+  // Construct comparison models.
+  ModelTreeNode same_model{kModelName,
+                           ModelFile(kModelPath, kModelFileType),
+                           PredecessorInfo(kParentName, kParentBodyName, false),
+                           MakeTransform(),
+                           kBaseJointType,
+                           MakeModelTreeNodes()};
+
+  ModelTreeNode different_name{
+      "my_other_model",
+      ModelFile(kModelPath, kModelFileType),
+      PredecessorInfo(kParentName, kParentBodyName, false),
+      MakeTransform(),
+      kBaseJointType,
+      MakeModelTreeNodes()};
+
+  ModelTreeNode different_model_file{
+      kModelName,
+      ModelFile(kModelPath, ModelFileType::kSdf),
+      PredecessorInfo(kParentName, kParentBodyName, false),
+      MakeTransform(),
+      kBaseJointType,
+      MakeModelTreeNodes()};
+
+  ModelTreeNode different_predecessor_info{
+      kModelName,
+      ModelFile(kModelPath, kModelFileType),
+      PredecessorInfo("foo", kParentBodyName, false),
+      MakeTransform(),
+      kBaseJointType,
+      MakeModelTreeNodes()};
+
+  ModelTreeNode different_X_PM{
+      kModelName,
+      ModelFile(kModelPath, kModelFileType),
+      PredecessorInfo(kParentName, kParentBodyName, false),
+      {},
+      kBaseJointType,
+      MakeModelTreeNodes()};
+
+  ModelTreeNode different_base_joint_type{
+      kModelName,
+      ModelFile(kModelPath, kModelFileType),
+      PredecessorInfo(kParentName, kParentBodyName, false),
+      MakeTransform(),
+      FloatingBaseType::kFixed,
+      MakeModelTreeNodes()};
+
+  ModelTreeNode different_children{
+      kModelName,
+      ModelFile(kModelPath, ModelFileType::kSdf),
+      PredecessorInfo(kParentName, kParentBodyName, false),
+      MakeTransform(),
+      kBaseJointType,
+      std::vector<ModelTreeNode>(1,
+                                 ModelTreeNode("different_child", {}, {}, {},
+                                               FloatingBaseType::kFixed, {}))};
+
+  EXPECT_TRUE(model_ == same_model);
+  EXPECT_FALSE(model_ != same_model);
+
+  EXPECT_FALSE(model_ == different_name);
+  EXPECT_TRUE(model_ != different_name);
+
+  EXPECT_FALSE(model_ == different_model_file);
+  EXPECT_TRUE(model_ != different_model_file);
+
+  EXPECT_FALSE(model_ == different_predecessor_info);
+  EXPECT_TRUE(model_ != different_predecessor_info);
+
+  EXPECT_FALSE(model_ == different_X_PM);
+  EXPECT_TRUE(model_ != different_X_PM);
+
+  EXPECT_FALSE(model_ == different_base_joint_type);
+  EXPECT_TRUE(model_ != different_base_joint_type);
+
+  EXPECT_FALSE(model_ == different_children);
+  EXPECT_TRUE(model_ != different_children);
+}
+
+}  // namespace
+}  // namespace model_tree
+}  // namespace util
+}  // namespace manipulation
+}  // namespace drake


### PR DESCRIPTION
This directory contains one class:
 - `drake::manipulation::util::model_tree:: ModelTree[Node]`: Represents a
 tree of models (each one of which is described by a URDF or SDF file).

 This PR is a step towards allowing us to create multi-model-instance
 RigidBodyTrees from configuration files, rather than through multiple
 API calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8506)
<!-- Reviewable:end -->
