### PR TITLE
Some framework updates (witness functions + sugar for getting discrete state vector)

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -155,7 +155,8 @@ class Context : public ContextBase {
   }
 
   /// Returns a reference to the _only_ discrete state vector. The vector may be
-  /// of size zero. Fails if there is more than one discrete state group.
+  /// of size zero.
+  /// @pre There is only one discrete state group.
   const BasicVector<T>& get_discrete_state_vector() const {
     return get_discrete_state().get_vector();
   }
@@ -168,6 +169,7 @@ class Context : public ContextBase {
 
   /// Returns a mutable reference to the _only_ discrete state vector.
   /// @sa get_discrete_state_vector().
+  /// @pre There is only one discrete state group.
   BasicVector<T>& get_mutable_discrete_state_vector() {
     return get_mutable_discrete_state().get_mutable_vector();
   }

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -167,7 +167,7 @@ class Context : public ContextBase {
   }
 
   /// Returns a mutable reference to the _only_ discrete state vector.
-  /// @sa get_discrete_state_vector(). 
+  /// @sa get_discrete_state_vector().
   BasicVector<T>& get_mutable_discrete_state_vector() {
     return get_mutable_discrete_state().get_mutable_vector();
   }

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -166,6 +166,12 @@ class Context : public ContextBase {
     return get_mutable_state().get_mutable_discrete_state();
   }
 
+  /// Returns a mutable reference to the _only_ discrete state vector.
+  /// @sa get_discrete_state_vector(). 
+  BasicVector<T>& get_mutable_discrete_state_vector() {
+    return get_mutable_discrete_state().get_mutable_vector();
+  }
+
   /// Returns a mutable reference to group (vector) @p index of the discrete
   /// state.
   /// @pre @p index must identify an existing group.

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -881,7 +881,7 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
-  /// for debugging and logging), direction type, calculation function, and
+  /// for debugging and logging), direction type, calculator function, and
   /// publish event callback function for when this triggers.
   template <class MySystem>
   std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(
@@ -905,7 +905,7 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
-  /// for debugging and logging), direction type, calculation function, and
+  /// for debugging and logging), direction type, calculator function, and
   /// discrete update event callback function for when this triggers.
   template <class MySystem>
   std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(
@@ -929,7 +929,7 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
-  /// for debugging and logging), direction type, calculation function, and
+  /// for debugging and logging), direction type, calculator function, and
   /// unrestricted update event callback function for when this triggers.
   template <class MySystem>
   std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(
@@ -953,10 +953,10 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
-  /// for debugging and logging), direction type, and calculation
-  /// function, and with a unique pointer to the event that is to be dispatched
-  /// when this witness function triggers. Example types of event objects are
-  /// publish, discrete variable update, unrestricted update events.
+  /// for debugging and logging), direction type, and calculator
+  /// function, and with an object corresponding to the event that is to be
+  /// dispatched when this witness function triggers. Example types of event
+  /// objects are publish, discrete variable update, unrestricted update events.
   /// A clone of the event will be owned by the newly constructed
   /// WitnessFunction.
   template <class MySystem>
@@ -972,10 +972,10 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
-  /// for debugging and logging), direction type, and calculation
-  /// function, and with a unique pointer to the event that is to be dispatched
-  /// when this witness function triggers. Example types of event objects are
-  /// publish, discrete variable update, unrestricted update events.
+  /// for debugging and logging), direction type, and calculator
+  /// function, and with an object corresponding to the event that is to be
+  /// dispatched when this witness function triggers. Example types of event
+  /// objects are publish, discrete variable update, unrestricted update events.
   /// A clone of the event will be owned by the newly constructed
   /// WitnessFunction.
   std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -870,6 +870,17 @@ class LeafSystem : public System<T> {
   }
 
   /// Constructs the witness function with the given description (used primarily
+  /// for debugging and logging), direction type, and calculator function; and
+  /// with no event object.
+  std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(
+      const std::string& description,
+      const WitnessFunctionDirection& direction_type,
+      std::function<T(const Context<T>&)> calc) const {
+    return std::make_unique<WitnessFunction<T>>(
+        this, description, direction_type, calc);
+  }
+
+  /// Constructs the witness function with the given description (used primarily
   /// for debugging and logging), direction type, calculation function, and
   /// publish event callback function for when this triggers.
   template <class MySystem>
@@ -956,6 +967,22 @@ class LeafSystem : public System<T> {
       const Event<T>& e) const {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
       "Expected to be invoked from a LeafSystem-derived system.");
+    return std::make_unique<WitnessFunction<T>>(
+        this, description, direction_type, calc, e.Clone());
+  }
+
+  /// Constructs the witness function with the given description (used primarily
+  /// for debugging and logging), direction type, and calculation
+  /// function, and with a unique pointer to the event that is to be dispatched
+  /// when this witness function triggers. Example types of event objects are
+  /// publish, discrete variable update, unrestricted update events.
+  /// A clone of the event will be owned by the newly constructed
+  /// WitnessFunction.
+  std::unique_ptr<WitnessFunction<T>> DeclareWitnessFunction(
+      const std::string& description,
+      const WitnessFunctionDirection& direction_type,
+      std::function<T(const Context<T>&)> calc,
+      const Event<T>& e) const {
     return std::make_unique<WitnessFunction<T>>(
         this, description, direction_type, calc, e.Clone());
   }

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -53,8 +53,16 @@ class LeafContextTest : public ::testing::Test {
         kGeneralizedPositionSize, kGeneralizedVelocitySize,
         kMiscContinuousStateSize));
 
-    // Reserve a discrete state with two elements, of size 1 and size 2.
+    // Reserve a discrete state with a single element of size 1, and verify
+    // that we can change it using get_mutable_discrete_state_vector().
     std::vector<std::unique_ptr<BasicVector<double>>> xd;
+    xd.push_back(BasicVector<double>::Make({128.0}));
+    context_.set_discrete_state(
+        std::make_unique<DiscreteValues<double>>(std::move(xd)));
+    context_.get_mutable_discrete_state_vector()[0] = 192.0;
+    EXPECT_EQ(context_.get_discrete_state().get_vector()[0], 192.0);
+
+    // Reserve a discrete state with two elements, of size 1 and size 2.
     xd.push_back(BasicVector<double>::Make({128.0}));
     xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
     context_.set_discrete_state(

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -55,14 +55,15 @@ class LeafContextTest : public ::testing::Test {
 
     // Reserve a discrete state with a single element of size 1, and verify
     // that we can change it using get_mutable_discrete_state_vector().
-    std::vector<std::unique_ptr<BasicVector<double>>> xd;
-    xd.push_back(BasicVector<double>::Make({128.0}));
+    std::vector<std::unique_ptr<BasicVector<double>>> xd_single;
+    xd_single.push_back(BasicVector<double>::Make({128.0}));
     context_.set_discrete_state(
-        std::make_unique<DiscreteValues<double>>(std::move(xd)));
+        std::make_unique<DiscreteValues<double>>(std::move(xd_single)));
     context_.get_mutable_discrete_state_vector()[0] = 192.0;
     EXPECT_EQ(context_.get_discrete_state().get_vector()[0], 192.0);
 
     // Reserve a discrete state with two elements, of size 1 and size 2.
+    std::vector<std::unique_ptr<BasicVector<double>>> xd;
     xd.push_back(BasicVector<double>::Make({128.0}));
     xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
     context_.set_discrete_state(

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -150,13 +150,6 @@ class TestSystem : public LeafSystem<T> {
       return unrestricted_update_callback_called_;
   }
 
-  // Resets the callback flags, so repeated tests can be run.
-  void ResetCallbackFlags() {
-    publish_callback_called_ = false;
-    discrete_update_callback_called_ = false;
-    unrestricted_update_callback_called_ = false;
-  }
-
  private:
   // This dummy witness function exists only to test that the
   // DeclareWitnessFunction() interface works as promised.
@@ -182,14 +175,6 @@ class TestSystem : public LeafSystem<T> {
   // appropriate DeclareWitnessFunction() interface works as promised.
   void UnrestrictedUpdateCallback(const Context<T>&,
       const UnrestrictedUpdateEvent<T>&, State<T>*) const {
-    unrestricted_update_callback_called_ = true;
-  }
-
-  // Unrestricted update callback function, which serves to test whether the
-  // appropriate DeclareWitnessFunction() interface works as promised.
-  void DoCalcUnrestrictedUpdate(
-      const Context<T>&, const std::vector<const UnrestrictedUpdateEvent<T>*>&,
-      State<T>*) const override {
     unrestricted_update_callback_called_ = true;
   }
 
@@ -248,7 +233,6 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   ASSERT_TRUE(pe);
   pe->handle(context_);
   EXPECT_TRUE(system_.publish_callback_called());
-  system_.ResetCallbackFlags();
 
   auto witness4 = system_.DeclareWitnessWithDiscreteUpdate();
   ASSERT_TRUE(witness4);
@@ -262,7 +246,6 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   ASSERT_TRUE(de);
   de->handle(context_, nullptr);
   EXPECT_TRUE(system_.discrete_update_callback_called());
-  system_.ResetCallbackFlags();
 
   auto witness5 = system_.DeclareWitnessWithUnrestrictedUpdate();
   ASSERT_TRUE(witness5);
@@ -276,7 +259,6 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   ASSERT_TRUE(ue);
   ue->handle(context_, nullptr);
   EXPECT_TRUE(system_.unrestricted_update_callback_called());
-  system_.ResetCallbackFlags();
 
   auto witness6 = system_.DeclareLambdaWitnessWithoutEvent();
   ASSERT_TRUE(witness6);
@@ -295,9 +277,6 @@ TEST_F(LeafSystemTest, WitnessDeclarations) {
   ue = dynamic_cast<const UnrestrictedUpdateEvent<double>*>(
       witness7->get_event());
   ASSERT_TRUE(ue);
-  ue->handle(context_, nullptr);
-  EXPECT_TRUE(system_.unrestricted_update_callback_called());
-  system_.ResetCallbackFlags();
 }
 
 // Tests that if no update events are configured, none are reported.

--- a/systems/framework/witness_function.h
+++ b/systems/framework/witness_function.h
@@ -155,15 +155,8 @@ class WitnessFunction final {
     set_calculator_function(calc);
   }
 
-  // Constructs the witness function with the pointer to the given non-null
-  // System; with the given description (used primarily for debugging and
-  // logging), direction type, and calculator function, and with a unique
-  // pointer to the event that is to be dispatched when this witness function
-  // triggers. Example events are publish, discrete variable update,
-  // unrestricted update events.
-  // @tparam EventType a class derived from Event<T>
-  // @warning the pointer to the System must be valid as long or longer than
-  // the lifetime of the witness function.
+  // See documentation for above constructor, which applies here without
+  // reservations.
   template <class EventType>
   WitnessFunction(const System<T>* system,
                   std::string description,

--- a/systems/framework/witness_function.h
+++ b/systems/framework/witness_function.h
@@ -119,8 +119,8 @@ class WitnessFunction final {
                   std::string description,
                   const WitnessFunctionDirection& direction,
                   T (MySystem::*calc)(const Context<T>&) const)
-      : WitnessFunction(system, description, direction, calc,
-          std::unique_ptr<Event<T>>()) {}
+      : WitnessFunction(system, std::move(description), direction,
+                        std::move(calc), std::unique_ptr<Event<T>>()) {}
 
   // See documentation for above constructor, which applies here without
   // reservations.
@@ -128,8 +128,8 @@ class WitnessFunction final {
                   std::string description,
                   const WitnessFunctionDirection& direction,
                   std::function<T(const Context<T>&)> calc)
-      : WitnessFunction(system, description, direction, calc,
-                        std::unique_ptr<Event<T>>()) {}
+      : WitnessFunction(system, std::move(description), direction,
+                        std::move(calc), std::unique_ptr<Event<T>>()) {}
 
   // Constructs the witness function with the pointer to the given non-null
   // System; with the given description (used primarily for debugging and
@@ -171,7 +171,8 @@ class WitnessFunction final {
                   std::function<T(const Context<T>&)> calc,
                   std::unique_ptr<EventType> e) :
       system_(system), description_(std::move(description)),
-      direction_type_(direction), event_(std::move(e)), calc_function_{calc} {
+      direction_type_(direction), event_(std::move(e)),
+      calc_function_{std::move(calc)} {
     static_assert(std::is_base_of<Event<T>, EventType>::value,
                   "EventType must be a descendant of Event");
     DRAKE_DEMAND(system);

--- a/systems/framework/witness_function.h
+++ b/systems/framework/witness_function.h
@@ -165,7 +165,7 @@ class WitnessFunction final {
                   std::unique_ptr<EventType> e) :
       system_(system), description_(std::move(description)),
       direction_type_(direction), event_(std::move(e)),
-      calc_function_{std::move(calc)} {
+      calc_function_(std::move(calc)) {
     static_assert(std::is_base_of<Event<T>, EventType>::value,
                   "EventType must be a descendant of Event");
     DRAKE_DEMAND(system);


### PR DESCRIPTION
* Adds the ability to get a mutable discrete state vector directly from the context.

* Adds the ability to declare witness functions using lambdas, which is useful if the same witness function may be called using different arguments (like contact points).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8656)
<!-- Reviewable:end -->
