### PR TITLE
Disable support for multiple Python versions for a library on MacOS

### DIFF
--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -18,7 +18,13 @@ list_only = False
 # On linux, dynamic libraries may have their version number
 # as a suffix (e.g. my_lib.so.x.y.z).
 dylib_match = r"(.*\.so)(\.\d+)*$|(.*\.dylib)$"
-
+# Python C/C++ extensions are broken on Mac if library_prefix is r'lib':
+# On MacOS, both shared libraries and Python C/C++ extensions need to have
+# their image name fixed up.
+if sys.platform == "darwin":
+    library_prefix=r''
+else:
+    library_prefix=r'lib'
 
 def is_relative_link(filepath):
     """Find if a file is a relative link.
@@ -127,7 +133,7 @@ def install(src, dst):
     # are in different subdirectories.
     # Caveat: We assume that no C/C++ shared libraries depend on these Python
     # C/C++ extensions and require some RPath fix-up.
-    re_result = re.match(r'lib' + dylib_match, os.path.basename(dst))
+    re_result = re.match(library_prefix + dylib_match, os.path.basename(dst))
     if re_result is not None:  # It is a library
         basename = os.path.basename(re_result.group(0))
         # Check that dependency is only referenced once


### PR DESCRIPTION
This PR is a follow up of #9148 which allowed support for multiple
verions of Python for a library. This introduced a bug on MacOS.
Since this feature is not necessary on MacOS, we just disable it
for this platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9190)
<!-- Reviewable:end -->
