### PR TITLE
Use GRB_LICENSE_FILE and MOSEKLM_LICENSE_FILE explicitly to locate license files

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -151,18 +151,20 @@ Install on Ubuntu
 ~~~~~~~~~~~~~~~~~
 1. Register for an account on https://www.gurobi.com.
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
-3. Download ``gurobi7.5.2_linux64.tar.gz``.
-4. Unzip it.  We suggest that you use ``/opt/gurobi752`` to simplify working with Drake installations.
-5. ``export GUROBI_PATH=/opt/gurobi752/linux64``
+3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``.
+4. Download ``gurobi7.5.2_linux64.tar.gz``
+5. Unzip it.  We suggest that you use ``/opt/gurobi752`` to simplify working with Drake installations.
+6. ``export GUROBI_PATH=/opt/gurobi752/linux64``
 
 Install on macOS
 ~~~~~~~~~~~~~~~~
 1. Register for an account on http://www.gurobi.com.
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
-3. Download and install ``gurobi7.5.2_mac64.pkg``.
+3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``
+4. Download and install ``gurobi7.5.2_mac64.pkg``.
 
 
-To confirm that your setup was successful, run the tests that require Gurobi.
+To confirm that your setup was successful, run the tests that require Gurobi:
 
   ``bazel test --config gurobi --test_tag_filters=gurobi //...``
 
@@ -175,10 +177,11 @@ MOSEK 7.1
 ---------
 
 The Drake Bazel build system downloads MOSEK 7.1 automatically.  No manual
-installation is required.  Please obtain and save a license file at
-``~/mosek/mosek.lic``.
+installation is required.  Set the location of your license file as follows:
 
-To confirm that your setup was successful, run the tests that require MOSEK.
+``export MOSEKLM_LICENSE_FILE=/path/to/mosek.lic``
+
+To confirm that your setup was successful, run the tests that require MOSEK:
 
   ``bazel test --config mosek --test_tag_filters=mosek //...``
 
@@ -213,7 +216,7 @@ source archive has not been specified.
 Test the build (for either mechanism)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To confirm that your setup was successful, run the tests that require SNOPT.
+To confirm that your setup was successful, run the tests that require SNOPT:
 
   ``bazel test --config snopt --test_tag_filters=snopt //...``
 

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -866,6 +866,15 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "gurobi_solver_grb_license_file_test",
+    tags = gurobi_test_tags(),
+    deps = [
+        ":gurobi_solver",
+        ":mathematical_program",
+    ],
+)
+
+drake_cc_googletest(
     name = "integer_optimization_util_test",
     deps = [
         ":integer_optimization_util",
@@ -977,6 +986,15 @@ drake_cc_googletest(
         ":quadratic_program_examples",
         ":second_order_cone_program_examples",
         ":semidefinite_program_examples",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mosek_solver_moseklm_license_file_test",
+    tags = mosek_test_tags(),
+    deps = [
+        ":mathematical_program",
+        ":mosek_solver",
     ],
 )
 

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <stdexcept>
 #include <vector>
@@ -607,6 +608,13 @@ bool GurobiSolver::available() const { return true; }
 SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
   // We only process quadratic costs and linear / bounding box
   // constraints.
+
+  const char* grb_license_file = std::getenv("GRB_LICENSE_FILE");
+  if (grb_license_file == nullptr) {
+    throw std::runtime_error(
+        "Could not locate Gurobi license key file because GRB_LICENSE_FILE "
+        "environment variable was not set.");
+  }
 
   GRBenv* env = nullptr;
   GRBloadenv(&env, nullptr);

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <limits>
 #include <list>
 #include <stdexcept>
@@ -588,6 +589,13 @@ MSKrescodee SpecifyVariableType(const MathematicalProgram& prog,
 class MosekSolver::License {
  public:
   License() {
+    const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+    if (moseklm_license_file == nullptr) {
+      throw std::runtime_error(
+          "Could not locate MOSEK license file because MOSEKLM_LICENSE_FILE "
+          "environment variable was not set.");
+    }
+
     MSKrescodee rescode = MSK_makeenv(&mosek_env_, nullptr);
     if (rescode != MSK_RES_OK) {
       throw std::runtime_error("Could not create MOSEK environment.");

--- a/solvers/test/gurobi_solver_grb_license_file_test.cc
+++ b/solvers/test/gurobi_solver_grb_license_file_test.cc
@@ -1,0 +1,52 @@
+#include <cstdlib>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/solvers/gurobi_solver.h"
+#include "drake/solvers/mathematical_program.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+// These tests are deliberately not in gurobi_solver_test.cc to avoid causing
+// license issues during tests in that file.
+
+GTEST_TEST(GrbLicenseFileTest, GrbLicenseFileSet) {
+  const char* grb_license_file = std::getenv("GRB_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, grb_license_file);
+
+  MathematicalProgram program;
+  GurobiSolver solver;
+
+  EXPECT_NO_THROW(solver.Solve(program));
+}
+
+GTEST_TEST(GrbLicenseFileTest, GrbLicenseFileUnset) {
+  const char* grb_license_file = std::getenv("GRB_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, grb_license_file);
+
+  const int unsetenv_result = ::unsetenv("GRB_LICENSE_FILE");
+  ASSERT_EQ(0, unsetenv_result);
+
+  MathematicalProgram program;
+  GurobiSolver solver;
+
+  try {
+    solver.Solve(program);
+    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+  } catch (const std::runtime_error& err) {
+    EXPECT_EQ(err.what(), std::string("Could not locate Gurobi license key "
+        "file because GRB_LICENSE_FILE environment variable was not set."));
+  } catch (...) {
+    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+  }
+
+  const int setenv_result = ::setenv("GRB_LICENSE_FILE", grb_license_file, 1);
+  ASSERT_EQ(0, setenv_result);
+}
+
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/solvers/test/mosek_solver_moseklm_license_file_test.cc
+++ b/solvers/test/mosek_solver_moseklm_license_file_test.cc
@@ -1,0 +1,53 @@
+#include <cstdlib>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mosek_solver.h"
+
+namespace drake {
+namespace solvers {
+namespace {
+
+// These tests is deliberately not in mosek_solver_test.cc to avoid causing
+// license issues during tests in that file.
+
+GTEST_TEST(MoseklmLicenseFileTest, MoseklmLicenseFileSet) {
+  const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, moseklm_license_file);
+
+  MathematicalProgram program;
+  MosekSolver solver;
+
+  EXPECT_NO_THROW(solver.Solve(program));
+}
+
+GTEST_TEST(MoseklmLicenseFileTest, MoseklmLicenseFileUnset) {
+  const char* moseklm_license_file = std::getenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_STRNE(nullptr, moseklm_license_file);
+
+  const int unsetenv_result = ::unsetenv("MOSEKLM_LICENSE_FILE");
+  ASSERT_EQ(0, unsetenv_result);
+
+  MathematicalProgram program;
+  MosekSolver solver;
+
+  try {
+    solver.Solve(program);
+    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+  } catch (const std::runtime_error& err) {
+    EXPECT_EQ(err.what(), std::string("Could not locate MOSEK license file "
+        "because MOSEKLM_LICENSE_FILE environment variable was not set."));
+  } catch (...) {
+    ADD_FAILURE() << "Expected exception of type std::runtime_error.";
+  }
+
+  const int setenv_result =
+      ::setenv("MOSEKLM_LICENSE_FILE", moseklm_license_file, 1);
+  ASSERT_EQ(0, setenv_result);
+}
+
+}  // namespace
+}  // namespace solvers
+}  // namespace drake

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -24,29 +24,35 @@ test --test_tag_filters=-gurobi,-mosek,-snopt
 # Inject DISPLAY into test runner environment for tests that use X.
 test --test_env=DISPLAY
 
+# Location of the Gurobi license key file, typically named "gurobi.lic".
+# Setting this --test_env for all configurations is deliberate to improve
+# remote caching performance.
+test --test_env=GRB_LICENSE_FILE
+
+# Location of the MOSEK license file, typically named "mosek.lic". Setting
+# this --test_env for all configurations is deliberate to improve remote
+# caching performance.
+test --test_env=MOSEKLM_LICENSE_FILE
+
 ### A configuration that enables Gurobi. ###
-# -- To use this config, the GUROBI_PATH environment variable must be the
-# -- linux64 directory in the Gurobi 7.0.2 release.
+# -- To use this config, the GRB_LICENSE_FILE environment variable must be set
+# -- to the location of the Gurobi license key file. On Ubuntu, the GUROBI_PATH
+# -- environment variable must be set to the linux64 directory of the extracted
+# -- archive downloaded from gurobi.com.
 #
 # -- To run tests where Gurobi is used, ensure that you include
 # -- "gurobi_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If Gurobi is optional, set gurobi_required=False.
 build:gurobi --define=WITH_GUROBI=ON
-# -- By default, Gurobi looks for the license file in the homedir.
-test:gurobi --test_env=HOME
-# -- If set, the GRB_LICENSE_FILE path takes precedence.
-test:gurobi --test_env=GRB_LICENSE_FILE
 
 ### A configuration that enables MOSEK. ###
-# -- To use this config, you must have a MOSEK license file installed to
-# -- $HOME/mosek/mosek.lic.
+# -- To use this config, the MOSEKLM_LICENSE_FILE environment variable must be
+# -- set to the location of the MOSEK license file.
 #
 # -- To run tests where MOSEK is used, ensure that you include
 # -- "mosek_test_tags()" from //tools/skylark:test_tags.bzl.
 # -- If MOSEK is optional, set mosek_required=False.
 build:mosek --define=WITH_MOSEK=ON
-# -- MOSEK looks for its license file at $HOME/mosek/mosek.lic
-test:mosek --test_env=HOME
 
 ### A configuration that enables SNOPT. ###
 # -- To use this config, you must have access to the private repository
@@ -62,10 +68,7 @@ test:everything --test_tag_filters=-no_everything
 
 # -- Options for Gurobi.
 build:everything --define=WITH_GUROBI=ON
-test:everything --test_env=GRB_LICENSE_FILE
 # -- Options for MOSEK.
 build:everything --define=WITH_MOSEK=ON
-# -- Options for Gurobi and MOSEK.
-test:everything --test_env=HOME
 # -- Options for SNOPT.
 build:everything --define=WITH_SNOPT=ON

--- a/tools/dynamic_analysis/bazel.rc
+++ b/tools/dynamic_analysis/bazel.rc
@@ -22,8 +22,6 @@ build:kcov_everything --define=WITH_SNOPT=ON
 build:kcov_everything --copt -g
 build:kcov_everything --copt -O0
 
-test:kcov_everything --test_env=GRB_LICENSE_FILE
-test:kcov_everything --test_env=HOME
 test:kcov_everything --spawn_strategy=standalone
 test:kcov_everything --run_under=//tools/dynamic_analysis:kcov
 test:kcov_everything --local_test_jobs=1
@@ -59,8 +57,6 @@ build:asan_everything --copt -O1
 build:asan_everything --copt -fno-omit-frame-pointer
 build:asan_everything --linkopt -fsanitize=address
 
-test:asan_everything --test_env=GRB_LICENSE_FILE
-test:asan_everything --test_env=HOME
 # LSan is run with ASan by default
 test:asan_everything --test_tag_filters=-no_asan,-no_lsan
 test:asan_everything --run_under=//tools/dynamic_analysis:asan
@@ -94,8 +90,6 @@ build:lsan_everything --copt -O1
 build:lsan_everything --copt -fno-omit-frame-pointer
 build:lsan_everything --linkopt -fsanitize=leak
 
-test:lsan_everything --test_env=GRB_LICENSE_FILE
-test:lsan_everything --test_env=HOME
 test:lsan_everything --test_tag_filters=-no_lsan
 test:lsan_everything --run_under=//tools/dynamic_analysis:lsan
 test:lsan_everything --test_env=LSAN_OPTIONS
@@ -129,8 +123,6 @@ build:msan_everything --copt -O1
 build:msan_everything --copt -fno-omit-frame-pointer
 build:msan_everything --linkopt -fsanitize=memory
 
-test:msan_everything --test_env=GRB_LICENSE_FILE
-test:msan_everything --test_env=HOME
 test:msan_everything --test_tag_filters=-no_msan
 test:msan_everything --run_under=//tools/dynamic_analysis:msan
 test:msan_everything --test_lang_filters=-sh,-py
@@ -176,8 +168,6 @@ build:tsan_everything --copt -fno-omit-frame-pointer
 build:tsan_everything --noforce_pic
 build:tsan_everything --linkopt -fsanitize=thread
 
-test:tsan_everything --test_env=GRB_LICENSE_FILE
-test:tsan_everything --test_env=HOME
 test:tsan_everything --test_tag_filters=-no_tsan
 test:tsan_everything --run_under=//tools/dynamic_analysis:tsan
 test:tsan_everything --test_env=TSAN_OPTIONS
@@ -219,8 +209,6 @@ build:ubsan_everything --linkopt -fsanitize=undefined
 # https://groups.google.com/forum/#!topic/bazel-discuss/15h4GPixeGI
 build:ubsan_everything --linkopt /usr/lib/llvm-4.0/lib/clang/4.0.0/lib/linux/libclang_rt.ubsan_standalone_cxx-x86_64.a
 build:ubsan_everything --linkopt /usr/lib/llvm-4.0/lib/clang/4.0.0/lib/linux/libclang_rt.ubsan_standalone-x86_64.a
-test:ubsan_everything --test_env=GRB_LICENSE_FILE
-test:ubsan_everything --test_env=HOME
 test:ubsan_everything --test_tag_filters=-no_ubsan
 test:ubsan_everything --run_under=//tools/dynamic_analysis:ubsan
 test:ubsan_everything --test_env=UBSAN_OPTIONS
@@ -246,8 +234,6 @@ build:memcheck_everything --define=WITH_SNOPT=ON
 build:memcheck_everything --copt -g
 build:memcheck_everything --copt -O1
 
-test:memcheck_everything --test_env=GRB_LICENSE_FILE
-test:memcheck_everything --test_env=HOME
 test:memcheck_everything --test_tag_filters=-no_memcheck
 test:memcheck_everything --run_under=//tools/dynamic_analysis:valgrind
 test:memcheck_everything --test_lang_filters=-sh,-py


### PR DESCRIPTION
Removes the need to add `$HOME` to the environment and improves remote caching between different jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8619)
<!-- Reviewable:end -->
