### PR TITLE
Add EqualTo methods to symbolic classes in Python bindings

### DIFF
--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -71,6 +71,10 @@ PYBIND11_MODULE(_symbolic_py, m) {
              return pow(self, other);
            },
            py::is_operator())
+      // We add `EqualTo` instead of `equal_to` to maintain consistency among
+      // symbolic classes (Variable, Expression, Formula, Polynomial) on Python
+      // side. This enables us to achieve polymorphism via ducktyping in Python.
+      .def("EqualTo", &Variable::equal_to)
       // Unary Plus.
       .def(+py::self)
       // Unary Minus.
@@ -128,6 +132,8 @@ PYBIND11_MODULE(_symbolic_py, m) {
       .def("IsSupersetOf", &Variables::IsSupersetOf)
       .def("IsStrictSubsetOf", &Variables::IsStrictSubsetOf)
       .def("IsStrictSupersetOf", &Variables::IsStrictSupersetOf)
+      .def("EqualTo", [](const Variables& self,
+                         const Variables& vars) { return self == vars; })
       .def(py::self == py::self)
       .def(py::self < py::self)
       .def(py::self + py::self)
@@ -158,6 +164,7 @@ PYBIND11_MODULE(_symbolic_py, m) {
            [](const Expression& self, const Environment::map& env) {
              return self.Evaluate(Environment{env});
            })
+      .def("EqualTo", &Expression::EqualTo)
       // Addition
       .def(py::self + py::self)
       .def(py::self + Variable())
@@ -356,6 +363,8 @@ PYBIND11_MODULE(_symbolic_py, m) {
            [](const Monomial& self) {
              return fmt::format("<Monomial \"{}\">", self);
            })
+      .def("EqualTo", [](const Monomial& self,
+                         const Monomial& monomial) { return self == monomial; })
       .def("GetVariables", &Monomial::GetVariables)
       .def("get_powers", &Monomial::get_powers, py_reference_internal)
       .def("ToExpression", &Monomial::ToExpression)

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -94,6 +94,10 @@ class TestSymbolicVariable(unittest.TestCase):
     def test_neg(self):
         self.assertEqual(str(-(x + 1)), "(-1 - x)")
 
+    def test_equalto(self):
+        self.assertTrue(x.EqualTo(x))
+        self.assertFalse(x.EqualTo(y))
+
     def test_logical(self):
         self.assertEqual(str(sym.logical_not(x == 0)),
                          "!((x = 0))")
@@ -179,6 +183,13 @@ class TestSymbolicVariables(unittest.TestCase):
     def test_include(self):
         vars = sym.Variables([x, y, z])
         self.assertTrue(vars.include(y))
+
+    def test_equalto(self):
+        vars1 = sym.Variables([x, y, z])
+        vars2 = sym.Variables([y, z])
+        vars3 = sym.Variables([x, y, z])
+        self.assertTrue(vars1.EqualTo(vars3))
+        self.assertFalse(vars1.EqualTo(vars2))
 
     def test_to_string(self):
         vars = sym.Variables()
@@ -385,6 +396,10 @@ class TestSymbolicExpression(unittest.TestCase):
         self.assertIsInstance(xv[0], sym.Variable)
         self.assertEquals(e_xv.shape, (2,))
         self.assertIsInstance(e_xv[0], sym.Expression)
+
+    def test_equalto(self):
+        self.assertTrue((x + y).EqualTo(x + y))
+        self.assertFalse((x + y).EqualTo(x - y))
 
     def test_relational_operators(self):
         # TODO(eric.cousineau): Use `VectorizedAlgebra` overloads once #8315 is
@@ -624,6 +639,13 @@ class TestSymbolicMonomial(unittest.TestCase):
         self.assertTrue(m2 != m3)
         self.assertTrue(m2 != m4)
         self.assertTrue(m3 != m4)
+
+    def test_equalto(self):
+        m1 = sym.Monomial(x, 2)
+        m2 = sym.Monomial(x, 1)
+        m3 = sym.Monomial(x, 2)
+        self.assertTrue(m1.EqualTo(m3))
+        self.assertFalse(m1.EqualTo(m2))
 
     def test_str(self):
         m1 = sym.Monomial(x, 2)


### PR DESCRIPTION
Close #8505
Related issue: #8500

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8510)
<!-- Reviewable:end -->
