### PR TITLE
rgbd_camera: Teach RgbdCamera to take different image sizes 

### DIFF
--- a/bindings/pydrake/systems/sensors_py.cc
+++ b/bindings/pydrake/systems/sensors_py.cc
@@ -191,11 +191,13 @@ PYBIND11_MODULE(sensors, m) {
     .def(
       py::init<
         string, const RigidBodyTree<T>&, const RigidBodyFrame<T>&,
-        double, double, double, bool>(),
+        double, double, double, bool, int, int>(),
       py::arg("name"), py::arg("tree"), py::arg("frame"),
       py::arg("z_near") = 0.5, py::arg("z_far") = 5.0,
       py::arg("fov_y") = M_PI_4,
       py::arg("show_window") = bool{RenderingConfig::kDefaultShowWindow},
+      py::arg("width") = int{RenderingConfig::kDefaultWidth},
+      py::arg("height") = int{RenderingConfig::kDefaultHeight},
       // Keep alive, reference: `this` keeps  `RigidBodyTree` alive.
       py::keep_alive<1, 3>())
     .def("color_camera_info", &RgbdCamera::color_camera_info,

--- a/bindings/pydrake/systems/test/sensors_test.py
+++ b/bindings/pydrake/systems/test/sensors_test.py
@@ -206,13 +206,23 @@ class TestSensors(unittest.TestCase):
         frame = RigidBodyFrame("rgbd camera frame", tree.FindBody("link"))
         tree.addFrame(frame)
 
+        # Use HDTV size.
+        width = 1280
+        height = 720
+
         camera = mut.RgbdCamera(
             name="camera", tree=tree, frame=frame,
             z_near=0.5, z_far=5.0,
-            fov_y=np.pi / 4, show_window=False)
+            fov_y=np.pi / 4, show_window=False,
+            width=width, height=height)
 
-        self.assertIsInstance(camera.color_camera_info(), mut.CameraInfo)
-        self.assertIsInstance(camera.depth_camera_info(), mut.CameraInfo)
+        def check_info(camera_info):
+            self.assertIsInstance(camera_info, mut.CameraInfo)
+            self.assertEqual(camera_info.width(), width)
+            self.assertEqual(camera_info.height(), height)
+
+        check_info(camera.color_camera_info())
+        check_info(camera.depth_camera_info())
         self.assertIsInstance(camera.color_camera_optical_pose(), Isometry3)
         self.assertIsInstance(camera.depth_camera_optical_pose(), Isometry3)
         self.assertTrue(camera.tree() is tree)

--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -128,7 +128,9 @@ class RgbdCamera final : public LeafSystem<double> {
              double z_near = 0.5,
              double z_far = 5.0,
              double fov_y = M_PI_4,
-             bool show_window = RenderingConfig::kDefaultShowWindow);
+             bool show_window = RenderingConfig::kDefaultShowWindow,
+             int width = RenderingConfig::kDefaultWidth,
+             int height = RenderingConfig::kDefaultHeight);
 
   /// A constructor for %RgbdCamera that defines `B` using a RigidBodyFrame.
   /// The pose of %RgbdCamera is fixed to a user-defined frame and will be
@@ -167,7 +169,9 @@ class RgbdCamera final : public LeafSystem<double> {
              double z_near = 0.5,
              double z_far = 5.0,
              double fov_y = M_PI_4,
-             bool show_window = RenderingConfig::kDefaultShowWindow);
+             bool show_window = RenderingConfig::kDefaultShowWindow,
+             int width = RenderingConfig::kDefaultWidth,
+             int height = RenderingConfig::kDefaultHeight);
 
   ~RgbdCamera() = default;
 

--- a/systems/sensors/rgbd_renderer.h
+++ b/systems/sensors/rgbd_renderer.h
@@ -20,9 +20,13 @@ struct RenderingConfig {
   // TODO(eric.cousineau): Define all default values be defined here to
   // minimize duplication.
   /// The width of the image to be rendered in pixels.
-  const int width;
+  const int width{kDefaultWidth};
+  /// Default value for `width`.
+  static constexpr int kDefaultWidth{640};
   /// The height of the image to be rendered in pixels.
-  const int height;
+  const int height{kDefaultHeight};
+  /// Default value for `height`.
+  static constexpr int kDefaultHeight{480};
   /// The renderer's camera vertical field of view in radians.
   const double fov_y;
   /// The minimum depth RgbdRenderer can output. Note that this is different


### PR DESCRIPTION
Checks box 1 of #8850.

This just appends the `width` and `height `arguments, prioritizing backwards compatibility and getting it done. My next step is to resolve #8123, and ultimately deprecate these overly coupled constructors.

\cc @naveenoid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8852)
<!-- Reviewable:end -->
