### PR TITLE
Fix tolerance usage in Mutilane Endpoints' comparisons

### DIFF
--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -29,16 +29,20 @@ using Which = api::LaneEnd::Which;
 // StartReference::Spec using an Endpoint.
 GTEST_TEST(StartReferenceSpecTest, Endpoint) {
   const Endpoint point{{1., 2., 3.}, {4., 5., 6., 7.}};
-  const double kVeryExact{1e-15};
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
 
   const StartReference::Spec forward_dut =
       StartReference().at(point, Direction::kForward);
-  EXPECT_TRUE(test::IsEndpointClose(forward_dut.endpoint(), point, kVeryExact));
+  EXPECT_TRUE(test::IsEndpointClose(forward_dut.endpoint(), point,
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 
   const StartReference::Spec reversed_dut =
       StartReference().at(point, Direction::kReverse);
   EXPECT_TRUE(test::IsEndpointClose(reversed_dut.endpoint(), point.reverse(),
-                                    kVeryExact));
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 }
 
 // StartReference::Spec using a connection's reference curve.
@@ -56,7 +60,8 @@ GTEST_TEST(StartReferenceSpecTest, Connection) {
   const Connection conn("conn", kStartEndpoint, kFlatZ, 2, 0., 1., 1.5, 1.5,
                         kLineOffset, kLinearTolerance, kScaleLength,
                         kComputationPolicy);
-  const double kVeryExact{1e-15};
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
 
   const StartReference::Spec forward_start_dut =
       StartReference().at(conn, Which::kStart, Direction::kForward);
@@ -64,7 +69,8 @@ GTEST_TEST(StartReferenceSpecTest, Connection) {
                                                  kFlatZWithoutThetaDot};
   EXPECT_TRUE(test::IsEndpointClose(forward_start_dut.endpoint(),
                                     expected_forward_start_endpoint,
-                                    kVeryExact));
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 
   const StartReference::Spec reversed_start_dut =
       StartReference().at(conn, Which::kStart, Direction::kReverse);
@@ -72,36 +78,44 @@ GTEST_TEST(StartReferenceSpecTest, Connection) {
       kStartXy.reverse(), kFlatZWithoutThetaDot.reverse()};
   EXPECT_TRUE(test::IsEndpointClose(reversed_start_dut.endpoint(),
                                     expected_reversed_start_endpoint,
-                                    kVeryExact));
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 
   const StartReference::Spec forward_end_dut =
       StartReference().at(conn, Which::kFinish, Direction::kForward);
   const Endpoint expected_forward_end_endpoint{kEndXy, kFlatZWithoutThetaDot};
   EXPECT_TRUE(test::IsEndpointClose(forward_end_dut.endpoint(),
-                                    expected_forward_end_endpoint, kVeryExact));
+                                    expected_forward_end_endpoint,
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 
   const StartReference::Spec reversed_end_dut =
       StartReference().at(conn, Which::kFinish, Direction::kReverse);
   const Endpoint expected_reversed_end_endpoint{
       kEndXy.reverse(), kFlatZWithoutThetaDot.reverse()};
-  EXPECT_TRUE(test::IsEndpointClose(
-      reversed_end_dut.endpoint(), expected_reversed_end_endpoint, kVeryExact));
+  EXPECT_TRUE(test::IsEndpointClose(reversed_end_dut.endpoint(),
+                                    expected_reversed_end_endpoint,
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
 }
 
 // EndReference::Spec using an EndpointZ.
 GTEST_TEST(EndReferenceSpecTest, Endpoint) {
   const EndpointZ z_point{4., 5., 6., 7.};
-  const double kVeryExact{1e-15};
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
 
   const EndReference::Spec z_forward_dut =
       EndReference().z_at(z_point, Direction::kForward);
-  EXPECT_TRUE(
-      test::IsEndpointZClose(z_forward_dut.endpoint_z(), z_point, kVeryExact));
+  EXPECT_TRUE(test::IsEndpointZClose(
+      z_forward_dut.endpoint_z(), z_point,
+      kEndpointLinearTolerance, kEndpointAngularTolerance));
 
   const EndReference::Spec z_reversed_dut =
       EndReference().z_at(z_point, Direction::kReverse);
-  EXPECT_TRUE(test::IsEndpointZClose(z_reversed_dut.endpoint_z(),
-                                     z_point.reverse(), kVeryExact));
+  EXPECT_TRUE(test::IsEndpointZClose(
+      z_reversed_dut.endpoint_z(), z_point.reverse(),
+      kEndpointLinearTolerance, kEndpointAngularTolerance));
 }
 
 // EndReference::Spec using a connection's reference curve.
@@ -117,30 +131,37 @@ GTEST_TEST(EndReferenceSpecTest, Connection) {
   const Connection conn("conn", kStartEndpoint, kFlatZ, 2, 0., 1., 1.5, 1.5,
                         LineOffset(10.), kLinearTolerance, kScaleLength,
                         kComputationPolicy);
-  const double kVeryExact{1e-15};
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
 
   const EndReference::Spec forward_start_dut =
       EndReference().z_at(conn, Which::kStart, Direction::kForward);
   const EndpointZ expected_forward_start_endpoint{kFlatZWithoutThetaDot};
   EXPECT_TRUE(test::IsEndpointZClose(forward_start_dut.endpoint_z(),
-                                     kFlatZWithoutThetaDot, kVeryExact));
+                                     kFlatZWithoutThetaDot,
+                                     kEndpointLinearTolerance,
+                                     kEndpointAngularTolerance));
 
   const EndReference::Spec reversed_start_dut =
       EndReference().z_at(conn, Which::kStart, Direction::kReverse);
   EXPECT_TRUE(test::IsEndpointZClose(reversed_start_dut.endpoint_z(),
                                      kFlatZWithoutThetaDot.reverse(),
-                                     kVeryExact));
+                                     kEndpointLinearTolerance,
+                                     kEndpointAngularTolerance));
 
   const EndReference::Spec forward_end_dut =
       EndReference().z_at(conn, Which::kFinish, Direction::kForward);
   EXPECT_TRUE(test::IsEndpointZClose(forward_end_dut.endpoint_z(),
-                                     kFlatZWithoutThetaDot, kVeryExact));
+                                     kFlatZWithoutThetaDot,
+                                     kEndpointLinearTolerance,
+                                     kEndpointAngularTolerance));
 
   const EndReference::Spec reversed_end_dut =
       EndReference().z_at(conn, Which::kFinish, Direction::kReverse);
   EXPECT_TRUE(test::IsEndpointZClose(reversed_end_dut.endpoint_z(),
                                      kFlatZWithoutThetaDot.reverse(),
-                                     kVeryExact));
+                                     kEndpointLinearTolerance,
+                                     kEndpointAngularTolerance));
 }
 
 // LaneLayout check.
@@ -181,13 +202,14 @@ GTEST_TEST(MultilaneBuilderTest, ParameterConstructor) {
 
 // Checks that Connection instances are properly built by the Builder.
 GTEST_TEST(MultilaneBuilderTest, ProperConnections) {
-  const double kVeryExact = 1e-15;
-  const double kLaneWidth = 4.;
+  constexpr double kLaneWidth = 4.;
   const api::HBounds kElevationBounds(0., 5.);
-  const double kLinearTolerance = 0.01;
-  const double kAngularTolerance = 0.01 * M_PI;
-  const double kScaleLength = 1.0;
-  const ComputationPolicy kComputationPolicy{
+  constexpr double kLinearTolerance = 0.01;
+  constexpr double kAngularTolerance = 0.01 * M_PI;
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
+  constexpr double kScaleLength = 1.0;
+  constexpr ComputationPolicy kComputationPolicy{
     ComputationPolicy::kPreferAccuracy};
   Builder builder(kLaneWidth, kElevationBounds, kLinearTolerance,
                   kAngularTolerance, kScaleLength, kComputationPolicy);
@@ -212,7 +234,9 @@ GTEST_TEST(MultilaneBuilderTest, ProperConnections) {
   EXPECT_EQ(line_connection->id(), "line");
   EXPECT_EQ(line_connection->r0(), kRefR0);
   EXPECT_TRUE(test::IsEndpointClose(line_connection->start(),
-                                    kStartEndpoint, kVeryExact));
+                                    kStartEndpoint,
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
   EXPECT_EQ(line_connection->lane_width(), kLaneWidth);
   EXPECT_EQ(line_connection->left_shoulder(), kLeftShoulder);
   EXPECT_EQ(line_connection->right_shoulder(), kRightShoulder);
@@ -230,7 +254,8 @@ GTEST_TEST(MultilaneBuilderTest, ProperConnections) {
   EXPECT_EQ(arc_connection->r0(), kRefR0);
   EXPECT_TRUE(test::IsEndpointClose(arc_connection->start(),
                                     line_connection->end(),
-                                    kVeryExact));
+                                    kEndpointLinearTolerance,
+                                    kEndpointAngularTolerance));
   EXPECT_EQ(arc_connection->lane_width(), kLaneWidth);
   EXPECT_EQ(arc_connection->left_shoulder(), kLeftShoulder);
   EXPECT_EQ(arc_connection->right_shoulder(), kRightShoulder);
@@ -696,13 +721,13 @@ TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneLineSegment) {
   EXPECT_NE(c0, nullptr);
   EXPECT_TRUE(test::IsEndpointClose(
       c0->start(), {kStartEndpoint.xy(), {1., 2., M_PI / 6., 0.}},
-      kLinearTolerance));
+      kLinearTolerance, kAngularTolerance));
   EXPECT_TRUE(
       test::IsEndpointClose(c0->end(),
                             {{50. * std::cos(kStartHeading),
                               50. * std::sin(kStartHeading), kStartHeading},
                              {4., 5., -M_PI / 6., 0.}},
-                            kLinearTolerance));
+                            kLinearTolerance, kAngularTolerance));
 }
 
 // Checks how theta_dot is adjusted at the end points of the connection based
@@ -721,12 +746,12 @@ TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneArcSegment) {
   EXPECT_TRUE(test::IsEndpointClose(
       counter_clockwise_conn->start(),
       {kStartEndpoint.xy(), {1., 2., M_PI / 6., -0.0298142396999972}},
-      kLinearTolerance));
+      kLinearTolerance, kAngularTolerance));
   EXPECT_TRUE(test::IsEndpointClose(
       counter_clockwise_conn->end(),
       {{kRadius * std::sqrt(2.), 0., kStartHeading + kDTheta},
        {4., 5., -M_PI / 6., -0.0326860225230307}},
-      kLinearTolerance));
+      kLinearTolerance, kAngularTolerance));
 
   auto clockwise_conn =
       b.Connect("clockwise", kLaneLayout,
@@ -737,12 +762,12 @@ TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneArcSegment) {
   EXPECT_TRUE(test::IsEndpointClose(
       clockwise_conn->start(),
       {kStartEndpoint.xy(), {1., 2., M_PI / 6., 0.0298142396999972}},
-      kLinearTolerance));
+      kLinearTolerance, kAngularTolerance));
   EXPECT_TRUE(test::IsEndpointClose(
       clockwise_conn->end(),
       {{0., -kRadius * std::sqrt(2.), kStartHeading - kDTheta},
        {4., 5., -M_PI / 6., 0.0326860225230307}},
-      kLinearTolerance));
+      kLinearTolerance, kAngularTolerance));
 }
 
 // Holds common properties for lane-to-lane curve primitive tests.

--- a/automotive/maliput/multilane/test/multilane_connection_test.cc
+++ b/automotive/maliput/multilane/test/multilane_connection_test.cc
@@ -36,10 +36,11 @@ GTEST_TEST(EndpointXyTest, ParametrizedConstructor) {
 
 GTEST_TEST(EndpointXyTest, Reverse) {
   const EndpointXy dut{1., 2., M_PI / 7.123456};
-  const double kVeryExact{1e-15};
-  EXPECT_TRUE(test::IsEndpointXyClose(dut.reverse(),
-                                      {1., 2., -M_PI * (1. - 1. / 7.123456)},
-                                      kVeryExact));
+  constexpr double kEndpointLinearTolerance{1e-15};
+  constexpr double kEndpointAngularTolerance{1e-15};
+  EXPECT_TRUE(test::IsEndpointXyClose(
+      dut.reverse(), {1., 2., -M_PI * (1. - 1. / 7.123456)},
+      kEndpointLinearTolerance, kEndpointAngularTolerance));
 }
 
 // EndpointZ checks.
@@ -67,16 +68,17 @@ GTEST_TEST(EndpointZTest, ParametrizedConstructors) {
 }
 
 GTEST_TEST(EndpointZTest, Reverse) {
-  const double kZeroTolerance{0.};
+  constexpr double kZeroTolerance{0.};
+
   const EndpointZ dut_without_theta_dot{1., 2., M_PI / 4., {}};
   EXPECT_TRUE(test::IsEndpointZClose(dut_without_theta_dot.reverse(),
                                      {1., -2., -M_PI / 4., {}},
-                                     kZeroTolerance));
+                                     kZeroTolerance, kZeroTolerance));
 
   const EndpointZ dut_with_theta_dot{1., 2., M_PI / 4., M_PI / 2.};
   EXPECT_TRUE(test::IsEndpointZClose(dut_with_theta_dot.reverse(),
                                      {1., -2., -M_PI / 4., M_PI / 2.},
-                                     kZeroTolerance));
+                                     kZeroTolerance, kZeroTolerance));
 }
 
 // LineOffset check.
@@ -105,6 +107,8 @@ class MultilaneConnectionTest : public ::testing::Test {
   const EndpointXy kStartXy{20., 30., kHeading};
   const Endpoint kStartEndpoint{kStartXy, kLowFlatZ};
   const double kZeroTolerance{0.};
+  const double kEndpointLinearTolerance{1e-12};
+  const double kEndpointAngularTolerance{1e-12};
   const double kLinearTolerance{0.01};
   const double kScaleLength{1.0};
   const ComputationPolicy kComputationPolicy{
@@ -136,9 +140,10 @@ TEST_F(MultilaneConnectionTest, ArcAccessors) {
   EXPECT_EQ(dut.r_max(),
             kR0 + kLaneWidth * (static_cast<double>(kNumLanes - 1) + .5) +
                 kLeftShoulder);
-  EXPECT_TRUE(
-      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
-  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kVeryExact));
+  EXPECT_TRUE(test::IsEndpointClose(dut.start(), kStartEndpoint,
+                                    kZeroTolerance, kZeroTolerance));
+  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint,
+                                    kZeroTolerance, kZeroTolerance));
   EXPECT_EQ(dut.lane_offset(0), kR0);
   EXPECT_EQ(dut.lane_offset(1), kR0 + kLaneWidth);
   EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
@@ -168,9 +173,10 @@ TEST_F(MultilaneConnectionTest, LineAccessors) {
   EXPECT_EQ(dut.r_max(),
             kR0 + kLaneWidth * (static_cast<double>(kNumLanes - 1) + .5) +
                 kLeftShoulder);
-  EXPECT_TRUE(
-      test::IsEndpointClose(dut.start(), kStartEndpoint, kZeroTolerance));
-  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint, kVeryExact));
+  EXPECT_TRUE(test::IsEndpointClose(dut.start(), kStartEndpoint,
+                                    kZeroTolerance, kZeroTolerance));
+  EXPECT_TRUE(test::IsEndpointClose(dut.end(), kEndEndpoint,
+                                    kZeroTolerance, kZeroTolerance));
   EXPECT_EQ(dut.lane_offset(0), kR0);
   EXPECT_EQ(dut.lane_offset(1), kR0 + kLaneWidth);
   EXPECT_EQ(dut.lane_offset(2), kR0 + 2. * kLaneWidth);
@@ -395,6 +401,8 @@ class MultilaneConnectionEndpointZTest
   const double kLaneWidth{2.};
   const double kHeading{-M_PI / 4.};
   const EndpointXy kStartXy{20., 30., kHeading};
+  const double kEndpointLinearTolerance{1e-12};
+  const double kEndpointAngularTolerance{1e-12};
   const double kLinearTolerance{0.01};
   const double kScaleLength{1.0};
   const ComputationPolicy kComputationPolicy{
@@ -437,8 +445,9 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
          wrap(kTheta0 + M_PI / 2.)},
         {start_z.z(), start_z.z_dot() * kRadius / start_radius, start_z.theta(),
          (*start_z.theta_dot()) * kRadius / start_radius}};
-    EXPECT_TRUE(
-        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneStart(i), lane_start,
+                                      kEndpointLinearTolerance,
+                                      kEndpointAngularTolerance));
     // End endpoints.
     const double end_radius =
         kRadius - (r0 + static_cast<double>(i) * kLaneWidth) *
@@ -449,7 +458,9 @@ TEST_P(MultilaneConnectionEndpointZTest, ArcLaneEndpoints) {
          wrap(kTheta0 + kDTheta + M_PI / 2.)},
         {end_z.z(), end_z.z_dot() * kRadius / end_radius, end_z.theta(),
          (*end_z.theta_dot()) * kRadius / end_radius}};
-    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end,
+                                      kEndpointLinearTolerance,
+                                      kEndpointAngularTolerance));
   }
 }
 
@@ -470,14 +481,17 @@ TEST_P(MultilaneConnectionEndpointZTest, LineLaneEndpoints) {
     const Endpoint lane_start{
         {kStartXy.x() - offset * kNormalDirection.x(),
          kStartXy.y() - offset * kNormalDirection.y(), kHeading}, start_z};
-    EXPECT_TRUE(
-        test::IsEndpointClose(dut.LaneStart(i), lane_start, kVeryExact));
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneStart(i), lane_start,
+                                      kEndpointLinearTolerance,
+                                      kEndpointAngularTolerance));
     // End endpoints.
     const Endpoint lane_end{
         {kStartXy.x() - offset * kNormalDirection.x() + kDirection.x(),
          kStartXy.y() - offset * kNormalDirection.y() + kDirection.y(),
          kHeading}, end_z};
-    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end, kVeryExact));
+    EXPECT_TRUE(test::IsEndpointClose(dut.LaneEnd(i), lane_end,
+                                      kEndpointLinearTolerance,
+                                      kEndpointAngularTolerance));
   }
 }
 

--- a/automotive/maliput/multilane/test/multilane_loader_test.cc
+++ b/automotive/maliput/multilane/test/multilane_loader_test.cc
@@ -434,10 +434,10 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                                  kThreeLanes, kRefLane, kZeroRRef),
                       kZeroTolerance),
               Matches(StartReference().at(kEndpointA, Direction::kForward),
-                      kLinearTolerance),
+                      kLinearTolerance, kAngularTolerance),
               Matches(LineOffset(50), kZeroTolerance),
               Matches(EndReference().z_at(kFlatZ, Direction::kForward),
-                      kLinearTolerance)));
+                      kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -447,10 +447,10 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                         kZeroTolerance),
           Matches(StartLane(0).at({{50., 10., 0.}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(10., M_PI), kLinearTolerance, kAngularTolerance),
           Matches(EndLane(0).z_at(kFlatZWithoutThetaDot, Direction::kForward),
-                  kLinearTolerance)));
+                  kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -460,10 +460,10 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                         kZeroTolerance),
           Matches(StartLane(0).at({{50., 30., M_PI}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(LineOffset(50), kZeroTolerance),
           Matches(EndLane(0).z_at(kFlatZWithoutThetaDot, Direction::kForward),
-                  kLinearTolerance)));
+                  kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -473,10 +473,10 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                         kZeroTolerance),
           Matches(StartLane(0).at({{0., 30., M_PI}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., M_PI), kLinearTolerance, kAngularTolerance),
           Matches(EndLane(0).z_at(kFlatZWithoutThetaDot, Direction::kForward),
-                  kLinearTolerance)));
+                  kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -485,11 +485,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                                    kTwoLanes, kRefLane, -5.),
                         kZeroTolerance),
           Matches(StartReference().at(kEndpointB, Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., -M_PI), kLinearTolerance, kAngularTolerance),
           Matches(
               EndReference().z_at(kFlatZWithoutThetaDot, Direction::kForward),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -500,11 +500,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(
               StartReference().at({{50., -35., -M_PI}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-              kLinearTolerance),
+              kLinearTolerance, kAngularTolerance),
           Matches(LineOffset(50), kZeroTolerance),
           Matches(
               EndReference().z_at(kFlatZWithoutThetaDot, Direction::kForward),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -515,11 +515,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(
               StartReference().at({{0., -35., -M_PI}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-              kLinearTolerance),
+              kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., -M_PI), kLinearTolerance, kAngularTolerance),
           Matches(
               EndReference().z_at(kFlatZWithoutThetaDot, Direction::kForward),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -530,11 +530,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(
               StartLane(0).at({{0., -35., -M_PI}, kFlatZWithoutThetaDot},
                                   Direction::kForward),
-              kLinearTolerance),
+              kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., M_PI / 2.), kLinearTolerance,
                   kAngularTolerance),
           Matches(EndLane(0).z_at({5., 1., 0.523, {}}, Direction::kForward),
-                  kLinearTolerance)));
+                  kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -545,12 +545,12 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(StartLane(0).at(
                       {{-20., -55., -M_PI / 2.}, {5., 1., 0.523, {}}},
                       Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., M_PI / 2.), kLinearTolerance,
                   kAngularTolerance),
           Matches(
               EndLane(0).z_at({10., 0., 0.523, {}}, Direction::kForward),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -560,12 +560,12 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
                       kZeroTolerance),
               Matches(StartLane(0).at({{0, -75., 0}, {10., 0., 0.523, {}}},
                                       Direction::kForward),
-                      kLinearTolerance),
+                      kLinearTolerance, kAngularTolerance),
               Matches(ArcOffset(20., M_PI / 2.), kLinearTolerance,
                       kAngularTolerance),
               Matches(EndLane(0).z_at(kElevatedZWithoutThetaDot,
                                       Direction::kForward),
-                      kLinearTolerance)));
+                      kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -576,12 +576,12 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(StartReference().at(
                       {{20., -55., M_PI / 2.}, kElevatedZWithoutThetaDot},
                       Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(ArcOffset(20., M_PI / 2.), kLinearTolerance,
                   kAngularTolerance),
           Matches(
               EndReference().z_at(kFlatZWithoutThetaDot, Direction::kReverse),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -592,11 +592,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
               Matches(StartReference().at(
                           {{20., -55., M_PI / 2.}, kElevatedZWithoutThetaDot},
                           Direction::kForward),
-                      kLinearTolerance),
+                      kLinearTolerance, kAngularTolerance),
               Matches(LineOffset(30.), kZeroTolerance),
               Matches(EndReference().z_at(kElevatedZWithoutThetaDot,
                                           Direction::kForward),
-                      kLinearTolerance)));
+                      kLinearTolerance, kAngularTolerance)));
 
   prebuild_expectations += EXPECT_CALL(
       *builder_mock,
@@ -607,11 +607,11 @@ GTEST_TEST(MultilaneLoaderTest, RoadCircuit) {
           Matches(StartLane(0).at(
                       {{20., -25., M_PI / 2.}, kElevatedZWithoutThetaDot},
                       Direction::kForward),
-                  kLinearTolerance),
+                  kLinearTolerance, kAngularTolerance),
           Matches(LineOffset(15.), kZeroTolerance),
           Matches(
               EndLane(0).z_at(kFlatZWithoutThetaDot, Direction::kForward),
-              kLinearTolerance)));
+              kLinearTolerance, kAngularTolerance)));
 
   // Group expectations.
   {
@@ -734,10 +734,10 @@ GTEST_TEST(MultilaneLoaderTest, ContinuityConstraintOnReference) {
                                  kOneLane, kRefLane, kZeroRRef),
                       kZeroTolerance),
               Matches(StartReference().at(kOrigin, Direction::kForward),
-                      kLinearTolerance),
+                      kLinearTolerance, kAngularTolerance),
               Matches(ArcOffset(10., M_PI), kZeroTolerance, kAngularTolerance),
               Matches(EndReference().z_at(kZEndSpiral, Direction::kForward),
-                      kLinearTolerance)));
+                      kLinearTolerance, kAngularTolerance)));
 
   // EndpointXy is reversed and EndpointZ is reversed and theta_dot cleared.
   prebuild_expectations += EXPECT_CALL(
@@ -749,11 +749,11 @@ GTEST_TEST(MultilaneLoaderTest, ContinuityConstraintOnReference) {
               Matches(StartReference().at({kXYOrigin.reverse(),
                                            {0., -0.75, 30. * M_PI / 180., {}}},
                                           Direction::kForward),
-                      kLinearTolerance),
+                      kLinearTolerance, kAngularTolerance),
               Matches(LineOffset(100.), kLinearTolerance),
               Matches(EndReference().z_at({-7.5, -0.75, 30. * M_PI / 180., {}},
                                           Direction::kForward),
-                      kLinearTolerance)));
+                      kLinearTolerance, kAngularTolerance)));
 
   EXPECT_CALL(*builder_mock, Build(api::RoadGeometryId("spir")))
       .After(prebuild_expectations);

--- a/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
+++ b/automotive/maliput/multilane/test_utilities/multilane_types_compare.cc
@@ -14,80 +14,82 @@ namespace test {
 
 ::testing::AssertionResult IsEndpointXyClose(const EndpointXy& xy1,
                                              const EndpointXy& xy2,
-                                             double tolerance) {
+                                             double linear_tolerance,
+                                             double angular_tolerance) {
   bool fails = false;
   std::string error_message{};
   double delta = std::abs(xy1.x() - xy2.x());
-  if (delta > tolerance) {
+  if (delta > linear_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointXys are different at x coordinate. "
-        "xy1.x(): {} vs.xy2.x(): {}, diff = {}, tolerance = {}.\n",
-        xy1.x(), xy2.x(), delta, tolerance);
+        "xy1.x(): {} vs.xy2.x(): {}, diff = {}, linear tolerance = {}.\n",
+        xy1.x(), xy2.x(), delta, linear_tolerance);
   }
   delta = std::abs(xy1.y() - xy2.y());
-  if (delta > tolerance) {
+  if (delta > linear_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointXys are different at y coordinate. "
-        "xy1.y(): {} vs.xy2.y(): {}, diff = {}, tolerance = {}.\n",
-        xy1.y(), xy2.y(), delta, tolerance);
+        "xy1.y(): {} vs.xy2.y(): {}, diff = {}, linear tolerance = {}.\n",
+        xy1.y(), xy2.y(), delta, linear_tolerance);
   }
   delta = std::abs(xy1.heading() - xy2.heading());
-  if (delta > tolerance) {
+  if (delta > angular_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointXys are different at heading angle. "
         "xy1.heading(): {} vs.xy2.heading(): {}, diff = {}, "
-        "tolerance = {}.\n",
-        xy1.heading(), xy2.heading(), delta, tolerance);
+        "angular tolerance = {}.\n",
+        xy1.heading(), xy2.heading(), delta, angular_tolerance);
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
   return ::testing::AssertionSuccess() << fmt::format(
              "xy1 =\n{}\nis approximately equal to xy2 =\n{}\n"
-             "tolerance = {}",
-             xy1, xy2, tolerance);
+             "linear tolerance = {}, angular tolerance = {}",
+             xy1, xy2, linear_tolerance, angular_tolerance);
 }
 
 ::testing::AssertionResult IsEndpointZClose(const EndpointZ& z1,
                                             const EndpointZ& z2,
-                                            double tolerance) {
+                                            double linear_tolerance,
+                                            double angular_tolerance) {
   bool fails = false;
   std::string error_message{};
   double delta = std::abs(z1.z() - z2.z());
-  if (delta > tolerance) {
+  if (delta > linear_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointZ are different at z coordinate. z1.z(): {} vs z2.z(): {}"
-        ", diff = {}, tolerance = {}\n",
-        z1.z(), z2.z(), delta, tolerance);
+        ", diff = {}, linear tolerance = {}\n",
+        z1.z(), z2.z(), delta, linear_tolerance);
   }
   delta = std::abs(z1.z_dot() - z2.z_dot());
-  if (delta > tolerance) {
+  if (delta > linear_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointZ are different at z_dot coordinate. z1.z_dot(): {} vs "
-        "z2.z_dot(): {}, diff = {}, tolerance = {}\n",
-        z1.z_dot(), z2.z_dot(), delta, tolerance);
+        "z2.z_dot(): {}, diff = {}, linear tolerance = {}\n",
+        z1.z_dot(), z2.z_dot(), delta, linear_tolerance);
   }
   delta = std::abs(z1.theta() - z2.theta());
-  if (delta > tolerance) {
+  if (delta > angular_tolerance) {
     fails = true;
     error_message += fmt::format(
         "EndpointZ are different at theta angle. z1.theta(): {} vs "
-        "z2.theta(): {}, diff = {}, tolerance = {}\n",
-        z1.theta(), z2.theta(), delta, tolerance);
+        "z2.theta(): {}, diff = {}, angular tolerance = {}\n",
+        z1.theta(), z2.theta(), delta, angular_tolerance);
   }
   if (z1.theta_dot().has_value() && z2.theta_dot().has_value()) {
     delta = std::abs(*z1.theta_dot() - *z2.theta_dot());
-    if (delta > tolerance) {
+    if (delta > angular_tolerance) {
       fails = true;
       error_message += fmt::format(
           "EndpointZ are different at theta_dot. z1.theta_dot(): {} vs "
-          "z2.theta_dot(): {}, diff = {}, tolerance = {}\n",
-          *z1.theta_dot(), *z2.theta_dot(), delta, tolerance);
+          "z2.theta_dot(): {}, diff = {}, angular tolerance = {}\n",
+          *z1.theta_dot(), *z2.theta_dot(), delta, angular_tolerance);
     }
   } else if (z1.theta_dot().has_value() && !z2.theta_dot().has_value()) {
     fails = true;
@@ -107,18 +109,19 @@ namespace test {
   }
   return ::testing::AssertionSuccess() << fmt::format(
              "z1 =\n{}\nis approximately equal to z2 =\n{}\n"
-             "tolerance = {}",
-             z1, z2, tolerance);
+             "linear tolerance = {}, angular tolerance = {}",
+             z1, z2, linear_tolerance, angular_tolerance);
 }
 
 ::testing::AssertionResult IsEndpointClose(const Endpoint& p1,
                                            const Endpoint& p2,
-                                           double tolerance) {
+                                           double linear_tolerance,
+                                           double angular_tolerance) {
   bool fails = false;
   std::string error_message{};
 
   const ::testing::AssertionResult endpoint_xy_comparison =
-      IsEndpointXyClose(p1.xy(), p2.xy(), tolerance);
+      IsEndpointXyClose(p1.xy(), p2.xy(), linear_tolerance, angular_tolerance);
   if (!endpoint_xy_comparison) {
     fails = true;
     error_message +=
@@ -126,7 +129,7 @@ namespace test {
                     endpoint_xy_comparison.message());
   }
   const ::testing::AssertionResult endpoint_z_comparison =
-      IsEndpointZClose(p1.z(), p2.z(), tolerance);
+      IsEndpointZClose(p1.z(), p2.z(), linear_tolerance, angular_tolerance);
   if (!endpoint_z_comparison) {
     fails = true;
     error_message +=
@@ -138,8 +141,8 @@ namespace test {
   }
   return ::testing::AssertionSuccess() << fmt::format(
              "p1 =\n{}\nis approximately equal to p2 =\n{}\n"
-             "tolerance = {}",
-             p1, p2, tolerance);
+             "linear tolerance = {}, angular tolerance = {}",
+             p1, p2, linear_tolerance, angular_tolerance);
 }
 
 ::testing::AssertionResult IsArcOffsetClose(const ArcOffset& arc_offset1,
@@ -229,23 +232,31 @@ Matcher<const LaneLayout&> Matches(const LaneLayout& lane_layout,
 }
 
 Matcher<const StartReference::Spec&> Matches(
-    const StartReference::Spec& start_reference, double tolerance) {
-  return MakeMatcher(new StartReferenceSpecMatcher(start_reference, tolerance));
+    const StartReference::Spec& start_reference, double linear_tolerance,
+    double angular_tolerance) {
+  return MakeMatcher(new StartReferenceSpecMatcher(
+      start_reference, linear_tolerance, angular_tolerance));
 }
 
 Matcher<const StartLane::Spec&> Matches(
-    const StartLane::Spec& start_lane, double tolerance) {
-  return MakeMatcher(new StartLaneSpecMatcher(start_lane, tolerance));
+    const StartLane::Spec& start_lane, double linear_tolerance,
+    double angular_tolerance) {
+  return MakeMatcher(new StartLaneSpecMatcher(
+      start_lane, linear_tolerance, angular_tolerance));
 }
 
 Matcher<const EndReference::Spec&> Matches(
-    const EndReference::Spec& end_reference, double tolerance) {
-  return MakeMatcher(new EndReferenceSpecMatcher(end_reference, tolerance));
+    const EndReference::Spec& end_reference, double linear_tolerance,
+    double angular_tolerance) {
+  return MakeMatcher(new EndReferenceSpecMatcher(
+      end_reference, linear_tolerance, angular_tolerance));
 }
 
 Matcher<const EndLane::Spec&> Matches(
-    const EndLane::Spec& end_lane, double tolerance) {
-  return MakeMatcher(new EndLaneSpecMatcher(end_lane, tolerance));
+    const EndLane::Spec& end_lane, double linear_tolerance,
+    double angular_tolerance) {
+  return MakeMatcher(new EndLaneSpecMatcher(
+      end_lane, linear_tolerance, angular_tolerance));
 }
 
 }  // namespace test


### PR DESCRIPTION
Connected to #8899. This (small) pull request adapts Multilane test utilities to use linear and angular tolerances appropriately when comparing `EndpointXy`, `EndpointZ` and `Endpoint` instances. As a side effect, `...SpecMatcher`s had to be adapted too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9239)
<!-- Reviewable:end -->
