### PR TITLE
Update Godot to support clang 6 compilation

### DIFF
--- a/tools/workspace/godotengine/package.BUILD.bazel
+++ b/tools/workspace/godotengine/package.BUILD.bazel
@@ -133,6 +133,10 @@ cc_library(
         x + "/*.inc"
         for x in _PACKAGES
     ] + [
+        x + "/*.hpp"
+        for x in _PACKAGES
+    ] + [
+        "main/*.h",
         "drivers/unix/**/*.h",
     ]),
     copts = [

--- a/tools/workspace/godotengine/repository.bzl
+++ b/tools/workspace/godotengine/repository.bzl
@@ -8,8 +8,8 @@ def godotengine_repository(
     github_archive(
         name = name,
         repository = "godotengine/godot",
-        commit = "9bd402698cfa299b79b9144f8d7744c308a4e085",
-        sha256 = "cbec9b48d79b1fdc16a253f438fb06544a59baf71cf2c1f47c193817f2127a10",  # noqa
+        commit = "edc3e6b0daf4acfeb3565f0f799d304d945e5a0a",
+        sha256 = "136c1e958e75de15cf1dddfdd53906cbedb02343338a986694f50e1bfd5014e5",  # noqa
         build_file = "@drake//tools/workspace/godotengine:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
Clang 6 is the default clang compiler on Ubuntu 18.04 Bionic.
The previous Godot commit used was not compiling due to a bug in
Clang 6 that has been corrected in Clang 7 development branch.

A workaround has been integrated in Godot [1] in the current
development branch and was backported in the branch 2.1. It
has not yet been integrated in the branch 3.x.

Several include files in Godot are now generated by the build system.
To avoid having to recreate the rules to generate these files with
Bazel, we picked a commit that contained the workaround for Clang 6
but that does not integrate these automatically generated include
files.

[1] https://github.com/godotengine/godot/pull/18868

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9184)
<!-- Reviewable:end -->
