### PR TITLE
 Fix various spelling mistakes in comments and strings, part 1

### DIFF
--- a/lcm/test/drake_lcm_test.cc
+++ b/lcm/test/drake_lcm_test.cc
@@ -93,7 +93,7 @@ TEST_F(DrakeLcmTest, PublishTest) {
 
   MessageSubscriber subscriber(channel_name, dut.get_lcm_instance());
 
-  // Start the LCM recieve thread after all objects it can potentially use like
+  // Start the LCM receive thread after all objects it can potentially use like
   // subscribers are instantiated. Since objects are destructed in the reverse
   // order of construction, this ensures the LCM receive thread stops before any
   // resources it uses are destroyed. If the Lcm receive thread is stopped after

--- a/math/discrete_algebraic_riccati_equation.cc
+++ b/math/discrete_algebraic_riccati_equation.cc
@@ -255,8 +255,8 @@ void swap_block_22(Eigen::Ref<Eigen::MatrixXd> S, Eigen::Ref<Eigen::MatrixXd> T,
 
 // Functionality of "swap_block" function:
 // swap the 1x1 or 2x2 blocks pointed by p and q.
-// There are four cases: swaping 1x1 and 1x1 matrices, swaping 2x2 and 1x1
-// matrices, swaping 1x1 and 2x2 matrices, and swaping 2x2 and 2x2 matrices.
+// There are four cases: swapping 1x1 and 1x1 matrices, swapping 2x2 and 1x1
+// matrices, swapping 1x1 and 2x2 matrices, and swapping 2x2 and 2x2 matrices.
 // Algorithms are described in the papers
 // "A generalized eigenvalue approach for solving Riccati equations" by P. Van
 // Dooren, 1981 ( http://epubs.siam.org/doi/pdf/10.1137/0902010 ), and

--- a/math/quaternion.h
+++ b/math/quaternion.h
@@ -410,7 +410,7 @@ bool IsBothQuaternionAndQuaternionDtOK(const Eigen::Quaternion<T>& quat,
 
 /** This function tests if a quaternion and a quaternions time-derivative
  * can calculate and match an angular velocity to within a tolerance.
- * Note: This function first tests if the quaternion [w, x, y, z] satisifies
+ * Note: This function first tests if the quaternion [w, x, y, z] satisfies
  * w^2 + x^2 + y^2 + z^2 = 1 (to within tolerance) and if its time-derivative
  * satisfies  w*ẇ + x*ẋ + y*ẏ + z*ż = 0  (to within tolerance).  Lastly, it
  * tests if each element of the angular velocity calculated from quat and quatDt
@@ -429,7 +429,7 @@ bool IsQuaternionAndQuaternionDtEqualAngularVelocityExpressedInB(
                                        const Vector4<T>& quatDt,
                                        const Vector3<T>& w_B,
                                        const double tolerance) {
-  // Ensure time-derivative of quaternion satifies quarternionDt test.
+  // Ensure time-derivative of quaternion satisfies quarternionDt test.
   if ( !math::IsBothQuaternionAndQuaternionDtOK(quat, quatDt, tolerance) )
     return false;
 

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -296,7 +296,7 @@ class RollPitchYaw {
   // TODO(Mitiguy) Improve speed -- last column of M is (0, 0, 1).
   Vector3<T> CalcAngularVelocityInParentFromRpyDt(
       const Vector3<T>& rpyDt) const {
-    // Get the 3x3 coefficent matrix M that contains the partial derivatives of
+    // Get the 3x3 coefficient matrix M that contains the partial derivatives of
     // w_AD_A with respect to ṙ, ṗ, ẏ.  In other words, `w_AD_A = M * rpyDt`.
     const Matrix3<T> M = CalcMatrixRelatingAngularVelocityInParentToRpyDt();
     return M * rpyDt;
@@ -309,7 +309,7 @@ class RollPitchYaw {
   // TODO(Mitiguy) Improve speed -- first column of M is (1, 0, 0).
   Vector3<T> CalcAngularVelocityInChildFromRpyDt(
       const Vector3<T>& rpyDt) const {
-    // Get the 3x3 coefficent matrix M that contains the partial derivatives of
+    // Get the 3x3 coefficient matrix M that contains the partial derivatives of
     // w_AD_D with respect to ṙ, ṗ, ẏ.  In other words, `w_AD_D = M * rpyDt`.
     const Matrix3<T> M = CalcMatrixRelatingAngularVelocityInChildToRpyDt();
     return M * rpyDt;
@@ -466,7 +466,7 @@ class RollPitchYaw {
 
   // For `this` %RollPitchYaw with roll-pitch-yaw angles `[r; p; y]` which
   // relate the orientation of two generic frames A and D, returns the 3x3
-  // coefficent matrix M that contains the partial derivatives of `w_AD_A`
+  // coefficient matrix M that contains the partial derivatives of `w_AD_A`
   // (D's angular velocity in A, expressed in A) with respect to ṙ, ṗ, ẏ.
   // In other words, `w_AD_A = M * rpyDt` where `rpyDt` is `[ṙ; ṗ; ẏ]`.
   const Matrix3<T> CalcMatrixRelatingAngularVelocityInParentToRpyDt() const {
@@ -512,7 +512,7 @@ class RollPitchYaw {
 
   // For `this` %RollPitchYaw with roll-pitch-yaw angles `[r; p; y]` which
   // relate the orientation of two generic frames A and D, returns the 3x3
-  // coefficent matrix M that contains the partial derivatives of `w_AD_D`
+  // coefficient matrix M that contains the partial derivatives of `w_AD_D`
   // (D's angular velocity in A, expressed in D) with respect to ṙ, ṗ, ẏ.
   // In other words, `w_AD_D = M * rpyDt` where `rpyDt` is `[ṙ; ṗ; ẏ]`.
   const Matrix3<T> CalcMatrixRelatingAngularVelocityInChildToRpyDt() const {

--- a/math/test/quaternion_test.cc
+++ b/math/test/quaternion_test.cc
@@ -31,7 +31,7 @@ Eigen::Quaterniond  GetGenericArbitraryQuaternion(const double half_angle,
 
 // Form a generic time-derivative of the quaternion [e0, e1, e2, e3] generated
 // by a pi/6 rotation about a generic vector.  Ensure the time-derivative
-// satisifies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
+// satisfies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
 // MotionGenesis was used to calculate these values of e0Dt, e1Dt, e2Dt, e3Dt.
 Eigen::Vector4d  GetQuaternionDtAssociatedWith30DegRotation() {
   const double e0Dt = -0.4211981425390414;
@@ -194,7 +194,7 @@ GTEST_TEST(CalculateAngularVelocityExpressedInBFromQuaternionDtTest, testA) {
 // This function tests CalculateQuaternionDtConstraintViolation.
 GTEST_TEST(CalculateQuaternionDtConstraintViolationTest, testA) {
   // MotionGenesis was used to calculate values for e0Dt, e1Dt, e2Dt, e3Dt that
-  // satisifies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
+  // satisfies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
   const Eigen::Quaterniond quat = GetGenericArbitraryQuaternion(M_PI/6, true);
   const Eigen::Vector4d quatDt = GetQuaternionDtAssociatedWith30DegRotation();
   const double z_bad = 0.99 * quatDt(3);
@@ -225,7 +225,7 @@ GTEST_TEST(IsQuaternionValid, testA) {
 // This function tests IsBothQuaternionAndQuaternionDtOK.
 GTEST_TEST(IsBothQuaternionAndQuaternionDtOK, testA) {
   // MotionGenesis was used to calculate values for e0Dt, e1Dt, e2Dt, e3Dt that
-  // satisifies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
+  // satisfies the constraint  e0*ė0 + e1*ė1 + e2*ė2 + e3*ė3 = 0.
   const Eigen::Quaterniond quat = GetGenericArbitraryQuaternion(M_PI/6, true);
   const Eigen::Vector4d quatDt = GetQuaternionDtAssociatedWith30DegRotation();
   const double z_bad = 0.99 * quatDt(3);

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -275,7 +275,7 @@ GTEST_TEST(RollPitchYaw, PrecisionOfAngularVelocityFromRpyDtAndViceVersa) {
       // max_rpyDt scales with 1/cos(pitch_angle) multiplied by angular velocity
       // wA = (1, 1, 1).  Check that max_rpyDt has a range that is within
       // a reasonable multiplier (1000) of that scale.
-      // max_rpyDDt scales with 1/cos(pitch_angle)² multipled by angular
+      // max_rpyDDt scales with 1/cos(pitch_angle)² multiplied by angular
       // acceleration alphaA = (1, 1, 1).  Check that max_rpyDDt has a range
       // that is within a reasonable multiplier (1000²) of that scale.
       EXPECT_TRUE(1E-3 / tolerance <= max_rpyDt &&

--- a/math/test/rotation_conversion_test.cc
+++ b/math/test/rotation_conversion_test.cc
@@ -226,7 +226,7 @@ class RotationConversionTest : public ::testing::Test {
     // 1E-10 rotation around an arbitrary axis
     addAngleAxisTestCase(1E-10, axis);
 
-    // -epsilon rotation around an arbitary axis
+    // -epsilon rotation around an arbitrary axis
     addAngleAxisTestCase(-kEpsilon, axis);
 
     // -1E-10 rotation around an arbitrary axis
@@ -250,10 +250,10 @@ class RotationConversionTest : public ::testing::Test {
     // -180 rotation around z axis
     addAngleAxisTestCase(-M_PI, Vector3d::UnitZ());
 
-    // 180 rotation around an arbitary axis
+    // 180 rotation around an arbitrary axis
     addAngleAxisTestCase(M_PI, axis);
 
-    // -180 rotation around an arbitary axis
+    // -180 rotation around an arbitrary axis
     addAngleAxisTestCase(-M_PI, axis);
 
     // (1-epsilon)*pi rotation around an arbitrary axis

--- a/perception/dev/feedforward_neural_network.cc
+++ b/perception/dev/feedforward_neural_network.cc
@@ -118,7 +118,7 @@ template <typename T>
 VectorX<T> FeedforwardNeuralNetwork<T>::EvaluateLayer(
     const VectorX<T>& layerInput, MatrixX<T> Weights, VectorX<T> bias,
     LayerType layer, NonlinearityType nonlinearity) const {
-  // Only suppports fully-connected RELU at this time
+  // Only supports fully-connected RELU at this time
   DRAKE_DEMAND(layer == LayerType::FullyConnected);
   DRAKE_DEMAND(nonlinearity == NonlinearityType::Relu);
   VectorX<T> layer_output = relu(Weights * layerInput + bias);

--- a/perception/estimators/dev/articulated_icp.cc
+++ b/perception/estimators/dev/articulated_icp.cc
@@ -152,7 +152,7 @@ void ComputeCorrespondences(const SceneState& scene_state,
   vector<BodyIndex> body_indices(num_points);
 
   const bool use_margins = false;
-  // TOOD(eric.cousineau): Figure out better access.
+  // TODO(eric.cousineau): Figure out better access.
   // TODO(eric.cousineau): Tie this directly to the visuals, rather than the
   // collision geometry.
   RigidBodyTreed& mutable_tree = const_cast<RigidBodyTreed&>(scene.tree());

--- a/solvers/ipopt_solver.cc
+++ b/solvers/ipopt_solver.cc
@@ -174,7 +174,7 @@ class IpoptSolver_NLP : public Ipopt::TNLP {
     n = problem_->num_vars();
 
     // The IPOPT interface defines eval_f() and eval_grad_f() as
-    // ouputting a single number for the result, and the size of the
+    // outputting a single number for the result, and the size of the
     // output gradient array at the same order as the x variables.
     // Initialize the cost cache with those dimensions.
     cost_cache_.reset(new ResultCache(n, 1, n));

--- a/solvers/mathematical_program.h
+++ b/solvers/mathematical_program.h
@@ -2156,7 +2156,7 @@ class MathematicalProgram {
   }
 
   /**
-   * Set the intial guess for ALL decision variables.
+   * Set the initial guess for ALL decision variables.
    * Note that variables begin with a default initial guess of NaN to indicate
    * that no guess is available.
    * @param x0 A vector of appropriate size (num_vars() x 1).
@@ -2199,11 +2199,11 @@ class MathematicalProgram {
    *
    * Supported solver names/options:
    *
-   * "SNOPT" -- Paramater names and values as specified in SNOPT
+   * "SNOPT" -- Parameter names and values as specified in SNOPT
    * User's Guide section 7.7 "Description of the optional parameters",
    * used as described in section 7.5 for snSet().
    *
-   * "IPOPT" -- Paramater names and values as specified in IPOPT users
+   * "IPOPT" -- Parameter names and values as specified in IPOPT users
    * guide section "Options Reference"
    * http://www.coin-or.org/Ipopt/documentation/node40.html
    *
@@ -2413,7 +2413,7 @@ class MathematicalProgram {
   const Eigen::VectorXd& initial_guess() const { return x_initial_guess_; }
 
   /** Returns the index of the decision variable. Internally the solvers thinks
-   * all variables are stored in an array, and it acceses each individual
+   * all variables are stored in an array, and it accesses each individual
    * variable using its index. This index is used when adding constraints
    * and costs for each solver.
    * @pre{@p var is a decision variable in the mathematical program, otherwise
@@ -2423,7 +2423,7 @@ class MathematicalProgram {
 
   /**
    * Returns the indices of the decision variables. Internally the solvers
-   * thinks all variables are stored in an array, and it acceses each individual
+   * thinks all variables are stored in an array, and it accesses each individual
    * variable using its index. This index is used when adding constraints
    * and costs for each solver.
    * @pre{@p vars are decision variables in the mathematical program, otherwise
@@ -2436,7 +2436,7 @@ class MathematicalProgram {
   int num_indeterminates() const { return indeterminates_.rows(); }
 
   /** Returns the index of the indeterminate. Internally a solver
-   * thinks all indeterminates are stored in an array, and it acceses each
+   * thinks all indeterminates are stored in an array, and it accesses each
    * individual indeterminate using its index. This index is used when adding
    * constraints and costs for each solver.
    * @pre @p var is a indeterminate in the mathematical program,

--- a/solvers/mosek_solver.cc
+++ b/solvers/mosek_solver.cc
@@ -614,7 +614,7 @@ class MosekSolver::License {
     // fail fast if the license file is missing or the server is
     // unavailable. Any additional features should be checked out
     // later by MSK_optimizetrm if needed (so there's still the
-    // possiblity of later failure at that stage if the desired
+    // possibility of later failure at that stage if the desired
     // feature is unavailable or another error occurs).
     rescode = MSK_checkoutlicense(mosek_env_, MSK_FEATURE_PTS);
     if (rescode != MSK_RES_OK) {
@@ -747,7 +747,7 @@ SolutionResult MosekSolver::Solve(MathematicalProgram& prog) const {
   }
 
   SolverResult solver_result(id());
-  // TODO(hongkai.dai@tri.global) : Add MOSEK paramaters.
+  // TODO(hongkai.dai@tri.global) : Add MOSEK parameters.
   // Mosek parameter are added by enum, not by string.
   if (rescode == MSK_RES_OK) {
     MSKsolstae solution_status;

--- a/solvers/nlopt_solver.cc
+++ b/solvers/nlopt_solver.cc
@@ -160,7 +160,7 @@ void EvaluateVectorConstraint(unsigned m, double* result, unsigned n,
   }
 
   // http://ab-initio.mit.edu/wiki/index.php/NLopt_Reference#Vector-valued_constraints
-  // explicity tells us that it's allocated m * n array elements
+  // explicitly tells us that it's allocated m * n array elements
   // before invoking this function.  It does not seem to have been
   // zeroed, and not all constraints will store gradients for all
   // decision variables (so don't leave junk in the other array

--- a/solvers/qp.cc
+++ b/solvers/qp.cc
@@ -208,7 +208,7 @@ int fastQPThatTakesQinv(vector<MatrixXd*> QinvblkDiag, const VectorXd& f,
 
     i = 0;
     set<int>::iterator iter = active.begin(), tmp;
-    while (iter != active.end()) {  // to accomodating inloop erase
+    while (iter != active.end()) {  // to accommodating inloop erase
       tmp = iter++;
       if (lamIneq(i++) < 0) {
         active.erase(tmp);

--- a/solvers/system_identification.h
+++ b/solvers/system_identification.h
@@ -71,7 +71,7 @@ class SystemIdentification {
 
   /// Same as GetLumpedParametersFromPolynomial but for multiple Polynomials.
   /**
-   * It is preferrable to use this if you have multiple Polynomials as it
+   * It is preferable to use this if you have multiple Polynomials as it
    * saves you from having to union the resulting LumpingMapType results
    * together.
    */

--- a/solvers/test/cost_test.cc
+++ b/solvers/test/cost_test.cc
@@ -261,7 +261,7 @@ GTEST_TEST(testCost, testFunctionCost) {
   // Test that we can construct FunctionCosts with different signatures.
   Eigen::Vector2d x(1, 2);
   VerifyFunctionCost(GenericTrivialCost2(), x);
-  // Ensure that we explictly call the default constructor for a const class.
+  // Ensure that we explicitly call the default constructor for a const class.
   // @ref http://stackoverflow.com/a/28338123/7829525
   const GenericTrivialCost2 obj_const{};
   VerifyFunctionCost(obj_const, x);

--- a/solvers/test/quadratic_program_examples.cc
+++ b/solvers/test/quadratic_program_examples.cc
@@ -191,7 +191,7 @@ QuadraticProgram1::QuadraticProgram1(CostForm cost_form,
       prog()->AddLinearConstraint(x_(0) + 2 * x_(1) + 3 * x_(2) >= 4);
       prog()->AddLinearConstraint(-x_(0) - x_(1) <= -1);
       prog()->AddLinearConstraint(x_(1) + 2 * x_(2), -20, 100);
-      // TODO(hongkai.dai): Uncoment the next line, when we resolves the error
+      // TODO(hongkai.dai): Uncomment the next line, when we resolve the error
       // with infinity on the right handside of a formula.
       // prog()->AddLinearConstraint(x_(0) + x_(1) + 2 * x_(2) <=
       // numeric_limits<double>::infinity());

--- a/systems/analysis/integrator_base.h
+++ b/systems/analysis/integrator_base.h
@@ -910,7 +910,7 @@ class IntegratorBase {
    * integration. This is an advanced topic and most users can simply specify
    * desired accuracy and accept the default state variable weights.
    *
-   * A collection of state variables is generally defined in heterogenous units
+   * A collection of state variables is generally defined in heterogeneous units
    * (e.g. length, angles, velocities, energy). Some of the state
    * variables cannot even be expressed in meaningful units, like
    * quaternions. Certain integrators provide an estimate of the absolute error
@@ -1606,7 +1606,7 @@ bool IntegratorBase<T>::StepOnceErrorControlledAtMost(const T& dt_max) {
     // Constants used to determine whether modifications to the step size are
     // close enough to the attempted step size to use the unadjusted originals,
     // or (1) whether the step size to be attempted is so small that we should
-    // consider it to be artifically limited or (2) whether the step size to
+    // consider it to be artificially limited or (2) whether the step size to
     // be attempted is sufficiently close to that requested such that the step
     // size should be stretched slightly.
     const double near_enough_smaller = 0.95;

--- a/systems/analysis/test/simulator_test.cc
+++ b/systems/analysis/test/simulator_test.cc
@@ -669,7 +669,7 @@ GTEST_TEST(SimulatorTest, WitnessTestCountChallenging) {
 // in the case of multiple witness functions. See issue #6184.
 
 GTEST_TEST(SimulatorTest, SecondConstructor) {
-  // Create the spring-mass sytem and context.
+  // Create the spring-mass system and context.
   analysis_test::MySpringMassSystem<double> spring_mass(1., 1., 0.);
   auto context = spring_mass.CreateDefaultContext();
 

--- a/systems/controllers/inverse_dynamics_controller.h
+++ b/systems/controllers/inverse_dynamics_controller.h
@@ -50,7 +50,7 @@ class InverseDynamicsController : public StateFeedbackControllerInterface<T>,
   /**
    * Constructs the controller that takes ownership of a given RigidBodyTree
    * unique pointer.
-   * @param robot Unique pointer whose ownership will be transfered to this
+   * @param robot Unique pointer whose ownership will be transferred to this
    * instance.
    * @param kp Position gain
    * @param ki Integral gain

--- a/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics.h
+++ b/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics.h
@@ -88,7 +88,7 @@ class QpInverseDynamics {
   int num_basis_{0};
   int num_torque_{0};
   int num_variable_{0};
-  // One cost / eqaulity constraint term per body motion.
+  // One cost / equality constraint term per body motion.
   // For each dimension (row) of the desired body motion, it can be treated
   // as a cost term (Soft), skipped (SKip) or as an equality constraint (Hard)
   // depending on the given constraint type. If it's a Soft constraint, the

--- a/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_common.h
+++ b/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_common.h
@@ -153,7 +153,7 @@ class ContactInformation {
   /**
    * Constructs a ContactInformation object for @p body.
    * @param body Reference to a RigidBody, which must be valid through the
-   * lifespan of this obejct.
+   * lifespan of this object.
    * @param num_basis_per_contact_point Number of basis per contact point.
    */
   ContactInformation(const RigidBody<double>& body,
@@ -341,7 +341,7 @@ class DesiredBodyMotion : public ConstrainedValues {
    * Constructs a DesiredBodyMotion object that hold desired spatial
    * acceleration for @p body.
    * @param body Reference to a RigidBody, which must be valid through the
-   * lifespan of this obejct.
+   * lifespan of this object.
    */
   explicit DesiredBodyMotion(const RigidBody<double>& body)
       : ConstrainedValues(6), body_(&body), control_during_contact_(false) {}
@@ -633,7 +633,7 @@ class BodyAcceleration {
   /**
    * Constructs a BodyAcceleration object for @p body.
    * @param body Reference to a RigidBody, which must be valid through the
-   * lifespan of this obejct.
+   * lifespan of this object.
    */
   explicit BodyAcceleration(const RigidBody<double>& body)
       : body_(&body), accelerations_(Vector6<double>::Zero()) {}

--- a/systems/controllers/qp_inverse_dynamics/test/iiwa_inverse_dynamics_test.cc
+++ b/systems/controllers/qp_inverse_dynamics/test/iiwa_inverse_dynamics_test.cc
@@ -77,7 +77,7 @@ GTEST_TEST(testQPInverseDynamicsController, testForIiwa) {
                                      output.vd(), 1e-9,
                                      drake::MatrixCompareType::absolute));
 
-  // Without any external forces or hitting any contraints, torque = M * vd_d +
+  // Without any external forces or hitting any constraints, torque = M * vd_d +
   // h.
   VectorX<double> expected_torque =
       robot_status.get_M() * input.desired_dof_motions().values() +

--- a/systems/controllers/qp_inverse_dynamics/test/param_parser_test.cc
+++ b/systems/controllers/qp_inverse_dynamics/test/param_parser_test.cc
@@ -171,7 +171,7 @@ TEST_F(ParamParserTests, BodyMotionParams) {
   weights << 1, 1, 1, 1, 1, 2;
   TestDesiredBodyMotion(motion, body, weights, kTolerance);
 
-  // "NO_SUCH_BODY_GROUP" is not a valid group name, so this returns emtpy.
+  // "NO_SUCH_BODY_GROUP" is not a valid group name, so this returns empty.
   EXPECT_TRUE(paramset_.MakeDesiredBodyMotion("NO_SUCH_BODY_GROUP", *rbt_alias_)
                   .empty());
 

--- a/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
+++ b/systems/controllers/qp_inverse_dynamics/test/qp_inverse_dynamics_system_test.cc
@@ -114,7 +114,7 @@ GTEST_TEST(testQpInverseDynamicsSystem, IiwaInverseDynamics) {
                                      qp_output.vd(), 1e-9,
                                      drake::MatrixCompareType::absolute));
 
-  // Without any external forces or hitting any contraints, torque = M * vd_d +
+  // Without any external forces or hitting any constraints, torque = M * vd_d +
   // h.
   VectorX<double> expected_torque =
       robot_status.get_M() * input.desired_dof_motions().values() +

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -304,7 +304,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   /// Returns a constant reference to the subcontext that corresponds to the
   /// system @p subsystem.
   /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the apropriate subcontext. Aborts if
+  /// pass their constituent subsystems the appropriate subcontext. Aborts if
   /// @p subsystem is not actually a subsystem of this diagram.
   const Context<T>& GetSubsystemContext(const System<T>& subsystem,
                                         const Context<T>& context) const {
@@ -315,7 +315,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
 
   /// Returns the subcontext that corresponds to the system @p subsystem.
   /// Classes inheriting from %Diagram need access to this method in order to
-  /// pass their constituent subsystems the apropriate subcontext. Aborts if
+  /// pass their constituent subsystems the appropriate subcontext. Aborts if
   /// @p subsystem is not actually a subsystem of this diagram.
   Context<T>& GetMutableSubsystemContext(const System<T>& subsystem,
                                          Context<T>* context) const {
@@ -442,7 +442,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     }
 
     // -- Add edges from the input and output port nodes to the subsystems that
-    //    actually service that port.  These edges are higlighted in blue
+    //    actually service that port.  These edges are highlighted in blue
     //    (input) and green (output), matching the port nodes.
     for (int i = 0; i < this->get_num_input_ports(); ++i) {
       const auto& port_id = input_port_ids_[i];
@@ -1493,7 +1493,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
   // they were registered. Index by SubsystemIndex.
   std::vector<std::unique_ptr<System<T>>> registered_systems_;
 
-  // Map to quickly satisify "What is the subsytem index of the child system?"
+  // Map to quickly satisfy "What is the subsystem index of the child system?"
   std::map<const System<T>*, SubsystemIndex> system_index_map_;
 
   // The ordered inputs and outputs of this Diagram. Index by InputPortIndex

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -2405,7 +2405,7 @@ GTEST_TEST(DiagramConstraintTest, SystemConstraintsTest) {
 }
 
 GTEST_TEST(DiagramParametersTest, ParameterTest) {
-  // Construct a diagram with multiple subsytems that have parameters.
+  // Construct a diagram with multiple subsystems that have parameters.
   systems::DiagramBuilder<double> builder;
   auto pendulum1 =
       builder.AddSystem<examples::pendulum::PendulumPlant<double>>();

--- a/systems/framework/test_utilities/test/my_vector_test.cc
+++ b/systems/framework/test_utilities/test/my_vector_test.cc
@@ -52,7 +52,7 @@ GTEST_TEST(MyVectorTest, MakeMethod) {
   EXPECT_EQ(vector4->get_value(), Vector4d(10., 20., 30., 40.));
 }
 
-// Tests that cloning works and check compatiblity with copyable_unique_ptr
+// Tests that cloning works and check compatibility with copyable_unique_ptr
 // and AbstractValue.
 GTEST_TEST(MyVectorTest, Clone) {
   MyVector3d vector3(Vector3d(1., 2., 3.));

--- a/systems/framework/value.h
+++ b/systems/framework/value.h
@@ -61,7 +61,7 @@ struct ValueTraitsImpl<T, false> {
   //   template <class Foo> DoBar(const Foo& foo) { DoBar(Value<Foo>{foo}); }
   // and accidentally called DoBar<AbstractValue>, or similar mistakes.
   static_assert(!std::is_same<T, std::remove_cv<AbstractValue>::type>::value,
-                "T in Value<T> cannnot be AbstractValue.");
+                "T in Value<T> cannot be AbstractValue.");
 
   using UseCopy = std::false_type;
   using Storage = typename drake::copyable_unique_ptr<T>;

--- a/systems/sensors/rgbd_camera.cc
+++ b/systems/sensors/rgbd_camera.cc
@@ -18,7 +18,7 @@ namespace systems {
 namespace sensors {
 
 // Note that if `depth_image` holds any pixels that have NaN, the converted
-// points will aslo become NaN.
+// points will also become NaN.
 void RgbdCamera::ConvertDepthImageToPointCloud(const ImageDepth32F& depth_image,
                                                const CameraInfo& camera_info,
                                                Eigen::Matrix3Xf* point_cloud) {

--- a/systems/sensors/rgbd_renderer_ospray.cc
+++ b/systems/sensors/rgbd_renderer_ospray.cc
@@ -83,7 +83,7 @@ using ActorCollection = std::vector<vtkSmartPointer<vtkActor>>;
 std::string RemoveFileExtension(const std::string& filepath) {
   const size_t last_dot = filepath.find_last_of(".");
   if (last_dot == std::string::npos) {
-    DRAKE_ABORT_MSG("File has no extention.");
+    DRAKE_ABORT_MSG("File has no extension.");
   }
   return filepath.substr(0, last_dot);
 }

--- a/systems/sensors/rgbd_renderer_vtk.cc
+++ b/systems/sensors/rgbd_renderer_vtk.cc
@@ -85,7 +85,7 @@ struct ModuleInitVtkRenderingOpenGL2 {
 std::string RemoveFileExtension(const std::string& filepath) {
   const size_t last_dot = filepath.find_last_of(".");
   if (last_dot == std::string::npos) {
-    DRAKE_ABORT_MSG("File has no extention.");
+    DRAKE_ABORT_MSG("File has no extension.");
   }
   return filepath.substr(0, last_dot);
 }

--- a/systems/sensors/rotary_encoders.h
+++ b/systems/sensors/rotary_encoders.h
@@ -50,7 +50,7 @@ class RotaryEncoders final : public VectorSystem<T> {
       Context<T>* context,
       const Eigen::Ref<VectorX<T>>& calibration_offsets) const;
 
-  /// Retreive the calibration offset parameters.
+  /// Retrieve the calibration offset parameters.
   Eigen::VectorBlock<const VectorX<T>> get_calibration_offsets(
       const Context<T>& context) const;
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -48,7 +48,7 @@ config_setting(
 )
 
 # IPOPT is an open-source solver, and is included in the Drake build by
-# default. The IPOPT solver is irrelvant to some users of MathematicalProgram,
+# default. The IPOPT solver is irrelevant to some users of MathematicalProgram,
 # so we provide a hidden switch to shut it off for developers who don't
 # actually need it.  This is not a supported configuration. Use at your own
 # risk: --define=NO_IPOPT=ON
@@ -58,7 +58,7 @@ config_setting(
 )
 
 # NLOPT is an open-source solver, and is included in the Drake build by
-# default. The NLOPT solver is irrelvant to some users of MathematicalProgram,
+# default. The NLOPT solver is irrelevant to some users of MathematicalProgram,
 # so we provide a hidden switch to shut it off for developers who don't
 # actually need it.  This is not a supported configuration. Use at your own
 # risk: --define=NO_NLOPT=ON
@@ -68,7 +68,7 @@ config_setting(
 )
 
 # OSQP is an open-source solver, and is included in the Drake build by
-# default. The OSQP solver is irrelvant to some users of MathematicalProgram,
+# default. The OSQP solver is irrelevant to some users of MathematicalProgram,
 # so we provide a hidden switch to shut it off for developers who don't
 # actually need it.  This is not a supported configuration. Use at your own
 # risk: --define=NO_OSQP=ON

--- a/tools/external_data/test/workspace_test.bzl
+++ b/tools/external_data/test/workspace_test.bzl
@@ -19,7 +19,7 @@ def workspace_test(
         data = []):
     """
     Copies all contents under `*.runfiles/${workspace}/**` to a temporary
-    directory, then evalutates `args` in `bash` in the new temporary runfiles
+    directory, then evaluates `args` in `bash` in the new temporary runfiles
     workspace directory.
 
     @param args

--- a/tools/lint/util.py
+++ b/tools/lint/util.py
@@ -43,7 +43,7 @@ def find_all_sources(workspace_name):
     if not os.path.exists(workspace_file):
         raise RuntimeError("Cannot find WORKSPACE at " + workspace_root)
     # Walk the tree (ignoring symlinks), and collect a list of all workspace-
-    # relative filenames, but exluding a few specific items.
+    # relative filenames, but excluding a few specific items.
     relpaths = []
     for abs_dirpath, dirs, files in os.walk(workspace_root):
         assert abs_dirpath.startswith(workspace_root)

--- a/tools/prstat
+++ b/tools/prstat
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # prstat -- Report the lines of code added or changed in the current tree vs
-# upsteam/master, excluding files that are known not to count against the line
+# upstream/master, excluding files that are known not to count against the line
 # limit for platform review.
 
 set -e

--- a/tools/vector_gen/vector_gen.bzl
+++ b/tools/vector_gen/vector_gen.bzl
@@ -26,7 +26,7 @@ def _relative_dirname_basename(label):
 def _vector_gen_outs(srcs, kind):
     """Return the list of output filenames.  The `kind` is one of "vector"
     (foo.h, foo.cc), "translator" (foo_translator.h, foo_translator.cc),
-    or "lcm" (lcmt_foo_t.lcm).  For compatiblity with past practice, C++
+    or "lcm" (lcmt_foo_t.lcm).  For compatibility with past practice, C++
     output will appear under a "gen" folder, but *.lcm output will not.
     """
 
@@ -126,7 +126,7 @@ def drake_cc_vector_gen(
     for those `srcs`.  Returns a struct with fields `srcs`, `hdrs`, and `deps`
     that are appropriate for use in a cc_library rule.
 
-    The drake_workspace_name is a required argment, and is used to formulate
+    The drake_workspace_name is a required argument, and is used to formulate
     the correct `result.deps`.  When this macro is called from within Drake,
     the correct value is ""; when called from other workspaces, the correct
     value is the name of Drake's workspace, such as "@drake".

--- a/tools/workspace/pkg_config.bzl
+++ b/tools/workspace/pkg_config.bzl
@@ -79,7 +79,7 @@ def setup_pkg_config_repository(repository_ctx):
     # or labels ("foo").  We should only get switches from `pkg-config --libs`.
     # However, sometimes it produces "-framework CoreFoundation" or similar,
     # which is *supposed* to be a single switch, but our split heuristic
-    # chopped it up.  We recombine non-switch args with their preceeding arg as
+    # chopped it up.  We recombine non-switch args with their preceding arg as
     # a repair.  We process args in reserve order to keep our loop index
     # unchanged by a pop.
     for i in reversed(range(len(linkopts))):
@@ -326,6 +326,6 @@ Args:
     extra_linkopts: (Optional) Extra items to add to the library target.
     extra_deps: (Optional) Extra items to add to the library target.
     pkg_config_paths: (Optional) Paths to find pkg-config files (.pc). Note
-                      that we ignore the enviornment variable PKG_CONFIG_PATH
+                      that we ignore the environment variable PKG_CONFIG_PATH
                       set by the user.
 """

--- a/tools/workspace/snopt/repository.bzl
+++ b/tools/workspace/snopt/repository.bzl
@@ -124,7 +124,7 @@ def _impl(repo_ctx):
 
     snopt_path = repo_ctx.os.environ.get("SNOPT_PATH", "")
 
-    # For now, an empty path defaults to use git.  In the future, settting
+    # For now, an empty path defaults to use git.  In the future, setting
     # SNOPT_PATH="git" will be required -- an empty path will report an error.
     if snopt_path in ["git", ""]:
         _setup_git(repo_ctx)


### PR DESCRIPTION
Note this mostly preserves grammar mistakes unfortunately. Misspellings were identified with `codespell` and manually reviewed.
