### PR TITLE
Update the colors of the visuals in some examples

### DIFF
--- a/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
+++ b/examples/multibody/bouncing_ball/make_bouncing_ball_plant.cc
@@ -10,6 +10,7 @@ namespace bouncing_ball {
 using geometry::Sphere;
 using geometry::HalfSpace;
 using geometry::SceneGraph;
+using geometry::VisualMaterial;
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::RigidBody;
@@ -40,11 +41,24 @@ MakeBouncingBallPlant(double radius, double mass,
         plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
         HalfSpace(), surface_friction, scene_graph);
 
+    // Add visual for the ground.
+    plant->RegisterVisualGeometry(
+        plant->world_body(), HalfSpace::MakePose(normal_W, point_W),
+        HalfSpace(), scene_graph);
+
     // Add sphere geometry for the ball.
     plant->RegisterCollisionGeometry(
         ball,
         /* Pose X_BG of the geometry frame G in the ball frame B. */
         Isometry3<double>::Identity(), Sphere(radius), surface_friction,
+        scene_graph);
+
+    // Add visual for the ball.
+    const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
+    plant->RegisterVisualGeometry(
+        ball,
+        /* Pose X_BG of the geometry frame G in the ball frame B. */
+        Isometry3<double>::Identity(), Sphere(radius), orange,
         scene_graph);
   }
 

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -10,6 +10,7 @@ namespace inclined_plane {
 using geometry::HalfSpace;
 using geometry::SceneGraph;
 using geometry::Sphere;
+using geometry::VisualMaterial;
 using multibody_plant::CoulombFriction;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RigidBody;
@@ -49,6 +50,11 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
                                    HalfSpace::MakePose(normal_W, point_W),
                                    HalfSpace(), surface_friction, scene_graph);
 
+  // Visual for the ground.
+  plant->RegisterVisualGeometry(plant->world_body(),
+                                   HalfSpace::MakePose(normal_W, point_W),
+                                   HalfSpace(), scene_graph);
+
   // Add sphere geometry for the ball.
   plant->RegisterCollisionGeometry(
       ball,
@@ -56,27 +62,36 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
       Isometry3<double>::Identity(), Sphere(radius), surface_friction,
       scene_graph);
 
+  // Visual for the ball.
+  const VisualMaterial orange(Vector4<double>(1.0, 0.55, 0.0, 1.0));
+  plant->RegisterVisualGeometry(
+      ball,
+      /* Pose X_BG of the geometry frame G in the ball frame B. */
+      Isometry3<double>::Identity(), Sphere(radius), orange,
+      scene_graph);
+
   // Adds little spherical spokes highlight the sphere's rotation.
+  const VisualMaterial red(Vector4<double>(1.0, 0.0, 0.0, 1.0));
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(0, 0, radius)), Sphere(radius / 5),
-      scene_graph);
+      red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(0, 0, -radius)),
-      Sphere(radius / 5), scene_graph);
+      Sphere(radius / 5), red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(radius, 0, 0)), Sphere(radius / 5),
-      scene_graph);
+      red, scene_graph);
   plant->RegisterVisualGeometry(
       ball,
       /* Pose X_BG of the geometry frame G in the ball frame B. */
       Isometry3<double>(Translation3<double>(-radius, 0, 0)),
-      Sphere(radius / 5), scene_graph);
+      Sphere(radius / 5), red, scene_graph);
 
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(


### PR DESCRIPTION
As we updated MBP so that by default collision geometry is not shown, some examples for which only collision geometry was added ended up not having visualization. This PR adds that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9240)
<!-- Reviewable:end -->
