### PR TITLE
Implements example on parameter derivatives

### DIFF
--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -130,6 +130,17 @@ drake_cc_binary(
     ],
 )
 
+drake_cc_binary(
+    name = "pendulum_parameters_derivatives",
+    srcs = ["pendulum_parameters_derivatives.cc"],
+    add_test_rule = 1,
+    deps = [
+        ":pendulum_plant",
+        ":pendulum_vector_types",
+        "@fmt",
+    ],
+)
+
 # === test/ ===
 
 drake_cc_googletest(

--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -1,0 +1,88 @@
+#include <iostream>
+
+#include "fmt/ostream.h"
+
+#include "drake/common/eigen_types.h"
+#include "drake/examples/pendulum/gen/pendulum_input.h"
+#include "drake/examples/pendulum/gen/pendulum_params.h"
+#include "drake/examples/pendulum/gen/pendulum_state.h"
+#include "drake/examples/pendulum/pendulum_plant.h"
+
+// A simple example on how to take derivatives of the forward dynamics for a
+// simple pendulum with respect to the mass parameter.
+// The result get printed to std::out.
+
+namespace drake {
+namespace examples {
+namespace pendulum {
+namespace {
+
+int DoMain() {
+  // The plant and its context.
+  PendulumPlant<AutoDiffXd> system;
+  auto context = system.CreateDefaultContext();
+  context->FixInputPort(0, Vector1<AutoDiffXd>::Constant(0.0));
+
+  // Retrieve the (mutable) state from context so that we can set it.
+  PendulumState<AutoDiffXd>& state =
+      PendulumPlant<AutoDiffXd>::get_mutable_state(context.get());
+
+  // An arbitrary state configuration around which we'll take derivatives with
+  // respect to the mass parameter.
+  state.set_theta(M_PI / 4.0);
+  state.set_thetadot(-1.0);
+
+  // Retrieve the (mutable) parameters so that we can set it.
+  PendulumParams<AutoDiffXd>& params =
+      system.get_mutable_parameters(context.get());
+
+  // Mass is our independent variable for this example and therefore we set its
+  // vector of derivatives to one.
+  // Note: all the other parameter values were set by PendulumParams's default
+  // constructor to be constants (i.e. their derivative with respect to the mass
+  // parameter is zero).
+  params.set_mass(AutoDiffXd(1.0, Vector1<double>::Constant(1.0)));
+
+  // Allocate and compute derivatives.
+  auto derivatives = system.AllocateTimeDerivatives();
+  system.CalcTimeDerivatives(*context, derivatives.get());
+  const PendulumState<AutoDiffXd>& xdot =
+      PendulumPlant<AutoDiffXd>::get_state(*derivatives);
+
+  // NOLINTNEXTLINE(build/namespaces)  Usage documented by fmt library.
+  using namespace fmt::literals;
+  // Derivatives values
+  fmt::print("Forward dynamics, ẋ = [θ̇, ω̇]:\n");
+  fmt::print("θ̇ = {thetadot:8.4f}\n", "thetadot"_a = xdot.theta().value());
+  fmt::print("ω̇ = {omegadot:8.4f}\n", "omegadot"_a = xdot.thetadot().value());
+
+  // Partial of xdot with respect to mass parameter.
+  fmt::print(
+      "Partial of the forward dynamics with respect to mass, i.e. ∂ẋ/∂m:\n");
+  // θ̇ is independent of the mass parameter. We verify it by checking the
+  // derivatives size before printing a lie.
+  DRAKE_DEMAND(xdot.theta().derivatives().size() == 0);
+  fmt::print("∂θ̇/∂m = {:8.4f}\n", 0.0);
+  fmt::print("∂ω̇/∂m = {:8.4f}\n", xdot.thetadot().derivatives()[0]);
+
+  // Note: for the pendulum, forward dynamics is:
+  // ω̇ = (τ - bω)/(mℓ²) - g/ℓ⋅sin(θ), with:
+  // ℓ: length, in m.
+  // m: mass, in kg.
+  // b: dissipation, in N⋅m⋅s.
+  // τ: input torque, in N⋅m.
+  // g: acceleration of gravity, in m/s².
+  // Therefore the derivative of ω̇ with respect to m is:
+  // ∂ω̇/∂m = -(τ - bω)/(m²ℓ²).
+
+  return 0;
+}
+
+}  // namespace
+}  // namespace pendulum
+}  // namespace examples
+}  // namespace drake
+
+int main() {
+  return drake::examples::pendulum::DoMain();
+}

--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -37,7 +37,7 @@ int DoMain() {
       system.get_mutable_parameters(context.get());
 
   // Mass is our independent variable for this example and therefore we set its
-  // vector of derivatives to one.
+  // derivative to one.
   // Note: all the other parameter values were set by PendulumParams's default
   // constructor to be constants (i.e. their derivative with respect to the mass
   // parameter is zero).
@@ -56,11 +56,12 @@ int DoMain() {
   fmt::print("θ̇ = {thetadot:8.4f}\n", "thetadot"_a = xdot.theta().value());
   fmt::print("ω̇ = {omegadot:8.4f}\n", "omegadot"_a = xdot.thetadot().value());
 
-  // Partial of xdot with respect to mass parameter.
-  fmt::print(
-      "Partial of the forward dynamics with respect to mass, i.e. ∂ẋ/∂m:\n");
-  // θ̇ is independent of the mass parameter. We verify it by checking the
-  // derivatives size before printing a lie.
+  // Partial derivative of xdot with respect to mass parameter.
+  fmt::print("Partial derivative of the forward dynamics with respect to mass, "
+                 "i.e. ∂ẋ/∂m:\n");
+  // θ̇ is independent of the mass parameter. We verify this by checking the
+  // size of its vector of derivatives. Since we are using AutoDiffXd, we expect
+  // this size to be zero (a constant).
   DRAKE_DEMAND(xdot.theta().derivatives().size() == 0);
   fmt::print("∂θ̇/∂m = {:8.4f}\n", 0.0);
   fmt::print("∂ω̇/∂m = {:8.4f}\n", xdot.thetadot().derivatives()[0]);

--- a/examples/pendulum/pendulum_parameters_derivatives.cc
+++ b/examples/pendulum/pendulum_parameters_derivatives.cc
@@ -10,7 +10,7 @@
 
 // A simple example on how to take derivatives of the forward dynamics for a
 // simple pendulum with respect to the mass parameter.
-// The result get printed to std::out.
+// The result gets printed to std::out.
 
 namespace drake {
 namespace examples {

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -74,6 +74,12 @@ class PendulumPlant : public systems::LeafSystem<T> {
     return this->template GetNumericParameter<PendulumParams>(context, 0);
   }
 
+  PendulumParams<T>& get_mutable_parameters(
+      systems::Context<T>* context) const {
+    return this->template GetMutableNumericParameter<PendulumParams>(
+        context, 0);
+  }
+
  private:
   // This is the calculator method for the state output port.
   void CopyStateOut(const systems::Context<T>& context,


### PR DESCRIPTION
We were having some fun with plant's parameters with @aespielberg today and this example came out.
This little example shows how to take derivatives of the forward dynamics of a pendulum with respect to its mass parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8823)
<!-- Reviewable:end -->
