### PR TITLE
Disable print_host_settings_test; it fails on macOS

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -687,6 +687,8 @@ sh_test(
     name = "print_host_settings_test",
     srcs = ["test/print_host_settings_test.sh"],
     data = [":print_host_settings"],
+    # TODO(jwnimmer-tri) Temporarily disabled because it fails on macOS.
+    tags = ["manual"],
 )
 
 drake_cc_googletest(


### PR DESCRIPTION
#8851 added a test that doesn't pass on macOS.  Disable it unconditionally for now to unbreak CI, until it can be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8931)
<!-- Reviewable:end -->
