### PR TITLE
Fixing sdf joint pose

### DIFF
--- a/multibody/benchmarks/acrobot/make_acrobot_plant_sdf.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant_sdf.cc
@@ -75,6 +75,7 @@ MakeAcrobotPlantSdf() {
     "      </inertial>"
     "    </link>"
     "    <joint name='ShoulderJoint' type='revolute'>"
+    "      <pose>0 0 0.5 0 0 0</pose>"
     "      <parent>world</parent>"
     "      <child>Link1</child>"
     "      <axis>"
@@ -82,7 +83,7 @@ MakeAcrobotPlantSdf() {
     "      </axis>"
     "    </joint>"
     "    <joint name='ElbowJoint' type='revolute'>"
-    "      <pose>0 0 -1.0 0 0 0</pose>"
+    "      <pose>0 0 1.0 0 0 0</pose>"
     "      <parent>Link1</parent>"
     "      <child>Link2</child>"
     "      <axis>"
@@ -146,15 +147,8 @@ MakeAcrobotPlantSdf() {
     const sdf::Joint* joint = model->JointByIndex(joint_index);
     const sdf::JointAxis* axis = joint->Axis();
 
-    // Get the location of the joint in the model frame.
-    const Isometry3d X_MJ = ToIsometry3(joint->Pose());
-
-    // Get the location of the child link in the model frame.
-    const Isometry3d X_MC = ToIsometry3(
-        model->LinkByName(joint->ChildLinkName())->Pose());
-
-    // Compute the location of the child joint in the child link's frame.
-    const Isometry3d X_CJ = X_MC.inverse() * X_MJ;
+    // Get the location of the joint in the child link's frame.
+    const Isometry3d X_CJ = ToIsometry3(joint->Pose());
 
     // Only supporting revolute joints for now.
     if (joint->Type() == sdf::JointType::REVOLUTE) {


### PR DESCRIPTION
@amcastro-tri Found a bug in the way Joint::Pose was being used. This pull request fixes an error in the acrobot SDF, and the way Joint::Pose was being used.

Related SDF pull request: https://bitbucket.org/osrf/sdformat/pull-requests/435

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8853)
<!-- Reviewable:end -->
