### PR TITLE
Introduce ContinuousExtension classes

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -14,7 +14,9 @@ drake_cc_package_library(
     name = "analysis",
     deps = [
         ":antiderivative_function",
+        ":continuous_extension",
         ":explicit_euler_integrator",
+        ":hermitian_continuous_extension",
         ":implicit_euler_integrator",
         ":initial_value_problem",
         ":integrator_base",
@@ -24,6 +26,34 @@ drake_cc_package_library(
         ":scalar_initial_value_problem",
         ":semi_explicit_euler_integrator",
         ":simulator",
+        ":stepwise_continuous_extension",
+    ],
+)
+
+drake_cc_library(
+    name = "continuous_extension",
+    hdrs = ["continuous_extension.h"],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "stepwise_continuous_extension",
+    hdrs = ["stepwise_continuous_extension.h"],
+    deps = [
+        ":continuous_extension",
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "hermitian_continuous_extension",
+    hdrs = ["hermitian_continuous_extension.h"],
+    deps = [
+        ":stepwise_continuous_extension",
+        "//common:essential",
+        "//common/trajectories:piecewise_polynomial",
     ],
 )
 
@@ -114,8 +144,8 @@ drake_cc_library(
         "initial_value_problem-inl.h",
     ],
     deps = [
+        ":integrator_base",
         ":runge_kutta3_integrator",
-        "//common:essential",
         "//systems/framework:context",
         "//systems/framework:continuous_state",
         "//systems/framework:leaf_system",
@@ -212,6 +242,7 @@ drake_cc_googletest(
     name = "runge_kutta2_integrator_test",
     deps = [
         ":runge_kutta2_integrator",
+        "//common/test_utilities:eigen_matrix_compare",
         "//systems/analysis/test_utilities",
     ],
 )
@@ -222,6 +253,7 @@ drake_cc_googletest(
     timeout = "moderate",
     deps = [
         ":runge_kutta3_integrator",
+        "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
         "//multibody/parsers",
         "//multibody/rigid_body_plant",
@@ -252,6 +284,7 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "scalar_initial_value_problem_test",
     deps = [
+        ":runge_kutta2_integrator",
         ":scalar_initial_value_problem",
     ],
 )
@@ -260,6 +293,17 @@ drake_cc_googletest(
     name = "antiderivative_function_test",
     deps = [
         ":antiderivative_function",
+        ":runge_kutta2_integrator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "hermitian_continuous_extension_test",
+    deps = [
+        ":hermitian_continuous_extension",
+        "//common:essential",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/trajectories:piecewise_polynomial",
     ],
 )
 

--- a/systems/analysis/continuous_extension.h
+++ b/systems/analysis/continuous_extension.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+
+namespace drake {
+namespace systems {
+
+/// An interface for continuous extension of ODE and DAE solutions, to
+/// efficiently approximate them in between integration steps when solving
+/// them numerically (see IntegratorBase class documentation).
+///
+/// This _continuous extension_ (see [Engquist, 2015]) concept can be formally
+/// stated as follows: given a solution 𝐱(t) ∈ ℝⁿ to an ODE or DAE system that
+/// is approximated at a discrete set of points 𝐲(tₖ) ∈ ℝⁿ where
+/// tₖ ∈ {t₁, ..., tᵢ} with tᵢ ∈ ℝ (e.g. as a result of numerical integration),
+/// a continuous extension of 𝐱(t) is another function 𝐳(t) ∈ ℝⁿ defined for
+/// t ∈ [t₁, tᵢ] such that 𝐳(tⱼ) = 𝐲(tⱼ) for all tⱼ ∈ {t₁, ..., tᵢ} and that
+/// approximates 𝐱(t) for every value in the closed interval [t₁, tᵢ].
+///
+/// - [Engquist, 2105] B. Engquist. Encyclopedia of Applied and Computational
+///                    Mathematics, p. 339, Springer, 2015.
+/// @tparam T A valid Eigen scalar type.
+template <typename T>
+class ContinuousExtension {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ContinuousExtension)
+
+  ContinuousExtension() = default;
+  virtual ~ContinuousExtension() = default;
+
+  /// Evaluates the extension function at the given time @p t.
+  /// @param t Time to evaluate extension at.
+  /// @return Extension function vector value.
+  /// @pre Extension is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions are not met.
+  /// @throw std::runtime_error if the extension is not defined for the
+  ///                           given @p t.
+  virtual VectorX<T> Evaluate(const T& t) const = 0;
+
+  /// Returns the extension dimension `n`.
+  /// @pre Extension is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual int get_dimensions() const = 0;
+
+  /// Checks whether the extension is empty or not.
+  virtual bool is_empty() const = 0;
+
+  /// Returns extension's start time, or in other words, the oldest time
+  /// `t` that it can be evaluated at e.g. via Evaluate().
+  /// @pre Extension is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual const T& get_start_time() const = 0;
+
+  /// Returns extension's end time, or in other words, the newest time
+  /// `t` that it can be evaluated at e.g. via Evaluate().
+  /// @pre Extension is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual const T& get_end_time() const = 0;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/hermitian_continuous_extension.h
+++ b/systems/analysis/hermitian_continuous_extension.h
@@ -1,0 +1,326 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/systems/analysis/stepwise_continuous_extension.h"
+
+namespace drake {
+namespace systems {
+
+/// A StepwiseContinuousExtension class implementation using Hermitian
+/// interpolators. Updates take the form of integration steps, for which
+/// state 𝐱 and state time derivative d𝐱/dt are known at least at both ends
+/// of the step. Hermite cubic polynomials are then constructed upon
+/// consolidation, yielding a C1 extension of the solution 𝐱(t).
+///
+/// Hermitian continuous extensions exhibit the same truncation error as that of
+/// the integration scheme being used for up to 3rd order schemes (see
+/// [Hairer, 1993]).
+///
+/// - [Hairer, 1993] E. Hairer, S. Nørsett and G. Wanner. Solving Ordinary
+///                  Differential Equations I (Nonstiff Problems), p.190,
+///                  Springer, 1993.
+/// @tparam T A valid Eigen scalar type.
+template <typename T>
+class HermitianContinuousExtension : public StepwiseContinuousExtension<T> {
+  // TODO(hidmic): Support non `double` type scalars.
+  static_assert(std::is_same<T, double>::value,
+                "HermitianContinuousExtension only supports double for now.");
+
+ public:
+  /// An integration step representation class, holding just enough
+  /// for Hermitian interpolation: three (3) related sets containing
+  /// step times {t₀, ..., tᵢ₋₁, tᵢ} where tᵢ ∈ ℝ, step states
+  /// {𝐱₀, ..., 𝐱ᵢ₋₁, 𝐱ᵢ} where 𝐱ᵢ ∈ ℝⁿ, and state derivatives
+  /// {d𝐱/dt₀, ..., d𝐱/dtᵢ₋₁, d𝐱/dtᵢ} where d𝐱/dtᵢ ∈ ℝⁿ.
+  ///
+  /// This step definition allows for intermediate time, state and state
+  /// derivative triplets (e.g. the integrator internal stages) to improve
+  /// interpolation.
+  class IntegrationStep {
+   public:
+    /// Constructs a zero length step (i.e. a step containing a single time,
+    /// state and state derivative triplet) from column matrices.
+    ///
+    /// @param initial_time Initial time t₀ where the step starts.
+    /// @param initial_state Initial state vector 𝐱₀ at @p initial_time
+    ///                      as a column matrix.
+    /// @param initial_state_derivative Initial state derivative vector
+    ///                                 d𝐱/dt₀ at @p initial_time as a
+    ///                                 column matrix.
+    /// @throw std::runtime_error
+    ///   if given @p initial_state 𝐱₀ is not a column matrix.<br>
+    ///   if given @p initial_state_derivative d𝐱/t₀ is not a column matrix.<br>
+    ///   if given @p initial_state 𝐱₀ and @p initial_state_derivative d𝐱/dt₀ do
+    ///   not match each other's dimension.
+    IntegrationStep(const T& initial_time, MatrixX<T> initial_state,
+                    MatrixX<T> initial_state_derivative) {
+      ValidateStepExtendTripletOrThrow(initial_time, initial_state,
+                                       initial_state_derivative);
+      times_.push_back(initial_time);
+      states_.push_back(std::move(initial_state));
+      state_derivatives_.push_back(std::move(initial_state_derivative));
+    }
+
+    /// Extends the step forward in time from column matrices.
+    ///
+    /// Provided @p time, @p state and @p state_derivative are appended
+    /// to the current step, effectively increasing its time length.
+    ///
+    /// @param time Time tᵢ to extend the step to.
+    /// @param state State vector 𝐱ᵢ at @p time tᵢ as a column matrix.
+    /// @param state_derivative State derivative vector d𝐱/dtᵢ at @p time tᵢ
+    ///                         as a column matrix.
+    /// @throw std::runtime_error
+    ///   if given @p state 𝐱ᵢ is not a column matrix.<br>
+    ///   if given @p state_derivative d𝐱/dtᵢ is not a column matrix.<br>
+    ///   if given @p time tᵢ is not greater than the previous time tᵢ₋₁ in
+    ///   the step.<br>
+    ///   if given @p state 𝐱ᵢ dimension does not match the dimension of the
+    ///   previous state 𝐱ᵢ₋₁.<br>
+    ///   if given @p state 𝐱ᵢ and @p state_derivative d𝐱/dtᵢ do not match each
+    ///   other's dimension.
+    void Extend(const T& time, MatrixX<T> state, MatrixX<T> state_derivative) {
+      ValidateStepExtendTripletOrThrow(time, state, state_derivative);
+      times_.push_back(time);
+      states_.push_back(std::move(state));
+      state_derivatives_.push_back(std::move(state_derivative));
+    }
+
+    /// Returns step start time t₀ (that of the first time, state and state
+    /// derivative triplet), which may coincide with its end time tᵢ (that of
+    /// the last time, state and state derivative triplet) if the step has zero
+    /// length (that is, it contains a single triplet).
+    const T& get_start_time() const { return times_.front(); }
+
+    /// Returns step end time tᵢ (that of the first time, state and state
+    /// derivative triplet), which may coincide with its start time t₀ (that of
+    /// the last time, state and state derivative triplet) if the step has zero
+    /// length (that is, it contains a single triplet).
+    const T& get_end_time() const { return times_.back(); }
+
+    /// Returns the step state 𝐱 dimensions.
+    int get_dimensions() const {
+      return states_.back().rows();
+    }
+
+    /// Returns step times {t₀, ..., tᵢ₋₁, tᵢ}.
+    const std::vector<T>& get_times() const { return times_; }
+
+    /// Returns step states {𝐱₀, ..., 𝐱ᵢ₋₁, 𝐱ᵢ} as column matrices.
+    const std::vector<MatrixX<T>>& get_states() const { return states_; }
+
+    /// Gets step state derivatives {d𝐱/dt₀, ..., d𝐱/dtᵢ₋₁, d𝐱/dtᵢ}
+    /// as column matrices.
+    const std::vector<MatrixX<T>>& get_state_derivatives() const {
+      return state_derivatives_;
+    }
+
+   private:
+    // Validates step update triplet for consistency between the triplet
+    // and with current step content.
+    //
+    // @see Extend(const T&, const MatrixX<T>&, const MatrixX<T>&)
+    void ValidateStepExtendTripletOrThrow(
+        const T& time, const MatrixX<T>& state,
+        const MatrixX<T>& state_derivative) {
+      if (state.cols() != 1) {
+        throw std::runtime_error("Provided state for step is "
+                                 "not a column matrix.");
+      }
+      if (state_derivative.cols() != 1) {
+        throw std::runtime_error("Provided state derivative for "
+                                 " step is not a column matrix.");
+      }
+      if (!times_.empty()) {
+        if (time < times_.front()) {
+          throw std::runtime_error("Step cannot be extended"
+                                   " backwards in time.");
+        }
+        if (time <= times_.back()) {
+          throw std::runtime_error("Step already extends up"
+                                   " to the given time.");
+        }
+      }
+      if (!states_.empty() && states_.back().rows() != state.rows()) {
+          throw std::runtime_error("Provided state dimensions do not "
+                                   "match that of the states in the step.");
+      }
+      if (state.rows() != state_derivative.rows()) {
+        throw std::runtime_error("Provided state and state derivative "
+                                 "dimensions do not match.");
+      }
+    }
+    // Step times, ordered in increasing order.
+    std::vector<T> times_{};
+    // Step states, ordered as to match its corresponding time in `times_`.
+    std::vector<MatrixX<T>> states_{};
+    // Step state derivatives, ordered as to match its corresponding
+    // time in `times_`.
+    std::vector<MatrixX<T>> state_derivatives_{};
+  };
+
+  VectorX<T> Evaluate(const T& t) const override {
+    if (is_empty()) {
+      throw std::logic_error("Empty continuous extension cannot"
+                             " be evaluated.");
+    }
+    if (t < get_start_time() || t > get_end_time()) {
+      throw std::runtime_error("Continuous extension is not "
+                               "defined for given time.");
+    }
+    return continuous_trajectory_.value(t).col(0);
+  }
+
+  int get_dimensions() const override {
+    if (is_empty()) {
+      throw std::logic_error("Dimension is not defined for an"
+                             " empty continuous extension.");
+    }
+    return continuous_trajectory_.rows();
+  }
+
+  bool is_empty() const override {
+    return continuous_trajectory_.empty();
+  }
+
+  const T& get_end_time() const override {
+    if (is_empty()) {
+      throw std::logic_error("End time is not defined for an"
+                             " empty continuous extension.");
+    }
+    return end_time_;
+  }
+
+  const T& get_start_time() const override {
+    if (is_empty()) {
+      throw std::logic_error("Start time is not defined for an"
+                             " empty continuous extension.");
+    }
+    return start_time_;
+  }
+
+  /// Update extension with the given @p step.
+  ///
+  /// Provided @p step is queued for later consolidation. Note that
+  /// the time the @p step extends cannot be readily evaluated (see
+  /// StepwiseContinuousExtension class documentation).
+  ///
+  /// @param step Integration step to update this extension with.
+  /// @throw std::runtime_error
+  ///   if given @p step has zero length.<br>
+  ///   if given @p step does not ensure C1 continuity at the end of
+  ///   this continuous extension.<br>
+  ///   if given @p step dimensions does not match this continuous
+  ///   extension dimensions.
+  void Update(IntegrationStep step) {
+    ValidateStepCanBeConsolidatedOrThrow(step);
+    raw_steps_.push_back(std::move(step));
+  }
+
+  void Rollback() override {
+    if (raw_steps_.empty()) {
+      throw std::logic_error("No updates to rollback.");
+    }
+    raw_steps_.pop_back();
+  }
+
+  void Consolidate() override {
+    if (raw_steps_.empty()) {
+      throw std::logic_error("No updates to consolidate.");
+    }
+    for (const IntegrationStep& step : raw_steps_) {
+      continuous_trajectory_.ConcatenateInTime(
+          trajectories::PiecewisePolynomial<double>::Cubic(
+              step.get_times(), step.get_states(),
+              step.get_state_derivatives()));
+    }
+    // TODO(hidmic): Remove state keeping members when
+    // PiecewisePolynomial supports return by reference.
+    start_time_ = continuous_trajectory_.start_time();
+    end_time_ = continuous_trajectory_.end_time();
+
+    raw_steps_.clear();
+  }
+
+ private:
+  // Validates that the provided @p step can be consolidated
+  // into this continuous extension.
+  // @see Update(const IntegrationStep&)
+  void ValidateStepCanBeConsolidatedOrThrow(const IntegrationStep& step) {
+    if (step.get_start_time() == step.get_end_time()) {
+      throw std::runtime_error("Provided step has zero length "
+                               "i.e. start time and end time "
+                               "are equal.");
+    }
+    if (!raw_steps_.empty()) {
+      const IntegrationStep& last_raw_step = raw_steps_.back();
+      EnsureExtensionConsistencyOrThrow(step, last_raw_step.get_end_time(),
+                               last_raw_step.get_states().back(),
+                               last_raw_step.get_state_derivatives().back());
+    } else if (!continuous_trajectory_.empty()) {
+      EnsureExtensionConsistencyOrThrow(
+          step, end_time_, continuous_trajectory_.value(end_time_),
+          continuous_trajectory_.derivative().value(end_time_));
+    }
+  }
+
+  // Ensures that the continuous extension would remain consistent if the
+  // provided @p step were to be consolidated at its end.
+  // @param step Integration step to be taken.
+  // @param end_time Continuous extension end time.
+  // @param end_state Continuous extension end state.
+  // @param end_state Continuous extension end state derivative.
+  // @throw std::runtime_error
+  //   if given @p step does not ensure C1 continuity at the end
+  //   of this continuous extension.<br>
+  //   if given @p step dimension does not match this continuous
+  //   extension dimension.
+  void EnsureExtensionConsistencyOrThrow(
+      const IntegrationStep& step, const T& end_time,
+      const MatrixX<T>& end_state, const MatrixX<T>& end_state_derivative) {
+    if (end_state.rows() != step.get_dimensions()) {
+      throw std::runtime_error("Provided step dimension and continuous"
+                               " extension (inferred) dimension do not match.");
+    }
+    // Maximum time misalignment between step and continuous extension that can
+    // still be disregarded as a discontinuity in time.
+    const T allowed_time_misalignment = std::max(std::abs(end_time), 1.) *
+                                        std::numeric_limits<T>::epsilon();
+    const T time_misalignment = std::abs(end_time - step.get_start_time());
+    if (time_misalignment > allowed_time_misalignment) {
+      throw std::runtime_error("Provided step start time and continuous"
+                               " extension end time differ.");
+    }
+    if (!end_state.isApprox(step.get_states().front())) {
+      throw std::runtime_error("Provided step start state and continuous"
+                               " extension end state differ. Cannot ensure"
+                               " C0 continuity.");
+    }
+    if (!end_state_derivative.isApprox(step.get_state_derivatives().front())) {
+      throw std::runtime_error("Provided step start state derivative and"
+                               " continuous extension end state derivative"
+                               " differ. Cannot ensure C1 continuity.");
+    }
+  }
+
+  // The smallest time at which the extension is defined.
+  T start_time_{};
+  // The largest time at which the extension is defined.
+  T end_time_{};
+  // The integration steps taken but not consolidated yet (via Consolidate()).
+  std::vector<IntegrationStep> raw_steps_{};
+  // The underlying PiecewisePolynomial continuous trajectory.
+  trajectories::PiecewisePolynomial<T> continuous_trajectory_{};
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/stepwise_continuous_extension.h
+++ b/systems/analysis/stepwise_continuous_extension.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "drake/systems/analysis/continuous_extension.h"
+
+namespace drake {
+namespace systems {
+
+/// A ContinuousExtension class interface extension, geared towards
+/// step-wise construction procedures. Extensions of this kind are to be
+/// built incrementally by means of discrete updates that extend its domain.
+/// Nature of an update remains implementation specific.
+///
+/// To allow for update rectification (i.e. drop and replacement), in case it
+/// fails to meet certain criteria (e.g. not within tolerances), construction
+/// can be deferred to a consolidation step. In between consolidations, updates
+/// can be rolled back (i.e. discarded) one by one on a last-input-first-output
+/// basis. Implementations are thus encouraged to keep recent updates in a light
+/// weight form, deferring heavier computations and construction of a better
+/// suited representation for evaluation. As such, evaluation is bound to
+/// succeed only after consolidation.
+///
+/// @tparam T A valid Eigen scalar type.
+template <typename T>
+class StepwiseContinuousExtension : public ContinuousExtension<T> {
+ public:
+  /// Rolls back (drops) the last update.
+  /// @remarks This process is irreversible.
+  /// @pre Updates have taken place since instantiation or last
+  ///      consolidation (via Consolidate()).
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual void Rollback() = 0;
+
+  /// Consolidates latest updates.
+  ///
+  /// All updates since last call or construction are put into a form
+  /// that is suitable for evaluation.
+  ///
+  /// @remarks This process is irreversible.
+  /// @pre Updates have taken place since instantiation or last
+  ///      consolidation.
+  /// @post The extents covered by updates since instantiation or
+  ///       last consolidation can be evaluated (via Evaluate()).
+  /// @post Time extents covered by updates can be evaluated
+  ///       (via get_start_time()/get_end_time()).
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual void Consolidate() = 0;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/hermitian_continuous_extension_test.cc
+++ b/systems/analysis/test/hermitian_continuous_extension_test.cc
@@ -1,0 +1,260 @@
+#include "drake/systems/analysis/hermitian_continuous_extension.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+
+namespace drake {
+namespace systems {
+namespace analysis {
+namespace {
+
+template <typename T>
+class HermitianContinuousExtensionTest : public ::testing::Test {
+ protected:
+  const T kInvalidTime{-1.0};
+  const T kInitialTime{0.0};
+  const T kMidTime{0.5};
+  const T kFinalTime{1.0};
+  const T kTimeStep{0.1};
+  const MatrixX<T> kInitialState{
+    (MatrixX<T>(3, 1) << 0., 0., 0.).finished()};
+  const MatrixX<T> kMidState{
+    (MatrixX<T>(3, 1) << 0.5, 5., 50.).finished()};
+  const MatrixX<T> kFinalState{
+    (MatrixX<T>(3, 1) << 1., 10., 100.).finished()};
+  const MatrixX<T> kFinalStateWithFewerDimensions{
+    (MatrixX<T>(2, 1) << 1., 10.).finished()};
+  const MatrixX<T> kFinalStateWithMoreDimensions{
+    (MatrixX<T>(4, 1) << 1., 10., 100., 1000.).finished()};
+  const MatrixX<T> kFinalStateNotAVector{
+    (MatrixX<T>(2, 2) << 1., 10., 100., 1000.).finished()};
+  const MatrixX<T> kInitialStateDerivative{
+    (MatrixX<T>(3, 1) << 0., 1., 0.).finished()};
+  const MatrixX<T> kMidStateDerivative{
+    (MatrixX<T>(3, 1) << 0.5, 0.5, 0.5).finished()};
+  const MatrixX<T> kFinalStateDerivative{
+    (MatrixX<T>(3, 1) << 1., 0., 1.).finished()};
+  const MatrixX<T> kFinalStateDerivativeWithFewerDimensions{
+    (MatrixX<T>(2, 1) << 1., 0.).finished()};
+  const MatrixX<T> kFinalStateDerivativeWithMoreDimensions{
+    (MatrixX<T>(4, 1) << 1., 0., 1., 0.).finished()};
+  const MatrixX<T> kFinalStateDerivativeNotAVector{
+    (MatrixX<T>(2, 2) << 0., 1., 0., 1.).finished()};
+};
+
+// HermitianContinuousExtension types to test.
+typedef ::testing::Types<double> ExtensionTypes;
+
+TYPED_TEST_CASE(HermitianContinuousExtensionTest, ExtensionTypes);
+
+// Checks that HermitianContinuousExtension consistency is ensured.
+TYPED_TEST(HermitianContinuousExtensionTest, ExtensionConsistency) {
+  // Instantiates continuous extension.
+  HermitianContinuousExtension<TypeParam> continuous_extension;
+  // Verifies that the continuous extension is empty and API behavior
+  // is consistent with that fact.
+  ASSERT_TRUE(continuous_extension.is_empty());
+  EXPECT_THROW(continuous_extension.Evaluate(
+      this->kInitialTime), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_start_time(), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_end_time(), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_dimensions(), std::logic_error);
+  EXPECT_THROW(continuous_extension.Rollback(), std::logic_error);
+  EXPECT_THROW(continuous_extension.Consolidate(), std::logic_error);
+
+  // Verifies that trying to update the continuous extension with
+  // a zero length step fails.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep first_step(
+      this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
+  EXPECT_THROW(continuous_extension.Update(first_step), std::runtime_error);
+
+  // Verifies that trying to update the continuous extension with
+  // a valid step succeeds.
+  first_step.Extend(this->kMidTime, this->kMidState,
+                    this->kMidStateDerivative);
+  continuous_extension.Update(first_step);
+
+  // Verifies that an update does not imply a consolidation and thus
+  // the continuous extension remains empty.
+  ASSERT_TRUE(continuous_extension.is_empty());
+  EXPECT_THROW(continuous_extension.Evaluate(
+      this->kMidTime), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_start_time(), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_end_time(), std::logic_error);
+  EXPECT_THROW(continuous_extension.get_dimensions(), std::logic_error);
+
+  // Consolidates all previous updates.
+  continuous_extension.Consolidate();
+
+  // Verifies that it is not possible to roll back updates after consolidation.
+  EXPECT_THROW(continuous_extension.Rollback(), std::logic_error);
+
+  // Verifies that the continuous extension is not empty and that it
+  // reflects the data provided on updates.
+  ASSERT_FALSE(continuous_extension.is_empty());
+  EXPECT_EQ(continuous_extension.get_start_time(), first_step.get_start_time());
+  EXPECT_EQ(continuous_extension.get_end_time(), first_step.get_end_time());
+  EXPECT_EQ(continuous_extension.get_dimensions(), first_step.get_dimensions());
+  EXPECT_NO_THROW(continuous_extension.Evaluate(this->kMidTime));
+
+  // Verifies that invalid evaluation arguments generate errors.
+  EXPECT_THROW(continuous_extension.Evaluate(this->kInvalidTime),
+               std::runtime_error);
+
+  // Verifies that step updates that would disrupt the extension continuity
+  // fail.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep second_step(
+      (this->kFinalTime + this->kMidTime) / 2.,
+      this->kMidState, this->kMidStateDerivative);
+  second_step.Extend(this->kFinalTime, this->kFinalState,
+                     this->kFinalStateDerivative);
+  EXPECT_THROW(continuous_extension.Update(second_step), std::runtime_error);
+
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep third_step(
+      this->kMidTime, this->kMidState * 2., this->kMidStateDerivative);
+  third_step.Extend(this->kFinalTime, this->kFinalState,
+                     this->kFinalStateDerivative);
+  EXPECT_THROW(continuous_extension.Update(third_step), std::runtime_error);
+
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep fourth_step(
+      this->kMidTime, this->kMidState, this->kMidStateDerivative * 2.);
+  fourth_step.Extend(this->kFinalTime, this->kFinalState,
+                     this->kFinalStateDerivative);
+  EXPECT_THROW(continuous_extension.Update(fourth_step), std::runtime_error);
+}
+
+// Checks that HermitianContinuousExtension::Step consistency is ensured.
+TYPED_TEST(HermitianContinuousExtensionTest, StepsConsistency) {
+  // Verifies that zero length steps are properly constructed.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep step(
+      this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
+  ASSERT_EQ(step.get_times().size(), 1);
+  EXPECT_EQ(step.get_start_time(), this->kInitialTime);
+  EXPECT_EQ(step.get_end_time(), this->kInitialTime);
+  EXPECT_EQ(step.get_dimensions(), this->kInitialState.rows());
+  ASSERT_EQ(step.get_states().size(), 1);
+  EXPECT_TRUE(CompareMatrices(step.get_states().front(), this->kInitialState));
+  ASSERT_EQ(step.get_state_derivatives().size(), 1);
+  EXPECT_TRUE(CompareMatrices(step.get_state_derivatives().front(),
+                              this->kInitialStateDerivative));
+
+  // Verifies that any attempt to break step consistency fails.
+  EXPECT_THROW(step.Extend(this->kInvalidTime, this->kFinalState,
+                           this->kFinalStateDerivative),
+               std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime,
+                           this->kFinalStateWithFewerDimensions,
+                           this->kFinalStateDerivative), std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime,
+                           this->kFinalStateWithMoreDimensions,
+                           this->kFinalStateDerivative), std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime,
+                           this->kFinalStateNotAVector,
+                           this->kFinalStateDerivative), std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
+                           this->kFinalStateDerivativeWithFewerDimensions),
+               std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
+                           this->kFinalStateDerivativeWithMoreDimensions),
+               std::runtime_error);
+
+  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
+                           this->kFinalStateDerivativeNotAVector),
+               std::runtime_error);
+
+  // Extends the step with appropriate values.
+  step.Extend(this->kFinalTime, this->kFinalState, this->kFinalStateDerivative);
+
+  // Verifies that the step was properly extended.
+  EXPECT_EQ(step.get_times().size(), 2);
+  EXPECT_EQ(step.get_start_time(), this->kInitialTime);
+  EXPECT_EQ(step.get_end_time(), this->kFinalTime);
+  EXPECT_EQ(step.get_dimensions(), this->kInitialState.rows());
+  EXPECT_EQ(step.get_states().size(), 2);
+  EXPECT_TRUE(CompareMatrices(step.get_states().back(), this->kFinalState));
+  EXPECT_EQ(step.get_state_derivatives().size(), 2);
+  EXPECT_TRUE(CompareMatrices(step.get_state_derivatives().back(),
+                              this->kFinalStateDerivative));
+}
+
+// Checks that HermitianContinuousExtension properly supports stepwise
+// construction.
+TYPED_TEST(HermitianContinuousExtensionTest, CorrectConstruction) {
+  // Instantiates continuous extension.
+  HermitianContinuousExtension<TypeParam> continuous_extension;
+  // Updates extension for the first time.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep first_step(
+      this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
+  first_step.Extend(this->kMidTime, this->kMidState, this->kMidStateDerivative);
+  continuous_extension.Update(first_step);
+  // Updates extension a second time.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep second_step(
+      this->kMidTime, this->kMidState, this->kMidStateDerivative);
+  second_step.Extend(this->kFinalTime, this->kFinalState,
+                     this->kFinalStateDerivative);
+  continuous_extension.Update(second_step);
+  // Rolls back the last update.
+  continuous_extension.Rollback();  // `second_step`
+  // Consolidates existing updates.
+  continuous_extension.Consolidate();  // only `first_step`
+
+  // Verifies that the continuous extension only reflects the first step.
+  EXPECT_FALSE(continuous_extension.is_empty());
+  EXPECT_EQ(continuous_extension.get_start_time(), first_step.get_start_time());
+  EXPECT_EQ(continuous_extension.get_end_time(), first_step.get_end_time());
+  EXPECT_EQ(continuous_extension.get_dimensions(), first_step.get_dimensions());
+  EXPECT_TRUE(CompareMatrices(continuous_extension.Evaluate(this->kInitialTime),
+                              first_step.get_states().front()));
+  EXPECT_TRUE(CompareMatrices(continuous_extension.Evaluate(this->kMidTime),
+                              first_step.get_states().back()));
+}
+
+// Checks that HermitianContinuousExtension properly implements and evaluates
+// an Hermite interpolator.
+TYPED_TEST(HermitianContinuousExtensionTest, CorrectEvaluation) {
+  // Creates an Hermite cubic spline with times, states and state
+  // derivatives.
+  const trajectories::PiecewisePolynomial<double> hermite_spline =
+      trajectories::PiecewisePolynomial<double>::Cubic(
+          {this->kInitialTime, this->kMidTime, this->kFinalTime},
+          {this->kInitialState, this->kMidState, this->kFinalState},
+          {this->kInitialStateDerivative, this->kMidStateDerivative,
+                this->kFinalStateDerivative});
+  // Instantiates continuous extension.
+  HermitianContinuousExtension<TypeParam> continuous_extension;
+  // Updates extension for the first time.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep first_step(
+      this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
+  first_step.Extend(this->kMidTime, this->kMidState, this->kMidStateDerivative);
+  continuous_extension.Update(first_step);
+  // Updates extension a second time.
+  typename HermitianContinuousExtension<TypeParam>::IntegrationStep second_step(
+      this->kMidTime, this->kMidState, this->kMidStateDerivative);
+  second_step.Extend(this->kFinalTime, this->kFinalState,
+                     this->kFinalStateDerivative);
+  continuous_extension.Update(second_step);
+  // Consolidates all previous updates.
+  continuous_extension.Consolidate();
+  // Verifies that continuous extensions and Hermite spline match.
+  const double kAccuracy{1e-12};
+  EXPECT_FALSE(continuous_extension.is_empty());
+  for (TypeParam t = this->kInitialTime;
+       t <= this->kFinalTime; t += this->kTimeStep) {
+    EXPECT_TRUE(CompareMatrices(continuous_extension.Evaluate(t),
+                                hermite_spline.value(t),
+                                kAccuracy));
+  }
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This pull request is the second of a series of pull requests that ultimately introduce continuous extensions to Drake i.e. continuous approximations to numerical integration solutions. 

Specifically, this PR introduces the `ContinuousExtension` class and the `StepwiseContinuousExtension` class (interfaces, the latter in preparation for integrator level support), along with the `HermitianContinuousExtension` class, an implementation of the former using Hermite splines (currently supporting floating point type scalars only).

This PR builds on top of #8949 and as such it should be reviewed/merged afterwards.

For further details, refer to the [full diff](https://github.com/RobotLocomotion/drake/compare/master...ekumenlabs:Issue/Systems_Continuous_Extension_Support_For_IVP_Solvers) of the series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8950)
<!-- Reviewable:end -->
