### PR TITLE
Mark generated named vectors final

### DIFF
--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -198,7 +198,7 @@ def generate_set_to_named_variables(hh, caller_context, fields):
 
 
 DO_CLONE = """
-  %(camel)s<T>* DoClone() const override {
+  %(camel)s<T>* DoClone() const final {
     return new %(camel)s;
   }
 """
@@ -297,7 +297,7 @@ def generate_is_valid(hh, caller_context, fields):
 
 CALC_INEQUALITY_CONSTRAINT_BEGIN = """
   // VectorBase override.
-  void CalcInequalityConstraint(drake::VectorX<T>* value) const override {
+  void CalcInequalityConstraint(drake::VectorX<T>* value) const final {
     value->resize(%(num_constraints)d);
 """
 CALC_INEQUALITY_CONSTRAINT_MIN_VALUE = """
@@ -365,7 +365,7 @@ VECTOR_CLASS_BEGIN = """
 
 /// Specializes BasicVector with specific getters and setters.
 template <typename T>
-class %(camel)s : public drake::systems::BasicVector<T> {
+class %(camel)s final : public drake::systems::BasicVector<T> {
  public:
   /// An abbreviation for our row index constants.
   typedef %(indices)s K;
@@ -411,18 +411,18 @@ TRANSLATOR_CLASS_DECL = """
  * Translates between LCM message objects and VectorBase objects for the
  * %(camel)s type.
  */
-class %(camel)sTranslator
+class %(camel)sTranslator final
     : public drake::systems::lcm::LcmAndVectorBaseTranslator {
  public:
   %(camel)sTranslator()
       : LcmAndVectorBaseTranslator(%(indices)s::kNumCoordinates) {}
   std::unique_ptr<drake::systems::BasicVector<double>> AllocateOutputVector()
-      const override;
+      const final;
   void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
-      drake::systems::VectorBase<double>* vector_base) const override;
+      drake::systems::VectorBase<double>* vector_base) const final;
   void Serialize(double time,
       const drake::systems::VectorBase<double>& vector_base,
-      std::vector<uint8_t>* lcm_message_bytes) const override;
+      std::vector<uint8_t>* lcm_message_bytes) const final;
 };
 """
 

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -38,7 +38,7 @@ struct SampleIndices {
 
 /// Specializes BasicVector with specific getters and setters.
 template <typename T>
-class Sample : public drake::systems::BasicVector<T> {
+class Sample final : public drake::systems::BasicVector<T> {
  public:
   /// An abbreviation for our row index constants.
   typedef SampleIndices K;
@@ -63,7 +63,7 @@ class Sample : public drake::systems::BasicVector<T> {
     this->set_absone(symbolic::Variable("absone"));
   }
 
-  Sample<T>* DoClone() const override { return new Sample; }
+  Sample<T>* DoClone() const final { return new Sample; }
 
   /// @name Getters and Setters
   //@{
@@ -103,7 +103,7 @@ class Sample : public drake::systems::BasicVector<T> {
   }
 
   // VectorBase override.
-  void CalcInequalityConstraint(drake::VectorX<T>* value) const override {
+  void CalcInequalityConstraint(drake::VectorX<T>* value) const final {
     value->resize(3);
     (*value)[0] = x() - T(0.0);
     (*value)[1] = absone() - T(-1.0);

--- a/tools/vector_gen/test/goal/sample_translator.h
+++ b/tools/vector_gen/test/goal/sample_translator.h
@@ -18,19 +18,18 @@ namespace test {
  * Translates between LCM message objects and VectorBase objects for the
  * Sample type.
  */
-class SampleTranslator
+class SampleTranslator final
     : public drake::systems::lcm::LcmAndVectorBaseTranslator {
  public:
   SampleTranslator()
       : LcmAndVectorBaseTranslator(SampleIndices::kNumCoordinates) {}
   std::unique_ptr<drake::systems::BasicVector<double>> AllocateOutputVector()
-      const override;
-  void Deserialize(
-      const void* lcm_message_bytes, int lcm_message_length,
-      drake::systems::VectorBase<double>* vector_base) const override;
+      const final;
+  void Deserialize(const void* lcm_message_bytes, int lcm_message_length,
+                   drake::systems::VectorBase<double>* vector_base) const final;
   void Serialize(double time,
                  const drake::systems::VectorBase<double>& vector_base,
-                 std::vector<uint8_t>* lcm_message_bytes) const override;
+                 std::vector<uint8_t>* lcm_message_bytes) const final;
 };
 
 }  // namespace test


### PR DESCRIPTION
We don't really want users further subclassing these vector types.
Also, I would not be surprised if this was a performance improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8865)
<!-- Reviewable:end -->
