### PR TITLE
manipulation/util: Preserve env for show_model_test

### DIFF
--- a/manipulation/util/test/show_model_test.py
+++ b/manipulation/util/test/show_model_test.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import unittest
 
@@ -9,9 +10,8 @@ class TestShowModel(unittest.TestCase):
 
         # Use a bogus LCM URL so that we don't clobber people's desktop
         # visualizers when they run the unit tests.
-        env = {
-            "LCM_DEFAULT_URL": "udpm://239.87.65.43:2109?ttl=0",
-        }
+        env = dict(os.environ)
+        env["LCM_DEFAULT_URL"] = "udpm://239.87.65.43:2109?ttl=0"
 
         # Check a random SDF.
         subprocess.check_call([


### PR DESCRIPTION
The intent was never to zero out the environment, but as I originally wrote this test, it was zeroing.  This ended up causing a problem with a newer locally-installed numpy that errors out if `${PATH}` is unset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9004)
<!-- Reviewable:end -->
