### PR TITLE
Run global ik as mixed-integer linear programming

### DIFF
--- a/multibody/dev/test/global_inverse_kinematics_test.cc
+++ b/multibody/dev/test/global_inverse_kinematics_test.cc
@@ -10,6 +10,23 @@ using drake::solvers::SolutionResult;
 namespace drake {
 namespace multibody {
 namespace {
+GTEST_TEST(GlobalInverseKinematicsTest, TestConstructor) {
+  // Test the constructor. With options linear_constraint_only_ = false, the
+  // program contains lorentz cone constraint. Otherwise there are only linear
+  // constraints.
+  auto kuka = ConstructKuka();
+  GlobalInverseKinematics::Options global_ik_options;
+  // The default option sets linear_constraint_only_ to false.
+  GlobalInverseKinematics global_ik_default(*kuka, global_ik_options);
+  EXPECT_FALSE(global_ik_default.lorentz_cone_constraints().empty());
+  EXPECT_FALSE(global_ik_default.rotated_lorentz_cone_constraints().empty());
+
+  global_ik_options.linear_constraint_only_ = true;
+  GlobalInverseKinematics global_ik_milp(*kuka, global_ik_options);
+  EXPECT_TRUE(global_ik_milp.lorentz_cone_constraints().empty());
+  EXPECT_TRUE(global_ik_milp.rotated_lorentz_cone_constraints().empty());
+}
+
 TEST_F(KukaTest, UnreachableTest) {
   // Test a cartesian pose that we know is not reachable.
   Eigen::Vector3d ee_pos_lb(0.6, -0.1, 0.7);

--- a/multibody/global_inverse_kinematics.cc
+++ b/multibody/global_inverse_kinematics.cc
@@ -129,7 +129,8 @@ GlobalInverseKinematics::GlobalInverseKinematics(
               // Now we process the joint limits constraint.
               const double joint_lb = joint->getJointLimitMin()(0);
               const double joint_ub = joint->getJointLimitMax()(0);
-              AddJointLimitConstraint(body_idx, joint_lb, joint_ub);
+              AddJointLimitConstraint(body_idx, joint_lb, joint_ub,
+                                      options.linear_constraint_only_);
             } else {
               // TODO(hongkai.dai): Add prismatic and helical joint.
               throw std::runtime_error("Unsupported joint type.");

--- a/multibody/global_inverse_kinematics.cc
+++ b/multibody/global_inverse_kinematics.cc
@@ -59,8 +59,10 @@ GlobalInverseKinematics::GlobalInverseKinematics(
     } else {
       R_WB_[body_idx] = solvers::NewRotationMatrixVars(this, body_R_name);
 
-      solvers::AddRotationMatrixOrthonormalSocpConstraint(this,
-                                                          R_WB_[body_idx]);
+      if (!options.linear_constraint_only_) {
+        solvers::AddRotationMatrixOrthonormalSocpConstraint(this,
+                                                            R_WB_[body_idx]);
+      }
 
       // If the body has a parent, then add the constraint to connect the
       // parent body with this body through a joint.
@@ -408,8 +410,36 @@ GlobalInverseKinematics::BodyPointInOneOfRegions(
   return z;
 }
 
+// Approximate a Lorentz cone constraint xᵀx ≤ c² by
+// -c ≤ xᵢ ≤ c
+// ± xᵢ ± xⱼ ≤ √2 * c
+// ± x₀ ± x₁ ± x₂ ≤ √3 * c
+void ApproximateBoundedNormByLinearConstraints(
+    const Eigen::Ref<const Vector3<symbolic::Expression>>& x, double c,
+    solvers::MathematicalProgram* prog) {
+  DRAKE_DEMAND(c >= 0);
+  // -c ≤ xᵢ ≤ c
+  prog->AddLinearConstraint(x, Eigen::Vector3d::Constant(-c),
+                            Eigen::Vector3d::Constant(c));
+  const double sqrt2_c = std::sqrt(2) * c;
+  const double sqrt3_c = std::sqrt(3) * c;
+  // ± xᵢ ± xⱼ ≤ √2 * c
+  for (int i = 0; i < 3; ++i) {
+    for (int j = i + 1; j < 3; ++j) {
+      prog->AddLinearConstraint(x(i) + x(j), -sqrt2_c, sqrt2_c);
+      prog->AddLinearConstraint(x(i) - x(j), -sqrt2_c, sqrt2_c);
+    }
+  }
+  // ± x₀ ± x₁ ± x₂ ≤ √3 * c
+  prog->AddLinearConstraint(x(0) + x(1) + x(2), -sqrt3_c, sqrt3_c);
+  prog->AddLinearConstraint(x(0) + x(1) - x(2), -sqrt3_c, sqrt3_c);
+  prog->AddLinearConstraint(x(0) - x(1) + x(2), -sqrt3_c, sqrt3_c);
+  prog->AddLinearConstraint(x(0) - x(1) - x(2), -sqrt3_c, sqrt3_c);
+}
+
 void GlobalInverseKinematics::AddJointLimitConstraint(
-    int body_index, double joint_lower_bound, double joint_upper_bound) {
+    int body_index, double joint_lower_bound, double joint_upper_bound,
+    bool linear_constraint_approximation) {
   if (joint_lower_bound > joint_upper_bound) {
     throw std::runtime_error(
         "The joint lower bound should be no larger than the upper bound.");
@@ -451,9 +481,9 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
             const Vector3d axis_F = revolute_joint->joint_axis().head<3>();
 
             // Now we process the joint limits constraint.
-            double joint_bound = (joint_upper_bounds_[joint_idx] -
-                                  joint_lower_bounds_[joint_idx]) /
-                                 2;
+            const double joint_bound = (joint_upper_bounds_[joint_idx] -
+                                        joint_lower_bounds_[joint_idx]) /
+                                       2;
 
             if (joint_bound < M_PI) {
               // We use the fact that if the angle between two unit length
@@ -530,14 +560,22 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
 
               // joint_limit_expr is going to be within the Lorentz cone.
               Eigen::Matrix<Expression, 4, 1> joint_limit_expr;
-              joint_limit_expr(0) = 2 * sin(joint_bound / 2);
+              const double joint_limit_lorentz_rhs = 2 * sin(joint_bound / 2);
+              joint_limit_expr(0) = joint_limit_lorentz_rhs;
               for (const auto& v : v_samples) {
                 // joint_limit_expr.tail<3> is
                 // R_WC * v - R_WP * R_PF * R(k,(a+b)/2) * v mentioned above.
                 joint_limit_expr.tail<3>() =
                     R_WB_[body_index] * v -
                     R_WB_[parent_idx] * X_PF.linear() * rotmat_joint_offset * v;
-                AddLorentzConeConstraint(joint_limit_expr);
+                if (linear_constraint_approximation) {
+                  ApproximateBoundedNormByLinearConstraints(
+                      joint_limit_expr.tail<3>(), joint_limit_lorentz_rhs,
+                      this);
+
+                } else {
+                  AddLorentzConeConstraint(joint_limit_expr);
+                }
               }
               if (robot_->get_body(parent_idx).IsRigidlyFixedToWorld()) {
                 // If the parent body is rigidly fixed to the world. Then we
@@ -573,15 +611,17 @@ void GlobalInverseKinematics::AddJointLimitConstraint(
                     (X_WP.linear() * X_PF.linear() * rotmat_joint_offset)
                         .transpose() *
                     R_WB_[body_index];
-                Eigen::Matrix<double, 3, 2> V;
-                V << v_basis[0], v_basis[1];
                 const double joint_bound_cos{std::cos(joint_bound)};
-                const Eigen::Matrix<symbolic::Expression, 2, 2> M =
-                    V.transpose() * (R_joint_beta + R_joint_beta.transpose()) /
-                        2 * V -
-                    joint_bound_cos * Eigen::Matrix2d::Identity();
-                AddRotatedLorentzConeConstraint(
-                    Vector3<symbolic::Expression>(M(0, 0), M(1, 1), M(1, 0)));
+                if (!linear_constraint_approximation) {
+                  Eigen::Matrix<double, 3, 2> V;
+                  V << v_basis[0], v_basis[1];
+                  const Eigen::Matrix<symbolic::Expression, 2, 2> M =
+                      V.transpose() *
+                          (R_joint_beta + R_joint_beta.transpose()) / 2 * V -
+                      joint_bound_cos * Eigen::Matrix2d::Identity();
+                  AddRotatedLorentzConeConstraint(
+                      Vector3<symbolic::Expression>(M(0, 0), M(1, 1), M(1, 0)));
+                }
 
                 // From Rodriguez formula, we know that -α <= β <= α implies
                 // trace(R(k, β)) = 1 + 2 * cos(β) >= 1 + 2*cos(α)

--- a/multibody/global_inverse_kinematics.h
+++ b/multibody/global_inverse_kinematics.h
@@ -35,6 +35,11 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
             kBilinearMcCormick};
     solvers::IntervalBinning interval_binning_{
         solvers::IntervalBinning::kLogarithmic};
+    /** Set to true if we add only mixed-integer linear constraints in the
+     * constructor of GlobalInverseKinematics. The mixed-integer relaxation
+     * is tighter if we allow nonlinear constraints (such as Lorentz cone
+     * constraint), but the optimization takes longer time. */
+    bool linear_constraint_only_{false};
   };
 
   /**
@@ -255,9 +260,18 @@ class GlobalInverseKinematics : public solvers::MathematicalProgram {
    * constrained.
    * @param joint_lower_bound The lower bound for the joint.
    * @param joint_upper_bound The upper bound for the joint.
+   * @param linear_constraint_approximation Set to true if we approximate the
+   * joint limit as linear constraints on parent and child link orientations,
+   * otherwise we use a Lorentz cone constraint to impose the joint limits.
+   * With the Lorentz cone formulation, the joint limit constraint would be
+   * tight if our mixed-integer constraint on SO(3) were tight. By imposing the
+   * joint limits as linear constraint, we further relaxed the original inverse
+   * kinematics problem, on top of SO(3) relaxation, but potentially with faster
+   * computation speed. @default is false.
    */
   void AddJointLimitConstraint(int body_index, double joint_lower_bound,
-                               double joint_upper_bound);
+                               double joint_upper_bound,
+                               bool linear_constraint_approximation = false);
 
  private:
   // This is an utility function for `ReconstructGeneralizedPositionSolution`.


### PR DESCRIPTION
Adds the option to approximate the nonlinear constraints (Lorentz cone constraint) in GlobalInverseKinematics by linear constraint, so that we can run global IK as an MILP for faster speed.