### PR TITLE
pydrake deprecation: Make `ModuleShim` be `rlcompleter` friendly

### DIFF
--- a/bindings/pydrake/__init__.py
+++ b/bindings/pydrake/__init__.py
@@ -46,4 +46,4 @@ def _getattr_handler(name):
         raise AttributeError()
 
 
-ModuleShim.install(__name__, _getattr_handler)
+ModuleShim._install(__name__, _getattr_handler)

--- a/bindings/pydrake/util/deprecation.py
+++ b/bindings/pydrake/util/deprecation.py
@@ -15,6 +15,7 @@ If you would like to disable all Drake-related warnings, you may use the
 
 import sys
 import traceback
+from types import ModuleType
 import warnings
 
 # TODO(eric.cousineau): Make autocomplete ignore `ModuleShim` attributes
@@ -33,6 +34,8 @@ class ModuleShim(object):
     def __init__(self, orig_module, handler):
         assert hasattr(orig_module, "__all__"), (
             "Please define `__all__` for this module.")
+        assert isinstance(orig_module, ModuleType), (
+            "{} must be a module".format(orig_module))
         # https://stackoverflow.com/a/16237698/7829525
         object.__setattr__(self, '_orig_module', orig_module)
         object.__setattr__(self, '_handler', handler)
@@ -66,14 +69,23 @@ class ModuleShim(object):
     def __repr__(self):
         return repr(self._orig_module)
 
+    def __dir__(self):
+        # Implemented to provide a useful subset of completions to
+        # `rlcompleter`.
+        return self._orig_module.__all__
+
     @classmethod
-    def install(cls, name, handler):
-        """ Hook into module's attribute accessors and mutators.
+    def _install(cls, name, handler):
+        """
+        Hook into module's attribute accessors and mutators.
         @param name
             Module name. Generally should be __name__.
         @param handler
             Function of the form `handler(var)`, where `var` is
             the variable name.
+        @note This is private such that `install` does not pollute completion
+        candidations provided by `rlcompleter` when it iterates through
+        `__bases__`.
         """
         old_module = sys.modules[name]
         new_module = cls(old_module, handler)

--- a/bindings/pydrake/util/test/deprecation_example/__init__.py
+++ b/bindings/pydrake/util/test/deprecation_example/__init__.py
@@ -11,7 +11,7 @@ def _handler(name):
 
 
 __all__ = ["value", "sub_module"]
-ModuleShim.install(__name__, _handler)
+ModuleShim._install(__name__, _handler)
 
 
 class ExampleClass(object):

--- a/bindings/pydrake/util/test/deprecation_test.py
+++ b/bindings/pydrake/util/test/deprecation_test.py
@@ -4,6 +4,7 @@ from pydrake.util.deprecation import DrakeDeprecationWarning
 
 import pydoc
 import unittest
+import rlcompleter
 import sys
 from types import ModuleType
 import warnings
@@ -64,6 +65,48 @@ class TestDeprecation(unittest.TestCase):
         temp = {}
         exec "from deprecation_example import *" in temp
         self.assertIsInstance(temp["sub_module"], str)
+
+    def test_module_autocomplete(self):
+        # Ensure that we can autocomplete with our example module.
+        # Without `__dir__` being implemented, it'll only return `install` as a
+        # non-private autocomplete candidate.
+        import deprecation_example
+        namespace = locals()
+        completer = rlcompleter.Completer(namespace)
+        candidates = []
+        for i in xrange(1000):
+            candidate = completer.complete("deprecation_example.", i)
+            if candidate is None:
+                break
+            candidates.append(candidate)
+        candidates_expected = [
+            # Injection from `Completer.attr_matches`, via `get_class_members`.
+            "deprecation_example.__class__(",
+            "deprecation_example.__delattr__(",
+            "deprecation_example.__dict__",
+            "deprecation_example.__dir__(",
+            "deprecation_example.__doc__",
+            "deprecation_example.__format__(",
+            "deprecation_example.__getattr__(",
+            "deprecation_example.__getattribute__(",
+            "deprecation_example.__hash__(",
+            "deprecation_example.__init__(",
+            "deprecation_example.__module__",
+            "deprecation_example.__new__(",
+            "deprecation_example.__reduce__(",
+            "deprecation_example.__reduce_ex__(",
+            "deprecation_example.__repr__(",
+            "deprecation_example.__setattr__(",
+            "deprecation_example.__sizeof__(",
+            "deprecation_example.__str__(",
+            "deprecation_example.__subclasshook__(",
+            "deprecation_example.__weakref__",
+            "deprecation_example._install(",
+            # Intended completions via `__all__`.
+            "deprecation_example.sub_module",
+            "deprecation_example.value",
+        ]
+        self.assertSetEqual(set(candidates), set(candidates_expected))
 
     def _check_warning(
             self, item, message_expected, type=DrakeDeprecationWarning):


### PR DESCRIPTION
In preparation for more succinct deprecation as will be done in #9130.
Relates #8832 

\cc @CatchMeFastFat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9137)
<!-- Reviewable:end -->
