### PR TITLE
pkg_config: Robustify against repeated include paths

### DIFF
--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -157,7 +157,11 @@ def setup_pkg_config_repository(repository_ctx):
     # relative paths for them as required by cc_library's attributes.
     includes = []
     hdrs_path = repository_ctx.path("include")
+    seen = []
     for item in absolute_includes:
+        if item in seen:
+            continue
+        seen.append(item)
         if item == "/usr/include" or item == "/usr/local/include":
             print(("pkg-config of {} returned an include path that " +
                    "contains {} that may contain unrelated headers").format(


### PR DESCRIPTION
A while back, when tinkering with ROS stuff, @calderpg-tri had run into this. This is just a simple fix to ensure that Bazel doesn't try to symlink over an existing directory if the `pkg-config` output has repeated paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8635)
<!-- Reviewable:end -->
