### PR TITLE
Add drake_cc_package_library for some more packages

### DIFF
--- a/examples/multibody/inclined_plane/BUILD.bazel
+++ b/examples/multibody/inclined_plane/BUILD.bazel
@@ -20,7 +20,7 @@ drake_cc_binary(
     deps = [
         "//common:text_logging_gflags",
         "//geometry:geometry_visualization",
-        "//multibody/benchmarks/inclined_plane:make_inclined_plane_plant",
+        "//multibody/benchmarks/inclined_plane",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/lcm:lcm_pubsub_system",

--- a/examples/multibody/pendulum/BUILD.bazel
+++ b/examples/multibody/pendulum/BUILD.bazel
@@ -16,7 +16,7 @@ drake_cc_binary(
     test_rule_args = ["--target_realtime_rate=0.0"],
     deps = [
         "//geometry:geometry_visualization",
-        "//multibody/benchmarks/pendulum:make_pendulum_plant",
+        "//multibody/benchmarks/pendulum",
         "//systems/analysis:implicit_euler_integrator",
         "//systems/analysis:runge_kutta3_integrator",
         "//systems/analysis:semi_explicit_euler_integrator",

--- a/manipulation/planner/BUILD.bazel
+++ b/manipulation/planner/BUILD.bazel
@@ -89,7 +89,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//examples/kuka_iiwa_arm:iiwa_common",
         "//manipulation/util:world_sim_tree_builder",
-        "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",
+        "//multibody/benchmarks/kuka_iiwa_robot",
     ],
 )
 

--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -466,7 +466,7 @@ drake_cc_googletest(
         ":rigid_body_tree",
         "//common:find_resource",
         "//common/test_utilities:eigen_matrix_compare",
-        "//multibody/benchmarks/acrobot",
+        "//multibody/benchmarks/acrobot:analytical_acrobot",
         "//multibody/parsers",
     ],
 )

--- a/multibody/benchmarks/acrobot/BUILD.bazel
+++ b/multibody/benchmarks/acrobot/BUILD.bazel
@@ -1,12 +1,24 @@
 # -*- python -*-
 
-load("//tools:drake.bzl", "drake_cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
 
-drake_cc_library(
+drake_cc_package_library(
     name = "acrobot",
+    deps = [
+        ":analytical_acrobot",
+        ":make_acrobot_plant",
+    ],
+)
+
+drake_cc_library(
+    name = "analytical_acrobot",
     srcs = ["acrobot.cc"],
     hdrs = ["acrobot.h"],
     deps = [
@@ -40,8 +52,4 @@ drake_cc_library(
     ],
 )
 
-add_lint_tests(
-    # We need to more seriously refactor and deprecate some names here before
-    # we can start following package_library conventions.
-    enable_library_lint = False,
-)
+add_lint_tests()

--- a/multibody/benchmarks/free_body/BUILD.bazel
+++ b/multibody/benchmarks/free_body/BUILD.bazel
@@ -8,7 +8,9 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+# Because there are no meaninfully distinct components in this package, the
+# only public target we will offer is our drake_cc_package_library.
+package(default_visibility = ["//visibility:private"])
 
 filegroup(
     name = "models",
@@ -36,7 +38,6 @@ drake_cc_library(
     hdrs = [
         "free_body.h",
     ],
-    visibility = ["//visibility:private"],
     deps = [
         "//common",
         "//math:geometric_transform",

--- a/multibody/benchmarks/inclined_plane/BUILD.bazel
+++ b/multibody/benchmarks/inclined_plane/BUILD.bazel
@@ -1,9 +1,22 @@
 # -*- python -*-
 
-load("//tools:drake.bzl", "drake_cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+# Because there are no meaninfully distinct components in this package, the
+# only public target we will offer is our drake_cc_package_library.
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_package_library(
+    name = "inclined_plane",
+    deps = [
+        ":make_inclined_plane_plant",
+    ],
+)
 
 drake_cc_library(
     name = "make_inclined_plane_plant",

--- a/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
+++ b/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
@@ -8,7 +8,7 @@ load(
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-# Because there are no meaninfully distinct compoments in this package, the
+# Because there are no meaninfully distinct components in this package, the
 # only public target we will offer is our drake_cc_package_library.
 package(default_visibility = ["//visibility:private"])
 

--- a/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
+++ b/multibody/benchmarks/kuka_iiwa_robot/BUILD.bazel
@@ -1,12 +1,26 @@
 # -*- python -*-
 
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = [":__subpackages__"])
+# Because there are no meaninfully distinct compoments in this package, the
+# only public target we will offer is our drake_cc_package_library.
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_package_library(
+    name = "kuka_iiwa_robot",
+    deps = [
+        ":make_kuka_iiwa_model",
+    ],
+)
 
 drake_cc_library(
-    name = "kuka_iiwa_robot_library",
+    name = "drake_kuka_iiwa_robot",
     testonly = 1,
     srcs = [
         "drake_kuka_iiwa_robot.cc",
@@ -30,7 +44,6 @@ drake_cc_library(
     hdrs = [
         "make_kuka_iiwa_model.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//common:default_scalars",
         "//math:geometric_transform",
@@ -43,7 +56,7 @@ drake_cc_library(
 drake_cc_googletest(
     name = "kuka_iiwa_robot_kinematics_test",
     deps = [
-        ":kuka_iiwa_robot_library",
+        ":drake_kuka_iiwa_robot",
         "//multibody/benchmarks/kuka_iiwa_robot/MG:MG_kuka_robot_lib",
     ],
 )
@@ -51,7 +64,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "kuka_iiwa_robot_inverse_dynamics_test",
     deps = [
-        ":kuka_iiwa_robot_library",
+        ":drake_kuka_iiwa_robot",
         "//multibody/benchmarks/kuka_iiwa_robot/MG:MG_kuka_robot_lib",
     ],
 )

--- a/multibody/benchmarks/mass_damper_spring/BUILD.bazel
+++ b/multibody/benchmarks/mass_damper_spring/BUILD.bazel
@@ -1,14 +1,32 @@
 # -*- python -*-
 
-load("//tools:drake.bzl", "drake_cc_googletest", "drake_cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+# Because there are no meaninfully distinct components in this package, the
+# only public target we will offer is our drake_cc_package_library.
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_package_library(
+    name = "mass_damper_spring",
+    deps = [
+        ":mass_damper_spring_analytical_solution",
+    ],
+)
 
 drake_cc_library(
     name = "mass_damper_spring_analytical_solution",
-    srcs = ["mass_damper_spring_analytical_solution.cc"],
-    hdrs = ["mass_damper_spring_analytical_solution.h"],
+    srcs = [
+        "mass_damper_spring_analytical_solution.cc",
+    ],
+    hdrs = [
+        "mass_damper_spring_analytical_solution.h",
+    ],
     deps = [
         "//common:essential",
         "//math:autodiff",

--- a/multibody/benchmarks/pendulum/BUILD.bazel
+++ b/multibody/benchmarks/pendulum/BUILD.bazel
@@ -1,9 +1,22 @@
 # -*- python -*-
 
-load("//tools:drake.bzl", "drake_cc_library")
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
-package(default_visibility = ["//visibility:public"])
+# Because there are no meaninfully distinct components in this package, the
+# only public target we will offer is our drake_cc_package_library.
+package(default_visibility = ["//visibility:private"])
+
+drake_cc_package_library(
+    name = "pendulum",
+    deps = [
+        ":make_pendulum_plant",
+    ],
+)
 
 drake_cc_library(
     name = "make_pendulum_plant",

--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -255,7 +255,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//math:autodiff",
         "//math:gradient",
-        "//multibody/benchmarks/acrobot",
+        "//multibody/benchmarks/acrobot:analytical_acrobot",
     ],
 )
 
@@ -264,7 +264,7 @@ drake_cc_googletest(
     deps = [
         ":multibody_tree",
         "//common/test_utilities:eigen_matrix_compare",
-        "//multibody/benchmarks/acrobot",
+        "//multibody/benchmarks/acrobot:analytical_acrobot",
     ],
 )
 

--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -287,7 +287,7 @@ drake_cc_googletest(
         ":multibody_tree",
         "//common/test_utilities",
         "//math:gradient",
-        "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",
+        "//multibody/benchmarks/kuka_iiwa_robot",
         "//multibody/benchmarks/kuka_iiwa_robot/MG:MG_kuka_robot_lib",
     ],
 )

--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -127,7 +127,7 @@ drake_cc_library(
         "space_xyz_mobilizer.h",
         "uniform_gravity_field_element.h",
     ],
-    # Hide this library outside of this package; users shoud depend on
+    # Hide this library outside of this package; users should depend on
     # ":multibody_tree" broadly, not just ":multibody_tree_core".
     visibility = ["//visibility:private"],
     deps = [

--- a/multibody/multibody_tree/math/BUILD.bazel
+++ b/multibody/multibody_tree/math/BUILD.bazel
@@ -1,14 +1,27 @@
 # -*- python -*-
 
 load(
-    "//tools:drake.bzl",
+    "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(
     default_visibility = ["//visibility:public"],
+)
+
+drake_cc_package_library(
+    name = "math",
+    deps = [
+        ":spatial_acceleration",
+        ":spatial_algebra",
+        ":spatial_force",
+        ":spatial_momentum",
+        ":spatial_vector",
+        ":spatial_velocity",
+    ],
 )
 
 drake_cc_library(

--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -61,7 +61,7 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//multibody/benchmarks/acrobot",
-        "//multibody/benchmarks/pendulum:make_pendulum_plant",
+        "//multibody/benchmarks/pendulum",
         "//systems/primitives:linear_system",
     ],
 )

--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -61,7 +61,6 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//common/test_utilities:expect_throws_message",
         "//multibody/benchmarks/acrobot",
-        "//multibody/benchmarks/acrobot:make_acrobot_plant",
         "//multibody/benchmarks/pendulum:make_pendulum_plant",
         "//systems/primitives:linear_system",
     ],

--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -79,7 +79,7 @@ drake_cc_googletest(
     timeout = "moderate",
     deps = [
         ":multibody_plant",
-        "//multibody/benchmarks/inclined_plane:make_inclined_plane_plant",
+        "//multibody/benchmarks/inclined_plane",
         "//systems/analysis:simulator",
     ],
 )

--- a/multibody/parsing/BUILD.bazel
+++ b/multibody/parsing/BUILD.bazel
@@ -1,15 +1,25 @@
 # -*- python -*-
 
 load(
-    "//tools:drake.bzl",
+    "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/install:install_data.bzl", "install_data")
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(
     default_visibility = ["//visibility:public"],
+)
+
+drake_cc_package_library(
+    name = "parsing",
+    deps = [
+        ":frame_cache",
+        ":sdf_parser",
+        ":sdf_spec",
+    ],
 )
 
 drake_cc_library(

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -1,13 +1,22 @@
 # -*- python -*-
 
 load(
-    "//tools:drake.bzl",
+    "@drake//tools/skylark:drake_cc.bzl",
     "drake_cc_googletest",
     "drake_cc_library",
+    "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
 
 package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "perception",
+    deps = [
+        ":point_cloud",
+        ":point_cloud_flags",
+    ],
+)
 
 drake_cc_library(
     name = "point_cloud_flags",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -165,7 +165,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/benchmarks/free_body:free_body",
     "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",
     "//multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",  # noqa
-    "//multibody/benchmarks/pendulum:make_pendulum_plant",
+    "//multibody/benchmarks/pendulum:pendulum",
     "//multibody/collision:collision",
     "//multibody/collision:collision_api",
     "//multibody/collision:model",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -165,7 +165,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/benchmarks/free_body:free_body",
     "//multibody/benchmarks/inclined_plane:inclined_plane",
     "//multibody/benchmarks/kuka_iiwa_robot:kuka_iiwa_robot",
-    "//multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",  # noqa
+    "//multibody/benchmarks/mass_damper_spring:mass_damper_spring",
     "//multibody/benchmarks/pendulum:pendulum",
     "//multibody/collision:collision",
     "//multibody/collision:collision_api",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -160,6 +160,7 @@ LIBDRAKE_COMPONENTS = [
     "//math:vector3_util",
     "//math:wrap_to",
     "//multibody/benchmarks/acrobot:acrobot",
+    "//multibody/benchmarks/acrobot:analytical_acrobot",
     "//multibody/benchmarks/acrobot:make_acrobot_plant",
     "//multibody/benchmarks/free_body:free_body",
     "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -193,6 +193,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/multibody_tree:unit_inertia",
     "//multibody/parsers:parsers",
     "//multibody/parsing:frame_cache",
+    "//multibody/parsing:parsing",
     "//multibody/parsing:sdf_parser",
     "//multibody/parsing:sdf_spec",
     "//multibody/rigid_body_plant:compliant_contact_model",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -163,6 +163,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/benchmarks/acrobot:analytical_acrobot",
     "//multibody/benchmarks/acrobot:make_acrobot_plant",
     "//multibody/benchmarks/free_body:free_body",
+    "//multibody/benchmarks/inclined_plane:inclined_plane",
     "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",
     "//multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",  # noqa
     "//multibody/benchmarks/pendulum:pendulum",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -221,6 +221,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody:rigid_body_tree_alias_groups",
     "//multibody:rigid_body_tree_alias_groups_proto",
     "//multibody:rigid_body_tree_construction",
+    "//perception:perception",
     "//perception:point_cloud",
     "//perception:point_cloud_flags",
     "//solvers:bilinear_product_util",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -164,7 +164,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/benchmarks/acrobot:make_acrobot_plant",
     "//multibody/benchmarks/free_body:free_body",
     "//multibody/benchmarks/inclined_plane:inclined_plane",
-    "//multibody/benchmarks/kuka_iiwa_robot:make_kuka_iiwa_model",
+    "//multibody/benchmarks/kuka_iiwa_robot:kuka_iiwa_robot",
     "//multibody/benchmarks/mass_damper_spring:mass_damper_spring_analytical_solution",  # noqa
     "//multibody/benchmarks/pendulum:pendulum",
     "//multibody/collision:collision",

--- a/tools/install/libdrake/build_components.bzl
+++ b/tools/install/libdrake/build_components.bzl
@@ -174,6 +174,7 @@ LIBDRAKE_COMPONENTS = [
     "//multibody/constraint:constraint_problem_data",
     "//multibody/constraint:constraint_solver",
     "//multibody/joints:joints",
+    "//multibody/multibody_tree/math:math",
     "//multibody/multibody_tree/math:spatial_acceleration",
     "//multibody/multibody_tree/math:spatial_algebra",
     "//multibody/multibody_tree/math:spatial_force",

--- a/tools/skylark/drake_cc.bzl
+++ b/tools/skylark/drake_cc.bzl
@@ -355,15 +355,18 @@ def drake_cc_package_library(
         testonly = 0,
         visibility = ["//visibility:public"]):
     """Creates a rule to declare a C++ "package" library -- a library whose
-    target name matches the current package and whose dependencies are
-    (usually) all of the other drake_cc_library targets in the current package.
-    In short, a library named //foo/bar (short for //foo/bar:bar) that
-    conveniently provides all of the C++ code from the //foo/bar package in one
-    place.
+    name matches the current Bazel package name (i.e., directory name) and
+    whose dependencies are (usually) all of the other drake_cc_library targets
+    in the current package.  In short, e.g., creates a library named
+    //foo/bar:bar that conveniently provides all of the C++ code from the
+    //foo/bar package in one place.
 
     Using this macro documents the intent that the library is a summation of
     everything in the current package and enables Drake's linter rules to
     confirm that all of the drake_cc_library targets have been listed as deps.
+
+    Within Drake, by convention, every package (i.e., directory) that has any
+    C++ code should call this macro to create a library for its package.
 
     The name must be the same as the final element of the current package.
     This rule does not accept srcs, hdrs, etc. -- only deps.


### PR DESCRIPTION
Builds on #8664. Relates #6464.

The goal here is to use `drake_cc_package_library` more widely, which will in the future ease maintenance of the install rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8733)
<!-- Reviewable:end -->
