### PR TITLE
Brings in System-side OutputPort changes in preparation for caching

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_package_library(
         ":leaf_system",
         ":model_values",
         ":output_port",
+        ":output_port_base",
         ":output_port_value",
         ":parameters",
         ":single_output_vector_source",
@@ -261,6 +262,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "output_port_base",
+    srcs = [
+        "output_port_base.cc",
+    ],
+    hdrs = [
+        "output_port_base.h",
+    ],
+    deps = [
+        ":framework_common",
+    ],
+)
+
+drake_cc_library(
     name = "system_base",
     srcs = [
         "system_base.cc",
@@ -272,6 +286,7 @@ drake_cc_library(
         ":cache_entry",
         ":context_base",
         ":input_port_base",
+        ":output_port_base",
     ],
 )
 
@@ -335,17 +350,19 @@ drake_cc_library(
 
 drake_cc_library(
     name = "output_port",
-    srcs = ["output_port.cc"],
-    hdrs = ["output_port.h"],
+    srcs = [
+        "output_port.cc",
+    ],
+    hdrs = [
+        "output_port.h",
+    ],
     deps = [
         ":context",
-        ":framework_common",
+        ":output_port_base",
         ":system_base",
         ":value",
-        ":vector",
         "//common:default_scalars",
         "//common:essential",
-        "//common:type_safe_index",
     ],
 )
 
@@ -701,6 +718,7 @@ drake_cc_googletest(
         ":leaf_system",
         "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//systems/framework/test_utilities",
     ],
@@ -773,6 +791,7 @@ drake_cc_googletest(
         ":leaf_context",
         ":system",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
         "//systems/framework/test_utilities",
         "//systems/primitives:constant_vector_source",
     ],
@@ -805,6 +824,7 @@ drake_cc_googletest(
     deps = [
         ":value",
         "//common:essential",
+        "//systems/framework/test_utilities:my_vector",
     ],
 )
 

--- a/systems/framework/cache.cc
+++ b/systems/framework/cache.cc
@@ -49,22 +49,18 @@ void CacheEntryValue::ThrowIfBadOtherValue(
 
   DRAKE_DEMAND(value_ != nullptr);  // Should have been checked already.
 
-  // Extract these outside typeid() to avoid warnings.
-  const AbstractValue& abstract_value = *value_;
-  const AbstractValue& other_abstract_value = *other_value;
-  if (std::type_index(typeid(abstract_value)) !=
-      std::type_index(typeid(other_abstract_value))) {
+  if (value_->type_info() != other_value->type_info()) {
     throw std::logic_error(FormatName(api) +
                            "other_value has wrong concrete type " +
-                           NiceTypeName::Get(*other_value) + ". Expected " +
-                           NiceTypeName::Get(*value_) + ".");
+                           other_value->GetNiceTypeName() + ". Expected " +
+                           value_->GetNiceTypeName() + ".");
   }
 }
 
 CacheEntryValue& Cache::CreateNewCacheEntryValue(
     CacheIndex index, DependencyTicket ticket,
     const std::string& description,
-    const std::vector<DependencyTicket>& prerequisites,
+    const std::set<DependencyTicket>& prerequisites,
     DependencyGraph* trackers) {
   DRAKE_DEMAND(trackers != nullptr);
   DRAKE_DEMAND(index.is_valid() && ticket.is_valid());

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -6,6 +6,7 @@ values. */
 
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -619,7 +620,7 @@ class Cache {
   CacheEntryValue& CreateNewCacheEntryValue(
       CacheIndex index, DependencyTicket ticket,
       const std::string& description,
-      const std::vector<DependencyTicket>& prerequisites,
+      const std::set<DependencyTicket>& prerequisites,
       DependencyGraph* graph);
 
   /** Returns true if there is a CacheEntryValue in this cache that has the

--- a/systems/framework/cache_entry.cc
+++ b/systems/framework/cache_entry.cc
@@ -11,11 +11,11 @@ namespace drake {
 namespace systems {
 
 CacheEntry::CacheEntry(
-    const internal::SystemMessageInterface* owning_subsystem, CacheIndex index,
+    const internal::SystemMessageInterface* owning_system, CacheIndex index,
     DependencyTicket ticket, std::string description,
     AllocCallback alloc_function, CalcCallback calc_function,
-    std::vector<DependencyTicket> prerequisites_of_calc)
-    : owning_subsystem_(owning_subsystem),
+    std::set<DependencyTicket> prerequisites_of_calc)
+    : owning_system_(owning_system),
       cache_index_(index),
       ticket_(ticket),
       description_(std::move(description)),
@@ -24,7 +24,7 @@ CacheEntry::CacheEntry(
       prerequisites_of_calc_(
           std::move(prerequisites_of_calc)) {
   DRAKE_DEMAND(index.is_valid() && ticket.is_valid());
-  DRAKE_DEMAND(owning_subsystem && alloc_function_ && calc_function_);
+  DRAKE_DEMAND(owning_system && alloc_function_ && calc_function_);
 
   if (prerequisites_of_calc_.empty()) {
     throw std::logic_error(FormatName("CacheEntry") +
@@ -46,7 +46,7 @@ std::unique_ptr<AbstractValue> CacheEntry::Allocate() const {
 void CacheEntry::Calc(const ContextBase& context,
                       AbstractValue* value) const {
   DRAKE_DEMAND(value != nullptr);
-  DRAKE_ASSERT_VOID(owning_subsystem_->ThrowIfContextNotCompatible(context));
+  DRAKE_ASSERT_VOID(owning_system_->ThrowIfContextNotCompatible(context));
   DRAKE_ASSERT_VOID(CheckValidAbstractValue(*value));
 
   calc_function_(context, value);
@@ -61,17 +61,17 @@ void CacheEntry::CheckValidAbstractValue(const AbstractValue& proposed) const {
   //              need to pass in a ContextBase.
   auto good_ptr = Allocate();  // Very expensive!
   const AbstractValue& good = *good_ptr;
-  if (typeid(proposed) != typeid(good)) {
+  if (proposed.type_info() != good.type_info()) {
     throw std::logic_error(FormatName("Calc") +
                            "expected AbstractValue output type " +
-                           NiceTypeName::Get(good) + " but got " +
-                           NiceTypeName::Get(proposed) + ".");
+                           good.GetNiceTypeName() + " but got " +
+                           proposed.GetNiceTypeName() + ".");
   }
 }
 
 std::string CacheEntry::FormatName(const char* api) const {
-  return "Subsystem '" + owning_subsystem_->GetSystemPathname() + "' (" +
-      NiceTypeName::RemoveNamespaces(owning_subsystem_->GetSystemType()) +
+  return "System '" + owning_system_->GetSystemPathname() + "' (" +
+      NiceTypeName::RemoveNamespaces(owning_system_->GetSystemType()) +
       "): CacheEntry[" + std::to_string(cache_index_) + "](" +
       description() + ")::" + api + "(): ";
 }

--- a/systems/framework/cache_entry.h
+++ b/systems/framework/cache_entry.h
@@ -2,9 +2,9 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/systems/framework/context_base.h"
@@ -42,6 +42,9 @@ a manner very similar to the declaration of output ports. */
 class CacheEntry {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(CacheEntry)
+
+  // TODO(sherm1) These callbacks should not be specific to this class. Move
+  // elsewhere, e.g. framework_common.h so they can be shared with output port.
 
   /** Signature of a function suitable for allocating an object that can hold
   a value of a particular cache entry. The result is always returned as an
@@ -82,15 +85,15 @@ class CacheEntry {
   @see drake::systems::SystemBase::DeclareCacheEntry() */
   // All the nontrivial parameters here are moved to the CacheEntry which is
   // why they aren't references.
-  CacheEntry(const internal::SystemMessageInterface* owning_subsystem,
+  CacheEntry(const internal::SystemMessageInterface* owning_system,
              CacheIndex index, DependencyTicket ticket, std::string description,
              AllocCallback alloc_function, CalcCallback calc_function,
-             std::vector<DependencyTicket> prerequisites_of_calc);
+             std::set<DependencyTicket> prerequisites_of_calc);
 
   /** Returns a reference to the list of prerequisites needed by this cache
   entry's Calc() function. These are all within the same subsystem that
   owns this %CacheEntry. */
-  const std::vector<DependencyTicket>& prerequisites() const {
+  const std::set<DependencyTicket>& prerequisites() const {
     return prerequisites_of_calc_;
   }
 
@@ -294,7 +297,7 @@ class CacheEntry {
   // Provides an identifying prefix for error messages.
   std::string FormatName(const char* api) const;
 
-  const internal::SystemMessageInterface* const owning_subsystem_;
+  const internal::SystemMessageInterface* const owning_system_;
   const CacheIndex cache_index_;
   const DependencyTicket ticket_;
 
@@ -309,7 +312,7 @@ class CacheEntry {
   // changes, the cache value must be recalculated. Note that all possible
   // prerequisites are internal to the containing subsystem, so the ticket
   // alone is a unique specification of a prerequisite.
-  const std::vector<DependencyTicket> prerequisites_of_calc_;
+  const std::set<DependencyTicket> prerequisites_of_calc_;
 };
 
 }  // namespace systems

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -145,6 +145,23 @@ class ContextBase : public internal::ContextMessageInterface {
     return static_cast<int>(input_port_tickets_.size());
   }
 
+  /** Returns the number of output ports represented in this context. */
+  int get_num_output_ports() const {
+    return static_cast<int>(output_port_tickets_.size());
+  }
+
+  /** Returns the dependency ticket associated with a particular input port. */
+  DependencyTicket input_port_ticket(InputPortIndex port_num) {
+    DRAKE_DEMAND(port_num < get_num_input_ports());
+    return input_port_tickets_[port_num];
+  }
+
+  /** Returns the dependency ticket associated with a particular output port. */
+  DependencyTicket output_port_ticket(OutputPortIndex port_num) {
+    DRAKE_DEMAND(port_num < get_num_output_ports());
+    return output_port_tickets_[port_num];
+  }
+
   /** Connects the input port at `index` to a FixedInputPortValue with
   the given abstract `value`. Returns a reference to the allocated
   FixedInputPortValue that will remain valid until this input port's value
@@ -190,6 +207,11 @@ class ContextBase : public internal::ContextMessageInterface {
   // assigned ticket. Subscribe the "all input ports" tracker to this one.
   void AddInputPort(InputPortIndex expected_index, DependencyTicket ticket);
 
+  // Add the next output port. Expected index is supplied along with the
+  // assigned ticket.
+  void AddOutputPort(
+      OutputPortIndex expected_index, DependencyTicket ticket,
+      const internal::OutputPortPrerequisite& prerequisite);
 #endif
 
  protected:
@@ -284,8 +306,10 @@ class ContextBase : public internal::ContextMessageInterface {
 
   // Index by InputPortIndex.
   std::vector<DependencyTicket> input_port_tickets_;
+  // Index by OutputPortIndex.
+  std::vector<DependencyTicket> output_port_tickets_;
 
-  // TODO(sherm1) Output port, state, and parameter tickets go here.
+  // TODO(sherm1) State and parameter tickets go here.
 
   // For each input port, the fixed value or null if the port is connected to
   // something else (in which case we need System help to get the value).

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_optional.h"
 #include "drake/common/type_safe_index.h"
 
 namespace drake {
@@ -221,6 +222,16 @@ enum BuiltInTicketNumbers {
   kXcdotTicket          = 16,
   kXdhatTicket          = 17,
   kNextAvailableTicket  = kXdhatTicket+1
+};
+
+// Specifies the prerequisite of an output port. It will always be either
+// an internal cache entry within the subsystem that owns the output port, or
+// an output port of a child subsystem that is being forwarded as an output port
+// of the child's parent Diagram. If the `child_subsystem` index is missing it
+// indicates that the prerequisite is internal.
+struct OutputPortPrerequisite {
+  optional<SubsystemIndex> child_subsystem;
+  DependencyTicket dependency;
 };
 
 // These are some utility methods that are reused within the framework.

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -2,33 +2,21 @@
 
 #include <functional>
 #include <memory>
-#include <sstream>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
-#include "drake/common/never_destroyed.h"
-#include "drake/common/nice_type_name.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/output_port.h"
+#include "drake/systems/framework/system_base.h"
 #include "drake/systems/framework/value.h"
 
 namespace drake {
 namespace systems {
 
-template <typename T>
-class System;
-
-template <typename T>
-class Context;
-
-/** Adds methods for allocation, calculation, and caching of an output
-port's value. When created, an allocation and a calculation function must be
-provided. The output type of the calculation callback must match the type
-returned by the allocation function.
+/** Implements an output port whose value is managed by a cache entry in the
+same LeafSystem as the port. This is intended for internal use in implementing
+the DeclareOutputPort() variants in LeafSystem.
 
 @tparam T The vector element type, which must be a valid Eigen scalar.
 
@@ -39,13 +27,18 @@ Instantiated templates for the following kinds of T's are provided:
 
 They are already available to link against in the containing library.
 No other values for T are currently supported. */
-// TODO(sherm1) Implement caching for output ports.
+// TODO(sherm1) Output ports that simply expose existing Context objects
+// should not require a cache entry. Add provision for that to avoid the
+// unnecessary copying currently done by Eval() for those.
 template <typename T>
-class LeafOutputPort : public OutputPort<T> {
+class LeafOutputPort final : public OutputPort<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LeafOutputPort)
 
   ~LeafOutputPort() override = default;
+
+  // TODO(sherm1) These callbacks should not be specific to this class. Move
+  // elsewhere, e.g. framework_common.h so they can be shared with cache entry.
 
   /** Signature of a function suitable for allocating an object that can hold
   a value of a particular output port. The result is returned as an
@@ -62,146 +55,50 @@ class LeafOutputPort : public OutputPort<T> {
   using CalcVectorCallback =
   std::function<void(const Context<T>&, BasicVector<T>*)>;
 
-  /** Signature of a function suitable for obtaining the cached value of a
-  particular output port. */
-  using EvalCallback = std::function<const AbstractValue&(const Context<T>&)>;
-
-  // There is no EvalVectorCallback.
-
-  /** Constructs an abstract-valued output port. The supplied allocator must
-  return a suitable AbstractValue in which to hold the result. The supplied
-  calculator function must write to an AbstractValue of the same underlying
-  concrete type as is returned by the allocator. The allocator function is not
-  invoked here during construction of the port so it may depend on data that
-  becomes available only after completion of the containing System or
-  Diagram. The `system` parameter must be the same object as the `system_base`
-  parameter. */
-  LeafOutputPort(const System<T>& system,
-                 const internal::SystemMessageInterface& system_base,
-                 OutputPortIndex index,
-                 AllocCallback alloc_function,
-                 CalcCallback calc_function)
-      : OutputPort<T>(system, system_base, index, kAbstractValued,
-                      0 /* size */) {
-    set_allocation_function(alloc_function);
-    set_calculation_function(calc_function);
+  /** Constructs a cached output port. The `system` parameter must be the same
+  object as the `system_base` parameter. */
+  LeafOutputPort(const System<T>* system, SystemBase* system_base,
+                 OutputPortIndex index, DependencyTicket ticket,
+                 PortDataType data_type, int size,
+                 const CacheEntry* cache_entry)
+      : OutputPort<T>(system, system_base, index, ticket, data_type, size),
+        cache_entry_(cache_entry) {
+    DRAKE_DEMAND(cache_entry != nullptr);
   }
 
-  /** Constructs a fixed-size vector-valued output port. The supplied allocator
-  must return a `Value<BasicVector>` of the correct size in which to hold the
-  result. The supplied calculator function must write to a BasicVector of the
-  same underlying concrete type as is returned by the allocator. Requires the
-  fixed size to be given explicitly here. The allocator function is not invoked
-  here during construction of the port so it may depend on data that becomes
-  available only after completion of the containing System or Diagram. The
-  `system` parameter must be the same object as the `system_base` parameter. */
-  // Note: there is no guarantee that the allocator can be invoked successfully
-  // here since construction of the containing System is likely incomplete when
-  // this method is invoked. Do not attempt to extract the size from
-  // the allocator by calling it here.
-  LeafOutputPort(const System<T>& system,
-                 const internal::SystemMessageInterface& system_base,
-                 OutputPortIndex index,
-                 int fixed_size,
-                 AllocCallback vector_alloc_function,
-                 CalcVectorCallback vector_calc_function)
-      : OutputPort<T>(system, system_base, index, kVectorValued, fixed_size) {
-    set_allocation_function(vector_alloc_function);
-    set_calculation_function(vector_calc_function);
-  }
-
-  /** (Advanced) Sets or replaces the evaluation function for this output
-  port, using a function that returns an `AbstractValue`. By default, an
-  evaluation function is automatically provided that calls the calculation
-  function. */
-  // TODO(sherm1) Not useful yet; implement with caching.
-  void set_evaluation_function(EvalCallback eval_function) {
-    eval_function_ = eval_function;
+  /** Returns the cache entry associated with this output port. */
+  const CacheEntry& cache_entry() const {
+    DRAKE_ASSERT(cache_entry_ != nullptr);
+    return *cache_entry_;
   }
 
  private:
-  // Sets or replaces the allocation function for this output port, using
-  // a function that returns an AbstractValue.
-  void set_allocation_function(AllocCallback alloc_function) {
-    alloc_function_ = alloc_function;
-  }
-
-  // Sets or replaces the calculation function for this output port, using
-  // a function that writes into an `AbstractValue`.
-  void set_calculation_function(CalcCallback calc_function) {
-    calc_function_ = calc_function;
-  }
-
-  // Sets or replaces the calculation function for this vector-valued output
-  // port, using a function that writes into a `BasicVector<T>`.
-  void set_calculation_function(CalcVectorCallback vector_calc_function) {
-    if (!vector_calc_function) {
-      calc_function_ = nullptr;
-    } else {
-      // Wrap the vector-writing function with an AbstractValue-writing
-      // function.
-      calc_function_ = [this, vector_calc_function](const Context<T>& context,
-                                                    AbstractValue* abstract) {
-        // The abstract value must be a Value<BasicVector<T>>.
-        auto value = dynamic_cast<Value<BasicVector<T>>*>(abstract);
-        if (value == nullptr) {
-          std::ostringstream oss;
-          oss << "LeafOutputPort::Calc(): Expected a vector output type for "
-              << this->GetPortIdString() << " but got a "
-              << NiceTypeName::Get(*abstract) << " instead.";
-          throw std::logic_error(oss.str());
-        }
-        vector_calc_function(context, &value->get_mutable_value());
-      };
-    }
-  }
-
-  // Invokes the supplied allocation function if there is one, otherwise
-  // complains.
+  // Invokes the cache entry's allocation function.
   std::unique_ptr<AbstractValue> DoAllocate() const final {
-    std::unique_ptr<AbstractValue> result;
-
-    if (alloc_function_) {
-      result = alloc_function_();
-    } else {
-      throw std::logic_error(
-          "LeafOutputPort::DoAllocate(): " + this->GetPortIdString() +
-          " has no allocation function so cannot be allocated.");
-    }
-    if (result.get() == nullptr) {
-      throw std::logic_error(
-          "LeafOutputPort::DoAllocate(): allocator returned a nullptr for " +
-          this->GetPortIdString());
-    }
-    return result;
+    return cache_entry().Allocate();
   }
 
-  // Invokes the supplied calculation function if present, otherwise complains.
+  // Invokes the cache entry's calculator function.
   void DoCalc(const Context<T>& context, AbstractValue* value) const final {
-    if (calc_function_) {
-      calc_function_(context, value);
-    } else {
-      throw std::logic_error("LeafOutputPort::DoCalcWitnessValue(): " +
-                             this->GetPortIdString() +
-                             " had no calculation function available.");
-    }
+    cache_entry().Calc(context, value);
   }
 
-  // Currently just invokes the supplied evaluation function if present,
-  // otherwise complains.
-  // TODO(sherm1) Generate this automatically using the cache & DoEvaluate().
+  // Invokes the cache entry's Eval() function.
+  // TODO(sherm1) Caching is intentionally disabled here. Enable when
+  // invalidation wiring is connected up.
   const AbstractValue& DoEval(const Context<T>& context) const final {
-    if (eval_function_) return eval_function_(context);
-    // TODO(sherm1) Provide proper default behavior for an output port with
-    // its own cache entry.
-    DRAKE_ABORT_MSG("LeafOutputPort::DoEval(): NOT IMPLEMENTED YET");
-    static never_destroyed<Value<int>> dummy{0};
-    return dummy.access();
+    CacheEntryValue& cache_value =
+        cache_entry().get_mutable_cache_entry_value(context);
+    cache_value.mark_out_of_date();  // Force re-evaluation.
+    return cache_entry().EvalAbstract(context);
   }
 
-  AllocCallback alloc_function_;
-  CalcCallback  calc_function_;
-  EvalCallback  eval_function_;
+  // Returns the cache entry's ticket and no subsystem.
+  internal::OutputPortPrerequisite DoGetPrerequisite() const final {
+    return {nullopt, cache_entry().ticket()};
+  };
+
+  const CacheEntry* const cache_entry_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -5,6 +5,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -282,6 +283,9 @@ class LeafSystem : public System<T> {
   };
 
  protected:
+  // Promote so we don't need "this->" in defaults which show up in Doxygen.
+  using SystemBase::all_sources_ticket;
+
   /// Default constructor that declares no inputs, outputs, state, parameters,
   /// events, nor scalar-type conversion support (AutoDiff, etc.).  To enable
   /// AutoDiff support, use the SystemScalarConverter-based constructor.
@@ -1018,6 +1022,12 @@ class LeafSystem : public System<T> {
   /// methods below that are not given an explicit model value or construction
   /// ("make") method, the underlying type must be default constructible.
   /// @see drake::systems::Value for more about abstract values.
+  ///
+  /// A list of prerequisites may be provided for the calculator function to
+  /// avoid unnecessary recomputation. If no prerequisites are provided, the
+  /// default is to assume the output port value is dependent on all possible
+  /// sources. See @ref DeclareCacheEntry_documentation "DeclareCacheEntry"
+  /// for more information about prerequisites.
   //@{
 
   /// Declares a vector-valued output port by specifying (1) a model vector of
@@ -1033,7 +1043,9 @@ class LeafSystem : public System<T> {
   template <class MySystem, typename BasicVectorSubtype>
   const OutputPort<T>& DeclareVectorOutputPort(
       const BasicVectorSubtype& model_vector,
-      void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const) {
+      void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
     static_assert(std::is_base_of<LeafSystem<T>, MySystem>::value,
                   "Expected to be invoked from a LeafSystem-derived System.");
     static_assert(std::is_base_of<BasicVector<T>, BasicVectorSubtype>::value,
@@ -1055,7 +1067,7 @@ class LeafSystem : public System<T> {
           auto typed_result = dynamic_cast<BasicVectorSubtype*>(result);
           DRAKE_DEMAND(typed_result != nullptr);
           (this_ptr->*calc)(context, typed_result);
-        });
+        }, std::move(prerequisites_of_calc));
     MaybeDeclareVectorBaseInequalityConstraint(
         "output " + std::to_string(int{port.get_index()}), model_vector,
         [&port, storage = std::shared_ptr<AbstractValue>{}](
@@ -1093,13 +1105,16 @@ class LeafSystem : public System<T> {
   /// the `BasicVectorSubtype` default constructor.
   template <class MySystem, typename BasicVectorSubtype>
   const OutputPort<T>& DeclareVectorOutputPort(
-      void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const) {
+      void (MySystem::*calc)(const Context<T>&, BasicVectorSubtype*) const,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
     static_assert(
         std::is_default_constructible<BasicVectorSubtype>::value,
         "LeafSystem::DeclareVectorOutputPort(calc): the one-argument form of "
         "this method requires that the output type has a default constructor");
     // Invokes the previous method.
-    return DeclareVectorOutputPort(BasicVectorSubtype{}, calc);
+    return DeclareVectorOutputPort(BasicVectorSubtype{}, calc,
+                                   std::move(prerequisites_of_calc));
   }
 
   /// (Advanced) Declares a vector-valued output port using the given
@@ -1111,10 +1126,12 @@ class LeafSystem : public System<T> {
   /// @see LeafOutputPort::CalcVectorCallback
   const OutputPort<T>& DeclareVectorOutputPort(
       const BasicVector<T>& model_vector,
-      typename LeafOutputPort<T>::CalcVectorCallback vector_calc_function) {
-    auto& port = CreateVectorLeafOutputPort(model_vector.size(),
-                                            MakeAllocCallback(model_vector),
-                                            vector_calc_function);
+      typename LeafOutputPort<T>::CalcVectorCallback vector_calc_function,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
+    auto& port = CreateVectorLeafOutputPort(
+        model_vector.size(), MakeAllocCallback(model_vector),
+        vector_calc_function, std::move(prerequisites_of_calc));
     return port;
   }
 
@@ -1131,7 +1148,9 @@ class LeafSystem : public System<T> {
   template <class MySystem, typename OutputType>
   const OutputPort<T>& DeclareAbstractOutputPort(
       const OutputType& model_value,
-      void (MySystem::*calc)(const Context<T>&, OutputType*) const) {
+      void (MySystem::*calc)(const Context<T>&, OutputType*) const,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
     auto this_ptr = dynamic_cast<const MySystem*>(this);
     DRAKE_DEMAND(this_ptr != nullptr);
     auto& port = CreateAbstractLeafOutputPort(
@@ -1139,7 +1158,7 @@ class LeafSystem : public System<T> {
         [this_ptr, calc](const Context<T>& context, AbstractValue* result) {
           OutputType& typed_result = result->GetMutableValue<OutputType>();
           (this_ptr->*calc)(context, &typed_result);
-        });
+        }, std::move(prerequisites_of_calc));
     return port;
   }
 
@@ -1164,13 +1183,16 @@ class LeafSystem : public System<T> {
   /// @see drake::systems::Value
   template <class MySystem, typename OutputType>
   const OutputPort<T>& DeclareAbstractOutputPort(
-      void (MySystem::*calc)(const Context<T>&, OutputType*) const) {
+      void (MySystem::*calc)(const Context<T>&, OutputType*) const,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
     static_assert(
         std::is_default_constructible<OutputType>::value,
         "LeafSystem::DeclareAbstractOutputPort(calc): the one-argument form of "
         "this method requires that the output type has a default constructor");
     // Note that value initialization {} is required here.
-    return DeclareAbstractOutputPort(OutputType{}, calc);
+    return DeclareAbstractOutputPort(OutputType{}, calc,
+                                     std::move(prerequisites_of_calc));
   }
 
   /// Declares an abstract-valued output port by specifying member functions to
@@ -1187,7 +1209,9 @@ class LeafSystem : public System<T> {
   template <class MySystem, typename OutputType>
   const OutputPort<T>& DeclareAbstractOutputPort(
       OutputType (MySystem::*make)() const,
-      void (MySystem::*calc)(const Context<T>&, OutputType*) const) {
+      void (MySystem::*calc)(const Context<T>&, OutputType*) const,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
     auto this_ptr = dynamic_cast<const MySystem*>(this);
     DRAKE_DEMAND(this_ptr != nullptr);
     auto& port = CreateAbstractLeafOutputPort(
@@ -1197,7 +1221,7 @@ class LeafSystem : public System<T> {
         [this_ptr, calc](const Context<T>& context, AbstractValue* result) {
           OutputType& typed_result = result->GetMutableValue<OutputType>();
           (this_ptr->*calc)(context, &typed_result);
-        });
+        }, std::move(prerequisites_of_calc));
     return port;
   }
 
@@ -1207,8 +1231,11 @@ class LeafSystem : public System<T> {
   /// @see LeafOutputPort::AllocCallback, LeafOutputPort::CalcCallback
   const OutputPort<T>& DeclareAbstractOutputPort(
       typename LeafOutputPort<T>::AllocCallback alloc_function,
-      typename LeafOutputPort<T>::CalcCallback calc_function) {
-    auto& port = CreateAbstractLeafOutputPort(alloc_function, calc_function);
+      typename LeafOutputPort<T>::CalcCallback calc_function,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()}) {
+    auto& port = CreateAbstractLeafOutputPort(alloc_function, calc_function,
+                                              std::move(prerequisites_of_calc));
     return port;
   }
   //@}
@@ -1547,30 +1574,88 @@ class LeafSystem : public System<T> {
     }
   }
 
-  // Creates a new vector-valued LeafOutputPort in this LeafSystem and returns
-  // a reference to it.
+  // Creates a new cached, vector-valued LeafOutputPort in this LeafSystem and
+  // returns a reference to it.
   LeafOutputPort<T>& CreateVectorLeafOutputPort(
       int fixed_size,
       typename LeafOutputPort<T>::AllocCallback vector_allocator,
-      typename LeafOutputPort<T>::CalcVectorCallback vector_calculator) {
-    auto port = std::make_unique<LeafOutputPort<T>>(
-        *this, *this, OutputPortIndex(this->get_num_output_ports()),
-        fixed_size, vector_allocator, vector_calculator);
-    LeafOutputPort<T>* const port_ptr = port.get();
-    this->CreateOutputPort(std::move(port));
-    return *port_ptr;
+      typename LeafOutputPort<T>::CalcVectorCallback vector_calculator,
+      std::set<DependencyTicket> calc_prerequisites) {
+    // Construct a suitable type-erased cache calculator from the given
+    // BasicVector<T> calculator function.
+    auto cache_calc_function = [vector_calculator](
+        const ContextBase& context_base, AbstractValue* abstract) {
+      auto& context = dynamic_cast<const Context<T>&>(context_base);
+
+      // The abstract value must be a Value<BasicVector<T>>, even if the
+      // underlying object is a more-derived vector type.
+      auto value = dynamic_cast<Value<BasicVector<T>>*>(abstract);
+
+      // TODO(sherm1) Make this error message more informative by capturing
+      // system and port index info.
+      if (value == nullptr) {
+        throw std::logic_error(fmt::format(
+            "An output port calculation required a {} object for its result "
+            "but got a {} object instead.",
+            NiceTypeName::Get<Value<BasicVector<T>>>(),
+            abstract->GetNiceTypeName()));
+      }
+      vector_calculator(context, &value->get_mutable_value());
+    };
+
+    // The allocator function is identical between output port and cache.
+    return CreateCachedLeafOutputPort(fixed_size, std::move(vector_allocator),
+                                      std::move(cache_calc_function),
+                                      std::move(calc_prerequisites));
   }
 
-  // Creates a new abstract-valued LeafOutputPort in this LeafSystem and returns
-  // a reference to it.
+  // Creates a new cached, abstract-valued LeafOutputPort in this LeafSystem and
+  // returns a reference to it.
   LeafOutputPort<T>& CreateAbstractLeafOutputPort(
       typename LeafOutputPort<T>::AllocCallback allocator,
-      typename LeafOutputPort<T>::CalcCallback calculator) {
+      typename LeafOutputPort<T>::CalcCallback calculator,
+      std::set<DependencyTicket> calc_prerequisites) {
+    // Construct a suitable type-erased cache calculator from the given
+    // type-T calculator function.
+    auto cache_calc_function = [calculator](
+        const ContextBase& context_base, AbstractValue* result) {
+      const Context<T>& context = dynamic_cast<const Context<T>&>(context_base);
+      return calculator(context, result);
+    };
+
+    return CreateCachedLeafOutputPort(0 /* size */, std::move(allocator),
+                                      std::move(cache_calc_function),
+                                      std::move(calc_prerequisites));
+  }
+
+  // Creates a new cached LeafOutputPort in this LeafSystem and returns a
+  // reference to it. Pass fixed_size == 0 for abstract ports, or non-zero
+  // for vector ports. Prerequisites list must not be empty.
+  LeafOutputPort<T>& CreateCachedLeafOutputPort(
+      int fixed_size,
+      typename CacheEntry::AllocCallback allocator,
+      typename CacheEntry::CalcCallback calculator,
+      std::set<DependencyTicket> calc_prerequisites) {
+    DRAKE_DEMAND(!calc_prerequisites.empty());
+    // Create a cache entry for this output port.
+    const OutputPortIndex oport_index(this->get_num_output_ports());
+    const CacheEntry& cache_entry = this->DeclareCacheEntry(
+        "output port " + std::to_string(oport_index) + " cache",
+        std::move(allocator), std::move(calculator),
+        std::move(calc_prerequisites));
+
+    // Create and install the port. Note that it has a separate ticket from
+    // the cache entry; the port's tracker will be subscribed to the cache
+    // entry's tracker when a Context is created.
+    // TODO(sherm1) Use implicit_cast when available (from abseil).
     auto port = std::make_unique<LeafOutputPort<T>>(
-        *this, *this, OutputPortIndex(this->get_num_output_ports()),
-        allocator, calculator);
+        this,  // implicit_cast<const System<T>*>(this)
+        this,  // implicit_cast<const SystemBase*>(this)
+        oport_index, this->assign_next_dependency_ticket(),
+        fixed_size == 0 ? kAbstractValued : kVectorValued, fixed_size,
+        &cache_entry);
     LeafOutputPort<T>* const port_ptr = port.get();
-    this->CreateOutputPort(std::move(port));
+    this->AddOutputPort(std::move(port));
     return *port_ptr;
   }
 

--- a/systems/framework/output_port_base.cc
+++ b/systems/framework/output_port_base.cc
@@ -1,0 +1,26 @@
+#include "drake/systems/framework/output_port_base.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+OutputPortBase::~OutputPortBase() = default;
+
+OutputPortBase::OutputPortBase(
+    SystemBase* owning_system,
+    OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
+    int size)
+    : owning_system_(*owning_system),
+      index_(index),
+      ticket_(ticket),
+      data_type_(data_type),
+      size_(size) {
+  DRAKE_DEMAND(owning_system != nullptr);
+  if (size_ == kAutoSize)
+    DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
+}
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/output_port_base.h
+++ b/systems/framework/output_port_base.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "drake/systems/framework/framework_common.h"
+
+namespace drake {
+namespace systems {
+
+// Break the SystemBase <=> OutputPortBase physical dependency cycle. An
+// OutputPortBase contains a back-pointer to its owning SystemBase, but that
+// pointer is forward-declared here and never dereferenced within this file.
+class SystemBase;
+
+/** %OutputPortBase handles the scalar type-independent aspects of an
+OutputPort. An OutputPort belongs to a System and represents the properties of
+one of that System's output ports. */
+class OutputPortBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(OutputPortBase)
+
+  virtual ~OutputPortBase();
+
+  /** Returns the index of this output port within the owning System. For a
+  Diagram, this will be the index within the Diagram, _not_ the index within
+  the LeafSystem whose output port was forwarded. */
+  OutputPortIndex get_index() const {
+    return index_;
+  }
+
+  /** Returns the DependencyTicket for this output port within the owning
+  System. */
+  DependencyTicket ticket() const {
+    return ticket_;
+  }
+
+  /** Gets the port data type specified at port construction. */
+  PortDataType get_data_type() const { return data_type_; }
+
+  /** Returns the fixed size expected for a vector-valued output port. Not
+  meaningful for abstract output ports. */
+  int size() const { return size_; }
+
+  /** Returns a reference to the System that owns this output port. Note that
+  for a diagram output port this will be the diagram, not the leaf system whose
+  output port was forwarded. */
+  const SystemBase& get_system_base() const {
+    return owning_system_;
+  }
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Internal use only. Returns the prerequisite for this output port -- either
+  // a cache entry in this System, or an output port of a child System.
+  internal::OutputPortPrerequisite GetPrerequisite() const {
+    return DoGetPrerequisite();
+  }
+#endif
+
+ protected:
+  /** Provides derived classes the ability to set the base class members at
+  construction.
+
+  @param owning_system
+    The System that owns this output port.
+  @param index
+    The index to be assigned to this OutputPort.
+  @param ticket
+    The DependencyTicket to be assigned to this OutputPort.
+  @param data_type
+    Whether the port described is vector or abstract valued.
+  @param size
+    If the port described is vector-valued, the number of elements expected,
+    otherwise ignored. */
+  OutputPortBase(SystemBase* owning_system,
+                 OutputPortIndex index, DependencyTicket ticket,
+                 PortDataType data_type, int size);
+
+  SystemBase& get_mutable_system_base() {
+    return owning_system_;
+  }
+
+  /** Concrete output ports must implement this to return the prerequisite
+  dependency ticket for this port, which may be in the current System or one
+  of its immediate child subsystems. */
+  virtual internal::OutputPortPrerequisite DoGetPrerequisite() const = 0;
+
+ private:
+  // Associated System and System resources.
+  SystemBase& owning_system_;
+  const OutputPortIndex index_;
+  const DependencyTicket ticket_;
+
+  // Port details.
+  const PortDataType data_type_;
+  const int size_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -412,7 +412,7 @@ class System : public SystemBase {
 
     // The API allows an int but we'll use InputPortIndex internally.
     if (port_index < 0)
-      ThrowNegativeInputPortIndex(__func__, port_index);
+      ThrowNegativePortIndex(__func__, port_index);
     const InputPortIndex iport_index(port_index);
 
     const BasicVector<T>* const basic_value =
@@ -442,7 +442,7 @@ class System : public SystemBase {
   Eigen::VectorBlock<const VectorX<T>> EvalEigenVectorInput(
       const Context<T>& context, int port_index) const {
     if (port_index < 0)
-      ThrowNegativeInputPortIndex(__func__, port_index);
+      ThrowNegativePortIndex(__func__, port_index);
     const InputPortIndex port(port_index);
 
     const BasicVector<T>* const basic_value =
@@ -960,11 +960,7 @@ class System : public SystemBase {
 
   // So we don't have to keep writing this->get_num_input_ports().
   using SystemBase::get_num_input_ports;
-
-  /// Returns the number of output ports of the system.
-  int get_num_output_ports() const {
-    return static_cast<int>(output_ports_.size());
-  }
+  using SystemBase::get_num_output_ports;
 
   /// Returns the typed input port at index @p port_index.
   // TODO(sherm1) Make this an InputPortIndex.
@@ -976,13 +972,8 @@ class System : public SystemBase {
   /// Returns the typed output port at index @p port_index.
   // TODO(sherm1) Make this an OutputPortIndex.
   const OutputPort<T>& get_output_port(int port_index) const {
-    if (port_index < 0 || port_index >= get_num_output_ports()) {
-      throw std::out_of_range(
-          "System " + get_name() + ": Port index " +
-          std::to_string(port_index) + " is out of range. There are only " +
-          std::to_string(get_num_output_ports()) + " output ports.");
-    }
-    return *output_ports_[port_index];
+    return dynamic_cast<const OutputPort<T>&>(
+        this->GetOutputPortBaseOrThrow(__func__, port_index));
   }
 
   /// Returns the number of constraints specified for the system.
@@ -1021,14 +1012,6 @@ class System : public SystemBase {
     return true;
   }
 
-  /// Returns the total dimension of all of the output ports (as if they were
-  /// muxed).
-  int get_num_total_outputs() const {
-    int count = 0;
-    for (const auto& out : output_ports_) count += out->size();
-    return count;
-  }
-
   /// Checks that @p output is consistent with the number and size of output
   /// ports declared by the system.
   /// @throw exception unless `output` is non-null and valid for this system.
@@ -1064,8 +1047,11 @@ class System : public SystemBase {
     DRAKE_THROW_UNLESS(context.get_num_input_ports() ==
                        this->get_num_input_ports());
 
-    // Checks that the size of the fixed vector input ports in the
-    // context matches the declarations made by the system.
+    DRAKE_THROW_UNLESS(context.get_num_output_ports() ==
+                       this->get_num_output_ports());
+
+    // Checks that the size of the fixed vector input ports in the context
+    // matches the declarations made by the system.
     for (InputPortIndex i(0); i < this->get_num_input_ports(); ++i) {
       const FixedInputPortValue* port_value =
           context.MaybeGetFixedInputPortValue(i);
@@ -1427,7 +1413,7 @@ class System : public SystemBase {
       optional<RandomDistribution> random_type = nullopt) {
     const InputPortIndex port_index(get_num_input_ports());
     const DependencyTicket port_ticket(this->assign_next_dependency_ticket());
-    this->CreateInputPort(
+    this->AddInputPort(
         std::make_unique<InputPortDescriptor<T>>(
             port_index, port_ticket, type, size, random_type, this, this));
     return get_input_port(port_index);
@@ -1439,15 +1425,6 @@ class System : public SystemBase {
     return DeclareInputPort(kAbstractValued, 0 /* size */);
   }
 
-  /// Adds an already-created output port to this System. Insists that the port
-  /// already contains a reference to this System, and that the port's index is
-  /// already set to the next available output port index for this System.
-  void CreateOutputPort(std::unique_ptr<OutputPort<T>> port) {
-    DRAKE_DEMAND(port != nullptr);
-    DRAKE_DEMAND(&port->get_system() == this);
-    DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
-    output_ports_.push_back(std::move(port));
-  }
   //@}
 
   /// Adds an already-created constraint to the list of constraints for this
@@ -1689,10 +1666,10 @@ class System : public SystemBase {
   }
   //@}
 
-//----------------------------------------------------------------------------
-/// @name             Constraint-related functions (protected).
-///
-// @{
+  //----------------------------------------------------------------------------
+  /// @name             Constraint-related functions (protected).
+  ///
+  // @{
 
   /// Gets the number of constraint equations for this system from the given
   /// context. The context is supplied in case the number of constraints is
@@ -1860,9 +1837,6 @@ class System : public SystemBase {
 
     return basic_value;
   }
-
-  // TODO(sherm1) Move output ports up with input ports.
-  std::vector<std::unique_ptr<OutputPort<T>>> output_ports_;
 
   std::vector<std::unique_ptr<SystemConstraint<T>>> constraints_;
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -10,6 +11,7 @@
 #include "drake/systems/framework/cache_entry.h"
 #include "drake/systems/framework/framework_common.h"
 #include "drake/systems/framework/input_port_base.h"
+#include "drake/systems/framework/output_port_base.h"
 
 namespace drake {
 namespace systems {
@@ -47,7 +49,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // intent that the label could be used programmatically.
   const std::string& get_name() const { return name_; }
 
-  /** Returns a human-readable name for this subsystem, for use in messages and
+  /** Returns a human-readable name for this system, for use in messages and
   logging. This will be the same as returned by get_name(), unless that would
   be an empty string. In that case we return a non-unique placeholder name,
   currently just "_" (a lone underscore). */
@@ -118,7 +120,7 @@ class SystemBase : public internal::SystemMessageInterface {
   const AbstractValue* EvalAbstractInput(const ContextBase& context,
                                          int port_index) const {
     if (port_index < 0)
-      ThrowNegativeInputPortIndex(__func__, port_index);
+      ThrowNegativePortIndex(__func__, port_index);
     const InputPortIndex port(port_index);
     return EvalAbstractInputImpl(__func__, context, port);
   }
@@ -139,7 +141,7 @@ class SystemBase : public internal::SystemMessageInterface {
   template <typename V>
   const V* EvalInputValue(const ContextBase& context, int port_index) const {
     if (port_index < 0)
-      ThrowNegativeInputPortIndex(__func__, port_index);
+      ThrowNegativePortIndex(__func__, port_index);
     const InputPortIndex port(port_index);
 
     const AbstractValue* const abstract_value =
@@ -164,10 +166,22 @@ class SystemBase : public internal::SystemMessageInterface {
     return static_cast<int>(input_ports_.size());
   }
 
+  /** Returns the number of output ports currently allocated in this System.
+  These are indexed from 0 to %get_num_output_ports()-1. */
+  int get_num_output_ports() const {
+    return static_cast<int>(output_ports_.size());
+  }
+
   /** Returns a reference to an InputPort given its `port_index`.
   @pre `port_index` selects an existing input port of this System. */
   const InputPortBase& get_input_port_base(InputPortIndex port_index) const {
     return GetInputPortBaseOrThrow(__func__, port_index);
+  }
+
+  /** Returns a reference to an OutputPort given its `port_index`.
+  @pre `port_index` selects an existing output port of this System. */
+  const OutputPortBase& get_output_port_base(OutputPortIndex port_index) const {
+    return GetOutputPortBaseOrThrow(__func__, port_index);
   }
 
   /** Returns the total dimension of all of the vector-valued input ports (as if
@@ -175,6 +189,14 @@ class SystemBase : public internal::SystemMessageInterface {
   int get_num_total_inputs() const {
     int count = 0;
     for (const auto& in : input_ports_) count += in->size();
+    return count;
+  }
+
+  /** Returns the total dimension of all of the vector-valued output ports (as
+  if they were muxed). */
+  int get_num_total_outputs() const {
+    int count = 0;
+    for (const auto& out : output_ports_) count += out->size();
     return count;
   }
 
@@ -300,10 +322,13 @@ class SystemBase : public internal::SystemMessageInterface {
     the list `{nothing_ticket()}`; an explicitly empty list `{}` is forbidden.
   @returns a const reference to the newly-created %CacheEntry.
   @throws std::logic_error if given an explicitly empty prerequisite list. */
+  // Arguments to these methods are moved from internally. Taking them by value
+  // rather than reference avoids a copy when the original argument is
+  // an rvalue.
   const CacheEntry& DeclareCacheEntry(
       std::string description, CacheEntry::AllocCallback alloc_function,
       CacheEntry::CalcCallback calc_function,
-      std::vector<DependencyTicket> prerequisites_of_calc = {
+      std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
   /** Declares a cache entry by specifying member functions to use both for the
@@ -323,7 +348,7 @@ class SystemBase : public internal::SystemMessageInterface {
       std::string description,
       ValueType (MySystem::*make)() const,
       void (MySystem::*calc)(const MyContext&, ValueType*) const,
-      std::vector<DependencyTicket> prerequisites_of_calc = {
+      std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
   /** Declares a cache entry by specifying a model value of concrete type
@@ -342,7 +367,7 @@ class SystemBase : public internal::SystemMessageInterface {
   const CacheEntry& DeclareCacheEntry(
       std::string description, const ValueType& model_value,
       void (MySystem::*calc)(const MyContext&, ValueType*) const,
-      std::vector<DependencyTicket> prerequisites_of_calc = {
+      std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
 
   /** Declares a cache entry by specifying only a calculator function that is a
@@ -370,7 +395,7 @@ class SystemBase : public internal::SystemMessageInterface {
   const CacheEntry& DeclareCacheEntry(
       std::string description,
       void (MySystem::*calc)(const MyContext&, ValueType*) const,
-      std::vector<DependencyTicket> prerequisites_of_calc = {
+      std::set<DependencyTicket> prerequisites_of_calc = {
           all_sources_ticket()});
   //@}
 
@@ -393,9 +418,9 @@ class SystemBase : public internal::SystemMessageInterface {
 
   Use these tickets to declare well-known sources as prerequisites of a
   downstream computation such as an output port, derivative, update, or cache
-  entry. The ticket numbers for these sources are the same for all subsystems.
+  entry. The ticket numbers for these sources are the same for all systems.
   For time and accuracy they refer to the same global resource; otherwise they
-  refer to the specified sources within the referencing subsystem.
+  refer to the specified sources within the referencing system.
 
   A dependency ticket for a more specific resource (a particular input or
   output port, a discrete variable group, abstract state variable, a parameter,
@@ -420,13 +445,13 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** Returns a ticket indicating dependence on time. This is the same ticket
-  for all subsystems and refers to the same time value. */
+  for all systems and refers to the same time value. */
   static DependencyTicket time_ticket() {
     return DependencyTicket(internal::kTimeTicket);
   }
 
   /** Returns a ticket indicating dependence on the accuracy setting in the
-  Context. This is the same ticket for all subsystems and refers to the same
+  Context. This is the same ticket for all systems and refers to the same
   accuracy value. */
   static DependencyTicket accuracy_ticket() {
     return DependencyTicket(internal::kAccuracyTicket);
@@ -470,7 +495,7 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** Returns a ticket indicating dependence on _all_ state variables x in this
-  subsystem, including continuous variables xc, discrete (numeric) variables xd,
+  system, including continuous variables xc, discrete (numeric) variables xd,
   and abstract state variables xa. This does not imply dependence on time,
   parameters, or inputs; those must be specified separately. If you mean to
   express dependence on all possible value sources, use all_sources_ticket()
@@ -518,13 +543,13 @@ class SystemBase : public internal::SystemMessageInterface {
   }
 
   /** Returns a ticket indicating dependence on _all_ parameters p in this
-  subsystem, including numeric parameters pn, and abstract parameters pa. */
+  system, including numeric parameters pn, and abstract parameters pa. */
   static DependencyTicket all_parameters_ticket() {
     return DependencyTicket(internal::kAllParametersTicket);
   }
 
   /** Returns a ticket indicating dependence on _all_ input ports u of this
-  subsystem. */
+  system. */
   static DependencyTicket all_input_ports_ticket() {
     return DependencyTicket(internal::kAllInputPortsTicket);
   }
@@ -537,6 +562,14 @@ class SystemBase : public internal::SystemMessageInterface {
     return input_ports_[index]->ticket();
   }
 
+  /** Returns a ticket indicating dependence on the output port indicated
+  by `index`.
+  @pre `index` selects an existing output port of this System. */
+  DependencyTicket output_port_ticket(OutputPortIndex index) {
+    DRAKE_DEMAND(0 <= index && index < get_num_output_ports());
+    return output_ports_[index]->ticket();
+  }
+
   /** Returns a ticket indicating dependence on the cache entry indicated
   by `index`.
   @pre `index` selects an existing cache entry in this System. */
@@ -547,36 +580,51 @@ class SystemBase : public internal::SystemMessageInterface {
   //@}
 
  protected:
+  /** (Internal use only) Default constructor. */
   SystemBase() = default;
 
-  /** Adds an already-constructed input port to this System. Insists that the
-  port already contains a reference to this System, and that the port's index is
-  already set to the next available input port index for this System. */
+  /** (Internal use only) Adds an already-constructed input port to this System.
+  Insists that the port already contains a reference to this System, and that
+  the port's index is already set to the next available input port index for
+  this System. */
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
-  void CreateInputPort(std::unique_ptr<InputPortBase> port) {
+  void AddInputPort(std::unique_ptr<InputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
     DRAKE_DEMAND(&port->get_system_base() == this);
     DRAKE_DEMAND(port->get_index() == this->get_num_input_ports());
     input_ports_.push_back(std::move(port));
   }
 
-  /** Returns a pointer to the service interface of the immediately enclosing
-  Diagram if one has been set, otherwise nullptr. */
+  /** (Internal use only) Adds an already-constructed output port to this
+  System. Insists that the port already contains a reference to this System, and
+  that the port's index is already set to the next available output port index
+  for this System. */
+  // TODO(sherm1) Add check on suitability of `size` parameter for the port's
+  // data type.
+  void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
+    DRAKE_DEMAND(port != nullptr);
+    DRAKE_DEMAND(&port->get_system_base() == this);
+    DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
+    output_ports_.push_back(std::move(port));
+  }
+
+  /** (Internal use only) Returns a pointer to the service interface of the
+  immediately enclosing Diagram if one has been set, otherwise nullptr. */
   const internal::SystemParentServiceInterface* get_parent_service() const {
     return parent_service_;
   }
 
-  /** Assigns the next unused dependency ticket number, unique only within a
-  particular subsystem. Each call to this method increments the ticket
-  number. */
+  /** (Internal use only) Assigns the next unused dependency ticket number,
+  unique only within a particular system. Each call to this method increments
+  the ticket number. */
   DependencyTicket assign_next_dependency_ticket() {
     return next_available_ticket_++;
   }
 
-  /** Declares that `parent_service` is the service interface of the Diagram
-  that owns this subsystem. Aborts if the parent service has already been set to
-  something else. */
+  /** (Internal use only) Declares that `parent_service` is the service
+  interface of the Diagram that owns this subsystem. Aborts if the parent
+  service has already been set to something else. */
   // Use static method so Diagram can invoke this on behalf of a child.
   // Output argument is listed first because it is serving as the 'this'
   // pointer here.
@@ -587,37 +635,43 @@ class SystemBase : public internal::SystemMessageInterface {
     child->set_parent_service(parent_service);
   }
 
-  /** Allows Diagram to use private MakeContext() to invoke the same method
-  on its children. */
+  /** (Internal use only) Allows Diagram to use private MakeContext() to invoke
+  the same method on its children. */
   static std::unique_ptr<ContextBase> MakeContext(const SystemBase& system) {
     return system.MakeContext();
   }
 
-  /** Allows Diagram to use its private ValidateAllocatedContext() to invoke the
-  same method on its children. */
+  /** (Internal use only) Allows Diagram to use its private
+  ValidateAllocatedContext() to invoke the same method on its children. */
   static void ValidateAllocatedContext(const SystemBase& system,
                                        const ContextBase& context) {
     system.ValidateAllocatedContext(context);
   }
 
-  /** Shared code for updating an input port and returning a pointer to its
-  abstract value, or nullptr if the port is not connected. `func` should
-  be the user-visible API function name obtained with __func__. */
+  /** (Internal use only) Shared code for updating an input port and returning a
+  pointer to its abstract value, or nullptr if the port is not connected. `func`
+  should be the user-visible API function name obtained with __func__. */
   const AbstractValue* EvalAbstractInputImpl(const char* func,
                                              const ContextBase& context,
                                              InputPortIndex port_index) const;
 
-  /** Throws std::out_of_range to report a negative input `port_index` that was
-  passed to API method `func`. */
-  // We're taking an int here for the index; InputPortIndex can't be negative.
-  [[noreturn]] void ThrowNegativeInputPortIndex(const char* func,
-                                                int port_index) const;
+  /** Throws std::out_of_range to report a negative `port_index` that was
+  passed to API method `func`. Caller must ensure that the function name
+  makes it clear what kind of port we're complaining about. */
+  // We're taking an int here for the index; InputPortIndex and OutputPortIndex
+  // can't be negative.
+  [[noreturn]] void ThrowNegativePortIndex(const char* func,
+                                           int port_index) const;
 
-  /** Throws std::out_of_range to report bad `port_index` that was passed to
-  API method `func`. */
-  [[noreturn]] void ThrowInputPortIndexOutOfRange(const char* func,
-                                                  InputPortIndex port_index,
-                                                  int num_input_ports) const;
+  /** Throws std::out_of_range to report bad input `port_index` that was passed
+  to API method `func`. */
+  [[noreturn]] void ThrowInputPortIndexOutOfRange(
+      const char* func, InputPortIndex port_index) const;
+
+  /** Throws std::out_of_range to report bad output `port_index` that was passed
+  to API method `func`. */
+  [[noreturn]] void ThrowOutputPortIndexOutOfRange(
+      const char* func, OutputPortIndex port_index) const;
 
   /** Throws std::logic_error because someone misused API method `func`, that is
   only allowed for declared-vector input ports, on an abstract port whose
@@ -637,18 +691,32 @@ class SystemBase : public internal::SystemMessageInterface {
   [[noreturn]] void ThrowCantEvaluateInputPort(const char* func,
                                                InputPortIndex port_index) const;
 
-  /** Returns the InputPortBase at index `port_index`, throwing
-  std::out_of_range we don't like the port index. The name of the public API
-  method that received the bad index is provided in `func` and is included
-  in the error message. */
+  /** (Internal use only) Returns the InputPortBase at index `port_index`,
+  throwing std::out_of_range we don't like the port index. The name of the
+  public API method that received the bad index is provided in `func` and is
+  included in the error message. */
   const InputPortBase& GetInputPortBaseOrThrow(const char* func,
                                                int port_index) const {
     if (port_index < 0)
-      ThrowNegativeInputPortIndex(func, port_index);
+      ThrowNegativePortIndex(func, port_index);
     const InputPortIndex port(port_index);
     if (port_index >= get_num_input_ports())
-      ThrowInputPortIndexOutOfRange(func, port, get_num_input_ports());
+      ThrowInputPortIndexOutOfRange(func, port);
     return *input_ports_[port];
+  }
+
+  /** (Internal use only) Returns the OutputPortBase at index `port_index`,
+  throwing std::out_of_range we don't like the port index. The name of the
+  public API method that received the bad index is provided in `func` and is
+  included in the error message. */
+  const OutputPortBase& GetOutputPortBaseOrThrow(const char* func,
+                                                 int port_index) const {
+    if (port_index < 0)
+      ThrowNegativePortIndex(func, port_index);
+    const OutputPortIndex port(port_index);
+    if (port_index >= get_num_output_ports())
+      ThrowOutputPortIndexOutOfRange(func, port);
+    return *output_ports_[port_index];
   }
 
   /** Derived class implementations should allocate a suitable
@@ -702,7 +770,8 @@ class SystemBase : public internal::SystemMessageInterface {
 
   // Indexed by InputPortIndex.
   std::vector<std::unique_ptr<InputPortBase>> input_ports_;
-  // TODO(sherm1) Output ports go here.
+  // Indexed by OutputPortIndex.
+  std::vector<std::unique_ptr<OutputPortBase>> output_ports_;
   // Indexed by CacheIndex.
   std::vector<std::unique_ptr<CacheEntry>> cache_entries_;
 
@@ -717,7 +786,7 @@ class SystemBase : public internal::SystemMessageInterface {
   // The enclosing Diagram. Null/invalid when this is the root system.
   const internal::SystemParentServiceInterface* parent_service_{nullptr};
 
-  // Name of this subsystem.
+  // Name of this system.
   std::string name_;
 };
 
@@ -729,7 +798,7 @@ const CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description,
     ValueType (MySystem::*make)() const,
     void (MySystem::*calc)(const MyContext&, ValueType*) const,
-    std::vector<DependencyTicket> prerequisites_of_calc) {
+    std::set<DependencyTicket> prerequisites_of_calc) {
   static_assert(std::is_base_of<SystemBase, MySystem>::value,
                 "Expected to be invoked from a SystemBase-derived System.");
   static_assert(std::is_base_of<ContextBase, MyContext>::value,
@@ -757,7 +826,7 @@ template <class MySystem, class MyContext, typename ValueType>
 const CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description, const ValueType& model_value,
     void (MySystem::*calc)(const MyContext&, ValueType*) const,
-    std::vector<DependencyTicket> prerequisites_of_calc) {
+    std::set<DependencyTicket> prerequisites_of_calc) {
   static_assert(std::is_base_of<SystemBase, MySystem>::value,
                 "Expected to be invoked from a SystemBase-derived System.");
   static_assert(std::is_base_of<ContextBase, MyContext>::value,
@@ -792,7 +861,7 @@ template <class MySystem, class MyContext, typename ValueType>
 const CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description,
     void (MySystem::*calc)(const MyContext&, ValueType*) const,
-    std::vector<DependencyTicket> prerequisites_of_calc) {
+    std::set<DependencyTicket> prerequisites_of_calc) {
   static_assert(std::is_base_of<SystemBase, MySystem>::value,
                 "Expected to be invoked from a SystemBase-derived System.");
   static_assert(std::is_base_of<ContextBase, MyContext>::value,

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -654,6 +654,24 @@ TEST_F(DiagramTest, CalcOutput) {
   ExpectDefaultOutputs();
 }
 
+// Tests that Diagram output ports are built with the right prerequisites
+// and that Eval caches as expected.
+TEST_F(DiagramTest, EvalOutput) {
+  AttachInputs();
+
+  // Sanity check output port prerequisites. Diagram ports should designate
+  // a subsystem since they are resolved internally. We don't know the right
+  // dependency ticket, but at least it should be valid.
+  ASSERT_EQ(diagram_->get_num_output_ports(), 3);
+  const int expected_subsystem[] = {1, 2, 5};  // From drawing above.
+  for (OutputPortIndex i(0); i < diagram_->get_num_output_ports(); ++i) {
+    internal::OutputPortPrerequisite prereq =
+        diagram_->get_output_port(i).GetPrerequisite();
+    EXPECT_EQ(*prereq.child_subsystem, expected_subsystem[i]);
+    EXPECT_TRUE(prereq.dependency.is_valid());
+  }
+}
+
 TEST_F(DiagramTest, CalcTimeDerivatives) {
   AttachInputs();
   std::unique_ptr<ContinuousState<double>> derivatives =

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/never_destroyed.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/diagram_builder.h"
@@ -19,12 +20,12 @@
 #include "drake/systems/framework/system.h"
 #include "drake/systems/framework/test_utilities/my_vector.h"
 #include "drake/systems/framework/value.h"
-#include "drake/systems/primitives/constant_vector_source.h"
 
 namespace drake {
 namespace systems {
 namespace {
 
+using Eigen::Vector2d;
 using Eigen::Vector3d;
 using std::string;
 using std::unique_ptr;
@@ -35,7 +36,125 @@ class DummySystem : public LeafSystem<double> {
  public:
   DummySystem() {}
   ~DummySystem() override {}
+  using SystemBase::assign_next_dependency_ticket;
 };
+
+// The only concrete output ports we expect to encounter are LeafOutputPort
+// and DiagramOutputPort. Those are well behaved so don't trigger some of the
+// base class error messages. Hence this feeble port. Derived classes will
+// introduce errors.
+class MyOutputPort : public OutputPort<double> {
+ public:
+  MyOutputPort(const System<double>* diagram, SystemBase* system_base,
+               OutputPortIndex index, DependencyTicket ticket)
+      : OutputPort<double>(diagram, system_base, index, ticket, kVectorValued,
+                           2) {}
+
+  std::unique_ptr<AbstractValue> DoAllocate() const override {
+    return AbstractValue::Make<BasicVector<double>>(
+        MyVector2d(Vector2d(1., 2.)));
+  }
+
+  void DoCalc(const Context<double>& diagram_context,
+              AbstractValue* value) const override {
+    EXPECT_NE(value, nullptr);
+    EXPECT_NO_THROW(value->SetValueOrThrow<BasicVector<double>>(
+        MyVector2d(Vector2d(3., 4.))));
+  }
+
+  const AbstractValue& DoEval(const Context<double>& context) const override {
+    // This is a fake cache entry for Eval to "update".
+    static never_destroyed<std::unique_ptr<AbstractValue>> temp(Allocate());
+    Calc(context, temp.access().get());
+    return *temp.access();
+  }
+
+  // We won't call this.
+  internal::OutputPortPrerequisite DoGetPrerequisite() const override {
+    DRAKE_ABORT();
+  };
+};
+
+class MyStringAllocatorPort : public MyOutputPort {
+ public:
+  using MyOutputPort::MyOutputPort;
+
+  // Allocator returns string but should have returned BasicVector.
+  std::unique_ptr<AbstractValue> DoAllocate() const override {
+    return AbstractValue::Make<std::string>("hello");
+  }
+};
+
+class MyBadSizeAllocatorPort : public MyOutputPort {
+ public:
+  using MyOutputPort::MyOutputPort;
+
+  // Allocator returns 3-element vector but should have returned 2-element.
+  std::unique_ptr<AbstractValue> DoAllocate() const override {
+    return AbstractValue::Make<BasicVector<double>>(
+        MyVector3d(Vector3d(1., 2., 3.)));
+  }
+};
+
+class MyNullAllocatorPort : public MyOutputPort {
+ public:
+  using MyOutputPort::MyOutputPort;
+
+  // Allocator returns nullptr.
+  std::unique_ptr<AbstractValue> DoAllocate() const override { return nullptr; }
+};
+
+// These "bad allocator" messages are likely to be caught earlier by
+// LeafOutputPort when it delegates to cache entries. These base class messages
+// may issue in case of (a) future addition of uncached concrete output ports,
+// or (b) implementation changes to existing ports or error handling in caching.
+GTEST_TEST(TestBaseClass, BadAllocators) {
+  DummySystem dummy;
+  MyStringAllocatorPort string_allocator{&dummy, &dummy, OutputPortIndex(0),
+                                         dummy.assign_next_dependency_ticket()};
+  MyBadSizeAllocatorPort bad_size_allocator{
+      &dummy, &dummy, OutputPortIndex(1),
+      dummy.assign_next_dependency_ticket()};
+  MyNullAllocatorPort null_allocator{&dummy, &dummy, OutputPortIndex(2),
+                                     dummy.assign_next_dependency_ticket()};
+
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
+      string_allocator.Allocate(), std::logic_error,
+      "OutputPort::Allocate().*expected BasicVector.*but got.*std::string"
+      ".*OutputPort\\[0\\].*");
+  DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
+      bad_size_allocator.Allocate(), std::logic_error,
+      "OutputPort::Allocate().*expected vector.*size 2.*but got.*size 3"
+      ".*OutputPort\\[1\\].*");
+
+  // Nullptr check is unconditional.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      null_allocator.Allocate(), std::logic_error,
+      "OutputPort::Allocate().*nullptr.*OutputPort\\[2\\].*");
+}
+
+// This message can be caused by user action.
+GTEST_TEST(TestBaseClass, BadOutputType) {
+  DummySystem dummy;
+  MyOutputPort port{&dummy, &dummy, OutputPortIndex(0),
+                    dummy.assign_next_dependency_ticket()};
+  auto context = dummy.AllocateContext();
+  auto good_port_value = port.Allocate();
+  auto bad_port_value = AbstractValue::Make<std::string>("hi there");
+
+  EXPECT_NO_THROW(port.Calc(*context, good_port_value.get()));
+
+// This message is thrown in Debug. In Release some other error may trigger
+// but not from OutputPort, so we can't use
+// DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED() which would insist that if any
+// message is thrown in Release it must be the expected one.
+#ifndef DRAKE_ASSERT_IS_DISARMED
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      port.Calc(*context, bad_port_value.get()), std::logic_error,
+      "OutputPort::Calc().*expected.*MyVector.*but got.*std::string"
+      ".*OutputPort\\[0\\].*");
+#endif
+}
 
 // These functions match the signatures required by LeafOutputPort.
 
@@ -51,57 +170,43 @@ unique_ptr<AbstractValue> alloc_myvector3() {
 }
 
 // CalcCallback that expects to have a string to write on.
-void calc_string(const Context<double>& context, AbstractValue* value) {
+void calc_string(const ContextBase&, AbstractValue* value) {
   ASSERT_NE(value, nullptr);
   string& str_value = value->GetMutableValueOrThrow<string>();
   str_value = "from calc_string";
 }
 
 // CalcVectorCallback sets the 3-element output vector to 99,100,101.
-void calc_vector3(const Context<double>& context, BasicVector<double>* value) {
+void calc_vector3(const ContextBase&, AbstractValue* value) {
   ASSERT_NE(value, nullptr);
-  EXPECT_EQ(value->size(), 3);
-  value->set_value(Vector3d(99., 100., 101.));
-}
-
-// EvalCallback returning a string.
-const AbstractValue& eval_string(const Context<double>& context) {
-  static const never_destroyed<Value<string>> fake_cache(
-      string("from eval_string"));
-  return fake_cache.access();
-}
-
-// EvalCallback returning a MyVector3d(3,1,4).
-const AbstractValue& eval_vector3(const Context<double>& context) {
-  static const never_destroyed<Value<BasicVector<double>>> fake_cache(
-      *MyVector3d::Make(3., 1., 4.));
-  return fake_cache.access();
+  auto& vec = value->template GetMutableValueOrThrow<BasicVector<double>>();
+  EXPECT_EQ(vec.size(), 3);
+  vec.set_value(Vector3d(99., 100., 101.));
 }
 
 // This class creates some isolated ports we can play with. They are not
 // actually part of a System. There are lots of tests of Systems that have
 // output ports elsewhere; that's not what we're trying to test here.
 class LeafOutputPortTest : public ::testing::Test {
- public:
-  void SetUp() override {
-    // TODO(sherm1) Eval methods should be generated automatically if not set.
-    // This is just testing the basic wiring.
-    absport_general_.set_evaluation_function(eval_string);
-    vecport_general_.set_evaluation_function(eval_vector3);
-  }
-
  protected:
-  systems::ConstantVectorSource<double> source_{Vector3d(3., -3., 0.)};
-  unique_ptr<Context<double>> context_{source_.CreateDefaultContext()};
-
   // Create abstract- and vector-valued ports.
   DummySystem dummy_;
+  // TODO(sherm1) Use implicit_cast when available (from abseil).
   LeafOutputPort<double> absport_general_{
-    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
-    alloc_string, calc_string};
+      &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
+      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      OutputPortIndex(dummy_.get_num_output_ports()),
+      dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
+      &dummy_.DeclareCacheEntry(
+          "absport", alloc_string, calc_string)};
   LeafOutputPort<double> vecport_general_{
-    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
-    3, alloc_myvector3, calc_vector3};
+      &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
+      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      OutputPortIndex(dummy_.get_num_output_ports()),
+      dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
+      &dummy_.DeclareCacheEntry(
+          "vecport", alloc_myvector3, calc_vector3)};
+  unique_ptr<Context<double>> context_{dummy_.CreateDefaultContext()};
 };
 
 // Helper function for testing an abstract-valued port.
@@ -112,8 +217,12 @@ void AbstractPortCheck(const Context<double>& context,
   EXPECT_EQ(val->GetValueOrThrow<string>(), alloc_string);
   port.Calc(context, val.get());
   EXPECT_EQ(val->GetValueOrThrow<string>(), string("from calc_string"));
-  const AbstractValue& val_cached = port.Eval(context);
-  EXPECT_EQ(val_cached.GetValueOrThrow<string>(), string("from eval_string"));
+  EXPECT_EQ(port.Eval<string>(context), string("from calc_string"));
+
+  // Can't Eval into the wrong type.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      port.Eval<int>(context), std::logic_error,
+      "OutputPort::Eval().*wrong value type int.*actual type.*std::string.*");
 }
 
 // Check for proper construction and functioning of abstract LeafOutputPorts.
@@ -153,10 +262,18 @@ unique_ptr<AbstractValue> alloc_null() {
 // The null check is done in all builds.
 TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
   // Create an abstract port with an allocator that returns null.
+  // TODO(sherm1) Use implicit_cast when available (from abseil).
   LeafOutputPort<double> null_port{
-    dummy_, dummy_, OutputPortIndex{dummy_.get_num_output_ports()},
-    alloc_null, calc_string};
-  EXPECT_THROW(null_port.Allocate(), std::logic_error);
+      &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
+      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      OutputPortIndex(dummy_.get_num_output_ports()),
+      dummy_.assign_next_dependency_ticket(),
+      kAbstractValued, 0 /* size */,
+      &dummy_.DeclareCacheEntry("null", alloc_null, calc_string)};
+
+  // Creating a context for this system should fail when it tries to allocate
+  // a cache entry for null_port.
+  EXPECT_THROW(dummy_.CreateDefaultContext(), std::logic_error);
 }
 
 // Check that Debug builds catch bad output types. We can't run these tests
@@ -168,15 +285,17 @@ TEST_F(LeafOutputPortTest, ThrowIfBadCalcOutput) {
   auto good_out = absport_general_.Allocate();
   auto bad_out = AbstractValue::Make<int>(5);
   EXPECT_NO_THROW(absport_general_.Calc(*context_, good_out.get()));
-  EXPECT_THROW(absport_general_.Calc(*context_, bad_out.get()),
-               std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      absport_general_.Calc(*context_, bad_out.get()), std::logic_error,
+      "OutputPort::Calc().*expected.*std::string.*got.*int.*");
 
-  // The vector port is a MyVector<3,double>, we'll give it a shorter one.
+  // The vector port is a MyVector<3,double>, we'll give it a BasicVector.
   auto good_vec = vecport_general_.Allocate();
   auto bad_vec = AbstractValue::Make(BasicVector<double>(2));
   EXPECT_NO_THROW(vecport_general_.Calc(*context_, good_vec.get()));
-  EXPECT_THROW(vecport_general_.Calc(*context_, bad_vec.get()),
-               std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      vecport_general_.Calc(*context_, bad_vec.get()), std::logic_error,
+      "OutputPort::Calc().*expected.*MyVector.*got.*BasicVector.*");
 }
 #endif
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -24,6 +24,11 @@ namespace {
 
 const int kSize = 3;
 
+// Note that Systems in this file are derived directly from drake::System for
+// testing purposes. User Systems should be derived only from LeafSystem which
+// handles much of the bookkeeping you'll see here, and won't need to call
+// methods that are intended only for internal use.
+
 // A shell System to test the default implementations.
 class TestSystem : public System<double> {
  public:
@@ -66,13 +71,21 @@ class TestSystem : public System<double> {
   }
 
   const LeafOutputPort<double>& AddAbstractOutputPort() {
-    // Create an abstract output port with no allocator or calculator.
+    // Create an abstract output port with dummy alloc and calc.
+    const CacheEntry& cache_entry = this->DeclareCacheEntry(
+        "null output port",
+        [] { return Value<int>::Make(0); },
+        [](const ContextBase&, AbstractValue*) {});
+    // TODO(sherm1) Use implicit_cast when available (from abseil). Several
+    // places in this test.
     auto port = std::make_unique<LeafOutputPort<double>>(
-        *this, *this, OutputPortIndex(get_num_output_ports()),
-        typename LeafOutputPort<double>::AllocCallback(nullptr),
-        typename LeafOutputPort<double>::CalcCallback(nullptr));
+        this,  // implicit_cast<const System<T>*>(this)
+        this,  // implicit_cast<const SystemBase*>(this)
+        OutputPortIndex(this->get_num_output_ports()),
+        assign_next_dependency_ticket(),
+        kAbstractValued, 0, &cache_entry);
     LeafOutputPort<double>* const port_ptr = port.get();
-    this->CreateOutputPort(std::move(port));
+    this->AddOutputPort(std::move(port));
     return *port_ptr;
   }
 
@@ -413,27 +426,33 @@ class ValueIOTestSystem : public System<T> {
         this->AllocateForcedUnrestrictedUpdateEventCollection());
 
     this->DeclareAbstractInputPort();
-    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
-        *this, *this, OutputPortIndex(this->get_num_output_ports()),
-        []() { return AbstractValue::Make(std::string()); },
-        [this](const Context<T>& context, AbstractValue* output) {
-          this->CalcStringOutput(context, output);
-        }));
-
+    this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
+        this,  // implicit_cast<const System<T>*>(this)
+        this,  // implicit_cast<const SystemBase*>(this)
+        OutputPortIndex(this->get_num_output_ports()),
+        this->assign_next_dependency_ticket(),
+        kAbstractValued, 0 /* size */,
+        &this->DeclareCacheEntry(
+            "absport",
+            []() { return AbstractValue::Make(std::string()); },
+            [this](const ContextBase& context, AbstractValue* output) {
+              this->CalcStringOutput(context, output);
+            })));
     this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareInputPort(kVectorValued, 1,
-                           RandomDistribution::kUniform);
-    this->DeclareInputPort(kVectorValued, 1,
-                           RandomDistribution::kGaussian);
-    this->CreateOutputPort(std::make_unique<LeafOutputPort<T>>(
-        *this, *this, OutputPortIndex(this->get_num_output_ports()),
-        1,  // Vector size.
-        []() {
-          return std::make_unique<Value<BasicVector<T>>>(1);
-        },
-        [this](const Context<T>& context, BasicVector<T>* output) {
-          this->CalcVectorOutput(context, output);
-        }));
+    this->DeclareInputPort(kVectorValued, 1, RandomDistribution::kUniform);
+    this->DeclareInputPort(kVectorValued, 1, RandomDistribution::kGaussian);
+    this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
+        this,  // implicit_cast<const System<T>*>(this)
+        this,  // implicit_cast<const SystemBase*>(this)
+        OutputPortIndex(this->get_num_output_ports()),
+        this->assign_next_dependency_ticket(),
+        kVectorValued, 1 /* size */,
+        &this->DeclareCacheEntry(
+            "vecport",
+            []() { return std::make_unique<Value<BasicVector<T>>>(1); },
+            [this](const ContextBase& context, AbstractValue* output) {
+              this->CalcVectorOutput(context, output);
+            })));
 
     this->set_name("ValueIOTestSystem");
   }
@@ -468,7 +487,7 @@ class ValueIOTestSystem : public System<T> {
   }
 
   std::unique_ptr<ContinuousState<T>> AllocateTimeDerivatives() const override {
-    return nullptr;
+    return std::make_unique<ContinuousState<T>>();
   }
 
   std::unique_ptr<ContextBase> DoMakeContext() const final {
@@ -500,7 +519,7 @@ class ValueIOTestSystem : public System<T> {
   }
 
   // Appends "output" to input(0) for output(0).
-  void CalcStringOutput(const Context<T>& context,
+  void CalcStringOutput(const ContextBase& context,
                         AbstractValue* output) const {
     const std::string* str_in =
         this->template EvalInputValue<std::string>(context, 0);
@@ -510,10 +529,12 @@ class ValueIOTestSystem : public System<T> {
   }
 
   // Sets output(1) = 2 * input(1).
-  void CalcVectorOutput(const Context<T>& context,
-                        BasicVector<T>* vec_out) const {
+  void CalcVectorOutput(const ContextBase& context_base,
+                        AbstractValue* output) const {
+    const Context<T>& context = dynamic_cast<const Context<T>&>(context_base);
     const BasicVector<T>* vec_in = this->EvalVectorInput(context, 1);
-    vec_out->get_mutable_value() = 2 * vec_in->get_value();
+    auto& vec_out = output->template GetMutableValue<BasicVector<T>>();
+    vec_out.get_mutable_value() = 2 * vec_in->get_value();
   }
 
   std::unique_ptr<SystemOutput<T>> AllocateOutput(
@@ -651,7 +672,7 @@ TEST_F(SystemInputErrorTest, CheckMessages) {
   EXPECT_NO_THROW(system_.EvalInputValue<BasicVector<double>>(*context_, 1));
   DRAKE_EXPECT_THROWS_MESSAGE_IF_ARMED(
       system_.EvalInputValue<int>(*context_, 1), std::logic_error,
-      ".*EvalInputValue.*expected.*int.*input port.*1.*actual.*BasicVector.*");
+      ".*EvalInputValue.*expected.*int.*input port.*1.*actual.*MyVector.*");
 
   // Now induce errors that only apply to abstract-valued input ports.
 

--- a/systems/framework/test/value_test.cc
+++ b/systems/framework/test/value_test.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/test_utilities/my_vector.h"
 
 namespace drake {
 namespace systems {
@@ -151,9 +152,28 @@ TYPED_TEST(TypedValueTest, Make) {
 GTEST_TEST(ValueTest, NiceTypeName) {
   auto double_value = AbstractValue::Make<double>(3.);
   auto string_value = AbstractValue::Make<std::string>("hello");
+  auto base_value =
+      std::make_unique<Value<BasicVector<double>>>(MyVector2d::Make(1., 2.));
 
   EXPECT_EQ(double_value->GetNiceTypeName(), "double");
   EXPECT_EQ(string_value->GetNiceTypeName(), "std::string");
+
+  // Must return the name of the most-derived type.
+  EXPECT_EQ(base_value->GetNiceTypeName(),
+            "drake::systems::MyVector<2,double>");
+}
+
+GTEST_TEST(ValueTest, TypeInfo) {
+  auto double_value = AbstractValue::Make<double>(3.);
+  auto string_value = AbstractValue::Make<std::string>("hello");
+  auto base_value =
+      std::make_unique<Value<BasicVector<double>>>(MyVector2d::Make(1., 2.));
+
+  EXPECT_EQ(double_value->type_info(), typeid(double));
+  EXPECT_EQ(string_value->type_info(), typeid(std::string));
+
+  // Must return the typeid of the most-derived type.
+  EXPECT_EQ(base_value->type_info(), typeid(MyVector2d));
 }
 
 // Check that MaybeGetValue() returns nullptr for wrong-type requests,

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -180,7 +180,9 @@ TEST_F(VectorSystemTest, TopologyFailFast) {
   {  // A second output.
     TestVectorSystem dut;
     EXPECT_NO_THROW(dut.CreateDefaultContext());
-    dut.DeclareAbstractOutputPort(nullptr, nullptr);  // No alloc or calc.
+    dut.DeclareAbstractOutputPort(
+        []() { return AbstractValue::Make<int>(0); },  // Dummies.
+        [](const ContextBase&, AbstractValue*) {});
     EXPECT_THROW(dut.CreateDefaultContext(), std::exception);
   }
 

--- a/systems/framework/value.h
+++ b/systems/framework/value.h
@@ -118,9 +118,17 @@ class AbstractValue {
   /// Release builds.
   virtual void SetFromOrThrow(const AbstractValue& other) = 0;
 
+  /// Returns typeid of the contained object of type T. If T is polymorphic,
+  /// this returns the typeid of the most-derived type of the contained object.
+  virtual const std::type_info& type_info() const = 0;
+
   /// Returns a human-readable name for the underlying type T. This may be
-  /// slow but is useful for error messages.
-  virtual std::string GetNiceTypeName() const = 0;
+  /// slow but is useful for error messages. If T is polymorphic, this returns
+  /// the typeid of the most-derived type of the contained object.
+  std::string GetNiceTypeName() const {
+    return NiceTypeName::Canonicalize(
+        NiceTypeName::Demangle(type_info().name()));
+  }
 
   /// Returns the value wrapped in this AbstractValue, which must be of
   /// exactly type T.  T cannot be a superclass, abstract or otherwise.
@@ -342,8 +350,8 @@ class Value : public AbstractValue {
     value_ = Traits::to_storage(other.GetValueOrThrow<T>());
   }
 
-  std::string GetNiceTypeName() const override {
-    return NiceTypeName::Get<T>();
+  const std::type_info& type_info() const override {
+    return typeid(get_value());
   }
 
   /// Returns a const reference to the stored value.


### PR DESCRIPTION
This is another caching lemma extracted from #7668. 

Output ports required significant re-engineering to make them cacheable, too much for one PR. This is an attempt to carve off a reasonably coherent, reviewable chunk of that. 

```
Category            added  modified  removed  
----------------------------------------------
code                311    146       171      
comments            133    39        73       
blank               48     0         13       
----------------------------------------------
TOTAL               492    185       257      
```
Most of the new output port structure is here, but execution still runs through the old code (which will be removed in a subsequent PR), unless new code is invoked explicitly. Output port Eval() methods are now functional, but no actual caching of the computations is being done here.

- Splits OutputPort into `OutputPortBase` and `OutputPort<T>` parts (most of that is rote code motion with some minor cleanups).
- Move output ports to SystemBase (now parallel to input ports).
- Assigns a cache entry for every LeafOutputPort, allocates space for the value, and enables `output_port.Eval()` methods using the cache entry values. However, a hack here currently forces recalculation on every Eval() since invalidation propagation is not yet wired up.
- Assigns tickets and prerequisites (as yet unused).

I still need to add more unit tests here but I think it is ready for design and feature review. Please let me know if you think this is too much for one PR -- I wanted to make as few changes from the caching branch as possible to avoid busy work so there are likely some things I could have edited out (but would rather not).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8920)
<!-- Reviewable:end -->
