### PR TITLE
python3 prep, unittest: Remove deprecated test methods (`assert*Equals` => `assert*Equal`)

### DIFF
--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -35,45 +35,45 @@ class TestRigidBodyPlant(unittest.TestCase):
                 mut.CompliantContactModelParameters())
             plant.set_default_compliant_material(mut.CompliantMaterial())
             self.assertTrue(plant.get_rigid_body_tree() is tree)
-            self.assertEquals(plant.get_num_bodies(), tree.get_num_bodies())
+            self.assertEqual(plant.get_num_bodies(), tree.get_num_bodies())
 
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_num_positions(), tree.get_num_positions())
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_num_positions(model_id), tree.get_num_positions())
 
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_num_velocities(), tree.get_num_velocities())
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_num_velocities(model_id), tree.get_num_velocities())
 
             num_states = plant.get_num_positions() + plant.get_num_velocities()
-            self.assertEquals(plant.get_num_states(), num_states)
-            self.assertEquals(plant.get_num_states(model_id), num_states)
+            self.assertEqual(plant.get_num_states(), num_states)
+            self.assertEqual(plant.get_num_states(model_id), num_states)
 
             num_actuators = 1
-            self.assertEquals(plant.get_num_actuators(), num_actuators)
-            self.assertEquals(plant.get_num_actuators(model_id), num_actuators)
+            self.assertEqual(plant.get_num_actuators(), num_actuators)
+            self.assertEqual(plant.get_num_actuators(model_id), num_actuators)
 
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_num_model_instances(), 1)
-            self.assertEquals(
+            self.assertEqual(
                 plant.get_input_size(), plant.get_num_actuators())
-            self.assertEquals(plant.get_output_size(), plant.get_num_states())
+            self.assertEqual(plant.get_output_size(), plant.get_num_states())
 
             context = plant.CreateDefaultContext()
             x = plant.GetStateVector(context)
             plant.SetDefaultState(context, context.get_mutable_state())
             plant.set_position(context, 0, 1.)
-            self.assertEquals(x[0], 1.)
+            self.assertEqual(x[0], 1.)
             plant.set_velocity(context, 0, 2.)
-            self.assertEquals(x[1], 2.)
+            self.assertEqual(x[1], 2.)
             plant.set_state_vector(context, [3., 3.])
             self.assertTrue(np.allclose(x, [3., 3.]))
             plant.set_state_vector(context.get_mutable_state(), [4., 4.])
             self.assertTrue(np.allclose(x, [4., 4.]))
 
-            self.assertEquals(
+            self.assertEqual(
                 plant.FindInstancePositionIndexFromWorldIndex(0, 0), 0)
 
             # Existence checks.
@@ -96,15 +96,15 @@ class TestRigidBodyPlant(unittest.TestCase):
                 plant.contact_results_output_port() is not None)
 
             # Basic status.
-            self.assertEquals(plant.is_state_discrete(), is_discrete)
-            self.assertEquals(plant.get_time_step(), timestep)
+            self.assertEqual(plant.is_state_discrete(), is_discrete)
+            self.assertEqual(plant.get_time_step(), timestep)
 
     def test_contact_parameters_api(self):
         cls = mut.CompliantContactModelParameters
         param = cls()
-        self.assertEquals(
+        self.assertEqual(
             param.v_stiction_tolerance, cls.kDefaultVStictionTolerance)
-        self.assertEquals(
+        self.assertEqual(
             param.characteristic_radius, cls.kDefaultCharacteristicRadius)
         # Test simple mutuation.
         param.v_stiction_tolerance *= 2
@@ -117,7 +117,7 @@ class TestRigidBodyPlant(unittest.TestCase):
         # Test contact result bindings in isolation
         # by constructing dummy contact results
         results = mut.ContactResults()
-        self.assertEquals(results.get_num_contacts(), 0)
+        self.assertEqual(results.get_num_contacts(), 0)
         f = np.array([0., 1., 2.])
         results.set_generalized_contact_force(f)
         self.assertTrue(np.allclose(
@@ -126,12 +126,12 @@ class TestRigidBodyPlant(unittest.TestCase):
         id_1 = 42
         id_2 = 43
         info = results.AddContact(element_a=id_1, element_b=id_2)
-        self.assertEquals(results.get_num_contacts(), 1)
+        self.assertEqual(results.get_num_contacts(), 1)
         info_dup = results.get_contact_info(0)
         self.assertIsInstance(info_dup, mut.ContactInfo)
         self.assertIs(info, info_dup)
-        self.assertEquals(info.get_element_id_1(), id_1)
-        self.assertEquals(info.get_element_id_2(), id_2)
+        self.assertEqual(info.get_element_id_1(), id_1)
+        self.assertEqual(info.get_element_id_2(), id_2)
 
         pt = np.array([0.1, 0.2, 0.3])
         normal = np.array([0.0, 1.0, 0.0])
@@ -151,7 +151,7 @@ class TestRigidBodyPlant(unittest.TestCase):
         self.assertTrue(np.allclose(cf.get_normal(), normal))
 
         results.Clear()
-        self.assertEquals(results.get_num_contacts(), 0)
+        self.assertEqual(results.get_num_contacts(), 0)
 
     def test_compliant_material_api(self):
 
@@ -171,7 +171,7 @@ class TestRigidBodyPlant(unittest.TestCase):
             cls.kDefaultStaticFriction,
             cls.kDefaultDynamicFriction,
         )
-        self.assertEquals(flat_values(material), expected_default)
+        self.assertEqual(flat_values(material), expected_default)
         # Test mutation by chaining.
         # Ensure these values and the defaults do not overlap.
         expected = tuple(2*x for x in expected_default)
@@ -179,7 +179,7 @@ class TestRigidBodyPlant(unittest.TestCase):
             .set_youngs_modulus(expected[0])
             .set_dissipation(expected[1])
             .set_friction(expected[2], expected[3]))
-        self.assertEquals(flat_values(material), expected)
+        self.assertEqual(flat_values(material), expected)
         # Test mutation to default.
         material.set_youngs_modulus_to_default()
         self.assertTrue(material.youngs_modulus_is_default())
@@ -189,16 +189,16 @@ class TestRigidBodyPlant(unittest.TestCase):
         self.assertTrue(material.friction_is_default())
         # Test access with defaults.
         material_default = cls()
-        self.assertEquals(
+        self.assertEqual(
             material_default.youngs_modulus(default_value=expected[0]),
             expected[0])
-        self.assertEquals(
+        self.assertEqual(
             material_default.dissipation(default_value=expected[1]),
             expected[1])
-        self.assertEquals(
+        self.assertEqual(
             material_default.static_friction(default_value=expected[2]),
             expected[2])
-        self.assertEquals(
+        self.assertEqual(
             material_default.dynamic_friction(default_value=expected[3]),
             expected[3])
         # Test construction styles.

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -173,7 +173,7 @@ class TestRigidBodyTree(unittest.TestCase):
 
         num_q = num_v = 7
         num_u = tree.get_num_actuators()
-        self.assertEquals(num_u, 1)
+        self.assertEqual(num_u, 1)
         q = np.zeros(num_q)
         v = np.zeros(num_v)
         # Update kinematics.
@@ -184,29 +184,29 @@ class TestRigidBodyTree(unittest.TestCase):
         kinsol_ad = tree.doKinematics(q_ad, v_ad)
         # Sanity checks:
         # - Actuator map.
-        self.assertEquals(tree.B.shape, (num_v, num_u))
+        self.assertEqual(tree.B.shape, (num_v, num_u))
         B_expected = np.zeros((num_v, num_u))
         B_expected[-1] = 1
         self.assertTrue(np.allclose(tree.B, B_expected))
         # - Mass matrix.
         H = tree.massMatrix(kinsol)
         H_ad = tree.massMatrix(kinsol_ad)
-        self.assertEquals(H.shape, (num_v, num_v))
-        self.assertEquals(H_ad.shape, (num_v, num_v))
+        self.assertEqual(H.shape, (num_v, num_v))
+        self.assertEqual(H_ad.shape, (num_v, num_v))
         assert_sane(H)
         self.assertTrue(np.allclose(H[-1, -1], 0.25))
         # - Bias terms.
         C = tree.dynamicsBiasTerm(kinsol, {})
         C_ad = tree.dynamicsBiasTerm(kinsol_ad, {})
-        self.assertEquals(C.shape, (num_v,))
-        self.assertEquals(C_ad.shape, (num_v,))
+        self.assertEqual(C.shape, (num_v,))
+        self.assertEqual(C_ad.shape, (num_v,))
         assert_sane(C)
         # - Inverse dynamics.
         vd = np.zeros(num_v)
         tau = tree.inverseDynamics(kinsol, {}, vd)
         tau_ad = tree.inverseDynamics(kinsol_ad, {}, vd)
-        self.assertEquals(tau.shape, (num_v,))
-        self.assertEquals(tau_ad.shape, (num_v,))
+        self.assertEqual(tau.shape, (num_v,))
+        self.assertEqual(tau_ad.shape, (num_v,))
         assert_sane(tau)
         # - Friction torques.
         friction_torques = tree.frictionTorques(v)

--- a/bindings/pydrake/solvers/test/mathematicalprogram_test.py
+++ b/bindings/pydrake/solvers/test/mathematicalprogram_test.py
@@ -157,7 +157,7 @@ class TestMathematicalProgram(unittest.TestCase):
         # Test deprecated method.
         with warnings.catch_warnings(record=True) as w:
             c = binding.constraint()
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_eval_binding(self):
         qp = TestQP()
@@ -288,7 +288,7 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddCost(cost, x)
         prog.AddConstraint(constraint, [0.], [2.], x)
         prog.Solve()
-        self.assertAlmostEquals(prog.GetSolution(x)[0], 1.)
+        self.assertAlmostEqual(prog.GetSolution(x)[0], 1.)
 
     def test_addcost_symbolic(self):
         prog = mp.MathematicalProgram()
@@ -297,7 +297,7 @@ class TestMathematicalProgram(unittest.TestCase):
         prog.AddConstraint(0 <= x[0])
         prog.AddConstraint(x[0] <= 2)
         prog.Solve()
-        self.assertAlmostEquals(prog.GetSolution(x)[0], 1.)
+        self.assertAlmostEqual(prog.GetSolution(x)[0], 1.)
 
     def test_initial_guess(self):
         prog = mp.MathematicalProgram()

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -95,7 +95,7 @@ class TestCustom(unittest.TestCase):
         return system
 
     def _fix_adder_inputs(self, context):
-        self.assertEquals(context.get_num_input_ports(), 2)
+        self.assertEqual(context.get_num_input_ports(), 2)
         context.FixInputPort(0, BasicVector([1, 2, 3]))
         context.FixInputPort(1, BasicVector([4, 5, 6]))
 
@@ -104,7 +104,7 @@ class TestCustom(unittest.TestCase):
         context = system.CreateDefaultContext()
         self._fix_adder_inputs(context)
         output = system.AllocateOutput(context)
-        self.assertEquals(output.get_num_ports(), 1)
+        self.assertEqual(output.get_num_ports(), 1)
         system.CalcOutput(context, output)
         value = output.get_vector_data(0).get_value()
         self.assertTrue(np.allclose([5, 7, 9], value))
@@ -162,8 +162,8 @@ class TestCustom(unittest.TestCase):
 
             def _DoHasDirectFeedthrough(self, input_port, output_port):
                 # Test inputs.
-                test.assertEquals(input_port, 0)
-                test.assertEquals(output_port, 0)
+                test.assertEqual(input_port, 0)
+                test.assertEqual(output_port, 0)
                 # Call base method to ensure we do not get recursion.
                 base_return = LeafSystem._DoHasDirectFeedthrough(
                     self, input_port, output_port)
@@ -196,7 +196,7 @@ class TestCustom(unittest.TestCase):
         self.assertFalse(results["has_direct_feedthrough"])
         self.assertTrue(system.called_continuous)
         self.assertTrue(system.called_discrete)
-        self.assertEquals(results["discrete_next_t"], 0.1)
+        self.assertEqual(results["discrete_next_t"], 0.1)
 
         self.assertFalse(system.HasAnyDirectFeedthrough())
         self.assertFalse(system.HasDirectFeedthrough(output_port=0))
@@ -219,7 +219,7 @@ class TestCustom(unittest.TestCase):
 
             # Check call order.
             update_type = is_discrete and "discrete" or "continuous"
-            self.assertEquals(
+            self.assertEqual(
                 system.has_called,
                 [update_type, "feedthrough", "output", "feedthrough"])
 
@@ -259,22 +259,22 @@ class TestCustom(unittest.TestCase):
         self.assertTrue(
             context.get_discrete_state_vector() is
             context.get_mutable_discrete_state_vector())
-        self.assertEquals(context.get_num_abstract_states(), 1)
+        self.assertEqual(context.get_num_abstract_states(), 1)
         self.assertTrue(
             context.get_abstract_state() is
             context.get_mutable_abstract_state())
         self.assertTrue(
             context.get_abstract_state(0) is
             context.get_mutable_abstract_state(0))
-        self.assertEquals(
+        self.assertEqual(
             context.get_abstract_state(0).get_value(), model_value.get_value())
 
         # Check AbstractValues API.
         values = context.get_abstract_state()
-        self.assertEquals(values.size(), 1)
-        self.assertEquals(
+        self.assertEqual(values.size(), 1)
+        self.assertEqual(
             values.get_value(0).get_value(), model_value.get_value())
-        self.assertEquals(
+        self.assertEqual(
             values.get_mutable_value(0).get_value(), model_value.get_value())
         values.CopyFrom(values.Clone())
 
@@ -317,5 +317,5 @@ class TestCustom(unittest.TestCase):
             for index in range(4):
                 system = TrivialSystem(index)
                 context = system.CreateDefaultContext()
-                self.assertEquals(
+                self.assertEqual(
                     context.get_continuous_state_vector().size(), 6)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -138,7 +138,7 @@ class TestGeneral(unittest.TestCase):
             def check_output(context):
                 # Check number of output ports and value for a given context.
                 output = system.AllocateOutput(context)
-                self.assertEquals(output.get_num_ports(), 1)
+                self.assertEqual(output.get_num_ports(), 1)
                 system.CalcOutput(context, output)
                 if T == float:
                     value = output.get_vector_data(0).get_value()
@@ -167,7 +167,7 @@ class TestGeneral(unittest.TestCase):
             context.set_time(0.)
 
             context.set_accuracy(1e-4)
-            self.assertEquals(context.get_accuracy(), 1e-4)
+            self.assertEqual(context.get_accuracy(), 1e-4)
 
             # @note `simulator` now owns `context`.
             simulator = Simulator_[T](system, context)

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -45,8 +45,8 @@ def compare_value(test, a, b):
     if isinstance(a, VectorBase):
         test.assertTrue(np.allclose(a.get_value(), b.get_value()))
     else:
-        test.assertEquals(type(a.get_value()), type(b.get_value()))
-        test.assertEquals(a.get_value(), b.get_value())
+        test.assertEqual(type(a.get_value()), type(b.get_value()))
+        test.assertEqual(a.get_value(), b.get_value())
 
 
 class TestGeneral(unittest.TestCase):

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -35,7 +35,7 @@ class TestRendering(unittest.TestCase):
         self.assertTrue(isinstance(value, BasicVector))
         self.assertTrue(isinstance(copy.copy(value), PoseVector))
         self.assertTrue(isinstance(value.Clone(), PoseVector))
-        self.assertEquals(value.size(), PoseVector.kSize)
+        self.assertEqual(value.size(), PoseVector.kSize)
         # - Accessors.
         self.assertTrue(isinstance(
             value.get_isometry(), Isometry3))
@@ -68,7 +68,7 @@ class TestRendering(unittest.TestCase):
         self.assertTrue(isinstance(frame_velocity, BasicVector))
         self.assertTrue(isinstance(copy.copy(frame_velocity), FrameVelocity))
         self.assertTrue(isinstance(frame_velocity.Clone(), FrameVelocity))
-        self.assertEquals(frame_velocity.size(), FrameVelocity.kSize)
+        self.assertEqual(frame_velocity.size(), FrameVelocity.kSize)
         # - Accessors.
         self.assertTrue(isinstance(
             frame_velocity.get_velocity(), SpatialVelocity))

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -41,40 +41,40 @@ class TestSensors(unittest.TestCase):
     def test_image_traits(self):
         # Test instantiations of ImageTraits<>.
         t = mut.ImageTraits[pt.kRgba8U]
-        self.assertEquals(t.kNumChannels, 4)
-        self.assertEquals(t.ChannelType, np.uint8)
-        self.assertEquals(t.kPixelFormat, pf.kRgba)
+        self.assertEqual(t.kNumChannels, 4)
+        self.assertEqual(t.ChannelType, np.uint8)
+        self.assertEqual(t.kPixelFormat, pf.kRgba)
 
         t = mut.ImageTraits[pt.kDepth32F]
-        self.assertEquals(t.kNumChannels, 1)
-        self.assertEquals(t.ChannelType, np.float32)
-        self.assertEquals(t.kPixelFormat, pf.kDepth)
+        self.assertEqual(t.kNumChannels, 1)
+        self.assertEqual(t.ChannelType, np.float32)
+        self.assertEqual(t.kPixelFormat, pf.kDepth)
 
         t = mut.ImageTraits[pt.kLabel16I]
-        self.assertEquals(t.kNumChannels, 1)
-        self.assertEquals(t.ChannelType, np.int16)
-        self.assertEquals(t.kPixelFormat, pf.kLabel)
+        self.assertEqual(t.kNumChannels, 1)
+        self.assertEqual(t.ChannelType, np.int16)
+        self.assertEqual(t.kPixelFormat, pf.kLabel)
 
     def test_image_types(self):
         # Test instantiations of Image<>.
         for pixel_type, image_type_alias in (
                 zip(pixel_types, image_type_aliases)):
             ImageT = mut.Image[pixel_type]
-            self.assertEquals(ImageT.Traits, mut.ImageTraits[pixel_type])
-            self.assertEquals(ImageT, image_type_alias)
+            self.assertEqual(ImageT.Traits, mut.ImageTraits[pixel_type])
+            self.assertEqual(ImageT, image_type_alias)
 
             w = 640
             h = 480
             nc = ImageT.Traits.kNumChannels
             image = ImageT(w, h)
-            self.assertEquals(image.width(), w)
-            self.assertEquals(image.height(), h)
-            self.assertEquals(image.size(), h * w * nc)
+            self.assertEqual(image.width(), w)
+            self.assertEqual(image.height(), h)
+            self.assertEqual(image.size(), h * w * nc)
             # N.B. Since `shape` is a custom-Python extension, it's defined as
             # a property (not a function).
-            self.assertEquals(image.shape, (h, w, nc))
-            self.assertEquals(image.data.shape, image.shape)
-            self.assertEquals(image.data.dtype, ImageT.Traits.ChannelType)
+            self.assertEqual(image.shape, (h, w, nc))
+            self.assertEqual(image.data.shape, image.shape)
+            self.assertEqual(image.data.dtype, ImageT.Traits.ChannelType)
 
             w /= 2
             h /= 2
@@ -82,7 +82,7 @@ class TestSensors(unittest.TestCase):
             # `image.data` will cause `image.data` + `image.mutable_data` to be
             # invalid.
             image.resize(w, h)
-            self.assertEquals(image.shape, (h, w, nc))
+            self.assertEqual(image.shape, (h, w, nc))
 
     def test_image_data(self):
         # Test data mapping.
@@ -96,13 +96,13 @@ class TestSensors(unittest.TestCase):
             nc = ImageT.Traits.kNumChannels
 
             # Test default initialization.
-            self.assertEquals(image.at(0, 0)[0], channel_default)
+            self.assertEqual(image.at(0, 0)[0], channel_default)
             self.assertTrue(np.allclose(image.data, channel_default))
 
             # Test pixel / channel mutation and access.
             image.at(0, 0)[0] = 2
             # - Also test named arguments.
-            self.assertEquals(image.at(x=0, y=0)[0], 2)
+            self.assertEqual(image.at(x=0, y=0)[0], 2)
 
             bad_coords = [
                 # Bad X
@@ -126,12 +126,12 @@ class TestSensors(unittest.TestCase):
 
             # Test numpy views, access and mutation.
             image.mutable_data[:] = 3
-            self.assertEquals(image.at(0, 0)[0], 3)
+            self.assertEqual(image.at(0, 0)[0], 3)
             self.assertTrue(np.allclose(image.data, 3))
             self.assertTrue(np.allclose(image.mutable_data, 3))
 
             # Ensure that each dimension of the image array is unique.
-            self.assertEquals(len(set(image.shape)), 3)
+            self.assertEqual(len(set(image.shape)), 3)
             # Ensure indices match as expected. Fill each channel at each pixel
             # with unique values, and ensure that pixel / channels map
             # appropriately.
@@ -173,12 +173,12 @@ class TestSensors(unittest.TestCase):
         ]
 
         for info in infos:
-            self.assertEquals(info.width(), width)
-            self.assertEquals(info.height(), height)
-            self.assertEquals(info.focal_x(), focal_x)
-            self.assertEquals(info.focal_y(), focal_y)
-            self.assertEquals(info.center_x(), center_x)
-            self.assertEquals(info.center_y(), center_y)
+            self.assertEqual(info.width(), width)
+            self.assertEqual(info.height(), height)
+            self.assertEqual(info.focal_x(), focal_x)
+            self.assertEqual(info.focal_y(), focal_y)
+            self.assertEqual(info.center_x(), center_x)
+            self.assertEqual(info.center_y(), center_y)
             self.assertTrue(
                 (info.intrinsic_matrix() == intrinsic_matrix).all())
 
@@ -227,7 +227,7 @@ class TestSensors(unittest.TestCase):
         self.assertIsInstance(camera.depth_camera_optical_pose(), Isometry3)
         self.assertTrue(camera.tree() is tree)
         # N.B. `RgbdCamera` copies the input frame.
-        self.assertEquals(camera.frame().get_name(), frame.get_name())
+        self.assertEqual(camera.frame().get_name(), frame.get_name())
         self._check_ports(camera)
 
         # Test discrete camera.
@@ -236,7 +236,7 @@ class TestSensors(unittest.TestCase):
             camera=camera, period=period, render_label_image=True)
         self.assertTrue(discrete.camera() is camera)
         self.assertTrue(discrete.mutable_camera() is camera)
-        self.assertEquals(discrete.period(), period)
+        self.assertEqual(discrete.period(), period)
         self._check_ports(discrete)
 
         # That we can access the state as images.

--- a/bindings/pydrake/systems/test/value_test.py
+++ b/bindings/pydrake/systems/test/value_test.py
@@ -62,7 +62,7 @@ class TestValue(unittest.TestCase):
                     np.allclose(value_data.get_mutable_value(), expected_set))
                 # Ensure we can construct from size.
                 value_data = BasicVector(n)
-                self.assertEquals(value_data.size(), n)
+                self.assertEqual(value_data.size(), n)
                 # Ensure we can clone.
                 value_copies = [
                     value_data.Clone(),
@@ -71,40 +71,40 @@ class TestValue(unittest.TestCase):
                 ]
                 for value_copy in value_copies:
                     self.assertTrue(value_copy is not value_data)
-                    self.assertEquals(value_data.size(), n)
+                    self.assertEqual(value_data.size(), n)
 
     def test_basic_vector_set_get(self):
         value = BasicVector(np.arange(3., 5.))
-        self.assertEquals(value.GetAtIndex(1), 4.)
+        self.assertEqual(value.GetAtIndex(1), 4.)
         value.SetAtIndex(1, 5.)
-        self.assertEquals(value.GetAtIndex(1), 5.)
+        self.assertEqual(value.GetAtIndex(1), 5.)
 
     def test_abstract_value_copyable(self):
         expected = "Hello world"
         value = Value[str](expected)
         self.assertTrue(isinstance(value, AbstractValue))
-        self.assertEquals(value.get_value(), expected)
+        self.assertEqual(value.get_value(), expected)
         expected_new = "New value"
         value.set_value(expected_new)
-        self.assertEquals(value.get_value(), expected_new)
+        self.assertEqual(value.get_value(), expected_new)
         # Test docstring.
         self.assertFalse("unique_ptr" in value.set_value.__doc__)
 
     def test_abstract_value_move_only(self):
         obj = MoveOnlyType(10)
         # This *always* clones `obj`.
-        self.assertEquals(
+        self.assertEqual(
             str(Value[MoveOnlyType]),
             "<class 'pydrake.systems.framework.Value[MoveOnlyType]'>")
         value = Value[MoveOnlyType](obj)
         self.assertTrue(value.get_value() is not obj)
-        self.assertEquals(value.get_value().x(), 10)
+        self.assertEqual(value.get_value().x(), 10)
         # Set value.
         value.get_mutable_value().set_x(20)
-        self.assertEquals(value.get_value().x(), 20)
+        self.assertEqual(value.get_value().x(), 20)
         # Test custom emplace constructor.
         emplace_value = Value[MoveOnlyType](30)
-        self.assertEquals(emplace_value.get_value().x(), 30)
+        self.assertEqual(emplace_value.get_value().x(), 30)
         # Test docstring.
         self.assertTrue("unique_ptr" in value.set_value.__doc__)
 
@@ -115,15 +115,15 @@ class TestValue(unittest.TestCase):
         self.assertTrue(value.get_value() is expected)
         # Update mutable version.
         value.get_mutable_value()["y"] = 30
-        self.assertEquals(value.get_value(), expected)
+        self.assertEqual(value.get_value(), expected)
         # Cloning the value should perform a deep copy of the Python object.
         value_clone = copy.deepcopy(value)
-        self.assertEquals(value_clone.get_value(), expected)
+        self.assertEqual(value_clone.get_value(), expected)
         self.assertTrue(value_clone.get_value() is not expected)
         # Using `set_value` on the original value changes object reference.
         expected_new = {"a": 20}
         value.set_value(expected_new)
-        self.assertEquals(value.get_value(), expected_new)
+        self.assertEqual(value.get_value(), expected_new)
         self.assertTrue(value.get_value() is not expected)
 
     def test_abstract_value_make(self):
@@ -150,20 +150,20 @@ class TestValue(unittest.TestCase):
     def test_parameters_api(self):
 
         def compare(actual, expected):
-            self.assertEquals(type(actual), type(expected))
+            self.assertEqual(type(actual), type(expected))
             if isinstance(actual, VectorBase):
                 self.assertTrue(
                     np.allclose(actual.get_value(), expected.get_value()))
             else:
-                self.assertEquals(actual.get_value(), expected.get_value())
+                self.assertEqual(actual.get_value(), expected.get_value())
 
         model_numeric = BasicVector([0.])
         model_abstract = AbstractValue.Make("Hello")
 
         params = Parameters(
             numeric=[model_numeric.Clone()], abstract=[model_abstract.Clone()])
-        self.assertEquals(params.num_numeric_parameters(), 1)
-        self.assertEquals(params.num_abstract_parameters(), 1)
+        self.assertEqual(params.num_numeric_parameters(), 1)
+        self.assertEqual(params.num_abstract_parameters(), 1)
         # Numeric.
         compare(params.get_numeric_parameter(index=0), model_numeric)
         compare(params.get_mutable_numeric_parameter(index=0), model_numeric)

--- a/bindings/pydrake/test/autodiffutils_test.py
+++ b/bindings/pydrake/test/autodiffutils_test.py
@@ -23,20 +23,20 @@ class TestAutoDiffXd(unittest.TestCase):
     def _check_scalar(self, actual, expected):
         if isinstance(actual, bool):
             self.assertTrue(isinstance(expected, bool))
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
         elif isinstance(actual, float):
             self.assertTrue(isinstance(expected, float))
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
         else:
-            self.assertAlmostEquals(actual.value(), expected.value())
+            self.assertAlmostEqual(actual.value(), expected.value())
             self.assertTrue(
                 (actual.derivatives() == expected.derivatives()).all(),
                 (actual.derivatives(), expected.derivatives()))
 
     def _check_array(self, actual, expected):
         expected = np.array(expected)
-        self.assertEquals(actual.dtype, expected.dtype)
-        self.assertEquals(actual.shape, expected.shape)
+        self.assertEqual(actual.dtype, expected.dtype)
+        self.assertEqual(actual.shape, expected.shape)
         if actual.dtype == object:
             for a, b in zip(actual.flat, expected.flat):
                 self._check_scalar(a, b)
@@ -45,10 +45,10 @@ class TestAutoDiffXd(unittest.TestCase):
 
     def test_scalar_api(self):
         a = AD(1, [1., 0])
-        self.assertEquals(a.value(), 1.)
+        self.assertEqual(a.value(), 1.)
         self.assertTrue((a.derivatives() == [1., 0]).all())
-        self.assertEquals(str(a), "AD{1.0, nderiv=2}")
-        self.assertEquals(repr(a), "<AutoDiffXd 1.0 nderiv=2>")
+        self.assertEqual(str(a), "AD{1.0, nderiv=2}")
+        self.assertEqual(repr(a), "<AutoDiffXd 1.0 nderiv=2>")
         self._check_scalar(a, a)
         # Test construction from `float` and `int`.
         self._check_scalar(AD(1), AD(1., []))
@@ -65,7 +65,7 @@ class TestAutoDiffXd(unittest.TestCase):
         a = AD(1, [1., 0])
         b = AD(2, [0, 1.])
         x = np.array([a, b])
-        self.assertEquals(x.dtype, object)
+        self.assertEqual(x.dtype, object)
         # Idempotent check.
         self._check_array(x, x)
         # Conversion.
@@ -146,7 +146,7 @@ class TestAutoDiffXd(unittest.TestCase):
         ceil_a = algebra.ceil(a)
         floor_a = algebra.floor(a)
         if isinstance(algebra, VectorizedAlgebra):
-            self.assertEquals(ceil_a.dtype, object)
+            self.assertEqual(ceil_a.dtype, object)
             self.assertIsInstance(ceil_a[0], float)
             ceil_a = ceil_a.astype(float)
             floor_a = floor_a.astype(float)
@@ -159,12 +159,12 @@ class TestAutoDiffXd(unittest.TestCase):
         a = self._check_algebra(
             ScalarAlgebra(
                 self._check_scalar, scalar_to_float=lambda x: x.value()))
-        self.assertEquals(type(a), AD)
+        self.assertEqual(type(a), AD)
 
     def test_array_algebra(self):
         a = self._check_algebra(
             VectorizedAlgebra(
                 self._check_array,
                 scalar_to_float=lambda x: x.value()))
-        self.assertEquals(type(a), np.ndarray)
-        self.assertEquals(a.shape, (2,))
+        self.assertEqual(type(a), np.ndarray)
+        self.assertEqual(a.shape, (2,))

--- a/bindings/pydrake/test/backwards_compatability_test.py
+++ b/bindings/pydrake/test/backwards_compatability_test.py
@@ -22,13 +22,13 @@ class TestBackwardsCompatibility(unittest.TestCase):
             warnings.simplefilter("default", DrakeDeprecationWarning)
             self.assertTrue(pydrake.rbtree is not None)
             self.assertTrue(pydrake.rbtree.RigidBodyTree is not None)
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_rbtree_import(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("default", DrakeDeprecationWarning)
             import pydrake.rbtree
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_rbtree_deprecated(self):
         with warnings.catch_warnings(record=True) as w:
@@ -46,7 +46,7 @@ class TestBackwardsCompatibility(unittest.TestCase):
                 kQuaternion,
             )
             self.assertTrue(RigidBodyTree is not None)
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_parsers_deprecated(self):
         # Test symbol forwarding.
@@ -54,4 +54,4 @@ class TestBackwardsCompatibility(unittest.TestCase):
             warnings.simplefilter("default", DrakeDeprecationWarning)
             from pydrake.parsers import PackageMap
             self.assertTrue(PackageMap is not None)
-            self.assertEquals(len(w), 1)
+            self.assertEqual(len(w), 1)

--- a/bindings/pydrake/test/math_overloads_test.py
+++ b/bindings/pydrake/test/math_overloads_test.py
@@ -159,7 +159,7 @@ class TestMathOverloads(unittest.TestCase):
                 y_builtin = f_builtin(*args_float)
                 y_float = f_drake(*args_float)
                 debug_print(" - - Float Eval:", repr(y_builtin), repr(y_float))
-                self.assertEquals(y_float, y_builtin)
+                self.assertEqual(y_float, y_builtin)
                 self.assertIsInstance(y_float, float)
                 # Test method current overload, and ensure value is accurate.
                 y_T = f_drake(*args_T)
@@ -167,7 +167,7 @@ class TestMathOverloads(unittest.TestCase):
                 debug_print(" - - Overload Eval:", repr(y_T), repr(y_T_float))
                 self.assertIsInstance(y_T, overload.T)
                 # - Ensure the translated value is accurate.
-                self.assertEquals(y_T_float, y_float)
+                self.assertEqual(y_T_float, y_float)
 
         debug_print("\n\nOverload: ", qualname(type(overload)))
         float_overload = FloatOverloads()
@@ -203,6 +203,6 @@ class TestMathOverloads(unittest.TestCase):
                 args = [sys.executable, sys.argv[0], str(i)]
                 subprocess.check_call(args)
         else:
-            self.assertEquals(len(sys.argv), 2)
+            self.assertEqual(len(sys.argv), 2)
             i = int(sys.argv[1])
             self._check_overloads(orders[i])

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -16,20 +16,20 @@ class TestBarycentricMesh(unittest.TestCase):
         values = np.array([[0, 1, 2, 3]])
         grid = mesh.get_input_grid()
         self.assertIsInstance(grid, list)
-        self.assertEquals(len(grid), 2)
+        self.assertEqual(len(grid), 2)
         self.assertIsInstance(grid[0], set)
-        self.assertEquals(len(grid[0]), 2)
-        self.assertEquals(mesh.get_input_size(), 2)
-        self.assertEquals(mesh.get_num_mesh_points(), 4)
-        self.assertEquals(mesh.get_num_interpolants(), 3)
+        self.assertEqual(len(grid[0]), 2)
+        self.assertEqual(mesh.get_input_size(), 2)
+        self.assertEqual(mesh.get_num_mesh_points(), 4)
+        self.assertEqual(mesh.get_num_interpolants(), 3)
         self.assertTrue((mesh.get_mesh_point(0) == [0., 0.]).all())
         points = mesh.get_all_mesh_points()
         self.assertEqual(points.shape, (2, 4))
         self.assertTrue((points[:, 3] == [1., 1.]).all())
-        self.assertEquals(mesh.Eval(values, (0, 0))[0], 0)
-        self.assertEquals(mesh.Eval(values, (1, 0))[0], 1)
-        self.assertEquals(mesh.Eval(values, (0, 1))[0], 2)
-        self.assertEquals(mesh.Eval(values, (1, 1))[0], 3)
+        self.assertEqual(mesh.Eval(values, (0, 0))[0], 0)
+        self.assertEqual(mesh.Eval(values, (1, 0))[0], 1)
+        self.assertEqual(mesh.Eval(values, (0, 1))[0], 2)
+        self.assertEqual(mesh.Eval(values, (1, 1))[0], 3)
 
     def test_weight(self):
         mesh = BarycentricMesh([{0, 1}, {0, 1}])
@@ -45,10 +45,10 @@ class TestBarycentricMesh(unittest.TestCase):
             return [x.dot(x)]
 
         values = mesh.MeshValuesFrom(mynorm)
-        self.assertEquals(values.size, 4)
+        self.assertEqual(values.size, 4)
 
     def test_wrap_to(self):
-        self.assertEquals(wrap_to(1.5, 0., 1.), .5)
+        self.assertEqual(wrap_to(1.5, 0., 1.), .5)
 
     def test_math(self):
         # Compare against `math` functions.
@@ -81,9 +81,9 @@ class TestBarycentricMesh(unittest.TestCase):
         a = 0.1
         b = 0.2
         for f_core, f_cpp in unary:
-            self.assertEquals(f_core(a), f_cpp(a), (f_core, f_cpp))
+            self.assertEqual(f_core(a), f_cpp(a), (f_core, f_cpp))
         for f_core, f_cpp in binary:
-            self.assertEquals(f_core(a, b), f_cpp(a, b))
+            self.assertEqual(f_core(a, b), f_cpp(a, b))
 
     def test_rotation_matrix(self):
         R = mut.RotationMatrix()

--- a/bindings/pydrake/test/symbolic_test.py
+++ b/bindings/pydrake/test/symbolic_test.py
@@ -433,9 +433,9 @@ class TestSymbolicExpression(SymbolicTestCase):
             VectorizedAlgebra(
                 self._check_array,
                 scalar_to_float=lambda x: x.Evaluate()))
-        self.assertEquals(xv.shape, (2,))
+        self.assertEqual(xv.shape, (2,))
         self.assertIsInstance(xv[0], sym.Variable)
-        self.assertEquals(e_xv.shape, (2,))
+        self.assertEqual(e_xv.shape, (2,))
         self.assertIsInstance(e_xv[0], sym.Expression)
 
     def test_equalto(self):

--- a/bindings/pydrake/util/test/containers_test.py
+++ b/bindings/pydrake/util/test/containers_test.py
@@ -49,14 +49,14 @@ class TestEqualToDict(unittest.TestCase):
         d = EqualToDict({a: "a", b: "b"})
         # Ensure that we call `EqualTo`.
         self.assertFalse(Item.equal_to_called)
-        self.assertEquals(d[a], "a")
+        self.assertEqual(d[a], "a")
         self.assertTrue(Item.equal_to_called)
 
-        self.assertEquals(d[b], "b")
+        self.assertEqual(d[b], "b")
         self.assertTrue(a in d)
 
         # Ensure hash collision does not occur.
-        self.assertEquals(hash(a.value), hash(a))
+        self.assertEqual(hash(a.value), hash(a))
         self.assertFalse(a.value in d)
 
         # Obtaining the original representation (e.g. for `pybind11`):

--- a/bindings/pydrake/util/test/cpp_const_test.py
+++ b/bindings/pydrake/util/test/cpp_const_test.py
@@ -80,7 +80,7 @@ class TestCppConst(unittest.TestCase):
         # Dictionary.
         d = {"a": 0, "b": 1, "z": [25]}
         d_const = cpp_const.to_const(d)
-        self.assertEquals(d_const["a"], 0)
+        self.assertEqual(d_const["a"], 0)
         with self._ex():
             d_const["c"] = 2
         with self._ex():
@@ -93,8 +93,8 @@ class TestCppConst(unittest.TestCase):
         obj = Basic("Tim")
         obj_const = cpp_const.to_const(obj)
         obj.new_attr = "Something"
-        self.assertEquals(obj_const.get_name(), "Tim")
-        self.assertEquals(obj_const.__dict__["_name"], "Tim")
+        self.assertEqual(obj_const.get_name(), "Tim")
+        self.assertEqual(obj_const.__dict__["_name"], "Tim")
         with self._ex():
             obj_const.set_name("Bob")
         with self._ex():
@@ -115,7 +115,7 @@ class TestCppConst(unittest.TestCase):
         obj.add("z", [10])
         obj_const = cpp_const.to_const(obj)
         self.assertTrue(cpp_const.is_const_test(obj_const.get_values()))
-        self.assertEquals(obj_const.get("a"), 0)
+        self.assertEqual(obj_const.get("a"), 0)
         with self._ex():
             obj_const.add("c", 2)
         with self._ex():
@@ -133,7 +133,7 @@ class TestCppConst(unittest.TestCase):
         obj = AdvancedChild()
         obj.add("a", 0)
         obj_const = cpp_const.to_const(obj)
-        self.assertEquals(obj_const.const_safe("a"), 0)
+        self.assertEqual(obj_const.const_safe("a"), 0)
         with self._ex():
             obj_const.const_unsafe("a")
         with self._ex():

--- a/bindings/pydrake/util/test/cpp_param_test.py
+++ b/bindings/pydrake/util/test/cpp_param_test.py
@@ -36,7 +36,7 @@ class TestCppParam(unittest.TestCase):
     def _check_names(self, name_canonical, aliases):
         for alias in aliases:
             actual = get_param_names([alias])[0]
-            self.assertEquals(actual, name_canonical)
+            self.assertEqual(actual, name_canonical)
 
     def test_idempotent(self):
         # Check idempotent mapping for unaliased types.

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -39,14 +39,14 @@ class DummyD(object):
 class TestCppTemplate(unittest.TestCase):
     def test_base(self):
         template = m.TemplateBase("BaseTpl")
-        self.assertEquals(str(template), "<TemplateBase {}.BaseTpl>".format(
+        self.assertEqual(str(template), "<TemplateBase {}.BaseTpl>".format(
             _TEST_MODULE))
 
         # Single arguments.
         template.add_instantiation(int, 1)
-        self.assertEquals(template[int], 1)
-        self.assertEquals(template.get_instantiation(int), (1, (int,)))
-        self.assertEquals(template.get_param_set(1), {(int,)})
+        self.assertEqual(template[int], 1)
+        self.assertEqual(template.get_instantiation(int), (1, (int,)))
+        self.assertEqual(template.get_param_set(1), {(int,)})
         self.assertTrue(template.is_instantiation(1))
         self.assertFalse(template.is_instantiation(10))
         # Duplicate parameters.
@@ -57,21 +57,21 @@ class TestCppTemplate(unittest.TestCase):
         self.assertRaises(RuntimeError, lambda: template[float])
         # New instantiation.
         template.add_instantiation(float, 2)
-        self.assertEquals(template[float], 2)
+        self.assertEqual(template[float], 2)
 
         # Default instantiation.
-        self.assertEquals(template[None], 1)
-        self.assertEquals(template.get_instantiation(), (1, (int,)))
+        self.assertEqual(template[None], 1)
+        self.assertEqual(template.get_instantiation(), (1, (int,)))
 
         # Multiple arguments.
         template.add_instantiation((int, int), 3)
-        self.assertEquals(template[int, int], 3)
+        self.assertEqual(template[int, int], 3)
         # Duplicate instantiation.
         template.add_instantiation((float, float), 1)
-        self.assertEquals(template.get_param_set(1), {(int,), (float, float)})
+        self.assertEqual(template.get_param_set(1), {(int,), (float, float)})
         # Nested getitem indices.
-        self.assertEquals(template[(int, int)], 3)
-        self.assertEquals(template[[int, int]], 3)
+        self.assertEqual(template[(int, int)], 3)
+        self.assertEqual(template[[int, int]], 3)
 
         # List instantiation.
         def instantiation_func(param):
@@ -79,8 +79,8 @@ class TestCppTemplate(unittest.TestCase):
         dummy_a = (str,) * 5
         dummy_b = (str,) * 10
         template.add_instantiations(instantiation_func, [dummy_a, dummy_b])
-        self.assertEquals(template[dummy_a], 105)
-        self.assertEquals(template[dummy_b], 110)
+        self.assertEqual(template[dummy_a], 105)
+        self.assertEqual(template[dummy_b], 110)
 
         # Ensure that we can only call this once.
         dummy_c = (str,) * 7
@@ -89,17 +89,17 @@ class TestCppTemplate(unittest.TestCase):
 
     def test_class(self):
         template = m.TemplateClass("ClassTpl")
-        self.assertEquals(str(template), "<TemplateClass {}.ClassTpl>".format(
+        self.assertEqual(str(template), "<TemplateClass {}.ClassTpl>".format(
             _TEST_MODULE))
 
         template.add_instantiation(int, DummyA)
         template.add_instantiation(float, DummyB)
 
-        self.assertEquals(template[int], DummyA)
-        self.assertEquals(str(DummyA), "<class '{}.ClassTpl[int]'>".format(
+        self.assertEqual(template[int], DummyA)
+        self.assertEqual(str(DummyA), "<class '{}.ClassTpl[int]'>".format(
             _TEST_MODULE))
-        self.assertEquals(template[float], DummyB)
-        self.assertEquals(str(DummyB), "<class '{}.ClassTpl[float]'>".format(
+        self.assertEqual(template[float], DummyB)
+        self.assertEqual(str(DummyB), "<class '{}.ClassTpl[float]'>".format(
             _TEST_MODULE))
 
     def test_user_class(self):
@@ -157,9 +157,9 @@ class TestCppTemplate(unittest.TestCase):
         template.add_instantiation(int, dummy_a)
         template.add_instantiation(float, dummy_b)
 
-        self.assertEquals(template[int](), 1)
-        self.assertEquals(template[float](), 2)
-        self.assertEquals(str(template), "<TemplateFunction {}.func>".format(
+        self.assertEqual(template[int](), 1)
+        self.assertEqual(template[float](), 2)
+        self.assertEqual(str(template), "<TemplateFunction {}.func>".format(
             _TEST_MODULE))
 
     def test_method(self):
@@ -167,11 +167,11 @@ class TestCppTemplate(unittest.TestCase):
         DummyC.method.add_instantiation(int, DummyC.dummy_c)
         DummyC.method.add_instantiation(float, DummyC.dummy_d)
 
-        self.assertEquals(str(DummyC.method),
-                          "<unbound TemplateMethod DummyC.method>")
-        self.assertEquals(DummyC.method[int], DummyC.dummy_c)
-        self.assertEquals(str(DummyC.method[int]),
-                          "<unbound method DummyC.dummy_c>")
+        self.assertEqual(str(DummyC.method),
+                         "<unbound TemplateMethod DummyC.method>")
+        self.assertEqual(DummyC.method[int], DummyC.dummy_c)
+        self.assertEqual(str(DummyC.method[int]),
+                         "<unbound method DummyC.dummy_c>")
 
         obj = DummyC()
         self.assertTrue(
@@ -180,10 +180,10 @@ class TestCppTemplate(unittest.TestCase):
         self.assertTrue(
             str(obj.method[int]).startswith(
                 "<bound method DummyC.dummy_c of "))
-        self.assertEquals(obj.method[int](), (obj, 3))
-        self.assertEquals(DummyC.method[int](obj), (obj, 3))
-        self.assertEquals(obj.method[float](), (obj, 4))
-        self.assertEquals(DummyC.method[float](obj), (obj, 4))
+        self.assertEqual(obj.method[int](), (obj, 3))
+        self.assertEqual(DummyC.method[int](obj), (obj, 3))
+        self.assertEqual(obj.method[float](), (obj, 4))
+        self.assertEqual(DummyC.method[float](obj), (obj, 4))
 
     def test_get_or_init(self):
         m_test = ModuleType("test_module")
@@ -192,7 +192,7 @@ class TestCppTemplate(unittest.TestCase):
             return m.get_or_init(m_test, "ClassTpl", m.TemplateClass)
 
         tpl_1 = get_tpl_cls()
-        self.assertEquals(str(tpl_1), "<TemplateClass test_module.ClassTpl>")
+        self.assertEqual(str(tpl_1), "<TemplateClass test_module.ClassTpl>")
         self.assertTrue(m_test.ClassTpl is tpl_1)
         tpl_2 = get_tpl_cls()
         self.assertTrue(tpl_1 is tpl_2)
@@ -202,6 +202,6 @@ class TestCppTemplate(unittest.TestCase):
 
         tpl_1 = get_tpl_method()
         self.assertTrue(tpl_1 is DummyD.method)
-        self.assertEquals(str(tpl_1), "<unbound TemplateMethod DummyD.method>")
+        self.assertEqual(str(tpl_1), "<unbound TemplateMethod DummyD.method>")
         tpl_2 = get_tpl_method()
         self.assertTrue(tpl_1 is tpl_2)

--- a/bindings/pydrake/util/test/deprecation_test.py
+++ b/bindings/pydrake/util/test/deprecation_test.py
@@ -67,10 +67,10 @@ class TestDeprecation(unittest.TestCase):
 
     def _check_warning(
             self, item, message_expected, type=DrakeDeprecationWarning):
-        self.assertEquals(item.category, type)
+        self.assertEqual(item.category, type)
         if type == DrakeDeprecationWarning:
             message_expected += DrakeDeprecationWarning.addendum
-        self.assertEquals(item.message.message, message_expected)
+        self.assertEqual(item.message.message, message_expected)
 
     def test_member_deprecation(self):
         from deprecation_example import ExampleClass
@@ -89,19 +89,19 @@ class TestDeprecation(unittest.TestCase):
             # - Method.
             for _ in range(3):
                 method = ExampleClass.deprecated_method
-                self.assertEquals(obj.deprecated_method(), 1)
+                self.assertEqual(obj.deprecated_method(), 1)
                 # The next line will not show a warning.
-                self.assertEquals(method(obj), 1)
-            self.assertEquals(method.__doc__, ExampleClass.doc_method)
+                self.assertEqual(method(obj), 1)
+            self.assertEqual(method.__doc__, ExampleClass.doc_method)
             # - Property.
             for _ in range(3):
                 prop = ExampleClass.deprecated_prop
-                self.assertEquals(obj.deprecated_prop, 2)
+                self.assertEqual(obj.deprecated_prop, 2)
                 # The next line will not show a warning.
-                self.assertEquals(prop.__get__(obj), 2)
-            self.assertEquals(prop.__doc__, ExampleClass.doc_prop)
+                self.assertEqual(prop.__get__(obj), 2)
+            self.assertEqual(prop.__doc__, ExampleClass.doc_prop)
             # Check warnings.
-            self.assertEquals(len(w), 2)
+            self.assertEqual(len(w), 2)
             self._check_warning(w[0], ExampleClass.message_method)
             self._check_warning(w[1], ExampleClass.message_prop)
 
@@ -120,7 +120,7 @@ class TestDeprecation(unittest.TestCase):
             warnings.simplefilter("default", DeprecationWarning)
             base_deprecation()
             method = ExampleClass.deprecated_method
-            self.assertEquals(len(w), 2)
+            self.assertEqual(len(w), 2)
             self._check_warning(
                 w[0], "Non-drake warning", type=DeprecationWarning)
             self._check_warning(w[1], ExampleClass.message_method)

--- a/bindings/pydrake/util/test/eigen_geometry_test.py
+++ b/bindings/pydrake/util/test/eigen_geometry_test.py
@@ -17,16 +17,16 @@ class TestEigenGeometry(unittest.TestCase):
         self.assertTrue(np.allclose(q_identity.wxyz(), [1, 0, 0, 0]))
         self.assertTrue(np.allclose(
             q_identity.wxyz(), mut.Quaternion.Identity().wxyz()))
-        self.assertEquals(
+        self.assertEqual(
             str(q_identity), "Quaternion(w=1.0, x=0.0, y=0.0, z=0.0)")
         # Test ordering.
         q_wxyz = normalize([0.1, 0.3, 0.7, 0.9])
         q = mut.Quaternion(w=q_wxyz[0], x=q_wxyz[1], y=q_wxyz[2], z=q_wxyz[3])
         # - Accessors.
-        self.assertEquals(q.w(), q_wxyz[0])
-        self.assertEquals(q.x(), q_wxyz[1])
-        self.assertEquals(q.y(), q_wxyz[2])
-        self.assertEquals(q.z(), q_wxyz[3])
+        self.assertEqual(q.w(), q_wxyz[0])
+        self.assertEqual(q.x(), q_wxyz[1])
+        self.assertEqual(q.y(), q_wxyz[2])
+        self.assertEqual(q.z(), q_wxyz[3])
         self.assertTrue(np.allclose(q.xyz(), q_wxyz[1:]))
         self.assertTrue(np.allclose(q.wxyz(), q_wxyz))
         # - Mutators.
@@ -82,7 +82,7 @@ class TestEigenGeometry(unittest.TestCase):
         transform = mut.Isometry3()
         X = np.eye(4, 4)
         self.assertTrue(np.allclose(transform.matrix(), X))
-        self.assertEquals(str(transform), str(X))
+        self.assertEqual(str(transform), str(X))
         # - Constructor with (X)
         transform = mut.Isometry3(matrix=X)
         self.assertTrue(np.allclose(transform.matrix(), X))
@@ -131,5 +131,5 @@ class TestEigenGeometry(unittest.TestCase):
     def test_translation(self):
         # Test `type_caster`s.
         value = test_util.create_translation()
-        self.assertEquals(value.shape, (3,))
+        self.assertEqual(value.shape, (3,))
         test_util.check_translation(value)

--- a/common/test_utilities/drake_py_unittest_main.py
+++ b/common/test_utilities/drake_py_unittest_main.py
@@ -103,6 +103,7 @@ if __name__ == '__main__':
         unittest.main(module=test_name, argv=unittest_argv)
 
     if not args.nostdout_to_stderr:
+        sys.stdout.flush()
         sys.stdout = sys.stderr
 
     if args.trace != "none":


### PR DESCRIPTION
Simple fix towards #8352

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8607)
<!-- Reviewable:end -->
