### PR TITLE
Maliput: analyze connected components of Segments with confluent Lanes

### DIFF
--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -27,10 +27,12 @@ drake_cc_library(
     srcs = [
         "generate_obj.cc",
         "generate_urdf.cc",
+        "segment_analysis.cc",
     ],
     hdrs = [
         "generate_obj.h",
         "generate_urdf.h",
+        "segment_analysis.h",
     ],
     visibility = ["//visibility:private"],
     deps = [
@@ -103,6 +105,14 @@ drake_cc_googletest(
         ":utility",
         "//automotive/maliput/monolane",
         "@spruce",
+    ],
+)
+
+drake_cc_googletest(
+    name = "segment_analysis_test",
+    deps = [
+        ":utility",
+        "//automotive/maliput/multilane:loader",
     ],
 )
 

--- a/automotive/maliput/utility/segment_analysis.cc
+++ b/automotive/maliput/utility/segment_analysis.cc
@@ -1,0 +1,83 @@
+#include "drake/automotive/maliput/utility/segment_analysis.h"
+
+#include <queue>
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+
+std::unordered_set<const api::Segment*>
+FindConfluentSegments(const api::Segment* const seed_segment) {
+  // Make an empty workqueue (FIFO).
+  std::queue<const api::Segment*> workqueue;
+  // Make an empty visited set.
+  std::unordered_set<const api::Segment*> visited;
+
+  // Add seed_segment to the workqueue.
+  workqueue.push(seed_segment);
+
+  // Work the queue.
+  while (!workqueue.empty()) {
+    const api::Segment* working_segment = workqueue.front();
+    workqueue.pop();
+
+    // Loop over each Lane in the Segment.
+    for (int lane_index = 0;
+         lane_index < working_segment->num_lanes(); ++lane_index) {
+      const api::Lane* const lane = working_segment->lane(lane_index);
+      // Loop over each End of the Lane.
+      for (const api::LaneEnd::Which end :
+        {api::LaneEnd::kStart, api::LaneEnd::kFinish}) {
+        const api::LaneEndSet* const confluent_set =
+            lane->GetConfluentBranches(end);
+        // Loop over the set of confluent lanes.
+        for (int i = 0; i < confluent_set->size(); ++i) {
+          // Get confluent segment.
+          const api::Segment* confluent_segment =
+              confluent_set->get(i).lane->segment();
+          // Is confluent segment in visited set?
+          if (visited.find(confluent_segment) == visited.end()) {
+            // Not yet:  then push onto end of workqueue, and mark as visited.
+            workqueue.push(confluent_segment);
+            visited.insert(confluent_segment);
+          }
+        }
+      }
+    }
+  }
+  // Return the visited set, which is the set of all Segments connected to
+  // seed_segment (including seed_segment itself).
+  return visited;
+}
+
+
+std::vector<std::unordered_set<const api::Segment*>>
+AnalyzeConfluentSegments(const api::RoadGeometry* road_geometry) {
+  std::vector<std::unordered_set<const api::Segment*>> components;
+  std::unordered_set<const api::Segment*> visited;
+  for (int junction_index = 0;
+       junction_index < road_geometry->num_junctions(); ++junction_index) {
+    const api::Junction* const junction =
+        road_geometry->junction(junction_index);
+    for (int segment_index = 0;
+         segment_index < junction->num_segments(); ++segment_index) {
+      const api::Segment* const segment = junction->segment(segment_index);
+      // If segment has already been visited, skip it.
+      if (visited.count(segment) > 0) { continue; }
+      // Explore segment's connected component.
+      components.emplace_back(FindConfluentSegments(segment));
+      // Record all segments from the new component as visited.
+      visited.insert(components.back().begin(), components.back().end());
+    }
+  }
+  // Return the list of connected components.
+  return components;
+}
+
+
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/segment_analysis.h
+++ b/automotive/maliput/utility/segment_analysis.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+
+/// Finds all Segments connected to @p seed_segment via confluent Lanes.
+///
+/// This function performs a breadth-first search over the graph of Segments,
+/// Lanes, and BranchPoints originating at `seed_segment`.  It does not
+/// explore any other elements and does not require these elements to have
+/// valid ownership pointers upwards to Junctions or to a RoadGeometry.
+///
+/// @returns an unordered_set of Segments connected to `seed_segment`,
+///          including `seed_segment` itself.
+std::unordered_set<const api::Segment*>
+FindConfluentSegments(const api::Segment* seed_segment);
+
+
+/// Analyzes how Segments in @p road_geometry are connected via confluency
+/// of their Lanes at BranchPoints.
+///
+/// Two Lanes which are confluent at a BranchPoint necessarily overlap near
+/// the BranchPoint, so the Segments which own those Lanes ought to belong
+/// to a common Junction. The output of this function is thus a lower-bound
+/// for how Segments should be grouped together into Junctions, which can
+/// be used for verifying or synthesizing (approximately) the Junction
+/// structure.  (This function will not detect Lanes which have overlapping
+/// geometries independent of their BranchPoints.)
+///
+/// @returns the set of
+/// <a href="https://en.wikipedia.org/wiki/Connected_component_(graph_theory)">
+///          connected components</a> of Segments, as a vector of
+///          unordered_sets.  The ordering of the components in the vector is
+///          arbitrary.  Each Segment in @p road_geometry shall belong
+///          to exactly one component.
+std::vector<std::unordered_set<const api::Segment*>>
+AnalyzeConfluentSegments(const api::RoadGeometry* road_geometry);
+
+
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/test/segment_analysis_test.cc
+++ b/automotive/maliput/utility/test/segment_analysis_test.cc
@@ -1,0 +1,143 @@
+#include "drake/automotive/maliput/utility/segment_analysis.h"
+
+#include <memory>
+#include <set>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/multilane/loader.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace {
+
+
+GTEST_TEST(SegmentAnalysisAnalyzeConfluentSegments, BasicOperation) {
+  // ---------------------------------------------------
+  // |                                                 |
+  // |                   ^^                            |
+  // |                   || north2                     |
+  // |                   ||                            |
+  // |                   ||                            |
+  // |                   oo                            |
+  // |                   ^^                            |
+  // |                   || north1                     |
+  // |     east0         ||       east2                |
+  // |    o--------->o---++---->o--------->            |
+  // |    o--------->o---++---->o--------->o--\        |
+  // |                \  || east1              \       |
+  // |            turn \ ||                    | loop  |
+  // |                  \oo                    |       |
+  // |                   ^^                    |       |
+  // |                   || north0             |       |
+  // |                   ||                    |       |
+  // |                   ||                    |       |
+  // |                   oo                   /        |
+  // |                   ^                   /         |
+  // |                   |                  /          |
+  // |                    \                /           |
+  // |                     \--------------/            |
+  // |                                                 |
+  // ---------------------------------------------------
+  const std::string dut_yaml = R"R(# -*- yaml -*-
+---
+# distances are meters; angles are degrees.
+maliput_multilane_builder:
+  id: dut
+  lane_width: 1
+  left_shoulder: 1
+  right_shoulder: 1
+  elevation_bounds: [0, 5]
+  scale_length: 1.0
+  linear_tolerance: 0.01
+  angular_tolerance: 0.5
+  computation_policy: prefer-speed
+  points:
+    origin:
+      xypoint: [0, 0, 0]
+      zpoint: [0, 0, 0, 0]
+  connections:
+    east0:
+      lanes: [2, 0, 0]
+      start: ["ref", "points.origin.forward"]
+      length:  100
+      z_end: ["ref", [0, 0, 0]]
+    east1:
+      lanes: [2, 0, 0]
+      start: ["lane.0", "connections.east0.end.0.forward"]
+      length: 100
+      z_end: ["lane.0", [0, 0, 0]]
+    east2:
+      lanes: [2, 0, 0]
+      start: ["lane.0", "connections.east1.end.0.forward"]
+      length: 100
+      z_end: ["lane.0", [0, 0, 0]]
+
+    loop:
+      lanes: [1, 0, 0]
+      start: ["lane.0", "connections.east2.end.0.forward"]
+      arc: [150, -270]
+      z_end: ["lane.0", [0, 0, 0]]
+
+    north0:
+      lanes: [2, 0, 0]
+      start: ["lane.0", "connections.loop.end.0.forward"]
+      length: 100
+      z_end: ["lane.0", [0, 0, 0]]
+    north1:
+      lanes: [2, 0, 0]
+      start: ["lane.0", "connections.north0.end.0.forward"]
+      length: 100
+      z_end: ["lane.0", [0, 0, 0]]
+    north2:
+      lanes: [2, 0, 0]
+      start: ["lane.0", "connections.north1.end.0.forward"]
+      length: 100
+      z_end: ["lane.0", [0, 0, 0]]
+
+    turn:
+      lanes: [1, 0, 0]
+      start: ["lane.0", "connections.east0.end.0.forward"]
+      arc: [50, -90]
+      explicit_end: ["lane.0", "connections.north0.end.0.reverse"]
+
+  groups: {}
+)R";
+  const std::unique_ptr<const api::RoadGeometry> rg =
+      multilane::Load(multilane::BuilderFactory(), dut_yaml);
+
+  const std::vector<std::unordered_set<const api::Segment*>> groups =
+      AnalyzeConfluentSegments(rg.get());
+
+  const auto lookup_segment = [&rg] (const std::string& id_string) {
+    return rg->ById().GetSegment(api::SegmentId(id_string));
+  };
+  const std::set<std::set<const api::Segment*>> expected
+      {{lookup_segment("s:east0")},
+       {lookup_segment("s:east2")},
+       {lookup_segment("s:north0")},
+       {lookup_segment("s:north2")},
+       {lookup_segment("s:loop")},
+       {lookup_segment("s:north1"),
+        lookup_segment("s:east1"),
+        lookup_segment("s:turn")}
+      };
+
+  // Recast groups as "set of sets" (instead of "vector of unordered_sets")
+  // to make equality testing trivial.
+  std::set<std::set<const api::Segment*>> actual;
+  for (const auto& group : groups) {
+    std::set<const api::Segment*> set(group.begin(), group.end());
+    actual.insert(set);
+  }
+  EXPECT_EQ(actual, expected);
+}
+
+
+}  // anonymous namespace
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
This provides methods to figure out which Segments should be grouped
together into Junctions simply on account of how the Segments are
joined together at BranchPoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9214)
<!-- Reviewable:end -->
