### PR TITLE
Build AgentTrajectory from waypoints

### DIFF
--- a/automotive/agent_trajectory.cc
+++ b/automotive/agent_trajectory.cc
@@ -1,7 +1,24 @@
 #include "drake/automotive/agent_trajectory.h"
 
+#include <algorithm>
+
 namespace drake {
 namespace automotive {
+
+namespace {
+
+// Helper to construct a vector of Eigen::MatrixXd from a vector of
+// Eigen::Vector3d.
+std::vector<Eigen::MatrixXd> ToVectorOfMatrixXd(
+    const std::vector<Eigen::Vector3d>& translations) {
+  std::vector<Eigen::MatrixXd> result{};
+  for (const auto& translation : translations) {
+    result.emplace_back(translation);
+  }
+  return result;
+}
+
+}  // namespace
 
 using multibody::SpatialVelocity;
 using trajectories::PiecewisePolynomial;
@@ -9,58 +26,101 @@ using trajectories::PiecewiseQuaternionSlerp;
 
 PoseVelocity::PoseVelocity()
     : PoseVelocity::PoseVelocity(
-          Eigen::Quaternion<double>::Identity(),
-          Eigen::Translation<double, 3>::Identity(),
+          Eigen::Quaternion<double>::Identity(), Eigen::Vector3d::Zero(),
           SpatialVelocity<double>(Vector6<double>::Zero())) {}
 
 PoseVelocity::PoseVelocity(const Eigen::Quaternion<double>& rotation,
-                           const Eigen::Translation<double, 3>& translation,
+                           const Eigen::Vector3d& translation,
                            const SpatialVelocity<double>& velocity)
     : rotation_(rotation), translation_(translation), velocity_(velocity) {}
 
 PoseVelocity AgentTrajectory::value(double time) const {
   const Eigen::Quaternion<double> rotation(rotation_.orientation(time));
-  const Eigen::Translation<double, 3> translation(translation_.value(time));
-  const Eigen::Vector3d translation_dot = translation_dot_.value(time);
-  const Eigen::Vector3d rpy_dot = rotation_.angular_velocity(time);
+  const Eigen::Vector3d translation(translation_.value(time));
+  const Eigen::Vector3d translation_dot(translation_dot_.value(time));
+  const Eigen::Vector3d rpy_dot(rotation_.angular_velocity(time));
   const SpatialVelocity<double> velocity(rpy_dot, translation_dot);
   return PoseVelocity{rotation, translation, velocity};
 }
 
 AgentTrajectory AgentTrajectory::Make(
     const std::vector<double>& times,
-    const std::vector<Eigen::Isometry3d>& knots,
+    const std::vector<Eigen::Quaternion<double>>& knots_rotation,
+    const std::vector<Eigen::Vector3d>& knots_translation,
     const InterpolationType& interp_type) {
-  DRAKE_THROW_UNLESS(times.size() == knots.size());
-  std::vector<Eigen::Quaternion<double>> knots_rotation(times.size());
-  std::vector<Eigen::MatrixXd> knots_translation(times.size());
-  for (int i{0}; i < static_cast<int>(times.size()); ++i) {
-    knots_rotation[i] = knots[i].rotation();
-    knots_translation[i] = knots[i].translation();
-  }
+  DRAKE_THROW_UNLESS(times.size() == knots_rotation.size());
+  DRAKE_THROW_UNLESS(times.size() == knots_translation.size());
   const PiecewiseQuaternionSlerp<double> rotation(times, knots_rotation);
   PiecewisePolynomial<double> translation;
   switch (interp_type) {
-    case InterpolationType::kZeroOrderHold:
-      translation =
-          PiecewisePolynomial<double>::ZeroOrderHold(times, knots_translation);
-      break;
     case InterpolationType::kFirstOrderHold:
-      translation =
-          PiecewisePolynomial<double>::FirstOrderHold(times, knots_translation);
+      translation = PiecewisePolynomial<double>::FirstOrderHold(
+          times, ToVectorOfMatrixXd(knots_translation));
       break;
     case InterpolationType::kCubic:
-      translation =
-          PiecewisePolynomial<double>::Cubic(times, knots_translation);
+      translation = PiecewisePolynomial<double>::Cubic(
+          times, ToVectorOfMatrixXd(knots_translation));
       break;
     case InterpolationType::kPchip:
-      translation =
-          PiecewisePolynomial<double>::Pchip(times, knots_translation);
+      translation = PiecewisePolynomial<double>::Pchip(
+          times, ToVectorOfMatrixXd(knots_translation));
       break;
     default:
       throw std::logic_error("The provided interp_type is not supported.");
   }
   return AgentTrajectory{translation, rotation};
+}
+
+AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
+    const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
+    const std::vector<Eigen::Vector3d>& waypoints_translation,
+    const std::vector<double>& speeds) {
+  DRAKE_THROW_UNLESS(!waypoints_rotation.empty());
+  DRAKE_THROW_UNLESS(!waypoints_translation.empty());
+  DRAKE_THROW_UNLESS(speeds.size() == waypoints_rotation.size());
+  DRAKE_THROW_UNLESS(speeds.size() == waypoints_translation.size());
+  std::vector<double> times(waypoints_rotation.size());
+  std::vector<Eigen::MatrixXd> translations =
+      ToVectorOfMatrixXd(waypoints_translation);
+  times[0] = 0.;
+  // Populate the segment times given a piecewise-linear travel time estimate.
+  for (int i{0}; i < static_cast<int>(speeds.size()) - 1; i++) {
+    DRAKE_THROW_UNLESS(speeds[i] >= 0.);
+    // speed_k == 0. ⇒ speed_k+1 > 0., ∀ k = 0..N-1
+    DRAKE_THROW_UNLESS(speeds[i + 1] > 0. || speeds[i] != 0.);
+    const double distance = (translations[i] - translations[i + 1]).norm();
+    const double average_speed = 0.5 * (speeds[i] + speeds[i + 1]);
+    const double delta_t = distance / average_speed;
+    times[i + 1] = delta_t + times[i];
+  }
+  const PiecewiseQuaternionSlerp<double> rotation(times, waypoints_rotation);
+
+  // Starting with a piecewise-linear estimate of spline segment lengths, make
+  // a loop that refines the segment lengths based on the constructed spline,
+  // iterating until a tolerance is met.
+  std::vector<Eigen::MatrixXd> linear_velocities(times.size());
+  for (int i{0}; i < static_cast<int>(times.size()); i++) {
+    const Eigen::Matrix3d rotation_matrix =
+        math::RotationMatrix<double>(waypoints_rotation[i]).matrix();
+    // Represent forward speed in frame A as velocity in frame W.
+    linear_velocities[i] = rotation_matrix * Eigen::Vector3d{speeds[i], 0., 0.};
+  }
+  const PiecewisePolynomial<double> translation =
+      PiecewisePolynomial<double>::Cubic(times, translations,
+                                         linear_velocities);
+
+  return AgentTrajectory(translation, rotation);
+}
+
+AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
+    const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
+    const std::vector<Eigen::Vector3d>& waypoints_translation, double speed) {
+  DRAKE_THROW_UNLESS(waypoints_rotation.size() == waypoints_translation.size());
+  DRAKE_THROW_UNLESS(speed > 0.);
+  std::vector<double> speeds(waypoints_rotation.size());
+  std::fill(speeds.begin(), speeds.end(), speed);
+  return MakeCubicFromWaypoints(waypoints_rotation, waypoints_translation,
+                                speeds);
 }
 
 AgentTrajectory::AgentTrajectory(

--- a/automotive/test/agent_trajectory_test.cc
+++ b/automotive/test/agent_trajectory_test.cc
@@ -1,5 +1,6 @@
 #include "drake/automotive/agent_trajectory.h"
 
+#include <algorithm>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -14,20 +15,19 @@ namespace automotive {
 namespace {
 
 static constexpr double kTol = 1e-12;
+static constexpr double kDeltaT = 2.;  // The expected time interval to traverse
+                                       // a pair of waypoints.
 
+using Eigen::Quaternion;
+using Eigen::Vector3d;
 using math::IsQuaternionValid;
 using multibody::SpatialVelocity;
-using Eigen::Isometry3d;
-using Eigen::Quaternion;
-using Eigen::Translation;
-using Eigen::Vector3d;
 
 // Checks the defaults.
 GTEST_TEST(PoseVelocityTest, Defaults) {
   const PoseVelocity actual;
 
-  EXPECT_TRUE(CompareMatrices(actual.translation().vector(),
-                              Translation<double, 3>::Identity().vector()));
+  EXPECT_TRUE(CompareMatrices(actual.translation(), Vector3d::Zero()));
   EXPECT_TRUE(CompareMatrices(actual.rotation().matrix(),
                               Quaternion<double>::Identity().matrix()));
   EXPECT_TRUE(
@@ -41,16 +41,15 @@ GTEST_TEST(PoseVelocityTest, Accessors) {
   using std::pow;
   using std::sqrt;
 
-  const Translation<double, 3> translation{1., 2., 3.};
-  const math::RollPitchYaw<double> rpy(0.4, 0.5, 0.6);
+  const Vector3d translation{1., 2., 3.};
+  const math::RollPitchYaw<double> rpy{0.4, 0.5, 0.6};
   const Quaternion<double> quaternion = rpy.ToQuaternion();
   const Vector3d w{8., 9., 10.};
   const Vector3d v{11., 12., 13.};
   const SpatialVelocity<double> velocity{w, v};
   const PoseVelocity actual(quaternion, translation, velocity);
 
-  EXPECT_TRUE(
-      CompareMatrices(actual.translation().vector(), translation.vector()));
+  EXPECT_TRUE(CompareMatrices(actual.translation(), translation));
   EXPECT_TRUE(
       CompareMatrices(actual.rotation().matrix(), quaternion.matrix(), kTol));
   EXPECT_TRUE(CompareMatrices(actual.velocity().rotational(), w));
@@ -61,12 +60,40 @@ GTEST_TEST(PoseVelocityTest, Accessors) {
   EXPECT_EQ(actual.speed(), sqrt(pow(v(0), 2) + pow(v(1), 2) + pow(v(2), 2)));
 }
 
-// Mismatched-sized vectors are rejected.
-GTEST_TEST(AgentTrajectoryTest, MismatchedSizes) {
-  const std::vector<double> times{0., 1., 2.};  // A 3D vector.
-  const Isometry3d dummy_value(Quaternion<double>::Identity());
-  std::vector<Isometry3d> values{dummy_value};  // A 1D vector.
-  EXPECT_THROW(AgentTrajectory::Make(times, values), std::exception);
+void CheckAllConstructors(const std::vector<double>& times,
+                          const std::vector<Quaternion<double>>& rotations,
+                          const std::vector<Vector3d>& translations,
+                          const std::vector<double> speeds) {
+  EXPECT_THROW(AgentTrajectory::Make(times, rotations, translations),
+               std::exception);
+  EXPECT_THROW(
+      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      std::exception);
+  EXPECT_THROW(AgentTrajectory::MakeCubicFromWaypoints(rotations, translations,
+                                                       speeds[0]),
+               std::exception);
+}
+
+// Empty or mismatched-sized vectors are rejected.
+GTEST_TEST(AgentTrajectoryTest, InvalidSizes) {
+  const std::vector<double> times_3d{0., 1., 2.};
+  const Quaternion<double> dummy_rotation = Quaternion<double>::Identity();
+  const Vector3d dummy_translation = Vector3d::Zero();
+  const std::vector<Quaternion<double>> rotations_empty{};
+  const std::vector<Quaternion<double>> rotations_1d{dummy_rotation};
+  const std::vector<Quaternion<double>> rotations_3d{
+      dummy_rotation, dummy_rotation, dummy_rotation};
+  const std::vector<Vector3d> translations_empty{};
+  const std::vector<Vector3d> translations_1d{dummy_translation};
+  const std::vector<Vector3d> translations_3d{
+      dummy_translation, dummy_translation, dummy_translation};
+  const std::vector<double> speeds_3d{3., 4., 5.};
+
+  CheckAllConstructors(times_3d, rotations_empty, translations_3d, speeds_3d);
+  CheckAllConstructors(times_3d, rotations_3d, translations_empty, speeds_3d);
+  CheckAllConstructors(times_3d, rotations_1d, translations_1d, speeds_3d);
+  CheckAllConstructors(times_3d, rotations_3d, translations_1d, speeds_3d);
+  CheckAllConstructors(times_3d, rotations_1d, translations_3d, speeds_3d);
 }
 
 // Accepts all interpolation types.
@@ -74,11 +101,15 @@ GTEST_TEST(AgentTrajectoryTest, InterpolationType) {
   using Type = AgentTrajectory::InterpolationType;
 
   const std::vector<double> times{0., 1., 2.};
-  const Isometry3d dummy_value(Quaternion<double>::Identity());
-  std::vector<Isometry3d> values{dummy_value, dummy_value, dummy_value};
-  for (const auto& type : {Type::kZeroOrderHold, Type::kFirstOrderHold,
-                           Type::kCubic, Type::kPchip}) {
-    EXPECT_NO_THROW(AgentTrajectory::Make(times, values, type));
+  const Quaternion<double> dummy_rotation = Quaternion<double>::Identity();
+  const Vector3d dummy_translation = Vector3d::Zero();
+  std::vector<Quaternion<double>> rotations{dummy_rotation, dummy_rotation,
+                                            dummy_rotation};
+  std::vector<Vector3d> translations{dummy_translation, dummy_translation,
+                                     dummy_translation};
+  for (const auto& type : {Type::kFirstOrderHold, Type::kCubic, Type::kPchip}) {
+    EXPECT_NO_THROW(
+        AgentTrajectory::Make(times, rotations, translations, type));
   }
 }
 
@@ -87,10 +118,8 @@ GTEST_TEST(AgentTrajectoryTest, InterpolationType) {
 GTEST_TEST(AgentTrajectoryTest, AgentTrajectory) {
   using Type = AgentTrajectory::InterpolationType;
 
-  const double delta_t = 1.;
-  const std::vector<double> times{0., delta_t, 2 * delta_t};
-  std::vector<Isometry3d> poses{};
-  std::vector<Translation<double, 3>> translations{};
+  const std::vector<double> times{0., kDeltaT, 2 * kDeltaT};
+  std::vector<Vector3d> translations{};
   std::vector<Quaternion<double>> rotations{};
 
   for (double time : times) {
@@ -100,13 +129,10 @@ GTEST_TEST(AgentTrajectoryTest, AgentTrajectory) {
                          0.6 + 0.3 * time,  // BR
                          0.7 + 0.4 * time});
     rotations.back().normalize();
-    Isometry3d pose(translations.back());
-    pose.rotate(rotations.back());
-    poses.push_back(pose);
   }
 
-  const AgentTrajectory trajectory =
-      AgentTrajectory::Make(times, poses, Type::kFirstOrderHold);
+  const AgentTrajectory trajectory = AgentTrajectory::Make(
+      times, rotations, translations, Type::kFirstOrderHold);
 
   for (int i{0}; i < static_cast<int>(times.size()); i++) {
     if (i < static_cast<int>(times.size()) - 1) {
@@ -121,20 +147,161 @@ GTEST_TEST(AgentTrajectoryTest, AgentTrajectory) {
     // knot points.
     const PoseVelocity actual = trajectory.value(times[i]);
     EXPECT_TRUE(IsQuaternionValid(actual.rotation(), kTol));
-    EXPECT_TRUE(CompareMatrices(actual.translation().vector(),
-                                translations[i].vector()));
+    EXPECT_TRUE(CompareMatrices(actual.translation(), translations[i]));
     EXPECT_TRUE(CompareMatrices(actual.rotation().matrix(),
                                 rotations[i].matrix(), kTol));
 
     // Check that the velocities are consistent with the translational movement
     // under linear interpolation and the velocities are as expected given the
     // change in rotations between time steps.
-    const Vector3d v_expected{1. / delta_t, 1. / delta_t, 1. / delta_t};
+    const Vector3d v_expected{1., 1., 1.};
     EXPECT_TRUE(
         CompareMatrices(actual.velocity().translational(), v_expected, kTol));
     EXPECT_LT(0., actual.velocity().rotational().x());
     EXPECT_LT(0., actual.velocity().rotational().y());
     EXPECT_LT(0., actual.velocity().rotational().z());
+  }
+}
+
+// Computes a vector of x-y-z positions (with y, z fixed), under
+// piecewise-linear interpolation of the vector of speeds, enforcing the
+// expected time increment `kDeltaT` between each waypoint.  `translations`
+// starts from x-y-z position [1., 2., 3.].  `rotations` is held constant at an
+// orientation (r-p-y) of [0., 0., 0.] unless otherwise specified.
+void MakePoses(const std::vector<double>& speeds,
+               std::vector<Quaternion<double>>* rotations,
+               std::vector<Vector3d>* translations,
+               const Vector3d& rpy = Vector3d{0., 0., 0.}) {
+  rotations->resize(speeds.size());
+  translations->resize(speeds.size());
+  double displacement = 0.;
+  for (int i{0}; i < static_cast<int>(speeds.size()); i++) {
+    (*rotations)[i] = math::RollPitchYaw<double>(rpy).ToQuaternion();
+    (*translations)[i] = Vector3d(1. + displacement, 2., 3.);
+
+    double interval_speed{0.};
+    interval_speed = 0.5 * (speeds[i] + speeds[i + 1]);
+    displacement += kDeltaT * interval_speed;
+  }
+}
+
+// Negative speeds are rejected.
+GTEST_TEST(AgentTrajectoryTest, NegativeSpeeds) {
+  const std::vector<double> speeds{-1, 5.};
+  std::vector<Quaternion<double>> rotations{};
+  std::vector<Vector3d> translations{};
+  MakePoses(speeds, &rotations, &translations);
+
+  EXPECT_THROW(
+      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      std::exception);
+  EXPECT_THROW(
+      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, -1.),
+      std::exception);
+}
+
+// Deadlock detection rejects unreachable waypoints.
+GTEST_TEST(AgentTrajectoryTest, UnreachableCubicWaypoints) {
+  const std::vector<double> speeds{0., 0., 1.};
+  std::vector<Quaternion<double>> rotations{};
+  std::vector<Vector3d> translations{};
+  MakePoses(speeds, &rotations, &translations);
+
+  EXPECT_THROW(
+      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      std::exception);
+}
+
+struct RpyCase {
+  RpyCase(const Vector3d& rpy, const Vector3d& vel)
+      : rpy_value(rpy), expected_velocity_basis(vel) {}
+  const Vector3d rpy_value{};
+  const Vector3d expected_velocity_basis{};  // Basis vector for velocity in
+                                             // x-y-z coordinates.
+};
+
+// Checks that the provided speeds and waypoints yield correctly-formed
+// trajectories using InterpolationType::kCubic on the linear quantities.
+GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypoints) {
+  using std::max_element;
+  using std::min_element;
+
+  const std::vector<double> speeds{1., 5., 0.};
+  std::vector<RpyCase> rpy_cases{};
+  rpy_cases.push_back(RpyCase({0., 0., 0.}, {1., 0., 0.}));
+  rpy_cases.push_back(RpyCase({0., 0., M_PI_2}, {0., 1., 0.}));
+  rpy_cases.push_back(RpyCase({0., M_PI_2, 0.}, {0., 0., -1.}));
+  rpy_cases.push_back(RpyCase({M_PI_2, 0., 0.}, {1., 0., 0.}));
+
+  for (const auto& rpy_case : rpy_cases) {
+    std::vector<Quaternion<double>> rotations{};
+    std::vector<Vector3d> translations{};
+    MakePoses(speeds, &rotations, &translations, rpy_case.rpy_value);
+
+    const AgentTrajectory trajectory = AgentTrajectory::MakeCubicFromWaypoints(
+        rotations, translations, speeds);
+
+    double time{0.};
+    for (int i{0}; i < static_cast<int>(speeds.size()); i++, time += kDeltaT) {
+      // Evaluate at the expected time corresponding to the i-th waypoint.
+      const PoseVelocity actual_at = trajectory.value(time);
+      EXPECT_TRUE(
+          CompareMatrices(actual_at.translation(), translations[i], kTol));
+      EXPECT_TRUE(CompareMatrices(actual_at.velocity().translational(),
+                                  rpy_case.expected_velocity_basis * speeds[i],
+                                  kTol));
+      EXPECT_NEAR(actual_at.speed(), speeds[i], kTol);
+      EXPECT_TRUE(CompareMatrices(actual_at.rotation().matrix(),
+                                  rotations[i].matrix(), kTol));
+      EXPECT_TRUE(CompareMatrices(actual_at.velocity().rotational(),
+                                  Vector3d{0., 0., 0.}, kTol));
+
+      if (i == static_cast<int>(speeds.size()) - 1) break;
+
+      // Evaluate between waypoints i and i + 1.
+      const PoseVelocity actual_between = trajectory.value(time + kDeltaT / 2.);
+      EXPECT_GT(actual_between.translation().x(), translations[i].x());
+      EXPECT_LT(actual_between.translation().x(), translations[i + 1].x());
+      EXPECT_GT(actual_between.speed(),
+                *min_element(speeds.begin(), speeds.end()));
+      EXPECT_LT(actual_between.speed(),
+                *max_element(speeds.begin(), speeds.end()));
+      EXPECT_TRUE(CompareMatrices(actual_between.rotation().matrix(),
+                                  rotations[i].matrix(), kTol));
+      EXPECT_TRUE(CompareMatrices(actual_between.velocity().rotational(),
+                                  Vector3d{0., 0., 0.}, kTol));
+    }
+  }
+}
+
+// Checks that the provided waypoints yield correctly-formed trajectories with
+// the constant-speed constructor.
+GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypointsWithConstantSpeed) {
+  const double speed = 5.;
+  const std::vector<double> speeds{speed, speed};  // Only for sizing `poses`.
+  std::vector<Quaternion<double>> rotations{};
+  std::vector<Vector3d> translations{};
+  MakePoses(speeds, &rotations, &translations);
+
+  const AgentTrajectory trajectory =
+      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speed);
+
+  const std::vector<double> expected_times{0., kDeltaT};
+  for (int i{0}; i < static_cast<int>(expected_times.size()); i++) {
+    const double time = expected_times[i];
+    // Evaluate at the expected time corresponding to the i-th waypoint.
+    const PoseVelocity actual_at = trajectory.value(time);
+    EXPECT_TRUE(
+        CompareMatrices(actual_at.translation(), translations[i], kTol));
+    EXPECT_TRUE(CompareMatrices(actual_at.rotation().matrix(),
+                                rotations[i].matrix(), kTol));
+    EXPECT_EQ(actual_at.speed(), speed);
+
+    if (i == static_cast<int>(speeds.size()) - 1) break;
+
+    // Evaluate between waypoints i and i+1.
+    const PoseVelocity actual_between = trajectory.value(time + kDeltaT / 2.);
+    EXPECT_NEAR(actual_between.speed(), speed, kTol);
   }
 }
 


### PR DESCRIPTION
Allow additional constructors to build AgentTrajectories from a set of (time-independent) waypoints consisting of pose and speed.

Toward #8529.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8720)
<!-- Reviewable:end -->
