### PR TITLE
Python bindings for ContactResults

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -58,6 +58,7 @@ drake_pybind_library(
 drake_pybind_library(
     name = "rigid_body_plant_py",
     cc_deps = [
+        "//bindings/pydrake/systems:systems_pybind",
         "//lcmtypes:viewer",
     ],
     cc_so_name = "rigid_body_plant",

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -89,14 +89,13 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         .def("get_contact_info",
              &Class::get_contact_info, py_reference_internal)
         .def("set_generalized_contact_force",
-            [](Class* self,
-               const Eigen::VectorXd& f) {
+            [](Class* self, const Eigen::VectorXd& f) {
                 self->set_generalized_contact_force(f);
             })
         .def("get_generalized_contact_force",
              &Class::get_generalized_contact_force, py_reference_internal)
         .def("AddContact", &Class::AddContact, py_reference_internal,
-            py::arg("element_a_id"), py::arg("element_b_id"))
+            py::arg("element_a"), py::arg("element_b"))
         .def("Clear", &Class::Clear);
     pysystems::AddValueInstantiation<Class>(m);
   }

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -51,6 +51,7 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = ContactInfo<T>;
     py::class_<Class> cls(m, "ContactInfo");
     cls
+        .def(py::init<>())
         .def("get_element_id_1", &Class::get_element_id_1)
         .def("get_element_id_2", &Class::get_element_id_2)
         .def("get_resultant_force", &Class::get_resultant_force,

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -2,6 +2,7 @@
 #include "pybind11/pybind11.h"
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/systems/systems_pybind.h"
 #include "drake/multibody/rigid_body_plant/drake_visualizer.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 
@@ -44,6 +45,42 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         Class::kDefaultVStictionTolerance;
     cls.attr("kDefaultCharacteristicRadius") =
         Class::kDefaultCharacteristicRadius;
+  }
+
+  {
+    using Class = ContactInfo<T>;
+    py::class_<Class> cls(m, "ContactInfo");
+    cls
+        .def("get_element_id_1", &Class::get_element_id_1)
+        .def("get_element_id_2", &Class::get_element_id_2)
+        .def("get_resultant_force", &Class::get_resultant_force,
+             py_reference_internal);
+  }
+
+  {
+    using Class = ContactForce<T>;
+    py::class_<Class> cls(m, "ContactForce");
+    cls
+        .def(py::init<>())
+        .def("get_reaction_force", &Class::get_reaction_force)
+        .def("get_application_point", &Class::get_application_point)
+        .def("get_force", &Class::get_force)
+        .def("get_normal_force", &Class::get_normal_force)
+        .def("get_tangent_force", &Class::get_tangent_force)
+        .def("get_torque", &Class::get_torque)
+        .def("get_normal", &Class::get_normal);
+  }
+
+  {
+    using Class = ContactResults<T>;
+    py::class_<Class> cls(m, "ContactResults");
+    cls
+        .def(py::init<>())
+        .def("get_num_contacts", &Class::get_num_contacts)
+        .def("get_contact_info", &Class::get_contact_info, py_reference_internal)
+        .def("get_generalized_contact_force",
+             &Class::get_generalized_contact_force, py_reference_internal);
+    pysystems::AddValueInstantiation<Class>(m);
   }
 
   {

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -51,7 +51,8 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = ContactInfo<T>;
     py::class_<Class> cls(m, "ContactInfo");
     cls
-        .def(py::init<>())
+        .def(py::init<const drake::multibody::collision::ElementId,
+                      const drake::multibody::collision::ElementId>())
         .def("get_element_id_1", &Class::get_element_id_1)
         .def("get_element_id_2", &Class::get_element_id_2)
         .def("get_resultant_force", &Class::get_resultant_force,
@@ -62,7 +63,16 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = ContactForce<T>;
     py::class_<Class> cls(m, "ContactForce");
     cls
-        .def(py::init<>())
+        .def(
+            py::init<
+                const Eigen::Vector3d&,
+                const Eigen::Vector3d&,
+                const Eigen::Vector3d&,
+                const Eigen::Vector3d&>(),
+            py::arg("application_point"),
+            py::arg("normal"),
+            py::arg("force"),
+            py::arg("torque") = Eigen::Vector3d::Zero())
         .def("get_reaction_force", &Class::get_reaction_force)
         .def("get_application_point", &Class::get_application_point)
         .def("get_force", &Class::get_force)
@@ -78,9 +88,17 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     cls
         .def(py::init<>())
         .def("get_num_contacts", &Class::get_num_contacts)
-        .def("get_contact_info", &Class::get_contact_info, py_reference_internal)
+        .def("get_contact_info",
+             &Class::get_contact_info, py_reference_internal)
+        .def("set_generalized_contact_force",
+            [](Class * cr,
+               const Eigen::VectorXd& f) {
+                cr->set_generalized_contact_force(f);
+            })
         .def("get_generalized_contact_force",
-             &Class::get_generalized_contact_force, py_reference_internal);
+             &Class::get_generalized_contact_force, py_reference_internal)
+        .def("AddContact", &Class::AddContact, py_reference_internal)
+        .def("Clear", &Class::Clear);
     pysystems::AddValueInstantiation<Class>(m);
   }
 

--- a/bindings/pydrake/multibody/rigid_body_plant_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_plant_py.cc
@@ -51,8 +51,6 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     using Class = ContactInfo<T>;
     py::class_<Class> cls(m, "ContactInfo");
     cls
-        .def(py::init<const drake::multibody::collision::ElementId,
-                      const drake::multibody::collision::ElementId>())
         .def("get_element_id_1", &Class::get_element_id_1)
         .def("get_element_id_2", &Class::get_element_id_2)
         .def("get_resultant_force", &Class::get_resultant_force,
@@ -65,14 +63,14 @@ PYBIND11_MODULE(rigid_body_plant, m) {
     cls
         .def(
             py::init<
-                const Eigen::Vector3d&,
-                const Eigen::Vector3d&,
-                const Eigen::Vector3d&,
-                const Eigen::Vector3d&>(),
+                const Vector3<T>&,
+                const Vector3<T>&,
+                const Vector3<T>&,
+                const Vector3<T>&>(),
             py::arg("application_point"),
             py::arg("normal"),
             py::arg("force"),
-            py::arg("torque") = Eigen::Vector3d::Zero())
+            py::arg("torque") = Vector3<T>::Zero())
         .def("get_reaction_force", &Class::get_reaction_force)
         .def("get_application_point", &Class::get_application_point)
         .def("get_force", &Class::get_force)
@@ -91,13 +89,14 @@ PYBIND11_MODULE(rigid_body_plant, m) {
         .def("get_contact_info",
              &Class::get_contact_info, py_reference_internal)
         .def("set_generalized_contact_force",
-            [](Class * cr,
+            [](Class* self,
                const Eigen::VectorXd& f) {
-                cr->set_generalized_contact_force(f);
+                self->set_generalized_contact_force(f);
             })
         .def("get_generalized_contact_force",
              &Class::get_generalized_contact_force, py_reference_internal)
-        .def("AddContact", &Class::AddContact, py_reference_internal)
+        .def("AddContact", &Class::AddContact, py_reference_internal,
+            py::arg("element_a_id"), py::arg("element_b_id"))
         .def("Clear", &Class::Clear);
     pysystems::AddValueInstantiation<Class>(m);
   }

--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -125,9 +125,11 @@ class TestRigidBodyPlant(unittest.TestCase):
 
         id_1 = 42
         id_2 = 43
-        info = results.AddContact(id_1, id_2)
+        info = results.AddContact(element_a_id=id_1, element_b_id=id_2)
         self.assertEquals(results.get_num_contacts(), 1)
-        self.assertEquals(results.get_contact_info(0), info)
+        info_dup = results.get_contact_info(0)
+        self.assertIsInstance(info_dup, mut.ContactInfo)
+        self.assertIs(info, info_dup)
         self.assertEquals(info.get_element_id_1(), id_1)
         self.assertEquals(info.get_element_id_2(), id_2)
 
@@ -135,7 +137,10 @@ class TestRigidBodyPlant(unittest.TestCase):
         normal = np.array([0.0, 1.0, 0.0])
         force = np.array([0.9, 0.1, 0.9])
         torque = np.array([0.6, 0.6, 0.6])
-        cf = mut.ContactForce(pt, normal, force, torque)
+        cf = mut.ContactForce(application_point=pt,
+                              normal=normal,
+                              force=force,
+                              torque=torque)
         self.assertTrue(np.allclose(cf.get_application_point(), pt))
         self.assertTrue(np.allclose(cf.get_force(), force))
         self.assertTrue(np.allclose(cf.get_normal_force(),

--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -113,6 +113,41 @@ class TestRigidBodyPlant(unittest.TestCase):
         param = cls(0.1, 0.2)
         param = cls(v_stiction_tolerance=0.1, characteristic_radius=0.2)
 
+    def test_contact_result_api(self):
+        # Test contact result bindings in isolation
+        # by constructing dummy contact results
+        results = mut.ContactResults()
+        self.assertEquals(results.get_num_contacts(), 0)
+        f = np.array([0., 1., 2.])
+        results.set_generalized_contact_force(f)
+        self.assertTrue(np.allclose(
+            results.get_generalized_contact_force(), f))
+
+        id_1 = 42
+        id_2 = 43
+        info = results.AddContact(id_1, id_2)
+        self.assertEquals(results.get_num_contacts(), 1)
+        self.assertEquals(results.get_contact_info(0), info)
+        self.assertEquals(info.get_element_id_1(), id_1)
+        self.assertEquals(info.get_element_id_2(), id_2)
+
+        pt = np.array([0.1, 0.2, 0.3])
+        normal = np.array([0.0, 1.0, 0.0])
+        force = np.array([0.9, 0.1, 0.9])
+        torque = np.array([0.6, 0.6, 0.6])
+        cf = mut.ContactForce(pt, normal, force, torque)
+        self.assertTrue(np.allclose(cf.get_application_point(), pt))
+        self.assertTrue(np.allclose(cf.get_force(), force))
+        self.assertTrue(np.allclose(cf.get_normal_force(),
+                                    normal*force.dot(normal)))
+        self.assertTrue(np.allclose(cf.get_tangent_force(),
+                                    force - normal*force.dot(normal)))
+        self.assertTrue(np.allclose(cf.get_torque(), torque))
+        self.assertTrue(np.allclose(cf.get_normal(), normal))
+
+        results.Clear()
+        self.assertEquals(results.get_num_contacts(), 0)
+
     def test_compliant_material_api(self):
 
         def flat_values(material):

--- a/bindings/pydrake/multibody/test/rigid_body_plant_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_plant_test.py
@@ -125,7 +125,7 @@ class TestRigidBodyPlant(unittest.TestCase):
 
         id_1 = 42
         id_2 = 43
-        info = results.AddContact(element_a_id=id_1, element_b_id=id_2)
+        info = results.AddContact(element_a=id_1, element_b=id_2)
         self.assertEquals(results.get_num_contacts(), 1)
         info_dup = results.get_contact_info(0)
         self.assertIsInstance(info_dup, mut.ContactInfo)


### PR DESCRIPTION
These bindings enable construction of systems that subscribe to the contact results port of a RigidBodyPlant, for e.g. plotting and visualizing contact forces.

@EricCousineau-TRI, would you mind feature reviewing this one (or delegating it) once I get this through CI?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8736)
<!-- Reviewable:end -->
