### PR TITLE
Improve explicit theta_dot treatment in Multilane's Builder

### DIFF
--- a/automotive/maliput/multilane/BUILD.bazel
+++ b/automotive/maliput/multilane/BUILD.bazel
@@ -112,6 +112,7 @@ drake_cc_googletest(
         ":builder",
         "//automotive/maliput/api/test_utilities",
         "//automotive/maliput/multilane/test_utilities",
+        "//common:essential",
         "//common/test_utilities:eigen_matrix_compare",
     ],
 )

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -59,9 +59,9 @@ class StartReference {
   }
 
   /// Builds a Spec at `connection`'s `end` side with `direction` direction.
-  /// When `direction` == `Direction::kReverse`, `endpoint` is reversed.
-  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
-  /// continuity constraints.
+  /// `connection`'s theta_dot at the given `end` will be ignored by the new
+  /// Spec so that the Builder can adjust it to match road continuity
+  /// constraints.
   Spec at(const Connection& connection, api::LaneEnd::Which end,
           Direction direction) const {
     Endpoint endpoint = end == api::LaneEnd::Which::kStart ? connection.start()
@@ -121,7 +121,8 @@ class StartLane {
 
   /// Builds a Spec at `endpoint` with `direction` direction. When
   /// `direction` == `Direction::kReverse`, `endpoint` is reversed.
-  /// `endpoint`'s theta_dot must be nullopt.
+  /// Additionally, `endpoint`'s theta_dot must be nullopt. Otherwise
+  /// the Builder is unable to match road continuity constraints.
   Spec at(const Endpoint& endpoint, Direction direction) const {
     DRAKE_DEMAND(!endpoint.z().theta_dot().has_value());
     return direction == Direction::kForward
@@ -130,13 +131,12 @@ class StartLane {
   }
 
   /// Builds a Spec at `connection`'s `lane_id` lane at `end` side with
-  /// `direction` direction. When `direction` == `Direction::kReverse`,
-  /// `endpoint` is reversed.
+  /// `direction` direction. `connection`'s theta_dot at the given `end`
+  /// will be ignored by the new Spec so that the Builder can adjust it
+  /// to match road continuity constraints.
   ///
   /// `lane_id` must be non-negative and smaller than `connection`'s number of
   /// lanes.
-  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
-  /// continuity constraints.
   Spec at(const Connection& connection, int lane_id, api::LaneEnd::Which end,
           Direction direction) const {
     DRAKE_DEMAND(lane_id >= 0 && lane_id < connection.num_lanes());
@@ -189,10 +189,9 @@ class EndReference {
   EndReference() = default;
 
   /// Builds a Spec at `connection`'s `end` side with `direction` direction.
-  /// When `direction` == `Direction::kReverse`, `end`-side endpoint's
-  /// EndpointZ is reversed.
-  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
-  /// continuity constraints.
+  /// `connection`'s theta_dot at the given `end` will be ignored by the new
+  /// Spec so that the Builder can adjust it to match road continuity
+  /// constraints.
   Spec z_at(const Connection& connection, api::LaneEnd::Which end,
             Direction direction) const {
     EndpointZ endpoint_z = end == api::LaneEnd::Which::kStart
@@ -258,13 +257,12 @@ class EndLane {
   }
 
   /// Builds a Spec at `connection`'s `end` side with `direction` direction.
-  /// When `direction` == `Direction::kReverse`, `end`-side endpoint's
-  /// EndpointZ is reversed.
+  /// `connection`'s theta_dot at the given `end` will be ignored by the new
+  /// Spec so that the Builder can adjust it to match road continuity
+  /// constraints.
   ///
   /// `lane_id` must be non-negative and smaller than `connection`'s number of
   /// lanes.
-  /// Spec's theta_dot will be cleared so the Builder adjusts it to match
-  /// continuity constraints.
   Spec z_at(const Connection& connection, int lane_id, api::LaneEnd::Which end,
             Direction direction) const {
     DRAKE_DEMAND(lane_id >= 0 && lane_id < connection.num_lanes());
@@ -279,7 +277,8 @@ class EndLane {
 
   /// Builds an Spec at `endpoint_z` with `direction` direction.
   /// When `direction` == `Direction::kReverse`, `endpoint_z` is reversed.
-  /// `endpoint_z`'s theta_dot must be nullopt.
+  /// Additionally, `endpoint`'s theta_dot must be nullopt. Otherwise
+  /// the Builder is unable to match road continuity constraints.
   Spec z_at(const EndpointZ& endpoint_z, Direction direction) const {
     DRAKE_DEMAND(!endpoint_z.theta_dot().has_value());
     return direction == Direction::kForward
@@ -471,6 +470,8 @@ class BuilderBase {
       const std::vector<const Connection*>& connections) = 0;
 
   /// Produces a RoadGeometry, with the ID `id`.
+  /// @throws std::runtime_error if unable to produce a valid
+  ///                            (i.e. G1) RoadGeometry.
   virtual std::unique_ptr<const api::RoadGeometry> Build(
       const api::RoadGeometryId& id) const = 0;
 };
@@ -522,6 +523,16 @@ class BuilderFactoryBase {
 /// Segment bearing multiple Lanes. Each Group yields a Junction containing
 /// the Segments associated with the grouped Connections; ungrouped
 /// Connections each receive their own Junction.
+///
+/// At Endpoints where theta_dot (i.e. the rate of change of superelevation with
+/// respect to an arc-length coordinate t that travels along the Connection
+/// curve’s projection over the z = 0 plane) has not been explicitly specified
+/// the Builder will automatically calculate theta_dot values to preserve G1
+/// continuity across Connections. theta_dot values can only be explicitly
+/// specified for a Connection created from a reference curve with an explicit
+/// start or end Endpoint. However, specifying an explicit theta_dot may cause
+/// Builder::Build() to throw if it cannot assemble a G1 continuous
+/// RoadGeometry.
 ///
 /// Specific suffixes are used to name Maliput entities. The following list
 /// explains the naming convention:

--- a/automotive/maliput/multilane/circuit.yaml
+++ b/automotive/maliput/multilane/circuit.yaml
@@ -14,32 +14,32 @@ maliput_multilane_builder:
   points:
     a:
       xypoint: [0, 0, 0]
-      zpoint: [0, 0, 0, 0]
+      zpoint: [0, 0, 0]
     b:
       xypoint: [50, 5, 0]
-      zpoint: [0, 0, 0, 0]
+      zpoint: [0, 0, 0]
   connections:
     s1:
       lanes: [3, 0, 0]
       start: ["ref", "points.a.forward"]
       length: 50
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s2:
       lanes: [1, 0, 10]
       start: ["ref", "connections.s1.end.ref.forward"]
       arc: [20, 180]
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s3:
       lanes: [1, 0, 10]
       start: ["ref", "connections.s2.end.ref.forward"]
       length: 40
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s4:
       lanes: [1, 0, 10]
       right_shoulder: 0
       start: ["ref", "connections.s3.end.ref.forward"]
       length: 10
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s5:
       lanes: [2, 0, 5]
       start: ["ref", "connections.s4.end.ref.forward"]
@@ -49,38 +49,40 @@ maliput_multilane_builder:
       lanes: [2, 0, -5]
       start: ["ref", "points.b.forward"]
       arc: [20, -180]
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s7:
       lanes: [2, 0, -5]
       start: ["ref", "connections.s6.end.ref.forward"]
       length: 50
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s8:
       lanes: [2, 0, -5]
       start: ["ref", "connections.s7.end.ref.forward"]
       arc: [20, -180]
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s9:
       lanes: [1, 0, 0]
       right_shoulder: 0
       start: ["ref", "connections.s7.end.ref.forward"]
       arc: [20, 30.5]
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
     s10:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s9.end.ref.forward"]
       arc: [20, 59.5]
-      z_end: ["ref", [5, 0.5, -15, 0.7255]]
+      z_end: ["ref", [5, 0.5, -15]]  # theta_dot is left unspecified for the
+                                     # Builder to properly adjust it to match
+                                     # continuity constraints.
     s11:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s10.end.ref.forward"]
       arc: [20, 90]
-      z_end: ["ref", [10, 0, -15, 0]]
+      z_end: ["ref", [10, 0, -15]]
     s12:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s11.end.ref.forward"]
       arc: [20, 90]
-      z_end: ["ref", [10, 0, 0, 0]]
+      z_end: ["ref", [10, 0, 0]]
     s13:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s12.end.ref.forward"]
@@ -90,18 +92,18 @@ maliput_multilane_builder:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s13.end.ref.forward"]
       length: 30
-      z_end: ["ref", [-10, 0, 0, 0]]
+      z_end: ["ref", [-10, 0, 0]]
     s15:
       lanes: [1, 0, 0]
       start: ["ref", "connections.s14.end.ref.forward"]
       length: 20
-      z_end: ["ref", [-10, 0, 0, 0]]
+      z_end: ["ref", [-10, 0, 0]]
     s16:
       lanes: [1, 0, 0]
       left_shoulder: 0
       start: ["ref", "connections.s15.end.ref.forward"]
       arc: [20, 90]
-      z_end: ["ref", [0, 0, 0, 0]]
+      z_end: ["ref", [0, 0, 0]]
   groups:
     g1: [s2, s6]
     g2: [s5, s9, s12]


### PR DESCRIPTION
Connected to #8899. Initially intended to introduce a missing test, after some discussion with @maddog-tri and @agalbachicar this pull request evolved to provide:
- better documentation on how _theta_dot_ is handled in Multilane's `Builder` class,
- additional continuity checks on `Builder::Build()` method call to cope with API misuse,
- two tests demonstrating proper and inappropriate usage of `Builder` API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9270)
<!-- Reviewable:end -->
