### PR TITLE
Upgrade gurobi 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ endif()
 option(WITH_GUROBI "Build with support for Gurobi" OFF)
 
 if(WITH_GUROBI)
-  find_package(Gurobi 7.5.2 MODULE REQUIRED)
+  find_package(Gurobi 8.0.0 MODULE REQUIRED)
 
   list(APPEND BAZEL_ARGS --config=gurobi)
 

--- a/cmake/modules/FindGurobi.cmake
+++ b/cmake/modules/FindGurobi.cmake
@@ -3,9 +3,9 @@
 
 find_path(Gurobi_INCLUDE_DIR NAMES gurobi_c.h
   PATHS
-    /Library/gurobi752/mac64
-    /opt/gurobi752/linux64
-    /opt/gurobi752/power64
+    /Library/gurobi800/mac64
+    /opt/gurobi800/linux64
+    /opt/gurobi800/power64
     ENV GUROBI_PATH
   PATH_SUFFIXES include
 )
@@ -38,9 +38,9 @@ find_library(Gurobi_LIBRARY
   NAMES "gurobi${Gurobi_VERSION_MAJOR}${Gurobi_VERSION_MINOR}"
   HINTS "${_GUROBI_ROOT}"
   PATHS
-    /Library/gurobi752/mac64
-    /opt/gurobi752/linux64
-    /opt/gurobi752/power64
+    /Library/gurobi800/mac64
+    /opt/gurobi800/linux64
+    /opt/gurobi800/power64
     ENV GUROBI_PATH
   PATH_SUFFIXES lib
 )

--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -138,13 +138,13 @@ Proprietary Solvers
 
 The Drake Bazel build currently supports the following proprietary solvers:
 
- * Gurobi 7.5.2
+ * Gurobi 8.0.0
  * MOSEK 8.1
  * SNOPT 7.2
 
 .. _gurobi:
 
-Gurobi 7.5.2
+Gurobi 8.0.0
 ------------
 
 Install on Ubuntu
@@ -152,16 +152,16 @@ Install on Ubuntu
 1. Register for an account on https://www.gurobi.com.
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``.
-4. Download ``gurobi7.5.2_linux64.tar.gz``
-5. Unzip it.  We suggest that you use ``/opt/gurobi752`` to simplify working with Drake installations.
-6. ``export GUROBI_PATH=/opt/gurobi752/linux64``
+4. Download ``gurobi8.0.0_linux64.tar.gz``
+5. Unzip it.  We suggest that you use ``/opt/gurobi800`` to simplify working with Drake installations.
+6. ``export GUROBI_PATH=/opt/gurobi800/linux64``
 
 Install on macOS
 ~~~~~~~~~~~~~~~~
 1. Register for an account on http://www.gurobi.com.
 2. Set up your Gurobi license file in accordance with Gurobi documentation.
 3. ``export GRB_LICENSE_FILE=/path/to/gurobi.lic``
-4. Download and install ``gurobi7.5.2_mac64.pkg``.
+4. Download and install ``gurobi8.0.0_mac64.pkg``.
 
 
 To confirm that your setup was successful, run the tests that require Gurobi:

--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -29,6 +29,6 @@ called_from_lib:libmosek64.so.8.1
 # data race (libglib-2.0.*) in g_static_rec_mutex_lock
 race:g_static_rec_mutex_lock
 
-# data race in libgurobi75.so.  Gurobi has not been instrumented with TSan.
+# data race in libgurobi80.so.  Gurobi has not been instrumented with TSan.
 called_from_lib:libgurobi.so
-called_from_lib:libgurobi75.so
+called_from_lib:libgurobi80.so

--- a/tools/workspace/gurobi/package-macos.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-macos.BUILD.bazel.in
@@ -11,7 +11,7 @@ licenses(["by_exception_only"])  # Gurobi
 genrule(
     name = "error-message",
     outs = ["error-message.h"],
-    cmd = "echo 'error: Gurobi 7.5.2 is not installed at {gurobi_path}' && false",  # noqa
+    cmd = "echo 'error: Gurobi 8.0.0 is not installed at {gurobi_path}' && false",  # noqa
     visibility = ["//visibility:private"],
 )
 
@@ -26,7 +26,7 @@ cc_library(
     includes = ["gurobi-distro/include"],
     linkopts = [
         "-L{gurobi_path}/lib",
-        "-lgurobi75",
+        "-lgurobi80",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
@@ -21,19 +21,19 @@ GUROBI_HDRS = glob([
     "gurobi-distro/include/gurobi_c++.h",
 ]) or [":error-message.h"]
 
-# In the Gurobi package, libgurobi75.so is a symlink to libgurobi.so.7.5.2.
-# However, if we use libgurobi.so.7.5.2 in srcs, executables that link this
+# In the Gurobi package, libgurobi80.so is a symlink to libgurobi.so.8.0.0.
+# However, if we use libgurobi.so.8.0.0 in srcs, executables that link this
 # library will be unable to find it at runtime in the Bazel sandbox,
 # because the NEEDED statements in the executable will not square with the
 # RPATH statements.  I don't really know why this happens, but I suspect it
 # might be a Bazel bug.
 GUROBI_SRCS = glob([
-    "gurobi-distro/lib/libgurobi75.so",
+    "gurobi-distro/lib/libgurobi80.so",
 ]) or [":error-message.h"]
 
 GUROBI_INSTALL_LIBRARIES = glob([
-    "gurobi-distro/lib/libgurobi.so.7.5.2",
-    "gurobi-distro/lib/libgurobi75.so",
+    "gurobi-distro/lib/libgurobi.so.8.0.0",
+    "gurobi-distro/lib/libgurobi80.so",
 ]) or [":error-message.h"]
 
 GUROBI_DOCS = glob([

--- a/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
@@ -12,7 +12,7 @@ licenses(["by_exception_only"])  # Gurobi
 genrule(
     name = "error-message",
     outs = ["error-message.h"],
-    cmd = "echo 'error: The value of environment variable GUROBI_PATH=\"{gurobi_path}\" is invalid; export GUROBI_PATH to the correct value.' && false",  # noqa
+    cmd = "echo 'error: Gurobi 8.0.0 is not installed at {gurobi_path}, export GUROBI_PATH to the correct value' && false",  # noqa
     visibility = ["//visibility:private"],
 )
 

--- a/tools/workspace/gurobi/repository.bzl
+++ b/tools/workspace/gurobi/repository.bzl
@@ -4,10 +4,10 @@
 
 load("@drake//tools/workspace:os.bzl", "determine_os")
 
-# Ubuntu only: GUROBI_PATH should be the linux64 directory in the Gurobi 7.5.2
+# Ubuntu only: GUROBI_PATH should be the linux64 directory in the Gurobi 8.0.0
 # release.
 #
-# TODO(jwnimmer-tri) The Gurobi docs use /opt/gurobi752/linux64, so we should
+# TODO(jwnimmer-tri) The Gurobi docs use /opt/gurobi800/linux64, so we should
 # probably look in that location as a reasonable default guess.
 def _gurobi_impl(repo_ctx):
     os_result = determine_os(repo_ctx)
@@ -16,7 +16,7 @@ def _gurobi_impl(repo_ctx):
 
     if os_result.is_macos:
         # Gurobi must be installed into its standard location.
-        gurobi_path = "/Library/gurobi752/mac64"
+        gurobi_path = "/Library/gurobi800/mac64"
         repo_ctx.symlink(gurobi_path, "gurobi-distro")
     else:
         # Locate Gurobi using an environment variable.  If GUROBI_PATH is


### PR DESCRIPTION
According to http://www.gurobi.com/products/whats-new/whats-new-in-the-latest-version, Gurobi 8 is 16% faster than Gurobi 7.5, on mixed integer problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8695)
<!-- Reviewable:end -->
