### PR TITLE
Formally initialize place holders in FrameKinematicsVector

### DIFF
--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -11,6 +11,35 @@
 namespace drake {
 namespace geometry {
 
+#ifndef DRAKE_DOXYGEN_CXX
+namespace detail {
+
+// A type-traits-style initializer for making sure that quantities in the frame
+// kinematics vector are initialized. This is because Eigen actively does *not*
+// initialize its data types and there is a code path by which uninitialized
+// values in the vector can be accessed.
+
+template <typename Value>
+struct KinematicsValueInitializer {
+  static void Initialize(Value* value) {
+    std::logic_error("Unsupported kinematics value");
+  }
+};
+
+template <typename S>
+struct KinematicsValueInitializer<Isometry3<S>> {
+  static void Initialize(Isometry3<S>* value) {
+    value->setIdentity();
+  }
+};
+
+// TODO(SeanCurtis-TRI): Add specializations for SpatialVelocity and
+// SpatialAcceleration (setting them to zero vectors) as those quantities are
+// added to SceneGraph.
+
+}  // namespace detail
+#endif  // DRAKE_DOXYGEN_CXX
+
 /** A %FrameKinematicsVector is used to report kinematics data for registered
  frames (identified by unique FrameId values) to SceneGraph.
  It serves as the basis of FramePoseVector, FrameVelocityVector, and
@@ -182,6 +211,9 @@ class FrameKinematicsVector {
  private:
   // Utility function to help catch misuse.
   struct FlaggedValue {
+    FlaggedValue() {
+      detail::KinematicsValueInitializer<KinematicsValue>::Initialize(&value);
+    }
     int64_t version{0};
     KinematicsValue value;
   };

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -13,6 +13,13 @@ namespace drake {
 namespace geometry {
 namespace test {
 
+::testing::AssertionResult ExpectExactIdentity(const Isometry3<double>& pose) {
+  const Isometry3<double> I = Isometry3<double>::Identity();
+  return CompareMatrices(pose.matrix().block<3, 4>(0, 0),
+                         I.matrix().block<3, 4>(0, 0));
+}
+
+
 GTEST_TEST(FrameKinematicsVector, Constructor) {
   SourceId source_id = SourceId::get_new_id();
 
@@ -28,6 +35,11 @@ GTEST_TEST(FrameKinematicsVector, Constructor) {
 
   EXPECT_EQ(poses2.source_id(), source_id);
   EXPECT_EQ(poses2.size(), kCount);
+
+  // Confirm that the values are properly initialized.
+  for (int i = 0; i < kCount; ++i) {
+    EXPECT_TRUE(ExpectExactIdentity(poses2.value(ids[i])));
+  }
 
   FrameId duplicate = FrameId::get_new_id();
   std::vector<FrameId> duplicate_ids{duplicate, FrameId::get_new_id(),


### PR DESCRIPTION
Previous state of affairs.
  1. Eigen does not initialize its types and
  2. there is a workflow via which uninitialized values in a
     FrameKinematicsVector can be initialized.

This patch guarantees initialization to prevent potential compiler or test errors sensitive to this initialization.

Closes #9233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9259)
<!-- Reviewable:end -->
