### PR TITLE
pydrake systems: Add initial custom scalar conversion test / example

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -210,9 +210,5 @@ struct overload_cast_impl {
 template <typename Return, typename... Args>
 constexpr auto overload_cast_explicit = overload_cast_impl<Return, Args...>{};
 
-// TODO(eric.cousineau): pybind11 defaults to C++-like copies when dealing
-// with rvalues. We should wrap this into a drake-level binding, so that we
-// can default this to `py_reference` or `py_reference_internal.`
-
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -79,6 +79,14 @@ drake_pybind_library(
     ],
 )
 
+drake_py_library(
+    name = "scalar_conversion_py",
+    srcs = ["scalar_conversion.py"],
+    deps = [
+        ":framework_py",
+    ],
+)
+
 drake_pybind_library(
     name = "primitives_py",
     cc_deps = [
@@ -309,6 +317,14 @@ drake_py_unittest(
     deps = [
         ":rendering_py",
         "//bindings/pydrake/multibody:multibody_tree_py",
+    ],
+)
+
+drake_py_unittest(
+    name = "scalar_conversion_test",
+    deps = [
+        ":framework_py",
+        ":scalar_conversion_py",
     ],
 )
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -58,6 +58,7 @@ drake_pybind_library(
         "//bindings/pydrake/util:drake_optional_pybind",
         "//bindings/pydrake/util:eigen_pybind",
         "//bindings/pydrake/util:type_safe_index_pybind",
+        "//bindings/pydrake/util:wrap_pybind",
     ],
     cc_so_name = "framework",
     cc_srcs = [
@@ -111,7 +112,7 @@ drake_pybind_library(
     name = "controllers_py",
     cc_deps = [
         "//bindings/pydrake:symbolic_types_pybind",
-        "//bindings/pydrake/util:wrap_function",
+        "//bindings/pydrake/util:wrap_pybind",
     ],
     cc_so_name = "controllers",
     cc_srcs = ["controllers_py.cc"],

--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -5,34 +5,12 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
-#include "drake/bindings/pydrake/util/wrap_function.h"
+#include "drake/bindings/pydrake/util/wrap_pybind.h"
 #include "drake/systems/controllers/dynamic_programming.h"
 #include "drake/systems/controllers/linear_quadratic_regulator.h"
 
 namespace drake {
 namespace pydrake {
-
-namespace {
-
-template <typename T, typename = void>
-struct wrap_ptr : public wrap_arg_default<T> {};
-
-template <typename T>
-struct wrap_ptr<const systems::Context<T>&> {
-  using Type = systems::Context<T>;
-  static auto wrap(const Type& arg) { return &arg; }
-  static auto unwrap(const Type* arg_wrapped) { return *arg_wrapped; }
-};
-
-// Ensures that `const Context<T>&` is wrapped with `const Context<T>*`.
-// TODO(eric.cousineau): Replace this with general wrappper, place in
-// `pydrake_pybind` or somewhere related.
-template <typename Func>
-auto WrapPtr(Func&& func) {
-  return WrapFunction<wrap_ptr>(std::forward<Func>(func));
-}
-
-}  // namespace
 
 PYBIND11_MODULE(controllers, m) {
   // NOLINTNEXTLINE(build/namespaces): Emulate placement in namespace.
@@ -58,10 +36,10 @@ PYBIND11_MODULE(controllers, m) {
       .def_readwrite("visualization_callback",
                      &DynamicProgrammingOptions::visualization_callback);
 
-  m.def("FittedValueIteration", WrapPtr(&FittedValueIteration));
+  m.def("FittedValueIteration", WrapCallbacks(&FittedValueIteration));
 
   m.def("LinearProgrammingApproximateDynamicProgramming",
-        WrapPtr(&LinearProgrammingApproximateDynamicProgramming));
+        WrapCallbacks(&LinearProgrammingApproximateDynamicProgramming));
 
   m.def("LinearQuadraticRegulator",
         [](const Eigen::Ref<const Eigen::MatrixXd>& A,

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -1,0 +1,220 @@
+"""Provides utilities to aid in scalar type conversion."""
+
+import copy
+
+from pydrake.systems.framework import (
+    LeafSystem_,
+    SystemScalarConverter,
+)
+from pydrake.util.cpp_template import (
+    _get_module_name_from_stack,
+    TemplateClass,
+)
+
+
+def _get_conversion_pairs(T_list):
+    # Take subset from supported conversions.
+    T_pairs = []
+    for T, U in SystemScalarConverter.SupportedConversionPairs:
+        if T in T_list and U in T_list:
+            T_pairs.append((T, U))
+    return T_pairs
+
+
+class TemplateSystem(TemplateClass):
+    """Defines templated systems enabling scalar type conversion in Python.
+
+    This differs from `TemplateClass` in that (a) the template must specify its
+    parameters at construction time and (b) `.define` is overridden to allow
+    defining `f(T)` for convenience.
+
+    Any class that is added must:
+    - Not define `__init__`, as this will be overridden.
+    - Define `_construct(self, <args>, converter=None, <kwargs>)` and
+      `_construct_copy(self, other, converter=None)` instead.
+      - `converter` must be present as an argument to ensure that it
+        propagates properly.
+
+    If any of these constraints are violated, then an error will be thrown
+    at the time of the first class instantiation.
+
+    Example:
+
+        @TemplateSystem.define("MySystem_")
+        def MySystem_(T):
+
+            class Impl(LeafSystem_[T]):
+                def _construct(self, value, converter=None):
+                    LeafSystem_[T].__init__(self, converter=converter)
+                    self.value = value
+
+                def _construct_copy(self, other, converter=None):
+                    Impl._construct(self, other.value, converter=converter)
+
+            return Impl
+
+        MySystem = MySystem_[None]  # Default instantiation.
+
+    Things to note:
+    - When defining `_construct_copy`, if you are delegating to `_construct`
+      within the same class, you should use `Impl._construct(self, ...)`; if
+      you use `self._construct`, then you may get a child class's constructor
+      if you are inheriting.
+    - If you are delegating construction to a parent Python class for both
+      constructors, use the parent class's `__init__` method, not its
+      `_construct` or `_construct_copy` methods.
+    - `converter` should always be non-None, as guaranteed by the overriding
+      `__init__`. We use `converter=None` to imply it should be positional,
+       since Python2 does not have keyword-only arguments.
+    """
+    # TODO(eric.cousineau): Figure out if there is a way to avoid needing to
+    # pass around converters in user code, avoiding the need to have Python
+    # users deal with `SystemScalarConverter`.
+    def __init__(self, name, T_list=None, T_pairs=None, module_name=None):
+        """Constructs `TemplateSystem`.
+
+        @param T_list
+            List of T's that the given system supports. By default, it is all
+            types supported by `LeafSystem`.
+        @param T_pairs List of pairs, (T, U), defining a conversion from a
+            scalar type of U to T.
+            If None, this will use all possible pairs that the Python bindings
+            of `SystemScalarConverter` support.
+        @param module_name
+            Defining `module_name`, per `TemplateClass`'s constructor.
+        """
+        if module_name is None:
+            module_name = _get_module_name_from_stack()
+        TemplateClass.__init__(self, name, module_name=module_name)
+
+        # Check scalar types and conversions, using defaults if unspecified.
+        if T_list is None:
+            T_list = SystemScalarConverter.SupportedScalars
+        for T in T_list:
+            assert T in SystemScalarConverter.SupportedScalars, (
+                "Type {} is not a supported scalar type".format(T))
+        if T_pairs is None:
+            T_pairs = _get_conversion_pairs(T_list)
+        for T_pair in T_pairs:
+            T, U = T_pair
+            assert T in T_list and U in T_list, (
+                "Conversion {} is not in the original parameter list"
+                .format(T_pair))
+            assert T_pair in \
+                SystemScalarConverter.SupportedConversionPairs, (
+                    "Conversion {} is not supported".format(T_pair))
+
+        self._T_list = list(T_list)
+        self._T_pairs = list(T_pairs)
+        self._converter = self._make_converter()
+
+    @classmethod
+    def define(cls, name, T_list=None, T_pairs=None, *args, **kwargs):
+        """Provides a decorator which can be used define a scalar-type
+        convertible System as a template.
+
+        The decorated function must be of the from `f(T)`, which returns a
+        class which will be the instantation for type `T` of the given
+        template.
+
+        @param name
+            Name of the system template. This should match the name of the
+            object being decorated.
+        @param T_list
+            See `__init__` for more information.
+        @param T_pairs
+            See `__init__` for more information.
+        @param args, kwargs
+            These are passed to the constructor of `TemplateSystem`.
+        """
+        template = cls(name, T_list, T_pairs, *args, **kwargs)
+        param_list = [(T,) for T in template._T_list]
+
+        def decorator(instantiation_func):
+
+            def wrapped(param):
+                T, = param
+                return instantiation_func(T)
+
+            template.add_instantiations(wrapped, param_list)
+            return template
+
+        return decorator
+
+    def _on_add(self, param, cls):
+        TemplateClass._on_add(self, param, cls)
+        T, = param
+
+        # Check that the user has not defined `__init__`, and has defined
+        # `_construct` and `_construct_copy`.
+        if not issubclass(cls, LeafSystem_[T]):
+            raise RuntimeError(
+                "{} must inherit from {}".format(cls, LeafSystem_[T]))
+
+        # Use the immediate `__dict__`, rather than querying the attributes, so
+        # that we don't get spillover from inheritance.
+        d = cls.__dict__
+        no_init = "__init__" not in d
+        has_construct = "_construct" in d
+        has_copy = "_construct_copy" in d
+        if not no_init:
+            raise RuntimeError(
+                "{} defines `__init__`, but should not. Please implement "
+                "`_construct` and `_construct_copy` instead."
+                .format(cls.__name__))
+        if not has_construct:
+            raise RuntimeError(
+                "{} does not define `_construct`. Pleaes ensure this is "
+                "defined.".format(cls.__name__))
+        if not has_copy:
+            raise RuntimeError(
+                "{} does not define `_construct_copy`. Please ensure this "
+                "is defined.".format(cls.__name__))
+
+        # Patch `__init__`.
+        template = self
+
+        def system_init(self, *args, **kwargs):
+            converter = None
+            if "converter" in kwargs:
+                converter = kwargs.pop("converter")
+            if converter is None:
+                # Use default converter.
+                converter = template._converter
+            if template._check_if_copying(self, *args, **kwargs):
+                other = args[0]
+                cls._construct_copy(self, other, converter=converter)
+            else:
+                cls._construct(
+                    self, *args, converter=converter, **kwargs)
+
+        cls.__init__ = system_init
+
+    def _check_if_copying(self, obj, *args, **kwargs):
+        # Checks if a function signature implies a copy constructor.
+        # Since this is called after `converter` has been removed from
+        # `kwargs`, we just ensure that there are no additional arguments.
+        if len(args) == 1 and len(kwargs) == 0:
+            if self.is_subclass_of_instantiation(type(args[0])):
+                return True
+        return False
+
+    def _make_converter(self):
+        # Creates system scalar converter for the template class.
+        converter = SystemScalarConverter()
+
+        # Define capture to ensure the current values are bound, and do not
+        # change through iteration.
+        # N.B. This does not directly instantiate the template; it is deferred
+        # to when the conversion is called.
+        def add_captured(T_pair):
+            T, U = T_pair
+
+            def conversion(system):
+                assert isinstance(system, self[U])
+                return self[T](system)
+
+            converter.Add[T, U](conversion)
+
+        map(add_captured, self._T_pairs)
+        return converter

--- a/bindings/pydrake/systems/test/scalar_conversion_test.py
+++ b/bindings/pydrake/systems/test/scalar_conversion_test.py
@@ -1,0 +1,228 @@
+import pydrake.systems.scalar_conversion as mut
+
+import copy
+import unittest
+
+from pydrake.autodiffutils import AutoDiffXd
+from pydrake.symbolic import Expression
+from pydrake.systems.framework import LeafSystem_, SystemScalarConverter
+from pydrake.util.cpp_template import TemplateClass
+
+
+@mut.TemplateSystem.define("Example_")
+def Example_(T):
+
+    class Impl(LeafSystem_[T]):
+        """Testing example."""
+
+        def _construct(self, value, converter=None):
+            LeafSystem_[T].__init__(self, converter=converter)
+            self.value = value
+            self.copied_from = None
+
+        def _construct_copy(self, other, converter=None):
+            Impl._construct(self, other.value, converter=converter)
+            self.copied_from = other
+
+    return Impl
+
+
+Example = Example_[None]
+
+
+class TestScalarConversion(unittest.TestCase):
+    def test_converter_attributes(self):
+        conversion_scalars = (
+            float, AutoDiffXd, Expression,
+        )
+        self.assertTupleEqual(
+            SystemScalarConverter.SupportedScalars,
+            conversion_scalars)
+        conversion_pairs = (
+            (AutoDiffXd, float),
+            (Expression, float),
+            (float, AutoDiffXd),
+            (Expression, AutoDiffXd),
+            (float, Expression),
+            (AutoDiffXd, Expression),
+        )
+        self.assertTupleEqual(
+            SystemScalarConverter.SupportedConversionPairs,
+            conversion_pairs)
+
+    def test_example_system(self):
+        """Tests the Example_ system."""
+        # Test template.
+        self.assertIsInstance(Example_, TemplateClass)
+        self.assertIs(Example_[float], Example)
+
+        # Test parameters.
+        param_list = [(T,) for T in SystemScalarConverter.SupportedScalars]
+        self.assertListEqual(Example_.param_list, param_list)
+
+        # Test private properties (do NOT use these in your code!).
+        self.assertTupleEqual(
+            tuple(Example_._T_list), SystemScalarConverter.SupportedScalars)
+        self.assertTupleEqual(
+            tuple(Example_._T_pairs),
+            SystemScalarConverter.SupportedConversionPairs)
+        converter = Example_._converter
+        for T, U in SystemScalarConverter.SupportedConversionPairs:
+            self.assertTrue(converter.IsConvertible[T, U]())
+
+        # Test calls that we have available for scalar conversion.
+        for T, U in SystemScalarConverter.SupportedConversionPairs:
+            system_U = Example_[U](100)
+            self.assertIs(system_U.copied_from, None)
+            if T == AutoDiffXd:
+                method = LeafSystem_[U].ToAutoDiffXd
+            elif T == Expression:
+                method = LeafSystem_[U].ToSymbolic
+            else:
+                continue
+            system_T = method(system_U)
+            self.assertIsInstance(system_T, Example_[T])
+            self.assertEqual(system_T.value, 100)
+            self.assertIs(system_T.copied_from, system_U)
+
+    def test_define_convertible_system_api(self):
+        """Tests more advanced API of `TemplateSystem.define`, both
+        positive and negative tests."""
+
+        def generic_instantiation_func(T):
+
+            class GenericInstantiation(LeafSystem_[T]):
+                def _construct(self, converter=None):
+                    LeafSystem_[T].__init__(self, converter)
+
+                def _construct_copy(self, other, converter=None):
+                    LeafSystem_[T].__init__(self, converter)
+
+            return GenericInstantiation
+
+        # Non-symbolic
+        # - Implicit conversion pairs.
+        T_list = [float, AutoDiffXd]
+        T_pairs_full = [
+            (AutoDiffXd, float),
+            (float, AutoDiffXd),
+        ]
+        A = mut.TemplateSystem.define("A", T_list=T_list)(
+            generic_instantiation_func)
+        self.assertListEqual(A._T_list, T_list)
+        self.assertListEqual(A._T_pairs, T_pairs_full)
+
+        # - Explicit conversion pairs.
+        T_pairs = [
+            (float, AutoDiffXd),
+        ]
+        B = mut.TemplateSystem.define("B", T_list=T_list, T_pairs=T_pairs)(
+            generic_instantiation_func)
+        self.assertListEqual(B._T_list, T_list)
+        self.assertListEqual(B._T_pairs, T_pairs)
+
+        # Negative tests.
+        # - Not a supported scalar.
+        T_list_bad = [int, float]
+        with self.assertRaises(AssertionError):
+            mut.TemplateSystem.define("C", T_list=T_list_bad)
+        # - Not in original `T_list`.
+        T_pairs_bad = [
+            (float, Expression),
+        ]
+        with self.assertRaises(AssertionError):
+            mut.TemplateSystem.define(
+                "C", T_list=T_list, T_pairs=T_pairs_bad)
+        # - Unsupported conversion.
+        T_pairs_unsupported = [
+            (float, float),
+        ]
+        with self.assertRaises(AssertionError):
+            mut.TemplateSystem.define("C", T_pairs=T_pairs_unsupported)
+
+    def test_inheritance(self):
+
+        @mut.TemplateSystem.define("Child_")
+        def Child_(T):
+
+            class Impl(Example_[T]):
+                def _construct(self, converter=None):
+                    Example_[T].__init__(self, 1000, converter=converter)
+
+                def _construct_copy(self, other, converter=None):
+                    Example_[T].__init__(self, other, converter=converter)
+
+            return Impl
+
+        c_float = Child_[float]()
+        self.assertIsInstance(c_float, Child_[float])
+        self.assertIsInstance(c_float, Example_[float])
+        self.assertEqual(c_float.value, 1000)
+        self.assertIs(c_float.copied_from, None)
+        c_ad = c_float.ToAutoDiffXd()
+        self.assertEqual(c_ad.value, 1000)
+        self.assertIs(c_ad.copied_from, c_float)
+        self.assertIsInstance(c_ad, Child_[AutoDiffXd])
+        self.assertIsInstance(c_ad, Example_[AutoDiffXd])
+
+    def test_bad_class_definitions(self):
+        """Tests bad class definitions."""
+
+        # Should not define `__init__`.
+        @mut.TemplateSystem.define("NoInit_")
+        def NoInit_(T):
+
+            class NoInitInstantiation(LeafSystem_[T]):
+                def __init__(self):
+                    pass
+
+                def _construct(self, converter=None):
+                    pass
+
+                def _construct_copy(self, converter=None):
+                    pass
+
+            return NoInitInstantiation
+
+        with self.assertRaises(RuntimeError) as cm:
+            NoInit_[float]
+        self.assertIn(
+            "NoInit_[float] defines `__init__`, but should not",
+            str(cm.exception))
+
+        # Should define `_construct_copy`.
+        @mut.TemplateSystem.define("NoConstructCopy_")
+        def NoConstructCopy_(T):
+
+            class NoConstructCopyInstantiation(LeafSystem_[T]):
+                def _construct(self, converter=None):
+                    pass
+
+            return NoConstructCopyInstantiation
+
+        with self.assertRaises(RuntimeError) as cm:
+            NoConstructCopy_[float]
+        self.assertIn(
+            "NoConstructCopy_[float] does not define `_construct_copy`",
+            str(cm.exception))
+
+        # Should inherit from `LeafSystem_[T]`.
+        @mut.TemplateSystem.define("BadParenting_")
+        def BadParenting_(T):
+
+            class BadParentingInstantiation(object):
+                def __init__(self):
+                    pass
+
+                def _construct(self, converter=None):
+                    pass
+
+                def _construct_copy(self, converter=None):
+                    pass
+
+            return BadParentingInstantiation
+
+        with self.assertRaises(RuntimeError) as cm:
+            BadParenting_[float]
+        self.assertIn("BadParenting_[float]", str(cm.exception))
+        self.assertIn("LeafSystem_[float]", str(cm.exception))

--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -62,6 +62,7 @@ class TemplateBase(object):
         if module_name is None:
             module_name = _get_module_name_from_stack()
         self._module_name = module_name
+        self._instantiation_func = None
 
     def __getitem__(self, param):
         """Gets concrete class associate with the given arguments.
@@ -75,6 +76,28 @@ class TemplateBase(object):
         """
         return self.get_instantiation(param)[0]
 
+    # Unique token to signify that this instantiation is deferred when using
+    # `add_instantiations` or `define`. The instantiation function will not be
+    # called until the specific instantiation is requested. To illustrate, the
+    # following example defines a template via `@define`, and refers to
+    # itself:
+    #
+    # @TemplateClass.define("MyTemplate", ((int,), (float,)))
+    # def MyTemplate(param):
+    #     print(MyTemplate)
+    #     # ... Make and return a class.
+    #
+    # If the instantiation were not deferred and the inner function was called
+    # before the decorator returned, an error would be raised since
+    # `MyTemplate` is not yet defined. However, since it is deferred, this
+    # should print out that `MyTemplate` is `<TemplateClass ...MyTemplate>`,
+    # would only be called when the user requests something such as
+    # `MyTemplate[float]`.
+    class _Deferred(object):
+        pass
+
+    _deferred = _Deferred()
+
     def get_instantiation(self, param=None, throw_error=True):
         """Gets the instantiation for the given parameters.
 
@@ -85,14 +108,20 @@ class TemplateBase(object):
         """
         param = self._param_resolve(param)
         instantiation = self._instantiation_map.get(param)
-        if instantiation is None and throw_error:
+        if instantiation is TemplateBase._deferred:
+            assert self._instantiation_func is not None
+            instantiation = self._instantiation_func(param)
+            self._add_instantiation_internal(param, instantiation)
+        elif instantiation is None and throw_error:
             raise RuntimeError("Invalid instantiation: {}".format(
                 self._instantiation_name(param)))
         return (instantiation, param)
 
     def add_instantiation(self, param, instantiation):
-        """Adds a unique instantiation. """
-        assert instantiation is not None
+        """Adds a unique instantiation.
+
+        @pre `param` must not have already been added.
+        """
         # Ensure that we do not already have this tuple.
         param = get_param_canonical(self._param_resolve(param))
         if param in self._instantiation_map:
@@ -100,27 +129,36 @@ class TemplateBase(object):
                 "Parameter instantiation already registered: {}".format(param))
         # Register it.
         self.param_list.append(param)
-        self._instantiation_map[param] = instantiation
-        self._on_add(param, instantiation)
+        self._add_instantiation_internal(param, instantiation)
         return param
+
+    def _add_instantiation_internal(self, param, instantiation):
+        # Adds instantiation. Permits overwriting for deferred cases.
+        assert instantiation is not None
+        self._instantiation_map[param] = instantiation
+        if instantiation is not TemplateBase._deferred:
+            self._on_add(param, instantiation)
 
     def add_instantiations(self, instantiation_func, param_list):
         """Adds a set of instantiations given a function and a list of
         parameter sets.
 
-        @param instantiation_func Function of the form `f(template, param)`,
-        where `template` is the current template and `param` is the parameter
-        set for the current instantiation.
-        @param param_list Ordered container of parameter sets to produce
-        instantiations. This list will be iterated through, the wrapped
-        function will be called, and the inner method will return a class (or
-        method).
+        @pre This method can only be called once.
+        @param instantiation_func
+            Function of the form `f(template, param)`, where `template` is the
+            current template and `param` is the parameter set for the current
+            instantiation.
+        @param param_list
+            Ordered container of parameter sets that these instantiations
+            should be produced for.
         """
-        # N.B. The `template` argument is added for decorators, where
-        # instantiations may want to refer to the template before the decorator
-        # has returned.
+        assert instantiation_func is not None
+        if self._instantiation_func is not None:
+            raise RuntimeError(
+                "`add_instsantiations` cannot be called multiple times.")
+        self._instantiation_func = instantiation_func
         for param in param_list:
-            self.add_instantiation(param, instantiation_func(self, param))
+            self.add_instantiation(param, TemplateBase._deferred)
 
     def get_param_set(self, instantiation):
         """Returns all parameters for a given `instantiation`.
@@ -131,6 +169,15 @@ class TemplateBase(object):
             if check == instantiation:
                 param_list.append(param)
         return set(param_list)
+
+    def is_instantiation(self, obj):
+        """Determines if an object is an instantion of the given template."""
+        # Use `get_instantiation` so that we can handled deferred cases.
+        for param in self.param_list:
+            instantiation, _ = self.get_instantiation(param)
+            if instantiation is obj:
+                return True
+        return False
 
     def _param_resolve(self, param):
         # Resolves to canonical parameters, including default case.
@@ -168,25 +215,27 @@ class TemplateBase(object):
         `add_instantiations`, where the instantiation function is the decorated
         function.
 
-        @param name Name of the template. This should generally match the name
-        of the object being decorated for clarity.
-        @param param_list Ordered container of parameter sets. For more
-        information, see `add_instantiations`.
+        @param name
+            Name of the template. This should generally match the name of the
+            object being decorated for clarity.
+        @param param_list
+            Ordered container of parameter sets. For more information, see
+            `add_instantiations`.
 
         Note that the name of the inner class will not matter as it will be
         overritten with the template instantiation name.
-        In the below example, ``MyTemplateInstantiation` will be renamed to
+        In the below example, ``Impl` will be renamed to
         `MyTemplate[int]` when `param=(int,)`.
 
         Example:
 
         @TemplateClass.define("MyTemplate", param_list=[(int,), (float,)])
-        def MyTemplate(template, param):
+        def MyTemplate(param):
             T, = param
-            class MyTemplateInstantiation(object):
+            class Impl(object):
                 def __init__(self):
                     self.T = T
-            return MyTemplateInstantiation
+            return Impl
         """
 
         def decorator(instantiation_func):
@@ -216,6 +265,17 @@ class TemplateClass(TemplateBase):
             # ensure this handles nesting.
             cls.__qualname__ = cls.__name__
             cls.__module__ = self._module_name
+
+    def is_subclass_of_instantiation(self, obj):
+        """Determines if `obj` is a subclass of one of the instantiations.
+
+        @return The first instantiation of which `obj` is a subclass.
+        """
+        for param in self.param_list:
+            instantiation, _ = self.get_instantiation(param)
+            if issubclass(obj, instantiation):
+                return instantiation
+        return None
 
 
 class TemplateFunction(TemplateBase):
@@ -260,8 +320,3 @@ class TemplateMethod(TemplateBase):
         def __str__(self):
             return '<bound TemplateMethod {} of {}>'.format(
                 self._tpl._full_name(), self._obj)
-
-
-def is_instantiation_of(obj, template):
-    """Determines of an object is registered as an instantiation. """
-    return obj in template._instantiation_map.values()

--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -237,9 +237,9 @@ class TemplateBase(object):
                     self.T = T
             return Impl
         """
+        template = cls(name, *args, **kwargs)
 
         def decorator(instantiation_func):
-            template = cls(name, *args, **kwargs)
             template.add_instantiations(instantiation_func, param_list)
             return template
 

--- a/bindings/pydrake/util/cpp_template.py
+++ b/bindings/pydrake/util/cpp_template.py
@@ -257,6 +257,8 @@ class TemplateClass(TemplateBase):
     def _on_add(self, param, cls):
         # Update class name for easier debugging.
         if self._override_meta:
+            cls._original_name = cls.__name__
+            cls._original_qualname = getattr(cls, "__qualname__", cls.__name__)
             cls.__name__ = self._instantiation_name(param)
             # Define `__qualname__` in Python2 because that's what `pybind11`
             # uses when showing function signatures when an overload cannot be

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -114,6 +114,11 @@ class TestCppTemplate(unittest.TestCase):
             class Impl(object):
                 def __init__(self):
                     self.T = T
+                    self.mangled_result = self.__mangled_method()
+
+                def __mangled_method(self):
+                    # Ensure that that mangled methods are usable.
+                    return (T, 10)
 
             return Impl
 
@@ -134,6 +139,17 @@ class TestCppTemplate(unittest.TestCase):
         result = MyTemplate.is_subclass_of_instantiation(Subclass)
         self.assertTrue(result)
         self.assertEqual(result, MyTemplate[float])
+
+        # Test mangling behavior.
+        # TODO(eric.couisneau): If we use the name `Impl` for instantiations,
+        # then mangling among inherited templated classes will not work as
+        # intended. Consider an alternative, if it's ever necessary.
+        self.assertEqual(MyInt().mangled_result, (int, 10))
+        self.assertEqual(MyInt._original_name, "Impl")
+        self.assertTrue(hasattr(MyInt, "_Impl__mangled_method"))
+        self.assertEqual(MyFloat._original_name, "Impl")
+        self.assertEqual(MyFloat().mangled_result, (float, 10))
+        self.assertTrue(hasattr(MyFloat, "_Impl__mangled_method"))
 
     def test_function(self):
         template = m.TemplateFunction("func")

--- a/bindings/pydrake/util/test/cpp_template_test.py
+++ b/bindings/pydrake/util/test/cpp_template_test.py
@@ -47,8 +47,8 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEquals(template[int], 1)
         self.assertEquals(template.get_instantiation(int), (1, (int,)))
         self.assertEquals(template.get_param_set(1), {(int,)})
-        self.assertTrue(m.is_instantiation_of(1, template))
-        self.assertFalse(m.is_instantiation_of(10, template))
+        self.assertTrue(template.is_instantiation(1))
+        self.assertFalse(template.is_instantiation(10))
         # Duplicate parameters.
         self.assertRaises(
             RuntimeError, lambda: template.add_instantiation(int, 4))
@@ -74,14 +74,18 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEquals(template[[int, int]], 3)
 
         # List instantiation.
-        def instantiation_func(template, param):
-            self.assertIsInstance(template, m.TemplateBase)
+        def instantiation_func(param):
             return 100 + len(param)
         dummy_a = (str,) * 5
         dummy_b = (str,) * 10
         template.add_instantiations(instantiation_func, [dummy_a, dummy_b])
         self.assertEquals(template[dummy_a], 105)
         self.assertEquals(template[dummy_b], 110)
+
+        # Ensure that we can only call this once.
+        dummy_c = (str,) * 7
+        with self.assertRaises(RuntimeError):
+            template.add_instantiations(instantiation_func, [dummy_c])
 
     def test_class(self):
         template = m.TemplateClass("ClassTpl")
@@ -99,16 +103,19 @@ class TestCppTemplate(unittest.TestCase):
             _TEST_MODULE))
 
     def test_user_class(self):
+        test = self
 
         @m.TemplateClass.define("MyTemplate", param_list=((int,), (float,)))
-        def MyTemplate(_, param):
+        def MyTemplate(param):
             T, = param
+            # Ensure that we have deferred evaluation.
+            test.assertEqual(MyTemplate.param_list, [(int,), (float,)])
 
-            class MyTemplateInstantiation(object):
+            class Impl(object):
                 def __init__(self):
                     self.T = T
 
-            return MyTemplateInstantiation
+            return Impl
 
         self.assertIsInstance(MyTemplate, m.TemplateClass)
         MyDefault = MyTemplate[None]
@@ -117,6 +124,16 @@ class TestCppTemplate(unittest.TestCase):
         self.assertEqual(MyInt().T, int)
         MyFloat = MyTemplate[float]
         self.assertEqual(MyFloat().T, float)
+
+        # Test subclass checks.
+        class Subclass(MyTemplate[float]):
+            pass
+
+        self.assertFalse(MyTemplate.is_instantiation(Subclass))
+        self.assertFalse(MyTemplate.is_subclass_of_instantiation(object))
+        result = MyTemplate.is_subclass_of_instantiation(Subclass)
+        self.assertTrue(result)
+        self.assertEqual(result, MyTemplate[float])
 
     def test_function(self):
         template = m.TemplateFunction("func")

--- a/bindings/pydrake/util/test/wrap_function_test.cc
+++ b/bindings/pydrake/util/test/wrap_function_test.cc
@@ -356,5 +356,39 @@ GTEST_TEST(WrapFunction, ChangeCallbackNested) {
   check_expected::run(wrapped);
 }
 
+// Test `wrap_arg_function`.
+template <typename T, typename = void>
+struct wrap_change_callback : public wrap_arg_default<T> {};
+
+template <typename Signature>
+struct wrap_change_callback<const std::function<Signature>&>
+    : public wrap_arg_function<wrap_change, Signature> {};
+
+template <typename Signature>
+struct wrap_change_callback<std::function<Signature>>
+    : public wrap_change_callback<const std::function<Signature>&> {};
+
+// Test to check `wrap_change`, but only for functions.
+template <typename Func>
+auto WrapChangeCallbackOnly(Func&& func) {
+  return WrapFunction<wrap_change_callback, false>(std::forward<Func>(func));
+}
+
+Callback ChangeCallbackOnly(
+    double*, Callback, const Callback&) { return {}; }
+
+GTEST_TEST(WrapFunction, ChangeCallbackOnly) {
+  auto wrapped = WrapChangeCallbackOnly(ChangeCallbackOnly);
+  using check_expected =
+      check_signature<
+          // Return.
+          CallbackWrapped,
+          // Arguments.
+          double*,
+          CallbackWrapped,
+          CallbackWrapped>;
+  check_expected::run(wrapped);
+}
+
 }  // namespace pydrake
 }  // namespace drake

--- a/bindings/pydrake/util/wrap_pybind.h
+++ b/bindings/pydrake/util/wrap_pybind.h
@@ -8,6 +8,8 @@
 
 #include "pybind11/pybind11.h"
 
+#include "drake/bindings/pydrake/util/wrap_function.h"
+
 namespace drake {
 namespace pydrake {
 
@@ -35,6 +37,49 @@ class MirrorDef {
   A* const a_{};
   B* const b_{};
 };
+
+namespace detail {
+
+template <typename T, typename = void>
+struct wrap_ref_ptr : public wrap_arg_default<T> {};
+
+template <typename T>
+using is_generic_pybind =
+  std::is_base_of<py::detail::type_caster_generic, py::detail::make_caster<T>>;
+
+template <typename T>
+struct wrap_ref_ptr<T&, std::enable_if_t<is_generic_pybind<T>::value>> {
+  // NOLINTNEXTLINE[runtime/references]: Intentional.
+  static T* wrap(T& arg) { return &arg; }
+  static T& unwrap(T* arg_wrapped) { return *arg_wrapped; }
+};
+
+template <typename T, typename = void>
+struct wrap_callback : public wrap_arg_default<T> {};
+
+template <typename Signature>
+struct wrap_callback<const std::function<Signature>&>
+    : public wrap_arg_function<wrap_ref_ptr, Signature> {};
+
+template <typename Signature>
+struct wrap_callback<std::function<Signature>>
+    : public wrap_callback<const std::function<Signature>&> {};
+
+}  // namespace detail
+
+/// Ensures that any `std::function<>` arguments are wrapped such that any `T&`
+/// (which can infer for `T = const U`) is wrapped as `U*` (and conversely
+/// unwrapped when returned).
+/// Use this when you have a callback in C++ that has a lvalue reference (const
+/// or mutable) to a C++ argument or return value.
+/// Otherwise, `pybind11` may try and copy the object, will be bad if either
+/// the type is a non-copyable or if you are trying to mutate the object; in
+/// this case, the copy is mutated, but not the original you care about.
+/// For more information, see: https://github.com/pybind/pybind11/issues/1241
+template <typename Func>
+auto WrapCallbacks(Func&& func) {
+  return WrapFunction<detail::wrap_callback, false>(std::forward<Func>(func));
+}
 
 }  // namespace pydrake
 }  // namespace drake

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -100,6 +100,8 @@ class SystemScalarConverter {
   SystemScalarConverter(
       SystemTypeTag<S>, GuaranteedSubtypePreservation subtype_preservation)
       : SystemScalarConverter() {
+    // N.B. When changing the pairs of supported types below, be sure to also
+    // change the `ConversionPairs` type pack in `DefineFrameworkPySystems`.
     using Expression = symbolic::Expression;
     // From double to all other types.
     AddIfSupported<S, AutoDiffXd, double>(subtype_preservation);


### PR DESCRIPTION
This shows authoring a scalar-convertible class in Python.
This can be used to author a class, or can be used to write a Python trampoline class, which can then call a simpler Python implementation.

\cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8701)
<!-- Reviewable:end -->
