### PR TITLE
Introduce a tolerance in rotational symmetry test for PurePursuit

### DIFF
--- a/automotive/test/pure_pursuit_test.cc
+++ b/automotive/test/pure_pursuit_test.cc
@@ -153,7 +153,7 @@ TEST_F(PurePursuitTest, RotationalSymmetry) {
   double result_pi_by_two = PurePursuit<double>::Evaluate(
       pp_params_, car_params_, {lane, true /* with_s */}, ego_pose);
 
-  EXPECT_EQ(result_zero, result_pi_by_two);
+  EXPECT_NEAR(result_zero, result_pi_by_two, 1e-6);
 }
 
 TEST_F(PurePursuitTest, EvaluateAutoDiff) {


### PR DESCRIPTION
Resolves two Mac CI errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8755)
<!-- Reviewable:end -->
