### PR TITLE
Enable non-allocating calls to doKinematics, ComputeFramePose, Spatia…

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -126,6 +126,7 @@ drake_cc_library(
         "kinematics_cache-inl.h",
     ],
     deps = [
+        ":rigid_body_tree_datatypes",
         "//common:autodiff",
         "//common:essential",
         "//multibody/joints",

--- a/util/drakeGeometryUtil.h
+++ b/util/drakeGeometryUtil.h
@@ -154,19 +154,18 @@ Eigen::Matrix<typename Derived::Scalar, 3, 4> quatdot2angularvelMatrix(
 /*
  * spatial transform functions
  */
-template <typename Derived>
-struct TransformSpatial {
-  typedef typename Eigen::Matrix<typename Derived::Scalar, drake::kTwistSize,
-                                 Derived::ColsAtCompileTime>
-      type;
-};
 
+// This function is only applicable to input matrices with columns less than or
+// equal to 6 and will assert if the number of columns is greater than 6.
 template <typename DerivedM>
-typename TransformSpatial<DerivedM>::type transformSpatialMotion(
+decltype(auto) transformSpatialMotion(
     const Eigen::Transform<typename DerivedM::Scalar, 3, Eigen::Isometry>& T,
     const Eigen::MatrixBase<DerivedM>& M) {
+  DRAKE_ASSERT(M.cols() <= 6);
   Eigen::Matrix<typename DerivedM::Scalar, drake::kTwistSize,
-                DerivedM::ColsAtCompileTime>
+                DerivedM::ColsAtCompileTime, 0, drake::kTwistSize,
+                DerivedM::ColsAtCompileTime == Eigen::Dynamic
+                  ? 6 : DerivedM::ColsAtCompileTime>
       ret(drake::kTwistSize, M.cols());
   ret.template topRows<3>().noalias() = T.linear() * M.template topRows<3>();
   ret.template bottomRows<3>().noalias() =
@@ -230,12 +229,11 @@ dTransformSpatialMotion(const Eigen::Transform<Scalar, 3, Eigen::Isometry>& T,
 }
 
 template <typename DerivedF>
-typename TransformSpatial<DerivedF>::type transformSpatialForce(
+decltype(auto) transformSpatialForce(
     const Eigen::Transform<typename DerivedF::Scalar, 3, Eigen::Isometry>& T,
     const Eigen::MatrixBase<DerivedF>& F) {
   Eigen::Matrix<typename DerivedF::Scalar, drake::kTwistSize,
-                DerivedF::ColsAtCompileTime>
-      ret(drake::kTwistSize, F.cols());
+                DerivedF::ColsAtCompileTime> ret(drake::kTwistSize, F.cols());
   ret.template bottomRows<3>().noalias() =
       T.linear() * F.template bottomRows<3>().eval();
   ret.template topRows<3>() =
@@ -394,10 +392,11 @@ drake::SquareTwistMatrix<typename DerivedI::Scalar> transformSpatialInertia(
 }
 
 template <typename DerivedA, typename DerivedB>
-typename TransformSpatial<DerivedB>::type crossSpatialMotion(
+decltype(auto) crossSpatialMotion(
     const Eigen::MatrixBase<DerivedA>& a,
     const Eigen::MatrixBase<DerivedB>& b) {
-  typename TransformSpatial<DerivedB>::type ret(drake::kTwistSize, b.cols());
+  Eigen::Matrix<typename DerivedB::Scalar, drake::kTwistSize,
+                DerivedB::ColsAtCompileTime> ret(drake::kTwistSize, b.cols());
   ret.template topRows<3>() =
       -b.template topRows<3>().colwise().cross(a.template topRows<3>());
   ret.template bottomRows<3>() =
@@ -408,10 +407,11 @@ typename TransformSpatial<DerivedB>::type crossSpatialMotion(
 }
 
 template <typename DerivedA, typename DerivedB>
-typename TransformSpatial<DerivedB>::type crossSpatialForce(
+decltype(auto) crossSpatialForce(
     const Eigen::MatrixBase<DerivedA>& a,
     const Eigen::MatrixBase<DerivedB>& b) {
-  typename TransformSpatial<DerivedB>::type ret(drake::kTwistSize, b.cols());
+  Eigen::Matrix<typename DerivedB::Scalar, drake::kTwistSize,
+                DerivedB::ColsAtCompileTime> ret(drake::kTwistSize, b.cols());
   ret.template topRows<3>() =
       -b.template topRows<3>().colwise().cross(a.template topRows<3>());
   ret.template topRows<3>() -=


### PR DESCRIPTION
…lVelocity and SpatialJacobian

- Change checkCachedKinematicsSettings to take in a char* to prevent allocating a std::string
- Redefine transformSpatialMotion to preallocate a maximum of 6 columns for dynamic matrices
- Move geometricJacobian from transformSpatialMotion to explict calculation of frame changes
- Add a new set of ComputeXSpatialVelocityJacobian methods which take as argument the Jacobian to prevent allocation. This includes adding a new geometricJacobian method and findKinematicPath which use preallocated private member variables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8803)
<!-- Reviewable:end -->
