### PR TITLE
Add workspace name when retrieving label for CPPLINT.cfg

### DIFF
--- a/tools/lint/cpplint.bzl
+++ b/tools/lint/cpplint.bzl
@@ -60,7 +60,7 @@ def _add_linter_rules(source_labels, source_filenames, name, data = None):
     # (Projects that want their own config can place a CPPLINT.cfg in their
     # root package.  Projects that want to use exactly the Drake defaults can
     # alias Drake's config file into their top-level BUILD.bazel file.)
-    cpplint_cfg = ["//:CPPLINT.cfg"] + native.glob([
+    cpplint_cfg = ["@drake//:CPPLINT.cfg"] + native.glob([
         "CPPLINT.cfg",
         "test/CPPLINT.cfg",
     ])


### PR DESCRIPTION
This change allows external projects e.g. [drake-shambhala](https://github.com/RobotLocomotion/drake-shambhala) type projects to reuse drake's C++ lint tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9273)
<!-- Reviewable:end -->
