### PR TITLE
[Maliput] Utility OBJ Parser

### DIFF
--- a/automotive/maliput/multilane/circuit.yaml
+++ b/automotive/maliput/multilane/circuit.yaml
@@ -1,0 +1,105 @@
+# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+maliput_multilane_builder:
+  id: "circuit"
+  lane_width: 5
+  left_shoulder: 1
+  right_shoulder: 1.5
+  elevation_bounds: [0, 5]
+  linear_tolerance: 0.01
+  angular_tolerance: 0.5
+  points:
+    a:
+      xypoint: [0, 0, 0]
+      zpoint: [0, 0, 0, 0]
+    b:
+      xypoint: [50, 5, 0]
+      zpoint: [0, 0, 0, 0]
+  connections:
+    s1:
+      lanes: [3, 0, 0]
+      start: ["ref", "points.a.forward"]
+      length: 50
+      z_end: ["ref", [0, 0, 0, 0]]
+    s2:
+      lanes: [1, 0, 10]
+      start: ["ref", "connections.s1.end.ref.forward"]
+      arc: [20, 180]
+      z_end: ["ref", [0, 0, 0, 0]]
+    s3:
+      lanes: [1, 0, 10]
+      start: ["ref", "connections.s2.end.ref.forward"]
+      length: 40
+      z_end: ["ref", [0, 0, 0, 0]]
+    s4:
+      lanes: [1, 0, 10]
+      right_shoulder: 0
+      start: ["ref", "connections.s3.end.ref.forward"]
+      length: 10
+      z_end: ["ref", [0, 0, 0, 0]]
+    s5:
+      lanes: [2, 0, 5]
+      start: ["ref", "connections.s4.end.ref.forward"]
+      arc: [20, 180]
+      explicit_end: ["ref", "connections.s1.start.ref.forward"]
+    s6:
+      lanes: [2, 0, -5]
+      start: ["ref", "points.b.forward"]
+      arc: [20, -180]
+      z_end: ["ref", [0, 0, 0, 0]]
+    s7:
+      lanes: [2, 0, -5]
+      start: ["ref", "connections.s6.end.ref.forward"]
+      length: 50
+      z_end: ["ref", [0, 0, 0, 0]]
+    s8:
+      lanes: [2, 0, -5]
+      start: ["ref", "connections.s7.end.ref.forward"]
+      arc: [20, -180]
+      z_end: ["ref", [0, 0, 0, 0]]
+    s9:
+      lanes: [1, 0, 0]
+      right_shoulder: 0
+      start: ["ref", "connections.s7.end.ref.forward"]
+      arc: [20, 30.5]
+      z_end: ["ref", [0, 0, 0, 0]]
+    s10:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s9.end.ref.forward"]
+      arc: [20, 59.5]
+      z_end: ["ref", [5, 0.5, -15, 0.7255]]
+    s11:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s10.end.ref.forward"]
+      arc: [20, 90]
+      z_end: ["ref", [10, 0, -15, 0]]
+    s12:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s11.end.ref.forward"]
+      arc: [20, 90]
+      z_end: ["ref", [10, 0, 0, 0]]
+    s13:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s12.end.ref.forward"]
+      length: 20
+      explicit_end: ["ref", "connections.s12.end.ref.forward"]
+    s14:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s13.end.ref.forward"]
+      length: 30
+      z_end: ["ref", [-10, 0, 0, 0]]
+    s15:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.s14.end.ref.forward"]
+      length: 20
+      z_end: ["ref", [-10, 0, 0, 0]]
+    s16:
+      lanes: [1, 0, 0]
+      left_shoulder: 0
+      start: ["ref", "connections.s15.end.ref.forward"]
+      arc: [20, 90]
+      z_end: ["ref", [0, 0, 0, 0]]
+  groups:
+    g1: [s2, s6]
+    g2: [s5, s9, s12]

--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -46,7 +46,9 @@ drake_cc_binary(
     deps = [
         ":utility",
         "//automotive/maliput/monolane",
+        "//automotive/maliput/multilane",
         "//common:text_logging_gflags",
+        "@yaml_cpp",
     ],
 )
 
@@ -112,6 +114,7 @@ drake_py_unittest(
     data = [
         ":yaml_to_obj",
         "//automotive/maliput/monolane:yamls",
+        "//automotive/maliput/multilane:yamls",
     ],
 )
 

--- a/automotive/maliput/utility/yaml_to_obj.cc
+++ b/automotive/maliput/utility/yaml_to_obj.cc
@@ -1,31 +1,62 @@
 /// @file yaml_to_obj.cc
 ///
-/// Take a yaml file as input, build the resulting monolane road geometry, and
-/// render the road surface to a WaveFront OBJ output file.
+/// Take a yaml file as input, build the resulting monolane or multilane road
+/// geometry, and render the road surface to a WaveFront OBJ output file.
 #include <string>
 
 #include <gflags/gflags.h>
+#include "yaml-cpp/yaml.h"
 
 #include "drake/automotive/maliput/monolane/loader.h"
+#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/loader.h"
 #include "drake/automotive/maliput/utility/generate_obj.h"
 #include "drake/common/text_logging.h"
 #include "drake/common/text_logging_gflags.h"
 
-namespace mono = drake::maliput::monolane;
-namespace utility = drake::maliput::utility;
-
 DEFINE_string(yaml_file, "",
-              "yaml input file defining a monolane road geometry");
+              "yaml input file defining a monolane or multilane road geometry");
 DEFINE_string(obj_dir, ".", "Directory to contain rendered road surface");
 DEFINE_string(obj_file, "",
               "Basename for output Wavefront OBJ and MTL files");
-DEFINE_double(max_grid_unit, utility::ObjFeatures().max_grid_unit,
-              "Maximum size of a grid unit in the rendered mesh covering the"
-              " road surface");
-DEFINE_double(min_grid_resolution, utility::ObjFeatures().min_grid_resolution,
-              "Minimum number of grid-units in either lateral or longitudinal"
-              " direction in the rendered mesh covering the road surface");
+DEFINE_double(max_grid_unit,
+              drake::maliput::utility::ObjFeatures().max_grid_unit,
+              "Maximum size of a grid unit in the rendered mesh covering the "
+              "road surface");
+DEFINE_double(min_grid_resolution,
+              drake::maliput::utility::ObjFeatures().min_grid_resolution,
+              "Minimum number of grid-units in either lateral or longitudinal "
+              "direction in the rendered mesh covering the road surface");
 
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace {
+
+// Available maliput implentations to load.
+enum class MaliputImplementation {
+  kMonolane,   //< monolane implementation.
+  kMultilane,  //< multilane implementation.
+  kUnknown     //< Used when none of the implementation could be identified.
+};
+
+// Parses a file whose path is `filename` as a YAML and looks for a node called
+// "maliput_multilane_builder" or "maliput_monolane_builder".
+// When the first key is found, MaliputImplementation::kMultilane is returned.
+// When the second key is found, MaliputImplementation::kMonolane is returned.
+// Otherwise, MaliputImplementation::kUnknown is returned.
+MaliputImplementation GetMaliputImplementation(const std::string& filename) {
+  const YAML::Node yaml_file = YAML::LoadFile(filename);
+  DRAKE_DEMAND(yaml_file.IsMap());
+  if (yaml_file["maliput_multilane_builder"]) {
+    return MaliputImplementation::kMultilane;
+  } else if (yaml_file["maliput_monolane_builder"]) {
+    return MaliputImplementation::kMonolane;
+  }
+  return MaliputImplementation::kUnknown;
+}
+
+// Generates an OBJ file from a YAML file path given as CLI argument.
 int main(int argc, char* argv[]) {
   drake::log()->debug("main()");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -40,16 +71,42 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  drake::log()->info("Loading road geometry.");
-  auto rg = mono::LoadFile(FLAGS_yaml_file);
-
+  drake::log()->info("Loading road geometry...");
+  std::unique_ptr<const drake::maliput::api::RoadGeometry> rg{};
+  switch (GetMaliputImplementation(FLAGS_yaml_file)) {
+    case MaliputImplementation::kMultilane: {
+      rg = drake::maliput::multilane::LoadFile(
+          drake::maliput::multilane::BuilderFactory(), FLAGS_yaml_file);
+      drake::log()->info("Loaded a multilane road geometry.");
+      break;
+    }
+    case MaliputImplementation::kMonolane: {
+      rg = drake::maliput::monolane::LoadFile(FLAGS_yaml_file);
+      drake::log()->info("Loaded a monolane road geometry.");
+      break;
+    }
+    default: {
+      drake::log()->error("Unknown map.");
+      DRAKE_ABORT();
+      break;
+    }
+  }
 
   utility::ObjFeatures features;
   features.max_grid_unit = FLAGS_max_grid_unit;
   features.min_grid_resolution = FLAGS_min_grid_resolution;
 
   drake::log()->info("Generating OBJ.");
-  utility::GenerateObjFile(rg.get(), FLAGS_obj_dir, FLAGS_obj_file, features);
+  GenerateObjFile(rg.get(), FLAGS_obj_dir, FLAGS_obj_file, features);
 
   return 0;
+}
+
+}  // namespace
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake
+
+int main(int argc, char* argv[]) {
+  return drake::maliput::utility::main(argc, argv);
 }


### PR DESCRIPTION
This PR modifies current `yaml_to_obj` utility to support both `multilane` and `monolane` yaml files. Generated OBJ meshes remain the same.

In addition, a new multilane sample is added. The output render should look like this:

![circuit](https://user-images.githubusercontent.com/3825465/39270033-20b062b2-48ab-11e8-9e9b-08b0092ca243.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8679)
<!-- Reviewable:end -->
