### PR TITLE
Add names to geometries and provide facility to access geometries by name

### DIFF
--- a/examples/geometry_world/bouncing_ball_plant.cc
+++ b/examples/geometry_world/bouncing_ball_plant.cc
@@ -48,7 +48,8 @@ BouncingBallPlant<T>::BouncingBallPlant(SourceId source_id,
   ball_id_ = scene_graph->RegisterGeometry(
       source_id, ball_frame_id_,
       make_unique<GeometryInstance>(Isometry3<double>::Identity(), /*X_FG*/
-                                    make_unique<Sphere>(diameter_ / 2.0)));
+                                    make_unique<Sphere>(diameter_ / 2.0),
+                                    "ball"));
 
   // Allocate the output port now that the frame has been registered.
   geometry_pose_port_ = this->DeclareAbstractOutputPort(

--- a/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -58,7 +58,7 @@ int do_main() {
   scene_graph->RegisterAnchoredGeometry(
       global_source,
       make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
-                                    make_unique<HalfSpace>()));
+                                    make_unique<HalfSpace>(), "ground"));
   DrakeLcm lcm;
   PoseBundleToDrawMessage* converter =
       builder.template AddSystem<PoseBundleToDrawMessage>();

--- a/examples/geometry_world/solar_system.cc
+++ b/examples/geometry_world/solar_system.cc
@@ -105,16 +105,17 @@ void MakeArm(SourceId source_id, ParentId parent_id, double length,
       Eigen::AngleAxis<double>(M_PI / 2, Vector3<double>::UnitY()).matrix();
   arm_pose.translation() << length / 2, 0, 0;
   scene_graph->RegisterGeometry(
-      source_id, parent_id,
-      make_unique<GeometryInstance>(
-          arm_pose, make_unique<Cylinder>(radius, length), material));
+      source_id, parent_id, make_unique<GeometryInstance>(
+                                arm_pose, make_unique<Cylinder>(radius, length),
+                                "horz_arm", material));
 
   Isometry3<double> post_pose = Isometry3<double>::Identity();
-  post_pose.translation() << length, 0, height/2;
+  post_pose.translation() << length, 0, height / 2;
   scene_graph->RegisterGeometry(
       source_id, parent_id,
-      make_unique<GeometryInstance>(
-          post_pose, make_unique<Cylinder>(radius, height), material));
+      make_unique<GeometryInstance>(post_pose,
+                                    make_unique<Cylinder>(radius, height),
+                                    "vert_arm", material));
 }
 
 template <typename T>
@@ -133,7 +134,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   scene_graph->RegisterAnchoredGeometry(
       source_id_, make_unique<GeometryInstance>(
                       Isometry3<double>::Identity(), make_unique<Sphere>(1.f),
-                      VisualMaterial(Vector4d(1, 1, 0, 1))));
+                      "sun", VisualMaterial(Vector4d(1, 1, 0, 1))));
 
   // The fixed post on which Sun sits and around which all planets rotate.
   const double post_height = 1;
@@ -143,7 +144,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       source_id_,
       make_unique<GeometryInstance>(
           post_pose, make_unique<Cylinder>(pipe_radius, post_height),
-          post_material));
+          "post", post_material));
 
   // Allocate the "celestial bodies": two planets orbiting on different planes,
   // each with a moon.
@@ -166,7 +167,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
       Translation3<double>{kEarthOrbitRadius, 0, -kEarthBottom}};
   scene_graph->RegisterGeometry(
       source_id_, planet_id,
-      make_unique<GeometryInstance>(X_EGe, make_unique<Sphere>(0.25f),
+      make_unique<GeometryInstance>(X_EGe, make_unique<Sphere>(0.25f), "earth",
                                     VisualMaterial(Vector4d(0, 0, 1, 1))));
   // Earth's orrery arm.
   MakeArm(source_id_, planet_id, kEarthOrbitRadius, -kEarthBottom, pipe_radius,
@@ -191,7 +192,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   Isometry3<double> X_LGl{Translation3<double>{luna_position}};
   scene_graph->RegisterGeometry(
       source_id_, luna_id, make_unique<GeometryInstance>(
-                               X_LGl, make_unique<Sphere>(0.075f),
+                               X_LGl, make_unique<Sphere>(0.075f), "luna",
                                VisualMaterial(Vector4d(0.5, 0.5, 0.35, 1))));
 
   // Mars's frame M lies directly *below* the sun (to account for the orrery
@@ -210,9 +211,9 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   Isometry3<double> X_MGm{
       Translation3<double>{kMarsOrbitRadius, 0, -orrery_bottom}};
   GeometryId mars_geometry_id = scene_graph->RegisterGeometry(
-      source_id_, planet_id,
-      make_unique<GeometryInstance>(X_MGm, make_unique<Sphere>(kMarsSize),
-                                    VisualMaterial(Vector4d(0.9, 0.1, 0, 1))));
+      source_id_, planet_id, make_unique<GeometryInstance>(
+                                 X_MGm, make_unique<Sphere>(kMarsSize), "mars",
+                                 VisualMaterial(Vector4d(0.9, 0.1, 0, 1))));
 
   std::string rings_absolute_path =
       FindResourceOrThrow("drake/examples/geometry_world/planet_rings.obj");
@@ -221,7 +222,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   scene_graph->RegisterGeometry(
       source_id_, mars_geometry_id,
       make_unique<GeometryInstance>(
-          X_GmGr, make_unique<Mesh>(rings_absolute_path, kMarsSize),
+          X_GmGr, make_unique<Mesh>(rings_absolute_path, kMarsSize), "rings",
           VisualMaterial(Vector4d(0.45, 0.9, 0, 1))));
 
   // Mars's orrery arm.
@@ -244,7 +245,7 @@ void SolarSystem<T>::AllocateGeometry(SceneGraph<T>* scene_graph) {
   Isometry3<double> X_PGp{Translation3<double>{kPhobosOrbitRadius, 0, 0}};
   scene_graph->RegisterGeometry(
       source_id_, phobos_id, make_unique<GeometryInstance>(
-                                 X_PGp, make_unique<Sphere>(0.06f),
+                                 X_PGp, make_unique<Sphere>(0.06f), "phobos",
                                  VisualMaterial(Vector4d(0.65, 0.6, 0.8, 1))));
 
   DRAKE_DEMAND(static_cast<int>(body_ids_.size()) == kBodyCount);

--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -39,26 +39,26 @@ MakeBouncingBallPlant(double radius, double mass,
     // A half-space for the ground geometry.
     plant->RegisterCollisionGeometry(
         plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-        HalfSpace(), surface_friction, scene_graph);
+        HalfSpace(), "collision", surface_friction, scene_graph);
 
     // Add visual for the ground.
     plant->RegisterVisualGeometry(
         plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-        HalfSpace(), scene_graph);
+        HalfSpace(), "visual", scene_graph);
 
     // Add sphere geometry for the ball.
     plant->RegisterCollisionGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */
-        Isometry3<double>::Identity(), Sphere(radius), surface_friction,
-        scene_graph);
+        Isometry3<double>::Identity(), Sphere(radius), "collision",
+            surface_friction, scene_graph);
 
     // Add visual for the ball.
     const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
     plant->RegisterVisualGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */
-        Isometry3<double>::Identity(), Sphere(radius), orange,
+        Isometry3<double>::Identity(), Sphere(radius), "visual", orange,
         scene_graph);
   }
 

--- a/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
+++ b/examples/multibody/cylinder_with_multicontact/make_cylinder_plant.cc
@@ -32,7 +32,8 @@ void AddCylinderWithMultiContact(
   plant->RegisterVisualGeometry(
       body,
       /* Pose X_BG of the geometry frame G in the cylinder body frame B. */
-      Isometry3d::Identity(), Cylinder(radius, length), orange, scene_graph);
+      Isometry3d::Identity(), Cylinder(radius, length), "visual", orange,
+      scene_graph);
 
   // Add a bunch of little spheres to simulate "multi-contact".
   for (int i = 0; i < num_contacts; ++i) {
@@ -46,22 +47,26 @@ void AddCylinderWithMultiContact(
     plant->RegisterCollisionGeometry(
         body,
         X_BG,
-        Sphere(contact_spheres_radius), friction, scene_graph);
+        Sphere(contact_spheres_radius), "collision_top_" + std::to_string(i),
+        friction, scene_graph);
     plant->RegisterVisualGeometry(
         body,
         X_BG,
-        Sphere(contact_spheres_radius), red, scene_graph);
+        Sphere(contact_spheres_radius), "visual_top_" + std::to_string(i), red,
+        scene_graph);
 
     // Bottom spheres:
     X_BG.translation() << x, y, -length / 2;
     plant->RegisterCollisionGeometry(
         body,
         X_BG,
-        Sphere(contact_spheres_radius), friction, scene_graph);
+        Sphere(contact_spheres_radius), "collision_bottom_" + std::to_string(i),
+        friction, scene_graph);
     plant->RegisterVisualGeometry(
         body,
         X_BG,
-        Sphere(contact_spheres_radius), red, scene_graph);
+        Sphere(contact_spheres_radius), "visual_bottom_" + std::to_string(i),
+        red, scene_graph);
   }
 }
 
@@ -101,13 +106,13 @@ MakeCylinderPlant(double radius, double length, double mass,
   // A half-space for the ground geometry.
   plant->RegisterCollisionGeometry(
       plant->world_body(),
-      HalfSpace::MakePose(normal_W, point_W), HalfSpace(), surface_friction,
-      scene_graph);
+      HalfSpace::MakePose(normal_W, point_W), HalfSpace(), "collision",
+      surface_friction, scene_graph);
 
   // Add visual for the ground.
   plant->RegisterVisualGeometry(
       plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
-      HalfSpace(), scene_graph);
+      HalfSpace(), "visual", scene_graph);
 
   plant->AddForceElement<UniformGravityFieldElement>(gravity_W);
 

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include <gflags/gflags.h>
 #include "fmt/ostream.h"
@@ -162,12 +163,14 @@ void AddGripperPads(MultibodyPlant<double>* plant,
     CoulombFriction<double> friction(
         FLAGS_ring_static_friction, FLAGS_ring_static_friction);
 
-    plant->RegisterCollisionGeometry(
-        finger, X_FS, Sphere(kPadMinorRadius), friction, scene_graph);
+    plant->RegisterCollisionGeometry(finger, X_FS, Sphere(kPadMinorRadius),
+                                     "collision" + std::to_string(i), friction,
+                                     scene_graph);
 
     const geometry::VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
-    plant->RegisterVisualGeometry(
-        finger, X_FS, Sphere(kPadMinorRadius), red, scene_graph);
+    plant->RegisterVisualGeometry(finger, X_FS, Sphere(kPadMinorRadius),
+                                  "visual" + std::to_string(i), red,
+                                  scene_graph);
   }
 }
 

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -28,7 +28,9 @@ drake_cc_package_library(
         ":materials",
         ":proximity_engine",
         ":scene_graph",
+        ":scene_graph_inspector",
         ":shape_specification",
+        ":utilities",
     ],
 )
 
@@ -109,6 +111,7 @@ drake_cc_library(
         ":geometry_ids",
         ":materials",
         ":shape_specification",
+        ":utilities",
         "//common:copyable_unique_ptr",
         "//common:essential",
     ],
@@ -160,12 +163,19 @@ drake_cc_library(
     deps = [
         ":geometry_context",
         ":geometry_state",
+        ":scene_graph_inspector",
         "//common:essential",
         "//geometry/query_results:penetration_as_point_pair",
         "//geometry/query_results:signed_distance_pair",
         "//systems/framework",
         "//systems/rendering:pose_bundle",
     ],
+)
+
+drake_cc_library(
+    name = "scene_graph_inspector",
+    hdrs = ["scene_graph_inspector.h"],
+    deps = [":geometry_state"],
 )
 
 drake_cc_library(
@@ -220,6 +230,13 @@ drake_cc_library(
     deps = ["//common:essential"],
 )
 
+drake_cc_library(
+    name = "utilities",
+    srcs = ["utilities.cc"],
+    hdrs = ["utilities.h"],
+    deps = ["//common"],
+)
+
 # -----------------------------------------------------
 
 drake_cc_googletest(
@@ -249,7 +266,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "geometry_instance_test",
-    deps = [":geometry_instance"],
+    deps = [
+        ":geometry_instance",
+        "//common/test_utilities",
+    ],
 )
 
 drake_cc_googletest(
@@ -293,6 +313,8 @@ drake_cc_googletest(
 drake_cc_googletest(
     name = "query_object_test",
     deps = [
+        ":geometry_frame",
+        ":geometry_instance",
         ":scene_graph",
         "//common/test_utilities:expect_throws_message",
     ],
@@ -304,6 +326,11 @@ drake_cc_googletest(
         ":shape_specification",
         "//common/test_utilities",
     ],
+)
+
+drake_cc_googletest(
+    name = "utilities_test",
+    deps = ["utilities"],
 )
 
 drake_cc_googletest(

--- a/geometry/geometry_instance.cc
+++ b/geometry/geometry_instance.cc
@@ -1,21 +1,29 @@
 #include "drake/geometry/geometry_instance.h"
 
-#include <utility>
+#include "drake/geometry/utilities.h"
 
 namespace drake {
 namespace geometry {
 
 GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
-                                   std::unique_ptr<Shape> shape)
-    : GeometryInstance(X_PG, std::move(shape), VisualMaterial()) {}
+                                   std::unique_ptr<Shape> shape,
+                                   const std::string& name)
+    : GeometryInstance(X_PG, std::move(shape), name, VisualMaterial()) {}
 
 GeometryInstance::GeometryInstance(const Isometry3<double>& X_PG,
                                    std::unique_ptr<Shape> shape,
+                                   const std::string& name,
                                    const VisualMaterial& vis_material)
     : id_(GeometryId::get_new_id()),
       X_PG_(X_PG),
       shape_(std::move(shape)),
-      visual_material_(vis_material) {}
+      name_(detail::CanonicalizeStringName(name)),
+      visual_material_(vis_material) {
+  if (name_.empty()) {
+    throw std::logic_error("GeometryInstance given the name '" + name +
+                           "' which is an empty canonical string");
+  }
+}
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/geometry_instance.h
+++ b/geometry/geometry_instance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/common/copyable_unique_ptr.h"
@@ -16,7 +17,63 @@ namespace geometry {
 /** A geometry instance combines a geometry definition (i.e., a shape of some
  sort), a pose (relative to a parent "frame" P), material information, and an
  opaque collection of metadata. The parent frame can be a registered frame or
- another registered geometry. */
+ another registered geometry.
+
+ Every %GeometryInstance must be named. The naming convention mirrors that of
+ valid names in SDF files. Specifically, any user-specified name will have
+ all leading and trailing space and tab characters trimmed off. The trimmed name
+ will have to satisfy the following requirements:
+   - cannot be empty, and
+   - the name should be unique in the scope of its frame and role. For example,
+     two GeometryInstances can both be called "ball" as long as they are
+     affixed to different frames or if one is a collision geometry and the
+     other is a visual geometry. This requirement is not *currently* enforced
+     but will be enforced in the future.
+     <!-- TODO(SeanCurtis-TRI): When geometry roles lands, change this to
+     indicate that this is enforced. -->
+ If valid, the trimmed name will be assigned to the instance.
+
+ Names *can* have internal whitespace (e.g., "my geometry name").
+
+ @anchor canonicalized_geometry_names
+ <h3>Canonicalized names</h3>
+
+ The silent transformation of a user-defined name to canonical name mirrors that
+ of specifying geometry names in an SDF file. Consider the following SDF
+ snippet:
+
+ @code{xml}
+   ...
+   <visual name="  visual">
+     <geometry>
+       <sphere>
+         <radius>1.0</radius>
+       </sphere>
+     </geometry>
+   </visual>
+   ...
+ @endcode
+
+ The name has two leading whitespace characters. The parsing process will
+ consider this name as equivalent to "visual" and tests for uniqueness and
+ non-emptiness will be applied to that trimmed result. The following code has
+ an analogous effect:
+
+ ```
+ scene_graph->RegisterGeometry(
+    source_id, frame_id,
+    make_unique<GeometryInstance>(pose, make_unique<Sphere>(1.0), "  visual"));
+ ```
+
+ The specified name includes leading whitespace. That name will be trimmed and
+ the *result* will be stored in the %GeometryInstance (to be later validated by
+ SceneGraph as part of geometry registration). Querying the instance of its name
+ will return this *canonicalized* name.
+
+ <!-- Note to developers: The sdf requirements for naming are captured in a
+ unit test in `scene_graph_parser_detail_test.cc. See test
+ VisualGeometryNameRequirements and keep those tests and this list in sync. -->
+ */
 class GeometryInstance {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(GeometryInstance)
@@ -24,14 +81,21 @@ class GeometryInstance {
   /** Constructor with default visual material (see VisualMaterial default
    constructor for details on what that color is).
    @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
-   @param shape  The underlying shape for this geometry instance. */
-  GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape);
+   @param shape  The underlying shape for this geometry instance.
+   @param name   The name of the geometry (must satisfy the name requirements).
+   @throws std::logic_error if the canonicalized version of `name` is empty.
+   */
+  GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape,
+                   const std::string& name);
 
   /** Constructor.
    @param X_PG   The pose of this geometry (`G`) in its parent's frame (`P`).
    @param shape  The underlying shape for this geometry instance.
-   @param vis_material The visual material to apply to this geometry. */
+   @param name   The name of the geometry (must satisfy the name requirements).
+   @param vis_material The visual material to apply to this geometry.
+   @throws std::logic_error if the canonicalized version of `name` is empty.  */
   GeometryInstance(const Isometry3<double>& X_PG, std::unique_ptr<Shape> shape,
+                   const std::string& name,
                    const VisualMaterial& vis_material);
 
   /** Returns the globally unique id for this geometry specification. Every
@@ -54,6 +118,9 @@ class GeometryInstance {
 
   const VisualMaterial& visual_material() const { return visual_material_; }
 
+  /** Returns the *canonicalized* name for the instance. */
+  const std::string& name() const { return name_; }
+
  private:
   // The *globally* unique identifier for this instance. It is functionally
   // const (i.e. defined in construction) but not marked const to allow for
@@ -65,6 +132,9 @@ class GeometryInstance {
 
   // The shape associated with this instance.
   copyable_unique_ptr<Shape> shape_;
+
+  // The name of the geometry instance.
+  std::string name_;
 
   // The "rendering" material -- e.g., OpenGl contexts and the like.
   VisualMaterial visual_material_;

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -51,7 +51,7 @@ class InternalFrame {
 
   SourceId get_source_id() const { return source_id_; }
   FrameId get_id() const { return id_; }
-  const std::string &get_name() const { return name_; }
+  const std::string& get_name() const { return name_; }
   int get_frame_group() const { return frame_group_; }
   PoseIndex get_pose_index() const { return pose_index_; }
   void set_pose_index(PoseIndex index) { pose_index_ = index; }
@@ -145,7 +145,7 @@ class InternalFrame {
   // It does *not* include geometries hung on child frames.
   std::unordered_set<GeometryId> child_geometries_;
 
-  // The clique used to prevent self-collision among the geomtries affixed to
+  // The clique used to prevent self-collision among the geometries affixed to
   // this frame.
   int clique_{};
 

--- a/geometry/internal_geometry.cc
+++ b/geometry/internal_geometry.cc
@@ -8,19 +8,22 @@ InternalGeometry::InternalGeometry() : InternalGeometryBase() {}
 
 InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
                                    FrameId frame_id, GeometryId geometry_id,
+                                   const std::string& name,
                                    const Isometry3<double>& X_PG,
                                    GeometryIndex engine_index,
                                    const optional<GeometryId>& parent_id)
-    : InternalGeometry(std::move(shape), frame_id, geometry_id, X_PG,
+    : InternalGeometry(std::move(shape), frame_id, geometry_id, name, X_PG,
                        engine_index, VisualMaterial(), parent_id) {}
 
 InternalGeometry::InternalGeometry(std::unique_ptr<Shape> shape,
                                    FrameId frame_id, GeometryId geometry_id,
+                                   const std::string& name,
                                    const Isometry3<double>& X_PG,
                                    GeometryIndex engine_index,
                                    const VisualMaterial& vis_material,
                                    const optional<GeometryId>& parent_id)
-    : InternalGeometryBase(std::move(shape), geometry_id, X_PG, vis_material),
+    : InternalGeometryBase(std::move(shape), geometry_id, name, X_PG,
+                           vis_material),
       frame_id_(frame_id),
       engine_index_(engine_index),
       parent_id_(parent_id) {}
@@ -29,15 +32,17 @@ InternalAnchoredGeometry::InternalAnchoredGeometry() : InternalGeometryBase() {}
 
 InternalAnchoredGeometry::InternalAnchoredGeometry(
     std::unique_ptr<Shape> shape, GeometryId geometry_id,
-    const Isometry3<double>& X_WG, AnchoredGeometryIndex engine_index)
-    : InternalAnchoredGeometry(std::move(shape), geometry_id, X_WG,
+    const std::string& name, const Isometry3<double> X_WG,
+    AnchoredGeometryIndex engine_index)
+    : InternalAnchoredGeometry(std::move(shape), geometry_id, name, X_WG,
                                engine_index, VisualMaterial()) {}
 
 InternalAnchoredGeometry::InternalAnchoredGeometry(
     std::unique_ptr<Shape> shape, GeometryId geometry_id,
-    const Isometry3<double>& X_WG, AnchoredGeometryIndex engine_index,
-    const VisualMaterial& vis_material)
-    : InternalGeometryBase(std::move(shape), geometry_id, X_WG, vis_material),
+    const std::string& name, const Isometry3<double> X_WG,
+    AnchoredGeometryIndex engine_index, const VisualMaterial& vis_material)
+    : InternalGeometryBase(std::move(shape), geometry_id, name, X_WG,
+                           vis_material),
       engine_index_(engine_index) {}
 
 }  // namespace internal

--- a/geometry/internal_geometry.h
+++ b/geometry/internal_geometry.h
@@ -37,23 +37,26 @@ class InternalGeometryBase {
   /** Default material, full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_PG          The pose of the geometry G in the parent frame P. */
   InternalGeometryBase(std::unique_ptr<Shape> shape, GeometryId geometry_id,
-                       const Isometry3<double>& X_PG)
-      : InternalGeometryBase(std::move(shape), geometry_id, X_PG,
+                       const std::string& name, const Isometry3<double>& X_PG)
+      : InternalGeometryBase(std::move(shape), geometry_id, name, X_PG,
                              VisualMaterial()) {}
 
   /** Full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_PG          The pose of the geometry G in the parent frame P.
    @param engine_index  The position in the geometry engine of this geometry.
    @param vis_material  The visual material for this geometry. */
   InternalGeometryBase(std::unique_ptr<Shape> shape, GeometryId geometry_id,
-                       const Isometry3<double>& X_PG,
+                       const std::string& name, const Isometry3<double>& X_PG,
                        const VisualMaterial& vis_material)
       : shape_spec_(std::move(shape)),
         id_(geometry_id),
+        name_(name),
         X_PG_(X_PG),
         visual_material_(vis_material) {}
 
@@ -73,6 +76,8 @@ class InternalGeometryBase {
 
   GeometryId get_id() const { return id_; }
 
+  const std::string& get_name() const { return name_; }
+
   const Isometry3<double>& get_pose_in_parent() const { return X_PG_; }
 
   const VisualMaterial& get_visual_material() const { return visual_material_; }
@@ -83,6 +88,10 @@ class InternalGeometryBase {
 
   // The identifier for this frame.
   GeometryId id_;
+
+  // The name of the geometry. Must be unique among geometries attached to the
+  // same frame.
+  std::string name_;
 
   // The pose of this geometry in the parent frame. The parent may be a frame or
   // another registered geometry.
@@ -109,12 +118,13 @@ class InternalGeometry : public InternalGeometryBase {
    @param shape         The shape specification for this instance.
    @param frame_id      The identifier of the frame this belongs to.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_PG          The pose of the geometry G in the parent frame P. The
                         parent may be a frame, or another registered geometry.
    @param engine_index  The position in the geometry engine of this geometry.
    @param parent_id     The optional id of the parent geometry. */
   InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
-                   GeometryId geometry_id,
+                   GeometryId geometry_id, const std::string& name,
                    const Isometry3<double>& X_PG, GeometryIndex engine_index,
                    const optional<GeometryId>& parent_id = {});
 
@@ -122,13 +132,14 @@ class InternalGeometry : public InternalGeometryBase {
    @param shape         The shape specification for this instance.
    @param frame_id      The identifier of the frame this belongs to.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_PG          The pose of the geometry G in the parent frame P. The
                         parent may be a frame, or another registered geometry.
    @param engine_index  The position in the geometry engine of this geometry.
    @param vis_material  The visual material for this geometry.
    @param parent_id     The optional id of the parent geometry. */
   InternalGeometry(std::unique_ptr<Shape> shape, FrameId frame_id,
-                   GeometryId geometry_id,
+                   GeometryId geometry_id, const std::string& name,
                    const Isometry3<double>& X_PG, GeometryIndex engine_index,
                    const VisualMaterial& vis_material,
                    const optional<GeometryId>& parent_id = {});
@@ -208,20 +219,24 @@ class InternalAnchoredGeometry : public InternalGeometryBase {
   /** Default material, full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_WG          The pose of the geometry G in the world frame W.
    @param engine_index  The position in the geometry engine of this geometry. */
   InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
-                           const Isometry3<double>& X_WG,
+                           const std::string& name,
+                           const Isometry3<double> X_WG,
                            AnchoredGeometryIndex engine_index);
 
   /** Full constructor.
    @param shape         The shape specification for this instance.
    @param geometry_id   The identifier for _this_ geometry.
+   @param name          The name of the geometry.
    @param X_WG          The pose of the geometry G in the world frame W.
    @param engine_index  The position in the geometry engine of this geometry.
    @param vis_material  The visual material for this geometry. */
   InternalAnchoredGeometry(std::unique_ptr<Shape> shape, GeometryId geometry_id,
-                           const Isometry3<double>& X_WG,
+                           const std::string& name,
+                           const Isometry3<double> X_WG,
                            AnchoredGeometryIndex engine_index,
                            const VisualMaterial& vis_material);
 

--- a/geometry/query_object.cc
+++ b/geometry/query_object.cc
@@ -19,32 +19,13 @@ QueryObject<T>& QueryObject<T>::operator=(const QueryObject<T>&) {
 }
 
 template <typename T>
-const std::string& QueryObject<T>::GetSourceName(SourceId id) const {
-  ThrowIfDefault();
-  return context_->get_geometry_state().get_source_name(id);
-}
-
-template <typename T>
-FrameId QueryObject<T>::GetFrameId(GeometryId geometry_id) const {
-  ThrowIfDefault();
-  return context_->get_geometry_state().GetFrameId(geometry_id);
-}
-
-template <typename T>
-const VisualMaterial* QueryObject<T>::GetVisualMaterial(
-    GeometryId geometry_id) const {
-  ThrowIfDefault();
-  return context_->get_geometry_state().get_visual_material(geometry_id);
-}
-
-template <typename T>
 std::vector<PenetrationAsPointPair<double>>
 QueryObject<T>::ComputePointPairPenetration() const {
   ThrowIfDefault();
 
   // TODO(SeanCurtis-TRI): Modify this when the cache system is in place.
   scene_graph_->FullPoseUpdate(*context_);
-  const GeometryState<T>& state = context_->get_geometry_state();
+  const GeometryState<T>& state = geometry_state();
   return state.ComputePointPairPenetration();
 }
 
@@ -57,6 +38,14 @@ QueryObject<T>::ComputeSignedDistancePairwiseClosestPoints() const {
   scene_graph_->FullPoseUpdate(*context_);
   const GeometryState<T>& state = context_->get_geometry_state();
   return state.ComputeSignedDistancePairwiseClosestPoints();
+}
+
+template <typename T>
+const GeometryState<T>& QueryObject<T>::geometry_state() const {
+  // TODO(SeanCurtis-TRI): Handle the "baked" query object case.
+  DRAKE_DEMAND(scene_graph_ != nullptr);
+  DRAKE_DEMAND(context_ != nullptr);
+  return context_->get_geometry_state();
 }
 
 }  // namespace geometry

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -9,6 +9,7 @@
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/query_object.h"
 #include "drake/geometry/query_results/penetration_as_point_pair.h"
+#include "drake/geometry/scene_graph_inspector.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/rendering/pose_bundle.h"
@@ -315,6 +316,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    previously registered frame F (indicated by `frame_id`). The pose of the
    geometry is defined in a fixed pose relative to F (i.e., `X_FG`).
    Returns the corresponding unique geometry id.
+
    @param source_id   The id for the source registering the geometry.
    @param frame_id    The id for the frame F to hang the geometry on.
    @param geometry    The geometry G to affix to frame F.
@@ -323,7 +325,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
                              source,
                              2. the `frame_id` doesn't belong to the source,
                              3. the `geometry` is equal to `nullptr`,
-                             4. a context has been allocated. */
+                             4. a context has been allocated, or
+                             5. the geometry's name doesn't satisfy the
+                             requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, FrameId frame_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -340,8 +344,10 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @throws std::logic_error 1. the `source_id` does _not_ map to a registered
                             source,
                             2. the `geometry_id` doesn't belong to the source,
-                            3. the `geometry` is equal to `nullptr`, or
-                            4. a context has been allocated. */
+                            3. the `geometry` is equal to `nullptr`,
+                            4. a context has been allocated, or
+                            5. the geometry's name doesn't satisfy the
+                            requirements outlined in GeometryInstance.  */
   GeometryId RegisterGeometry(SourceId source_id, GeometryId geometry_id,
                               std::unique_ptr<GeometryInstance> geometry);
 
@@ -351,12 +357,24 @@ class SceneGraph final : public systems::LeafSystem<T> {
    @param source_id     The id for the source registering the frame.
    @param geometry      The anchored geometry G to add to the world.
    @returns The index for the added geometry.
-   @throws std::logic_error  If the `source_id` does _not_ map to a registered
-                             source or a context has been allocated. */
+   @throws std::logic_error  1. the `source_id` does _not_ map to a registered
+                             source,
+                             2. a context has been allocated, or
+                             3. the geometry's name doesn't satisfy the
+                             requirements outlined in GeometryInstance.  */
   GeometryId RegisterAnchoredGeometry(
       SourceId source_id, std::unique_ptr<GeometryInstance> geometry);
 
   //@}
+
+  /** Reports the identifier for the world frame. */
+  static FrameId world_frame_id() {
+    return internal::InternalFrame::get_world_frame_id();
+  }
+
+  /** Returns an inspector on the system's *model* scene graph data.
+   @throw std::logic_error If a context has been allocated.*/
+  const SceneGraphInspector<T>& model_inspector() const;
 
   /** @name         Collision filtering
    @anchor scene_graph_collision_filtering
@@ -487,12 +505,9 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   // A raw pointer to the default geometry state (which serves as the model for
   // allocating contexts for this system). The instance is owned by
-  // model_abstract_states_. This pointer will only be non-null between
-  // construction and context allocation. It serves a key role in enforcing the
-  // property that source ids can only be added prior to context allocation.
-  // This is mutable so that it can be cleared in the const method
-  // AllocateContext().
+  // model_abstract_states_.
   GeometryState<T>* initial_state_{};
+  SceneGraphInspector<T> model_inspector_;
 
   // TODO(SeanCurtis-TRI): Get rid of this.
   mutable bool context_has_been_allocated_{false};

--- a/geometry/scene_graph_inspector.h
+++ b/geometry/scene_graph_inspector.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <string>
+
+#include "drake/geometry/geometry_state.h"
+
+namespace drake {
+namespace geometry {
+
+template <typename T>
+class SceneGraph;
+template <typename T>
+class QueryObject;
+
+/** The %SceneGraphInspector serves as a mechanism to query the topological
+ structure of a SceneGraph instance. The topological structure consists of all
+ of the SceneGraph data that does *not* depend on input pose data. Including,
+ but not limited to:
+
+   - names of frames and geometries
+   - hierarchies (parents of geometries, parents of frames, etc.)
+   - geometry parameters (e.g., contact, rendering, visualization)
+   - fixed poses of geometries relative to frames
+
+ In contrast, the following pieces of data *do* depend on input pose data and
+ *cannot* be performed with the %SceneGraphInspector (see the QueryObject
+ instead):
+
+   - world pose of frames or geometry
+   - collision queries
+   - proximity queries
+
+ A %SceneGraphInspector cannot be instantiated explicitly. Nor can it be copied
+ or moved. A *reference* to a %SceneGraphInspector instance can be acquired from
+   - a SceneGraph instance (to inspect the state of the system's _model_), or
+   - a QueryObject instance (to inspect the state of the scene graph data stored
+     in the context).
+
+ The reference should not be persisted (and, as previously indicated, cannot
+ be copied). %SceneGraphInspector instances are cheap; they can be created,
+ queried, and thrown out. If there is any doubt about the valid lifespan of
+ a %SceneGraphInspector, throw out the old instance and request a new instance.
+
+ @tparam T The scalar of the associated SceneGraph instance. The template
+ parameter is provided for the sake of compatibility, although no queries (or
+ their results) depend on the scalar.  */
+template <typename T>
+class SceneGraphInspector {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGraphInspector)
+
+  //----------------------------------------------------------------------------
+  /** @name                State queries */
+  //@{
+
+  // NOTE: An inspector should never be released into the wild without having
+  // set the state variable. Every query should start by demanding that state_
+  // is defined.
+
+  /** Reports the name for the given source id.
+   @throws  std::logic_error if the identifier is invalid.  */
+  const std::string& GetSourceName(SourceId id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_source_name(id);
+  }
+
+  /** Reports the id of the frame to which the given geometry id is registered.
+   @throws  std::logic_error if the geometry id is invalid.  */
+  FrameId GetFrameId(GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetFrameId(geometry_id);
+  }
+
+  /** Returns the visual material of the geometry indicated by the given
+   `geometry_id` (if it exists).
+   @throws  std::logic_error if the geometry id is invalid.  */
+  const VisualMaterial* GetVisualMaterial(GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_visual_material(geometry_id);
+  }
+
+  /** Reports the name of the frame indicated by the given id.
+   @throws std::logic_error if `frame_id` doesn't refer to a valid frame.  */
+  const std::string& GetName(FrameId frame_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_frame_name(frame_id);
+  }
+
+  /** Reports the name of the geometry indicated by the given id.
+   @throws std::logic_error if `geometry_id` doesn't refer to a valid geometry.
+   */
+  const std::string& GetName(GeometryId geometry_id) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->get_name(geometry_id);
+  }
+
+  /** Reports the id of the geometry with the given name, attached to the
+   indicated frame.
+   @param frame_id  The frame whose geometry is being queried.
+   @param name      The name of the geometry to query for. The name will be
+                    canonicalized prior to lookup (see
+                    @ref canonicalized_geometry_names "GeometryInstance" for
+                    details).
+   @return The id of the queried geometry.
+   @throws std::logic_error if no such geometry exists, multiple geometries have
+                            that name, or if the frame doesn't exist. */
+  // TODO(SeanCurtis-TRI): Extend to include role.
+  GeometryId GetGeometryIdByName(FrameId frame_id,
+                                 const std::string& name) const {
+    DRAKE_DEMAND(state_ != nullptr);
+    return state_->GetGeometryFromName(frame_id, name);
+  }
+
+  //@}
+
+ private:
+  // Only SceneGraph and QueryObject instances can construct
+  // SceneGraphInspector instances.
+  friend class SceneGraph<T>;
+  friend class QueryObject<T>;
+
+  // Testing utility.
+  friend class SceneGraphInspectorTester;
+
+  // Simple default constructor to be used by SceneGraph and QueryObject.
+  SceneGraphInspector() = default;
+
+  // Sets the scene graph data to inspect -- the inspector does *not* own the
+  // data and expects that the lifespan of the provided data is longer than
+  // the inspector.
+  void set(const GeometryState<T>* state) { state_ = state; }
+
+  const GeometryState<T>* state_{nullptr};
+};
+
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/test/geometry_instance_test.cc
+++ b/geometry/test/geometry_instance_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "drake/common/copyable_unique_ptr.h"
+#include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/shape_specification.h"
 
 namespace drake {
@@ -20,22 +21,52 @@ GTEST_TEST(GeometryInstanceTest, IsCopyable) {
   // have a runtime check available but this will fail to compile if the class
   // is not copyable.
   copyable_unique_ptr<GeometryInstance> geo(make_unique<GeometryInstance>
-      (Isometry3<double>(), make_unique<Sphere>(1)));
+      (Isometry3<double>(), make_unique<Sphere>(1), "sphere"));
   EXPECT_TRUE(geo->id().is_valid());
 }
 
 GTEST_TEST(GeometryInstanceTest, IdCopies) {
   Isometry3<double> pose = Isometry3<double>::Identity();
   auto shape = make_unique<Sphere>(1.0);
-  GeometryInstance geometry_a{pose, move(shape)};
+  GeometryInstance geometry_a{pose, move(shape), "geometry_a"};
   GeometryInstance geometry_b(geometry_a);
   EXPECT_EQ(geometry_a.id(), geometry_b.id());
+  EXPECT_EQ(geometry_a.name(), geometry_b.name());
 
   shape = make_unique<Sphere>(2.0);
-  GeometryInstance geometry_c{pose, move(shape)};
+  GeometryInstance geometry_c{pose, move(shape), "geometry_c"};
   EXPECT_NE(geometry_a.id(), geometry_c.id());
+  EXPECT_NE(geometry_a.name(), geometry_c.name());
   geometry_c = geometry_a;
   EXPECT_EQ(geometry_a.id(), geometry_c.id());
+  EXPECT_EQ(geometry_a.name(), geometry_c.name());
+}
+
+// Confirms that the name stored in GeometryInstance is the canonicalized
+// version of the given name. This doesn't test the definition of
+// canonicalization merely the fact of the act.
+GTEST_TEST(GeometryInstanceTest, CanonicalName) {
+  Isometry3<double> pose = Isometry3<double>::Identity();
+
+  auto make_instance = [&pose](const std::string& name) {
+    auto shape = make_unique<Sphere>(1.0);
+    return GeometryInstance{pose, move(shape), name};
+  };
+
+  const std::string canonical = "name";
+
+  GeometryInstance already_canonical = make_instance(canonical);
+  EXPECT_EQ(already_canonical.name(), canonical);
+
+  GeometryInstance leading = make_instance("  " + canonical);
+  EXPECT_EQ(leading.name(), canonical);
+
+  GeometryInstance trailing = make_instance(canonical + "  ");
+  EXPECT_EQ(trailing.name(), canonical);
+
+  DRAKE_EXPECT_THROWS_MESSAGE(make_instance(" "), std::logic_error,
+                              "GeometryInstance given the name '.*' which is "
+                              "an empty canonical string");
 }
 
 }  // namespace

--- a/geometry/test/geometry_visualization_test.cc
+++ b/geometry/test/geometry_visualization_test.cc
@@ -46,7 +46,7 @@ GTEST_TEST(GeometryVisualization, SimpleScene) {
   scene_graph.RegisterGeometry(
       source_id, frame_id,
       make_unique<GeometryInstance>(Isometry3d::Identity(),
-                                    make_unique<Sphere>(radius),
+                                    make_unique<Sphere>(radius), "sphere",
                                     VisualMaterial(Vector4d{r, g, b, a})));
 
   unique_ptr<Context<double>> context = scene_graph.AllocateContext();

--- a/geometry/test/query_object_test.cc
+++ b/geometry/test/query_object_test.cc
@@ -6,6 +6,8 @@
 
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_context.h"
+#include "drake/geometry/geometry_frame.h"
+#include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/scene_graph.h"
 
 namespace drake {
@@ -25,8 +27,7 @@ class QueryObjectTester {
   static std::unique_ptr<QueryObject<T>> MakeQueryObject(
       const GeometryContext<T>* context, const SceneGraph<T>* scene_graph) {
     auto q = std::unique_ptr<QueryObject<T>>(new QueryObject<T>());
-    q->scene_graph_ = scene_graph;
-    q->context_ = context;
+    q->set(context, scene_graph);
     return q;
   }
 
@@ -50,6 +51,7 @@ class QueryObjectTester {
 
 namespace {
 
+using std::make_unique;
 using std::unique_ptr;
 using systems::Context;
 
@@ -86,6 +88,11 @@ TEST_F(QueryObjectTest, CopySemantics) {
   QOT::expect_default(from_live);
 }
 
+// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
+// the class (SceneGraph) that actually *performs* those queries. The
+// correctness of those queries is handled in geometry_state_test.cc. The
+// wrapper merely confirms that the state is correct and that wrapper
+// functionality is tested in DefaultQueryThrows.
 TEST_F(QueryObjectTest, DefaultQueryThrows) {
   unique_ptr<QueryObject<double>> default_object =
       QOT::MakeQueryObject<double>();
@@ -98,18 +105,36 @@ TEST_F(QueryObjectTest, DefaultQueryThrows) {
   EXPECT_DEFAULT_ERROR(QOT::ThrowIfDefault(*default_object));
 
   // Enumerate *all* queries to confirm they throw the proper exception.
-  EXPECT_DEFAULT_ERROR(default_object->GetFrameId(GeometryId::get_new_id()));
-  EXPECT_DEFAULT_ERROR(default_object->GetSourceName(SourceId::get_new_id()));
   EXPECT_DEFAULT_ERROR(default_object->ComputePointPairPenetration());
+  EXPECT_DEFAULT_ERROR(
+      default_object->ComputeSignedDistancePairwiseClosestPoints());
 
 #undef EXPECT_DEFAULT_ERROR
 }
 
-// NOTE: This doesn't test the specific queries; GeometryQuery simply wraps
-// the class (SceneGraph) that actually *performs* those queries. The
-// correctness of those queries is handled in geometry_state_test.cc. The
-// wrapper merely confirms that the state is correct and that wrapper
-// functionality is tested in DefaultQueryThrows.
+// Confirms the inspector returned by the QueryObject is "correct" (in that
+// it accesses the correct state).
+GTEST_TEST(QueryObjectInspectTest, CreateValidInspector) {
+  SceneGraph<double> scene_graph;
+  SourceId source_id = scene_graph.RegisterSource("source");
+  auto identity = Isometry3<double>::Identity();
+  FrameId frame_id =
+      scene_graph.RegisterFrame(source_id, GeometryFrame("frame", identity));
+  GeometryId geometry_id = scene_graph.RegisterGeometry(
+      source_id, frame_id, make_unique<GeometryInstance>(
+                               identity, make_unique<Sphere>(1.0), "sphere"));
+  unique_ptr<Context<double>> context = scene_graph.AllocateContext();
+  auto geo_context = dynamic_cast<GeometryContext<double>*>(context.get());
+  unique_ptr<QueryObject<double>> query_object =
+      QueryObjectTester::MakeQueryObject<double>(geo_context, &scene_graph);
+
+  const SceneGraphInspector<double>& inspector = query_object->inspector();
+
+  // Perform a single query to confirm that the inspector has access to the
+  // state uniquely populated above (guaranteed via the uniqueness of frame and
+  // geometry identifiers).
+  EXPECT_EQ(inspector.GetFrameId(geometry_id), frame_id);
+}
 
 }  // namespace
 }  // namespace geometry

--- a/geometry/test/utilities_test.cc
+++ b/geometry/test/utilities_test.cc
@@ -1,0 +1,58 @@
+#include "drake/geometry/utilities.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace detail {
+namespace {
+
+GTEST_TEST(GeometryUtilities, CanonicalizeGeometryName) {
+  // Confirms that the canonical version of the given name is unchanged.
+  auto expect_unchanged = [](const std::string& name) {
+    const std::string canonicalized = CanonicalizeStringName(name);
+    EXPECT_EQ(name, canonicalized)
+        << "Input string '" << name << "' different from the "
+        << "canonicalized name '" << canonicalized << "'";
+  };
+
+  // Test various names -- including names with internal whitespace.
+  for (const std::string& canonical :
+       {"name", "with space", "with\ttab", "with\nnewline",
+        "with\vvertical tab", "with\fformfeed"}) {
+    // Confirms that the given name canonicalizes to the given canonical name.
+    auto expect_canonical = [&canonical](const std::string& name) {
+      const std::string canonicalized = CanonicalizeStringName(name);
+      EXPECT_EQ(canonical, canonicalized)
+          << "Input string '" << name << "' canonicalized to '" << canonicalized
+          << "' instead of the expected '" << canonical << "'";
+    };
+
+    // The canonical name should always come back as itself.
+    expect_unchanged(canonical);
+
+    // Characters that *do* get trimmed off.
+    for (const std::string& whitespace : {" ", "\t"}) {
+      expect_canonical(whitespace + canonical);
+      expect_canonical(whitespace + canonical + whitespace);
+      expect_canonical(canonical + whitespace);
+    }
+
+    // Characters that do *not* get trimmed off.
+    // These should be considered a defect in the SDF trimming logic. An issue
+    // has been submitted and these tests should be updated when the sdformat
+    // trimming logic has been updated.
+    for (const std::string& whitespace : {"\n", "\v", "\f"}) {
+      expect_unchanged(whitespace + canonical + whitespace);
+      expect_unchanged(whitespace + canonical);
+      expect_unchanged(canonical + whitespace);
+    }
+  }
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/utilities.cc
+++ b/geometry/utilities.cc
@@ -1,0 +1,34 @@
+#include "drake/geometry/utilities.h"
+
+#include <regex>
+
+#include "drake/common/drake_assert.h"
+
+namespace drake {
+namespace geometry {
+namespace detail {
+
+std::string CanonicalizeStringName(const std::string& name) {
+  // The definition of "canonical" is based on SDF and the functionality in
+  // sdformat. Essentially, it trims off leading and trailing white space (as
+  // shown here):
+  // https://bitbucket.org/osrf/sdformat/src/2fa714812545abeb5ae05a8aebf0047aeb35d6a4/src/Types.cc?at=default&fileviewer=file-view-default#Types.cc-51
+  // An issue has been filed to extend it to all whitespace characters:
+  // https://bitbucket.org/osrf/sdformat/issues/194/string-trimming-only-considers-space-and
+  // Keep this in sync in case it changes.
+
+  // NOTE: The regular expression "." operator encompasses all characters
+  // *except* new line characters. A "canonical" string implicitly allows
+  // arbitrary internal whitespace (including newlines) so this trimming must do
+  // so as well. To include them in the accepted set, we simply define the "not
+  // empty" set of characters which *does* include  the newlines.
+  std::regex trim_regex("[ \\t]*([^]*?)[ \\t]*");
+  std::smatch matches;
+  std::regex_match(name, matches, trim_regex);
+  DRAKE_DEMAND(matches.size() == 2);
+  return matches[1].str();
+}
+
+}  // namespace detail
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/utilities.h
+++ b/geometry/utilities.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace drake {
+namespace geometry {
+namespace detail {
+
+/** Canonicalizes the given geometry *candidate* name. A canonicalized name may
+ still not be valid (as it may duplicate a previously used name). See
+ @ref canonicalized_geometry_names "documentation in GeometryInstance" for
+ details. */
+std::string CanonicalizeStringName(const std::string& name);
+
+}  // namespace detail
+}  // namespace geometry
+}  // namespace drake

--- a/multibody/benchmarks/acrobot/make_acrobot_plant.cc
+++ b/multibody/benchmarks/acrobot/make_acrobot_plant.cc
@@ -60,20 +60,22 @@ MakeAcrobotPlant(const AcrobotParameters& params, bool finalize,
     // Pose of the geometry for link 1 in the link's frame.
     const Isometry3d X_L1G1{
         Translation3d(-params.l1() / 2.0 * Vector3d::UnitZ())};
-    plant->RegisterVisualGeometry(
-        link1, X_L1G1, Cylinder(params.r1(), params.l1()), scene_graph);
+    plant->RegisterVisualGeometry(link1, X_L1G1,
+                                  Cylinder(params.r1(), params.l1()), "visual",
+                                  scene_graph);
 
     // Pose of the geometry for link 2 in the link's frame.
     const Isometry3d X_L2G2{
         Translation3d(-params.l2() / 2.0 * Vector3d::UnitZ())};
-    plant->RegisterVisualGeometry(
-        link2, X_L2G2, Cylinder(params.r2(), params.l2()), scene_graph);
+    plant->RegisterVisualGeometry(link2, X_L2G2,
+                                  Cylinder(params.r2(), params.l2()), "visual",
+                                  scene_graph);
 
     // Register some (anchored) geometry to the world.
     plant->RegisterVisualGeometry(
         plant->world_body(), Isometry3d::Identity(), /* X_WG */
         Sphere(params.l1() / 8.0), /* Arbitrary radius to decorate the model. */
-        scene_graph);
+        "visual", scene_graph);
   }
 
   plant->AddJoint<RevoluteJoint>(

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -46,28 +46,28 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
   const Vector3<double> point_W = -normal_W * radius;
 
   // A half-space for the inclined plane geometry.
-  plant->RegisterCollisionGeometry(plant->world_body(),
-                                   HalfSpace::MakePose(normal_W, point_W),
-                                   HalfSpace(), surface_friction, scene_graph);
+  plant->RegisterCollisionGeometry(
+      plant->world_body(), HalfSpace::MakePose(normal_W, point_W), HalfSpace(),
+      "collision", surface_friction, scene_graph);
 
   // Visual for the ground.
   plant->RegisterVisualGeometry(plant->world_body(),
-                                   HalfSpace::MakePose(normal_W, point_W),
-                                   HalfSpace(), scene_graph);
+                                HalfSpace::MakePose(normal_W, point_W),
+                                HalfSpace(), "visual", scene_graph);
 
   // Add sphere geometry for the ball.
   plant->RegisterCollisionGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
-      Isometry3<double>::Identity(), Sphere(radius), surface_friction,
-      scene_graph);
+      Isometry3<double>::Identity(), Sphere(radius), "collision",
+      surface_friction, scene_graph);
 
   // Visual for the ball.
   const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
-      Isometry3<double>::Identity(), Sphere(radius), orange,
+      Isometry3<double>::Identity(), Sphere(radius), "visual1", orange,
       scene_graph);
 
   // Adds little spherical spokes highlight the sphere's rotation.
@@ -76,22 +76,22 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(0, 0, radius)), Sphere(radius / 5),
-      red, scene_graph);
+      "visual2", red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(0, 0, -radius)),
-      Sphere(radius / 5), red, scene_graph);
+      Sphere(radius / 5), "visual3", red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(radius, 0, 0)), Sphere(radius / 5),
-      red, scene_graph);
+      "visual4", red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(-radius, 0, 0)),
-      Sphere(radius / 5), red, scene_graph);
+      Sphere(radius / 5), "visual5", red, scene_graph);
 
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(

--- a/multibody/benchmarks/pendulum/make_pendulum_plant.cc
+++ b/multibody/benchmarks/pendulum/make_pendulum_plant.cc
@@ -52,15 +52,16 @@ MakePendulumPlant(const PendulumParameters& params,
     // Pose of the sphere used to visualize the point mass in the body frame B.
     const Isometry3d X_BGs{
         Translation3d(-params.l() * Vector3d::UnitZ())};
-    plant->RegisterVisualGeometry(
-        point_mass, X_BGs, Sphere(params.point_mass_radius()), scene_graph);
+    plant->RegisterVisualGeometry(point_mass, X_BGs,
+                                  Sphere(params.point_mass_radius()),
+                                  params.body_name(), scene_graph);
 
     // Pose of the cylinder used to visualize the massless rod in frame B.
     const Isometry3d X_BGc{
         Translation3d(-params.l() / 2.0 * Vector3d::UnitZ())};
     plant->RegisterVisualGeometry(
         point_mass, X_BGc, Cylinder(params.massless_rod_radius(), params.l()),
-        scene_graph);
+        "arm", scene_graph);
   }
 
   const RevoluteJoint<double>& pin = plant->AddJoint<RevoluteJoint>(

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -737,6 +737,9 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @param[in] shape
   ///   The geometry::Shape used for visualization. E.g.: geometry::Sphere,
   ///   geometry::Cylinder, etc.
+  /// @param[in] name
+  ///   The name for the geometry. It must satsify the requirements defined in
+  ///   drake::geometry::GeometryInstance.
   /// @param[in] material
   ///   The visual material to assign to the geometry.
   /// @param[out] scene_graph
@@ -749,14 +752,16 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @returns the id for the registered geometry.
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
-      const geometry::Shape& shape, const geometry::VisualMaterial& material,
+      const geometry::Shape& shape, const std::string& name,
+      const geometry::VisualMaterial& material,
       geometry::SceneGraph<T>* scene_graph);
 
   /// Overload for visual geometry registration; it implicitly assigns the
   /// default material.
   geometry::GeometryId RegisterVisualGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
-      const geometry::Shape& shape, geometry::SceneGraph<T>* scene_graph);
+      const geometry::Shape& shape, const std::string& name,
+      geometry::SceneGraph<T>* scene_graph);
 
   /// Returns an array of GeometryId's identifying the different visual
   /// geometries for `body` previously registered with a SceneGraph.
@@ -800,7 +805,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// same instance with which RegisterAsSourceForSceneGraph() was called.
   geometry::GeometryId RegisterCollisionGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
-      const geometry::Shape& shape,
+      const geometry::Shape& shape, const std::string& name,
       const CoulombFriction<double>& coulomb_friction,
       geometry::SceneGraph<T>* scene_graph);
 
@@ -1371,6 +1376,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   geometry::GeometryId RegisterGeometry(
       const Body<T>& body, const Isometry3<double>& X_BG,
       const geometry::Shape& shape,
+      const std::string& name,
       const optional<geometry::VisualMaterial>& material,
       geometry::SceneGraph<T>* scene_graph);
 
@@ -1383,6 +1389,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   //    passed to RegisterAsSourceForSceneGraph().
   geometry::GeometryId RegisterAnchoredGeometry(
       const Isometry3<double>& X_WG, const geometry::Shape& shape,
+      const std::string& name,
       const optional<geometry::VisualMaterial>& material,
       geometry::SceneGraph<T>* scene_graph);
 

--- a/multibody/multibody_tree/multibody_plant/test/box.sdf
+++ b/multibody/multibody_tree/multibody_plant/test/box.sdf
@@ -27,7 +27,7 @@
           <izz>1.0</izz>
         </inertia>
       </inertial>
-      <visual name='ground_plane'>
+      <visual name='visual'>
         <geometry>
           <plane>
             <normal>0.0 0.0 1.0</normal>
@@ -35,7 +35,7 @@
         </geometry>
       </visual>
 
-      <collision name='ground_plane'>
+      <collision name='collision'>
         <geometry>
           <plane>
             <normal>0.0 0.0 1.0</normal>

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -391,7 +391,8 @@ ModelInstanceIndex AddModelFromSdfFile(
         if (geometry_instance) {
           plant->RegisterVisualGeometry(
               body, geometry_instance->pose(), geometry_instance->shape(),
-              geometry_instance->visual_material(), scene_graph);
+              geometry_instance->name(), geometry_instance->visual_material(),
+              scene_graph);
         }
       }
 
@@ -407,8 +408,9 @@ ModelInstanceIndex AddModelFromSdfFile(
               detail::MakeShapeFromSdfGeometry(sdf_geometry);
           const CoulombFriction<double> coulomb_friction =
               detail::MakeCoulombFrictionFromSdfCollisionOde(sdf_collision);
-          plant->RegisterCollisionGeometry(
-              body, X_LG, *shape, coulomb_friction, scene_graph);
+          plant->RegisterCollisionGeometry(body, X_LG, *shape,
+                                           sdf_collision.Name(),
+                                           coulomb_friction, scene_graph);
         }
       }
     }

--- a/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
+++ b/multibody/multibody_tree/parsing/scene_graph_parser_detail.cc
@@ -214,8 +214,9 @@ std::unique_ptr<GeometryInstance> MakeGeometryInstanceFromSdfVisual(
   }
 
   const VisualMaterial material = MakeVisualMaterialFromSdfVisual(sdf_visual);
-  return make_unique<GeometryInstance>(
-      X_LC, MakeShapeFromSdfGeometry(sdf_geometry), material);
+  return make_unique<GeometryInstance>(X_LC,
+                                       MakeShapeFromSdfGeometry(sdf_geometry),
+                                       sdf_visual.Name(), material);
 }
 
 VisualMaterial MakeVisualMaterialFromSdfVisual(const sdf::Visual& sdf_visual) {

--- a/multibody/multibody_tree/parsing/test/scene_graph_parser_detail_test.cc
+++ b/multibody/multibody_tree/parsing/test/scene_graph_parser_detail_test.cc
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <gtest/gtest.h>
+#include "fmt/ostream.h"
 
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
@@ -253,6 +254,113 @@ GTEST_TEST(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
                               kTolerance, MatrixCompareType::relative));
   EXPECT_TRUE(CompareMatrices(X_LC.translation(), p_LCo_expected,
                               kTolerance, MatrixCompareType::relative));
+}
+
+// Confirms the failure conditions for SDFormat. SceneGraph requirements on
+// geometry names are supposed to mirror the SDFormat behavior. If these tests
+// no longer fail, the requirements in SceneGraph should become more relaxed.
+// Alternatively, if more failure modes are learned, they should be encoded
+// here and in the SceneGraph logic (start at the documentation of
+// GeometryInstace).
+// Note: This is only tested for visual geometries, but the same requirements
+// are assumed for collision geometries.
+GTEST_TEST(SceneGraphParserDetail, VisualGeometryNameRequirements) {
+  // It is necessary to do a full, deep parse from the root to reveal *all*
+  // of the failure modes.
+
+  // A fmt::format-compatible string for testing various permutations of visual
+  // names.
+  const std::string visual_tag =
+      "<visual name='{}'>"
+      "  <pose>1.0 2.0 3.0 3.14 6.28 1.57</pose>"
+      "  <geometry>"
+      "    <cylinder>"
+      "      <radius>0.5</radius>"
+      "      <length>1.2</length>"
+      "    </cylinder>"
+      "  </geometry>"
+      "</visual>";
+
+  auto valid_parse = [](const std::string& visual_str) -> bool {
+    const std::string sdf_str = fmt::format(
+        "<?xml version='1.0'?>"
+        "<sdf version='1.6'>"
+        "  <model name='my_model'>"
+        "    <link name='link'>{}"
+        "    </link>"
+        "  </model>"
+        "</sdf>",
+        visual_str);
+    sdf::Root root;
+    auto errors = root.LoadSdfString(sdf_str);
+    return errors.empty();
+  };
+
+  // Allowable naming.
+  // Case: control group - a simple valid name.
+  EXPECT_TRUE(valid_parse(fmt::format(visual_tag, "visual")));
+
+  // Case: Valid name with leading whitespace.
+  EXPECT_TRUE(valid_parse(fmt::format(visual_tag, "  visual")));
+
+  // Case: Valid name with trailing whitespace.
+  EXPECT_TRUE(valid_parse(fmt::format(visual_tag, "visual   ")));
+
+  // These whitespace characters are *not* considered to be whitespace by SDF.
+  std::vector<std::pair<char, std::string>> ignored_whitespace{
+      {'\n', "\\n"}, {'\v', "\\v"}, {'\r', "\\r"}, {'\f', "\\f"}};
+  for (const auto& pair : ignored_whitespace) {
+    // Case: Whitespace-only name.
+    EXPECT_TRUE(valid_parse(fmt::format(visual_tag, pair.first)))
+        << "Failed on " << pair.second;
+  }
+
+  {
+    // Case: Same name for two different geometry types (collision vs visual).
+    const std::string collision_tag =
+        "<collision name='thing'>"
+        "  <pose>1.0 2.0 3.0 3.14 6.28 1.57</pose>"
+        "  <geometry>"
+        "    <sphere/>"
+        "  </geometry>"
+        "</collision>";
+    EXPECT_TRUE(valid_parse(fmt::format(visual_tag, "thing") + collision_tag));
+  }
+
+  // Invalid naming
+  {
+    // Case: Missing name element.
+    const std::string missing_name_parameter =
+        "<visual>"
+        "  <pose>1.0 2.0 3.0 3.14 6.28 1.57</pose>"
+        "  <geometry>"
+        "    <cylinder>"
+        "      <radius>0.5</radius>"
+        "      <length>1.2</length>"
+        "    </cylinder>"
+        "  </geometry>"
+        "</visual>";
+    EXPECT_FALSE(valid_parse(missing_name_parameter));
+  }
+
+  // Case: Empty name element.
+  EXPECT_FALSE(valid_parse(fmt::format(visual_tag, "")));
+
+  std::vector<std::pair<char, std::string>> invalid_whitespace{{' ', "space"},
+                                                               {'\t', "\\t"}};
+  for (const auto& pair : invalid_whitespace) {
+    // Case: Whitespace-only name.
+    EXPECT_FALSE(valid_parse(fmt::format(visual_tag, pair.first)))
+        << "Failed on " << pair.second;
+  }
+
+  // Case: Duplicate names.
+  EXPECT_FALSE(valid_parse(fmt::format(visual_tag, "visual") +
+                           fmt::format(visual_tag, "visual")));
+
+  // Case: Duplicate names which arise from trimming whitespace.
+  EXPECT_FALSE(valid_parse(fmt::format(visual_tag, "visual  ") +
+                           fmt::format(visual_tag, "  visual")));
 }
 
 // Verify MakeGeometryInstanceFromSdfVisual can make a GeometryInstance from an

--- a/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
+++ b/multibody/rigid_body_plant/rigid_body_plant_bridge.cc
@@ -1,6 +1,7 @@
 #include "drake/multibody/rigid_body_plant/rigid_body_plant_bridge.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -87,6 +88,7 @@ void RigidBodyPlantBridge<T>::RegisterTree(SceneGraph<T>* scene_graph) {
       body_ids_.push_back(body_id);
       // TODO(SeanCurtis-TRI): Handle collision and visual elements differently.
       // For now, we're simply consuming the visual elements.
+      int visual_count = 0;
       for (const auto& visual_element : body.get_visual_elements()) {
         std::unique_ptr<Shape> shape;
         Isometry3<double> X_FG = visual_element.getLocalTransform();
@@ -125,9 +127,10 @@ void RigidBodyPlantBridge<T>::RegisterTree(SceneGraph<T>* scene_graph) {
         if (shape) {
           // Visual element's "material" is simply the diffuse rgba values.
           const Vector4<double>& diffuse = visual_element.getMaterial();
+          const std::string name = "visual_" + std::to_string(visual_count++);
           scene_graph->RegisterGeometry(
               source_id_, body_id,
-              std::make_unique<GeometryInstance>(X_FG, std::move(shape),
+              std::make_unique<GeometryInstance>(X_FG, std::move(shape), name,
                                                  VisualMaterial(diffuse)));
           DRAKE_DEMAND(shape == nullptr);
         }


### PR DESCRIPTION
Adds names to geometries and the ability to get GeometryIds from those names.

Anything *outside* of the `geometry` folder reflects a change to the definition of a `GeometryInstance` -- names are required.  Everything *inside* the `geometry` folder is in support of the geometry names.

Sorry for the size. I can break the inspector out of this PR if you'd prefer a smaller PR.

```
Category            added  modified  removed  
----------------------------------------------
code                372    122       29       
comments            184    30        7        
blank               75     0         2        
----------------------------------------------
TOTAL               631    152       38 
```

Resolves: #9122 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9147)
<!-- Reviewable:end -->
