### PR TITLE
pydrake rbt: Add simple binding of `RigidBodyActuator` and related methods

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -13,6 +13,7 @@
 #include "drake/multibody/parsers/package_map.h"
 #include "drake/multibody/parsers/sdf_parser.h"
 #include "drake/multibody/parsers/urdf_parser.h"
+#include "drake/multibody/rigid_body_actuator.h"
 #include "drake/multibody/rigid_body_tree.h"
 #include "drake/multibody/rigid_body_tree_construction.h"
 
@@ -153,6 +154,13 @@ PYBIND11_MODULE(rigid_body_tree, m) {
     .def_readonly("B", &RigidBodyTree<double>::B)
     .def_readonly("joint_limit_min", &RigidBodyTree<double>::joint_limit_min)
     .def_readonly("joint_limit_max", &RigidBodyTree<double>::joint_limit_max)
+    // N.B. This will return *copies* of the actuators.
+    // N.B. `def_readonly` implicitly adds `reference_internal` to the getter,
+    // which is necessary since an actuator references a `RigidBody` that is
+    // most likely owned by this tree.
+    .def_readonly("actuators", &RigidBodyTree<double>::actuators)
+    .def("GetActuator", &RigidBodyTree<double>::GetActuator,
+         py_reference_internal)
     .def("FindBaseBodies", &RigidBodyTree<double>::FindBaseBodies,
          py::arg("model_instance_id") = -1);
 
@@ -331,6 +339,13 @@ PYBIND11_MODULE(rigid_body_tree, m) {
   m.def("AddFlatTerrainToWorld", &multibody::AddFlatTerrainToWorld,
         py::arg("tree"), py::arg("box_size") = 1000,
         py::arg("box_depth") = 10);
+
+  py::class_<RigidBodyActuator>(m, "RigidBodyActuator")
+    .def_readonly("name", &RigidBodyActuator::name_)
+    .def_readonly("body", &RigidBodyActuator::body_)
+    .def_readonly("reduction", &RigidBodyActuator::reduction_)
+    .def_readonly("effort_limit_min", &RigidBodyActuator::effort_limit_min_)
+    .def_readonly("effort_limit_max", &RigidBodyActuator::effort_limit_max_);
 }
 
 }  // namespace pydrake

--- a/bindings/pydrake/multibody/test/parsers_test.py
+++ b/bindings/pydrake/multibody/test/parsers_test.py
@@ -12,6 +12,7 @@ from pydrake.multibody.rigid_body_tree import (
     AddModelInstancesFromSdfString,
     AddModelInstancesFromSdfStringSearchingInRosPackages,
     FloatingBaseType,
+    RigidBodyActuator,
     RigidBodyTree,
 )
 
@@ -45,6 +46,19 @@ class TestParsers(unittest.TestCase):
         self.assertEqual(robot.get_num_bodies(), expected_num_bodies,
                          msg='Incorrect number of bodies: {0} vs. {1}'.format(
                              robot.get_num_bodies(), expected_num_bodies))
+
+        # Check actuators.
+        actuator = robot.GetActuator("head_pan_motor")
+        self.assertIsInstance(actuator, RigidBodyActuator)
+        self.assertEqual(actuator.name, "head_pan_motor")
+        self.assertIs(actuator.body, robot.FindBody("head_pan_link"))
+        self.assertEqual(actuator.reduction, 6.0)
+        self.assertEqual(actuator.effort_limit_min, -2.645)
+        self.assertEqual(actuator.effort_limit_max, 2.645)
+        # Check full number of actuators.
+        self.assertEqual(len(robot.actuators), robot.get_num_actuators())
+        for actuator in robot.actuators:
+            self.assertIsInstance(actuator, RigidBodyActuator)
 
     def test_sdf(self):
         sdf_file = os.path.join(


### PR DESCRIPTION
Per @mpetersen94's request.

Please note that the RBT actuator name typically refers to the URDF's transmission name; not sure what happens if there is no transmission specified.

The behavior of `MulitbodyTree` w.r.t. actuator information and parsing should be much more ideal once it is fully online.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8967)
<!-- Reviewable:end -->
