### PR TITLE
Add python bindings for SimpleCarState

### DIFF
--- a/bindings/pydrake/automotive_py.cc
+++ b/bindings/pydrake/automotive_py.cc
@@ -76,7 +76,16 @@ PYBIND11_MODULE(automotive, m) {
            py_reference_internal);
 
   // TODO(eric.cousineau) Bind this named vector automatically (see #8096).
-  py::class_<SimpleCarState<T>, BasicVector<T>>(m, "SimpleCarState");
+  py::class_<SimpleCarState<T>, BasicVector<T>>(m, "SimpleCarState")
+      .def(py::init<>())
+      .def("x", &SimpleCarState<T>::x)
+      .def("y", &SimpleCarState<T>::y)
+      .def("heading", &SimpleCarState<T>::heading)
+      .def("velocity", &SimpleCarState<T>::velocity)
+      .def("set_x", &SimpleCarState<T>::set_x)
+      .def("set_y", &SimpleCarState<T>::set_y)
+      .def("set_heading", &SimpleCarState<T>::set_heading)
+      .def("set_velocity", &SimpleCarState<T>::set_velocity);
 
   py::class_<SimpleCar<T>, LeafSystem<T>>(m, "SimpleCar")
       .def(py::init<>())

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -105,6 +105,23 @@ class TestAutomotive(unittest.TestCase):
         self.assertEqual(len(steering.get_value()), 1)
         self.assertTrue(steering.get_value() < 0.)
 
+    def test_simple_car_state(self):
+        simple_car_state = SimpleCarState()
+        self.assertTrue(isinstance(simple_car_state, framework.BasicVector))
+        self.assertEqual(simple_car_state.size(), 4)
+        self.assertNotEqual(simple_car_state.x(), 5.)
+        simple_car_state.set_x(5.)
+        self.assertEqual(simple_car_state.x(), 5.)
+        self.assertNotEqual(simple_car_state.y(), 2.)
+        simple_car_state.set_y(2.)
+        self.assertEqual(simple_car_state.y(), 2.)
+        self.assertNotEqual(simple_car_state.heading(), 14.)
+        simple_car_state.set_heading(14.)
+        self.assertEqual(simple_car_state.heading(), 14.)
+        self.assertNotEqual(simple_car_state.velocity(), 52.)
+        simple_car_state.set_velocity(52.)
+        self.assertEqual(simple_car_state.velocity(), 52.)
+
     def test_idm_controller(self):
         rg = make_two_lane_road()
         idm = IdmController(


### PR DESCRIPTION
This PR adds the python bindings for the `SimpleCarState` class, as well as its respective python test.
The `TODO` comment above the definition of the binding was left since this implementation is temporal and bound to be replaced by a vector-gen version (See #8096 ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8690)
<!-- Reviewable:end -->
