### PR TITLE
Defaults friction coefficients to 1.0 when reading from an SDF file

### DIFF
--- a/multibody/multibody_tree/parsing/BUILD.bazel
+++ b/multibody/multibody_tree/parsing/BUILD.bazel
@@ -40,6 +40,7 @@ drake_cc_library(
     ],
     deps = [
         "//common:essential",
+        "//multibody/multibody_tree/multibody_plant:coulomb_friction",
         "@sdformat",
     ],
 )

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h
@@ -5,6 +5,7 @@
 #include "drake/geometry/scene_graph.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
+#include "drake/multibody/multibody_tree/parsing/sdf_parser_common.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
+++ b/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
@@ -316,9 +316,8 @@ CoulombFriction<double> MakeCoulombFrictionFromSdfCollisionOde(
   const sdf::Element* const surface_element =
       MaybeGetChildElement(*collision_element, "surface");
 
-  // If the surface is not found, the default is that of a frictionless
-  // surface (i.e. zero friction coefficients).
-  if (!surface_element) return CoulombFriction<double>();
+  // If the surface is not found, we return default friction properties.
+  if (!surface_element) return kDefaultFriction;
 
   // Once <surface> is found, <friction> and <ode> are required.
   const sdf::Element& friction_element =

--- a/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
+++ b/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
@@ -317,7 +317,7 @@ CoulombFriction<double> MakeCoulombFrictionFromSdfCollisionOde(
       MaybeGetChildElement(*collision_element, "surface");
 
   // If the surface is not found, we return default friction properties.
-  if (!surface_element) return kDefaultFriction;
+  if (!surface_element) return default_friction();
 
   // Once <surface> is found, <friction> and <ode> are required.
   const sdf::Element& friction_element =

--- a/multibody/multibody_tree/parsing/sdf_parser_common.h
+++ b/multibody/multibody_tree/parsing/sdf_parser_common.h
@@ -3,10 +3,16 @@
 #include <ignition/math/Pose3.hh>
 
 #include "drake/common/eigen_types.h"
+#include "drake/multibody/multibody_tree/multibody_plant/coulomb_friction.h"
 
 namespace drake {
 namespace multibody {
 namespace parsing {
+
+/// Default value of the Coulomb's law coefficients of friction for when they
+/// are not specified in the SDF file.
+const multibody_plant::CoulombFriction<double> kDefaultFriction(1.0, 1.0);
+
 namespace detail {
 
 /// Helper function to express an ignition::math::Vector3d instance as

--- a/multibody/multibody_tree/parsing/sdf_parser_common.h
+++ b/multibody/multibody_tree/parsing/sdf_parser_common.h
@@ -11,7 +11,14 @@ namespace parsing {
 
 /// Default value of the Coulomb's law coefficients of friction for when they
 /// are not specified in the SDF file.
-const multibody_plant::CoulombFriction<double> kDefaultFriction(1.0, 1.0);
+// Note:
+//   static global variables are strongly discouraged by the C++ style guide:
+// http://drake.mit.edu/styleguide/cppguide.html#Static_and_Global_Variables
+// For this reason, we create and return an instance of CoulombFriction
+// instead of using a static variable.
+inline multibody_plant::CoulombFriction<double> default_friction() {
+  return multibody_plant::CoulombFriction<double>(1.0, 1.0);
+}
 
 namespace detail {
 

--- a/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
+++ b/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
@@ -103,14 +103,6 @@
             <size>1.0 2.0 3.0</size>
           </box>
         </geometry>
-        <surface>
-          <friction>
-            <ode>
-              <mu>0.5</mu>
-              <mu2>0.5</mu2>
-            </ode>
-          </friction>
-        </surface>
       </collision>
     </link>
 

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -24,7 +24,7 @@ using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::Body;
 using multibody::parsing::AddModelFromSdfFile;
-using multibody::parsing::kDefaultFriction;
+using multibody::parsing::default_friction;
 using systems::Context;
 
 namespace multibody {
@@ -281,7 +281,7 @@ TEST_F(MultibodyPlantSdfParser, LinksWithCollisions) {
   // not specify them in the SDF file.
   EXPECT_TRUE(ExtractBoolOrThrow(
       plant_.default_coulomb_friction(link3_collision_geometry_ids[0]) ==
-          kDefaultFriction));
+          default_friction()));
 }
 // Verifies model instances are correctly created in the plant.
 TEST_F(MultibodyPlantSdfParser, ModelInstanceTest) {

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -24,6 +24,7 @@ using multibody::benchmarks::acrobot::AcrobotParameters;
 using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::Body;
 using multibody::parsing::AddModelFromSdfFile;
+using multibody::parsing::kDefaultFriction;
 using systems::Context;
 
 namespace multibody {
@@ -276,9 +277,11 @@ TEST_F(MultibodyPlantSdfParser, LinksWithCollisions) {
   const std::vector<GeometryId>& link3_collision_geometry_ids =
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link3"));
   ASSERT_EQ(link3_collision_geometry_ids.size(), 1);
+  // Verifies the default value of the friction coefficients when the user does
+  // not specify them in the SDF file.
   EXPECT_TRUE(ExtractBoolOrThrow(
       plant_.default_coulomb_friction(link3_collision_geometry_ids[0]) ==
-          CoulombFriction<double>(0.5, 0.5)));
+          kDefaultFriction));
 }
 // Verifies model instances are correctly created in the plant.
 TEST_F(MultibodyPlantSdfParser, ModelInstanceTest) {


### PR DESCRIPTION
This helps users in not having to specify a friction coefficient for everything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9116)
<!-- Reviewable:end -->
