### PR TITLE
Transform point cloud to world frame

### DIFF
--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -18,6 +18,7 @@ drake_cc_package_library(
         ":point_cloud",
         ":point_cloud_flags",
         ":transform_point_cloud",
+        ":transform_point_cloud_to_world",
     ],
 )
 

--- a/perception/BUILD.bazel
+++ b/perception/BUILD.bazel
@@ -53,6 +53,19 @@ drake_cc_library(
 )
 
 drake_cc_library(
+    name = "transform_point_cloud_to_world",
+    srcs = ["transform_point_cloud_to_world.cc"],
+    hdrs = ["transform_point_cloud_to_world.h"],
+    deps = [
+        ":point_cloud",
+        "//common:essential",
+        "//math:geometric_transform",
+        "//multibody:rigid_body_tree",
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
     name = "transform_point_cloud",
     srcs = ["transform_point_cloud.cc"],
     hdrs = ["transform_point_cloud.h"],
@@ -88,6 +101,16 @@ drake_cc_googletest(
     deps = [
         ":point_cloud",
         "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+drake_cc_googletest(
+    name = "transform_point_cloud_to_world_test",
+    srcs = ["test/transform_point_cloud_to_world_test.cc"],
+    deps = [
+        ":transform_point_cloud_to_world",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//multibody/rigid_body_plant",
     ],
 )
 

--- a/perception/test/transform_point_cloud_to_world_test.cc
+++ b/perception/test/transform_point_cloud_to_world_test.cc
@@ -1,0 +1,125 @@
+#include "drake/perception/transform_point_cloud_to_world.h"
+
+#include <cmath>
+#include <random>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/multibody/joints/roll_pitch_yaw_floating_joint.h"
+#include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
+#include "drake/multibody/rigid_body_tree.h"
+
+namespace drake {
+namespace perception {
+namespace {
+
+const Vector3<double> kFrameToBodyRpy(M_PI_4, -M_PI_2, 0.543);
+const Vector3<double> kFrameToBodyP(-0.3, 5.4, -2.7);
+
+const Vector3<double> kWorldToBodyRpy(M_PI, 0.236, M_PI_4);
+const Vector3<double> kWorldToBodyP(-1.4, 0.3, 2.8);
+
+class FixedTransformPointCloudTest : public ::testing::Test {
+ public:
+  static Matrix3X<float> GenerateBoundedSample(const Vector3<float>& min,
+                                               const Vector3<float>& max,
+                                               int num_cols) {
+    Matrix3X<float> return_matrix = Matrix3X<float>::Zero(3, num_cols);
+    const Vector3<float> increment = (max - min) / static_cast<float>(num_cols);
+
+    for (int i = 0; i < num_cols; ++i) {
+      return_matrix.col(i) = increment * static_cast<float>(i);
+    }
+
+    return return_matrix;
+  }
+
+ protected:
+  void SetUp() override {
+    std::unique_ptr<RigidBodyTree<double>> tree =
+        std::make_unique<RigidBodyTree<double>>();
+
+    std::unique_ptr<RigidBody<double>> body =
+        std::make_unique<RigidBody<double>>();
+    body->set_name("body");
+    body->set_mass(1.0);
+    body->set_spatial_inertia(Matrix6<double>::Identity());
+
+    Isometry3<double> body_transform;
+    body_transform =
+        Eigen::Translation3d(kWorldToBodyP) *
+        (Eigen::AngleAxisd(kWorldToBodyRpy(0), Eigen::Vector3d::UnitX()) *
+         Eigen::AngleAxisd(kWorldToBodyRpy(1), Eigen::Vector3d::UnitY()) *
+         Eigen::AngleAxisd(kWorldToBodyRpy(2), Eigen::Vector3d::UnitZ()));
+    body->add_joint(&tree->world(), std::make_unique<RollPitchYawFloatingJoint>(
+                                        "base", body_transform));
+
+    RigidBody<double>* b = tree->add_rigid_body(std::move(body));
+
+    frame_ = std::make_shared<RigidBodyFrame<double>>("frame", b,
+        kFrameToBodyP, kFrameToBodyRpy);
+
+    tree->addFrame(frame_);
+    tree->compile();
+
+    plant_ = std::make_unique<systems::RigidBodyPlant<double>>(std::move(tree));
+
+    transformer_ = std::make_unique<TransformPointCloudToWorld>(
+        plant_->get_rigid_body_tree(), *frame_);
+    context_ = transformer_->CreateDefaultContext();
+    output_ = transformer_->point_cloud_output_port().Allocate();
+  }
+
+  std::shared_ptr<RigidBodyFrame<double>> frame_;
+  std::unique_ptr<systems::RigidBodyPlant<double>> plant_;
+  std::unique_ptr<TransformPointCloudToWorld> transformer_;
+  std::unique_ptr<systems::Context<double>> context_;
+  std::unique_ptr<systems::AbstractValue> output_;
+};
+
+// Verifies that the system applies the transform correctly to the point cloud.
+TEST_F(FixedTransformPointCloudTest, ApplyTransformTest) {
+  const Vector3<float> kMin(-10.0, -20.0, -30.0);
+  const Vector3<float> kMax(10.0, 20.0, 30.0);
+  const int kNumPoints = 5;
+
+  VectorX<double> state(transformer_->state_input_port().size());
+  state << 0.3, -0.4, 2.3, 0, 0, 0, 1;
+
+  MatrixX<float> test_data =
+      FixedTransformPointCloudTest::GenerateBoundedSample(kMin, kMax,
+                                                          kNumPoints);
+  PointCloud cloud(kNumPoints);
+  cloud.mutable_xyzs() = test_data;
+
+  context_->FixInputPort(0, systems::AbstractValue::Make<PointCloud>(cloud));
+  context_->FixInputPort(1, state);
+
+  transformer_->point_cloud_output_port().Calc(*context_, output_.get());
+  auto output_cloud = output_->GetValueOrThrow<PointCloud>();
+
+  // The rigid transform below uses `float` because the point cloud uses
+  // `float` as the numerical representation.
+  const KinematicsCache<double> cache =
+      plant_->get_rigid_body_tree().doKinematics(
+          state.head(plant_->get_num_positions()));
+  const Isometry3<double> isom =
+      plant_->get_rigid_body_tree().CalcFramePoseInWorldFrame(cache, *frame_);
+  math::RigidTransform<float> transform(isom.cast<float>());
+  Matrix4X<float> test_data_homogeneous(4, kNumPoints);
+  test_data_homogeneous.block(0, 0, 3, kNumPoints) = test_data;
+  test_data_homogeneous.row(3) = VectorX<float>::Ones(kNumPoints);
+  Matrix4X<float> expected_output =
+      transform.GetAsMatrix4() * test_data_homogeneous;
+
+  // The tolerance used here has this value because the point cloud uses
+  // `float` as the numerical representation.
+  EXPECT_TRUE(CompareMatrices(output_cloud.xyzs(),
+                              expected_output.block(0, 0, 3, kNumPoints),
+                              16.0f * std::numeric_limits<float>::epsilon()));
+}
+
+}  // namespace
+}  // namespace perception
+}  // namespace drake

--- a/perception/test/transform_point_cloud_to_world_test.cc
+++ b/perception/test/transform_point_cloud_to_world_test.cc
@@ -17,7 +17,7 @@ namespace {
 const Vector3<double> kFrameToBodyRpy(M_PI_4, -M_PI_2, 0.543);
 const Vector3<double> kFrameToBodyP(-0.3, 5.4, -2.7);
 
-const Vector3<double> kWorldToBodyRpy(M_PI, 0.236, M_PI_4);
+const Vector3<double> kWorldToBodyRpy(M_PI_2, -0.236, M_PI_4);
 const Vector3<double> kWorldToBodyP(-1.4, 0.3, 2.8);
 
 class FixedTransformPointCloudTest : public ::testing::Test {
@@ -106,7 +106,8 @@ TEST_F(FixedTransformPointCloudTest, ApplyTransformTest) {
           state.head(plant_->get_num_positions()));
   const Isometry3<double> isom =
       plant_->get_rigid_body_tree().CalcFramePoseInWorldFrame(cache, *frame_);
-  math::RigidTransform<float> transform(isom.cast<float>());
+  math::RigidTransform<double> transform_d(isom);
+  math::RigidTransform<float> transform(transform_d.cast<float>());
   Matrix4X<float> test_data_homogeneous(4, kNumPoints);
   test_data_homogeneous.block(0, 0, 3, kNumPoints) = test_data;
   test_data_homogeneous.row(3) = VectorX<float>::Ones(kNumPoints);

--- a/perception/transform_point_cloud_to_world.cc
+++ b/perception/transform_point_cloud_to_world.cc
@@ -1,0 +1,52 @@
+#include "drake/perception/transform_point_cloud_to_world.h"
+
+namespace drake {
+namespace perception {
+
+TransformPointCloudToWorld::TransformPointCloudToWorld(
+    const RigidBodyTree<double>& tree, const RigidBodyFrame<double>& frame)
+    : tree_(tree), frame_(frame) {
+  // Create input port for point cloud.
+  point_cloud_input_port_index_ = this->DeclareAbstractInputPort().get_index();
+
+  // Create input port for state of a RigidBodyTree.
+  const int q_dim = tree.get_num_positions();
+  const int v_dim = tree.get_num_velocities();
+  state_input_port_index_ =
+      this->DeclareInputPort(systems::kVectorValued, q_dim + v_dim).get_index();
+
+  // Create output port for transformed point cloud.
+  this->DeclareAbstractOutputPort(
+      &TransformPointCloudToWorld::MakeOutputPointCloud,
+      &TransformPointCloudToWorld::ApplyTransformToPointCloud);
+}
+
+PointCloud TransformPointCloudToWorld::MakeOutputPointCloud() const {
+  PointCloud cloud(0);
+  return cloud;
+}
+
+void TransformPointCloudToWorld::ApplyTransformToPointCloud(
+    const systems::Context<double>& context, PointCloud* output) const {
+  const PointCloud* input_point_cloud =
+      this->EvalInputValue<PointCloud>(context, point_cloud_input_port_index_);
+  DRAKE_ASSERT(input_point_cloud != nullptr);
+
+  const Eigen::VectorXd q =
+      this->EvalEigenVectorInput(context, state_input_port_index_)
+          .head(tree_.get_num_positions());
+
+  const KinematicsCache<double> cache = tree_.doKinematics(q);
+
+  const Isometry3<double> isom = tree_.CalcFramePoseInWorldFrame(cache, frame_);
+
+  const math::RigidTransform<float> rigid_transform(isom.cast<float>());
+
+  output->resize(input_point_cloud->size());
+  for (int i = 0; i < output->size(); i++) {
+    output->mutable_xyz(i) = rigid_transform * input_point_cloud->xyz(i);
+  }
+}
+
+}  // namespace perception
+}  // namespace drake

--- a/perception/transform_point_cloud_to_world.h
+++ b/perception/transform_point_cloud_to_world.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/multibody/rigid_body_tree.h"
+#include "drake/perception/point_cloud.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace perception {
+
+/// Transforms a point cloud to the world frame.
+///
+/// The system first computes a RigidTransform between a RigidBodyFrame and
+/// the world frame based on the state of a RigidBodyTree. Then it applies
+/// this transform to a point cloud.
+///
+/// The system has two input ports and one output port. The first input port
+/// takes a PointCloud and the second takes the state of a RigidBodyTree. The
+/// output port contains a PointCloud.
+class TransformPointCloudToWorld final : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(TransformPointCloudToWorld)
+
+  /// Constructs the transformer.
+  TransformPointCloudToWorld(const RigidBodyTree<double>& tree,
+      const RigidBodyFrame<double>& frame);
+
+  /// Returns the abstract valued input port that contains a PointCloud.
+  const systems::InputPort<double>& point_cloud_input_port() const {
+    return this->get_input_port(point_cloud_input_port_index_);
+  }
+
+  /// Returns the vector valued input port that contains the state associated
+  /// with a RigidBodyTree.
+  const systems::InputPort<double>& state_input_port() const {
+    return this->get_input_port(state_input_port_index_);
+  }
+
+  /// Returns the abstract valued output port that contains a PointCloud.
+  const systems::OutputPort<double>& point_cloud_output_port() const {
+    return LeafSystem<double>::get_output_port(0);
+  }
+
+ private:
+  /// Returns an empty point cloud.
+  PointCloud MakeOutputPointCloud() const;
+
+  /// Transforms the point cloud using a RigidTransform between `frame_` and
+  /// the world frame that is calculated based on the state of `tree_`.
+  void ApplyTransformToPointCloud(const systems::Context<double>& context,
+                                  PointCloud* output) const;
+
+  const RigidBodyTree<double>& tree_;
+  const RigidBodyFrame<double>& frame_;
+
+  systems::InputPortIndex point_cloud_input_port_index_;
+  systems::InputPortIndex state_input_port_index_;
+};
+
+}  // namespace perception
+}  // namespace drake


### PR DESCRIPTION
Transforms a point cloud to the world frame. The transform is calculated based on the state of a RigidBodyTree. 

This PR differs from PR [#9157](https://github.com/RobotLocomotion/drake/pull/9157) in that it fixes the frames that are used to calculate the transform.

This system will be used to apply filters to the point cloud that require it to be in the same frame as the RigidBodyTree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9180)
<!-- Reviewable:end -->
