### PR TITLE
symbolic: Allow for EIGEN_INITIALIZE_MATRICES_BY_ZERO

### DIFF
--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -118,6 +118,11 @@ class Formula {
   /** Default constructor. */
   Formula() { *this = True(); }
 
+  /** Constructs a default value.  This overload is used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+   */
+  explicit Formula(std::nullptr_t) : Formula() {}
+
   explicit Formula(std::shared_ptr<FormulaCell> ptr);
 
   /** Constructs a formula from @p var.

--- a/common/symbolic_monomial.h
+++ b/common/symbolic_monomial.h
@@ -31,6 +31,11 @@ class Monomial {
   /** Constructs a monomial equal to 1. Namely the total degree is zero. */
   Monomial() = default;
 
+  /** Constructs a default value.  This overload is used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+   */
+  explicit Monomial(std::nullptr_t) : Monomial() {}
+
   /** Constructs a Monomial from @p powers.
    * @throws std::logic_error if `powers` includes a negative exponent.
    */

--- a/common/symbolic_polynomial.h
+++ b/common/symbolic_polynomial.h
@@ -35,6 +35,11 @@ class Polynomial {
   Polynomial() = default;
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Polynomial)
 
+  /** Constructs a default value.  This overload is used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+   */
+  explicit Polynomial(std::nullptr_t) : Polynomial() {}
+
   /// Constructs a polynomial from a map, Monomial → Expression.
   explicit Polynomial(MapType init);
 

--- a/common/symbolic_variable.h
+++ b/common/symbolic_variable.h
@@ -50,6 +50,11 @@ class Variable {
         type_{Type::CONTINUOUS},
         name_{std::make_shared<std::string>()} {}
 
+  /** Constructs a default value.  This overload is used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+   */
+  explicit Variable(std::nullptr_t) : Variable() {}
+
   /** Constructs a variable with a string. If not specified, it has CONTINUOUS
    * type by default.*/
   explicit Variable(std::string name, Type type = Type::CONTINUOUS);

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -1217,6 +1217,15 @@ TEST_F(SymbolicFormulaTest, DrakeAssert) {
   DRAKE_THROW_UNLESS(mutable_f);
 }
 
+// Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
+// constructor both create the same value.
+GTEST_TEST(FormulaTest, DefaultConstructors) {
+  const Formula f_default;
+  const Formula f_zero(0);
+  EXPECT_TRUE(is_true(f_default));
+  EXPECT_TRUE(is_true(f_zero));
+}
+
 // This test checks whether symbolic::Formula is compatible with
 // std::unordered_set.
 GTEST_TEST(FormulaTest, CompatibleWithUnorderedSet) {

--- a/common/test/symbolic_monomial_test.cc
+++ b/common/test/symbolic_monomial_test.cc
@@ -119,6 +119,15 @@ class MonomialTest : public ::testing::Test {
   }
 };
 
+// Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
+// constructor both create the same value.
+TEST_F(MonomialTest, DefaultConstructors) {
+  const Monomial m_default;
+  const Monomial m_zero(0);
+  EXPECT_EQ(m_default.total_degree(), 0);
+  EXPECT_EQ(m_zero.total_degree(), 0);
+}
+
 TEST_F(MonomialTest, ConstructFromVariable) {
   const Monomial m1{var_x_};
   const std::map<Variable, int> powers{m1.get_powers()};

--- a/common/test/symbolic_polynomial_test.cc
+++ b/common/test/symbolic_polynomial_test.cc
@@ -80,9 +80,14 @@ class SymbolicPolynomialTest : public ::testing::Test {
   };
 };
 
-TEST_F(SymbolicPolynomialTest, DefaultConstructor) {
-  const Polynomial p{};
+// Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
+// constructor both create the same value.
+TEST_F(SymbolicPolynomialTest, DefaultConstructors) {
+  const Polynomial p;
   EXPECT_TRUE(p.monomial_to_coefficient_map().empty());
+
+  const Polynomial p_zero(0);
+  EXPECT_TRUE(p_zero.monomial_to_coefficient_map().empty());
 }
 
 TEST_F(SymbolicPolynomialTest, ConstructFromMapType1) {

--- a/common/test/symbolic_variable_test.cc
+++ b/common/test/symbolic_variable_test.cc
@@ -52,6 +52,15 @@ class VariableTest : public ::testing::Test {
   }
 };
 
+// Tests that default constructor and EIGEN_INITIALIZE_MATRICES_BY_ZERO
+// constructor both create the same value.
+TEST_F(VariableTest, DefaultConstructors) {
+  const Variable v_default;
+  const Variable v_zero(0);
+  EXPECT_TRUE(v_default.is_dummy());
+  EXPECT_TRUE(v_zero.is_dummy());
+}
+
 TEST_F(VariableTest, GetId) {
   const Variable dummy{};
   const Variable x_prime{"x"};


### PR DESCRIPTION
When a downstream user of Drake sets EIGEN_INITIALIZE_MATRICES_BY_ZERO,
Eigen will assume that any Eigen Scalar can be constructed from "0"
(a literal zero int).  This fixes the symbolic variable, monomial,
polynomial, and formula scalars to obey that contract.

Since an Eigen::Matrix over these types would be using the default
constructor when the ..._BY_ZERO macro is unset (as in Drake's default
build configuration), we choose to overload them to promote the zero int
to a nullptr, and then delegate to the existing default constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9030)
<!-- Reviewable:end -->
