### PR TITLE
pydrake rbt: Add `FindBaseBodies`

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -152,7 +152,9 @@ PYBIND11_MODULE(rigid_body_tree, m) {
         }, py::arg("body"), py::arg("group_name")="")
     .def_readonly("B", &RigidBodyTree<double>::B)
     .def_readonly("joint_limit_min", &RigidBodyTree<double>::joint_limit_min)
-    .def_readonly("joint_limit_max", &RigidBodyTree<double>::joint_limit_max);
+    .def_readonly("joint_limit_max", &RigidBodyTree<double>::joint_limit_max)
+    .def("FindBaseBodies", &RigidBodyTree<double>::FindBaseBodies,
+         py::arg("model_instance_id") = -1);
 
   // This lambda defines RigidBodyTree methods which are defined for a given
   // templated type. The methods are either (a) direct explicit template

--- a/bindings/pydrake/multibody/test/parsers_test.py
+++ b/bindings/pydrake/multibody/test/parsers_test.py
@@ -4,6 +4,7 @@ import unittest
 import os.path
 
 from pydrake import getDrakePath
+from pydrake.common import FindResourceOrThrow
 from pydrake.multibody.parsers import PackageMap
 from pydrake.multibody.rigid_body_tree import (
     AddModelInstanceFromUrdfStringSearchingInRosPackages,
@@ -77,6 +78,20 @@ class TestParsers(unittest.TestCase):
         for robot in robot_1, robot_2, robot_3:
             expected_num_bodies = 4
             self.assertEqual(robot.get_num_bodies(), expected_num_bodies)
+
+    def test_id_table(self):
+        robot = RigidBodyTree()
+        id_table = AddModelInstancesFromSdfFile(
+            FindResourceOrThrow("drake/examples/acrobot/Acrobot.sdf"),
+            FloatingBaseType.kRollPitchYaw, None, robot)
+        # Check IDs.
+        (name, id), = id_table.items()
+        self.assertEqual(name, "Acrobot")
+        self.assertEqual(id, 0)
+        # Ensure that we have our desired base body.
+        base_body_id, = robot.FindBaseBodies(id)
+        expected_body_id = robot.FindBody("base_link").get_body_index()
+        self.assertEqual(base_body_id, expected_body_id)
 
     def test_package_map(self):
         pm = PackageMap()


### PR DESCRIPTION
Needed for Anzu usages for rendering

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8923)
<!-- Reviewable:end -->
