### PR TITLE
Introduce penetrating pair order invariant guarantee

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -295,6 +295,13 @@ bool SingleCollisionCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
       penetration.p_WCa = p_WAc;
       penetration.p_WCb = p_WBc;
       penetration.nhat_BA_W = drake_normal;
+      // Guarantee fixed ordering of pair (A, B). Swap the ids and points on
+      // surfaces and then flip the normal.
+      if (penetration.id_B < penetration.id_A) {
+        std::swap(penetration.id_A, penetration.id_B);
+        std::swap(penetration.p_WCa, penetration.p_WCb);
+        penetration.nhat_BA_W = -penetration.nhat_BA_W;
+      }
       collision_data.contacts->emplace_back(std::move(penetration));
     }
   }

--- a/geometry/proximity_engine.h
+++ b/geometry/proximity_engine.h
@@ -132,7 +132,8 @@ class ProximityEngine {
    have been filtered will not produce contacts, even if their collision
    geometry is penetrating.
 
-   @endcond
+   For two penetrating geometries g₁ and g₂, it is guaranteed that they will
+   map to `id_A` and `id_B` in a fixed, repeatable manner.
 
    @param[in]   dynamic_map   A map from geometry _index_ to the corresponding
                               global geometry identifier for dynamic geometries.

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -102,12 +102,14 @@ class QueryObject {
    geometry are also not reported. The penetration between two geometries is
    characterized as a point pair (see PenetrationAsPointPair).
 
-   <!--
+   For two penetrating geometries g₁ and g₂, it is guaranteed that they will
+   map to `id_A` and `id_B` in a fixed, repeatable manner.
+
    This method is affected by collision filtering; element pairs that
    have been filtered will not produce contacts, even if their collision
    geometry is penetrating.
-   TODO(SeanCurtis-TRI): This isn't true yet.
 
+   <!--
    NOTE: This is currently declared as double because we haven't exposed FCL's
    templated functionality yet. When that happens, double -> T.
    -->


### PR DESCRIPTION
If two geometries (g and h) are penetrating, SceneGraph (via its supporting
infrastructure) did not guarantee whether the pair would be reporting as
(g, h) or (h, g). While the values were correct, regardless of order, it
led to incoherency in interpreting them (particularly visually). This
introduces a guarantee that the pair will *always* be reported in the same
order (although the basis for the order is left undocumented.)

Resolves #9063

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9070)
<!-- Reviewable:end -->
