### PR TITLE
Fix various spelling mistakes in comments and strings, part 2

### DIFF
--- a/automotive/automotive_demo.cc
+++ b/automotive/automotive_demo.cc
@@ -381,7 +381,7 @@ void AddVehicles(RoadNetworkType road_network_type,
 
 // Adds a flat terrain to the provided simulator.
 void AddFlatTerrain(AutomotiveSimulator<double>*) {
-  // Intentially do nothing. This is possible since only non-physics-based
+  // Intentionally do nothing. This is possible since only non-physics-based
   // vehicles are supported and they will not fall through the "ground" when no
   // flat terrain is present.
   //

--- a/automotive/automotive_simulator.h
+++ b/automotive/automotive_simulator.h
@@ -291,7 +291,7 @@ class AutomotiveSimulator {
   /// @pre Build() and BuildandInitialize() have NOT been called.
   void Build();
 
-  /// Builds the Diagram and intializes the Diagram Context to the predefined
+  /// Builds the Diagram and initializes the Diagram Context to the predefined
   /// initial states.
   ///
   /// @pre Build() and BuildandInitialize() have NOT been called.

--- a/automotive/idm_controller.cc
+++ b/automotive/idm_controller.cc
@@ -46,7 +46,7 @@ IdmController<T>::IdmController(const RoadGeometry& road,
               .get_index()) {
   this->DeclareNumericParameter(IdmPlannerParameters<T>());
   // TODO(jadecastro) It is possible to replace the following AbstractState with
-  // a caching sceme once #4364 lands, preventing the need to use abstract
+  // a caching scheme once #4364 lands, preventing the need to use abstract
   // states and periodic sampling time.
   if (road_position_strategy == RoadPositionStrategy::kCache) {
     this->DeclareAbstractState(systems::AbstractValue::Make<RoadPosition>(

--- a/automotive/maliput/doc/maliput-design.org
+++ b/automotive/maliput/doc/maliput-design.org
@@ -343,7 +343,7 @@ presents a different $(s,r,h)$ parameterization of that same pavement.
 
 We would like for the driveable-bounds of each =Lane= to map to the
 same extent of physical space in the World frame, but that isn't always
-possible due to the geometric contraints of parallel curves.  However,
+possible due to the geometric constraints of parallel curves.  However,
 we do require that the union of the driveable-bounds of all =Lanes=
 in a =Segment= is simply-connected.  This means that:
  * a =Segment= doesn't have any "holes" in its driveable space (e.g.,
@@ -383,7 +383,7 @@ to go around an impassable monument.
 terms of the union of the driveable-bounds of their =Lanes=) are
 grouped together into a =Junction=.  The primary (sole?) purpose of a
 =Junction= is to indicate that objects in its component =Segments= may
-spatially interact with eachother (e.g., collide!).  Conversely, if
+spatially interact with each other (e.g., collide!).  Conversely, if
 two =Segments= belong to two distinct =Junctions=, then objects within
 their respective driveable-bounds should /not/ be touching.  (Note
 that in considering intersection, we ignore the measure-zero overlap

--- a/automotive/maliput/rndf/lane.h
+++ b/automotive/maliput/rndf/lane.h
@@ -23,7 +23,7 @@ class BranchPoint;
 /// private virtual functions.
 ///
 /// This base implementation will handle all the non-geometric stuff from the
-/// lane. All geometric computation will be moved to each sub lane childs. See
+/// lane. All geometric computation will be moved to each sub lane child. See
 /// SplineLane for an example.
 class Lane : public api::Lane {
  public:

--- a/automotive/maliput/rndf/test/builder_test.cc
+++ b/automotive/maliput/rndf/test/builder_test.cc
@@ -111,7 +111,7 @@ GTEST_TEST(RNDFBuilder, ZigZagLane) {
   EXPECT_EQ(road_geometry->branch_point(3)->GetASide()->size(), 1);
   EXPECT_EQ(road_geometry->branch_point(3)->GetBSide()->size(), 0);
 
-  // Checks branch point assigment regarding the lanes.
+  // Checks branch point assignment regarding the lanes.
   EXPECT_EQ(road_geometry->junction(0)->segment(0)->lane(0)->GetBranchPoint(
                 api::LaneEnd::kStart),
             road_geometry->branch_point(0));

--- a/automotive/maliput/rndf/test/junction_test.cc
+++ b/automotive/maliput/rndf/test/junction_test.cc
@@ -17,7 +17,7 @@ namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
-// constuctor.
+// constructor.
 const double kLinearTolerance = 1e-12;
 const double kAngularTolerance = 1e-12;
 

--- a/automotive/maliput/rndf/test/road_geometry_test.cc
+++ b/automotive/maliput/rndf/test/road_geometry_test.cc
@@ -17,7 +17,7 @@ namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
-// constuctor.
+// constructor.
 const double kLinearTolerance = 1e-12;
 const double kAngularTolerance = 1e-12;
 

--- a/automotive/maliput/rndf/test/segment_test.cc
+++ b/automotive/maliput/rndf/test/segment_test.cc
@@ -15,7 +15,7 @@ namespace {
 
 // The following tolerances are very strict as they are not used to compute
 // anything in the following tests. However, we need them for the RoadGeometry
-// constuctor.
+// constructor.
 const double kLinearTolerance = 1e-12;
 const double kAngularTolerance = 1e-12;
 

--- a/automotive/maliput/utility/yaml_to_obj.cc
+++ b/automotive/maliput/utility/yaml_to_obj.cc
@@ -36,7 +36,7 @@ namespace maliput {
 namespace utility {
 namespace {
 
-// Available maliput implentations to load.
+// Available maliput implementations to load.
 enum class MaliputImplementation {
   kMonolane,   //< monolane implementation.
   kMultilane,  //< multilane implementation.

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -51,7 +51,7 @@ MobilPlanner<T>::MobilPlanner(const RoadGeometry& road, bool initial_with_s,
   this->DeclareNumericParameter(IdmPlannerParameters<T>());
   this->DeclareNumericParameter(MobilPlannerParameters<T>());
   // TODO(jadecastro) It is possible to replace the following AbstractState with
-  // a caching sceme once #4364 lands, preventing the need to use abstract
+  // a caching scheme once #4364 lands, preventing the need to use abstract
   // states and periodic sampling time.
   if (road_position_strategy == RoadPositionStrategy::kCache) {
     this->DeclareAbstractState(systems::AbstractValue::Make<RoadPosition>(

--- a/automotive/pose_selector.h
+++ b/automotive/pose_selector.h
@@ -98,7 +98,7 @@ class PoseSelector {
   /// traffic cars are found.  Note that when no vehicle is detected in front of
   /// (resp. behind) the ego vehicle, the respective RoadPosition within
   /// ClosestPoses will contain an `s`-value of positive (resp. negative)
-  /// infinity.  Any traffic poses that are redunant with `ego_pose` (i.e. have
+  /// infinity.  Any traffic poses that are redundant with `ego_pose` (i.e. have
   /// the same RoadPosition as the ego car and thus the same `s` and `r` value)
   /// are discarded.  If no leading/trailing vehicles are seen within
   /// scan-distance of the ego car, `s`-positions are taken to be at infinite

--- a/automotive/test/pose_selector_test.cc
+++ b/automotive/test/pose_selector_test.cc
@@ -741,7 +741,7 @@ GTEST_TEST(PoseSelectorTest, MultiSegmentRoad) {
   }
 }
 
-// Construct a monolane road with three confluent feeder lanes correponding to
+// Construct a monolane road with three confluent feeder lanes corresponding to
 // three distinct branch points.
 //
 // TODO(jadecastro) Port this to multilane.

--- a/automotive/test/road_path_test.cc
+++ b/automotive/test/road_path_test.cc
@@ -97,7 +97,7 @@ GTEST_TEST(IdmControllerTest, ConstructOpposingSegments) {
   const LaneDirection initial_lane_dir =
       LaneDirection(GetLaneById(*road_opposing, "j:0_fwd"), /* lane */
                     true);                                  /* with_s */
-  // Create a finely-discretized path with a sufficent number of segments to
+  // Create a finely-discretized path with a sufficient number of segments to
   // cover the full length.
   const auto path =
       RoadPath<double>(initial_lane_dir, /* initial_lane_direction */
@@ -151,7 +151,7 @@ GTEST_TEST(IdmControllerTest, ConstructConfluentSegments) {
   const LaneDirection initial_lane_dir =
       LaneDirection(GetLaneById(*road_confluent, "j:1_fwd"), /* lane */
                     false);                                  /* with_s */
-  // Create a finely-discretized path with a sufficent number of segments to
+  // Create a finely-discretized path with a sufficient number of segments to
   // cover the full length.
   const auto path =
       RoadPath<double>(initial_lane_dir, /* initial_lane_direction */

--- a/bindings/pydrake/autodiffutils_py.cc
+++ b/bindings/pydrake/autodiffutils_py.cc
@@ -19,7 +19,7 @@ PYBIND11_MODULE(_autodiffutils_py, m) {
 
   // Install NumPy warning filtres.
   // N.B. This may interfere with other code, but until that is a confirmed
-  // issue, we should agressively try to avoid these warnings.
+  // issue, we should aggressively try to avoid these warnings.
   py::module::import("pydrake.util.deprecation")
       .attr("install_numpy_warning_filters")();
 

--- a/bindings/pydrake/multibody/test/parsers_test.py
+++ b/bindings/pydrake/multibody/test/parsers_test.py
@@ -143,7 +143,7 @@ class TestParsers(unittest.TestCase):
 
         # Populate from folder.
         # TODO(eric.cousineau): This mismatch between casing is confusing, with
-        # `Atlas` being the package name, but `atlas` being the dirctory name.
+        # `Atlas` being the package name, but `atlas` being the directory name.
         pm = PackageMap()
         self.assertEqual(pm.size(), 0)
         pm.PopulateFromFolder(

--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -120,7 +120,7 @@ one of the other arguments (`self` is included in those arguments, for
 - "Keep alive, reference" implies a reference that is lifetime-sensitive
 (something that is not necessarily owned by the other arguments).
 - "Keep alive, transitive" implies a transfer of ownership of owned
-objects from one container to another (e.g. transfering all `System`s
+objects from one container to another (e.g. transferring all `System`s
 from `DiagramBuilder` to `Diagram` when calling
 `DiagramBuilder.Build()`).
 

--- a/bindings/pydrake/symbolic_py.cc
+++ b/bindings/pydrake/symbolic_py.cc
@@ -25,7 +25,7 @@ PYBIND11_MODULE(_symbolic_py, m) {
 
   // Install NumPy warning filtres.
   // N.B. This may interfere with other code, but until that is a confirmed
-  // issue, we should agressively try to avoid these warnings.
+  // issue, we should aggressively try to avoid these warnings.
   py::module::import("pydrake.util.deprecation")
       .attr("install_numpy_warning_filters")();
 

--- a/bindings/pydrake/systems/scalar_conversion.py
+++ b/bindings/pydrake/systems/scalar_conversion.py
@@ -164,7 +164,7 @@ class TemplateSystem(TemplateClass):
                 .format(cls.__name__))
         if not has_construct:
             raise RuntimeError(
-                "{} does not define `_construct`. Pleaes ensure this is "
+                "{} does not define `_construct`. Please ensure this is "
                 "defined.".format(cls.__name__))
         if not has_copy:
             raise RuntimeError(

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -55,7 +55,7 @@ class CustomAdder(LeafSystem):
 # TODO(eric.cousineau): Make this class work with custom scalar types once
 # referencing with custom dtypes lands.
 # WARNING: At present, dtype=object matrices are NOT well supported, and may
-# produce unexecpted results (e.g. references not actually being respected).
+# produce unexpected results (e.g. references not actually being respected).
 
 
 class CustomVectorSystem(VectorSystem):

--- a/bindings/pydrake/test/automotive_test.py
+++ b/bindings/pydrake/test/automotive_test.py
@@ -147,7 +147,7 @@ class TestAutomotive(unittest.TestCase):
         lane_index = pure_pursuit.lane_input().get_index()
         context.FixInputPort(lane_index, ld_value)
 
-        pos = [1., 2., 3.]  # An aribtrary position with the lane.
+        pos = [1., 2., 3.]  # An arbitrary position with the lane.
         pose_vector = PoseVector()
         pose_vector.set_translation(pos)
         pose_index = pure_pursuit.ego_pose_input().get_index()

--- a/bindings/pydrake/util/cpp_const.py
+++ b/bindings/pydrake/util/cpp_const.py
@@ -64,7 +64,7 @@ class _ConstClassMetaMap(object):
         self._meta_map = {}
 
     def emplace(self, cls, owned_properties=None, mutable_methods=None):
-        # Constructs metadata and reigstered it.
+        # Constructs metadata and registers it.
         meta = _ConstClassMeta(cls, owned_properties, mutable_methods)
         return self._add(cls, meta)
 

--- a/bindings/pydrake/util/deprecation_pybind.h
+++ b/bindings/pydrake/util/deprecation_pybind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file
-/// Provides access to Python deprecation utilites from C++.
+/// Provides access to Python deprecation utilities from C++.
 
 #include "pybind11/pybind11.h"
 

--- a/bindings/pydrake/util/test/deprecation_test.py
+++ b/bindings/pydrake/util/test/deprecation_test.py
@@ -127,7 +127,7 @@ class TestDeprecation(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             base_deprecation()  # Should not appear.
             obj = ExampleClass()
-            # Call each deprecated method / propery repeatedly; it should only
+            # Call each deprecated method / property repeatedly; it should only
             # warn once per unique line of source code.
             # - Method.
             for _ in range(3):

--- a/bindings/pydrake/util/test/wrap_function_test.cc
+++ b/bindings/pydrake/util/test/wrap_function_test.cc
@@ -20,7 +20,7 @@ auto WrapIdentity(Func&& func) {
   return WrapFunction<wrap_arg_default>(std::forward<Func>(func));
 }
 
-// Functions with primitive values (int) as return, with 0-1 arugments and/or
+// Functions with primitive values (int) as return, with 0-1 arguments and/or
 // parameters.
 void Void() {}
 void IntToVoid(int) {}

--- a/bindings/pydrake/util/wrap_function.h
+++ b/bindings/pydrake/util/wrap_function.h
@@ -72,7 +72,7 @@ struct functor_helpers {
     return Ptr{};
   }
 
-  // Infers funtion pointer from functor.
+  // Infers function pointer from functor.
   // @pre `Func` must have only *one* overload of `operator()`.
   template <typename Func>
   static auto infer_function_ptr() {
@@ -226,7 +226,7 @@ struct wrap_function_impl {
 ///   If true (default), will recursively wrap callbacks. If your policy
 ///   provides handling for functions, then you should set this to false.
 /// @param func
-///   Functor to be wrapped. Returns a function with wrapped arugments and
+///   Functor to be wrapped. Returns a function with wrapped arguments and
 ///   return type. If functor is a method pointer, it will return a function of
 ///   the form `Return ([const] Class* self, ...)`.
 /// @return Wrapped function lambda.
@@ -253,7 +253,7 @@ struct wrap_arg_default {
     return std::forward<Wrapped&&>(arg_wrapped);
   }
   // N.B. `T` rather than `T&&` is used as arguments here as it behaves well
-  // with primitve types, such as `int`.
+  // with primitive types, such as `int`.
 };
 
 /// Policy for explicitly wrapping functions for a given policy.

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -644,7 +644,7 @@ drake_cc_googletest(
     ],
 )
 
-# Functional test that mistyped DRAKE_ASSERTs will failt to compile.
+# Functional test that mistyped DRAKE_ASSERTs will fail to compile.
 sh_test(
     name = "drake_assert_test_compile_variants",
     size = "small",

--- a/common/find_resource.cc
+++ b/common/find_resource.cc
@@ -220,7 +220,7 @@ optional<string> FindSentinelDir() {
 const char* const kDrakeResourceRootEnvironmentVariableName =
     "DRAKE_RESOURCE_ROOT";
 
-// Saves search directorys path in a persistent variable.
+// Saves search directories path in a persistent variable.
 // This function is only accessible from this file and should not
 // be used outside of `GetResourceSearchPaths()` and
 // `AddResourceSearchPath()`.

--- a/common/proto/call_python_client.py
+++ b/common/proto/call_python_client.py
@@ -69,7 +69,7 @@ def _get_required_helpers(scope_locals):
             return slice(*pieces)
 
     def make_slice_arg(*args):
-        """Create a scalar or tuple for acessing objects via slices. """
+        """Create a scalar or tuple for accessing objects via slices. """
         out = [None] * len(args)
         for i, arg in enumerate(args):
             if isinstance(arg, str):

--- a/common/proto/test/call_python_server_test.cc
+++ b/common/proto/test/call_python_server_test.cc
@@ -50,7 +50,7 @@ GTEST_TEST(TestCallPython, SetVar) {
   CallPython("eval", "print(example_var)");
   // Print a letter.
   CallPython("print", CallPython("eval", "example_var")[2]);
-  // Print all variables avaiable.
+  // Print all variables available.
   CallPython("print", CallPython("locals").attr("keys")());
 }
 

--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -94,7 +94,7 @@ bool determine_polynomial(
 // Determines if pow(base, exponent) is polynomial-convertible or not. This
 // function is used in constructor of ExpressionPow.
 bool determine_polynomial(const Expression& base, const Expression& exponent) {
-  // base ^ exponent is polynomial-convertible if the followings hold:
+  // base ^ exponent is polynomial-convertible if the following hold:
   //    - base is polynomial-convertible.
   //    - exponent is a non-negative integer.
   if (!(base.is_polynomial() && is_constant(exponent))) {

--- a/common/test/copyable_unique_ptr_test.cc
+++ b/common/test/copyable_unique_ptr_test.cc
@@ -409,7 +409,7 @@ GTEST_TEST(CopyableUniquePtrTest, CopyConstructFromCopyable) {
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_TRUE(is_dynamic_castable<CloneOnlyChildWithClone>(u_ptr2.get()));
   // Copy constructor on copyable_unique-ptr of same specialized class, but
-  // contains derived clas.
+  // contains derived class.
   cup<CloneOnly> cup_ptr2(u_ptr2);
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_NE(cup_ptr2.get(), co_ptr);
@@ -450,7 +450,7 @@ GTEST_TEST(CopyableUniquePtrTest, CopyConstructFromUniquePtr) {
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_TRUE(is_dynamic_castable<CloneOnlyChildWithClone>(u_ptr2.get()));
   // Copy constructor on copyable_unique-ptr of same specialized class, but
-  // contains derived clas.
+  // contains derived class.
   cup<CloneOnly> cup_ptr2(u_ptr2);
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_NE(cup_ptr2.get(), co_ptr);
@@ -490,7 +490,7 @@ GTEST_TEST(CopyableUniquePtrTest, MoveConstructFromCopyable) {
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_TRUE(is_dynamic_castable<CloneOnlyChildWithClone>(u_ptr2.get()));
   // Copy constructor on copyable_unique-ptr of same specialized class, but
-  // contains derived clas.
+  // contains derived class.
   cup<CloneOnly> cup_ptr2(move(u_ptr2));
   EXPECT_EQ(u_ptr2.get(), nullptr);
   EXPECT_EQ(cup_ptr2.get(), co_ptr);
@@ -525,7 +525,7 @@ GTEST_TEST(CopyableUniquePtrTest, MoveConstructFromUnique) {
   EXPECT_EQ(u_ptr2.get(), co_ptr);
   EXPECT_TRUE(is_dynamic_castable<CloneOnlyChildWithClone>(u_ptr2.get()));
   // Copy constructor on copyable_unique-ptr of same specialized class, but
-  // contains derived clas.
+  // contains derived class.
   cup<CloneOnly> cup_ptr2(move(u_ptr2));
   EXPECT_EQ(u_ptr2.get(), nullptr);
   EXPECT_EQ(cup_ptr2.get(), co_ptr);

--- a/common/test/cpplint_wrapper.py
+++ b/common/test/cpplint_wrapper.py
@@ -64,7 +64,7 @@ def worker_summarize_cpplint(cmdline_and_files, args):
 
 def multiprocess_cpplint(cmdline, files, args):
     """Given a cpplint subprocess command line (just the program and arguments),
-    separate list of files, and number of processess (None for "all CPUs"), run
+    separate list of files, and number of processes (None for "all CPUs"), run
     cpplint, display a progress bar, warning summary, and return a shell
     exitcode (0 on success, 1 on failure).
     """

--- a/common/test/find_loaded_library_test.cc
+++ b/common/test/find_loaded_library_test.cc
@@ -16,7 +16,7 @@ namespace {
 GTEST_TEST(FindLibraryTest, Library) {
   // See above.
   lib_is_real_dummy_function();
-  // Test wether or not `LoadedLibraryPath()` can find the path to a library
+  // Test whether or not `LoadedLibraryPath()` can find the path to a library
   // loaded by the process.
   optional<string> library_path = LoadedLibraryPath("lib_is_real.so");
   ASSERT_TRUE(library_path);

--- a/common/test/symbolic_expansion_test.cc
+++ b/common/test/symbolic_expansion_test.cc
@@ -64,7 +64,7 @@ class SymbolicExpansionTest : public ::testing::Test {
 };
 
 TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPolynomial) {
-  // The followings are all already expanded.
+  // The following are all already expanded.
   EXPECT_TRUE(CheckAlreadyExpanded(0));
   EXPECT_TRUE(CheckAlreadyExpanded(1));
   EXPECT_TRUE(CheckAlreadyExpanded(-1));
@@ -82,7 +82,7 @@ TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPolynomial) {
 }
 
 TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPow) {
-  // The followings are all already expanded.
+  // The following are all already expanded.
   EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, y_)));            // x^y
   EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
   EXPECT_TRUE(CheckAlreadyExpanded(pow(x_, -1)));            // x^(-1)
@@ -94,7 +94,7 @@ TEST_F(SymbolicExpansionTest, ExpressionAlreadyExpandedPow) {
 
 TEST_F(SymbolicExpansionTest, ExpressionExpansion) {
   // test_exprs includes pairs of expression `e` and its expected expansion
-  // `expected`. For each pair (e, expected), we check the followings:
+  // `expected`. For each pair (e, expected), we check the following:
   //     1. e.Expand() is structurally equal to expected.
   //     2. Evaluate e and e.Expand() under multiple environments to check the
   //        correctness of expansions.

--- a/common/test/symbolic_expression_transform_test.cc
+++ b/common/test/symbolic_expression_transform_test.cc
@@ -50,7 +50,7 @@ class SymbolicExpressionTransformationTest : public ::testing::Test {
   Eigen::Transform<double, 3, Eigen::Projective, Eigen::DontAlign> projective_;
 };
 
-// Checks if `lhs.cast<Expresion>() * rhs` and `(lhs * rhs).cast<Expresion>()`
+// Checks if `lhs.cast<Expression>() * rhs` and `(lhs * rhs).cast<Expression>()`
 // produce almost identical output. Also checks the symmetric case. See the
 // following commutative diagram.
 //                  * rhs
@@ -62,7 +62,7 @@ class SymbolicExpressionTransformationTest : public ::testing::Test {
 //    ||                                ||
 //    || * rhs                          ||
 //    \/                          ?     \/
-//   lhs.cast<Expresion>() * rhs  ==  (lhs * rhs).cast<Expresion>()
+//   lhs.cast<Expression>() * rhs  ==  (lhs * rhs).cast<Expression>()
 //
 // The exactness is not guaranteed due to the non-associativity of
 // floating-point arithmetic (+, *).

--- a/common/test_utilities/eigen_matrix_compare.h
+++ b/common/test_utilities/eigen_matrix_compare.h
@@ -59,7 +59,7 @@ template <typename DerivedA, typename DerivedB>
       // Check for case where one value is NaN and the other is not
       if ((isnan(m1(ii, jj)) && !isnan(m2(ii, jj))) ||
           (!isnan(m1(ii, jj)) && isnan(m2(ii, jj)))) {
-        return ::testing::AssertionFailure() << "NaN missmatch at (" << ii
+        return ::testing::AssertionFailure() << "NaN mismatch at (" << ii
                                              << ", " << jj << "):\nm1 =\n"
                                              << m1 << "\nm2 =\n"
                                              << m2;

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -33,7 +33,7 @@ genrule(
         # Cleanup temporary files.
         "rm -rf $(@D)/.doctrees/ $(@D)/.tmpout",
     ]),
-    # Some (currently disabled) Sphinx extentions try to reach out to the
+    # Some (currently disabled) Sphinx extensions try to reach out to the
     # network; we should fail-fast if someone tries to turn them on.
     tags = ["block-network"],
     tools = ["@sphinx//:sphinx-build"],

--- a/doc/bazel.rst
+++ b/doc/bazel.rst
@@ -99,7 +99,7 @@ Cheat sheet for operating on specific portions of the project::
 
 - The "``:``" syntax separates target names from the directory path of the
   ``BUILD`` file they appear in.  In this case, for example,
-  ``drake/commmon/BUILD`` specifies ``cc_test(name = "polynomial_test")``.
+  ``drake/common/BUILD`` specifies ``cc_test(name = "polynomial_test")``.
 - Note that the configuration switches (``-c`` and ``--config``) influence the
   entire command.  For example, running a test in ``dbg`` mode means that its
   prerequisite libraries are also compiled and linked in ``dbg`` mode.

--- a/doc/clion.rst
+++ b/doc/clion.rst
@@ -254,7 +254,7 @@ find such issues. We'll define two tools:
   ``#include`` directives.
 
 These tools produce reports. In some cases, the reports can be automatically
-converted into clickable links so that you can click on a messsage and be taken
+converted into clickable links so that you can click on a message and be taken
 to the file and line indicated in the message. The configuration instructions
 include the details of how to configure these clickable links.
 

--- a/doc/docker.rst
+++ b/doc/docker.rst
@@ -10,7 +10,7 @@ Introduction
 Docker containers have emerged as a solution to running code or services in a
 way that is isolated from the host operating system. This allows code to be
 compiled and run on systems running unsupported operating systems or with
-incompatable configurations to the software dependencies. Docker is available
+incompatible configurations to the software dependencies. Docker is available
 for `all major operating systems <https://www.docker.com/community-edition>`_.
 
 Two Docker containers are provided with Drake to allow developers to test and

--- a/doc/drakeURDF.xsd
+++ b/doc/drakeURDF.xsd
@@ -108,7 +108,7 @@ from an input to the system, with different scalings for each.</xs:documentation
                 <xs:annotation>
                     <xs:documentation> Places added-mass coefficients on a point on the parent body. Added-mass forces act like a 'drag' that is proportional to the acceleration of the body, rather than the velocity. Important when the body is comparable in mass to the surrounding fluid, or if rapid motions are needed.
 
-These forces are represented by a 6x6 matrix 'Ma' similar to a mass matrix, where the force is F=-Ma*a (+coriolis terms). Each matrix element is refered as 'mij', where 'i' and 'j' are the rows and columns of the matrix. As is standard in the oceanographic literature, rows 123 are the linear accelerations, and 456 are the angular accelerations [note this is opposite of Featherstone's notation] </xs:documentation>
+These forces are represented by a 6x6 matrix 'Ma' similar to a mass matrix, where the force is F=-Ma*a (+coriolis terms). Each matrix element is referred as 'mij', where 'i' and 'j' are the rows and columns of the matrix. As is standard in the oceanographic literature, rows 123 are the linear accelerations, and 456 are the angular accelerations [note this is opposite of Featherstone's notation] </xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="buoyancy" type="buoyancy">

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -126,7 +126,7 @@ The fix is to change the compiler CMake is using. One way to do this is to set t
 
 .. note::
 
-    Do not change the compiler using ``update-alternatives`` in Ubuntu, as this may affect your DKMS module compatiblity with the kernel (among other things) [#update_alt]_.
+    Do not change the compiler using ``update-alternatives`` in Ubuntu, as this may affect your DKMS module compatibility with the kernel (among other things) [#update_alt]_.
 
 .. [#dual_abi] https://stackoverflow.com/q/36159238/7829525
 .. [#binary_install] :ref:`binary-installation`

--- a/doc/mcode.sty
+++ b/doc/mcode.sty
@@ -81,7 +81,7 @@
 %%      1.8  --  Fixed typo in documentation regarding §...§
 %%      1.7  --  Added MATLAB block comment syntax %{ ...... %}
 %%      1.6  --  Added some infos, dealing with keyword ``end''
-%%      1.5  --  Tweaked check to see wether textcomp is loaded
+%%      1.5  --  Tweaked check to see whether textcomp is loaded
 %%      1.4  --  Fixed misconfig (mathescape now set to false)
 %%      1.3  --  Purely cosmetic (tabs replaced by spaces)
 %%      1.2  --  Added \lstset{showstringspaces=false}
@@ -128,8 +128,8 @@
 }
 \ProcessOptions
 
-\ifbw\typeout{ - settings optimized for printing (bw formating)}
-\else\typeout{ - settings optimized for display (colour formating)}\fi
+\ifbw\typeout{ - settings optimized for printing (bw formatting)}
+\else\typeout{ - settings optimized for display (colour formatting)}\fi
 \ifnumbered\typeout{ - line numbering enabled}\else\fi
 \ifuseliterate\typeout{ - literate programming (character replacements) enabled}\else\fi
 \ifautolinebreaks\typeout{ - automatic line breaking enabled (careful, buggy!)}\else\fi
@@ -194,7 +194,7 @@
 
 % ---------------------------------------------------------------------------------
 % define colours and styles
-\ifbw % use font formating and gray 'colors'
+\ifbw % use font formatting and gray 'colors'
 	\def\mcommentfont{\color[gray]{.75}\itshape} %comments light gray and italic
   \lstset{language=matlabfloz,                % use our version of highlighting
     keywordstyle=\bfseries,                   % keywords in bold

--- a/doc/no_push_to_origin.rst
+++ b/doc/no_push_to_origin.rst
@@ -9,7 +9,7 @@ The Issue
 
 We want to prevent developers from accidentally pushing changes into RobotLocomotion/drake. This is accomplished by:
 
-   1. Everybody agreeing in a naming convention for the respositories.
+   1. Everybody agreeing on a naming convention for the repositories.
    2. Providing a dummy url for the repository we want to protect.
 
 
@@ -35,7 +35,7 @@ If a push to the master repository is attempted issuing a ``git push upstream my
 
    fatal: 'no_push' does not appear to be a git repository
    fatal: Could not read from remote repository.
-   
+
    Please make sure you have the correct access rights
    and the repository exists.
 

--- a/doc/pivot_column.tex
+++ b/doc/pivot_column.tex
@@ -121,7 +121,7 @@ We now introduce some terminology:
 	\item \textsc{independent z}: the tuple of variables from $z$ that (partially) comprise $z'$ in the order in which they are found in $z$ (i.e., the elements of \textsc{independent z} appear in ascending order, e.g., $\{ z_1, z_2 \}$). In the running example, \textsc{independent z} is $\{ z_1, z_2 \}$. The elements in \textsc{independent z} are present in ascending order (e.g., $\{ z_1, z_2 \}$).
 		\begin{itemize}
 			\item $\bar{\beta}$: one greater, respectively, than the positions in $z$ of the elements from \textsc{independent z}. In the running examples, $\bar{\beta} = \{1, 2 \}$. From the definition of \textsc{independent z}, the elements of $\bar{\beta}$'s elements appear in ascending order.
-			\item $\bar{\beta}'$: the respective indices in $z'$ of the variables from \textsc{independent z}. In the running example, $\bar{\beta}' = \{4, 3 \}$. These $z$ elments of $\bar{\beta}'$ \emph{elements are not necessarily present in ascending order}.
+			\item $\bar{\beta}'$: the respective indices in $z'$ of the variables from \textsc{independent z}. In the running example, $\bar{\beta}' = \{4, 3 \}$. These $z$ elements of $\bar{\beta}'$ \emph{elements are not necessarily present in ascending order}.
 		\end{itemize}
 		Once more, note that the elements in the ``vanilla'' tuple correspond to variable indices, while elements in the primed tuple correspond to tuple indices. Also, \textbf{observe} the invariant $z_{\bar{\beta}_i} = z'_{\bar{\beta}'_i}$.
 \end{itemize}

--- a/doc/python_bindings.rst
+++ b/doc/python_bindings.rst
@@ -126,7 +126,7 @@ An example of importing symbols directly from ``pydrake.all``:
     simulator = Simulator(RigidBodyPlant(tree))
 
 An alternative is to use ``pydrake.all`` to import all modules, but then
-explicity refer to each symbol:
+explicitly refer to each symbol:
 
 .. code-block:: python
 

--- a/examples/humanoid_controller/dev/humanoid_manipulation_plan.h
+++ b/examples/humanoid_controller/dev/humanoid_manipulation_plan.h
@@ -42,7 +42,7 @@ class HumanoidManipulationPlan
 
   /**
    * Returns true if @p robot has at least 2 rigid bodies; the first rigid body
-   * has a RPY parametrized floating joint, and it has the same number of
+   * has a RPY parameterized floating joint, and it has the same number of
    * generalized positions and velocities.
    */
   bool IsRigidBodyTreeCompatible(const RigidBodyTree<T>& robot) const override;
@@ -102,7 +102,7 @@ class HumanoidManipulationPlan
    * and every configuration in `Q_plan` is statically stable given the support
    * region defined by the current foot poses. `T_plan` has to be strictly
    * increasing, and `T_plan[0]` is bigger than 0. The current implementation
-   * assumes that the message is encoded with a RPY parametrized floating base
+   * assumes that the message is encoded with a RPY parameterized floating base
    * model as opposed to a quaternion floating joint.
    *
    * This function returns without changing the current trajectories if the

--- a/examples/humanoid_controller/humanoid_plan_eval_system.cc
+++ b/examples/humanoid_controller/humanoid_plan_eval_system.cc
@@ -41,7 +41,7 @@ void HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
       EvalInputValue<RobotKinematicState<double>>(
           context, get_input_port_kinematic_state().get_index());
 
-  // Gets the plan message fron input.
+  // Gets the plan message from input.
   const systems::AbstractValue* msg_as_value =
       EvalAbstractInput(context, input_port_index_manip_plan_msg_);
   DRAKE_DEMAND(msg_as_value != nullptr);

--- a/examples/humanoid_controller/humanoid_status.h
+++ b/examples/humanoid_controller/humanoid_status.h
@@ -26,7 +26,7 @@ class BodyOfInterest {
   /**
    * @param name Name of this object. It does not have to match \p body's name.
    * @param body Reference to a RigidBody, which must be valid through the
-   * lifespan of this obejct.
+   * lifespan of this object.
    * @param off Offset expressed in the body frame.
    */
   BodyOfInterest(const std::string& name, const RigidBody<double>& body,
@@ -98,7 +98,7 @@ class HumanoidStatus final
 
   /**
    * @param robot Pointer to a RigidBodyTree, which must be valid through the
-   * lifespan of this obejct.
+   * lifespan of this object.
    */
   HumanoidStatus(const RigidBodyTree<double>* robot,
                  const RigidBodyTreeAliasGroups<double>& alias_group);

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_trajectory.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_trajectory.cc
@@ -82,7 +82,7 @@ PiecewisePolynomial<double> MakeControlledKukaPlan() {
   for (size_t i = 0; i < kTimes.size(); ++i) {
     // Zero configuration is a bad initial guess for IK, to be solved through
     // nonlinear optimization, as the robot configuration is in singularity,
-    // and the gradient is zero. So we add 0.1 as the arbitrary pertubation
+    // and the gradient is zero. So we add 0.1 as the arbitrary perturbation
     // to the zero configuration.
     q_seed.col(i) =
         zero_conf + 0.1 * Eigen::VectorXd::Ones(tree->get_num_positions());

--- a/examples/kuka_iiwa_arm/dev/box_rotation/models/README.md
+++ b/examples/kuka_iiwa_arm/dev/box_rotation/models/README.md
@@ -2,7 +2,7 @@ This directory contains various urdf models describing the dual iiwa arm setup
 for the box rotation simulation. The inter-arm distance defined in these urdf's
 is particularly important in making sure the open-loop simulation actually works.
 Changing this value could cause the open-loop simulation to break. Future versions
-will probablly just check and/or enforce it.
+will probably just check and/or enforce it.
 
 There are two collision models defined for the arms:
 1. Overlapping spheres, representing relevant parts of the arm (i.e., parts that are

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.h
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/lcm_plant.h
@@ -15,7 +15,7 @@ namespace pick_and_place {
 simulated Optitrack system, and SchunkWsgControllers for each gripper in the
 plant. The purpose of this system is to provide a drop-in replacement for the
 hardware + drivers. Note that LCM publishers and subscribers are intentionally
-ommitted from this system so that it can be directly connected to other systems.
+omitted from this system so that it can be directly connected to other systems.
 The block diagram for a system with a single arm is shown below:
 
                        ┌─────────┐    ┌───────────┐    ┌───────────┐

--- a/examples/kuka_iiwa_arm/iiwa_common.h
+++ b/examples/kuka_iiwa_arm/iiwa_common.h
@@ -40,7 +40,7 @@ void VerifyIiwaTree(const RigidBodyTree<double>& tree);
 
 /// Builds a RigidBodyTree at the specified @position and @orientation from
 /// the model specified by @model_file_name.
-/// This method is a convinience wrapper over `AddModelInstanceFromUrdfFile`.
+/// This method is a convenience wrapper over `AddModelInstanceFromUrdfFile`.
 /// @see drake::parsers::urdf::AddModelInstanceFromUrdfFile
 void CreateTreedFromFixedModelAtPose(
     const std::string& model_file_name, RigidBodyTreed* tree,

--- a/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
+++ b/examples/kuka_iiwa_arm/lcm_plan_interpolator.h
@@ -42,7 +42,7 @@ class LcmPlanInterpolator : public systems::Diagram<double> {
   int input_port_iiwa_status_{-1};
   int input_port_iiwa_plan_{-1};
 
-  // Ouptut ports.
+  // Output ports.
   int output_port_iiwa_command_{-1};
 
   manipulation::planner::RobotPlanInterpolator* robot_plan_interpolator_{};

--- a/examples/kuka_iiwa_arm/pick_and_place/action.cc
+++ b/examples/kuka_iiwa_arm/pick_and_place/action.cc
@@ -43,7 +43,7 @@ void IiwaMove::MoveJoints(const WorldState& est_state,
   *plan = EncodeKeyFrames(joint_names, time, info, q_mat);
   StartAction(est_state.get_iiwa_time());
   // Set the duration for this action to be longer than that of the plan to
-  // ensure that we do not advance to the next action befor the robot finishes
+  // ensure that we do not advance to the next action before the robot finishes
   // executing the plan.
   const double additional_duaration{0.5};
   duration_ = time.back() + additional_duaration;

--- a/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration_parsing.h
+++ b/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_configuration_parsing.h
@@ -28,7 +28,7 @@ ParsePlannerConfigurationsOrThrow(const std::string& filename);
 pick_and_place::SimulatedPlantConfiguration
 ParseSimulatedPlantConfigurationOrThrow(const std::string& filename);
 
-/// Parse the pick and place configuration from @p configuation,
+/// Parse the pick and place configuration from @p configuration,
 /// returning the simulated plant configuration.
 pick_and_place::SimulatedPlantConfiguration
 ParseSimulatedPlantConfigurationStringOrThrow(const std::string& configuration);

--- a/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
+++ b/examples/kuka_iiwa_arm/pick_and_place/pick_and_place_state_machine.cc
@@ -55,7 +55,7 @@ struct PostureInterpolationResult {
 };
 
 // Generates a joint-space trajectory for @p robot that interpolates between the
-// inital and final configurations specified in @p request. If @p
+// initial and final configurations specified in @p request. If @p
 // straight_line_motion is true, the end-effector position at all knot points of
 // the returned trajectory will lie on the line between the end-effector
 // positions at the initial and final configurations.
@@ -144,10 +144,10 @@ PostureInterpolationResult PlanInterpolatingMotion(
     Vector3<double> axis_E{aaxis.axis()};
     Vector3<double> dir_W{X_WG_initial.linear() * axis_E};
 
-    // If the intial and final end-effector orientations are close to each other
-    // (to within the orientation tolerance), fix the orientation for all via
-    // points. Otherwise, only allow the end-effector to rotate about the axis
-    // defining the rotation between the initial and final orientations.
+    // If the initial and final end-effector orientations are close to each
+    // other (to within the orientation tolerance), fix the orientation for all
+    // via points. Otherwise, only allow the end-effector to rotate about the
+    // axis defining the rotation between the initial and final orientations.
     if (std::abs(aaxis.angle()) < orientation_tolerance) {
       orientation_constraints.emplace_back(new WorldQuatConstraint(
           robot, grasp_frame_index,
@@ -295,8 +295,8 @@ std::unique_ptr<RigidBodyTree<double>> BuildTree(
     // grasp frame as a named frame.
     auto grasp_frame = std::make_unique<RigidBody<double>>();
     grasp_frame->set_name(kGraspFrameName);
-    // The gripper (and therfore the grasp frame) is rotated relative to the end
-    // effector link.
+    // The gripper (and therefore the grasp frame) is rotated relative to the
+    // end effector link.
     const double grasp_frame_angular_offset{-M_PI / 8};
     // The grasp frame is located between the fingertips of the gripper, which
     // puts it grasp_frame_translational_offset from the origin of the

--- a/examples/pr2/pr2_passive_simulation.cc
+++ b/examples/pr2/pr2_passive_simulation.cc
@@ -49,7 +49,7 @@ int DoMain() {
       std::move(tree_));
   plant_->set_name("plant_");
 
-  // Send the PR2's actuators zeros in abscence of a controller.
+  // Send the PR2's actuators zeros in absence of a controller.
   auto constant_zero_source =
       diagram_builder.AddSystem<systems::ConstantVectorSource<double>>(
           VectorX<double>::Zero(plant_->actuator_command_input_port().size()));

--- a/examples/rimless_wheel/rimless_wheel.h
+++ b/examples/rimless_wheel/rimless_wheel.h
@@ -130,7 +130,7 @@ class RimlessWheel final : public systems::LeafSystem<T> {
   //   θ = slope + the interleg angle (α).
   T StepForwardGuard(const systems::Context<T>& context) const;
 
-  // Handles the impact dynamics, including reseting theta to the angle of the
+  // Handles the impact dynamics, including resetting theta to the angle of the
   // new stance leg, and updating the toe position by the step length.
   void StepForwardReset(const systems::Context<T>& context,
                         const systems::UnrestrictedUpdateEvent<T>&,
@@ -140,7 +140,7 @@ class RimlessWheel final : public systems::LeafSystem<T> {
   //   θ = slope - the interleg angle (α).
   T StepBackwardGuard(const systems::Context<T>& context) const;
 
-  // Handles the impact dynamics, including reseting theta to the angle of the
+  // Handles the impact dynamics, including resetting theta to the angle of the
   // new stance leg, and updating the toe position by the step length.
   void StepBackwardReset(const systems::Context<T>& context,
                          const systems::UnrestrictedUpdateEvent<T>&,

--- a/examples/rod2d/rod2d_sim.cc
+++ b/examples/rod2d/rod2d_sim.cc
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
   message.link.back().geom.resize(1);
   message.link.back().geom[0] = MakeGeometryData(rod_vis);
 
-  // Send a load mesage.
+  // Send a load message.
   Publish(&lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
 
   // Set the names of the systems.

--- a/examples/simple_gripper/simple_gripper.sdf
+++ b/examples/simple_gripper/simple_gripper.sdf
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <sdf version='1.6'>
   <!-- Note: This is the accompaning SDF file for the example demo in
-       simple_gripper.cc and thefore these two files must be kept in sync.
+       simple_gripper.cc and therefore these two files must be kept in sync.
 
          This file defines the model for a simple gripper having two fingers.
        The right finger is fixed to the body of the gripper. The left finger

--- a/manipulation/dev/quasistatic_system.cc
+++ b/manipulation/dev/quasistatic_system.cc
@@ -29,7 +29,7 @@ T MaxStlVector(const std::vector<T>& v) {
   return *result;
 }
 
-/* returns the indicies of positions/velocities of the bodies in idx_body. The
+/* returns the indices of positions/velocities of the bodies in idx_body. The
  * indices are into the rigidbodytree containing these bodies.
  */
 std::vector<int> GetPositionOrVelocityIndicesOfBodiesFromRBT(

--- a/manipulation/dev/quasistatic_system.h
+++ b/manipulation/dev/quasistatic_system.h
@@ -19,7 +19,7 @@ namespace manipulation {
 struct QuasistaticSystemOptions {
   double period_sec{0.01};
   std::vector<bool> is_contact_2d{};
-  double mu{1};  // coefficent of friction for all contacts
+  double mu{1};  // coefficient of friction for all contacts
   double kBigM{1};
   bool is_analytic{false};
   bool is_using_kinetic_energy_minimizing_QP{false};
@@ -88,7 +88,7 @@ class QuasistaticSystem : public systems::LeafSystem<Scalar> {
 
   // As half of the vectors that span the tangent spaces are the negation of
   // the other half, half of the columns of Jf are also the negation of the
-  // other half. Jf_half is one of the two halfs of J.
+  // other half. Jf_half is one of the two halves of J.
   void CalcJf(const Eigen::Ref<const Eigen::MatrixXd>& Jf_half,
               Eigen::MatrixXd* const Jf_ptr) const;
   void CalcWnWfJnJfPhi(const KinematicsCache<double>& cache,
@@ -146,7 +146,7 @@ class QuasistaticSystem : public systems::LeafSystem<Scalar> {
   // DoFs of the floating joint of the base body of the unactuated rigid body
   // mechanisms that are fixed.
   const std::vector<int> fixed_base_positions_;
-  // When base rotation is parametrized by a quaternion, fixing components of
+  // When base rotation is parameterized by a quaternion, fixing components of
   // the quaternion doesn't make much sense. Instead, we fix the rotations
   // about axes defined by components of the base body's angular velocity.
   std::vector<int> fixed_base_velocities_;
@@ -169,7 +169,7 @@ class QuasistaticSystem : public systems::LeafSystem<Scalar> {
   int na_{0};           // number of actuated DOFs (inputs), dim(qa)
   int nc_;              // number of contacts.
   int nq_tree_;         // number of positions in RBT
-  Eigen::VectorXi nf_;  // nubmer of vectors spanning each friction cone
+  Eigen::VectorXi nf_;  // number of vectors spanning each friction cone
 
   // indices of actuated states in increasing order.
   std::vector<int> idx_qa_;

--- a/manipulation/models/iiwa_description/README.md
+++ b/manipulation/models/iiwa_description/README.md
@@ -1,5 +1,5 @@
 Execute the following commands to regenerate the URDF files using xacro. Note
-that ROS Jade or newer must be used becase the xacro scripts make use of more
+that ROS Jade or newer must be used because the xacro scripts make use of more
 expressive conditional statements [1].
 
 ```

--- a/manipulation/scene_generation/random_clutter_generator.cc
+++ b/manipulation/scene_generation/random_clutter_generator.cc
@@ -67,7 +67,7 @@ RandomClutterGenerator::RandomClutterGenerator(
   DRAKE_DEMAND(clutter_model_instances.size() >= 1);
   for (auto& it : clutter_model_instances) {
     // Check that the tree contains the model instance in question. I.e.
-    // Atleast one body exists for each model instance listed in
+    // At least one body exists for each model instance listed in
     // clutter_model_instance.
     DRAKE_DEMAND(scene_tree_ptr_->FindModelInstanceBodies(it).size() > 0);
   }
@@ -105,7 +105,7 @@ VectorX<double> RandomClutterGenerator::GenerateFloatingClutter(
     // state (q) equal some random orientation and the translation components
     // of the state are sampled from a bounded distribution.
     // The following vectors are populated on the basis of this equation, with
-    // the A matrix being specified by a sparse matrix notation, i,e the ith
+    // the A matrix being specified by a sparse matrix notation, i.e., the ith
     // (linear_posture_iAfun) and jth position (linear_posture_jAVar) specifying
     // the index values for elements which take on the value specified by
     // linear_posture_A.

--- a/manipulation/scene_generation/random_clutter_generator.h
+++ b/manipulation/scene_generation/random_clutter_generator.h
@@ -17,7 +17,7 @@ namespace scene_generation {
 /**
  * Given a RigidBodyTree containing a given scene, the RandomClutterGenerator
  * can repeatedly generate bounded random poses/configurations on selected
- * model instances within the tree. Each of these objects are seperated from
+ * model instances within the tree. Each of these objects are separated from
  * each other by (settable) minimum distance and their object frames are
  * located within a (settable) bounding box volume. This class solves the
  * IK problem to find feasible poses on the clutter bodies
@@ -65,7 +65,7 @@ class RandomClutterGenerator {
    * from this value.
    * @param generator Used to pass a seed.
    * @param z_height_cost An optional cost added to the optimization problem
-   * on the height (z) of each of the model intances. Set to either 0 or {}
+   * on the height (z) of each of the model instances. Set to either 0 or {}
    * in order to not utilise any z cost. @pre z_height_cost must be
    * non-negative, if specified.
    * @returns The generalized coordinates q representing a feasible

--- a/manipulation/schunk_wsg/schunk_wsg_lcm.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_lcm.cc
@@ -67,7 +67,7 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
   DRAKE_ASSERT(input != nullptr);
   const auto& command = input->GetValue<lcmt_schunk_wsg_command>();
   // The target_position_mm field represents the distance between the two
-  // fingers in milimeters. This class generates trajectories for the negative
+  // fingers in millimeters. This class generates trajectories for the negative
   // of the distance between the fingers in meters.
   double target_position = -command.target_position_mm / 1e3;
   if (std::isnan(target_position)) {

--- a/manipulation/util/moving_average_filter.cc
+++ b/manipulation/util/moving_average_filter.cc
@@ -21,7 +21,7 @@ MovingAverageFilter<T>::MovingAverageFilter(int window_size)
 
 template <typename T>
 T MovingAverageFilter<T>::Update(const T& new_data) {
-  // First intialize sum (needed when type is not a scalar)
+  // First initialize sum (needed when type is not a scalar)
 
   if (window_.size() == 0) {
     sum_ = new_data;

--- a/manipulation/util/sim_diagram_builder.h
+++ b/manipulation/util/sim_diagram_builder.h
@@ -59,7 +59,7 @@ class SimDiagramBuilder {
   /**
    * Adds a RigidBodyPlant. Can be called at most once.
    * @param plant unique pointer to the RigidBodyPlant. Ownership will be
-   * transfered.
+   * transferred.
    * @return Pointer to the added plant.
    */
   systems::RigidBodyPlant<T>* AddPlant(
@@ -68,7 +68,7 @@ class SimDiagramBuilder {
   /**
    * Adds a RigidBodyPlant. Can be called at most once.
    * @param plant unique pointer to a RigidBodyTree that is used to construct a
-   * RigidBodyPlant. Ownership will be transfered.
+   * RigidBodyPlant. Ownership will be transferred.
    * @return Pointer to the added plant.
    */
   systems::RigidBodyPlant<T>* AddPlant(
@@ -89,7 +89,7 @@ class SimDiagramBuilder {
    * to be controlled by the added controller. Each model instance can have at
    * most one controller.
    * @param controller Unique pointer to the controller. Ownership will be
-   * transfered.
+   * transferred.
    * @return Pointer to the added controller.
    */
   template <class ControllerType>
@@ -113,7 +113,7 @@ class SimDiagramBuilder {
    * StateFeedbackControllerInterface<T>. Assumes the RigidBodyPlant only has
    * one model instance. Can be called at most once.
    * @param controller Unique pointer to the controller. Ownership will be
-   * transfered.
+   * transferred.
    * @return Pointer to the added controller.
    */
   template <class ControllerType>

--- a/multibody/benchmarks/acrobot/acrobot.h
+++ b/multibody/benchmarks/acrobot/acrobot.h
@@ -13,9 +13,9 @@ namespace benchmarks {
 /// of Underactuated Robotics</a>.
 ///
 /// This system essentially is a double pendulum consisting of two links.
-/// Link 1 is connected to the world by a "shoulder" revolute joint parametrized
-/// by angle theta1 and Link 2 is connected to Link 1 by an "elbow" revolute
-/// joint parametrized by angle theta2.
+/// Link 1 is connected to the world by a "shoulder" revolute joint
+//  parameterized by angle theta1 and Link 2 is connected to Link 1 by an
+/// "elbow" revolute joint parameterized by angle theta2.
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///
@@ -31,7 +31,7 @@ class Acrobot {
   /// Essentially the two dimensional equations of the acrobot are described
   /// in a model frame D within a x-y plane with y the vertical direction
   /// and gravity pointing downwards.
-  /// Thefore the axes defining the model frame D are: <pre>
+  /// Therefore the axes defining the model frame D are: <pre>
   ///   z_W = normal_W.normalized()
   ///   y_W = (up - up.dot(z_W) * z_W).normalized()
   ///   x_W = y_W.cross(z_W)

--- a/multibody/benchmarks/free_body/test/rigid_body_plant_free_body_test.cc
+++ b/multibody/benchmarks/free_body/test/rigid_body_plant_free_body_test.cc
@@ -124,7 +124,7 @@ using Eigen::Quaterniond;
   EXPECT_TRUE(CompareMatrices(vDt_NBo_B_drake, vDt_NBo_B_exact,  10*tolerance));
 
   // Multi-step process to compare Drake vs exact time-derivative of quaternion.
-  // Ensure time-derivative of Drake's quaternion satifies quarternionDt test.
+  // Ensure time-derivative of Drake's quaternion satisfies quaternionDt test.
   // Since more than one time-derivative of a quaternion is associated with the
   // same angular velocity, convert to angular velocity to compare results.
   EXPECT_TRUE(math::IsBothQuaternionAndQuaternionDtOK(

--- a/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
+++ b/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.cc
@@ -27,7 +27,7 @@ using std::unique_ptr;
 /// Utility method for creating a transform from frame A to frame B.
 /// @param[in] R_AB Rotation matrix relating Ax, Ay, Az to Bx, By, Bz.
 /// @param[in] p_AoBo_A Position vector from Ao to Bo, expressed in A.
-/// @retval X_AB Tranform relating frame A to frame B.
+/// @retval X_AB Transform relating frame A to frame B.
 Eigen::Isometry3d MakeIsometry3d(const Eigen::Matrix3d& R_AB,
                                  const Eigen::Vector3d& p_AoBo_A) {
   // Initialize all of X_AB (may be more than just linear and translation).

--- a/multibody/collision/collision_filter_doxygen.h
+++ b/multibody/collision/collision_filter_doxygen.h
@@ -373,7 +373,7 @@ elements.
 collision filter groups is to create a new group which ignores itself and
 make all of the collision elements of both bodies members of that group.
 
-<b>Comparision</b> Both representations offer a straightforward implementation.
+<b>Comparison</b> Both representations offer a straightforward implementation.
 However, because of the fixed-width bitmask, we have a finite number of
 collision filter groups. For a _single_ robot with `k` links, we would need, on
 the average, `k - 1` groups to handle this case.  If we extend this to multiple
@@ -459,7 +459,7 @@ In this representation, the right-most bit is the low-order bit.  Remember that
 all elements belong to the universal group (bit 0). It should be clear that
 `groupA` and `groupB` were assigned to bits 1 and 2, respectively.
 
-<b>Comparision</b> Collision filtering based on _classes_ of bodies fits
+<b>Comparison</b> Collision filtering based on _classes_ of bodies fits
 naturally with the collision filter group model.  Its representation is compact
 and its runtime cost remains unchanged.  The efficacy of the clique approach
 depends on the size of the groups and, handled greedily, could lead to an

--- a/multibody/joints/prismatic_joint.h
+++ b/multibody/joints/prismatic_joint.h
@@ -15,7 +15,7 @@
 class PrismaticJoint : public FixedAxisOneDoFJoint<PrismaticJoint> {
  public:
   /**
-   * The constructor that intializes the name, position, and axis of motion
+   * The constructor that initializes the name, position, and axis of motion
    * of this prismatic joint.
    *
    * @param[in] name The name of this joint.

--- a/multibody/multibody_tree/body_node_impl.h
+++ b/multibody/multibody_tree/body_node_impl.h
@@ -15,7 +15,7 @@ namespace internal {
 /// For internal use only of the MultibodyTree implementation.
 /// While all code that is common to any node can be placed in the BodyNode
 /// class, %BodyNodeImpl provides compile-time fixed-size BodyNode
-/// implementations so that all operations can be perfomed with fixed-size
+/// implementations so that all operations can be performed with fixed-size
 /// stack-allocated Eigen variables.
 /// In particular, most of the across mobilizer code for velocity kinematics
 /// lives in this class since the across mobilizer Jacobian matrices `H_FM(q)`

--- a/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
+++ b/multibody/multibody_tree/implicit_stribeck/implicit_stribeck_solver.h
@@ -130,7 +130,7 @@ struct DirectionChangeLimiter {
   /// @param[in] cos_theta_max precomputed value of cos(θₘₐₓ).
   /// @param[in] v_stiction the stiction tolerance vₛ, in m/s.
   /// @param[in] relative_tolerance a value << 1 used to determine when
-  /// ‖vₜ‖ ≈ 0. Typical values lie withing the 10⁻³ - 10⁻² range. This allows
+  /// ‖vₜ‖ ≈ 0. Typical values lie within the 10⁻³ - 10⁻² range. This allows
   /// us to compute `εᵥ = tolerance⋅vₛ` (in m/s) which defines a "small
   /// tangential velocity scale". This value is used to compute "soft norms"
   /// (see class's documentation) and to detect values close to
@@ -1014,7 +1014,7 @@ class ImplicitStribeckSolver {
     }
 
     // Returns a mutable reference to the vector storing ∂fₜ/∂vₜ (in ℝ²ˣ²)
-    // for each contact pont, of size nc.
+    // for each contact point, of size nc.
     std::vector<Matrix2<T>>& mutable_dft_dvt() {
       return dft_dv_;
     }

--- a/multibody/multibody_tree/implicit_stribeck/test/implicit_stribeck_solver_test.cc
+++ b/multibody/multibody_tree/implicit_stribeck/test/implicit_stribeck_solver_test.cc
@@ -335,7 +335,7 @@ TEST_F(DirectionLimiter, ChangesWithinTheSlidingRegion_VeryLargeTheta) {
 }
 
 // This is a very degenerate case in which the angle formed by vt and dvt
-// equals (whithin machine epsilon) to theta_max. It so happens than in this
+// equals (within machine epsilon) to theta_max. It so happens that in this
 // case there is a single solution to the quadratic equation solved by the
 // limiter (the equation becomes linear).
 // Even though this will rarely (or impossibly) happen, we make sure we consider
@@ -773,7 +773,7 @@ TEST_F(PizzaSaver, NoContact) {
 // bodies first make contact. That is, we set the normal force to
 // fn = -m * vy / dt + m * g, where the small contribution due to gravity is
 // needed to exactly bring the cylinder's vertical velocity to zero. The solver
-// keeps this value constant througout the computation.
+// keeps this value constant throughout the computation.
 // The equations governing the motion for the cylinder during impact are:
 //   (1)  I Δω = pt R,  Δω  = ω, since ω0 = 0.
 //   (2)  m Δvx = pt ,  Δvx = vx - vx0

--- a/multibody/multibody_tree/mobilizer.h
+++ b/multibody/multibody_tree/mobilizer.h
@@ -246,8 +246,8 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
   /// generalized coordinate representing the rotational degree of freedom about
   /// a given axis between the inboard and outboard frames. Another example
   /// would be a 6 DOF "free" mobilizer internally using a quaternion
-  /// representation to parametrize free rotations and a position vector to
-  /// parametrize free translations; this method would return 7 (a quaternion
+  /// representation to parameterize free rotations and a position vector to
+  /// parameterize free translations; this method would return 7 (a quaternion
   /// plus a position vector).
   /// @see num_velocities()
   virtual int num_positions() const = 0;
@@ -326,7 +326,7 @@ class Mobilizer : public MultibodyTreeElement<Mobilizer<T>, MobilizerIndex> {
 
   /// Computes the across-mobilizer transform `X_FM(q)` between the inboard
   /// frame F and the outboard frame M as a function of the vector of
-  /// generalized postions `q`.
+  /// generalized positions `q`.
   /// %Mobilizer subclasses implementing this method can retrieve the fixed-size
   /// vector of generalized positions for `this` mobilizer from `context` with:
   ///

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -432,10 +432,10 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
   for (JointIndex joint_index(0); joint_index < model().num_joints();
        ++joint_index) {
     // Currently MultibodyPlant applies these "compliant" joint limit forces
-    // using an explicit Euler strategy. Stability analysis of the explict Euler
-    // applied to the harmonic oscillator (the model used for these compliant
-    // forces) shows the scheme to be stable for kAlpha > 2π. We take a
-    // significantly larger kAlpha so that we are well within the stability
+    // using an explicit Euler strategy. Stability analysis of the explicit
+    // Euler applied to the harmonic oscillator (the model used for these
+    // compliant forces) shows the scheme to be stable for kAlpha > 2π. We take
+    // a significantly larger kAlpha so that we are well within the stability
     // region of the scheme.
     // TODO(amcastro-tri): Decrease the value of kAlpha to be closer to one when
     // the time stepping scheme is updated to be implicit in the joint limits.

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1701,7 +1701,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // TODO(amcastro-tri): Remove this when caching lands and properly cache the
   // contact results.
   // Until caching lands, we use this variable as a "caching" entry.
-  // We make it mutable so we can change its values even from withing const
+  // We make it mutable so we can change its values even from within const
   // methods.
   mutable ContactResults<T> contact_results_;
 };

--- a/multibody/multibody_tree/multibody_plant/test/box.sdf
+++ b/multibody/multibody_tree/multibody_plant/test/box.sdf
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <sdf version='1.6'>
   <!-- Note: This is the accompaning SDF file for the unit test box_test.cc
-       and thefore these two files must be kept in sync.
+       and therefore these two files must be kept in sync.
 
        This file defines the model for a box on a flat plane. The unit test
        applies a horizontal force in order to verify the value of the friction

--- a/multibody/multibody_tree/multibody_plant/test/inclined_plane_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/inclined_plane_test.cc
@@ -26,8 +26,8 @@ namespace multibody {
 namespace multibody_plant {
 namespace {
 
-// This parametrized fixture allows us to run inclined planes tests using either
-// a continuous plant model or a discrete plant model.
+// This parameterized fixture allows us to run inclined planes tests using
+// either a continuous plant model or a discrete plant model.
 class InclinedPlaneTest : public ::testing::TestWithParam<bool> {
  public:
   void SetUp() override {

--- a/multibody/multibody_tree/multibody_plant/test/spring_mass_system_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/spring_mass_system_test.cc
@@ -60,9 +60,9 @@ class SpringMassSystemTest : public ::testing::Test {
 
   // Returns the position x(t) of the body mass in the spring-mass system for
   // time `t = time` given the parameters of the system (period and
-  // damping_ratio) and the intial position x0 and initial velocity v0 at
+  // damping_ratio) and the initial position x0 and initial velocity v0 at
   // `t = 0`.
-  // This method cannnot compute the solution for damping_ratio = 1, i.e. the
+  // This method cannot compute the solution for damping_ratio = 1, i.e. the
   // critically damped system.
   double CalcAnalyticSolution(
       double period, double damping_ratio,

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -428,7 +428,7 @@ class MultibodyTree {
     DRAKE_ASSERT(mobilizer_index == num_mobilizers());
 
     // TODO(sammy-tri) This effectively means that there's no way to
-    // programatically add mobilizers from outside of MultibodyTree
+    // programmatically add mobilizers from outside of MultibodyTree
     // itself with multiple model instances.  I'm not convinced that
     // this is a problem.
     if (!mobilizer->model_instance().is_valid()) {

--- a/multibody/multibody_tree/parsing/test/scene_graph_parser_detail_test.cc
+++ b/multibody/multibody_tree/parsing/test/scene_graph_parser_detail_test.cc
@@ -241,7 +241,7 @@ GTEST_TEST(SceneGraphParserDetail, MakeGeometryInstanceFromSdfVisual) {
 
   const Isometry3d& X_LC = geometry_instance->pose();
 
-  // Thes are the expected values as specified by the string above.
+  // These are the expected values as specified by the string above.
   const Vector3d expected_rpy(3.14, 6.28, 1.57);
   const Matrix3d R_LC_expected =
       RotationMatrix<double>(RollPitchYaw<double>(expected_rpy)).matrix();

--- a/multibody/multibody_tree/quaternion_floating_mobilizer.cc
+++ b/multibody/multibody_tree/quaternion_floating_mobilizer.cc
@@ -221,7 +221,7 @@ Eigen::Matrix<T, 4, 3> QuaternionFloatingMobilizer<T>::CalcLMatrix(
   // component of the quaternion (Euler parameters). Notice however here we use
   // qs and qv for the "scalar" and "vector" components of the quaternion q_FM,
   // respectively, while Mitiguy uses ε₀ and ε (in bold), respectively.
-  // This mobilizer is parametrized by the angular velocity w_FM, i.e. time
+  // This mobilizer is parameterized by the angular velocity w_FM, i.e. time
   // derivatives of the vector component of the quaternion are taken in the F
   // frame. If you are confused by this, notice that the vector component of a
   // quaternion IS a vector, and therefore you must specify in what frame time
@@ -231,7 +231,7 @@ Eigen::Matrix<T, 4, 3> QuaternionFloatingMobilizer<T>::CalcLMatrix(
   // Dt_F(q) = 1/2 * w_FM⋅q_FM, where ⋅ denotes the "quaternion product" and
   // both the vector component qv_FM of q_FM and w_FM are expressed in frame F.
   // Dt_F(q) is short for [Dt_F(q)]_F.
-  // The expression above can be writen as:
+  // The expression above can be written as:
   // Dt_F(q) = 1/2 * (-w_FM.dot(qv_F); qs * w_FM + w_FM.cross(qv_F))
   //         = 1/2 * (-w_FM.dot(qv_F); qs * w_FM - qv_F.cross(w_FM))
   //         = 1/2 * (-w_FM.dot(qv_F); (qs * Id - [qv_F]x) * w_FM)

--- a/multibody/multibody_tree/space_xyz_mobilizer.h
+++ b/multibody/multibody_tree/space_xyz_mobilizer.h
@@ -21,7 +21,7 @@ namespace multibody {
 /// is allowed and the inboard frame origin `Fo` and the outboard frame origin
 /// `Mo` are coincident at all times.
 ///
-/// The orientation `R_FM` of the outboard frame M in F is parametrized with
+/// The orientation `R_FM` of the outboard frame M in F is parameterized with
 /// space `x-y-z` Euler angles (also known as extrinsic angles). That is, the
 /// generalized coordinates for this mobilizer correspond to angles
 /// θ₁, θ₂, θ₃, for a sequence of rotations about the x̂, ŷ, ẑ axes solidary with

--- a/multibody/multibody_tree/spatial_inertia.h
+++ b/multibody/multibody_tree/spatial_inertia.h
@@ -367,7 +367,7 @@ class SpatialInertia {
   ///
   /// @note
   /// The term `F_Bo_E` computed by this operator appears in the equations of
-  /// motion for a rigid body which, when writen about the origin `Bo` of the
+  /// motion for a rigid body which, when written about the origin `Bo` of the
   /// body frame B (which does not necessarily need to coincide with the body's
   /// center of mass), read as: <pre>
   ///   Ftot_BBo = M_Bo_W * A_WB + b_Bo

--- a/multibody/multibody_tree/test/floating_body_test.cc
+++ b/multibody/multibody_tree/test/floating_body_test.cc
@@ -215,7 +215,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
   const Quaterniond q_WB = mobilizer.get_quaternion(context);
   const Vector4d q_WB_vec4(q_WB.w(), q_WB.x(), q_WB.y(), q_WB.z());
 
-  // After numerical intergration, and with no projection, the quaternion
+  // After numerical integration, and with no projection, the quaternion
   // representing the body's orientation is no longer unit length, however close
   // to it by kNormalizationTolerance.
   const double kNormalizationTolerance = 5e-9;

--- a/multibody/multibody_tree/test/rotational_inertia_test.cc
+++ b/multibody/multibody_tree/test/rotational_inertia_test.cc
@@ -480,7 +480,7 @@ GTEST_TEST(RotationalInertia, MultiplicationWithScalarFromTheLeft) {
   EXPECT_EQ(Ixs.get_moments(), sxI.get_moments());
   EXPECT_EQ(Ixs.get_products(), sxI.get_products());
 
-  // Verify the scalar can be a variable symbolic expresion
+  // Verify the scalar can be a variable symbolic expression
   const Variable a("a");  // A "variable" scalar.
   const RotationalInertia<Expression> axI = a * I.cast<Expression>();
   EXPECT_EQ(axI.get_moments(), a * m);

--- a/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
@@ -680,7 +680,7 @@ class PendulumKinematicTests : public PendulumTests {
         forcing.mutable_body_forces();
     VectorX<double>& tau_applied = forcing.mutable_generalized_forces();
 
-    // Try first using different arrays for input/ouput:
+    // Try first using different arrays for input/output:
     // Initialize output to garbage, it should not affect the results.
     tau.setConstant(std::numeric_limits<double>::quiet_NaN());
     tau_applied.setZero();

--- a/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -578,7 +578,7 @@ GTEST_TEST(UnitInertia, CompatibleWithSymbolicExpression) {
   // (the default).
   UnitInertia<Expression> Gz = UnitInertia<Expression>::SolidCylinder(r, L);
 
-  // Lets give the varaibles above some values.
+  // Let's give the variables above some values.
   const double r_value = 0.025;
   const double L_value = 0.2;
   // And the expected principal moments.

--- a/multibody/multibody_tree/test_utilities/spatial_kinematics.h
+++ b/multibody/multibody_tree/test_utilities/spatial_kinematics.h
@@ -106,7 +106,7 @@ class SpatialKinematicsPVA {
   // in N) and v_NBo_N (Bo's velocity in N, expressed in N).
   SpatialVelocity<T> V_NBo_N_;
 
-  // Spatial acceleration containig alpha_NB_N (B's angular acceleration in N,
+  // Spatial acceleration containing alpha_NB_N (B's angular acceleration in N,
   // expressed in N) and a_NBo_N (Bo's acceleration in N, expressed in N).
   SpatialAcceleration<T> A_NBo_N_;
 

--- a/multibody/multibody_tree/uniform_gravity_field_element.cc
+++ b/multibody/multibody_tree/uniform_gravity_field_element.cc
@@ -42,7 +42,7 @@ VectorX<T> UniformGravityFieldElement<T>::CalcGravityGeneralizedForces(
   // Temporary array for body accelerations.
   std::vector<SpatialAcceleration<T>> A_WB_array(model.num_bodies());
 
-  // Ouput vector of generalized forces:
+  // Output vector of generalized forces:
   VectorX<T> tau_g(model.num_velocities());
 
   // Compute inverse dynamics with zero generalized velocities and zero

--- a/multibody/parsers/model_instance_id_table.cc
+++ b/multibody/parsers/model_instance_id_table.cc
@@ -10,7 +10,7 @@ void AddModelInstancesToTable(const ModelInstanceIdTable& source_table,
   for (auto const &model_entry : source_table) {
     const std::string& model_name = model_entry.first;
     if (dest_table->find(model_name) != dest_table->end()) {
-      throw std::runtime_error("AddModelInstancesToTable: Collision occured "
+      throw std::runtime_error("AddModelInstancesToTable: Collision occurred "
           "with model name\"" + model_name + "\".");
     }
     (*dest_table)[model_name] = model_entry.second;

--- a/multibody/rigid_body_frame.h
+++ b/multibody/rigid_body_frame.h
@@ -164,7 +164,7 @@ class RigidBodyFrame final {
    * @see RigidBodyFrame::get_transform_to_body
    */
   // Frames' poses should only be specified at construction as described in
-  // #4407. Fix parsers to use construtor instead.
+  // #4407. Fix parsers to use constructor instead.
   void set_transform_to_body(const Eigen::Isometry3d& transform_to_body);
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/multibody/rigid_body_tree_contact.cc
+++ b/multibody/rigid_body_tree_contact.cc
@@ -82,7 +82,7 @@ void getUniqueBodiesSorted(
   sort(bodyIndsSorted.begin(), bodyIndsSorted.end());
 }
 
-// Finds the n occurences of the body index in the original list of m contact
+// Finds the n occurrences of the body index in the original list of m contact
 // indexes
 // INPUTS:
 //   idxList: (m x 1) Indexes of m bodies for possible contact pairs

--- a/multibody/shapes/geometry.cc
+++ b/multibody/shapes/geometry.cc
@@ -324,7 +324,7 @@ void Mesh::LoadObjFile(PointsVector* vertices, TrianglesVector* triangles,
       obj_file_name.c_str(), path.c_str(), do_tinyobj_triangulation);
 
   // Use the boolean return value and the error string to determine
-  // if we should proceeed.
+  // if we should proceed.
   if (!ret || !err.empty()) {
     throw std::runtime_error("Error parsing file \""
         + obj_file_name + "\" : " + err);

--- a/multibody/shapes/geometry.h
+++ b/multibody/shapes/geometry.h
@@ -45,7 +45,7 @@ class Geometry {
    * @returns `true` if this geometry can return faces.
    */
   virtual bool hasFaces() const {
-    // By default, arbitary geometry doesn't know how to provide faces.
+    // By default, arbitrary geometry doesn't know how to provide faces.
     return false;
   }
   /**

--- a/multibody/test/rigid_body_tree/rbt_collisions_test.cc
+++ b/multibody/test/rigid_body_tree/rbt_collisions_test.cc
@@ -27,7 +27,7 @@ namespace {
 struct SurfacePoint {
   SurfacePoint() { }
   SurfacePoint(Vector3d wf, Vector3d bf) : world_frame(wf), body_frame(bf) { }
-  // Eigen variables are left uninitalized by default.
+  // Eigen variables are left uninitialized by default.
   Vector3d world_frame;
   Vector3d body_frame;
 };

--- a/solvers/test/branch_and_bound_test.cc
+++ b/solvers/test/branch_and_bound_test.cc
@@ -157,7 +157,7 @@ std::unique_ptr<MathematicalProgram> ConstructMathematicalProgram4() {
 void CheckNewRootNode(
     const MixedIntegerBranchAndBoundNode& root,
     const std::list<symbolic::Variable>& binary_vars_expected) {
-  // The left and right childs are empty.
+  // The left and right children are empty.
   EXPECT_FALSE(root.left_child());
   EXPECT_FALSE(root.right_child());
   // The parent node is empty.
@@ -775,7 +775,7 @@ GTEST_TEST(MixedIntegerBranchAndBoundTest, TestBranchAndUpdate3) {
       dut.bnb()->root()->prog()->decision_variables();
 
   dut.BranchAndUpdate(dut.mutable_root(), x(0));
-  // Both left and right childs are unbounded.
+  // Both left and right children are unbounded.
   EXPECT_EQ(dut.bnb()->best_upper_bound(),
             std::numeric_limits<double>::infinity());
   EXPECT_EQ(dut.bnb()->best_lower_bound(),

--- a/systems/controllers/test/zmp_planner_test.cc
+++ b/systems/controllers/test/zmp_planner_test.cc
@@ -109,7 +109,7 @@ class ZMPPlannerTest : public ::testing::Test {
   // the optimal control u (CoM acceleration) is achieved by:
   // min_u L(y, u) + dV / dx_bar * x_bar_dot,
   // where L = (y - y_d)^T * Qy * (y - y_d) + u^T * R u.
-  // The minimum is achived when the derivative w.r.t u equals to 0.
+  // The minimum is achieved when the derivative w.r.t u equals to 0.
   // This expands to:
   // 2 * (C * x + D * u - y_d)^T * Qy * D + 2 * u^T * R +
   // (2 * S1 * x_bar + S2)^T * B = 0.

--- a/systems/controllers/zmp_planner.h
+++ b/systems/controllers/zmp_planner.h
@@ -11,7 +11,7 @@ namespace controllers {
 
 /**
  * Given a desired two dimensional (X and Y) zero-moment point (ZMP) trajectory
- * parametrized as a piecewise polynomial, an optimal center of mass (CoM)
+ * parameterized as a piecewise polynomial, an optimal center of mass (CoM)
  * trajectory is planned using a linear inverted pendulum model (LIPM).
  * A second order value function (optimal cost-to-go) and a linear policy are
  * also computed along the optimal trajectory.


### PR DESCRIPTION
As with #9200, this mostly preserves grammar mistakes, unfortunately. Misspellings were identified with `codespell` and manually reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9203)
<!-- Reviewable:end -->
