### PR TITLE
Increase size of spring_mass_system_test

### DIFF
--- a/systems/plants/spring_mass_system/BUILD.bazel
+++ b/systems/plants/spring_mass_system/BUILD.bazel
@@ -31,6 +31,7 @@ drake_cc_library(
 
 drake_cc_googletest(
     name = "spring_mass_system_test",
+    size = "medium",
     deps = [
         ":spring_mass_system",
         "//common/test_utilities",


### PR DESCRIPTION
[We think that  `//systems/plants/spring_mass_system:spring_mass_system_test` warrants a size increase.](https://drake-cdash.csail.mit.edu/testDetails.php?test=21419205&build=1037888)

[ASan, in bazel.rc.](https://github.com/RobotLocomotion/drake/blob/master/tools/dynamic_analysis/bazel.rc#L69)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9249)
<!-- Reviewable:end -->
