### PR TITLE
AgentTrajectory/TrajectoryAgent -> Trajectory/TrajectoryFollower

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -28,7 +28,6 @@ package(default_visibility = ["//visibility:public"])
 drake_cc_package_library(
     name = "automotive",
     deps = [
-        ":agent_trajectory",
         ":automotive_simulator",
         ":bicycle_car",
         ":box_car_vis",
@@ -54,8 +53,9 @@ drake_cc_package_library(
         ":road_path",
         ":simple_car",
         ":simple_powertrain",
-        ":trajectory_agent",
+        ":trajectory",
         ":trajectory_car",
+        ":trajectory_follower",
         ":trivial_right_of_way_state_provider",
     ],
 )
@@ -94,9 +94,9 @@ drake_cc_vector_gen_translator_library(
 )
 
 drake_cc_library(
-    name = "agent_trajectory",
-    srcs = ["agent_trajectory.cc"],
-    hdrs = ["agent_trajectory.h"],
+    name = "trajectory",
+    srcs = ["trajectory.cc"],
+    hdrs = ["trajectory.h"],
     deps = [
         "//common/trajectories:piecewise_polynomial",
         "//common/trajectories:piecewise_quaternion",
@@ -398,12 +398,12 @@ drake_cc_library(
 )
 
 drake_cc_library(
-    name = "trajectory_agent",
-    srcs = ["trajectory_agent.cc"],
-    hdrs = ["trajectory_agent.h"],
+    name = "trajectory_follower",
+    srcs = ["trajectory_follower.cc"],
+    hdrs = ["trajectory_follower.h"],
     deps = [
-        ":agent_trajectory",
         ":generated_vectors",
+        ":trajectory",
         "//common:autodiff",
         "//common:extract_double",
         "//systems/framework:leaf_system",
@@ -564,9 +564,9 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
-    name = "agent_trajectory_test",
+    name = "trajectory_test",
     deps = [
-        "//automotive:agent_trajectory",
+        "//automotive:trajectory",
         "//common/test_utilities:eigen_matrix_compare",
         "//systems/framework/test_utilities",
     ],
@@ -755,9 +755,9 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
-    name = "trajectory_agent_test",
+    name = "trajectory_follower_test",
     deps = [
-        "//automotive:trajectory_agent",
+        "//automotive:trajectory_follower",
         "//common:extract_double",
         "//systems/analysis:simulator",
         "//systems/framework/test_utilities",

--- a/automotive/test/trajectory_follower_test.cc
+++ b/automotive/test/trajectory_follower_test.cc
@@ -1,4 +1,4 @@
-#include "drake/automotive/trajectory_agent.h"
+#include "drake/automotive/trajectory_follower.h"
 
 #include <vector>
 
@@ -20,33 +20,33 @@ using Eigen::Vector3d;
 using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 
-GTEST_TEST(TrajectoryAgentTest, Topology) {
+GTEST_TEST(TrajectoryFollowerTest, Topology) {
   const std::vector<double> times{0., 1.};
   std::vector<Quaternion<double>> rotations{Quaternion<double>::Identity(),
                                             Quaternion<double>::Identity()};
   std::vector<Vector3d> translations{Vector3d::Zero(), Vector3d::Zero()};
-  const TrajectoryAgent<double> car(
-      CarAgent(), AgentTrajectory::Make(times, rotations, translations));
+  const TrajectoryFollower<double> follower(
+      Trajectory::Make(times, rotations, translations));
 
-  ASSERT_EQ(0, car.get_num_input_ports());
-  ASSERT_EQ(3, car.get_num_output_ports());
+  ASSERT_EQ(0, follower.get_num_input_ports());
+  ASSERT_EQ(3, follower.get_num_output_ports());
 
-  const auto& state_output = car.raw_pose_output();
+  const auto& state_output = follower.state_output();
   EXPECT_EQ(systems::kVectorValued, state_output.get_data_type());
   EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates, state_output.size());
 
-  const auto& pose_output = car.pose_output();
+  const auto& pose_output = follower.pose_output();
   EXPECT_EQ(systems::kVectorValued, pose_output.get_data_type());
   EXPECT_EQ(PoseVector<double>::kSize, pose_output.size());
 
-  const auto& velocity_output = car.velocity_output();
+  const auto& velocity_output = follower.velocity_output();
   EXPECT_EQ(systems::kVectorValued, velocity_output.get_data_type());
   EXPECT_EQ(FrameVelocity<double>::kSize, velocity_output.size());
 
-  ASSERT_FALSE(car.HasAnyDirectFeedthrough());
+  ASSERT_FALSE(follower.HasAnyDirectFeedthrough());
 }
 
-GTEST_TEST(TrajectoryAgentTest, Outputs) {
+GTEST_TEST(TrajectoryFollowerTest, Outputs) {
   using std::cos;
   using std::sin;
 
@@ -79,16 +79,16 @@ GTEST_TEST(TrajectoryAgentTest, Outputs) {
     const std::vector<Vector3d> translations{start_translation,
                                              end_translation};
     const std::vector<double> times{0., it.distance / kSpeed};
-    const AgentTrajectory trajectory =
-        AgentTrajectory::Make(times, rotations, translations);
+    const Trajectory trajectory =
+        Trajectory::Make(times, rotations, translations);
 
-    const TrajectoryAgent<double> agent(CarAgent(), trajectory);
+    const TrajectoryFollower<double> follower(trajectory);
 
     // Check that the outputs are correct over the entirety of the trajectory.
-    systems::Simulator<double> simulator(agent);
+    systems::Simulator<double> simulator(follower);
     systems::Context<double>& context = simulator.get_mutable_context();
     std::unique_ptr<systems::SystemOutput<double>> outputs =
-        agent.AllocateOutput(context);
+        follower.AllocateOutput(context);
     simulator.Initialize();
 
     const double end_time = it.distance / kSpeed;
@@ -101,21 +101,21 @@ GTEST_TEST(TrajectoryAgentTest, Outputs) {
       Eigen::Translation<double, 3> expected_translation(
           start_translation +
           Vector3d{cos(it.heading) * position, sin(it.heading) * position, 0.});
-      agent.CalcOutput(context, outputs.get());
+      follower.CalcOutput(context, outputs.get());
 
-      // Tests the raw pose output.
-      const auto raw_pose = dynamic_cast<const SimpleCarState<double>*>(
-          outputs->get_vector_data(agent.raw_pose_output().get_index()));
-      EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates, raw_pose->size());
+      // Tests the state output.
+      const auto state = dynamic_cast<const SimpleCarState<double>*>(
+          outputs->get_vector_data(follower.state_output().get_index()));
+      EXPECT_EQ(SimpleCarStateIndices::kNumCoordinates, state->size());
 
-      EXPECT_NEAR(expected_translation.x(), raw_pose->x(), kTol);
-      EXPECT_NEAR(expected_translation.y(), raw_pose->y(), kTol);
-      EXPECT_NEAR(it.heading, raw_pose->heading(), kTol);
-      EXPECT_DOUBLE_EQ(kSpeed, raw_pose->velocity());
+      EXPECT_NEAR(expected_translation.x(), state->x(), kTol);
+      EXPECT_NEAR(expected_translation.y(), state->y(), kTol);
+      EXPECT_NEAR(it.heading, state->heading(), kTol);
+      EXPECT_DOUBLE_EQ(kSpeed, state->velocity());
 
       // Tests the PoseVector output.
       const auto pose = dynamic_cast<const PoseVector<double>*>(
-          outputs->get_vector_data(agent.pose_output().get_index()));
+          outputs->get_vector_data(follower.pose_output().get_index()));
       ASSERT_NE(nullptr, pose);
       EXPECT_EQ(PoseVector<double>::kSize, pose->size());
 
@@ -128,7 +128,7 @@ GTEST_TEST(TrajectoryAgentTest, Outputs) {
 
       // Tests the FrameVelocity output.
       const auto velocity = dynamic_cast<const FrameVelocity<double>*>(
-          outputs->get_vector_data(agent.velocity_output().get_index()));
+          outputs->get_vector_data(follower.velocity_output().get_index()));
 
       ASSERT_NE(nullptr, velocity);
       EXPECT_EQ(FrameVelocity<double>::kSize, velocity->size());
@@ -141,15 +141,16 @@ GTEST_TEST(TrajectoryAgentTest, Outputs) {
   }
 }
 
-GTEST_TEST(TrajectoryAgentTest, ToAutoDiff) {
+GTEST_TEST(TrajectoryFollowerTest, ToAutoDiff) {
   const std::vector<double> times{0., 1.};
   std::vector<Quaternion<double>> rotations{Quaternion<double>::Identity(),
                                             Quaternion<double>::Identity()};
   std::vector<Vector3d> translations{Vector3d::Zero(), Vector3d::Zero()};
-  const TrajectoryAgent<double> agent(
-      CarAgent(), AgentTrajectory::Make(times, rotations, translations));
+  const TrajectoryFollower<double> follower(
+      Trajectory::Make(times, rotations, translations));
 
-  EXPECT_TRUE(is_autodiffxd_convertible(agent, [&](const auto& autodiff_dut) {
+  EXPECT_TRUE(is_autodiffxd_convertible(follower,
+                                        [&](const auto& autodiff_dut) {
     auto context = autodiff_dut.CreateDefaultContext();
     auto output = autodiff_dut.AllocateOutput(*context);
 
@@ -157,7 +158,7 @@ GTEST_TEST(TrajectoryAgentTest, ToAutoDiff) {
     autodiff_dut.CalcOutput(*context, output.get());
   }));
 
-  EXPECT_TRUE(is_symbolic_convertible(agent));
+  EXPECT_TRUE(is_symbolic_convertible(follower));
 }
 
 }  // namespace

--- a/automotive/test/trajectory_test.cc
+++ b/automotive/test/trajectory_test.cc
@@ -1,4 +1,4 @@
-#include "drake/automotive/agent_trajectory.h"
+#include "drake/automotive/trajectory.h"
 
 #include <algorithm>
 #include <vector>
@@ -64,18 +64,18 @@ void CheckAllConstructors(const std::vector<double>& times,
                           const std::vector<Quaternion<double>>& rotations,
                           const std::vector<Vector3d>& translations,
                           const std::vector<double> speeds) {
-  EXPECT_THROW(AgentTrajectory::Make(times, rotations, translations),
+  EXPECT_THROW(Trajectory::Make(times, rotations, translations),
                std::exception);
   EXPECT_THROW(
-      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      Trajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
       std::exception);
-  EXPECT_THROW(AgentTrajectory::MakeCubicFromWaypoints(rotations, translations,
+  EXPECT_THROW(Trajectory::MakeCubicFromWaypoints(rotations, translations,
                                                        speeds[0]),
                std::exception);
 }
 
 // Empty or mismatched-sized vectors are rejected.
-GTEST_TEST(AgentTrajectoryTest, InvalidSizes) {
+GTEST_TEST(TrajectoryTest, InvalidSizes) {
   const std::vector<double> times_3d{0., 1., 2.};
   const Quaternion<double> dummy_rotation = Quaternion<double>::Identity();
   const Vector3d dummy_translation = Vector3d::Zero();
@@ -97,8 +97,8 @@ GTEST_TEST(AgentTrajectoryTest, InvalidSizes) {
 }
 
 // Accepts all interpolation types.
-GTEST_TEST(AgentTrajectoryTest, InterpolationType) {
-  using Type = AgentTrajectory::InterpolationType;
+GTEST_TEST(TrajectoryTest, InterpolationType) {
+  using Type = Trajectory::InterpolationType;
 
   const std::vector<double> times{0., 1., 2.};
   const Quaternion<double> dummy_rotation = Quaternion<double>::Identity();
@@ -109,14 +109,14 @@ GTEST_TEST(AgentTrajectoryTest, InterpolationType) {
                                      dummy_translation};
   for (const auto& type : {Type::kFirstOrderHold, Type::kCubic, Type::kPchip}) {
     EXPECT_NO_THROW(
-        AgentTrajectory::Make(times, rotations, translations, type));
+        Trajectory::Make(times, rotations, translations, type));
   }
 }
 
 // Checks that all data fields agree with the input data vectors at the knot
 // points, and checks that the velocity components are correctly inferred.
-GTEST_TEST(AgentTrajectoryTest, AgentTrajectory) {
-  using Type = AgentTrajectory::InterpolationType;
+GTEST_TEST(TrajectoryTest, Trajectory) {
+  using Type = Trajectory::InterpolationType;
 
   const std::vector<double> times{0., kDeltaT, 2 * kDeltaT};
   std::vector<Vector3d> translations{};
@@ -131,7 +131,7 @@ GTEST_TEST(AgentTrajectoryTest, AgentTrajectory) {
     rotations.back().normalize();
   }
 
-  const AgentTrajectory trajectory = AgentTrajectory::Make(
+  const Trajectory trajectory = Trajectory::Make(
       times, rotations, translations, Type::kFirstOrderHold);
 
   for (int i{0}; i < static_cast<int>(times.size()); i++) {
@@ -188,29 +188,29 @@ void MakePoses(const std::vector<double>& speeds,
 }
 
 // Negative speeds are rejected.
-GTEST_TEST(AgentTrajectoryTest, NegativeSpeeds) {
+GTEST_TEST(TrajectoryTest, NegativeSpeeds) {
   const std::vector<double> speeds{-1, 5.};
   std::vector<Quaternion<double>> rotations{};
   std::vector<Vector3d> translations{};
   MakePoses(speeds, &rotations, &translations);
 
   EXPECT_THROW(
-      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      Trajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
       std::exception);
   EXPECT_THROW(
-      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, -1.),
+      Trajectory::MakeCubicFromWaypoints(rotations, translations, -1.),
       std::exception);
 }
 
 // Deadlock detection rejects unreachable waypoints.
-GTEST_TEST(AgentTrajectoryTest, UnreachableCubicWaypoints) {
+GTEST_TEST(TrajectoryTest, UnreachableCubicWaypoints) {
   const std::vector<double> speeds{0., 0., 1.};
   std::vector<Quaternion<double>> rotations{};
   std::vector<Vector3d> translations{};
   MakePoses(speeds, &rotations, &translations);
 
   EXPECT_THROW(
-      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
+      Trajectory::MakeCubicFromWaypoints(rotations, translations, speeds),
       std::exception);
 }
 
@@ -224,7 +224,7 @@ struct RpyCase {
 
 // Checks that the provided speeds and waypoints yield correctly-formed
 // trajectories using InterpolationType::kCubic on the linear quantities.
-GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypoints) {
+GTEST_TEST(TrajectoryTest, MakeCubicFromWaypoints) {
   using std::max_element;
   using std::min_element;
 
@@ -240,7 +240,7 @@ GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypoints) {
     std::vector<Vector3d> translations{};
     MakePoses(speeds, &rotations, &translations, rpy_case.rpy_value);
 
-    const AgentTrajectory trajectory = AgentTrajectory::MakeCubicFromWaypoints(
+    const Trajectory trajectory = Trajectory::MakeCubicFromWaypoints(
         rotations, translations, speeds);
 
     double time{0.};
@@ -278,15 +278,15 @@ GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypoints) {
 
 // Checks that the provided waypoints yield correctly-formed trajectories with
 // the constant-speed constructor.
-GTEST_TEST(AgentTrajectoryTest, MakeCubicFromWaypointsWithConstantSpeed) {
+GTEST_TEST(TrajectoryTest, MakeCubicFromWaypointsWithConstantSpeed) {
   const double speed = 5.;
   const std::vector<double> speeds{speed, speed};  // Only for sizing `poses`.
   std::vector<Quaternion<double>> rotations{};
   std::vector<Vector3d> translations{};
   MakePoses(speeds, &rotations, &translations);
 
-  const AgentTrajectory trajectory =
-      AgentTrajectory::MakeCubicFromWaypoints(rotations, translations, speed);
+  const Trajectory trajectory =
+      Trajectory::MakeCubicFromWaypoints(rotations, translations, speed);
 
   const std::vector<double> expected_times{0., kDeltaT};
   for (int i{0}; i < static_cast<int>(expected_times.size()); i++) {

--- a/automotive/trajectory.cc
+++ b/automotive/trajectory.cc
@@ -1,4 +1,4 @@
-#include "drake/automotive/agent_trajectory.h"
+#include "drake/automotive/trajectory.h"
 
 #include <algorithm>
 
@@ -34,7 +34,7 @@ PoseVelocity::PoseVelocity(const Eigen::Quaternion<double>& rotation,
                            const SpatialVelocity<double>& velocity)
     : rotation_(rotation), translation_(translation), velocity_(velocity) {}
 
-PoseVelocity AgentTrajectory::value(double time) const {
+PoseVelocity Trajectory::value(double time) const {
   const Eigen::Quaternion<double> rotation(rotation_.orientation(time));
   const Eigen::Vector3d translation(translation_.value(time));
   const Eigen::Vector3d translation_dot(translation_dot_.value(time));
@@ -43,7 +43,7 @@ PoseVelocity AgentTrajectory::value(double time) const {
   return PoseVelocity{rotation, translation, velocity};
 }
 
-AgentTrajectory AgentTrajectory::Make(
+Trajectory Trajectory::Make(
     const std::vector<double>& times,
     const std::vector<Eigen::Quaternion<double>>& knots_rotation,
     const std::vector<Eigen::Vector3d>& knots_translation,
@@ -68,10 +68,10 @@ AgentTrajectory AgentTrajectory::Make(
     default:
       throw std::logic_error("The provided interp_type is not supported.");
   }
-  return AgentTrajectory{translation, rotation};
+  return Trajectory{translation, rotation};
 }
 
-AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
+Trajectory Trajectory::MakeCubicFromWaypoints(
     const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
     const std::vector<Eigen::Vector3d>& waypoints_translation,
     const std::vector<double>& speeds) {
@@ -109,10 +109,10 @@ AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
       PiecewisePolynomial<double>::Cubic(times, translations,
                                          linear_velocities);
 
-  return AgentTrajectory(translation, rotation);
+  return Trajectory(translation, rotation);
 }
 
-AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
+Trajectory Trajectory::MakeCubicFromWaypoints(
     const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
     const std::vector<Eigen::Vector3d>& waypoints_translation, double speed) {
   DRAKE_THROW_UNLESS(waypoints_rotation.size() == waypoints_translation.size());
@@ -123,7 +123,7 @@ AgentTrajectory AgentTrajectory::MakeCubicFromWaypoints(
                                 speeds);
 }
 
-AgentTrajectory::AgentTrajectory(
+Trajectory::Trajectory(
     const PiecewisePolynomial<double>& translation,
     const PiecewiseQuaternionSlerp<double>& rotation)
     : translation_(translation),

--- a/automotive/trajectory.h
+++ b/automotive/trajectory.h
@@ -82,17 +82,17 @@ class PoseVelocity final {
 /// PoseVelocity instance is therefore well-defined when evaluated at a given
 /// time and, additionally, the translaton and rotation components of PoseVector
 /// match the input pose data exactly.
-class AgentTrajectory final {
+class Trajectory final {
  public:
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(AgentTrajectory)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Trajectory)
 
   /// An identifier for the type of valid types of interpolation used in
-  /// evaluating the translational component of an AgentTrajectory.  These types
+  /// evaluating the translational component of a Trajectory.  These types
   /// mirror the associated constructors for PiecewisePolynomial (see
   /// common/trajectories/piecewise_polynomial.h for further details).
   enum class InterpolationType { kFirstOrderHold, kCubic, kPchip };
 
-  /// Makes an AgentTrajectory from a discrete set of time-indexed pose data
+  /// Makes a Trajectory from a discrete set of time-indexed pose data
   /// under the specified interpolation scheme.
   ///
   /// @param times a vector of time indices representing the break points of the
@@ -109,14 +109,14 @@ class AgentTrajectory final {
   /// @throws std::runtime_error if `times` and `knots` have different lengths,
   /// `times` is not strictly increasing, and the inputs are otherwise
   /// inconsistent with the given `interp_type` (see piecewise_polynomial.h).
-  static AgentTrajectory Make(
+  static Trajectory Make(
       const std::vector<double>& times,
       const std::vector<Eigen::Quaternion<double>>& knots_rotation,
       const std::vector<Eigen::Vector3d>& knots_translation,
       const InterpolationType& interp_type =
           InterpolationType::kFirstOrderHold);
 
-  /// Makes an AgentTrajectory from a discrete set of (time-independent)
+  /// Makes a Trajectory from a discrete set of (time-independent)
   /// waypoints and a vector of speeds.  The resulting trajectory is assumed to
   /// start at time time t = 0 and follow a cubic-spline profile
   /// (InterpolationType::kCubic) for the translation elements, rendering speed
@@ -142,12 +142,12 @@ class AgentTrajectory final {
   //
   // TODO(jadecastro) Compute the break points as the solution to an
   // optimization problem or from additional user inputs.
-  static AgentTrajectory MakeCubicFromWaypoints(
+  static Trajectory MakeCubicFromWaypoints(
       const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
       const std::vector<Eigen::Vector3d>& waypoints_translation,
       const std::vector<double>& speeds);
 
-  /// Makes an AgentTrajectory from a discrete set of (time-independent)
+  /// Makes a Trajectory from a discrete set of (time-independent)
   /// waypoints, based on a constant speed, using cubic-polynomial
   /// interpolation.
   ///
@@ -159,18 +159,18 @@ class AgentTrajectory final {
   /// trajectory.
   /// @throws std::exception if `speed` is non-positive or if either of the
   /// input vectors is empty.
-  static AgentTrajectory MakeCubicFromWaypoints(
+  static Trajectory MakeCubicFromWaypoints(
       const std::vector<Eigen::Quaternion<double>>& waypoints_rotation,
       const std::vector<Eigen::Vector3d>& waypoints_translation, double speed);
 
-  /// Evaluates the AgentTrajectory at a given @p time, returning a packed
+  /// Evaluates the Trajectory at a given @p time, returning a packed
   /// PoseVelocity.
   PoseVelocity value(double time) const;
 
  private:
-  // Constructs an AgentTrajectory from a translation PiecewisePolynomial, @p
+  // Constructs a Trajectory from a translation PiecewisePolynomial, @p
   // translation, and a rotation PiecewiseQuaternionSlerp, @p rotation.
-  explicit AgentTrajectory(
+  explicit Trajectory(
       const trajectories::PiecewisePolynomial<double>& translation,
       const trajectories::PiecewiseQuaternionSlerp<double>& rotation);
 

--- a/automotive/trajectory_follower.cc
+++ b/automotive/trajectory_follower.cc
@@ -1,4 +1,4 @@
-#include "drake/automotive/trajectory_agent.h"
+#include "drake/automotive/trajectory_follower.h"
 
 #include "drake/common/default_scalars.h"
 
@@ -10,21 +10,19 @@ using systems::rendering::FrameVelocity;
 using systems::rendering::PoseVector;
 
 template <typename T>
-TrajectoryAgent<T>::TrajectoryAgent(const AgentData& agent_data,
-                                    const AgentTrajectory& trajectory,
-                                    double sampling_time_sec)
+TrajectoryFollower<T>::TrajectoryFollower(const Trajectory& trajectory,
+                                          double sampling_time_sec)
     : systems::LeafSystem<T>(
-          systems::SystemTypeTag<automotive::TrajectoryAgent>{}),
-      agent_data_(agent_data),
+          systems::SystemTypeTag<automotive::TrajectoryFollower>{}),
       trajectory_(trajectory) {
   this->DeclarePeriodicUnrestrictedUpdate(sampling_time_sec, 0.);
-  this->DeclareVectorOutputPort(&TrajectoryAgent::CalcStateOutput);
-  this->DeclareVectorOutputPort(&TrajectoryAgent::CalcPoseOutput);
-  this->DeclareVectorOutputPort(&TrajectoryAgent::CalcVelocityOutput);
+  this->DeclareVectorOutputPort(&TrajectoryFollower::CalcStateOutput);
+  this->DeclareVectorOutputPort(&TrajectoryFollower::CalcPoseOutput);
+  this->DeclareVectorOutputPort(&TrajectoryFollower::CalcVelocityOutput);
 }
 
 template <typename T>
-void TrajectoryAgent<T>::CalcStateOutput(
+void TrajectoryFollower<T>::CalcStateOutput(
     const systems::Context<T>& context,
     SimpleCarState<T>* output_vector) const {
   const PoseVelocity values = GetValues(context);
@@ -35,7 +33,7 @@ void TrajectoryAgent<T>::CalcStateOutput(
 }
 
 template <typename T>
-void TrajectoryAgent<T>::CalcPoseOutput(const systems::Context<T>& context,
+void TrajectoryFollower<T>::CalcPoseOutput(const systems::Context<T>& context,
                                         PoseVector<T>* pose) const {
   const PoseVelocity values = GetValues(context);
   pose->set_translation(Eigen::Translation<T, 3>{values.translation()});
@@ -45,8 +43,9 @@ void TrajectoryAgent<T>::CalcPoseOutput(const systems::Context<T>& context,
 }
 
 template <typename T>
-void TrajectoryAgent<T>::CalcVelocityOutput(const systems::Context<T>& context,
-                                            FrameVelocity<T>* velocity) const {
+void TrajectoryFollower<T>::CalcVelocityOutput(
+    const systems::Context<T>& context,
+    FrameVelocity<T>* velocity) const {
   const PoseVelocity values = GetValues(context);
   const Eigen::Vector3d& v = values.velocity().translational();
   const Eigen::Vector3d& w = values.velocity().rotational();
@@ -54,7 +53,7 @@ void TrajectoryAgent<T>::CalcVelocityOutput(const systems::Context<T>& context,
 }
 
 template <typename T>
-PoseVelocity TrajectoryAgent<T>::GetValues(
+PoseVelocity TrajectoryFollower<T>::GetValues(
     const systems::Context<T>& context) const {
   return trajectory_.value(ExtractDoubleOrThrow(context.get_time()));
 }
@@ -63,4 +62,4 @@ PoseVelocity TrajectoryAgent<T>::GetValues(
 }  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::automotive::TrajectoryAgent)
+    class ::drake::automotive::TrajectoryFollower)

--- a/automotive/trajectory_follower.h
+++ b/automotive/trajectory_follower.h
@@ -2,8 +2,8 @@
 
 #include <Eigen/Geometry>
 
-#include "drake/automotive/agent_trajectory.h"
 #include "drake/automotive/gen/simple_car_state.h"
+#include "drake/automotive/trajectory.h"
 #include "drake/common/drake_copyable.h"
 #include "drake/common/extract_double.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -13,23 +13,7 @@
 namespace drake {
 namespace automotive {
 
-/// Container for static data for a given agent model.
-struct AgentData {
-  enum class AgentType { kCar, kBicycle, kPedestrian };
-  // TODO(jadecastro) Add more types as necessary.
-
-  explicit AgentData(const AgentType& t) : type(t) {}
-
-  AgentType type{AgentType::kCar};
-};
-
-// Provide an explicit specialization for the kCar agent type.
-struct CarAgent : AgentData {
-  CarAgent() : AgentData(AgentType::kCar) {}
-};
-
-/// TrajectoryAgent models an agent that follows a pre-established trajectory,
-/// taking as input an AgentData structure and an AgentTrajectory.
+/// TrajectoryFollower simply moves along a pre-established trajectory.
 ///
 /// Note that, when T = AutoDiffXd, the AutoDiffXd derivatives for each element
 /// of the the outputs are empty.
@@ -39,7 +23,7 @@ struct CarAgent : AgentData {
 ///   heading is 0 rad when pointed +x, pi/2 rad when pointed +y;
 ///   heading is defined around the +z axis, positive-left-turn.
 /// * speed: s = √{ẋ² + ẏ²}
-///   (OutputPort getter: raw_pose_output())
+///   (OutputPort getter: state_output())
 ///
 /// output port 1: A PoseVector containing X_WA, where A is the agent's
 /// reference frame.
@@ -58,28 +42,26 @@ struct CarAgent : AgentData {
 ///
 /// @ingroup automotive_plants
 template <typename T>
-class TrajectoryAgent final : public systems::LeafSystem<T> {
+class TrajectoryFollower final : public systems::LeafSystem<T> {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryAgent)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TrajectoryFollower)
 
-  /// Constructs a TrajectoryAgent system that traces a given AgentTrajectory.
+  /// Constructs a TrajectoryFollower system that traces a given Trajectory.
   ///
-  /// @param agent_data an AgentData structure defining the agent.
-  /// @param trajectory an AgentTrajectory containing the trajectory.
+  /// @param trajectory a Trajectory containing the trajectory.
   /// @param sampling_time_sec the requested sampling time (in sec) for this
   /// system.  @default 0.01.
-  TrajectoryAgent(const AgentData& agent_data,
-                  const AgentTrajectory& trajectory,
-                  double sampling_time_sec = 0.01);
+  TrajectoryFollower(const Trajectory& trajectory,
+                     double sampling_time_sec = 0.01);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
-  explicit TrajectoryAgent(const TrajectoryAgent<U>& other)
-      : TrajectoryAgent<T>(other.agent_data_, other.trajectory_) {}
+  explicit TrajectoryFollower(const TrajectoryFollower<U>& other)
+      : TrajectoryFollower<T>(other.trajectory_) {}
 
   /// @name Accessors for the outputs, as enumerated in the class documentation.
   /// @{
-  const systems::OutputPort<T>& raw_pose_output() const {
+  const systems::OutputPort<T>& state_output() const {
     return this->get_output_port(0);
   }
   const systems::OutputPort<T>& pose_output() const {
@@ -112,10 +94,9 @@ class TrajectoryAgent final : public systems::LeafSystem<T> {
 
   // Allow different specializations to access each other's private data.
   template <typename>
-  friend class TrajectoryAgent;
+  friend class TrajectoryFollower;
 
-  const AgentData agent_data_;
-  const AgentTrajectory trajectory_;
+  const Trajectory trajectory_;
 };
 
 }  // namespace automotive


### PR DESCRIPTION
AgentTrajectory/TrajectoryAgent renamed to Trajectory/TrajectoryFollower
respectively. This aims to minimalise the functionality to the system
level (only what is necessary to compute in the simulation update step).

Agent and agent-related data will be handled elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8839)
<!-- Reviewable:end -->
