### PR TITLE
Create DrivingCommandMux, Disable Multiplexer output vector downcasting under AutoDiff

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -37,6 +37,7 @@ drake_cc_package_library(
         ":car_vis_applicator",
         ":create_trajectory_params",
         ":curve2",
+        ":driving_command_mux",
         ":generated_translators",
         ":generated_vectors",
         ":idm_controller",
@@ -173,6 +174,17 @@ drake_cc_library(
         ":generated_vectors",
         "//common:autodiff",
         "//common:autodiffxd_make_coherent",
+    ],
+)
+
+drake_cc_library(
+    name = "driving_command_mux",
+    srcs = ["driving_command_mux.cc"],
+    hdrs = ["driving_command_mux.h"],
+    deps = [
+        ":generated_vectors",
+        "//common:default_scalars",
+        "//systems/framework:leaf_system",
     ],
 )
 
@@ -448,6 +460,7 @@ drake_cc_library(
     hdrs = ["automotive_simulator.h"],
     deps = [
         ":car_vis_applicator",
+        ":driving_command_mux",
         ":generated_translators",
         ":generated_vectors",
         ":idm_controller",
@@ -469,7 +482,6 @@ drake_cc_library(
         "//systems/lcm:lcm_pubsub_system",
         "//systems/lcm:lcmt_drake_signal_translator",
         "//systems/primitives:constant_value_source",
-        "//systems/primitives:multiplexer",
         "//systems/rendering:pose_aggregator",
         "//systems/rendering:pose_bundle_to_draw_message",
     ],
@@ -616,6 +628,15 @@ drake_cc_googletest(
     name = "curve2_test",
     deps = [
         "//automotive:curve2",
+    ],
+)
+
+drake_cc_googletest(
+    name = "driving_command_mux_test",
+    deps = [
+        ":driving_command_mux",
+        "//systems/framework",
+        "//systems/framework/test_utilities",
     ],
 )
 

--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "drake/automotive/driving_command_mux.h"
 #include "drake/automotive/gen/driving_command.h"
 #include "drake/automotive/gen/driving_command_translator.h"
 #include "drake/automotive/gen/maliput_railcar_state_translator.h"
@@ -28,7 +29,6 @@
 #include "drake/systems/lcm/lcm_subscriber_system.h"
 #include "drake/systems/lcm/lcmt_drake_signal_translator.h"
 #include "drake/systems/primitives/constant_value_source.h"
-#include "drake/systems/primitives/multiplexer.h"
 
 namespace drake {
 
@@ -173,8 +173,7 @@ int AutomotiveSimulator<T>::AddMobilControlledSimpleCar(
   simple_car_initial_states_[simple_car].set_value(initial_state.get_value());
   auto pursuit = builder_->template AddSystem<PurePursuitController<T>>();
   pursuit->set_name(name + "_pure_pursuit_controller");
-  auto mux = builder_->template AddSystem<systems::Multiplexer<T>>(
-      DrivingCommand<T>());
+  auto mux = builder_->template AddSystem<DrivingCommandMux<T>>();
   mux->set_name(name + "_mux");
 
   // Wire up MobilPlanner and IdmController.
@@ -197,9 +196,9 @@ int AutomotiveSimulator<T>::AddMobilControlledSimpleCar(
   builder_->Connect(mobil_planner->lane_output(), pursuit->lane_input());
   // Build DrivingCommand via a mux of two scalar outputs (a BasicVector where
   // row 0 = steering command, row 1 = acceleration command).
-  builder_->Connect(pursuit->steering_command_output(), mux->get_input_port(0));
+  builder_->Connect(pursuit->steering_command_output(), mux->steering_input());
   builder_->Connect(idm_controller->acceleration_output(),
-                    mux->get_input_port(1));
+                    mux->acceleration_input());
   builder_->Connect(mux->get_output_port(0), simple_car->get_input_port(0));
 
   ConnectCarOutputsAndPriusVis(id, simple_car->pose_output(),
@@ -281,8 +280,7 @@ int AutomotiveSimulator<T>::AddIdmControlledCar(
 
   auto pursuit = builder_->template AddSystem<PurePursuitController<T>>();
   pursuit->set_name(name + "_pure_pursuit_controller");
-  auto mux = builder_->template AddSystem<systems::Multiplexer<T>>(
-      DrivingCommand<T>());
+  auto mux = builder_->template AddSystem<DrivingCommandMux<T>>();
   mux->set_name(name + "_mux");
 
   // Wire up the simple car and pose aggregator to IdmController.
@@ -299,9 +297,9 @@ int AutomotiveSimulator<T>::AddIdmControlledCar(
   // Build DrivingCommand via a mux of two scalar outputs (a BasicVector where
   // row 0 = steering command, row 1 = acceleration command).
   builder_->Connect(pursuit->steering_command_output(),
-                    mux->get_input_port(0));
+                    mux->steering_input());
   builder_->Connect(idm_controller->acceleration_output(),
-                    mux->get_input_port(1));
+                    mux->acceleration_input());
   builder_->Connect(mux->get_output_port(0), simple_car->get_input_port(0));
 
   ConnectCarOutputsAndPriusVis(id, simple_car->pose_output(),

--- a/automotive/driving_command_mux.cc
+++ b/automotive/driving_command_mux.cc
@@ -1,0 +1,57 @@
+#include "drake/automotive/driving_command_mux.h"
+
+#include <numeric>
+#include <utility>
+
+#include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace automotive {
+
+template <typename T>
+DrivingCommandMux<T>::DrivingCommandMux()
+    : systems::LeafSystem<T>(
+          systems::SystemTypeTag<automotive::DrivingCommandMux>{}),
+      steering_port_index_(
+          this->DeclareInputPort(systems::kVectorValued, 1).get_index()),
+      acceleration_port_index_(
+          this->DeclareInputPort(systems::kVectorValued, 1).get_index()) {
+  this->DeclareVectorOutputPort(DrivingCommand<T>(),
+                                &DrivingCommandMux<T>::CombineInputsToOutput);
+}
+
+template <typename T>
+template <typename U>
+DrivingCommandMux<T>::DrivingCommandMux(const DrivingCommandMux<U>&)
+    : DrivingCommandMux<T>() {}
+
+template <typename T>
+const systems::InputPortDescriptor<T>& DrivingCommandMux<T>::steering_input()
+    const {
+  return systems::System<T>::get_input_port(steering_port_index_);
+}
+
+template <typename T>
+const systems::InputPortDescriptor<T>&
+DrivingCommandMux<T>::acceleration_input() const {
+  return systems::System<T>::get_input_port(acceleration_port_index_);
+}
+
+template <typename T>
+void DrivingCommandMux<T>::CombineInputsToOutput(
+    const systems::Context<T>& context, DrivingCommand<T>* output) const {
+  const systems::BasicVector<T>* steering =
+      this->EvalVectorInput(context, steering_port_index_);
+  DRAKE_DEMAND(steering->size() == 1);
+  output->set_steering_angle(steering->GetAtIndex(0));
+  const systems::BasicVector<T>* acceleration =
+      this->EvalVectorInput(context, acceleration_port_index_);
+  DRAKE_DEMAND(acceleration->size() == 1);
+  output->set_acceleration(acceleration->GetAtIndex(0));
+}
+
+}  // namespace automotive
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::automotive::DrivingCommandMux)

--- a/automotive/driving_command_mux.h
+++ b/automotive/driving_command_mux.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "drake/automotive/gen/driving_command.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace automotive {
+
+/// A special-purpose multiplexer that packs two scalar inputs, steering angle
+/// (in units rad) and acceleration (in units m/s^2), into a vector-valued
+/// output of type DrivingCommand<T>, where the inputs feed directly through to
+/// the output.
+///
+/// This class differs from systems::Multiplexer<T> constructed with a
+/// DrivingCommand<T> model vector because a BasicVector (and notably any of its
+/// subclasses) stored as T=double cannot yet be converted to another type.  See
+/// #8921.
+///
+/// @tparam T The vector element type, which must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following `T` values are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+///
+/// They are already available to link against in the containing library.
+/// Currently, no other values for `T` are supported.
+///
+/// @ingroup automotive_systems
+template <typename T>
+class DrivingCommandMux : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DrivingCommandMux)
+
+  /// Constructs a %DrivingCommandMux with two scalar-valued input ports, and
+  /// one output port containing a DrivingCommand<T>.
+  DrivingCommandMux();
+
+  /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DrivingCommandMux(const DrivingCommandMux<U>&);
+
+  /// See the class description for details on the following input ports.
+  /// @{
+  const systems::InputPortDescriptor<T>& steering_input() const;
+  const systems::InputPortDescriptor<T>& acceleration_input() const;
+  /// @}
+
+ private:
+  // Packs a DrivingCommand based on the values seen at the input ports.
+  void CombineInputsToOutput(const systems::Context<T>& context,
+                             DrivingCommand<T>* output) const;
+
+  const int steering_port_index_{};
+  const int acceleration_port_index_{};
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/test/automotive_simulator_test.cc
+++ b/automotive/test/automotive_simulator_test.cc
@@ -472,8 +472,18 @@ GTEST_TEST(AutomotiveSimulatorTest, TestIdmControlledSimpleCarAutoDiff) {
 
   simulator->Build();
 
+  const auto& plant = simulator->GetDiagram();
+  auto plant_simulator =
+      std::make_unique<systems::Simulator<double>>(plant);
+
+  plant_simulator->StepTo(0.5);
+
   // Converts to AutoDiffXd.
-  EXPECT_NO_THROW(simulator->GetDiagram().ToAutoDiffXd());
+  auto plant_ad = plant.ToAutoDiffXd();
+  auto plant_ad_simulator =
+      std::make_unique<systems::Simulator<AutoDiffXd>>(*plant_ad);
+
+  plant_ad_simulator->StepTo(0.5);
 }
 
 // Returns the x-position of the vehicle based on an lcmt_viewer_draw message.

--- a/automotive/test/driving_command_mux_test.cc
+++ b/automotive/test/driving_command_mux_test.cc
@@ -1,0 +1,99 @@
+#include "drake/automotive/driving_command_mux.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/gen/driving_command.h"
+#include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
+#include "drake/systems/framework/basic_vector.h"
+#include "drake/systems/framework/test_utilities/scalar_conversion.h"
+
+namespace drake {
+namespace automotive {
+namespace {
+
+class DrivingCommandMuxTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mux_ = std::make_unique<DrivingCommandMux<double>>();
+    context_ = mux_->CreateDefaultContext();
+    output_ = mux_->AllocateOutput(*context_);
+  }
+
+  std::unique_ptr<DrivingCommandMux<double>> mux_;
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::SystemOutput<double>> output_;
+};
+
+TEST_F(DrivingCommandMuxTest, Basic) {
+  // Confirm the shape.
+  ASSERT_EQ(2, mux_->get_num_input_ports());
+  ASSERT_EQ(1, mux_->steering_input().size());
+  ASSERT_EQ(1, mux_->acceleration_input().size());
+  ASSERT_EQ(1, mux_->get_num_output_ports());
+  ASSERT_EQ(2, mux_->get_output_port(0).size());
+
+  // Confirm the output is indeed a DrivingCommand.
+  const DrivingCommand<double>* driving_command_output =
+      dynamic_cast<const DrivingCommand<double>*>(output_->get_vector_data(0));
+  ASSERT_NE(nullptr, driving_command_output);
+
+  // Provide input data.
+  context_->FixInputPort(mux_->steering_input().get_index(),
+                         systems::BasicVector<double>::Make({42.}));
+  context_->FixInputPort(mux_->acceleration_input().get_index(),
+                         systems::BasicVector<double>::Make({11.}));
+
+  // Confirm output data.
+  mux_->CalcOutput(*context_, output_.get());
+  ASSERT_EQ(42., driving_command_output->steering_angle());
+  ASSERT_EQ(11., driving_command_output->acceleration());
+}
+
+TEST_F(DrivingCommandMuxTest, IsStateless) {
+  EXPECT_EQ(0, context_->get_continuous_state().size());
+}
+
+// Tests conversion to AutoDiffXd.
+TEST_F(DrivingCommandMuxTest, ToAutoDiff) {
+  EXPECT_TRUE(is_autodiffxd_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(2, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(2, converted.get_output_port(0).size());
+
+    const auto context = converted.CreateDefaultContext();
+    const auto output = converted.AllocateOutput(*context);
+    const DrivingCommand<AutoDiffXd>* driving_command_output =
+        dynamic_cast<const DrivingCommand<AutoDiffXd>*>(
+            output->get_vector_data(0));
+    EXPECT_NE(nullptr, driving_command_output);
+  }));
+}
+
+// Tests conversion to symbolic::Expression.
+TEST_F(DrivingCommandMuxTest, ToSymbolic) {
+  EXPECT_TRUE(is_symbolic_convertible(*mux_, [&](const auto& converted) {
+    EXPECT_EQ(2, converted.get_num_input_ports());
+    EXPECT_EQ(1, converted.get_num_output_ports());
+
+    EXPECT_EQ(1, converted.get_input_port(0).size());
+    EXPECT_EQ(1, converted.get_input_port(1).size());
+    EXPECT_EQ(2, converted.get_output_port(0).size());
+
+    const auto context = converted.CreateDefaultContext();
+    const auto output = converted.AllocateOutput(*context);
+    const DrivingCommand<symbolic::Expression>* driving_command_output =
+        dynamic_cast<const DrivingCommand<symbolic::Expression>*>(
+            output->get_vector_data(0));
+    EXPECT_NE(nullptr, driving_command_output);
+  }));
+}
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake

--- a/systems/primitives/multiplexer.cc
+++ b/systems/primitives/multiplexer.cc
@@ -1,32 +1,40 @@
 #include "drake/systems/primitives/multiplexer.h"
 
 #include <functional>
-#include <numeric>
+#include <memory>
+#include <utility>
 
 #include "drake/common/default_scalars.h"
 
 namespace drake {
 namespace systems {
 
+// N.B. This overload can support scalar conversion because our output port is
+// definitely typed as BasicVector (and not some subtype of BasicVector).
 template <typename T>
 Multiplexer<T>::Multiplexer(int num_scalar_inputs)
     : Multiplexer<T>(std::vector<int>(num_scalar_inputs, 1)) {}
 
+// N.B. This overload also supports scalar conversion.
 template <typename T>
 Multiplexer<T>::Multiplexer(std::vector<int> input_sizes)
-    : Multiplexer<T>(input_sizes, BasicVector<T>(std::accumulate(
-                                      input_sizes.begin(), input_sizes.end(), 0,
-                                      std::plus<int>{}))) {}
+    : Multiplexer<T>(
+          SystemTypeTag<systems::Multiplexer>{}, input_sizes,
+          BasicVector<T>(std::accumulate(input_sizes.begin(), input_sizes.end(),
+                                         0, std::plus<int>{}))) {}
 
+// N.B. This overload cannot support scalar conversion, until we have a way to
+// convert a BasicVector subtype between scalar types.
 template <typename T>
 Multiplexer<T>::Multiplexer(const systems::BasicVector<T>& model_vector)
-    : Multiplexer<T>(std::vector<int>(model_vector.size(), 1), model_vector) {}
+    : Multiplexer<T>({} /* empty to disallow scalar conversion */,
+                     std::vector<int>(model_vector.size(), 1), model_vector) {}
 
 template <typename T>
-Multiplexer<T>::Multiplexer(std::vector<int> input_sizes,
+Multiplexer<T>::Multiplexer(SystemScalarConverter converter,
+                            std::vector<int> input_sizes,
                             const systems::BasicVector<T>& model_vector)
-    : LeafSystem<T>(SystemTypeTag<systems::Multiplexer>{}),
-      input_sizes_(input_sizes) {
+    : LeafSystem<T>(std::move(converter)), input_sizes_(input_sizes) {
   DRAKE_DEMAND(model_vector.size() == std::accumulate(input_sizes_.begin(),
                                                       input_sizes_.end(), 0,
                                                       std::plus<int>{}));
@@ -40,9 +48,7 @@ Multiplexer<T>::Multiplexer(std::vector<int> input_sizes,
 template <typename T>
 template <typename U>
 Multiplexer<T>::Multiplexer(const Multiplexer<U>& other)
-    : Multiplexer<T>(other.input_sizes_,
-                     systems::BasicVector<T>(other.get_output_port(0).size())) {
-}
+    : Multiplexer<T>(other.input_sizes_) {}
 
 template <typename T>
 void Multiplexer<T>::CombineInputsToOutput(const Context<T>& context,

--- a/systems/primitives/multiplexer.h
+++ b/systems/primitives/multiplexer.h
@@ -41,6 +41,9 @@ class Multiplexer : public LeafSystem<T> {
   /// and one vector-valued output port whose size equals the size of
   /// `model_vector`.  In addition, the output type derives from that of
   /// `model_vector`.
+  ///
+  /// @note Objects created using this constructor overload do not support
+  /// system scalar conversion.  See @ref system_scalar_conversion.
   explicit Multiplexer(const systems::BasicVector<T>& model_vector);
 
   /// Scalar-converting copy constructor. See @ref system_scalar_conversion.
@@ -50,7 +53,8 @@ class Multiplexer : public LeafSystem<T> {
  private:
   template <typename> friend class Multiplexer;
 
-  Multiplexer(std::vector<int> input_sizes,
+  // All other constructors delegate to here.
+  Multiplexer(SystemScalarConverter converter, std::vector<int> input_sizes,
               const systems::BasicVector<T>& model_vector);
 
   // This is the calculator for the output port.


### PR DESCRIPTION
Closes #8921.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8957)
<!-- Reviewable:end -->
