### PR TITLE
Pull DiagramOutputPort into its own file and untangle from Diagram.

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -24,6 +24,7 @@ drake_cc_package_library(
         ":diagram_context",
         ":diagram_continuous_state",
         ":diagram_discrete_values",
+        ":diagram_output_port",
         ":discrete_values",
         ":event_collection",
         ":framework_common",
@@ -478,11 +479,26 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "diagram_output_port",
+    srcs = ["diagram_output_port.cc"],
+    hdrs = ["diagram_output_port.h"],
+    deps = [
+        ":diagram_context",
+        ":framework_common",
+        ":output_port",
+        ":value",
+        "//common:default_scalars",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
     name = "diagram",
     srcs = ["diagram.cc"],
     hdrs = ["diagram.h"],
     deps = [
         ":diagram_context",
+        ":diagram_output_port",
         ":system",
         "//common:default_scalars",
         "//common:essential",

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -3,9 +3,6 @@
 #include "drake/common/default_scalars.h"
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::internal::DiagramOutputPort)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::internal::DiagramOutput)
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -19,6 +19,7 @@
 #include "drake/systems/framework/diagram_context.h"
 #include "drake/systems/framework/diagram_continuous_state.h"
 #include "drake/systems/framework/diagram_discrete_values.h"
+#include "drake/systems/framework/diagram_output_port.h"
 #include "drake/systems/framework/discrete_values.h"
 #include "drake/systems/framework/event.h"
 #include "drake/systems/framework/state.h"
@@ -35,70 +36,6 @@ template <typename T>
 class DiagramBuilder;
 
 namespace internal {
-
-//==============================================================================
-//                          DIAGRAM OUTPUT PORT
-//==============================================================================
-/// Holds information about the subsystem output port that has been exported to
-/// become one of this Diagram's output ports. The actual methods for
-/// determining the port's value are supplied by the LeafSystem that ultimately
-/// underlies the source port, although that may be any number of levels down.
-template <typename T>
-class DiagramOutputPort : public OutputPort<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramOutputPort)
-
-  /// Construct a %DiagramOutputPort for the given `diagram` that exports the
-  /// indicated port. That port's owning system must be a subsystem of the
-  /// diagram.
-  DiagramOutputPort(const Diagram<T>& diagram,
-                    const OutputPort<T>* source_output_port)
-      : OutputPort<T>(
-          diagram, diagram, OutputPortIndex(diagram.get_num_output_ports()),
-          source_output_port->get_data_type(), source_output_port->size()),
-        source_output_port_(source_output_port),
-        subsystem_index_(
-            diagram.GetSystemIndexOrAbort(&source_output_port->get_system())) {}
-
-  ~DiagramOutputPort() final = default;
-
-  /// Obtain a reference to the subsystem output port that was exported to
-  /// create this diagram port. Note that the source may itself be a diagram
-  /// output port.
-  const OutputPort<T>& get_source_output_port() const {
-    return *source_output_port_;
-  }
-
- private:
-  // These forward to the source system output port.
-  std::unique_ptr<AbstractValue> DoAllocate() const final {
-    return source_output_port_->Allocate();
-  }
-
-  // Pass in just the source System's Context, not the whole Diagram context
-  // we're given.
-  void DoCalc(
-      const Context<T>& context, AbstractValue* value) const final {
-    const Context<T>& subcontext = get_subcontext(context);
-    return source_output_port_->Calc(subcontext, value);
-  }
-
-  const AbstractValue& DoEval(const Context<T>& context) const final {
-    const Context<T>& subcontext = get_subcontext(context);
-    return source_output_port_->Eval(subcontext);
-  }
-
-  // Dig out the right subcontext for delegation.
-  const Context<T>& get_subcontext(const Context<T>& context) const {
-    const DiagramContext<T>* diagram_context =
-        dynamic_cast<const DiagramContext<T>*>(&context);
-    DRAKE_DEMAND(diagram_context != nullptr);
-    return diagram_context->GetSubsystemContext(subsystem_index_);
-  }
-
-  const OutputPort<T>* const source_output_port_;
-  const SubsystemIndex subsystem_index_;
-};
 
 //==============================================================================
 //                             DIAGRAM OUTPUT
@@ -1523,8 +1460,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     const System<T>* const sys = port.first;
     const int port_index = port.second;
     const auto& source_output_port = sys->get_output_port(port_index);
-    auto diagram_port = std::make_unique<internal::DiagramOutputPort<T>>(
-        *this, &source_output_port);
+    auto diagram_port = std::make_unique<DiagramOutputPort<T>>(
+        *this, *this, OutputPortIndex(this->get_num_output_ports()),
+        &source_output_port,
+        GetSystemIndexOrAbort(&source_output_port.get_system()));
     this->CreateOutputPort(std::move(diagram_port));
   }
 

--- a/systems/framework/diagram_output_port.cc
+++ b/systems/framework/diagram_output_port.cc
@@ -1,0 +1,6 @@
+#include "drake/systems/framework/diagram_output_port.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiagramOutputPort)

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <memory>
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/diagram_context.h"
+#include "drake/systems/framework/framework_common.h"
+#include "drake/systems/framework/output_port.h"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace systems {
+
+/** Holds information about a subsystem output port that has been exported to
+become one of this Diagram's output ports. The actual methods for determining
+the port's value are supplied by the LeafOutputPort that ultimately underlies
+the source port, although that may be any number of levels down.
+
+@tparam T The vector element type, which must be a valid Eigen scalar.
+
+Instantiated templates for the following kinds of T's are provided:
+- double
+- AutoDiffXd
+- symbolic::Expression
+
+They are already available to link against in the containing library. */
+template <typename T>
+class DiagramOutputPort final : public OutputPort<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiagramOutputPort)
+
+  /** (Internal use only) Constructs a %DiagramOutputPort that exports an
+  output port of one of the diagram's child subsystems.
+
+  @param diagram The Diagram that will own this port.
+  @param system_base The same Diagram cast to its messaging interface.
+  @param index The output port index to be assigned to the new port.
+  @param source_output_port An output port of one of this diagram's child
+      subsystems that is to be forwarded to the new port.
+  @param source_subsystem_index The index of the child subsystem that owns
+      `source_output_port`.
+
+  @pre The `diagram` System must actually be a Diagram.
+  @pre `diagram` and `system_base` must be the same object.
+  @pre `source_output_port` must be owned by a child of `diagram`.
+  @pre `source_subsystem_index` must be the index of that child in `diagram`.
+
+  This is intended only for use by Diagram and we depend on the caller to
+  meet the above preconditions, not all of which can be independently
+  verified here. */
+  // To avoid a Diagram <=> DiagramOutputPort physical dependency, this class
+  // doesn't have access to a declaration of Diagram<T> so would not be able
+  // to static_cast up to System<T> as is required by OutputPort. We expect
+  // the caller to do that cast for us so take a System<T> here.
+  DiagramOutputPort(const System<T>& diagram,
+                    const internal::SystemMessageInterface& system_base,
+                    OutputPortIndex index,
+                    const OutputPort<T>* source_output_port,
+                    SubsystemIndex source_subsystem_index)
+      : OutputPort<T>(diagram, system_base, index,
+                      source_output_port->get_data_type(),
+                      source_output_port->size()),
+        source_output_port_(source_output_port),
+        source_subsystem_index_(source_subsystem_index) {
+    DRAKE_DEMAND(index.is_valid() && source_subsystem_index.is_valid());
+    DRAKE_DEMAND(source_output_port != nullptr);
+  }
+
+  ~DiagramOutputPort() final = default;
+
+  /** Obtains a reference to the subsystem output port that was exported to
+  create this diagram port. Note that the source may itself be a diagram
+  output port. */
+  const OutputPort<T>& get_source_output_port() const {
+    return *source_output_port_;
+  }
+
+ private:
+  // Asks the source system output port to allocate an appropriate object.
+  std::unique_ptr<AbstractValue> DoAllocate() const final {
+    return source_output_port_->Allocate();
+  }
+
+  // Given the whole Diagram context, extracts the appropriate subcontext and
+  // delegates to the source output port.
+  void DoCalc(const Context<T>& diagram_context,
+              AbstractValue* value) const final {
+    const Context<T>& subcontext = get_subcontext(diagram_context);
+    return source_output_port_->Calc(subcontext, value);
+  }
+
+  // Given he whole Diagram context, extracts the appropriate subcontext and
+  // delegates to the source output port.
+  const AbstractValue& DoEval(const Context<T>& diagram_context) const final {
+    const Context<T>& subcontext = get_subcontext(diagram_context);
+    return source_output_port_->Eval(subcontext);
+  }
+
+  // Digs out the right subcontext for delegation.
+  const Context<T>& get_subcontext(const Context<T>& diagram_context) const {
+    const DiagramContext<T>* diagram_context_downcast =
+        dynamic_cast<const DiagramContext<T>*>(&diagram_context);
+    DRAKE_DEMAND(diagram_context_downcast != nullptr);
+    return diagram_context_downcast->GetSubsystemContext(
+        source_subsystem_index_);
+  }
+
+  const OutputPort<T>* const source_output_port_;
+  const SubsystemIndex source_subsystem_index_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -204,7 +204,5 @@ class LeafOutputPort : public OutputPort<T> {
   EvalCallback  eval_function_;
 };
 
-// See diagram.h for DiagramOutputPort.
-
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -26,8 +26,6 @@ namespace systems {
 template <typename T>
 class System;
 
-using OutputPortIndex = TypeSafeIndex<class OutputPortTag>;
-
 /** An %OutputPort belongs to a System and represents the properties of one of
 that System's output ports. %OutputPort objects are assigned OutputPortIndex
 values in the order they are declared; these are unique within a single System.


### PR DESCRIPTION
This is a small cleanup PR to extract DiagramOutputPort from its hiding place, untangle it from Diagram, and generally make it parallel to LeafOutputPort.

The one remaining hidden class in diagram.h is gone in the caching branch, after which diagram.h will contain just Diagram.

Reviewers: DiagramOutputPort code was moved intact to diagram_output_port.h, then mildly modified as @jwnimmer-tri did to LeafOutputPort in #8786 so that it does not depend on Diagram.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8857)
<!-- Reviewable:end -->
