### PR TITLE
Defer SNOPT_PATH unpacking errors until build time

### DIFF
--- a/tools/workspace/snopt/package-error.BUILD.bazel
+++ b/tools/workspace/snopt/package-error.BUILD.bazel
@@ -1,0 +1,27 @@
+# -*- python -*-
+
+# This stub BUILD file for SNOPT contains the same public targets as the real
+# BUILD file, always reports an error (from error.txt) during compilation, but
+# does not report any loading-phase errors.  This is useful to defer error
+# reporting until after the loading phase, so that `bazel query` commands will
+# still work even with SNOPT missing.
+
+genrule(
+    name = "error-message",
+    srcs = ["error.txt"],
+    outs = ["error-message.h"],
+    cmd = "cat $< && false",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "snopt_c",
+    hdrs = [":error-message.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "libf2c",
+    hdrs = [":error-message.h"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This is useful to defer error reporting until after the loading phase, so that `bazel query` commands will still work even with SNOPT missing.

This is extracted from the first commit of #8825.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8872)
<!-- Reviewable:end -->
