### PR TITLE
Combines diagram and leaf system parameter support in Context.

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -274,24 +274,38 @@ class Context : public ContextBase {
   // =========================================================================
   // Accessors and Mutators for Parameters.
 
-  virtual const Parameters<T>& get_parameters() const = 0;
-  virtual Parameters<T>& get_mutable_parameters() = 0;
+  /// Returns a const reference to this %Context's parameters.
+  const Parameters<T>& get_parameters() const { return *parameters_; }
+
+  /// Returns a mutable reference to this %Context's parameters.
+  Parameters<T>& get_mutable_parameters() {
+    return *parameters_;
+  }
+
+  /// Sets the parameters to @p params, deleting whatever was there before.
+  /// You must supply a Parameters object; null is not acceptable.
+  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
+  void set_parameters(std::unique_ptr<Parameters<T>> params) {
+    DRAKE_DEMAND(params != nullptr);
+    parameters_ = std::move(params);
+  }
 
   /// Returns the number of vector-valued parameters.
   int num_numeric_parameters() const {
-    return get_parameters().num_numeric_parameters();
+    return parameters_->num_numeric_parameters();
   }
 
   /// Returns a const reference to the vector-valued parameter at @p index.
-  /// Asserts if @p index doesn't exist.
+  /// @pre @p index must identify an existing parameter.
   const BasicVector<T>& get_numeric_parameter(int index) const {
-    return get_parameters().get_numeric_parameter(index);
+    return parameters_->get_numeric_parameter(index);
   }
 
   /// Returns a mutable reference to element @p index of the vector-valued
-  /// parameters. Asserts if @p index doesn't exist.
+  /// parameters.
+  /// @pre @p index must identify an existing parameter.
   BasicVector<T>& get_mutable_numeric_parameter(int index) {
-    return get_mutable_parameters().get_mutable_numeric_parameter(index);
+    return parameters_->get_mutable_numeric_parameter(index);
   }
 
   /// Returns the number of abstract-valued parameters.
@@ -300,13 +314,14 @@ class Context : public ContextBase {
   }
 
   /// Returns a const reference to the abstract-valued parameter at @p index.
-  /// Asserts if @p index doesn't exist.
+  /// @pre @p index must identify an existing parameter.
   const AbstractValue& get_abstract_parameter(int index) const {
     return get_parameters().get_abstract_parameter(index);
   }
 
   /// Returns a mutable reference to element @p index of the abstract-valued
-  /// parameters. Asserts if @p index doesn't exist.
+  /// parameters.
+  /// @pre @p index must identify an existing parameter.
   AbstractValue& get_mutable_abstract_parameter(int index) {
     return get_mutable_parameters().get_mutable_abstract_parameter(index);
   }
@@ -405,6 +420,10 @@ class Context : public ContextBase {
 
   // Accuracy setting.
   optional<double> accuracy_;
+
+  // The parameter values p for this System; this is never null.
+  copyable_unique_ptr<Parameters<T>> parameters_{
+      std::make_unique<Parameters<T>>()};
 };
 
 }  // namespace systems

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -282,14 +282,6 @@ class Context : public ContextBase {
     return *parameters_;
   }
 
-  /// Sets the parameters to @p params, deleting whatever was there before.
-  /// You must supply a Parameters object; null is not acceptable.
-  // TODO(sherm1) Shouldn't be user-callable, especially for Diagrams!
-  void set_parameters(std::unique_ptr<Parameters<T>> params) {
-    DRAKE_DEMAND(params != nullptr);
-    parameters_ = std::move(params);
-  }
-
   /// Returns the number of vector-valued parameters.
   int num_numeric_parameters() const {
     return parameters_->num_numeric_parameters();
@@ -414,6 +406,13 @@ class Context : public ContextBase {
   /// Returns a const reference to current time and step information.
   const StepInfo<T>& get_step_info() const { return step_info_; }
 
+  /// Provides storage for declared parameters, deleting whatever was there
+  /// before. You must supply a Parameters object; null is not acceptable.
+  void init_parameters(std::unique_ptr<Parameters<T>> params) {
+    DRAKE_DEMAND(params != nullptr);
+    parameters_ = std::move(params);
+  }
+
  private:
   // Current time and step information.
   StepInfo<T> step_info_;
@@ -421,7 +420,7 @@ class Context : public ContextBase {
   // Accuracy setting.
   optional<double> accuracy_;
 
-  // The parameter values p for this System; this is never null.
+  // The parameter values (p) for this Context; this is never null.
   copyable_unique_ptr<Parameters<T>> parameters_{
       std::make_unique<Parameters<T>>()};
 };

--- a/systems/framework/context_base.h
+++ b/systems/framework/context_base.h
@@ -342,7 +342,7 @@ namespace detail {
 // certain specific ContextBase private methods, and nothing else.
 class SystemBaseContextBaseAttorney {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemBaseContextBaseAttorney);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SystemBaseContextBaseAttorney)
   SystemBaseContextBaseAttorney() = delete;
 
  private:

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -233,11 +233,12 @@ class DiagramContext final : public Context<T> {
             &subparams.get_mutable_abstract_parameter(i));
       }
     }
-    Parameters<T>& params = this->get_mutable_parameters();
-    params.set_numeric_parameters(
+    auto params = std::make_unique<Parameters<T>>();
+    params->set_numeric_parameters(
         std::make_unique<DiscreteValues<T>>(numeric_params));
-    params.set_abstract_parameters(
+    params->set_abstract_parameters(
         std::make_unique<AbstractValues>(abstract_params));
+    this->init_parameters(std::move(params));
   }
 
   /// Returns the output structure for a given constituent system at @p index.

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -233,10 +233,10 @@ class DiagramContext final : public Context<T> {
             &subparams.get_mutable_abstract_parameter(i));
       }
     }
-    parameters_ = std::make_unique<Parameters<T>>();
-    parameters_->set_numeric_parameters(
+    Parameters<T>& params = this->get_mutable_parameters();
+    params.set_numeric_parameters(
         std::make_unique<DiscreteValues<T>>(numeric_params));
-    parameters_->set_abstract_parameters(
+    params.set_abstract_parameters(
         std::make_unique<AbstractValues>(abstract_params));
   }
 
@@ -300,14 +300,6 @@ class DiagramContext final : public Context<T> {
     return *state_;
   }
 
-  const Parameters<T>& get_parameters() const final {
-    return *parameters_;
-  }
-
-  Parameters<T>& get_mutable_parameters() final {
-    return *parameters_;
-  }
-
  protected:
   /// Protected copy constructor takes care of the local data members and
   /// all base class members, but doesn't update base class pointers so is
@@ -367,9 +359,6 @@ class DiagramContext final : public Context<T> {
 
   // The internal state of the Diagram, which includes all its subsystem states.
   std::unique_ptr<DiagramState<T>> state_;
-
-  // The parameters of the Diagram, which includes all subsystem parameters.
-  std::unique_ptr<Parameters<T>> parameters_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -46,6 +46,17 @@ class LeafContext : public Context<T> {
     return *state_.get();
   }
 
+#ifndef DRAKE_DOXYGEN_CXX
+  // Temporarily promoting this to public so that LeafSystem and testing
+  // code can construct a LeafContext with parameters. Users should never
+  // call this because parameters should not be resized once allocated (or at
+  // least should be done under Framework control so that dependency tracking
+  // can be correctly revised).
+  // TODO(sherm1) Make this inaccessible to users, along with other dangerous
+  // context resource sizing methods. See discussion in PR #9029.
+  using Context<T>::init_parameters;
+#endif
+
  protected:
   /// Protected copy constructor takes care of the local data members and
   /// all base class members, but doesn't update base class pointers so is
@@ -84,7 +95,7 @@ class LeafContext : public Context<T> {
   }
 
  private:
-  // The internal state (x) of this LeafSystem.
+  // The state values (x) for this LeafContext; this is never null.
   std::unique_ptr<State<T>> state_;
 };
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -33,8 +33,7 @@ class LeafContext : public Context<T> {
   //@}
 
   LeafContext()
-      : state_(std::make_unique<State<T>>()),
-        parameters_(std::make_unique<Parameters<T>>()) {}
+      : state_(std::make_unique<State<T>>()) {}
   ~LeafContext() override {}
 
   const State<T>& get_state() const final {
@@ -47,24 +46,6 @@ class LeafContext : public Context<T> {
     return *state_.get();
   }
 
-  // =========================================================================
-  // Accessors and Mutators for Parameters.
-
-  /// Sets the parameters to @p params, deleting whatever was there before.
-  void set_parameters(std::unique_ptr<Parameters<T>> params) {
-    parameters_ = std::move(params);
-  }
-
-  /// Returns the entire Parameters object.
-  const Parameters<T>& get_parameters() const final {
-    return *parameters_;
-  }
-
-  /// Returns the entire Parameters object.
-  Parameters<T>& get_mutable_parameters() final {
-    return *parameters_;
-  }
-
  protected:
   /// Protected copy constructor takes care of the local data members and
   /// all base class members, but doesn't update base class pointers so is
@@ -72,9 +53,6 @@ class LeafContext : public Context<T> {
   LeafContext(const LeafContext& source) : Context<T>(source) {
     // Make a deep copy of the state.
     state_ = source.CloneState();
-
-    // Make deep copies of the parameters.
-    set_parameters(source.parameters_->Clone());
 
     // Everything else was handled by the Context<T> copy constructor.
   }
@@ -106,11 +84,8 @@ class LeafContext : public Context<T> {
   }
 
  private:
-  // The internal state of the System.
+  // The internal state (x) of this LeafSystem.
   std::unique_ptr<State<T>> state_;
-
-  // The parameters of the system.
-  std::unique_ptr<Parameters<T>> parameters_;
 };
 
 }  // namespace systems

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -134,8 +134,9 @@ class LeafSystem : public System<T> {
     // Reserve discrete state via delegation to subclass.
     context->set_discrete_state(this->AllocateDiscreteState());
     context->set_abstract_state(this->AllocateAbstractState());
+
     // Reserve parameters via delegation to subclass.
-    context->set_parameters(this->AllocateParameters());
+    context->init_parameters(this->AllocateParameters());
 
     // Note that the outputs are not part of the Context, but instead are
     // checked by LeafSystemOutput::add_port.

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -91,9 +91,9 @@ class LeafContextTest : public ::testing::Test {
     vector_params.push_back(BasicVector<double>::Make({8.0, 16.0, 32.0, 64.0}));
     std::vector<std::unique_ptr<AbstractValue>> abstract_params;
     abstract_params.push_back(std::make_unique<Value<TestAbstractType>>());
-    context_.set_parameters(std::make_unique<Parameters<double>>(
-        std::move(vector_params),
-        std::move(abstract_params)));
+
+    context_.init_parameters(std::make_unique<Parameters<double>>(
+        std::move(vector_params), std::move(abstract_params)));
   }
 
   // Reads a FixedInputPortValue connected to @p context at @p index.

--- a/systems/sensors/rotary_encoders.cc
+++ b/systems/sensors/rotary_encoders.cc
@@ -58,6 +58,8 @@ RotaryEncoders<T>::RotaryEncoders(int input_port_size,
   DRAKE_ASSERT(ticks_per_revolution_.empty() ||
                *std::min_element(ticks_per_revolution_.begin(),
                                  ticks_per_revolution_.end()) >= 0);
+
+  // This vector is numeric parameter 0.
   this->DeclareNumericParameter(
       BasicVector<T>(VectorX<T>::Zero(num_encoders_)));
 }
@@ -78,7 +80,7 @@ void RotaryEncoders<T>::DoCalcVectorOutput(
   unused(state);
 
   const Eigen::VectorBlock<const VectorX<T>>& calibration_offsets =
-      this->GetNumericParameter(context, 0).get_value();
+      context.get_numeric_parameter(0).get_value();
   DRAKE_ASSERT(calibration_offsets.size() == num_encoders_);
 
   // Loop through the outputs.
@@ -102,17 +104,14 @@ template <typename T>
 void RotaryEncoders<T>::set_calibration_offsets(
     Context<T>* context,
     const Eigen::Ref<VectorX<T>>& calibration_offsets) const {
-  auto leaf_context = dynamic_cast<LeafContext<T>*>(context);
-  DRAKE_DEMAND(leaf_context != nullptr);
   DRAKE_DEMAND(calibration_offsets.rows() == num_encoders_);
-  leaf_context->set_parameters(std::make_unique<Parameters<T>>(
-      std::make_unique<BasicVector<T>>(calibration_offsets)));
+  context->get_mutable_numeric_parameter(0).set_value(calibration_offsets);
 }
 
 template <typename T>
 Eigen::VectorBlock<const VectorX<T>> RotaryEncoders<T>::get_calibration_offsets(
     const Context<T>& context) const {
-  return this->template GetNumericParameter(context, 0).get_value();
+  return context.get_numeric_parameter(0).get_value();
 }
 
 }  // namespace sensors


### PR DESCRIPTION
More code from caching branch #7668.

Previously there were two separate implementations of Parameter support for DiagramContext and LeafContext. Here that code is moved up to the parent Context class and shared. Besides being good code hygiene, this makes it easier to track parameter modifications and issue invalidations (in caching branch -- not done here).

There should be no API or functionality change.

This is a tiny PR:
```
Category            added  modified  removed  
----------------------------------------------
code                8      9         19       
comments            8      5         8        
blank               3      0         9        
----------------------------------------------
TOTAL               19     14        36       
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9029)
<!-- Reviewable:end -->
