### PR TITLE
Provide macOS stubs for @blas and @lapack

### DIFF
--- a/tools/workspace/README.md
+++ b/tools/workspace/README.md
@@ -157,7 +157,7 @@ it into Drake are roughly:
 
 ## When using a library from the host operating system
 
-See `blas` or `glib` for examples.
+See `glib` for an example.
 
 Update the package setup lists to mention the new package:
 

--- a/tools/workspace/blas/package-macos.BUILD.bazel
+++ b/tools/workspace/blas/package-macos.BUILD.bazel
@@ -1,0 +1,9 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+# On macOS, no targets should depend on @blas.
+cc_library(
+    name = "blas",
+    srcs = ["missing-macos.cc"],
+)

--- a/tools/workspace/blas/repository.bzl
+++ b/tools/workspace/blas/repository.bzl
@@ -1,17 +1,36 @@
 # -*- mode: python -*-
 
 load(
+    "@drake//tools/workspace:os.bzl",
+    "determine_os",
+)
+load(
     "@drake//tools/workspace:pkg_config.bzl",
-    "pkg_config_repository",
+    "setup_pkg_config_repository",
 )
 
-def blas_repository(
-        name,
-        licenses = ["notice"],  # BSD-3-Clause
-        modname = "blas",
-        **kwargs):
-    pkg_config_repository(
-        name = name,
-        licenses = licenses,
-        modname = modname,
-        **kwargs)
+def _impl(repo_ctx):
+    # On Ubuntu, we'll use use pkg-config to find libblas.
+    # On macOS, no targets should depend on @blas.
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_ubuntu:
+        error = setup_pkg_config_repository(repo_ctx).error
+        if error != None:
+            fail(error)
+    else:
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/blas:package-macos.BUILD.bazel"),
+            "BUILD.bazel")
+
+blas_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
+    # The license for this package should be:
+    #    licenses(["notice"])  # BSD-3-Clause
+    attrs = {
+        "modname": attr.string(default = "blas"),
+    },
+    local = True,
+    implementation = _impl,
+)

--- a/tools/workspace/lapack/package-macos.BUILD.bazel
+++ b/tools/workspace/lapack/package-macos.BUILD.bazel
@@ -1,0 +1,9 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+# On macOS, no targets should depend on @lapack.
+cc_library(
+    name = "lapack",
+    srcs = ["missing-macos.cc"],
+)

--- a/tools/workspace/lapack/repository.bzl
+++ b/tools/workspace/lapack/repository.bzl
@@ -1,17 +1,36 @@
 # -*- mode: python -*-
 
 load(
+    "@drake//tools/workspace:os.bzl",
+    "determine_os",
+)
+load(
     "@drake//tools/workspace:pkg_config.bzl",
-    "pkg_config_repository",
+    "setup_pkg_config_repository",
 )
 
-def lapack_repository(
-        name,
-        licenses = ["notice"],  # BSD-3-Clause
-        modname = "lapack",
-        **kwargs):
-    pkg_config_repository(
-        name = name,
-        licenses = licenses,
-        modname = modname,
-        **kwargs)
+def _impl(repo_ctx):
+    # On Ubuntu, we'll use use pkg-config to find liblapack.
+    # On macOS, no targets should depend on @lapack.
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_ubuntu:
+        error = setup_pkg_config_repository(repo_ctx).error
+        if error != None:
+            fail(error)
+    else:
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/lapack:package-macos.BUILD.bazel"),
+            "BUILD.bazel")
+
+lapack_repository = repository_rule(
+    # TODO(jamiesnape): Pass down licenses to setup_pkg_config_repository.
+    # The license for this package should be:
+    #    licenses(["notice"])  # BSD-3-Clause
+    attrs = {
+        "modname": attr.string(default = "lapack"),
+    },
+    local = True,
+    implementation = _impl,
+)


### PR DESCRIPTION
On macOS we should never use `@blas` and `@lapack`, but in order for `bazel query` to succeed, all branches of `select()` statements need to resolve, so because Ubuntu has real `@blas` and `@lapack`, we need to stub these out on macOS.  The stubs merely have to load -- the library targets do not need to (and should not) compile successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8667)
<!-- Reviewable:end -->
