### PR TITLE
Relax IpOpt tolerance

### DIFF
--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -510,7 +510,7 @@ SolutionResult IpoptSolver::Solve(MathematicalProgram& prog) const {
   Ipopt::SmartPtr<Ipopt::IpoptApplication> app = IpoptApplicationFactory();
   app->RethrowNonIpoptException(true);
 
-  const double tol = 1e-10;  // Note: SNOPT is only 1e-6, but in #3712 we
+  const double tol = 1.05e-10;  // Note: SNOPT is only 1e-6, but in #3712 we
   // diagnosed that the CompareMatrices tolerance needed to be the sqrt of the
   // constr_viol_tol
   app->Options()->SetNumericValue("tol", tol);


### PR DESCRIPTION
This PR is related to #3712.
Without this, valkyrie_ik_test fails on Ubuntu 18.04 with the message:

Restoration phase is called at point that is almost feasible,
  with constraint violation 4.163336e-17. Abort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9178)
<!-- Reviewable:end -->
