### PR TITLE
Add ModelInstance to MultibodyTree

### DIFF
--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -30,7 +30,9 @@ drake_cc_package_library(
 drake_cc_library(
     name = "multibody_tree_indexes",
     srcs = [],
-    hdrs = ["multibody_tree_indexes.h"],
+    hdrs = [
+        "multibody_tree_indexes.h",
+    ],
     deps = [
         "//common:type_safe_index",
     ],
@@ -95,6 +97,7 @@ drake_cc_library(
         "joints/revolute_joint.cc",
         "joints/weld_joint.cc",
         "mobilizer_impl.cc",
+        "model_instance.cc",
         "multibody_forces.cc",
         "multibody_tree.cc",
         "prismatic_mobilizer.cc",
@@ -121,6 +124,7 @@ drake_cc_library(
         "joints/weld_joint.h",
         "mobilizer.h",
         "mobilizer_impl.h",
+        "model_instance.h",
         "multibody_forces.h",
         "multibody_tree.h",
         "prismatic_mobilizer.h",
@@ -275,6 +279,14 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "frames_test",
     deps = [":multibody_tree"],
+)
+
+drake_cc_googletest(
+    name = "model_instance_test",
+    deps = [
+        ":multibody_tree",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
 )
 
 drake_cc_googletest(

--- a/multibody/multibody_tree/body.h
+++ b/multibody/multibody_tree/body.h
@@ -147,13 +147,13 @@ class Body : public MultibodyTreeElement<Body<T>, BodyIndex> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Body)
 
-  /// Creates a %Body with a BodyFrame associated with it.
-  Body() : body_frame_(*this) {}
-
-  /// Creates a %Body named `name` with a given `default_mass` and a BodyFrame
-  /// associated with it.
-  explicit Body(const std::string& name, double default_mass) :
-      name_(name), body_frame_(*this), default_mass_(default_mass) {}
+  /// Creates a %Body named `name` in model instance `model_instance`
+  /// with a given `default_mass` and a BodyFrame associated with it.
+  Body(const std::string& name, ModelInstanceIndex model_instance,
+       double default_mass)
+      : MultibodyTreeElement<Body<T>, BodyIndex>(model_instance),
+        name_(name),
+        body_frame_(*this), default_mass_(default_mass) {}
 
   /// Gets the `name` associated with `this` body.
   const std::string& name() const { return name_; }

--- a/multibody/multibody_tree/body_node.h
+++ b/multibody/multibody_tree/body_node.h
@@ -116,8 +116,12 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   /// @note %BodyNode keeps a reference to the parent body, body and mobilizer
   /// for this node, which must outlive `this` BodyNode.
   BodyNode(const BodyNode<T>* parent_node,
-           const Body<T>* body, const Mobilizer<T>* mobilizer) :
-      parent_node_(parent_node), body_(body), mobilizer_(mobilizer) {
+           const Body<T>* body, const Mobilizer<T>* mobilizer)
+      : MultibodyTreeElement<BodyNode<T>, BodyNodeIndex>(
+            body->model_instance()),
+        parent_node_(parent_node),
+        body_(body),
+        mobilizer_(mobilizer) {
     DRAKE_DEMAND(!(parent_node == nullptr &&
         body->index() != world_index()));
     DRAKE_DEMAND(!(mobilizer == nullptr && body->index() != world_index()));

--- a/multibody/multibody_tree/body_node.h
+++ b/multibody/multibody_tree/body_node.h
@@ -167,7 +167,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
 
   /// Returns the number of generalized velocities for the Mobilizer in `this`
   /// node.
-  int get_num_mobilizer_velocites() const {
+  int get_num_mobilizer_velocities() const {
     return topology_.num_mobilizer_velocities;
   }
   //@}
@@ -256,7 +256,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
 
     DRAKE_ASSERT(vc != nullptr);
     DRAKE_DEMAND(H_PB_W.rows() == 6);
-    DRAKE_DEMAND(H_PB_W.cols() == get_num_mobilizer_velocites());
+    DRAKE_DEMAND(H_PB_W.cols() == get_num_mobilizer_velocities());
 
     // As a guideline for developers, a summary of the computations performed in
     // this method is provided:
@@ -556,7 +556,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
   ///   Externally applied generalized force at this node's mobilizer. It can
   ///   have zero size, implying no generalized forces are applied. Otherwise it
   ///   must have a size equal to the number of generalized velocities for this
-  ///   node's mobilizer, see get_num_mobilizer_velocites().
+  ///   node's mobilizer, see get_num_mobilizer_velocities().
   ///   `tau_applied` **must** not be an entry into `tau_array`, which would
   ///   result in undefined results.
   /// @param[out] F_BMo_W_array_ptr
@@ -604,7 +604,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     DRAKE_DEMAND(F_BMo_W_array_ptr != nullptr);
     std::vector<SpatialForce<T>>& F_BMo_W_array = *F_BMo_W_array_ptr;
     DRAKE_DEMAND(
-        tau_applied.size() == get_num_mobilizer_velocites() ||
+        tau_applied.size() == get_num_mobilizer_velocities() ||
         tau_applied.size() == 0);
     DRAKE_DEMAND(tau_array != nullptr);
     DRAKE_DEMAND(tau_array->size() ==
@@ -786,7 +786,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     DRAKE_DEMAND(topology_.body != world_index());
     DRAKE_DEMAND(H_PB_W != nullptr);
     DRAKE_DEMAND(H_PB_W->rows() == 6);
-    DRAKE_DEMAND(H_PB_W->cols() == get_num_mobilizer_velocites());
+    DRAKE_DEMAND(H_PB_W->cols() == get_num_mobilizer_velocities());
 
     // Inboard frame F of this node's mobilizer.
     const Frame<T>& frame_F = inboard_frame();
@@ -808,11 +808,11 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
         get_X_FM(pc).linear() * X_MB.translation();
 
     // Compute the imob-th column in J_PB_W:
-    VectorUpTo6<T> v = VectorUpTo6<T>::Zero(get_num_mobilizer_velocites());
+    VectorUpTo6<T> v = VectorUpTo6<T>::Zero(get_num_mobilizer_velocities());
     // We compute H_FM(q) one column at a time by calling the multiplication by
     // H_FM operation on a vector of generalized velocities which is zero except
     // for its imob-th component, which is one.
-    for (int imob = 0; imob < get_num_mobilizer_velocites(); ++imob) {
+    for (int imob = 0; imob < get_num_mobilizer_velocities(); ++imob) {
       v(imob) = 1.0;
       // Compute the imob-th column of H_FM:
       const SpatialVelocity<T> Himob_FM =
@@ -1000,7 +1000,7 @@ class BodyNode : public MultibodyTreeElement<BodyNode<T>, BodyNodeIndex> {
     }
 
     // Get the number of mobilizer velocities (number of columns of H_PB_W).
-    const int nv = get_num_mobilizer_velocites();
+    const int nv = get_num_mobilizer_velocities();
 
     // Compute common term HTxP.
     const MatrixUpTo6<T> HTxP = H_PB_W.transpose() * P_B_W;

--- a/multibody/multibody_tree/force_element.h
+++ b/multibody/multibody_tree/force_element.h
@@ -39,7 +39,9 @@ class ForceElement : public
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ForceElement)
 
   /// Default constructor for a generic force element.
-  ForceElement() {}
+  explicit ForceElement(ModelInstanceIndex model_instance)
+      : MultibodyTreeElement<ForceElement<T>, ForceElementIndex>(
+            model_instance) {}
 
   /// Computes the force contribution for `this` force element and **adds** it
   /// to the output arrays of forces. Depending on their model, different force

--- a/multibody/multibody_tree/frame.h
+++ b/multibody/multibody_tree/frame.h
@@ -84,8 +84,11 @@ class Frame : public FrameBase<T> {
 
  protected:
   /// Only derived classes can use this constructor. It creates a %Frame
-  /// object attached to `body`.
-  explicit Frame(const Body<T>& body) : body_(body) {}
+  /// object attached to `body` and puts the frame in the body's model
+  /// instance.
+  explicit Frame(const Body<T>& body)
+      : FrameBase<T>(body.model_instance()),
+        body_(body) {}
 
   /// @name Methods to make a clone templated on different scalar types.
   ///

--- a/multibody/multibody_tree/frame_base.h
+++ b/multibody/multibody_tree/frame_base.h
@@ -56,6 +56,9 @@ class FrameBase : public MultibodyTreeElement<FrameBase<T>, FrameIndex> {
   //     const FrameBase<T> measured_in_frame) const;
   // That computes the pose of `this` frame as measured in the
   // `measured_in_frame` frame.
+ protected:
+  explicit FrameBase(ModelInstanceIndex model_instance)
+      : MultibodyTreeElement<FrameBase<T>, FrameIndex>(model_instance) {}
 };
 
 }  // namespace multibody

--- a/multibody/multibody_tree/joint_actuator.cc
+++ b/multibody/multibody_tree/joint_actuator.cc
@@ -33,11 +33,13 @@ void JointActuator<T>::AddInOneForce(
 
 template <typename T>
 void JointActuator<T>::set_actuation_vector(
-    const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
+    const Eigen::Ref<const VectorX<T>>& u_instance,
+    EigenPtr<VectorX<T>> u) const {
   DRAKE_DEMAND(u != nullptr);
   DRAKE_DEMAND(u->size() == this->get_parent_tree().num_actuated_dofs());
-  DRAKE_DEMAND(u_a.size() == joint().num_dofs());
-  u->segment(topology_.actuator_index_start, joint().num_dofs()) = u_a;
+  DRAKE_DEMAND(u_instance.size() == joint().num_dofs());
+  u->segment(topology_.actuator_index_start, joint().num_dofs()) =
+      u_instance;
 }
 
 template <typename T>

--- a/multibody/multibody_tree/joint_actuator.cc
+++ b/multibody/multibody_tree/joint_actuator.cc
@@ -10,7 +10,9 @@ namespace multibody {
 template <typename T>
 JointActuator<T>::JointActuator(
     const std::string& name, const Joint<T>& joint)
-    : name_(name), joint_index_(joint.index()) {}
+    : MultibodyTreeElement<JointActuator<T>, JointActuatorIndex>(
+          joint.model_instance()),
+    name_(name), joint_index_(joint.index()) {}
 
 template <typename T>
 const Joint<T>& JointActuator<T>::joint() const {

--- a/multibody/multibody_tree/joint_actuator.h
+++ b/multibody/multibody_tree/joint_actuator.h
@@ -84,9 +84,9 @@ class JointActuator final
       const T& tau,
       MultibodyForces<T>* forces) const;
 
-  /// Given the actuation values u for `this` actuator, this method sets the
-  /// actuation vector u for the entire %MultibodyTree model to which this
-  /// actuator belongs to.
+  /// Given the actuation values u_a for `this` actuator, this method
+  /// sets the actuation vector u for the entire MultibodyTree model
+  /// to which this actuator belongs to.
   /// @param[in] u_a
   ///   Actuation values for `this` actuator. It must be of size equal to the
   ///   number of degrees of freedom of the actuated Joint, see

--- a/multibody/multibody_tree/joint_actuator.h
+++ b/multibody/multibody_tree/joint_actuator.h
@@ -84,10 +84,10 @@ class JointActuator final
       const T& tau,
       MultibodyForces<T>* forces) const;
 
-  /// Given the actuation values u_a for `this` actuator, this method
+  /// Given the actuation values u_instance for `this` actuator, this method
   /// sets the actuation vector u for the entire MultibodyTree model
   /// to which this actuator belongs to.
-  /// @param[in] u_a
+  /// @param[in] u_instance
   ///   Actuation values for `this` actuator. It must be of size equal to the
   ///   number of degrees of freedom of the actuated Joint, see
   ///   Joint::num_dofs(). For units and sign conventions refer to the specific
@@ -95,11 +95,12 @@ class JointActuator final
   /// @param[out] u
   ///   The vector containing the actuation values for the entire MultibodyTree
   ///   model to which `this` actuator belongs to.
-  /// @throws if `u_a.size() != this->joint().num_dofs()`.
+  /// @throws if `u_instance.size() != this->joint().num_dofs()`.
   /// @throws if u is nullptr.
   /// @throws if `u.size() != this->get_parent_tree().num_actuated_dofs()`.
   void set_actuation_vector(
-      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const;
+      const Eigen::Ref<const VectorX<T>>& u_instance,
+      EigenPtr<VectorX<T>> u) const;
 
   /// @cond
   // For internal use only.

--- a/multibody/multibody_tree/joints/joint.h
+++ b/multibody/multibody_tree/joints/joint.h
@@ -17,13 +17,6 @@
 namespace drake {
 namespace multibody {
 
-namespace internal {
-// This is a class used by MultibodyTree internals to create the implementation
-// for a particular joint object.
-template <typename T>
-class JointImplementationBuilder;
-}  // namespace internal
-
 /// A %Joint models the kinematical relationship which characterizes the
 /// possible relative motion between two bodies.
 /// The two bodies connected by a %Joint object are referred to as the
@@ -79,8 +72,10 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
 
   /// Creates a joint between two Frame objects which imposes a given kinematic
   /// relation between frame F attached on the parent body P and frame M
-  /// attached on the child body B. See this class's documentation for further
-  /// details.
+  /// attached on the child body B. The joint will be initialized to the model
+  /// instance from @p frame_on_child (this is the typical convention for joints
+  /// between the world and a model, or between two models (e.g. an arm to a
+  /// gripper)).  See this class's documentation for further details.
   ///
   /// @param[in] name
   ///   A string with a name identifying `this` joint.
@@ -89,9 +84,11 @@ class Joint : public MultibodyTreeElement<Joint<T>, JointIndex>  {
   /// @param[in] frame_on_child
   ///   The frame M attached on the child body connected by this joint.
   Joint(const std::string& name,
-        const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child) :
-      name_(name),
-      frame_on_parent_(frame_on_parent), frame_on_child_(frame_on_child) {
+        const Frame<T>& frame_on_parent, const Frame<T>& frame_on_child)
+      : MultibodyTreeElement<Joint<T>, JointIndex>(
+            frame_on_child.model_instance()),
+        name_(name),
+        frame_on_parent_(frame_on_parent), frame_on_child_(frame_on_child) {
     // Notice `this` joint references `frame_on_parent` and `frame_on_child` and
     // therefore they must outlive it.
   }

--- a/multibody/multibody_tree/mobilizer.h
+++ b/multibody/multibody_tree/mobilizer.h
@@ -443,8 +443,7 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// Returns a const Eigen expression of the vector of generalized positions
   /// for `this` mobilizer from a vector `q_array` of generalized positions for
   /// the entire MultibodyTree model.
-  /// This method aborts if `q_array` is not of size
-  /// MultibodyTree::num_positions().
+  /// @pre @p q_array is of size MultibodyTree::num_positions().
   Eigen::VectorBlock<const Eigen::Ref<const VectorX<T>>>
   get_positions_from_array(const Eigen::Ref<const VectorX<T>>& q_array) const {
     DRAKE_DEMAND(
@@ -466,8 +465,7 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// Returns a const Eigen expression of the vector of generalized velocities
   /// for `this` mobilizer from a vector `v_array` of generalized velocities for
   /// the entire MultibodyTree model.
-  /// This method aborts if the input array is not of size
-  /// MultibodyTree::num_velocities().
+  /// @pre @p v_array is of size MultibodyTree::num_velocities().
   Eigen::VectorBlock<const Eigen::Ref<const VectorX<T>>>
   get_velocities_from_array(const Eigen::Ref<const VectorX<T>>& v_array) const {
     DRAKE_DEMAND(

--- a/multibody/multibody_tree/model_instance.cc
+++ b/multibody/multibody_tree/model_instance.cc
@@ -10,16 +10,18 @@ namespace internal {
 
 template <typename T>
 void ModelInstance<T>::set_actuation_vector(
-    const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
+    const Eigen::Ref<const VectorX<T>>& u_instance,
+    EigenPtr<VectorX<T>> u) const {
   DRAKE_DEMAND(u != nullptr);
   DRAKE_DEMAND(u->size() == this->get_parent_tree().num_actuated_dofs());
-  DRAKE_DEMAND(u_a.size() == num_actuated_dofs_);
-  int u_a_offset = 0;
+  DRAKE_DEMAND(u_instance.size() == num_actuated_dofs_);
+  int u_instance_offset = 0;
   for (const JointActuator<T>* actuator : joint_actuators_) {
     const int num_dofs = actuator->joint().num_dofs();
-    actuator->set_actuation_vector(u_a.segment(u_a_offset, num_dofs), u);
-    u_a_offset += num_dofs;
-    DRAKE_DEMAND(u_a_offset <= u->size());
+    actuator->set_actuation_vector(
+        u_instance.segment(u_instance_offset, num_dofs), u);
+    u_instance_offset += num_dofs;
+    DRAKE_DEMAND(u_instance_offset <= u->size());
   }
 }
 

--- a/multibody/multibody_tree/model_instance.cc
+++ b/multibody/multibody_tree/model_instance.cc
@@ -1,0 +1,65 @@
+#include "drake/multibody/multibody_tree/model_instance.h"
+
+#include "drake/common/default_scalars.h"
+#include "drake/multibody/multibody_tree/joints/joint.h"
+#include "drake/multibody/multibody_tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+namespace internal {
+
+template <typename T>
+void ModelInstance<T>::set_actuation_vector(
+    const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
+  DRAKE_DEMAND(u != nullptr);
+  DRAKE_DEMAND(u->size() == this->get_parent_tree().num_actuated_dofs());
+  DRAKE_DEMAND(u_a.size() == num_actuated_dofs_);
+  int u_a_offset = 0;
+  for (const JointActuator<T>* actuator : joint_actuators_) {
+    const int num_dofs = actuator->joint().num_dofs();
+    actuator->set_actuation_vector(u_a.segment(u_a_offset, num_dofs), u);
+    u_a_offset += num_dofs;
+    DRAKE_DEMAND(u_a_offset <= u->size());
+  }
+}
+
+template <typename T>
+VectorX<T> ModelInstance<T>::get_positions_from_array(
+    const Eigen::Ref<const VectorX<T>>& q_array) const {
+  DRAKE_DEMAND(
+      q_array.size() == this->get_parent_tree().num_positions());
+  VectorX<T> positions(num_positions_);
+  int position_offset = 0;
+  for (const Mobilizer<T>* mobilizer : mobilizers_) {
+    const int mobilizer_positions = mobilizer->num_positions();
+    positions.segment(position_offset, mobilizer_positions) =
+        mobilizer->get_positions_from_array(q_array);
+    position_offset += mobilizer_positions;
+    DRAKE_DEMAND(position_offset <= positions.size());
+  }
+  return positions;
+}
+
+template <typename T>
+VectorX<T> ModelInstance<T>::get_velocities_from_array(
+    const Eigen::Ref<const VectorX<T>>& v_array) const {
+  DRAKE_DEMAND(
+      v_array.size() == this->get_parent_tree().num_velocities());
+  VectorX<T> velocities(num_velocities_);
+  int velocity_offset = 0;
+  for (const Mobilizer<T>* mobilizer : mobilizers_) {
+    const int mobilizer_velocities = mobilizer->num_velocities();
+    velocities.segment(velocity_offset, mobilizer_velocities) =
+        mobilizer->get_velocities_from_array(v_array);
+    velocity_offset += mobilizer_velocities;
+    DRAKE_DEMAND(velocity_offset <= velocities.size());
+  }
+  return velocities;
+}
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::multibody::internal::ModelInstance)

--- a/multibody/multibody_tree/model_instance.h
+++ b/multibody/multibody_tree/model_instance.h
@@ -101,18 +101,19 @@ class ModelInstance :
     joint_actuators_.push_back(joint_actuator);
   }
 
-  /// Given the actuation values @p u_a for all actuators in `this` model
+  /// Given the actuation values @p u_instance for all actuators in `this` model
   /// instance, this method sets the portion of the actuation vector @p u (which
   /// is the actuation vector for the entire MultibodyTee) corresponding to the
   /// actuators for this model instance.
-  /// @param[in] u_a Actuation values for the actuators. It must be of size
-  ///   equal to the number of degrees of freedom of all of the actuated
+  /// @param[in] u_instance Actuation values for the actuators. It must be of
+  ///   size equal to the number of degrees of freedom of all of the actuated
   ///   joints in this model instance.
   /// @param[out] u
   ///   The vector containing the actuation values for the entire MultibodyTree
   ///   model to which `this` actuator belongs to.
   void set_actuation_vector(
-      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const;
+      const Eigen::Ref<const VectorX<T>>& u_instance,
+      EigenPtr<VectorX<T>> u) const;
 
   /// Returns a const Eigen expression of the vector of generalized positions
   /// for `this` model instance from a vector `q_array` of generalized

--- a/multibody/multibody_tree/model_instance.h
+++ b/multibody/multibody_tree/model_instance.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/eigen_types.h"
+#include "drake/multibody/multibody_tree/joint_actuator.h"
+#include "drake/multibody/multibody_tree/mobilizer.h"
+#include "drake/multibody/multibody_tree/multibody_tree_element.h"
+#include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
+
+namespace drake {
+namespace multibody {
+
+/// @file
+/// Model instance information for multibody trees.
+///
+/// A MultiBodyTree is composed of a number of MultibodyTreeElement items.  In
+/// more complex trees, these items will be loaded from multiple models
+/// (e.g. robot arm, attached gripper, free bodies being manipulated).  Each
+/// model may have a different controller or observer, so the ability to view
+/// the state or command actuation for each model independently can be useful.
+/// For this reason, elements are associated with a ModelInstanceIndex to
+/// determine which model an element belongs to.  In most cases, the allocation
+/// of model instances and assignment of elements to the appropriate model
+/// instance will be handled by the parser loading the model.
+///
+/// There are two special ModelElementIndex values.  The world body is always
+/// ModelInstanceIndex 0, and ModelInstanceIndex 1 is reserved for all elements
+/// with no explicit model instance.  This is generally only relevant for
+/// elements created programmatically (and for which a model instance is not
+/// explicitly specified), as model parsers should handle creating model
+/// elements as needed.
+///
+/// For different types of MultibodyTreeElement, the model instance is
+/// sometimes specified explicitly, and sometimes inferred when the
+/// element is created.  The current convention is:
+///
+/// * Body: Specified at creation
+/// * BodyNode: Same as the associated Body
+/// * Frame: Same as the associated Body
+/// * Joint: Same as the child frame
+/// * JointActuator: Same as the associated Joint
+/// * Mobilizer:
+///   * Same as the joint (if created from a joint)
+///   * Same as the body (for free floating bodies)
+///   * When creating mobilizers for other reasons (e.g. for unit tests) the
+///     author should take care to choose a reasonable model instance.
+/// * ForceElement: Depends on the type of element
+///   * UniformGravityFieldElement: uses the world model instance
+
+// Note:
+//   static global variables are strongly discouraged by the C++ style guide:
+// https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables
+// For this reason, we create and return an instance of ModelInstanceIndex
+// instead of using a static variable.
+
+/// Returns the model instance containing the *world* body.  For
+/// every MultibodyTree the **world** body _always_ has this unique
+/// model instance and it is always zero (as described in #3088).
+inline ModelInstanceIndex world_model_instance() {
+  return ModelInstanceIndex(0);
+}
+
+/// Returns the model instance which contains all tree elements with
+/// no explicit model instance specified.
+inline ModelInstanceIndex default_model_instance() {
+  return ModelInstanceIndex(1);
+}
+
+namespace internal {
+
+/// @tparam T The scalar type. Must be a valid Eigen scalar.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+template <typename T>
+class ModelInstance :
+      public MultibodyTreeElement<ModelInstance<T>, ModelInstanceIndex> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ModelInstance)
+
+  explicit ModelInstance(ModelInstanceIndex index)
+      : MultibodyTreeElement<ModelInstance<T>, ModelInstanceIndex>(index) {}
+
+  int num_positions() const { return num_positions_; }
+  int num_velocities() const { return num_velocities_; }
+  int num_states() const { return num_positions_ + num_velocities_; }
+  int num_actuated_dofs() const { return num_actuated_dofs_; }
+
+  void add_mobilizer(const Mobilizer<T>* mobilizer) {
+    num_positions_ += mobilizer->num_positions();
+    num_velocities_ += mobilizer->num_velocities();
+    mobilizers_.push_back(mobilizer);
+  }
+
+  void add_joint_actuator(const JointActuator<T>* joint_actuator) {
+    num_actuated_dofs_ += joint_actuator->joint().num_dofs();
+    joint_actuators_.push_back(joint_actuator);
+  }
+
+  /// Given the actuation values @p u_a for all actuators in `this` model
+  /// instance, this method sets the portion of the actuation vector @p u (which
+  /// is the actuation vector for the entire MultibodyTee) corresponding to the
+  /// actuators for this model instance.
+  /// @param[in] u_a Actuation values for the actuators. It must be of size
+  ///   equal to the number of degrees of freedom of all of the actuated
+  ///   joints in this model instance.
+  /// @param[out] u
+  ///   The vector containing the actuation values for the entire MultibodyTree
+  ///   model to which `this` actuator belongs to.
+  void set_actuation_vector(
+      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const;
+
+  /// Returns a const Eigen expression of the vector of generalized positions
+  /// for `this` model instance from a vector `q_array` of generalized
+  /// positions for the entire MultibodyTree model.
+  /// @pre @p q_array is of size MultibodyTree::num_positions().
+  VectorX<T> get_positions_from_array(
+      const Eigen::Ref<const VectorX<T>>& q_array) const;
+
+  /// Returns a const Eigen expression of the vector of generalized velocities
+  /// for `this` mobilizer from a vector `v_array` of generalized velocities for
+  /// the entire MultibodyTree model.
+  /// @pre @p v_array is of size MultibodyTree::num_velocities().
+  VectorX<T> get_velocities_from_array(
+      const Eigen::Ref<const VectorX<T>>& v_array) const;
+
+ private:
+  void DoSetTopology(const MultibodyTreeTopology&) final {}
+
+  int num_positions_{0};
+  int num_velocities_{0};
+  int num_actuated_dofs_{0};
+
+  std::vector<const Mobilizer<T>*> mobilizers_;
+  std::vector<const JointActuator<T>*> joint_actuators_;
+};
+
+}  // namespace internal
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -264,7 +264,9 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   const RigidBody<T>& AddRigidBody(
       const std::string& name, const SpatialInertia<double>& M_BBo_B) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    const RigidBody<T>& body = model_->AddRigidBody(name, M_BBo_B);
+    // TODO(sam.creasey) Expose model instances through MultibodyPlant.
+    const RigidBody<T>& body = model_->AddRigidBody(
+        name, default_model_instance(), M_BBo_B);
     // Each entry of visual_geometries_, ordered by body index, contains a
     // std::vector of geometry ids for that body. The emplace_back() below
     // resizes visual_geometries_ to store the geometry ids for the body we

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -32,16 +32,20 @@ template <typename T>
 class JointImplementationBuilder {
  public:
   JointImplementationBuilder() = delete;
-  static void Build(Joint<T>* joint, MultibodyTree<T>* tree) {
+  static std::vector<Mobilizer<T>*> Build(
+      Joint<T>* joint, MultibodyTree<T>* tree) {
+    std::vector<Mobilizer<T>*> mobilizers;
     std::unique_ptr<JointBluePrint> blue_print =
         joint->MakeImplementationBlueprint();
     auto implementation = std::make_unique<JointImplementation>(*blue_print);
     DRAKE_DEMAND(implementation->num_mobilizers() != 0);
     for (auto& mobilizer : blue_print->mobilizers_) {
+      mobilizers.push_back(mobilizer.get());
       tree->AddMobilizer(std::move(mobilizer));
     }
     // TODO(amcastro-tri): add force elements, bodies, constraints, etc.
     joint->OwnImplementation(std::move(implementation));
+    return mobilizers;
   }
  private:
   typedef typename Joint<T>::BluePrint JointBluePrint;
@@ -52,7 +56,41 @@ class JointImplementationBuilder {
 template <typename T>
 MultibodyTree<T>::MultibodyTree() {
   // Adds a "world" body to MultibodyTree having a NaN SpatialInertia.
-  world_body_ = &AddRigidBody("WorldBody", SpatialInertia<double>());
+  ModelInstanceIndex world_instance = AddModelInstance("WorldModelInstance");
+
+  // `world_model_instance()` hardcodes the returned index.  Make sure it's
+  // correct.
+  DRAKE_DEMAND(world_instance == world_model_instance());
+  world_body_ = &AddRigidBody("WorldBody", world_model_instance(),
+                              SpatialInertia<double>());
+
+  // `default_model_instance()` hardcodes the returned index.  Make sure it's
+  // correct.
+  ModelInstanceIndex default_instance =
+      AddModelInstance("DefaultModelInstance");
+  DRAKE_DEMAND(default_instance == default_model_instance());
+}
+
+template <typename T>
+void MultibodyTree<T>::set_actuation_vector(
+    ModelInstanceIndex model_instance,
+    const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
+  model_instances_.at(model_instance)->set_actuation_vector(u_a, u);
+}
+
+template <typename T>
+VectorX<T> MultibodyTree<T>::get_positions_from_array(
+    ModelInstanceIndex model_instance,
+    const Eigen::Ref<const VectorX<T>>& q_array) const {
+  return model_instances_.at(model_instance)->get_positions_from_array(q_array);
+}
+
+template <typename T>
+VectorX<T> MultibodyTree<T>::get_velocities_from_array(
+    ModelInstanceIndex model_instance,
+    const Eigen::Ref<const VectorX<T>>& v_array) const {
+  return model_instances_.at(model_instance)->get_velocities_from_array(
+      v_array);
 }
 
 template <typename T>
@@ -64,8 +102,11 @@ void MultibodyTree<T>:: AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer() {
     const BodyTopology& body_topology =
         get_topology().get_body(body.index());
     if (!body_topology.inboard_mobilizer.is_valid()) {
-      this->template AddMobilizer<QuaternionFloatingMobilizer>(
-          world_body().body_frame(), body.body_frame());
+      std::unique_ptr<QuaternionFloatingMobilizer<T>> mobilizer =
+          std::make_unique<QuaternionFloatingMobilizer<T>>(
+              world_body().body_frame(), body.body_frame());
+      mobilizer->set_model_instance(body.model_instance());
+      this->AddMobilizer(std::move(mobilizer));
     }
   }
 }
@@ -144,6 +185,8 @@ void MultibodyTree<T>::FinalizeInternals() {
     CreateBodyNode(body_node_index);
   }
 
+  CreateModelInstances();
+
   // TODO(amcastro-tri): Remove when MultibodyCachingEvaluatorInterface lands.
   AllocateFakeCacheEntries();
 }
@@ -164,7 +207,11 @@ void MultibodyTree<T>::Finalize() {
   // changes are NOT allowed after Finalize(), joint implementations MUST be
   // assembled BEFORE the tree's topology is finalized.
   for (auto& joint : owned_joints_) {
-    internal::JointImplementationBuilder<T>::Build(joint.get(), this);
+    std::vector<Mobilizer<T>*> mobilizers =
+        internal::JointImplementationBuilder<T>::Build(joint.get(), this);
+    for (Mobilizer<T>* mobilizer : mobilizers) {
+      mobilizer->set_model_instance(joint->model_instance());
+    }
   }
   // It is VERY important to add quaternions if needed only AFTER joints had a
   // chance to get implemented with mobilizers. This is because joints's
@@ -204,6 +251,37 @@ void MultibodyTree<T>::CreateBodyNode(BodyNodeIndex body_node_index) {
   body_node->SetTopology(topology_);
 
   body_nodes_.push_back(std::move(body_node));
+}
+
+template <typename T>
+void MultibodyTree<T>::CreateModelInstances() {
+  DRAKE_ASSERT(model_instances_.empty());
+
+  // First create the pool of instances.
+  for (ModelInstanceIndex model_instance_index(0);
+       model_instance_index < num_model_instances(); ++model_instance_index) {
+    std::unique_ptr<internal::ModelInstance<T>> model_instance =
+        std::make_unique<internal::ModelInstance<T>>(model_instance_index);
+    model_instance->set_parent_tree(this, model_instance_index);
+    model_instances_.push_back(std::move(model_instance));
+  }
+
+  // Add all of our mobilizers and joint actuators to the appropriate instance.
+  // The order of the mobilizers should match the order in which the bodies were
+  // added to the tree, which may not be the order in which the mobilizers were
+  // added, so we get the mobilizer through the BodyNode.
+  for (const auto& body_node : body_nodes_) {
+    if (body_node->get_num_mobilizer_positions() > 0 ||
+        body_node->get_num_mobilizer_velocities() > 0) {
+      model_instances_.at(body_node->model_instance())->add_mobilizer(
+          &body_node->get_mobilizer());
+    }
+  }
+
+  for (const auto& joint_actuator : owned_actuators_) {
+    model_instances_.at(joint_actuator->model_instance())->add_joint_actuator(
+        joint_actuator.get());
+  }
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -74,8 +74,9 @@ MultibodyTree<T>::MultibodyTree() {
 template <typename T>
 void MultibodyTree<T>::set_actuation_vector(
     ModelInstanceIndex model_instance,
-    const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const {
-  model_instances_.at(model_instance)->set_actuation_vector(u_a, u);
+    const Eigen::Ref<const VectorX<T>>& u_instance,
+    EigenPtr<VectorX<T>> u) const {
+  model_instances_.at(model_instance)->set_actuation_vector(u_instance, u);
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1015,17 +1015,18 @@ class MultibodyTree {
   /// those vectors which apply to a single model instance only.
   /// @{
 
-  /// Given the actuation values @p u_a for all actuators in @p model_instance,
-  /// this method sets the actuation vector u for the entire MultibodyTree model
-  /// to which this actuator belongs to.
-  /// @param[in] u_a Actuation values for the actuators. It must be of size
-  ///   equal to the number of degrees of freedom of all of the actuated
+  /// Given the actuation values @p u_instance for all actuators in @p
+  /// model_instance, this method sets the actuation vector u for the entire
+  /// MultibodyTree model to which this actuator belongs to.
+  /// @param[in] u_instance Actuation values for the actuators. It must be of
+  ///   size equal to the number of degrees of freedom of all of the actuated
   ///   joints in @p model_instance.
   /// @param[out] u
   ///   The vector containing the actuation values for the entire MultibodyTree.
   void set_actuation_vector(
       ModelInstanceIndex model_instance,
-      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const;
+      const Eigen::Ref<const VectorX<T>>& u_instance,
+      EigenPtr<VectorX<T>> u) const;
 
   /// Returns a vector of generalized positions for @p model_instance from a
   /// vector `q_array` of generalized positions for the entire MultibodyTree

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -19,6 +19,7 @@
 #include "drake/multibody/multibody_tree/joint_actuator.h"
 #include "drake/multibody/multibody_tree/joints/joint.h"
 #include "drake/multibody/multibody_tree/mobilizer.h"
+#include "drake/multibody/multibody_tree/model_instance.h"
 #include "drake/multibody/multibody_tree/multibody_forces.h"
 #include "drake/multibody/multibody_tree/multibody_tree_context.h"
 #include "drake/multibody/multibody_tree/multibody_tree_topology.h"
@@ -29,6 +30,16 @@
 
 namespace drake {
 namespace multibody {
+
+/// @cond
+// Helper macro to throw an exception within methods that should not be called
+// post-finalize.
+#define DRAKE_MBT_THROW_IF_FINALIZED() ThrowIfFinalized(__func__)
+
+// Helper macro to throw an exception within methods that should not be called
+// pre-finalize.
+#define DRAKE_MBT_THROW_IF_NOT_FINALIZED() ThrowIfNotFinalized(__func__)
+/// @endcond
 
 /// %MultibodyTree provides a representation for a physical system consisting of
 /// a collection of interconnected rigid and deformable bodies. As such, it owns
@@ -107,8 +118,9 @@ class MultibodyTree {
     std::tie(body_index, body_frame_index) = topology_.add_body();
     // These tests MUST be performed BEFORE frames_.push_back() and
     // owned_bodies_.push_back() below. Do not move them around!
-    DRAKE_ASSERT(body_index == num_bodies());
-    DRAKE_ASSERT(body_frame_index == num_frames());
+    DRAKE_DEMAND(body_index == num_bodies());
+    DRAKE_DEMAND(body_frame_index == num_frames());
+    DRAKE_DEMAND(body->model_instance().is_valid());
 
     // TODO(amcastro-tri): consider not depending on setting this pointer at
     // all. Consider also removing MultibodyTreeElement altogether.
@@ -163,9 +175,56 @@ class MultibodyTree {
     return AddBody(std::make_unique<BodyType<T>>(std::forward<Args>(args)...));
   }
 
-  /// Creates a rigid body model with the provided name and spatial inertia.
-  /// This method returns a constant reference to the body just added, which
-  /// will remain valid for the lifetime of `this` %MultibodyTree.
+  /// Creates a rigid body model with the provided name, model
+  /// instance, and spatial inertia.  This method returns a constant
+  /// reference to the body just added, which will remain valid for
+  /// the lifetime of `this` %MultibodyTree.
+  ///
+  /// Example of usage:
+  /// @code
+  ///   MultibodyTree<T> model;
+  ///   // ... Code to define spatial_inertia, a SpatialInertia<T> object ...
+  ///   ModelInstanceIndex model_instance = model.AddModelInstance("instance");
+  ///   const RigidBody<T>& body =
+  ///     model.AddRigidBody("BodyName", model_instance, spatial_inertia);
+  /// @endcode
+  ///
+  /// @param[in] name
+  ///   A string that uniquely identifies the new body to be added to `this`
+  ///   model. A std::runtime_error is thrown if a body named `name` already is
+  ///   part of the model. See HasBodyNamed(), Body::name().
+  /// @param[in] model_instance
+  ///   A model instance index which this body is part of.
+  /// @param[in] M_BBo_B
+  ///   The SpatialInertia of the new rigid body to be added to `this` model,
+  ///   computed about the body frame origin `Bo` and expressed in the body
+  ///   frame B.
+  /// @returns A constant reference to the new RigidBody just added, which will
+  ///          remain valid for the lifetime of `this` %MultibodyTree.
+  /// @throws std::logic_error if a body named `name` already exists.
+  /// @throws std::logic_error if the model instance does not exist.
+  const RigidBody<T>& AddRigidBody(
+      const std::string& name, ModelInstanceIndex model_instance,
+      const SpatialInertia<double>& M_BBo_B) {
+    if (HasBodyNamed(name)) {
+      throw std::logic_error(
+          "This model already contains a body named '" + name + "'. " +
+          "Body names must be unique within a given model.");
+    }
+    if (model_instance >= num_model_instances()) {
+      throw std::logic_error("Invalid model instance specified.");
+    }
+
+    const RigidBody<T>& body =
+        this->template AddBody<RigidBody>(name, model_instance, M_BBo_B);
+    body_name_to_index_[name] = body.index();
+    return body;
+  }
+
+  /// Creates a rigid body model with the provided name, model instance, and
+  /// spatial inertia.  The newly created body will be placed in the default
+  /// model instance.  This method returns a constant reference to the body just
+  /// added, which will remain valid for the lifetime of `this` %MultibodyTree.
   ///
   /// Example of usage:
   /// @code
@@ -185,16 +244,18 @@ class MultibodyTree {
   ///   frame B.
   /// @returns A constant reference to the new RigidBody just added, which will
   ///          remain valid for the lifetime of `this` %MultibodyTree.
+  /// @throws std::logic_error if a body named `name` already exists.
+  /// @throws std::logic_error if additional model instances have been created
+  ///                          beyond the world and default instances.
   const RigidBody<T>& AddRigidBody(
       const std::string& name, const SpatialInertia<double>& M_BBo_B) {
-    if (HasBodyNamed(name)) {
+    if (num_model_instances() != 2) {
       throw std::logic_error(
-          "This model already contains a body named '" + name + "'. " +
-          "Body names must be unique within a given model.");
+          "This model has more model instances than the default.  Please "
+          "call AddRigidBody with an explicit model instance.");
     }
-    const RigidBody<T>& body = this->template AddBody<RigidBody>(name, M_BBo_B);
-    body_name_to_index_[name] = body.index();
-    return body;
+
+    return AddRigidBody(name, default_model_instance(), M_BBo_B);
   }
 
   /// Takes ownership of `frame` and adds it to `this` %MultibodyTree. Returns
@@ -237,7 +298,9 @@ class MultibodyTree {
     FrameIndex frame_index = topology_.add_frame(frame->body().index());
     // This test MUST be performed BEFORE frames_.push_back() and
     // owned_frames_.push_back() below. Do not move it around!
-    DRAKE_ASSERT(frame_index == num_frames());
+    DRAKE_DEMAND(frame_index == num_frames());
+    DRAKE_DEMAND(frame->model_instance().is_valid());
+
     // TODO(amcastro-tri): consider not depending on setting this pointer at
     // all. Consider also removing MultibodyTreeElement altogether.
     frame->set_parent_tree(this, frame_index);
@@ -301,7 +364,7 @@ class MultibodyTree {
   ///   // MultibodyTree::AddFrame() ...
   ///   const RevoluteMobilizer<T>& pin =
   ///     model.AddMobilizer(std::make_unique<RevoluteMobilizer<T>>(
-  ///       inboard_frame, elbow_outboard_frame,
+  ///       inboard_frame, outboard_frame,
   ///       Vector3d::UnitZ() /*revolute axis*/));
   /// @endcode
   ///
@@ -358,6 +421,14 @@ class MultibodyTree {
     // This DRAKE_ASSERT MUST be performed BEFORE owned_mobilizers_.push_back()
     // below. Do not move it around!
     DRAKE_ASSERT(mobilizer_index == num_mobilizers());
+
+    // TODO(sammy-tri) This effectively means that there's no way to
+    // programatically add mobilizers from outside of MultibodyTree
+    // itself with multiple model instances.  I'm not convinced that
+    // this is a problem.
+    if (!mobilizer->model_instance().is_valid()) {
+      mobilizer->set_model_instance(default_model_instance());
+    }
 
     // TODO(amcastro-tri): consider not depending on setting this pointer at
     // all. Consider also removing MultibodyTreeElement altogether.
@@ -438,8 +509,10 @@ class MultibodyTree {
     ForceElementIndex force_element_index = topology_.add_force_element();
     // This test MUST be performed BEFORE owned_force_elements_.push_back()
     // below. Do not move it around!
-    DRAKE_ASSERT(force_element_index == num_force_elements());
+    DRAKE_DEMAND(force_element_index == num_force_elements());
+    DRAKE_DEMAND(force_element->model_instance().is_valid());
     force_element->set_parent_tree(this, force_element_index);
+
     ForceElementType<T>* raw_force_element_ptr = force_element.get();
     owned_force_elements_.push_back(std::move(force_element));
     return *raw_force_element_ptr;
@@ -464,7 +537,7 @@ class MultibodyTree {
   /// bodies.
   /// As explained in the Joint class's documentation, in Drake we define a
   /// frame F attached to the parent body P with pose `X_PF` and a frame M
-  /// attached to the child body B with pose `X_BM`. This method helps creating
+  /// attached to the child body B with pose `X_BM`. This method helps create
   /// a joint between two bodies with fixed poses `X_PF` and `X_BM`.
   /// Refer to the Joint class's documentation for more details.
   ///
@@ -472,7 +545,7 @@ class MultibodyTree {
   /// constructor. The newly created `JointType` object will be specialized on
   /// the scalar type T of this %MultibodyTree.
   ///
-  /// @param name
+  /// @param[in] name
   ///   The name of the joint.
   /// @param[in] parent
   ///   The parent body connected by the new joint.
@@ -598,6 +671,32 @@ class MultibodyTree {
     return *actuator;
   }
 
+  /// Creates a new model instance.  Returns the index for a new model
+  /// instance (as there is no concrete object beyond the index).
+  ///
+  /// @param[in] name
+  ///   A string that uniquely identifies the new instance to be added to `this`
+  ///   model. An exception is thrown if an instance with the same name
+  ///   already exists in the model. See HasModelInstanceNamed().
+  /// @throws std::logic_error if Finalize() was already called on `this` tree.
+  ModelInstanceIndex AddModelInstance(const std::string& name) {
+    if (HasModelInstanceNamed(name)) {
+      throw std::logic_error(
+          "This model already contains a model instance named '" + name +
+          "'. Model instancs names must be unique within a given model.");
+    }
+
+    if (topology_is_valid()) {
+      throw std::logic_error("This MultibodyTree is finalized already. "
+                             "Therefore adding more model instances is not "
+                             "allowed. See documentation for Finalize() for "
+                             "details.");
+    }
+    const ModelInstanceIndex index(num_model_instances());
+    instance_name_to_index_[name] = index;
+    return index;
+  }
+
   /// @}
   // Closes Doxygen section "Methods to add new MultibodyTree elements."
 
@@ -637,9 +736,20 @@ class MultibodyTree {
     return static_cast<int>(owned_force_elements_.size());
   }
 
+  /// Returns the number of model instances in the MultibodyTree.
+  int num_model_instances() const {
+    return static_cast<int>(instance_name_to_index_.size());
+  }
+
   /// Returns the number of generalized positions of the model.
   int num_positions() const {
     return topology_.num_positions();
+  }
+
+  /// Returns the number of generalized positions in a specific model instance.
+  int num_positions(ModelInstanceIndex model_instance) const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+    return model_instances_.at(model_instance)->num_positions();
   }
 
   /// Returns the number of generalized velocities of the model.
@@ -647,15 +757,35 @@ class MultibodyTree {
     return topology_.num_velocities();
   }
 
+  /// Returns the number of generalized velocities in a specific model instance.
+  int num_velocities(ModelInstanceIndex model_instance) const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+    return model_instances_.at(model_instance)->num_velocities();
+  }
+
   /// Returns the total size of the state vector in the model.
   int num_states() const {
     return topology_.num_states();
+  }
+
+  /// Returns the total size of the state vector in a specific model instance.
+  int num_states(ModelInstanceIndex model_instance) const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+    return model_instances_.at(model_instance)->num_positions() +
+        model_instances_.at(model_instance)->num_velocities();
   }
 
   /// Returns the total number of Joint degrees of freedom actuated by the set
   /// of JointActuator elements added to `this` model.
   int num_actuated_dofs() const {
     return topology_.num_actuated_dofs();
+  }
+
+  /// Returns the total number of Joint degrees of freedom actuated by the set
+  /// of JointActuator elements added to a specific model instance.
+  int num_actuated_dofs(ModelInstanceIndex model_instance) const {
+    DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+    return model_instances_.at(model_instance)->num_actuated_dofs();
   }
 
   /// Returns the height of the tree data structure of `this` %MultibodyTree.
@@ -751,6 +881,12 @@ class MultibodyTree {
   bool HasJointActuatorNamed(const std::string& name) const {
     return actuator_name_to_index_.find(name) != actuator_name_to_index_.end();
   }
+
+  /// @returns `true` if a model instance named `name` was added to the model.
+  /// @see AddModelInstance().
+  bool HasModelInstanceNamed(const std::string& name) const {
+    return instance_name_to_index_.find(name) != instance_name_to_index_.end();
+  }
   /// @}
 
   /// @name Retrieving multibody elements by name
@@ -843,6 +979,20 @@ class MultibodyTree {
     }
     return get_joint_actuator(it->second);
   }
+
+  /// Returns the index to the model instance that is uniquely identified
+  /// by the string `name` in `this` model.
+  /// @throws std::logic_error if there is no instance with the requested name.
+  /// @see HasModelInstanceNamed() to query if there exists an instance in
+  /// `this` model with a given specified name.
+  ModelInstanceIndex GetModelInstanceByName(const std::string& name) const {
+    const auto it = instance_name_to_index_.find(name);
+    if (it == instance_name_to_index_.end()) {
+      throw std::logic_error("There is no model instance named '" + name +
+          "' in the model.");
+    }
+    return it->second;
+  }
   /// @}
 
   /// Returns `true` if this %MultibodyTree was finalized with Finalize() after
@@ -857,6 +1007,44 @@ class MultibodyTree {
   /// bookkeeping detail. Used at Finalize() stage by multibody elements to
   /// retrieve a local copy of their topology.
   const MultibodyTreeTopology& get_topology() const { return topology_; }
+
+  /// @name Model instance accessors
+  /// Many functions on %MultibodyTree expect vectors of tree state or
+  /// joint actuator inputs which encompass the entire tree.  Methods
+  /// in this section are convenience accessors for the portion of
+  /// those vectors which apply to a single model instance only.
+  /// @{
+
+  /// Given the actuation values @p u_a for all actuators in @p model_instance,
+  /// this method sets the actuation vector u for the entire MultibodyTree model
+  /// to which this actuator belongs to.
+  /// @param[in] u_a Actuation values for the actuators. It must be of size
+  ///   equal to the number of degrees of freedom of all of the actuated
+  ///   joints in @p model_instance.
+  /// @param[out] u
+  ///   The vector containing the actuation values for the entire MultibodyTree.
+  void set_actuation_vector(
+      ModelInstanceIndex model_instance,
+      const Eigen::Ref<const VectorX<T>>& u_a, EigenPtr<VectorX<T>> u) const;
+
+  /// Returns a vector of generalized positions for @p model_instance from a
+  /// vector `q_array` of generalized positions for the entire MultibodyTree
+  /// model.  This method aborts if `q_array` is not of size
+  /// MultibodyTree::num_positions().
+  VectorX<T> get_positions_from_array(
+      ModelInstanceIndex model_instance,
+      const Eigen::Ref<const VectorX<T>>& q_array) const;
+
+  /// Returns a vector of generalized velocities for @p model_instance from a
+  /// vector `v_array` of generalized velocities for the entire MultibodyTree
+  /// model.  This method aborts if the input array is not of size
+  /// MultibodyTree::num_velocities().
+  VectorX<T> get_velocities_from_array(
+      ModelInstanceIndex model_instance,
+      const Eigen::Ref<const VectorX<T>>& v_array) const;
+
+  /// @}
+  // End of "Model instance accessors" section.
 
   /// This method must be called after all elements in the tree (joints, bodies,
   /// force elements, constraints) were added and before any computations are
@@ -1804,6 +1992,7 @@ class MultibodyTree {
     tree_clone->body_name_to_index_ = this->body_name_to_index_;
     tree_clone->joint_name_to_index_ = this->joint_name_to_index_;
     tree_clone->actuator_name_to_index_ = this->actuator_name_to_index_;
+    tree_clone->instance_name_to_index_ = this->instance_name_to_index_;
 
     // All other internals templated on T are created with the following call to
     // FinalizeInternals().
@@ -1938,6 +2127,8 @@ class MultibodyTree {
 
   void CreateBodyNode(BodyNodeIndex body_node_index);
 
+  void CreateModelInstances();
+
   // Helper method to create a clone of `frame` and add it to `this` tree.
   template <typename FromScalar>
   Frame<T>* CloneFrameAndAdd(const Frame<FromScalar>& frame) {
@@ -1945,6 +2136,7 @@ class MultibodyTree {
 
     auto frame_clone = frame.CloneToScalar(*this);
     frame_clone->set_parent_tree(this, frame_index);
+    frame_clone->set_model_instance(frame.model_instance());
 
     Frame<T>* raw_frame_clone_ptr = frame_clone.get();
     // The order in which frames are added into frames_ is important to keep the
@@ -1968,11 +2160,13 @@ class MultibodyTree {
 
     auto body_clone = body.CloneToScalar(*this);
     body_clone->set_parent_tree(this, body_index);
+    body_clone->set_model_instance(body.model_instance());
     // MultibodyTree can access selected private methods in Body through its
     // BodyAttorney.
     Frame<T>* body_frame_clone =
         &internal::BodyAttorney<T>::get_mutable_body_frame(body_clone.get());
     body_frame_clone->set_parent_tree(this, body_frame_index);
+    body_frame_clone->set_model_instance(body.model_instance());
 
     // The order in which frames are added into frames_ is important to keep the
     // topology invariant. Therefore we index new clones according to the
@@ -1993,6 +2187,7 @@ class MultibodyTree {
     MobilizerIndex mobilizer_index = mobilizer.index();
     auto mobilizer_clone = mobilizer.CloneToScalar(*this);
     mobilizer_clone->set_parent_tree(this, mobilizer_index);
+    mobilizer_clone->set_model_instance(mobilizer.model_instance());
     Mobilizer<T>* raw_mobilizer_clone_ptr = mobilizer_clone.get();
     owned_mobilizers_.push_back(std::move(mobilizer_clone));
     return raw_mobilizer_clone_ptr;
@@ -2006,6 +2201,7 @@ class MultibodyTree {
     ForceElementIndex force_element_index = force_element.index();
     auto force_element_clone = force_element.CloneToScalar(*this);
     force_element_clone->set_parent_tree(this, force_element_index);
+    force_element_clone->set_model_instance(force_element.model_instance());
     owned_force_elements_.push_back(std::move(force_element_clone));
   }
 
@@ -2015,6 +2211,7 @@ class MultibodyTree {
     JointIndex joint_index = joint.index();
     auto joint_clone = joint.CloneToScalar(*this);
     joint_clone->set_parent_tree(this, joint_index);
+    joint_clone->set_model_instance(joint.model_instance());
     owned_joints_.push_back(std::move(joint_clone));
     return owned_joints_.back().get();
   }
@@ -2028,6 +2225,7 @@ class MultibodyTree {
     std::unique_ptr<JointActuator<T>> actuator_clone =
         actuator.CloneToScalar(*this);
     actuator_clone->set_parent_tree(this, actuator_index);
+    actuator_clone->set_model_instance(actuator.model_instance());
     owned_actuators_.push_back(std::move(actuator_clone));
   }
 
@@ -2126,6 +2324,7 @@ class MultibodyTree {
   std::vector<std::unique_ptr<ForceElement<T>>> owned_force_elements_;
   std::vector<std::unique_ptr<JointActuator<T>>> owned_actuators_;
   std::vector<std::unique_ptr<internal::BodyNode<T>>> body_nodes_;
+  std::vector<std::unique_ptr<internal::ModelInstance<T>>> model_instances_;
 
   std::vector<std::unique_ptr<Joint<T>>> owned_joints_;
 
@@ -2146,6 +2345,9 @@ class MultibodyTree {
   // Map used to find actuator indexes by their actuator name.
   std::unordered_map<std::string, JointActuatorIndex> actuator_name_to_index_;
 
+  // Map used to find a model instance index by its model instance name.
+  std::unordered_map<std::string, ModelInstanceIndex> instance_name_to_index_;
+
   // Body node indexes ordered by level (a.k.a depth). Therefore for the
   // i-th level body_node_levels_[i] contains the list of all body node indexes
   // in that level.
@@ -2158,6 +2360,16 @@ class MultibodyTree {
   std::unique_ptr<PositionKinematicsCache<T>> pc_;
   std::unique_ptr<VelocityKinematicsCache<T>> vc_;
 };
+
+/// @cond
+// Undef macros defined at the top of the file. From the GSG:
+// "Exporting macros from headers (i.e. defining them in a header without
+// #undefing them before the end of the header) is extremely strongly
+// discouraged."
+// This will require us to re-define them in the .cc file.
+#undef DRAKE_MBT_THROW_IF_FINALIZED
+#undef DRAKE_MBT_THROW_IF_NOT_FINALIZED
+/// @endcond
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/multibody_tree/multibody_tree_element.h
+++ b/multibody/multibody_tree/multibody_tree_element.h
@@ -2,6 +2,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
+#include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
 #include "drake/multibody/multibody_tree/multibody_tree_topology.h"
 
 namespace drake {
@@ -9,6 +10,13 @@ namespace multibody {
 
 // Forward declaration.
 template<typename T> class MultibodyTree;
+
+namespace internal {
+// This is a class used by MultibodyTree internals to create the implementation
+// for a particular joint object.
+template <typename T>
+class JointImplementationBuilder;
+}  // namespace internal
 
 // Primary template defining the signature of this class.
 // Two template arguments are required in general, the type of the class
@@ -85,6 +93,9 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   /// Returns this element's unique index in its parent MultibodyTree.
   ElementIndexType index() const { return index_;}
 
+  /// Returns this element's model instance index in its parent MultibodyTree.
+  ModelInstanceIndex model_instance() const { return model_instance_;}
+
   /// Checks whether this MultibodyTreeElement has been registered into a
   /// MultibodyTree. If not, it throws an exception of type std::logic_error.
   void HasParentTreeOrThrow() const {
@@ -131,6 +142,10 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   /// their default constructors if they need to.
   MultibodyTreeElement() {}
 
+  /// Constructor which allows specifying a model instance.
+  explicit MultibodyTreeElement(ModelInstanceIndex model_instance)
+      : model_instance_(model_instance) {}
+
   /// Gives MultibodyTree elements the opportunity to retrieve their topology
   /// when MultibodyTree::Finalize() is invoked.
   /// NVI to pure virtual method DoSetTopology().
@@ -149,6 +164,10 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
     parent_tree_ = tree;
   }
 
+  void set_model_instance(ModelInstanceIndex model_instance) {
+    model_instance_ = model_instance;
+  }
+
   // MultibodyTree<T> is a natural friend of MultibodyTreeElement objects and
   // therefore it can set the owning parent tree and unique index in that tree.
   friend class MultibodyTree<T>;
@@ -158,6 +177,10 @@ class MultibodyTreeElement<ElementType<T>, ElementIndexType> {
   // The default index value is *invalid*. This must be set to a valid index
   // value before the element is released to the wild.
   ElementIndexType index_;
+
+  // The default model instance id is *invalid*. This must be set to a
+  // valid index value before the element is released to the wild.
+  ModelInstanceIndex model_instance_;
 };
 
 }  // namespace multibody

--- a/multibody/multibody_tree/multibody_tree_indexes.h
+++ b/multibody/multibody_tree/multibody_tree_indexes.h
@@ -27,11 +27,17 @@ using JointIndex = TypeSafeIndex<class JointElementTag>;
 /// Type used to identify actuators by index within a multibody tree system.
 using JointActuatorIndex = TypeSafeIndex<class JointActuatorElementTag>;
 
+/// Type used to identify model instances by index within a multibody
+/// tree system.
+using ModelInstanceIndex = TypeSafeIndex<class ModelInstanceTag>;
+
 /// For every MultibodyTree the **world** body _always_ has this unique index
 /// and it is always zero.
 // Note:
 //   static global variables are strongly discouraged by the C++ style guide:
 // https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables
+// For this reason, we create and return an instance of BodyIndex
+// instead of using a static variable.
 inline BodyIndex world_index() { return BodyIndex(0); }
 
 }  // namespace multibody

--- a/multibody/multibody_tree/rigid_body.cc
+++ b/multibody/multibody_tree/rigid_body.cc
@@ -3,18 +3,27 @@
 #include <memory>
 
 #include "drake/common/autodiff.h"
+#include "drake/multibody/multibody_tree/model_instance.h"
 
 namespace drake {
 namespace multibody {
 
 template <typename T>
-RigidBody<T>::RigidBody(const SpatialInertia<double> M) :
-    default_spatial_inertia_(M) {}
+RigidBody<T>::RigidBody(const SpatialInertia<double>& M)
+    : Body<T>("", default_model_instance(), M.get_mass()),
+      default_spatial_inertia_(M) {}
 
 template <typename T>
 RigidBody<T>::RigidBody(const std::string& body_name,
-                        const SpatialInertia<double> M)
-    : Body<T>(body_name, M.get_mass()),
+                        const SpatialInertia<double>& M)
+    : Body<T>(body_name, default_model_instance(), M.get_mass()),
+      default_spatial_inertia_(M) {}
+
+template <typename T>
+RigidBody<T>::RigidBody(const std::string& body_name,
+                        ModelInstanceIndex model_instance,
+                        const SpatialInertia<double>& M)
+    : Body<T>(body_name, model_instance, M.get_mass()),
       default_spatial_inertia_(M) {}
 
 // Explicitly instantiates on the most common scalar types.

--- a/multibody/multibody_tree/rigid_body.h
+++ b/multibody/multibody_tree/rigid_body.h
@@ -59,7 +59,7 @@ class RigidBody : public Body<T> {
   ///   expressed in the body frame B.
   /// @note See @ref multibody_spatial_inertia for details on the monogram
   /// notation used for spatial inertia quantities.
-  explicit RigidBody(const SpatialInertia<double> M_BBo_B);
+  explicit RigidBody(const SpatialInertia<double>& M_BBo_B);
 
   /// Constructs a %RigidBody named `body_name` with the given default
   /// SpatialInertia.
@@ -71,7 +71,24 @@ class RigidBody : public Body<T> {
   ///   expressed in the body frame B.
   /// @note See @ref multibody_spatial_inertia for details on the monogram
   /// notation used for spatial inertia quantities.
-  RigidBody(const std::string& body_name, const SpatialInertia<double> M_BBo_B);
+  RigidBody(const std::string& body_name,
+            const SpatialInertia<double>& M_BBo_B);
+
+  /// Constructs a %RigidBody named `body_name` with the given default
+  /// SpatialInertia.
+  ///
+  /// @param[in] body_name
+  ///   A name associated with `this` body.
+  /// @param[in] model_instance
+  ///   The model instance associated with `this` body.
+  /// @param[in] M_BBo_B
+  ///   Spatial inertia of `this` body B about the frame's origin `Bo` and
+  ///   expressed in the body frame B.
+  /// @note See @ref multibody_spatial_inertia for details on the monogram
+  /// notation used for spatial inertia quantities.
+  RigidBody(const std::string& body_name,
+            ModelInstanceIndex model_instance,
+            const SpatialInertia<double>& M_BBo_B);
 
   /// There are no flexible degrees of freedom associated with a rigid body and
   /// therefore this method returns zero. By definition, a rigid body has no

--- a/multibody/multibody_tree/test/model_instance_test.cc
+++ b/multibody/multibody_tree/test/model_instance_test.cc
@@ -1,0 +1,111 @@
+#include <gtest/gtest.h>
+
+#include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
+#include "drake/multibody/multibody_tree/joints/weld_joint.h"
+#include "drake/multibody/multibody_tree/multibody_tree.h"
+
+namespace drake {
+namespace multibody {
+namespace {
+
+GTEST_TEST(ModelInstance, ModelInstanceTest) {
+  // Create a tree with enough bodies to make two models, one with a
+  // welded base and one free.
+  MultibodyTree<double> tree;
+
+  const ModelInstanceIndex instance1 = tree.AddModelInstance("instance1");
+
+  const RigidBody<double>& body1 =
+      tree.AddRigidBody("Body1", instance1, SpatialInertia<double>());
+  const RigidBody<double>& body2 =
+      tree.AddRigidBody("Body2", instance1, SpatialInertia<double>());
+  const RigidBody<double>& body3 =
+      tree.AddRigidBody("Body3", instance1, SpatialInertia<double>());
+
+  tree.AddJoint<WeldJoint>(
+      "weld1", tree.world_body(), Eigen::Isometry3d::Identity(),
+      body1, Eigen::Isometry3d::Identity(),
+      Eigen::Isometry3d::Identity());
+  const Joint<double>& body1_body2 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism1", body1, Eigen::Isometry3d::Identity(),
+          body2, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  tree.AddJointActuator("act1", body1_body2);
+
+  const Joint<double>& body2_body3 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism2", body2, Eigen::Isometry3d::Identity(),
+          body3, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  tree.AddJointActuator("act2", body2_body3);
+
+  const ModelInstanceIndex instance2 = tree.AddModelInstance("instance2");
+
+  const RigidBody<double>& body4 =
+      tree.AddRigidBody("Body4", instance2, SpatialInertia<double>());
+  const RigidBody<double>& body5 =
+      tree.AddRigidBody("Body5", instance2, SpatialInertia<double>());
+
+  const Joint<double>& body4_body5 =
+      tree.AddJoint<PrismaticJoint>(
+          "prism3", body4, Eigen::Isometry3d::Identity(),
+          body5, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+  tree.AddJointActuator("act3", body4_body5);
+
+  tree.Finalize();
+
+  EXPECT_EQ(tree.num_positions(instance1), 2);
+  EXPECT_EQ(tree.num_velocities(instance1), 2);
+  EXPECT_EQ(tree.num_actuated_dofs(instance1), 2);
+  EXPECT_EQ(tree.num_positions(instance2), 8);
+  EXPECT_EQ(tree.num_velocities(instance2), 7);
+  EXPECT_EQ(tree.num_actuated_dofs(instance2), 1);
+
+  Eigen::Vector3d act_vector(0, 0, 0);
+  tree.set_actuation_vector(instance1, Eigen::Vector2d(1, 2), &act_vector);
+  tree.set_actuation_vector(instance2, Vector1d(3), &act_vector);
+  EXPECT_TRUE(CompareMatrices(act_vector, Eigen::Vector3d(1, 2, 3)));
+
+  Eigen::VectorXd pos_vector(10);
+  pos_vector << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+  Eigen::VectorXd instance1_pos =
+      tree.get_positions_from_array(instance1, pos_vector);
+  EXPECT_TRUE(CompareMatrices(instance1_pos, Eigen::Vector2d(8, 10)));
+
+  Eigen::VectorXd instance2_pos =
+      tree.get_positions_from_array(instance2, pos_vector);
+
+  Eigen::VectorXd instance2_pos_expected(8);
+  instance2_pos_expected << 1, 2, 3, 4, 5, 6, 7, 9;
+  EXPECT_TRUE(CompareMatrices(instance2_pos, instance2_pos_expected));
+
+  Eigen::VectorXd vel_vector(9);
+  vel_vector << 11, 12, 13, 14, 15, 16, 17, 18, 19;
+
+  Eigen::VectorXd instance1_vel =
+      tree.get_velocities_from_array(instance1, vel_vector);
+  EXPECT_TRUE(CompareMatrices(instance1_vel, Eigen::Vector2d(17, 19)));
+
+  Eigen::VectorXd instance2_vel =
+      tree.get_velocities_from_array(instance2, vel_vector);
+  Eigen::VectorXd instance2_vel_expected(7);
+  instance2_vel_expected << 11, 12, 13, 14, 15, 16, 18;
+  EXPECT_TRUE(CompareMatrices(instance2_vel, instance2_vel_expected));
+
+  // Test that scalar conversion produces properly shaped results.
+  std::unique_ptr<MultibodyTree<AutoDiffXd>> tree_ad =
+      tree.CloneToScalar<AutoDiffXd>();
+
+  EXPECT_EQ(tree_ad->num_positions(instance1), 2);
+  EXPECT_EQ(tree_ad->num_velocities(instance1), 2);
+  EXPECT_EQ(tree_ad->num_actuated_dofs(instance1), 2);
+  EXPECT_EQ(tree_ad->num_positions(instance2), 8);
+  EXPECT_EQ(tree_ad->num_velocities(instance2), 7);
+  EXPECT_EQ(tree_ad->num_actuated_dofs(instance2), 1);
+}
+
+}  // namespace
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -785,4 +785,3 @@ TEST_F(WeldMobilizerTest, PositionKinematics) {
 }  // namespace multibody_model
 }  // namespace multibody
 }  // namespace drake
-

--- a/multibody/multibody_tree/uniform_gravity_field_element.cc
+++ b/multibody/multibody_tree/uniform_gravity_field_element.cc
@@ -10,8 +10,9 @@ namespace drake {
 namespace multibody {
 
 template <typename T>
-UniformGravityFieldElement<T>::UniformGravityFieldElement(Vector3<double> g_W) :
-    g_W_(g_W) {}
+UniformGravityFieldElement<T>::UniformGravityFieldElement(Vector3<double> g_W)
+    : ForceElement<T>(world_model_instance()),
+      g_W_(g_W) {}
 
 template <typename T>
 VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(


### PR DESCRIPTION
This doesn't include support for model instance in the plant.

Note that in `model_instance.h` the names of all the variables on the accessors (e.g. `u_a`, `q_array`, and the like) are preserving existing conventions for similar implementations on other tree elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8986)
<!-- Reviewable:end -->
