### PR TITLE
Add num_shards=10 for multilane_lanes_test

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -127,6 +127,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "multilane_lanes_test",
     srcs = ["test/multilane_lanes_test.cc"],
+    shard_count = 10,
     deps = [
         ":lanes",
         "//automotive/maliput/api/test_utilities",


### PR DESCRIPTION
Similar reason as #8880 
Failing builds:
[1](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind/), [2](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/linux-xenial-clang-bazel-nightly-memcheck-valgrind-everything/), [3](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-highsierra-clang-bazel-nightly-memcheck-tsan/), [4](https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-sierra-clang-bazel-nightly-memcheck-tsan/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8893)
<!-- Reviewable:end -->
