### PR TITLE
Do not regex test failures since CDash can now handle Bazel test output natively

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -17,12 +17,10 @@ list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
   "^${ESC}\\[(33mDEBUG|35mWARNING): ${ESC}\\[0m"
 )
 
-# ERROR, FAIL, and TIMEOUT may be colored red (CSI 31m) and bolded (CSI 1m).
+# ERROR may be colored red (CSI 31m) and bolded (CSI 1m).
 list(APPEND CTEST_CUSTOM_ERROR_MATCH
   "^ERROR: "
-  "^FAIL: "
-  "^TIMEOUT: "
-  "^${ESC}\\[31m${ESC}\\[1m(ERROR|FAIL|TIMEOUT): ${ESC}\\[0m"
+  "^${ESC}\\[31m${ESC}\\[1mERROR: ${ESC}\\[0m"
 )
 
 # Ignore various Mac CROSSTOOL-related warnings.


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9266)
<!-- Reviewable:end -->
