### PR TITLE
Get rid of get_ from get_mutable_renderer()

### DIFF
--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -194,7 +194,7 @@ class RgbdCamera final : public LeafSystem<double> {
   }
 
   /// Reterns mutable renderer.
-  RgbdRenderer& get_mutable_renderer() { return *renderer_; }
+  RgbdRenderer& mutable_renderer() { return *renderer_; }
 
   /// Reterns the color sensor's info.
   const CameraInfo& color_camera_info() const { return color_camera_info_; }

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -313,7 +313,7 @@ TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
     Init("nothing.sdf", X_WB, size);
     Verify();
 
-    auto renderer1 = &diagram_->camera().get_mutable_renderer();
+    auto renderer1 = &diagram_->camera().mutable_renderer();
 
     auto const rgb1 =
         output_->GetMutableData(0)->GetMutableValue<ImageRgba8U>();
@@ -321,10 +321,9 @@ TEST_F(RgbdCameraDiagramTest, ResetRendererTest) {
     diagram_->camera().ResetRenderer(
         std::unique_ptr<RgbdRenderer>(new RgbdRendererVTK(
             RenderingConfig{size.width, size.height, kFovY,
-                            kDepthRangeNear, kDepthRangeFar, kShowWindow},
-            Eigen::Isometry3d::Identity())));
+                            kDepthRangeNear, kDepthRangeFar, kShowWindow})));
 
-    auto renderer2 = &diagram_->camera().get_mutable_renderer();
+    auto renderer2 = &diagram_->camera().mutable_renderer();
     EXPECT_NE(renderer1, renderer2);
 
     CalcOutput();


### PR DESCRIPTION
Just to be consistent with other getters in the same class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8953)
<!-- Reviewable:end -->
