### PR TITLE
pydrake: Expose subset of `*_pybind.h` headers for downstream consumption

### DIFF
--- a/bindings/pydrake/BUILD.bazel
+++ b/bindings/pydrake/BUILD.bazel
@@ -35,6 +35,7 @@ drake_cc_library(
     # NOTE: We must violate IWYU and not list any Drake libraries in "deps"
     # here because we do not want these dependencies violating ODR (at both
     # development and install time).
+    visibility = ["//visibility:public"],
 )
 
 drake_pybind_library(
@@ -54,6 +55,7 @@ drake_pybind_library(
 drake_cc_library(
     name = "autodiff_types_pybind",
     hdrs = ["autodiff_types_pybind.h"],
+    visibility = ["//visibility:public"],
 )
 
 drake_pybind_library(
@@ -119,10 +121,10 @@ drake_pybind_library(
     ],
 )
 
-# TODO(eric.cousineau): Make private.
 drake_cc_library(
     name = "symbolic_types_pybind",
     hdrs = ["symbolic_types_pybind.h"],
+    visibility = ["//visibility:public"],
 )
 
 drake_pybind_library(

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -52,7 +52,7 @@ derived class, you should use
 
 ## Target Conventions
 
-Target names should be of the following form:
+### Names
 
 - `*_py`: A Python library (can be pure Python or pybind)
   - File Names: `*.py`, `*_py.cc`
@@ -62,6 +62,15 @@ Target names should be of the following form:
   - File Names: `*_pybind.{h,cc}`
 
 File names should follow form with their respective target.
+
+### Visibility
+
+- All Python libraries should generally be private, as `pydrake` will
+  be consumed as one encapsulated target.
+
+- All C++ `*_pybind` libraries for binding utilities should be public to aide
+  downstream Bazel projects. If the API is unstable, consider making it private
+  with a TODO to make public once it stabilizes.
 
 ### Bazel
 

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -40,10 +40,12 @@ drake_py_library(
     ],
 )
 
-# N.B. Any C++ libraries that include this must include `cpp_template_py`.
+# N.B. Any C++ libraries that include this must include `cpp_template_py` when
+# being used in Python.
 drake_cc_library(
     name = "systems_pybind",
     hdrs = ["systems_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//bindings/pydrake:autodiff_types_pybind",
         "//bindings/pydrake:symbolic_types_pybind",

--- a/bindings/pydrake/systems/primitives_py.cc
+++ b/bindings/pydrake/systems/primitives_py.cc
@@ -3,6 +3,7 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/bindings/pydrake/util/cpp_template_pybind.h"
 #include "drake/bindings/pydrake/util/drake_optional_pybind.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/affine_system.h"

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -36,16 +36,19 @@ PACKAGE_INFO = get_pybind_package_info("//bindings")
 drake_cc_library(
     name = "type_pack",
     hdrs = ["type_pack.h"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_library(
     name = "wrap_function",
     hdrs = ["wrap_function.h"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_library(
     name = "wrap_pybind",
     hdrs = ["wrap_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = [":wrap_function"],
 )
 
@@ -66,12 +69,14 @@ drake_py_library(
 drake_cc_library(
     name = "eigen_pybind",
     hdrs = ["eigen_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = ["//bindings/pydrake:pydrake_pybind"],
 )
 
 drake_cc_library(
     name = "eigen_geometry_pybind",
     hdrs = ["eigen_geometry_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = ["//bindings/pydrake:pydrake_pybind"],
 )
 
@@ -89,6 +94,7 @@ drake_cc_library(
     name = "cpp_param_pybind",
     srcs = ["cpp_param_pybind.cc"],
     hdrs = ["cpp_param_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":type_pack",
         "//bindings/pydrake:pydrake_pybind",
@@ -117,6 +123,7 @@ drake_cc_library(
     name = "cpp_template_pybind",
     srcs = [],
     hdrs = ["cpp_template_pybind.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":cpp_param_pybind",
         "//bindings/pydrake:pydrake_pybind",
@@ -136,11 +143,13 @@ drake_py_library(
 drake_cc_library(
     name = "drake_optional_pybind",
     hdrs = ["drake_optional_pybind.h"],
+    visibility = ["//visibility:public"],
 )
 
 drake_cc_library(
     name = "type_safe_index_pybind",
     hdrs = ["type_safe_index_pybind.h"],
+    visibility = ["//visibility:public"],
 )
 
 generate_pybind11_version_py_file(


### PR DESCRIPTION
Resolves #9009

\cc @mposa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9010)
<!-- Reviewable:end -->
