### PR TITLE
Adding in torsional springs to RigidBodyTree

### DIFF
--- a/multibody/BUILD.bazel
+++ b/multibody/BUILD.bazel
@@ -469,6 +469,18 @@ drake_cc_googletest(
 )
 
 drake_cc_googletest(
+    name = "rigid_body_tree_spring_test",
+    srcs = ["test/rigid_body_tree/rigid_body_tree_spring_test.cc"],
+    data = [":test_models"],
+    deps = [
+        ":rigid_body_tree",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/parsers",
+    ],
+)
+
+drake_cc_googletest(
     name = "rigid_body_distance_constraint_test",
     deps = [
         ":rigid_body_distance_constraint",

--- a/multibody/joints/BUILD.bazel
+++ b/multibody/joints/BUILD.bazel
@@ -71,6 +71,7 @@ drake_cc_googletest(
     name = "joint_test",
     deps = [
         ":joint_compare_to_clone",
+        "//common/test_utilities:eigen_matrix_compare",
     ],
 )
 

--- a/multibody/joints/drake_joint.h
+++ b/multibody/joints/drake_joint.h
@@ -54,6 +54,10 @@
                                                                              \
   virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1> frictionTorque(           \
       const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v)   \
+      const = 0;                                                             \
+                                                                             \
+  virtual Eigen::Matrix<Scalar, Eigen::Dynamic, 1> SpringTorque(             \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q)   \
       const = 0;
 
 /**

--- a/multibody/joints/drake_joint_impl.h
+++ b/multibody/joints/drake_joint_impl.h
@@ -61,6 +61,12 @@
       const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& v)   \
       const override {                                                       \
     return derived_.frictionTorque(v);                                       \
+  };                                                                         \
+                                                                             \
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1> SpringTorque(                     \
+      const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>& q)   \
+      const override {                                                       \
+    return derived_.SpringTorque(q);                                         \
   };
 
 #pragma GCC diagnostic push

--- a/multibody/joints/fixed_joint.h
+++ b/multibody/joints/fixed_joint.h
@@ -102,6 +102,14 @@ class FixedJoint : public DrakeJointImpl<FixedJoint> {
         get_num_velocities(), 1);
   }
 
+  template <typename DerivedQ>
+  Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, 1> SpringTorque(
+      const Eigen::MatrixBase<DerivedQ>& q) const {
+    drake::unused(q);
+    // Fixed joints have zero degrees of freedom.
+    return drake::VectorX<typename DerivedQ::Scalar>::Zero(0, 1);
+  }
+
   std::string get_position_name(int index) const override;
   Eigen::VectorXd zeroConfiguration() const override;
   Eigen::VectorXd randomConfiguration(

--- a/multibody/joints/quaternion_ball_joint.h
+++ b/multibody/joints/quaternion_ball_joint.h
@@ -262,6 +262,17 @@ class QuaternionBallJoint : public DrakeJointImpl<QuaternionBallJoint> {
         get_num_velocities(), 1);
   }
 
+  template <typename DerivedQ>
+  Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, 1> SpringTorque(
+      const Eigen::MatrixBase<DerivedQ>& q) const {
+    drake::unused(q);
+    // Returning zero for now, but a 3D torsional spring could theoretically be
+    // added here.
+    return drake::VectorX<typename DerivedQ::Scalar>::Zero(
+        get_num_velocities(), 1);
+  }
+
+
   bool is_floating() const override { return false; };
 
   // TODO(liang.fok) Remove this deprecated method prior to release 1.0.

--- a/multibody/joints/quaternion_floating_joint.h
+++ b/multibody/joints/quaternion_floating_joint.h
@@ -304,6 +304,17 @@ class QuaternionFloatingJoint : public DrakeJointImpl<QuaternionFloatingJoint> {
         get_num_velocities(), 1);
   }
 
+  template <typename DerivedQ>
+  Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, 1> SpringTorque(
+      const Eigen::MatrixBase<DerivedQ>& q) const {
+    drake::unused(q);
+    // Returning zero for now, but a 3D torsional spring could theoretically be
+    // added here.
+    return drake::VectorX<typename DerivedQ::Scalar>::Zero(
+        get_num_velocities(), 1);
+  }
+
+
   bool is_floating() const override { return true; };
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.

--- a/multibody/joints/roll_pitch_yaw_floating_joint.h
+++ b/multibody/joints/roll_pitch_yaw_floating_joint.h
@@ -272,6 +272,17 @@ class RollPitchYawFloatingJoint
         get_num_velocities(), 1);
   }
 
+  template <typename DerivedQ>
+  Eigen::Matrix<typename DerivedQ::Scalar, Eigen::Dynamic, 1> SpringTorque(
+      const Eigen::MatrixBase<DerivedQ>& q) const {
+    drake::unused(q);
+    // Returning zero for now, but a 3D torsional spring could theoretically be
+    // added here.
+    return drake::VectorX<typename DerivedQ::Scalar>::Zero(
+        get_num_velocities(), 1);
+  }
+
+
   bool is_floating() const override { return true; }
 
 // TODO(liang.fok) Remove this deprecated method prior to release 1.0.

--- a/multibody/rigid_body.h
+++ b/multibody/rigid_body.h
@@ -12,6 +12,7 @@
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_deprecated.h"
+#include "drake/common/drake_throw.h"
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/collision/drake_collision.h"
 #include "drake/multibody/joints/drake_joint.h"
@@ -118,6 +119,19 @@ class RigidBody {
    */
   const DrakeJoint& getJoint() const {
     DRAKE_DEMAND(joint_ != nullptr);
+    return *joint_;
+  }
+
+  /**
+   * An accessor to this rigid body's mutable inboard joint. Also called "parent joint".
+   *
+   * @throws std::runtime_error if there is no joint (joint == nullptr)
+   * @return The mutable inboard joint of this rigid body.
+   */
+  DrakeJoint& get_mutable_joint() {
+    DRAKE_THROW_UNLESS(joint_ != nullptr);
+    if (body_index_ == 0)
+      throw std::runtime_error("This method cannot be called on world body");
     return *joint_;
   }
 

--- a/multibody/rigid_body_tree.h
+++ b/multibody/rigid_body_tree.h
@@ -844,6 +844,15 @@ class RigidBodyTree {
   Eigen::Matrix<typename DerivedV::Scalar, Eigen::Dynamic, 1> frictionTorques(
       Eigen::MatrixBase<DerivedV> const& v) const;
 
+
+  /// Computes the generalized forces that correspond to joint springs.
+  ///
+  /// Spring forces are computed joint-by-joint and are a function of position
+  /// only (they do not couple between joints)
+  template <typename Scalar>
+  drake::VectorX<Scalar> CalcGeneralizedSpringForces(
+      const drake::VectorX<Scalar>& q) const;
+
   template <
       typename Scalar,
       typename DerivedPoints>  // not necessarily any relation between the two;

--- a/multibody/test/rigid_body_tree/rigid_body_tree_spring_test.cc
+++ b/multibody/test/rigid_body_tree/rigid_body_tree_spring_test.cc
@@ -1,0 +1,98 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/multibody/joints/revolute_joint.h"
+/* clang-format on */
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/find_resource.h"
+#include "drake/common/pointer_cast.h"
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/joints/floating_base_types.h"
+#include "drake/multibody/parsers/urdf_parser.h"
+
+namespace drake {
+namespace systems {
+namespace plants {
+namespace test {
+namespace {
+
+using std::unique_ptr;
+using Eigen::VectorXd;
+using parsers::urdf::AddModelInstanceFromUrdfFileToWorld;
+
+class RigidBodyTreeSpringTest : public ::testing::Test {
+ protected:
+  void TestTreeWithSpring(bool use_fixed_base) {
+    unique_ptr<RigidBodyTree<double>> tree =
+        std::make_unique<RigidBodyTree<double>>();
+    const std::string filename = FindResourceOrThrow(
+        "drake/multibody/test/rigid_body_tree/two_dof_robot.urdf");
+    if (use_fixed_base) {
+      AddModelInstanceFromUrdfFileToWorld(filename,
+          multibody::joints::kQuaternion, tree.get());
+    } else {
+      AddModelInstanceFromUrdfFileToWorld(filename, multibody::joints::kFixed,
+          tree.get());
+    }
+
+    // Compute bias without spring forces.
+    VectorXd q(tree->get_num_positions());
+    VectorXd v(tree->get_num_velocities());
+    for (int i = 0; i < q.size(); ++i) {
+      q(i) = i+1;
+    }
+    for (int i = 0; i < v.size(); ++i) {
+      v(i) = -2*i-1;
+    }
+
+
+    KinematicsCache<double> kinsol = tree->doKinematics(q, v);
+    const typename RigidBodyTree<double>::BodyToWrenchMap no_external_wrenches;
+    VectorXd bias_no_spring = tree->dynamicsBiasTerm(kinsol,
+                                                     no_external_wrenches,
+                                                     true);
+
+    const double stiffness = 102.0;  // Nm/rad
+    const double nominal_position = 1.1;  // rad
+
+    const int body_index = tree->FindIndexOfChildBodyOfJoint("joint2");
+    auto body = tree->get_mutable_body(body_index);
+
+    RevoluteJoint& joint = dynamic_cast<RevoluteJoint&>(
+        body->get_mutable_joint());
+
+    joint.SetSpringDynamics(stiffness, nominal_position);
+
+    VectorXd bias_spring = tree->dynamicsBiasTerm(kinsol,
+                                                  no_external_wrenches, true);
+    VectorXd delta_bias = VectorXd::Zero(tree->get_num_velocities());
+    const int q_ind = body->get_position_start_index();
+    const int v_ind = body->get_velocity_start_index();
+    delta_bias(v_ind) = stiffness * (nominal_position - q(q_ind));
+
+    EXPECT_TRUE(CompareMatrices(bias_no_spring - delta_bias, bias_spring,
+      0, MatrixCompareType::absolute));
+  }
+};
+
+// Tests spring forces effect on RigidBodyTree dynamics.
+// Computes dynamics with and without a spring, and checks that the difference
+// is correct.
+TEST_F(RigidBodyTreeSpringTest, QuaternionBaseSpringTest) {
+  TestTreeWithSpring(false);
+}
+
+TEST_F(RigidBodyTreeSpringTest, FixedBaseSpringTest) {
+  TestTreeWithSpring(true);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace plants
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
A first pass at adding torsional springs to RigidBodyTree. This implementation adds them to DrakeJoint, and then generates the spring forces in a manner similar to frictionTorques. No URDF parser is included. Parameters must be set manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9044)
<!-- Reviewable:end -->
