### PR TITLE
setup/ubuntu: Install `libtbb2`

### DIFF
--- a/setup/ubuntu/16.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/16.04/binary_distribution/packages.txt
@@ -19,6 +19,7 @@ libpng12-0
 libprotobuf-dev
 libqt5multimedia5
 libqt5x11extras5
+libtbb2
 libtheora0
 libtiff5
 libtinyxml2-dev

--- a/setup/ubuntu/18.04/binary_distribution/packages.txt
+++ b/setup/ubuntu/18.04/binary_distribution/packages.txt
@@ -19,6 +19,7 @@ libpng16-16
 libprotobuf-dev
 libqt5multimedia5
 libqt5x11extras5
+libtbb2
 libtheora0
 libtiff5
 libtinyxml2-dev


### PR DESCRIPTION
Resolves #8964

(Assuming `libtbb2` was the only missing dependency.)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9042)
<!-- Reviewable:end -->
