### PR TITLE
Marks MBP final.

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -150,8 +150,10 @@ namespace multibody_plant {
 ///
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
+// TODO(amcastro-tri): consider to allow the inheritance from MBP. This will
+// require proper handling of scalar conversion.
 template<typename T>
-class MultibodyPlant : public systems::LeafSystem<T> {
+class MultibodyPlant final : public systems::LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPlant)
 


### PR DESCRIPTION
We mark MBP final for now to avoid the accidental use of this feature with is not currently supported (scalar conversion for instance is not properly handled for sub-classing).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8516)
<!-- Reviewable:end -->
