### PR TITLE
Add underlying S3 bucket as a mirror for dreal download

### DIFF
--- a/tools/workspace/dreal/repository.bzl
+++ b/tools/workspace/dreal/repository.bzl
@@ -86,6 +86,7 @@ dreal_repository = repository_rule(
         "mirrors": attr.string_list(
             default = [
                 "https://drake-apt.csail.mit.edu/xenial/pool/main",
+                "https://s3.amazonaws.com/drake-apt/xenial/pool/main",
             ],
         ),
         "filenames": attr.string_list(


### PR DESCRIPTION
Pretty superficial, but just in case something ever goes wrong with the MIT DNS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9003)
<!-- Reviewable:end -->
