### PR TITLE
Fixes warning reported in #8751

### DIFF
--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -17,10 +17,12 @@ namespace systems {
 SystemBase::~SystemBase() {}
 
 std::string SystemBase::GetSystemPathname() const {
-  using std::string_literals::operator""s;
+  // NOLINTNEXTLINE(build/namespaces): using operator""s issues a warning.
+  using namespace std::string_literals;
+
   const std::string parent_path =
-    get_parent_service() ? get_parent_service()->GetParentPathname()
-                         : ""s;
+      get_parent_service() ? get_parent_service()->GetParentPathname()
+                           : ""s;
   return parent_path + "::"s + GetSystemName();
 }
 


### PR DESCRIPTION
@liangfok reported getting a spurious warning due to the GSG-compatible 
```c++
using std::string_literals::operator""s;
```
for using the string literal suffix. Including the whole namespace (consisting only of a few operators) gets rid of the warning but violates the GSG. This PR nolints that.

Fixes #8751.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8753)
<!-- Reviewable:end -->
