### PR TITLE
Disable SolveLorentzConeConstraint test

### DIFF
--- a/solvers/test/dreal_solver_test.cc
+++ b/solvers/test/dreal_solver_test.cc
@@ -548,7 +548,8 @@ TEST_F(DrealSolverTest, SolveQuadraticConstraint) {
   EXPECT_NEAR(v1, 1.7320 /* sqrt(3.0) */, delta);
 }
 
-TEST_F(DrealSolverTest, SolveLorentzConeConstraint) {
+// TODO(soonho): Enable this when mac CIs are using >= dReal-4.18.05.3.
+TEST_F(DrealSolverTest, DISABLED_SolveLorentzConeConstraint) {
   const Variable& x0{xvec_(0)};
   const Variable& x1{xvec_(1)};
   const Variable& x2{xvec_(2)};


### PR DESCRIPTION
Mac CIs are using an old version. It's a temporary fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8945)
<!-- Reviewable:end -->
