### PR TITLE
Cleanup MacOS rpath fixup step

### DIFF
--- a/tools/install/install.py.in
+++ b/tools/install/install.py.in
@@ -215,7 +215,7 @@ def macos_fix_rpaths(basename, dst_full):
              os.path.join('@loader_path', diff_path),
              dst_full]
             )
-    # Remove RPATH values that contain $ORIGIN. These are from the build
+    # Remove RPATH values that contain @loader_path. These are from the build
     # tree and are irrelevant in the install tree. RPATH is not necessary as
     # relative or absolute path to each library is already known.
     file_output = check_output(["otool", "-l", dst_full])
@@ -223,7 +223,7 @@ def macos_fix_rpaths(basename, dst_full):
         split_line = line.strip().split(' ')
         if len(split_line) >= 2 \
                 and split_line[0] == 'path' \
-                and split_line[1].startswith('$ORIGIN'):
+                and split_line[1].startswith('@loader_path'):
             check_call(
                 ['install_name_tool', "-delete_rpath", split_line[1], dst_full]
             )


### PR DESCRIPTION
Bazel does not use $ORIGIN for rpath on MacOS anymore. This was changed
in commit [1].

[1] https://github.com/bazelbuild/bazel/commit/f98a7a2fedb3e714cef1038dcb85f83731150246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9213)
<!-- Reviewable:end -->
