### PR TITLE
RgbdRendererOSPRay: Fix #9274

### DIFF
--- a/systems/sensors/BUILD.bazel
+++ b/systems/sensors/BUILD.bazel
@@ -455,7 +455,67 @@ drake_cc_library(
 )
 
 drake_cc_googletest(
-    name = "rgbd_renderer_ospray_test",
+    name = "rgbd_renderer_ospray_test0",
+    data = [
+        ":test_models",
+    ],
+    tags = vtk_test_tags,
+    deps = [
+        ":rgbd_renderer",
+        ":rgbd_renderer_test_util",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_renderer_ospray_test1",
+    data = [
+        ":test_models",
+    ],
+    tags = vtk_test_tags,
+    deps = [
+        ":rgbd_renderer",
+        ":rgbd_renderer_test_util",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_renderer_ospray_test2",
+    data = [
+        ":test_models",
+    ],
+    tags = vtk_test_tags,
+    deps = [
+        ":rgbd_renderer",
+        ":rgbd_renderer_test_util",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_renderer_ospray_test3",
+    data = [
+        ":test_models",
+    ],
+    tags = vtk_test_tags,
+    deps = [
+        ":rgbd_renderer",
+        ":rgbd_renderer_test_util",
+        "//common:find_resource",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//math:geometric_transform",
+    ],
+)
+
+drake_cc_googletest(
+    name = "rgbd_renderer_ospray_test4",
     data = [
         ":test_models",
     ],

--- a/systems/sensors/test/rgbd_renderer_ospray_test0.cc
+++ b/systems/sensors/test/rgbd_renderer_ospray_test0.cc
@@ -1,5 +1,4 @@
 #include "drake/systems/sensors/rgbd_renderer_ospray.h"
-
 #include "drake/systems/sensors/test/rgbd_renderer_test_util.h"
 
 namespace drake {
@@ -9,6 +8,7 @@ namespace test {
 
 using RgbdRendererOSPRayTest = RgbdRendererTest<RgbdRendererOSPRay>;
 using Eigen::Isometry3d;
+
 
 TEST_F(RgbdRendererOSPRayTest, InstantiationTest) {
   Init(Isometry3d::Identity());
@@ -92,113 +92,6 @@ TEST_F(RgbdRendererOSPRayTest, HorizonTest) {
     const double expected_horizon = CalcHorizon(z, kFovY, kHeight);
     ASSERT_NEAR(expected_horizon, actual_horizon, 1.001);
   }
-}
-
-TEST_F(RgbdRendererOSPRayTest, BoxTest) {
-  Init(X_WC_, false);
-
-  // Sets up a box.
-  Isometry3d X_WV = Isometry3d::Identity();
-  X_WV.translation().z() = 0.5;
-  DrakeShapes::VisualElement visual(X_WV);
-  Eigen::Vector3d box_size(1, 1, 1);
-  visual.setGeometry(DrakeShapes::Box(box_size));
-  const int kBodyID = 0;
-  const RgbdRenderer::VisualIndex kVisualID(0);
-  renderer_->RegisterVisual(visual, kBodyID);
-  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
-  renderer_->RenderColorImage(&color_);
-
-  // Verifies outside the box.
-  for (const auto& p : kOutliers) {
-    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
-                 kColorPixelTolerance);
-  }
-  // Verifies inside the box.
-  const int x = kInlier.x;
-  const int y = kInlier.y;
-  // Color
-  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
-               kColorPixelTolerance);
-}
-
-TEST_F(RgbdRendererOSPRayTest, SphereTest) {
-  Init(X_WC_, false);
-
-  // Sets up a sphere.
-  Isometry3d X_WV = Isometry3d::Identity();
-  X_WV.translation().z() = 0.5;
-  DrakeShapes::VisualElement visual(X_WV);
-  visual.setGeometry(DrakeShapes::Sphere(0.5));
-  const int kBodyID = 0;
-  const RgbdRenderer::VisualIndex kVisualID(0);
-  renderer_->RegisterVisual(visual, kBodyID);
-  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
-  renderer_->RenderColorImage(&color_);
-
-  // Verifies outside the sphere.
-  for (const auto& p : kOutliers) {
-    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
-                 kColorPixelTolerance);
-  }
-  // Verifies inside the sphere.
-  const int x = kInlier.x;
-  const int y = kInlier.y;
-  // Color
-  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
-               kColorPixelTolerance);
-}
-
-TEST_F(RgbdRendererOSPRayTest, CylinderTest) {
-  Init(X_WC_, false);
-
-  // Sets up a cylinder.
-  Isometry3d X_WV = Isometry3d::Identity();
-  X_WV.translation().z() = 0.6;
-  DrakeShapes::VisualElement visual(X_WV);
-  visual.setGeometry(DrakeShapes::Cylinder(0.2, 1.2));  // Radius and length.
-  const int kBodyID = 1;
-  const RgbdRenderer::VisualIndex kVisualID(0);
-  renderer_->RegisterVisual(visual, kBodyID);
-  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
-  renderer_->RenderColorImage(&color_);
-
-  // Verifies outside the cylinder.
-  for (const auto& p : kOutliers) {
-    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
-                 kColorPixelTolerance);
-  }
-  // Verifies inside the cylinder.
-  const int x = kInlier.x;
-  const int y = kInlier.y;
-  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
-               kColorPixelTolerance);
-}
-
-TEST_F(RgbdRendererOSPRayTest, MeshTest) {
-  Init(X_WC_, false);
-
-  Isometry3d X_WV = Isometry3d::Identity();
-  DrakeShapes::VisualElement visual(X_WV);
-  auto filename =
-      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
-  visual.setGeometry(DrakeShapes::Mesh("", filename));
-  const int kBodyID = 0;
-  const RgbdRenderer::VisualIndex kVisualID(0);
-  renderer_->RegisterVisual(visual, kBodyID);
-  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
-  renderer_->RenderColorImage(&color_);
-
-  // Verifies outside the mesh.
-  for (const auto& p : kOutliers) {
-    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
-                 kColorPixelTolerance);
-  }
-  // Verifies inside the mesh.
-  const int x = kInlier.x;
-  const int y = kInlier.y;
-  // Color
-  CompareColor(color_.at(x, y), ColorI({104, 255, 129}), 214u, 2);
 }
 
 TEST_F(RgbdRendererOSPRayTest, MeshMaterialNotFoundTest) {

--- a/systems/sensors/test/rgbd_renderer_ospray_test1.cc
+++ b/systems/sensors/test/rgbd_renderer_ospray_test1.cc
@@ -1,0 +1,40 @@
+#include "drake/systems/sensors/rgbd_renderer_ospray.h"
+#include "drake/systems/sensors/test/rgbd_renderer_test_util.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace test {
+
+using RgbdRendererOSPRayTest = RgbdRendererTest<RgbdRendererOSPRay>;
+using Eigen::Isometry3d;
+
+TEST_F(RgbdRendererOSPRayTest, MeshTest) {
+  Init(X_WC_, false);
+
+  Isometry3d X_WV = Isometry3d::Identity();
+  DrakeShapes::VisualElement visual(X_WV);
+  auto filename =
+      FindResourceOrThrow("drake/systems/sensors/test/models/meshes/box.obj");
+  visual.setGeometry(DrakeShapes::Mesh("", filename));
+  const int kBodyID = 0;
+  const RgbdRenderer::VisualIndex kVisualID(0);
+  renderer_->RegisterVisual(visual, kBodyID);
+  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
+  renderer_->RenderColorImage(&color_);
+  // Verifies outside the mesh.
+  for (const auto& p : kOutliers) {
+    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
+                 kColorPixelTolerance);
+  }
+  // Verifies inside the mesh.
+  const int x = kInlier.x;
+  const int y = kInlier.y;
+  // Color
+  CompareColor(color_.at(x, y), ColorI({104, 255, 129}), 214u, 2);
+}
+
+}  // namespace test
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_renderer_ospray_test2.cc
+++ b/systems/sensors/test/rgbd_renderer_ospray_test2.cc
@@ -1,0 +1,44 @@
+#include "drake/systems/sensors/rgbd_renderer_ospray.h"
+#include "drake/systems/sensors/test/rgbd_renderer_test_util.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace test {
+
+using RgbdRendererOSPRayTest = RgbdRendererTest<RgbdRendererOSPRay>;
+using Eigen::Isometry3d;
+
+
+TEST_F(RgbdRendererOSPRayTest, BoxTest) {
+  Init(X_WC_, false);
+
+  // Sets up a box.
+  Isometry3d X_WV = Isometry3d::Identity();
+  X_WV.translation().z() = 0.5;
+  DrakeShapes::VisualElement visual(X_WV);
+  Eigen::Vector3d box_size(1, 1, 1);
+  visual.setGeometry(DrakeShapes::Box(box_size));
+  const int kBodyID = 0;
+  const RgbdRenderer::VisualIndex kVisualID(0);
+  renderer_->RegisterVisual(visual, kBodyID);
+  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
+  renderer_->RenderColorImage(&color_);
+
+  // Verifies outside the box.
+  for (const auto& p : kOutliers) {
+    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
+                 kColorPixelTolerance);
+  }
+  // Verifies inside the box.
+  const int x = kInlier.x;
+  const int y = kInlier.y;
+  // Color
+  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
+               kColorPixelTolerance);
+}
+
+}  // namespace test
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_renderer_ospray_test3.cc
+++ b/systems/sensors/test/rgbd_renderer_ospray_test3.cc
@@ -1,0 +1,43 @@
+#include "drake/systems/sensors/rgbd_renderer_ospray.h"
+#include "drake/systems/sensors/test/rgbd_renderer_test_util.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace test {
+
+using RgbdRendererOSPRayTest = RgbdRendererTest<RgbdRendererOSPRay>;
+using Eigen::Isometry3d;
+
+
+TEST_F(RgbdRendererOSPRayTest, SphereTest) {
+  Init(X_WC_, false);
+
+  // Sets up a sphere.
+  Isometry3d X_WV = Isometry3d::Identity();
+  X_WV.translation().z() = 0.5;
+  DrakeShapes::VisualElement visual(X_WV);
+  visual.setGeometry(DrakeShapes::Sphere(0.5));
+  const int kBodyID = 0;
+  const RgbdRenderer::VisualIndex kVisualID(0);
+  renderer_->RegisterVisual(visual, kBodyID);
+  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
+  renderer_->RenderColorImage(&color_);
+
+  // Verifies outside the sphere.
+  for (const auto& p : kOutliers) {
+    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
+                 kColorPixelTolerance);
+  }
+  // Verifies inside the sphere.
+  const int x = kInlier.x;
+  const int y = kInlier.y;
+  // Color
+  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
+               kColorPixelTolerance);
+}
+
+}  // namespace test
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake

--- a/systems/sensors/test/rgbd_renderer_ospray_test4.cc
+++ b/systems/sensors/test/rgbd_renderer_ospray_test4.cc
@@ -1,0 +1,42 @@
+#include "drake/systems/sensors/rgbd_renderer_ospray.h"
+#include "drake/systems/sensors/test/rgbd_renderer_test_util.h"
+
+namespace drake {
+namespace systems {
+namespace sensors {
+namespace test {
+
+using RgbdRendererOSPRayTest = RgbdRendererTest<RgbdRendererOSPRay>;
+using Eigen::Isometry3d;
+
+
+TEST_F(RgbdRendererOSPRayTest, CylinderTest) {
+  Init(X_WC_, false);
+
+  // Sets up a cylinder.
+  Isometry3d X_WV = Isometry3d::Identity();
+  X_WV.translation().z() = 0.6;
+  DrakeShapes::VisualElement visual(X_WV);
+  visual.setGeometry(DrakeShapes::Cylinder(0.2, 1.2));  // Radius and length.
+  const int kBodyID = 1;
+  const RgbdRenderer::VisualIndex kVisualID(0);
+  renderer_->RegisterVisual(visual, kBodyID);
+  renderer_->UpdateVisualPose(X_WV, kBodyID, kVisualID);
+  renderer_->RenderColorImage(&color_);
+
+  // Verifies outside the cylinder.
+  for (const auto& p : kOutliers) {
+    CompareColor(color_.at(p.x, p.y), ColorI({0, 0, 0}), 0,
+                 kColorPixelTolerance);
+  }
+  // Verifies inside the cylinder.
+  const int x = kInlier.x;
+  const int y = kInlier.y;
+  CompareColor(color_.at(x, y), ColorI({255, 255, 255}), 254u,
+               kColorPixelTolerance);
+}
+
+}  // namespace test
+}  // namespace sensors
+}  // namespace systems
+}  // namespace drake


### PR DESCRIPTION
This fixes #9274.

Note that the original `rgbd_renderer_ospray_test.cc` needed to split into multiple `.cc` files to avoid unexpected termination issue. This is probably related to multithreading mechanism in OSPRay, but I don't exactly know where it is and even why this happens. With this split, I ran the unit test 100 times and had no problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9284)
<!-- Reviewable:end -->
