### PR TITLE
Support setting SNOPT_PATH=git

### DIFF
--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -212,6 +212,7 @@ Using the RobotLocomotion git repository
 
 1. Obtain access to the private RobotLocomotion/snopt GitHub repository.
 2. `Set up SSH access to github.com <https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/>`_.
+3. ``export SNOPT_PATH=git``
 
 The build will attempt to use this mechanism anytime SNOPT is enabled and a
 source archive has not been specified.

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -87,7 +87,9 @@ def _setup_local_archive(repo_ctx, snopt_path):
 
 def _impl(repo_ctx):
     snopt_path = repo_ctx.os.environ.get("SNOPT_PATH", "")
-    if not snopt_path:
+    # For now, an empty path defaults to use git.  In the future, settting
+    # SNOPT_PATH="git" will be required -- an empty path will report an error.
+    if snopt_path in ["git", ""]:
         _setup_git(repo_ctx)
     else:
         _setup_local_archive(repo_ctx, snopt_path)


### PR DESCRIPTION
In support of #8825.  For now, this is the same as the default (i.e., when SNOPT_PATH is unset).  In the future, this will be required to use SNOPT from git.

Relates #8801.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8863)
<!-- Reviewable:end -->
