### PR TITLE
Added approximating functions support for IVP and quadrature classes

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -250,6 +250,7 @@ drake_cc_googletest(
         ":runge_kutta2_integrator",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/trajectories:piecewise_polynomial",
+        "//systems/analysis/test_utilities:approximation_techniques",
     ],
 )
 
@@ -257,6 +258,8 @@ drake_cc_googletest(
     name = "scalar_initial_value_problem_test",
     deps = [
         ":scalar_initial_value_problem",
+        "//common/trajectories:piecewise_polynomial",
+        "//systems/analysis/test_utilities:approximation_techniques",
     ],
 )
 
@@ -264,6 +267,8 @@ drake_cc_googletest(
     name = "antiderivative_function_test",
     deps = [
         ":antiderivative_function",
+        "//common/trajectories:piecewise_polynomial",
+        "//systems/analysis/test_utilities:approximation_techniques",
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -116,6 +116,7 @@ drake_cc_library(
     deps = [
         ":runge_kutta3_integrator",
         "//common:essential",
+        "//common/trajectories:piecewise_polynomial",
         "//systems/framework:context",
         "//systems/framework:continuous_state",
         "//systems/framework:leaf_system",
@@ -131,6 +132,7 @@ drake_cc_library(
     ],
     hdrs = [
         "scalar_initial_value_problem.h",
+        "scalar_initial_value_problem-inl.h",
     ],
     deps = [
         ":initial_value_problem",
@@ -146,6 +148,7 @@ drake_cc_library(
     ],
     hdrs = [
         "antiderivative_function.h",
+        "antiderivative_function-inl.h",
     ],
     deps = [
         ":scalar_initial_value_problem",
@@ -246,6 +249,7 @@ drake_cc_googletest(
         ":initial_value_problem",
         ":runge_kutta2_integrator",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/trajectories:piecewise_polynomial",
     ],
 )
 

--- a/systems/analysis/antiderivative_function-inl.h
+++ b/systems/analysis/antiderivative_function-inl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "drake/systems/analysis/scalar_initial_value_problem-inl.h"

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -59,8 +59,8 @@ class AntiderivativeFunction {
 
   /// Approximation technique function type, to build an approximating function
   /// G(u) to an F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx antiderivative function based on a
-  /// partition of its domain for which function value and first derivative are
-  /// known and provided at multiple values of u.
+  /// partition of its domain into multiple contiguous intervals where function
+  /// value and first derivative are known and provided at the boundaries.
   ///
   /// @param u_sequence The integration upper bound sequence
   ///                   (u₁ ... uₚ) where uₚ ∈ ℝ.
@@ -177,6 +177,8 @@ class AntiderivativeFunction {
   ApproximatingFn Approximate(
       const ApproximationTechnique<ApproximatingFn>& approximation_technique,
       const T& u, const SpecifiedValues& values = {}) const {
+    // Delegates request to the scalar IVP used for computations, by putting
+    // specified values in scalar IVP terms.
     typename ScalarInitialValueProblem<T>::SpecifiedValues
         scalar_ivp_values(values.v, {}, values.k);
     return this->scalar_ivp_->Approximate(

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -54,7 +55,27 @@ class AntiderivativeFunction {
   /// @param x The variable of integration x ∈ ℝ .
   /// @param k The parameter vector 𝐤 ∈ ℝᵐ.
   /// @return The function value f(@p x; @p k).
-  typedef std::function<T(const T& x, const VectorX<T>& k)> IntegrableFunction;
+  using IntegrableFunction = std::function<T(const T& x, const VectorX<T>& k)>;
+
+  /// Approximation technique function type, to build an approximating function
+  /// G(u) to an F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx antiderivative function based on a
+  /// partition of its domain for which function value and first derivative are
+  /// known and provided at multiple values of u.
+  ///
+  /// @param u_sequence The integration upper bound sequence
+  ///                   (u₁ ... uₚ) where uₚ ∈ ℝ.
+  /// @param f_sequence The dependent scalar variable sequence
+  ///                   (F(u₁; 𝐤) ... F(uₚ; 𝐤)) where F(uₚ; 𝐤) ∈ ℝ.
+  /// @param dfdt_sequence The dependent scalar variable first derivative
+  ///                      sequence (f(u₁; 𝐤) ... f(uₚ; 𝐤)) where
+  ///                      f(uₚ; 𝐤) ∈ ℝ.
+  /// @return The approximating function G(u) ∈ ℝ.
+  /// @tparam ApproximatingFn The approximating function type.
+  template <typename ApproximatingFn>
+  using ApproximationTechnique = std::function<ApproximatingFn (
+      const std::vector<T>& u_sequence,
+      const std::vector<T>& f_sequence,
+      const std::vector<T>& dfdt_sequence)>;
 
   /// The set of values that, along with the function being integrated,
   /// partially specify the definite integral i.e. providing the lower
@@ -111,10 +132,10 @@ class AntiderivativeFunction {
         scalar_ode_function, scalar_ivp_default_values);
   }
 
-  /// Evaluates the definite integral over the lower integration bound v (see
-  /// definition in class documentation) to @p u using the parameter vector 𝐤
-  /// (see definition in class documentation) if present in @p values, falling
-  /// back to the ones given on construction if not given.
+  /// Evaluates the definite integral F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx from the lower
+  /// integration bound v (see definition in class documentation) to @p u using
+  /// the parameter vector 𝐤 (see definition in class documentation) if present
+  /// in @p values, falling back to the ones given on construction if missing.
   ///
   /// @param u The upper integration bound.
   /// @param values The specified values for the integration.
@@ -129,6 +150,37 @@ class AntiderivativeFunction {
     typename ScalarInitialValueProblem<T>::SpecifiedValues
         scalar_ivp_values(values.v, {}, values.k);
     return scalar_ivp_->Solve(u, scalar_ivp_values);
+  }
+
+  /// Approximates the definite integral F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx with
+  /// another function G(w) defined for v <= w <= @p u using the given
+  /// @p approximation_technique. Above's lower integration bound v and
+  /// parameter vector 𝐤 (see definition in class documentation) are taken from
+  /// @p values, falling back to the ones given on construction if missing.
+  ///
+  /// @param approximation_technique The technique to build the approximating
+  ///                                function G(w).
+  /// @param u The uppermost integration bound.
+  /// @param values The specified values for the integration.
+  /// @return The approximating function G(w) to the definite integral for
+  ///         for v <= w <= @p u.
+  /// @tparam ApproximatingFn The approximating function type.
+  /// @pre The given upper integration bound @p u must be larger than or equal
+  ///      to the lower integration bound v.
+  /// @pre If given, the dimension of the parameter vector @p values.k
+  ///      must match that of the parameter vector 𝐤 in the default specified
+  ///      values given on construction.
+  /// @throw std::logic_error if preconditions are not met.
+  /// @note See ScalarInitialValueProblem::Approximate() documentation for
+  ///       further reference.
+  template <typename ApproximatingFn>
+  ApproximatingFn Approximate(
+      const ApproximationTechnique<ApproximatingFn>& approximation_technique,
+      const T& u, const SpecifiedValues& values = {}) const {
+    typename ScalarInitialValueProblem<T>::SpecifiedValues
+        scalar_ivp_values(values.v, {}, values.k);
+    return this->scalar_ivp_->Approximate(
+        approximation_technique, u, scalar_ivp_values);
   }
 
   /// Resets the internal integrator instance.

--- a/systems/analysis/initial_value_problem.cc
+++ b/systems/analysis/initial_value_problem.cc
@@ -1,10 +1,18 @@
 #include "drake/systems/analysis/initial_value_problem.h"
+
+#include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/systems/analysis/initial_value_problem-inl.h"
 
 namespace drake {
 namespace systems {
 
 template class InitialValueProblem<double>;
+
+template <typename T>
+using PP = trajectories::PiecewisePolynomial<T>;
+template PP<double> InitialValueProblem<double>::Approximate<PP<double>>(
+    const ApproximationTechnique<PP<double>>&,
+    const double&, const SpecifiedValues&) const;
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -21,11 +22,15 @@ namespace systems {
 /// allows for generic IVP definitions, which can later be solved for any
 /// instance of said vector.
 ///
-/// Additionally, this class' implementation performs basic computation caching,
-/// optimizing away repeated integration whenever the IVP is solved for
-/// increasing values of time t while both initial conditions and parameters are
-/// kept constant, e.g. if solved for t₁ > t₀ first, solving for t₂ > t₁ will
-/// only require integrating from t₁ onward.
+/// Additionally, basic support to compute approximating functions for the IVP
+/// solution is provided. This is convenient when throughput and efficiency are
+/// of paramount importance.
+///
+/// This class' implementation performs basic computation caching, optimizing
+/// away repeated integration whenever the IVP is solved for increasing values
+/// of time t while both initial conditions and parameters are kept constant,
+/// e.g. if solved for t₁ > t₀ first, solving for t₂ > t₁ will only require
+/// integrating from t₁ onward.
 ///
 /// For further insight into its use, consider the following examples:
 ///
@@ -63,9 +68,28 @@ class InitialValueProblem {
   /// @param x The dependent vector variable 𝐱 ∈ ℝⁿ.
   /// @param k The vector of parameters 𝐤 ∈ ℝᵐ.
   /// @return The derivative vector d𝐱/dt ∈ ℝⁿ.
-  typedef std::function<VectorX<T> (
-      const T& t, const VectorX<T>& x,
-      const VectorX<T>& k)> ODEFunction;
+  using ODEFunction = std::function<VectorX<T> (
+      const T& t, const VectorX<T>& x, const VectorX<T>& k)>;
+
+  /// Approximation technique function type, to build an approximating function
+  /// 𝐳(t) to an 𝐱(t; 𝐤) solution based on a partition of the solution domain
+  /// for which value 𝐱 and first derivative d𝐱/dt are known and provided at
+  /// multiple argument values t.
+  ///
+  /// @param t_sequence The independent scalar variable sequence
+  ///                   (t₁ ... tₚ) where tₚ ∈ ℝ sequence.
+  /// @param x_sequence The dependent vector variable sequence
+  ///                   (𝐱(t₁) ... 𝐱(tₚ)) where 𝐱(tₚ) ∈ ℝⁿ.
+  /// @param dxdt_sequence The dependent vector variable first derivative
+  ///                      sequence ((d𝐱/dt)(t₁) ... (d𝐱/dt)(tₚ)) where
+  ///                      (d𝐱/dt)(tₚ) ∈ ℝⁿ.
+  /// @return The approximating function 𝐳(t) ∈ ℝⁿ.
+  /// @tparam ApproximatingFn The approximating function type.
+  template <typename ApproximatingFn>
+  using ApproximationTechnique = std::function<ApproximatingFn (
+      const std::vector<T>& t_sequence,
+      const std::vector<VectorX<T>>& x_sequence,
+      const std::vector<VectorX<T>>& dxdt_sequence)>;
 
   /// A collection of values i.e. initial time t₀, initial state vector 𝐱₀
   /// and parameters vector 𝐤.to further specify the ODE system (in order
@@ -83,6 +107,14 @@ class InitialValueProblem {
                     const optional<VectorX<T>>& x0_in,
                     const optional<VectorX<T>>& k_in)
         : t0(t0_in), x0(x0_in), k(k_in) {}
+
+    bool operator==(const SpecifiedValues& rhs) const {
+      return (t0 == rhs.t0 && x0 == rhs.x0 && k == rhs.k);
+    }
+
+    bool operator!=(const SpecifiedValues& rhs) const {
+      return (t0 != rhs.t0 || x0 != rhs.x0 || k != rhs.k);
+    }
 
     optional<T> t0;  ///< The initial time t₀ for the IVP.
     optional<VectorX<T>> x0;  ///< The initial state vector 𝐱₀ for the IVP.
@@ -123,6 +155,50 @@ class InitialValueProblem {
   /// @throw std::logic_error if preconditions are not met.
   VectorX<T> Solve(const T& tf, const SpecifiedValues& values = {}) const;
 
+  /// Approximates the IVP solution 𝐱(t; 𝐤) with 𝐱(t₀; 𝐤) = 𝐱₀ using
+  /// another function 𝐳(t; 𝐤) defined for t₀ <= t <= @p tf using the
+  /// given @p approximation_technique.
+  ///
+  /// To this end, the domain interval [t₀, @p tf] is partitioned. Both
+  /// 𝐱 and d𝐱/dt values are then solved and computed respectively for the
+  /// boundaries of each sub-interval to feed the @p approximation_technique
+  /// (see ApproximationTechnique's documentation).
+  ///
+  /// Implementation wise, above's procedure is equivalent to repeatedly
+  /// calling the solver (see InitialValueProblem::Solve() method) and
+  /// the ODE function (see InitialValueProblem::ODEFunction) specified
+  /// on construction, iterating over the domain interval with an
+  /// appropriate step. In this case, however, step selection is delegated
+  /// to the integrator. This allows, depending on the integrator type, for
+  /// fixed step computations with reduced overhead and error controlled
+  /// step sizes, particularly helpful when an error bounded dense output
+  /// [Hairer, 1993] is to be generated.
+  ///
+  /// - [Hairer, 1993] E. Hairer, S. Nørsett and G. Wanner. Solving Ordinary
+  ///                  Differential Equations I (Nonstiff Problems), p. 190.
+  ///                  Springer, 1993.
+  ///
+  /// @param approximation_technique The technique that builds the
+  /// approximating function 𝐳(t; 𝐤) out of the provided partition.
+  /// @param tf The time to approximate the IVP up to.
+  /// @param values The specified values for the IVP.
+  /// @return The approximation 𝐳(t; 𝐤) to the IVP solution 𝐱(t; 𝐤)
+  ///         with 𝐱(t₀; 𝐤) = 𝐱₀ for t₀ <= t <= @p tf.
+  /// @tparam ApproximatingFn The approximating function type.
+  /// @pre Given @p tf must be larger than or equal to the specified initial
+  ///      time t₀ (either given or default).
+  /// @pre If given, the dimension of the initial state vector @p values.x0
+  ///      must match that of the default initial state vector in the default
+  ///      specified values given on construction.
+  /// @pre If given, the dimension of the parameter vector @p values.k
+  ///      must match that of the parameter vector in the default specified
+  ///      values given on construction.
+  /// @throw std::logic_error if preconditions are not met.
+  template <typename ApproximatingFn>
+  ApproximatingFn Approximate(
+      const ApproximationTechnique<ApproximatingFn>& approximation_technique,
+      const T& tf, const SpecifiedValues& values = {}) const;
+
   /// Resets the internal integrator instance by in-place
   /// construction of the given integrator type.
   ///
@@ -148,16 +224,31 @@ class InitialValueProblem {
   }
 
   /// Gets a pointer to the internal integrator instance.
-  inline const IntegratorBase<T>* get_integrator() const {
+  const IntegratorBase<T>* get_integrator() const {
     return integrator_.get();
   }
 
   /// Gets a pointer to the internal mutable integrator instance.
-  inline IntegratorBase<T>* get_mutable_integrator() {
+  IntegratorBase<T>* get_mutable_integrator() {
     return integrator_.get();
   }
 
  private:
+  // Sanitizes given @p values to solve for @p tf, i.e. sets defaults
+  // when values are missing and validates that all preconditions specified
+  // for InitialValueProblem::Solve() and InitialValueProblem::Approximate()
+  // hold.
+  //
+  // @param tf The time to solve the IVP for.
+  // @param values The specified values for the IVP.
+  // @return Sanitized values.
+  // @throw std::logic_error If preconditions specified for
+  //                         InitialValueProblem::Solve() and
+  //                         InitialValueProblem::Approximate()
+  //                         do not hold.
+  SpecifiedValues SanitizeValuesOrThrow(
+      const T& tf, const SpecifiedValues& values) const;
+
   // IVP values specified by default.
   const SpecifiedValues default_values_;
 
@@ -169,6 +260,16 @@ class InitialValueProblem {
   // (and the conditions that must hold for them to be valid)
   // expresses the fact that neither computation results nor IVP
   // definition are affected when these change.
+
+  // Invalidates and initializes cached IVP specified values and
+  // integration context based on the newly provided @p values.
+  void ResetCachedState(const SpecifiedValues& values) const;
+
+  // Conditionally invalidates and initializes cached IVP specified
+  // values and integration context based on time @p tf to solve for
+  // and the provided @p values. If cached state can be reused, it's a
+  // no-op.
+  void MayResetCachedState(const T& tf, const SpecifiedValues& values) const;
 
   // IVP current specified values (for caching).
   mutable SpecifiedValues current_values_;

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -72,9 +72,9 @@ class InitialValueProblem {
       const T& t, const VectorX<T>& x, const VectorX<T>& k)>;
 
   /// Approximation technique function type, to build an approximating function
-  /// 𝐳(t) to an 𝐱(t; 𝐤) solution based on a partition of the solution domain
-  /// for which value 𝐱 and first derivative d𝐱/dt are known and provided at
-  /// multiple argument values t.
+  /// 𝐳(t) to an 𝐱(t; 𝐤) solution based on a partition of its domain into
+  /// multiple contiguous intervals where value 𝐱 and first derivative d𝐱/dt
+  /// are known and provided at the boundaries.
   ///
   /// @param t_sequence The independent scalar variable sequence
   ///                   (t₁ ... tₚ) where tₚ ∈ ℝ sequence.

--- a/systems/analysis/scalar_initial_value_problem-inl.h
+++ b/systems/analysis/scalar_initial_value_problem-inl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "drake/systems/analysis/initial_value_problem-inl.h"

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
@@ -56,8 +58,27 @@ class ScalarInitialValueProblem {
   /// @param x The dependent variable x ∈ ℝ .
   /// @param k The parameter vector 𝐤 ∈ ℝᵐ.
   /// @return The derivative dx/dt ∈ ℝ.
-  typedef std::function<T(const T& t, const T& x,
-                          const VectorX<T>& k)> ScalarODEFunction;
+  using ScalarODEFunction = std::function<T(const T& t, const T& x,
+                                            const VectorX<T>& k)>;
+
+  /// Approximation technique function type, to build an approximating function
+  /// z(t) to an x(t; 𝐤) solution based on a partition of its domain for which
+  /// value x and first derivative dx/dt are known and provided at multiple
+  /// values of t.
+  ///
+  /// @param t_sequence The independent scalar variable sequence
+  ///                   (t₁ ... tₚ) where tₚ ∈ ℝ.
+  /// @param x_sequence The dependent scalar variable sequence
+  ///                   (x(t₁) ... x(tₚ)) where x(tₚ) ∈ ℝ.
+  /// @param dx_dt_sequence The dependent scalar variable first derivative
+  ///                       sequence ((dx/dt)(t₁) ... (dx/dt)(tₚ)) where
+  ///                       (dx/dt)(tₚ) ∈ ℝ.
+  /// @return The approximating function z(t) ∈ ℝ.
+  /// @tparam ApproximatingFn The approximating function type.
+  template <typename ApproximatingFn>
+  using ApproximationTechnique = std::function<ApproximatingFn (
+      const std::vector<T>& t, const std::vector<T>& x,
+      const std::vector<T>& dx_dt)>;
 
   /// A collection of values i.e. initial time t₀, initial state x₀
   /// and parameter vector 𝐤 to further specify the ODE system (in
@@ -124,6 +145,37 @@ class ScalarInitialValueProblem {
     return this->vector_ivp_->Solve(tf, ToVectorIVPSpecifiedValues(values))[0];
   }
 
+  /// Approximates the IVP solution x(t; 𝐤) with x(t₀; 𝐤) = x₀ using
+  /// another function z(t) defined for t₀ <= t <= @p tf using the
+  /// given @p approximation_technique.
+  ///
+  /// @param approximation_technique The technique to build the approximating
+  ///                                function z(t).
+  /// @param tf The time to solve the IVP for.
+  /// @param values The specified values for the IVP.
+  /// @return The approximating function z(t) to the IVP solution x(t; 𝐤)
+  ///         with x(t₀; 𝐤) = x₀ for t₀ <= t <= @p tf.
+  /// @tparam ApproximatingFn The approximating function type.
+  /// @pre Given @p tf must be larger than or equal to the specified initial
+  ///      time t₀ (either given or default).
+  /// @pre If given, the dimension of the initial state vector @p values.x0
+  ///      must match that of the default initial state vector in the default
+  ///      specified values given on construction.
+  /// @pre If given, the dimension of the parameter vector @p values.k
+  ///      must match that of the parameter vector in the default specified
+  ///      values given on construction.
+  /// @throw std::logic_error if preconditions are not met.
+  /// @note See InitialValueProblem::Approximate() documentation for
+  ///       further reference.
+  template <typename ApproximatingFn>
+  ApproximatingFn Approximate(
+      const ApproximationTechnique<ApproximatingFn>& approximation_technique,
+      const T& tf, const SpecifiedValues& values = {}) const {
+    return this->vector_ivp_->Approximate(
+        ToVectorApproximationTechnique(approximation_technique),
+        tf, ToVectorIVPSpecifiedValues(values));
+  }
+
   /// Resets the internal integrator instance by in-place
   /// construction of the given integrator type.
   ///
@@ -164,10 +216,36 @@ class ScalarInitialValueProblem {
     typename InitialValueProblem<T>::SpecifiedValues vector_ivp_values;
     vector_ivp_values.k = values.k;
     vector_ivp_values.t0 = values.t0;
-    if (values.x0) {
-      vector_ivp_values.x0 = VectorX<T>::Constant(1, values.x0.value()).eval();
+    if (values.x0.has_value()) {
+      vector_ivp_values.x0 = VectorX<T>::Constant(
+          1, values.x0.value()).eval();
     }
     return vector_ivp_values;
+  }
+
+  template <typename A>
+  using VectorApproximationTechnique =
+      typename InitialValueProblem<T>::template ApproximationTechnique<A>;
+
+  // Transforms given scalar @p approximation_technique into its vector form.
+  template <typename ApproximatingFn>
+  static VectorApproximationTechnique<ApproximatingFn>
+  ToVectorApproximationTechnique(
+      const ApproximationTechnique<ApproximatingFn>& approximation_technique) {
+    return [&approximation_technique](
+        const std::vector<T>& t_sequence,
+        const std::vector<VectorX<T>>& x_sequence,
+        const std::vector<VectorX<T>>& dxdt_sequence) {
+      auto vector_to_scalar = [](const VectorX<T>& v) { return v[0]; };
+      std::vector<T> scalar_x_sequence(x_sequence.size());
+      std::transform(x_sequence.begin(), x_sequence.end(),
+                     scalar_x_sequence.begin(), vector_to_scalar);
+      std::vector<T> scalar_dxdt_sequence(x_sequence.size());
+      std::transform(dxdt_sequence.begin(), dxdt_sequence.end(),
+                     scalar_dxdt_sequence.begin(), vector_to_scalar);
+      return approximation_technique(
+          t_sequence, scalar_x_sequence, scalar_dxdt_sequence);
+    };
   }
 
   // Vector IVP representation of this scalar IVP.

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -6,9 +6,11 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
+#include "drake/systems/analysis/test_utilities/approximation_techniques.h"
 
 namespace drake {
 namespace systems {
+namespace analysis {
 namespace {
 
 // Checks antiderivative function usage with multiple integrators.
@@ -127,23 +129,7 @@ class AntiderivativeFunctionAccuracyTest
 };
 
 using trajectories::PiecewisePolynomial;
-
-PiecewisePolynomial<double> CubicApproximationTechnique(
-    const std::vector<double>& t_sequence,
-    const std::vector<double>& x_sequence,
-    const std::vector<double>& dxdt_sequence) {
-  auto scalar_to_matrix = [](const double& v) {
-    return (MatrixX<double>(1, 1) << v).finished();
-  };
-  std::vector<MatrixX<double>> x_matrix_sequence(x_sequence.size());
-  std::transform(x_sequence.begin(), x_sequence.end(),
-                 x_matrix_sequence.begin(), scalar_to_matrix);
-  std::vector<MatrixX<double>> dxdt_matrix_sequence(dxdt_sequence.size());
-  std::transform(dxdt_sequence.begin(), dxdt_sequence.end(),
-                 dxdt_matrix_sequence.begin(), scalar_to_matrix);
-  return PiecewisePolynomial<double>::Cubic(
-      t_sequence, x_matrix_sequence, dxdt_matrix_sequence);
-}
+using test::CubicApproximationTechnique;
 
 // Accuracy test for the numerical integration of ∫₀ᵘ xⁿ dx,
 // parameterized in its order n.
@@ -178,7 +164,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
 
     PiecewisePolynomial<double> antiderivative_function_approximation =
         antiderivative_function.Approximate<PiecewisePolynomial<double>>(
-            CubicApproximationTechnique, kArgIntervalUBound, values);
+            CubicApproximationTechnique<double>, kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
@@ -236,7 +222,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
 
     PiecewisePolynomial<double> antiderivative_function_approximation =
         antiderivative_function.Approximate<PiecewisePolynomial<double>>(
-            CubicApproximationTechnique, kArgIntervalUBound, values);
+            CubicApproximationTechnique<double>, kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
@@ -301,7 +287,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
 
       PiecewisePolynomial<double> antiderivative_function_approximation =
           antiderivative_function.Approximate<PiecewisePolynomial<double>>(
-              CubicApproximationTechnique, kArgIntervalUBound, values);
+              CubicApproximationTechnique<double>, kArgIntervalUBound, values);
 
       for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
            u += kArgStep) {
@@ -360,7 +346,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
 
     PiecewisePolynomial<double> antiderivative_function_approximation =
         antiderivative_function.Approximate<PiecewisePolynomial<double>>(
-            CubicApproximationTechnique, kArgIntervalUBound, values);
+            CubicApproximationTechnique<double>, kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
@@ -418,7 +404,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
 
     PiecewisePolynomial<double> antiderivative_function_approximation =
         antiderivative_function.Approximate<PiecewisePolynomial<double>>(
-            CubicApproximationTechnique, kArgIntervalUBound, values);
+            CubicApproximationTechnique<double>, kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
@@ -447,5 +433,6 @@ INSTANTIATE_TEST_CASE_P(IncreasingAccuracyAntiderivativeFunctionTests,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4));
 
 }  // namespace
+}  // namespace analysis
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -7,9 +7,11 @@
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/analysis/scalar_initial_value_problem-inl.h"
+#include "drake/systems/analysis/test_utilities/approximation_techniques.h"
 
 namespace drake {
 namespace systems {
+namespace analysis {
 namespace {
 
 // Checks scalar IVP solver usage with multiple integrators.
@@ -193,23 +195,7 @@ class ScalarInitialValueProblemAccuracyTest
 };
 
 using trajectories::PiecewisePolynomial;
-
-PiecewisePolynomial<double> CubicApproximationTechnique(
-    const std::vector<double>& t_sequence,
-    const std::vector<double>& x_sequence,
-    const std::vector<double>& dxdt_sequence) {
-  auto scalar_to_matrix = [](const double& v) {
-    return (MatrixX<double>(1, 1) << v).finished();
-  };
-  std::vector<MatrixX<double>> x_matrix_sequence(x_sequence.size());
-  std::transform(x_sequence.begin(), x_sequence.end(),
-                 x_matrix_sequence.begin(), scalar_to_matrix);
-  std::vector<MatrixX<double>> dxdt_matrix_sequence(dxdt_sequence.size());
-  std::transform(dxdt_sequence.begin(), dxdt_sequence.end(),
-                 dxdt_matrix_sequence.begin(), scalar_to_matrix);
-  return PiecewisePolynomial<double>::Cubic(
-      t_sequence, x_matrix_sequence, dxdt_matrix_sequence);
-}
+using test::CubicApproximationTechnique;
 
 // Accuracy test of the solution for the stored charge Q in an RC
 // series circuit excited by a sinusoidal voltage source E(t),
@@ -266,7 +252,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
 
       PiecewisePolynomial<double> stored_charge_approx =
           stored_charge_ivp.Approximate<PiecewisePolynomial<double>>(
-              CubicApproximationTechnique, tf, values);
+              CubicApproximationTechnique<double>, tf, values);
 
       const double tau = Rs * Cs;
       const double tau_sq = tau * tau;
@@ -345,7 +331,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
 
     PiecewisePolynomial<double> population_growth_approx =
         population_growth_ivp.Approximate<PiecewisePolynomial<double>>(
-            CubicApproximationTechnique, tf, values);
+            CubicApproximationTechnique<double>, tf, values);
 
     for (double t = kInitialTime; t <= kTotalTime; t += kTimeStep) {
       // Tests are performed against the closed form
@@ -375,5 +361,6 @@ INSTANTIATE_TEST_CASE_P(IncreasingAccuracyScalarInitialValueProblemTests,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4, 1e-5));
 
 }  // namespace
+}  // namespace analysis
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test_utilities/BUILD.bazel
+++ b/systems/analysis/test_utilities/BUILD.bazel
@@ -14,6 +14,7 @@ drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
     deps = [
+        ":approximation_techniques",
         ":controlled_spring_mass_system",
         ":discontinuous_spring_mass_damper_system",
         ":explicit_error_controlled_integrator_test",
@@ -109,6 +110,16 @@ drake_cc_library(
     testonly = 1,
     hdrs = ["stiff_double_mass_spring_system.h"],
     deps = [],
+)
+
+drake_cc_library(
+    name = "approximation_techniques",
+    testonly = 1,
+    hdrs = ["approximation_techniques.h"],
+    deps = [
+        "//common:essential",
+        "//common/trajectories:piecewise_polynomial",
+    ],
 )
 
 drake_cc_googletest(

--- a/systems/analysis/test_utilities/approximation_techniques.h
+++ b/systems/analysis/test_utilities/approximation_techniques.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+
+namespace drake {
+namespace systems {
+namespace analysis {
+namespace test {
+
+/// Approximation technique for vector functions ℝ → ℝⁿ based on
+/// a cubic Hermite interpolator. Returns a PiecewisePolynomial
+/// instance to be queried through PiecewisePolynomial::value().
+///
+/// @note See InitialValueProblem::ApproximationTechnique and
+///       InitialValueProblem::Approximate() definitions for
+///       further reference.
+template <typename T>
+trajectories::PiecewisePolynomial<T> CubicVectorApproximationTechnique(
+    const std::vector<T>& t_sequence,
+    const std::vector<VectorX<T>>& x_sequence,
+    const std::vector<VectorX<T>>& dxdt_sequence) {
+  // Transforms values and first derivatives of the function to be
+  // approximated into N-by-1 matrices (i.e. column vectors) to match
+  // PiecewisePolynomial API.
+  auto vector_to_matrix = [](const VectorX<T>& v) {
+    return (MatrixX<T>(v.size(), 1) << v).finished();
+  };
+  std::vector<MatrixX<T>> x_matrix_sequence(x_sequence.size());
+  std::transform(x_sequence.begin(), x_sequence.end(),
+                 x_matrix_sequence.begin(), vector_to_matrix);
+  std::vector<MatrixX<T>> dxdt_matrix_sequence(dxdt_sequence.size());
+  std::transform(dxdt_sequence.begin(), dxdt_sequence.end(),
+                 dxdt_matrix_sequence.begin(), vector_to_matrix);
+  // Computes and returns the cubic spline.
+  return trajectories::PiecewisePolynomial<T>::Cubic(
+      t_sequence, x_matrix_sequence, dxdt_matrix_sequence);
+}
+
+/// Approximation technique for scalar functions ℝ → ℝ based on
+/// a cubic Hermite interpolator. Returns a PiecewisePolynomial
+/// instance to be queried through PiecewisePolynomial::scalarValue().
+///
+/// @note See ScalarInitialValueProblem::ApproximationTechnique and
+///       ScalarInitialValueProblem::Approximate() definitions for
+///       further reference.
+template <typename T>
+trajectories::PiecewisePolynomial<T> CubicApproximationTechnique(
+    const std::vector<T>& t_sequence,
+    const std::vector<T>& x_sequence,
+    const std::vector<T>& dxdt_sequence) {
+  // Transforms values and first derivatives of the function to be
+  // approximated into one element matrices to match PiecewisePolynomial
+  // API.
+  auto scalar_to_matrix = [](const T& v) {
+    return (MatrixX<T>(1, 1) << v).finished();
+  };
+  std::vector<MatrixX<T>> x_matrix_sequence(x_sequence.size());
+  std::transform(x_sequence.begin(), x_sequence.end(),
+                 x_matrix_sequence.begin(), scalar_to_matrix);
+  std::vector<MatrixX<T>> dxdt_matrix_sequence(dxdt_sequence.size());
+  std::transform(dxdt_sequence.begin(), dxdt_sequence.end(),
+                 dxdt_matrix_sequence.begin(), scalar_to_matrix);
+  // Computes and returns the cubic spline.
+  return trajectories::PiecewisePolynomial<T>::Cubic(
+      t_sequence, x_matrix_sequence, dxdt_matrix_sequence);
+}
+
+}  // namespace test
+}  // namespace analysis
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This pull request adds support to obtain an `ApproximatingFunction` based on a provided `ApproximationTechnique` for any of the IVP and quadrature classes available below the `drake::systems::analysis` namespace. The motivating use case for this implementation involves _dense output_ requirements for both an IVP solution and a quadrature computation, while maintaining a given accuracy.

A few high level explanations to help the review. The `ApproximatingFunction` is not bound to any given type to avoid constraining the user in the absence of a general enough approximation device that can also remain consistent with the public interface of each class (e.g. vector vs scalar IVP solvers). Performing the interpolation within these classes where direct access to the underlying integrators is available reduces the overhead and allows leveraging variable, error controlled step sizes for the final result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8707)
<!-- Reviewable:end -->
