### PR TITLE
RotationMatrix supports symbolic

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -68,6 +68,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:default_scalars",
+        "//common:drake_bool",
         "//common:essential",
         "//common:is_approx_equal_abstol",
         "@fmt",

--- a/math/rotation_matrix.cc
+++ b/math/rotation_matrix.cc
@@ -7,8 +7,11 @@
 
 namespace drake {
 namespace math {
+
 template<typename T>
-void RotationMatrix<T>::ThrowIfNotValid(const Matrix3<T>& R) {
+template <typename S>
+typename std::enable_if<is_numeric<S>::value>::type
+RotationMatrix<T>::ThrowIfNotValid(const Matrix3<T>& R) {
   if (!R.allFinite()) {
     throw std::logic_error(
         "Error: Rotation matrix contains an element that is infinity or "
@@ -16,7 +19,7 @@ void RotationMatrix<T>::ThrowIfNotValid(const Matrix3<T>& R) {
   }
   // If the matrix is not-orthogonal, try to give a detailed message.
   // This is particularly important if matrix is very-near orthogonal.
-  if (!IsOrthonormal(R, get_internal_tolerance_for_orthonormality())) {
+  if (!IsOrthonormal(R, get_internal_tolerance_for_orthonormality()).value()) {
     const T measure_of_orthonormality = GetMeasureOfOrthonormality(R);
     const double measure = ExtractDoubleOrThrow(measure_of_orthonormality);
     std::string message = fmt::format(
@@ -36,7 +39,5 @@ void RotationMatrix<T>::ThrowIfNotValid(const Matrix3<T>& R) {
 }  // namespace drake
 
 // Explicitly instantiate on non-symbolic scalar types.
-// TODO(Mitiguy) Ensure this class handles RotationMatrix<symbolic::Expression>.
-// To enable symbolic expressions, remove _NONSYMBOLIC in next line.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::RotationMatrix)

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -7,6 +7,7 @@
 #include <Eigen/Dense>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
@@ -327,7 +328,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between R * Rᵀ
   /// and the identity matrix I, i.e., checks if `‖R ⋅ Rᵀ - I‖∞ <= tolerance`.
   /// @returns `true` if R is an orthonormal matrix.
-  static bool IsOrthonormal(const Matrix3<T>& R, double tolerance) {
+  static Bool<T> IsOrthonormal(const Matrix3<T>& R, double tolerance) {
     return GetMeasureOfOrthonormality(R) <= tolerance;
   }
 
@@ -337,7 +338,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference of `R * Rᵀ`
   /// and the identity matrix I (i.e., checks if `‖R ⋅ Rᵀ - I‖∞ <= tolerance`).
   /// @returns `true` if R is a valid rotation matrix.
-  static bool IsValid(const Matrix3<T>& R, double tolerance) {
+  static Bool<T> IsValid(const Matrix3<T>& R, double tolerance) {
     return IsOrthonormal(R, tolerance) && R.determinant() > 0;
   }
 
@@ -345,21 +346,21 @@ class RotationMatrix {
   /// within the threshold of get_internal_tolerance_for_orthonormality().
   /// @param[in] R an allegedly valid rotation matrix.
   /// @returns `true` if R is a valid rotation matrix.
-  static bool IsValid(const Matrix3<T>& R) {
+  static Bool<T> IsValid(const Matrix3<T>& R) {
     return IsValid(R, get_internal_tolerance_for_orthonormality());
   }
 
   /// Tests if `this` rotation matrix R is a proper orthonormal rotation matrix
   /// to within the threshold of get_internal_tolerance_for_orthonormality().
   /// @returns `true` if `this` is a valid rotation matrix.
-  bool IsValid() const { return IsValid(matrix()); }
+  Bool<T> IsValid() const { return IsValid(matrix()); }
 
   /// Returns `true` if `this` is exactly equal to the identity matrix.
-  bool IsExactlyIdentity() const { return matrix() == Matrix3<T>::Identity(); }
+  Bool<T> IsExactlyIdentity() const { return matrix() == Matrix3<T>::Identity(); }
 
   /// Returns true if `this` is equal to the identity matrix to within the
   /// threshold of get_internal_tolerance_for_orthonormality().
-  bool IsIdentityToInternalTolerance() const {
+  Bool<T> IsIdentityToInternalTolerance() const {
     return IsNearlyEqualTo(matrix(), Matrix3<T>::Identity(),
                            get_internal_tolerance_for_orthonormality());
   }
@@ -370,7 +371,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between the
   /// matrix elements in `this` and `other`.
   /// @returns `true` if `‖this - other‖∞ <= tolerance`.
-  bool IsNearlyEqualTo(const RotationMatrix<T>& other, double tolerance) const {
+  Bool<T> IsNearlyEqualTo(const RotationMatrix<T>& other, double tolerance) const {
     return IsNearlyEqualTo(matrix(), other.matrix(), tolerance);
   }
 
@@ -379,7 +380,7 @@ class RotationMatrix {
   /// @param[in] other %RotationMatrix to compare to `this`.
   /// @returns true if each element of `this` is exactly equal to the
   /// corresponding element in `other`.
-  bool IsExactlyEqualTo(const RotationMatrix<T>& other) const {
+  Bool<T> IsExactlyEqualTo(const RotationMatrix<T>& other) const {
     return matrix() == other.matrix();
   }
 
@@ -432,6 +433,13 @@ class RotationMatrix {
         ProjectMatrix3ToOrthonormalMatrix3(M, quality_factor);
     ThrowIfNotValid(M_orthonormalized);
     return RotationMatrix<S>(M_orthonormalized, true);
+  }
+
+  template <typename S = T>
+  static typename std::enable_if<!is_numeric<S>::value, RotationMatrix<S>>::type
+  ProjectToRotationMatrix(const Matrix3<S>& M, T* quality_factor = NULL) {
+    throw std::runtime_error("This method is not supported for scalar types "
+                             "that are not is_numeric<S>.");
   }
 
   /// Returns an internal tolerance that checks rotation matrix orthonormality.
@@ -552,15 +560,21 @@ class RotationMatrix {
   // @param[in] tolerance maximum allowable absolute difference between the
   // matrix elements in R and `other`.
   // @returns `true` if `‖R - `other`‖∞ <= tolerance`.
-  static bool IsNearlyEqualTo(const Matrix3<T>& R, const Matrix3<T>& other,
-                              double tolerance) {
+  static Bool<T> IsNearlyEqualTo(const Matrix3<T>& R, const Matrix3<T>& other,
+                                 double tolerance) {
     const T R_max_difference = GetMaximumAbsoluteDifference(R, other);
     return R_max_difference <= tolerance;
   }
 
   // Throws an exception if R is not a valid %RotationMatrix.
   // @param[in] R an allegedly valid rotation matrix.
-  static void ThrowIfNotValid(const Matrix3<T>& R);
+  template <typename S = T>
+  static typename std::enable_if<is_numeric<S>::value>::type
+  ThrowIfNotValid(const Matrix3<T>& R);
+
+  template <typename S = T>
+  static typename std::enable_if<!is_numeric<S>::value>::type
+  ThrowIfNotValid(const Matrix3<T>& R) {}
 
   // Given an approximate rotation matrix M, finds the orthonormal matrix R
   // closest to M.  Closeness is measured with a matrix-2 norm (or equivalently

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -356,7 +356,9 @@ class RotationMatrix {
   Bool<T> IsValid() const { return IsValid(matrix()); }
 
   /// Returns `true` if `this` is exactly equal to the identity matrix.
-  Bool<T> IsExactlyIdentity() const { return matrix() == Matrix3<T>::Identity(); }
+  Bool<T> IsExactlyIdentity() const {
+    return matrix() == Matrix3<T>::Identity();
+  }
 
   /// Returns true if `this` is equal to the identity matrix to within the
   /// threshold of get_internal_tolerance_for_orthonormality().
@@ -371,7 +373,8 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between the
   /// matrix elements in `this` and `other`.
   /// @returns `true` if `‖this - other‖∞ <= tolerance`.
-  Bool<T> IsNearlyEqualTo(const RotationMatrix<T>& other, double tolerance) const {
+  Bool<T> IsNearlyEqualTo(
+      const RotationMatrix<T>& other, double tolerance) const {
     return IsNearlyEqualTo(matrix(), other.matrix(), tolerance);
   }
 

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -301,7 +301,8 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   const Vector3d angles(0.1, 0.2, 0.3);
   m = RotationMatrix<double>::MakeSpaceXYZRotation(angles).matrix();
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
+  EXPECT_TRUE(
+      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
   EXPECT_TRUE(std::abs(quality_factor - 1.0) < 40*kEpsilon);
 
   // Test scaling each element of a rotation matrix by 2 (linear scaling).

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -181,20 +181,20 @@ GTEST_TEST(RotationMatrix, RotationMatrixBodyZYX) {
   const RotationMatrix<double> R_eigen(m);
   const RotationMatrix<double> R_bodyZYX =
       RotationMatrix<double>::MakeBodyZYXRotation(q);
-  EXPECT_TRUE(R_bodyZYX.IsNearlyEqualTo(R_eigen, kEpsilon));
+  EXPECT_TRUE(R_bodyZYX.IsNearlyEqualTo(R_eigen, kEpsilon).value());
 
   RotationMatrix<double> R1 = RotationMatrix<double>::MakeZRotation(q(0));
   RotationMatrix<double> R2 = RotationMatrix<double>::MakeYRotation(q(1));
   RotationMatrix<double> R3 = RotationMatrix<double>::MakeXRotation(q(2));
   RotationMatrix<double> R_expected = R1 * R2 * R3;
-  EXPECT_TRUE(R_bodyZYX.IsExactlyEqualTo(R_expected));
+  EXPECT_TRUE(R_bodyZYX.IsExactlyEqualTo(R_expected).value());
 
   // Compare to SpaceXYZ rotation sequence.
   const Vector3d roll_pitch_yaw(q(2), q(1), q(0));
   const RotationMatrix<double> R_spaceXYZ =
       RotationMatrix<double>::MakeSpaceXYZRotation(roll_pitch_yaw);
-  EXPECT_TRUE(R_spaceXYZ.IsNearlyEqualTo(R_eigen, kEpsilon));
-  EXPECT_TRUE(R_spaceXYZ.IsExactlyEqualTo(R_bodyZYX));
+  EXPECT_TRUE(R_spaceXYZ.IsNearlyEqualTo(R_eigen, kEpsilon).value());
+  EXPECT_TRUE(R_spaceXYZ.IsExactlyEqualTo(R_bodyZYX).value());
 }
 
 // Test calculating the inverse of a RotationMatrix.
@@ -208,7 +208,7 @@ GTEST_TEST(RotationMatrix, Inverse) {
   RotationMatrix<double> R(m);
   RotationMatrix<double> RRinv = R * R.inverse();
   const RotationMatrix<double>& I = RotationMatrix<double>::Identity();
-  EXPECT_TRUE(RRinv.IsNearlyEqualTo(I, 8 * kEpsilon));
+  EXPECT_TRUE(RRinv.IsNearlyEqualTo(I, 8 * kEpsilon).value());
 }
 
 // Test rotation matrix multiplication and IsNearlyEqualTo.
@@ -228,12 +228,12 @@ GTEST_TEST(RotationMatrix, OperatorMultiplyAndIsNearlyEqualTo) {
   RotationMatrix<double> R_CA_expected(m_CA);
 
   // Also test IsNearlyEqualTo.
-  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 10 * kEpsilon));
+  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 10 * kEpsilon).value());
 
   // Also test operator*=().
   R_CB *= R_BA;
-  EXPECT_TRUE(R_CB.IsNearlyEqualTo(R_CA, 10 * kEpsilon));
-  EXPECT_FALSE(R_CB.IsNearlyEqualTo(R_BA, 10000 * kEpsilon));
+  EXPECT_TRUE(R_CB.IsNearlyEqualTo(R_CA, 10 * kEpsilon).value());
+  EXPECT_FALSE(R_CB.IsNearlyEqualTo(R_BA, 10000 * kEpsilon).value());
 
   // Also test operator*() with vectors.
   Vector3d vA(1, 2, 3);     // Vector v expressed in frame A.
@@ -251,24 +251,24 @@ GTEST_TEST(RotationMatrix, IsValid) {
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   EXPECT_GT(m.determinant(), 0);
-  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
-  EXPECT_TRUE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
+  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
+  EXPECT_TRUE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
 
   // Test a matrix that should fail orthonormality check.
   m << 1, 10 * kEpsilon, 10 * kEpsilon,
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   EXPECT_GT(m.determinant(), 0);
-  EXPECT_FALSE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
+  EXPECT_FALSE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
 
   // Test a matrix that should fail determinant test.
   m << -1, 0, 0,
         0, cos_theta, sin_theta,
         0, -sin_theta, cos_theta;
   EXPECT_LT(m.determinant(), 0);
-  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
+  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
 }
 
 // Tests whether or not a RotationMatrix is an identity matrix.
@@ -282,8 +282,8 @@ GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
 
   const RotationMatrix<double> R1(m);
   const RotationMatrix<double> R2;
-  EXPECT_FALSE(R1.IsExactlyIdentity());
-  EXPECT_TRUE(R2.IsExactlyIdentity());
+  EXPECT_FALSE(R1.IsExactlyIdentity().value());
+  EXPECT_TRUE(R2.IsExactlyIdentity().value());
 }
 
 // Test ProjectMatrixToRotationMatrix.
@@ -294,29 +294,30 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   RotationMatrix<double> R =
       RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
   EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                10 * kEpsilon));
+                                10 * kEpsilon).value());
   EXPECT_TRUE(std::abs(quality_factor - 1.0) < 40 * kEpsilon);
 
   // Test another valid rotation matrix.  Ensure near-perfect quality_factor.
   const Vector3d angles(0.1, 0.2, 0.3);
   m = RotationMatrix<double>::MakeSpaceXYZRotation(angles).matrix();
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon));
+  EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
   EXPECT_TRUE(std::abs(quality_factor - 1.0) < 40*kEpsilon);
 
   // Test scaling each element of a rotation matrix by 2 (linear scaling).
   const Matrix3d m2 = 2 * m;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m2, &quality_factor);
-  EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon));
+  EXPECT_TRUE(
+      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
   EXPECT_TRUE(std::abs(quality_factor - 2.0) < 40*kEpsilon);
 
   // Test a 3x3 matrix that is far from orthonormal.
   m << 1,   0.1, 0.1,
       -0.2, 1.0, 0.1,
        0.5, 0.6, 0.8;
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 64000 * kEpsilon));
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 64000 * kEpsilon).value());
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid());
+  EXPECT_TRUE(R.IsValid().value());
   // Singular values from MotionGenesis [1.405049, 1.061152, 0.4688222]
   EXPECT_TRUE(std::abs(quality_factor - 0.4688222) < 1E-5);
 
@@ -325,7 +326,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
        4, 5,  6,
        7, 8, -10;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid());
+  EXPECT_TRUE(R.IsValid().value());
   // Singular values from MotionGenesis [14.61524, 9.498744, 0.4105846]
   EXPECT_TRUE(std::abs(quality_factor - 14.61524) < 1E-5);
 
@@ -334,7 +335,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
           4, 5, 6,
           7, 8, -1E6;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid());
+  EXPECT_TRUE(R.IsValid().value());
   // Singular values from MotionGenesis [1000000, 6.597777, 1.21254]
   EXPECT_TRUE(std::abs(quality_factor - 1000000) < 1E-1);
 
@@ -345,11 +346,11 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   EXPECT_TRUE(0 < m.determinant() &&
               m.determinant() < 64 * kEpsilon * kEpsilon * kEpsilon);
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid());
+  EXPECT_TRUE(R.IsValid().value());
   // Singular values from MotionGenesis [kEpsilon, kEpsilon, kEpsilon]
   EXPECT_TRUE(quality_factor > 0 &&  quality_factor < 64 * kEpsilon);
   EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                64 * kEpsilon));
+                                64 * kEpsilon).value());
 
   // Test a 3x3 near-zero matrix whose determinant is negative (det = -1E-47).
   m << kEpsilon, 0, 0,
@@ -418,7 +419,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
   const RotationMatrix<double> I = R * R.inverse();
   EXPECT_TRUE(I.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                10 * kEpsilon));
+                                10 * kEpsilon).value());
 }
 
 // Test RotationMatrix cast method from double to AutoDiffXd.
@@ -504,7 +505,7 @@ TEST_F(RotationMatrixConversionTests, QuaternionToRotationMatrix) {
     const Matrix3d m_expected = qi.toRotationMatrix();
     const RotationMatrix<double> R_expected(m_expected);
     const RotationMatrix<double> R(qi);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 40 * kEpsilon));
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 40 * kEpsilon).value());
   }
 
 #ifdef DRAKE_ASSERT_IS_ARMED
@@ -526,7 +527,7 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     // Compare R with the RotationMatrix constructor that uses Eigen::AngleAxis.
     const Eigen::AngleAxisd angle_axis(qi);
     const RotationMatrix<double> R_expected(angle_axis);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 200 * kEpsilon));
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 200 * kEpsilon).value());
 
     // Check that inverting this operation (calculating the AngleAxis from
     // rotation matrix R_expected) corresponds to the same orientation.
@@ -536,7 +537,7 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     Eigen::AngleAxis<double> inverse_angle_axis;
     inverse_angle_axis.fromRotationMatrix(R_expected.matrix());
     const RotationMatrix<double> R_test(inverse_angle_axis);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_test, 200 * kEpsilon));
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_test, 200 * kEpsilon).value());
     // Ensure the angle returned via Eigen's AngleAxis is between 0 and PI.
     const double angle = inverse_angle_axis.angle();
     EXPECT_TRUE(0 <= angle && angle <= M_PI);

--- a/math/test/transform_test.cc
+++ b/math/test/transform_test.cc
@@ -84,7 +84,7 @@ Transform<double> GetTransformB() {
 // Tests default constructor - should be identity transform.
 GTEST_TEST(Transform, DefaultTransformIsIdentity) {
   const Transform<double> X;
-  EXPECT_TRUE(X.IsExactlyIdentity());
+  EXPECT_TRUE(X.IsExactlyIdentity().value());
 }
 
 // Tests constructing a Transform from a RotationMatrix and Vector3.
@@ -176,7 +176,7 @@ GTEST_TEST(Transform, Isometry3) {
 // Tests method Identity (identity rotation matrix and zero vector).
 GTEST_TEST(Transform, Identity) {
   const Transform<double>& X = Transform<double>::Identity();
-  EXPECT_TRUE(X.IsExactlyIdentity());
+  EXPECT_TRUE(X.IsExactlyIdentity().value());
 }
 
 // Tests method SetIdentity.
@@ -185,34 +185,34 @@ GTEST_TEST(Transform, SetIdentity) {
   const Vector3d p(2, 3, 4);
   Transform<double> X(R, p);
   X.SetIdentity();
-  EXPECT_TRUE(X.IsExactlyIdentity());
+  EXPECT_TRUE(X.IsExactlyIdentity().value());
 }
 
 // Tests whether or not a Transform is an identity transform.
 GTEST_TEST(Transform, IsIdentity) {
   // Test whether it is an identity matrix multiple ways.
   Transform<double> X1;
-  EXPECT_TRUE(X1.IsExactlyIdentity());
-  EXPECT_TRUE(X1.IsIdentityToEpsilon(0.0));
-  EXPECT_TRUE(X1.rotation().IsExactlyIdentity());
+  EXPECT_TRUE(X1.IsExactlyIdentity().value());
+  EXPECT_TRUE(X1.IsIdentityToEpsilon(0.0).value());
+  EXPECT_TRUE(X1.rotation().IsExactlyIdentity().value());
   EXPECT_TRUE((X1.translation().array() == 0).all());
 
   // Test non-identity matrix.
   const RotationMatrix<double> R = GetRotationMatrixA();
   const Vector3d p(2, 3, 4);
   Transform<double> X2(R, p);
-  EXPECT_FALSE(X2.IsExactlyIdentity());
+  EXPECT_FALSE(X2.IsExactlyIdentity().value());
 
   // Change rotation matrix to identity, but leave non-zero position vector.
   X2.set_rotation(RotationMatrix<double>::Identity());
-  EXPECT_FALSE(X2.IsExactlyIdentity());
-  EXPECT_FALSE(X2.IsIdentityToEpsilon(3.99));
-  EXPECT_TRUE(X2.IsIdentityToEpsilon(4.01));
+  EXPECT_FALSE(X2.IsExactlyIdentity().value());
+  EXPECT_FALSE(X2.IsIdentityToEpsilon(3.99).value());
+  EXPECT_TRUE(X2.IsIdentityToEpsilon(4.01).value());
 
   // Change position vector to zero vector.
   const Vector3d zero_vector(0, 0, 0);
   X2.set_translation(zero_vector);
-  EXPECT_TRUE(X2.IsExactlyIdentity());
+  EXPECT_TRUE(X2.IsExactlyIdentity().value());
 }
 
 // Tests calculating the inverse of a Transform.
@@ -227,7 +227,7 @@ GTEST_TEST(Transform, Inverse) {
   // Note: The square-root of the condition number for a Transform is roughly
   // the magnitude of the position vector.  The accuracy of the calculation for
   // the inverse of a Transform drops off with the sqrt condition number.
-  EXPECT_TRUE(I.IsNearlyEqualTo(X_identity, 8 * kEpsilon));
+  EXPECT_TRUE(I.IsNearlyEqualTo(X_identity, 8 * kEpsilon).value());
 }
 
 // Tests Transform multiplied by another Transform
@@ -241,7 +241,7 @@ GTEST_TEST(Transform, OperatorMultiplyByTransform) {
   const RotationMatrix<double> R_BA = GetRotationMatrixA();
   const RotationMatrix<double> R_CB = GetRotationMatrixB();
   const RotationMatrix<double> R_CA_expected = R_CB * R_BA;
-  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 0));
+  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 0).value());
 
   // Expected position vector (from MotionGenesis).
   const double x_expected = 5.761769695362743;
@@ -257,7 +257,7 @@ GTEST_TEST(Transform, OperatorMultiplyByTransform) {
   // As documented in IsNearlyEqualTo(), 32 * epsilon was chosen because it is
   // slightly larger than the characteristic length |p_CoAo_C| = 14.2
   const Transform<double> X_CA_expected(R_CA_expected, p_CoAo_C_expected);
-  EXPECT_TRUE(X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon));
+  EXPECT_TRUE(X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon).value());
 }
 
 // Tests Transform multiplied by a position vector.

--- a/math/transform.cc
+++ b/math/transform.cc
@@ -3,7 +3,5 @@
 #include "drake/common/default_scalars.h"
 
 // Explicitly instantiate on non-symbolic scalar types.
-// TODO(Mitiguy) Ensure this class handles Transform<symbolic::Expression>.
-// To enable symbolic expressions, remove _NONSYMBOLIC in next line.
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::math::Transform)

--- a/math/transform.h
+++ b/math/transform.h
@@ -3,6 +3,7 @@
 #include <limits>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_bool.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/eigen_types.h"
 #include "drake/common/never_destroyed.h"
@@ -156,7 +157,7 @@ class Transform {
   /// Returns `true` if `this` is exactly the identity transform.
   /// @returns `true` if `this` is exactly the identity transform.
   /// @see IsIdentityToEpsilon().
-  bool IsExactlyIdentity() const {
+  Bool<T> IsExactlyIdentity() const {
     return rotation().IsExactlyIdentity() && (translation().array() == 0).all();
   }
 
@@ -169,7 +170,7 @@ class Transform {
   /// (e.g., the magnitude of a characteristic position vector) by an epsilon
   /// (e.g., RotationMatrix::get_internal_tolerance_for_orthonormality()).
   /// @see IsExactlyIdentity().
-  bool IsIdentityToEpsilon(double translation_tolerance) const {
+  Bool<T> IsIdentityToEpsilon(double translation_tolerance) const {
     const T max_component = translation().template lpNorm<Eigen::Infinity>();
     return max_component <= translation_tolerance &&
         rotation().IsIdentityToInternalTolerance();
@@ -224,7 +225,7 @@ class Transform {
   /// @note Consider scaling tolerance with the largest of magA and magB, where
   /// magA and magB denoted the magnitudes of `this` position vector and `other`
   /// position vectors, respectively.
-  bool IsNearlyEqualTo(const Transform<T>& other, double tolerance) const {
+  Bool<T> IsNearlyEqualTo(const Transform<T>& other, double tolerance) const {
     return GetMaximumAbsoluteDifference(other) <= tolerance;
   }
 


### PR DESCRIPTION
Incomplete PR. Just minimum set of changes to make `RotationMatrix` and `Transform` classes to compile with `symbolic::Expression`. A complete PR requires a review of the documentation + a couple unit tests. As a template, see changes introduced into `SpatialInertia` in #8298.
MBP depends on this through `geometric_transform`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8561)
<!-- Reviewable:end -->
