### PR TITLE
Overhaul maliput's RightOfWayRule in order to handle yield logic.

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -794,6 +794,7 @@ drake_cc_googletest(
     name = "trivial_right_of_way_state_provider_test",
     deps = [
         ":trivial_right_of_way_state_provider",
+        "//automotive/maliput/api/test_utilities:rules_test_utilities",
     ],
 )
 

--- a/automotive/maliput/api/rules/right_of_way_rule.h
+++ b/automotive/maliput/api/rules/right_of_way_rule.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "drake/automotive/maliput/api/rules/regions.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
 
 namespace drake {
 namespace maliput {
@@ -17,100 +22,189 @@ namespace rules {
 /// flows take turns traversing regions of the road network.
 ///
 /// Each rule instance comprises:
-/// * a controlled_zone (a LaneSRoute) which specifies a contiguous
-///   longitudinal lane-wise section of the road network to which the
-///   instance applies;
-/// * a type (a Type) which indicates the right-of-way semantics for a vehicle
-///   traversing the controlled_zone.
-/// The type may be "dynamic", in which the semantic state is delegated to
-/// an RightOfWayStateProvider agent, linked by this rule's Id.
+/// * a zone (a LaneSRoute) which specifies a contiguous longitudinal
+///   lane-wise section of the road network to which the rule instance
+///   applies;
+/// * a ZoneType describing whether or not stopping within the zone is
+///   allowed;
+/// * a catalog of one or more States, each of which indicate the possible
+///   right-of-way semantics for a vehicle traversing the zone.
 ///
-/// A RightOfWayRule instance determines whether or not a vehicle is
-/// allowed to enter the controlled_zone.  Having entered, vehicles
-/// should not stop within a controlled_zone, and thus should not
-/// enter the controlled_zone if traffic conditions may cause them
-/// to stop within the zone.
-class RightOfWayRule {
+/// The `zone` is directed; the rule applies to vehicles traveling forward
+/// through the `zone`.
+///
+/// A rule instance with a single State is considered "static", and has fixed
+/// semantics.  A rule instance with multiple States is considered "dynamic"
+/// and determination of the active rule State at any given time is delegated
+/// to a RightOfWayStateProvider agent, linked by the rule's Id.
+class RightOfWayRule final {
  public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RightOfWayRule);
+
+  /// Unique identifier for a RightOfWayRule.
   using Id = TypeSpecificIdentifier<class RightOfWayRule>;
 
-  /// Basic static semantics of the rule instance.
-  // TODO(maddog@tri.global) Describe turn-taking rules for StopThenGo
-  //                          (e.g., 4-way stop intersection), which is
-  //                          related to...
-  // TODO(maddog@tri.global) Add explicit yield-to-whom semantics.
-  enum class Type {
-    kProceed = 0,  ///< No restriction on vehicle's right-of-way, but it
-                   ///  must still avoid stopping within the controlled-zone.
-    kYield,        ///< Vehicles must yield to competing traffic.
-    kStopThenGo,   ///< Vehicles must come to a complete stop before entering
-                   ///  the controlled-zone, but may then proceed if safe.
-    kDynamic       ///< Delegate semantics to a RightOfWayStateProvider,
-                   ///  with state linked by the Id of this rule.
+  /// Description of stopping properties of the zone.
+  enum class ZoneType {
+    kStopExcluded,  ///< Vehicles should not stop within the zone; vehicles
+                    ///  should avoid entering the zone if traffic conditions
+                    ///  may cause them to stop within the zone.  Vehicles
+                    ///  already in the zone when a kStop state occurs should
+                    ///  exit the zone.
+    kStopAllowed    ///< Vehicles are allowed to stop within the zone.
   };
 
-  /// Rule semantics which may be expressed via a dynamic agent.
-  // TODO(maddog@tri.global) Better define fallback semantics of "dark-mode".
-  // TODO(maddog@tri.global) Better distinguish Go, Caution, Yield
-  enum class DynamicState {
-    kUncontrolled = 0,    ///< Signaling apparatus is non-functional (e.g.,
-                          ///  "dark mode").
-    kGo,                  ///< Vehicle has right-of-way.
-    kPrepareToStop,       ///< Vehicle has right-of-way, but rule state will
-                          ///  soon transition to kStop.
-    kStop,                ///< Vehicle does not have right-of-way (and thus
-                          ///  must not enter the controlled-zone).
-    kPrepareToGo,         ///< Vehicle does not have right-of-way, but rule
-                          ///  state will soon transition to kGo.
-    kProceedWithCaution,  ///< Vehicle has right-of-way.
-    kYield,               ///< Vehicles must yield to competing traffic.
-    kStopThenGo           ///< Vehicle must come to complete stop before
-                          ///  entering controlled-zone, but may then
-                          ///  proceed if safe;
-  };
+  /// Semantic state of a RightOfWayRule.
+  ///
+  /// A State describes the semantic state of a RightOfWayRule,
+  /// basically "Go", "Stop", or "Stop, Then Go".  A RightOfWayRule
+  /// may have multiple possible States, in which case its States must
+  /// have Id's which are unique within the context of that
+  /// RightOfWayRule.
+  ///
+  /// A State also describes the yield logic of a RightOfWayRule, via
+  /// a list of Id's of other RightOfWayRules (and thus the zones
+  /// which they control) which have priority over this rule.  An
+  /// empty list means that a rule in this State has priority over all
+  /// other rules.  Vehicles with lower priority (i.e., traveling on
+  /// lower-priority paths) must yield to vehicles with higher priority.
+  class State final {
+   public:
+    DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(State);
 
-  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(RightOfWayRule);
+    /// Unique identifier for a State
+    using Id = TypeSpecificIdentifier<class State>;
+
+    /// List of RightOfWayRule::Id's of rules/zones with priority.
+    using YieldGroup = std::vector<RightOfWayRule::Id>;
+
+    /// Basic semantic type of a rule state.
+    enum class Type {
+      kGo = 0,              ///< Vehicle has right-of-way and may proceed if
+                            ///  safe to do so.
+      kStop,                ///< Vehicle does not have right-of-way and must
+                            ///  stop.
+      kStopThenGo           ///< Vehicle must come to complete stop before
+                            ///  entering controlled zone, but may then
+                            ///  proceed if safe;
+    };
+
+    /// Constructs a State instance.
+    ///
+    /// @param id the unique Id
+    /// @param type the semantic Type
+    /// @param yield_to the other paths/rules which must be yielded to
+    State(Id id, Type type, const YieldGroup& yield_to)
+        : id_(id), type_(type), yield_to_(yield_to) {}
+
+    /// Returns the Id.
+    const Id& id() const { return id_; }
+
+    /// Returns the Type.
+    Type type() const { return type_; }
+
+    /// Returns the YieldGroup.
+    const YieldGroup& yield_to() const { return yield_to_; }
+
+   private:
+    Id id_;
+    Type type_{};
+    YieldGroup yield_to_;
+  };
 
   /// Constructs a RightOfWayRule.
   ///
   /// @param id the unique ID of this rule (in the RoadRulebook)
   /// @param controlled_zone LaneSRoute to which this rule applies
   /// @param type the static semantics of this rule
+  ///
+  /// Throws a std::exception if `states` is empty or if `states` contains
+  /// duplicate State::Id's.
   RightOfWayRule(const Id& id,
-                 const LaneSRoute& controlled_zone, Type type)
-      : id_(id), controlled_zone_(controlled_zone), type_(type) {}
+                 const LaneSRoute& zone,
+                 ZoneType zone_type,
+                 const std::vector<State>& states)
+      : id_(id), zone_(zone), zone_type_(zone_type) {
+    DRAKE_THROW_UNLESS(states.size() >= 1);
+    for (const State& state : states) {
+      // Construct index of states by ID, ensuring uniqueness of ID's.
+      auto result = states_.emplace(state.id(), state);
+      DRAKE_THROW_UNLESS(result.second);
+    }
+  }
 
-  /// Returns the persistent identifier.
-  Id id() const { return id_; }
+  /// Returns the rule's identifier.
+  const Id& id() const { return id_; }
 
-  /// Returns the rule's controlled zone.
-  const LaneSRoute& controlled_zone() const { return controlled_zone_; }
+  /// Returns the zone controlled by the rule.
+  const LaneSRoute& zone() const { return zone_; }
 
-  /// Returns the static rule semantic.
-  Type type() const { return type_; }
+  /// Returns the zone's type.
+  ZoneType zone_type() const { return zone_type_; }
+
+  /// Returns the catalog of possible States.
+  const std::unordered_map<State::Id, State>& states() const { return states_; }
+
+  /// Returns true if the rule is static, i.e., has no dynamic state,
+  /// otherwise false.
+  ///
+  /// This is true if and only if the rule has a single state.
+  bool is_static() const { return states_.size() == 1; }
+
+  /// Returns the static state of the rule.
+  ///
+  /// This is a convenience function for returning a static rule's single state.
+  ///
+  /// Throws a std::exception if `is_static()` is false.
+  const State& static_state() const {
+    DRAKE_THROW_UNLESS(is_static());
+    return states_.begin()->second;
+  }
 
  private:
   Id id_;
-  LaneSRoute controlled_zone_;
-  Type type_{};
-  // TODO(maddog) Add bool field for "stopping is excluded in zone"?
+  LaneSRoute zone_;
+  ZoneType zone_type_{};
+  std::unordered_map<State::Id, State> states_;
 };
 
 
-/// Abstract interface for the provider of the dynamic semantic state of
-/// a RightOfWayRule.
+/// Abstract interface for the provider of the state of a dynamic
+/// (multiple state) RightOfWayRule.
 class RightOfWayStateProvider {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RightOfWayStateProvider)
 
   virtual ~RightOfWayStateProvider() = default;
 
-  /// Returns the current state of the RightOfWayRule identified by `id`.
+  /// Result returned by GetState().
+  struct Result {
+    /// Information about a subsequent State.
+    struct Next {
+      /// ID of the State.
+      RightOfWayRule::State::Id id;
+      /// If known, estimated time until the transition to the State.
+      drake::optional<double> duration_until;
+    };
+
+    /// ID of the rule's current State.
+    RightOfWayRule::State::Id current_id;
+    /// Information about the rule's upcoming State if a state transition
+    /// is anticipated.
+    drake::optional<Next> next;
+  };
+
+  /// Gets the state of the RightOfWayRule identified by `id`.
   ///
-  /// Throws an exception if `id` is unrecognized, which should be the
-  /// case if no such rule exists or if the rule has only static semantics.
-  // TODO(maddog@tri.global)  Better to throw exception or return an optional?
-  RightOfWayRule::DynamicState GetState(const RightOfWayRule::Id& id) const {
+  /// Returns a Result struct bearing the State::Id of the rule's current
+  /// state.  If a transition to a new state is anticipated,
+  /// Result::next will be populated and bear the State::Id of the next
+  /// state.  If the time until the transition is known, then
+  /// Result::next.duration_until will be populated with that duration.
+  ///
+  /// Returns nullopt if `id` is unrecognized, which would be the case
+  /// if no such rule exists or if the rule has only static semantics.
+  drake::optional<Result> GetState(const RightOfWayRule::Id& id) const {
     return DoGetState(id);
   }
 
@@ -118,7 +212,7 @@ class RightOfWayStateProvider {
   RightOfWayStateProvider() = default;
 
  private:
-  virtual RightOfWayRule::DynamicState DoGetState(
+  virtual drake::optional<Result> DoGetState(
       const RightOfWayRule::Id& id) const = 0;
 };
 

--- a/automotive/maliput/api/test/rules_right_of_way_test.cc
+++ b/automotive/maliput/api/test/rules_right_of_way_test.cc
@@ -15,30 +15,134 @@ namespace api {
 namespace rules {
 namespace {
 
+// Tests for RightOfWayRule::State
+
 const LaneSRoute kZone({LaneSRange(LaneId("a"), {0., 9.}),
                         LaneSRange(LaneId("b"), {17., 12.})});
 
+const RightOfWayRule::State::YieldGroup kYieldGroupSize2{
+  RightOfWayRule::Id("other_rule_a"),
+  RightOfWayRule::Id("other_rule_b")};
+
+GTEST_TEST(RightOfWayRuleStateTest, Construction) {
+  EXPECT_NO_THROW(RightOfWayRule::State(
+      RightOfWayRule::State::Id("some_id"),
+      RightOfWayRule::State::Type::kStop,
+      {}));
+  EXPECT_NO_THROW(RightOfWayRule::State(
+      RightOfWayRule::State::Id("some_id"),
+      RightOfWayRule::State::Type::kGo,
+      kYieldGroupSize2));
+}
+
+
+GTEST_TEST(RightOfWayRuleStateTest, Accessors) {
+  const RightOfWayRule::State dut(RightOfWayRule::State::Id("dut_id"),
+                                  RightOfWayRule::State::Type::kStop,
+                                  kYieldGroupSize2);
+  EXPECT_EQ(dut.id(), RightOfWayRule::State::Id("dut_id"));
+  EXPECT_EQ(dut.type(), RightOfWayRule::State::Type::kStop);
+  EXPECT_EQ(dut.yield_to(), kYieldGroupSize2);
+}
+
+
+GTEST_TEST(RightOfWayRuleStateTest, Copying) {
+  const RightOfWayRule::State source(RightOfWayRule::State::Id("dut_id"),
+                                     RightOfWayRule::State::Type::kStopThenGo,
+                                     kYieldGroupSize2);
+  const RightOfWayRule::State dut(source);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, source));
+}
+
+
+GTEST_TEST(RightOfWayRuleStateTest, Assignment) {
+  const RightOfWayRule::State source(RightOfWayRule::State::Id("source_id"),
+                                     RightOfWayRule::State::Type::kStopThenGo,
+                                     {});
+  RightOfWayRule::State dut(RightOfWayRule::State::Id("dut_id"),
+                            RightOfWayRule::State::Type::kGo,
+                            kYieldGroupSize2);
+  dut = source;
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, source));
+}
+
+
+// Tests for RightOfWayRule itself
+
+const RightOfWayRule::State kNoYieldState(RightOfWayRule::State::Id("s1"),
+                                          RightOfWayRule::State::Type::kStop,
+                                          {});
+
+const RightOfWayRule::State kYieldingState(RightOfWayRule::State::Id("s2"),
+                                           RightOfWayRule::State::Type::kGo,
+                                           kYieldGroupSize2);
+
 
 GTEST_TEST(RightOfWayRuleTest, Construction) {
-  EXPECT_NO_THROW(RightOfWayRule(RightOfWayRule::Id("some_id"), kZone,
-                                 RightOfWayRule::Type::kStopThenGo));
-  EXPECT_NO_THROW(RightOfWayRule(RightOfWayRule::Id("some_id"), kZone,
-                                 RightOfWayRule::Type::kDynamic));
+  EXPECT_NO_THROW(RightOfWayRule(
+      RightOfWayRule::Id("some_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState, kYieldingState}));
+  EXPECT_NO_THROW(RightOfWayRule(
+      RightOfWayRule::Id("some_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState}));
+
+  // At least one State must be provided.
+  EXPECT_THROW(RightOfWayRule(
+      RightOfWayRule::Id("some_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {}),
+      std::exception);
+  // At least one State::Id's must be unique.
+  const RightOfWayRule::State kDupIdState(RightOfWayRule::State::Id("s1"),
+                                          RightOfWayRule::State::Type::kGo,
+                                          {});
+  EXPECT_THROW(RightOfWayRule(
+      RightOfWayRule::Id("some_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState, kDupIdState}),
+      std::exception);
 }
 
 
 GTEST_TEST(RightOfWayRuleTest, Accessors) {
-  const RightOfWayRule dut(RightOfWayRule::Id("dut_id"), kZone,
-                           RightOfWayRule::Type::kStopThenGo);
+  const RightOfWayRule dut(
+      RightOfWayRule::Id("dut_id"),
+      kZone,
+      RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState, kYieldingState});
   EXPECT_EQ(dut.id(), RightOfWayRule::Id("dut_id"));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.controlled_zone(), kZone));
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.type(), RightOfWayRule::Type::kStopThenGo));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.zone(), kZone));
+  EXPECT_EQ(dut.zone_type(), RightOfWayRule::ZoneType::kStopExcluded);
+  EXPECT_EQ(dut.states().size(), 2);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.states().at(RightOfWayRule::State::Id("s1")),
+                               kNoYieldState));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.states().at(RightOfWayRule::State::Id("s2")),
+                               kYieldingState));
+  EXPECT_FALSE(dut.is_static());
+  EXPECT_THROW(dut.static_state(), std::exception);
+}
+
+
+// Specifically test the different results for a static (single state) rule.
+GTEST_TEST(RightOfWayRuleTest, StaticRuleOnlyAccessors) {
+  const RightOfWayRule dut(
+      RightOfWayRule::Id("dut_id"),
+      kZone,
+      RightOfWayRule::ZoneType::kStopExcluded,
+      {kYieldingState});
+  EXPECT_TRUE(dut.is_static());
+  EXPECT_NO_THROW(dut.static_state());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.static_state(), kYieldingState));
 }
 
 
 GTEST_TEST(RightOfWayRuleTest, Copying) {
-  const RightOfWayRule source(RightOfWayRule::Id("dut_id"), kZone,
-                              RightOfWayRule::Type::kStopThenGo);
+  const RightOfWayRule source(
+      RightOfWayRule::Id("source_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState, kYieldingState});
 
   const RightOfWayRule dut(source);
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, source));
@@ -46,13 +150,61 @@ GTEST_TEST(RightOfWayRuleTest, Copying) {
 
 
 GTEST_TEST(RightOfWayRuleTest, Assignment) {
-  const RightOfWayRule source(RightOfWayRule::Id("dut_id"), kZone,
-                              RightOfWayRule::Type::kStopThenGo);
-  RightOfWayRule dut(RightOfWayRule::Id("other_id"),
-                     LaneSRoute({{LaneId("z"), {3., 4.}}}),
-                     RightOfWayRule::Type::kYield);
+  const RightOfWayRule source(
+      RightOfWayRule::Id("source_id"),
+      kZone, RightOfWayRule::ZoneType::kStopExcluded,
+      {kNoYieldState, kYieldingState});
+
+  RightOfWayRule dut(RightOfWayRule::Id("some_id"),
+                     kZone, RightOfWayRule::ZoneType::kStopAllowed,
+                     {kNoYieldState});
+
   dut = source;
   EXPECT_TRUE(MALIPUT_IS_EQUAL(dut, source));
+}
+
+
+class RightOfWayStateProviderTest : public ::testing::Test {
+ protected:
+  const RightOfWayRule::Id kExistingId{"aye"};
+  const RightOfWayRule::Id kNonExistingId{"nay"};
+
+  const RightOfWayRule::State::Id kCurrentStateId{"state"};
+  const RightOfWayRule::State::Id kNextStateId{"next"};
+  const double kDurationUntil{99.};
+
+  class MockStateProvider : public RightOfWayStateProvider {
+   public:
+    explicit MockStateProvider(const RightOfWayStateProviderTest* fixture)
+        : fixture_(fixture) {}
+   private:
+    drake::optional<Result> DoGetState(
+        const RightOfWayRule::Id& id) const final {
+      if (id == fixture_->kExistingId) {
+        return Result{fixture_->kCurrentStateId,
+                      Result::Next{fixture_->kNextStateId,
+                                   fixture_->kDurationUntil}};
+      }
+      return nullopt;
+    }
+
+    const RightOfWayStateProviderTest* const fixture_;
+  };
+};
+
+
+TEST_F(RightOfWayStateProviderTest, ExerciseInterface) {
+  using Result = RightOfWayStateProvider::Result;
+
+  const MockStateProvider dut(this);
+
+  EXPECT_TRUE(dut.GetState(kExistingId).has_value());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetState(kExistingId).value(),
+      (Result{kCurrentStateId,
+              Result::Next{kNextStateId, kDurationUntil}})));
+
+  EXPECT_FALSE(dut.GetState(kNonExistingId).has_value());
 }
 
 

--- a/automotive/maliput/api/test/rules_road_rulebook_test.cc
+++ b/automotive/maliput/api/test/rules_road_rulebook_test.cc
@@ -18,9 +18,13 @@ namespace {
 
 const LaneSRange kZone(LaneId("some_lane"), {10., 20.});
 
-const RightOfWayRule kRightOfWay(RightOfWayRule::Id("rowr_id"),
-                                 LaneSRoute({kZone}),
-                                 RightOfWayRule::Type::kStopThenGo);
+const RightOfWayRule kRightOfWay(
+    RightOfWayRule::Id("rowr_id"),
+    LaneSRoute({kZone}), RightOfWayRule::ZoneType::kStopExcluded,
+    {RightOfWayRule::State(
+        RightOfWayRule::State::Id("green"),
+        RightOfWayRule::State::Type::kGo,
+        {})});
 
 const SpeedLimitRule kSpeedLimit(SpeedLimitRule::Id("slr_id"),
                                  kZone,

--- a/automotive/maliput/api/test_utilities/rules_right_of_way_compare.cc
+++ b/automotive/maliput/api/test_utilities/rules_right_of_way_compare.cc
@@ -1,5 +1,9 @@
 #include "drake/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h"
 
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
@@ -12,17 +16,78 @@ namespace rules {
 namespace test {
 
 
-/// Predicate-formatter which tests equality of RightOfWayRule::Type.
-// TODO(maddog@tri.global)  This should be replaced by a generic predicate
-//                          which handles anything with operator==.
 ::testing::AssertionResult IsEqual(const char* a_expression,
                                    const char* b_expression,
-                                   rules::RightOfWayRule::Type a,
-                                   rules::RightOfWayRule::Type b) {
+                                   rules::RightOfWayRule::ZoneType a,
+                                   rules::RightOfWayRule::ZoneType b) {
   return ::testing::internal::CmpHelperEQ(a_expression, b_expression, a, b);
 }
 
-/// Predicate-formatter which tests equality of RightOfWayRule.
+
+::testing::AssertionResult IsEqual(const char* a_expression,
+                                   const char* b_expression,
+                                   rules::RightOfWayRule::State::Type a,
+                                   rules::RightOfWayRule::State::Type b) {
+  return ::testing::internal::CmpHelperEQ(a_expression, b_expression, a, b);
+}
+
+
+// TODO(maddog@tri.global)  Make a generic template for vector<T>.
+::testing::AssertionResult IsEqual(
+     const char* a_expression, const char* b_expression,
+     const std::vector<rules::RightOfWayRule::Id>& a,
+     const std::vector<rules::RightOfWayRule::Id>& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.size(), b.size()));
+  const int smallest = std::min(a.size(), b.size());
+  for (int i = 0; i < smallest; ++i) {
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a[i], b[i]));
+  }
+  return c.result();
+}
+
+
+::testing::AssertionResult IsEqual(const char* a_expression,
+                                   const char* b_expression,
+                                   const rules::RightOfWayRule::State& a,
+                                   const rules::RightOfWayRule::State& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.id(), b.id()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.type(), b.type()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.yield_to(), b.yield_to()));
+  return c.result();
+}
+
+
+::testing::AssertionResult IsEqual(
+     const char* a_expression, const char* b_expression,
+     const std::unordered_map<rules::RightOfWayRule::State::Id,
+                              rules::RightOfWayRule::State>& a,
+     const std::unordered_map<rules::RightOfWayRule::State::Id,
+                              rules::RightOfWayRule::State>& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.size(), b.size()));
+  const std::unordered_map<rules::RightOfWayRule::State::Id,
+                           rules::RightOfWayRule::State>& largest =
+      (a.size() < b.size()) ? b : a;
+
+  for (const auto& pair : largest) {
+    const rules::RightOfWayRule::State::Id& key = pair.first;
+    auto a_it = a.find(key);
+    auto b_it = b.find(key);
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL((a_it != a.cend()), true));
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL((b_it != b.cend()), true));
+    if ((a_it != a.cend()) && (b_it != b.cend())) {
+      MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a_it->second, b_it->second));
+    }
+  }
+  return c.result();
+}
+
+
 ::testing::AssertionResult IsEqual(const char* a_expression,
                                    const char* b_expression,
                                    const rules::RightOfWayRule& a,
@@ -30,13 +95,39 @@ namespace test {
   unused(a_expression, b_expression);
   AssertionResultCollector c;
   MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.id(), b.id()));
-  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.controlled_zone(),
-                                         b.controlled_zone()));
-  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.type(), b.type()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.zone(), b.zone()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.zone_type(), b.zone_type()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.states(), b.states()));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.is_static(), b.is_static()));
+  if (a.is_static() && b.is_static()) {
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.static_state(), b.static_state()));
+  }
   return c.result();
 }
 
 
+::testing::AssertionResult IsEqual(
+     const char* a_expression,
+     const char* b_expression,
+     const rules::RightOfWayStateProvider::Result& a,
+     const rules::RightOfWayStateProvider::Result& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.current_id, b.current_id));
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.next.has_value(),
+                                         b.next.has_value()));
+  if (a.next.has_value() && b.next.has_value()) {
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.next->id, b.next->id));
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.next->duration_until.has_value(),
+                                           b.next->duration_until.has_value()));
+    if (a.next->duration_until.has_value() &&
+        b.next->duration_until.has_value()) {
+      MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.next->duration_until.value(),
+                                             b.next->duration_until.value()));
+    }
+  }
+  return c.result();
+}
 
 
 }  // namespace test

--- a/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h
+++ b/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h
@@ -12,13 +12,29 @@ namespace rules {
 namespace test {
 
 
-/// Predicate-formatter which tests equality of RightOfWayRule::Type.
+/// Predicate-formatter which tests equality of RightOfWayRule::ZoneType.
 // TODO(maddog@tri.global)  This should be replaced by a generic predicate
 //                          which handles anything with operator==.
 ::testing::AssertionResult IsEqual(const char* a_expression,
                                    const char* b_expression,
-                                   rules::RightOfWayRule::Type a,
-                                   rules::RightOfWayRule::Type b);
+                                   rules::RightOfWayRule::ZoneType a,
+                                   rules::RightOfWayRule::ZoneType b);
+
+
+/// Predicate-formatter which tests equality of RightOfWayRule::State::Type.
+// TODO(maddog@tri.global)  This should be replaced by a generic predicate
+//                          which handles anything with operator==.
+::testing::AssertionResult IsEqual(const char* a_expression,
+                                   const char* b_expression,
+                                   rules::RightOfWayRule::State::Type a,
+                                   rules::RightOfWayRule::State::Type b);
+
+
+/// Predicate-formatter which tests equality of RightOfWayRule::State.
+::testing::AssertionResult IsEqual(const char* a_expression,
+                                   const char* b_expression,
+                                   const rules::RightOfWayRule::State& a,
+                                   const rules::RightOfWayRule::State& b);
 
 
 /// Predicate-formatter which tests equality of RightOfWayRule.
@@ -26,6 +42,14 @@ namespace test {
                                    const char* b_expression,
                                    const rules::RightOfWayRule& a,
                                    const rules::RightOfWayRule& b);
+
+
+/// Predicate-formatter which tests equality of RightOfWayStateProvider::Result.
+::testing::AssertionResult IsEqual(
+     const char* a_expression,
+     const char* b_expression,
+     const rules::RightOfWayStateProvider::Result& a,
+     const rules::RightOfWayStateProvider::Result& b);
 
 
 }  // namespace test

--- a/automotive/maliput/simplerulebook/simple_rulebook.cc
+++ b/automotive/maliput/simplerulebook/simple_rulebook.cc
@@ -63,13 +63,13 @@ class SimpleRulebook::RangeIndex {
   }
 
   void AddRule(const RightOfWayRule& rule) {
-    for (const LaneSRange& range : rule.controlled_zone().ranges()) {
+    for (const LaneSRange& range : rule.zone().ranges()) {
       AddRange(rule.id(), range);
     }
   }
 
   void RemoveRule(const RightOfWayRule& rule) {
-    for (const LaneSRange& range : rule.controlled_zone().ranges()) {
+    for (const LaneSRange& range : rule.zone().ranges()) {
       RemoveRanges(rule.id(), range.lane_id());
     }
   }

--- a/automotive/maliput/simplerulebook/test/simple_rulebook_test.cc
+++ b/automotive/maliput/simplerulebook/test/simple_rulebook_test.cc
@@ -23,9 +23,13 @@ using api::rules::SpeedLimitRule;
 
 const LaneSRange kZone(LaneId("a"), {10., 20.});
 
-const RightOfWayRule kRightOfWay(RightOfWayRule::Id("rowr_id"),
-                                 LaneSRoute({kZone}),
-                                 RightOfWayRule::Type::kStopThenGo);
+const RightOfWayRule kRightOfWay(
+    RightOfWayRule::Id("rowr_id"),
+    LaneSRoute({kZone}),
+    RightOfWayRule::ZoneType::kStopExcluded,
+    {RightOfWayRule::State{RightOfWayRule::State::Id("rowr_state_id"),
+                           RightOfWayRule::State::Type::kStopThenGo,
+                           {}}});
 
 const SpeedLimitRule kSpeedLimit(SpeedLimitRule::Id("slr_id"),
                                  kZone,

--- a/automotive/maliput/simplerulebook/yaml_io.h
+++ b/automotive/maliput/simplerulebook/yaml_io.h
@@ -30,11 +30,17 @@ namespace simplerulebook {
 ///     .
 ///   right_of_way:  # RightOfWayRule group
 ///     ID1:  # ID, as a string
-///       controlled_zone:  # sequence of LaneSRange items
+///       zone:  # sequence of LaneSRange items
 ///         - [LANE_ID, S0, S1]
 ///         - [LANE_ID, S0, S1]
 ///         - [LANE_ID, S0, S1]
-///       type: StopThenGo  # ...the Type enum, without the leading 'k'
+///       zone_type: StopExcluded  # ...ZoneType enum, without the leading 'k'
+///       states:
+///         STATE_ID1:
+///           type: StopThenGo  # ...Type enum, without the leading 'k'
+///           yield_to:
+///             - OTHER_RULE_ID
+///             - OTHER_RULE_ID
 ///     .
 ///     .
 ///     .

--- a/automotive/test/trivial_right_of_way_state_provider_test.cc
+++ b/automotive/test/trivial_right_of_way_state_provider_test.cc
@@ -4,33 +4,39 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/test_utilities/rules_right_of_way_compare.h"
+
 namespace drake {
 namespace automotive {
 namespace {
 
 using maliput::api::rules::RightOfWayRule;
+using maliput::api::rules::RightOfWayStateProvider;
 
 GTEST_TEST(TrivialRightOfWayStateProviderTest, BasicTest) {
   TrivialRightOfWayStateProvider dut;
-  RightOfWayRule::Id id("foo");
+  const RightOfWayRule::Id kRuleId("foo");
+  const RightOfWayRule::State::Id kStateId("bar");
 
   // No rule with specified ID exists.
-  EXPECT_THROW(dut.GetState(id), std::out_of_range);
-  EXPECT_THROW(dut.SetState(id, RightOfWayRule::DynamicState::kUncontrolled),
-               std::out_of_range);
+  EXPECT_FALSE(dut.GetState(kRuleId).has_value());
+  EXPECT_THROW(dut.SetState(kRuleId, kStateId), std::out_of_range);
 
-  dut.AddState(id, RightOfWayRule::DynamicState::kGo);
-  EXPECT_EQ(dut.GetState(id), RightOfWayRule::DynamicState::kGo);
+  dut.AddState(kRuleId, kStateId);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetState(kRuleId).value(),
+      (RightOfWayStateProvider::Result{kStateId, nullopt})));
 
   // Attempting to add duplicate state.
-  EXPECT_THROW(dut.AddState(id, RightOfWayRule::DynamicState::kStop),
-               std::logic_error);
+  EXPECT_THROW(dut.AddState(kRuleId, kStateId), std::logic_error);
 
-  dut.SetState(id, RightOfWayRule::DynamicState::kPrepareToStop);
-  EXPECT_EQ(dut.GetState(id), RightOfWayRule::DynamicState::kPrepareToStop);
+  const RightOfWayRule::State::Id kOtherStateId("baz");
+  dut.SetState(kRuleId, kOtherStateId);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetState(kRuleId).value(),
+      (RightOfWayStateProvider::Result{kOtherStateId, nullopt})));
 }
 
 }  // namespace
 }  // namespace automotive
 }  // namespace drake
-

--- a/automotive/trivial_right_of_way_state_provider.cc
+++ b/automotive/trivial_right_of_way_state_provider.cc
@@ -12,8 +12,8 @@ using maliput::api::rules::RightOfWayRule;
 
 void TrivialRightOfWayStateProvider::AddState(
     const RightOfWayRule::Id& id,
-    const RightOfWayRule::DynamicState& initial_state) {
-  auto result = dynamic_states_.emplace(id, initial_state);
+    const RightOfWayRule::State::Id& initial_state) {
+  auto result = states_.emplace(id, initial_state);
   if (!result.second) {
      throw std::logic_error(
         "Attempted to add multiple rules with id " + id.string());
@@ -22,13 +22,18 @@ void TrivialRightOfWayStateProvider::AddState(
 
 void TrivialRightOfWayStateProvider::SetState(
     const RightOfWayRule::Id& id,
-    const RightOfWayRule::DynamicState& state) {
-  dynamic_states_.at(id) = state;
+    const RightOfWayRule::State::Id& state) {
+  states_.at(id) = state;
 }
 
-RightOfWayRule::DynamicState TrivialRightOfWayStateProvider::DoGetState(
+drake::optional<maliput::api::rules::RightOfWayStateProvider::Result>
+TrivialRightOfWayStateProvider::DoGetState(
     const RightOfWayRule::Id& id) const {
-  return dynamic_states_.at(id);
+  auto it = states_.find(id);
+  if (it == states_.end()) {
+    return nullopt;
+  }
+  return Result{it->second, nullopt};
 }
 
 }  // namespace automotive

--- a/automotive/trivial_right_of_way_state_provider.h
+++ b/automotive/trivial_right_of_way_state_provider.h
@@ -27,21 +27,23 @@ class TrivialRightOfWayStateProvider final
   /// Throws std::runtime_error if the dynamic state failed to be added.
   void AddState(
       const maliput::api::rules::RightOfWayRule::Id& id,
-      const maliput::api::rules::RightOfWayRule::DynamicState& initial_state);
+      const maliput::api::rules::RightOfWayRule::State::Id& initial_state);
 
   /// Sets the dynamic state of a RightOfWayRule within this provider.
   ///
   /// Throws std::out_of_range if no dynamic state with @p id exists in this
   /// provider.
   void SetState(const maliput::api::rules::RightOfWayRule::Id& id,
-                const maliput::api::rules::RightOfWayRule::DynamicState& state);
+                const maliput::api::rules::RightOfWayRule::State::Id& state);
 
  private:
-  maliput::api::rules::RightOfWayRule::DynamicState DoGetState(
-      const maliput::api::rules::RightOfWayRule::Id& id) const final;
+  drake::optional<maliput::api::rules::RightOfWayStateProvider::Result>
+      DoGetState(
+          const maliput::api::rules::RightOfWayRule::Id& id) const final;
 
-  std::unordered_map<maliput::api::rules::RightOfWayRule::Id,
-      maliput::api::rules::RightOfWayRule::DynamicState> dynamic_states_;
+  std::unordered_map<
+    maliput::api::rules::RightOfWayRule::Id,
+    maliput::api::rules::RightOfWayRule::State::Id> states_;
 };
 
 }  // namespace automotive


### PR DESCRIPTION
The overall design is much improved, even without the yield aspect
(which, it turns out, is a really important aspect).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8886)
<!-- Reviewable:end -->
