### PR TITLE
Adds MultilaneOnRamp generator to automotive simulator.

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -47,6 +47,7 @@ drake_cc_package_library(
         ":maliput_railcar",
         ":mobil_planner",
         ":monolane_onramp_merge",
+        ":multilane_onramp_merge",
         ":pose_selector",
         ":prius_vis",
         ":pure_pursuit",
@@ -286,6 +287,16 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "multilane_onramp_merge",
+    srcs = ["multilane_onramp_merge.cc"],
+    hdrs = ["multilane_onramp_merge.h"],
+    deps = [
+        "//automotive/maliput/api",
+        "//automotive/maliput/multilane",
+    ],
+)
+
+drake_cc_library(
     name = "pose_selector",
     srcs = ["pose_selector.cc"],
     hdrs = ["pose_selector.h"],
@@ -513,6 +524,7 @@ drake_cc_binary(
         ":automotive_simulator",
         ":create_trajectory_params",
         ":monolane_onramp_merge",
+        ":multilane_onramp_merge",
         "//automotive/maliput/dragway",
         "//common:text_logging_gflags",
         "//lcm",
@@ -678,6 +690,16 @@ drake_cc_googletest(
     name = "monolane_onramp_merge_test",
     deps = [
         ":monolane_onramp_merge",
+        "//automotive/maliput/utility",
+    ],
+)
+
+drake_cc_googletest(
+    name = "multilane_onramp_merge_test",
+    deps = [
+        ":multilane_onramp_merge",
+        "//automotive/maliput/api",
+        "//automotive/maliput/api/test_utilities",
         "//automotive/maliput/utility",
     ],
 )

--- a/automotive/automotive_demo.cc
+++ b/automotive/automotive_demo.cc
@@ -11,6 +11,7 @@
 #include "drake/automotive/maliput/api/lane_data.h"
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/monolane_onramp_merge.h"
+#include "drake/automotive/multilane_onramp_merge.h"
 #include "drake/common/drake_assert.h"
 #include "drake/common/text_logging_gflags.h"
 #include "drake/lcm/drake_lcm.h"
@@ -78,10 +79,24 @@ DEFINE_double(dragway_vehicle_spacing, 10,
 DEFINE_bool(with_onramp, false, "Loads the onramp road network. Only one road "
             "network can be enabled. Thus, if this option is enabled, no other "
             "road network can be enabled.");
+DEFINE_bool(with_multilane_onramp, false,
+            "Loads the onramp road network. Only one road "
+            "network can be enabled. Thus, if this option is enabled, no other "
+            "road network can be enabled.");
+DEFINE_int32(multilane_num_lanes, 1,
+             "The number of lanes on the multilane. The number of lanes is by "
+             "default one. A multilane road network is only enabled when the "
+             "user specifies <with_multilane_onramp> flag.");
+DEFINE_double(multilane_lane_width, 3.7, "The multilane lane width.");
+DEFINE_double(multilane_shoulder_width, 3.0, "The multilane's shoulder width.");
 DEFINE_double(onramp_base_speed, 25, "The speed of the vehicles added to the "
-              "onramp.");
+              "onramp or multilane_onramp scenarios, i.e. this option is only "
+              "valid when either `with_onramp` or `with_multilane_onramp` "
+              "options are used.");
 DEFINE_bool(onramp_swap_start, false, "Whether to swap the starting lanes of "
-            "the vehicles on the onramp.");
+            "the vehicles on the onramp or multilane_onramp scenarios, i.e. "
+            " this option is only valid when either `with_onramp` or "
+            "`with_multilane_onramp` options are used.");
 
 DEFINE_bool(with_stalled_cars, false, "Places a stalled vehicle at the end of "
             "each lane of a dragway. This option is only enabled when the "
@@ -103,7 +118,8 @@ constexpr double kControlledCarRowSpacing{5};
 enum class RoadNetworkType {
   flat = 0,
   dragway = 1,
-  onramp = 2
+  onramp = 2,
+  multilane_onramp = 3,
 };
 
 std::string MakeChannelName(const std::string& name) {
@@ -158,6 +174,79 @@ void AddMaliputRailcar(int num_cars, bool idm_controlled, int initial_s_offset,
     } else {
       simulator->AddPriusMaliputRailcar("MaliputRailcar" + std::to_string(i),
                                         LaneDirection(lane), params, state);
+    }
+  }
+}
+
+// Adds a MaliputRailcar to the simulation involving an onramp RoadGeometry.
+// It throws a std::runtime_error if there is insufficient lane length for
+// adding the vehicle (it may happen when @p idm_controlled is true).
+//
+// @param num_cars The number of vehicles to add.
+//
+// @param idm_controlled Whether the vehicle should be IDM-controlled.
+//
+// @param road_network_type The road network type. It must be one of the onramp
+// types.
+//
+// @param simulator The simulator to modify.
+// TODO(agalbachicar):  Refactor this function and merge it with
+//                      AddMaliputRailcar() so there is a better interface to
+//                      add cars.
+void AddOnrampMaliputRailcars(int num_cars, bool idm_controlled,
+    RoadNetworkType road_network_type,
+    AutomotiveSimulator<double>* simulator) {
+  DRAKE_DEMAND(road_network_type == RoadNetworkType::onramp ||
+               road_network_type == RoadNetworkType::multilane_onramp);
+  auto lane_name_selector = [road_network_type](int index) {
+    if (road_network_type == RoadNetworkType::onramp) {
+      return (index % 2 == 0) ? "l:onramp0" : "l:pre0";
+    } else if (road_network_type == RoadNetworkType::multilane_onramp) {
+      return (index % 2 == 0) ? "l:onramp0_0" : "l:pre0_0";
+    } else {
+      DRAKE_ABORT();
+    }
+  };
+  auto maliput_railcar_name = [](int car_index) {
+    return "MaliputRailcar" + std::to_string(car_index);
+  };
+  auto idm_controlled_name = [](int car_index) {
+    return "IdmControlledMaliputRailcar" + std::to_string(car_index);
+  };
+
+  for (int i = 0; i < num_cars; ++i) {
+    // Alternate starting the MaliputRailcar vehicles between the two possible
+    // starting locations.
+    const int n = FLAGS_onramp_swap_start ? (i + 1) : i;
+    const std::string lane_name = lane_name_selector(n);
+    const bool with_s = false;
+
+    const LaneDirection lane_direction(simulator->FindLane(lane_name), with_s);
+    MaliputRailcarParams<double> params;
+    params.set_r(0);
+    params.set_h(0);
+    MaliputRailcarState<double> state;
+    state.set_speed(FLAGS_onramp_base_speed);
+
+    if (idm_controlled) {
+      const int row = i / lane_direction.lane->segment()->num_lanes();
+      const double s_offset =
+          lane_direction.lane->length() - kRailcarRowSpacing * row;
+      state.set_s(with_s ? 0 : lane_direction.lane->length() - s_offset);
+      if (s_offset < 0.) {
+        throw std::runtime_error(
+            "Ran out of lane length to add IDM Controlled cars.");
+      }
+      state.set_s(with_s ? 0 : s_offset);
+
+      simulator->AddIdmControlledPriusMaliputRailcar(
+          idm_controlled_name(i), lane_direction, ScanStrategy::kPath,
+          RoadPositionStrategy::kExhaustiveSearch,
+          0. /* time period (unused) */, params, state);
+    } else {
+      state.set_s(with_s ? 0 : lane_direction.lane->length());
+      simulator->AddPriusMaliputRailcar(maliput_railcar_name(i), lane_direction,
+                                        params, state);
     }
   }
 }
@@ -273,23 +362,12 @@ void AddVehicles(RoadNetworkType road_network_type,
 
   } else if (road_network_type == RoadNetworkType::onramp) {
     DRAKE_DEMAND(road_geometry != nullptr);
-    for (int i = 0; i < FLAGS_num_maliput_railcar; ++i) {
-      // Alternate starting the MaliputRailcar vehicles between the two possible
-      // starting locations.
-      const int n = FLAGS_onramp_swap_start ? (i + 1) : i;
-      const std::string lane_name = (n % 2 == 0) ? "l:onramp0" : "l:pre0";
-      const bool with_s = false;
-
-      LaneDirection lane_direction(simulator->FindLane(lane_name), with_s);
-      MaliputRailcarParams<double> params;
-      params.set_r(0);
-      params.set_h(0);
-      MaliputRailcarState<double> state;
-      state.set_s(with_s ? 0 : lane_direction.lane->length());
-      state.set_speed(FLAGS_onramp_base_speed);
-      simulator->AddPriusMaliputRailcar("MaliputRailcar" + std::to_string(i),
-          lane_direction, params, state);
-    }
+    AddOnrampMaliputRailcars(FLAGS_num_maliput_railcar,
+        false /* IDM controlled */, road_network_type, simulator);
+  } else if (road_network_type == RoadNetworkType::multilane_onramp) {
+    DRAKE_DEMAND(road_geometry != nullptr);
+    AddOnrampMaliputRailcars(FLAGS_num_maliput_railcar,
+        false /* IDM controlled */, road_network_type, simulator);
   } else {
     for (int i = 0; i < FLAGS_num_trajectory_car; ++i) {
       const auto& params = CreateTrajectoryParams(i);
@@ -340,6 +418,16 @@ const maliput::api::RoadGeometry* AddOnramp(
   return simulator->SetRoadGeometry(onramp_generator->BuildOnramp());
 }
 
+// Adds a multilane-based onramp road network to the provided `simulator`.
+const maliput::api::RoadGeometry* AddMultilaneOnramp(
+    AutomotiveSimulator<double>* simulator) {
+  const MultilaneRoadCharacteristics rc(
+      FLAGS_multilane_lane_width, FLAGS_multilane_shoulder_width,
+      FLAGS_multilane_shoulder_width, FLAGS_multilane_num_lanes);
+  auto onramp_generator = std::make_unique<MultilaneOnrampMerge>(rc);
+  return simulator->SetRoadGeometry(onramp_generator->BuildOnramp());
+}
+
 // Adds a terrain to the simulated world. The type of terrain added depends on
 // the provided `road_network_type` parameter. A pointer to the road network is
 // returned. A return value of `nullptr` is possible if no road network is
@@ -360,6 +448,10 @@ const maliput::api::RoadGeometry* AddTerrain(RoadNetworkType road_network_type,
       road_geometry = AddOnramp(simulator);
       break;
     }
+    case RoadNetworkType::multilane_onramp: {
+      road_geometry = AddMultilaneOnramp(simulator);
+      break;
+    }
   }
   return road_geometry;
 }
@@ -369,6 +461,7 @@ const maliput::api::RoadGeometry* AddTerrain(RoadNetworkType road_network_type,
 RoadNetworkType DetermineRoadNetworkType() {
   int num_environments_selected{0};
   if (FLAGS_with_onramp) ++num_environments_selected;
+  if (FLAGS_with_multilane_onramp) ++num_environments_selected;
   if (FLAGS_num_dragway_lanes) ++num_environments_selected;
   if (num_environments_selected > 1) {
     throw std::runtime_error("ERROR: More than one road network selected. Only "
@@ -379,6 +472,8 @@ RoadNetworkType DetermineRoadNetworkType() {
     return RoadNetworkType::dragway;
   } else if (FLAGS_with_onramp) {
     return RoadNetworkType::onramp;
+  } else if (FLAGS_with_multilane_onramp) {
+    return RoadNetworkType::multilane_onramp;
   } else {
     return RoadNetworkType::flat;
   }

--- a/automotive/multilane_onramp_merge.cc
+++ b/automotive/multilane_onramp_merge.cc
@@ -1,0 +1,131 @@
+#include "drake/automotive/multilane_onramp_merge.h"
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+
+namespace drake {
+namespace automotive {
+
+using maliput::api::LaneEnd;
+
+namespace multi = maliput::multilane;
+
+std::unique_ptr<const maliput::api::RoadGeometry>
+MultilaneOnrampMerge::BuildOnramp() const {
+  auto rb = multi::BuilderFactory().Make(rc_.lane_width, rc_.elevation_bounds,
+                                         linear_tolerance_, angular_tolerance_,
+                                         scale_length_, computation_policy_);
+
+  // Initialize roads lane layouts.
+  // Reference lane from which the reference curve of the segment is placed (at
+  // kRefR0 lateral distance).
+  const int kRefLane = 0;
+  // Distance between the reference curve and kRefLane lane curve.
+  const double kRefR0 = 0.;
+  const multi::LaneLayout lane_layout(rc_.left_shoulder, rc_.right_shoulder,
+                                      rc_.lane_number, kRefLane, kRefR0);
+
+  // Initialize the road from the origin.
+  const multi::EndpointXy kOriginXy{0., 0., 0.};
+  const multi::EndpointZ kFlatZ{0., 0., 0., {}};
+  const multi::Endpoint kRoadOrigin{kOriginXy, kFlatZ};
+
+  // Construct the post-merge road.
+  const double kPostArcLength = 25.;
+  const double kPostArcRadius = 40.;
+  const auto& post5 = rb->Connect(
+      "post5", lane_layout,
+      multi::StartReference().at(kRoadOrigin, multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, -kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& post4 = rb->Connect(
+      "post4", lane_layout,
+      multi::StartReference().at(*post5, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& post3 = rb->Connect(
+      "post3", lane_layout,
+      multi::StartReference().at(*post4, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, -kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& post2 = rb->Connect(
+      "post2", lane_layout,
+      multi::StartReference().at(*post3, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& post1 = rb->Connect(
+      "post1", lane_layout,
+      multi::StartReference().at(*post2, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, -kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& post0 = rb->Connect(
+      "post0", lane_layout,
+      multi::StartReference().at(*post1, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kPostArcLength, kPostArcRadius / kPostArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+
+  // Construct the pre-merge road.
+  const double kPostLinearLength = 100.;
+  const int pre_num_lanes = rc_.lane_number / 2 + 1;
+  const multi::LaneLayout pre_lane_layout(rc_.left_shoulder, rc_.right_shoulder,
+                                          pre_num_lanes, kRefLane, kRefR0);
+  const auto& pre0 = rb->Connect(
+      "pre0", pre_lane_layout,
+      multi::StartReference().at(*post0, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::LineOffset(kPostLinearLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+
+  // Construct the on-ramp (starting at merge junction at the `pre0` - `post0`
+  // interface and working backwards).
+  const double kOnrampArcLength = 35.;
+  const double kOnrampArcRadius = 50.;
+  const double kOnrampLinearLength = 100.;
+  const int onramp_num_lanes = rc_.lane_number / 2 + 1;
+  const multi::LaneLayout on_ramp_lane_layout(
+      rc_.left_shoulder, rc_.right_shoulder, onramp_num_lanes, kRefLane,
+      kRefR0 +
+          static_cast<double>(rc_.lane_number - onramp_num_lanes) *
+              rc_.lane_width);
+  const auto& onramp1 = rb->Connect(
+      "onramp1", on_ramp_lane_layout,
+      multi::StartReference().at(*post0, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::ArcOffset(kOnrampArcLength, kOnrampArcRadius / kOnrampArcLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+  const auto& onramp0 = rb->Connect(
+      "onramp0", on_ramp_lane_layout,
+      multi::StartReference().at(*onramp1, LaneEnd::kFinish,
+                                 multi::Direction::kForward),
+      multi::LineOffset(kOnrampLinearLength),
+      multi::EndReference().z_at(kFlatZ, multi::Direction::kForward));
+
+  // Manually specify the default branches for all junctions in the road.
+  auto set_default_branches = [&](
+      const multi::Connection* in, int in_first_lane,
+      const multi::Connection* out, int out_first_lane, int num_lanes) {
+    for (int i = 0; i < num_lanes; ++i) {
+      rb->SetDefaultBranch(in, i + in_first_lane, LaneEnd::kStart, out,
+                           i + out_first_lane, LaneEnd::kFinish);
+    }
+  };
+  set_default_branches(pre0, 0, post0, 0, pre_num_lanes);
+  set_default_branches(post0, 0, post1, 0, rc_.lane_number);
+  set_default_branches(post1, 0, post2, 0, rc_.lane_number);
+  set_default_branches(post2, 0, post3, 0, rc_.lane_number);
+  set_default_branches(post3, 0, post4, 0, rc_.lane_number);
+  set_default_branches(post4, 0, post5, 0, rc_.lane_number);
+  set_default_branches(onramp1, 0, post0,
+                       rc_.lane_number / 2 - (rc_.lane_number % 2 == 0 ? 1 : 0),
+                       onramp_num_lanes);
+  set_default_branches(onramp0, 0, onramp1, 0, onramp_num_lanes);
+
+  return rb->Build(maliput::api::RoadGeometryId{"multilane-merge-example"});
+}
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/multilane_onramp_merge.h
+++ b/automotive/multilane_onramp_merge.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <cmath>
+#include <memory>
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/road_curve.h"
+
+namespace drake {
+namespace automotive {
+
+/// MultilaneRoadCharacteristics computes and stores characteristics of a
+/// multilane road network; i.e. bounds on the lane width and shoulders width.
+/// Default settings are taken if no others are specified.
+struct MultilaneRoadCharacteristics {
+  /// Constructor for using default road geometries.
+  MultilaneRoadCharacteristics() = default;
+
+  /// Constructor for custom road geometries.
+  ///
+  /// @param lw Lane's width.
+  /// @param lshoulder The left shoulder width.
+  /// @param rshoulder The right shoulder width.
+  /// @param lnumber The number of lanes.
+  MultilaneRoadCharacteristics(double lw, double lshoulder, double rshoulder,
+                               int lnumber)
+      : lane_width(lw),
+        left_shoulder(lshoulder),
+        right_shoulder(rshoulder),
+        lane_number(lnumber) {}
+
+  const double lane_width{4.};
+  const double left_shoulder{2.};
+  const double right_shoulder{2.};
+  const int lane_number{1};
+
+  const maliput::api::HBounds elevation_bounds{0., 5.2};
+};
+
+/// MultilaneOnrampMerge contains an example lane-merge scenario expressed as a
+/// maliput mulitilane road geometry.  The intent of this class is to enable
+/// easy creation and modification of road geometries for simulating/analyzing
+/// such scenarios.
+///
+/// Implements the following onramp example, where each road section is composed
+/// of sequences of linear and arc primitives:
+///
+/// <pre>
+///           pre-merge           post-merge
+///             road                 road
+///        |------>------------+------>-------|
+///        |------>------------+------>-------|
+///                           /+------>-------|
+///                          //
+///                         //
+///                        //   onramp
+///                       ^^
+///                       ||
+///                       ||
+///                       __
+/// </pre>
+///
+/// The number of lanes of each road depends on the properties the
+/// MultilaneRoadCharacteristics. `post` roads will have the full number of
+/// lanes. `pre` and `onramp` roads will have half plus one lanes (note the
+/// integer division) and will be placed to the left and right sides of `post`
+/// road respectively. When the full lane number is even, two lanes from `pre`
+/// and `onramp` will overlap. Otherwise, only one lane will overlap.
+///
+/// For the special case of a single lane, the output RoadGeometry will be
+/// identical to a `monolane::RoadGeometry`.
+///
+/// Note that this factory sets some constants to the `multilane::Builder` when
+/// creating the RoadGeometry. Linear and angular tolerances, the scale length
+/// and the ComputationPolicy are set to appropriate values to build this
+/// RoadGeometry.
+class MultilaneOnrampMerge {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultilaneOnrampMerge)
+
+  /// Constructor for the factory.
+  ///
+  /// @param rc A structure that aggregates the road boundary data.
+  explicit MultilaneOnrampMerge(const MultilaneRoadCharacteristics& rc)
+      : rc_(rc) {}
+
+  /// Constructor for the example, using default MultilaneRoadCharacteristics
+  /// settings.
+  MultilaneOnrampMerge()
+      : MultilaneOnrampMerge(MultilaneRoadCharacteristics{}) {}
+
+  /// @return A std::unique_ptr<const maliput::api::RoadGeometry> with the
+  /// onramp example.
+  std::unique_ptr<const maliput::api::RoadGeometry> BuildOnramp() const;
+
+ private:
+  // Tolerances and properties for multilane's Builder.
+  const double linear_tolerance_{0.01};
+  const double angular_tolerance_{0.01 * M_PI};
+  const double scale_length_{1.};
+  const maliput::multilane::ComputationPolicy computation_policy_{
+      maliput::multilane::ComputationPolicy::kPreferSpeed};
+  // Road characteristics.
+  const MultilaneRoadCharacteristics rc_;
+};
+
+}  // namespace automotive
+}  // namespace drake

--- a/automotive/test/multilane_onramp_merge_test.cc
+++ b/automotive/test/multilane_onramp_merge_test.cc
@@ -1,0 +1,275 @@
+#include "drake/automotive/multilane_onramp_merge.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/test_utilities/maliput_types_compare.h"
+
+namespace drake {
+namespace automotive {
+namespace {
+
+namespace api = maliput::api;
+
+// @return `lane_id` Lane from `rg` RoadGeometry assuming `junction_id` Junction
+// has only one segment in that Junction.
+// @throws std::runtime_error When the Lane cannot be found.
+const api::Lane* GetLaneByJunctionId(const api::RoadGeometry& rg,
+                                     const std::string& junction_id,
+                                     int lane_id) {
+  for (int i = 0; i < rg.num_junctions(); ++i) {
+    if (rg.junction(i)->id() == api::JunctionId(junction_id)) {
+      return rg.junction(i)->segment(0)->lane(lane_id);
+    }
+  }
+  throw std::runtime_error("No matching junction name in the road network");
+}
+
+// Check the correctness of the default parameters of a
+// MultilaneRoadCharacteristics structure.
+GTEST_TEST(MultilaneOnrampMergeTest, DefaultMultilaneRoadCharacteristics) {
+  const double kZeroTolerance = 0.;
+  const MultilaneRoadCharacteristics rc{};
+  EXPECT_EQ(4., rc.lane_width);
+  EXPECT_EQ(2., rc.left_shoulder);
+  EXPECT_EQ(2., rc.right_shoulder);
+  EXPECT_EQ(1., rc.lane_number);
+  EXPECT_TRUE(api::test::IsHBoundsClose({0., 5.2}, rc.elevation_bounds,
+                                        kZeroTolerance));
+}
+
+// Check the correctness of non-default parameters of a
+// MultilaneRoadCharacteristics structure.
+GTEST_TEST(MultilaneOnrampMergeTest, NonDefaultMultilaneRoadCharacteristics) {
+  const double kZeroTolerance = 0.;
+  const double kLaneWidth = 6.3;
+  const double kLeftShoulder = 1.2;
+  const double kRightShoulder = 2.1;
+  const int kLaneNumber = 3;
+  const MultilaneRoadCharacteristics rc(kLaneWidth, kLeftShoulder,
+                                        kRightShoulder, kLaneNumber);
+  EXPECT_EQ(kLaneWidth, rc.lane_width);
+  EXPECT_EQ(kLeftShoulder, rc.left_shoulder);
+  EXPECT_EQ(kRightShoulder, rc.right_shoulder);
+  EXPECT_EQ(kLaneNumber, rc.lane_number);
+  EXPECT_TRUE(api::test::IsHBoundsClose({0., 5.2}, rc.elevation_bounds,
+                                        kZeroTolerance));
+}
+
+// Tests the default RoadGeometry of MultilaneOnrampMerge example generator.
+GTEST_TEST(MultilaneOnrampMergeTest, TestDefaultAttributes) {
+  const double kZeroTolerance = 0.;
+  const double kSPosition = 0.;
+  const int kFirstLane = 0;
+  const MultilaneRoadCharacteristics rc{};
+
+  // Create the road with default road characteristics.
+  auto merge_example = std::make_unique<MultilaneOnrampMerge>();
+  std::unique_ptr<const maliput::api::RoadGeometry> rg =
+      merge_example->BuildOnramp();
+  EXPECT_NE(nullptr, rg);
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-merge-example"));
+  EXPECT_EQ(rg->num_junctions(), 9);
+  for (int i = 0; i < rg->num_junctions(); ++i) {
+    EXPECT_EQ(1, rg->junction(i)->num_segments());
+    EXPECT_EQ(1, rg->junction(i)->segment(0)->num_lanes());
+  }
+
+  // Checks lane and driveable bounds.
+  const api::RBounds kLaneBounds{-rc.lane_width / 2., rc.lane_width / 2.};
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      kLaneBounds,
+      rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition),
+      kZeroTolerance));
+
+  const api::RBounds kDriveableBounds{-rc.lane_width / 2. - rc.left_shoulder,
+                                      rc.lane_width / 2. + rc.right_shoulder};
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      kDriveableBounds,
+      rg->junction(0)->segment(0)->lane(0)->driveable_bounds(kSPosition),
+      kZeroTolerance));
+
+  // Verify that there's only one ongoing branch from `onramp1_0`, and that it
+  // is lane `post0_0`.
+  EXPECT_NO_THROW(GetLaneByJunctionId(*rg, "j:onramp1", kFirstLane));
+  const api::Lane* lane_onramp1 =
+      GetLaneByJunctionId(*rg, "j:onramp1", kFirstLane);
+  const api::LaneEndSet* lanes_beyond_onramp1 =
+      lane_onramp1->GetOngoingBranches(api::LaneEnd::kStart);
+  EXPECT_EQ(1, lanes_beyond_onramp1->size());
+  const api::Lane* lane_beyond_onramp1 = lanes_beyond_onramp1->get(0).lane;
+  EXPECT_EQ(api::LaneId("l:post0_0"), lane_beyond_onramp1->id());
+
+  // Verify that the default branch of `onramp1_0` is `post0_0`.
+  optional<api::LaneEnd> onramp1_default_lane_end =
+      lane_onramp1->GetDefaultBranch(api::LaneEnd::kStart);
+  EXPECT_TRUE(onramp1_default_lane_end);
+  EXPECT_EQ(api::LaneId("l:post0_0"), onramp1_default_lane_end->lane->id());
+
+  // Verify that there's only one ongoing branch from `pre0_0`, and that it is
+  // also lane `post0_0`.
+  EXPECT_NO_THROW(GetLaneByJunctionId(*rg, "j:pre0", kFirstLane));
+  const api::Lane* lane_pre0 = GetLaneByJunctionId(*rg, "j:pre0", kFirstLane);
+  const api::LaneEndSet* lanes_beyond_pre0 =
+      lane_pre0->GetOngoingBranches(api::LaneEnd::kStart);
+  EXPECT_EQ(1, lanes_beyond_pre0->size());
+  const api::Lane* lane_beyond_pre0 = lanes_beyond_pre0->get(0).lane;
+  EXPECT_EQ(api::LaneId("l:post0_0"), lane_beyond_pre0->id());
+
+  // Verify that the default branch of `pre0_0` is `post0_0`.
+  optional<api::LaneEnd> pre0_default_lane_end =
+      lane_pre0->GetDefaultBranch(api::LaneEnd::kStart);
+  EXPECT_TRUE(pre0_default_lane_end);
+  EXPECT_EQ(api::LaneId("l:post0_0"), pre0_default_lane_end->lane->id());
+}
+
+// Tests a non default RoadGeometry of MultilaneOnrampMerge example generator.
+GTEST_TEST(MultilaneOnrampMergeTest, TestNonDefaultAttributes) {
+  const double kZeroTolerance = 0.;
+  const double kSPosition = 0.;
+  // Initialize non-default road characteristics.
+  const double kLaneWidth = 6.3;
+  const double kShoulder = 1.2;
+  const int kLaneNumber = 3;
+  const MultilaneRoadCharacteristics rc(kLaneWidth, kShoulder, kShoulder,
+                                        kLaneNumber);
+
+  auto merge_example = std::make_unique<MultilaneOnrampMerge>(rc);
+  std::unique_ptr<const maliput::api::RoadGeometry> rg =
+      merge_example->BuildOnramp();
+  EXPECT_NE(nullptr, rg);
+
+  // Check the correctness of the non-default parameters.
+  const api::RBounds kLaneBounds{-rc.lane_width / 2., rc.lane_width / 2.};
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      kLaneBounds,
+      rg->junction(0)->segment(0)->lane(0)->lane_bounds(kSPosition),
+      kZeroTolerance));
+
+  const api::RBounds kDriveableBounds{
+      -rc.lane_width / 2. - rc.left_shoulder,
+      rc.lane_width / 2. + 2. * kLaneWidth + rc.right_shoulder};
+  EXPECT_TRUE(api::test::IsRBoundsClose(
+      kDriveableBounds,
+      rg->junction(0)->segment(0)->lane(0)->driveable_bounds(kSPosition),
+      kZeroTolerance));
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-merge-example"));
+  EXPECT_EQ(rg->num_junctions(), 9);
+  for (int i = 0; i < rg->num_junctions(); ++i) {
+    EXPECT_EQ(1, rg->junction(i)->num_segments());
+    if (rg->id().string().find("j:post") != std::string::npos) {
+      EXPECT_EQ(kLaneNumber, rg->junction(i)->segment(0)->num_lanes());
+    } else if (rg->id().string().find("j:pre") != std::string::npos) {
+      EXPECT_EQ(kLaneNumber / 2 + 1, rg->junction(i)->segment(0)->num_lanes());
+    } else if (rg->id().string().find("j:onramp") != std::string::npos) {
+      EXPECT_EQ(kLaneNumber / 2 + 1, rg->junction(i)->segment(0)->num_lanes());
+    }
+  }
+}
+
+// A test fixture to analyze the output RoadGeometry with different lane numbers
+// for the generator.
+class MultilaneOnrampVariableLaneTest : public ::testing::TestWithParam<int> {
+ protected:
+  const double kLaneWidth = 3.;
+  const double kShoulder = 1.2;
+};
+
+// Checks the correct lane number assignment to each road.
+TEST_P(MultilaneOnrampVariableLaneTest, TestLaneNumberAssigment) {
+  const int lane_number = GetParam();
+  const MultilaneRoadCharacteristics rc(kLaneWidth, kShoulder, kShoulder,
+                                        lane_number);
+
+  auto merge_example = std::make_unique<MultilaneOnrampMerge>(rc);
+  std::unique_ptr<const maliput::api::RoadGeometry> rg =
+      merge_example->BuildOnramp();
+  EXPECT_NE(nullptr, rg);
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-merge-example"));
+  EXPECT_EQ(rg->num_junctions(), 9);
+  for (int i = 0; i < rg->num_junctions(); ++i) {
+    EXPECT_EQ(1, rg->junction(i)->num_segments());
+    if (rg->id().string().find("j:post") != std::string::npos) {
+      EXPECT_EQ(lane_number, rg->junction(i)->segment(0)->num_lanes());
+    } else if (rg->id().string().find("j:pre") != std::string::npos) {
+      EXPECT_EQ(lane_number / 2 + 1, rg->junction(i)->segment(0)->num_lanes());
+    } else if (rg->id().string().find("j:onramp") != std::string::npos) {
+      EXPECT_EQ(lane_number / 2 + 1, rg->junction(i)->segment(0)->num_lanes());
+    }
+  }
+}
+
+// Checks the correct default BranchPoint assignment.
+TEST_P(MultilaneOnrampVariableLaneTest, TestDefaultBranchAssigment) {
+  const int lane_number = GetParam();
+  const MultilaneRoadCharacteristics rc(kLaneWidth, kShoulder, kShoulder,
+                                        lane_number);
+
+  auto merge_example = std::make_unique<MultilaneOnrampMerge>(rc);
+  std::unique_ptr<const maliput::api::RoadGeometry> rg =
+      merge_example->BuildOnramp();
+  EXPECT_NE(nullptr, rg);
+
+  EXPECT_EQ(rg->id(), api::RoadGeometryId("multilane-merge-example"));
+  EXPECT_EQ(rg->num_junctions(), 9);
+
+  // Builds a Lane name from the name and the lane ID.
+  auto lane_name = [](const std::string& name, int lane_id) {
+    return std::string("l:") + name + std::string("_") +
+           std::to_string(lane_id);
+  };
+
+  const int on_ramp_lane_number = lane_number / 2 + 1;
+  // Verify that there's only one ongoing branch from `onramp1_X`, and that it
+  // is lane `post0_Y`.
+  for (int i = 0; i < on_ramp_lane_number; ++i) {
+    EXPECT_NO_THROW(GetLaneByJunctionId(*rg, "j:onramp1", i));
+    const api::Lane* lane_onramp1 = GetLaneByJunctionId(*rg, "j:onramp1", i);
+    const api::LaneEndSet* lanes_beyond_onramp1 =
+        lane_onramp1->GetOngoingBranches(api::LaneEnd::kStart);
+    EXPECT_EQ(1, lanes_beyond_onramp1->size());
+    const api::Lane* lane_beyond_onramp1 = lanes_beyond_onramp1->get(0).lane;
+    EXPECT_EQ(
+        api::LaneId(lane_name("post0", lane_number - on_ramp_lane_number + i)),
+        lane_beyond_onramp1->id());
+
+    // Verify that the default branch of `onramp1_X` is `post0_Y`.
+    optional<api::LaneEnd> onramp1_default_lane_end =
+        lane_onramp1->GetDefaultBranch(api::LaneEnd::kStart);
+    EXPECT_TRUE(onramp1_default_lane_end);
+    EXPECT_EQ(
+        api::LaneId(lane_name("post0", lane_number - on_ramp_lane_number + i)),
+        onramp1_default_lane_end->lane->id());
+  }
+
+  const int pre_lane_number = lane_number / 2 + 1;
+  // Verify that there's only one ongoing branch from `pre0_X`, and that it is
+  // also lane `post0_X`.
+  for (int i = 0; i < pre_lane_number; ++i) {
+    EXPECT_NO_THROW(GetLaneByJunctionId(*rg, "j:pre0", i));
+    const api::Lane* lane_pre0 = GetLaneByJunctionId(*rg, "j:pre0", i);
+    const api::LaneEndSet* lanes_beyond_pre0 =
+        lane_pre0->GetOngoingBranches(api::LaneEnd::kStart);
+    EXPECT_EQ(1, lanes_beyond_pre0->size());
+    const api::Lane* lane_beyond_pre0 = lanes_beyond_pre0->get(0).lane;
+    EXPECT_EQ(api::LaneId(lane_name("post0", i)), lane_beyond_pre0->id());
+
+    // Verify that the default branch of `pre0_X` is `post0_X`.
+    optional<api::LaneEnd> pre0_default_lane_end =
+        lane_pre0->GetDefaultBranch(api::LaneEnd::kStart);
+    EXPECT_TRUE(pre0_default_lane_end);
+    EXPECT_EQ(api::LaneId(lane_name("post0", i)),
+              pre0_default_lane_end->lane->id());
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(MultilaneOnrampMergeLaneNumber,
+                        MultilaneOnrampVariableLaneTest, testing::Range(1, 6));
+
+}  // namespace
+}  // namespace automotive
+}  // namespace drake


### PR DESCRIPTION
This PR introduces `multilane_onramp_merge` library so as to mimic the behavior of `monolane_onramp_merge` and introduce `multilane` into the automotive simulator.

The factory can be set with only one lane, and the same result as with `monolane` will be achieved. If more than one lane is set, the `post` merge roads will use that value but half plus one lanes will be used for `pre` and `onramp` roads. There is going to be always at least one lane that overlaps from `pre` and `onramp` roads.

To run the automotive simulator with `multilane_onramp_merge` sample, you could try:

```
bazel run //automotive:demo -- --visualizer --with_multilane_onramp --multilane_num_lanes=3 --num_maliput_railcar=2 
```

And you should see the following:

![multilane_onramp_merge_3lanes](https://user-images.githubusercontent.com/3825465/43153986-2e6463b0-8f49-11e8-8b91-a8d5e23a0405.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9173)
<!-- Reviewable:end -->
