### PR TITLE
Automotive: Adds FindLaneSequences()

### DIFF
--- a/automotive/maliput/multilane/branch_and_merge.yaml
+++ b/automotive/maliput/multilane/branch_and_merge.yaml
@@ -1,0 +1,76 @@
+# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+maliput_multilane_builder:
+  id: "branch_and_merge"
+  lane_width: 6
+  left_shoulder: 5
+  right_shoulder: 5
+  elevation_bounds: [0, 5]
+  linear_tolerance: .01
+  angular_tolerance: 0.5
+  points:
+    start:
+      xypoint: [0, 0, 0]  # x,y, heading
+      zpoint: [0, 0, 0, 0]  # z, z_dot, theta (superelevation), theta_dot
+  connections:
+    0:
+      lanes: [2, 0, 0]  # num_lanes, ref_lane, r_ref
+      start: ["ref", "points.start.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]
+    1.1:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.0.end.1.forward"]
+      arc: [50, 90]  # radius, d_theta
+      z_end: ["ref", [0, 0, 0, 0]]
+    1.2:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.1.1.end.ref.forward"]
+      arc: [50, -90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    1.3:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.1.2.end.ref.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]
+    1.4:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.1.3.end.ref.forward"]
+      arc: [50, -90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    1.5:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.1.4.end.ref.forward"]
+      arc: [50, 90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    2.1:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.0.end.0.forward"]
+      arc: [50, -90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    2.2:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.2.1.end.ref.forward"]
+      arc: [50, 90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    2.3:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.2.2.end.ref.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]
+    2.4:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.2.3.end.ref.forward"]
+      arc: [50, 90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    2.5:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.2.4.end.ref.forward"]
+      arc: [50, -90]
+      z_end: ["ref", [0, 0, 0, 0]]
+    3:
+      lanes: [2, 0, 0]
+      start: ["ref", "connections.2.5.end.ref.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]

--- a/automotive/maliput/multilane/dual_non_intersecting_lanes.yaml
+++ b/automotive/maliput/multilane/dual_non_intersecting_lanes.yaml
@@ -1,0 +1,29 @@
+# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+maliput_multilane_builder:
+  id: "dual_non_intersecting_lanes"
+  lane_width: 6
+  left_shoulder: 5
+  right_shoulder: 5
+  elevation_bounds: [0, 5]
+  linear_tolerance: .01
+  angular_tolerance: 0.5
+  points:
+    start1:
+      xypoint: [0, 0, 0]  # x,y, heading
+      zpoint: [0, 0, 0, 0]  # z, z_dot, theta (superelevation), theta_dot
+    start2:
+      xypoint: [0, 20, 0]
+      zpoint: [0, 0, 0, 0]
+  connections:
+    0:
+      lanes: [1, 0, 0]  # num_lanes, ref_lane, r_ref
+      start: ["ref", "points.start1.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]
+    1:
+      lanes: [1, 0, 0]  # num_lanes, ref_lane, r_ref
+      start: ["ref", "points.start2.forward"]
+      length: 100
+      z_end: ["ref", [0, 0, 0, 0]]

--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -25,10 +25,12 @@ drake_cc_package_library(
 drake_cc_library(
     name = "everything",
     srcs = [
+        "derive_lane_s_route.cc",
         "generate_obj.cc",
         "generate_urdf.cc",
     ],
     hdrs = [
+        "derive_lane_s_route.h",
         "generate_obj.h",
         "generate_urdf.h",
     ],
@@ -83,6 +85,18 @@ filegroup(
     name = "test_data",
     testonly = 1,
     srcs = glob(["test/data/*"]),
+)
+
+drake_cc_googletest(
+    name = "derive_lane_s_route_test",
+    data = [
+        "//automotive/maliput/multilane:yamls",
+    ],
+    deps = [
+        ":utility",
+        "//automotive/maliput/dragway",
+        "//automotive/maliput/multilane",
+    ],
 )
 
 drake_cc_googletest(

--- a/automotive/maliput/utility/derive_lane_s_route.cc
+++ b/automotive/maliput/utility/derive_lane_s_route.cc
@@ -1,0 +1,76 @@
+#include "drake/automotive/maliput/utility/derive_lane_s_route.h"
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace {
+
+using api::Lane;
+using api::LaneEnd;
+using api::LaneEndSet;
+
+// Defines the maximum sequence length. This prevents memory overflows when
+// dealing with giant road networks.
+int constexpr kMaxSequenceLength{100};
+
+void AddLanesInLaneEndSet(const LaneEndSet* lane_end_set,
+                          std::vector<const Lane*>* container) {
+  for (int i = 0; i < lane_end_set->size(); ++i) {
+    const LaneEnd& lane_end = lane_end_set->get(i);
+    container->push_back(lane_end.lane);
+  }
+}
+
+std::vector<std::vector<const Lane*>> FindLaneSequencesHelper(const Lane& start,
+    const Lane& end, const std::vector<const Lane*>& visited_list,
+    int current_length) {
+  std::vector<std::vector<const Lane*>> result;
+  if (current_length >= kMaxSequenceLength) return result;
+
+  // Gather all of the start lane's ongoing and neighboring lanes. These are the
+  // lanes that will be checked in search for the end lane.
+  std::vector<const Lane*> lanes_to_check;
+  AddLanesInLaneEndSet(start.GetOngoingBranches(api::LaneEnd::kStart),
+                       &lanes_to_check);
+  AddLanesInLaneEndSet(start.GetOngoingBranches(api::LaneEnd::kFinish),
+                       &lanes_to_check);
+  if (start.to_left()) lanes_to_check.push_back(start.to_left());
+  if (start.to_right()) lanes_to_check.push_back(start.to_right());
+
+  for (const auto& next_lane : lanes_to_check) {
+    if (std::find(visited_list.begin(), visited_list.end(), next_lane)
+        != visited_list.end()) {
+      continue;
+    }
+    if (next_lane->id() == end.id()) {
+      result.push_back({&start, &end});
+    } else {
+      std::vector<const Lane*> new_visited_list = visited_list;
+      new_visited_list.push_back(next_lane);
+      const auto subsequences = FindLaneSequencesHelper(
+          *next_lane, end, new_visited_list, current_length + 1);
+      for (std::vector<const Lane*> sequence : subsequences) {
+        sequence.insert(sequence.begin(), &start);
+        result.push_back(sequence);
+      }
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+std::vector<std::vector<const Lane*>> FindLaneSequences(const Lane& start,
+                                                        const Lane& end) {
+  if (start.id() == end.id()) {
+    return {{&start}};
+  }
+  return FindLaneSequencesHelper(start, end, {&start}, 0);
+}
+
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/derive_lane_s_route.h
+++ b/automotive/maliput/utility/derive_lane_s_route.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/automotive/maliput/api/lane.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+
+/// Finds and returns sequences of lanes that go from a specified start lane to
+/// a specified end lane. All adjacent and ongoing lanes in both sides of a lane
+/// are searched. If @p start and @p end are the same lane, only one sequence of
+/// length one is returned.
+///
+/// @param start The lane at the start of the sequence.
+/// @param end The lane at the end of the sequence.
+/// @return A vector of sequences of lanes. A vector of length zero is returned
+/// if no sequences are found.
+std::vector<std::vector<const api::Lane*>> FindLaneSequences(
+    const api::Lane& start, const api::Lane& end);
+
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/test/derive_lane_s_route_test.cc
+++ b/automotive/maliput/utility/test/derive_lane_s_route_test.cc
@@ -1,0 +1,241 @@
+#include "drake/automotive/maliput/utility/derive_lane_s_route.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/dragway/road_geometry.h"
+#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/loader.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+
+using api::GeoPosition;
+
+class DragwayBasedTest : public ::testing::Test {
+ protected:
+  DragwayBasedTest()
+      : dragway_(
+            api::RoadGeometryId("my_dragway"), kNumLanes, kLength, kLaneWidth,
+            kShoulderWidth, kMaxHeight,
+            std::numeric_limits<double>::epsilon() /* linear_tolerance */,
+            std::numeric_limits<double>::epsilon() /* angular_tolerance */),
+        right_lane_(*dragway_.ToRoadPosition(GeoPosition(0, -kLaneWidth, 0),
+                                             nullptr, nullptr, nullptr).lane),
+        center_lane_(*dragway_.ToRoadPosition(GeoPosition(0, 0, 0),
+                                              nullptr, nullptr, nullptr).lane),
+        left_lane_(*dragway_.ToRoadPosition(GeoPosition(0, kLaneWidth, 0),
+                                            nullptr, nullptr, nullptr).lane) {
+  }
+
+  void SetUp() override {
+    ASSERT_TRUE(right_lane_.to_left());
+    ASSERT_TRUE(center_lane_.to_left());
+    ASSERT_TRUE(center_lane_.to_right());
+    ASSERT_TRUE(left_lane_.to_right());
+  }
+
+  // The number of lanes was intentionally chosen to evaluate all combinations
+  // of adjacent lanes, i.e., it includes a lane with just a lane to the left, a
+  // lane with just a lane to the right, and a lane with lanes to both the left
+  // and right. The rest of the parameters were arbitrarily chosen.
+  const int kNumLanes{3};
+  const double kLength{100};
+  const double kLaneWidth{6};
+  const double kShoulderWidth{1};
+  const double kMaxHeight{5};
+  const dragway::RoadGeometry dragway_;
+  const api::Lane& right_lane_;
+  const api::Lane& center_lane_;
+  const api::Lane& left_lane_;
+};
+
+class DragwayBasedSequenceTest : public DragwayBasedTest {
+ protected:
+  void CheckSequences(
+      const std::vector<std::vector<const api::Lane*>>& sequences,
+      std::vector<api::LaneId> expected_ids) {
+    ASSERT_EQ(sequences.size(), 1);
+    const std::vector<const api::Lane*> sequence = sequences.at(0);
+    ASSERT_EQ(sequence.size(), expected_ids.size());
+    for (int i = 0; i < static_cast<int>(expected_ids.size()); ++i) {
+      ASSERT_EQ(sequence.at(i)->id(), expected_ids.at(i));
+    }
+  }
+};
+
+TEST_F(DragwayBasedSequenceTest, CenterToLeft) {
+  CheckSequences(FindLaneSequences(center_lane_, left_lane_),
+                 {center_lane_.id(), left_lane_.id()});
+}
+
+TEST_F(DragwayBasedSequenceTest, CenterToRight) {
+  CheckSequences(FindLaneSequences(center_lane_, right_lane_),
+                 {center_lane_.id(), right_lane_.id()});
+}
+
+TEST_F(DragwayBasedSequenceTest, RightToLeft) {
+  CheckSequences(FindLaneSequences(right_lane_, left_lane_),
+                 {right_lane_.id(), center_lane_.id(), left_lane_.id()});
+}
+
+TEST_F(DragwayBasedSequenceTest, LeftToRight) {
+  CheckSequences(FindLaneSequences(left_lane_, right_lane_),
+                 {left_lane_.id(), center_lane_.id(), right_lane_.id()});
+}
+
+class MultilaneBasedTest : public ::testing::Test {
+ protected:
+  MultilaneBasedTest()
+      : road_geometry_(multilane::LoadFile(multilane::BuilderFactory(),
+          "automotive/maliput/multilane/branch_and_merge.yaml")) {
+  }
+
+  void SetUp() override {
+    for (int i = 0; i < road_geometry_->num_junctions(); ++i) {
+      const api::Junction* junction = road_geometry_->junction(i);
+      for (int j = 0; j < junction->num_segments(); ++j) {
+        const api::Segment* segment = junction->segment(j);
+        for (int k = 0; k < segment->num_lanes(); ++k) {
+          const api::Lane* lane = segment->lane(k);
+          lanes_[lane->id().string()] = lane;
+        }
+      }
+    }
+    ASSERT_EQ(lanes_.size(), 14);
+  }
+
+  std::unique_ptr<const api::RoadGeometry> road_geometry_;
+  std::map<std::string, const api::Lane*> lanes_;
+};
+
+class MultilaneBasedSequenceTest : public MultilaneBasedTest {
+ protected:
+  void CheckSequences(
+      const std::vector<std::vector<const api::Lane*>>& sequences,
+      std::vector<std::vector<std::string>> expected_ids) {
+    ASSERT_TRUE(sequences.size() == expected_ids.size());
+    for (const auto& sequence : sequences) {
+      bool found = false;
+      for (int j = 0; !found && j < static_cast<int>(expected_ids.size());
+          ++j) {
+        const std::vector<std::string>& expected_seq = expected_ids.at(j);
+        bool match = true;
+        if (sequence.size() == expected_seq.size()) {
+          for (int i = 0; match && i < static_cast<int>(sequence.size()); ++i) {
+            if (sequence.at(i)->id().string() != expected_seq.at(i)) {
+              match = false;
+            }
+          }
+        } else {
+          match = false;
+        }
+        if (match) {
+          found = true;
+        }
+      }
+      ASSERT_TRUE(found);
+    }
+  }
+};
+
+TEST_F(MultilaneBasedSequenceTest, StartLeftLaneToEndLeftLane) {
+  const api::Lane& start_lane = *lanes_["l:0_1"];
+  const api::Lane& end_lane = *lanes_["l:3_1"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1"},
+                  {"l:0_1", "l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0", "l:3_1"}});
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartRightLaneToEndRightLane) {
+  const api::Lane& start_lane = *lanes_["l:0_0"];
+  const api::Lane& end_lane = *lanes_["l:3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0"},
+                  {"l:0_0", "l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1", "l:3_0"}});
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartLeftLaneToEndRightLane) {
+  const api::Lane& start_lane = *lanes_["l:0_1"];
+  const api::Lane& end_lane = *lanes_["l:3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1", "l:3_0"},
+                  {"l:0_1", "l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0"}});
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartRightLaneToEndLeftLane) {
+  const api::Lane& start_lane = *lanes_["l:0_0"];
+  const api::Lane& end_lane = *lanes_["l:3_1"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0", "l:3_1"},
+                  {"l:0_0", "l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1"}});
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartRightLaneToMiddleLeftLane) {
+  const api::Lane& start_lane = *lanes_["l:0_0"];
+  const api::Lane& end_lane = *lanes_["l:1.3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_0", "l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0"},
+                  {"l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0", "l:3_1", "l:1.5_0", "l:1.4_0", "l:1.3_0"}
+                 });
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartRightLaneToMiddleRightLane) {
+  const api::Lane& start_lane = *lanes_["l:0_0"];
+  const api::Lane& end_lane = *lanes_["l:2.3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0"},
+                  {"l:0_0", "l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1", "l:3_0", "l:2.5_0", "l:2.4_0", "l:2.3_0"}
+                 });
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartLeftLaneToMiddleLeftLane) {
+  const api::Lane& start_lane = *lanes_["l:0_1"];
+  const api::Lane& end_lane = *lanes_["l:1.3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0"},
+                  {"l:0_1", "l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0", "l:2.4_0",
+                   "l:2.5_0", "l:3_0", "l:3_1", "l:1.5_0", "l:1.4_0", "l:1.3_0"}
+                 });
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartLeftLaneToMiddleRightLane) {
+  const api::Lane& start_lane = *lanes_["l:0_1"];
+  const api::Lane& end_lane = *lanes_["l:2.3_0"];
+  CheckSequences(FindLaneSequences(start_lane, end_lane),
+                 {{"l:0_1", "l:0_0", "l:2.1_0", "l:2.2_0", "l:2.3_0"},
+                  {"l:0_1", "l:1.1_0", "l:1.2_0", "l:1.3_0", "l:1.4_0",
+                   "l:1.5_0", "l:3_1", "l:3_0", "l:2.5_0", "l:2.4_0", "l:2.3_0"}
+                 });
+}
+
+TEST_F(MultilaneBasedSequenceTest, StartAndStopInSameLane) {
+  const std::string lane_id = "l:0_1";
+  const api::Lane& lane = *lanes_[lane_id];
+  CheckSequences(FindLaneSequences(lane, lane), {{lane_id}});
+}
+
+GTEST_TEST(DeriveLaneSRouteTest, NoRouteToEndLane) {
+  std::unique_ptr<const api::RoadGeometry> road = multilane::LoadFile(
+        multilane::BuilderFactory(),
+        "automotive/maliput/multilane/dual_non_intersecting_lanes.yaml");
+  const api::Lane& start_lane = *road->junction(0)->segment(0)->lane(0);
+  const api::Lane& end_lane = *road->junction(1)->segment(0)->lane(0);
+  ASSERT_EQ(FindLaneSequences(start_lane, end_lane).size(), 0);
+}
+
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This is a utility method for finding a sequence of lanes that will eventually constitute a LaneSRoute.

The following labeling of the lanes in the branch_and_merge road network should help towards understanding the multilane-based unit tests.

![branch_and_merge](https://user-images.githubusercontent.com/1388098/39825689-71ea3330-5380-11e8-8cbf-a257033972f2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8781)
<!-- Reviewable:end -->
