### PR TITLE
Change 'joint_limits_test' to manual

### DIFF
--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -179,6 +179,8 @@ drake_cc_googletest(
     data = [
         "//manipulation/models/iiwa_description:models",
     ],
+    # TODO (amcastro): Re-enable test, times out on mac tsan
+    tags = ["manual"],
     deps = [
         ":multibody_plant",
         "//common:find_resource",


### PR DESCRIPTION
This test was introduced in #9111 and is timing out on mac-tsan builds, see:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-highsierra-clang-bazel-nightly-memcheck-tsan/256/
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-sierra-clang-bazel-nightly-memcheck-tsan/361/

As the test is already 'long', and as an alternative to reverting the entire PR, mark the test as 'manual'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9132)
<!-- Reviewable:end -->
