### PR TITLE
Updates simple gripper example README after fixing 7874

### DIFF
--- a/examples/simple_gripper/README.md
+++ b/examples/simple_gripper/README.md
@@ -59,23 +59,14 @@ Launch the visualizer
 ```
 ./bazel-bin/tools/drake_visualizer
 ```
-
-Launch the kuka simulation. Due to
-[#7874](https://github.com/RobotLocomotion/drake/issues/7874), we first need to
-change our working directory to the `.runfiles` directory for this example
+Launch the simulation with
 ```
-cd bazel-bin/examples/simple_gripper/simple_gripper.runfiles/drake
-```
-Until [#7874](https://github.com/RobotLocomotion/drake/issues/7874) is resolved,
-this allows `sdformat` to find the SDF files for this demo.
-From within this directory we now launch the simulation with
-```
-./examples/simple_gripper/simple_gripper --simulation_time=10.0
+./bazel-bin/examples/simple_gripper/simple_gripper --simulation_time=10.0
 ```
 where for this particular invocation example we are specifying the simulation
 time in seconds as a command line option. To get a list of command line options
 for this example run
 ```
-./examples/simple_gripper/simple_gripper --help
+./bazel-bin/examples/simple_gripper/simple_gripper --help
 ```
 which will also provide a description for each option.


### PR DESCRIPTION
I can happily say that now we don't have to get into the `.runfiles` directory!!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8992)
<!-- Reviewable:end -->
