### PR TITLE
install: Increase test timeout

### DIFF
--- a/tools/install/install.bzl
+++ b/tools/install/install.bzl
@@ -867,10 +867,12 @@ def install_test(
     drake_py_unittest(
         name = name,
         # This is an integration test with significant I/O that requires at
-        # least a "moderate" timeout so that debug builds are successful.
-        # Therefore, the test size is increased to "medium".
+        # least a "long" timeout so that debug builds are successful.
+        # Therefore, the test size is increased to "medium", and the timeout to
+        # "long".
         size = "medium",
         srcs = [src],
+        timeout = "long",
         deps = ["//tools/install:install_test_helper"],
         **kwargs
     )


### PR DESCRIPTION
Resolves #9264.

Per the issue, perhaps we wait to see if flakiness subsides; otherwise, we increase just the timeout (not the resources, unless that would be useful).

\cc @fbudin69500 @jamiesnape

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9265)
<!-- Reviewable:end -->
