### PR TITLE
Fix integrator timeouts due to cache invalidation with no active caching

### DIFF
--- a/systems/analysis/BUILD.bazel
+++ b/systems/analysis/BUILD.bazel
@@ -250,6 +250,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "explicit_euler_integrator_test",
+    timeout = "moderate",
     deps = [
         ":explicit_euler_integrator",
         "//systems/analysis/test_utilities",
@@ -258,8 +259,12 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "implicit_euler_integrator_test",
-    # Test timeout increased to not timeout when run with Valgrind.
     timeout = "moderate",
+    # Adding cache invalidation made this take too long with Valgrind.
+    # See Drake issue #9261.
+    tags = [
+        "no_memcheck",
+    ],
     deps = [
         ":implicit_euler_integrator",
         "//systems/analysis/test_utilities",
@@ -300,6 +305,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "semi_explicit_euler_integrator_test",
+    timeout = "moderate",
     deps = [
         ":explicit_euler_integrator",
         ":semi_explicit_euler_integrator",
@@ -311,6 +317,7 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "initial_value_problem_test",
+    timeout = "moderate",
     deps = [
         ":initial_value_problem",
         ":runge_kutta2_integrator",


### PR DESCRIPTION
Four long integrator tests went over their time limits in memcheck/asan builds as reported by buildcop in PR #9258. This is due to the new cache invalidation code. The memcheck builds have Debug enabled and there are a lot of Debug-only expensive bugcatchers in caching. I looked at a sampling of Release build times and see much smaller penalties for cache invalidation.

I propose to
- adjust the time limits on the four integrator tests
- file an issue (#9261) to do a performance study of cache invalidation and optimize it further

rather than revert and wait for that study. 

This PR adds time to the shorter three tests and disables memcheck of the longest one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9260)
<!-- Reviewable:end -->
