### PR TITLE
Add set_name to Python bindings for RigidBodyFrame

### DIFF
--- a/bindings/pydrake/multibody/rigid_body_tree_py.cc
+++ b/bindings/pydrake/multibody/rigid_body_tree_py.cc
@@ -404,7 +404,8 @@ PYBIND11_MODULE(rigid_body_tree, m) {
          // Keep alive: `this` keeps `return` alive.
          py::keep_alive<1, 0>())
     .def("get_transform_to_body",
-         &RigidBodyFrame<double>::get_transform_to_body);
+         &RigidBodyFrame<double>::get_transform_to_body)
+    .def("set_name", &RigidBodyFrame<double>::set_name);
 
   m.def("AddModelInstanceFromUrdfFile",
         [](const std::string& urdf_filename,

--- a/bindings/pydrake/multibody/test/rigid_body_tree_test.py
+++ b/bindings/pydrake/multibody/test/rigid_body_tree_test.py
@@ -248,6 +248,8 @@ class TestRigidBodyTree(unittest.TestCase):
         self.assertTrue(frame.get_rigid_body() is tree.world())
         self.assertIsInstance(frame.get_transform_to_body(), Isometry3)
         self.assertTrue(tree.findFrame(frame_name="frame_1") is frame)
+        frame.set_name("frame_2")
+        self.assertEqual(frame.get_name(), "frame_2")
 
     def test_flat_terrain(self):
         tree = RigidBodyTree(FindResourceOrThrow(


### PR DESCRIPTION
Allows to rename frames that are automatically added to a RigidBodyTree when a model is loaded from a URDF file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9195)
<!-- Reviewable:end -->
