### PR TITLE
Disable strict overflow warning for multiple_shooting target

### DIFF
--- a/systems/trajectory_optimization/BUILD.bazel
+++ b/systems/trajectory_optimization/BUILD.bazel
@@ -59,6 +59,8 @@ drake_cc_library(
     name = "multiple_shooting",
     srcs = ["multiple_shooting.cc"],
     hdrs = ["multiple_shooting.h"],
+    # NOTE: This is necessary for gcc 7.3 to not throw a warning.
+    gcc_copts = ["-Wno-strict-overflow"],
     deps = [
         "//common:essential",
         "//common/trajectories:piecewise_polynomial",


### PR DESCRIPTION
gcc 7.3 on Ubuntu 18.04 gives the following warning message otherwise:
...systems/trajectory_optimization/multiple_shooting.h:
  In member function 'void drake::systems::trajectory_optimization::DirectTranscription::ConstrainEqualInputAtFinalTwoTimesteps()':
...systems/trajectory_optimization/multiple_shooting.h:109:29:
  warning: assuming signed overflow does not occur when assuming that (X - c) <= X is always true [-Wstrict-overflow]
     DRAKE_DEMAND(index >= 0 && index < N_);
                  ~~~~~~~~~~~^~~~~~~~~~~~
...common/drake_assert.h:107:26: note: in definition of macro 'DRAKE_DEMAND'
     if (!Trait::Evaluate(condition)) {

This most likely happens because N_ is initialized to 0. But since N_ can also take
other values, this warning is not relevant (see complaints in the gcc bug reports [1]).

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9218)
<!-- Reviewable:end -->
