### PR TITLE
Add API for users to create "collision filter group"-like filtering via MBP

### DIFF
--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -27,6 +27,8 @@ using systems::Value;
 using std::make_unique;
 using std::vector;
 
+// TODO(SeanCurtis-TRI): Fix this so that it's invocation ends with ();.
+// https://github.com/RobotLocomotion/drake/issues/8959
 #define GS_THROW_IF_CONTEXT_ALLOCATED ThrowIfContextAllocated(__FUNCTION__);
 
 namespace {

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -973,6 +973,12 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // bodies connected by a joint.
   void FilterAdjacentBodies(geometry::SceneGraph<T>* scene_graph);
 
+  // This is a *temporary* method to eliminate visual geometries from collision
+  // while we wait for geometry roles to be introduced.
+  // TODO(SeanCurtis-TRI): Remove this when geometry roles are introduced.
+  void ExcludeCollisionsWithVisualGeometry(
+      geometry::SceneGraph<T>* scene_graph);
+
   // No inputs implies no feedthrough; this makes it explicit.
   // TODO(amcastro-tri): add input ports for actuators.
   optional<bool> DoHasDirectFeedthrough(int, int) const override {

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -9,6 +9,7 @@
 
 #include "drake/common/drake_optional.h"
 #include "drake/common/nice_type_name.h"
+#include "drake/geometry/geometry_set.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/multibody_tree/force_element.h"
 #include "drake/multibody/multibody_tree/multibody_plant/coulomb_friction.h"
@@ -613,6 +614,33 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     return geometry_id_to_collision_index_.size();
   }
 
+  /// For each of the provided `bodies`, collects up all geometries that have
+  /// been registered to that body. Intended to be used in conjunction with
+  /// SceneGraph::ExcludeCollisionsWithin() and
+  /// SceneGraph::ExcludeCollisionsBetween() to filter collisions between the
+  /// geometries registered to the bodies.
+  ///
+  /// For example:
+  /// ```
+  /// // Don't report on collisions between geometries affixed to `body1`,
+  /// // `body2`, or `body3`.
+  /// std::vector<const RigidBody<T>*> bodies{&body1, &body2, &body3};
+  /// geometry::GeometrySet set = plant.CollectRegisteredGeometries(bodies);
+  /// scene_graph.ExcludeCollisionsWithin(set);
+  /// ```
+  ///
+  /// Note: There is a *very* specific order of operations.
+  ///   1. Bodies and geometries must be added to the %MultibodyPlant.
+  ///   2. The %MultibodyPlant must be finalized (via Finalize()).
+  ///   3. Create GeometrySet instances from bodies (via this method).
+  ///   4. Invoke SceneGraph::ExcludeCollisions*() to filter collisions.
+  ///   5. Allocate context.
+  /// Changing the order will cause exceptions to be thrown.
+  ///
+  /// @throws std::exception if called pre-finalize.
+  geometry::GeometrySet CollectRegisteredGeometries(
+      const std::vector<const RigidBody<T>*>& bodies) const;
+
   /// Returns the friction coefficients provided during geometry registration
   /// for the given geometry `id`. We call these the "default" coefficients but
   /// note that we mean user-supplied per-geometry default, not something more
@@ -1014,6 +1042,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // 2. RegisterAsSourceForSceneGraph() was called on `this` plant.
   // 3. `scene_graph` points to the same SceneGraph instance previously
   //    passed to RegisterAsSourceForSceneGraph().
+  // 4. The body is *not* the world body.
   geometry::GeometryId RegisterGeometry(const Body<T>& body,
                                         const Isometry3<double>& X_BG,
                                         const geometry::Shape& shape,

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -580,6 +580,10 @@ class SphereChainScenario {
       GeometryId sphere_id = plant_->RegisterCollisionGeometry(
           sphere, Isometry3d::Identity(), geometry::Sphere(radius),
           CoulombFriction<double>(), scene_graph_);
+      // We add visual geometry to implicitly test that they are *not* included
+      // in the collision results. We don't even save the ids for them.
+      plant_->RegisterVisualGeometry(sphere, Isometry3d::Identity(),
+                                     geometry::Sphere(radius), scene_graph_);
       return std::make_tuple(&sphere, sphere_id);
     };
 
@@ -622,6 +626,7 @@ class SphereChainScenario {
     plant_context_ =
         &diagram_->GetMutableSubsystemContext(*plant_, context_.get());
 
+    // NOTE: Only ids for collision geometries are included.
     for (int i = 0; i < sphere_count; ++i) {
       unfiltered_collisions_.insert(std::make_pair(ground_id(), sphere_id(i)));
       for (int j = i + 2; j < sphere_count; ++j) {
@@ -689,6 +694,10 @@ class SphereChainScenario {
 // contact is reported between S1 & S2, or S2 & S3. But there *should* be a
 // collision between S1 & S3. Therefore, four total collisions will be reported:
 // (G, S1), (G, S2), (G, S3), (S1, S3).
+//
+// NOTE: This *implicitly* tests that visual geometries are *not* included in
+// collision because the `expected_pairs` only accounts for collision
+// geometries.
 GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
   SphereChainScenario scenario(3);
   std::vector<geometry::PenetrationAsPointPair<double>> contacts =

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -13,6 +13,7 @@
 #include "drake/common/find_resource.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
+#include "drake/geometry/geometry_frame.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/math/autodiff_gradient.h"
 #include "drake/math/roll_pitch_yaw.h"
@@ -531,12 +532,155 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodiesSourceErrors) {
             "RegisterAsSourceForSceneGraph\\(\\)");
   }
 
-  // Case: Not registered as source, but passed scenegraph in anyways.
+  // Case: Not registered as source, but passed SceneGraph in anyways.
   {
     MultibodyPlant<double> plant;
     EXPECT_NO_THROW(plant.Finalize(&scene_graph));
   }
 }
+
+// A class for constructing a multibody plant/scenegraph system consisting of
+// a chain of spheres resting on the ground: S1 -> S2 -> S3 -> ... -> SN.
+// In the zero configurations, the spheres are overlapping. However, due to
+// adjacency filtering, no contact is reported between S1 & S2, S2 & S3, or,
+// more, generally, between Si and Si+1. But there *should* be collisions
+// between all other pairs: i.e., (S1, S3), (S1, S4), ..., (S1, SN), ...,
+// (SN-1, SN) and between the ground and all elements: (G, S1), (G, S2), ...,
+// (G, SN).
+//
+// The chain terminates with two additional bodies: one body registers a frame
+// (but has no geometry), the other has no frame at all. It will have no bearing
+// on collision tests but is used for geometry collection testing.
+//
+// Also accepts a filtering function that is applied between geometry
+// registration and context compilation.
+class SphereChainScenario {
+ public:
+  SphereChainScenario(
+      int sphere_count,
+      std::function<void(SphereChainScenario*)> apply_filters = nullptr) {
+    using std::to_string;
+    systems::DiagramBuilder<double> builder;
+    scene_graph_ = builder.AddSystem<SceneGraph<double>>();
+    plant_ = builder.AddSystem<MultibodyPlant<double>>();
+
+    plant_->RegisterAsSourceForSceneGraph(scene_graph_);
+
+    // A half-space for the ground geometry.
+    ground_id_ = plant_->RegisterCollisionGeometry(
+        plant_->world_body(),
+        // A half-space passing through the origin in the x-z plane.
+        geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
+        geometry::HalfSpace(), CoulombFriction<double>(), scene_graph_);
+
+    auto make_sphere = [this](int i) {
+      const double radius = 0.5;
+      const RigidBody<double>& sphere = plant_->AddRigidBody(
+          "Sphere" + to_string(i), SpatialInertia<double>());
+      GeometryId sphere_id = plant_->RegisterCollisionGeometry(
+          sphere, Isometry3d::Identity(), geometry::Sphere(radius),
+          CoulombFriction<double>(), scene_graph_);
+      return std::make_tuple(&sphere, sphere_id);
+    };
+
+    // Add sphere bodies.
+    for (int i = 0; i < sphere_count; ++i) {
+      // TODO(SeanCurtis-TRI): Make this prettier when C++17 is available.
+      // E.g., auto [id, geometry] = make_sphere(i);
+      GeometryId id{};
+      const RigidBody<double>* body{};
+      std::tie(body, id) = make_sphere(i);
+      spheres_.push_back(body);
+      sphere_ids_.push_back(id);
+    }
+    // Add hinges between spheres.
+    for (int i = 0; i < sphere_count - 1; ++i) {
+      plant_->AddJoint<RevoluteJoint>(
+          "hinge" + to_string(i) + "_" + to_string(i + 1), *spheres_[i], {},
+          *spheres_[i + 1], {}, Vector3d::UnitY());
+    }
+
+    // Body with no registered frame.
+    no_geometry_body_ = &plant_->AddRigidBody("NothingRegistered",
+                                              SpatialInertia<double>());
+
+    // We are done defining the model.
+    plant_->Finalize(scene_graph_);
+
+    builder.Connect(
+        plant_->get_geometry_poses_output_port(),
+        scene_graph_->get_source_pose_port(*plant_->get_source_id()));
+    builder.Connect(scene_graph_->get_query_output_port(),
+                    plant_->get_geometry_query_input_port());
+
+    if (apply_filters != nullptr) apply_filters(this);
+
+    diagram_ = builder.Build();
+    context_ = diagram_->CreateDefaultContext();
+
+    // Set the zero configuration.
+    plant_context_ =
+        &diagram_->GetMutableSubsystemContext(*plant_, context_.get());
+
+    for (int i = 0; i < sphere_count; ++i) {
+      unfiltered_collisions_.insert(std::make_pair(ground_id(), sphere_id(i)));
+      for (int j = i + 2; j < sphere_count; ++j) {
+        unfiltered_collisions_.insert(
+            std::make_pair(sphere_id(i), sphere_id(j)));
+      }
+    }
+  }
+
+  // Perform the pair-wise collision detection.
+  std::vector<geometry::PenetrationAsPointPair<double>>
+  ComputePointPairPenetration() const {
+    // Grab query object to test for collisions.
+    const geometry::QueryObject<double>& query_object =
+        plant_
+            ->EvalAbstractInput(
+                *plant_context_,
+                plant_->get_geometry_query_input_port().get_index())
+            ->GetValue<geometry::QueryObject<double>>();
+
+    return query_object.ComputePointPairPenetration();
+  }
+
+  const RigidBody<double>& sphere(int i) const { return *spheres_.at(i); }
+  const RigidBody<double>& no_geometry_body() const {
+    return *no_geometry_body_;
+  }
+  const GeometryId sphere_id(int i) const { return sphere_ids_.at(i); }
+  const GeometryId ground_id() const { return ground_id_; }
+  MultibodyPlant<double>* mutable_plant() { return plant_; }
+  SceneGraph<double>* mutable_scene_graph() { return scene_graph_; }
+
+  // Reports all collisions that *should* be reported when no custom filters
+  // have been applied.
+  const std::set<std::pair<GeometryId, GeometryId>>& unfiltered_collisions()
+      const {
+    return unfiltered_collisions_;
+  }
+
+ private:
+  // The diagram components.
+  std::unique_ptr<Diagram<double>> diagram_{};
+  std::unique_ptr<Context<double>> context_{};
+
+  // Convenient handles into the diagram_ and context_.
+  SceneGraph<double>* scene_graph_{};
+  MultibodyPlant<double>* plant_{};
+  systems::Context<double>* plant_context_{};
+
+  // The bodies -- body Si is at index i.
+  std::vector<const RigidBody<double>*> spheres_;
+  std::vector<GeometryId> sphere_ids_;
+  GeometryId ground_id_{};
+  // The set of expected collision pairs with *no* user-defined collision
+  // filters applied (but automatic filters -- adjacent bodies and geometries
+  // affixed to the same body -- are accounted for).
+  std::set<std::pair<GeometryId, GeometryId>> unfiltered_collisions_;
+  const RigidBody<double>* no_geometry_body_{};
+};
 
 // Tests the automatic filtering of adjacent bodies.
 // Introduces a ground plane with three spheres sitting on the plane.
@@ -546,82 +690,13 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodiesSourceErrors) {
 // collision between S1 & S3. Therefore, four total collisions will be reported:
 // (G, S1), (G, S2), (G, S3), (S1, S3).
 GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
-  systems::DiagramBuilder<double> builder;
-  auto scene_graph = builder.AddSystem<SceneGraph<double>>();
-  auto plant = builder.AddSystem<MultibodyPlant<double>>();
-
-  plant->RegisterAsSourceForSceneGraph(scene_graph);
-
-  // A half-space for the ground geometry.
-  CoulombFriction<double> ground_friction(0.5, 0.3);
-  GeometryId ground_id = plant->RegisterCollisionGeometry(
-      plant->world_body(),
-      // A half-space passing through the origin in the x-z plane.
-      geometry::HalfSpace::MakePose(Vector3d::UnitY(), Vector3d::Zero()),
-      geometry::HalfSpace(), ground_friction, scene_graph);
-
-  auto make_sphere = [&plant, &scene_graph](int i) {
-    const double radius = 0.5;
-    const RigidBody<double>& sphere =
-    plant->AddRigidBody("Sphere" + std::to_string(i), SpatialInertia<double>());
-    CoulombFriction<double> sphere_friction(0.8, 0.5);
-    GeometryId sphere_id = plant->RegisterCollisionGeometry(
-        sphere, Isometry3d::Identity(), geometry::Sphere(radius),
-        sphere_friction, scene_graph);
-    return std::make_tuple(&sphere, sphere_id);
-  };
-
-  // TODO(SeanCurtis-TRI): Make this prettier when C++17 is available.
-  // E.g., auto [id, geometry] = make_sphere(i);
-  GeometryId sphere1_id, sphere2_id, sphere3_id;
-  const RigidBody<double>* sphere1;
-  const RigidBody<double>* sphere2;
-  const RigidBody<double>* sphere3;
-  std::tie(sphere1, sphere1_id) = make_sphere(1);
-  std::tie(sphere2, sphere2_id) = make_sphere(2);
-  std::tie(sphere3, sphere3_id) = make_sphere(3);
-
-  plant->AddJoint<RevoluteJoint>("hinge12",
-                                 *sphere1, {},
-                                 *sphere2, {},
-                                 Vector3d::UnitY());
-  plant->AddJoint<RevoluteJoint>("hinge23",
-                                 *sphere2, {},
-                                 *sphere3, {},
-                                 Vector3d::UnitY());
-
-  // We are done defining the model.
-  plant->Finalize(scene_graph);
-
-  builder.Connect(plant->get_geometry_poses_output_port(),
-                  scene_graph->get_source_pose_port(*plant->get_source_id()));
-  builder.Connect(scene_graph->get_query_output_port(),
-                  plant->get_geometry_query_input_port());
-
-  auto diagram = builder.Build();
-  std::unique_ptr<Context<double>> context = diagram->CreateDefaultContext();
-
-  // Set the zero configuration.
-  systems::Context<double>& plant_context =
-      diagram->GetMutableSubsystemContext(*plant, context.get());
-
-  // Grab query object to test for collisions.
-  const geometry::QueryObject<double>& query_object =
-      plant
-          ->EvalAbstractInput(
-              plant_context, plant->get_geometry_query_input_port().get_index())
-          ->GetValue<geometry::QueryObject<double>>();
-
+  SphereChainScenario scenario(3);
   std::vector<geometry::PenetrationAsPointPair<double>> contacts =
-      query_object.ComputePointPairPenetration();
+      scenario.ComputePointPairPenetration();
 
   // The expected collisions.
-  std::set<std::pair<GeometryId, GeometryId>> expected_pairs {
-      std::make_pair(ground_id, sphere1_id),
-      std::make_pair(ground_id, sphere2_id),
-      std::make_pair(ground_id, sphere3_id),
-      std::make_pair(sphere1_id, sphere3_id)
-  };
+  const std::set<std::pair<GeometryId, GeometryId>>& expected_pairs =
+      scenario.unfiltered_collisions();
   ASSERT_EQ(contacts.size(), expected_pairs.size());
 
   auto expect_pair_in_set = [&expected_pairs](GeometryId id1, GeometryId id2) {
@@ -635,6 +710,76 @@ GTEST_TEST(MultibodyPlantTest, FilterAdjacentBodies) {
   for (int i = 0; i < static_cast<int>(contacts.size()); ++i) {
     const auto& point_pair = contacts[i];
     expect_pair_in_set(point_pair.id_A, point_pair.id_B);
+  }
+}
+
+// Tests the error conditions for CollectRegisteredGeometries.
+GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometriesErrors) {
+  MultibodyPlant<double> plant;
+
+  // A throw-away rigid body I can use to satisfy the function interface; it
+  // will never be used because the function will fail in a pre-requisite test.
+  RigidBody<double> body{SpatialInertia<double>()};
+  // The case where the plant has *not* been finalized.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.CollectRegisteredGeometries({&body}), std::logic_error,
+      "Pre-finalize calls to 'CollectRegisteredGeometries\\(\\)' are not "
+      "allowed; you must call Finalize\\(\\) first.");
+
+  // The case where the plant has *not* been registered as a source.
+  plant.Finalize();
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant.CollectRegisteredGeometries({&body}), std::runtime_error,
+      "Failure .* in CollectRegisteredGeometries.* failed.");
+}
+
+// Tests the ability to accumulate the geometries associated with a set of
+// bodies.
+// NOTE: This exploits the implementation detail of GeometrySet that a FrameId
+// is sufficient to capture one or more geometries. So, the contents of the
+// set will be *typically* only be FrameIds -- specifically, the FrameId
+// associated with each body -- even if no *geometries* are registered.
+// The exception is if the world body is included, then anchored geometry ids
+// will be included.
+GTEST_TEST(MultibodyPlantTest, CollectRegisteredGeometries) {
+  using geometry::GeometrySet;
+
+  SphereChainScenario scenario(5);
+
+  const MultibodyPlant<double>& plant = *scenario.mutable_plant();
+
+  // Case: Empty vector produces empty geometry set.
+  {
+    GeometrySet set = plant.CollectRegisteredGeometries({});
+    EXPECT_EQ(set.num_geometries(), 0);
+    EXPECT_EQ(set.num_frames(), 0);
+  }
+
+  // Case: Single body produces single, corresponding frame.
+  {
+    GeometrySet set = plant.CollectRegisteredGeometries({&scenario.sphere(0)});
+    EXPECT_EQ(set.num_geometries(), 0);
+    EXPECT_EQ(set.num_frames(), 1);
+    FrameId id_0 = plant.GetBodyFrameIdOrThrow(scenario.sphere(0).index());
+    EXPECT_TRUE(set.contains(id_0));
+  }
+
+  // Case: Body with no corresponding geometry frame.
+  {
+    GeometrySet set =
+        plant.CollectRegisteredGeometries({&scenario.no_geometry_body()});
+    EXPECT_EQ(set.num_geometries(), 0);
+    EXPECT_EQ(set.num_frames(), 0);
+  }
+
+  // Case: Include the world body.
+  {
+    GeometrySet set =
+        plant.CollectRegisteredGeometries(
+            {&scenario.mutable_plant()->world_body()});
+    EXPECT_EQ(set.num_geometries(), 1);
+    EXPECT_TRUE(set.contains(scenario.ground_id()));
+    EXPECT_EQ(set.num_frames(), 0);
   }
 }
 


### PR DESCRIPTION
Introduces MBP public API for adding collision filters via bodies

Ultimately, this is the mechanism that enables the user to reproduce an effect akin to "collision filter groups". Example (drawn from the code):

```c++
std::vector<const RigidBody<T>*> bodies{&body1, &body2, &body3};
geometry::GeometrySet set = plant.CollectRegisteredGeometries(bodies);
scene_graph.ExcludeCollisionsWithin(set);
````

The user specifies a group of *bodies* and then asks the plant for a set of geometry registered to that collection of bodies. Then that geometry set can be passed into the SceneGraph API for filtering collisions. There is no syntactic sugar but provides the foundational functionality.

```
Category            added  modified  removed  
----------------------------------------------
code                242    15        58       
comments            99     7         7        
blank               36     0         0        
----------------------------------------------
TOTAL               377    22        65 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8954)
<!-- Reviewable:end -->
