### PR TITLE
adds get_variable_vector to symbolic expression. 

### DIFF
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -837,6 +837,15 @@ const Expression& get_else_expression(const Expression& e) {
 Expression operator+(const Variable& var) { return Expression{var}; }
 Expression operator-(const Variable& var) { return -Expression{var}; }
 
+VectorX<Variable> get_variable_vector(
+    const Eigen::Ref<const VectorX<Expression>>& evec) {
+  VectorX<Variable> vec(evec.size());
+  for (int i = 0; i < evec.size(); i++) {
+    vec(i) = get_variable(evec(i));
+  }
+  return vec;
+}
+
 MatrixX<Expression> Jacobian(const Eigen::Ref<const VectorX<Expression>>& f,
                              const vector<Variable>& vars) {
   DRAKE_DEMAND(!vars.empty());

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -877,6 +877,12 @@ struct ScalarBinaryOpTraits<double, drake::symbolic::Expression, BinaryOp> {
 
 namespace drake {
 namespace symbolic {
+
+/// Constructs a vector of variables from the vector of variable expressions.
+/// \pre{@p evec is a vector of variable expressions.}
+VectorX<Variable> get_variable_vector(
+    const Eigen::Ref<const VectorX<Expression>>& evec);
+
 /// Computes the Jacobian matrix J of the vector function @p f with respect to
 /// @p vars. J(i,j) contains ∂f(i)/∂vars(j).
 ///

--- a/common/test/symbolic_expression_matrix_test.cc
+++ b/common/test/symbolic_expression_matrix_test.cc
@@ -74,6 +74,14 @@ TEST_F(SymbolicExpressionMatrixTest, EigenAdd) {
   EXPECT_EQ(M, M_expected);
 }
 
+TEST_F(SymbolicExpressionMatrixTest, GetVariableVector) {
+  const Vector3<Expression> evec(x_, y_, z_);
+  const VectorX<Variable> vec = get_variable_vector(evec);
+  EXPECT_EQ(vec(0), x_);
+  EXPECT_EQ(vec(1), y_);
+  EXPECT_EQ(vec(2), z_);
+}
+
 TEST_F(SymbolicExpressionMatrixTest, EigenSub1) {
   auto const M(A_ - A_);
   Eigen::Matrix<Expression, 3, 2> M_expected;


### PR DESCRIPTION
needed this to take Jacobians of my state vector (which is naturally a symbolic::Expression)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8600)
<!-- Reviewable:end -->
