### PR TITLE
 rbt: Make `q` and `v` size mismatch assertions trigger on release builds 

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -244,9 +244,11 @@ PYBIND11_MODULE(rigid_body_tree, m) {
                                     const KinematicsCache<T>& cache,
                                     int base_or_frame_ind,
                                     int body_or_frame_ind) {
-        return tree.relativeTransform(cache, base_or_frame_ind,
-          body_or_frame_ind).matrix();
-      })
+          return tree.relativeTransform(cache, base_or_frame_ind,
+            body_or_frame_ind).matrix();
+        },
+        py::arg("cache"),
+        py::arg("base_or_frame_ind"), py::arg("body_or_frame_ind"))
       .def("centerOfMassJacobian",
            &RigidBodyTree<double>::centerOfMassJacobian<T>,
            py::arg("cache"),

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -41,6 +41,18 @@ class TestRigidBodyTree(unittest.TestCase):
         p = tree.transformPoints(kinsol, np.zeros(3), 0, 1)
         self.assertTrue(np.allclose(p, np.zeros(3)))
 
+        # Ensure mismatched sizes throw an error.
+        q_bad = np.zeros(num_q + 1)
+        v_bad = np.zeros(num_v + 1)
+        bad_args_list = (
+            (q_bad,),
+            (q_bad, v),
+            (q, v_bad),
+        )
+        for bad_args in bad_args_list:
+            with self.assertRaises(SystemExit):
+                tree.doKinematics(*bad_args)
+
         # AutoDiff jacobians.
 
         def do_transform(q):

--- a/multibody/kinematics_cache-inl.h
+++ b/multibody/kinematics_cache-inl.h
@@ -79,7 +79,7 @@ void KinematicsCache<T>::initialize(const Eigen::MatrixBase<Derived>& q_in) {
   static_assert(Derived::ColsAtCompileTime == 1, "q must be a vector");
   static_assert(std::is_same<typename Derived::Scalar, T>::value,
                 "T type of q must match T type of KinematicsCache");
-  DRAKE_ASSERT(q.rows() == q_in.rows());
+  DRAKE_DEMAND(q.rows() == q_in.rows());
   q = q_in;
   invalidate();
   velocity_vector_valid = false;
@@ -93,7 +93,7 @@ void KinematicsCache<T>::initialize(const Eigen::MatrixBase<DerivedQ>& q_in,
   static_assert(DerivedV::ColsAtCompileTime == 1, "v must be a vector");
   static_assert(std::is_same<typename DerivedV::Scalar, T>::value,
                 "T type of v must match T type of KinematicsCache");
-  DRAKE_ASSERT(v.rows() == v_in.rows());
+  DRAKE_DEMAND(v.rows() == v_in.rows());
   v = v_in;
   velocity_vector_valid = true;
 }


### PR DESCRIPTION
Resolves #8861

@thduynguyen and @naveenoid have both hit this issue in the past month.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9047)
<!-- Reviewable:end -->
