### PR TITLE
Improve RigidTransform::GetMaximumAbsoluteDifference() to avoid throwing exception.  New constructor and tests.

### DIFF
--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -55,13 +55,20 @@ class RigidTransform {
   /// so unit vectors Ax = Bx, Ay = By, Az = Bz and point Ao is coincident with
   /// Bo.  Hence, the constructed %RigidTransform contains an identity
   /// RotationMatrix and a zero position vector.
-  RigidTransform() { SetIdentity(); }
+  // @internal The default RotationMatrix constructor is an identity matrix.
+  RigidTransform() { set_translation(Vector3<T>::Zero()); }
 
   /// Constructs a %RigidTransform from a rotation matrix and a position vector.
   /// @param[in] R rotation matrix relating frames A and B (e.g., `R_AB`).
   /// @param[in] p position vector from frame A's origin to frame B's origin,
   /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
   RigidTransform(const RotationMatrix<T>& R, const Vector3<T>& p) { set(R, p); }
+
+  /// Constructs a %RigidTransform with an identity RotationMatrix and a given
+  /// position vector 'p'.
+  /// @param[in] p position vector from frame A's origin to frame B's origin,
+  /// expressed in frame A.  In monogram notation p is denoted `p_AoBo_A`.
+  explicit RigidTransform(const Vector3<T>& p) {  set_translation(p); }
 
   /// Constructs a %RigidTransform from an Eigen Isometry3.
   /// @param[in] pose Isometry3 that contains an allegedly valid rotation matrix
@@ -155,6 +162,19 @@ class RigidTransform {
     pose.template topLeftCorner<3, 3>() = rotation().matrix();
     pose.template topRightCorner<3, 1>() = translation();
     pose.row(3) = Vector4<T>(0, 0, 0, 1);
+    return pose;
+  }
+
+  /// Returns the 3x4 matrix associated with this %RigidTransform, i.e., X_AB.
+  /// <pre>
+  ///  ┌                ┐
+  ///  │ R_AB  p_AoBo_A │
+  ///  └                ┘
+  /// </pre>
+  Eigen::Matrix<T, 3, 4> GetAsMatrix34() const {
+    Eigen::Matrix<T, 3, 4> pose;
+    pose.template topLeftCorner<3, 3>() = rotation().matrix();
+    pose.template topRightCorner<3, 1>() = translation();
     return pose;
   }
 
@@ -255,16 +275,22 @@ class RigidTransform {
     return GetMaximumAbsoluteDifference(other) <= tolerance;
   }
 
+  /// Returns true if `this` is exactly equal to `other`.
+  /// @param[in] other %RigidTransform to compare to `this`.
+  /// @returns `true` if each element of `this` is exactly equal to the
+  /// corresponding element of `other`.
+  Bool<T> IsExactlyEqualTo(const RigidTransform<T>& other) const {
+    return rotation().IsExactlyEqualTo(other.rotation()) &&
+           translation() == other.translation();
+  }
+
   /// Computes the infinity norm of `this` - `other` (i.e., the maximum absolute
   /// value of the difference between the elements of `this` and `other`).
   /// @param[in] other %RigidTransform to subtract from `this`.
   /// @returns ‖`this` - `other`‖∞
-  // @internal The last line of this method throws an exception if T is a
-  // symbolic::Expression and there are free variables in `this` or `other`.
   T GetMaximumAbsoluteDifference(const RigidTransform<T>& other) const {
-    const T R_difference = R_AB_.GetMaximumAbsoluteDifference(other.rotation());
-    const T p_difference = GetMaximumAbsoluteTranslationDifference(other);
-    return R_difference > p_difference ? R_difference : p_difference;
+    const Eigen::Matrix<T, 3, 4> diff = GetAsMatrix34() - other.GetAsMatrix34();
+    return diff.template lpNorm<Eigen::Infinity>();
   }
 
   /// Returns the maximum absolute value of the difference in the position
@@ -287,6 +313,7 @@ class RigidTransform {
   friend class RigidTransform;
 
   // Rotation matrix relating two frames, e.g. frame A and frame B.
+  // The default constructor for R_AB_ is an identity matrix.
   RotationMatrix<T> R_AB_;
 
   // Position vector from A's origin Ao to B's origin Bo, expressed in A.

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -121,14 +121,23 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorAndSet) {
 #endif
 }
 
-// Tests getting a 4x4 matrix from a RigidTransform.
-GTEST_TEST(RigidTransform, Matrix44) {
+// Tests constructing a RigidTransform from just a position vector.
+GTEST_TEST(RigidTransform, RigidTransformConstructorFromPositionVector) {
+  const Vector3<double> p(4, 5, 6);
+  const RigidTransform<double> X(p);
+  EXPECT_TRUE(ExtractBoolOrThrow(X.rotation().IsExactlyIdentity()));
+  EXPECT_TRUE(X.translation() == p);
+}
+
+// Tests getting a 4x4 and 3x4 matrix from a RigidTransform.
+GTEST_TEST(RigidTransform, GetAsMatrices) {
   const RotationMatrix<double> R = GetRotationMatrixB();
+  const Matrix3d m = R.matrix();
   const Vector3<double> p(4, 5, 6);
   const RigidTransform<double> X(R, p);
-  const Matrix4<double> Y = X.GetAsMatrix4();
-  const Matrix3d m = R.matrix();
 
+  // Test GetAsMatrix4()
+  const Matrix4<double> Y = X.GetAsMatrix4();
   EXPECT_EQ(Y(0, 0), m(0, 0));
   EXPECT_EQ(Y(0, 1), m(0, 1));
   EXPECT_EQ(Y(0, 2), m(0, 2));
@@ -145,6 +154,21 @@ GTEST_TEST(RigidTransform, Matrix44) {
   EXPECT_EQ(Y(3, 1), 0);
   EXPECT_EQ(Y(3, 2), 0);
   EXPECT_EQ(Y(3, 3), 1);
+
+  // Test GetAsMatrix34()
+  const Eigen::Matrix<double, 3, 4> Z = X.GetAsMatrix34();
+  EXPECT_EQ(Z(0, 0), m(0, 0));
+  EXPECT_EQ(Z(0, 1), m(0, 1));
+  EXPECT_EQ(Z(0, 2), m(0, 2));
+  EXPECT_EQ(Z(0, 3), p(0));
+  EXPECT_EQ(Z(1, 0), m(1, 0));
+  EXPECT_EQ(Z(1, 1), m(1, 1));
+  EXPECT_EQ(Z(1, 2), m(1, 2));
+  EXPECT_EQ(Z(1, 3), p(1));
+  EXPECT_EQ(Z(2, 0), m(2, 0));
+  EXPECT_EQ(Z(2, 1), m(2, 1));
+  EXPECT_EQ(Z(2, 2), m(2, 2));
+  EXPECT_EQ(Z(2, 3), p(2));
 }
 
 // Tests set/get a RigidTransform with an Isometry3.
@@ -335,10 +359,15 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformSimpleTests) {
   test_Bool = X.IsIdentityToEpsilon(kEpsilon);
   EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
 
-  // Test IsNearlyEqualTo() nominally works for symbolic::Expression.
+  // Test IsExactlyEqualTo() nominally works for symbolic::Expression.
   const RigidTransform<symbolic::Expression>& X_built_in_identity =
       RigidTransform<symbolic::Expression>::Identity();
+  test_Bool = X.IsExactlyEqualTo(X_built_in_identity);
+  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
+
+  // Test IsNearlyEqualTo() nominally works for symbolic::Expression.
   test_Bool = X.IsNearlyEqualTo(X_built_in_identity, kEpsilon);
+  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
 
   // Now perform the same tests on a non-identity transform.
   const Vector3<symbolic::Expression> p_symbolic(1, 2, 3);
@@ -350,6 +379,10 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformSimpleTests) {
 
   // Test IsIdentityToEpsilon() works with symbolic::Expression.
   test_Bool = X.IsIdentityToEpsilon(kEpsilon);
+  EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
+
+  // Test IsExactlyEqualTo() works for symbolic::Expression.
+  test_Bool = X.IsExactlyEqualTo(X_built_in_identity);
   EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
 
   // Test IsNearlyEqualTo() works for symbolic::Expression.
@@ -368,8 +401,8 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
   const Vector3<symbolic::Expression> p_symbolic(0, 0, 0);
   const RigidTransform<symbolic::Expression> X_symbolic(R_symbolic, p_symbolic);
 
-  // The next tests should throw exceptions since the tests are inconclusive
-  // because the value of x is unknown.
+  // The next four tests should throw exceptions since the tests are
+  // inconclusive because the value of x is unknown.
   Bool<symbolic::Expression> test_Bool = X_symbolic.IsExactlyIdentity();
   EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
 
@@ -378,11 +411,11 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
 
   const RigidTransform<symbolic::Expression>& X_identity =
       RigidTransform<symbolic::Expression>::Identity();
-  // The next line throws an exception in GetMaximumAbsoluteDifference() which
-  // requires a C++ bool (not drake Bool) to properly return.
-  // GetMaximumAbsoluteDifference() is called by IsNearlyEqual().
-  EXPECT_THROW(test_Bool = X_symbolic.IsNearlyEqualTo(X_identity, kEpsilon),
-               std::runtime_error);
+  test_Bool = X_symbolic.IsExactlyEqualTo(X_identity);
+  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
+
+  test_Bool = X_symbolic.IsNearlyEqualTo(X_identity, kEpsilon);
+  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
 }
 
 }  // namespace


### PR DESCRIPTION
Improve RigidTransform::GetMaximumAbsoluteDifference() to avoid throwing exception early in connection with symbolic::Expression.  Add new constructor and method to facilitate replacing Isometry3.