### PR TITLE
Add fmt dependency to drake_shared_library

### DIFF
--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -97,12 +97,17 @@ cc_library(
     ],
 )
 
-# Provide a cc_library target that provides libdrake.so, its headers, and its
-# required *.so's that are WORKSPACE downloads (such as VTK, Gurobi, etc).
+# Provide a cc_library target that provides libdrake.so, its headers, its
+# header-only dependencies, and its required *.so's that are WORKSPACE
+# downloads (such as VTK, Gurobi, etc).
 #
 # TODO(jwnimmer-tri) Ideally, Bazel should be able to handle the depended-on
 # *.so files for us, without us having to know up-front here which dependencies
 # are coming from the WORKSPACE in the form of *.so.
+#
+# TODO(jwnimmer-tri) Ideally, drake_cc_library's installed_headers support
+# would capture a list of headerfile dependencies, so that we don't need to
+# write out the "list of libraries directly mentioned in Drake headers" below.
 cc_library(
     name = "drake_shared_library",
     hdrs = [":libdrake_headers"],
@@ -113,6 +118,7 @@ cc_library(
         "//examples:__subpackages__",
     ],
     deps = [
+        # The list of depended-on *.so files.
         ":gurobi_deps",
         ":mosek_deps",
         ":vtk_deps",
@@ -124,6 +130,9 @@ cc_library(
         "@osqp",
         "@scs//:scsdir",
         "@tinyxml2",
+    ] + [
+        # The list of libraries directly mentioned in Drake headers.
+        "@fmt",
     ],
 )
 


### PR DESCRIPTION
Drake's headers directly include `fmt`, so in order to compile the `pydrake` bindings, we need to have `fmt` as a dependency.

I've pulled this up and out of #8889.  This also appears to be needed for #8875.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8892)
<!-- Reviewable:end -->
