### PR TITLE
Increase simulated_schunk_wsg_system_test timeout to moderate

### DIFF
--- a/examples/schunk_wsg/BUILD.bazel
+++ b/examples/schunk_wsg/BUILD.bazel
@@ -85,6 +85,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "simulated_schunk_wsg_system_test",
+    timeout = "moderate",
     data = [
         "//manipulation/models/wsg_50_description:models",
     ],


### PR DESCRIPTION
Fixes timeouts in all nightly Valgrind jobs (typical runtime is 1100-1300s seconds for that test, `short` timeout is 1200s, `moderate` timeout is 6000s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8670)
<!-- Reviewable:end -->
