### PR TITLE
Setting accuracy in the context copies accuracy to all subcontexts.

### DIFF
--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -101,17 +101,11 @@ void RimlessWheel<T>::StepForwardReset(
   // only for efficiency, to avoid simulation at the Zeno).
   // Note: I already know that thetadot > 0 since the guard triggered.
   DRAKE_ASSERT(next_state.thetadot() >= 0.);
-
   // The threshold value below only impacts early termination.  Setting it
   // closer to zero will not cause the wheel to miss an event, but will cause
   // the simulator to perform arbitrarily more event detection calculations.
   // The threshold is multiplied by sqrt(g/l) to make it dimensionless.
-  // Note: the scaling factor below (100.0) is used to maintain the current
-  //       behavior of this system, with a context-set-accuracy of 1e-4. See
-  //       issue #
-  const double tol = (context.get_accuracy()) ?
-                     context.get_accuracy().value() : 1e-2;
-  if (next_state.thetadot() < tol * sqrt(params.gravity() / params.length())) {
+  if (next_state.thetadot() < 0.01*sqrt(params.gravity()/params.length())) {
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);
@@ -160,14 +154,11 @@ void RimlessWheel<T>::StepBackwardReset(
   // If thetadot is very small, then transition to double support.
   // Note: I already know that thetadot < 0 since the guard triggered.
   DRAKE_ASSERT(next_state.thetadot() <= 0.);
-
   // The threshold value below only impacts early termination.  Setting it
   // closer to zero will not cause the wheel to miss an event, but will cause
   // the simulator to perform arbitrarily more event detection calculations.
   // The threshold is multiplied by sqrt(g/l) to make it dimensionless.
-  const double tol = (context.get_accuracy()) ?
-                     context.get_accuracy().value() : 1e-2;
-  if (next_state.thetadot() > -tol * sqrt(params.gravity() / params.length())) {
+  if (next_state.thetadot() > -0.01*sqrt(params.gravity()/params.length())) {
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);

--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -105,7 +105,9 @@ void RimlessWheel<T>::StepForwardReset(
   // closer to zero will not cause the wheel to miss an event, but will cause
   // the simulator to perform arbitrarily more event detection calculations.
   // The threshold is multiplied by sqrt(g/l) to make it dimensionless.
-  if (next_state.thetadot() < 0.01*sqrt(params.gravity()/params.length())) {
+  const double tol = (context.get_accuracy()) ?
+                     context.get_accuracy().value() : 1e-2;
+  if (next_state.thetadot() < tol * sqrt(params.gravity() / params.length())) {
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);
@@ -154,11 +156,14 @@ void RimlessWheel<T>::StepBackwardReset(
   // If thetadot is very small, then transition to double support.
   // Note: I already know that thetadot < 0 since the guard triggered.
   DRAKE_ASSERT(next_state.thetadot() <= 0.);
+
   // The threshold value below only impacts early termination.  Setting it
   // closer to zero will not cause the wheel to miss an event, but will cause
   // the simulator to perform arbitrarily more event detection calculations.
   // The threshold is multiplied by sqrt(g/l) to make it dimensionless.
-  if (next_state.thetadot() > -0.01*sqrt(params.gravity()/params.length())) {
+  const double tol = (context.get_accuracy()) ?
+                     context.get_accuracy().value() : 1e-2;
+  if (next_state.thetadot() > -tol * sqrt(params.gravity() / params.length())) {
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);

--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -101,10 +101,14 @@ void RimlessWheel<T>::StepForwardReset(
   // only for efficiency, to avoid simulation at the Zeno).
   // Note: I already know that thetadot > 0 since the guard triggered.
   DRAKE_ASSERT(next_state.thetadot() >= 0.);
+
   // The threshold value below only impacts early termination.  Setting it
   // closer to zero will not cause the wheel to miss an event, but will cause
   // the simulator to perform arbitrarily more event detection calculations.
   // The threshold is multiplied by sqrt(g/l) to make it dimensionless.
+  // Note: the scaling factor below (100.0) is used to maintain the current
+  //       behavior of this system, with a context-set-accuracy of 1e-4. See
+  //       issue #
   const double tol = (context.get_accuracy()) ?
                      context.get_accuracy().value() : 1e-2;
   if (next_state.thetadot() < tol * sqrt(params.gravity() / params.length())) {

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -17,7 +17,7 @@ namespace examples {
 namespace rimless_wheel {
 namespace {
 
-DEFINE_double(accuracy, 1e-2, "Accuracy of the rimless wheel system (unitless);"
+DEFINE_double(accuracy, 1e-4, "Accuracy of the rimless wheel system (unitless);"
     " must be positive.");
 DEFINE_double(initial_angle, 0.0, "Initial angle of the wheel (rad).  Must be"
     " in the interval (slope - alpha, slope + alpha), as described in "

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -17,6 +17,8 @@ namespace examples {
 namespace rimless_wheel {
 namespace {
 
+DEFINE_double(accuracy, 1e-2, "Accuracy of the rimless wheel system (unitless);"
+    " must be positive.");
 DEFINE_double(initial_angle, 0.0, "Initial angle of the wheel (rad).  Must be"
     " in the interval (slope - alpha, slope + alpha), as described in "
     "http://underactuated.mit.edu/underactuated.html?chapter=simple_legs .");
@@ -86,7 +88,7 @@ int DoMain() {
   state.set_thetadot(FLAGS_initial_angular_velocity);
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
-  simulator.get_mutable_context().set_accuracy(1e-4);
+  simulator.get_mutable_context().set_accuracy(FLAGS_accuracy);
   simulator.StepTo(10);
 
   // Check that the state is still inside the expected region (I did not miss

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -400,7 +400,9 @@ class Context {
   /// control all accuracy-dependent computations.
   // TODO(edrumwri) Invalidate all cached accuracy-dependent computations, and
   // propagate accuracy to all subcontexts in a diagram context.
-  void set_accuracy(const optional<double>& accuracy) { accuracy_ = accuracy; }
+  virtual void set_accuracy(const optional<double>& accuracy) {
+    accuracy_ = accuracy;
+  }
 
   /// Returns the accuracy setting (if any).
   /// @see set_accuracy() for details.

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -273,6 +273,17 @@ class DiagramContext : public Context<T> {
     }
   }
 
+  /// Recursively sets the accuracy on this context and all subcontexts,
+  /// overwriting any accuracy value set in any subcontexts.
+  void set_accuracy(const optional<double>& accuracy) override {
+    Context<T>::set_accuracy(accuracy);
+    for (auto& subcontext : contexts_) {
+      if (subcontext != nullptr) {
+        subcontext->set_accuracy(accuracy);
+      }
+    }
+  }
+
   int get_num_input_ports() const override {
     return static_cast<int>(input_ids_.size());
   }

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -183,6 +183,19 @@ TEST_F(DiagramContextTest, Time) {
   }
 }
 
+// Tests that the accuracy writes through to the subsystem contexts.
+TEST_F(DiagramContextTest, Accuracy) {
+  const double kAccuracy = 1e-12;
+  context_->set_accuracy(kAccuracy);
+  EXPECT_TRUE(context_->get_accuracy());
+  EXPECT_EQ(kAccuracy, context_->get_accuracy().value());
+  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
+    EXPECT_TRUE(context_->GetSubsystemContext(i).get_accuracy());
+    EXPECT_EQ(kAccuracy,
+              context_->GetSubsystemContext(i).get_accuracy().value());
+  }
+}
+
 // Tests that state variables appear in the diagram context, and write
 // transparently through to the constituent system contexts.
 TEST_F(DiagramContextTest, State) {
@@ -300,8 +313,8 @@ TEST_F(DiagramContextTest, CloneState) {
   EXPECT_EQ(43.0, context_->get_continuous_state()[1]);
 }
 
-// Verifies that accuracy is set properly.
-TEST_F(DiagramContextTest, Accuracy) {
+// Verifies that accuracy is set properly during cloning.
+TEST_F(DiagramContextTest, CloneAccuracy) {
   // Verify accuracy is not set by default.
   EXPECT_FALSE(context_->get_accuracy());
 


### PR DESCRIPTION
(Prototype, toward addressing issue #8489)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8577)
<!-- Reviewable:end -->
