### PR TITLE
Compile rigid_body_tree.cc in separate halves

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -192,29 +192,47 @@ drake_cc_library(
     ],
 )
 
+# We compile rigid_body_tree.cc in shards (only a portion of the source code in
+# the file is compiled at a time).  See comments in the .cc file for details.
+_RBT_SHARD_COUNT = 2
+
+# Define a library for each shard.
+[
+    drake_cc_library(
+        name = "rigid_body_tree_cc_{}".format(i),
+        srcs = ["rigid_body_tree.cc".format(i)],
+        hdrs = ["rigid_body_tree.h"],
+        copts = ["-DDRAKE_RBT_SHARD={}".format(i)],
+        visibility = [],
+        deps = [
+            ":kinematics_cache",
+            ":resolve_center_of_pressure",
+            ":rigid_body",
+            ":rigid_body_actuator",
+            ":rigid_body_frame",
+            ":rigid_body_loop",
+            ":rigid_body_tree_datatypes",
+            "//common:autodiff",
+            "//common:essential",
+            "//math:geometric_transform",
+            "//math:gradient",
+            "//multibody/collision",
+            "//multibody/joints",
+            "//multibody/shapes",
+            "//util",
+        ],
+    )
+    for i in range(_RBT_SHARD_COUNT)
+]
+
 # The rigid_body_tree.h implementation is in two files: rigid_body_tree.cc and
 # rigid_body_tree_contact.cc.  This is the rule for the first file.
 drake_cc_library(
     name = "rigid_body_tree_cc",
-    srcs = ["rigid_body_tree.cc"],
-    hdrs = ["rigid_body_tree.h"],
     visibility = [],
     deps = [
-        ":kinematics_cache",
-        ":resolve_center_of_pressure",
-        ":rigid_body",
-        ":rigid_body_actuator",
-        ":rigid_body_frame",
-        ":rigid_body_loop",
-        ":rigid_body_tree_datatypes",
-        "//common:autodiff",
-        "//common:essential",
-        "//math:geometric_transform",
-        "//math:gradient",
-        "//multibody/collision",
-        "//multibody/joints",
-        "//multibody/shapes",
-        "//util",
+        ":rigid_body_tree_cc_{}".format(i)  # N.B. Defined immediately above.
+        for i in range(_RBT_SHARD_COUNT)
     ],
 )
 

--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -82,6 +82,34 @@ using std::unordered_map;
 using std::vector;
 using std::endl;
 
+// We compile rigid_body_tree.cc in shards (only a portion of the source code
+// in the file is compiled at a time) in order to reduce build latency and
+// mitigate the memory footprint of any single compiler instance.
+//
+// The build system will compile this file multiple times, each with a
+// different numeric value for DRAKE_RBT_SHARD.
+//
+// Within this file, we guard various functions or instantiations with
+// preprocessor statements like "if DRAKE_RBT_SHARD == 0".
+//
+// In shard 0 we compile all class methods that are not also method templates,
+// as well as some method templates.  In shard 1 we compile the remainder of
+// the method templates.
+//
+// The shard assignments are chosen so that methods that might benefit from
+// inlining their calls are within the same shard.  (In other words, the shards
+// draw a partition through the call graph that crosses as few performance-
+// critical edges as practical.)  When assigning or updating new methods to a
+// shard, try to assign the new method to the same shard as the methods it
+// calls.  If it does not need to call anything else, assign it to the shard
+// that compiles most quickly currently.
+
+#ifndef DRAKE_RBT_SHARD
+#error Missing DRAKE_RBT_SHARD definition
+#endif
+
+#if DRAKE_RBT_SHARD == 0
+
 const char* const RigidBodyTreeConstants::kWorldName = "world";
 const int RigidBodyTreeConstants::kWorldBodyIndex = 0;
 // TODO(liang.fok) Update the following two variables along with the resolution
@@ -1190,6 +1218,9 @@ KinematicsCache<T> RigidBodyTree<T>::CreateKinematicsCache() const {
   return CreateKinematicsCacheWithType<T>();
 }
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 template <typename T>
 template <typename DerivedQ>
 KinematicsCache<typename DerivedQ::Scalar> RigidBodyTree<T>::doKinematics(
@@ -1315,6 +1346,9 @@ void RigidBodyTree<T>::doKinematics(KinematicsCache<Scalar>& cache,
 
   cache.setJdotVCached(compute_JdotV && cache.hasV());
 }
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 template <typename T>
 template <typename Scalar>
@@ -1901,6 +1935,9 @@ KinematicPath RigidBodyTree<T>::findKinematicPath(
   return path;
 }
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 template <typename T>
 template <typename Scalar>
 TwistMatrix<Scalar> RigidBodyTree<T>::geometricJacobian(
@@ -2048,6 +2085,9 @@ TwistVector<Scalar> RigidBodyTree<T>::transformSpatialAcceleration(
   spatial_accel_temp += spatial_acceleration;
   return transformSpatialMotion(T_old_to_new, spatial_accel_temp);
 }
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 template <typename T>
 template <typename Scalar>
@@ -2345,6 +2385,9 @@ Matrix<typename DerivedV::Scalar, Dynamic, 1> RigidBodyTree<T>::frictionTorques(
   return ret;
 }
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 template <typename T>
 template <typename Scalar, typename PointScalar>
 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>
@@ -2440,6 +2483,9 @@ RigidBodyTree<T>::relativeRollPitchYawJacobian(
                        in_terms_of_qdot);
 }
 
+#endif
+#if DRAKE_RBT_SHARD == 0
+
 template <typename T>
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>
@@ -2461,6 +2507,9 @@ RigidBodyTree<T>::forwardKinPositionGradient(
   }
   return ret;
 }
+
+#endif
+#if DRAKE_RBT_SHARD == 1
 
 template <typename T>
 template <typename Scalar>
@@ -2597,6 +2646,9 @@ RigidBodyTree<T>::relativeRollPitchYawJacobianDotTimesV(
       Phi * J_geometric_dot_times_v.template topRows<kSpaceDimension>();
   return ret;
 }
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 template <typename T>
 RigidBody<T>* RigidBodyTree<T>::FindBody(const std::string& body_name,
@@ -2967,6 +3019,9 @@ Matrix<Scalar, Eigen::Dynamic, 1> RigidBodyTree<T>::positionConstraints(
   return ret;
 }
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 template <typename T>
 template <typename Scalar>
 Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>
@@ -3012,6 +3067,9 @@ RigidBodyTree<T>::positionConstraintsJacDotTimesV(
   }
   return ret;
 }
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 template <typename T>
 template <typename DerivedA, typename DerivedB, typename DerivedC>
@@ -3318,6 +3376,9 @@ RigidBodyTree<T>::CalcFrameSpatialVelocityJacobianDotTimesVInWorldFrame(
 
 // clang-format off
 
+#endif
+#if DRAKE_RBT_SHARD == 0
+
 // Explicit template instantiations for massMatrix.
 template MatrixX<AutoDiffXd     > RigidBodyTree<double>::massMatrix<AutoDiffXd     >(KinematicsCache<AutoDiffXd     >&) const;  // NOLINT
 template MatrixXd                 RigidBodyTree<double>::massMatrix<double         >(KinematicsCache<double         >&) const;  // NOLINT
@@ -3346,9 +3407,15 @@ template MatrixX<double         > RigidBodyTree<double>::GetQDotToVelocityMappin
 template VectorX<AutoDiffXd     > RigidBodyTree<double>::dynamicsBiasTerm<AutoDiffXd     >(KinematicsCache<AutoDiffXd     >&, unordered_map<RigidBody<double> const*, WrenchVector<AutoDiffXd     >, hash<RigidBody<double> const*>, equal_to<RigidBody<double> const*>, Eigen::aligned_allocator<pair<RigidBody<double> const* const, WrenchVector<AutoDiffXd     >>>> const&, bool) const;  // NOLINT
 template VectorXd                 RigidBodyTree<double>::dynamicsBiasTerm<double         >(KinematicsCache<double         >&, unordered_map<RigidBody<double> const*, WrenchVector<double         >, hash<RigidBody<double> const*>, equal_to<RigidBody<double> const*>, Eigen::aligned_allocator<pair<RigidBody<double> const* const, WrenchVector<double         >>>> const&, bool) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 // Explicit template instantiations for geometricJacobian.
 template TwistMatrix<AutoDiffXd     > RigidBodyTree<double>::geometricJacobian<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int, int, bool, vector<int, allocator<int>>*) const;  // NOLINT
 template TwistMatrix<double         > RigidBodyTree<double>::geometricJacobian<double         >(KinematicsCache<double         > const&, int, int, int, bool, vector<int, allocator<int>>*) const;  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 // Explicit template instantiations for relativeTransform.
 template Eigen::Transform<AutoDiffXd     , 3, 1, 0> RigidBodyTree<double>::relativeTransform<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int) const;  // NOLINT
@@ -3366,9 +3433,15 @@ template TwistMatrix<double         > RigidBodyTree<double>::centroidalMomentumM
 template MatrixX<AutoDiffXd     > RigidBodyTree<double>::forwardKinPositionGradient<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int, int) const;  // NOLINT
 template MatrixXd                 RigidBodyTree<double>::forwardKinPositionGradient<double         >(KinematicsCache<double         > const&, int, int, int) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 // Explicit template instantiations for geometricJacobianDotTimesV.
 template TwistVector<AutoDiffXd     > RigidBodyTree<double>::geometricJacobianDotTimesV<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int, int) const;  // NOLINT
 template TwistVector<double         > RigidBodyTree<double>::geometricJacobianDotTimesV<double         >(KinematicsCache<double         > const&, int, int, int) const;  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 // Explicit template instantiations for centerOfMassJacobianDotTimesV.
 template Vector3<AutoDiffXd     > RigidBodyTree<double>::centerOfMassJacobianDotTimesV<AutoDiffXd     >(KinematicsCache<AutoDiffXd     >&, set<int, less<int>, allocator<int>> const&) const;  // NOLINT
@@ -3382,6 +3455,9 @@ template TwistVector<double         > RigidBodyTree<double>::centroidalMomentumM
 template VectorX<AutoDiffXd     > RigidBodyTree<double>::positionConstraints<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&) const;  // NOLINT
 template VectorXd                 RigidBodyTree<double>::positionConstraints<double         >(KinematicsCache<double         > const&) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 // Explicit template instantiations for positionConstraintsJacobian.
 template MatrixX<AutoDiffXd     > RigidBodyTree<double>::positionConstraintsJacobian<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, bool) const;  // NOLINT
 template MatrixXd                 RigidBodyTree<double>::positionConstraintsJacobian<double         >(KinematicsCache<double         > const&, bool) const;  // NOLINT
@@ -3390,13 +3466,22 @@ template MatrixXd                 RigidBodyTree<double>::positionConstraintsJaco
 template VectorX<AutoDiffXd     > RigidBodyTree<double>::positionConstraintsJacDotTimesV<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&) const;  // NOLINT
 template VectorXd                 RigidBodyTree<double>::positionConstraintsJacDotTimesV<double         >(KinematicsCache<double         > const&) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 0
+
 // Explicit template instantiations for jointLimitConstriants.
 template void RigidBodyTree<double>::jointLimitConstraints<VectorXd            , VectorXd            , MatrixXd            >(Eigen::MatrixBase<VectorXd            > const&, Eigen::MatrixBase<VectorXd            >&, Eigen::MatrixBase<MatrixXd            >&) const;  // NOLINT
 template void RigidBodyTree<double>::jointLimitConstraints<Eigen::Map<VectorXd>, Eigen::Map<VectorXd>, Eigen::Map<MatrixXd>>(Eigen::MatrixBase<Eigen::Map<VectorXd>> const&, Eigen::MatrixBase<Eigen::Map<VectorXd>>&, Eigen::MatrixBase<Eigen::Map<MatrixXd>>&) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 // Explicit template instantiations for relativeTwist.
 template TwistVector<AutoDiffXd     > RigidBodyTree<double>::relativeTwist<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int, int) const;  // NOLINT
 template TwistVector<double         > RigidBodyTree<double>::relativeTwist<double         >(KinematicsCache<double         > const&, int, int, int) const;  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 // Explicit template instantiations for worldMomentumMatrix.
 template TwistMatrix<AutoDiffXd     > RigidBodyTree<double>::worldMomentumMatrix<AutoDiffXd     >(KinematicsCache<AutoDiffXd     >&, set<int, less<int>, allocator<int>> const&, bool) const;  // NOLINT
@@ -3405,8 +3490,14 @@ template TwistMatrix<double         > RigidBodyTree<double>::worldMomentumMatrix
 // Explicit template instantiations for worldMomentumMatrixDotTimesV.
 template TwistVector<double> RigidBodyTree<double>::worldMomentumMatrixDotTimesV<double>(KinematicsCache<double>&, set<int, less<int>, allocator<int>> const&) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 1
+
 // Explicit template instantiations for transformSpatialAcceleration.
 template TwistVector<double> RigidBodyTree<double>::transformSpatialAcceleration<double>(KinematicsCache<double> const&, TwistVector<double> const&, int, int, int, int) const;  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 // Explicit template instantiations for frictionTorques
 template VectorX<AutoDiffXd     > RigidBodyTree<double>::frictionTorques(Eigen::MatrixBase<VectorX<AutoDiffXd     >> const& v) const;  // NOLINT
@@ -3429,6 +3520,9 @@ template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMa
 template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<MatrixXd                  >(const KinematicsCache<double>&, const Eigen::MatrixBase<MatrixXd                  >&);  // NOLINT
 template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd const>>(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::Map<MatrixXd const>>&);  // NOLINT
 template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd      >>(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::Map<MatrixXd      >>&);  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 1
 
 // Explicit template instantiations for DoTransformPointsJacobian.
 template MatrixX<double    > RigidBodyTree<double>::DoTransformPointsJacobian<double    , double    >(const KinematicsCache<double    >&, const Eigen::Ref<const Matrix3X<double    >>&, int, int, bool) const;  // NOLINT
@@ -3455,9 +3549,15 @@ template VectorX<AutoDiffXd     > RigidBodyTree<double>::relativeRollPitchYawJac
 template VectorXd                 RigidBodyTree<double>::relativeQuaternionJacobianDotTimesV<double         >(KinematicsCache<double         > const&, int, int) const;  // NOLINT
 template VectorX<AutoDiffXd     > RigidBodyTree<double>::relativeQuaternionJacobianDotTimesV<AutoDiffXd     >(KinematicsCache<AutoDiffXd     > const&, int, int) const;  // NOLINT
 
+#endif
+#if DRAKE_RBT_SHARD == 0
+
 // Explicit template instantiations for CheckCacheValidity(cache).
 template void RigidBodyTree<double>::CheckCacheValidity(const KinematicsCache<double         >&) const;  // NOLINT
 template void RigidBodyTree<double>::CheckCacheValidity(const KinematicsCache<AutoDiffXd     >&) const;  // NOLINT
+
+#endif
+#if DRAKE_RBT_SHARD == 1
 
 // Explicit template instantiations for doKinematics(cache).
 template void RigidBodyTree<double>::doKinematics(KinematicsCache<double         >&, bool) const;  // NOLINT
@@ -3479,8 +3579,8 @@ template KinematicsCache<AutoDiffXd     > RigidBodyTree<double>::doKinematics(Ei
 template KinematicsCache<double>          RigidBodyTree<double>::doKinematics(Eigen::MatrixBase<Eigen::Map<VectorXd                      >> const&, Eigen::MatrixBase<Eigen::Map<VectorXd                      >> const&, bool) const;  // NOLINT
 template KinematicsCache<double>          RigidBodyTree<double>::doKinematics(Eigen::MatrixBase<Eigen::Map<VectorXd const                >> const&, Eigen::MatrixBase<Eigen::Map<VectorXd const                >> const&, bool) const;  // NOLINT
 
-// Explicit template instantiations for parseBodyOrFrameID.
-template int RigidBodyTree<double>::parseBodyOrFrameID(const int body_or_frame_id, Eigen::Transform<double, 3, Eigen::Isometry>* Tframe) const;  // NOLINT
+#endif
+#if DRAKE_RBT_SHARD == 0
 
 // Explicit template instantiations for CreateKinematicsCacheWithType.
 template KinematicsCache<AutoDiffXd     > RigidBodyTree<double>::CreateKinematicsCacheWithType<AutoDiffXd     >() const;  // NOLINT
@@ -3493,3 +3593,5 @@ template std::vector<drake::multibody::collision::PointPair<double         >> Ri
 
 // Explicitly instantiates on the most common scalar types.
 template class RigidBodyTree<double>;
+
+#endif

--- a/multibody/rigid_body_tree.h
+++ b/multibody/rigid_body_tree.h
@@ -114,9 +114,14 @@ class RigidBodyTree {
 
   /**
    * Returns a deep clone of this RigidBodyTree<double>. Currently, everything
-   * *except* for collision and visual elements are cloned.
+   * *except* for collision and visual elements are cloned.  Only supported for
+   * T = double.
    */
-  std::unique_ptr<RigidBodyTree<double>> Clone() const;
+  std::unique_ptr<RigidBodyTree<double>> Clone() const {
+    // N.B. We specialize this method below for T = double.  This method body
+    // is the default implementation for all _other_ values of T.
+    throw std::logic_error("RigidBodyTree::Clone only supports T = double");
+  }
 
   /**
    * Adds a new model instance to this `RigidBodyTree`. The model instance is
@@ -1727,5 +1732,15 @@ class RigidBodyTree {
   drake::multibody::collision::CollisionFilterGroupManager<T>
       collision_group_manager_{};
 };
+
+// This template method specialization is defined in the cc file.
+template <>
+std::unique_ptr<RigidBodyTree<double>> RigidBodyTree<double>::Clone() const;
+
+
+// To mitigate compilation time, only one `*.o` file will instantiate the
+// methods of RigidBodyTree that are templated only on `T` (and not on, e.g.,
+// `Scalar`).  Refer to the the rigid_body_tree.cc comments for details.
+extern template class RigidBodyTree<double>;
 
 typedef RigidBodyTree<double> RigidBodyTreed;


### PR DESCRIPTION
On master, on my T460p laptop, this file takes ~60s to compile.

With this change, this files takes ~20s + ~40s to compile -- the same amount of time, but split across two CPUs.

Do not merge until:
- [x] tested on macOS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8543)
<!-- Reviewable:end -->
