### PR TITLE
Removes redundant anonymous namespace

### DIFF
--- a/common/test/never_destroyed_test.cc
+++ b/common/test/never_destroyed_test.cc
@@ -9,12 +9,10 @@
 namespace drake {
 namespace {
 
-namespace {
 class Boom : public std::exception { };
 struct DtorGoesBoom {
   ~DtorGoesBoom() noexcept(false) { throw Boom(); }
 };
-}
 
 // Confirm that we see booms by default.
 GTEST_TEST(NeverDestroyedTest, BoomTest) {


### PR DESCRIPTION
The missing closing `// namespace` comment first caught my attention. Then I noticed the whole thing was already in an anonymous namespace, so I figured might as well remove the redundant one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9106)
<!-- Reviewable:end -->
