### PR TITLE
Allows installing libraries with the same name to support multiple Py…

### DIFF
--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -120,7 +120,14 @@ def install(src, dst):
         installed = True
     else:
         print("-- Up-to-date: {}".format(dst_full))
-    re_result = re.match(dylib_match, dst)
+    # NOTE: Only the libraries whose filenames start with `lib` are taken into
+    # account. This workaround allows to install Python C/C++ extensions for
+    # multiple Python versions without triggering the error message below.
+    # These Python C/C++ extensions can have the same name, as long as they
+    # are in different subdirectories.
+    # Caveat: We assume that no C/C++ shared libraries depend on these Python
+    # C/C++ extensions and require some RPath fix-up.
+    re_result = re.match(r'lib' + dylib_match, os.path.basename(dst))
     if re_result is not None:  # It is a library
         basename = os.path.basename(re_result.group(0))
         # Check that dependency is only referenced once


### PR DESCRIPTION
…thon versions

We relax the conditions under which an error message is thrown if multiple
libraries with the same name are installed. The error message is only thrown
if the library file name starts with the prefix `lib`. Python library file
names do not start with this prefix. This allows to install these libraries
in different subfolders without any problem.

The limitation is that we assume that no library depends on these Python libraries
and therefore nothing requires any RPath fix-up. This limitation is due to the fact
that these potentially duplicated libraries are not added to the dictionary which
maps the file name to its install location which is used in the RPath fixup step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9148)
<!-- Reviewable:end -->
