### PR TITLE
Switch to SNOPT 7.6.1 2018-01-20 release

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -142,6 +142,9 @@ The Drake Bazel build currently supports the following proprietary solvers:
  * MOSEK 8.1
  * SNOPT 7.6
 
+.. When upgrading SNOPT to a newer revision, re-enable TestPrintFile in
+   solvers/test/snopt_solver_test.cc.
+
 .. _gurobi:
 
 Gurobi 8.0.0

--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -140,7 +140,7 @@ The Drake Bazel build currently supports the following proprietary solvers:
 
  * Gurobi 8.0.0
  * MOSEK 8.1
- * SNOPT 7.2
+ * SNOPT 7.6
 
 .. _gurobi:
 
@@ -190,8 +190,8 @@ these tests.  If you will be developing with MOSEK regularly, you may wish
 to specify a more convenient ``--test_tag_filters`` in a local ``.bazelrc``.
 See https://docs.bazel.build/versions/master/user-manual.html#bazelrc.
 
-SNOPT 7.2
----------
+SNOPT
+-----
 
 Drake provides two mechanisms to include the SNOPT sources.  One mechanism is
 to provide your own SNOPT source archive.  The other mechanism is via access to
@@ -201,8 +201,8 @@ Using your own source archive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Download the SNOPT sources from the distributor in ``.tar.gz`` format (e.g.,
-   named ``snopt7.5-1.4.tar.gz``).
-2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.5-1.4.tar.gz``
+   named ``snopt7.6.tar.gz``).
+2. ``export SNOPT_PATH=/home/username/Downloads/snopt7.6.tar.gz``
 
 Using the RobotLocomotion git repository
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/multibody/test/test_ik.cc
+++ b/multibody/test/test_ik.cc
@@ -107,7 +107,7 @@ GTEST_TEST(testIK, iiwaIK) {
   inverseKin(model.get(), q0, q0, constraint_array.size(),
              constraint_array.data(), ikoptions, &q_sol, &info,
              &infeasible_constraint);
-  EXPECT_EQ(info, 1);
+  ASSERT_EQ(info, 1);
 
   // Check that our constrained joint is within where we tried to constrain it.
   EXPECT_GE(q_sol(joint_position_start_idx(0)), joint_lb(0));
@@ -117,7 +117,7 @@ GTEST_TEST(testIK, iiwaIK) {
   const KinematicsCache<double> cache = model->doKinematics(q_sol);
   EXPECT_TRUE(CompareMatrices(
       pos_end, model->relativeTransform(cache, 0, link_7_idx).translation(),
-      pos_tol + 1e-6, MatrixCompareType::absolute));
+      pos_tol + 2e-6, MatrixCompareType::absolute));
 }
 
 GTEST_TEST(testIK, iiwaIKInfeasible) {

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -82,7 +82,7 @@ def _impl(repo_ctx):
 snopt_repository = repository_rule(
     attrs = {
         "remote": attr.string(default = "git@github.com:RobotLocomotion/snopt.git"),  # noqa
-        "commit": attr.string(default = "0f475624131c9ca4d5624e74c3f8273ccc926f9b"),  # noqa
+        "commit": attr.string(default = "c17db3769e59d4a8d651631d5d79641cecca0504"),  # noqa
         "use_drake_build_rules": attr.bool(default = True),
     },
     environ = ["SNOPT_PATH"],


### PR DESCRIPTION
This reverts commit 27e748f (#8348), by re-applying commit 9fea3ae (#8263).

New in this PR is the second commit, to disable `SnoptSolver.TestPrintFile` under ASan.

Closes #8263 again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8793)
<!-- Reviewable:end -->
