### PR TITLE
Complete construction of context including dependency graph

### DIFF
--- a/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
+++ b/examples/kuka_iiwa_arm/test/iiwa_lcm_test.cc
@@ -60,7 +60,7 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
       dut.AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
   dut.CalcDiscreteVariableUpdates(*context, update.get());
-  context->set_discrete_state(std::move(update));
+  context->get_mutable_discrete_state().SetFrom(*update);
 
   dut.CalcOutput(*context, output.get());
   EXPECT_TRUE(CompareMatrices(
@@ -88,7 +88,7 @@ GTEST_TEST(IiwaLcmTest, IiwaCommandReceiverTest) {
       0, std::make_unique<systems::Value<lcmt_iiwa_command>>(command));
   update = dut.AllocateDiscreteVariables();
   dut.CalcDiscreteVariableUpdates(*context, update.get());
-  context->set_discrete_state(std::move(update));
+  context->get_mutable_discrete_state().SetFrom(*update);
   dut.CalcOutput(*context, output.get());
 
   EXPECT_TRUE(CompareMatrices(
@@ -162,7 +162,7 @@ GTEST_TEST(IiwaLcmTest, IiwaStatusReceiverTest) {
       dut.AllocateDiscreteVariables();
   update->SetFrom(context->get_mutable_discrete_state());
   dut.CalcDiscreteVariableUpdates(*context, update.get());
-  context->set_discrete_state(std::move(update));
+  context->get_mutable_discrete_state().SetFrom(*update);
 
   dut.CalcOutput(*context, output.get());
   const auto measured = output->get_vector_data(

--- a/multibody/multibody_tree/multibody_tree_context.h
+++ b/multibody/multibody_tree/multibody_tree_context.h
@@ -82,11 +82,11 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
       auto xc = std::make_unique<ContinuousState<T>>(
           std::make_unique<BasicVector<T>>(num_states),
           num_positions, num_velocities, 0);
-      this->set_continuous_state(std::move(xc));
+      this->init_continuous_state(std::move(xc));
     } else {
       auto xd = std::make_unique<DiscreteValues<T>>(
           std::make_unique<BasicVector<T>>(num_states));
-      this->set_discrete_state(std::move(xd));
+      this->init_discrete_state(std::move(xd));
     }
 
     // TODO(amcastro-tri): Create cache entries.

--- a/systems/framework/cache.h
+++ b/systems/framework/cache.h
@@ -609,14 +609,17 @@ class Cache {
   dependency notifications are issued. */
   ~Cache() = default;
 
-  /** Allocates a new CacheEntryValue and corresponding DependencyTracker using
-  the given CacheIndex and DependencyTicket number. The CacheEntryValue
-  object is owned by this Cache and the returned reference remains valid
-  if other cache entry values are created. The created DependencyTracker
-  object is owned by the given DependencyGraph, which must be owned by
-  the same Context that owns this Cache. The graph must already contain
-  trackers for the indicated prerequisites. The new tracker will retain a
-  pointer to the created CacheEntryValue for invalidation purposes. */
+  /** Allocates a new CacheEntryValue and provides it a DependencyTracker using
+  the given CacheIndex and DependencyTicket number. The CacheEntryValue object
+  is owned by this Cache and the returned reference remains valid if other cache
+  entry values are created. If there is a pre-existing tracker with the given
+  ticket number (allowed only for well-known cached computations, such as time
+  derivatives), it is assigned the new cache entry value to manage. Otherwise a
+  new DependencyTracker is created. The created tracker object is owned by the
+  given DependencyGraph, which must be owned by the same Context that owns this
+  Cache. The graph must already contain trackers for the indicated
+  prerequisites. The tracker will retain a pointer to the created
+  CacheEntryValue for invalidation purposes. */
   CacheEntryValue& CreateNewCacheEntryValue(
       CacheIndex index, DependencyTicket ticket,
       const std::string& description,

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -111,11 +111,6 @@ class Context : public ContextBase {
     return count;
   }
 
-  /// Sets the continuous state to @p xc, deleting whatever was there before.
-  void set_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
-    get_mutable_state().set_continuous_state(std::move(xc));
-  }
-
   /// Returns a mutable reference to the continuous component of the state,
   /// which may be of size zero.
   ContinuousState<T>& get_mutable_continuous_state() {
@@ -179,11 +174,6 @@ class Context : public ContextBase {
     return xd.get_mutable_vector(index);
   }
 
-  /// Sets the discrete state to @p xd, deleting whatever was there before.
-  void set_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
-    get_mutable_state().set_discrete_state(std::move(xd));
-  }
-
   /// Returns a const reference to group (vector) @p index of the discrete
   /// state.
   /// @pre @p index must identify an existing group.
@@ -215,11 +205,6 @@ class Context : public ContextBase {
   U& get_mutable_abstract_state(int index) {
     AbstractValues& xa = get_mutable_abstract_state();
     return xa.get_mutable_value(index).GetMutableValue<U>();
-  }
-
-  /// Sets the abstract state to @p xa, deleting whatever was there before.
-  void set_abstract_state(std::unique_ptr<AbstractValues> xa) {
-    get_mutable_state().set_abstract_state(std::move(xa));
   }
 
   /// Returns a const reference to the abstract component of the
@@ -406,8 +391,31 @@ class Context : public ContextBase {
   /// Returns a const reference to current time and step information.
   const StepInfo<T>& get_step_info() const { return step_info_; }
 
-  /// Provides storage for declared parameters, deleting whatever was there
-  /// before. You must supply a Parameters object; null is not acceptable.
+  /// Sets the continuous state to @p xc, deleting whatever was there before.
+  /// Invalidates all continuous state-dependent computations in this context
+  /// and its subcontexts.
+  void init_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
+    get_mutable_state().set_continuous_state(std::move(xc));
+  }
+
+  /// Sets the discrete state to @p xd, deleting whatever was there before.
+  /// Invalidates all discrete state-dependent computations in this context and
+  /// its subcontexts.
+  void init_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
+    get_mutable_state().set_discrete_state(std::move(xd));
+  }
+
+  /// Sets the abstract state to @p xa, deleting whatever was there before.
+  /// Invalidates all abstract state-dependent computations in this context and
+  /// its subcontexts.
+  void init_abstract_state(std::unique_ptr<AbstractValues> xa) {
+    get_mutable_state().set_abstract_state(std::move(xa));
+  }
+
+  /// Sets the parameters to @p params, deleting whatever was there before.
+  /// You must supply a Parameters object; null is not acceptable. Invalidates
+  /// all parameter-dependent computations recursively in this context and
+  /// its subcontexts.
   void init_parameters(std::unique_ptr<Parameters<T>> params) {
     DRAKE_DEMAND(params != nullptr);
     parameters_ = std::move(params);

--- a/systems/framework/dependency_tracker.cc
+++ b/systems/framework/dependency_tracker.cc
@@ -219,9 +219,9 @@ void DependencyTracker::RepairTrackerPointers(
   owning_subcontext_ = owning_subcontext;
 
   // Set the cache entry pointer.
-  if (source.cache_value_ == &CacheEntryValue::dummy()) {
-    cache_value_ = &CacheEntryValue::dummy();
-  } else {
+  DRAKE_DEMAND(has_associated_cache_entry_ ==
+               source.has_associated_cache_entry_);
+  if (has_associated_cache_entry_) {
     const CacheIndex source_index(source.cache_value_->cache_index());
     cache_value_ = &cache->get_mutable_cache_entry_value(source_index);
     DRAKE_SPDLOG_DEBUG(log(),

--- a/systems/framework/dependency_tracker.h
+++ b/systems/framework/dependency_tracker.h
@@ -150,6 +150,31 @@ class DependencyTracker {
   DependencyGraph. The ticket is unique within the containing subcontext. */
   DependencyTicket ticket() const { return ticket_; }
 
+  /** (Internal use only) Sets the cache entry value to be marked out-of-date
+  when this tracker's prerequisites change.
+  @pre The supplied cache entry value is non-null.
+  @pre No cache entry value has previously been assigned. */
+  // This is intended for use in connecting pre-defined trackers to cache
+  // entry values that are created later. See the private constructor
+  // documentation for more information.
+  void set_cache_entry_value(CacheEntryValue* cache_value) {
+    DRAKE_DEMAND(cache_value != nullptr);
+    DRAKE_DEMAND(!has_associated_cache_entry_);
+    cache_value_ = cache_value;
+    has_associated_cache_entry_ = true;
+  }
+
+  /** (Internal use only) Returns a pointer to the CacheEntryValue if this
+  tracker is a cache entry tracker, otherwise nullptr. */
+  // This is for validating that this tracker is associated with the right
+  // cache entry. Don't use this during runtime invalidation.
+  const CacheEntryValue* cache_entry_value() const {
+    DRAKE_DEMAND(cache_value_);
+    if (!has_associated_cache_entry_)
+      return nullptr;  // cache_value_ actually points to a dummy entry.
+    return cache_value_;
+  }
+
   /** Notifies `this` %DependencyTracker that its managed value was directly
   modified or made available for mutable access. That is, this is the
   _initiating_ event of a value modification. All of our downstream
@@ -297,13 +322,15 @@ class DependencyTracker {
       : ticket_(ticket),
         description_(std::move(description)),
         owning_subcontext_(owning_subcontext),
+        has_associated_cache_entry_(cache_value != nullptr),
         cache_value_(cache_value ? cache_value : &CacheEntryValue::dummy()) {
     DRAKE_SPDLOG_DEBUG(
         log(), "Tracker #{} '{}' constructed {} invalidation {:#x}{}.", ticket_,
-        description_, cache_value ? "with" : "without", size_t(cache_value),
-        cache_value
-        ? " cache entry " + std::to_string(cache_value->cache_index())
-        : "");
+        description_, has_associated_cache_entry_ ? "with" : "without",
+        size_t(cache_value),
+        has_associated_cache_entry_
+            ? " cache entry " + std::to_string(cache_value->cache_index())
+            : "");
   }
 
   // Copies the current tracker but with all pointers set to null, and all
@@ -313,9 +340,11 @@ class DependencyTracker {
     // Can't use make_unique here because constructor is private.
     std::unique_ptr<DependencyTracker> clone(
         new DependencyTracker(ticket(), description(), nullptr, nullptr));
-    // cache_value_ is set to dummy by default; must reset to null now so we
-    // can fix it up later.
-    clone->cache_value_ = nullptr;
+    clone->has_associated_cache_entry_ = has_associated_cache_entry_;
+    // The constructor sets cache_value_ to dummy by default, but that's wrong
+    // if there is an associated cache entry. In that case we'll set it later.
+    if (has_associated_cache_entry_)
+      clone->cache_value_ = nullptr;
     clone->subscribers_.resize(num_subscribers(), nullptr);
     clone->prerequisites_.resize(num_prerequisites(), nullptr);
     return clone;
@@ -367,7 +396,9 @@ class DependencyTracker {
   // Pointer to the system name service of the owning subcontext.
   const internal::ContextMessageInterface* owning_subcontext_{nullptr};
 
-  // Points to CacheEntryValue::dummy() if we're not told otherwise.
+  // If false, cache_value_ will be set to point to CacheEntryValue::dummy() so
+  // we don't need to check during invalidation sweeps.
+  bool has_associated_cache_entry_{false};
   CacheEntryValue* cache_value_{nullptr};
 
   std::vector<const DependencyTracker*> subscribers_;

--- a/systems/framework/fixed_input_port_value.h
+++ b/systems/framework/fixed_input_port_value.h
@@ -41,13 +41,8 @@ class FixedInputPortValue {
   FixedInputPortValue& operator=(FixedInputPortValue&&) = delete;
   /** @} */
 
-  /** Constructs an abstract-valued %FixedInputPortValue from a value
-  of arbitrary type. Takes ownership of the given value and sets the serial
-  number to 1. The value must not be null. */
-  explicit FixedInputPortValue(std::unique_ptr<AbstractValue> value)
-      : value_(std::move(value)), serial_number_{1} {
-    DRAKE_DEMAND(value_ != nullptr);
-  }
+  // Construction is private and only accessible to ContextBase via the
+  // attorney.
 
   ~FixedInputPortValue() = default;
 
@@ -96,6 +91,12 @@ class FixedInputPortValue {
   time the contained value changes, or when mutable access is granted. */
   int64_t serial_number() const { return serial_number_; }
 
+  /** Returns the ticket used to find the associated DependencyTracker. */
+  DependencyTicket ticket() const {
+    DRAKE_ASSERT(ticket_.is_valid());
+    return ticket_;
+  }
+
   /** Returns a const reference to the context that owns this object. */
   const ContextBase& get_owning_context() const {
     DRAKE_ASSERT(owning_subcontext_ != nullptr);
@@ -109,12 +110,26 @@ class FixedInputPortValue {
   // only for use by ContextBase.
   friend class copyable_unique_ptr<FixedInputPortValue>;
 
+  // Constructs an abstract-valued FixedInputPortValue from a value
+  // of arbitrary type. Takes ownership of the given value and sets the serial
+  // number to 1. The value must not be null.
+  explicit FixedInputPortValue(std::unique_ptr<AbstractValue> value)
+      : value_(std::move(value)), serial_number_{1} {
+    DRAKE_DEMAND(value_ != nullptr);
+  }
+
   // Copy constructor is only used for cloning and is not a complete copy --
   // owning_subcontext_ is left unassigned.
-  FixedInputPortValue(const FixedInputPortValue& source) =
-      default;
+  FixedInputPortValue(const FixedInputPortValue& source) = default;
 
-  // Informs this FixedInputPortValue of the subcontext that owns it.
+  // Informs this FixedInputPortValue of its assigned DependencyTracker
+  // so it knows who to notify when its value changes.
+  void set_ticket(DependencyTicket ticket) {
+    DRAKE_DEMAND(ticket.is_valid() && !ticket_.is_valid());
+    ticket_ = ticket;
+  }
+
+  // Informs this %FixedInputPortValue of the subcontext that owns it.
   // Aborts if this has already been done or given bad args.
   void set_owning_subcontext(ContextBase* owning_subcontext) {
     DRAKE_DEMAND(owning_subcontext != nullptr && owning_subcontext_ == nullptr);
@@ -134,6 +149,10 @@ class FixedInputPortValue {
   // recorded the number somewhere. If the serial number matches, the value
   // is either unchanged since you last saw it, or an identical copy.
   int64_t serial_number_{-1};
+
+  // Index of the dependency tracker for this fixed value. The input port
+  // should have registered with this tracker.
+  DependencyTicket ticket_;
 };
 
 // TODO(sherm1) Get rid of this after 8/7/2018 (three months).
@@ -154,8 +173,24 @@ class ContextBaseFixedInputAttorney {
   // "Output" argument is first here since it is serving as a `this` pointer.
   static void set_owning_subcontext(FixedInputPortValue* fixed,
                                     ContextBase* owning_subcontext) {
-    DRAKE_DEMAND(owning_subcontext != nullptr && fixed != nullptr);
+    DRAKE_DEMAND(fixed != nullptr);
     fixed->set_owning_subcontext(owning_subcontext);
+  }
+
+  static void set_ticket(FixedInputPortValue* fixed,
+                         DependencyTicket ticket) {
+    DRAKE_DEMAND(fixed != nullptr);
+    fixed->set_ticket(ticket);
+  }
+
+  // This serves as the only accessible constructor for FixedInputPortValues.
+  // It must be followed immediately by inserting into a Context with the
+  // assigned ticket and the owning subcontext set using the above methods.
+  static std::unique_ptr<FixedInputPortValue> CreateFixedInputPortValue(
+      std::unique_ptr<AbstractValue> value) {
+    // Can't use make_unique here since constructor is private.
+    return std::unique_ptr<FixedInputPortValue>(
+        new FixedInputPortValue(std::move(value)));
   }
 };
 

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -47,13 +47,15 @@ class LeafContext : public Context<T> {
   }
 
 #ifndef DRAKE_DOXYGEN_CXX
-  // Temporarily promoting this to public so that LeafSystem and testing
-  // code can construct a LeafContext with parameters. Users should never
-  // call this because parameters should not be resized once allocated (or at
-  // least should be done under Framework control so that dependency tracking
-  // can be correctly revised).
-  // TODO(sherm1) Make this inaccessible to users, along with other dangerous
-  // context resource sizing methods. See discussion in PR #9029.
+  // Temporarily promoting these to public so that LeafSystem and testing code
+  // can construct a LeafContext with state & parameters. Users should never
+  // call these because state & parameters should not be resized once allocated
+  // (or at least should be done under Framework control so that dependency
+  // tracking can be correctly revised).
+  // TODO(sherm1) Make these inaccessible to users. See discussion in PR #9029.
+  using Context<T>::init_continuous_state;
+  using Context<T>::init_discrete_state;
+  using Context<T>::init_abstract_state;
   using Context<T>::init_parameters;
 #endif
 
@@ -95,6 +97,10 @@ class LeafContext : public Context<T> {
   }
 
  private:
+  friend class LeafContextTest;
+  using ContextBase::AddInputPort;    // For LeafContextTest.
+  using ContextBase::AddOutputPort;
+
   // The state values (x) for this LeafContext; this is never null.
   std::unique_ptr<State<T>> state_;
 };

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -561,7 +561,7 @@ class LeafSystem : public System<T> {
   /// re-declared as inequality constraints on this system (see
   /// DeclareInequalityConstraint()).  Returns the index of the new parameter.
   int DeclareNumericParameter(const BasicVector<T>& model_vector) {
-    const int index = model_numeric_parameters_.size();
+    const NumericParameterIndex index(model_numeric_parameters_.size());
     model_numeric_parameters_.AddVectorModel(index, model_vector.Clone());
     MaybeDeclareVectorBaseInequalityConstraint(
         "parameter " + std::to_string(index), model_vector,
@@ -569,6 +569,7 @@ class LeafSystem : public System<T> {
           const BasicVector<T>& result = context.get_numeric_parameter(index);
           return result;
         });
+    this->AddNumericParameter(index);
     return index;
   }
 
@@ -608,8 +609,9 @@ class LeafSystem : public System<T> {
   /// the default implementation of SetDefaultParameters() will reset parameters
   /// to their model values.  Returns the index of the new parameter.
   int DeclareAbstractParameter(const AbstractValue& model_value) {
-    const int index = model_abstract_parameters_.size();
+    const AbstractParameterIndex index(model_abstract_parameters_.size());
     model_abstract_parameters_.AddModel(index, model_value.Clone());
+    this->AddAbstractParameter(index);
     return index;
   }
 
@@ -774,17 +776,22 @@ class LeafSystem : public System<T> {
   /// Declares that this System should reserve discrete state with
   /// @p num_state_variables state variables. Has no effect if
   /// AllocateDiscreteState is overridden.
+  // TODO(sherm1) Repeated calls to this should allocate additional discrete
+  // state groups. Currently there is only one.
   void DeclareDiscreteState(int num_state_variables) {
+    const DiscreteStateIndex index(0);  // Only one implemented currently.
     model_discrete_state_vector_ =
         std::make_unique<BasicVector<T>>(num_state_variables);
+    this->AddDiscreteStateGroup(index);
   }
 
   /// Declares an abstract state.
   /// @param abstract_state The abstract state, its ownership is transferred.
   /// @return index of the declared abstract state.
   int DeclareAbstractState(std::unique_ptr<AbstractValue> abstract_state) {
-    int index = model_abstract_states_.size();
+    const AbstractStateIndex index(model_abstract_states_.size());
     model_abstract_states_.AddModel(index, std::move(abstract_state));
+    this->AddAbstractState(index);
     return index;
   }
 

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -30,23 +30,36 @@ const CacheEntry& SystemBase::DeclareCacheEntry(
     std::string description, CacheEntry::AllocCallback alloc_function,
     CacheEntry::CalcCallback calc_function,
     std::set<DependencyTicket> prerequisites_of_calc) {
+  return DeclareCacheEntryWithKnownTicket(
+      assign_next_dependency_ticket(), std::move(description),
+      std::move(alloc_function), std::move(calc_function),
+      std::move(prerequisites_of_calc));
+}
+
+const CacheEntry& SystemBase::DeclareCacheEntryWithKnownTicket(
+    DependencyTicket known_ticket, std::string description,
+    CacheEntry::AllocCallback alloc_function,
+    CacheEntry::CalcCallback calc_function,
+    std::set<DependencyTicket> prerequisites_of_calc) {
   // If the prerequisite list is empty the CacheEntry constructor will throw
   // a logic error.
   const CacheIndex index(num_cache_entries());
-  const DependencyTicket ticket(assign_next_dependency_ticket());
   cache_entries_.emplace_back(std::make_unique<CacheEntry>(
-      this, index, ticket, std::move(description), std::move(alloc_function),
-      std::move(calc_function), std::move(prerequisites_of_calc)));
+      this, index, known_ticket, std::move(description),
+      std::move(alloc_function), std::move(calc_function),
+      std::move(prerequisites_of_calc)));
   const CacheEntry& new_entry = *cache_entries_.back();
   return new_entry;
 }
 
-std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
-  // Derived class creates the concrete Context object, which already contains
-  // all the well-known trackers (the ones with fixed tickets).
-  std::unique_ptr<ContextBase> context_ptr = DoMakeContext();
+void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
   DRAKE_DEMAND(context_ptr != nullptr);
   ContextBase& context = *context_ptr;
+
+  // Initialization should happen only once per Context.
+  DRAKE_DEMAND(
+      !detail::SystemBaseContextBaseAttorney::is_context_base_initialized(
+          context));
 
   detail::SystemBaseContextBaseAttorney::set_system_name(&context, get_name());
 
@@ -78,11 +91,13 @@ std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
   // an exported output port in the parent Diagram. The associated cache entries
   // were just created above. Any intra-system prerequisites are set up now.
   for (const auto& oport : output_ports_) {
-    context.AddOutputPort(oport->get_index(), oport->ticket(),
-                          oport->GetPrerequisite());
+    detail::SystemBaseContextBaseAttorney::AddOutputPort(
+        &context, oport->get_index(), oport->ticket(),
+        oport->GetPrerequisite());
   }
 
-  return context_ptr;
+  detail::SystemBaseContextBaseAttorney::mark_context_base_initialized(
+      &context);
 }
 
 // Set up trackers for variable-numbered independent sources: discrete and
@@ -92,13 +107,53 @@ std::unique_ptr<ContextBase> SystemBase::MakeContext() const {
 // elements now.
 void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
   ContextBase& context = *context_ptr;
+  DependencyGraph& graph = context.get_mutable_dependency_graph();
 
-  // TODO(sherm1) Add state and parameter trackers here.
+  // Define a lambda to do the repeated work below: create trackers for
+  // individual entities and subscribe the group tracker to each of them.
+  auto MakeTrackers = [&graph](
+      DependencyTicket subscriber_ticket,
+      const std::vector<TrackerInfo>& system_ticket_info,
+      std::vector<DependencyTicket>* context_tickets) {
+    DependencyTracker& subscriber =
+        graph.get_mutable_tracker(subscriber_ticket);
+    DRAKE_DEMAND(context_tickets->empty());
+    for (const auto& info : system_ticket_info) {
+      auto& source_tracker =
+          graph.CreateNewDependencyTracker(info.ticket, info.description);
+      context_tickets->push_back(info.ticket);
+      subscriber.SubscribeToPrerequisite(&source_tracker);
+    }
+  };
 
-  // Allocate trackers for each input port uᵢ. Note that this also takes care of
-  // subscribing the "all input ports" tracker u to them.
+  // Allocate trackers for each discrete variable group xdᵢ, and subscribe
+  // the "all discrete variables" tracker xd to those.
+  MakeTrackers(
+      xd_ticket(), discrete_state_tickets_,
+      &detail::SystemBaseContextBaseAttorney::discrete_state_tickets(&context));
+
+  // Allocate trackers for each abstract state variable xaᵢ, and subscribe
+  // the "all abstract variables" tracker xa to those.
+  MakeTrackers(
+      xa_ticket(), abstract_state_tickets_,
+      &detail::SystemBaseContextBaseAttorney::abstract_state_tickets(&context));
+
+  // Allocate trackers for each numeric parameter pnᵢ and each abstract
+  // parameter paᵢ, and subscribe the "all parameters" tracker p to those.
+  MakeTrackers(
+      all_parameters_ticket(), numeric_parameter_tickets_,
+      &detail::SystemBaseContextBaseAttorney::numeric_parameter_tickets(
+          &context));
+  MakeTrackers(
+      all_parameters_ticket(), abstract_parameter_tickets_,
+      &detail::SystemBaseContextBaseAttorney::abstract_parameter_tickets(
+          &context));
+
+  // Allocate trackers for each input port uᵢ, and subscribe the "all input
+  // ports" tracker u to them. Doesn't use TrackerInfo so can't use the lambda.
   for (const auto& iport : input_ports_) {
-    context.AddInputPort(iport->get_index(), iport->ticket());
+    detail::SystemBaseContextBaseAttorney::AddInputPort(
+        &context, iport->get_index(), iport->ticket());
   }
 }
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -608,6 +608,28 @@ class SystemBase : public internal::SystemMessageInterface {
     return cache_entries_[index]->ticket();
   }
 
+  /** Returns the number of declared discrete state groups (each group is
+  a vector-valued discrete state variable). */
+  int num_discrete_state_groups() const {
+    return static_cast<int>(discrete_state_tickets_.size());
+  }
+
+  /** Returns the number of declared abstract state variables. */
+  int num_abstract_states() const {
+    return static_cast<int>(abstract_state_tickets_.size());
+  }
+
+  /** Returns the number of declared numeric parameters (each of these is
+  a vector-valued parameter). */
+  int num_numeric_parameters() const {
+    return static_cast<int>(numeric_parameter_tickets_.size());
+  }
+
+  /** Returns the number of declared abstract parameters. */
+  int num_abstract_parameters() const {
+    return static_cast<int>(abstract_parameter_tickets_.size());
+  }
+
   /** Returns a ticket indicating dependence on a particular discrete state
   variable (may be a vector). (We sometimes refer to this as a "discrete
   variable group".) */
@@ -663,6 +685,50 @@ class SystemBase : public internal::SystemMessageInterface {
     DRAKE_DEMAND(&port->get_system_base() == this);
     DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
     output_ports_.push_back(std::move(port));
+  }
+
+  /** (Internal use only) Assigns a ticket to a new discrete variable group
+  with the given `index`.
+  @pre The supplied index must be the next available one; that is, indexes
+       must be assigned sequentially. */
+  void AddDiscreteStateGroup(DiscreteStateIndex index) {
+    DRAKE_DEMAND(index == num_discrete_state_groups());
+    const DependencyTicket ticket(assign_next_dependency_ticket());
+    discrete_state_tickets_.push_back(
+        {ticket, "discrete state group " + std::to_string(index)});
+  }
+
+  /** (Internal use only) Assigns a ticket to a new abstract state variable with
+  the given `index`.
+  @pre The supplied index must be the next available one; that is, indexes
+       must be assigned sequentially. */
+  void AddAbstractState(AbstractStateIndex index) {
+    const DependencyTicket ticket(assign_next_dependency_ticket());
+    DRAKE_DEMAND(index == num_abstract_states());
+    abstract_state_tickets_.push_back(
+        {ticket, "abstract state " + std::to_string(index)});
+  }
+
+  /** (Internal use only) Assigns a ticket to a new numeric parameter with
+  the given `index`.
+  @pre The supplied index must be the next available one; that is, indexes
+       must be assigned sequentially. */
+  void AddNumericParameter(NumericParameterIndex index) {
+    DRAKE_DEMAND(index == num_numeric_parameters());
+    const DependencyTicket ticket(assign_next_dependency_ticket());
+    numeric_parameter_tickets_.push_back(
+        {ticket, "numeric parameter " + std::to_string(index)});
+  }
+
+  /** (Internal use only) Assigns a ticket to a new abstract parameter with
+  the given `index`.
+  @pre The supplied index must be the next available one; that is, indexes
+       must be assigned sequentially. */
+  void AddAbstractParameter(AbstractParameterIndex index) {
+    const DependencyTicket ticket(assign_next_dependency_ticket());
+    DRAKE_DEMAND(index == num_abstract_parameters());
+    abstract_parameter_tickets_.push_back(
+        {ticket, "abstract parameter " + std::to_string(index)});
   }
 
   /** (Internal use only) This is for cache entries associated with pre-defined
@@ -801,22 +867,6 @@ class SystemBase : public internal::SystemMessageInterface {
  private:
   void CreateSourceTrackers(ContextBase*) const;
 
-  int num_discrete_state_tickets() const {
-    return static_cast<int>(discrete_state_tickets_.size());
-  }
-
-  int num_abstract_state_tickets() const {
-    return static_cast<int>(abstract_state_tickets_.size());
-  }
-
-  int num_numeric_parameter_tickets() const {
-    return static_cast<int>(numeric_parameter_tickets_.size());
-  }
-
-  int num_abstract_parameter_tickets() const {
-    return static_cast<int>(abstract_parameter_tickets_.size());
-  }
-
   // Used to create trackers for variable-number System-allocated objects.
   struct TrackerInfo {
     DependencyTicket ticket;
@@ -825,25 +875,25 @@ class SystemBase : public internal::SystemMessageInterface {
 
   const TrackerInfo& discrete_state_tracker_info(
       DiscreteStateIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_discrete_state_tickets());
+    DRAKE_DEMAND(0 <= index && index < num_discrete_state_groups());
     return discrete_state_tickets_[index];
   }
 
   const TrackerInfo& abstract_state_tracker_info(
       AbstractStateIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_abstract_state_tickets());
+    DRAKE_DEMAND(0 <= index && index < num_abstract_states());
     return abstract_state_tickets_[index];
   }
 
   const TrackerInfo& numeric_parameter_tracker_info(
       NumericParameterIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_numeric_parameter_tickets());
+    DRAKE_DEMAND(0 <= index && index < num_numeric_parameters());
     return numeric_parameter_tickets_[index];
   }
 
   const TrackerInfo& abstract_parameter_tracker_info(
       AbstractParameterIndex index) const {
-    DRAKE_DEMAND(0 <= index && index < num_abstract_parameter_tickets());
+    DRAKE_DEMAND(0 <= index && index < num_abstract_parameters());
     return abstract_parameter_tickets_[index];
   }
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -82,10 +82,17 @@ class SystemBase : public internal::SystemMessageInterface {
   are allocated based on resource requests that were made during System
   construction. */
   std::unique_ptr<ContextBase> AllocateContext() const {
-    // Get a concrete Context of the right type and make connections.
-    std::unique_ptr<ContextBase> context = MakeContext();
-    // Validate that restrictions imposed by subsystems are satisfied.
-    ValidateAllocatedContext(*context);
+    // Get a concrete Context of the right type, allocate internal resources
+    // like parameters, state, and cache entries, and set up intra- and
+    // inter-subcontext dependencies.
+    std::unique_ptr<ContextBase> context = DoAllocateContext();
+
+    // We depend on derived classes to call our InitializeContextBase() method
+    // after allocating the appropriate concrete Context.
+    DRAKE_DEMAND(
+        detail::SystemBaseContextBaseAttorney::is_context_base_initialized(
+            *context));
+
     return context;
   }
 
@@ -429,6 +436,10 @@ class SystemBase : public internal::SystemMessageInterface {
   you can recover them with methods here knowing only the resource index. */
   //@{
 
+  // The DependencyTrackers associated with these tickets are allocated
+  // in ContextBase::CreateBuiltInTrackers() and the implementation there must
+  // be kept up to date with the API contracts here.
+
   /** Returns a ticket indicating dependence on every possible independent
   source value, including time, state, input ports, parameters, and the accuracy
   setting (but not cache entries). This is the default dependency for
@@ -520,23 +531,42 @@ class SystemBase : public internal::SystemMessageInterface {
   variables for this System. By default this is set to the continuous
   second-order state variables q, but configuration may be represented
   differently in some systems (discrete ones, for example), in which case this
-  ticket should have been set to depend on that representation. */
+  ticket should have been set to depend on that representation. This ticket
+  also assumes that configuration computations may depend on any parameter and
+  on the accuracy setting (which don't change often), but not on time.
+  Examples: a parameter that affects length may change the computation of an
+  end-effector location. A change in accuracy requirement may require
+  recomputation of an iterative approximation of contact forces. */
+  // The configuration_tracker implementation in ContextBase must be kept
+  // up to date with the above API contract.
   static DependencyTicket configuration_ticket() {
     return DependencyTicket(internal::kConfigurationTicket);
   }
 
-  /** Returns a ticket indicating dependence on all of the velocity variables
-  for this System. By default this is set to the continuous state variables v,
-  but velocity may be represented differently in some systems (discrete ones,
-  for example), in which case this ticket should have been set to depend on that
-  representation. */
+  /** (Advanced) Returns a ticket indicating dependence on all of the velocity
+  variables, but _not_ the configuration variables for this System. By default
+  this is set to the continuous state variables v, but velocity may be
+  represented differently in some systems (discrete ones, for example), in which
+  case this ticket should have been set to depend on that representation. This
+  ticket also assumes that velocity calculations may depend on any parameter and
+  on the accuracy setting (which don't change often), but not on time.
+  Examples: a parameter that affects length may change the computation of an
+  end-effector velocity. A change in accuracy requirement may require
+  recomputation of an iterative approximation of friction forces.
+
+  @warning This _does not_ include dependence on configuration, although
+  most velocity calculations do depend on configuration. If you want to
+  register dependence on both (more common), use kinematics_ticket(). */
+  // The velocity_tracker implementation in ContextBase must be kept
+  // up to date with the above API contract.
   static DependencyTicket velocity_ticket() {
     return DependencyTicket(internal::kVelocityTicket);
   }
 
   /** Returns a ticket indicating dependence on all of the configuration
   and velocity state variables of this System. This ticket depends on the
-  configuration_ticket and the velocity_ticket.
+  configuration_ticket and the velocity_ticket. Note that this includes
+  dependence on all parameters and the accuracy setting, but not on time.
   @see configuration_ticket(), velocity_ticket() */
   static DependencyTicket kinematics_ticket() {
     return DependencyTicket(internal::kKinematicsTicket);
@@ -577,6 +607,32 @@ class SystemBase : public internal::SystemMessageInterface {
     DRAKE_DEMAND(0 <= index && index < num_cache_entries());
     return cache_entries_[index]->ticket();
   }
+
+  /** Returns a ticket indicating dependence on a particular discrete state
+  variable (may be a vector). (We sometimes refer to this as a "discrete
+  variable group".) */
+  DependencyTicket discrete_state_ticket(DiscreteStateIndex index) const {
+    return discrete_state_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular abstract state
+  variable. */
+  DependencyTicket abstract_state_ticket(AbstractStateIndex index) const {
+    return abstract_state_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular numeric parameter
+  (may be a vector). */
+  DependencyTicket numeric_parameter_ticket(NumericParameterIndex index) const {
+    return numeric_parameter_tracker_info(index).ticket;
+  }
+
+  /** Returns a ticket indicating dependence on a particular abstract
+  parameter. */
+  DependencyTicket abstract_parameter_ticket(
+      AbstractParameterIndex index) const {
+    return abstract_parameter_tracker_info(index).ticket;
+  }
   //@}
 
  protected:
@@ -609,8 +665,19 @@ class SystemBase : public internal::SystemMessageInterface {
     output_ports_.push_back(std::move(port));
   }
 
-  /** (Internal use only) Returns a pointer to the service interface of the
-  immediately enclosing Diagram if one has been set, otherwise nullptr. */
+  /** (Internal use only) This is for cache entries associated with pre-defined
+  tickets, for example the cache entry for time derivatives. See the public API
+  for the most-general DeclareCacheEntry() signature for the meanings of the
+  other parameters here. */
+  const CacheEntry& DeclareCacheEntryWithKnownTicket(
+      DependencyTicket known_ticket,
+      std::string description, CacheEntry::AllocCallback alloc_function,
+      CacheEntry::CalcCallback calc_function,
+      std::set<DependencyTicket> prerequisites_of_calc = {
+          all_sources_ticket()});
+
+  /** Returns a pointer to the service interface of the immediately enclosing
+  Diagram if one has been set, otherwise nullptr. */
   const internal::SystemParentServiceInterface* get_parent_service() const {
     return parent_service_;
   }
@@ -631,21 +698,10 @@ class SystemBase : public internal::SystemMessageInterface {
   static void set_parent_service(
       SystemBase* child,
       const internal::SystemParentServiceInterface* parent_service) {
-    DRAKE_DEMAND(child != nullptr);
-    child->set_parent_service(parent_service);
-  }
-
-  /** (Internal use only) Allows Diagram to use private MakeContext() to invoke
-  the same method on its children. */
-  static std::unique_ptr<ContextBase> MakeContext(const SystemBase& system) {
-    return system.MakeContext();
-  }
-
-  /** (Internal use only) Allows Diagram to use its private
-  ValidateAllocatedContext() to invoke the same method on its children. */
-  static void ValidateAllocatedContext(const SystemBase& system,
-                                       const ContextBase& context) {
-    system.ValidateAllocatedContext(context);
+    DRAKE_DEMAND(child != nullptr && parent_service != nullptr);
+    DRAKE_DEMAND(child->parent_service_ == nullptr ||
+                 child->parent_service_ == parent_service);
+    child->parent_service_ = parent_service;
   }
 
   /** (Internal use only) Shared code for updating an input port and returning a
@@ -719,51 +775,77 @@ class SystemBase : public internal::SystemMessageInterface {
     return *output_ports_[port_index];
   }
 
-  /** Derived class implementations should allocate a suitable
-  default-constructed Context, with default-constructed subcontexts for
-  diagrams. The base class allocates trackers for known resources and
-  intra-subcontext dependencies. */
-  virtual std::unique_ptr<ContextBase> DoMakeContext() const = 0;
+  /** This method must be invoked from within derived class DoAllocateContext()
+  implementations right after the concrete Context object has been allocated.
+  It allocates cache entries, sets up all intra-Context dependencies, and marks
+  the ContextBase as initialized so that we can verify proper derived-class
+  behavior.
+  @pre The supplied context must not be null and must not already have been
+       initialized. */
+  void InitializeContextBase(ContextBase* context) const;
 
-  /** Any derived class that imposes restrictions on the structure or content
-  of an acceptable Context should enforce those restrictions by overriding
-  this method. The supplied Context is guaranteed to have come from the
-  AllocateContext() sequence of this System so you don't need to check that.
-  This method is invoked _only_ during Context allocation and will not be
-  called during runtime use. It will _always_ be called as the final step in
-  Context allocation, even in Release builds.
-  @see DoCheckValidContext() for runtime checking. */
-  virtual void DoValidateAllocatedContext(const ContextBase& context) const = 0;
+  /** Derived class implementations should allocate a suitable concrete Context
+  type, then invoke the above InitializeContextBase() method. A Diagram must
+  then invoke AllocateContext() to obtain each of the subcontexts for its
+  DiagramContext, and must set up inter-subcontext dependencies among its
+  children and between itself and its children. Then context resources such as
+  parameters and state should be allocated. */
+  virtual std::unique_ptr<ContextBase> DoAllocateContext() const = 0;
 
   /** Derived classes must implement this to verify that the supplied
   Context is suitable, and throw an exception if not. This is a runtime check
   but may be expensive so is not guaranteed to be invoked except in Debug
-  builds.
-  @see DoValidateAllocatedContext() for one-time validity checking during
-       Context allocation. */
+  builds. */
   virtual void DoCheckValidContext(const ContextBase&) const = 0;
 
  private:
-  // Obtains a context of the right concrete type, with all internal trackers
-  // allocated and internal wiring set up.
-  std::unique_ptr<ContextBase> MakeContext() const;
-
-  // Check that all subsystems are prepared to deal with a context like this.
-  void ValidateAllocatedContext(const ContextBase& context) const {
-    DoValidateAllocatedContext(context);
-  }
-
-  // Declares that `parent_service` is the service interface of the immediately
-  // enclosing Diagram. Aborts if the parent service has already been set to
-  // something else.
-  void set_parent_service(
-      const internal::SystemParentServiceInterface* parent_service) {
-    DRAKE_DEMAND(parent_service_ == nullptr ||
-                 parent_service_ == parent_service);
-    parent_service_ = parent_service;
-  }
-
   void CreateSourceTrackers(ContextBase*) const;
+
+  int num_discrete_state_tickets() const {
+    return static_cast<int>(discrete_state_tickets_.size());
+  }
+
+  int num_abstract_state_tickets() const {
+    return static_cast<int>(abstract_state_tickets_.size());
+  }
+
+  int num_numeric_parameter_tickets() const {
+    return static_cast<int>(numeric_parameter_tickets_.size());
+  }
+
+  int num_abstract_parameter_tickets() const {
+    return static_cast<int>(abstract_parameter_tickets_.size());
+  }
+
+  // Used to create trackers for variable-number System-allocated objects.
+  struct TrackerInfo {
+    DependencyTicket ticket;
+    std::string description;
+  };
+
+  const TrackerInfo& discrete_state_tracker_info(
+      DiscreteStateIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_discrete_state_tickets());
+    return discrete_state_tickets_[index];
+  }
+
+  const TrackerInfo& abstract_state_tracker_info(
+      AbstractStateIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_abstract_state_tickets());
+    return abstract_state_tickets_[index];
+  }
+
+  const TrackerInfo& numeric_parameter_tracker_info(
+      NumericParameterIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_numeric_parameter_tickets());
+    return numeric_parameter_tickets_[index];
+  }
+
+  const TrackerInfo& abstract_parameter_tracker_info(
+      AbstractParameterIndex index) const {
+    DRAKE_DEMAND(0 <= index && index < num_abstract_parameter_tickets());
+    return abstract_parameter_tickets_[index];
+  }
 
   // Ports and cache entries hold their own DependencyTickets. Note that the
   // addresses of the elements are stable even if the std::vectors are resized.
@@ -776,7 +858,15 @@ class SystemBase : public internal::SystemMessageInterface {
   std::vector<std::unique_ptr<CacheEntry>> cache_entries_;
 
   // States and parameters don't hold their own tickets so we track them here.
-  // TODO(sherm1) Add state & parameter trackers here.
+
+  // Indexed by DiscreteStateIndex.
+  std::vector<TrackerInfo> discrete_state_tickets_;
+  // Indexed by AbstractStateIndex.
+  std::vector<TrackerInfo> abstract_state_tickets_;
+  // Indexed by NumericParameterIndex.
+  std::vector<TrackerInfo> numeric_parameter_tickets_;
+  // Indexed by AbstractParameterIndex.
+  std::vector<TrackerInfo> abstract_parameter_tickets_;
 
   // Initialize to the first ticket number available after all the well-known
   // ones. This gets incremented as tickets are handed out for the optional

--- a/systems/framework/test/cache_entry_test.cc
+++ b/systems/framework/test/cache_entry_test.cc
@@ -133,11 +133,11 @@ class MySystemBase final : public SystemBase {
   }
 
  private:
-  std::unique_ptr<ContextBase> DoMakeContext() const final {
-    return std::make_unique<MyContextBase>();
+  std::unique_ptr<ContextBase> DoAllocateContext() const final {
+    auto context = std::make_unique<MyContextBase>();
+    this->InitializeContextBase(&*context);
+    return context;
   }
-
-  void DoValidateAllocatedContext(const ContextBase& context) const final {}
 
   void DoCheckValidContext(const ContextBase&) const final {}
 

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -39,7 +39,6 @@ class SystemWithNumericParameters : public LeafSystem<double> {
   SystemWithNumericParameters() {}
   ~SystemWithNumericParameters() override {}
 
-
   std::unique_ptr<Parameters<double>> AllocateParameters() const override {
     return std::make_unique<Parameters<double>>(
         std::make_unique<BasicVector<double>>(2));
@@ -53,6 +52,11 @@ class SystemWithAbstractParameters : public LeafSystem<double> {
   }
   ~SystemWithAbstractParameters() override {}
 };
+
+}  // namespace
+
+// This class must be outside the anonymous namespace to permit the
+// DiagramContext friend declaration to work.
 
 class DiagramContextTest : public ::testing::Test {
  protected:
@@ -132,6 +136,8 @@ class DiagramContextTest : public ::testing::Test {
   std::unique_ptr<SystemWithAbstractParameters>
       system_with_abstract_parameters_;
 };
+
+namespace {
 
 // Verifies that @p state is a clone of the state constructed in
 // DiagramContextTest::SetUp.
@@ -245,9 +251,9 @@ TEST_F(DiagramContextTest, DiagramState) {
 // Tests that no exception is thrown when connecting a valid source
 // and destination port.
 TEST_F(DiagramContextTest, ConnectValid) {
-  EXPECT_NO_THROW(
-      context_->Connect({SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
-                        {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)}));
+  EXPECT_NO_THROW(context_->SubscribeInputPortToOutputPort(
+      {SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
+      {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)}));
 }
 
 // Tests that input ports can be assigned to the DiagramContext and then
@@ -260,8 +266,9 @@ TEST_F(DiagramContextTest, SetAndGetInputPorts) {
 }
 
 TEST_F(DiagramContextTest, Clone) {
-  context_->Connect({SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
-                    {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)});
+  context_->SubscribeInputPortToOutputPort(
+      {SubsystemIndex(0) /* adder0_ */, OutputPortIndex(0)},
+      {SubsystemIndex(1) /* adder1_ */, InputPortIndex(1)});
   AttachInputPorts();
 
   auto clone = dynamic_pointer_cast<DiagramContext<double>>(context_->Clone());

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -44,7 +44,20 @@ class FixedInputPortTest : public ::testing::Test {
     port1_value_ = &context_.FixInputPort(
         InputPortIndex(1), Value<std::string>("foo"));
 
-    // TODO(sherm1) Tracker & ticket setup here.
+    // The input ports and free values should have distinct tickets.
+    DependencyTicket ticket0 = context_.input_port_ticket(InputPortIndex(0));
+    DependencyTicket ticket1 = context_.input_port_ticket(InputPortIndex(1));
+    DependencyTicket free_ticket0 = port0_value_->ticket();
+    DependencyTicket free_ticket1 = port1_value_->ticket();
+    EXPECT_TRUE(ticket0.is_valid() && ticket1.is_valid());
+    EXPECT_TRUE(free_ticket0.is_valid() && free_ticket1.is_valid());
+    EXPECT_NE(ticket0, free_ticket0);
+    EXPECT_NE(ticket1, free_ticket1);
+
+    tracker0_ = &context_.get_tracker(ticket0);
+    tracker1_ = &context_.get_tracker(ticket1);
+    free_tracker0_ = &context_.get_tracker(free_ticket0);
+    free_tracker1_ = &context_.get_tracker(free_ticket1);
 
     serial0_ = port0_value_->serial_number();
     serial1_ = port1_value_->serial_number();
@@ -55,6 +68,11 @@ class FixedInputPortTest : public ::testing::Test {
   FixedInputPortValue* port0_value_{};
   FixedInputPortValue* port1_value_{};
 
+  const DependencyTracker* tracker0_{};
+  const DependencyTracker* tracker1_{};
+  const DependencyTracker* free_tracker0_{};
+  const DependencyTracker* free_tracker1_{};
+
   int64_t serial0_{-1}, serial1_{-1};
 };
 
@@ -64,10 +82,23 @@ TEST_F(FixedInputPortTest, SystemAndContext) {
   // The input port trackers should have declared the free values as
   // prerequisites, and the free values should know the input ports are
   // subscribers.
-  // TODO(sherm1) Tracker wiring tests go here.
+  ASSERT_EQ(tracker0_->num_prerequisites(), 1);
+  ASSERT_EQ(free_tracker0_->num_subscribers(), 1);
+  EXPECT_EQ(free_tracker0_->num_prerequisites(), 0);
+  ASSERT_EQ(tracker1_->num_prerequisites(), 1);
+  ASSERT_EQ(free_tracker1_->num_subscribers(), 1);
+  EXPECT_EQ(free_tracker1_->num_prerequisites(), 0);
+
+  EXPECT_EQ(tracker0_->prerequisites()[0], free_tracker0_);
+  EXPECT_EQ(tracker1_->prerequisites()[0], free_tracker1_);
+  EXPECT_EQ(free_tracker0_->subscribers()[0], tracker0_);
+  EXPECT_EQ(free_tracker1_->subscribers()[0], tracker1_);
 
   EXPECT_EQ(&port0_value_->get_owning_context(), &context_);
   EXPECT_EQ(&port1_value_->get_owning_context(), &context_);
+
+  EXPECT_EQ(port0_value_->ticket(), free_tracker0_->ticket());
+  EXPECT_EQ(port1_value_->ticket(), free_tracker1_->ticket());
 
   EXPECT_EQ(port0_value_->serial_number(), 1);
   EXPECT_EQ(port1_value_->serial_number(), 1);

--- a/systems/framework/test/leaf_context_test.cc
+++ b/systems/framework/test/leaf_context_test.cc
@@ -56,7 +56,7 @@ class LeafContextTest : public ::testing::Test {
     }
 
     // Reserve a continuous state with five elements.
-    context_.set_continuous_state(std::make_unique<ContinuousState<double>>(
+    context_.init_continuous_state(std::make_unique<ContinuousState<double>>(
         BasicVector<double>::Make({1.0, 2.0, 3.0, 5.0, 8.0}),
         kGeneralizedPositionSize, kGeneralizedVelocitySize,
         kMiscContinuousStateSize));
@@ -65,7 +65,7 @@ class LeafContextTest : public ::testing::Test {
     // that we can change it using get_mutable_discrete_state_vector().
     std::vector<std::unique_ptr<BasicVector<double>>> xd_single;
     xd_single.push_back(BasicVector<double>::Make({128.0}));
-    context_.set_discrete_state(
+    context_.init_discrete_state(
         std::make_unique<DiscreteValues<double>>(std::move(xd_single)));
     context_.get_mutable_discrete_state_vector()[0] = 192.0;
     EXPECT_EQ(context_.get_discrete_state().get_vector()[0], 192.0);
@@ -74,14 +74,14 @@ class LeafContextTest : public ::testing::Test {
     std::vector<std::unique_ptr<BasicVector<double>>> xd;
     xd.push_back(BasicVector<double>::Make({128.0}));
     xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
-    context_.set_discrete_state(
+    context_.init_discrete_state(
         std::make_unique<DiscreteValues<double>>(std::move(xd)));
 
     // Reserve an abstract state with one element, which is not owned.
     abstract_state_ = PackValue(42);
     std::vector<AbstractValue*> xa;
     xa.push_back(abstract_state_.get());
-    context_.set_abstract_state(
+    context_.init_abstract_state(
         std::make_unique<AbstractValues>(std::move(xa)));
 
     // Reserve two numeric parameters of size 3 and size 4, and one abstract
@@ -124,7 +124,7 @@ class LeafContextTest : public ::testing::Test {
 
   // Mocks up some input ports sufficient to allow us to give them fixed values.
   template <typename T>
-  void AddInputPorts(int n, Context<T>* context) {
+  void AddInputPorts(int n, LeafContext<T>* context) {
     for (InputPortIndex i(0); i < n; ++i) {
       input_port_tickets_.push_back(next_ticket_);
       context->AddInputPort(i, next_ticket_++);
@@ -133,9 +133,9 @@ class LeafContextTest : public ::testing::Test {
 
   // Mocks up some output ports sufficient to check that they are installed and
   // wired up properly. (We can't evaluate output ports without a System.)
-  // This code mimics SystemBase::MakeContext().
+  // This code mimics SystemBase::AllocateContext().
   template <typename T>
-  void AddOutputPorts(int n, Context<T>* context) {
+  void AddOutputPorts(int n, LeafContext<T>* context) {
     // Pretend the first output port has an external dependency (so tracking
     // should be deferred) while the rest are dependent on a built-in tracker.
     output_port_tickets_.push_back(next_ticket_);
@@ -158,6 +158,8 @@ class LeafContextTest : public ::testing::Test {
   std::vector<DependencyTicket> input_port_tickets_;
   std::vector<DependencyTicket> output_port_tickets_;
 };
+
+namespace {
 
 // Verifies that @p state is a clone of the state constructed in
 // LeafContextTest::SetUp.
@@ -221,16 +223,15 @@ TEST_F(LeafContextTest, CheckPorts) {
   ASSERT_EQ(kNumOutputPorts, context_.get_num_output_ports());
 
   // The "all inputs" tracker should have been subscribed to each of the
-  // input ports.
-  // TODO(sherm1) And each input port should have subscribed to its fixed
+  // input ports. And each input port should have subscribed to its fixed
   // input value.
   auto& u_tracker =
       context_.get_tracker(DependencyTicket(internal::kAllInputPortsTicket));
   for (InputPortIndex i(0); i < kNumInputPorts; ++i) {
     EXPECT_EQ(context_.input_port_ticket(i), input_port_tickets_[i]);
     auto& tracker = context_.get_tracker(input_port_tickets_[i]);
-    // TODO(sherm1) The fixed input value should be a prerequisite.
-    EXPECT_EQ(tracker.num_prerequisites(), 0);
+    // The fixed input value is a prerequisite.
+    EXPECT_EQ(tracker.num_prerequisites(), 1);
     EXPECT_EQ(tracker.num_subscribers(), 1);
     EXPECT_TRUE(u_tracker.HasPrerequisite(tracker));
   }
@@ -269,15 +270,15 @@ TEST_F(LeafContextTest, IsStateless) {
 
 TEST_F(LeafContextTest, HasOnlyContinuousState) {
   EXPECT_FALSE(context_.has_only_continuous_state());
-  context_.set_discrete_state(std::make_unique<DiscreteValues<double>>());
-  context_.set_abstract_state(std::make_unique<AbstractValues>());
+  context_.init_discrete_state(std::make_unique<DiscreteValues<double>>());
+  context_.init_abstract_state(std::make_unique<AbstractValues>());
   EXPECT_TRUE(context_.has_only_continuous_state());
 }
 
 TEST_F(LeafContextTest, HasOnlyDiscreteState) {
   EXPECT_FALSE(context_.has_only_discrete_state());
-  context_.set_continuous_state(std::make_unique<ContinuousState<double>>());
-  context_.set_abstract_state(std::make_unique<AbstractValues>());
+  context_.init_continuous_state(std::make_unique<ContinuousState<double>>());
+  context_.init_abstract_state(std::make_unique<AbstractValues>());
   EXPECT_TRUE(context_.has_only_discrete_state());
 }
 
@@ -286,7 +287,7 @@ TEST_F(LeafContextTest, GetNumStates) {
   EXPECT_EQ(context.get_num_total_states(), 0);
 
   // Reserve a continuous state with five elements.
-  context.set_continuous_state(std::make_unique<ContinuousState<double>>(
+  context.init_continuous_state(std::make_unique<ContinuousState<double>>(
       BasicVector<double>::Make({1.0, 2.0, 3.0, 5.0, 8.0})));
   EXPECT_EQ(context.get_num_total_states(), 5);
 
@@ -294,7 +295,7 @@ TEST_F(LeafContextTest, GetNumStates) {
   std::vector<std::unique_ptr<BasicVector<double>>> xd;
   xd.push_back(BasicVector<double>::Make({128.0}));
   xd.push_back(BasicVector<double>::Make({256.0, 512.0}));
-  context.set_discrete_state(
+  context.init_discrete_state(
       std::make_unique<DiscreteValues<double>>(std::move(xd)));
   EXPECT_EQ(context.get_num_total_states(), 8);
 
@@ -302,7 +303,7 @@ TEST_F(LeafContextTest, GetNumStates) {
   std::unique_ptr<AbstractValue> abstract_state = PackValue(42);
   std::vector<AbstractValue*> xa;
   xa.push_back(abstract_state.get());
-  context.set_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
+  context.init_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
   EXPECT_THROW(context.get_num_total_states(), std::runtime_error);
 }
 
@@ -461,7 +462,7 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   // interesting values.
   // In actual applications, System<T>::CreateDefaultContext does this.
   LeafContext<AutoDiffXd> target;
-  target.set_continuous_state(std::make_unique<ContinuousState<AutoDiffXd>>(
+  target.init_continuous_state(std::make_unique<ContinuousState<AutoDiffXd>>(
       std::make_unique<BasicVector<AutoDiffXd>>(5),
       kGeneralizedPositionSize, kGeneralizedVelocitySize,
       kMiscContinuousStateSize));
@@ -469,12 +470,12 @@ TEST_F(LeafContextTest, SetTimeStateAndParametersFrom) {
   std::vector<std::unique_ptr<BasicVector<AutoDiffXd>>> xd;
   xd.push_back(std::make_unique<BasicVector<AutoDiffXd>>(1));
   xd.push_back(std::make_unique<BasicVector<AutoDiffXd>>(2));
-  target.set_discrete_state(
+  target.init_discrete_state(
       std::make_unique<DiscreteValues<AutoDiffXd>>(std::move(xd)));
 
   std::vector<std::unique_ptr<AbstractValue>> xa;
   xa.push_back(PackValue(76));
-  target.set_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
+  target.init_abstract_state(std::make_unique<AbstractValues>(std::move(xa)));
 
   std::vector<std::unique_ptr<BasicVector<AutoDiffXd>>> params;
   params.push_back(std::make_unique<BasicVector<AutoDiffXd>>(3));
@@ -528,5 +529,6 @@ TEST_F(LeafContextTest, Accuracy) {
   EXPECT_EQ(clone->get_accuracy().value(), unity);
 }
 
+}  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/framework/test/system_base_test.cc
+++ b/systems/framework/test/system_base_test.cc
@@ -42,11 +42,11 @@ class MySystemBase final : public SystemBase {
   MySystemBase() {}
 
  private:
-  std::unique_ptr<ContextBase> DoMakeContext() const final {
-    return std::make_unique<MyContextBase>(true);  // A valid context.
+  std::unique_ptr<ContextBase> DoAllocateContext() const final {
+    auto context = std::make_unique<MyContextBase>(true);  // A valid context.
+    InitializeContextBase(&*context);
+    return context;
   }
-
-  void DoValidateAllocatedContext(const ContextBase& context) const final {}
 
   void DoCheckValidContext(const ContextBase& context) const final {
     auto& my_context = dynamic_cast<const MyContextBase&>(context);

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -218,11 +218,11 @@ class TestSystem : public System<double> {
   }
 
  private:
-  std::unique_ptr<ContextBase> DoMakeContext() const final {
-    return std::make_unique<LeafContext<double>>();
+  std::unique_ptr<ContextBase> DoAllocateContext() const final {
+    auto context = std::make_unique<LeafContext<double>>();
+    InitializeContextBase(&*context);
+    return context;
   }
-
-  void DoValidateAllocatedContext(const ContextBase&) const final {}
 
   mutable int publish_count_ = 0;
   mutable int update_count_ = 0;
@@ -485,11 +485,11 @@ class ValueIOTestSystem : public System<T> {
     return std::make_unique<ContinuousState<T>>();
   }
 
-  std::unique_ptr<ContextBase> DoMakeContext() const final {
-    return std::make_unique<LeafContext<T>>();
+  std::unique_ptr<ContextBase> DoAllocateContext() const final {
+    auto context = std::make_unique<LeafContext<T>>();
+    this->InitializeContextBase(&*context);
+    return context;
   }
-
-  void DoValidateAllocatedContext(const ContextBase& context) const final {}
 
   std::unique_ptr<CompositeEventCollection<T>>
   AllocateCompositeEventCollection() const override {


### PR DESCRIPTION
This is hopefully the penultimate major PR for initial caching functionality from #7668.

This one completes the Context construction process including all the dependency tracking wiring. What's missing after this lands is just the code that initiates invalidation sweeps.
```
Category            added  modified  removed  
----------------------------------------------
code                366    96        35       
comments            138    55        28       
blank               55     0         0        
----------------------------------------------
TOTAL               559    151       63       
```
Changes here for Context construction:
- Adds tickets and trackers for state and parameters and records them in SystemBase and ContextBase (see SystemBase::CreateSourceTrackers()).
- Adds tickets and trackers for fixed input port values and subscribes input ports to their values. 
- Allows the managed cache entry to be added later to a DependencyTracker rather than requiring it at construction. This allows setting up all the well-known trackers early in Context construction, although some of the cache entries can't be known until later.
- Cloning context now correctly re-creates the entire dependency graph.
- Renamed DiagramContext::ExportInput, ExportOutput, and Connect to reflect their actual function now that they set up the necessary dependencies (removes existing TODOs).
- Renames dangerous `set_`_`blah`_`_state()` methods to `init_`_`blah`_`_state()` to match `init_parameters()`.

Other opportunistic changes here:
- Propagates cache debug settings throughout the context tree (e.g. disable caching).
- Adds assumed parameter and accuracy dependency to kinematic tickets (forgot those earlier).

Still needs more unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9067)
<!-- Reviewable:end -->
