### PR TITLE
Restore PlaybackTrajectory() for state trajectories.

### DIFF
--- a/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/multibody/rigid_body_plant/drake_visualizer.cc
@@ -110,7 +110,9 @@ void DrakeVisualizer::PlaybackTrajectory(
 
   // Final evaluation is at the final time stamp, guaranteeing the final state
   // is visualized.
-  data.set_value(input_trajectory.value(input_trajectory.end_time()));
+  data.set_value(input_trajectory.value(input_trajectory.end_time())
+                     .col(0)
+                     .head(num_positions));
   std::vector<uint8_t> message_bytes;
   draw_message_translator_.Serialize(sim_time, data, &message_bytes);
   lcm_->Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),

--- a/multibody/rigid_body_plant/test/drake_visualizer_test.cc
+++ b/multibody/rigid_body_plant/test/drake_visualizer_test.cc
@@ -523,6 +523,32 @@ GTEST_TEST(DrakeVisualizerTests, TestPublishPeriod) {
   }
 }
 
+// Tests that PlaybackTrajectory() works with both num_position and num_position
+// + num_velocity trajectories.
+GTEST_TEST(DrakeVisualizerTests, TestPlaybackTrajectory) {
+  unique_ptr<RigidBodyTree<double>> tree = CreateRigidBodyTree();
+  drake::lcm::DrakeMockLcm lcm;
+
+  // Instantiates the "device under test".
+  DrakeVisualizer dut(*tree, &lcm);
+
+  // Create a trivial position trajectory.
+  const VectorX<double> q_zero = tree->getZeroConfiguration();
+  const auto x_zero =
+      (VectorX<double>(tree->get_num_positions() + tree->get_num_velocities())
+           << q_zero, VectorX<double>::Zero(tree->get_num_velocities()))
+          .finished();
+  const auto position_trajectory =
+      trajectories::PiecewisePolynomial<double>::ZeroOrderHold(
+          {0, 1}, {q_zero, q_zero});
+  const auto state_trajectory =
+      trajectories::PiecewisePolynomial<double>::ZeroOrderHold(
+          {0, 1}, {x_zero, x_zero});
+
+  EXPECT_NO_THROW(dut.PlaybackTrajectory(position_trajectory));
+  EXPECT_NO_THROW(dut.PlaybackTrajectory(state_trajectory));
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake


### PR DESCRIPTION
Adds a change that was inadvertently ommitted in #8683. Also adds a unit
test that would have caught #8697. Fixes #8697.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8698)
<!-- Reviewable:end -->
