### PR TITLE
Rework OutputPort to not depend on System

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -33,6 +33,7 @@ drake_cc_package_library(
         ":leaf_output_port",
         ":leaf_system",
         ":model_values",
+        ":output_port",
         ":output_port_value",
         ":parameters",
         ":single_output_vector_source",
@@ -330,14 +331,28 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "output_port",
+    srcs = ["output_port.cc"],
+    hdrs = ["output_port.h"],
+    deps = [
+        ":context",
+        ":framework_common",
+        ":system_base",
+        ":value",
+        ":vector",
+        "//common:default_scalars",
+        "//common:essential",
+        "//common:type_safe_index",
+    ],
+)
+
+drake_cc_library(
     name = "system",
     srcs = [
-        "output_port.cc",
         "system.cc",
         "witness_function.cc",
     ],
     hdrs = [
-        "output_port.h",
         "system.h",
         "witness_function.h",
     ],
@@ -345,6 +360,7 @@ drake_cc_library(
         ":context",
         ":event_collection",
         ":input_port_descriptor",
+        ":output_port",
         ":system_base",
         ":system_constraint",
         ":system_scalar_converter",
@@ -364,11 +380,13 @@ drake_cc_library(
     srcs = ["leaf_output_port.cc"],
     hdrs = ["leaf_output_port.h"],
     deps = [
-        ":system",
+        ":framework_common",
+        ":output_port",
         ":value",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
+        "//common:nice_type_name",
     ],
 )
 

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -53,8 +53,9 @@ class DiagramOutputPort : public OutputPort<T> {
   /// diagram.
   DiagramOutputPort(const Diagram<T>& diagram,
                     const OutputPort<T>* source_output_port)
-      : OutputPort<T>(diagram, source_output_port->get_data_type(),
-                      source_output_port->size()),
+      : OutputPort<T>(
+          diagram, diagram, OutputPortIndex(diagram.get_num_output_ports()),
+          source_output_port->get_data_type(), source_output_port->size()),
         source_output_port_(source_output_port),
         subsystem_index_(
             diagram.GetSystemIndexOrAbort(&source_output_port->get_system())) {}

--- a/systems/framework/leaf_output_port.cc
+++ b/systems/framework/leaf_output_port.cc
@@ -6,6 +6,7 @@
 #include "drake/common/autodiff.h"
 #include "drake/common/default_scalars.h"
 #include "drake/common/drake_assert.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/common/nice_type_name.h"
 
 namespace drake {
@@ -73,7 +74,8 @@ const AbstractValue& LeafOutputPort<T>::DoEval(
   // TODO(sherm1) Provide proper default behavior for an output port with
   // its own cache entry.
   DRAKE_ABORT_MSG("LeafOutputPort::DoEval(): NOT IMPLEMENTED YET");
-  return *reinterpret_cast<const AbstractValue*>(0);
+  static never_destroyed<Value<int>> dummy{0};
+  return dummy.access();
 }
 
 // The Vector2/3 instantiations here are for the benefit of some

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -71,11 +71,15 @@ class LeafOutputPort : public OutputPort<T> {
   concrete type as is returned by the allocator. The allocator function is not
   invoked here during construction of the port so it may depend on data that
   becomes available only after completion of the containing System or
-  Diagram. */
+  Diagram. The `system` parameter must be the same object as the `system_base`
+  parameter. */
   LeafOutputPort(const System<T>& system,
+                 const internal::SystemMessageInterface& system_base,
+                 OutputPortIndex index,
                  AllocCallback alloc_function,
                  CalcCallback calc_function)
-      : OutputPort<T>(system, kAbstractValued, 0 /* size */) {
+      : OutputPort<T>(system, system_base, index, kAbstractValued,
+                      0 /* size */) {
     set_allocation_function(alloc_function);
     set_calculation_function(calc_function);
   }
@@ -86,16 +90,19 @@ class LeafOutputPort : public OutputPort<T> {
   same underlying concrete type as is returned by the allocator. Requires the
   fixed size to be given explicitly here. The allocator function is not invoked
   here during construction of the port so it may depend on data that becomes
-  available only after completion of the containing System or Diagram. */
+  available only after completion of the containing System or Diagram. The
+  `system` parameter must be the same object as the `system_base` parameter. */
   // Note: there is no guarantee that the allocator can be invoked successfully
   // here since construction of the containing System is likely incomplete when
   // this method is invoked. Do not attempt to extract the size from
   // the allocator by calling it here.
   LeafOutputPort(const System<T>& system,
+                 const internal::SystemMessageInterface& system_base,
+                 OutputPortIndex index,
                  int fixed_size,
                  AllocCallback vector_alloc_function,
                  CalcVectorCallback vector_calc_function)
-      : OutputPort<T>(system, kVectorValued, fixed_size) {
+      : OutputPort<T>(system, system_base, index, kVectorValued, fixed_size) {
     set_allocation_function(vector_alloc_function);
     set_calculation_function(vector_calc_function);
   }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -1553,7 +1553,8 @@ class LeafSystem : public System<T> {
       typename LeafOutputPort<T>::AllocCallback vector_allocator,
       typename LeafOutputPort<T>::CalcVectorCallback vector_calculator) {
     auto port = std::make_unique<LeafOutputPort<T>>(
-        *this, fixed_size, vector_allocator, vector_calculator);
+        *this, *this, OutputPortIndex(this->get_num_output_ports()),
+        fixed_size, vector_allocator, vector_calculator);
     LeafOutputPort<T>* const port_ptr = port.get();
     this->CreateOutputPort(std::move(port));
     return *port_ptr;
@@ -1564,8 +1565,9 @@ class LeafSystem : public System<T> {
   LeafOutputPort<T>& CreateAbstractLeafOutputPort(
       typename LeafOutputPort<T>::AllocCallback allocator,
       typename LeafOutputPort<T>::CalcCallback calculator) {
-    auto port =
-        std::make_unique<LeafOutputPort<T>>(*this, allocator, calculator);
+    auto port = std::make_unique<LeafOutputPort<T>>(
+        *this, *this, OutputPortIndex(this->get_num_output_ports()),
+        allocator, calculator);
     LeafOutputPort<T>* const port_ptr = port.get();
     this->CreateOutputPort(std::move(port));
     return *port_ptr;

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -96,9 +96,12 @@ class LeafOutputPortTest : public ::testing::Test {
 
   // Create abstract- and vector-valued ports.
   DummySystem dummy_;
-  LeafOutputPort<double> absport_general_{dummy_, alloc_string, calc_string};
-  LeafOutputPort<double> vecport_general_{dummy_, 3, alloc_myvector3,
-                                          calc_vector3};
+  LeafOutputPort<double> absport_general_{
+    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
+    alloc_string, calc_string};
+  LeafOutputPort<double> vecport_general_{
+    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
+    3, alloc_myvector3, calc_vector3};
 };
 
 // Helper function for testing an abstract-valued port.
@@ -150,7 +153,9 @@ unique_ptr<AbstractValue> alloc_null() {
 // The null check is done in all builds.
 TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
   // Create an abstract port with an allocator that returns null.
-  LeafOutputPort<double> null_port{dummy_, alloc_null, calc_string};
+  LeafOutputPort<double> null_port{
+    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
+    alloc_null, calc_string};
   EXPECT_THROW(null_port.Allocate(), std::logic_error);
 }
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -67,7 +67,8 @@ class TestSystem : public System<double> {
 
   const LeafOutputPort<double>& AddAbstractOutputPort() {
     // Create an abstract output port with no allocator or calculator.
-    auto port = std::make_unique<LeafOutputPort<double>>(*this,
+    auto port = std::make_unique<LeafOutputPort<double>>(
+        *this, *this, OutputPortIndex(get_num_output_ports()),
         typename LeafOutputPort<double>::AllocCallback(nullptr),
         typename LeafOutputPort<double>::CalcCallback(nullptr));
     LeafOutputPort<double>* const port_ptr = port.get();
@@ -412,7 +413,8 @@ class ValueIOTestSystem : public System<T> {
         this->AllocateForcedUnrestrictedUpdateEventCollection());
 
     this->DeclareAbstractInputPort();
-    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(*this,
+    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
+        *this, *this, OutputPortIndex(this->get_num_output_ports()),
         []() { return AbstractValue::Make(std::string()); },
         [this](const Context<T>& context, AbstractValue* output) {
           this->CalcStringOutput(context, output);
@@ -424,7 +426,7 @@ class ValueIOTestSystem : public System<T> {
     this->DeclareInputPort(kVectorValued, 1,
                            RandomDistribution::kGaussian);
     this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
-        *this,
+        *this, *this, OutputPortIndex(this->get_num_output_ports()),
         1,  // Vector size.
         []() {
           return std::make_unique<Value<BasicVector<T>>>(1);


### PR DESCRIPTION
This breaks the cycle between system.{h,cc} and output_port.{h,cc}, in preparation for moving the method bodies into the header in support of user-defined scalar types.  (This is a step toward #8640.  See #8685 for the follow-up work that takes advantage of this.)

Relatedly, we stop forward-declaring a Context<T> and instead directly include it, per GSG rules.

Relatedly, we also stop casting nullptr to a reference to return; this is general a bad idea, and will cause problems with the user-defined scalar commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8786)
<!-- Reviewable:end -->
