### PR TITLE
Fix remaining comments from #9008

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -472,7 +472,6 @@ drake_cc_googletest(
     name = "rigid_body_distance_constraint_test",
     deps = [
         ":rigid_body_distance_constraint",
-        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/rigid_body_distance_constraint.h
+++ b/multibody/rigid_body_distance_constraint.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <iostream>
-#include <memory>
-
 #include <Eigen/Dense>
 
 /// Defines a "relative distance constraint" that models a constraint between

--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -3192,9 +3192,8 @@ void RigidBodyTree<T>::addDistanceConstraint(int bodyA_index_in,
                                              int bodyB_index_in,
                                              const Eigen::Vector3d& r_BQ_in,
                                              double distance_in) {
-  RigidBodyDistanceConstraint dc(bodyA_index_in, r_AP_in, bodyB_index_in,
-                                 r_BQ_in, distance_in);
-  distance_constraints.push_back(dc);
+  distance_constraints.emplace_back(bodyA_index_in, r_AP_in, bodyB_index_in,
+                                    r_BQ_in, distance_in);
 }
 
 template <typename T>

--- a/multibody/test/rigid_body_distance_constraint_test.cc
+++ b/multibody/test/rigid_body_distance_constraint_test.cc
@@ -3,18 +3,17 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
-#include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
 namespace multibody {
 namespace {
 
 GTEST_TEST(RigidBodyDistanceConstraintTest, TestInitialization) {
-  int body1 = 1;
-  int body2 = 2;
-  Vector3<double> point1(0, 1, 2);
-  Vector3<double> point2(4, 5, 6);
-  double distance = 0.5;
+  const int body1 = 1;
+  const int body2 = 2;
+  const Vector3<double> point1(0, 1, 2);
+  const Vector3<double> point2(4, 5, 6);
+  const double distance = 0.5;
 
   RigidBodyDistanceConstraint dc(body1, point1, body2, point2, distance);
   EXPECT_EQ(dc.bodyA_index, body1);


### PR DESCRIPTION
Addresses the remaining nit comments after closing #9008 per @jwnimmer-tri's suggestion.  @sherm1 and @soonho-tri, let me know if there are other needed changes that haven't been addressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9023)
<!-- Reviewable:end -->
