### PR TITLE
pydrake cpp_template: Add decorator for ease of defining instantiations

### DIFF
--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -108,15 +108,19 @@ class TemplateBase(object):
         """Adds a set of instantiations given a function and a list of
         parameter sets.
 
-        @param instantiation_func Function of the form `f(param)`, where
-        `param` is the parameter set for the current instantiation.
+        @param instantiation_func Function of the form `f(template, param)`,
+        where `template` is the current template and `param` is the parameter
+        set for the current instantiation.
         @param param_list Ordered container of parameter sets to produce
         instantiations. This list will be iterated through, the wrapped
         function will be called, and the inner method will return a class (or
         method).
         """
+        # N.B. The `template` argument is added for decorators, where
+        # instantiations may want to refer to the template before the decorator
+        # has returned.
         for param in param_list:
-            self.add_instantiation(param, instantiation_func(param))
+            self.add_instantiation(param, instantiation_func(self, param))
 
     def get_param_set(self, instantiation):
         """Returns all parameters for a given `instantiation`.
@@ -175,8 +179,9 @@ class TemplateBase(object):
         `MyTemplate[int]` when `param=(int,)`.
 
         Example:
+
         @TemplateClass.define("MyTemplate", param_list=[(int,), (float,)])
-        def MyTemplate(param):
+        def MyTemplate(template, param):
             T, = param
             class MyTemplateInstantiation(object):
                 def __init__(self):
@@ -185,9 +190,9 @@ class TemplateBase(object):
         """
 
         def decorator(instantiation_func):
-            tpl = cls(name, *args, **kwargs)
-            tpl.add_instantiations(instantiation_func, param_list)
-            return tpl
+            template = cls(name, *args, **kwargs)
+            template.add_instantiations(instantiation_func, param_list)
+            return template
 
         return decorator
 

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -97,6 +97,26 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEquals(str(DummyB), "<class '{}.ClassTpl[float]'>".format(
             _TEST_MODULE))
 
+    def test_user_class(self):
+
+        @m.TemplateClass.define("MyTemplate", param_list=((int,), (float,)))
+        def MyTemplate(param):
+            T, = param
+
+            class MyTemplateInstantiation(object):
+                def __init__(self):
+                    self.T = T
+
+            return MyTemplateInstantiation
+
+        self.assertIsInstance(MyTemplate, m.TemplateClass)
+        MyDefault = MyTemplate[None]
+        MyInt = MyTemplate[int]
+        self.assertEqual(MyDefault, MyInt)
+        self.assertEqual(MyInt().T, int)
+        MyFloat = MyTemplate[float]
+        self.assertEqual(MyFloat().T, float)
+
     def test_function(self):
         template = m.TemplateFunction("func")
 

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -74,7 +74,8 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEquals(template[[int, int]], 3)
 
         # List instantiation.
-        def instantiation_func(param):
+        def instantiation_func(template, param):
+            self.assertIsInstance(template, m.TemplateBase)
             return 100 + len(param)
         dummy_a = (str,) * 5
         dummy_b = (str,) * 10
@@ -100,7 +101,7 @@ class TestCppTemplate(unittest.TestCase):
     def test_user_class(self):
 
         @m.TemplateClass.define("MyTemplate", param_list=((int,), (float,)))
-        def MyTemplate(param):
+        def MyTemplate(_, param):
             T, = param
 
             class MyTemplateInstantiation(object):


### PR DESCRIPTION
Towards defining user classes with scalar type conversion, etc, in parallel with #8665.

\cc @gizatt @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8666)
<!-- Reviewable:end -->
