### PR TITLE
 pybind: Move clang-specific options to `clang_opts`

### DIFF
--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -42,9 +42,9 @@ GCC_CC_TEST_FLAGS = [
     "-Wno-unused-parameter",
 ]
 
-def _platform_copts(rule_copts, rule_gcc_copts, cc_test = 0):
-    """Returns both the rule_copts (plus rule_gcc_copts iff under GCC), and
-    platform-specific copts.
+def _platform_copts(rule_copts, rule_gcc_copts, rule_clang_copts, cc_test = 0):
+    """Returns both the rule_copts (plus rule_{cc}_copts iff under the
+    specified compiler), and platform-specific copts.
 
     When cc_test=1, the GCC_CC_TEST_FLAGS will be added.  It should only be set
     to 1 from cc_test rules or rules that are boil down to cc_test rules.
@@ -53,8 +53,10 @@ def _platform_copts(rule_copts, rule_gcc_copts, cc_test = 0):
     if cc_test:
         extra_gcc_flags = GCC_CC_TEST_FLAGS
     return select({
-        "//tools/cc_toolchain:apple": CLANG_FLAGS + rule_copts,
-        "//tools/cc_toolchain:clang4.0-linux": CLANG_FLAGS + rule_copts,
+        "//tools/cc_toolchain:apple":
+            CLANG_FLAGS + rule_copts + rule_clang_copts,
+        "//tools/cc_toolchain:clang4.0-linux":
+            CLANG_FLAGS + rule_copts + rule_clang_copts,
         "//tools/cc_toolchain:gcc5-linux":
             GCC_FLAGS + extra_gcc_flags + rule_copts + rule_gcc_copts,
         "//tools/cc_toolchain:gcc6-linux":
@@ -299,6 +301,7 @@ def drake_cc_library(
         srcs = [],
         deps = [],
         copts = [],
+        clang_copts = [],
         gcc_copts = [],
         linkstatic = 1,
         install_hdrs_exclude = [],
@@ -314,7 +317,7 @@ def drake_cc_library(
     of Drake).  In other words, all of Drake's C++ libraries must be declared
     using the drake_cc_library macro.
     """
-    new_copts = _platform_copts(copts, gcc_copts)
+    new_copts = _platform_copts(copts, gcc_copts, clang_copts)
     # We install private_hdrs by default, because Bazel's visibility denotes
     # whether headers can be *directly* included when using cc_library; it does
     # not precisely relate to which headers should appear in the install tree.
@@ -347,6 +350,7 @@ def drake_cc_binary(
         copts = [],
         linkopts = [],
         gcc_copts = [],
+        clang_copts = [],
         linkshared = 0,
         linkstatic = 1,
         testonly = 0,
@@ -367,7 +371,7 @@ def drake_cc_binary(
     tests. The smoke-test will be named <name>_test. You may override cc_test
     defaults using test_rule_args=["-f", "--bar=42"] or test_rule_size="baz".
     """
-    new_copts = _platform_copts(copts, gcc_copts)
+    new_copts = _platform_copts(copts, gcc_copts, clang_copts)
     new_srcs, new_deps = _maybe_add_pruned_private_hdrs_dep(
         base_name = name,
         srcs = srcs,
@@ -441,6 +445,7 @@ def drake_cc_test(
         deps = [],
         copts = [],
         gcc_copts = [],
+        clang_copts = [],
         disable_in_compilation_mode_dbg = False,
         **kwargs):
     """Creates a rule to declare a C++ unit test.  Note that for almost all
@@ -459,7 +464,7 @@ def drake_cc_test(
     if not srcs:
         srcs = ["test/%s.cc" % name]
     kwargs['testonly'] = 1
-    new_copts = _platform_copts(copts, gcc_copts, cc_test = 1)
+    new_copts = _platform_copts(copts, gcc_copts, clang_copts, cc_test = 1)
     new_srcs, new_deps = _maybe_add_pruned_private_hdrs_dep(
         base_name = name,
         srcs = srcs,

--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -40,10 +40,13 @@ def _drake_pybind_cc_binary(
         srcs = srcs + ["//tools/install/libdrake:libdrake.so"],
         # These copts are per pybind11 deficiencies.
         copts = [
+            "-Wno-cpp",
+        ] + copts,
+        clang_copts = [
             "-Wno-#warnings",
             "-Wno-cpp",
             "-Wno-unknown-warning-option",
-        ] + copts,
+        ],
         # This is how you tell Bazel to create a shared library.
         linkshared = 1,
         linkstatic = 1,


### PR DESCRIPTION
Resolves #8437