### PR TITLE
Add inline definitions (and simplify a bit) some accessors.

### DIFF
--- a/multibody/joints/drake_joint.cc
+++ b/multibody/joints/drake_joint.cc
@@ -37,16 +37,6 @@ std::unique_ptr<DrakeJoint> DrakeJoint::Clone() const {
   return clone;
 }
 
-const Isometry3d& DrakeJoint::get_transform_to_parent_body() const {
-  return transform_to_parent_body_;
-}
-
-int DrakeJoint::get_num_positions() const { return num_positions_; }
-
-int DrakeJoint::get_num_velocities() const { return num_velocities_; }
-
-const std::string& DrakeJoint::get_name() const { return name_; }
-
 std::string DrakeJoint::get_velocity_name(int index) const {
   return get_position_name(index) + "dot";
 }

--- a/multibody/joints/drake_joint.h
+++ b/multibody/joints/drake_joint.h
@@ -113,22 +113,24 @@ class DrakeJoint {
    * p_PQ = X_PF * p_FQ
    * </pre>
    */
-  const Eigen::Isometry3d& get_transform_to_parent_body() const;
+  const Eigen::Isometry3d& get_transform_to_parent_body() const {
+    return transform_to_parent_body_;
+  }
 
   /**
    * Returns the number of position states of this joint.
    */
-  int get_num_positions() const;
+  int get_num_positions() const { return num_positions_; }
 
   /**
    * Returns the number of velocity states of this joint.
    */
-  int get_num_velocities() const;
+  int get_num_velocities() const { return num_velocities_; }
 
   /**
    * Returns the name of this joint.
    */
-  const std::string& get_name() const;
+  const std::string& get_name() const { return name_; }
 
   /**
    * Returns the name of a particular position degree of freedom of this joint.

--- a/multibody/rigid_body.cc
+++ b/multibody/rigid_body.cc
@@ -68,24 +68,8 @@ void RigidBody<T>::setJoint(std::unique_ptr<DrakeJoint> joint) {
 }
 
 template <typename T>
-const DrakeJoint& RigidBody<T>::getJoint() const {
-  if (joint_) {
-    return (*joint_);
-  } else {
-    throw runtime_error("ERROR: RigidBody<T>::getJoint(): Rigid body \"" +
-                        name_ + "\" in model " + model_name_ +
-                        " does not have a joint!");
-  }
-}
-
-template <typename T>
 void RigidBody<T>::set_parent(RigidBody* parent) { parent_ = parent; }
 
-template <typename T>
-const RigidBody<T>* RigidBody<T>::get_parent() const { return parent_; }
-
-template <typename T>
-bool RigidBody<T>::has_parent_body() const { return parent_ != nullptr; }
 
 // TODO(liang.fok): Remove this deprecated method prior to Release 1.0.
 template <typename T>
@@ -95,16 +79,8 @@ template <typename T>
 void RigidBody<T>::set_body_index(int body_index) { body_index_ = body_index; }
 
 template <typename T>
-int RigidBody<T>::get_body_index() const { return body_index_; }
-
-template <typename T>
 void RigidBody<T>::set_position_start_index(int position_start_index) {
   position_start_index_ = position_start_index;
-}
-
-template <typename T>
-int RigidBody<T>::get_position_start_index() const {
-  return position_start_index_;
 }
 
 template <typename T>
@@ -112,10 +88,6 @@ void RigidBody<T>::set_velocity_start_index(int velocity_start_index) {
   velocity_start_index_ = velocity_start_index;
 }
 
-template <typename T>
-int RigidBody<T>::get_velocity_start_index() const {
-  return velocity_start_index_;
-}
 
 template <typename T>
 void RigidBody<T>::AddVisualElement(const DrakeShapes::VisualElement& element) {
@@ -136,12 +108,6 @@ void RigidBody<T>::AddCollisionElement(
   collision_element_ids_.push_back(id);
   collision_element_groups_[group_name].push_back(id);
   collision_elements_.push_back(element);
-}
-
-template <typename T>
-const std::vector<drake::multibody::collision::ElementId>&
-RigidBody<T>::get_collision_element_ids() const {
-  return collision_element_ids_;
 }
 
 template <typename T>
@@ -288,12 +254,6 @@ template <typename T>
 void RigidBody<T>::set_spatial_inertia(const drake::SquareTwistMatrix<double>&
     spatial_inertia) {
   spatial_inertia_ = spatial_inertia;
-}
-
-template <typename T>
-const drake::SquareTwistMatrix<double>& RigidBody<T>::get_spatial_inertia()
-    const {
-  return spatial_inertia_;
 }
 
 ostream& operator<<(ostream& out, const RigidBody<double>& b) {

--- a/multibody/rigid_body.h
+++ b/multibody/rigid_body.h
@@ -116,7 +116,10 @@ class RigidBody {
    *
    * @return The parent joint of this rigid body.
    */
-  const DrakeJoint& getJoint() const;
+  const DrakeJoint& getJoint() const {
+    DRAKE_DEMAND(joint_ != nullptr);
+    return *joint_;
+  }
 
   /**
    * Reports if the body has a parent joint.
@@ -134,7 +137,7 @@ class RigidBody {
   /**
    * Returns a const pointer to this rigid body's parent rigid body.
    */
-  const RigidBody* get_parent() const;
+  const RigidBody* get_parent() const { return parent_; }
 
   /**
    * Returns whether this RigidBody has a "parent", which is a RigidBody that is
@@ -144,7 +147,7 @@ class RigidBody {
    * the RigidBodyTree. Thus, by definition, all RigidBody objects should have a
    * parent RigidBody except for the RigidBodyTree's root, which is the world.
    */
-  bool has_parent_body() const;
+  bool has_parent_body() const { return parent_ != nullptr; }
 
   // TODO(liang.fok): Remove this deprecated method prior to Release 1.0.
   DRAKE_DEPRECATED("Please use has_parent_body().")
@@ -173,7 +176,7 @@ class RigidBody {
    * Returns the "body index" of this `RigidBody`. This is the index within the
    * vector of `RigidBody` objects within the `RigidBodyTree`.
    */
-  int get_body_index() const;
+  int get_body_index() const { return body_index_; }
 
   /**
    * Sets the start index of this rigid body's mobilizer joint's contiguous
@@ -189,7 +192,7 @@ class RigidBody {
    * Returns the start index of this body's parent jont's position states; see
    * RigidBody::set_position_start_index() for more information.
    */
-  int get_position_start_index() const;
+  int get_position_start_index() const { return position_start_index_; }
 
   /**
    * Sets the start index of this rigid body's mobilizer joint's contiguous
@@ -205,7 +208,7 @@ class RigidBody {
    * Returns the start index of this body's parent jont's velocity states; see
    * RigidBody::set_velocity_start_index() for more information.
    */
-  int get_velocity_start_index() const;
+  int get_velocity_start_index() const { return velocity_start_index_; }
 
   void AddVisualElement(const DrakeShapes::VisualElement& elements);
 
@@ -229,7 +232,7 @@ class RigidBody {
    * represent the collision geometry of this rigid body.
    */
   const std::vector<drake::multibody::collision::ElementId>&
-  get_collision_element_ids() const;
+  get_collision_element_ids() const { return collision_element_ids_; }
 
   /**
    * Returns a reference to an `std::vector` of collision elements that
@@ -376,8 +379,9 @@ class RigidBody {
   /**
    * Returns the spatial inertia of this rigid body.
    */
-  const drake::SquareTwistMatrix<double>& get_spatial_inertia()
-      const;
+  const drake::SquareTwistMatrix<double>& get_spatial_inertia() const {
+    return spatial_inertia_;
+  }
 
   /**
    * Transforms all of the visual, collision, and inertial elements associated

--- a/multibody/rigid_body_frame.cc
+++ b/multibody/rigid_body_frame.cc
@@ -25,31 +25,13 @@ int RigidBodyFrame<T>::get_model_instance_id() const {
 }
 
 template <typename T>
-const std::string& RigidBodyFrame<T>::get_name() const { return name_; }
-
-template <typename T>
-const RigidBody<T>& RigidBodyFrame<T>::get_rigid_body() const {
-  return *body_;
-}
-
-template <typename T>
 RigidBody<T>* RigidBodyFrame<T>::get_mutable_rigid_body() {
   return body_;
 }
 
 template <typename T>
-const Eigen::Isometry3d& RigidBodyFrame<T>::get_transform_to_body() const {
-  return transform_to_body_;
-}
-
-template <typename T>
 Eigen::Isometry3d* RigidBodyFrame<T>::get_mutable_transform_to_body() {
   return &transform_to_body_;
-}
-
-template <typename T>
-int RigidBodyFrame<T>::get_frame_index() const {
-  return frame_index_;
 }
 
 template <typename T>

--- a/multibody/rigid_body_frame.h
+++ b/multibody/rigid_body_frame.h
@@ -69,12 +69,12 @@ class RigidBodyFrame final {
   /**
    * Returns the name of this frame.
    */
-  const std::string& get_name() const;
+  const std::string& get_name() const { return name_; }
 
   /**
    * Returns the rigid body to which this frame is attached.
    */
-  const RigidBody<T>& get_rigid_body() const;
+  const RigidBody<T>& get_rigid_body() const { return *body_; }
 
   /**
    * Returns the rigid body to which this frame is attached.
@@ -104,7 +104,9 @@ class RigidBodyFrame final {
    * p_B = T_BF * p_F;
    * </pre>
    */
-  const Eigen::Isometry3d& get_transform_to_body() const;
+  const Eigen::Isometry3d& get_transform_to_body() const {
+    return transform_to_body_;
+  }
 
   // TODO(liang.fok) Remove this method once it's no longer needed by
   // drake/systems/plants/constructModelmex.cpp.
@@ -121,7 +123,7 @@ class RigidBodyFrame final {
    * Returns the index of this `RigidBodyFrame` within the vector of
    * `RigidBodyFrame` objects in the `RigidBodyTree`.
    */
-  int get_frame_index() const;
+  int get_frame_index() const { return frame_index_; }
 
   /**
    * Sets the name of this `RigidBodyFrame`.

--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -370,6 +370,14 @@ void RigidBodyTree<T>::compile() {
   //   from the root towards the last leaf.
   for (size_t i = 0; i < bodies_.size(); ++i) {
     const auto& body = bodies_[i];
+
+    if (body->has_parent_body() && !body->has_joint()) {
+      throw runtime_error(
+          "ERROR: RigidBodyTree::compile(): Rigid body \"" +
+          body->get_name() + "\" in model " + body->get_model_name() +
+          " has no joint!");
+    }
+
     if (body->has_parent_body() &&
         body->get_spatial_inertia().isConstant(0)) {
       bool hasChild = false;
@@ -1545,18 +1553,6 @@ void RigidBodyTree<T>::TestConnectedToWorld(const RigidBody<T>& body,
     "The connected set should always include the world node: 0.");
   int id = body.get_body_index();
   if (connected->find(id) == connected->end()) {
-    if (!body.has_joint()) {
-      // NOTE: This test is redundant if it is called during
-      // RigidBodyTree::compile because two previous operations will catch
-      // the missing joint error.  However, for the sake of completeness
-      // and because the cost of the redundancy is negligible, the joint
-      // test is also included.
-      throw runtime_error(
-          "ERROR: RigidBodyTree::TestConnectedToWorld(): "
-              "Rigid body \"" +
-              body.get_name() + "\" in model " + body.get_model_name() +
-              " has no joint!");
-    }
     const RigidBody<T>* parent = body.get_parent();
     if (parent == nullptr) {
       // We know this is *not* the world node because the world node is in the
@@ -3087,21 +3083,11 @@ int RigidBodyTree<T>::FindIndexOfChildBodyOfJoint(const std::string& joint_name,
   return link->get_body_index();
 }
 
-template <typename T>
-const RigidBody<T>& RigidBodyTree<T>::get_body(int body_index) const {
-  DRAKE_DEMAND(body_index >= 0 && body_index < get_num_bodies());
-  return *bodies_[body_index].get();
-}
 
 template <typename T>
 RigidBody<T>* RigidBodyTree<T>::get_mutable_body(int body_index) {
   DRAKE_DEMAND(body_index >= 0 && body_index < get_num_bodies());
   return bodies_[body_index].get();
-}
-
-template <typename T>
-int RigidBodyTree<T>::get_num_bodies() const {
-  return static_cast<int>(bodies_.size());
 }
 
 // TODO(liang.fok) Remove this method prior to Release 1.0.
@@ -3339,21 +3325,12 @@ RigidBody<T>* RigidBodyTree<T>::add_rigid_body(
   return bodies_.back().get();
 }
 
-template <typename T>
-int RigidBodyTree<T>::get_num_positions() const {
-  return num_positions_;
-}
-
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
 template <typename T>
 int RigidBodyTree<T>::number_of_positions() const {
   return get_num_positions();
 }
 
-template <typename T>
-int RigidBodyTree<T>::get_num_velocities() const {
-  return num_velocities_;
-}
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.
 template <typename T>
@@ -3362,20 +3339,8 @@ int RigidBodyTree<T>::number_of_velocities() const {
 }
 
 template <typename T>
-int RigidBodyTree<T>::get_num_actuators() const {
-  return static_cast<int>(actuators.size());
-}
-
-template <typename T>
 int RigidBodyTree<T>::add_model_instance() {
   return num_model_instances_++;
-}
-
-// TODO(liang.fok) Update this method implementation once the world is assigned
-// its own model instance ID (#3088). It should return num_model_instances_ - 1.
-template <typename T>
-int RigidBodyTree<T>::get_num_model_instances() const {
-  return num_model_instances_;
 }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.

--- a/multibody/rigid_body_tree.h
+++ b/multibody/rigid_body_tree.h
@@ -135,10 +135,13 @@ class RigidBodyTree {
   // This method is not thread safe.
   int get_next_clique_id() { return next_available_clique_++; }
 
+  // TODO(liang.fok) Update this method implementation once the world
+  // is assigned its own model instance ID (#3088). It should return
+  // num_model_instances_ - 1.
   /**
    * Returns the number of model instances in the tree, not including the world.
    */
-  int get_num_model_instances() const;
+  int get_num_model_instances() const { return num_model_instances_; }
 
   DRAKE_DEPRECATED("Please use get_num_model_instances().")
   int get_number_of_model_instances() const;
@@ -1349,7 +1352,10 @@ class RigidBodyTree {
    * between zero and the number of bodies in this tree, which can be determined
    * by calling RigidBodyTree::get_num_bodies().
    */
-  const RigidBody<T>& get_body(int body_index) const;
+  const RigidBody<T>& get_body(int body_index) const {
+    DRAKE_DEMAND(body_index >= 0 && body_index < get_num_bodies());
+    return *bodies_[body_index].get();
+  }
 
   /**
    * Returns the body at index @p body_index. Parameter @p body_index must be
@@ -1362,7 +1368,9 @@ class RigidBodyTree {
    * Returns the number of bodies in this tree. This includes the one body that
    * represents the world.
    */
-  int get_num_bodies() const;
+  int get_num_bodies() const {
+    return static_cast<int>(bodies_.size());
+  }
 
   /**
    * Returns the number of frames in this tree.
@@ -1516,7 +1524,7 @@ class RigidBodyTree {
   /**
    * Returns the number of position states outputted by this %RigidBodyTree.
    */
-  int get_num_positions() const;
+  int get_num_positions() const { return num_positions_; }
 
   DRAKE_DEPRECATED("Please use get_num_positions().")
   int number_of_positions() const;
@@ -1524,7 +1532,7 @@ class RigidBodyTree {
   /**
    * Returns the number of velocity states outputted by this %RigidBodyTree.
    */
-  int get_num_velocities() const;
+  int get_num_velocities() const { return num_velocities_; }
 
   DRAKE_DEPRECATED("Please use get_num_velocities().")
   int number_of_velocities() const;
@@ -1532,7 +1540,7 @@ class RigidBodyTree {
   /**
    * Returns the number of actuators in this %RigidBodyTree.
    */
-  int get_num_actuators() const;
+  int get_num_actuators() const { return static_cast<int>(actuators.size()); }
 
   /**
    * Returns whether this %RigidBodyTree is initialized. It is initialized after

--- a/multibody/test/rigid_body_test.cc
+++ b/multibody/test/rigid_body_test.cc
@@ -21,13 +21,6 @@ namespace {
 
 using std::make_unique;
 
-// Tests whether an exception is thrown if RigidBody::getJoint() is called prior
-// to a joint being set.
-GTEST_TEST(RigidBodyTest, TestGetJointThatIsNotSet) {
-  auto rigid_body_ptr = make_unique<RigidBody<double>>();
-  EXPECT_THROW(rigid_body_ptr->getJoint(), std::runtime_error);
-}
-
 // Confirms that the adjacency of bodies is evaluated correctly.  See
 // RigidBody::adjacentTo for details
 GTEST_TEST(RigidBodyTest, TestAdjacency) {

--- a/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
+++ b/multibody/test/rigid_body_tree/rigid_body_tree_completeness_test.cc
@@ -109,8 +109,8 @@ GTEST_TEST(RigidBodyTreeCompleteness, MissingJointWeldingError) {
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string msg =
-        "ERROR: RigidBody<T>::getJoint(): Rigid body \"body3\" in "
-            "model robot does not have a joint!";
+        "ERROR: RigidBodyTree::compile(): Rigid body \"body3\" in "
+            "model robot has no joint!";
     ASSERT_EQ(e.what(), msg);
   }
 }
@@ -143,8 +143,8 @@ GTEST_TEST(RigidBodyTreeCompleteness, MissingJointConfigurationError) {
     GTEST_FAIL();
   } catch (std::runtime_error& e) {
     std::string msg =
-        "ERROR: RigidBody<T>::getJoint(): Rigid body \"body3\" in "
-            "model robot does not have a joint!";
+        "ERROR: RigidBodyTree::compile(): Rigid body \"body3\" in "
+            "model robot has no joint!";
     ASSERT_EQ(e.what(), msg);
   }
 }


### PR DESCRIPTION
In a particular simulation (not in drake master), this results in up
to 10% speedup improvement.

I mostly only bothered with the accessors which were visibile in
callgrind output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8847)
<!-- Reviewable:end -->
