### PR TITLE
iiwa: Add dense sphere geometry from Calder, with simple collision visualization tool

### DIFF
--- a/manipulation/models/iiwa_description/urdf/.gitattributes
+++ b/manipulation/models/iiwa_description/urdf/.gitattributes
@@ -1,1 +1,3 @@
 *.urdf -diff
+
+iiwa14_spheres*.urdf diff

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_collision.urdf
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
-<!-- =================================================================================== -->
-<!-- |    This model is a hand edited version of the original model (see               | -->
-<!-- |    iiwa14_primitive_collision.urdf).                                            | -->
-<!-- =================================================================================== -->
+<!-- ===================================================================== -->
+<!-- |    This model is a hand edited version of the original model (see | -->
+<!-- |    iiwa14_primitive_collision.urdf).                              | -->
+<!-- ===================================================================== -->
 <!-- ===================================================================== -->
 <!-- Collision models: complex meshes can drastically affect run time.
      Therefore some collision models are represented as simple spheres

--- a/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
+++ b/manipulation/models/iiwa_description/urdf/iiwa14_spheres_dense_collision.urdf
@@ -1,0 +1,723 @@
+<?xml version="1.0" ?>
+<!-- ===================================================================== -->
+<!-- |    This model is a hand edited version of the original model (see | -->
+<!-- |    iiwa14_primitive_collision.urdf).                              | -->
+<!-- ===================================================================== -->
+<!-- ===================================================================== -->
+<!-- Collision models: complex meshes can drastically affect run time.
+     Therefore some collision models are represented as simple spheres
+     instead of meshes. However it's important to have accurate collision
+     models for the end of the arm because we anticipate that the end is the
+     most likely part of the arm to make contact.
+-->
+<!-- ===================================================================== -->
+<robot name="iiwa14" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- Import Rviz colors -->
+  <material name="Black">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+  <material name="Blue">
+    <color rgba="0.0 0.0 0.8 1.0"/>
+  </material>
+  <material name="Green">
+    <color rgba="0.0 0.8 0.0 1.0"/>
+  </material>
+  <material name="Grey">
+    <color rgba="0.4 0.4 0.4 1.0"/>
+  </material>
+  <material name="Orange">
+    <color rgba="1.0 0.423529411765 0.0392156862745 1.0"/>
+  </material>
+  <material name="Brown">
+    <color rgba="0.870588235294 0.811764705882 0.764705882353 1.0"/>
+  </material>
+  <material name="Red">
+    <color rgba="0.8 0.0 0.0 1.0"/>
+  </material>
+  <material name="White">
+    <color rgba="1.0 1.0 1.0 1.0"/>
+  </material>
+  <!-- Defines a base link that will serve as the model's root. -->
+  <link name="base"/>
+  <!--joint between {parent} and link_0-->
+  <joint name="iiwa_base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="base"/>
+    <child link="iiwa_link_0"/>
+  </joint>
+  <link name="iiwa_link_0">
+    <inertial>
+      <origin rpy="0 0 0" xyz="-0.1 0 0.07"/>
+      <mass value="5"/>
+      <inertia ixx="0.05" ixy="0" ixz="0" iyy="0.06" iyz="0" izz="0.03"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_0.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.03"/>
+      <geometry>
+        <sphere radius="0.12"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.08 0.0 0.103"/>
+      <geometry>
+        <sphere radius="0.08"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.08 0.0 0.04"/>
+      <geometry>
+        <sphere radius="0.08"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.14"/>
+      <geometry>
+        <sphere radius="0.1"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <self_collision_checking>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <capsule length="0.25" radius="0.15"/>
+      </geometry>
+    </self_collision_checking>
+  </link>
+  <!-- joint between link_0 and link_1 -->
+  <joint name="iiwa_joint_1" type="revolute">
+    <parent link="iiwa_link_0"/>
+    <child link="iiwa_link_1"/>
+    <origin rpy="0 0 0" xyz="0 0 0.1575"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.96705972839" upper="2.96705972839" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.93215314335" soft_upper_limit="2.93215314335"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_1">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 -0.03 0.12"/>
+      <mass value="5.76"/>
+      <inertia ixx="0.033" ixy="0" ixz="0" iyy="0.0333" iyz="0" izz="0.0123"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_1.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.0 -0.0005"/>
+      <geometry>
+        <sphere radius="0.08"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 -0.025 0.0425"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 -0.025 0.0425"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 -0.045 0.1025"/>
+      <geometry>
+        <sphere radius="0.07"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 -0.045 0.1025"/>
+      <geometry>
+        <sphere radius="0.07"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_1 and link_2 -->
+  <joint name="iiwa_joint_2" type="revolute">
+    <parent link="iiwa_link_1"/>
+    <child link="iiwa_link_2"/>
+    <origin rpy="1.570796326794897   0 3.141592653589793" xyz="0 0 0.2025"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_2">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0003 0.059 0.042"/>
+      <mass value="6.35"/>
+      <!-- 3.95 kuka CAD value-->
+      <!--4 Original Drake URDF value-->
+      <inertia ixx="0.0305" ixy="0" ixz="0" iyy="0.0304" iyz="0" izz="0.011"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_2.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -0.01"/>
+      <geometry>
+        <sphere radius="0.095"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.045"/>
+      <geometry>
+        <sphere radius="0.09"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.04 0.054"/>
+      <geometry>
+        <sphere radius="0.07"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.09 0.04"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.13 0.02"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.04 0.054"/>
+      <geometry>
+        <sphere radius="0.07"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.09 0.04"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.13 0.02"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.0 0.18 0"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_2 and link_3 -->
+  <joint name="iiwa_joint_3" type="revolute">
+    <parent link="iiwa_link_2"/>
+    <child link="iiwa_link_3"/>
+    <origin rpy="1.570796326794897 0 3.141592653589793" xyz="0 0.2045 0"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.96705972839" upper="2.96705972839" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_3">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.03 0.13"/>
+      <mass value="3.5"/>
+      <!--3.18 kuka CAD value-->
+      <!--3 Original Drake URDF value-->
+      <inertia ixx="0.025" ixy="0" ixz="0" iyy="0.0238" iyz="0" izz="0.0076"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_3.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0355"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.023 0.0855"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.048 0.1255"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.056 0.1755"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.023 0.0855"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.048 0.1255"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.056 0.1755"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.045 0.2155"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.2155"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_3 and link_4 -->
+  <joint name="iiwa_joint_4" type="revolute">
+    <parent link="iiwa_link_3"/>
+    <child link="iiwa_link_4"/>
+    <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_4">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.067 0.034"/>
+      <mass value="3.5"/>
+      <!--2.74 kuka CAD value-->
+      <!--2.7 Original Drake URDF value-->
+      <inertia ixx="0.017" ixy="0" ixz="0" iyy="0.0164" iyz="0" izz="0.006"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_4.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.01 0.046"/>
+      <geometry>
+        <sphere radius="0.078"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.06 0.052"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.12 0.034"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.06 0.052"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.12 0.034"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.184 0"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_4 and link_5 -->
+  <joint name="iiwa_joint_5" type="revolute">
+    <parent link="iiwa_link_4"/>
+    <child link="iiwa_link_5"/>
+    <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.1845 0"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.96705972839" upper="2.96705972839" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_5">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0.0001 0.021 0.076"/>
+      <mass value="3.5"/>
+      <!--1.69 kuka CAD value-->
+      <!--1.7 Original Drake URDF value-->
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.0087" iyz="0" izz="0.00449"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_5.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.0335"/>
+      <geometry>
+        <sphere radius="0.075"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.012 0.031 0.0755"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.012 0.031 0.0755"/>
+      <geometry>
+        <sphere radius="0.05"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.012 0.06 0.1155"/>
+      <geometry>
+        <sphere radius="0.04"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.012 0.06 0.1155"/>
+      <geometry>
+        <sphere radius="0.04"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.01 0.065 0.1655"/>
+      <geometry>
+        <sphere radius="0.04"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.01 0.065 0.1655"/>
+      <geometry>
+        <sphere radius="0.04"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="-0.012 0.065 0.1855"/>
+      <geometry>
+        <sphere radius="0.035"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0.012 0.065 0.1855"/>
+      <geometry>
+        <sphere radius="0.035"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_5 and link_6 -->
+  <joint name="iiwa_joint_6" type="revolute">
+    <parent link="iiwa_link_5"/>
+    <child link="iiwa_link_6"/>
+    <origin rpy="1.570796326794897 0 0" xyz="0 0 0.2155"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-2.09439510239" upper="2.09439510239" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-2.05948851735" soft_upper_limit="2.05948851735"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_6">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0.0006 0.0004"/>
+      <mass value="1.8"/>
+      <!--1.8 kuka CAD value-->
+      <!--1.8 Original Drake URDF value-->
+      <inertia ixx="0.0049" ixy="0" ixz="0" iyy="0.0047" iyz="0" izz="0.0036"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_6.obj"/>
+      </geometry>
+      <material name="Orange"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 -0.059"/>
+      <geometry>
+        <sphere radius="0.055"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 -0.03 0.011"/>
+      <geometry>
+        <sphere radius="0.065"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0.0 0"/>
+      <geometry>
+        <sphere radius="0.08"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <!-- joint between link_6 and link_7 -->
+  <joint name="iiwa_joint_7" type="revolute">
+    <parent link="iiwa_link_6"/>
+    <child link="iiwa_link_7"/>
+    <origin rpy="-1.570796326794897 3.141592653589793 0" xyz="0 0.081 0"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="300" lower="-3.05432619099" upper="3.05432619099" velocity="10"/>
+    <safety_controller k_position="100" k_velocity="2" soft_lower_limit="-3.01941960595" soft_upper_limit="3.01941960595"/>
+    <dynamics damping="0.5"/>
+  </joint>
+  <link name="iiwa_link_7">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0.02"/>
+      <mass value="1.2"/>
+      <!--0.31 kuka CAD value-->
+      <!--0.3 Original Drake URDF value-->
+      <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../meshes/visual/link_7.obj"/>
+      </geometry>
+      <material name="Grey"/>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.001"/>
+      <geometry>
+        <sphere radius="0.06"/>
+      </geometry>
+      <material name="Grey"/>
+    </collision>
+  </link>
+  <joint name="iiwa_joint_ee" type="fixed">
+    <parent link="iiwa_link_7"/>
+    <child link="iiwa_link_ee_kuka"/>
+    <origin rpy="3.141592653589793 3.141592653589793 3.141592653589793" xyz="0 0 0.045"/>
+    <axis xyz="0 0 1"/>
+  </joint>
+  <link name="iiwa_link_ee_kuka">
+    </link>
+  <joint name="tool0_joint" type="fixed">
+    <parent link="iiwa_link_7"/>
+    <child link="iiwa_link_ee"/>
+    <origin rpy="0 -1.570796326794897 0" xyz="0 0 0.045"/>
+  </joint>
+  <link name="iiwa_link_ee">
+    </link>
+  <frame link="iiwa_link_ee" name="iiwa_frame_ee" rpy="3.141592653589793 0 1.570796326794897" xyz="0.09 0 0"/>
+  <!-- Load Gazebo lib and set the robot namespace -->
+  <gazebo>
+    <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_controller">
+      <robotNamespace>/iiwa</robotNamespace>
+    </plugin>
+  </gazebo>
+  <!-- Link0 -->
+  <gazebo reference="iiwa_link_0">
+    <material>Gazebo/Grey</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link1 -->
+  <gazebo reference="iiwa_link_1">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link2 -->
+  <gazebo reference="iiwa_link_2">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link3 -->
+  <gazebo reference="iiwa_link_3">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link4 -->
+  <gazebo reference="iiwa_link_4">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link5 -->
+  <gazebo reference="iiwa_link_5">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link6 -->
+  <gazebo reference="iiwa_link_6">
+    <material>Gazebo/Orange</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <!-- Link7 -->
+  <gazebo reference="iiwa_link_7">
+    <material>Gazebo/Grey</material>
+    <mu1>0.2</mu1>
+    <mu2>0.2</mu2>
+  </gazebo>
+  <transmission name="iiwa_tran_1">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_1">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_1">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_2">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_2">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_3">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_3">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_3">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_4">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_4">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_5">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_5">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_5">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_6">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_6">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <transmission name="iiwa_tran_7">
+    <robotNamespace>/iiwa</robotNamespace>
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="iiwa_joint_7">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="iiwa_motor_7">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+  <collision_filter_group name="wrist">
+    <member link="iiwa_link_5"/>
+    <member link="iiwa_link_6"/>
+    <member link="iiwa_link_7"/>
+    <ignored_collision_filter_group collision_filter_group="wrist"/>
+  </collision_filter_group>
+</robot>

--- a/manipulation/util/BUILD.bazel
+++ b/manipulation/util/BUILD.bazel
@@ -247,4 +247,8 @@ drake_py_unittest(
     ],
 )
 
-add_lint_tests()
+add_lint_tests(
+    python_lint_extra_srcs = [
+        "convert_to_visualize_collisions.py",
+    ],
+)

--- a/manipulation/util/convert_to_visualize_collisions.py
+++ b/manipulation/util/convert_to_visualize_collisions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python2
+"""
+Try removing <visual> tags and turn <collision> tags into <visual> tags, for
+both URDF and SDF.
+
+@note May produce invalid XML if comments are nested within the original
+<visual> tags.
+"""
+
+import argparse
+import re
+import sys
+
+
+def replace_list(text, sub_list):
+    for old, new in sub_list:
+        text = re.sub(old, new, text)
+    return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "file", type=argparse.FileType("r"), metavar="FILENAME")
+    args = parser.parse_args()
+
+    with args.file as f:
+        contents = f.read()
+    contents = replace_list(contents, (
+        (r"<visual\b", "<!-- <visual"),
+        (r"</visual>", "</visual> -->"),
+        (r"<collision\b", "<visual"),
+        (r"</collision>", "</visual>"),
+    ))
+
+    sys.stdout.write(contents)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We ran into a case where we did not have sufficient collision geometry to prevent the arm from colliding with the sink. As an option for more conservative movements, this provides an URDF with a more dense sampling of spheres from @calderpg-tri.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9192)
<!-- Reviewable:end -->
