### PR TITLE
Implements getter methods for fixed poses

### DIFF
--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -144,6 +144,7 @@ drake_cc_library(
         ":multibody_tree_indexes",
         ":spatial_inertia",
         "//common:autodiff",
+        "//common:nice_type_name",
         "//math:geometric_transform",
     ],
 )

--- a/multibody/multibody_tree/body.h
+++ b/multibody/multibody_tree/body.h
@@ -70,6 +70,15 @@ class BodyFrame final : public Frame<T> {
     return X_FQ;
   }
 
+  Isometry3<T> GetFixedPoseInBodyFrame() const override {
+    return Isometry3<T>::Identity();
+  }
+
+  Isometry3<T> GetFixedOffsetPoseInBody(
+      const Isometry3<T>& X_FQ) const override {
+    return X_FQ;
+  }
+
  protected:
   // Frame<T>::DoCloneToScalar() overrides.
   std::unique_ptr<Frame<double>> DoCloneToScalar(

--- a/multibody/multibody_tree/fixed_offset_frame.h
+++ b/multibody/multibody_tree/fixed_offset_frame.h
@@ -60,6 +60,11 @@ class FixedOffsetFrame final : public Frame<T> {
     return parent_frame_.CalcOffsetPoseInBody(context, X_PF_.cast<T>());
   }
 
+  Isometry3<T> GetFixedPoseInBodyFrame() const override {
+    // X_BF = X_BP * X_PF
+    return parent_frame_.GetFixedOffsetPoseInBody(X_PF_.cast<T>());
+  }
+
  protected:
   /// @name Methods to make a clone templated on different scalar types.
   ///

--- a/multibody/multibody_tree/test/frames_test.cc
+++ b/multibody/multibody_tree/test/frames_test.cc
@@ -110,11 +110,20 @@ TEST_F(FrameTests, BodyFrameCalcPoseMethods) {
   EXPECT_TRUE(frameB_->CalcPoseInBodyFrame(*context_).
       isApprox(Isometry3d::Identity()));
 
+  // Now verify the fixed pose version of the same method.
+  EXPECT_TRUE(frameB_->GetFixedPoseInBodyFrame().
+      isApprox(Isometry3d::Identity()));
+
   // Verify this method computes the pose of a frame G measured in this
   // frame F given the pose of frame G in this frame F as: X_BG = X_BF * X_FG.
   // Since in this case frame F IS the body frame B, X_BF = Id and this method
   // simply returns X_FG.
   EXPECT_TRUE(frameB_->CalcOffsetPoseInBody(*context_, X_FG_).isApprox(X_FG_));
+
+  // Now verify the fixed pose version of the same method.
+  // As in the variant above, since in this case frame F IS the body frame B,
+  // X_BF = Id and this method simply returns X_FG.
+  EXPECT_TRUE(frameB_->GetFixedOffsetPoseInBody(X_FG_).isApprox(X_FG_));
 }
 
 // Verifies the FixedOffsetFrame methods to compute poses in different frames.
@@ -127,11 +136,17 @@ TEST_F(FrameTests, FixedOffsetFrameCalcPoseMethods) {
   // Verify this method returns the pose X_BP of frame P in body frame B.
   EXPECT_TRUE(frameP_->CalcPoseInBodyFrame(*context_).isApprox(X_BP_));
 
+  // Now verify the fixed pose version of the same method.
+  EXPECT_TRUE(frameP_->GetFixedPoseInBodyFrame().isApprox(X_BP_));
+
   // Verify this method computes the pose X_BQ of a third frame Q measured in
   // the body frame B given we know the pose X_PQ of frame G in our frame P as:
   // X_BQ = X_BP * X_PQ
   EXPECT_TRUE(frameP_->CalcOffsetPoseInBody(*context_, X_PQ_).
       isApprox(X_BP_ * X_PQ_));
+
+  // Now verify the fixed pose version of the same method.
+  EXPECT_TRUE(frameP_->GetFixedOffsetPoseInBody(X_PQ_).isApprox(X_BP_ * X_PQ_));
 }
 
 // Verifies FixedOffsetFrame methods to compute poses in different frames when
@@ -146,10 +161,17 @@ TEST_F(FrameTests, ChainedFixedOffsetFrames) {
   // X_BQ = X_BP * X_PQ
   EXPECT_TRUE(frameQ_->CalcPoseInBodyFrame(*context_).isApprox(X_BP_ * X_PQ_));
 
+  // Now verify the fixed pose version of the same method.
+  EXPECT_TRUE(frameQ_->GetFixedPoseInBodyFrame().isApprox(X_BP_ * X_PQ_));
+
   // Verify this method computes the pose X_BG of a fourth frame G measured in
   // the body frame B given we know the pose X_QG of frame G in our frame Q as:
   // X_BG = X_BP * X_PQ * X_QG
   EXPECT_TRUE(frameQ_->CalcOffsetPoseInBody(*context_, X_QG_).
+      isApprox(X_BP_ * X_PQ_ * X_QG_));
+
+  // Now verify the fixed pose version of the same method.
+  EXPECT_TRUE(frameQ_->GetFixedOffsetPoseInBody(X_QG_).
       isApprox(X_BP_ * X_PQ_ * X_QG_));
 }
 


### PR DESCRIPTION
This PR introduces a couple convenience APIs to `Frame` so that we can easily retrieve poses when they are fixes (non-context dependent).

(priority bumped to high since needed for the completion of some high priority features in MBP).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9098)
<!-- Reviewable:end -->
