### PR TITLE
Enable SolveLorentzConeConstraint in DrealSolverTest

### DIFF
--- a/solvers/test/dreal_solver_test.cc
+++ b/solvers/test/dreal_solver_test.cc
@@ -548,8 +548,7 @@ TEST_F(DrealSolverTest, SolveQuadraticConstraint) {
   EXPECT_NEAR(v1, 1.7320 /* sqrt(3.0) */, delta);
 }
 
-// TODO(soonho): Enable this when mac CIs are using >= dReal-4.18.05.3.
-TEST_F(DrealSolverTest, DISABLED_SolveLorentzConeConstraint) {
+TEST_F(DrealSolverTest, SolveLorentzConeConstraint) {
   const Variable& x0{xvec_(0)};
   const Variable& x1{xvec_(1)};
   const Variable& x2{xvec_(2)};


### PR DESCRIPTION
@BetsyMcPhail confirmed that Mac CIs are using the latest version of dReal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8947)
<!-- Reviewable:end -->
