### PR TITLE
Provide maliput::geometry_base, basic implementation of the object graph

### DIFF
--- a/automotive/maliput/geometry_base/BUILD.bazel
+++ b/automotive/maliput/geometry_base/BUILD.bazel
@@ -1,0 +1,68 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_binary",
+    "drake_cc_googletest",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load(
+    "@drake//tools/skylark:drake_py.bzl",
+    "drake_py_unittest",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "geometry_base",
+    deps = [
+        ":everything",
+    ],
+)
+
+drake_cc_library(
+    name = "everything",
+    srcs = [
+        "branch_point.cc",
+        "junction.cc",
+        "lane.cc",
+        "road_geometry.cc",
+        "segment.cc",
+    ],
+    hdrs = [
+        "branch_point.h",
+        "junction.h",
+        "lane.h",
+        "lane_end_set.h",
+        "passkey.h",
+        "road_geometry.h",
+        "segment.h",
+    ],
+    deps = [
+        "//automotive/maliput/api",
+        "//common:essential",
+        "//common:unused",
+        "//math:geometric_transform",
+        "//math:saturate",
+    ],
+)
+
+# === test/ ===
+
+drake_cc_googletest(
+    name = "geometry_base_test",
+    srcs = [
+        "test/geometry_base_test.cc",
+    ],
+    deps = [
+        ":everything",
+        "//automotive/maliput/api/test_utilities",
+        "//automotive/maliput/api/test_utilities:maliput_types_compare",
+        "//automotive/maliput/geometry_base/test_utilities:mock_geometry",
+        "//common/test_utilities:eigen_matrix_compare",
+    ],
+)
+
+add_lint_tests()

--- a/automotive/maliput/geometry_base/branch_point.cc
+++ b/automotive/maliput/geometry_base/branch_point.cc
@@ -1,0 +1,95 @@
+#include "drake/automotive/maliput/geometry_base/branch_point.h"
+
+#include "drake/automotive/maliput/geometry_base/lane.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+BranchPoint::BranchPoint(const api::BranchPointId& id) : id_(id) {}
+
+void BranchPoint::AttachToRoadGeometry(
+    Passkey<RoadGeometry>,
+    const api::RoadGeometry* road_geometry) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(road_geometry != nullptr);
+  // Preconditions
+  DRAKE_THROW_UNLESS(road_geometry_ == nullptr);
+  road_geometry_ = road_geometry;
+}
+
+
+void BranchPoint::AddBranch(Lane* lane, api::LaneEnd::Which end,
+                            LaneEndSet* side) {
+  // Parameter checks
+  // TODO(maddog@tri.global)  This invariant should be part of api::LaneEnd.
+  DRAKE_THROW_UNLESS(lane != nullptr);
+  DRAKE_THROW_UNLESS((side == &a_side_) || (side == &b_side_));
+  // Preconditions
+  const api::LaneEnd lane_end{lane, end};
+  DRAKE_THROW_UNLESS(confluent_branches_.count(lane_end) == 0);
+  DRAKE_THROW_UNLESS(ongoing_branches_.count(lane_end) == 0);
+  LaneEndSet* const other_side = (side == &a_side_) ? &b_side_ : &a_side_;
+  side->Add(lane_end);
+  confluent_branches_[lane_end] = side;
+  ongoing_branches_[lane_end] = other_side;
+  switch (end) {
+    case api::LaneEnd::kStart:  {
+      lane->SetStartBranchPoint({}, this);
+      break;
+    }
+    case api::LaneEnd::kFinish: {
+      lane->SetFinishBranchPoint({}, this);
+      break;
+    }
+  }
+}
+
+
+void BranchPoint::SetDefault(const api::LaneEnd& lane_end,
+                             const api::LaneEnd& default_branch) {
+  // Parameter checks
+  const auto& le_ongoing = ongoing_branches_.find(lane_end);
+  const auto& db_confluent = confluent_branches_.find(default_branch);
+  // Verify that lane_end belongs to this BranchPoint.
+  DRAKE_THROW_UNLESS(le_ongoing != ongoing_branches_.end());
+  // Verify that default_branch belongs to this BranchPoint.
+  DRAKE_THROW_UNLESS(db_confluent != confluent_branches_.end());
+  // Verify that default_branch is an ongoing lane for lane_end.
+  DRAKE_THROW_UNLESS(db_confluent->second == le_ongoing->second);
+
+  defaults_[lane_end] = default_branch;
+}
+
+
+const api::BranchPointId BranchPoint::do_id() const { return id_; }
+
+const api::RoadGeometry* BranchPoint::do_road_geometry() const {
+  return road_geometry_;
+}
+
+const api::LaneEndSet* BranchPoint::DoGetConfluentBranches(
+    const api::LaneEnd& end) const {
+  return confluent_branches_.at(end);
+}
+
+const api::LaneEndSet* BranchPoint::DoGetOngoingBranches(
+    const api::LaneEnd& end) const {
+  return ongoing_branches_.at(end);
+}
+
+optional<api::LaneEnd> BranchPoint::DoGetDefaultBranch(
+    const api::LaneEnd& end) const {
+  auto default_it = defaults_.find(end);
+  if (default_it == defaults_.end()) { return nullopt; }
+  return default_it->second;
+}
+
+const api::LaneEndSet* BranchPoint::DoGetASide() const { return &a_side_; }
+
+const api::LaneEndSet* BranchPoint::DoGetBSide() const { return &b_side_; }
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/branch_point.h
+++ b/automotive/maliput/geometry_base/branch_point.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/geometry_base/lane_end_set.h"
+#include "drake/automotive/maliput/geometry_base/passkey.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+class BranchPoint;
+class Lane;
+class RoadGeometry;
+
+/// geometry_base's implementation of api::BranchPoint.
+class BranchPoint : public api::BranchPoint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(BranchPoint);
+
+  /// Constructs an empty BranchPoint.
+  ///
+  /// @param id the ID of the BranchPoint
+  ///
+  /// The BranchPoint is not fully initialized until it is added to a
+  /// RoadGeometry.
+  explicit BranchPoint(const api::BranchPointId& id);
+
+  /// Adds the @p end of @p lane to the "A side" of this BranchPoint.
+  ///
+  /// @throws std::exception if `lane` is nullptr.
+  void AddABranch(Lane* lane, api::LaneEnd::Which end) {
+    AddBranch(lane, end, &a_side_);
+  }
+
+  /// Adds the @p end of @p lane to the "B side" of this BranchPoint.
+  ///
+  /// @throws std::exception if `lane` is nullptr.
+  void AddBBranch(Lane* lane, api::LaneEnd::Which end) {
+    AddBranch(lane, end, &b_side_);
+  }
+
+  /// Sets the default branch for @p lane_end to @p default_branch.
+  ///
+  /// @throws std::exception if the specified LaneEnds do not belong
+  ///         to opposite sides of this BranchPoint.
+  void SetDefault(const api::LaneEnd& lane_end,
+                  const api::LaneEnd& default_branch);
+
+  ~BranchPoint() override = default;
+
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Notifies BranchPoint of its parent RoadGeometry.
+  // This may only be called, once, by a RoadGeometry.
+  //
+  // @param road_geometry  the parent RoadGeometry
+  //
+  // @pre `road_geometry` is non-null.
+  // @pre Parent RoadGeometry has not already been set.
+  void AttachToRoadGeometry(Passkey<RoadGeometry>,
+                            const api::RoadGeometry* road_geometry);
+#endif  // DRAKE_DOXYGEN_CXX
+
+ private:
+  // Common implementation for AddABranch() and AddBBranch().
+  void AddBranch(Lane* lane, api::LaneEnd::Which end, LaneEndSet* side);
+
+  const api::BranchPointId do_id() const override;
+
+  const api::RoadGeometry* do_road_geometry() const override;
+
+  const api::LaneEndSet* DoGetConfluentBranches(
+      const api::LaneEnd& end) const override;
+
+  const api::LaneEndSet* DoGetOngoingBranches(
+      const api::LaneEnd& end) const override;
+
+  optional<api::LaneEnd> DoGetDefaultBranch(
+      const api::LaneEnd& end) const override;
+
+  const api::LaneEndSet* DoGetASide() const override;
+
+  const api::LaneEndSet* DoGetBSide() const override;
+
+  api::BranchPointId id_;
+  const api::RoadGeometry* road_geometry_{};
+  LaneEndSet a_side_;
+  LaneEndSet b_side_;
+
+  std::map<api::LaneEnd, LaneEndSet*,
+           api::LaneEnd::StrictOrder> confluent_branches_;
+  std::map<api::LaneEnd, LaneEndSet*,
+           api::LaneEnd::StrictOrder> ongoing_branches_;
+  std::map<api::LaneEnd, api::LaneEnd,
+           api::LaneEnd::StrictOrder> defaults_;
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/junction.cc
+++ b/automotive/maliput/geometry_base/junction.cc
@@ -1,0 +1,59 @@
+#include "drake/automotive/maliput/geometry_base/junction.h"
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+void Junction::AttachToRoadGeometry(
+    Passkey<RoadGeometry>,
+    const api::RoadGeometry* road_geometry,
+    const std::function<void(const api::Segment*)>& segment_indexing_callback,
+    const std::function<void(const api::Lane*)>& lane_indexing_callback) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(road_geometry != nullptr);
+  DRAKE_THROW_UNLESS(!!segment_indexing_callback);
+  DRAKE_THROW_UNLESS(!!lane_indexing_callback);
+  // Preconditions
+  DRAKE_THROW_UNLESS(road_geometry_ == nullptr);
+  DRAKE_THROW_UNLESS(!segment_indexing_callback_);
+  DRAKE_THROW_UNLESS(!lane_indexing_callback_);
+
+  road_geometry_ = road_geometry;
+  // Store the indexing callbacks for future use.
+  segment_indexing_callback_ = segment_indexing_callback;
+  lane_indexing_callback_ = lane_indexing_callback;
+
+  // Index any Segments that had already been added to this Junction.
+  for (auto& segment : segments_) {
+    segment_indexing_callback_(segment.get());
+    segment->SetLaneIndexingCallback({}, lane_indexing_callback_);
+  }
+}
+
+
+void Junction::AddSegmentPrivate(std::unique_ptr<Segment> segment) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(segment.get() != nullptr);
+  segments_.emplace_back(std::move(segment));
+  Segment* const raw_segment = segments_.back().get();
+
+  raw_segment->AttachToJunction({}, this);
+  if (segment_indexing_callback_) {
+    segment_indexing_callback_(raw_segment);
+  }
+  if (lane_indexing_callback_) {
+    raw_segment->SetLaneIndexingCallback({}, lane_indexing_callback_);
+  }
+}
+
+
+const api::RoadGeometry* Junction::do_road_geometry() const {
+  return road_geometry_;
+}
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/junction.h
+++ b/automotive/maliput/geometry_base/junction.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/geometry_base/passkey.h"
+#include "drake/automotive/maliput/geometry_base/segment.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+class RoadGeometry;
+
+/// geometry_base's implementation of api::Junction.
+class Junction : public api::Junction {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Junction);
+
+  /// Constructs a Junction.
+  ///
+  /// @param id the ID of the Junction
+  ///
+  /// The Junction is not fully initialized until it is added to a
+  /// RoadGeometry.
+  explicit Junction(const api::JunctionId& id) : id_(id) {}
+
+  /// Adds @p segment to this Junction.
+  ///
+  /// This Junction will take ownership of `segment` and will be assigned
+  /// as its parent.
+  ///
+  /// @returns `segment`'s raw pointer.
+  ///
+  /// @tparam T must be derived from geometry_base::Segment.
+  ///
+  /// @throws std::exception if `segment` is empty.
+  template <class T>
+  T* AddSegment(std::unique_ptr<T> segment) {
+    static_assert(std::is_base_of<Segment, T>::value,
+                  "T is not derived from geometry_base::Segment");
+    T* const raw_pointer = segment.get();
+    AddSegmentPrivate(std::move(segment));
+    return raw_pointer;
+  }
+
+  ~Junction() override = default;
+
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Notifies Junction of its parent RoadGeometry.
+  // This may only be called, once, by a RoadGeometry.
+  //
+  // @param road_geometry  the parent RoadGeometry
+  // @param segment_indexing_callback  function to be called on every Segment
+  //                                   which is attached to this Junction,
+  //                                   both now and in the future
+  // @param lane_indexing_callback  function to be called on every Lane
+  //                                which is attached to this Junction (via
+  //                                a Segment), both now and in the future
+  //
+  // @pre `road_geometry` is non-null.
+  // @pre `segment_indexing_callback` is non-empty.
+  // @pre `lane_indexing_callback` is non-empty.
+  // @pre Parent RoadGeometry and the callbacks have not already been set.
+  void AttachToRoadGeometry(
+      Passkey<RoadGeometry>,
+      const api::RoadGeometry* road_geometry,
+      const std::function<void(const api::Segment*)>& segment_indexing_callback,
+      const std::function<void(const api::Lane*)>& lane_indexing_callback);
+#endif  // DRAKE_DOXYGEN_CXX
+
+ private:
+  // The non-template implementation of AddSegment<T>()
+  void AddSegmentPrivate(std::unique_ptr<Segment> segment);
+
+  const api::JunctionId do_id() const override { return id_; }
+
+  const api::RoadGeometry* do_road_geometry() const override;
+
+  int do_num_segments() const override { return segments_.size(); }
+
+  const api::Segment* do_segment(int index) const override {
+    return segments_.at(index).get();
+  }
+
+  const api::JunctionId id_;
+  const api::RoadGeometry* road_geometry_{};
+  std::function<void(const api::Segment*)> segment_indexing_callback_;
+  std::function<void(const api::Lane*)> lane_indexing_callback_;
+  std::vector<std::unique_ptr<Segment>> segments_;
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/lane.cc
+++ b/automotive/maliput/geometry_base/lane.cc
@@ -1,0 +1,93 @@
+#include "drake/automotive/maliput/geometry_base/lane.h"
+
+#include "drake/automotive/maliput/geometry_base/branch_point.h"
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+void Lane::AttachToSegment(Passkey<Segment>,
+                           const api::Segment* segment, int index) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(segment != nullptr);
+  DRAKE_THROW_UNLESS(index >= 0);
+  // Preconditions
+  DRAKE_THROW_UNLESS(segment_ == nullptr);
+  DRAKE_THROW_UNLESS(index_ == -1);
+
+  segment_ = segment;
+  index_ = index;
+}
+
+void Lane::SetStartBranchPoint(Passkey<BranchPoint>,
+                               BranchPoint* branch_point) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(branch_point != nullptr);
+  // Preconditions
+  DRAKE_THROW_UNLESS(start_branch_point_ == nullptr);
+
+  start_branch_point_ = branch_point;
+}
+
+void Lane::SetFinishBranchPoint(Passkey<BranchPoint>,
+                                BranchPoint* branch_point) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(branch_point != nullptr);
+  // Preconditions
+  DRAKE_THROW_UNLESS(finish_branch_point_ == nullptr);
+
+  finish_branch_point_ = branch_point;
+}
+
+
+const api::LaneId Lane::do_id() const { return id_; }
+
+const api::Segment* Lane::do_segment() const { return segment_; }
+
+int Lane::do_index() const { return index_; }
+
+const api::Lane* Lane::do_to_left() const {
+  if (index_ == (segment_->num_lanes() - 1)) {
+    return nullptr;
+  } else {
+    return segment_->lane(index_ + 1);
+  }
+}
+
+const api::Lane* Lane::do_to_right() const {
+  if (index_ == 0) {
+    return nullptr;
+  } else {
+    return segment_->lane(index_ - 1);
+  }
+}
+
+const api::BranchPoint* Lane::DoGetBranchPoint(
+    const api::LaneEnd::Which which_end) const {
+  switch (which_end) {
+    case api::LaneEnd::kStart:  { return start_branch_point_; }
+    case api::LaneEnd::kFinish: { return finish_branch_point_; }
+  }
+  DRAKE_ABORT();
+}
+
+const api::LaneEndSet* Lane::DoGetConfluentBranches(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetConfluentBranches({this, which_end});
+}
+
+const api::LaneEndSet* Lane::DoGetOngoingBranches(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetOngoingBranches({this, which_end});
+}
+
+optional<api::LaneEnd> Lane::DoGetDefaultBranch(
+    api::LaneEnd::Which which_end) const {
+  return GetBranchPoint(which_end)->GetDefaultBranch({this, which_end});
+}
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/lane.h
+++ b/automotive/maliput/geometry_base/lane.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/geometry_base/passkey.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_optional.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+class BranchPoint;
+class Segment;
+
+/// geometry_base's implementation of api::Lane.
+class Lane : public api::Lane {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Lane);
+
+  /// Constructs a Lane.
+  ///
+  /// @param id the ID of the Lane
+  ///
+  /// The Lane is not fully initialized until it is added to a Segment
+  /// and each end is added to (one or two) BranchPoints.
+  ///
+  /// The Lane's index will be assigned when it is added to a Segment.
+  explicit Lane(const api::LaneId& id) : id_(id) {}
+
+  /// Returns a mutable pointer to the BranchPoint at the start end,
+  /// or nullptr if the start end hasn't been added to a BranchPoint yet.
+  BranchPoint* mutable_start_branch_point() { return start_branch_point_; }
+
+  /// Returns a mutable pointer to the BranchPoint at the finish end,
+  /// or nullptr if the finish end hasn't been added to a BranchPoint yet.
+  BranchPoint* mutable_finish_branch_point() { return finish_branch_point_; }
+
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Notifies Lane of its parent Segment.
+  // This may only be called, once, by a Segment.
+  //
+  // @param segment  the parent Segment
+  // @param index  index of this Lane within `segment`
+  //
+  // @pre `segment` is non-null.
+  // @pre `index` is non-negative.
+  // @pre Parent Segment and the index have not already been set.
+  void AttachToSegment(Passkey<Segment>,
+                       const api::Segment* segment, int index);
+
+  // Notifies Lane of the BranchPoint for its "start" end.
+  // This may only be called, once, by a BranchPoint.
+  //
+  // @param branch_point  the BranchPoint
+  //
+  // @pre `branch_point` is non-null.
+  // @pre The "start" BranchPoint has not already been set.
+  void SetStartBranchPoint(Passkey<BranchPoint>, BranchPoint* branch_point);
+
+  // Notifies Lane of the BranchPoint for its "finish" end.
+  // This may only be called, once, by a BranchPoint.
+  //
+  // @param branch_point  the BranchPoint
+  //
+  // @pre `branch_point` is non-null.
+  // @pre The "finish" BranchPoint has not already been set.
+  void SetFinishBranchPoint(Passkey<BranchPoint>, BranchPoint* branch_point);
+#endif  // DRAKE_DOXYGEN_CXX
+
+  ~Lane() override = default;
+
+ private:
+  const api::LaneId do_id() const override;
+
+  const api::Segment* do_segment() const override;
+
+  int do_index() const override;
+
+  const api::Lane* do_to_left() const override;
+
+  const api::Lane* do_to_right() const override;
+
+  const api::BranchPoint* DoGetBranchPoint(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneEndSet* DoGetConfluentBranches(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneEndSet* DoGetOngoingBranches(
+      const api::LaneEnd::Which which_end) const override;
+
+  optional<api::LaneEnd> DoGetDefaultBranch(
+      const api::LaneEnd::Which which_end) const override;
+
+  const api::LaneId id_;
+  const api::Segment* segment_{};
+  int index_{-1};
+  BranchPoint* start_branch_point_{};
+  BranchPoint* finish_branch_point_{};
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/lane_end_set.h
+++ b/automotive/maliput/geometry_base/lane_end_set.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <vector>
+
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+
+/// geometry_base's implementation of api::LaneEndSet.
+class LaneEndSet : public api::LaneEndSet {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LaneEndSet);
+
+  /// Constructs an empty LaneEndSet.
+  LaneEndSet() = default;
+
+  /// Adds an api::LaneEnd to the set.
+  ///
+  /// @throws std::exception if `end.lane` is nullptr.
+  void Add(const api::LaneEnd& end) {
+    // TODO(maddog@tri.global)  This assertion belongs in LaneEnd itself.
+    DRAKE_THROW_UNLESS(end.lane != nullptr);
+    ends_.push_back(end);
+  }
+
+  ~LaneEndSet() override = default;
+
+ private:
+  int do_size() const override { return ends_.size(); }
+
+  const api::LaneEnd&
+  do_get(int index) const override { return ends_.at(index); }
+
+  std::vector<api::LaneEnd> ends_;
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/passkey.h
+++ b/automotive/maliput/geometry_base/passkey.h
@@ -1,0 +1,32 @@
+#pragma once
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+/// Simple generic implementation of the "Passkey Idiom".
+///
+/// Passkey<T> allows a class to provide method-level friendship to another
+/// class.  By tagging an otherwise `public` method with a `Passkey<Other>`
+/// parameter, only the class `Other` will be able to construct the required
+/// passkey and call the method (typically using just `{}` to construct the
+/// passkey instance at the call site).
+///
+/// @see https://arne-mertz.de/2016/10/passkey-idiom/
+/// @see https://stackoverflow.com/questions/3324898/can-we-increase-the-re-usability-of-this-key-oriented-access-protection-pattern
+template <class T>
+class Passkey {
+ private:
+  // Only T may construct a Passkey<T>!
+  friend T;
+  // NB: These trivial methods *must not* be "= default", otherwise C++'s
+  //     "uniform initialization" will allow anyone to aggregate-construct
+  //     an instance, not just T.
+  Passkey() {}
+  Passkey(const Passkey&) {}
+  Passkey& operator=(const Passkey&) = delete;
+};
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/road_geometry.cc
+++ b/automotive/maliput/geometry_base/road_geometry.cc
@@ -1,0 +1,50 @@
+#include "drake/automotive/maliput/geometry_base/road_geometry.h"
+
+#include <utility>
+
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/lane_data.h"
+#include "drake/automotive/maliput/api/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+
+void RoadGeometry::AddJunctionPrivate(std::unique_ptr<Junction> junction) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(junction.get() != nullptr);
+  junctions_.emplace_back(std::move(junction));
+  Junction* const raw_junction = junctions_.back().get();
+  raw_junction->AttachToRoadGeometry(
+      {},
+      this,
+      [this](auto segment) { id_index_.AddSegment(segment); },
+      [this](auto lane) { id_index_.AddLane(lane); });
+  id_index_.AddJunction(raw_junction);
+}
+
+
+void RoadGeometry::AddBranchPointPrivate(
+    std::unique_ptr<BranchPoint> branch_point) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(branch_point.get() != nullptr);
+  branch_points_.emplace_back(std::move(branch_point));
+  BranchPoint* const raw_branch_point = branch_points_.back().get();
+  raw_branch_point->AttachToRoadGeometry({}, this);
+  id_index_.AddBranchPoint(raw_branch_point);
+}
+
+
+const api::Junction* RoadGeometry::do_junction(int index) const {
+  return junctions_.at(index).get();
+}
+
+const api::BranchPoint* RoadGeometry::do_branch_point(int index) const {
+  return branch_points_.at(index).get();
+}
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/road_geometry.h
+++ b/automotive/maliput/geometry_base/road_geometry.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "drake/automotive/maliput/api/basic_id_index.h"
+#include "drake/automotive/maliput/api/branch_point.h"
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/geometry_base/branch_point.h"
+#include "drake/automotive/maliput/geometry_base/junction.h"
+#include "drake/common/drake_copyable.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+/// @namespace drake::maliput::geometry_base
+///
+/// geometry_base provides basic implementations for a subset of the
+/// interfaces of maliput's geometry API (api::RoadGeometry, etc) that
+/// can be shared by most "leaf" backends.  It is suitable for use as
+/// base classes for a complete backend implementation, or for mock
+/// implementations for unit tests (such as
+/// test_utilities/mock_geometry.h).
+///
+/// geometry_base implements all the virtual methods involved in
+/// managing the object graph of the road network.  It does not
+/// implement any of the fundamental geometric methods that define the
+/// immersion of lane-frame into world-frame; that is the job of each
+/// specific backend.
+///
+/// TODO(maddog@tri.global) Provide a basic naive implementation of
+///                         RoadGeometry::DoToRoadPosition() which
+///                         only requires generic calls to
+///                         Lane::ToLanePosition().
+
+/// geometry_base's implementation of api::RoadGeometry.
+class RoadGeometry : public api::RoadGeometry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RoadGeometry);
+
+  /// Constructs an empty RoadGeometry with the specified tolerances.
+  ///
+  /// @param id the ID of the RoadGeometry
+  /// @param linear_tolerance the linear tolerance
+  /// @param angular_tolerance the angular tolerance
+  ///
+  /// @throws std::exception if either `linear_tolerance` or
+  ///         `angular_tolerance` is non-positive.
+  RoadGeometry(const api::RoadGeometryId& id,
+               double linear_tolerance, double angular_tolerance)
+      : id_(id),
+        linear_tolerance_(linear_tolerance),
+        angular_tolerance_(angular_tolerance) {
+    DRAKE_THROW_UNLESS(linear_tolerance_ > 0.);
+    DRAKE_THROW_UNLESS(angular_tolerance_ > 0.);
+  }
+
+  /// Adds @p junction to this RoadGeometry.
+  ///
+  /// This RoadGeometry will take ownership of `junction` and will be assigned
+  /// as its parent.
+  ///
+  /// @returns `junction`'s raw pointer.
+  ///
+  /// @tparam T must be derived from geometry_base::Junction.
+  ///
+  /// @throws std::exception if `junction` is empty.
+  template <class T>
+  T* AddJunction(std::unique_ptr<T> junction) {
+    static_assert(std::is_base_of<Junction, T>::value,
+                  "T is not derived from geometry_base::Junction");
+    T* const raw_pointer = junction.get();
+    AddJunctionPrivate(std::move(junction));
+    return raw_pointer;
+  }
+
+  /// Adds @p branch_point to this RoadGeometry.
+  ///
+  /// This RoadGeometry will take ownership of `branch_point` and will be
+  /// assigned as its parent.
+  ///
+  /// @returns `branch_point`'s raw pointer.
+  ///
+  /// @tparam T must be derived from geometry_base::BranchPoint.
+  ///
+  /// @throws std::exception if `branch_point` is empty.
+  template <class T>
+  T* AddBranchPoint(std::unique_ptr<T> branch_point) {
+    static_assert(std::is_base_of<BranchPoint, T>::value,
+                  "T is not derived from geometry_base::BranchPoint");
+    T* const raw_pointer = branch_point.get();
+    AddBranchPointPrivate(std::move(branch_point));
+    return raw_pointer;
+  }
+
+  ~RoadGeometry() override = default;
+
+ private:
+  // The non-template implementation of AddJunction<T>()
+  void AddJunctionPrivate(std::unique_ptr<Junction> junction);
+
+  // The non-template implementation of AddBranchPoint<T>()
+  void AddBranchPointPrivate(std::unique_ptr<BranchPoint> branch_point);
+
+  const api::RoadGeometryId do_id() const override { return id_; }
+
+  int do_num_junctions() const override { return junctions_.size(); }
+
+  const api::Junction* do_junction(int index) const override;
+
+  int do_num_branch_points() const override { return branch_points_.size(); }
+
+  const api::BranchPoint* do_branch_point(int index) const override;
+
+  const IdIndex& DoById() const override { return id_index_; }
+
+  double do_linear_tolerance() const override { return linear_tolerance_; }
+
+  double do_angular_tolerance() const override { return angular_tolerance_; }
+
+  api::RoadGeometryId id_;
+  double linear_tolerance_{};
+  double angular_tolerance_{};
+  std::vector<std::unique_ptr<Junction>> junctions_;
+  std::vector<std::unique_ptr<BranchPoint>> branch_points_;
+  api::BasicIdIndex id_index_;
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/segment.cc
+++ b/automotive/maliput/geometry_base/segment.cc
@@ -1,0 +1,62 @@
+#include "drake/automotive/maliput/geometry_base/segment.h"
+
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+const api::Junction* Segment::do_junction() const {
+  return junction_;
+}
+
+
+void Segment::AttachToJunction(Passkey<Junction>,
+                               const api::Junction* junction) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(junction != nullptr);
+  // Preconditions
+  DRAKE_THROW_UNLESS(junction_ == nullptr);
+
+  junction_ = junction;
+}
+
+
+void Segment::SetLaneIndexingCallback(
+    Passkey<Junction>,
+    const std::function<void(const api::Lane*)>& callback) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(!!callback);
+  // Preconditions
+  DRAKE_THROW_UNLESS(!lane_indexing_callback_);
+
+  lane_indexing_callback_ = callback;
+  // Index any Lanes that had already been added to this Segment.
+  for (const auto& lane : lanes_) {
+    lane_indexing_callback_(lane.get());
+  }
+}
+
+
+void Segment::AddLanePrivate(std::unique_ptr<Lane> lane) {
+  // Parameter checks
+  DRAKE_THROW_UNLESS(lane.get() != nullptr);
+  lanes_.emplace_back(std::move(lane));
+  Lane* const raw_lane = lanes_.back().get();
+
+  raw_lane->AttachToSegment({}, this, lanes_.size() - 1);
+  if (lane_indexing_callback_) {
+    lane_indexing_callback_(raw_lane);
+  }
+}
+
+
+
+const api::Lane* Segment::do_lane(int index) const {
+  return lanes_.at(index).get();
+}
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/segment.h
+++ b/automotive/maliput/geometry_base/segment.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "drake/automotive/maliput/api/junction.h"
+#include "drake/automotive/maliput/api/lane.h"
+#include "drake/automotive/maliput/api/road_geometry.h"
+#include "drake/automotive/maliput/api/segment.h"
+#include "drake/automotive/maliput/geometry_base/lane.h"
+#include "drake/automotive/maliput/geometry_base/passkey.h"
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+
+class Junction;
+
+/// geometry_base's implementation of api::Segment.
+class Segment : public api::Segment {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Segment);
+
+  /// Constructs a new Segment.
+  ///
+  /// @param id Segment's ID.
+  ///
+  /// The Segment is not fully initialized until it is added to a Junction.
+  explicit Segment(const api::SegmentId& id) : id_(id) {}
+
+
+  /// Adds @p lane to this Segment.
+  ///
+  /// This Segment will take ownership of `lane` and will be assigned
+  /// as its parent.  The index of `lane` will also be assigned, in
+  /// order of addition.  (The first Lane added to this Segment, by
+  /// the first call to AddLane(), will be assigned index 0.)
+  ///
+  /// Note that the maliput API requires that lanes are indexed in a Segment
+  /// in right-to-left order, thus `AddLane()` should be called on lanes
+  /// in right-to-left order.
+  ///
+  /// @returns `lane`'s raw pointer.
+  ///
+  /// @tparam T must be derived from geometry_base::Lane.
+  ///
+  /// @throws std::exception if `lane` is empty.
+  // TODO(maddog@tri.global)  Consider enforcing right-to-left order.  (The
+  //                          downside is that it makes these classes less
+  //                          useful for creating aberrant test cases.)
+  template <class T>
+  T* AddLane(std::unique_ptr<T> lane) {
+    static_assert(std::is_base_of<Lane, T>::value,
+                  "T is not derived from geometry_base::Lane");
+    T* const raw_pointer = lane.get();
+    AddLanePrivate(std::move(lane));
+    return raw_pointer;
+  }
+
+
+#ifndef DRAKE_DOXYGEN_CXX
+  // Notifies Segment of its parent Junction.
+  // This may only be called, once, by a Junction.
+  //
+  // @param junction  the parent Junction
+  //
+  // @pre `junction` is non-null.
+  // @pre Parent Junction has not already been set.
+  void AttachToJunction(Passkey<Junction>, const api::Junction* junction);
+
+  // Sets the lane indexing callback.
+  // This may only be called, once, by a Junction.
+  //
+  // @param callback  function to be called on every Lane which is attached
+  //                  to this Segment, both now and in the future
+  //
+  // @pre `callback` is non-empty.
+  // @pre The lane indexing callback has not already been set.
+  void SetLaneIndexingCallback(
+      Passkey<Junction>,
+      const std::function<void(const api::Lane*)>& callback);
+#endif  // DRAKE_DOXYGEN_CXX
+
+  ~Segment() override = default;
+
+ private:
+  // The non-template implementation of AddLane<T>()
+  void AddLanePrivate(std::unique_ptr<Lane> lane);
+
+  const api::SegmentId do_id() const override { return id_; }
+
+  const api::Junction* do_junction() const override;
+
+  int do_num_lanes() const override { return lanes_.size(); }
+
+  const api::Lane* do_lane(int index) const override;
+
+  const api::SegmentId id_;
+  const api::Junction* junction_{};
+  std::function<void(const api::Lane*)> lane_indexing_callback_;
+  std::vector<std::unique_ptr<Lane>> lanes_;
+};
+
+
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/test/geometry_base_test.cc
+++ b/automotive/maliput/geometry_base/test/geometry_base_test.cc
@@ -1,0 +1,415 @@
+/* clang-format off to disable clang-format-includes */
+#include "drake/automotive/maliput/geometry_base/test_utilities/mock_geometry.h"
+/* clang-format on */
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "drake/automotive/maliput/api/test_utilities/rules_test_utilities.h"
+
+namespace drake {
+namespace maliput {
+
+// TODO(maddog@tri.global) When the maliput test machinery is cleaned up (e.g.,
+//                         moved out of the `rules` namespace), these predicates
+//                         should become proper public-use predicates in the
+//                         api's test_utilities.
+namespace api {
+namespace rules {
+namespace test {
+
+// Predicate-formatter which tests equality of Lane*.
+inline ::testing::AssertionResult IsEqual(
+    const char* a_expression, const char* b_expression,
+    const api::Lane* a, const api::Lane* b) {
+  return ::testing::internal::CmpHelperEQ(a_expression, b_expression, a, b);
+}
+
+// Predicate-formatter which tests equality of LaneEnd.
+inline ::testing::AssertionResult IsEqual(
+    const char* a_expression, const char* b_expression,
+    const api::LaneEnd& a, const api::LaneEnd& b) {
+  unused(a_expression, b_expression);
+  AssertionResultCollector c;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.lane, b.lane));;
+  MALIPUT_ADD_RESULT(c, MALIPUT_IS_EQUAL(a.end, b.end));
+  return c.result();
+}
+
+}  // namespace test
+}  // namespace rules
+}  // namespace api
+
+namespace geometry_base {
+namespace test {
+namespace {
+
+GTEST_TEST(GeometryBaseTest, LaneEndSet) {
+  LaneEndSet dut;
+  EXPECT_EQ(dut.size(), 0);
+  EXPECT_THROW(dut.get(0), std::exception);
+
+  // NB:  LaneEndSet::Add() only tests for non-nullness of the lane pointer,
+  //      so we fake up a non-null pointer for this test.
+  const api::Lane* const kNonNullLane =
+      reinterpret_cast<api::Lane*>(0xDeadBeef);
+  const api::LaneEnd kValidLaneEnd{kNonNullLane, api::LaneEnd::kFinish};
+  const api::LaneEnd kInvalidLaneEnd{nullptr, api::LaneEnd::kFinish};
+
+  EXPECT_THROW(dut.Add(kInvalidLaneEnd), std::exception);
+  EXPECT_NO_THROW(dut.Add(kValidLaneEnd));
+  EXPECT_EQ(dut.size(), 1);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.get(0), kValidLaneEnd));
+}
+
+
+GTEST_TEST(GeometryBaseLaneTest, BasicConstruction) {
+  const MockLane dut(api::LaneId("dut"));
+  EXPECT_EQ(dut.id(), api::LaneId("dut"));
+}
+
+
+GTEST_TEST(GeometryBaseLaneTest, UnimplementedMethods) {
+  const MockLane dut(api::LaneId("dut"));
+  // Ensure that the not-actually-implemented methods throw an exception.
+  EXPECT_THROW(dut.length(), std::exception);
+  EXPECT_THROW(dut.lane_bounds(0.), std::exception);
+  EXPECT_THROW(dut.driveable_bounds(0.), std::exception);
+  EXPECT_THROW(dut.elevation_bounds(0., 0.), std::exception);
+  EXPECT_THROW(dut.ToGeoPosition(api::LanePosition()), std::exception);
+  EXPECT_THROW(dut.GetOrientation(api::LanePosition()), std::exception);
+  EXPECT_THROW(dut.EvalMotionDerivatives(api::LanePosition(),
+                                         api::IsoLaneVelocity()),
+               std::exception);
+  EXPECT_THROW(dut.ToLanePosition(
+      api::GeoPosition(), nullptr, nullptr), std::exception);
+}
+
+
+GTEST_TEST(GeometryBaseBranchPointTest, BasicConstruction) {
+  const MockBranchPoint dut(api::BranchPointId("dut"));
+  EXPECT_EQ(dut.id(), api::BranchPointId("dut"));
+}
+
+
+GTEST_TEST(GeometryBaseBranchPointTest, AddingLanes) {
+  constexpr auto kStart = api::LaneEnd::kStart;
+  constexpr auto kFinish = api::LaneEnd::kFinish;
+
+  MockLane lane1(api::LaneId("lane1"));
+  MockLane lane2(api::LaneId("lane2"));
+  MockLane lane3(api::LaneId("lane3"));
+
+  MockBranchPoint dut(api::BranchPointId("dut"));
+
+  // Test the empty dut.
+  EXPECT_EQ(dut.GetASide()->size(), 0);
+  EXPECT_EQ(dut.GetBSide()->size(), 0);
+  EXPECT_THROW(dut.GetConfluentBranches({&lane1, kStart}), std::exception);
+  EXPECT_THROW(dut.GetOngoingBranches({&lane1, kStart}), std::exception);
+  EXPECT_FALSE(dut.GetDefaultBranch({&lane1, kStart}).has_value());
+
+  // Add the first lane-end to the "B-side".
+  dut.AddBBranch(&lane1, kStart);
+  EXPECT_EQ(dut.GetASide()->size(), 0);
+  EXPECT_EQ(dut.GetBSide()->size(), 1);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(dut.GetBSide()->get(0),
+                               api::LaneEnd(&lane1, kStart)));
+  EXPECT_EQ(dut.GetConfluentBranches({&lane1, kStart})->size(), 1);
+  EXPECT_EQ(dut.GetOngoingBranches({&lane1, kStart})->size(), 0);
+  EXPECT_FALSE(dut.GetDefaultBranch({&lane1, kStart}).has_value());
+  // Ensure that the Lane has been told about its BranchPoint.
+  EXPECT_EQ(lane1.GetBranchPoint(kStart), &dut);
+  // A Lane's end can only be added once, to one side.
+  EXPECT_THROW(dut.AddABranch(&lane1, kStart), std::exception);
+  EXPECT_THROW(dut.AddBBranch(&lane1, kStart), std::exception);
+  // But it is fine to add the other end to the same side.
+  dut.AddBBranch(&lane1, kFinish);
+  EXPECT_EQ(lane1.GetBranchPoint(kFinish), &dut);
+
+  // Add a second lane-end to the "A-side".
+  dut.AddABranch(&lane2, kFinish);
+  EXPECT_EQ(lane2.GetBranchPoint(kFinish), &dut);
+  EXPECT_EQ(dut.GetOngoingBranches({&lane2, kFinish})->size(), 2);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetOngoingBranches({&lane2, kFinish})->get(0),
+      api::LaneEnd(&lane1, kStart)));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetOngoingBranches({&lane2, kFinish})->get(1),
+      api::LaneEnd(&lane1, kFinish)));
+  EXPECT_EQ(dut.GetOngoingBranches({&lane1, kStart})->size(), 1);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetOngoingBranches({&lane1, kStart})->get(0),
+      api::LaneEnd(&lane2, kFinish)));
+
+  // Add a third lane-end to the "B-side" again.
+  dut.AddBBranch(&lane3, kFinish);
+  EXPECT_EQ(dut.GetConfluentBranches({&lane1, kStart})->size(), 3);
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetConfluentBranches({&lane1, kStart})->get(0),
+      api::LaneEnd(&lane1, kStart)));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetOngoingBranches({&lane2, kFinish})->get(1),
+      api::LaneEnd(&lane1, kFinish)));
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetConfluentBranches({&lane1, kStart})->get(2),
+      api::LaneEnd(&lane3, kFinish)));
+
+  // Set default branches.
+  // First try:  fails because specified default is not an ongoing branch.
+  EXPECT_THROW(dut.SetDefault({&lane1, kStart}, {&lane3, kFinish}),
+               std::exception);
+  // Second try:  succeeds.
+  dut.SetDefault({&lane1, kStart}, {&lane2, kFinish});
+  EXPECT_TRUE(dut.GetDefaultBranch({&lane1, kStart}).has_value());
+  EXPECT_TRUE(MALIPUT_IS_EQUAL(
+      dut.GetDefaultBranch({&lane1, kStart}).value(),
+      api::LaneEnd(&lane2, kFinish)));
+}
+
+
+GTEST_TEST(GeometryBaseSegmentTest, BasicConstruction) {
+  const MockSegment dut(api::SegmentId("dut"));
+  EXPECT_EQ(dut.id(), api::SegmentId("dut"));
+}
+
+
+GTEST_TEST(GeometryBaseSegmentTest, AddingLanes) {
+  auto lane0 = std::make_unique<MockLane>(api::LaneId("lane0"));
+  MockLane* raw_lane0 = lane0.get();
+  auto lane1 = std::make_unique<MockLane>(api::LaneId("lane1"));
+  MockLane* raw_lane1 = lane1.get();
+
+  MockSegment dut(api::SegmentId("dut"));
+
+  // Test the empty dut.
+  EXPECT_EQ(dut.num_lanes(), 0);
+
+  // Test adding two Lanes.
+  EXPECT_EQ(dut.AddLane(std::move(lane0)), raw_lane0);
+  EXPECT_TRUE(!lane0);
+  EXPECT_EQ(dut.AddLane(std::move(lane1)), raw_lane1);
+  EXPECT_TRUE(!lane1);
+
+  ASSERT_EQ(dut.num_lanes(), 2);
+  EXPECT_EQ(dut.lane(0), raw_lane0);
+  EXPECT_EQ(dut.lane(1), raw_lane1);
+  EXPECT_EQ(raw_lane0->segment(), &dut);
+  EXPECT_EQ(raw_lane1->segment(), &dut);
+  EXPECT_EQ(raw_lane0->index(), 0);
+  EXPECT_EQ(raw_lane1->index(), 1);
+  EXPECT_THROW(dut.lane(2), std::exception);
+}
+
+
+GTEST_TEST(GeometryBaseJunctionTest, BasicConstruction) {
+  const MockJunction dut(api::JunctionId("dut"));
+  EXPECT_EQ(dut.id(), api::JunctionId("dut"));
+}
+
+
+GTEST_TEST(GeometryBaseJunctionTest, AddingSegments) {
+  auto segment0 = std::make_unique<MockSegment>(api::SegmentId("s0"));
+  MockSegment* raw_segment0 = segment0.get();
+  auto segment1 = std::make_unique<MockSegment>(api::SegmentId("s1"));
+  MockSegment* raw_segment1 = segment1.get();
+
+  MockJunction dut(api::JunctionId("dut"));
+
+  // Test the empty dut.
+  EXPECT_EQ(dut.num_segments(), 0);
+
+  // Test adding two Segments.
+  EXPECT_EQ(dut.AddSegment(std::move(segment0)), raw_segment0);
+  EXPECT_TRUE(!segment0);
+  EXPECT_EQ(dut.AddSegment(std::move(segment1)), raw_segment1);
+  EXPECT_TRUE(!segment1);
+
+  ASSERT_EQ(dut.num_segments(), 2);
+  EXPECT_EQ(dut.segment(0), raw_segment0);
+  EXPECT_EQ(dut.segment(1), raw_segment1);
+  EXPECT_EQ(raw_segment0->junction(), &dut);
+  EXPECT_EQ(raw_segment1->junction(), &dut);
+  EXPECT_THROW(dut.segment(2), std::exception);
+}
+
+
+GTEST_TEST(GeometryBaseRoadGeometryTest, BasicConstruction) {
+  const double kValidLinearTolerance = 7.0;
+  const double kValidAngularTolerance = 99.0;
+  // Tolerance values must be positive.
+  EXPECT_THROW(MockRoadGeometry(
+      api::RoadGeometryId("dut"), kValidLinearTolerance, 0.), std::exception);
+  EXPECT_THROW(MockRoadGeometry(
+      api::RoadGeometryId("dut"), 0., kValidAngularTolerance), std::exception);
+
+  const MockRoadGeometry dut(api::RoadGeometryId("dut"),
+                             kValidLinearTolerance, kValidAngularTolerance);
+  EXPECT_EQ(dut.id(), api::RoadGeometryId("dut"));
+  EXPECT_EQ(dut.linear_tolerance(), kValidLinearTolerance);
+  EXPECT_EQ(dut.angular_tolerance(), kValidAngularTolerance);
+}
+
+
+GTEST_TEST(GeometryBaseRoadGeometryTest, AddingBranchPoints) {
+  auto branch_point0 = std::make_unique<MockBranchPoint>(
+      api::BranchPointId("bp0"));
+  MockBranchPoint* raw_branch_point0 = branch_point0.get();
+  auto branch_point1 = std::make_unique<MockBranchPoint>(
+      api::BranchPointId("bp1"));
+  MockBranchPoint* raw_branch_point1 = branch_point1.get();
+
+  const double kSomePositiveDouble = 7.0;
+  MockRoadGeometry dut(
+      api::RoadGeometryId("dut"), kSomePositiveDouble, kSomePositiveDouble);
+
+  // Test the empty dut.
+  EXPECT_EQ(dut.num_branch_points(), 0);
+
+  // Test adding two BranchPoints.
+  EXPECT_EQ(dut.AddBranchPoint(std::move(branch_point0)), raw_branch_point0);
+  EXPECT_TRUE(!branch_point0);
+  EXPECT_EQ(dut.AddBranchPoint(std::move(branch_point1)), raw_branch_point1);
+  EXPECT_TRUE(!branch_point1);
+
+  ASSERT_EQ(dut.num_branch_points(), 2);
+  EXPECT_EQ(dut.branch_point(0), raw_branch_point0);
+  EXPECT_EQ(dut.branch_point(1), raw_branch_point1);
+  EXPECT_EQ(raw_branch_point0->road_geometry(), &dut);
+  EXPECT_EQ(raw_branch_point1->road_geometry(), &dut);
+  EXPECT_THROW(dut.branch_point(2), std::exception);
+
+  EXPECT_EQ(dut.ById().GetBranchPoint(api::BranchPointId("bp0")),
+            raw_branch_point0);
+  EXPECT_EQ(dut.ById().GetBranchPoint(api::BranchPointId("bp1")),
+            raw_branch_point1);
+  // ID's must be unique.
+  auto another0 = std::make_unique<MockBranchPoint>(api::BranchPointId("bp0"));
+  EXPECT_THROW(dut.AddBranchPoint(std::move(another0)), std::exception);
+}
+
+
+GTEST_TEST(GeometryBaseRoadGeometryTest, AddingJunctions) {
+  auto junction0 = std::make_unique<MockJunction>(api::JunctionId("j0"));
+  MockJunction* raw_junction0 = junction0.get();
+  auto junction1 = std::make_unique<MockJunction>(api::JunctionId("j1"));
+  MockJunction* raw_junction1 = junction1.get();
+
+  const double kSomePositiveDouble = 7.0;
+  MockRoadGeometry dut(
+      api::RoadGeometryId("dut"), kSomePositiveDouble, kSomePositiveDouble);
+
+  // Test the empty dut.
+  EXPECT_EQ(dut.num_junctions(), 0);
+
+  // Test adding two Junctions.
+  EXPECT_EQ(dut.AddJunction(std::move(junction0)), raw_junction0);
+  EXPECT_TRUE(!junction0);
+  EXPECT_EQ(dut.AddJunction(std::move(junction1)), raw_junction1);
+  EXPECT_TRUE(!junction1);
+
+  ASSERT_EQ(dut.num_junctions(), 2);
+  EXPECT_EQ(dut.junction(0), raw_junction0);
+  EXPECT_EQ(dut.junction(1), raw_junction1);
+  EXPECT_EQ(raw_junction0->road_geometry(), &dut);
+  EXPECT_EQ(raw_junction1->road_geometry(), &dut);
+  EXPECT_THROW(dut.junction(2), std::exception);
+
+  EXPECT_EQ(dut.ById().GetJunction(api::JunctionId("j0")), raw_junction0);
+  EXPECT_EQ(dut.ById().GetJunction(api::JunctionId("j1")), raw_junction1);
+  // ID's must be unique.
+  auto another0 = std::make_unique<MockJunction>(api::JunctionId("j0"));
+  EXPECT_THROW(dut.AddJunction(std::move(another0)), std::exception);
+}
+
+
+// Test by-id indexing of Segments and Lanes in RoadGeometry.
+class GeometryBaseRoadGeometryIndexingTest : public ::testing::Test {
+ protected:
+  enum AttachOperation { kAttachLane, kAttachSegment, kAttachJunction };
+
+  struct TestCase {
+    std::string name;
+    std::vector<AttachOperation> operations;
+  };
+
+  void SetUp() override {
+    constexpr double kArbitrary{1.};
+    road_geometry_ = std::make_unique<MockRoadGeometry>(
+        api::RoadGeometryId("dut"), kArbitrary, kArbitrary);
+  }
+
+  std::unique_ptr<RoadGeometry> road_geometry_;
+};
+
+
+TEST_F(GeometryBaseRoadGeometryIndexingTest, Test) {
+  // The intent here is to ensure that all Lanes and Segments are recorded
+  // in a RoadGeometry's id index, regardless of the order in which the
+  // Lanes, Segments, and parent Junctions are attached to each other and
+  // to the RoadGeometry.  This is testing that the internal "index callback"
+  // machinery is working correctly.  (Indexing of Junctions is already
+  // tested elsewhere, in the AddingJunctions test.)
+  //
+  // Every object has an "attach" operation that (should) occurs when an
+  // object is added to a parent.  So, we need to test the six possible
+  // orderings of "attach Lane", "attach Segment", and "attach Junction":
+  //
+  //       L-S-J   L-J-S   S-J-L
+  //       S-L-J   J-L-S   J-S-L
+  const std::vector<TestCase> cases{
+    {"LSJ", {kAttachLane,     kAttachSegment,  kAttachJunction}},
+    {"SLJ", {kAttachSegment,  kAttachLane,     kAttachJunction}},
+
+    {"LJS", {kAttachLane,     kAttachJunction, kAttachSegment}},
+    {"JLS", {kAttachJunction, kAttachLane,     kAttachSegment}},
+
+    {"SJL", {kAttachSegment,  kAttachJunction, kAttachLane}},
+    {"JSL", {kAttachJunction, kAttachSegment,  kAttachLane}},
+  };
+
+  for (const auto& kase : cases) {
+    auto lane = std::make_unique<MockLane>(api::LaneId(kase.name));
+    auto segment = std::make_unique<MockSegment>(api::SegmentId(kase.name));
+    auto junction = std::make_unique<MockJunction>(api::JunctionId(kase.name));
+
+    Lane* raw_lane = lane.get();
+    Segment* raw_segment = segment.get();
+    Junction* raw_junction = junction.get();
+
+    for (const auto& operation : kase.operations) {
+      switch (operation) {
+        case kAttachLane: {
+          raw_segment->AddLane(std::move(lane));
+          break;
+        }
+        case kAttachSegment: {
+          raw_junction->AddSegment(std::move(segment));
+          break;
+        }
+        case kAttachJunction: {
+          road_geometry_->AddJunction(std::move(junction));
+          break;
+        }
+      }
+    }
+    EXPECT_EQ(road_geometry_->ById().GetLane(raw_lane->id()), raw_lane);
+    EXPECT_EQ(road_geometry_->ById().GetSegment(raw_segment->id()),
+              raw_segment);
+  }
+}
+
+
+GTEST_TEST(GeometryBaseRoadGeometryTest, UnimplementedMethods) {
+  MockRoadGeometry dut(api::RoadGeometryId("dut"), 1., 1.);
+  // Ensure that the not-actually-implemented methods throw an exception.
+  EXPECT_THROW(dut.ToRoadPosition(
+      api::GeoPosition(), nullptr, nullptr, nullptr), std::exception);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/test_utilities/BUILD.bazel
+++ b/automotive/maliput/geometry_base/test_utilities/BUILD.bazel
@@ -1,0 +1,30 @@
+# -*- python -*-
+
+load(
+    "@drake//tools/skylark:drake_cc.bzl",
+    "drake_cc_library",
+    "drake_cc_package_library",
+)
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+package(default_visibility = ["//visibility:public"])
+
+drake_cc_package_library(
+    name = "test_utilities",
+    testonly = 1,
+    deps = [
+        ":mock_geometry",
+    ],
+)
+
+drake_cc_library(
+    name = "mock_geometry",
+    testonly = 1,
+    srcs = ["mock_geometry.cc"],
+    hdrs = ["mock_geometry.h"],
+    deps = [
+        "//automotive/maliput/geometry_base",
+    ],
+)
+
+add_lint_tests()

--- a/automotive/maliput/geometry_base/test_utilities/mock_geometry.cc
+++ b/automotive/maliput/geometry_base/test_utilities/mock_geometry.cc
@@ -1,0 +1,66 @@
+#include "drake/automotive/maliput/geometry_base/test_utilities/mock_geometry.h"
+
+#include "drake/common/drake_assert.h"
+#include "drake/common/drake_throw.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+namespace test {
+
+
+api::RoadPosition MockRoadGeometry::DoToRoadPosition(
+    const api::GeoPosition&, const api::RoadPosition*,
+    api::GeoPosition*, double*) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+
+double MockLane::do_length() const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::RBounds MockLane::do_lane_bounds(double) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::RBounds MockLane::do_driveable_bounds(double) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::HBounds MockLane::do_elevation_bounds(double, double) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::GeoPosition MockLane::DoToGeoPosition(const api::LanePosition&) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::Rotation MockLane::DoGetOrientation(const api::LanePosition&) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::LanePosition MockLane::DoEvalMotionDerivatives(
+    const api::LanePosition&, const api::IsoLaneVelocity&) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+api::LanePosition MockLane::DoToLanePosition(
+    const api::GeoPosition&, api::GeoPosition*, double*) const {
+  DRAKE_THROW_UNLESS(false);
+  DRAKE_ABORT();  // To avoid "control reaches end of non-void function" msg.
+}
+
+
+}  // namespace test
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake

--- a/automotive/maliput/geometry_base/test_utilities/mock_geometry.h
+++ b/automotive/maliput/geometry_base/test_utilities/mock_geometry.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "drake/automotive/maliput/geometry_base/branch_point.h"
+#include "drake/automotive/maliput/geometry_base/junction.h"
+#include "drake/automotive/maliput/geometry_base/lane.h"
+#include "drake/automotive/maliput/geometry_base/road_geometry.h"
+#include "drake/automotive/maliput/geometry_base/segment.h"
+
+namespace drake {
+namespace maliput {
+namespace geometry_base {
+namespace test {
+
+/// @file
+/// Mock concrete implementation of maliput geometry API, useful for tests.
+///
+/// The classes in this file are concrete implementations of the
+/// maliput geometry API, built on top of the @ref
+/// drake::maliput::geometry_base "geometry_base" base classes.  The
+/// only difference between these classes and @ref
+/// drake::maliput::geometry_base "geometry_base" is that all the
+/// remaining pure virtual methods in @ref
+/// drake::maliput::geometry_base "geometry_base" (i.e., the methods
+/// involving actual lane-frame and world-frame geometry) have been
+/// provided with implementations that simply throw `std::exception`.
+/// These "Mock" classes do provide sufficient functionality to
+/// exercise the geometry API's object graph.
+///
+/// All virtual methods are overridable (i.e., none are marked `final`).
+/// Test implementors may re-implement methods as they see fit.
+
+/// Mock api::RoadGeometry implementation; see mock_geometry.h.
+class MockRoadGeometry : public geometry_base::RoadGeometry {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockRoadGeometry);
+
+  /// Constructs an empty MockRoadGeometry with the specified tolerances.
+  ///
+  /// @param id the ID of the RoadGeometry
+  /// @param linear_tolerance the linear tolerance
+  /// @param angular_tolerance the angular tolerance
+  ///
+  /// @throws std::exception if either `linear_tolerance` or
+  ///         `angular_tolerance` is non-positive.
+  MockRoadGeometry(const api::RoadGeometryId& id,
+                   const double linear_tolerance,
+                   const double angular_tolerance)
+      : geometry_base::RoadGeometry(id, linear_tolerance, angular_tolerance) {}
+
+ private:
+  api::RoadPosition DoToRoadPosition(const api::GeoPosition& geo_position,
+                                     const api::RoadPosition* hint,
+                                     api::GeoPosition* nearest_position,
+                                     double* distance) const override;
+};
+
+
+/// Mock api::BranchPoint implementation; see mock_geometry.h.
+class MockBranchPoint : public geometry_base::BranchPoint {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockBranchPoint);
+
+  /// Constructs a partially-initialized MockBranchPoint.
+  ///
+  /// @param id the ID
+  ///
+  /// See geometry_base::BranchPoint for discussion on initialization.
+  explicit MockBranchPoint(const api::BranchPointId& id)
+      : geometry_base::BranchPoint(id) {}
+};
+
+
+/// Mock api::Junction implementation; see mock_geometry.h.
+class MockJunction : public geometry_base::Junction {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockJunction);
+
+  /// Constructs a partially-initialized MockJunction.
+  ///
+  /// @param id the ID
+  ///
+  /// See geometry_base::Junction for discussion on initialization.
+  explicit MockJunction(const api::JunctionId& id)
+      : geometry_base::Junction(id) {}
+};
+
+
+/// Mock api::Segment implementation; see mock_geometry.h.
+class MockSegment : public geometry_base::Segment {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockSegment);
+
+  /// Constructs a partially-initialized MockSegment.
+  ///
+  /// @param id the ID
+  ///
+  /// See geometry_base::Segment for discussion on initialization.
+  explicit MockSegment(const api::SegmentId& id)
+      : geometry_base::Segment(id) {}
+};
+
+
+/// Mock api::Lane implementation; see mock_geometry.h.
+class MockLane : public geometry_base::Lane {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MockLane);
+
+  /// Constructs a partially-initialized MockLane.
+  ///
+  /// @param id the ID
+  ///
+  /// See geometry_base::Lane for discussion on initialization.
+  explicit MockLane(const api::LaneId& id) : geometry_base::Lane(id) {}
+
+ private:
+  double do_length() const override;
+  api::RBounds do_lane_bounds(double) const override;
+  api::RBounds do_driveable_bounds(double) const override;
+  api::HBounds do_elevation_bounds(double, double) const override;
+  api::GeoPosition DoToGeoPosition(
+      const api::LanePosition& lane_pos) const override;
+  api::Rotation DoGetOrientation(
+      const api::LanePosition& lane_pos) const override;
+  api::LanePosition DoEvalMotionDerivatives(
+      const api::LanePosition& position,
+      const api::IsoLaneVelocity& velocity) const override;
+  api::LanePosition DoToLanePosition(
+      const api::GeoPosition& geo_position,
+      api::GeoPosition* nearest_position, double* distance) const override;
+};
+
+
+}  // namespace test
+}  // namespace geometry_base
+}  // namespace maliput
+}  // namespace drake


### PR DESCRIPTION
Provide maliput::geometry_base, basic implementation of the object graph
interfaces of the maliput geometry API, serving as base classes to handle
the object graph boilerplate for maliput geometry API backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9272)
<!-- Reviewable:end -->
