### PR TITLE
Add missing fmt target to common:symbolic

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -215,6 +215,7 @@ drake_cc_library(
         ":number_traits",
         ":polynomial",
         "//math:matrix_util",
+        "@fmt",
     ],
 )
 


### PR DESCRIPTION
External projects depending on `common:symbolic` balk otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8746)
<!-- Reviewable:end -->
