### PR TITLE
Bump spring_mass_system_test timeout to "moderate".

### DIFF
--- a/systems/plants/spring_mass_system/BUILD.bazel
+++ b/systems/plants/spring_mass_system/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "spring_mass_system_test",
+    timeout = "moderate",
     deps = [
         ":spring_mass_system",
         "//common/test_utilities",


### PR DESCRIPTION
Addresses the failure in that test seen in [this job](https://drake-jenkins.csail.mit.edu/view/Valgrind/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/355/) from linux-xenial-clang-bazel-nightly-memcheck-valgrind. The other failure in that job was addressed by #8618.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8628)
<!-- Reviewable:end -->
