### PR TITLE
Added text logging features

### DIFF
--- a/common/text_logging.cc
+++ b/common/text_logging.cc
@@ -6,29 +6,94 @@
 
 namespace drake {
 
+void SetLoggerLevel(const std::shared_ptr<logging::logger>& logger_ptr,
+                    const std::string& logger_level) {
+  const bool want_unchanged = (logger_level == "unchanged");
+  const bool want_trace = (logger_level == "trace");
+  const bool want_debug = (logger_level == "debug");
+  const bool want_info = (logger_level == "info");
+  const bool want_warn = (logger_level == "warn");
+  const bool want_err = (logger_level == "err");
+  const bool want_critical = (logger_level == "critical");
+  const bool want_off = (logger_level == "off");
+  if (
+        !want_unchanged &&
+        !want_trace &&
+        !want_debug &&
+        !want_info &&
+        !want_warn &&
+        !want_err &&
+        !want_critical &&
+        !want_off
+      ) {
+    logger_ptr->critical("Unknown spdlog_level {}", logger_level);
+    throw std::runtime_error("Unknown spdlog level");
+  }
+#ifdef HAVE_SPDLOG
+  if (want_trace) {
+    logger_ptr->set_level(spdlog::level::trace);
+  } else if (want_debug) {
+    logger_ptr->set_level(spdlog::level::debug);
+  } else if (want_info) {
+    logger_ptr->set_level(spdlog::level::info);
+  } else if (want_warn) {
+    logger_ptr->set_level(spdlog::level::warn);
+  } else if (want_err) {
+    logger_ptr->set_level(spdlog::level::err);
+  } else if (want_critical) {
+    logger_ptr->set_level(spdlog::level::critical);
+  } else if (want_off) {
+    logger_ptr->set_level(spdlog::level::off);
+  }
+#endif
+}
+
 #ifdef HAVE_SPDLOG
 
 namespace {
-// Returns the default logger.  NOTE: This function assumes that it is mutexed,
+// Returns a named logger.  NOTE: This function assumes that it is mutexed,
 // as in the initializer of a static local.
-std::shared_ptr<logging::logger> onetime_create_log() {
-  // Check if anyone has already set up a logger named "console".  If so, we
-  // will just return it; if not, we'll create our own default one.
-  std::shared_ptr<logging::logger> result(spdlog::get("console"));
-  if (!result) {
+std::shared_ptr<logging::logger> ReturnLoggerAlwaysNamed(
+        const std::string& logger_name) {
+  // Check if anyone has already set up a logger named logger_name. If so, we
+  // will just return it; if not, we'll create our own.
+  std::shared_ptr<logging::logger> logger_ptr(spdlog::get(logger_name));
+  if (!logger_ptr) {
     // We use the logger_mt (instead of logger_st) so more than one thread can
     // use this logger and have their messages be staggered by line, instead of
     // co-mingling their character bytes.
-    result = spdlog::stderr_logger_mt("console");
+    logger_ptr = spdlog::stderr_logger_mt(logger_name);
   }
-  return result;
+  return logger_ptr;
 }
 }  // namespace
 
+std::shared_ptr<logging::logger> ReturnDefaultLogger() {
+  return ReturnLoggerAlwaysNamed("console");
+}
+
 logging::logger* log() {
   static const never_destroyed<std::shared_ptr<logging::logger>> g_logger(
-      onetime_create_log());
+          ReturnDefaultLogger());
   return g_logger.access().get();
+}
+
+std::shared_ptr<logging::logger> ReturnLoggerPreferablyNamed(
+        const std::string& logger_name) {
+  std::shared_ptr<logging::logger> logger_ptr = spdlog::get(logger_name);
+  if (!logger_ptr) {
+    logger_ptr = ReturnDefaultLogger();
+  }
+  return logger_ptr;
+}
+
+std::shared_ptr<logging::logger> MakeLoggerSetLevel(
+        const std::string& logger_name,
+        const std::string& logger_level) {
+  std::shared_ptr<logging::logger> logger_ptr = ReturnLoggerAlwaysNamed(
+          logger_name);
+  SetLoggerLevel(logger_ptr, logger_level);
+  return logger_ptr;
 }
 
 #else  // HAVE_SPDLOG
@@ -39,6 +104,24 @@ logging::logger* log() {
   // A do-nothing logger instance.
   static logging::logger g_logger;
   return &g_logger;
+}
+
+std::shared_ptr<logging::logger> ReturnLoggerPreferablyNamed(
+        const std::string& logger_name) {
+  std::shared_ptr<logging::logger> g_logger;
+  return g_logger;
+}
+
+std::shared_ptr<logging::logger> MakeLoggerSetLevel(
+        const std::string& logger_name,
+        const std::string& logger_level) {
+  std::shared_ptr<logging::logger> g_logger;
+  return g_logger;
+}
+
+std::shared_ptr<logging::logger> ReturnDefaultLogger() {
+  std::shared_ptr<logging::logger> g_logger;
+  return g_logger;
 }
 
 #endif  // HAVE_SPDLOG

--- a/common/text_logging_gflags.h
+++ b/common/text_logging_gflags.h
@@ -4,6 +4,7 @@
 /// This file defines gflags settings to control spdlog levels.
 /// Only include this from translation units that declare a `main` function.
 
+#include <memory>
 #include <string>
 
 #include <gflags/gflags.h>
@@ -19,14 +20,19 @@ DEFINE_string(spdlog_level, "unchanged",
 namespace drake {
 namespace logging {
 
+inline void HandleSpdlogGflags() {
+  std::shared_ptr<logging::logger> log_console = ReturnDefaultLogger();
+  SetLoggerLevel(log_console, FLAGS_spdlog_level);
+}
+
 /// Creates loggers at specified logging levels. The example below sets the
 /// default logger to "off", creates a logger named "logger_a" and sets
 /// it to trace and creates a logger named "logger_b" and sets it to info.
 /// <pre>
 ///  ./compiled_project --spdlog_level=off logger_a trace logger_b info
 /// </pre>
-inline void HandleSpdlogGFlags(int argc, char *argv[]) {
-  MakeLoggerSetLevel("console", FLAGS_spdlog_level);
+inline void HandleSpdlogGflags(int argc, char *argv[]) {
+  HandleSpdlogGflags();
 
   if (argc % 2 == 0) {
     throw std::runtime_error("Commandline argument number is odd.");

--- a/common/text_logging_gflags.h
+++ b/common/text_logging_gflags.h
@@ -4,6 +4,8 @@
 /// This file defines gflags settings to control spdlog levels.
 /// Only include this from translation units that declare a `main` function.
 
+#include <string>
+
 #include <gflags/gflags.h>
 
 #include "drake/common/text_logging.h"
@@ -11,32 +13,56 @@
 // Declare the --spdlog_level gflags option.
 DEFINE_string(spdlog_level, "unchanged",
               "sets the spdlog output threshold; "
-              "possible values are 'unchanged', 'trace', 'debug', 'warn'");
+              "possible values are 'unchanged', 'trace', 'debug', 'info', "
+                      "'warn', 'err', 'critical', 'off'");
 
 namespace drake {
 namespace logging {
 
-/// Check the gflags settings for validity.  If spdlog is enabled, update its
-/// configuration to match the flags.
-inline void HandleSpdlogGflags() {
-  const bool want_unchanged = (FLAGS_spdlog_level == "unchanged");
-  const bool want_trace = (FLAGS_spdlog_level == "trace");
-  const bool want_debug = (FLAGS_spdlog_level == "debug");
-  const bool want_warn = (FLAGS_spdlog_level == "warn");
-  if (!want_unchanged && !want_trace && !want_debug && !want_warn) {
-    log()->critical("Unknown spdlog_level {}", FLAGS_spdlog_level);
-    throw std::runtime_error("Unknown spdlog level");
+/// Creates loggers at specified logging levels. The example below sets the
+/// default logger to "off", creates a logger named "logger_a" and sets
+/// it to trace and creates a logger named "logger_b" and sets it to info.
+/// <pre>
+///  ./compiled_project --spdlog_level=off logger_a trace logger_b info
+/// </pre>
+inline void HandleSpdlogGFlags(int argc, char *argv[]) {
+  MakeLoggerSetLevel("console", FLAGS_spdlog_level);
+
+  if (argc % 2 == 0) {
+    throw std::runtime_error("Commandline argument number is odd.");
   }
-#ifdef HAVE_SPDLOG
-  if (want_trace) {
-    log()->set_level(spdlog::level::trace);
-  } else if (want_debug) {
-    log()->set_level(spdlog::level::debug);
-  } else if (want_warn) {
-    log()->set_level(spdlog::level::warn);
+
+  for (int k = 1; k < argc; k+=2) {
+    std::string logger_name = argv[k];
+    std::string logger_level = argv[k + 1];
+    MakeLoggerSetLevel(logger_name, logger_level);
   }
-#endif
 }
 
 }  // namespace logging
 }  // namespace drake
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/common/text_logging_gflags.h
+++ b/common/text_logging_gflags.h
@@ -41,28 +41,3 @@ inline void HandleSpdlogGFlags(int argc, char *argv[]) {
 
 }  // namespace logging
 }  // namespace drake
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This pull request expands Drake's text logging tools to handle multiple loggers whose names are not known a priori. Named loggers can be created at the command line or in code. The logging level (debug, trace, etc) of loggers are set independently. A logger's level can change in a function if more data is desired. Attempting to log to a non-existant logger doesn't error and logs to a default logger instead. All data is logged to the same sink. Messages from different loggers should be stagger by line and not commingle. The goal of this PR is to give users the tools to discover the most valuable ways to log their data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8955)
<!-- Reviewable:end -->
