### PR TITLE
Make Doxygen fast again

### DIFF
--- a/doc/Doxyfile_CXX.in
+++ b/doc/Doxyfile_CXX.in
@@ -28,8 +28,8 @@ ABBREVIATE_BRIEF       = a \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = "@DRAKE_WORKSPACE_ROOT@"
-STRIP_FROM_INC_PATH    = "@DRAKE_WORKSPACE_ROOT@"
+STRIP_FROM_PATH        = "@INPUT_ROOT@"
+STRIP_FROM_INC_PATH    = "@INPUT_ROOT@"
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = YES
 QT_AUTOBRIEF           = NO
@@ -96,7 +96,7 @@ SHOW_USED_FILES        = YES
 SHOW_FILES             = YES
 SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    =
-LAYOUT_FILE            = "@DRAKE_WORKSPACE_ROOT@/doc/DoxygenLayout.xml"
+LAYOUT_FILE            = "@INPUT_ROOT@/drake/doc/DoxygenLayout.xml"
 CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
@@ -112,7 +112,7 @@ WARN_LOGFILE           = "@BINARY_DIR@/doxygen_cxx.log"
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = "@DRAKE_WORKSPACE_ROOT@"
+INPUT                  = "@INPUT_ROOT@"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -125,16 +125,14 @@ FILE_PATTERNS          = *.c \
                          *.hpp \
                          *.h++
 RECURSIVE              = YES
-EXCLUDE                = "@DRAKE_WORKSPACE_ROOT@/build" \
-                         "@DRAKE_WORKSPACE_ROOT@/third_party"
+EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = "@DRAKE_WORKSPACE_ROOT@/bazel-*" \
-                         "@DRAKE_WORKSPACE_ROOT@/*/dev/*"
+EXCLUDE_PATTERNS       = "@INPUT_ROOT@/*/dev/*"
 EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = "@DRAKE_WORKSPACE_ROOT@"
+IMAGE_PATH             = "@INPUT_ROOT@/drake"
 INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO

--- a/doc/doxygen.py
+++ b/doc/doxygen.py
@@ -6,13 +6,14 @@
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 
 from collections import OrderedDict
 from os.path import dirname
 
-def _get_drake_distro():
+def _get_drake_workspace():
     """Find and return the path to the drake workspace."""
 
     result = dirname(dirname(os.path.abspath(sys.argv[0])))
@@ -30,13 +31,61 @@ def _run_doxygen(args):
     doxygen = subprocess.check_output(["which", "doxygen"], env=env).strip()
     dot = subprocess.check_output(["which", "dot"], env=env).strip()
 
-    # Compute the definitions dict needed by Doxygen_CXX.in.
-    drake_distro = _get_drake_distro()
-    binary_dir = os.path.join(drake_distro, "build/drake/doc")
-    if not os.path.exists(binary_dir):
-        os.makedirs(binary_dir)
+    # Prepare the input and output folders.  We will copy the requested input
+    # file(s) into a temporary scratch directory, so that Doxygen doesn't root
+    # around in the drake_workspace (which is extremely slow).
+    drake_workspace = _get_drake_workspace()
+    binary_dir = os.path.join(drake_workspace, "build/drake/doc")
+    input_root = os.path.join(binary_dir, "input")
+    if os.path.exists(input_root):
+        shutil.rmtree(input_root)
+    source_root = os.path.join(input_root, "drake")
+    os.makedirs(source_root)
+    shutil.copytree(
+        os.path.join(drake_workspace, "doc"),
+        os.path.join(source_root, "doc"))
+    inputs = args.inputs
+    if not inputs:
+        # No inputs were specified; use everything.
+        inputs = [
+            os.path.join(drake_workspace, x)
+            for x in os.listdir(drake_workspace)
+        ]
+    for x in inputs:
+        # Find the workspace-relative pathname.
+        abs_x = os.path.abspath(x)
+        rel_x = os.path.relpath(abs_x, drake_workspace)
+        assert not rel_x.startswith(".."), rel_x
+
+        # Skip bad things.
+        if rel_x.startswith("."): continue
+        if rel_x.startswith("bazel"): continue
+        if rel_x.startswith("build"): continue
+        if rel_x.startswith("doc"): continue  # N.B. Done above.
+        if rel_x.startswith("third_party"): continue
+
+        # Copy the workspace files into the input scratch dir.
+        target = os.path.join(source_root, rel_x)
+        if os.path.isfile(abs_x):
+            parent = os.path.dirname(target)
+            if not os.path.exists(parent):
+                os.makedirs(parent)
+            shutil.copy2(abs_x, target)
+        else:
+            assert os.path.isdir(abs_x)
+            # N.B. This won't work if the user redundantly requested both a
+            # parent directory and one of its children.  For now, the answer is
+            # just "don't do that".
+            try:
+                shutil.copytree(abs_x, target)
+            except OSError, e:
+                print(str(e) + " during copytree.  Perhaps you tried to input "
+                      "both a parent directory and its child?")
+                sys.exit(1)
+
+    # Populate the definitions dict needed by Doxygen_CXX.in.
     definitions = OrderedDict()
-    definitions["DRAKE_WORKSPACE_ROOT"] = drake_distro
+    definitions["INPUT_ROOT"] = input_root
     definitions["BINARY_DIR"] = binary_dir
     if args.quick:
         definitions["DOXYGEN_DOT_FOUND"] = "NO"
@@ -48,11 +97,11 @@ def _run_doxygen(args):
                        for key, value in definitions.iteritems()]
 
     # Create Doxyfile_CXX.
-    in_filename = os.path.join(drake_distro, "doc/Doxyfile_CXX.in")
-    doxyfile = os.path.join(drake_distro, "build/drake/doc/Doxyfile_CXX")
+    in_filename = os.path.join(drake_workspace, "doc/Doxyfile_CXX.in")
+    doxyfile = os.path.join(binary_dir, "Doxyfile_CXX")
     subprocess.check_call(
         [os.path.join(
-            _get_drake_distro(), "tools/workspace/cmake_configure_file.py"),
+            drake_workspace, "tools/workspace/cmake_configure_file.py"),
          "--input", in_filename,
          "--output", doxyfile,
          ] + definition_args)
@@ -62,6 +111,7 @@ def _run_doxygen(args):
     print "Building C++ Doxygen documentation...",
     sys.stdout.flush()
     subprocess.check_call([doxygen, doxyfile], cwd=binary_dir)
+    shutil.rmtree(input_root)  # Don't let Bazel find the build/input copy.
     print "done"
     print "See file://%s/doxygen_cxx/html/index.html" % binary_dir
 
@@ -72,6 +122,11 @@ def main():
     parser.add_argument(
         '--quick', action='store_true', default=False,
         help="Disable slow features (e.g., all graphs)")
+    parser.add_argument(
+        'inputs', nargs='*',
+        help="Process only these files and/or directories; "
+        "most useful using shell globbing, e.g., "
+        "doxygen.py --quick systems/framework/*leaf*.h")
     args = parser.parse_args()
     _run_doxygen(args)
 


### PR DESCRIPTION
Change the way input files are handled.  Previously, we just pointed the tool at our workspace (git) root.  However, in this case Doxygen will recursively scan all of the bazel folders for IMAGE_PATH files, even though we have excluded the bazel folders as sources.  In local testing, this speeds up a --quick build from 93s to 23s.

Add an option to run over only certain input files or directories.  When specifying, e.g., systems/framework vs the whole tree, in local testing this speeds up a --quick build from 23s to 2s.

Fixes #8503.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8867)
<!-- Reviewable:end -->
