### PR TITLE
Fix to joint poses in SDF parsing

### DIFF
--- a/examples/multibody/cart_pole/cart_pole.sdf
+++ b/examples/multibody/cart_pole/cart_pole.sdf
@@ -72,7 +72,9 @@
     </joint>
 
     <joint name='PolePin' type='revolute'>
-      <pose>0 0 0 0 0 0</pose>
+      <!-- Pose of the joint frame in the pole's frame (located at the point
+           mass) -->
+      <pose>0 0 0.5 0 0 0</pose>
       <parent>Cart</parent>
       <child>Pole</child>
       <axis>

--- a/multibody/benchmarks/acrobot/acrobot.sdf
+++ b/multibody/benchmarks/acrobot/acrobot.sdf
@@ -73,6 +73,7 @@
     <joint name='ElbowJoint' type='revolute'>
       <parent>Link1</parent>
       <child>Link2</child>
+      <!-- Pose X_CJ of the joint frame J in the frame C of the child link -->
       <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>0 1 0</xyz>

--- a/multibody/benchmarks/acrobot/acrobot.sdf
+++ b/multibody/benchmarks/acrobot/acrobot.sdf
@@ -73,7 +73,7 @@
     <joint name='ElbowJoint' type='revolute'>
       <parent>Link1</parent>
       <child>Link2</child>
-      <pose>0 0 -1 0 0 0</pose>
+      <pose>0 0 0 0 0 0</pose>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>

--- a/multibody/multibody_tree/multibody_plant/test/split_pendulum.sdf
+++ b/multibody/multibody_tree/multibody_plant/test/split_pendulum.sdf
@@ -34,9 +34,9 @@
     </link>
 
     <joint name='pin' type='revolute'>
-      <pose>0 3 0 0 0 0</pose>
       <parent>world</parent>
       <child>upper_section</child>
+      <pose>0 3 0 0 0 0</pose>
       <axis>
         <xyz>0.0 0.0 1.0</xyz>
       </axis>
@@ -44,9 +44,10 @@
 
     <!-- Weld the upper and lower sections to form a single rod of length 12 -->
     <joint name='weld' type='fixed'>
-      <pose>0 3.0 0 0 0 0</pose>
       <parent>upper_section</parent>
       <child>lower_section</child>
+      <!-- Pose X_CJ of the joint frame J in frame C of the child link. -->
+      <pose>0 3.0 0 0 0 0</pose>
     </joint>
   </model>
 </sdf>

--- a/multibody/multibody_tree/multibody_plant/test/split_pendulum.sdf
+++ b/multibody/multibody_tree/multibody_plant/test/split_pendulum.sdf
@@ -34,7 +34,7 @@
     </link>
 
     <joint name='pin' type='revolute'>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 3 0 0 0 0</pose>
       <parent>world</parent>
       <child>upper_section</child>
       <axis>
@@ -44,7 +44,7 @@
 
     <!-- Weld the upper and lower sections to form a single rod of length 12 -->
     <joint name='weld' type='fixed'>
-      <pose>0 -6.0 0 0 0 0</pose>
+      <pose>0 3.0 0 0 0 0</pose>
       <parent>upper_section</parent>
       <child>lower_section</child>
     </joint>

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -108,7 +108,8 @@ const Body<double>& GetBodyByLinkSpecificationName(
 }
 
 // Extracts a Vector3d representation of the joint axis for joints with an axis.
-Vector3d ExtractJointAxis(const sdf::Joint& joint_spec) {
+Vector3d ExtractJointAxis(const sdf::Model& model_spec,
+                          const sdf::Joint& joint_spec) {
   DRAKE_DEMAND(joint_spec.Type() == sdf::JointType::REVOLUTE ||
       joint_spec.Type() == sdf::JointType::PRISMATIC);
 
@@ -124,7 +125,12 @@ Vector3d ExtractJointAxis(const sdf::Joint& joint_spec) {
   // supported by sdformat.
   Vector3d axis_J = ToVector3(axis->Xyz());
   if (axis->UseParentModelFrame()) {
-    const Isometry3d X_MJ = ToIsometry3(joint_spec.Pose());
+    // Pose of the joint frame J in the frame of the child link C.
+    const Isometry3d X_CJ = ToIsometry3(joint_spec.Pose());
+    // Get the pose of the child link C in the model frame M.
+    const Isometry3d X_MC =
+        ToIsometry3(model_spec.LinkByName(joint_spec.ChildLinkName())->Pose());
+    const Isometry3d X_MJ = X_MC * X_CJ;
     // axis_J actually contains axis_M, expressed in the model frame M.
     axis_J = X_MJ.linear().transpose() * axis_J;
   }
@@ -176,7 +182,7 @@ void AddJointFromSpecification(
   const Body<double>& child_body = GetBodyByLinkSpecificationName(
       model_spec, joint_spec.ChildLinkName(), *plant);
 
-  // Get the pose of frame J in the model frame M, as specified in
+  // Get the pose of frame J in the frame of the child link C, as specified in
   // <joint> <pose> ... </pose></joint>.
   // TODO(amcastro-tri): Verify sdformat supports frame specifications
   // correctly.
@@ -187,15 +193,15 @@ void AddJointFromSpecification(
   // And combinations of the above?
   // There is no way to verify at this level which one is supported or not.
   // Here we trust that no mather how a user specified the file, joint.Pose()
-  // will ALWAYS return X_MJ.
-  const Isometry3d X_MJ = ToIsometry3(joint_spec.Pose());
+  // will ALWAYS return X_CJ.
+  const Isometry3d X_CJ = ToIsometry3(joint_spec.Pose());
 
   // Get the pose of the child link C in the model frame M.
   const Isometry3d X_MC =
       ToIsometry3(model_spec.LinkByName(joint_spec.ChildLinkName())->Pose());
 
-  // Compute the location of the joint in the child link's frame.
-  const Isometry3d X_CJ = X_MC.inverse() * X_MJ;
+  // Pose of the joint frame J in the model frame M.
+  const Isometry3d X_MJ = X_MC * X_CJ;
 
   // Pose of the frame J in the parent body frame P.
   optional<Isometry3d> X_PJ;
@@ -225,7 +231,7 @@ void AddJointFromSpecification(
       break;
     }
     case sdf::JointType::PRISMATIC: {
-      Vector3d axis_J = ExtractJointAxis(joint_spec);
+      Vector3d axis_J = ExtractJointAxis(model_spec, joint_spec);
       const auto& joint = plant->AddJoint<PrismaticJoint>(
           joint_spec.Name(),
           parent_body, X_PJ,
@@ -234,7 +240,7 @@ void AddJointFromSpecification(
       break;
     }
     case sdf::JointType::REVOLUTE: {
-      Vector3d axis_J = ExtractJointAxis(joint_spec);
+      Vector3d axis_J = ExtractJointAxis(model_spec, joint_spec);
       const auto& joint = plant->AddJoint<RevoluteJoint>(
           joint_spec.Name(),
           parent_body, X_PJ,


### PR DESCRIPTION
Playing with URDF files converted to SDF using `gz` (`gz sdf -p my.urdf > my.sdf`), I found out that `sdf::Joint::Pose()` really returns the pose of the joint in the child link frame, not in the model frame as we were assuming.
Further, this gets confirmed by [the old SDF docs for v 1.4](http://sdformat.org/spec?ver=1.4&elem=joint#joint_pose) (which unfortunately did not make it to 1.6).

The good news, we can convert URDF files with `gz`!!! (tested with kuka models).

cc'ing @nkoenig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8838)
<!-- Reviewable:end -->
