### PR TITLE
common: Always provide fmt from text_logging.h

### DIFF
--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -36,7 +36,6 @@ drake_cc_library(
     deps = [
         "//automotive/maliput/api",
         "//math:geometric_transform",
-        "@fmt",
     ],
 )
 

--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -130,7 +130,6 @@ drake_pybind_library(
     cc_deps = [
         ":symbolic_types_pybind",
         "//bindings/pydrake/util:wrap_pybind",
-        "@fmt",
     ],
     cc_srcs = ["symbolic_py.cc"],
     package_info = PACKAGE_INFO,

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -76,6 +76,7 @@ drake_cc_library(
     ],
     deps = [
         "@eigen",
+        "@fmt",
         "@spdlog",
         "@stx",
     ],
@@ -218,7 +219,6 @@ drake_cc_library(
         ":number_traits",
         ":polynomial",
         "//math:matrix_util",
-        "@fmt",
     ],
 )
 
@@ -377,7 +377,6 @@ drake_cc_library(
     hdrs = ["pointer_cast.h"],
     deps = [
         ":nice_type_name",
-        "@fmt",
     ],
 )
 

--- a/common/text_logging.h
+++ b/common/text_logging.h
@@ -73,7 +73,18 @@ printed without any special handling.
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
 /* clang-format on */
-#endif
+
+#else  /* HAVE_SPDLOG */
+
+// We always want text_logging.h to provide fmt support to those who include
+// it, even if spdlog is disabled.
+
+/* clang-format off */
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+/* clang-format on */
+
+#endif  /* HAVE_SPDLOG */
 
 #include "drake/common/drake_copyable.h"
 

--- a/examples/pendulum/BUILD.bazel
+++ b/examples/pendulum/BUILD.bazel
@@ -137,7 +137,6 @@ drake_cc_binary(
     deps = [
         ":pendulum_plant",
         ":pendulum_vector_types",
-        "@fmt",
     ],
 )
 

--- a/examples/simple_gripper/BUILD.bazel
+++ b/examples/simple_gripper/BUILD.bazel
@@ -40,7 +40,6 @@ drake_cc_binary(
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:sine",
         "//systems/rendering:pose_bundle_to_draw_message",
-        "@fmt",
         "@gflags",
     ],
 )

--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -96,7 +96,6 @@ drake_cc_library(
         "//common:default_scalars",
         "//common:essential",
         "//common:is_approx_equal_abstol",
-        "@fmt",
     ],
 )
 

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -375,7 +375,6 @@ drake_cc_library(
         "//common:symbolic",
         "//common:type_safe_index",
         "//common:unused",
-        "@fmt",
     ],
 )
 


### PR DESCRIPTION
When we include fmt from some `cc_library` in Drake, we generally don't have to add `@fmt` to `deps` because it is (almost always) transitively added via `//common:essential` -- our essential library uses spdlog and spdlog uses fmt. Thus, our CI doesn't enforce LWYU in the BUILD file for code we write that uses fmt.  However, if some Bazel-using downstream code has decided to stub out spdlog (with `HAVE_SPDLOG` absent, etc.), then that code is not getting the implicit dependency on `@fmt` and may fail to compile.

Fixes #8930.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/8999)
<!-- Reviewable:end -->
