### PR TITLE
Selects the artificial variable as the blocking variable when possible.

### DIFF
--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -96,10 +96,10 @@ GTEST_TEST(TestUnrevisedLemke, TestPSD) {
       -1, 1;
 
   Eigen::Matrix<double, 2, 1> q;
-  q << 1, -1; 
+  q << 1, -1;
 
   Eigen::VectorXd expected_z(2);
-  expected_z << 0, 1; 
+  expected_z << 0, 1;
   RunLCP(M, q, expected_z);
 }
 

--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -806,7 +806,7 @@ TEST_F(UnrevisedLemkePrivateTests, FindComplementIndex) {
 
   // Since the indices of the LCP variables from SetUp()
   // correspond to their array indices, verification is straightforward.
-  EXPECT_EQ(lcp_.FindComplementIndex(query, lcp_.indep_variables_), 1);
+  EXPECT_EQ(lcp_.FindComplementIndex(query), 1);
 }
 
 TEST_F(UnrevisedLemkePrivateTests, FindBlockingIndex) {

--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -90,12 +90,15 @@ GTEST_TEST(TestUnrevisedLemke, TestSimple) {
 // Tests that the artificial variable is always selected in a tie
 // (Example 4.4.16 in [Cottle 1992]). We know Lemke's algorithm can solve
 // this one since the matrix is symmetric and positive semi-definite.
+// Lemke implementations without the necessary special-case code can terminate
+// on an unblocked variable (i.e., fail to find the solution when one is known
+// to exist).
 GTEST_TEST(TestUnrevisedLemke, TestPSD) {
   MatrixX<double> M(2, 2);
   M << 1, -1,
       -1, 1;
 
-  Eigen::Matrix<double, 2, 1> q;
+  Eigen::Vector2d q;
   q << 1, -1;
 
   Eigen::VectorXd expected_z(2);

--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -93,6 +93,12 @@ GTEST_TEST(TestUnrevisedLemke, TestSimple) {
 // Lemke implementations without the necessary special-case code can terminate
 // on an unblocked variable (i.e., fail to find the solution when one is known
 // to exist).
+// NOTE: This is a necessary but not sufficient test that the special-case code
+// is working. This test failed before the special-case code was added, but it's
+// possible that the test could succeed using other strategies for selecting
+// one of multiple valid blocking indices. For example, Miranda and Fackler's
+// Lemke solver uses a random blocking variable selection when multiple are
+// possible.
 GTEST_TEST(TestUnrevisedLemke, TestPSD) {
   MatrixX<double> M(2, 2);
   M << 1, -1,

--- a/solvers/test/unrevised_lemke_solver_test.cc
+++ b/solvers/test/unrevised_lemke_solver_test.cc
@@ -87,6 +87,22 @@ GTEST_TEST(TestUnrevisedLemke, TestSimple) {
   RunLCP(M, q, expected_z);
 }
 
+// Tests that the artificial variable is always selected in a tie
+// (Example 4.4.16 in [Cottle 1992]). We know Lemke's algorithm can solve
+// this one since the matrix is symmetric and positive semi-definite.
+GTEST_TEST(TestUnrevisedLemke, TestPSD) {
+  MatrixX<double> M(2, 2);
+  M << 1, -1,
+      -1, 1;
+
+  Eigen::Matrix<double, 2, 1> q;
+  q << 1, -1; 
+
+  Eigen::VectorXd expected_z(2);
+  expected_z << 0, 1; 
+  RunLCP(M, q, expected_z);
+}
+
 GTEST_TEST(TestUnrevisedLemke, TestProblem1) {
   // Problem from example 10.2.1 in "Handbook of Test Problems in
   // Local and Global Optimization".

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -576,6 +576,13 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
   return true;
 }
 
+// Checks to see whether a given variable is the artificial variable.
+template <class T>
+bool UnrevisedLemkeSolver<T>::IsArtificial(const LCPVariable& v) const {
+  const int n = static_cast<int>(dep_variables_.size());
+  return v.is_z() && v.index() == n;
+}
+
 // Method for finding the index of the complement of an LCP variable in
 // a tuple (strictly speaking, an unsorted vector) of independent variables.
 // Aborts if the index is not found in the set or the variable is the artificial
@@ -666,7 +673,7 @@ bool UnrevisedLemkeSolver<T>::FindBlockingIndex(
     if (matrix_col[i] < -zero_tol) {
       DRAKE_SPDLOG_DEBUG(log(), "Ratio for index {}: {}", i, ratios[i]);
       if (ratios[i] < min_ratio + zero_tol) {
-        if (dep_variables_[i].is_z() && dep_variables_[i].index() == n) {
+        if (IsArtificial(dep_variables_[i])) {
           // *Always* select the artificial variable, if multiple choices are
           // possible ([Cottle 1992] p. 280).
           *blocking_index = i;

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -587,8 +587,7 @@ bool UnrevisedLemkeSolver<T>::IsArtificial(const LCPVariable& v) const {
 // variable (it never should be).
 template <class T>
 int UnrevisedLemkeSolver<T>::FindComplementIndex(
-    const LCPVariable& query,
-    const std::vector<LCPVariable>& indep_variables) const {
+    const LCPVariable& query) const {
   // Verify that the query is not the artificial variable.
   DRAKE_DEMAND(!IsArtificial(query));
 
@@ -917,7 +916,7 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
         driving_index;
 
     // Make the driving variable the complement of the blocking variable.
-    driving_index = FindComplementIndex(blocking, indep_variables_);
+    driving_index = FindComplementIndex(blocking);
 
     DRAKE_SPDLOG_DEBUG(log(), "Independent set variables: {}",
         to_string(indep_variables_));

--- a/solvers/unrevised_lemke_solver.cc
+++ b/solvers/unrevised_lemke_solver.cc
@@ -452,7 +452,7 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
     VectorX<T>* q_prime) const {
   DRAKE_DEMAND(q_prime);
 
-  const int kArtificial = M.rows();  // Artificial variable index.
+  const int kArtificial = M.rows();
   DRAKE_DEMAND(driving_index >= 0 && driving_index <= kArtificial);
 
   // Verify that each member in the independent and dependent sets is unique.
@@ -461,10 +461,8 @@ bool UnrevisedLemkeSolver<T>::LemkePivot(
 
   // If the driving index does not correspond to the artificial variable,
   // M_prime_col must be non-null.
-  if (!indep_variables_[driving_index].is_z() ||
-      indep_variables_[driving_index].index() != kArtificial) {
+  if (!IsArtificial(indep_variables_[driving_index]))
     DRAKE_DEMAND(M_prime_col);
-  }
 
   // Determine the sets.
   DetermineIndexSets();
@@ -592,8 +590,7 @@ int UnrevisedLemkeSolver<T>::FindComplementIndex(
     const LCPVariable& query,
     const std::vector<LCPVariable>& indep_variables) const {
   // Verify that the query is not the artificial variable.
-  const int kArtificial = static_cast<int>(indep_variables.size() - 1);
-  DRAKE_DEMAND(!(query.is_z() && query.index() == kArtificial));
+  DRAKE_DEMAND(!IsArtificial(query));
 
   const auto iter = indep_variables_indices_.find(query.Complement());
   DRAKE_DEMAND(iter != indep_variables_indices_.end());
@@ -788,10 +785,8 @@ bool UnrevisedLemkeSolver<T>::SolveLcpLemke(const MatrixX<T>& M,
     int zn_index = -1;
     for (int i = 0;
          i < static_cast<int>(indep_variables_.size()) && zn_index < 0; ++i) {
-      if (indep_variables_[i].is_z() &&
-          indep_variables_[i].index() == kArtificial) {
+      if (IsArtificial(indep_variables_[i]))
         zn_index = i;
-      }
     }
 
     if (zn_index >= 0) {

--- a/solvers/unrevised_lemke_solver.h
+++ b/solvers/unrevised_lemke_solver.h
@@ -193,6 +193,7 @@ class UnrevisedLemkeSolver : public MathematicalProgramSolverInterface {
   bool FindBlockingIndex(
       const T& zero_tol, const VectorX<T>& matrix_col, const VectorX<T>& ratios,
       int* blocking_index) const;
+  bool IsArtificial(const LCPVariable& v) const;
 
   typedef std::vector<LCPVariable> LCPVariableVector;
 

--- a/solvers/unrevised_lemke_solver.h
+++ b/solvers/unrevised_lemke_solver.h
@@ -186,9 +186,7 @@ class UnrevisedLemkeSolver : public MathematicalProgramSolverInterface {
                   T zero_tol, VectorX<T>* M_bar_col, VectorX<T>* q_bar) const;
   bool ConstructLemkeSolution(const MatrixX<T>& M, const VectorX<T>& q,
       int artificial_index, T zero_tol, VectorX<T>* z) const;
-  int FindComplementIndex(
-      const LCPVariable& query,
-      const std::vector<LCPVariable>& indep_variables) const;
+  int FindComplementIndex(const LCPVariable& query) const;
   void DetermineIndexSets() const;
   bool FindBlockingIndex(
       const T& zero_tol, const VectorX<T>& matrix_col, const VectorX<T>& ratios,


### PR DESCRIPTION
This simple fix allows the algorithm to solve an example LCP with a PSD matrix that it wasn't able to solve previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8593)
<!-- Reviewable:end -->
