### PR TITLE
Remove leftover references to input port "descriptors"

### DIFF
--- a/automotive/automotive_simulator.cc
+++ b/automotive/automotive_simulator.cc
@@ -98,8 +98,8 @@ void AutomotiveSimulator<T>::ConnectCarOutputsAndPriusVis(
   DRAKE_DEMAND(&pose_output.get_system() == &velocity_output.get_system());
   const std::string name = pose_output.get_system().get_name();
   auto ports = aggregator_->AddSinglePoseAndVelocityInput(name, id);
-  builder_->Connect(pose_output, ports.pose_descriptor);
-  builder_->Connect(velocity_output, ports.velocity_descriptor);
+  builder_->Connect(pose_output, ports.pose_input_port);
+  builder_->Connect(velocity_output, ports.velocity_input_port);
   if (lcm_) {
     car_vis_applicator_->AddCarVis(std::make_unique<PriusVis<T>>(id, name));
   }

--- a/automotive/bicycle_car.h
+++ b/automotive/bicycle_car.h
@@ -75,11 +75,10 @@ class BicycleCar final : public systems::LeafSystem<T> {
 
   ~BicycleCar() override;
 
-  /// Returns a descriptor of the input port that contains the steering angle.
+  /// Returns the input port that contains the steering angle.
   const systems::InputPort<T>& get_steering_input_port() const;
 
-  /// Returns a descriptor of the input port that contains the applied
-  /// powertrain force.
+  /// Returns the input port that contains the applied powertrain force.
   const systems::InputPort<T>& get_force_input_port() const;
 
   /// Returns the output port that contains the bicycle states.

--- a/automotive/car_vis_applicator.h
+++ b/automotive/car_vis_applicator.h
@@ -46,7 +46,7 @@ class CarVisApplicator : public systems::LeafSystem<T> {
   CarVisApplicator();
   ~CarVisApplicator() override {}
 
-  /// Returns a descriptor of the input port that contains the vehicle poses in
+  /// Returns the input port that contains the vehicle poses in
   /// the form of a PoseBundle.
   const systems::InputPort<T>& get_car_poses_input_port() const;
 

--- a/automotive/test/bicycle_car_test.cc
+++ b/automotive/test/bicycle_car_test.cc
@@ -69,13 +69,13 @@ class BicycleCarTest : public ::testing::Test {
 TEST_F(BicycleCarTest, Topology) {
   ASSERT_EQ(2, dut_->get_num_input_ports()); /* steering angle, force input */
 
-  const auto& steering_input_descriptor = dut_->get_steering_input_port();
-  EXPECT_EQ(systems::kVectorValued, steering_input_descriptor.get_data_type());
-  EXPECT_EQ(kSteeringInputDimension, steering_input_descriptor.size());
+  const auto& steering_input_port = dut_->get_steering_input_port();
+  EXPECT_EQ(systems::kVectorValued, steering_input_port.get_data_type());
+  EXPECT_EQ(kSteeringInputDimension, steering_input_port.size());
 
-  const auto& force_input_descriptor = dut_->get_force_input_port();
-  EXPECT_EQ(systems::kVectorValued, force_input_descriptor.get_data_type());
-  EXPECT_EQ(kForceInputDimension, force_input_descriptor.size());
+  const auto& force_input_port = dut_->get_force_input_port();
+  EXPECT_EQ(systems::kVectorValued, force_input_port.get_data_type());
+  EXPECT_EQ(kForceInputDimension, force_input_port.size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports()); /* state vector */
 

--- a/automotive/test/car_vis_applicator_test.cc
+++ b/automotive/test/car_vis_applicator_test.cc
@@ -65,8 +65,8 @@ class CarVisApplicatorTest : public ::testing::Test {
 
 TEST_F(CarVisApplicatorTest, Topology) {
   ASSERT_EQ(dut_->get_num_input_ports(), 1);
-  const auto& pose_port_descriptor = dut_->get_car_poses_input_port();
-  EXPECT_EQ(pose_port_descriptor.get_data_type(), systems::kAbstractValued);
+  const auto& pose_port = dut_->get_car_poses_input_port();
+  EXPECT_EQ(pose_port.get_data_type(), systems::kAbstractValued);
 
   ASSERT_EQ(dut_->get_num_output_ports(), 1);
   const auto& lane_output_port =

--- a/automotive/test/idm_controller_test.cc
+++ b/automotive/test/idm_controller_test.cc
@@ -117,18 +117,18 @@ TEST_P(IdmControllerTest, Topology) {
   SetUpIdm(ScanStrategy::kPath);
 
   ASSERT_EQ(3, dut_->get_num_input_ports());
-  const auto& ego_pose_input_descriptor =
+  const auto& ego_pose_input_port =
       dut_->get_input_port(ego_pose_input_index_);
-  EXPECT_EQ(systems::kVectorValued, ego_pose_input_descriptor.get_data_type());
-  EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_descriptor.size());
-  const auto& ego_velocity_input_descriptor =
+  EXPECT_EQ(systems::kVectorValued, ego_pose_input_port.get_data_type());
+  EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_port.size());
+  const auto& ego_velocity_input_port =
       dut_->get_input_port(ego_velocity_input_index_);
   EXPECT_EQ(systems::kVectorValued,
-            ego_velocity_input_descriptor.get_data_type());
-  EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_descriptor.size());
-  const auto& traffic_input_descriptor =
+            ego_velocity_input_port.get_data_type());
+  EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_port.size());
+  const auto& traffic_input_port =
       dut_->get_input_port(traffic_input_index_);
-  EXPECT_EQ(systems::kAbstractValued, traffic_input_descriptor.get_data_type());
+  EXPECT_EQ(systems::kAbstractValued, traffic_input_port.get_data_type());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& output_port = dut_->get_output_port(acceleration_output_index_);

--- a/automotive/test/mobil_planner_test.cc
+++ b/automotive/test/mobil_planner_test.cc
@@ -158,24 +158,24 @@ TEST_P(MobilPlannerTest, Topology) {
   InitializeMobilPlanner(true /* initial_with_s */);
 
   ASSERT_EQ(4, dut_->get_num_input_ports());
-  const auto& ego_pose_input_descriptor =
+  const auto& ego_pose_input_port =
       dut_->get_input_port(ego_pose_input_index_);
-  EXPECT_EQ(systems::kVectorValued, ego_pose_input_descriptor.get_data_type());
-  EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_descriptor.size());
-  const auto& ego_velocity_input_descriptor =
+  EXPECT_EQ(systems::kVectorValued, ego_pose_input_port.get_data_type());
+  EXPECT_EQ(7 /* PoseVector input */, ego_pose_input_port.size());
+  const auto& ego_velocity_input_port =
       dut_->get_input_port(ego_velocity_input_index_);
   EXPECT_EQ(systems::kVectorValued,
-            ego_velocity_input_descriptor.get_data_type());
-  EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_descriptor.size());
-  const auto& ego_acceleration_input_descriptor =
+            ego_velocity_input_port.get_data_type());
+  EXPECT_EQ(6 /* FrameVelocity input */, ego_velocity_input_port.size());
+  const auto& ego_acceleration_input_port =
       dut_->get_input_port(ego_acceleration_input_index_);
   EXPECT_EQ(systems::kVectorValued,
-            ego_acceleration_input_descriptor.get_data_type());
+            ego_acceleration_input_port.get_data_type());
   EXPECT_EQ(1 /* acceleration input */,
-            ego_acceleration_input_descriptor.size());
-  const auto& traffic_input_descriptor =
+            ego_acceleration_input_port.size());
+  const auto& traffic_input_port =
       dut_->get_input_port(traffic_input_index_);
-  EXPECT_EQ(systems::kAbstractValued, traffic_input_descriptor.get_data_type());
+  EXPECT_EQ(systems::kAbstractValued, traffic_input_port.get_data_type());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& lane_output_port = dut_->get_output_port(lane_output_index_);

--- a/automotive/test/pure_pursuit_controller_test.cc
+++ b/automotive/test/pure_pursuit_controller_test.cc
@@ -68,13 +68,13 @@ class PurePursuitControllerTest : public ::testing::Test {
 
 TEST_F(PurePursuitControllerTest, Topology) {
   ASSERT_EQ(2, dut_->get_num_input_ports());
-  const auto& lane_input_descriptor =
+  const auto& lane_input_port =
       dut_->get_input_port(dut_->lane_input().get_index());
-  EXPECT_EQ(systems::kAbstractValued, lane_input_descriptor.get_data_type());
-  const auto& ego_input_descriptor =
+  EXPECT_EQ(systems::kAbstractValued, lane_input_port.get_data_type());
+  const auto& ego_input_port =
       dut_->get_input_port(dut_->ego_pose_input().get_index());
-  EXPECT_EQ(systems::kVectorValued, ego_input_descriptor.get_data_type());
-  EXPECT_EQ(7 /* PoseVector input */, ego_input_descriptor.size());
+  EXPECT_EQ(systems::kVectorValued, ego_input_port.get_data_type());
+  EXPECT_EQ(7 /* PoseVector input */, ego_input_port.size());
 
   ASSERT_EQ(1, dut_->get_num_output_ports());
   const auto& command_output_port =

--- a/automotive/test/simple_car_test.cc
+++ b/automotive/test/simple_car_test.cc
@@ -109,9 +109,9 @@ class SimpleCarTest : public ::testing::Test {
 
 TEST_F(SimpleCarTest, Topology) {
   ASSERT_EQ(1, dut_->get_num_input_ports());
-  const auto& input_descriptor = dut_->get_input_port(0);
-  EXPECT_EQ(systems::kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(DrivingCommandIndices::kNumCoordinates, input_descriptor.size());
+  const auto& input_port = dut_->get_input_port(0);
+  EXPECT_EQ(systems::kVectorValued, input_port.get_data_type());
+  EXPECT_EQ(DrivingCommandIndices::kNumCoordinates, input_port.size());
 
   ASSERT_EQ(3, dut_->get_num_output_ports());
   const auto& state_output = dut_->state_output();

--- a/bindings/pydrake/systems/rendering_py.cc
+++ b/bindings/pydrake/systems/rendering_py.cc
@@ -66,15 +66,15 @@ PYBIND11_MODULE(rendering, m) {
       m, "PoseVelocityInputPorts")
       // N.B. We use lambdas below since we cannot use `def_readonly` with
       // reference members.
-      .def_property_readonly("pose_descriptor",
+      .def_property_readonly("pose_input_port",
            [](PoseVelocityInputPorts<T>* self) ->
            const InputPort<T>& {
-             return self->pose_descriptor;
+             return self->pose_input_port;
            })
-      .def_property_readonly("velocity_descriptor",
+      .def_property_readonly("velocity_input_port",
            [](PoseVelocityInputPorts<T>* self) ->
            const InputPort<T>& {
-             return self->velocity_descriptor;
+             return self->velocity_input_port;
            });
 
   py::class_<PoseAggregator<T>, LeafSystem<T>>(m, "PoseAggregator")

--- a/bindings/pydrake/systems/test/rendering_test.py
+++ b/bindings/pydrake/systems/test/rendering_test.py
@@ -134,12 +134,12 @@ class TestRendering(unittest.TestCase):
         instance_id2 = 42  # Supply another random, but unique, id.
         ports2 = aggregator.AddSinglePoseAndVelocityInput(
             "pose_and_velocity", instance_id2)
-        self.assertEqual(ports2.pose_descriptor.get_data_type(),
+        self.assertEqual(ports2.pose_input_port.get_data_type(),
                          PortDataType.kVectorValued)
-        self.assertEqual(ports2.pose_descriptor.size(), PoseVector.kSize)
-        self.assertEqual(ports2.velocity_descriptor.get_data_type(),
+        self.assertEqual(ports2.pose_input_port.size(), PoseVector.kSize)
+        self.assertEqual(ports2.velocity_input_port.get_data_type(),
                          PortDataType.kVectorValued)
-        self.assertEqual(ports2.velocity_descriptor.size(),
+        self.assertEqual(ports2.velocity_input_port.size(),
                          FrameVelocity.kSize)
         num_poses = 1
         port3 = aggregator.AddBundleInput("pose_bundle", num_poses)

--- a/examples/particles/test/particle_test.cc
+++ b/examples/particles/test/particle_test.cc
@@ -66,10 +66,10 @@ TYPED_TEST_P(ParticleTest, OutputTest) {
 /// consistent with its state and input (velocity and acceleration).
 TYPED_TEST_P(ParticleTest, DerivativesTest) {
   // Set input.
-  const systems::InputPort<TypeParam>& input_descriptor =
+  const systems::InputPort<TypeParam>& input_port =
       this->dut_->get_input_port(0);
   auto input = std::make_unique<systems::BasicVector<TypeParam>>(
-      input_descriptor.size());
+      input_port.size());
   input->SetZero();
   input->SetAtIndex(0, static_cast<TypeParam>(1.0));  // u0 = 1 m/s^2
   this->context_->FixInputPort(0, std::move(input));

--- a/examples/particles/test/utilities_test.cc
+++ b/examples/particles/test/utilities_test.cc
@@ -47,10 +47,10 @@ TYPED_TEST_CASE_P(SingleDOFEulerJointTest);
 /// output is the right mapping of its inputs.
 TYPED_TEST_P(SingleDOFEulerJointTest, OutputTest) {
   // Set input.
-  const systems::InputPort<TypeParam>& input_descriptor =
+  const systems::InputPort<TypeParam>& input_port =
       this->dut_->get_input_port(0);
   auto input = std::make_unique<systems::BasicVector<TypeParam>>(
-      input_descriptor.size());
+      input_port.size());
   input->SetZero();
   input->SetAtIndex(0, static_cast<TypeParam>(1.0));  // q0 = 1.0
   input->SetAtIndex(input->size()/2, static_cast<TypeParam>(5.0));  // v0 = 5.0

--- a/examples/valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
+++ b/examples/valkyrie/actuator_effort_to_rigid_body_plant_input_converter.h
@@ -25,8 +25,7 @@ class ActuatorEffortToRigidBodyPlantInputConverter : public LeafSystem<T> {
       const ActuatorEffortToRigidBodyPlantInputConverter&) = delete;
 
 
-  /// Returns the descriptor of the effort input port corresponding for
-  /// @param actuator
+  /// Returns the effort input port corresponding to @param actuator.
   const InputPort<T>& effort_input_port(
       const RigidBodyActuator& actuator);
 

--- a/examples/valkyrie/robot_state_encoder.h
+++ b/examples/valkyrie/robot_state_encoder.h
@@ -42,13 +42,13 @@ class RobotStateEncoder final : public LeafSystem<double> {
   /// Returns the output port on which the LCM message is presented.
   const OutputPort<double>& lcm_message_port() const;
 
-  /// Returns descriptor of kinematics result input port.
+  /// Returns kinematics result input port.
   const InputPort<double>& kinematics_results_port() const;
 
-  /// Returns descriptor of contact results input port.
+  /// Returns contact results input port.
   const InputPort<double>& contact_results_port() const;
 
-  /// Returns descriptor of effort input port corresponding to @param actuator.
+  /// Returns effort input port corresponding to @param actuator.
   const InputPort<double>& effort_port(
       const RigidBodyActuator& actuator) const;
 

--- a/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
+++ b/manipulation/schunk_wsg/schunk_wsg_plain_controller.h
@@ -112,7 +112,7 @@ class SchunkWsgPlainController
       ControlMode control_mode = ControlMode::kPosition, double kp = 2000,
       double ki = 0, double kd = 5);
 
-  /** Returns the descriptor for the feed-forward force input port.
+  /** Returns the feed-forward force input port.
    * @pre `this` was constructed with `control_mode` set to
    * `ControlMode::kForce`.*/
   const systems::InputPort<double>&
@@ -131,7 +131,7 @@ class SchunkWsgPlainController
     return this->get_input_port(state_input_port_);
   }
 
-  /** Returns the descriptor for the desired grip state input port.
+  /** Returns the desired grip state input port.
    * @pre `this` was constructed with `control_mode` set to
    * `ControlMode::kPosition`.*/
   const systems::InputPort<double>& get_input_port_desired_state()

--- a/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/multibody/rigid_body_plant/rigid_body_plant.h
@@ -282,14 +282,14 @@ class RigidBodyPlant : public LeafSystem<T> {
   int FindInstancePositionIndexFromWorldIndex(int model_instance_id,
                                               int world_position_index);
 
-  /// @name System input port descriptor accessors.
-  /// These are accessors for obtaining descriptors of this RigidBodyPlant's
-  /// input ports. See this class's description for details about these ports
-  /// and how these accessors are typically used.
+  /// @name System input port accessors.
+  /// These are accessors for obtaining this RigidBodyPlant's input ports. See
+  /// this class's description for details about these ports and how these
+  /// accessors are typically used.
   ///@{
 
-  /// Returns a descriptor of the actuator command input port. This method can
-  /// only be called when there is only one model instance in the RigidBodyTree.
+  /// Returns a the actuator command input port. This method can only be
+  /// called when there is only one model instance in the RigidBodyTree.
   /// Otherwise, a std::runtime_error will be thrown. It returns the same port
   /// as model_instance_actuator_command_input_port() using input
   /// parameter RigidBodyTreeConstants::kFirstNonWorldModelInstanceId.
@@ -312,8 +312,8 @@ class RigidBodyPlant : public LeafSystem<T> {
   /// whether it's safe to call model_instance_actuator_command_input_port().
   bool model_instance_has_actuators(int model_instance_id) const;
 
-  /// Returns a descriptor of the input port for a specific model instance. This
-  /// method can only be called when this class is instantiated with constructor
+  /// Returns the input port for a specific model instance. This method can
+  /// only be called when this class is instantiated with constructor
   /// parameter `export_model_instance_centric_ports` equal to `true`.
   const InputPort<T>& model_instance_actuator_command_input_port(
       int model_instance_id) const;

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -789,9 +789,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   }
 
   BasicVector<T>* DoAllocateInputVector(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     // Ask the subsystem to perform the allocation.
-    const InputPortLocator& id = input_port_ids_[descriptor.get_index()];
+    const InputPortLocator& id = input_port_ids_[input_port.get_index()];
     const System<T>* subsystem = id.first;
     const InputPortIndex subindex = id.second;
     return subsystem->AllocateInputVector(subsystem->get_input_port(subindex))
@@ -799,9 +799,9 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   }
 
   AbstractValue* DoAllocateInputAbstract(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     // Ask the subsystem to perform the allocation.
-    const InputPortLocator& id = input_port_ids_[descriptor.get_index()];
+    const InputPortLocator& id = input_port_ids_[input_port.get_index()];
     const System<T>* subsystem = id.first;
     const InputPortIndex subindex = id.second;
     return subsystem->AllocateInputAbstract(subsystem->get_input_port(subindex))
@@ -1382,10 +1382,10 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     GetSystemIndexOrAbort(sys);
 
     // Add this port to our externally visible topology.
-    const auto& subsystem_descriptor = sys->get_input_port(port_index);
-    this->DeclareInputPort(subsystem_descriptor.get_data_type(),
-                           subsystem_descriptor.size(),
-                           subsystem_descriptor.get_random_type());
+    const auto& subsystem_input_port = sys->get_input_port(port_index);
+    this->DeclareInputPort(subsystem_input_port.get_data_type(),
+                           subsystem_input_port.size(),
+                           subsystem_input_port.get_random_type());
   }
 
   // Exposes the given subsystem output port as an output of the Diagram.

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -362,32 +362,32 @@ class LeafSystem : public System<T> {
     DoCalcNextUpdateTimeImpl(context, events, time);
   }
 
-  /// Allocates a vector that is suitable as an input value for @p descriptor.
+  /// Allocates a vector that is suitable as an input value for @p input_port.
   /// The default implementation in this class either clones the model_vector
   /// (if the port was declared via DeclareVectorInputPort) or else allocates a
   /// BasicVector (if the port was declared via DeclareInputPort(kVectorValued,
   /// size).  Subclasses can override this method if the default behavior is
   /// not sufficient.
   BasicVector<T>* DoAllocateInputVector(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     std::unique_ptr<BasicVector<T>> model_result =
-        model_input_values_.CloneVectorModel<T>(descriptor.get_index());
+        model_input_values_.CloneVectorModel<T>(input_port.get_index());
     if (model_result) {
       return model_result.release();
     }
-    return new BasicVector<T>(descriptor.size());
+    return new BasicVector<T>(input_port.size());
   }
 
-  /// Allocates an AbstractValue suitable as an input value for @p descriptor.
+  /// Allocates an AbstractValue suitable as an input value for @p input_port.
   /// The default implementation in this class either clones the model_value
   /// (if the port was declared via DeclareAbstractInputPort) or else aborts.
   ///
   /// Subclasses with abstract input ports must either provide a model_value
   /// when declaring the port, or else override this method.
   AbstractValue* DoAllocateInputAbstract(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     std::unique_ptr<AbstractValue> model_result =
-        model_input_values_.CloneModel(descriptor.get_index());
+        model_input_values_.CloneModel(input_port.get_index());
     if (model_result) {
       return model_result.release();
     }

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -560,10 +560,10 @@ TEST_F(DiagramTest, Witness) {
 TEST_F(DiagramTest, Topology) {
   ASSERT_EQ(kSize, diagram_->get_num_input_ports());
   for (int i = 0; i < kSize; ++i) {
-    const auto& descriptor = diagram_->get_input_port(i);
-    EXPECT_EQ(diagram_.get(), descriptor.get_system());
-    EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(kSize, descriptor.size());
+    const auto& input_port = diagram_->get_input_port(i);
+    EXPECT_EQ(diagram_.get(), input_port.get_system());
+    EXPECT_EQ(kVectorValued, input_port.get_data_type());
+    EXPECT_EQ(kSize, input_port.size());
   }
 
   ASSERT_EQ(kSize, diagram_->get_num_output_ports());

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -125,12 +125,12 @@ class TestSystem : public System<double> {
 
  protected:
   BasicVector<double>* DoAllocateInputVector(
-      const InputPort<double>& descriptor) const override {
+      const InputPort<double>& input_port) const override {
     return nullptr;
   }
 
   AbstractValue* DoAllocateInputAbstract(
-      const InputPort<double>& descriptor) const override {
+      const InputPort<double>& input_port) const override {
     return nullptr;
   }
 
@@ -317,9 +317,9 @@ TEST_F(SystemTest, DiscreteUpdate) {
   EXPECT_EQ(1, system_.get_update_count());
 }
 
-// Tests that descriptor references remain valid even if lots of other
-// descriptors are added to the system, forcing a vector resize.
-TEST_F(SystemTest, PortDescriptorsAreStable) {
+// Tests that port references remain valid even if lots of other ports are added
+// to the system, forcing a vector resize.
+TEST_F(SystemTest, PortReferencesAreStable) {
   const auto& first_input = system_.AddAbstractInputPort();
   const auto& first_output = system_.AddAbstractOutputPort();
   for (int i = 0; i < 1000; i++) {
@@ -468,16 +468,16 @@ class ValueIOTestSystem : public System<T> {
   }
 
   AbstractValue* DoAllocateInputAbstract(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     // Should only get called for the first input.
-    EXPECT_EQ(descriptor.get_index(), 0);
+    EXPECT_EQ(input_port.get_index(), 0);
     return AbstractValue::Make<std::string>("").release();
   }
 
   BasicVector<T>* DoAllocateInputVector(
-      const InputPort<T>& descriptor) const override {
+      const InputPort<T>& input_port) const override {
     // Should not get called for the first (abstract) input.
-    EXPECT_GE(descriptor.get_index(), 1);
+    EXPECT_GE(input_port.get_index(), 1);
     return new TestTypedVector<T>();
   }
 

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -147,9 +147,9 @@ TEST_F(VectorSystemTest, Topology) {
 
   // One input port.
   ASSERT_EQ(dut.get_num_input_ports(), 1);
-  const InputPort<double>& descriptor_in = dut.get_input_port();
-  EXPECT_EQ(descriptor_in.get_data_type(), kVectorValued);
-  EXPECT_EQ(descriptor_in.size(), TestVectorSystem::kSize);
+  const InputPort<double>& input_port = dut.get_input_port();
+  EXPECT_EQ(input_port.get_data_type(), kVectorValued);
+  EXPECT_EQ(input_port.size(), TestVectorSystem::kSize);
 
   // One output port.
   ASSERT_EQ(dut.get_num_output_ports(), 1);

--- a/systems/primitives/test/adder_test.cc
+++ b/systems/primitives/test/adder_test.cc
@@ -37,9 +37,9 @@ class AdderTest : public ::testing::Test {
 TEST_F(AdderTest, Topology) {
   ASSERT_EQ(2, adder_->get_num_input_ports());
   for (int i = 0; i < 2; ++i) {
-    const InputPort<double>& descriptor = adder_->get_input_port(i);
-    EXPECT_EQ(kVectorValued, descriptor.get_data_type());
-    EXPECT_EQ(3, descriptor.size());
+    const InputPort<double>& input_port = adder_->get_input_port(i);
+    EXPECT_EQ(kVectorValued, input_port.get_data_type());
+    EXPECT_EQ(3, input_port.size());
   }
 
   ASSERT_EQ(1, adder_->get_num_output_ports());

--- a/systems/primitives/test/first_order_low_pass_filter_test.cc
+++ b/systems/primitives/test/first_order_low_pass_filter_test.cc
@@ -57,9 +57,9 @@ class FirstOrderLowPassFilterTest : public ::testing::Test {
 TEST_F(FirstOrderLowPassFilterTest, Topology) {
   SetUpSingleTimeConstantFilter();
   ASSERT_EQ(1, filter_->get_num_input_ports());
-  const auto& input_descriptor = filter_->get_input_port();
-  EXPECT_EQ(kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(kSignalSize, input_descriptor.size());
+  const auto& input_input_port = filter_->get_input_port();
+  EXPECT_EQ(kVectorValued, input_input_port.get_data_type());
+  EXPECT_EQ(kSignalSize, input_input_port.size());
 
   ASSERT_EQ(1, filter_->get_num_output_ports());
   const auto& output_port = filter_->get_output_port();

--- a/systems/primitives/test/integrator_test.cc
+++ b/systems/primitives/test/integrator_test.cc
@@ -45,9 +45,9 @@ class IntegratorTest : public ::testing::Test {
 // Tests that the system exports the correct topology.
 TEST_F(IntegratorTest, Topology) {
   ASSERT_EQ(1, integrator_->get_num_input_ports());
-  const auto& input_descriptor = integrator_->get_input_port(0);
-  EXPECT_EQ(kVectorValued, input_descriptor.get_data_type());
-  EXPECT_EQ(kLength, input_descriptor.size());
+  const auto& input_port = integrator_->get_input_port(0);
+  EXPECT_EQ(kVectorValued, input_port.get_data_type());
+  EXPECT_EQ(kLength, input_port.size());
 
   ASSERT_EQ(1, integrator_->get_num_output_ports());
   const auto& output_port = integrator_->get_output_port(0);

--- a/systems/rendering/pose_aggregator.cc
+++ b/systems/rendering/pose_aggregator.cc
@@ -45,12 +45,12 @@ PoseVelocityInputPorts<T>
 PoseAggregator<T>::AddSinglePoseAndVelocityInput(const std::string& name,
                                                  int model_instance_id) {
   // Add an input for the pose.
-  const auto& pose_descriptor =
+  const auto& pose_input_port =
       DeclareInput(MakeSinglePoseInputRecord(name, model_instance_id));
   // Add an input for the velocity.
-  const auto& velocity_descriptor =
+  const auto& velocity_input_port =
       DeclareInput(MakeSingleVelocityInputRecord(name, model_instance_id));
-  return {pose_descriptor, velocity_descriptor};
+  return {pose_input_port, velocity_input_port};
 }
 
 template <typename T>

--- a/systems/rendering/pose_aggregator.h
+++ b/systems/rendering/pose_aggregator.h
@@ -15,12 +15,12 @@ namespace rendering {
 
 namespace pose_aggregator_detail { struct InputRecord; }
 
-/// A container with references to the input port descriptor for the pose input,
-/// and a reference to an input port descriptor for the velocity input.
+/// A container with references to the input port for the pose input, and a
+/// reference to the input port for the velocity input.
 template <typename T>
 struct PoseVelocityInputPorts {
-  const InputPort<T>& pose_descriptor;
-  const InputPort<T>& velocity_descriptor;
+  const InputPort<T>& pose_input_port;
+  const InputPort<T>& velocity_input_port;
 };
 
 
@@ -99,7 +99,7 @@ class PoseAggregator : public LeafSystem<T> {
   /// FrameVelocity. @p name must be unique for all inputs with the same
   /// @p model_instance_id.
   ///
-  /// @return Descriptors for pose and velocity.
+  /// @return Input ports for pose and velocity.
   PoseVelocityInputPorts<T>
   AddSinglePoseAndVelocityInput(const std::string& name, int model_instance_id);
 

--- a/systems/rendering/test/pose_aggregator_test.cc
+++ b/systems/rendering/test/pose_aggregator_test.cc
@@ -194,12 +194,12 @@ TEST_F(PoseAggregatorTest, CompositeAggregation) {
 // Tests that PoseAggregator allocates no state variables in the context_.
 TEST_F(PoseAggregatorTest, Stateless) { EXPECT_TRUE(context_->is_stateless()); }
 
-// Tests that AddSinglePoseAndVelocityInput returns descriptors for both
+// Tests that AddSinglePoseAndVelocityInput returns input ports for both
 // the new ports.
 TEST_F(PoseAggregatorTest, AddSinglePoseAndVelocityPorts) {
   auto ports = aggregator_.AddSinglePoseAndVelocityInput("test", 100);
-  const InputPort<double>& pose_port = ports.pose_descriptor;
-  const InputPort<double>& velocity_port = ports.velocity_descriptor;
+  const InputPort<double>& pose_port = ports.pose_input_port;
+  const InputPort<double>& velocity_port = ports.velocity_input_port;
   EXPECT_EQ(PoseVector<double>::kSize, pose_port.size());
   EXPECT_EQ(FrameVelocity<double>::kSize, velocity_port.size());
 }

--- a/systems/sensors/accelerometer.h
+++ b/systems/sensors/accelerometer.h
@@ -159,16 +159,15 @@ class Accelerometer : public systems::LeafSystem<double> {
   /// @see get_tree()
   const RigidBodyFrame<double>& get_frame() const { return frame_; }
 
-  /// Returns a descriptor of the input port that should contain the generalized
-  /// position and velocity vector of the RigidBodyPlant that this sensor is
-  /// sensing.
+  /// Returns the input port that should contain the generalized position and
+  /// velocity vector of the RigidBodyPlant that this sensor is sensing.
   const InputPort<double>& get_plant_state_input_port() const {
     return System<double>::get_input_port(plant_state_input_port_index_);
   }
 
-  /// Returns a descriptor of the input port that should contain the derivative
-  /// of the generalized position and velocity vector of the RigidBodyPlant that
-  /// this sensor is sensing.
+  /// Returns the input port that should contain the derivative of the
+  /// generalized position and velocity vector of the RigidBodyPlant that this
+  /// sensor is sensing.
   const InputPort<double>& get_plant_state_derivative_input_port()
       const {
     return System<double>::get_input_port(

--- a/systems/sensors/depth_sensor.h
+++ b/systems/sensors/depth_sensor.h
@@ -142,8 +142,8 @@ class DepthSensor : public systems::LeafSystem<double> {
     return specification_.num_depth_readings();
   }
 
-  /// Returns a descriptor of the input port containing the generalized state of
-  /// the RigidBodyTree.
+  /// Returns the input port containing the generalized state of the
+  /// RigidBodyTree.
   const InputPort<double>& get_rigid_body_tree_state_input_port()
       const;
 

--- a/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
+++ b/systems/sensors/depth_sensor_to_lcm_point_cloud_message.h
@@ -29,10 +29,10 @@ class DepthSensorToLcmPointCloudMessage : public systems::LeafSystem<double> {
   explicit DepthSensorToLcmPointCloudMessage(
       const DepthSensorSpecification& spec);
 
-  /// Returns a descriptor of the input port containing a DepthSensorOutput.
+  /// Returns the input port containing a DepthSensorOutput.
   const InputPort<double>& depth_readings_input_port() const;
 
-  /// Returns a descriptor of the input port containing `X_WS`.
+  /// Returns the input port containing `X_WS`.
   const InputPort<double>& pose_input_port() const;
 
   /// Returns the abstract valued output port that contains a

--- a/systems/sensors/gyroscope.h
+++ b/systems/sensors/gyroscope.h
@@ -85,9 +85,8 @@ class Gyroscope : public systems::LeafSystem<double> {
   /// @see get_tree()
   const RigidBodyFrame<double>& get_frame() const { return frame_; }
 
-  /// Returns a descriptor of the input port that should contain the generalized
-  /// (i.e., linear and rotational) position and velocity state of the
-  /// RigidBodyTree DOFs.
+  /// Returns the input port that should contain the generalized (i.e., linear
+  /// and rotational) position and velocity state of the RigidBodyTree DOFs.
   const InputPort<double>& get_input_port() const {
     return System<double>::get_input_port(input_port_index_);
   }

--- a/systems/sensors/image_to_lcm_image_array_t.h
+++ b/systems/sensors/image_to_lcm_image_array_t.h
@@ -38,16 +38,16 @@ class ImageToLcmImageArrayT : public systems::LeafSystem<double> {
                         const std::string& label_frame_name,
                         bool do_compress = false);
 
-  /// Returns a descriptor of the input port containing a color image.
+  /// Returns the input port containing a color image.
   const InputPort<double>& color_image_input_port() const;
 
-  /// Returns a descriptor of the input port containing a depth image.
+  /// Returns the input port containing a depth image.
   const InputPort<double>& depth_image_input_port() const;
 
-  /// Returns a descriptor of the input port containing a label image.
+  /// Returns the input port containing a label image.
   const InputPort<double>& label_image_input_port() const;
 
-  /// Returns a descriptor of the abstract valued output port that contains a
+  /// Returns the abstract valued output port that contains a
   /// `Value<robotlocomotion::image_array_t>`.
   const OutputPort<double>& image_array_t_msg_output_port() const;
 

--- a/systems/sensors/rgbd_camera.h
+++ b/systems/sensors/rgbd_camera.h
@@ -225,9 +225,9 @@ class RgbdCamera final : public LeafSystem<double> {
   /// Returns the RigidBodyTree to which this RgbdCamera is attached.
   const RigidBodyTree<double>& tree() const { return tree_; }
 
-  /// Returns a descriptor of the vector valued input port that takes a vector
-  /// of `q, v` corresponding to the positions and velocities associated with
-  /// the RigidBodyTree.
+  /// Returns the vector valued input port that takes a vector of `q, v`
+  /// corresponding to the positions and velocities associated with the
+  /// RigidBodyTree.
   const InputPort<double>& state_input_port() const;
 
   /// Returns the abstract valued output port that contains a RGBA image of the


### PR DESCRIPTION
PR #9130 renamed InputPortDescriptor to just-plain-InputPort. The "descriptor" term had leaked into comments and variable names in numerous places. This PR fixes those, changing any mention of an input port "descriptor" to refer instead just to an input port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9142)
<!-- Reviewable:end -->
