### PR TITLE
Contact results: Fixes sign in the reported friction force

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -889,7 +889,7 @@ void MultibodyPlant<T>::CalcContactResults(
 
     // Contact forces applied on B at contact point C.
     const Vector3<T> f_Bc_C(
-        ft(2 * icontact), ft(2 * icontact + 1), fn(icontact));
+        -ft(2 * icontact), -ft(2 * icontact + 1), fn(icontact));
     const Vector3<T> f_Bc_W = R_WC * f_Bc_C;
 
     // Slip velocity.

--- a/multibody/multibody_tree/multibody_plant/test/box_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/box_test.cc
@@ -150,11 +150,11 @@ GTEST_TEST(Box, UnderStiction) {
   // in the -z direction).
   double direction = contact_info.bodyA_index() == box.index() ? 1.0 : -1.0;
 
-  // The expected value of the contact force applied on the body with index
-  // contact_info.bodyB_index() at the contact point C.
-  const Vector3<double> f_Bc_W(-applied_force, 0.0, mass * g * direction);
+  // The expected value of the contact force applied on the box at the contact
+  // point C.
+  const Vector3<double> f_Bc_W(-applied_force, 0.0, mass * g);
   EXPECT_TRUE(CompareMatrices(
-      contact_info.contact_force(), f_Bc_W,
+      contact_info.contact_force(), f_Bc_W * direction,
       kTolerance, MatrixCompareType::relative));
 
   // Upper limit on the x displacement computed using the maximum possible


### PR DESCRIPTION
This bug doesn't affect the results of the dynamics, it only affects the reported results. Most notably, for visualization.
It is easy to verify in the [cylinder with multicontact example](https://github.com/RobotLocomotion/drake/blob/master/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc) that the sign of the friction forces is wrong just by inspection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9256)
<!-- Reviewable:end -->
