### PR TITLE
Adds dense output support at IVP classes' level

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_library(
     hdrs = ["dense_output.h"],
     deps = [
         "//common:essential",
+        "@fmt"
     ],
 )
 
@@ -77,6 +78,7 @@ drake_cc_library(
         ":dense_output",
         ":scalar_dense_output",
         "//common:essential",
+        "@fmt"
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -37,7 +37,7 @@ drake_cc_library(
     hdrs = ["dense_output.h"],
     deps = [
         "//common:essential",
-        "@fmt"
+        "@fmt",
     ],
 )
 
@@ -78,7 +78,7 @@ drake_cc_library(
         ":dense_output",
         ":scalar_dense_output",
         "//common:essential",
-        "@fmt"
+        "@fmt",
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -23,7 +23,9 @@ drake_cc_package_library(
         ":lyapunov",
         ":runge_kutta2_integrator",
         ":runge_kutta3_integrator",
+        ":scalar_dense_output",
         ":scalar_initial_value_problem",
+        ":scalar_view_dense_output",
         ":semi_explicit_euler_integrator",
         ":simulator",
         ":stepwise_dense_output",
@@ -57,6 +59,24 @@ drake_cc_library(
         "//common:extract_double",
         "//common/trajectories:piecewise_polynomial",
         "//systems/framework:vector",
+    ],
+)
+
+drake_cc_library(
+    name = "scalar_dense_output",
+    hdrs = ["scalar_dense_output.h"],
+    deps = [
+        "//common:essential",
+    ],
+)
+
+drake_cc_library(
+    name = "scalar_view_dense_output",
+    hdrs = ["scalar_view_dense_output.h"],
+    deps = [
+        ":dense_output",
+        ":scalar_dense_output",
+        "//common:essential",
     ],
 )
 
@@ -150,6 +170,7 @@ drake_cc_library(
         "initial_value_problem-inl.h",
     ],
     deps = [
+        ":dense_output",
         ":integrator_base",
         ":runge_kutta3_integrator",
         "//systems/framework:context",
@@ -167,9 +188,12 @@ drake_cc_library(
     ],
     hdrs = [
         "scalar_initial_value_problem.h",
+        "scalar_initial_value_problem-inl.h",
     ],
     deps = [
         ":initial_value_problem",
+        ":scalar_dense_output",
+        ":scalar_view_dense_output",
         "//common:essential",
         "//common:unused",
     ],
@@ -182,8 +206,10 @@ drake_cc_library(
     ],
     hdrs = [
         "antiderivative_function.h",
+        "antiderivative_function-inl.h",
     ],
     deps = [
+        ":scalar_dense_output",
         ":scalar_initial_value_problem",
         "//common:essential",
         "//common:unused",
@@ -311,6 +337,16 @@ drake_cc_googletest(
         "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
         "//common/trajectories:piecewise_polynomial",
+    ],
+)
+
+drake_cc_googletest(
+    name = "scalar_view_dense_output_test",
+    deps = [
+        ":hermitian_dense_output",
+        ":scalar_view_dense_output",
+        "//common:autodiff",
+        "//common:essential",
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -354,6 +354,7 @@ drake_cc_googletest(
         ":scalar_view_dense_output",
         "//common:autodiff",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -310,6 +310,7 @@ drake_cc_googletest(
         ":initial_value_problem",
         ":runge_kutta2_integrator",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -318,6 +319,7 @@ drake_cc_googletest(
     deps = [
         ":runge_kutta2_integrator",
         ":scalar_initial_value_problem",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -326,6 +328,7 @@ drake_cc_googletest(
     deps = [
         ":antiderivative_function",
         ":runge_kutta2_integrator",
+        "//common/test_utilities:expect_throws_message",
     ],
 )
 
@@ -336,6 +339,7 @@ drake_cc_googletest(
         "//common:autodiff",
         "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
+        "//common/test_utilities:expect_throws_message",
         "//common/trajectories:piecewise_polynomial",
     ],
 )

--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -173,6 +173,7 @@ drake_cc_library(
         ":dense_output",
         ":integrator_base",
         ":runge_kutta3_integrator",
+        "//common:default_scalars",
         "//systems/framework:context",
         "//systems/framework:continuous_state",
         "//systems/framework:leaf_system",
@@ -194,6 +195,7 @@ drake_cc_library(
         ":initial_value_problem",
         ":scalar_dense_output",
         ":scalar_view_dense_output",
+        "//common:default_scalars",
         "//common:essential",
         "//common:unused",
     ],
@@ -211,6 +213,7 @@ drake_cc_library(
     deps = [
         ":scalar_dense_output",
         ":scalar_initial_value_problem",
+        "//common:default_scalars",
         "//common:essential",
         "//common:unused",
     ],

--- a/systems/analysis/antiderivative_function-inl.h
+++ b/systems/analysis/antiderivative_function-inl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "drake/systems/analysis/scalar_initial_value_problem-inl.h"

--- a/systems/analysis/antiderivative_function-inl.h
+++ b/systems/analysis/antiderivative_function-inl.h
@@ -1,3 +1,5 @@
 #pragma once
 
+// Instantiation of AntiderivateFunction<T> for T other than double
+// requires ScalarInitialValueProblem<T> definition.
 #include "drake/systems/analysis/scalar_initial_value_problem-inl.h"

--- a/systems/analysis/antiderivative_function.cc
+++ b/systems/analysis/antiderivative_function.cc
@@ -1,4 +1,5 @@
 #include "drake/systems/analysis/antiderivative_function.h"
+#include "drake/systems/analysis/antiderivative_function-inl.h"
 
 namespace drake {
 namespace systems {

--- a/systems/analysis/antiderivative_function.cc
+++ b/systems/analysis/antiderivative_function.cc
@@ -1,10 +1,13 @@
 #include "drake/systems/analysis/antiderivative_function.h"
 #include "drake/systems/analysis/antiderivative_function-inl.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace systems {
 
-template class AntiderivativeFunction<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class AntiderivativeFunction);
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -147,14 +147,15 @@ class AntiderivativeFunction {
   ///
   /// @param w The uppermost integration bound.
   /// @param values The specified values for the integration.
-  /// @returns A dense approximation to F(u; 𝐤), defined for v ≤ u ≤ w.
+  /// @returns A dense approximation to F(u; 𝐤) (that is, a function), defined
+  ///          for v ≤ u ≤ w.
   /// @pre The given uppermost integration bound @p w must be larger than or
   ///      equal to the lower integration bound v.
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.
   /// @throws std::logic_error if any of the preconditions is not met.
-  std::unique_ptr<ScalarDenseOutput<T>> DenseEvaluate(
+  std::unique_ptr<ScalarDenseOutput<T>> MakeDenseEvalFunction(
       const T& w, const SpecifiedValues& values = {}) const {
     // Delegates request to the scalar IVP used for computations, by putting
     // specified values in scalar IVP terms.

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -145,11 +145,15 @@ class AntiderivativeFunction {
   /// present in @p values, falling back to the ones given on construction
   /// if missing.
   ///
-  /// @param w The uppermost integration bound, usually v < @p w, as an empty
+  /// @param w The uppermost integration bound. Usually, v < @p w as an empty
   ///          dense output would result if v = @p w.
   /// @param values The specified values for the integration.
   /// @returns A dense approximation to F(u; 𝐤) (that is, a function), defined
   ///          for v ≤ u ≤ w.
+  /// @note The larger the given @p w value is, the larger the approximated
+  ///       interval will be. See documentation of the specific dense output
+  ///       technique in use for reference on performance impact as this
+  ///       interval grows.
   /// @pre The given uppermost integration bound @p w must be larger than or
   ///      equal to the lower integration bound v.
   /// @pre If given, the dimension of the parameter vector @p values.k

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -145,6 +145,11 @@ class AntiderivativeFunction {
   /// present in @p values, falling back to the ones given on construction
   /// if missing.
   ///
+  /// To this end, the wrapped IntegratorBase instance solves the integral
+  /// from v to @p w (i.e. advances the state x of its differential form
+  /// x'(t) = f(x; 𝐤) from v to @p w), creating a scalar dense output over
+  /// that [v, @p w] interval along the way.
+  ///
   /// @param w The uppermost integration bound. Usually, v < @p w as an empty
   ///          dense output would result if v = @p w.
   /// @param values The specified values for the integration.

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -145,7 +145,8 @@ class AntiderivativeFunction {
   /// present in @p values, falling back to the ones given on construction
   /// if missing.
   ///
-  /// @param w The uppermost integration bound.
+  /// @param w The uppermost integration bound, usually v < @p w, as an empty
+  ///          dense output would result if v = @p w.
   /// @param values The specified values for the integration.
   /// @returns A dense approximation to F(u; 𝐤) (that is, a function), defined
   ///          for v ≤ u ≤ w.

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -124,13 +124,13 @@ class AntiderivativeFunction {
   ///
   /// @param u The upper integration bound.
   /// @param values The specified values for the integration.
-  /// @return The value of the definite integral.
+  /// @returns The value of the definite integral.
   /// @pre The given upper integration bound @p u must be larger than or equal
   ///      to the lower integration bound v.
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   T Evaluate(const T& u, const SpecifiedValues& values = {}) const {
     typename ScalarInitialValueProblem<T>::SpecifiedValues
         scalar_ivp_values(values.v, {}, values.k);
@@ -138,28 +138,29 @@ class AntiderivativeFunction {
   }
 
   /// Evaluates and yields an approximation of the definite integral
-  /// F(u; 𝐤) = ∫ᵥᵘ f(x; 𝐤) dx for the closed interval that goes from the
-  /// lower integration bound v (see definition in class documentation) to
-  /// the uppermost integration bound @p w using the parameter vector 𝐤 (see
-  /// definition in class documentation) if present in @p values, falling back
-  /// to the ones given on construction if missing.
+  /// F(u; 𝐤) = ∫ᵥᵘ f(x; 𝐤) dx for v ≤ u ≤ w, i.e. the closed interval
+  /// that goes from the lower integration bound v (see definition in
+  /// class documentation) to the uppermost integration bound @p w, using
+  /// the parameter vector 𝐤 (see definition in class documentation) if
+  /// present in @p values, falling back to the ones given on construction
+  /// if missing.
   ///
   /// @param w The uppermost integration bound.
   /// @param values The specified values for the integration.
-  /// @return A dense approximation to F(u; 𝐤), defined for v <= u <= w.
+  /// @returns A dense approximation to F(u; 𝐤), defined for v ≤ u ≤ w.
   /// @pre The given upper integration bound @p u must be larger than or equal
   ///      to the lower integration bound v.
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   std::unique_ptr<ScalarDenseOutput<T>> DenseEvaluate(
-      const T& u, const SpecifiedValues& values = {}) const {
+      const T& w, const SpecifiedValues& values = {}) const {
     // Delegates request to the scalar IVP used for computations, by putting
     // specified values in scalar IVP terms.
     typename ScalarInitialValueProblem<T>::SpecifiedValues
         scalar_ivp_values(values.v, {}, values.k);
-    return this->scalar_ivp_->DenseSolve(u, scalar_ivp_values);
+    return this->scalar_ivp_->DenseSolve(w, scalar_ivp_values);
   }
 
   /// Resets the internal integrator instance.
@@ -170,7 +171,7 @@ class AntiderivativeFunction {
   /// @endcode
   ///
   /// @param args The integrator type-specific arguments.
-  /// @return The new integrator instance.
+  /// @returns The new integrator instance.
   /// @tparam Integrator The integrator type, which must be an
   ///                    IntegratorBase subclass.
   /// @tparam Args The integrator specific argument types.

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -148,8 +148,8 @@ class AntiderivativeFunction {
   /// @param w The uppermost integration bound.
   /// @param values The specified values for the integration.
   /// @returns A dense approximation to F(u; 𝐤), defined for v ≤ u ≤ w.
-  /// @pre The given upper integration bound @p u must be larger than or equal
-  ///      to the lower integration bound v.
+  /// @pre The given uppermost integration bound @p w must be larger than or
+  ///      equal to the lower integration bound v.
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector 𝐤 in the default specified
   ///      values given on construction.

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -18,21 +18,15 @@ namespace systems {
 /// Drake's ODE initial value problem solvers ("integrators"), provide the
 /// ability to perform quadrature on an arbitrary scalar integrable function.
 /// That is, it allows the evaluation of an antiderivative function F(u; 𝐤),
-/// such that F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx where f : ℝ  →  ℝ , u ∈ ℝ, v ∈ ℝ,
+/// such that F(u; 𝐤) = ∫ᵥᵘ f(x; 𝐤) dx where f : ℝ  →  ℝ , u ∈ ℝ, v ∈ ℝ,
 /// 𝐤 ∈ ℝᵐ. The parameter vector 𝐤 allows for generic function definitions,
 /// which can later be evaluated for any instance of said vector. Also, note
 /// that 𝐤 can be understood as an m-tuple or as an element of ℝᵐ, the vector
 /// space, depending on how it is used by the integrable function.
 ///
-/// Additionally, configured integrator's dense output support can be leveraged
-/// to efficiently approximate the antiderivative function F within integration
-/// intervals. This is convenient when there's a need for a more dense sampling
-/// of F than what would be available through either fixed or error-controlled
-/// step integration (for a given accuracy), or when F is to be evaluated at a
-/// high rate for arbitrary values of u within a given interval.
-/// See ScalarInitialValueProblem class documentation for further details on
-/// dense output usage. See configured integrator's documentation for further
-/// reference on the specific dense output technique in use.
+/// See ScalarInitialValueProblem class documentation for information
+/// on caching support and dense output usage for improved efficiency in
+/// antiderivative function F evaluation.
 ///
 /// For further insight into its use, consider the following examples.
 ///
@@ -123,7 +117,7 @@ class AntiderivativeFunction {
         scalar_ode_function, scalar_ivp_default_values);
   }
 
-  /// Evaluates the definite integral F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx from the lower
+  /// Evaluates the definite integral F(u; 𝐤) = ∫ᵥᵘ f(x; 𝐤) dx from the lower
   /// integration bound v (see definition in class documentation) to @p u using
   /// the parameter vector 𝐤 (see definition in class documentation) if present
   /// in @p values, falling back to the ones given on construction if missing.
@@ -144,7 +138,7 @@ class AntiderivativeFunction {
   }
 
   /// Evaluates and yields an approximation of the definite integral
-  /// F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx for the closed interval that goes from the
+  /// F(u; 𝐤) = ∫ᵥᵘ f(x; 𝐤) dx for the closed interval that goes from the
   /// lower integration bound v (see definition in class documentation) to
   /// the uppermost integration bound @p w using the parameter vector 𝐤 (see
   /// definition in class documentation) if present in @p values, falling back

--- a/systems/analysis/antiderivative_function.h
+++ b/systems/analysis/antiderivative_function.h
@@ -24,11 +24,15 @@ namespace systems {
 /// that 𝐤 can be understood as an m-tuple or as an element of ℝᵐ, the vector
 /// space, depending on how it is used by the integrable function.
 ///
-/// Additionally, support for computing the antiderivative function F for
-/// entire integration intervals is provided. This is convenient when a more
-/// dense sampling of the IVP solution than what would be available through
-/// either fixed or error-controlled step integration (for a given accuracy)
-/// is needed.
+/// Additionally, configured integrator's dense output support can be leveraged
+/// to efficiently approximate the antiderivative function F within integration
+/// intervals. This is convenient when there's a need for a more dense sampling
+/// of F than what would be available through either fixed or error-controlled
+/// step integration (for a given accuracy), or when F is to be evaluated at a
+/// high rate for arbitrary values of u within a given interval.
+/// See ScalarInitialValueProblem class documentation for further details on
+/// dense output usage. See configured integrator's documentation for further
+/// reference on the specific dense output technique in use.
 ///
 /// For further insight into its use, consider the following examples.
 ///
@@ -139,11 +143,12 @@ class AntiderivativeFunction {
     return scalar_ivp_->Solve(u, scalar_ivp_values);
   }
 
-  /// Evaluates the definite integral F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx for the whole
-  /// interval that goes from the lower integration bound v (see definition
-  /// in class documentation) to the uppermost integration bound @p w using
-  /// the parameter vector 𝐤 (see definition in class documentation) if present
-  /// in @p values, falling back to the ones given on construction if missing.
+  /// Evaluates and yields an approximation of the definite integral
+  /// F(u; 𝐤) =∫ᵥᵘ f(x; 𝐤) dx for the closed interval that goes from the
+  /// lower integration bound v (see definition in class documentation) to
+  /// the uppermost integration bound @p w using the parameter vector 𝐤 (see
+  /// definition in class documentation) if present in @p values, falling back
+  /// to the ones given on construction if missing.
   ///
   /// @param w The uppermost integration bound.
   /// @param values The specified values for the integration.

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -65,7 +65,7 @@ class DenseOutput {
   ///       method may be lower than that of of indexing an
   ///       Evaluate(const T&) call return vector value, thus making
   ///       it the preferred mechanism when targeting a single dimension.
-  /// @param t Time to evaluate output at.
+  /// @param t Time at which to evaluate output.
   /// @param dimension Dimension to evaluate.
   /// @returns Output @p dimension scalar value.
   /// @pre Output is not empty i.e. is_empty() equals false.

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -53,15 +53,15 @@ class DenseOutput {
   /// @returns Output vector value.
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throws std::logic_error if any of the preconditions are not met.
-  /// @throws std::runtime_error if given @p t is not valid
-  ///                            i.e. start_time() ≤ @p t ≤ end_time().
+  /// @throws std::runtime_error if given @p t is not within output's domain
+  ///                            i.e. @p t ∉ [start_time(), end_time()].
   VectorX<T> Evaluate(const T& t) const {
     ThrowIfOutputIsEmpty(__func__);
     ThrowIfTimeIsInvalid(__func__, t);
     return this->DoEvaluate(t);
   }
 
-  /// Evaluates the output value `n`th scalar element (0-indexed) at the
+  /// Evaluates the output value's `n`th scalar element (0-indexed) at the
   /// given time @p t.
   /// @note On some implementations, the computational cost of this
   ///       method may be lower than that of indexing an Evaluate(const T&)
@@ -73,10 +73,10 @@ class DenseOutput {
   /// @returns Output value's `n`th scalar element (0-indexed).
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throws std::logic_error if any of the preconditions are not met.
-  /// @throws std::runtime_error if given @p t is not valid
-  ///                            i.e. start_time() ≤ @p t ≤ end_time().
-  /// @throws std::runtime_error if given @p n is not valid
-  ///                            i.e. 0 ≤ @p n < size().
+  /// @throws std::runtime_error if given @p t is not within output's domain
+  ///                            i.e. @p t ∉ [start_time(), end_time()].
+  /// @throws std::runtime_error if given @p n does not refer to a valid
+  ///                            output dimension i.e. @p n ∉ [0, size()).
   T EvaluateNth(const T& t, int n) const {
     ThrowIfOutputIsEmpty(__func__);
     ThrowIfNthElementIsInvalid(__func__, n);
@@ -142,8 +142,7 @@ class DenseOutput {
 
   // Asserts that this dense output is not empty.
   // @param func_name Call site name for error message clarity (i.e. __func__).
-  // @throws std::logic_error if output is empty i.e. is_empty()
-  //                          equals false..
+  // @throws std::logic_error if output is empty i.e. is_empty() equals false.
   void ThrowIfOutputIsEmpty(const char* func_name) const {
     if (is_empty()) {
       throw std::logic_error(fmt::format(
@@ -154,8 +153,8 @@ class DenseOutput {
   // Asserts that the given element index @p n is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
   // @param n The nth scalar element (0-indexed) to be checked.
-  // @throws std::runtime_error if given @p n is not valid
-  //                            i.e. 0 ≤ @p n < size().
+  // @throws std::runtime_error if given @p n does not refer to a valid
+  //                            output dimension i.e. @p n ∉ [0, size()).
   void ThrowIfNthElementIsInvalid(const char* func_name, int n) const {
     if (n < 0 || this->do_size() <= n) {
       throw std::runtime_error(fmt::format(
@@ -167,8 +166,8 @@ class DenseOutput {
   // Asserts that the given given time @p t is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
   // @param t Time to be checked.
-  // @throws std::runtime_error if given @p t is not valid
-  //                            i.e. start_time() ≤ @p t ≤ end_time().
+  // @throws std::runtime_error if given @p t is not within output's domain
+  //                            i.e. @p t ∉ [start_time(), end_time()].
   void ThrowIfTimeIsInvalid(const char* func_name, const T& t) const {
     if (t < this->do_start_time() || t > this->do_end_time()) {
       throw std::runtime_error(fmt::format(

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -74,7 +74,7 @@ class DenseOutput {
   ///                            given @p t.
   /// @throws std::runtime_error if given @p dimension is not valid
   ///                            i.e. 0 <= @p dimension < size().
-  T Evaluate(const T& t, int dimension) const {
+  T EvaluateNth(const T& t, int dimension) const {
     if (is_empty()) {
       throw std::logic_error("Empty dense output cannot be evaluated.");
     }
@@ -84,7 +84,7 @@ class DenseOutput {
     if (t < this->do_start_time() || t > this->do_end_time()) {
       throw std::runtime_error("Dense output is not defined for given time.");
     }
-    return this->DoEvaluate(t, dimension);
+    return this->DoEvaluateNth(t, dimension);
   }
 
   /// Returns the output size (i.e. the number of elements in an
@@ -129,7 +129,6 @@ class DenseOutput {
  protected:
   DenseOutput() = default;
 
- private:
   // @see Evaluate(const T&)
   virtual VectorX<T> DoEvaluate(const T& t) const = 0;
 
@@ -137,7 +136,7 @@ class DenseOutput {
   //          be less than or equal to that of indexing
   //          DoEvaluate(const T&) return value.
   // @see Evaluate(const T&, int)
-  virtual T DoEvaluate(const T& t, int dimension) const {
+  virtual T DoEvaluateNth(const T& t, int dimension) const {
     return this->DoEvaluate(t)(dimension);
   }
 

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -6,9 +6,9 @@
 namespace drake {
 namespace systems {
 
-/// An interface for dense output of ODEs and DAEs solutions, to efficiently
-/// approximate them at arbitrarily many points when solving them numerically
-/// (see IntegratorBase class documentation).
+/// An interface for dense output of ODEs solutions, to efficiently approximate
+/// them at arbitrarily many points when solving them numerically (see
+/// IntegratorBase class documentation).
 ///
 /// Multiple definitions of _dense output_ may be found in literature. For some
 /// authors, it refers to the process of repeatedly adjusting the integration
@@ -49,10 +49,9 @@ class DenseOutput {
   virtual VectorX<T> Evaluate(const T& t) const = 0;
 
   /// Evaluates the output's @p dimension at the given time @p t.
-  /// @remarks The computational cost of this method may vary across
-  ///          implementations but it's guaranteed to be less than or
-  ///          equal to that of of indexing an Evaluate(const T&) call
-  ///          return.
+  /// @note On some implementations, the computational cost of this
+  ///       method may be lower than that of of indexing an
+  ///       Evaluate(const T&) call return vector value.
   /// @param t Time to evaluate output at.
   /// @param dimension Dimension to evaluate.
   /// @return Output @p dimension scalar value .

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -32,8 +32,8 @@ namespace systems {
 /// @warning Dense outputs are, in general, not bound to attain the same
 ///          accuracy that error-controlled integration schemes do. Check
 ///          each subclass documentation for further specification.
-/// @warning Note that dense outputs do not enforce the same solution
-///          constraints that integrators may enforce on each time step.
+/// @warning Note that dense outputs do not enforce any algebraic constraints
+///          on the solution that integrators might enforce.
 ///
 /// - [Engquist, 2105] B. Engquist. Encyclopedia of Applied and Computational
 ///                    Mathematics, p. 339, Springer, 2015.
@@ -61,15 +61,16 @@ class DenseOutput {
     return this->DoEvaluate(t);
   }
 
-  /// Evaluates the output value `n`th scalar element at the given time @p t.
+  /// Evaluates the output value `n`th scalar element (0-indexed) at the
+  /// given time @p t.
   /// @note On some implementations, the computational cost of this
-  ///       method may be lower than that of of indexing an
-  ///       Evaluate(const T&) call return vector value, thus making
-  ///       it the preferred mechanism when targeting a single dimension.
+  ///       method may be lower than that of indexing an Evaluate(const T&)
+  ///       call return vector value, thus making it the preferred mechanism
+  ///       when targeting a single dimension.
   /// @param t Time at which to evaluate output.
-  /// @param n The nth element (or 0-indexed dimension) of the output
+  /// @param n The nth scalar element (0-indexed) of the output
   ///          value to evaluate.
-  /// @returns Output value `n`th scalar element (or 0-indexed dimension).
+  /// @returns Output value's `n`th scalar element (0-indexed).
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throws std::logic_error if any of the preconditions are not met.
   /// @throws std::runtime_error if given @p t is not valid
@@ -78,7 +79,7 @@ class DenseOutput {
   ///                            i.e. 0 ≤ @p n < size().
   T EvaluateNth(const T& t, int n) const {
     ThrowIfOutputIsEmpty(__func__);
-    ThrowIfNthDimensionIsInvalid(__func__, n);
+    ThrowIfNthElementIsInvalid(__func__, n);
     ThrowIfTimeIsInvalid(__func__, t);
     return this->DoEvaluateNth(t, n);
   }
@@ -150,15 +151,15 @@ class DenseOutput {
     }
   }
 
-  // Asserts that the given dimension @p n is valid for this dense output.
+  // Asserts that the given element index @p n is valid for this dense output.
   // @param func_name Call site name for error message clarity (i.e. __func__).
-  // @param n The nth scalar element (or 0-indexed dimension) to be checked.
+  // @param n The nth scalar element (0-indexed) to be checked.
   // @throws std::runtime_error if given @p n is not valid
   //                            i.e. 0 ≤ @p n < size().
-  void ThrowIfNthDimensionIsInvalid(const char* func_name, int n) const {
+  void ThrowIfNthElementIsInvalid(const char* func_name, int n) const {
     if (n < 0 || this->do_size() <= n) {
       throw std::runtime_error(fmt::format(
-          "{}(): Dimension {} out of dense output [0, {}) range.",
+          "{}(): Index {} out of dense output [0, {}) range.",
           func_name, n, this->do_size()));
     }
   }

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -48,6 +48,18 @@ class DenseOutput {
   ///                           given @p t.
   virtual VectorX<T> Evaluate(const T& t) const = 0;
 
+  /// Evaluates the output's @p dimension at the given time @p t.
+  /// @param t Time to evaluate output at.
+  /// @param dimension Dimension to evaluate.
+  /// @return Output @p dimension scalar value .
+  /// @pre Output is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions are not met.
+  /// @throw std::runtime_error if the output is not defined for the
+  ///                           given @p t.
+  /// @throw std::runtime_error if given @p dimension is not valid
+  ///                           i.e. 0 <= @p dimension < get_dimensions().
+  virtual T Evaluate(const T& t, int dimension) const = 0;
+
   /// Returns the output dimension `n`.
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throw std::logic_error if any of the preconditions is not met.

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -6,7 +6,7 @@
 namespace drake {
 namespace systems {
 
-/// An interface for dense output of ODE and DAE solutions, to efficiently
+/// An interface for dense output of ODEs and DAEs solutions, to efficiently
 /// approximate them at arbitrarily many points when solving them numerically
 /// (see IntegratorBase class documentation).
 ///
@@ -49,6 +49,10 @@ class DenseOutput {
   virtual VectorX<T> Evaluate(const T& t) const = 0;
 
   /// Evaluates the output's @p dimension at the given time @p t.
+  /// @remarks The computational cost of this method may vary across
+  ///          implementations but it's guaranteed to be less than or
+  ///          equal to that of of indexing an Evaluate(const T&) call
+  ///          return.
   /// @param t Time to evaluate output at.
   /// @param dimension Dimension to evaluate.
   /// @return Output @p dimension scalar value .

--- a/systems/analysis/dense_output.h
+++ b/systems/analysis/dense_output.h
@@ -128,8 +128,8 @@ class DenseOutput {
   // @see Evaluate(const T&)
   virtual VectorX<T> DoEvaluate(const T& t) const = 0;
 
-  // @remarks The computational cost of this method ought
-  //          to be less than or equal to that of indexing
+  // @remarks The computational cost of this method must
+  //          be less than or equal to that of indexing
   //          DoEvaluate(const T&) return value.
   // @see Evaluate(const T&, int)
   virtual T DoEvaluate(const T& t, int dimension) const {

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -280,14 +280,14 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     raw_steps_.clear();
   }
 
- private:
+ protected:
   VectorX<T> DoEvaluate(const T& t) const override {
     const MatrixX<double> matrix_value =
         continuous_trajectory_.value(ExtractDoubleOrThrow(t));
     return matrix_value.col(0).cast<T>();
   }
 
-  T DoEvaluate(const T& t, const int dimension) const override {
+  T DoEvaluateNth(const T& t, const int dimension) const override {
     return continuous_trajectory_.scalarValue(
         ExtractDoubleOrThrow(t), dimension, 0);
   }
@@ -304,6 +304,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
 
   const T& do_start_time() const override { return start_time_; }
 
+ private:
   // Validates that the provided @p step can be consolidated into this
   // dense output.
   // @see Update(const IntegrationStep&)

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -84,6 +84,10 @@ ExtractDoublesOrThrow(const std::vector<MatrixX<S>>& input_vector) {
 /// of the integration scheme being used for up to 3rd order schemes (see
 /// [Hairer, 1993]).
 ///
+/// From a performance standpoint, memory footprint and evaluation overhead
+/// (i.e. the computational cost of an evaluation) increase linearly and
+/// logarithmically with the amount of steps taken, respectively.
+///
 /// - [Engquist, 2105] B. Engquist. Encyclopedia of Applied and Computational
 ///                    Mathematics, p. 339, Springer, 2015.
 /// - [Hairer, 1993] E. Hairer, S. Nørsett and G. Wanner. Solving Ordinary

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -123,7 +123,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     /// @param initial_state_derivative Initial state derivative vector
     ///                                 d𝐱/dt₀ at @p initial_time as a
     ///                                 column matrix.
-    /// @throw std::runtime_error
+    /// @throws std::runtime_error
     ///   if given @p initial_state 𝐱₀ is not a column matrix.<br>
     ///   if given @p initial_state_derivative d𝐱/t₀ is not a column
     ///   matrix.<br>
@@ -147,7 +147,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     /// @param state State vector 𝐱ᵢ at @p time tᵢ as a column matrix.
     /// @param state_derivative State derivative vector d𝐱/dtᵢ at @p time tᵢ
     ///                         as a column matrix.
-    /// @throw std::runtime_error
+    /// @throws std::runtime_error
     ///   if given @p state 𝐱ᵢ is not a column matrix.<br>
     ///   if given @p state_derivative d𝐱/dtᵢ is not a column matrix.<br>
     ///   if given @p time tᵢ is not greater than the previous time
@@ -167,16 +167,16 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     /// derivative triplet), which may coincide with its end time tᵢ (that of
     /// the last time, state and state derivative triplet) if the step has zero
     /// length (that is, it contains a single triplet).
-    const T& get_start_time() const { return times_.front(); }
+    const T& start_time() const { return times_.front(); }
 
     /// Returns step end time tᵢ (that of the first time, state and state
     /// derivative triplet), which may coincide with its start time t₀ (that of
     /// the last time, state and state derivative triplet) if the step has zero
     /// length (that is, it contains a single triplet).
-    const T& get_end_time() const { return times_.back(); }
+    const T& end_time() const { return times_.back(); }
 
-    /// Returns the step state 𝐱 dimensions.
-    int get_dimensions() const {
+    /// Returns the step state 𝐱 size (i.e. dimension).
+    int size() const {
       return states_.back().rows();
     }
 
@@ -245,7 +245,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
   /// StepwiseDenseOutput class documentation).
   ///
   /// @param step Integration step to update this output with.
-  /// @throw std::runtime_error
+  /// @throws std::runtime_error
   ///   if given @p step has zero length.<br>
   ///   if given @p step does not ensure C1 continuity at the end of
   ///   this dense output.<br>
@@ -296,19 +296,19 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     return continuous_trajectory_.empty();
   }
 
-  int do_get_dimensions() const override {
+  int do_size() const override {
     return continuous_trajectory_.rows();
   }
 
-  const T& do_get_end_time() const override { return end_time_; }
+  const T& do_end_time() const override { return end_time_; }
 
-  const T& do_get_start_time() const override { return start_time_; }
+  const T& do_start_time() const override { return start_time_; }
 
   // Validates that the provided @p step can be consolidated into this
   // dense output.
   // @see Update(const IntegrationStep&)
   void ValidateStepCanBeConsolidatedOrThrow(const IntegrationStep& step) {
-    if (step.get_start_time() == step.get_end_time()) {
+    if (step.start_time() == step.end_time()) {
       throw std::runtime_error("Provided step has zero length "
                                "i.e. start time and end time "
                                "are equal.");
@@ -325,7 +325,7 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
   // @param next_step Integration step to be taken.
   // @param prev_step Last integration step consolidated or to be
   //                  consolidated into dense output.
-  // @throw std::runtime_error
+  // @throws std::runtime_error
   //   if given @p next_step does not ensure C1 continuity at the
   //   end of the given @p prev_step.<br>
   //   if given @p next_step dimensions does not match @p prev_step
@@ -335,14 +335,14 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     using std::abs;
     using std::max;
 
-    if (prev_step.get_dimensions() != next_step.get_dimensions()) {
+    if (prev_step.size() != next_step.size()) {
       throw std::runtime_error("Provided step dimensions and previous"
                                " step dimensions do not match.");
     }
     // Maximum time misalignment between previous step and next step that
     // can still be disregarded as a discontinuity in time.
-    const T& prev_end_time = prev_step.get_end_time();
-    const T& next_start_time = next_step.get_start_time();
+    const T& prev_end_time = prev_step.end_time();
+    const T& next_start_time = next_step.start_time();
     const T allowed_time_misalignment =
         max(abs(prev_end_time), T{1.}) * std::numeric_limits<T>::epsilon();
     const T time_misalignment = abs(prev_end_time - next_start_time);

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -370,8 +370,8 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
   // TODO(hidmic): Remove redundant time-keeping member fields when
   // PiecewisePolynomial supports return by-reference of its time extents.
   // It currently returns them by-value, double type only, and thus the
-  // need for this storage in order to meet DenseOutput::get_start_time()
-  // and DenseOutput::get_end_time() API.
+  // need for this storage in order to meet DenseOutput::start_time()
+  // and DenseOutput::end_time() API.
 
   // The smallest time at which the output is defined.
   T start_time_{};

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -250,6 +250,20 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     return matrix_value.col(0).cast<T>();
   }
 
+  T Evaluate(const T& t, const int dimension) const override {
+    if (is_empty()) {
+      throw std::logic_error("Empty dense output cannot be evaluated.");
+    }
+    if (dimension < 0 || get_dimensions() <= dimension) {
+      throw std::runtime_error("Invalid dimension for dense output.");
+    }
+    if (t < get_start_time() || t > get_end_time()) {
+      throw std::runtime_error("Dense output is not defined for given time.");
+    }
+    return continuous_trajectory_.scalarValue(
+        ExtractDoubleOrThrow(t), dimension, 0);
+  }
+
   int get_dimensions() const override {
     if (is_empty()) {
       throw std::logic_error("Dimension is not defined for"

--- a/systems/analysis/hermitian_dense_output.h
+++ b/systems/analysis/hermitian_dense_output.h
@@ -291,9 +291,9 @@ class HermitianDenseOutput final : public StepwiseDenseOutput<T> {
     return matrix_value.col(0).cast<T>();
   }
 
-  T DoEvaluateNth(const T& t, const int dimension) const override {
+  T DoEvaluateNth(const T& t, const int n) const override {
     return continuous_trajectory_.scalarValue(
-        ExtractDoubleOrThrow(t), dimension, 0);
+        ExtractDoubleOrThrow(t), n, 0);
   }
 
   bool do_is_empty() const override {

--- a/systems/analysis/initial_value_problem-inl.h
+++ b/systems/analysis/initial_value_problem-inl.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/systems/analysis/initial_value_problem.h"
 #include "drake/systems/analysis/runge_kutta3_integrator-inl.h"
@@ -106,8 +109,8 @@ const T InitialValueProblem<T>::kMaxStepSize = static_cast<T>(1e-1);
 
 template <typename T>
 InitialValueProblem<T>::InitialValueProblem(
-    const typename InitialValueProblem<T>::ODEFunction& ode_function,
-    const typename InitialValueProblem<T>::SpecifiedValues& default_values)
+    const ODEFunction& ode_function,
+    const SpecifiedValues& default_values)
     : default_values_(default_values),
       current_values_(default_values) {
   // Checks that preconditions are met.
@@ -143,70 +146,14 @@ InitialValueProblem<T>::InitialValueProblem(
 }
 
 template <typename T>
-VectorX<T> InitialValueProblem<T>::Solve(const T& tf,
-    const typename InitialValueProblem<T>::SpecifiedValues& values) const {
-  // Gets specified values to solve with, while checking
-  // that all preconditions hold.
-  const T t0 = values.t0.value_or(default_values_.t0.value());
-  if (tf < t0) {
-    throw std::logic_error("Cannot solve IVP for a time tf"
-                           " before the initial time t0.");
-  }
-  const VectorX<T> x0 = values.x0.value_or(default_values_.x0.value());
-  if (x0.size() != default_values_.x0.value().size()) {
-    throw std::logic_error("IVP initial state vector x0 is"
-                           " of the wrong dimension.");
-  }
-  const VectorX<T> k = values.k.value_or(default_values_.k.value());
-  if (k.size() != default_values_.k.value().size()) {
-    throw std::logic_error("IVP parameter vector k is "
-                           " of the wrong dimension");
-  }
-  // Performs cache invalidation and re-initializes both
-  // integrator and integration context if necessary.
-  if (t0 != current_values_.t0 ||
-      x0 != current_values_.x0 ||
-      k != current_values_.k ||
-      tf < context_->get_time()) {
-    // Sets context (initial) time.
-    context_->set_time(t0);
+VectorX<T> InitialValueProblem<T>::Solve(
+    const T& tf, const SpecifiedValues& values) const {
+  // Gets all values to solve with, either given or default, while
+  // checking that all preconditions hold.
+  const SpecifiedValues safe_values = SanitizeValuesOrThrow(tf, values);
 
-    // Sets context (initial) state. This cast is safe because the
-    // ContinuousState<T> of a LeafSystem<T> is flat i.e. it is just
-    // a BasicVector<T>, and the implementation deals with LeafSystem<T>
-    // instances only by design.
-    BasicVector<T>& state_vector = dynamic_cast<BasicVector<T>&>(
-        context_->get_mutable_continuous_state_vector());
-    state_vector.set_value(x0);
-
-    // Sets context parameters.
-    BasicVector<T>& parameter_vector =
-        context_->get_mutable_numeric_parameter(0);
-    parameter_vector.set_value(k);
-
-    // Keeps track of current step size and accuracy settings (regardless
-    // of whether these are actually used by the integrator instance or not).
-    const T max_step_size = integrator_->get_maximum_step_size();
-    const T initial_step_size = integrator_->get_initial_step_size_target();
-    const T target_accuracy = integrator_->get_target_accuracy();
-
-    // Resets the integrator internal state.
-    integrator_->Reset();
-
-    // Sets integrator settings again.
-    integrator_->set_maximum_step_size(max_step_size);
-    if (integrator_->supports_error_estimation()) {
-      // Specifies initial step and accuracy setting only if necessary.
-      integrator_->request_initial_step_size_target(initial_step_size);
-      integrator_->set_target_accuracy(target_accuracy);
-    }
-
-    // Keeps track of the current initial conditions and parameters
-    // for future cache invalidation.
-    current_values_.t0 = t0;
-    current_values_.x0 = x0;
-    current_values_.k = k;
-  }
+  // Potentially invalidates the cache.
+  MayResetCachedState(tf, safe_values);
 
   // Initializes integrator if necessary.
   if (!integrator_->is_initialized()) {
@@ -217,13 +164,112 @@ VectorX<T> InitialValueProblem<T>::Solve(const T& tf,
   integrator_->IntegrateWithMultipleSteps(
       tf - context_->get_time());
 
-  // Retrieves the system's state vector. This cast is safe because the
+  // Retrieves the state vector. This cast is safe because the
   // ContinuousState<T> of a LeafSystem<T> is flat i.e. it is just
   // a BasicVector<T>, and the implementation deals with LeafSystem<T>
   // instances only by design.
   const BasicVector<T>& state_vector = dynamic_cast<const BasicVector<T>&>(
       context_->get_continuous_state_vector());
   return state_vector.get_value();
+}
+
+template <typename T>
+void InitialValueProblem<T>::ResetCachedState(
+    const SpecifiedValues& values) const {
+  // Sets context (initial) time.
+  context_->set_time(values.t0.value());
+
+  // Sets context (initial) state. This cast is safe because the
+  // ContinuousState<T> of a LeafSystem<T> is flat i.e. it is just
+  // a BasicVector<T>, and the implementation deals with LeafSystem<T>
+  // instances only by design.
+  BasicVector<T>& state_vector = dynamic_cast<BasicVector<T>&>(
+      context_->get_mutable_continuous_state_vector());
+  state_vector.set_value(values.x0.value());
+
+  // Sets context parameters.
+  BasicVector<T>& parameter_vector =
+      context_->get_mutable_numeric_parameter(0);
+  parameter_vector.set_value(values.k.value());
+
+  // Keeps track of current step size and accuracy settings (regardless
+  // of whether these are actually used by the integrator instance or not).
+  const T max_step_size = integrator_->get_maximum_step_size();
+  const T initial_step_size = integrator_->get_initial_step_size_target();
+  const T target_accuracy = integrator_->get_target_accuracy();
+
+  // Resets the integrator internal state.
+  integrator_->Reset();
+
+  // Sets integrator settings again.
+  integrator_->set_maximum_step_size(max_step_size);
+  if (integrator_->supports_error_estimation()) {
+    // Specifies initial step and accuracy setting only if necessary.
+    integrator_->request_initial_step_size_target(initial_step_size);
+    integrator_->set_target_accuracy(target_accuracy);
+  }
+  // Keeps track of the current initial conditions and parameters
+  // for future cache invalidation.
+  current_values_ = values;
+}
+
+template <typename T>
+void InitialValueProblem<T>::MayResetCachedState(
+    const T& tf, const SpecifiedValues& values) const {
+  // Only resets cache if necessary.
+  if (values != current_values_ || tf < context_->get_time()) {
+    ResetCachedState(values);
+  }
+}
+
+template <typename T>
+typename InitialValueProblem<T>::SpecifiedValues
+InitialValueProblem<T>::SanitizeValuesOrThrow(
+    const T& tf, const SpecifiedValues& values) const {
+  SpecifiedValues safe_values;
+  safe_values.t0 = values.t0.has_value() ? values.t0 : default_values_.t0;
+  if (tf < safe_values.t0.value()) {
+    throw std::logic_error("Cannot solve IVP for a time"
+                           " before the initial condition.");
+  }
+  safe_values.x0 = values.x0.has_value() ? values.x0 : default_values_.x0;
+  if (safe_values.x0.value().size() != default_values_.x0.value().size()) {
+    throw std::logic_error("IVP initial state vector x0 is"
+                           " of the wrong dimension.");
+  }
+  safe_values.k = values.k.has_value() ? values.k : default_values_.k;
+  if (safe_values.k.value().size() != default_values_.k.value().size()) {
+    throw std::logic_error("IVP parameter vector k is "
+                           " of the wrong dimension");
+  }
+  return safe_values;
+}
+
+template <typename T>
+std::unique_ptr<DenseOutput<T>> InitialValueProblem<T>::DenseSolve(
+    const T& tf, const SpecifiedValues& values) const {
+  // Gets all values to solve with, either given or default, while
+  // checking that all preconditions hold.
+  const SpecifiedValues safe_values = SanitizeValuesOrThrow(tf, values);
+
+  // Unconditionally invalidates the cache. All integration steps need
+  // to be made generate a DenseOutput.
+  ResetCachedState(safe_values);
+
+  // Re-initialize integrator after cache invalidation.
+  integrator_->Initialize();
+
+  // Starts dense integration to build a dense output.
+  integrator_->StartDenseIntegration();
+
+  // Steps the integrator through the entire interval.
+  integrator_->IntegrateWithMultipleSteps(
+      tf - context_->get_time());
+
+  // Stops dense integration to prevent future updates to
+  // the built continuous extension and yields dense output
+  // to the caller.
+  return integrator_->StopDenseIntegration();
 }
 
 }  // namespace systems

--- a/systems/analysis/initial_value_problem-inl.h
+++ b/systems/analysis/initial_value_problem-inl.h
@@ -99,7 +99,7 @@ void ODESystem<T>::DoCalcTimeDerivatives(
 }  // namespace detail
 
 template<typename T>
-const T InitialValueProblem<T>::kDefaultAccuracy = static_cast<T>(1e-4);
+const double InitialValueProblem<T>::kDefaultAccuracy = 1e-4;
 
 template<typename T>
 const T InitialValueProblem<T>::kInitialStepSize = static_cast<T>(1e-4);
@@ -196,7 +196,7 @@ void InitialValueProblem<T>::ResetCachedState(
   // of whether these are actually used by the integrator instance or not).
   const T max_step_size = integrator_->get_maximum_step_size();
   const T initial_step_size = integrator_->get_initial_step_size_target();
-  const T target_accuracy = integrator_->get_target_accuracy();
+  const double target_accuracy = integrator_->get_target_accuracy();
 
   // Resets the integrator internal state.
   integrator_->Reset();

--- a/systems/analysis/initial_value_problem-inl.h
+++ b/systems/analysis/initial_value_problem-inl.h
@@ -153,7 +153,7 @@ VectorX<T> InitialValueProblem<T>::Solve(
   const SpecifiedValues safe_values = SanitizeValuesOrThrow(tf, values);
 
   // Potentially invalidates the cache.
-  MayResetCachedState(tf, safe_values);
+  ResetCachedStateIfNecessary(tf, safe_values);
 
   // Initializes integrator if necessary.
   if (!integrator_->is_initialized()) {
@@ -214,7 +214,7 @@ void InitialValueProblem<T>::ResetCachedState(
 }
 
 template <typename T>
-void InitialValueProblem<T>::MayResetCachedState(
+void InitialValueProblem<T>::ResetCachedStateIfNecessary(
     const T& tf, const SpecifiedValues& values) const {
   // Only resets cache if necessary.
   if (values != current_values_ || tf < context_->get_time()) {

--- a/systems/analysis/initial_value_problem.cc
+++ b/systems/analysis/initial_value_problem.cc
@@ -1,10 +1,13 @@
 #include "drake/systems/analysis/initial_value_problem.h"
 #include "drake/systems/analysis/initial_value_problem-inl.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace systems {
 
-template class InitialValueProblem<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class InitialValueProblem);
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -66,7 +66,7 @@ class InitialValueProblem {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(InitialValueProblem);
 
   /// Default integration accuracy in the relative tolerance sense.
-  static const T kDefaultAccuracy;
+  static const double kDefaultAccuracy;
   /// Default initial integration step size.
   static const T kInitialStepSize;
   /// Default maximum integration step size.

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -31,13 +31,13 @@ namespace systems {
 /// e.g. if solved for t₁ > t₀ first, solving for t₂ > t₁ will only require
 /// integrating from t₁ onward.
 ///
-/// Additionally, configured integrator's dense output support can be leveraged
-/// to efficiently approximate the IVP solution within closed time intervals.
+/// Additionally, integrator's dense output support can be leveraged to
+/// efficiently approximate the IVP solution within closed intervals of t.
 /// This is convenient when there's a need for a more dense sampling of the
 /// IVP solution than what would be available through either fixed or
 /// error-controlled step integration (for a given accuracy), or when the IVP
-/// is to be solved at a high rate for arbitrary times within a given interval.
-/// See configured integrator's documentation for further reference on the
+/// is to be solved repeatedly for arbitrarily many t values within a given
+/// interval. See integrator's documentation for further reference on the
 /// specific dense output technique in use.
 ///
 /// For further insight into its use, consider the following examples:

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -23,16 +23,22 @@ namespace systems {
 /// allows for generic IVP definitions, which can later be solved for any
 /// instance of said vector.
 ///
-/// Additionally, support for solving the IVP for entire time intervals is
-/// provided. This is convenient when a more dense sampling of the IVP
-/// solution than what would be available through either fixed or
-/// error-controlled step integration (for a given accuracy) is needed.
+/// By default, an explicit 3rd order RungeKutta integration scheme is used.
 ///
 /// This class' implementation performs basic computation caching, optimizing
 /// away repeated integration whenever the IVP is solved for increasing values
 /// of time t while both initial conditions and parameters are kept constant,
 /// e.g. if solved for t₁ > t₀ first, solving for t₂ > t₁ will only require
 /// integrating from t₁ onward.
+///
+/// Additionally, configured integrator's dense output support can be leveraged
+/// to efficiently approximate the IVP solution within closed time intervals.
+/// This is convenient when there's a need for a more dense sampling of the
+/// IVP solution than what would be available through either fixed or
+/// error-controlled step integration (for a given accuracy), or when the IVP
+/// is to be solved at a high rate for arbitrary times within a given interval.
+/// See configured integrator's documentation for further reference on the
+/// specific dense output technique in use.
 ///
 /// For further insight into its use, consider the following examples:
 ///
@@ -137,10 +143,10 @@ class InitialValueProblem {
   /// @throw std::logic_error if preconditions are not met.
   VectorX<T> Solve(const T& tf, const SpecifiedValues& values = {}) const;
 
-  /// Solves the IVP for the whole time interval between the initial time t₀
-  /// and the given final time @p tf, using initial state 𝐱₀ and parameter
-  /// vector 𝐤 present in @p values (falling back to the ones given on
-  /// construction if not given).
+  /// Solves and yields an approximation of the IVP solution x(t; 𝐤) for
+  /// the closed time interval between the initial time t₀ and the given final
+  /// time @p tf, using initial state 𝐱₀ and parameter vector 𝐤 present in
+  /// @p values (falling back to the ones given on construction if not given).
   ///
   /// @param tf The time to solve the IVP up to.
   /// @param values The specified values for the IVP.
@@ -228,7 +234,8 @@ class InitialValueProblem {
   // values and integration context based on time @p tf to solve for
   // and the provided @p values. If cached state can be reused, it's a
   // no-op.
-  void MayResetCachedState(const T& tf, const SpecifiedValues& values) const;
+  void ResetCachedStateIfNecessary(
+      const T& tf, const SpecifiedValues& values) const;
 
   // IVP current specified values (for caching).
   mutable SpecifiedValues current_values_;

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -150,7 +150,8 @@ class InitialValueProblem {
   /// time @p tf, using initial state 𝐱₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
-  /// @param tf The IVP will be solved up to this time.
+  /// @param tf The IVP will be solved up to this time, usually t₀ < @p tf, as
+  ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.
   /// @returns A dense approximation to 𝐱(t; 𝐤) with 𝐱(t₀; 𝐤) = 𝐱₀, defined for
   ///          t₀ ≤ t ≤ tf.

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -150,6 +150,10 @@ class InitialValueProblem {
   /// time @p tf, using initial state 𝐱₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
+  /// To this end, the wrapped IntegratorBase instance solves this IVP,
+  /// advancing time and state from t₀ and 𝐱₀ = 𝐱(t₀) to @p tf and 𝐱(@p tf),
+  /// creating a dense output over that [t₀, @p tf] interval along the way.
+  ///
   /// @param tf The IVP will be solved up to this time. Usually, t₀ < @p tf as
   ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.

--- a/systems/analysis/initial_value_problem.h
+++ b/systems/analysis/initial_value_problem.h
@@ -150,11 +150,15 @@ class InitialValueProblem {
   /// time @p tf, using initial state 𝐱₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
-  /// @param tf The IVP will be solved up to this time, usually t₀ < @p tf, as
+  /// @param tf The IVP will be solved up to this time. Usually, t₀ < @p tf as
   ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.
   /// @returns A dense approximation to 𝐱(t; 𝐤) with 𝐱(t₀; 𝐤) = 𝐱₀, defined for
   ///          t₀ ≤ t ≤ tf.
+  /// @note The larger the given @p tf value is, the larger the approximated
+  ///       interval will be. See documentation of the specific dense output
+  ///       technique in use for reference on performance impact as this
+  ///       interval grows.
   /// @pre Given @p tf must be larger than or equal to the specified initial
   ///      time t₀ (either given or default).
   /// @pre If given, the dimension of the initial state vector @p values.x0

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -795,7 +795,8 @@ class IntegratorBase {
 
 
   /**
-   * @name             Methods for dense output computation
+   * @name               Methods for dense output computation
+   * @anchor dense_output_computation
    * @{
    *
    * In general, dense output computations entail both CPU load and memory
@@ -804,6 +805,9 @@ class IntegratorBase {
    * are only carried out by explicit user request. The API to start and stop
    * a _dense integration_ process (i.e. a numerical integration process that
    * also computes dense output) is consistent with this design choice.
+   *
+   * Once dense integration is started, and until it is stopped, all subsequent
+   * integration steps taken will update the allocated dense output.
    */
 
   /**

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -814,7 +814,7 @@ class IntegratorBase {
    * @pre The system being integrated has continuous state.
    * @pre No dense integration is in progress (no dense output is held by the
    *      integrator)
-   * @throw std::logic_error if any of the preconditions is not met.
+   * @throws std::logic_error if any of the preconditions is not met.
    * @warning Dense integration may incur significant overhead.
    */
   void StartDenseIntegration() {
@@ -846,17 +846,17 @@ class IntegratorBase {
    * to the caller.
    *
    * @remarks This process is irreversible.
-   * @return A DenseOutput instance, i.e. a representation of the
-   *         continuous state trajectory of the system being integrated
-   *         that can be evaluated at any time within its extension. This
-   *         representation is defined starting at the context time of the
-   *         last StartDenseIntegration() call and finishing at the current
-   *         context time.
+   * @returns A DenseOutput instance, i.e. a representation of the
+   *          continuous state trajectory of the system being integrated
+   *          that can be evaluated at any time within its extension. This
+   *          representation is defined starting at the context time of the
+   *          last StartDenseIntegration() call and finishing at the current
+   *          context time.
    * @pre Dense integration is in progress (a dense output is held by this
    *      integrator, after a call to StartDenseIntegration()).
    * @post Previously held dense output is not updated nor referenced by
    *       the integrator anymore.
-   * @throw std::logic_error if any of the preconditions is not met.
+   * @throws std::logic_error if any of the preconditions is not met.
    */
   std::unique_ptr<DenseOutput<T>> StopDenseIntegration() {
     if (!dense_output_) {

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -5,7 +5,7 @@
 namespace drake {
 namespace systems {
 
-/// An interface for dense output of scalar ODEs solutions.
+/// An interface for dense output of scalar ODE solutions.
 ///
 /// See DenseOutput class documentation for further details.
 ///
@@ -24,25 +24,60 @@ class ScalarDenseOutput {
   /// @throw std::logic_error if any of the preconditions is not met.
   /// @throw std::runtime_error if the output is not defined for the
   ///                           given @p t.
-  virtual T Evaluate(const T& t) const = 0;
+  T Evaluate(const T& t) const {
+    if (is_empty()) {
+      throw std::logic_error("Empty scalar dense output"
+                             " cannot be evaluated.");
+    }
+    if (t < this->do_get_start_time() || t > this->do_get_end_time()) {
+      throw std::runtime_error("Scalar dense output is not"
+                               " defined for given time.");
+    }
+    return this->DoEvaluate(t);
+  }
 
   /// Checks whether the output is empty or not.
-  virtual bool is_empty() const = 0;
+  virtual bool is_empty() const { return do_is_empty(); }
 
   /// Returns output's start time, or in other words, the oldest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throw std::logic_error if any of the preconditions is not met.
-  virtual const T& get_start_time() const = 0;
+  const T& get_start_time() const {
+    if (is_empty()) {
+      throw std::logic_error("Start time is not defined for"
+                             " an empty scalar dense output.");
+    }
+    return this->do_get_start_time();
+  }
 
   /// Returns output's end time, or in other words, the newest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throw std::logic_error if any of the preconditions is not met.
-  virtual const T& get_end_time() const = 0;
+  const T& get_end_time() const {
+    if (is_empty()) {
+      throw std::logic_error("End time is not defined for"
+                             " an empty scalar dense output.");
+    }
+    return this->do_get_end_time();
+  }
 
  protected:
   ScalarDenseOutput() = default;
+
+ private:
+  // @see Evaluate(const T&)
+  virtual T DoEvaluate(const T& t) const = 0;
+
+  // @see is_empty()
+  virtual bool do_is_empty() const = 0;
+
+  // @see get_start_time()
+  virtual const T& do_get_start_time() const = 0;
+
+  // @see get_end_time()
+  virtual const T& do_get_end_time() const = 0;
 };
 
 }  // namespace systems

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -28,8 +28,8 @@ class ScalarDenseOutput : public DenseOutput<T> {
   /// @throws std::runtime_error if given @p t is not valid
   ///                            i.e. start_time() ≤ @p t ≤ end_time().
   T EvaluateScalar(const T& t) const {
-    this->ThrowIfOutputIsEmpty();
-    this->ThrowIfTimeIsInvalid(t);
+    this->ThrowIfOutputIsEmpty(__func__);
+    this->ThrowIfTimeIsInvalid(__func__, t);
     return this->DoEvaluateScalar(t);
   }
 

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -31,7 +31,7 @@ class ScalarDenseOutput : public DenseOutput<T> {
     if (this->is_empty()) {
       throw std::logic_error("Empty dense output cannot be evaluated.");
     }
-    if (t < this->start_time() || t > this->end_time()) {
+    if (t < this->do_start_time() || t > this->do_end_time()) {
       throw std::runtime_error("Dense output is not defined for given time.");
     }
     return this->DoEvaluateScalar(t);
@@ -40,10 +40,6 @@ class ScalarDenseOutput : public DenseOutput<T> {
  protected:
   ScalarDenseOutput() = default;
 
- private:
-  // @see EvaluateScalar(const T&)
-  virtual T DoEvaluateScalar(const T& t) const = 0;
-
   VectorX<T> DoEvaluate(const T& t) const override {
     return VectorX<T>::Constant(1, this->DoEvaluateScalar(t));
   }
@@ -51,6 +47,9 @@ class ScalarDenseOutput : public DenseOutput<T> {
   int do_size() const override {
     return 1;
   }
+
+  // @see EvaluateScalar(const T&)
+  virtual T DoEvaluateScalar(const T& t) const = 0;
 };
 
 }  // namespace systems

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -18,7 +18,7 @@ class ScalarDenseOutput {
   virtual ~ScalarDenseOutput() = default;
 
   /// Evaluates output at the given time @p t.
-  /// @param t Time to evaluate output at.
+  /// @param t Time at which to evaluate output.
   /// @returns Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
   /// @throws std::logic_error if any of the preconditions is not met.

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -5,7 +5,7 @@
 namespace drake {
 namespace systems {
 
-/// An interface for dense output of scalar ODEs and DAEs solutions.
+/// An interface for dense output of scalar ODEs solutions.
 ///
 /// See DenseOutput class documentation for further details.
 ///

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -25,15 +25,11 @@ class ScalarDenseOutput : public DenseOutput<T> {
   /// @returns Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
   /// @throws std::logic_error if any of the preconditions is not met.
-  /// @throws std::runtime_error if the output is not defined for the
-  ///                            given @p t.
+  /// @throws std::runtime_error if given @p t is not valid
+  ///                            i.e. start_time() ≤ @p t ≤ end_time().
   T EvaluateScalar(const T& t) const {
-    if (this->is_empty()) {
-      throw std::logic_error("Empty dense output cannot be evaluated.");
-    }
-    if (t < this->do_start_time() || t > this->do_end_time()) {
-      throw std::runtime_error("Dense output is not defined for given time.");
-    }
+    this->ThrowIfOutputIsEmpty();
+    this->ThrowIfTimeIsInvalid(t);
     return this->DoEvaluateScalar(t);
   }
 

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -25,8 +25,8 @@ class ScalarDenseOutput : public DenseOutput<T> {
   /// @returns Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
   /// @throws std::logic_error if any of the preconditions is not met.
-  /// @throws std::runtime_error if given @p t is not valid
-  ///                            i.e. start_time() ≤ @p t ≤ end_time().
+  /// @throws std::runtime_error if given @p t is not within output's domain
+  ///                            i.e. @p t ∉ [start_time(), end_time()].
   T EvaluateScalar(const T& t) const {
     this->ThrowIfOutputIsEmpty(__func__);
     this->ThrowIfTimeIsInvalid(__func__, t);

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -5,7 +5,7 @@
 namespace drake {
 namespace systems {
 
-/// An interface for dense output of scalar ODE and DAE solutions.
+/// An interface for dense output of scalar ODEs and DAEs solutions.
 ///
 /// See DenseOutput class documentation for further details.
 ///
@@ -18,15 +18,15 @@ class ScalarDenseOutput {
   virtual ~ScalarDenseOutput() = default;
 
   /// Evaluates output at the given time @p t.
-  /// @param t Time to evaluate extension at.
+  /// @param t Time to evaluate output at.
   /// @return Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
   /// @throw std::logic_error if any of the preconditions is not met.
-  /// @throw std::runtime_error if the extension is not defined for the
+  /// @throw std::runtime_error if the output is not defined for the
   ///                           given @p t.
   virtual T Evaluate(const T& t) const = 0;
 
-  /// Checks whether the extension is empty or not.
+  /// Checks whether the output is empty or not.
   virtual bool is_empty() const = 0;
 
   /// Returns output's start time, or in other words, the oldest time

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace systems {
+
+/// An interface for dense output of scalar ODE and DAE solutions.
+///
+/// See DenseOutput class documentation for further details.
+///
+/// @tparam T A valid Eigen scalar type.
+template <typename T>
+class ScalarDenseOutput {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScalarDenseOutput)
+
+  virtual ~ScalarDenseOutput() = default;
+
+  /// Evaluates output at the given time @p t.
+  /// @param t Time to evaluate extension at.
+  /// @return Output scalar value.
+  /// @pre Output is not empty i.e. is_empty() is false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throw std::runtime_error if the extension is not defined for the
+  ///                           given @p t.
+  virtual T Evaluate(const T& t) const = 0;
+
+  /// Checks whether the extension is empty or not.
+  virtual bool is_empty() const = 0;
+
+  /// Returns output's start time, or in other words, the oldest time
+  /// `t` that it can be evaluated at e.g. via Evaluate().
+  /// @pre Output is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual const T& get_start_time() const = 0;
+
+  /// Returns output's end time, or in other words, the newest time
+  /// `t` that it can be evaluated at e.g. via Evaluate().
+  /// @pre Output is not empty i.e. is_empty() equals false.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  virtual const T& get_end_time() const = 0;
+
+ protected:
+  ScalarDenseOutput() = default;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/scalar_dense_output.h
+++ b/systems/analysis/scalar_dense_output.h
@@ -19,17 +19,17 @@ class ScalarDenseOutput {
 
   /// Evaluates output at the given time @p t.
   /// @param t Time to evaluate output at.
-  /// @return Output scalar value.
+  /// @returns Output scalar value.
   /// @pre Output is not empty i.e. is_empty() is false.
-  /// @throw std::logic_error if any of the preconditions is not met.
-  /// @throw std::runtime_error if the output is not defined for the
-  ///                           given @p t.
+  /// @throws std::logic_error if any of the preconditions is not met.
+  /// @throws std::runtime_error if the output is not defined for the
+  ///                            given @p t.
   T Evaluate(const T& t) const {
     if (is_empty()) {
       throw std::logic_error("Empty scalar dense output"
                              " cannot be evaluated.");
     }
-    if (t < this->do_get_start_time() || t > this->do_get_end_time()) {
+    if (t < this->do_start_time() || t > this->do_end_time()) {
       throw std::runtime_error("Scalar dense output is not"
                                " defined for given time.");
     }
@@ -42,25 +42,25 @@ class ScalarDenseOutput {
   /// Returns output's start time, or in other words, the oldest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
-  /// @throw std::logic_error if any of the preconditions is not met.
-  const T& get_start_time() const {
+  /// @throws std::logic_error if any of the preconditions is not met.
+  const T& start_time() const {
     if (is_empty()) {
       throw std::logic_error("Start time is not defined for"
                              " an empty scalar dense output.");
     }
-    return this->do_get_start_time();
+    return this->do_start_time();
   }
 
   /// Returns output's end time, or in other words, the newest time
   /// `t` that it can be evaluated at e.g. via Evaluate().
   /// @pre Output is not empty i.e. is_empty() equals false.
   /// @throw std::logic_error if any of the preconditions is not met.
-  const T& get_end_time() const {
+  const T& end_time() const {
     if (is_empty()) {
       throw std::logic_error("End time is not defined for"
                              " an empty scalar dense output.");
     }
-    return this->do_get_end_time();
+    return this->do_end_time();
   }
 
  protected:
@@ -73,11 +73,11 @@ class ScalarDenseOutput {
   // @see is_empty()
   virtual bool do_is_empty() const = 0;
 
-  // @see get_start_time()
-  virtual const T& do_get_start_time() const = 0;
+  // @see start_time()
+  virtual const T& do_start_time() const = 0;
 
-  // @see get_end_time()
-  virtual const T& do_get_end_time() const = 0;
+  // @see end_time()
+  virtual const T& do_end_time() const = 0;
 };
 
 }  // namespace systems

--- a/systems/analysis/scalar_initial_value_problem-inl.h
+++ b/systems/analysis/scalar_initial_value_problem-inl.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "drake/systems/analysis/initial_value_problem-inl.h"

--- a/systems/analysis/scalar_initial_value_problem-inl.h
+++ b/systems/analysis/scalar_initial_value_problem-inl.h
@@ -1,3 +1,5 @@
 #pragma once
 
+// Instantiation of ScalarInitialValueProblem<T> for T other than double
+// requires InitialValueProblem<T> definition.
 #include "drake/systems/analysis/initial_value_problem-inl.h"

--- a/systems/analysis/scalar_initial_value_problem.cc
+++ b/systems/analysis/scalar_initial_value_problem.cc
@@ -1,10 +1,13 @@
 #include "drake/systems/analysis/scalar_initial_value_problem.h"
 #include "drake/systems/analysis/scalar_initial_value_problem-inl.h"
 
+#include "drake/common/default_scalars.h"
+
 namespace drake {
 namespace systems {
 
-template class ScalarInitialValueProblem<double>;
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class ScalarInitialValueProblem);
 
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/scalar_initial_value_problem.cc
+++ b/systems/analysis/scalar_initial_value_problem.cc
@@ -1,4 +1,5 @@
 #include "drake/systems/analysis/scalar_initial_value_problem.h"
+#include "drake/systems/analysis/scalar_initial_value_problem-inl.h"
 
 namespace drake {
 namespace systems {

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/eigen_types.h"
 #include "drake/systems/analysis/initial_value_problem.h"
+#include "drake/systems/analysis/scalar_view_dense_output.h"
 
 namespace drake {
 namespace systems {
@@ -25,6 +28,11 @@ namespace systems {
 /// with almost zero overhead, leading to clearer code if applicable.
 /// Moreover, this scalar form facilitates single-dimensional quadrature
 /// using methods for solving initial value problems.
+///
+/// Additionally, support for solving the IVP for entire time intervals is
+/// provided. This is convenient when a more dense sampling of the IVP
+/// solution than what would be available through either fixed or
+/// error-controlled step integration (for a given accuracy) is needed.
 ///
 /// For further insight into its use, consider the following examples of scalar
 /// IVPs:
@@ -56,8 +64,8 @@ class ScalarInitialValueProblem {
   /// @param x The dependent variable x ∈ ℝ .
   /// @param k The parameter vector 𝐤 ∈ ℝᵐ.
   /// @return The derivative dx/dt ∈ ℝ.
-  typedef std::function<T(const T& t, const T& x,
-                          const VectorX<T>& k)> ScalarODEFunction;
+  using ScalarODEFunction = std::function<T(const T& t, const T& x,
+                                            const VectorX<T>& k)>;
 
   /// A collection of values i.e. initial time t₀, initial state x₀
   /// and parameter vector 𝐤 to further specify the ODE system (in
@@ -119,9 +127,39 @@ class ScalarInitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if preconditions are not met.
+  /// @throw std::logic_error if preconditions is not met.
   T Solve(const T& tf, const SpecifiedValues& values = {}) const {
     return this->vector_ivp_->Solve(tf, ToVectorIVPSpecifiedValues(values))[0];
+  }
+
+  /// Solves the IVP for the whole time interval between the initial time t₀
+  /// and the given final time @p tf, using initial state x₀ and parameter
+  /// vector 𝐤 present in @p values (falling back to the ones given on
+  /// construction if not given).
+  ///
+  /// @param tf The time to solve the IVP up to.
+  /// @param values The specified values for the IVP.
+  /// @return A dense approximation to x(t; 𝐤) with x(t₀; 𝐤) = x₀,
+  ///         defined for t₀ <= t <= tf.
+  /// @pre Given @p tf must be larger than or equal to the specified initial
+  ///      time t₀ (either given or default).
+  /// @pre If given, the dimension of the initial state vector @p values.x0
+  ///      must match that of the default initial state vector in the default
+  ///      specified values given on construction.
+  /// @pre If given, the dimension of the parameter vector @p values.k
+  ///      must match that of the parameter vector in the default specified
+  ///      values given on construction.
+  /// @throw std::logic_error if any of the preconditions is not met.
+  std::unique_ptr<ScalarDenseOutput<T>> DenseSolve(
+      const T& tf, const SpecifiedValues& values = {}) const {
+    // Delegates request to the vector form of this IVP by putting
+    // specified values in vector form and the resulting dense output
+    // back into scalar form.
+    const int kDimension = 0;
+    std::unique_ptr<DenseOutput<T>> vector_dense_output =
+        this->vector_ivp_->DenseSolve(tf, ToVectorIVPSpecifiedValues(values));
+    return std::make_unique<ScalarViewDenseOutput<T>>(
+        std::move(vector_dense_output), kDimension);
   }
 
   /// Resets the internal integrator instance by in-place
@@ -164,8 +202,11 @@ class ScalarInitialValueProblem {
     typename InitialValueProblem<T>::SpecifiedValues vector_ivp_values;
     vector_ivp_values.k = values.k;
     vector_ivp_values.t0 = values.t0;
-    if (values.x0) {
-      vector_ivp_values.x0 = VectorX<T>::Constant(1, values.x0.value()).eval();
+    if (values.x0.has_value()) {
+      // Scalar initial state x₀ as a vector initial state 𝐱₀
+      // of a single dimension.
+      vector_ivp_values.x0 = VectorX<T>::Constant(
+          1, values.x0.value()).eval();
     }
     return vector_ivp_values;
   }

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -100,7 +100,7 @@ class ScalarInitialValueProblem {
   /// @pre An initial time @p default_values.t0 is provided.
   /// @pre An initial state @p default_values.x0 is provided.
   /// @pre An parameter vector @p default_values.k is provided.
-  /// @throw std::logic_error if preconditions are not met.
+  /// @throws std::logic_error if preconditions are not met.
   ScalarInitialValueProblem(const ScalarODEFunction& scalar_ode_function,
                             const SpecifiedValues& default_values) {
     // Wraps the given scalar ODE function as a vector ODE function.
@@ -118,15 +118,15 @@ class ScalarInitialValueProblem {
   /// x₀ and parameter vector 𝐤 present in @p values, falling back to the ones
   /// given on construction if not given.
   ///
-  /// @param tf The time to solve the IVP for.
-  /// @param values The specified values for the IVP.
-  /// @return The IVP solution x(@p tf; 𝐤) for x(t₀; 𝐤) = x₀.
+  /// @param tf The IVP will be solved for this time.
+  /// @param values IVP initial conditions and parameters.
+  /// @returns The IVP solution x(@p tf; 𝐤) for x(t₀; 𝐤) = x₀.
   /// @pre Given @p tf must be larger than or equal to the specified initial
   ///      time t₀ (either given or default).
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   T Solve(const T& tf, const SpecifiedValues& values = {}) const {
     return this->vector_ivp_->Solve(tf, ToVectorIVPSpecifiedValues(values))[0];
   }
@@ -136,10 +136,10 @@ class ScalarInitialValueProblem {
   /// time @p tf, using initial state x₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
-  /// @param tf The time to solve the IVP up to.
-  /// @param values The specified values for the IVP.
-  /// @return A dense approximation to x(t; 𝐤) with x(t₀; 𝐤) = x₀,
-  ///         defined for t₀ <= t <= tf.
+  /// @param tf The IVP will be solved up to this time.
+  /// @param values IVP initial conditions and parameters.
+  /// @returns A dense approximation to x(t; 𝐤) with x(t₀; 𝐤) = x₀, defined for
+  ///          t₀ ≤ t ≤ tf.
   /// @pre Given @p tf must be larger than or equal to the specified initial
   ///      time t₀ (either given or default).
   /// @pre If given, the dimension of the initial state vector @p values.x0
@@ -148,7 +148,7 @@ class ScalarInitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   std::unique_ptr<ScalarDenseOutput<T>> DenseSolve(
       const T& tf, const SpecifiedValues& values = {}) const {
     // Delegates request to the vector form of this IVP by putting
@@ -170,7 +170,7 @@ class ScalarInitialValueProblem {
   /// @endcode
   ///
   /// @param args The integrator type-specific arguments.
-  /// @return The new integrator instance.
+  /// @returns The new integrator instance.
   /// @tparam Integrator The integrator type, which must be an
   ///                    IntegratorBase subclass.
   /// @tparam Args The integrator specific argument types.

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -136,11 +136,15 @@ class ScalarInitialValueProblem {
   /// time @p tf, using initial state x₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
-  /// @param tf The IVP will be solved up to this time, usually t₀ < @p tf, as
+  /// @param tf The IVP will be solved up to this time. Usually, t₀ < @p tf as
   ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.
   /// @returns A dense approximation to x(t; 𝐤) with x(t₀; 𝐤) = x₀, defined for
   ///          t₀ ≤ t ≤ tf.
+  /// @note The larger the given @p tf value is, the larger the approximated
+  ///       interval will be. See documentation of the specific dense output
+  ///       technique in use for reference on performance impact as this
+  ///       interval grows.
   /// @pre Given @p tf must be larger than or equal to the specified initial
   ///      time t₀ (either given or default).
   /// @pre If given, the dimension of the initial state vector @p values.x0

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -29,16 +29,9 @@ namespace systems {
 /// Moreover, this scalar form facilitates single-dimensional quadrature
 /// using methods for solving initial value problems.
 ///
-/// Additionally, configured integrator's dense output support can be leveraged
-/// to efficiently approximate the IVP solution within closed time intervals.
-/// This is convenient when there's a need for a more dense sampling of the
-/// IVP solution than what would be available through either fixed or
-/// error-controlled step integration (for a given accuracy), or when the IVP
-/// is to be solved at a high rate for arbitrary times within a given interval.
-/// After construction, if necessary, equivalent vector dense outputs may be
-/// wrapped into a scalar form that is consistent with the IVP definition.
-/// See configured integrator's documentation for further reference on the
-/// specific dense output technique in use.
+/// See InitialValueProblem class documentation for information on caching
+/// support and dense output usage for improved efficiency in scalar IVP
+/// solving.
 ///
 /// For further insight into its use, consider the following examples of scalar
 /// IVPs:

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -29,10 +29,16 @@ namespace systems {
 /// Moreover, this scalar form facilitates single-dimensional quadrature
 /// using methods for solving initial value problems.
 ///
-/// Additionally, support for solving the IVP for entire time intervals is
-/// provided. This is convenient when a more dense sampling of the IVP
-/// solution than what would be available through either fixed or
-/// error-controlled step integration (for a given accuracy) is needed.
+/// Additionally, configured integrator's dense output support can be leveraged
+/// to efficiently approximate the IVP solution within closed time intervals.
+/// This is convenient when there's a need for a more dense sampling of the
+/// IVP solution than what would be available through either fixed or
+/// error-controlled step integration (for a given accuracy), or when the IVP
+/// is to be solved at a high rate for arbitrary times within a given interval.
+/// After construction, if necessary, equivalent vector dense outputs may be
+/// wrapped into a scalar form that is consistent with the IVP definition.
+/// See configured integrator's documentation for further reference on the
+/// specific dense output technique in use.
 ///
 /// For further insight into its use, consider the following examples of scalar
 /// IVPs:
@@ -127,15 +133,15 @@ class ScalarInitialValueProblem {
   /// @pre If given, the dimension of the parameter vector @p values.k
   ///      must match that of the parameter vector in the default specified
   ///      values given on construction.
-  /// @throw std::logic_error if preconditions is not met.
+  /// @throw std::logic_error if any of the preconditions is not met.
   T Solve(const T& tf, const SpecifiedValues& values = {}) const {
     return this->vector_ivp_->Solve(tf, ToVectorIVPSpecifiedValues(values))[0];
   }
 
-  /// Solves the IVP for the whole time interval between the initial time t₀
-  /// and the given final time @p tf, using initial state x₀ and parameter
-  /// vector 𝐤 present in @p values (falling back to the ones given on
-  /// construction if not given).
+  /// Solves and yields an approximation of the IVP solution x(t; 𝐤) for the
+  /// closed time interval between the initial time t₀ and the given final
+  /// time @p tf, using initial state x₀ and parameter vector 𝐤 present in
+  /// @p values (falling back to the ones given on construction if not given).
   ///
   /// @param tf The time to solve the IVP up to.
   /// @param values The specified values for the IVP.

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -136,7 +136,8 @@ class ScalarInitialValueProblem {
   /// time @p tf, using initial state x₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
-  /// @param tf The IVP will be solved up to this time.
+  /// @param tf The IVP will be solved up to this time, usually t₀ < @p tf, as
+  ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.
   /// @returns A dense approximation to x(t; 𝐤) with x(t₀; 𝐤) = x₀, defined for
   ///          t₀ ≤ t ≤ tf.

--- a/systems/analysis/scalar_initial_value_problem.h
+++ b/systems/analysis/scalar_initial_value_problem.h
@@ -136,6 +136,11 @@ class ScalarInitialValueProblem {
   /// time @p tf, using initial state x₀ and parameter vector 𝐤 present in
   /// @p values (falling back to the ones given on construction if not given).
   ///
+  /// To this end, the wrapped IntegratorBase instance solves this scalar IVP,
+  /// advancing time and state from t₀ and x₀ = x(t₀) to @p tf and x(@p tf),
+  /// creating a scalar dense output over that [t₀, @p tf] interval along the
+  /// way.
+  ///
   /// @param tf The IVP will be solved up to this time. Usually, t₀ < @p tf as
   ///           an empty dense output would result if t₀ = @p tf.
   /// @param values IVP initial conditions and parameters.

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -42,7 +42,7 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
   }
 
  private:
-  T DoEvaluate(const T& t) const override {
+  T DoEvaluateScalar(const T& t) const override {
     return base_output_->Evaluate(t, dimension_);
   }
 

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -35,22 +35,6 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
     }
   }
 
-  T Evaluate(const T& t) const override {
-    return base_output_->Evaluate(t, dimension_);
-  }
-
-  bool is_empty() const override {
-    return base_output_->is_empty();
-  }
-
-  const T& get_start_time() const override {
-    return base_output_->get_start_time();
-  }
-
-  const T& get_end_time() const override {
-    return base_output_->get_end_time();
-  }
-
   /// Returns the base dense output upon which the
   /// view operates.
   const DenseOutput<T>* get_base_output() const {
@@ -58,6 +42,22 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
   }
 
  private:
+  T DoEvaluate(const T& t) const override {
+    return base_output_->Evaluate(t, dimension_);
+  }
+
+  bool do_is_empty() const override {
+    return base_output_->is_empty();
+  }
+
+  const T& do_get_start_time() const override {
+    return base_output_->get_start_time();
+  }
+
+  const T& do_get_end_time() const override {
+    return base_output_->get_end_time();
+  }
+
   // The base (vector) dense output being wrapped.
   const std::unique_ptr<DenseOutput<T>> base_output_;
   // The dimension of interest for the view.

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -24,7 +24,8 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
 
   /// Constructs a view of another DenseOutput instance.
   /// @param base_output Base dense output to operate with.
-  /// @param n The nth dimension of the output value to view.
+  /// @param n The nth element (or the 0-indexed dimension) of
+  ///          the output value to view.
   /// @throws std::runtime_error if @p n is not a valid dimension
   ///                            of @p base_output.
   explicit ScalarViewDenseOutput(
@@ -62,7 +63,8 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
 
   // The base (vector) dense output being wrapped.
   const std::unique_ptr<DenseOutput<T>> base_output_;
-  // The nth dimension of interest for the view.
+  // The nth element (or the 0-indexed dimension) of the base
+  // (vector) dense output value to view.
   const int n_;
 };
 

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -27,8 +27,9 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
   /// @param n The nth scalar element (0-indexed) of the output value
   ///          to view.
   /// @throws std::runtime_error if @p base_output is nullptr.
-  /// @throws std::runtime_error if @p n is not valid
-  ///                            i.e. 0 ≤ @p n < `base_output`->size().
+  /// @throws std::runtime_error if given @p n does not refer to a valid
+  ///                            base output dimension
+  ///                            i.e. @p n ∉ [0, `base_output`->size()).
   explicit ScalarViewDenseOutput(
       std::unique_ptr<DenseOutput<T>> base_output, int n)
       : base_output_(std::move(base_output)), n_(n) {

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -14,7 +14,7 @@ namespace systems {
 
 /// A ScalarDenseOutput class implementation that wraps a
 /// DenseOutput class instance and behaves as a view to one of
-/// its dimensions.
+/// its elements.
 ///
 /// @tparam T A valid Eigen scalar.
 template <typename T>
@@ -24,16 +24,20 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
 
   /// Constructs a view of another DenseOutput instance.
   /// @param base_output Base dense output to operate with.
-  /// @param n The nth element (or the 0-indexed dimension) of
-  ///          the output value to view.
-  /// @throws std::runtime_error if @p n is not a valid dimension
-  ///                            of @p base_output.
+  /// @param n The nth scalar element (0-indexed) of the output value
+  ///          to view.
+  /// @throws std::runtime_error if @p base_output is nullptr.
+  /// @throws std::runtime_error if @p n is not valid
+  ///                            i.e. 0 ≤ @p n < `base_output`->size().
   explicit ScalarViewDenseOutput(
       std::unique_ptr<DenseOutput<T>> base_output, int n)
       : base_output_(std::move(base_output)), n_(n) {
+    if (base_output_ == nullptr) {
+      throw std::runtime_error("Base dense output to view is null.");
+    }
     if (n < 0 || base_output_->size() <= n) {
       throw std::runtime_error(fmt::format(
-          "Dimension {} out of base dense output [0, {}) range.",
+          "Index {} out of base dense output [0, {}) range.",
           n, base_output_->size()));
     }
   }
@@ -63,7 +67,7 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
 
   // The base (vector) dense output being wrapped.
   const std::unique_ptr<DenseOutput<T>> base_output_;
-  // The nth element (or the 0-indexed dimension) of the base
+  // The nth scalar element (0-indexed) of the base
   // (vector) dense output value to view.
   const int n_;
 };

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -41,9 +41,9 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
     return base_output_.get();
   }
 
- private:
+ protected:
   T DoEvaluateScalar(const T& t) const override {
-    return base_output_->Evaluate(t, dimension_);
+    return base_output_->EvaluateNth(t, dimension_);
   }
 
   bool do_is_empty() const override {

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/analysis/dense_output.h"
+#include "drake/systems/analysis/scalar_dense_output.h"
+
+namespace drake {
+namespace systems {
+
+/// A ScalarDenseOutput class implementation that wraps a
+/// DenseOutput class instance and behaves as a view to one of
+/// its dimensions.
+///
+/// @tparam T A valid Eigen scalar.
+template <typename T>
+class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ScalarViewDenseOutput)
+
+  /// Constructs a view of another DenseOutput instance.
+  /// @param base_output Base dense output to operate with.
+  /// @param dimension The dimension to view.
+  /// @throw std::logic_error if specified @p dimension is not a
+  ///                         valid dimension of @p base_output.
+  explicit ScalarViewDenseOutput(
+      std::unique_ptr<DenseOutput<T>> base_output, int dimension)
+      : base_output_(std::move(base_output)),
+        dimension_(dimension) {
+    if (dimension < 0 || dimension >= base_output_->get_dimensions()) {
+      throw std::logic_error("Dimension out of range for the "
+                             "given base dense output.");
+    }
+  }
+
+  T Evaluate(const T& t) const override {
+    return base_output_->Evaluate(t, dimension_);
+  }
+
+  bool is_empty() const override {
+    return base_output_->is_empty();
+  }
+
+  const T& get_start_time() const override {
+    return base_output_->get_start_time();
+  }
+
+  const T& get_end_time() const override {
+    return base_output_->get_end_time();
+  }
+
+  /// Returns the base dense output upon which the
+  /// view operates.
+  const DenseOutput<T>* get_base_output() const {
+    return base_output_.get();
+  }
+
+ private:
+  // The base (vector) dense output being wrapped.
+  const std::unique_ptr<DenseOutput<T>> base_output_;
+  // The dimension of interest for the view.
+  const int dimension_;
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/scalar_view_dense_output.h
+++ b/systems/analysis/scalar_view_dense_output.h
@@ -23,13 +23,13 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
   /// Constructs a view of another DenseOutput instance.
   /// @param base_output Base dense output to operate with.
   /// @param dimension The dimension to view.
-  /// @throw std::logic_error if specified @p dimension is not a
-  ///                         valid dimension of @p base_output.
+  /// @throws std::logic_error if specified @p dimension is not a
+  ///                          valid dimension of @p base_output.
   explicit ScalarViewDenseOutput(
       std::unique_ptr<DenseOutput<T>> base_output, int dimension)
       : base_output_(std::move(base_output)),
         dimension_(dimension) {
-    if (dimension < 0 || dimension >= base_output_->get_dimensions()) {
+    if (dimension < 0 || dimension >= base_output_->size()) {
       throw std::logic_error("Dimension out of range for the "
                              "given base dense output.");
     }
@@ -50,12 +50,12 @@ class ScalarViewDenseOutput : public ScalarDenseOutput<T> {
     return base_output_->is_empty();
   }
 
-  const T& do_get_start_time() const override {
-    return base_output_->get_start_time();
+  const T& do_start_time() const override {
+    return base_output_->start_time();
   }
 
-  const T& do_get_end_time() const override {
-    return base_output_->get_end_time();
+  const T& do_end_time() const override {
+    return base_output_->end_time();
   }
 
   // The base (vector) dense output being wrapped.

--- a/systems/analysis/stepwise_dense_output.h
+++ b/systems/analysis/stepwise_dense_output.h
@@ -46,7 +46,7 @@ class StepwiseDenseOutput : public DenseOutput<T> {
   /// @post The extents covered by updates since instantiation or
   ///       last consolidation can be evaluated (via Evaluate()).
   /// @post Time extents covered by updates can be evaluated
-  ///       (via get_start_time()/get_end_time()).
+  ///       (via start_time()/end_time()).
   /// @throws std::logic_error if any of the preconditions is not met.
   virtual void Consolidate() = 0;
 

--- a/systems/analysis/stepwise_dense_output.h
+++ b/systems/analysis/stepwise_dense_output.h
@@ -32,7 +32,7 @@ class StepwiseDenseOutput : public DenseOutput<T> {
   /// @remarks This process is irreversible.
   /// @pre Updates have taken place since instantiation or last
   ///      consolidation (via Consolidate()).
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   virtual void Rollback() = 0;
 
   /// Consolidates latest updates.
@@ -47,7 +47,7 @@ class StepwiseDenseOutput : public DenseOutput<T> {
   ///       last consolidation can be evaluated (via Evaluate()).
   /// @post Time extents covered by updates can be evaluated
   ///       (via get_start_time()/get_end_time()).
-  /// @throw std::logic_error if any of the preconditions is not met.
+  /// @throws std::logic_error if any of the preconditions is not met.
   virtual void Consolidate() = 0;
 
  protected:

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -110,7 +110,7 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
       std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      antiderivative_function.DenseEvaluate(
+      antiderivative_function.MakeDenseEvalFunction(
           kInvalidUpperIntegrationBound),
       std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
@@ -124,7 +124,7 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE({
       AntiderivativeFunction<double>::SpecifiedValues values;
       values.k = kInvalidParameters;
-      antiderivative_function.DenseEvaluate(
+      antiderivative_function.MakeDenseEvalFunction(
           kValidUpperIntegrationBound, values);
     }, std::logic_error, kInvalidParametersErrorMessage);
 
@@ -138,7 +138,7 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
   DRAKE_EXPECT_THROWS_MESSAGE({
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = kValidParameters;
-    antiderivative_function.DenseEvaluate(
+    antiderivative_function.MakeDenseEvalFunction(
         kInvalidUpperIntegrationBound, values);
     }, std::logic_error, kInvalidIntegrationBoundErrorMessage);
 }
@@ -188,7 +188,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
 
     const std::unique_ptr<ScalarDenseOutput<double>>
         antiderivative_function_approx =
-        antiderivative_function.DenseEvaluate(
+        antiderivative_function.MakeDenseEvalFunction(
             kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
@@ -247,7 +247,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
 
     const std::unique_ptr<ScalarDenseOutput<double>>
         antiderivative_function_approx =
-        antiderivative_function.DenseEvaluate(
+        antiderivative_function.MakeDenseEvalFunction(
             kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
@@ -313,7 +313,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
 
     const std::unique_ptr<ScalarDenseOutput<double>>
         antiderivative_function_approx =
-        antiderivative_function.DenseEvaluate(
+        antiderivative_function.MakeDenseEvalFunction(
             kArgIntervalUBound, values);
 
       for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
@@ -374,7 +374,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
 
     const std::unique_ptr<ScalarDenseOutput<double>>
         antiderivative_function_approx =
-        antiderivative_function.DenseEvaluate(
+        antiderivative_function.MakeDenseEvalFunction(
             kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
@@ -434,7 +434,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
 
     const std::unique_ptr<ScalarDenseOutput<double>>
         antiderivative_function_approx =
-        antiderivative_function.DenseEvaluate(
+        antiderivative_function.MakeDenseEvalFunction(
             kArgIntervalUBound, values);
 
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 
@@ -98,43 +99,48 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
   // parameter vector of the expected dimension.
   const VectorX<double> kValidParameters = VectorX<double>::Constant(2, 5.0);
 
-  EXPECT_THROW(
+  const std::string kInvalidIntegrationBoundErrorMessage{
+    "Cannot solve IVP for.*time.*"};
+  const std::string kInvalidParametersErrorMessage{
+    ".*parameters.*wrong dimension.*"};
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
       antiderivative_function.Evaluate(
           kInvalidUpperIntegrationBound),
-      std::logic_error);
+      std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
-  EXPECT_THROW(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       antiderivative_function.DenseEvaluate(
           kInvalidUpperIntegrationBound),
-      std::logic_error);
+      std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
-  EXPECT_THROW({
+  DRAKE_EXPECT_THROWS_MESSAGE({
       AntiderivativeFunction<double>::SpecifiedValues values;
       values.k = kInvalidParameters;
       antiderivative_function.Evaluate(
           kValidUpperIntegrationBound, values);
-    }, std::logic_error);
+    }, std::logic_error, kInvalidParametersErrorMessage);
 
-  EXPECT_THROW({
+  DRAKE_EXPECT_THROWS_MESSAGE({
       AntiderivativeFunction<double>::SpecifiedValues values;
       values.k = kInvalidParameters;
       antiderivative_function.DenseEvaluate(
           kValidUpperIntegrationBound, values);
-    }, std::logic_error);
+    }, std::logic_error, kInvalidParametersErrorMessage);
 
-  EXPECT_THROW({
+  DRAKE_EXPECT_THROWS_MESSAGE({
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = kValidParameters;
     antiderivative_function.Evaluate(
         kInvalidUpperIntegrationBound, values);
-  }, std::logic_error);
+    }, std::logic_error, kInvalidIntegrationBoundErrorMessage);
 
-  EXPECT_THROW({
+  DRAKE_EXPECT_THROWS_MESSAGE({
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = kValidParameters;
     antiderivative_function.DenseEvaluate(
         kInvalidUpperIntegrationBound, values);
-  }, std::logic_error);
+    }, std::logic_error, kInvalidIntegrationBoundErrorMessage);
 }
 
 class AntiderivativeFunctionAccuracyTest

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -8,6 +8,7 @@
 
 namespace drake {
 namespace systems {
+namespace analysis {
 namespace {
 
 // Checks antiderivative function usage with multiple integrators.
@@ -26,7 +27,7 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
       kDefaultLowerIntegrationBound, kDefaultParameters);
 
   // Defines an antiderivative function for f(x; 𝐤) = k₁ * x + k₂.
-  AntiderivativeFunction<double> antiderivative_f(
+  AntiderivativeFunction<double> antiderivative_function(
       [](const double& x, const VectorX<double>& k) -> double {
         return k[0] * x + k[1];
       }, kDefaultValues);
@@ -36,19 +37,19 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
   // integration lower bound.
   const double u1 = kDefaultLowerIntegrationBound + 10.0;
   const VectorX<double>& k1 = kDefaultParameters;
-  EXPECT_NEAR(antiderivative_f.Evaluate(u1),
+  EXPECT_NEAR(antiderivative_function.Evaluate(u1),
               k1[0]/2 * std::pow(u1, 2.0) + k1[1] * u1,
               kAccuracy);
 
   // Replaces default integrator.
   const double kMaximumStep = 0.1;
   const IntegratorBase<double>* default_integrator =
-      antiderivative_f.get_integrator();
+      antiderivative_function.get_integrator();
   using RK2 = RungeKutta2Integrator<double>;
   IntegratorBase<double>* configured_integrator =
-      antiderivative_f.reset_integrator<RK2>(kMaximumStep);
+      antiderivative_function.reset_integrator<RK2>(kMaximumStep);
   EXPECT_NE(configured_integrator, default_integrator);
-  EXPECT_EQ(configured_integrator, antiderivative_f.get_integrator());
+  EXPECT_EQ(configured_integrator, antiderivative_function.get_integrator());
 
   // Specifies a different parameter vector, but leaves the default
   // integration lower bound.
@@ -60,7 +61,7 @@ GTEST_TEST(AntiderivativeFunctionTest, UsingMultipleIntegrators) {
   // can be written as F(u; 𝐤) = k₀/2 * u^2 + k₁ * u for the specified
   // integration lower bound.
   EXPECT_NEAR(
-      antiderivative_f.Evaluate(u2, values),
+      antiderivative_function.Evaluate(u2, values),
       k2[0]/2 * std::pow(u2, 2.0) + k2[1] * u2,
       kAccuracy);
 }
@@ -77,7 +78,7 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
       kDefaultLowerIntegrationBound, kDefaultParameters);
 
   // Defines a antiderivative function for f(x; 𝐤) = k₀ * x + k₁.
-  const AntiderivativeFunction<double> antiderivative_f(
+  const AntiderivativeFunction<double> antiderivative_function(
       [](const double& x, const VectorX<double>& k) -> double {
         return k[0] * x + k[1];
       }, kDefaultValues);
@@ -97,19 +98,42 @@ GTEST_TEST(AntiderivativeFunctionTest, EvaluatePreconditionValidation) {
   // parameter vector of the expected dimension.
   const VectorX<double> kValidParameters = VectorX<double>::Constant(2, 5.0);
 
-  EXPECT_THROW(antiderivative_f.Evaluate(kInvalidUpperIntegrationBound),
-               std::logic_error);
+  EXPECT_THROW(
+      antiderivative_function.Evaluate(
+          kInvalidUpperIntegrationBound),
+      std::logic_error);
+
+  EXPECT_THROW(
+      antiderivative_function.DenseEvaluate(
+          kInvalidUpperIntegrationBound),
+      std::logic_error);
 
   EXPECT_THROW({
       AntiderivativeFunction<double>::SpecifiedValues values;
       values.k = kInvalidParameters;
-      antiderivative_f.Evaluate(kValidUpperIntegrationBound, values);
+      antiderivative_function.Evaluate(
+          kValidUpperIntegrationBound, values);
+    }, std::logic_error);
+
+  EXPECT_THROW({
+      AntiderivativeFunction<double>::SpecifiedValues values;
+      values.k = kInvalidParameters;
+      antiderivative_function.DenseEvaluate(
+          kValidUpperIntegrationBound, values);
     }, std::logic_error);
 
   EXPECT_THROW({
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = kValidParameters;
-    antiderivative_f.Evaluate(kInvalidUpperIntegrationBound, values);
+    antiderivative_function.Evaluate(
+        kInvalidUpperIntegrationBound, values);
+  }, std::logic_error);
+
+  EXPECT_THROW({
+    AntiderivativeFunction<double>::SpecifiedValues values;
+    values.k = kValidParameters;
+    antiderivative_function.DenseEvaluate(
+        kInvalidUpperIntegrationBound, values);
   }, std::logic_error);
 }
 
@@ -155,16 +179,29 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
   for (int n = kLowestOrder; n <= kHighestOrder; ++n) {
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = VectorX<double>::Constant(1, static_cast<double>(n)).eval();
+
+    const std::unique_ptr<ScalarDenseOutput<double>>
+        antiderivative_function_approx =
+        antiderivative_function.DenseEvaluate(
+            kArgIntervalUBound, values);
+
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
       // Tests are performed against the closed form solution of
       // the definite integral, which is (n + 1)⁻¹ uⁿ⁺¹.
-      const double exact_solution = std::pow(u, n + 1.) / (n + 1.);
+      const double solution = std::pow(u, n + 1.) / (n + 1.);
+
       EXPECT_NEAR(antiderivative_function.Evaluate(u, values),
-                  exact_solution, integration_accuracy_)
+                  solution, integration_accuracy_)
           << "Failure integrating ∫₀ᵘ xⁿ dx for u = "
           << u << " and n = " << n << " to an accuracy of "
           << integration_accuracy_;
+
+      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+                  solution, integration_accuracy_)
+          << "Failure approximating ∫₀ᵘ xⁿ dx for u = "
+          << u << " and n = " << n << " to an accuracy of "
+          << integration_accuracy_ << " with solver's continuous extension.";
     }
   }
 }
@@ -201,16 +238,29 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
        a += kParamStep) {
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = VectorX<double>::Constant(1, a).eval();
+
+    const std::unique_ptr<ScalarDenseOutput<double>>
+        antiderivative_function_approx =
+        antiderivative_function.DenseEvaluate(
+            kArgIntervalUBound, values);
+
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
       // Tests are performed against the closed form solution of
       // the definite integral, which is a⁻¹ ln(cosh(a ⋅ u)).
-      const double exact_solution = std::log(std::cosh(a * u)) / a;
+      const double solution = std::log(std::cosh(a * u)) / a;
+
       EXPECT_NEAR(antiderivative_function.Evaluate(u, values),
-                  exact_solution, integration_accuracy_)
+                  solution, integration_accuracy_)
           << "Failure integrating ∫₀ᵘ tanh(a⋅x) dx for"
           << " u = " << u << " and a = " << a << " to an accuracy of "
           << integration_accuracy_;
+
+      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+                  solution, integration_accuracy_)
+          << "Failure approximating ∫₀ᵘ tanh(a⋅x) dx for"
+          << " u = " << u << " and a = " << a << " to an accuracy of "
+          << integration_accuracy_ << " with solver's continuous extension.";
     }
   }
 }
@@ -254,17 +304,31 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
          b += k2ndPoleStep) {
       AntiderivativeFunction<double>::SpecifiedValues values;
       values.k = (VectorX<double>(2) << a, b).finished();
+
+    const std::unique_ptr<ScalarDenseOutput<double>>
+        antiderivative_function_approx =
+        antiderivative_function.DenseEvaluate(
+            kArgIntervalUBound, values);
+
       for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
            u += kArgStep) {
         // Tests are performed against the closed form solution of the definite
         // integral, which is (b - a)⁻¹ ln [(b / a) ⋅ (u + a) / (u + b)].
-        const double exact_solution =
+        const double solution =
             std::log((b / a) * ((u + a) / (u + b))) / (b - a);
+
         EXPECT_NEAR(antiderivative_function.Evaluate(u, values),
-                    exact_solution, integration_accuracy_)
+                    solution, integration_accuracy_)
             << "Failure integrating ∫₀ᵘ [(x + a)⋅(x + b)]⁻¹ dx for"
             << " u = " << u << ", a = " << a << "and b = " << b
             << " to an accuracy of " << integration_accuracy_;
+
+        EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+                    solution, integration_accuracy_)
+            << "Failure approximating ∫₀ᵘ [(x + a)⋅(x + b)]⁻¹ dx for"
+            << " u = " << u << ", a = " << a << "and b = " << b
+            << " to an accuracy of " << integration_accuracy_
+            << " with solver's continuous extension.";
       }
     }
   }
@@ -301,17 +365,31 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
        n += kParamStep) {
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = VectorX<double>::Constant(1, n).eval();
+
+    const std::unique_ptr<ScalarDenseOutput<double>>
+        antiderivative_function_approx =
+        antiderivative_function.DenseEvaluate(
+            kArgIntervalUBound, values);
+
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
       // Tests are performed against the closed form solution of the definite
       // integral, which is (u / n - 1 / n²) ⋅ e^(n ⋅ u) + 1 / n².
-      const double exact_solution =
+      const double solution =
           (u / n - 1. / (n * n)) * std::exp(n * u) + 1. / (n * n);
+
       EXPECT_NEAR(antiderivative_function.Evaluate(u, values),
-                  exact_solution, integration_accuracy_)
+                  solution, integration_accuracy_)
           << "Failure integrating ∫₀ᵘ x eⁿˣ dx for"
           << " u = " << u << " and n = " << n
           << " to an accuracy of " << integration_accuracy_;
+
+      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+                  solution, integration_accuracy_)
+          << "Failure approximating ∫₀ᵘ x eⁿˣ dx for"
+          << " u = " << u << " and n = " << n
+          << " to an accuracy of " << integration_accuracy_
+          << " with solver's continuous extension.";
     }
   }
 }
@@ -347,17 +425,30 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
        a += kParamStep) {
     AntiderivativeFunction<double>::SpecifiedValues values;
     values.k = VectorX<double>::Constant(1, a).eval();
+
+    const std::unique_ptr<ScalarDenseOutput<double>>
+        antiderivative_function_approx =
+        antiderivative_function.DenseEvaluate(
+            kArgIntervalUBound, values);
+
     for (double u = kArgIntervalLBound; u <= kArgIntervalUBound;
          u += kArgStep) {
       // Tests are performed against the closed form solution of the definite
       // integral, which is -u ⋅ cos(a ⋅ u) / a + sin(a ⋅ u) / a².
-      const double exact_solution =
+      const double solution =
           -u * std::cos(a * u) / a + std::sin(a * u) / (a * a);
+
       EXPECT_NEAR(antiderivative_function.Evaluate(u, values),
-                  exact_solution, integration_accuracy_)
+                  solution, integration_accuracy_)
           << "Failure integrating ∫₀ᵘ x⋅sin(a⋅x) dx for"
           << " u = " << u << " and a = " << a << " to an accuracy of "
           << integration_accuracy_;
+
+      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+                  solution, integration_accuracy_)
+          << "Failure approximating ∫₀ᵘ x⋅sin(a⋅x) dx for"
+          << " u = " << u << " and a = " << a << " to an accuracy of "
+          << integration_accuracy_ << "with solver's continuous extension.";;
     }
   }
 }
@@ -367,5 +458,6 @@ INSTANTIATE_TEST_CASE_P(IncreasingAccuracyAntiderivativeFunctionTests,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4));
 
 }  // namespace
+}  // namespace analysis
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/antiderivative_function_test.cc
+++ b/systems/analysis/test/antiderivative_function_test.cc
@@ -203,7 +203,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, NthPowerMonomialTestCase) {
           << u << " and n = " << n << " to an accuracy of "
           << integration_accuracy_;
 
-      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+      EXPECT_NEAR(antiderivative_function_approx->EvaluateScalar(u),
                   solution, integration_accuracy_)
           << "Failure approximating ∫₀ᵘ xⁿ dx for u = "
           << u << " and n = " << n << " to an accuracy of "
@@ -262,7 +262,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, HyperbolicTangentTestCase) {
           << " u = " << u << " and a = " << a << " to an accuracy of "
           << integration_accuracy_;
 
-      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+      EXPECT_NEAR(antiderivative_function_approx->EvaluateScalar(u),
                   solution, integration_accuracy_)
           << "Failure approximating ∫₀ᵘ tanh(a⋅x) dx for"
           << " u = " << u << " and a = " << a << " to an accuracy of "
@@ -329,7 +329,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest,
             << " u = " << u << ", a = " << a << "and b = " << b
             << " to an accuracy of " << integration_accuracy_;
 
-        EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+        EXPECT_NEAR(antiderivative_function_approx->EvaluateScalar(u),
                     solution, integration_accuracy_)
             << "Failure approximating ∫₀ᵘ [(x + a)⋅(x + b)]⁻¹ dx for"
             << " u = " << u << ", a = " << a << "and b = " << b
@@ -390,7 +390,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, ExponentialFunctionTestCase) {
           << " u = " << u << " and n = " << n
           << " to an accuracy of " << integration_accuracy_;
 
-      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+      EXPECT_NEAR(antiderivative_function_approx->EvaluateScalar(u),
                   solution, integration_accuracy_)
           << "Failure approximating ∫₀ᵘ x eⁿˣ dx for"
           << " u = " << u << " and n = " << n
@@ -450,7 +450,7 @@ TEST_P(AntiderivativeFunctionAccuracyTest, TrigonometricFunctionTestCase) {
           << " u = " << u << " and a = " << a << " to an accuracy of "
           << integration_accuracy_;
 
-      EXPECT_NEAR(antiderivative_function_approx->Evaluate(u),
+      EXPECT_NEAR(antiderivative_function_approx->EvaluateScalar(u),
                   solution, integration_accuracy_)
           << "Failure approximating ∫₀ᵘ x⋅sin(a⋅x) dx for"
           << " u = " << u << " and a = " << a << " to an accuracy of "

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -43,6 +43,8 @@ class HermitianDenseOutputTest : public ::testing::Test {
     (MatrixX<double>(4, 1) << 1., 0., 1., 0.).finished()};
   const MatrixX<double> kFinalStateDerivativeNotAVector{
     (MatrixX<double>(2, 2) << 0., 1., 0., 1.).finished()};
+  const int kValidDimension{0};
+  const int kInvalidDimension{10};
 };
 
 
@@ -60,6 +62,8 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   ASSERT_TRUE(dense_output.is_empty());
   EXPECT_THROW(dense_output.Evaluate(
       this->kInitialTime), std::logic_error);
+  EXPECT_THROW(dense_output.Evaluate(
+      this->kInitialTime, this->kValidDimension), std::logic_error);
   EXPECT_THROW(dense_output.get_start_time(), std::logic_error);
   EXPECT_THROW(dense_output.get_end_time(), std::logic_error);
   EXPECT_THROW(dense_output.get_dimensions(), std::logic_error);
@@ -83,6 +87,8 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   ASSERT_TRUE(dense_output.is_empty());
   EXPECT_THROW(dense_output.Evaluate(
       this->kMidTime), std::logic_error);
+  EXPECT_THROW(dense_output.Evaluate(
+      this->kMidTime, this->kValidDimension), std::logic_error);
   EXPECT_THROW(dense_output.get_start_time(), std::logic_error);
   EXPECT_THROW(dense_output.get_end_time(), std::logic_error);
   EXPECT_THROW(dense_output.get_dimensions(), std::logic_error);
@@ -100,8 +106,14 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   EXPECT_EQ(dense_output.get_end_time(), first_step.get_end_time());
   EXPECT_EQ(dense_output.get_dimensions(), first_step.get_dimensions());
   EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime));
+  EXPECT_NO_THROW(dense_output.Evaluate(
+      this->kMidTime, this->kValidDimension));
 
   // Verifies that invalid evaluation arguments generate errors.
+  EXPECT_THROW(dense_output.Evaluate(
+      this->kMidTime, this->kInvalidDimension), std::runtime_error);
+  EXPECT_THROW(dense_output.Evaluate(
+      this->kInvalidTime, this->kValidDimension), std::runtime_error);
   EXPECT_THROW(dense_output.Evaluate(this->kInvalidTime),
                std::runtime_error);
 

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -88,7 +88,7 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       dense_output.Evaluate(this->kInitialTime),
       std::logic_error, this->kEmptyOutputErrorMessage);
-  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Evaluate(
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.EvaluateNth(
       this->kInitialTime, this->kValidDimension),
       std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
@@ -122,7 +122,7 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Evaluate(this->kMidTime),
                              std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.Evaluate(this->kMidTime, this->kValidDimension),
+      dense_output.EvaluateNth(this->kMidTime, this->kValidDimension),
       std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
                              this->kEmptyOutputErrorMessage);
@@ -149,14 +149,15 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   EXPECT_EQ(dense_output.end_time(), first_step.end_time());
   EXPECT_EQ(dense_output.size(), first_step.size());
   EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime));
-  EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime, this->kValidDimension));
+  EXPECT_NO_THROW(dense_output.EvaluateNth(
+      this->kMidTime, this->kValidDimension));
 
   // Verifies that invalid evaluation arguments generate errors.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.Evaluate(this->kMidTime, this->kInvalidDimension),
+      dense_output.EvaluateNth(this->kMidTime, this->kInvalidDimension),
       std::runtime_error, this->kInvalidDimensionErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.Evaluate(this->kInvalidTime, this->kValidDimension),
+      dense_output.EvaluateNth(this->kInvalidTime, this->kValidDimension),
       std::runtime_error, this->kInvalidTimeErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
       dense_output.Evaluate(this->kInvalidTime),

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -48,7 +48,7 @@ class HermitianDenseOutputTest : public ::testing::Test {
   const int kInvalidDimension{10};
 
   const std::string kEmptyOutputErrorMessage{
-    ".*[Ee]mpty dense output.*"};
+    ".*[Dd]ense output.*empty.*"};
   const std::string kZeroLengthStepErrorMessage{
     ".*step has zero length.*"};
   const std::string kCannotRollbackErrorMessage{
@@ -56,9 +56,9 @@ class HermitianDenseOutputTest : public ::testing::Test {
   const std::string kCannotConsolidateErrorMessage{
     "No updates to consolidate."};
   const std::string kInvalidDimensionErrorMessage{
-    ".*[Ii]nvalid dimension.*"};
+    ".*[Dd]imension.*out of.*dense output.*range.*"};
   const std::string kInvalidTimeErrorMessage{
-    ".*not defined for given time.*"};
+    ".*[Tt]ime.*out of.*dense output.*domain.*"};
   const std::string kTimeMismatchErrorMessage{
     ".*start time.*end time.*differ.*"};
   const std::string kStateMismatchErrorMessage{

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
 namespace drake {
@@ -45,6 +46,30 @@ class HermitianDenseOutputTest : public ::testing::Test {
     (MatrixX<double>(2, 2) << 0., 1., 0., 1.).finished()};
   const int kValidDimension{0};
   const int kInvalidDimension{10};
+
+  const std::string kEmptyOutputErrorMessage{
+    ".*[Ee]mpty dense output.*"};
+  const std::string kZeroLengthStepErrorMessage{
+    ".*step has zero length.*"};
+  const std::string kCannotRollbackErrorMessage{
+    "No updates to rollback."};
+  const std::string kCannotConsolidateErrorMessage{
+    "No updates to consolidate."};
+  const std::string kInvalidDimensionErrorMessage{
+    ".*[Ii]nvalid dimension.*"};
+  const std::string kInvalidTimeErrorMessage{
+    ".*not defined for given time.*"};
+  const std::string kTimeMismatchErrorMessage{
+    ".*start time.*end time.*differ.*"};
+  const std::string kStateMismatchErrorMessage{
+    ".*start state.*end state.*differ.*"};
+  const std::string kStateDerivativeMismatchErrorMessage{
+    ".*start state derivative.*end state derivative.*differ.*"};
+  const std::string kStepBackwardsErrorMessage{
+    ".*cannot be extended backwards.*"};
+  const std::string kDimensionMismatchErrorMessage{
+    ".*dimensions do not match.*"};
+  const std::string kNotAVectorErrorMessage{".*not a column matrix.*"};
 };
 
 
@@ -60,21 +85,30 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   // Verifies that the dense output is empty and API behavior
   // is consistent with that fact.
   ASSERT_TRUE(dense_output.is_empty());
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kInitialTime), std::logic_error);
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kInitialTime, this->kValidDimension), std::logic_error);
-  EXPECT_THROW(dense_output.get_start_time(), std::logic_error);
-  EXPECT_THROW(dense_output.get_end_time(), std::logic_error);
-  EXPECT_THROW(dense_output.get_dimensions(), std::logic_error);
-  EXPECT_THROW(dense_output.Rollback(), std::logic_error);
-  EXPECT_THROW(dense_output.Consolidate(), std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kInitialTime),
+      std::logic_error, this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Evaluate(
+      this->kInitialTime, this->kValidDimension),
+      std::logic_error, this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.end_time(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.size(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Rollback(), std::logic_error,
+                             this->kCannotRollbackErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Consolidate(), std::logic_error,
+                             this->kCannotConsolidateErrorMessage);
 
   // Verifies that trying to update the dense output with
   // a zero length step fails.
   typename HermitianDenseOutput<TypeParam>::IntegrationStep first_step(
       this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
-  EXPECT_THROW(dense_output.Update(first_step), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Update(first_step),
+                             std::runtime_error,
+                             this->kZeroLengthStepErrorMessage);
 
   // Verifies that trying to update the dense output with
   // a valid step succeeds.
@@ -85,37 +119,48 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   // Verifies that an update does not imply a consolidation and thus
   // the dense output remains empty.
   ASSERT_TRUE(dense_output.is_empty());
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kMidTime), std::logic_error);
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kMidTime, this->kValidDimension), std::logic_error);
-  EXPECT_THROW(dense_output.get_start_time(), std::logic_error);
-  EXPECT_THROW(dense_output.get_end_time(), std::logic_error);
-  EXPECT_THROW(dense_output.get_dimensions(), std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Evaluate(this->kMidTime),
+                             std::logic_error, this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kMidTime, this->kValidDimension),
+      std::logic_error, this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.end_time(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.size(), std::logic_error,
+                             this->kEmptyOutputErrorMessage);
 
   // Consolidates all previous updates.
   dense_output.Consolidate();
 
   // Verifies that it is not possible to roll back updates after consolidation.
-  EXPECT_THROW(dense_output.Rollback(), std::logic_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Rollback(), std::logic_error,
+                             this->kCannotRollbackErrorMessage);
+
+  // Verifies that it is not possible to consolidate again.
+  DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Consolidate(), std::logic_error,
+                             this->kCannotConsolidateErrorMessage);
 
   // Verifies that the dense output is not empty and that it
   // reflects the data provided on updates.
   ASSERT_FALSE(dense_output.is_empty());
-  EXPECT_EQ(dense_output.get_start_time(), first_step.get_start_time());
-  EXPECT_EQ(dense_output.get_end_time(), first_step.get_end_time());
-  EXPECT_EQ(dense_output.get_dimensions(), first_step.get_dimensions());
+  EXPECT_EQ(dense_output.start_time(), first_step.start_time());
+  EXPECT_EQ(dense_output.end_time(), first_step.end_time());
+  EXPECT_EQ(dense_output.size(), first_step.size());
   EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime));
-  EXPECT_NO_THROW(dense_output.Evaluate(
-      this->kMidTime, this->kValidDimension));
+  EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime, this->kValidDimension));
 
   // Verifies that invalid evaluation arguments generate errors.
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kMidTime, this->kInvalidDimension), std::runtime_error);
-  EXPECT_THROW(dense_output.Evaluate(
-      this->kInvalidTime, this->kValidDimension), std::runtime_error);
-  EXPECT_THROW(dense_output.Evaluate(this->kInvalidTime),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kMidTime, this->kInvalidDimension),
+      std::runtime_error, this->kInvalidDimensionErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kInvalidTime, this->kValidDimension),
+      std::runtime_error, this->kInvalidTimeErrorMessage);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kInvalidTime),
+      std::runtime_error, this->kInvalidTimeErrorMessage);
 
   // Verifies that step updates that would disrupt the output continuity
   // fail.
@@ -124,19 +169,26 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
       this->kMidState, this->kMidStateDerivative);
   second_step.Extend(this->kFinalTime, this->kFinalState,
                      this->kFinalStateDerivative);
-  EXPECT_THROW(dense_output.Update(second_step), std::runtime_error);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Update(second_step), std::runtime_error,
+      this->kTimeMismatchErrorMessage);
 
   typename HermitianDenseOutput<TypeParam>::IntegrationStep third_step(
       this->kMidTime, this->kMidState * 2., this->kMidStateDerivative);
   third_step.Extend(this->kFinalTime, this->kFinalState,
                      this->kFinalStateDerivative);
-  EXPECT_THROW(dense_output.Update(third_step), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Update(third_step), std::runtime_error,
+      this->kStateMismatchErrorMessage);
 
   typename HermitianDenseOutput<TypeParam>::IntegrationStep fourth_step(
       this->kMidTime, this->kMidState, this->kMidStateDerivative * 2.);
   fourth_step.Extend(this->kFinalTime, this->kFinalState,
                      this->kFinalStateDerivative);
-  EXPECT_THROW(dense_output.Update(fourth_step), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Update(fourth_step), std::runtime_error,
+      this->kStateDerivativeMismatchErrorMessage);
 }
 
 // Checks that HermitianDenseOutput::Step consistency is ensured.
@@ -145,9 +197,9 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
   typename HermitianDenseOutput<TypeParam>::IntegrationStep step(
       this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
   ASSERT_EQ(step.get_times().size(), 1);
-  EXPECT_EQ(step.get_start_time(), this->kInitialTime);
-  EXPECT_EQ(step.get_end_time(), this->kInitialTime);
-  EXPECT_EQ(step.get_dimensions(), this->kInitialState.rows());
+  EXPECT_EQ(step.start_time(), this->kInitialTime);
+  EXPECT_EQ(step.end_time(), this->kInitialTime);
+  EXPECT_EQ(step.size(), this->kInitialState.rows());
   ASSERT_EQ(step.get_states().size(), 1);
   EXPECT_TRUE(CompareMatrices(step.get_states().front(), this->kInitialState));
   ASSERT_EQ(step.get_state_derivatives().size(), 1);
@@ -155,42 +207,49 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
                               this->kInitialStateDerivative));
 
   // Verifies that any attempt to break step consistency fails.
-  EXPECT_THROW(step.Extend(this->kInvalidTime, this->kFinalState,
-                           this->kFinalStateDerivative),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kInvalidTime, this->kFinalState,
+                  this->kFinalStateDerivative),
+      std::runtime_error, this->kStepBackwardsErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime,
-                           this->kFinalStateWithFewerDimensions,
-                           this->kFinalStateDerivative), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalStateWithFewerDimensions,
+                  this->kFinalStateDerivative), std::runtime_error,
+      this->kDimensionMismatchErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime,
-                           this->kFinalStateWithMoreDimensions,
-                           this->kFinalStateDerivative), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalStateWithMoreDimensions,
+                  this->kFinalStateDerivative), std::runtime_error,
+      this->kDimensionMismatchErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime,
-                           this->kFinalStateNotAVector,
-                           this->kFinalStateDerivative), std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalStateNotAVector,
+                  this->kFinalStateDerivative), std::runtime_error,
+      this->kNotAVectorErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
-                           this->kFinalStateDerivativeWithFewerDimensions),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalState,
+                  this->kFinalStateDerivativeWithFewerDimensions),
+      std::runtime_error, this->kDimensionMismatchErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
-                           this->kFinalStateDerivativeWithMoreDimensions),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalState,
+                  this->kFinalStateDerivativeWithMoreDimensions),
+      std::runtime_error, this->kDimensionMismatchErrorMessage);
 
-  EXPECT_THROW(step.Extend(this->kFinalTime, this->kFinalState,
-                           this->kFinalStateDerivativeNotAVector),
-               std::runtime_error);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      step.Extend(this->kFinalTime, this->kFinalState,
+                  this->kFinalStateDerivativeNotAVector),
+      std::runtime_error, this->kNotAVectorErrorMessage);
 
   // Extends the step with appropriate values.
   step.Extend(this->kFinalTime, this->kFinalState, this->kFinalStateDerivative);
 
   // Verifies that the step was properly extended.
   EXPECT_EQ(step.get_times().size(), 2);
-  EXPECT_EQ(step.get_start_time(), this->kInitialTime);
-  EXPECT_EQ(step.get_end_time(), this->kFinalTime);
-  EXPECT_EQ(step.get_dimensions(), this->kInitialState.rows());
+  EXPECT_EQ(step.start_time(), this->kInitialTime);
+  EXPECT_EQ(step.end_time(), this->kFinalTime);
+  EXPECT_EQ(step.size(), this->kInitialState.rows());
   EXPECT_EQ(step.get_states().size(), 2);
   EXPECT_TRUE(CompareMatrices(step.get_states().back(), this->kFinalState));
   EXPECT_EQ(step.get_state_derivatives().size(), 2);
@@ -221,9 +280,9 @@ TYPED_TEST(HermitianDenseOutputTest, CorrectConstruction) {
 
   // Verifies that the dense output only reflects the first step.
   EXPECT_FALSE(dense_output.is_empty());
-  EXPECT_EQ(dense_output.get_start_time(), first_step.get_start_time());
-  EXPECT_EQ(dense_output.get_end_time(), first_step.get_end_time());
-  EXPECT_EQ(dense_output.get_dimensions(), first_step.get_dimensions());
+  EXPECT_EQ(dense_output.start_time(), first_step.start_time());
+  EXPECT_EQ(dense_output.end_time(), first_step.end_time());
+  EXPECT_EQ(dense_output.size(), first_step.size());
   EXPECT_TRUE(CompareMatrices(dense_output.Evaluate(this->kInitialTime),
                               first_step.get_states().front()));
   EXPECT_TRUE(CompareMatrices(dense_output.Evaluate(this->kMidTime),

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -44,8 +44,8 @@ class HermitianDenseOutputTest : public ::testing::Test {
     (MatrixX<double>(4, 1) << 1., 0., 1., 0.).finished()};
   const MatrixX<double> kFinalStateDerivativeNotAVector{
     (MatrixX<double>(2, 2) << 0., 1., 0., 1.).finished()};
-  const int kValidDimension{0};
-  const int kInvalidDimension{10};
+  const int kValidElementIndex{0};
+  const int kInvalidElementIndex{10};
 
   const std::string kEmptyOutputErrorMessage{
     ".*[Dd]ense output.*empty.*"};
@@ -55,8 +55,8 @@ class HermitianDenseOutputTest : public ::testing::Test {
     "No updates to rollback."};
   const std::string kCannotConsolidateErrorMessage{
     "No updates to consolidate."};
-  const std::string kInvalidDimensionErrorMessage{
-    ".*[Dd]imension.*out of.*dense output.*range.*"};
+  const std::string kInvalidElementIndexErrorMessage{
+    ".*out of.*dense output.*range.*"};
   const std::string kInvalidTimeErrorMessage{
     ".*[Tt]ime.*out of.*dense output.*domain.*"};
   const std::string kTimeMismatchErrorMessage{
@@ -89,7 +89,7 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
       dense_output.Evaluate(this->kInitialTime),
       std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.EvaluateNth(
-      this->kInitialTime, this->kValidDimension),
+      this->kInitialTime, this->kValidElementIndex),
       std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
                              this->kEmptyOutputErrorMessage);
@@ -122,7 +122,7 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.Evaluate(this->kMidTime),
                              std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.EvaluateNth(this->kMidTime, this->kValidDimension),
+      dense_output.EvaluateNth(this->kMidTime, this->kValidElementIndex),
       std::logic_error, this->kEmptyOutputErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(dense_output.start_time(), std::logic_error,
                              this->kEmptyOutputErrorMessage);
@@ -150,14 +150,14 @@ TYPED_TEST(HermitianDenseOutputTest, OutputConsistency) {
   EXPECT_EQ(dense_output.size(), first_step.size());
   EXPECT_NO_THROW(dense_output.Evaluate(this->kMidTime));
   EXPECT_NO_THROW(dense_output.EvaluateNth(
-      this->kMidTime, this->kValidDimension));
+      this->kMidTime, this->kValidElementIndex));
 
   // Verifies that invalid evaluation arguments generate errors.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.EvaluateNth(this->kMidTime, this->kInvalidDimension),
-      std::runtime_error, this->kInvalidDimensionErrorMessage);
+      dense_output.EvaluateNth(this->kMidTime, this->kInvalidElementIndex),
+      std::runtime_error, this->kInvalidElementIndexErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
-      dense_output.EvaluateNth(this->kInvalidTime, this->kValidDimension),
+      dense_output.EvaluateNth(this->kInvalidTime, this->kValidElementIndex),
       std::runtime_error, this->kInvalidTimeErrorMessage);
   DRAKE_EXPECT_THROWS_MESSAGE(
       dense_output.Evaluate(this->kInvalidTime),
@@ -214,14 +214,14 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
       std::runtime_error, this->kStepBackwardsErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      step.Extend(this->kFinalTime, this->kFinalStateWithFewerDimensions,
+      step.Extend(this->kFinalTime, this->kFinalStateWithFewerElementIndexs,
                   this->kFinalStateDerivative), std::runtime_error,
-      this->kDimensionMismatchErrorMessage);
+      this->kElementIndexMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      step.Extend(this->kFinalTime, this->kFinalStateWithMoreDimensions,
+      step.Extend(this->kFinalTime, this->kFinalStateWithMoreElementIndexs,
                   this->kFinalStateDerivative), std::runtime_error,
-      this->kDimensionMismatchErrorMessage);
+      this->kElementIndexMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalStateNotAVector,
@@ -230,13 +230,13 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,
-                  this->kFinalStateDerivativeWithFewerDimensions),
-      std::runtime_error, this->kDimensionMismatchErrorMessage);
+                  this->kFinalStateDerivativeWithFewerElementIndexs),
+      std::runtime_error, this->kElementIndexMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,
-                  this->kFinalStateDerivativeWithMoreDimensions),
-      std::runtime_error, this->kDimensionMismatchErrorMessage);
+                  this->kFinalStateDerivativeWithMoreElementIndexs),
+      std::runtime_error, this->kElementIndexMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,

--- a/systems/analysis/test/hermitian_dense_output_test.cc
+++ b/systems/analysis/test/hermitian_dense_output_test.cc
@@ -214,14 +214,14 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
       std::runtime_error, this->kStepBackwardsErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      step.Extend(this->kFinalTime, this->kFinalStateWithFewerElementIndexs,
+      step.Extend(this->kFinalTime, this->kFinalStateWithFewerDimensions,
                   this->kFinalStateDerivative), std::runtime_error,
-      this->kElementIndexMismatchErrorMessage);
+      this->kDimensionMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
-      step.Extend(this->kFinalTime, this->kFinalStateWithMoreElementIndexs,
+      step.Extend(this->kFinalTime, this->kFinalStateWithMoreDimensions,
                   this->kFinalStateDerivative), std::runtime_error,
-      this->kElementIndexMismatchErrorMessage);
+      this->kDimensionMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalStateNotAVector,
@@ -230,13 +230,13 @@ TYPED_TEST(HermitianDenseOutputTest, StepsConsistency) {
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,
-                  this->kFinalStateDerivativeWithFewerElementIndexs),
-      std::runtime_error, this->kElementIndexMismatchErrorMessage);
+                  this->kFinalStateDerivativeWithFewerDimensions),
+      std::runtime_error, this->kDimensionMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,
-                  this->kFinalStateDerivativeWithMoreElementIndexs),
-      std::runtime_error, this->kElementIndexMismatchErrorMessage);
+                  this->kFinalStateDerivativeWithMoreDimensions),
+      std::runtime_error, this->kDimensionMismatchErrorMessage);
 
   DRAKE_EXPECT_THROWS_MESSAGE(
       step.Extend(this->kFinalTime, this->kFinalState,

--- a/systems/analysis/test/initial_value_problem_test.cc
+++ b/systems/analysis/test/initial_value_problem_test.cc
@@ -1,8 +1,11 @@
 #include "drake/systems/analysis/initial_value_problem.h"
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/systems/analysis/initial_value_problem-inl.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -10,10 +13,11 @@
 
 namespace drake {
 namespace systems {
+namespace analysis {
 namespace {
 
 // Checks IVP solver usage with multiple integrators.
-GTEST_TEST(InitialValueProblemTest, UsingMultipleIntegrators) {
+GTEST_TEST(InitialValueProblemTest, SolutionUsingMultipleIntegrators) {
   // Accuracy upper bound, as not all the integrators used below support
   // error control.
   const double kAccuracy = 1e-2;
@@ -70,7 +74,7 @@ GTEST_TEST(InitialValueProblemTest, UsingMultipleIntegrators) {
 }
 
 // Validates preconditions when constructing any given IVP.
-GTEST_TEST(InitialValueProblemTest, ConstructorPreconditionValidation) {
+GTEST_TEST(InitialValueProblemTest, ConstructionPreconditionsValidation) {
   // Defines a generic ODE d𝐱/dt = -𝐱 + 𝐤, that does not
   // model (nor attempts to model) any physical process.
   const InitialValueProblem<double>::ODEFunction dummy_ode_function =
@@ -116,7 +120,7 @@ GTEST_TEST(InitialValueProblemTest, ConstructorPreconditionValidation) {
 }
 
 // Validates preconditions when solving any given IVP.
-GTEST_TEST(InitialValueProblemTest, SolvePreconditionValidation) {
+GTEST_TEST(InitialValueProblemTest, ComputationPreconditionsValidation) {
   // The initial time t₀, for IVP definition.
   const double kDefaultInitialTime = 0.0;
   // The initial state 𝐱₀, for IVP definition.
@@ -158,17 +162,19 @@ GTEST_TEST(InitialValueProblemTest, SolvePreconditionValidation) {
   const VectorX<double> kValidState = VectorX<double>::Constant(2, 1.0);
 
   EXPECT_THROW(ivp.Solve(kInvalidTime), std::logic_error);
-
+  EXPECT_THROW(ivp.DenseSolve(kInvalidTime), std::logic_error);
   {
     InitialValueProblem<double>::SpecifiedValues values;
     values.k = kInvalidParameters;
     EXPECT_THROW(ivp.Solve(kValidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kValidTime, values), std::logic_error);
   }
 
   {
     InitialValueProblem<double>::SpecifiedValues values;
     values.k = kValidParameters;
     EXPECT_THROW(ivp.Solve(kInvalidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kInvalidTime, values), std::logic_error);
   }
 
   {
@@ -176,6 +182,7 @@ GTEST_TEST(InitialValueProblemTest, SolvePreconditionValidation) {
     values.x0 = kInvalidState;
     values.k = kValidParameters;
     EXPECT_THROW(ivp.Solve(kValidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kValidTime, values), std::logic_error);
   }
 
   {
@@ -183,6 +190,7 @@ GTEST_TEST(InitialValueProblemTest, SolvePreconditionValidation) {
     values.x0 = kValidState;
     values.k = kInvalidParameters;
     EXPECT_THROW(ivp.Solve(kValidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kValidTime, values), std::logic_error);
   }
 
   {
@@ -190,6 +198,7 @@ GTEST_TEST(InitialValueProblemTest, SolvePreconditionValidation) {
     values.x0 = kValidState;
     values.k = kValidParameters;
     EXPECT_THROW(ivp.Solve(kInvalidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kInvalidTime, values), std::logic_error);
   }
 }
 
@@ -203,7 +212,7 @@ class InitialValueProblemAccuracyTest
 
   // Expected accuracy for numerical integral
   // evaluation in the relative tolerance sense.
-  double integration_accuracy_;
+  double integration_accuracy_{0.};
 };
 
 // Accuracy test of the solution for the momentum 𝐩 of a particle
@@ -212,8 +221,9 @@ class InitialValueProblemAccuracyTest
 TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
   // The initial time t₀.
   const double kInitialTime = 0.0;
-  // The initial velocity 𝐯₀ of the particle at time t₀.
-  const VectorX<double> kInitialParticleMomentum = VectorX<double>::Zero(3);
+  // The initial momentum 𝐩₀ of the particle at time t₀.
+  const VectorX<double> kInitialParticleMomentum = (
+      VectorX<double>(3) << -3.0, 1.0, 2.0).finished();
   // The mass m of the particle and the dynamic viscosity μ
   // of the gas.
   const double kDefaultGasViscosity = 0.1;
@@ -250,6 +260,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
   const double kTimeStep = 0.1;
 
   const double t0 = kInitialTime;
+  const double tf = kTotalTime;
   const VectorX<double>& p0 = kInitialParticleMomentum;
   for (double mu = kLowestGasViscosity; mu <= kHighestGasViscosity;
        mu += kGasViscosityStep) {
@@ -257,21 +268,31 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
          m += kParticleMassStep) {
       InitialValueProblem<double>::SpecifiedValues values;
       values.k = (VectorX<double>(2) << mu, m).finished();
+
+      const std::unique_ptr<DenseOutput<double>> particle_momentum_approx =
+          particle_momentum_ivp.DenseSolve(tf, values);
+
       for (double t = kInitialTime; t <= kTotalTime; t += kTimeStep) {
         // Tests are performed against the closed form
         // solution for the IVP described above, which is
         // 𝐩(t; [μ, m]) = 𝐩₀ * e^(-μ * (t - t₀) / m).
-        const VectorX<double> exact_solution =
-            p0 * std::exp(-mu * (t - t0) / m);
-        const VectorX<double> approximate_solution =
-            particle_momentum_ivp.Solve(t, values);
-        EXPECT_TRUE(CompareMatrices(
-            approximate_solution, exact_solution, integration_accuracy_))
+        const VectorX<double> solution = p0 * std::exp(-mu * (t - t0) / m);
+
+        EXPECT_TRUE(CompareMatrices(particle_momentum_ivp.Solve(t, values),
+                                    solution, integration_accuracy_))
             << "Failure solving d𝐩/dt = -μ * 𝐩/m"
             << " using 𝐩(" << t0 << "; [μ, m]) = " << p0
             << " for t = " << t << ", μ = " << mu
             << " and m = " << m << " to an accuracy of "
             << integration_accuracy_;
+
+        EXPECT_TRUE(CompareMatrices(particle_momentum_approx->Evaluate(t),
+                                    solution, integration_accuracy_))
+            << "Failure approximating the solution for d𝐩/dt = -μ * 𝐩/m"
+            << " using 𝐩(" << t0 << "; [μ, m]) = " << p0
+            << " for t = " << t << ", μ = " << mu
+            << " and m = " << m << " to an accuracy of "
+            << integration_accuracy_ << " with solver's continuous extension.";
       }
     }
   }
@@ -279,7 +300,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasMomentum) {
 
 // Accuracy test of the solution for the velocity 𝐯 of a particle
 // with mass m travelling through a gas with dynamic viscosity μ
-// and being pushed by constant force 𝐅, where
+// and being pushed by a constant force 𝐅, where
 // d𝐯/dt = (𝐅 - μ * 𝐯) / m and 𝐯(t₀; [m, μ]) = 𝐯₀.
 TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
   // The initial time t₀.
@@ -301,7 +322,7 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
   // Instantiates the particle velocity IVP.
   InitialValueProblem<double> particle_velocity_ivp(
       [&kPushingForce](const double& t, const VectorX<double>& v,
-         const VectorX<double>& k) -> VectorX<double> {
+                       const VectorX<double>& k) -> VectorX<double> {
         const double mu = k[0];
         const double m = k[1];
         const VectorX<double>& F = kPushingForce;
@@ -324,31 +345,45 @@ TEST_P(InitialValueProblemAccuracyTest, ParticleInAGasForcedVelocity) {
   const double kTimeStep = 0.1;
 
   const double t0 = kInitialTime;
+  const double tf = kTotalTime;
+
   const VectorX<double>& F = kPushingForce;
   const VectorX<double>& v0 = kInitialParticleVelocity;
+
   for (double mu = kLowestGasViscosity; mu <= kHighestGasViscosity;
        mu += kGasViscosityStep) {
     for (double m = kLowestParticleMass; m <= kHighestParticleMass;
          m += kParticleMassStep) {
       InitialValueProblem<double>::SpecifiedValues values;
       values.k = (VectorX<double>(2) << mu, m).finished();
+
+      const std::unique_ptr<DenseOutput<double>> particle_velocity_approx =
+          particle_velocity_ivp.DenseSolve(tf, values);
+
       for (double t = kInitialTime; t <= kTotalTime; t += kTimeStep) {
         // Tests are performed against the closed form
         // solution for the IVP described above, which is
         // 𝐯(t; [μ, m]) = 𝐯₀ * e^(-μ * (t - t₀) / m) +
-        //                𝐅 / μ * (1 - e^(-μ * (t - t₀) / m)).
-        const VectorX<double> exact_solution =
+        //                𝐅 / μ * (1 - e^(-μ * (t - t₀) / m))
+        // with 𝐅 = (0., 1., 0.).
+        const VectorX<double> solution =
             v0 * std::exp(-mu * (t - t0) / m) +
             F / mu * (1. - std::exp(-mu * (t - t0) / m));
-        const VectorX<double> approximate_solution =
-            particle_velocity_ivp.Solve(t, values);
-        EXPECT_TRUE(CompareMatrices(
-            approximate_solution, exact_solution, integration_accuracy_))
+        EXPECT_TRUE(CompareMatrices(particle_velocity_ivp.Solve(t, values),
+                                    solution, integration_accuracy_))
             << "Failure solving d𝐯/dt = (-μ * 𝐯 + 𝐅) / m"
             << " using 𝐯(" << t0 << "; [μ, m]) = " << v0
             << " for t = " << t << ", μ = " << mu
             << ", m = " << m << "and 𝐅 = " << F
             << " to an accuracy of " << integration_accuracy_;
+
+        EXPECT_TRUE(CompareMatrices(particle_velocity_approx->Evaluate(t),
+                                    solution, integration_accuracy_))
+            << "Failure approximating the solution for d𝐯/dt = (-μ * 𝐯 + 𝐅) / m"
+            << " using 𝐯(" << t0 << "; [μ, m]) = " << v0 << " for t = " << t
+            << ", μ = " << mu << ", m = " << m << "and 𝐅 = " << F
+            << " to an accuracy of " << integration_accuracy_
+            << " with solver's continuous extension.";
       }
     }
   }
@@ -359,5 +394,6 @@ INSTANTIATE_TEST_CASE_P(IncreasingAccuracyInitialValueProblemTests,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4, 1e-5));
 
 }  // namespace
+}  // namespace analysis
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/runge_kutta3_integrator_test.cc
+++ b/systems/analysis/test/runge_kutta3_integrator_test.cc
@@ -153,7 +153,7 @@ TEST_F(RK3IntegratorTest, DenseOutputAccuracy) {
   rk3.IntegrateWithMultipleSteps(t_step);
 
   // Verify that the dense output was not updated.
-  EXPECT_LT(rk3_dense_output->get_end_time(), context->get_time());
+  EXPECT_LT(rk3_dense_output->end_time(), context->get_time());
 }
 
 }  // namespace analysis_test

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -273,7 +273,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
             << Rs << " and Cs = " << Cs << " to an accuracy of "
             << integration_accuracy_;
 
-        EXPECT_NEAR(stored_charge_approx->Evaluate(t),
+        EXPECT_NEAR(stored_charge_approx->EvaluateScalar(t),
                     solution, integration_accuracy_)
             << "Failure approximating the solution for"
             << " dQ/dt = (sin(t) - Q / Cs) / Rs using Q(t₀ = "
@@ -344,7 +344,7 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
           << " and r = " << r << " to an accuracy of "
           << integration_accuracy_;
 
-      EXPECT_NEAR(population_growth_approx->Evaluate(t),
+      EXPECT_NEAR(population_growth_approx->EvaluateScalar(t),
                   solution, integration_accuracy_)
           << "Failure approximating the solution for dN/dt = r * N"
           << " using N(t₀ = " << t0 << "; r) = " << N0 << " for t = "

--- a/systems/analysis/test/scalar_initial_value_problem_test.cc
+++ b/systems/analysis/test/scalar_initial_value_problem_test.cc
@@ -5,9 +5,11 @@
 #include "drake/common/unused.h"
 #include "drake/systems/analysis/integrator_base.h"
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
+#include "drake/systems/analysis/scalar_initial_value_problem-inl.h"
 
 namespace drake {
 namespace systems {
+namespace analysis {
 namespace {
 
 // Checks scalar IVP solver usage with multiple integrators.
@@ -68,7 +70,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, UsingMultipleIntegrators) {
 }
 
 // Validates preconditions when constructing any given scalar IVP.
-GTEST_TEST(ScalarInitialValueProblemTest, ConstructorPreconditionValidation) {
+GTEST_TEST(ScalarInitialValueProblemTest, ConstructionPreconditionsValidation) {
   // Defines a generic ODE dx/dt = -x * t, that does not
   // model (nor attempts to model) any physical process.
   const ScalarInitialValueProblem<double>::
@@ -115,7 +117,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, ConstructorPreconditionValidation) {
 }
 
 // Validates preconditions when solving any given IVP.
-GTEST_TEST(ScalarInitialValueProblemTest, SolvePreconditionValidation) {
+GTEST_TEST(ScalarInitialValueProblemTest, ComputationPreconditionsValidation) {
   // The initial time t₀, for IVP definition.
   const double kDefaultInitialTime = 0.0;
   // The initial state x₀, for IVP definition.
@@ -136,6 +138,7 @@ GTEST_TEST(ScalarInitialValueProblemTest, SolvePreconditionValidation) {
         return -x + k[0];
       }, kDefaultValues);
 
+
   // Instantiates an invalid time for testing, i.e. a time to
   // solve for that's in the past with respect to the IVP initial
   // time.
@@ -152,17 +155,19 @@ GTEST_TEST(ScalarInitialValueProblemTest, SolvePreconditionValidation) {
   const VectorX<double> kValidParameters = VectorX<double>::Constant(2, 5.0);
 
   EXPECT_THROW(ivp.Solve(kInvalidTime), std::logic_error);
-
+  EXPECT_THROW(ivp.DenseSolve(kInvalidTime), std::logic_error);
   {
     ScalarInitialValueProblem<double>::SpecifiedValues values;
     values.k = kInvalidParameters;
     EXPECT_THROW(ivp.Solve(kValidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kValidTime, values), std::logic_error);
   }
 
   {
     ScalarInitialValueProblem<double>::SpecifiedValues values;
     values.k = kValidParameters;
     EXPECT_THROW(ivp.Solve(kInvalidTime, values), std::logic_error);
+    EXPECT_THROW(ivp.DenseSolve(kInvalidTime, values), std::logic_error);
   }
 }
 
@@ -222,12 +227,18 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
   const double kTotalTime = 1.0;
   const double kTimeStep = 0.1;
 
+  const double Q0 = kInitialStoredCharge;
+  const double t0 = kInitialTime;
+  const double tf = kTotalTime;
   for (double Rs = kLowestResistance; Rs <= kHighestResistance ;
        Rs += kResistanceStep) {
     for (double Cs = kLowestCapacitance; Cs <= kHighestCapacitance ;
          Cs += kCapacitanceStep) {
       ScalarInitialValueProblem<double>::SpecifiedValues values;
       values.k = (VectorX<double>(2) << Rs, Cs).finished();
+
+      const std::unique_ptr<ScalarDenseOutput<double>> stored_charge_approx =
+          stored_charge_ivp.DenseSolve(tf, values);
 
       const double tau = Rs * Cs;
       const double tau_sq = tau * tau;
@@ -237,17 +248,25 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, StoredCharge) {
         // Q(t; [Rs, Cs]) = 1/Rs * (τ²/ (1 + τ²) * e^(-t / τ) +
         //                  τ / √(1 + τ²) * sin(t - arctan(τ)))
         // where τ = Rs * Cs for Q(t₀ = 0; [Rs, Cs]) = Q₀ = 0.
-        const double exact_solution = (
+        const double solution = (
             tau_sq / (1. + tau_sq) * std::exp(-t / tau)
             + tau / std::sqrt(1. + tau_sq)
             * std::sin(t - std::atan(tau))) / Rs;
         EXPECT_NEAR(stored_charge_ivp.Solve(t, values),
-                    exact_solution, integration_accuracy_)
+                    solution, integration_accuracy_)
             << "Failure solving dQ/dt = (sin(t) - Q / Cs) / Rs using Q(t₀ = "
-            << kInitialTime << "; [Rs, Cs]) = " << kInitialStoredCharge
-            << " for t = " << t << ", Rs = " << Rs
-            << " and Cs = " << Cs << " with an accuracy of "
+            << t0 << "; [Rs, Cs]) = " << Q0 << " for t = " << t << ", Rs = "
+            << Rs << " and Cs = " << Cs << " to an accuracy of "
             << integration_accuracy_;
+
+        EXPECT_NEAR(stored_charge_approx->Evaluate(t),
+                    solution, integration_accuracy_)
+            << "Failure approximating the solution for"
+            << " dQ/dt = (sin(t) - Q / Cs) / Rs using Q(t₀ = "
+            << t0 << "; [Rs, Cs]) = " << Q0 << " for t = " << t
+            << ", Rs = " << Rs << " and Cs = " << Cs
+            << " to an accuracy of " << integration_accuracy_
+            << " with solver's continuous extension.";
       }
     }
   }
@@ -288,21 +307,35 @@ TEST_P(ScalarInitialValueProblemAccuracyTest, PopulationGrowth) {
   const double kTotalTime = 1.0;
   const double kTimeStep = 0.1;
 
+  const double N0 = kInitialPopulation;
+  const double t0 = kInitialTime;
+  const double tf = kTotalTime;
   for (double r = kLowestMalthusParam; r <= kHighestMalthusParam;
        r += kMalthusParamStep) {
     ScalarInitialValueProblem<double>::SpecifiedValues values;
     values.k = VectorX<double>::Constant(1, r).eval();
+
+    const std::unique_ptr<ScalarDenseOutput<double>> population_growth_approx =
+        population_growth_ivp.DenseSolve(tf, values);
+
     for (double t = kInitialTime; t <= kTotalTime; t += kTimeStep) {
       // Tests are performed against the closed form
       // solution for the IVP described above, which is
       // N(t; r) = N₀ * e^(r * t).
-      const double exact_solution = kInitialPopulation * std::exp(r * t);
-      EXPECT_NEAR(population_growth_ivp.Solve(t, values), exact_solution,
-                  integration_accuracy_)
+      const double solution = N0 * std::exp(r * t);
+      EXPECT_NEAR(population_growth_ivp.Solve(t, values),
+                  solution, integration_accuracy_)
           << "Failure solving dN/dt = r * N using N(t₀ = "
-          << kInitialTime << "; r) = " << kInitialPopulation
-          << " for t = " << t << " and r = " << r
-          << " to an accuracy of " << integration_accuracy_;
+          << t0 << "; r) = " << N0 << " for t = " << t
+          << " and r = " << r << " to an accuracy of "
+          << integration_accuracy_;
+
+      EXPECT_NEAR(population_growth_approx->Evaluate(t),
+                  solution, integration_accuracy_)
+          << "Failure approximating the solution for dN/dt = r * N"
+          << " using N(t₀ = " << t0 << "; r) = " << N0 << " for t = "
+          << t << " and r = " << r << " to an accuracy of "
+          << integration_accuracy_ << " with solver's continuous extension.";
     }
   }
 }
@@ -312,5 +345,6 @@ INSTANTIATE_TEST_CASE_P(IncreasingAccuracyScalarInitialValueProblemTests,
                         ::testing::Values(1e-1, 1e-2, 1e-3, 1e-4, 1e-5));
 
 }  // namespace
+}  // namespace analysis
 }  // namespace systems
 }  // namespace drake

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -54,7 +54,7 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       ScalarViewDenseOutput<TypeParam> dense_output(
           this->CreateDummyDenseOutput(), this->kInvalidDimension),
-      std::logic_error, "[Dd]imension out of range.*");
+      std::runtime_error, ".*[Dd]imension.*out of.*dense output.*range.*");
 
   // Instantiates scalar continuous extension properly.
   ScalarViewDenseOutput<TypeParam> dense_output(
@@ -76,7 +76,8 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   // Checks evaluation preconditions.
   DRAKE_EXPECT_THROWS_MESSAGE(
       dense_output.Evaluate(this->kInvalidTime),
-      std::runtime_error, ".*not defined for.*time.*");
+      std::runtime_error,
+      ".*[Tt]ime.*out of.*dense output.*domain.*");
 
   // Compares evaluations for consistency.
   EXPECT_EQ(

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -71,10 +71,10 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   // Checks basic getters for consistency.
   EXPECT_EQ(dense_output.is_empty(),
             base_output->is_empty());
-  EXPECT_EQ(dense_output.get_start_time(),
-            base_output->get_start_time());
-  EXPECT_EQ(dense_output.get_end_time(),
-            base_output->get_end_time());
+  EXPECT_EQ(dense_output.start_time(),
+            base_output->start_time());
+  EXPECT_EQ(dense_output.end_time(),
+            base_output->end_time());
 
   // Compares evaluations for consistency.
   EXPECT_THROW(

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -71,6 +71,7 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
             base_output->start_time());
   EXPECT_EQ(dense_output.end_time(),
             base_output->end_time());
+  EXPECT_EQ(dense_output.size(), 1);
 
   // Checks evaluation preconditions.
   DRAKE_EXPECT_THROWS_MESSAGE(
@@ -79,13 +80,13 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
 
   // Compares evaluations for consistency.
   EXPECT_EQ(
-      dense_output.Evaluate(this->kInitialTime),
+      dense_output.EvaluateScalar(this->kInitialTime),
       base_output->Evaluate(this->kInitialTime, this->kValidDimension));
   EXPECT_EQ(
-      dense_output.Evaluate(this->kMidTime),
+      dense_output.EvaluateScalar(this->kMidTime),
       base_output->Evaluate(this->kMidTime, this->kValidDimension));
   EXPECT_EQ(
-      dense_output.Evaluate(this->kFinalTime),
+      dense_output.EvaluateScalar(this->kFinalTime),
       base_output->Evaluate(this->kFinalTime, this->kValidDimension));
 }
 

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -1,0 +1,96 @@
+#include "drake/systems/analysis/scalar_view_dense_output.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/eigen_types.h"
+#include "drake/systems/analysis/hermitian_dense_output.h"
+
+namespace drake {
+namespace systems {
+namespace analysis {
+namespace {
+
+template <typename T>
+class ScalarViewDenseOutputTest : public ::testing::Test {
+ protected:
+  std::unique_ptr<DenseOutput<T>> CreateDummyDenseOutput() {
+    auto dense_output =
+        std::make_unique<HermitianDenseOutput<T>>();
+    typename HermitianDenseOutput<T>::IntegrationStep step(
+        this->kInitialTime, this->kInitialState, this->kInitialStateDerivative);
+    step.Extend(this->kFinalTime, this->kFinalState,
+                this->kFinalStateDerivative);
+    dense_output->Update(std::move(step));
+    dense_output->Consolidate();
+    return std::move(dense_output);
+  }
+
+  const double kInvalidTime{-1.0};
+  const double kInitialTime{0.0};
+  const double kMidTime{0.5};
+  const double kFinalTime{1.0};
+  const MatrixX<double> kInitialState{
+    (MatrixX<double>(3, 1) << 0., 0., 0.).finished()};
+  const MatrixX<T> kFinalState{
+    (MatrixX<double>(3, 1) << 1., 10., 100.).finished()};
+  const MatrixX<double> kInitialStateDerivative{
+    (MatrixX<double>(3, 1) << 0., 1., 0.).finished()};
+  const MatrixX<double> kFinalStateDerivative{
+    (MatrixX<double>(3, 1) << 1., 0., 1.).finished()};
+  const int kValidDimension{0};
+  const int kInvalidDimension{10};
+};
+
+typedef ::testing::Types<double, AutoDiffXd> ExtensionTypes;
+
+TYPED_TEST_CASE(ScalarViewDenseOutputTest, ExtensionTypes);
+
+// Checks that ScalarViewDenseOutput properly wraps a
+// DenseOutput instance.
+TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
+  // Verifies that views to invalid dimensions result in an error.
+  EXPECT_THROW(
+      ScalarViewDenseOutput<TypeParam> dense_output(
+          this->CreateDummyDenseOutput(), this->kInvalidDimension),
+      std::logic_error);
+
+  EXPECT_THROW(
+      ScalarViewDenseOutput<TypeParam> dense_output(
+          this->CreateDummyDenseOutput(), -this->kInvalidDimension),
+      std::logic_error);
+
+  // Instantiates scalar continuous extension properly.
+  ScalarViewDenseOutput<TypeParam> dense_output(
+      this->CreateDummyDenseOutput(), this->kValidDimension);
+
+  // Retrieves dummy base continuous extension.
+  const DenseOutput<TypeParam>* base_output =
+      dense_output.get_base_output();
+
+  // Checks basic getters for consistency.
+  EXPECT_EQ(dense_output.is_empty(),
+            base_output->is_empty());
+  EXPECT_EQ(dense_output.get_start_time(),
+            base_output->get_start_time());
+  EXPECT_EQ(dense_output.get_end_time(),
+            base_output->get_end_time());
+
+  // Compares evaluations for consistency.
+  EXPECT_THROW(
+      dense_output.Evaluate(this->kInvalidTime), std::runtime_error);
+  EXPECT_EQ(
+      dense_output.Evaluate(this->kInitialTime),
+      base_output->Evaluate(this->kInitialTime, this->kValidDimension));
+  EXPECT_EQ(
+      dense_output.Evaluate(this->kMidTime),
+      base_output->Evaluate(this->kMidTime, this->kValidDimension));
+  EXPECT_EQ(
+      dense_output.Evaluate(this->kFinalTime),
+      base_output->Evaluate(this->kFinalTime, this->kValidDimension));
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace systems
+}  // namespace drake

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -81,13 +81,13 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   // Compares evaluations for consistency.
   EXPECT_EQ(
       dense_output.EvaluateScalar(this->kInitialTime),
-      base_output->Evaluate(this->kInitialTime, this->kValidDimension));
+      base_output->EvaluateNth(this->kInitialTime, this->kValidDimension));
   EXPECT_EQ(
       dense_output.EvaluateScalar(this->kMidTime),
-      base_output->Evaluate(this->kMidTime, this->kValidDimension));
+      base_output->EvaluateNth(this->kMidTime, this->kValidDimension));
   EXPECT_EQ(
       dense_output.EvaluateScalar(this->kFinalTime),
-      base_output->Evaluate(this->kFinalTime, this->kValidDimension));
+      base_output->EvaluateNth(this->kFinalTime, this->kValidDimension));
 }
 
 }  // namespace

--- a/systems/analysis/test/scalar_view_dense_output_test.cc
+++ b/systems/analysis/test/scalar_view_dense_output_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/systems/analysis/hermitian_dense_output.h"
 
 namespace drake {
@@ -50,15 +51,10 @@ TYPED_TEST_CASE(ScalarViewDenseOutputTest, ExtensionTypes);
 // DenseOutput instance.
 TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   // Verifies that views to invalid dimensions result in an error.
-  EXPECT_THROW(
+  DRAKE_EXPECT_THROWS_MESSAGE(
       ScalarViewDenseOutput<TypeParam> dense_output(
           this->CreateDummyDenseOutput(), this->kInvalidDimension),
-      std::logic_error);
-
-  EXPECT_THROW(
-      ScalarViewDenseOutput<TypeParam> dense_output(
-          this->CreateDummyDenseOutput(), -this->kInvalidDimension),
-      std::logic_error);
+      std::logic_error, "[Dd]imension out of range.*");
 
   // Instantiates scalar continuous extension properly.
   ScalarViewDenseOutput<TypeParam> dense_output(
@@ -76,9 +72,12 @@ TYPED_TEST(ScalarViewDenseOutputTest, ExtensionConsistency) {
   EXPECT_EQ(dense_output.end_time(),
             base_output->end_time());
 
+  // Checks evaluation preconditions.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      dense_output.Evaluate(this->kInvalidTime),
+      std::runtime_error, ".*not defined for.*time.*");
+
   // Compares evaluations for consistency.
-  EXPECT_THROW(
-      dense_output.Evaluate(this->kInvalidTime), std::runtime_error);
   EXPECT_EQ(
       dense_output.Evaluate(this->kInitialTime),
       base_output->Evaluate(this->kInitialTime, this->kValidDimension));


### PR DESCRIPTION
This pull request is the fourth and last of a series of pull requests that ultimately introduce dense outputs to Drake i.e. dense approximations to numerical integration solutions. 

Specifically, this PR exposes dense output computation in the `InitialValueProblem`, `ScalarInitialValueProblem` and `AntiderivativeFunction` classes' API. To that end, the `ScalarDenseOutput` class (yet another interface) is introduced to keep scalar APIs, well, scalar, and a `ScalarViewDenseOutput` class that implements said interface to wrap the `IntegratorBase` vector dense output that gets internally built.

This PR builds on top of #8951 and as such it should be reviewed/merged afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8952)
<!-- Reviewable:end -->
