### PR TITLE
Update FCL dependency

### DIFF
--- a/geometry/proximity_engine.cc
+++ b/geometry/proximity_engine.cc
@@ -295,8 +295,12 @@ bool DistanceCallback(fcl::CollisionObjectd* fcl_object_A_ptr,
     nearest_pair.id_A = EncodedData(fcl_object_A).id(dynamic_map, anchored_map);
     nearest_pair.id_B = EncodedData(fcl_object_B).id(dynamic_map, anchored_map);
 
-    nearest_pair.p_ACa = result.nearest_points[0];
-    nearest_pair.p_BCb = result.nearest_points[1];
+    // Note: The result of FCL's distance query is in the *world* frame, the
+    // SignedDistancePair reports in geometry frame.
+    nearest_pair.p_ACa =
+        fcl_object_A.getTransform().inverse() * result.nearest_points[0];
+    nearest_pair.p_BCb =
+        fcl_object_B.getTransform().inverse() * result.nearest_points[1];
     nearest_pair.distance = result.min_distance;
     // Guarantee fixed ordering of pair (A, B). Swap the ids and points on
     // surfaces and then flip the normal.

--- a/geometry/query_results/signed_distance_pair.h
+++ b/geometry/query_results/signed_distance_pair.h
@@ -31,6 +31,14 @@ struct SignedDistancePair{
   GeometryId id_A;
   /** The id of the second geometry in the pair. */
   GeometryId id_B;
+  // TODO(SeanCurtis-TRI): Determine if this is the *right* API. Should we
+  // really be returning the points in geometry frame and not the world frame?
+  //  1. Penetration as point pair returns the points in world frame.
+  //  2. FCL computes it in world frame.
+  //  3. Generally, MBP would want the points in *body* frame. MBP has access
+  //     to X_WB but does *not* generally have access to X_BG (it would have to
+  //     query QueryObject for that information). Although, such a query can
+  //     easily be provided.
   /** The witness point on geometry A's surface, expressed in A's frame. */
   Vector3<T> p_ACa;
   /** The witness point on geometry B's surface, expressed in B's frame. */

--- a/tools/workspace/fcl/repository.bzl
+++ b/tools/workspace/fcl/repository.bzl
@@ -8,8 +8,8 @@ def fcl_repository(
     github_archive(
         name = name,
         repository = "flexible-collision-library/fcl",
-        commit = "8fb2ce0e3463ab7e431d4e5afee05724d45c2eeb",
-        sha256 = "24a81577b6b01b17755e1bd38dfd0a35439ae0c559f787a3da44052a2b0373db",  # noqa
+        commit = "91d9d4d5735e44f91ba9df013c9fcd16a22938e4",
+        sha256 = "bf878bcd92f97f5eea697896812014985bad3c98032abf8e72123b673db2cbeb",  # noqa
         build_file = "@drake//tools/workspace/fcl:package.BUILD.bazel",
         mirrors = mirrors,
     )


### PR DESCRIPTION
1. Pick up guard in EPA function for degenerate faces.
2. Pick up correction to distance queries.
3. Pick up primitive cylinder-sphere collision and distance functions.
4. This required an incidental change to reporting signed distance queries; the nearest points were transformed *back* from world frames into the geometries' frames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9257)
<!-- Reviewable:end -->
