### PR TITLE
Disable monolithic_pick_and_place_system_test

### DIFF
--- a/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/dev/monolithic_pick_and_place/BUILD.bazel
@@ -90,6 +90,9 @@ drake_cc_googletest(
         "no_tsan",
         "no_ubsan",
         "snopt",
+        # TODO(9039) This test should be re-enabled in CI; it was disabled
+        # because it was timing out frequenutly.
+        "manual",
     ],
     deps = [
         ":kuka_pick_and_place_monolithic",


### PR DESCRIPTION
This test is currently timing out frequently in Jenkins.  It is in a `dev` folder so the best answer is just to disable it.

Relates #9039.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9052)
<!-- Reviewable:end -->
