### PR TITLE
enable stream logger for mosek.

### DIFF
--- a/solvers/BUILD.bazel
+++ b/solvers/BUILD.bazel
@@ -1053,6 +1053,8 @@ drake_cc_googletest(
         ":quadratic_program_examples",
         ":second_order_cone_program_examples",
         ":semidefinite_program_examples",
+        "//common:temp_directory",
+        "@spruce",
     ],
 )
 

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -21,8 +21,9 @@ namespace {
 
 // This function is used to print information for each iteration to the console,
 // it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
-// https://docs.mosek.com/8.1/capi/solver-io.html.
-static void MSKAPI printstr(void* handle, const char str[]) {
+// https://docs.mosek.com/8.1/capi/solver-io.html. This printstr is copied
+// directly from https://docs.mosek.com/8.1/capi/solver-io.html#stream-logging.
+void MSKAPI printstr(void* , const char str[]) {
   printf("%s", str);
 }
 
@@ -713,7 +714,8 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
   }
   if (rescode == MSK_RES_OK && stream_logging_) {
     if (log_file_.empty()) {
-      rescode = MSK_linkfunctotaskstream(task, MSK_STREAM_LOG, NULL, printstr);
+      rescode =
+          MSK_linkfunctotaskstream(task, MSK_STREAM_LOG, nullptr, printstr);
     } else {
       rescode =
           MSK_linkfiletotaskstream(task, MSK_STREAM_LOG, log_file_.c_str(), 0);

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -19,6 +19,13 @@ namespace drake {
 namespace solvers {
 namespace {
 
+// This function is used to print information for each iteration to the console,
+// it will show PRSTATUS, PFEAS, DFEAS, etc. For more information, check out
+// https://docs.mosek.com/8.1/capi/solver-io.html.
+static void MSKAPI printstr(void* handle, const char str[]) {
+  printf("%s", str);
+}
+
 // Add LinearConstraints and LinearEqualityConstraints to the Mosek task.
 template <typename C>
 MSKrescodee AddLinearConstraintsFromBindings(
@@ -703,6 +710,14 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
   // Add linear matrix inequality constraints.
   if (rescode == MSK_RES_OK) {
     rescode = AddLinearMatrixInequalityConstraint(prog, &task);
+  }
+  if (rescode == MSK_RES_OK && stream_logging_) {
+    if (log_file_.empty()) {
+      rescode = MSK_linkfunctotaskstream(task, MSK_STREAM_LOG, NULL, printstr);
+    } else {
+      rescode =
+          MSK_linkfiletotaskstream(task, MSK_STREAM_LOG, log_file_.c_str(), 0);
+    }
   }
 
   SolutionResult result = SolutionResult::kUnknownError;

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -73,7 +73,9 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   // or a log file. Default to false, such that the solver runs silently.
   // Check out https://docs.mosek.com/8.1/capi/solver-io.html for more info.
   bool stream_logging_{false};
-  // The log file
+  // set @p log_file to the name of that file. If the user wants to output the
+  // logging to the console, then set log_file to empty string. Default to an
+  // empty string.
   std::string log_file_{};
 };
 

--- a/solvers/mosek_solver.h
+++ b/solvers/mosek_solver.h
@@ -31,6 +31,19 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   static SolverId id();
 
   /**
+   * Control stream logging. Refer to
+   * https://docs.mosek.com/8.1/capi/solver-io.html for more details.
+   * @param flag Set to true if the user want to turn on stream logging.
+   * @param log_file If the user wants to output the logging to a file, then
+   * set @p log_file to the name of that file. If the user wants to output the
+   * logging to the console, then set log_file to empty string.
+   */
+  void set_stream_logging(bool flag, const std::string& log_file) {
+    stream_logging_ = flag;
+    log_file_ = log_file;
+  }
+
+  /**
    * This type contains a valid MOSEK license environment, and is only to be
    * used from AcquireLicense().
    */
@@ -56,6 +69,12 @@ class MosekSolver : public MathematicalProgramSolverInterface {
   // during the first call of Solve() (which avoids grabbing a Mosek license
   // before we know that we actually want one).
   mutable std::shared_ptr<License> license_;
+  // Set to true if the user wants the solver to produce output to the console
+  // or a log file. Default to false, such that the solver runs silently.
+  // Check out https://docs.mosek.com/8.1/capi/solver-io.html for more info.
+  bool stream_logging_{false};
+  // The log file
+  std::string log_file_{};
 };
 
 }  // namespace solvers


### PR DESCRIPTION
Now we can see the info (PRSTATUS, DFEAS, PFEAS, etc) for each iteration in Mosek solver,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9097)
<!-- Reviewable:end -->
