### PR TITLE
Missing break statement

### DIFF
--- a/solvers/gurobi_solver.cc
+++ b/solvers/gurobi_solver.cc
@@ -697,6 +697,7 @@ SolutionResult GurobiSolver::Solve(MathematicalProgram& prog) const {
       case MathematicalProgram::VarType::INTEGER:
         gurobi_var_type[i] = GRB_INTEGER;
         is_mip = true;
+        break;
       case MathematicalProgram::VarType::BOOLEAN:
         throw std::runtime_error(
             "Boolean variables should not be used with Gurobi solver.");


### PR DESCRIPTION
This was found compiling drake with gcc 7.3 on Ubuntu 18.04 with all
the solvers (--config=everything).
Prior to this commit, the following error message was printed:

ERROR: /home/fbudin/Devel/drake/solvers/BUILD.bazel:576:1:
  Couldn't build file solvers/_objs/gurobi_solver/gurobi_solver.pic.o:
  C++ compilation of rule '//solvers:gurobi_solver' failed (Exit 1)
solvers/gurobi_solver.cc: In member function 'virtual drake::solvers::SolutionResult
  drake::solvers::GurobiSolver::Solve(drake::solvers::MathematicalProgram&) const':
solvers/gurobi_solver.cc:699:16: error: this statement may fall through [-Werror=implicit-fallthrough=]
         is_mip = true;
         ~~~~~~~^~~~~~
solvers/gurobi_solver.cc:700:7: note: here
       case MathematicalProgram::VarType::BOOLEAN:
       ^~~~
cc1plus: some warnings being treated as errors
Target //solvers:mosek_solver_test failed to build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9217)
<!-- Reviewable:end -->
