### PR TITLE
Minor comment fixes, and updates CollectRegisteredGeometries.

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -341,12 +341,12 @@ MultibodyPlant<T>::GetCollisionGeometriesForBody(const Body<T>& body) const {
 
 template <typename T>
 geometry::GeometrySet MultibodyPlant<T>::CollectRegisteredGeometries(
-    const std::vector<const RigidBody<T>*>& bodies) const {
+    const std::vector<const Body<T>*>& bodies) const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(geometry_source_is_registered());
 
   geometry::GeometrySet geometry_set;
-  for (const RigidBody<T>* body : bodies) {
+  for (const Body<T>* body : bodies) {
     optional<FrameId> frame_id = GetBodyFrameIdIfExists(body->index());
     if (frame_id) {
       geometry_set.Add(frame_id.value());

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -600,7 +600,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///
   /// @{
 
-  /// Returns a constant reference to a rigid body that is identified
+  /// Returns a constant reference to a body that is identified
   /// by the string `name` in `this` %MultibodyPlant.
   /// @throws std::logic_error if there is no body with the requested name.
   /// @throws std::logic_error if the body name occurs in multiple model
@@ -611,7 +611,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     return model_->GetBodyByName(name);
   }
 
-  /// Returns a constant reference to the rigid body that is uniquely identified
+  /// Returns a constant reference to the body that is uniquely identified
   /// by the string `name` and @p model_instance in `this` %MultibodyPlant.
   /// @throws std::logic_error if there is no body with the requested name.
   /// @see HasBodyNamed() to query if there exists a body in `this`
@@ -846,7 +846,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///
   /// @throws std::exception if called pre-finalize.
   geometry::GeometrySet CollectRegisteredGeometries(
-      const std::vector<const RigidBody<T>*>& bodies) const;
+      const std::vector<const Body<T>*>& bodies) const;
 
   /// Returns the friction coefficients provided during geometry registration
   /// for the given geometry `id`. We call these the "default" coefficients but


### PR DESCRIPTION
Allows `CollectRegisteredGeometries` to take in a more general Body object (vs. RigidBody).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9291)
<!-- Reviewable:end -->
