### PR TITLE
Removed regularization parameters from the acceleration constraint…

### DIFF
--- a/examples/rod2d/rod2d-inl.h
+++ b/examples/rod2d/rod2d-inl.h
@@ -375,7 +375,6 @@ void Rod2D<T>::CalcConstraintProblemData(
     Ndot.row(i) =  GetJacobianDotRow(context, points[i], contact_normal);
   const Vector3<T> v = GetRodVelocity(context);
   data->kN = Ndot * v;
-  data->gammaN.setZero(nc);
 
   // Form the tangent directions contact Jacobian (F), its time derivative
   // (Fdot), and compute Fdot * v.
@@ -393,8 +392,6 @@ void Rod2D<T>::CalcConstraintProblemData(
   data->F_transpose_mult = [F](const VectorX<T>& w) -> VectorX<T> {
     return F.transpose() * w;
   };
-  data->gammaF.setZero(nr);
-  data->gammaE.setZero(non_sliding_contacts.size());
 
   // Form N - mu*Q (Q is sliding contact direction Jacobian).
   MatrixX<T> N_minus_mu_Q = N;
@@ -411,7 +408,6 @@ void Rod2D<T>::CalcConstraintProblemData(
       VectorX<T> { return N_minus_mu_Q.transpose() * w; };
 
   data->kL.resize(0);
-  data->gammaL.resize(0);
 
   // Set external force vector.
   data->tau = ComputeExternalForces(context);

--- a/multibody/constraint/constraint_problem_data.h
+++ b/multibody/constraint/constraint_problem_data.h
@@ -164,10 +164,6 @@ struct ConstraintAccelProblemData {
 
   /// This ℝⁿ vector is the vector kᴺ(t,q,v) defined above.
   VectorX<T> kN;
-
-  // TODO(edrumwri): define this quantity properly (documentation forthcoming).
-  /// This ℝⁿ vector represents the diagonal matrix γᴺ.
-  VectorX<T> gammaN;
   /// @}
 
   /// @name Data for non-sliding contact friction constraints
@@ -211,14 +207,6 @@ struct ConstraintAccelProblemData {
 
   /// This ℝʸʳ vector is the vector kᶠ(t,q,v) defined above.
   VectorX<T> kF;
-
-  // TODO(edrumwri): define this quantity properly (documentation forthcoming).
-  /// This ℝʸʳ vector represents the diagonal matrix γᶠ.
-  VectorX<T> gammaF;
-
-  // TODO(edrumwri): define this quantity properly (documentation forthcoming).
-  /// This ℝᴺ vector represents the diagonal matrix γᴱ.
-  VectorX<T> gammaE;
   /// @}
 
   /// @name Data for unilateral constraints at the acceleration level
@@ -261,10 +249,6 @@ struct ConstraintAccelProblemData {
 
   /// This ℝˢ vector is the vector kᴸ(t,q,v) defined above.
   VectorX<T> kL;
-
-  // TODO(edrumwri): define this quantity properly (documentation forthcoming).
-  /// This ℝˢ vector represents the diagonal matrix γᴸ.
-  VectorX<T> gammaL;
   /// @}
 
   /// The ℝᵐ vector tau, the generalized external force vector that

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -231,8 +231,6 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
     // and gammaE.
     data->kF.setZero(data->non_sliding_contacts.size() *
                                new_friction_directions);
-    data->gammaF.setZero(data->kF.size());
-    data->gammaE.setZero(data->non_sliding_contacts.size());
 
     // Add in empty rows to G, by default, allowing us to verify that no
     // constraint forces are added (and that solution method is robust to
@@ -384,11 +382,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
     CheckTransOperatorDim(data.L_transpose_mult, data.kL.size());
     EXPECT_EQ(data.tau.size(), ngc);
     EXPECT_EQ(data.kN.size(), num_contacts);
-    EXPECT_EQ(data.gammaN.size(), num_contacts);
     EXPECT_EQ(data.kF.size(), num_fdir);
-    EXPECT_EQ(data.gammaF.size(), num_fdir);
-    EXPECT_EQ(data.gammaE.size(), data.non_sliding_contacts.size());
-    EXPECT_EQ(data.gammaL.size(), data.kL.size());
     EXPECT_EQ(data.mu_non_sliding.size(), data.non_sliding_contacts.size());
     EXPECT_EQ(data.mu_sliding.size(), data.sliding_contacts.size());
     EXPECT_EQ(data.r.size(), data.non_sliding_contacts.size());
@@ -1340,9 +1334,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
       return N.row(0) * v;
     };
     accel_data_->kN.setZero(1);
-    accel_data_->gammaN.setZero(1);
     accel_data_->kL.setZero(1);
-    accel_data_->gammaL.setZero(1);
     accel_data_->N_minus_muQ_transpose_mult =
         [&N_minus_muQ_transpose](const VectorX<double>& l) {
       return N_minus_muQ_transpose.col(0) * l;
@@ -1477,7 +1469,6 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
     const int ngc = get_rod_num_coordinates();
     const int num_generic_unilateral_constraints = 1;
     accel_data_->kL.resize(num_generic_unilateral_constraints);
-    accel_data_->gammaL.setZero(num_generic_unilateral_constraints);
 
     // Set the Jacobian entry- in this case, the limit is an upper limit on the
     // second coordinate (vertical position). The constraint is: v̇₂ ≤ 0, which
@@ -1539,7 +1530,6 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
       return VectorX<double>(0);
     };
     accel_data_->kN.resize(0);
-    accel_data_->gammaN.resize(0);
     accel_data_->F_mult = [](const VectorX<double>&) {
       return VectorX<double>(0);
     };
@@ -1547,10 +1537,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
       return VectorX<double>::Zero(ngc);
     };
     accel_data_->kF.resize(0);
-    accel_data_->gammaF.resize(0);
-    accel_data_->gammaE.resize(0);
     accel_data_->kL.resize(1);
-    accel_data_->gammaL.setZero(1);
     accel_data_->N_minus_muQ_transpose_mult = [ngc](const VectorX<double>&) {
       return VectorX<double>::Zero(ngc);
     };


### PR DESCRIPTION
…data and solver, following discussion with @amcastro-tri on #7055. The thought behind having them in the first place was that regularization that can be necessary to solve constraint problems might be practically useful (as it is with the first-order discretization). I'm now convinced that these will not be "physically" useful and that any regularization should be handled as a numerical artifact (and hence be located in a constraint solver). Removing the "directed regularization" (i.e., different regularization coefficients applied to different constraints) accordingly, which simplifies the constraint problem data (and documentation), constraint solver, and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8790)
<!-- Reviewable:end -->
