### PR TITLE
Enable caching in Drake (but disabled by default)

### DIFF
--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -61,7 +61,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   template <typename Derived>
   explicit PiecewisePolynomial(const Eigen::MatrixBase<Derived>& value)
       : PiecewiseTrajectory<T>(std::vector<double>(
-            {{0.0, std::numeric_limits<double>::infinity()}})) {
+            {0.0, std::numeric_limits<double>::infinity()})) {
     polynomials_.push_back(value.template cast<PolynomialType>());
   }
 

--- a/examples/acrobot/spong_controller.h
+++ b/examples/acrobot/spong_controller.h
@@ -122,8 +122,8 @@ class AcrobotSpongController : public systems::LeafSystem<T> {
       const double k_p = 50;
       const double k_d = 5;
 
-      const T PE = acrobot_.CalcPotentialEnergy(*acrobot_context_);
-      const T KE = acrobot_.CalcKineticEnergy(*acrobot_context_);
+      const T PE = acrobot_.EvalPotentialEnergy(*acrobot_context_);
+      const T KE = acrobot_.EvalKineticEnergy(*acrobot_context_);
       const T E = PE + KE;
       const T E_desired =
           (p.m1() * p.lc1() + p.m2() * (p.l1() + p.lc2())) * p.gravity();

--- a/examples/compass_gait/test/compass_gait_test.cc
+++ b/examples/compass_gait/test/compass_gait_test.cc
@@ -30,18 +30,17 @@ GTEST_TEST(CompassGaitTest, TestEnergyConservedInSwing) {
   auto context = cg.CreateDefaultContext();
   CompassGaitContinuousState<Expression>& state =
       cg.get_mutable_continuous_state(context.get());
-  auto derivatives = cg.AllocateTimeDerivatives();
 
   // Set the state vector to be symbolic variables.
   state.SetToNamedVariables();
 
   // Compute the time-derivative of the energy symbolically.
   const Expression energy =
-      cg.CalcKineticEnergy(*context) + cg.CalcPotentialEnergy(*context);
-  cg.CalcTimeDerivatives(*context, derivatives.get());
+      cg.EvalKineticEnergy(*context) + cg.EvalPotentialEnergy(*context);
+  const VectorX<Expression> derivatives =
+      cg.EvalTimeDerivatives(*context).CopyToVector();
   const Expression energy_dot =
-      energy.Jacobian(GetVariableVector(state.CopyToVector())) *
-      derivatives->CopyToVector();
+      energy.Jacobian(GetVariableVector(state.CopyToVector())) * derivatives;
 
   // Evaluate the time-derivative of energy at a few arbitrary states, it
   // should be zero.

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.cc
@@ -28,8 +28,6 @@ void QpOutputTranslatorSystem::CalcActuationTorques(
   // Output:
   auto out_vector = output->get_mutable_value();
 
-  // TODO(sherm1) This computation should be cached so it will be evaluated
-  // when first requested and then available for re-use.
   out_vector = robot_.B.transpose() * qp_output->dof_torques();
 
   DRAKE_ASSERT(out_vector.size() == robot_.get_num_actuators());

--- a/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
+++ b/systems/controllers/qp_inverse_dynamics/qp_output_translator_system.h
@@ -54,7 +54,6 @@ class QpOutputTranslatorSystem : public systems::LeafSystem<double> {
    * selection matrix that maps the actuator indices to the generalized
    * coordinate indices.
    */
-  // TODO(sherm1) This should be cached so it doesn't need to be recomputed.
   void CalcActuationTorques(const systems::Context<double>& context,
                             systems::BasicVector<double>* output) const;
 

--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -329,7 +329,6 @@ drake_cc_library(
     deps = [
         ":cache_and_dependency_tracker",
         ":context",
-        ":parameters",
         ":vector",
         "//common:default_scalars",
         "//common:essential",
@@ -666,6 +665,7 @@ drake_cc_googletest(
     deps = [
         ":diagram",
         "//common:essential",
+        "//common/test_utilities:expect_throws_message",
         "//common/test_utilities:is_dynamic_castable",
         "//examples/pendulum:pendulum_plant",
         "//systems/analysis/test_utilities:stateless_system",

--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -7,7 +7,6 @@
 #include "drake/common/drake_throw.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/systems/framework/context_base.h"
-#include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/parameters.h"
 #include "drake/systems/framework/state.h"
 #include "drake/systems/framework/value.h"
@@ -48,31 +47,29 @@ class Context : public ContextBase {
   Context& operator=(Context&&) = delete;
   //@}
 
-  /// Returns a deep copy of this Context.
-  // This is just an intentional shadowing of the base class method to return
-  // a more convenient type.
-  std::unique_ptr<Context<T>> Clone() const {
-    return dynamic_pointer_cast_or_throw<Context<T>>(ContextBase::Clone());
-  }
-
-  ~Context() override = default;
-
-  // =========================================================================
-  // Accessors and Mutators for Time.
+  /// @name           Accessors for locally-stored values
+  /// Methods in this group provide `const` access to values stored locally in
+  /// this %Context. The available values are:
+  /// - time
+  /// - state
+  /// - parameters
+  /// - accuracy
+  ///
+  /// Fixed input port values and cached values (including output port values)
+  /// are also stored in the %Context but are accessed indirectly via methods
+  /// like SystemBase::EvalInputValue(), through CacheEntry and OutputPort
+  /// objects, or via the FixedInputPortValue object that was returned when
+  /// an input port value was set.
+  /// @see FixInputPort()
+  //@{
 
   /// Returns the current time in seconds.
   const T& get_time() const { return get_step_info().time_sec; }
 
-  /// Set the current time in seconds.
-  virtual void set_time(const T& time_sec) {
-    step_info_.time_sec = time_sec;
+  /// Returns a const reference to the whole State.
+  const State<T>& get_state() const {
+    return do_access_state();
   }
-
-  // =========================================================================
-  // Accessors and Mutators for State.
-
-  virtual const State<T>& get_state() const = 0;
-  virtual State<T>& get_mutable_state() = 0;
 
   /// Returns true if the Context has no state.
   bool is_stateless() const {
@@ -111,18 +108,6 @@ class Context : public ContextBase {
     return count;
   }
 
-  /// Returns a mutable reference to the continuous component of the state,
-  /// which may be of size zero.
-  ContinuousState<T>& get_mutable_continuous_state() {
-    return get_mutable_state().get_mutable_continuous_state();
-  }
-
-  /// Returns a mutable reference to the continuous state vector, devoid
-  /// of second-order structure. The vector may be of size zero.
-  VectorBase<T>& get_mutable_continuous_state_vector() {
-    return get_mutable_continuous_state().get_mutable_vector();
-  }
-
   /// Returns a const reference to the continuous component of the state,
   /// which may be of size zero.
   const ContinuousState<T>& get_continuous_state() const {
@@ -153,27 +138,6 @@ class Context : public ContextBase {
     return get_discrete_state().get_vector();
   }
 
-  /// Returns a mutable reference to the discrete component of the state,
-  /// which may be of size zero.
-  DiscreteValues<T>& get_mutable_discrete_state() {
-    return get_mutable_state().get_mutable_discrete_state();
-  }
-
-  /// Returns a mutable reference to the _only_ discrete state vector.
-  /// @sa get_discrete_state_vector().
-  /// @pre There is only one discrete state group.
-  BasicVector<T>& get_mutable_discrete_state_vector() {
-    return get_mutable_discrete_state().get_mutable_vector();
-  }
-
-  /// Returns a mutable reference to group (vector) @p index of the discrete
-  /// state.
-  /// @pre @p index must identify an existing group.
-  BasicVector<T>& get_mutable_discrete_state(int index) {
-    DiscreteValues<T>& xd = get_mutable_discrete_state();
-    return xd.get_mutable_vector(index);
-  }
-
   /// Returns a const reference to group (vector) @p index of the discrete
   /// state.
   /// @pre @p index must identify an existing group.
@@ -193,31 +157,345 @@ class Context : public ContextBase {
     return get_state().get_abstract_state();
   }
 
-  /// Returns a mutable reference to the abstract component of the state,
-  /// which may be of size zero.
-  AbstractValues& get_mutable_abstract_state() {
-    return get_mutable_state().get_mutable_abstract_state();
-  }
-
-  /// Returns a mutable reference to element @p index of the abstract state.
-  /// @pre @p index must identify an existing element.
-  template <typename U>
-  U& get_mutable_abstract_state(int index) {
-    AbstractValues& xa = get_mutable_abstract_state();
-    return xa.get_mutable_value(index).GetMutableValue<U>();
-  }
-
   /// Returns a const reference to the abstract component of the
   /// state at @p index.
   /// @pre @p index must identify an existing element.
+  /// @pre the abstract state's type must match the template argument.
   template <typename U>
   const U& get_abstract_state(int index) const {
     const AbstractValues& xa = get_state().get_abstract_state();
     return xa.get_value(index).GetValue<U>();
   }
 
-  // =========================================================================
-  // Accessors and Mutators for Input.
+  /// Returns the accuracy setting (if any). Note that the return type is
+  /// `optional<double>` rather than the double value itself.
+  /// @see set_accuracy() for details.
+  const optional<double>& get_accuracy() const { return accuracy_; }
+
+  /// Returns a const reference to this %Context's parameters.
+  const Parameters<T>& get_parameters() const { return *parameters_; }
+
+  /// Returns the number of vector-valued parameters.
+  int num_numeric_parameters() const {
+    return parameters_->num_numeric_parameters();
+  }
+
+  /// Returns a const reference to the vector-valued parameter at @p index.
+  /// @pre @p index must identify an existing parameter.
+  const BasicVector<T>& get_numeric_parameter(int index) const {
+    return parameters_->get_numeric_parameter(index);
+  }
+
+  /// Returns the number of abstract-valued parameters.
+  int num_abstract_parameters() const {
+    return get_parameters().num_abstract_parameters();
+  }
+
+  /// Returns a const reference to the abstract-valued parameter at @p index.
+  /// @pre @p index must identify an existing parameter.
+  const AbstractValue& get_abstract_parameter(int index) const {
+    return get_parameters().get_abstract_parameter(index);
+  }
+  //@}
+
+  /// @name           Methods for changing locally-stored values
+  /// Methods in this group allow changes to the values of quantities stored
+  /// locally in this %Context. The changeable quantities are:
+  /// - time
+  /// - state
+  /// - parameters
+  /// - accuracy
+  /// - fixed input port values
+  ///
+  /// Expensive computations may be performed that depend on the current values
+  /// of some or all of the above quantities. For efficiency, we save the
+  /// results of such computations in the %Context so that we can reuse
+  /// those results without unnecessary recomputation.
+  ///
+  /// <h3>Terminology</h3>
+  /// We call a quantity whose value is needed in order to perform a particular
+  /// computation a _prerequisite_ of that computation, and we say that the
+  /// computation is a _dependent_ of that prerequisite. If a prerequisite's
+  /// value changes, a result computed using an earlier value is _invalid_; we
+  /// say that the prerequisite change _invalidates_ that result, and that the
+  /// result is _out of date_ with respect to its prerequisites. It is important
+  /// to note that the result of one computation can serve as a prerequisite to
+  /// another computation; we call the dependent computation a _downstream_
+  /// computation and the prerequisite an _upstream_ computation.
+  ///
+  /// <h3>Caching</h3>
+  /// Drake provides a caching system that is responsible for
+  /// - storing computed results in the %Context's _cache_, and
+  /// - ensuring that any cached result that _may_ be invalid is marked
+  ///   "out of date".
+  ///
+  /// The correctness of results reported by Drake depends critically on _every_
+  /// cached result being correctly flagged as up to date or out of date with
+  /// respect to its prerequisites. Only when it is known _for certain_ that
+  /// a result is valid can it be marked up to date. Access to cached results
+  /// is performed through `Eval()` methods that return up to date results
+  /// immediately but initiate recomputation first for results marked out of
+  /// date. The methods in the group below are responsible for ensuring that
+  /// cached results are marked out of date whenever a prerequisite value may
+  /// have changed. These methods _do not_ initiate such recomputation
+  /// themselves.
+  ///
+  /// <h3>Invalidation and "out of date" notification</h3>
+  /// Each method in this group provides the ability to change a particular
+  /// subset of the available quantities listed above. This triggers "out of
+  /// date" notifications to the cached results for all computations for which
+  /// any element of that subset is a prerequisite. Such notifications
+  /// propagate to downstream computations, whose cached results may reside
+  /// anywhere in the full Diagram context tree of which this %Context is a
+  /// part. That ensures that "out of date" flags are set correctly for the
+  /// cached results of all computations that could be made invalid by a value
+  /// change to any of the affected subset of quantities. We call this
+  /// process a _notification sweep_.
+  ///
+  /// <h3>Which method to use</h3>
+  /// Choose the most-specific method in this group that permits you to perform
+  /// the modifications you need. For example, if you need to modify only
+  /// continuous state variables, don't use a method that provides mutable
+  /// access to the whole state. That provides two performance advantages:
+  /// - fewer downstream computations need to be marked out of date, making the
+  ///   notification sweep faster, and
+  /// - fewer results will need to be recomputed later.
+  ///
+  /// The methods below may be grouped into "safe" methods that begin with
+  /// `set` or `Set` and "dangerous" methods that begin with `get_mutable`
+  /// and return a mutable reference. In addition the `FixInputPort` methods
+  /// return an object that has `get_mutable` methods with the same dangers
+  /// (see FixedInputPortValue). Prefer the safe methods when possible.
+  ///
+  /// <h4>Safe "set" methods</h4>
+  /// The `set` and `Set` methods are safe in the sense that they perform both
+  /// the "mark as out of date" notification sweep through dependent cached
+  /// results and the update to the local quantity's value. They do not return
+  /// a reference to the value object. Using these methods ensures that no value
+  /// modification can occur without an appropriate notification sweep. Also,
+  /// these methods can be used to perform multiple changes at once (say time
+  /// and state), requiring only a single notification sweep, and _may_ perform
+  /// optimizations to avoid notifications in case some of the new values are
+  /// the same as the old ones.
+  ///
+  /// <h4>Dangerous "get_mutable" methods</h4>
+  /// The `get_mutable` methods return a mutable reference to the local value
+  /// object within this %Context. The notification sweep is done prior to
+  /// returning that reference. You can then use the reference to make the
+  /// desired change. Note that with these methods we do not actually know
+  /// whether dependent computations are invalid; that depends what you do with
+  /// the reference once you have it. Nevertheless you will pay the cost of
+  /// the notifications sweep immediately and the cost of recomputation later
+  /// when you ask for the value. So don't call one of these methods unless
+  /// you are certain you will be writing through the returned reference.
+  ///
+  /// You _must not_ hold on to the returned reference expecting
+  /// to be able to make subsequent changes, because those changes can't be
+  /// seen by the framework and thus will not cause the necessary notification
+  /// sweep to occur. Instead, request the mutable reference again when
+  /// you need it so that the necessary notification sweep can be performed.
+  ///
+  /// <h3>Implementation note</h3>
+  /// Each method in the group below guarantees to mark as out of date any
+  /// dependents of the quantities to which it permits modification, including
+  /// all downstream dependents. However, the current implementations may also
+  /// perform some unnecessary notifications. If so, that is noted in the method
+  /// documentation. You should still use the most-specific available method so
+  /// that you will benefit from later improvements that result in fewer
+  /// notifications.
+  //@{
+
+  // TODO(sherm1) All these methods perform invalidation sweeps so aren't
+  // entitled to lower_case_names. Deprecate and replace (see #9205).
+
+  /// Sets the current time in seconds. Sends out of date notifications for all
+  /// time-dependent computations (at least if the time has actually changed).
+  /// Time must have the same value in every subcontext within the same Diagram
+  /// context tree so may only be modified at the root context of the tree.
+  /// @throws std::logic_error if this is not the root context.
+  // TODO(sherm1) Consider whether this should avoid the notification sweep
+  // if the new time is the same as the old time.
+  void set_time(const T& time_sec) {
+    ThrowIfNotRootContext(__func__, "Time");
+    const int64_t change_event = this->start_new_change_event();
+    PropagateTimeChange(this, time_sec, change_event);
+  }
+
+  /// Returns a mutable reference to the whole State, potentially invalidating
+  /// _all_ state-dependent computations so requiring out of date notifications
+  /// to be made for all such computations. If you don't mean to change the
+  /// whole state, use more focused methods to modify only a portion of the
+  /// state. See class documentation for more information.
+  State<T>& get_mutable_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
+    return do_access_mutable_state();
+  }
+
+  /// Returns a mutable reference to the continuous component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// continuous-state-dependent computations.
+  ContinuousState<T>& get_mutable_continuous_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllContinuousStateChanged);
+    return do_access_mutable_state().get_mutable_continuous_state();
+  }
+
+  /// Returns a mutable reference to the continuous state vector, devoid
+  /// of second-order structure. The vector may be of size zero. Sends out of
+  /// date notifications for all continuous-state-dependent computations.
+  VectorBase<T>& get_mutable_continuous_state_vector() {
+    return get_mutable_continuous_state().get_mutable_vector();
+  }
+
+  // TODO(sherm1) Add more-specific state "set" methods for smaller
+  // state groupings (issue #9205).
+
+  /// Sets the continuous state to @p xc, including q, v, and z partitions.
+  /// The supplied vector must be the same size as the existing continuous
+  /// state. Sends out of date notifications for all continuous-state-dependent
+  /// computations.
+  void SetContinuousState(const Eigen::Ref<const VectorX<T>>& xc) {
+    get_mutable_continuous_state().SetFromVector(xc);
+  }
+
+  /// Sets time to @p time_sec and continuous state to @p xc. Performs a single
+  /// notification sweep to avoid duplicate notifications for computations that
+  /// depend on both time and state.
+  /// @throws std::logic_error if this is not the root context.
+  // TODO(sherm1) Consider whether this should avoid invalidation of
+  // time-dependent quantities if the new time is the same as the old time.
+  void SetTimeAndContinuousState(const T& time_sec,
+                                 const Eigen::Ref<const VectorX<T>>& xc) {
+    ThrowIfNotRootContext(__func__, "Time");
+    const int64_t change_event = this->start_new_change_event();
+    PropagateTimeChange(this, time_sec, change_event);
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllContinuousStateChanged);
+    do_access_mutable_state().get_mutable_continuous_state().SetFromVector(xc);
+  }
+
+  /// Returns a mutable reference to the discrete component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// discrete-state-dependent computations.
+  DiscreteValues<T>& get_mutable_discrete_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllDiscreteStateChanged);
+    return do_access_mutable_state().get_mutable_discrete_state();
+  }
+
+  /// Returns a mutable reference to the _only_ discrete state vector.
+  /// Sends out of date notifications for all discrete-state-dependent
+  /// computations.
+  /// @sa get_discrete_state_vector().
+  /// @pre There is only one discrete state group.
+  BasicVector<T>& get_mutable_discrete_state_vector() {
+    return get_mutable_discrete_state().get_mutable_vector();
+  }
+
+  /// Returns a mutable reference to group (vector) @p index of the discrete
+  /// state. Sends out of date notifications for all computations that depend
+  /// on this discrete state group.
+  /// @pre @p index must identify an existing group.
+  /// @bug Currently notifies dependents of _all_ groups.
+  // TODO(sherm1) Invalidate only dependents of this one discrete group.
+  BasicVector<T>& get_mutable_discrete_state(int index) {
+    DiscreteValues<T>& xd = get_mutable_discrete_state();
+    return xd.get_mutable_vector(index);
+  }
+
+  /// Returns a mutable reference to the abstract component of the state,
+  /// which may be of size zero. Sends out of date notifications for all
+  /// abstract-state-dependent computations.
+  AbstractValues& get_mutable_abstract_state() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllAbstractStateChanged);
+    return do_access_mutable_state().get_mutable_abstract_state();
+  }
+
+  /// Returns a mutable reference to element @p index of the abstract state.
+  /// Sends out of date notifications for all computations that depend on this
+  /// abstract state variable.
+  /// @pre @p index must identify an existing element.
+  /// @pre the abstract state's type must match the template argument.
+  /// @bug Currently notifies dependents of _any_ abstract state variable.
+  // TODO(sherm1) Invalidate only dependents of this one abstract variable.
+  template <typename U>
+  U& get_mutable_abstract_state(int index) {
+    AbstractValues& xa = get_mutable_abstract_state();
+    return xa.get_mutable_value(index).GetMutableValue<U>();
+  }
+
+  /// Returns a mutable reference to this %Context's parameters. Sends out of
+  /// date notifications for all parameter-dependent computations. If you don't
+  /// mean to change all the parameters, use the indexed methods to modify only
+  /// some of the parameters so that fewer computations are invalidated and
+  /// fewer notifications need be sent.
+  Parameters<T>& get_mutable_parameters() {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
+    return *parameters_;
+  }
+
+  /// Returns a mutable reference to element @p index of the vector-valued
+  /// (numeric) parameters. Sends out of date notifications for all computations
+  /// dependent on this parameter.
+  /// @pre @p index must identify an existing numeric parameter.
+  /// @bug Currently notifies dependents of _all_ numeric parameters.
+  // TODO(sherm1) Invalidate only dependents of this one parameter.
+  BasicVector<T>& get_mutable_numeric_parameter(int index) {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllNumericParametersChanged);
+    return parameters_->get_mutable_numeric_parameter(index);
+  }
+
+  /// Returns a mutable reference to element @p index of the abstract-valued
+  /// parameters. Sends out of date notifications for all computations dependent
+  /// on this parameter.
+  /// @pre @p index must identify an existing abstract parameter.
+  /// @bug Currently notifies dependents of _all_ abstract parameters.
+  // TODO(sherm1) Invalidate only dependents of this one parameter.
+  AbstractValue& get_mutable_abstract_parameter(int index) {
+    const int64_t change_event = this->start_new_change_event();
+    PropagateBulkChange(change_event,
+                        &Context<T>::NoteAllAbstractParametersChanged);
+    return parameters_->get_mutable_abstract_parameter(index);
+  }
+
+  /// Sets this context's time, accuracy, state, and parameters from the
+  /// `double` values in @p source, regardless of this context's scalar type.
+  /// Sends out of date notifications for all dependent computations in this
+  /// context.
+  /// @throws std::logic_error if this is not the root context.
+  /// @bug Currently does not copy fixed input port values from `source`.
+  /// See System::FixInputPortsFrom() if you want to copy those.
+  // TODO(sherm1) Should treat fixed input port values same as parameters.
+  // TODO(sherm1) Change the name of this method to be more inclusive since it
+  //              also copies accuracy (now) and fixed input port values
+  //              (pending above TODO).
+  void SetTimeStateAndParametersFrom(const Context<double>& source) {
+    ThrowIfNotRootContext(__func__, "Time");
+    // A single change event for all these changes is faster than doing
+    // each separately.
+    const int64_t change_event = this->start_new_change_event();
+
+    // These two both set the value and perform notifications.
+    PropagateTimeChange(this, T(source.get_time()), change_event);
+    PropagateAccuracyChange(this, source.get_accuracy(), change_event);
+
+    // Notification is separate from the actual value change for bulk changes.
+    PropagateBulkChange(change_event, &Context<T>::NoteAllStateChanged);
+    do_access_mutable_state().SetFrom(source.get_state());
+
+    PropagateBulkChange(change_event, &Context<T>::NoteAllParametersChanged);
+    parameters_->SetFrom(source.get_parameters());
+
+    // TODO(sherm1) Fixed input copying goes here.
+  }
 
   // Allow access to the base class method (takes an AbstractValue).
   using ContextBase::FixInputPort;
@@ -256,65 +534,23 @@ class Context : public ContextBase {
     return FixInputPort(index, *vec);
   }
 
-  // =========================================================================
-  // Accessors and Mutators for Parameters.
-
-  /// Returns a const reference to this %Context's parameters.
-  const Parameters<T>& get_parameters() const { return *parameters_; }
-
-  /// Returns a mutable reference to this %Context's parameters.
-  Parameters<T>& get_mutable_parameters() {
-    return *parameters_;
-  }
-
-  /// Returns the number of vector-valued parameters.
-  int num_numeric_parameters() const {
-    return parameters_->num_numeric_parameters();
-  }
-
-  /// Returns a const reference to the vector-valued parameter at @p index.
-  /// @pre @p index must identify an existing parameter.
-  const BasicVector<T>& get_numeric_parameter(int index) const {
-    return parameters_->get_numeric_parameter(index);
-  }
-
-  /// Returns a mutable reference to element @p index of the vector-valued
-  /// parameters.
-  /// @pre @p index must identify an existing parameter.
-  BasicVector<T>& get_mutable_numeric_parameter(int index) {
-    return parameters_->get_mutable_numeric_parameter(index);
-  }
-
-  /// Returns the number of abstract-valued parameters.
-  int num_abstract_parameters() const {
-    return get_parameters().num_abstract_parameters();
-  }
-
-  /// Returns a const reference to the abstract-valued parameter at @p index.
-  /// @pre @p index must identify an existing parameter.
-  const AbstractValue& get_abstract_parameter(int index) const {
-    return get_parameters().get_abstract_parameter(index);
-  }
-
-  /// Returns a mutable reference to element @p index of the abstract-valued
-  /// parameters.
-  /// @pre @p index must identify an existing parameter.
-  AbstractValue& get_mutable_abstract_parameter(int index) {
-    return get_mutable_parameters().get_mutable_abstract_parameter(index);
-  }
-
-  // =========================================================================
-  // Accessors and Mutators for Accuracy.
-
   /// Records the user's requested accuracy. If no accuracy is requested,
   /// computations are free to choose suitable defaults, or to refuse to
-  /// proceed without an explicit accuracy setting.
+  /// proceed without an explicit accuracy setting. Any accuracy-dependent
+  /// computation in this Context and its subcontexts may be invalidated
+  /// by a change to the accuracy setting, so out of date notifications are
+  /// sent to all such computations (at least if the accuracy setting has
+  /// actually changed). Accuracy must have the same value in every subcontext
+  /// within the same context tree so may only be modified at the root context
+  /// of a tree.
+  ///
+  /// @throws std::logic_error if this is not the root context.
   ///
   /// Requested accuracy is stored in the %Context for two reasons:
   /// - It permits all computations performed over a System to see the _same_
   ///   accuracy request since accuracy is stored in one shared place, and
-  /// - it allows us to invalidate accuracy-dependent cached computations when
-  ///   the requested accuracy has changed.
+  /// - it allows us to notify accuracy-dependent cached results that they are
+  ///   out of date when the accuracy setting changes.
   ///
   /// The accuracy of a complete simulation or other numerical study depends on
   /// the accuracy of _all_ contributing computations, so it is important that
@@ -332,36 +568,30 @@ class Context : public ContextBase {
   /// The common thread among these examples is that they all share the
   /// same %Context, so by keeping accuracy here it can be used effectively to
   /// control all accuracy-dependent computations.
-  // TODO(edrumwri) Invalidate all cached accuracy-dependent computations, and
-  // propagate accuracy to all subcontexts in a diagram context.
-  virtual void set_accuracy(const optional<double>& accuracy) {
-    accuracy_ = accuracy;
+  // TODO(sherm1) Consider whether to avoid invalidation if the new value is
+  // the same as the old one.
+  void set_accuracy(const optional<double>& accuracy) {
+    ThrowIfNotRootContext(__func__, "Accuracy");
+    const int64_t change_event = this->start_new_change_event();
+    PropagateAccuracyChange(this, accuracy, change_event);
   }
+  //@}
 
-  /// Returns the accuracy setting (if any).
-  /// @see set_accuracy() for details.
-  const optional<double>& get_accuracy() const { return accuracy_; }
+  /// @name             Miscellaneous public methods
+  //@{
 
-  // =========================================================================
-  // Miscellaneous Public Methods
+  /// Returns a deep copy of this Context.
+  // This is just an intentional shadowing of the base class method to return
+  // a more convenient type.
+  std::unique_ptr<Context<T>> Clone() const {
+    return dynamic_pointer_cast_or_throw<Context<T>>(ContextBase::Clone());
+  }
 
   /// Returns a deep copy of this Context's State.
   std::unique_ptr<State<T>> CloneState() const {
     return DoCloneState();
   }
-
-  /// Initializes this context's time, state, and parameters from the real
-  /// values in @p source, regardless of this context's scalar type.
-  /// Requires a constructor T(double).
-  // TODO(sherm1) Should treat fixed input port values same as parameters.
-  void SetTimeStateAndParametersFrom(const Context<double>& source) {
-    set_time(T(source.get_time()));
-    set_accuracy(source.get_accuracy());
-    get_mutable_state().SetFrom(source.get_state());
-    get_mutable_parameters().SetFrom(source.get_parameters());
-
-    // TODO(sherm1) Fixed input copying goes here.
-  }
+  //@}
 
  protected:
   Context() = default;
@@ -373,9 +603,48 @@ class Context : public ContextBase {
   // the local member copy constructors.
   Context(const Context<T>&) = default;
 
-  /// Clones a context but without any of its internal pointers.
-  // Structuring this as a static method permits a DiagramContext to invoke
-  // this protected functionality on its children.
+  // Structuring these methods as statics permits a DiagramContext to invoke
+  // the protected functionality on its children.
+
+  /// (Internal use only) Sets a new time and notifies time-dependent
+  /// quantities that they are now invalid, as part of a given change event.
+  static void PropagateTimeChange(Context<T>* context, const T& time_sec,
+                                  int64_t change_event) {
+    DRAKE_ASSERT(context != nullptr);
+    context->NoteTimeChanged(change_event);
+    context->step_info_.time_sec = time_sec;
+    context->DoPropagateTimeChange(time_sec, change_event);
+  }
+
+  /// (Internal use only) Sets a new accuracy and notifies accuracy-dependent
+  /// quantities that they are now invalid, as part of a given change event.
+  static void PropagateAccuracyChange(Context<T>* context,
+                                      const optional<double>& accuracy,
+                                      int64_t change_event) {
+    DRAKE_ASSERT(context != nullptr);
+    context->NoteAccuracyChanged(change_event);
+    context->accuracy_ = accuracy;
+    context->DoPropagateAccuracyChange(accuracy, change_event);
+  }
+
+  /// (Internal use only) Returns a reference to mutable parameters _without_
+  /// invalidation notifications. Use get_mutable_parameters() instead for
+  /// normal access.
+  static Parameters<T>& access_mutable_parameters(Context<T>* context) {
+    DRAKE_ASSERT(context);
+    return *context->parameters_;
+  }
+
+  /// (Internal use only) Returns a reference to a mutable state _without_
+  /// invalidation notifications. Use get_mutable_state() instead for normal
+  /// access.
+  static State<T>& access_mutable_state(Context<T>* context) {
+    DRAKE_ASSERT(context);
+    return context->do_access_mutable_state();
+  }
+
+  /// (Internal use only) Clones a context but without any of its internal
+  /// pointers.
   // This is just an intentional shadowing of the base class method to return a
   // more convenient type.
   static std::unique_ptr<Context<T>> CloneWithoutPointers(
@@ -384,44 +653,77 @@ class Context : public ContextBase {
         ContextBase::CloneWithoutPointers(source));
   }
 
-  /// Override to return the appropriate concrete State class to be returned
-  /// by CloneState().
+  /// Returns a const reference to its concrete State object.
+  virtual const State<T>& do_access_state() const = 0;
+
+  /// Returns a mutable reference to its concrete State object _without_ any
+  /// invalidation. We promise not to allow user access to this object without
+  /// invalidation.
+  virtual State<T>& do_access_mutable_state() = 0;
+
+  /// Returns the appropriate concrete State object to be returned by
+  /// CloneState().
   virtual std::unique_ptr<State<T>> DoCloneState() const = 0;
+
+  /// Invokes PropagateTimeChange() on all subcontexts of this Context. The
+  /// default implementation does nothing, which is suitable for leaf contexts.
+  /// Diagram contexts must override.
+  virtual void DoPropagateTimeChange(const T& time_sec, int64_t change_event) {
+    unused(time_sec, change_event);
+  }
+
+  /// Invokes PropagateAccuracyChange() on all subcontexts of this Context. The
+  /// default implementation does nothing, which is suitable for leaf contexts.
+  /// Diagram contexts must override.
+  virtual void DoPropagateAccuracyChange(const optional<double>& accuracy,
+                                         int64_t change_event) {
+    unused(accuracy, change_event);
+  }
 
   /// Returns a const reference to current time and step information.
   const StepInfo<T>& get_step_info() const { return step_info_; }
 
-  /// Sets the continuous state to @p xc, deleting whatever was there before.
-  /// Invalidates all continuous state-dependent computations in this context
-  /// and its subcontexts.
+  /// (Internal use only) Sets the continuous state to @p xc, deleting whatever
+  /// was there before.
+  /// @warning Does _not_ invalidate state-dependent computations.
   void init_continuous_state(std::unique_ptr<ContinuousState<T>> xc) {
-    get_mutable_state().set_continuous_state(std::move(xc));
+    do_access_mutable_state().set_continuous_state(std::move(xc));
   }
 
-  /// Sets the discrete state to @p xd, deleting whatever was there before.
-  /// Invalidates all discrete state-dependent computations in this context and
-  /// its subcontexts.
+  /// (Internal use only) Sets the discrete state to @p xd, deleting whatever
+  /// was there before.
+  /// @warning Does _not_ invalidate state-dependent computations.
   void init_discrete_state(std::unique_ptr<DiscreteValues<T>> xd) {
-    get_mutable_state().set_discrete_state(std::move(xd));
+    do_access_mutable_state().set_discrete_state(std::move(xd));
   }
 
-  /// Sets the abstract state to @p xa, deleting whatever was there before.
-  /// Invalidates all abstract state-dependent computations in this context and
-  /// its subcontexts.
+  /// (Internal use only) Sets the abstract state to @p xa, deleting whatever
+  /// was there before.
+  /// @warning Does _not_ invalidate state-dependent computations.
   void init_abstract_state(std::unique_ptr<AbstractValues> xa) {
-    get_mutable_state().set_abstract_state(std::move(xa));
+    do_access_mutable_state().set_abstract_state(std::move(xa));
   }
 
-  /// Sets the parameters to @p params, deleting whatever was there before.
-  /// You must supply a Parameters object; null is not acceptable. Invalidates
-  /// all parameter-dependent computations recursively in this context and
-  /// its subcontexts.
+  /// (Internal use only) Sets the parameters to @p params, deleting whatever
+  /// was there before. You must supply a Parameters object; null is not
+  /// acceptable.
+  /// @warning Does _not_ invalidate parameter-dependent computations.
   void init_parameters(std::unique_ptr<Parameters<T>> params) {
     DRAKE_DEMAND(params != nullptr);
     parameters_ = std::move(params);
   }
 
  private:
+  // Call with arguments like (__func__, "Time"), capitalized as shown.
+  void ThrowIfNotRootContext(const char* func_name,
+                             const char* quantity) const {
+    if (!is_root_context()) {
+      throw std::logic_error(
+          fmt::format("{}(): {} change allowed only in the root Context.",
+                      func_name, quantity));
+    }
+  }
+
   // Current time and step information.
   StepInfo<T> step_info_;
 

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -827,12 +827,21 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
     // Creates this diagram's composite data structures that collect its
     // subsystems' resources, which must have already been allocated above.
+    // No dependencies are set up in these two calls.
     context->MakeParameters();
     context->MakeState();
 
-    // Connect child subsystem input ports to the child subsystem output ports
-    // on which they depend. Declares dependency of each input port on its
-    // connected output port.
+    // Subscribe each of the Diagram's composite-entity dependency trackers to
+    // the trackers for the corresponding constituent entities in the child
+    // subsystems. This ensures that changes made at the subcontext level are
+    // propagated correctly to the diagram context level. That includes state
+    // and parameter changes, as well as local changes that affect composite
+    // diagram-level computations like xcdot and pe.
+    context->SubscribeDiagramCompositeTrackersToChildrens();
+
+    // Peer-to-peer connections wire a child subsystem's input port to a
+    // child subsystem's output port. Subscribe each child input port to the
+    // child output port on which it depends.
     for (const auto& connection : connection_map_) {
       const OutputPortLocator& src = connection.second;
       const InputPortLocator& dest = connection.first;
@@ -841,23 +850,28 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
           ConvertToContextPortIdentifier(dest));
     }
 
-    // Diagram-external input ports are exported from child subsystems. Inform
-    // the new context so that it it can set up dependency tracking for the
-    // child subsystem's input port on its parent Diagram's input port.
+    // Diagram-external input ports are exported from child subsystems (meaning
+    // the Diagram input is fed into the input of one of its children.
+    // Subscribe the child subsystem's input port to its parent Diagram's input
+    // port on which it depends.
     for (InputPortIndex i(0); i < this->get_num_input_ports(); ++i) {
       const InputPortLocator& id = input_port_ids_[i];
       context->SubscribeExportedInputPortToDiagramPort(
           i, ConvertToContextPortIdentifier(id));
     }
 
-    // Connect exported child subsystem output ports to the Diagram-level output
-    // ports to which they have been exported. Declares dependency of each
-    // Diagram-level output on its child-level output.
+    // Diagram-external output ports are exported from child subsystem output
+    // ports. Subscribe each Diagram-level output to the child-level output on
+    // which it depends.
     for (OutputPortIndex i(0); i < this->get_num_output_ports(); ++i) {
       const OutputPortLocator& id = output_port_ids_[i];
       context->SubscribeDiagramPortToExportedOutputPort(
           i, ConvertToContextPortIdentifier(id));
     }
+
+    // TODO(sherm1) Remove this line and the corresponding one in
+    // LeafSystem to enable caching by default in Drake (issue #9205).
+    context->DisableCaching();
 
     return context;
   }

--- a/systems/framework/diagram_context.h
+++ b/systems/framework/diagram_context.h
@@ -106,8 +106,8 @@ class DiagramState : public State<T> {
 
 /// The DiagramContext is a container for all of the data necessary to uniquely
 /// determine the computations performed by a Diagram. Specifically, a
-/// DiagramContext contains contexts and outputs for all the constituent
-/// Systems, wired up as specified by calls to `DiagramContext::Connect`.
+/// DiagramContext contains Context objects for all its constituent Systems.
+/// @see Context for more information.
 ///
 /// In general, users should not need to interact with a DiagramContext
 /// directly. Use the accessors on Diagram instead.
@@ -247,39 +247,80 @@ class DiagramContext final : public Context<T> {
     iport_tracker.SubscribeToPrerequisite(&oport_tracker);
   }
 
-  /// Generates the state vector for the entire diagram by wrapping the states
-  /// of all the constituent diagrams.
-  ///
-  /// User code should not call this method. It is for use during Diagram
-  /// context allocation only.
+  /// (Internal use only) Makes the diagram state, parameter, and composite
+  /// cache entry trackers subscribe to the corresponding constituent trackers
+  /// in the child subcontexts.
+  // Diagrams don't provide diagram-level tickets for individual
+  // discrete or abstract state or individual numerical or abstract parameters.
+  // That means we need only subscribe the aggregate trackers xd, xa, pn, pa
+  // to their children's xd, xa, pn, pa, resp.
+  void SubscribeDiagramCompositeTrackersToChildrens() {
+    std::vector<internal::BuiltInTicketNumbers> composites{
+        internal::kQTicket,  // Value sources.
+        internal::kVTicket,
+        internal::kZTicket,
+        internal::kXdTicket,
+        internal::kXaTicket,
+        internal::kPnTicket,
+        internal::kPaTicket,
+        internal::kXcdotTicket,  // Cache entries.
+        internal::kPeTicket,
+        internal::kKeTicket,
+        internal::kPcTicket,
+        internal::kPncTicket};
+
+    // Validate the claim above that Diagrams do not have tickets for individual
+    // variables and parameters.
+    DRAKE_DEMAND(!this->owns_any_variables_or_parameters());
+
+    // Collect the diagram trackers for each composite item above.
+    DependencyGraph& graph = this->get_mutable_dependency_graph();
+    std::vector<DependencyTracker*> diagram_trackers;
+    for (auto ticket : composites) {
+      diagram_trackers.push_back(
+          &graph.get_mutable_tracker(DependencyTicket(ticket)));
+    }
+
+    // Subscribe those trackers to the corresponding subcontext trackers.
+    for (auto& subcontext : contexts_) {
+      DependencyGraph& subgraph = subcontext->get_mutable_dependency_graph();
+      for (size_t i = 0; i < composites.size(); ++i) {
+        auto& sub_tracker =
+            subgraph.get_mutable_tracker(DependencyTicket(composites[i]));
+        diagram_trackers[i]->SubscribeToPrerequisite(&sub_tracker);
+      }
+    }
+  }
+
+  /// (Internal use only) Generates the state vector for the entire diagram by
+  /// wrapping the states of all the constituent diagrams.
   void MakeState() {
     auto state = std::make_unique<DiagramState<T>>(num_subcontexts());
     for (SubsystemIndex i(0); i < num_subcontexts(); ++i) {
-      Context<T>* context = contexts_[i].get();
-      state->set_substate(i, &context->get_mutable_state());
+      Context<T>& subcontext = *contexts_[i].get();
+      // Using `access` here to avoid sending invalidations.
+      state->set_substate(i, &Context<T>::access_mutable_state(&subcontext));
     }
     state->Finalize();
     state_ = std::move(state);
   }
 
-  /// Generates the parameters for the entire diagram by wrapping the parameters
-  /// of all the constituent Systems. The wrapper simply holds pointers to the
-  /// parameters in the subsystem Contexts.  It does not make a copy, or take
-  /// ownership.
-  ///
-  /// User code should not call this method. It is for use during Diagram
-  /// context allocation only.
+  /// (Internal use only) Generates the parameters for the entire diagram by
+  /// wrapping the parameters of all the constituent Systems. The wrapper simply
+  /// holds pointers to the parameters in the subsystem Contexts. It does not
+  /// make a copy, or take ownership.
   void MakeParameters() {
     std::vector<BasicVector<T>*> numeric_params;
     std::vector<AbstractValue*> abstract_params;
     for (auto& subcontext : contexts_) {
-      Parameters<T>& subparams = subcontext->get_mutable_parameters();
+      // Using `access` here to avoid sending invalidations.
+      Parameters<T>& subparams =
+          Context<T>::access_mutable_parameters(&*subcontext);
       for (int i = 0; i < subparams.num_numeric_parameters(); ++i) {
         numeric_params.push_back(&subparams.get_mutable_numeric_parameter(i));
       }
       for (int i = 0; i < subparams.num_abstract_parameters(); ++i) {
-        abstract_params.push_back(
-            &subparams.get_mutable_abstract_parameter(i));
+        abstract_params.push_back(&subparams.get_mutable_abstract_parameter(i));
       }
     }
     auto params = std::make_unique<Parameters<T>>();
@@ -308,37 +349,6 @@ class DiagramContext final : public Context<T> {
     DRAKE_DEMAND(index >= 0 && index < num_subcontexts());
     DRAKE_DEMAND(contexts_[index] != nullptr);
     return *contexts_[index].get();
-  }
-
-  /// Recursively sets the time on this context and all subcontexts.
-  void set_time(const T& time_sec) override {
-    Context<T>::set_time(time_sec);
-    for (auto& subcontext : contexts_) {
-      if (subcontext != nullptr) {
-        subcontext->set_time(time_sec);
-      }
-    }
-  }
-
-  /// Recursively sets the accuracy on this context and all subcontexts,
-  /// overwriting any accuracy value set in any subcontexts.
-  void set_accuracy(const optional<double>& accuracy) override {
-    Context<T>::set_accuracy(accuracy);
-    for (auto& subcontext : contexts_) {
-      if (subcontext != nullptr) {
-        subcontext->set_accuracy(accuracy);
-      }
-    }
-  }
-
-  const State<T>& get_state() const final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  State<T>& get_mutable_state() final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
   }
 
  protected:
@@ -388,6 +398,44 @@ class DiagramContext final : public Context<T> {
   // Returns the number of immediate child subcontexts in this DiagramContext.
   int num_subcontexts() const {
     return static_cast<int>(contexts_.size());
+  }
+
+  const State<T>& do_access_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  State<T>& do_access_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  // Recursively sets the time on all subcontexts.
+  void DoPropagateTimeChange(const T& time_sec, int64_t change_event) final {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      Context<T>::PropagateTimeChange(&*subcontext, time_sec, change_event);
+    }
+  }
+
+  // Recursively sets the accuracy on all subcontexts.
+  void DoPropagateAccuracyChange(const optional<double>& accuracy,
+                                 int64_t change_event) final {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      Context<T>::PropagateAccuracyChange(&*subcontext, accuracy, change_event);
+    }
+  }
+
+  // Recursively notifies subcontexts of bulk changes.
+  void DoPropagateBulkChange(
+      int64_t change_event,
+      void (ContextBase::*note_bulk_change)(int64_t change_event)) final {
+    for (auto& subcontext : contexts_) {
+      DRAKE_ASSERT(subcontext != nullptr);
+      ContextBase::PropagateBulkChange(&*subcontext, change_event,
+                                       note_bulk_change);
+    }
   }
 
   // Recursively notifies subcontexts of some caching behavior change.

--- a/systems/framework/fixed_input_port_value.cc
+++ b/systems/framework/fixed_input_port_value.cc
@@ -1,10 +1,16 @@
 #include "drake/systems/framework/fixed_input_port_value.h"
 
+#include "drake/systems/framework/context_base.h"
+
 namespace drake {
 namespace systems {
 
 AbstractValue* FixedInputPortValue::GetMutableData() {
-  // TODO(sherm1) Change event tracking goes here.
+  DRAKE_DEMAND(owning_subcontext_ != nullptr);
+  ContextBase& context = *owning_subcontext_;
+  const DependencyTracker& tracker = context.get_tracker(ticket_);
+  const int64_t change_event = context.start_new_change_event();
+  tracker.NoteValueChange(change_event);
   ++serial_number_;
   return value_.get_mutable();
 }

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -203,25 +203,36 @@ class SystemParentServiceInterface {
 // Ticket numbers for conditionally-allocated objects like ports and cache
 // entries are allocated beginning with kNextAvailableTicket defined below.
 enum BuiltInTicketNumbers {
-  kNothingTicket        =  0,
-  kTimeTicket           =  1,
-  kAccuracyTicket       =  2,
-  kQTicket              =  3,
-  kVTicket              =  4,
-  kZTicket              =  5,
-  kXcTicket             =  6,
-  kXdTicket             =  7,
-  kXaTicket             =  8,
-  kXTicket              =  9,
-  kConfigurationTicket  = 10,
-  kVelocityTicket       = 11,
-  kKinematicsTicket     = 12,
-  kAllParametersTicket  = 13,
-  kAllInputPortsTicket  = 14,
-  kAllSourcesTicket     = 15,
-  kXcdotTicket          = 16,
-  kXdhatTicket          = 17,
-  kNextAvailableTicket  = kXdhatTicket+1
+  // This set of tickets represents independent source values in a Context,
+  // and groupings of such source values.
+  kNothingTicket        =  0,  // Indicates "not dependent on anything".
+  kTimeTicket           =  1,  // Time.
+  kAccuracyTicket       =  2,  // Accuracy.
+  kQTicket              =  3,  // Continuous configuration variables.
+  kVTicket              =  4,  // Continuous velocity variables.
+  kZTicket              =  5,  // Miscellaneous continuous variables.
+  kXcTicket             =  6,  // All continuous variables xc = {q, v, z}.
+  kXdTicket             =  7,  // All discrete (numeric) state variables.
+  kXaTicket             =  8,  // All abstract state variables.
+  kXTicket              =  9,  // All state variables x = {xc, xd, xa}.
+  kPnTicket             = 10,  // All numeric parameters.
+  kPaTicket             = 11,  // All abstract parameters.
+  kAllParametersTicket  = 12,  // All parameters p = {pn, pa}.
+  kAllInputPortsTicket  = 13,  // All input ports u.
+  kAllSourcesTicket     = 14,  // All of the above.
+  kConfigurationTicket  = 15,  // All values that may affect configuration.
+  kKinematicsTicket     = 16,  // Configuration plus velocity-affecting values.
+  kLastSourceTicket     = kKinematicsTicket,  // (Used in testing.)
+
+  // The rest of these are pre-defined computations with associated cache
+  // entries.
+  kXcdotTicket          = 17,  // d/dt xc = {qdot, vdot, zdot}.
+  kPeTicket             = 18,  // Potential energy.
+  kKeTicket             = 19,  // Kinetic energy.
+  kPcTicket             = 20,  // Conservative power.
+  kPncTicket            = 21,  // Non-conservative power.
+
+  kNextAvailableTicket  = kPncTicket+1
 };
 
 // Specifies the prerequisite of an output port. It will always be either

--- a/systems/framework/leaf_context.h
+++ b/systems/framework/leaf_context.h
@@ -16,11 +16,12 @@
 namespace drake {
 namespace systems {
 
-/// %LeafContext contains all prerequisite data necessary to uniquely determine
-/// the results of computations performed by the associated LeafSystem.
-///
-/// @tparam T The mathematical type of the context, which must be a valid Eigen
-///           scalar.
+/** %LeafContext contains all prerequisite data necessary to uniquely determine
+the results of computations performed by the associated LeafSystem.
+@see Context for more information.
+
+@tparam T The mathematical type of the context, which must be a valid Eigen
+          scalar. */
 template <typename T>
 class LeafContext : public Context<T> {
  public:
@@ -35,16 +36,6 @@ class LeafContext : public Context<T> {
   LeafContext()
       : state_(std::make_unique<State<T>>()) {}
   ~LeafContext() override {}
-
-  const State<T>& get_state() const final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_;
-  }
-
-  State<T>& get_mutable_state() final {
-    DRAKE_ASSERT(state_ != nullptr);
-    return *state_.get();
-  }
 
 #ifndef DRAKE_DOXYGEN_CXX
   // Temporarily promoting these to public so that LeafSystem and testing code
@@ -90,8 +81,8 @@ class LeafContext : public Context<T> {
         xc_vector.Clone(), num_q, num_v, num_z));
 
     // Make deep copies of the discrete and abstract states.
-    clone->set_discrete_state(get_state().get_discrete_state().Clone());
-    clone->set_abstract_state(get_state().get_abstract_state().Clone());
+    clone->set_discrete_state(state_->get_discrete_state().Clone());
+    clone->set_abstract_state(state_->get_abstract_state().Clone());
 
     return clone;
   }
@@ -100,6 +91,20 @@ class LeafContext : public Context<T> {
   friend class LeafContextTest;
   using ContextBase::AddInputPort;    // For LeafContextTest.
   using ContextBase::AddOutputPort;
+  using ContextBase::AddDiscreteStateTicket;
+  using ContextBase::AddAbstractStateTicket;
+  using ContextBase::AddNumericParameterTicket;
+  using ContextBase::AddAbstractParameterTicket;
+
+  const State<T>& do_access_state() const final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
+
+  State<T>& do_access_mutable_state() final {
+    DRAKE_ASSERT(state_ != nullptr);
+    return *state_;
+  }
 
   // The state values (x) for this LeafContext; this is never null.
   std::unique_ptr<State<T>> state_;

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -84,12 +84,7 @@ class LeafOutputPort final : public OutputPort<T> {
   }
 
   // Invokes the cache entry's Eval() function.
-  // TODO(sherm1) Caching is intentionally disabled here. Enable when
-  // invalidation wiring is connected up.
   const AbstractValue& DoEval(const Context<T>& context) const final {
-    CacheEntryValue& cache_value =
-        cache_entry().get_mutable_cache_entry_value(context);
-    cache_value.mark_out_of_date();  // Force re-evaluation.
     return cache_entry().EvalAbstract(context);
   }
 

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -169,6 +169,10 @@ class LeafSystem : public System<T> {
     // Allow derived LeafSystem to validate allocated Context.
     DoValidateAllocatedLeafContext(*context);
 
+    // TODO(sherm1) Remove this line and the corresponding one in
+    // Diagram to enable caching by default in Drake.
+    context->DisableCaching();
+
     return context;
   }
 

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -80,9 +80,7 @@ class OutputPort : public OutputPortBase {
   already up to date with respect to its prerequisites, this port's Calc()
   method is used first to update the value before the reference is returned. The
   Calc() method may be arbitrarily expensive, but Eval() is constant time and
-  _very_ fast if the value is already up to date.
-  @warning Caching is currently disabled -- Calc() will be invoked. */
-  // TODO(sherm1) Remove the above warning asap. See LeafOutputPort::DoEval().
+  _very_ fast if the value is already up to date. */
   template <typename ValueType>
   const ValueType& Eval(const Context<T>& context) const {
     const AbstractValue& abstract_value = EvalAbstract(context);
@@ -126,9 +124,7 @@ class OutputPort : public OutputPortBase {
   /** Returns a reference to the value of this output port contained in the
   given Context. If that value is not up to date with respect to its
   prerequisites, the Calc() method above is used first to update the value
-  before the reference is returned.
-  @warning Caching is currently disabled -- Calc() will be invoked. */
-  // TODO(sherm1) Remove the above warning asap. See LeafOutputPort::DoEval().
+  before the reference is returned. */
   const AbstractValue& EvalAbstract(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(
         get_system_base().ThrowIfContextNotCompatible(context));

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -320,7 +320,6 @@ class System : public SystemBase {
     }
     return false;
   }
-
   //@}
 
   //----------------------------------------------------------------------------
@@ -383,23 +382,132 @@ class System : public SystemBase {
   /// a helpful message.
   //@{
 
-  /// Returns a reference to the cached value of the conservative power. If
-  /// necessary the cache will be updated first using CalcConservativePower().
-  /// @see CalcConservativePower()
-  const T& EvalConservativePower(const Context<T>& context) const {
-    // TODO(sherm1) Replace with an actual cache entry.
-    fake_cache_conservative_power_ = CalcConservativePower(context);
-    return fake_cache_conservative_power_;
+  /// Returns a reference to the cached value of the continuous state variable
+  /// time derivatives, evaluating first if necessary using
+  /// CalcTimeDerivatives().
+  ///
+  /// This method returns the time derivatives `xcdot` of the continuous state
+  /// `xc`. The referenced return object will correspond elementwise with the
+  /// continuous state in the given Context. Thus, if the state in the Context
+  /// has second-order structure `xc=[q v z]`, that same structure applies to
+  /// the derivatives so we will have `xcdot=[qdot vdot zdot]`.
+  ///
+  /// @param context The Context whose time, input port, parameter, state, and
+  /// accuracy values may be used to evaluate the derivatives.
+  ///
+  /// @retval xcdot The time derivatives of `xc` returned as a reference to an
+  ///               object of the same type and size as this %Context's
+  ///               continuous state.
+  /// @see CalcTimeDerivatives()
+  const ContinuousState<T>& EvalTimeDerivatives(
+      const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(time_derivatives_cache_index_);
+    return entry.Eval<ContinuousState<T>>(context);
   }
 
-  /// Returns a reference to the cached value of the non-conservative power. If
-  /// necessary the cache will be updated first using
-  /// CalcNonConservativePower().
-  /// @see CalcNonConservativePower()
+  /// Returns a reference to the cached value of the potential energy (PE),
+  /// evaluating first if necessary using CalcPotentialEnergy().
+  ///
+  /// By definition here, potential energy depends only on "configuration"
+  /// (e.g. orientation and position), which includes a subset of the state
+  /// variables, and parameters that affect configuration or conservative
+  /// forces (such as lengths and masses). The calculated value may also be
+  /// affected by the accuracy value supplied in the Context. PE cannot depend
+  /// explicitly on time (∂PE/∂t = 0), velocities (∂PE/∂v = 0), or input port
+  /// values (∂PE/∂u = 0).
+  ///
+  /// Non-physical systems where PE is not meaningful will return PE = 0.
+  ///
+  /// @param context The Context whose configuration variables may be used to
+  ///                evaluate potential energy.
+  /// @retval PE The potential energy in joules (J) represented by the
+  ///            configuration given in `context`.
+  /// @see CalcPotentialEnergy()
+  const T& EvalPotentialEnergy(const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(potential_energy_cache_index_);
+    return entry.Eval<T>(context);
+  }
+
+  /// Returns a reference to the cached value of the kinetic energy (KE),
+  /// evaluating first if necessary using CalcKineticEnergy().
+  ///
+  /// By definition here, kinetic energy depends only on "configuration" and
+  /// "velocity" (e.g. angular and translational velocity) of moving masses
+  /// which includes a subset of the state variables, and parameters that affect
+  /// configuration, velocities, or mass properties. The calculated value may
+  /// also be affected by the accuracy value supplied in the Context. KE cannot
+  /// depend explicitly on time (∂KE/∂t = 0) or input port values (∂KE/∂u = 0).
+  ///
+  /// Non-physical systems where KE is not meaningful will return KE = 0.
+  ///
+  /// @param context The Context whose configuration and velocity variables may
+  ///                be used to evaluate kinetic energy.
+  /// @retval KE The kinetic energy in joules (J) represented by the
+  ///            configuration and velocity given in `context`.
+  /// @see CalcKineticEnergy()
+  const T& EvalKineticEnergy(const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(kinetic_energy_cache_index_);
+    return entry.Eval<T>(context);
+  }
+
+  /// Returns a reference to the cached value of the conservative power (Pc),
+  /// evaluating first if necessary using CalcConservativePower().
+  ///
+  /// The returned Pc represents the rate at which mechanical energy is being
+  /// converted _from_ potential energy (PE) _to_ kinetic energy (KE) by this
+  /// system in the given Context. This quantity will be _positive_ when PE
+  /// is _decreasing_. By definition here, conservative power may depend only
+  /// on quantities that explicitly contribute to PE and KE. See
+  /// EvalPotentialEnergy() and EvalKineticEnergy() for details.
+  ///
+  /// Power due to non-conservative forces (e.g. dampers) can contribute to the
+  /// rate of change of KE. Therefore this method alone cannot be used to
+  /// determine whether KE is increasing or decreasing, only whether the
+  /// conservative power is adding or removing kinetic energy.
+  /// EvalNonConservativePower() can be used in conjunction with this method to
+  /// find the total rate of change of KE.
+  ///
+  /// Non-physical systems where Pc is not meaningful will return Pc = 0.
+  ///
+  /// @param context The Context whose contents may be used to evaluate
+  ///                conservative power.
+  /// @retval Pc The conservative power in watts (W or J/s) represented by the
+  ///            contents of the given `context`.
+  /// @see CalcConservativePower(), EvalNonConservativePower(),
+  ///      EvalPotentialEnergy(), EvalKineticEnergy()
+  const T& EvalConservativePower(const Context<T>& context) const {
+    const CacheEntry& entry =
+        this->get_cache_entry(conservative_power_cache_index_);
+    return entry.Eval<T>(context);
+  }
+
+  /// Returns a reference to the cached value of the non-conservative power
+  /// (Pnc), evaluating first if necessary using CalcNonConservativePower().
+  ///
+  /// The returned Pnc represents the rate at which work W is done on the system
+  /// by non-conservative forces. Pnc is _negative_ if the non-conservative
+  /// forces are _dissipative_, positive otherwise. Time integration of Pnc
+  /// yields work W, and the total mechanical energy `E = PE + KE − W` should be
+  /// conserved by any physically-correct model, to within integration accuracy
+  /// of W. Power is in watts (J/s). (Watts are abbreviated W but not to be
+  /// confused with work!) Any values in the supplied Context (including time
+  /// and input ports) may contribute to the computation of non-conservative
+  /// power.
+  ///
+  /// Non-physical systems where Pnc is not meaningful will return Pnc = 0.
+  ///
+  /// @param context The Context whose contents may be used to evaluate
+  ///                non-conservative power.
+  /// @retval Pnc The non-conservative power in watts (W or J/s) represented by
+  ///             the contents of the given `context`.
+  /// @see CalcNonConservativePower(), EvalConservativePower()
   const T& EvalNonConservativePower(const Context<T>& context) const {
-    // TODO(sherm1) Replace with an actual cache entry.
-    fake_cache_nonconservative_power_ = CalcNonConservativePower(context);
-    return fake_cache_nonconservative_power_;
+    const CacheEntry& entry =
+        this->get_cache_entry(nonconservative_power_cache_index_);
+    return entry.Eval<T>(context);
   }
 
   /// Returns the value of the vector-valued input port with the given
@@ -469,9 +577,8 @@ class System : public SystemBase {
   //@}
 
   //----------------------------------------------------------------------------
-  /// @name               Constraint-related functions.
-  ///
-  // @{
+  /// @name               Constraint-related functions
+  //@{
 
   /// Gets the number of constraint equations for this system using the given
   /// context (useful in case the number of constraints is dependent upon the
@@ -547,7 +654,6 @@ class System : public SystemBase {
       throw std::logic_error("Error vector is mis-sized.");
     return DoCalcConstraintErrorNorm(context, error);
   }
-
   //@}
 
   //----------------------------------------------------------------------------
@@ -565,15 +671,13 @@ class System : public SystemBase {
   /// depend on both Context and additional input arguments.
   //@{
 
-  /// Calculates the time derivatives `xcdot` of the continuous state `xc`.
-  /// The `derivatives` vector will correspond elementwise with the continuous
-  /// state in the given Context. Thus, if the state in
-  /// the Context has second-order structure `xc=[q v z]`, that same structure
-  /// applies to the derivatives so we will have `xcdot=[qdot vdot zdot]`.
+  /// Calculates the time derivatives `xcdot` of the continuous state `xc` into
+  /// a given output argument. Prefer EvalTimeDerivatives() instead to avoid
+  /// unnecessary recomputation.
+  /// @see EvalTimeDerivatives() for more information.
   ///
-  /// @param context The Context whose time, input port, parameter, and state
-  /// values are used to evaluate the derivatives.
-  ///
+  /// @param context The Context whose contents will be used to evaluate the
+  ///                derivatives.
   /// @param derivatives The time derivatives `xcdot`. Must be the same size as
   ///                    the continuous state vector in `context`.
   void CalcTimeDerivatives(const Context<T>& context,
@@ -763,46 +867,41 @@ class System : public SystemBase {
     }
   }
 
-  /// Calculates and returns the potential energy current stored in the
-  /// configuration provided in `context`. Non-physical Systems will return
-  /// zero.
-  /// @see EvalPotentialEnergy()
+  /// Calculates and returns the potential energy represented by the current
+  /// configuration provided in `context`. Prefer EvalPotentialEnergy() to
+  /// avoid unnecessary recalculation.
+  ///
+  /// @see EvalPotentialEnergy() for more information.
   T CalcPotentialEnergy(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     return DoCalcPotentialEnergy(context);
   }
 
-  /// Calculates and returns the kinetic energy currently present in the motion
-  /// provided in the given Context. Non-physical Systems will return zero.
-  /// @see EvalKineticEnergy()
+  /// Calculates and returns the kinetic energy represented by the current
+  /// configuration and velocity provided in `context`. Prefer
+  /// EvalKineticEnergy() to avoid unnecessary recalculation.
+  ///
+  /// @see EvalKineticEnergy() for more information.
   T CalcKineticEnergy(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     return DoCalcKineticEnergy(context);
   }
 
-  /// Calculates and returns the rate at which mechanical energy is being
-  /// converted *from* potential energy *to* kinetic energy by this system in
-  /// the given Context. This quantity will be positive when potential energy is
-  /// decreasing. Note that kinetic energy will also be affected by
-  /// non-conservative forces so we can't say whether it is increasing or
-  /// decreasing in an absolute sense, only whether the conservative
-  /// power is increasing or decreasing the kinetic energy. Power is in watts
-  /// (J/s).Non-physical Systems will return zero.
-  /// @see EvalConservativePower()
+  /// Calculates and returns the conservative power represented by the current
+  /// contents of the given `context`. Prefer EvalConservativePower() to avoid
+  /// unnecessary recalculation.
+  ///
+  /// @see EvalConservativePower() for more information.
   T CalcConservativePower(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     return DoCalcConservativePower(context);
   }
 
-  /// Calculates and returns the rate at which mechanical energy is being
-  /// generated (positive) or dissipated (negative) *other than* by conversion
-  /// between potential and kinetic energy (in the given Context). Integrating
-  /// this quantity yields work W, and the total energy `E=PE+KE-W` should be
-  /// conserved by any physically-correct model, to within integration accuracy
-  /// of W. Power is in watts (J/s). (Watts are abbreviated W but not to be
-  /// confused with work!) This method is meaningful only for physical systems;
-  /// others return zero.
-  /// @see EvalNonConservativePower()
+  /// Calculates and returns the non-conservative power represented by the
+  /// current contents of the given `context`. Prefer EvalNonConservativePower()
+  /// to avoid unnecessary recalculation.
+  ///
+  /// @see EvalNonConservativePower() for more information.
   T CalcNonConservativePower(const Context<T>& context) const {
     DRAKE_ASSERT_VOID(CheckValidContext(context));
     return DoCalcNonConservativePower(context);
@@ -1132,7 +1231,6 @@ class System : public SystemBase {
   /// Returns an opaque integer that uniquely identifies this system in the
   /// Graphviz output.
   int64_t GetGraphvizId() const { return reinterpret_cast<int64_t>(this); }
-
   //@}
 
   //----------------------------------------------------------------------------
@@ -1196,7 +1294,7 @@ class System : public SystemBase {
   //@}
 
   //----------------------------------------------------------------------------
-  /// @name                Symbolics
+  /// @name                          Symbolics
   /// From a %System templatized by `double`, you can obtain an identical system
   /// templatized by a symbolic expression scalar.
 
@@ -1251,7 +1349,8 @@ class System : public SystemBase {
   //@}
 
   //----------------------------------------------------------------------------
-  /// @name                Transmogrification utilities
+  /// @name                Scalar type conversion utilities
+  //@{
 
   /// Fixes all of the input ports in @p target_context to their current values
   /// in @p other_context, as evaluated by @p other_system. Throws an exception
@@ -1298,7 +1397,6 @@ class System : public SystemBase {
   const SystemScalarConverter& get_system_scalar_converter() const {
     return system_scalar_converter_;
   }
-
   //@}
 
   /// Gets the witness functions active for the given state.
@@ -1332,8 +1430,42 @@ class System : public SystemBase {
       Event<T>* event,
       CompositeEventCollection<T>* events) const = 0;
 
-  // Promote so we don't need "this->" everywhere.
-  using SystemBase::get_name;
+  // Promote these frequently-used methods so users (and tutorial examples)
+  // don't need "this->" everywhere when in templated derived classes.
+  using SystemBase::DeclareCacheEntry;
+
+  // All pre-defined ticket methods should be listed here. They are ordered as
+  // they appear in SystemBase to make it easy to check that none are missing.
+  using SystemBase::nothing_ticket;
+  using SystemBase::time_ticket;
+  using SystemBase::accuracy_ticket;
+  using SystemBase::q_ticket;
+  using SystemBase::v_ticket;
+  using SystemBase::z_ticket;
+  using SystemBase::xc_ticket;
+  using SystemBase::discrete_state_ticket;
+  using SystemBase::xd_ticket;
+  using SystemBase::abstract_state_ticket;
+  using SystemBase::xa_ticket;
+  using SystemBase::all_state_ticket;
+  using SystemBase::numeric_parameter_ticket;
+  using SystemBase::pn_ticket;
+  using SystemBase::abstract_parameter_ticket;
+  using SystemBase::pa_ticket;
+  using SystemBase::all_parameters_ticket;
+  using SystemBase::input_port_ticket;
+  using SystemBase::all_input_ports_ticket;
+  using SystemBase::all_sources_ticket;
+  using SystemBase::cache_entry_ticket;
+  using SystemBase::configuration_ticket;
+  using SystemBase::kinematics_ticket;
+  using SystemBase::xcdot_ticket;
+  using SystemBase::pe_ticket;
+  using SystemBase::ke_ticket;
+  using SystemBase::pc_ticket;
+  using SystemBase::pnc_ticket;
+
+  // Don't promote output_port_ticket() since it is for internal use only.
 
  protected:
   /// Derived classes will implement this method to evaluate a witness function
@@ -1383,8 +1515,8 @@ class System : public SystemBase {
   /// derived implementations can assume that @p context is valid. See, e.g.,
   /// LeafSystem::DispatchPublishHandler() and Diagram::DispatchPublishHandler()
   /// for more details.
-
   //@{
+
   /// This function dispatches all publish events to the appropriate handlers.
   virtual void DispatchPublishHandler(
       const Context<T>& context,
@@ -1406,17 +1538,82 @@ class System : public SystemBase {
   //@}
 
   //----------------------------------------------------------------------------
-  /// @name                 System construction
+  /// @name                    System construction
   /// Authors of derived %Systems can use these methods in the constructor
   /// for those %Systems.
   //@{
-  /// Constructs an empty %System base class object, possibly supporting
-  /// scalar-type conversion support (AutoDiff, etc.) using @p converter.
+
+  /// Constructs an empty %System base class object and allocates base class
+  /// resources, possibly supporting scalar-type conversion support (AutoDiff,
+  /// etc.) using @p converter.
   ///
   /// See @ref system_scalar_conversion for detailed background and examples
   /// related to scalar-type conversion support.
   explicit System(SystemScalarConverter converter)
-      : system_scalar_converter_(std::move(converter)) {}
+      : system_scalar_converter_(std::move(converter)) {
+    // Note that configuration and kinematics tickets also include dependence
+    // on parameters and accuracy, but not time or input ports.
+
+    // Potential and kinetic energy, and conservative power that measures
+    // the transfer between them, must _not_ be (explicitly) time dependent.
+    // See API documentation above for Eval{Potential|Kinetic}Energy() and
+    // EvalConservativePower() to see why.
+
+    // TODO(sherm1) Due to issue #9171 we cannot always recognize which
+    // variables contribute to configuration so we'll invalidate on all changes.
+    // Use configuration, kinematics, and mass tickets when #9171 is resolved.
+    potential_energy_cache_index_ =
+        DeclareCacheEntry("potential energy",
+            &System<T>::CalcPotentialEnergy,
+            {all_sources_ticket()})  // After #9171: configuration + mass.
+            .cache_index();
+
+    kinetic_energy_cache_index_ =
+        DeclareCacheEntry("kinetic energy",
+            &System<T>::CalcKineticEnergy,
+            {all_sources_ticket()})  // After #9171: kinematics + mass.
+            .cache_index();
+
+    conservative_power_cache_index_ =
+        DeclareCacheEntry("conservative power",
+            &System<T>::CalcConservativePower,
+            {all_sources_ticket()})  // After #9171: kinematics + mass.
+            .cache_index();
+
+    // Only non-conservative power can have an explicit time or input
+    // port dependence. See API documentation above for
+    // EvalNonConservativePower() to see why.
+    nonconservative_power_cache_index_ =
+        DeclareCacheEntry("non-conservative power",
+                          &System<T>::CalcNonConservativePower,
+                          {all_sources_ticket()})  // This is correct.
+            .cache_index();
+
+    // For the time derivative cache we need to use the general form for
+    // cache creation because we're dealing with pre-defined allocator and
+    // calculator method signatures.
+    CacheEntry::AllocCallback alloc_derivatives = [this]() {
+      return std::make_unique<Value<ContinuousState<T>>>(
+          this->AllocateTimeDerivatives());
+    };
+    CacheEntry::CalcCallback calc_derivatives = [this](
+        const ContextBase& context_base, AbstractValue* result) {
+      DRAKE_DEMAND(result != nullptr);
+      ContinuousState<T>& state = result->GetMutableValue<ContinuousState<T>>();
+      const Context<T>& context = dynamic_cast<const Context<T>&>(context_base);
+      CalcTimeDerivatives(context, &state);
+    };
+
+    // We must assume that time derivatives can depend on *any* context source.
+    time_derivatives_cache_index_ =
+        this->DeclareCacheEntryWithKnownTicket(
+                xcdot_ticket(), "time derivatives",
+                std::move(alloc_derivatives), std::move(calc_derivatives),
+                {all_sources_ticket()})
+            .cache_index();
+
+    // TODO(sherm1) Allocate and use discrete update cache.
+  }
 
   /// Adds a port with the specified @p type and @p size to the input topology.
   /// If the port is intended to model a random noise or disturbance input,
@@ -1441,7 +1638,6 @@ class System : public SystemBase {
   const InputPort<T>& DeclareAbstractInputPort() {
     return DeclareInputPort(kAbstractValued, 0 /* size */);
   }
-
   //@}
 
   /// Adds an already-created constraint to the list of constraints for this
@@ -1457,6 +1653,7 @@ class System : public SystemBase {
   /// @name               Virtual methods for input allocation
   /// Authors of derived %Systems should override these methods to self-describe
   /// acceptable inputs to the %System.
+  //@{
 
   /// Allocates an input vector of the leaf type that the System requires on
   /// the port specified by @p input_port. Caller owns the returned memory.
@@ -1566,50 +1763,58 @@ class System : public SystemBase {
   }
 
   /// Override this method for physical systems to calculate the potential
-  /// energy currently stored in the configuration provided in the given
+  /// energy PE currently stored in the configuration provided in the given
   /// Context. The default implementation returns 0 which is correct for
   /// non-physical systems. You may assume that `context` has already
   /// been validated before it is passed to you here.
+  ///
+  /// See EvalPotentialEnergy() for details on what you must compute here. In
+  /// particular, your potential energy method must _not_ depend explicitly on
+  /// time, velocities, or any input port values.
   virtual T DoCalcPotentialEnergy(const Context<T>& context) const {
     unused(context);
     return T(0);
   }
 
   /// Override this method for physical systems to calculate the kinetic
-  /// energy currently present in the motion provided in the given
+  /// energy KE currently present in the motion provided in the given
   /// Context. The default implementation returns 0 which is correct for
   /// non-physical systems. You may assume that `context` has already
   /// been validated before it is passed to you here.
+  ///
+  /// See EvalKineticEnergy() for details on what you must compute here. In
+  /// particular, your kinetic energy method must _not_ depend explicitly on
+  /// time or any input port values.
   virtual T DoCalcKineticEnergy(const Context<T>& context) const {
     unused(context);
     return T(0);
   }
 
-  /// Override this method to return the rate at which mechanical energy is
-  /// being converted *from* potential energy *to* kinetic energy by this system
-  /// in the given Context. This quantity must be positive when potential energy
-  /// is *decreasing*. Power is in watts (J/s).
+  /// Override this method to return the rate Pc at which mechanical energy is
+  /// being converted _from_ potential energy _to_ kinetic energy by this system
+  /// in the given Context. By default, returns zero. Physical systems should
+  /// override. You may assume that `context` has already been validated before
+  /// it is passed to you here.
   ///
-  /// By default, returns zero. Continuous, physical systems should override.
-  /// You may assume that `context` has already been validated before it is
-  /// passed to you here.
+  /// See EvalConservativePower() for details on what you must compute here. In
+  /// particular, this quantity must be _positive_ when potential energy
+  /// is _decreasing_, and your conservative power method must _not_ depend
+  /// explicitly on time or any input port values.
   virtual T DoCalcConservativePower(const Context<T>& context) const {
     unused(context);
     return T(0);
   }
 
-  /// Override this method to return the rate at which mechanical energy is
-  /// being generated (positive) or dissipated (negative) *other than* by
-  /// conversion between potential and kinetic energy (in the given Context).
-  /// Integrating this quantity yields work W, and the total energy `E=PE+KE-W`
-  /// should be conserved by any physically-correct model, to within integration
-  /// accuracy of W. Power is in watts (J/s). (Watts are abbreviated W but not
-  /// to be confused with work!) This method is meaningful only for physical
-  /// systems; others return zero.
+  /// Override this method to return the rate Pnc at which work W is done on the
+  /// system by non-conservative forces. By default, returns zero. Physical
+  /// systems should override. You may assume that `context` has already been
+  /// validated before it is passed to you here.
   ///
-  /// By default, returns zero. Continuous, physical systems should override.
-  /// You may assume that `context` has already been validated before it is
-  /// passed to you here.
+  /// See EvalNonConservativePower() for details on what you must compute here.
+  /// In particular, this quantity must be _negative_ if the non-conservative
+  /// forces are _dissipative_, positive otherwise. Your non-conservative power
+  /// method can depend on anything you find in the given Context, including
+  /// time and input ports.
   virtual T DoCalcNonConservativePower(const Context<T>& context) const {
     unused(context);
     return T(0);
@@ -1685,8 +1890,7 @@ class System : public SystemBase {
 
   //----------------------------------------------------------------------------
   /// @name             Constraint-related functions (protected).
-  ///
-  // @{
+  //@{
 
   /// Gets the number of constraint equations for this system from the given
   /// context. The context is supplied in case the number of constraints is
@@ -1758,6 +1962,7 @@ class System : public SystemBase {
     unused(context);
     return error.norm();
   }
+  //@}
 
   //----------------------------------------------------------------------------
   /// @name                 Utility methods (protected)
@@ -1870,12 +2075,11 @@ class System : public SystemBase {
   // Functions to convert this system to use alternative scalar types.
   SystemScalarConverter system_scalar_converter_;
 
-  // TODO(sherm1) Replace these fake cache entries with real cache asap.
-  // These are temporaries and hence uninitialized.
-  mutable T fake_cache_pe_;
-  mutable T fake_cache_ke_;
-  mutable T fake_cache_conservative_power_;
-  mutable T fake_cache_nonconservative_power_;
+  CacheIndex time_derivatives_cache_index_;
+  CacheIndex potential_energy_cache_index_;
+  CacheIndex kinetic_energy_cache_index_;
+  CacheIndex conservative_power_cache_index_;
+  CacheIndex nonconservative_power_cache_index_;
 };
 
 }  // namespace systems

--- a/systems/framework/system_base.cc
+++ b/systems/framework/system_base.cc
@@ -107,47 +107,45 @@ void SystemBase::InitializeContextBase(ContextBase* context_ptr) const {
 // elements now.
 void SystemBase::CreateSourceTrackers(ContextBase* context_ptr) const {
   ContextBase& context = *context_ptr;
-  DependencyGraph& graph = context.get_mutable_dependency_graph();
 
   // Define a lambda to do the repeated work below: create trackers for
   // individual entities and subscribe the group tracker to each of them.
-  auto MakeTrackers = [&graph](
+  auto make_trackers = [&context](
       DependencyTicket subscriber_ticket,
       const std::vector<TrackerInfo>& system_ticket_info,
-      std::vector<DependencyTicket>* context_tickets) {
+      void (*add_ticket_to_context)(ContextBase*, DependencyTicket)) {
+    DependencyGraph& graph = context.get_mutable_dependency_graph();
     DependencyTracker& subscriber =
         graph.get_mutable_tracker(subscriber_ticket);
-    DRAKE_DEMAND(context_tickets->empty());
+
     for (const auto& info : system_ticket_info) {
       auto& source_tracker =
           graph.CreateNewDependencyTracker(info.ticket, info.description);
-      context_tickets->push_back(info.ticket);
+      add_ticket_to_context(&context, info.ticket);
       subscriber.SubscribeToPrerequisite(&source_tracker);
     }
   };
 
   // Allocate trackers for each discrete variable group xdᵢ, and subscribe
   // the "all discrete variables" tracker xd to those.
-  MakeTrackers(
+  make_trackers(
       xd_ticket(), discrete_state_tickets_,
-      &detail::SystemBaseContextBaseAttorney::discrete_state_tickets(&context));
+      &detail::SystemBaseContextBaseAttorney::AddDiscreteStateTicket);
 
   // Allocate trackers for each abstract state variable xaᵢ, and subscribe
   // the "all abstract variables" tracker xa to those.
-  MakeTrackers(
+  make_trackers(
       xa_ticket(), abstract_state_tickets_,
-      &detail::SystemBaseContextBaseAttorney::abstract_state_tickets(&context));
+      &detail::SystemBaseContextBaseAttorney::AddAbstractStateTicket);
 
   // Allocate trackers for each numeric parameter pnᵢ and each abstract
-  // parameter paᵢ, and subscribe the "all parameters" tracker p to those.
-  MakeTrackers(
-      all_parameters_ticket(), numeric_parameter_tickets_,
-      &detail::SystemBaseContextBaseAttorney::numeric_parameter_tickets(
-          &context));
-  MakeTrackers(
-      all_parameters_ticket(), abstract_parameter_tickets_,
-      &detail::SystemBaseContextBaseAttorney::abstract_parameter_tickets(
-          &context));
+  // parameter paᵢ, and subscribe the pn and pa trackers to them.
+  make_trackers(
+      pn_ticket(), numeric_parameter_tickets_,
+      &detail::SystemBaseContextBaseAttorney::AddNumericParameterTicket);
+  make_trackers(
+      pa_ticket(), abstract_parameter_tickets_,
+      &detail::SystemBaseContextBaseAttorney::AddAbstractParameterTicket);
 
   // Allocate trackers for each input port uᵢ, and subscribe the "all input
   // ports" tracker u to them. Doesn't use TrackerInfo so can't use the lambda.

--- a/systems/framework/system_symbolic_inspector.h
+++ b/systems/framework/system_symbolic_inspector.h
@@ -113,7 +113,7 @@ class SystemSymbolicInspector {
   /// @param i The discrete state group number.
   Eigen::VectorBlock<const VectorX<symbolic::Expression>> discrete_update(
       int i) const {
-    DRAKE_DEMAND(i >= 0 && i < static_cast<int>(discrete_updates_->size()));
+    DRAKE_DEMAND(i >= 0 && i < context_->get_num_discrete_state_groups());
     return discrete_updates_->get_vector(i).get_value();
   }
 

--- a/systems/framework/test/dependency_tracker_test.cc
+++ b/systems/framework/test/dependency_tracker_test.cc
@@ -97,32 +97,35 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   auto& xd = context.get_tracker(DT(internal::kXdTicket));
   auto& xa = context.get_tracker(DT(internal::kXaTicket));
   auto& x = context.get_tracker(DT(internal::kXTicket));
-  auto& configuration = context.get_tracker(DT(internal::kConfigurationTicket));
-  auto& velocity = context.get_tracker(DT(internal::kVelocityTicket));
-  auto& kinematics = context.get_tracker(DT(internal::kKinematicsTicket));
+  auto& pn = context.get_tracker(DT(internal::kPnTicket));
+  auto& pa = context.get_tracker(DT(internal::kPaTicket));
   auto& p = context.get_tracker(DT(internal::kAllParametersTicket));
   auto& u = context.get_tracker(DT(internal::kAllInputPortsTicket));
   auto& all_sources = context.get_tracker(DT(internal::kAllSourcesTicket));
+  auto& configuration = context.get_tracker(DT(internal::kConfigurationTicket));
+  auto& kinematics = context.get_tracker(DT(internal::kKinematicsTicket));
   auto& xc_dot = context.get_tracker(DT(internal::kXcdotTicket));
-  auto& xd_hat = context.get_tracker(DT(internal::kXdhatTicket));
+  auto& pe = context.get_tracker(DT(internal::kPeTicket));
+  auto& ke = context.get_tracker(DT(internal::kKeTicket));
+  auto& pc = context.get_tracker(DT(internal::kPcTicket));
+  auto& pnc = context.get_tracker(DT(internal::kPncTicket));
 
   // "nothing" has no prerequisites or subscribers.
   EXPECT_EQ(nothing.prerequisites().size(), 0);
   EXPECT_EQ(nothing.subscribers().size(), 0);
 
   // time and accuracy are independent. all_sources depends on both,
-  // configuration and velocity trackers depend on accuracy.
+  // configuration tracker depends on accuracy.
   EXPECT_EQ(time.prerequisites().size(), 0);
   ASSERT_EQ(time.subscribers().size(), 1);
   EXPECT_EQ(time.subscribers()[0], &all_sources);
   EXPECT_EQ(accuracy.prerequisites().size(), 0);
-  ASSERT_EQ(accuracy.subscribers().size(), 3);
+  ASSERT_EQ(accuracy.subscribers().size(), 2);
   EXPECT_EQ(accuracy.subscribers()[0], &all_sources);
   EXPECT_EQ(accuracy.subscribers()[1], &configuration);
-  EXPECT_EQ(accuracy.subscribers()[2], &velocity);
 
   // q, v, z are independent but xc subscribes to all, configuration to q,
-  // and velocity to v.
+  // and kinematics to v.
   EXPECT_EQ(q.prerequisites().size(), 0);
   ASSERT_EQ(q.subscribers().size(), 2);
   EXPECT_EQ(q.subscribers()[0], &xc);
@@ -130,10 +133,11 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   EXPECT_EQ(v.prerequisites().size(), 0);
   ASSERT_EQ(v.subscribers().size(), 2);
   EXPECT_EQ(v.subscribers()[0], &xc);
-  EXPECT_EQ(v.subscribers()[1], &velocity);
+  EXPECT_EQ(v.subscribers()[1], &kinematics);
   EXPECT_EQ(z.prerequisites().size(), 0);
-  ASSERT_EQ(z.subscribers().size(), 1);
+  ASSERT_EQ(z.subscribers().size(), 2);
   EXPECT_EQ(z.subscribers()[0], &xc);
+  EXPECT_EQ(z.subscribers()[1], &configuration);
 
   // xc depends on q, v, and z and x subscribes.
   ASSERT_EQ(xc.prerequisites().size(), 3);
@@ -143,15 +147,19 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   ASSERT_EQ(xc.subscribers().size(), 1);
   EXPECT_EQ(xc.subscribers()[0], &x);
 
-  // No discrete variables so xd is independent; x subscribes.
+  // No discrete variables yet so xd is independent; x, configuration
+  // subscribes.
   EXPECT_EQ(xd.prerequisites().size(), 0);
-  ASSERT_EQ(xd.subscribers().size(), 1);
+  ASSERT_EQ(xd.subscribers().size(), 2);
   EXPECT_EQ(xd.subscribers()[0], &x);
+  EXPECT_EQ(xd.subscribers()[1], &configuration);
 
-  // No abstract variables so xa is independent; x subscribes.
+  // No abstract variables yet so xa is independent; x, configuration
+  // subscribes.
   EXPECT_EQ(xa.prerequisites().size(), 0);
-  ASSERT_EQ(xa.subscribers().size(), 1);
+  ASSERT_EQ(xa.subscribers().size(), 2);
   EXPECT_EQ(xa.subscribers()[0], &x);
+  EXPECT_EQ(xa.subscribers()[1], &configuration);
 
   // x depends on xc, xd, and xa; all_sources subscribes.
   ASSERT_EQ(x.prerequisites().size(), 3);
@@ -161,40 +169,42 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   ASSERT_EQ(x.subscribers().size(), 1);
   EXPECT_EQ(x.subscribers()[0], &all_sources);
 
-  // configuration depends on q, parameters, accuracy & kinematics subscribes.
-  ASSERT_EQ(configuration.prerequisites().size(), 3);
-  EXPECT_EQ(configuration.prerequisites()[0], &q);
-  EXPECT_EQ(configuration.prerequisites()[1], &p);
-  EXPECT_EQ(configuration.prerequisites()[2], &accuracy);
+  // Until #9171 is resolved, we don't know which states and parameters affect
+  // configuration so we have to assume they all do (except v).
+  // TODO(sherm1) Revise after #9171 is resolved.
+  ASSERT_EQ(configuration.prerequisites().size(), 6);
+  EXPECT_EQ(configuration.prerequisites()[0], &accuracy);
+  EXPECT_EQ(configuration.prerequisites()[1], &q);
+  EXPECT_EQ(configuration.prerequisites()[2], &z);
+  EXPECT_EQ(configuration.prerequisites()[3], &xd);
+  EXPECT_EQ(configuration.prerequisites()[4], &xa);
+  EXPECT_EQ(configuration.prerequisites()[5], &p);
   ASSERT_EQ(configuration.subscribers().size(), 1);
   EXPECT_EQ(configuration.subscribers()[0], &kinematics);
 
-  // velocity depends on q, parameters, accuracy & kinematics subscribes.
-  ASSERT_EQ(velocity.prerequisites().size(), 3);
-  EXPECT_EQ(velocity.prerequisites()[0], &v);
-  EXPECT_EQ(velocity.prerequisites()[1], &p);
-  EXPECT_EQ(velocity.prerequisites()[2], &accuracy);
-  ASSERT_EQ(velocity.subscribers().size(), 1);
-  EXPECT_EQ(velocity.subscribers()[0], &kinematics);
-
-  // kinematics depends on configuration and velocity.
+  // kinematics depends on everything configuration depends on, plus v.
+  // TODO(sherm1) Revise after #9171 is resolved.
   ASSERT_EQ(kinematics.prerequisites().size(), 2);
   EXPECT_EQ(kinematics.prerequisites()[0], &configuration);
-  EXPECT_EQ(kinematics.prerequisites()[1], &velocity);
+  EXPECT_EQ(kinematics.prerequisites()[1], &v);
   EXPECT_EQ(kinematics.subscribers().size(), 0);
 
-  // No parameters or inputs yet so p,u independent; all_sources, configuration,
-  // and velocity subscribe.
-  EXPECT_EQ(p.prerequisites().size(), 0);
-  ASSERT_EQ(p.subscribers().size(), 3);
+  // all_parameters tracker depends on the numeric and abstract parameter
+  // trackers. all_sources, and configuration subscribe.
+  EXPECT_EQ(p.prerequisites().size(), 2);
+  EXPECT_EQ(p.prerequisites()[0], &pn);
+  EXPECT_EQ(p.prerequisites()[1], &pa);
+  ASSERT_EQ(p.subscribers().size(), 2);
   EXPECT_EQ(p.subscribers()[0], &all_sources);
   EXPECT_EQ(p.subscribers()[1], &configuration);
-  EXPECT_EQ(p.subscribers()[2], &velocity);
+
+  // We don't have any specific input ports yet so u has no prerequisites. Only
+  // all_sources subscribes.
   EXPECT_EQ(u.prerequisites().size(), 0);
   ASSERT_EQ(u.subscribers().size(), 1);
   EXPECT_EQ(u.subscribers()[0], &all_sources);
 
-  // All sources depends on time, accuracy, x, p, u; no subscribers.
+  // All sources depends on time, accuracy, x, p, u; no subscribers yet.
   ASSERT_EQ(all_sources.prerequisites().size(), 5);
   EXPECT_EQ(all_sources.prerequisites()[0], &time);
   EXPECT_EQ(all_sources.prerequisites()[1], &accuracy);
@@ -203,13 +213,19 @@ GTEST_TEST(DependencyTracker, BuiltInTrackers) {
   EXPECT_EQ(all_sources.prerequisites()[4], &u);
   EXPECT_EQ(all_sources.subscribers().size(), 0);
 
-  // xcdot and xdhat are created during Context construction but are not
+  // Cache entry trackers are created during Context construction but are not
   // connected to the corresponding cache entry values until those are
   // allocated later by the system framework (in SystemBase).
   EXPECT_EQ(xc_dot.prerequisites().size(), 0);
   EXPECT_EQ(xc_dot.subscribers().size(), 0);
-  EXPECT_EQ(xd_hat.prerequisites().size(), 0);
-  EXPECT_EQ(xd_hat.subscribers().size(), 0);
+  EXPECT_EQ(pe.prerequisites().size(), 0);
+  EXPECT_EQ(pe.subscribers().size(), 0);
+  EXPECT_EQ(ke.prerequisites().size(), 0);
+  EXPECT_EQ(ke.subscribers().size(), 0);
+  EXPECT_EQ(pc.prerequisites().size(), 0);
+  EXPECT_EQ(pc.subscribers().size(), 0);
+  EXPECT_EQ(pnc.prerequisites().size(), 0);
+  EXPECT_EQ(pnc.subscribers().size(), 0);
 }
 
 // Normally the dependency trackers are allocated automatically by the

--- a/systems/framework/test/diagram_context_test.cc
+++ b/systems/framework/test/diagram_context_test.cc
@@ -16,7 +16,6 @@
 #include "drake/systems/framework/test_utilities/pack_value.h"
 #include "drake/systems/primitives/adder.h"
 #include "drake/systems/primitives/integrator.h"
-#include "drake/systems/primitives/zero_order_hold.h"
 
 namespace drake {
 namespace systems {
@@ -25,6 +24,14 @@ namespace {
 constexpr int kSize = 1;
 constexpr int kNumSystems = 8;
 constexpr double kTime = 12.0;
+
+class SystemWithDiscreteState : public LeafSystem<double> {
+ public:
+  SystemWithDiscreteState() {
+    DeclareDiscreteState(1);
+  }
+  ~SystemWithDiscreteState() override {}
+};
 
 class SystemWithAbstractState : public LeafSystem<double> {
  public:
@@ -36,19 +43,16 @@ class SystemWithAbstractState : public LeafSystem<double> {
 
 class SystemWithNumericParameters : public LeafSystem<double> {
  public:
-  SystemWithNumericParameters() {}
-  ~SystemWithNumericParameters() override {}
-
-  std::unique_ptr<Parameters<double>> AllocateParameters() const override {
-    return std::make_unique<Parameters<double>>(
-        std::make_unique<BasicVector<double>>(2));
+  SystemWithNumericParameters() {
+    DeclareNumericParameter(BasicVector<double>(2));
   }
+  ~SystemWithNumericParameters() override {}
 };
 
 class SystemWithAbstractParameters : public LeafSystem<double> {
  public:
   SystemWithAbstractParameters() {
-    this->DeclareAbstractParameter(Value<int>(2048));
+    DeclareAbstractParameter(Value<int>(2048));
   }
   ~SystemWithAbstractParameters() override {}
 };
@@ -68,21 +72,24 @@ class DiagramContextTest : public ::testing::Test {
 
     integrator0_.reset(new Integrator<double>(kSize));
     integrator1_.reset(new Integrator<double>(kSize));
-    hold_ = std::make_unique<ZeroOrderHold<double>>(13.0 /* sec */, kSize);
 
+    discrete_state_system_ = std::make_unique<SystemWithDiscreteState>();
     abstract_state_system_ = std::make_unique<SystemWithAbstractState>();
     system_with_numeric_parameters_ =
         std::make_unique<SystemWithNumericParameters>();
     system_with_abstract_parameters_ =
         std::make_unique<SystemWithAbstractParameters>();
 
+    // This chunk of code is partially mimicking Diagram::DoAllocateContext()
+    // which is normally in charge of making DiagramContexts.
     context_ = std::make_unique<DiagramContext<double>>(kNumSystems);
 
+    // Don't change these indexes -- tests below depend on them.
     AddSystem(*adder0_, SubsystemIndex(0));
     AddSystem(*adder1_, SubsystemIndex(1));
     AddSystem(*integrator0_, SubsystemIndex(2));
     AddSystem(*integrator1_, SubsystemIndex(3));
-    AddSystem(*hold_, SubsystemIndex(4));
+    AddSystem(*discrete_state_system_, SubsystemIndex(4));
     AddSystem(*abstract_state_system_, SubsystemIndex(5));
     AddSystem(*system_with_numeric_parameters_, SubsystemIndex(6));
     AddSystem(*system_with_abstract_parameters_, SubsystemIndex(7));
@@ -93,6 +100,7 @@ class DiagramContextTest : public ::testing::Test {
 
     context_->MakeState();
     context_->MakeParameters();
+    context_->SubscribeDiagramCompositeTrackersToChildrens();
 
     context_->set_time(kTime);
     ContinuousState<double>& xc = context_->get_mutable_continuous_state();
@@ -104,7 +112,24 @@ class DiagramContextTest : public ::testing::Test {
 
     context_->get_mutable_numeric_parameter(0).SetAtIndex(0, 76.0);
     context_->get_mutable_numeric_parameter(0).SetAtIndex(1, 77.0);
+
+    // Sanity checks: tests below count on these dimensions.
+    EXPECT_EQ(context_->get_continuous_state().size(), 2);
+    EXPECT_EQ(context_->get_num_discrete_state_groups(), 1);
+    EXPECT_EQ(context_->get_num_abstract_states(), 1);
+    EXPECT_EQ(context_->num_numeric_parameters(), 1);
+    EXPECT_EQ(context_->num_abstract_parameters(), 1);
+    EXPECT_EQ(context_->num_subcontexts(), kNumSystems);
   }
+
+  // Some tests below need to know which of the subsystems above have particular
+  // resources. They use kNumSystems to identify the "parent" subsystem which
+  // inherits all the resources of its children.
+  static std::set<int> has_discrete_state() { return {4, kNumSystems}; }
+  static std::set<int> has_abstract_state() { return {5, kNumSystems}; }
+  static std::set<int> has_numeric_parameter() { return {6, kNumSystems}; }
+  static std::set<int> has_abstract_parameter() { return {7, kNumSystems}; }
+  static std::set<int> has_parameter() { return {6, 7, kNumSystems}; }
 
   void AddSystem(const System<double>& sys, SubsystemIndex index) {
     auto subcontext = sys.CreateDefaultContext();
@@ -125,12 +150,108 @@ class DiagramContextTest : public ::testing::Test {
     return free_value ? &free_value->get_vector_value<double>() : nullptr;
   }
 
+
+  // Check that time is set as expected in the Diagram and all the subcontexts.
+  void VerifyTimeValue(double expected_time) {
+    // Check the Diagram.
+    EXPECT_EQ(context_->get_time(), expected_time);
+
+    // Make sure time got delivered to the subcontexts.
+    for (SubsystemIndex i(0); i < kNumSystems; ++i) {
+      const auto& subcontext = context_->GetSubsystemContext(i);
+      EXPECT_EQ(subcontext.get_time(), expected_time);
+    }
+  }
+
+  // Check that accuracy is set to the expected numerical value in the Diagram
+  // and all the subcontexts. Don't call this for uninitialized (optional)
+  // accuracy.
+  void VerifyAccuracyValue(double expected_accuracy) {
+    // Check the Diagram.
+    ASSERT_TRUE(context_->get_accuracy());
+    EXPECT_EQ(context_->get_accuracy().value(), expected_accuracy);
+
+    // Make sure time got delivered to the subcontexts.
+    for (SubsystemIndex i(0); i < kNumSystems; ++i) {
+      const auto& subcontext = context_->GetSubsystemContext(i);
+      ASSERT_TRUE(subcontext.get_accuracy());
+      EXPECT_EQ(subcontext.get_accuracy().value(), expected_accuracy);
+    }
+  }
+
+  // Check that the continuous state has the expected value, in both the
+  // Diagram and its continuous-state-holding subcontexts, which are the two
+  // integrators.
+  void VerifyContinuousStateValue(const Eigen::Vector2d& expected) {
+    // Make sure state is right in the Diagram.
+    EXPECT_EQ(context_->get_continuous_state_vector().CopyToVector(), expected);
+
+    // Make sure state got delivered to the integrators.
+    EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(2))
+                  .get_continuous_state_vector()[0],
+              expected[0]);
+    EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(3))
+                  .get_continuous_state_vector()[0],
+              expected[1]);
+  }
+
+  // Record the notification count for the given tracker in each of the
+  // subcontexts, followed by the notification count for that same tracker in
+  // the diagram context, so there are kNumSystems + 1 in the returned vector.
+  std::vector<int64_t> SaveNotifications(DependencyTicket ticket) {
+    std::vector<int64_t> notifications;
+    for (SubsystemIndex i(0); i < kNumSystems; ++i) {
+      notifications.push_back(
+          NumNotifications(context_->GetSubsystemContext(i), ticket));
+    }
+    notifications.push_back(NumNotifications(*context_, ticket));
+    return notifications;
+  }
+
+  // Verify that the current notification count is as expected, relative to the
+  // given `before_count`. `should_have_been_notified` says which subsystems
+  // should have received a notification, with kNumSystems treated as the index
+  // of the diagram "subsystem". `before_count` is updated on return so it can
+  // be used in a subsequent test.
+  void VerifyNotifications(const std::string& which,
+                           const std::set<int>& should_have_been_notified,
+                           DependencyTicket ticket,
+                           std::vector<int64_t>* before_count) {  // in/out
+    auto count_now = SaveNotifications(ticket);
+    ASSERT_EQ(count_now.size(), kNumSystems + 1);
+    ASSERT_EQ(before_count->size(), kNumSystems + 1);
+    for (int i = 0; i <= kNumSystems; ++i) {
+      const int n = should_have_been_notified.count(i) ? 1 : 0;
+      (*before_count)[i] += n;
+      EXPECT_EQ(count_now[i], (*before_count)[i]) << which << " of system "
+                                                  << i;
+    }
+  }
+
+  // Verify that all subsystem trackers with this ticket were notified,
+  // including the diagram, and updated the expected notification count.
+  void VerifyNotifications(const std::string& which, DependencyTicket ticket,
+                           std::vector<int64_t>* before_count) {  // in/out
+    std::set<int> should_have_been_notified;
+    for (int i = 0; i <= kNumSystems; ++i) should_have_been_notified.insert(i);
+    VerifyNotifications(which, should_have_been_notified, ticket, before_count);
+  }
+
+  // Return the current notification count for the given tracker in the given
+  // context. Don't count multiple notifications for the same change event.
+  static int64_t NumNotifications(const ContextBase& context,
+                                  DependencyTicket ticket) {
+    const auto& tracker = context.get_tracker(ticket);
+    return tracker.num_notifications_received()
+        - tracker.num_ignored_notifications();
+  }
+
   std::unique_ptr<DiagramContext<double>> context_;
   std::unique_ptr<Adder<double>> adder0_;
   std::unique_ptr<Adder<double>> adder1_;
   std::unique_ptr<Integrator<double>> integrator0_;
   std::unique_ptr<Integrator<double>> integrator1_;
-  std::unique_ptr<ZeroOrderHold<double>> hold_;
+  std::unique_ptr<SystemWithDiscreteState> discrete_state_system_;
   std::unique_ptr<SystemWithAbstractState> abstract_state_system_;
   std::unique_ptr<SystemWithNumericParameters> system_with_numeric_parameters_;
   std::unique_ptr<SystemWithAbstractParameters>
@@ -174,26 +295,284 @@ TEST_F(DiagramContextTest, RetrieveConstituents) {
   }
 }
 
-// Tests that the time writes through to the subsystem contexts.
+// The notification tests here are verifying the "down" notification direction.
+// That is, we want to see that if we modify a context value at the Diagram
+// level, change notifications propagate out to the contained LeafSystems.
+// The other direction, modifying a LeafContext value that should notify
+// the Diagram, is verified in diagram_test.
+
+// Tests that the time writes through to the subsystem contexts, and that all
+// time trackers are notified.
 TEST_F(DiagramContextTest, Time) {
+  auto before = SaveNotifications(SystemBase::time_ticket());
+
   context_->set_time(42.0);
-  EXPECT_EQ(42.0, context_->get_time());
-  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
-    EXPECT_EQ(42.0, context_->GetSubsystemContext(i).get_time());
-  }
+  VerifyTimeValue(42.);
+  VerifyNotifications("Time", SystemBase::time_ticket(), &before);
 }
 
-// Tests that the accuracy writes through to the subsystem contexts.
+// Tests that the accuracy writes through to the subsystem contexts, and that
+// all accuracy trackers are notified.
 TEST_F(DiagramContextTest, Accuracy) {
-  const double kAccuracy = 1e-12;
-  context_->set_accuracy(kAccuracy);
-  EXPECT_TRUE(context_->get_accuracy());
-  EXPECT_EQ(kAccuracy, context_->get_accuracy().value());
-  for (SubsystemIndex i(0); i < kNumSystems; ++i) {
-    EXPECT_TRUE(context_->GetSubsystemContext(i).get_accuracy());
-    EXPECT_EQ(kAccuracy,
-              context_->GetSubsystemContext(i).get_accuracy().value());
-  }
+  auto before = SaveNotifications(SystemBase::accuracy_ticket());
+
+  const double new_accuracy = 1e-12;
+  context_->set_accuracy(new_accuracy);
+  VerifyAccuracyValue(new_accuracy);
+  VerifyNotifications("Accuracy", SystemBase::accuracy_ticket(), &before);
+}
+
+// Test that State notifications propagate down from the diagram to the leaves.
+TEST_F(DiagramContextTest, MutableStateNotifications) {
+  auto x_before = SaveNotifications(SystemBase::all_state_ticket());
+  auto xc_before = SaveNotifications(SystemBase::xc_ticket());
+  auto xd_before = SaveNotifications(SystemBase::xd_ticket());
+  auto xa_before = SaveNotifications(SystemBase::xa_ticket());
+
+  // Changing the whole state should affect all the substates.
+  context_->get_mutable_state();  // Return value ignored.
+  VerifyNotifications("get_mutable_state: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_state: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_state: xd", has_discrete_state(),
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("get_mutable_state: xa", has_abstract_state(),
+                      SystemBase::xa_ticket(), &xa_before);
+
+  // Changing continuous state should affect only x and xc.
+  context_->get_mutable_continuous_state();  // Return value ignored.
+  VerifyNotifications("get_mutable_continuous_state: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_continuous_state: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_continuous_state: xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("get_mutable_continuous_state: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  context_->get_mutable_continuous_state_vector();  // Return value ignored.
+  VerifyNotifications("get_mutable_continuous_state_vector: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_continuous_state_vector: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_continuous_state_vector: xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("get_mutable_continuous_state_vector: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  const Eigen::Vector2d new_xc1(3.25, 5.5);
+  context_->SetContinuousState(VectorX<double>(new_xc1));
+  VerifyContinuousStateValue(new_xc1);
+  VerifyNotifications("SetContinuousState: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("SetContinuousState: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("SetContinuousState: xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("SetContinuousState: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  // Changing time and continuous state should affect only t, x and xc.
+  auto t_before = SaveNotifications(SystemBase::time_ticket());
+  const double new_time = context_->get_time() + 1.;
+  const Eigen::Vector2d new_xc2(1.25, 1.5);
+  context_->SetTimeAndContinuousState(new_time, VectorX<double>(new_xc2));
+  VerifyTimeValue(new_time);
+  // Make sure state got delivered to the integrators.
+  VerifyContinuousStateValue(new_xc2);
+  // Make sure notifications got delivered.
+  VerifyNotifications("SetTimeAndContinuousState: t",
+                      SystemBase::time_ticket(), &t_before);
+  VerifyNotifications("SetTimeAndContinuousState: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("SetTimeAndContinuousState: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("SetTimeAndContinuousState: xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("SetTimeAndContinuousState: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  // Changing discrete state should affect only x and xd, and those should only
+  // get notified for systems that actually have discrete variables.
+
+  context_->get_mutable_discrete_state();  // Return value ignored.
+  VerifyNotifications("get_mutable_discrete_state: x", has_discrete_state(),
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_discrete_state: xd", has_discrete_state(),
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("get_mutable_discrete_state: xc", {},  // None.
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_discrete_state: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  context_->get_mutable_discrete_state_vector();  // Return value ignored.
+  VerifyNotifications("get_mutable_discrete_state_vector: x",
+                      has_discrete_state(),
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_discrete_state_vector: xd",
+                      has_discrete_state(), SystemBase::xd_ticket(),
+                      &xd_before);
+  VerifyNotifications("get_mutable_discrete_state_vector: xc", {},  // None.
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_discrete_state_vector: xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  context_->get_mutable_discrete_state(0);  // Return value ignored.
+  VerifyNotifications("get_mutable_discrete_state(0): x", has_discrete_state(),
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_discrete_state(0): xd", has_discrete_state(),
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("get_mutable_discrete_state(0): xc", {},  // None.
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_discrete_state(0): xa", {},  // None.
+                      SystemBase::xa_ticket(), &xa_before);
+
+  // Changing abstract state should affect only x and xa, and those should only
+  // get notified for systems that actually have discrete variables.
+
+  context_->get_mutable_abstract_state();  // Return value ignored.
+  VerifyNotifications("get_mutable_abstract_state: x", has_abstract_state(),
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_abstract_state: xa", has_abstract_state(),
+                      SystemBase::xa_ticket(), &xa_before);
+  VerifyNotifications("get_mutable_abstract_state: xc", {},  // None.
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_abstract_state: xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+
+  context_->get_mutable_abstract_state<int>(0);  // Return value ignored.
+  VerifyNotifications("get_mutable_abstract_state(0): x", has_abstract_state(),
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("get_mutable_abstract_state(0): xa", has_abstract_state(),
+                      SystemBase::xa_ticket(), &xa_before);
+  VerifyNotifications("get_mutable_abstract_state(0): xc", {},  // None.
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("get_mutable_abstract_state(0): xd", {},  // None.
+                      SystemBase::xd_ticket(), &xd_before);
+}
+
+TEST_F(DiagramContextTest, MutableParameterNotifications) {
+  auto p_before =
+      SaveNotifications(SystemBase::all_parameters_ticket());
+  auto pn_before = SaveNotifications(SystemBase::pn_ticket());
+  auto pa_before = SaveNotifications(SystemBase::pa_ticket());
+
+  // Changing the whole set of parameters should affect all subcontexts that
+  // have any parameters.
+  context_->get_mutable_parameters();  // Return value ignored.
+  VerifyNotifications("get_mutable_parameters: p", has_parameter(),
+                      SystemBase::all_parameters_ticket(), &p_before);
+  VerifyNotifications("get_mutable_parameters: pn", has_numeric_parameter(),
+                      SystemBase::pn_ticket(), &pn_before);
+  VerifyNotifications("get_mutable_parameters: pa", has_abstract_parameter(),
+                      SystemBase::pa_ticket(), &pa_before);
+
+  // Changing numeric or abstract should affect only subcontexts with that kind
+  // of parameter.
+  context_->get_mutable_numeric_parameter(0);  // Return value ignored.
+  VerifyNotifications("get_mutable_numeric_parameter(0): p",
+                      has_numeric_parameter(),
+                      SystemBase::all_parameters_ticket(), &p_before);
+  VerifyNotifications("get_mutable_numeric_parameter(0): pn",
+                      has_numeric_parameter(),
+                      SystemBase::pn_ticket(), &pn_before);
+  VerifyNotifications("get_mutable_numeric_parameter(0): pa", {},  // None.
+                      SystemBase::pa_ticket(), &pa_before);
+
+  context_->get_mutable_abstract_parameter(0);  // Return value ignored.
+  VerifyNotifications("get_mutable_abstract_parameter(0): p",
+                      has_abstract_parameter(),
+                      SystemBase::all_parameters_ticket(), &p_before);
+  VerifyNotifications("get_mutable_abstract_parameter(0): pa",
+                      has_abstract_parameter(),
+                      SystemBase::pa_ticket(), &pa_before);
+  VerifyNotifications("get_mutable_abstract_parameter(0): pn", {},  // None.
+                      SystemBase::pn_ticket(), &pn_before);
+}
+
+// We have a method that copies everything from one context to another. That
+// should produce a lot of notifications in the destination context.
+TEST_F(DiagramContextTest, MutableEverythingNotifications) {
+  auto clone = context_->Clone();
+  ASSERT_TRUE(clone != nullptr);
+
+  // Make sure clone's values are different from context's. These numbers are
+  // arbitrary as long as they don't match the default context_ values.
+  const double new_time = context_->get_time() + 1.;
+  const double new_accuracy = 3e-12;
+  const Eigen::Vector2d new_xc(0.125, 7.5);
+  const double new_xd = -1.;
+  const int new_xa = 12345;
+  const double new_pn = -2;
+  const int new_pa = 101;
+
+  clone->set_time(new_time);
+  clone->set_accuracy(new_accuracy);
+  clone->SetContinuousState(new_xc);
+  clone->get_mutable_discrete_state(0).SetAtIndex(0, new_xd);
+  clone->get_mutable_abstract_state<int>(0) = new_xa;
+  clone->get_mutable_numeric_parameter(0).SetAtIndex(0, new_pn);
+  clone->get_mutable_abstract_parameter(0).SetValue<int>(new_pa);
+
+  auto t_before = SaveNotifications(SystemBase::time_ticket());
+  auto a_before = SaveNotifications(SystemBase::accuracy_ticket());
+  auto p_before =
+      SaveNotifications(SystemBase::all_parameters_ticket());
+  auto pn_before = SaveNotifications(SystemBase::pn_ticket());
+  auto pa_before = SaveNotifications(SystemBase::pa_ticket());
+  auto x_before = SaveNotifications(SystemBase::all_state_ticket());
+  auto xc_before = SaveNotifications(SystemBase::xc_ticket());
+  auto xd_before = SaveNotifications(SystemBase::xd_ticket());
+  auto xa_before = SaveNotifications(SystemBase::xa_ticket());
+
+  // This is the method under test.
+  context_->SetTimeStateAndParametersFrom(*clone);
+
+  // First make sure that all the values got passed through.
+  VerifyTimeValue(new_time);
+  VerifyAccuracyValue(new_accuracy);
+  VerifyContinuousStateValue(new_xc);
+  // Check that non-continuous states and parameter got set in diagram and
+  // subcontext that has the resource.
+  EXPECT_EQ(context_->get_discrete_state_vector()[0], new_xd);
+  EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(4))  // discrete state
+                .get_discrete_state_vector()[0],
+            new_xd);
+  EXPECT_EQ(context_->get_abstract_state<int>(0), new_xa);
+  EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(5))  // abstract state
+                .get_abstract_state<int>(0),
+            new_xa);
+  EXPECT_EQ(context_->get_numeric_parameter(0)[0], new_pn);
+  EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(6))  // numeric param.
+                .get_numeric_parameter(0)[0],
+            new_pn);
+  EXPECT_EQ(context_->get_abstract_parameter(0).GetValue<int>(), new_pa);
+  EXPECT_EQ(context_->GetSubsystemContext(SubsystemIndex(7))  // abstract param.
+                .get_abstract_parameter(0).GetValue<int>(),
+            new_pa);
+
+  VerifyNotifications("SetTimeStateAndParametersFrom: t",
+                      SystemBase::time_ticket(), &t_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: a",
+                      SystemBase::accuracy_ticket(), &a_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: p", has_parameter(),
+                      SystemBase::all_parameters_ticket(),
+                      &p_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: pn",
+                      has_numeric_parameter(),
+                      SystemBase::pn_ticket(), &pn_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: pa",
+                      has_abstract_parameter(),
+                      SystemBase::pa_ticket(), &pa_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: x",
+                      SystemBase::all_state_ticket(), &x_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: xc",
+                      SystemBase::xc_ticket(), &xc_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: xd", has_discrete_state(),
+                      SystemBase::xd_ticket(), &xd_before);
+  VerifyNotifications("SetTimeStateAndParametersFrom: xa", has_abstract_state(),
+                      SystemBase::xa_ticket(), &xa_before);
 }
 
 // Tests that state variables appear in the diagram context, and write
@@ -206,7 +585,7 @@ TEST_F(DiagramContextTest, State) {
   EXPECT_EQ(0, xc.get_generalized_velocity().size());
   EXPECT_EQ(2, xc.get_misc_continuous_state().size());
 
-  // The zero-order hold has a discrete state vector of length 1.
+  // The discrete state vector has length 1.
   DiscreteValues<double>& xd = context_->get_mutable_discrete_state();
   EXPECT_EQ(1, xd.num_groups());
   EXPECT_EQ(1, xd.get_vector(0).size());
@@ -222,17 +601,17 @@ TEST_F(DiagramContextTest, State) {
   EXPECT_EQ(42.0, integrator0_xc.get_vector().GetAtIndex(0));
   EXPECT_EQ(43.0, integrator1_xc.get_vector().GetAtIndex(0));
   // - Discrete
-  DiscreteValues<double>& hold_xd =
+  DiscreteValues<double>& discrete_xd =
       context_->GetMutableSubsystemContext(SubsystemIndex(4))
           .get_mutable_discrete_state();
-  EXPECT_EQ(44.0, hold_xd.get_vector(0).GetAtIndex(0));
+  EXPECT_EQ(44.0, discrete_xd.get_vector(0).GetAtIndex(0));
 
   // Changes to constituent system states appear in the diagram state.
   // - Continuous
   integrator1_xc.get_mutable_vector().SetAtIndex(0, 1000.0);
   EXPECT_EQ(1000.0, xc.get_vector().GetAtIndex(1));
   // - Discrete
-  hold_xd.get_mutable_vector(0).SetAtIndex(0, 1001.0);
+  discrete_xd.get_mutable_vector(0).SetAtIndex(0, 1001.0);
   EXPECT_EQ(1001.0, xd.get_vector(0).GetAtIndex(0));
 }
 
@@ -263,6 +642,30 @@ TEST_F(DiagramContextTest, SetAndGetInputPorts) {
   AttachInputPorts();
   EXPECT_EQ(128, ReadVectorInputPort(*context_, 0)->get_value()[0]);
   EXPECT_EQ(256, ReadVectorInputPort(*context_, 1)->get_value()[0]);
+}
+
+// Test that start_next_change_event() returns a sequentially increasing
+// number regardless of from where in the DiagramContext tree the request
+// is initiated. Also, it should continue counting up after cloning.
+TEST_F(DiagramContextTest, NextChangeEventNumber) {
+  const int64_t first = context_->start_new_change_event();
+
+  EXPECT_EQ(context_->start_new_change_event(), first + 1);
+  EXPECT_EQ(context_->start_new_change_event(), first + 2);
+
+  // Obtain a subcontext and verify we still count up.
+  Context<double>& discrete_context =
+      context_->GetMutableSubsystemContext(SubsystemIndex(4));
+  EXPECT_EQ(discrete_context.start_new_change_event(), first + 3);
+
+  // Now clone the context and make sure we're still counting up.
+  auto clone = dynamic_pointer_cast<DiagramContext<double>>(context_->Clone());
+  EXPECT_EQ(clone->start_new_change_event(), first + 4);
+  EXPECT_EQ(context_->start_new_change_event(), first + 4);  // Sanity check.
+
+  Context<double>& discrete_clone =
+      clone->GetMutableSubsystemContext(SubsystemIndex(4));
+  EXPECT_EQ(discrete_clone.start_new_change_event(), first + 5);
 }
 
 TEST_F(DiagramContextTest, Clone) {

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -5,11 +5,13 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/eigen_types.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/common/test_utilities/is_dynamic_castable.h"
 #include "drake/examples/pendulum/pendulum_plant.h"
 #include "drake/systems/analysis/test_utilities/stateless_system.h"
 #include "drake/systems/framework/basic_vector.h"
 #include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/framework/fixed_input_port_value.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/output_port.h"
 #include "drake/systems/framework/test_utilities/pack_value.h"
@@ -469,6 +471,11 @@ class DiagramTest : public ::testing::Test {
     context_ = diagram_->CreateDefaultContext();
     output_ = diagram_->AllocateOutput();
 
+    // Make sure caching is on locally, even if it is off by default.
+    // Do not remove this line; we want to show that these tests function
+    // correctly with caching on. It is easier to pass with caching off!
+    context_->EnableCaching();
+
     // Initialize the integrator states.
     auto& integrator0_xc = GetMutableContinuousState(integrator0());
     integrator0_xc.get_mutable_vector().SetAtIndex(0, 3);
@@ -590,8 +597,9 @@ TEST_F(DiagramTest, Topology) {
 
 // Tests that dependency wiring is set up correctly between
 //  1. input ports and their source output ports,
-//  2. diagram output ports and their source leaf output ports, and
-//  3. diagram input ports and the corresponding exported leaf inputs.
+//  2. diagram output ports and their source leaf output ports,
+//  3. diagram input ports and the corresponding exported leaf inputs,
+//  4. diagram states/parameters and their constituent leaf states/parameters.
 TEST_F(DiagramTest, CheckPortSubscriptions) {
   const Context<double>& adder1_subcontext =
       diagram_->GetSubsystemContext(*diagram_->adder1(), *context_);
@@ -635,6 +643,30 @@ TEST_F(DiagramTest, CheckPortSubscriptions) {
   // 3. Diagram's input port 2 is imported to adder1's input port 1.
   EXPECT_TRUE(diagram_iport2_tracker.HasSubscriber(adder1_iport1_tracker));
   EXPECT_TRUE(adder1_iport1_tracker.HasPrerequisite(diagram_iport2_tracker));
+
+  // 4. Diagrams q, v, z, xd, xa state trackers and pn, pa parameter trackers
+  //    subscribe to the corresponding leaf trackers.
+  auto systems = diagram_->GetSystems();
+  for (auto subsystem : systems) {
+    const auto& subcontext =
+        diagram_->GetSubsystemContext(*subsystem, *context_);
+    // Not checking "HasSubscriber" separately to cut down on fluff;
+    // prerequisite and subscriber are set in the same call and checked above.
+    EXPECT_TRUE(context_->get_tracker(diagram_->q_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->q_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->v_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->v_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->z_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->z_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->xd_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->xd_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->xa_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->xa_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->pn_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->pn_ticket())));
+    EXPECT_TRUE(context_->get_tracker(diagram_->pa_ticket())
+        .HasPrerequisite(subcontext.get_tracker(subsystem->pa_ticket())));
+  }
 }
 
 TEST_F(DiagramTest, Path) {
@@ -963,6 +995,12 @@ class DiagramOfDiagramsTest : public ::testing::Test {
     diagram_->set_name("DiagramOfDiagrams");
 
     context_ = diagram_->CreateDefaultContext();
+
+    // Make sure caching is on locally, even if it is off by default.
+    // Do not remove this line; we want to show that these tests function
+    // correctly with caching on. It is easier to pass with caching off!
+    context_->EnableCaching();
+
     output_ = diagram_->AllocateOutput();
 
     context_->FixInputPort(0, {8});
@@ -1019,9 +1057,15 @@ TEST_F(DiagramOfDiagramsTest, Graphviz) {
   EXPECT_NE(std::string::npos, dot.find("_" + id0 + "_y0 -> _" + id1 + "_u0"));
 }
 
-// Tests that a diagram composed of diagrams can be evaluated.
+// Tests that a diagram composed of diagrams can be evaluated, and gives
+// correct answers with caching enabled.
 TEST_F(DiagramOfDiagramsTest, EvalOutput) {
-  diagram_->CalcOutput(*context_, output_.get());
+  context_->EnableCaching();  // Just to be sure.
+
+  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 0)->GetAtIndex(0), 8.);
+  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 1)->GetAtIndex(0), 64.);
+  EXPECT_EQ(diagram_->EvalVectorInput(*context_, 2)->GetAtIndex(0), 512.);
+
   // The outputs of subsystem0_ are:
   //   output0 = 8 + 64 + 512 = 584
   //   output1 = output0 + 8 + 64 = 656
@@ -1031,9 +1075,47 @@ TEST_F(DiagramOfDiagramsTest, EvalOutput) {
   //   output0 = 584 + 656 + 9 = 1249
   //   output1 = output0 + 584 + 656 = 2489
   //   output2 = 81 (state of integrator1_)
-  EXPECT_EQ(1249, output_->get_vector_data(0)->get_value().x());
-  EXPECT_EQ(2489, output_->get_vector_data(1)->get_value().x());
-  EXPECT_EQ(81, output_->get_vector_data(2)->get_value().x());
+  EXPECT_EQ(1249, diagram_->get_output_port(0).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(2489, diagram_->get_output_port(1).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(81, diagram_->get_output_port(2).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+
+  // Check that invalidation flows through input ports properly, either due
+  // to replacing the fixed value or by modifying it.
+  //
+  // First we'll replace the fixed input value 8 for input port 0 with
+  // a new object that has value 10. That should cause everything to get
+  // recalculated when the ports are Eval()-ed.
+  // The outputs of subsystem0_ are now:
+  //   output0 = 10 + 64 + 512 = 586
+  //   output1 = output0 + 10 + 64 = 660
+  //   output2 = 9 (state of integrator1_)
+
+  // So, the outputs of subsystem1_, and thus of the whole diagram, are:
+  //   output0 = 586 + 660 + 9 = 1255
+  //   output1 = output0 + 586 + 660 = 2501
+  //   output2 = 81 (state of integrator1_)
+  auto value10 = BasicVector<double>::Make({10});
+  FixedInputPortValue& port_value =
+      context_->FixInputPort(0, std::move(value10));
+  EXPECT_EQ(1255, diagram_->get_output_port(0).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(2501, diagram_->get_output_port(1).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(81, diagram_->get_output_port(2).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+
+  // Now change the value back to 8 using mutable access to the port_value
+  // object. Should also cause re-evaluation.
+  port_value.GetMutableVectorData<double>()->SetAtIndex(0, 8.0);
+  EXPECT_EQ(1249, diagram_->get_output_port(0).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(2489, diagram_->get_output_port(1).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
+  EXPECT_EQ(81, diagram_->get_output_port(2).
+      Eval<BasicVector<double>>(*context_).GetAtIndex(0));
 }
 
 TEST_F(DiagramOfDiagramsTest, DirectFeedthrough) {
@@ -1848,6 +1930,11 @@ class NestedDiagramContextTest : public ::testing::Test {
     big_diagram_->set_name("big_diagram");
     big_context_ = big_diagram_->CreateDefaultContext();
     big_output_ = big_diagram_->AllocateOutput();
+
+    // Make sure caching is on locally, even if it is off by default.
+    // Do not remove this line; we want to show that these tests function
+    // correctly with caching on. It is easier to pass with caching off!
+    big_context_->EnableCaching();
   }
 
   Integrator<double>* integrator0_;
@@ -2000,6 +2087,174 @@ TEST_F(NestedDiagramContextTest, CachingChangePropagation) {
 
   big_context_->SetAllCacheEntriesOutOfDate();
   EXPECT_TRUE(cache_entry.is_out_of_date(integrator3_subcontext));
+}
+
+/* Check that changes made directly to a subcontext still affect the
+parent Diagram's behavior properly. Also, time and accuracy must be identical
+in every subcontext of a Context tree. They are only permitted to change at the
+root so they can be properly propagated down.
+
+        +-----------------------------------------------------+
+        |                                                     |
+        |       +------------+             +-----------+      |
+        |       |            |             |           |      |
+      u |    u0 |            | y0       u1 |           | y1   | y (=x1)
+Fixed ---------->  integ0    +------------->  integ1   +-------->
+value   |       |            |             |           |      |
+        |       |     x0     |             |    x1     |      |
+        |       +------------+             +-----------+      |
+        |                                                     | xdot={u0,u1,u2}
+        |                    +------------+            +-------->
+        |                    |            |                   |
+        |               u2   |            | y2                |
+        |       Fixed ------->  integ2    +------>            |
+        |       value        |            |                   |
+        |                    |     x2     |                   |
+        |                    +------------+                   |
+        |                                                     |
+        |                   diagram x={x0,x1,x2}              |
+        |                        xdot={u0,u1,u2}              |
+        +-----------------------------------------------------+
+
+Note that integ2's input port is invisible to the diagram, but a value change
+to that hidden port should invalidate the diagram's composite derivative
+calculation. */
+GTEST_TEST(MutateSubcontextTest, DiagramRecalculatesOnSubcontextChange) {
+  DiagramBuilder<double> builder;
+  auto integ0 = builder.AddSystem<Integrator>(1);  // (xdot = u; y = x)
+  auto integ1 = builder.AddSystem<Integrator>(1);
+  auto integ2 = builder.AddSystem<Integrator>(1);
+  builder.ExportInput(integ0->get_input_port());
+  builder.Cascade(*integ0, *integ1);
+  builder.ExportOutput(integ1->get_output_port());
+  auto diagram = builder.Build();
+
+  auto diagram_context = diagram->AllocateContext();
+  diagram_context->EnableCaching();
+  diagram_context->FixInputPort(0, {1.5});  // u(=u0)
+
+  // Hunt down the cache entry for the Diagram's derivative computation so we
+  // can verify that it gets invalidated and recomputed as we expect.
+  auto& derivative_tracker =
+      diagram_context->get_tracker(diagram->xcdot_ticket());
+  ASSERT_NE(derivative_tracker.cache_entry_value(), nullptr);
+  const CacheEntryValue& derivative_cache =
+      *derivative_tracker.cache_entry_value();
+  EXPECT_TRUE(derivative_cache.is_out_of_date());
+
+  // Record the derivative serial number so we can watch out for unnecessary
+  // extra computations.
+  int64_t expected_derivative_serial = derivative_cache.serial_number();
+
+  Eigen::VectorXd init_state(3);
+  init_state << 5., 6., 7.;  // x0(=y0=u1), x1(=y1), x2(=y2)
+
+  // Set the state from the diagram level, then evaluate the diagram
+  // output, which should have copied the second state value (x1). Also, this
+  // shouldn't complain even though input u2 is dangling since we don't need it
+  // for this computation.
+  diagram_context->SetContinuousState(init_state);
+  EXPECT_EQ(diagram->get_output_port(0).Eval<BasicVector<double>>(
+                *diagram_context)[0],
+            6.);
+
+  // That should not have caused derivative evaluations.
+  EXPECT_TRUE(derivative_cache.is_out_of_date());
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Must set the dangling input port to a value to evaluate derivatives.
+  Context<double>& context2 =
+      diagram->GetMutableSubsystemContext(*integ2, &*diagram_context);
+  FixedInputPortValue& u2_value = context2.FixInputPort(0, {0.75});
+
+  // The diagram derivatives should be (u0,u1,u2)=(u,x0,u2).
+  auto& eval_derivs =
+      diagram->EvalTimeDerivatives(*diagram_context);
+  ++expected_derivative_serial;
+  EXPECT_EQ(eval_derivs[0], 1.5);
+  EXPECT_EQ(eval_derivs[1], 5.);
+  EXPECT_EQ(eval_derivs[2], 0.75);
+
+  EXPECT_FALSE(derivative_cache.is_out_of_date());
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Now try to sneak in a change to subcontext state variables and then ask for
+  // the diagram's output value and derivatives again.
+  Context<double>& context0 =
+      diagram->GetMutableSubsystemContext(*integ0, &*diagram_context);
+  Context<double>& context1 =
+      diagram->GetMutableSubsystemContext(*integ1, &*diagram_context);
+
+  Eigen::VectorXd new_x0(1), new_x1(1);
+  new_x0 << 13.; new_x1 << 17.;
+  context0.SetContinuousState(new_x0);
+  context1.SetContinuousState(new_x1);
+
+  // Diagram should know to recopy x1 to the output port cache entry.
+  EXPECT_EQ(diagram->get_output_port(0).Eval<BasicVector<double>>(
+                *diagram_context)[0],
+            17.);
+
+  // Diagram derivatives should be out of date since they depend on x0.
+  EXPECT_TRUE(derivative_cache.is_out_of_date());
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Diagram should know that the time derivatives cache entry is out of date
+  // so initiate subsystem derivative calculations and pick up the changed x0.
+  // This will fail if subcontext *state* modifications aren't transmitted
+  // properly to the Diagram.
+  diagram->EvalTimeDerivatives(*diagram_context);
+  ++expected_derivative_serial;
+  EXPECT_EQ(eval_derivs[0], 1.5);
+  EXPECT_EQ(eval_derivs[1], 13.);
+  EXPECT_EQ(eval_derivs[2], 0.75);
+
+  EXPECT_FALSE(derivative_cache.is_out_of_date());
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Re-evaluate derivatives now and verify that they weren't recomputed.
+  diagram->EvalTimeDerivatives(*diagram_context);
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Now let's try modifying the internal input port. That shouldn't have any
+  // effect on the Diagram output port, since that depends only on state and
+  // hasn't changed. However, input u2 is the derivative result for integ2 and
+  // that should be reflected in the diagram derivative result.
+  u2_value.GetMutableVectorData<double>()->SetAtIndex(0, 300.);
+  EXPECT_EQ(diagram->get_output_port(0).Eval<BasicVector<double>>(
+      *diagram_context)[0],
+            17.);  // No change.
+  EXPECT_TRUE(derivative_cache.is_out_of_date());
+
+  diagram->EvalTimeDerivatives(*diagram_context);
+  ++expected_derivative_serial;
+  EXPECT_EQ(eval_derivs[0], 1.5);
+  EXPECT_EQ(eval_derivs[1], 13.);
+  EXPECT_EQ(eval_derivs[2], 300.);
+
+  EXPECT_FALSE(derivative_cache.is_out_of_date());
+  EXPECT_EQ(derivative_cache.serial_number(), expected_derivative_serial);
+
+  // Time & accuracy changes are allowed at the root (diagram) level.
+  EXPECT_NO_THROW(diagram_context->set_time(1.));
+  EXPECT_NO_THROW(diagram_context->SetTimeAndContinuousState(2., init_state));
+  auto diagram_context_clone = diagram_context->Clone();
+  EXPECT_NO_THROW(
+      diagram_context->SetTimeStateAndParametersFrom(*diagram_context_clone));
+  EXPECT_NO_THROW(diagram_context->set_accuracy(1e-6));
+
+  // Time & accuracy changes NOT allowed at child (leaf) level.
+  DRAKE_EXPECT_THROWS_MESSAGE(context0.set_time(3.), std::logic_error,
+                              ".*set_time.*Time change allowed only.*root.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      context0.SetTimeAndContinuousState(4., new_x0), std::logic_error,
+      ".*SetTimeAndContinuousState.*Time change allowed only.*root.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      context0.SetTimeStateAndParametersFrom(context1), std::logic_error,
+      ".*SetTimeStateAndParametersFrom.*Time change allowed only.*root.*");
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      context0.set_accuracy(1e-7), std::logic_error,
+      ".*set_accuracy.*Accuracy change allowed only.*root.*");
 }
 
 // Tests that an exception is thrown if the systems in a Diagram do not have

--- a/systems/framework/test/fixed_input_port_value_test.cc
+++ b/systems/framework/test/fixed_input_port_value_test.cc
@@ -59,6 +59,12 @@ class FixedInputPortTest : public ::testing::Test {
     free_tracker0_ = &context_.get_tracker(free_ticket0);
     free_tracker1_ = &context_.get_tracker(free_ticket1);
 
+    // Record the initial notification statistics so we can see if they
+    // change properly.
+    sent0_ = free_tracker0_->num_notifications_sent();
+    sent1_ = free_tracker1_->num_notifications_sent();
+    rcvd0_ = tracker0_->num_notifications_received();
+    rcvd1_ = tracker1_->num_notifications_received();
     serial0_ = port0_value_->serial_number();
     serial1_ = port1_value_->serial_number();
   }
@@ -73,6 +79,8 @@ class FixedInputPortTest : public ::testing::Test {
   const DependencyTracker* free_tracker0_{};
   const DependencyTracker* free_tracker1_{};
 
+  int64_t sent0_{-1}, sent1_{-1};
+  int64_t rcvd0_{-1}, rcvd1_{-1};
   int64_t serial0_{-1}, serial1_{-1};
 };
 
@@ -171,9 +179,13 @@ TEST_F(FixedInputPortTest, Clone) {
 TEST_F(FixedInputPortTest, Access) {
   EXPECT_EQ(Vector2<double>(5, 6),
             port0_value_->get_vector_value<double>().get_value());
+  EXPECT_EQ(free_tracker0_->num_notifications_sent(), sent0_);
+  EXPECT_EQ(tracker0_->num_notifications_received(), rcvd0_);
   EXPECT_EQ(port0_value_->serial_number(), serial0_);
 
   EXPECT_EQ("foo", port1_value_->get_value().GetValue<std::string>());
+  EXPECT_EQ(free_tracker1_->num_notifications_sent(), sent1_);
+  EXPECT_EQ(tracker1_->num_notifications_received(), rcvd1_);
   EXPECT_EQ(port1_value_->serial_number(), serial1_);
 }
 
@@ -187,7 +199,8 @@ TEST_F(FixedInputPortTest, Mutation) {
   EXPECT_EQ(Vector2<double>(7, 8),
             port0_value_->get_vector_value<double>().get_value());
   // Check that notifications were sent and serial number bumped.
-  // TODO(sherm1) Check notifications.
+  EXPECT_EQ(free_tracker0_->num_notifications_sent(), sent0_ + 1);
+  EXPECT_EQ(tracker0_->num_notifications_received(), rcvd0_ + 1);
   EXPECT_EQ(port0_value_->serial_number(), serial0_ + 1);
 
   // Change the abstract port's value.
@@ -195,7 +208,8 @@ TEST_F(FixedInputPortTest, Mutation) {
   // Check that the contents changed.
   EXPECT_EQ("bar", port1_value_->get_value().GetValue<std::string>());
   // Check that notifications were sent and serial number bumped.
-  // TODO(sherm1) Check notifications.
+  EXPECT_EQ(free_tracker1_->num_notifications_sent(), sent1_ + 1);
+  EXPECT_EQ(tracker1_->num_notifications_received(), rcvd1_ + 1);
   EXPECT_EQ(port1_value_->serial_number(), serial1_ + 1);
 }
 

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -200,6 +200,10 @@ class LeafSystemTest : public ::testing::Test {
     event_info_ = system_.AllocateCompositeEventCollection();
     leaf_info_ = dynamic_cast<const LeafCompositeEventCollection<double>*>(
         event_info_.get());
+
+    // Make sure caching tests will work properly even if caching is off
+    // by default.
+    context_.EnableCaching();
   }
 
   TestSystem<double> system_;
@@ -526,13 +530,13 @@ TEST_F(LeafSystemTest, NumericParameters) {
   EXPECT_EQ(42.0, vec[1]);
 
   EXPECT_EQ(system_.num_numeric_parameters(), 1);
-  const DependencyTracker& all_parameters_tracker =
-      context->get_tracker(system_.all_parameters_ticket());
+  const DependencyTracker& pn_tracker =
+      context->get_tracker(system_.pn_ticket());
   for (NumericParameterIndex i(0); i < system_.num_numeric_parameters(); ++i) {
     const DependencyTracker& tracker =
         context->get_tracker(system_.numeric_parameter_ticket(i));
-    EXPECT_TRUE(all_parameters_tracker.HasPrerequisite(tracker));
-    EXPECT_TRUE(tracker.HasSubscriber(all_parameters_tracker));
+    EXPECT_TRUE(pn_tracker.HasPrerequisite(tracker));
+    EXPECT_TRUE(tracker.HasSubscriber(pn_tracker));
   }
 }
 
@@ -551,14 +555,14 @@ TEST_F(LeafSystemTest, AbstractParameters) {
   EXPECT_EQ("modified parameter value", param);
 
   EXPECT_EQ(system_.num_abstract_parameters(), 1);
-  const DependencyTracker& all_parameters_tracker =
-      context->get_tracker(system_.all_parameters_ticket());
+  const DependencyTracker& pa_tracker =
+      context->get_tracker(system_.pa_ticket());
   for (AbstractParameterIndex i(0); i < system_.num_abstract_parameters();
        ++i) {
     const DependencyTracker& tracker =
         context->get_tracker(system_.abstract_parameter_ticket(i));
-    EXPECT_TRUE(all_parameters_tracker.HasPrerequisite(tracker));
-    EXPECT_TRUE(tracker.HasSubscriber(all_parameters_tracker));
+    EXPECT_TRUE(pa_tracker.HasPrerequisite(tracker));
+    EXPECT_TRUE(tracker.HasSubscriber(pa_tracker));
   }
 }
 
@@ -867,6 +871,9 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
   DeclaredModelPortsSystem dut;
   auto context = dut.CreateDefaultContext();
 
+  // Make sure caching is on locally, even if it is off by default.
+  context->EnableCaching();
+
   // Calculate values for each output port and save copies of those values.
   std::vector<std::unique_ptr<AbstractValue>> values;
   for (OutputPortIndex i(0); i < 4; ++i) {
@@ -874,6 +881,43 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsCalcOutput) {
     values.emplace_back(out.Allocate());
     out.Calc(*context, values.back().get());
   }
+
+  const auto& port2 = dut.get_output_port(OutputPortIndex(2));
+  const auto& cache2 =
+      dynamic_cast<const LeafOutputPort<double>&>(port2).cache_entry();
+  const auto& cacheval2 = cache2.get_cache_entry_value(*context);
+  EXPECT_EQ(cacheval2.serial_number(), 1);
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  EXPECT_THROW(cache2.GetKnownUpToDate<std::string>(*context),
+               std::logic_error);
+  const std::string& str2_cached = port2.Eval<std::string>(*context);
+  EXPECT_EQ(str2_cached, "concrete string");
+  EXPECT_EQ(cacheval2.serial_number(), 2);
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cache2.GetKnownUpToDate<std::string>(*context),
+            "concrete string");  // Doesn't throw now.
+
+  // Check that setting time invalidates correctly. Note that the method
+  // *may* avoid invalidation if the time hasn't actually changed.
+
+  // Should invalidate time- and everything-dependents.
+  context->set_time(context->get_time() + 1.);
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 2);  // Unchanged since invalid.
+  (void)port2.EvalAbstract(*context);  // Recalculate.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 3);
+  (void)port2.EvalAbstract(*context);  // "Recalculate" (should do nothing).
+  EXPECT_EQ(cacheval2.serial_number(), 3);
+
+  // Should invalidate accuracy- and everything-dependents. Note that the
+  // method *may* avoid invalidation if the accuracy hasn't actually changed.
+  EXPECT_FALSE(context->get_accuracy());  // None set initially.
+  context->set_accuracy(.000025);  // This is a change.
+  EXPECT_TRUE(cache2.is_out_of_date(*context));
+  (void)port2.EvalAbstract(*context);  // Recalculate.
+  EXPECT_FALSE(cache2.is_out_of_date(*context));
+  EXPECT_EQ(cacheval2.serial_number(), 4);
 
   // Downcast to concrete types.
   const BasicVector<double>* vec0{};
@@ -1049,6 +1093,9 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   auto context = dut.CreateDefaultContext();
   auto system_output = dut.AllocateOutput();  // Invokes all allocators.
 
+  // Make sure caching is on locally, even if it is off by default.
+  context->EnableCaching();
+
   // Check topology.
   EXPECT_EQ(dut.get_num_input_ports(), 0);
   EXPECT_EQ(dut.get_num_output_ports(), 5);
@@ -1088,10 +1135,8 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   EXPECT_EQ(out0.Eval<BasicVector<double>>(*context).get_value(),
             out0_dummy->get_value());
   EXPECT_EQ(dut.calc_dummy_vec2_calls(), 2);
-  // Verify that caching is currently disabled.
-  // TODO(sherm1) Verify that caching is working as soon as it is enabled.
   out0.Eval<BasicVector<double>>(*context);
-  EXPECT_EQ(dut.calc_dummy_vec2_calls(), 3);  // Will be 2 with caching.
+  EXPECT_EQ(dut.calc_dummy_vec2_calls(), 2);  // Should have been cached.
 
   // Check that Value<string>() came out, default initialized to empty.
   auto output1 = system_output->GetMutableData(1);
@@ -1105,10 +1150,8 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   EXPECT_EQ(dut.calc_string_calls(), 1);
   EXPECT_EQ(out1.Eval<std::string>(*context), *downcast_output1);
   EXPECT_EQ(dut.calc_string_calls(), 2);
-  // Verify that caching is currently disabled.
-  // TODO(sherm1) Verify that caching is working as soon as it is enabled.
   out1.Eval<std::string>(*context);
-  EXPECT_EQ(dut.calc_string_calls(), 3);  // Will be 2 with caching.
+  EXPECT_EQ(dut.calc_string_calls(), 2);  // Should have been cached.
 
   // Check that Value<int> came out, default initialized to -2.
   auto output2 = system_output->GetMutableData(2);
@@ -1146,10 +1189,8 @@ GTEST_TEST(NonModelLeafSystemTest, NonModelPortsOutput) {
   EXPECT_EQ(eval_out.some_int, -10);
   EXPECT_EQ(eval_out.some_double, 3.25);
   EXPECT_EQ(dut.calc_POD_calls(), 2);
-  // Verify that caching is currently disabled.
-  // TODO(sherm1) Verify that caching is working as soon as it is enabled.
   out4.Eval<SomePOD>(*context);
-  EXPECT_EQ(dut.calc_POD_calls(), 3);  // Will be 2 with caching.
+  EXPECT_EQ(dut.calc_POD_calls(), 2);  // Should have been cached.
 }
 
 // Tests both that an unrestricted update callback is called and that

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -770,6 +770,219 @@ TEST_F(SystemIOTest, TransmogrifyAndFix) {
   EXPECT_EQ(0, fixed_vec->GetAtIndex(0).derivatives().size());
 }
 
+// This class implements various computational methods so we can check that
+// they get invoked properly. The particular results don't mean anything.
+// As above, lots of painful bookkeeping here that is normally buried by
+// LeafSystem.
+class ComputationTestSystem final : public System<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(ComputationTestSystem)
+
+  ComputationTestSystem() : System<double>(SystemScalarConverter{}) {}
+
+  // One q, one v, one z.
+  std::unique_ptr<ContinuousState<double>> AllocateTimeDerivatives()
+      const final {
+    return std::make_unique<ContinuousState<double>>(
+        std::make_unique<BasicVector<double>>(3), 1, 1, 1);  // q, v, z
+  }
+
+  // Verify that the number of calls is as expected.
+  void ExpectCount(int xcdot, int pe, int ke, int pc, int pnc) const {
+    EXPECT_EQ(xcdot, xcdot_count_);
+    EXPECT_EQ(pe, pe_count_);
+    EXPECT_EQ(ke, ke_count_);
+    EXPECT_EQ(pc, pc_count_);
+    EXPECT_EQ(pnc, pnc_count_);
+  }
+
+ private:
+  // Two discrete variable groups of lengths 2 and 4.
+  std::unique_ptr<DiscreteValues<double>> AllocateDiscreteVariables()
+      const final {
+    std::vector<std::unique_ptr<BasicVector<double>>> data;
+    data.emplace_back(std::make_unique<BasicVector<double>>(2));
+    data.emplace_back(std::make_unique<BasicVector<double>>(4));
+    return std::make_unique<DiscreteValues<double>>(std::move(data));
+  }
+
+  std::unique_ptr<ContextBase> DoAllocateContext() const final {
+    auto context = std::make_unique<LeafContext<double>>();
+    InitializeContextBase(&*context);
+    return context;
+  }
+
+  // Derivatives can depend on time. Here x = (-1, -2, -3) * t.
+  void DoCalcTimeDerivatives(const Context<double>& context,
+                             ContinuousState<double>* derivatives) const final {
+    unused(context);
+    EXPECT_EQ(derivatives->size(), 3);
+    const double t = context.get_time();
+    (*derivatives)[0] = -1 * t;
+    (*derivatives)[1] = -2 * t;
+    (*derivatives)[2] = -3 * t;
+    ++xcdot_count_;
+  }
+
+  double DoCalcPotentialEnergy(const Context<double>& context) const final {
+    unused(context);
+    ++pe_count_;
+    return 1.;
+  }
+
+  double DoCalcKineticEnergy(const Context<double>& context) const final {
+    unused(context);
+    ++ke_count_;
+    return 2.;
+  }
+
+  double DoCalcConservativePower(const Context<double>& context) const final {
+    unused(context);
+    ++pc_count_;
+    return 3.;
+  }
+
+  // Non-conservative power can depend on time. Here it is 4*t.
+  double DoCalcNonConservativePower(
+      const Context<double>& context) const final {
+    ++pnc_count_;
+    return 4. * context.get_time();
+  }
+
+  // These are required by the base class but not used here.
+  std::unique_ptr<CompositeEventCollection<double>>
+  AllocateCompositeEventCollection() const final { return {}; }
+  void SetDefaultState(const Context<double>&, State<double>*) const final {}
+  void SetDefaultParameters(const Context<double>&,
+                            Parameters<double>*) const final {}
+  std::unique_ptr<EventCollection<PublishEvent<double>>>
+  AllocateForcedPublishEventCollection() const final { return {}; }
+  std::unique_ptr<EventCollection<DiscreteUpdateEvent<double>>>
+  AllocateForcedDiscreteUpdateEventCollection() const final { return {}; }
+  std::unique_ptr<EventCollection<UnrestrictedUpdateEvent<double>>>
+  AllocateForcedUnrestrictedUpdateEventCollection() const final { return {}; }
+  std::multimap<int, int> GetDirectFeedthroughs() const final { return {}; }
+  double DoCalcWitnessValue(const Context<double>&,
+                            const WitnessFunction<double>&) const final {
+    DRAKE_ABORT_MSG("test should not get here");
+  }
+  void AddTriggeredWitnessFunctionToCompositeEventCollection(
+      Event<double>*, CompositeEventCollection<double>*) const final {
+    DRAKE_ABORT_MSG("test should not get here");
+  }
+  BasicVector<double>* DoAllocateInputVector(
+      const InputPort<double>&) const final { return nullptr; }
+  AbstractValue* DoAllocateInputAbstract(const InputPort<double>&) const final {
+    return nullptr;
+  }
+  void DispatchPublishHandler(
+      const Context<double>& context,
+      const EventCollection<PublishEvent<double>>& events) const final {
+    DRAKE_ABORT_MSG("test should not get here");
+  }
+  void DispatchDiscreteVariableUpdateHandler(
+      const Context<double>& context,
+      const EventCollection<DiscreteUpdateEvent<double>>& events,
+      DiscreteValues<double>* discrete_state) const final {
+    DRAKE_ABORT_MSG("test should not get here");
+  }
+  void DispatchUnrestrictedUpdateHandler(
+      const Context<double>&,
+      const EventCollection<UnrestrictedUpdateEvent<double>>&,
+      State<double>*) const final {
+    DRAKE_ABORT_MSG("test should not get here");
+  }
+  std::map<PeriodicEventData, std::vector<const Event<double>*>,
+           PeriodicEventDataComparator>
+  DoGetPeriodicEvents() const final { return {}; }
+
+  mutable int xcdot_count_{};
+  mutable int pe_count_{};
+  mutable int ke_count_{};
+  mutable int pc_count_{};
+  mutable int pnc_count_{};
+};
+
+// Provides values for some of the inputs and sets up for outputs.
+class ComputationTest : public ::testing::Test {
+ protected:
+  void SetUp() final {
+    context_->EnableCaching();
+  }
+
+  ComputationTestSystem test_sys_;
+  std::unique_ptr<Context<double>> context_ =
+      test_sys_.CreateDefaultContext();
+};
+
+TEST_F(ComputationTest, Eval) {
+  context_->set_time(1.);
+
+  //                 xcdot, pe, ke, pc, pnc
+  test_sys_.ExpectCount(0, 0, 0, 0, 0);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[0], -1.);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[1], -2.);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[2], -3.);
+  // Caching should have kept us to a single derivative evaluation.
+  test_sys_.ExpectCount(1, 0, 0, 0, 0);
+
+  EXPECT_EQ(test_sys_.EvalPotentialEnergy(*context_), 1.);
+  test_sys_.ExpectCount(1, 1, 0, 0, 0);
+  EXPECT_EQ(test_sys_.EvalKineticEnergy(*context_), 2.);
+  test_sys_.ExpectCount(1, 1, 1, 0, 0);
+  EXPECT_EQ(test_sys_.EvalConservativePower(*context_), 3.);
+  test_sys_.ExpectCount(1, 1, 1, 1, 0);
+  EXPECT_EQ(test_sys_.EvalNonConservativePower(*context_), 4.);
+  test_sys_.ExpectCount(1, 1, 1, 1, 1);
+
+  // These should not require re-evaluation.
+  EXPECT_EQ(test_sys_.EvalPotentialEnergy(*context_), 1.);
+  EXPECT_EQ(test_sys_.EvalKineticEnergy(*context_), 2.);
+  EXPECT_EQ(test_sys_.EvalConservativePower(*context_), 3.);
+  EXPECT_EQ(test_sys_.EvalNonConservativePower(*context_), 4.);
+  test_sys_.ExpectCount(1, 1, 1, 1, 1);
+
+  // Each of the Calc methods should cause computation.
+  auto derivatives = test_sys_.AllocateTimeDerivatives();
+  test_sys_.CalcTimeDerivatives(*context_, &*derivatives);
+  test_sys_.ExpectCount(2, 1, 1, 1, 1);
+  EXPECT_EQ((*derivatives)[1], -2.);
+  EXPECT_EQ(test_sys_.CalcPotentialEnergy(*context_), 1.);
+  test_sys_.ExpectCount(2, 2, 1, 1, 1);
+  EXPECT_EQ(test_sys_.CalcKineticEnergy(*context_), 2.);
+  test_sys_.ExpectCount(2, 2, 2, 1, 1);
+  EXPECT_EQ(test_sys_.CalcConservativePower(*context_), 3.);
+  test_sys_.ExpectCount(2, 2, 2, 2, 1);
+  EXPECT_EQ(test_sys_.CalcNonConservativePower(*context_), 4.);
+  test_sys_.ExpectCount(2, 2, 2, 2, 2);
+
+  // TODO(sherm1) Pending resolution of issue #9171 we can be more precise
+  // about dependencies here. For now we'll just verify that changing
+  // some significant variables causes recomputation, not that *only*
+  // significant variables cause recomputation.
+  context_->set_time(2.);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[0], -2.);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[1], -4.);
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[2], -6.);
+  test_sys_.ExpectCount(3, 2, 2, 2, 2);  // Above is just one evaluation.
+  EXPECT_EQ(test_sys_.EvalNonConservativePower(*context_), 8.);
+  test_sys_.ExpectCount(3, 2, 2, 2, 3);
+  // TODO(sherm1) Verify that other methods don't depend on time.
+
+  // This should mark all state variables as changed and force recomputation.
+  context_->get_mutable_state();
+  EXPECT_EQ(test_sys_.EvalTimeDerivatives(*context_)[2], -6.);  // Again.
+  test_sys_.ExpectCount(4, 2, 2, 2, 3);
+  EXPECT_EQ(test_sys_.EvalPotentialEnergy(*context_), 1.);
+  test_sys_.ExpectCount(4, 3, 2, 2, 3);
+  EXPECT_EQ(test_sys_.EvalKineticEnergy(*context_), 2.);
+  test_sys_.ExpectCount(4, 3, 3, 2, 3);
+  EXPECT_EQ(test_sys_.EvalConservativePower(*context_), 3.);
+  test_sys_.ExpectCount(4, 3, 3, 3, 3);
+  EXPECT_EQ(test_sys_.EvalNonConservativePower(*context_), 8.);  // Again.
+  test_sys_.ExpectCount(4, 3, 3, 3, 4);
+}
+
 }  // namespace
 }  // namespace systems
 }  // namespace drake

--- a/systems/primitives/test/constant_value_source_test.cc
+++ b/systems/primitives/test/constant_value_source_test.cc
@@ -36,9 +36,13 @@ class ConstantValueSourceTest : public ::testing::Test {
 TEST_F(ConstantValueSourceTest, Output) {
   ASSERT_EQ(source_->get_num_input_ports(), context_->get_num_input_ports());
 
+  // Check Calc() method.
   source_->get_output_port(0).Calc(*context_, output_.get());
-
   EXPECT_EQ("foo", output_->GetValue<std::string>());
+
+  // Check Eval() method.
+  auto& cached_value = source_->get_output_port(0).Eval<std::string>(*context_);
+  EXPECT_EQ("foo", cached_value);
 }
 
 // Tests that ConstantValueSource allocates no state variables in the context_.

--- a/systems/sensors/depth_sensor.cc
+++ b/systems/sensors/depth_sensor.cc
@@ -54,10 +54,11 @@ DepthSensor::DepthSensor(const std::string& name,
   }
   DRAKE_DEMAND(specification_.min_range() <= specification_.max_range() &&
                "min_range must be less than or equal to max_range");
-  input_port_index_ =
-      DeclareInputPort(kVectorValued,
-                       tree.get_num_positions() + tree.get_num_velocities())
-          .get_index();
+
+  const auto& input_port = DeclareInputPort(
+      kVectorValued, tree.get_num_positions() + tree.get_num_velocities());
+  input_port_index_ = input_port.get_index();
+
   depth_output_port_index_ =
       DeclareVectorOutputPort(DepthSensorOutput<double>(specification_),
                               &DepthSensor::CalcDepthOutput)
@@ -66,7 +67,27 @@ DepthSensor::DepthSensor(const std::string& name,
       DeclareVectorOutputPort(PoseVector<double>(),
                               &DepthSensor::CalcPoseOutput)
           .get_index();
+
+  // Kinematics cache here depends only on the input port, specifically just
+  // the q's (but the port has v's also).
+  kinematics_cache_entry_ = &DeclareCacheEntry(
+      "kinematics cache", &DepthSensor::AllocateKinematicsCache,
+      &DepthSensor::CalcKinematics, {input_port.ticket()});
+
   PrecomputeRaycastEndpoints();
+}
+
+KinematicsCache<double> DepthSensor::AllocateKinematicsCache() const {
+  return tree_.CreateKinematicsCache();
+}
+
+void DepthSensor::CalcKinematics(
+    const Context<double>& context,
+    KinematicsCache<double>* kinematics_cache) const {
+  VectorXd u = this->EvalEigenVectorInput(context, input_port_index_);
+  auto q = u.head(tree_.get_num_positions());
+  kinematics_cache->initialize(q);
+  tree_.doKinematics(*kinematics_cache);
 }
 
 void DepthSensor::PrecomputeRaycastEndpoints() {
@@ -128,14 +149,11 @@ const OutputPort<double>& DepthSensor::get_pose_output_port() const {
   return System<double>::get_output_port(pose_output_port_index_);
 }
 
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcDepthOutput(
     const Context<double>& context,
     DepthSensorOutput<double>* data_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const int frame_index = frame_.get_frame_index();
 
@@ -187,13 +205,10 @@ void DepthSensor::ApplyLimits(VectorX<double>* distances) const {
 }
 
 // Evaluates the output port containing X_WS.
-// TODO(sherm1) Should be accessing an already-calculated kinematics cache,
-// not recalculating.
 void DepthSensor::CalcPoseOutput(const Context<double>& context,
                                  PoseVector<double>* pose_output) const {
-  VectorXd u = this->EvalEigenVectorInput(context, 0);
-  auto q = u.head(tree_.get_num_positions());
-  KinematicsCache<double> kinematics_cache = tree_.doKinematics(q);
+  const auto& kinematics_cache =
+      kinematics_cache_entry_->Eval<KinematicsCache<double>>(context);
 
   const drake::Isometry3<double> X_WS =
       tree_.CalcFramePoseInWorldFrame(kinematics_cache, frame_);

--- a/systems/sensors/depth_sensor.h
+++ b/systems/sensors/depth_sensor.h
@@ -166,6 +166,14 @@ class DepthSensor : public systems::LeafSystem<double> {
   void CalcPoseOutput(const Context<double>& context,
                       rendering::PoseVector<double>* pose_output) const;
 
+  // Allocator for our CacheEntry. Returns a KinematicsCache suitable for
+  // the RigidBodyTree we're using.
+  KinematicsCache<double> AllocateKinematicsCache() const;
+
+  // Calculator for the CacheEntry. Updates the KinematicsCache to reflect
+  // the current q's at the input port.
+  void CalcKinematics(const Context<double>& context,
+                      KinematicsCache<double>*) const;
 
   // The depth sensor will cast a ray with its start point at (0,0,0) in the
   // sensor's base frame (as defined by get_frame()). Its end, also in the
@@ -189,6 +197,7 @@ class DepthSensor : public systems::LeafSystem<double> {
   int input_port_index_{};
   int depth_output_port_index_{};
   int pose_output_port_index_{};
+  const CacheEntry* kinematics_cache_entry_{};
 
   // A cache of where a depth measurement ray endpoint would be if the maximum
   // range were achieved. This is cached to avoid repeated allocation and


### PR DESCRIPTION
This is the final PR for enabling operation of the Drake caching system, following on from #9067 and draining the last of the changes from #7668. However, caching is turned off by default to permit separation of the effect of the dependency-tracking infrastructure (a cost) from the effect of caching results (a benefit). A very short PR will follow that only changes the default behavior.

This adds 
- notifications when Context source quantities are modified, so that dependent output port and cache entry computations are invalidated,
- cache entries for built-in computations involving power, energy, and time derivatives,
- modifications to depth_sensor as an example of using a cache entry to avoid recalculation of kinematics.

After this lands, you can try out caching by adding `context.EnableCaching()` to whatever context you are working with. (That is done here to enable the unit tests to work.) In that case, output ports will be automatically cached with assumed dependencies on _any_ source value changes (time, accuracy, parameters, states, input ports). That benefits any Systems that have output port "fan out" to multiple clients. In general, however, obtaining speedups requires using `Eval()` methods rather than `Calc()` methods, creating explicit cache entries, and specifying limited prerequisite tickets rather than the default "all sources".

Resolves #4364.
```
Category            added  modified  removed  
----------------------------------------------
code                1444   166       141      
comments            823    220       118      
blank               229    0         0        
----------------------------------------------
TOTAL               2496   386       259      
```
Apologies for the size -- started out modest, but grew substantially during feature review due to some needed code rearrangement, documentation imporvement, bug fixes, and new unit tests, including several large-but-repetitive tests that check for each possible Context source value that the right invalidations occur upon modification. Commits are curated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9113)
<!-- Reviewable:end -->
