### PR TITLE
Add test for "Find test resources in runfiles" 

### DIFF
--- a/automotive/maliput/dragway/dragway_to_urdf.cc
+++ b/automotive/maliput/dragway/dragway_to_urdf.cc
@@ -65,8 +65,7 @@ int exec(int argc, char* argv[]) {
   // The following is necessary for users to know where to find the resulting
   // files when this program is executed in a sandbox. This occurs, for example
   // when using `bazel run //automotive/maliput/dragway:dragway_to_urdf`.
-  spruce::path my_path;
-  my_path.setAsCurrent();
+  const spruce::path my_path = spruce::dir::getcwd();
 
   drake::log()->info("Creating Dragway URDF in {}.", my_path.getStr());
   utility::GenerateUrdfFile(&road_geometry, directory.getStr(),

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -190,8 +190,7 @@ optional<string> GetTestRunfilesDir() {
 // path element, or possibly a related name like "drake2"; that is, they will
 // contain files named like "common/foo.txt", not "drake/common/foo.txt".
 optional<string> FindSentinelDir() {
-  spruce::path candidate_dir;
-  candidate_dir.setAsCurrent();
+  spruce::path candidate_dir = spruce::dir::getcwd();
   int num_attempts = 0;
   while (true) {
     DRAKE_THROW_UNLESS(num_attempts < 1000);  // Insanity fail-fast.

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -124,9 +124,7 @@ GTEST_TEST(ZZZ_FindResourceTest, ZZZ_AlternativeDirectory) {
   // Test `AddResourceSearchPath()` and `GetResourceSearchPaths()` by creating
   // an empty file in a scratch directory with a sentinel file. Bazel tests are
   // run in a scratch directory, so we don't need to remove anything manually.
-  spruce::path cwd;
-  cwd.setAsCurrent();
-  const std::string test_directory = cwd.getStr() +
+  const std::string test_directory = spruce::dir::getcwd().getStr() +
                                      "/find_resource_test_scratch";
   const std::string candidate_filename = "drake/candidate.ext";
   spruce::dir::mkdir(test_directory);

--- a/common/test/find_resource_test.cc
+++ b/common/test/find_resource_test.cc
@@ -1,6 +1,9 @@
 #include "drake/common/find_resource.h"
 
+#include <cstdlib>
 #include <fstream>
+#include <functional>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -8,7 +11,9 @@
 #include <gtest/gtest.h>
 #include <spruce.hh>
 
+#include "drake/common/drake_assert.h"
 #include "drake/common/drake_path.h"
+#include "drake/common/drake_throw.h"
 
 using std::string;
 
@@ -93,6 +98,64 @@ GTEST_TEST(FindResourceTest, RelativeResourcePathShouldFail) {
   // fail.
   const std::string test_directory = "find_resource_test_scratch";
   EXPECT_THROW(AddResourceSearchPath(test_directory), std::runtime_error);
+}
+
+optional<std::string> GetEnv(const std::string& name) {
+  const char* result = ::getenv(name.c_str());
+  if (!result) { return nullopt; }
+  return std::string(result);
+}
+
+void SetEnv(const std::string& name, const optional<std::string>& value) {
+  if (value) {
+    const int result = ::setenv(name.c_str(), value->c_str(), 1);
+    DRAKE_THROW_UNLESS(result == 0);
+  } else {
+    const int result = ::unsetenv(name.c_str());
+    DRAKE_THROW_UNLESS(result == 0);
+  }
+}
+
+// Make a scope exit guard -- an object that when destroyed runs `func`.
+auto MakeGuard(std::function<void()> func) {
+  // The shared_ptr deleter func is always invoked, even for nullptrs.
+  // http://en.cppreference.com/w/cpp/memory/shared_ptr/%7Eshared_ptr
+  return std::shared_ptr<void>(nullptr, [=](void*) { func(); });
+}
+
+GTEST_TEST(FindResourceTest, FindUsingTestSrcdir) {
+  // Confirm that the resource is found normally.
+  const string relpath = "drake/common/test/find_resource_test_data.txt";
+  EXPECT_TRUE(FindResource(relpath).get_absolute_path());
+
+  // If we defeat both (1) the "look in current working directory" heuristic
+  // and (2) the "look in TEST_SRCDIR" heuristic, then we should no longer be
+  // able to find the resource.
+
+  // Change cwd to be "/", but put it back when this test case ends.
+  const spruce::path original_cwd = spruce::dir::getcwd();
+  auto restore_cwd_guard = MakeGuard([original_cwd]() {
+      const bool restore_ok = spruce::dir::chdir(original_cwd);
+      DRAKE_DEMAND(restore_ok);
+    });
+  const bool chdir_ok = spruce::dir::chdir(spruce::path("/"));
+  ASSERT_TRUE(chdir_ok);
+
+  // Unset TEST_SRCDIR for a moment, and confirm that FindResource now fails.
+  const std::string original_test_srcdir = GetEnv("TEST_SRCDIR").value_or("");
+  ASSERT_FALSE(original_test_srcdir.empty());
+  {
+    auto restore_test_srcdir_guard = MakeGuard([original_test_srcdir]() {
+        SetEnv("TEST_SRCDIR", original_test_srcdir);
+      });
+    SetEnv("TEST_SRCDIR", nullopt);
+
+    // Can't find the resource anymore.
+    EXPECT_TRUE(FindResource(relpath).get_error_message());
+  }
+
+  // Having TEST_SRCDIR back again is enough to get us working.
+  EXPECT_TRUE(FindResource(relpath).get_absolute_path());
 }
 
 GTEST_TEST(GetDrakePathTest, BasicTest) {

--- a/multibody/parsers/parser_common.cc
+++ b/multibody/parsers/parser_common.cc
@@ -51,8 +51,7 @@ string GetFullPath(const string& file_name) {
   } else {
     // The specified file is a relative path. The following code obtains the
     // full path and verifies that the file exists.
-    spruce::path path(".");
-    path.setAsCurrent();
+    spruce::path path = spruce::dir::getcwd();
     path.append(file_name);
     if (path.isFile()) {
       result = path.getStr();
@@ -127,8 +126,7 @@ string ResolveFilename(const string& filename, const PackageMap& package_map,
     bool dir_is_relative =
         !(normalized_root_dir.size() >= 1 && normalized_root_dir[0] == '/');
     if (dir_is_relative) {
-      mesh_filename_spruce = spruce::path();
-      mesh_filename_spruce.setAsCurrent();
+      mesh_filename_spruce = spruce::dir::getcwd();
       mesh_filename_spruce.append(normalized_root_dir);
     } else {
       mesh_filename_spruce = spruce::path(normalized_root_dir);

--- a/third_party/josephdavisco_spruce/spruce.cc
+++ b/third_party/josephdavisco_spruce/spruce.cc
@@ -398,6 +398,10 @@ bool spruce::dir::rename(const spruce::path& source, const spruce::path& dest) {
     dir::chdir
 ---------------------------------------------------------*/
 bool spruce::dir::chdir(const spruce::path& p) {
-  if (SPRUCE_CHDIR((p.getStr()).c_str()) != 0) return false;
+  std::string target = p.getStr();
+  if (target.empty()) {  // Empty denotes the root folder.
+    target = "/";
+  }
+  if (SPRUCE_CHDIR(target.c_str()) != 0) return false;
   return true;
 }

--- a/third_party/josephdavisco_spruce/spruce.cc
+++ b/third_party/josephdavisco_spruce/spruce.cc
@@ -405,3 +405,9 @@ bool spruce::dir::chdir(const spruce::path& p) {
   if (SPRUCE_CHDIR(target.c_str()) != 0) return false;
   return true;
 }
+
+spruce::path spruce::dir::getcwd() {
+  spruce::path result;
+  result.setAsCurrent();
+  return result;
+}

--- a/third_party/josephdavisco_spruce/spruce.hh
+++ b/third_party/josephdavisco_spruce/spruce.hh
@@ -96,6 +96,8 @@ bool rename( const spruce::path& source, const spruce::path& dest );
 
 bool chdir( const spruce::path& p );
 
+spruce::path getcwd();
+
 }
 
 }


### PR DESCRIPTION
This belatedly adds a test for dfcd66a from #8255.  Closes #8266.  (It turns out that the install-testing framework did not end up being relevant.  Oops.)

To make path manipulation less awkward, this PR also improves some of the spruce primitives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8669)
<!-- Reviewable:end -->
