### PR TITLE
Deprecate stand-alone functions XRotation(), YRotation(), ZRotation() in favor of math::RotationMatrix::MakeXRotation(), etc.

### DIFF
--- a/automotive/maliput/rndf/spline_lane.cc
+++ b/automotive/maliput/rndf/spline_lane.cc
@@ -50,7 +50,7 @@ api::GeoPosition SplineLane::DoToGeoPosition(
   // Calculate x,y of (s,0,0).
   const Vector2<double> xy = xy_of_s(s);
   // Calculate orientation of (s,r,h) basis at (s,0,0).
-  const Matrix3<double> rotation_matrix = Rabg_of_s(s);
+  const math::RotationMatrix<double> rotation_matrix = Rabg_of_s(s);
   // Rotate (0,r,h) and sum with mapped (s,0,h).
   const Vector3<double> xyz =
       rotation_matrix * Vector3<double>(0., r, lane_pos.h()) +
@@ -118,8 +118,9 @@ double SplineLane::heading_dot_of_s(double s) const {
   return (m / (1.0 + heading * heading));
 }
 
-Matrix3<double> SplineLane::Rabg_of_s(double s) const {
-  return drake::math::ZRotation<double>(heading_of_s(s));
+math::RotationMatrix<double> SplineLane::Rabg_of_s(double s) const {
+  const double angle = heading_of_s(s);
+  return math::RotationMatrix<double>::MakeZRotation(angle);
 }
 
 api::RBounds SplineLane::do_lane_bounds(double) const {

--- a/automotive/maliput/rndf/spline_lane.h
+++ b/automotive/maliput/rndf/spline_lane.h
@@ -128,7 +128,7 @@ class SplineLane : public Lane {
   // Provides a rotation matrix in terms of Euler angles, with only
   // yaw angle set as RNDF is defined without any change in elevation.
   // See heading_of_s for more information.
-  Matrix3<double> Rabg_of_s(double s) const;
+  math::RotationMatrix<double> Rabg_of_s(double s) const;
 
   // Returns the length of the curve.
   double do_length() const override {

--- a/common/test/symbolic_expression_transform_test.cc
+++ b/common/test/symbolic_expression_transform_test.cc
@@ -9,36 +9,36 @@ namespace drake {
 namespace symbolic {
 namespace {
 
-using math::XRotation;
-using math::YRotation;
-using math::ZRotation;
-
 class SymbolicExpressionTransformationTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    R1_ = XRotation(.25 * M_PI) * YRotation(.5 * M_PI) * ZRotation(.33 * M_PI);
-    R2_ = XRotation(M_PI / 2) * YRotation(-M_PI / 2) * ZRotation(M_PI / 2);
+    R1_ = math::RotationMatrixd::MakeXRotation(.25 * M_PI) *
+          math::RotationMatrixd::MakeYRotation(.5 * M_PI) *
+          math::RotationMatrixd::MakeZRotation(.33 * M_PI);
+    R2_ = math::RotationMatrixd::MakeXRotation(M_PI / 2) *
+          math::RotationMatrixd::MakeYRotation(-M_PI / 2) *
+          math::RotationMatrixd::MakeZRotation(M_PI / 2);
 
     affine_.setIdentity();
-    affine_.rotate(R1_);
+    affine_.rotate(R1_.matrix());
     affine_.translation() << 1.0, 2.0, 3.0;
 
     affine_compact_.setIdentity();
-    affine_compact_.rotate(R1_ * R2_);
+    affine_compact_.rotate((R1_ * R2_).matrix());
     affine_compact_.translation() << -2.0, 1.0, 3.0;
 
     isometry_.setIdentity();
-    isometry_.rotate(-R2_);
+    isometry_.rotate(-R2_.matrix());
     isometry_.translation() << 3.0, -1.0, 2.0;
 
     projective_.setIdentity();
-    projective_.rotate(-R2_ * R1_);
+    projective_.rotate(-(R2_ * R1_).matrix());
     projective_.translation() << 2.0, 3.0, -1.0;
   }
 
   // Rotation Matrices.
-  Eigen::Matrix3d R1_;
-  Eigen::Matrix3d R2_;
+  math::RotationMatrixd R1_;
+  math::RotationMatrixd R2_;
 
   // Transformations.
   Eigen::Transform<double, 3, Eigen::Affine, Eigen::DontAlign> affine_;

--- a/common/test/symbolic_expression_transform_test.cc
+++ b/common/test/symbolic_expression_transform_test.cc
@@ -9,15 +9,17 @@ namespace drake {
 namespace symbolic {
 namespace {
 
+using math::RotationMatrixd;
+
 class SymbolicExpressionTransformationTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    R1_ = math::RotationMatrixd::MakeXRotation(.25 * M_PI) *
-          math::RotationMatrixd::MakeYRotation(.5 * M_PI) *
-          math::RotationMatrixd::MakeZRotation(.33 * M_PI);
-    R2_ = math::RotationMatrixd::MakeXRotation(M_PI / 2) *
-          math::RotationMatrixd::MakeYRotation(-M_PI / 2) *
-          math::RotationMatrixd::MakeZRotation(M_PI / 2);
+    R1_ = RotationMatrixd::MakeXRotation(.25 * M_PI) *
+          RotationMatrixd::MakeYRotation(.5 * M_PI) *
+          RotationMatrixd::MakeZRotation(.33 * M_PI);
+    R2_ = RotationMatrixd::MakeXRotation(M_PI / 2) *
+          RotationMatrixd::MakeYRotation(-M_PI / 2) *
+          RotationMatrixd::MakeZRotation(M_PI / 2);
 
     affine_.setIdentity();
     affine_.rotate(R1_.matrix());
@@ -37,8 +39,8 @@ class SymbolicExpressionTransformationTest : public ::testing::Test {
   }
 
   // Rotation Matrices.
-  math::RotationMatrixd R1_;
-  math::RotationMatrixd R2_;
+  RotationMatrixd R1_;
+  RotationMatrixd R2_;
 
   // Transformations.
   Eigen::Transform<double, 3, Eigen::Affine, Eigen::DontAlign> affine_;

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -48,11 +48,7 @@ class RotationMatrix {
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
   explicit RotationMatrix(const Matrix3<T>& R) : R_AB_() {
-#ifdef DRAKE_ASSERT_IS_ARMED
-    SetOrThrowIfNotValid(R);
-#else
-    SetUnchecked(R);
-#endif
+    SetOrThrowIfNotValidInDebugBuild(R);
   }
 
   /// Constructs a %RotationMatrix from an Eigen::Quaternion.
@@ -248,9 +244,12 @@ class RotationMatrix {
   /// Sets `this` %RotationMatrix from a Matrix3.
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
-  void SetOrThrowIfNotValid(const Matrix3<T>& R) {
+  void SetOrThrowIfNotValidInDebugBuild(const Matrix3<T>& R) {
+#ifdef DRAKE_ASSERT_IS_ARMED
     ThrowIfNotValid(R);
+#else
     SetUnchecked(R);
+#endif
   }
 
   /// Returns the 3x3 identity %RotationMatrix.

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -245,9 +245,7 @@ class RotationMatrix {
   /// @param[in] R an allegedly valid rotation matrix.
   /// @throws std::logic_error in debug builds if R fails IsValid(R).
   void SetOrThrowIfNotValidInDebugBuild(const Matrix3<T>& R) {
-#ifdef DRAKE_ASSERT_IS_ARMED
-    ThrowIfNotValid(R);
-#endif
+    DRAKE_ASSERT_VOID(ThrowIfNotValid(R));
     SetUnchecked(R);
   }
 

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -247,9 +247,8 @@ class RotationMatrix {
   void SetOrThrowIfNotValidInDebugBuild(const Matrix3<T>& R) {
 #ifdef DRAKE_ASSERT_IS_ARMED
     ThrowIfNotValid(R);
-#else
-    SetUnchecked(R);
 #endif
+    SetUnchecked(R);
   }
 
   /// Returns the 3x3 identity %RotationMatrix.

--- a/math/rotation_matrix_deprecated.h
+++ b/math/rotation_matrix_deprecated.h
@@ -138,7 +138,7 @@ VectorX<typename Derived::Scalar> rotmat2Representation(
 }
 
 /// (Deprecated), use @ref math::RotationMatrix::MakeXRotation().
-// TODO(mitiguy) Delete this code after July 12, 2018.
+// TODO(mitiguy) Delete this code after October 6, 2018.
 template <typename T>
 DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
                  "Use math::RotationMatrix::MakeXRotation(theta).")
@@ -147,7 +147,7 @@ Matrix3<T> XRotation(const T& theta) {
 }
 
 /// (Deprecated), use @ref math::RotationMatrix::MakeYRotation().
-// TODO(mitiguy) Delete this code after July 12, 2018.
+// TODO(mitiguy) Delete this code after October 6, 2018.
 template <typename T>
 DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
                  "Use math::RotationMatrix::MakeYRotation(theta).")
@@ -156,7 +156,7 @@ Matrix3<T> YRotation(const T& theta) {
 }
 
 /// (Deprecated), use @ref math::RotationMatrix::MakeZRotation().
-// TODO(mitiguy) Delete this code after July 12, 2018.
+// TODO(mitiguy) Delete this code after October 6, 2018.
 template <typename T>
 DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
                  "Use math::RotationMatrix::MakeZRotation(theta).")

--- a/math/rotation_matrix_deprecated.h
+++ b/math/rotation_matrix_deprecated.h
@@ -137,20 +137,29 @@ VectorX<typename Derived::Scalar> rotmat2Representation(
                          "or math::RotationMatrix::ToQuaternionAsVector4.");
 }
 
-/// (Deprecated), use @ref math::RotationMatrix::MakeXRotation
+/// (Deprecated), use @ref math::RotationMatrix::MakeXRotation().
+// TODO(mitiguy) Delete this code after July 12, 2018.
 template <typename T>
+DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
+                 "Use math::RotationMatrix::MakeXRotation(theta).")
 Matrix3<T> XRotation(const T& theta) {
   return drake::math::RotationMatrix<T>::MakeXRotation(theta).matrix();
 }
 
-/// (Deprecated), use @ref math::RotationMatrix::MakeYRotation
+/// (Deprecated), use @ref math::RotationMatrix::MakeYRotation().
+// TODO(mitiguy) Delete this code after July 12, 2018.
 template <typename T>
+DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
+                 "Use math::RotationMatrix::MakeYRotation(theta).")
 Matrix3<T> YRotation(const T& theta) {
   return drake::math::RotationMatrix<T>::MakeYRotation(theta).matrix();
 }
 
-/// (Deprecated), use @ref math::RotationMatrix::MakeZRotation
+/// (Deprecated), use @ref math::RotationMatrix::MakeZRotation().
+// TODO(mitiguy) Delete this code after July 12, 2018.
 template <typename T>
+DRAKE_DEPRECATED("This code is deprecated per issue #8323. "
+                 "Use math::RotationMatrix::MakeZRotation(theta).")
 Matrix3<T> ZRotation(const T& theta) {
   return drake::math::RotationMatrix<T>::MakeZRotation(theta).matrix();
 }

--- a/math/test/rotation_matrix_deprecated_test.cc
+++ b/math/test/rotation_matrix_deprecated_test.cc
@@ -18,42 +18,6 @@ namespace drake {
 namespace math {
 namespace {
 
-// Test XRotation, YRotation, ZRotation
-GTEST_TEST(RotationMatrixTest, TestXYZ) {
-  Vector3d i(1, 0, 0), j(0, 1, 0), k(0, 0, 1);
-
-  double tol = 1e-12;
-  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * i, i, tol));
-  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * j,
-                              Vector3d(0, M_SQRT1_2, M_SQRT1_2), tol));
-  EXPECT_TRUE(CompareMatrices(XRotation(M_PI_4) * k,
-                              Vector3d(0, -M_SQRT1_2, M_SQRT1_2), tol));
-
-  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * i,
-                              Vector3d(M_SQRT1_2, 0, -M_SQRT1_2), tol));
-  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * j, j, tol));
-  EXPECT_TRUE(CompareMatrices(YRotation(M_PI_4) * k,
-                              Vector3d(M_SQRT1_2, 0, M_SQRT1_2), tol));
-
-  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * i,
-                              Vector3d(M_SQRT1_2, M_SQRT1_2, 0), tol));
-  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * j,
-                              Vector3d(-M_SQRT1_2, M_SQRT1_2, 0), tol));
-  EXPECT_TRUE(CompareMatrices(ZRotation(M_PI_4) * k, k, tol));
-
-  // Test that rotations by PI do not change the rotation axis, and flip the
-  // signs on the other two axes.
-  EXPECT_TRUE(CompareMatrices(
-      XRotation(M_PI + 0.3),
-      Eigen::DiagonalMatrix<double, 3>(1, -1, -1) * XRotation(0.3), tol));
-  EXPECT_TRUE(CompareMatrices(
-      YRotation(M_PI + 0.3),
-      Eigen::DiagonalMatrix<double, 3>(-1, 1, -1) * YRotation(0.3), tol));
-  EXPECT_TRUE(CompareMatrices(
-      ZRotation(M_PI + 0.3),
-      Eigen::DiagonalMatrix<double, 3>(-1, -1, 1) * ZRotation(0.3), tol));
-}
-
 // Take many possible samples of the rotation angle θ, make sure the rotation
 // matrix as R[θ] = AngleAxis(θ, axis) has larger error than the projected
 // matrix R, namely

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -84,7 +84,7 @@ GTEST_TEST(RotationMatrix, SetRotationMatrix) {
       0, -sin_theta, cos_theta;
 
   RotationMatrix<double> R;
-  R.SetOrThrowIfNotValid(m);
+  R.SetOrThrowIfNotValidInDebugBuild(m);
   Matrix3d zero_matrix = m - R.matrix();
   EXPECT_TRUE((zero_matrix.array() == 0).all());
 
@@ -92,7 +92,11 @@ GTEST_TEST(RotationMatrix, SetRotationMatrix) {
   m << 1, 9000*kEpsilon, 9000*kEpsilon,
       0, cos_theta, sin_theta,
       0, -sin_theta, cos_theta;
-  EXPECT_THROW(R.SetOrThrowIfNotValid(m), std::logic_error);
+#ifdef DRAKE_ASSERT_IS_ARMED
+  EXPECT_THROW(R.SetOrThrowIfNotValidInDebugBuild(m), std::logic_error);
+#else
+  R.SetOrThrowIfNotValidInDebugBuild(m);
+#endif
 }
 
 // Test setting a RotationMatrix to an identity matrix.
@@ -102,31 +106,67 @@ GTEST_TEST(RotationMatrix, MakeIdentityMatrix) {
   EXPECT_TRUE((zero_matrix.array() == 0).all());
 }
 
-// Test making a rotation matrix associated with a X-rotation.
-GTEST_TEST(RotationMatrix, RotationMatrixX) {
-  const double theta = 0.3;
-  const Matrix3d m = Eigen::AngleAxisd(theta, Vector3d::UnitX()).matrix();
+// Test making a rotation matrix associated with a X, Y, or Z-rotation.
+GTEST_TEST(RotationMatrix, MakeXRotationMakeYRotationMakeZRotation) {
+  const Vector3d i(1, 0, 0), j(0, 1, 0), k(0, 0, 1);
+  double tolerance = 32 * kEpsilon;
+
+  // Test making a rotation matrix associated with X-rotation.
+  double theta = 0.3;
+  Matrix3d m = Eigen::AngleAxisd(theta, Vector3d::UnitX()).matrix();
   RotationMatrix<double> R = RotationMatrix<double>::MakeXRotation(theta);
-  const Matrix3d zero_matrix = m - R.matrix();
+  Matrix3d zero_matrix = m - R.matrix();
   EXPECT_TRUE((zero_matrix.array() == 0).all());
-}
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeXRotation(M_PI_4) * i,
+                              i, tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeXRotation(M_PI_4) * j,
+                              Vector3d(0, M_SQRT1_2, M_SQRT1_2), tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeXRotation(M_PI_4) * k,
+                              Vector3d(0, -M_SQRT1_2, M_SQRT1_2), tolerance));
 
-// Test making a rotation matrix associated with a Y-rotation.
-GTEST_TEST(RotationMatrix, RotationMatrixY) {
-  const double theta = 0.4;
-  const Matrix3d m = Eigen::AngleAxisd(theta, Vector3d::UnitY()).matrix();
-  RotationMatrix<double> R = RotationMatrix<double>::MakeYRotation(theta);
-  const Matrix3d zero_matrix = m - R.matrix();
+  // Test making a rotation matrix associated with Y-rotation.
+  theta = 0.4;
+  m = Eigen::AngleAxisd(theta, Vector3d::UnitY()).matrix();
+  R = RotationMatrix<double>::MakeYRotation(theta);
+  zero_matrix = m - R.matrix();
   EXPECT_TRUE((zero_matrix.array() == 0).all());
-}
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeYRotation(M_PI_4) * i,
+                              Vector3d(M_SQRT1_2, 0, -M_SQRT1_2), tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeYRotation(M_PI_4) * j,
+                              j, tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeYRotation(M_PI_4) * k,
+                              Vector3d(M_SQRT1_2, 0, M_SQRT1_2), tolerance));
 
-// Test making a rotation matrix associated with a Z-rotation.
-GTEST_TEST(RotationMatrix, RotationMatrixZ) {
-  const double theta = 0.5;
-  const Matrix3d m = Eigen::AngleAxisd(theta, Vector3d::UnitZ()).matrix();
-  RotationMatrix<double> R = RotationMatrix<double>::MakeZRotation(theta);
-  const Matrix3d zero_matrix = m - R.matrix();
+  // Test making a rotation matrix associated with Z-rotation.
+  theta = 0.5;
+  m = Eigen::AngleAxisd(theta, Vector3d::UnitZ()).matrix();
+  R = RotationMatrix<double>::MakeZRotation(theta);
+  zero_matrix = m - R.matrix();
   EXPECT_TRUE((zero_matrix.array() == 0).all());
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeZRotation(M_PI_4) * i,
+                              Vector3d(M_SQRT1_2, M_SQRT1_2, 0), tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeZRotation(M_PI_4) * j,
+                              Vector3d(-M_SQRT1_2, M_SQRT1_2, 0), tolerance));
+  EXPECT_TRUE(CompareMatrices(RotationMatrixd::MakeZRotation(M_PI_4) * k,
+                              k, tolerance));
+
+  // Test that rotation by Pi + theta does not change the rotation axis and
+  // flips the signs on the other two axes.
+  RotationMatrixd RA, RB;
+  RA = RotationMatrixd::MakeXRotation(M_PI + theta);
+  RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(1, -1, -1)) *
+       RotationMatrixd::MakeXRotation(theta);
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
+
+  RA = RotationMatrixd::MakeYRotation(M_PI + theta);
+  RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(-1, 1, -1)) *
+       RotationMatrixd::MakeYRotation(theta);
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
+
+  RA = RotationMatrixd::MakeZRotation(M_PI + theta);
+  RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(-1, -1, 1)) *
+       RotationMatrixd::MakeZRotation(theta);
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
 }
 
 // Test making a rotation matrix from a RollPitchYaw rotation sequence (which is

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -95,7 +95,7 @@ GTEST_TEST(RotationMatrix, SetRotationMatrix) {
 #ifdef DRAKE_ASSERT_IS_ARMED
   EXPECT_THROW(R.SetOrThrowIfNotValidInDebugBuild(m), std::logic_error);
 #else
-  R.SetOrThrowIfNotValidInDebugBuild(m);
+  EXPECT_NO_THROW(R.SetOrThrowIfNotValidInDebugBuild(m));
 #endif
 }
 
@@ -108,7 +108,9 @@ GTEST_TEST(RotationMatrix, MakeIdentityMatrix) {
 
 // Test making a rotation matrix associated with a X, Y, or Z-rotation.
 GTEST_TEST(RotationMatrix, MakeXRotationMakeYRotationMakeZRotation) {
-  const Vector3d i(1, 0, 0), j(0, 1, 0), k(0, 0, 1);
+  const Vector3d i = Eigen::Vector3d::UnitX();
+  const Vector3d j = Eigen::Vector3d::UnitY();
+  const Vector3d k = Eigen::Vector3d::UnitZ();
   double tolerance = 32 * kEpsilon;
 
   // Test making a rotation matrix associated with X-rotation.

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -18,6 +18,7 @@
 using Eigen::Vector3d;
 using Eigen::Matrix3d;
 
+using drake::math::RotationMatrixd;
 using drake::symbolic::Expression;
 
 using std::sqrt;
@@ -58,7 +59,7 @@ class TestMixedIntegerRotationConstraint {
     return IsFeasibleCheck(&prog_, feasibility_constraint_, R_to_check);
   }
 
-  bool IsFeasible(const math::RotationMatrixd& R_to_check) {
+  bool IsFeasible(const RotationMatrixd& R_to_check) {
     return IsFeasible(R_to_check.matrix());
   }
 
@@ -66,25 +67,25 @@ class TestMixedIntegerRotationConstraint {
     // If R is exactly on SO(3), test whether it also satisfies our relaxation.
 
     // Test a few valid rotation matrices.
-    math::RotationMatrixd R_test;  // Identity matrix.
+    RotationMatrixd R_test;  // Identity matrix.
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeZRotation(M_PI_4) * R_test;
+    R_test = RotationMatrixd::MakeZRotation(M_PI_4) * R_test;
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4) * R_test;
+    R_test = RotationMatrixd::MakeYRotation(M_PI_4) * R_test;
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeZRotation(M_PI_2);
+    R_test = RotationMatrixd::MakeZRotation(M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeZRotation(-M_PI_2);
+    R_test = RotationMatrixd::MakeZRotation(-M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeYRotation(M_PI_2);
+    R_test = RotationMatrixd::MakeYRotation(M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeYRotation(-M_PI_2);
+    R_test = RotationMatrixd::MakeYRotation(-M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
     // This one caught a bug (in the loop finding the most conservative linear
@@ -131,10 +132,10 @@ class TestMixedIntegerRotationConstraint {
     R_test(2, 2) = -1;
     EXPECT_FALSE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeZRotation(M_PI_4).matrix() * R_test;
+    R_test = RotationMatrixd::MakeZRotation(M_PI_4).matrix() * R_test;
     EXPECT_FALSE(IsFeasible(R_test));
 
-    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4).matrix() * R_test;
+    R_test = RotationMatrixd::MakeYRotation(M_PI_4).matrix() * R_test;
     EXPECT_FALSE(IsFeasible(R_test));
 
     // Checks a few cases just outside the L1 ball. If we use the formulation
@@ -142,7 +143,7 @@ class TestMixedIntegerRotationConstraint {
     // envelope, then it should always be infeasible. Otherwise should be
     // feasible for num_intervals_per_half_axis_=1, but infeasible for
     // num_intervals_per_half_axis_>1.
-    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4).matrix();
+    R_test = RotationMatrixd::MakeYRotation(M_PI_4).matrix();
     R_test(2, 0) -= 0.1;
     EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
     EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -58,41 +58,47 @@ class TestMixedIntegerRotationConstraint {
     return IsFeasibleCheck(&prog_, feasibility_constraint_, R_to_check);
   }
 
+  bool IsFeasible(const math::RotationMatrixd& R_to_check) {
+    return IsFeasible(R_to_check.matrix());
+  }
+
   void TestExactRotationMatrix() {
     // If R is exactly on SO(3), test whether it also satisfies our relaxation.
 
     // Test a few valid rotation matrices.
-    Matrix3d R_test = Matrix3d::Identity();
+    math::RotationMatrixd R_test;  // Identity matrix.
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::ZRotation(M_PI_4) * R_test;
+    R_test = math::RotationMatrixd::MakeZRotation(M_PI_4) * R_test;
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::YRotation(M_PI_4) * R_test;
+    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4) * R_test;
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::ZRotation(M_PI_2);
+    R_test = math::RotationMatrixd::MakeZRotation(M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::ZRotation(-M_PI_2);
+    R_test = math::RotationMatrixd::MakeZRotation(-M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::YRotation(M_PI_2);
+    R_test = math::RotationMatrixd::MakeYRotation(M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
-    R_test = math::YRotation(-M_PI_2);
+    R_test = math::RotationMatrixd::MakeYRotation(-M_PI_2);
     EXPECT_TRUE(IsFeasible(R_test));
 
     // This one caught a bug (in the loop finding the most conservative linear
     // constraint for a given region) during random testing.
-    R_test << 0.17082017792981191, 0.65144498431260445, -0.73921573253413542,
-        -0.82327804434149443, -0.31781600529013027, -0.47032568342231595,
-        -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
+    Matrix3d R_check;
+    R_check << 0.17082017792981191, 0.65144498431260445, -0.73921573253413542,
+              -0.82327804434149443, -0.31781600529013027, -0.47032568342231595,
+              -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
+    R_test.SetOrThrowIfNotValidInDebugBuild(R_check);
     EXPECT_TRUE(IsFeasible(R_test));
 
     std::mt19937 generator(41);
     for (int i = 0; i < 40; i++) {
-      R_test = math::UniformlyRandomRotationMatrix(&generator).matrix();
+      R_test = math::UniformlyRandomRotationMatrix(&generator);
       EXPECT_TRUE(IsFeasible(R_test));
     }
   }
@@ -126,10 +132,10 @@ class TestMixedIntegerRotationConstraint {
     R_test(2, 2) = -1;
     EXPECT_FALSE(IsFeasible(R_test));
 
-    R_test = math::ZRotation(M_PI_4) * R_test;
+    R_test = math::RotationMatrixd::MakeZRotation(M_PI_4).matrix() * R_test;
     EXPECT_FALSE(IsFeasible(R_test));
 
-    R_test = math::YRotation(M_PI_4) * R_test;
+    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4).matrix() * R_test;
     EXPECT_FALSE(IsFeasible(R_test));
 
     // Checks a few cases just outside the L1 ball. If we use the formulation
@@ -137,7 +143,7 @@ class TestMixedIntegerRotationConstraint {
     // envelope, then it should always be infeasible. Otherwise should be
     // feasible for num_intervals_per_half_axis_=1, but infeasible for
     // num_intervals_per_half_axis_>1.
-    R_test = math::YRotation(M_PI_4);
+    R_test = math::RotationMatrixd::MakeYRotation(M_PI_4).matrix();
     R_test(2, 0) -= 0.1;
     EXPECT_GT(R_test.col(0).lpNorm<1>(), 1.0);
     EXPECT_GT(R_test.row(2).lpNorm<1>(), 1.0);

--- a/solvers/test/mixed_integer_rotation_constraint_test.cc
+++ b/solvers/test/mixed_integer_rotation_constraint_test.cc
@@ -93,8 +93,7 @@ class TestMixedIntegerRotationConstraint {
     R_check << 0.17082017792981191, 0.65144498431260445, -0.73921573253413542,
               -0.82327804434149443, -0.31781600529013027, -0.47032568342231595,
               -0.54132589862048197, 0.68892119955432829, 0.48203096610835455;
-    R_test.SetOrThrowIfNotValidInDebugBuild(R_check);
-    EXPECT_TRUE(IsFeasible(R_test));
+    EXPECT_TRUE(IsFeasible(R_check));
 
     std::mt19937 generator(41);
     for (int i = 0; i < 40; i++) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9089)
<!-- Reviewable:end -->
