### PR TITLE
Revert "workspace: Update sdformat to latest commit"

### DIFF
--- a/tools/workspace/sdformat/package.BUILD.bazel
+++ b/tools/workspace/sdformat/package.BUILD.bazel
@@ -82,7 +82,6 @@ cmake_configure_file(
 
 SDFORMAT_MOST_PUBLIC_HDRS = [
     "include/sdf/Assert.hh",
-    "include/sdf/Atmosphere.hh",
     "include/sdf/Box.hh",
     # TODO(jwnimmer-tri) Collision.hh isn't marked public in upstream sdformat,
     # but it should be.
@@ -94,7 +93,6 @@ SDFORMAT_MOST_PUBLIC_HDRS = [
     "include/sdf/Exception.hh",
     "include/sdf/Filesystem.hh",
     "include/sdf/Geometry.hh",
-    "include/sdf/Gui.hh",
     "include/sdf/Joint.hh",
     "include/sdf/JointAxis.hh",
     "include/sdf/Link.hh",
@@ -166,7 +164,6 @@ cc_library(
         "include/sdf/SDFImplPrivate.hh",
         "include/sdf/parser_private.hh",
         "include/sdf/parser_urdf.hh",
-        "src/Atmosphere.cc",
         "src/Box.cc",
         "src/Collision.cc",
         "src/Console.cc",
@@ -177,7 +174,6 @@ cc_library(
         "src/Exception.cc",
         "src/Filesystem.cc",
         "src/Geometry.cc",
-        "src/Gui.cc",
         "src/Joint.cc",
         "src/JointAxis.cc",
         "src/Link.cc",

--- a/tools/workspace/sdformat/repository.bzl
+++ b/tools/workspace/sdformat/repository.bzl
@@ -5,12 +5,12 @@ load("//tools/workspace:bitbucket.bzl", "bitbucket_archive")
 def sdformat_repository(
         name,
         mirrors = None):
-    commit = "13546ead5493"
+    commit = "8db558193cb3"
     bitbucket_archive(
         name = name,
         repository = "osrf/sdformat",
         commit = commit,
-        sha256 = "87a61f3cdef4b96fbe0bed1ab0e462c3d40f745251f8312bc10b55cfd3450d80",  # noqa
+        sha256 = "eddd4bbddf2ebee1e832efa95ff00140b5ddff90a253653397a5f299169db74e",  # noqa
         strip_prefix = "osrf-sdformat-%s" % (commit),
         build_file = "@drake//tools/workspace/sdformat:package.BUILD.bazel",
         mirrors = mirrors,


### PR DESCRIPTION
This reverts commit db8f435905f3dbac9515b7e877b9b5778eb1e478.

As demonstrated by #9220 built against master, we currently choke on (Drake's non-standard) `collision_filter_group` elements, when using the latest SDFormat that tries to copy unknown XML elements into the parse tree.

I don't know exactly what is going wrong, but for now let's just stop the bleeding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9221)
<!-- Reviewable:end -->
