### PR TITLE
MBP generalized contact forces output port

### DIFF
--- a/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
+++ b/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
@@ -630,8 +630,14 @@ class ImplicitStribeckSolver {
 
   /// Returns a constant reference to the last solved vector of generalized
   /// friction forces.
-  const VectorX<T>& get_generalized_forces() const {
+  const VectorX<T>& get_generalized_friction_forces() const {
     return fixed_size_workspace_.mutable_tau_f();
+  }
+
+  /// Returns a constant reference to the last solved vector of generalized
+  /// contact forces, including both friction and normal forces.
+  const VectorX<T>& get_generalized_contact_forces() const {
+    return fixed_size_workspace_.mutable_tau();
   }
 
   /// Returns a constant reference to the last solved vector of tangential

--- a/multibody/multibody_tree/implicit_stribeck/test/implicit_stribeck_solver_test.cc
+++ b/multibody/multibody_tree/implicit_stribeck/test/implicit_stribeck_solver_test.cc
@@ -532,7 +532,7 @@ TEST_F(PizzaSaver, SmallAppliedMoment) {
   ComputationInfo info = solver_.SolveWithGuess(dt, v0);
   ASSERT_EQ(info, ComputationInfo::Success);
 
-  VectorX<double> tau_f = solver_.get_generalized_forces();
+  VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
   const IterationStats& stats = solver_.get_iteration_statistics();
 
@@ -634,7 +634,7 @@ TEST_F(PizzaSaver, LargeAppliedMoment) {
   ComputationInfo info = solver_.SolveWithGuess(dt, v0);
   ASSERT_EQ(info, ComputationInfo::Success);
 
-  VectorX<double> tau_f = solver_.get_generalized_forces();
+  VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
   const IterationStats& stats = solver_.get_iteration_statistics();
 
@@ -726,7 +726,7 @@ TEST_F(PizzaSaver, NoContact) {
   ComputationInfo info = solver_.SolveWithGuess(dt, v0);
   ASSERT_EQ(info, ComputationInfo::Success);
 
-  EXPECT_EQ(solver_.get_generalized_forces(), Vector3<double>::Zero());
+  EXPECT_EQ(solver_.get_generalized_friction_forces(), Vector3<double>::Zero());
 
   const IterationStats& stats = solver_.get_iteration_statistics();
   EXPECT_EQ(stats.vt_residual(), 0);
@@ -934,7 +934,7 @@ TEST_F(RollingCylinder, StictionAfterImpact) {
   ComputationInfo info = solver_.SolveWithGuess(dt, v0);
   ASSERT_EQ(info, ComputationInfo::Success);
 
-  VectorX<double> tau_f = solver_.get_generalized_forces();
+  VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
   const IterationStats& stats = solver_.get_iteration_statistics();
 
@@ -1024,7 +1024,7 @@ TEST_F(RollingCylinder, SlidingAfterImpact) {
   ComputationInfo info = solver_.SolveWithGuess(dt, v0);
   ASSERT_EQ(info, ComputationInfo::Success);
 
-  VectorX<double> tau_f = solver_.get_generalized_forces();
+  VectorX<double> tau_f = solver_.get_generalized_friction_forces();
 
   const IterationStats& stats = solver_.get_iteration_statistics();
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -976,7 +976,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     actuated_instance_ = last_actuated_instance;
   }
 
-  // Declare on output port for the entire state vector.
+  // Declare one output port for the entire state vector.
   continuous_state_output_port_ =
       this->DeclareVectorOutputPort(
           BasicVector<T>(num_multibody_states()),
@@ -1051,8 +1051,8 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
 
 template <typename T>
 void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
-    ModelInstanceIndex model_instance,
-    const Context<T>& context, BasicVector<T>* tau_vector) const {
+    ModelInstanceIndex model_instance, const Context<T>&,
+    BasicVector<T>* tau_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(is_discrete());
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -946,6 +946,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
         model_->num_velocities(), 0 /* num_z */);
   }
 
+  // Declare per model instance actuation ports.
   int num_actuated_instances = 0;
   ModelInstanceIndex last_actuated_instance;
   instance_actuation_ports_.resize(num_model_instances());
@@ -967,11 +968,13 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     actuated_instance_ = last_actuated_instance;
   }
 
+  // Declare on output port for the entire state vector.
   continuous_state_output_port_ =
       this->DeclareVectorOutputPort(
           BasicVector<T>(num_multibody_states()),
           &MultibodyPlant::CopyContinuousStateOut).get_index();
 
+  // Declare per model instance state output ports.
   instance_continuous_state_output_ports_.resize(num_model_instances());
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
@@ -989,6 +992,26 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
         this->DeclareVectorOutputPort(
             BasicVector<T>(instance_num_states), calc).get_index();
   }
+
+  // Declare per model instance output port of generalized contact forces.
+  instance_generalized_contact_forces_output_ports_.resize(
+      num_model_instances());
+  for (ModelInstanceIndex model_instance_index(0);
+       model_instance_index < num_model_instances(); ++model_instance_index) {
+    const int instance_num_velocities =
+        model_->num_velocities(model_instance_index);
+    if (instance_num_velocities == 0) {
+      continue;
+    }
+    auto calc = [this, model_instance_index](const systems::Context<T>& context,
+                                             systems::BasicVector<T>* result) {
+      this->CopyGeneralizedContactForcesOut(
+          model_instance_index, context, result);
+    };
+    instance_generalized_contact_forces_output_ports_[model_instance_index] =
+        this->DeclareVectorOutputPort(
+            BasicVector<T>(instance_num_velocities), calc).get_index();
+  }
 }
 
 template <typename T>
@@ -1004,7 +1027,7 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
 
-  VectorX<T> continuous_state_vector =
+  const VectorX<T> continuous_state_vector =
       context.get_continuous_state_vector().CopyToVector();
 
   VectorX<T> instance_state_vector(model_->num_states(model_instance));
@@ -1016,6 +1039,29 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
           model_instance, continuous_state_vector.tail(num_velocities()));
 
   state_vector->set_value(instance_state_vector);
+}
+
+template <typename T>
+void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
+    ModelInstanceIndex model_instance,
+    const Context<T>& context, BasicVector<T>* tau_vector) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(is_discrete());
+
+  // Vector of generalized contact forces for the entire plant's multibody
+  // system.
+  // TODO(amcastro-tri): Contact forces should be computed into a cache entry
+  // and evaluated here. Update this to use caching as soon as the capability
+  // lands.
+  const VectorX<T>& tau_contact =
+      implicit_stribeck_solver_->get_generalized_contact_forces();
+
+  // Generalized velocities and generalized forces are ordered in the same way.
+  // Thus we can call get_velocities_from_array().
+  const VectorX<T> instance_tau_contact =
+      model_->get_velocities_from_array(model_instance, tau_contact);
+
+  tau_vector->set_value(instance_tau_contact);
 }
 
 template <typename T>
@@ -1056,6 +1102,19 @@ MultibodyPlant<T>::get_continuous_state_output_port(
   DRAKE_THROW_UNLESS(model_->num_states(model_instance) > 0);
   return this->get_output_port(
       instance_continuous_state_output_ports_.at(model_instance));
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+MultibodyPlant<T>::get_generalized_contact_forces_output_port(
+    ModelInstanceIndex model_instance) const {
+  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+  DRAKE_THROW_UNLESS(is_discrete());
+  DRAKE_THROW_UNLESS(model_instance.is_valid());
+  DRAKE_THROW_UNLESS(model_instance < num_model_instances());
+  DRAKE_THROW_UNLESS(model_->num_states(model_instance) > 0);
+  return this->get_output_port(
+      instance_generalized_contact_forces_output_ports_.at(model_instance));
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1490,10 +1490,14 @@ class MultibodyPlant : public systems::LeafSystem<T> {
 
   systems::OutputPortIndex continuous_state_output_port_;
   // A vector containing state output ports for each model instance indexed by
-  // ModelInstanceIndex.  An invalid value indicates that the model instance has
+  // ModelInstanceIndex. An invalid value indicates that the model instance has
   // no state.
   std::vector<systems::OutputPortIndex> instance_continuous_state_output_ports_;
 
+  // A vector containing the index for the generalized contact forces port for
+  // each model instance. This vector is indexed by ModelInstanceIndex. An
+  // invalid value indicates that the model instance has no generalized
+  // velocities and thus no generalized forces.
   std::vector<systems::OutputPortIndex>
       instance_generalized_contact_forces_output_ports_;
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -881,6 +881,20 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @}
   // Closes Doxygen section "Continuous state output"
 
+  /// Returns a constant reference to the output port of generalized contact
+  /// forces for a specific model instance. This output port is only available
+  /// when modeling the plant as a discrete system with periodic updates, see
+  /// is_discrete().
+  ///
+  /// @pre Finalize() was already called on `this` plant.
+  /// @throws std::exception if `this` plant is not modeled as a discrete system
+  /// with periodic updates.
+  /// @throws std::exception if called before Finalize() or if the model
+  /// instance does not have any generalized velocities.
+  /// @throws std::exception if the model instance does not exist.
+  const systems::OutputPort<T>& get_generalized_contact_forces_output_port(
+      ModelInstanceIndex model_instance) const;
+
   /// Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
     return model_->world_body();
@@ -1234,6 +1248,12 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       ModelInstanceIndex model_instance,
       const systems::Context<T>& context, systems::BasicVector<T>* state) const;
 
+  // Calc method to output per model instance vector of generalized contact
+  // forces.
+  void CopyGeneralizedContactForcesOut(
+      ModelInstanceIndex model_instance, const systems::Context<T>& context,
+      systems::BasicVector<T>* tau_vector) const;
+
   // Helper method to declare output ports used by this plant to communicate
   // with a SceneGraph.
   void DeclareSceneGraphPorts();
@@ -1456,6 +1476,9 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // ModelInstanceIndex.  An invalid value indicates that the model instance has
   // no state.
   std::vector<systems::OutputPortIndex> instance_continuous_state_output_ports_;
+
+  std::vector<systems::OutputPortIndex>
+      instance_generalized_contact_forces_output_ports_;
 
   // If the plant is modeled as a discrete system with periodic updates,
   // time_step_ corresponds to the period of those updates. Otherwise, if the

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -146,7 +146,7 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(plant->num_positions(pendulum_model_instance), 1);
   EXPECT_EQ(plant->num_velocities(pendulum_model_instance), 1);
 
-  // Check that the input/output ports have the approptiate geometry.
+  // Check that the input/output ports have the appropriate geometry.
   EXPECT_THROW(plant->get_actuation_input_port(), std::runtime_error);
   EXPECT_EQ(plant->get_actuation_input_port(
       default_model_instance()).size(), 1);
@@ -467,6 +467,15 @@ TEST_F(AcrobotPlantTests, CalcTimeDerivatives) {
 TEST_F(AcrobotPlantTests, DoCalcDiscreteVariableUpdates) {
   // Set up an additional discrete state model of the same acrobot model.
   SetUpDiscreteAcrobotPlant(0.001 /* time step in seconds. */);
+
+  const ModelInstanceIndex instance_index =
+      discrete_plant_->GetModelInstanceByName("acrobot");
+
+  // The generalized contact forces output port should have the same size as
+  // number of generalized velocities in the model instance, even if there is
+  // no contact geometry in the model.
+  EXPECT_EQ(discrete_plant_->get_generalized_contact_forces_output_port(
+      instance_index).size(), 2);
 
   // Verify the implementation for a number of arbitrarily chosen states.
   VerifyDoCalcDiscreteVariableUpdates(


### PR DESCRIPTION
This PR adds an output port for the vector of generalized contact forces per model instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9053)
<!-- Reviewable:end -->
