### PR TITLE
Rotation constraint mccormick

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -269,6 +269,7 @@ drake_cc_library(
     ],
     deps = [
         ":bilinear_product_util",
+        ":integer_optimization_util",
         ":mathematical_program",
         ":mixed_integer_optimization_util",
         "//math:gradient",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1033,6 +1033,7 @@ drake_cc_googletest(
         # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
         "no_tsan",
     ],
+    use_default_main = False,
     deps = [
         ":gurobi_solver",
         ":mathematical_program",

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -1191,8 +1191,12 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
 
   // For convenience, we also introduce additional expressions to
   // represent the individual sections of the real line
+  // CRpos[k](i, j) = 1 => phi(k) <= R(i, j) <= phi(k + 1)
   //   CRpos[k](i,j) = BRpos[k](i,j) if k=N-1, otherwise
   //   CRpos[k](i,j) = BRpos[k](i,j) - BRpos[k+1](i,j)
+  // Similarly CRneg[k](i, j) = 1 => -phi(k + 1) <= R(i, j) <= -phi(k)
+  //   CRneg[k](i, j) = CRneg[k](i, j) if k = N-1, otherwise
+  //   CRneg[k](i, j) = CRneg[k](i, j) - CRneg[k+1](i, j)
   std::vector<Matrix3<Expression>> CRpos, CRneg;
   CRpos.reserve(num_intervals_per_half_axis);
   CRneg.reserve(num_intervals_per_half_axis);
@@ -1255,7 +1259,8 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   AddBoundingBoxConstraintsImpliedByRollPitchYawLimitsToBinary(prog, BRpos[0],
                                                                limits);
 
-  AddMcCormickVectorConstraintsForR(R, CRpos, CRneg, num_intervals_per_half_axis, prog);
+  AddMcCormickVectorConstraintsForR(R, CRpos, CRneg,
+                                    num_intervals_per_half_axis, prog);
 
   AddCrossProductImpliedOrthantConstraint(prog, BRpos[0]);
   AddCrossProductImpliedOrthantConstraint(prog, BRpos[0].transpose());
@@ -1276,33 +1281,46 @@ void GetCRposAndCRnegForLogarithmicBinning(
     MathematicalProgram* prog, std::vector<Matrix3<Expression>>* CRpos,
     std::vector<Matrix3<Expression>>* CRneg) {
   DRAKE_DEMAND(is_power_of_two(num_intervals_per_half_axis));
-  CRpos->reserve(num_intervals_per_half_axis);
-  CRneg->reserve(num_intervals_per_half_axis);
-  for (int i = 0; i < num_intervals_per_half_axis; ++i) {
-    CRpos->push_back(prog->NewContinuousVariables<3, 3>("CRpos"));
-    CRneg->push_back(prog->NewContinuousVariables<3, 3>("CRneg"));
-  }
-  // B[i][j](0) = 0 => R(i, j) <= 0
-  // B[i][j](0) = 1 => R(i, j) >= 0
 
   const auto gray_codes = math::CalculateReflectedGrayCodes(
       CeilLog2(num_intervals_per_half_axis) + 1);
 
-  // CRpos[k](i, j) = 1 if B[i][j] represents num_interval_per_half_axis + k
-  // in reflected Gray code.
-  // CRneg[k](i, j) = 1 if B[i][j] represents num_interval_per_half_axis - k - 1
-  // in reflected Gray code.
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      for (int k = 0; k < num_intervals_per_half_axis; ++k) {
-        prog->AddConstraint(CreateBinaryCodeMatchConstraint(
-            B[i][j],
-            gray_codes.row(num_intervals_per_half_axis + k).transpose(),
-            (*CRpos)[k](i, j)));
-        prog->AddConstraint(CreateBinaryCodeMatchConstraint(
-            B[i][j],
-            gray_codes.row(num_intervals_per_half_axis - k - 1).transpose(),
-            (*CRneg)[k](i, j)));
+  // CRpos[k](i, j) = 1 <=> phi(k) <= R(i, j) <= phi(k+1)
+  // <=> B[i][j] represents num_interval_per_half_axis + k in reflected Gray
+  // code.
+  // CRneg[k](i, j) = 1 <=> -phi(k+1) <= R(i, j) <= -phi(k)
+  // <=> B[i][j] represents num_interval_per_half_axis - k - 1 in reflected Gray
+  // code.
+  if (num_intervals_per_half_axis > 1) {
+    CRpos->reserve(num_intervals_per_half_axis);
+    CRneg->reserve(num_intervals_per_half_axis);
+    for (int k = 0; k < num_intervals_per_half_axis; ++k) {
+      CRpos->push_back(prog->NewContinuousVariables<3, 3>(
+          "CRpos[" + std::to_string(k) + "]"));
+      CRneg->push_back(prog->NewContinuousVariables<3, 3>(
+          "CRneg[" + std::to_string(k) + "]"));
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          prog->AddConstraint(CreateBinaryCodeMatchConstraint(
+              B[i][j],
+              gray_codes.row(num_intervals_per_half_axis + k).transpose(),
+              (*CRpos)[k](i, j)));
+          prog->AddConstraint(CreateBinaryCodeMatchConstraint(
+              B[i][j],
+              gray_codes.row(num_intervals_per_half_axis - k - 1).transpose(),
+              (*CRneg)[k](i, j)));
+        }
+      }
+    }
+  } else {
+    // num_interval_per_half_axis = 1 is the special case, B[i][j](0) = 0 if
+    // -1 <= R(i, j) <= 0, and B[i][j](0) = 1 if 0 <= R(i, j) <= 1
+    CRpos->resize(1);
+    CRneg->resize(1);
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        (*CRpos)[0](i, j) = B[i][j](0);
+        (*CRneg)[0](i, j) = 1 - B[i][j](0);
       }
     }
   }
@@ -1433,16 +1451,14 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
   }
 
   if (add_mccormick_for_sphere_box_intersection) {
-    if (is_power_of_two(num_intervals_per_half_axis)) {
-      std::vector<Matrix3<symbolic::Expression>> CRpos(
-          num_intervals_per_half_axis);
-      std::vector<Matrix3<symbolic::Expression>> CRneg(
-          num_intervals_per_half_axis);
-      GetCRposAndCRnegForLogarithmicBinning(B, num_intervals_per_half_axis,
-                                            prog, &CRpos, &CRneg);
-      AddMcCormickVectorConstraintsForR(R, CRpos, CRneg,
-                                        num_intervals_per_half_axis, prog);
-    }
+    std::vector<Matrix3<symbolic::Expression>> CRpos(
+        num_intervals_per_half_axis);
+    std::vector<Matrix3<symbolic::Expression>> CRneg(
+        num_intervals_per_half_axis);
+    GetCRposAndCRnegForLogarithmicBinning(B, num_intervals_per_half_axis, prog,
+                                          &CRpos, &CRneg);
+    AddMcCormickVectorConstraintsForR(R, CRpos, CRneg,
+                                      num_intervals_per_half_axis, prog);
   }
   return std::make_pair(B, phi);
 }

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -1282,23 +1282,16 @@ void GetCRposAndCRnegForLogarithmicBinning(
     std::vector<Matrix3<Expression>>* CRneg) {
   DRAKE_DEMAND(is_power_of_two(num_intervals_per_half_axis));
 
-  const auto gray_codes = math::CalculateReflectedGrayCodes(
-      CeilLog2(num_intervals_per_half_axis) + 1);
-
-  // CRpos[k](i, j) = 1 <=> phi(k) <= R(i, j) <= phi(k+1)
-  // <=> B[i][j] represents num_interval_per_half_axis + k in reflected Gray
-  // code.
-  // CRneg[k](i, j) = 1 <=> -phi(k+1) <= R(i, j) <= -phi(k)
-  // <=> B[i][j] represents num_interval_per_half_axis - k - 1 in reflected Gray
-  // code.
   if (num_intervals_per_half_axis > 1) {
-    CRpos->reserve(num_intervals_per_half_axis);
-    CRneg->reserve(num_intervals_per_half_axis);
+    const auto gray_codes = math::CalculateReflectedGrayCodes(
+        CeilLog2(num_intervals_per_half_axis) + 1);
+    CRpos->resize(num_intervals_per_half_axis);
+    CRneg->resize(num_intervals_per_half_axis);
     for (int k = 0; k < num_intervals_per_half_axis; ++k) {
-      CRpos->push_back(prog->NewContinuousVariables<3, 3>(
-          "CRpos[" + std::to_string(k) + "]"));
-      CRneg->push_back(prog->NewContinuousVariables<3, 3>(
-          "CRneg[" + std::to_string(k) + "]"));
+      (*CRpos)[k] = prog->NewContinuousVariables<3, 3>("CRpos[" +
+                                                       std::to_string(k) + "]");
+      (*CRneg)[k] = prog->NewContinuousVariables<3, 3>("CRneg[" +
+                                                       std::to_string(k) + "]");
       for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
           prog->AddConstraint(CreateBinaryCodeMatchConstraint(
@@ -1327,16 +1320,17 @@ void GetCRposAndCRnegForLogarithmicBinning(
 }
 
 template <typename T>
-void GetCRposAndCRnegForLinearBinning(
-    const std::array<std::array<T, 3>, 3>& B, int num_intervals_per_half_axis,
-    MathematicalProgram* prog, std::vector<Matrix3<Expression>>* CRpos,
-    std::vector<Matrix3<Expression>>* CRneg) {
+void GetCRposAndCRnegForLinearBinning(const std::array<std::array<T, 3>, 3>& B,
+                                      int num_intervals_per_half_axis,
+                                      MathematicalProgram* prog,
+                                      std::vector<Matrix3<Expression>>* CRpos,
+                                      std::vector<Matrix3<Expression>>* CRneg) {
   CRpos->resize(num_intervals_per_half_axis);
   CRneg->resize(num_intervals_per_half_axis);
 
   // CRpos[k](i, j) = 1 <=> phi(k) <= R(i, j) <= phi(k + 1)
   //   <=> B[i][j](num_interval_per_half_axis + k) = 1
-  // CRneg[k](i, j) = 1 <=> -phi(k + 1) <= R(i, j) <= -phi(k) 
+  // CRneg[k](i, j) = 1 <=> -phi(k + 1) <= R(i, j) <= -phi(k)
   //   <=> B[i][j](num_interval_per_half_axis - k - 1) = 1
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -10,6 +10,7 @@
 
 #include "drake/math/cross_product.h"
 #include "drake/solvers/bilinear_product_util.h"
+#include "drake/solvers/integer_optimization_util.h"
 #include "drake/math/gray_code.h"
 
 using std::numeric_limits;
@@ -227,9 +228,9 @@ namespace {
 // Decodes the discretization of the axes.
 // For compactness, this method is referred to as phi(i) in the documentation
 // below.  The implementation must give a valid number even for i<0 and
-// i>num_binary_variables_per_half_axis.
-double EnvelopeMinValue(int i, int num_binary_variables_per_half_axis) {
-  return static_cast<double>(i) / num_binary_variables_per_half_axis;
+// i>num_intervals_per_half_axis.
+double EnvelopeMinValue(int i, int num_intervals_per_half_axis) {
+  return static_cast<double>(i) / num_intervals_per_half_axis;
 }
 
 // Given (an integer enumeration of) the orthant, takes a vector in the
@@ -1130,28 +1131,58 @@ void AddCrossProductImpliedOrthantConstraint(
     }
   }
 }
+
+void AddMcCormickVectorConstraintsForR(
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    const std::vector<Matrix3<symbolic::Expression>> & CRpos,
+    const std::vector<Matrix3<symbolic::Expression>> & CRneg,
+    int num_intervals_per_half_axis, MathematicalProgram* prog) {
+  // Add constraints to the column and row vectors.
+  std::vector<Vector3<Expression>> cpos(num_intervals_per_half_axis),
+      cneg(num_intervals_per_half_axis);
+  for (int i = 0; i < 3; i++) {
+    // Make lists of the decision variables in terms of column vectors and row
+    // vectors to facilitate the calls below.
+    // TODO(russt): Consider reorganizing the original CRpos/CRneg variables to
+    // avoid this (albeit minor) cost?
+    for (int k = 0; k < num_intervals_per_half_axis; k++) {
+      cpos[k] = CRpos[k].col(i);
+      cneg[k] = CRneg[k].col(i);
+    }
+    AddMcCormickVectorConstraints(prog, R.col(i), cpos, cneg,
+                                  R.col((i + 1) % 3), R.col((i + 2) % 3));
+
+    for (int k = 0; k < num_intervals_per_half_axis; k++) {
+      cpos[k] = CRpos[k].row(i).transpose();
+      cneg[k] = CRneg[k].row(i).transpose();
+    }
+    AddMcCormickVectorConstraints(prog, R.row(i).transpose(), cpos, cneg,
+                                  R.row((i + 1) % 3).transpose(),
+                                  R.row((i + 2) % 3).transpose());
+  }
+}
 }  // namespace
 
 AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_binary_vars_per_half_axis, RollPitchYawLimits limits) {
-  DRAKE_DEMAND(num_binary_vars_per_half_axis >= 1);
+    int num_intervals_per_half_axis, RollPitchYawLimits limits) {
+  DRAKE_DEMAND(num_intervals_per_half_axis >= 1);
 
   // Use a simple lambda to make the constraints more readable below.
   // Note that
   //  forall k>=0, 0<=phi(k), and
-  //  forall k<=num_binary_vars_per_half_axis, phi(k)<=1.
+  //  forall k<=num_intervals_per_half_axis, phi(k)<=1.
   auto phi = [&](int k) -> double {
-    return EnvelopeMinValue(k, num_binary_vars_per_half_axis);
+    return EnvelopeMinValue(k, num_intervals_per_half_axis);
   };
 
   // Creates binary decision variables which discretize each axis.
   //   BRpos[k](i,j) = 1 => R(i,j) >= phi(k)
   //   BRneg[k](i,j) = 1 => R(i,j) <= -phi(k)
   std::vector<MatrixDecisionVariable<3, 3>> BRpos, BRneg;
-  for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
+  for (int k = 0; k < num_intervals_per_half_axis; k++) {
     BRpos.push_back(
         prog->NewBinaryVariables<3, 3>("BRpos" + std::to_string(k)));
     BRneg.push_back(
@@ -1163,20 +1194,20 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   //   CRpos[k](i,j) = BRpos[k](i,j) if k=N-1, otherwise
   //   CRpos[k](i,j) = BRpos[k](i,j) - BRpos[k+1](i,j)
   std::vector<Matrix3<Expression>> CRpos, CRneg;
-  CRpos.reserve(num_binary_vars_per_half_axis);
-  CRneg.reserve(num_binary_vars_per_half_axis);
-  for (int k = 0; k < num_binary_vars_per_half_axis - 1; k++) {
+  CRpos.reserve(num_intervals_per_half_axis);
+  CRneg.reserve(num_intervals_per_half_axis);
+  for (int k = 0; k < num_intervals_per_half_axis - 1; k++) {
     CRpos.push_back(BRpos[k] - BRpos[k + 1]);
     CRneg.push_back(BRneg[k] - BRneg[k + 1]);
   }
   CRpos.push_back(
-    BRpos[num_binary_vars_per_half_axis - 1].cast<symbolic::Expression>());
+    BRpos[num_intervals_per_half_axis - 1].cast<symbolic::Expression>());
   CRneg.push_back(
-    BRneg[num_binary_vars_per_half_axis - 1].cast<symbolic::Expression>());
+    BRneg[num_intervals_per_half_axis - 1].cast<symbolic::Expression>());
 
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
-      for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
+      for (int k = 0; k < num_intervals_per_half_axis; k++) {
         // R(i,j) > phi(k) => BRpos[k](i,j) = 1
         // R(i,j) < phi(k) => BRpos[k](i,j) = 0
         // R(i,j) = phi(k) => BRpos[k](i,j) = 0 or 1
@@ -1224,30 +1255,7 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   AddBoundingBoxConstraintsImpliedByRollPitchYawLimitsToBinary(prog, BRpos[0],
                                                                limits);
 
-  // Add constraints to the column and row vectors.
-  std::vector<Vector3<Expression>>
-      cpos(num_binary_vars_per_half_axis),
-      cneg(num_binary_vars_per_half_axis);
-  for (int i = 0; i < 3; i++) {
-    // Make lists of the decision variables in terms of column vectors and row
-    // vectors to facilitate the calls below.
-    // TODO(russt): Consider reorganizing the original CRpos/CRneg variables to
-    // avoid this (albeit minor) cost?
-    for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-      cpos[k] = CRpos[k].col(i);
-      cneg[k] = CRneg[k].col(i);
-    }
-    AddMcCormickVectorConstraints(prog, R.col(i), cpos, cneg,
-                                  R.col((i + 1) % 3), R.col((i + 2) % 3));
-
-    for (int k = 0; k < num_binary_vars_per_half_axis; k++) {
-      cpos[k] = CRpos[k].row(i).transpose();
-      cneg[k] = CRneg[k].row(i).transpose();
-    }
-    AddMcCormickVectorConstraints(prog, R.row(i).transpose(), cpos, cneg,
-                                  R.row((i + 1) % 3).transpose(),
-                                  R.row((i + 2) % 3).transpose());
-  }
+  AddMcCormickVectorConstraintsForR(R, CRpos, CRneg, num_intervals_per_half_axis, prog);
 
   AddCrossProductImpliedOrthantConstraint(prog, BRpos[0]);
   AddCrossProductImpliedOrthantConstraint(prog, BRpos[0].transpose());
@@ -1270,26 +1278,15 @@ void GetCRposAndCRnegForLogarithmicBinning(
   DRAKE_DEMAND(is_power_of_two(num_intervals_per_half_axis));
   CRpos->reserve(num_intervals_per_half_axis);
   CRneg->reserve(num_intervals_per_half_axis);
+  for (int i = 0; i < num_intervals_per_half_axis; ++i) {
+    CRpos->push_back(prog->NewContinuousVariables<3, 3>("CRpos"));
+    CRneg->push_back(prog->NewContinuousVariables<3, 3>("CRneg"));
+  }
   // B[i][j](0) = 0 => R(i, j) <= 0
   // B[i][j](0) = 1 => R(i, j) >= 0
 
   const auto gray_codes = math::CalculateReflectedGrayCodes(
       CeilLog2(num_intervals_per_half_axis) + 1);
-  auto AddBijRepresentsNumberConstraint = [prog, &gray_codes](
-      const T& Bij, int number, const symbolic::Expression c) {
-    // If the elementwise and of c_and is 1, then Bij represents the number
-    VectorX<symbolic::Expression> c_and(gray_codes.cols());
-    for (int i = 0; i < gray_codes.cols(); ++i) {
-      if (gray_codes(number, i) == 0) {
-        c_and(i) = 1 - Bij(i);
-      } else {
-        c_and(i) = Bij(i);
-      }
-      prog->AddLinearConstraint(c_and(i) <= c);
-    }
-    prog->AddLinearConstraint(c_and.sum() - (c_and.rows() - 1) <= c);
-    prog->AddLinearConstraint(c >= 0 && c <= 1);
-  };
 
   // CRpos[k](i, j) = 1 if B[i][j] represents num_interval_per_half_axis + k
   // in reflected Gray code.
@@ -1298,10 +1295,36 @@ void GetCRposAndCRnegForLogarithmicBinning(
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
       for (int k = 0; k < num_intervals_per_half_axis; ++k) {
-        AddBijRepresentsNumberConstraint(
-            B[i][j], num_intervals_per_half_axis + k, (*CRpos)[k](i, j));
-        AddBijRepresentsNumberConstraint(
-            B[i][j], num_intervals_per_half_axis - k - 1, (*CRneg)[k](i, j));
+        prog->AddConstraint(CreateBinaryCodeMatchConstraint(
+            B[i][j],
+            gray_codes.row(num_intervals_per_half_axis + k).transpose(),
+            (*CRpos)[k](i, j)));
+        prog->AddConstraint(CreateBinaryCodeMatchConstraint(
+            B[i][j],
+            gray_codes.row(num_intervals_per_half_axis - k - 1).transpose(),
+            (*CRneg)[k](i, j)));
+      }
+    }
+  }
+}
+
+template <typename T>
+void GetCRposAndCRnegForLinearBinning(
+    const std::array<std::array<T, 3>, 3>& B, int num_intervals_per_half_axis,
+    MathematicalProgram* prog, std::vector<Matrix3<Expression>>* CRpos,
+    std::vector<Matrix3<Expression>>* CRneg) {
+  CRpos->resize(num_intervals_per_half_axis);
+  CRneg->resize(num_intervals_per_half_axis);
+
+  // CRpos[k](i, j) = 1 <=> phi(k) <= R(i, j) <= phi(k + 1)
+  //   <=> B[i][j](num_interval_per_half_axis + k) = 1
+  // CRneg[k](i, j) = 1 <=> -phi(k + 1) <= R(i, j) <= -phi(k) 
+  //   <=> B[i][j](num_interval_per_half_axis - k - 1) = 1
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < num_intervals_per_half_axis; ++k) {
+        (*CRpos)[k](i, j) = B[i][j](num_intervals_per_half_axis + k);
+        (*CRneg)[k](i, j) = B[i][j](num_intervals_per_half_axis - k - 1);
       }
     }
   }
@@ -1317,7 +1340,8 @@ typename std::enable_if<
 AddRotationMatrixBilinearMcCormickMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_intervals_per_half_axis) {
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection) {
   typedef typename AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
       kNumIntervalsPerHalfAxis>::BinaryVarType Btype;
   typedef typename AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
@@ -1408,41 +1432,55 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
     }
   }
 
+  if (add_mccormick_for_sphere_box_intersection) {
+    if (is_power_of_two(num_intervals_per_half_axis)) {
+      std::vector<Matrix3<symbolic::Expression>> CRpos(
+          num_intervals_per_half_axis);
+      std::vector<Matrix3<symbolic::Expression>> CRneg(
+          num_intervals_per_half_axis);
+      GetCRposAndCRnegForLogarithmicBinning(B, num_intervals_per_half_axis,
+                                            prog, &CRpos, &CRneg);
+      AddMcCormickVectorConstraintsForR(R, CRpos, CRneg,
+                                        num_intervals_per_half_axis, prog);
+    }
+  }
   return std::make_pair(B, phi);
 }
 
 template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
     Eigen::Dynamic>::type
 AddRotationMatrixBilinearMcCormickMilpConstraints<Eigen::Dynamic>(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
-    int num_intervals_per_half_axis);
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection);
 
-template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
-    1>::type
+template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<1>::type
 AddRotationMatrixBilinearMcCormickMilpConstraints<1>(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
-    int num_intervals_per_half_axis);
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection);
 
-template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
-    2>::type
+template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<2>::type
 AddRotationMatrixBilinearMcCormickMilpConstraints<2>(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
-    int num_intervals_per_half_axis);
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection);
 
-template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<
-    3>::type
+template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<3>::type
 AddRotationMatrixBilinearMcCormickMilpConstraints<3>(
-    MathematicalProgram *prog,
-    const Eigen::Ref<const MatrixDecisionVariable<3, 3>> &R,
-    int num_intervals_per_half_axis);
+    MathematicalProgram* prog,
+    const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection);
 
 template AddRotationMatrixBilinearMcCormickMilpConstraintsReturn<4>::type
 AddRotationMatrixBilinearMcCormickMilpConstraints<4>(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_intervals_per_half_axis);
+    int num_intervals_per_half_axis,
+    bool add_mccormick_for_sphere_box_intersection);
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -9,9 +9,9 @@
 #include <limits>
 
 #include "drake/math/cross_product.h"
+#include "drake/math/gray_code.h"
 #include "drake/solvers/bilinear_product_util.h"
 #include "drake/solvers/integer_optimization_util.h"
-#include "drake/math/gray_code.h"
 
 using std::numeric_limits;
 using drake::symbolic::Expression;
@@ -1285,13 +1285,15 @@ void GetCRposAndCRnegForLogarithmicBinning(
   if (num_intervals_per_half_axis > 1) {
     const auto gray_codes = math::CalculateReflectedGrayCodes(
         CeilLog2(num_intervals_per_half_axis) + 1);
-    CRpos->resize(num_intervals_per_half_axis);
-    CRneg->resize(num_intervals_per_half_axis);
+    CRpos->clear();
+    CRneg->clear();
+    CRpos->reserve(num_intervals_per_half_axis);
+    CRneg->reserve(num_intervals_per_half_axis);
     for (int k = 0; k < num_intervals_per_half_axis; ++k) {
-      (*CRpos)[k] = prog->NewContinuousVariables<3, 3>("CRpos[" +
-                                                       std::to_string(k) + "]");
-      (*CRneg)[k] = prog->NewContinuousVariables<3, 3>("CRneg[" +
-                                                       std::to_string(k) + "]");
+      CRpos->push_back(prog->NewContinuousVariables<3, 3>(
+          "CRpos[" + std::to_string(k) + "]"));
+      CRneg->push_back(prog->NewContinuousVariables<3, 3>(
+          "CRneg[" + std::to_string(k) + "]"));
       for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
           prog->AddConstraint(CreateBinaryCodeMatchConstraint(
@@ -1445,10 +1447,7 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
   }
 
   if (add_mccormick_for_sphere_box_intersection) {
-    std::vector<Matrix3<symbolic::Expression>> CRpos(
-        num_intervals_per_half_axis);
-    std::vector<Matrix3<symbolic::Expression>> CRneg(
-        num_intervals_per_half_axis);
+    std::vector<Matrix3<symbolic::Expression>> CRpos, CRneg;
     GetCRposAndCRnegForLogarithmicBinning(B, num_intervals_per_half_axis, prog,
                                           &CRpos, &CRneg);
     AddMcCormickVectorConstraintsForR(R, CRpos, CRneg,

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -10,6 +10,7 @@
 
 #include "drake/math/cross_product.h"
 #include "drake/solvers/bilinear_product_util.h"
+#include "drake/math/gray_code.h"
 
 using std::numeric_limits;
 using drake::symbolic::Expression;
@@ -1254,6 +1255,59 @@ AddRotationMatrixMcCormickEnvelopeMilpConstraints(
   return make_tuple(CRpos, CRneg, BRpos, BRneg);
 }
 
+namespace {
+// Returns true if n is positive and n is a power of 2.
+bool is_power_of_two(int n) {
+  DRAKE_ASSERT(n > 0);
+  return  (n & (n-1)) == 0;
+}
+
+template <typename T>
+void GetCRposAndCRnegForLogarithmicBinning(
+    const std::array<std::array<T, 3>, 3>& B, int num_intervals_per_half_axis,
+    MathematicalProgram* prog, std::vector<Matrix3<Expression>>* CRpos,
+    std::vector<Matrix3<Expression>>* CRneg) {
+  DRAKE_DEMAND(is_power_of_two(num_intervals_per_half_axis));
+  CRpos->reserve(num_intervals_per_half_axis);
+  CRneg->reserve(num_intervals_per_half_axis);
+  // B[i][j](0) = 0 => R(i, j) <= 0
+  // B[i][j](0) = 1 => R(i, j) >= 0
+
+  const auto gray_codes = math::CalculateReflectedGrayCodes(
+      CeilLog2(num_intervals_per_half_axis) + 1);
+  auto AddBijRepresentsNumberConstraint = [prog, &gray_codes](
+      const T& Bij, int number, const symbolic::Expression c) {
+    // If the elementwise and of c_and is 1, then Bij represents the number
+    VectorX<symbolic::Expression> c_and(gray_codes.cols());
+    for (int i = 0; i < gray_codes.cols(); ++i) {
+      if (gray_codes(number, i) == 0) {
+        c_and(i) = 1 - Bij(i);
+      } else {
+        c_and(i) = Bij(i);
+      }
+      prog->AddLinearConstraint(c_and(i) <= c);
+    }
+    prog->AddLinearConstraint(c_and.sum() - (c_and.rows() - 1) <= c);
+    prog->AddLinearConstraint(c >= 0 && c <= 1);
+  };
+
+  // CRpos[k](i, j) = 1 if B[i][j] represents num_interval_per_half_axis + k
+  // in reflected Gray code.
+  // CRneg[k](i, j) = 1 if B[i][j] represents num_interval_per_half_axis - k - 1
+  // in reflected Gray code.
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      for (int k = 0; k < num_intervals_per_half_axis; ++k) {
+        AddBijRepresentsNumberConstraint(
+            B[i][j], num_intervals_per_half_axis + k, (*CRpos)[k](i, j));
+        AddBijRepresentsNumberConstraint(
+            B[i][j], num_intervals_per_half_axis - k - 1, (*CRneg)[k](i, j));
+      }
+    }
+  }
+}
+}  // namespace
+
 template <int kNumIntervalsPerHalfAxis>
 typename std::enable_if<
     kNumIntervalsPerHalfAxis == Eigen::Dynamic ||
@@ -1318,7 +1372,7 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
   // B[i][j](0) = 0 => R(i, j) <= 0
   // B[i][j](0) = 1 => R(i, j) >= 0
   // We can thus impose constraints on B[i][j](0).
-  if ((num_intervals_per_half_axis & (num_intervals_per_half_axis - 1)) == 0) {
+  if (is_power_of_two(num_intervals_per_half_axis)) {
     // num_intervals_per_half_axis is a power of 2.
 
     // Bpos(i, j) = sign(R(i, j)).

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -117,7 +117,7 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  * Note: The particular representation/algorithm here was developed in an
  * attempt:
  *  - to enable efficient reuse of the variables between the constraints
- *    between multiple rows/columns (e.g. the constraints on R^T use the same
+ *    between multiple rows/columns (e.g. the constraints on Rᵀ use the same
  *    variables as the constraints on R), and
  *  - to facilitate branch-and-bound solution techniques -- binary regions are
  *    layered so that constraining one region establishes constraints
@@ -125,8 +125,7 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  *    the on other binary variables.
  * @param prog The mathematical program to which the constraints are added.
  * @param R The rotation matrix
- * @param num_binary_vars_per_half_axis number of binary variables for a half
- * axis.
+ * @param num_intervals_per_half_axis number of intervals for a half axis.
  * @param limits The angle joints for space fixed z-y-x representation of the
  * rotation. @default is no constraint. @see RollPitchYawLimitOptions
  * @retval NewVars  Included the newly added variables
@@ -140,14 +139,14 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  *   BRpos[k](i, j) = 1 => R(i, j) >= k / N
  *   BRneg[k](i, j) = 1 => R(i, j) <= -k / N
  * </pre>
- * where `N` is `num_binary_vars_per_half_axis`.
+ * where `N` is `num_intervals_per_half_axis`.
  */
 
 AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_binary_vars_per_half_axis = 2,
+    int num_intervals_per_half_axis = 2,
     RollPitchYawLimits limits = kNoLimits);
 
 /**
@@ -181,8 +180,9 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * the bilinear product terms in the SO(3) constraint, with a new auxiliary
  * variable in the McCormick envelope of bilinear product. For more details,
  * please refer to
- * Global Inverse Kinematics via Mixed-Integer Convex Optimization
- * by Hongkai Dai, Gregory Izatt and Russ Tedrake, 2017.
+ *  Global Inverse Kinematics via Mixed-Integer Convex Optimization
+ *   by Hongkai Dai, Gregory Izatt and Russ Tedrake, 
+ *   International Symposium on Robotics Research 2017.
  * @tparam kNumIntervalsPerHalfAxis We cut the interval [-1, 1] evenly into
  * KNumIntervalsPerHalfAxis * 2 intervals. Then depending on in which interval
  * R(i, j) is, we impose corresponding linear constraints. Currently only

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -193,6 +193,10 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * @param R The rotation matrix.
  * @param num_intervals_per_half_axis Same as NumIntervalsPerHalfAxis, use this
  * variable when NumIntervalsPerHalfAxis is dynamic.
+ * @param add_mccormick_for_sphere_box_intersection Set to true if we add some
+ * constraint to tighten the relaxation, that can be obtained by considering
+ * the McCormick Envelope of an intersection region, between an axis-aligned box
+ * and the surface of the sphere.
  * @return pair. pair = (B, φ). B[i][j] is a column vector. If B[i][j]
  * represents integer M in the reflected Gray code, then R(i, j) is in the
  * interval [φ(M), φ(M+1)]. φ contains the end points of the all the intervals,
@@ -207,6 +211,7 @@ typename std::enable_if<
 AddRotationMatrixBilinearMcCormickMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_intervals_per_half_axis = kNumIntervalsPerHalfAxis);
+    int num_intervals_per_half_axis = kNumIntervalsPerHalfAxis,
+    bool add_mccormick_for_sphere_box_intersection = true);
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -11,6 +11,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mosek_solver.h"
 
 using Eigen::Vector3d;
 using Eigen::Matrix3d;
@@ -238,8 +239,13 @@ std::string to_string(ConstraintType type) {
     case ConstraintType::kBoth:
       return "both";
   }
+  // This code should not be reached, we add the next line due to a compiler
+  // defect.
+  throw std::runtime_error("Should not reach this part of the code.");
 }
 
+// This operator overloading is useful, when GTEST prints out which parameter
+// causes the test failure.
 std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
   os << to_string(type);
   return os;
@@ -609,3 +615,12 @@ INSTANTIATE_TEST_CASE_P(
 }  // namespace
 }  // namespace solvers
 }  // namespace drake
+
+int main(int argc, char** argv) {
+  // Ensure that we have the MOSEK license for the entire duration of this test,
+  // so that we do not have to release and re-acquire the license for every
+  // test.
+  auto mosek_license = drake::solvers::MosekSolver::AcquireLicense();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -223,14 +223,38 @@ GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
       "Incorrect type.");
 }*/
 
-class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
+enum class ConstraintType {
+  kBoxSphereIntersection,
+  kReplaceBilinear,
+  kBoth,
+};
+
+std::string to_string(ConstraintType type) {
+  switch (type) {
+    case ConstraintType::kBoxSphereIntersection:
+      return "box_sphere_intersection";
+    case ConstraintType::kReplaceBilinear:
+      return "replace_bilinear";
+    case ConstraintType::kBoth:
+      return "both";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
+  os << to_string(type);
+  return os;
+}
+
+
+class TestMcCormick
+    : public ::testing::TestWithParam<std::tuple<ConstraintType, int>> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMcCormick)
 
   TestMcCormick()
       : prog_(),
         R_(NewRotationMatrixVars(&prog_)),
-        replace_bilinear_product_(std::get<0>(GetParam())),
+        constraint_type_(std::get<0>(GetParam())),
         num_intervals_per_half_axis_(std::get<1>(GetParam())),
         feasibility_constraint_{prog_
                                     .AddLinearEqualityConstraint(
@@ -238,12 +262,19 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
                                         Eigen::Matrix<double, 9, 1>::Zero(),
                                         {R_.col(0), R_.col(1), R_.col(2)})
                                     .evaluator()} {
-    if (replace_bilinear_product_) {
-      AddRotationMatrixBilinearMcCormickMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_, true);
-    } else {
-      AddRotationMatrixMcCormickEnvelopeMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_);
+    switch (constraint_type_) {
+      case ConstraintType::kBoxSphereIntersection:
+        AddRotationMatrixMcCormickEnvelopeMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_);
+        break;
+      case ConstraintType::kReplaceBilinear:
+        AddRotationMatrixBilinearMcCormickMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_, false);
+        break;
+      case ConstraintType::kBoth:
+        AddRotationMatrixBilinearMcCormickMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_, true);
+        break;
     }
   }
 
@@ -256,9 +287,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
   MathematicalProgram prog_;
   MatrixDecisionVariable<3, 3> R_;
-  bool replace_bilinear_product_{};  // If true, replace the bilinear product
-  // with another varaible in the McCormick envelope. Otherwise, relax the
-  // surface ofthe unit sphere to its convex hull.
+  ConstraintType constraint_type_;
   int num_intervals_per_half_axis_{};
   std::shared_ptr<LinearEqualityConstraint> feasibility_constraint_;
 };
@@ -318,7 +347,8 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   R_test(0, 2) *= -1.0;
   R_test(1, 2) *= -1.0;
   // Requires 2 intervals per half axis to catch.
-  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+  if (num_intervals_per_half_axis_ == 1 &&
+      constraint_type_ == ConstraintType::kBoxSphereIntersection)
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
@@ -344,7 +374,8 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   R_test(2, 0) -= 0.1;
   EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
   EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);
-  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+  if (num_intervals_per_half_axis_ == 1 &&
+      constraint_type_ == ConstraintType::kBoxSphereIntersection)
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
@@ -352,7 +383,10 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
 
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
-    ::testing::Combine(::testing::ValuesIn<std::vector<bool>>({false, true}),
+    ::testing::Combine(::testing::ValuesIn<std::vector<ConstraintType>>(
+                           {ConstraintType::kBoxSphereIntersection,
+                            ConstraintType::kReplaceBilinear,
+                            ConstraintType::kBoth}),
                        ::testing::ValuesIn<std::vector<int>>({1, 2})));
 
 // Test some corner cases of McCormick envelope.

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -240,7 +240,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
                                     .evaluator()} {
     if (replace_bilinear_product_) {
       AddRotationMatrixBilinearMcCormickMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_);
+          &prog_, R_, num_intervals_per_half_axis_, true);
     } else {
       AddRotationMatrixMcCormickEnvelopeMilpConstraints(
           &prog_, R_, num_intervals_per_half_axis_);

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -186,7 +186,7 @@ bool IsFeasibleCheck(
 
   return (prog->Solve() == kSolutionFound);
 }
-
+/*
 GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
   MathematicalProgram prog;
   auto R = NewRotationMatrixVars(&prog);
@@ -221,7 +221,7 @@ GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
           std::pair<std::array<std::array<VectorDecisionVariable<3>, 3>, 3>,
                     Eigen::Matrix<double, 9, 1>>>::value,
       "Incorrect type.");
-}
+}*/
 
 class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  public:


### PR DESCRIPTION
This is one step to clean up `rotation_constraint.cc`. 

In `rotation_constraint.h`, we have two approaches to relax SO(3) constraint as mixed-integer convex constraint. The first one is to consider the intersection between the box and the surface of the sphere; the second approach is to replace all the bilinear terms in RᵀR=I with a new term in the McCormick envelope.

In this PR, I add a new option so that we can impose these two relaxations simultaneously. Potentially this makes the relaxation tighter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8517)
<!-- Reviewable:end -->
