### PR TITLE
[multilane] Group-related interfaces to allow loader testing

### DIFF
--- a/automotive/maliput/multilane/builder.cc
+++ b/automotive/maliput/multilane/builder.cc
@@ -46,16 +46,19 @@ std::ostream& operator<<(std::ostream& out, const LaneLayout& lane_layout) {
 
 Builder::Builder(double lane_width, const api::HBounds& elevation_bounds,
                  double linear_tolerance, double angular_tolerance,
-                 double scale_length, ComputationPolicy computation_policy)
+                 double scale_length, ComputationPolicy computation_policy,
+                 std::unique_ptr<GroupFactoryBase> group_factory)
     : lane_width_(lane_width),
       elevation_bounds_(elevation_bounds),
       linear_tolerance_(linear_tolerance),
       angular_tolerance_(angular_tolerance),
       scale_length_(scale_length),
-      computation_policy_(computation_policy) {
+      computation_policy_(computation_policy),
+      group_factory_(std::move(group_factory)) {
   DRAKE_DEMAND(lane_width_ >= 0.);
   DRAKE_DEMAND(linear_tolerance_ >= 0.);
   DRAKE_DEMAND(angular_tolerance_ >= 0.);
+  DRAKE_DEMAND(group_factory_ != nullptr);
 }
 
 namespace {
@@ -285,14 +288,14 @@ void Builder::SetDefaultBranch(const Connection* in, int in_lane_index,
 
 
 Group* Builder::MakeGroup(const std::string& id) {
-  groups_.push_back(std::make_unique<Group>(id));
+  groups_.push_back(group_factory_->Make(id));
   return groups_.back().get();
 }
 
 
 Group* Builder::MakeGroup(const std::string& id,
                           const std::vector<const Connection*>& connections) {
-  groups_.push_back(std::make_unique<Group>(id, connections));
+  groups_.push_back(group_factory_->Make(id, connections));
   return groups_.back().get();
 }
 

--- a/automotive/maliput/multilane/builder.h
+++ b/automotive/maliput/multilane/builder.h
@@ -551,9 +551,11 @@ class Builder : public BuilderBase {
   /// tolerances for the resulting RoadGeometry. `scale_length` constrains
   /// the maximum level of detail captured by the resulting RoadGeometry.
   /// `computation_policy` sets the speed vs. accuracy balance for computations.
+  /// `group_factory` allows to create groups.
   Builder(double lane_width, const api::HBounds& elevation_bounds,
           double linear_tolerance, double angular_tolerance,
-          double scale_length, ComputationPolicy computation_policy);
+          double scale_length, ComputationPolicy computation_policy,
+          std::unique_ptr<GroupFactoryBase> group_factory);
 
   /// Gets `lane_width` value.
   double get_lane_width() const override { return lane_width_; }
@@ -606,8 +608,9 @@ class Builder : public BuilderBase {
 
   Group* MakeGroup(const std::string& id) override;
 
-  Group* MakeGroup(const std::string& id,
-                   const std::vector<const Connection*>& connections) override;
+  Group* MakeGroup(
+      const std::string& id,
+      const std::vector<const Connection*>& connections) override;
 
   std::unique_ptr<const api::RoadGeometry> Build(
       const api::RoadGeometryId& id) const override;
@@ -707,6 +710,7 @@ class Builder : public BuilderBase {
   double angular_tolerance_{};
   double scale_length_{};
   ComputationPolicy computation_policy_{};
+  std::unique_ptr<GroupFactoryBase> group_factory_;
   std::vector<std::unique_ptr<Connection>> connections_;
   std::vector<DefaultBranch> default_branches_;
   std::vector<std::unique_ptr<Group>> groups_;
@@ -725,7 +729,8 @@ class BuilderFactory : public BuilderFactoryBase {
       ComputationPolicy computation_policy) const override {
     return std::make_unique<Builder>(lane_width, elevation_bounds,
                                      linear_tolerance, angular_tolerance,
-                                     scale_length, computation_policy);
+                                     scale_length, computation_policy,
+                                     std::make_unique<GroupFactory>());
   }
 };
 

--- a/automotive/maliput/multilane/connection.h
+++ b/automotive/maliput/multilane/connection.h
@@ -401,46 +401,118 @@ class Connection {
 ///
 /// Upon building the RoadGeometry, a Group yields a Junction containing the
 /// corresponding Segments specified by all the Connections in the Group.
+///
+/// Users should construct Groups via a Builder using one of the
+/// Builder::MakeGroup() methods.
 class Group {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Group)
 
-  /// Constructs an empty Group with the specified `id`.
-  explicit Group(const std::string& id) : id_(id) {}
+  Group() = default;
 
-  /// Constructs a Group with `id`, populated by `connections`.
-  ///
-  /// `connections` must not contain duplicates.
-  Group(const std::string& id,
-        const std::vector<const Connection*>& connections)
-      : id_(id) {
-    for (const Connection* connection : connections) {
-      Add(connection);
-    }
-  }
+  virtual ~Group() = default;
 
-  /// Adds a Connection.
-  ///
-  /// `connection` must not already be added.
-  void Add(const Connection* connection) {
-    auto result = connection_set_.insert(connection);
-    DRAKE_DEMAND(result.second);
-    connection_vector_.push_back(connection);
-  }
+  /// Adds a `connection` to the group.
+  virtual void Add(const Connection* connection) = 0;
 
   /// Returns the ID string.
-  const std::string& id() const { return id_; }
+  virtual const std::string& id() const = 0;
 
   /// Returns the grouped Connections.
-  const std::vector<const Connection*>& connections() const {
-    return connection_vector_;
+  virtual const std::vector<const Connection*>& connections() const = 0;
+};
+
+/// Factory interface to construct Group instances.
+///
+/// Defined for testing purposes, and production code must use GroupFactory
+/// objects.
+class GroupFactoryBase {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GroupFactoryBase)
+
+  GroupFactoryBase() = default;
+
+  virtual ~GroupFactoryBase() = default;
+
+  /// Makes an empty Group with the specified `id`.
+  virtual std::unique_ptr<Group> Make(const std::string& id) const = 0;
+
+  /// Makes a Group with `id`, populated by `connections`.
+  ///
+  /// `connections` must not contain duplicates.
+  virtual std::unique_ptr<Group> Make(
+      const std::string& id,
+      const std::vector<const Connection*>& connections) const = 0;
+};
+
+
+/// Implements a GroupFactoryBase to construct Group objects.
+class GroupFactory : public GroupFactoryBase {
+ private:
+  // A group of Connections.
+  //
+  // Upon building the RoadGeometry, a Group yields a Junction containing the
+  // corresponding Segments specified by all the Connections in the Group.
+  class RealGroup : public Group {
+   public:
+    DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(RealGroup)
+
+    // Constructs an empty Group with the specified `id`.
+    explicit RealGroup(const std::string& id) : id_(id) {}
+
+    // Constructs a Group with `id`, populated by `connections`.
+    //
+    // `connections` must not contain duplicates.
+    RealGroup(const std::string& id,
+              const std::vector<const Connection*>& connections)
+        : id_(id) {
+      for (const Connection* connection : connections) {
+        Add(connection);
+      }
+    }
+
+    // Adds a Connection.
+    //
+    // `connection` must not already be added.
+    void Add(const Connection* connection) override {
+      auto result = connection_set_.insert(connection);
+      DRAKE_DEMAND(result.second);
+      connection_vector_.push_back(connection);
+    }
+
+    // Returns the ID string.
+    const std::string& id() const override { return id_; }
+
+    // Returns the grouped Connections.
+    const std::vector<const Connection*>& connections() const override {
+      return connection_vector_;
+    }
+
+   private:
+    std::string id_;
+    std::unordered_set<const Connection*> connection_set_;
+    std::vector<const Connection*> connection_vector_;
+  };
+
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(GroupFactory)
+
+  GroupFactory() = default;
+
+  virtual ~GroupFactory() = default;
+
+  virtual std::unique_ptr<Group> Make(const std::string& id) const {
+    return std::make_unique<RealGroup>(id);
   }
 
- private:
-  std::string id_;
-  std::unordered_set<const Connection*> connection_set_;
-  std::vector<const Connection*> connection_vector_;
+  virtual std::unique_ptr<Group> Make(
+      const std::string& id,
+      const std::vector<const Connection*>& connections) const {
+    return std::make_unique<RealGroup>(id, connections);
+  }
 };
+
+
 
 }  // namespace multilane
 }  // namespace maliput

--- a/automotive/maliput/multilane/test/multilane_builder_test.cc
+++ b/automotive/maliput/multilane/test/multilane_builder_test.cc
@@ -169,7 +169,8 @@ GTEST_TEST(MultilaneBuilderTest, ParameterConstructor) {
   const ComputationPolicy kComputationPolicy{
     ComputationPolicy::kPreferAccuracy};
   Builder builder(kLaneWidth, kElevationBounds, kLinearTolerance,
-                  kAngularTolerance, kScaleLength, kComputationPolicy);
+                  kAngularTolerance, kScaleLength, kComputationPolicy,
+                  std::make_unique<GroupFactory>());
   EXPECT_EQ(builder.get_lane_width(), kLaneWidth);
   EXPECT_TRUE(api::test::IsHBoundsClose(builder.get_elevation_bounds(),
                                         kElevationBounds, 0.));
@@ -190,7 +191,8 @@ GTEST_TEST(MultilaneBuilderTest, ProperConnections) {
   const ComputationPolicy kComputationPolicy{
     ComputationPolicy::kPreferAccuracy};
   Builder builder(kLaneWidth, kElevationBounds, kLinearTolerance,
-                  kAngularTolerance, kScaleLength, kComputationPolicy);
+                  kAngularTolerance, kScaleLength, kComputationPolicy,
+                  std::make_unique<GroupFactory>());
 
   const double kLeftShoulder = 2.;
   const double kRightShoulder = 2.;
@@ -249,9 +251,8 @@ GTEST_TEST(MultilaneBuilderTest, Fig8) {
   const double kScaleLength = 1.0;
   const ComputationPolicy kComputationPolicy{
     ComputationPolicy::kPreferAccuracy};
-  Builder b(kLaneWidth, kElevationBounds,
-            kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kLeftShoulder = 2.;
   const double kRightShoulder = 2.;
@@ -374,9 +375,8 @@ GTEST_TEST(MultilaneBuilderTest, QuadRing) {
   const double kScaleLength = 1.0;
   const ComputationPolicy kComputationPolicy{
     ComputationPolicy::kPreferAccuracy};
-  Builder b(kLaneWidth, kElevationBounds,
-            kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+  Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kLeftShoulder = 2.;
   const double kRightShoulder = 2.;
@@ -538,7 +538,7 @@ class MultilaneBuilderReferenceCurvePrimitivesTest : public ::testing::Test {
 // Checks that a multi-lane line segment is correctly created.
 TEST_F(MultilaneBuilderReferenceCurvePrimitivesTest, LineSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const LineOffset kLineOffset(50.);
   b.Connect("c0", kLaneLayout, StartReference().at(kStart, Direction::kForward),
@@ -591,7 +591,7 @@ TEST_F(MultilaneBuilderReferenceCurvePrimitivesTest, LineSegment) {
 // Checks that a multi-lane arc segment is correctly created.
 TEST_F(MultilaneBuilderReferenceCurvePrimitivesTest, ArcSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kRadius = 30.;
   const double kDTheta = 0.5 * M_PI;
@@ -687,7 +687,7 @@ class MultilaneBuilderPrimitiveContinuityConstraintTest
 // to zero always because of infinite curvature radius of a line.
 TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneLineSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
   const LineOffset kLineOffset(50.);
   auto c0 =
       b.Connect("c0", kLaneLayout,
@@ -709,7 +709,7 @@ TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneLineSegment) {
 // on curvature and angular displacement.
 TEST_F(MultilaneBuilderPrimitiveContinuityConstraintTest, MonolaneArcSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
   const double kRadius = 30.;
   const double kDTheta = 0.5 * M_PI;
   auto counter_clockwise_conn =
@@ -773,7 +773,7 @@ class MultilaneBuilderLaneToLanePrimitivesTest : public ::testing::Test {
 // Checks that a multi-lane line segment is correctly created.
 TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, FlatLineSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const LineOffset kLineOffset(50.);
   b.Connect("c0", kLaneLayout,
@@ -828,7 +828,7 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, FlatLineSegment) {
 // Checks that a multi-lane line segment is correctly created.
 TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndLineSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kLength{50.};
   const LineOffset kLineOffset(kLength);
@@ -895,7 +895,7 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndLineSegment) {
 // Checks that a multi-lane arc segment is correctly created.
 TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ArcSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kRadius = 30.;
   const double kDTheta = 0.5 * M_PI;
@@ -952,7 +952,7 @@ TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ArcSegment) {
 // Checks that a multi-lane arc segment is correctly created.
 TEST_F(MultilaneBuilderLaneToLanePrimitivesTest, ElevatedEndArcSegment) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   const double kRadius = 30.;
   const double kDTheta = 0.5 * M_PI;
@@ -1220,7 +1220,7 @@ class MultilaneBuilderMultilaneCrossTest : public ::testing::Test {
 
 TEST_F(MultilaneBuilderMultilaneCrossTest, MultilaneRefCurveToRefCurve) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
   // Creates connections.
   b.Connect(
       "c1",
@@ -1275,7 +1275,7 @@ TEST_F(MultilaneBuilderMultilaneCrossTest, MultilaneRefCurveToRefCurve) {
 
 TEST_F(MultilaneBuilderMultilaneCrossTest, MultilaneLaneCurveToLaneCurve) {
   Builder b(kLaneWidth, kElevationBounds, kLinearTolerance, kAngularTolerance,
-            kScaleLength, kComputationPolicy);
+            kScaleLength, kComputationPolicy, std::make_unique<GroupFactory>());
 
   // Creates connections.
   auto c1 = b.Connect(

--- a/automotive/test/maliput_railcar_test.cc
+++ b/automotive/test/maliput_railcar_test.cc
@@ -27,6 +27,7 @@ using maliput::api::LaneEnd;
 using maliput::api::HBounds;
 
 using maliput::multilane::ArcOffset;
+using maliput::multilane::BuilderFactory;
 using maliput::multilane::ComputationPolicy;
 using maliput::multilane::Connection;
 using maliput::multilane::Direction;
@@ -87,10 +88,10 @@ class MaliputRailcarTest : public ::testing::Test {
   // @param with_s Whether the MaliputRailcar is traveling with or against the
   // lane's s-curve.
   void InitializeCurvedMultilane(bool with_s = true) {
-    maliput::multilane::Builder builder(kLaneWidth, kHBounds, kLinearTolerance,
-                                        kAngularTolerance, kScaleLength,
-                                        kComputationPolicy);
-    builder.Connect(
+    auto builder = BuilderFactory().Make(kLaneWidth, kHBounds, kLinearTolerance,
+                                         kAngularTolerance, kScaleLength,
+                                         kComputationPolicy);
+    builder->Connect(
         "point.0", kSingleLaneLayout,
         StartReference().at(
             Endpoint(EndpointXy(0, 0, 0), EndpointZ(0, 0, 0, {})),
@@ -98,7 +99,7 @@ class MaliputRailcarTest : public ::testing::Test {
         ArcOffset(kCurvedRoadRadius, kCurvedRoadTheta),
         EndReference().z_at(EndpointZ(0, 0, 0, {}), Direction::kForward));
     Initialize(
-        builder.Build(maliput::api::RoadGeometryId("RailcarTestCurvedRoad")),
+        builder->Build(maliput::api::RoadGeometryId("RailcarTestCurvedRoad")),
         with_s);
   }
 
@@ -108,10 +109,10 @@ class MaliputRailcarTest : public ::testing::Test {
   // @param with_s Whether the MaliputRailcar is traveling with or against the
   // lane's s-curve.
   void InitializeSlopedCurvedMultilane(bool with_s = true) {
-    maliput::multilane::Builder builder(kLaneWidth, kHBounds, kLinearTolerance,
-                                        kAngularTolerance, kScaleLength,
-                                        kComputationPolicy);
-    builder.Connect(
+    auto builder = BuilderFactory().Make(kLaneWidth, kHBounds, kLinearTolerance,
+                                         kAngularTolerance, kScaleLength,
+                                         kComputationPolicy);
+    builder->Connect(
         "point.0", kSingleLaneLayout,
         StartReference().at(
             Endpoint(EndpointXy(0, 0, 0), EndpointZ(0, 0, 0, {})),
@@ -119,7 +120,7 @@ class MaliputRailcarTest : public ::testing::Test {
         ArcOffset(kCurvedRoadRadius, kCurvedRoadTheta),
         EndReference().z_at(EndpointZ(2, 0, 0.5, {}), Direction::kForward));
     Initialize(
-        builder.Build(maliput::api::RoadGeometryId("RailcarTestCurvedRoad")),
+        builder->Build(maliput::api::RoadGeometryId("RailcarTestCurvedRoad")),
         with_s);
   }
 
@@ -135,11 +136,11 @@ class MaliputRailcarTest : public ::testing::Test {
   // opposing s-directions.
   void InitializeTwoLaneStretchOfRoad(bool with_s = true,
                                 bool flip_curve_lane = false) {
-    maliput::multilane::Builder builder(kLaneWidth, kHBounds, kLinearTolerance,
-                                        kAngularTolerance, kScaleLength,
-                                        kComputationPolicy);
+    auto builder = BuilderFactory().Make(kLaneWidth, kHBounds, kLinearTolerance,
+                                         kAngularTolerance, kScaleLength,
+                                         kComputationPolicy);
 
-    const Connection* straight_lane_connection = builder.Connect(
+    const Connection* straight_lane_connection = builder->Connect(
         "point.0", kSingleLaneLayout,
         StartReference().at(
             Endpoint(EndpointXy(0, 0, 0), EndpointZ(0, 0, 0, {})),
@@ -162,7 +163,7 @@ class MaliputRailcarTest : public ::testing::Test {
 
       An OBJ rendering of this configuration is given in #5552.
       */
-      const Connection* curved_lane_connection = builder.Connect(
+      const Connection* curved_lane_connection = builder->Connect(
           "point.1" /* id */, kSingleLaneLayout,
           StartReference().at(
               Endpoint(EndpointXy(kStraightRoadLength + kCurvedRoadRadius,
@@ -171,12 +172,12 @@ class MaliputRailcarTest : public ::testing::Test {
               Direction::kForward),
           ArcOffset(kCurvedRoadRadius, -kCurvedRoadTheta),
           EndReference().z_at(EndpointZ(0, 0, 0, {}), Direction::kForward));
-      builder.SetDefaultBranch(straight_lane_connection, first_lane_id,
-                               LaneEnd::kFinish, curved_lane_connection,
-                               first_lane_id, LaneEnd::kFinish);
-      builder.SetDefaultBranch(curved_lane_connection, first_lane_id,
-                               LaneEnd::kFinish, straight_lane_connection,
-                               first_lane_id, LaneEnd::kFinish);
+      builder->SetDefaultBranch(straight_lane_connection, first_lane_id,
+                                LaneEnd::kFinish, curved_lane_connection,
+                                first_lane_id, LaneEnd::kFinish);
+      builder->SetDefaultBranch(curved_lane_connection, first_lane_id,
+                                LaneEnd::kFinish, straight_lane_connection,
+                                first_lane_id, LaneEnd::kFinish);
     } else {
       /*
       When flip_curve_lane == false, the two lanes are configured as follows:
@@ -189,23 +190,23 @@ class MaliputRailcarTest : public ::testing::Test {
 
       An OBJ rendering of this configuration is given in #5552.
       */
-      const Connection* curved_lane_connection = builder.Connect(
+      const Connection* curved_lane_connection = builder->Connect(
           "point.1", kSingleLaneLayout,
           StartReference().at(Endpoint(EndpointXy(kStraightRoadLength, 0, 0),
                                        EndpointZ(0, 0, 0, {})),
                               Direction::kForward),
           ArcOffset(kCurvedRoadRadius, kCurvedRoadTheta),
           EndReference().z_at(EndpointZ(0, 0, 0, {}), Direction::kForward));
-      builder.SetDefaultBranch(straight_lane_connection, first_lane_id,
-                               LaneEnd::kFinish, curved_lane_connection,
-                               first_lane_id, LaneEnd::kStart);
-      builder.SetDefaultBranch(curved_lane_connection, first_lane_id,
-                               LaneEnd::kStart, straight_lane_connection,
-                               first_lane_id, LaneEnd::kFinish);
+      builder->SetDefaultBranch(straight_lane_connection, first_lane_id,
+                                LaneEnd::kFinish, curved_lane_connection,
+                                first_lane_id, LaneEnd::kStart);
+      builder->SetDefaultBranch(curved_lane_connection, first_lane_id,
+                                LaneEnd::kStart, straight_lane_connection,
+                                first_lane_id, LaneEnd::kFinish);
     }
 
     std::unique_ptr<const maliput::api::RoadGeometry> road =
-        builder.Build(maliput::api::RoadGeometryId(
+        builder->Build(maliput::api::RoadGeometryId(
             "RailcarTestTwoLaneStretchOfRoad"));
     Initialize(std::move(road), with_s);
   }

--- a/automotive/test/pure_pursuit_test.cc
+++ b/automotive/test/pure_pursuit_test.cc
@@ -4,6 +4,7 @@
 
 #include "drake/automotive/maliput/dragway/road_geometry.h"
 #include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/connection.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 
 namespace drake {
@@ -20,6 +21,7 @@ using maliput::api::GeoPosition;
 using maliput::api::RoadGeometryId;
 using maliput::multilane::ArcOffset;
 using maliput::multilane::Builder;
+using maliput::multilane::GroupFactory;
 using maliput::multilane::Direction;
 using maliput::multilane::Endpoint;
 using maliput::multilane::EndpointZ;
@@ -48,7 +50,8 @@ class PurePursuitTest : public ::testing::Test {
     const double kScaleLength{1.0};
     Builder builder(
         4. /* lane width */, {0., 5.}, 0.01, 0.01 * M_PI,
-        kScaleLength, ComputationPolicy::kPreferSpeed);
+        kScaleLength, ComputationPolicy::kPreferSpeed,
+        std::make_unique<GroupFactory>());
     builder.Connect("0", kLaneLayout,
                     StartReference().at(kStartEndpoint, Direction::kForward),
                     kCounterClockwiseArc,

--- a/automotive/test/road_path_test.cc
+++ b/automotive/test/road_path_test.cc
@@ -26,6 +26,7 @@ using maliput::api::RoadGeometry;
 
 using maliput::multilane::ArcOffset;
 using maliput::multilane::Builder;
+using maliput::multilane::BuilderFactory;
 using maliput::multilane::ComputationPolicy;
 using maliput::multilane::Direction;
 using maliput::multilane::Endpoint;
@@ -48,7 +49,7 @@ const EndpointZ kEndZ{0, 0, 0, 0};  // Specifies zero elevation/super-elevation.
 
 // Build a road with two lanes in series.
 std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
-  Builder builder(
+  auto builder = BuilderFactory().Make(
       4. /* lane width */, HBounds(0., 5.), 0.01 /* linear tolerance */,
       M_PI_2 / 180.0 /* angular tolerance */, 1. /* scale length*/,
       ComputationPolicy::kPreferAccuracy /* accuracy */);
@@ -56,7 +57,7 @@ std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
       2. /* left shoulder */, 2. /* right shoulder */, 1 /* number of lanes */,
       0 /* reference lane*/, 0. /* reference r0 */);
 
-  builder.Connect(
+  builder->Connect(
       "0_fwd", lane_layout,
       StartReference().at(Endpoint({0, 0, 0}, kEndZ), Direction::kForward),
       LineOffset(kStraightRoadLength),
@@ -65,7 +66,7 @@ std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
   if (is_opposing) {
     // Construct a curved segment that is directionally opposite the straight
     // lane.
-    builder.Connect(
+    builder->Connect(
         "1_rev", lane_layout,
         StartReference().at(Endpoint({kStraightRoadLength + kCurvedRoadRadius,
                                       kCurvedRoadRadius, 1.5 * M_PI},
@@ -76,7 +77,7 @@ std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
   } else {
     // Construct a curved segment that is directionally confluent with the
     // straight lane.
-    builder.Connect(
+    builder->Connect(
         "1_fwd", lane_layout,
         StartReference().at(Endpoint({kStraightRoadLength, 0, 0}, kEndZ),
                             Direction::kForward),
@@ -84,7 +85,7 @@ std::unique_ptr<const RoadGeometry> MakeTwoLaneRoad(bool is_opposing) {
         EndReference().z_at(kEndZ, Direction::kForward));
   }
 
-  return builder.Build(maliput::api::RoadGeometryId("TwoLaneStretchOfRoad"));
+  return builder->Build(maliput::api::RoadGeometryId("TwoLaneStretchOfRoad"));
 }
 
 const Lane* GetLaneById(const RoadGeometry& road, const std::string& lane_id) {


### PR DESCRIPTION
This PR modifies the `Group` class to implement an interface, this way it can be mocked and the loader tests are improved.

Relates to #8899 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9278)
<!-- Reviewable:end -->
