### PR TITLE
[Multilane] Adds continuity constraints into the loader

### DIFF
--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -60,15 +60,23 @@ class StartReference {
 
   /// Builds a Spec at `connection`'s `end` side with `direction` direction.
   /// When `direction` == `Direction::kReverse`, `endpoint` is reversed.
+  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
+  /// continuity constraints.
   Spec at(const Connection& connection, api::LaneEnd::Which end,
           Direction direction) const {
-    const Endpoint endpoint = end == api::LaneEnd::Which::kStart
-                                  ? connection.start()
-                                  : connection.end();
+    Endpoint endpoint = end == api::LaneEnd::Which::kStart ? connection.start()
+                                                           : connection.end();
+    endpoint.get_mutable_z().get_mutable_theta_dot() = {};
     return direction == Direction::kForward ? Spec(endpoint)
                                             : Spec(endpoint.reverse());
   }
 };
+
+/// Streams a string representation of `start_spec` into `out`. Returns `out`.
+/// This method is provided for the purposes of debugging or text-logging.
+/// It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out,
+                         const StartReference::Spec& start_spec);
 
 /// Provides methods to build an EndReference::Spec.
 class EndReference {
@@ -102,11 +110,14 @@ class EndReference {
   /// Builds a Spec at `connection`'s `end` side with `direction` direction.
   /// When `direction` == `Direction::kReverse`, `end`-side endpoint's
   /// EndpointZ is reversed.
+  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
+  /// continuity constraints.
   Spec z_at(const Connection& connection, api::LaneEnd::Which end,
             Direction direction) const {
-    const EndpointZ endpoint_z = end == api::LaneEnd::Which::kStart
-                                     ? connection.start().z()
-                                     : connection.end().z();
+    EndpointZ endpoint_z = end == api::LaneEnd::Which::kStart
+                               ? connection.start().z()
+                               : connection.end().z();
+    endpoint_z.get_mutable_theta_dot() = {};
     return direction == Direction::kForward ? Spec(endpoint_z)
                                             : Spec(endpoint_z.reverse());
   }
@@ -118,6 +129,11 @@ class EndReference {
                                             : Spec(endpoint_z.reverse());
   }
 };
+
+/// Streams a string representation of `end_spec` into `out`. Returns `out`.
+/// This method is provided for the purposes of debugging or text-logging.
+/// It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out, const EndReference::Spec& end_spec);
 
 /// Wraps all the lane-related specifications in a Connection.
 class LaneLayout {

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -15,8 +15,11 @@ std::ostream& operator<<(std::ostream& out, const EndpointXy& endpoint_xy) {
 
 std::ostream& operator<<(std::ostream& out, const EndpointZ& endpoint_z) {
   return out << "(z = " << endpoint_z.z() << ", z_dot = " << endpoint_z.z_dot()
-             << ", theta = " << endpoint_z.theta()
-             << ", theta_dot = " << endpoint_z.theta_dot() << ")";
+             << ", theta = " << endpoint_z.theta() << ", theta_dot = "
+             << (endpoint_z.theta_dot().has_value()
+                     ? std::to_string(*endpoint_z.theta_dot())
+                     : std::string("nullopt"))
+             << ")";
 }
 
 std::ostream& operator<<(std::ostream& out, const Endpoint& endpoint) {
@@ -35,7 +38,7 @@ std::ostream& operator<<(std::ostream& out, const ArcOffset& arc_offset) {
 Connection::Connection(const std::string& id, const Endpoint& start,
                        const EndpointZ& end_z, int num_lanes, double r0,
                        double lane_width, double left_shoulder,
-                       double right_shoulder, double line_length,
+                       double right_shoulder, const LineOffset& line_offset,
                        double linear_tolerance, double scale_length,
                        ComputationPolicy computation_policy)
     : type_(kLine),
@@ -52,7 +55,7 @@ Connection::Connection(const std::string& id, const Endpoint& start,
       linear_tolerance_(linear_tolerance),
       scale_length_(scale_length),
       computation_policy_(computation_policy),
-      line_length_(line_length) {
+      line_length_(line_offset.length()) {
   DRAKE_DEMAND(num_lanes_ > 0);
   DRAKE_DEMAND(lane_width_ >= 0);
   DRAKE_DEMAND(left_shoulder_ >= 0);
@@ -153,9 +156,10 @@ Endpoint Connection::LaneStart(int lane_index) const {
   // theta_dot is derivative with respect to t, but the reference curve t
   // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
   // coordinate and t_i the arc-length xy projection for lane_index lane.
-  const double theta_dot = type_ == kLine ?
-      start_.z().theta_dot() :
-      start_.z().theta_dot() * std::abs(d_theta_ * radius_) / planar_length;
+  const double theta_dot = type_ == kLine ? *start_.z().theta_dot()
+                                          : (*start_.z().theta_dot()) *
+                                                std::abs(d_theta_ * radius_) /
+                                                planar_length;
   return Endpoint({position[0], position[1], rotation.yaw()},
                   {position[2], z_dot, start_.z().theta(), theta_dot});
 }
@@ -192,9 +196,10 @@ Endpoint Connection::LaneEnd(int lane_index) const {
   // theta_dot is derivative with respect to t, but the reference curve t
   // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
   // coordinate and t_i the arc-length xy projection for lane_index lane.
-  const double theta_dot = type_ == kLine ?
-      end_.z().theta_dot() :
-      end_.z().theta_dot() * std::abs(d_theta_ * radius_) / planar_length;
+  const double theta_dot = type_ == kLine ? *end_.z().theta_dot()
+                                          : (*end_.z().theta_dot()) *
+                                                std::abs(d_theta_ * radius_) /
+                                                planar_length;
   return Endpoint({position[0], position[1], rotation.yaw()},
                   {position[2], z_dot, end_.z().theta(), theta_dot});
 }
@@ -230,11 +235,8 @@ std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
           start_.z().z_dot(),
           end_.z().z_dot()));
       const CubicPolynomial superelevation(MakeCubic(
-          dxy.norm(),
-          start_.z().theta(),
-          end_.z().theta() - start_.z().theta(),
-          start_.z().theta_dot(),
-          end_.z().theta_dot()));
+          dxy.norm(), start_.z().theta(), end_.z().theta() - start_.z().theta(),
+          *start_.z().theta_dot(), *end_.z().theta_dot()));
       return std::make_unique<LineRoadCurve>(
           xy0, dxy, elevation, superelevation,
           linear_tolerance_, scale_length_,
@@ -250,11 +252,8 @@ std::unique_ptr<RoadCurve> Connection::CreateRoadCurve() const {
           start_.z().z_dot(),
           end_.z().z_dot()));
       const CubicPolynomial superelevation(MakeCubic(
-          arc_length,
-          start_.z().theta(),
-          end_.z().theta() - start_.z().theta(),
-          start_.z().theta_dot(),
-          end_.z().theta_dot()));
+          arc_length, start_.z().theta(), end_.z().theta() - start_.z().theta(),
+          *start_.z().theta_dot(), *end_.z().theta_dot()));
       return std::make_unique<ArcRoadCurve>(
           center, radius_, theta0_, d_theta_, elevation, superelevation,
           linear_tolerance_, scale_length_, computation_policy_);

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -47,42 +47,44 @@ GTEST_TEST(EndpointZTest, DefaultConstructor) {
   EXPECT_EQ(dut.z(), 0.);
   EXPECT_EQ(dut.z_dot(), 0.);
   EXPECT_EQ(dut.theta(), 0.);
-  EXPECT_EQ(dut.theta_dot(), 0.);
+  EXPECT_FALSE(dut.theta_dot().has_value());
 }
 
-GTEST_TEST(EndpointZTest, ParametrizedConstructor) {
-  const EndpointZ dut{1., 2., M_PI / 4., M_PI / 2.};
-  EXPECT_EQ(dut.z(), 1.);
-  EXPECT_EQ(dut.z_dot(), 2.);
-  EXPECT_EQ(dut.theta(), M_PI / 4.);
-  EXPECT_EQ(dut.theta_dot(), M_PI / 2.);
+GTEST_TEST(EndpointZTest, ParametrizedConstructors) {
+  const EndpointZ dut_without_theta_dot{1., 2., M_PI / 4., {}};
+  EXPECT_EQ(dut_without_theta_dot.z(), 1.);
+  EXPECT_EQ(dut_without_theta_dot.z_dot(), 2.);
+  EXPECT_EQ(dut_without_theta_dot.theta(), M_PI / 4.);
+  EXPECT_FALSE(dut_without_theta_dot.theta_dot().has_value());
+
+  const EndpointZ dut_with_theta_dot{1., 2., M_PI / 4., M_PI / 2.};
+  EXPECT_EQ(dut_with_theta_dot.z(), 1.);
+  EXPECT_EQ(dut_with_theta_dot.z_dot(), 2.);
+  EXPECT_EQ(dut_with_theta_dot.theta(), M_PI / 4.);
+  EXPECT_TRUE(dut_with_theta_dot.theta_dot().has_value());
+  EXPECT_EQ(*dut_with_theta_dot.theta_dot(), M_PI / 2.);
 }
 
 GTEST_TEST(EndpointZTest, Reverse) {
-  const EndpointZ dut{1., 2., M_PI / 4., M_PI / 2.};
   const double kZeroTolerance{0.};
-  EXPECT_TRUE(test::IsEndpointZClose(
-      dut.reverse(), {1., -2., -M_PI / 4., M_PI / 2.}, kZeroTolerance));
+  const EndpointZ dut_without_theta_dot{1., 2., M_PI / 4., {}};
+  EXPECT_TRUE(test::IsEndpointZClose(dut_without_theta_dot.reverse(),
+                                     {1., -2., -M_PI / 4., {}},
+                                     kZeroTolerance));
+
+  const EndpointZ dut_with_theta_dot{1., 2., M_PI / 4., M_PI / 2.};
+  EXPECT_TRUE(test::IsEndpointZClose(dut_with_theta_dot.reverse(),
+                                     {1., -2., -M_PI / 4., M_PI / 2.},
+                                     kZeroTolerance));
 }
 
-// LineOffset checks.
-GTEST_TEST(LineOffsetTest, DefaultConstructor) {
-  const LineOffset dut{};
-  EXPECT_EQ(dut.length(), 0.);
-}
-
+// LineOffset check.
 GTEST_TEST(LineOffsetTest, ParametrizedConstructor) {
   const LineOffset dut{123.456};
   EXPECT_EQ(dut.length(), 123.456);
 }
 
-// ArcOffset checks.
-GTEST_TEST(ArcOffsetTest, DefaultConstructor) {
-  const ArcOffset dut{};
-  EXPECT_EQ(dut.radius(), 0.);
-  EXPECT_EQ(dut.d_theta(), 0.);
-}
-
+// ArcOffset check.
 GTEST_TEST(ArcOffsetTest, ParametrizedConstructor) {
   const ArcOffset dut{1., M_PI / 4.};
   EXPECT_EQ(dut.radius(), 1.);
@@ -151,8 +153,9 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
 
   const double kLineLength{30. * std::sqrt(2.)};
+  const LineOffset kLineOffset{kLineLength};
   const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
-                       kLaneWidth, kLeftShoulder, kRightShoulder, kLineLength,
+                       kLaneWidth, kLeftShoulder, kRightShoulder, kLineOffset,
                        kLinearTolerance, kScaleLength, kComputationPolicy);
   EXPECT_EQ(dut.type(), Connection::Type::kLine);
   EXPECT_EQ(dut.id(), kId);
@@ -294,9 +297,10 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
   const std::string kId{"line_connection"};
   const Endpoint kEndEndpoint{{50., 0., kHeading}, kLowFlatZ};
   const double kLineLength{30. * std::sqrt(2.)};
+  const LineOffset kLineOffset{kLineLength};
   const Connection flat_dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                             kLaneWidth, kLeftShoulder, kRightShoulder,
-                            kLineLength, kLinearTolerance, kScaleLength,
+                            kLineOffset, kLinearTolerance, kScaleLength,
                             kComputationPolicy);
   std::unique_ptr<RoadCurve> road_curve = flat_dut.CreateRoadCurve();
   EXPECT_NE(dynamic_cast<LineRoadCurve*>(road_curve.get()), nullptr);
@@ -341,7 +345,7 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
                                       {5., 1., M_PI / 6., 1.}};
   const Connection complex_dut(kId, kStartEndpoint, kEndElevatedEndpoint.z(),
                                kNumLanes, kR0, kLaneWidth, kLeftShoulder,
-                               kRightShoulder, kLineLength, kLinearTolerance,
+                               kRightShoulder, kLineOffset, kLinearTolerance,
                                kScaleLength, kComputationPolicy);
   std::unique_ptr<RoadCurve> complex_road_curve = complex_dut.CreateRoadCurve();
 
@@ -473,8 +477,8 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
         {kCenterX + start_radius * std::cos(kTheta0),
          kCenterY + start_radius * std::sin(kTheta0),
          wrap(kTheta0 + M_PI / 2.)},
-        {start_z.z(), start_z.z_dot() * kRadius / start_radius,
-         start_z.theta(), start_z.theta_dot() * kRadius / start_radius}};
+        {start_z.z(), start_z.z_dot() * kRadius / start_radius, start_z.theta(),
+         (*start_z.theta_dot()) * kRadius / start_radius}};
     EXPECT_TRUE(
         test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
     // End endpoints.
@@ -485,8 +489,8 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
         {kCenterX + end_radius * std::cos(kTheta0 + kDTheta),
          kCenterY + end_radius * std::sin(kTheta0 + kDTheta),
          wrap(kTheta0 + kDTheta + M_PI / 2.)},
-        {end_z.z(), end_z.z_dot() * kRadius / end_radius,
-         end_z.theta(), end_z.theta_dot() * kRadius / end_radius}};
+        {end_z.z(), end_z.z_dot() * kRadius / end_radius, end_z.theta(),
+         (*end_z.theta_dot()) * kRadius / end_radius}};
     EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
   }
 }
@@ -494,8 +498,9 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
 TEST_P(MultilaneConnectionEndpointZTest, LineLaneEndpoints) {
   const std::string kId{"line_connection"};
   const double kLineLength{25. * std::sqrt(2.)};
+  const LineOffset kLineOffset{kLineLength};
   const Connection dut(kId, start_endpoint, end_z, num_lanes, r0, kLaneWidth,
-                       kLeftShoulder, kRightShoulder, kLineLength,
+                       kLeftShoulder, kRightShoulder, kLineOffset,
                        kLinearTolerance, kScaleLength, kComputationPolicy);
   const Vector2<double> kDirection{45. - kStartXy.x(), 5. - kStartXy.y()};
   const Vector2<double> kNormalDirection =

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -90,16 +90,28 @@ namespace test {
                     ", tolerance = " +
                     std::to_string(tolerance) + "\n";
   }
-  delta = std::abs(z1.theta_dot() - z2.theta_dot());
-  if (delta > tolerance) {
+  if (z1.theta_dot().has_value() && z2.theta_dot().has_value()) {
+    delta = std::abs(*z1.theta_dot() - *z2.theta_dot());
+    if (delta > tolerance) {
+      fails = true;
+      error_message =
+          error_message + "EndpointZ are different at theta_dot. " +
+          "z1.theta_dot(): " + std::to_string(*z1.theta_dot()) +
+          " vs. z2.theta_dot(): " + std::to_string(*z2.theta_dot()) +
+          ", diff = " + std::to_string(delta) +
+          ", tolerance = " + std::to_string(tolerance) + "\n";
+    }
+  } else if (z1.theta_dot().has_value() && !z2.theta_dot().has_value()) {
     fails = true;
-    error_message = error_message +
-                    "EndpointZ are different at theta_dot. " +
-                    "z1.theta_dot(): " + std::to_string(z1.theta_dot()) +
-                    " vs. z2.theta_dot(): " + std::to_string(z2.theta_dot()) +
-                    ", diff = " + std::to_string(delta) +
-                    ", tolerance = " + std::to_string(tolerance) + "\n";
+    error_message = error_message + "EndpointZ are different at theta_dot. " +
+                    "z1.theta_dot() has value but z2.theta_dot does not.\n";
+  } else if (!z1.theta_dot().has_value() && z2.theta_dot().has_value()) {
+    fails = true;
+    error_message = error_message + "EndpointZ are different at theta_dot. " +
+                    "z1.theta_dot() does not have a value but " +
+                    "z2.theta_dot does.\n";
   }
+
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
@@ -155,7 +155,7 @@ class LineOffsetMatcher : public MatcherInterface<const LineOffset&> {
   }
 
  private:
-  const LineOffset line_offset_{};
+  const LineOffset line_offset_;
   const double tolerance_{};
 };
 
@@ -218,8 +218,8 @@ class StartReferenceSpecMatcher
   }
 
   void DescribeTo(std::ostream* os) const override {
-    *os << "is within tolerance: [" << tolerance_ << "] of start_reference: [{"
-        << start_reference_.endpoint() << "}].";
+    *os << "is within tolerance: [" << tolerance_ << "] of start_reference: ["
+        << start_reference_ << "].";
   }
 
  private:
@@ -247,8 +247,8 @@ class EndReferenceSpecMatcher
   }
 
   void DescribeTo(std::ostream* os) const override {
-    *os << "is within tolerance: [" << tolerance_ << "] of end_reference: [{"
-        << end_reference_.endpoint_z() << "}].";
+    *os << "is within tolerance: [" << tolerance_ << "] of end_reference: ["
+        << end_reference_ << "].";
   }
 
  private:


### PR DESCRIPTION
This PR goes on top of #8302.

In this PR you'll find:

- `EndpointZ::theta_dot`'s type is changed from `double` to `drake::optional<double>`.
- Forces a continuity constraint to match two roads connecting road curves.
- Modifies the loader to identify if a start or end point belongs to either a reference curve or a lane curve.
- Modifies loader tests to provide code coverage to the continuity constraint involved.

A follow up PR will provide Builder support to build lane-connected segments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8676)
<!-- Reviewable:end -->
