### PR TITLE
Drake Automotive: Adds a TrivialRightOfWayStateProvider

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -364,6 +364,20 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "trivial_right_of_way_state_provider",
+    srcs = [
+        "trivial_right_of_way_state_provider.cc",
+    ],
+    hdrs = [
+        "trivial_right_of_way_state_provider.h",
+    ],
+    deps = [
+        "//automotive/maliput/api",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "automotive_simulator",
     srcs = ["automotive_simulator.cc"],
     hdrs = ["automotive_simulator.h"],
@@ -379,6 +393,7 @@ drake_cc_library(
         ":pure_pursuit_controller",
         ":simple_car",
         ":trajectory_car",
+        ":trivial_right_of_way_state_provider",
         "//automotive/maliput/api",
         "//automotive/maliput/utility",
         "//common:temp_directory",
@@ -687,6 +702,13 @@ drake_cc_googletest(
         "//common/proto:call_matlab",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/trajectory_optimization:direct_collocation",
+    ],
+)
+
+drake_cc_googletest(
+    name = "trivial_right_of_way_state_provider_test",
+    deps = [
+        ":trivial_right_of_way_state_provider",
     ],
 )
 

--- a/automotive/test/trivial_right_of_way_state_provider_test.cc
+++ b/automotive/test/trivial_right_of_way_state_provider_test.cc
@@ -1,0 +1,36 @@
+#include "drake/automotive/trivial_right_of_way_state_provider.h"
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace automotive {
+namespace {
+
+using maliput::api::rules::RightOfWayRule;
+
+GTEST_TEST(TrivialRightOfWayStateProviderTest, BasicTest) {
+  TrivialRightOfWayStateProvider dut;
+  RightOfWayRule::Id id("foo");
+
+  // No rule with specified ID exists.
+  EXPECT_THROW(dut.GetState(id), std::out_of_range);
+  EXPECT_THROW(dut.SetState(id, RightOfWayRule::DynamicState::kUncontrolled),
+               std::out_of_range);
+
+  dut.AddState(id, RightOfWayRule::DynamicState::kGo);
+  EXPECT_EQ(dut.GetState(id), RightOfWayRule::DynamicState::kGo);
+
+  // Attempting to add duplicate state.
+  EXPECT_THROW(dut.AddState(id, RightOfWayRule::DynamicState::kStop),
+               std::logic_error);
+
+  dut.SetState(id, RightOfWayRule::DynamicState::kPrepareToStop);
+  EXPECT_EQ(dut.GetState(id), RightOfWayRule::DynamicState::kPrepareToStop);
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake
+

--- a/automotive/trivial_right_of_way_state_provider.cc
+++ b/automotive/trivial_right_of_way_state_provider.cc
@@ -1,0 +1,35 @@
+#include "drake/automotive/trivial_right_of_way_state_provider.h"
+
+#include <stdexcept>
+#include <string>
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace automotive {
+
+using maliput::api::rules::RightOfWayRule;
+
+void TrivialRightOfWayStateProvider::AddState(
+    const RightOfWayRule::Id& id,
+    const RightOfWayRule::DynamicState& initial_state) {
+  auto result = dynamic_states_.emplace(id, initial_state);
+  if (!result.second) {
+     throw std::logic_error(
+        "Attempted to add multiple rules with id " + id.string());
+  }
+}
+
+void TrivialRightOfWayStateProvider::SetState(
+    const RightOfWayRule::Id& id,
+    const RightOfWayRule::DynamicState& state) {
+  dynamic_states_.at(id) = state;
+}
+
+RightOfWayRule::DynamicState TrivialRightOfWayStateProvider::DoGetState(
+    const RightOfWayRule::Id& id) const {
+  return dynamic_states_.at(id);
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/trivial_right_of_way_state_provider.h
+++ b/automotive/trivial_right_of_way_state_provider.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "drake/automotive/maliput/api/rules/right_of_way_rule.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace automotive {
+
+/// A trivial implementation of an api::rules::RightOfWayStateProvider.
+class TrivialRightOfWayStateProvider final
+    : public maliput::api::rules::RightOfWayStateProvider {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrivialRightOfWayStateProvider)
+
+  /// Default constructor.
+  TrivialRightOfWayStateProvider() {}
+
+  ~TrivialRightOfWayStateProvider() final = default;
+
+  /// Adds a dynamic state to this manager.
+  ///
+  /// Throws std::logic_error if a RightOfWayRule with an ID of @p id
+  /// already exists in this manager.
+  ///
+  /// Throws std::runtime_error if the dynamic state failed to be added.
+  void AddState(
+      const maliput::api::rules::RightOfWayRule::Id& id,
+      const maliput::api::rules::RightOfWayRule::DynamicState& initial_state);
+
+  /// Sets the dynamic state of a RightOfWayRule within this manager.
+  ///
+  /// Throws std::out_of_range if no dynamic state with @p id exists in this
+  /// manager.
+  void SetState(const maliput::api::rules::RightOfWayRule::Id& id,
+                const maliput::api::rules::RightOfWayRule::DynamicState& state);
+
+ private:
+  maliput::api::rules::RightOfWayRule::DynamicState DoGetState(
+      const maliput::api::rules::RightOfWayRule::Id& id) const final;
+
+  std::unordered_map<maliput::api::rules::RightOfWayRule::Id,
+      maliput::api::rules::RightOfWayRule::DynamicState> dynamic_states_;
+};
+
+}  // namespace automotive
+}  // namespace drake


### PR DESCRIPTION
This is a trivial manager that simply allows applications to set all `RightOfWayRule` dynamic states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8642)
<!-- Reviewable:end -->
