### PR TITLE
Set abstract state in SetDefaultState

### DIFF
--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -173,8 +173,8 @@ class LeafSystem : public System<T> {
 
   /// Default implementation: sets all continuous state to the model vector
   /// given in DeclareContinuousState (or zero if no model vector was given) and
-  /// discrete states to zero.  This method makes no attempt to set abstract
-  /// state values.  Overrides must not change the number of state variables.
+  /// discrete states to zero. Overrides must not change the number of state
+  /// variables.
   // TODO(sherm/russt): Initialize the discrete state from the model vector
   // pending resolution of #7058.
   void SetDefaultState(const Context<T>& context,
@@ -192,6 +192,8 @@ class LeafSystem : public System<T> {
       BasicVector<T>& s = xd.get_mutable_vector(i);
       s.SetFromVector(VectorX<T>::Zero(s.size()));
     }
+    AbstractValues& xa = state->get_mutable_abstract_state();
+    xa.CopyFrom(AbstractValues(model_abstract_states_.CloneAllModels()));
   }
 
   /// Default implementation: sets all numeric parameters to the model vector

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -27,12 +27,10 @@ constexpr double kTime = 12.0;
 
 class SystemWithAbstractState : public LeafSystem<double> {
  public:
-  SystemWithAbstractState() {}
-  ~SystemWithAbstractState() override {}
-
-  std::unique_ptr<AbstractValues> AllocateAbstractState() const override {
-    return std::make_unique<AbstractValues>(PackValue(42));
+  SystemWithAbstractState() {
+    DeclareAbstractState(AbstractValue::Make<int>(42));
   }
+  ~SystemWithAbstractState() override {}
 };
 
 class SystemWithNumericParameters : public LeafSystem<double> {

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -1575,18 +1575,13 @@ class SystemWithAbstractState : public LeafSystem<double> {
  public:
   SystemWithAbstractState(int id, double update_period) : id_(id) {
     DeclarePeriodicUnrestrictedUpdate(update_period, 0);
+    DeclareAbstractState(AbstractValue::Make<double>(id_));
 
     // Verify that no periodic discrete updates are registered.
     EXPECT_FALSE(this->GetUniquePeriodicDiscreteUpdateAttribute());
   }
 
   ~SystemWithAbstractState() override {}
-
-  std::unique_ptr<AbstractValues> AllocateAbstractState() const override {
-    std::vector<std::unique_ptr<AbstractValue>> values;
-    values.push_back({PackValue<double>(id_)});
-    return std::make_unique<AbstractValues>(std::move(values));
-  }
 
   // Abstract state is set to time + id.
   void DoCalcUnrestrictedUpdate(

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -827,10 +827,30 @@ GTEST_TEST(ModelLeafSystemTest, ModelAbstractState) {
   };
 
   DeclaredModelAbstractStateSystem dut;
-  auto context = dut.CreateDefaultContext();
 
+  // Allocate the resources that were created on system construction.
+  auto context = dut.AllocateContext();
+
+  // Check that the allocations were made and with the correct type
+  EXPECT_NO_THROW(context->get_abstract_state<int>(0));
+  EXPECT_NO_THROW(context->get_abstract_state<std::string>(1));
+
+  // Mess with the abstract values on the context.
+  drake::systems::AbstractValues& values =
+      context->get_mutable_abstract_state();
+  drake::systems::AbstractValue& value = values.get_mutable_value(1);
+  EXPECT_NO_THROW(value.SetValue<std::string>("whoops"));
+  EXPECT_EQ(context->get_abstract_state<std::string>(1), "whoops");
+
+  // Ask it to reset to the defaults specified on system construction.
+  dut.SetDefaultContext(context.get());
   EXPECT_EQ(context->get_abstract_state<int>(0), 1);
   EXPECT_EQ(context->get_abstract_state<std::string>(1), "wow");
+
+  // Just create a default context directly.
+  auto default_context = dut.CreateDefaultContext();
+  EXPECT_EQ(default_context->get_abstract_state<int>(0), 1);
+  EXPECT_EQ(default_context->get_abstract_state<std::string>(1), "wow");
 }
 
 


### PR DESCRIPTION
Hitherto conspicuously missing and probably not heavily noticed since `AllocateContext` is tasked with  transferring initial abstract state values (specified via `DeclareAbstractState`) at construction time to the context.

i.e. This particular bug would only hurt you if you try and rewind back to the default state later.

It does beg the question though, why is `AllocateContext` transferring the values as well as allocating the space? e.g. `System::CreateDefaultContext()` would seem to indicate that both have separate tasks:

```
  std::unique_ptr<Context<T>> CreateDefaultContext() const {
    std::unique_ptr<Context<T>> context = AllocateContext();
    SetDefaultContext(context.get());
    return context;
  }
```

where in actuality, at least for abstract state, the `SetDefaultContext` is redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8934)
<!-- Reviewable:end -->
