### PR TITLE
Add TSan Suppressions for libc, libembree3 and libtbb

### DIFF
--- a/tools/dynamic_analysis/tsan.supp
+++ b/tools/dynamic_analysis/tsan.supp
@@ -32,3 +32,17 @@ race:g_static_rec_mutex_lock
 # data race in libgurobi80.so.  Gurobi has not been instrumented with TSan.
 called_from_lib:libgurobi.so
 called_from_lib:libgurobi80.so
+
+# data race in libtbb.so.  libtbb has not been instrumented with TSan.
+called_from_lib:libtbb.so
+
+# leak in libtbb.so
+thread:libtbb.so
+
+# thread leak in libembree3.so.  libembree3 has not been instrumented with TSan.
+called_from_lib:libembree3.so
+
+# Somehow libtbb appears to be trying to release a thread twice, the
+# second time inside a global destructor.
+race:__cxa_finalize
+mutex:__cxa_finalize


### PR DESCRIPTION
```
$ ldd /usr/lib/x86_64-linux-gnu/libtbb.so.2
        linux-vdso.so.1 =>  (0x00007fff1f9d6000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f4e27181000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4e26f64000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f4e26be2000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4e268d9000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4e266c3000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4e262f9000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f4e275c2000)
```
If `libtbb` were instrumented with TSan, we'd see a `libtsan.*` in the list ?

This is towards the following failures in CI:
[1](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-memcheck-tsan/), [2](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-clang-bazel-continuous-memcheck-tsan-everything/), [3](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-tsan/), [4](https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-tsan-everything/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9174)
<!-- Reviewable:end -->
