### PR TITLE
Disable multi-sampling because of NVidia driver bug

### DIFF
--- a/systems/sensors/rgbd_renderer_vtk.cc
+++ b/systems/sensors/rgbd_renderer_vtk.cc
@@ -385,6 +385,12 @@ RgbdRendererVTK::Impl::Impl(RgbdRendererVTK* parent,
 
     pipeline->window->SetSize(parent_->config().width,
                               parent_->config().height);
+    // Disable multi sampling that has a bug with on-screen rendering
+    // with NVidia drivers on Ubuntu 16.04: In certain very specific
+    // cases (camera position, scene, triangle drawing order, normal
+    // orientation), a plain surface has partial background pixels
+    // bleeding through it which changes ever so slightly its color.
+    pipeline->window->SetMultiSamples(0);
     pipeline->window->AddRenderer(pipeline->renderer.GetPointer());
     pipeline->filter->SetInput(pipeline->window.GetPointer());
 #if VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 0


### PR DESCRIPTION
Disable multi-sampling that has a bug with on-screen rendering with NVidia
drivers on Ubuntu 16.04: In certain very specific cases (camera position,
scene, triangle drawing order, normal orientation), a plain surface has
partial background pixels  bleeding through it which changes ever so
slightly its color.