### PR TITLE
Add ModelInstance to multibody plant

### DIFF
--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -24,9 +24,11 @@ drake_cc_package_library(
 drake_cc_library(
     name = "multibody_plant_core",
     srcs = [
+        "model_instance.cc",
         "multibody_plant.cc",
     ],
     hdrs = [
+        "model_instance.h",
         "multibody_plant.h",
     ],
     visibility = ["//visibility:private"],
@@ -75,6 +77,14 @@ drake_cc_googletest(
         "//multibody/benchmarks/pendulum",
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/primitives:linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "model_instance_test",
+    deps = [
+        ":multibody_plant_core",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -25,10 +25,12 @@ drake_cc_library(
     name = "multibody_plant_core",
     srcs = [
         "model_instance.cc",
+        "model_instance_multiplexer.cc",
         "multibody_plant.cc",
     ],
     hdrs = [
         "model_instance.h",
+        "model_instance_multiplexer.h",
         "multibody_plant.h",
     ],
     visibility = ["//visibility:private"],
@@ -77,6 +79,19 @@ drake_cc_googletest(
         "//multibody/benchmarks/pendulum",
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/primitives:linear_system",
+    ],
+)
+
+drake_cc_googletest(
+    name = "model_instance_multiplexer_test",
+    data = [
+        "test/split_pendulum.sdf",
+        "//multibody/benchmarks/acrobot:models",
+    ],
+    deps = [
+        ":multibody_plant_core",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
     ],
 )
 

--- a/multibody/multibody_tree/multibody_plant/model_instance.cc
+++ b/multibody/multibody_tree/multibody_plant/model_instance.cc
@@ -1,0 +1,68 @@
+#include "drake/multibody/multibody_tree/multibody_plant/model_instance.h"
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+template <typename T>
+ModelInstance<T>::ModelInstance(
+    const std::vector<BodyIndex>& bodies,
+    const std::vector<JointActuatorIndex>& joint_actuators)
+    : bodies_(bodies),
+      joint_actuators_(joint_actuators) {
+}
+
+template <typename T>
+ModelInstance<T>::~ModelInstance() {}
+
+template <typename T>
+void ModelInstance<T>::Finalize(const MultibodyTree<T>& tree) {
+  if (!tree.topology_is_valid()) {
+    throw std::logic_error("The MultibodyTree must be finalized before "
+                           "calling ModelInstance::Finalize().");
+  }
+
+  num_tree_positions_ = tree.num_positions();
+  num_tree_velocities_ = tree.num_velocities();
+  num_tree_actuated_dofs_ = tree.num_actuated_dofs();
+
+  const MultibodyTreeTopology& topology = tree.get_topology();
+  for (const BodyIndex body_index : bodies_) {
+    const Body<T>& body = tree.get_body(body_index);
+    const BodyNodeTopology& node_topology =
+        topology.get_body_node(body.node_index());
+    for (int i = node_topology.mobilizer_positions_start;
+         i < node_topology.mobilizer_positions_start +
+             node_topology.num_mobilizer_positions; ++i) {
+      position_map_.push_back(i);
+      ++num_positions_;
+    }
+    for (int i = node_topology.mobilizer_velocities_start_in_v;
+         i < node_topology.mobilizer_velocities_start_in_v +
+             node_topology.num_mobilizer_velocities; ++i) {
+      velocity_map_.push_back(i);
+      ++num_velocities_;
+    }
+  }
+
+
+  for (const JointActuatorIndex actuator_index : joint_actuators_) {
+    const JointActuatorTopology& actuator_topology =
+        topology.get_joint_actuator(actuator_index);
+    for (int i = actuator_topology.actuator_index_start;
+         i < actuator_topology.actuator_index_start +
+             actuator_topology.num_dofs; ++i) {
+      actuator_map_.push_back(i);
+      ++num_actuated_dofs_;
+    }
+  }
+}
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::multibody_plant::ModelInstance)

--- a/multibody/multibody_tree/multibody_plant/model_instance.h
+++ b/multibody/multibody_tree/multibody_plant/model_instance.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/multibody_tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+template <typename T>
+class ModelInstance {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstance)
+
+  /// Create a model instance describing a colllection of bodies and joint
+  /// actuators to facilitate accessing portions of state and actuation
+  /// vectors.  State vectors are populates with positions/velocites for each
+  /// body in the order described in @bodies.  Actuation vectors follow the
+  /// ordering of the actuators in @p joint_actuators.
+  ModelInstance(const std::vector<BodyIndex>& bodies,
+                const std::vector<JointActuatorIndex>& joint_actuators);
+
+  /// Scalar-converting copy constructor.  See @ref
+  /// system_scalar_conversion.  The new instance will need be
+  /// finalised.
+  template<typename U>
+  ModelInstance(const ModelInstance<U>& other)
+      : ModelInstance<T>(other.bodies_, other.joint_actuators_) {}
+
+  ~ModelInstance();
+
+  /// Finalize the ModelInstance using the information in @p tree.  @p
+  /// tree must be finalized prior to calling this method.
+  void Finalize(const MultibodyTree<T>& tree);
+
+  int num_positions() const { return num_positions_; }
+  int num_velocities() const { return num_velocities_; }
+  int num_actuated_dofs() const { return num_actuated_dofs_; }
+
+  /// Populates @p q with the subset of @p q_array corresponding to the
+  /// positions of the bodies in this model instance.
+  ///
+  /// @param[in] q_array A vector of generalized positions for the entire
+  ///   %MultibodyTree model.
+  ///
+  /// @param [out] q A pointer to a vector which will contain the generalized
+  ///   positions of the bodies in this model instance.
+  void get_positions_from_array(
+      const Eigen::Ref<const VectorX<T>>& q_array,
+      EigenPtr<VectorX<T>> q) const {
+    DRAKE_DEMAND(q_array.size() == num_tree_positions_);
+    DRAKE_DEMAND(q->size() == num_positions_);
+    for (int i = 0; i < num_positions_; ++i) {
+      (*q)(i) = q_array(position_map_[i]);
+    }
+  }
+
+  /// Populates @p v with the subset of @p v_array corresponding to the
+  /// velocities of the bodies in this model instance.
+  ///
+  /// @param[in] v_array A vector of generalized velocities for the entire
+  ///   %MultibodyTree model.
+  ///
+  /// @param [out] v A pointer to a vector which will contain the generalized
+  ///   velocities of the bodies in this model instance.
+  void get_velocities_from_array(
+      const Eigen::Ref<const VectorX<T>>& v_array,
+      EigenPtr<VectorX<T>> v) const {
+    DRAKE_DEMAND(v_array.size() == num_tree_velocities_);
+    DRAKE_DEMAND(v->size() == num_velocities_);
+    for (int i = 0; i < num_velocities_; ++i) {
+      (*v)(i) = v_array(velocity_map_[i]);
+    }
+  }
+
+  /// Given the actuation values @p u_a for all actuators in this model
+  /// instance, this method sets the actuation vector u for the entire
+  /// %MultibodyTree model to which this actuator belongs to.
+  ///
+  /// @param[in] u_a Actuation values for the actuators. It must be of size
+  ///   equal to the number of degrees of freedom of all of the actuated
+  ///   Joints in this model instance.
+  ///
+  /// @param[out] u
+  ///   The vector containing the actuation values for the entire MultibodyTree
+  ///   model to which the actuators belongs to.
+  /// @throws if `u_a.size() != this->joint().num_dofs()`.
+  /// @throws if u is nullptr.
+  /// @throws if `u.size() != this->num_actuated_dofs()`.
+  void set_actuation_vector(
+      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
+    DRAKE_DEMAND(u_a.size() == num_actuated_dofs_);
+    DRAKE_DEMAND(u->size() == num_tree_actuated_dofs_);
+    for (int i = 0; i < num_actuated_dofs_; ++i) {
+      (*u)(actuator_map_[i]) = u_a(i);
+    }
+  }
+
+ private:
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U> friend class ModelInstance;
+
+  int num_positions_{0};
+  int num_velocities_{0};
+  int num_actuated_dofs_{0};
+
+  int num_tree_positions_{0};
+  int num_tree_velocities_{0};
+  int num_tree_actuated_dofs_{0};
+
+  const std::vector<BodyIndex> bodies_;
+  const std::vector<JointActuatorIndex> joint_actuators_;
+  std::vector<int> position_map_;
+  std::vector<int> velocity_map_;
+  std::vector<int> actuator_map_;
+};
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.cc
+++ b/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.cc
@@ -1,0 +1,133 @@
+#include "drake/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.h"
+
+#include <functional>
+
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+template <typename T>
+ModelInstanceMultiplexer<T>::ModelInstanceMultiplexer(
+    const MultibodyPlant<T>& plant)
+    : plant_(plant) {
+
+  for (int i = 0; i < plant_.num_model_instances(); ++i) {
+    const ModelInstance<T>& instance = plant_.get_model_instance(i);
+    const int model_dofs = instance.num_actuated_dofs();
+    if (model_dofs != 0) {
+      input_port_map_.push_back(
+          this->DeclareVectorInputPort(
+              systems::BasicVector<T>(model_dofs)).get_index());
+    } else {
+      input_port_map_.push_back(-1);
+    }
+
+    const int model_states =
+        instance.num_positions() + instance.num_velocities();
+    auto calc = [this, i](const systems::Context<T>& context,
+                          systems::BasicVector<T>* result) {
+      this->CopyStateOutput(i, context, result);
+    };
+
+    output_port_map_.push_back(
+        this->DeclareVectorOutputPort(
+            systems::BasicVector<T>(model_states), calc).get_index());
+  }
+
+  actuation_output_port_ = this->DeclareVectorOutputPort(
+      systems::BasicVector<T>(plant_.num_actuated_dofs()),
+      &ModelInstanceMultiplexer::CopyActuationInputs).get_index();
+
+  state_input_port_ = this->DeclareVectorInputPort(
+      systems::BasicVector<T>(plant_.num_multibody_states())).get_index();
+}
+
+template <typename T>
+ModelInstanceMultiplexer<T>::~ModelInstanceMultiplexer() {}
+
+template <typename T>
+const systems::InputPortDescriptor<T>&
+ModelInstanceMultiplexer<T>::get_actuation_input_port(
+    int model_instance) const {
+  DRAKE_DEMAND(model_instance < static_cast<int>(input_port_map_.size()));
+
+  const int port_index = input_port_map_[model_instance];
+  DRAKE_DEMAND(port_index >= 0);
+  return this->get_input_port(port_index);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+ModelInstanceMultiplexer<T>::get_state_output_port(
+    int model_instance) const {
+  DRAKE_DEMAND(model_instance < static_cast<int>(output_port_map_.size()));
+  return this->get_output_port(output_port_map_[model_instance]);
+}
+
+template <typename T>
+optional<bool>
+ModelInstanceMultiplexer<T>::DoHasDirectFeedthrough(
+    int input_port, int output_port) const {
+  if (input_port == state_input_port_ &&
+      output_port == actuation_output_port_) {
+    return false;
+  } else {
+    // This is one of the actuation input ports.  It's only direct
+    // feedthrough to the actuation output port.
+    if (output_port != actuation_output_port_) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T>
+void ModelInstanceMultiplexer<T>::CopyActuationInputs(
+    const systems::Context<T>& context,
+    systems::BasicVector<T>* output) const {
+  VectorX<T> out(plant_.num_actuated_dofs());
+  out.setZero();
+
+  for (int i = 0; i < plant_.num_model_instances(); ++i) {
+    if (input_port_map_[i] == -1) {
+      continue;
+    }
+
+    auto actuation_input =
+        this->EvalEigenVectorInput(context, input_port_map_[i]);
+    plant_.get_model_instance(i).set_actuation_vector(actuation_input, &out);
+  }
+
+  output->set_value(out);
+}
+
+template <typename T>
+void ModelInstanceMultiplexer<T>::CopyStateOutput(
+    int model_instance_idx, const systems::Context<T>& context,
+    systems::BasicVector<T>* output) const {
+  auto state_input = this->EvalEigenVectorInput(context, state_input_port_);
+
+  const ModelInstance<T>& model_instance =
+      plant_.get_model_instance(model_instance_idx);
+  VectorX<T> positions(model_instance.num_positions());
+  model_instance.get_positions_from_array(
+      state_input.head(plant_.num_positions()), &positions);
+
+  VectorX<T> velocities(model_instance.num_velocities());
+  model_instance.get_velocities_from_array(
+      state_input.tail(plant_.num_velocities()), &velocities);
+
+  output->get_mutable_value().head(positions.size()) = positions;
+  output->get_mutable_value().tail(velocities.size()) = velocities;
+}
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ::drake::multibody::multibody_plant::ModelInstanceMultiplexer)

--- a/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.h
+++ b/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/multibody/multibody_tree/multibody_plant/model_instance.h"
+#include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+/// This system provides separate input ports for the actuation
+/// vectors of different model instances in a %MultibodyPlant,
+/// combining all of the inputs into a single output port indended to
+/// be connected to the actuation input port of a %MultibodyPlant.
+/// Additionally, it provides an input port for the state vector from
+/// %MultibodyPlant and an output port for the state of each model
+/// instance.
+template <typename T>
+class ModelInstanceMultiplexer : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstanceMultiplexer)
+
+  /// @param[in] plant A multibody plant.  This will be aliased
+  /// internally and must remain valid for the lifetime of the object.
+  explicit ModelInstanceMultiplexer(const MultibodyPlant<T>& plant);
+  ~ModelInstanceMultiplexer();
+
+  /// @returns the actuation input port for the model instance at index
+  /// @p model_instance.
+  const systems::InputPortDescriptor<T>& get_actuation_input_port(
+      int model_instance) const;
+
+  const systems::OutputPort<T>& get_actuation_output_port() const {
+    return this->get_output_port(actuation_output_port_);
+  }
+
+  const systems::InputPortDescriptor<T>& get_state_input_port() const {
+    return this->get_input_port(state_input_port_);
+  }
+
+  /// @returns the state port for the model instance at index
+  /// @p model_instance.
+  const systems::OutputPort<T>& get_state_output_port(
+      int model_instance) const;
+
+ private:
+  optional<bool> DoHasDirectFeedthrough(
+      int input_port, int output_port) const final;
+
+  void CopyActuationInputs(
+      const systems::Context<T>& context,
+      systems::BasicVector<T>* output) const;
+
+  void CopyStateOutput(
+      int model_instance_idx, const systems::Context<T>& context,
+      systems::BasicVector<T>* output) const;
+
+  const MultibodyPlant<T>& plant_;
+
+  // Contains the input port index for the model instance at the
+  // corresponding position in the vector of model instances passd
+  // into the constructor (or -1 if that instance has no actuation).
+  std::vector<int> input_port_map_;
+
+  // Contains the output port index for the model instance at the
+  // corresponding position in the vector of model instances passed
+  // into the constructor.
+  std::vector<int> output_port_map_;
+
+  int state_input_port_{-1};
+  int actuation_output_port_{-1};
+};
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -204,6 +204,9 @@ void MultibodyPlant<T>::FinalizePlantOnly() {
   if (num_collision_geometries() > 0 &&
       stribeck_model_.stiction_tolerance() < 0)
     set_stiction_tolerance();
+  for (auto& model_instance : model_instances_) {
+    model_instance->Finalize(*model_);
+  }
 }
 
 template <typename T>
@@ -425,6 +428,16 @@ void MultibodyPlant<T>::set_penetration_allowance(
   penalty_method_contact_parameters_.damping = damping;
   // The time scale can be requested to hint the integrator's time step.
   penalty_method_contact_parameters_.time_scale = time_scale;
+}
+
+template <typename T>
+int MultibodyPlant<T>::AddModelInstance(
+      const std::vector<BodyIndex>& bodies,
+      const std::vector<JointActuatorIndex>& joint_actuators) {
+  std::unique_ptr<ModelInstance<T>> model_instance =
+      std::make_unique<ModelInstance<T>>(bodies, joint_actuators);
+  model_instances_.push_back(std::move(model_instance));
+  return model_instances_.size() - 1;
 }
 
 template<>

--- a/multibody/multibody_tree/multibody_plant/test/model_instance_multiplexer_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/model_instance_multiplexer_test.cc
@@ -1,0 +1,77 @@
+#include "drake/multibody/multibody_tree/multibody_plant/model_instance_multiplexer.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+namespace {
+
+GTEST_TEST(ModelInstanceMultiplexer, ModelInstanceMultiplexerTest) {
+  MultibodyPlant<double> plant;
+
+  int instance1_idx = parsing::AddModelFromSdfFile(
+      FindResourceOrThrow("drake/multibody/benchmarks/acrobot/acrobot.sdf"),
+      &plant);
+  int instance2_idx = parsing::AddModelFromSdfFile(
+      FindResourceOrThrow("drake/multibody/multibody_tree/multibody_plant/"
+                          "test/split_pendulum.sdf"),
+      &plant);
+
+  plant.Finalize();
+
+  ModelInstanceMultiplexer<double> dut(plant);
+  std::unique_ptr<systems::Context<double>> context =
+      dut.CreateDefaultContext();
+
+  context->FixInputPort(
+      dut.get_actuation_input_port(instance1_idx).get_index(), {1});
+  context->FixInputPort(
+      dut.get_actuation_input_port(instance2_idx).get_index(), {2});
+
+  const systems::OutputPort<double>& actuation_output_port =
+      dut.get_actuation_output_port();
+  std::unique_ptr<systems::AbstractValue> actuation_output =
+      actuation_output_port.Allocate();
+  actuation_output_port.Calc(*context, actuation_output.get());
+  const systems::BasicVector<double>& actuation_vec =
+      actuation_output->GetValueOrThrow<systems::BasicVector<double>>();
+  EXPECT_EQ(actuation_vec.GetAtIndex(0), 1);
+  EXPECT_EQ(actuation_vec.GetAtIndex(1), 2);
+
+  context->FixInputPort(dut.get_state_input_port().get_index(),
+                        {11, 12, 13, 14, 15, 16});
+
+  const systems::OutputPort<double>& instance1_output_port =
+      dut.get_state_output_port(instance1_idx);
+  std::unique_ptr<systems::AbstractValue> instance1_output =
+      instance1_output_port.Allocate();
+  instance1_output_port.Calc(*context, instance1_output.get());
+  const systems::BasicVector<double>& instance1_vec =
+      instance1_output->GetValueOrThrow<systems::BasicVector<double>>();
+  EXPECT_EQ(instance1_vec.GetAtIndex(0), 11);
+  EXPECT_EQ(instance1_vec.GetAtIndex(1), 13);
+  EXPECT_EQ(instance1_vec.GetAtIndex(2), 14);
+  EXPECT_EQ(instance1_vec.GetAtIndex(3), 16);
+
+  const systems::OutputPort<double>& instance2_output_port =
+      dut.get_state_output_port(instance2_idx);
+  std::unique_ptr<systems::AbstractValue> instance2_output =
+      instance2_output_port.Allocate();
+  instance2_output_port.Calc(*context, instance2_output.get());
+  const systems::BasicVector<double>& instance2_vec =
+      instance2_output->GetValueOrThrow<systems::BasicVector<double>>();
+  EXPECT_EQ(instance2_vec.GetAtIndex(0), 12);
+  EXPECT_EQ(instance2_vec.GetAtIndex(1), 15);
+}
+
+}  // namespace
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/test/model_instance_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/model_instance_test.cc
@@ -1,0 +1,136 @@
+#include "drake/multibody/multibody_tree/multibody_plant/model_instance.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
+#include "drake/multibody/multibody_tree/joints/weld_joint.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+namespace {
+
+GTEST_TEST(ModelInstance, ModelInstanceTest) {
+  // Create a tree with enough bodies to make two models, one with a
+  // welded base and one free.
+  MultibodyTree<double> tree;
+
+  std::vector<BodyIndex> instance1_bodies;
+  const RigidBody<double>& body1 =
+      tree.AddRigidBody("Body1", SpatialInertia<double>());
+  instance1_bodies.push_back(body1.index());
+  const RigidBody<double>& body2 =
+      tree.AddRigidBody("Body2", SpatialInertia<double>());
+  instance1_bodies.push_back(body2.index());
+  const RigidBody<double>& body3 =
+      tree.AddRigidBody("Body3", SpatialInertia<double>());
+  instance1_bodies.push_back(body3.index());
+
+  std::vector<JointActuatorIndex> instance1_actuators;
+  tree.AddJoint<WeldJoint>(
+      "weld1", tree.world_body(), Eigen::Isometry3d::Identity(),
+      body1, Eigen::Isometry3d::Identity(),
+      Eigen::Isometry3d::Identity());
+  const Joint<double>& body1_body2 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism1", body1, Eigen::Isometry3d::Identity(),
+          body2, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  const JointActuator<double>& act1 =
+      tree.AddJointActuator("act1", body1_body2);
+  instance1_actuators.push_back(act1.index());
+
+  const Joint<double>& body2_body3 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism2", body2, Eigen::Isometry3d::Identity(),
+          body3, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  const JointActuator<double>& act2 =
+      tree.AddJointActuator("act2", body2_body3);
+  instance1_actuators.push_back(act2.index());
+
+  ModelInstance<double> instance1(instance1_bodies, instance1_actuators);
+
+  std::vector<BodyIndex> instance2_bodies;
+  const RigidBody<double>& body4 =
+      tree.AddRigidBody("Body4", SpatialInertia<double>());
+  instance2_bodies.push_back(body4.index());
+  const RigidBody<double>& body5 =
+      tree.AddRigidBody("Body5", SpatialInertia<double>());
+  instance2_bodies.push_back(body5.index());
+
+  std::vector<JointActuatorIndex> instance2_actuators;
+  const Joint<double>& body4_body5 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism3", body4, Eigen::Isometry3d::Identity(),
+          body5, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  const JointActuator<double>& act3 =
+      tree.AddJointActuator("act3", body4_body5);
+  instance2_actuators.push_back(act3.index());
+
+  ModelInstance<double> instance2(instance2_bodies, instance2_actuators);
+
+  EXPECT_THROW(instance1.Finalize(tree), std::logic_error);
+  tree.Finalize();
+  instance1.Finalize(tree);
+  EXPECT_EQ(instance1.num_positions(), 2);
+  EXPECT_EQ(instance1.num_velocities(), 2);
+  EXPECT_EQ(instance1.num_actuated_dofs(), 2);
+
+  instance2.Finalize(tree);
+  EXPECT_EQ(instance2.num_positions(), 8);
+  EXPECT_EQ(instance2.num_velocities(), 7);
+  EXPECT_EQ(instance2.num_actuated_dofs(), 1);
+
+  Eigen::Vector3d act_vector(0, 0, 0);
+  instance1.set_actuation_vector(Eigen::Vector2d(1, 2), &act_vector);
+  instance2.set_actuation_vector(Vector1d(3), &act_vector);
+  EXPECT_TRUE(CompareMatrices(act_vector, Eigen::Vector3d(1, 2, 3)));
+
+  Eigen::VectorXd pos_vector(10);
+  pos_vector << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+  Eigen::VectorXd instance1_pos(2);
+  instance1.get_positions_from_array(pos_vector, &instance1_pos);
+  EXPECT_TRUE(CompareMatrices(instance1_pos, Eigen::Vector2d(8, 10)));
+
+  Eigen::VectorXd instance2_pos(8);
+  instance2.get_positions_from_array(pos_vector, &instance2_pos);
+  Eigen::VectorXd instance2_pos_expected(8);
+  instance2_pos_expected << 1, 2, 3, 4, 5, 6, 7, 9;
+  EXPECT_TRUE(CompareMatrices(instance2_pos, instance2_pos_expected));
+
+  Eigen::VectorXd vel_vector(9);
+  vel_vector << 11, 12, 13, 14, 15, 16, 17, 18, 19;
+
+  Eigen::VectorXd instance1_vel(2);
+  instance1.get_velocities_from_array(vel_vector, &instance1_vel);
+  EXPECT_TRUE(CompareMatrices(instance1_vel, Eigen::Vector2d(17, 19)));
+
+  Eigen::VectorXd instance2_vel(7);
+  instance2.get_velocities_from_array(vel_vector, &instance2_vel);
+  Eigen::VectorXd instance2_vel_expected(7);
+  instance2_vel_expected << 11, 12, 13, 14, 15, 16, 18;
+  EXPECT_TRUE(CompareMatrices(instance2_vel, instance2_vel_expected));
+
+  // Test that scalar conversion produces properly shaped results.
+  std::unique_ptr<MultibodyTree<AutoDiffXd>> tree_ad =
+      tree.CloneToScalar<AutoDiffXd>();
+
+  ModelInstance<AutoDiffXd> instance1_ad(instance1);
+  instance1_ad.Finalize(*tree_ad);
+  EXPECT_EQ(instance1_ad.num_positions(), 2);
+  EXPECT_EQ(instance1_ad.num_velocities(), 2);
+  EXPECT_EQ(instance1_ad.num_actuated_dofs(), 2);
+
+  ModelInstance<AutoDiffXd> instance2_ad(instance2);
+  instance2_ad.Finalize(*tree_ad);
+  EXPECT_EQ(instance2_ad.num_positions(), 8);
+  EXPECT_EQ(instance2_ad.num_velocities(), 7);
+  EXPECT_EQ(instance2_ad.num_actuated_dofs(), 1);
+}
+
+}  // namespace
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -958,6 +958,8 @@ GTEST_TEST(MultibodyPlantTest, ScalarConversionConstructor) {
       plant_autodiff.GetBodyByName("link2")).size(), link2_num_visuals);
   EXPECT_EQ(plant_autodiff.GetVisualGeometriesForBody(
       plant_autodiff.GetBodyByName("link3")).size(), link3_num_visuals);
+  EXPECT_EQ(plant_autodiff.num_model_instances(),
+            plant.num_model_instances());
 }
 
 // This test is used to verify the correctness of the methods to compute the
@@ -1299,4 +1301,3 @@ TEST_F(MultibodyPlantContactJacobianTests, TangentJacobian) {
 }  // namespace multibody_plant
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h
@@ -30,7 +30,8 @@ namespace parsing {
 /// @param scene_graph
 ///   A pointer to a mutable SceneGraph object used for geometry registration
 ///   (either to model visual or contact geometry).
-void AddModelFromSdfFile(
+/// @returns the index of the newly created model instance
+int AddModelFromSdfFile(
     const std::string& file_name,
     multibody_plant::MultibodyPlant<double>* plant,
     geometry::SceneGraph<double>* scene_graph = nullptr);

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -276,6 +276,33 @@ TEST_F(MultibodyPlantSdfParser, LinksWithCollisions) {
           CoulombFriction<double>(0.5, 0.5)));
 }
 
+// Verifies model instances are correctly created in the plant.
+TEST_F(MultibodyPlantSdfParser, ModelInstanceTest) {
+  int instance1_idx = AddModelFromSdfFile(full_name_, &plant_);
+
+  const std::string acrobot_sdf_name = FindResourceOrThrow(
+      "drake/multibody/benchmarks/acrobot/acrobot.sdf");
+  int instance2_idx = AddModelFromSdfFile(acrobot_sdf_name, &plant_);
+  // We are done adding models.
+  plant_.Finalize();
+
+  ASSERT_EQ(plant_.num_model_instances(), 2);
+
+  // The first instance is just a collection of free bodies.
+  const ModelInstance<double>& instance1 =
+      plant_.get_model_instance(instance1_idx);
+  EXPECT_EQ(instance1.num_positions(), 21);
+  EXPECT_EQ(instance1.num_velocities(), 18);
+  EXPECT_EQ(instance1.num_actuated_dofs(), 0);
+
+  // The second instance is an acrobot.
+  const ModelInstance<double>& instance2 =
+      plant_.get_model_instance(instance2_idx);
+  EXPECT_EQ(instance2.num_positions(), 2);
+  EXPECT_EQ(instance2.num_velocities(), 2);
+  EXPECT_EQ(instance2.num_actuated_dofs(), 1);
+}
+
 }  // namespace
 }  // namespace multibody_plant
 }  // namespace multibody


### PR DESCRIPTION
This creates the idea of a "model instance" which is a group of bodies and actuators.  More usefully, it includes a system to multiplex/demultiplex the actuation and state for each model (which would typically be used when creating a diagram around `MultibodyPlant`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8928)
<!-- Reviewable:end -->
