### PR TITLE
Shortened //systems/analysis/antiderivative_function.h documentation line count

### DIFF
--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -16,11 +16,11 @@ namespace systems {
 /// Drake's ODE initial value problem solvers ("integrators"), provide the
 /// ability to perform quadrature on an arbitrary scalar integrable function.
 /// That is, it allows the evaluation of an antiderivative function F(u; 𝐤),
-/// such that F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx where f : ℝ  →  ℝ , u ∈ ℝ, v ∈ ℝ, 𝐤 ∈ ℝᵐ.
-/// The parameter vector 𝐤 allows for generic function definitions, which can
-/// later be evaluated for any instance of said vector. Also, note that 𝐤 can be
-/// understood as an m-tuple or as an element of ℝᵐ, the vector space, depending
-/// on how it is used by the integrable function.
+/// such that F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx where f : ℝ  →  ℝ , u ∈ ℝ, v ∈ ℝ,
+/// 𝐤 ∈ ℝᵐ. The parameter vector 𝐤 allows for generic function definitions,
+/// which can later be evaluated for any instance of said vector. Also, note
+/// that 𝐤 can be understood as an m-tuple or as an element of ℝᵐ, the vector
+/// space, depending on how it is used by the integrable function.
 ///
 /// For further insight into its use, consider the following examples.
 ///


### PR DESCRIPTION
To deal with linter issues with Unicode characters in Mac builds (refer to #8316 for more details).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8523)
<!-- Reviewable:end -->
