### PR TITLE
Updates Doxygen comment lines from /// to /** and <pre> to <verbatim>.

### DIFF
--- a/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
+++ b/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
@@ -261,134 +261,144 @@ struct IterationStats {
   std::vector<double> residuals;
 };
 
-/// %ImplicitStribeckSolver solves the equations below for mechanical systems
-/// with contact using a modified Stribeck model of friction: <pre>
-///             q̇ = N(q)⋅v
-///   (1)  M(q)⋅v̇ = τ + Jₙᵀ(q)⋅fₙ(q, v) + Jₜᵀ(q)⋅fₜ(q, v)
-/// </pre>
-/// where `v ∈ ℝⁿᵛ` is the vector of generalized velocities, `M(q) ∈ ℝⁿᵛˣⁿᵛ` is
-/// the mass matrix, `Jₙ(q) ∈ ℝⁿᶜˣⁿᵛ` is the Jacobian of normal separation
-/// velocities, `Jₜ(q) ∈ ℝ²ⁿᶜˣⁿᵛ` is the Jacobian of tangent velocities,
-/// `fₙ ∈ ℝⁿᶜ` is the vector of normal contact forces, `fₜ ∈ ℝ²ⁿᶜ` is the
-/// vector of tangent friction forces and τ ∈ ℝⁿᵛ is a vector of generalized
-/// forces containing all other applied forces (e.g., Coriolis, gyroscopic
-/// terms, actuator forces, etc.) but contact forces.
-/// This solver assumes a compliant law for the normal forces `fₙ(q, v)` and
-/// therefore the functional dependence of `fₙ(q, v)` with q and v is stated
-/// explicitly.
-/// Since %ImplicitStribeckSolver uses a modified Stribeck model for friction,
-/// we explicitly emphasize the functional dependence of `fₜ(q, v)` with the
-/// generalized velocities. The functional dependence of `fₜ(q, v)` with the
-/// generalized positions stems from its direct dependence with the normal
-/// forces `fₙ(q, v)`.
-///
-/// Equations (1) is discretized in time using a first order semi-implicit Euler
-/// scheme with time step `δt` as: <pre>
-///              qⁿ⁺¹ = qⁿ + δt N(qⁿ)⋅vⁿ⁺¹
-///   (2)  M(qⁿ)⋅vⁿ⁺¹ =
-///          M(qⁿ)⋅vⁿ + δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(qⁿ, vⁿ⁺¹))
-/// </pre>
-/// Please see details in the @ref time_discretization "Discretization in Time"
-/// section.
-/// The equation for the generalized velocities in Eq. (2) is rewritten as:
-/// <pre>
-///   (3)  M⋅vⁿ⁺¹ = p* + δt Jₜᵀ⋅fₜ(vⁿ⁺¹)
-/// </pre>
-/// where `p* = M⋅vⁿ + δt τⁿ + δt Jₙᵀ⋅fₙ` is the generalized momentum that the
-/// system would have in the absence of friction forces and, for simplicity, we
-/// have only kept the functional dependencies in generalized velocities. Notice
-/// that %ImplicitStribeckSolver uses a precomputed value of the normal forces.
-/// These normal forces could be available for instance if
-/// using a compliant contact approach, for which normal forces are a function
-/// of the state.
-///
-/// %ImplicitStribeckSolver is designed to solve, implicitly, the system in
-/// Eq. (3) for the next time step vector of generalized velocities `vⁿ⁺¹`.
-/// The solver uses a Newton-Raphson iteration to compute an update `Δvᵏ` at the
-/// k-th Newton-Raphson iteration. Once `Δvᵏ` is computed, the solver limits the
-/// change in the tangential velocities `Δvₜᵏ = Jₜᵀ⋅Δvᵏ` using the approach
-/// described in [Uchida et al., 2015]. This approach limits the maximum angle
-/// change θ between two successive iterations in the tangential velocity.
-///
-/// Uchida, T.K., Sherman, M.A. and Delp, S.L., 2015.
-///   Making a meaningful impact: modelling simultaneous frictional collisions
-///   in spatial multibody systems. Proc. R. Soc. A, 471(2177), p.20140859.
-///
-/// @anchor time_discretization
-/// <h2>Discretization in Time</h2>
-/// In this section we provide a detailed derivation of the first order time
-/// stepping approach in Eq. (2). We start from the continuous Eq. (1): <pre>
-///   (1)  M(q)⋅v̇ = τ + Jₙᵀ(q)⋅fₙ(q, v) + Jₜᵀ(q)⋅fₜ(v)
-/// </pre>
-/// we can discretize Eq. (1) in time using a first order semi-implicit Euler
-/// scheme in velocities: <pre>
-///   (4)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
-///           δt (τⁿ⁺¹ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ⁺¹) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) + O₁(δt²)
-/// </pre>
-/// where the equality holds strictly since we included the leading terms in
-/// `O(δt²)`. We use `τⁿ⁺¹ = τ(tⁿ, qⁿ, vⁿ⁺¹)` for brevity in Eq. (4).
-/// When moving from the continuous Eq. (1) to the discrete version Eq. (4), we
-/// lost the nice property that our compliant normal forces are decoupled from
-/// the friction forces (both depend on the same unknown vⁿ⁺¹ in Eq (4)). The
-/// reason is that Eq. (4) includes an integration over a small interval of
-/// size δt. To solve the discrete system in Eq. (4), we'd like to decouple the
-/// normal forces from the tangential forces again, which will require a new
-/// (though still valid) approximation.
-/// To do so we will expand in Taylor series the term `fₙ(qⁿ, vⁿ⁺¹)`: <pre>
-///   (5)  fₙ(qⁿ, vⁿ⁺¹) = fₙ(qⁿ, vⁿ) + ∇ᵥfₙ(qⁿ,vⁿ)⋅(vⁿ⁺¹-vⁿ) + O₂(‖vⁿ⁺¹-vⁿ‖²)
-/// </pre>
-/// The difference between `vⁿ` and `vⁿ⁺¹` can be written as: <pre>
-///   (6)  vⁿ⁺¹-vⁿ = δtv̇ⁿ + δtO₃(δt²) = O₄(δt)
-/// </pre>
-/// Substituting `vⁿ⁺¹-vⁿ` from Eq. (6) into Eq. (5) we arrive to: <pre>
-///   (7)  fₙ(qⁿ, vⁿ⁺¹) = fₙ(qⁿ, vⁿ) + ∇ᵥfₙ(qⁿ,vⁿ)⋅O₄(δt) + O₅(δt²)
-///                     = fₙ(qⁿ, vⁿ) + O₆(δt)
-/// </pre>
-/// where `O₅(δt²) = O₂(‖vⁿ⁺¹-vⁿ‖²) = O₂(‖O₄(δt)‖²)`. A similar argument for
-/// τⁿ⁺¹ shows it also differs in O(δt) from τⁿ = τ(tⁿ, qⁿ, vⁿ).
-/// We can now use Eq. (7) into Eq. (4) to arrive to: <pre>
-///   (8)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
-///         δt (τⁿ + Jₙᵀ(qⁿ)⋅(fₙ(qⁿ, vⁿ) + O₆(δt)) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) +
-///         O₁(δt²)
-/// </pre>
-/// which we can rewrite as: <pre>
-///   (9)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
-///       δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) + O₇(δt²)
-/// </pre>
-/// with `O₇(δt²) = δt Jₙᵀ(qⁿ)⋅O₆(δt) + O₁(δt²)`.
-/// That is, Eq. (9) introduces the same order of approximation as in the
-/// semi-implicit method in Eq. (4).
-/// Up to this point we have made no approximations but we instead propagated
-/// the `O(⋅)` leading terms. Therefore the equalities in the equations above
-/// are exact. To obtain an approximate time stepping scheme, we drop `O₇(δt²)`
-/// (we neglect it) in Eq. (9) to arrive to a first order scheme:<pre>
-///   (10)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
-///                      δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹))
-/// </pre>
-/// Therefore, with the scheme in Eq. (10) we are able to decouple the
-/// computation of (compliant) normal forces from that of friction forces.
-/// A very important feature of this scheme however, is the explicit nature (in
-/// the velocities v) of the term associated with the normal forces (usually
-/// including dissipation in the normal direction), which will become unstable
-/// for a sufficiently large time step. However, for most applications in
-/// practice, the stability of the scheme is mostly determined by the explicit
-/// update of normal forces with positions, that is, Eq. (10) is explicit in
-/// positions through the normal forces `fₙ(qⁿ, vⁿ)`. For many common
-/// applications, the explicit dependence of `τⁿ(tⁿ, qⁿ, vⁿ)` on the
-/// previous time step velocities `vⁿ` determines the overall stability of
-/// the scheme, since this term can include velocity dependent contributions
-/// such as control forces and dampers. Notice that Eq. (5) introduces an
-/// expansion of `fₙ` with an order of approximation consistent with the
-/// first order scheme as needed. Therefore, it propagates into a `O(δt²)`
-/// term exactly as needed in Eq. (9).
-///
-/// @tparam T The type of mathematical object being added.
-/// Instantiated templates for the following kinds of T's are provided:
-/// - double
-/// - AutoDiffXd
-///
-/// They are already available to link against in the containing library.
-/// No other values for T are currently supported.
+/** %ImplicitStribeckSolver solves the equations below for mechanical systems
+with contact using a modified Stribeck model of friction:
+ @verbatim
+            q̇ = N(q)⋅v
+  (1)  M(q)⋅v̇ = τ + Jₙᵀ(q)⋅fₙ(q, v) + Jₜᵀ(q)⋅fₜ(q, v)
+ @endverbatim
+where `v ∈ ℝⁿᵛ` is the vector of generalized velocities, `M(q) ∈ ℝⁿᵛˣⁿᵛ` is
+the mass matrix, `Jₙ(q) ∈ ℝⁿᶜˣⁿᵛ` is the Jacobian of normal separation
+velocities, `Jₜ(q) ∈ ℝ²ⁿᶜˣⁿᵛ` is the Jacobian of tangent velocities,
+`fₙ ∈ ℝⁿᶜ` is the vector of normal contact forces, `fₜ ∈ ℝ²ⁿᶜ` is the
+vector of tangent friction forces and τ ∈ ℝⁿᵛ is a vector of generalized
+forces containing all other applied forces (e.g., Coriolis, gyroscopic
+terms, actuator forces, etc.) but contact forces.
+This solver assumes a compliant law for the normal forces `fₙ(q, v)` and
+therefore the functional dependence of `fₙ(q, v)` with q and v is stated
+explicitly.
+Since %ImplicitStribeckSolver uses a modified Stribeck model for friction,
+we explicitly emphasize the functional dependence of `fₜ(q, v)` with the
+generalized velocities. The functional dependence of `fₜ(q, v)` with the
+generalized positions stems from its direct dependence with the normal
+forces `fₙ(q, v)`.
+
+Equations (1) is discretized in time using a first order semi-implicit Euler
+scheme with time step `δt` as:
+@verbatim
+             qⁿ⁺¹ = qⁿ + δt N(qⁿ)⋅vⁿ⁺¹
+  (2)  M(qⁿ)⋅vⁿ⁺¹ =
+         M(qⁿ)⋅vⁿ + δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(qⁿ, vⁿ⁺¹))
+@endverbatim
+Please see details in the @ref time_discretization "Discretization in Time"
+section.
+The equation for the generalized velocities in Eq. (2) is rewritten as:
+@verbatim
+  (3)  M⋅vⁿ⁺¹ = p* + δt Jₜᵀ⋅fₜ(vⁿ⁺¹)
+@endverbatim
+where `p* = M⋅vⁿ + δt τⁿ + δt Jₙᵀ⋅fₙ` is the generalized momentum that the
+system would have in the absence of friction forces and, for simplicity, we
+have only kept the functional dependencies in generalized velocities. Notice
+that %ImplicitStribeckSolver uses a precomputed value of the normal forces.
+These normal forces could be available for instance if
+using a compliant contact approach, for which normal forces are a function
+of the state.
+
+%ImplicitStribeckSolver is designed to solve, implicitly, the system in
+Eq. (3) for the next time step vector of generalized velocities `vⁿ⁺¹`.
+The solver uses a Newton-Raphson iteration to compute an update `Δvᵏ` at the
+k-th Newton-Raphson iteration. Once `Δvᵏ` is computed, the solver limits the
+change in the tangential velocities `Δvₜᵏ = Jₜᵀ⋅Δvᵏ` using the approach
+described in [Uchida et al., 2015]. This approach limits the maximum angle
+change θ between two successive iterations in the tangential velocity.
+
+Uchida, T.K., Sherman, M.A. and Delp, S.L., 2015.
+  Making a meaningful impact: modelling simultaneous frictional collisions
+  in spatial multibody systems. Proc. R. Soc. A, 471(2177), p.20140859.
+
+@anchor time_discretization
+<h2>Discretization in Time</h2>
+In this section we provide a detailed derivation of the first order time
+stepping approach in Eq. (2). We start from the continuous Eq. (1):
+@verbatim
+  (1)  M(q)⋅v̇ = τ + Jₙᵀ(q)⋅fₙ(q, v) + Jₜᵀ(q)⋅fₜ(v)
+@endverbatim
+we can discretize Eq. (1) in time using a first order semi-implicit Euler
+scheme in velocities:
+@verbatim
+  (4)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
+          δt (τⁿ⁺¹ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ⁺¹) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) + O₁(δt²)
+@endverbatim
+where the equality holds strictly since we included the leading terms in
+`O(δt²)`. We use `τⁿ⁺¹ = τ(tⁿ, qⁿ, vⁿ⁺¹)` for brevity in Eq. (4).
+When moving from the continuous Eq. (1) to the discrete version Eq. (4), we
+lost the nice property that our compliant normal forces are decoupled from
+the friction forces (both depend on the same unknown vⁿ⁺¹ in Eq (4)). The
+reason is that Eq. (4) includes an integration over a small interval of
+size δt. To solve the discrete system in Eq. (4), we'd like to decouple the
+normal forces from the tangential forces again, which will require a new
+(though still valid) approximation.
+To do so we will expand in Taylor series the term `fₙ(qⁿ, vⁿ⁺¹)`:
+@verbatim
+  (5)  fₙ(qⁿ, vⁿ⁺¹) = fₙ(qⁿ, vⁿ) + ∇ᵥfₙ(qⁿ,vⁿ)⋅(vⁿ⁺¹-vⁿ) + O₂(‖vⁿ⁺¹-vⁿ‖²)
+@endverbatim
+The difference between `vⁿ` and `vⁿ⁺¹` can be written as:
+@verbatim
+  (6)  vⁿ⁺¹-vⁿ = δtv̇ⁿ + δtO₃(δt²) = O₄(δt)
+@endverbatim
+Substituting `vⁿ⁺¹-vⁿ` from Eq. (6) into Eq. (5) we arrive to:
+@verbatim
+  (7)  fₙ(qⁿ, vⁿ⁺¹) = fₙ(qⁿ, vⁿ) + ∇ᵥfₙ(qⁿ,vⁿ)⋅O₄(δt) + O₅(δt²)
+                    = fₙ(qⁿ, vⁿ) + O₆(δt)
+@endverbatim
+where `O₅(δt²) = O₂(‖vⁿ⁺¹-vⁿ‖²) = O₂(‖O₄(δt)‖²)`. A similar argument for
+τⁿ⁺¹ shows it also differs in O(δt) from τⁿ = τ(tⁿ, qⁿ, vⁿ).
+We can now use Eq. (7) into Eq. (4) to arrive to:
+@verbatim
+  (8)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
+        δt (τⁿ + Jₙᵀ(qⁿ)⋅(fₙ(qⁿ, vⁿ) + O₆(δt)) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) +
+        O₁(δt²)
+@endverbatim
+which we can rewrite as:
+@verbatim
+  (9)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
+      δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹)) + O₇(δt²)
+@endverbatim
+with `O₇(δt²) = δt Jₙᵀ(qⁿ)⋅O₆(δt) + O₁(δt²)`.
+That is, Eq. (9) introduces the same order of approximation as in the
+semi-implicit method in Eq. (4).
+Up to this point we have made no approximations but we instead propagated
+the `O(⋅)` leading terms. Therefore the equalities in the equations above
+are exact. To obtain an approximate time stepping scheme, we drop `O₇(δt²)`
+(we neglect it) in Eq. (9) to arrive to a first order scheme:
+@verbatim
+  (10)  M(qⁿ)⋅vⁿ⁺¹ = M(qⁿ)⋅vⁿ +
+                     δt (τⁿ + Jₙᵀ(qⁿ)⋅fₙ(qⁿ, vⁿ) + Jₜᵀ(qⁿ)⋅fₜ(vⁿ⁺¹))
+@endverbatim
+Therefore, with the scheme in Eq. (10) we are able to decouple the
+computation of (compliant) normal forces from that of friction forces.
+A very important feature of this scheme however, is the explicit nature (in
+the velocities v) of the term associated with the normal forces (usually
+including dissipation in the normal direction), which will become unstable
+for a sufficiently large time step. However, for most applications in
+practice, the stability of the scheme is mostly determined by the explicit
+update of normal forces with positions, that is, Eq. (10) is explicit in
+positions through the normal forces `fₙ(qⁿ, vⁿ)`. For many common
+applications, the explicit dependence of `τⁿ(tⁿ, qⁿ, vⁿ)` on the
+previous time step velocities `vⁿ` determines the overall stability of
+the scheme, since this term can include velocity dependent contributions
+such as control forces and dampers. Notice that Eq. (5) introduces an
+expansion of `fₙ` with an order of approximation consistent with the
+first order scheme as needed. Therefore, it propagates into a `O(δt²)`
+term exactly as needed in Eq. (9).
+
+@tparam T The type of mathematical object being added.
+Instantiated templates for the following kinds of T's are provided:
+- double
+- AutoDiffXd
+
+They are already available to link against in the containing library.
+No other values for T are currently supported. */
 template <typename T>
 class ImplicitStribeckSolver {
  public:


### PR DESCRIPTION
This PR simply refactors the Doxygen format of the ImplicitStribeckSolver.
I found out some limitations on using `///` and `<pre>` for certain symbols coming in the following PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9027)
<!-- Reviewable:end -->
