### PR TITLE
pydrake systems: Fix mis-directed binding `System.get_num_output_ports`

### DIFF
--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -254,7 +254,7 @@ struct Impl {
         .def("get_num_input_ports", &System<T>::get_num_input_ports)
         .def("get_input_port",
              &System<T>::get_input_port, py_reference_internal)
-        .def("get_num_output_ports", &System<T>::get_num_input_ports)
+        .def("get_num_output_ports", &System<T>::get_num_output_ports)
         .def("get_output_port",
              &System<T>::get_output_port, py_reference_internal)
         .def(

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -79,6 +79,14 @@ class TestGeneral(unittest.TestCase):
             rhs_port = rhs.get_output_port(i)
             self.assertEqual(lhs_port.size(), rhs_port.size())
 
+    def test_system_base_api(self):
+        # Test a system with a different number of inputs from outputs.
+        system = Adder(3, 10)
+        self.assertEqual(system.get_num_input_ports(), 3)
+        self.assertEqual(system.get_num_output_ports(), 1)
+        # TODO(eric.cousineau): Consolidate the main API tests for `System`
+        # to this test point.
+
     def test_instantiations(self):
         # Quick check of instantions for given types.
         # N.B. These checks are ordered according to their binding definitions


### PR DESCRIPTION
Found this while reviewing #8936 - whoops!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8938)
<!-- Reviewable:end -->
