### PR TITLE
Adds fmt as dependency of pointer_cast

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -377,6 +377,7 @@ drake_cc_library(
     hdrs = ["pointer_cast.h"],
     deps = [
         ":nice_type_name",
+        "@fmt",
     ],
 )
 


### PR DESCRIPTION
Without this, downstream projects will complain saying fmt/format.h not found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8929)
<!-- Reviewable:end -->
