### PR TITLE
List of welded bodies in MBT

### DIFF
--- a/multibody/multibody_tree/multibody_tree_topology.h
+++ b/multibody/multibody_tree/multibody_tree_topology.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <queue>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -189,6 +190,12 @@ struct MobilizerTopology {
   bool connects_bodies(BodyIndex body1, BodyIndex body2) const {
     return (inboard_body == body1 && outboard_body == body2) ||
            (inboard_body == body2 && outboard_body == body1);
+  }
+
+  /// Returns `true` if this mobilizer topology corresponds to that of a weld
+  /// mobilizer.
+  bool is_weld_mobilizer() const {
+    return num_velocities == 0;
   }
 
   /// Unique index in the set of mobilizers.
@@ -887,6 +894,44 @@ class MultibodyTreeTopology {
     (*path_to_world)[0] = BodyNodeIndex(0);  // Add the world.
   }
 
+  /// This methods creates a list of welded bodies.
+  /// A "welded body" is some connected sub-graph of the tree where the
+  /// connected edges (i.e., mobilizers) are weld mobilizers.
+  /// A welded body may have un-welded children (that is, connected by non-weld
+  /// mobilizers) and those children may be defined as children of arbitrary
+  /// bodies in that welded body sub-graph.
+  /// We represent a welded body as a set of bodies (body indexes), the
+  /// particular order in the set does not matter.
+  /// The list of welded bodies is represented as a vector of these welded
+  /// bodies (each in turn a set of bodies). The order in this vector is not
+  /// relevant and this method does not gurantee any particular ordering.
+  /// However it is guranteed that the first set in this list (element with
+  /// index zero) corresponds to the welded body containing the world body. That
+  /// is, entry zero in the returned vector, contains the set of all bodies
+  /// welded to the world.
+  /// A few more notes:
+  /// - All bodies in the topology are included in one set and one set only.
+  /// - The maximum size of the list equals the number of bodies in the topology
+  ///   (num_bodies()). This corresponds to a topology with no weld mobilizers.
+  /// - The world body is also included to a welded bodies set, and this set is
+  ///   element zero in the returned vector.
+  /// - The minimum size of the list is one. This corresponds to a topology with
+  ///   all bodies welded to the world.
+  std::vector<std::set<BodyIndex>> CreateListOfWeldedBodies() const   {
+    std::vector<std::set<BodyIndex>> welded_bodies;
+    // Reserve the maximum possible of welded bodies (that is, when each body
+    // forms its own welded body) in advance in order to avoid reallocation in
+    // welded_bodies which would case the invalidation of references as we
+    // recursively fill it in.
+    welded_bodies.reserve(num_bodies());
+    welded_bodies.emplace_back(std::set<BodyIndex>{world_index()});
+    // We build the list of welded bodies recursively, starting with the world
+    // body added to the very first welded body in the list.
+    std::set<BodyIndex>& world_body = welded_bodies.back();
+    PartitionWeldedBodiesRecurse(world_index(), &world_body, &welded_bodies);
+    return welded_bodies;
+  }
+
  private:
   // Returns `true` if there is _any_ mobilizer in the multibody tree
   // connecting the frames with indexes `frame` and `frame2`.
@@ -906,6 +951,37 @@ class MultibodyTreeTopology {
       if (mobilizer_topology.connects_bodies(body1, body2)) return true;
     }
     return false;
+  }
+
+  // Helper, recursive, method for CreateListOfWeldedBodies().
+  // This method scans the children of body with parent_index. If a child is
+  // welded to body with parent_index, it gets added to the parent's body welded
+  // body, parent_welded_body. Otherwise a new welded body is created for the
+  // child body and gets added to the list of all welded bodies, welded_bodies.
+  void PartitionWeldedBodiesRecurse(
+      BodyIndex parent_index, std::set<BodyIndex>* parent_welded_body,
+      std::vector<std::set<BodyIndex>>* welded_bodies) const {
+    const BodyTopology& parent = get_body(parent_index);
+    for (BodyIndex child_index : parent.child_bodies) {
+      const BodyTopology& child = get_body(child_index);
+      const MobilizerTopology& child_mobilizer =
+          get_mobilizer(child.inboard_mobilizer);
+      if (child_mobilizer.is_weld_mobilizer()) {
+        // If the child body is welded to the parent body, we then add it to
+        // the parent's body welded body, parent_welded_body. We continue the
+        // recursion down the tree starting at child.
+        parent_welded_body->insert(child_index);
+        PartitionWeldedBodiesRecurse(
+            child_index, parent_welded_body, welded_bodies);
+      } else {
+        // If the child body is not weled to the parent body, then we create a
+        // new welded body to which child is added. We continue the recursion
+        // down the tree starting at child.
+        welded_bodies->emplace_back(std::set<BodyIndex>{child_index});
+        std::set<BodyIndex>& child_group = welded_bodies->back();
+        PartitionWeldedBodiesRecurse(child_index, &child_group, welded_bodies);
+      }
+    }
   }
 
   // is_valid is set to `true` after a successful Finalize().

--- a/multibody/multibody_tree/multibody_tree_topology.h
+++ b/multibody/multibody_tree/multibody_tree_topology.h
@@ -894,18 +894,19 @@ class MultibodyTreeTopology {
     (*path_to_world)[0] = BodyNodeIndex(0);  // Add the world.
   }
 
-  /// Generates a list of sub-graphs containing bodies that are welded together
-  /// (joined by a weld mobilizer). Each sub-graph of welded bodies is
-  /// represented as a set of body indices. By definition, these sub-graphs will
-  /// be disconnected by any non-weld mobilizers that may be inboard or outboard
-  /// of any given body. The first sub-graph will have all of the bodies
-  /// connected to the world; all subsequent sub-graphs will be in no particular
-  /// order.
+  /// This method partitions the tree topology into sub-graphs such that two
+  /// bodies are in the same sub-graph if there is a path between them which
+  /// includes only welded-mobilizer.
+  /// Each sub-graph of welded bodies is represented as a set of body indices.
+  /// By definition, these sub-graphs will be disconnected by any non-weld
+  /// mobilizers that may be inboard or outboard of any given body. The first
+  /// sub-graph will have all of the bodies welded to the world; all
+  /// subsequent sub-graphs will be in no particular order.
   /// A few more notes:
   /// - Each body in the topology is included in one set and one set only.
   /// - The maximum size of the list equals the number of bodies in the topology
   ///   (num_bodies()). This corresponds to a topology with no weld mobilizers.
-  /// - The world body is also included in a welded bodies set, and this set is
+  /// - The world body is also included in a welded-bodies set, and this set is
   ///   element zero in the returned vector.
   /// - The minimum size of the list is one. This corresponds to a topology with
   ///   all bodies welded to the world.
@@ -916,7 +917,7 @@ class MultibodyTreeTopology {
     // welded_bodies which would cause the invalidation of references as we
     // recursively fill it in.
     welded_bodies.reserve(num_bodies());
-    welded_bodies.emplace_back(std::set<BodyIndex>{world_index()});
+    welded_bodies.push_back(std::set<BodyIndex>{world_index()});
     // We build the list of welded bodies recursively, starting with the world
     // body added to the very first welded body in the list.
     std::set<BodyIndex>& bodies_welded_to_world = welded_bodies.back();
@@ -970,7 +971,7 @@ class MultibodyTreeTopology {
         // If the child body is not welded to the parent body, then we create a
         // new welded body to which child is added. We continue the recursion
         // down the tree starting at child.
-        welded_bodies->emplace_back(std::set<BodyIndex>{child_index});
+        welded_bodies->push_back(std::set<BodyIndex>{child_index});
         std::set<BodyIndex>& child_group = welded_bodies->back();
         CreateListOfWeldedBodiesRecurse(child_index,
                                         &child_group,

--- a/multibody/multibody_tree/test/multibody_tree_creation_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_creation_test.cc
@@ -2,6 +2,7 @@
 #include "drake/multibody/multibody_tree/multibody_tree.h"
 /* clang-format on */
 
+#include <algorithm>
 #include <memory>
 #include <set>
 #include <sstream>
@@ -11,6 +12,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
+#include "drake/multibody/multibody_tree/joints/weld_joint.h"
 #include "drake/multibody/multibody_tree/revolute_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
@@ -558,6 +560,158 @@ TEST_F(TreeTopologyTests, KinematicPathToWorld) {
     // Verify the
     EXPECT_EQ(path_to_world[level], expected_node_index);
   }
+}
+
+// Unit test to verify the correctness of
+// MultibodyTreeTopology::CreateListOfWeldedBodies().
+// This test creates a tree with a topology as shown below. Single vertical
+// lines indicate bodies that are connected by a non-weld mobilizer. Double
+// vertical lines indicate bodies that are welded.
+// A "welded body" is defined as some connected sub-graph of the tree where the
+// connected edges (i.e., mobilizers) are weld mobilizers (double vertical lines
+// in the schematic below). According to this definition, welded bodies for the
+// tree below are (see MultibodyTreeTopology::CreateListOfWeldedBodies() for
+// further details on this definition):
+// - Welded body 0: w, l, m, n
+// - Welded body 1: a, b
+// - Welded body 2: c
+// - Welded body 3: d, e, g, f
+// - Welded body 4: i
+// - Welded body 5: j, k
+// - Welded body 6: h
+//
+// In no particular order however, welded body zero contains the world.
+//
+//
+//                      +---+
+//                      | w | (world body)
+//          +-----------+-+-+-----------+-------------+
+//          |             |             |             ║
+//          |             |             |             ║
+//          |             |             |             ║
+//        +-v-+         +-v-+         +-v-+         +-v-+
+//        | a |         | d |         | i |         | l |
+//        +---+      +--+---+--+      +-+-+      +--+---+--+
+//          ║        ║         ║        |        ║         ║
+//          ║        ║         ║        |        ║         ║
+//          ║        ║         ║        |        ║         ║
+//        +-v-+    +-v-+     +-v-+    +-v-+    +-v-+     +-v-+
+//        | b |    | e |     | g |    | j |    | m |     | n |
+//        +---+    +---+     +---+    +-+-+    +---+     +---+
+//         |         ║         |        ║
+//         |         ║         |        ║
+//         |         ║         |        ║
+//       +-v-+     +-v-+     +-v-+    +-v-+
+//       | c |     | f |     | h |    | k |
+//       +---+     +---+     +---+    +-+-+
+//
+// This test verifies MultibodyTreeTopology::CreateListOfWeldedBodies() returns
+// this list of welded bodies.
+GTEST_TEST(WeldedBodies, CreateListOfWeldedBodies) {
+  MultibodyTree<double> model;
+
+  // Helper to add a rigid body. For these tests the value of the spatial
+  // inertia is not relevant and therefore we leave it un-initialized.
+  auto AddRigidBody =
+      [&model](const std::string& name) -> const RigidBody<double>& {
+    return model.AddRigidBody(name, SpatialInertia<double>());
+  };
+
+  // Helper to add a joint between two bodies. For this test the actual type of
+  // the joint is not relevant, only the fact that "is not" a WeldJoint.
+  auto AddJoint =
+      [&model](const std::string& name,
+               const Body<double>& parent, const Body<double>& child) {
+    model.AddJoint<RevoluteJoint>(
+        name, parent, {}, child, {}, Vector3<double>::UnitX());
+  };
+
+  // Helper method to add a WeldJoint between two bodies.
+  auto AddWeldJoint =
+      [&model](const std::string& name,
+               const Body<double>& parent, const Body<double>& child) {
+        model.AddJoint<WeldJoint>(
+            name, parent, {}, child, {}, Isometry3d::Identity());
+      };
+
+  // Start building the test model.
+  const RigidBody<double>& body_a = AddRigidBody("a");
+  const RigidBody<double>& body_b = AddRigidBody("b");
+  const RigidBody<double>& body_c = AddRigidBody("c");
+  const RigidBody<double>& body_d = AddRigidBody("d");
+  const RigidBody<double>& body_e = AddRigidBody("e");
+  const RigidBody<double>& body_f = AddRigidBody("f");
+  const RigidBody<double>& body_g = AddRigidBody("g");
+  const RigidBody<double>& body_h = AddRigidBody("h");
+  const RigidBody<double>& body_i = AddRigidBody("i");
+  const RigidBody<double>& body_j = AddRigidBody("j");
+  const RigidBody<double>& body_k = AddRigidBody("k");
+  const RigidBody<double>& body_l = AddRigidBody("l");
+  const RigidBody<double>& body_m = AddRigidBody("m");
+  const RigidBody<double>& body_n = AddRigidBody("n");
+
+  AddJoint("wa", model.world_body(), body_a);
+
+  // Welded body formed by bodies a and b.
+  AddWeldJoint("ab", body_a, body_b);
+
+  AddJoint("bc", body_b, body_c);
+  AddJoint("wd", model.world_body(), body_d);
+
+  // Welded body formed by bodies d, e, f and, g.
+  AddWeldJoint("de", body_d, body_e);
+  AddWeldJoint("ef", body_e, body_f);
+  AddWeldJoint("dg", body_d, body_g);
+
+  AddJoint("gh", body_g, body_h);
+  AddJoint("wi", model.world_body(), body_i);
+  AddJoint("ij", body_i, body_j);
+
+  // Welded body formed by bodies j and k.
+  AddWeldJoint("jk", body_j, body_k);
+
+  // Welded body formed by bodies w (world), l, m and n.
+  AddWeldJoint("wl", model.world_body(), body_l);
+  AddWeldJoint("lm", body_l, body_m);
+  AddWeldJoint("ln", body_l, body_n);
+
+  // We are done building the test model.
+  model.Finalize();
+
+  const MultibodyTreeTopology& topology = model.get_topology();
+
+  // Ask the topology to build the list of welded bodies.
+  std::vector<std::set<BodyIndex>> welded_bodies =
+      topology.CreateListOfWeldedBodies();
+  EXPECT_EQ(welded_bodies.size(), 7);
+
+  // Welded body "0" must correspond to the set of bodies welded to the world.
+  const std::set<BodyIndex>& world_welded_body = welded_bodies[0];
+  // Therefore world_welded_body must contain the index of the world body.
+  EXPECT_NE(
+      std::find(world_welded_body.begin(), world_welded_body.end(),
+                world_index()), world_welded_body.end());
+
+  // Build the expected result.
+  std::set<std::set<BodyIndex>> expected_welded_bodies;
+  expected_welded_bodies.insert({body_a.index(), body_b.index()});
+  expected_welded_bodies.insert({body_c.index()});
+  expected_welded_bodies.insert(
+      {body_d.index(), body_e.index(), body_f.index(), body_g.index()});
+  expected_welded_bodies.insert({body_h.index()});
+  expected_welded_bodies.insert({body_i.index()});
+  expected_welded_bodies.insert({body_j.index(), body_k.index()});
+  expected_welded_bodies.insert(
+      {world_index(), body_l.index(), body_m.index(), body_n.index()});
+
+  // In order to compare the computed list of welded bodies against the expected
+  // list, irrespective of the ordering in the computed list, we first convert
+  // the computed list to a set.
+  std::set<std::set<BodyIndex>> welded_bodies_set(
+      welded_bodies.begin(), welded_bodies.end());
+
+  // Verify the computed list has the expected entries.
+  EXPECT_EQ(welded_bodies_set, expected_welded_bodies);
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/multibody_tree_creation_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_creation_test.cc
@@ -683,14 +683,12 @@ GTEST_TEST(WeldedBodies, CreateListOfWeldedBodies) {
   // Ask the topology to build the list of welded bodies.
   std::vector<std::set<BodyIndex>> welded_bodies =
       topology.CreateListOfWeldedBodies();
-  EXPECT_EQ(welded_bodies.size(), 7);
+  ASSERT_EQ(welded_bodies.size(), 7);
 
   // Welded body "0" must correspond to the set of bodies welded to the world.
   const std::set<BodyIndex>& world_welded_body = welded_bodies[0];
   // Therefore world_welded_body must contain the index of the world body.
-  EXPECT_NE(
-      std::find(world_welded_body.begin(), world_welded_body.end(),
-                world_index()), world_welded_body.end());
+  EXPECT_NE(world_welded_body.find(world_index()), world_welded_body.end());
 
   // Build the expected result.
   std::set<std::set<BodyIndex>> expected_welded_bodies;


### PR DESCRIPTION
This PR introduces the idea of "welded bodies", a set of bodies in the tree that are welded together. 
A method is implemented in `MultibodyTreeTopology` to compute a list of all welded bodies. In particular, the welded body containing the world, contains all bodies welded to the world (i.e they are static or "anchored").

This capability will be used for:
- Compute per body penalty stiffness for contact handling (high priority).
- Label which bodies are anchored to pass this information to SceneGraph.

Special thanks to @SeanCurtis-TRI who provided the initial pseudo-code for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9168)
<!-- Reviewable:end -->
