### PR TITLE
multibody/parsing: Add a collision_filter_group to the unit test

### DIFF
--- a/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
+++ b/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
@@ -106,5 +106,11 @@
       </collision>
     </link>
 
+    <!-- For now at least, We care only that Drake's custom tag doesn't break
+         parsing the rest of the elements in this file. -->
+    <collision_filter_group name="filter_group1">
+      <member link="link1"/>
+      <member link="link2"/>
+    </collision_filter_group>
   </model>
 </sdf>


### PR DESCRIPTION
We don't parse collision_filter_group elements yet, but we also want to make sure that we don't choke on them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9220)
<!-- Reviewable:end -->
