### PR TITLE
Add an IdIndex interface to maliput::api::RoadGeometry.

### DIFF
--- a/automotive/maliput/api/BUILD.bazel
+++ b/automotive/maliput/api/BUILD.bazel
@@ -20,11 +20,13 @@ drake_cc_package_library(
 drake_cc_library(
     name = "everything",
     srcs = [
+        "basic_id_index.cc",
         "lane.cc",
         "lane_data.cc",
         "road_geometry.cc",
     ],
     hdrs = [
+        "basic_id_index.h",
         "branch_point.h",
         "junction.h",
         "lane.h",

--- a/automotive/maliput/api/basic_id_index.cc
+++ b/automotive/maliput/api/basic_id_index.cc
@@ -1,0 +1,80 @@
+#include "drake/automotive/maliput/api/basic_id_index.h"
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+void BasicIdIndex::AddLane(const Lane* lane) {
+  DRAKE_THROW_UNLESS(lane_map_.emplace(lane->id(), lane).second);
+}
+
+
+void BasicIdIndex::AddSegment(const Segment* segment) {
+  DRAKE_THROW_UNLESS(segment_map_.emplace(segment->id(), segment).second);
+}
+
+
+void BasicIdIndex::AddJunction(const Junction* junction) {
+  DRAKE_THROW_UNLESS(junction_map_.emplace(junction->id(), junction).second);
+}
+
+
+void BasicIdIndex::AddBranchPoint(const BranchPoint* branch_point) {
+  DRAKE_THROW_UNLESS(
+      branch_point_map_.emplace(branch_point->id(), branch_point).second);
+}
+
+
+void BasicIdIndex::WalkAndAddAll(const RoadGeometry* road_geometry) {
+  for (int ji = 0; ji < road_geometry->num_junctions(); ++ji) {
+    const Junction* junction = road_geometry->junction(ji);
+    AddJunction(junction);
+    for (int si = 0; si < junction->num_segments(); ++si) {
+      const Segment* segment = junction->segment(si);
+      AddSegment(segment);
+      for (int li = 0; li < segment->num_lanes(); ++li) {
+        AddLane(segment->lane(li));
+      }
+    }
+  }
+  for (int bi = 0; bi < road_geometry->num_branch_points(); ++bi) {
+    AddBranchPoint(road_geometry->branch_point(bi));
+  }
+}
+
+
+namespace {
+template <typename T, typename U>
+T find_or_nullptr(const std::unordered_map<U, T>& map, const U& id) {
+  auto it = map.find(id);
+  return (it == map.end()) ? nullptr : it->second;
+}
+}  // namespace
+
+
+const Lane* BasicIdIndex::DoGetLane(const LaneId& id) const {
+  return find_or_nullptr(lane_map_, id);
+}
+
+
+const Segment* BasicIdIndex::DoGetSegment(const SegmentId& id) const {
+  return find_or_nullptr(segment_map_, id);
+}
+
+
+const Junction* BasicIdIndex::DoGetJunction(const JunctionId& id) const {
+  return find_or_nullptr(junction_map_, id);
+}
+
+
+const BranchPoint*
+BasicIdIndex::DoGetBranchPoint(const BranchPointId& id) const {
+  return find_or_nullptr(branch_point_map_, id);
+}
+
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/basic_id_index.h
+++ b/automotive/maliput/api/basic_id_index.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+
+/// Basic general-purpose concrete implementation of the
+/// RoadGeometry::IdIndex interface.
+class BasicIdIndex : public RoadGeometry::IdIndex {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BasicIdIndex);
+
+  BasicIdIndex() = default;
+  ~BasicIdIndex() override = default;
+
+  /// Adds @p lane to the index.
+  ///
+  /// @throws if @p lane's id() already exists in the index.
+  /// @pre @p lane is not nullptr.
+  void AddLane(const Lane* lane);
+
+  /// Adds @p segment to the index.
+  ///
+  /// @throws if @p segment's id() already exists in the index.
+  /// @pre @p segment is not nullptr.
+  void AddSegment(const Segment* segment);
+
+  /// Adds @p junction to the index.
+  ///
+  /// @throws if @p junction's id() already exists in the index.
+  /// @pre @p junction is not nullptr.
+  void AddJunction(const Junction* junction);
+
+  /// Adds @p branch_point to the index.
+  ///
+  /// @throws if @p branch_point's id() already exists in the index.
+  /// @pre @p branch_point is not nullptr.
+  void AddBranchPoint(const BranchPoint* branch_point);
+
+  /// Walks the object graph rooted at @p road_geometry and adds all
+  /// components (Lane, Segment, Junction, BranchPoint) to the index.
+  ///
+  /// @throws if the graph of @p road_geometry contains any duplicate id's,
+  ///         or if any of its id's already exist in the index.
+  /// @pre @p road_geometry is not nullptr.
+  void WalkAndAddAll(const RoadGeometry* road_geometry);
+
+ private:
+  const Lane* DoGetLane(const LaneId& id) const final;
+  const Segment* DoGetSegment(const SegmentId& id) const final;
+  const Junction* DoGetJunction(const JunctionId& id) const final;
+  const BranchPoint* DoGetBranchPoint(const BranchPointId& id) const final;
+
+  std::unordered_map<JunctionId, const Junction*> junction_map_;
+  std::unordered_map<SegmentId, const Segment*> segment_map_;
+  std::unordered_map<LaneId, const Lane*> lane_map_;
+  std::unordered_map<BranchPointId, const BranchPoint*> branch_point_map_;
+};
+
+
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/road_geometry.h
+++ b/automotive/maliput/api/road_geometry.h
@@ -3,7 +3,11 @@
 #include <string>
 #include <vector>
 
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/segment.h"
 #include "drake/automotive/maliput/api/type_specific_identifier.h"
 #include "drake/common/drake_copyable.h"
 
@@ -25,7 +29,9 @@ using RoadGeometryId = TypeSpecificIdentifier<class RoadGeometry>;
 //                          scalar type T like everything else in drake.
 class RoadGeometry {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry)
+  class IdIndex;
+
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry);
 
   virtual ~RoadGeometry() = default;
 
@@ -57,6 +63,10 @@ class RoadGeometry {
   const BranchPoint* branch_point(int index) const {
     return do_branch_point(index);
   }
+
+  /// Accesses the IdIndex interface, which allows getting elements of
+  /// the RoadGeometry's object graph by their unique id's.
+  const IdIndex& ById() const { return DoById(); }
 
   /// Determines the RoadPosition corresponding to GeoPosition @p geo_position.
   ///
@@ -140,6 +150,8 @@ class RoadGeometry {
 
   virtual const BranchPoint* do_branch_point(int index) const = 0;
 
+  virtual const IdIndex& DoById() const = 0;
+
   virtual RoadPosition DoToRoadPosition(const GeoPosition& geo_pos,
                                         const RoadPosition* hint,
                                         GeoPosition* nearest_position,
@@ -149,6 +161,47 @@ class RoadGeometry {
 
   virtual double do_angular_tolerance() const = 0;
   ///@}
+};
+
+
+/// Abstract interface for a collection of methods which allow accessing
+/// objects in a RoadGeometry's object graph (Lanes, Segments, Junctions,
+/// BranchPoints) by their unique id's.
+class RoadGeometry::IdIndex {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IdIndex);
+  virtual ~IdIndex() = default;
+
+  /// Returns the Lane identified by @p id, or `nullptr` if @p id is unknown.
+  const Lane* GetLane(const LaneId& id) const { return DoGetLane(id); }
+
+  /// Returns the Segment identified by @p id, or `nullptr` if @p id is
+  /// unknown.
+  const Segment* GetSegment(const SegmentId& id) const {
+    return DoGetSegment(id);
+  }
+
+  /// Returns the Junction identified by @p id, or `nullptr` if @p id is
+  /// unknown.
+  const Junction* GetJunction(const JunctionId& id) const {
+    return DoGetJunction(id);
+  }
+
+  /// Returns the BranchPoint identified by @p id, or `nullptr` if @p id is
+  /// unknown.
+  const BranchPoint* GetBranchPoint(const BranchPointId& id) const {
+    return DoGetBranchPoint(id);
+  }
+
+ protected:
+  IdIndex() = default;
+
+ private:
+  virtual const Lane* DoGetLane(const LaneId& id) const = 0;
+  virtual const Segment* DoGetSegment(const SegmentId& id) const = 0;
+  virtual const Junction* DoGetJunction(const JunctionId& id) const = 0;
+  virtual const BranchPoint* DoGetBranchPoint(
+      const BranchPointId& id) const = 0;
 };
 
 

--- a/automotive/maliput/api/test_utilities/BUILD.bazel
+++ b/automotive/maliput/api/test_utilities/BUILD.bazel
@@ -13,8 +13,22 @@ drake_cc_package_library(
     name = "test_utilities",
     testonly = 1,
     deps = [
+        ":check_id_indexing",
         ":maliput_types_compare",
         ":rules_test_utilities",
+    ],
+)
+
+drake_cc_library(
+    name = "check_id_indexing",
+    testonly = 1,
+    srcs = ["check_id_indexing.cc"],
+    hdrs = ["check_id_indexing.h"],
+    deps = [
+        ":rules_test_utilities",
+        "//automotive/maliput/api",
+        "//common:essential",
+        "@gtest//:without_main",
     ],
 )
 

--- a/automotive/maliput/api/test_utilities/check_id_indexing.cc
+++ b/automotive/maliput/api/test_utilities/check_id_indexing.cc
@@ -1,0 +1,54 @@
+#include "drake/automotive/maliput/api/test_utilities/check_id_indexing.h"
+
+#include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+
+namespace rules {
+namespace test {
+template <typename T>
+::testing::AssertionResult IsEqual(const char* a_expression,
+                                   const char* b_expression,
+                                   const T* a,
+                                   const T* b) {
+  return ::testing::internal::CmpHelperEQ(a_expression, b_expression, a, b);
+}
+}  // namespace test
+}  // namespace rules
+
+namespace test {
+
+
+::testing::AssertionResult CheckIdIndexing(const RoadGeometry* road_geometry) {
+  rules::test::AssertionResultCollector c;
+  for (int ji = 0; ji < road_geometry->num_junctions(); ++ji) {
+    const api::Junction* junction = road_geometry->junction(ji);
+    MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(
+        road_geometry->ById().GetJunction(junction->id()), junction));
+    for (int si = 0; si < junction->num_segments(); ++si) {
+      const api::Segment* segment = junction->segment(si);
+      MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(
+          road_geometry->ById().GetSegment(segment->id()), segment));
+      for (int li = 0; li < segment->num_lanes(); ++li) {
+        const api::Lane* lane = segment->lane(li);
+        MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(
+            road_geometry->ById().GetLane(lane->id()), lane));
+      }
+    }
+    for (int bi = 0; bi < road_geometry->num_branch_points(); ++bi) {
+      const api::BranchPoint* branch_point = road_geometry->branch_point(bi);
+      MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(
+          road_geometry->ById().GetBranchPoint(branch_point->id()),
+          branch_point));
+    }
+  }
+  return c.result();
+}
+
+
+}  // namespace test
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/api/test_utilities/check_id_indexing.h
+++ b/automotive/maliput/api/test_utilities/check_id_indexing.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+
+namespace drake {
+namespace maliput {
+namespace api {
+namespace test {
+
+/// Walks the object graph of @p road_geometry and checks that every
+/// component can be found via `ById().Get*(const *Id& id)` methods.
+///
+/// @return ::testing::AssertionSuccess() when all objects are found,
+/// otherwise ::testing::AssertionFailure().
+::testing::AssertionResult CheckIdIndexing(const RoadGeometry* road_geometry);
+
+}  // namespace test
+}  // namespace api
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/dragway/road_geometry.cc
+++ b/automotive/maliput/dragway/road_geometry.cc
@@ -35,6 +35,8 @@ RoadGeometry::RoadGeometry(const api::RoadGeometryId& id,
   DRAKE_DEMAND(maximum_height >= 0);
   DRAKE_DEMAND(linear_tolerance >= 0);
   DRAKE_DEMAND(angular_tolerance >= 0);
+
+  id_index_.WalkAndAddAll(this);
 }
 
 const api::Junction* RoadGeometry::do_junction(int index) const {

--- a/automotive/maliput/dragway/road_geometry.h
+++ b/automotive/maliput/dragway/road_geometry.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/automotive/maliput/api/basic_id_index.h"
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/lane_data.h"
@@ -69,6 +70,8 @@ class RoadGeometry final : public api::RoadGeometry {
 
   const api::BranchPoint* do_branch_point(int index) const final;
 
+  const IdIndex& DoById() const override { return id_index_; }
+
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_position,
       const api::RoadPosition* hint,
@@ -92,6 +95,7 @@ class RoadGeometry final : public api::RoadGeometry {
   const double linear_tolerance_{};
   const double angular_tolerance_{};
   const Junction junction_;
+  api::BasicIdIndex id_index_;
 };
 
 }  // namespace dragway

--- a/automotive/maliput/dragway/test/dragway_test.cc
+++ b/automotive/maliput/dragway/test/dragway_test.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/test_utilities/check_id_indexing.h"
 #include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
 #include "drake/automotive/maliput/dragway/branch_point.h"
 #include "drake/automotive/maliput/dragway/junction.h"
@@ -388,6 +389,7 @@ TEST_F(MaliputDragwayLaneTest, SingleLane) {
 
   VerifyLaneCorrectness(lane_, kNumLanes);
   VerifyBranches(lane_, road_geometry_.get());
+  EXPECT_TRUE(api::test::CheckIdIndexing(road_geometry_.get()));
 }
 
 /*
@@ -421,6 +423,7 @@ TEST_F(MaliputDragwayLaneTest, TwoLaneDragway) {
     VerifyLaneCorrectness(lane, kNumLanes);
     VerifyBranches(lane, road_geometry_.get());
   }
+  EXPECT_TRUE(api::test::CheckIdIndexing(road_geometry_.get()));
 }
 
 // Tests dragway::RoadGeometry::ToRoadPosition() using a two-lane dragway where

--- a/automotive/maliput/monolane/BUILD.bazel
+++ b/automotive/maliput/monolane/BUILD.bazel
@@ -92,6 +92,7 @@ drake_cc_googletest(
     srcs = ["test/monolane_builder_test.cc"],
     deps = [
         ":builder",
+        "//automotive/maliput/api/test_utilities",
     ],
 )
 

--- a/automotive/maliput/monolane/branch_point.cc
+++ b/automotive/maliput/monolane/branch_point.cc
@@ -7,7 +7,7 @@ namespace maliput {
 namespace monolane {
 
 BranchPoint::BranchPoint(const api::BranchPointId& id,
-                         api::RoadGeometry* road_geometry)
+                         const api::RoadGeometry* road_geometry)
     : id_(id), road_geometry_(road_geometry) {}
 
 const api::RoadGeometry* BranchPoint::do_road_geometry() const {

--- a/automotive/maliput/monolane/branch_point.h
+++ b/automotive/maliput/monolane/branch_point.h
@@ -46,7 +46,8 @@ class BranchPoint : public api::BranchPoint {
   /// Constructs an empty BranchPoint.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class.
-  BranchPoint(const api::BranchPointId& id, api::RoadGeometry* road_geometry);
+  BranchPoint(const api::BranchPointId& id,
+              const api::RoadGeometry* road_geometry);
 
   /// Adds a LaneEnd to the "A side" of the BranchPoint.
   const api::LaneEnd& AddABranch(const api::LaneEnd& lane_end);
@@ -81,7 +82,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetBSide() const override { return &b_side_; }
 
   api::BranchPointId id_;
-  api::RoadGeometry* road_geometry_{};
+  const api::RoadGeometry* road_geometry_{};
   LaneEndSet a_side_;
   LaneEndSet b_side_;
 

--- a/automotive/maliput/monolane/junction.cc
+++ b/automotive/maliput/monolane/junction.cc
@@ -10,8 +10,10 @@ const api::RoadGeometry* Junction::do_road_geometry() const {
 
 
 Segment* Junction::NewSegment(api::SegmentId id) {
-  segments_.push_back(std::make_unique<Segment>(id, this));
-  return segments_.back().get();
+  segments_.push_back(std::make_unique<Segment>(id, this, register_lane_));
+  Segment* segment = segments_.back().get();
+  register_segment_(segment);
+  return segment;
 }
 
 }  // namespace monolane

--- a/automotive/maliput/monolane/junction.h
+++ b/automotive/maliput/monolane/junction.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -16,15 +17,21 @@ namespace monolane {
 /// An api::Junction implementation.
 class Junction : public api::Junction {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction);
 
   /// Constructs an empty Junction.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class,
   /// and must refer to the RoadGeometry which will contain the newly
   /// constructed Junction instance.
-  Junction(const api::JunctionId& id, api::RoadGeometry* road_geometry)
-      : id_(id), road_geometry_(road_geometry) {}
+  /// @p register_segment and @p register_lane will be called on any new
+  /// Segment or Lane instances created as children of the Junction.
+  Junction(const api::JunctionId& id, const api::RoadGeometry* road_geometry,
+           const std::function<void(const api::Segment*)>& register_segment,
+           const std::function<void(const api::Lane*)>& register_lane)
+      : id_(id), road_geometry_(road_geometry),
+        register_segment_(register_segment),
+        register_lane_(register_lane) {}
 
   /// Creates and adds a new Segment with the specified @p id.
   Segment* NewSegment(api::SegmentId id);
@@ -43,7 +50,9 @@ class Junction : public api::Junction {
   }
 
   api::JunctionId id_;
-  api::RoadGeometry* road_geometry_{};
+  const api::RoadGeometry* road_geometry_{};
+  std::function<void(const api::Segment*)> register_segment_;
+  std::function<void(const api::Lane*)> register_lane_;
   std::vector<std::unique_ptr<Segment>> segments_;
 };
 

--- a/automotive/maliput/monolane/road_geometry.cc
+++ b/automotive/maliput/monolane/road_geometry.cc
@@ -42,13 +42,20 @@ void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
 }  // namespace
 
 Junction* RoadGeometry::NewJunction(api::JunctionId id) {
-  junctions_.push_back(std::make_unique<Junction>(id, this));
-  return junctions_.back().get();
+  junctions_.push_back(std::make_unique<Junction>(
+      id, this,
+      [this](auto segment) { id_index_.AddSegment(segment); },
+      [this](auto lane) { id_index_.AddLane(lane); }));
+  Junction* junction = junctions_.back().get();
+  id_index_.AddJunction(junction);
+  return junction;
 }
 
 BranchPoint* RoadGeometry::NewBranchPoint(api::BranchPointId id) {
   branch_points_.push_back(std::make_unique<BranchPoint>(id, this));
-  return branch_points_.back().get();
+  BranchPoint* branch_point = branch_points_.back().get();
+  id_index_.AddBranchPoint(branch_point);
+  return branch_point;
 }
 
 const api::Junction* RoadGeometry::do_junction(int index) const {

--- a/automotive/maliput/monolane/road_geometry.h
+++ b/automotive/maliput/monolane/road_geometry.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/automotive/maliput/api/basic_id_index.h"
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
@@ -48,6 +49,8 @@ class RoadGeometry : public api::RoadGeometry {
 
   const api::BranchPoint* do_branch_point(int index) const override;
 
+  const IdIndex& DoById() const override { return id_index_; }
+
   // Returns a RoadPosition for a lane containing the provided `geo_position`.
   // If there is no containing lane, the position is returned for the lane
   // closest to the centerline curve.  If `hint` is non-null, then the search is
@@ -67,6 +70,7 @@ class RoadGeometry : public api::RoadGeometry {
   double angular_tolerance_{};
   std::vector<std::unique_ptr<Junction>> junctions_;
   std::vector<std::unique_ptr<BranchPoint>> branch_points_;
+  api::BasicIdIndex id_index_;
 };
 
 }  // namespace monolane

--- a/automotive/maliput/monolane/segment.cc
+++ b/automotive/maliput/monolane/segment.cc
@@ -29,6 +29,7 @@ LineLane* Segment::NewLineLane(api::LaneId id,
       elevation, superelevation);
   LineLane* result = lane.get();
   lane_ = std::move(lane);
+  register_lane_(result);
   return result;
 }
 
@@ -48,6 +49,7 @@ ArcLane* Segment::NewArcLane(api::LaneId id,
       elevation, superelevation);
   ArcLane* result = lane.get();
   lane_ = std::move(lane);
+  register_lane_(result);
   return result;
 }
 

--- a/automotive/maliput/monolane/segment.h
+++ b/automotive/maliput/monolane/segment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "drake/automotive/maliput/api/junction.h"
@@ -18,15 +19,19 @@ class LineLane;
 /// An api::Segment implementation.
 class Segment : public api::Segment {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment);
 
   /// Constructs a new Segment.
   ///
   /// The Segment is not fully initialized until one of NewLineLane()
   /// or NewArcLane() is called exactly once.  @p junction must remain
   /// valid for the lifetime of this class.
-  Segment(const api::SegmentId& id, api::Junction* junction)
-      : id_(id), junction_(junction) {}
+  ///
+  /// @p register_lane will be called on any new Lane instance created as
+  /// a child of the Segment.
+  Segment(const api::SegmentId& id, const api::Junction* junction,
+          const std::function<void(const api::Lane*)>& register_lane)
+      : id_(id), junction_(junction), register_lane_(register_lane) {}
 
   /// Gives the segment a newly constructed LineLane.
   LineLane* NewLineLane(api::LaneId id,
@@ -59,7 +64,8 @@ class Segment : public api::Segment {
   const api::Lane* do_lane(int index) const override;
 
   api::SegmentId id_;
-  api::Junction* junction_{};
+  const api::Junction* junction_{};
+  std::function<void(const api::Lane*)> register_lane_;
   std::unique_ptr<Lane> lane_;
 };
 

--- a/automotive/maliput/monolane/test/monolane_builder_test.cc
+++ b/automotive/maliput/monolane/test/monolane_builder_test.cc
@@ -7,6 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/automotive/maliput/api/test_utilities/check_id_indexing.h"
+
 namespace drake {
 namespace maliput {
 namespace monolane {
@@ -93,6 +95,8 @@ GTEST_TEST(MonolaneBuilderTest, Fig8) {
     EXPECT_EQ(bp->GetASide()->size(), 1);
     EXPECT_EQ(bp->GetBSide()->size(), 1);
   }
+
+  EXPECT_TRUE(api::test::CheckIdIndexing(rg.get()));
 };
 
 
@@ -217,6 +221,7 @@ GTEST_TEST(MonolaneBuilderTest, QuadRing) {
       GTEST_FAIL();
     }
   }
+  EXPECT_TRUE(api::test::CheckIdIndexing(rg.get()));
 };
 
 

--- a/automotive/maliput/monolane/test/monolane_road_geometry_test.cc
+++ b/automotive/maliput/monolane/test/monolane_road_geometry_test.cc
@@ -31,7 +31,7 @@ const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
   throw std::runtime_error("No matching junction name in the road network");
 }
 
-GTEST_TEST(MonolaneLanesTest, DoToRoadPosition) {
+GTEST_TEST(MonolaneRoadGeometryTest, DoToRoadPosition) {
   // Define a serpentine road with multiple segments and branches.
   std::unique_ptr<monolane::Builder> rb(
       new monolane::Builder(RBounds(-kWidth, kWidth), RBounds(-kWidth, kWidth),
@@ -197,7 +197,7 @@ GTEST_TEST(MonolaneLanesTest, DoToRoadPosition) {
       kVeryExact));
 }
 
-GTEST_TEST(MonolaneLanesTest, HintWithDisconnectedLanes) {
+GTEST_TEST(MonolaneRoadGeometryTest, HintWithDisconnectedLanes) {
   // Define a road with two disconnected, diverging lanes such that there are no
   // ongoing lanes.  This tests the pathological case when a `hint` is provided
   // in a topologically isolated lane, so the code returns the default road

--- a/automotive/maliput/multilane/branch_point.cc
+++ b/automotive/maliput/multilane/branch_point.cc
@@ -7,7 +7,7 @@ namespace maliput {
 namespace multilane {
 
 BranchPoint::BranchPoint(const api::BranchPointId& id,
-                         api::RoadGeometry* road_geometry)
+                         const api::RoadGeometry* road_geometry)
     : id_(id), road_geometry_(road_geometry) {}
 
 const api::RoadGeometry* BranchPoint::do_road_geometry() const {

--- a/automotive/maliput/multilane/branch_point.h
+++ b/automotive/maliput/multilane/branch_point.h
@@ -46,7 +46,8 @@ class BranchPoint : public api::BranchPoint {
   /// Constructs an empty BranchPoint.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class.
-  BranchPoint(const api::BranchPointId& id, api::RoadGeometry* road_geometry);
+  BranchPoint(const api::BranchPointId& id,
+              const api::RoadGeometry* road_geometry);
 
   /// Adds a LaneEnd to the "A side" of the BranchPoint.
   const api::LaneEnd& AddABranch(const api::LaneEnd& lane_end);
@@ -81,7 +82,7 @@ class BranchPoint : public api::BranchPoint {
   const api::LaneEndSet* DoGetBSide() const override { return &b_side_; }
 
   api::BranchPointId id_;
-  api::RoadGeometry* road_geometry_{};
+  const api::RoadGeometry* road_geometry_{};
   LaneEndSet a_side_;
   LaneEndSet b_side_;
 

--- a/automotive/maliput/multilane/junction.cc
+++ b/automotive/maliput/multilane/junction.cc
@@ -16,8 +16,11 @@ Segment* Junction::NewSegment(const api::SegmentId& id,
                               double r_min, double r_max,
                               const api::HBounds& elevation_bounds) {
   segments_.push_back(std::make_unique<Segment>(
-      id, this, std::move(road_curve), r_min, r_max, elevation_bounds));
-  return segments_.back().get();
+      id, this, register_lane_,
+      std::move(road_curve), r_min, r_max, elevation_bounds));
+  Segment* segment = segments_.back().get();
+  register_segment_(segment);
+  return segment;
 }
 
 }  // namespace multilane

--- a/automotive/maliput/multilane/junction.h
+++ b/automotive/maliput/multilane/junction.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -17,15 +18,21 @@ namespace multilane {
 /// An api::Junction implementation.
 class Junction : public api::Junction {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction);
 
   /// Constructs an empty Junction.
   ///
   /// @p road_geometry must remain valid for the lifetime of this class,
   /// and must refer to the RoadGeometry which will contain the newly
   /// constructed Junction instance.
-  Junction(const api::JunctionId& id, api::RoadGeometry* road_geometry)
-      : id_(id), road_geometry_(road_geometry) {}
+  /// @p register_segment and @p register_lane will be called on any new
+  /// Segment or Lane instances created as children of the Junction.
+  Junction(const api::JunctionId& id, const api::RoadGeometry* road_geometry,
+           const std::function<void(const api::Segment*)>& register_segment,
+           const std::function<void(const api::Lane*)>& register_lane)
+      : id_(id), road_geometry_(road_geometry),
+        register_segment_(register_segment),
+        register_lane_(register_lane) {}
 
   /// Creates and adds a new Segment.
   /// @param id Segment's ID.
@@ -54,7 +61,9 @@ class Junction : public api::Junction {
   }
 
   api::JunctionId id_;
-  api::RoadGeometry* road_geometry_{};
+  const api::RoadGeometry* road_geometry_{};
+  std::function<void(const api::Segment*)> register_segment_;
+  std::function<void(const api::Lane*)> register_lane_;
   std::vector<std::unique_ptr<Segment>> segments_;
 };
 

--- a/automotive/maliput/multilane/road_geometry.cc
+++ b/automotive/maliput/multilane/road_geometry.cc
@@ -86,13 +86,21 @@ void GetPositionIfSmallerDistance(const api::GeoPosition& geo_position,
 }  // namespace
 
 Junction* RoadGeometry::NewJunction(api::JunctionId id) {
-  junctions_.push_back(std::make_unique<Junction>(id, this));
-  return junctions_.back().get();
+  namespace sp = std::placeholders;
+  junctions_.push_back(std::make_unique<Junction>(
+      id, this,
+      [this](auto segment) { id_index_.AddSegment(segment); },
+      [this](auto lane) { id_index_.AddLane(lane); }));
+  Junction* junction = junctions_.back().get();
+  id_index_.AddJunction(junction);
+  return junction;
 }
 
 BranchPoint* RoadGeometry::NewBranchPoint(api::BranchPointId id) {
   branch_points_.push_back(std::make_unique<BranchPoint>(id, this));
-  return branch_points_.back().get();
+  BranchPoint* branch_point = branch_points_.back().get();
+  id_index_.AddBranchPoint(branch_point);
+  return branch_point;
 }
 
 const api::Junction* RoadGeometry::do_junction(int index) const {

--- a/automotive/maliput/multilane/road_geometry.h
+++ b/automotive/maliput/multilane/road_geometry.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "drake/automotive/maliput/api/basic_id_index.h"
 #include "drake/automotive/maliput/api/branch_point.h"
 #include "drake/automotive/maliput/api/junction.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
@@ -48,6 +49,8 @@ class RoadGeometry : public api::RoadGeometry {
 
   const api::BranchPoint* do_branch_point(int index) const override;
 
+  const IdIndex& DoById() const override { return id_index_; }
+
   // Returns a RoadPosition for a lane containing the provided `geo_position`.
   // Either if there is or not a containing lane, the position is returned for
   // the lane whose centerline curve is closest to `geo_position`. In other
@@ -69,6 +72,7 @@ class RoadGeometry : public api::RoadGeometry {
   double angular_tolerance_{};
   std::vector<std::unique_ptr<Junction>> junctions_;
   std::vector<std::unique_ptr<BranchPoint>> branch_points_;
+  api::BasicIdIndex id_index_;
 };
 
 }  // namespace multilane

--- a/automotive/maliput/multilane/segment.cc
+++ b/automotive/maliput/multilane/segment.cc
@@ -22,7 +22,9 @@ Lane* Segment::NewLane(api::LaneId id, double r0,
       std::make_unique<Lane>(id, this, index, lane_bounds, driveable_bounds,
                              elevation_bounds_, road_curve_.get(), r0);
   lanes_.push_back(std::move(lane_));
-  return lanes_.back().get();
+  Lane* result = lanes_.back().get();
+  register_lane_(result);
+  return result;
 }
 
 const api::Lane* Segment::do_lane(int index) const {

--- a/automotive/maliput/multilane/segment.h
+++ b/automotive/maliput/multilane/segment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -23,7 +24,7 @@ class LineLane;
 /// An api::Segment implementation.
 class Segment : public api::Segment {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment)
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment);
 
   /// Constructs a new Segment.
   ///
@@ -31,6 +32,8 @@ class Segment : public api::Segment {
   /// once. `junction` must remain valid for the lifetime of this class.
   /// @param id Segment's ID.
   /// @param junction Parent junction.
+  /// @param register_lane will be called on any new Lane instance created as
+  /// a child of the Segment.
   /// @param road_curve A curve that defines the reference trajectory over the
   /// segment. A child Lane object will be constructed from an offset of the
   /// road_curve's reference curve.
@@ -41,11 +44,13 @@ class Segment : public api::Segment {
   /// from where Segment's surface ends. It should be greater or equal than
   /// `r_min`.
   /// @param elevation_bounds The height bounds over the segment' surface.
-  Segment(const api::SegmentId& id, api::Junction* junction,
+  Segment(const api::SegmentId& id, const api::Junction* junction,
+          const std::function<void(const api::Lane*)>& register_lane,
           std::unique_ptr<RoadCurve> road_curve, double r_min, double r_max,
           const api::HBounds& elevation_bounds)
       : id_(id),
         junction_(junction),
+        register_lane_(register_lane),
         road_curve_(std::move(road_curve)),
         r_min_(r_min),
         r_max_(r_max),
@@ -85,7 +90,8 @@ class Segment : public api::Segment {
   // Segment's ID.
   api::SegmentId id_;
   // Parent junction.
-  api::Junction* junction_{};
+  const api::Junction* junction_{};
+  std::function<void(const api::Lane*)> register_lane_;
   // Child Lane vector.
   std::vector<std::unique_ptr<Lane>> lanes_;
   // Reference trajectory over the Segment's surface.

--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/test_utilities/check_id_indexing.h"
 #include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
 #include "drake/automotive/maliput/multilane/test_utilities/multilane_types_compare.h"
 
@@ -232,6 +233,8 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
     EXPECT_EQ(bp->GetASide()->size(), 1);
     EXPECT_EQ(bp->GetBSide()->size(), 1);
   }
+
+  EXPECT_TRUE(api::test::CheckIdIndexing(rg.get()));
 };
 
 
@@ -371,6 +374,8 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
       GTEST_FAIL();
     }
   }
+
+  EXPECT_TRUE(api::test::CheckIdIndexing(rg.get()));
 };
 
 // Holds Lane IDs for each Lane, both at the start and end of the Lane.
@@ -723,6 +728,8 @@ GTEST_TEST(MultilaneBuilderTest, MultilaneCross) {
     }
   }
   EXPECT_EQ(rg->num_branch_points(), 20);
+
+  EXPECT_TRUE(api::test::CheckIdIndexing(rg.get()));
 }
 
 }  // namespace

--- a/automotive/maliput/rndf/road_geometry.h
+++ b/automotive/maliput/rndf/road_geometry.h
@@ -65,6 +65,9 @@ class RoadGeometry : public api::RoadGeometry {
   // and the current maximum available index of branch_points_ vector.
   const api::BranchPoint* do_branch_point(int index) const override;
 
+  // TODO(maddog@tri.global) Implement when someone needs it.
+  const IdIndex& DoById() const override { DRAKE_ABORT(); }
+
   // This function will abort as it's not implemented and should not be called.
   api::RoadPosition DoToRoadPosition(const api::GeoPosition& geo_pos,
                                      const api::RoadPosition* hint,


### PR DESCRIPTION
Add an IdIndex interface to maliput::api::RoadGeometry. 

This provides four "GetXXX(const XXXId& id)" methods where XXX is Lane, Segment, Junction, BranchPoint, allowing lookup of those objects by their unique id's in the RoadGeometry. 

Also, provide a general-purpose implementation, BasicIdIndex, and use it to provide the IdIndex interface for all backends in drake, except for `rndf` (which is stubbed-out with an abort until someone actually uses/needs it). Also, add a test utility which walks a RoadGeometry graph and checks that all elements have been indexed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8937)
<!-- Reviewable:end -->
