### PR TITLE
Increases size of inclined_plane_run_dynamics_test

### DIFF
--- a/examples/multibody/inclined_plane/BUILD.bazel
+++ b/examples/multibody/inclined_plane/BUILD.bazel
@@ -17,6 +17,7 @@ drake_cc_binary(
         "--simulation_time=0.1",
         "--target_realtime_rate=0.0",
     ],
+    test_rule_size = "medium",
     deps = [
         "//common:text_logging_gflags",
         "//geometry:geometry_visualization",


### PR DESCRIPTION
PR #8550 introduced a timeout failure in  `//examples/multibody/inclined_plane:inclined_plane_run_dynamics_test` running under valgrind. Thus this PR increases the test size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8618)
<!-- Reviewable:end -->
