### PR TITLE
Adding collision filter interface to SceneGraph and Multibody Plant

### DIFF
--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -68,7 +68,7 @@ int DoMain() {
       -9.81 * Vector3<double>::UnitZ());
 
   // Now the model is complete.
-  kuka_plant.Finalize();
+  kuka_plant.Finalize(&scene_graph);
   DRAKE_THROW_UNLESS(kuka_plant.num_positions() == 7);
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!kuka_plant.get_source_id());

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -113,7 +113,7 @@ int do_main() {
       -9.81 * Vector3<double>::UnitZ());
 
   // We are done defining the model.
-  acrobot.Finalize();
+  acrobot.Finalize(&scene_graph);
 
   DRAKE_DEMAND(acrobot.num_actuators() == 1);
   DRAKE_DEMAND(acrobot.num_actuated_dofs() == 1);

--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -52,7 +52,7 @@ MakeBouncingBallPlant(double radius, double mass,
   plant->AddForceElement<UniformGravityFieldElement>(gravity_W);
 
   // We are done creating the plant.
-  plant->Finalize();
+  plant->Finalize(scene_graph);
 
   return plant;
 }

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -68,7 +68,7 @@ int do_main() {
       -9.81 * Vector3<double>::UnitZ());
 
   // Now the model is complete.
-  cart_pole.Finalize();
+  cart_pole.Finalize(&scene_graph);
 
   // Boilerplate used to connect the plant to a SceneGraph for
   // visualization.

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -219,7 +219,7 @@ int do_main() {
   }
 
   // Now the model is complete.
-  plant.Finalize();
+  plant.Finalize(&scene_graph);
 
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(FLAGS_penetration_allowance);

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
         ":geometry_ids",
         ":geometry_index",
         ":geometry_instance",
+        ":geometry_set",
         ":geometry_state",
         ":geometry_visualization",
         ":identifier",
@@ -113,6 +114,12 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "geometry_set",
+    hdrs = ["geometry_set.h"],
+    deps = [":geometry_ids"],
+)
+
+drake_cc_library(
     # NOTE: The material library and file name don't appear to match. This
     # library will eventually contain multiple types of materials (e.g.,
     # contact, rendering, depth, etc.)
@@ -132,6 +139,7 @@ drake_cc_library(
         ":geometry_ids",
         ":geometry_index",
         ":geometry_instance",
+        ":geometry_set",
         ":internal_frame",
         ":internal_geometry",
         ":proximity_engine",
@@ -240,6 +248,14 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "geometry_instance_test",
     deps = [":geometry_instance"],
+)
+
+drake_cc_googletest(
+    name = "geometry_set_test",
+    deps = [
+        ":geometry_ids",
+        ":geometry_set",
+    ],
 )
 
 drake_cc_googletest(

--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -1,0 +1,260 @@
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/geometry_ids.h"
+
+namespace drake {
+namespace geometry {
+
+/** The %GeometrySet, as its name implies, is a convenience class for defining a
+ set of geometries. What makes it unique from a simple `std::set<GeometryId>`
+ instance is that membership doesn't require explicit GeometryId enumeration;
+ GeometryId values can be added to the set by adding the `FrameId` for the
+ frame to which the geometries are rigidly affixed.
+
+ This class does no validation; it is a simple collection. Ultimately, it serves
+ as the operand of SceneGraph operations (e.g.,
+ SceneGraph::DisallowSelfCollision()). If the _operation_ has a particular
+ prerequisite on the members of a %GeometrySet, it is the operation's
+ responsibility to enforce that requirement.
+
+ More formally, the SceneGraph consists of a set of geometries, each associated
+ with a unique identifier. As such, we can consider the set of all identifiers
+ `SG = {g₀, g₁, ..., gₙ}` that belong to a SceneGraph. A %GeometrySet should
+ represent a subset of those identifiers, `Gₛ ⊆ SG`. The convenience of the
+ %GeometrySet class is _how_ the subset is defined. Given a set of frame ids
+ `F = {f₀, f₁, ..., fₙ}` and geometry ids `G = {g₀, g₁, ..., gₘ}`,
+ `Gₛ = G ⋃ geometry(f₀) ⋃ ... ⋃ geometry(fₙ)` (where `geometry(f)` is the set of
+ geometries rigidly affixed to frame f).  */
+class GeometrySet {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometrySet)
+
+  GeometrySet() = default;
+
+  /** @name    Explicit constructors
+
+   Various workflows may arise for operating on %GeometrySet instances, e.g.:
+
+   ```
+   // Perform operation on previously existing collection of frame ids.
+   std::vector<FrameId> my_ids{...};  // Previously-defined vector of ids.
+   GeometrySet geometry_set;
+   geometry_set.Add(my_ids);
+   UnaryOperation(geometry_set);
+   ```
+
+   or
+
+   ```
+   // Perform operation between two frames.
+   GeometrySet set1;
+   set1.add(frame1);
+   GeometrySet set2;
+   set2.add(frame2);
+   BinaryOperation(set1, set2);
+   ```
+
+   This set of constructors allow on-the-fly construction at the call site
+   to create temporary instances when the group membership is a single id or a
+   previously existing id. By doing so, the above cases become:
+
+   ```
+   // Perform operation on previously existing collection of frame ids.
+   std::vector<FrameId> my_ids{...};  // Previously-defined vector of ids.
+   UnaryOperation(GeometrySet(my_ids));
+
+   // Perform operation between two frames.
+   BinaryOperation(GeometrySet(frame1), GeometrySet(frame2));
+   ```
+
+   The following are all valid constructions -- this is _not_ an exhaustive list
+   but a representative sampling:
+
+   ```
+   // Assume that g_* and f_* are valid GeometryId and FrameId instances,
+   // respectively.
+   std::vector<GeometryId> g_vector{g_0, g_1, g_2};
+   std::set<GeometryId> g_set{g_3, g_4, g_5};
+   std::unordered_set<FrameId> f_set{f_0, f_1};
+   auto f_list = {f_2, f_3, f_4};
+
+   GeometrySet(g_0);
+   GeometrySet(f_0);
+   GeometrySet({g_0, g_1});
+   GeometrySet({f_0, f_1});
+   GeometrySet(g_vector, f_set);
+   GeometrySet(g_set, f_list);
+   // Note: construction on values of both geometry and frame identifiers
+   // requires passing in "collections" of ids; the initializer list is the
+   // simplest collection that serves the purpose. When both are provided,
+   // GeometryId always comes before FrameId.
+   GeometrySet({g_0}, {f_1});
+   GeometrySet({g_0}, f_set);
+   // etc.
+   ```
+   */
+  //@{
+
+  // TODO(SeanCurtis-TRI): The call sites would become even simpler if these
+  // constructors were *implicit*. E.g.,:
+  //    UnaryFilterOp(my_ids);
+  //    BinaryFilterOp(frame1, frame2);
+  // Determine if this convenience justifies getting a style guide exception.
+
+  explicit GeometrySet(GeometryId id) { geometries_.insert(id); }
+
+  explicit GeometrySet(FrameId id) { frames_.insert(id); }
+
+  template <typename Container>
+  explicit GeometrySet(const Container& ids) {
+    Add(ids);
+  }
+
+  // NOTE: initializer lists cannot be inferred by ADL, so they must be
+  // explicitly enumerated.
+  template <typename Id>
+  explicit GeometrySet(std::initializer_list<Id> id_list) {
+    Add(id_list);
+  }
+
+  template <typename Container>
+  explicit GeometrySet(std::initializer_list<GeometryId> geometries,
+                       const Container& frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  template <typename Container>
+  explicit GeometrySet(const Container& geometries,
+                       std::initializer_list<FrameId> frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  //@}
+
+  /** @name    Methods for adding to the set
+
+   The interface for adding geometries to the set is simply an overload of the
+   Add() method. For maximum flexibility, the Add method can take:
+     - a single geometry id
+     - a single frame id
+     - an iterable object containing geometry ids
+     - an iterable object containing frame ids
+     - two iterable objects, the first containing geometry ids, the second
+       containing frame ids.
+
+   NOTE: the iterable objects don't have to be the same type. The "iterable"
+   can also be an initializer list. All of the following invocations are valid
+   (this isn't an exhaustive list, but a representative set):
+
+   ```
+   // Assuming that f_* are valid FrameId instances and g_* are valid GeometryId
+   // instances.
+   GeometrySet group;
+   group.Add(f_1);
+   group.Add(g_1);
+
+   std::vector<FrameId> frames{f_2, f_3, f_4};
+   group.Add(frames);
+   std::vector<GeometryId> geometries{g_2, g_3, g_4};
+   group.Add(geometries);
+
+   // This is valid, but redundant; the the ids in those vectors have already
+   // been added.
+   group.Add(geometries, frames);
+
+   // Mismatched iterable types.
+   std::set<FrameId> frame_set{f_5, f_6, f_7};
+   group.Add({g_7, g_8}, frame_set);
+   ```  */
+  //@{
+
+  void Add(GeometryId geometry_id) { geometries_.insert(geometry_id); }
+
+  void Add(FrameId frame_id) { frames_.insert(frame_id); }
+
+  template <typename Container>
+  typename std::enable_if<
+      std::is_same<typename Container::value_type, GeometryId>::value>::type
+  Add(const Container& geometries) {
+    geometries_.insert(geometries.begin(), geometries.end());
+  }
+
+  template <typename Container>
+  typename std::enable_if<
+      std::is_same<typename Container::value_type, FrameId>::value>::type
+  Add(const Container& frames) {
+    frames_.insert(frames.begin(), frames.end());
+  }
+
+  void Add(std::initializer_list<FrameId> frames) {
+    frames_.insert(frames.begin(), frames.end());
+  }
+
+  void Add(std::initializer_list<GeometryId> geometries) {
+    geometries_.insert(geometries.begin(), geometries.end());
+  }
+
+  template <typename ContainerG, typename ContainerF>
+  typename std::enable_if<
+      std::is_same<typename ContainerG::value_type, GeometryId>::value &&
+      std::is_same<typename ContainerF::value_type, FrameId>::value>::type
+  Add(const ContainerG& geometries, const ContainerF& frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  template <typename ContainerF>
+  typename std::enable_if<
+      std::is_same<typename ContainerF::value_type, FrameId>::value>::type
+  Add(std::initializer_list<GeometryId> geometries, const ContainerF& frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  template <typename ContainerG>
+  typename std::enable_if<
+      std::is_same<typename ContainerG::value_type, GeometryId>::value>::type
+  Add(const ContainerG& geometries, std::initializer_list<FrameId> frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  //@}
+
+  /** Returns the frame ids in the set. */
+  const std::unordered_set<FrameId> frames() const { return frames_; }
+
+  /** Reports the number of frames in the set. */
+  int num_frames() const { return static_cast<int>(frames_.size()); }
+
+  /** Returns the geometry ids in the set. */
+  const std::unordered_set<GeometryId> geometries() const {
+    return geometries_;
+  }
+
+  /** Reports the number of geometries _explicitly_ in the set. It does
+   _not_ count the geometries that belong to the added frames.  */
+  int num_geometries() const { return static_cast<int>(geometries_.size()); }
+
+  /** Reports if the given `frame_id` has been added to the group. */
+  bool contains(FrameId frame_id) const { return frames_.count(frame_id) > 0; }
+
+  /** Reports if the given `geometry_id` has been *explicitly* added to the
+   group. It will *not* capture geometry ids affixed to added frames.  */
+  bool contains(GeometryId geometry_id) const {
+    return geometries_.count(geometry_id) > 0;
+  }
+
+ private:
+  std::unordered_set<FrameId> frames_;
+  std::unordered_set<GeometryId> geometries_;
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -187,6 +187,19 @@ GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
 }
 
 template <typename T>
+void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet&) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  // TODO(SeanCurtis-TRI): Implemented in the follow-up PR.
+}
+
+template <typename T>
+void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet&,
+                                             const GeometrySet&) {
+  GS_THROW_IF_CONTEXT_ALLOCATED
+  // TODO(SeanCurtis-TRI): Implemented in the follow-up PR.
+}
+
+template <typename T>
 void SceneGraph<T>::MakeSourcePorts(SourceId source_id) {
   // This will fail only if the source generator starts recycling source ids.
   DRAKE_ASSERT(input_source_ids_.count(source_id) == 0);

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
@@ -355,6 +356,54 @@ class SceneGraph final : public systems::LeafSystem<T> {
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
+  //@}
+
+  /** @name         Collision filtering
+   The interface for limiting the scope of penetration queries (i.e., "filtering
+   collisions").
+
+   The scene graph consists of the set of geometry
+   `G = D ⋃ A = {g₀, g₁, ..., gₙ}`, where D is the set of dynamic geometry and
+   A is the set of anchored geometry (by definition `D ⋂ A = ∅`). Collision
+   occurs between pairs of geometries (e.g., (gᵢ, gⱼ)). The set of collision
+   candidate pairs is initially defined as `C = (G × G) - (A × A) - F - I`,
+   where:
+     - `G × G = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` is the cartesian product of the set
+       of SceneGraph geometries.
+     - `A × A` represents all pairs consisting only of anchored geometry;
+       anchored geometry is never tested against other anchored geometry.
+     - `F = (gᵢ, gⱼ)`, such that `frame(gᵢ) == frame(gⱼ)`; the pair where both
+       geometries are rigidly affixed to the same frame. By implication,
+       `gᵢ, gⱼ ∈ D` as only dynamic geometries are affixed to frames.
+     - `I = {(g, g)}, ∀ g ∈ G` is the set of all pairs consisting a geometry
+        with itself; there is no collision between a geometry and itself.
+
+   Only pairs contained in C will be tested as part of penetration queries.
+   These filter methods essentially create new sets of pairs and then subtract
+   them from the candidate set C. See each method for details.
+
+   Modifications to C _must_ be performed before context allocation.
+   */
+  //@{
+
+  /** Excludes geometry pairs from collision evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `set` of geometries.
+
+   @throws std::logic_error if the set includes ids that don't exist in the
+                            scene graph.  */
+  void ExcludeCollisionsWithin(const GeometrySet& set);
+
+  /** Excludes geometry pairs from collision evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
+   `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `setA` and `setB`, respectively. This does _not_ preclude
+   collisions between members of the _same_ set.
+
+   @throws std::logic_error if the groups include ids that don't exist in the
+                            scene graph.   */
+  void ExcludeCollisionsBetween(const GeometrySet& setA,
+                                const GeometrySet& setB);
   //@}
 
  private:

--- a/geometry/test/geometry_set_test.cc
+++ b/geometry/test/geometry_set_test.cc
@@ -1,0 +1,288 @@
+#include "drake/geometry/geometry_set.h"
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace {
+
+// Helper class -- used to determine that the indicated identifiers are found
+// in the GeometrySet.
+
+template <typename IdContainer>
+void ExpectContainsAll(const GeometrySet& geometry_set, const IdContainer& ids,
+                       const char* failure_message) {
+  for (auto id : ids) {
+    EXPECT_TRUE(geometry_set.contains(id)) << failure_message;
+  }
+}
+
+GTEST_TEST(GeometrySetTests, DefaultConstructor) {
+  GeometrySet geometry_set;
+
+  // Should report containing no frames or geometries.
+  EXPECT_EQ(geometry_set.num_frames(), 0);
+  EXPECT_EQ(geometry_set.num_geometries(), 0);
+
+  // A random frame/geometry id will not be reported as being *in* the set.
+  EXPECT_FALSE(geometry_set.contains(GeometryId::get_new_id()));
+  EXPECT_FALSE(geometry_set.contains(FrameId::get_new_id()));
+}
+
+GTEST_TEST(GeometrySetTests, ConversionConstructor) {
+  GeometryId g_id = GeometryId::get_new_id();
+  FrameId f_id = FrameId::get_new_id();
+  // NOTE: Subsequent tests depend on
+  //   1) the vector of ids to be constructed from the initializer list of ids,
+  //      and
+  //   2) The initializer list has *two* ids.
+  // This applies to both the vector of frame ids as well as the vector of
+  // geometry ids. A change to either of those properties will require a change
+  // of tests below (sets 6 & 7 for geometry ids and sets 8 & 9 for frame ids).
+  auto geometry_list = {GeometryId::get_new_id(), GeometryId::get_new_id()};
+  std::vector<GeometryId> geometry_vector = geometry_list;
+  std::set<GeometryId> geometry_set{GeometryId::get_new_id(),
+                                    GeometryId::get_new_id(),
+                                    GeometryId::get_new_id()};
+  std::unordered_set<GeometryId> geometry_hash{
+      GeometryId::get_new_id(), GeometryId::get_new_id(),
+      GeometryId::get_new_id(), GeometryId::get_new_id()};
+  auto frame_list = {FrameId::get_new_id(), FrameId::get_new_id()};
+  std::vector<FrameId> frame_vector{frame_list};
+
+  auto test_single_source_constructor = [](
+      const GeometrySet& set, const auto& source, int expected_frame_count,
+      int expected_geometry_count, const char* message) {
+    EXPECT_EQ(set.num_frames(), expected_frame_count) << message;
+    EXPECT_EQ(set.num_geometries(), expected_geometry_count) << message;
+    ExpectContainsAll(set, source, message);
+  };
+
+  GeometrySet set1(g_id);
+  test_single_source_constructor(set1, std::set<GeometryId>{g_id}, 0, 1,
+                                 "Single geometry id constructor");
+
+  GeometrySet set2(f_id);
+  test_single_source_constructor(set2, std::set<FrameId>{f_id}, 1, 0,
+                                 "Single frame id constructor");
+
+  GeometrySet set3(geometry_vector);
+  test_single_source_constructor(set3, geometry_vector, 0,
+                                 static_cast<int>(geometry_vector.size()),
+                                 "Vector constructor");
+
+  GeometrySet set4(geometry_set);
+  test_single_source_constructor(set4, geometry_set, 0,
+                                 static_cast<int>(geometry_set.size()),
+                                 "Set constructor");
+
+  GeometrySet set5(geometry_hash);
+  test_single_source_constructor(set5, geometry_hash, 0,
+                                 static_cast<int>(geometry_hash.size()),
+                                 "Unordered set constructor");
+
+  // These next two tests with initializer lists rely on the fact that the
+  // geometry vector was initialized from `geometry_list`.
+  GeometrySet set6(geometry_list);
+  test_single_source_constructor(
+      set6, geometry_list, 0, static_cast<int>(geometry_vector.size()),
+      "GeometryId initializer list lvalue constructor");
+
+  GeometrySet set7({geometry_vector[0], geometry_vector[1]});
+  test_single_source_constructor(
+      set7, geometry_vector, 0, static_cast<int>(geometry_vector.size()),
+      "GeometryId initializer list rvalue constructor");
+
+  GeometrySet set8(frame_list);
+  test_single_source_constructor(set8, frame_vector,
+                                 static_cast<int>(frame_vector.size()), 0,
+                                 "FrameId initializer list lvalue constructor");
+
+  GeometrySet set9({frame_vector[0], frame_vector[1]});
+  test_single_source_constructor(set9, frame_vector,
+                                 static_cast<int>(frame_vector.size()), 0,
+                                 "FrameId initializer list rvalue constructor");
+
+  // Constructors using geometry and frame id sets.
+  GeometrySet set10(geometry_list, frame_vector);
+  EXPECT_EQ(set10.num_frames(), static_cast<int>(frame_vector.size()));
+  EXPECT_EQ(set10.num_geometries(), static_cast<int>(geometry_vector.size()));
+  ExpectContainsAll(set10, geometry_vector,
+                    "Geometry initializer list, frame vector constructor");
+  ExpectContainsAll(set10, frame_vector,
+                    "Geometry initializer list, frame vector constructor");
+
+  GeometrySet set11(geometry_vector, {frame_vector[0], frame_vector[1]});
+  EXPECT_EQ(set11.num_frames(), static_cast<int>(frame_vector.size()));
+  EXPECT_EQ(set11.num_geometries(), static_cast<int>(geometry_vector.size()));
+  ExpectContainsAll(set11, geometry_vector,
+                    "Geometry vector, frame initializer list constructor");
+  ExpectContainsAll(set11, frame_vector,
+                    "Geometry vector, frame initializer list constructor");
+}
+
+GTEST_TEST(GeometrySetTests, SingleFrameAdd) {
+  GeometrySet geometry_set;
+
+  FrameId f = FrameId::get_new_id();
+  EXPECT_FALSE(geometry_set.contains(f));
+  geometry_set.Add(f);
+  EXPECT_EQ(geometry_set.num_frames(), 1);
+  EXPECT_TRUE(geometry_set.contains(f));
+
+  // Adding a frame redundantly should not be a problem.
+  EXPECT_NO_THROW(geometry_set.Add(f));
+  // It should also not change the membership.
+  EXPECT_EQ(geometry_set.num_frames(), 1);
+  EXPECT_TRUE(geometry_set.contains(f));
+}
+
+GTEST_TEST(GeometrySetTests, SingleGeometryAdd) {
+  GeometrySet geometry_set;
+
+  GeometryId g = GeometryId::get_new_id();
+  EXPECT_FALSE(geometry_set.contains(g));
+  geometry_set.Add(g);
+  EXPECT_EQ(geometry_set.num_geometries(), 1);
+  EXPECT_TRUE(geometry_set.contains(g));
+
+  // Adding a geometry redundantly should not be a problem.
+  EXPECT_NO_THROW(geometry_set.Add(g));
+  // It should also not change the membership.
+  EXPECT_EQ(geometry_set.num_geometries(), 1);
+  EXPECT_TRUE(geometry_set.contains(g));
+}
+
+GTEST_TEST(GeometrySetTests, IterableFrameAdd) {
+  GeometrySet geometry_set;
+
+  // Each has a *different* number of frames so that the result of each can be
+  // easily distinguished by count.
+  std::vector<FrameId> frames_vector{FrameId::get_new_id(),
+                                     FrameId::get_new_id()};
+  std::set<FrameId> frames_set{FrameId::get_new_id(), FrameId::get_new_id(),
+                               FrameId::get_new_id()};
+  std::unordered_set<FrameId> frames_hash{
+      FrameId::get_new_id(), FrameId::get_new_id(), FrameId::get_new_id(),
+      FrameId::get_new_id()};
+
+  int expected_num_frames = 0;
+  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
+
+  geometry_set.Add(frames_vector);
+  expected_num_frames += static_cast<int>(frames_vector.size());
+  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
+  ExpectContainsAll(geometry_set, frames_vector,
+                    "IterableFrameAdd - frames_vector");
+
+  geometry_set.Add(frames_set);
+  expected_num_frames += static_cast<int>(frames_set.size());
+  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
+  ExpectContainsAll(geometry_set, frames_set, "IterableFrameAdd - frames_set");
+
+  geometry_set.Add(frames_hash);
+  expected_num_frames += static_cast<int>(frames_hash.size());
+  EXPECT_EQ(geometry_set.num_frames(), expected_num_frames);
+  ExpectContainsAll(geometry_set, frames_hash,
+                    "IterableFrameAdd - frames_hash");
+
+  GeometrySet geometry_set2;
+  geometry_set2.Add({frames_vector[0], frames_vector[1]});
+  EXPECT_EQ(geometry_set2.num_frames(), 2);
+  ExpectContainsAll(geometry_set, frames_vector,
+                    "IterableFrameAdd - initializer_list");
+}
+
+GTEST_TEST(GeometrySetTests, IterableGeometryAdd) {
+  GeometrySet geometry_set;
+
+  // Each has a *different* number of geometries so that the result of each can
+  // be easily distinguished by count.
+  std::vector<GeometryId> geometry_id_vector{GeometryId::get_new_id(),
+                                             GeometryId::get_new_id()};
+  std::set<GeometryId> geometry_id_set{GeometryId::get_new_id(),
+                                       GeometryId::get_new_id(),
+                                       GeometryId::get_new_id()};
+  std::unordered_set<GeometryId> geometry_id_hash{
+      GeometryId::get_new_id(), GeometryId::get_new_id(),
+      GeometryId::get_new_id(), GeometryId::get_new_id()};
+
+  int expected_num_geometries = 0;
+  EXPECT_EQ(geometry_set.num_frames(), expected_num_geometries);
+
+  geometry_set.Add(geometry_id_vector);
+  expected_num_geometries += static_cast<int>(geometry_id_vector.size());
+  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(geometry_set, geometry_id_vector,
+                    "IterableGeometryAdd - geometry_id_vector");
+
+  geometry_set.Add(geometry_id_set);
+  expected_num_geometries += static_cast<int>(geometry_id_set.size());
+  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(geometry_set, geometry_id_set,
+                    "IterableGeometryAdd - geometry_id_set");
+
+  geometry_set.Add(geometry_id_hash);
+  expected_num_geometries += static_cast<int>(geometry_id_hash.size());
+  EXPECT_EQ(geometry_set.num_geometries(), expected_num_geometries);
+  ExpectContainsAll(geometry_set, geometry_id_hash,
+                    "IterableGeometryAdd - geometry_id_hash");
+
+  GeometrySet geometry_set2;
+  geometry_set2.Add({geometry_id_vector[0], geometry_id_vector[1]});
+  EXPECT_EQ(geometry_set2.num_geometries(), 2);
+  ExpectContainsAll(geometry_set, geometry_id_vector,
+                    "IterableGeometryAdd - initializer_list");
+}
+
+GTEST_TEST(GeometrySetTests, IterableGeometryAndFrames) {
+  GeometrySet geometry_set;
+  std::vector<GeometryId> geometry_id_vector{GeometryId::get_new_id(),
+                                             GeometryId::get_new_id()};
+  std::set<FrameId> frame_id_set{FrameId::get_new_id(), FrameId::get_new_id()};
+
+  geometry_set.Add(geometry_id_vector, frame_id_set);
+  EXPECT_EQ(geometry_set.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(geometry_set.num_geometries(),
+            static_cast<int>(geometry_id_vector.size()));
+  ExpectContainsAll(geometry_set, geometry_id_vector,
+                    "IterableGeometryAndFrames - both containers - "
+                    "geometry_id_vector");
+  ExpectContainsAll(
+      geometry_set, frame_id_set,
+      "IterableGeometryAndFrames - both containers - frame_id_set");
+
+  GeometrySet geometry_set2;
+  geometry_set2.Add({geometry_id_vector[0], geometry_id_vector[1]},
+                    frame_id_set);
+  EXPECT_EQ(geometry_set2.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(geometry_set2.num_geometries(),
+            static_cast<int>(geometry_id_vector.size()));
+  ExpectContainsAll(
+      geometry_set2, geometry_id_vector,
+      "IterableGeometryAndFrames - geometry initializer list - geometry");
+  ExpectContainsAll(geometry_set2, frame_id_set,
+                    "IterableGeometryAndFrames - geometry initializer list - "
+                    "frame_id_set");
+
+  GeometrySet geometry_set3;
+  geometry_set3.Add(geometry_id_vector,
+                    {*frame_id_set.begin(), *(++frame_id_set.begin())});
+  EXPECT_EQ(geometry_set3.num_frames(), static_cast<int>(frame_id_set.size()));
+  EXPECT_EQ(geometry_set3.num_geometries(),
+            static_cast<int>(geometry_id_vector.size()));
+  ExpectContainsAll(geometry_set3, geometry_id_vector,
+                    "IterableGeometryAndFrames - frame initializer list - "
+                    "geometry_id_vector");
+  ExpectContainsAll(geometry_set3, frame_id_set,
+                    "IterableGeometryAndFrames - frame initializer list - "
+                    "frame initializer list");
+}
+
+}  // namespace
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/scene_graph_test.cc
+++ b/geometry/test/scene_graph_test.cc
@@ -9,6 +9,7 @@
 #include "drake/geometry/geometry_context.h"
 #include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/geometry_instance.h"
+#include "drake/geometry/geometry_set.h"
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/shape_specification.h"
@@ -334,6 +335,25 @@ TEST_F(SceneGraphTest, TransmogrifyContext) {
   EXPECT_THROW(geo_context_ad->get_geometry_state().BelongsToSource(
                    GeometryId::get_new_id(), s_id),
                std::logic_error);
+}
+
+// Tests that exercising the collision filtering logic *after* allocation leads
+// to an exception being thrown.
+TEST_F(SceneGraphTest, PostAllocationCollisionFiltering) {
+  AllocateContext();
+
+  GeometrySet geometry_set1{FrameId::get_new_id()};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      scene_graph_.ExcludeCollisionsWithin(geometry_set1), std::logic_error,
+      "The call to ExcludeCollisionsWithin is invalid; a context has already "
+      "been allocated.");
+
+  GeometrySet geometry_set2{FrameId::get_new_id()};
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      scene_graph_.ExcludeCollisionsBetween(geometry_set1, geometry_set2),
+      std::logic_error,
+      "The call to ExcludeCollisionsBetween is invalid; a context has already "
+      "been allocated.");
 }
 
 // Dummy system to serve as geometry source.

--- a/multibody/benchmarks/acrobot/make_acrobot_plant.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.cc
@@ -102,7 +102,7 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
       -params.g() * Vector3d::UnitZ());
 
   // We are done creating the plant.
-  if (finalize) plant->Finalize();
+  if (finalize) plant->Finalize(scene_graph);
 
   return plant;
 }

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -81,7 +81,7 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
       -gravity * Vector3<double>::UnitZ());
 
   // We are done creating the plant.
-  plant->Finalize();
+  plant->Finalize(scene_graph);
 
   return plant;
 }

--- a/multibody/benchmarks/pendulum/make_pendulum_plant.cc
+++ b/multibody/benchmarks/pendulum/make_pendulum_plant.cc
@@ -78,7 +78,7 @@ MakePendulumPlant(const PendulumParameters& params,
   plant->AddForceElement<UniformGravityFieldElement>(
       -params.g() * Vector3d::UnitZ());
 
-  plant->Finalize();
+  plant->Finalize(scene_graph);
 
   return plant;
 }

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -172,7 +172,7 @@ class MultibodyPlantSdfParser : public ::testing::Test {
   // geometries for both visualization and contact modeling.
   void LoadMultibodyPlantAndSceneGraph() {
     AddModelFromSdfFile(full_name_, &plant_, &scene_graph_);
-    plant_.Finalize();
+    plant_.Finalize(&scene_graph_);
   }
 
  protected:


### PR DESCRIPTION
This is the first of two (maybe three) PRs.

Overall Plan
==========
The goal is to filter pairs of geometries for consideration in penetration queries. There are triggers that would cause geometries to not be considered: multiple geometries rigidly affixed to a single frame, disallowing collision between geometries on adjacent bodies, user-specified collision filtering. The end goal will consist of appropriate public APIs, code that automatically configures filters, and the underlying filtering mechanism.

This functionality is being spread over several PRs
1. (This PR) The public API for SceneGraph and the example of MultibodyPlant using it to prevent collisions between adjacent bodies automatically. No actual filtering takes place.
2. The core functionality that implements collision filtering. This will introduce filtered effects into the code (and unit tests will change).
3. Extend MBP's filtering API to allow user-declared collision filtering on bodies in the MultibodyPlant.

This PR in detail
=============
- `MultibodyPlant`: added filtering adjacent bodies to the `Finalize()` method.
- `SceneGraph`: public interface for specifying collision filtering between "collision groups"
- `CollisionGroup` : the definition of the collision filter declaration primitive

```
Category            added  modified  removed  
----------------------------------------------
code                455    9         0        
comments            211    2         0        
blank               133    0         0        
----------------------------------------------
TOTAL               799    11        0  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8884)
<!-- Reviewable:end -->
