### PR TITLE
Prefer to use FixInputPort initializer_list overload

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1275,7 +1275,7 @@ class System : public SystemBase {
         for (int j = 0; j < our_vec->size(); ++j) {
           our_vec->SetAtIndex(j, T(other_vec->GetAtIndex(j)));
         }
-        target_context->FixInputPort(i, std::move(our_vec));
+        target_context->FixInputPort(i, *our_vec);
       } else if (descriptor.get_data_type() == kAbstractValued) {
         // For abstract-valued input ports, we just clone the value and fix
         // it to the port.

--- a/systems/framework/system_scalar_conversion_doxygen.h
+++ b/systems/framework/system_scalar_conversion_doxygen.h
@@ -30,7 +30,7 @@ code sample compiles and runs successfully.
   //   tau = 0, theta = 0.1, thetadot = 0.2.
   auto plant = std::make_unique<PendulumPlant<double>>();
   auto context = plant->CreateDefaultContext();
-  context->FixInputPort(0, Vector1d::Zero());  // tau
+  context->FixInputPort(0, {0.0});  // tau
   auto* state = dynamic_cast<PendulumState<double>*>(
       context->get_mutable_continuous_state_vector());
   state->set_theta(0.1);

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -91,7 +91,7 @@ void SystemSymbolicInspector::InitializeVectorInputs(
       input_variables_[i][j] = symbolic::Variable(name.str());
       value->SetAtIndex(j, input_variables_[i][j]);
     }
-    context_->FixInputPort(i, std::move(value));
+    context_->FixInputPort(i, *value);
   }
 }
 

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -111,8 +111,8 @@ class DiagramContextTest : public ::testing::Test {
   }
 
   void AttachInputPorts() {
-    context_->FixInputPort(0, BasicVector<double>::Make({128}));
-    context_->FixInputPort(1, BasicVector<double>::Make({256}));
+    context_->FixInputPort(0, {128.0});
+    context_->FixInputPort(1, {256.0});
   }
 
   // Reads a FixedInputPortValue connected to @p context at @p index.

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -38,14 +38,11 @@ class MyContextBase : public ContextBase {
 class FixedInputPortTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    std::unique_ptr<BasicVector<double>> vec(new BasicVector<double>(2));
-    vec->get_mutable_value() << 5, 6;
     port0_value_ = &context_.FixInputPort(
-        InputPortIndex(0),
-        std::make_unique<Value<BasicVector<double>>>(std::move(vec)));
+        InputPortIndex(0), Value<BasicVector<double>>({5.0, 6.0}));
 
-    auto value = std::make_unique<Value<std::string>>("foo");
-    port1_value_ = &context_.FixInputPort(InputPortIndex(1), std::move(value));
+    port1_value_ = &context_.FixInputPort(
+        InputPortIndex(1), Value<std::string>("foo"));
 
     // TODO(sherm1) Tracker & ticket setup here.
 

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -49,8 +49,7 @@ class LeafContextTest : public ::testing::Test {
     // counter here so this test can add more ticketed things later.
     // (That's not allowed in user code.)
     for (int i = 0; i < kNumInputPorts; ++i) {
-      context_.FixInputPort(
-          i, std::make_unique<BasicVector<double>>(kInputSize[i]));
+      context_.FixInputPort(i, BasicVector<double>(kInputSize[i]));
       ++next_ticket_;
     }
 
@@ -254,7 +253,7 @@ TEST_F(LeafContextTest, GetVectorInput) {
   SetNumInputPorts(2, &context);
 
   // Add input port 0 to the context, but leave input port 1 uninitialized.
-  context.FixInputPort(0, BasicVector<double>::Make({5, 6}));
+  context.FixInputPort(0, {5.0, 6.0});
 
   // Test that port 0 is retrievable.
   VectorX<double> expected(2);
@@ -286,8 +285,7 @@ TEST_F(LeafContextTest, FixInputPort) {
   // Test the unique_ptr<BasicVector> overload.
   {
     FixedInputPortValue& value = context_.FixInputPort(
-        index, std::make_unique<BasicVector<double>>(
-            VectorXd::Constant(size, 3.0)));
+        index, VectorXd::Constant(size, 3.0));
     EXPECT_EQ(context_.MaybeGetFixedInputPortValue(index), &value);
     EXPECT_EQ(value.get_vector_value<double>()[0], 3.0);
   }

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -1737,9 +1737,9 @@ GTEST_TEST(SystemConstraintTest, ModelVectorTest) {
   EXPECT_TRUE(CompareMatrices(value1, Vector1<double>::Constant(-20.0)));
 
   // `u0[0] >= 33.0` with `u0[0] == 3.0` produces `-30.0 >= 0.0`.
-  auto input = std::make_unique<InputVector>();
-  input->SetAtIndex(0, 3.0);
-  context->FixInputPort(0, std::move(input));
+  InputVector input;
+  input.SetAtIndex(0, 3.0);
+  context->FixInputPort(0, input);
   Eigen::VectorXd value2;
   constraint2.Calc(*context, &value2);
   EXPECT_TRUE(CompareMatrices(value2, Vector1<double>::Constant(-30.0)));

--- a/systems/framework/test/system_scalar_conversion_doxygen_test.cc
+++ b/systems/framework/test/system_scalar_conversion_doxygen_test.cc
@@ -18,7 +18,7 @@ GTEST_TEST(SystemScalarConversionDoxygen, PendulumPlantAutodiff) {
   //   tau = 0, theta = 0.1, thetadot = 0.2.
   auto plant = std::make_unique<PendulumPlant<double>>();
   auto context = plant->CreateDefaultContext();
-  context->FixInputPort(0, Vector1d::Zero());  // tau
+  context->FixInputPort(0, {0.0});  // tau
   auto* state = dynamic_cast<PendulumState<double>*>(
       &context->get_mutable_continuous_state_vector());
   state->set_theta(0.1);

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -682,15 +682,10 @@ class SystemIOTest : public ::testing::Test {
     output_ = test_sys_.AllocateOutput(*context_);
 
     // make string input
-    std::unique_ptr<Value<std::string>> str_input =
-        std::make_unique<Value<std::string>>("input");
-    context_->FixInputPort(0, std::move(str_input));
+    context_->FixInputPort(0, Value<std::string>("input"));
 
     // make vector input
-    std::unique_ptr<BasicVector<double>> vec_input =
-        std::make_unique<BasicVector<double>>(1);
-    vec_input->SetAtIndex(0, 2);
-    context_->FixInputPort(1, std::move(vec_input));
+    context_->FixInputPort(1, {2.0});
   }
 
   ValueIOTestSystem<double> test_sys_;

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -221,7 +221,7 @@ TEST_F(VectorSystemTest, OutputStateless) {
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
   std::unique_ptr<AbstractValue> output = output_port.Allocate();
-  context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
+  context->FixInputPort(0, {1.0, 2.0});
   output_port.Calc(*context, output.get());
   EXPECT_EQ(dut.get_output_count(), 1);
   EXPECT_EQ(dut.get_last_context(), context.get());
@@ -244,7 +244,7 @@ TEST_F(VectorSystemTest, OutputContinuous) {
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
   std::unique_ptr<AbstractValue> output = output_port.Allocate();
-  context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
+  context->FixInputPort(0, {1.0, 2.0});
   context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d::Ones());
   output_port.Calc(*context, output.get());
@@ -267,7 +267,7 @@ TEST_F(VectorSystemTest, OutputDiscrete) {
   auto context = dut.CreateDefaultContext();
   auto& output_port = dut.get_output_port();
   std::unique_ptr<AbstractValue> output = output_port.Allocate();
-  context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
+  context->FixInputPort(0, {1.0, 2.0});
   context->get_mutable_discrete_state(0).SetFromVector(
       Eigen::Vector2d::Ones());
   output_port.Calc(*context, output.get());
@@ -302,7 +302,7 @@ TEST_F(VectorSystemTest, TimeDerivatives) {
   // Now we have state, so the VectorSystem base should call our DUT.
   dut.DeclareContinuousState(TestVectorSystem::kSize);
   context = dut.CreateDefaultContext();
-  context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
+  context->FixInputPort(0, {1.0, 2.0});
   context->get_mutable_continuous_state_vector().SetFromVector(
       Eigen::Vector2d::Ones());
   derivatives = dut.AllocateTimeDerivatives();
@@ -331,7 +331,7 @@ TEST_F(VectorSystemTest, DiscreteVariableUpdates) {
   // Now we have state, so the VectorSystem base should call our DUT.
   dut.set_prototype_discrete_state_count(1);
   context = dut.CreateDefaultContext();
-  context->FixInputPort(0, BasicVector<double>::Make({1, 2}));
+  context->FixInputPort(0, {1.0, 2.0});
   context->get_mutable_discrete_state(0).SetFromVector(
       Eigen::Vector2d::Ones());
   discrete_updates = dut.AllocateDiscreteVariables();


### PR DESCRIPTION
The `unique_ptr<BasicVector<T>>` overload is slated for deprecation.

This commit changes `systems/framework/**` to prefer this overload.
Other folders will be ported after this commit is approved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8905)
<!-- Reviewable:end -->
