### PR TITLE
workspace: Add ruby interpreter

### DIFF
--- a/setup/ubuntu/16.04/source_distribution/packages.txt
+++ b/setup/ubuntu/16.04/source_distribution/packages.txt
@@ -48,6 +48,7 @@ python-protobuf
 python-pygame
 python-sphinx
 python-tk
+ruby
 unzip
 valgrind
 zip

--- a/setup/ubuntu/18.04/source_distribution/packages.txt
+++ b/setup/ubuntu/18.04/source_distribution/packages.txt
@@ -48,6 +48,7 @@ python-protobuf
 python-pygame
 python-sphinx
 python-tk
+ruby
 unzip
 valgrind
 zip

--- a/tools/workspace/com_google_protobuf/package.BUILD.bazel
+++ b/tools/workspace/com_google_protobuf/package.BUILD.bazel
@@ -10,7 +10,7 @@ package(
 exports_files(["protobuf.bzl"])
 
 # The protobuf.bzl looks here to find which protoc to use.
-# Drake uses the protoc found on $PATH (typically from the host OS).
+# Drake uses the protoc from the host OS.
 filegroup(
     name = "protoc",
     srcs = ["@protoc"],

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -46,6 +46,7 @@ load("@drake//tools/workspace/pybind11:repository.bzl", "pybind11_repository")
 load("@drake//tools/workspace/pycodestyle:repository.bzl", "pycodestyle_repository")  # noqa
 load("@drake//tools/workspace/pycps:repository.bzl", "pycps_repository")
 load("@drake//tools/workspace/python:repository.bzl", "python_repository")
+load("@drake//tools/workspace/ruby:repository.bzl", "ruby_repository")
 load("@drake//tools/workspace/scs:repository.bzl", "scs_repository")
 load("@drake//tools/workspace/sdformat:repository.bzl", "sdformat_repository")
 load("@drake//tools/workspace/semantic_version:repository.bzl", "semantic_version_repository")  # noqa
@@ -163,6 +164,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         pycps_repository(name = "pycps", mirrors = mirrors)
     if "python" not in excludes:
         python_repository(name = "python")
+    if "ruby" not in excludes:
+        ruby_repository(name = "ruby")
     if "scs" not in excludes:
         scs_repository(name = "scs", mirrors = mirrors)
     if "sdformat" not in excludes:

--- a/tools/workspace/ruby/BUILD.bazel
+++ b/tools/workspace/ruby/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/ruby/repository.bzl
+++ b/tools/workspace/ruby/repository.bzl
@@ -2,9 +2,9 @@
 
 load("@drake//tools/workspace:which.bzl", "which_repository")
 
-def protoc_repository(name):
-    # Find the protoc binary.
+def ruby_repository(name):
+    # Find the ruby binary.
     which_repository(
         name = name,
-        command = "protoc",
+        command = "ruby",
     )


### PR DESCRIPTION
This will be used first by the `sdformat` library, but in general is the standard interpreted language used by OSRF / ROS so may have additional uses in the future, such as `*.rsdf` files.

See #8975 for the PR that puts this to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8976)
<!-- Reviewable:end -->
