### PR TITLE
pydrake rbt: Add bindings for ChildOfJoint and QDotToV methods

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -138,6 +138,15 @@ PYBIND11_MODULE(rigid_body_tree, m) {
        py::arg("model_name") = "",
        py::arg("model_id") = -1,
        py::return_value_policy::reference)
+    .def("FindChildBodyOfJoint", [](const RigidBodyTree<double>& self,
+                        const std::string& joint_name,
+                        int model_id) {
+      return self.FindChildBodyOfJoint(joint_name, model_id);
+    }, py::arg("joint_name"), py::arg("model_id") = -1,
+       py::return_value_policy::reference)
+    .def("FindIndexOfChildBodyOfJoint",
+         &RigidBodyTree<double>::FindIndexOfChildBodyOfJoint,
+         py::arg("joint_name"), py::arg("model_id") = -1)
     .def("world",
          static_cast<RigidBody<double>& (RigidBodyTree<double>::*)()>(
              &RigidBodyTree<double>::world),
@@ -186,10 +195,24 @@ PYBIND11_MODULE(rigid_body_tree, m) {
          py::arg("cache"),
          py::arg("model_instance_id_set") =
            RigidBodyTreeConstants::default_model_instance_id_set)
-      // transformVelocityToQDot
-      // transformQDotToVelocity
-      // GetVelocityToQDotMapping
-      // GetQDotToVelocityMapping
+      .def("transformVelocityToQDot", [](const RigidBodyTree<double>& tree,
+                                          const KinematicsCache<T>& cache,
+                                          const VectorX<T>& v) {
+             return tree.transformVelocityToQDot(cache, v);
+           })
+      .def("transformQDotToVelocity", [](const RigidBodyTree<double>& tree,
+                                          const KinematicsCache<T>& cache,
+                                          const VectorX<T>& qdot) {
+             return tree.transformQDotToVelocity(cache, qdot);
+           })
+      .def("GetVelocityToQDotMapping", [](const RigidBodyTree<double>& tree,
+                                          const KinematicsCache<T>& cache) {
+             return tree.GetVelocityToQDotMapping(cache);
+           })
+      .def("GetQDotToVelocityMapping", [](const RigidBodyTree<double>& tree,
+                                          const KinematicsCache<T>& cache) {
+             return tree.GetQDotToVelocityMapping(cache);
+           })
       .def("dynamicsBiasTerm", &RigidBodyTree<double>::dynamicsBiasTerm<T>,
            py::arg("cache"), py::arg("external_wrenches"),
            py::arg("include_velocity_terms") = true)
@@ -244,8 +267,18 @@ PYBIND11_MODULE(rigid_body_tree, m) {
            py::arg("vd"),
            py::arg("include_velocity_terms") = true)
       // resolveCenterOfPressure
-      // transformVelocityMappingToQDotMapping
-      // transformQDotMappingToVelocityMapping
+      .def("transformVelocityMappingToQDotMapping",
+           [](const RigidBodyTree<double>& tree,
+              const KinematicsCache<T>& cache,
+              const MatrixX<T>& Av) {
+             return tree.transformVelocityMappingToQDotMapping(cache, Av);
+           })
+      .def("transformQDotMappingToVelocityMapping",
+           [](const RigidBodyTree<double>& tree,
+              const KinematicsCache<T>& cache,
+              const MatrixX<T>& Ap) {
+             return tree.transformQDotMappingToVelocityMapping(cache, Ap);
+           })
       // DoTransformPointsJacobian
       // DoTransformPointsJacobianDotTimesV
       // relativeQuaternionJacobian

--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -3722,15 +3722,18 @@ template VectorX<double         > RigidBodyTree<double>::inverseDynamics<double 
 template pair<Vector3d, double> RigidBodyTree<double>::resolveCenterOfPressure<Vector3d, Vector3d>(KinematicsCache<double> const&, vector<ForceTorqueMeasurement, allocator<ForceTorqueMeasurement>> const&, Eigen::MatrixBase<Vector3d> const&, Eigen::MatrixBase<Vector3d> const&) const;  // NOLINT
 
 // Explicit template instantiations for transformVelocityMappingToQDotMapping.
-template MatrixX<double> RigidBodyTree<double>::transformVelocityMappingToQDotMapping<VectorXd          >(const KinematicsCache<double>&, const Eigen::MatrixBase<VectorXd          >&);  // NOLINT
-template MatrixX<double> RigidBodyTree<double>::transformVelocityMappingToQDotMapping<Eigen::RowVectorXd>(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::RowVectorXd>&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformVelocityMappingToQDotMapping<VectorXd           >(const KinematicsCache<double>&,     const Eigen::MatrixBase<VectorXd           >&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformVelocityMappingToQDotMapping<Eigen::RowVectorXd >(const KinematicsCache<double>&,     const Eigen::MatrixBase<Eigen::RowVectorXd >&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformVelocityMappingToQDotMapping<MatrixXd           >(const KinematicsCache<double>&,     const Eigen::MatrixBase<MatrixXd           >&);  // NOLINT
+template MatrixX<AutoDiffXd> RigidBodyTree<double>::transformVelocityMappingToQDotMapping<MatrixX<AutoDiffXd>>(const KinematicsCache<AutoDiffXd>&, const Eigen::MatrixBase<MatrixX<AutoDiffXd>>&);  // NOLINT
 
 // Explicit template instantiations for transformQDotMappingToVelocityMapping.
-template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<VectorXd                  >(const KinematicsCache<double>&, const Eigen::MatrixBase<VectorXd                  >&);  // NOLINT
-template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::RowVectorXd        >(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::RowVectorXd        >&);  // NOLINT
-template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<MatrixXd                  >(const KinematicsCache<double>&, const Eigen::MatrixBase<MatrixXd                  >&);  // NOLINT
-template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd const>>(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::Map<MatrixXd const>>&);  // NOLINT
-template MatrixX<double> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd      >>(const KinematicsCache<double>&, const Eigen::MatrixBase<Eigen::Map<MatrixXd      >>&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformQDotMappingToVelocityMapping<VectorXd                  >(const KinematicsCache<double>&,     const Eigen::MatrixBase<VectorXd                  >&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::RowVectorXd        >(const KinematicsCache<double>&,     const Eigen::MatrixBase<Eigen::RowVectorXd        >&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformQDotMappingToVelocityMapping<MatrixXd                  >(const KinematicsCache<double>&,     const Eigen::MatrixBase<MatrixXd                  >&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd const>>(const KinematicsCache<double>&,     const Eigen::MatrixBase<Eigen::Map<MatrixXd const>>&);  // NOLINT
+template MatrixX<double>     RigidBodyTree<double>::transformQDotMappingToVelocityMapping<Eigen::Map<MatrixXd      >>(const KinematicsCache<double>&,     const Eigen::MatrixBase<Eigen::Map<MatrixXd      >>&);  // NOLINT
+template MatrixX<AutoDiffXd> RigidBodyTree<double>::transformQDotMappingToVelocityMapping<MatrixX<AutoDiffXd       >>(const KinematicsCache<AutoDiffXd>&, const Eigen::MatrixBase<MatrixX<AutoDiffXd       >>&);  // NOLINT
 
 #endif
 #if DRAKE_RBT_SHARD == 1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9014)
<!-- Reviewable:end -->
