### PR TITLE
Deprecate named_vector implicit default to 0.0

### DIFF
--- a/automotive/bicycle_car_state.named_vector
+++ b/automotive/bicycle_car_state.named_vector
@@ -3,24 +3,30 @@ namespace: "drake::automotive"
 element {
      name: "Psi"  # Must be element 0.
      doc: "yaw angle"
+     default_value: "0.0"
 }
 element {
      name: "Psi_dot"  # Must be element 1.
      doc: "yaw angular rate"
+     default_value: "0.0"
 }
 element {
      name: "beta"
      doc: "slip angle at the center of mass"
+     default_value: "0.0"
 }
 element {
      name: "vel"
      doc: "velocity magnitude"
+     default_value: "0.0"
 }
 element {
      name: "sx"
      doc: "x-position at the center of mass"
+     default_value: "0.0"
 }
 element {
      name: "sy"
      doc: "y-position at the center of mass"
+     default_value: "0.0"
 }

--- a/automotive/trajectory_car_state.named_vector
+++ b/automotive/trajectory_car_state.named_vector
@@ -3,8 +3,10 @@ namespace: "drake::automotive"
 element {
     name: "position"
     doc: "The along-curve position of the vehicle."
+    default_value: "0.0"
 }
 element {
     name: "speed"
     doc: "The along-curve speed of the vehicle."
+    default_value: "0.0"
 }

--- a/examples/geometry_world/bouncing_ball_vector.named_vector
+++ b/examples/geometry_world/bouncing_ball_vector.named_vector
@@ -3,8 +3,10 @@ namespace: "drake::examples::geometry_world::bouncing_ball"
 element {
     name: "z"
     doc: "z"
+    default_value: "0.0"
 }
 element {
     name: "zdot"
     doc: "zdot"
+    default_value: "0.0"
 }

--- a/examples/rod2d/rod2d_state_vector.named_vector
+++ b/examples/rod2d/rod2d_state_vector.named_vector
@@ -4,29 +4,35 @@ element {
      name: "x"
      doc: "Horizontal location of the center-of-mass."
      doc_units: "m"
+     default_value: "0.0"
 }
 element {
      name: "y"
      doc: "Vertical location of the center-of-mass."
      doc_units: "m"
+     default_value: "0.0"
 }
 element {
      name: "theta"
      doc: "Angle of the rod (measured counter-clockwise)."
      doc_units: "rad"
+     default_value: "0.0"
 }
 element {
      name: "xdot"
      doc: "Velocity of the horizontal location of the center-of-mass."
      doc_units: "m/s"
+     default_value: "0.0"
 }
 element {
      name: "ydot"
      doc: "Velocity of the vertical location of the center-of-mass."
      doc_units: "m/s"
+     default_value: "0.0"
 }
 element {
      name: "thetadot"
      doc: "Angular velocity of the rod."
      doc_units: "rad/s"
+     default_value: "0.0"
 }

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator_state_vector.named_vector
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator_state_vector.named_vector
@@ -3,16 +3,20 @@ namespace: "drake::manipulation::schunk_wsg"
 element {
     name: "last_target_position"
     doc: "last_target_position"
+    default_value: "0.0"
 }
 element {
     name: "trajectory_start_time"
     doc: "trajectory_start_time"
+    default_value: "0.0"
 }
 element {
     name: "last_position"
     doc: "last_position"
+    default_value: "0.0"
 }
 element {
     name: "max_force"
     doc: "max_force"
+    default_value: "0.0"
 }

--- a/tools/vector_gen/named_vector.proto
+++ b/tools/vector_gen/named_vector.proto
@@ -27,7 +27,10 @@ message NamedVectorElement {
     // comments.
     optional string doc = 2;
 
-    // An optional default value for this element.
+    // A default value for this element.  Use the magic value "dummy" to
+    // initialize with a drake::dummy_value<T> (i.e., NAN).
+    // (Currently this element is optional and defaults to 0.0 if unspecified,
+    // but in the future it will become required.)
     optional string default_value = 3;
 
     // An optional documentation string stating the units of this element.

--- a/tools/vector_gen/test/goal/lcmt_sample_t.lcm
+++ b/tools/vector_gen/test/goal/lcmt_sample_t.lcm
@@ -10,4 +10,5 @@ struct lcmt_sample_t {
   double x;  // Some coordinate
   double two_word;  // A very long documentation string that will certainly flow across multiple lines of C++
   double absone;  // A signed, normalized value
+  double unset;  // A value that is unset by default
 }

--- a/tools/vector_gen/test/goal/sample.cc
+++ b/tools/vector_gen/test/goal/sample.cc
@@ -11,6 +11,7 @@ const int SampleIndices::kNumCoordinates;
 const int SampleIndices::kX;
 const int SampleIndices::kTwoWord;
 const int SampleIndices::kAbsone;
+const int SampleIndices::kUnset;
 
 const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
   static const drake::never_destroyed<std::vector<std::string>> coordinates(
@@ -18,6 +19,7 @@ const std::vector<std::string>& SampleIndices::GetCoordinateNames() {
           "x",         // BR
           "two_word",  // BR
           "absone",    // BR
+          "unset",     // BR
       });
   return coordinates.access();
 }

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -11,6 +11,7 @@
 #include <Eigen/Core>
 
 #include "drake/common/drake_bool.h"
+#include "drake/common/dummy_value.h"
 #include "drake/common/never_destroyed.h"
 #include "drake/common/symbolic.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -22,12 +23,13 @@ namespace test {
 /// Describes the row indices of a Sample.
 struct SampleIndices {
   /// The total number of rows (coordinates).
-  static const int kNumCoordinates = 3;
+  static const int kNumCoordinates = 4;
 
   // The index of each individual coordinate.
   static const int kX = 0;
   static const int kTwoWord = 1;
   static const int kAbsone = 2;
+  static const int kUnset = 3;
 
   /// Returns a vector containing the names of each coordinate within this
   /// class. The indices within the returned vector matches that of this class.
@@ -47,10 +49,12 @@ class Sample : public drake::systems::BasicVector<T> {
   /// @arg @c x defaults to 42.0 m/s.
   /// @arg @c two_word defaults to 0.0 with unknown units.
   /// @arg @c absone defaults to 0.0 with unknown units.
+  /// @arg @c unset defaults to a dummy value with unknown units.
   Sample() : drake::systems::BasicVector<T>(K::kNumCoordinates) {
     this->set_x(42.0);
     this->set_two_word(0.0);
     this->set_absone(0.0);
+    this->set_unset(drake::dummy_value<T>::get());
   }
 
   /// Create a symbolic::Variable for each element with the known variable
@@ -61,6 +65,7 @@ class Sample : public drake::systems::BasicVector<T> {
     this->set_x(symbolic::Variable("x"));
     this->set_two_word(symbolic::Variable("two_word"));
     this->set_absone(symbolic::Variable("absone"));
+    this->set_unset(symbolic::Variable("unset"));
   }
 
   Sample<T>* DoClone() const override { return new Sample; }
@@ -82,6 +87,9 @@ class Sample : public drake::systems::BasicVector<T> {
   /// @note @c absone has a limited domain of [-1.0, 1.0].
   const T& absone() const { return this->GetAtIndex(K::kAbsone); }
   void set_absone(const T& absone) { this->SetAtIndex(K::kAbsone, absone); }
+  /// A value that is unset by default
+  const T& unset() const { return this->GetAtIndex(K::kUnset); }
+  void set_unset(const T& unset) { this->SetAtIndex(K::kUnset, unset); }
   //@}
 
   /// See SampleIndices::GetCoordinateNames().
@@ -99,6 +107,7 @@ class Sample : public drake::systems::BasicVector<T> {
     result = result && !isnan(absone());
     result = result && (absone() >= T(-1.0));
     result = result && (absone() <= T(1.0));
+    result = result && !isnan(unset());
     return result;
   }
 

--- a/tools/vector_gen/test/goal/sample_translator.cc
+++ b/tools/vector_gen/test/goal/sample_translator.cc
@@ -26,6 +26,7 @@ void SampleTranslator::Serialize(
   message.x = vector->x();
   message.two_word = vector->two_word();
   message.absone = vector->absone();
+  message.unset = vector->unset();
   const int lcm_message_length = message.getEncodedSize();
   lcm_message_bytes->resize(lcm_message_length);
   message.encode(lcm_message_bytes->data(), 0, lcm_message_length);
@@ -46,6 +47,7 @@ void SampleTranslator::Deserialize(
   my_vector->set_x(message.x);
   my_vector->set_two_word(message.two_word);
   my_vector->set_absone(message.absone);
+  my_vector->set_unset(message.unset);
 }
 
 }  // namespace test

--- a/tools/vector_gen/test/sample.named_vector
+++ b/tools/vector_gen/test/sample.named_vector
@@ -10,10 +10,17 @@ element {
 element {
     name: "two_word"
     doc: "A very long documentation string that will certainly flow across multiple lines of C++"
+    default_value: "0.0"
 }
 element {
     name: "absone"
     doc: "A signed, normalized value"
     min_value: "-1.0"
     max_value: "1.0"
+    default_value: "0.0"
+}
+element {
+    name: "unset"
+    doc: "A value that is unset by default"
+    default_value: "dummy"
 }

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -16,10 +16,11 @@ namespace {
 // to touch every method as an API sanity check, so that we are reminded in
 // case we change the generated API without realizing it.
 GTEST_TEST(SampleTest, SimpleCoverage) {
-  EXPECT_EQ(SampleIndices::kNumCoordinates, 3);
+  EXPECT_EQ(SampleIndices::kNumCoordinates, 4);
   EXPECT_EQ(SampleIndices::kX, 0);
   EXPECT_EQ(SampleIndices::kTwoWord, 1);
   EXPECT_EQ(SampleIndices::kAbsone, 2);
+  EXPECT_EQ(SampleIndices::kUnset, 3);
 
   // The device under test.
   Sample<double> dut;
@@ -46,7 +47,9 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
 
   // Coordinate names.
   const std::vector<std::string>& coordinate_names = dut.GetCoordinateNames();
-  const std::vector<std::string> expected_names = {"x", "two_word", "absone"};
+  const std::vector<std::string> expected_names = {
+    "x", "two_word", "absone", "unset",
+  };
   ASSERT_EQ(coordinate_names.size(), expected_names.size());
   for (int i = 0; i < dut.size(); ++i) {
     EXPECT_EQ(coordinate_names.at(i), expected_names.at(i));
@@ -55,12 +58,16 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
 
 // Cover Simple<double>::IsValid.
 GTEST_TEST(SampleTest, IsValid) {
+  // N.B. Sample<T>.unset is an invalid value by default.
   Sample<double> dummy1;
+  EXPECT_FALSE(ExtractBoolOrThrow(dummy1.IsValid()));
+  dummy1.set_unset(0.0);
   EXPECT_TRUE(ExtractBoolOrThrow(dummy1.IsValid()));
   dummy1.set_x(std::numeric_limits<double>::quiet_NaN());
   EXPECT_FALSE(ExtractBoolOrThrow(dummy1.IsValid()));
 
   Sample<double> dummy2;
+  dummy2.set_unset(0.0);
   EXPECT_TRUE(ExtractBoolOrThrow(dummy2.IsValid()));
   dummy2.set_two_word(std::numeric_limits<double>::quiet_NaN());
   EXPECT_FALSE(ExtractBoolOrThrow(dummy2.IsValid()));
@@ -70,6 +77,7 @@ GTEST_TEST(SampleTest, IsValid) {
 GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
   // A NaN in the AutoDiffScalar::value() makes us invalid.
   Sample<AutoDiffXd> dut;
+  dut.set_unset(0.0);  // N.B. Sample<T>.unset is an invalid value by default.
   EXPECT_TRUE(ExtractBoolOrThrow(dut.IsValid()));
   dut.set_x(std::numeric_limits<double>::quiet_NaN());
   EXPECT_FALSE(ExtractBoolOrThrow(dut.IsValid()));
@@ -100,6 +108,7 @@ GTEST_TEST(SampleTest, SymbolicIsValid) {
       !isnan(dut.x()) &&
       !isnan(dut.two_word()) &&
       !isnan(dut.absone()) &&
+      !isnan(dut.unset()) &&
       (dut.x() >= 0.0) &&
       (dut.absone() >= -1.0) &&
       (dut.absone() <= 1.0);

--- a/tools/vector_gen/vector_gen.bzl
+++ b/tools/vector_gen/vector_gen.bzl
@@ -147,6 +147,7 @@ def drake_cc_vector_gen(
         hdrs = outs.hdrs,
         deps = [drake_workspace_name + x for x in [
             "//systems/framework:vector",
+            "//common:dummy_value",
             "//common:essential",
             "//common:symbolic",
         ]]


### PR DESCRIPTION
Add support for default_value choice of "dummy", for any vectors that wish to have NAN-like defaults.

Update all current named_vector declarations with implicit defaults to explicitly state 0.0 now.

This is the first half of the fix for #8560.  (The second half is just to remove the deprecated implicit default code.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8866)
<!-- Reviewable:end -->
