### PR TITLE
Fixes inconsistency with the default values of basic vectors vs named (basic) vectors.

### DIFF
--- a/automotive/maliput_railcar_state.named_vector
+++ b/automotive/maliput_railcar_state.named_vector
@@ -3,8 +3,10 @@ namespace: "drake::automotive"
 element {
     name: "s"
     doc: "The s-coordinate of the vehicle in a `Lane`-frame."
+    default_value: "0.0"
 }
 element {
     name: "speed"
     doc: "The speed of the vehicle in physical space."
+    default_value: "0.0"
 }

--- a/automotive/simple_car_state.named_vector
+++ b/automotive/simple_car_state.named_vector
@@ -3,16 +3,20 @@ namespace: "drake::automotive"
 element {
     name: "x"
     doc: "x"
+    default_value: "0.0"
 }
 element {
     name: "y"
     doc: "y"
+    default_value: "0.0"
 }
 element {
     name: "heading"
     doc: "heading"
+    default_value: "0.0"
 }
 element {
     name: "velocity"
     doc: "velocity"
+    default_value: "0.0"
 }

--- a/examples/acrobot/acrobot_input.named_vector
+++ b/examples/acrobot/acrobot_input.named_vector
@@ -4,4 +4,5 @@ element {
     name: "tau"
     doc: "Torque at the elbow"
     doc_units: "Nm"
+    default_value: "0.0"
 }

--- a/examples/acrobot/acrobot_state.named_vector
+++ b/examples/acrobot/acrobot_state.named_vector
@@ -4,19 +4,23 @@ element {
     name: "theta1"
     doc: "The shoulder joint angle"
     doc_units: "rad"
+    default_value: "0.0"
 }
 element {
     name: "theta2"
     doc: "The elbow joint angle"
     doc_units: "rad"
+    default_value: "0.0"
 }
 element {
     name: "theta1dot"
     doc: "The shoulder joint velocity "
     doc_units: "rad/s"
+    default_value: "0.0"
 }
 element {
     name: "theta2dot"
     doc: "The elbow joint velocity"
     doc_units: "rad/s"
+    default_value: "0.0"
 }

--- a/examples/pendulum/pendulum_input.named_vector
+++ b/examples/pendulum/pendulum_input.named_vector
@@ -2,5 +2,7 @@ namespace: "drake::examples::pendulum"
 
 element {
     name: "tau"
-    doc: "tau"
+    doc: "Torque at the joint."
+    doc_units: "Newton-meters"
+    default_value: "0.0"
 }

--- a/examples/pendulum/pendulum_state.named_vector
+++ b/examples/pendulum/pendulum_state.named_vector
@@ -2,9 +2,13 @@ namespace: "drake::examples::pendulum"
 
 element {
     name: "theta"
-    doc: "theta"
+    doc: "The angle of the pendulum."
+    doc_units: "radians"
+    default_value: "0.0"
 }
 element {
     name: "thetadot"
-    doc: "thetadot"
+    doc: "The angular velocity of the pendulum."
+    doc_units: "radians/sec"
+    default_value: "0.0"
 }

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -12,6 +12,7 @@
 
 #include "drake/common/drake_bool.h"
 #include "drake/common/never_destroyed.h"
+#include "drake/common/symbolic.h"
 #include "drake/systems/framework/basic_vector.h"
 
 namespace drake {
@@ -50,6 +51,16 @@ class Sample : public systems::BasicVector<T> {
     this->set_x(42.0);
     this->set_two_word(0.0);
     this->set_absone(0.0);
+  }
+
+  /// Create a symbolic::Variable for each element with the known variable
+  /// name.  This is only available for T == symbolic::Expression.
+  template <typename U = T>
+  typename std::enable_if<std::is_same<U, symbolic::Expression>::value>::type
+  SetToNamedVariables() {
+    this->set_x(symbolic::Variable("x"));
+    this->set_two_word(symbolic::Variable("two_word"));
+    this->set_absone(symbolic::Variable("absone"));
   }
 
   Sample<T>* DoClone() const override { return new Sample; }

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -84,22 +84,25 @@ GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
   EXPECT_TRUE(ExtractBoolOrThrow(dut.IsValid()));
 }
 
+GTEST_TEST(SampleTest, SetToNamedVariablesTest) {
+  Sample<symbolic::Expression> dut;
+  dut.SetToNamedVariables();
+  EXPECT_EQ(dut.x().to_string(), "x");
+  EXPECT_EQ(dut.two_word().to_string(), "two_word");
+  EXPECT_EQ(dut.absone().to_string(), "absone");
+}
+
 // Cover Simple<Expression>::IsValid.
 GTEST_TEST(SampleTest, SymbolicIsValid) {
   Sample<symbolic::Expression> dut;
-  const symbolic::Variable x{"x"};
-  const symbolic::Variable two_word{"two_word"};
-  const symbolic::Variable absone{"absone"};
-  dut.set_x(x);
-  dut.set_two_word(two_word);
-  dut.set_absone(absone);
+  dut.SetToNamedVariables();
   const symbolic::Formula expected_is_valid =
-      !isnan(x) &&
-      !isnan(two_word) &&
-      !isnan(absone) &&
-      (x >= 0.0) &&
-      (absone >= -1.0) &&
-      (absone <= 1.0);
+      !isnan(dut.x()) &&
+      !isnan(dut.two_word()) &&
+      !isnan(dut.absone()) &&
+      (dut.x() >= 0.0) &&
+      (dut.absone() >= -1.0) &&
+      (dut.absone() <= 1.0);
   EXPECT_TRUE(dut.IsValid().value().EqualTo(expected_is_valid));
 }
 

--- a/tools/vector_gen/vector_gen.bzl
+++ b/tools/vector_gen/vector_gen.bzl
@@ -127,8 +127,9 @@ def drake_cc_vector_gen_library(
         srcs = outs.srcs,
         hdrs = outs.hdrs,
         deps = deps + [
-            "//systems/framework:vector",
             "//common:essential",
+            "//common:symbolic",
+            "//systems/framework:vector",
         ],
         **kwargs)
 


### PR DESCRIPTION
Adds helper that initializes the vector to vector of Variable with the known variable names.  (this makes using named vectors with Expression so much nicer).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8538)
<!-- Reviewable:end -->
