### PR TITLE
pydrake rbt: Bind `AddCollisionFilterGroupMember`

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -102,6 +102,7 @@ PYBIND11_MODULE(rigid_body_tree, m) {
         py::arg("urdf_filename"), py::arg("joint_type") = "ROLLPITCHYAW"
       )
     .def("compile", &RigidBodyTree<double>::compile)
+    .def("initialized", &RigidBodyTree<double>::initialized)
     .def("drawKinematicTree", &RigidBodyTree<double>::drawKinematicTree)
     .def("getRandomConfiguration", [](const RigidBodyTree<double>& tree) {
       std::default_random_engine generator(std::random_device {}());
@@ -128,6 +129,13 @@ PYBIND11_MODULE(rigid_body_tree, m) {
     .def("get_position_name", &RigidBodyTree<double>::get_position_name)
     .def("add_rigid_body", &RigidBodyTree<double>::add_rigid_body)
     .def("addCollisionElement", &RigidBodyTree<double>::addCollisionElement)
+    .def("AddCollisionFilterGroupMember",
+         &RigidBodyTree<double>::AddCollisionFilterGroupMember,
+         py::arg("group_name"), py::arg("body_name"),
+         py::arg("model_id"))
+    .def("DefineCollisionFilterGroup",
+         &RigidBodyTree<double>::DefineCollisionFilterGroup,
+         py::arg("name"))
     .def("addFrame", &RigidBodyTree<double>::addFrame, py::arg("frame"))
     .def("FindBody", [](const RigidBodyTree<double>& self,
                         const std::string& body_name,
@@ -364,12 +372,18 @@ PYBIND11_MODULE(rigid_body_tree, m) {
          &RigidBodyFrame<double>::get_transform_to_body);
 
   m.def("AddModelInstanceFromUrdfFile",
-        py::overload_cast<const std::string&, const FloatingBaseType,
-                          shared_ptr<RigidBodyFrame<double>>,
-                          RigidBodyTree<double>*>(
-            &parsers::urdf::AddModelInstanceFromUrdfFile),
+        [](const std::string& urdf_filename,
+           const FloatingBaseType floating_base_type,
+           shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+           RigidBodyTree<double>* tree,
+           bool do_compile) {
+          return parsers::urdf::AddModelInstanceFromUrdfFile(
+              urdf_filename, floating_base_type, weld_to_frame,
+              do_compile, tree);
+        },
         py::arg("urdf_filename"), py::arg("floating_base_type"),
-        py::arg("weld_to_frame"), py::arg("tree"));
+        py::arg("weld_to_frame"), py::arg("tree"),
+        py::arg("do_compile") = true);
   m.def("AddModelInstanceFromUrdfStringSearchingInRosPackages",
         py::overload_cast<const std::string&, const PackageMap&,
                           const std::string&, const FloatingBaseType,
@@ -378,10 +392,17 @@ PYBIND11_MODULE(rigid_body_tree, m) {
             &parsers::urdf::
                 AddModelInstanceFromUrdfStringSearchingInRosPackages));
   m.def("AddModelInstancesFromSdfFile",
-        py::overload_cast<const std::string&, const FloatingBaseType,
-                          std::shared_ptr<RigidBodyFrame<double>>,
-                          RigidBodyTree<double>*>(
-            &sdf::AddModelInstancesFromSdfFile)),
+        [](const std::string& sdf_filename,
+           const FloatingBaseType floating_base_type,
+           std::shared_ptr<RigidBodyFrame<double>> weld_to_frame,
+           RigidBodyTree<double>* tree, bool do_compile) {
+          return sdf::AddModelInstancesFromSdfFile(
+              sdf_filename, floating_base_type, weld_to_frame, do_compile,
+              tree);
+        },
+        py::arg("sdf_filename"), py::arg("floating_base_type"),
+        py::arg("weld_to_frame"), py::arg("tree"),
+        py::arg("do_compile") = true);
   m.def("AddModelInstancesFromSdfString",
         py::overload_cast<const std::string&, const FloatingBaseType,
                           shared_ptr<RigidBodyFrame<double>>,

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -473,7 +473,13 @@ class TestRigidBodyTree(unittest.TestCase):
         box_collision_element.set_body(body_2)
         rbt.addCollisionElement(box_collision_element, body_2, "default")
 
+        rbt.DefineCollisionFilterGroup(name="test_group")
+        rbt.AddCollisionFilterGroupMember(
+            group_name="test_group", body_name="body_2", model_id=0)
+
+        self.assertFalse(rbt.initialized())
         rbt.compile()
+        self.assertTrue(rbt.initialized())
 
         # The RBT's position vector should now be [z, theta].
         self.assertEqual(body_1.get_position_start_index(), 0)


### PR DESCRIPTION
Expose `do_compile` in basic `AddModelInstanceFrom*File` overloads in
a backwards-compatible fashion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9045)
<!-- Reviewable:end -->
