### PR TITLE
Remove dependency of output port allocation on context in GeometrySystem

### DIFF
--- a/geometry/geometry_system.h
+++ b/geometry/geometry_system.h
@@ -417,8 +417,7 @@ class GeometrySystem final : public systems::LeafSystem<T> {
 
   // Constructs a PoseBundle of length equal to the concatenation of all inputs.
   // This is the method used by the allocator for the output port.
-  systems::rendering::PoseBundle<T> MakePoseBundle(
-      const systems::Context<T>& context) const;
+  systems::rendering::PoseBundle<T> MakePoseBundle() const;
 
   // Aggregates the input poses into the output PoseBundle, in the same order as
   // was used in allocation. Aborts if any inputs have a _different_ size than
@@ -468,7 +467,10 @@ class GeometrySystem final : public systems::LeafSystem<T> {
   // property that source ids can only be added prior to context allocation.
   // This is mutable so that it can be cleared in the const method
   // AllocateContext().
-  mutable GeometryState<T>* initial_state_;
+  GeometryState<T>* initial_state_{};
+
+  // TODO(SeanCurtis-TRI): Get rid of this.
+  mutable bool context_has_been_allocated_{false};
 
   // The index of the geometry state in the context's abstract state.
   int geometry_state_index_{-1};


### PR DESCRIPTION
In preparation for resolving #8567 by removing the context parameter to output port allocators, this PR removes GeometrySystem's use of the context for sizing its PoseBundle output port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8579)
<!-- Reviewable:end -->
