### PR TITLE
Suppress MOSEK 8.1 data races

### DIFF
--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -23,8 +23,8 @@ thread:__kmp_create_worker
 # thread leak (libiomp5.*) in __kmp_create_monitor
 thread:__kmp_create_monitor
 
-# data race (libmosek64.*) in MSK_memman_free
-race:MSK_memman_free
+# data race libmosek64.so.8.1.  MOSEK has not been instrumented with TSan.
+called_from_lib:libmosek64.so.8.1
 
 # data race (libglib-2.0.*) in g_static_rec_mutex_lock
 race:g_static_rec_mutex_lock


### PR DESCRIPTION
To reproduce (according to @hongkai-dai):
`bazel test --compiler=gcc-5 --nocache_test_results --runs_per_test=5 --compilation_mode=dbg --config=tsan_everything //solvers:non_convex_optimization_util_test`

The test non-deterministically fails with TSan.

[Failing build](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-tsan-everything/1193/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8710)
<!-- Reviewable:end -->
