### PR TITLE
Prevent heap overflow in agent trajectory test

### DIFF
--- a/automotive/test/agent_trajectory_test.cc
+++ b/automotive/test/agent_trajectory_test.cc
@@ -179,6 +179,8 @@ void MakePoses(const std::vector<double>& speeds,
     (*rotations)[i] = math::RollPitchYaw<double>(rpy).ToQuaternion();
     (*translations)[i] = Vector3d(1. + displacement, 2., 3.);
 
+    if (i == static_cast<int>(speeds.size()) - 1) break;
+
     double interval_speed{0.};
     interval_speed = 0.5 * (speeds[i] + speeds[i + 1]);
     displacement += kDeltaT * interval_speed;


### PR DESCRIPTION
Fixes an asan/tsan-related CI errors:
`linux-xenial-gcc-bazel-continuous-memcheck-asan`
`linux-xenial-clang-bazel-continuous-memcheck-tsan`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8769)
<!-- Reviewable:end -->
