### PR TITLE
simulator: Make a less template-laden overload of `reset_integrator` for binding in Python

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -261,18 +261,30 @@ class Simulator {
 
   /// Resets the integrator with a new one. An example usage is:
   /// @code
-  /// simulator.reset_integrator<ExplicitEulerIntegrator<double>>
-  ///               (sys, DT, context).
+  /// simulator.reset_integrator(std::move(integrator));
   /// @endcode
   /// The %Simulator must be reinitialized after resetting the integrator to
   /// ensure the integrator is properly initialized. You can do that explicitly
   /// with the Initialize() method or it will be done implicitly at the first
   /// time step.
+  template <class U>
+  U* reset_integrator(std::unique_ptr<U> integrator) {
+    initialization_done_ = false;
+    integrator_ = std::move(integrator);
+    return static_cast<U*>(integrator_.get());
+  }
+
+  /// Resets the integrator with a new one using factory construction. An
+  /// example usage is:
+  /// @code
+  /// simulator.reset_integrator<ExplicitEulerIntegrator<double>>
+  ///               (sys, DT, context).
+  /// @endcode
+  /// See the base overload for `reset_integrator` for more details.
   template <class U, typename... Args>
   U* reset_integrator(Args&&... args) {
-    initialization_done_ = false;
-    integrator_ = std::make_unique<U>(std::forward<Args>(args)...);
-    return static_cast<U*>(integrator_.get());
+    auto integrator = std::make_unique<U>(std::forward<Args>(args)...);
+    return reset_integrator(std::move(integrator));
   }
 
   /// Gets the length of the interval used for witness function time isolation.

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -800,9 +800,11 @@ GTEST_TEST(SimulatorTest, ResetIntegratorTest) {
   // Get the context.
   Context<double>& context = simulator.get_mutable_context();
 
-  // Create the integrator.
-  simulator.reset_integrator<ExplicitEulerIntegrator<double>>(spring_mass, dt,
-                                                              &context);
+  // Create the integrator with the simple spelling.
+  auto euler_integrator =
+      std::make_unique<ExplicitEulerIntegrator<double>>(
+          spring_mass, dt, &context);
+  simulator.reset_integrator(std::move(euler_integrator));
 
   // set the integrator and initialize the simulator
   simulator.Initialize();


### PR DESCRIPTION
At present, `reset_integrator` is difficult to bind in Python, but can easily be worked around by making a simpler overload.

@gizatt With this overload, you should be able to bind `&Simulator<T>::reset_integrator<IntegratorBase<T>>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8835)
<!-- Reviewable:end -->
