### PR TITLE
workspace: Add support for bionic as a detected platform

### DIFF
--- a/tools/workspace/os.bzl
+++ b/tools/workspace/os.bzl
@@ -73,7 +73,7 @@ def _determine_linux(repository_ctx):
     distro = " ".join([x for x in lines if len(x) > 0])
 
     # Match supported Ubuntu release(s).
-    for ubuntu_release in ["16.04"]:
+    for ubuntu_release in ["16.04", "18.04"]:
         if distro == "Ubuntu " + ubuntu_release:
             return _make_result(ubuntu_release = ubuntu_release)
 


### PR DESCRIPTION
This detects ubuntu_release = "18.04" as used within repository rules.

I have inspected all call sites to confirm that they are either:
- already have support for 18.04 (gflags, vtk, drake_visualizer);
- insensitive to the particular ubuntu release (i.e., only needs to
  distinguish macOS vs Ubuntu);
- probably sensitive to the particular ubuntu release (dreal), but
  does not need to be mitigated further for now.

Relates #7882.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8985)
<!-- Reviewable:end -->
