### PR TITLE
Adding "periodic" boundary condition option for cubic splines.

### DIFF
--- a/bindings/pydrake/test/trajectories_test.py
+++ b/bindings/pydrake/test/trajectories_test.py
@@ -42,8 +42,9 @@ class TestTrajectories(unittest.TestCase):
     def test_cubic(self):
         t = [0., 1., 2.]
         x = np.diag((4., 5., 6.))
+        periodic_end = False
         # Just test the spelling for these.
-        pp1 = PiecewisePolynomial.Cubic(t, x)
+        pp1 = PiecewisePolynomial.Cubic(t, x, periodic_end)
         pp2 = PiecewisePolynomial.Cubic(t, x, np.identity(3))
         pp3 = PiecewisePolynomial.Cubic(t, x, [0., 0., 0.], [0., 0., 0.])
 

--- a/bindings/pydrake/trajectories_py.cc
+++ b/bindings/pydrake/trajectories_py.cc
@@ -61,9 +61,10 @@ PYBIND11_MODULE(trajectories, m) {
                   py::arg("breaks"), py::arg("knots"), py::arg("knots_dot"))
       .def_static("Cubic",
                   py::overload_cast<const Eigen::Ref<const Eigen::VectorXd>&,
-                                    const Eigen::Ref<const MatrixX<T>>&>(
+                                    const Eigen::Ref<const MatrixX<T>>&,
+                                    bool>(
                       &PiecewisePolynomial<T>::Cubic),
-                  py::arg("breaks"), py::arg("knots"))
+                  py::arg("breaks"), py::arg("knots"), py::arg("periodic_end"))
       .def("value", &PiecewisePolynomial<T>::value)
       .def("derivative", &PiecewisePolynomial<T>::derivative)
       .def("rows", &PiecewisePolynomial<T>::rows)

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
 
 using std::runtime_error;
 using std::vector;
@@ -103,8 +104,8 @@ PiecewisePolynomial<T>::integral(
 
 template <typename T>
 double PiecewisePolynomial<T>::scalarValue(double t,
-                                                         Eigen::Index row,
-                                                         Eigen::Index col) {
+                                           Eigen::Index row,
+                                           Eigen::Index col) const {
   int segment_index = this->get_segment_index(t);
   return segmentValueAtGlobalAbscissa(segment_index, t, row, col);
 }
@@ -264,6 +265,38 @@ bool PiecewisePolynomial<T>::isApprox(
     }
   }
   return true;
+}
+
+template <typename T>
+void PiecewisePolynomial<T>::ConcatenateInTime(
+    const PiecewisePolynomial<T>& other) {
+  if (!empty()) {
+    // Performs basic sanity checks.
+    DRAKE_THROW_UNLESS(this->rows() == other.rows());
+    DRAKE_THROW_UNLESS(this->cols() == other.cols());
+    const double time_offset = other.start_time() - this->end_time();
+    // Absolute tolerance is scaled along with the time scale.
+    const double absolute_tolerance = std::max(std::abs(this->end_time()), 1.) *
+                                      std::numeric_limits<double>::epsilon();
+    DRAKE_THROW_UNLESS(std::abs(time_offset) < absolute_tolerance);
+    // Gets instance breaks.
+    std::vector<double>& breaks = this->get_mutable_breaks();
+    // Drops first break to avoid duplication.
+    breaks.pop_back();
+    // Concatenates other breaks, while shifting them appropriately
+    // for both trajectories to be time-aligned.
+    for (double other_break : other.breaks()) {
+      breaks.push_back(other_break - time_offset);
+    }
+    // Concatenates other polynomials.
+    polynomials_.insert(polynomials_.end(),
+                        other.polynomials_.begin(),
+                        other.polynomials_.end());
+  } else {
+    std::vector<double>& breaks = this->get_mutable_breaks();
+    breaks = other.breaks();
+    polynomials_ = other.polynomials_;
+  }
 }
 
 template <typename T>
@@ -740,7 +773,7 @@ PiecewisePolynomial<T>
 PiecewisePolynomial<T>::Cubic(
     const std::vector<double>& breaks,
     const std::vector<CoefficientMatrix>& knots,
-    const bool periodic_end_condition) {
+    bool periodic_end_condition) {
   const std::vector<double>& times = breaks;
   const std::vector<CoefficientMatrix>& Y = knots;
   CheckSplineGenerationInputValidityOrThrow(times, Y, 3);
@@ -769,8 +802,8 @@ PiecewisePolynomial<T>::Cubic(
 
       if (N > 3 && !periodic_end_condition) {
         // Ydddot(times[1]) is continuous.
-        A(row_idx, 3) = 1; // Cubic term of 1st segment
-        A(row_idx, 4 + 3) = -1; // Cubic term of 2nd segment
+        A(row_idx, 3) = 1;  // Cubic term of 1st segment
+        A(row_idx, 4 + 3) = -1;  // Cubic term of 2nd segment
         b(row_idx++) = 0;
 
         // Ydddot(times[N-2]) is continuous.
@@ -782,18 +815,19 @@ PiecewisePolynomial<T>::Cubic(
         const double end_dt = times[times.size() - 1] - times[times.size() - 2];
         // Enforce velocity between end-of-last and beginning-of-first segments
         // are continuous.
-        A(row_idx, 1) = -1; // Linear term of 1st segment.
-        A(row_idx, 4 * (N - 2) + 1) = 1; // Linear term of last segment.
-        A(row_idx, 4 * (N - 2) + 2) = 2*end_dt; // Squared term of last segment.
-        A(row_idx, 4 * (N - 2) + 3) = 3*end_dt*end_dt; // Cubic term of last
-                                                       // segment.
+        A(row_idx, 1) = -1;  // Linear term of 1st segment.
+        A(row_idx, 4 * (N - 2) + 1) = 1;  // Linear term of last segment.
+        A(row_idx, 4 * (N - 2) + 2) = 2*end_dt;  // Squared term of last
+                                                 // segment.
+        A(row_idx, 4 * (N - 2) + 3) = 3*end_dt*end_dt;  // Cubic term of last
+                                                        // segment.
         b(row_idx++) = 0;
 
         // Enforce acceleration between end-of-last and beginning-of-first
         // segments are continuous.
-        A(row_idx, 2) = -2; // Quadratic term of 1st segment.
-        A(row_idx, 4 * (N - 2) + 2) = 2; // Quadratic term of last segment.
-        A(row_idx, 4 * (N - 2) + 3) = 6*end_dt; // Cubic term of last segment.
+        A(row_idx, 2) = -2;  // Quadratic term of 1st segment.
+        A(row_idx, 4 * (N - 2) + 2) = 2;  // Quadratic term of last segment.
+        A(row_idx, 4 * (N - 2) + 3) = 6*end_dt;  // Cubic term of last segment.
         b(row_idx++) = 0;
       } else {
         // Set Jerk to zero if only have 3 points, becomes a quadratic.
@@ -892,7 +926,7 @@ template <typename T>
 PiecewisePolynomial<T> PiecewisePolynomial<T>::Cubic(
     const Eigen::Ref<const Eigen::VectorXd>& breaks,
     const Eigen::Ref<const MatrixX<T>>& knots,
-    const bool periodic_end_condition) {
+    bool periodic_end_condition) {
   DRAKE_DEMAND(knots.cols() == breaks.size());
   std::vector<double> my_breaks(breaks.data(), breaks.data() + breaks.size());
   return PiecewisePolynomial<T>::Cubic(my_breaks, ColsToStdVector(knots),
@@ -924,3 +958,4 @@ template class PiecewisePolynomial<double>;
 
 }  // namespace trajectories
 }  // namespace drake
+

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -763,11 +763,11 @@ PiecewisePolynomial<T>::Cubic(
 
 // Makes a cubic piecewise polynomial.
 // Internal knot points have continuous values, first and second derivatives.
-// If periodic_end_condition is true, the first and second derivatives will
+// If `periodic_end_condition` is `true`, the first and second derivatives will
 // be continuous between the end of the last segment and the beginning of
-// the first. Otherwise, third derivative is made continuous at the end of
-// the first segment and the beginning of the last segment "not-a-knot"
-// condition.
+// the first. Otherwise, the third derivative is made continuous at the end
+// of the first segment and the beginning of the last segment (i.e the
+// "not-a-knot" condition).
 template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::Cubic(
@@ -802,8 +802,8 @@ PiecewisePolynomial<T>::Cubic(
 
       if (N > 3 && !periodic_end_condition) {
         // Ydddot(times[1]) is continuous.
-        A(row_idx, 3) = 1;  // Cubic term of 1st segment
-        A(row_idx, 4 + 3) = -1;  // Cubic term of 2nd segment
+        A(row_idx, 3) = 1;  // Cubic term of 1st segment.
+        A(row_idx, 4 + 3) = -1;  // Cubic term of 2nd segment.
         b(row_idx++) = 0;
 
         // Ydddot(times[N-2]) is continuous.
@@ -814,20 +814,21 @@ PiecewisePolynomial<T>::Cubic(
         // Time during the last segment.
         const double end_dt = times[times.size() - 1] - times[times.size() - 2];
         // Enforce velocity between end-of-last and beginning-of-first segments
-        // are continuous.
+        // is continuous.
         A(row_idx, 1) = -1;  // Linear term of 1st segment.
         A(row_idx, 4 * (N - 2) + 1) = 1;  // Linear term of last segment.
-        A(row_idx, 4 * (N - 2) + 2) = 2*end_dt;  // Squared term of last
-                                                 // segment.
-        A(row_idx, 4 * (N - 2) + 3) = 3*end_dt*end_dt;  // Cubic term of last
-                                                        // segment.
+        A(row_idx, 4 * (N - 2) + 2) = 2 * end_dt;  // Squared term of last
+                                                   // segment.
+        A(row_idx, 4 * (N - 2) + 3) = 3 * end_dt * end_dt;  // Cubic term of
+                                                            // last segment.
         b(row_idx++) = 0;
 
-        // Enforce acceleration between end-of-last and beginning-of-first
-        // segments are continuous.
+        // Enforce that acceleration between end-of-last and beginning-of-first
+        // segments is continuous.
         A(row_idx, 2) = -2;  // Quadratic term of 1st segment.
         A(row_idx, 4 * (N - 2) + 2) = 2;  // Quadratic term of last segment.
-        A(row_idx, 4 * (N - 2) + 3) = 6*end_dt;  // Cubic term of last segment.
+        A(row_idx, 4 * (N - 2) + 3) = 6 * end_dt;  // Cubic term of last
+                                                   // segment.
         b(row_idx++) = 0;
       } else {
         // Set Jerk to zero if only have 3 points, becomes a quadratic.

--- a/common/trajectories/piecewise_polynomial.cc
+++ b/common/trajectories/piecewise_polynomial.cc
@@ -4,7 +4,6 @@
 #include <memory>
 
 #include "drake/common/drake_assert.h"
-#include "drake/common/drake_throw.h"
 
 using std::runtime_error;
 using std::vector;
@@ -104,8 +103,8 @@ PiecewisePolynomial<T>::integral(
 
 template <typename T>
 double PiecewisePolynomial<T>::scalarValue(double t,
-                                           Eigen::Index row,
-                                           Eigen::Index col) const {
+                                                         Eigen::Index row,
+                                                         Eigen::Index col) {
   int segment_index = this->get_segment_index(t);
   return segmentValueAtGlobalAbscissa(segment_index, t, row, col);
 }
@@ -265,38 +264,6 @@ bool PiecewisePolynomial<T>::isApprox(
     }
   }
   return true;
-}
-
-template <typename T>
-void PiecewisePolynomial<T>::ConcatenateInTime(
-    const PiecewisePolynomial<T>& other) {
-  if (!empty()) {
-    // Performs basic sanity checks.
-    DRAKE_THROW_UNLESS(this->rows() == other.rows());
-    DRAKE_THROW_UNLESS(this->cols() == other.cols());
-    const double time_offset = other.start_time() - this->end_time();
-    // Absolute tolerance is scaled along with the time scale.
-    const double absolute_tolerance = std::max(std::abs(this->end_time()), 1.) *
-                                      std::numeric_limits<double>::epsilon();
-    DRAKE_THROW_UNLESS(std::abs(time_offset) < absolute_tolerance);
-    // Gets instance breaks.
-    std::vector<double>& breaks = this->get_mutable_breaks();
-    // Drops first break to avoid duplication.
-    breaks.pop_back();
-    // Concatenates other breaks, while shifting them appropriately
-    // for both trajectories to be time-aligned.
-    for (double other_break : other.breaks()) {
-      breaks.push_back(other_break - time_offset);
-    }
-    // Concatenates other polynomials.
-    polynomials_.insert(polynomials_.end(),
-                        other.polynomials_.begin(),
-                        other.polynomials_.end());
-  } else {
-    std::vector<double>& breaks = this->get_mutable_breaks();
-    breaks = other.breaks();
-    polynomials_ = other.polynomials_;
-  }
 }
 
 template <typename T>
@@ -762,14 +729,18 @@ PiecewisePolynomial<T>::Cubic(
 }
 
 // Makes a cubic piecewise polynomial.
-// Internal knot points have continuous values, first and second derivatives,
-// Third derivative is also continuous at the end of the first segment and the
-// beginning of the last segment.
+// Internal knot points have continuous values, first and second derivatives.
+// If periodic_end_condition is true, the first and second derivatives will
+// be continuous between the end of the last segment and the beginning of
+// the first. Otherwise, third derivative is made continuous at the end of
+// the first segment and the beginning of the last segment "not-a-knot"
+// condition.
 template <typename T>
 PiecewisePolynomial<T>
 PiecewisePolynomial<T>::Cubic(
     const std::vector<double>& breaks,
-    const std::vector<CoefficientMatrix>& knots) {
+    const std::vector<CoefficientMatrix>& knots,
+    const bool periodic_end_condition) {
   const std::vector<double>& times = breaks;
   const std::vector<CoefficientMatrix>& Y = knots;
   CheckSplineGenerationInputValidityOrThrow(times, Y, 3);
@@ -796,15 +767,33 @@ PiecewisePolynomial<T>::Cubic(
       int row_idx =
           SetupCubicSplineInteriorCoeffsLinearSystem(times, Y, j, k, &A, &b);
 
-      if (N > 3) {
+      if (N > 3 && !periodic_end_condition) {
         // Ydddot(times[1]) is continuous.
-        A(row_idx, 3) = 1;
-        A(row_idx, 4 + 3) = -1;
+        A(row_idx, 3) = 1; // Cubic term of 1st segment
+        A(row_idx, 4 + 3) = -1; // Cubic term of 2nd segment
         b(row_idx++) = 0;
 
         // Ydddot(times[N-2]) is continuous.
         A(row_idx, 4 * (N - 3) + 3) = 1;
         A(row_idx, 4 * (N - 2) + 3) = -1;
+        b(row_idx++) = 0;
+      } else if (periodic_end_condition) {
+        // Time during the last segment.
+        const double end_dt = times[times.size() - 1] - times[times.size() - 2];
+        // Enforce velocity between end-of-last and beginning-of-first segments
+        // are continuous.
+        A(row_idx, 1) = -1; // Linear term of 1st segment.
+        A(row_idx, 4 * (N - 2) + 1) = 1; // Linear term of last segment.
+        A(row_idx, 4 * (N - 2) + 2) = 2*end_dt; // Squared term of last segment.
+        A(row_idx, 4 * (N - 2) + 3) = 3*end_dt*end_dt; // Cubic term of last
+                                                       // segment.
+        b(row_idx++) = 0;
+
+        // Enforce acceleration between end-of-last and beginning-of-first
+        // segments are continuous.
+        A(row_idx, 2) = -2; // Quadratic term of 1st segment.
+        A(row_idx, 4 * (N - 2) + 2) = 2; // Quadratic term of last segment.
+        A(row_idx, 4 * (N - 2) + 3) = 6*end_dt; // Cubic term of last segment.
         b(row_idx++) = 0;
       } else {
         // Set Jerk to zero if only have 3 points, becomes a quadratic.
@@ -902,10 +891,12 @@ PiecewisePolynomial<T> PiecewisePolynomial<T>::Cubic(
 template <typename T>
 PiecewisePolynomial<T> PiecewisePolynomial<T>::Cubic(
     const Eigen::Ref<const Eigen::VectorXd>& breaks,
-    const Eigen::Ref<const MatrixX<T>>& knots) {
+    const Eigen::Ref<const MatrixX<T>>& knots,
+    const bool periodic_end_condition) {
   DRAKE_DEMAND(knots.cols() == breaks.size());
   std::vector<double> my_breaks(breaks.data(), breaks.data() + breaks.size());
-  return PiecewisePolynomial<T>::Cubic(my_breaks, ColsToStdVector(knots));
+  return PiecewisePolynomial<T>::Cubic(my_breaks, ColsToStdVector(knots),
+                                       periodic_end_condition);
 }
 
 // Computes the cubic spline coefficients based on the given values and first

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -252,9 +252,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   /**
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
    * The PiecewisePolynomial is constructed such that the interior segments
-   * have the same value, first and second derivatives at `breaks`.
-   * "Not-a-knot" end condition is used here, which means the third derivatives
-   * are continuous for the first two and last two segments.
+   * have the same value, first and second derivatives at `breaks`. If
+   * periodic_end_condition is false (default), then "Not-a-knot" end
+   * condition is used here, which means the third derivatives are
+   * continuous for the first two and last two segments. If
+   * periodic_end_condition is true, then the first and second derivatives
+   * between the end of the last segment and the beginning of the first
+   * segment will be continuous.
    * See https://en.wikipedia.org/wiki/Spline_interpolation for more details
    * about "Not-a-knot" condition.
    * The matlab file "spline.m" and
@@ -264,6 +268,9 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @p breaks and @p knots must have at least 3 elements. Otherwise there is
    * not enough information to solve for the coefficients.
    *
+   * @param periodic_end_condition Determines whether the "not-a-knot" or the
+   * periodic spline end condition is used.
+   *
    * @throws std::runtime_error if
    *    `breaks` and `knots` have different length,
    *    `breaks` is not strictly increasing,
@@ -272,7 +279,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
-      const std::vector<CoefficientMatrix>& knots);
+      const std::vector<CoefficientMatrix>& knots,
+      const bool periodic_end_condition=false);
 
   /**
    * Eigen version of Cubic(breaks, knots) where each column of knots is used
@@ -282,7 +290,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    */
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
-      const Eigen::Ref<const MatrixX<T>>& knots);
+      const Eigen::Ref<const MatrixX<T>>& knots,
+      const bool periodic_end_condition=false);
 
 
   /// Takes the derivative of this PiecewisePolynomial.
@@ -329,8 +338,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   bool empty() const { return polynomials_.empty(); }
 
-  double scalarValue(double t, Eigen::Index row = 0,
-                     Eigen::Index col = 0) const;
+  double scalarValue(double t, Eigen::Index row = 0, Eigen::Index col = 0);
 
   /**
    * Evaluates the PiecewisePolynomial at the given time \p t.
@@ -348,10 +356,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   int getSegmentPolynomialDegree(int segment_index, Eigen::Index row = 0,
                                  Eigen::Index col = 0) const;
 
-  /// Returns the row count of each and every PolynomialMatrix segment.
   Eigen::Index rows() const override;
 
-  /// Returns the column count of each and every PolynomialMatrix segment.
   Eigen::Index cols() const override;
 
   /// @throws std::runtime_error if other.segment_times is not within
@@ -401,18 +407,6 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * if any Polynomial in either PiecewisePolynomial is not univariate.
    */
   bool isApprox(const PiecewisePolynomial& other, double tol) const;
-
-  /// Concatenates @p other at the end, yielding a continuous trajectory
-  /// from current start_time() to @p other end_time().
-  ///
-  /// @param other PiecewisePolynomial instance to concatenate.
-  /// @throw std::runtime_error if trajectories' dimensions do not match
-  ///                           each other (either rows() or cols() does
-  ///                           not match between this and @p other).
-  /// @throw std::runtime_error if this end_time() and @p other start_time() are
-  ///                           not within PiecewiseTrajectory<T>::kEpsilonTime
-  ///                           from each other.
-  void ConcatenateInTime(const PiecewisePolynomial& other);
 
   void shiftRight(double offset);
 

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -253,13 +253,13 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
    * The PiecewisePolynomial is constructed such that the interior segments
    * have the same value, first and second derivatives at `breaks`. If
-   * periodic_end_condition is `false` (default), then the "Not-a-knot" end
+   * `periodic_end_condition` is `false` (default), then the "Not-a-knot" end
    * condition is used here, which means the third derivatives are
    * continuous for the first two and last two segments. If
    * `periodic_end_condition` is `true`, then the first and second derivatives
    * between the end of the last segment and the beginning of the first
    * segment will be continuous. Note that the periodic end condition does
-   * not require the first and last knot to be colocated, nor does it add
+   * not require the first and last knot to be collocated, nor does it add
    * an additional knot to connect the first and last segments. Only first
    * and second derivative continuity is enforced. 
    * See https://en.wikipedia.org/wiki/Spline_interpolation, 
@@ -270,7 +270,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    *
    * @p breaks and @p knots must have at least 3 elements. The "not-a-knot" 
    * condition is ill-defined for two knots, and the "periodic" condition 
-   * produces a straight line (use `FirstOrderHold` for this instead).
+   * would produce a straight line (use `FirstOrderHold` for this instead).
    *
    * @param periodic_end_condition Determines whether the "not-a-knot" 
    * (`false`) or the periodic spline (`true`) end condition is used.

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -258,15 +258,19 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * continuous for the first two and last two segments. If
    * `periodic_end_condition` is `true`, then the first and second derivatives
    * between the end of the last segment and the beginning of the first
-   * segment will be continuous.
-   * See https://en.wikipedia.org/wiki/Spline_interpolation for more details
-   * about "Not-a-knot" condition.
-   * The matlab file "spline.m" and
-   * http://home.uchicago.edu/~sctchoi/courses/cs138/interp.pdf are also good
-   * references.
+   * segment will be continuous. Note that the periodic end condition does
+   * not require the first and last knot to be colocated, nor does it add
+   * an additional knot to connect the first and last segments. Only first
+   * and second derivative continuity is enforced. 
+   * See https://en.wikipedia.org/wiki/Spline_interpolation, 
+   * https://www.math.uh.edu/~jingqiu/math4364/spline.pdf, and
+   * http://www.maths.lth.se/na/courses/FMN081/FMN081-06/lecture11.pdf
+   * for more about cubic splines and their end conditions.
+   * The MATLAB files "spline.m" and "csape.m" are also good references.
    *
-   * @p breaks and @p knots must have at least 3 elements. Otherwise there is
-   * not enough information to solve for the coefficients.
+   * @p breaks and @p knots must have at least 3 elements. The "not-a-knot" 
+   * condition is ill-defined for two knots, and the "periodic" condition 
+   * produces a straight line (use `FirstOrderHold` for this instead).
    *
    * @param periodic_end_condition Determines whether the "not-a-knot" 
    * (`false`) or the periodic spline (`true`) end condition is used.

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -253,10 +253,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * Constructs a third order PiecewisePolynomial from `breaks` and `knots`.
    * The PiecewisePolynomial is constructed such that the interior segments
    * have the same value, first and second derivatives at `breaks`. If
-   * periodic_end_condition is false (default), then "Not-a-knot" end
+   * periodic_end_condition is `false` (default), then the "Not-a-knot" end
    * condition is used here, which means the third derivatives are
    * continuous for the first two and last two segments. If
-   * periodic_end_condition is true, then the first and second derivatives
+   * `periodic_end_condition` is `true`, then the first and second derivatives
    * between the end of the last segment and the beginning of the first
    * segment will be continuous.
    * See https://en.wikipedia.org/wiki/Spline_interpolation for more details
@@ -268,8 +268,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * @p breaks and @p knots must have at least 3 elements. Otherwise there is
    * not enough information to solve for the coefficients.
    *
-   * @param periodic_end_condition Determines whether the "not-a-knot" or the
-   * periodic spline end condition is used.
+   * @param periodic_end_condition Determines whether the "not-a-knot" 
+   * (`false`) or the periodic spline (`true`) end condition is used.
    *
    * @throws std::runtime_error if
    *    `breaks` and `knots` have different length,

--- a/common/trajectories/piecewise_polynomial.h
+++ b/common/trajectories/piecewise_polynomial.h
@@ -280,7 +280,7 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   static PiecewisePolynomial<T> Cubic(
       const std::vector<double>& breaks,
       const std::vector<CoefficientMatrix>& knots,
-      const bool periodic_end_condition=false);
+      bool periodic_end_condition = false);
 
   /**
    * Eigen version of Cubic(breaks, knots) where each column of knots is used
@@ -291,7 +291,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   static PiecewisePolynomial<T> Cubic(
       const Eigen::Ref<const Eigen::VectorXd>& breaks,
       const Eigen::Ref<const MatrixX<T>>& knots,
-      const bool periodic_end_condition=false);
+      bool periodic_end_condition = false);
+
 
 
   /// Takes the derivative of this PiecewisePolynomial.
@@ -338,7 +339,8 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
   bool empty() const { return polynomials_.empty(); }
 
-  double scalarValue(double t, Eigen::Index row = 0, Eigen::Index col = 0);
+  double scalarValue(double t, Eigen::Index row = 0,
+                     Eigen::Index col = 0) const;
 
   /**
    * Evaluates the PiecewisePolynomial at the given time \p t.
@@ -356,8 +358,10 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
   int getSegmentPolynomialDegree(int segment_index, Eigen::Index row = 0,
                                  Eigen::Index col = 0) const;
 
+  /// Returns the row count of each and every PolynomialMatrix segment.
   Eigen::Index rows() const override;
 
+  /// Returns the column count of each and every PolynomialMatrix segment.
   Eigen::Index cols() const override;
 
   /// @throws std::runtime_error if other.segment_times is not within
@@ -407,6 +411,18 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
    * if any Polynomial in either PiecewisePolynomial is not univariate.
    */
   bool isApprox(const PiecewisePolynomial& other, double tol) const;
+
+  /// Concatenates @p other at the end, yielding a continuous trajectory
+  /// from current start_time() to @p other end_time().
+  ///
+  /// @param other PiecewisePolynomial instance to concatenate.
+  /// @throw std::runtime_error if trajectories' dimensions do not match
+  ///                           each other (either rows() or cols() does
+  ///                           not match between this and @p other).
+  /// @throw std::runtime_error if this end_time() and @p other start_time() are
+  ///                           not within PiecewiseTrajectory<T>::kEpsilonTime
+  ///                           from each other.
+  void ConcatenateInTime(const PiecewisePolynomial& other);
 
   void shiftRight(double offset);
 
@@ -481,3 +497,4 @@ class PiecewisePolynomial final : public PiecewiseTrajectory<T> {
 
 }  // namespace trajectories
 }  // namespace drake
+

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -217,9 +217,10 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
         0, 3, 3,
         -2, 2, 2,
         1, 1, 1;
+  const bool periodic_endpoint = true;
 
   PiecewisePolynomial<double> periodic_spline =
-      PiecewisePolynomial<double>::Cubic(breaks, knots, true);
+      PiecewisePolynomial<double>::Cubic(breaks, knots, periodic_endpoint);
 
   std::unique_ptr<Trajectory<double>> spline_dt =
       periodic_spline.MakeDerivative(1);
@@ -235,8 +236,8 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   Eigen::VectorXd dt_diff = end_dt - begin_dt;
   Eigen::VectorXd ddt_diff = end_ddt - begin_ddt;
 
-  EXPECT_TRUE(dt_diff.template lpNorm<Eigen::Infinity>() < 1e-8);
-  EXPECT_TRUE(ddt_diff.template lpNorm<Eigen::Infinity>() < 1e-8);
+  EXPECT_TRUE(dt_diff.template lpNorm<Eigen::Infinity>() < 1e-14);
+  EXPECT_TRUE(ddt_diff.template lpNorm<Eigen::Infinity>() < 1e-14);
 }
 
 GTEST_TEST(testPiecewisePolynomial, AllTests

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -1,6 +1,5 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
-#include <iostream>
 #include <random>
 #include <vector>
 
@@ -92,6 +91,12 @@ void testBasicFunctionality() {
     PiecewisePolynomialType piecewise2 =
         test::MakeRandomPiecewisePolynomial<CoefficientType>(
             rows, cols, num_coefficients, segment_times);
+    PiecewisePolynomialType piecewise3_not_matching_rows =
+        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+            rows + 1, cols, num_coefficients, segment_times);
+    PiecewisePolynomialType piecewise4_not_matching_cols =
+        test::MakeRandomPiecewisePolynomial<CoefficientType>(
+            rows, cols + 1, num_coefficients, segment_times);
 
     normal_distribution<double> normal;
     double shift = normal(generator);
@@ -105,6 +110,36 @@ void testBasicFunctionality() {
     PiecewisePolynomialType piecewise1_shifted = piecewise1;
     piecewise1_shifted.shiftRight(shift);
     PiecewisePolynomialType product = piecewise1 * piecewise2;
+
+    const double total_time = segment_times.back() - segment_times.front();
+    PiecewisePolynomialType piecewise2_twice = piecewise2;
+    PiecewisePolynomialType piecewise2_shifted = piecewise2;
+    piecewise2_shifted.shiftRight(total_time);
+
+    // Checks that concatenation of trajectories that are not time
+    // aligned at the connecting ends is a failure.
+    PiecewisePolynomialType piecewise2_shifted_twice = piecewise2;
+    piecewise2_shifted_twice.shiftRight(2. * total_time);
+    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
+        piecewise2_shifted_twice), std::runtime_error);
+
+    // Checks that concatenation of trajectories that have different
+    // row counts is a failure.
+    PiecewisePolynomialType piecewise3_not_matching_rows_shifted =
+        piecewise3_not_matching_rows;
+    piecewise3_not_matching_rows_shifted.shiftRight(total_time);
+    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
+        piecewise3_not_matching_rows_shifted), std::runtime_error);
+
+    // Checks that concatenation of trajectories that have different
+    // col counts is a failure.
+    PiecewisePolynomialType piecewise4_not_matching_cols_shifted =
+        piecewise4_not_matching_cols;
+    piecewise4_not_matching_cols_shifted.shiftRight(total_time);
+    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
+        piecewise4_not_matching_cols_shifted), std::runtime_error);
+
+    piecewise2_twice.ConcatenateInTime(piecewise2_shifted);
 
     uniform_real_distribution<double> uniform(piecewise1.start_time(),
                                               piecewise1.end_time());
@@ -133,6 +168,17 @@ void testBasicFunctionality() {
     EXPECT_TRUE(CompareMatrices(
         product.value(t),
         (piecewise1.value(t).array() * piecewise2.value(t).array()).matrix(),
+        1e-8, MatrixCompareType::absolute));
+
+    // Checks that `piecewise2_twice` is effectively the concatenation of
+    // `piecewise2` and a copy of `piecewise2` that is shifted to the right
+    // (i.e. towards increasing values of t) by an amount equal to its entire
+    // time length. To this end, it verifies that R(tₓ) = R(tₓ + d), where
+    // R(t) = P(t) for t0 <= t <= t1, R(t) = Q(t) for t1 <= t <= t2,
+    // Q(t) = P(t - d) for t1 <= t <= t2, d = t1 - t0 = t2 - t1 and
+    // t0 < tₓ < t1, with P, Q and R functions being piecewise polynomials.
+    EXPECT_TRUE(CompareMatrices(
+        piecewise2_twice.value(t), piecewise2_twice.value(t + total_time),
         1e-8, MatrixCompareType::absolute));
   }
 }
@@ -165,7 +211,7 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   breaks << 0, 1, 2, 3, 4;
 
   // Spline in 3d.
-  Eigen::MatrixXd knots(3,5);
+  Eigen::MatrixXd knots(3, 5);
   knots << 1, 1, 1,
         2, 2, 2,
         0, 3, 3,
@@ -186,13 +232,11 @@ GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
   Eigen::VectorXd begin_ddt = spline_ddt->value(breaks(0));
   Eigen::VectorXd end_ddt = spline_ddt->value(breaks(breaks.size() - 1));
 
-
   Eigen::VectorXd dt_diff = end_dt - begin_dt;
   Eigen::VectorXd ddt_diff = end_ddt - begin_ddt;
 
-  EXPECT_TRUE(dt_diff.lpNorm<Eigen::Infinity>() < 1e-8);
-  EXPECT_TRUE(ddt_diff.lpNorm<Eigen::Infinity>() < 1e-8);
-
+  EXPECT_TRUE(dt_diff.template lpNorm<Eigen::Infinity>() < 1e-8);
+  EXPECT_TRUE(ddt_diff.template lpNorm<Eigen::Infinity>() < 1e-8);
 }
 
 GTEST_TEST(testPiecewisePolynomial, AllTests
@@ -207,3 +251,4 @@ testValueOutsideOfRange<double>();
 }  // namespace
 }  // namespace trajectories
 }  // namespace drake
+

--- a/common/trajectories/test/piecewise_polynomial_test.cc
+++ b/common/trajectories/test/piecewise_polynomial_test.cc
@@ -1,5 +1,6 @@
 #include "drake/common/trajectories/piecewise_polynomial.h"
 
+#include <iostream>
 #include <random>
 #include <vector>
 
@@ -91,12 +92,6 @@ void testBasicFunctionality() {
     PiecewisePolynomialType piecewise2 =
         test::MakeRandomPiecewisePolynomial<CoefficientType>(
             rows, cols, num_coefficients, segment_times);
-    PiecewisePolynomialType piecewise3_not_matching_rows =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
-            rows + 1, cols, num_coefficients, segment_times);
-    PiecewisePolynomialType piecewise4_not_matching_cols =
-        test::MakeRandomPiecewisePolynomial<CoefficientType>(
-            rows, cols + 1, num_coefficients, segment_times);
 
     normal_distribution<double> normal;
     double shift = normal(generator);
@@ -110,36 +105,6 @@ void testBasicFunctionality() {
     PiecewisePolynomialType piecewise1_shifted = piecewise1;
     piecewise1_shifted.shiftRight(shift);
     PiecewisePolynomialType product = piecewise1 * piecewise2;
-
-    const double total_time = segment_times.back() - segment_times.front();
-    PiecewisePolynomialType piecewise2_twice = piecewise2;
-    PiecewisePolynomialType piecewise2_shifted = piecewise2;
-    piecewise2_shifted.shiftRight(total_time);
-
-    // Checks that concatenation of trajectories that are not time
-    // aligned at the connecting ends is a failure.
-    PiecewisePolynomialType piecewise2_shifted_twice = piecewise2;
-    piecewise2_shifted_twice.shiftRight(2. * total_time);
-    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
-        piecewise2_shifted_twice), std::runtime_error);
-
-    // Checks that concatenation of trajectories that have different
-    // row counts is a failure.
-    PiecewisePolynomialType piecewise3_not_matching_rows_shifted =
-        piecewise3_not_matching_rows;
-    piecewise3_not_matching_rows_shifted.shiftRight(total_time);
-    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
-        piecewise3_not_matching_rows_shifted), std::runtime_error);
-
-    // Checks that concatenation of trajectories that have different
-    // col counts is a failure.
-    PiecewisePolynomialType piecewise4_not_matching_cols_shifted =
-        piecewise4_not_matching_cols;
-    piecewise4_not_matching_cols_shifted.shiftRight(total_time);
-    EXPECT_THROW(piecewise2_twice.ConcatenateInTime(
-        piecewise4_not_matching_cols_shifted), std::runtime_error);
-
-    piecewise2_twice.ConcatenateInTime(piecewise2_shifted);
 
     uniform_real_distribution<double> uniform(piecewise1.start_time(),
                                               piecewise1.end_time());
@@ -169,17 +134,6 @@ void testBasicFunctionality() {
         product.value(t),
         (piecewise1.value(t).array() * piecewise2.value(t).array()).matrix(),
         1e-8, MatrixCompareType::absolute));
-
-    // Checks that `piecewise2_twice` is effectively the concatenation of
-    // `piecewise2` and a copy of `piecewise2` that is shifted to the right
-    // (i.e. towards increasing values of t) by an amount equal to its entire
-    // time length. To this end, it verifies that R(tₓ) = R(tₓ + d), where
-    // R(t) = P(t) for t0 <= t <= t1, R(t) = Q(t) for t1 <= t <= t2,
-    // Q(t) = P(t - d) for t1 <= t <= t2, d = t1 - t0 = t2 - t1 and
-    // t0 < tₓ < t1, with P, Q and R functions being piecewise polynomials.
-    EXPECT_TRUE(CompareMatrices(
-        piecewise2_twice.value(t), piecewise2_twice.value(t + total_time),
-        1e-8, MatrixCompareType::absolute));
   }
 }
 
@@ -201,6 +155,44 @@ void testValueOutsideOfRange() {
   EXPECT_TRUE(CompareMatrices(piecewise.value(piecewise.end_time()),
                               piecewise.value(piecewise.end_time() + 1.0),
                               1e-10, MatrixCompareType::absolute));
+}
+
+// Test the generation of cubic splines with first and second derivatives
+// continuous between the end of the last segment and the beginning of the
+// first.
+GTEST_TEST(testPiecewisePolynomial, CubicSplinePeriodicBoundaryConditionTest) {
+  Eigen::VectorXd breaks(5);
+  breaks << 0, 1, 2, 3, 4;
+
+  // Spline in 3d.
+  Eigen::MatrixXd knots(3,5);
+  knots << 1, 1, 1,
+        2, 2, 2,
+        0, 3, 3,
+        -2, 2, 2,
+        1, 1, 1;
+
+  PiecewisePolynomial<double> periodic_spline =
+      PiecewisePolynomial<double>::Cubic(breaks, knots, true);
+
+  std::unique_ptr<Trajectory<double>> spline_dt =
+      periodic_spline.MakeDerivative(1);
+  std::unique_ptr<Trajectory<double>> spline_ddt =
+      periodic_spline.MakeDerivative(2);
+
+  Eigen::VectorXd begin_dt = spline_dt->value(breaks(0));
+  Eigen::VectorXd end_dt = spline_dt->value(breaks(breaks.size() - 1));
+
+  Eigen::VectorXd begin_ddt = spline_ddt->value(breaks(0));
+  Eigen::VectorXd end_ddt = spline_ddt->value(breaks(breaks.size() - 1));
+
+
+  Eigen::VectorXd dt_diff = end_dt - begin_dt;
+  Eigen::VectorXd ddt_diff = end_ddt - begin_ddt;
+
+  EXPECT_TRUE(dt_diff.lpNorm<Eigen::Infinity>() < 1e-8);
+  EXPECT_TRUE(ddt_diff.lpNorm<Eigen::Infinity>() < 1e-8);
+
 }
 
 GTEST_TEST(testPiecewisePolynomial, AllTests


### PR DESCRIPTION
Adds the option for cubic splines to have continuous 1st and 2nd derivatives between the end of the last segment and the beginning of the first segment. This is sometimes called a "periodic" end condition.

By default, if the derivatives of the first and last nodes are not user-provided, the 3rd derivatives are made continuous between 1st and 2nd segments and the last and (last - 1) segments. This is sometimes called the "not-a-knot" end condition.

This PR adds a flag to switch between the not-a-knot and periodic end conditions.

Fixes #9120.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9150)
<!-- Reviewable:end -->
