### PR TITLE
Begin to deprecate FixInputPort overload taking a unique_ptr

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -67,12 +67,10 @@ void DefineFrameworkPySemantics(py::module m) {
         m, "Context", GetPyParam<T>())
       .def("get_num_input_ports", &Context<T>::get_num_input_ports)
       .def("FixInputPort",
-           py::overload_cast<int, unique_ptr<BasicVector<T>>>(
+           py::overload_cast<int, const BasicVector<T>&>(
                &Context<T>::FixInputPort),
            py::arg("index"), py::arg("vec"),
-           py_reference_internal,
-           // Keep alive, ownership: `BasicVector` keeps `self` alive.
-           py::keep_alive<3, 1>())
+           py_reference_internal)
       .def("FixInputPort",
            py::overload_cast<int, unique_ptr<AbstractValue>>(
                &Context<T>::FixInputPort),

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -245,25 +245,30 @@ class Context : public ContextBase {
   /// modify the input port's value using the appropriate
   /// FixedInputPortValue method, which will ensure that invalidation
   /// notifications are delivered.
-  FixedInputPortValue& FixInputPort(
-      int index, std::unique_ptr<BasicVector<T>> vec) {
-    return ContextBase::FixInputPort(index,
-       std::make_unique<Value<BasicVector<T>>>(std::move(vec)));
-  }
-
-  /// Same as above method but the vector is passed by const reference instead
-  /// of by unique_ptr.  The port will contain a copy of the `vec` (not retain
-  /// a pointer to the `vec`).
   FixedInputPortValue& FixInputPort(int index, const BasicVector<T>& vec) {
-    return FixInputPort(index, vec.Clone());
+    return ContextBase::FixInputPort(
+        index, std::make_unique<Value<BasicVector<T>>>(vec.Clone()));
   }
 
   /// Same as above method but starts with an Eigen vector whose contents are
   /// used to initialize a BasicVector in the FixedInputPortValue.
   FixedInputPortValue& FixInputPort(
       int index, const Eigen::Ref<const VectorX<T>>& data) {
-    auto vec = std::make_unique<BasicVector<T>>(data);
-    return FixInputPort(index, std::move(vec));
+    return FixInputPort(index, BasicVector<T>(data));
+  }
+
+  /// Same as the above method that takes a `const BasicVector<T>&`, but here
+  /// the vector is passed by unique_ptr instead of by const reference.  The
+  /// caller must not retain any aliases to `vec`; within this method, `vec`
+  /// is cloned and then deleted.
+  /// @note This overload will become deprecated in the future, because it can
+  /// mislead users to believe that they can retain an alias of `vec` to mutate
+  /// the fixed value during a simulation.  Callers should prefer to use one of
+  /// the other overloads instead.
+  FixedInputPortValue& FixInputPort(
+      int index, std::unique_ptr<BasicVector<T>> vec) {
+    DRAKE_THROW_UNLESS(vec.get() != nullptr);
+    return FixInputPort(index, *vec);
   }
 
   // =========================================================================


### PR DESCRIPTION
~This removes the pydrake binding for FixInputPort that takes ownership of a BasicVector, because I don't see any good reason to give pydrake more rope to hang itself with -- since the caller is not allowed to use the vec (via a retained alias) after this call, we should prevent pydrake users from accidentally doing so.~

~I noticed the lack of FixInputPort for a numpy when writing up #8856, and for #7560 I will need the by-const-reference BasicVector overload.~

_Edit: New description, after rebasing:_

This removes from `pydrake` and starts to deprecate the overload of `Context::FixInputPort` that takes ownership of a `BasicVector`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8862)
<!-- Reviewable:end -->
