### PR TITLE
Ensure pybind11 CMake targets match upstream

### DIFF
--- a/tools/workspace/pybind11/package-create-cps.py
+++ b/tools/workspace/pybind11/package-create-cps.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python2
 
+import sys
+
 from drake.tools.install.cpsutils import read_defs
 
+# Targets correct as of pybind11/pybind11@6d0b470. Ensure that SHA is taken
+# from pybind11/pybind11 and not RobotLocomotion/pybind11.
+
 defs = read_defs("#define PYBIND11_(VERSION[^\s]+)\s+([^\s]+)")
+
+if sys.platform.startswith('darwin'):
+    defs["MODULE_LINK_FLAGS"] = '"Link-Flags": ["-undefined dynamic_lookup"],'
+else:
+    defs["MODULE_LINK_FLAGS"] = ""
 
 content = """
 {
@@ -11,12 +21,43 @@ content = """
   "Description": "Seamless operability between C++11 and Python",
   "License": "BSD-3-Clause",
   "Version": "%(VERSION_MAJOR)s.%(VERSION_MINOR)s.%(VERSION_PATCH)s",
-  "Default-Components": [":module"],
+  "Requires": {
+    "PythonInterp": {
+      "Version": "2.7",
+      "X-CMake-Find-Args": [
+        "EXACT",
+        "MODULE"
+      ]
+    },
+    "PythonLibs": {
+      "Version": "2.7",
+      "X-CMake-Find-Args": [
+        "EXACT",
+        "MODULE"
+      ]
+    }
+  },
+  "Default-Components": [":pybind11"],
   "Components": {
+    "embed": {
+      "Type": "interface",
+      "Requires": [
+        ":pybind11",
+        "${PYTHON_LIBRARIES}"
+      ]
+    },
     "module": {
       "Type": "interface",
-      "Includes": ["@prefix@/include/pybind11"],
-      "Compile-Features": ["c++11"]
+      %(MODULE_LINK_FLAGS)s
+      "Requires": [":pybind11"]
+    },
+    "pybind11": {
+      "Type": "interface",
+      "Includes": [
+        "@prefix@/include/pybind11",
+        "${PYTHON_INCLUDE_DIRS}"
+      ],
+      "Compile-Features": ["c++14"]
     }
   },
   "X-CMake-Includes": ["${CMAKE_CURRENT_LIST_DIR}/pybind11Tools.cmake"],


### PR DESCRIPTION
Toward #8644. This is a very CMake-oriented fix for the moment. I need a change to the `FindPythonLibs` module in upstream CMake (that I will vendor in and install for previous versions) to make the pure CPS fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8650)
<!-- Reviewable:end -->
