### PR TITLE
Remove quotes from buildifier "fix via" message.

### DIFF
--- a/tools/lint/buildifier.py
+++ b/tools/lint/buildifier.py
@@ -119,7 +119,7 @@ def main(workspace_name="drake"):
             if not _passes_check_mode(tool_cmds + switches + [one_file]):
                 print("ERROR: %s:1: error: %s" % (
                     one_file, "the required formatting is incorrect"))
-                print("ERROR: %s:1: note: fix via '%s' '%s'" % (
+                print("ERROR: %s:1: note: fix via %s %s" % (
                     one_file, "bazel-bin/tools/lint/buildifier", one_file))
         print("NOTE: see http://drake.mit.edu/bazel.html#buildifier")
         return 1

--- a/tools/lint/test/buildifier_test.py
+++ b/tools/lint/test/buildifier_test.py
@@ -45,7 +45,7 @@ class BuildifierTest(unittest.TestCase):
             ("ERROR: tmp/BUILD.bazel:1: " +
              "error: the required formatting is incorrect"),
             ("ERROR: tmp/BUILD.bazel:1: note: " +
-             "fix via 'bazel-bin/tools/lint/buildifier' 'tmp/BUILD.bazel'"),
+             "fix via bazel-bin/tools/lint/buildifier tmp/BUILD.bazel"),
             "NOTE: see http://drake.mit.edu/bazel.html#buildifier"
         ])
 


### PR DESCRIPTION
This makes it easier to cut-and-paste into the command line to fix
BUILD.bazel formatting errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8878)
<!-- Reviewable:end -->
