### PR TITLE
Optimized Multilane RoadCurve computations.

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -55,6 +55,7 @@ drake_cc_library(
         "//math:geometric_transform",
         "//math:saturate",
         "//systems/analysis:antiderivative_function",
+        "//systems/analysis:scalar_dense_output",
         "//systems/analysis:scalar_initial_value_problem",
     ],
 )

--- a/automotive/maliput/multilane/lane.cc
+++ b/automotive/maliput/multilane/lane.cc
@@ -35,13 +35,10 @@ optional<api::LaneEnd> Lane::DoGetDefaultBranch(
   return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
 }
 
-
-double Lane::do_length() const { return road_curve_->CalcSFromP(1., r0_); }
-
 api::GeoPosition Lane::DoToGeoPosition(
     const api::LanePosition& lane_pos) const {
   // Recover parameter p from arc-length position s.
-  const double p = road_curve_->CalcPFromS(lane_pos.s(), r0_);
+  const double p = p_from_s_at_r0_(lane_pos.s());
   const Vector3<double> xyz =
       road_curve_->W_of_prh(p, lane_pos.r() + r0_, lane_pos.h());
   return {xyz.x(), xyz.y(), xyz.z()};
@@ -49,7 +46,7 @@ api::GeoPosition Lane::DoToGeoPosition(
 
 
 api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
-  const double p = road_curve_->CalcPFromS(lane_pos.s(), r0_);
+  const double p = p_from_s_at_r0_(lane_pos.s());
   const Rot3 rotation =
       road_curve_->Orientation(p, lane_pos.r() + r0_, lane_pos.h());
   return api::Rotation::FromRpy(rotation.roll(), rotation.pitch(),
@@ -60,7 +57,7 @@ api::Rotation Lane::DoGetOrientation(const api::LanePosition& lane_pos) const {
 api::LanePosition Lane::DoEvalMotionDerivatives(
     const api::LanePosition& position,
     const api::IsoLaneVelocity& velocity) const {
-  const double p = road_curve_->CalcPFromS(position.s(), r0_);
+  const double p = p_from_s_at_r0_(position.s());
   const double r = position.r() + r0_;
   const double h = position.h();
   const Rot3 R = road_curve_->Rabg_of_p(p);
@@ -96,8 +93,7 @@ api::LanePosition Lane::DoToLanePosition(
   // coordinate because of the offset.
   const V3 lane_position_in_segment_curve_frame = road_curve_->ToCurveFrame(
       geo_position.xyz(), r_min, r_max, elevation_bounds_);
-  const double s = road_curve_->CalcSFromP(
-      lane_position_in_segment_curve_frame[0], r0_);
+  const double s = s_from_p_at_r0_(lane_position_in_segment_curve_frame[0]);
   const api::LanePosition lane_position = api::LanePosition(
       s,
       lane_position_in_segment_curve_frame[1] - r0_,

--- a/automotive/maliput/multilane/lane.h
+++ b/automotive/maliput/multilane/lane.h
@@ -64,6 +64,9 @@ class Lane : public api::Lane {
     DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
     DRAKE_DEMAND(lane_bounds_.max() <= driveable_bounds_.max());
     DRAKE_DEMAND(road_curve != nullptr);
+    s_from_p_at_r0_ = road_curve_->OptimizeCalcSFromP(r0_);
+    p_from_s_at_r0_ = road_curve_->OptimizeCalcPFromS(r0_);
+    lane_length_ = s_from_p_at_r0_(1.0);
   }
 
   // TODO(maddog-tri)  Allow superelevation to have a center-of-rotation
@@ -123,7 +126,7 @@ class Lane : public api::Lane {
   optional<api::LaneEnd> DoGetDefaultBranch(
       const api::LaneEnd::Which which_end) const override;
 
-  double do_length() const override;
+  double do_length() const override { return lane_length_; }
 
   api::RBounds do_lane_bounds(double) const override { return lane_bounds_; }
 
@@ -161,6 +164,10 @@ class Lane : public api::Lane {
   const api::HBounds elevation_bounds_;
   const RoadCurve* road_curve_{};
   const double r0_;
+
+  std::function<double(double)> s_from_p_at_r0_;
+  std::function<double(double)> p_from_s_at_r0_;
+  double lane_length_;
 };
 
 

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -212,7 +212,8 @@ std::function<double(double)> RoadCurve::OptimizeCalcPFromS(double r) const {
       p_from_s_ivp_->DenseSolve(full_length, values)};
     DRAKE_DEMAND(dense_output->start_time() <= 0.);
     DRAKE_DEMAND(dense_output->end_time() >= full_length);
-    return [dense_output, full_length, absolute_tolerance] (double s) -> double {
+    return [dense_output, full_length,
+            absolute_tolerance] (double s) -> double {
       // Saturates s to lie within the [0., full_length] interval.
       const double saturated_s = std::min(std::max(s, 0.), full_length);
       DRAKE_THROW_UNLESS(std::abs(saturated_s - s) < absolute_tolerance);

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -141,8 +141,8 @@ class RoadCurve {
   /// planar reference curve.
   /// @return A function that relates parametric position p along the reference
   ///         curve to longitudinal position s at the specified parallel curve,
-  ///         defined for all p between 0 and 1 (and throwing for any given value
-  ///         outside this interval).
+  ///         defined for all p between 0 and 1 (and throwing for any given
+  ///         value outside this interval).
   /// @throw std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   std::function<double(double)> OptimizeCalcSFromP(double r) const;
@@ -319,14 +319,6 @@ class RoadCurve {
   // @param r Lateral offset of the reference curve over the z = 0 plane.
   // @return The minimum radius of curvature.
   virtual double CalcMinimumRadiusAtOffset(double r) const = 0;
-
-  // Computes the parametric position p along the reference curve corresponding
-  // to longitudinal position (in path-length) `s` along a parallel curve
-  // laterally offset by `r` from the reference curve using numerical methods.
-  // @return The parametric position p along an offset of the reference curve.
-  // @throw std::runtime_error When `r` makes the radius of curvature be a non
-  //                           positive number.
-  double CalcPFromS(double s, double r) const;
 
   // Computes the path length integral in the interval of the parameter [0; p]
   // and along a parallel curve laterally offset by `r` the planar reference

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -130,7 +130,8 @@ class RoadCurve {
   /// @return A function that relates longitudinal position `s` at the specified
   ///         parallel curve to parametric position p along the reference curve,
   ///         defined for all `s` values between 0 and the total path length of
-  ///         the parallel curve.
+  ///         the parallel curve (and throwing for any given value outside this
+  ///         interval).
   /// @throw std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   std::function<double(double)> OptimizeCalcPFromS(double r) const;
@@ -140,7 +141,8 @@ class RoadCurve {
   /// planar reference curve.
   /// @return A function that relates parametric position p along the reference
   ///         curve to longitudinal position s at the specified parallel curve,
-  ///         defined for all p between 0 and 1.
+  ///         defined for all p between 0 and 1 (and throwing for any given value
+  ///         outside this interval).
   /// @throw std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   std::function<double(double)> OptimizeCalcSFromP(double r) const;
@@ -379,6 +381,9 @@ class RoadCurve {
   CubicPolynomial superelevation_;
   // A policy to guide computations in terms of speed and accuracy.
   ComputationPolicy computation_policy_;
+
+  // Relative tolerance for numerical integrators.
+  double relative_tolerance_;
   // The inverse arc length IVP, or the parameter p as a function of the
   // arc length s.
   std::unique_ptr<systems::ScalarInitialValueProblem<double>> p_from_s_ivp_;

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -13,7 +13,6 @@
 #include "drake/common/unused.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/systems/analysis/antiderivative_function.h"
-#include "drake/systems/analysis/scalar_dense_output.h"
 #include "drake/systems/analysis/scalar_initial_value_problem.h"
 
 namespace drake {
@@ -125,18 +124,9 @@ class RoadCurve {
     return computation_policy_;
   }
 
-  /// Computes the parametric position p along the reference curve corresponding
-  /// to longitudinal position (in path-length) `s` along a parallel curve
-  /// laterally offset by `r` from the reference curve.
-  /// @return The parametric position p along an offset of the reference curve.
-  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
-  ///                           positive number.
-  double CalcPFromS(double s, double r) const;
-
   /// Optimizes the computation of the parametric position p along the reference
   /// curve from the longitudinal position (in path-length) `s` along a parallel
   /// curve laterally offset by `r` from the reference curve.
-  /// @see CalcPFromS(double, double)
   /// @return A function that relates longitudinal position `s` at the specified
   ///         parallel curve to parametric position p along the reference curve,
   ///         defined for all `s` values between 0 and the total path length of
@@ -145,19 +135,9 @@ class RoadCurve {
   ///                           positive number.
   std::function<double(double)> OptimizeCalcPFromS(double r) const;
 
-  /// Computes the path length integral in the interval of the parameter [0; p]
-  /// and along a parallel curve laterally offset by `r` the planar reference
-  /// curve.
-  /// @return The path length integral of the curve composed with the elevation
-  /// polynomial.
-  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
-  ///                           positive number.
-  double CalcSFromP(double p, double r) const;
-
   /// Optimizes the computation of path length integral in the interval of the
   /// parameter [0; p] and along a parallel curve laterally offset by `r` the
   /// planar reference curve.
-  /// @see CalcSFromP(double, double)
   /// @return A function that relates parametric position p along the reference
   ///         curve to longitudinal position s at the specified parallel curve,
   ///         defined for all p between 0 and 1.
@@ -337,6 +317,23 @@ class RoadCurve {
   // @param r Lateral offset of the reference curve over the z = 0 plane.
   // @return The minimum radius of curvature.
   virtual double CalcMinimumRadiusAtOffset(double r) const = 0;
+
+  // Computes the parametric position p along the reference curve corresponding
+  // to longitudinal position (in path-length) `s` along a parallel curve
+  // laterally offset by `r` from the reference curve using numerical methods.
+  // @return The parametric position p along an offset of the reference curve.
+  // @throw std::runtime_error When `r` makes the radius of curvature be a non
+  //                           positive number.
+  double CalcPFromS(double s, double r) const;
+
+  // Computes the path length integral in the interval of the parameter [0; p]
+  // and along a parallel curve laterally offset by `r` the planar reference
+  // curve using numerical methods.
+  // @return The path length integral of the curve composed with the elevation
+  // polynomial.
+  // @throw std::runtime_error When `r` makes the radius of curvature be a non
+  //                           positive number.
+  double CalcSFromP(double p, double r) const;
 
   // TODO(hidmic): Fast, analytical methods and the conditions in which these
   // are expected to hold were tailored for the currently available

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <utility>
 
@@ -12,6 +13,7 @@
 #include "drake/common/unused.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/systems/analysis/antiderivative_function.h"
+#include "drake/systems/analysis/scalar_dense_output.h"
 #include "drake/systems/analysis/scalar_initial_value_problem.h"
 
 namespace drake {
@@ -131,6 +133,18 @@ class RoadCurve {
   ///                           positive number.
   double CalcPFromS(double s, double r) const;
 
+  /// Optimizes the computation of the parametric position p along the reference
+  /// curve from the longitudinal position (in path-length) `s` along a parallel
+  /// curve laterally offset by `r` from the reference curve.
+  /// @see CalcPFromS(double, double)
+  /// @return A function that relates longitudinal position `s` at the specified
+  ///         parallel curve to parametric position p along the reference curve,
+  ///         defined for all `s` values between 0 and the total path length of
+  ///         the parallel curve.
+  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
+  ///                           positive number.
+  std::function<double(double)> OptimizeCalcPFromS(double r) const;
+
   /// Computes the path length integral in the interval of the parameter [0; p]
   /// and along a parallel curve laterally offset by `r` the planar reference
   /// curve.
@@ -139,6 +153,17 @@ class RoadCurve {
   /// @throw std::runtime_error When `r` makes the radius of curvature be a non
   ///                           positive number.
   double CalcSFromP(double p, double r) const;
+
+  /// Optimizes the computation of path length integral in the interval of the
+  /// parameter [0; p] and along a parallel curve laterally offset by `r` the
+  /// planar reference curve.
+  /// @see CalcSFromP(double, double)
+  /// @return A function that relates parametric position p along the reference
+  ///         curve to longitudinal position s at the specified parallel curve,
+  ///         defined for all p between 0 and 1.
+  /// @throw std::runtime_error When `r` makes the radius of curvature be a non
+  ///                           positive number.
+  std::function<double(double)> OptimizeCalcSFromP(double r) const;
 
   /// Computes the reference curve.
   /// @param p The reference curve parameter.

--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -71,7 +71,9 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
                          kLinearTolerance, kScaleLength, kComputationPolicy);
   // Checks the length.
   EXPECT_NEAR(dut.p_scale(), kDTheta * kRadius, kVeryExact);
-  EXPECT_NEAR(dut.CalcSFromP(1., kNoOffset), kDTheta * kRadius, kVeryExact);
+  std::function<double(double)> s_from_p_at_r =
+      dut.OptimizeCalcSFromP(kNoOffset);
+  EXPECT_NEAR(s_from_p_at_r(1.), kDTheta * kRadius, kVeryExact);
   // Checks the evaluation of xy at different values over the reference curve.
   EXPECT_TRUE(CompareMatrices(
       dut.xy_of_p(0.0), kCenter + Vector2<double>(kRadius * std::cos(kTheta0),
@@ -250,18 +252,16 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
                               kComputationPolicy);
   EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kRadius * kDTheta);
   // Checks that functions throw when lateral offset is exceeded.
-  EXPECT_THROW(flat_dut.CalcPFromS(0., kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.CalcPFromS(0., 2.0 * kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.CalcSFromP(0., kRadius), std::runtime_error);
-  EXPECT_THROW(flat_dut.CalcSFromP(0., 2.0 * kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(2.0 * kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius), std::runtime_error);
+  EXPECT_THROW(flat_dut.OptimizeCalcSFromP(2.0 * kRadius), std::runtime_error);
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
     std::function<double(double)> p_from_s_at_r =
         flat_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
-      const double s = p * (kRadius - r) * kDTheta;
-      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(s, r), p);
-      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(p * (kRadius - r) * kDTheta), p);
     }
   }
   // Evaluates the path length integral for different offset values.
@@ -269,9 +269,7 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
     std::function<double(double)> s_from_p_at_r =
         flat_dut.OptimizeCalcSFromP(r);
     for (double p : p_vector) {
-      const double s = p * (kRadius - r) * kDTheta;
-      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), s);
-      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
+      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), p * (kRadius - r) * kDTheta);
     }
   }
 
@@ -292,9 +290,7 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
     for (double p : p_vector) {
       const double s = p * kRadius * kDTheta *
           std::sqrt(std::pow((kRadius - r) / kRadius, 2.) + slope * slope);
-      EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s , r), p);
       EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
-      EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
       EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
     }
   }

--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -256,14 +256,22 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   EXPECT_THROW(flat_dut.CalcSFromP(0., 2.0 * kRadius), std::runtime_error);
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
+    std::function<double(double)> p_from_s_at_r =
+        flat_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(p * (kRadius - r) * kDTheta, r), p);
+      const double s = p * (kRadius - r) * kDTheta;
+      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(s, r), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
     }
   }
   // Evaluates the path length integral for different offset values.
   for (double r : r_vector) {
+    std::function<double(double)> s_from_p_at_r =
+        flat_dut.OptimizeCalcSFromP(r);
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), p * (kRadius - r) * kDTheta);
+      const double s = p * (kRadius - r) * kDTheta;
+      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), s);
+      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
     }
   }
 
@@ -277,11 +285,17 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   // Evaluates inverse function and path length integral for different values of
   // p and r lateral offsets.
   for (double r : r_vector) {
+    std::function<double(double)> s_from_p_at_r =
+        elevated_dut.OptimizeCalcSFromP(r);
+    std::function<double(double)> p_from_s_at_r =
+        elevated_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
       const double s = p * kRadius * kDTheta *
           std::sqrt(std::pow((kRadius - r) / kRadius, 2.) + slope * slope);
       EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s , r), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
       EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
+      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
     }
   }
 }

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -141,9 +141,7 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
     std::function<double(double)> p_from_s_at_r =
         flat_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
-      const double s = p * kDirection.norm();
-      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(s, r), p);
-      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(p * kDirection.norm()), p);
     }
   }
   // Evaluates the path length integral for different offset values.
@@ -151,7 +149,6 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
     std::function<double(double)> s_from_p_at_r =
         flat_dut.OptimizeCalcSFromP(r);
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), p * kDirection.norm());
       EXPECT_DOUBLE_EQ(s_from_p_at_r(p), p * kDirection.norm());
     }
   }
@@ -172,9 +169,7 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
         elevated_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
       const double s = p * kDirection.norm() * std::sqrt(1. + slope * slope);
-      EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s, r), p);
       EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
-      EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
       EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
     }
   }

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -138,14 +138,21 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kDirection.norm());
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
+    std::function<double(double)> p_from_s_at_r =
+        flat_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
-      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(p * kDirection.norm(), r), p);
+      const double s = p * kDirection.norm();
+      EXPECT_DOUBLE_EQ(flat_dut.CalcPFromS(s, r), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
     }
   }
   // Evaluates the path length integral for different offset values.
   for (double r : r_vector) {
+    std::function<double(double)> s_from_p_at_r =
+        flat_dut.OptimizeCalcSFromP(r);
     for (double p : p_vector) {
       EXPECT_DOUBLE_EQ(flat_dut.CalcSFromP(p, r), p * kDirection.norm());
+      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), p * kDirection.norm());
     }
   }
 
@@ -159,10 +166,16 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   // Evaluates inverse function and path length integral for different values of
   // p and r lateral offsets.
   for (double r : r_vector) {
+    std::function<double(double)> s_from_p_at_r =
+        elevated_dut.OptimizeCalcSFromP(r);
+    std::function<double(double)> p_from_s_at_r =
+        elevated_dut.OptimizeCalcPFromS(r);
     for (double p : p_vector) {
       const double s = p * kDirection.norm() * std::sqrt(1. + slope * slope);
       EXPECT_DOUBLE_EQ(elevated_dut.CalcPFromS(s, r), p);
+      EXPECT_DOUBLE_EQ(p_from_s_at_r(s), p);
       EXPECT_DOUBLE_EQ(elevated_dut.CalcSFromP(p, r), s);
+      EXPECT_DOUBLE_EQ(s_from_p_at_r(p), s);
     }
   }
 }

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -38,11 +38,21 @@ class MultilaneLineRoadCurveTest : public ::testing::Test {
 TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
   const LineRoadCurve dut(kOrigin, kDirection, zp, zp, kLinearTolerance,
                           kScaleLength, kComputationPolicy);
-  // Checks the length.
-  EXPECT_NEAR(dut.p_scale(),
-              std::sqrt(kDirection.x() * kDirection.x() +
-                        kDirection.y() * kDirection.y()),
-              kVeryExact);
+  // Checks curve length computations.
+  const double kExpectedLength = std::sqrt(kDirection.x() * kDirection.x() +
+                                           kDirection.y() * kDirection.y());
+  EXPECT_NEAR(dut.p_scale(), kExpectedLength, kVeryExact);
+  std::function<double(double)> s_from_p_at_r =
+      dut.OptimizeCalcSFromP(kNoOffset);
+  const double length = s_from_p_at_r(1.);
+  EXPECT_NEAR(length, kExpectedLength, kVeryExact);
+  // Checks that both `s` and `p` bounds are enforced on
+  // mapping evaluation.
+  std::function<double(double)> p_from_s_at_r =
+      dut.OptimizeCalcPFromS(kNoOffset);
+  EXPECT_THROW(s_from_p_at_r(2.), std::runtime_error);
+  EXPECT_THROW(p_from_s_at_r(2. * length), std::runtime_error);
+
   // Check the evaluation of xy at different p values.
   EXPECT_TRUE(
       CompareMatrices(dut.xy_of_p(0.0), kOrigin, kVeryExact));

--- a/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
@@ -54,7 +54,7 @@ GTEST_TEST(BruteForceIntegralTest, ArcRoadCurvePathLength) {
   EXPECT_NEAR(maximum_step, path_length_zero_order, kAccuracy);
 
   int k_order_hint = 0;
-  const double tolerance = .01 * rc.CalcSFromP(1., 0.);
+  const double tolerance = .01 * rc.OptimizeCalcSFromP(0.)(1.);
   const double path_length_adaptive_approx =
       test::AdaptiveBruteForcePathLengthIntegral(
           rc, kP0, kP1, kR, kH, tolerance, &k_order_hint);
@@ -65,44 +65,8 @@ GTEST_TEST(BruteForceIntegralTest, ArcRoadCurvePathLength) {
 class RoadCurveAccuracyTest
     : public ::testing::TestWithParam<std::shared_ptr<RoadCurve>> {};
 
-// Checks that path length computations are within tolerance.
-TEST_P(RoadCurveAccuracyTest, PathLengthComputationAccuracy) {
-  const double kMinimumP = 0.;
-  const double kMaximumP = 1.;
-  const double kPStep = 0.2;
-
-  const double kMinimumR = -5.0;
-  const double kMaximumR = 5.0;
-  const double kRStep = 2.5;
-
-  const double kH = 0.0;
-
-  std::shared_ptr<RoadCurve> road_curve = GetParam();
-  const double kTolerance = road_curve->linear_tolerance()
-                            / road_curve->scale_length();
-  for (double r = kMinimumR; r <= kMaximumR; r += kRStep) {
-    int k_order = 0;
-    for (double p = kMinimumP; p <= kMaximumP; p += kPStep) {
-      const double k_order_s_approximation =
-          test::AdaptiveBruteForcePathLengthIntegral(
-              *road_curve, kMinimumP, p, r, kH,
-              road_curve->linear_tolerance(), &k_order);
-      const double relative_error =
-          (k_order_s_approximation != 0.0) ?
-          (road_curve->CalcSFromP(p, r) - k_order_s_approximation) /
-          k_order_s_approximation : road_curve->CalcSFromP(p, r);
-      EXPECT_LE(relative_error, kTolerance) << fmt::format(
-          "Path length estimation with a tolerance of {} "
-          "m failed at p = {}, r = {}m, h = {}m with "
-          "{} for elevation and {} for superelevation",
-          road_curve->linear_tolerance(), p, r, kH, road_curve->elevation(),
-          road_curve->superelevation());
-    }
-  }
-}
-
 // Checks that optimized path length computations are within tolerance.
-TEST_P(RoadCurveAccuracyTest, OptimizedPathLengthComputationAccuracy) {
+TEST_P(RoadCurveAccuracyTest, PathLengthComputationAccuracy) {
   const double kMinimumP = 0.;
   const double kMaximumP = 1.;
   const double kPStep = 0.2;
@@ -129,12 +93,12 @@ TEST_P(RoadCurveAccuracyTest, OptimizedPathLengthComputationAccuracy) {
           (k_order_s_approximation != 0.0) ?
           (s_from_p_at_r(p) - k_order_s_approximation) /
           k_order_s_approximation : s_from_p_at_r(p);
-      EXPECT_LE(relative_error, kTolerance)
-          << "Optimized Path length estimation with a tolerance of "
-          << road_curve->linear_tolerance() << " m failed"
-          << " at p = " << p << ", r = " << r << "m, h = " << kH
-          << "m with " << road_curve->elevation() << " for elevation and "
-          << road_curve->superelevation() << " for superelevation";
+      EXPECT_LE(relative_error, kTolerance) << fmt::format(
+          "Path length estimation with a tolerance of {} "
+          "m failed at p = {}, r = {} m, h = {} m with "
+          "{} for elevation and {} for superelevation",
+          road_curve->linear_tolerance(), p, r, kH,
+          road_curve->elevation(), road_curve->superelevation());
     }
   }
 }

--- a/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
+++ b/automotive/maliput/multilane/test/multilane_road_curve_accuracy_test.cc
@@ -66,7 +66,7 @@ class RoadCurveAccuracyTest
     : public ::testing::TestWithParam<std::shared_ptr<RoadCurve>> {};
 
 // Checks that path length computations are within tolerance.
-TEST_P(RoadCurveAccuracyTest, PathLengthAccuracy) {
+TEST_P(RoadCurveAccuracyTest, PathLengthComputationAccuracy) {
   const double kMinimumP = 0.;
   const double kMaximumP = 1.;
   const double kPStep = 0.2;
@@ -97,6 +97,44 @@ TEST_P(RoadCurveAccuracyTest, PathLengthAccuracy) {
           "{} for elevation and {} for superelevation",
           road_curve->linear_tolerance(), p, r, kH, road_curve->elevation(),
           road_curve->superelevation());
+    }
+  }
+}
+
+// Checks that optimized path length computations are within tolerance.
+TEST_P(RoadCurveAccuracyTest, OptimizedPathLengthComputationAccuracy) {
+  const double kMinimumP = 0.;
+  const double kMaximumP = 1.;
+  const double kPStep = 0.2;
+
+  const double kMinimumR = -5.0;
+  const double kMaximumR = 5.0;
+  const double kRStep = 2.5;
+
+  const double kH = 0.0;
+
+  std::shared_ptr<RoadCurve> road_curve = GetParam();
+  const double kTolerance = road_curve->linear_tolerance()
+                            / road_curve->scale_length();
+  for (double r = kMinimumR; r <= kMaximumR; r += kRStep) {
+    int k_order = 0;
+    std::function<double(double)> s_from_p_at_r =
+        road_curve->OptimizeCalcSFromP(r);
+    for (double p = kMinimumP; p <= kMaximumP; p += kPStep) {
+      const double k_order_s_approximation =
+          test::AdaptiveBruteForcePathLengthIntegral(
+              *road_curve, kMinimumP, p, r, kH,
+              road_curve->linear_tolerance(), &k_order);
+      const double relative_error =
+          (k_order_s_approximation != 0.0) ?
+          (s_from_p_at_r(p) - k_order_s_approximation) /
+          k_order_s_approximation : s_from_p_at_r(p);
+      EXPECT_LE(relative_error, kTolerance)
+          << "Optimized Path length estimation with a tolerance of "
+          << road_curve->linear_tolerance() << " m failed"
+          << " at p = " << p << ", r = " << r << "m, h = " << kH
+          << "m with " << road_curve->elevation() << " for elevation and "
+          << road_curve->superelevation() << " for superelevation";
     }
   }
 }


### PR DESCRIPTION
This pull requests leverages dense output support, as introduced by #8949, #8950, #8951 and #8952, to reduce the computational cost involved in computing longitudinal coordinate `s` from parametric position `p` and vice versa, in exchange for larger memory footprints. This results in an overall reduction of the cost of performing `Lane` queries in Multilane implementation of Maliput.

Built on top of #8952, and thus due for rebase once said PR reaches master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9155)
<!-- Reviewable:end -->
