### PR TITLE
Add diff-ik with linear velocity constraints.

### DIFF
--- a/manipulation/planner/differential_inverse_kinematics.h
+++ b/manipulation/planner/differential_inverse_kinematics.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "drake/common/copyable_unique_ptr.h"
 #include "drake/common/drake_copyable.h"
@@ -95,6 +96,9 @@ class DifferentialInverseKinematicsParameters {
   get_joint_acceleration_limits() const {
     return vd_bounds_;
   }
+
+  const std::vector<std::shared_ptr<solvers::LinearConstraint>>&
+  get_linear_velocity_constraints() const;
   /// @}
 
   /// @name Setters.
@@ -191,6 +195,20 @@ class DifferentialInverseKinematicsParameters {
   }
   /// @}
 
+  /**
+   * Adds a linear velocity constraint.
+   * @param linear_velocity_constraint A linear constraint on joint velocities.
+   * @throws std::invalid_argument if `constraint->num_vars !=
+   * this->get_num_velocities()`.
+   */
+  void AddLinearVelocityConstraint(
+      const std::shared_ptr<solvers::LinearConstraint> constraint);
+
+  /**
+   * Clears all linear velocity constraints.
+   */
+  void ClearLinearVelocityConstraints();
+
  private:
   int num_positions_{0};
   int num_velocities_{0};
@@ -201,6 +219,8 @@ class DifferentialInverseKinematicsParameters {
   optional<double> unconstrained_degrees_of_freedom_velocity_limit_{};
   Vector6<double> gain_E_{Vector6<double>::Ones()};
   double dt_{1};
+  std::vector<std::shared_ptr<solvers::LinearConstraint>>
+      linear_velocity_constraints_;
 };
 
 /**

--- a/manipulation/planner/test/differential_inverse_kinematics_test.cc
+++ b/manipulation/planner/test/differential_inverse_kinematics_test.cc
@@ -17,6 +17,7 @@
 #include "drake/multibody/rigid_body.h"
 #include "drake/multibody/rigid_body_frame.h"
 #include "drake/multibody/rigid_body_tree.h"
+#include "drake/solvers/constraint.h"
 
 namespace drake {
 namespace manipulation {
@@ -28,6 +29,7 @@ using examples::kuka_iiwa_arm::get_iiwa_max_joint_velocities;
 using multibody::MultibodyTree;
 using multibody::RevoluteJoint;
 using multibody::FixedOffsetFrame;
+using solvers::LinearConstraint;
 
 std::unique_ptr<RigidBodyTree<double>> BuildTree() {
   const std::string iiwa_absolute_path = FindResourceOrThrow(
@@ -102,6 +104,39 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
     }
   }
 
+  void CheckPositiveResult(const Vector6<double>& V_WE,
+                           const DifferentialInverseKinematicsResult& result) {
+    const auto& q_bounds = *(params_->get_joint_position_limits());
+    const auto& v_bounds = *(params_->get_joint_velocity_limits());
+    const auto& q = cache_->getQ();
+    const double dt = params_->get_timestep();
+
+    const double velocity_tolerance{1e-6};
+
+    ASSERT_TRUE(result.joint_velocities != nullopt);
+    drake::log()->info("result.joint_velocities = {}",
+                       result.joint_velocities->transpose());
+
+    const KinematicsCache<double> cache1 =
+        tree_->doKinematics(q, result.joint_velocities.value());
+
+    const int num_velocities{tree_->get_num_velocities()};
+    Vector6<double> V_WE_actual =
+        tree_->CalcFrameSpatialVelocityInWorldFrame(cache1, *frame_E_);
+    drake::log()->info("V_WE_actual = {}", V_WE_actual.transpose());
+    drake::log()->info("V_WE = {}", V_WE.transpose());
+
+    EXPECT_TRUE(CompareMatrices(V_WE_actual.normalized(), V_WE.normalized(),
+                                velocity_tolerance));
+    ASSERT_EQ(result.joint_velocities->size(), num_velocities);
+    for (int i = 0; i < num_velocities; ++i) {
+      EXPECT_GE(q(i) + dt * (*result.joint_velocities)(i), q_bounds.first(i));
+      EXPECT_LE(q(i) + dt * (*result.joint_velocities)(i), q_bounds.second(i));
+      EXPECT_GE((*result.joint_velocities)(i), v_bounds.first(i));
+      EXPECT_LE((*result.joint_velocities)(i), v_bounds.second(i));
+    }
+  }
+
   std::unique_ptr<RigidBodyTree<double>> tree_;
   std::unique_ptr<KinematicsCache<double>> cache_;
   std::shared_ptr<RigidBodyFrame<double>> frame_E_;
@@ -115,43 +150,45 @@ class DifferentialInverseKinematicsTest : public ::testing::Test {
 
 TEST_F(DifferentialInverseKinematicsTest, PositiveTest) {
   auto V_WE = (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();
-  const auto& q_bounds = *(params_->get_joint_position_limits());
-  const auto& v_bounds = *(params_->get_joint_velocity_limits());
-  const auto& q = cache_->getQ();
-  const double dt = params_->get_timestep();
 
-  const double velocity_tolerance{1e-6};
+  // Test without additional linear constraints.
+  DifferentialInverseKinematicsResult result = DoDifferentialInverseKinematics(
+      *tree_, *cache_, V_WE, *frame_E_, *params_);
+  DifferentialInverseKinematicsStatus function_status{result.status};
+  drake::log()->info("function_status = {}", function_status);
 
+  CheckPositiveResult(V_WE, result);
+
+  // Test with additional linear constraints.
+  const auto A = (MatrixX<double>(1, 7) << 1, -1, 0, 0, 0, 0, 0).finished();
+  const auto b = VectorX<double>::Zero(A.rows());
+  params_->AddLinearVelocityConstraint(
+      std::make_shared<LinearConstraint>(A, b, b));
+  result = DoDifferentialInverseKinematics(*tree_, *cache_, V_WE, *frame_E_,
+                                           *params_);
+  drake::log()->info("function_status = {}", function_status);
+
+  CheckPositiveResult(V_WE, result);
+}
+
+TEST_F(DifferentialInverseKinematicsTest, OverConstrainedTest) {
+  auto V_WE = (Vector6<double>() << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0).finished();
+
+  // clang-format off
+  const auto A = (MatrixX<double>(2, 7) <<
+      1, -1,  0, 0, 0, 0, 0,
+      0,  1, -1, 0, 0, 0, 0).finished();
+  // clang-format on
+  const auto b = VectorX<double>::Zero(A.rows());
+  params_->AddLinearVelocityConstraint(
+      std::make_shared<LinearConstraint>(A, b, b));
   DifferentialInverseKinematicsResult function_result =
       DoDifferentialInverseKinematics(*tree_, *cache_, V_WE, *frame_E_,
                                       *params_);
   DifferentialInverseKinematicsStatus function_status{function_result.status};
   drake::log()->info("function_status = {}", function_status);
 
-  ASSERT_TRUE(function_result.joint_velocities != nullopt);
-  drake::log()->info("function_result.joint_velocities = {}",
-                     function_result.joint_velocities->transpose());
-
-  const KinematicsCache<double> cache1 =
-      tree_->doKinematics(q, function_result.joint_velocities.value());
-
-  const int num_velocities{tree_->get_num_velocities()};
-  Vector6<double> V_WE_actual =
-      tree_->CalcFrameSpatialVelocityInWorldFrame(cache1, *frame_E_);
-  drake::log()->info("V_WE_actual = {}", V_WE_actual.transpose());
-  drake::log()->info("V_WE = {}", V_WE.transpose());
-
-  EXPECT_TRUE(CompareMatrices(V_WE_actual.normalized(), V_WE.normalized(),
-                              velocity_tolerance));
-  ASSERT_EQ(function_result.joint_velocities->size(), num_velocities);
-  for (int i = 0; i < num_velocities; ++i) {
-    EXPECT_GE(q(i) + dt * (*function_result.joint_velocities)(i),
-              q_bounds.first(i));
-    EXPECT_LE(q(i) + dt * (*function_result.joint_velocities)(i),
-              q_bounds.second(i));
-    EXPECT_GE((*function_result.joint_velocities)(i), v_bounds.first(i));
-    EXPECT_LE((*function_result.joint_velocities)(i), v_bounds.second(i));
-  }
+  ASSERT_TRUE(function_result.joint_velocities == nullopt);
 }
 
 TEST_F(DifferentialInverseKinematicsTest, MultiBodyTreeTest) {
@@ -293,6 +330,32 @@ GTEST_TEST(DifferentialInverseKinematicsParametersTest, TestSetter) {
                std::exception);
   EXPECT_THROW(dut.set_joint_acceleration_limits({VectorX<double>(2), h}),
                std::exception);
+}
+
+// Test linear velocity constraint mutators.
+GTEST_TEST(DifferentialInverseKinematicsParametersTest, TestMutators) {
+  DifferentialInverseKinematicsParameters dut(3, 3);
+  // Test with right number of variables.
+  dut.AddLinearVelocityConstraint(std::make_shared<LinearConstraint>(
+      Eigen::RowVector3d(1, 1, 1), Eigen::VectorXd::Zero(1),
+      Eigen::VectorXd::Zero(1)));
+  EXPECT_EQ(dut.get_linear_velocity_constraints().size(), 1);
+  dut.AddLinearVelocityConstraint(std::make_shared<LinearConstraint>(
+      Eigen::RowVector3d(1, 0, 1), Eigen::VectorXd::Zero(1),
+      Eigen::VectorXd::Zero(1)));
+  EXPECT_EQ(dut.get_linear_velocity_constraints().size(), 2);
+
+  // Test with wrong number of variables.
+  EXPECT_THROW(
+      dut.AddLinearVelocityConstraint(std::make_shared<LinearConstraint>(
+          Eigen::RowVector2d(0, 0), Eigen::VectorXd::Zero(1),
+          Eigen::VectorXd::Zero(1))),
+      std::invalid_argument);
+  EXPECT_EQ(dut.get_linear_velocity_constraints().size(), 2);
+
+  // Test clearing constraints.
+  dut.ClearLinearVelocityConstraints();
+  EXPECT_EQ(dut.get_linear_velocity_constraints().size(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds an overload of `DoDifferentialInverseKinematics()` that accepts a vector of linear constraints on velocity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9254)
<!-- Reviewable:end -->
