### PR TITLE
Increase symbolic_polynomial_test timeout to moderate

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -891,6 +891,8 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "symbolic_polynomial_test",
+    # Test timeout increased to not timeout when run with AddressSanitizer.
+    timeout = "moderate",
     deps = [
         ":symbolic",
         "//common/test_utilities:symbolic_test_util",


### PR DESCRIPTION
Usually takes less than 120s with ASan, but I did not leave enough margin for error, it seems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8675)
<!-- Reviewable:end -->
