### PR TITLE
Allow installed Drake headers to directly use fmt

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -16,6 +16,10 @@
       "Hints": ["@prefix@/lib/cmake/eigen3"],
       "X-CMake-Find-Args": ["CONFIG"]
     },
+    "fmt": {
+      "Hints": ["@prefix@/lib/cmake/fmt"],
+      "X-CMake-Find-Args": ["CONFIG"]
+    },
     "ignition-math4": {
       "Version": "4.0.0",
       "Hints": ["@prefix@/lib/cmake/ignition-math4"],
@@ -65,6 +69,7 @@
         ":drake-lcmtypes-cpp",
         "bot2-core-lcmtypes:lcmtypes_bot2-core-cpp",
         "Eigen3:Eigen",
+        "fmt:fmt-header-only",
         "ignition-math4:ignition-math4",
         "ignition-rndf0:ignition-rndf0",
         "lcm:lcm",


### PR DESCRIPTION
It is likely that nothing would currently break by using `fmt` directly in Drake headers, but this is the correct way to declare that intent.

I also looked at whether fmt has a new release -- it does not.

~But spdlog did, so I've added that here as well.~ _Edit: withdrawn, because yak-shave._

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8528)
<!-- Reviewable:end -->
