### PR TITLE
Remove unused parameter warnings due to protobuf version in Ubuntu 18.04

### DIFF
--- a/tools/skylark/drake_proto.bzl
+++ b/tools/skylark/drake_proto.bzl
@@ -52,6 +52,7 @@ def drake_cc_proto_library(
             "@com_google_protobuf//:protobuf",
             "@drake//common/proto:protobuf_ubsan_fixup",
         ],
+        copts = ["-Wno-unused-parameter"],
         **kwargs
     )
 


### PR DESCRIPTION
Without this commit, error messages such as the one below are visible when compiling
drake with gcc 5 and 6 on Ubuntu 18.04.

error: unused parameter 'deterministic' [-Werror=unused-parameter]
     bool deterministic, ::google::protobuf::uint8* target) const {

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9161)
<!-- Reviewable:end -->
