### PR TITLE
Update to VTK 8.1 and latest Director and add packages for Bionic

### DIFF
--- a/setup/mac/binary_distribution/Brewfile
+++ b/setup/mac/binary_distribution/Brewfile
@@ -21,7 +21,7 @@ brew 'python@2'
 brew 'scipy'
 brew 'tinyxml'
 brew 'tinyxml2'
-brew 'vtk@8.0'
+brew 'vtk@8.1'
 brew 'yaml-cpp'
 
 cask 'java8' unless system '/usr/libexec/java_home --version 1.8 --failfast &> /dev/null'

--- a/systems/sensors/rgbd_renderer_vtk.cc
+++ b/systems/sensors/rgbd_renderer_vtk.cc
@@ -31,7 +31,6 @@
 #include <vtkSphereSource.h>
 #include <vtkTransform.h>
 #include <vtkTransformPolyDataFilter.h>
-#include <vtkVersion.h>
 #include <vtkWindowToImageFilter.h>
 
 #include "drake/common/drake_assert.h"
@@ -125,19 +124,11 @@ class ShaderCallback : public vtkCommand {
 
   // NOLINTNEXTLINE(runtime/int): To match pre-existing APIs.
   void Execute(vtkObject*, unsigned long, void* callback_object) VTK_OVERRIDE {
-#if VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 0
-    vtkOpenGLHelper* cell_bo =
-        reinterpret_cast<vtkOpenGLHelper*>(callback_object);
-    cell_bo->Program->SetUniformf("z_near", z_near_);
-    cell_bo->Program->SetUniformf("z_far", z_far_);
-    cell_bo = nullptr;
-#else
     vtkShaderProgram* program =
         reinterpret_cast<vtkShaderProgram*>(callback_object);
     program->SetUniformf("z_near", z_near_);
     program->SetUniformf("z_far", z_far_);
     program = nullptr;
-#endif
   }
 
   void set_renderer(vtkRenderer* renderer) { renderer_ = renderer; }
@@ -397,11 +388,7 @@ RgbdRendererVTK::Impl::Impl(RgbdRendererVTK* parent,
                               parent_->config().height);
     pipeline->window->AddRenderer(pipeline->renderer.GetPointer());
     pipeline->filter->SetInput(pipeline->window.GetPointer());
-#if VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 0
-    pipeline->filter->SetMagnification(1);
-#else
     pipeline->filter->SetScale(1);
-#endif
     pipeline->filter->ReadFrontBufferOff();
     pipeline->filter->SetInputBufferTypeToRGBA();
     pipeline->filter->Update();

--- a/tools/workspace/drake_visualizer/drake_visualizer.py
+++ b/tools/workspace/drake_visualizer/drake_visualizer.py
@@ -47,9 +47,14 @@ except KeyError:
 # TODO(eric.cousineau): Remove these shims if we can teach Bazel how to handle
 # these on its own.
 if sys.platform.startswith("linux"):
-    # Ensure that we handle LD_LIBRARY_PATH and PYTHONPATH for `@vtk`.
-    set_path("LD_LIBRARY_PATH", "external/vtk/lib")
+    # Ensure that we handle LD_LIBRARY_PATH for @lcm and @vtk and PYTHONPATH
+    # for @vtk.
+    set_path("LD_LIBRARY_PATH", "external/lcm")
+    prepend_path("LD_LIBRARY_PATH", "external/vtk/lib")
     prepend_path("PYTHONPATH", "external/vtk/lib/python2.7/site-packages")
+elif sys.platform == "darwin":
+    # Ensure that we handle DYLD_LIBRARY_PATH for @lcm.
+    set_path("DYLD_LIBRARY_PATH", "external/lcm")
 
 # Execute binary.
 bin_path = resolve_path("external/drake_visualizer/bin/drake-visualizer")

--- a/tools/workspace/drake_visualizer/repository.bzl
+++ b/tools/workspace/drake_visualizer/repository.bzl
@@ -15,6 +15,7 @@ Build configuration:
     DD_QT_VERSION=5
     USE_EXTERNAL_INSTALL=ON
     USE_LCM=ON
+    USE_SYSTEM_LCM=ON
     USE_SYSTEM_VTK=ON
 
 Example:
@@ -46,11 +47,14 @@ def _impl(repository_ctx):
         fail(os_result.error)
 
     if os_result.is_macos:
-        archive = "dv-0.1.0-286-g10f57e8-qt-5.10.1-vtk-8.0.1-mac-x86_64.tar.gz"
-        sha256 = "daf55d0966bb1b82fa6214214c203c20da61a5a97d1beb2d449e433141553dee"  # noqa
+        archive = "dv-0.1.0-310-g37b8e23-qt-5.10.1-vtk-8.1.1-mac-x86_64.tar.gz"
+        sha256 = "72c613c2a9d6717f912640d1c51a68297367d5c7241c7d24b22848d0fbfe9b8b"  # noqa
     elif os_result.ubuntu_release == "16.04":
-        archive = "dv-0.1.0-286-g10f57e8-qt-5.5.1-vtk-8.0.1-xenial-x86_64.tar.gz"  # noqa
-        sha256 = "66fb82efa163ce10e665319c2628dbce2aac7698e0bd53965bdc05bbc5abe7b5"  # noqa
+        archive = "dv-0.1.0-310-g37b8e23-qt-5.5.1-vtk-8.1.1-xenial-x86_64.tar.gz"  # noqa
+        sha256 = "c770a1da2147274ecaa715292223f7f065e51a905a65cbc4a18589eee396a171"  # noqa
+    elif os_result.ubuntu_release == "18.04":
+        archive = "dv-0.1.0-310-g37b8e23-qt-5.9.5-vtk-8.1.1-bionic-x86_64.tar.gz"  # noqa
+        sha256 = "023ada72358f1c6e8c690ebdf3f98decbb15a7623bba743a010e221ff4b93b05"  # noqa
     else:
         fail("Operating system is NOT supported", attr = os_result)
 
@@ -108,6 +112,7 @@ filegroup(
     ],
     data = [
         ":drake_visualizer_python_deps",
+        "@lcm//:libdrake_lcm.so",
         "@vtk",
     ],
     visibility = ["//visibility:public"],

--- a/tools/workspace/lcm/package.BUILD.bazel
+++ b/tools/workspace/lcm/package.BUILD.bazel
@@ -108,7 +108,7 @@ cc_binary(
         "@//conditions:default": [],
     }),
     linkshared = 1,
-    visibility = [],
+    visibility = ["@drake_visualizer//:__pkg__"],
     deps = ["@glib"],
 )
 

--- a/tools/workspace/vtk/repository.bzl
+++ b/tools/workspace/vtk/repository.bzl
@@ -14,7 +14,8 @@ Build configuration:
     BUILD_TESTING=OFF
     BUILD_SHARED_LIBS=ON
     CMAKE_BUILD_TYPE=Release
-    Module_vtkGUISupportQt=ON
+    Module_vtkRenderingOSPRay=ON
+    VTK_Group_Qt=ON
     VTK_LEGACY_REMOVE=ON
     VTK_QT_VERSION=5
     VTK_USE_SYSTEM_EXPAT=ON
@@ -51,7 +52,7 @@ Argument:
 
 load("@drake//tools/workspace:os.bzl", "determine_os")
 
-VTK_MAJOR_MINOR_VERSION = "8.0"
+VTK_MAJOR_MINOR_VERSION = "8.1"
 
 def _vtk_cc_library(os_name, name, hdrs = None, visibility = None, deps = None,
                     header_only = False, linkopts = []):
@@ -110,8 +111,11 @@ def _impl(repository_ctx):
             VTK_MAJOR_MINOR_VERSION), "include")
     elif os_result.is_ubuntu:
         if os_result.ubuntu_release == "16.04":
-            archive = "vtk-v8.0.1-qt-5.5.1-xenial-x86_64-1.tar.gz"
-            sha256 = "d6cb1b8cfe8d8b9abe400c39267954cbba5b12d4ff550d42a1fe695d3e01dc40"  # noqa
+            archive = "vtk-v8.1.1-qt-5.5.1-xenial-x86_64.tar.gz"
+            sha256 = "b2bc97da2d21dda16775de50638ffeaa4070673dcc01aaee88311f09678a36bc"  # noqa
+        elif os_result.ubuntu_release == "18.04":
+            archive = "vtk-v8.1.1-qt-5.9.5-bionic-x86_64.tar.gz"
+            sha256 = "3f61705139f2475bd035ccdd3d52920f2308b3581ca044a6a4bc535ceea9cc71"  # noqa
         else:
             fail("Operating system is NOT supported", attr = os_result)
 


### PR DESCRIPTION
Needs local testing on Linux of `drake-visualizer` using both `bazel run //tools:drake_visualizer` and the installed executable (`bazel run install -- /opt/drake && /opt/drake/bin/drake-visualizer`). Note that for licensing reasons this switches to using a shared library for LCM (c.f., #7423, #8153).

Fixes #7908, fixes #8322, fixes #8764. Relates #7907.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8789)
<!-- Reviewable:end -->