### PR TITLE
Formally deprecate the AllocateOutput() signature that takes a Context

### DIFF
--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -694,8 +694,7 @@ template <typename T>
 PoseBundle<T> AutomotiveSimulator<T>::GetCurrentPoses() const {
   DRAKE_DEMAND(has_started());
   const auto& context = simulator_->get_context();
-  std::unique_ptr<SystemOutput<T>> system_output = diagram_->AllocateOutput(
-      context);
+  std::unique_ptr<SystemOutput<T>> system_output = diagram_->AllocateOutput();
   diagram_->CalcOutput(context, system_output.get());
   DRAKE_DEMAND(system_output->get_num_ports() == 1);
   const AbstractValue* abstract_value = system_output->get_data(0);

--- a/automotive/test/bicycle_car_test.cc
+++ b/automotive/test/bicycle_car_test.cc
@@ -23,7 +23,7 @@ class BicycleCarTest : public ::testing::Test {
     dut_.reset(new BicycleCar<double>());
 
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 

--- a/automotive/test/car_vis_applicator_test.cc
+++ b/automotive/test/car_vis_applicator_test.cc
@@ -39,7 +39,7 @@ class CarVisApplicatorTest : public ::testing::Test {
 
   void CreateOutputAndContext() {
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
   }
 
   void SetInput(const PoseBundle<double>& pose_bundle) {

--- a/automotive/test/driving_command_mux_test.cc
+++ b/automotive/test/driving_command_mux_test.cc
@@ -19,7 +19,7 @@ class DrivingCommandMuxTest : public ::testing::Test {
   void SetUp() override {
     mux_ = std::make_unique<DrivingCommandMux<double>>();
     context_ = mux_->CreateDefaultContext();
-    output_ = mux_->AllocateOutput(*context_);
+    output_ = mux_->AllocateOutput();
   }
 
   std::unique_ptr<DrivingCommandMux<double>> mux_;
@@ -67,7 +67,7 @@ TEST_F(DrivingCommandMuxTest, ToAutoDiff) {
     EXPECT_EQ(2, converted.get_output_port(0).size());
 
     const auto context = converted.CreateDefaultContext();
-    const auto output = converted.AllocateOutput(*context);
+    const auto output = converted.AllocateOutput();
     const DrivingCommand<AutoDiffXd>* driving_command_output =
         dynamic_cast<const DrivingCommand<AutoDiffXd>*>(
             output->get_vector_data(0));
@@ -86,7 +86,7 @@ TEST_F(DrivingCommandMuxTest, ToSymbolic) {
     EXPECT_EQ(2, converted.get_output_port(0).size());
 
     const auto context = converted.CreateDefaultContext();
-    const auto output = converted.AllocateOutput(*context);
+    const auto output = converted.AllocateOutput();
     const DrivingCommand<symbolic::Expression>* driving_command_output =
         dynamic_cast<const DrivingCommand<symbolic::Expression>*>(
             output->get_vector_data(0));

--- a/automotive/test/dynamic_bicycle_car_test.cc
+++ b/automotive/test/dynamic_bicycle_car_test.cc
@@ -145,9 +145,9 @@ class DynamicBicycleCarTest : public ::testing::Test {
     test_car_ = std::make_unique<DynamicBicycleCar<double>>();
     test_car_params_ = std::make_unique<DynamicBicycleCarParams<double>>();
     context_ = test_car_->CreateDefaultContext();
-    output_ = test_car_->AllocateOutput(*context_);
+    output_ = test_car_->AllocateOutput();
     derivatives_ = test_car_->AllocateTimeDerivatives();
-    system_output_ = test_car_->AllocateOutput(*context_);
+    system_output_ = test_car_->AllocateOutput();
   }
 
   // Returns a pointer to the state vector.

--- a/automotive/test/idm_controller_test.cc
+++ b/automotive/test/idm_controller_test.cc
@@ -43,7 +43,7 @@ class IdmControllerTest
     dut_.reset(new IdmController<double>(*road_, path_or_branches,
                cache_or_search_, period_sec_));
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
 
     const auto idm = dynamic_cast<const IdmController<double>*>(dut_.get());
     DRAKE_DEMAND(idm != nullptr);
@@ -227,7 +227,7 @@ TEST_P(IdmControllerTest, ToAutoDiff) {
 
   EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& other_dut) {
     const auto other_context = other_dut.CreateDefaultContext();
-    const auto other_output = other_dut.AllocateOutput(*other_context);
+    const auto other_output = other_dut.AllocateOutput();
 
     // Verify that CalcOutput returns a result and validate its AutoDiff
     // derivatives.

--- a/automotive/test/maliput_railcar_test.cc
+++ b/automotive/test/maliput_railcar_test.cc
@@ -179,7 +179,7 @@ class MaliputRailcarTest : public ::testing::Test {
     const maliput::api::Lane* lane = road_->junction(0)->segment(0)->lane(0);
     dut_.reset(new MaliputRailcar<double>(LaneDirection(lane, with_s)));
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 

--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -53,7 +53,7 @@ class MobilPlannerTest : public ::testing::TestWithParam<RoadPositionStrategy> {
     dut_.reset(new MobilPlanner<double>(
         *road_, initial_with_s, cache_or_search_, period_sec_));
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
 
     const auto mp = dynamic_cast<const MobilPlanner<double>*>(dut_.get());
     DRAKE_DEMAND(mp != nullptr);

--- a/automotive/test/pure_pursuit_controller_test.cc
+++ b/automotive/test/pure_pursuit_controller_test.cc
@@ -36,7 +36,7 @@ class PurePursuitControllerTest : public ::testing::Test {
     // Initialize PurePursuitController with the dragway.
     dut_.reset(new PurePursuitController<double>());
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
   }
 
   // Create poses for one ego car and two traffic cars.
@@ -86,7 +86,7 @@ TEST_F(PurePursuitControllerTest, Topology) {
 TEST_F(PurePursuitControllerTest, ToAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& other_dut) {
     auto other_context = other_dut.CreateDefaultContext();
-    auto other_output = other_dut.AllocateOutput(*other_context);
+    auto other_output = other_dut.AllocateOutput();
     auto other_derivatives = other_dut.AllocateTimeDerivatives();
 
     other_context->FixInputPort(dut_->lane_input().get_index(),

--- a/automotive/test/simple_car_test.cc
+++ b/automotive/test/simple_car_test.cc
@@ -24,7 +24,7 @@ class SimpleCarTest : public ::testing::Test {
   void SetUp() override {
     dut_.reset(new SimpleCar<double>);
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
     SetInputValue(0.0, 0.0);
   }
@@ -354,7 +354,7 @@ TEST_F(SimpleCarTest, Derivatives) {
 TEST_F(SimpleCarTest, TransmogrifyAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(*dut_, [&](const auto& other_dut) {
     auto other_context = other_dut.CreateDefaultContext();
-    auto other_output = other_dut.AllocateOutput(*other_context);
+    auto other_output = other_dut.AllocateOutput();
     auto other_derivatives = other_dut.AllocateTimeDerivatives();
 
     auto input_value = std::make_unique<DrivingCommand<AutoDiffXd>>();
@@ -369,7 +369,7 @@ TEST_F(SimpleCarTest, TransmogrifyAutoDiff) {
 TEST_F(SimpleCarTest, TransmogrifySymbolic) {
   EXPECT_TRUE(is_symbolic_convertible(*dut_, [&](const auto& other_dut) {
     auto other_context = other_dut.CreateDefaultContext();
-    auto other_output = other_dut.AllocateOutput(*other_context);
+    auto other_output = other_dut.AllocateOutput();
     auto other_derivatives = other_dut.AllocateTimeDerivatives();
 
     // TODO(jwnimmer-tri) We should have a framework way to just say "make the

--- a/automotive/test/trajectory_car_test.cc
+++ b/automotive/test/trajectory_car_test.cc
@@ -104,7 +104,7 @@ TYPED_TEST(TrajectoryCarTest, ConstantSpeedTest) {
     systems::Simulator<T> simulator(car_dut);
     systems::Context<T>& context = simulator.get_mutable_context();
     std::unique_ptr<systems::SystemOutput<T>> all_output =
-        car_dut.AllocateOutput(context);
+        car_dut.AllocateOutput();
 
     // Specify the initial position and speed.
     auto car_state = dynamic_cast<TrajectoryCarState<T>*>(
@@ -347,7 +347,7 @@ GTEST_TEST(TrajectoryCarTest, ToAutoDiff) {
 
   EXPECT_TRUE(is_autodiffxd_convertible(dut, [&](const auto& autodiff_dut) {
     auto context = autodiff_dut.CreateDefaultContext();
-    auto output = autodiff_dut.AllocateOutput(*context);
+    auto output = autodiff_dut.AllocateOutput();
     auto derivatives = autodiff_dut.AllocateTimeDerivatives();
 
     context->FixInputPort(

--- a/automotive/test/trajectory_follower_test.cc
+++ b/automotive/test/trajectory_follower_test.cc
@@ -88,7 +88,7 @@ GTEST_TEST(TrajectoryFollowerTest, Outputs) {
     systems::Simulator<double> simulator(follower);
     systems::Context<double>& context = simulator.get_mutable_context();
     std::unique_ptr<systems::SystemOutput<double>> outputs =
-        follower.AllocateOutput(context);
+        follower.AllocateOutput();
     simulator.Initialize();
 
     const double end_time = it.distance / kSpeed;
@@ -152,7 +152,7 @@ GTEST_TEST(TrajectoryFollowerTest, ToAutoDiff) {
   EXPECT_TRUE(is_autodiffxd_convertible(follower,
                                         [&](const auto& autodiff_dut) {
     auto context = autodiff_dut.CreateDefaultContext();
-    auto output = autodiff_dut.AllocateOutput(*context);
+    auto output = autodiff_dut.AllocateOutput();
 
     // Check that the public methods can be called without exceptions.
     autodiff_dut.CalcOutput(*context, output.get());

--- a/bindings/pydrake/solvers/BUILD.bazel
+++ b/bindings/pydrake/solvers/BUILD.bazel
@@ -51,6 +51,7 @@ drake_pybind_library(
     cc_deps = [
         "//bindings/pydrake:autodiff_types_pybind",
         "//bindings/pydrake:symbolic_types_pybind",
+        "//bindings/pydrake/util:deprecation_pybind",
         "//bindings/pydrake/util:drake_optional_pybind",
     ],
     cc_srcs = ["mathematicalprogram_py.cc"],

--- a/bindings/pydrake/solvers/mathematicalprogram_py.cc
+++ b/bindings/pydrake/solvers/mathematicalprogram_py.cc
@@ -9,6 +9,7 @@
 #include "drake/bindings/pydrake/autodiff_types_pybind.h"
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/symbolic_types_pybind.h"
+#include "drake/bindings/pydrake/util/deprecation_pybind.h"
 #include "drake/bindings/pydrake/util/drake_optional_pybind.h"
 #include "drake/solvers/mathematical_program.h"
 #include "drake/solvers/solver_type_converter.h"
@@ -82,11 +83,9 @@ auto RegisterBinding(py::handle* pscope,
                          .def("constraint", &B::evaluator)
                          .def("variables", &B::variables);
   // Deprecate `constraint`.
-  py::module deprecation = py::module::import("pydrake.util.deprecation");
-  py::object deprecated = deprecation.attr("deprecated");
-  binding_cls.attr("constraint") =
-      deprecated("`constraint` is deprecated; please use `evaluator` instead.")(
-          binding_cls.attr("constraint"));
+  DeprecateAttribute(
+      binding_cls, "constraint",
+      "`constraint` is deprecated; please use `evaluator` instead.");
   // Register overloads for MathematicalProgram class
   prog_cls.def(
       "EvalBindingAtSolution",

--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -57,6 +57,7 @@ drake_pybind_library(
     name = "framework_py",
     cc_deps = [
         ":systems_pybind",
+        "//bindings/pydrake/util:deprecation_pybind",
         "//bindings/pydrake/util:drake_optional_pybind",
         "//bindings/pydrake/util:eigen_pybind",
         "//bindings/pydrake/util:type_safe_index_pybind",

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -8,6 +8,7 @@
 
 #include "drake/bindings/pydrake/pydrake_pybind.h"
 #include "drake/bindings/pydrake/systems/systems_pybind.h"
+#include "drake/bindings/pydrake/util/deprecation_pybind.h"
 #include "drake/bindings/pydrake/util/drake_optional_pybind.h"
 #include "drake/bindings/pydrake/util/eigen_pybind.h"
 #include "drake/bindings/pydrake/util/wrap_pybind.h"
@@ -279,9 +280,12 @@ struct Impl {
                  &System<T>::AllocateOutput))
         // TODO(sherm1) Deprecate this next signature (context unused).
         .def("AllocateOutput",
-             overload_cast_explicit<unique_ptr<SystemOutput<T>>,
-                                    const Context<T>&>(
-                 &System<T>::AllocateOutput), py::arg("context"))
+             [](const System<T>* self, const Context<T>&) {
+               WarnDeprecated(
+                  "`System.AllocateOutput(self, Context)` is deprecated. "
+                  "Please use `System.AllocateOutput(self)` instead.");
+               return self->AllocateOutput();
+             }, py::arg("context"))
         .def(
             "EvalVectorInput",
             [](const System<T>* self, const Context<T>& arg1, int arg2) {

--- a/bindings/pydrake/systems/rgbd_camera_example.py
+++ b/bindings/pydrake/systems/rgbd_camera_example.py
@@ -43,7 +43,7 @@ x = np.zeros(tree.get_num_positions() + tree.get_num_velocities())
 # Allocate context and render.
 context = camera.CreateDefaultContext()
 context.FixInputPort(0, BasicVector(x))
-output = camera.AllocateOutput(context)
+output = camera.AllocateOutput()
 camera.CalcOutput(context, output)
 
 # Get images from computed output.

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -103,7 +103,7 @@ class TestCustom(unittest.TestCase):
         system = self._create_adder_system()
         context = system.CreateDefaultContext()
         self._fix_adder_inputs(context)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         self.assertEqual(output.get_num_ports(), 1)
         system.CalcOutput(context, output)
         value = output.get_vector_data(0).get_value()
@@ -354,7 +354,7 @@ class TestCustom(unittest.TestCase):
 
             self.assertEqual(context.get_num_input_ports(), 1)
             context.FixInputPort(0, AbstractValue.Make(expected_input_value))
-            output = system.AllocateOutput(context)
+            output = system.AllocateOutput()
             self.assertEqual(output.get_num_ports(), 1)
             system.CalcOutput(context, output)
             value = output.get_data(0)

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import copy
+import warnings
 
 import unittest
 import numpy as np
@@ -84,6 +85,11 @@ class TestGeneral(unittest.TestCase):
         system = Adder(3, 10)
         self.assertEqual(system.get_num_input_ports(), 3)
         self.assertEqual(system.get_num_output_ports(), 1)
+        # Test deprecated methods.
+        context = system.CreateDefaultContext()
+        with warnings.catch_warnings(record=True) as w:
+            c = system.AllocateOutput(context)
+            self.assertEqual(len(w), 1)
         # TODO(eric.cousineau): Consolidate the main API tests for `System`
         # to this test point.
 
@@ -145,7 +151,7 @@ class TestGeneral(unittest.TestCase):
 
             def check_output(context):
                 # Check number of output ports and value for a given context.
-                output = system.AllocateOutput(context)
+                output = system.AllocateOutput()
                 self.assertEqual(output.get_num_ports(), 1)
                 system.CalcOutput(context, output)
                 if T == float:

--- a/bindings/pydrake/systems/test/primitives_test.py
+++ b/bindings/pydrake/systems/test/primitives_test.py
@@ -156,7 +156,7 @@ class TestGeneral(unittest.TestCase):
         system = PassThrough(model_value.size())
         context = system.CreateDefaultContext()
         context.FixInputPort(0, model_value)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         input_eval = system.EvalVectorInput(context, 0)
         compare_value(self, input_eval, model_value)
         system.CalcOutput(context, output)
@@ -168,7 +168,7 @@ class TestGeneral(unittest.TestCase):
         system = PassThrough(model_value)
         context = system.CreateDefaultContext()
         context.FixInputPort(0, model_value)
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
         input_eval = system.EvalAbstractInput(context, 0)
         compare_value(self, input_eval, model_value)
         system.CalcOutput(context, output)
@@ -183,7 +183,7 @@ class TestGeneral(unittest.TestCase):
 
         for system in systems:
             context = system.CreateDefaultContext()
-            output = system.AllocateOutput(context)
+            output = system.AllocateOutput()
 
             def mytest(input, expected):
                 context.FixInputPort(0, BasicVector(input))
@@ -197,7 +197,7 @@ class TestGeneral(unittest.TestCase):
     def test_saturation(self):
         system = Saturation((0., -1., 3.), (1., 2., 4.))
         context = system.CreateDefaultContext()
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
 
         def mytest(input, expected):
             context.FixInputPort(0, BasicVector(input))
@@ -212,7 +212,7 @@ class TestGeneral(unittest.TestCase):
         system = WrapToSystem(2)
         system.set_interval(1, 1., 2.)
         context = system.CreateDefaultContext()
-        output = system.AllocateOutput(context)
+        output = system.AllocateOutput()
 
         def mytest(input, expected):
             context.FixInputPort(0, BasicVector(input))
@@ -238,7 +238,7 @@ class TestGeneral(unittest.TestCase):
             port_size = sum([len(vec) for vec in case['data']])
             self.assertEqual(mux.get_output_port(0).size(), port_size)
             context = mux.CreateDefaultContext()
-            output = mux.AllocateOutput(context)
+            output = mux.AllocateOutput()
             num_ports = len(case['data'])
             self.assertEqual(context.get_num_input_ports(), num_ports)
             for j, vec in enumerate(case['data']):

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -147,7 +147,7 @@ class TestRendering(unittest.TestCase):
 
         # - CalcOutput.
         context = aggregator.CreateDefaultContext()
-        output = aggregator.AllocateOutput(context)
+        output = aggregator.AllocateOutput()
 
         p1 = [0, 1, 2]
         pose1 = PoseVector()

--- a/bindings/pydrake/systems/test/test_util_py.cc
+++ b/bindings/pydrake/systems/test/test_util_py.cc
@@ -180,7 +180,7 @@ PYBIND11_MODULE(test_util, m) {
           state.CopyToVector() + dt * state_dot.CopyToVector());
     }
     // Calculate output.
-    auto output = system.AllocateOutput(*context);
+    auto output = system.AllocateOutput();
     system.CalcOutput(*context, output.get());
     return output;
   });

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -139,7 +139,7 @@ class TestAutomotive(unittest.TestCase):
         lane = rg.junction(0).segment(0).lane(0)
         pure_pursuit = PurePursuitController()
         context = pure_pursuit.CreateDefaultContext()
-        output = pure_pursuit.AllocateOutput(context)
+        output = pure_pursuit.AllocateOutput()
 
         # Fix the inputs.
         ld_value = framework.AbstractValue.Make(
@@ -189,7 +189,7 @@ class TestAutomotive(unittest.TestCase):
             road_position_strategy=RoadPositionStrategy.kExhaustiveSearch,
             period_sec=0.)
         context = idm.CreateDefaultContext()
-        output = idm.AllocateOutput(context)
+        output = idm.AllocateOutput()
 
         # Fix the inputs.
         pose_vector1 = PoseVector()
@@ -235,7 +235,7 @@ class TestAutomotive(unittest.TestCase):
         simple_car = SimpleCar()
         simulator = Simulator(simple_car)
         context = simulator.get_mutable_context()
-        output = simple_car.AllocateOutput(context)
+        output = simple_car.AllocateOutput()
 
         # Fix the input.
         command = DrivingCommand()

--- a/bindings/pydrake/util/BUILD.bazel
+++ b/bindings/pydrake/util/BUILD.bazel
@@ -66,6 +66,15 @@ drake_py_library(
     imports = PACKAGE_INFO.py_imports,
 )
 
+# N.B. Since `common_py` incorporates `deprecation_py`, C++ Python libraries
+# need not worry about it.
+drake_cc_library(
+    name = "deprecation_pybind",
+    hdrs = ["deprecation_pybind.h"],
+    visibility = ["//visibility:public"],
+    deps = ["//bindings/pydrake:pydrake_pybind"],
+)
+
 drake_cc_library(
     name = "eigen_pybind",
     hdrs = ["eigen_pybind.h"],
@@ -232,12 +241,25 @@ drake_cc_googletest(
     ],
 )
 
+drake_pybind_library(
+    name = "deprecation_example_cc_module_py",
+    testonly = 1,
+    add_install = False,
+    cc_deps = ["//bindings/pydrake/util:deprecation_pybind"],
+    cc_so_name = "test/deprecation_example/cc_module",
+    cc_srcs = ["test/deprecation_example/cc_module_py.cc"],
+    package_info = PACKAGE_INFO,
+)
+
 drake_py_library(
     name = "deprecation_example",
     testonly = 1,
     srcs = glob(["test/deprecation_example/*.py"]),
     imports = ["test"],
-    deps = [":deprecation_py"],
+    deps = [
+        ":deprecation_example_cc_module_py",
+        ":deprecation_py",
+    ],
 )
 
 drake_py_unittest(

--- a/bindings/pydrake/util/deprecation.py
+++ b/bindings/pydrake/util/deprecation.py
@@ -91,6 +91,13 @@ class DrakeDeprecationWarning(DeprecationWarning):
         DeprecationWarning.__init__(self, extra_message, *args)
 
 
+def _warn_deprecated(message, stacklevel=2):
+    # Logs a deprecation warning message.  Also used by `deprecation_pybind.h`
+    # in addition to this file.
+    warnings.warn(
+        message, category=DrakeDeprecationWarning, stacklevel=stacklevel)
+
+
 class _DeprecatedDescriptor(object):
     """Wraps a descriptor to warn that it is deprecated any time it is
     acccessed."""
@@ -102,8 +109,7 @@ class _DeprecatedDescriptor(object):
         self._message = message
 
     def _warn(self):
-        warnings.warn(
-            self._message, category=DrakeDeprecationWarning, stacklevel=3)
+        _warn_deprecated(self._message, stacklevel=4)
 
     def __get__(self, obj, objtype):
         self._warn()

--- a/bindings/pydrake/util/deprecation_pybind.h
+++ b/bindings/pydrake/util/deprecation_pybind.h
@@ -1,0 +1,36 @@
+#pragma once
+
+/// @file
+/// Provides access to Python deprecation utilites from C++.
+
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+
+namespace drake {
+namespace pydrake {
+
+/// Deprecates an attribute `name` of a class `cls`.
+/// This *only* works with class attributes (unbound members or methods) as it
+/// is implemented with a Python property descriptor.
+inline void DeprecateAttribute(
+    py::object cls, py::str name, py::str message) {
+  py::object deprecated =
+      py::module::import("pydrake.util.deprecation").attr("deprecated");
+  py::object original = cls.attr(name);
+  cls.attr(name) = deprecated(message)(original);
+}
+
+/// Raises a deprecation warning.
+///
+/// @note If you are deprecating a class's member or method, please use
+/// `DeprecateAttribute` so that the warning is issued immediately when
+/// accessed, not only when it is called.
+inline void WarnDeprecated(py::str message) {
+  py::object warn_deprecated =
+      py::module::import("pydrake.util.deprecation").attr("_warn_deprecated");
+  warn_deprecated(message);
+}
+
+}  // namespace pydrake
+}  // namespace drake

--- a/bindings/pydrake/util/test/deprecation_example/cc_module_py.cc
+++ b/bindings/pydrake/util/test/deprecation_example/cc_module_py.cc
@@ -1,0 +1,45 @@
+#include "pybind11/pybind11.h"
+
+#include "drake/bindings/pydrake/pydrake_pybind.h"
+#include "drake/bindings/pydrake/util/deprecation_pybind.h"
+
+namespace drake {
+namespace pydrake {
+namespace {
+
+class ExampleCppClass {
+ public:
+  void DeprecatedMethod() {}
+  int deprecated_prop{};
+
+  // Good overload.
+  void overload() {}
+
+  // Bad overload.
+  void overload(int) {}
+};
+
+PYBIND11_MODULE(cc_module, m) {
+  py::class_<ExampleCppClass> cls(m, "ExampleCppClass");
+  py::handle cls_handle = cls;
+  // Store messages for testing.
+  cls.attr("message_overload") = "overload(int) is deprecated";
+  cls.attr("message_method") = "Deprecated method";
+  cls.attr("message_prop") = "Deprecated property";
+  // Add deprecated members.
+  cls
+      .def(py::init())
+      .def("DeprecatedMethod", &ExampleCppClass::DeprecatedMethod)
+      .def_readwrite("deprecated_prop", &ExampleCppClass::deprecated_prop)
+      .def("overload", py::overload_cast<>(&ExampleCppClass::overload))
+      .def("overload", [cls_handle](ExampleCppClass* self, int value) {
+        WarnDeprecated(cls_handle.attr("message_overload"));
+        self->overload(value);
+      });
+  DeprecateAttribute(cls, "DeprecatedMethod", cls.attr("message_method"));
+  DeprecateAttribute(cls, "deprecated_prop", cls.attr("message_prop"));
+}
+
+}  // namespace
+}  // namespace pydrake
+}  // namespace drake

--- a/examples/acrobot/test/urdf_dynamics_test.cc
+++ b/examples/acrobot/test/urdf_dynamics_test.cc
@@ -35,8 +35,8 @@ GTEST_TEST(UrdfDynamicsTest, AllTests) {
   Vector1d u;
   auto xdot_rbp = rbp.AllocateTimeDerivatives();
   auto xdot_p = p.AllocateTimeDerivatives();
-  auto y_rbp = rbp.AllocateOutput(*context_rbp);
-  auto y_p = p.AllocateOutput(*context_p);
+  auto y_rbp = rbp.AllocateOutput();
+  auto y_p = p.AllocateOutput();
 
   srand(42);
   for (int i = 0; i < 100; ++i) {

--- a/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
+++ b/examples/bead_on_a_wire/test/bead_on_a_wire_test.cc
@@ -23,8 +23,8 @@ class BeadOnAWireTest : public ::testing::Test {
     context_min_ = dut_min_->CreateDefaultContext();
 
     // Construct outputs.
-    output_abs_ = dut_abs_->AllocateOutput(*context_abs_);
-    output_min_ = dut_min_->AllocateOutput(*context_abs_);
+    output_abs_ = dut_abs_->AllocateOutput();
+    output_min_ = dut_min_->AllocateOutput();
 
     // Allocate storage for derivatives.
     derivatives_abs_ = dut_abs_->AllocateTimeDerivatives();

--- a/examples/bouncing_ball/test/bouncing_ball_test.cc
+++ b/examples/bouncing_ball/test/bouncing_ball_test.cc
@@ -72,7 +72,7 @@ class BouncingBallTest : public ::testing::Test {
   void SetUp() override {
     dut_ = std::make_unique<BouncingBall<double>>();
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }
 

--- a/examples/humanoid_controller/test/atlas_command_translator_system_test.cc
+++ b/examples/humanoid_controller/test/atlas_command_translator_system_test.cc
@@ -36,7 +36,7 @@ GTEST_TEST(JointLevelControllerTest, AtlasJointLevelControllerTest) {
 
   auto dut = std::make_unique<AtlasCommandTranslatorSystem>(*robot);
   auto context = dut->CreateDefaultContext();
-  auto output = dut->AllocateOutput(*context);
+  auto output = dut->AllocateOutput();
 
   context->set_time(3.);
 

--- a/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
+++ b/examples/humanoid_controller/test/humanoid_plan_eval_system_test.cc
@@ -106,7 +106,7 @@ class HumanoidPlanEvalAndQpInverseDynamicsTest : public ::testing::Test {
 
     context_ = diagram_->CreateDefaultContext();
     context_->set_time(0);
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
 
     // Initializes.
     auto& plan_eval_context =

--- a/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
+++ b/examples/kinova_jaco_arm/test/jaco_lcm_test.cc
@@ -28,7 +28,7 @@ GTEST_TEST(JacoLcmTest, JacoCommandPassthroughTest) {
   std::unique_ptr<systems::Context<double>> context =
       diagram->CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      diagram->AllocateOutput(*context);
+      diagram->AllocateOutput();
 
   lcmt_jaco_command command{};
   command.num_joints = kJacoDefaultArmNumJoints;
@@ -82,7 +82,7 @@ GTEST_TEST(JacoLcmTest, JacoStatusPassthroughTest) {
   std::unique_ptr<systems::Context<double>> context =
       diagram->CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      diagram->AllocateOutput(*context);
+      diagram->AllocateOutput();
 
   lcmt_jaco_status status{};
   status.num_joints = kJacoDefaultArmNumJoints;

--- a/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
+++ b/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
@@ -20,7 +20,7 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   // Check that the commanded pose starts out at zero, and that we can
   // set a different initial position.
@@ -102,7 +102,7 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandSenderTest) {
   std::unique_ptr<systems::Context<double>>
       context = dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   Eigen::VectorXd position(kNumJoints);
   position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7;
@@ -136,7 +136,7 @@ GTEST_TEST(IiwaLcmTest, IiwaStatusReceiverTest) {
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   lcmt_iiwa_status status{};
   status.num_joints = kNumJoints;
@@ -186,7 +186,7 @@ GTEST_TEST(IiwaLcmTest, IiwaStatusSenderTest) {
   std::unique_ptr<systems::Context<double>>
       context = dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   Eigen::VectorXd position(kNumJoints);
   position << 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7;
@@ -256,7 +256,7 @@ GTEST_TEST(IiwaLcmTest, IiwaContactResultsToExternalTorque) {
   std::unique_ptr<systems::Context<double>>
       context = dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   VectorX<double> expected(tree->get_num_velocities());
   for (int i = 0; i < expected.size(); i++)

--- a/examples/particles/test/particle_test.cc
+++ b/examples/particles/test/particle_test.cc
@@ -25,7 +25,7 @@ class ParticleTest : public ::testing::Test {
   void SetUp() override {
     this->dut_ = std::make_unique<Particle<T>>();
     this->context_ = this->dut_->CreateDefaultContext();
-    this->output_ = this->dut_->AllocateOutput(*context_);
+    this->output_ = this->dut_->AllocateOutput();
     this->derivatives_ = this->dut_->AllocateTimeDerivatives();
   }
 

--- a/examples/particles/test/utilities_test.cc
+++ b/examples/particles/test/utilities_test.cc
@@ -30,7 +30,7 @@ class SingleDOFEulerJointTest : public ::testing::Test {
     translating_matrix(0, 0) = 1.0;
     this->dut_ = MakeDegenerateEulerJoint(translating_matrix);
     this->context_ = this->dut_->CreateDefaultContext();
-    this->output_ = this->dut_->AllocateOutput(*this->context_);
+    this->output_ = this->dut_->AllocateOutput();
   }
 
   /// System (aka Device Under Test) being tested.

--- a/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
+++ b/examples/qp_inverse_dynamics/test/manipulator_joint_space_controller_test.cc
@@ -117,7 +117,7 @@ class ManipulatorJointSpaceControllerTest : public ::testing::Test {
 
     context_ = diagram_->CreateDefaultContext();
     context_->set_time(0);
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
 
     // Initializes.
     qp_id_controller->Initialize(

--- a/examples/rod2d/test/rod2d_test.cc
+++ b/examples/rod2d/test/rod2d_test.cc
@@ -38,7 +38,7 @@ class Rod2DDAETest : public ::testing::Test {
     dut_ = std::make_unique<Rod2D<double>>(
         Rod2D<double>::SystemType::kPiecewiseDAE, 0.0);
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
 
     // Use a non-unit mass.
@@ -298,7 +298,7 @@ TEST_F(Rod2DDAETest, ExpectedIndices) {
 TEST_F(Rod2DDAETest, Output) {
   const ContinuousState<double>& xc = context_->get_continuous_state();
   std::unique_ptr<SystemOutput<double>> output =
-      dut_->AllocateOutput(*context_);
+      dut_->AllocateOutput();
   dut_->CalcOutput(*context_, output.get());
   for (int i = 0; i < xc.size(); ++i)
     EXPECT_EQ(xc[i], output->get_vector_data(0)->get_value()(i));
@@ -766,7 +766,7 @@ class Rod2DDiscretizedTest : public ::testing::Test {
     dut_ = std::make_unique<Rod2D<double>>(
         Rod2D<double>::SystemType::kDiscretized, dt);
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
 
     // Use a non-unit mass.
     dut_->set_rod_mass(2.0);
@@ -974,7 +974,7 @@ class Rod2DContinuousTest : public ::testing::Test {
     dut_ = std::make_unique<Rod2D<double>>(
         Rod2D<double>::SystemType::kContinuous, 0.0);
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
     derivatives_ = dut_->AllocateTimeDerivatives();
 
     // Use a non-unit mass.
@@ -1151,8 +1151,8 @@ GTEST_TEST(Rod2DCrossValidationTest, Outputs) {
   std::unique_ptr<Context<double>> context_pdae = pdae.CreateDefaultContext();
 
   // Allocate outputs for both.
-  auto output_ts = ts.AllocateOutput(*context_ts);
-  auto output_pdae = pdae.AllocateOutput(*context_pdae);
+  auto output_ts = ts.AllocateOutput();
+  auto output_pdae = pdae.AllocateOutput();
 
   // Compute outputs.
   ts.CalcOutput(*context_ts, output_ts.get());

--- a/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
+++ b/examples/schunk_wsg/test/schunk_wsg_lift_test.cc
@@ -424,7 +424,7 @@ TEST_P(SchunkWsgLiftTest, BoxLiftTest) {
 
   // Capture the "initial" positions of the box and the gripper finger as
   // discussed in the test notes below.
-  auto state_output = model->AllocateOutput(simulator.get_context());
+  auto state_output = model->AllocateOutput();
   model->CalcOutput(simulator.get_context(), state_output.get());
   auto& interim_kinematics_results =
       state_output->get_data(kinematrics_results_index)

--- a/examples/schunk_wsg/test/simulated_schunk_wsg_system_test.cc
+++ b/examples/schunk_wsg/test/simulated_schunk_wsg_system_test.cc
@@ -114,7 +114,7 @@ GTEST_TEST(SimulatedSchunkWsgSystemTest, OpenGripper) {
   simulator.Initialize();
 
   // Verify that the robot starts in the correct (zero) configuration.
-  auto initial_output = model->AllocateOutput(simulator.get_context());
+  auto initial_output = model->AllocateOutput();
   model->CalcOutput(simulator.get_context(), initial_output.get());
   const auto initial_output_data =
       initial_output->get_vector_data(0)->get_value();
@@ -126,7 +126,7 @@ GTEST_TEST(SimulatedSchunkWsgSystemTest, OpenGripper) {
   simulator.StepTo(1.0);
 
   // Extract and log the final state of the robot.
-  auto final_output = model->AllocateOutput(simulator.get_context());
+  auto final_output = model->AllocateOutput();
   model->CalcOutput(simulator.get_context(), final_output.get());
   const auto final_output_data =
       final_output->get_vector_data(0)->get_value();

--- a/examples/valkyrie/test/robot_command_to_desired_effort_converter_test.cc
+++ b/examples/valkyrie/test/robot_command_to_desired_effort_converter_test.cc
@@ -52,7 +52,7 @@ void TestCommandToDesiredEffortConverter(
   auto diagram = builder.Build();
 
   auto context = diagram->CreateDefaultContext();
-  auto output = diagram->AllocateOutput(*context);
+  auto output = diagram->AllocateOutput();
   diagram->CalcOutput(*context, output.get());
 
   // TODO(tkoolen): assumption about ordering of exported output ports.

--- a/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
+++ b/examples/valkyrie/test/robot_state_encoder_decoder_test.cc
@@ -221,7 +221,7 @@ void TestEncodeThenDecode(FloatingBaseType floating_base_type) {
   auto diagram = builder.Build();
 
   auto context = diagram->CreateDefaultContext();
-  auto output = diagram->AllocateOutput(*context);
+  auto output = diagram->AllocateOutput();
   diagram->CalcOutput(*context, output.get());
 
   // TODO(tkoolen): magic numbers.

--- a/examples/valkyrie/valkyrie_pd_ff_controller.cc
+++ b/examples/valkyrie/valkyrie_pd_ff_controller.cc
@@ -187,7 +187,7 @@ void run_valkyrie_pd_ff_controller() {
 
   std::unique_ptr<Diagram<double>> diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
-  auto output = diagram->AllocateOutput(*context);
+  auto output = diagram->AllocateOutput();
 
   lcm.StartReceiveThread();
   std::cout << "controller started\n";

--- a/manipulation/perception/test/optitrack_pose_extractor_test.cc
+++ b/manipulation/perception/test/optitrack_pose_extractor_test.cc
@@ -29,7 +29,7 @@ class OptitrackPoseTest : public ::testing::Test {
     dut_ = std::make_unique<OptitrackPoseExtractor>(
         object_id, world_X_optitrack, 0.01 /* optitrack_lcm_status_period */);
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
 
     EXPECT_EQ(dut_->get_num_input_ports(), 1);
     EXPECT_EQ(dut_->get_num_output_ports(), 1);

--- a/manipulation/perception/test/pose_smoother_test.cc
+++ b/manipulation/perception/test/pose_smoother_test.cc
@@ -43,7 +43,7 @@ class PoseSmootherTest : public ::testing::Test {
           kPoseSmootherPeriod, filter_window_size);
 
     context_ = dut_->CreateDefaultContext();
-    output_ = dut_->AllocateOutput(*context_);
+    output_ = dut_->AllocateOutput();
 
     EXPECT_EQ(dut_->get_num_input_ports(), 1);
     EXPECT_EQ(dut_->get_num_output_ports(), 2);

--- a/manipulation/planner/test/robot_plan_interpolator_test.cc
+++ b/manipulation/planner/test/robot_plan_interpolator_test.cc
@@ -103,7 +103,7 @@ void DoTrajectoryTest(InterpolatorType interp_type) {
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
   context->FixInputPort(
       dut.get_state_input_port().get_index(),
       Eigen::VectorXd::Zero(kNumJoints * 2));

--- a/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_controller_test.cc
@@ -24,7 +24,7 @@ std::pair<double, double> RunWsgControllerTestStep(
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
   context->FixInputPort(
       dut.get_command_input_port().get_index(),
       std::make_unique<systems::Value<lcmt_schunk_wsg_command>>(wsg_command));

--- a/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
+++ b/manipulation/schunk_wsg/test/schunk_wsg_lcm_test.cc
@@ -19,7 +19,7 @@ GTEST_TEST(SchunkWsgLcmTest, SchunkWsgTrajectoryGeneratorTest) {
   std::unique_ptr<systems::Context<double>> context =
       dut.CreateDefaultContext();
   std::unique_ptr<systems::SystemOutput<double>> output =
-      dut.AllocateOutput(*context);
+      dut.AllocateOutput();
 
   // Start off with the gripper closed (zero) and a command to open to
   // 100mm.

--- a/manipulation/util/test/frame_pose_tracker_test.cc
+++ b/manipulation/util/test/frame_pose_tracker_test.cc
@@ -73,7 +73,7 @@ class FramePoseTrackerTest : public ::testing::Test {
     input->SetValue(input_results);
 
     auto context_ = dut.CreateDefaultContext();
-    auto output_ = dut.AllocateOutput(*context_);
+    auto output_ = dut.AllocateOutput();
     context_->FixInputPort(
         dut.get_kinematics_input_port_index() /* input port ID*/,
         std::move(input));

--- a/manipulation/util/test/sim_diagram_builder_test.cc
+++ b/manipulation/util/test/sim_diagram_builder_test.cc
@@ -178,7 +178,7 @@ GTEST_TEST(SimDiagramBuilderTest, TestSimulation) {
   simulator.Initialize();
   simulator.StepTo(0.02);
 
-  auto state_output = diagram->AllocateOutput(simulator.get_context());
+  auto state_output = diagram->AllocateOutput();
   diagram->CalcOutput(simulator.get_context(), state_output.get());
   const auto final_output_data = state_output->get_vector_data(0)->get_value();
 

--- a/multibody/rigid_body_plant/test/compute_contact_result_test.cc
+++ b/multibody/rigid_body_plant/test/compute_contact_result_test.cc
@@ -56,7 +56,7 @@ class ContactResultTest : public ContactResultTestCommon<double> {
     plant_->set_contact_model_parameters(model_parameters);
 
     context_ = plant_->CreateDefaultContext();
-    output_ = plant_->AllocateOutput(*context_);
+    output_ = plant_->AllocateOutput();
     plant_->CalcOutput(*context_.get(), output_.get());
 
     const int port_index = plant_->contact_results_output_port().get_index();

--- a/multibody/rigid_body_plant/test/contact_force_formula_test.cc
+++ b/multibody/rigid_body_plant/test/contact_force_formula_test.cc
@@ -46,7 +46,7 @@ class ContactFormulaTest : public ::testing::Test {
     //  the plant requires a *compiled* tree at constructor time.
     plant_ = make_unique<RigidBodyPlant<double>>(move(unique_tree));
     context_ = plant_->CreateDefaultContext();
-    output_ = plant_->AllocateOutput(*context_);
+    output_ = plant_->AllocateOutput();
     const int port_index = plant_->contact_results_output_port().get_index();
 
     // Set Sphere 2's velocity.

--- a/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
+++ b/multibody/rigid_body_plant/test/rigid_body_plant_test.cc
@@ -227,7 +227,7 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
                                                       this->GetParam());
 
     context_ = kuka_plant_->CreateDefaultContext();
-    output_ = kuka_plant_->AllocateOutput(*context_);
+    output_ = kuka_plant_->AllocateOutput();
     derivatives_ = kuka_plant_->AllocateTimeDerivatives();
   }
 

--- a/perception/dev/test/feedforward_neural_network_test.cc
+++ b/perception/dev/test/feedforward_neural_network_test.cc
@@ -296,7 +296,7 @@ void TestIO(std::vector<MatrixX<T>> W, std::vector<VectorX<T>> B,
   FeedforwardNeuralNetwork<double> dut(W, B, GenerateFullyConnectedLayers(3),
                                        GenerateReluNonlinearities(3));
   unique_ptr<Context<double>> context = dut.CreateDefaultContext();
-  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput(*context);
+  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput();
 
   context->FixInputPort(dut.input().get_index(), input);
   dut.CalcOutput(*context, output.get());

--- a/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
+++ b/systems/analysis/test_utilities/test/controlled_spring_mass_system_test.cc
@@ -28,7 +28,7 @@ class SpringMassSystemTest : public ::testing::Test {
             kTargetPosition);
 
     model_context_ = model_->CreateDefaultContext();
-    output_ = model_->AllocateOutput(*model_context_);
+    output_ = model_->AllocateOutput();
 
     // Gets the plant subcontext.
     plant_context_ =

--- a/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
+++ b/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
@@ -101,7 +101,7 @@ GTEST_TEST(testQpInverseDynamicsSystem, IiwaInverseDynamics) {
   // Uses the simulator to avoid various allocations by hand.
   Simulator<double> sim(*diagram);
   std::unique_ptr<SystemOutput<double>> output =
-      diagram->AllocateOutput(sim.get_context());
+      diagram->AllocateOutput();
   sim.Initialize();
   sim.StepTo(controller->get_control_dt());
 

--- a/systems/controllers/qp_inverse_dynamics/test/qp_output_translator_system_test.cc
+++ b/systems/controllers/qp_inverse_dynamics/test/qp_output_translator_system_test.cc
@@ -31,7 +31,7 @@ GTEST_TEST(QpOutputTranslatorTest, QpOutputTranslatorTest) {
 
   auto dut = std::make_unique<QpOutputTranslatorSystem>(*robot);
   auto context = dut->CreateDefaultContext();
-  auto output = dut->AllocateOutput(*context);
+  auto output = dut->AllocateOutput();
 
   context->set_time(3.);
 

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -56,7 +56,7 @@ GTEST_TEST(InverseDynamicsControllerTest, TestTorque) {
   auto dut = std::make_unique<InverseDynamicsController<double>>(
       std::move(robot_ptr), kp, ki, kd, true);
   auto context = dut->CreateDefaultContext();
-  auto output = dut->AllocateOutput(*context);
+  auto output = dut->AllocateOutput();
   const RigidBodyTree<double>& robot = dut->get_robot_for_control();
 
   // Sets current state and reference state and acceleration values.

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -45,7 +45,7 @@ class InverseDynamicsTest : public ::testing::Test {
     inverse_dynamics_ = make_unique<InverseDynamics<double>>(
         *tree_, pure_gravity_compensation /* pure gravity compensation mode */);
     context_ = inverse_dynamics_->CreateDefaultContext();
-    output_ = inverse_dynamics_->AllocateOutput(*context_);
+    output_ = inverse_dynamics_->AllocateOutput();
 
     // Checks that the number of input ports in the Gravity Compensator system
     // and the Context are consistent.

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -73,7 +73,7 @@ TEST_F(TestMpcWithDoubleIntegrator, TestAgainstInfiniteHorizonSolution) {
 
   auto context = dut_->CreateDefaultContext();
   context->FixInputPort(0, BasicVector<double>::Make(x0(0), x0(1)));
-  std::unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context);
+  std::unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput();
 
   dut_->CalcOutput(*context, output.get());
 

--- a/systems/controllers/test/pid_controlled_system_test.cc
+++ b/systems/controllers/test/pid_controlled_system_test.cc
@@ -131,7 +131,7 @@ class PidControlledSystemTest : public ::testing::Test {
     builder.ExportOutput(controller->get_output_port(0));
     diagram_ = builder.Build();
     auto context = diagram_->CreateDefaultContext();
-    auto output = diagram_->AllocateOutput(*context);
+    auto output = diagram_->AllocateOutput();
 
     const systems::Context<double>& plant_context =
         diagram_->GetSubsystemContext(*controller->plant(),
@@ -220,7 +220,7 @@ class ConnectControllerTest : public ::testing::Test {
   double ComputePidInput() {
     auto standard_diagram = builder_.Build();
     auto context = standard_diagram->CreateDefaultContext();
-    auto output = standard_diagram->AllocateOutput(*context);
+    auto output = standard_diagram->AllocateOutput();
 
     auto& plant_context =
         standard_diagram->GetSubsystemContext(*plant_, *context);

--- a/systems/controllers/test/pid_controller_test.cc
+++ b/systems/controllers/test/pid_controller_test.cc
@@ -23,7 +23,7 @@ class PidControllerTest : public ::testing::Test {
  protected:
   void SetUp() override {
     context_ = controller_.CreateDefaultContext();
-    output_ = controller_.AllocateOutput(*context_);
+    output_ = controller_.AllocateOutput();
     derivatives_ = controller_.AllocateTimeDerivatives();
 
     // State:
@@ -207,7 +207,7 @@ GTEST_TEST(PidIOProjectionTest, Test) {
 
   PidController<double> dut(P_input, P_output, kp, ki, kd);
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
 
   VectorX<double> x = VectorX<double>::Random(2 * num_full_q);
   VectorX<double> x_d = VectorX<double>::Random(2 * num_controlled_q);

--- a/systems/estimators/luenberger_observer.cc
+++ b/systems/estimators/luenberger_observer.cc
@@ -17,8 +17,7 @@ LuenbergerObserver<T>::LuenbergerObserver(
     : observed_system_(std::move(observed_system)),
       observer_gain_(observer_gain),
       observed_system_context_(std::move(observed_system_context)),
-      observed_system_output_(
-          observed_system_->AllocateOutput(*observed_system_context_)),
+      observed_system_output_(observed_system_->AllocateOutput()),
       observed_system_derivatives_(
           observed_system_->AllocateTimeDerivatives()) {
   DRAKE_DEMAND(observed_system_ != nullptr);

--- a/systems/estimators/test/luenberger_observer_test.cc
+++ b/systems/estimators/test/luenberger_observer_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(LuenbergerObserverTest, ErrorDynamics) {
 
   auto context = observer->CreateDefaultContext();
   auto derivatives = observer->AllocateTimeDerivatives();
-  auto output = observer->AllocateOutput(*context);
+  auto output = observer->AllocateOutput();
 
   EXPECT_FALSE(observer->HasAnyDirectFeedthrough());
 

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -144,11 +144,13 @@ class System : public SystemBase {
     return output;
   }
 
-  /// (Deprecated) Context is ignored.
-  // TODO(sherm1) Get rid of this.
+#ifndef DRAKE_DOXYGEN_CXX
+  // TODO(sherm1) Remove this after 10/1/2018 (three months).
+  DRAKE_DEPRECATED("Call AllocateOutput() with no Context argument.")
   std::unique_ptr<SystemOutput<T>> AllocateOutput(const Context<T>&) const {
     return AllocateOutput();
   }
+#endif
 
   /// Returns a ContinuousState of the same size as the continuous_state
   /// allocated in CreateDefaultContext. The simulator will provide this state

--- a/systems/framework/system_symbolic_inspector.cc
+++ b/systems/framework/system_symbolic_inspector.cc
@@ -19,7 +19,7 @@ SystemSymbolicInspector::SystemSymbolicInspector(
       continuous_state_variables_(context_->get_continuous_state().size()),
       discrete_state_variables_(context_->get_num_discrete_state_groups()),
       numeric_parameters_(context_->num_numeric_parameters()),
-      output_(system.AllocateOutput(*context_)),
+      output_(system.AllocateOutput()),
       derivatives_(system.AllocateTimeDerivatives()),
       discrete_updates_(system.AllocateDiscreteVariables()),
       output_port_types_(system.get_num_output_ports()),

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -467,7 +467,7 @@ class DiagramTest : public ::testing::Test {
     diagram_->set_name("Unicode Snowman's Favorite Diagram!!1!☃!");
 
     context_ = diagram_->CreateDefaultContext();
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
 
     // Initialize the integrator states.
     auto& integrator0_xc = GetMutableContinuousState(integrator0());
@@ -728,7 +728,7 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   std::unique_ptr<Context<AutoDiffXd>> context =
       ad_diagram->CreateDefaultContext();
   std::unique_ptr<SystemOutput<AutoDiffXd>> output =
-      ad_diagram->AllocateOutput(*context);
+      ad_diagram->AllocateOutput();
 
   // The name was preserved.
   EXPECT_EQ(diagram_->get_name(), ad_diagram->get_name());
@@ -882,7 +882,7 @@ class DiagramOfDiagramsTest : public ::testing::Test {
     diagram_->set_name("DiagramOfDiagrams");
 
     context_ = diagram_->CreateDefaultContext();
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
 
     context_->FixInputPort(0, {8});
     context_->FixInputPort(1, {64});
@@ -995,7 +995,7 @@ class AddConstantDiagram : public Diagram<double> {
 GTEST_TEST(DiagramSubclassTest, TwelvePlusSevenIsNineteen) {
   AddConstantDiagram plus_seven(7.0);
   auto context = plus_seven.CreateDefaultContext();
-  auto output = plus_seven.AllocateOutput(*context);
+  auto output = plus_seven.AllocateOutput();
   ASSERT_TRUE(context != nullptr);
   ASSERT_TRUE(output != nullptr);
 
@@ -1766,7 +1766,7 @@ class NestedDiagramContextTest : public ::testing::Test {
     big_diagram_ = big_diagram_builder.Build();
     big_diagram_->set_name("big_diagram");
     big_context_ = big_diagram_->CreateDefaultContext();
-    big_output_ = big_diagram_->AllocateOutput(*big_context_);
+    big_output_ = big_diagram_->AllocateOutput();
   }
 
   Integrator<double>* integrator0_;

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -768,7 +768,7 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsInput) {
 GTEST_TEST(ModelLeafSystemTest, ModelPortsAllocOutput) {
   DeclaredModelPortsSystem dut;
   auto context = dut.CreateDefaultContext();
-  auto system_output = dut.AllocateOutput(*context);
+  auto system_output = dut.AllocateOutput();
 
   // Check that BasicVector<double>(3) came out.
   auto output0 = system_output->get_vector_data(0);
@@ -980,7 +980,7 @@ class DeclaredNonModelOutputSystem : public LeafSystem<double> {
 GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   DeclaredNonModelOutputSystem dut;
   auto context = dut.CreateDefaultContext();
-  auto system_output = dut.AllocateOutput(*context);  // Invokes all allocators.
+  auto system_output = dut.AllocateOutput();  // Invokes all allocators.
 
   // Check topology.
   EXPECT_EQ(dut.get_num_input_ports(), 0);

--- a/systems/framework/test/single_output_vector_source_test.cc
+++ b/systems/framework/test/single_output_vector_source_test.cc
@@ -34,7 +34,7 @@ class SingleOutputVectorSourceTest : public ::testing::Test {
   void SetUp() override {
     source_ = std::make_unique<TestSource>();
     context_ = source_->CreateDefaultContext();
-    output_ = source_->AllocateOutput(*context_);
+    output_ = source_->AllocateOutput();
   }
 
   std::unique_ptr<System<double>> source_;

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -686,7 +686,7 @@ class SystemIOTest : public ::testing::Test {
  protected:
   void SetUp() override {
     context_ = test_sys_.CreateDefaultContext();
-    output_ = test_sys_.AllocateOutput(*context_);
+    output_ = test_sys_.AllocateOutput();
 
     // make string input
     context_->FixInputPort(0, Value<std::string>("input"));

--- a/systems/lcm/lcm_driven_loop.cc
+++ b/systems/lcm/lcm_driven_loop.cc
@@ -20,7 +20,7 @@ LcmDrivenLoop::LcmDrivenLoop(
   // Allocates extra context and output just for the driving subscriber, so
   // that this can explicitly query the message.
   sub_context_ = driving_sub_.CreateDefaultContext();
-  sub_output_ = driving_sub_.AllocateOutput(*sub_context_);
+  sub_output_ = driving_sub_.AllocateOutput();
   sub_swap_state_ = sub_context_->CloneState();
   sub_events_ = driving_sub_.AllocateCompositeEventCollection();
 

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -32,7 +32,7 @@ void TestPublisher(const std::string& channel_name, lcm::DrakeMockLcm* lcm,
   EXPECT_EQ(dut->get_name(), "LcmPublisherSystem(" + channel_name + ")");
 
   unique_ptr<Context<double>> context = dut->CreateDefaultContext();
-  unique_ptr<SystemOutput<double>> output = dut->AllocateOutput(*context);
+  unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
 
   // Verifies that the context has one input port.
   EXPECT_EQ(context->get_num_input_ports(), 1);
@@ -138,7 +138,7 @@ GTEST_TEST(LcmPublisherSystemTest, SerializerTest) {
 
   // Establishes the context, output, and input for the dut.
   unique_ptr<Context<double>> context = dut->CreateDefaultContext();
-  unique_ptr<SystemOutput<double>> output = dut->AllocateOutput(*context);
+  unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
   const lcmt_drake_signal sample_data{
     2, { 1.0, 2.0, }, { "x", "y", }, 12345,
   };

--- a/systems/lcm/test/lcm_subscriber_system_test.cc
+++ b/systems/lcm/test/lcm_subscriber_system_test.cc
@@ -48,7 +48,7 @@ void TestSubscriber(drake::lcm::DrakeMockLcm* lcm,
   EXPECT_EQ(dut->get_name(), "LcmSubscriberSystem(" + channel_name + ")");
 
   std::unique_ptr<Context<double>> context = dut->CreateDefaultContext();
-  std::unique_ptr<SystemOutput<double>> output = dut->AllocateOutput(*context);
+  std::unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
 
   drake::lcmt_drake_signal message;
   message.dim = kDim;
@@ -150,7 +150,7 @@ GTEST_TEST(LcmSubscriberSystemTest, SerializerTest) {
 
   // Establishes the context and output for the dut.
   std::unique_ptr<Context<double>> context = dut->CreateDefaultContext();
-  std::unique_ptr<SystemOutput<double>> output = dut->AllocateOutput(*context);
+  std::unique_ptr<SystemOutput<double>> output = dut->AllocateOutput();
 
   // MockLcm produces a sample message.
   SampleData sample_data;
@@ -295,7 +295,7 @@ GTEST_TEST(LcmSubscriberSystemTest, CustomVectorBaseTest) {
 
   // Read back the vector via CalcOutput.
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   EvalOutputHelper(dut, context.get(), output.get());
   const VectorBase<double>* const output_vector = output->get_vector_data(0);
   ASSERT_NE(nullptr, output_vector);

--- a/systems/lcm/test/translator_test.cc
+++ b/systems/lcm/test/translator_test.cc
@@ -199,7 +199,7 @@ GTEST_TEST(TranslatorTest, EncodeBasicVectorVersion) {
   LcmEncoderSystem<TestVector<double>, lcmt_drake_signal> dut(
       std::make_unique<TestVectorTranslator>(kVecSize));
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   context->FixInputPort(0, vec.Clone());
   context->set_time(233);
 
@@ -223,7 +223,7 @@ GTEST_TEST(TranslatorTest, EncodeAbstractValVersion) {
   LcmEncoderSystem<TestData, lcmt_drake_signal> dut(
       std::make_unique<TestDataTranslator>(kVecSize));
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   context->FixInputPort(0, AbstractValue::Make<TestData>(data));
   context->set_time(233);
 
@@ -243,7 +243,7 @@ GTEST_TEST(TranslatorTest, DecodeAbstractValVersion) {
       std::make_unique<TestDataTranslator>(kVecSize));
 
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   lcmt_drake_signal msg = MakeTestMessage(kVecSize);
   context->FixInputPort(0, AbstractValue::Make<lcmt_drake_signal>(msg));
 
@@ -267,7 +267,7 @@ GTEST_TEST(TranslatorTest, FromLcmMessageBasicVectorVersion) {
       std::make_unique<TestVectorTranslator>(kVecSize));
 
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   lcmt_drake_signal msg = MakeTestMessage(kVecSize);
   context->FixInputPort(0, AbstractValue::Make<lcmt_drake_signal>(msg));
 

--- a/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
+++ b/systems/plants/spring_mass_system/test/spring_mass_system_test.cc
@@ -34,7 +34,7 @@ class SpringMassSystemTest : public ::testing::Test {
                                                          with_input_force);
     system_->set_name("test_system");
     context_ = system_->CreateDefaultContext();
-    system_output_ = system_->AllocateOutput(*context_);
+    system_output_ = system_->AllocateOutput();
     system_derivatives_ = system_->AllocateTimeDerivatives();
     const int nq = system_derivatives_->get_generalized_position().size();
     configuration_derivatives_ = std::make_unique<BasicVector<double>>(nq);
@@ -394,7 +394,7 @@ TEST_F(SpringMassSystemTest, Integrate) {
   // Allocate resources.
   for (int i = 0; i < kNumIntegrators; ++i) {
     contexts.push_back(system_->CreateDefaultContext());
-    outputs.push_back(system_->AllocateOutput(*contexts.back()));
+    outputs.push_back(system_->AllocateOutput());
     derivs.push_back(system_->AllocateTimeDerivatives());
   }
 

--- a/systems/primitives/test/affine_system_test.cc
+++ b/systems/primitives/test/affine_system_test.cc
@@ -22,7 +22,7 @@ class AffineSystemTest : public AffineLinearSystemTest {
     dut_->set_name("test_affine_system");
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput(*context_);
+    system_output_ = dut_->AllocateOutput();
     state_ = &context_->get_mutable_continuous_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
     updates_ = dut_->AllocateDiscreteVariables();
@@ -206,7 +206,7 @@ GTEST_TEST(DiscreteAffineSystemTest, DiscreteTime) {
   EXPECT_TRUE(CompareMatrices(system.y0(t), y0));
 
   // Compare the calculated output against the expected output.
-  auto system_output = system.AllocateOutput(*context);
+  auto system_output = system.AllocateOutput();
   system.CalcOutput(*context, system_output.get());
   EXPECT_TRUE(CompareMatrices(system_output->get_vector_data(0)->get_value(),
                               C * x0 + D * u0 + y0));
@@ -263,7 +263,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, EvalTest) {
   EXPECT_TRUE(CompareMatrices(sys.A(t) * x + 42.0 * sys.B(t),
                               derivs->CopyToVector()));
 
-  auto output = sys.AllocateOutput(*context);
+  auto output = sys.AllocateOutput();
   sys.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(x + sys.y0(t) + 42.0 * sys.D(t),
                               output->get_vector_data(0)->CopyToVector()));
@@ -284,7 +284,7 @@ GTEST_TEST(SimpleTimeVaryingAffineSystemTest, DiscreteEvalTest) {
   EXPECT_TRUE(CompareMatrices(sys.A(t) * x + 42.0 * sys.B(t),
                               updates->get_vector().CopyToVector()));
 
-  auto output = sys.AllocateOutput(*context);
+  auto output = sys.AllocateOutput();
   sys.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(x + sys.y0(t) + 42.0 * sys.D(t),
                               output->get_vector_data(0)->CopyToVector()));

--- a/systems/primitives/test/gain_scalartype_test.cc
+++ b/systems/primitives/test/gain_scalartype_test.cc
@@ -39,7 +39,7 @@ GTEST_TEST(GainScalarTypeTest, AutoDiff) {
   const double kGain = 2.0;
   auto gain = make_unique<Gain<T>>(kGain /* gain */, 3 /* size */);
   auto context = gain->CreateDefaultContext();
-  auto output = gain->AllocateOutput(*context);
+  auto output = gain->AllocateOutput();
   auto input = make_unique<BasicVector<T>>(3 /* size */);
 
   // Sets the input values.
@@ -85,7 +85,7 @@ class SymbolicGainTest : public ::testing::Test {
     gain_ = make_unique<Gain<symbolic::Expression>>(kGain_ /* gain */,
                                                     3 /* length */);
     context_ = gain_->CreateDefaultContext();
-    output_ = gain_->AllocateOutput(*context_);
+    output_ = gain_->AllocateOutput();
     input_ = make_unique<BasicVector<symbolic::Expression>>(3 /* length */);
   }
 

--- a/systems/primitives/test/gain_test.cc
+++ b/systems/primitives/test/gain_test.cc
@@ -25,7 +25,7 @@ void TestGainSystem(const Gain<T>& gain_system,
 
   // Verifies that Gain allocates no state variables in the context.
   EXPECT_EQ(0, context->get_continuous_state().size());
-  auto output = gain_system.AllocateOutput(*context);
+  auto output = gain_system.AllocateOutput();
   auto input =
       make_unique<BasicVector<double>>(gain_system.get_gain_vector().size());
 

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -23,7 +23,7 @@ class IntegratorTest : public ::testing::Test {
     integrator_.reset(new Integrator<double>(kLength));
     context_ = integrator_->CreateDefaultContext();
     derivatives_ = integrator_->AllocateTimeDerivatives();
-    output_ = integrator_->AllocateOutput(*context_);
+    output_ = integrator_->AllocateOutput();
 
     // Set the state to zero initially.
     ContinuousState<double>& xc = continuous_state();
@@ -97,7 +97,7 @@ class SymbolicIntegratorTest : public IntegratorTest {
     symbolic_integrator_ = integrator_->ToSymbolic();
     symbolic_context_ = symbolic_integrator_->CreateDefaultContext();
     symbolic_derivatives_ = symbolic_integrator_->AllocateTimeDerivatives();
-    symbolic_output_ = symbolic_integrator_->AllocateOutput(*symbolic_context_);
+    symbolic_output_ = symbolic_integrator_->AllocateOutput();
 
     ASSERT_EQ(1, symbolic_context_->get_num_input_ports());
     symbolic_context_->FixInputPort(

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -27,7 +27,7 @@ class LinearSystemTest : public AffineLinearSystemTest {
     dut_->set_name("test_linear_system");
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput(*context_);
+    system_output_ = dut_->AllocateOutput();
     state_ = &context_->get_mutable_continuous_state();
     derivatives_ = dut_->AllocateTimeDerivatives();
   }

--- a/systems/primitives/test/matrix_gain_test.cc
+++ b/systems/primitives/test/matrix_gain_test.cc
@@ -21,7 +21,7 @@ class MatrixGainTest : public AffineLinearSystemTest {
     dut_->set_name("test_matrix_gain_system");
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput(*context_);
+    system_output_ = dut_->AllocateOutput();
   }
 
  protected:

--- a/systems/primitives/test/multiplexer_test.cc
+++ b/systems/primitives/test/multiplexer_test.cc
@@ -23,13 +23,13 @@ class MultiplexerTest : public ::testing::Test {
   void InitializeFromSizes(std::vector<int> input_sizes) {
     mux_ = make_unique<Multiplexer<double>>(input_sizes);
     context_ = mux_->CreateDefaultContext();
-    output_ = mux_->AllocateOutput(*context_);
+    output_ = mux_->AllocateOutput();
   }
 
   void InitializeFromMyVector() {
     mux_ = make_unique<Multiplexer<double>>(MyVector<2, double>());
     context_ = mux_->CreateDefaultContext();
-    output_ = mux_->AllocateOutput(*context_);
+    output_ = mux_->AllocateOutput();
   }
 
   std::unique_ptr<System<double>> mux_;
@@ -71,7 +71,7 @@ TEST_F(MultiplexerTest, Basic) {
 TEST_F(MultiplexerTest, ScalarConstructor) {
   mux_ = make_unique<Multiplexer<double>>(4);
   context_ = mux_->CreateDefaultContext();
-  output_ = mux_->AllocateOutput(*context_);
+  output_ = mux_->AllocateOutput();
 
   // Confirm the shape.
   ASSERT_EQ(4, mux_->get_num_input_ports());

--- a/systems/primitives/test/pass_through_scalartype_test.cc
+++ b/systems/primitives/test/pass_through_scalartype_test.cc
@@ -30,7 +30,7 @@ GTEST_TEST(PassThroughScalarTypeTest, AutoDiff) {
   // Set a PassThrough system with input and output of size 3.
   auto buffer = make_unique<PassThrough<T>>(3 /* size */);
   auto context = buffer->CreateDefaultContext();
-  auto output = buffer->AllocateOutput(*context);
+  auto output = buffer->AllocateOutput();
   auto input = make_unique<BasicVector<T>>(3 /* size */);
 
   // Sets the input values.

--- a/systems/primitives/test/pass_through_test.cc
+++ b/systems/primitives/test/pass_through_test.cc
@@ -48,7 +48,7 @@ class PassThroughTest : public ::testing::TestWithParam<bool> {
           make_unique<PassThrough<double>>(Value<SimpleAbstractType>(size));
     }
     context_ = pass_through_->CreateDefaultContext();
-    output_ = pass_through_->AllocateOutput(*context_);
+    output_ = pass_through_->AllocateOutput();
   }
 
   const bool is_abstract_;

--- a/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_affine_system_test.cc
@@ -37,7 +37,7 @@ class PiecewisePolynomialAffineSystemTest
     }
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput(*context_);
+    system_output_ = dut_->AllocateOutput();
     continuous_state_ = &context_->get_mutable_continuous_state();
     discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();

--- a/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
+++ b/systems/primitives/test/piecewise_polynomial_linear_system_test.cc
@@ -37,7 +37,7 @@ class PiecewisePolynomialLinearSystemTest
     }
     context_ = dut_->CreateDefaultContext();
     input_vector_ = make_unique<BasicVector<double>>(2 /* size */);
-    system_output_ = dut_->AllocateOutput(*context_);
+    system_output_ = dut_->AllocateOutput();
     continuous_state_ = &context_->get_mutable_continuous_state();
     discrete_state_ = &context_->get_mutable_discrete_state();
     derivatives_ = dut_->AllocateTimeDerivatives();

--- a/systems/primitives/test/saturation_test.cc
+++ b/systems/primitives/test/saturation_test.cc
@@ -21,7 +21,7 @@ void TestInputAndOutput(const Saturation<T>& saturation_system,
 
   // Verifies that Saturation allocates no state variables in the context.
   EXPECT_EQ(context->get_continuous_state().size(), 0);
-  auto output = saturation_system.AllocateOutput(*context);
+  auto output = saturation_system.AllocateOutput();
   auto input = std::make_unique<BasicVector<T>>(port_size);
 
   input->get_mutable_value() << input_vector;

--- a/systems/primitives/test/sine_test.cc
+++ b/systems/primitives/test/sine_test.cc
@@ -32,7 +32,7 @@ void TestSineSystem(const Sine<T>& sine_system,
 
   // Verifies that Sine allocates no state variables in the context.
   EXPECT_EQ(0, context->get_continuous_state().size());
-  auto output = sine_system.AllocateOutput(*context);
+  auto output = sine_system.AllocateOutput();
 
   if (sine_system.is_time_based()) {
     // If the system is time based, the input_vectors Matrix should only contain

--- a/systems/primitives/test/trajectory_source_test.cc
+++ b/systems/primitives/test/trajectory_source_test.cc
@@ -30,7 +30,7 @@ class TrajectorySourceTest : public ::testing::Test {
     source_ = make_unique<TrajectorySource<double>>(*kppTraj_, kDerivativeOrder,
                                                     true);
     context_ = source_->CreateDefaultContext();
-    output_ = source_->AllocateOutput(*context_);
+    output_ = source_->AllocateOutput();
     input_ = make_unique<BasicVector<double>>(3 /* length */);
   }
 

--- a/systems/primitives/test/wrap_to_system_test.cc
+++ b/systems/primitives/test/wrap_to_system_test.cc
@@ -19,7 +19,7 @@ void CheckOutput(const System<T>& dut,
                  const Eigen::Ref<const VectorX<T>>& input,
                  const Eigen::Ref<const VectorX<T>>& expected_output) {
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   context->FixInputPort(0, input);
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(output->get_vector_data(0)->CopyToVector(),

--- a/systems/primitives/test/zero_order_hold_test.cc
+++ b/systems/primitives/test/zero_order_hold_test.cc
@@ -60,7 +60,7 @@ class ZeroOrderHoldTest : public ::testing::TestWithParam<bool> {
           kTenHertz, Value<SimpleAbstractType>(Eigen::Vector3d::Zero()));
     }
     context_ = hold_->CreateDefaultContext();
-    output_ = hold_->AllocateOutput(*context_);
+    output_ = hold_->AllocateOutput();
     if (!is_abstract_) {
       context_->FixInputPort(
           0, std::make_unique<BasicVector<double>>(input_value_));
@@ -222,7 +222,7 @@ class SymbolicZeroOrderHoldTest : public ::testing::Test {
     auto& xd = context_->get_mutable_discrete_state(0);
     xd[0] = symbolic::Variable("x0");
 
-    output_ = hold_->AllocateOutput(*context_);
+    output_ = hold_->AllocateOutput();
     update_ = hold_->AllocateDiscreteVariables();
   }
 

--- a/systems/rendering/test/pose_aggregator_test.cc
+++ b/systems/rendering/test/pose_aggregator_test.cc
@@ -44,7 +44,7 @@ class PoseAggregatorTest : public ::testing::Test {
     aggregator_.AddSingleInput("single_x", kRandomModelInstanceId1);
 
     context_ = aggregator_.CreateDefaultContext();
-    output_ = aggregator_.AllocateOutput(*context_);
+    output_ = aggregator_.AllocateOutput();
   }
 
   PoseAggregator<double> aggregator_;
@@ -173,7 +173,7 @@ TEST_F(PoseAggregatorTest, CompositeAggregation) {
   autodiff_context->FixInputPort(2, std::move(autodiff_frame_vel1));
   autodiff_context->FixInputPort(3, std::move(autodiff_pose_vec2));
 
-  auto autodiff_output = autodiff_aggregator->AllocateOutput(*autodiff_context);
+  auto autodiff_output = autodiff_aggregator->AllocateOutput();
   autodiff_aggregator->CalcOutput(*autodiff_context, autodiff_output.get());
   const PoseBundle<AutoDiffXd>& autodiff_bundle =
       autodiff_output->get_data(0)->GetValueOrThrow<PoseBundle<AutoDiffXd>>();

--- a/systems/rendering/test/pose_bundle_to_draw_message_test.cc
+++ b/systems/rendering/test/pose_bundle_to_draw_message_test.cc
@@ -28,7 +28,7 @@ GTEST_TEST(PoseBundleToDrawMessageTest, Conversion) {
   PoseBundleToDrawMessage converter;
   auto context = converter.AllocateContext();
   context->FixInputPort(0, AbstractValue::Make(bundle));
-  auto output = converter.AllocateOutput(*context);
+  auto output = converter.AllocateOutput();
   converter.CalcOutput(*context, output.get());
 
   const auto& message = output->get_data(0)->GetValue<lcmt_viewer_draw>();

--- a/systems/sensors/test/accelerometer_test/accelerometer_test.cc
+++ b/systems/sensors/test/accelerometer_test/accelerometer_test.cc
@@ -85,7 +85,7 @@ void TestAccelerometerFreeFall(const Eigen::Vector3d& xyz,
       dut.get_plant_state_derivative_input_port().get_index(),
       make_unique<BasicVector<double>>(VectorX<double>::Zero(num_states)));
 
-  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput(*dut_context);
+  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput();
   ASSERT_EQ(output->get_num_ports(), 1);
   dut.CalcOutput(*dut_context, output.get());
 

--- a/systems/sensors/test/depth_sensor_test.cc
+++ b/systems/sensors/test/depth_sensor_test.cc
@@ -67,7 +67,7 @@ void DoEmptyWorldTest(const char* const name,
   DepthSensor dut(name, tree, frame, specification);
 
   unique_ptr<Context<double>> context = dut.CreateDefaultContext();
-  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput(*context);
+  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput();
 
   int input_port_index = dut.get_rigid_body_tree_state_input_port().get_index();
   context->FixInputPort(
@@ -168,7 +168,7 @@ std::pair<VectorX<double>, Matrix3Xd> DoBoxOcclusionTest(
   DepthSensor dut(name, tree, *frame, specification);
 
   unique_ptr<Context<double>> context = dut.CreateDefaultContext();
-  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput(*context);
+  unique_ptr<SystemOutput<double>> output = dut.AllocateOutput();
 
   int input_port_index = dut.get_rigid_body_tree_state_input_port().get_index();
   context->FixInputPort(input_port_index,

--- a/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
+++ b/systems/sensors/test/depth_sensor_to_lcm_point_cloud_message_test.cc
@@ -57,7 +57,7 @@ class TestDepthSensorToLcmPointCloudMessage : public ::testing::Test {
       context->FixInputPort(pose_input_port.get_index(), std::move(pose_input));
     }
 
-    output_ = dut.AllocateOutput(*context);
+    output_ = dut.AllocateOutput();
 
     dut.CalcOutput(*context, output_.get());
 

--- a/systems/sensors/test/gyroscope_test.cc
+++ b/systems/sensors/test/gyroscope_test.cc
@@ -83,7 +83,7 @@ TEST_F(TestGyroscope, TestFreeFall) {
       dut_->get_input_port().get_index(),
       make_unique<BasicVector<double>>(state_vector));
 
-  unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context_);
+  unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput();
   ASSERT_EQ(output->get_num_ports(), 1);
   dut_->CalcOutput(*context_, output.get());
 
@@ -119,7 +119,7 @@ TEST_F(TestGyroscope, TestNonZeroRotationalVelocity) {
       dut_->get_input_port().get_index(),
       make_unique<BasicVector<double>>(state_vector));
 
-  unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput(*context_);
+  unique_ptr<SystemOutput<double>> output = dut_->AllocateOutput();
   ASSERT_EQ(output->get_num_ports(), 1);
   dut_->CalcOutput(*context_, output.get());
 

--- a/systems/sensors/test/image_to_lcm_image_array_t_test.cc
+++ b/systems/sensors/test/image_to_lcm_image_array_t_test.cc
@@ -42,7 +42,7 @@ robotlocomotion::image_array_t SetUpInputAndOutput(
   context->FixInputPort(label_image_input_port.get_index(),
                         std::move(label_image_value));
 
-  auto output = dut->AllocateOutput(*context);
+  auto output = dut->AllocateOutput();
   dut->CalcOutput(*context, output.get());
 
   auto output_image_array_t = output->get_data(

--- a/systems/sensors/test/optitrack_sender_test.cc
+++ b/systems/sensors/test/optitrack_sender_test.cc
@@ -49,7 +49,7 @@ GTEST_TEST(OptitrackSenderTest, OptitrackLcmSenderTest) {
       new systems::Value<geometry::FramePoseVector<double>>(pose_vector));
 
   auto context = dut.CreateDefaultContext();
-  auto output = dut.AllocateOutput(*context);
+  auto output = dut.AllocateOutput();
   context->FixInputPort(0 /* input port ID*/, std::move(input));
 
   dut.CalcUnrestrictedUpdate(*context, &context->get_mutable_state());

--- a/systems/sensors/test/rgbd_camera_test.cc
+++ b/systems/sensors/test/rgbd_camera_test.cc
@@ -232,7 +232,7 @@ class RgbdCameraDiagramTest : public ::testing::Test {
     size_ = size;
     diagram_->Init(position, orientation, size_.width, size_.height);
     context_ = diagram_->CreateDefaultContext();
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
   }
 
   // For moving camera base.
@@ -244,7 +244,7 @@ class RgbdCameraDiagramTest : public ::testing::Test {
     size_ = size;
     diagram_->Init(transformation, size_.width, size_.height);
     context_ = diagram_->CreateDefaultContext();
-    output_ = diagram_->AllocateOutput(*context_);
+    output_ = diagram_->AllocateOutput();
   }
 
   void CalcOutput() {

--- a/systems/sensors/test/rotary_encoders_test.cc
+++ b/systems/sensors/test/rotary_encoders_test.cc
@@ -26,7 +26,7 @@ GTEST_TEST(TestEncoders, QuantizeOnly) {
   ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
-  auto output = encoders.AllocateOutput(*context);
+  auto output = encoders.AllocateOutput();
   auto measurement = output->get_vector_data(0);
 
   double tol = 1e-10;
@@ -59,7 +59,7 @@ GTEST_TEST(TestEncoders, SelectorOnly) {
   systems::sensors::RotaryEncoders<double> encoders(4, indices);
 
   auto context = encoders.CreateDefaultContext();
-  auto output = encoders.AllocateOutput(*context);
+  auto output = encoders.AllocateOutput();
   auto measurement = output->get_vector_data(0);
 
   double tol = 1e-10;
@@ -93,7 +93,7 @@ GTEST_TEST(TestEncoders, QuantizationAndSelector) {
   ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
-  auto output = encoders.AllocateOutput(*context);
+  auto output = encoders.AllocateOutput();
   auto measurement = output->get_vector_data(0);
 
   double tol = 1e-10;
@@ -132,7 +132,7 @@ GTEST_TEST(TestEncoders, CalibrationOffsets) {
   ticks_per_radian << tick_counts[0] / k2Pi, tick_counts[1] / k2Pi;
 
   auto context = encoders.CreateDefaultContext();
-  auto output = encoders.AllocateOutput(*context);
+  auto output = encoders.AllocateOutput();
   auto measurement = output->get_vector_data(0);
 
   // Set some offsets.
@@ -191,7 +191,7 @@ GTEST_TEST(TestEncoders, ScalarConversion) {
     context->FixInputPort(0, input);
 
     // Obtain the symbolic outputs.
-    auto outputs = dut.AllocateOutput(*context);
+    auto outputs = dut.AllocateOutput();
     dut.CalcOutput(*context, outputs.get());
     const systems::BasicVector<Expression>& output =
         *(outputs->get_vector_data(0));


### PR DESCRIPTION
System::AllocateOutput(Context) has been ignoring the Context argument for a long time. This formally deprecates that signature and removes the argument from all the calls in Drake.

I also removed the Python binding for the deprecated signature rather than deprecating it; would be OK with deprecating that instead if that seems worth doing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9051)
<!-- Reviewable:end -->
