### PR TITLE
Geometric Jacobian for the world fix

### DIFF
--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -736,7 +736,7 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
   const Body<T>& body_B = frame_B.body();
 
   // Do nothing for the world body and return a zero Jacobian.
-  // That is Jv_WQi * v = 0, always, for the world body.
+  // That is, Jv_WQi * v = 0, always, for the world body.
   if (body_B.index() == world_index()) {
     // Since B = W, we must set p_WQi_set = p_BQi_set.
     *p_WQi_set = p_BQi_set;
@@ -813,7 +813,7 @@ void MultibodyTree<T>::CalcFrameGeometricJacobianExpressedInWorld(
   const Body<T>& body_B = frame_B.body();
 
   // Do nothing for the world body and return a zero Jacobian.
-  // That is Jv_WQi * v = 0, always, for the world body.
+  // That is, Jv_WQi * v = 0, always, for the world body.
   if (body_B.index() == world_index()) return;
 
   // Compute kinematic path from body B to the world:

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -728,8 +728,20 @@ void MultibodyTree<T>::CalcPointsGeometricJacobianExpressedInWorld(
   DRAKE_THROW_UNLESS(Jv_WQi->rows() == 3 * num_points);
   DRAKE_THROW_UNLESS(Jv_WQi->cols() == num_velocities());
 
+  // If a user is re-using this Jacobian within a loop the first thing we'll
+  // want to do is to re-initialize it to zero.
+  Jv_WQi->setZero();
+
   // Body to which frame B is attached to:
   const Body<T>& body_B = frame_B.body();
+
+  // Do nothing for the world body and return a zero Jacobian.
+  // That is Jv_WQi * v = 0, always, for the world body.
+  if (body_B.index() == world_index()) {
+    // Since B = W, we must set p_WQi_set = p_BQi_set.
+    *p_WQi_set = p_BQi_set;
+    return;
+  }
 
   // Compute kinematic path from body B to the world:
   std::vector<BodyNodeIndex> path_to_world;

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -805,8 +805,16 @@ void MultibodyTree<T>::CalcFrameGeometricJacobianExpressedInWorld(
   DRAKE_THROW_UNLESS(Jv_WF->rows() == 6);
   DRAKE_THROW_UNLESS(Jv_WF->cols() == num_velocities());
 
+  // If a user is re-using this Jacobian within a loop the first thing we'll
+  // want to do is to re-initialize it to zero.
+  Jv_WF->setZero();
+
   // Body to which frame B is attached to:
   const Body<T>& body_B = frame_B.body();
+
+  // Do nothing for the world body and return a zero Jacobian.
+  // That is Jv_WQi * v = 0, always, for the world body.
+  if (body_B.index() == world_index()) return;
 
   // Compute kinematic path from body B to the world:
   std::vector<BodyNodeIndex> path_to_world;

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -662,7 +662,7 @@ TEST_F(KukaIiwaModelTests, PointsGeometricJacobianForTheWorldFrame) {
   //   a) the output set should match the input set exactly and,
   //   b) the Jacobian should be exactly zero.
   EXPECT_EQ(p_WP_out, p_WP_set);
-  EXPECT_EQ(Jv_WP, Matrix3X<double>::Zero(3 * npoints, nv));
+  EXPECT_EQ(Jv_WP, MatrixX<double>::Zero(3 * npoints, nv));
 }
 
 // Verify that even when the input set of points and/or the Jacobian might
@@ -689,7 +689,7 @@ TEST_F(KukaIiwaModelTests, FrameGeometricJacobianForTheWorldFrame) {
 
   // Since in this case we are querying for the world frame, the Jacobian should
   // be exactly zero.
-  EXPECT_EQ(Jv_WP, Matrix3X<double>::Zero(6, nv));
+  EXPECT_EQ(Jv_WP, MatrixX<double>::Zero(6, nv));
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -633,20 +633,20 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
 
 // Verify that even when the input set of points and/or the Jacobian might
 // contain garbage on input, a query for the world body Jacobian will always
-// return:
+// yield the following results:
 //  a) p_WP_set = p_BP_set, since in this case B = W and,
 //  b) J_WP is exactly zero, since the world does not move.
 TEST_F(KukaIiwaModelTests, PointsGeometricJacobianForTheWorldFrame) {
-  // Simply a non-zero set of points in the world body. The actual value does
-  // not matter for this test. What matters is that we **always** get a zero
-  // Jacobian for the world body.
+  // We choose an arbitrary set of non-zero points in the world body. The actual
+  // value does not matter for this test. What matters is that we **always** get
+  // a zero Jacobian for the world body.
   const Matrix3X<double> p_WP_set = Matrix3X<double>::Identity(3, 10);
 
   const int nv = model_->num_velocities();
   const int npoints = p_WP_set.cols();
 
-  // We set the output arrays to garbage so that on output from
-  // CalcPointsGeometricJacobianExpressedInWorld() we can verify the were
+  // We set the output arrays to garbage so that upon returning from
+  // CalcPointsGeometricJacobianExpressedInWorld() we can verify they were
   // properly set.
   Matrix3X<double> p_WP_out = Matrix3X<double>::Constant(3, npoints, M_PI);
   MatrixX<double> Jv_WP = MatrixX<double>::Constant(3 * npoints, nv, M_E);
@@ -669,14 +669,14 @@ TEST_F(KukaIiwaModelTests, PointsGeometricJacobianForTheWorldFrame) {
 // contain garbage on input, a query for the world body Jacobian will always
 // return a zero Jacobian since the world does not move.
 TEST_F(KukaIiwaModelTests, FrameGeometricJacobianForTheWorldFrame) {
-  // Simply a non-zero point in the world body. The actual value does
-  // not matter for this test. What matters is that we **always** get a zero
-  // Jacobian for the world body.
+  // We choose an arbitrary non-zero point in the world body. The actual value
+  // does not matter for this test. What matters is that we **always** get a
+  // zero Jacobian for the world body.
   const Vector3<double> p_WP(1.0, 1.0, 1.0);
 
   const int nv = model_->num_velocities();
 
-  // We set the output Jacobian to garbage so that on output from
+  // We set the output Jacobian to garbage so that upon returning from
   // CalcFrameGeometricJacobianExpressedInWorld() we can verify it was
   // properly set to zero.
   MatrixX<double> Jv_WP = MatrixX<double>::Constant(6, nv, M_E);
@@ -687,7 +687,7 @@ TEST_F(KukaIiwaModelTests, FrameGeometricJacobianForTheWorldFrame) {
   model_->CalcFrameGeometricJacobianExpressedInWorld(
       *context_, model_->world_body().body_frame(), p_WP, &Jv_WP);
 
-  // Since in this case we are querying for the world frame the Jacobian should
+  // Since in this case we are querying for the world frame, the Jacobian should
   // be exactly zero.
   EXPECT_EQ(Jv_WP, Matrix3X<double>::Zero(6, nv));
 }


### PR DESCRIPTION
It fixes a simple bug in the computation for the geometric Jacobian when requested for the world frame (it should return a zero Jacobian!).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8749)
<!-- Reviewable:end -->
