### PR TITLE
Fixes bug when the state is discrete

### DIFF
--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -49,6 +49,10 @@ DEFINE_double(target_realtime_rate, 1.0,
 DEFINE_double(simulation_time, 10.0,
               "Desired duration of the simulation in seconds.");
 
+DEFINE_bool(time_stepping, true, "If 'true', the plant is modeled as a "
+    "discrete system with periodic updates. "
+    "If 'false', the plant is modeled as a continuous system.");
+
 // This helper method makes an LQR controller to balance an acrobot model
 // specified in the SDF file `file_name`.
 std::unique_ptr<systems::AffineSystem<double>> MakeBalancingLQRController(
@@ -101,11 +105,15 @@ int do_main() {
 
   const double simulation_time = FLAGS_simulation_time;
 
+  const double time_step = FLAGS_time_stepping ? 1.0e-3 : 0.0;
+
   // Make and add the acrobot model.
   const std::string relative_name =
       "drake/multibody/benchmarks/acrobot/acrobot.sdf";
   const std::string full_name = FindResourceOrThrow(relative_name);
-  MultibodyPlant<double>& acrobot = *builder.AddSystem<MultibodyPlant>();
+  MultibodyPlant<double>& acrobot =
+      *builder.AddSystem<MultibodyPlant>(time_step);
+
   AddModelFromSdfFile(full_name, &acrobot, &scene_graph);
 
   // Add gravity to the model.

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -1023,10 +1023,21 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
 }
 
 template <typename T>
+const systems::BasicVector<T>& MultibodyPlant<T>::GetStateVector(
+    const Context<T>& context) const {
+  if (is_discrete()) {
+    return context.get_discrete_state(0);
+  } else {
+    return dynamic_cast<const systems::BasicVector<T>&>(
+        context.get_continuous_state_vector());
+  }
+}
+
+template <typename T>
 void MultibodyPlant<T>::CopyContinuousStateOut(
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-  state_vector->SetFrom(context.get_continuous_state_vector());
+  state_vector->SetFrom(GetStateVector(context));
 }
 
 template <typename T>
@@ -1035,8 +1046,8 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
     const Context<T>& context, BasicVector<T>* state_vector) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
 
-  const VectorX<T> continuous_state_vector =
-      context.get_continuous_state_vector().CopyToVector();
+  VectorX<T> continuous_state_vector =
+      GetStateVector(context).CopyToVector();
 
   VectorX<T> instance_state_vector(model_->num_states(model_instance));
   instance_state_vector.head(num_positions(model_instance)) =

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1238,6 +1238,10 @@ class MultibodyPlant : public systems::LeafSystem<T> {
         body_index_to_frame_id_.end();
   }
 
+  // Helper to retrieve a constant reference to the state vector from context.
+  const systems::BasicVector<T>& GetStateVector(
+      const systems::Context<T>& context) const;
+
   // Calc method for the continuous state vector output port.
   void CopyContinuousStateOut(
       const systems::Context<T>& context, systems::BasicVector<T>* state) const;


### PR DESCRIPTION
When the plant is modeled as a discrete system we were still retrieving the continuous state vector. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9058)
<!-- Reviewable:end -->
