### PR TITLE
Minor PiecewisePolynomial modifications

### DIFF
--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -329,7 +329,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   bool empty() const { return polynomials_.empty(); }
 
-  double scalarValue(double t, Eigen::Index row = 0, Eigen::Index col = 0);
+  double scalarValue(double t, Eigen::Index row = 0,
+                     Eigen::Index col = 0) const;
 
   /**
    * Evaluates the PiecewisePolynomial at the given time \p t.
@@ -347,8 +348,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   int getSegmentPolynomialDegree(int segment_index, Eigen::Index row = 0,
                                  Eigen::Index col = 0) const;
 
+  /// Returns the row count of each and every PolynomialMatrix segment.
   Eigen::Index rows() const override;
 
+  /// Returns the column count of each and every PolynomialMatrix segment.
   Eigen::Index cols() const override;
 
   /// @throws std::runtime_error if other.segment_times is not within
@@ -398,6 +401,18 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * if any Polynomial in either PiecewisePolynomial is not univariate.
    */
   bool isApprox(const PiecewisePolynomial& other, double tol) const;
+
+  /// Concatenates @p other at the end, yielding a continuous trajectory
+  /// from current start_time() to @p other end_time().
+  ///
+  /// @param other PiecewisePolynomial instance to concatenate.
+  /// @throw std::runtime_error if trajectories' dimensions do not match
+  ///                           each other (either rows() or cols() does
+  ///                           not match between this and @p other).
+  /// @throw std::runtime_error if this end_time() and @p other start_time() are
+  ///                           not within PiecewiseTrajectory<T>::kEpsilonTime
+  ///                           from each other.
+  void ConcatenateInTime(const PiecewisePolynomial& other);
 
   void shiftRight(double offset);
 


### PR DESCRIPTION
This pull request is the first of a series of pull requests that ultimately introduce continuous extensions to Drake i.e. continuous approximations to numerical integration solutions. 

Specifically, this PR applies minor modifications to the `PiecewisePolynomial` class below `//common/trajectories` in preparation for their use within continuous extensions' implementations.

For further details, refer to the [full diff](https://github.com/RobotLocomotion/drake/compare/master...ekumenlabs:Issue/Systems_Continuous_Extension_Support_For_IVP_Solvers) of the series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8949)
<!-- Reviewable:end -->
