### PR TITLE
Fixes problem with velocity stepping using purely bilaterally...

### DIFF
--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -207,9 +207,9 @@ class ConstraintSolver {
   /// </pre>
   /// The key variables for using the MLCP-based formulations are the matrix `A`
   /// and vector `a`, as seen in documentation of MlcpToLcpData and the
-  /// following methods. During its operation, ConstructBaseDiscretizedTimeLCP()
+  /// following methods. During its operation, ConstructBaseDiscretizedTimeLcp()
   /// constructs (and returns) functions for solving `AX=B`, where `B` is a
-  /// given matrix and `X` is an unknown matrix. UpdateDiscretizedTimeLCP()
+  /// given matrix and `X` is an unknown matrix. UpdateDiscretizedTimeLcp()
   /// computes and returns `a` during its operation.
   ///
   /// <h3>Another use of the MLCP formulation (discretized multi-body dynamics
@@ -251,18 +251,18 @@ class ConstraintSolver {
   ///
   /// The procedure one uses to formulate and solve this discretization problem
   /// is:
-  /// -# Call ConstructBaseDiscretizedTimeLCP()
+  /// -# Call ConstructBaseDiscretizedTimeLcp()
   /// -# Select an integration step size, dt
   /// -# Compute `kᴺ' and `kᴸ` in the problem data, accounting for dt as
   ///    necessary
-  /// -# Call UpdateDiscretizedTimeLCP(), obtaining MM and qq that encode the
+  /// -# Call UpdateDiscretizedTimeLcp(), obtaining MM and qq that encode the
   ///    linear complementarity problem
   /// -# Solve the linear complementarity problem
   /// -# If LCP solved, quit.
   /// -# Reduce dt and repeat the process from 3. until success.
   ///
   /// The solution to the LCP can be used to obtain the constraint forces via
-  /// PopulatePackedConstraintForcesFromLCPSolution().
+  /// PopulatePackedConstraintForcesFromLcpSolution().
   ///
   /// <h3>Obtaining the generalized constraint forces:</h3>
   ///
@@ -270,7 +270,7 @@ class ConstraintSolver {
   /// SolveImpactProblem() (in which case the forces are impulsive) or through
   /// direct solution of the LCP corresponding to the discretized multibody
   /// dynamics problem, followed by
-  /// PopulatePackedConstraintForcesFromLCPSolution() (in which cases the forces
+  /// PopulatePackedConstraintForcesFromLcpSolution() (in which cases the forces
   /// are non-impulsive), the generalized forces/impulses due to the constraints
   /// can then be acquired via ComputeGeneralizedForceFromConstraintForces().
   // @{
@@ -280,9 +280,9 @@ class ConstraintSolver {
   /// LCP corresponds to an impact problem (i.e., the multibody dynamics problem
   /// would not be discretized). The data output (`mlcp_to_lcp_data`, `MM`, and
   /// `qq`) can be updated using a particular time step in
-  /// UpdateDiscretizedTimeLCP(), resulting in a non-impulsive problem
+  /// UpdateDiscretizedTimeLcp(), resulting in a non-impulsive problem
   /// formulation. In that case, the multibody dynamics equations *are*
-  /// discretized, as described in UpdateDiscretizedTimeLCP().
+  /// discretized, as described in UpdateDiscretizedTimeLcp().
   /// @note If you really do wish to solve an impact problem, you should use
   ///       SolveImpactProblem() instead.
   /// @param problem_data the constraint problem data.
@@ -294,17 +294,17 @@ class ConstraintSolver {
   /// @param[out] qq a pointer to a vector that will contain the parts of the
   ///             LCP vector not dependent upon the time step on return.
   /// @pre `mlcp_to_lcp_data`, `MM`, and `qq` are non-null on entry.
-  /// @see UpdateDiscretizedTimeLCP()
-  static void ConstructBaseDiscretizedTimeLCP(
+  /// @see UpdateDiscretizedTimeLcp()
+  static void ConstructBaseDiscretizedTimeLcp(
       const ConstraintVelProblemData<T>& problem_data,
       MlcpToLcpData* mlcp_to_lcp_data,
       MatrixX<T>* MM,
       VectorX<T>* qq);
 
   /// Updates the time-discretization of the LCP initially computed in
-  /// ConstructBaseDiscretizedTimeLCP() using the problem data and time step
+  /// ConstructBaseDiscretizedTimeLcp() using the problem data and time step
   /// `h`. Solving the resulting pure LCP yields non-impulsive constraint forces
-  /// that can be obtained from PopulatePackedConstraintForcesFromLCPSolution().
+  /// that can be obtained from PopulatePackedConstraintForcesFromLcpSolution().
   /// @param problem_data the constraint problem data.
   /// @param[out] mlcp_to_lcp_data a pointer to a valid MlcpToLcpData object;
   ///             the caller must ensure that this pointer remains valid through
@@ -313,8 +313,8 @@ class ConstraintSolver {
   /// @param[out] MM a pointer to the updated LCP matrix on return.
   /// @param[out] qq a pointer to the updated LCP vector on return.
   /// @pre `mlcp_to_lcp_data`, `a`, `MM`, and `qq` are non-null on entry.
-  /// @see ConstructBaseDiscretizedTimeLCP()
-  static void UpdateDiscretizedTimeLCP(
+  /// @see ConstructBaseDiscretizedTimeLcp()
+  static void UpdateDiscretizedTimeLcp(
       const ConstraintVelProblemData<T>& problem_data,
       double h,
       MlcpToLcpData* mlcp_to_lcp_data,
@@ -352,16 +352,29 @@ class ConstraintSolver {
 
   /// Populates the packed constraint force vector from the solution to the
   /// linear complementarity problem (LCP) constructed using
-  /// ConstructBaseDiscretizedTimeLCP() and UpdateDiscretizedTimeLCP().
+  /// ConstructBaseDiscretizedTimeLcp() and UpdateDiscretizedTimeLcp().
   /// @param problem_data the constraint problem data.
   /// @param mlcp_to_lcp_data a reference to a MlcpToLcpData object.
   /// @param zz the solution to the LCP resulting from
-  ///        UpdateDiscretizedTimeLCP().
-  /// @param a the vector `a` output from UpdateDiscretizedTimeLCP().
+  ///        UpdateDiscretizedTimeLcp().
+  /// @param a the vector `a` output from UpdateDiscretizedTimeLcp().
   /// @param dt the time step used to discretize the problem.
-  /// @param[out] cf the constraint forces, on return.
+  /// @param[out] cf the constraint forces, on return. The first `nc` elements
+  ///        of `cf` correspond to the magnitudes of the contact forces applied
+  ///        along the normals of the `nc` contact points. The next elements of
+  ///        `cf` correspond to the frictional forces along the `r` spanning
+  ///        directions at each point of contact. The first `r` values (after
+  ///        the initial `nc` elements) correspond to the first contact, the
+  ///        next `r` values correspond to the second contact, etc. The next
+  ///        `ℓ` values of `cf` correspond to the impulsive forces applied to
+  ///        enforce unilateral constraint functions. The final `b` values of
+  ///        `cf` correspond to the forces applied to enforce generic bilateral
+  ///        constraints. This packed storage format can be turned into more
+  ///        useful representations through
+  ///        ComputeGeneralizedForceFromConstraintForces() and
+  ///        CalcContactForcesInContactFrames(). 
   /// @pre cf is non-null.
-  static void PopulatePackedConstraintForcesFromLCPSolution(
+  static void PopulatePackedConstraintForcesFromLcpSolution(
       const ConstraintVelProblemData<T>& problem_data,
       const MlcpToLcpData& mlcp_to_lcp_data,
       const VectorX<T>& zz,
@@ -418,7 +431,7 @@ class ConstraintSolver {
   /// @param problem_data The data used to compute the contact forces.
   /// @param cf The computed constraint forces, in the packed storage
   ///           format described in documentation for
-  ///           PopulatePackedConstraintForcesFromLCPSolution().
+  ///           PopulatePackedConstraintForcesFromLcpSolution().
   /// @param[out] generalized_force The generalized force acting on the system
   ///             from the total constraint wrench is stored here, on return.
   ///             This method will resize `generalized_force` as necessary. The
@@ -537,16 +550,16 @@ class ConstraintSolver {
       std::vector<Vector2<T>>* contact_forces);
 
  private:
-  static void PopulatePackedConstraintForcesFromLCPSolution(
+  static void PopulatePackedConstraintForcesFromLcpSolution(
       const ConstraintVelProblemData<T>& problem_data,
       const MlcpToLcpData& mlcp_to_lcp_data,
       const VectorX<T>& zz,
       const VectorX<T>& a,
       VectorX<T>* cf);
-  static void ConstructLinearEquationSolversForMLCP(
+  static void ConstructLinearEquationSolversForMlcp(
       const ConstraintVelProblemData<T>& problem_data,
       MlcpToLcpData* mlcp_to_lcp_data);
-  void FormAndSolveConstraintLCP(
+  void FormAndSolveConstraintLcp(
       const ConstraintAccelProblemData<T>& problem_data,
       const VectorX<T>& trunc_neg_invA_a,
       VectorX<T>* cf) const;
@@ -581,11 +594,11 @@ class ConstraintSolver {
       int m,
       MatrixX<T>* iM_GT);
 
-  static void FormImpactingConstraintLCP(
+  static void FormImpactingConstraintLcp(
       const ConstraintVelProblemData<T>& problem_data,
       const VectorX<T>& invA_a,
       MatrixX<T>* MM, VectorX<T>* qq);
-  static void FormSustainedConstraintLCP(
+  static void FormSustainedConstraintLcp(
       const ConstraintAccelProblemData<T>& problem_data,
       const VectorX<T>& invA_a,
       MatrixX<T>* MM, VectorX<T>* qq);
@@ -859,7 +872,7 @@ void ConstraintSolver<T>::FormAndSolveConstraintLinearSystem(
       num_eq_constraints);
 
   // Using Equations (f) and (g) from the comments in
-  // FormAndSolveConstraintLCP() and defining C as the upper left block of A⁻¹,
+  // FormAndSolveConstraintLcp() and defining C as the upper left block of A⁻¹,
   // the linear system is defined as MM*z + qq = 0, where:
   //
   // MM ≡ | NC(Nᵀ-μQᵀ)  NCDᵀ   NCLᵀ |
@@ -893,7 +906,7 @@ void ConstraintSolver<T>::FormAndSolveConstraintLinearSystem(
 // required, however.
 // @sa FormAndSolveConstraintLinearSystem for descriptions of parameters.
 template <typename T>
-void ConstraintSolver<T>::FormAndSolveConstraintLCP(
+void ConstraintSolver<T>::FormAndSolveConstraintLcp(
     const ConstraintAccelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     VectorX<T>* cf) const {
@@ -997,7 +1010,7 @@ void ConstraintSolver<T>::FormAndSolveConstraintLCP(
   // Set up the pure linear complementarity problem.
   MatrixX<T> MM;
   VectorX<T> qq;
-  FormSustainedConstraintLCP(problem_data, trunc_neg_invA_a, &MM, &qq);
+  FormSustainedConstraintLcp(problem_data, trunc_neg_invA_a, &MM, &qq);
 
   // Get the zero tolerance for solving the LCP.
   const T zero_tol = lcp_.ComputeZeroTolerance(MM);
@@ -1144,7 +1157,7 @@ void ConstraintSolver<T>::SolveConstraintProblem(
 
   // Determine which problem formulation to use.
   if (problem_data.use_complementarity_problem_solver) {
-    FormAndSolveConstraintLCP(problem_data, trunc_neg_invA_a, cf);
+    FormAndSolveConstraintLcp(problem_data, trunc_neg_invA_a, cf);
   } else {
     FormAndSolveConstraintLinearSystem(problem_data, trunc_neg_invA_a, cf);
   }
@@ -1234,9 +1247,9 @@ void ConstraintSolver<T>::SolveImpactProblem(
   // Construct the operators required to "factor out" the bilateral constraints
   // through conversion of a mixed linear complementarity problem into a "pure"
   // linear complementarity problem. See
-  // ConstructLinearEquationSolversForMLCP() for more information.
+  // ConstructLinearEquationSolversForMlcp() for more information.
   MlcpToLcpData mlcp_to_lcp_data;
-  ConstructLinearEquationSolversForMLCP(problem_data, &mlcp_to_lcp_data);
+  ConstructLinearEquationSolversForMlcp(problem_data, &mlcp_to_lcp_data);
 
   // Copy the problem data and then update it to account for bilateral
   // constraints.
@@ -1258,7 +1271,7 @@ void ConstraintSolver<T>::SolveImpactProblem(
   // Construct the linear complementarity problem.
   MatrixX<T> MM;
   VectorX<T> qq;
-  FormImpactingConstraintLCP(problem_data, trunc_neg_invA_a, &MM, &qq);
+  FormImpactingConstraintLcp(problem_data, trunc_neg_invA_a, &MM, &qq);
 
   // Get the tolerance for zero used by the LCP solver.
   const T zero_tol = lcp_.ComputeZeroTolerance(MM);
@@ -1311,12 +1324,12 @@ void ConstraintSolver<T>::SolveImpactProblem(
   }
 
   // Construct the packed force vector.
-  PopulatePackedConstraintForcesFromLCPSolution(
+  PopulatePackedConstraintForcesFromLcpSolution(
       problem_data, mlcp_to_lcp_data, zz, a, cf);
 }
 
 template <typename T>
-void ConstraintSolver<T>::ConstructLinearEquationSolversForMLCP(
+void ConstraintSolver<T>::ConstructLinearEquationSolversForMlcp(
     const ConstraintVelProblemData<T>& problem_data,
     MlcpToLcpData* mlcp_to_lcp_data) {
   // --------------------------------------------------------------------------
@@ -1375,22 +1388,22 @@ void ConstraintSolver<T>::ConstructLinearEquationSolversForMLCP(
 // linear complementarity problem (LCP).
 // @param problem_data the constraint problem data.
 // @param a reference to a MlcpToLcpData object.
-// @param a the vector `a` output from UpdateDiscretizedTimeLCP().
+// @param a the vector `a` output from UpdateDiscretizedTimeLcp().
 // @param[out] cf the constraint forces, on return.
 // @pre cf is non-null.
 template <typename T>
-void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLCPSolution(
+void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
     const ConstraintVelProblemData<T>& problem_data,
     const MlcpToLcpData& mlcp_to_lcp_data,
     const VectorX<T>& zz,
     const VectorX<T>& a,
     VectorX<T>* cf) {
-  PopulatePackedConstraintForcesFromLCPSolution(
+  PopulatePackedConstraintForcesFromLcpSolution(
       problem_data, mlcp_to_lcp_data, zz, a, 1.0, cf);
 }
 
 template <typename T>
-void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLCPSolution(
+void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
     const ConstraintVelProblemData<T>& problem_data,
     const MlcpToLcpData& mlcp_to_lcp_data,
     const VectorX<T>& zz,
@@ -1406,12 +1419,12 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLCPSolution(
   cf->resize(num_contacts + num_spanning_vectors + num_limits +
       num_eq_constraints);
 
-  // Quit now if zz is empty.
+  // Quit early if zz is empty.
   if (zz.size() == 0) {
     cf->setZero();
     if (num_eq_constraints > 0) {
-      VectorX<T> aug = a;
-      const VectorX<T> u = -mlcp_to_lcp_data.A_solve(aug);
+      const VectorX<T> u = -mlcp_to_lcp_data.A_solve(a);
+      // Get lambda subvector (as specified in 
       auto lambda = cf->segment(num_contacts +
           num_spanning_vectors + num_limits, num_eq_constraints);
 
@@ -1478,7 +1491,7 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLCPSolution(
 }
 
 template <typename T>
-void ConstraintSolver<T>::UpdateDiscretizedTimeLCP(
+void ConstraintSolver<T>::UpdateDiscretizedTimeLcp(
     const ConstraintVelProblemData<T>& problem_data,
     double dt,
     MlcpToLcpData* mlcp_to_lcp_data,
@@ -1495,7 +1508,7 @@ void ConstraintSolver<T>::UpdateDiscretizedTimeLCP(
 
   // Recompute the linear equation solvers, if necessary.
   if (problem_data.kG.size() > 0) {
-    ConstructLinearEquationSolversForMLCP(
+    ConstructLinearEquationSolversForMlcp(
         problem_data, mlcp_to_lcp_data);
   }
 
@@ -1572,7 +1585,7 @@ void ConstraintSolver<T>::UpdateDiscretizedTimeLCP(
 }
 
 template <typename T>
-void ConstraintSolver<T>::ConstructBaseDiscretizedTimeLCP(
+void ConstraintSolver<T>::ConstructBaseDiscretizedTimeLcp(
     const ConstraintVelProblemData<T>& problem_data,
     MlcpToLcpData* mlcp_to_lcp_data,
     MatrixX<T>* MM,
@@ -1618,7 +1631,7 @@ void ConstraintSolver<T>::ConstructBaseDiscretizedTimeLCP(
   // solve the mixed linear complementarity problem by first solving a "pure"
   // linear complementarity problem. See @ref Velocity-level-MLCPs in
   // Doxygen documentation (above).
-  ConstructLinearEquationSolversForMLCP(problem_data, mlcp_to_lcp_data);
+  ConstructLinearEquationSolversForMlcp(problem_data, mlcp_to_lcp_data);
 
   // Allocate storage for a.
   VectorX<T> a(problem_data.Mv.size() + num_eq_constraints);
@@ -1631,7 +1644,7 @@ void ConstraintSolver<T>::ConstructBaseDiscretizedTimeLCP(
   const VectorX<T> trunc_neg_invA_a = -invA_a.head(Mv.size());
 
   // Set up the linear complementarity problem.
-  FormImpactingConstraintLCP(problem_data, trunc_neg_invA_a, MM, qq);
+  FormImpactingConstraintLcp(problem_data, trunc_neg_invA_a, MM, qq);
 }
 
 template <class T>
@@ -1815,7 +1828,7 @@ void ConstraintSolver<T>::FormSustainedConstraintLinearSystem(
 // forces (and can also be used to determine the active set of constraints at
 // the acceleration-level).
 template <class T>
-void ConstraintSolver<T>::FormSustainedConstraintLCP(
+void ConstraintSolver<T>::FormSustainedConstraintLcp(
     const ConstraintAccelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     MatrixX<T>* MM, VectorX<T>* qq) {
@@ -2009,19 +2022,20 @@ void ConstraintSolver<T>::CheckVelConstraintMatrix(
   const double zero_tol = std::numeric_limits<double>::epsilon() * MM.norm() *
       MM.rows();
 
-  // Check that the blocks are nearly equal.
-  if (nr > 0 && num_contacts > 0)
-    DRAKE_ASSERT((F_iM_NT - F_iM_NT_true).norm() < zero_tol);
-  if (num_contacts > 0 && nl > 0)
-    DRAKE_ASSERT((L_iM_NT - L_iM_NT_true).norm() < zero_tol);
-  if (nr > 0 && nl > 0)
-    DRAKE_ASSERT((L_iM_FT - L_iM_FT_true).norm() < zero_tol);
+  // Check that the blocks are nearly equal. Note: these tests are necessary
+  // because Eigen does not correctly compute the norm of an empty matrix.
+  DRAKE_ASSERT(F_iM_NT.rows() == 0 || F_iM_NT.cols() == 0 ||
+      (F_iM_NT - F_iM_NT_true).norm() < zero_tol);
+  DRAKE_ASSERT(L_iM_NT.rows() == 0 || L_iM_NT.cols() == 0 ||
+      (L_iM_NT - L_iM_NT_true).norm() < zero_tol);
+  DRAKE_ASSERT(L_iM_FT.rows() == 0 || L_iM_FT.cols() == 0 ||
+      (L_iM_FT - L_iM_FT_true).norm() < zero_tol);
 }
 
 // Forms the LCP matrix and vector, which is used to determine the collisional
 // impulses.
 template <class T>
-void ConstraintSolver<T>::FormImpactingConstraintLCP(
+void ConstraintSolver<T>::FormImpactingConstraintLcp(
     const ConstraintVelProblemData<T>& problem_data,
     const VectorX<T>& trunc_neg_invA_a,
     MatrixX<T>* MM, VectorX<T>* qq) {

--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -372,7 +372,7 @@ class ConstraintSolver {
   ///        constraints. This packed storage format can be turned into more
   ///        useful representations through
   ///        ComputeGeneralizedForceFromConstraintForces() and
-  ///        CalcContactForcesInContactFrames(). 
+  ///        CalcContactForcesInContactFrames().
   /// @pre cf is non-null.
   static void PopulatePackedConstraintForcesFromLcpSolution(
       const ConstraintVelProblemData<T>& problem_data,
@@ -1424,7 +1424,6 @@ void ConstraintSolver<T>::PopulatePackedConstraintForcesFromLcpSolution(
     cf->setZero();
     if (num_eq_constraints > 0) {
       const VectorX<T> u = -mlcp_to_lcp_data.A_solve(a);
-      // Get lambda subvector (as specified in 
       auto lambda = cf->segment(num_contacts +
           num_spanning_vectors + num_limits, num_eq_constraints);
 

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -290,9 +290,9 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
     VectorX<double> qq, a;
     MatrixX<double> MM;
     ConstraintSolver<double>::MlcpToLcpData mlcp_to_lcp_data;
-    solver_.ConstructBaseDiscretizedTimeLCP(
+    solver_.ConstructBaseDiscretizedTimeLcp(
         problem_data, &mlcp_to_lcp_data, &MM, &qq);
-    solver_.UpdateDiscretizedTimeLCP(
+    solver_.UpdateDiscretizedTimeLcp(
         problem_data, dt, &mlcp_to_lcp_data, &a, &MM, &qq);
 
     // Determine the zero tolerance.
@@ -2058,9 +2058,9 @@ TEST_P(Constraint2DSolverTest, TwoPointImpactAsLimit) {
 TEST_P(Constraint2DSolverTest, BilateralOnly) {
   // Set the rod to a ballistic state.
   ContinuousState<double>& xc = context_->get_mutable_continuous_state();
-  xc[0] = 0.0;     // com horizontal position
-  xc[1] = 10.0;     // com vertical position
-  xc[2] = 0.0;     // rod rotation
+  xc[0] = 0.0;     // com horizontal position.
+  xc[1] = 10.0;    // com vertical position.
+  xc[2] = 0.0;     // rod rotation.
   xc[3] = 0.0;     // no horizontal velocity.
   xc[4] = 0.0;     // upward velocity.
   xc[5] = 0.0;     // no angular velocity.
@@ -2074,21 +2074,19 @@ TEST_P(Constraint2DSolverTest, BilateralOnly) {
   // Add in bilateral constraints on rotational motion.
   vel_data_->G_mult = [](const VectorX<double>& w) -> VectorX<double> {
     VectorX<double> result(1);   // Only one constraint.
-
-    // Constrain the angular velocity to be zero.
-    result[0] = w[2];
+    result[0] = w[2];            // Constrain the angular velocity to be zero.
     return result;
   };
   vel_data_->G_transpose_mult =
       [this](const VectorX<double>& f) -> VectorX<double> {
-        // An impulsive force (torque) applied to the third component needs no
-        // transformation.
-        DRAKE_DEMAND(f.size() == 1);
-        VectorX<double> result(get_rod_num_coordinates());
-        result.setZero();
-        result[2] = f[0];
-        return result;
-      };
+    // An impulsive force (torque) applied to the third component needs no
+    // transformation.
+    DRAKE_DEMAND(f.size() == 1);
+    VectorX<double> result(get_rod_num_coordinates());
+    result.setZero();
+    result[2] = f[0];
+    return result;
+  };
 
   // Indicate through construction of the kG term that the system already has
   // angular orientation (which violates our desire to keep the rod at

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -316,7 +316,7 @@ class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
                            std::max(1.0, ww.maxCoeff()) * num_vars * zero_tol);
 
     // Compute the packed constraint forces.
-    solver_.PopulatePackedConstraintForcesFromLCPSolution(
+    solver_.PopulatePackedConstraintForcesFromLcpSolution(
         problem_data, mlcp_to_lcp_data, zz, a, dt, cf);
   }
 


### PR DESCRIPTION
constrained systems.

A short-circuit employed to keep from building the complementarity problem if not required caused the bilateral constraint forces to not be computed. This PR fixes that and adds a unit test which will detect the condition if reverted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9054)
<!-- Reviewable:end -->
