### PR TITLE
pydrake math: Move plotting to example, ensure grid shape + type is tested

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load(
     "//tools/skylark:drake_py.bzl",
+    "drake_py_binary",
     "drake_py_library",
     "drake_py_test",
     "drake_py_unittest",
@@ -321,5 +322,14 @@ add_lint_tests(
     python_lint_extra_srcs = [
         ":test/all_install_test.py",
         ":test/common_install_test.py",
+    ],
+)
+
+drake_py_binary(
+    name = "math_example",
+    srcs = ["math_example.py"],
+    isolate = 1,
+    deps = [
+        ":math_py",
     ],
 )

--- a/bindings/pydrake/math_example.py
+++ b/bindings/pydrake/math_example.py
@@ -1,0 +1,23 @@
+"""Shows examples using math utilities."""
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+import numpy as np
+
+from pydrake.math import BarycentricMesh
+
+# Plot a surface using BarycentricMesh.
+mesh = BarycentricMesh([{0, 1}, {0, 1}])
+values = np.array([[0, 1, 2, 3]])
+
+fig = plt.figure()
+ax = fig.add_subplot(111, projection='3d')
+
+X, Y = np.meshgrid(list(mesh.get_input_grid()[0]),
+                   list(mesh.get_input_grid()[1]))
+Z = np.reshape(values, X.shape)
+
+ax.plot_surface(X, Y, Z)
+ax.set_xlabel('x')
+ax.set_ylabel('y')
+plt.show()

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -13,8 +13,11 @@ class TestBarycentricMesh(unittest.TestCase):
     def test_spelling(self):
         mesh = BarycentricMesh([{0, 1}, {0, 1}])
         values = np.array([[0, 1, 2, 3]])
-
-        mesh.get_input_grid()
+        grid = mesh.get_input_grid()
+        self.assertIsInstance(grid, list)
+        self.assertEquals(len(grid), 2)
+        self.assertIsInstance(grid[0], set)
+        self.assertEquals(len(grid[0]), 2)
         self.assertEquals(mesh.get_input_size(), 2)
         self.assertEquals(mesh.get_num_mesh_points(), 4)
         self.assertEquals(mesh.get_num_interpolants(), 3)
@@ -42,23 +45,6 @@ class TestBarycentricMesh(unittest.TestCase):
 
         values = mesh.MeshValuesFrom(mynorm)
         self.assertEquals(values.size, 4)
-
-    def test_surf(self):
-        mesh = BarycentricMesh([{0, 1}, {0, 1}])
-        values = np.array([[0, 1, 2, 3]])
-
-        import matplotlib.pyplot as plt
-        from mpl_toolkits.mplot3d import Axes3D
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection='3d')
-
-        X, Y = np.meshgrid(list(mesh.get_input_grid()[0]),
-                           list(mesh.get_input_grid()[1]))
-        Z = np.reshape(values, X.shape)
-
-        ax.plot_surface(X, Y, Z)
-        ax.set_xlabel('x')
-        ax.set_ylabel('y')
 
     def test_wrap_to(self):
         self.assertEquals(wrap_to(1.5, 0., 1.), .5)


### PR DESCRIPTION
Should Resolve #8752 - if not, we can re-open it.

Since the method `TestMath.test_surf` does not directly test values, but just shows an example of plotting, I think it'd be better to move that to an example, and keep the test focused on the numerics.
Otherwise, this test, when executed with sandboxing on CI, frequently times out.

NOTE: It could be that this is the first `matplotlib`-using test on CI, in which case it's not caching for every test, but just the first. If that's the case, we should probably make sure that this stuff is cached before starting to execute tests.

\cc @RussTedrake @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8756)
<!-- Reviewable:end -->
