### PR TITLE
Add visual materials to MBP/SG parsing from SDF

### DIFF
--- a/geometry/geometry_state.cc
+++ b/geometry/geometry_state.cc
@@ -175,6 +175,26 @@ const Isometry3<double>& GeometryState<T>::GetPoseInParent(
 }
 
 template <typename T>
+const VisualMaterial* GeometryState<T>::get_visual_material(
+    GeometryId geometry_id) const {
+  // TODO(SeanCurtis-TRI): Wrap this in a function accessible to all geometry
+  // property introspection functions.
+  {
+    auto iterator = geometries_.find(geometry_id);
+    if (iterator != geometries_.end()) {
+      return &iterator->second.get_visual_material();
+    }
+  }
+  {
+    auto iterator = anchored_geometries_.find(geometry_id);
+    if (iterator != anchored_geometries_.end()) {
+      return &iterator->second.get_visual_material();
+    }
+  }
+  throw std::logic_error(get_missing_id_message(geometry_id));
+}
+
+template <typename T>
 SourceId GeometryState<T>::RegisterNewSource(const std::string& name) {
   SourceId source_id = SourceId::get_new_id();
   const std::string final_name =

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -228,6 +228,12 @@ class GeometryState {
                              GeometryInstance. */
   const Isometry3<double>& GetPoseInParent(GeometryId geometry_id) const;
 
+  /** Returns the visual material defined for geometry indicated by the given
+   `geometry_id` (if defined).
+   @throws std::logic_error If the `geometry_id` does _not_ map to a valid
+                            GeometryInstance. */
+  const VisualMaterial* get_visual_material(GeometryId geometry_id) const;
+
   //@}
 
   /** @name        State management

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -31,6 +31,13 @@ FrameId QueryObject<T>::GetFrameId(GeometryId geometry_id) const {
 }
 
 template <typename T>
+const VisualMaterial* QueryObject<T>::GetVisualMaterial(
+    GeometryId geometry_id) const {
+  ThrowIfDefault();
+  return context_->get_geometry_state().get_visual_material(geometry_id);
+}
+
+template <typename T>
 std::vector<PenetrationAsPointPair<double>>
 QueryObject<T>::ComputePointPairPenetration() const {
   ThrowIfDefault();

--- a/geometry/query_object.h
+++ b/geometry/query_object.h
@@ -84,6 +84,12 @@ class QueryObject {
    @throws  std::logic_error if the geometry id is invalid. */
   FrameId GetFrameId(GeometryId geometry_id) const;
 
+  /** Returns the visual material of the geometry indicated by the given
+   `geometry_id` (if it exists).
+   @throws  std::runtime_error if the %QueryObject is in default configuration.
+   @throws  std::logic_error if the geometry id is invalid. */
+  const VisualMaterial* GetVisualMaterial(GeometryId geometry_id) const;
+
   //@}
 
   //----------------------------------------------------------------------------

--- a/geometry/visual_material.h
+++ b/geometry/visual_material.h
@@ -16,7 +16,8 @@ class VisualMaterial final {
   /** Constructs a material with the default grey color. */
   VisualMaterial();
 
-  /** Constructs a material with the given diffuse color. */
+  /** Constructs a material with the given diffuse color.
+   @param diffuse  A vector of [r, g, b, a] values, each in the range [0, 1]. */
   explicit VisualMaterial(const Eigen::Vector4d& diffuse);
 
   /** Returns the material's diffuse color. */

--- a/multibody/benchmarks/acrobot/acrobot.sdf
+++ b/multibody/benchmarks/acrobot/acrobot.sdf
@@ -27,6 +27,9 @@
             <radius>0.05</radius>
           </cylinder>
         </geometry>
+        <material>
+          <diffuse>0 1 0 1</diffuse>
+        </material>
       </visual>
       <!-- A visual to show the link's pivot point -->
       <visual name='Link1_pivot_visual'>
@@ -37,6 +40,9 @@
             <radius>0.125</radius>
           </sphere>
         </geometry>
+        <material>
+          <diffuse>0 0 1 1</diffuse>
+        </material>
       </visual>
     </link>
     <joint name='ShoulderJoint' type='revolute'>
@@ -78,6 +84,9 @@
             <radius>0.05</radius>
           </cylinder>
         </geometry>
+        <material>
+          <diffuse>1 0 0 1</diffuse>
+        </material>
       </visual>
     </link>
     <joint name='ElbowJoint' type='revolute'>

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -73,15 +73,15 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
 }
 
 template <typename T>
-void MultibodyPlant<T>::RegisterVisualGeometry(
+geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape, geometry::SceneGraph<T>* scene_graph) {
-  RegisterVisualGeometry(body, X_BG, shape, geometry::VisualMaterial(),
-                         scene_graph);
+  return RegisterVisualGeometry(body, X_BG, shape, geometry::VisualMaterial(),
+                                scene_graph);
 }
 
 template <typename T>
-void MultibodyPlant<T>::RegisterVisualGeometry(
+geometry::GeometryId MultibodyPlant<T>::RegisterVisualGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
     const geometry::Shape& shape, const geometry::VisualMaterial& material,
     SceneGraph<T>* scene_graph) {
@@ -111,6 +111,7 @@ void MultibodyPlant<T>::RegisterVisualGeometry(
   geometry_id_to_visual_index_[id] = visual_index;
   DRAKE_ASSERT(num_bodies() == static_cast<int>(visual_geometries_.size()));
   visual_geometries_[body.index()].push_back(id);
+  return id;
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -73,10 +73,23 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
 }
 
 template <typename T>
-void MultibodyPlant<T>::RegisterVisualGeometry(const Body<T>& body,
-                                               const Isometry3<double>& X_BG,
-                                               const geometry::Shape& shape,
-                                               SceneGraph<T>* scene_graph) {
+void MultibodyPlant<T>::RegisterVisualGeometry(
+    const Body<T>& body, const Isometry3<double>& X_BG,
+    const geometry::Shape& shape, geometry::SceneGraph<T>* scene_graph) {
+  RegisterVisualGeometry(body, X_BG, shape, geometry::VisualMaterial(),
+                         scene_graph);
+}
+
+template <typename T>
+void MultibodyPlant<T>::RegisterVisualGeometry(
+    const Body<T>& body, const Isometry3<double>& X_BG,
+    const geometry::Shape& shape, const geometry::VisualMaterial& material,
+    SceneGraph<T>* scene_graph) {
+  // TODO(SeanCurtis-TRI): Consider simply adding an interface that takes a
+  // unique pointer to an already instantiated GeometryInstance. This will
+  // require shuffling around a fair amount of code and should ultimately be
+  // supplanted by providing a cleaner interface between parsing MBP and SG
+  // elements.
   DRAKE_MBP_THROW_IF_FINALIZED();
   DRAKE_THROW_UNLESS(scene_graph != nullptr);
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
@@ -90,9 +103,9 @@ void MultibodyPlant<T>::RegisterVisualGeometry(const Body<T>& body,
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register anchored geometry on ANY body welded to the world.
   if (body.index() == world_index()) {
-    id = RegisterAnchoredGeometry(X_BG, shape, scene_graph);
+    id = RegisterAnchoredGeometry(X_BG, shape, material, scene_graph);
   } else {
-    id = RegisterGeometry(body, X_BG, shape, scene_graph);
+    id = RegisterGeometry(body, X_BG, shape, material, scene_graph);
   }
   const int visual_index = geometry_id_to_visual_index_.size();
   geometry_id_to_visual_index_[id] = visual_index;
@@ -125,9 +138,9 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register anchored geometry on ANY body welded to the world.
   if (body.index() == world_index()) {
-    id = RegisterAnchoredGeometry(X_BG, shape, scene_graph);
+    id = RegisterAnchoredGeometry(X_BG, shape, {}, scene_graph);
   } else {
-    id = RegisterGeometry(body, X_BG, shape, scene_graph);
+    id = RegisterGeometry(body, X_BG, shape, {}, scene_graph);
   }
   const int collision_index = geometry_id_to_collision_index_.size();
   geometry_id_to_collision_index_[id] = collision_index;
@@ -170,7 +183,9 @@ geometry::GeometrySet MultibodyPlant<T>::CollectRegisteredGeometries(
 template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
     const Body<T>& body, const Isometry3<double>& X_BG,
-    const geometry::Shape& shape, SceneGraph<T>* scene_graph) {
+    const geometry::Shape& shape,
+    const optional<geometry::VisualMaterial>& material,
+    SceneGraph<T>* scene_graph) {
   // This should never be called with the world index.
   DRAKE_DEMAND(body.index() != world_index());
   DRAKE_ASSERT(!is_finalized());
@@ -187,9 +202,16 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
   }
 
   // Register geometry in the body frame.
+  std::unique_ptr<geometry::GeometryInstance> geometry_instance;
+  if (material) {
+    geometry_instance = std::make_unique<GeometryInstance>(X_BG, shape.Clone(),
+                                                           material.value());
+  } else {
+    geometry_instance = std::make_unique<GeometryInstance>(X_BG, shape.Clone());
+  }
   GeometryId geometry_id = scene_graph->RegisterGeometry(
       source_id_.value(), body_index_to_frame_id_[body.index()],
-      std::make_unique<GeometryInstance>(X_BG, shape.Clone()));
+      std::move(geometry_instance));
   geometry_id_to_body_index_[geometry_id] = body.index();
   return geometry_id;
 }
@@ -197,13 +219,22 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
 template <typename T>
 geometry::GeometryId MultibodyPlant<T>::RegisterAnchoredGeometry(
     const Isometry3<double>& X_WG, const geometry::Shape& shape,
+    const optional<geometry::VisualMaterial>& material,
     SceneGraph<T>* scene_graph) {
   DRAKE_ASSERT(!is_finalized());
   DRAKE_ASSERT(geometry_source_is_registered());
   DRAKE_ASSERT(scene_graph == scene_graph_);
+
+  std::unique_ptr<geometry::GeometryInstance> geometry_instance;
+  if (material) {
+    geometry_instance = std::make_unique<GeometryInstance>(X_WG, shape.Clone(),
+                                                           material.value());
+  } else {
+    geometry_instance = std::make_unique<GeometryInstance>(X_WG, shape.Clone());
+  }
   GeometryId geometry_id = scene_graph->RegisterAnchoredGeometry(
       source_id_.value(),
-      std::make_unique<GeometryInstance>(X_WG, shape.Clone()));
+      std::move(geometry_instance));
   geometry_id_to_body_index_[geometry_id] = world_index();
   return geometry_id;
 }

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -635,6 +635,8 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @param[in] shape
   ///   The geometry::Shape used for visualization. E.g.: geometry::Sphere,
   ///   geometry::Cylinder, etc.
+  /// @param[in] material
+  ///   The visual material to assign to the geometry.
   /// @param[out] scene_graph
   ///   A valid non nullptr to a SceneGraph on which geometry will get
   ///   registered.
@@ -642,8 +644,14 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if called post-finalize.
   /// @throws if `scene_graph` does not correspond to the same instance with
   /// which RegisterAsSourceForSceneGraph() was called.
-  // TODO(amcastro-tri): When GS supports it, provide argument to specify
-  // visual properties.
+  void RegisterVisualGeometry(const Body<T>& body,
+                              const Isometry3<double>& X_BG,
+                              const geometry::Shape& shape,
+                              const geometry::VisualMaterial& material,
+                              geometry::SceneGraph<T>* scene_graph);
+
+  /// Overload for visual geometry registration; it implicitly assigns the
+  /// default material.
   void RegisterVisualGeometry(const Body<T>& body,
                               const Isometry3<double>& X_BG,
                               const geometry::Shape& shape,
@@ -1217,10 +1225,11 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // 3. `scene_graph` points to the same SceneGraph instance previously
   //    passed to RegisterAsSourceForSceneGraph().
   // 4. The body is *not* the world body.
-  geometry::GeometryId RegisterGeometry(const Body<T>& body,
-                                        const Isometry3<double>& X_BG,
-                                        const geometry::Shape& shape,
-                                        geometry::SceneGraph<T>* scene_graph);
+  geometry::GeometryId RegisterGeometry(
+      const Body<T>& body, const Isometry3<double>& X_BG,
+      const geometry::Shape& shape,
+      const optional<geometry::VisualMaterial>& material,
+      geometry::SceneGraph<T>* scene_graph);
 
   // Helper method to register anchored geometry to the world, either visual or
   // collision. This associates a GeometryId with the world body.
@@ -1231,6 +1240,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   //    passed to RegisterAsSourceForSceneGraph().
   geometry::GeometryId RegisterAnchoredGeometry(
       const Isometry3<double>& X_WG, const geometry::Shape& shape,
+      const optional<geometry::VisualMaterial>& material,
       geometry::SceneGraph<T>* scene_graph);
 
   bool body_has_registered_frame(const Body<T>& body) const {

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -644,18 +644,17 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if called post-finalize.
   /// @throws if `scene_graph` does not correspond to the same instance with
   /// which RegisterAsSourceForSceneGraph() was called.
-  void RegisterVisualGeometry(const Body<T>& body,
-                              const Isometry3<double>& X_BG,
-                              const geometry::Shape& shape,
-                              const geometry::VisualMaterial& material,
-                              geometry::SceneGraph<T>* scene_graph);
+  /// @returns the id for the registered geometry.
+  geometry::GeometryId RegisterVisualGeometry(
+      const Body<T>& body, const Isometry3<double>& X_BG,
+      const geometry::Shape& shape, const geometry::VisualMaterial& material,
+      geometry::SceneGraph<T>* scene_graph);
 
   /// Overload for visual geometry registration; it implicitly assigns the
   /// default material.
-  void RegisterVisualGeometry(const Body<T>& body,
-                              const Isometry3<double>& X_BG,
-                              const geometry::Shape& shape,
-                              geometry::SceneGraph<T>* scene_graph);
+  geometry::GeometryId RegisterVisualGeometry(
+      const Body<T>& body, const Isometry3<double>& X_BG,
+      const geometry::Shape& shape, geometry::SceneGraph<T>* scene_graph);
 
   /// Returns an array of GeometryId's identifying the different visual
   /// geometries for `body` previously registered with a SceneGraph.

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -364,7 +364,7 @@ ModelInstanceIndex AddModelFromSdfFile(
         if (geometry_instance) {
           plant->RegisterVisualGeometry(
               body, geometry_instance->pose(), geometry_instance->shape(),
-              scene_graph);
+              geometry_instance->visual_material(), scene_graph);
         }
       }
 

--- a/multibody/multibody_tree/parsing/scene_graph_parser_detail.h
+++ b/multibody/multibody_tree/parsing/scene_graph_parser_detail.h
@@ -30,6 +30,33 @@ std::unique_ptr<geometry::Shape> MakeShapeFromSdfGeometry(
 std::unique_ptr<geometry::GeometryInstance> MakeGeometryInstanceFromSdfVisual(
     const sdf::Visual& sdf_visual);
 
+/// Given an sdf::Visual object representing a <visual> element from an SDF
+/// file, this method makes a new @ref drake::geometry::VisualMaterial
+/// "VisualMaterial" object from the specification.
+///
+/// The visual material comes from the child <material> tag. E.g.,
+/// ```xml
+/// <visual>
+///   <geometry>
+///   ...
+///   </geometry>
+///   <material>
+///     <ambient>r_a g_a b_a a_a</ambient>
+///     <diffuse>r_d g_d b_d a_d</diffuse>
+///     <specular>r_s g_s b_s a_s</specular>
+///     <emissive>r_e g_e b_e a_e</emissive>
+///   </material>
+/// </visual>
+/// ```
+/// If there is no material tag, the supported material tags are missing, or
+/// there is an error parsing the supported values, the instantiated
+/// VisualMaterial will use default values. (See geometry::VisualMaterial for
+/// description of the default color.)
+///
+/// @note Currently, only the diffuse value is included in the VisualMaterial.
+geometry::VisualMaterial MakeVisualMaterialFromSdfVisual(
+    const sdf::Visual& sdf_visual);
+
 /// Given `sdf_collision` stemming from the parsing of a `<collision>` element
 /// in an SDF file, this method makes the pose `X_LG` of frame G for the
 /// geometry of that collision element in the frame L of the link it belongs to.
@@ -40,7 +67,8 @@ Eigen::Isometry3d MakeGeometryPoseFromSdfCollision(
 /// This method looks for the definitions specific to ODE, as given by the SDF
 /// specification in `<collision><surface><friction><ode>`. Drake understands
 /// `<mu>` as the static coefficient of friction and `<mu2>` as the dynamic
-/// coefficient of friction. Consider the example below: <pre>
+/// coefficient of friction. Consider the example below:
+/// ```xml
 ///   <collision>
 ///     <surface>
 ///       <friction>
@@ -51,7 +79,7 @@ Eigen::Isometry3d MakeGeometryPoseFromSdfCollision(
 ///       </friction>
 ///     </surface>
 ///   </collision>
-/// </pre>
+/// ```
 /// If a `<surface>` is not found, it returns the coefficients for a
 /// frictionless surface. If `<surface>` is found, all other nested elements
 /// are required and an exception is thrown if not present.


### PR DESCRIPTION
1. Extend the parser to extract the material and diffuse tags from the SDF. (Will be replaced when sdformat API updates.)
2. Add unit tests
3. Modify upstream multibody parser and multibody plant to handle the visual material.
4. Modify the acrobot.sdf file used in the MBP examples to illustrate color parsing. Run examples/multibody/acrobot:run_lqr

```
Category            added  modified  removed  
----------------------------------------------
code                69     17        0        
comments            60     2         2        
blank               15     0         0        
----------------------------------------------
TOTAL               144    19        2  
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9083)
<!-- Reviewable:end -->
