### PR TITLE
Make ViewerDrawTranslator use positions rather than state.

### DIFF
--- a/examples/valkyrie/test/valkyrie_ik_test.cc
+++ b/examples/valkyrie/test/valkyrie_ik_test.cc
@@ -259,11 +259,6 @@ GTEST_TEST(ValkyrieIK_Test, ValkyrieIK_Test_StandingPose_Test) {
   EXPECT_GT(com(2), 0);
 
   // show it in drake visualizer
-  VectorX<double> x = VectorX<double>::Zero(tree->get_num_positions() +
-                                            tree->get_num_velocities());
-  x.head(q_sol.size()) = q_sol;
-  systems::BasicVector<double> q_draw(x);
-
   lcm::DrakeLcm lcm;
 
   lcmt_viewer_load_robot load_msg =
@@ -272,7 +267,8 @@ GTEST_TEST(ValkyrieIK_Test, ValkyrieIK_Test_StandingPose_Test) {
 
   systems::ViewerDrawTranslator posture_drawer(*tree);
   std::vector<uint8_t> message_bytes;
-  posture_drawer.Serialize(0, q_draw, &message_bytes);
+  posture_drawer.Serialize(0, systems::BasicVector<double>{q_sol},
+                           &message_bytes);
   lcm.Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),
               message_bytes.size(), {});
 }

--- a/manipulation/util/simple_tree_visualizer.cc
+++ b/manipulation/util/simple_tree_visualizer.cc
@@ -30,15 +30,11 @@ SimpleTreeVisualizer::SimpleTreeVisualizer(const RigidBodyTreed& tree,
 
 void SimpleTreeVisualizer::visualize(const VectorX<double>& position_vector) {
   DRAKE_DEMAND(position_vector.size() == tree_.get_num_positions());
-  Eigen::VectorXd state = Eigen::VectorXd::Zero(state_dimension_);
-  state.head(tree_.get_num_positions()) = position_vector;
-  systems::BasicVector<double> state_vector(state_dimension_);
-
-  state_vector.SetFromVector(state);
 
   std::vector<uint8_t> message_bytes;
   constexpr double kTime = 0;
-  draw_message_translator_.Serialize(kTime, state_vector, &message_bytes);
+  draw_message_translator_.Serialize(
+      kTime, systems::BasicVector<double>{position_vector}, &message_bytes);
 
   // Publishes onto the specified LCM channel.
   lcm_->Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),

--- a/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/multibody/rigid_body_plant/drake_visualizer.cc
@@ -21,11 +21,13 @@ DrakeVisualizer::DrakeVisualizer(const RigidBodyTree<double>& tree,
                                  bool enable_playback)
     : lcm_(lcm),
       load_message_(multibody::CreateLoadRobotMessage<double>(tree)),
-      draw_message_translator_(tree) {
+      draw_message_translator_(tree),
+      tree_(tree) {
   set_name("drake_visualizer");
-  const int vector_size = tree.get_num_positions() + tree.get_num_velocities();
-  DeclareInputPort(kVectorValued, vector_size);
-  if (enable_playback) log_.reset(new SignalLog<double>(vector_size));
+  const int input_size = tree.get_num_positions() + tree.get_num_velocities();
+  DeclareInputPort(kVectorValued, input_size);
+  if (enable_playback)
+    log_.reset(new SignalLog<double>(tree.get_num_positions()));
 
   PublishEvent<double> init_event(
       Event<double>::TriggerType::kInitialization);
@@ -85,9 +87,10 @@ void DrakeVisualizer::PlaybackTrajectory(
   const double kFrameLength = 1 / 60.0;
   double sim_time = input_trajectory.start_time();
   TimePoint prev_time = Clock::now();
-  BasicVector<double> data(log_->get_input_size());
+  const int num_positions = tree_.get_num_positions();
+  BasicVector<double> data(num_positions);
   while (sim_time < input_trajectory.end_time()) {
-    data.set_value(input_trajectory.value(sim_time));
+    data.set_value(input_trajectory.value(sim_time).col(0).head(num_positions));
 
     // Translates the input vector into an array of bytes representing an LCM
     // message.
@@ -128,14 +131,15 @@ void DrakeVisualizer::DoPublish(
   // RigidBodyTree.
   const BasicVector<double>* input_vector =
       EvalVectorInput(context, kPortIndex);
+  const auto q = input_vector->get_value().head(tree_.get_num_positions());
   if (log_ != nullptr) {
-    log_->AddData(context.get_time(), input_vector->get_value());
+    log_->AddData(context.get_time(), q);
   }
 
   // Translates the input vector into an array of bytes representing an LCM
   // message.
   std::vector<uint8_t> message_bytes;
-  draw_message_translator_.Serialize(context.get_time(), *input_vector,
+  draw_message_translator_.Serialize(context.get_time(), BasicVector<double>{q},
                                      &message_bytes);
 
   // Publishes onto the specified LCM channel.

--- a/multibody/rigid_body_plant/drake_visualizer.h
+++ b/multibody/rigid_body_plant/drake_visualizer.h
@@ -139,6 +139,10 @@ class DrakeVisualizer : public LeafSystem<double> {
 
   // The (optional) log used for recording and playback.
   std::unique_ptr<SignalLog<double>> log_{nullptr};
+
+  // The RigidBodyTree with which the poses of each RigidBody can be
+  // determined given the state vector of the RigidBodyTree.
+  const RigidBodyTree<double>& tree_;
 };
 
 }  // namespace systems

--- a/multibody/rigid_body_plant/test/viewer_draw_translator_test.cc
+++ b/multibody/rigid_body_plant/test/viewer_draw_translator_test.cc
@@ -47,24 +47,24 @@ GTEST_TEST(ViewerDrawTranslatorTests, BasicTest) {
   // was just created. This is the "device under test."
   ViewerDrawTranslator viewer_draw_translator(*tree);
 
-  // Instantiates a generalized state vector containing all zeros. This is
+  // Instantiates a generalized position vector containing all zeros. This is
   // selected to make the resulting quaternion values be easily specified.
-  int num_states = tree->get_num_positions() + tree->get_num_velocities();
-  BasicVector<double> generalized_state(num_states);
-  generalized_state.set_value(Eigen::VectorXd::Zero(num_states));
+  int num_positions = tree->get_num_positions();
+  BasicVector<double> generalized_position(num_positions);
+  generalized_position.set_value(Eigen::VectorXd::Zero(num_positions));
 
   // Places body0 to be at location X = 1, Y = 2, Z = 3 with an orientation of
   // roll = PI.
-  generalized_state.SetAtIndex(0, 1);
-  generalized_state.SetAtIndex(1, 2);
-  generalized_state.SetAtIndex(2, 3);
-  generalized_state.SetAtIndex(3, M_PI);
+  generalized_position.SetAtIndex(0, 1);
+  generalized_position.SetAtIndex(1, 2);
+  generalized_position.SetAtIndex(2, 3);
+  generalized_position.SetAtIndex(3, M_PI);
 
   // Uses the `ViewerDrawTranslator` to convert the `BasicVector<double>` into
   // a byte array for a `drake::lcmt_viewer_draw` message.
   double time = 0;
   std::vector<uint8_t> message_bytes;
-  viewer_draw_translator.Serialize(time, generalized_state, &message_bytes);
+  viewer_draw_translator.Serialize(time, generalized_position, &message_bytes);
   EXPECT_GT(message_bytes.size(), 0u);
 
   // Verifies that the serialized message is correct. This entails:

--- a/multibody/rigid_body_plant/viewer_draw_translator.cc
+++ b/multibody/rigid_body_plant/viewer_draw_translator.cc
@@ -13,11 +13,8 @@ namespace systems {
 
 using std::runtime_error;
 
-ViewerDrawTranslator::ViewerDrawTranslator(
-    const RigidBodyTree<double>& tree) :
-    LcmAndVectorBaseTranslator(
-        tree.get_num_positions() + tree.get_num_velocities()),
-    tree_(tree) {
+ViewerDrawTranslator::ViewerDrawTranslator(const RigidBodyTree<double>& tree)
+    : LcmAndVectorBaseTranslator(tree.get_num_positions()), tree_(tree) {
   // Initializes the draw message.
   draw_message_.num_links = tree_.get_bodies().size();
   std::vector<float> position = {0, 0, 0};
@@ -52,8 +49,7 @@ void ViewerDrawTranslator::Serialize(double time,
   message.timestamp = static_cast<int64_t>(time * 1000);
 
   // Obtains the generalized positions from vector_base.
-  const Eigen::VectorXd q = vector_base.CopyToVector().head(
-      tree_.get_num_positions());
+  const Eigen::VectorXd q = vector_base.CopyToVector();
 
   // Computes the poses of each body.
   KinematicsCache<double> cache = tree_.doKinematics(q);

--- a/multibody/rigid_body_plant/viewer_draw_translator.h
+++ b/multibody/rigid_body_plant/viewer_draw_translator.h
@@ -15,7 +15,7 @@ namespace systems {
 /**
  * Specializes `LcmAndVectorBaseTranslator` to handle LCM messages of type
  * `drake::lcmt_viewer_draw`. It translates between a VectorBase<double> that
- * contains the state vector of a RigidBodyTree, and a
+ * contains the position vector of a RigidBodyTree, and a
  * `drake::lcmt_viewer_draw` message.
  */
 class ViewerDrawTranslator : public lcm::LcmAndVectorBaseTranslator {

--- a/perception/estimators/dev/test/articulated_icp_test.cc
+++ b/perception/estimators/dev/test/articulated_icp_test.cc
@@ -53,14 +53,7 @@ class ArticulatedIcpVisualizer : public PointCloudVisualizer {
     const ViewerDrawTranslator draw_msg_tx(scene_->tree());
     drake::lcmt_viewer_draw draw_msg{};
     vector<uint8_t> bytes;
-    const int num_q = scene_->tree().get_num_positions();
-    const int num_v = scene_->tree().get_num_velocities();
-    const int num_x = num_q + num_v;
-    BasicVector<double> x(num_x);
-    auto xb = x.get_mutable_value();
-    xb.setZero();
-    xb.head(num_q) = scene_state.q();
-    draw_msg_tx.Serialize(0, x, &bytes);
+    draw_msg_tx.Serialize(0, BasicVector<double>{scene_state.q()}, &bytes);
     lcm().Publish("DRAKE_VIEWER_DRAW", bytes.data(), bytes.size(), {});
   }
 


### PR DESCRIPTION
This cleans up a lot of our interactions with the class. Also modifies
DrakeVisualizer::PlaybackTrajectory() to accept either position or
(position, velocity) trajectories. As it stands, this will break any user code that calls `ViewerDrawTranslator` directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8683)
<!-- Reviewable:end -->
