### PR TITLE
Remove mathematical_program dependency on dReal

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -227,7 +227,6 @@ drake_cc_library(
         ":create_constraint",
         ":create_cost",
         ":decision_variable",
-        ":dreal_solver",
         ":equality_constrained_qp_solver",
         ":gurobi_solver",
         ":indeterminate",


### PR DESCRIPTION
We don't want to force any solver externals on bazel users.  All the other ones have (sometimes unsupported) bazel flags to disable them, but doing so for dReal is difficult because it uses external types in its public Drake headers.

With this change, only saying either `//solvers` or `//solvers:dreal_solver` will induce the dependency; `//solvers:mathematical_program` will not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8830)
<!-- Reviewable:end -->
