### PR TITLE
github: Add issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,108 @@
+> Please fill out all quoted sections (`> `) that need a response; feel free
+to remove the quoted sections that do not need a response.
+
+> Before you post:
+
+> * Have you reviewed the documentation on
+[Getting Help](http://drake.mit.edu/getting_help.html)?
+> * Have you reviewed existing GitHub issues and StackOverflow posts?
+> * Have you rerun `install_prereqs.sh` on your current commit of `drake`?
+
+## Description
+
+> Please provide a short description: expected behavior, and what actually
+happens. If this is an enhancement request, please provide a concrete use case.
+
+## Reproduction
+
+> Please provide a minimal snippet of code or shell commands (<10 lines)
+that reproduces the issue. If it is self-contained, but 10-50 lines,
+please link to a Gist.
+
+> If your changes to `drake` are more comprehensive, please try to isolate your
+problem to the above amount, ensuring that you are using a branch as close to
+`master` as possible.
+
+## Debug Information
+
+> If this is an enhancement / feature request that is not platform-specific,
+you do not need to include this section. However, please ensure that the
+current version of `master` does not already provide what you want.
+
+* What operating system are you running Drake on?
+(e.g. Ubuntu 16.04, macOS 10.13)
+
+    > Replace this with your answer.
+
+* Is this an issue with (a) C++, (b) Python, or (c) the distributed tools
+(e.g. `drake-visualizer`)?
+
+    > Replace this with your answer.
+
+* Are you (a) building `drake` from source, or (b) from a binary release?
+
+    > Replace this with your answer.
+
+* What version of `python` are you using?
+
+    > Replace this with the output of
+    `bash -x -c 'which python2; python2 --version'`
+
+* If you are building from source or using the `drake` C++ library as an
+external:
+
+    * What version of Bazel and CMake are you using?
+
+        > Replace this with the output of
+        `bash -x -c 'which bazel; bazel version; which cmake; cmake --version'`
+
+    * If you are using Bazel, please provide the host settings in your present
+    project workspace:
+
+        > In your workspace, please copy the output of:
+        `bazel run @drake//common:print_host_settings`
+
+    * If you are using CMake, please provide the compilers being used in your
+    project:
+
+        > First, in your build directory, execute
+        `cmake -LA <path_to_source_dir> | grep 'CMAKE_.*_COMPILER'`
+
+        > Given these values, execute `<compiler> --version`, and provide its
+        output.
+
+* If you are building `drake`
+[from source](http://drake.mit.edu/from_source.html):
+
+    * What git commit of `drake` are you using?
+
+        > Replace this with the output of `git rev-parse --short HEAD`.
+
+    * Are you building `drake` with Bazel or CMake?
+
+        > Replace this with your answer.
+
+    * Are you using `drake` directly, or consuming it as an external?
+
+        > Replace this with your answer.
+
+    * If an external, is it most like
+    [`drake_bazel_external`](https://github.com/RobotLocomotion/drake-shambhala/tree/master/drake_bazel_external) or
+    [`drake_cmake_external`](https://github.com/RobotLocomotion/drake-shambhala/tree/master/drake_cmake_external)?
+
+        > Replace this with your answer.
+
+* If you are using `drake` [from a binary release](http://drake.mit.edu/from_binary.html):
+
+    * What are the contents of `.../drake/share/doc/drake/VERSION.txt`?
+
+        > Replace this with your answer.
+
+    * What URL did you download `drake` from?
+
+        > Replace this with your answer.
+
+    * Are you writing a CMake project which is using `drake`, like
+    [`drake_cmake_installed`](https://github.com/RobotLocomotion/drake-shambhala/tree/master/drake_cmake_installed)?
+
+        > Replace this with your answer.

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -647,6 +647,23 @@ sh_test(
     ],
 )
 
+# Utility script to indicate which compiler is being used.
+sh_binary(
+    name = "print_host_settings",
+    srcs = ["print_host_settings.sh"],
+    args = ["$(location :capture_cc.env)"],
+    data = [":capture_cc.env"],
+)
+
+# Test the above script; if CROSSTOOL is removed or changed, $(CC) may be an
+# invalid binary (related to #7763), and CI should catch this.
+# N.B. We have to use a proxy script since `print_host_settings` has `data`.
+sh_test(
+    name = "print_host_settings_test",
+    srcs = ["test/print_host_settings_test.sh"],
+    data = [":print_host_settings"],
+)
+
 drake_cc_googletest(
     name = "is_cloneable_test",
     deps = [

--- a/common/print_host_settings.sh
+++ b/common/print_host_settings.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This should only be invoked via Bazel.
+set -eux
+
+capture_cc_env="$1"
+source "$capture_cc_env"
+
+"$BAZEL_CC" --version

--- a/common/test/print_host_settings_test.sh
+++ b/common/test/print_host_settings_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eux
+
+exec common/print_host_settings.sh common/capture_cc.env


### PR DESCRIPTION
Resolves #8812 

Following GitHub instructions: https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/
The format is semi-cribbed from [bazel](https://github.com/bazelbuild/bazel/blob/f5280fd00f33321f7634251442ed4384ae6ca31c/ISSUE_TEMPLATE.md).

Since we use `doc/` and not `docs/`, I have placed the file in `.github/`. This is a single template for issues and enhancement requests; if desired, I can split them up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8851)
<!-- Reviewable:end -->
