### PR TITLE
drake_py: Remove alias from isolated targets; rename prefix from `_isolated/` to `py/`

### DIFF
--- a/tools/skylark/drake_py.bzl
+++ b/tools/skylark/drake_py.bzl
@@ -26,8 +26,8 @@ def _py_target_isolated(
     # Do not isolate targets that are already isolated. This generally happens
     # when linting tests (which are isolated) are invoked for isolated Python
     # targets. Without this check, the actual test turns into
-    # `_isolated/_isolated/{name}`.
-    prefix = "_isolated/"
+    # `py/py/{name}`.
+    prefix = "py/"
     if isolate and not name.startswith(prefix):
         actual = prefix + name
         # Preserve original functionality.


### PR DESCRIPTION
Resolves #8557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8724)
<!-- Reviewable:end -->
