### PR TITLE
Removes context parameter to output port allocator function

### DIFF
--- a/examples/geometry_world/bouncing_ball_plant.cc
+++ b/examples/geometry_world/bouncing_ball_plant.cc
@@ -96,8 +96,7 @@ void BouncingBallPlant<T>::CopyStateToOutput(
 }
 
 template <typename T>
-FramePoseVector<T> BouncingBallPlant<T>::AllocateFramePoseOutput(
-    const Context<T>&) const {
+FramePoseVector<T> BouncingBallPlant<T>::AllocateFramePoseOutput() const {
   FramePoseVector<T> poses(source_id_);
   poses.mutable_vector().push_back(Isometry3<T>::Identity());
   return poses;
@@ -115,16 +114,15 @@ void BouncingBallPlant<T>::CalcFramePoseOutput(
 }
 
 template <typename T>
-FrameIdVector BouncingBallPlant<T>::AllocateFrameIdOutput(
-    const systems::Context<T>&) const {
+FrameIdVector BouncingBallPlant<T>::AllocateFrameIdOutput() const {
   return FrameIdVector(source_id_,
                        std::vector<geometry::FrameId>{ball_frame_id_});
 }
 
 template <typename T>
-void BouncingBallPlant<T>::CalcFrameIdOutput(const systems::Context<T>& context,
+void BouncingBallPlant<T>::CalcFrameIdOutput(const systems::Context<T>&,
                                              FrameIdVector* frame_ids) const {
-  *frame_ids = AllocateFrameIdOutput(context);
+  *frame_ids = AllocateFrameIdOutput();
 }
 
 // Compute the actual physics.

--- a/examples/geometry_world/bouncing_ball_plant.h
+++ b/examples/geometry_world/bouncing_ball_plant.h
@@ -83,16 +83,14 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
                          BouncingBallVector<T>* state_output_vector) const;
 
   // Allocate the frame pose set output port value.
-  geometry::FramePoseVector<T> AllocateFramePoseOutput(
-      const systems::Context<T>& context) const;
+  geometry::FramePoseVector<T> AllocateFramePoseOutput() const;
 
   // Calculate the frame pose set output port value.
   void CalcFramePoseOutput(const systems::Context<T>& context,
                            geometry::FramePoseVector<T>* poses) const;
 
   // Allocate the id output.
-  geometry::FrameIdVector AllocateFrameIdOutput(
-      const systems::Context<T>& context) const;
+  geometry::FrameIdVector AllocateFrameIdOutput() const;
 
   // Calculate the id output.
   void CalcFrameIdOutput(const systems::Context<T>& context,

--- a/examples/geometry_world/solar_system.cc
+++ b/examples/geometry_world/solar_system.cc
@@ -261,8 +261,7 @@ void SolarSystem<T>::AllocateGeometry(GeometrySystem<T>* geometry_system) {
 }
 
 template <typename T>
-FramePoseVector<T> SolarSystem<T>::AllocateFramePoseOutput(
-    const Context<T>&) const {
+FramePoseVector<T> SolarSystem<T>::AllocateFramePoseOutput() const {
   DRAKE_DEMAND(source_id_.is_valid());
   DRAKE_DEMAND(static_cast<int>(body_offset_.size()) == kBodyCount);
   // NOTE: We initialize with the translational offset during allocation so that
@@ -285,7 +284,7 @@ void SolarSystem<T>::CalcFramePoseOutput(const Context<T>& context,
 }
 
 template <typename T>
-FrameIdVector SolarSystem<T>::AllocateFrameIdOutput(const MyContext&) const {
+FrameIdVector SolarSystem<T>::AllocateFrameIdOutput() const {
   DRAKE_DEMAND(source_id_.is_valid());
   DRAKE_DEMAND(static_cast<int>(body_offset_.size()) == kBodyCount);
   FrameIdVector ids(source_id_);

--- a/examples/geometry_world/solar_system.h
+++ b/examples/geometry_world/solar_system.h
@@ -125,15 +125,14 @@ class SolarSystem : public systems::LeafSystem<T> {
   void AllocateGeometry(geometry::GeometrySystem<T>* geometry_system);
 
   // Allocate the frame pose set output port value.
-  geometry::FramePoseVector<T> AllocateFramePoseOutput(
-      const MyContext& context) const;
+  geometry::FramePoseVector<T> AllocateFramePoseOutput() const;
 
   // Calculate the frame pose set output port value.
   void CalcFramePoseOutput(const MyContext& context,
                            geometry::FramePoseVector<T>* poses) const;
 
   // Allocate the id output.
-  geometry::FrameIdVector AllocateFrameIdOutput(const MyContext& context) const;
+  geometry::FrameIdVector AllocateFrameIdOutput() const;
   // Calculate the id output.
   void CalcFrameIdOutput(const MyContext& context,
                          geometry::FrameIdVector* id_set) const;

--- a/geometry/geometry_system.cc
+++ b/geometry/geometry_system.cc
@@ -209,8 +209,7 @@ void GeometrySystem<T>::MakeSourcePorts(SourceId source_id) {
 }
 
 template <typename T>
-QueryObject<T> GeometrySystem<T>::MakeQueryObject(
-    const systems::Context<T>&) const {
+QueryObject<T> GeometrySystem<T>::MakeQueryObject() const {
   // Returns a null-initialized QueryObject to be compatible with context
   // allocation (see documentation on QueryObject).
   return QueryObject<T>();

--- a/geometry/geometry_system.h
+++ b/geometry/geometry_system.h
@@ -408,7 +408,7 @@ class GeometrySystem final : public systems::LeafSystem<T> {
   friend void DispatchLoadMessage(const GeometrySystem<double>&);
 
   // Constructs a QueryObject for OutputPort allocation.
-  QueryObject<T> MakeQueryObject(const systems::Context<T>& context) const;
+  QueryObject<T> MakeQueryObject() const;
 
   // Sets the context into the output port value so downstream consumers can
   // perform queries.

--- a/geometry/test/geometry_system_test.cc
+++ b/geometry/test/geometry_system_test.cc
@@ -385,8 +385,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
 
  private:
   // Frame id output allocation and calculation.
-  FrameIdVector AllocateFrameIdOutput(
-      const Context<double>& context) const {
+  FrameIdVector AllocateFrameIdOutput() const {
     FrameIdVector ids(source_id_, frame_ids_);
     ids.AddFrameIds(extra_frame_ids_);
     return ids;
@@ -395,8 +394,7 @@ class GeometrySourceSystem : public systems::LeafSystem<double> {
   void CalcFrameIdOutput(const Context<double> &context,
                                                FrameIdVector *) const {}
   // Frame pose output allocation.
-  FramePoseVector<double> AllocateFramePoseOutput(
-  const Context<double>& context) const {
+  FramePoseVector<double> AllocateFramePoseOutput() const {
     FramePoseVector<double> poses(source_id_);
     for (size_t i = 0; i < frame_ids_.size(); ++i) {
       poses.mutable_vector().push_back(Isometry3<double>::Identity());

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -534,8 +534,7 @@ void MultibodyPlant<T>::DeclareGeometrySystemPorts() {
 }
 
 template <typename T>
-FrameIdVector MultibodyPlant<T>::AllocateFrameIdOutput(
-    const Context<T>&) const {
+FrameIdVector MultibodyPlant<T>::AllocateFrameIdOutput() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(source_id_ != nullopt);
   // User must be done adding elements to the model.
@@ -553,8 +552,7 @@ void MultibodyPlant<T>::CalcFrameIdOutput(
 }
 
 template <typename T>
-FramePoseVector<T> MultibodyPlant<T>::AllocateFramePoseOutput(
-    const Context<T>&) const {
+FramePoseVector<T> MultibodyPlant<T>::AllocateFramePoseOutput() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(source_id_ != nullopt);
   FramePoseVector<T> poses(source_id_.value());

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -885,15 +885,13 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // with a GeometrySystem.
   void DeclareGeometrySystemPorts();
 
-  geometry::FrameIdVector AllocateFrameIdOutput(
-      const systems::Context<T>& context) const;
+  geometry::FrameIdVector AllocateFrameIdOutput() const;
 
   void CalcFrameIdOutput(
       const systems::Context<T>& context,
       geometry::FrameIdVector* id_set) const;
 
-  geometry::FramePoseVector<T> AllocateFramePoseOutput(
-      const systems::Context<T>& context) const;
+  geometry::FramePoseVector<T> AllocateFramePoseOutput() const;
 
   void CalcFramePoseOutput(const systems::Context<T>& context,
                            geometry::FramePoseVector<T>* poses) const;

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -306,14 +306,14 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
       plant_->CreateDefaultContext();
 
   std::unique_ptr<AbstractValue> ids_value =
-      plant_->get_geometry_ids_output_port().Allocate(*context);
+      plant_->get_geometry_ids_output_port().Allocate();
   EXPECT_NO_THROW(ids_value->GetValueOrThrow<FrameIdVector>());
   const FrameIdVector& ids = ids_value->GetValueOrThrow<FrameIdVector>();
   EXPECT_EQ(ids.get_source_id(), plant_->get_source_id());
   EXPECT_EQ(ids.size(), 2);  // Only two frames move.
 
   std::unique_ptr<AbstractValue> poses_value =
-      plant_->get_geometry_poses_output_port().Allocate(*context);
+      plant_->get_geometry_poses_output_port().Allocate();
   EXPECT_NO_THROW(poses_value->GetValueOrThrow<FramePoseVector<double>>());
   const FramePoseVector<double>& poses =
       poses_value->GetValueOrThrow<FramePoseVector<double>>();
@@ -399,14 +399,14 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
       context.get());
 
   std::unique_ptr<AbstractValue> ids_value =
-      plant.get_geometry_ids_output_port().Allocate(*context);
+      plant.get_geometry_ids_output_port().Allocate();
   EXPECT_NO_THROW(ids_value->GetValueOrThrow<FrameIdVector>());
   const FrameIdVector& ids = ids_value->GetValueOrThrow<FrameIdVector>();
   EXPECT_EQ(ids.get_source_id(), plant.get_source_id());
   EXPECT_EQ(ids.size(), 2);  // Only two frames move.
 
   std::unique_ptr<AbstractValue> poses_value =
-      plant.get_geometry_poses_output_port().Allocate(*context);
+      plant.get_geometry_poses_output_port().Allocate();
   EXPECT_NO_THROW(poses_value->GetValueOrThrow<FramePoseVector<double>>());
   const FramePoseVector<double>& poses =
       poses_value->GetValueOrThrow<FramePoseVector<double>>();
@@ -494,7 +494,7 @@ TEST_F(AcrobotPlantTests, EvalContinuousStateOutputPort) {
   elbow_->set_angular_rate(context.get(), 2.5);
 
   std::unique_ptr<AbstractValue> state_value =
-      plant_->get_continuous_state_output_port().Allocate(*context);
+      plant_->get_continuous_state_output_port().Allocate();
   EXPECT_NO_THROW(state_value->GetValueOrThrow<BasicVector<double>>());
   const BasicVector<double>& state_out =
       state_value->GetValueOrThrow<BasicVector<double>>();

--- a/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -139,8 +139,7 @@ void RigidBodyPlantBridge<T>::RegisterTree(GeometrySystem<T>* geometry_system) {
 }
 
 template <typename T>
-FramePoseVector<T> RigidBodyPlantBridge<T>::AllocateFramePoseOutput(
-    const MyContext&) const {
+FramePoseVector<T> RigidBodyPlantBridge<T>::AllocateFramePoseOutput() const {
   DRAKE_DEMAND(source_id_.is_valid());
   // Poses of the registered bodies in the world -- defaults to identity.
   std::vector<Isometry3<T>> X_WF(body_ids_.size(), Isometry3<T>::Identity());
@@ -172,8 +171,7 @@ void RigidBodyPlantBridge<T>::CalcFramePoseOutput(
 }
 
 template <typename T>
-FrameIdVector RigidBodyPlantBridge<T>::AllocateFrameIdOutput(
-    const MyContext&) const {
+FrameIdVector RigidBodyPlantBridge<T>::AllocateFrameIdOutput() const {
   DRAKE_DEMAND(source_id_.is_valid());
   FrameIdVector ids(source_id_, body_ids_);
   return ids;

--- a/multibody/rigid_body_plant/rigid_body_plant_bridge.h
+++ b/multibody/rigid_body_plant/rigid_body_plant_bridge.h
@@ -129,15 +129,14 @@ class RigidBodyPlantBridge : public systems::LeafSystem<T> {
   }
 
   // Allocate the frame pose set output port value.
-  geometry::FramePoseVector<T> AllocateFramePoseOutput(
-      const MyContext& context) const;
+  geometry::FramePoseVector<T> AllocateFramePoseOutput() const;
 
   // Calculate the frame pose set output port value.
   void CalcFramePoseOutput(const MyContext& context,
                            geometry::FramePoseVector<T>* poses) const;
 
   // Allocate the id output.
-  geometry::FrameIdVector AllocateFrameIdOutput(const MyContext& context) const;
+  geometry::FrameIdVector AllocateFrameIdOutput() const;
   // Calculate the id output.
   void CalcFrameIdOutput(const MyContext& context,
                          geometry::FrameIdVector* id_set) const;

--- a/systems/controllers/test/dynamic_programming_test.cc
+++ b/systems/controllers/test/dynamic_programming_test.cc
@@ -52,7 +52,7 @@ GTEST_TEST(FittedValueIterationTest, SingleIntegrator) {
   // Optimal policy is 1 if x < 0, 0 if x = 0, -1 if x > 0.
   EXPECT_EQ(policy->get_output_port().size(), 1);
   auto context = policy->CreateDefaultContext();
-  auto output = policy->get_output_port().Allocate(*context);
+  auto output = policy->get_output_port().Allocate();
   for (const double x : state_grid[0]) {
     context->FixInputPort(0, Vector1d{x});
     policy->get_output_port().Calc(*context, output.get());

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -47,17 +47,18 @@ void CacheEntry::Calc(const ContextBase& context,
                       AbstractValue* value) const {
   DRAKE_DEMAND(value != nullptr);
   DRAKE_ASSERT_VOID(owning_subsystem_->ThrowIfContextNotCompatible(context));
-  DRAKE_ASSERT_VOID(CheckValidAbstractValue(context, *value));
+  DRAKE_ASSERT_VOID(CheckValidAbstractValue(*value));
 
   calc_function_(context, value);
 }
 
-void CacheEntry::CheckValidAbstractValue(const ContextBase&,
-                                         const AbstractValue& proposed) const {
+// See OutputPort::CheckValidOutputType; treat both methods similarly.
+void CacheEntry::CheckValidAbstractValue(const AbstractValue& proposed) const {
   // TODO(sherm1) Consider whether we can depend on there already being an
   //              object of this type in the context's CacheEntryValue so we
   //              wouldn't have to allocate one here. If so could also store
-  //              a precomputed type_index there for further savings.
+  //              a precomputed type_index there for further savings. Would
+  //              need to pass in a ContextBase.
   auto good_ptr = Allocate();  // Very expensive!
   const AbstractValue& good = *good_ptr;
   if (typeid(proposed) != typeid(good)) {

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -289,8 +289,7 @@ class CacheEntry {
 
   // Check that an AbstractValue provided to Calc() is suitable for this cache
   // entry. (Very expensive; use in Debug only.)
-  void CheckValidAbstractValue(const ContextBase& context,
-                               const AbstractValue& proposed) const;
+  void CheckValidAbstractValue(const AbstractValue& proposed) const;
 
   // Provides an identifying prefix for error messages.
   std::string FormatName(const char* api) const;

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -69,14 +69,13 @@ class DiagramOutputPort : public OutputPort<T> {
   }
 
  private:
-  // These forward to the source system output port, passing in just the source
-  // System's Context, not the whole Diagram context we're given.
-  std::unique_ptr<AbstractValue> DoAllocate(
-      const Context<T>& context) const final {
-    const Context<T>& subcontext = get_subcontext(context);
-    return source_output_port_->Allocate(subcontext);
+  // These forward to the source system output port.
+  std::unique_ptr<AbstractValue> DoAllocate() const final {
+    return source_output_port_->Allocate();
   }
 
+  // Pass in just the source System's Context, not the whole Diagram context
+  // we're given.
   void DoCalc(
       const Context<T>& context, AbstractValue* value) const final {
     const Context<T>& subcontext = get_subcontext(context);

--- a/systems/framework/leaf_output_port.cc
+++ b/systems/framework/leaf_output_port.cc
@@ -36,14 +36,11 @@ void LeafOutputPort<T>::set_calculation_function(
 }
 
 template <typename T>
-std::unique_ptr<AbstractValue> LeafOutputPort<T>::DoAllocate(
-    const Context<T>& context) const {
+std::unique_ptr<AbstractValue> LeafOutputPort<T>::DoAllocate() const {
   std::unique_ptr<AbstractValue> result;
 
-  // Use the allocation function if available, otherwise clone the model
-  // value.
   if (alloc_function_) {
-    result = alloc_function_(context);
+    result = alloc_function_();
   } else {
     throw std::logic_error(
         "LeafOutputPort::DoAllocate(): " + this->GetPortIdString() +

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -47,8 +47,7 @@ class LeafOutputPort : public OutputPort<T> {
   /** Signature of a function suitable for allocating an object that can hold
   a value of a particular output port. The result is returned as an
   AbstractValue even if this is a vector-valued port. */
-  using AllocCallback = std::function<std::unique_ptr<AbstractValue>(
-      const Context<T>&)>;
+  using AllocCallback = std::function<std::unique_ptr<AbstractValue>()>;
 
   /** Signature of a function suitable for calculating a value of a particular
   output port, given a place to put the value. */
@@ -129,8 +128,7 @@ class LeafOutputPort : public OutputPort<T> {
 
   // Invokes the supplied allocation function if there is one, otherwise
   // complains.
-  std::unique_ptr<AbstractValue> DoAllocate(
-      const Context<T>& context) const final;
+  std::unique_ptr<AbstractValue> DoAllocate() const final;
 
   // Invokes the supplied calculation function if present, otherwise complains.
   void DoCalc(const Context<T>& context, AbstractValue* value) const final;

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -78,7 +78,7 @@ class OutputPort {
   @note If this is a vector-valued port, the underlying type is
   `Value<BasicVector<T>>`; downcast to `BasicVector<T>` before downcasting to
   the specific `BasicVector` subclass. */
-  std::unique_ptr<AbstractValue> Allocate(const Context<T>& context) const;
+  std::unique_ptr<AbstractValue> Allocate() const;
 
   /** Unconditionally computes the value of this output port with respect to the
   given context, into an already-allocated AbstractValue object whose concrete
@@ -130,12 +130,8 @@ class OutputPort {
   /** A concrete %OutputPort must provide a way to allocate a suitable object
   for holding the runtime value of this output port. The particulars may depend
   on values and types of objects in the given Context.
-  @param context
-     A Context that has already been validated as compatible with
-     the System whose output port this is.
   @returns A unique_ptr to the new value-holding object as an AbstractValue. */
-  virtual std::unique_ptr<AbstractValue> DoAllocate(
-      const Context<T>& context) const = 0;
+  virtual std::unique_ptr<AbstractValue> DoAllocate() const = 0;
 
   /** A concrete %OutputPort must implement this method to calculate the value
   this output port should have, given the supplied Context. The value may be
@@ -169,7 +165,7 @@ class OutputPort {
 
   // Check that an AbstractValue provided to Calc() is suitable for this port.
   // (Very expensive; use in Debug only.)
-  void CheckValidOutputType(const Context<T>&, const AbstractValue&) const;
+  void CheckValidOutputType(const AbstractValue&) const;
 
   // Check that both type-erased arguments have the same underlying type.
   void CheckValidAbstractValue(const AbstractValue& good,

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -134,9 +134,9 @@ class System : public SystemBase {
   /// Returns a container that can hold the values of all of this System's
   /// output ports. It is sized with the number of output ports and uses each
   /// output port's allocation method to provide an object of the right type
-  /// for that port. A Context is provided as
-  /// an argument to support some specialized use cases. Most typical
-  /// System implementations should ignore it.
+  /// for that port.
+  // TODO(sherm1) Get rid of context parameter. We are stuck with it for now
+  // because of the way DiagramOutput is implemented. Fixed in caching branch.
   virtual std::unique_ptr<SystemOutput<T>> AllocateOutput(
       const Context<T>& context) const = 0;
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -746,7 +746,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   std::vector<std::unique_ptr<AbstractValue>> values;
   for (int i = 0; i < 4; ++i) {
     const OutputPort<double>& out = dut.get_output_port(i);
-    values.emplace_back(out.Allocate(*context));
+    values.emplace_back(out.Allocate());
     out.Calc(*context, values.back().get());
   }
 
@@ -841,7 +841,7 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
     // Output port 2 uses the "Advanced" method for abstract ports, providing
     // explicit non-member functors for allocator and calculator.
     this->DeclareAbstractOutputPort(
-        [](const Context<double>&) {
+        []() {
           return AbstractValue::Make<int>(-2);
         },
         [](const Context<double>&, AbstractValue* out) {
@@ -869,7 +869,7 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
   }
 
   // Explicit allocator method.
-  std::string MakeString(const Context<double>&) const {
+  std::string MakeString() const {
     return std::string("freshly made");
   }
 

--- a/systems/framework/test/single_output_vector_source_test.cc
+++ b/systems/framework/test/single_output_vector_source_test.cc
@@ -47,7 +47,7 @@ TEST_F(SingleOutputVectorSourceTest, OutputTest) {
   ASSERT_EQ(output_->get_num_ports(), 1);
 
   std::unique_ptr<AbstractValue> output =
-      source_->get_output_port(0).Allocate(*context_);
+      source_->get_output_port(0).Allocate();
   source_->get_output_port(0).Calc(*context_, output.get());
 
   const auto& output_vector = output->GetValueOrThrow<BasicVector<double>>();

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -411,7 +411,7 @@ class ValueIOTestSystem : public System<T> {
 
     this->DeclareAbstractInputPort();
     this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(*this,
-        [](const Context<T>&) { return AbstractValue::Make(std::string()); },
+        []() { return AbstractValue::Make(std::string()); },
         [this](const Context<T>& context, AbstractValue* output) {
           this->CalcStringOutput(context, output);
         }));
@@ -424,7 +424,7 @@ class ValueIOTestSystem : public System<T> {
     this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
         *this,
         1,  // Vector size.
-        [](const Context<T>&) {
+        []() {
           return std::make_unique<Value<BasicVector<T>>>(1);
         },
         [this](const Context<T>& context, BasicVector<T>* output) {
@@ -518,8 +518,8 @@ class ValueIOTestSystem : public System<T> {
       const Context<T>& context) const override {
     std::unique_ptr<LeafSystemOutput<T>> output(
         new LeafSystemOutput<T>);
-    output->add_port(this->get_output_port(0).Allocate(context));
-    output->add_port(this->get_output_port(1).Allocate(context));
+    output->add_port(this->get_output_port(0).Allocate());
+    output->add_port(this->get_output_port(1).Allocate());
     return std::move(output);
   }
 

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -220,7 +220,7 @@ TEST_F(VectorSystemTest, OutputStateless) {
   TestVectorSystem dut;
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
-  std::unique_ptr<AbstractValue> output = output_port.Allocate(*context);
+  std::unique_ptr<AbstractValue> output = output_port.Allocate();
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
   output_port.Calc(*context, output.get());
   EXPECT_EQ(dut.get_output_count(), 1);
@@ -243,7 +243,7 @@ TEST_F(VectorSystemTest, OutputContinuous) {
   dut.DeclareContinuousState(TestVectorSystem::kSize);
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
-  std::unique_ptr<AbstractValue> output = output_port.Allocate(*context);
+  std::unique_ptr<AbstractValue> output = output_port.Allocate();
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
   context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d::Ones());
@@ -266,7 +266,7 @@ TEST_F(VectorSystemTest, OutputDiscrete) {
   dut.set_prototype_discrete_state_count(1);
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
-  std::unique_ptr<AbstractValue> output = output_port.Allocate(*context);
+  std::unique_ptr<AbstractValue> output = output_port.Allocate();
   context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
   context->get_mutable_discrete_state(0).SetFromVector(
       Eigen::Vector2d::Ones());
@@ -398,7 +398,7 @@ TEST_F(VectorSystemTest, NoFeedthroughContinuousTimeSystemTest) {
 
   // The non-connected input is never evaluated.
   auto context = dut.CreateDefaultContext();
-  auto output = dut.get_output_port().Allocate(*context);
+  auto output = dut.get_output_port().Allocate();
   dut.get_output_port().Calc(*context, output.get());
   EXPECT_EQ(output->GetValueOrThrow<BasicVector<double>>().GetAtIndex(0), 0.0);
 }
@@ -415,7 +415,7 @@ TEST_F(VectorSystemTest, NoInputContinuousTimeSystemTest) {
   dut.CalcTimeDerivatives(*context, derivatives.get());
   EXPECT_EQ(derivatives->get_vector().GetAtIndex(0), -1.0);
 
-  auto output = dut.get_output_port().Allocate(*context);
+  auto output = dut.get_output_port().Allocate();
   dut.get_output_port().Calc(*context, output.get());
   EXPECT_EQ(output->GetValueOrThrow<BasicVector<double>>().GetAtIndex(0), 1.0);
 
@@ -551,7 +551,7 @@ TEST_F(VectorSystemTest, MissingMethodsContinuousTimeSystemTest) {
   EXPECT_THROW(dut.CalcTimeDerivatives(*context, derivatives.get()),
                std::exception);
 
-  auto output = dut.get_output_port().Allocate(*context);
+  auto output = dut.get_output_port().Allocate();
   EXPECT_THROW(dut.get_output_port().Calc(*context, output.get()),
                std::exception);
 }
@@ -577,7 +577,7 @@ TEST_F(VectorSystemTest, MissingMethodsDiscreteTimeSystemTest) {
       dut.CalcDiscreteVariableUpdates(*context, discrete_updates.get()),
       std::exception);
 
-  auto output = dut.get_output_port().Allocate(*context);
+  auto output = dut.get_output_port().Allocate();
   EXPECT_THROW(dut.get_output_port().Calc(*context, output.get()),
                std::exception);
 }

--- a/systems/lcm/lcm_subscriber_system.cc
+++ b/systems/lcm/lcm_subscriber_system.cc
@@ -53,7 +53,7 @@ LcmSubscriberSystem::LcmSubscriberSystem(
     // Use the "advanced" method to construct explicit non-member functors
     // to deal with the unusual methods we have available.
     DeclareAbstractOutputPort(
-        [this](const Context<double>&) {
+        [this]() {
           return this->AllocateSerializerOutputValue();
         },
         [this](const Context<double>& context, AbstractValue* out) {

--- a/systems/primitives/constant_value_source-inl.h
+++ b/systems/primitives/constant_value_source-inl.h
@@ -23,7 +23,7 @@ ConstantValueSource<T>::ConstantValueSource(
   // Use the "advanced" method to provide explicit non-member functors here
   // since we already have AbstractValues.
   this->DeclareAbstractOutputPort(
-      [this](const Context<T>&) {
+      [this]() {
         return source_value_->Clone();
       },
       [this](const Context<T>&, AbstractValue* output) {

--- a/systems/primitives/linear_system.cc
+++ b/systems/primitives/linear_system.cc
@@ -239,8 +239,7 @@ std::unique_ptr<AffineSystem<double>> DoFirstOrderTaylorApproximation(
   Eigen::VectorXd y0 = Eigen::VectorXd::Zero(num_outputs);
 
   if (output_port) {
-    std::unique_ptr<AbstractValue> autodiff_y0 =
-        output_port->Allocate(*autodiff_context);
+    std::unique_ptr<AbstractValue> autodiff_y0 = output_port->Allocate();
     output_port->Calc(*autodiff_context, autodiff_y0.get());
 
     auto autodiff_y0_vec =

--- a/systems/primitives/pass_through-inl.h
+++ b/systems/primitives/pass_through-inl.h
@@ -36,7 +36,7 @@ PassThrough<T>::PassThrough(
     this->DeclareAbstractInputPort(*abstract_model_value_);
     // Use the std::function<> overloads to work with `AbstractValue` type
     // directly and maintain type erasure.
-    auto abstract_value_allocator = [this](const Context<T>&) {
+    auto abstract_value_allocator = [this]() {
       return abstract_model_value_->Clone();
     };
     namespace sp = std::placeholders;

--- a/systems/primitives/test/adder_test.cc
+++ b/systems/primitives/test/adder_test.cc
@@ -21,7 +21,7 @@ class AdderTest : public ::testing::Test {
   void SetUp() override {
     adder_.reset(new Adder<double>(2 /* inputs */, 3 /* size */));
     context_ = adder_->CreateDefaultContext();
-    output_ = adder_->get_output_port().Allocate(*context_);
+    output_ = adder_->get_output_port().Allocate();
     input0_.reset(new BasicVector<double>(3 /* size */));
     input1_.reset(new BasicVector<double>(3 /* size */));
   }

--- a/systems/primitives/test/barycentric_system_test.cc
+++ b/systems/primitives/test/barycentric_system_test.cc
@@ -42,8 +42,8 @@ GTEST_TEST(BarycentricSystemTest, MatrixGain) {
   auto gain_context = gain.CreateDefaultContext();
   auto bary_context = bary_sys.CreateDefaultContext();
 
-  auto gain_output = gain.get_output_port().Allocate(*gain_context);
-  auto bary_output = bary_sys.get_output_port().Allocate(*bary_context);
+  auto gain_output = gain.get_output_port().Allocate();
+  auto bary_output = bary_sys.get_output_port().Allocate();
   for (double x : {-1., -.5, .3, .7}) {
     for (double y : {-.24, .4, .8}) {
       test = Vector2d{x, y};

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -23,7 +23,7 @@ class ConstantValueSourceTest : public ::testing::Test {
     std::unique_ptr<AbstractValue> value(new Value<std::string>("foo"));
     source_ = make_unique<ConstantValueSource<double>>(std::move(value));
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port(0).Allocate(*context_);
+    output_ = source_->get_output_port(0).Allocate();
     input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 

--- a/systems/primitives/test/constant_vector_source_test.cc
+++ b/systems/primitives/test/constant_vector_source_test.cc
@@ -21,7 +21,7 @@ class ConstantVectorSourceTest : public ::testing::Test {
   void SetUpEigenModel() {
     source_ = make_unique<ConstantVectorSource<double>>(kConstantVectorSource);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port(0).Allocate(*context_);
+    output_ = source_->get_output_port(0).Allocate();
   }
 
   void SetUpBasicVectorModel() {
@@ -30,7 +30,7 @@ class ConstantVectorSourceTest : public ::testing::Test {
 
     source_ = make_unique<ConstantVectorSource<double>>(vec);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->get_output_port(0).Allocate(*context_);
+    output_ = source_->get_output_port(0).Allocate();
   }
 
   const Matrix<double, 2, 1, Eigen::DontAlign> kConstantVectorSource{2.0, 1.5};

--- a/systems/primitives/test/demultiplexer_test.cc
+++ b/systems/primitives/test/demultiplexer_test.cc
@@ -23,7 +23,7 @@ class DemultiplexerTest : public ::testing::Test {
   void SetUp() override {
     demux_ = make_unique<Demultiplexer<double>>(3 /* size */);
     context_ = demux_->CreateDefaultContext();
-    output_ = demux_->get_output_port(0).Allocate(*context_);
+    output_ = demux_->get_output_port(0).Allocate();
     input_ = make_unique<BasicVector<double>>(3 /* size */);
   }
 
@@ -69,7 +69,7 @@ GTEST_TEST(OutputSize, SizeDifferentFromOne) {
   auto demux = make_unique<Demultiplexer<double>>(
       kInputSize /* size */, kOutputSize /* output_ports_sizes */);
   auto context = demux->CreateDefaultContext();
-  auto output = demux->get_output_port(0).Allocate(*context);
+  auto output = demux->get_output_port(0).Allocate();
   auto input = make_unique<BasicVector<double>>(kInputSize /* size */);
 
   // Checks that the number of input ports in the system and in the context

--- a/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -22,7 +22,7 @@ class FirstOrderLowPassFilterTest : public ::testing::Test {
         kTimeConstant, kSignalSize);
     context_ = filter_->CreateDefaultContext();
     derivatives_ = filter_->AllocateTimeDerivatives();
-    output_ = filter_->get_output_port().Allocate(*context_);
+    output_ = filter_->get_output_port().Allocate();
 
     // Sets the state to zero initially.
     filter_->set_initial_output_value(
@@ -34,7 +34,7 @@ class FirstOrderLowPassFilterTest : public ::testing::Test {
     filter_ = std::make_unique<FirstOrderLowPassFilter<double>>(time_constants);
     context_ = filter_->CreateDefaultContext();
     derivatives_ = filter_->AllocateTimeDerivatives();
-    output_ = filter_->get_output_port().Allocate(*context_);
+    output_ = filter_->get_output_port().Allocate();
 
     // Sets the state to zero initially.
     ContinuousState<double>& xc = continuous_state();

--- a/systems/primitives/zero_order_hold-inl.h
+++ b/systems/primitives/zero_order_hold-inl.h
@@ -40,7 +40,7 @@ ZeroOrderHold<T>::ZeroOrderHold(
     this->DeclareAbstractInputPort(*abstract_model_value_);
     // Use the std::function<> overloads to work with `AbstractValue` type
     // directly and maintain type erasure.
-    auto abstract_value_allocator = [this](const Context<T>&) {
+    auto abstract_value_allocator = [this]() {
       return abstract_model_value_->Clone();
     };
     namespace sp = std::placeholders;


### PR DESCRIPTION
This PR removes the `context` parameter from the output port allocator function signature. 

Reviewers: there a lots of files but the changes are small and trivial. The only substantive changes are in systems/framework/output_port.*, system.h, leaf_system.h. The latter loses the commonly-used DeclareOutputPort signature that allowed allocator methods with no context; that's not needed any more.

One disappointing note: we still require a context to `System::AllocateOutput()` because of an odd quirk of how DiagramOutput is implemented. That is fixed in the caching branch so context will be removed from there also eventually.

Resolves #8567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8590)
<!-- Reviewable:end -->
