### PR TITLE
Make identifiers orderable

### DIFF
--- a/geometry/identifier.h
+++ b/geometry/identifier.h
@@ -164,6 +164,14 @@ class Identifier {
     return value_ != other.value_ && is_valid() && other.is_valid();
   }
 
+  /** Compare two identifiers in order to define a total ordering among
+   identifiers. This makes identifiers compatible with data structures which
+   require total ordering (e.g., std::set).  */
+  bool operator<(Identifier other) const {
+    DRAKE_ASSERT(is_valid() && other.is_valid());
+    return value_ < other.value_;
+  }
+
   /** Generates a new identifier for this id type. This new identifier will be
    different from all previous identifiers created. This method does _not_
    make any guarantees about the values of ids from successive invocations.

--- a/geometry/test/identifier_test.cc
+++ b/geometry/test/identifier_test.cc
@@ -1,5 +1,6 @@
 #include "drake/geometry/identifier.h"
 
+#include <set>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -13,6 +14,7 @@ namespace {
 
 
 // Creates various dummy index types to test.
+using std::set;
 using std::stringstream;
 using std::unordered_set;
 using std::unordered_map;
@@ -105,6 +107,26 @@ TEST_F(IdentifierTests, ServeAsMapValue) {
   EXPECT_NE(ids.find(b1), ids.end());
   ids[b3] = a3_;
   EXPECT_NE(ids.find(b3), ids.end());
+}
+
+// Confirms that ids can be put into a set.
+TEST_F(IdentifierTests, PutInSet) {
+  set<AId> ids;
+  AId a1 = AId::get_new_id();
+  AId a2 = AId::get_new_id();
+
+  EXPECT_EQ(ids.size(), 0u);
+  ids.insert(a1);
+  EXPECT_EQ(ids.size(), 1u);
+  EXPECT_EQ(ids.count(a1), 1u);
+
+  ids.insert(a2);
+  EXPECT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids.count(a2), 1u);
+
+  ids.insert(a1);
+  EXPECT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids.count(a1), 1u);
 }
 
 // Tests the streaming behavior.


### PR DESCRIPTION
This allows identifiers to be used in data structures that require ordering (e.g., std::set).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8848)
<!-- Reviewable:end -->
