### PR TITLE
py math: Bind additional constructors for `RotationMatrix` and `RollPitchYaw`

### DIFF
--- a/bindings/pydrake/math_py.cc
+++ b/bindings/pydrake/math_py.cc
@@ -59,6 +59,7 @@ PYBIND11_MODULE(math, m) {
       .def(py::init<const T&, const T&, const T&>(),
            py::arg("roll"), py::arg("pitch"), py::arg("yaw"))
       .def(py::init<const RotationMatrix<T>&>(), py::arg("R"))
+      .def(py::init<const Eigen::Quaternion<T>&>(), py::arg("quaternion"))
       .def("vector", &RollPitchYaw<T>::vector)
       .def("roll_angle", &RollPitchYaw<T>::roll_angle)
       .def("pitch_angle", &RollPitchYaw<T>::pitch_angle)
@@ -67,6 +68,7 @@ PYBIND11_MODULE(math, m) {
 
   py::class_<RotationMatrix<T>>(m, "RotationMatrix")
       .def(py::init())
+      .def(py::init<const Matrix3<T>&>(), py::arg("R"))
       .def(py::init<Eigen::Quaternion<T>>(), py::arg("quaternion"))
       .def(py::init<const RollPitchYaw<T>&>(), py::arg("rpy"))
       .def("matrix", &RotationMatrix<T>::matrix)

--- a/bindings/pydrake/test/math_test.py
+++ b/bindings/pydrake/test/math_test.py
@@ -86,10 +86,13 @@ class TestBarycentricMesh(unittest.TestCase):
             self.assertEqual(f_core(a, b), f_cpp(a, b))
 
     def test_rotation_matrix(self):
+        # - Constructors.
         R = mut.RotationMatrix()
         self.assertTrue(np.allclose(R.matrix(), np.eye(3)))
         self.assertTrue(np.allclose(
             mut.RotationMatrix.Identity().matrix(), np.eye(3)))
+        R = mut.RotationMatrix(R=np.eye(3))
+        self.assertTrue(np.allclose(R.matrix(), np.eye(3)))
         R = mut.RotationMatrix(quaternion=Quaternion.Identity())
         self.assertTrue(np.allclose(R.matrix(), np.eye(3)))
         R = mut.RotationMatrix(rpy=mut.RollPitchYaw(rpy=[0, 0, 0]))
@@ -104,11 +107,17 @@ class TestBarycentricMesh(unittest.TestCase):
         self.assertTrue(np.allclose(R_I.matrix(), np.eye(3)))
 
     def test_roll_pitch_yaw(self):
+        # - Constructors.
         rpy = mut.RollPitchYaw(rpy=[0, 0, 0])
         self.assertTrue(np.allclose(rpy.vector(), [0, 0, 0]))
         rpy = mut.RollPitchYaw(roll=0, pitch=0, yaw=0)
         self.assertTupleEqual(
             (rpy.roll_angle(), rpy.pitch_angle(), rpy.yaw_angle()),
             (0, 0, 0))
+        rpy = mut.RollPitchYaw(R=mut.RotationMatrix())
+        self.assertTrue(np.allclose(rpy.vector(), [0, 0, 0]))
         q_I = Quaternion()
+        rpy_q_I = mut.RollPitchYaw(quaternion=q_I)
+        self.assertTrue(np.allclose(rpy_q_I.vector(), [0, 0, 0]))
+        # - Additional properties.
         self.assertTrue(np.allclose(rpy.ToQuaternion().wxyz(), q_I.wxyz()))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9227)
<!-- Reviewable:end -->
