### PR TITLE
[WIP] Possible ODR failure

### DIFF
--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -178,7 +178,6 @@ void DefineFrameworkPySemantics(py::module m) {
 
     auto system_output = DefineTemplateClassWithDefault<SystemOutput<T>>(
         m, "SystemOutput", GetPyParam<T>());
-    DefClone(&system_output);
     system_output
       .def("get_num_ports", &SystemOutput<T>::get_num_ports)
       .def("get_data", &SystemOutput<T>::get_data,

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -273,7 +273,9 @@ struct Impl {
              py::arg("input_port"), py::arg("output_port"))
         // Context.
         .def("CreateDefaultContext", &System<T>::CreateDefaultContext)
-        .def("AllocateOutput", &System<T>::AllocateOutput)
+        .def("AllocateOutput",
+             overload_cast_explicit<unique_ptr<SystemOutput<T>>>(
+                 &System<T>::AllocateOutput))
         .def(
             "EvalVectorInput",
             [](const System<T>* self, const Context<T>& arg1, int arg2) {

--- a/bindings/pydrake/systems/rgbd_camera_example.py
+++ b/bindings/pydrake/systems/rgbd_camera_example.py
@@ -43,7 +43,7 @@ x = np.zeros(tree.get_num_positions() + tree.get_num_velocities())
 # Allocate context and render.
 context = camera.CreateDefaultContext()
 context.FixInputPort(0, BasicVector(x))
-output = camera.AllocateOutput(context)
+output = camera.AllocateOutput()
 camera.CalcOutput(context, output)
 
 # Get images from computed output.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -103,7 +103,7 @@ class TestCustom(unittest.TestCase):
         system = self._create_adder_system()
         context = system.CreateDefaultContext()
         self._fix_adder_inputs(context)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         self.assertEquals(output.get_num_ports(), 1)
         system.CalcOutput(context, output)
         value = output.get_vector_data(0).get_value()

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -137,7 +137,7 @@ class TestGeneral(unittest.TestCase):
 
             def check_output(context):
                 # Check number of output ports and value for a given context.
-                output = system.AllocateOutput(context)
+                output = system.AllocateOutput()
                 self.assertEquals(output.get_num_ports(), 1)
                 system.CalcOutput(context, output)
                 if T == float:

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -156,7 +156,7 @@ class TestGeneral(unittest.TestCase):
         system = PassThrough(model_value.size())
         context = system.CreateDefaultContext()
         context.FixInputPort(0, model_value)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         input_eval = system.EvalVectorInput(context, 0)
         compare_value(self, input_eval, model_value)
         system.CalcOutput(context, output)
@@ -168,7 +168,7 @@ class TestGeneral(unittest.TestCase):
         system = PassThrough(model_value)
         context = system.CreateDefaultContext()
         context.FixInputPort(0, model_value)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         input_eval = system.EvalAbstractInput(context, 0)
         compare_value(self, input_eval, model_value)
         system.CalcOutput(context, output)
@@ -183,7 +183,7 @@ class TestGeneral(unittest.TestCase):
 
         for system in systems:
             context = system.CreateDefaultContext()
-            output = system.AllocateOutput(context)
+            output = system.AllocateOutput()
 
             def mytest(input, expected):
                 context.FixInputPort(0, BasicVector(input))
@@ -197,7 +197,7 @@ class TestGeneral(unittest.TestCase):
     def test_saturation(self):
         system = Saturation((0., -1., 3.), (1., 2., 4.))
         context = system.CreateDefaultContext()
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
 
         def mytest(input, expected):
             context.FixInputPort(0, BasicVector(input))
@@ -212,7 +212,7 @@ class TestGeneral(unittest.TestCase):
         system = WrapToSystem(2)
         system.set_interval(1, 1., 2.)
         context = system.CreateDefaultContext()
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
 
         def mytest(input, expected):
             context.FixInputPort(0, BasicVector(input))
@@ -238,7 +238,7 @@ class TestGeneral(unittest.TestCase):
             port_size = sum([len(vec) for vec in case['data']])
             self.assertEqual(mux.get_output_port(0).size(), port_size)
             context = mux.CreateDefaultContext()
-            output = mux.AllocateOutput(context)
+            output = mux.AllocateOutput()
             num_ports = len(case['data'])
             self.assertEqual(context.get_num_input_ports(), num_ports)
             for j, vec in enumerate(case['data']):

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -147,7 +147,7 @@ class TestRendering(unittest.TestCase):
 
         # - CalcOutput.
         context = aggregator.CreateDefaultContext()
-        output = aggregator.AllocateOutput(context)
+        output = aggregator.AllocateOutput()
 
         p1 = [0, 1, 2]
         pose1 = PoseVector()

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -180,7 +180,7 @@ PYBIND11_MODULE(test_util, m) {
           state.CopyToVector() + dt * state_dot.CopyToVector());
     }
     // Calculate output.
-    auto output = system.AllocateOutput(*context);
+    auto output = system.AllocateOutput();
     system.CalcOutput(*context, output.get());
     return output;
   });

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -139,7 +139,7 @@ class TestAutomotive(unittest.TestCase):
         lane = rg.junction(0).segment(0).lane(0)
         pure_pursuit = PurePursuitController()
         context = pure_pursuit.CreateDefaultContext()
-        output = pure_pursuit.AllocateOutput(context)
+        output = pure_pursuit.AllocateOutput()
 
         # Fix the inputs.
         ld_value = framework.AbstractValue.Make(
@@ -189,7 +189,7 @@ class TestAutomotive(unittest.TestCase):
             road_position_strategy=RoadPositionStrategy.kExhaustiveSearch,
             period_sec=0.)
         context = idm.CreateDefaultContext()
-        output = idm.AllocateOutput(context)
+        output = idm.AllocateOutput()
 
         # Fix the inputs.
         pose_vector1 = PoseVector()
@@ -235,7 +235,7 @@ class TestAutomotive(unittest.TestCase):
         simple_car = SimpleCar()
         simulator = Simulator(simple_car)
         context = simulator.get_mutable_context()
-        output = simple_car.AllocateOutput(context)
+        output = simple_car.AllocateOutput()
 
         # Fix the input.
         command = DrivingCommand()

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
@@ -28,8 +28,6 @@ void QpOutputTranslatorSystem::CalcActuationTorques(
   // Output:
   auto out_vector = output->get_mutable_value();
 
-  // TODO(sherm1) This computation should be cached so it will be evaluated
-  // when first requested and then available for re-use.
   out_vector = robot_.B.transpose() * qp_output->dof_torques();
 
   DRAKE_ASSERT(out_vector.size() == robot_.get_num_actuators());

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
@@ -54,7 +54,6 @@ class QpOutputTranslatorSystem : public systems::LeafSystem<double> {
    * selection matrix that maps the actuator indices to the generalized
    * coordinate indices.
    */
-  // TODO(sherm1) This should be cached so it doesn't need to be recomputed.
   void CalcActuationTorques(const systems::Context<double>& context,
                             systems::BasicVector<double>* output) const;
 

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_package_library(
         ":leaf_system",
         ":model_values",
         ":output_port",
+        ":output_port_base",
         ":output_port_value",
         ":parameters",
         ":single_output_vector_source",
@@ -261,6 +262,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "output_port_base",
+    srcs = [
+        "output_port_base.cc",
+    ],
+    hdrs = [
+        "output_port_base.h",
+    ],
+    deps = [
+        ":framework_common",
+    ],
+)
+
+drake_cc_library(
     name = "system_base",
     srcs = [
         "system_base.cc",
@@ -272,6 +286,7 @@ drake_cc_library(
         ":cache_entry",
         ":context_base",
         ":input_port_base",
+        ":output_port_base",
     ],
 )
 
@@ -280,6 +295,7 @@ drake_cc_library(
     srcs = ["output_port_value.cc"],
     hdrs = ["output_port_value.h"],
     deps = [
+        ":framework_common",
         ":value",
         ":value_checker",
         ":vector",
@@ -295,7 +311,6 @@ drake_cc_library(
     hdrs = ["context.h"],
     deps = [
         ":context_base",
-        ":output_port_value",
         ":parameters",
         ":state",
         "//common:default_scalars",
@@ -309,15 +324,14 @@ drake_cc_library(
     srcs = ["leaf_context.cc"],
     hdrs = ["leaf_context.h"],
     deps = [
-        ":cache_and_dependency_tracker",
         ":context",
-        ":parameters",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
     ],
 )
 
+# TODO(sherm1) This should be "input_port".
 drake_cc_library(
     name = "input_port_descriptor",
     srcs = [
@@ -335,17 +349,19 @@ drake_cc_library(
 
 drake_cc_library(
     name = "output_port",
-    srcs = ["output_port.cc"],
-    hdrs = ["output_port.h"],
+    srcs = [
+        "output_port.cc",
+    ],
+    hdrs = [
+        "output_port.h",
+    ],
     deps = [
         ":context",
-        ":framework_common",
+        ":output_port_base",
         ":system_base",
         ":value",
-        ":vector",
         "//common:default_scalars",
         "//common:essential",
-        "//common:type_safe_index",
     ],
 )
 
@@ -364,6 +380,7 @@ drake_cc_library(
         ":event_collection",
         ":input_port_descriptor",
         ":output_port",
+        ":output_port_value",
         ":system_base",
         ":system_constraint",
         ":system_scalar_converter",
@@ -384,7 +401,7 @@ drake_cc_library(
     srcs = ["leaf_output_port.cc"],
     hdrs = ["leaf_output_port.h"],
     deps = [
-        ":framework_common",
+        ":leaf_context",
         ":output_port",
         ":value",
         ":vector",
@@ -584,7 +601,6 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "cache_test",
     deps = [
-        ":cache_and_dependency_tracker",
         ":context_base",
         "//common:essential",
         "//systems/framework/test_utilities",
@@ -765,6 +781,7 @@ drake_cc_googletest(
     deps = [
         ":output_port_value",
         "//common:essential",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -3,11 +3,12 @@
 #include <memory>
 #include <utility>
 
+#include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/drake_throw.h"
 #include "drake/common/pointer_cast.h"
+#include "drake/common/unused.h"
 #include "drake/systems/framework/context_base.h"
-#include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/parameters.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/value.h"
@@ -63,16 +64,33 @@ class Context : public ContextBase {
   /// Returns the current time in seconds.
   const T& get_time() const { return get_step_info().time_sec; }
 
-  /// Set the current time in seconds.
-  virtual void set_time(const T& time_sec) {
-    step_info_.time_sec = time_sec;
+  /// Set the current time in seconds. If this is a time change, invalidates all
+  /// time-dependent quantities in this context and its subcontexts.
+  void set_time(const T& time_sec) {
+    if (time_sec != get_time()) {
+      const int64_t change_event = this->start_new_change_event();
+      PropagateTimeChange(time_sec, change_event);
+    }
   }
 
   // =========================================================================
   // Accessors and Mutators for State.
 
-  virtual const State<T>& get_state() const = 0;
-  virtual State<T>& get_mutable_state() = 0;
+  /// Returns a const reference to the whole State.
+  const State<T>& get_state() const {
+    return do_access_state();
+  }
+
+  /// Returns a mutable reference to the whole State, invalidating _all_
+  /// state-dependent computations. If you don't mean to change the whole
+  /// thing, use more focused methods to get mutable access to only a portion
+  /// of the state so that fewer computations are invalidated.
+  State<T>& get_mutable_state() {
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllStateChanged(change_event);
+    PropagateBulkChange(change_event, &ContextBase::NoteAllStateChanged);
+    return do_access_mutable_state();
+  }
 
   /// Returns true if the Context has no state.
   bool is_stateless() const {
@@ -111,21 +129,57 @@ class Context : public ContextBase {
     return count;
   }
 
-  /// Sets the continuous state to @p xc, deleting whatever was there before.
-  void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
-    get_mutable_state().set_continuous_state(std::move(xc));
-  }
-
   /// Returns a mutable reference to the continuous component of the state,
-  /// which may be of size zero.
+  /// which may be of size zero. Invalidates all continuous state-dependent
+  /// computations in this context and its subcontexts, recursively.
   ContinuousState<T>& get_mutable_continuous_state() {
-    return get_mutable_state().get_mutable_continuous_state();
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllContinuousStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllContinuousStateChanged);
+    return do_access_mutable_state().get_mutable_continuous_state();
   }
 
   /// Returns a mutable reference to the continuous state vector, devoid
-  /// of second-order structure. The vector may be of size zero.
+  /// of second-order structure. The vector may be of size zero. Invalidates all
+  /// continuous state-dependent computations in this context and its
+  /// subcontexts, recursively.
   VectorBase<T>& get_mutable_continuous_state_vector() {
     return get_mutable_continuous_state().get_mutable_vector();
+  }
+
+  /// Sets the continuous state to @p xc, including q, v, and z partitions.
+  /// The supplied vector must be the same size as the existing continuous
+  /// state. Invalidates all continuous state-dependent computations in this
+  /// context and its subcontexts, recursively.
+  void SetContinuousState(const Eigen::Ref<const VectorX<T>>& xc) {
+    get_mutable_continuous_state().SetFromVector(xc);
+  }
+
+  /// Sets time to @p t_sec and continuous state to @p xc. Performs a single
+  /// invalidation pass to avoid duplicate invalidations for computations that
+  /// depend on both time and state.
+  void SetTimeAndContinuousState(const T& t_sec,
+                                 const Eigen::Ref<const VectorX<T>>& xc) {
+    const int64_t change_event = this->start_new_change_event();
+    if (t_sec != get_time())
+      PropagateTimeChange(t_sec, change_event);
+    NoteAllContinuousStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllContinuousStateChanged);
+    do_access_mutable_state().get_mutable_continuous_state().SetFromVector(xc);
+  }
+
+  /// Sets the continuous state to @p xc, deleting whatever was there before.
+  /// Invalidates all continuous state-dependent computations in this context
+  /// and its subcontexts, recursively.
+  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
+  void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllContinuousStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllContinuousStateChanged);
+    do_access_mutable_state().set_continuous_state(std::move(xc));
   }
 
   /// Returns a const reference to the continuous component of the state,
@@ -159,9 +213,14 @@ class Context : public ContextBase {
   }
 
   /// Returns a mutable reference to the discrete component of the state,
-  /// which may be of size zero.
+  /// which may be of size zero. Invalidates all discrete state-dependent
+  /// computations in this context and its subcontexts, recursively.
   DiscreteValues<T>& get_mutable_discrete_state() {
-    return get_mutable_state().get_mutable_discrete_state();
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllDiscreteStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllDiscreteStateChanged);
+    return do_access_mutable_state().get_mutable_discrete_state();
   }
 
   /// Returns a mutable reference to the _only_ discrete state vector.
@@ -172,16 +231,25 @@ class Context : public ContextBase {
   }
 
   /// Returns a mutable reference to group (vector) @p index of the discrete
-  /// state.
+  /// state. Invalidates all computations that depend (directly or indirectly)
+  /// on this discrete state group.
   /// @pre @p index must identify an existing group.
   BasicVector<T>& get_mutable_discrete_state(int index) {
+    // TODO(sherm1) Invalidate only dependents of this one discrete group.
     DiscreteValues<T>& xd = get_mutable_discrete_state();
     return xd.get_mutable_vector(index);
   }
 
   /// Sets the discrete state to @p xd, deleting whatever was there before.
+  /// Invalidates all discrete state-dependent computations in this context and
+  /// its subcontexts, recursively.
+  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
   void set_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
-    get_mutable_state().set_discrete_state(std::move(xd));
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllDiscreteStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllDiscreteStateChanged);
+    do_access_mutable_state().set_discrete_state(std::move(xd));
   }
 
   /// Returns a const reference to group (vector) @p index of the discrete
@@ -204,22 +272,37 @@ class Context : public ContextBase {
   }
 
   /// Returns a mutable reference to the abstract component of the state,
-  /// which may be of size zero.
+  /// which may be of size zero. Invalidates all abstract state-dependent
+  /// computations in this context and its subcontexts, recursively.
   AbstractValues& get_mutable_abstract_state() {
-    return get_mutable_state().get_mutable_abstract_state();
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllAbstractStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllAbstractStateChanged);
+    return do_access_mutable_state().get_mutable_abstract_state();
   }
 
   /// Returns a mutable reference to element @p index of the abstract state.
+  /// Invalidates all computations that depend (directly or indirectly) on this
+  /// abstract state variable.
   /// @pre @p index must identify an existing element.
   template <typename U>
   U& get_mutable_abstract_state(int index) {
+    // TODO(sherm1) Invalidate only dependents of this one abstract variable.
     AbstractValues& xa = get_mutable_abstract_state();
     return xa.get_mutable_value(index).GetMutableValue<U>();
   }
 
   /// Sets the abstract state to @p xa, deleting whatever was there before.
+  /// Invalidates all abstract state-dependent computations in this context and
+  /// its subcontexts, recursively.
+  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
   void set_abstract_state(std::unique_ptr<AbstractValues> xa) {
-    get_mutable_state().set_abstract_state(std::move(xa));
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllAbstractStateChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllAbstractStateChanged);
+    do_access_mutable_state().set_abstract_state(std::move(xa));
   }
 
   /// Returns a const reference to the abstract component of the
@@ -274,24 +357,55 @@ class Context : public ContextBase {
   // =========================================================================
   // Accessors and Mutators for Parameters.
 
-  virtual const Parameters<T>& get_parameters() const = 0;
-  virtual Parameters<T>& get_mutable_parameters() = 0;
+  /// Returns a const reference to this %Context's parameters.
+  const Parameters<T>& get_parameters() const { return *parameters_; }
+
+  /// Returns a mutable reference to this %Context's parameters after
+  /// invalidating all parameter-dependent computations in this context and
+  /// all its subcontexts, recursively. This is likely to be a _lot_ of
+  /// invalidation -- if you are really just changing a single parameter use
+  /// one of the indexed methods instead.
+  Parameters<T>& get_mutable_parameters() {
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllParametersChanged(change_event);
+    PropagateBulkChange(change_event, &ContextBase::NoteAllParametersChanged);
+    return *parameters_;
+  }
+
+  /// Sets the parameters to @p params, deleting whatever was there before.
+  /// You must supply a Parameters object; null is not acceptable. Invalidates
+  /// all parameter-dependent computations recursively in this context and
+  /// its subcontexts.
+  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
+  void set_parameters(std::unique_ptr<Parameters<T>> params) {
+    DRAKE_DEMAND(params != nullptr);
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllParametersChanged(change_event);
+    PropagateBulkChange(change_event, &ContextBase::NoteAllParametersChanged);
+    parameters_ = std::move(params);
+  }
 
   /// Returns the number of vector-valued parameters.
   int num_numeric_parameters() const {
-    return get_parameters().num_numeric_parameters();
+    return parameters_->num_numeric_parameters();
   }
 
   /// Returns a const reference to the vector-valued parameter at @p index.
-  /// Asserts if @p index doesn't exist.
+  /// @pre @p index must identify an existing parameter.
   const BasicVector<T>& get_numeric_parameter(int index) const {
-    return get_parameters().get_numeric_parameter(index);
+    return parameters_->get_numeric_parameter(index);
   }
 
   /// Returns a mutable reference to element @p index of the vector-valued
-  /// parameters. Asserts if @p index doesn't exist.
+  /// parameters. Invalidates all computations dependent on this parameter.
+  /// @pre @p index must identify an existing parameter.
   BasicVector<T>& get_mutable_numeric_parameter(int index) {
-    return get_mutable_parameters().get_mutable_numeric_parameter(index);
+    // TODO(sherm1) Invalidate only dependents of this one parameter.
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllNumericParametersChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllNumericParametersChanged);
+    return parameters_->get_mutable_numeric_parameter(index);
   }
 
   /// Returns the number of abstract-valued parameters.
@@ -300,14 +414,20 @@ class Context : public ContextBase {
   }
 
   /// Returns a const reference to the abstract-valued parameter at @p index.
-  /// Asserts if @p index doesn't exist.
+  /// @pre @p index must identify an existing parameter.
   const AbstractValue& get_abstract_parameter(int index) const {
     return get_parameters().get_abstract_parameter(index);
   }
 
   /// Returns a mutable reference to element @p index of the abstract-valued
-  /// parameters. Asserts if @p index doesn't exist.
+  /// parameters. Invalidates all computations dependent on this parameter.
+  /// @pre @p index must identify an existing parameter.
   AbstractValue& get_mutable_abstract_parameter(int index) {
+    // TODO(sherm1) Invalidate only dependents of this one parameter.
+    const int64_t change_event = this->start_new_change_event();
+    NoteAllAbstractParametersChanged(change_event);
+    PropagateBulkChange(change_event,
+                        &ContextBase::NoteAllAbstractParametersChanged);
     return get_mutable_parameters().get_mutable_abstract_parameter(index);
   }
 
@@ -316,7 +436,9 @@ class Context : public ContextBase {
 
   /// Records the user's requested accuracy. If no accuracy is requested,
   /// computations are free to choose suitable defaults, or to refuse to
-  /// proceed without an explicit accuracy setting.
+  /// proceed without an explicit accuracy setting. If this is a change to
+  /// the current accuracy setting, all accuracy-dependent computations in this
+  /// Context and its subcontexts are invalidated.
   ///
   /// Requested accuracy is stored in the %Context for two reasons:
   /// - It permits all computations performed over a System to see the _same_
@@ -340,13 +462,15 @@ class Context : public ContextBase {
   /// The common thread among these examples is that they all share the
   /// same %Context, so by keeping accuracy here it can be used effectively to
   /// control all accuracy-dependent computations.
-  // TODO(edrumwri) Invalidate all cached accuracy-dependent computations, and
-  // propagate accuracy to all subcontexts in a diagram context.
-  virtual void set_accuracy(const optional<double>& accuracy) {
-    accuracy_ = accuracy;
+  void set_accuracy(const optional<double>& accuracy) {
+    if (accuracy != get_accuracy()) {
+      const int64_t change_event = this->start_new_change_event();
+      PropagateAccuracyChange(accuracy, change_event);
+    }
   }
 
-  /// Returns the accuracy setting (if any).
+  /// Returns the accuracy setting (if any). Note that the return type is
+  /// `optional<double>` rather than the double value itself.
   /// @see set_accuracy() for details.
   const optional<double>& get_accuracy() const { return accuracy_; }
 
@@ -363,13 +487,54 @@ class Context : public ContextBase {
   /// Requires a constructor T(double).
   // TODO(sherm1) Should treat fixed input port values same as parameters.
   void SetTimeStateAndParametersFrom(const Context<double>& source) {
-    set_time(T(source.get_time()));
-    set_accuracy(source.get_accuracy());
-    get_mutable_state().SetFrom(source.get_state());
-    get_mutable_parameters().SetFrom(source.get_parameters());
+    // A single change event for all these changes is much faster than doing
+    // each separately.
+    const int64_t change_event = this->start_new_change_event();
+
+    // These two both set the value and perform invalidations.
+    PropagateTimeChange(T(source.get_time()), change_event);
+    PropagateAccuracyChange(source.get_accuracy(), change_event);
+
+    // Invalidation is separate from the actual value change for bulk changes.
+    PropagateBulkChange(change_event, &ContextBase::NoteAllStateChanged);
+    do_access_mutable_state().SetFrom(source.get_state());
+
+    PropagateBulkChange(change_event, &ContextBase::NoteAllParametersChanged);
+    parameters_->SetFrom(source.get_parameters());
 
     // TODO(sherm1) Fixed input copying goes here.
   }
+
+  /// (Internal use only) Sets a new time and notifies time-dependent
+  /// quantities that they are now invalid, as part of a given change event.
+  void PropagateTimeChange(const T& time_sec, int64_t change_event) {
+    NoteTimeChanged(change_event);
+    step_info_.time_sec = time_sec;
+    DoPropagateTimeChange(time_sec, change_event);
+  }
+
+  /// (Internal use only) Sets a new accuracy and notifies accuracy-dependent
+  /// quantities that they are now invalid, as part of a given change event.
+  void PropagateAccuracyChange(const optional<double>& accuracy,
+                               int64_t change_event) {
+    NoteAccuracyChanged(change_event);
+    accuracy_ = accuracy;
+    DoPropagateAccuracyChange(accuracy, change_event);
+  }
+
+  /// (Internal use only) Applies the given bulk-change notification method
+  /// to this context, and propagates the notification to subcontexts if this
+  /// is a Diagram.
+  void PropagateBulkChange(
+      int64_t change_event,
+      void (ContextBase::*NoteBulkChange)(int64_t change_event)) {
+    (this->*NoteBulkChange)(change_event);
+    DoPropagateBulkChange(change_event, NoteBulkChange);
+  }
+
+  /// (Internal use only) Returns a reference to a mutable state _without_
+  /// invalidation notifications. Use get_mutable_state() instead.
+  State<T>& access_mutable_state() { return do_access_mutable_state(); }
 
  protected:
   Context() = default;
@@ -392,9 +557,41 @@ class Context : public ContextBase {
         ContextBase::CloneWithoutPointers(source));
   }
 
+  /// Derived context class should return a const reference to its concrete
+  /// State object.
+  virtual const State<T>& do_access_state() const = 0;
+
+  /// Derived context class should return a mutable reference to its concrete
+  /// State object _without_ any invalidation. We promise not to allow user
+  /// access to this object without invalidation.
+  virtual State<T>& do_access_mutable_state() = 0;
+
   /// Override to return the appropriate concrete State class to be returned
   /// by CloneState().
   virtual std::unique_ptr<State<T>> DoCloneState() const = 0;
+
+  /// Diagram contexts should override this to invoke PropagateTimeChange()
+  /// on their subcontexts. The default implementation does nothing.
+  virtual void DoPropagateTimeChange(const T& time_sec, int64_t change_event) {
+    unused(time_sec, change_event);
+  }
+
+  /// Diagram contexts should override this to invoke PropagateAccuracyChange()
+  /// on their subcontexts. The default implementation does nothing.
+  virtual void DoPropagateAccuracyChange(const optional<double>& accuracy,
+                                         int64_t change_event) {
+    unused(accuracy, change_event);
+  }
+
+  /// Diagram contexts should override this to invoke PropagateBulkChange()
+  /// on their subcontexts, passing along the indicated method that specifies
+  /// the particular bulk change (e.g. whole state, all parameters, all
+  /// discrete state variables, etc.). The default implementation does nothing.
+  virtual void DoPropagateBulkChange(
+      int64_t change_event,
+      void (ContextBase::*NoteBulkChange)(int64_t change_event)) {
+    unused(change_event, NoteBulkChange);
+  }
 
   /// Returns a const reference to current time and step information.
   const StepInfo<T>& get_step_info() const { return step_info_; }
@@ -405,6 +602,10 @@ class Context : public ContextBase {
 
   // Accuracy setting.
   optional<double> accuracy_;
+
+  // The parameter values p for this System; this is never null.
+  copyable_unique_ptr<Parameters<T>> parameters_{
+      std::make_unique<Parameters<T>>()};
 };
 
 }  // namespace systems

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -30,17 +30,23 @@ ContextBase::~ContextBase() {}
 
 void ContextBase::DisableCaching() const {
   cache_.DisableCaching();
-  // TODO(sherm1) Recursive disabling of descendents goes here.
+  const int n = do_num_subcontexts();
+  for (SubsystemIndex i(0); i < n; ++i)
+    do_get_subcontext(i).DisableCaching();
 }
 
 void ContextBase::EnableCaching() const {
   cache_.EnableCaching();
-  // TODO(sherm1) Recursive enabling of descendents goes here.
+  const int n = do_num_subcontexts();
+  for (SubsystemIndex i(0); i < n; ++i)
+    do_get_subcontext(i).EnableCaching();
 }
 
 void ContextBase::SetAllCacheEntriesOutOfDate() const {
   cache_.SetAllEntriesOutOfDate();
-  // TODO(sherm1) Recursive update of descendents goes here.
+  const int n = do_num_subcontexts();
+  for (SubsystemIndex i(0); i < n; ++i)
+    do_get_subcontext(i).SetAllCacheEntriesOutOfDate();
 }
 
 std::string ContextBase::GetSystemPathname() const {
@@ -79,10 +85,31 @@ void ContextBase::SetFixedInputPortValue(
   DRAKE_DEMAND(0 <= index && index < get_num_input_ports());
   DRAKE_DEMAND(port_value != nullptr);
 
+  DependencyTracker& port_tracker =
+      get_mutable_tracker(input_port_tickets()[index]);
+  FixedInputPortValue* old_value =
+      input_port_values_[index].get_mutable();
+
+  if (old_value != nullptr) {
+    // All the dependency wiring is already in place.
+    detail::ContextBaseFixedInputAttorney::set_ticket(port_value.get(),
+                                                      old_value->ticket());
+  } else {
+    // Create a new tracker and subscribe to it.
+    DependencyTracker& value_tracker = graph_.CreateNewDependencyTracker(
+        "Value for fixed input port " + std::to_string(index));
+    detail::ContextBaseFixedInputAttorney::set_ticket(port_value.get(),
+                                                      value_tracker.ticket());
+    port_tracker.SubscribeToPrerequisite(&value_tracker);
+  }
+
   // Fill in the FixedInputPortValue object and install it.
   detail::ContextBaseFixedInputAttorney::set_owning_subcontext(
       port_value.get(), this);
   input_port_values_[index] = std::move(port_value);
+
+  // Invalidate anyone who cares about this input port.
+  port_tracker.NoteValueChange(start_new_change_event());
 }
 
 // Set up trackers for independent sources: time, accuracy, state, parameters,
@@ -206,7 +233,10 @@ void ContextBase::BuildTrackerPointerMap(
   // First map the pointers local to this context.
   graph_.AppendToTrackerPointerMap(clone.get_dependency_graph(),
                                    &(*tracker_map));
-  // TODO(sherm1) Recursive update of descendents goes here.
+  // Then recursively ask our descendants to add their information to the map.
+  for (SubsystemIndex i(0); i < num_subcontexts(); ++i)
+    get_subcontext(i).BuildTrackerPointerMap(clone.get_subcontext(i),
+                                             &(*tracker_map));
 }
 
 void ContextBase::FixContextPointers(
@@ -224,7 +254,10 @@ void ContextBase::FixContextPointers(
     }
   }
 
-  // TODO(sherm1) Recursive update of descendents goes here.
+  // Then recursively ask our descendants to repair their pointers.
+  for (SubsystemIndex i(0); i < num_subcontexts(); ++i)
+    get_mutable_subcontext(i).FixContextPointers(source.get_subcontext(i),
+                                                 tracker_map);
 }
 
 }  // namespace systems

--- a/systems/framework/context_base.cc
+++ b/systems/framework/context_base.cc
@@ -200,6 +200,8 @@ void ContextBase::CreateBuiltInTrackers() {
   // This default subscription must be changed if configuration is not
   // represented by q in this System.
   configuration_tracker.SubscribeToPrerequisite(&q_tracker);
+  configuration_tracker.SubscribeToPrerequisite(&p_tracker);
+  configuration_tracker.SubscribeToPrerequisite(&accuracy_tracker);
 
   // Should track changes to configuration time rate of change (i.e., velocity)
   // regardless of how represented. The default is that the continuous "v"
@@ -209,6 +211,8 @@ void ContextBase::CreateBuiltInTrackers() {
   // This default subscription must be changed if velocity is not
   // represented by v in this System.
   velocity_tracker.SubscribeToPrerequisite(&v_tracker);
+  velocity_tracker.SubscribeToPrerequisite(&p_tracker);
+  velocity_tracker.SubscribeToPrerequisite(&accuracy_tracker);
 
   // This tracks configuration & velocity regardless of how represented.
   auto& kinematics_tracker = graph.CreateNewDependencyTracker(
@@ -216,14 +220,18 @@ void ContextBase::CreateBuiltInTrackers() {
   kinematics_tracker.SubscribeToPrerequisite(&configuration_tracker);
   kinematics_tracker.SubscribeToPrerequisite(&velocity_tracker);
 
+  // The following trackers are for well-known cache entries which don't
+  // exist yet at this point in Context creation. When the corresponding cache
+  // entry values are created (by SystemBase), these trackers will be subscribed
+  // to the Calc() method's prerequisites, and set to invalidate the cache entry
+  // value when the prerequisites change.
+
   auto& xcdot_tracker = graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kXcdotTicket), "xcdot");
-  // TODO(sherm1) Connect to cache entry.
   unused(xcdot_tracker);
 
   auto& xdhat_tracker = graph.CreateNewDependencyTracker(
       DependencyTicket(internal::kXdhatTicket), "xdhat");
-  // TODO(sherm1) Connect to cache entry.
   unused(xdhat_tracker);
 }
 

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -150,6 +150,17 @@ class DependencyTracker {
   DependencyGraph. The ticket is unique within the containing subcontext. */
   DependencyTicket ticket() const { return ticket_; }
 
+  /** Returns a pointer to the CacheEntryValue if this tracker is a cache
+  entry tracker, otherwise nullptr. */
+  // This is for validating that this tracker is associated with the right
+  // cache entry. Don't use this during runtime invalidation.
+  const CacheEntryValue* cache_entry_value() const {
+    DRAKE_DEMAND(cache_value_);
+    if (cache_value_ == &CacheEntryValue::dummy())
+      return nullptr;
+    return cache_value_;
+  }
+
   /** Notifies `this` %DependencyTracker that its managed value was directly
   modified or made available for mutable access. That is, this is the
   _initiating_ event of a value modification. All of our downstream

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -150,6 +150,19 @@ class DependencyTracker {
   DependencyGraph. The ticket is unique within the containing subcontext. */
   DependencyTicket ticket() const { return ticket_; }
 
+  /** (Internal use only) Sets the cache entry value to be marked out-of-date
+  when this tracker's prerequisites change.
+  @pre The supplied cache entry value is non-null.
+  @pre No cache entry value has previously been assigned. */
+  // This is intended for use in connecting pre-defined trackers to cache
+  // entry values that are created later. See the private constructor
+  // documentation for more information.
+  void set_cache_entry_value(CacheEntryValue* cache_value) {
+    DRAKE_DEMAND(cache_value != nullptr);
+    DRAKE_DEMAND(cache_entry_value() == nullptr);
+    cache_value_ = cache_value;
+  }
+
   /** Returns a pointer to the CacheEntryValue if this tracker is a cache
   entry tracker, otherwise nullptr. */
   // This is for validating that this tracker is associated with the right

--- a/systems/framework/diagram.cc
+++ b/systems/framework/diagram.cc
@@ -3,7 +3,4 @@
 #include "drake/common/default_scalars.h"
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::internal::DiagramOutput)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::Diagram)

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -12,7 +12,7 @@
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_continuous_state.h"
 #include "drake/systems/framework/fixed_input_port_value.h"
-#include "drake/systems/framework/output_port_value.h"
+#include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/parameters.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/supervector.h"
@@ -20,6 +20,9 @@
 namespace drake {
 namespace systems {
 
+//==============================================================================
+//                                DIAGRAM STATE
+//==============================================================================
 /// DiagramState is a State, annotated with pointers to all the mutable
 /// substates that it spans.
 template <typename T>
@@ -103,6 +106,9 @@ class DiagramState : public State<T> {
   std::vector<std::unique_ptr<State<T>>> owned_substates_;
 };
 
+//==============================================================================
+//                              DIAGRAM CONTEXT
+//==============================================================================
 /// The DiagramContext is a container for all of the data necessary to uniquely
 /// determine the computations performed by a Diagram. Specifically, a
 /// DiagramContext contains contexts and outputs for all the constituent
@@ -134,22 +140,26 @@ class DiagramContext final : public Context<T> {
   /// number and ordering of subcontexts is identical to the number and
   /// ordering of subsystems in the corresponding Diagram.
   explicit DiagramContext(int num_subcontexts)
-      : outputs_(num_subcontexts), contexts_(num_subcontexts),
+      : contexts_(num_subcontexts),
         state_(std::make_unique<DiagramState<T>>(num_subcontexts)) {}
+
+  /// Returns the number of immediate child subcontexts in this %DiagramContext.
+  // This shadows the ContextBase method of the same name to avoid the
+  // virtual function call when used locally, but is functionally identical.
+  int num_subcontexts() const {
+    return static_cast<int>(contexts_.size());
+  }
 
   /// Declares a new subsystem in the DiagramContext. Subsystems are identified
   /// by number. If the subsystem has already been declared, aborts.
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void AddSystem(SubsystemIndex index, std::unique_ptr<Context<T>> context,
-                 std::unique_ptr<SystemOutput<T>> output) {
+  void AddSystem(SubsystemIndex index, std::unique_ptr<Context<T>> context) {
     DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(contexts_[index] == nullptr);
-    DRAKE_DEMAND(outputs_[index] == nullptr);
-    Context<T>::set_parent(context.get(), this);
+    ContextBase::set_parent(context.get(), this);
     contexts_[index] = std::move(context);
-    outputs_[index] = std::move(output);
   }
 
   /// (Internal use only) Declares that a particular input port of a child
@@ -168,34 +178,85 @@ class DiagramContext final : public Context<T> {
     InputPortIndex subsystem_iport_index = subsystem_input_port.second;
     Context<T>& subcontext = GetMutableSubsystemContext(subsystem_index);
     DRAKE_DEMAND(0 <= subsystem_iport_index &&
-        subsystem_iport_index < subcontext.get_num_input_ports());
+                 subsystem_iport_index < subcontext.get_num_input_ports());
 
-    // TODO(sherm1) Set up dependency of subsystem input on diagram input.
-    unused(input_port_index);  // For now.
+    // Get this Diagram's input port that serves as the source.
+    const DependencyTicket iport_ticket =
+        this->input_port_tickets()[input_port_index];
+    DependencyTracker& iport_tracker =
+        this->get_mutable_tracker(iport_ticket);
+    const DependencyTicket subsystem_iport_ticket =
+        subcontext.input_port_tickets()[subsystem_iport_index];
+    DependencyTracker& subsystem_iport_tracker =
+        subcontext.get_mutable_tracker(subsystem_iport_ticket);
+    subsystem_iport_tracker.SubscribeToPrerequisite(&iport_tracker);
   }
 
-  /// (Internal use only) Declares that the output port specified by @p src is
-  /// connected to the input port specified by @p dest.
+  /// (Internal use only) Declares that a particular output port of this
+  /// diagram is simply forwarded from an output port of one of its child
+  /// subsystems. Sets up tracking of the diagram port's dependency on the child
+  /// port. Aborts if the subsystem has not been added to the DiagramContext.
   ///
   /// User code should not call this method. It is for use during Diagram
   /// context allocation only.
-  void Connect(const OutputPortIdentifier& src,
-               const InputPortIdentifier& dest) {
-    // Identify and validate the source port.
-    SubsystemIndex src_system_index = src.first;
-    OutputPortIndex src_port_index = src.second;
-    SystemOutput<T>* src_ports = GetSubsystemOutput(src_system_index);
-    DRAKE_DEMAND(src_port_index >= 0);
-    DRAKE_DEMAND(src_port_index < src_ports->get_num_ports());
+  void ExportOutput(OutputPortIndex oport_index,
+                    const OutputPortIdentifier& subsystem_oport) {
+    // Identify and validate the source output port.
+    SubsystemIndex subsystem_index = subsystem_oport.first;
+    OutputPortIndex subsystem_oport_index = subsystem_oport.second;
+    Context<T>& subcontext = GetMutableSubsystemContext(subsystem_index);
+    DRAKE_DEMAND(0 <= subsystem_oport_index &&
+        subsystem_oport_index < subcontext.get_num_output_ports());
 
-    // Identify and validate the destination port.
-    SubsystemIndex dest_system_index = dest.first;
-    InputPortIndex dest_port_index = dest.second;
-    Context<T>& dest_context = GetMutableSubsystemContext(dest_system_index);
-    DRAKE_DEMAND(dest_port_index >= 0);
-    DRAKE_DEMAND(dest_port_index < dest_context.get_num_input_ports());
+    // Get the child subsystem's output port tracker that serves as the source.
+    const DependencyTicket subsystem_oport_ticket =
+        subcontext.output_port_tickets()[subsystem_oport_index];
+    DependencyTracker& subsystem_oport_tracker =
+        subcontext.get_mutable_tracker(subsystem_oport_ticket);
 
-    // TODO(sherm1) Set up dependency of input port on connected output port.
+    // Get the diagram's output port tracker that is the destination.
+    const DependencyTicket oport_ticket =
+        this->output_port_tickets()[oport_index];
+    DependencyTracker& oport_tracker =
+        this->get_mutable_tracker(oport_ticket);
+
+    oport_tracker.SubscribeToPrerequisite(&subsystem_oport_tracker);
+  }
+
+  /// (Internal use only) Declares that a connection exists between a peer
+  /// output port and input port in this Diagram, records that fact in the
+  /// connection map, and registers the input port's dependency
+  /// tracker with the output port's dependency tracker. By "peer" we mean that
+  /// both ports belong to immediate child subsystems of this Diagram (it is
+  /// also possible for both ports to belong to the same subsystem).
+  ///
+  /// User code should not call this method. It is for use during Diagram
+  /// context allocation and cloning only.
+  void Connect(const OutputPortIdentifier& oport,
+               const InputPortIdentifier& iport) {
+    // Identify and validate the source output port.
+    SubsystemIndex oport_system_index = oport.first;
+    OutputPortIndex oport_index = oport.second;
+    Context<T>& oport_context = GetMutableSubsystemContext(oport_system_index);
+    DRAKE_DEMAND(oport_index >= 0);
+    DRAKE_DEMAND(oport_index < oport_context.get_num_output_ports());
+
+    // Identify and validate the destination input port.
+    SubsystemIndex iport_system_index = iport.first;
+    InputPortIndex iport_index = iport.second;
+    Context<T>& iport_context = GetMutableSubsystemContext(iport_system_index);
+    DRAKE_DEMAND(iport_index >= 0);
+    DRAKE_DEMAND(iport_index < iport_context.get_num_input_ports());
+
+    DependencyTicket oport_ticket =
+        oport_context.output_port_tickets()[oport_index];
+    DependencyTicket iport_ticket =
+        iport_context.input_port_tickets()[iport_index];
+    DependencyTracker& oport_tracker =
+        oport_context.get_mutable_tracker(oport_ticket);
+    DependencyTracker& iport_tracker =
+        iport_context.get_mutable_tracker(iport_ticket);
+    iport_tracker.SubscribeToPrerequisite(&oport_tracker);
   }
 
   /// Generates the state vector for the entire diagram by wrapping the states
@@ -207,7 +268,8 @@ class DiagramContext final : public Context<T> {
     auto state = std::make_unique<DiagramState<T>>(num_subcontexts());
     for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
       Context<T>* context = contexts_[i].get();
-      state->set_substate(i, &context->get_mutable_state());
+      // Using `access` here to avoid sending invalidations.
+      state->set_substate(i, &context->access_mutable_state());
     }
     state->Finalize();
     state_ = std::move(state);
@@ -233,20 +295,11 @@ class DiagramContext final : public Context<T> {
             &subparams.get_mutable_abstract_parameter(i));
       }
     }
-    parameters_ = std::make_unique<Parameters<T>>();
-    parameters_->set_numeric_parameters(
+    Parameters<T>& params = this->get_mutable_parameters();
+    params.set_numeric_parameters(
         std::make_unique<DiscreteValues<T>>(numeric_params));
-    parameters_->set_abstract_parameters(
+    params.set_abstract_parameters(
         std::make_unique<AbstractValues>(abstract_params));
-  }
-
-  /// Returns the output structure for a given constituent system at @p index.
-  /// Aborts if @p index is out of bounds, or if no system has been added to the
-  /// DiagramContext at that index.
-  SystemOutput<T>* GetSubsystemOutput(SubsystemIndex index) const {
-    DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
-    DRAKE_DEMAND(outputs_[index] != nullptr);
-    return outputs_[index].get();
   }
 
   /// Returns the context structure for a given constituent system @p index.
@@ -269,62 +322,18 @@ class DiagramContext final : public Context<T> {
     return *contexts_[index].get();
   }
 
-  /// Recursively sets the time on this context and all subcontexts.
-  void set_time(const T& time_sec) override {
-    Context<T>::set_time(time_sec);
-    for (auto& subcontext : contexts_) {
-      if (subcontext != nullptr) {
-        subcontext->set_time(time_sec);
-      }
-    }
-  }
-
-  /// Recursively sets the accuracy on this context and all subcontexts,
-  /// overwriting any accuracy value set in any subcontexts.
-  void set_accuracy(const optional<double>& accuracy) override {
-    Context<T>::set_accuracy(accuracy);
-    for (auto& subcontext : contexts_) {
-      if (subcontext != nullptr) {
-        subcontext->set_accuracy(accuracy);
-      }
-    }
-  }
-
-  const State<T>& get_state() const final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  State<T>& get_mutable_state() final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  const Parameters<T>& get_parameters() const final {
-    return *parameters_;
-  }
-
-  Parameters<T>& get_mutable_parameters() final {
-    return *parameters_;
-  }
-
  protected:
   /// Protected copy constructor takes care of the local data members and
   /// all base class members, but doesn't update base class pointers so is
   /// not a complete copy.
   DiagramContext(const DiagramContext& source)
       : Context<T>(source),
-        outputs_(source.num_subcontexts()),
         contexts_(source.num_subcontexts()),
         state_(std::make_unique<DiagramState<T>>(source.num_subcontexts())) {
     // Clone all the subsystem contexts and outputs.
-    for (SubsystemIndex i(0); i < source.num_subcontexts(); ++i) {
+    for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
       DRAKE_DEMAND(source.contexts_[i] != nullptr);
-      DRAKE_DEMAND(source.outputs_[i] != nullptr);
-      // When a leaf context is cloned, it will clone the data that currently
-      // appears on each of its input ports into a FixedInputPortValue.
-      AddSystem(i, Context<T>::CloneWithoutPointers(*source.contexts_[i]),
-                source.outputs_[i]->Clone());
+      AddSystem(i, Context<T>::CloneWithoutPointers(*source.contexts_[i]));
     }
 
     // Build a superstate over the subsystem contexts.
@@ -353,23 +362,62 @@ class DiagramContext final : public Context<T> {
     return clone;
   }
 
-  int num_subcontexts() const {
-    DRAKE_ASSERT(contexts_.size() == outputs_.size());
-    return static_cast<int>(contexts_.size());
+  const State<T>& do_access_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
   }
 
-  // The outputs are stored in SubsystemIndex order, and outputs_ is equal in
-  // length to the number of subsystems specified at construction time.
-  std::vector<std::unique_ptr<SystemOutput<T>>> outputs_;
+  State<T>& do_access_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  // Recursively sets the time on all subcontexts.
+  void DoPropagateTimeChange(const T& time_sec, int64_t change_event) final {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      subcontext->PropagateTimeChange(time_sec, change_event);
+    }
+  }
+
+  // Recursively sets the accuracy on all subcontexts.
+  void DoPropagateAccuracyChange(const optional<double>& accuracy,
+                                 int64_t change_event) final {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      subcontext->PropagateAccuracyChange(accuracy, change_event);
+    }
+  }
+
+  // Recursively notifies subcontexts of bulk changes.
+  void DoPropagateBulkChange(
+      int64_t change_event,
+      void (ContextBase::*NoteBulkChange)(int64_t change_event)) {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      subcontext->PropagateBulkChange(change_event, NoteBulkChange);
+    }
+  }
+
+  int do_num_subcontexts() const final {
+    return num_subcontexts();  // That is, the local one.
+  }
+
+  // Note the covariant return type here, instead of ContextBase&. That allows
+  // us to use this locally to get a Context<T> without downcasting.
+  const Context<T>& do_get_subcontext(
+      SubsystemIndex index) const final {
+    DRAKE_ASSERT(index >= 0 && index < num_subcontexts());
+    DRAKE_ASSERT(contexts_[index] != nullptr);
+    return *contexts_[index].get();
+  }
+
   // The contexts are stored in SubsystemIndex order, and contexts_ is equal in
   // length to the number of subsystems specified at construction time.
   std::vector<std::unique_ptr<Context<T>>> contexts_;
 
   // The internal state of the Diagram, which includes all its subsystem states.
   std::unique_ptr<DiagramState<T>> state_;
-
-  // The parameters of the Diagram, which includes all subsystem parameters.
-  std::unique_ptr<Parameters<T>> parameters_;
 };
 
 }  // namespace systems

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
 #include "drake/systems/framework/diagram_context.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port.h"
@@ -34,14 +36,16 @@ class DiagramOutputPort final : public OutputPort<T> {
   output port of one of the diagram's child subsystems.
 
   @param diagram The Diagram that will own this port.
-  @param system_base The same Diagram cast to its messaging interface.
+  @param system_base The same Diagram cast to its base class.
   @param index The output port index to be assigned to the new port.
+  @param ticket The DependencyTicket to be assigned to the new port.
   @param source_output_port An output port of one of this diagram's child
       subsystems that is to be forwarded to the new port.
   @param source_subsystem_index The index of the child subsystem that owns
       `source_output_port`.
 
   @pre The `diagram` System must actually be a Diagram.
+  @pre `diagram` lifetime must exceed the port's; we retain the pointer here.
   @pre `diagram` and `system_base` must be the same object.
   @pre `source_output_port` must be owned by a child of `diagram`.
   @pre `source_subsystem_index` must be the index of that child in `diagram`.
@@ -53,17 +57,19 @@ class DiagramOutputPort final : public OutputPort<T> {
   // doesn't have access to a declaration of Diagram<T> so would not be able
   // to static_cast up to System<T> as is required by OutputPort. We expect
   // the caller to do that cast for us so take a System<T> here.
-  DiagramOutputPort(const System<T>& diagram,
-                    const internal::SystemMessageInterface& system_base,
+  DiagramOutputPort(const System<T>* diagram,
+                    SystemBase* system_base,
                     OutputPortIndex index,
+                    DependencyTicket ticket,
                     const OutputPort<T>* source_output_port,
                     SubsystemIndex source_subsystem_index)
-      : OutputPort<T>(diagram, system_base, index,
+      : OutputPort<T>(diagram, system_base, index, ticket,
                       source_output_port->get_data_type(),
                       source_output_port->size()),
         source_output_port_(source_output_port),
         source_subsystem_index_(source_subsystem_index) {
-    DRAKE_DEMAND(index.is_valid() && source_subsystem_index.is_valid());
+    DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
+    DRAKE_DEMAND(source_subsystem_index.is_valid());
     DRAKE_DEMAND(source_output_port != nullptr);
   }
 
@@ -94,8 +100,16 @@ class DiagramOutputPort final : public OutputPort<T> {
   // delegates to the source output port.
   const AbstractValue& DoEval(const Context<T>& diagram_context) const final {
     const Context<T>& subcontext = get_subcontext(diagram_context);
-    return source_output_port_->Eval(subcontext);
+    return source_output_port_->EvalAbstract(subcontext);
   }
+
+  // Returns the source output port's subsystem, and the ticket for that
+  // port's tracker.
+  std::pair<optional<SubsystemIndex>, DependencyTicket>
+  DoGetPrerequisite() const final {
+    return std::make_pair(source_subsystem_index_,
+                          source_output_port_->ticket());
+  };
 
   // Digs out the right subcontext for delegation.
   const Context<T>& get_subcontext(const Context<T>& diagram_context) const {

--- a/systems/framework/fixed_input_port_value.cc
+++ b/systems/framework/fixed_input_port_value.cc
@@ -1,10 +1,15 @@
 #include "drake/systems/framework/fixed_input_port_value.h"
 
+#include "drake/systems/framework/context_base.h"
+
 namespace drake {
 namespace systems {
 
 AbstractValue* FixedInputPortValue::GetMutableData() {
-  // TODO(sherm1) Change event tracking goes here.
+  ContextBase& context = get_mutable_owning_context();
+  const DependencyTracker& tracker = context.get_tracker(ticket_);
+  const int64_t change_event = context.start_new_change_event();
+  tracker.NoteValueChange(change_event);
   ++serial_number_;
   return value_.get_mutable();
 }

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -16,11 +16,28 @@
 namespace drake {
 namespace systems {
 
-/// %LeafContext contains all prerequisite data necessary to uniquely determine
-/// the results of computations performed by the associated LeafSystem.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
+/** %LeafContext contains all prerequisite data necessary to uniquely determine
+the results of computations performed by the associated LeafSystem. It also
+contains mutable cache for holding the results of those computations, and
+infrastructure for ensuring that those results are up to date with their
+prerequisites. Here is an inventory:
+
+##### Source data
+- Time t, accuracy a (from base class)
+- %State values x
+- %Parameter values p
+- %Value sources for input ports u
+  - Stored values for locally-fixed input ports
+  - References to value sources for externally-connected input ports
+
+##### Cached computations
+- Output port values
+- %State derivatives and discrete update values
+- Constraint errors
+- User-specified cached computations
+
+@tparam T The mathematical type of the context, which must be a valid Eigen
+          scalar. */
 template <typename T>
 class LeafContext : public Context<T> {
  public:
@@ -33,37 +50,8 @@ class LeafContext : public Context<T> {
   //@}
 
   LeafContext()
-      : state_(std::make_unique<State<T>>()),
-        parameters_(std::make_unique<Parameters<T>>()) {}
+      : state_(std::make_unique<State<T>>()) {}
   ~LeafContext() override {}
-
-  const State<T>& get_state() const final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  State<T>& get_mutable_state() final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_.get();
-  }
-
-  // =========================================================================
-  // Accessors and Mutators for Parameters.
-
-  /// Sets the parameters to @p params, deleting whatever was there before.
-  void set_parameters(std::unique_ptr<Parameters<T>> params) {
-    parameters_ = std::move(params);
-  }
-
-  /// Returns the entire Parameters object.
-  const Parameters<T>& get_parameters() const final {
-    return *parameters_;
-  }
-
-  /// Returns the entire Parameters object.
-  Parameters<T>& get_mutable_parameters() final {
-    return *parameters_;
-  }
 
  protected:
   /// Protected copy constructor takes care of the local data members and
@@ -72,9 +60,6 @@ class LeafContext : public Context<T> {
   LeafContext(const LeafContext& source) : Context<T>(source) {
     // Make a deep copy of the state.
     state_ = source.CloneState();
-
-    // Make deep copies of the parameters.
-    set_parameters(source.parameters_->Clone());
 
     // Everything else was handled by the Context<T> copy constructor.
   }
@@ -99,18 +84,25 @@ class LeafContext : public Context<T> {
         xc_vector.Clone(), num_q, num_v, num_z));
 
     // Make deep copies of the discrete and abstract states.
-    clone->set_discrete_state(get_state().get_discrete_state().Clone());
-    clone->set_abstract_state(get_state().get_abstract_state().Clone());
+    clone->set_discrete_state(state_->get_discrete_state().Clone());
+    clone->set_abstract_state(state_->get_abstract_state().Clone());
 
     return clone;
   }
 
  private:
-  // The internal state of the System.
-  std::unique_ptr<State<T>> state_;
+  const State<T>& do_access_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
 
-  // The parameters of the system.
-  std::unique_ptr<Parameters<T>> parameters_;
+  State<T>& do_access_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_.get();
+  }
+
+  // The internal state x of this LeafSystem.
+  std::unique_ptr<State<T>> state_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -9,21 +9,15 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/never_destroyed.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port.h"
+#include "drake/systems/framework/system_base.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
-
-template <typename T>
-class System;
-
-template <typename T>
-class Context;
 
 /** Adds methods for allocation, calculation, and caching of an output
 port's value. When created, an allocation and a calculation function must be
@@ -39,9 +33,8 @@ Instantiated templates for the following kinds of T's are provided:
 
 They are already available to link against in the containing library.
 No other values for T are currently supported. */
-// TODO(sherm1) Implement caching for output ports.
 template <typename T>
-class LeafOutputPort : public OutputPort<T> {
+class LeafOutputPort final : public OutputPort<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafOutputPort)
 
@@ -74,17 +67,15 @@ class LeafOutputPort : public OutputPort<T> {
   concrete type as is returned by the allocator. The allocator function is not
   invoked here during construction of the port so it may depend on data that
   becomes available only after completion of the containing System or
-  Diagram. The `system` parameter must be the same object as the `system_base`
-  parameter. */
-  LeafOutputPort(const System<T>& system,
-                 const internal::SystemMessageInterface& system_base,
-                 OutputPortIndex index,
-                 AllocCallback alloc_function,
-                 CalcCallback calc_function)
-      : OutputPort<T>(system, system_base, index, kAbstractValued,
+  Diagram. */
+  LeafOutputPort(const System<T>* system, SystemBase* system_base,
+                 OutputPortIndex index, DependencyTicket ticket,
+                 AllocCallback alloc_function, CalcCallback calc_function,
+                 std::vector<DependencyTicket> calc_prerequisites)
+      : OutputPort<T>(system, system_base, index, ticket, kAbstractValued,
                       0 /* size */) {
-    set_allocation_function(alloc_function);
-    set_calculation_function(calc_function);
+    CompleteConstruction(std::move(alloc_function), std::move(calc_function),
+                         std::move(calc_prerequisites));
   }
 
   /** Constructs a fixed-size vector-valued output port. The supplied allocator
@@ -93,21 +84,21 @@ class LeafOutputPort : public OutputPort<T> {
   same underlying concrete type as is returned by the allocator. Requires the
   fixed size to be given explicitly here. The allocator function is not invoked
   here during construction of the port so it may depend on data that becomes
-  available only after completion of the containing System or Diagram. The
-  `system` parameter must be the same object as the `system_base` parameter. */
+  available only after completion of the containing System or Diagram. */
   // Note: there is no guarantee that the allocator can be invoked successfully
   // here since construction of the containing System is likely incomplete when
   // this method is invoked. Do not attempt to extract the size from
   // the allocator by calling it here.
-  LeafOutputPort(const System<T>& system,
-                 const internal::SystemMessageInterface& system_base,
-                 OutputPortIndex index,
-                 int fixed_size,
-                 AllocCallback vector_alloc_function,
-                 CalcVectorCallback vector_calc_function)
-      : OutputPort<T>(system, system_base, index, kVectorValued, fixed_size) {
-    set_allocation_function(vector_alloc_function);
-    set_calculation_function(vector_calc_function);
+  LeafOutputPort(const System<T>* system, SystemBase* system_base,
+                 OutputPortIndex index, DependencyTicket ticket, int fixed_size,
+                 AllocCallback alloc_function,
+                 CalcVectorCallback vector_calc_function,
+                 std::vector<DependencyTicket> calc_prerequisites)
+      : OutputPort<T>(system, system_base, index, ticket, kVectorValued,
+                      fixed_size) {
+    CompleteConstruction(std::move(alloc_function),
+                         ConvertVectorCallback(std::move(vector_calc_function)),
+                         std::move(calc_prerequisites));
   }
 
   /** (Advanced) Sets or replaces the evaluation function for this output
@@ -119,90 +110,140 @@ class LeafOutputPort : public OutputPort<T> {
     eval_function_ = eval_function;
   }
 
+  /** Returns the cache entry associated with this output port. */
+  CacheIndex cache_index() const { return cache_index_; }
+
  private:
-  // Sets or replaces the allocation function for this output port, using
-  // a function that returns an AbstractValue.
-  void set_allocation_function(AllocCallback alloc_function) {
-    alloc_function_ = alloc_function;
-  }
-
-  // Sets or replaces the calculation function for this output port, using
-  // a function that writes into an `AbstractValue`.
-  void set_calculation_function(CalcCallback calc_function) {
-    calc_function_ = calc_function;
-  }
-
-  // Sets or replaces the calculation function for this vector-valued output
+  // Creates an AbstractValue calculation function for this vector-valued output
   // port, using a function that writes into a `BasicVector<T>`.
-  void set_calculation_function(CalcVectorCallback vector_calc_function) {
-    if (!vector_calc_function) {
-      calc_function_ = nullptr;
-    } else {
-      // Wrap the vector-writing function with an AbstractValue-writing
-      // function.
-      calc_function_ = [this, vector_calc_function](const Context<T>& context,
-                                                    AbstractValue* abstract) {
-        // The abstract value must be a Value<BasicVector<T>>.
-        auto value = dynamic_cast<Value<BasicVector<T>>*>(abstract);
-        if (value == nullptr) {
-          std::ostringstream oss;
-          oss << "LeafOutputPort::Calc(): Expected a vector output type for "
-              << this->GetPortIdString() << " but got a "
-              << NiceTypeName::Get(*abstract) << " instead.";
-          throw std::logic_error(oss.str());
-        }
-        vector_calc_function(context, &value->get_mutable_value());
-      };
-    }
-  }
+  CalcCallback ConvertVectorCallback(CalcVectorCallback vector_calc_function);
+
+  // Handles common constructor tasks.
+  void CompleteConstruction(
+  AllocCallback alloc_function, CalcCallback calc_function,
+      std::vector<DependencyTicket> calc_prerequisites);
 
   // Invokes the supplied allocation function if there is one, otherwise
   // complains.
-  std::unique_ptr<AbstractValue> DoAllocate() const final {
-    std::unique_ptr<AbstractValue> result;
-
-    if (alloc_function_) {
-      result = alloc_function_();
-    } else {
-      throw std::logic_error(
-          "LeafOutputPort::DoAllocate(): " + this->GetPortIdString() +
-          " has no allocation function so cannot be allocated.");
-    }
-    if (result.get() == nullptr) {
-      throw std::logic_error(
-          "LeafOutputPort::DoAllocate(): allocator returned a nullptr for " +
-          this->GetPortIdString());
-    }
-    return result;
-  }
+  std::unique_ptr<AbstractValue> DoAllocate() const final;
 
   // Invokes the supplied calculation function if present, otherwise complains.
-  void DoCalc(const Context<T>& context, AbstractValue* value) const final {
-    if (calc_function_) {
-      calc_function_(context, value);
-    } else {
-      throw std::logic_error("LeafOutputPort::DoCalcWitnessValue(): " +
-                             this->GetPortIdString() +
-                             " had no calculation function available.");
-    }
-  }
+  void DoCalc(const Context<T>& context, AbstractValue* value) const final;
 
   // Currently just invokes the supplied evaluation function if present,
-  // otherwise complains.
-  // TODO(sherm1) Generate this automatically using the cache & DoEvaluate().
-  const AbstractValue& DoEval(const Context<T>& context) const final {
-    if (eval_function_) return eval_function_(context);
-    // TODO(sherm1) Provide proper default behavior for an output port with
-    // its own cache entry.
-    DRAKE_ABORT_MSG("LeafOutputPort::DoEval(): NOT IMPLEMENTED YET");
-    static never_destroyed<Value<int>> dummy{0};
-    return dummy.access();
-  }
+  // otherwise forwards to this port's cache entry.
+  const AbstractValue& DoEval(const Context<T>& context) const final;
+
+  // Returns the cache entry's ticket and no subsystem.
+  std::pair<optional<SubsystemIndex>, DependencyTicket> DoGetPrerequisite()
+      const final;
 
   AllocCallback alloc_function_;
   CalcCallback  calc_function_;
   EvalCallback  eval_function_;
+
+  CacheIndex cache_index_;
 };
+
+// See diagram.h for DiagramOutputPort.
+
+template <typename T>
+auto LeafOutputPort<T>::ConvertVectorCallback(
+    CalcVectorCallback vector_calc_function) -> CalcCallback {
+  if (!vector_calc_function) return nullptr;
+
+  // Wrap the vector-writing function with an AbstractValue-writing function.
+  return [this, vector_calc_function](const Context<T>& context,
+                                      AbstractValue* abstract) {
+    // The abstract value must be a Value<BasicVector<T>>.
+    auto value = dynamic_cast<Value<BasicVector<T>>*>(abstract);
+    if (value == nullptr) {
+      std::ostringstream oss;
+      oss << "LeafOutputPort::Calc(): Expected a vector output type for "
+          << this->GetPortIdString() << " but got a "
+          << NiceTypeName::Get(*abstract) << " instead.";
+      throw std::logic_error(oss.str());
+    }
+    vector_calc_function(context, &value->get_mutable_value());
+  };
+}
+
+// Private method to be called from cached output port constructors, after the
+// base class construction is complete. Records the functors and Calc()
+// prerequisites, and allocates an appropriate cache entry.
+template <typename T>
+void LeafOutputPort<T>::CompleteConstruction(
+    AllocCallback alloc_function, CalcCallback calc_function,
+    std::vector<DependencyTicket> calc_prerequisites) {
+  alloc_function_ = std::move(alloc_function);
+  calc_function_ = std::move(calc_function);
+
+  if (calc_prerequisites.empty())
+    calc_prerequisites.push_back(this->get_system_base().all_sources_ticket());
+
+  auto cache_alloc_function = [alloc = alloc_function_]() { return alloc(); };
+  auto cache_calc_function = [calc = calc_function_](
+      const ContextBase& context_base, AbstractValue* result) {
+    const Context<T>& context = dynamic_cast<const Context<T>&>(context_base);
+    return calc(context, result);
+  };
+  cache_index_ =
+      this->get_mutable_system_base()
+          .DeclareCacheEntry(
+              "output port " + std::to_string(this->get_index()) + " cache",
+              std::move(cache_alloc_function), std::move(cache_calc_function),
+              std::move(calc_prerequisites))
+          .cache_index();
+}
+
+template <typename T>
+std::unique_ptr<AbstractValue> LeafOutputPort<T>::DoAllocate() const {
+  std::unique_ptr<AbstractValue> result;
+
+  if (alloc_function_) {
+    result = alloc_function_();
+  } else {
+    throw std::logic_error(
+        "LeafOutputPort::DoAllocate(): " + this->GetPortIdString() +
+            " has no allocation function so cannot be allocated.");
+  }
+  if (result.get() == nullptr) {
+    throw std::logic_error(
+        "LeafOutputPort::DoAllocate(): allocator returned a nullptr for " +
+            this->GetPortIdString());
+  }
+  return result;
+}
+
+template <typename T>
+void LeafOutputPort<T>::DoCalc(const Context<T>& context,
+                               AbstractValue* value) const {
+  if (calc_function_) {
+    calc_function_(context, value);
+  } else {
+    throw std::logic_error("LeafOutputPort::DoCalcWitnessValue(): " +
+        this->GetPortIdString() +
+        " had no calculation function available.");
+  }
+}
+
+template <typename T>
+const AbstractValue& LeafOutputPort<T>::DoEval(
+    const Context<T>& context) const {
+  if (eval_function_)
+    return eval_function_(context);
+  const CacheEntry& entry =
+      this->get_system_base().get_cache_entry(cache_index_);
+  return entry.EvalAbstract(context);
+}
+
+template <typename T>
+std::pair<optional<SubsystemIndex>, DependencyTicket>
+LeafOutputPort<T>::DoGetPrerequisite() const {
+  const CacheEntry& entry =
+      this->get_system_base().get_cache_entry(cache_index_);
+  return std::make_pair(nullopt, entry.ticket());
+}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <typeinfo>
 #include <utility>
 #include <vector>
 
@@ -15,6 +14,8 @@
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/framework_common.h"
+#include "drake/systems/framework/output_port_base.h"
+#include "drake/systems/framework/system_base.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
@@ -66,11 +67,24 @@ No other values for T are currently supported. */
 // TODO(sherm1) Implement caching for output ports and update the above
 // documentation to explain in more detail.
 template <typename T>
-class OutputPort {
+class OutputPort : public OutputPortBase {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPort)
 
-  virtual ~OutputPort() = default;
+  ~OutputPort() override = default;
+
+  /** Returns a reference to the up-to-date value of this output port contained
+  in the given Context. This is the preferred way to obtain an output port's
+  value since it will not be recalculated once up to date. If the value is not
+  already up to date with respect to its prerequisites, this port's Calc()
+  method is used first to update the value before the reference is returned. The
+  Calc() method may be arbitrarily expensive, but Eval() is constant time and
+  _very_ fast if the value is already up to date. */
+  template <typename ValueType>
+  const ValueType& Eval(const Context<T>& context) const {
+    const AbstractValue& abstract_value = EvalAbstract(context);
+    return ExtractValueOrThrow<ValueType>(abstract_value, __func__);
+  }
 
   /** Allocates a concrete object suitable for holding the value to be exposed
   by this output port, and returns that as an AbstractValue. The returned object
@@ -98,7 +112,8 @@ class OutputPort {
   the Allocate() method. */
   void Calc(const Context<T>& context, AbstractValue* value) const {
     DRAKE_DEMAND(value != nullptr);
-    DRAKE_ASSERT_VOID(system_base_.ThrowIfContextNotCompatible(context));
+    DRAKE_ASSERT_VOID(
+        get_system_base().ThrowIfContextNotCompatible(context));
     DRAKE_ASSERT_VOID(CheckValidOutputType(*value));
 
     DoCalc(context, value);
@@ -107,10 +122,10 @@ class OutputPort {
   /** Returns a reference to the value of this output port contained in the
   given Context. If that value is not up to date with respect to its
   prerequisites, the Calc() method above is used first to update the value
-  before the reference is returned. (Not implemented yet.) */
-  // TODO(sherm1) Implement properly.
-  const AbstractValue& Eval(const Context<T>& context) const {
-    DRAKE_ASSERT_VOID(system_base_.ThrowIfContextNotCompatible(context));
+  before the reference is returned. */
+  const AbstractValue& EvalAbstract(const Context<T>& context) const {
+    DRAKE_ASSERT_VOID(
+        get_system_base().ThrowIfContextNotCompatible(context));
     return DoEval(context);
   }
 
@@ -121,49 +136,20 @@ class OutputPort {
     return system_;
   }
 
-  /** Returns the index of this output port within the owning System. */
-  OutputPortIndex get_index() const {
-    return index_;
-  }
-
-  /** Gets the port data type specified at port construction. */
-  PortDataType get_data_type() const { return data_type_; }
-
-  /** Returns the fixed size expected for a vector-valued output port. Not
-  meaningful for abstract output ports. */
-  int size() const { return size_; }
-
  protected:
   /** Provides derived classes the ability to set the base class members at
-  construction.
-  @param system
-    The System that will own this new output port (as forward-declared class).
-  @param system_base
-    The System that will own this new output port (as pure virtual interface).
-  @param index
-    The index of this port within its owning System.
-  @param data_type
-    Whether the port described is vector or abstract valued.
-  @param size
-    If the port described is vector-valued, the number of elements expected,
-    otherwise ignored.
-  @pre The `system` parameter must be the same object as the `system_base`
-    parameter. */
+  construction. See OutputPortBase::OutputPortBase() for the meaning of these
+  parameters. */
   // The System and SystemBase are provided separately since we don't have
   // access to System's declaration here so can't cast but the caller can.
-  OutputPort(
-      const System<T>& system,
-      const internal::SystemMessageInterface& system_base,
-      OutputPortIndex index, PortDataType data_type, int size)
-      : system_(system),
-        system_base_(system_base),
-        index_(index),
-        data_type_(data_type),
-        size_(size) {
-    DRAKE_DEMAND(static_cast<const void*>(&system) == &system_base);
-    if (size_ == kAutoSize) {
-      DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
-    }
+  // They must refer to the same System.
+  OutputPort(const System<T>* system,
+             SystemBase* system_base,
+             OutputPortIndex index,
+             DependencyTicket ticket, PortDataType data_type, int size)
+      : OutputPortBase(system_base, index, ticket, data_type, size),
+        system_{*system} {
+    DRAKE_DEMAND(static_cast<const void*>(system) == system_base);
   }
 
   /** A concrete %OutputPort must provide a way to allocate a suitable object
@@ -195,95 +181,133 @@ class OutputPort {
   /** This is useful for error messages and produces a human-readable
   identification of an offending output port. */
   std::string GetPortIdString() const {
-    std::ostringstream oss;
-    oss << "output port " << this->get_index() << " of "
-        << NiceTypeName::Get(system_base_) + " System " +
-           system_base_.GetSystemPathname();
-    return oss.str();
+    const std::string port_id =
+        "OutputPort[" + std::to_string(this->get_index()) + "] of subsystem " +
+            this->get_system_base().GetSystemPathname() + "(" +
+            NiceTypeName::RemoveNamespaces(
+                this->get_system_base().GetSystemType()) +
+            ").";
+    return port_id;
   }
 
  private:
   // Check whether the allocator returned a value that is consistent with
   // this port's specification.
-  // If this is a vector-valued port, we can check that the returned abstract
-  // value actually holds a BasicVector-derived object, and for fixed-size ports
-  // that the object has the right size.
-  void CheckValidAllocation(const AbstractValue& proposed) const {
-    if (this->get_data_type() != kVectorValued)
-      return;  // Nothing we can check for an abstract port.
-
-    auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
-    if (proposed_vec == nullptr) {
-      std::ostringstream oss;
-      oss << "Allocate(): expected BasicVector output type but got "
-          << NiceTypeName::Get(proposed) << " for " << GetPortIdString();
-      throw std::logic_error(oss.str());
-    }
-
-    if (this->size() == kAutoSize)
-      return;  // Any size is acceptable.
-
-    const int proposed_size = proposed_vec->get_value().size();
-    if (proposed_size != this->size()) {
-      std::ostringstream oss;
-      oss << "Allocate(): expected vector output type of size " << this->size()
-          << " but got a vector of size " << proposed_size
-          << " for " << GetPortIdString();
-      throw std::logic_error(oss.str());
-    }
-  }
+  void CheckValidAllocation(const AbstractValue&) const;
 
   // Check that an AbstractValue provided to Calc() is suitable for this port.
   // (Very expensive; use in Debug only.)
-  // See CacheEntry::CheckValidAbstractValue; treat both methods similarly.
-  void CheckValidOutputType(const AbstractValue& proposed) const {
-    // TODO(sherm1) Consider whether we can depend on there already being an
-    // object of this type in the output port's CacheEntryValue so we wouldn't
-    // have to allocate one here. If so could also store a precomputed
-    // type_index there for further savings. Would need to pass in a Context.
-    auto good = DoAllocate();  // Expensive!
-    // Attempt to interpret these as BasicVectors.
-    auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
-    auto good_vec = dynamic_cast<const Value<BasicVector<T>>*>(good.get());
-    if (proposed_vec && good_vec) {
-      CheckValidBasicVector(good_vec->get_value(),
-                            proposed_vec->get_value());
-    } else {
-      // At least one is not a BasicVector.
-      CheckValidAbstractValue(*good, proposed);
-    }
-  }
+  void CheckValidOutputType(const AbstractValue&) const;
 
   // Check that both type-erased arguments have the same underlying type.
   void CheckValidAbstractValue(const AbstractValue& good,
-                               const AbstractValue& proposed) const {
-    if (typeid(proposed) != typeid(good)) {
-      std::ostringstream oss;
-      oss << "Calc(): expected AbstractValue output type "
-          << NiceTypeName::Get(good) << " but got "
-          << NiceTypeName::Get(proposed) << " for " << GetPortIdString();
-      throw std::logic_error(oss.str());
-    }
-  }
+                               const AbstractValue& proposed) const;
 
   // Check that both BasicVector arguments have the same underlying type.
   void CheckValidBasicVector(const BasicVector<T>& good,
-                             const BasicVector<T>& proposed) const {
-    if (typeid(proposed) != typeid(good)) {
-      std::ostringstream oss;
-      oss << "Calc(): expected BasicVector output type "
-          << NiceTypeName::Get(good) << " but got "
-          << NiceTypeName::Get(proposed) << " for " << GetPortIdString();
-      throw std::logic_error(oss.str());
-    }
+                             const BasicVector<T>& proposed) const;
+
+  // The user told us the output port would have a particular concrete type
+  // but it doesn't.
+  template <typename ValueType>
+  void ThrowBadValueType(const char* func_name,
+                         const AbstractValue& abstract) const {
+    std::ostringstream msg;
+    msg << "OutputPort::" << func_name << "(): wrong value type <"
+        << NiceTypeName::Get<ValueType>() << "> specified but actual type was <"
+        << abstract.GetNiceTypeName() << ">."
+        << "\n-- " << GetPortIdString();
+    throw std::logic_error(msg.str());
+  }
+
+  // Pull a value of a given type from an abstract value or issue a nice
+  // message if the type is not correct.
+  template <typename ValueType>
+  const ValueType& ExtractValueOrThrow(const AbstractValue& abstract,
+                                       const char* func_name) const {
+    const ValueType* value = abstract.MaybeGetValue<ValueType>();
+    if (!value)
+      ThrowBadValueType<ValueType>(func_name, abstract);
+    return *value;
   }
 
   const System<T>& system_;
-  const internal::SystemMessageInterface& system_base_;
-  const OutputPortIndex index_;
-  const PortDataType data_type_;
-  const int size_;
 };
+
+// If this is a vector-valued port, we can check that the returned abstract
+// value actually holds a BasicVector-derived object, and for fixed-size ports
+// that the object has the right size.
+template <typename T>
+void OutputPort<T>::CheckValidAllocation(const AbstractValue& proposed) const {
+  if (this->get_data_type() != kVectorValued)
+    return;  // Nothing we can check for an abstract port.
+
+  auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
+  if (proposed_vec == nullptr) {
+    std::ostringstream oss;
+    oss << "Allocate(): expected BasicVector output type but got "
+        << NiceTypeName::Get(proposed) << " for " << GetPortIdString();
+    throw std::logic_error(oss.str());
+  }
+
+  if (this->size() == kAutoSize)
+    return;  // Any size is acceptable.
+
+  const int proposed_size = proposed_vec->get_value().size();
+  if (proposed_size != this->size()) {
+    std::ostringstream oss;
+    oss << "Allocate(): expected vector output type of size " << this->size()
+        << " but got a vector of size " << proposed_size
+        << " for " << GetPortIdString();
+    throw std::logic_error(oss.str());
+  }
+}
+
+// Check that an AbstractValue provided to Calc() is suitable for this port.
+// (Very expensive; use in Debug only.)
+// See CacheEntry::CheckValidAbstractValue; treat both methods similarly.
+template <typename T>
+void OutputPort<T>::CheckValidOutputType(const AbstractValue& proposed) const {
+  // TODO(sherm1) Consider whether we can depend on there already being an
+  // object of this type in the output port's CacheEntryValue so we wouldn't
+  // have to allocate one here. If so could also store a precomputed
+  // type_index there for further savings. Would need to pass in a Context.
+  auto good = DoAllocate();  // Expensive!
+  // Attempt to interpret these as BasicVectors.
+  auto proposed_vec = dynamic_cast<const Value<BasicVector<T>>*>(&proposed);
+  auto good_vec = dynamic_cast<const Value<BasicVector<T>>*>(good.get());
+  if (proposed_vec && good_vec) {
+    CheckValidBasicVector(good_vec->get_value(), proposed_vec->get_value());
+  } else {
+    // At least one is not a BasicVector.
+    CheckValidAbstractValue(*good, proposed);
+  }
+}
+
+// Check that both type-erased arguments have the same underlying type.
+template <typename T>
+void OutputPort<T>::CheckValidAbstractValue(
+    const AbstractValue& good, const AbstractValue& proposed) const {
+  if (typeid(proposed) != typeid(good)) {
+    std::ostringstream oss;
+    oss << "Calc(): expected AbstractValue output type "
+        << NiceTypeName::Get(good) << " but got " << NiceTypeName::Get(proposed)
+        << " for " << GetPortIdString();
+    throw std::logic_error(oss.str());
+  }
+}
+
+template <typename T>
+void OutputPort<T>::CheckValidBasicVector(
+    const BasicVector<T>& good, const BasicVector<T>& proposed) const {
+  if (typeid(proposed) != typeid(good)) {
+    std::ostringstream oss;
+    oss << "Calc(): expected BasicVector output type "
+        << NiceTypeName::Get(good) << " but got " << NiceTypeName::Get(proposed)
+        << " for " << GetPortIdString();
+    throw std::logic_error(oss.str());
+  }
+}
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/output_port_base.cc
+++ b/systems/framework/output_port_base.cc
@@ -1,0 +1,24 @@
+#include "drake/systems/framework/output_port_base.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+OutputPortBase::OutputPortBase(
+    SystemBase* owning_subsystem,
+    OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
+    int size)
+    : owning_subsystem_(*owning_subsystem),
+      index_(index),
+      ticket_(ticket),
+      data_type_(data_type),
+      size_(size) {
+  DRAKE_DEMAND(owning_subsystem != nullptr);
+  if (size_ == kAutoSize)
+    DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/output_port_base.h
+++ b/systems/framework/output_port_base.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "drake/common/drake_optional.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+class SystemBase;
+
+/** An OutputPort belongs to a System and represents the properties of one of
+that System's output ports. OutputPort objects are assigned OutputPortIndex
+values in the order they are declared; these are unique within a single System.
+A DependencyTicket is assigned so that downstream dependents can subscribe to
+the value of this port. Also, each output port has a single prerequisite to
+which it must be subscribed. For leaf systems, that prerequisite is a cache
+entry that holds the most-recently-calculated port value. For diagrams, it is
+the output port of a child subsystem which has been exported to be an output
+of its parent.
+
+%OutputPortBase handles the scalar type-independent aspects of an OutputPort. */
+class OutputPortBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortBase)
+
+  virtual ~OutputPortBase() = default;
+
+  /** Returns the index of this output port within the owning System. For a
+  Diagram, this will be the index within the Diagram, _not_ the index within
+  the LeafSystem whose output port was forwarded. */
+  OutputPortIndex get_index() const {
+    return index_;
+  }
+
+  /** Returns the DependencyTicket for this output port within the owning
+  System. */
+  DependencyTicket ticket() const {
+    return ticket_;
+  }
+
+  /** Gets the port data type specified at port construction. */
+  PortDataType get_data_type() const { return data_type_; }
+
+  /** Returns the fixed size expected for a vector-valued output port. Not
+  meaningful for abstract output ports. */
+  int size() const { return size_; }
+
+  /** Returns a reference to the System that owns this output port. Note that
+  for a diagram output port this will be the diagram, not the leaf system whose
+  output port was forwarded. */
+  const SystemBase& get_system_base() const {
+    return owning_subsystem_;
+  }
+
+  /** Returns the prerequisite for this output port -- either a cache entry
+  in this System, or an output port of a child System. */
+  std::pair<optional<SubsystemIndex>, DependencyTicket> GetPrerequisite()
+      const {
+    return DoGetPrerequisite();
+  };
+
+ protected:
+  /** Provides derived classes the ability to set the base class members at
+  construction.
+
+  @param owning_subsystem
+    The System that owns this output port.
+  @param index
+    The index to be assigned to this OutputPort.
+  @param ticket
+      The DependencyTicket to be assigned to this OutputPort.
+  @param data_type
+    Whether the port described is vector or abstract valued.
+  @param size
+    If the port described is vector-valued, the number of elements expected,
+    otherwise ignored. */
+  OutputPortBase(SystemBase* owning_subsystem,
+                 OutputPortIndex index, DependencyTicket ticket,
+                 PortDataType data_type, int size);
+
+  SystemBase& get_mutable_system_base() {
+    return owning_subsystem_;
+  }
+
+  /** Concrete output ports must implement this to return the prerequisite
+  dependency ticket for this port, which may be in the current System or one
+  of its immediate child subsystems. */
+  virtual std::pair<optional<SubsystemIndex>, DependencyTicket>
+  DoGetPrerequisite() const = 0;
+
+ private:
+  // Associated System and System resources.
+  SystemBase& owning_subsystem_;
+  const OutputPortIndex index_;
+  const DependencyTicket ticket_;
+
+  // Port details.
+  const PortDataType data_type_;
+  const int size_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/output_port_value.cc
+++ b/systems/framework/output_port_value.cc
@@ -2,23 +2,5 @@
 
 #include "drake/common/default_scalars.h"
 
-namespace drake {
-namespace systems {
-
-OutputPortValue::~OutputPortValue() {}
-
-std::unique_ptr<OutputPortValue> OutputPortValue::Clone() const {
-  if (data_ != nullptr) {
-    return std::make_unique<OutputPortValue>(data_->Clone());
-  }
-  return nullptr;
-}
-
-}  // namespace systems
-}  // namespace drake
-
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::SystemOutput)
-
-DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
-    class ::drake::systems::LeafSystemOutput)

--- a/systems/framework/output_port_value.h
+++ b/systems/framework/output_port_value.h
@@ -8,191 +8,88 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/pointer_cast.h"
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/value.h"
 #include "drake/systems/framework/value_checker.h"
 
 namespace drake {
 namespace systems {
 
-/// %OutputPortValue contains the value of a single System output port.
-/// Input ports of other Systems may depend on an %OutputPortValue. When an
-/// %OutputPortValue is deleted, it will automatically notify the listeners that
-/// depend on it to disconnect, meaning those ports will resolve to nullptr.
-class OutputPortValue {
- public:
-  // OutputPortValue objects are neither copyable nor moveable.
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortValue)
+/** Conveniently stores a snapshot of the values of every output port of
+a System. There is framework support for allocating the right types and filling
+them in but otherwise this is not used internally. Note that there is never any
+live connection between a SystemOutput object and the System whose output values
+it has captured.
 
-  /// Constructs a vector-valued OutputPortValue.
-  /// Takes ownership of @p vec.
-  ///
-  /// @tparam T The type of the vector data. Must be a valid Eigen scalar.
-  /// @tparam V The type of @p vec itself. Must implement BasicVector<T>.
-  template <template <typename T> class V, typename T>
-  explicit OutputPortValue(std::unique_ptr<V<T>> vec)
-      : data_(std::make_unique<Value<BasicVector<T>>>(std::move(vec))) {}
-
-  /// Constructs an abstract-valued OutputPortValue.
-  /// Takes ownership of @p data.
-  explicit OutputPortValue(std::unique_ptr<AbstractValue> data)
-      : data_(std::move(data)) {}
-
-  /// Constructs an abstract-valued OutputPortValue.
-  /// Takes ownership of @p data.
-  ///
-  /// @tparam T The type of the data.
-  template <typename T>
-  explicit OutputPortValue(std::unique_ptr<Value<T>> data)
-      : OutputPortValue(static_pointer_cast<AbstractValue>(std::move(data))) {}
-
-  virtual ~OutputPortValue();
-
-  /// Returns the abstract value in this port.
-  const AbstractValue* get_abstract_data() const { return data_.get(); }
-
-  /// Returns the vector of data in this output port. Throws std::bad_cast
-  /// if this is not a vector-valued port.
-  template <typename T>
-  const BasicVector<T>* get_vector_data() const {
-    return &data_->GetValue<BasicVector<T>>();
-  }
-
-  /// Returns a pointer to the data inside this %OutputPortValue.
-  AbstractValue* GetMutableData() {
-    return data_.get();
-  }
-
-  /// Returns a pointer to the data inside this %OutputPortValue.
-  ///
-  /// Throws std::bad_cast if this is not a vector-valued port.
-  template <typename T>
-  BasicVector<T>* GetMutableVectorData() {
-    return &data_->GetMutableValue<BasicVector<T>>();
-  }
-
-  /// Returns a clone of this %OutputPortValue containing a clone of the data,
-  /// but without any dependents.
-  std::unique_ptr<OutputPortValue> Clone() const;
-
- private:
-  // The port data.
-  std::unique_ptr<AbstractValue> data_;
-};
-
-/// An abstract base class template for the values of the output ports of
-/// a System.
-///
-/// @tparam T The type of the output data. Must be a valid Eigen scalar.
+@tparam T The type of the output data. Must be a valid Eigen scalar. */
 template <typename T>
 class SystemOutput {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemOutput)
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(SystemOutput);
 
-  SystemOutput() {}
-  virtual ~SystemOutput() {}
+  SystemOutput() = default;
+  ~SystemOutput() = default;
 
-  virtual int get_num_ports() const = 0;
-  virtual OutputPortValue* get_mutable_port_value(int index) = 0;
-  virtual const OutputPortValue& get_port_value(int index) const = 0;
+  /** Returns the number of output ports specified for this %SystemOutput
+  during allocation. */
+  int get_num_ports() const { return static_cast<int>(port_values_.size()); }
 
-  /// Returns a type-preserving clone of this SystemOutput using the NVI idiom.
-  std::unique_ptr<SystemOutput<T>> Clone() const {
-    return std::unique_ptr<SystemOutput<T>>(DoClone());
-  }
+  // TODO(sherm1) All of these should return references. We don't need to
+  // support missing entries.
 
-  /// Returns the abstract value in the port at @p index.
+  /** Returns the last-saved value of output port `index` as an AbstractValue.
+  This works for any output port regardless of it actual type. */
   const AbstractValue* get_data(int index) const {
-    DRAKE_ASSERT(index >= 0 && index < get_num_ports());
-    return get_port_value(index).get_abstract_data();
-  }
-
-  /// Returns the vector value in the port at @p index. Throws std::bad_cast if
-  /// the port is not vector-valued.
-  const BasicVector<T>* get_vector_data(int index) const {
-    DRAKE_ASSERT(index >= 0 && index < get_num_ports());
-    return get_port_value(index).template get_vector_data<T>();
-  }
-
-  /// Returns a pointer to the data inside the port at @p index, and updates the
-  /// version so that Contexts depending on that OutputPortValue know to
-  /// invalidate
-  /// their caches. Callers MUST NOT write on the returned pointer if there is
-  /// any possibility this OutputPortValue has been accessed since the last time
-  /// GetMutableVectorData was called.
-  AbstractValue* GetMutableData(int index) {
-    DRAKE_ASSERT(index >= 0 && index < get_num_ports());
-    return get_mutable_port_value(index)->GetMutableData();
-  }
-
-  /// Returns a pointer to the data inside the port at @p index, and updates the
-  /// version so that Contexts depending on that OutputPortValue know to
-  /// invalidate
-  /// their caches. Callers MUST NOT write on the returned pointer if there is
-  /// any possibility this OutputPortValue has been accessed since the last time
-  /// GetMutableVectorData was called.
-  ///
-  /// Throws std::bad_cast if this is not a vector-valued port.
-  BasicVector<T>* GetMutableVectorData(int index) {
-    DRAKE_ASSERT(index >= 0 && index < get_num_ports());
-    return get_mutable_port_value(index)->template GetMutableVectorData<T>();
-  }
-
- protected:
-  /// The NVI implementation of Clone().
-  virtual SystemOutput<T>* DoClone() const = 0;
-};
-
-/// A container for the values of all output ports of a leaf System.
-///
-/// @tparam T The type of the output data. Must be a valid Eigen scalar.
-template <typename T>
-class LeafSystemOutput : public SystemOutput<T> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafSystemOutput)
-
-  LeafSystemOutput() = default;
-  ~LeafSystemOutput() override = default;
-
-  int get_num_ports() const override {
-    return static_cast<int>(port_values_.size());
-  }
-
-  OutputPortValue* get_mutable_port_value(int index) override {
-    DRAKE_DEMAND(index >= 0 && index < get_num_ports());
+    DRAKE_ASSERT(0 <= index && index < get_num_ports());
     return port_values_[index].get();
   }
 
-  const OutputPortValue& get_port_value(int index) const override {
-    DRAKE_DEMAND(index >= 0 && index < get_num_ports());
-    return *port_values_[index];
+  /** Returns the last-saved value of output port `index` as a `BasicVector<T>`,
+  although the actual concrete type is preserved from the actual output port.
+  Throws std::bad_cast if the port is not vector-valued. */
+  const BasicVector<T>* get_vector_data(int index) const {
+    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    return &port_values_[index]->template GetValue<BasicVector<T>>();
   }
 
-  void add_port(std::unique_ptr<AbstractValue> value) {
-    add_port(std::make_unique<OutputPortValue>(std::move(value)));
+  /** (Advanced) Returns mutable access to an AbstractValue object that is
+  suitable for holding the value of output port `index` of the allocating
+  System. This works for any output port regardless of it actual type. Most
+  users should just call `System<T>::CalcOutputs()` to get all the output
+  port values at once. */
+  AbstractValue* GetMutableData(int index) {
+    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    return port_values_[index].get_mutable();
   }
 
-  void add_port(std::unique_ptr<OutputPortValue> port) {
-    // This is a good time to confirm that the port's value is well-formed.
-    // This check will mostly occur only once per System.
-    DRAKE_ASSERT_VOID(detail::CheckVectorValueInvariants<T>(
-        port->get_abstract_data()));
-    port_values_.emplace_back(std::move(port));
+  /** (Advanced) Returns mutable access to a `BasicVector<T>` object that is
+  suitable for holding the value of output port `index` of the allocating
+  System. The object's concrete type is preserved from the output port. Most
+  users should just call `System<T>::CalcOutputs()` to get all the output
+  port values at once. Throws std::bad_cast if the port is not vector-valued. */
+  BasicVector<T>* GetMutableVectorData(int index) {
+    DRAKE_ASSERT(0 <= index && index < get_num_ports());
+    return &port_values_[index]
+                ->template GetMutableValueOrThrow<BasicVector<T>>();
   }
 
- protected:
-  // Returns a clone that includes a deep copy of all the output port values.
-  LeafSystemOutput<T>* DoClone() const override {
-    LeafSystemOutput<T>* clone = new LeafSystemOutput<T>();
-    for (const auto& port_value : port_values_) {
-      clone->port_values_.push_back(port_value->Clone());
-    }
-    return clone;
+  /** (Internal use only) Add a suitable object to hold values for the next
+  output port. */
+  void add_port(std::unique_ptr<AbstractValue> model_value) {
+    port_values_.emplace_back(std::move(model_value));
+  }
+
+  /** (Internal use only) Add a suitable BasicVector object to hold values for
+  the next output port. Still stored as an AbstractValue internally. */
+  void add_port(std::unique_ptr<BasicVector<T>> model_value) {
+    auto abs_value = std::unique_ptr<AbstractValue>(
+        new Value<BasicVector<T>>(std::move(model_value)));
+    add_port(std::move(abs_value));
   }
 
  private:
-  std::vector<std::unique_ptr<OutputPortValue>> port_values_;
+  std::vector<copyable_unique_ptr<AbstractValue>> port_values_;
 };
 
 }  // namespace systems

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -134,10 +134,20 @@ class System : public SystemBase {
   /// output ports. It is sized with the number of output ports and uses each
   /// output port's allocation method to provide an object of the right type
   /// for that port.
-  // TODO(sherm1) Get rid of context parameter. We are stuck with it for now
-  // because of the way DiagramOutput is implemented. Fixed in caching branch.
-  virtual std::unique_ptr<SystemOutput<T>> AllocateOutput(
-      const Context<T>& context) const = 0;
+  std::unique_ptr<SystemOutput<T>> AllocateOutput() const {
+    std::unique_ptr<SystemOutput<T>> output(new SystemOutput<T>);
+    for (int i = 0; i < this->get_num_output_ports(); ++i) {
+      const OutputPort<T>& port = this->get_output_port(i);
+      output->add_port(port.Allocate());
+    }
+    return std::move(output);
+  }
+
+  /// (Deprecated) Context is ignored.
+  // TODO(sherm1) Get rid of this.
+  std::unique_ptr<SystemOutput<T>> AllocateOutput(const Context<T>&) const {
+    return AllocateOutput();
+  }
 
   /// Returns a ContinuousState of the same size as the continuous_state
   /// allocated in CreateDefaultContext. The simulator will provide this state
@@ -370,13 +380,42 @@ class System : public SystemBase {
   /// a helpful message.
   //@{
 
+  /// Returns a reference to the cached value of the continuous state variable
+  /// time derivatives, evaluating first if necessary using
+  /// CalcTimeDerivatives().
+  /// @see CalcTimeDerivatives()
+  const ContinuousState<T>& EvalTimeDerivatives(
+      const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(time_derivatives_cache_index_);
+    return entry.Eval<ContinuousState<T>>(context);
+  }
+
+  /// Returns a reference to the cached value of the potential energy. If
+  /// necessary the cache will be updated first using CalcPotentialEnergy().
+  /// @see CalcPotentialEnergy()
+  const T& EvalPotentialEnergy(const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(potential_energy_cache_index_);
+    return entry.Eval<T>(context);
+  }
+
+  /// Returns a reference to the cached value of the kinetic energy. If
+  /// necessary the cache will be updated first using CalcKineticEnergy().
+  /// @see CalcPotentialEnergy()
+  const T& EvalKineticEnergy(const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(kinetic_energy_cache_index_);
+    return entry.Eval<T>(context);
+  }
+
   /// Returns a reference to the cached value of the conservative power. If
   /// necessary the cache will be updated first using CalcConservativePower().
   /// @see CalcConservativePower()
   const T& EvalConservativePower(const Context<T>& context) const {
-    // TODO(sherm1) Replace with an actual cache entry.
-    fake_cache_conservative_power_ = CalcConservativePower(context);
-    return fake_cache_conservative_power_;
+    const CacheEntry& entry =
+        this->get_cache_entry(conservative_power_cache_index_);
+    return entry.Eval<T>(context);
   }
 
   /// Returns a reference to the cached value of the non-conservative power. If
@@ -384,9 +423,9 @@ class System : public SystemBase {
   /// CalcNonConservativePower().
   /// @see CalcNonConservativePower()
   const T& EvalNonConservativePower(const Context<T>& context) const {
-    // TODO(sherm1) Replace with an actual cache entry.
-    fake_cache_nonconservative_power_ = CalcNonConservativePower(context);
-    return fake_cache_nonconservative_power_;
+    const CacheEntry& entry =
+        this->get_cache_entry(nonconservative_power_cache_index_);
+    return entry.Eval<T>(context);
   }
 
   /// Returns the value of the vector-valued input port with the given
@@ -417,7 +456,8 @@ class System : public SystemBase {
 
     const BasicVector<T>* const basic_value =
         EvalBasicVectorInputImpl(__func__, context, iport_index);
-    if (basic_value == nullptr) return nullptr;  // An unconnected port.
+    if (basic_value == nullptr)
+      return nullptr;  // An unconnected port.
 
     // It's a BasicVector, but we're fussy about the subtype here.
     const Vec<T>* const value = dynamic_cast<const Vec<T>*>(basic_value);
@@ -452,6 +492,7 @@ class System : public SystemBase {
 
     return basic_value->get_value();
   }
+
   //@}
 
   //----------------------------------------------------------------------------
@@ -627,7 +668,7 @@ class System : public SystemBase {
   }
 
   /// This method forces an unrestricted update on the system given a
-  /// @p context, and the updated state is stored in @p discrete_state. The
+  /// @p context, and the updated state is stored in @p state. The
   /// unrestricted update event will have a trigger type of kForced, with no
   /// additional data, attribute or custom callback.
   ///
@@ -741,8 +782,11 @@ class System : public SystemBase {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     DRAKE_ASSERT_VOID(CheckValidOutput(outputs));
     for (OutputPortIndex i(0); i < get_num_output_ports(); ++i) {
-      get_output_port(i).Calc(
-          context, outputs->get_mutable_port_value(i)->GetMutableData());
+      // TODO(sherm1) Would be better to use Eval() here but we don't have
+      // a generic abstract assignment capability that would allow us to
+      // copy into existing memory in `outputs` (rather than clone). User
+      // code depends on memory stability in SystemOutput.
+      get_output_port(i).Calc(context, outputs->GetMutableData(i));
     }
   }
 
@@ -960,11 +1004,7 @@ class System : public SystemBase {
 
   // So we don't have to keep writing this->get_num_input_ports().
   using SystemBase::get_num_input_ports;
-
-  /// Returns the number of output ports of the system.
-  int get_num_output_ports() const {
-    return static_cast<int>(output_ports_.size());
-  }
+  using SystemBase::get_num_output_ports;
 
   /// Returns the typed input port at index @p port_index.
   // TODO(sherm1) Make this an InputPortIndex.
@@ -976,13 +1016,8 @@ class System : public SystemBase {
   /// Returns the typed output port at index @p port_index.
   // TODO(sherm1) Make this an OutputPortIndex.
   const OutputPort<T>& get_output_port(int port_index) const {
-    if (port_index < 0 || port_index >= get_num_output_ports()) {
-      throw std::out_of_range(
-          "System " + get_name() + ": Port index " +
-          std::to_string(port_index) + " is out of range. There are only " +
-          std::to_string(get_num_output_ports()) + " output ports.");
-    }
-    return *output_ports_[port_index];
+    return dynamic_cast<const OutputPort<T>&>(
+        this->GetOutputPortBaseOrThrow(__func__, port_index));
   }
 
   /// Returns the number of constraints specified for the system.
@@ -1021,14 +1056,6 @@ class System : public SystemBase {
     return true;
   }
 
-  /// Returns the total dimension of all of the output ports (as if they were
-  /// muxed).
-  int get_num_total_outputs() const {
-    int count = 0;
-    for (const auto& out : output_ports_) count += out->size();
-    return count;
-  }
-
   /// Checks that @p output is consistent with the number and size of output
   /// ports declared by the system.
   /// @throw exception unless `output` is non-null and valid for this system.
@@ -1064,8 +1091,11 @@ class System : public SystemBase {
     DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
                        this->get_num_input_ports());
 
-    // Checks that the size of the fixed vector input ports in the
-    // context matches the declarations made by the system.
+    DRAKE_THROW_UNLESS(context.get_num_output_ports() ==
+                       this->get_num_output_ports());
+
+    // Checks that the size of the fixed vector input ports in the context
+    // matches the declarations made by the system.
     for (InputPortIndex i(0); i < this->get_num_input_ports(); ++i) {
       const FixedInputPortValue* port_value =
           context.MaybeGetFixedInputPortValue(i);
@@ -1329,8 +1359,35 @@ class System : public SystemBase {
       Event<T>* event,
       CompositeEventCollection<T>* events) const = 0;
 
-  // Promote so we don't need "this->" everywhere.
+  // Promote these so we don't need "this->" everywhere.
   using SystemBase::get_name;
+  using SystemBase::CheckValidContext;
+  using SystemBase::DeclareCacheEntry;
+  using SystemBase::all_sources_ticket;
+  using SystemBase::nothing_ticket;
+  using SystemBase::time_ticket;
+  using SystemBase::accuracy_ticket;
+  using SystemBase::q_ticket;
+  using SystemBase::v_ticket;
+  using SystemBase::z_ticket;
+  using SystemBase::xc_ticket;
+  using SystemBase::xd_ticket;
+  using SystemBase::xa_ticket;
+  using SystemBase::all_state_ticket;
+  using SystemBase::xcdot_ticket;
+  using SystemBase::xdhat_ticket;
+  using SystemBase::configuration_ticket;
+  using SystemBase::velocity_ticket;
+  using SystemBase::kinematics_ticket;
+  using SystemBase::all_parameters_ticket;
+  using SystemBase::all_input_ports_ticket;
+  using SystemBase::input_port_ticket;
+  using SystemBase::output_port_ticket;
+  using SystemBase::cache_entry_ticket;
+  using SystemBase::discrete_state_ticket;
+  using SystemBase::abstract_state_ticket;
+  using SystemBase::numeric_parameter_ticket;
+  using SystemBase::abstract_parameter_ticket;
 
  protected:
   /// Derived classes will implement this method to evaluate a witness function
@@ -1402,18 +1459,63 @@ class System : public SystemBase {
       State<T>* state) const = 0;
   //@}
 
+
   //----------------------------------------------------------------------------
   /// @name                 System construction
   /// Authors of derived %Systems can use these methods in the constructor
   /// for those %Systems.
   //@{
-  /// Constructs an empty %System base class object, possibly supporting
-  /// scalar-type conversion support (AutoDiff, etc.) using @p converter.
+  /// Constructs an empty %System base class object and allocates base class
+  /// resources, possibly supporting scalar-type conversion support (AutoDiff,
+  /// etc.) using @p converter.
   ///
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
   explicit System(SystemScalarConverter converter)
-      : system_scalar_converter_(std::move(converter)) {}
+      : system_scalar_converter_(std::move(converter)) {
+    // Potential energy must *not* be time dependent.
+    potential_energy_cache_index_ =
+        DeclareCacheEntry("potential energy", T(0),
+                          &System::CalcPotentialEnergy2,
+                          {all_parameters_ticket(), configuration_ticket()})
+            .cache_index();
+    kinetic_energy_cache_index_ =
+        DeclareCacheEntry("kinetic energy", T(0), &System::CalcKineticEnergy2,
+                          {all_parameters_ticket(), kinematics_ticket()})
+            .cache_index();
+    conservative_power_cache_index_ =
+        DeclareCacheEntry("conservative power", T(0),
+                          &System::CalcConservativePower2,
+                          {all_parameters_ticket(), kinematics_ticket()})
+            .cache_index();
+
+    // Only non-conservative power can have an explicit time dependence.
+    nonconservative_power_cache_index_ =
+        DeclareCacheEntry(
+            "non-conservative power", T(0), &System::CalcNonConservativePower2,
+            {all_parameters_ticket(), time_ticket(), kinematics_ticket()})
+            .cache_index();
+
+    // For the time derivative cache we need to use the general form for
+    // cache creation because we're dealing with pre-defined allocator and
+    // calculator method signatures.
+    CacheEntry::AllocCallback alloc_derivatives = [this]() {
+      return std::make_unique<Value<ContinuousState<T>>>(
+          this->AllocateTimeDerivatives());
+    };
+    CacheEntry::CalcCallback calc_derivatives = [this](
+        const ContextBase& context_base, AbstractValue* result) {
+      DRAKE_DEMAND(result != nullptr);
+      ContinuousState<T>& state = result->GetMutableValue<ContinuousState<T>>();
+      const Context<T>& context = dynamic_cast<const Context<T>&>(context_base);
+      CalcTimeDerivatives(context, &state);
+    };
+    time_derivatives_cache_index_ =
+        this->DeclareCacheEntry(
+                "time derivatives", std::move(alloc_derivatives),
+                std::move(calc_derivatives), {all_sources_ticket()})
+            .cache_index();
+  }
 
   /// Adds a port with the specified @p type and @p size to the input topology.
   /// If the port is intended to model a random noise or disturbance input,
@@ -1439,15 +1541,6 @@ class System : public SystemBase {
     return DeclareInputPort(kAbstractValued, 0 /* size */);
   }
 
-  /// Adds an already-created output port to this System. Insists that the port
-  /// already contains a reference to this System, and that the port's index is
-  /// already set to the next available output port index for this System.
-  void CreateOutputPort(std::unique_ptr<OutputPort<T>> port) {
-    DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system() == this);
-    DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
-    output_ports_.push_back(std::move(port));
-  }
   //@}
 
   /// Adds an already-created constraint to the list of constraints for this
@@ -1689,10 +1782,10 @@ class System : public SystemBase {
   }
   //@}
 
-//----------------------------------------------------------------------------
-/// @name             Constraint-related functions (protected).
-///
-// @{
+  //----------------------------------------------------------------------------
+  /// @name             Constraint-related functions (protected).
+  ///
+  // @{
 
   /// Gets the number of constraint equations for this system from the given
   /// context. The context is supplied in case the number of constraints is
@@ -1827,6 +1920,23 @@ class System : public SystemBase {
     CheckValidContextT(*context);
   }
 
+  void CalcPotentialEnergy2(const Context<T>& context, T* pe) const {
+    DRAKE_DEMAND(pe != nullptr);
+    *pe = CalcPotentialEnergy(context);
+  }
+  void CalcKineticEnergy2(const Context<T>& context, T* ke) const {
+    DRAKE_DEMAND(ke != nullptr);
+    *ke = CalcKineticEnergy(context);
+  }
+  void CalcConservativePower2(const Context<T>& context, T* power) const {
+    DRAKE_DEMAND(power != nullptr);
+    *power = CalcConservativePower(context);
+  }
+  void CalcNonConservativePower2(const Context<T>& context, T* power) const {
+    DRAKE_DEMAND(power != nullptr);
+    *power = CalcNonConservativePower(context);
+  }
+
   // Shared code for updating a vector input port and returning a pointer to its
   // value as a BasicVector<T>, or nullptr if the port is not connected. Throws
   // a logic_error if the port_index is out of range or if the input port is not
@@ -1861,9 +1971,6 @@ class System : public SystemBase {
     return basic_value;
   }
 
-  // TODO(sherm1) Move output ports up with input ports.
-  std::vector<std::unique_ptr<OutputPort<T>>> output_ports_;
-
   std::vector<std::unique_ptr<SystemConstraint<T>>> constraints_;
 
   // These are only used to dispatch forced event handling. For a LeafSystem,
@@ -1879,12 +1986,11 @@ class System : public SystemBase {
   // Functions to convert this system to use alternative scalar types.
   SystemScalarConverter system_scalar_converter_;
 
-  // TODO(sherm1) Replace these fake cache entries with real cache asap.
-  // These are temporaries and hence uninitialized.
-  mutable T fake_cache_pe_;
-  mutable T fake_cache_ke_;
-  mutable T fake_cache_conservative_power_;
-  mutable T fake_cache_nonconservative_power_;
+  CacheIndex time_derivatives_cache_index_,
+             potential_energy_cache_index_,
+             kinetic_energy_cache_index_,
+             conservative_power_cache_index_,
+             nonconservative_power_cache_index_;
 };
 
 }  // namespace systems

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -70,18 +70,43 @@ std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
                                    &graph);
   }
 
-  // TODO(sherm1) Create the output port trackers yᵢ here.
+  // Create the output port trackers yᵢ here. Nothing in this System may
+  // depend on them; subscribers will be input ports from peer Systems or
+  // an exported output port in the parent Diagram. The associated cache entries
+  // were just created above. If the output port's prerequisite is just a
+  // cache entry in this subsystem, set up that dependency here. For output
+  // ports that have been exported from a child subsystem, defer setting up the
+  // dependency until we're doing inter-subsystem dependencies later.
+  context.output_port_tickets().clear();
+  for (const auto& oport : output_ports_) {
+    auto& yi_tracker = graph.CreateNewDependencyTracker(
+        oport->ticket(), "y_" + std::to_string(oport->get_index()));
+    context.output_port_tickets().push_back(oport->ticket());
+    std::pair<optional<SubsystemIndex>, DependencyTicket> prerequisite =
+        oport->GetPrerequisite();
+    if (prerequisite.first)
+      continue;  // Depends on some other subsystem; defer until later.
+    yi_tracker.SubscribeToPrerequisite(
+        &context.get_mutable_tracker(prerequisite.second));
+  }
 
-  // TODO(sherm1) Move this to the AcquireContextResources phase.
+  return context_ptr;
+}
+
+void SystemBase::AcquireContextResources(ContextBase* context) const {
+  DRAKE_DEMAND(context != nullptr);
+  // Let the derived class acquire its needed resources and validate
+  // that it can handle a System with this structure.
+  DoAcquireContextResources(&*context);
+
   // We now have a complete Context. We can allocate space for cache entry
   // values using the allocators, which require a context.
+  Cache& cache = context->get_mutable_cache();
   for (CacheIndex index(0); index < num_cache_entries(); ++index) {
     const CacheEntry& entry = get_cache_entry(index);
     CacheEntryValue& cache_value = cache.get_mutable_cache_entry_value(index);
     cache_value.SetInitialValue(entry.Allocate());
   }
-
-  return context_ptr;
 }
 
 // Set up trackers for variable-numbered independent sources: discrete and
@@ -91,11 +116,44 @@ std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
 // elements now.
 void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
   ContextBase& context = *context_ptr;
+  DependencyGraph& graph = context.get_mutable_dependency_graph();
 
-  // TODO(sherm1) Add state and parameter trackers here.
+  // Define a lambda to do the repeated work below: create trackers for
+  // individual entities and subscribe the group tracker to each of them.
+  auto MakeTrackers = [&graph](
+      DependencyTicket subscriber_ticket,
+      const std::vector<TrackerInfo>& system_ticket_info,
+      std::vector<DependencyTicket>* context_tickets) {
+    DependencyTracker& subscriber =
+        graph.get_mutable_tracker(subscriber_ticket);
+    context_tickets->clear();
+    for (const auto& info : system_ticket_info) {
+      auto& source_tracker =
+          graph.CreateNewDependencyTracker(info.ticket, info.description);
+      context_tickets->push_back(info.ticket);
+      subscriber.SubscribeToPrerequisite(&source_tracker);
+    }
+  };
 
-  // Allocate trackers for each input port uᵢ. Note that this also takes care of
-  // subscribing the "all input ports" tracker u to them.
+  // Allocate trackers for each discrete variable group xdᵢ, and subscribe
+  // the "all discrete variables" tracker xd to those.
+  MakeTrackers(xd_ticket(), discrete_state_tickets_,
+               &context.discrete_state_tickets());
+
+  // Allocate trackers for each abstract state variable xaᵢ, and subscribe
+  // the "all abstract variables" tracker xa to those.
+  MakeTrackers(xa_ticket(), abstract_state_tickets_,
+               &context.abstract_state_tickets());
+
+  // Allocate trackers for each numeric parameter pnᵢ and each abstract
+  // parameter paᵢ, and subscribe the "all parameters" tracker p to those.
+  MakeTrackers(all_parameters_ticket(), numeric_parameter_tickets_,
+               &context.numeric_parameter_tickets());
+  MakeTrackers(all_parameters_ticket(), abstract_parameter_tickets_,
+               &context.abstract_parameter_tickets());
+
+  // Allocate trackers for each input port uᵢ, and subscribe the "all input
+  // ports" tracker u to them. Doesn't use TrackerInfo so can't use the lambda.
   for (const auto& iport : input_ports_) {
     context.AddInputPort(iport->get_index(), iport->ticket());
   }
@@ -118,12 +176,12 @@ const AbstractValue* SystemBase::EvalAbstractInputImpl(
   if (free_port_value != nullptr)
     return &free_port_value->get_value();  // A fixed input port.
 
-  // The only way to satisfy an input port of a root System is to make it fixed.
-  // Since it wasn't fixed, it is unconnected.
+  // The only way to satisfy an input port of a root System is to make
+  // it fixed. Since it wasn't fixed, it is unconnected.
   if (get_parent_service() == nullptr) return nullptr;
 
-  // This is not the root System, and the port isn't fixed, so ask our parent to
-  // evaluate it.
+  // This is not the root System, and the port isn't fixed, so ask our parent
+  // to evaluate it.
   return get_parent_service()->EvalConnectedSubsystemInputPort(
       *detail::SystemBaseContextBaseAttorney::get_parent_base(context),
       get_input_port_base(port_index));
@@ -131,6 +189,14 @@ const AbstractValue* SystemBase::EvalAbstractInputImpl(
 
 void SystemBase::ThrowNegativeInputPortIndex(const char* func,
                                              int port_index) const {
+  DRAKE_DEMAND(port_index < 0);
+  throw std::out_of_range(
+      fmt::format("{}: negative port index {} is illegal. (Subsystem {})",
+                  FmtFunc(func), port_index, GetSystemPathname()));
+}
+
+void SystemBase::ThrowNegativeOutputPortIndex(const char* func,
+                                              int port_index) const {
   DRAKE_DEMAND(port_index < 0);
   throw std::out_of_range(
       fmt::format("{}: negative port index {} is illegal. (Subsystem {})",
@@ -145,6 +211,16 @@ void SystemBase::ThrowInputPortIndexOutOfRange(const char* func,
       fmt::format("{}: there is no input port with index {} because there "
                       "are only {} input ports in subsystem {}.",
                   FmtFunc(func), port, num_input_ports, GetSystemPathname()));
+}
+
+void SystemBase::ThrowOutputPortIndexOutOfRange(const char* func,
+                                                OutputPortIndex port,
+                                                int num_output_ports) const {
+  DRAKE_DEMAND(num_output_ports >= 0);
+  throw std::out_of_range(
+      fmt::format("{}: there is no output port with index {} because there "
+                      "are only {} output ports in subsystem {}.",
+                  FmtFunc(func), port, num_output_ports, GetSystemPathname()));
 }
 
 void SystemBase::ThrowNotAVectorInputPort(const char* func,
@@ -167,7 +243,7 @@ void SystemBase::ThrowInputPortHasWrongType(
 }
 
 void SystemBase::ThrowCantEvaluateInputPort(const char* func,
-                                           InputPortIndex port) const {
+                                            InputPortIndex port) const {
   throw std::logic_error(
       fmt::format("{}: input port[{}] is neither connected nor fixed so "
                       "cannot be evaluated. (Subsystem {})",

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -10,6 +10,7 @@
 #include "drake/systems/framework/cache_entry.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/input_port_base.h"
+#include "drake/systems/framework/output_port_base.h"
 
 namespace drake {
 namespace systems {
@@ -80,8 +81,12 @@ class SystemBase : public internal::SystemMessageInterface {
   are allocated based on resource requests that were made during System
   construction. */
   std::unique_ptr<ContextBase> AllocateContext() const {
-    // Get a concrete Context of the right type and make connections.
+    // Get a concrete Context of the right type and make internal connections.
     std::unique_ptr<ContextBase> context = MakeContext();
+    // Make inter-subsystem connections (input and output port wiring).
+    MakeContextConnections(&*context);
+    // Allocate resources, possibly dependent on interconnection details.
+    AcquireContextResources(&*context);
     // Validate that restrictions imposed by subsystems are satisfied.
     ValidateAllocatedContext(*context);
     return context;
@@ -164,10 +169,22 @@ class SystemBase : public internal::SystemMessageInterface {
     return static_cast<int>(input_ports_.size());
   }
 
+  /** Returns the number ny of output ports currently allocated in this System.
+  These are indexed from 0 to ny-1. */
+  int get_num_output_ports() const {
+    return static_cast<int>(output_ports_.size());
+  }
+
   /** Returns a reference to an InputPort given its `port_index`.
   @pre `port_index` selects an existing input port of this System. */
   const InputPortBase& get_input_port_base(InputPortIndex port_index) const {
     return GetInputPortBaseOrThrow(__func__, port_index);
+  }
+
+  /** Returns a reference to an OutputPort given its `port_index`.
+  @pre `port_index` selects an existing output port of this System. */
+  const OutputPortBase& get_output_port_base(OutputPortIndex port_index) const {
+    return GetOutputPortBaseOrThrow(__func__, port_index);
   }
 
   /** Returns the total dimension of all of the vector-valued input ports (as if
@@ -175,6 +192,14 @@ class SystemBase : public internal::SystemMessageInterface {
   int get_num_total_inputs() const {
     int count = 0;
     for (const auto& in : input_ports_) count += in->size();
+    return count;
+  }
+
+  /** Returns the total dimension of all of the vector-valued output ports (as
+  if they were muxed). */
+  int get_num_total_outputs() const {
+    int count = 0;
+    for (const auto& out : output_ports_) count += out->size();
     return count;
   }
 
@@ -537,14 +562,79 @@ class SystemBase : public internal::SystemMessageInterface {
     return input_ports_[index]->ticket();
   }
 
+  /** Returns a ticket indicating dependence on the output port indicated
+  by `index`.
+  @pre `index` selects an existing output port of this System. */
+  DependencyTicket output_port_ticket(OutputPortIndex index) {
+    DRAKE_DEMAND(0 <= index && index < get_num_output_ports());
+    return output_ports_[index]->ticket();
+  }
+
   /** Returns a ticket indicating dependence on the cache entry indicated
   by `index`.
-  @pre `index` selects an existing cache entry in this System. */
-  DependencyTicket cache_entry_ticket(CacheIndex index) {
+  @pre `index` selects an existing cache entry in this System. */  DependencyTicket cache_entry_ticket(CacheIndex index) {
     DRAKE_DEMAND(0 <= index && index < num_cache_entries());
     return cache_entries_[index]->ticket();
   }
+
+  /** Returns a ticket indicating dependence on a particular discrete state
+  variable (may be a vector). (We sometimes refer to this as a "discrete
+  variable group".) */
+  DependencyTicket discrete_state_ticket(DiscreteStateIndex index) const {
+    return discrete_state_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular abstract state
+  variable. */
+  DependencyTicket abstract_state_ticket(AbstractStateIndex index) const {
+    return abstract_state_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular numeric parameter
+  (may be a vector). */
+  DependencyTicket numeric_parameter_ticket(NumericParameterIndex index) const {
+    return numeric_parameter_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular abstract
+  parameter. */
+  DependencyTicket abstract_parameter_ticket(
+      AbstractParameterIndex index) const {
+    return abstract_parameter_tracker_info(index).ticket;
+  }
   //@}
+
+  #ifndef DRAKE_DOXYGEN_CXX
+  // Used to create trackers for variable-number System-allocated objects.
+  struct TrackerInfo {
+    DependencyTicket ticket;
+    std::string description;
+  };
+
+  const TrackerInfo& discrete_state_tracker_info(
+      DiscreteStateIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_discrete_state_tickets());
+    return discrete_state_tickets_[index];
+  }
+
+  const TrackerInfo& abstract_state_tracker_info(
+      AbstractStateIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_abstract_state_tickets());
+    return abstract_state_tickets_[index];
+  }
+
+  const TrackerInfo& numeric_parameter_tracker_info(
+      NumericParameterIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_numeric_parameter_tickets());
+    return numeric_parameter_tickets_[index];
+  }
+
+  const TrackerInfo& abstract_parameter_tracker_info(
+      AbstractParameterIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_abstract_parameter_tickets());
+    return abstract_parameter_tickets_[index];
+  }
+  #endif  // DRAKE_DOXYGEN_CXX
 
  protected:
   SystemBase() = default;
@@ -559,6 +649,18 @@ class SystemBase : public internal::SystemMessageInterface {
     DRAKE_DEMAND(&port->get_system_base() == this);
     DRAKE_DEMAND(port->get_index() == this->get_num_input_ports());
     input_ports_.push_back(std::move(port));
+  }
+
+  /** Adds an already-constructed output port to this System. Insists that the
+  port already contains a reference to this System, and that the port's index is
+  already set to the next available output port index for this System. */
+  // TODO(sherm1) Add check on suitability of `size` parameter for the port's
+  // data type.
+  void CreateOutputPort(std::unique_ptr<OutputPortBase> port) {
+    DRAKE_DEMAND(port != nullptr);
+    DRAKE_DEMAND(&port->get_system_base() == this);
+    DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
+    output_ports_.push_back(std::move(port));
   }
 
   /** Returns a pointer to the service interface of the immediately enclosing
@@ -587,10 +689,40 @@ class SystemBase : public internal::SystemMessageInterface {
     child->set_parent_service(parent_service);
   }
 
+  /** Returns the number of direct child subsystems this system has.
+  A leaf system will return 0. */
+  int num_subsystems() const { return do_num_subsystems(); }
+
+  /** Gets const access to a particular subsystem of this diagram system.
+  The index must be in range [0..num_subsystems()-1]. */
+  const SystemBase& get_subsystem(SubsystemIndex index) const {
+    return do_get_subsystem(index);
+  }
+
+  /** Gets mutable access to a particular subsystem of this diagram system.
+  The index must be in range [0..num_subsystems()-1]. */
+  SystemBase& get_mutable_subsystem(SubsystemIndex index) {
+    return const_cast<SystemBase&>(get_subsystem(index));
+  }
+
   /** Allows Diagram to use private MakeContext() to invoke the same method
   on its children. */
   static std::unique_ptr<ContextBase> MakeContext(const SystemBase& system) {
     return system.MakeContext();
+  }
+
+  /** Allows Diagram to use its private MakeContextConnections() to invoke the
+  same method on its children. */
+  static void MakeContextConnections(const SystemBase& system,
+                                     ContextBase* context) {
+    system.MakeContextConnections(&*context);
+  }
+
+  /** Allows Diagram to use its private AcquireContextResources() to invoke the
+  same method on its children. */
+  static void AcquireContextResources(const SystemBase& system,
+                                      ContextBase* context) {
+    system.AcquireContextResources(&*context);
   }
 
   /** Allows Diagram to use its private ValidateAllocatedContext() to invoke the
@@ -613,11 +745,23 @@ class SystemBase : public internal::SystemMessageInterface {
   [[noreturn]] void ThrowNegativeInputPortIndex(const char* func,
                                                 int port_index) const;
 
-  /** Throws std::out_of_range to report bad `port_index` that was passed to
-  API method `func`. */
+  /** Throws std::out_of_range to report a negative output `port_index` that was
+  passed to API method `func`. */
+  // We're taking an int here for the index; OutputPortIndex can't be negative.
+  [[noreturn]] void ThrowNegativeOutputPortIndex(const char* func,
+                                                 int port_index) const;
+
+  /** Throws std::out_of_range to report bad input `port_index` that was passed
+  to API method `func`. */
   [[noreturn]] void ThrowInputPortIndexOutOfRange(const char* func,
                                                   InputPortIndex port_index,
                                                   int num_input_ports) const;
+
+  /** Throws std::out_of_range to report bad output `port_index` that was passed
+  to API method `func`. */
+  [[noreturn]] void ThrowOutputPortIndexOutOfRange(const char* func,
+                                                   OutputPortIndex port_index,
+                                                   int num_output_ports) const;
 
   /** Throws std::logic_error because someone misused API method `func`, that is
   only allowed for declared-vector input ports, on an abstract port whose
@@ -651,11 +795,43 @@ class SystemBase : public internal::SystemMessageInterface {
     return *input_ports_[port];
   }
 
+  /** Returns the OutputPortBase at index `port_index`, throwing
+  std::out_of_range we don't like the port index. The name of the public API
+  method that received the bad index is provided in `func` and is included
+  in the error message. */
+  const OutputPortBase& GetOutputPortBaseOrThrow(const char* func,
+                                                 int port_index) const {
+    if (port_index < 0)
+      ThrowNegativeOutputPortIndex(func, port_index);
+    const OutputPortIndex port(port_index);
+    if (port_index >= get_num_output_ports())
+      ThrowOutputPortIndexOutOfRange(func, port, get_num_output_ports());
+    return *output_ports_[port_index];
+  }
+
   /** Derived class implementations should allocate a suitable
   default-constructed Context, with default-constructed subcontexts for
   diagrams. The base class allocates trackers for known resources and
-  intra-subcontext dependencies. */
+  intra-subcontext dependencies. No inter-subcontext dependencies should be
+  made in this step. */
   virtual std::unique_ptr<ContextBase> DoMakeContext() const = 0;
+
+  /** If the derived class is a diagram it should implement this method to
+  set up the inter-subcontext dependencies. The given `context` already has
+  the right structure and each subcontext has trackers available for each of
+  its resources. The supplied context is guaranteed to be non-null; you don't
+  need to error-check that. The default implementation does nothing, which is
+  suitable for leaf systems. */
+  virtual void DoMakeContextConnections(ContextBase* context) const {
+    unused(context);
+  }
+
+  /** Derived classes should override to complete resource allocation. The
+  supplied Context is the one returned earlier from DoMakeContext(), with all
+  intra- and inter-subsystem connections made via DoMakeContextConnections().
+  The supplied context is guaranteed to have come from this System and to be
+  non-null; you don't need to error-check that. */
+  virtual void DoAcquireContextResources(ContextBase* context) const = 0;
 
   /** Any derived class that imposes restrictions on the structure or content
   of an acceptable Context should enforce those restrictions by overriding
@@ -666,6 +842,19 @@ class SystemBase : public internal::SystemMessageInterface {
   Context allocation, even in Release builds.
   @see DoCheckValidContext() for runtime checking. */
   virtual void DoValidateAllocatedContext(const ContextBase& context) const = 0;
+
+  /** DiagramSystem must override this to return the actual number of immediate
+  child subsystems it contains. The default is 0, suitable for leaf systems. */
+  virtual int do_num_subsystems() const { return 0; }
+
+  /** DiagramSystem must override this to provide access to its contained
+  subsystems. The default implementation throws a logic error, which is
+  a suitable implementation for leaf systems. */
+  virtual const SystemBase& do_get_subsystem(SubsystemIndex index) const {
+    unused(index);
+    throw std::logic_error(
+        "SystemBase::do_get_subsystem(): called on a leaf system.");
+  }
 
   /** Derived classes must implement this to verify that the supplied
   Context is suitable, and throw an exception if not. This is a runtime check
@@ -679,6 +868,15 @@ class SystemBase : public internal::SystemMessageInterface {
   // Obtains a context of the right concrete type, with all internal trackers
   // allocated and internal wiring set up.
   std::unique_ptr<ContextBase> MakeContext() const;
+
+  // Sets up the inter-subsystem wiring in the context.
+  void MakeContextConnections(ContextBase* context) const {
+    DRAKE_DEMAND(context != nullptr);
+    DoMakeContextConnections(&*context);
+  }
+
+  // Allocates additional context resources if needed.
+  void AcquireContextResources(ContextBase* context) const;
 
   // Check that all subsystems are prepared to deal with a context like this.
   void ValidateAllocatedContext(const ContextBase& context) const {
@@ -697,17 +895,42 @@ class SystemBase : public internal::SystemMessageInterface {
 
   void CreateSourceTrackers(ContextBase*) const;
 
+  int num_discrete_state_tickets() const {
+    return static_cast<int>(discrete_state_tickets_.size());
+  }
+
+  int num_abstract_state_tickets() const {
+    return static_cast<int>(abstract_state_tickets_.size());
+  }
+
+  int num_numeric_parameter_tickets() const {
+    return static_cast<int>(numeric_parameter_tickets_.size());
+  }
+
+  int num_abstract_parameter_tickets() const {
+    return static_cast<int>(abstract_parameter_tickets_.size());
+  }
+
   // Ports and cache entries hold their own DependencyTickets. Note that the
   // addresses of the elements are stable even if the std::vectors are resized.
 
   // Indexed by InputPortIndex.
   std::vector<std::unique_ptr<InputPortBase>> input_ports_;
-  // TODO(sherm1) Output ports go here.
+  // Indexed by OutputPortIndex.
+  std::vector<std::unique_ptr<OutputPortBase>> output_ports_;
   // Indexed by CacheIndex.
   std::vector<std::unique_ptr<CacheEntry>> cache_entries_;
 
   // States and parameters don't hold their own tickets so we track them here.
-  // TODO(sherm1) Add state & parameter trackers here.
+
+  // Indexed by DiscreteStateIndex.
+  std::vector<TrackerInfo> discrete_state_tickets_;
+  // Indexed by AbstractStateIndex.
+  std::vector<TrackerInfo> abstract_state_tickets_;
+  // Indexed by NumericParameterIndex.
+  std::vector<TrackerInfo> numeric_parameter_tickets_;
+  // Indexed by AbstractParameterIndex.
+  std::vector<TrackerInfo> abstract_parameter_tickets_;
 
   // Initialize to the first ticket number available after all the well-known
   // ones. This gets incremented as tickets are handed out for the optional

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -19,7 +19,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
       continuous_state_variables_(context_->get_continuous_state().size()),
       discrete_state_variables_(context_->get_num_discrete_state_groups()),
       numeric_parameters_(context_->num_numeric_parameters()),
-      output_(system.AllocateOutput(*context_)),
+      output_(system.AllocateOutput()),
       derivatives_(system.AllocateTimeDerivatives()),
       discrete_updates_(system.AllocateDiscreteVariables()),
       output_port_types_(system.get_num_output_ports()),

--- a/systems/framework/system_symbolic_inspector.h
+++ b/systems/framework/system_symbolic_inspector.h
@@ -113,7 +113,7 @@ class SystemSymbolicInspector {
   /// @param i The discrete state group number.
   Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
       int i) const {
-    DRAKE_DEMAND(i >= 0 && i < static_cast<int>(discrete_updates_->size()));
+    DRAKE_DEMAND(i >= 0 && i < context_->get_num_discrete_state_groups());
     return discrete_updates_->get_vector(i).get_value();
   }
 

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -137,8 +137,8 @@ class MySystemBase final : public SystemBase {
     return std::make_unique<MyContextBase>();
   }
 
-  void DoValidateAllocatedContext(const ContextBase& context) const final {}
-
+  void DoAcquireContextResources(ContextBase* context) const final {}
+  void DoValidateAllocatedContext(const ContextBase&) const final {}
   void DoCheckValidContext(const ContextBase&) const final {}
 
   const CacheEntry& entry0_;

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -106,8 +106,7 @@ class DiagramContextTest : public ::testing::Test {
 
   void AddSystem(const System<double>& sys, SubsystemIndex index) {
     auto subcontext = sys.CreateDefaultContext();
-    auto suboutput = sys.AllocateOutput(*subcontext);
-    context_->AddSystem(index, std::move(subcontext), std::move(suboutput));
+    context_->AddSystem(SubsystemIndex(index), std::move(subcontext));
   }
 
   void AttachInputPorts() {
@@ -161,17 +160,13 @@ void VerifyClonedParameters(const Parameters<double>& params) {
   EXPECT_EQ(2048, UnpackIntValue(params.get_abstract_parameter(0)));
 }
 
-// Tests that subsystems have outputs and contexts in the DiagramContext.
+// Tests that subsystems have contexts in the DiagramContext.
 TEST_F(DiagramContextTest, RetrieveConstituents) {
   // All of the subsystems should be leaf Systems.
   for (SubsystemIndex i(0); i < kNumSystems; ++i) {
     auto context = dynamic_cast<const LeafContext<double>*>(
         &context_->GetSubsystemContext(i));
     EXPECT_TRUE(context != nullptr);
-
-    auto output = dynamic_cast<const LeafSystemOutput<double>*>(
-        context_->GetSubsystemOutput(i));
-    EXPECT_TRUE(output != nullptr);
   }
 }
 

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -935,6 +935,25 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   EXPECT_EQ(1249, output_->get_vector_data(0)->get_value().x());
   EXPECT_EQ(2489, output_->get_vector_data(1)->get_value().x());
   EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
+
+  // Check that invalidation flows through input ports properly. We'll change
+  // the fixed input value for input port 0 from 8 to 10. That should cause
+  // everything to get recalculated.
+  // The outputs of subsystem0_ are now:
+  //   output0 = 10 + 64 + 512 = 586
+  //   output1 = output0 + 10 + 64 = 660
+  //   output2 = 9 (state of integrator1_)
+
+  // So, the outputs of subsystem1_, and thus of the whole diagram, are:
+  //   output0 = 586 + 660 + 9 = 1255
+  //   output1 = output0 + 586 + 660 = 2501
+  //   output2 = 81 (state of integrator1_)
+  auto value10 = BasicVector<double>::Make({10});
+  context_->FixInputPort(0, std::move(value10));
+  diagram_->CalcOutput(*context_, output_.get());
+  EXPECT_EQ(1255, output_->get_vector_data(0)->get_value().x());
+  EXPECT_EQ(2501, output_->get_vector_data(1)->get_value().x());
+  EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
 }
 
 TEST_F(DiagramOfDiagramsTest, DirectFeedthrough) {

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -278,6 +278,46 @@ TEST_F(LeafContextTest, GetAbstractInput) {
   EXPECT_EQ(nullptr, ReadAbstractInputPort(context, 1));
 }
 
+// Tests that items can be stored and retrieved in the cache, even when
+// the LeafContext is const.
+TEST_F(LeafContextTest, SetAndGetCache) {
+  CacheIndex index = context_.get_mutable_cache()
+                         .CreateNewCacheEntryValue(
+                             CacheIndex(0), ++next_ticket_, "entry",
+                             {DependencyTicket(internal::kNothingTicket)},
+                             &context_.get_mutable_dependency_graph())
+                         .cache_index();
+  CacheEntryValue& entry =
+      context_.get_mutable_cache().get_mutable_cache_entry_value(index);
+  entry.SetInitialValue(PackValue(42));
+  EXPECT_EQ(entry.cache_index(), index);
+  EXPECT_TRUE(entry.ticket().is_valid());
+  EXPECT_EQ(entry.description(), "entry");
+
+  EXPECT_TRUE(entry.is_out_of_date());  // Initial value is not up to date.
+  EXPECT_THROW(entry.GetValueOrThrow<int>(), std::logic_error);
+  entry.mark_up_to_date();
+  EXPECT_NO_THROW(entry.GetValueOrThrow<int>());
+
+  const AbstractValue& value = entry.GetAbstractValueOrThrow();
+  EXPECT_EQ(42, UnpackIntValue(value));
+  EXPECT_EQ(42, entry.GetValueOrThrow<int>());
+  EXPECT_EQ(42, entry.get_value<int>());
+
+  // Already up to date.
+  EXPECT_THROW(entry.SetValueOrThrow<int>(43), std::logic_error);
+  entry.mark_out_of_date();
+
+  EXPECT_NO_THROW(entry.SetValueOrThrow<int>(43));
+  EXPECT_FALSE(entry.is_out_of_date());  // Set marked it up to date.
+  EXPECT_EQ(43, UnpackIntValue(entry.GetAbstractValueOrThrow()));
+
+  entry.mark_out_of_date();
+  entry.set_value<int>(99);
+  EXPECT_FALSE(entry.is_out_of_date());  // Set marked it up to date.
+  EXPECT_EQ(99, entry.get_value<int>());
+}
+
 TEST_F(LeafContextTest, FixInputPort) {
   const InputPortIndex index{0};
   const int size = kInputSize[index];

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #include <Eigen/Dense>
 #include <gmock/gmock.h>
@@ -196,7 +197,8 @@ class LeafSystemTest : public ::testing::Test {
   }
 
   TestSystem<double> system_;
-  LeafContext<double> context_;
+  std::unique_ptr<LeafContext<double>> context_ptr_ = system_.AllocateContext();
+  LeafContext<double>& context_ = *context_ptr_;
 
   std::unique_ptr<CompositeEventCollection<double>> event_info_;
   const LeafCompositeEventCollection<double>* leaf_info_;
@@ -742,8 +744,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsInput) {
 // correct values.
 GTEST_TEST(ModelLeafSystemTest, ModelPortsAllocOutput) {
   DeclaredModelPortsSystem dut;
-  auto context = dut.CreateDefaultContext();
-  auto system_output = dut.AllocateOutput(*context);
+  auto system_output = dut.AllocateOutput();
 
   // Check that BasicVector<double>(3) came out.
   auto output0 = system_output->get_vector_data(0);
@@ -776,12 +777,49 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   DeclaredModelPortsSystem dut;
   auto context = dut.CreateDefaultContext();
 
+  // Calculate values for each output port and save copies of those values.
   std::vector<std::unique_ptr<AbstractValue>> values;
-  for (int i = 0; i < 4; ++i) {
+  for (OutputPortIndex i(0); i < 4; ++i) {
     const OutputPort<double>& out = dut.get_output_port(i);
     values.emplace_back(out.Allocate());
     out.Calc(*context, values.back().get());
   }
+
+  const auto& port2 = dut.get_output_port(OutputPortIndex(2));
+  const auto& cache2 = dut.get_cache_entry(
+      dynamic_cast<const LeafOutputPort<double>&>(port2).cache_index());
+  const auto& cacheval2 = cache2.get_cache_entry_value(*context);
+  EXPECT_EQ(cacheval2.serial_number(), 1);
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  EXPECT_THROW(cache2.GetKnownUpToDate<std::string>(*context),
+               std::logic_error);
+  const std::string& str2_cached = port2.Eval<std::string>(*context);
+  EXPECT_EQ(str2_cached, "concrete string");
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 2);
+
+  // Check that setting time invalidates correctly.
+  context->set_time(1.);  // Should invalidate time- and everything-dependents.
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 2);  // Unchanged since invalid.
+  (void)port2.EvalAbstract(*context);  // Recalculate.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 3);
+  context->set_time(1.);  // Same time; no invalidation.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 3);
+  (void)port2.EvalAbstract(*context);  // "Recalculate" (should do nothing).
+  EXPECT_EQ(cacheval2.serial_number(), 3);
+
+  // Should invalidate accuracy- and everything-dependents.
+  context->set_accuracy(.000025);
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  (void)port2.EvalAbstract(*context);  // Recalculate.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 4);
+  context->set_accuracy(.000025);  // Same accuracy; no invalidation.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 4);
 
   // Downcast to concrete types.
   const BasicVector<double>* vec0{};
@@ -922,7 +960,7 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
 GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   DeclaredNonModelOutputSystem dut;
   auto context = dut.CreateDefaultContext();
-  auto system_output = dut.AllocateOutput(*context);  // Invokes all allocators.
+  auto system_output = dut.AllocateOutput();  // Invokes all allocators.
 
   // Check topology.
   EXPECT_EQ(dut.get_num_input_ports(), 0);

--- a/systems/framework/test/output_port_value_test.cc
+++ b/systems/framework/test/output_port_value_test.cc
@@ -6,131 +6,80 @@
 #include <gtest/gtest.h>
 
 #include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
 
-class OutputPortVectorTest : public ::testing::Test {
+
+class SystemOutputTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    const BasicVector<double> vec{5, 6};
-    output_port_value_.reset(new OutputPortValue(vec.Clone()));
+    // Vector output port 0 is just a BasicVector<double>.
+    const BasicVector<double> vec{5, 25};
+    output_.add_port(vec.Clone());
+
+    // Vector output port 1 is derived from BasicVector<double>. The concrete
+    // type should be preserved when copying.
+    auto my_vec = MyVector<3, double>::Make(125, 625, 3125);
+    output_.add_port(std::move(my_vec));
+
+    // Abstract output port 2 is a string.
+    auto str = AbstractValue::Make(std::string("foo"));
+    output_.add_port(std::move(str));
   }
 
-  std::unique_ptr<OutputPortValue> output_port_value_;
+  SystemOutput<double> output_;
 };
 
-TEST_F(OutputPortVectorTest, Access) {
+TEST_F(SystemOutputTest, Access) {
   VectorX<double> expected(2);
-  expected << 5, 6;
+  expected << 5, 25;
   EXPECT_EQ(
       expected,
-      output_port_value_->template get_vector_data<double>()->get_value());
+      output_.get_vector_data(0)->get_value());
+
+  EXPECT_EQ("foo", output_.get_data(2)->GetValue<std::string>());
 }
 
-TEST_F(OutputPortVectorTest, Mutation) {
-  output_port_value_->template GetMutableVectorData<double>()
-          ->get_mutable_value()
-      << 7,
-      8;
+TEST_F(SystemOutputTest, Mutation) {
+  output_.GetMutableVectorData(0)->get_mutable_value() << 7, 8;
 
   // Check that the vector contents changed.
   VectorX<double> expected(2);
   expected << 7, 8;
-  EXPECT_EQ(
-      expected,
-      output_port_value_->template get_vector_data<double>()->get_value());
-}
+  EXPECT_EQ(expected, output_.get_vector_data(0)->get_value());
 
-// Tests that a clone of an OutputPortValue has a deep copy of the data.
-TEST_F(OutputPortVectorTest, Clone) {
-  auto clone = output_port_value_->Clone();
-  // Changes to the original port should not affect the clone.
-  output_port_value_->template GetMutableVectorData<double>()
-          ->get_mutable_value()
-      << 7,
-      8;
-
-  VectorX<double> expected(2);
-  expected << 5, 6;
-  EXPECT_EQ(expected, clone->template get_vector_data<double>()->get_value());
-
-  // The type should be preserved.
-  EXPECT_NE(nullptr, clone->template get_vector_data<double>());
-}
-
-class OutputPortAbstractValueTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    auto value = std::make_unique<Value<std::string>>("foo");
-    output_port_value_.reset(new OutputPortValue(std::move(value)));
-  }
-
-  std::unique_ptr<OutputPortValue> output_port_value_;
-};
-
-TEST_F(OutputPortAbstractValueTest, Access) {
-  EXPECT_EQ("foo",
-            output_port_value_->get_abstract_data()->GetValue<std::string>());
-}
-
-TEST_F(OutputPortAbstractValueTest, Mutation) {
-  output_port_value_->GetMutableData()->GetMutableValue<std::string>() = "bar";
+  output_.GetMutableData(2)->GetMutableValue<std::string>() = "bar";
 
   // Check that the contents changed.
-  EXPECT_EQ("bar",
-            output_port_value_->get_abstract_data()->GetValue<std::string>());
+  EXPECT_EQ("bar", output_.get_data(2)->GetValue<std::string>());
 }
 
-// Tests that a clone of an OutputPortValue has a deep copy of the data.
-TEST_F(OutputPortAbstractValueTest, Clone) {
-  auto clone = output_port_value_->Clone();
+// Tests that a copy of a SystemOutput has a deep copy of the data.
+TEST_F(SystemOutputTest, Copy) {
+  auto clone(output_);
   // Changes to the original port should not affect the clone.
-  clone->GetMutableData()->GetMutableValue<std::string>() = "bar";
-  EXPECT_EQ("bar", clone->get_abstract_data()->GetValue<std::string>());
-  EXPECT_EQ("foo",
-            output_port_value_->get_abstract_data()->GetValue<std::string>());
-}
+  output_.GetMutableVectorData(0)->get_mutable_value() << 7, 8;
+  output_.GetMutableData(2)->GetMutableValue<std::string>() = "bar";
 
-class LeafSystemOutputTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    {
-      const BasicVector<double> vec{5, 25};
-      output_.add_port(std::make_unique<OutputPortValue>(vec.Clone()));
-    }
-    {
-      const BasicVector<double> vec{125, 625, 3125};
-      output_.add_port(std::make_unique<OutputPortValue>(vec.Clone()));
-    }
-  }
+  VectorX<double> expected(2);
+  expected << 5, 25;
+  EXPECT_EQ(expected, clone.get_vector_data(0)->get_value());
 
-  LeafSystemOutput<double> output_;
-};
+  EXPECT_EQ("foo", clone.get_data(2)->GetValue<std::string>());
 
-// Tests that a clone of the LeafSystemOutput has a deep copy of the data on
-// each port.
-TEST_F(LeafSystemOutputTest, Clone) {
-  std::unique_ptr<SystemOutput<double>> clone = output_.Clone();
+  // The type and value should be preserved.
+  const BasicVector<double>* basic = clone.get_vector_data(1);
+  auto* my_vec = dynamic_cast<const MyVector<3, double>*>(basic);
+  ASSERT_NE(my_vec, nullptr);
 
-  {
-    const OutputPortValue& port_value = clone->get_port_value(0);
-    VectorX<double> expected(2);
-    expected << 5, 25;
-    EXPECT_EQ(expected,
-              port_value.template get_vector_data<double>()->get_value());
-    EXPECT_NE(nullptr, port_value.template get_vector_data<double>());
-  }
+  expected.resize(3);
+  expected << 125, 625, 3125;
+  EXPECT_EQ(expected, my_vec->get_value());
 
-  {
-    const OutputPortValue& port_value = clone->get_port_value(1);
-    VectorX<double> expected(3);
-    expected << 125, 625, 3125;
-    EXPECT_EQ(expected,
-              port_value.template get_vector_data<double>()->get_value());
-    EXPECT_NE(nullptr, port_value.template get_vector_data<double>());
-  }
+  EXPECT_EQ(clone.get_data(2)->GetValueOrThrow<std::string>(), "foo");
 }
 
 }  // namespace systems

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -46,7 +46,8 @@ class MySystemBase final : public SystemBase {
     return std::make_unique<MyContextBase>(true);  // A valid context.
   }
 
-  void DoValidateAllocatedContext(const ContextBase& context) const final {}
+  void DoAcquireContextResources(ContextBase*) const final {}
+  void DoValidateAllocatedContext(const ContextBase&) const final {}
 
   void DoCheckValidContext(const ContextBase& context) const final {
     auto& my_context = dynamic_cast<const MyContextBase&>(context);

--- a/systems/plants/spring_mass_system/spring_mass_system.cc
+++ b/systems/plants/spring_mass_system/spring_mass_system.cc
@@ -118,7 +118,7 @@ const OutputPort<T>& SpringMassSystem<T>::get_output_port() const {
 }
 
 template <typename T>
-T SpringMassSystem<T>::EvalSpringForce(const Context<T>& context) const {
+T SpringMassSystem<T>::CalcSpringForce(const Context<T>& context) const {
   const double k = spring_constant_N_per_m_;
   const T& x = get_position(context);
   T x0 = 0;  // TODO(david-german-tri) should be a parameter.
@@ -145,7 +145,7 @@ T SpringMassSystem<T>::DoCalcKineticEnergy(const Context<T>& context) const {
 template <typename T>
 T SpringMassSystem<T>::DoCalcConservativePower(
     const Context<T>& context) const {
-  const T& power_c = EvalSpringForce(context) * get_velocity(context);
+  const T& power_c = CalcSpringForce(context) * get_velocity(context);
   return power_c;
 }
 
@@ -183,14 +183,14 @@ void SpringMassSystem<T>::DoCalcTimeDerivatives(
   // By Newton's 2nd law, the derivative of velocity (acceleration) is f/m where
   // f is the force applied to the body by the spring, and m is the mass of the
   // body.
-  const T force_applied_to_body = EvalSpringForce(context) + external_force;
+  const T force_applied_to_body = CalcSpringForce(context) + external_force;
   derivative_vector.set_velocity(force_applied_to_body / mass_kg_);
 
   // We are integrating conservative power to get the work done by conservative
   // force elements, that is, the net energy transferred between the spring and
   // the mass over time.
   derivative_vector.set_conservative_work(
-      this->CalcConservativePower(context));
+      this->EvalConservativePower(context));
 }
 
 

--- a/systems/plants/spring_mass_system/spring_mass_system.h
+++ b/systems/plants/spring_mass_system/spring_mass_system.h
@@ -153,7 +153,7 @@ class SpringMassSystem : public LeafSystem<T> {
   /// Context. This force f is given by `f = -k (x-x0)`; the spring applies the
   /// opposite force -f to the world attachment point at the other end. The
   /// force is in newtons N (kg-m/s^2).
-  T EvalSpringForce(const Context<T>& context) const;
+  T CalcSpringForce(const Context<T>& context) const;
 
   /// Returns the potential energy currently stored in the spring in the given
   /// Context. For this linear spring, `pe = k (x-x0)^2 / 2`, so that spring

--- a/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -54,6 +54,17 @@ class SpringMassSystemTest : public ::testing::Test {
     state_->set_conservative_work(0);
   }
 
+  // Get a reference to the cached derivatives, downcast to our custom
+  // state vector type.
+  const SpringMassStateVector<double>&
+  EvalSpringMassDerivs(const Context<double>& context) {
+    const auto& generic_derivs =
+        system_->EvalTimeDerivatives(context).get_vector();
+    const auto& derivatives =
+        dynamic_cast<const SpringMassStateVector<double>&>(generic_derivs);
+    return derivatives;
+  }
+
  protected:
   std::unique_ptr<SpringMassSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
@@ -158,24 +169,24 @@ TEST_F(SpringMassSystemTest, MapVelocityToConfigurationDerivative) {
 
 TEST_F(SpringMassSystemTest, ForcesPositiveDisplacement) {
   InitializeState(0.1, 0.1);  // Displacement 0.1m, velocity 0.1m/sec.
-  system_->CalcTimeDerivatives(*context_, system_derivatives_.get());
+  auto& derivatives = EvalSpringMassDerivs(*context_);
 
-  ASSERT_EQ(3, derivatives_->size());
+  ASSERT_EQ(3, derivatives.size());
   // The derivative of position is velocity.
-  EXPECT_NEAR(0.1, derivatives_->get_position(), 1e-8);
+  EXPECT_NEAR(0.1, derivatives.get_position(), 1e-8);
   // The derivative of velocity is force over mass.
-  EXPECT_NEAR(-kSpring * 0.1 / kMass, derivatives_->get_velocity(), 1e-8);
+  EXPECT_NEAR(-kSpring * 0.1 / kMass, derivatives.get_velocity(), 1e-8);
 }
 
 TEST_F(SpringMassSystemTest, ForcesNegativeDisplacement) {
   InitializeState(-0.1, 0.2);  // Displacement -0.1m, velocity 0.2m/sec.
-  system_->CalcTimeDerivatives(*context_, system_derivatives_.get());
+  auto& derivatives = EvalSpringMassDerivs(*context_);
 
-  ASSERT_EQ(3, derivatives_->size());
+  ASSERT_EQ(3, derivatives.size());
   // The derivative of position is velocity.
-  EXPECT_NEAR(0.2, derivatives_->get_position(), 1e-8);
+  EXPECT_NEAR(0.2, derivatives.get_position(), 1e-8);
   // The derivative of velocity is force over mass.
-  EXPECT_NEAR(-kSpring * -0.1 / kMass, derivatives_->get_velocity(), 1e-8);
+  EXPECT_NEAR(-kSpring * -0.1 / kMass, derivatives.get_velocity(), 1e-8);
 }
 
 TEST_F(SpringMassSystemTest, DynamicsWithExternalForce) {
@@ -200,15 +211,15 @@ TEST_F(SpringMassSystemTest, DynamicsWithExternalForce) {
   context_->FixInputPort(0, std::move(force_vector));
 
   InitializeState(0.1, 0.1);  // Displacement 0.1m, velocity 0.1m/sec.
-  system_->CalcTimeDerivatives(*context_, system_derivatives_.get());
+  auto& derivatives = EvalSpringMassDerivs(*context_);
 
-  ASSERT_EQ(3, derivatives_->size());
+  ASSERT_EQ(3, derivatives.size());
   // The derivative of position is velocity.
-  EXPECT_NEAR(0.1, derivatives_->get_position(),
+  EXPECT_NEAR(0.1, derivatives.get_position(),
               Eigen::NumTraits<double>::epsilon());
   // The derivative of velocity is force over mass.
   EXPECT_NEAR((-kSpring * 0.1 + kExternalForce) / kMass,
-              derivatives_->get_velocity(),
+              derivatives.get_velocity(),
               Eigen::NumTraits<double>::epsilon());
 }
 
@@ -220,11 +231,11 @@ TEST_F(SpringMassSystemTest, ForceEnergyAndPower) {
   const double q = system_->get_position(*context_);
   const double v = system_->get_velocity(*context_);
   const double w_c = system_->get_conservative_work(*context_);
-  const double f = system_->EvalSpringForce(*context_);
-  const double pe = system_->CalcPotentialEnergy(*context_);
-  const double ke = system_->CalcKineticEnergy(*context_);
-  const double power_c = system_->CalcConservativePower(*context_);
-  const double power_nc = system_->CalcNonConservativePower(*context_);
+  const double f = system_->CalcSpringForce(*context_);
+  const double pe = system_->EvalPotentialEnergy(*context_);
+  const double ke = system_->EvalKineticEnergy(*context_);
+  const double power_c = system_->EvalConservativePower(*context_);
+  const double power_nc = system_->EvalNonConservativePower(*context_);
 
   EXPECT_EQ(q, 1.0);
   EXPECT_EQ(v, 2.0);
@@ -250,41 +261,43 @@ switching to central differences here to get more decimal places. */
 MatrixX<double> CalcDxdotDx(const System<double>& system,
                             const Context<double>& context) {
   const double perturb = 1e-7;  // roughly sqrt(precision)
-  auto derivs0 = system.AllocateTimeDerivatives();
-  system.CalcTimeDerivatives(context, derivs0.get());
-  const int nx = derivs0->size();
-  const VectorX<double> xdot0 = derivs0->CopyToVector();
+  const VectorX<double> xdot0 =
+      system.EvalTimeDerivatives(context).CopyToVector();
+  const int nx = static_cast<int>(xdot0.size());
   MatrixX<double> d_xdot_dx(nx, nx);
 
-  auto temp_context = context.Clone();
-  auto& x = temp_context->get_mutable_continuous_state_vector();
+  // We need a mutable Context.
+  auto x = context.Clone();
 
-  // This is a temp that holds one column of the result as a ContinuousState.
-  auto derivs = system.AllocateTimeDerivatives();
+  for (int i = 0; i < nx; ++i) {
+    const double xi = x->get_continuous_state_vector().GetAtIndex(i);
+    // Invalidates all xc-dependent quantities.
+    x->get_mutable_continuous_state_vector().SetAtIndex(i, xi + perturb);
 
-  for (int i = 0; i < x.size(); ++i) {
-    const double xi = x.GetAtIndex(i);
-    x.SetAtIndex(i, xi + perturb);
-    system.CalcTimeDerivatives(*temp_context, derivs.get());
-    d_xdot_dx.col(i) = (derivs->CopyToVector() - xdot0) / perturb;
-    x.SetAtIndex(i, xi);  // repair Context
+    const auto& derivs = system.EvalTimeDerivatives(*x);
+    d_xdot_dx.col(i) = (derivs.CopyToVector() - xdot0) / perturb;
+
+    // Undo above change (invalidates again).
+    x->get_mutable_continuous_state_vector().SetAtIndex(i, xi);  // repair xc
   }
 
   return d_xdot_dx;
 }
 
 /* Explicit Euler (unstable): x1 = x0 + h xdot(t0,x0) */
-void StepExplicitEuler(
-    double h, const ContinuousState<double>& derivs,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    Context<double>& context) {
-  const double t = context.get_time();
-  // Invalidate all xc-dependent quantities.
+void StepExplicitEuler(double h, const System<double>& system,
+                       Context<double>* context) {
+  const double t = context->get_time();
+
+  // Grabs a reference to the derivatives; still good after invalidation.
+  const auto& dx0 = system.EvalTimeDerivatives(*context).get_vector();
+
+  // Invalidates all xc-dependent quantities.
   VectorBase<double>& xc =
-      context.get_mutable_continuous_state_vector();
-  const auto& dxc = derivs.get_vector();
-  xc.PlusEqScaled(h, dxc);  // xc += h*dxc
-  context.set_time(t + h);
+      context->get_mutable_continuous_state_vector();
+
+  xc.PlusEqScaled(h, dx0);  // xc += h * dx0
+  context->set_time(t + h);
 }
 
 /* Semi-explicit Euler (neutrally stable):
@@ -293,30 +306,34 @@ void StepExplicitEuler(
     q1 = q0 + h qdot(q0,v1) */
 void StepSemiExplicitEuler(
     double h, const System<double>& system,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    ContinuousState<double>& derivs,  // in/out
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    Context<double>& context) {
-  const double t = context.get_time();
-  ContinuousState<double>& xc = context.get_mutable_continuous_state();
+    Context<double>* context) {
+  const double t0 = context->get_time();
 
-  // Invalidate z-dependent quantities.
+  // Grabs a reference to the derivatives; still good after invalidation.
+  const auto& dx0 = system.EvalTimeDerivatives(*context);
+
+  // Invalidates all xc-dependent quantities.
+  ContinuousState<double>& xc = context->get_mutable_continuous_state();
+
+  // Update z.
   VectorBase<double>& xz = xc.get_mutable_misc_continuous_state();
-  const auto& dxz = derivs.get_misc_continuous_state();
-  xz.PlusEqScaled(h, dxz);  // xz += h*dxz
+  const auto& dxz = dx0.get_misc_continuous_state();
+  xz.PlusEqScaled(h, dxz);  // xz += h * dxz
 
-  // Invalidate v-dependent quantities.
+  // Update v.
   VectorBase<double>& xv = xc.get_mutable_generalized_velocity();
-  const auto& dxv = derivs.get_generalized_velocity();
-  xv.PlusEqScaled(h, dxv);  // xv += h*dxv
+  const auto& dxv = dx0.get_generalized_velocity();
+  xv.PlusEqScaled(h, dxv);  // xv += h * dxv
 
-  context.set_time(t + h);
+  // Invalidates all time-dependent quantities.
+  context->set_time(t0 + h);
 
-  // Invalidate q-dependent quantities.
+  // Update q.
   VectorBase<double>& xq = xc.get_mutable_generalized_position();
-  auto& dxq = derivs.get_mutable_generalized_position();
-  system.MapVelocityToQDot(context, xv, &dxq);  // qdot = N(q)*v
-  xq.PlusEqScaled(h, dxq);                       // xq += h*qdot
+  // Yuck -- heap allocation for dxq. Don't do this in a real integrator.
+  BasicVector<double> dxq(dx0.num_q());
+  system.MapVelocityToQDot(*context, xv, &dxq);  // qdot = N(q) * v
+  xq.PlusEqScaled(h, dxq);                       // xq += h * qdot
 }
 
 /* Implicit Euler (unconditionally stable): x1 = x0 + h xdot(t1,x1)
@@ -328,36 +345,30 @@ void StepSemiExplicitEuler(
     while (norm(dx)/norm(x0) > tol) */
 void StepImplicitEuler(
     double h, const System<double>& system,
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    ContinuousState<double>& derivs,  // in/out
-    // TODO(#2274) Fix NOLINTNEXTLINE(runtime/references).
-    Context<double>& context) {
-  const double t = context.get_time();
-  ContinuousState<double>& xc = context.get_mutable_continuous_state();
+    Context<double>* context) {
 
-  // Invalidate all xc-dependent quantities.
-  VectorBase<double>& x1 = xc.get_mutable_vector();
-
-  const auto vx0 = x1.CopyToVector();
-  const auto& dx0 = derivs.get_vector();
-  x1.PlusEqScaled(h, dx0);  // x1 += h*dx0 (initial guess)
-  context.set_time(t + h);   // t=t1
+  // Save initial time and state.
+  const double t0 = context->get_time();
+  const VectorX<double> vx0 = context->get_continuous_state().CopyToVector();
   const int nx = static_cast<int>(vx0.size());
   const auto I = MatrixX<double>::Identity(nx, nx);
+
+  const VectorX<double> vdx0 =
+      system.EvalTimeDerivatives(*context).CopyToVector();
+  context->SetTimeAndContinuousState(t0 + h,           // t = t1
+                                     vx0 + h * vdx0);  // Initial guess for x1.
 
   // Would normally iterate until convergence of dx norm as shown above.
   // Here I'm just iterating a fixed number of time that I know is plenty!
   for (int i = 0; i < 6; ++i) {
-    system.CalcTimeDerivatives(context, &derivs);
-    const auto& dx1 = derivs.get_vector();
-    const auto vx1 = x1.CopyToVector();
-    const auto vdx1 = dx1.CopyToVector();
+    const auto vdx1 = system.EvalTimeDerivatives(*context).CopyToVector();
+    const auto vx1 = context->get_continuous_state().CopyToVector();
     const auto err = vx1 - (vx0 + h * vdx1);
-    const auto DxdotDx = CalcDxdotDx(system, context);
+    const auto DxdotDx = CalcDxdotDx(system, *context);
     const auto J = I - h * DxdotDx;
     Eigen::PartialPivLU<MatrixX<double>> Jlu(J);
     VectorX<double> dx = Jlu.solve(err);
-    x1.SetFromVector(vx1 - dx);
+    context->SetContinuousState(vx1 - dx);
   }
 }
 
@@ -365,8 +376,8 @@ void StepImplicitEuler(
 TODO(sherm1): assuming there is only KE and PE to worry about. */
 double CalcEnergy(const SpringMassSystem<double>& system,
                   const Context<double>& context) {
-  return system.CalcPotentialEnergy(context) +
-         system.CalcKineticEnergy(context);
+  return system.EvalPotentialEnergy(context) +
+         system.EvalKineticEnergy(context);
 }
 
 /* This test simulates the spring-mass system simultaneously using three first-
@@ -419,7 +430,7 @@ TEST_F(SpringMassSystemTest, Integrate) {
     both regression test form and as friendlier examples. */
 
     for (int i = 0; i < kNumIntegrators; ++i) {
-      system_->CalcTimeDerivatives(*contexts[i], derivs[i].get());
+      derivs[i] = system_->EvalTimeDerivatives(*contexts[i]).Clone();
       system_->CalcOutput(*contexts[i], outputs[i].get());
     }
 
@@ -429,9 +440,9 @@ TEST_F(SpringMassSystemTest, Integrate) {
     if (t >= kTfinal) break;
 
     // Integrate three ways.
-    StepExplicitEuler(h, *derivs[kXe], *contexts[kXe]);
-    StepImplicitEuler(h, *system_, *derivs[kIe], *contexts[kIe]);
-    StepSemiExplicitEuler(h, *system_, *derivs[kSxe], *contexts[kSxe]);
+    StepExplicitEuler(h, *system_, &*contexts[kXe]);
+    StepImplicitEuler(h, *system_, &*contexts[kIe]);
+    StepSemiExplicitEuler(h, *system_, &*contexts[kSxe]);
   }
 
   // Now verify that each integrator behaved as expected.
@@ -457,8 +468,6 @@ TEST_F(SpringMassSystemTest, IntegrateConservativePower) {
 
   // Resources.
   unique_ptr<Context<double>> context = system_->CreateDefaultContext();
-  unique_ptr<ContinuousState<double>> derivs =
-      system_->AllocateTimeDerivatives();
 
   // Set initial conditions..
   context->set_time(0);
@@ -467,20 +476,16 @@ TEST_F(SpringMassSystemTest, IntegrateConservativePower) {
   system_->set_conservative_work(context.get(), 0.);  // W(0)=0
 
   // Save the initial energy.
-  const double pe0 = system_->CalcPotentialEnergy(*context);
-  const double ke0 = system_->CalcKineticEnergy(*context);
+  const double pe0 = system_->EvalPotentialEnergy(*context);
+  const double ke0 = system_->EvalKineticEnergy(*context);
   const double e0 = pe0 + ke0;
 
   while (true) {
     const auto t = context->get_time();
-
-    // Evaluate derivatives at the beginning of a step. We don't need outputs.
-    system_->CalcTimeDerivatives(*context, derivs.get());
-
     if (t >= kTfinal) break;
 
-    const double pe = system_->CalcPotentialEnergy(*context);
-    const double ke = system_->CalcKineticEnergy(*context);
+    const double pe = system_->EvalPotentialEnergy(*context);
+    const double ke = system_->EvalKineticEnergy(*context);
     const double e = pe + ke;
     EXPECT_NEAR(e, e0, 1e-3);
 
@@ -493,7 +498,7 @@ TEST_F(SpringMassSystemTest, IntegrateConservativePower) {
     EXPECT_NEAR(pe, pe0 - w, 1e-2);
 
     // Take a step of size h.
-    StepSemiExplicitEuler(h, *system_, *derivs, *context);
+    StepSemiExplicitEuler(h, *system_, &*context);
   }
 }
 

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -36,9 +36,13 @@ class ConstantValueSourceTest : public ::testing::Test {
 TEST_F(ConstantValueSourceTest, Output) {
   ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
 
+  // Check Calc() method.
   source_->get_output_port(0).Calc(*context_, output_.get());
-
   EXPECT_EQ("foo", output_->GetValue<std::string>());
+
+  // Check Eval() method.
+  auto& cached_value = source_->get_output_port(0).Eval<std::string>(*context_);
+  EXPECT_EQ("foo", cached_value);
 }
 
 // Tests that ConstantValueSource allocates no state variables in the context_.

--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -426,6 +426,7 @@ filegroup(
 
 drake_cc_googletest(
     name = "rgbd_camera_test",
+    srcs = ["test/rgbd_camera_test.cc"],
     data = [
         ":test_models",
     ],

--- a/systems/sensors/depth_sensor.cc
+++ b/systems/sensors/depth_sensor.cc
@@ -54,10 +54,11 @@ DepthSensor::DepthSensor(const std::string& name,
   }
   DRAKE_DEMAND(specification_.min_range() <= specification_.max_range() &&
                "min_range must be less than or equal to max_range");
-  input_port_index_ =
-      DeclareInputPort(kVectorValued,
-                       tree.get_num_positions() + tree.get_num_velocities())
-          .get_index();
+
+  const auto& input_port = DeclareInputPort(kVectorValued,
+                       tree.get_num_positions() + tree.get_num_velocities());
+  input_port_index_ = input_port.get_index();
+
   depth_output_port_index_ =
       DeclareVectorOutputPort(DepthSensorOutput<double>(specification_),
                               &DepthSensor::CalcDepthOutput)
@@ -66,7 +67,27 @@ DepthSensor::DepthSensor(const std::string& name,
       DeclareVectorOutputPort(PoseVector<double>(),
                               &DepthSensor::CalcPoseOutput)
           .get_index();
+
+  // Kinematics cache here depends only on the input port, specifically just
+  // the q's (but the port has v's also).
+  kinematics_cache_entry_ = &DeclareCacheEntry(
+      "kinematics cache", &DepthSensor::AllocateKinematicsCache,
+      &DepthSensor::CalcKinematics, {input_port.ticket()});
+
   PrecomputeRaycastEndpoints();
+}
+
+KinematicsCache<double> DepthSensor::AllocateKinematicsCache() const {
+  return tree_.CreateKinematicsCache();
+}
+
+void DepthSensor::CalcKinematics(
+    const Context<double>& context,
+    KinematicsCache<double>* kinematics_cache) const {
+  VectorXd u = this->EvalEigenVectorInput(context, input_port_index_);
+  auto q = u.head(tree_.get_num_positions());
+  kinematics_cache->initialize(q);
+  tree_.doKinematics(*kinematics_cache);
 }
 
 void DepthSensor::PrecomputeRaycastEndpoints() {
@@ -128,14 +149,11 @@ const OutputPort<double>& DepthSensor::get_pose_output_port() const {
   return System<double>::get_output_port(pose_output_port_index_);
 }
 
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcDepthOutput(
     const Context<double>& context,
     DepthSensorOutput<double>* data_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const int frame_index = frame_.get_frame_index();
 
@@ -187,13 +205,10 @@ void DepthSensor::ApplyLimits(VectorX<double>* distances) const {
 }
 
 // Evaluates the output port containing X_WS.
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcPoseOutput(const Context<double>& context,
                                  PoseVector<double>* pose_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const drake::Isometry3<double> X_WS =
       tree_.CalcFramePoseInWorldFrame(kinematics_cache, frame_);

--- a/systems/sensors/depth_sensor.h
+++ b/systems/sensors/depth_sensor.h
@@ -166,6 +166,14 @@ class DepthSensor : public systems::LeafSystem<double> {
   void CalcPoseOutput(const Context<double>& context,
                       rendering::PoseVector<double>* pose_output) const;
 
+  // Allocator for our CacheEntry. Returns a KinematicsCache suitable for
+  // the RigidBodyTree we're using.
+  KinematicsCache<double> AllocateKinematicsCache() const;
+
+  // Calculator for the CacheEntry. Updates the KinematicsCache to reflect
+  // the current q's at the input port.
+  void CalcKinematics(const Context<double>& context,
+                      KinematicsCache<double>*) const;
 
   // The depth sensor will cast a ray with its start point at (0,0,0) in the
   // sensor's base frame (as defined by get_frame()). Its end, also in the
@@ -189,6 +197,7 @@ class DepthSensor : public systems::LeafSystem<double> {
   int input_port_index_{};
   int depth_output_port_index_{};
   int pose_output_port_index_{};
+  const CacheEntry* kinematics_cache_entry_{};
 
   // A cache of where a depth measurement ray endpoint would be if the maximum
   // range were achieved. This is cached to avoid repeated allocation and

--- a/systems/sensors/test/beam_model_test.cc
+++ b/systems/sensors/test/beam_model_test.cc
@@ -100,7 +100,7 @@ GTEST_TEST(BeamModelTest, TestProbabilityDensity) {
     }
   }
 
-  auto& params =
+  BeamModelParams<double>& params =
       beam_model->get_mutable_parameters(&diagram->GetMutableSubsystemContext(
           *beam_model, &simulator.get_mutable_context()));
 


### PR DESCRIPTION
This is an attempt to reproduce the ODR failure I reported on Slack #cpp. This should have CI failures.

Slack discussion:

sherm1 [2:10 PM]
TL;DR: Likely not a good idea to rely on the address of function static variables to be invariant across all executing code.

I ran into a case where depending on a static object to have the same address in all the code using it failed, specifically in python test cases, which I believe use a shared library not used in other tests(?). I had a never-destroyed "dummy" value defined like this in `cache.h`:
```c++
static CacheEntryValue& dummy() {
    static never_destroyed<CacheEntryValue> dummy;
    return dummy.access();
  }
```
I was using `ptr==&dummy` as a flag to tell me that ptr wasn't set to anything useful. A `DRAKE_DEMAND(ptr==&dummy)` failed in a case where it should have succeeded. Switching to an explicit bool flag to indicate whether ptr is meaningful fixed the problem (should have done that in the first place!).

I speculate that this would have worked if I'd put the definition of dummy() in a .cc rather than a header (didn't try that as a fix since the mechanism seems brittle). (edited)

jwnimmer-tri [2:18 PM]
@sherm1 That result would indicate a build system misconfiguration.  It is supposed to work.  Can you post a repro for us?  Which test failed? (edited)
Possibly it is something like #8908, where we were violating ODR.  I also noted in #python that the pydrake bindings for `//examples` code are also broken with respect to ODR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8910)
<!-- Reviewable:end -->
