### PR TITLE
Initialize AutodiffScalar in default constructor

### DIFF
--- a/common/autodiffxd.h
+++ b/common/autodiffxd.h
@@ -55,7 +55,8 @@ class AutoDiffScalar<VectorXd>
   using Base::operator+;
   using Base::operator*;
 
-  AutoDiffScalar() {}
+  AutoDiffScalar()
+    : m_value(Scalar(0)), m_derivatives(DerType::Zero(0)) {}
 
   AutoDiffScalar(const Scalar& value, int nbDer, int derNumber)
       : m_value(value), m_derivatives(DerType::Zero(nbDer)) {


### PR DESCRIPTION
This removes the following error message on Ubuntu Bionic with
gcc 7.3

 error: '*((void*)&<anonymous> +376)' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     m_value = other.value();

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9216)
<!-- Reviewable:end -->
