### PR TITLE
Add BasicVector initializer_list constructor

### DIFF
--- a/systems/framework/basic_vector.h
+++ b/systems/framework/basic_vector.h
@@ -29,6 +29,9 @@ class BasicVector : public VectorBase<T> {
   // assignment of a BasicVector could change its size.)
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BasicVector)
 
+  /// Constructs an empty BasicVector.
+  BasicVector() = default;
+
   /// Initializes with the given @p size using the drake::dummy_value<T>, which
   /// is NaN when T = double.
   explicit BasicVector(int size)
@@ -38,14 +41,18 @@ class BasicVector : public VectorBase<T> {
   explicit BasicVector(const VectorX<T>& data) : values_(data) {}
 
   /// Constructs a BasicVector whose elements are the elements of @p data.
-  static std::unique_ptr<BasicVector<T>> Make(
-      const std::initializer_list<T>& data) {
-    auto vec = std::make_unique<BasicVector<T>>(data.size());
+  BasicVector(const std::initializer_list<T>& data)
+      : BasicVector<T>(data.size()) {
     int i = 0;
     for (const T& datum : data) {
-      vec->SetAtIndex(i++, datum);
+      this->SetAtIndex(i++, datum);
     }
-    return vec;
+  }
+
+  /// Constructs a BasicVector whose elements are the elements of @p data.
+  static std::unique_ptr<BasicVector<T>> Make(
+      const std::initializer_list<T>& data) {
+    return std::make_unique<BasicVector<T>>(data);
   }
 
   /// Constructs a BasicVector where each element is constructed using the

--- a/systems/framework/test/basic_vector_test.cc
+++ b/systems/framework/test/basic_vector_test.cc
@@ -15,12 +15,35 @@ namespace drake {
 namespace systems {
 namespace {
 
+// Tests the initializer_list functionality.
+GTEST_TEST(BasicVectorTest, InitializerList) {
+  const BasicVector<double> empty1;  // Default constructor.
+  const BasicVector<double> empty2{};  // Initializer list.
+  EXPECT_EQ(0, empty1.size());
+  EXPECT_EQ(0, empty2.size());
+
+  const BasicVector<double> pair{1.0, 2.0};
+  ASSERT_EQ(2, pair.size());
+  EXPECT_EQ(1.0, pair[0]);
+  EXPECT_EQ(2.0, pair[1]);
+
+  const BasicVector<double> from_floats{3.0f, 4.0f, 5.0f};
+  ASSERT_EQ(3, from_floats.size());
+  EXPECT_EQ(3.0, from_floats[0]);
+  EXPECT_EQ(4.0, from_floats[1]);
+  EXPECT_EQ(5.0, from_floats[2]);
+
+  const BasicVector<AutoDiffXd> autodiff{22.0};
+  ASSERT_EQ(1, autodiff.size());
+  EXPECT_EQ(22.0, autodiff[0].value());
+}
+
 // Tests SetZero functionality.
 GTEST_TEST(BasicVectorTest, SetZero) {
-  auto vec = BasicVector<double>::Make(1.0, 2.0, 3.0);
-  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec->get_value());
-  vec->SetZero();
-  EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec->get_value());
+  BasicVector<double> vec{1.0, 2.0, 3.0};
+  EXPECT_EQ(Eigen::Vector3d(1.0, 2.0, 3.0), vec.get_value());
+  vec.SetZero();
+  EXPECT_EQ(Eigen::Vector3d(0, 0, 0), vec.get_value());
 }
 
 // Tests that the BasicVector<double> is initialized to NaN.
@@ -44,6 +67,14 @@ GTEST_TEST(BasicVectorTest, AutodiffInitiallyNaN) {
 GTEST_TEST(BasicVectorTest, SymbolicInitiallyNaN) {
   BasicVector<symbolic::Expression> vec(1);
   EXPECT_TRUE(symbolic::is_nan(vec.get_value()[0]));
+}
+
+// Tests BasicVector<T>::Make.
+GTEST_TEST(BasicVectorTest, Make) {
+  auto dut1 = BasicVector<double>::Make(1.0, 2.0);
+  auto dut2 = BasicVector<double>::Make({3.0, 4.0});
+  EXPECT_TRUE(CompareMatrices(dut1->get_value(), Eigen::Vector2d(1.0, 2.0)));
+  EXPECT_TRUE(CompareMatrices(dut2->get_value(), Eigen::Vector2d(3.0, 4.0)));
 }
 
 // Tests that BasicVector<symbolic::Expression>::Make does what it says on
@@ -135,7 +166,7 @@ GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
   AutoDiffXd element1;
   element1.value() = 22.5;
   element1.derivatives() = Vector1d(3.5);
-  auto dut = BasicVector<AutoDiffXd>::Make({element0, element1});
+  BasicVector<AutoDiffXd> dut{element0, element1};
 
   // The norminf(DUT) is 22.5 and the ∂/∂t of norminf(DUT) is 3.5.
   // The element1 has the max absolute value of the AutoDiffScalar's scalar.
@@ -143,18 +174,18 @@ GTEST_TEST(BasicVectorTest, NormInfAutodiff) {
   AutoDiffXd expected_norminf;
   expected_norminf.value() = 22.5;
   expected_norminf.derivatives() = Vector1d(3.5);
-  EXPECT_EQ(dut->NormInf().value(), expected_norminf.value());
-  EXPECT_EQ(dut->NormInf().derivatives(), expected_norminf.derivatives());
+  EXPECT_EQ(dut.NormInf().value(), expected_norminf.value());
+  EXPECT_EQ(dut.NormInf().derivatives(), expected_norminf.derivatives());
 
   // We change the DUT to two values [-11.5, -33.5] with ∂/∂t of [1.5, 3.5].
   // The norminf(DUT) is now 33.5 and the ∂/∂t of norminf(DUT) is -3.5.
   // The element0 has the max absolute value of the AutoDiffScalar's scalar.
   // It is negative, so the sign of its derivatives gets flipped.
-  dut->GetAtIndex(0).value() = -33.5;
+  dut.GetAtIndex(0).value() = -33.5;
   expected_norminf.value() = 33.5;
   expected_norminf.derivatives() = Vector1d(-1.5);
-  EXPECT_EQ(dut->NormInf().value(), expected_norminf.value());
-  EXPECT_EQ(dut->NormInf().derivatives(), expected_norminf.derivatives());
+  EXPECT_EQ(dut.NormInf().value(), expected_norminf.value());
+  EXPECT_EQ(dut.NormInf().derivatives(), expected_norminf.derivatives());
 }
 
 // Tests all += * operations for BasicVector.

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -28,7 +28,7 @@ class TestSystem : public LeafSystem<T> {
  public:
   TestSystem() {
     this->set_name("TestSystem");
-    this->DeclareNumericParameter(BasicVector<T>(Vector2<T>(13.0, 7.0)));
+    this->DeclareNumericParameter(BasicVector<T>{13.0, 7.0});
     this->DeclareAbstractParameter(Value<std::string>("parameter value"));
   }
   ~TestSystem() override {}
@@ -631,7 +631,7 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
     this->DeclareNumericParameter(*MyVector2d::Make(1.1, 2.2));
   }
 
-  const BasicVector<double>& expected_basic() const { return *expected_basic_; }
+  const BasicVector<double>& expected_basic() const { return expected_basic_; }
   const MyVector4d& expected_myvector() const { return *expected_myvector_; }
 
  private:
@@ -657,8 +657,7 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
     *out = "concrete string";
   }
 
-  std::unique_ptr<BasicVector<double>> expected_basic_{
-      BasicVector<double>::Make(1., .5, .25)};
+  const BasicVector<double> expected_basic_{1., .5, .25};
   std::unique_ptr<MyVector4d> expected_myvector_{
       MyVector4d::Make(4., 3., 2., 1.)};
 };

--- a/systems/framework/test/output_port_value_test.cc
+++ b/systems/framework/test/output_port_value_test.cc
@@ -14,9 +14,8 @@ namespace systems {
 class OutputPortVectorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(2));
-    vec->get_mutable_value() << 5, 6;
-    output_port_value_.reset(new OutputPortValue(std::move(vec)));
+    const BasicVector<double> vec{5, 6};
+    output_port_value_.reset(new OutputPortValue(vec.Clone()));
   }
 
   std::unique_ptr<OutputPortValue> output_port_value_;
@@ -98,14 +97,12 @@ class LeafSystemOutputTest : public ::testing::Test {
  protected:
   void SetUp() override {
     {
-      std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(2));
-      vec->get_mutable_value() << 5, 25;
-      output_.add_port(std::make_unique<OutputPortValue>(std::move(vec)));
+      const BasicVector<double> vec{5, 25};
+      output_.add_port(std::make_unique<OutputPortValue>(vec.Clone()));
     }
     {
-      std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(3));
-      vec->get_mutable_value() << 125, 625, 3125;
-      output_.add_port(std::make_unique<OutputPortValue>(std::move(vec)));
+      const BasicVector<double> vec{125, 625, 3125};
+      output_.add_port(std::make_unique<OutputPortValue>(vec.Clone()));
     }
   }
 

--- a/systems/framework/test/subvector_test.cc
+++ b/systems/framework/test/subvector_test.cc
@@ -85,9 +85,7 @@ TEST_F(SubvectorTest, ArrayOperator) {
 
 // Tests that a VectorBase can be added to a Subvector.
 TEST_F(SubvectorTest, PlusEq) {
-  BasicVector<double> addend(2);
-  addend.SetAtIndex(0, 7);
-  addend.SetAtIndex(1, 8);
+  const BasicVector<double> addend{7, 8};
 
   Subvector<double> subvec(vector_.get(), 1, kSubVectorLength);
   subvec += addend;
@@ -171,13 +169,11 @@ TEST_F(SubvectorTest, InfNormAutodiff) {
 // Tests all += * operations for VectorBase.
 TEST_F(SubvectorTest, PlusEqScaled) {
   Subvector<double> orig_vec(vector_.get(), 0, kSubVectorLength);
-  BasicVector<double> vec1(2), vec2(2), vec3(2), vec4(2), vec5(2);
-  Eigen::Vector2d ans1, ans2, ans3, ans4, ans5;
-  vec1.get_mutable_value() << 1, 2;
-  vec2.get_mutable_value() << 3, 5;
-  vec3.get_mutable_value() << 7, 11;
-  vec4.get_mutable_value() << 13, 17;
-  vec5.get_mutable_value() << 19, 23;
+  BasicVector<double> vec1{1, 2};
+  BasicVector<double> vec2{3, 5};
+  BasicVector<double> vec3{7, 11};
+  BasicVector<double> vec4{13, 17};
+  BasicVector<double> vec5{19, 23};
   VectorBase<double>& v1 = vec1;
   VectorBase<double>& v2 = vec2;
   VectorBase<double>& v3 = vec3;

--- a/systems/sensors/accelerometer_output.cc
+++ b/systems/sensors/accelerometer_output.cc
@@ -9,9 +9,8 @@ const int AccelerometerOutputConstants::kAccelYIndex;
 const int AccelerometerOutputConstants::kAccelZIndex;
 
 template <typename T>
-AccelerometerOutput<T>::AccelerometerOutput() : BasicVector<double>(3) {
-  this->SetFromVector(VectorX<double>::Zero(3));
-}
+AccelerometerOutput<T>::AccelerometerOutput()
+    : BasicVector<double>(VectorX<double>::Zero(3)) {}
 
 template <typename T>
 Vector3<T> AccelerometerOutput<T>::get_accel() const {

--- a/systems/sensors/depth_sensor_output.cc
+++ b/systems/sensors/depth_sensor_output.cc
@@ -15,9 +15,8 @@ namespace sensors {
 
 template <typename T>
 DepthSensorOutput<T>::DepthSensorOutput(const DepthSensorSpecification& spec)
-    : BasicVector<double>(spec.num_depth_readings()), spec_(spec) {
-  this->SetFromVector(VectorX<double>::Zero(spec_.num_depth_readings()));
-}
+    : BasicVector<double>(VectorX<double>::Zero(spec.num_depth_readings())),
+      spec_(spec) {}
 
 template <typename T>
 double DepthSensorOutput<T>::GetTooFarDistance() {

--- a/systems/sensors/gyroscope_output.cc
+++ b/systems/sensors/gyroscope_output.cc
@@ -9,9 +9,8 @@ const int GyroscopeOutputConstants::kIndexWy;
 const int GyroscopeOutputConstants::kIndexWz;
 
 template <typename T>
-GyroscopeOutput<T>::GyroscopeOutput() : BasicVector<double>(3) {
-  this->SetFromVector(VectorX<double>::Zero(3));
-}
+GyroscopeOutput<T>::GyroscopeOutput()
+    : BasicVector<double>(VectorX<double>::Zero(3)) {}
 
 template <typename T>
 Vector3<T> GyroscopeOutput<T>::get_rotational_velocities() const {


### PR DESCRIPTION
We should make it easy to use terse initialization (without having to deal with heap lifetime issues, like `BasicVector::Make` currently does).

This also ports several call sites to use the new sugar as a proof of concept.  Many more call sites of `FixInputPort` can also be ported after this merges.  (See the final commit in https://github.com/jwnimmer-tri/drake/commits/framework-fixinputport-overloads-pr4 for more example uses of this API.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8894)
<!-- Reviewable:end -->
