### PR TITLE
Make RgbdRenderer replaceable from RgbdCamera

### DIFF
--- a/systems/sensors/rgbd_camera.cc
+++ b/systems/sensors/rgbd_camera.cc
@@ -68,7 +68,8 @@ RgbdCamera::RgbdCamera(const std::string& name,
                           show_window},
           Eigen::Translation3d(position[0], position[1], position[2]) *
               Eigen::Isometry3d(math::rpy2rotmat(orientation)) * X_BC_)) {
-  Init(name);
+  InitPorts(name);
+  InitRenderer();
 }
 
 RgbdCamera::RgbdCamera(const std::string& name,
@@ -85,10 +86,11 @@ RgbdCamera::RgbdCamera(const std::string& name,
           new RgbdRendererVTK(RenderingConfig{width, height, fov_y,
                                               z_near, z_far, show_window},
                               Eigen::Isometry3d::Identity())) {
-  Init(name);
+  InitPorts(name);
+  InitRenderer();
 }
 
-void RgbdCamera::Init(const std::string& name) {
+void RgbdCamera::InitPorts(const std::string& name) {
   set_name(name);
   const int kVecNum =
       tree_.get_num_positions() + tree_.get_num_velocities();
@@ -112,7 +114,9 @@ void RgbdCamera::Init(const std::string& name) {
 
   camera_base_pose_port_ = &this->DeclareVectorOutputPort(
       rendering::PoseVector<double>(), &RgbdCamera::OutputPoseVector);
+}
 
+void RgbdCamera::InitRenderer() {
   // Creates rendering world.
   for (const auto& body : tree_.get_bodies()) {
     if (body->get_name() == std::string(RigidBodyTreeConstants::kWorldName)) {

--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -182,8 +182,9 @@ class RgbdCamera final : public LeafSystem<double> {
   void ResetRenderer(std::unique_ptr<RgbdRenderer> renderer) {
     renderer_ = std::move(renderer);
     InitRenderer();
-    // This needs only for camera_fixed_ is true since this will be called
-    // in UpdateModelPoses() if false.
+    // This is needed only for camera_fixed_ is true since UpdateViewpoint()
+    // will be called while rendering related output ports are evaluated
+    // if it is false.
     if (camera_fixed_) {
       renderer_->UpdateViewpoint(X_WB_initial_ * X_BC_);
     }

--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -176,9 +176,12 @@ class RgbdCamera final : public LeafSystem<double> {
 
   ~RgbdCamera() = default;
 
-  /// Sets and initializes RgbdRenderer. You don't need to think about the
-  /// viewpoint of renderer since it will be appropriately handled inside this
-  /// function.
+  /// Sets and initializes RgbdRenderer. The viewpoint of renderer will be
+  /// appropriately handled inside this function.
+  /// Note that if any visual element is registered with renderer before
+  /// this method is called, its behavior will not be guaranteed.
+  // TODO(kunimatsu-tri) Initialize the internal state of renderer when this
+  // method is called.
   void ResetRenderer(std::unique_ptr<RgbdRenderer> renderer) {
     renderer_ = std::move(renderer);
     InitRenderer();
@@ -189,6 +192,9 @@ class RgbdCamera final : public LeafSystem<double> {
       renderer_->UpdateViewpoint(X_WB_initial_ * X_BC_);
     }
   }
+
+  /// Reterns mutable renderer.
+  RgbdRenderer& get_mutable_renderer() { return *renderer_; }
 
   /// Reterns the color sensor's info.
   const CameraInfo& color_camera_info() const { return color_camera_info_; }

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -302,7 +302,7 @@ TEST_F(RgbdCameraDiagramTest, MovableCameraOutputTest) {
   }
 }
 
-// Making sure that output image will be the same before v.s. after calling
+// Making sure that output image will be the same before vs. after calling
 // ResetRenderer()
 TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
   // RgbdCamera is looking straight down 1m above the ground.

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -247,6 +247,10 @@ class RgbdCameraDiagramTest : public ::testing::Test {
     output_ = diagram_->AllocateOutput(*context_);
   }
 
+  void CalcOutput() {
+    diagram_->CalcOutput(*context_, output_.get());
+  }
+
   std::unique_ptr<RgbdCameraDiagram> diagram_;
   std::unique_ptr<systems::SystemOutput<double>> output_;
   Size size_;
@@ -317,6 +321,8 @@ TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
             RenderingConfig{size.width, size.height, kFovY,
                             kDepthRangeNear, kDepthRangeFar, kShowWindow},
             Eigen::Isometry3d::Identity())));
+
+    CalcOutput();
 
     auto const rgb2 =
         output_->GetMutableData(0)->GetMutableValue<ImageRgba8U>();

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -313,6 +313,8 @@ TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
     Init("nothing.sdf", X_WB, size);
     Verify();
 
+    auto renderer1 = &diagram_->camera().get_mutable_renderer();
+
     auto const rgb1 =
         output_->GetMutableData(0)->GetMutableValue<ImageRgba8U>();
 
@@ -321,6 +323,9 @@ TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
             RenderingConfig{size.width, size.height, kFovY,
                             kDepthRangeNear, kDepthRangeFar, kShowWindow},
             Eigen::Isometry3d::Identity())));
+
+    auto renderer2 = &diagram_->camera().get_mutable_renderer();
+    EXPECT_NE(renderer1, renderer2);
 
     CalcOutput();
 

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -24,6 +24,7 @@
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/rendering/pose_vector.h"
 #include "drake/systems/sensors/image.h"
+#include "drake/systems/sensors/rgbd_renderer_vtk.h"
 
 namespace drake {
 namespace systems {
@@ -169,6 +170,8 @@ class RgbdCameraDiagram : public systems::Diagram<double> {
     Connect();
   }
 
+  RgbdCamera& camera() { return *rgbd_camera_; }
+
  private:
   void Connect() {
     builder_.Connect(plant_->state_output_port(),
@@ -244,11 +247,11 @@ class RgbdCameraDiagramTest : public ::testing::Test {
     output_ = diagram_->AllocateOutput(*context_);
   }
 
+  std::unique_ptr<RgbdCameraDiagram> diagram_;
   std::unique_ptr<systems::SystemOutput<double>> output_;
   Size size_;
 
  private:
-  std::unique_ptr<RgbdCameraDiagram> diagram_;
   std::unique_ptr<systems::Context<double>> context_;
 };
 
@@ -292,6 +295,40 @@ TEST_F(RgbdCameraDiagramTest, MovableCameraOutputTest) {
     const Eigen::Isometry3d actual = camera_base_pose->get_isometry();
     EXPECT_TRUE(CompareMatrices(X_WB.matrix(),
                                 actual.matrix(), kTolerance));
+  }
+}
+
+// Making sure that output image will be the same before v.s. after calling
+// ResetRenderer()
+TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
+  // RgbdCamera is looking straight down 1m above the ground.
+  const Eigen::Isometry3d X_WB = Eigen::Translation3d(0., 0., 1.) *
+      Eigen::AngleAxisd(M_PI_2, Eigen::Vector3d::UnitY());
+
+  for (auto size : kSizes) {
+    Init("nothing.sdf", X_WB, size);
+    Verify();
+
+    auto const rgb1 =
+        output_->GetMutableData(0)->GetMutableValue<ImageRgba8U>();
+
+    diagram_->camera().ResetRenderer(
+        std::unique_ptr<RgbdRenderer>(new RgbdRendererVTK(
+            RenderingConfig{size.width, size.height, kFovY,
+                            kDepthRangeNear, kDepthRangeFar, kShowWindow},
+            Eigen::Isometry3d::Identity())));
+
+    auto const rgb2 =
+        output_->GetMutableData(0)->GetMutableValue<ImageRgba8U>();
+
+    for (int y = 0; y < size.height; ++y) {
+      for (int x = 0; x < size.width; ++x) {
+        for (int ch = 0; ch < 4; ++ch) {
+          // Use ASSERT here instead of EXPECT to stop all subsequent testing.
+          ASSERT_EQ(rgb1.at(x, y)[ch], rgb2.at(x, y)[ch]);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This enables us to have full control for forthcoming `RgbdRender`'s APIs, e.g. setting parameters for lighting, material properties, environment map, etc., without wrapping them on `RgbdCamera` side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8944)
<!-- Reviewable:end -->
