### PR TITLE
Revert "Constraint solver discretization tests"

### DIFF
--- a/multibody/constraint/constraint_solver.h
+++ b/multibody/constraint/constraint_solver.h
@@ -103,9 +103,6 @@ class ConstraintSolver {
   };
   // TODO(edrumwri): Describe conditions under which it is safe to replace
   // A⁻¹ by a pseudo-inverse.
-  // TODO(edrumwri): Constraint solver needs to use monogram notation throughout
-  // to make it consistent with the rest of Drake's multibody dynamics
-  // documentation (see Issue #9080).
 
   /// @name Velocity-level constraint problems formulated as MLCPs.
   /// @anchor Velocity-level-MLCPs
@@ -449,11 +446,8 @@ class ConstraintSolver {
 
   /// Computes the system generalized acceleration due to both external forces
   /// and constraint forces.
-  /// @param problem_data The acceleration-level constraint data.
   /// @param cf The computed constraint forces, in the packed storage
   ///           format described in documentation for SolveConstraintProblem.
-  /// @param[out] generalized_acceleration The generalized acceleration, on
-  ///             return.
   /// @throws std::logic_error if @p generalized_acceleration is null or
   ///         @p cf vector is incorrectly sized.
   static void ComputeGeneralizedAcceleration(
@@ -465,31 +459,6 @@ class ConstraintSolver {
     (*generalized_acceleration) += problem_data.solve_inertia(
         problem_data.tau);
   }
-
-  /// Computes a first-order approximation of generalized acceleration due
-  /// *only* to constraint forces.
-  /// @param problem_data The velocity-level constraint data.
-  /// @param cf The computed constraint forces, in the packed storage
-  ///           format described in documentation for SolveConstraintProblem.
-  /// @param v  The system generalized velocity at time t.
-  /// @param dt The discretization time constant (i.e., the "time step" for
-  ///           simulations) used to take the system's generalized velocities
-  ///           from time t to time t + `dt`.
-  /// @param[out] generalized_acceleration The generalized acceleration, on
-  ///             return. The original will be resized (if necessary) and
-  ///             overwritten.
-  /// @warning This method uses the method `problem_data.solve_inertia()` in
-  ///          order to compute `v(t+dt)`, so the computational demands may
-  ///          be significant.
-  /// @throws std::logic_error if `generalized_acceleration` is null or
-  ///         `cf` vector is incorrectly sized.
-  /// @pre `dt` is positive.
-  static void ComputeGeneralizedAcceleration(
-      const ConstraintVelProblemData<T>& problem_data,
-      const VectorX<T>& v,
-      const VectorX<T>& cf,
-      double dt,
-      VectorX<T>* generalized_acceleration);
 
   /// Computes the system generalized acceleration due *only* to constraint
   /// forces.
@@ -553,13 +522,9 @@ class ConstraintSolver {
       const std::vector<Matrix2<T>>& contact_frames,
       std::vector<Vector2<T>>* contact_forces);
 
-  /// Gets the contact forces expressed in each contact frame *for 2D contact
-  /// problems* from a "packed" solution returned by, e.g.,
-  /// SolveImpactProblem().  If the constraint forces are impulsive, the contact
-  /// forces are impulsive (with units of Ns); similarly, if the constraint
-  /// forces are non-impulsive, the contact forces will be non-impulsive (with
-  /// units of N).
-  /// @param cf the constraint forces in packed format.
+  /// Gets the contact impulses expressed in each contact frame *for 2D contact
+  /// problems* from the "packed" solution returned by SolveImpactProblem().
+  /// @param cf the output from SolveImpactProblem()
   /// @param problem_data the problem data input to SolveImpactProblem()
   /// @param contact_frames the contact frames corresponding to the contacts.
   ///        The first column of each matrix should give the contact normal,
@@ -567,7 +532,7 @@ class ConstraintSolver {
   ///        tangent direction used to determine `problem_data.F`). All
   ///        vectors should be expressed in the global frame.
   /// @param[out] contact_forces a non-null vector of a doublet of values,
-  ///             where the iᵗʰ element represents the force along
+  ///             where the iᵗʰ element represents the impulsive force along
   ///             each basis vector in the iᵗʰ contact frame.
   /// @throws std::logic_error if `contact_forces` is null, if
   ///         `contact_forces` is not empty, if `cf` is not the
@@ -576,7 +541,7 @@ class ConstraintSolver {
   ///         the number of contact frames is not equal to the number
   ///         of contacts, or if a contact frame does not appear to be
   ///         orthonormal.
-  /// @note On return, the contact force at the iᵗʰ contact point expressed
+  /// @note On return, the contact impulse at the iᵗʰ contact point expressed
   ///       in the world frame is `contact_frames[i]` * `contact_forces[i]`.
   static void CalcContactForcesInContactFrames(
       const VectorX<T>& cf,
@@ -2308,31 +2273,6 @@ void ConstraintSolver<T>::ComputeGeneralizedForceFromConstraintForces(
       problem_data.F_transpose_mult(f_frictional) +
       problem_data.L_transpose_mult(f_limit) +
       problem_data.G_transpose_mult(f_bilat);
-}
-
-template <class T>
-void ConstraintSolver<T>::ComputeGeneralizedAcceleration(
-    const ConstraintVelProblemData<T>& problem_data,
-    const VectorX<T>& v,
-    const VectorX<T>& cf,
-    double dt,
-    VectorX<T>* generalized_acceleration) {
-  DRAKE_DEMAND(dt > 0);
-
-  // Keep from allocating storage by reusing `generalized_acceleration`; at
-  // first, it will hold the generalized force from constraint forces.
-  ComputeGeneralizedForceFromConstraintForces(problem_data, cf,
-                                              generalized_acceleration);
-
-  // Using a first-order approximation to velocity, the new velocity is:
-  // v(t+dt) = v(t) + dt * ga
-  //         = inv(M) * (M * v(t) + dt * gf)
-  // where ga is the generalized acceleration and gf is the generalized force.
-  // Note: we have no way to break apart the Mv term. But, we can instead
-  // compute v(t+dt) and then solve for the acceleration.
-  const VectorX<T> vplus = problem_data.solve_inertia(problem_data.Mv +
-      dt * (*generalized_acceleration));
-  *generalized_acceleration = (vplus - v)/dt;
 }
 
 template <class T>

--- a/multibody/constraint/test/constraint_solver_test.cc
+++ b/multibody/constraint/test/constraint_solver_test.cc
@@ -20,9 +20,10 @@ namespace multibody {
 namespace constraint {
 namespace {
 
-class Constraint2DSolverTest : public ::testing::Test {
+class Constraint2DSolverTest : public ::testing::TestWithParam<double> {
  protected:
   void SetUp() override {
+    cfm_ = GetParam();
     rod_ = std::make_unique<Rod2D<double>>(
         Rod2D<double>::SystemType::kPiecewiseDAE, 0);
     context_ = rod_->CreateDefaultContext();
@@ -45,14 +46,15 @@ class Constraint2DSolverTest : public ::testing::Test {
     vel_data_ = std::make_unique<ConstraintVelProblemData<double>>(
       num_velocities);
 
-    // Set epsilon for floating point tolerance testing; due to rounding error
-    // in the LCP solver, this is approximately the tightest tolerance with
-    // which the tests will still pass.
-    eps_ = 100 * std::numeric_limits<double>::epsilon();
+    // Set epsilon for quantities dependent on an LCP solve. Tests will fail
+    // without epsilon being this large, apparently due to the rounding error
+    // introduced by LCP solver pivoting.
+    lcp_eps_ = 300 * std::max(std::numeric_limits<double>::epsilon(), cfm_);
   }
 
   // Zero tolerance for results depending on LCP solve (< 0 indicates not set).
-  double eps_{-1};
+  double lcp_eps_{-1};
+  double cfm_{0};    // Regularization parameter.
   ConstraintSolver<double> solver_;
   std::unique_ptr<Rod2D<double>> rod_;
   std::unique_ptr<Context<double>> context_;
@@ -257,7 +259,7 @@ class Constraint2DSolverTest : public ::testing::Test {
   //        friction basis direction should be duplicated. Since the 2D tests
   //        only use one friction direction, duplication ensures that the
   //        algorithms are able to handle duplicated directions without error.
-  void CalcDiscreteTimeProblemData(
+  void CalcConstraintAccelProblemData(
       double dt,
       ConstraintVelProblemData<double>* data,
       int contact_points_dup,
@@ -311,7 +313,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     ASSERT_TRUE(zz.size() == 0 || zz.minCoeff() > -num_vars * zero_tol);
     ASSERT_TRUE(ww.size() == 0 || ww.minCoeff() > -num_vars * zero_tol);
     ASSERT_TRUE(zz.size() == 0 || max_dot < std::max(1.0, zz.maxCoeff()) *
-        std::max(1.0, ww.maxCoeff()) * num_vars * zero_tol);
+                           std::max(1.0, ww.maxCoeff()) * num_vars * zero_tol);
 
     // Compute the packed constraint forces.
     solver_.PopulatePackedConstraintForcesFromLcpSolution(
@@ -328,13 +330,6 @@ class Constraint2DSolverTest : public ::testing::Test {
         0);   // no friction directions duplicated
   }
 
-  // Computes constraint data without duplicate contacts or friction directions.
-  void CalcDiscreteTimeProblemData(
-      double dt,
-      ConstraintVelProblemData<double>* data) {
-    CalcDiscreteTimeProblemData(dt, data, 0, 0);
-  }
-
   // Computes rigid impacting contact data.
   // @param contact_points_dup the number of times (>= 0) each contact point
   //        should be duplicated in the contact data.
@@ -349,7 +344,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     DRAKE_DEMAND(contact_points_dup >= 0);
     DRAKE_DEMAND(friction_directions_dup >= 0);
 
-    // Reset constraint acceleration data.
+    // Reset constraint velocity data.
     const int num_velocities = 3;
     *data = ConstraintVelProblemData<double>(num_velocities);
 
@@ -521,11 +516,6 @@ class Constraint2DSolverTest : public ::testing::Test {
         // Set the state of the rod to resting vertically with no velocity.
         SetRodToRestingVerticalConfig();
 
-        // Construct the contact frame.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Compute the problem data.
         CalcConstraintAccelProblemData(
           accel_data_.get(), contact_dup, friction_dir_dup);
@@ -537,94 +527,87 @@ class Constraint2DSolverTest : public ::testing::Test {
         accel_data_->tau[0] += horz_f;
         accel_data_->tau[2] += horz_f * rod_->get_rod_half_length();
 
-        // Case 1: set kN as if the bodies are not accelerating into each
+        // First, set kN as if the bodies are not accelerating into each
         // other along the contact normal and verify that no contact forces
         // are applied.
-        {
-          accel_data_->kN.setOnes() *= std::fabs(grav_accel);
+        accel_data_->kN.setOnes() *= std::fabs(grav_accel);
 
-          // Compute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Compute the contact forces.
+        VectorX<double> cf;
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // Verify that no forces are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+        // Verify that no forces are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+
+        // Zero stabilization term and recompute the contact forces.
+        accel_data_->kN.setZero();
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
+
+        // Construct the contact frame.
+        std::vector<Matrix2<double>> frames;
+        for (int i = 0; i < n_contacts; ++i)
+          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
+
+        // These tests preclude friction direction duplication because
+        // CalcContactForcesInContactFrames() would throw an exception.
+        std::vector<Vector2<double>> contact_forces;
+        if (friction_dir_dup == 0) {
+          // Get the contact forces expressed in the contact frame.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
+              *accel_data_, frames, &contact_forces);
+
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), frames.size());
+
+          // Verify that the frictional forces equal the horizontal force.
+          const int total_cone_edges = std::accumulate(
+              accel_data_->r.begin(), accel_data_->r.end(), 0);
+          double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
+          EXPECT_NEAR(ffriction, -horz_f, lcp_eps_ * cf.size());
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *accel_data_, frames, &contact_forces), std::logic_error);
         }
 
-        // Case 2: zero stabilization term and recompute the contact forces.
-        {
-          accel_data_->kN.setZero();
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Verify that the generalized acceleration of the rod is equal to zero.
+        VectorX<double> ga;
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_LT(ga.norm(), lcp_eps_ * cf.size());
 
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                *accel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
-
-            // Verify that the frictional forces equal the horizontal force.
-            const int total_cone_edges = std::accumulate(
-                accel_data_->r.begin(), accel_data_->r.end(), 0);
-            double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
-            EXPECT_NEAR(ffriction, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                    *accel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Verify the generalized acceleration of the rod is equal to zero.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_LT(ga.norm(), eps_ * cf.size());
-        }
-
-        // Case 3: set kN as if the bodies are accelerating twice as hard into
+        // Now, set kN as if the bodies are accelerating twice as hard into
         // each other along the contact normal.
-        {
-          accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
+        accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
 
-          // Recompute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Recompute the contact forces.
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *accel_data_, frames, &contact_forces);
+        // These tests preclude friction direction duplication because
+        // CalcContactForcesInContactFrames() would throw an exception.
+        contact_forces.clear();
+        if (friction_dir_dup == 0) {
+          // Get the contact forces expressed in the contact frame.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *accel_data_, frames, &contact_forces);
 
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), frames.size());
 
-            // Verify that the frictional forces equal the horizontal force.
-            const int total_cone_edges = std::accumulate(
-                accel_data_->r.begin(), accel_data_->r.end(), 0);
-            double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
-            EXPECT_NEAR(ffriction, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *accel_data_, frames, &contact_forces),
-                std::logic_error);
-          }
-
-          // Verify that the generalized acceleration of the rod is equal to the
-          // gravitational acceleration.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_NEAR(ga.norm(), std::fabs(grav_accel), eps_ * cf.size());
+          // Verify that the frictional forces equal the horizontal force.
+          const int total_cone_edges = std::accumulate(
+              accel_data_->r.begin(), accel_data_->r.end(), 0);
+          double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
+          EXPECT_NEAR(ffriction, -horz_f, lcp_eps_ * cf.size());
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *accel_data_, frames, &contact_forces), std::logic_error);
         }
+
+        // Verify that the generalized acceleration of the rod is equal to the
+        // gravitational acceleration.
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_NEAR(ga.norm(), std::fabs(grav_accel), lcp_eps_ * cf.size());
       }
     }
   }
@@ -634,6 +617,9 @@ class Constraint2DSolverTest : public ::testing::Test {
   // force and sufficiently large friction coefficient, the contact should
   // remain in stiction.
   void SinglePointStickingDiscretized(bool force_applied_to_right) {
+    // Set the timestep size.
+    const double dt = 1e-8;
+
     // Set the contact to large friction. However, set_mu_static() throws an
     // exception if it is not at least as large as the Coulomb friction
     // coefficient.
@@ -650,116 +636,29 @@ class Constraint2DSolverTest : public ::testing::Test {
     // to three times.
     for (int contact_dup = 0; contact_dup < 3; ++contact_dup) {
       for (int friction_dir_dup = 0; friction_dir_dup < 4; ++friction_dir_dup) {
-        const int n_contacts = contact_dup + 1;
-
-        // Construct the contact frame.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Compute the problem data.
-        CalcDiscreteTimeProblemData(
-            dt_, vel_data_.get(), contact_dup, friction_dir_dup);
+        CalcConstraintAccelProblemData(
+          dt, vel_data_.get(), contact_dup, friction_dir_dup);
 
         // Add a force applied at the point of contact that results in a torque
         // at the rod center-of-mass.
         const double horz_f = (force_applied_to_right) ? 100 : -100;
-        vel_data_->Mv += Vector3<double>(
-            horz_f, 0, horz_f * rod_->get_rod_half_length()) * dt_;
+        vel_data_->Mv += Vector3<double>(horz_f, 0,
+            horz_f * rod_->get_rod_half_length()) * dt;
 
-        // Case 1: set kN as if the bodies are not moving into each other along
-        // the contact normal and verify that no contact forces are applied.
-        {
-          vel_data_->kN.setOnes() *= std::fabs(grav_accel) * dt_;
+        // Set kN as if the bodies are not moving into each other along the
+        // contact normal and verify that no contact forces are applied.
+        vel_data_->kN.setOnes() *= std::fabs(grav_accel);
 
-          // Compute the contact forces.
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
+        // Compute the contact forces.
+        VectorX<double> cf;
+        SolveDiscretizationProblem(*vel_data_, dt, &cf);
 
-          // Verify that no forces are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
-        }
+        // Verify that no forces are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
 
-        // Case 2: zero the stabilization term and recompute the contact forces.
-        {
-          vel_data_->kN.setZero();
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
-
-            // Verify that the frictional forces equal the horizontal force.
-            const int total_cone_edges = std::accumulate(
-                vel_data_->r.begin(), vel_data_->r.end(), 0);
-            double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
-            EXPECT_NEAR(ffriction, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Get the rod velocity.
-          const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-
-          // Verify the generalized acceleration of the rod is equal to zero.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-          EXPECT_LT(ga.norm(), eps_ * cf.size());
-        }
-
-        // Case 3: set kN as if the bodies are accelerating twice as hard into
-        // each other along the contact normal.
-        {
-          vel_data_->kN.setOnes() *= -std::fabs(grav_accel) * dt_;
-
-          // Recompute the contact forces.
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
-
-            // Verify that the frictional forces equal the applied,
-            // horizontal force.
-            const int total_cone_edges = std::accumulate(
-                vel_data_->r.begin(), vel_data_->r.end(), 0);
-            double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
-            EXPECT_NEAR(ffriction, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                    *vel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Get the rod velocity.
-          const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-
-          // Verify that the generalized acceleration of the rod is equal to
-          // the gravitational acceleration.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-          EXPECT_NEAR(ga.norm(), std::fabs(grav_accel), eps_ * cf.size());
-        }
+        // TODO(edrumwri): Do much more extensive testing with zeroed and
+        // doubled stabilization terms.
       }
     }
   }
@@ -787,11 +686,6 @@ class Constraint2DSolverTest : public ::testing::Test {
         // Set the state of the rod to resting on its side with no velocity.
         SetRodToRestingHorizontalConfig();
 
-        // Construct the contact frames.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Compute the problem data.
         CalcConstraintAccelProblemData(
             accel_data_.get(), contact_dup, friction_dir_dup);
@@ -804,104 +698,98 @@ class Constraint2DSolverTest : public ::testing::Test {
         const double horz_f = (force_applied_to_right) ? 100 : -100;
         accel_data_->tau[0] += horz_f;
 
-        // Case 1: set kN as if the bodies are not accelerating into each
+        // First, set kN as if the bodies are not accelerating into each
         // other along the contact normal and verify that no contact forces
         // are applied.
-        {
-          accel_data_->kN.setOnes() *= std::fabs(grav_accel);
+        accel_data_->kN.setOnes() *= std::fabs(grav_accel);
 
-          // Compute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Compute the contact forces.
+        VectorX<double> cf;
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // Verify that no forces are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
-        }
+        // Verify that no forces are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
 
-        // Case 2: zero stabilization term and recompute the contact forces.
-        {
-          accel_data_->kN.setZero();
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Zero stabilization term and recompute the contact forces.
+        accel_data_->kN.setZero();
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // Do this next part *only* if the friction directions are not
-          // duplicated (which would cause an exception to be thrown).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frames.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                *accel_data_, frames, &contact_forces);
+        // Construct the contact frames.
+        std::vector<Matrix2<double>> frames;
+        for (int i = 0; i < n_contacts; ++i)
+          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
 
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), n_contacts);
+        // Do this next part *only* if the friction directions are not
+        // duplicated (which would cause an exception to be thrown).
+        std::vector<Vector2<double>> contact_forces;
+        if (friction_dir_dup == 0) {
+          // Get the contact forces expressed in the contact frames.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
+              *accel_data_, frames, &contact_forces);
 
-            // Verify that the normal forces equal the gravitational force.
-            // Normal forces are in the first component of each vector.
-            // Frictional forces are in the second component of each vector.
-            const double mg = rod_->get_rod_mass() *
-                std::fabs(rod_->get_gravitational_acceleration());
-            double normal_force_mag = 0;
-            double fric_force = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-              normal_force_mag += contact_forces[i][0];
-              fric_force += contact_forces[i][1];
-            }
-            EXPECT_NEAR(normal_force_mag, mg, eps_ * cf.size());
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), n_contacts);
 
-            // Verify that the negation of the frictional forces equal the
-            // horizontal forces.
-            EXPECT_NEAR(fric_force, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *accel_data_, frames, &contact_forces),
-                std::logic_error);
+          // Verify that the normal forces equal the gravitational force.
+          // Normal forces are in the first component of each vector.
+          // Frictional forces are in the second component of each vector.
+          const double mg = rod_->get_rod_mass() *
+            std::fabs(rod_->get_gravitational_acceleration());
+          double normal_force_mag = 0;
+          double fric_force = 0;
+          for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            normal_force_mag += contact_forces[i][0];
+            fric_force += contact_forces[i][1];
           }
+          EXPECT_NEAR(normal_force_mag, mg, lcp_eps_ * cf.size());
 
-          // Verify the generalized acceleration of the rod is equal to zero.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_LT(ga.norm(), eps_ * cf.size());
-        }
-
-        // Case 3: set kN as if the bodies are accelerating twice as hard into
-        // each other along the contact normal.
-        {
-          accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
-
-          // Recompute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
-
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
+          // Verify that the negation of the frictional forces equal the
+          // horizontal forces.
+          EXPECT_NEAR(fric_force, -horz_f, lcp_eps_ * cf.size());
+        } else {
+        EXPECT_THROW(
             ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *accel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
-
-            // Verify that the frictional forces equal the horizontal force.
-            const int total_cone_edges = std::accumulate(
-                accel_data_->r.begin(), accel_data_->r.end(), 0);
-            double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
-            EXPECT_NEAR(ffriction, -horz_f, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                    *accel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Verify that the generalized acceleration of the rod is equal to the
-          // gravitational acceleration.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_NEAR(ga.norm(), std::fabs(grav_accel), eps_ * cf.size());
+              cf, *accel_data_, frames, &contact_forces), std::logic_error);
         }
+
+        // Verify that the generalized acceleration of the rod is equal to zero.
+        VectorX<double> ga;
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_LT(ga.norm(), lcp_eps_ * cf.size());
+
+        // Now, set kN as if the bodies are accelerating twice as hard into
+        // each other along the contact normal.
+        accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
+
+        // Recompute the contact forces.
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
+
+        // These tests preclude friction direction duplication because
+        // CalcContactForcesInContactFrames() would throw an exception.
+        contact_forces.clear();
+        if (friction_dir_dup == 0) {
+          // Get the contact forces expressed in the contact frame.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *accel_data_, frames, &contact_forces);
+
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), frames.size());
+
+          // Verify that the frictional forces equal the horizontal force.
+          const int total_cone_edges = std::accumulate(
+              accel_data_->r.begin(), accel_data_->r.end(), 0);
+          double ffriction = cf.segment(n_contacts, total_cone_edges).sum();
+          EXPECT_NEAR(ffriction, -horz_f, lcp_eps_ * cf.size());
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *accel_data_, frames, &contact_forces), std::logic_error);
+        }
+
+        // Verify that the generalized acceleration of the rod is equal to the
+        // gravitational acceleration.
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_NEAR(ga.norm(), std::fabs(grav_accel), lcp_eps_ * cf.size());
       }
     }
   }
@@ -928,11 +816,6 @@ class Constraint2DSolverTest : public ::testing::Test {
         // Set the state of the rod to resting on its side with no velocity.
         SetRodToRestingHorizontalConfig();
 
-        // Construct the contact frames.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Compute the problem data.
         CalcConstraintAccelProblemData(
             accel_data_.get(), contact_dup, friction_dir_dup);
@@ -941,250 +824,99 @@ class Constraint2DSolverTest : public ::testing::Test {
         const double horz_f = (applied_to_right) ? 100.0 : -100;
         accel_data_->tau[0] += horz_f;
 
-        // Case 1: set kN as if the bodies are not accelerating into each
+        // First, set kN as if the bodies are not accelerating into each
         // other along the contact normal and verify that no contact forces
         // are applied.
-        {
-          accel_data_->kN.setOnes() *= std::fabs(grav_accel);
+        accel_data_->kN.setOnes() *= std::fabs(grav_accel);
 
-          // Compute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
+        // Compute the contact forces.
+        VectorX<double> cf;
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // Verify that no forces are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
-        }
+        // Verify that no forces are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
 
-        // Case 2: zero stabilization term and recompute the contact forces.
-        {
-          accel_data_->kN.setZero();
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
-
-          // Get the contact forces expressed in the contact frames *only*
-          // if the friction directions are not duplicated (which would cause an
-          // exception to be thrown).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            EXPECT_TRUE(accel_data_->sliding_contacts.empty());
-
-            // Get the contact forces expressed in the contact frames.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *accel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), n_contacts);
-
-            // Verify that the frictional forces are maximized.
-            double fnormal = 0;
-            double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-              fnormal += contact_forces[i][0];
-              ffrictional += std::fabs(contact_forces[i][1]);
-            }
-            EXPECT_NEAR(ffrictional, mu_static * fnormal, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *accel_data_, frames, &contact_forces),
-                std::logic_error);
-          }
-
-          // Verify that the horizontal acceleration is in the appropriate
-          // direction.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
-        }
-
-        // Case 3: now, set kN as if the bodies are accelerating twice as hard
-        // into each other along the contact normal.
-        {
-          accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
-
-          // Recompute the contact forces.
-          VectorX<double> cf;
-          solver_.SolveConstraintProblem(*accel_data_, &cf);
-
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *accel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
-
-            // Verify that the frictional forces are maximized.
-            double fnormal = 0;
-            double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-              fnormal += contact_forces[i][0];
-              ffrictional += std::fabs(contact_forces[i][1]);
-            }
-            EXPECT_NEAR(ffrictional, mu_static * fnormal, eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-                    *accel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Verify that the vertical acceleration of the rod is equal to the
-          // gravitational acceleration and that the horizontal acceleration is
-          // in the appropriate direction.
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-          EXPECT_NEAR(ga[1], std::fabs(grav_accel), eps_ * cf.size());
-          EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
-        }
-      }
-    }
-  }
-
-  // Tests the rod in a two-point contact configuration, without sliding
-  // occurring at either contact point, that will transition to sliding from the
-  // external force (applied toward the right or the left, as specified).
-  void TwoPointNonSlidingToSlidingDiscretized(bool applied_to_right) {
-    // Set the contact to large friction.
-    const double mu_static = 0.1;
-    rod_->set_mu_coulomb(mu_static);
-    rod_->set_mu_static(mu_static);
-
-    // Get the acceleration due to gravity.
-    const double grav_accel = rod_->get_gravitational_acceleration();
-
-    // Duplicate contact points up to two times and the friction directions up
-    // to three times.
-    for (int contact_dup = 0; contact_dup < 3; ++contact_dup) {
-      for (int friction_dir_dup = 0; friction_dir_dup < 4; ++friction_dir_dup) {
-        const int n_contacts = 2 * (1 + contact_dup);
-
-        // Set the state of the rod to resting on its side with zero velocity.
-        SetRodToRestingHorizontalConfig();
+        // Zero stabilization term and recompute the contact forces.
+        accel_data_->kN.setZero();
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
         // Construct the contact frames.
         std::vector<Matrix2<double>> frames;
         for (int i = 0; i < n_contacts; ++i)
           frames.push_back(GetNonSlidingContactFrameToWorldTransform());
 
-        // Compute the problem data.
-        CalcDiscreteTimeProblemData(
-            dt_, vel_data_.get(), contact_dup, friction_dir_dup);
+        // Get the contact forces expressed in the contact frames *only*
+        // if the friction directions are not duplicated (which would cause an
+        // exception to be thrown).
+        std::vector<Vector2<double>> contact_forces;
+        if (friction_dir_dup == 0) {
+          EXPECT_TRUE(accel_data_->sliding_contacts.empty());
 
-        // Add a force pulling the rod horizontally.
-        const double horz_f = (applied_to_right) ? 100.0 : -100;
-        vel_data_->Mv[0] += horz_f * dt_;
+          // Get the contact forces expressed in the contact frames.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *accel_data_, frames, &contact_forces);
 
-        // Case 1: set kN as if the bodies are not accelerating into each
-        // other along the contact normal and verify that no contact forces
-        // are applied.
-        {
-          vel_data_->kN.setOnes() *= std::fabs(grav_accel) * dt_;
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), n_contacts);
 
-          // Compute the contact forces.
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-          // Verify that no forces are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
-        }
-
-        // Case 2: zero stabilization term and recompute the contact forces.
-        {
-          vel_data_->kN.setZero();
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-          // Get the contact forces expressed in the contact frames *only*
-          // if the friction directions are not duplicated (which would cause an
-          // exception to be thrown).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frames.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), n_contacts);
-
-            // Get the expected sign of the frictional forces.
-            const double ff_sign = (applied_to_right) ? -1.0 : 1.0;
-
-            // Verify that the frictional forces are maximized and in the
-            // correct direction.
-            double fnormal = 0;
-            double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-              fnormal += contact_forces[i][0];
-              ffrictional += contact_forces[i][1];
-              EXPECT_NEAR(ffrictional * ff_sign, mu_static * fnormal,
-                          eps_ * cf.size());
-            }
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_forces), std::logic_error);
+          // Verify that the frictional forces are maximized.
+          double fnormal = 0;
+          double ffrictional = 0;
+          for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            fnormal += contact_forces[i][0];
+            ffrictional += std::fabs(contact_forces[i][1]);
           }
-
-          // Verify that the horizontal acceleration is in the appropriate
-          // direction.
-          const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-          EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
+          EXPECT_NEAR(ffrictional, mu_static * fnormal, lcp_eps_ * cf.size());
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *accel_data_, frames, &contact_forces), std::logic_error);
         }
 
-        // Case 3: set kN as if the bodies are accelerating twice as hard into
+        // Verify that the horizontal acceleration is in the appropriate
+        // direction.
+        VectorX<double> ga;
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
+
+        // Now, set kN as if the bodies are accelerating twice as hard into
         // each other along the contact normal.
-        {
-          vel_data_->kN.setOnes() *= -std::fabs(grav_accel) * dt_;
+        accel_data_->kN.setOnes() *= -std::fabs(grav_accel);
 
-          // Recompute the contact forces.
-          VectorX<double> cf;
-          SolveDiscretizationProblem(*vel_data_, dt_, &cf);
+        // Recompute the contact forces.
+        solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-          // The primary test below is conducted when there is no friction
-          // direction duplication because CalcContactForcesInContactFrames()
-          // would throw an exception (the secondary test looks for this case).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            // Get the contact forces expressed in the contact frame.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_forces);
+        // These tests preclude friction direction duplication because
+        // CalcContactForcesInContactFrames() would throw an exception.
+        contact_forces.clear();
+        if (friction_dir_dup == 0) {
+          // Get the contact forces expressed in the contact frame.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *accel_data_, frames, &contact_forces);
 
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), frames.size());
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), frames.size());
 
-            // Get the sign of the force application.
-            const double ff_sign = (applied_to_right) ? -1.0 : 1.0;
-
-            // Verify that the frictional forces are maximized.
-            double fnormal = 0;
-            double ffrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-              fnormal += contact_forces[i][0];
-              ffrictional += contact_forces[i][1];
-            }
-            EXPECT_NEAR(ff_sign * ffrictional, mu_static * fnormal,
-                        eps_ * cf.size());
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_forces), std::logic_error);
+          // Verify that the frictional forces are maximized.
+          double fnormal = 0;
+          double ffrictional = 0;
+          for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+            fnormal += contact_forces[i][0];
+            ffrictional += std::fabs(contact_forces[i][1]);
           }
-
-          // Verify that the vertical acceleration of the rod is equal to the
-          // gravitational acceleration and that the horizontal acceleration is
-          // in the appropriate direction.
-          const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-          VectorX<double> ga;
-          solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-          EXPECT_NEAR(ga[1], std::fabs(grav_accel), eps_ * cf.size());
-          EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
+          EXPECT_NEAR(ffrictional, mu_static * fnormal, lcp_eps_ * cf.size());
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *accel_data_, frames, &contact_forces), std::logic_error);
         }
+
+        // Verify that the vertical acceleration of the rod is equal to the
+        // gravitational acceleration and that the horizontal acceleration is
+        // in the appropriate direction.
+        solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+        EXPECT_NEAR(ga[1], std::fabs(grav_accel), lcp_eps_ * cf.size());
+        EXPECT_GT((applied_to_right) ? ga[0] : -ga[0], 0);
       }
     }
   }
@@ -1203,11 +935,6 @@ class Constraint2DSolverTest : public ::testing::Test {
       for (int friction_dir_dup = 0; friction_dir_dup < 4; ++friction_dir_dup) {
         const int n_contacts = 2 * (contact_dup + 1);
 
-        // Construct the contact frames.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Set the configuration of the rod to lying on its side and impacting.
         SetRodToSlidingImpactingHorizontalConfig(sliding_to_right);
 
@@ -1215,116 +942,103 @@ class Constraint2DSolverTest : public ::testing::Test {
         const double vert_vel = context_->get_continuous_state().
             CopyToVector()[4];
 
-        // Set the sign of the sliding direction.
-        const double sign = (sliding_to_right) ? 1 : -1;
-
         // Compute the problem data.
         CalcConstraintProblemDataForImpact(
            vel_data_.get(), contact_dup, friction_dir_dup);
 
         // Get the generalized velocity of the rod.
-        const VectorX<double> v0 = vel_data_->solve_inertia(vel_data_->Mv);
+        const VectorX<double> v = vel_data_->solve_inertia(vel_data_->Mv);
 
-        // Case 1: set kN as if the bodies are not moving toward each
+        // First, set kN as if the bodies are not moving toward each
         // other along the contact normal and verify that no contact forces
         // are applied.
-        {
-          vel_data_->kN.setOnes() *= -vert_vel;
+        vel_data_->kN.setOnes() *= -vert_vel;
 
-          // Compute the contact impulses.
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Compute the contact impulses.
+        VectorX<double> cf;
+        solver_.SolveImpactProblem(*vel_data_, &cf);
 
-          // Verify that no impulses are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+        // Verify that no impulses are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+
+        // Zero stabilization term and recompute the contact impulses.
+        vel_data_->kN.setZero();
+        solver_.SolveImpactProblem(*vel_data_, &cf);
+
+        // Construct the contact frames.
+        std::vector<Matrix2<double>> frames;
+        for (int i = 0; i < n_contacts; ++i)
+          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
+
+        // Get the impact forces expressed in the contact frames *only*
+        // if the friction directions are not duplicated (which would cause an
+        // exception to be thrown).
+        std::vector<Vector2<double>> contact_impulses;
+        if (friction_dir_dup == 0) {
+          // Get the contact impulses expressed in the contact frames.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *vel_data_, frames, &contact_impulses);
+
+           // Verify that the number of contact impulse vectors is correct.
+           ASSERT_EQ(contact_impulses.size(), n_contacts);
+
+           // Verify that the frictional impulses are maximized.
+           double jnormal = 0;
+           double jfrictional = 0;
+           for (int i = 0; i < static_cast<int>(contact_impulses.size()); ++i) {
+             jnormal += contact_impulses[i][0];
+             jfrictional += std::fabs(contact_impulses[i][1]);
+           }
+           EXPECT_NEAR(jfrictional, mu * jnormal, lcp_eps_);
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *vel_data_, frames, &contact_impulses), std::logic_error);
         }
 
-        // Case 2: zero stabilization term and recompute the contact impulses.
-        {
-          vel_data_->kN.setZero();
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Verify that the horizontal velocity is in the proper direction.
+        VectorX<double> dgv;
+        solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
+        const double sign = (sliding_to_right) ? 1 : -1;
+        EXPECT_GT(sign * v[0] + dgv[0], 0);
 
-          // Get the sign of the force application.
-          const double ff_sign = (sliding_to_right) ? -1.0 : 1.0;
-
-          // Get the impact forces expressed in the contact frames *only*
-          // if the friction directions are not duplicated (which would cause an
-          // exception to be thrown).
-          std::vector<Vector2<double>> contact_impulses;
-          if (friction_dir_dup == 0) {
-            // Get the contact impulses expressed in the contact frames.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_impulses);
-
-            // Verify that the number of contact impulse vectors is correct.
-            ASSERT_EQ(contact_impulses.size(), n_contacts);
-
-            // Verify that the frictional impulses are maximized.
-            double jnormal = 0;
-            double jfrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_impulses.size());
-                 ++i) {
-              jnormal += contact_impulses[i][0];
-              jfrictional += contact_impulses[i][1];
-              EXPECT_NEAR(ff_sign * jfrictional, mu * jnormal, eps_);
-            }
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_impulses),
-                std::logic_error);
-          }
-
-          // Verify that the horizontal velocity is in the proper direction.
-          VectorX<double> dgv;
-          solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
-          EXPECT_GT(sign * v0[0] + dgv[0], 0);
-        }
-
-        // Case 3: set kN as if the bodies are moving twice as fast into
+        // Now, set kN as if the bodies are moving twice as fast into
         // each other along the contact normal.
-        {
-          vel_data_->kN.setOnes() *= vert_vel;
+        vel_data_->kN.setOnes() *= vert_vel;
 
-          // Recompute the contact impulses.
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Recompute the contact impulses.
+        solver_.SolveImpactProblem(*vel_data_, &cf);
 
-          // Get the impact forces expressed in the contact frames if the
-          // friction directions are not duplicated.
-          std::vector<Vector2<double>> contact_impulses;
-          if (friction_dir_dup == 0) {
-            // Get the contact impulses expressed in the contact frames.
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_impulses);
+        // Get the impact forces expressed in the contact frames if the
+        // friction directions are not duplicated.
+        contact_impulses.clear();
+        if (friction_dir_dup == 0) {
+          // Get the contact impulses expressed in the contact frames.
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *vel_data_, frames, &contact_impulses);
 
-            // Verify that the number of contact impulse vectors is correct.
-            ASSERT_EQ(contact_impulses.size(), n_contacts);
+          // Verify that the number of contact impulse vectors is correct.
+          ASSERT_EQ(contact_impulses.size(), n_contacts);
 
-            // Verify that the frictional impulses are maximized.
-            double jnormal = 0;
-            double jfrictional = 0;
-            for (int i = 0; i < static_cast<int>(contact_impulses.size());
-                 ++i) {
-              jnormal += contact_impulses[i][0];
-              jfrictional += std::fabs(contact_impulses[i][1]);
-            }
-            EXPECT_NEAR(jfrictional, mu * jnormal, eps_);
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_impulses),
-                std::logic_error);
+          // Verify that the frictional impulses are maximized.
+          double jnormal = 0;
+          double jfrictional = 0;
+          for (int i = 0; i < static_cast<int>(contact_impulses.size()); ++i) {
+            jnormal += contact_impulses[i][0];
+            jfrictional += std::fabs(contact_impulses[i][1]);
           }
-
-          // Verify that the horizontal velocity is in the proper direction and
-          // that the vertical velocity is essentially reversed.
-          VectorX<double> dgv;
-          solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
-          EXPECT_GT(sign * v0[0] + dgv[0], 0);
-          EXPECT_NEAR(v0[1] + dgv[1], -v0[1], eps_);
+          EXPECT_NEAR(jfrictional, mu * jnormal, lcp_eps_);
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *vel_data_, frames, &contact_impulses), std::logic_error);
         }
+
+        // Verify that the horizontal velocity is in the proper direction and
+        // that the vertical velocity is essentially reversed.
+        solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
+        EXPECT_GT(sign * v[0] + dgv[0], 0);
+        EXPECT_NEAR(v[1] + dgv[1], -v[1], lcp_eps_);
       }
     }
   }
@@ -1345,11 +1059,6 @@ class Constraint2DSolverTest : public ::testing::Test {
         // velocity and horizontally moving velocity.
         SetRodToSlidingImpactingHorizontalConfig(sliding_to_right);
 
-        // Construct the contact frames.
-        std::vector<Matrix2<double>> frames;
-        for (int i = 0; i < n_contacts; ++i)
-          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
         // Get the vertical velocity of the rod.
         const double vert_vel = context_->get_continuous_state().
             CopyToVector()[4];
@@ -1359,81 +1068,77 @@ class Constraint2DSolverTest : public ::testing::Test {
             vel_data_.get(), contact_dup, friction_dir_dup);
 
         // Get the generalized velocity of the rod.
-        const VectorX<double> v0 = vel_data_->solve_inertia(vel_data_->Mv);
+        const VectorX<double> v = vel_data_->solve_inertia(vel_data_->Mv);
 
-        // Case 1: set kN as if the bodies are not moving toward each
+        // First, set kN as if the bodies are not moving toward each
         // other along the contact normal and verify that no contact forces
         // are applied.
-        {
-          vel_data_->kN.setOnes() *= -vert_vel;
+        vel_data_->kN.setOnes() *= -vert_vel;
 
-          // Compute the contact impulses.
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Compute the contact impulses.
+        VectorX<double> cf;
+        solver_.SolveImpactProblem(*vel_data_, &cf);
 
-          // Verify that no impulses are applied.
-          EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+        // Verify that no impulses are applied.
+        EXPECT_LT(cf.norm(), std::numeric_limits<double>::epsilon());
+
+        // Zero stabilization term and recompute the contact impulses.
+        vel_data_->kN.setZero();
+        solver_.SolveImpactProblem(*vel_data_, &cf);
+
+        // Construct the contact frames.
+        std::vector<Matrix2<double>> frames;
+        for (int i = 0; i < n_contacts; ++i)
+          frames.push_back(GetNonSlidingContactFrameToWorldTransform());
+
+        // Verify that the x-axis of the contact frame, which corresponds to the
+        // contact normal, points along the world y-axis, and the y-axis of the
+        // contact frame, which corresponds to a contact tangent vector, points
+        // along the world x-axis.
+        for (int i = 0; i < static_cast<int>(frames.size()); ++i) {
+          EXPECT_LT(
+              std::fabs(frames[i].col(0).dot(Vector2<double>::UnitY()) - 1.0),
+              std::numeric_limits<double>::epsilon());
+          EXPECT_LT(
+              std::fabs(frames[i].col(1).dot(Vector2<double>::UnitX()) - 1.0),
+              std::numeric_limits<double>::epsilon());
         }
 
-        // Case 2: zero stabilization term and recompute the contact impulses.
-        {
-          vel_data_->kN.setZero();
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Get the impulsive contact forces expressed in the contact frames
+        // *only* if the friction directions are not duplicated (which would
+        // cause an exception to be thrown).
+        std::vector<Vector2<double>> contact_forces;
+        if (friction_dir_dup == 0) {
+          ConstraintSolver<double>::CalcContactForcesInContactFrames(
+              cf, *vel_data_, frames, &contact_forces);
 
-          // Verify that the x-axis of the contact frame, which corresponds to
-          // the contact normal, points along the world y-axis, and the y-axis
-          //  of the contact frame, which corresponds to a contact tangent
-          // vector, points along the world x-axis.
-          for (int i = 0; i < static_cast<int>(frames.size()); ++i) {
-            EXPECT_LT(
-                std::fabs(frames[i].col(0).dot(Vector2<double>::UnitY()) - 1.0),
-                std::numeric_limits<double>::epsilon());
-            EXPECT_LT(
-                std::fabs(frames[i].col(1).dot(Vector2<double>::UnitX()) - 1.0),
-                std::numeric_limits<double>::epsilon());
-          }
-
-          // Get the impulsive contact forces expressed in the contact frames
-          // *only* if the friction directions are not duplicated (which would
-          // cause an exception to be thrown).
-          std::vector<Vector2<double>> contact_forces;
-          if (friction_dir_dup == 0) {
-            ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                cf, *vel_data_, frames, &contact_forces);
-
-            // Verify that the number of contact force vectors is correct.
-            ASSERT_EQ(contact_forces.size(), n_contacts);
-          } else {
-            EXPECT_THROW(
-                ConstraintSolver<double>::CalcContactForcesInContactFrames(
-                    cf, *vel_data_, frames, &contact_forces), std::logic_error);
-          }
-
-          // Verify that the generalized velocity of the rod is equal to zero.
-          VectorX<double> dgv;
-          solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
-          EXPECT_LT((v0 + dgv).norm(), eps_);
+          // Verify that the number of contact force vectors is correct.
+          ASSERT_EQ(contact_forces.size(), n_contacts);
+        } else {
+          EXPECT_THROW(
+              ConstraintSolver<double>::CalcContactForcesInContactFrames(
+                  cf, *vel_data_, frames, &contact_forces), std::logic_error);
         }
 
-        // Case 3: set kN as if the bodies are moving twice as fast into
+        // Verify that the generalized velocity of the rod is equal to zero.
+        VectorX<double> dgv;
+        solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
+        EXPECT_LT((v + dgv).norm(), lcp_eps_);
+
+        // Now, set kN as if the bodies are moving twice as fast into
         // each other along the contact normal.
-        {
-          vel_data_->kN.setOnes() *= vert_vel;
+        vel_data_->kN.setOnes() *= vert_vel;
 
-          // Recompute the contact impulses.
-          VectorX<double> cf;
-          solver_.SolveImpactProblem(*vel_data_, &cf);
+        // Recompute the contact impulses.
+        solver_.SolveImpactProblem(*vel_data_, &cf);
 
-          // Verify that all components of the generalized velocity of the rod
-          // except that corresponding to the vertical motion are equal to zero;
-          // the vertical motion should oppose the initial vertical motion.
-          VectorX<double> dgv;
-          solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
-          EXPECT_LT((v0[0] + dgv[0]), eps_);
-          EXPECT_NEAR((v0[1] + dgv[1]), -vert_vel, eps_);
-          EXPECT_LT((v0[2] + dgv[2]), eps_);
-        }
+        // Verify that all components of the generalized velocity of the rod
+        // except that corresponding to the vertical motion are equal to zero;
+        // the vertical motion should oppose the initial vertical motion.
+        solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dgv);
+        EXPECT_LT((v[0] + dgv[0]), lcp_eps_);
+        EXPECT_NEAR((v[1] + dgv[1]), -vert_vel, lcp_eps_);
+        EXPECT_LT((v[2] + dgv[2]), lcp_eps_);
       }
     }
   }
@@ -1441,8 +1146,6 @@ class Constraint2DSolverTest : public ::testing::Test {
   // Tests the rod in a sliding configuration with sliding velocity as
   // specified. If `upright` is true, then the rod makes contact at a single
   // point. Otherwise, it will be on its side and make contact at two points.
-  // The fully upright and on-side configurations permit readily predicting
-  // the requisite force(s) and motion.
   void Sliding(bool sliding_to_right, bool upright, bool use_lcp_solver) {
     if (upright) {
       SetRodToRestingVerticalConfig();
@@ -1463,178 +1166,70 @@ class Constraint2DSolverTest : public ::testing::Test {
     CalcConstraintAccelProblemData(accel_data_.get());
     accel_data_->use_complementarity_problem_solver = use_lcp_solver;
 
-    // Case 1: counteract the acceleration from gravity using the kN term.
-    {
-      accel_data_->kN.setOnes() *= -grav_accel;
+    // First, counteract the acceleration from gravity using the kN term.
+    accel_data_->kN.setOnes() *= -grav_accel;
 
-      // Compute the contact forces.
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
+    // Compute the contact forces.
+    VectorX<double> cf;
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-      // Verify that no forces were applied.
-      EXPECT_LT(cf.norm(), eps_);
-    }
+    // Verify that no forces were applied.
+    EXPECT_LT(cf.norm(), lcp_eps_);
 
-    // Case 2: zero out the kN term and try again.
-    {
-      accel_data_->kN.setZero();
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
+    // Zero out the kN term and try again.
+    accel_data_->kN.setZero();
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-      // Get the contact tangent velocities.
-      std::vector<Vector2d> contacts;
-      std::vector<double> tangent_vels;
-      rod_->GetContactPoints(*context_, &contacts);
-      rod_->GetContactPointsTangentVelocities(*context_,
-                                              contacts,
-                                              &tangent_vels);
+    // Get the contact tangent velocities.
+    std::vector<Vector2d> contacts;
+    std::vector<double> tangent_vels;
+    rod_->GetContactPoints(*context_, &contacts);
+    rod_->GetContactPointsTangentVelocities(*context_, contacts, &tangent_vels);
 
-      // Construct the contact frame(s).
-      std::vector<Matrix2<double>> frames;
+    // Construct the contact frame(s).
+    std::vector<Matrix2<double>> frames;
+    frames.push_back(
+       GetSlidingContactFrameToWorldTransform(tangent_vels.front()));
+    if (!upright) {
       frames.push_back(
-          GetSlidingContactFrameToWorldTransform(tangent_vels.front()));
-      if (!upright) {
-        frames.push_back(
-            GetSlidingContactFrameToWorldTransform(tangent_vels.back()));
-      }
-
-      // Get the contact forces expressed in the contact frame.
-      std::vector<Vector2<double>> contact_forces;
-      ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
-          *accel_data_, frames, &contact_forces);
-
-      // Verify that the number of contact force vectors is correct.
-      ASSERT_EQ(contact_forces.size(), frames.size());
-
-      // Verify that there are no non-sliding frictional forces.
-      EXPECT_TRUE(accel_data_->non_sliding_contacts.empty());
-      const int nc = accel_data_->sliding_contacts.size();
-      EXPECT_EQ(cf.size(), nc);
-
-      // Verify that the normal contact forces exactly oppose gravity (the
-      // frictional forces should be zero).
-      const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
-          rod_->get_rod_mass();
-      double fN = 0, fF = 0;
-      for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-        fN += contact_forces[i][0];
-        fF += std::fabs(contact_forces[i][1]);
-      }
-      EXPECT_NEAR(fN, mg, eps_);
-      EXPECT_NEAR(fF, 0, eps_);
+          GetSlidingContactFrameToWorldTransform(tangent_vels.back()));
     }
 
-    // Case 3: set the kN term to indicate that the rod is accelerating downward
+    // Get the contact forces expressed in the contact frame.
+    std::vector<Vector2<double>> contact_forces;
+    ConstraintSolver<double>::CalcContactForcesInContactFrames(cf,
+        *accel_data_, frames, &contact_forces);
+
+    // Verify that the number of contact force vectors is correct.
+    ASSERT_EQ(contact_forces.size(), frames.size());
+
+    // Verify that there are no non-sliding frictional forces.
+    EXPECT_TRUE(accel_data_->non_sliding_contacts.empty());
+    const int nc = accel_data_->sliding_contacts.size();
+    EXPECT_EQ(cf.size(), nc);
+
+    // Verify that the normal contact forces exactly oppose gravity (the
+    // frictional forces should be zero).
+    const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
+        rod_->get_rod_mass();
+    double fN = 0, fF = 0;
+    for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
+      fN += contact_forces[i][0];
+      fF += std::fabs(contact_forces[i][1]);
+    }
+    EXPECT_NEAR(fN, mg, lcp_eps_);
+    EXPECT_NEAR(fF, 0, lcp_eps_);
+
+    // Now, set the kN term to indicate that the rod is accelerating downward
     // with twice the gravitational acceleration.
-    {
-      accel_data_->kN.setOnes() *= grav_accel;
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
+    accel_data_->kN.setOnes() *= grav_accel;
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-      // Verify that the normal component of the generalized acceleration is now
-      // equal to the negated gravitational acceleration.
-      VectorX<double> ga;
-      solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-      EXPECT_NEAR(ga[1], -grav_accel, eps_);
-    }
-  }
-
-  // Tests the rod in a sliding configuration with sliding velocity as
-  // specified. If `upright` is true, then the rod makes contact at a single
-  // point. Otherwise, it will be on its side and make contact at two points.
-  // The fully upright and on-side configurations permit readily predicting
-  // the requisite force(s) and motion.
-  void SlidingDiscretized(bool sliding_to_right, bool upright) {
-    if (upright) {
-      SetRodToRestingVerticalConfig();
-    } else {
-      // Set the state of the rod to resting on its side w/ horizontal velocity.
-      SetRodToRestingHorizontalConfig();
-    }
-    ContinuousState<double>& xc = context_->get_mutable_continuous_state();
-    xc[3] = (sliding_to_right) ? 1 : -1;
-
-    // Get the gravitational acceleration.
-    const double grav_accel = rod_->get_gravitational_acceleration();
-
-    // Set the coefficient of friction to zero. Note that a test that uses
-    // a non-zero coefficient of friction with sliding is
-    // SlidingPlusBilateralDiscretized().
-    rod_->set_mu_coulomb(0.0);
-
-    // Compute the problem data.
-    const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-    CalcDiscreteTimeProblemData(dt_, vel_data_.get());
-
-    // Case 1: counteract the acceleration from gravity using the kN term.
-    {
-      vel_data_->kN.setOnes() *= -grav_accel * dt_;
-
-      // Compute the contact forces.
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-      // Verify that no forces were applied.
-      EXPECT_LT(cf.norm(), eps_);
-    }
-
-    // Case 2: zero out the kN term and try again.
-    {
-      vel_data_->kN.setZero();
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-      // Get the contact tangent velocities.
-      std::vector<Vector2d> contacts;
-      std::vector<double> tangent_vels;
-      rod_->GetContactPoints(*context_, &contacts);
-      rod_->GetContactPointsTangentVelocities(*context_,
-                                              contacts,
-                                              &tangent_vels);
-
-      // Construct the contact frame(s).
-      std::vector<Matrix2<double>> frames;
-      frames.push_back(
-          GetSlidingContactFrameToWorldTransform(tangent_vels.front()));
-      if (!upright) {
-        frames.push_back(
-            GetSlidingContactFrameToWorldTransform(tangent_vels.back()));
-      }
-
-      // Get the contact forces expressed in the contact frame.
-      std::vector<Vector2<double>> contact_forces;
-      ConstraintSolver<double>::CalcContactForcesInContactFrames(
-          cf, *vel_data_, frames, &contact_forces);
-
-      // Verify that the number of contact force vectors is correct.
-      ASSERT_EQ(contact_forces.size(), frames.size());
-
-      // Verify that the normal contact forces exactly oppose gravity (the
-      // frictional forces should be zero).
-      const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
-          rod_->get_rod_mass();
-      double fN = 0, fF = 0;
-      for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-        fN += contact_forces[i][0];
-        fF += std::fabs(contact_forces[i][1]);
-      }
-      EXPECT_NEAR(fN, mg, eps_);
-      EXPECT_NEAR(fF, 0, eps_);
-    }
-
-    // Case 3: set the kN term to indicate that the rod is accelerating downward
-    // with twice the gravitational acceleration.
-    {
-      vel_data_->kN.setOnes() *= grav_accel * dt_;
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-      // Verify that the normal component of the generalized acceleration is now
-      // equal to the negated gravitational acceleration.
-      VectorX<double> ga;
-      solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-      EXPECT_NEAR(ga[1], -grav_accel, eps_);
-    }
+    // Verify that the normal component of the generalized acceleration is now
+    // equal to the negated gravitational acceleration.
+    VectorX<double> ga;
+    solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
+    EXPECT_NEAR(ga[1], -grav_accel, lcp_eps_);
   }
 
   // Tests the rod in an upright sliding configuration with sliding velocity as
@@ -1713,15 +1308,15 @@ class Constraint2DSolverTest : public ::testing::Test {
       fN += contact_forces[i][0];
       fF += contact_forces[i][1];
     }
-    EXPECT_NEAR(fN, mg, eps_);
+    EXPECT_NEAR(fN, mg, lcp_eps_);
     EXPECT_LT(fF, 0);
-    EXPECT_NEAR(fF, -mg * rod_->get_mu_coulomb(), eps_);
+    EXPECT_NEAR(fF, -mg * rod_->get_mu_coulomb(), lcp_eps_);
 
     // Get the generalized acceleration and verify that there is no angular
     // acceleration.
     VectorX<double> ga;
     solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-    EXPECT_LT(ga[2], eps_ * cf.size());
+    EXPECT_LT(ga[2], lcp_eps_ * cf.size());
 
     // Indicate through modification of the kG term that the system already has
     // angular velocity (which violates our desire to constrain the
@@ -1729,7 +1324,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     accel_data_->kG[0] = 1.0;    // Indicate a ccw angular motion..
     solver_.SolveConstraintProblem(*accel_data_, &cf);
     solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &ga);
-    EXPECT_NEAR(ga[2], -accel_data_->kG[0], eps_ * cf.size());
+    EXPECT_NEAR(ga[2], -accel_data_->kG[0], lcp_eps_ * cf.size());
   }
 
   // Tests the rod in an upright sliding and impacting state, with sliding
@@ -1746,7 +1341,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     CalcConstraintProblemDataForImpact(vel_data_.get());
 
     // Compute the generalized velocity.
-    const VectorX<double> v0 = vel_data_->solve_inertia(vel_data_->Mv);
+    const VectorX<double> v = vel_data_->solve_inertia(vel_data_->Mv);
 
     // Add in bilateral constraints on rotational motion.
     vel_data_->kG.setZero(1);    // No right hand side term.
@@ -1800,14 +1395,14 @@ class Constraint2DSolverTest : public ::testing::Test {
       fF += contact_forces[i][1];
     }
     const double sign = (sliding_to_right) ? 1 : -1;
-    EXPECT_NEAR(fN, -mv, eps_);
-    EXPECT_NEAR(fF, sign * mv * rod_->get_mu_coulomb(), eps_);
+    EXPECT_NEAR(fN, -mv, lcp_eps_);
+    EXPECT_NEAR(fF, sign * mv * rod_->get_mu_coulomb(), lcp_eps_);
 
     // Get the change in generalized velocity and verify that there is no
     // angular velocity.
     VectorX<double> gv;
     solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &gv);
-    EXPECT_LT((v0[2] + gv[2]), eps_ * cf.size());
+    EXPECT_LT((v[2] + gv[2]), lcp_eps_ * cf.size());
 
     // Indicate through modification of the kG term that the system already has
     // angular orientation (which violates our desire to keep the rod at
@@ -1815,111 +1410,8 @@ class Constraint2DSolverTest : public ::testing::Test {
     vel_data_->kG[0] = 1.0;    // Indicate a ccw orientation..
     solver_.SolveImpactProblem(*vel_data_, &cf);
     solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &gv);
-    EXPECT_NEAR(v0[2] + gv[2], -vel_data_->kG[0],
-                eps_ * cf.size());
-  }
-
-  // Tests the rod in an upright sliding state, with sliding
-  // direction as specified. The rod will be constrained to prevent rotational
-  // acceleration using a bilateral constraint as well.
-  void SlidingPlusBilateralDiscretized(bool sliding_to_right) {
-    using std::max;
-
-    SetRodToRestingVerticalConfig();
-
-    // Set the coefficient of friction. A nonzero coefficient of friction should
-    // cause the rod to rotate.
-    rod_->set_mu_coulomb(0.1);
-
-    // Compute the problem data with no duplicated contacts or friction
-    // directions.
-    CalcDiscreteTimeProblemData(dt_, vel_data_.get());
-
-    // Update Mv to slide to the given direction and to account for
-    // gravitational force.
-    const double rod_mass = rod_->get_rod_mass();
-    vel_data_->Mv[0] += ((sliding_to_right) ? 1.0 : -1.0) * rod_mass;
-
-    // Add in bilateral constraints on rotational motion.
-    vel_data_->kG.setZero(1);    // No right hand side term.
-    vel_data_->G_mult = [](const VectorX<double>& w) -> VectorX<double> {
-      VectorX<double> result(1);   // Only one constraint.
-      // Constrain the angular velocity to be zero.
-      result[0] = w[2];
-      return result;
-    };
-    vel_data_->G_transpose_mult =
-        [this](const VectorX<double>& f) -> VectorX<double> {
-          // A force (torque) applied to the third component needs no
-          // transformation.
-          DRAKE_DEMAND(f.size() == 1);
-          VectorX<double> result(get_rod_num_coordinates());
-          result.setZero();
-          result[2] = f[0];
-          return result;
-        };
-
-    // Solve the discretization problem.
-    VectorX<double> cf;
-    SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-    // cf should be 3-dimensional. First dimension is normal force (along
-    // global +y), second dimension is frictional force (along +x),
-    // third dimension is constraint force (along +theta). Since the bilateral
-    // constraint should prevent angular motion, the constraint force (cf[2])
-    // should counteract the rotation that would be induced by the frictional
-    // force (cf[1]).
-    ASSERT_EQ(cf.size(), 3);
-    const double zero_tol = 10 * std::numeric_limits<double>::epsilon();
-    EXPECT_NEAR(cf[1], -cf[2], zero_tol);
-
-    // Construct the contact frame(s).
-    std::vector<Matrix2<double>> frames;
-    frames.push_back(GetNonSlidingContactFrameToWorldTransform());
-
-    // Get the contact forces expressed in the contact frame.
-    std::vector<Vector2<double>> contact_forces;
-    ConstraintSolver<double>::CalcContactForcesInContactFrames(
-        cf, *vel_data_, frames, &contact_forces);
-
-    // Verify that the number of contact force vectors is correct.
-    ASSERT_EQ(contact_forces.size(), frames.size());
-
-    // Verify that there are no non-sliding frictional forces.
-    const int num_contacts = vel_data_->mu.size();
-    const int num_bilateral_eqns = vel_data_->kG.size();
-    EXPECT_EQ(cf.size(), num_contacts * 2 + num_bilateral_eqns);
-
-    // Determine the force that should be acting on the system.
-    const double fdown = -rod_->get_gravitational_acceleration() * rod_mass;
-
-    // Verify that the normal contact forces exactly oppose the discretized
-    // force.
-    double fN = 0, fF = 0;
-    for (int i = 0; i < static_cast<int>(contact_forces.size()); ++i) {
-      fN += contact_forces[i][0];
-      fF += contact_forces[i][1];
-    }
-    const double sign = (sliding_to_right) ? 1 : -1;
-    EXPECT_NEAR(fN, fdown, eps_);
-    EXPECT_NEAR(fF, sign * -fdown * rod_->get_mu_coulomb(), eps_);
-
-    // Get the generalized acceleration from the constraint forces and verify
-    // that the moment is zero.
-    const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-    VectorX<double> ga;
-    solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-    EXPECT_LT(ga[2], eps_ * cf.size());
-
-    // Indicate through modification of the kG term that the system already has
-    // angular orientation (which violates our desire to keep the rod at
-    // zero rotation) and solve again.
-    vel_data_->kG[0] = 1.0;    // Indicate a ccw orientation..
-    SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-    // Compute the generalized acceleration.
-    solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &ga);
-    EXPECT_NEAR(ga[2] * dt_, -vel_data_->kG[0], eps_ * cf.size());
+    EXPECT_NEAR(v[2] + gv[2], -vel_data_->kG[0],
+                lcp_eps_ * cf.size());
   }
 
   // Tests the rod in a one-point sliding contact configuration with a second
@@ -1983,177 +1475,39 @@ class Constraint2DSolverTest : public ::testing::Test {
     };
     accel_data_->kL.setZero(num_limits);
 
-    // Case 1: set kN and kL terms to counteract gravity, which should prevent
-    // any constraint forces from being applied.
-    {
-      accel_data_->kN.setOnes() *= -grav_accel;
-      accel_data_->kL.setOnes() *= -grav_accel;
+    // Set kN and kL terms to counteract gravity, which should prevent any
+    // constraint forces from being applied.
+    accel_data_->kN.setOnes() *= -grav_accel;
+    accel_data_->kL.setOnes() *= -grav_accel;
 
-      // Compute the constraint forces and verify that none are applied.
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
-      EXPECT_LT(cf.norm(), eps_);
-    }
+    // Compute the constraint forces and verify that none are applied.
+    VectorX<double> cf;
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
+    EXPECT_LT(cf.norm(), lcp_eps_);
 
-    // Case 2: reset kN and kL and recompute constraint forces.
-    {
-      accel_data_->kN.setZero();
-      accel_data_->kL.setZero();
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
+    // Reset kN and kL and recompute constraint forces.
+    accel_data_->kN.setZero();
+    accel_data_->kL.setZero();
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
 
-      // Verify the size of cf is as expected.
-      const int num_contacts = 1;
-      EXPECT_EQ(cf.size(), num_contacts + num_limits);
+    // Verify the size of cf is as expected.
+    const int num_contacts = 1;
+    EXPECT_EQ(cf.size(), num_contacts + num_limits);
 
-      // Verify that the vertical acceleration is zero. If the cross-constraint
-      // term LM⁻¹(Nᵀ - μQᵀ) is not computed properly, this acceleration might
-      // not be zero. Note that μQᵀ will not have any effect here.
-      VectorX<double> vdot;
-      solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
-      EXPECT_NEAR(vdot[1], 0, eps_);
-    }
+    // Verify that the vertical acceleration is zero. If the cross-constraint
+    // term LM⁻¹(Nᵀ - μQᵀ) is not computed properly, this acceleration might not
+    // be zero. Note that μQᵀ will not have any effect here.
+    VectorX<double> vdot;
+    solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
+    EXPECT_NEAR(vdot[1], 0, lcp_eps_);
 
-    // Case 3: set kN and kL terms to effectively double gravity, which should
-    // cause the rod to accelerate upward.
-    {
-      accel_data_->kN.setOnes() *= grav_accel;
-      accel_data_->kL.setOnes() *= grav_accel;
-      VectorX<double> cf;
-      solver_.SolveConstraintProblem(*accel_data_, &cf);
-      VectorX<double> vdot;
-      solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
-      EXPECT_NEAR(vdot[1], -grav_accel, eps_);
-    }
-  }
-
-  // Tests the rod in a one-point sliding contact configuration with a second
-  // constraint that prevents horizontal acceleration. This test tests the
-  // interaction between contact and limit constraints.
-  void OnePointPlusLimitDiscretized() {
-    // Set the state of the rod to resting on its side with horizontal velocity.
-    SetRodToRestingHorizontalConfig();
-    ContinuousState<double>& xc = context_->
-        get_mutable_continuous_state();
-    xc[3] = 1.0;
-
-    // Set the coefficient of friction to somewhat small (to limit the sliding
-    // force).
-    rod_->set_mu_coulomb(1e-1);
-
-    // Get the gravitational acceleration.
-    const double grav_accel = rod_->get_gravitational_acceleration();
-
-    // First, construct the acceleration-level problem data as normal to set
-    // inertia solver and external forces.
-    CalcDiscreteTimeProblemData(dt_, vel_data_.get());
-
-    // Get the original N
-    const int ngc = get_rod_num_coordinates();
-    const int num_old_contacts = 2;
-    MatrixX<double> N(num_old_contacts, ngc);
-    MatrixX<double> N_transpose(ngc, num_old_contacts);
-    for (int i = 0; i < num_old_contacts; ++i) {
-      N_transpose.col(i) = vel_data_->N_transpose_mult(
-          VectorX<double>::Unit(2, i));
-    }
-    for (int i = 0; i < ngc; ++i)
-      N.col(i) = vel_data_->N_mult(VectorX<double>::Unit(ngc, i));
-
-    // Get the original F.
-    const int num_friction_dirs = 1;
-    MatrixX<double> F(num_old_contacts * num_friction_dirs, ngc);
-    MatrixX<double> F_transpose(ngc, num_old_contacts * num_friction_dirs);
-    for (int i = 0; i < num_old_contacts * num_friction_dirs; ++i) {
-      F_transpose.col(i) = vel_data_->F_transpose_mult(
-          VectorX<double>::Unit(num_old_contacts * num_friction_dirs, i));
-    }
-    for (int i = 0; i < ngc; ++i)
-      F.col(i) = vel_data_->F_mult(VectorX<double>::Unit(ngc, i));
-
-    // Construct the problem as a limit constraint preventing movement in the
-    // downward direction.
-    vel_data_->mu.resize(1);
-    vel_data_->r = {1};
-    vel_data_->N_mult = [&N](const VectorX<double>& v) {
-      return N.row(0) * v;
-    };
-    vel_data_->F_mult = [&F](const VectorX<double>& v) {
-      return F.row(0) * v;
-    };
-    vel_data_->kN.setZero(1);
-    vel_data_->kF.setZero(1);
-    vel_data_->gammaN.setZero(1);
-    vel_data_->gammaF.setZero(1);
-    vel_data_->gammaE.setZero(1);
-    vel_data_->kL.setZero(1);
-    vel_data_->gammaL.setZero(1);
-    vel_data_->N_transpose_mult =
-        [&N_transpose](const VectorX<double>& l) {
-          return N_transpose.col(0) * l;
-        };
-    vel_data_->F_transpose_mult =
-        [&F_transpose](const VectorX<double>& l) {
-          return F_transpose.col(0) * l;
-        };
-
-    // Set the Jacobian entry- in this case, the limit is a lower limit on the
-    // second coordinate (vertical position).
-    const int num_limits = 1;
-    vel_data_->L_mult = [&N](const VectorX<double>& v) -> VectorX<double> {
-      return N.row(1) * v;
-    };
-    vel_data_->L_transpose_mult = [&N](const VectorX<double>& v) ->
-        VectorX<double> {
-      return N.row(1).transpose() * v;
-    };
-    vel_data_->kL.setZero(num_limits);
-
-    // Case 1: set kN and kL terms to counteract gravity, which should prevent
-    // any constraint forces from being applied.
-    {
-      vel_data_->kN.setOnes() *= -grav_accel * dt_;
-      vel_data_->kL.setOnes() *= -grav_accel * dt_;
-
-      // Compute the constraint forces and verify that none are applied.
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-      EXPECT_LT(cf.norm(), eps_);
-    }
-
-    // Case 2: reset kN and kL and recompute constraint forces.
-    {
-      vel_data_->kN.setZero();
-      vel_data_->kL.setZero();
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-      // Verify the size of cf is as expected.
-      const int num_contacts = 1;
-      EXPECT_EQ(cf.size(), num_contacts + num_friction_dirs * num_contacts +
-          num_limits);
-
-      // Verify that the vertical acceleration is zero. If the cross-constraint
-      // term LM⁻¹Nᵀ is not computed properly, this acceleration might not
-      // be zero.
-      const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-      VectorX<double> vdot;
-      solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &vdot);
-      EXPECT_NEAR(vdot[1], 0, eps_);
-    }
-
-    // Case 3: set kN and kL terms to effectively double gravity, which should
-    // cause the rod to accelerate upward.
-    {
-      vel_data_->kN.setOnes() *= grav_accel * dt_;
-      vel_data_->kL.setOnes() *= grav_accel * dt_;
-      VectorX<double> cf;
-      SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-      const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-      VectorX<double> vdot;
-      solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &vdot);
-      EXPECT_NEAR(vdot[1], -grav_accel, eps_);
-    }
+    // Set kN and kL terms to effectively double gravity, which should cause the
+    // rod to accelerate upward.
+    accel_data_->kN.setOnes() *= grav_accel;
+    accel_data_->kL.setOnes() *= grav_accel;
+    solver_.SolveConstraintProblem(*accel_data_, &cf);
+    solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
+    EXPECT_NEAR(vdot[1], -grav_accel, lcp_eps_);
   }
 
   // Tests the rod in a two-point contact configuration with both sticking and
@@ -2204,7 +1558,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     // not computed properly, this acceleration might not be zero.
     VectorX<double> vdot;
     solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
-    EXPECT_NEAR(vdot[0], 0, eps_);
+    EXPECT_NEAR(vdot[0], 0, lcp_eps_);
   }
 
   // Tests that the cross-term interaction between contact forces and generic
@@ -2270,8 +1624,8 @@ class Constraint2DSolverTest : public ::testing::Test {
     // is zero.
     VectorX<double> vdot;
     solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
-    EXPECT_NEAR(vdot[0], 0, eps_);
-    EXPECT_NEAR(vdot[1], 0, eps_);
+    EXPECT_NEAR(vdot[0], 0, lcp_eps_);
+    EXPECT_NEAR(vdot[1], 0, lcp_eps_);
   }
 
   // Tests the rod in a two-point contacting configuration *realized through
@@ -2336,7 +1690,7 @@ class Constraint2DSolverTest : public ::testing::Test {
     // Verify that the normal force exactly opposes gravity.
     const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
         rod_->get_rod_mass();
-    EXPECT_NEAR(cf[0], mg, eps_);
+    EXPECT_NEAR(cf[0], mg, lcp_eps_);
 
     // Set the Jacobian entry- in this case, the limit is an upper limit on the
     // second coordinate (vertical position).
@@ -2353,112 +1707,17 @@ class Constraint2DSolverTest : public ::testing::Test {
     // constraints.
     solver_.SolveConstraintProblem(*accel_data_, &cf);
     EXPECT_EQ(cf.size(), 1);
-    EXPECT_NEAR(cf[0], mg, eps_);
+    EXPECT_NEAR(cf[0], mg, lcp_eps_);
 
     // Verify that the vertical acceleration is zero.
     VectorX<double> vdot;
     solver_.ComputeGeneralizedAcceleration(*accel_data_, cf, &vdot);
-    EXPECT_NEAR(vdot[1], 0, eps_);
+    EXPECT_NEAR(vdot[1], 0, lcp_eps_);
   }
-
-  // Tests the rod in a two-point contacting configuration *realized through
-  // a configuration limit constraint*. No frictional forces are applied, so
-  // any velocity projections along directions other than the contact normal
-  // will be irrelevant.
-  void TwoPointAsLimitDiscretized() {
-    // Set the state of the rod to resting on its side.
-    SetRodToRestingHorizontalConfig();
-
-    // First, construct the acceleration-level problem data as normal to set
-    // inertia solver and external forces.
-    CalcDiscreteTimeProblemData(dt_, vel_data_.get());
-
-    // Construct the problem as a limit constraint preventing movement in the
-    // downward direction.
-    const int ngc = get_rod_num_coordinates();
-    vel_data_->mu.resize(0);
-    vel_data_->r.resize(0);
-    vel_data_->N_mult = [](const VectorX<double>&) {
-      return VectorX<double>(0);
-    };
-    vel_data_->kN.resize(0);
-    vel_data_->gammaN.resize(0);
-    vel_data_->F_mult = [](const VectorX<double>&) {
-      return VectorX<double>(0);
-    };
-    vel_data_->F_transpose_mult = [ngc](const VectorX<double>&) {
-      return VectorX<double>::Zero(ngc);
-    };
-    vel_data_->kF.resize(0);
-    vel_data_->gammaF.resize(0);
-    vel_data_->gammaE.resize(0);
-    vel_data_->kL.resize(1);
-    vel_data_->gammaL.setZero(1);
-    vel_data_->N_transpose_mult = [ngc](const VectorX<double>&) {
-      return VectorX<double>::Zero(ngc);
-    };
-
-    // Set the Jacobian entry- in this case, the limit is a lower limit on the
-    // second coordinate (vertical position).
-    const int num_limit_constraints = 1;
-    MatrixX<double> L(vel_data_->kL.size(), ngc);
-    L.setZero();
-    L(0, 1) = 1;
-    vel_data_->L_mult = [&L](const VectorX<double>& v) -> VectorX<double> {
-      return L * v;
-    };
-    vel_data_->L_transpose_mult = [&L](const VectorX<double>& v) ->
-        VectorX<double> {
-      return L.transpose() * v;
-    };
-    vel_data_->kL.setZero(num_limit_constraints);
-
-    // Compute the constraint forces.
-    VectorX<double> cf;
-    SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-
-    // Verify the size of cf is as expected.
-    EXPECT_EQ(cf.size(), 1);
-
-    // Verify that the normal force exactly opposes gravity.
-    const double mg = std::fabs(rod_->get_gravitational_acceleration()) *
-        rod_->get_rod_mass();
-    EXPECT_NEAR(cf[0], mg, eps_);
-
-    // Set the Jacobian entry- in this case, the limit is an upper limit on the
-    // second coordinate (vertical position).
-    L *= -1;
-
-    // Reverse the external force (gravity) on the rod. tau was set by the
-    // call to Rod2D::CalcConstraintProblemData().
-    vel_data_->Mv *= -1;
-
-    // Recompute the constraint forces, and verify that they're still equal
-    // to the force from gravity. Note: if the forces were to be applied to the
-    // rod, one will need to compute Lᵀcf[0] to obtain the generalized force;
-    // this is how we can handle upper and lower limits with only non-negativity
-    // constraints.
-    SolveDiscretizationProblem(*vel_data_, dt_, &cf);
-    EXPECT_EQ(cf.size(), 1);
-    EXPECT_NEAR(cf[0], mg, eps_);
-
-    // Verify that the vertical acceleration is zero.
-    const VectorX<double> v0 = rod_->GetRodVelocity(*context_);
-    VectorX<double> vdot;
-    solver_.ComputeGeneralizedAcceleration(*vel_data_, v0, cf, dt_, &vdot);
-    EXPECT_NEAR(vdot[1], 0, eps_);
-  }
-
- private:
-  // The timestep size for discretization. Note: if the timestep is too
-  // large, the accuracy might be too low for the necessary effect to emerge).
-  // But we also want the step size to be large enough to test robustness. The
-  // selected value should be a good compromise.
-  const double dt_{1e-4};
 };
 
 // Tests the rod in single-point sticking configurations.
-TEST_F(Constraint2DSolverTest, SinglePointStickingBothSigns) {
+TEST_P(Constraint2DSolverTest, SinglePointStickingBothSigns) {
   // Test sticking with applied force to the right (true) and the left (false).
   SinglePointSticking(kForceAppliedToRight);
   SinglePointSticking(kForceAppliedToLeft);
@@ -2467,7 +1726,7 @@ TEST_F(Constraint2DSolverTest, SinglePointStickingBothSigns) {
 }
 
 // Tests the rod in a two-point sticking configurations.
-TEST_F(Constraint2DSolverTest, TwoPointStickingSign) {
+TEST_P(Constraint2DSolverTest, TwoPointStickingSign) {
   // Test sticking with applied force to the right and the left, and with both
   // the LCP solver and the linear system solver.
   TwoPointSticking(kForceAppliedToRight, kLCPSolver);
@@ -2478,67 +1737,59 @@ TEST_F(Constraint2DSolverTest, TwoPointStickingSign) {
 
 // Tests the rod in two-point non-sliding configurations that will transition
 // to sliding.
-TEST_F(Constraint2DSolverTest, TwoPointNonSlidingToSlidingSign) {
+TEST_P(Constraint2DSolverTest, TwoPointNonSlidingToSlidingSign) {
   // Test sticking with applied force to the right (true) and the left (false).
   TwoPointNonSlidingToSliding(kForceAppliedToRight);
   TwoPointNonSlidingToSliding(kForceAppliedToLeft);
-  TwoPointNonSlidingToSlidingDiscretized(kForceAppliedToRight);
-  TwoPointNonSlidingToSlidingDiscretized(kForceAppliedToLeft);
 }
 
 // Tests the rod in a two-point impact which is insufficient to put the rod
 // into stiction, with pre-impact velocity in two directions (right = true,
 // left = false).
-TEST_F(Constraint2DSolverTest, TwoPointImpactNoTransitionToStictionTest) {
+TEST_P(Constraint2DSolverTest, TwoPointImpactNoTransitionToStictionTest) {
   TwoPointImpactNoTransitionToStiction(kSlideRight);
   TwoPointImpactNoTransitionToStiction(kSlideLeft);
 }
 
 // Tests the rod in a two-point impacting and sticking configuration with
 // pre-impact velocity to the right (true) or left (false).
-TEST_F(Constraint2DSolverTest, TwoPointImpactingAndStickingTest) {
+TEST_P(Constraint2DSolverTest, TwoPointImpactingAndStickingTest) {
   TwoPointImpactingAndSticking(kSlideRight);
   TwoPointImpactingAndSticking(kSlideLeft);
 }
 
 // Tests the rod in a two-point sliding configuration, both to the right
 // and to the left and using both the LCP and linear system solvers.
-TEST_F(Constraint2DSolverTest, TwoPointSlidingTest) {
+TEST_P(Constraint2DSolverTest, TwoPointSlidingTest) {
   Sliding(kSlideRight, false /* not upright */, kLCPSolver);
   Sliding(kSlideLeft, false /* not upright */, kLCPSolver);
   Sliding(kSlideRight, false /* not upright */, kLinearSystemSolver);
   Sliding(kSlideLeft, false /* not upright */, kLinearSystemSolver);
-  SlidingDiscretized(kSlideRight, false /* not upright */);
-  SlidingDiscretized(kSlideLeft, false /* not upright */);
 }
 
 // Tests the rod in a single point sliding configuration, with sliding both
 // to the right and to the left and using both the LCP and linear system
 // solvers.
-TEST_F(Constraint2DSolverTest, SinglePointSlidingTest) {
+TEST_P(Constraint2DSolverTest, SinglePointSlidingTest) {
   Sliding(kSlideRight, true /* upright */, kLCPSolver);
   Sliding(kSlideLeft, true /* upright */, kLCPSolver);
   Sliding(kSlideRight, true /* upright */, kLinearSystemSolver);
   Sliding(kSlideLeft, true /* upright */, kLinearSystemSolver);
-  SlidingDiscretized(kSlideRight, true /* upright */);
-  SlidingDiscretized(kSlideLeft, true /* upright */);
 }
 
 // Tests the rod in a single point sliding configuration, with sliding both
 // to the right and to the left, and with a bilateral constraint imposed, and
 // using both the LCP and linear system solvers.
-TEST_F(Constraint2DSolverTest, SinglePointSlidingPlusBilateralTest) {
+TEST_P(Constraint2DSolverTest, SinglePointSlidingPlusBilateralTest) {
   SlidingPlusBilateral(kSlideRight, kLCPSolver);
   SlidingPlusBilateral(kSlideLeft, kLCPSolver);
   SlidingPlusBilateral(kSlideRight, kLinearSystemSolver);
   SlidingPlusBilateral(kSlideLeft, kLinearSystemSolver);
-  SlidingPlusBilateralDiscretized(kSlideRight);
-  SlidingPlusBilateralDiscretized(kSlideLeft);
 }
 
 // Tests the rod in a single point impacting configuration, with sliding both
 // to the right and to the left, and with a bilateral constraint imposed.
-TEST_F(Constraint2DSolverTest, SinglePointSlidingImpactPlusBilateralTest) {
+TEST_P(Constraint2DSolverTest, SinglePointSlidingImpactPlusBilateralTest) {
   SlidingPlusBilateralImpact(kSlideRight);
   SlidingPlusBilateralImpact(kSlideLeft);
 }
@@ -2547,17 +1798,16 @@ TEST_F(Constraint2DSolverTest, SinglePointSlidingImpactPlusBilateralTest) {
 // constraint that prevents horizontal acceleration. This test tests the
 // interaction between contact and limit constraints using both the LCP solver
 // and the linear system solver.
-TEST_F(Constraint2DSolverTest, OnePointPlusLimitTest) {
+TEST_P(Constraint2DSolverTest, OnePointPlusLimitTest) {
   OnePointPlusLimit(kLCPSolver);
   OnePointPlusLimit(kLinearSystemSolver);
-  OnePointPlusLimitDiscretized();
 }
 
 // Tests the rod in a two-point contact configuration with both sticking and
 // sliding contacts and using both the LCP and linear system solvers. This test
 // tests that the cross-term interaction between sliding friction forces and
 // non-sliding friction forces constraints is correct.
-TEST_F(Constraint2DSolverTest, TwoPointContactCrossTermsTest) {
+TEST_P(Constraint2DSolverTest, TwoPointContactCrossTermsTest) {
   TwoPointContactCrossTerms(kLCPSolver);
   TwoPointContactCrossTerms(kLinearSystemSolver);
 }
@@ -2565,7 +1815,7 @@ TEST_F(Constraint2DSolverTest, TwoPointContactCrossTermsTest) {
 // Tests that the cross-term interaction between contact forces and generic
 // unilateral constraints is computed correctly at the acceleration level. Tests
 // both the LCP solver and the linear system solver.
-TEST_F(Constraint2DSolverTest, ContactLimitCrossTermAccelTest) {
+TEST_P(Constraint2DSolverTest, ContactLimitCrossTermAccelTest) {
   ContactLimitCrossTermAccel(kLCPSolver);
   ContactLimitCrossTermAccel(kLinearSystemSolver);
 }
@@ -2574,15 +1824,14 @@ TEST_F(Constraint2DSolverTest, ContactLimitCrossTermAccelTest) {
 // a configuration limit constraint* using both the LCP and linear system
 // solvers. No frictional forces are applied, so any velocity projections along
 // directions other than the contact normal will be irrelevant.
-TEST_F(Constraint2DSolverTest, TwoPointAsLimitTest) {
+TEST_P(Constraint2DSolverTest, TwoPointAsLimitTest) {
   TwoPointAsLimit(kLCPSolver);
   TwoPointAsLimit(kLinearSystemSolver);
-  TwoPointAsLimitDiscretized();
 }
 
 // Tests the rod in a two-point configuration, in a situation where a force
 // pulls the rod upward (and no contact forces should be applied).
-TEST_F(Constraint2DSolverTest, TwoPointPulledUpward) {
+TEST_P(Constraint2DSolverTest, TwoPointPulledUpward) {
   // Duplicate contact points up to two times and the friction directions up
   // to three times.
   for (int contact_dup = 0; contact_dup < 3; ++contact_dup) {
@@ -2602,14 +1851,14 @@ TEST_F(Constraint2DSolverTest, TwoPointPulledUpward) {
       solver_.SolveConstraintProblem(*accel_data_, &cf);
 
       // Verify that the contact forces are zero.
-      EXPECT_LT(cf.norm(), eps_);
+      EXPECT_LT(cf.norm(), lcp_eps_);
     }
   }
 }
 
 // Tests the rod in a two-point configuration, in a situation where the rod
 // is moving upward, so no impulsive forces should be applied.
-TEST_F(Constraint2DSolverTest, NoImpactImpliesNoImpulses) {
+TEST_P(Constraint2DSolverTest, NoImpactImpliesNoImpulses) {
   // Duplicate contact points up to two times and the friction directions up
   // to three times.
   for (int contact_dup = 0; contact_dup < 3; ++contact_dup) {
@@ -2626,14 +1875,14 @@ TEST_F(Constraint2DSolverTest, NoImpactImpliesNoImpulses) {
       solver_.SolveImpactProblem(*vel_data_, &cf);
 
       // Verify that the impact forces are zero.
-      EXPECT_LT(cf.norm(), eps_);
+      EXPECT_LT(cf.norm(), lcp_eps_);
     }
   }
 }
 
 // Tests that the cross-term interaction between contact forces and generic
 // unilateral constraints is computed correctly at the velocity level.
-TEST_F(Constraint2DSolverTest, ContactLimitCrossTermVel) {
+TEST_P(Constraint2DSolverTest, ContactLimitCrossTermVel) {
   // Set the state of the rod to resting.
   SetRodToSlidingImpactingHorizontalConfig(true);
 
@@ -2656,14 +1905,14 @@ TEST_F(Constraint2DSolverTest, ContactLimitCrossTermVel) {
 
   // Add in some horizontal velocity to test the transition to stiction too.
   vel_data_->Mv[0] = 1.0;
-  const VectorX<double> v0 = vel_data_->solve_inertia(vel_data_->Mv);
+  const VectorX<double> v = vel_data_->solve_inertia(vel_data_->Mv);
 
   // Construct the problem as a limit constraint preventing movement in the
   // downward direction.
   const int ngc = get_rod_num_coordinates();
   const int num_generic_unilateral_constraints = 1;
   vel_data_->kL.resize(num_generic_unilateral_constraints);
-  vel_data_->gammaL.setZero(num_generic_unilateral_constraints);
+  vel_data_->gammaL.setOnes(num_generic_unilateral_constraints) *= cfm_;
 
   // Set the Jacobian entry- in this case, the limit is an upper limit on the
   // second coordinate (vertical position). The constraint is: v₂ ≤ 0, which
@@ -2697,15 +1946,15 @@ TEST_F(Constraint2DSolverTest, ContactLimitCrossTermVel) {
   // velocity is zero.
   VectorX<double> dv;
   solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &dv);
-  EXPECT_NEAR(v0[0] + dv[0], 0, eps_);
-  EXPECT_NEAR(v0[1] + dv[1], 0, eps_);
+  EXPECT_NEAR(v[0] + dv[0], 0, lcp_eps_);
+  EXPECT_NEAR(v[1] + dv[1], 0, lcp_eps_);
 }
 
 // Tests the rod in a two-point configuration *realized through a configuration
 // limit constraint*, velocity-level version. No frictional forces are applied,
 // so any velocity projections along directions other than the contact normal
 // will be irrelevant.
-TEST_F(Constraint2DSolverTest, TwoPointImpactAsLimit) {
+TEST_P(Constraint2DSolverTest, TwoPointImpactAsLimit) {
   // Set the state of the rod to impacting on its side.
   SetRodToSlidingImpactingHorizontalConfig(true /* moving to the right */);
   ContinuousState<double>& xc = context_->get_mutable_continuous_state();
@@ -2716,7 +1965,7 @@ TEST_F(Constraint2DSolverTest, TwoPointImpactAsLimit) {
   CalcConstraintProblemDataForImpact(vel_data_.get());
 
   // Compute v.
-  VectorX<double> v0 = vel_data_->solve_inertia(vel_data_->Mv);
+  VectorX<double> v = vel_data_->solve_inertia(vel_data_->Mv);
 
   // Construct the problem as a limit constraint preventing movement in the
   // downward direction.
@@ -2766,7 +2015,7 @@ TEST_F(Constraint2DSolverTest, TwoPointImpactAsLimit) {
 
   // Verify that the normal force exactly opposes the momentum.
   const double mv = std::fabs(vert_vel) * rod_->get_rod_mass();
-  EXPECT_NEAR(cf[0], mv, eps_);
+  EXPECT_NEAR(cf[0], mv, lcp_eps_);
 
   // Set the Jacobian entry- in this case, the limit is an upper limit on the
   // second coordinate (vertical position).
@@ -2775,7 +2024,7 @@ TEST_F(Constraint2DSolverTest, TwoPointImpactAsLimit) {
   // Reverse the velocity on the rod, which was set by the call to
   // Rod2D::CalcImpactProblemData().
   vel_data_->Mv *= -1;
-  v0 *= -1;
+  v *= -1;
 
   // Recompute the constraint impulses, and verify that they're still equal
   // to the momentum. Note: if the impulses were to be applied to the
@@ -2784,28 +2033,29 @@ TEST_F(Constraint2DSolverTest, TwoPointImpactAsLimit) {
   // constraints.
   solver_.SolveImpactProblem(*vel_data_, &cf);
   EXPECT_EQ(cf.size(), 1);
-  EXPECT_NEAR(cf[0], mv, eps_);
+  EXPECT_NEAR(cf[0], mv, lcp_eps_);
 
   // Verify that the vertical velocity is zero.
   VectorX<double> vnew;
   solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &vnew);
-  EXPECT_NEAR(v0[1] + vnew[1], 0, eps_);
+  EXPECT_NEAR(v[1] + vnew[1], 0,
+              lcp_eps_);
 
   // Now test whether constraint stabilization works by trying to get the rod to
   // move downward as fast as it's currently moving upward
   // (according to vel_data_->v). Note that Lv is negative, indicating "error"
   // to be corrected (as desired in this test).
-  vel_data_->kL = L * v0;
+  vel_data_->kL = L * v;
 
   // Recompute the constraint impulses, and verify that they're now equal to
   // twice the momentum.
   solver_.SolveImpactProblem(*vel_data_, &cf);
   EXPECT_EQ(cf.size(), 1);
-  EXPECT_NEAR(cf[0], mv*2, eps_);
+  EXPECT_NEAR(cf[0], mv*2, lcp_eps_);
 }
 
 // Tests that a purely bilaterally constrained problem is handled correctly.
-TEST_F(Constraint2DSolverTest, BilateralOnly) {
+TEST_P(Constraint2DSolverTest, BilateralOnly) {
   // Set the rod to a ballistic state.
   ContinuousState<double>& xc = context_->get_mutable_continuous_state();
   xc[0] = 0.0;     // com horizontal position.
@@ -2853,8 +2103,14 @@ TEST_F(Constraint2DSolverTest, BilateralOnly) {
   VectorX<double> gv;
   solver_.ComputeGeneralizedVelocityChange(*vel_data_, cf, &gv);
   EXPECT_NEAR(v[2] + gv[2], -vel_data_->kG[0],
-              eps_ * cf.size());
+              lcp_eps_ * cf.size());
 }
+
+// Instantiate the value-parameterized tests to run with a range of CFM values
+// (i.e., constraint softening applied uniformly over all mathematical
+// programming variables).
+INSTANTIATE_TEST_CASE_P(Blank, Constraint2DSolverTest,
+                        testing::Values(0, 1e-15, 1e-11, 1e-7, 1e-3));
 
 }  // namespace
 }  // namespace constraint


### PR DESCRIPTION
Dear @edrumwri ,

The on-call build cop, @betsymcphail, believes that your PR #8804 may have
broken one or more of Drake's continuous integration builds [1,2]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-continuous-memcheck-asan/1708/
https://drake-jenkins.csail.mit.edu/job/linux-xenial-clang-bazel-continuous-memcheck-valgrind/31/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [3].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Continuous Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/
[2] CI Nightly Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/
[3] http://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9086)
<!-- Reviewable:end -->
