### PR TITLE
Collect GeometrySystem -> drake_visualizer boilerplate

### DIFF
--- a/examples/contact_model/BUILD.bazel
+++ b/examples/contact_model/BUILD.bazel
@@ -74,11 +74,8 @@ drake_cc_binary(
         "//multibody:rigid_body_tree_construction",
         "//multibody/parsers",
         "//multibody/rigid_body_plant",
-        "//multibody/rigid_body_plant:drake_visualizer",
         "//multibody/rigid_body_plant:rigid_body_plant_bridge",
         "//systems/analysis",
-        "//systems/lcm",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -31,9 +31,6 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/geometry/scene_graph.h"
-#include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant_bridge.h"
@@ -41,20 +38,13 @@
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace systems {
 
-using drake::lcm::DrakeLcm;
 using drake::multibody::joints::kQuaternion;
 using Eigen::VectorXd;
 using std::make_unique;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
-using systems::rendering::PoseBundleToDrawMessage;
 
 // Simulation parameters.
 DEFINE_double(v, 12, "The ball's initial linear speed down the lane (m/s)");
@@ -144,15 +134,6 @@ int main() {
   auto rbt_gs_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
       &tree, scene_graph);
 
-  DrakeLcm lcm;
-
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-  std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
 
   builder.Connect(plant.state_output_port(),
                   rbt_gs_bridge->rigid_body_plant_state_input_port());
@@ -161,13 +142,9 @@ int main() {
       rbt_gs_bridge->geometry_pose_output_port(),
       scene_graph->get_source_pose_port(rbt_gs_bridge->source_id()));
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConfigureVisualization(*scene_graph, &builder);
 
   auto diagram = builder.Build();
 

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -31,6 +31,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/geometry/geometry_visualization.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant_bridge.h"
@@ -42,7 +43,8 @@
 namespace drake {
 namespace systems {
 
-using drake::multibody::joints::kQuaternion;
+using lcm::DrakeLcm;
+using multibody::joints::kQuaternion;
 using Eigen::VectorXd;
 using std::make_unique;
 
@@ -144,7 +146,9 @@ int main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(*scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   auto diagram = builder.Build();
 

--- a/examples/geometry_world/BUILD.bazel
+++ b/examples/geometry_world/BUILD.bazel
@@ -38,10 +38,8 @@ drake_cc_binary(
         "//geometry:scene_graph",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
-        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 
@@ -68,10 +66,8 @@ drake_cc_binary(
         "//geometry:scene_graph",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
-        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -6,6 +6,7 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -20,6 +21,7 @@ using geometry::GeometryInstance;
 using geometry::SceneGraph;
 using geometry::HalfSpace;
 using geometry::SourceId;
+using lcm::DrakeLcm;
 using systems::InputPortDescriptor;
 using std::make_unique;
 
@@ -64,7 +66,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(*scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   auto diagram = builder.Build();
 

--- a/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -6,13 +6,9 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
-#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -24,11 +20,7 @@ using geometry::GeometryInstance;
 using geometry::SceneGraph;
 using geometry::HalfSpace;
 using geometry::SourceId;
-using lcm::DrakeLcm;
 using systems::InputPortDescriptor;
-using systems::rendering::PoseBundleToDrawMessage;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
 using std::make_unique;
 
 int do_main() {
@@ -59,14 +51,6 @@ int do_main() {
       global_source,
       make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
                                     make_unique<HalfSpace>()));
-  DrakeLcm lcm;
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
 
   builder.Connect(bouncing_ball1->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(ball_source_id1));
@@ -78,13 +62,10 @@ int do_main() {
   builder.Connect(scene_graph->get_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConfigureVisualization(*scene_graph, &builder);
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/geometry_world/solar_system_run_dynamics.cc
+++ b/examples/geometry_world/solar_system_run_dynamics.cc
@@ -1,6 +1,7 @@
 #include "drake/examples/geometry_world/solar_system.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 
@@ -11,6 +12,7 @@ namespace {
 
 using geometry::SceneGraph;
 using geometry::SourceId;
+using lcm::DrakeLcm;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -26,7 +28,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(*scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   auto diagram = builder.Build();
 

--- a/examples/geometry_world/solar_system_run_dynamics.cc
+++ b/examples/geometry_world/solar_system_run_dynamics.cc
@@ -1,13 +1,8 @@
 #include "drake/examples/geometry_world/solar_system.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
-#include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -16,10 +11,6 @@ namespace {
 
 using geometry::SceneGraph;
 using geometry::SourceId;
-using lcm::DrakeLcm;
-using systems::rendering::PoseBundleToDrawMessage;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -30,25 +21,12 @@ int do_main() {
   auto solar_system = builder.AddSystem<SolarSystem>(scene_graph);
   solar_system->set_name("SolarSystem");
 
-  DrakeLcm lcm;
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
-
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConfigureVisualization(*scene_graph, &builder);
 
   auto diagram = builder.Build();
 

--- a/examples/multibody/acrobot/BUILD.bazel
+++ b/examples/multibody/acrobot/BUILD.bazel
@@ -26,9 +26,7 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
         "//systems/primitives:constant_vector_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )
@@ -48,9 +46,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/controllers:linear_quadratic_regulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
         "//systems/primitives:affine_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -7,7 +7,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -15,8 +14,6 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
 #include "drake/systems/primitives/constant_vector_source.h"
 #include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
@@ -24,6 +21,7 @@ namespace drake {
 
 using geometry::SceneGraph;
 using geometry::SourceId;
+using lcm::DrakeLcm;
 using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::multibody_plant::MultibodyPlant;
@@ -91,7 +89,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // And build the Diagram:
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -24,15 +24,11 @@ namespace drake {
 
 using geometry::SceneGraph;
 using geometry::SourceId;
-using lcm::DrakeLcm;
 using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RevoluteJoint;
 using systems::ImplicitEulerIntegrator;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
-using systems::rendering::PoseBundleToDrawMessage;
 using systems::RungeKutta3Integrator;
 using systems::SemiExplicitEulerIntegrator;
 
@@ -86,17 +82,6 @@ int do_main() {
   builder.Connect(torque_source->get_output_port(),
                   acrobot.get_actuation_input_port());
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!acrobot.get_source_id());
 
@@ -104,13 +89,9 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConfigureVisualization(scene_graph, &builder);
 
   // And build the Diagram:
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -7,25 +7,24 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
 #include "drake/systems/primitives/affine_system.h"
 #include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 
 using geometry::SceneGraph;
+using lcm::DrakeLcm;
 using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RevoluteJoint;
 using systems::Context;
+
 namespace examples {
 namespace multibody {
 namespace acrobot {
@@ -108,7 +107,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // And build the Diagram:
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/multibody/bouncing_ball/BUILD.bazel
+++ b/examples/multibody/bouncing_ball/BUILD.bazel
@@ -44,8 +44,6 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -7,6 +7,7 @@
 #include "drake/examples/multibody/bouncing_ball/make_bouncing_ball_plant.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/math/random_rotation.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -41,6 +42,7 @@ using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using drake::multibody::multibody_plant::CoulombFriction;
+using lcm::DrakeLcm;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 using drake::multibody::QuaternionFloatingMobilizer;
@@ -93,7 +95,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // And build the Diagram:
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -7,8 +7,6 @@
 #include "drake/examples/multibody/bouncing_ball/make_bouncing_ball_plant.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
-#include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/math/random_rotation.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -17,9 +15,6 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -45,15 +40,11 @@ using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::SourceId;
-using lcm::DrakeLcm;
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 using drake::multibody::QuaternionFloatingMobilizer;
 using drake::systems::ImplicitEulerIntegrator;
-using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::Serializer;
-using drake::systems::rendering::PoseBundleToDrawMessage;
 using drake::systems::RungeKutta2Integrator;
 using drake::systems::RungeKutta3Integrator;
 using drake::systems::SemiExplicitEulerIntegrator;
@@ -91,17 +82,6 @@ int do_main() {
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
@@ -111,13 +91,9 @@ int do_main() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConfigureVisualization(scene_graph, &builder);
 
   // And build the Diagram:
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();

--- a/examples/multibody/pendulum/BUILD.bazel
+++ b/examples/multibody/pendulum/BUILD.bazel
@@ -22,9 +22,7 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm",
         "//systems/primitives:constant_vector_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -5,6 +5,7 @@
 #include "drake/common/drake_assert.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/multibody/benchmarks/pendulum/make_pendulum_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -18,6 +19,7 @@ namespace drake {
 
 using geometry::SceneGraph;
 using geometry::SourceId;
+using lcm::DrakeLcm;
 using multibody::benchmarks::pendulum::MakePendulumPlant;
 using multibody::benchmarks::pendulum::PendulumParameters;
 using multibody::multibody_plant::MultibodyPlant;
@@ -87,7 +89,9 @@ int do_main() {
 
   // Last thing before building the diagram; configure the system for
   // visualization.
-  geometry::ConfigureVisualization(scene_graph, &builder);
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -146,6 +146,9 @@ drake_cc_library(
         "//lcm",
         "//lcmtypes:viewer",
         "//math:geometric_transform",
+        "//systems/framework:diagram_builder",
+        "//systems/lcm",
+        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -18,7 +18,6 @@
 #include "drake/geometry/proximity_engine.h"
 
 namespace drake {
-
 namespace geometry {
 
 #ifndef DRAKE_DOXYGEN_CXX

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -7,6 +7,7 @@
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
+#include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace geometry {
@@ -27,12 +28,16 @@ class GeometryVisualizationImpl {
 }  // namespace internal
 #endif  // DRAKE_DOXYGEN_CXX
 
-/** Dispatches an LCM load message based on the registered geometry. It should
- be invoked _after_ registration is complete, but before context allocation.
- @param scene_graph    The system whose geometry will be sent in an LCM message.
+/** Configures the diagram to interface with drake_visualizer. This should be
+ invoked as the _last_ thing before building the diagram; registration of all
+ frames and geometries should be done, but not context allocated.
+ @param scene_graph  The system whose geometry will be sent in an LCM message.
+ @param builder      The diagram builder to which the system belongs; additional
+                     systems will be added to enable visualization updates.
  @throws std::logic_error if the system has already had its context allocated.
  */
-void DispatchLoadMessage(const SceneGraph<double>& scene_graph);
+void ConfigureVisualization(const SceneGraph<double>& scene_graph,
+                            systems::DiagramBuilder<double>* builder);
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -1,11 +1,12 @@
 /** @file
  Provides a set of functions to facilitate visualization operations based on
- geometry world state. */
+ geometry system state. */
 
 #pragma once
 
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
 #include "drake/systems/framework/diagram_builder.h"
 
@@ -28,16 +29,21 @@ class GeometryVisualizationImpl {
 }  // namespace internal
 #endif  // DRAKE_DOXYGEN_CXX
 
-/** Configures the diagram to interface with drake_visualizer. This should be
- invoked as the _last_ thing before building the diagram; registration of all
- frames and geometries should be done, but not context allocated.
- @param scene_graph  The system whose geometry will be sent in an LCM message.
+/** Dispatches an LCM load message based on the registered geometry. It should
+  be invoked _after_ registration is complete, but before context allocation. */
+void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
+                         lcm::DrakeLcmInterface* lcm);
+
+/** Extends the diagram with the required components to interface with
+ drake_visualizer.
+ @param scene_graph  The system whose geometry will be visualized.
  @param builder      The diagram builder to which the system belongs; additional
                      systems will be added to enable visualization updates.
- @throws std::logic_error if the system has already had its context allocated.
- */
-void ConfigureVisualization(const SceneGraph<double>& scene_graph,
-                            systems::DiagramBuilder<double>* builder);
+ @param lcm          The lcm interface through which lcm messages will be
+                     dispatched. */
+void ConnectVisualization(const SceneGraph<double>& scene_graph,
+                          systems::DiagramBuilder<double>* builder,
+                          lcm::DrakeLcmInterface* lcm);
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -13,6 +13,12 @@
 #include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
+namespace systems {
+
+template <typename T> class DiagramBuilder;
+
+}  // namespace systems
+
 namespace geometry {
 
 class GeometryInstance;
@@ -380,8 +386,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // Helper class to register input ports for a source id.
   void MakeSourcePorts(SourceId source_id);
 
-  // Allow the load dispatch to peek into SceneGraph.
-  friend void DispatchLoadMessage(const SceneGraph<double>&);
+  // Allow the load dispatch to peek into GeometrySystem.
+  friend void ConfigureVisualization(const SceneGraph<double>& scene_graph,
+                                     systems::DiagramBuilder<double>* builder);
 
   // Constructs a QueryObject for OutputPort allocation.
   QueryObject<T> MakeQueryObject() const;

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -13,11 +13,11 @@
 #include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
-namespace systems {
 
-template <typename T> class DiagramBuilder;
-
-}  // namespace systems
+// Forward declarations to give LCM message publication appropriate access.
+namespace lcm {
+class DrakeLcmInterface;
+}  // namespace lcm
 
 namespace geometry {
 
@@ -386,9 +386,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
   // Helper class to register input ports for a source id.
   void MakeSourcePorts(SourceId source_id);
 
-  // Allow the load dispatch to peek into GeometrySystem.
-  friend void ConfigureVisualization(const SceneGraph<double>& scene_graph,
-                                     systems::DiagramBuilder<double>* builder);
+  // Allow the load dispatch to peek into SceneGraph.
+  friend void DispatchLoadMessage(const SceneGraph<double>&,
+                                  lcm::DrakeLcmInterface*);
 
   // Constructs a QueryObject for OutputPort allocation.
   QueryObject<T> MakeQueryObject() const;


### PR DESCRIPTION
This PR is a basis for conversation about a design possibility and not for merging.

Related to #8473.

PR's Design
=========
This represents one approach to eliminating the boilerplate of connecting a diagram with a geometry system to drake_visualizer.
Pros:
  1. Hide the details of how GeometrySystem talks to drake_visualizer,
     simplifying the call sites.
  2. Automatically dispatches the "load robot" lcm message (without
     declaring it's doing so).

Cons:
  1. It is *slightly* brittle; it precludes the possibility of registering
     geometry after diagram construction.
  2. It must be invoked *after* geometry registration but *before* diagram building
     (another mark of brittleness)

The key modifications are in `geometry_visualization.*`. Most of the rest of the files represent the concentration of the boilerplate into one piece of functionality and you'll see a lot of deletion of boilerplate and its dependencies.

One of the constraints of note is that we currently need to send a "load robot" LCM message. This must take place after all registration. This current design passes the geometry system in *before* build/context allocation as a convenience to the user. Alternatively, we could break this into *two* calls. One instruments visualization, and the other dispatches the load message and takes a context as an input argument -- however, the user would have to extract the `GeometrySystem`'s context from the `DiagramContext`.

Alternative Design -- VisualGeometrySystem
==================================
This design would create a `Diagram` which would consist of a `GeometrySystem`, a `PoseBundleToDrawMessage`, and a `LcmPublisherSystem`. It would own it's own instance of `DrakeLcm`.  In principle, the user would instantiate one of these instead of a `GeometrySystem` to get visualized geometry.

Pros:
  1. The diagram is more consistent with the Drake paradigm.

Cons:

  1. `GeometrySystem` has a great deal of API that gets called by other code to register geometry and frames. This would have to:
     a. Leak the embedded `GeometrySystem` out via mutable accessor, or
     b. Create a thin shell wrapping all of the important API.
 2. `GeometrySystem` dynamically creates input ports based on registered geometry sources. The diagram would have to mirror this (making the diagram more complex than a "fixed" box and converging more strongly toward the "thin wrapper" approach.
 3. Without a thin shell wrapper of the complete API, code written to one would *not* be compatible with code written to the other. In an ideal world, we'd want to swap between the two based on a flag.

Based on the cost of creating the bundled diagram, silently appending systems to the current diagram felt the more flexible way forward.


```
Category            added  modified  removed  
----------------------------------------------
code                32     11        128      
comments            3      16        8        
blank               8      0         14       
----------------------------------------------
TOTAL               43     27        150  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8526)
<!-- Reviewable:end -->
