### PR TITLE
Reduce mesh quads on generate_obj

### DIFF
--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
     name = "utility",
     deps = [
         ":everything",
+        ":meshes",
     ],
 )
 
@@ -34,8 +35,24 @@ drake_cc_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        ":meshes",
         "//automotive/maliput/api",
         "//math:geometric_transform",
+    ],
+)
+
+drake_cc_library(
+    name = "meshes",
+    srcs = [
+        "mesh_simplification.cc",
+    ],
+    hdrs = [
+        "mesh.h",
+        "mesh_simplification.h",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//automotive/maliput/api",
     ],
 )
 
@@ -114,6 +131,13 @@ drake_py_unittest(
         ":yaml_to_obj",
         "//automotive/maliput/monolane:yamls",
         "//automotive/maliput/multilane:yamls",
+    ],
+)
+
+drake_cc_googletest(
+    name = "mesh_simplification_test",
+    deps = [
+        ":meshes",
     ],
 )
 

--- a/automotive/maliput/utility/generate_obj.cc
+++ b/automotive/maliput/utility/generate_obj.cc
@@ -17,277 +17,19 @@
 #include "drake/automotive/maliput/api/lane.h"
 #include "drake/automotive/maliput/api/road_geometry.h"
 #include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/utility/mesh.h"
+#include "drake/automotive/maliput/utility/mesh_simplification.h"
 #include "drake/common/drake_assert.h"
-#include "drake/common/hash.h"
 
 namespace drake {
 namespace maliput {
 namespace utility {
 
+using mesh::GeoMesh;
+using mesh::SrhFace;
+using mesh::SimplifyMeshFaces;
+
 namespace {
-
-// A container for a set of unique objects which keeps track of the original
-// insertion order.  Its primary purpose is to assign a stable unique index
-// to each element at time of insertion.
-//
-// @tparam T  the inserted element type
-// @tparam Hash  a hasher suitable for std::unordered_map (e.g., std::hash)
-// @tparam KeyEqual  an equivalence relation suitable for std::unordered_map
-//                   (e.g., std::equal_to)
-template <class T, class Hash, class KeyEqual>
-class UniqueIndexer {
- public:
-  // Creates an empty UniqueIndexer.
-  UniqueIndexer() {}
-
-  // Pushes @p thing onto the back of this container, and returns the unique
-  // index for @p thing.  If @p thing has already been added to the container,
-  // then this simply returns the original index for @p thing.
-  int push_back(const T& thing) {
-    auto mi = map_.find(thing);
-    if (mi != map_.end()) {
-      return mi->second;
-    }
-    const int index = vector_.size();
-    auto it = map_.emplace(thing, index).first;
-    vector_.push_back(&(it->first));
-    return index;
-  }
-
-  // Returns a vector of all elements added to this container.  The index of
-  // any element in the vector equals the index generated when the element
-  // was added to the container.
-  const std::vector<const T*>& vector() const { return vector_; }
-
- private:
-  std::unordered_map<T, int, Hash, KeyEqual> map_;
-  std::vector<const T*> vector_;
-};
-
-
-// A world frame vertex.
-class GeoVertex {
- public:
-  // A hasher operation suitable for std::unordered_map.
-  using Hash = drake::DefaultHash;
-
-  // An equivalence operation suitable for std::unordered_map.
-  struct Equiv {
-    bool operator()(const GeoVertex& lhs, const GeoVertex& rhs) const {
-      return (lhs.v().xyz() == rhs.v().xyz());
-    }
-  };
-
-  GeoVertex() {}
-
-  explicit GeoVertex(const api::GeoPosition& v) : v_(v) {}
-
-  const api::GeoPosition& v() const { return v_; }
-
-  /// Implements the @ref hash_append concept.
-  template <class HashAlgorithm>
-  friend void hash_append(
-      HashAlgorithm& hasher, const GeoVertex& item) noexcept {
-    using drake::hash_append;
-    hash_append(hasher, item.v_.x());
-    hash_append(hasher, item.v_.y());
-    hash_append(hasher, item.v_.z());
-  }
-
- private:
-  api::GeoPosition v_;
-};
-
-
-// A world frame normal vector.
-class GeoNormal {
- public:
-  // A hasher operation suitable for std::unordered_map.
-  using Hash = drake::DefaultHash;
-
-  // An equivalence operation suitable for std::unordered_map.
-  struct Equiv {
-    bool operator()(const GeoNormal& lhs, const GeoNormal& rhs) const {
-      return (lhs.n().xyz() == rhs.n().xyz());
-    }
-  };
-
-  GeoNormal() {}
-
-  explicit GeoNormal(const api::GeoPosition& n) : n_(n) {}
-
-  const api::GeoPosition& n() const { return n_; }
-
-  /// Implements the @ref hash_append concept.
-  template <class HashAlgorithm>
-  friend void hash_append(
-      HashAlgorithm& hasher, const GeoNormal& item) noexcept {
-    using drake::hash_append;
-    hash_append(hasher, item.n_.x());
-    hash_append(hasher, item.n_.y());
-    hash_append(hasher, item.n_.z());
-  }
-
- private:
-  api::GeoPosition n_;
-};
-
-
-// A world frame face:  a sequence of vertices with corresponding normals.
-class GeoFace {
- public:
-  GeoFace() {}
-
-  GeoFace(const std::vector<GeoVertex>& vertices,
-          const std::vector<GeoNormal>& normals)
-      : vertices_(vertices), normals_(normals) {
-    DRAKE_DEMAND(vertices.size() == normals.size());
-  }
-
-  void push_vn(const GeoVertex& vertex, const GeoNormal& normal) {
-    vertices_.push_back(vertex);
-    normals_.push_back(normal);
-  }
-
-  const std::vector<GeoVertex>& vertices() const { return vertices_; }
-
-  const std::vector<GeoNormal>& normals() const { return normals_; }
-
- private:
-  std::vector<GeoVertex> vertices_;
-  std::vector<GeoNormal> normals_;
-};
-
-
-// A face --- a sequence of vertices with normals --- in which the
-// vertices and normals are represented by integer indices into some
-// other container/dictionary.
-class IndexFace {
- public:
-  struct Vertex {
-    Vertex(int vertex_index_in, int normal_index_in)
-        : vertex_index(vertex_index_in),
-          normal_index(normal_index_in) {}
-
-    int vertex_index{};
-    int normal_index{};
-  };
-
-  void push_vertex(int vertex_index, int normal_index) {
-    vertices_.emplace_back(vertex_index, normal_index); }
-
-  const std::vector<Vertex>& vertices() const { return vertices_; }
-
- private:
-  std::vector<Vertex> vertices_;
-};
-
-
-// A world frame mesh:  a collection of GeoFaces.
-class GeoMesh {
- public:
-  GeoMesh() {}
-
-  void PushFace(const GeoFace& geo_face) {
-    IndexFace face;
-    for (size_t gi = 0; gi < geo_face.vertices().size(); ++gi) {
-      int vi = vertices_.push_back(geo_face.vertices()[gi]);
-      int ni = normals_.push_back(geo_face.normals()[gi]);
-      face.push_vertex(vi, ni);
-    }
-    faces_.push_back(face);
-  }
-
-  // Emits the mesh as Wavefront OBJ elements to @p os.  @p material is the
-  // name of an MTL-defined material to describe visual properties of the mesh.
-  // @p precision specifies the fixed-point precision (number of digits after
-  // the decimal point) for vertex and normal coordinate values.  @p origin
-  // specifies a world-frame origin for vertex coordinates (i.e., the emitted
-  // values for a vertex at `(x,y,z)` will be `(x,y,z) - origin`).
-  //
-  // If other meshes have already been emitted to stream @p os, then
-  // @p vertex_index_offset and @p normal_index_offset must correspond to the
-  // number of previously emitted vertices and normals respectively.
-  // Conveniently, EmitObj() returns a tuple of (vertex_index_offset,
-  // normal_index_offset) which can be chained into a succeeding call to
-  // EmitObj().
-  std::tuple<int, int>
-  EmitObj(std::ostream& os, const std::string& material,
-          int precision, const api::GeoPosition& origin,
-          int vertex_index_offset, int normal_index_offset) {
-    if (faces_.empty()) {
-      // Short-circuit if there is nothing to draw.
-      return std::make_tuple(vertex_index_offset, normal_index_offset);
-    }
-
-    // NOLINTNEXTLINE(build/namespaces)  Usage documented by fmt library.
-    using namespace fmt::literals;
-    fmt::print(os, "# Vertices\n");
-    for (const GeoVertex* gv : vertices_.vector()) {
-      fmt::print(os, "v {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
-                 "x"_a = (gv->v().x() - origin.x()),
-                 "y"_a = (gv->v().y() - origin.y()),
-                 "z"_a = (gv->v().z() - origin.z()),
-                 "p"_a = precision);
-    }
-    fmt::print(os, "# Normals\n");
-    for (const GeoNormal* gn : normals_.vector()) {
-      fmt::print(os, "vn {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
-                 "x"_a = gn->n().x(), "y"_a = gn->n().y(), "z"_a = gn->n().z(),
-                 "p"_a = precision);
-    }
-    fmt::print(os, "\n");
-    fmt::print(os, "# Faces\n");
-    if (!material.empty()) {
-      fmt::print(os, "usemtl {}\n", material);
-    }
-    for (const IndexFace& f : faces_) {
-      fmt::print(os, "f");
-      for (const IndexFace::Vertex& ifv : f.vertices()) {
-        fmt::print(os, " {}//{}",
-                   (ifv.vertex_index + 1 + vertex_index_offset),
-                   (ifv.normal_index + 1 + normal_index_offset));
-      }
-      fmt::print(os, "\n");
-    }
-    return std::make_tuple(vertex_index_offset + vertices_.vector().size(),
-                           normal_index_offset + normals_.vector().size());
-  }
-
- private:
-  UniqueIndexer<GeoVertex, GeoVertex::Hash, GeoVertex::Equiv> vertices_;
-  UniqueIndexer<GeoNormal, GeoNormal::Hash, GeoNormal::Equiv> normals_;
-  std::vector<IndexFace> faces_;
-};
-
-
-// A `Lane`-frame face: a sequence of vertices expressed in the (s,r,h)
-// coordinates of an api::Lane (which is not referenced here).  Each
-// vertex has a normal vector also expressed in the `Lane`-frame.
-class SrhFace {
- public:
-  SrhFace(const std::initializer_list<api::LanePosition> vertices,
-          const api::LanePosition& normal)
-      : vertices_(vertices),
-        normal_(normal) {}
-
-  // Given a @p lane, calculates the corresponding GeoFace.
-  GeoFace ToGeoFace(const api::Lane* lane) const {
-    GeoFace geo_face;
-    for (const api::LanePosition& srh : vertices_) {
-      api::GeoPosition xyz(lane->ToGeoPosition(srh));
-      api::GeoPosition n = api::GeoPosition::FromXyz(
-          lane->GetOrientation(srh).quat() * normal_.srh());
-      geo_face.push_vn(GeoVertex(xyz), GeoNormal(n));
-    }
-    return geo_face;
-  }
-
- private:
-  std::vector<api::LanePosition> vertices_;
-  api::LanePosition normal_;
-};
-
 
 // Traverses @p lane, generating a cover of the surface with with quads
 // (4-vertex faces) which are added to @p mesh.  The quads are squares in
@@ -303,8 +45,7 @@ class SrhFace {
 //        the corresponding elevation `h`, to yield a quad vertex `(s, r, h)`
 void CoverLaneWithQuads(
     GeoMesh* mesh, const api::Lane* lane,
-    double grid_unit,
-    bool use_driveable_bounds,
+    double grid_unit, bool use_driveable_bounds,
     const std::function<double(double, double)>& elevation) {
   const double s_max = lane->length();
   for (double s0 = 0; s0 < s_max; s0 += grid_unit) {
@@ -708,6 +449,12 @@ void RenderBranchPoint(
   draw_arrows(branch_point->GetBSide());
 }
 
+GeoMesh SimplifyMesh(const GeoMesh& mesh, const ObjFeatures& features) {
+  if (features.simplify_mesh_threshold == 0.) {
+    return mesh;  // Passes given mesh unmodified.
+  }
+  return SimplifyMeshFaces(mesh, features.simplify_mesh_threshold);
+}
 
 void RenderSegment(const api::Segment* segment,
                    const ObjFeatures& features,
@@ -715,32 +462,37 @@ void RenderSegment(const api::Segment* segment,
                    GeoMesh* lane_mesh,
                    GeoMesh* marker_mesh,
                    GeoMesh* h_bounds_mesh) {
-  // Lane 0 should be as good as any other for driveable-bounds.
-  CoverLaneWithQuads(asphalt_mesh, segment->lane(0),
-                     PickGridUnit(segment->lane(0),
-                                  features.max_grid_unit,
-                                  features.min_grid_resolution),
-                     true /*use_driveable_bounds*/,
-                     [](double, double) { return 0.; });
+  const double base_grid_unit = PickGridUnit(
+      segment->lane(0), features.max_grid_unit,
+      features.min_grid_resolution);
+  {
+    // Lane 0 should be as good as any other for driveable-bounds.
+    GeoMesh driveable_mesh;
+    CoverLaneWithQuads(&driveable_mesh, segment->lane(0),
+                       base_grid_unit,
+                       true /*use_driveable_bounds*/,
+                       [](double, double) { return 0.; });
+    asphalt_mesh->AddFacesFrom(SimplifyMesh(driveable_mesh, features));
+  }
+
   if (features.draw_elevation_bounds) {
+    GeoMesh upper_h_bounds_mesh, lower_h_bounds_mesh;
     CoverLaneWithQuads(
-        h_bounds_mesh,
+        &upper_h_bounds_mesh,
         segment->lane(0),
-        PickGridUnit(segment->lane(0),
-                     features.max_grid_unit,
-                     features.min_grid_resolution),
+        base_grid_unit,
         true /*use_driveable_bounds*/,
         [&segment](double s, double r) {
           return segment->lane(0)->elevation_bounds(s, r).max(); });
     CoverLaneWithQuads(
-        h_bounds_mesh,
+        &lower_h_bounds_mesh,
         segment->lane(0),
-        PickGridUnit(segment->lane(0),
-                     features.max_grid_unit,
-                     features.min_grid_resolution),
+        base_grid_unit,
         true /*use_driveable_bounds*/,
         [&segment](double s, double r) {
           return segment->lane(0)->elevation_bounds(s, r).min(); });
+    h_bounds_mesh->AddFacesFrom(SimplifyMesh(upper_h_bounds_mesh, features));
+    h_bounds_mesh->AddFacesFrom(SimplifyMesh(lower_h_bounds_mesh, features));
   }
   for (int li = 0; li < segment->num_lanes(); ++li) {
     const api::Lane* lane = segment->lane(li);
@@ -748,20 +500,26 @@ void RenderSegment(const api::Segment* segment,
                                           features.max_grid_unit,
                                           features.min_grid_resolution);
     if (features.draw_lane_haze) {
-      CoverLaneWithQuads(lane_mesh, lane, grid_unit,
+      GeoMesh haze_mesh;
+      CoverLaneWithQuads(&haze_mesh, lane, grid_unit,
                          false /*use_driveable_bounds*/,
                          [&features](double, double) {
                            return features.lane_haze_elevation;
                          });
+      lane_mesh->AddFacesFrom(SimplifyMesh(haze_mesh, features));
     }
     if (features.draw_stripes) {
-      StripeLaneBounds(marker_mesh, lane, grid_unit,
+      GeoMesh stripes_mesh;
+      StripeLaneBounds(&stripes_mesh, lane, grid_unit,
                        features.stripe_elevation,
                        features.stripe_width);
+      marker_mesh->AddFacesFrom(SimplifyMesh(stripes_mesh, features));
     }
     if (features.draw_arrows) {
-      MarkLaneEnds(marker_mesh, lane, grid_unit,
+      GeoMesh arrows_mesh;
+      MarkLaneEnds(&arrows_mesh, lane, grid_unit,
                    features.arrow_elevation);
+      marker_mesh->AddFacesFrom(SimplifyMesh(arrows_mesh, features));
     }
   }
 }

--- a/automotive/maliput/utility/generate_obj.h
+++ b/automotive/maliput/utility/generate_obj.h
@@ -29,6 +29,15 @@ struct ObjFeatures {
   bool draw_branch_points{true};
   /// Draw highlighting of elevation_bounds of each lane?
   bool draw_elevation_bounds{true};
+  /// Tolerance for mesh simplification, or the distance from a vertex to an
+  /// edge line or to a face plane at which said vertex is considered redundant
+  /// (i.e. it is not necessary to further define those geometrical entities),
+  /// in meters. If equal to 0, no mesh simplification will take place. If equal
+  /// to the road linear tolerance, mesh simplification will be constrained
+  /// enough so as to keep mesh geometrical accuracy. If greater than the road
+  /// linear tolerance, mesh size reductions will come at the expense of
+  /// geometrical accuracy.
+  double simplify_mesh_threshold{0.};
   /// Absolute width of stripes
   double stripe_width{0.25};
   /// Absolute elevation (h) of stripes above road surface

--- a/automotive/maliput/utility/mesh.h
+++ b/automotive/maliput/utility/mesh.h
@@ -1,0 +1,319 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <initializer_list>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "fmt/ostream.h"
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/hash.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace mesh {
+
+/// A container for a set of unique objects which keeps track of the original
+/// insertion order.  Its primary purpose is to assign a stable unique index
+/// to each element at time of insertion.
+///
+/// @tparam T  the inserted element type
+/// @tparam Hash  a hasher suitable for std::unordered_map (e.g., std::hash)
+/// @tparam KeyEqual  an equivalence relation suitable for std::unordered_map
+///                   (e.g., std::equal_to)
+template <class T, class Hash, class KeyEqual>
+class UniqueIndexer {
+ public:
+  /// Creates an empty UniqueIndexer.
+  UniqueIndexer() = default;
+
+  /// Pushes @p thing onto the back of this container, and returns the unique
+  /// index for @p thing.  If @p thing has already been added to the container,
+  /// then this simply returns the original index for @p thing.
+  int push_back(const T& thing) {
+    auto mi = map_.find(thing);
+    if (mi != map_.end()) {
+      return mi->second;
+    }
+    const int index = vector_.size();
+    auto it = map_.emplace(thing, index).first;
+    vector_.push_back(&(it->first));
+    return index;
+  }
+
+  /// Returns a vector of all elements added to this container.  The index of
+  /// any element in the vector equals the index generated when the element
+  /// was added to the container.
+  const std::vector<const T*>& vector() const { return vector_; }
+
+ private:
+  std::unordered_map<T, int, Hash, KeyEqual> map_;
+  std::vector<const T*> vector_;
+};
+
+
+/// A world frame vertex.
+class GeoVertex {
+ public:
+  /// A hasher operation suitable for std::unordered_map.
+  using Hash = drake::DefaultHash;
+
+  /// An equivalence operation suitable for std::unordered_map.
+  struct Equiv {
+    bool operator()(const GeoVertex& lhs, const GeoVertex& rhs) const {
+      return (lhs.v().xyz() == rhs.v().xyz());
+    }
+  };
+
+  GeoVertex() {}
+
+  explicit GeoVertex(const api::GeoPosition& v) : v_(v) {}
+
+  const api::GeoPosition& v() const { return v_; }
+
+  //// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const GeoVertex& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.v_.x());
+    hash_append(hasher, item.v_.y());
+    hash_append(hasher, item.v_.z());
+  }
+
+ private:
+  api::GeoPosition v_;
+};
+
+
+/// A world frame normal vector.
+class GeoNormal {
+ public:
+  /// A hasher operation suitable for std::unordered_map.
+  using Hash = drake::DefaultHash;
+
+  /// An equivalence operation suitable for std::unordered_map.
+  struct Equiv {
+    bool operator()(const GeoNormal& lhs, const GeoNormal& rhs) const {
+      return (lhs.n().xyz() == rhs.n().xyz());
+    }
+  };
+
+  GeoNormal() {}
+
+  explicit GeoNormal(const api::GeoPosition& n) : n_(n) {}
+
+  const api::GeoPosition& n() const { return n_; }
+
+  //// Implements the @ref hash_append concept.
+  template <class HashAlgorithm>
+  friend void hash_append(
+      HashAlgorithm& hasher, const GeoNormal& item) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, item.n_.x());
+    hash_append(hasher, item.n_.y());
+    hash_append(hasher, item.n_.z());
+  }
+
+ private:
+  api::GeoPosition n_;
+};
+
+
+/// A world frame face:  a sequence of vertices with corresponding normals.
+class GeoFace {
+ public:
+  GeoFace() {}
+
+  GeoFace(const std::vector<GeoVertex>& vertices,
+          const std::vector<GeoNormal>& normals)
+      : vertices_(vertices), normals_(normals) {
+    DRAKE_DEMAND(vertices.size() == normals.size());
+  }
+
+  void push_vn(const GeoVertex& vertex, const GeoNormal& normal) {
+    vertices_.push_back(vertex);
+    normals_.push_back(normal);
+  }
+
+  const std::vector<GeoVertex>& vertices() const { return vertices_; }
+
+  const std::vector<GeoNormal>& normals() const { return normals_; }
+
+ private:
+  std::vector<GeoVertex> vertices_;
+  std::vector<GeoNormal> normals_;
+};
+
+
+/// A face --- a sequence of vertices with normals --- in which the
+/// vertices and normals are represented by integer indices into some
+/// other container/dictionary.
+class IndexFace {
+ public:
+  struct Vertex {
+    Vertex(int vertex_index_in, int normal_index_in)
+        : vertex_index(vertex_index_in),
+          normal_index(normal_index_in) {}
+
+    int vertex_index{};
+    int normal_index{};
+  };
+
+  void push_vertex(int vertex_index, int normal_index) {
+    vertices_.emplace_back(vertex_index, normal_index);
+  }
+
+  const std::vector<Vertex>& vertices() const { return vertices_; }
+
+ private:
+  std::vector<Vertex> vertices_;
+};
+
+
+/// A world frame mesh:  a collection of GeoFaces.
+class GeoMesh {
+ public:
+  GeoMesh() {}
+
+  void PushFace(const GeoFace& geo_face) {
+    IndexFace face;
+    for (size_t gi = 0; gi < geo_face.vertices().size(); ++gi) {
+      int vi = vertices_.push_back(geo_face.vertices()[gi]);
+      int ni = normals_.push_back(geo_face.normals()[gi]);
+      face.push_vertex(vi, ni);
+    }
+    faces_.push_back(face);
+  }
+
+  void AddFacesFrom(const GeoMesh& other_mesh) {
+    const std::vector<IndexFace>& other_faces = other_mesh.faces();
+    const std::vector<const GeoVertex*>& other_vertices = other_mesh.vertices();
+    const std::vector<const GeoNormal*>& other_normals = other_mesh.normals();
+    for (const IndexFace& other_face : other_faces) {
+      IndexFace face;
+      const std::vector<IndexFace::Vertex>&
+          other_face_vertices = other_face.vertices();
+      for (size_t i = 0; i < other_face_vertices.size(); ++i) {
+        const IndexFace::Vertex& other_face_vertex = other_face_vertices[i];
+        int vi = vertices_.push_back(*other_vertices[
+            other_face_vertex.vertex_index]);
+        int ni = normals_.push_back(*other_normals[
+            other_face_vertex.normal_index]);
+        face.push_vertex(vi, ni);
+      }
+      faces_.push_back(face);
+    }
+  }
+
+  /// Emits the mesh as Wavefront OBJ elements to @p os.  @p material is the
+  /// name of an MTL-defined material to describe visual properties of the mesh.
+  /// @p precision specifies the fixed-point precision (number of digits after
+  /// the decimal point) for vertex and normal coordinate values.  @p origin
+  /// specifies a world-frame origin for vertex coordinates (i.e., the emitted
+  /// values for a vertex at `(x,y,z)` will be `(x,y,z) - origin`).
+  ///
+  /// If other meshes have already been emitted to stream @p os, then
+  /// @p vertex_index_offset and @p normal_index_offset must correspond to the
+  /// number of previously emitted vertices and normals respectively.
+  /// Conveniently, EmitObj() returns a tuple of (vertex_index_offset,
+  /// normal_index_offset) which can be chained into a succeeding call to
+  /// EmitObj().
+  std::tuple<int, int>
+  EmitObj(std::ostream& os, const std::string& material,
+          int precision, const api::GeoPosition& origin,
+          int vertex_index_offset, int normal_index_offset) const {
+    if (faces_.empty()) {
+      // Short-circuit if there is nothing to draw.
+      return std::make_tuple(vertex_index_offset, normal_index_offset);
+    }
+
+    // NOLINTNEXTLINE(build/namespaces)  Usage documented by fmt library.
+    using namespace fmt::literals;
+    fmt::print(os, "# Vertices\n");
+    for (const GeoVertex* gv : vertices_.vector()) {
+      fmt::print(os, "v {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
+                 "x"_a = (gv->v().x() - origin.x()),
+                 "y"_a = (gv->v().y() - origin.y()),
+                 "z"_a = (gv->v().z() - origin.z()),
+                 "p"_a = precision);
+    }
+    fmt::print(os, "# Normals\n");
+    for (const GeoNormal* gn : normals_.vector()) {
+      fmt::print(os, "vn {x:.{p}f} {y:.{p}f} {z:.{p}f}\n",
+                 "x"_a = gn->n().x(), "y"_a = gn->n().y(), "z"_a = gn->n().z(),
+                 "p"_a = precision);
+    }
+    fmt::print(os, "\n");
+    fmt::print(os, "# Faces\n");
+    if (!material.empty()) {
+      fmt::print(os, "usemtl {}\n", material);
+    }
+    for (const IndexFace& f : faces_) {
+      fmt::print(os, "f");
+      for (const IndexFace::Vertex& ifv : f.vertices()) {
+        fmt::print(os, " {}//{}",
+                   (ifv.vertex_index + 1 + vertex_index_offset),
+                   (ifv.normal_index + 1 + normal_index_offset));
+      }
+      fmt::print(os, "\n");
+    }
+    return std::make_tuple(vertex_index_offset + vertices_.vector().size(),
+                           normal_index_offset + normals_.vector().size());
+  }
+
+  const std::vector<const GeoVertex*>& vertices() const {
+    return vertices_.vector();
+  }
+
+  const std::vector<const GeoNormal*>& normals() const {
+    return normals_.vector();
+  }
+
+  const std::vector<IndexFace>& faces() const { return faces_; }
+
+ private:
+  UniqueIndexer<GeoVertex, GeoVertex::Hash, GeoVertex::Equiv> vertices_;
+  UniqueIndexer<GeoNormal, GeoNormal::Hash, GeoNormal::Equiv> normals_;
+  std::vector<IndexFace> faces_;
+};
+
+
+/// A `Lane`-frame face: a sequence of vertices expressed in the (s,r,h)
+/// coordinates of an api::Lane (which is not referenced here).  Each
+/// vertex has a normal vector also expressed in the `Lane`-frame.
+class SrhFace {
+ public:
+  SrhFace(const std::initializer_list<api::LanePosition> vertices,
+          const api::LanePosition& normal)
+      : vertices_(vertices),
+        normal_(normal) {}
+
+  /// Given a @p lane, calculates the corresponding GeoFace.
+  GeoFace ToGeoFace(const api::Lane* lane) const {
+    GeoFace geo_face;
+    for (const api::LanePosition& srh : vertices_) {
+      api::GeoPosition xyz(lane->ToGeoPosition(srh));
+      api::GeoPosition n = api::GeoPosition::FromXyz(
+          lane->GetOrientation(srh).quat() * normal_.srh());
+      geo_face.push_vn(GeoVertex(xyz), GeoNormal(n));
+    }
+    return geo_face;
+  }
+
+ private:
+  std::vector<api::LanePosition> vertices_;
+  api::LanePosition normal_;
+};
+
+
+}  // namespace mesh
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/mesh_simplification.cc
+++ b/automotive/maliput/utility/mesh_simplification.cc
@@ -1,0 +1,266 @@
+#include "drake/automotive/maliput/utility/mesh_simplification.h"
+
+#include <algorithm>
+#include <queue>
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace mesh {
+
+InverseFaceEdgeMap ComputeInverseFaceEdgeMap(
+    const std::vector<IndexFace>& faces) {
+  InverseFaceEdgeMap inverse_face_edge_map;
+  const int faces_count = static_cast<int>(faces.size());
+  for (int face_index = 0; face_index < faces_count; ++face_index) {
+    const IndexFace& face = faces[face_index];
+    const std::vector<IndexFace::Vertex>& face_vertices = face.vertices();
+    const int face_vertex_count = static_cast<int>(face_vertices.size());
+    for (int start_vertex_index = 0; start_vertex_index < face_vertex_count;
+         ++start_vertex_index) {
+      int end_vertex_index = (start_vertex_index + 1) % face_vertex_count;
+      const DirectedEdgeIndex global_edge{
+          face_vertices[start_vertex_index].vertex_index,
+          face_vertices[end_vertex_index].vertex_index};
+      DRAKE_DEMAND(inverse_face_edge_map.count(global_edge) == 0);
+      inverse_face_edge_map[global_edge] = {face_index, start_vertex_index};
+    }
+  }
+  return inverse_face_edge_map;
+}
+
+FaceAdjacencyMap ComputeFaceAdjacencyMap(const std::vector<IndexFace>& faces) {
+  FaceAdjacencyMap adjacent_faces_map;
+
+  InverseFaceEdgeMap inverse_face_edge_map = ComputeInverseFaceEdgeMap(faces);
+  for (const auto& entry : inverse_face_edge_map) {
+    const DirectedEdgeIndex& edge_index = entry.first;
+    const FaceEdgeIndex& face_edge_index = entry.second;
+    if (adjacent_faces_map.count(face_edge_index.face_index) == 0) {
+      adjacent_faces_map[face_edge_index.face_index].resize(
+          faces[face_edge_index.face_index].vertices().size());
+    }
+    const DirectedEdgeIndex reversed_edge_index = edge_index.reverse();
+    if (inverse_face_edge_map.count(reversed_edge_index) > 0) {
+      std::vector<FaceEdgeIndex>& adjacent_face_edges =
+          adjacent_faces_map[face_edge_index.face_index];
+      adjacent_face_edges[face_edge_index.edge_index] =
+          inverse_face_edge_map[reversed_edge_index];
+    }
+  }
+  return adjacent_faces_map;
+}
+
+const Vector3<double>& GetMeshFaceVertexPosition(
+    const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
+  return mesh.vertices().at(vertex.vertex_index)->v().xyz();
+}
+
+const Vector3<double>& GetMeshFaceVertexNormal(
+    const GeoMesh& mesh, const IndexFace::Vertex& vertex) {
+  return mesh.normals().at(vertex.normal_index)->n().xyz();
+}
+
+bool IsMeshFaceCoplanarWithPlane(const GeoMesh& mesh, const IndexFace& face,
+                                 const Hyperplane3<double>& plane,
+                                 double tolerance) {
+  const std::vector<IndexFace::Vertex>& face_vertices = face.vertices();
+  return DoMeshVerticesLieOnPlane(mesh, face_vertices.begin(),
+                                  face_vertices.end(), plane, tolerance);
+}
+
+bool IsMeshFacePlanar(const GeoMesh& mesh, const IndexFace& face,
+                      double tolerance, Hyperplane3<double>* plane) {
+  DRAKE_DEMAND(plane != nullptr);
+  const std::vector<IndexFace::Vertex>& face_vertices = face.vertices();
+  DRAKE_DEMAND(face_vertices.size() >= 3);
+  const Vector3<double>& x0 = GetMeshFaceVertexPosition(mesh, face_vertices[0]);
+  const Vector3<double>& n0 = GetMeshFaceVertexNormal(mesh, face_vertices[0]);
+  *plane = Hyperplane3<double>(n0.normalized(), x0);
+  return DoMeshVerticesLieOnPlane(mesh, face_vertices.begin() + 1,
+                                  face_vertices.end(), *plane, tolerance);
+}
+
+std::set<int> AggregateAdjacentCoplanarMeshFaces(
+    const GeoMesh& mesh, int start_face_index,
+    const FaceAdjacencyMap& adjacent_faces_map, double tolerance,
+    std::set<int>* visited_faces_indices) {
+  DRAKE_DEMAND(0 <= start_face_index);
+  const std::vector<IndexFace>& faces = mesh.faces();
+  DRAKE_DEMAND(start_face_index < static_cast<int>(faces.size()));
+  DRAKE_DEMAND(tolerance > 0.);
+  DRAKE_DEMAND(visited_faces_indices != nullptr);
+  DRAKE_DEMAND(visited_faces_indices->count(start_face_index) == 0);
+
+  // Traverse adjacent faces, collecting coplanar ones.
+  std::set<int> mergeable_faces_indices{start_face_index};
+  Hyperplane3<double> start_face_plane;
+  if (IsMeshFacePlanar(mesh, faces[start_face_index], tolerance,
+                       &start_face_plane)) {
+    std::queue<int> faces_indices_to_visit({start_face_index});
+    while (!faces_indices_to_visit.empty()) {
+      int face_index = faces_indices_to_visit.front();
+      const std::vector<FaceEdgeIndex>& adjacent_face_edges =
+          adjacent_faces_map.at(face_index);
+      const int face_edge_count = adjacent_face_edges.size();
+      for (int edge_index = 0; edge_index < face_edge_count; ++edge_index) {
+        const int adjacent_face_index =
+            adjacent_face_edges[edge_index].face_index;
+        if (adjacent_face_index == -1) continue;
+        if (mergeable_faces_indices.count(adjacent_face_index) > 0) {
+          continue;
+        }
+        if (visited_faces_indices->count(adjacent_face_index) > 0) {
+          continue;
+        }
+        if (IsMeshFaceCoplanarWithPlane(mesh, faces[adjacent_face_index],
+                                        start_face_plane, tolerance)) {
+          mergeable_faces_indices.insert(adjacent_face_index);
+          faces_indices_to_visit.push(adjacent_face_index);
+        }
+      }
+      visited_faces_indices->insert(face_index);
+      faces_indices_to_visit.pop();
+    }
+  } else {
+    visited_faces_indices->insert(start_face_index);
+  }
+  return mergeable_faces_indices;
+}
+
+FaceEdgeIndex FindOuterFaceEdgeIndex(
+    const std::set<int>& simply_connected_faces_indices,
+    const FaceAdjacencyMap& adjacent_faces_map) {
+  // Goes over each face in the simply connected region, looking
+  // for the first face edge that's not adjacent to a face within
+  // the same region.
+  for (int face_index : simply_connected_faces_indices) {
+    const std::vector<FaceEdgeIndex>& adjacent_face_edges =
+        adjacent_faces_map.at(face_index);
+    auto it = std::find_if(
+        adjacent_face_edges.begin(), adjacent_face_edges.end(),
+        [&simply_connected_faces_indices](const FaceEdgeIndex& face_edge) {
+          return (simply_connected_faces_indices.count(face_edge.face_index) ==
+                  0);
+        });
+    if (it != adjacent_face_edges.end()) {
+      const int edge_index = std::distance(adjacent_face_edges.begin(), it);
+      return {face_index, edge_index};
+    }
+  }
+  return FaceEdgeIndex();
+}
+
+std::vector<FaceVertexIndex> ComputeMeshFacesContour(
+    const std::set<int>& simply_connected_faces_indices,
+    const FaceAdjacencyMap& adjacent_faces_map) {
+  std::vector<FaceVertexIndex> faces_contour_indices;
+  // Finds first outer edge index for the given simply connected region.
+  const FaceEdgeIndex first_outer_face_edge_index = FindOuterFaceEdgeIndex(
+      simply_connected_faces_indices, adjacent_faces_map);
+  DRAKE_DEMAND(simply_connected_faces_indices.count(
+                   first_outer_face_edge_index.face_index) > 0);
+
+  // Follows simply connected region contour by crawling through
+  // adjacent faces.
+  FaceEdgeIndex outer_face_edge_index = first_outer_face_edge_index;
+  do {
+    const std::vector<FaceEdgeIndex>& adjacent_outer_face_edges =
+        adjacent_faces_map.at(outer_face_edge_index.face_index);
+    const FaceEdgeIndex& other_face_edge_index =
+        adjacent_outer_face_edges[outer_face_edge_index.edge_index];
+    if (simply_connected_faces_indices.count(
+            other_face_edge_index.face_index) == 0) {
+      faces_contour_indices.push_back(
+          {outer_face_edge_index.face_index, outer_face_edge_index.edge_index});
+    } else {
+      outer_face_edge_index = other_face_edge_index;
+    }
+    const int outer_face_edge_count =
+        adjacent_faces_map.at(outer_face_edge_index.face_index).size();
+    outer_face_edge_index.edge_index =
+        (outer_face_edge_index.edge_index + 1) % outer_face_edge_count;
+  } while (outer_face_edge_index != first_outer_face_edge_index);
+  return faces_contour_indices;
+}
+
+const IndexFace::Vertex& MeshFaceVertexAt(
+    const GeoMesh& mesh, const FaceVertexIndex& face_vertex_index) {
+  const std::vector<IndexFace>& faces = mesh.faces();
+  const std::vector<IndexFace::Vertex>& face_vertices =
+      faces.at(face_vertex_index.face_index).vertices();
+  return face_vertices.at(face_vertex_index.vertex_index);
+}
+
+template <typename T>
+using ParametrizedLine3 = Eigen::ParametrizedLine<T, 3>;
+
+std::vector<FaceVertexIndex> SimplifyMeshFacesContour(
+    const GeoMesh& mesh, const std::vector<FaceVertexIndex>& contour_indices,
+    double tolerance) {
+  const int contour_vertex_count = contour_indices.size();
+  if (contour_vertex_count <= 3) return contour_indices;
+  std::vector<FaceVertexIndex> simplified_contour_indices;
+  ApplyDouglasPeuckerSimplification(
+      contour_indices.begin(), contour_indices.end() - 1,
+      [&mesh](const FaceVertexIndex& face_vertex_index) {
+        return GetMeshFaceVertexPosition(
+            mesh, MeshFaceVertexAt(mesh, face_vertex_index));
+      },
+      [](const Vector3<double>& start_vertex,
+         const Vector3<double>& end_vertex) {
+        return ParametrizedLine3<double>{
+            start_vertex, (end_vertex - start_vertex).normalized()};
+      },
+      tolerance, std::back_inserter(simplified_contour_indices));
+  return simplified_contour_indices;
+}
+
+GeoFace MergeMeshFaces(const GeoMesh& mesh,
+                       const std::set<int>& mergeable_faces_indices,
+                       const FaceAdjacencyMap& adjacent_faces_map,
+                       double tolerance) {
+  // Computes mergeable faces contour.
+  const std::vector<FaceVertexIndex> contour_indices = SimplifyMeshFacesContour(
+      mesh,
+      ComputeMeshFacesContour(mergeable_faces_indices, adjacent_faces_map),
+      tolerance);
+  // Builds merged face by collecting all vertices in computed contour.
+  GeoFace merged_face;
+  const std::vector<const GeoVertex*>& vertices = mesh.vertices();
+  const std::vector<const GeoNormal*>& normals = mesh.normals();
+  for (const FaceVertexIndex& face_vertex_index : contour_indices) {
+    const IndexFace::Vertex& face_vertex =
+        MeshFaceVertexAt(mesh, face_vertex_index);
+    merged_face.push_vn(*vertices[face_vertex.vertex_index],
+                        *normals[face_vertex.normal_index]);
+  }
+  return merged_face;
+}
+
+GeoMesh SimplifyMeshFaces(const GeoMesh& input_mesh, double tolerance) {
+  GeoMesh output_mesh;
+  std::set<int> visited_faces_indices;
+  const FaceAdjacencyMap adjacent_faces_map =
+      ComputeFaceAdjacencyMap(input_mesh.faces());
+  const int faces_count = static_cast<int>(input_mesh.faces().size());
+  for (int face_index = 0; face_index < faces_count; ++face_index) {
+    if (visited_faces_indices.count(face_index) > 0) {
+      continue;
+    }
+
+    const std::set<int> mergeable_faces_indices =
+        AggregateAdjacentCoplanarMeshFaces(input_mesh, face_index,
+                                           adjacent_faces_map, tolerance,
+                                           &visited_faces_indices);
+
+    output_mesh.PushFace(MergeMeshFaces(input_mesh, mergeable_faces_indices,
+                                        adjacent_faces_map, tolerance));
+  }
+  return output_mesh;
+}
+
+}  // namespace mesh
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/mesh_simplification.h
+++ b/automotive/maliput/utility/mesh_simplification.h
@@ -1,0 +1,354 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+#include "drake/automotive/maliput/utility/mesh.h"
+#include "drake/common/hash.h"
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace mesh {
+
+/// Index for a directed edge in a GeoMesh.
+struct DirectedEdgeIndex {
+  /// Returns this edge but reversed.
+  DirectedEdgeIndex reverse() const {
+    return {end_vertex_index, start_vertex_index};
+  }
+
+  int start_vertex_index{-1};  ///< Index of start vertex, or -1
+                               ///  to mark index as invalid.
+  int end_vertex_index{-1};  ///< Index of end vertex, or -1 to
+                             ///  mark index as invalid.
+};
+
+
+inline bool operator==(const DirectedEdgeIndex& lhs,
+                       const DirectedEdgeIndex& rhs) {
+  return (lhs.start_vertex_index == rhs.start_vertex_index
+          && lhs.end_vertex_index == rhs.end_vertex_index);
+}
+
+inline bool operator!=(const DirectedEdgeIndex& lhs,
+                       const DirectedEdgeIndex& rhs) {
+  return !(lhs == rhs);
+}
+
+
+/// Implements the @ref hash_append concept.
+template <class HashAlgorithm>
+void hash_append(
+    HashAlgorithm& hasher, const DirectedEdgeIndex& item) noexcept {
+  using drake::hash_append;
+  hash_append(hasher, item.start_vertex_index);
+  hash_append(hasher, item.end_vertex_index);
+}
+
+
+/// Index for a face edge in a GeoMesh.
+struct FaceEdgeIndex {
+  int face_index{-1};  ///< Index of the face the edge belongs to, or
+                       ///  -1 to mark index as invalid.
+  int edge_index{-1};  ///< Index of the edge, corresponding to its
+                       ///  start vertex index in the face vertices
+                       ///  sequence (assumed to be defined in a
+                       ///  counter-clockwise fashion), or -1 to mark
+                       ///  index as invalid.
+};
+
+
+inline bool operator==(const FaceEdgeIndex& lhs, const FaceEdgeIndex& rhs) {
+  return (lhs.face_index == rhs.face_index &&
+          lhs.edge_index == rhs.edge_index);
+}
+
+
+inline bool operator!=(const FaceEdgeIndex& lhs, const FaceEdgeIndex& rhs) {
+  return !(lhs == rhs);
+}
+
+
+/// The inverse of the mapping from face edges indices to their
+/// associated directed edge indices.
+/// @see ComputeInverseFaceEdgeMap
+using InverseFaceEdgeMap =
+    std::unordered_map<DirectedEdgeIndex, FaceEdgeIndex, drake::DefaultHash>;
+
+
+/// Computes the inverse of the mapping from face edges indices to their
+/// associated directed edge indices for the given @p faces collection.
+/// @pre Mapping from directed edges to face edges is 1-to-1. In other
+///      words, any given pair of vertices can be shared by two faces at
+///      most. This implies that the mesh is well-oriented, such that any
+///      adjacent have the common edge in opposite directions.
+/// @warning If any of the preconditions is not met, this function will
+///          abort execution.
+InverseFaceEdgeMap
+ComputeInverseFaceEdgeMap(const std::vector<IndexFace>& faces);
+
+
+/// A mapping from each IndexFace index in a given GeoMesh to each of its
+/// adjacent faces, along with the index of the edge these share.
+/// @see FaceEdgeIndex
+using FaceAdjacencyMap = std::unordered_map<int, std::vector<FaceEdgeIndex>>;
+
+
+/// Computes a mapping from each IndexFace index in @p faces to each of its
+/// adjacent faces, along with the index of the edge these share.
+///
+/// For each face at index `i` in @p faces, a sequence to map each edge `j`
+/// to its adjacent face and edge index is added to the map at `i`. If a given
+/// edge is not adjacent to any face, an invalid face and edge index (both set
+/// to -1, see FaceEdgeIndex) is put in its place.
+/// @pre Any given pair of vertices is shared by two faces at most.
+/// @warning If any of the preconditions is not met, this function will
+///          abort execution.
+FaceAdjacencyMap ComputeFaceAdjacencyMap(const std::vector<IndexFace>& faces);
+
+
+template <typename T>
+using Hyperplane3 = Eigen::Hyperplane<T, 3>;
+
+
+/// Gets global position of the @p vertex in the given @p mesh.
+/// @pre Given @p vertex belongs to the @p mesh.
+/// @warning If any of the preconditions is not met, this function will
+///          abort execution.
+const Vector3<double>& GetMeshFaceVertexPosition(
+    const GeoMesh& mesh, const IndexFace::Vertex& vertex);
+
+
+/// Gets normal vector of the @p vertex in the given @p mesh.
+/// @pre Given @p vertex belongs to the @p mesh.
+/// @warning If any of the preconditions is not met, this function will
+///          abort execution.
+const Vector3<double>& GetMeshFaceVertexNormal(
+    const GeoMesh& mesh, const IndexFace::Vertex& vertex);
+
+
+/// Checks if all the IndexFace::Vertex instances, from @p first to
+/// @p last, in the given @p mesh lie on the provided @p plane by
+/// verifying all of them are within one @p tolerance distance, in
+/// meters, away from it along the line subtended by its normal.
+/// @pre Given @p vertices belong to the @p mesh.
+/// @warning If any of the preconditions is not met, this function
+///          will abort execution.
+/// @tparam InputIt An IndexFace::Vertex container iterator type.
+template <typename InputIt>
+bool DoMeshVerticesLieOnPlane(
+    const GeoMesh& mesh, InputIt first, InputIt last,
+    const Hyperplane3<double>& plane, double tolerance) {
+  return std::all_of(
+      first, last, [&mesh, &plane, tolerance](const IndexFace::Vertex& vertex) {
+        const Vector3<double>& x = GetMeshFaceVertexPosition(mesh, vertex);
+        const Vector3<double>& n = GetMeshFaceVertexNormal(mesh, vertex);
+        const double ctheta = std::abs(plane.normal().dot(n.normalized()));
+        return (ctheta != 0. && plane.absDistance(x) / ctheta < tolerance);
+      });
+}
+
+
+/// Checks if the @p face in the given @p mesh is coplanar with the
+/// given @p plane, by verifying if all @p face vertices are within
+/// one @p tolerance distance, in meters, from it.
+/// @pre Given @p face belongs to the @p mesh.
+/// @warning If any of the preconditions is not met, this function
+///          will abort execution.
+bool IsMeshFaceCoplanarWithPlane(const GeoMesh& mesh,
+                                 const IndexFace& face,
+                                 const Hyperplane3<double>& plane,
+                                 double tolerance);
+
+
+/// Checks if the @p face in the given @p mesh is planar, by verifying
+/// all @p face vertices lie on a plane using the given @p tolerance
+/// (see DoMeshVerticesLieOnPlane()). Said plane, built out of the
+/// first vertex position and normal in the @p face, is returned as
+/// @p plane.
+/// @pre Given @p plane is not nullptr.
+/// @pre Given @p face belongs to the @p mesh.
+/// @pre Given @p face has at least three (3) vertices.
+/// @warning If any of the preconditions is not met, this function
+///          will abort execution.
+bool IsMeshFacePlanar(const GeoMesh& mesh, const IndexFace& face,
+                      double tolerance, Hyperplane3<double>* plane);
+
+
+/// Aggregates all coplanar faces adjacent to the referred face in the @p mesh.
+/// @param mesh Mesh where faces are to be found.
+/// @param start_face_index Index of the face to start aggregation with.
+/// @param adjacent_faces_map Map of adjacent faces associated with the
+///                           given @p mesh.
+/// @param tolerance For coplanarity checks, in meters. See IsMeshFacePlanar()
+///                  and IsMeshFaceCoplanarWithPlane() functions for further
+///                  details.
+/// @param visited_faces_indices The indices of the faces visited so far.
+/// @returns The indices of the adjacent coplanar faces found.
+/// @pre Given @p start_face_index is valid for the given @p mesh.
+/// @pre Given @p tolerance is a positive real number.
+/// @pre Given @p visited_faces_indices collection is not nullptr.
+/// @pre Given @p start_face_index has not been visited yet
+///      (i.e. visited_faces_indices.count(start_face_index) == 0).
+/// @post All adjacent coplanar faces found are marked as visited.
+/// @warning If any of the preconditions is not met, this function
+///          will abort execution.
+std::set<int> AggregateAdjacentCoplanarMeshFaces(
+    const GeoMesh& mesh, int start_face_index,
+    const FaceAdjacencyMap& adjacent_faces_map,
+    double tolerance, std::set<int>* visited_faces_indices);
+
+
+/// Finds the index to the first outer face edge in the given
+/// @p simply_connected_faces_indices.
+/// @param simply_connected_faces_indices Indices of the faces whose
+///                                       outer face edge is to be found.
+/// @param adjacent_faces_map Mapping of adjacent faces for the faces
+///                           referred by @p simply_connected_faces_indices.
+/// @returns The index of first outer face edge found or an invalid index
+///          if it failed to find any due to unmet preconditions.
+/// @pre The union of the all the faces referred by the given
+///      @p simply_connected_faces_indices yields a simply
+///      connected region (i.e. with no holes).
+FaceEdgeIndex
+FindOuterFaceEdgeIndex(const std::set<int>& simply_connected_faces_indices,
+                       const FaceAdjacencyMap& adjacent_faces_map);
+
+
+/// Index of a face vertex in a GeoMesh.
+struct FaceVertexIndex {
+  int face_index{-1};  ///< Index of the face the vertex belongs to, or
+                       ///  -1 to mark index as invalid.
+  int vertex_index{-1};  ///< Index of the face vertex, or -1 to mark index
+                         /// as invalid.
+};
+
+
+/// Computes the contour of the simply connected region that all the faces
+/// referred by the given @p simply_connected_faces_indices yield.
+/// @param simply_connected_faces_indices Indices of the faces whose outer face
+///                                       edge is to be found.
+/// @param adjacent_faces_map Mapping of adjacent faces for the faces referred
+///                           in @p simply_connected_faces_indices.
+/// @returns Face vertices as a counter-clockwise contour.
+/// @pre The union of the all the faces referred by the given
+///      @p simply_connected_faces_indices yield a simply
+///      connected region (i.e. with no holes).
+std::vector<FaceVertexIndex> ComputeMeshFacesContour(
+    const std::set<int>& simply_connected_faces_indices,
+    const FaceAdjacencyMap& adjacent_faces_map);
+
+
+/// Gets the face vertex in the @p mesh referred by the given
+/// @p face_vertex_index.
+/// @pre Given @p face_vertex_index refers to a valid vertex
+///      in the @p mesh.
+/// @warning If any of the preconditions is not met, this function
+///          will abort execution.
+const IndexFace::Vertex& MeshFaceVertexAt(
+    const GeoMesh& mesh, const FaceVertexIndex& face_vertex_index);
+
+
+/// Applies the Douglas-Peucker simplification algorithm [1] over the
+/// given collection of vertices.
+///
+/// - [1] Douglas, D. H., & Peucker, T. K. (1973). Algorithms for the
+///       reduction of the number of points required to represent a
+///       digitized line or its caricature. Cartographica: The
+///       International Journal for Geographic Information and
+///       Geovisualization, 10(2), 112–122.
+/// @param first Iterator to first element of the collection.
+/// @param last Iterator to the last element of the collection.
+/// @param to_vertex A function to retrieve the vertex associated with
+///                  an element of the collection (may be a pass-through).
+/// @param to_edge A function to construct an edge out of a pair of
+///                vertices. Said edge MUST support a .distance() method
+///                taking a vertex as its sole argument.
+/// @param tolerance Simplification tolerance, in distance units.
+/// @param output Output iterator for the simplification result.
+/// @tparam InputIt Input iterators type.
+/// @tparam VertexFn Vertex getter function type.
+/// @tparam EdgeFn Edge building function type.
+/// @tparam OutputIt  Output iterator type.
+template <typename InputIt, typename VertexFn,
+          typename EdgeFn, typename OutputIt>
+void ApplyDouglasPeuckerSimplification(InputIt first, InputIt last,
+                                       VertexFn to_vertex, EdgeFn to_edge,
+                                       double tolerance, OutputIt output) {
+  if (first == last) {
+    *output++ = *last;
+    return;
+  }
+
+  const auto edge = to_edge(to_vertex(*first), to_vertex(*last));
+  auto farthest = std::max_element(
+      first, last, [&edge, &to_vertex](const auto& lhs, const auto& rhs) {
+        return (edge.distance(to_vertex(lhs)) < edge.distance(to_vertex(rhs)));
+      });
+  if (edge.distance(to_vertex(*farthest)) > tolerance) {
+    ApplyDouglasPeuckerSimplification(first, farthest, to_vertex,
+                                      to_edge, tolerance, output);
+    ApplyDouglasPeuckerSimplification(farthest + 1, last, to_vertex,
+                                      to_edge, tolerance, output);
+  } else {
+    *output++ = *first;
+    *output++ = *last;
+  }
+}
+
+
+/// Simplifies the @p mesh faces' contour referred by the given
+/// @p contour_indices by elimination of redundant vertices, i.e.
+/// vertices that lie within one @p tolerance distance, in meters,
+/// from the line that the their following and preceding vertices
+/// subtend.
+std::vector<FaceVertexIndex> SimplifyMeshFacesContour(
+    const GeoMesh& mesh,
+    const std::vector<FaceVertexIndex>& contour_indices,
+    double tolerance);
+
+
+/// Merges all the faces in the given @p mesh referred by
+/// @p mergeable_faces_indices into a single GeoFace.
+/// @param mesh Mesh the faces to be merged belong to.
+/// @param mergeable_faces_indices Indices of the faces in
+///                                @p mesh to be merged.
+/// @param adjacent_faces_map Mapping of adjacent faces for the faces
+///                           referred in @p mergeable_faces_indices.
+/// @param tolerance For contour simplification, in meters. See
+///                  SimplifyMeshFacesContour() function for further
+///                  details.
+/// @returns Merged mesh faces as a single GeoFace.
+/// @pre The union of the all the faces referred by the given
+///      @p mergeable_faces_indices yields a simply connected
+///      region (i.e. with no holes).
+GeoFace MergeMeshFaces(const GeoMesh& mesh,
+                       const std::set<int>& mergeable_faces_indices,
+                       const FaceAdjacencyMap& adjacent_faces_map,
+                       double tolerance);
+
+
+/// Simplifies a mesh by merging adjacent coplanar faces.
+/// @param input_mesh Mesh to be simplified.
+/// @param tolerance Tolerance for simplification, in meters. See
+///                  MergeMeshFaces() and AggregateAdjacentCoplanarMeshFaces()
+///                  functions for further details.
+/// @returns Output, simplified mesh.
+/// @pre The union of the all the faces in the given @p input_mesh
+///      yields a simply connected region (i.e. with no holes).
+GeoMesh SimplifyMeshFaces(const GeoMesh& input_mesh, double tolerance);
+
+
+}  // namespace mesh
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/test/mesh_simplification_test.cc
+++ b/automotive/maliput/utility/test/mesh_simplification_test.cc
@@ -1,0 +1,470 @@
+#include "drake/automotive/maliput/utility/mesh_simplification.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace maliput {
+namespace utility {
+namespace mesh {
+namespace {
+
+// Tests equality and inequality operator overloads
+// for DirectedEdgeIndex instances.
+GTEST_TEST(DirectedEdgeIndexTest, Equality) {
+  const DirectedEdgeIndex edge{0, 10};
+  const DirectedEdgeIndex same_end_edge{4, 10};
+  const DirectedEdgeIndex same_start_edge{0, 4};
+  const DirectedEdgeIndex reversed_edge{10, 0};
+
+  EXPECT_EQ(edge, edge);
+  EXPECT_NE(edge, same_end_edge);
+  EXPECT_NE(edge, same_start_edge);
+  EXPECT_NE(edge, reversed_edge);
+}
+
+
+// Tests equality and inequality operator overloads
+// for FaceEdgeIndex instances.
+GTEST_TEST(FaceEdgeIndexTest, Equality) {
+  const FaceEdgeIndex edge{0, 10};
+  const FaceEdgeIndex equivalent_edge{0, 10};
+  const FaceEdgeIndex edge_on_another_face{3, 10};
+  const FaceEdgeIndex other_edge_on_same_face{0, 5};
+
+  EXPECT_EQ(edge, edge);
+  EXPECT_EQ(edge, equivalent_edge);
+  EXPECT_NE(edge, edge_on_another_face);
+  EXPECT_NE(edge, other_edge_on_same_face);
+}
+
+// Fixture for mesh simplification tests.
+//
+// The mesh under test is depicted below:
+//
+// <pre>
+//
+//  I(0,2,1) ô---------------ǒ H(2,2,-1)
+//           |               |
+//           |               |
+//           |   C(1,1,0)    | F(2,1,0)
+//  D(0,1,0) o-------o-------o-------ô
+//           |       |       |     /  G(3,1,1)
+//           |       |       |   /
+//           |       |       | /           y ^   ⊙ z
+//  A(0,0,0) o-------o-------o E(2,0,0)      |
+//               B(1,0,0)                    +--->
+//                                               x
+// </pre>
+//
+// Notation being used is as follows:
+// - 'o' refers to a vertex on the z = 0 plane,
+// - 'ô' refers to a vertex on the z = 1 plane,
+// - 'ǒ' refers to a vertex on the z = -1 plane,
+// - '-', '|' and '/' refer to edges.
+class GeoMeshSimplificationTest : public ::testing::Test {
+ protected:
+  // Default constructor, initializing the mesh and its
+  // simplified counterpart (simplified by merging coplanar faces
+  // and removing redundant vertices).
+  GeoMeshSimplificationTest() {
+    const GeoNormal kNormal(api::GeoPosition::FromXyz(kNormalVector));
+    const GeoVertex kVertexA(api::GeoPosition::FromXyz(kVertexAPosition));
+    const GeoVertex kVertexB(api::GeoPosition::FromXyz(kVertexBPosition));
+    const GeoVertex kVertexC(api::GeoPosition::FromXyz(kVertexCPosition));
+    const GeoVertex kVertexD(api::GeoPosition::FromXyz(kVertexDPosition));
+    const GeoVertex kVertexE(api::GeoPosition::FromXyz(kVertexEPosition));
+    const GeoVertex kVertexF(api::GeoPosition::FromXyz(kVertexFPosition));
+    const GeoVertex kVertexG(api::GeoPosition::FromXyz(kVertexGPosition));
+    const GeoVertex kVertexH(api::GeoPosition::FromXyz(kVertexHPosition));
+    const GeoVertex kVertexI(api::GeoPosition::FromXyz(kVertexIPosition));
+
+    GeoFace first_quad_face;
+    first_quad_face.push_vn(kVertexA, kNormal);
+    first_quad_face.push_vn(kVertexB, kNormal);
+    first_quad_face.push_vn(kVertexC, kNormal);
+    first_quad_face.push_vn(kVertexD, kNormal);
+    mesh_.PushFace(first_quad_face);
+    GeoFace second_quad_face;
+    second_quad_face.push_vn(kVertexC, kNormal);
+    second_quad_face.push_vn(kVertexB, kNormal);
+    second_quad_face.push_vn(kVertexE, kNormal);
+    second_quad_face.push_vn(kVertexF, kNormal);
+    mesh_.PushFace(second_quad_face);
+    GeoFace triangle_face;
+    triangle_face.push_vn(kVertexF, kNormal);
+    triangle_face.push_vn(kVertexE, kNormal);
+    triangle_face.push_vn(kVertexG, kNormal);
+    mesh_.PushFace(triangle_face);
+    GeoFace third_quad_face;
+    third_quad_face.push_vn(kVertexD, kNormal);
+    third_quad_face.push_vn(kVertexC, kNormal);
+    third_quad_face.push_vn(kVertexF, kNormal);
+    third_quad_face.push_vn(kVertexH, kNormal);
+    third_quad_face.push_vn(kVertexI, kNormal);
+    mesh_.PushFace(third_quad_face);
+    GeoFace first_plus_second_quad_face;
+    first_plus_second_quad_face.push_vn(kVertexA, kNormal);
+    first_plus_second_quad_face.push_vn(kVertexE, kNormal);
+    first_plus_second_quad_face.push_vn(kVertexF, kNormal);
+    first_plus_second_quad_face.push_vn(kVertexD, kNormal);
+    GeoFace simple_third_quad_face;
+    simple_third_quad_face.push_vn(kVertexD, kNormal);
+    simple_third_quad_face.push_vn(kVertexF, kNormal);
+    simple_third_quad_face.push_vn(kVertexH, kNormal);
+    simple_third_quad_face.push_vn(kVertexI, kNormal);
+    simplified_mesh_.PushFace(first_plus_second_quad_face);
+    simplified_mesh_.PushFace(triangle_face);
+    simplified_mesh_.PushFace(simple_third_quad_face);
+  }
+
+  const GeoMesh& mesh() const { return mesh_; }
+
+  const std::vector<IndexFace>& faces() const { return mesh_.faces(); }
+
+  const GeoMesh& simplified_mesh() const { return simplified_mesh_; }
+
+  const int kNormalIndex{0};
+  const int kVertexAIndex{0};
+  const int kVertexBIndex{1};
+  const int kVertexCIndex{2};
+  const int kVertexDIndex{3};
+  const int kVertexEIndex{4};
+  const int kVertexFIndex{5};
+  const int kVertexGIndex{6};
+  const int kVertexHIndex{7};
+  const int kVertexIIndex{8};
+
+  const Vector3<double> kNormalVector{0., 0., 1.};
+  const Vector3<double> kVertexAPosition{0., 0., 0.};
+  const Vector3<double> kVertexBPosition{1., 0., 0.};
+  const Vector3<double> kVertexCPosition{1., 1., 0.};
+  const Vector3<double> kVertexDPosition{0., 1., 0.};
+  const Vector3<double> kVertexEPosition{2., 0., 0.};
+  const Vector3<double> kVertexFPosition{2., 1., 0.};
+  const Vector3<double> kVertexGPosition{3., 1., 1.};
+  const Vector3<double> kVertexHPosition{2., 2., -1.};
+  const Vector3<double> kVertexIPosition{0., 2., 1.};
+
+  const int kFirstQuadIndex{0};
+  const int kSecondQuadIndex{1};
+  const int kTriangleIndex{2};
+  const int kThirdQuadIndex{3};
+
+  const FaceEdgeIndex kFirstQuadAEdge{kFirstQuadIndex, 0};
+  const FaceEdgeIndex kFirstQuadBEdge{kFirstQuadIndex, 1};
+  const FaceEdgeIndex kFirstQuadCEdge{kFirstQuadIndex, 2};
+  const FaceEdgeIndex kFirstQuadDEdge{kFirstQuadIndex, 3};
+  const FaceEdgeIndex kSecondQuadCEdge{kSecondQuadIndex, 0};
+  const FaceEdgeIndex kSecondQuadBEdge{kSecondQuadIndex, 1};
+  const FaceEdgeIndex kSecondQuadEEdge{kSecondQuadIndex, 2};
+  const FaceEdgeIndex kSecondQuadFEdge{kSecondQuadIndex, 3};
+  const FaceEdgeIndex kTriangleFEdge{kTriangleIndex, 0};
+  const FaceEdgeIndex kTriangleEEdge{kTriangleIndex, 1};
+  const FaceEdgeIndex kTriangleGEdge{kTriangleIndex, 2};
+  const FaceEdgeIndex kThirdQuadDEdge{kThirdQuadIndex, 0};
+  const FaceEdgeIndex kThirdQuadCEdge{kThirdQuadIndex, 1};
+  const FaceEdgeIndex kThirdQuadFEdge{kThirdQuadIndex, 2};
+  const FaceEdgeIndex kThirdQuadHEdge{kThirdQuadIndex, 3};
+  const FaceEdgeIndex kThirdQuadIEdge{kThirdQuadIndex, 4};
+  const FaceEdgeIndex kNoEdge{-1, -1};
+
+  const DirectedEdgeIndex kABEdge{kVertexAIndex, kVertexBIndex};
+  const DirectedEdgeIndex kBCEdge{kVertexBIndex, kVertexCIndex};
+  const DirectedEdgeIndex kCBEdge{kVertexCIndex, kVertexBIndex};
+  const DirectedEdgeIndex kCDEdge{kVertexCIndex, kVertexDIndex};
+  const DirectedEdgeIndex kDCEdge{kVertexDIndex, kVertexCIndex};
+  const DirectedEdgeIndex kDAEdge{kVertexDIndex, kVertexAIndex};
+  const DirectedEdgeIndex kBEEdge{kVertexBIndex, kVertexEIndex};
+  const DirectedEdgeIndex kEFEdge{kVertexEIndex, kVertexFIndex};
+  const DirectedEdgeIndex kFEEdge{kVertexFIndex, kVertexEIndex};
+  const DirectedEdgeIndex kFCEdge{kVertexFIndex, kVertexCIndex};
+  const DirectedEdgeIndex kCFEdge{kVertexCIndex, kVertexFIndex};
+  const DirectedEdgeIndex kEGEdge{kVertexEIndex, kVertexGIndex};
+  const DirectedEdgeIndex kGFEdge{kVertexGIndex, kVertexFIndex};
+  const DirectedEdgeIndex kFHEdge{kVertexFIndex, kVertexHIndex};
+  const DirectedEdgeIndex kHIEdge{kVertexHIndex, kVertexIIndex};
+  const DirectedEdgeIndex kIDEdge{kVertexIIndex, kVertexDIndex};
+
+  const double kAlmostExact{1e-12};
+
+ private:
+  GeoMesh mesh_;
+  GeoMesh simplified_mesh_;
+};
+
+
+TEST_F(GeoMeshSimplificationTest, InverseFaceEdgeMapComputation) {
+  InverseFaceEdgeMap map = ComputeInverseFaceEdgeMap(faces());
+
+  // Tests first quad edges.
+  EXPECT_EQ(map.count(kABEdge), 1);
+  EXPECT_EQ(map.at(kABEdge), kFirstQuadAEdge);
+  map.erase(kABEdge);
+
+  EXPECT_EQ(map.count(kBCEdge), 1);
+  EXPECT_EQ(map.at(kBCEdge), kFirstQuadBEdge);
+  map.erase(kBCEdge);
+
+  EXPECT_EQ(map.count(kCDEdge), 1);
+  EXPECT_EQ(map.at(kCDEdge), kFirstQuadCEdge);
+  map.erase(kCDEdge);
+
+  EXPECT_EQ(map.count(kDAEdge), 1);
+  EXPECT_EQ(map.at(kDAEdge), kFirstQuadDEdge);
+  map.erase(kDAEdge);
+
+  // Tests second quad edges.
+  EXPECT_EQ(map.count(kCBEdge), 1);
+  EXPECT_EQ(map.at(kCBEdge), kSecondQuadCEdge);
+  map.erase(kCBEdge);
+
+  EXPECT_EQ(map.count(kBEEdge), 1);
+  EXPECT_EQ(map.at(kBEEdge), kSecondQuadBEdge);
+  map.erase(kBEEdge);
+
+  EXPECT_EQ(map.count(kEFEdge), 1);
+  EXPECT_EQ(map.at(kEFEdge), kSecondQuadEEdge);
+  map.erase(kEFEdge);
+
+  EXPECT_EQ(map.count(kFCEdge), 1);
+  EXPECT_EQ(map.at(kFCEdge), kSecondQuadFEdge);
+  map.erase(kFCEdge);
+
+  // Tests triangle edges.
+  EXPECT_EQ(map.count(kFEEdge), 1);
+  EXPECT_EQ(map.at(kFEEdge), kTriangleFEdge);
+  map.erase(kFEEdge);
+
+  EXPECT_EQ(map.count(kEGEdge), 1);
+  EXPECT_EQ(map.at(kEGEdge), kTriangleEEdge);
+  map.erase(kEGEdge);
+
+  EXPECT_EQ(map.count(kGFEdge), 1);
+  EXPECT_EQ(map.at(kGFEdge), kTriangleGEdge);
+  map.erase(kGFEdge);
+
+  // Tests third quad edges.
+  EXPECT_EQ(map.count(kDCEdge), 1);
+  EXPECT_EQ(map.at(kDCEdge), kThirdQuadDEdge);
+  map.erase(kDCEdge);
+
+  EXPECT_EQ(map.count(kCFEdge), 1);
+  EXPECT_EQ(map.at(kCFEdge), kThirdQuadCEdge);
+  map.erase(kCFEdge);
+
+  EXPECT_EQ(map.count(kFHEdge), 1);
+  EXPECT_EQ(map.at(kFHEdge), kThirdQuadFEdge);
+  map.erase(kFHEdge);
+
+  EXPECT_EQ(map.count(kHIEdge), 1);
+  EXPECT_EQ(map.at(kHIEdge), kThirdQuadHEdge);
+  map.erase(kHIEdge);
+
+  EXPECT_EQ(map.count(kIDEdge), 1);
+  EXPECT_EQ(map.at(kIDEdge), kThirdQuadIEdge);
+  map.erase(kIDEdge);
+
+  EXPECT_TRUE(map.empty());
+}
+
+
+TEST_F(GeoMeshSimplificationTest, FaceAdjacencyMapComputation) {
+  const FaceAdjacencyMap map = ComputeFaceAdjacencyMap(faces());
+
+  EXPECT_EQ(map.count(kFirstQuadIndex), 1);
+  {
+    const std::vector<FaceEdgeIndex>& face_edges = map.at(kFirstQuadIndex);
+    EXPECT_EQ(face_edges[kFirstQuadAEdge.edge_index], kNoEdge);
+    EXPECT_EQ(face_edges[kFirstQuadBEdge.edge_index], kSecondQuadCEdge);
+    EXPECT_EQ(face_edges[kFirstQuadCEdge.edge_index], kThirdQuadDEdge);
+    EXPECT_EQ(face_edges[kFirstQuadDEdge.edge_index], kNoEdge);
+  }
+
+  EXPECT_EQ(map.count(kSecondQuadIndex), 1);
+  {
+    const std::vector<FaceEdgeIndex>& face_edges = map.at(kSecondQuadIndex);
+    EXPECT_EQ(face_edges[kSecondQuadCEdge.edge_index], kFirstQuadBEdge);
+    EXPECT_EQ(face_edges[kSecondQuadBEdge.edge_index], kNoEdge);
+    EXPECT_EQ(face_edges[kSecondQuadEEdge.edge_index], kTriangleFEdge);
+    EXPECT_EQ(face_edges[kSecondQuadFEdge.edge_index], kThirdQuadCEdge);
+  }
+
+  EXPECT_EQ(map.count(kTriangleIndex), 1);
+  {
+    const std::vector<FaceEdgeIndex>& face_edges = map.at(kTriangleIndex);
+    EXPECT_EQ(face_edges[kTriangleFEdge.edge_index], kSecondQuadEEdge);
+    EXPECT_EQ(face_edges[kTriangleEEdge.edge_index], kNoEdge);
+    EXPECT_EQ(face_edges[kTriangleGEdge.edge_index], kNoEdge);
+  }
+
+  EXPECT_EQ(map.count(kThirdQuadIndex), 1);
+  {
+    const std::vector<FaceEdgeIndex>& face_edges = map.at(kThirdQuadIndex);
+    EXPECT_EQ(face_edges[kThirdQuadDEdge.edge_index], kFirstQuadCEdge);
+    EXPECT_EQ(face_edges[kThirdQuadCEdge.edge_index], kSecondQuadFEdge);
+    EXPECT_EQ(face_edges[kThirdQuadFEdge.edge_index], kNoEdge);
+    EXPECT_EQ(face_edges[kThirdQuadHEdge.edge_index], kNoEdge);
+    EXPECT_EQ(face_edges[kThirdQuadIEdge.edge_index], kNoEdge);
+  }
+}
+
+
+TEST_F(GeoMeshSimplificationTest, FaceVertexPosition) {
+  const IndexFace& first_quad = faces()[kFirstQuadIndex];
+  EXPECT_EQ(GetMeshFaceVertexPosition(
+      mesh(), first_quad.vertices()[0]), kVertexAPosition);
+  const IndexFace& second_quad = faces()[kSecondQuadIndex];
+  EXPECT_EQ(GetMeshFaceVertexPosition(
+      mesh(), second_quad.vertices()[0]), kVertexCPosition);
+  const IndexFace& triangle = faces()[kTriangleIndex];
+  EXPECT_EQ(GetMeshFaceVertexPosition(
+      mesh(), triangle.vertices()[0]), kVertexFPosition);
+}
+
+
+TEST_F(GeoMeshSimplificationTest, FaceVertexNormal) {
+  const IndexFace& first_quad = faces()[kFirstQuadIndex];
+  EXPECT_EQ(GetMeshFaceVertexNormal(
+      mesh(), first_quad.vertices()[0]), kNormalVector);
+  const IndexFace& second_quad = faces()[kSecondQuadIndex];
+  EXPECT_EQ(GetMeshFaceVertexNormal(
+      mesh(), second_quad.vertices()[0]), kNormalVector);
+  const IndexFace& triangle = faces()[kTriangleIndex];
+  EXPECT_EQ(GetMeshFaceVertexNormal(
+      mesh(), triangle.vertices()[0]), kNormalVector);
+}
+
+
+TEST_F(GeoMeshSimplificationTest, VerticesOnPlane) {
+  const Hyperplane3<double> planeA(kNormalVector, kVertexAPosition);
+
+  const std::vector<IndexFace::Vertex>&
+      first_quad_vertices = faces()[kFirstQuadIndex].vertices();
+  EXPECT_TRUE(DoMeshVerticesLieOnPlane(mesh(), first_quad_vertices.begin(),
+                                       first_quad_vertices.end(), planeA,
+                                       kAlmostExact));
+
+  const std::vector<IndexFace::Vertex>&
+      second_quad_vertices = faces()[kSecondQuadIndex].vertices();
+  EXPECT_TRUE(DoMeshVerticesLieOnPlane(mesh(), second_quad_vertices.begin(),
+                                       second_quad_vertices.end(), planeA,
+                                       kAlmostExact));
+
+  const std::vector<IndexFace::Vertex>&
+      triangle_vertices = faces()[kTriangleIndex].vertices();
+  EXPECT_FALSE(DoMeshVerticesLieOnPlane(mesh(), triangle_vertices.begin(),
+                                        triangle_vertices.end(), planeA,
+                                        kAlmostExact));
+}
+
+
+TEST_F(GeoMeshSimplificationTest, CoplanarFaces) {
+  const Hyperplane3<double> planeA(kNormalVector, kVertexAPosition);
+  EXPECT_TRUE(IsMeshFaceCoplanarWithPlane(mesh(), faces()[kFirstQuadIndex],
+                                          planeA, kAlmostExact));
+  EXPECT_TRUE(IsMeshFaceCoplanarWithPlane(mesh(), faces()[kSecondQuadIndex],
+                                          planeA, kAlmostExact));
+  EXPECT_FALSE(IsMeshFaceCoplanarWithPlane(mesh(), faces()[kTriangleIndex],
+                                           planeA, kAlmostExact));
+  EXPECT_FALSE(IsMeshFaceCoplanarWithPlane(mesh(), faces()[kThirdQuadIndex],
+                                           planeA, kAlmostExact));
+}
+
+
+TEST_F(GeoMeshSimplificationTest, PlanarFaces) {
+  Hyperplane3<double> plane;
+  EXPECT_TRUE(IsMeshFacePlanar(
+      mesh(), faces()[kFirstQuadIndex], kAlmostExact, &plane));
+  EXPECT_NEAR(plane.absDistance(kVertexCPosition), 0., kAlmostExact);
+  EXPECT_FALSE(IsMeshFacePlanar(
+      mesh(), faces()[kThirdQuadIndex], kAlmostExact, &plane));
+  // Triangle face would be planar BUT its specified normal does not
+  // match that of the plane its vertices define.
+  EXPECT_FALSE(IsMeshFacePlanar(
+      mesh(), faces()[kTriangleIndex], kAlmostExact, &plane));
+}
+
+
+TEST_F(GeoMeshSimplificationTest, FaceMerging) {
+  const FaceAdjacencyMap adjacency_map =
+      ComputeFaceAdjacencyMap(faces());
+  std::set<int> visited_faces;
+  const std::set<int> merged_faces =
+      AggregateAdjacentCoplanarMeshFaces(mesh(), kFirstQuadIndex,
+                                         adjacency_map, kAlmostExact,
+                                         &visited_faces);
+  EXPECT_EQ(merged_faces.count(kFirstQuadIndex), 1);
+  EXPECT_EQ(merged_faces.count(kSecondQuadIndex), 1);
+  EXPECT_EQ(merged_faces.count(kThirdQuadIndex), 0);
+  EXPECT_EQ(merged_faces.count(kTriangleIndex), 0);
+
+  // In what follows, the test relies heavily on the fact that
+  // std::set keys are integers and that this container uses
+  // std::less as ordering criterion by default.
+  const FaceEdgeIndex outer_edge =
+      FindOuterFaceEdgeIndex(merged_faces, adjacency_map);
+  EXPECT_EQ(outer_edge, kFirstQuadAEdge);
+
+  const std::vector<FaceVertexIndex> merged_face_contour =
+      ComputeMeshFacesContour(merged_faces, adjacency_map);
+  ASSERT_EQ(merged_face_contour.size(), 6);
+  EXPECT_EQ(merged_face_contour[0].face_index, kFirstQuadIndex);
+  EXPECT_EQ(merged_face_contour[0].vertex_index, 0);
+  EXPECT_EQ(merged_face_contour[1].face_index, kSecondQuadIndex);
+  EXPECT_EQ(merged_face_contour[1].vertex_index, 1);
+  EXPECT_EQ(merged_face_contour[2].face_index, kSecondQuadIndex);
+  EXPECT_EQ(merged_face_contour[2].vertex_index, 2);
+  EXPECT_EQ(merged_face_contour[3].face_index, kSecondQuadIndex);
+  EXPECT_EQ(merged_face_contour[3].vertex_index, 3);
+  EXPECT_EQ(merged_face_contour[4].face_index, kFirstQuadIndex);
+  EXPECT_EQ(merged_face_contour[4].vertex_index, 2);
+  EXPECT_EQ(merged_face_contour[5].face_index, kFirstQuadIndex);
+  EXPECT_EQ(merged_face_contour[5].vertex_index, 3);
+
+  const std::vector<FaceVertexIndex> simplified_contour =
+      SimplifyMeshFacesContour(mesh(), merged_face_contour, kAlmostExact);
+  ASSERT_EQ(simplified_contour.size(), 4);
+  EXPECT_EQ(simplified_contour[0].face_index, kFirstQuadIndex);
+  EXPECT_EQ(simplified_contour[0].vertex_index, 0);
+  EXPECT_EQ(simplified_contour[1].face_index, kSecondQuadIndex);
+  EXPECT_EQ(simplified_contour[1].vertex_index, 2);
+  EXPECT_EQ(simplified_contour[2].face_index, kSecondQuadIndex);
+  EXPECT_EQ(simplified_contour[2].vertex_index, 3);
+  EXPECT_EQ(simplified_contour[3].face_index, kFirstQuadIndex);
+  EXPECT_EQ(simplified_contour[3].vertex_index, 3);
+
+  const GeoFace merged_face = MergeMeshFaces(
+      mesh(), merged_faces, adjacency_map, kAlmostExact);
+  EXPECT_EQ(merged_face.vertices()[0].v().xyz(), kVertexAPosition);
+  EXPECT_EQ(merged_face.normals()[0].n().xyz(), kNormalVector);
+  EXPECT_EQ(merged_face.vertices()[1].v().xyz(), kVertexEPosition);
+  EXPECT_EQ(merged_face.normals()[1].n().xyz(), kNormalVector);
+  EXPECT_EQ(merged_face.vertices()[2].v().xyz(), kVertexFPosition);
+  EXPECT_EQ(merged_face.normals()[2].n().xyz(), kNormalVector);
+  EXPECT_EQ(merged_face.vertices()[3].v().xyz(), kVertexDPosition);
+  EXPECT_EQ(merged_face.normals()[3].n().xyz(), kNormalVector);
+}
+
+
+TEST_F(GeoMeshSimplificationTest, MeshSimplification) {
+  const std::string kDummyMaterial{"stone"};
+  const int kPrecision{3};
+  const api::GeoPosition kOrigin(1., 2., 3.);
+  const int kZeroVertexIndexOffset{2};
+  const int kZeroNormalIndexOffset{0};
+  std::stringstream simplified_mesh_obj;
+  SimplifyMeshFaces(mesh(), kAlmostExact).EmitObj(
+      simplified_mesh_obj, kDummyMaterial, kPrecision, kOrigin,
+      kZeroVertexIndexOffset, kZeroNormalIndexOffset);
+  std::stringstream reference_mesh_obj;
+  simplified_mesh().EmitObj(
+      reference_mesh_obj, kDummyMaterial, kPrecision, kOrigin,
+      kZeroVertexIndexOffset, kZeroNormalIndexOffset);
+  EXPECT_EQ(simplified_mesh_obj.str(), reference_mesh_obj.str());
+}
+
+}  // namespace
+}  // namespace mesh
+}  // namespace utility
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/utility/yaml_to_obj.cc
+++ b/automotive/maliput/utility/yaml_to_obj.cc
@@ -30,6 +30,11 @@ DEFINE_double(min_grid_resolution,
 DEFINE_bool(draw_elevation_bounds,
             drake::maliput::utility::ObjFeatures().draw_elevation_bounds,
             "Whether to draw the elevation bounds");
+DEFINE_double(simplify_mesh_threshold,
+              drake::maliput::utility::ObjFeatures().simplify_mesh_threshold,
+              "Optional tolerance for mesh simplification, in meters. Make it "
+              "equal to the road linear tolerance to get a mesh size reduction "
+              "while keeping geometrical fidelity.");
 
 namespace drake {
 namespace maliput {
@@ -99,7 +104,7 @@ int main(int argc, char* argv[]) {
   features.max_grid_unit = FLAGS_max_grid_unit;
   features.min_grid_resolution = FLAGS_min_grid_resolution;
   features.draw_elevation_bounds = FLAGS_draw_elevation_bounds;
-
+  features.simplify_mesh_threshold = FLAGS_simplify_mesh_threshold;
   drake::log()->info("Generating OBJ.");
   GenerateObjFile(rg.get(), FLAGS_obj_dir, FLAGS_obj_file, features);
 


### PR DESCRIPTION
When working with the generated meshes for road networks it came to our attention that in some cases they had more quads that what seemed required. To solve this issue this PR tweaks the `generate_obj` functions to produce equivalent meshes but with fewer quads. Some concrete cases we checked are:

- Dragways are the ones that get the biggest benefit, as the entire asphalt can be represented by a single quad (e.g. in a 100mt dragway with stripes, arrows, etc quads drop from 3.2K to 7 and vertices from 7.3K to 40).
- The onramp example shows ~10x improvement in mesh size (quads went from 15K to 1.1K and vertices from 18.5k to 4.4k).
- A sample multilane [circuit file](https://github.com/RobotLocomotion/drake/blob/master/automotive/maliput/multilane/circuit.yaml) that includes elevation and superelevation shows ~6x improvement in mesh size (quads went from 25K to 4.2K and vertices from 175K to 50k).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9234)
<!-- Reviewable:end -->
