### PR TITLE
Bump externals to latest releases

### DIFF
--- a/tools/install/libdrake/drake.cps
+++ b/tools/install/libdrake/drake.cps
@@ -48,7 +48,7 @@
       "X-CMake-Find-Args": ["CONFIG"]
     },
     "spdlog": {
-      "Version": "1.0.0",
+      "Version": "0.16.3",
       "Hints": ["@prefix@/lib/cmake/spdlog"],
       "X-CMake-Find-Args": ["CONFIG"]
     },

--- a/tools/workspace/bullet/repository.bzl
+++ b/tools/workspace/bullet/repository.bzl
@@ -8,8 +8,8 @@ def bullet_repository(
     github_archive(
         name = name,
         repository = "bulletphysics/bullet3",
-        commit = "2.86.1",
-        sha256 = "c058b2e4321ba6adaa656976c1a138c07b18fc03b29f5b82880d5d8228fbf059",  # noqa
+        commit = "2.87",
+        sha256 = "438c151c48840fe3f902ec260d9496f8beb26dba4b17769a4a53212903935f95",  # noqa
         build_file = "@drake//tools/workspace/bullet:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/ccd/repository.bzl
+++ b/tools/workspace/ccd/repository.bzl
@@ -8,8 +8,8 @@ def ccd_repository(
     github_archive(
         name = name,
         repository = "danfis/libccd",
-        commit = "5677d384315d64c41a9e1dabe6a531f10ffbb7fb",
-        sha256 = "3b37ef4555d087f7abb6aa59c3b5cecb96410ea10e95a086ef2771569fb6fdfb",  # noqa
+        commit = "63d3a911f016465a2ecf169d0c8bff8b601f1715",
+        sha256 = "1032cae04202330c5bcc9a652d75bef64669656bf4ea6cab74c5ff11c3f7a301",  # noqa
         build_file = "@drake//tools/workspace/ccd:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/fcl/repository.bzl
+++ b/tools/workspace/fcl/repository.bzl
@@ -8,8 +8,8 @@ def fcl_repository(
     github_archive(
         name = name,
         repository = "flexible-collision-library/fcl",
-        commit = "2d3d8f7ea6f255b5f3743658c49ad869b9978c03",
-        sha256 = "8a251eee79e916abe34d9f091ee247e77b5246fbe75ced544e9d2e4b460661ea",  # noqa
+        commit = "2b0f911841d7c116c8ac076b50b1992eb3dab22a",
+        sha256 = "dc1e60ad77b36b55e68f62bdf838815f8705baad08bce9de6e322958c368a6b6",  # noqa
         build_file = "@drake//tools/workspace/fcl:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/lcm/repository.bzl
+++ b/tools/workspace/lcm/repository.bzl
@@ -8,8 +8,8 @@ def lcm_repository(
     github_archive(
         name = name,
         repository = "lcm-proj/lcm",
-        commit = "87866bd0dbb1f9d5a0f662a6f5caecf469fd42d2",
-        sha256 = "fd0afaf29954c26a725626b7bd24e873e303e84bb62dfcc05162be3f5ae30cd1",  # noqa
+        commit = "82bd3a223e3227c70832307e53a65c13c1e5f81b",
+        sha256 = "4a50e23b6715d625fdd1f2d5f23152bab8af87ff11681b58aa14d7d61bb3280e",  # noqa
         build_file = "@drake//tools/workspace/lcm:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/lcmtypes_robotlocomotion/repository.bzl
+++ b/tools/workspace/lcmtypes_robotlocomotion/repository.bzl
@@ -8,8 +8,8 @@ def lcmtypes_robotlocomotion_repository(
     github_archive(
         name = "lcmtypes_robotlocomotion",
         repository = "RobotLocomotion/lcmtypes",
-        commit = "8aea7a94d53dea01bfceba5f3cbe8e8cc9fb0244",
-        sha256 = "f23a143d7865ea4f6cd9aeb2211fe36e20712a39d439cf16fea2b11685f29b61",  # noqa
+        commit = "821ff4b463a9cb8f616914d87289714fcb356a92",
+        sha256 = "1407f8197950a6798908bd26c2e6186cf781f7e13ce91510da2b4823f4564953",  # noqa
         build_file = "@drake//tools/workspace/lcmtypes_robotlocomotion:package.BUILD.bazel",  # noqa
         mirrors = mirrors,
     )

--- a/tools/workspace/octomap/repository.bzl
+++ b/tools/workspace/octomap/repository.bzl
@@ -8,8 +8,8 @@ def octomap_repository(
     github_archive(
         name = name,
         repository = "OctoMap/octomap",
-        commit = "v1.8.1",
-        sha256 = "8b18ef7693e87f1400b9a8bc41f86e3b28259ac98c0b458037232652380aa6af",  # noqa
+        commit = "v1.9.0",
+        sha256 = "5f81c9a8cbc9526b2e725251cd3a829e5222a28201b394314002146d8b9214dd",  # noqa
         build_file = "@drake//tools/workspace/octomap:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/osqp/repository.bzl
+++ b/tools/workspace/osqp/repository.bzl
@@ -8,8 +8,8 @@ def osqp_repository(
     github_archive(
         name = name,
         repository = "oxfordcontrol/osqp",
-        commit = "c1d13d4b499243ea4afa0a321aa2226c6c1cd29a",
-        sha256 = "8886fbaa794effcc39bb11c2cb089b247de552e95b9ccdcda7baa9d973507ba4",  # noqa
+        commit = "v0.3.0",
+        sha256 = "6fc0c4578f665aef8bdf1a8c8c3b474ce34f8782b100c7d06069da3435672c69",  # noqa
         build_file = "@drake//tools/workspace/osqp:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/spdlog/repository.bzl
+++ b/tools/workspace/spdlog/repository.bzl
@@ -8,8 +8,11 @@ def spdlog_repository(
     github_archive(
         name = name,
         repository = "gabime/spdlog",
-        commit = "v0.13.0",
-        sha256 = "d798a6ca19165f0a18a43938859359269f5a07fd8e0eb83ab8674739c9e8f361",  # noqa
+        # This the commit immediately following v0.16.3 that fixes the version
+        # badging.  We should change back to saying "v0.17.1" or whatever here
+        # (instead of a commit hash) upon the next upstream release.
+        commit = "f258af4364ed2aa966ddce8292b9bbde8bbb6152",
+        sha256 = "69799a0963fe396e569bedcc9263511a61e3b6dc586bd800bd9597ad3c2268f0",  # noqa
         build_file = "@drake//tools/workspace/spdlog:package.BUILD.bazel",
         mirrors = mirrors,
     )

--- a/tools/workspace/tinydir/repository.bzl
+++ b/tools/workspace/tinydir/repository.bzl
@@ -8,8 +8,8 @@ def tinydir_repository(
     github_archive(
         name = name,
         repository = "cxong/tinydir",
-        commit = "3aae9224376b5e1a23fd824f19d9501162620b53",
-        sha256 = "fa7eec0baaa5f6c57df1a38b064ec3a4f098f477f0a64d97c646a4470ffdd3b6",  # noqa
+        commit = "677733daa2859c963da953872f8d591251c2ae5e",
+        sha256 = "ac87282bf2a127df61fabe2eb2e4cbe2adb2050ecf3c4b9885ffddd4bf887125",  # noqa
         build_file = "@drake//tools/workspace/tinydir:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
I think checking up on this should be regular hygiene -- live close(ish) to head.

At least, for numbered releases that we compile from source, I think this is a good idea.  I am not 100% convinced about sources that we pull from an intermediate git revision being frequently refreshed, but in the cases where I've done that here, it seemed like a good idea.

(For reviewers: note that the `spdlog` bump's commit message has an extra detail.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8535)
<!-- Reviewable:end -->
