### PR TITLE
Added separate C and C++ rules for Gurobi

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -51,7 +51,7 @@ drake_cc_library(
         "//tools:with_gurobi": [
             ":rigid_body_constraint",
             ":rigid_body_tree",
-            "@gurobi",
+            "@gurobi//:gurobi_c",
         ],
         "//conditions:default": [],
     }),

--- a/multibody/approximate_ik.cc
+++ b/multibody/approximate_ik.cc
@@ -2,7 +2,7 @@
 
 #include <set>
 
-#include <gurobi_c++.h>
+#include <gurobi_c.h>
 
 #include "drake/multibody/ik_options.h"
 #include "drake/multibody/rigid_body_constraint.h"

--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -566,7 +566,7 @@ drake_cc_library(
         "//tools:with_gurobi": [
             ":mathematical_program_api",
             "//math:eigen_sparse_triplet",
-            "@gurobi",
+            "@gurobi//:gurobi_c",
         ],
         "//conditions:default": [
             ":mathematical_program_api",
@@ -762,7 +762,7 @@ drake_cc_library(
     deps = select({
         "//tools:with_gurobi": [
             "@eigen",
-            "@gurobi",
+            "@gurobi//:gurobi_c",
         ],
         "//conditions:default": [],
     }),

--- a/solvers/gurobi_qp.h
+++ b/solvers/gurobi_qp.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include <Eigen/Dense>
-#include <gurobi_c++.h>
+#include <gurobi_c.h>
 
 #define CGE(call, env)                                                  \
   {                                                                     \

--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -15,7 +15,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 // NOLINTNEXTLINE(build/include) False positive due to weird include style.
-#include "gurobi_c++.h"
+#include "gurobi_c.h"
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging.h"

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -63,7 +63,7 @@ install(
 cc_library(
     name = "gurobi_deps",
     deps = select({
-        "//tools:with_gurobi": ["@gurobi"],
+        "//tools:with_gurobi": ["@gurobi//:gurobi_c"],
         "//conditions:default": [],
     }),
 )

--- a/tools/workspace/gurobi/package-macos.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-macos.BUILD.bazel.in
@@ -15,19 +15,44 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
-GUROBI_HDRS = glob([
+GUROBI_C_HDRS = glob([
+    "gurobi-distro/include/gurobi_c.h",
+]) or [":error-message.h"]
+
+GUROBI_CXX_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
     "gurobi-distro/include/gurobi_c++.h",
 ]) or [":error-message.h"]
 
 cc_library(
-    name = "gurobi",
-    hdrs = GUROBI_HDRS,
+    name = "gurobi_c",
+    hdrs = GUROBI_C_HDRS,
     includes = ["gurobi-distro/include"],
     linkopts = [
         "-L{gurobi_path}/lib",
         "-lgurobi80",
     ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "gurobi_cxx",
+    hdrs = GUROBI_CXX_HDRS,
+    includes = ["gurobi-distro/include"],
+    linkopts = [
+        "-L{gurobi_path}/lib",
+        "-lgurobi80",
+        "-lgurobi_stdc++",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# TODO(pvarin): Remove this alias and deprecation message after 2018-09-21
+alias(
+    name = "gurobi",
+    actual = "gurobi_c",
+    deprecation = "The @gurobi//:gurobi target is deprecated, \
+                   you should use @gurobi//:gurobi_c instead",
     visibility = ["//visibility:public"],
 )
 

--- a/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
+++ b/tools/workspace/gurobi/package-ubuntu.BUILD.bazel.in
@@ -16,7 +16,11 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
-GUROBI_HDRS = glob([
+GUROBI_C_HDRS = glob([
+    "gurobi-distro/include/gurobi_c.h",
+]) or [":error-message.h"]
+
+GUROBI_CXX_HDRS = glob([
     "gurobi-distro/include/gurobi_c.h",
     "gurobi-distro/include/gurobi_c++.h",
 ]) or [":error-message.h"]
@@ -27,8 +31,14 @@ GUROBI_HDRS = glob([
 # because the NEEDED statements in the executable will not square with the
 # RPATH statements.  I don't really know why this happens, but I suspect it
 # might be a Bazel bug.
-GUROBI_SRCS = glob([
+
+GUROBI_C_SRCS = glob([
     "gurobi-distro/lib/libgurobi80.so",
+]) or [":error-message.h"]
+
+GUROBI_CXX_SRCS = glob([
+    "gurobi-distro/lib/libgurobi80.so",
+    "gurobi-distro/lib/libgurobi_g++5.2.a",
 ]) or [":error-message.h"]
 
 GUROBI_INSTALL_LIBRARIES = glob([
@@ -41,11 +51,29 @@ GUROBI_DOCS = glob([
 ]) or [":error-message.h"]
 
 cc_library(
-    name = "gurobi",
-    srcs = GUROBI_SRCS,
-    hdrs = GUROBI_HDRS,
+    name = "gurobi_c",
+    srcs = GUROBI_C_SRCS,
+    hdrs = GUROBI_C_HDRS,
     includes = ["gurobi-distro/include"],
     linkopts = ["-pthread"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "gurobi_cxx",
+    srcs = GUROBI_CXX_SRCS,
+    hdrs = GUROBI_CXX_HDRS,
+    includes = ["gurobi-distro/include"],
+    linkopts = ["-pthread"],
+    visibility = ["//visibility:public"],
+)
+
+# TODO(pvarin): Remove this alias and deprecation message after 2018-09-21
+alias(
+    name = "gurobi",
+    actual = "gurobi_c",
+    deprecation = "The @gurobi//:gurobi target is deprecated, \
+                   you should use @gurobi//:gurobi_c instead",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Per the discussion with @jwnimmer-tri  and @hongkai-dai  on Slack. I created separate rules for the C and C++ bindings for Gurobi, `@gurobi:c` and `@gurobi:cxx` respectively and aliased `@gurobi:gurobi` to `@gurobi:c`.

I also went through the places where `"gurobi_c++.h"` was included and changed this to `"gurobi_c.h"` since Drake only uses the C interface at the moment.

I edited both the MacOS and Ubuntu build files but could only test the Ubuntu file with my setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9035)
<!-- Reviewable:end -->
