### PR TITLE
Fix typo in automotive/steering_command_driver.py

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -8,6 +8,10 @@ load(
     "drake_cc_package_library",
 )
 load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
+load(
     "@drake//tools/skylark:drake_java.bzl",
     "drake_java_binary",
 )
@@ -793,6 +797,14 @@ drake_cc_googletest(
     name = "trivial_right_of_way_state_provider_test",
     deps = [
         ":trivial_right_of_way_state_provider",
+    ],
+)
+
+drake_py_unittest(
+    name = "steering_command_driver_test",
+    deps = [
+        ":steering_command_driver",
+        "@lcm//:lcm-python",
     ],
 )
 

--- a/automotive/steering_command_driver.py
+++ b/automotive/steering_command_driver.py
@@ -157,6 +157,13 @@ class bcolors:
     ENDC = '\033[0m'
 
 
+def make_driving_command(throttle, steering_angle):
+    msg = lcm_msg()
+    msg.acceleration = throttle
+    msg.steering_angle = steering_angle
+    return msg
+
+
 class SteeringCommandPublisher:
     def __init__(self, input_method, lcm_tag, joy_name):
         print 'Initializing...'
@@ -208,19 +215,16 @@ class SteeringCommandPublisher:
             else:
                 self.last_value = self.event_processor.processEvent(
                     event, self.last_value)
-                msg = lcm_msg()
-                msg.steering_angle = self.last_value.steering_angle
-                msg.acceleration = (self.last_value.throttle -
-                                    self.last_value.brake)
+                msg = make_driving_command(self.last_value.steering_angle,
+                                           self.last_value.throttle -
+                                           self.last_value.brake)
                 self.lc.publish(self.lcm_tag, msg.encode())
                 self.printLCMValues()
 
 
 def publish_driving_command(lcm_tag, throttle, steering_angle):
     lc = lcm.LCM()
-    last_msg = lcm_msg()
-    last_msg.accleration = throttle
-    last_msg.steering_angle = steering_angle
+    last_msg = make_driving_command(throttle, steering_angle)
     lc.publish(lcm_tag, last_msg.encode())
 
 

--- a/automotive/test/steering_command_driver_test.py
+++ b/automotive/test/steering_command_driver_test.py
@@ -1,0 +1,28 @@
+import lcm
+import unittest
+
+from drake.lcmt_driving_command_t import lcmt_driving_command_t as lcm_msg
+from drake.automotive.steering_command_driver import make_driving_command
+
+
+class SteeringCommandDriverTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(SteeringCommandDriverTest, self).__init__(*args, **kwargs)
+        self.lcm_tag = "EXAMPLE"
+        self.acceleration = 0.5
+        self.steering_angle = 0.2
+
+    def handler(self, channel, data):
+        msg = lcm_msg.decode(data)
+        self.assertEqual(msg.acceleration, self.acceleration)
+        self.assertEqual(msg.steering_angle, self.steering_angle)
+
+    def test_make_driving_command(self):
+        receiver = lcm.LCM()
+        subscription = receiver.subscribe(self.lcm_tag, self.handler)
+        sender = lcm.LCM()
+        sender.publish(self.lcm_tag,
+                       make_driving_command(self.acceleration,
+                                            self.steering_angle).encode())
+        receiver.handle()
+        receiver.unsubscribe(subscription)


### PR DESCRIPTION
See https://github.com/RobotLocomotion/drake/blob/master/automotive/driving_command.named_vector#L10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8745)
<!-- Reviewable:end -->
