### PR TITLE
Adds do/while guards to spdlog macros

### DIFF
--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -51,13 +51,19 @@ printed without any special handling.
 #define SPDLOG_DEBUG_ON 1
 #define SPDLOG_TRACE_ON 1
 
-#define DRAKE_SPDLOG_TRACE(logger, ...) \
-  if (logger->level() <= spdlog::level::trace) \
-    SPDLOG_TRACE(logger, __VA_ARGS__)
+#define DRAKE_SPDLOG_TRACE(logger, ...)            \
+  do {                                             \
+    if (logger->level() <= spdlog::level::trace) { \
+      SPDLOG_TRACE(logger, __VA_ARGS__);           \
+    }                                              \
+  } while (0)
 
-#define DRAKE_SPDLOG_DEBUG(logger, ...) \
-  if (logger->level() <= spdlog::level::debug) \
-    SPDLOG_DEBUG(logger, __VA_ARGS__)
+#define DRAKE_SPDLOG_DEBUG(logger, ...)            \
+  do {                                             \
+    if (logger->level() <= spdlog::level::debug) { \
+      SPDLOG_DEBUG(logger, __VA_ARGS__);           \
+    }                                              \
+  } while (0)
 #else
 #define DRAKE_SPDLOG_TRACE(logger, ...)
 #define DRAKE_SPDLOG_DEBUG(logger, ...)


### PR DESCRIPTION
DRAKE_SPDLOG macros were missing de rigueur do/while(0) guards to make them play well when used as blocks without curlies.

Fixes #8712.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8713)
<!-- Reviewable:end -->
