### PR TITLE
Add ConstantVectorSource transmogrification 

### DIFF
--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -5,15 +5,15 @@
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/vector_system.h"
-#include "drake/systems/primitives/constant_vector_source.h"
 
 using std::unique_ptr;
 
 namespace drake {
 
 using systems::BasicVector;
-using systems::ConstantVectorSource;
+using systems::LeafSystem;
 
 namespace pydrake {
 namespace {
@@ -21,10 +21,10 @@ namespace {
 using T = double;
 
 // Informs listener when this class is deleted.
-class DeleteListenerSystem : public ConstantVectorSource<T> {
+class DeleteListenerSystem : public LeafSystem<T> {
  public:
   explicit DeleteListenerSystem(std::function<void()> delete_callback)
-    : ConstantVectorSource(VectorX<T>::Constant(1, 0.)),
+      : LeafSystem<T>(),
       delete_callback_(delete_callback) {}
 
   ~DeleteListenerSystem() override {
@@ -89,7 +89,7 @@ PYBIND11_MODULE(test_util, m) {
   py::module::import("pydrake.systems.framework");
   py::module::import("pydrake.systems.primitives");
 
-  py::class_<DeleteListenerSystem, ConstantVectorSource<T>>(
+  py::class_<DeleteListenerSystem, LeafSystem<T>>(
       m, "DeleteListenerSystem")
     .def(py::init<std::function<void()>>());
   py::class_<DeleteListenerVector, BasicVector<T>>(

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -806,6 +806,7 @@ drake_cc_googletest(
     name = "single_output_vector_source_test",
     deps = [
         ":single_output_vector_source",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/framework/single_output_vector_source.h
+++ b/systems/framework/single_output_vector_source.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
@@ -41,11 +42,41 @@ class SingleOutputVectorSource : public LeafSystem<T> {
 
  protected:
   /// Creates a source with the given sole output port configuration.
+  ///
+  /// @note Objects created using this constructor overload do not support
+  /// system scalar conversion.  See @ref system_scalar_conversion.  Use a
+  /// different constructor overload if such conversion is desired.
   explicit SingleOutputVectorSource(int size)
-      : SingleOutputVectorSource(BasicVector<T>(size)) {}
+      : SingleOutputVectorSource({}, size) {}
 
   /// Creates a source with output type and dimension of the @p model_vector.
-  explicit SingleOutputVectorSource(const BasicVector<T>& model_vector) {
+  ///
+  /// @note Objects created using this constructor overload do not support
+  /// system scalar conversion.  See @ref system_scalar_conversion.  Use a
+  /// different constructor overload if such conversion is desired.
+  explicit SingleOutputVectorSource(const BasicVector<T>& model_vector)
+      : SingleOutputVectorSource({}, model_vector) {}
+
+  /// Creates a source with the given sole output port configuration.
+  ///
+  /// @note objects created using this constructor may support system scalar
+  /// conversion. See @ref system_scalar_conversion.
+  ///
+  /// @param converter is per LeafSystem::LeafSystem constructor documentation;
+  /// see that function documentation for details.
+  SingleOutputVectorSource(SystemScalarConverter converter, int size)
+      : SingleOutputVectorSource(std::move(converter), BasicVector<T>(size)) {}
+
+  /// Creates a source with output type and dimension of the @p model_vector.
+  ///
+  /// @note objects created using this constructor may support system scalar
+  /// conversion. See @ref system_scalar_conversion.
+  ///
+  /// @param converter is per LeafSystem::LeafSystem constructor documentation;
+  /// see that function documentation for details.
+  SingleOutputVectorSource(
+      SystemScalarConverter converter, const BasicVector<T>& model_vector)
+      : LeafSystem<T>(std::move(converter)) {
     this->DeclareVectorOutputPort(
         model_vector,
         &SingleOutputVectorSource<T>::CalcVectorOutput);

--- a/systems/framework/system_scalar_converter.h
+++ b/systems/framework/system_scalar_converter.h
@@ -114,6 +114,10 @@ class SystemScalarConverter {
     AddIfSupported<S, AutoDiffXd, Expression>(subtype_preservation);
   }
 
+  /// Returns true iff no conversions are supported.  (In other words, whether
+  /// this is a default-constructed object.)
+  bool empty() const { return funcs_.empty(); }
+
   /// A std::function used to convert a System<U> into a System<T>.
   template <typename T, typename U>
   using ConverterFunction =

--- a/systems/framework/test/single_output_vector_source_test.cc
+++ b/systems/framework/test/single_output_vector_source_test.cc
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
 
 namespace drake {
 namespace systems {
@@ -57,6 +58,57 @@ TEST_F(SingleOutputVectorSourceTest, OutputTest) {
 // Tests that the state is empty.
 TEST_F(SingleOutputVectorSourceTest, IsStateless) {
   EXPECT_EQ(context_->get_continuous_state().size(), 0);
+}
+
+// Some tag types used to select which constructor gets called.
+struct UseTransmogrify {};
+struct UseVector {};
+
+template <typename T>
+class Convertable final : public SingleOutputVectorSource<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Convertable)
+
+  using Base = SingleOutputVectorSource<T>;
+  using Tag = SystemTypeTag<systems::Convertable>;
+
+  Convertable() : Base(kSize) {}
+  explicit Convertable(UseVector) : Base(*MakeVec()) {}
+  explicit Convertable(UseTransmogrify) : Base(Tag{}, kSize) {}
+  Convertable(UseTransmogrify, UseVector) : Base(Tag{}, *MakeVec()) {}
+
+  template <typename U>
+  explicit Convertable(const Convertable<U>&)
+      : Convertable<T>(UseTransmogrify{}) {}
+
+ private:
+  auto MakeVec() const {
+    return std::make_unique<BasicVector<T>>(VectorX<T>::Constant(kSize, 22.0));
+  }
+
+  void DoCalcVectorOutput(
+      const Context<T>& context,
+      Eigen::VectorBlock<VectorX<T>>* output) const final {
+    *output = Eigen::Vector3d::Ones();
+  }
+};
+
+GTEST_TEST(SingleOutputVectorSourceConvertableTest, ScalarTypes) {
+  // The constructors without SystemScalarConverter do not support conversion.
+  const Convertable<double> false1;
+  const Convertable<double> false2{UseVector{}};
+  EXPECT_FALSE(is_autodiffxd_convertible(false1));
+  EXPECT_FALSE(is_autodiffxd_convertible(false2));
+  EXPECT_FALSE(is_symbolic_convertible(false1));
+  EXPECT_FALSE(is_symbolic_convertible(false2));
+
+  // The constructors with SystemScalarConverter do support conversion.
+  const Convertable<double> true1{UseTransmogrify{}};
+  const Convertable<double> true2{UseTransmogrify{}, UseVector{}};
+  EXPECT_TRUE(is_autodiffxd_convertible(true1));
+  EXPECT_TRUE(is_autodiffxd_convertible(true2));
+  EXPECT_TRUE(is_symbolic_convertible(true1));
+  EXPECT_TRUE(is_symbolic_convertible(true2));
 }
 
 }  // namespace

--- a/systems/framework/test/system_scalar_converter_test.cc
+++ b/systems/framework/test/system_scalar_converter_test.cc
@@ -146,6 +146,13 @@ void TestConversionFail() {
   EXPECT_TRUE(converted == nullptr);
 }
 
+GTEST_TEST(SystemScalarConverterTest, Empty) {
+  const SystemScalarConverter dut1;
+  const SystemScalarConverter dut2(SystemTypeTag<AnyToAnySystem>{});
+  EXPECT_TRUE(dut1.empty());
+  EXPECT_FALSE(dut2.empty());
+}
+
 GTEST_TEST(SystemScalarConverterTest, DefaualtConstructor) {
   // With the default ctor, nothing is convertible ...
   const SystemScalarConverter dut;

--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -87,7 +87,8 @@ drake_cc_library(
     srcs = ["constant_vector_source.cc"],
     hdrs = ["constant_vector_source.h"],
     deps = [
-        "//common:symbolic",
+        "//common:default_scalars",
+        "//common:extract_double",
         "//systems/framework",
     ],
 )
@@ -359,7 +360,7 @@ drake_cc_googletest(
         ":constant_vector_source",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/framework",
-        "//systems/framework/test_utilities:my_vector",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/primitives/constant_vector_source.cc
+++ b/systems/primitives/constant_vector_source.cc
@@ -1,25 +1,75 @@
 #include "drake/systems/primitives/constant_vector_source.h"
 
+#include <utility>
+
 #include "drake/common/default_scalars.h"
+#include "drake/common/extract_double.h"
 
 namespace drake {
 namespace systems {
+namespace {
 
+// Given a ConstantVectorSource with one scalar type, convert its default
+// output port value (i.e., its default parameter value) to an Eigen::Vector
+// with a different scalar type, by demoting the `U`s down to doubles and then
+// promoting back to `T`s.  This is only supported when the output port is
+// exactly typed as BasicVector (not a subclass of BasicVector) because
+// BasicVector does not support scalar conversion in a way that preserves
+// subtyping (see #5454 for some related discussion).
+template <typename T, typename U>
+VectorX<T> ConvertDefaultValue(const ConstantVectorSource<U>& other) {
+  const int size = other.get_output_port().size();
+  auto context = other.CreateDefaultContext();
+  const BasicVector<U>& old_default = other.get_source_value(*context);
+  DRAKE_DEMAND(old_default.size() == size);
+  DRAKE_THROW_UNLESS(typeid(old_default) == typeid(BasicVector<U>));
+  VectorX<T> new_default = VectorX<T>::Zero(size);
+  for (int i = 0; i < size; ++i) {
+    new_default[i] = ExtractDoubleOrThrow(old_default[i]);
+  }
+  return new_default;
+}
+
+}  // namespace
+
+// For this overload, we can support scalar conversion because our constant
+// value is stored as a parameter and our output port is definitely typed as
+// BasicVector (and not some subtype of BasicVector).
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(
     const Eigen::Ref<const VectorX<T>>& source_value)
-    : ConstantVectorSource(BasicVector<T>(source_value)) {}
+    : ConstantVectorSource(
+          SystemTypeTag<systems::ConstantVectorSource>{},
+          BasicVector<T>(source_value)) {}
 
-template <typename T>
-ConstantVectorSource<T>::ConstantVectorSource(
-    const BasicVector<T>& source_value)
-    : SingleOutputVectorSource<T>(source_value) {
-  source_value_index_ = this->DeclareNumericParameter(source_value);
-}
-
+// (N.B. This overload also indirectly supports scalar conversion.)
 template <typename T>
 ConstantVectorSource<T>::ConstantVectorSource(const T& source_value)
     : ConstantVectorSource(Vector1<T>::Constant(source_value)) {}
+
+// This overload cannot support scalar conversion, until we have a way to
+// convert a BasicVector subtype between scalar types.
+template <typename T>
+ConstantVectorSource<T>::ConstantVectorSource(
+    const BasicVector<T>& source_value)
+    : ConstantVectorSource<T>({}, source_value) {}
+
+template <typename T>
+template <typename U>
+ConstantVectorSource<T>::ConstantVectorSource(
+    const ConstantVectorSource<U>& other)
+    : ConstantVectorSource<T>(ConvertDefaultValue<T, U>(other)) {}
+
+// All other constructors delegate here.
+template <typename T>
+ConstantVectorSource<T>::ConstantVectorSource(
+    SystemScalarConverter converter, const BasicVector<T>& source_value)
+    : SingleOutputVectorSource<T>(std::move(converter), source_value),
+      source_value_index_(this->DeclareNumericParameter(source_value)) {
+  // This condition is always true because of the way our constructors delegate.
+  DRAKE_DEMAND(this->get_system_scalar_converter().empty() ||
+               typeid(source_value) == typeid(BasicVector<T>));
+}
 
 template <typename T>
 ConstantVectorSource<T>::~ConstantVectorSource() = default;

--- a/systems/primitives/constant_vector_source.h
+++ b/systems/primitives/constant_vector_source.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
@@ -22,7 +23,7 @@ namespace systems {
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template <typename T>
-class ConstantVectorSource : public SingleOutputVectorSource<T> {
+class ConstantVectorSource final : public SingleOutputVectorSource<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ConstantVectorSource)
 
@@ -41,7 +42,14 @@ class ConstantVectorSource : public SingleOutputVectorSource<T> {
 
   /// Constructs a system with a vector output that is constant, has the type of
   /// the @p source_value, and equals the @p source_value at all times.
+  ///
+  /// @note Objects created using this constructor overload do not support
+  /// system scalar conversion.  See @ref system_scalar_conversion.
   explicit ConstantVectorSource(const BasicVector<T>& source_value);
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit ConstantVectorSource(const ConstantVectorSource<U>& other);
 
   ~ConstantVectorSource() override;
 
@@ -54,12 +62,18 @@ class ConstantVectorSource : public SingleOutputVectorSource<T> {
   BasicVector<T>& get_mutable_source_value(Context<T>* context);
 
  private:
+  // Allow different specializations to access each other's private data.
+  template <typename U> friend class ConstantVectorSource;
+
+  // All other constructor overloads delegate to here.
+  ConstantVectorSource(SystemScalarConverter, const BasicVector<T>&);
+
   // Outputs a signal with a fixed value as specified by the user.
   void DoCalcVectorOutput(
       const Context<T>& context,
       Eigen::VectorBlock<VectorX<T>>* output) const override;
 
-  int source_value_index_{};
+  const int source_value_index_;
 };
 
 }  // namespace systems


### PR DESCRIPTION
Relates #5872 tangentially -- this provides a work-around until fixed-value ports can transmogrify.  Here, we can take advantage of the fact that we know how to transmogrify `VectorXd` without any special framework support -- we just elementwise cast it to `VectorX<T>`.

(Does not support `BasicVector` subclasses as output when transmogrifying.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8794)
<!-- Reviewable:end -->
