### PR TITLE
Add MBP's ContactResults to LCM system

### DIFF
--- a/examples/simple_gripper/BUILD.bazel
+++ b/examples/simple_gripper/BUILD.bazel
@@ -30,6 +30,7 @@ drake_cc_binary(
         "//geometry:geometry_visualization",
         "//math:geometric_transform",
         "//multibody/multibody_tree/multibody_plant",
+        "//multibody/multibody_tree/multibody_plant:contact_results_to_lcm",
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/analysis:implicit_euler_integrator",
         "//systems/analysis:runge_kutta2_integrator",

--- a/examples/simple_gripper/README.md
+++ b/examples/simple_gripper/README.md
@@ -55,10 +55,16 @@ bazel build //examples/simple_gripper
 Running the Example
 -------------------
 
-Launch the visualizer
+Launch the visualizer (optionally visualizing contact forces or not)
+
+Without contact forces visualized:
 ```
-./bazel-bin/tools/drake_visualizer
+./bazel-bin/tools/drake_visualizer```
+With contact forces visualized:
 ```
+./bazel-bin/tools/drake_visualizer --script multibody/rigid_body_plant/visualization/contact_viz.py
+```
+
 Launch the simulation with
 ```
 ./bazel-bin/examples/simple_gripper/simple_gripper --simulation_time=10.0

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -13,6 +13,8 @@
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results.h"
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
@@ -42,6 +44,7 @@ using drake::math::RollPitchYaw;
 using drake::math::RotationMatrix;
 using drake::multibody::Body;
 using drake::multibody::multibody_plant::CoulombFriction;
+using drake::multibody::multibody_plant::ContactResultsToLcmSystem;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::parsing::AddModelFromSdfFile;
 using drake::multibody::PrismaticJoint;
@@ -277,6 +280,18 @@ int do_main() {
   builder.Connect(scene_graph.get_pose_bundle_output_port(),
                   converter.get_input_port(0));
   builder.Connect(converter, publisher);
+
+  // Publish contact results for visualization.
+  const auto& contact_results_to_lcm =
+      *builder.AddSystem<ContactResultsToLcmSystem>(plant);
+  const auto& contact_results_publisher = *builder.AddSystem(
+      LcmPublisherSystem::Make<lcmt_contact_results_for_viz>(
+          "CONTACT_RESULTS", &lcm));
+  // Contact results to lcm msg.
+  builder.Connect(plant.get_contact_results_output_port(),
+                  contact_results_to_lcm.get_input_port(0));
+  builder.Connect(contact_results_to_lcm.get_output_port(0),
+                  contact_results_publisher.get_input_port());
 
   // Sinusoidal force input. We want the gripper to follow a trajectory of the
   // form x(t) = X0 * sin(ω⋅t). By differentiating once, we can compute the

--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -75,6 +75,28 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "contact_results_to_lcm",
+    srcs = [
+        "contact_results_to_lcm.cc",
+    ],
+    hdrs = [
+        "contact_results_to_lcm.h",
+    ],
+    tags = [
+        # Don't add this library into the ":multibody_plant" package library.
+        # Use of MBP doesn't imply use of contact visualization so this
+        # dependency should be invoked explicitly.
+        "exclude_from_package",
+    ],
+    deps = [
+        ":contact_results",
+        ":multibody_plant",
+        "//lcmtypes:contact_info_for_viz",
+        "//lcmtypes:contact_results_for_viz",
+    ],
+)
+
+drake_cc_library(
     name = "coulomb_friction",
     srcs = [
         "coulomb_friction.cc",
@@ -121,6 +143,15 @@ drake_cc_googletest(
         "//common/test_utilities:eigen_matrix_compare",
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/analysis:simulator",
+    ],
+)
+
+drake_cc_googletest(
+    name = "contact_results_to_lcm_test",
+    deps = [
+        ":contact_results_to_lcm",
+        "//common/test_utilities:eigen_geometry_compare",
+        "//multibody/benchmarks/acrobot",
     ],
 )
 

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
@@ -1,0 +1,93 @@
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h"
+
+#include <memory>
+
+#include "drake/common/default_scalars.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/systems/framework/value.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+using systems::Context;
+using systems::Value;
+
+template <typename T>
+ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
+    const MultibodyPlant<T>& plant)
+    : systems::LeafSystem<T>() {
+  DRAKE_DEMAND(plant.is_finalized());
+  const int body_count = plant.num_bodies();
+  const MultibodyTree<T>& model = plant.model();
+
+  body_names_.reserve(body_count);
+  using std::to_string;
+  for (BodyIndex i{0}; i < body_count; ++i) {
+    const Body<T>& body = model.get_body(i);
+    body_names_.push_back(body.name() + "(" + to_string(body.model_instance()) +
+                          ")");
+  }
+  this->set_name("ContactResultsToLcmSystem");
+  // Must be the first declared input port to be compatible with the constexpr
+  // declaration of contact_result_input_port_index_.
+  this->DeclareAbstractInputPort(Value<ContactResults<T>>());
+  this->DeclareAbstractOutputPort(
+      &ContactResultsToLcmSystem::CalcLcmContactOutput);
+}
+
+template <typename T>
+const systems::InputPortDescriptor<T>&
+ContactResultsToLcmSystem<T>::get_contact_result_input_port() const {
+  return this->get_input_port(contact_result_input_port_index_);
+}
+
+template <typename T>
+const systems::OutputPort<T>&
+ContactResultsToLcmSystem<T>::get_lcm_message_output_port() const {
+  return this->get_output_port(message_output_port_index_);
+}
+
+template <typename T>
+void ContactResultsToLcmSystem<T>::CalcLcmContactOutput(
+    const Context<T>& context, lcmt_contact_results_for_viz* output) const {
+  // Get input / output.
+  const auto& contact_results =
+      this->EvalAbstractInput(context, contact_result_input_port_index_)
+          ->template GetValue<ContactResults<T>>();
+  auto& msg = *output;
+
+  // Time in microseconds.
+  msg.timestamp = static_cast<int64_t>(
+      ExtractDoubleOrThrow(context.get_time()) * 1e6);
+  msg.num_contacts = contact_results.num_contacts();
+  msg.contact_info.resize(msg.num_contacts);
+
+  for (int i = 0; i < contact_results.num_contacts(); ++i) {
+    lcmt_contact_info_for_viz& info_msg = msg.contact_info[i];
+    info_msg.timestamp = msg.timestamp;
+
+    const PointPairContactInfo<T>& contact_info =
+        contact_results.contact_info(i);
+
+    info_msg.body1_name = body_names_.at(contact_info.bodyA_index());
+    info_msg.body2_name = body_names_.at(contact_info.bodyB_index());
+
+    auto write_double3 = [](const Vector3<T>& src, double* dest) {
+      dest[0] = ExtractDoubleOrThrow(src(0));
+      dest[1] = ExtractDoubleOrThrow(src(1));
+      dest[2] = ExtractDoubleOrThrow(src(2));
+    };
+    write_double3(contact_info.contact_point(), info_msg.contact_point);
+    write_double3(contact_info.contact_force(), info_msg.contact_force);
+    write_double3(contact_info.point_pair().nhat_BA_W, info_msg.normal);
+  }
+}
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake
+
+// This should be kept in sync with the scalars that MultibodyPlant supports.
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::multibody_plant::ContactResultsToLcmSystem)

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results.h"
+#include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+namespace multibody_plant {
+
+/** A System that encodes ContactResults into a lcmt_contact_results_for_viz
+ message. It has a single input port with type ContactResults<T> and a single
+ output port with lcmt_contact_results_for_viz.
+
+ @tparam T The scalar type. Must be a valid Eigen scalar.
+
+ Instantiated templates for the following kinds of T's are provided:
+   - double
+   - AutoDiffXd
+
+ They are already available to link against in the containing library. No other
+ values for T are currently supported.
+ */
+template <typename T>
+class ContactResultsToLcmSystem final : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ContactResultsToLcmSystem)
+
+  /** Constructs a ContactResultsToLcmSystem.
+   @param plant The MultibodyPlant that the ContactResults are generated from.
+   @pre The `plant` must be finalized already. The input port of this system
+        must be connected to the corresponding output port of `plant`.  */
+  explicit ContactResultsToLcmSystem(const MultibodyPlant<T>& plant);
+
+  /** Scalar-converting copy constructor.  */
+  template <typename U>
+  explicit ContactResultsToLcmSystem(const ContactResultsToLcmSystem<U>& other)
+      : systems::LeafSystem<T>(), body_names_(other.body_names_) {}
+
+  const systems::InputPortDescriptor<T>& get_contact_result_input_port() const;
+  const systems::OutputPort<T>& get_lcm_message_output_port() const;
+
+ private:
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U> friend class ContactResultsToLcmSystem;
+
+  void CalcLcmContactOutput(const systems::Context<T>& context,
+                            lcmt_contact_results_for_viz* output) const;
+
+  // Named indices for the i/o ports.
+  static constexpr int contact_result_input_port_index_{0};
+  static constexpr int message_output_port_index_{0};
+
+  // A mapping from body index values to body names.
+  std::vector<std::string> body_names_;
+};
+
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake

--- a/multibody/multibody_tree/multibody_plant/test/contact_results_to_lcm_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/contact_results_to_lcm_test.cc
@@ -1,0 +1,123 @@
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/lcmt_contact_results_for_viz.hpp"
+#include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
+#include "drake/multibody/multibody_tree/multibody_plant/contact_results.h"
+#include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
+#include "drake/systems/framework/context.h"
+
+namespace drake {
+
+using geometry::GeometryId;
+using geometry::PenetrationAsPointPair;
+using multibody::benchmarks::acrobot::MakeAcrobotPlant;
+using multibody::benchmarks::acrobot::AcrobotParameters;
+using systems::Value;
+
+namespace multibody {
+namespace multibody_plant {
+namespace {
+
+// Confirm that an empty multibody plant produces an empty lcm message.
+GTEST_TEST(ContactResultToLcmSystem, EmptyMultibodyPlant) {
+  MultibodyPlant<double> plant;
+  plant.Finalize();
+  ContactResultsToLcmSystem<double> lcm_system(plant);
+  auto lcm_context = lcm_system.AllocateContext();
+  lcm_context->FixInputPort(
+      lcm_system.get_contact_result_input_port().get_index(),
+      systems::Value<ContactResults<double>>());
+
+  Value<lcmt_contact_results_for_viz> lcm_message_value;
+  lcm_system.get_lcm_message_output_port().Calc(*lcm_context,
+                                                &lcm_message_value);
+
+  const lcmt_contact_results_for_viz& lcm_message =
+      lcm_message_value.GetValue<lcmt_contact_results_for_viz>();
+
+  // We haven't stepped, so we should assume the time is the context's default
+  // value.
+  EXPECT_EQ(lcm_message.timestamp, 0);
+  EXPECT_EQ(lcm_message.num_contacts, 0);
+}
+
+// Common case: confirm that the reported contacts map to the right lcm message.
+// In this test, we're using a MBP that doesn't actually have collision
+// geometry, but simulate collision results by reporting that two bodies are
+// colliding. That is enough to test the ContactResultsToLcmSystem.
+GTEST_TEST(ContactResultToLcmSystem, NonEmptyMultibodyPlantEmptyContact) {
+  using std::to_string;
+  const AcrobotParameters parameters;
+  std::unique_ptr<MultibodyPlant<double>> plant =
+      MakeAcrobotPlant(parameters, true /* finalize */);
+
+  ContactResultsToLcmSystem<double> lcm_system(*plant);
+
+  // Create ContactResults with single reported contact.
+  ContactResults<double> contacts;
+  // NOTE: The values in penetration_data are irrelevant except for nhat_BA_W.
+  // So, only that value is set; all other values are left as default.
+  PenetrationAsPointPair<double> penetration_data;
+  penetration_data.nhat_BA_W << 1, 2, 3;
+  const auto& link1 = plant->GetBodyByName(parameters.link1_name());
+  const BodyIndex index1 = link1.index();
+  const ModelInstanceIndex model_instance = link1.model_instance();
+  const std::string name1 =
+      parameters.link1_name() + "(" + to_string(model_instance) + ")";
+  const BodyIndex index2 =
+      plant->GetBodyByName(parameters.link2_name()).index();
+  // Assume that link1 and link2 belong to the same model instance.
+  const std::string name2 =
+      parameters.link2_name() + "(" + to_string(model_instance) + ")";
+  const Vector3<double> f_BC_W = Vector3<double>{1, 2, 3};
+  const Vector3<double> p_WC = Vector3<double>{-1, -2, -2};
+  const double separation_speed = 0.25;
+  const double slip_speed = 0.5;
+  PointPairContactInfo<double> pair_info{
+      index1,           index2,     f_BC_W,          p_WC,
+      separation_speed, slip_speed, penetration_data};
+  contacts.AddContactInfo(pair_info);
+  Value<ContactResults<double>> contacts_value(contacts);
+  auto lcm_context = lcm_system.AllocateContext();
+  lcm_context->FixInputPort(
+      lcm_system.get_contact_result_input_port().get_index(),
+      systems::Value<ContactResults<double>>(contacts));
+
+  Value<lcmt_contact_results_for_viz> lcm_message_value;
+  lcm_system.get_lcm_message_output_port().Calc(*lcm_context,
+                                                &lcm_message_value);
+  const lcmt_contact_results_for_viz& lcm_message =
+      lcm_message_value.GetValue<lcmt_contact_results_for_viz>();
+
+  // We haven't stepped, so we should assume the time is the context's default
+  // value.
+  EXPECT_EQ(lcm_message.timestamp, 0);
+  ASSERT_EQ(lcm_message.num_contacts, 1);
+  const lcmt_contact_info_for_viz& info_msg = lcm_message.contact_info[0];
+  EXPECT_EQ(info_msg.timestamp, 0);
+  EXPECT_EQ(info_msg.body1_name, name1);
+  EXPECT_EQ(info_msg.body2_name, name2);
+  CompareMatrices(Vector3<double>(info_msg.contact_point), p_WC, 0,
+                  MatrixCompareType::absolute);
+  CompareMatrices(Vector3<double>(info_msg.contact_force), f_BC_W, 0,
+                  MatrixCompareType::absolute);
+  CompareMatrices(Vector3<double>(info_msg.normal), penetration_data.nhat_BA_W,
+                  0, MatrixCompareType::absolute);
+}
+
+// Confirm that the system can be transmogrified to other supported scalars.
+GTEST_TEST(ContractResultToLcmSystem, Transmogrify) {
+  MultibodyPlant<double> plant;
+  plant.Finalize();
+  ContactResultsToLcmSystem<double> lcm_system(plant);
+
+  ContactResultsToLcmSystem<AutoDiffXd> lcm_system_ad(lcm_system);
+}
+
+}  // namespace
+}  // namespace multibody_plant
+}  // namespace multibody
+}  // namespace drake


### PR DESCRIPTION
Adds a system that converts MBP ContactResult output port contents into an LCM-compatible message.

1. Add new class to do the conversion.
2. Unit tests.
3. Wire into concrete example (simple gripper).

```
Category            added  modified  removed  
----------------------------------------------
code                205    0         0        
comments            37     0         0        
blank               49     0         0        
----------------------------------------------
TOTAL               291    0         0    
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9112)
<!-- Reviewable:end -->
