### PR TITLE
Defaults collision geometry to be invisible.

### DIFF
--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -164,6 +164,10 @@ void AddGripperPads(MultibodyPlant<double>* plant,
 
     plant->RegisterCollisionGeometry(
         finger, X_FS, Sphere(kPadMinorRadius), friction, scene_graph);
+
+    const geometry::VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
+    plant->RegisterVisualGeometry(
+        finger, X_FS, Sphere(kPadMinorRadius), red, scene_graph);
   }
 }
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -136,12 +136,19 @@ geometry::GeometryId MultibodyPlant<T>::RegisterCollisionGeometry(
         "RegisterAsSourceForSceneGraph()");
   }
   GeometryId id;
+  // We use an "invisible" color with alpha channel set to zero so that
+  // collision geometry does not render on top of visual geometry in our
+  // visualizer.
+  // TODO(amcastro-tri): Remove this "invisible" color once "roles" land in
+  // SceneGraph.
+  const geometry::VisualMaterial invisible_material(
+      Vector4<double>(0.0, 0.0, 0.0, 0.0));
   // TODO(amcastro-tri): Consider doing this after finalize so that we can
   // register anchored geometry on ANY body welded to the world.
   if (body.index() == world_index()) {
-    id = RegisterAnchoredGeometry(X_BG, shape, {}, scene_graph);
+    id = RegisterAnchoredGeometry(X_BG, shape, invisible_material, scene_graph);
   } else {
-    id = RegisterGeometry(body, X_BG, shape, {}, scene_graph);
+    id = RegisterGeometry(body, X_BG, shape, invisible_material, scene_graph);
   }
   const int collision_index = geometry_id_to_collision_index_.size();
   geometry_id_to_collision_index_[id] = collision_index;


### PR DESCRIPTION
A simple temporary fix to avoid the overlapping rendering of visuals and collision with SceneGraph, until the "roles" feature lands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9115)
<!-- Reviewable:end -->
