### PR TITLE
Expose RoadCurve settings in Multilane YAMLs

### DIFF
--- a/automotive/maliput/multilane/arc_road_curve.h
+++ b/automotive/maliput/multilane/arc_road_curve.h
@@ -40,21 +40,19 @@ class ArcRoadCurve : public RoadCurve {
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
   /// @throw std::runtime_error if @p radius is not a positive number.
+  /// @throw std::runtime_error if @p linear_tolerance is not a positive number.
+  /// @throw std::runtime_error if @p scale_length is not a positive number.
   explicit ArcRoadCurve(
       const Vector2<double>& center, double radius,
       double theta0, double d_theta,
       const CubicPolynomial& elevation,
       const CubicPolynomial& superelevation,
-      double linear_tolerance = 0.01, double scale_length = 1.0,
-      const ComputationPolicy computation_policy =
-            ComputationPolicy::kPreferAccuracy)
+      double linear_tolerance, double scale_length,
+      ComputationPolicy computation_policy)
       : RoadCurve(linear_tolerance, scale_length,
                   elevation, superelevation,
                   computation_policy),
         center_(center), radius_(radius), theta0_(theta0), d_theta_(d_theta) {
-    // TODO(hidmic): Remove default values in trailing arguments, which were
-    // added in the first place to defer the need to propagate changes upwards
-    // in the class hierarchy.
     DRAKE_THROW_UNLESS(radius > 0.0);
   }
 

--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -25,11 +25,14 @@ std::ostream& operator<<(std::ostream& out, const LaneLayout& lane_layout) {
 }
 
 Builder::Builder(double lane_width, const api::HBounds& elevation_bounds,
-                 double linear_tolerance, double angular_tolerance)
+                 double linear_tolerance, double angular_tolerance,
+                 double scale_length, ComputationPolicy computation_policy)
     : lane_width_(lane_width),
       elevation_bounds_(elevation_bounds),
       linear_tolerance_(linear_tolerance),
-      angular_tolerance_(angular_tolerance) {
+      angular_tolerance_(angular_tolerance),
+      scale_length_(scale_length),
+      computation_policy_(computation_policy) {
   DRAKE_DEMAND(lane_width_ >= 0.);
   DRAKE_DEMAND(linear_tolerance_ >= 0.);
   DRAKE_DEMAND(angular_tolerance_ >= 0.);
@@ -48,7 +51,8 @@ const Connection* Builder::Connect(const std::string& id,
   connections_.push_back(std::make_unique<Connection>(
       id, start_spec.endpoint(), end_spec.endpoint_z(), lane_layout.num_lanes(),
       lane_layout.ref_r0(), lane_width_, lane_layout.left_shoulder(),
-      lane_layout.right_shoulder(), line_offset.length()));
+      lane_layout.right_shoulder(), line_offset.length(), linear_tolerance_,
+      scale_length_, computation_policy_));
   return connections_.back().get();
 }
 
@@ -65,7 +69,8 @@ const Connection* Builder::Connect(const std::string& id,
   connections_.push_back(std::make_unique<Connection>(
       id, start_spec.endpoint(), end_spec.endpoint_z(), lane_layout.num_lanes(),
       lane_layout.ref_r0(), lane_width_, lane_layout.left_shoulder(),
-      lane_layout.right_shoulder(), arc_offset));
+      lane_layout.right_shoulder(), arc_offset, linear_tolerance_,
+      scale_length_, computation_policy_));
   return connections_.back().get();
 }
 

--- a/automotive/maliput/multilane/circuit.yaml
+++ b/automotive/maliput/multilane/circuit.yaml
@@ -7,8 +7,10 @@ maliput_multilane_builder:
   left_shoulder: 1
   right_shoulder: 1.5
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: 0.01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   points:
     a:
       xypoint: [0, 0, 0]

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -229,10 +229,17 @@ class Connection {
   /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
   /// and left side of the first and last lanes of the Segment. They will be
   /// added to Segment's bounds and must be greater or equal to zero.
+  ///
+  /// `scale_length` constrains the maximum level of detail captured by the
+  /// underlying RoadCurve.
+  ///
+  /// `linear_tolerance` and `computation_policy` set the efficiency vs. speed
+  /// balance for computations in the underlying RoadCurve.
   Connection(const std::string& id, const Endpoint& start,
              const EndpointZ& end_z, int num_lanes, double r0,
              double lane_width, double left_shoulder, double right_shoulder,
-             double line_length);
+             double line_length, double linear_tolerance, double scale_length,
+             ComputationPolicy computation_policy);
 
   /// Constructs an arc-segment connection.
   ///
@@ -253,10 +260,20 @@ class Connection {
   /// `left_shoulder` and `right_shoulder` are extra spaces added to the right
   /// and left side of the first and last lanes of the Segment. They will be
   /// added to Segment's bounds and must be greater or equal to zero.
+  ///
+  /// `linear_tolerance` applies to all RoadCurve-level computations. It must be
+  /// positive.
+  ///
+  /// `scale_length` constrains the maximum level of detail captured by the
+  /// underlying RoadCurve. It must be positive.
+  ///
+  /// `computation_policy` sets the speed vs. accuracy for computations in the
+  /// underlying RoadCurve.
   Connection(const std::string& id, const Endpoint& start,
              const EndpointZ& end_z, int num_lanes, double r0,
              double lane_width, double left_shoulder, double right_shoulder,
-             const ArcOffset& arc_offset);
+             const ArcOffset& arc_offset, double linear_tolerance,
+             double scale_length, ComputationPolicy computation_policy);
 
   /// Returns the geometric type of the path.
   Type type() const { return type_; }
@@ -321,6 +338,21 @@ class Connection {
   /// Segment.
   double r_max() const { return r_max_; }
 
+  /// Returns the linear tolerance, in meters, that applies to RoadCurve
+  /// instances as constructed by this Connection. Refer to RoadCurve class
+  /// documentation for further details.
+  double linear_tolerance() const { return linear_tolerance_; }
+
+  /// Returns the scale length, in meters, that applies to RoadCurve instances
+  /// as constructed by this Connection. Refer to RoadCurve class documentation
+  /// for further details.
+  double scale_length() const { return scale_length_; }
+
+  /// Returns the computation policy that applies to RoadCurve instances as
+  /// constructed by this Connection. Refer to RoadCurve class documentation
+  /// for further details.
+  ComputationPolicy computation_policy() const { return computation_policy_; }
+
   /// Returns an Endpoint describing the start of the `lane_index` lane.
   Endpoint LaneStart(int lane_index) const;
 
@@ -342,6 +374,9 @@ class Connection {
   const double right_shoulder_{};
   const double r_min_{};
   const double r_max_{};
+  const double linear_tolerance_{};
+  const double scale_length_{};
+  const ComputationPolicy computation_policy_;
   std::unique_ptr<RoadCurve> road_curve_;
   // Bits specific to type_ == kLine:
   double line_length_{};

--- a/automotive/maliput/multilane/double_ring.yaml
+++ b/automotive/maliput/multilane/double_ring.yaml
@@ -7,8 +7,10 @@ maliput_multilane_builder:
   right_shoulder: 2
   left_shoulder: 2
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: 0.01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   points:
     start:
       xypoint: [0, 0, 45]  # x,y, heading

--- a/automotive/maliput/multilane/fig8.yaml
+++ b/automotive/maliput/multilane/fig8.yaml
@@ -5,8 +5,10 @@ maliput_multilane_builder:
   id: "fig8"
   lane_width: 6
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: 0.01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   right_shoulder: 5
   left_shoulder: 5
   points:

--- a/automotive/maliput/multilane/helix.yaml
+++ b/automotive/maliput/multilane/helix.yaml
@@ -5,8 +5,10 @@ maliput_multilane_builder:
   id: "helix"
   lane_width: 4
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: 0.01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   right_shoulder: 2
   left_shoulder: 2
   points:

--- a/automotive/maliput/multilane/line_road_curve.h
+++ b/automotive/maliput/multilane/line_road_curve.h
@@ -38,20 +38,18 @@ class LineRoadCurve : public RoadCurve {
   /// @param computation_policy Policy to guide all computations. If geared
   /// towards speed, computations will make use of analytical expressions even
   /// if not actually correct for the curve as specified.
+  /// @throw std::runtime_error if @p linear_tolerance is not a positive number.
+  /// @throw std::runtime_error if @p scale_length is not a positive number.
   explicit LineRoadCurve(
       const Vector2<double>& xy0, const Vector2<double>& dxy,
       const CubicPolynomial& elevation,
       const CubicPolynomial& superelevation,
-      double linear_tolerance = 0.01, double scale_length = 1.0,
-      const ComputationPolicy computation_policy =
-         ComputationPolicy::kPreferAccuracy)
+      double linear_tolerance, double scale_length,
+      ComputationPolicy computation_policy)
       : RoadCurve(linear_tolerance, scale_length,
                   elevation, superelevation,
                   computation_policy),
         p0_(xy0), dp_(dxy), heading_(std::atan2(dxy.y(), dxy.x())) {
-    // TODO(hidmic): Remove default values in trailing arguments, which were
-    // added in the first place to defer the need to propagate changes upwards
-    // in the class hierarchy.
     DRAKE_DEMAND(dxy.norm() > kMinimumNorm);
   }
 

--- a/automotive/maliput/multilane/ring.yaml
+++ b/automotive/maliput/multilane/ring.yaml
@@ -5,8 +5,10 @@ maliput_multilane_builder:
   id: "ring"
   lane_width: 6
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: .01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   right_shoulder: 5
   left_shoulder: 5
   points:

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -79,10 +79,11 @@ struct InverseArcLengthODEFunction {
 
 }  // namespace
 
+
 RoadCurve::RoadCurve(double linear_tolerance, double scale_length,
                      const CubicPolynomial& elevation,
                      const CubicPolynomial& superelevation,
-                     const ComputationPolicy computation_policy)
+                     ComputationPolicy computation_policy)
     : scale_length_(scale_length),
       linear_tolerance_(linear_tolerance),
       elevation_(elevation),

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -300,7 +300,7 @@ class RoadCurve {
   RoadCurve(double linear_tolerance, double scale_length,
             const CubicPolynomial& elevation,
             const CubicPolynomial& superelevation,
-            const ComputationPolicy computation_policy);
+            ComputationPolicy computation_policy);
 
  private:
   // Computes the minimum radius of curvature along a parallel curve at a

--- a/automotive/maliput/multilane/segment.h
+++ b/automotive/maliput/multilane/segment.h
@@ -6,6 +6,7 @@
 
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
 #include "drake/automotive/maliput/multilane/cubic_polynomial.h"
 #include "drake/automotive/maliput/multilane/lane.h"
@@ -53,6 +54,8 @@ class Segment : public api::Segment {
     DRAKE_DEMAND(road_curve_.get() != nullptr);
     DRAKE_DEMAND(r_min <= r_max);
     DRAKE_DEMAND(road_curve_->IsValid(r_min_, r_max_, elevation_bounds_));
+    DRAKE_DEMAND(junction_->road_geometry()->linear_tolerance() ==
+                 road_curve_->linear_tolerance());
   }
 
   /// Creates a new Lane object.

--- a/automotive/maliput/multilane/sidewinder.yaml
+++ b/automotive/maliput/multilane/sidewinder.yaml
@@ -7,8 +7,10 @@ maliput_multilane_builder:
   left_shoulder: 5
   right_shoulder: 5
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: .01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   points:
     start:
       xypoint: [0, 0, 0]  # x,y, heading

--- a/automotive/maliput/multilane/tee_intersection.yaml
+++ b/automotive/maliput/multilane/tee_intersection.yaml
@@ -7,8 +7,10 @@ maliput_multilane_builder:
   right_shoulder: 2
   left_shoulder: 2
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: 0.01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   points:
     south_bp:
       xypoint: [0, -10, -90]  # x,y, heading

--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -21,6 +21,12 @@ class MultilaneArcRoadCurveTest : public ::testing::Test {
   const double kTheta1{3.0 * M_PI / 4.0};
   const double kDTheta{kTheta1 - kTheta0};
   const CubicPolynomial zp;
+  const double kZeroTolerance{0.};
+  const double kLinearTolerance{0.01};
+  const double kZeroScaleLength{0.};
+  const double kScaleLength{1.};
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   const double kRMin{-0.5 * kRadius};
   const double kRMax{ 0.5 * kRadius};
   const api::HBounds height_bounds{0.0, 10.0};
@@ -30,14 +36,39 @@ class MultilaneArcRoadCurveTest : public ::testing::Test {
 
 // Checks ArcRoadCurve constructor constraints.
 TEST_F(MultilaneArcRoadCurveTest, ConstructorTest) {
-  EXPECT_THROW(ArcRoadCurve(kCenter, -kRadius, kTheta0, kDTheta, zp, zp),
+  EXPECT_THROW(ArcRoadCurve(kCenter, -kRadius, kTheta0, kDTheta, zp, zp,
+                            kLinearTolerance, kScaleLength,
+                            kComputationPolicy),
                std::runtime_error);
-  EXPECT_NO_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp));
+
+  EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                            kZeroTolerance, kScaleLength, kComputationPolicy),
+               std::runtime_error);
+
+  EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                            -kLinearTolerance, kScaleLength,
+                            kComputationPolicy),
+               std::runtime_error);
+
+  EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                            kLinearTolerance, -kScaleLength,
+                            kComputationPolicy),
+               std::runtime_error);
+
+  EXPECT_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                            kLinearTolerance, kZeroScaleLength,
+                            kComputationPolicy),
+               std::runtime_error);
+
+  EXPECT_NO_THROW(ArcRoadCurve(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                               kLinearTolerance, kScaleLength,
+                               kComputationPolicy));
 }
 
 // Checks arc reference curve interpolations, derivatives, and lengths.
 TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
-  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                         kLinearTolerance, kScaleLength, kComputationPolicy);
   // Checks the length.
   EXPECT_NEAR(dut.p_scale(), kDTheta * kRadius, kVeryExact);
   EXPECT_NEAR(dut.CalcSFromP(1., kNoOffset), kDTheta * kRadius, kVeryExact);
@@ -102,10 +133,15 @@ GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
   const CubicPolynomial constant_superelevation(M_PI / 4.0, 0.0, 0.0, 0.0);
   const api::HBounds height_bounds(0.0, 10.0);
   const CubicPolynomial zp;
+  const double kLinearTolerance{0.01};
+  const double kScaleLength{1.};
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
 
   // Checks over a flat arc surface.
   const ArcRoadCurve flat_arc_geometry(kZeroCenter, kRadius, kInitTheta,
-                                       kDTheta1, zp, zp);
+                                       kDTheta1, zp, zp, kLinearTolerance,
+                                       kScaleLength, kComputationPolicy);
   EXPECT_TRUE(
       flat_arc_geometry.IsValid(-0.5 * kRadius, 0.5 * kRadius, height_bounds));
   EXPECT_TRUE(flat_arc_geometry.IsValid(-0.25 * kRadius, 0.25 * kRadius,
@@ -120,7 +156,8 @@ GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
 
   // Checks over a right handed cone.
   const ArcRoadCurve right_handed_cone_geometry(
-      kZeroCenter, kRadius, kInitTheta, kDTheta1, zp, constant_superelevation);
+      kZeroCenter, kRadius, kInitTheta, kDTheta1, zp, constant_superelevation,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   EXPECT_TRUE(right_handed_cone_geometry.IsValid(-0.5 * kRadius, 0.5 * kRadius,
                                                  height_bounds));
   EXPECT_TRUE(right_handed_cone_geometry.IsValid(
@@ -136,7 +173,8 @@ GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
 
   // Checks over a left handed cone.
   const ArcRoadCurve left_handed_cone_geometry(
-      kZeroCenter, kRadius, kInitTheta, kDTheta2, zp, constant_superelevation);
+      kZeroCenter, kRadius, kInitTheta, kDTheta2, zp, constant_superelevation,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   EXPECT_TRUE(left_handed_cone_geometry.IsValid(-0.5 * kRadius, 0.5 * kRadius,
                                                 height_bounds));
   EXPECT_TRUE(left_handed_cone_geometry.IsValid(-0.25 * kRadius, 0.25 * kRadius,
@@ -154,7 +192,8 @@ GTEST_TEST(MultilaneArcRoadCurve, IsValidTest) {
 // Checks the ToCurve frame coordinate conversion for different points in world
 // coordinates.
 TEST_F(MultilaneArcRoadCurveTest, ToCurveFrameTest) {
-  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                         kLinearTolerance, kScaleLength, kComputationPolicy);
   // Checks points over the composed curve.
   EXPECT_TRUE(CompareMatrices(
       dut.ToCurveFrame(
@@ -206,7 +245,9 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const std::vector<double> p_vector{0., 0.1, 0.2, 0.5, 0.7, 1.0};
 
   // Checks for flat ArcRoadCurve.
-  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                              kLinearTolerance, kScaleLength,
+                              kComputationPolicy);
   EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kRadius * kDTheta);
   // Checks that functions throw when lateral offset is exceeded.
   EXPECT_THROW(flat_dut.CalcPFromS(0., kRadius), std::runtime_error);
@@ -230,7 +271,8 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const double slope = 10. / (kRadius * kDTheta);
   const CubicPolynomial linear_elevation(10., slope, 0., 0.);
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
-                                  linear_elevation, zp);
+                                  linear_elevation, zp, kLinearTolerance,
+                                  kScaleLength, kComputationPolicy);
   EXPECT_DOUBLE_EQ(elevated_dut.p_scale(), kRadius * kDTheta);
   // Evaluates inverse function and path length integral for different values of
   // p and r lateral offsets.
@@ -251,7 +293,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
   const std::vector<double> h_vector{-5., 0., 5.};
 
   // Checks for a flat curve.
-  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                              kLinearTolerance, kScaleLength,
+                              kComputationPolicy);
   const Vector3<double> kGeoCenter(kCenter.x(), kCenter.y(), 0.);
   for (double p : p_vector) {
     for (double r : r_vector) {
@@ -274,7 +318,8 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
   const CubicPolynomial linear_elevation(kElevationOffset, kElevationSlope, 0.,
                                          0.);
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
-                                  linear_elevation, zp);
+                                  linear_elevation, zp, kLinearTolerance,
+                                  kScaleLength, kComputationPolicy);
   // Computes the rotation along the RoadCurve.
   const Vector3<double> z_vector(0., 0., kRadius * kDTheta);
   const double kZeroRoll{0.};
@@ -301,7 +346,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
   const CubicPolynomial constant_offset_superelevation(
       kSuperelevationOffset / (kRadius * kDTheta), 0., 0., 0.);
   const ArcRoadCurve superelevated_dut(kCenter, kRadius, kTheta0, kDTheta, zp,
-                                       constant_offset_superelevation);
+                                       constant_offset_superelevation,
+                                       kLinearTolerance, kScaleLength,
+                                       kComputationPolicy);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {
@@ -346,7 +393,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
   };
 
   // Checks for a flat curve.
-  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                              kLinearTolerance, kScaleLength,
+                              kComputationPolicy);
   const Vector3<double> kGeoCenter(kCenter.x(), kCenter.y(), 0.);
   for (double p : p_vector) {
     for (double r : r_vector) {
@@ -372,7 +421,8 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
   const CubicPolynomial linear_elevation(kElevationOffset, kElevationSlope, 0.,
                                          0.);
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
-                                  linear_elevation, zp);
+                                  linear_elevation, zp, kLinearTolerance,
+                                  kScaleLength, kComputationPolicy);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {
@@ -396,7 +446,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
   const CubicPolynomial constant_offset_superelevation(
       kSuperelevationOffset / (kRadius * kDTheta), 0., 0., 0.);
   const ArcRoadCurve superelevated_dut(kCenter, kRadius, kTheta0, kDTheta, zp,
-                                       constant_offset_superelevation);
+                                       constant_offset_superelevation,
+                                       kLinearTolerance, kScaleLength,
+                                       kComputationPolicy);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {
@@ -431,7 +483,9 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
   const double kZeroPitch{0.};
   // Checks for a flat curve.
   {
-    const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+    const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+                                kLinearTolerance, kScaleLength,
+                                kComputationPolicy);
 
     // Computes the rotation matrix and r versor at different p values and
     // checks versor direction and pitch and yaw angles which are not constants.
@@ -479,7 +533,8 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     const CubicPolynomial linear_elevation(kElevationOffset, kElevationSlope,
                                            0., 0.);
     const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
-                                    linear_elevation, zp);
+                                    linear_elevation, zp, kLinearTolerance,
+                                    kScaleLength, kComputationPolicy);
 
     // Computes the rotation matrix and r versor at different p values and
     // checks versor direction and pitch and yaw angles which are not constants.
@@ -525,7 +580,9 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     const CubicPolynomial constant_offset_superelevation(
         kSuperelevationOffset / (kRadius * kDTheta), 0., 0., 0.);
     const ArcRoadCurve superelevated_dut(kCenter, kRadius, kTheta0, kDTheta, zp,
-                                         constant_offset_superelevation);
+                                         constant_offset_superelevation,
+                                         kLinearTolerance, kScaleLength,
+                                         kComputationPolicy);
 
     // Computes the rotation matrix and r versor at different p values and
     // checks versor direction and pitch and yaw angles which are not constants.
@@ -583,7 +640,9 @@ TEST_F(MultilaneArcRoadCurveTest, Orientation) {
   };
 
   // Checks for a flat curve.
-  const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+  const ArcRoadCurve flat_dut(
+      kCenter, kRadius, kTheta0, kDTheta, zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   const double kZeroRoll{0.};
   const double kZeroPitch{0.};
   for (double p : p_vector) {
@@ -604,7 +663,8 @@ TEST_F(MultilaneArcRoadCurveTest, Orientation) {
   const CubicPolynomial linear_elevation(kElevationOffset, kElevationSlope, 0.,
                                          0.);
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
-                                  linear_elevation, zp);
+                                  linear_elevation, zp, kLinearTolerance,
+                                  kScaleLength, kComputationPolicy);
   // Checks that the roll angle remains zero for all the points.
   for (double p : p_vector) {
     for (double r : r_vector) {
@@ -637,7 +697,9 @@ TEST_F(MultilaneArcRoadCurveTest, Orientation) {
   const CubicPolynomial constant_offset_superelevation(
       kSuperelevationOffset / (kRadius * kDTheta), 0., 0., 0.);
   const ArcRoadCurve superelevated_dut(kCenter, kRadius, kTheta0, kDTheta, zp,
-                                       constant_offset_superelevation);
+                                       constant_offset_superelevation,
+                                       kLinearTolerance, kScaleLength,
+                                       kComputationPolicy);
   for (double p : p_vector) {
     for (double r : r_vector) {
       for (double h : h_vector) {

--- a/automotive/maliput/multilane/test/multilane_lanes_test.cc
+++ b/automotive/maliput/multilane/test/multilane_lanes_test.cc
@@ -43,6 +43,9 @@ class MultilaneLanesParamTest : public ::testing::TestWithParam<double> {
     r0 = this->GetParam();
   }
 
+  const double kScaleLength{1.};
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   const CubicPolynomial zp{0., 0., 0., 0.};
   const double kHalfWidth{10.};
   const double kMaxHeight{5.};
@@ -67,7 +70,8 @@ TEST_P(MultilaneLanesParamTest, FlatLineLane) {
   RoadGeometry rg(api::RoadGeometryId{"apple"},
                   kLinearTolerance, kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<LineRoadCurve>(
-      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp);
+      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   const Vector3<double> s_vector = Vector3<double>(100., 50., 0.).normalized();
   const Vector3<double> r_vector = Vector3<double>(-50, 100., 0.).normalized();
   const Vector3<double> r_offset_vector = r0 * r_vector;
@@ -166,7 +170,8 @@ TEST_P(MultilaneLanesParamTest, FlatLineLane) {
   const double length = std::sqrt(std::pow(100, 2.) + std::pow(50, 2.));
   std::unique_ptr<RoadCurve> road_curve_2 = std::make_unique<LineRoadCurve>(
       Vector2<double>(100., -75.), Vector2<double>(100., 50.),
-      CubicPolynomial(elevation / length, 0.0, 0.0, 0.0), zp);
+      CubicPolynomial(elevation / length, 0.0, 0.0, 0.0), zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s2 = rg.NewJunction(api::JunctionId{"j2"})
                     ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2),
                                  -kHalfWidth + r0, kHalfWidth + r0,
@@ -380,14 +385,13 @@ TEST_P(MultilaneLanesParamTest, CorkScrewLane) {
   // Road curve's scale length is computed as
   // half the path length of a single corkscrew
   // turn.
-  const double kScaleLength =
+  const double kCorkscrewScaleLength =
       corkscrew_curve.length() / (2 * kTurns);
   std::unique_ptr<RoadCurve> road_curve =
       std::make_unique<LineRoadCurve>(
-          Vector2<double>(0., 0.),
-          Vector2<double>(kLength, 0.),
-          zp, corkscrew_polynomial,
-          kLinearTolerance, kScaleLength);
+          Vector2<double>(0., 0.), Vector2<double>(kLength, 0.),
+          zp, corkscrew_polynomial, kLinearTolerance,
+          kCorkscrewScaleLength, kComputationPolicy);
 
   RoadGeometry rg(api::RoadGeometryId{"corkscrew"},
                   kLinearTolerance,
@@ -489,7 +493,9 @@ TEST_P(MultilaneLanesParamTest, FlatArcLane) {
   const double offset_radius = radius - r0;
 
   std::unique_ptr<RoadCurve> road_curve_1 =
-      std::make_unique<ArcRoadCurve>(center, radius, theta0, d_theta, zp, zp);
+      std::make_unique<ArcRoadCurve>(center, radius, theta0, d_theta, zp, zp,
+                                     kLinearTolerance, kScaleLength,
+                                     kComputationPolicy);
   Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
                     ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
                                  -kHalfWidth + r0, kHalfWidth + r0,
@@ -601,7 +607,8 @@ TEST_P(MultilaneLanesParamTest, FlatArcLane) {
   const double elevation = 10.;
   std::unique_ptr<RoadCurve> road_curve_2 = std::make_unique<ArcRoadCurve>(
       center, radius, theta0, d_theta,
-      CubicPolynomial(elevation / radius / d_theta, 0.0, 0.0, 0.0), zp);
+      CubicPolynomial(elevation / radius / d_theta, 0.0, 0.0, 0.0), zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s2 = rg.NewJunction(api::JunctionId{"j2"})
                     ->NewSegment(api::SegmentId{"s2"}, std::move(road_curve_2),
                                  -kHalfWidth + r0, kHalfWidth + r0,
@@ -629,7 +636,8 @@ TEST_P(MultilaneLanesParamTest, FlatArcLane) {
   // The result should be identical to Case 1.
   const double d_theta_overlap = 3 * M_PI;
   std::unique_ptr<RoadCurve> road_curve_3 = std::make_unique<ArcRoadCurve>(
-      center, radius, theta0, d_theta_overlap, zp, zp);
+      center, radius, theta0, d_theta_overlap, zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s3 =
       rg.NewJunction(api::JunctionId{"j3"})
       ->NewSegment(api::SegmentId{"s3"}, std::move(road_curve_3),
@@ -661,7 +669,8 @@ TEST_P(MultilaneLanesParamTest, FlatArcLane) {
   const double theta0_wrap = 1.2 * M_PI;
   const double d_theta_wrap = -0.4 * M_PI;
   std::unique_ptr<RoadCurve> road_curve_4 = std::make_unique<ArcRoadCurve>(
-      center, radius, theta0_wrap, d_theta_wrap, zp, zp);
+      center, radius, theta0_wrap, d_theta_wrap, zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s4 = rg.NewJunction(api::JunctionId{"j4"})
                     ->NewSegment(api::SegmentId{"s4"}, std::move(road_curve_4),
                                  -kHalfWidth + r0, kHalfWidth + r0,
@@ -779,7 +788,9 @@ TEST_P(MultilaneLanesParamTest, HillIntegration) {
                                         (-2. * (z1 - z0) / p_scale));
   std::unique_ptr<RoadCurve> road_curve_1 =
       std::make_unique<ArcRoadCurve>(Vector2<double>(-100., -100.), radius,
-                                     theta0, d_theta, kHillPolynomial, zp);
+                                     theta0, d_theta, kHillPolynomial, zp,
+                                     kLinearTolerance, kScaleLength,
+                                     kComputationPolicy);
   Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
                     ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
                                  -kHalfWidth + r0, kHalfWidth + r0,
@@ -836,6 +847,9 @@ INSTANTIATE_TEST_CASE_P(Offset, MultilaneLanesParamTest,
 
 GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
   CubicPolynomial zp{0., 0., 0., 0.};
+  const double kScaleLength{1.};
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   const double kTheta = 0.10 * M_PI;  // superelevation
   const double kR0 = 0.;
   const double kHalfWidth = 10.;
@@ -846,7 +860,8 @@ GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
                   kLinearTolerance, kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<ArcRoadCurve>(
       Vector2<double>(100., -75.), 100.0, 0.25 * M_PI, 1.5 * M_PI, zp,
-      CubicPolynomial((kTheta) / (100. * 1.5 * M_PI), 0., 0., 0.));
+      CubicPolynomial((kTheta) / (100. * 1.5 * M_PI), 0., 0., 0.),
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s1 = rg.NewJunction(api::JunctionId{"j1"})
                     ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1),
                                  -kHalfWidth + kR0, kHalfWidth + kR0,
@@ -940,6 +955,9 @@ GTEST_TEST(MultilaneLanesTest, ArcLaneWithConstantSuperelevation) {
 class MultilaneMultipleLanesTest : public ::testing::Test {
  protected:
   const CubicPolynomial zp{0., 0., 0., 0.};
+  const double kScaleLength{1.};
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   const double kR0{10.};
   const double kRSpacing{15.};
   const double kRMin{2.};
@@ -953,7 +971,8 @@ TEST_F(MultilaneMultipleLanesTest, MultipleLineLanes) {
   RoadGeometry rg(api::RoadGeometryId{"apple"}, kLinearTolerance,
                   kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve = std::make_unique<LineRoadCurve>(
-      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp);
+      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s1 =
       rg.NewJunction(api::JunctionId{"j1"})
           ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve), kRMin,
@@ -1088,7 +1107,8 @@ TEST_F(MultilaneMultipleLanesTest, MultipleArcLanes) {
   RoadGeometry rg(api::RoadGeometryId{"apple"}, kLinearTolerance,
                   kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve = std::make_unique<ArcRoadCurve>(
-      kCenter, kRadius, kTheta0, kDTheta, zp, zp);
+      kCenter, kRadius, kTheta0, kDTheta, zp, zp, kLinearTolerance,
+      kScaleLength, kComputationPolicy);
   Segment* s1 =
       rg.NewJunction(api::JunctionId{"j1"})
           ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve), kRMin,

--- a/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_geometry_test.cc
@@ -55,9 +55,14 @@ const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
 
 GTEST_TEST(MultilaneLanesTest, DoToRoadPosition) {
   // Define a serpentine road with multiple segments and branches.
+  const double kLinearTolerance = 0.01;
+  const double kAngularTolerance = 0.01 * M_PI;
+  const double kScaleLength = 1.0;
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   auto rb = multilane::BuilderFactory().Make(
-      2. * kWidth, HBounds(0., kHeight), 0.01, /* linear tolerance */
-      0.01 * M_PI /* angular tolerance */);
+      2. * kWidth, HBounds(0., kHeight), kLinearTolerance,
+      kAngularTolerance, kScaleLength, kComputationPolicy);
 
   // Initialize the road from the origin.
   const multilane::EndpointXy kOriginXy{0., 0., 0.};
@@ -251,9 +256,14 @@ GTEST_TEST(MultilaneLanesTest, HintWithDisconnectedLanes) {
   // ongoing lanes.  This tests the pathological case when a `hint` is provided
   // in a topologically isolated lane, so the code returns the default road
   // position given by the hint.
+  const double kLinearTolerance = 0.01;
+  const double kAngularTolerance = 0.01 * M_PI;
+  const double kScaleLength = 1.0;
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   auto rb = multilane::BuilderFactory().Make(
-      2. * kWidth, HBounds(0., kHeight), 0.01, /* linear tolerance */
-      0.01 * M_PI /* angular tolerance */);
+      2. * kWidth, HBounds(0., kHeight), kLinearTolerance,
+      kAngularTolerance, kScaleLength, kComputationPolicy);
 
   // Initialize the road from the origin.
   const multilane::EndpointXy kOriginXy0{0., 0., 0.};
@@ -328,9 +338,12 @@ GTEST_TEST(MultilaneLanesTest, MultipleLineLaneSegmentWithoutHint) {
   const double kLinearTolerance{kVeryExact};
   const double kAngularTolerance{0.01 * M_PI};
   const double kLaneWidth{2. * kWidth};
-
+  const double kScaleLength = 1.0;
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
   auto builder = multilane::BuilderFactory().Make(
-      kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance);
+      kLaneWidth, kElevationBounds, kLinearTolerance,
+      kAngularTolerance, kScaleLength, kComputationPolicy);
 
   // Initialize the road from the origin.
   const EndpointZ kFlatZ{0., 0., 0., 0.};

--- a/automotive/maliput/multilane/test/multilane_segments_test.cc
+++ b/automotive/maliput/multilane/test/multilane_segments_test.cc
@@ -31,11 +31,15 @@ GTEST_TEST(MultilaneSegmentsTest, MultipleLanes) {
   const double kRMax = 42.;
   const double kHalfLaneWidth = 0.5 * kRSpacing;
   const double kMaxHeight = 5.;
+  const double kScaleLength = 1.;
+  const ComputationPolicy kComputationPolicy{
+    ComputationPolicy::kPreferAccuracy};
 
   RoadGeometry rg(api::RoadGeometryId{"apple"}, kLinearTolerance,
                   kAngularTolerance);
   std::unique_ptr<RoadCurve> road_curve_1 = std::make_unique<LineRoadCurve>(
-      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp);
+      Vector2<double>(100., -75.), Vector2<double>(100., 50.), zp, zp,
+      kLinearTolerance, kScaleLength, kComputationPolicy);
   Segment* s1 =
       rg.NewJunction(api::JunctionId{"j1"})
           ->NewSegment(api::SegmentId{"s1"}, std::move(road_curve_1), kRMin,

--- a/automotive/maliput/multilane/village.yaml
+++ b/automotive/maliput/multilane/village.yaml
@@ -7,8 +7,10 @@ maliput_multilane_builder:
   right_shoulder: 2
   left_shoulder: 2
   elevation_bounds: [0, 5]
+  scale_length: 1.0
   linear_tolerance: .01
   angular_tolerance: 0.5
+  computation_policy: prefer-accuracy
   points:
     A-St_wend:
       xypoint: [-50, 60, 0]

--- a/automotive/test/pure_pursuit_test.cc
+++ b/automotive/test/pure_pursuit_test.cc
@@ -11,6 +11,10 @@ namespace automotive {
 namespace {
 
 static constexpr double kArcRadius = 25.;
+static constexpr double kLinearTolerance{
+  std::numeric_limits<double>::epsilon()};
+static constexpr double kAngularTolerance{
+  std::numeric_limits<double>::epsilon()};
 
 using maliput::api::GeoPosition;
 using maliput::api::RoadGeometryId;
@@ -22,6 +26,7 @@ using maliput::multilane::EndpointZ;
 using maliput::multilane::EndReference;
 using maliput::multilane::LaneLayout;
 using maliput::multilane::StartReference;
+using maliput::multilane::ComputationPolicy;
 
 class PurePursuitTest : public ::testing::Test {
  protected:
@@ -30,9 +35,7 @@ class PurePursuitTest : public ::testing::Test {
     road_.reset(new maliput::dragway::RoadGeometry(
         maliput::api::RoadGeometryId("Single-Lane Dragway"), 1 /* num_lanes */,
         100 /* length */, 4. /* lane_width */, 0. /* shoulder_width */,
-        5. /* maximum_height */,
-        std::numeric_limits<double>::epsilon() /* linear_tolerance */,
-        std::numeric_limits<double>::epsilon() /* angular_tolerance */));
+        5. /* maximum_height */, kLinearTolerance, kAngularTolerance));
   }
 
   void MakeQuarterCircleRoad() {
@@ -42,7 +45,10 @@ class PurePursuitTest : public ::testing::Test {
     const ArcOffset kCounterClockwiseArc(kArcRadius, M_PI /* arc angle */);
     const EndpointZ kFlat(0., 0., 0., 0.);
     const Endpoint kStartEndpoint{{0., 0., 0.}, kFlat};
-    Builder builder(4. /* lane width */, {0., 5.}, 0.01, 0.01 * M_PI);
+    const double kScaleLength{1.0};
+    Builder builder(
+        4. /* lane width */, {0., 5.}, 0.01, 0.01 * M_PI,
+        kScaleLength, ComputationPolicy::kPreferSpeed);
     builder.Connect("0", kLaneLayout,
                     StartReference().at(kStartEndpoint, Direction::kForward),
                     kCounterClockwiseArc,


### PR DESCRIPTION
This pull request is a follow-up to #7594. It enables proper `RoadCurve` class construction by exposing its parameters in Multilane YAML description file, propagating them from the `Loader` class, through the `Builder` class and down to the `RoadCurve` class. Specifically, both `scale_length` (i.e. minimum spatial period) and `computation_policy` parameters can now be configured. Additionally, the `linear_tolerance` present at the `RoadGeometry` class level now reaches the `RoadCurve` class too. 

It's also worth noting that this addition requires a Multilane format revision update.

As a follow-up, it depends on #7594 and thus should be merged afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8870)
<!-- Reviewable:end -->
