### PR TITLE
Remove useless allocations in MinDistanceConstraint.

### DIFF
--- a/multibody/rigid_body_constraint.cc
+++ b/multibody/rigid_body_constraint.cc
@@ -2036,7 +2036,7 @@ void MinDistanceConstraint::eval(const double* t,
         MatrixXd::Zero(num_pts, getRobotPointer()->get_num_positions());
 
     // Compute Jacobian of closest distance vector
-    scaleDistance(dist, scaled_dist, dscaled_dist_ddist);
+    scaleDistance(dist, min_distance_, scaled_dist, dscaled_dist_ddist);
     penalty(scaled_dist, pairwise_costs, dpairwise_costs_dscaled_dist);
 
     std::vector<std::vector<int>> orig_idx_of_pt_on_bodyA(
@@ -2092,17 +2092,17 @@ void MinDistanceConstraint::eval(const double* t,
 }
 
 void MinDistanceConstraint::scaleDistance(
-    const Eigen::VectorXd& dist, Eigen::VectorXd& scaled_dist,
-    Eigen::MatrixXd& dscaled_dist_ddist) const {
+    const Eigen::VectorXd& dist, double distance_threshold, Eigen::VectorXd& scaled_dist,
+    Eigen::MatrixXd& dscaled_dist_ddist) {
   int nd = static_cast<int>(dist.size());
-  double recip_min_dist = 1 / min_distance_;
+  double recip_min_dist = 1 / distance_threshold;
   scaled_dist = recip_min_dist * dist - VectorXd::Ones(nd, 1);
   dscaled_dist_ddist = recip_min_dist * MatrixXd::Identity(nd, nd);
 }
 
 void MinDistanceConstraint::penalty(const Eigen::VectorXd& dist,
                                     Eigen::VectorXd& cost,
-                                    Eigen::MatrixXd& dcost_ddist) const {
+                                    Eigen::MatrixXd& dcost_ddist) {
   int nd = static_cast<int>(dist.size());
   cost = VectorXd::Zero(nd, 1);
   dcost_ddist = MatrixXd::Zero(nd, nd);

--- a/multibody/rigid_body_constraint.cc
+++ b/multibody/rigid_body_constraint.cc
@@ -2006,9 +2006,9 @@ void MinDistanceConstraint::eval(const double* t,
   // std::cout << "MinDistanceConstraint::eval: START" << std::endl;
   // END_DEBUG
   if (isTimeValid(t)) {
-    VectorXd dist, scaled_dist, pairwise_costs;
+    VectorXd dist, pairwise_costs, dpairwise_costs_ddist;
     Matrix3Xd xA, xB, normal;
-    MatrixXd ddist_dq, dscaled_dist_ddist, dpairwise_costs_dscaled_dist;
+    MatrixXd ddist_dq;
     std::vector<int> idxA;
     std::vector<int> idxB;
 
@@ -2036,8 +2036,7 @@ void MinDistanceConstraint::eval(const double* t,
         MatrixXd::Zero(num_pts, getRobotPointer()->get_num_positions());
 
     // Compute Jacobian of closest distance vector
-    scaleDistance(dist, min_distance_, scaled_dist, dscaled_dist_ddist);
-    penalty(scaled_dist, pairwise_costs, dpairwise_costs_dscaled_dist);
+    Penalty(dist, min_distance_, &pairwise_costs, &dpairwise_costs_ddist);
 
     std::vector<std::vector<int>> orig_idx_of_pt_on_bodyA(
         getRobotPointer()->get_bodies().size());
@@ -2081,36 +2080,36 @@ void MinDistanceConstraint::eval(const double* t,
             J_k.block(3 * l, 0, 3, getRobotPointer()->get_num_positions());
       }
     }
-    MatrixXd dcost_dscaled_dist(dpairwise_costs_dscaled_dist.colwise().sum());
+    auto dcost_ddist = dpairwise_costs_ddist.transpose();
     c.resize(1);
     c(0) = pairwise_costs.sum();
-    dc = dcost_dscaled_dist * dscaled_dist_ddist * ddist_dq;
+    dc = dcost_ddist * ddist_dq;
   } else {
     c.resize(0);
     dc.resize(0, 0);
   }
 }
 
-void MinDistanceConstraint::scaleDistance(
-    const Eigen::VectorXd& dist, double distance_threshold, Eigen::VectorXd& scaled_dist,
-    Eigen::MatrixXd& dscaled_dist_ddist) {
-  int nd = static_cast<int>(dist.size());
-  double recip_min_dist = 1 / distance_threshold;
-  scaled_dist = recip_min_dist * dist - VectorXd::Ones(nd, 1);
-  dscaled_dist_ddist = recip_min_dist * MatrixXd::Identity(nd, nd);
-}
-
-void MinDistanceConstraint::penalty(const Eigen::VectorXd& dist,
-                                    Eigen::VectorXd& cost,
-                                    Eigen::MatrixXd& dcost_ddist) {
-  int nd = static_cast<int>(dist.size());
-  cost = VectorXd::Zero(nd, 1);
-  dcost_ddist = MatrixXd::Zero(nd, nd);
+void MinDistanceConstraint::Penalty(const Eigen::VectorXd& distance,
+                                    double distance_threshold,
+                                    Eigen::VectorXd* penalty,
+                                    Eigen::VectorXd* dpenalty_ddistance) {
+  DRAKE_ASSERT(penalty != nullptr);
+  DRAKE_ASSERT(penalty != dpenalty_ddistance);
+  int nd = static_cast<int>(distance.size());
+  penalty->resize(nd);
+  dpenalty_ddistance->resize(nd);
   for (int i = 0; i < nd; ++i) {
-    if (dist(i) < 0) {
-      double exp_recip_dist = exp(1 / dist(i));
-      cost(i) = -dist(i) * exp_recip_dist;
-      dcost_ddist(i, i) = exp_recip_dist * (1 / dist(i) - 1);
+    if (distance(i) < distance_threshold) {
+      double transformed_distance = (distance(i) / distance_threshold - 1.);
+      double exp_recip_distance = exp(1. / transformed_distance);
+      (*penalty)(i) = -transformed_distance * exp_recip_distance;
+      (*dpenalty_ddistance)(i) = exp_recip_distance *
+                                 (1. / transformed_distance - 1.) /
+                                 distance_threshold;
+    } else {
+      (*penalty)(i) = 0.;
+      (*dpenalty_ddistance)(i) = 0.;
     }
   }
 }

--- a/multibody/rigid_body_constraint.h
+++ b/multibody/rigid_body_constraint.h
@@ -880,10 +880,10 @@ class MinDistanceConstraint : public SingleTimeKinematicConstraint {
   virtual void eval(const double* t, KinematicsCache<double>& cache,
                     Eigen::VectorXd& c, Eigen::MatrixXd& dc) const;
   virtual void name(const double* t, std::vector<std::string>& name) const;
-  void scaleDistance(const Eigen::VectorXd& dist, Eigen::VectorXd& scaled_dist,
-                     Eigen::MatrixXd& dscaled_dist_ddist) const;
-  void penalty(const Eigen::VectorXd& dist, Eigen::VectorXd& cost,
-               Eigen::MatrixXd& dcost_ddist) const;
+  static void scaleDistance(const Eigen::VectorXd& dist, double distance_threshold, Eigen::VectorXd& scaled_dist,
+                     Eigen::MatrixXd& dscaled_dist_ddist);
+  static void penalty(const Eigen::VectorXd& dist, Eigen::VectorXd& cost,
+               Eigen::MatrixXd& dcost_ddist);
   virtual void bounds(const double* t, Eigen::VectorXd& lb,
                       Eigen::VectorXd& ub) const;
 

--- a/multibody/rigid_body_constraint.h
+++ b/multibody/rigid_body_constraint.h
@@ -880,10 +880,24 @@ class MinDistanceConstraint : public SingleTimeKinematicConstraint {
   virtual void eval(const double* t, KinematicsCache<double>& cache,
                     Eigen::VectorXd& c, Eigen::MatrixXd& dc) const;
   virtual void name(const double* t, std::vector<std::string>& name) const;
-  static void scaleDistance(const Eigen::VectorXd& dist, double distance_threshold, Eigen::VectorXd& scaled_dist,
-                     Eigen::MatrixXd& dscaled_dist_ddist);
-  static void penalty(const Eigen::VectorXd& dist, Eigen::VectorXd& cost,
-               Eigen::MatrixXd& dcost_ddist);
+
+  /** Evaluates a smooth hinge loss function for the elements of `distance`.
+   * Specifically, it sets `penalty[i]` to
+   * f(`distance[i]`, `distance_threshold`) and `dpenalty_ddistance[i]` to
+   * ∂f/∂x(`distance[i]`, `distance_threshold`), where
+   *
+   *               ⎧
+   *               ⎪ (1 - x/d) exp(1/(x/d - 1)), x < d
+   *     f(x, d) = ⎨                                  .
+   *               ⎪                          0, x ≥ d
+   *               ⎩
+   *
+   *
+   * @pre `distance_threshold` is greater than 0.
+   */
+  static void Penalty(const Eigen::VectorXd& distance,
+                      double distance_threshold, Eigen::VectorXd* penalty,
+                      Eigen::VectorXd* dpenalty_ddistance);
   virtual void bounds(const double* t, Eigen::VectorXd& lb,
                       Eigen::VectorXd& ub) const;
 

--- a/multibody/test/rigid_body_constraint_test.cc
+++ b/multibody/test/rigid_body_constraint_test.cc
@@ -53,9 +53,9 @@ GTEST_TEST(MinDistanceConstraintTests, PenaltyTest) {
   symbolic::Expression penalty_below_threshold{
       (1 - distance_symbolic / distance_threshold_symbolic) *
       exp(1 / (distance_symbolic / distance_threshold_symbolic - 1))};
-  auto penalty_symbolic =
-      symbolic::if_then_else(distance_symbolic < distance_threshold_symbolic,
-                             penalty_below_threshold, penalty_above_threshold);
+  auto penalty_symbolic = symbolic::if_then_else(
+      distance_symbolic < distance_threshold_symbolic,
+      penalty_below_threshold, penalty_above_threshold);
   auto dpenalty_ddistance_symbolic = symbolic::if_then_else(
       distance_symbolic < distance_threshold_symbolic,
       penalty_below_threshold.Differentiate(distance_symbolic),
@@ -65,20 +65,10 @@ GTEST_TEST(MinDistanceConstraintTests, PenaltyTest) {
       VectorX<double>::LinSpaced(num_evaluation_points, -1, 1);
   VectorX<double> penalty;
   VectorX<double> dpenalty_ddistance;
-  MatrixX<double> dpenalty_dscaled_distance;
-  VectorX<double> scaled_distance;
-  MatrixX<double> dscaled_distance_ddistance;
-  // This tolerance is the smallest integer multiple of epsilon for which the
-  // test passes.
   double tolerance = 64 * std::numeric_limits<double>::epsilon();
   for (double distance_threshold_numeric : {0.01, 0.1, 1.}) {
-    MinDistanceConstraint::scaleDistance(
-        distance_numeric, distance_threshold_numeric, scaled_distance,
-        dscaled_distance_ddistance);
-    MinDistanceConstraint::penalty(scaled_distance, penalty,
-                                   dpenalty_dscaled_distance);
-    dpenalty_ddistance =
-        (dpenalty_dscaled_distance * dscaled_distance_ddistance).diagonal();
+    MinDistanceConstraint::Penalty(distance_numeric, distance_threshold_numeric,
+                                   &penalty, &dpenalty_ddistance);
     for (int i = 0; i < num_evaluation_points; ++i) {
       EXPECT_NEAR(
           penalty(i),

--- a/multibody/test/rigid_body_constraint_test.cc
+++ b/multibody/test/rigid_body_constraint_test.cc
@@ -4,7 +4,9 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
+#include "drake/common/symbolic.h"
 #include "drake/multibody/joints/floating_base_types.h"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_tree.h"
@@ -33,6 +35,65 @@ GTEST_TEST(RigidBodyConstraintTest, TestWorldComConstraint) {
   EXPECT_NO_THROW(world_com_constraint =
       make_unique<WorldCoMConstraint>(tree.get(), kc1_lb, kc1_ub, tspan));
   EXPECT_NE(world_com_constraint, nullptr);
+}
+
+GTEST_TEST(MinDistanceConstraintTests, PenaltyTest) {
+  // Verifies that `MinDistanceConstraint::Penalty()`implements the following
+  // piecewise function:
+  //
+  //           ⎧
+  //           ⎪ (1 - x/d) exp(1/(x/d - 1)), x < d
+  //    f(x) = ⎨
+  //           ⎪                          0, x ≥ d
+  //           ⎩
+
+  symbolic::Variable distance_symbolic{"x"};
+  symbolic::Variable distance_threshold_symbolic{"d"};
+  symbolic::Expression penalty_above_threshold{0.};
+  symbolic::Expression penalty_below_threshold{
+      (1 - distance_symbolic / distance_threshold_symbolic) *
+      exp(1 / (distance_symbolic / distance_threshold_symbolic - 1))};
+  auto penalty_symbolic =
+      symbolic::if_then_else(distance_symbolic < distance_threshold_symbolic,
+                             penalty_below_threshold, penalty_above_threshold);
+  auto dpenalty_ddistance_symbolic = symbolic::if_then_else(
+      distance_symbolic < distance_threshold_symbolic,
+      penalty_below_threshold.Differentiate(distance_symbolic),
+      penalty_above_threshold.Differentiate(distance_symbolic));
+  constexpr int num_evaluation_points = 100;
+  auto distance_numeric =
+      VectorX<double>::LinSpaced(num_evaluation_points, -1, 1);
+  VectorX<double> penalty;
+  VectorX<double> dpenalty_ddistance;
+  MatrixX<double> dpenalty_dscaled_distance;
+  VectorX<double> scaled_distance;
+  MatrixX<double> dscaled_distance_ddistance;
+  // This tolerance is the smallest integer multiple of epsilon for which the
+  // test passes.
+  double tolerance = 64 * std::numeric_limits<double>::epsilon();
+  for (double distance_threshold_numeric : {0.01, 0.1, 1.}) {
+    MinDistanceConstraint::scaleDistance(
+        distance_numeric, distance_threshold_numeric, scaled_distance,
+        dscaled_distance_ddistance);
+    MinDistanceConstraint::penalty(scaled_distance, penalty,
+                                   dpenalty_dscaled_distance);
+    dpenalty_ddistance =
+        (dpenalty_dscaled_distance * dscaled_distance_ddistance).diagonal();
+    for (int i = 0; i < num_evaluation_points; ++i) {
+      EXPECT_NEAR(
+          penalty(i),
+          penalty_symbolic.Evaluate(
+              {{distance_symbolic, distance_numeric(i)},
+               {distance_threshold_symbolic, distance_threshold_numeric}}),
+          tolerance);
+      EXPECT_NEAR(
+          dpenalty_ddistance(i),
+          dpenalty_ddistance_symbolic.Evaluate(
+              {{distance_symbolic, distance_numeric(i)},
+               {distance_threshold_symbolic, distance_threshold_numeric}}),
+          tolerance);
+    }
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This PR modifies some truly unfortunate code that I wrote during grad school. Said code allocated dense matrices for the gradients of some intermediate quantities inside the `MinDistanceConstraint::eval()`. Those matrices were diagonal, and one of them was a scalar times the identity matrix. This PR puts the methods that previously allocated these matrices under test and modifies the methods to output a vector or scalar rather than a full matrix.

Here are screenshots of the Callgrind output before and after the change. 

Before  (30847fa67c4eeec253aaf80443a77ea4b638e0e5): ~67% of time spent *outside* of `RBT::collisionDetect()` calls
![Before](https://user-images.githubusercontent.com/2574034/39069223-2143fa38-44ad-11e8-8b14-d818e1f9b17f.png)

After (this PR) ~3% of time spent *outside* of `RBT::collisionDetect()` calls
![After](https://user-images.githubusercontent.com/2574034/39069275-477f4a54-44ad-11e8-9e89-72a4da8c7ffd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8652)
<!-- Reviewable:end -->
