### PR TITLE
Rotation constraint combining box-sphere intersection and bilinear product

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -270,6 +270,7 @@ drake_cc_library(
     ],
     deps = [
         ":bilinear_product_util",
+        ":integer_optimization_util",
         ":mathematical_program",
         ":mixed_integer_optimization_util",
         "//math:gradient",

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1053,6 +1053,7 @@ drake_cc_googletest(
         # Excluding tsan because an assertion fails in LLVM code. Issue #6179.
         "no_tsan",
     ],
+    use_default_main = False,
     deps = [
         ":gurobi_solver",
         ":mathematical_program",

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -453,6 +453,11 @@ void ComputeHalfSpaceRelaxationForBoxSphereIntersection(
   *n = prog_normal.GetSolution(n_var);
   *d = prog_normal.GetSolution(d_var(0));
 
+  n->normalize();
+  *d = std::numeric_limits<double>::infinity();
+  for (const auto& pt : pts) {
+    *d = std::min(*d, n->dot(pt));
+  }
   DRAKE_DEMAND((*n)(0) > 0 && (*n)(1) > 0 && (*n)(2) > 0);
   DRAKE_DEMAND(*d > 0 && *d < 1);
 }

--- a/solvers/rotation_constraint.cc
+++ b/solvers/rotation_constraint.cc
@@ -1243,7 +1243,6 @@ void GetCRposAndCRnegForLogarithmicBinning(
     const std::array<std::array<T, 3>, 3>& B, int num_intervals_per_half_axis,
     MathematicalProgram* prog, std::vector<Matrix3<Expression>>* CRpos,
     std::vector<Matrix3<Expression>>* CRneg) {
-  DRAKE_DEMAND(is_power_of_two(num_intervals_per_half_axis));
 
   if (num_intervals_per_half_axis > 1) {
     const auto gray_codes = math::CalculateReflectedGrayCodes(

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -117,7 +117,7 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  * Note: The particular representation/algorithm here was developed in an
  * attempt:
  *  - to enable efficient reuse of the variables between the constraints
- *    between multiple rows/columns (e.g. the constraints on R^T use the same
+ *    between multiple rows/columns (e.g. the constraints on Rᵀ use the same
  *    variables as the constraints on R), and
  *  - to facilitate branch-and-bound solution techniques -- binary regions are
  *    layered so that constraining one region establishes constraints
@@ -125,8 +125,7 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  *    the on other binary variables.
  * @param prog The mathematical program to which the constraints are added.
  * @param R The rotation matrix
- * @param num_binary_vars_per_half_axis number of binary variables for a half
- * axis.
+ * @param num_intervals_per_half_axis number of intervals for a half axis.
  * @param limits The angle joints for space fixed z-y-x representation of the
  * rotation. @default is no constraint. @see RollPitchYawLimitOptions
  * @retval NewVars  Included the newly added variables
@@ -140,14 +139,14 @@ std::tuple<std::vector<Matrix3<symbolic::Expression>>,
  *   BRpos[k](i, j) = 1 => R(i, j) >= k / N
  *   BRneg[k](i, j) = 1 => R(i, j) <= -k / N
  * </pre>
- * where `N` is `num_binary_vars_per_half_axis`.
+ * where `N` is `num_intervals_per_half_axis`.
  */
 
 AddRotationMatrixMcCormickEnvelopeReturnType
 AddRotationMatrixMcCormickEnvelopeMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_binary_vars_per_half_axis = 2,
+    int num_intervals_per_half_axis = 2,
     RollPitchYawLimits limits = kNoLimits);
 
 /**
@@ -181,8 +180,9 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * the bilinear product terms in the SO(3) constraint, with a new auxiliary
  * variable in the McCormick envelope of bilinear product. For more details,
  * please refer to
- * Global Inverse Kinematics via Mixed-Integer Convex Optimization
- * by Hongkai Dai, Gregory Izatt and Russ Tedrake, 2017.
+ *  Global Inverse Kinematics via Mixed-Integer Convex Optimization
+ *   by Hongkai Dai, Gregory Izatt and Russ Tedrake, 
+ *   International Symposium on Robotics Research 2017.
  * @tparam kNumIntervalsPerHalfAxis We cut the interval [-1, 1] evenly into
  * KNumIntervalsPerHalfAxis * 2 intervals. Then depending on in which interval
  * R(i, j) is, we impose corresponding linear constraints. Currently only

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -193,6 +193,10 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * @param R The rotation matrix.
  * @param num_intervals_per_half_axis Same as NumIntervalsPerHalfAxis, use this
  * variable when NumIntervalsPerHalfAxis is dynamic.
+ * @param add_mccormick_for_sphere_box_intersection Set to true if we add some
+ * constraint to tighten the relaxation, that can be obtained by considering
+ * the McCormick Envelope of an intersection region, between an axis-aligned box
+ * and the surface of the sphere.
  * @return pair. pair = (B, φ). B[i][j] is a column vector. If B[i][j]
  * represents integer M in the reflected Gray code, then R(i, j) is in the
  * interval [φ(M), φ(M+1)]. φ contains the end points of the all the intervals,
@@ -207,6 +211,7 @@ typename std::enable_if<
 AddRotationMatrixBilinearMcCormickMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
-    int num_intervals_per_half_axis = kNumIntervalsPerHalfAxis);
+    int num_intervals_per_half_axis = kNumIntervalsPerHalfAxis,
+    bool add_mccormick_for_sphere_box_intersection = true);
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -193,10 +193,10 @@ struct AddRotationMatrixBilinearMcCormickMilpConstraintsReturn {
  * @param R The rotation matrix.
  * @param num_intervals_per_half_axis Same as NumIntervalsPerHalfAxis, use this
  * variable when NumIntervalsPerHalfAxis is dynamic.
- * @param add_mccormick_for_sphere_box_intersection Set to true if we add some
- * constraint to tighten the relaxation, that can be obtained by considering
- * the McCormick Envelope of an intersection region, between an axis-aligned box
- * and the surface of the sphere.
+ * @param add_mccormick_for_sphere_box_intersection If set to true, then we add
+ * some constraint to tighten the relaxation, that can be obtained by
+ * considering the McCormick Envelope of an intersection region, between an
+ * axis-aligned box and the surface of the sphere.
  * @return pair. pair = (B, φ). B[i][j] is a column vector. If B[i][j]
  * represents integer M in the reflected Gray code, then R(i, j) is in the
  * interval [φ(M), φ(M+1)]. φ contains the end points of the all the intervals,

--- a/solvers/rotation_constraint.h
+++ b/solvers/rotation_constraint.h
@@ -212,6 +212,6 @@ AddRotationMatrixBilinearMcCormickMilpConstraints(
     MathematicalProgram* prog,
     const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
     int num_intervals_per_half_axis = kNumIntervalsPerHalfAxis,
-    bool add_mccormick_for_sphere_box_intersection = true);
+    bool add_mccormick_for_sphere_box_intersection = false);
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -389,8 +389,10 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
     ::testing::Combine(::testing::ValuesIn<std::vector<ConstraintType>>(
-                           { ConstraintType::kBoth}),
-                       ::testing::ValuesIn<std::vector<int>>({2})));
+                           {ConstraintType::kBoxSphereIntersection,
+                            ConstraintType::kReplaceBilinear,
+                            ConstraintType::kBoth}),
+                       ::testing::ValuesIn<std::vector<int>>({1, 2})));
 
 // Test some corner cases of McCormick envelope.
 // The corner cases happens when either the innermost or the outermost corner

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -22,7 +22,7 @@ using std::sqrt;
 namespace drake {
 namespace solvers {
 namespace {
-/*void AddObjective(MathematicalProgram* prog,
+void AddObjective(MathematicalProgram* prog,
                   const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
                   const Eigen::Ref<const Matrix3d>& R_desired) {
   const auto R_error = R - R_desired;
@@ -174,7 +174,7 @@ GTEST_TEST(RotationTest, TestOrthonormal) {
             2 - R.row(0).dot(R.row(0)) - R.row(1).dot(R.row(1)) + tol);
   EXPECT_LE(2 * std::abs(R.row(0).dot(R.row(2))),
             2 - R.row(0).dot(R.row(0)) - R.row(1).dot(R.row(1)) + tol);
-}*/
+}
 
 bool IsFeasibleCheck(
     MathematicalProgram* prog,
@@ -184,16 +184,9 @@ bool IsFeasibleCheck(
   feasibility_constraint->UpdateLowerBound(R_sample_vec);
   feasibility_constraint->UpdateUpperBound(R_sample_vec);
 
-  // Mosek solver has some numerical issue, that it can return "floating point
-  // exception" in this test.
-  GurobiSolver solver;
-  if (solver.available()) {
-    return (prog->Solve() == kSolutionFound);
-  } else {
-    throw std::runtime_error("Gurobi solver is not available.");
-  }
+  return (prog->Solve() == kSolutionFound);
 }
-/*
+
 GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
   MathematicalProgram prog;
   auto R = NewRotationMatrixVars(&prog);
@@ -228,7 +221,7 @@ GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
           std::pair<std::array<std::array<VectorDecisionVariable<3>, 3>, 3>,
                     Eigen::Matrix<double, 9, 1>>>::value,
       "Incorrect type.");
-}*/
+}
 
 enum class ConstraintType {
   kBoxSphereIntersection,
@@ -339,12 +332,10 @@ TEST_P(TestMcCormick, TestExactRotationMatrix) {
   std::mt19937 generator(41);
   for (int i = 0; i < 40; i++) {
     R_test = math::UniformlyRandomRotationMatrix(&generator).matrix();
-    const bool is_feasible = IsFeasible(R_test);
-    std::cout << i << " " << is_feasible << "\n";
-    EXPECT_TRUE(is_feasible);
+    EXPECT_TRUE(IsFeasible(R_test));
   }
 }
-/*
+
 TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   // If R is not exactly on SO(3), test whether it is infeasible for our SO(3)
   // relaxation.
@@ -393,14 +384,14 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
-}*/
+}
 
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
     ::testing::Combine(::testing::ValuesIn<std::vector<ConstraintType>>(
                            { ConstraintType::kBoth}),
                        ::testing::ValuesIn<std::vector<int>>({2})));
-/*
+
 // Test some corner cases of McCormick envelope.
 // The corner cases happens when either the innermost or the outermost corner
 // of the box bmin <= x <= bmax lies on the surface of the unit sphere.
@@ -617,7 +608,7 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn<std::vector<bool>>(
                            {false, true}),  // same of opposite orthant
                        ::testing::ValuesIn<std::vector<bool>>(
-                           {false, true})));  // replace bilinear or not.*/
+                           {false, true})));  // replace bilinear or not.
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -239,7 +239,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
                                     .evaluator()} {
     if (replace_bilinear_product_) {
       AddRotationMatrixBilinearMcCormickMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_);
+          &prog_, R_, num_intervals_per_half_axis_, true);
     } else {
       AddRotationMatrixMcCormickEnvelopeMilpConstraints(
           &prog_, R_, num_intervals_per_half_axis_);

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -184,7 +184,14 @@ bool IsFeasibleCheck(
   feasibility_constraint->UpdateLowerBound(R_sample_vec);
   feasibility_constraint->UpdateUpperBound(R_sample_vec);
 
-  return (prog->Solve() == kSolutionFound);
+  // Mosek solver has some numerical issue, that it can return "floating point
+  // exception" in this test.
+  GurobiSolver solver;
+  if (solver.available()) {
+    return (prog->Solve() == kSolutionFound);
+  } else {
+    throw std::runtime_error("Gurobi solver is not available.");
+  }
 }
 /*
 GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
@@ -332,7 +339,9 @@ TEST_P(TestMcCormick, TestExactRotationMatrix) {
   std::mt19937 generator(41);
   for (int i = 0; i < 40; i++) {
     R_test = math::UniformlyRandomRotationMatrix(&generator).matrix();
-    EXPECT_TRUE(IsFeasible(R_test));
+    const bool is_feasible = IsFeasible(R_test);
+    std::cout << i << " " << is_feasible << "\n";
+    EXPECT_TRUE(is_feasible);
   }
 }
 /*

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -10,6 +10,7 @@
 #include "drake/math/rotation_matrix.h"
 #include "drake/solvers/gurobi_solver.h"
 #include "drake/solvers/mathematical_program.h"
+#include "drake/solvers/mosek_solver.h"
 
 using Eigen::Vector3d;
 using Eigen::Matrix3d;
@@ -237,8 +238,13 @@ std::string to_string(ConstraintType type) {
     case ConstraintType::kBoth:
       return "both";
   }
+  // This code should not be reached, we add the next line due to a compiler
+  // defect.
+  throw std::runtime_error("Should not reach this part of the code.");
 }
 
+// This operator overloading is useful, when GTEST prints out which parameter
+// causes the test failure.
 std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
   os << to_string(type);
   return os;
@@ -608,3 +614,12 @@ INSTANTIATE_TEST_CASE_P(
 }  // namespace
 }  // namespace solvers
 }  // namespace drake
+
+int main(int argc, char** argv) {
+  // Ensure that we have the MOSEK license for the entire duration of this test,
+  // so that we do not have to release and re-acquire the license for every
+  // test.
+  auto mosek_license = drake::solvers::MosekSolver::AcquireLicense();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -22,7 +22,7 @@ using std::sqrt;
 namespace drake {
 namespace solvers {
 namespace {
-void AddObjective(MathematicalProgram* prog,
+/*void AddObjective(MathematicalProgram* prog,
                   const Eigen::Ref<const MatrixDecisionVariable<3, 3>>& R,
                   const Eigen::Ref<const Matrix3d>& R_desired) {
   const auto R_error = R - R_desired;
@@ -174,7 +174,7 @@ GTEST_TEST(RotationTest, TestOrthonormal) {
             2 - R.row(0).dot(R.row(0)) - R.row(1).dot(R.row(1)) + tol);
   EXPECT_LE(2 * std::abs(R.row(0).dot(R.row(2))),
             2 - R.row(0).dot(R.row(0)) - R.row(1).dot(R.row(1)) + tol);
-}
+}*/
 
 bool IsFeasibleCheck(
     MathematicalProgram* prog,
@@ -335,7 +335,7 @@ TEST_P(TestMcCormick, TestExactRotationMatrix) {
     EXPECT_TRUE(IsFeasible(R_test));
   }
 }
-
+/*
 TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   // If R is not exactly on SO(3), test whether it is infeasible for our SO(3)
   // relaxation.
@@ -384,16 +384,14 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
-}
+}*/
 
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
     ::testing::Combine(::testing::ValuesIn<std::vector<ConstraintType>>(
-                           {ConstraintType::kBoxSphereIntersection,
-                            ConstraintType::kReplaceBilinear,
-                            ConstraintType::kBoth}),
-                       ::testing::ValuesIn<std::vector<int>>({1, 2})));
-
+                           { ConstraintType::kBoth}),
+                       ::testing::ValuesIn<std::vector<int>>({2})));
+/*
 // Test some corner cases of McCormick envelope.
 // The corner cases happens when either the innermost or the outermost corner
 // of the box bmin <= x <= bmax lies on the surface of the unit sphere.
@@ -610,7 +608,7 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn<std::vector<bool>>(
                            {false, true}),  // same of opposite orthant
                        ::testing::ValuesIn<std::vector<bool>>(
-                           {false, true})));  // replace bilinear or not.
+                           {false, true})));  // replace bilinear or not.*/
 }  // namespace
 }  // namespace solvers
 }  // namespace drake

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -185,7 +185,7 @@ bool IsFeasibleCheck(
 
   return (prog->Solve() == kSolutionFound);
 }
-
+/*
 GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
   MathematicalProgram prog;
   auto R = NewRotationMatrixVars(&prog);
@@ -220,7 +220,7 @@ GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
           std::pair<std::array<std::array<VectorDecisionVariable<3>, 3>, 3>,
                     Eigen::Matrix<double, 9, 1>>>::value,
       "Incorrect type.");
-}
+}*/
 
 class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  public:

--- a/solvers/test/rotation_constraint_test.cc
+++ b/solvers/test/rotation_constraint_test.cc
@@ -222,14 +222,38 @@ GTEST_TEST(RotationConstraint, TestAddStaticSizeNumIntervalsPerHalfAxis) {
       "Incorrect type.");
 }*/
 
-class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
+enum class ConstraintType {
+  kBoxSphereIntersection,
+  kReplaceBilinear,
+  kBoth,
+};
+
+std::string to_string(ConstraintType type) {
+  switch (type) {
+    case ConstraintType::kBoxSphereIntersection:
+      return "box_sphere_intersection";
+    case ConstraintType::kReplaceBilinear:
+      return "replace_bilinear";
+    case ConstraintType::kBoth:
+      return "both";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
+  os << to_string(type);
+  return os;
+}
+
+
+class TestMcCormick
+    : public ::testing::TestWithParam<std::tuple<ConstraintType, int>> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TestMcCormick)
 
   TestMcCormick()
       : prog_(),
         R_(NewRotationMatrixVars(&prog_)),
-        replace_bilinear_product_(std::get<0>(GetParam())),
+        constraint_type_(std::get<0>(GetParam())),
         num_intervals_per_half_axis_(std::get<1>(GetParam())),
         feasibility_constraint_{prog_
                                     .AddLinearEqualityConstraint(
@@ -237,12 +261,19 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
                                         Eigen::Matrix<double, 9, 1>::Zero(),
                                         {R_.col(0), R_.col(1), R_.col(2)})
                                     .evaluator()} {
-    if (replace_bilinear_product_) {
-      AddRotationMatrixBilinearMcCormickMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_, true);
-    } else {
-      AddRotationMatrixMcCormickEnvelopeMilpConstraints(
-          &prog_, R_, num_intervals_per_half_axis_);
+    switch (constraint_type_) {
+      case ConstraintType::kBoxSphereIntersection:
+        AddRotationMatrixMcCormickEnvelopeMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_);
+        break;
+      case ConstraintType::kReplaceBilinear:
+        AddRotationMatrixBilinearMcCormickMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_, false);
+        break;
+      case ConstraintType::kBoth:
+        AddRotationMatrixBilinearMcCormickMilpConstraints(
+            &prog_, R_, num_intervals_per_half_axis_, true);
+        break;
     }
   }
 
@@ -255,9 +286,7 @@ class TestMcCormick : public ::testing::TestWithParam<std::tuple<bool, int>> {
  protected:
   MathematicalProgram prog_;
   MatrixDecisionVariable<3, 3> R_;
-  bool replace_bilinear_product_{};  // If true, replace the bilinear product
-  // with another varaible in the McCormick envelope. Otherwise, relax the
-  // surface ofthe unit sphere to its convex hull.
+  ConstraintType constraint_type_;
   int num_intervals_per_half_axis_{};
   std::shared_ptr<LinearEqualityConstraint> feasibility_constraint_;
 };
@@ -317,7 +346,8 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   R_test(0, 2) *= -1.0;
   R_test(1, 2) *= -1.0;
   // Requires 2 intervals per half axis to catch.
-  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+  if (num_intervals_per_half_axis_ == 1 &&
+      constraint_type_ == ConstraintType::kBoxSphereIntersection)
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
@@ -343,7 +373,8 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
   R_test(2, 0) -= 0.1;
   EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
   EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);
-  if (num_intervals_per_half_axis_ == 1 && !replace_bilinear_product_)
+  if (num_intervals_per_half_axis_ == 1 &&
+      constraint_type_ == ConstraintType::kBoxSphereIntersection)
     EXPECT_TRUE(IsFeasible(R_test));
   else
     EXPECT_FALSE(IsFeasible(R_test));
@@ -351,7 +382,10 @@ TEST_P(TestMcCormick, TestInexactRotationMatrix) {
 
 INSTANTIATE_TEST_CASE_P(
     RotationTest, TestMcCormick,
-    ::testing::Combine(::testing::ValuesIn<std::vector<bool>>({false, true}),
+    ::testing::Combine(::testing::ValuesIn<std::vector<ConstraintType>>(
+                           {ConstraintType::kBoxSphereIntersection,
+                            ConstraintType::kReplaceBilinear,
+                            ConstraintType::kBoth}),
                        ::testing::ValuesIn<std::vector<int>>({1, 2})));
 
 // Test some corner cases of McCormick envelope.


### PR DESCRIPTION
This is the first step to clean up our mixed-integer relaxation on SO(3) rotation constraint.

Previously we have two formulations on the relaxation

1. Consider the intersection region between a box and and sphere surface.
2. Consider the McCormick Envelope of the bilinear product w = x * y, in the SO(3) constraint RᵀR = I

In this PR, we provide the option, that these two formulations can be imposed jointly on a matrix `R`. Potentially this should tighten our relaxation.

@gizatt this could affect your pose estimation work, if you call `AddRotationMatrixBilinearMcCormickMilpConstraints`, with `add_mccormick_for_sphere_box_intersection` set to true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8694)
<!-- Reviewable:end -->
