### PR TITLE
[Multilane] Adds Builder::Connect to support lane-to-lane Connections

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -29,6 +29,7 @@ drake_cc_library(
     srcs = [
         "arc_road_curve.cc",
         "branch_point.cc",
+        "cubic_polynomial.cc",
         "junction.cc",
         "lane.cc",
         "line_road_curve.cc",

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -64,6 +64,8 @@ Connection::Connection(const std::string& id, const Endpoint& start,
   DRAKE_DEMAND(linear_tolerance_ > 0.);
   DRAKE_DEMAND(scale_length_ > 0.);
   DRAKE_DEMAND(line_length_ > 0.);
+  DRAKE_DEMAND(start.z().theta_dot().has_value());
+  DRAKE_DEMAND(end_z.theta_dot().has_value());
   // Computes end Endpoint and RoadCurve.
   end_ = Endpoint(
       {start_.xy().x() + line_length_ * std::cos(start_.xy().heading()),
@@ -107,6 +109,8 @@ Connection::Connection(const std::string& id, const Endpoint& start,
   DRAKE_DEMAND(linear_tolerance_ > 0.);
   DRAKE_DEMAND(scale_length_ > 0.);
   DRAKE_DEMAND(radius_ > 0);
+  DRAKE_DEMAND(start.z().theta_dot().has_value());
+  DRAKE_DEMAND(end_z.theta_dot().has_value());
   // Fills arc related parameters, computes end Endpoint and creates the
   // RoadCurve.
   theta0_ = start_.xy().heading() - std::copysign(M_PI / 2., d_theta_);

--- a/automotive/maliput/multilane/cubic_polynomial.cc
+++ b/automotive/maliput/multilane/cubic_polynomial.cc
@@ -1,0 +1,17 @@
+#include "drake/automotive/maliput/multilane/cubic_polynomial.h"
+
+namespace drake {
+namespace maliput {
+namespace multilane {
+
+std::ostream& operator<<(std::ostream& out,
+                         const CubicPolynomial& cubic_polynomial) {
+  return out << "(a: " << std::to_string(cubic_polynomial.a())
+             << ", b: " << std::to_string(cubic_polynomial.b())
+             << ", c: " << std::to_string(cubic_polynomial.c())
+             << ", d: " << std::to_string(cubic_polynomial.d()) << ")";
+}
+
+}  // namespace multilane
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/multilane/cubic_polynomial.h
+++ b/automotive/maliput/multilane/cubic_polynomial.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <ostream>
 
 #include "drake/common/drake_copyable.h"
 #include "drake/common/unused.h"
@@ -93,6 +94,12 @@ class CubicPolynomial {
   double d_{};
   double s_1_{};
 };
+
+/// Streams a string representation of `cubic_polynomial` into `out`.
+/// Returns `out`. This method is provided for the purposes of debugging or
+/// text-logging. It is not intended for serialization.
+std::ostream& operator<<(std::ostream& out,
+                         const CubicPolynomial& cubic_polynomial);
 
 }  // namespace multilane
 }  // namespace maliput

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -121,11 +121,9 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
   const Connection dut(kId, kStartEndpoint, kLowFlatZ, kNumLanes, kR0,
                        kLaneWidth, kLeftShoulder, kRightShoulder, kArcOffset,
                        kLinearTolerance, kScaleLength, kComputationPolicy);
+
   EXPECT_EQ(dut.type(), Connection::Type::kArc);
   EXPECT_EQ(dut.id(), kId);
-  EXPECT_TRUE(
-      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
-  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kZeroTolerance));
   EXPECT_EQ(dut.num_lanes(), kNumLanes);
   EXPECT_EQ(dut.r0(), kR0);
   EXPECT_EQ(dut.lane_width(), kLaneWidth);
@@ -159,9 +157,6 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
                        kLinearTolerance, kScaleLength, kComputationPolicy);
   EXPECT_EQ(dut.type(), Connection::Type::kLine);
   EXPECT_EQ(dut.id(), kId);
-  EXPECT_TRUE(
-      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
-  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kZeroTolerance));
   EXPECT_EQ(dut.num_lanes(), kNumLanes);
   EXPECT_EQ(dut.r0(), kR0);
   EXPECT_EQ(dut.lane_width(), kLaneWidth);
@@ -231,19 +226,10 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
       flat_end, kVeryExact));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
-  EXPECT_EQ(road_curve->elevation().a(), 0.);
-  EXPECT_EQ(road_curve->elevation().b(), 0.);
-  EXPECT_EQ(road_curve->elevation().c(), 0.);
-  EXPECT_EQ(road_curve->elevation().d(), 0.);
-  EXPECT_EQ(road_curve->superelevation().a(), 0.);
-  EXPECT_EQ(road_curve->superelevation().b(), 0.);
-  EXPECT_EQ(road_curve->superelevation().c(), 0.);
-  EXPECT_EQ(road_curve->superelevation().d(), 0.);
-  // Checks that computation accuracy and speed related parameters are
-  // correctly set.
-  EXPECT_EQ(road_curve->computation_policy(), kComputationPolicy);
-  EXPECT_EQ(road_curve->linear_tolerance(), kLinearTolerance);
-  EXPECT_EQ(road_curve->scale_length(), kScaleLength);
+  EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(),
+                                           CubicPolynomial(), kZeroTolerance));
+  EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->superelevation(),
+                                           CubicPolynomial(), kZeroTolerance));
 
   // Creates a new complex dut with cubic elevation and superelevation.
   const Endpoint kEndElevatedEndpoint{{40., 30., kHeading + kDTheta},
@@ -273,24 +259,14 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
                                               kEndElevatedEndpoint.xy().y(),
                                               kEndElevatedEndpoint.z().z()),
                               complex_end, kVeryExact));
-
-  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.32476276288217043,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.549841841921447,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.9292893218813453,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.9528595479208968,
-              kVeryExact);
-  // Checks that computation accuracy and speed related parameters are
-  // correctly set.
-  EXPECT_EQ(complex_road_curve->computation_policy(), kComputationPolicy);
-  EXPECT_EQ(complex_road_curve->linear_tolerance(), kLinearTolerance);
-  EXPECT_EQ(complex_road_curve->scale_length(), kScaleLength);
+  EXPECT_TRUE(test::IsCubicPolynomialClose(
+      complex_road_curve->elevation(),
+      CubicPolynomial(0., 0., -0.32476276288217043, 0.549841841921447),
+      kVeryExact));
+  EXPECT_TRUE(test::IsCubicPolynomialClose(
+      complex_road_curve->superelevation(),
+      CubicPolynomial(0., 0., -0.9292893218813453, 0.9528595479208968),
+      kVeryExact));
 }
 
 TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
@@ -326,19 +302,10 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
       flat_end, kVeryExact));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
-  EXPECT_EQ(road_curve->elevation().a(), 0.);
-  EXPECT_EQ(road_curve->elevation().b(), 0.);
-  EXPECT_EQ(road_curve->elevation().c(), 0.);
-  EXPECT_EQ(road_curve->elevation().d(), 0.);
-  EXPECT_EQ(road_curve->superelevation().a(), 0.);
-  EXPECT_EQ(road_curve->superelevation().b(), 0.);
-  EXPECT_EQ(road_curve->superelevation().c(), 0.);
-  EXPECT_EQ(road_curve->superelevation().d(), 0.);
-  // Checks that computation accuracy and speed related parameters are
-  // correctly set.
-  EXPECT_EQ(road_curve->computation_policy(), kComputationPolicy);
-  EXPECT_EQ(road_curve->linear_tolerance(), kLinearTolerance);
-  EXPECT_EQ(road_curve->scale_length(), kScaleLength);
+  EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(),
+                                           CubicPolynomial(), kZeroTolerance));
+  EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->superelevation(),
+                                           CubicPolynomial(), kZeroTolerance));
 
   // Creates a new complex dut with cubic elevation and superelevation.
   const Endpoint kEndElevatedEndpoint{{50., 0., kHeading},
@@ -369,24 +336,14 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
                                               kEndElevatedEndpoint.xy().y(),
                                               kEndElevatedEndpoint.z().z()),
                               complex_end, kVeryExact));
-
-  EXPECT_NEAR(complex_road_curve->elevation().a(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().b(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().c(), -0.646446609406726,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->elevation().d(), 0.764297739604484,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().a(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().b(), 0., kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().c(), -0.962975975515347,
-              kVeryExact);
-  EXPECT_NEAR(complex_road_curve->superelevation().d(), 0.975317317010231,
-              kVeryExact);
-  // Checks that computation accuracy and speed related parameters are
-  // correctly set.
-  EXPECT_EQ(complex_road_curve->computation_policy(), kComputationPolicy);
-  EXPECT_EQ(complex_road_curve->linear_tolerance(), kLinearTolerance);
-  EXPECT_EQ(complex_road_curve->scale_length(), kScaleLength);
+  EXPECT_TRUE(test::IsCubicPolynomialClose(
+      complex_road_curve->elevation(),
+      CubicPolynomial(0., 0., -0.646446609406726, 0.764297739604484),
+      kVeryExact));
+  EXPECT_TRUE(test::IsCubicPolynomialClose(
+      complex_road_curve->superelevation(),
+      CubicPolynomial(0., 0., -0.962975975515347, 0.975317317010231),
+      kVeryExact));
 }
 
 // Lane Endpoints with different EndpointZ. Those are selected to cover

--- a/automotive/maliput/multilane/test/multilane_loader_test.cc
+++ b/automotive/maliput/multilane/test/multilane_loader_test.cc
@@ -74,14 +74,32 @@ class BuilderMock : public BuilderBase {
     const Connection* (Builder::*connect_line_ref)(
         const std::string&, const LaneLayout&, const StartReference::Spec&,
         const LineOffset&, const EndReference::Spec&) = &Builder::Connect;
-    ON_CALL(*this, Connect(_, _, _, An<const LineOffset&>(), _))
+    ON_CALL(*this,
+            Connect(_, _, An<const StartReference::Spec&>(),
+                    An<const LineOffset&>(), An<const EndReference::Spec&>()))
         .WillByDefault(Invoke(&builder_, connect_line_ref));
 
     const Connection* (Builder::*connect_arc_ref)(
         const std::string&, const LaneLayout&, const StartReference::Spec&,
         const ArcOffset&, const EndReference::Spec&) = &Builder::Connect;
-    ON_CALL(*this, Connect(_, _, _, An<const ArcOffset&>(), _))
+    ON_CALL(*this,
+            Connect(_, _, An<const StartReference::Spec&>(),
+                    An<const ArcOffset&>(), An<const EndReference::Spec&>()))
         .WillByDefault(Invoke(&builder_, connect_arc_ref));
+
+    const Connection* (Builder::*connect_line_lane)(
+        const std::string&, const LaneLayout&, const StartLane::Spec&,
+        const LineOffset&, const EndLane::Spec&) = &Builder::Connect;
+    ON_CALL(*this, Connect(_, _, An<const StartLane::Spec&>(),
+                           An<const LineOffset&>(), An<const EndLane::Spec&>()))
+        .WillByDefault(Invoke(&builder_, connect_line_lane));
+
+    const Connection* (Builder::*connect_arc_lane)(
+        const std::string&, const LaneLayout&, const StartLane::Spec&,
+        const ArcOffset&, const EndLane::Spec&) = &Builder::Connect;
+    ON_CALL(*this, Connect(_, _, An<const StartLane::Spec&>(),
+                           An<const ArcOffset&>(), An<const EndLane::Spec&>()))
+        .WillByDefault(Invoke(&builder_, connect_arc_lane));
 
     ON_CALL(*this, SetDefaultBranch(_, _, _, _, _, _))
         .WillByDefault(Invoke(&builder_, &Builder::SetDefaultBranch));
@@ -121,6 +139,16 @@ class BuilderMock : public BuilderBase {
                const Connection*(const std::string&, const LaneLayout&,
                                  const StartReference::Spec&, const ArcOffset&,
                                  const EndReference::Spec&));
+
+  MOCK_METHOD5(Connect,
+               const Connection*(const std::string&, const LaneLayout&,
+                                 const StartLane::Spec&, const LineOffset&,
+                                 const EndLane::Spec&));
+
+  MOCK_METHOD5(Connect,
+               const Connection*(const std::string&, const LaneLayout&,
+                                 const StartLane::Spec&, const ArcOffset&,
+                                 const EndLane::Spec&));
 
   MOCK_METHOD6(SetDefaultBranch,
                void(const Connection*, int, const api::LaneEnd::Which,

--- a/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
@@ -17,15 +17,6 @@
 namespace drake {
 namespace maliput {
 namespace multilane {
-
-// Convenience stream operator overload for CubicPolynomial instances.
-// @note MUST be outside the anonymous namespace to be found by the
-// compiler.
-std::ostream& operator<<(std::ostream& o, const CubicPolynomial& p) {
-  return o << p.a() << " + " << p.b() << " p + "
-           << p.c() << " p^2 + " << p.d() << " p^3";
-}
-
 namespace {
 
 // Checks brute force integral computations against known

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <ostream>
 #include <string>
+#include <vector>
 
 namespace drake {
 namespace maliput {
@@ -188,6 +189,40 @@ namespace test {
          << arc_offset2 << "\nwith linear tolerance = " << linear_tolerance
          << "\nand angular tolerance =\n"
          << angular_tolerance;
+}
+
+::testing::AssertionResult IsCubicPolynomialClose(const CubicPolynomial& cubic1,
+                                                  const CubicPolynomial& cubic2,
+                                                  double tolerance) {
+  bool fails = false;
+  std::string error_message{};
+  const std::vector<std::string> coefficient_strs{"a", "b", "c", "d"};
+  const std::vector<double> coefficients1{cubic1.a(), cubic1.b(), cubic1.c(),
+                                          cubic1.d()};
+  const std::vector<double> coefficients2{cubic2.a(), cubic2.b(), cubic2.c(),
+                                          cubic2.d()};
+
+  for (int i = 0; i < 4; ++i) {
+    const double delta = std::abs(coefficients1[i] - coefficients2[i]);
+    if (delta > tolerance) {
+      fails = true;
+      error_message = error_message + "Cubic polynomials are different at " +
+                      coefficient_strs[i] + " coefficient. " + "cubic1." +
+                      coefficient_strs[i] +
+                      "(): " + std::to_string(coefficients1[i]) +
+                      " vs. cubic2." + coefficient_strs[i] +
+                      "(): " + std::to_string(coefficients2[i]) +
+                      ", diff = " + std::to_string(delta) +
+                      ", tolerance = " + std::to_string(tolerance) + "\n";
+    }
+  }
+  if (fails) {
+    return ::testing::AssertionFailure() << error_message;
+  }
+  return ::testing::AssertionSuccess()
+         << "cubic1 =\n"
+         << cubic1 << "\nis approximately equal to cubic2 =\n"
+         << cubic2 << "\ntolerance = " << tolerance;
 }
 
 Matcher<const api::HBounds&> Matches(const api::HBounds& elevation_bounds,

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.h
@@ -80,6 +80,19 @@ using ::testing::MatchResultListener;
                                             double linear_tolerance,
                                             double angular_tolerance);
 
+// Compares equality within @p tolerance of @p cubic1 and @p cubic2
+// coefficients.
+// @param cubic1 A CubicPolynomial object to compare.
+// @param cubic2 A CubicPolynomial object to compare.
+// @param tolerance An allowable absolute linear deviation for each coefficient.
+// @return ::testing::AssertionFailure() When any coefficient of
+// CubicPolynomial objects are different.
+// @return ::testing::AssertionSuccess() When all coefficients of
+// CubicPolynomial objects are equal.
+::testing::AssertionResult IsCubicPolynomialClose(const CubicPolynomial& cubic1,
+                                                  const CubicPolynomial& cubic2,
+                                                  double tolerance);
+
 /// Wraps api::HBounds comparison into a MatcherInterface.
 class HBoundsMatcher : public MatcherInterface<const api::HBounds&> {
  public:


### PR DESCRIPTION
This PR is a follow up of #8676 and introduces `Builder::Connect` methods to support lane-to-lane connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8973)
<!-- Reviewable:end -->
