### PR TITLE
Add FixInputPort convenience overloads

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -253,6 +253,13 @@ class Context : public ContextBase {
        std::make_unique<Value<BasicVector<T>>>(std::move(vec)));
   }
 
+  /// Same as above method but the vector is passed by const reference instead
+  /// of by unique_ptr.  The port will contain a copy of the `vec` (not retain
+  /// a pointer to the `vec`).
+  FixedInputPortValue& FixInputPort(int index, const BasicVector<T>& vec) {
+    return FixInputPort(index, vec.Clone());
+  }
+
   /// Same as above method but starts with an Eigen vector whose contents are
   /// used to initialize a BasicVector in the FixedInputPortValue.
   FixedInputPortValue& FixInputPort(

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -160,6 +160,13 @@ class ContextBase : public internal::ContextMessageInterface {
   FixedInputPortValue& FixInputPort(
       int index, std::unique_ptr<AbstractValue> value);
 
+  /** Same as above method but the value is passed by const reference instead
+  of by unique_ptr. The port will contain a copy of the `value` (not retain a
+  pointer to the `value`). */
+  FixedInputPortValue& FixInputPort(int index, const AbstractValue& value) {
+    return FixInputPort(index, value.Clone());
+  }
+
   /** For input port `index`, returns a const FixedInputPortValue if the port is
   fixed, otherwise nullptr.
   @pre `index` selects an existing input port of this Context. */


### PR DESCRIPTION
This ended up being using while developing #7560.

(This PR was extracted from #8862.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8877)
<!-- Reviewable:end -->
