### PR TITLE
Implementation of collision filtering logic

### DIFF
--- a/geometry/geometry_set.h
+++ b/geometry/geometry_set.h
@@ -17,7 +17,7 @@ namespace geometry {
 
  This class does no validation; it is a simple collection. Ultimately, it serves
  as the operand of SceneGraph operations (e.g.,
- SceneGraph::DisallowSelfCollision()). If the _operation_ has a particular
+ SceneGraph::ExcludeCollisionsWithin()). If the _operation_ has a particular
  prerequisite on the members of a %GeometrySet, it is the operation's
  responsibility to enforce that requirement.
 
@@ -130,6 +130,12 @@ class GeometrySet {
 
   template <typename Container>
   explicit GeometrySet(const Container& geometries,
+                       std::initializer_list<FrameId> frames) {
+    Add(geometries);
+    Add(frames);
+  }
+
+  explicit GeometrySet(std::initializer_list<GeometryId> geometries,
                        std::initializer_list<FrameId> frames) {
     Add(geometries);
     Add(frames);

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -13,6 +13,7 @@
 #include "drake/geometry/frame_kinematics_vector.h"
 #include "drake/geometry/geometry_ids.h"
 #include "drake/geometry/geometry_index.h"
+#include "drake/geometry/geometry_set.h"
 #include "drake/geometry/internal_frame.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/proximity_engine.h"
@@ -384,6 +385,35 @@ class GeometryState {
 
   //@}
 
+  /** @name               Collision filters
+
+   This interface allows control over which pairs of geometries can even be
+   considered for collision.
+
+   See @ref scene_graph_collision_filtering "Scene Graph Collision Filtering"
+   for more details.   */
+  //@{
+
+  /** Excludes geometry pairs from collision evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` and
+   `G = {g₀, g₁, ..., gₘ}` is the input `set` of geometries.
+
+   @throws std::logic_error if the set includes ids that don't exist in the
+                            scene graph.  */
+  void ExcludeCollisionsWithin(const GeometrySet& set);
+
+  /** Excludes geometry pairs from collision evaluation by updating the
+   candidate pair set `C = C - P`, where `P = {(a, b)}, ∀ a ∈ A, b ∈ B` and
+   `A = {a₀, a₁, ..., aₘ}` and `B = {b₀, b₁, ..., bₙ}` are the input sets of
+   geometries `setA` and `setB`, respectively. This does _not_ preclude
+   collisions between members of the _same_ set.
+
+   @throws std::logic_error if the groups include ids that don't exist in the
+                            scene graph.   */
+  void ExcludeCollisionsBetween(const GeometrySet& setA,
+                                const GeometrySet& setB);
+  //@}
+
   /** @name Scalar conversion */
   //@{
 
@@ -443,6 +473,20 @@ class GeometryState {
   // Friend declaration so that the internals of the state can be confirmed in
   // unit tests.
   template <class U> friend class GeometryStateTester;
+
+  // Function to facilitate testing.
+  int peek_next_clique() const {
+    return internal::GeometryStateCollisionFilterAttorney::peek_next_clique(
+        *geometry_engine_);
+  }
+
+  // Takes the frame and geometry ids from the given geometry set and
+  // populates the sets of geometry *indices* for the dynamic and anchored
+  // geometries implied by the group. Ids that can't be identified will cause
+  // an exception to be thrown.
+  void CollectIndices(const GeometrySet& geometry_set,
+                      std::unordered_set<GeometryIndex>* dynamic,
+                      std::unordered_set<AnchoredGeometryIndex>* anchored);
 
   // Sets the kinematic poses for the frames indicated by the given ids.
   // @param poses The frame id and pose values.

--- a/geometry/identifier.h
+++ b/geometry/identifier.h
@@ -100,14 +100,14 @@ namespace geometry {
 
  In principle, the *identifier* is related to the TypeSafeIndex. In
  some sense, both are "type-safe" `int`s. They differ in their semantics. We can
- consider `ints`, indexes, and identifiers as a list of `int` types with
+ consider `ints`, indices, and identifiers as a list of `int` types with
  _decreasing_ functionality.
 
    - The int, obviously, has the full range of C++ ints.
    - The TypeSafeIndex can be implicitly cast *to* an int, but there are a
      limited number of operations _on_ the index that produce other instances
      of the index (e.g., increment, in-place addition, etc.) They can be
-     compared with `int` and other indexes of the same type. This behavior
+     compared with `int` and other indices of the same type. This behavior
      arises from the intention of having them serve as an _index_ in an
      ordered set (e.g., `std::vector`).
    - The Identifier is the most restricted. They exist solely to serve as a
@@ -116,7 +116,7 @@ namespace geometry {
      type, hashing, writing to output stream). These *cannot* be used as
      indices.
 
- Ultimately, indexes _can_ serve as identifiers (within the scope of the object
+ Ultimately, indices _can_ serve as identifiers (within the scope of the object
  they index into). Although, their mutability could make this a dangerous
  practice for a public API. Identifiers are more general in that they don't
  reflect an object's position in memory (hence the inability to transform to or

--- a/geometry/internal_frame.cc
+++ b/geometry/internal_frame.cc
@@ -10,13 +10,15 @@ InternalFrame::InternalFrame() {}
 
 InternalFrame::InternalFrame(SourceId source_id, FrameId frame_id,
                              const std::string& name, int frame_group,
-                             PoseIndex pose_index, FrameId parent_id)
+                             PoseIndex pose_index, FrameId parent_id,
+                             int clique)
     : source_id_(source_id),
       id_(frame_id),
       name_(name),
       frame_group_(frame_group),
       pose_index_(pose_index),
-      parent_id_(parent_id) {}
+      parent_id_(parent_id),
+      clique_(clique) {}
 
 bool InternalFrame::operator==(const InternalFrame& other) const {
   return id_ == other.id_;

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -34,9 +34,12 @@ class InternalFrame {
    @param pose_index    The position in the pose vector of this frame's last
                         known pose.
    @param parent_id     The id of the parent frame.
+   @param clique        The clique that will be used to prevent self-collision
+                        among geomtries rigidly affixed to this frame.
    */
   InternalFrame(SourceId source_id, FrameId frame_id, const std::string &name,
-                int frame_group, PoseIndex pose_index, FrameId parent_id);
+                int frame_group, PoseIndex pose_index, FrameId parent_id,
+                int clique);
 
   /** Compares two %InternalFrame instances for "equality". Two internal frames
    are considered equal if they have the same frame identifier. */
@@ -104,6 +107,9 @@ class InternalFrame {
     child_geometries_.erase(geometry_id);
   }
 
+  /** Returns the clique associated with this frame. */
+  int clique() const { return clique_; }
+
   static FrameId get_world_frame_id() { return kWorldFrame; }
 
  private:
@@ -138,6 +144,10 @@ class InternalFrame {
   // that were hung on geometries that were already rigidly affixed.
   // It does *not* include geometries hung on child frames.
   std::unordered_set<GeometryId> child_geometries_;
+
+  // The clique used to prevent self-collision among the geomtries affixed to
+  // this frame.
+  int clique_{};
 
   // The frame identifier of the world frame.
   static const FrameId kWorldFrame;

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -100,7 +100,7 @@ SceneGraph<T>::SceneGraph(const SceneGraph<U>& other) : SceneGraph() {
   }
   context_has_been_allocated_ = other.context_has_been_allocated_;
 
-  // We need to guarantee that the same source ids map to the same port indexes.
+  // We need to guarantee that the same source ids map to the same port indices.
   // We'll do this by processing the source ids in monotonically increasing
   // order. This is predicated on several principles:
   //   1. Port indices monotonically increase.
@@ -187,16 +187,16 @@ GeometryId SceneGraph<T>::RegisterAnchoredGeometry(
 }
 
 template <typename T>
-void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet&) {
+void SceneGraph<T>::ExcludeCollisionsWithin(const GeometrySet& geometry_set) {
   GS_THROW_IF_CONTEXT_ALLOCATED
-  // TODO(SeanCurtis-TRI): Implemented in the follow-up PR.
+  initial_state_->ExcludeCollisionsWithin(geometry_set);
 }
 
 template <typename T>
-void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet&,
-                                             const GeometrySet&) {
+void SceneGraph<T>::ExcludeCollisionsBetween(const GeometrySet& setA,
+                                             const GeometrySet& setB) {
   GS_THROW_IF_CONTEXT_ALLOCATED
-  // TODO(SeanCurtis-TRI): Implemented in the follow-up PR.
+  initial_state_->ExcludeCollisionsBetween(setA, setB);
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -359,6 +359,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
   //@}
 
   /** @name         Collision filtering
+   @anchor scene_graph_collision_filtering
    The interface for limiting the scope of penetration queries (i.e., "filtering
    collisions").
 
@@ -369,13 +370,13 @@ class SceneGraph final : public systems::LeafSystem<T> {
    candidate pairs is initially defined as `C = (G × G) - (A × A) - F - I`,
    where:
      - `G × G = {(gᵢ, gⱼ)}, ∀ gᵢ, gⱼ ∈ G` is the cartesian product of the set
-       of SceneGraph geometries.
+       of %SceneGraph geometries.
      - `A × A` represents all pairs consisting only of anchored geometry;
        anchored geometry is never tested against other anchored geometry.
      - `F = (gᵢ, gⱼ)`, such that `frame(gᵢ) == frame(gⱼ)`; the pair where both
        geometries are rigidly affixed to the same frame. By implication,
        `gᵢ, gⱼ ∈ D` as only dynamic geometries are affixed to frames.
-     - `I = {(g, g)}, ∀ g ∈ G` is the set of all pairs consisting a geometry
+     - `I = {(g, g)}, ∀ g ∈ G` is the set of all pairs consisting of a geometry
         with itself; there is no collision between a geometry and itself.
 
    Only pairs contained in C will be tested as part of penetration queries.

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -620,11 +620,7 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
       std::make_pair(ground_id, sphere1_id),
       std::make_pair(ground_id, sphere2_id),
       std::make_pair(ground_id, sphere3_id),
-      std::make_pair(sphere1_id, sphere3_id),
-      // TODO(SeanCurtis-TRI): These two pairs will disappear in the next PR
-      // when the filtering is fully implemented.
-      std::make_pair(sphere1_id, sphere2_id),
-      std::make_pair(sphere2_id, sphere3_id),
+      std::make_pair(sphere1_id, sphere3_id)
   };
   ASSERT_EQ(contacts.size(), expected_pairs.size());
 


### PR DESCRIPTION
1. ProximityEngine - the *core* functionality.
    - Declare and implement the filtering interface.
2. GeometryState:
    - Responsible for mapping GeometrySet into parameters for proximity engine collision filtering API.
    - Handle no collision between geometries attached to the same frame.
3. InternalFrame
    - Assign a clique for preventing child geometries from colliding
4. SceneGraph - invoke the GeometryState interface
5. MultibodyPlant
    - Update the test to account for filtering

```
Category            added  modified  removed  
----------------------------------------------
code                484    23        8        
comments            195    11        5        
blank               127    0         0        
----------------------------------------------
TOTAL               806    34        13  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8924)
<!-- Reviewable:end -->
