### PR TITLE
pydrake common_test: Permit running via `bazel run`

### DIFF
--- a/bindings/pydrake/test/common_test.py
+++ b/bindings/pydrake/test/common_test.py
@@ -30,5 +30,10 @@ class TestCommon(unittest.TestCase):
             )
 
     def test_temp_directory(self):
-        self.assertEqual(os.environ.get('TEST_TMPDIR'),
-                         pydrake.common.temp_directory())
+        bazel_test_tmpdir = os.environ.get('TEST_TMPDIR')
+        drake_tmpdir = pydrake.common.temp_directory()
+        if bazel_test_tmpdir is not None:
+            self.assertEqual(bazel_test_tmpdir, drake_tmpdir)
+        else:
+            self.assertTrue(
+                drake_tmpdir.startswith('/tmp/robotlocomotion_drake_'))


### PR DESCRIPTION
This allows running `common_test` via `bazel run`; as of #8471, it would fail under `bazel run` because `TEST_TMPDIR` was not defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8658)
<!-- Reviewable:end -->
