### PR TITLE
pydrake eigen: Add `mul` and `inverse` for Quaternion and Isometry3

### DIFF
--- a/bindings/pydrake/util/eigen_geometry_py.cc
+++ b/bindings/pydrake/util/eigen_geometry_py.cc
@@ -109,6 +109,10 @@ PYBIND11_MODULE(eigen_geometry, m) {
         out.translation() = translation;
         return out;
       }), py::arg("quaternion"), py::arg("translation"))
+      .def(py::init([](const Class& other) {
+        CheckIsometry(other);
+        return other;
+      }), py::arg("other"))
       .def("matrix", [](const Class* self) -> Matrix4<T> {
         return self->matrix();
       })
@@ -139,6 +143,14 @@ PYBIND11_MODULE(eigen_geometry, m) {
       })
       .def("__str__", [](py::object self) {
         return py::str(self.attr("matrix")());
+      })
+      // Do not define an operator until we have the Python3 `@` operator so
+      // that operations are similar to those of arrays.
+      .def("multiply", [](const Class& self, const Class& other) {
+        return self * other;
+      })
+      .def("inverse", [](const Class* self) {
+        return self->inverse();
       });
   }
 
@@ -174,6 +186,10 @@ PYBIND11_MODULE(eigen_geometry, m) {
         CheckQuaternion(out);
         return out;
       }), py::arg("rotation"))
+      .def(py::init([](const Class& other) {
+        CheckQuaternion(other);
+        return other;
+      }), py::arg("other"))
       .def("w", [](const Class* self) { return self->w(); })
       .def("x", [](const Class* self) { return self->x(); })
       .def("y", [](const Class* self) { return self->y(); })
@@ -208,6 +224,14 @@ PYBIND11_MODULE(eigen_geometry, m) {
         return py::str("{}(w={}, x={}, y={}, z={})").format(
             py_class_obj.attr("__name__"),
             self->w(), self->x(), self->y(), self->z());
+      })
+      // Do not define an operator until we have the Python3 `@` operator so
+      // that operations are similar to those of arrays.
+      .def("multiply", [](const Class& self, const Class& other) {
+        return self * other;
+      })
+      .def("inverse", [](const Class* self) {
+        return self->inverse();
       });
   }
 }

--- a/bindings/pydrake/util/test/eigen_geometry_test.py
+++ b/bindings/pydrake/util/test/eigen_geometry_test.py
@@ -50,6 +50,9 @@ class TestEigenGeometry(unittest.TestCase):
         R_I = np.eye(3, 3)
         q_other.set_rotation(R_I)
         self.assertTrue(np.allclose(q_other.wxyz(), q_identity.wxyz()))
+        # - Copy constructor.
+        cp = mut.Quaternion(other=q)
+        self.assertTrue(np.allclose(q.wxyz(), cp.wxyz()))
         # Bad values.
         q = mut.Quaternion.Identity()
         # - wxyz
@@ -63,6 +66,11 @@ class TestEigenGeometry(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             q_other.set_rotation(R_bad)
         self.assertTrue(np.allclose(q_other.rotation(), R_I))
+
+        # Operations.
+        q = mut.Quaternion(wxyz=[0.5, 0.5, 0.5, 0.5])
+        q_I = q.inverse().multiply(q)
+        self.assertTrue(np.allclose(q_I.wxyz(), [1, 0, 0, 0]))
 
         # Test `type_caster`s.
         value = test_util.create_quaternion()
@@ -78,6 +86,9 @@ class TestEigenGeometry(unittest.TestCase):
         # - Constructor with (X)
         transform = mut.Isometry3(matrix=X)
         self.assertTrue(np.allclose(transform.matrix(), X))
+        # - Copy constructor.
+        cp = mut.Isometry3(other=transform)
+        self.assertTrue(np.allclose(transform.matrix(), cp.matrix()))
         # - Identity
         transform = mut.Isometry3.Identity()
         self.assertTrue(np.allclose(transform.matrix(), X))
@@ -112,6 +123,10 @@ class TestEigenGeometry(unittest.TestCase):
         value = test_util.create_isometry()
         self.assertTrue(isinstance(value, mut.Isometry3))
         test_util.check_isometry(value)
+        # Operations.
+        transform = mut.Isometry3(rotation=R, translation=p)
+        transform_I = transform.inverse().multiply(transform)
+        self.assertTrue(np.allclose(transform_I.matrix(), np.eye(4)))
 
     def test_translation(self):
         # Test `type_caster`s.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8802)
<!-- Reviewable:end -->
