### PR TITLE
Adds a status return to event handlers

### DIFF
--- a/attic/manipulation/dev/quasistatic_system.cc
+++ b/attic/manipulation/dev/quasistatic_system.cc
@@ -880,10 +880,11 @@ void QuasistaticSystem<Scalar>::StepForward(
 }
 
 template <class Scalar>
-void QuasistaticSystem<Scalar>::DoCalcDiscreteVariableUpdates(
-    const drake::systems::Context<Scalar>& context,
-    const std::vector<const drake::systems::DiscreteUpdateEvent<Scalar>*>&,
-    drake::systems::DiscreteValues<Scalar>* discrete_state_ptr) const {
+systems::EventHandlerStatus
+QuasistaticSystem<Scalar>::DoCalcDiscreteVariableUpdates(
+    const systems::Context<Scalar>& context,
+    const std::vector<const systems::DiscreteUpdateEvent<Scalar>*>&,
+    systems::DiscreteValues<Scalar>* discrete_state_ptr) const {
   // copy of discrete states at current time step (l)
   VectorX<Scalar> discrete_state_vector =
       context.get_discrete_state(0).CopyToVector();
@@ -979,6 +980,8 @@ void QuasistaticSystem<Scalar>::DoCalcDiscreteVariableUpdates(
   discrete_state_vector << ql1, delta_q_value, lambda_n_value, lambda_f_value,
       gamma_value, z_n_value, z_f_value, z_gamma_value;
   discrete_state_ptr->get_mutable_vector().SetFromVector(discrete_state_vector);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 // explicit template instantiations

--- a/attic/manipulation/dev/quasistatic_system.h
+++ b/attic/manipulation/dev/quasistatic_system.h
@@ -77,7 +77,7 @@ class QuasistaticSystem : public systems::LeafSystem<Scalar> {
 
  protected:
   void Initialize();
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<Scalar>& context,
       const std::vector<const systems::DiscreteUpdateEvent<Scalar>*>&,
       systems::DiscreteValues<Scalar>* discrete_state) const override;

--- a/attic/manipulation/planner/robot_plan_interpolator.cc
+++ b/attic/manipulation/planner/robot_plan_interpolator.cc
@@ -164,7 +164,7 @@ void RobotPlanInterpolator::Initialize(double plan_start_time,
   state->get_mutable_abstract_state<bool>(kAbsStateIdxInitFlag) = true;
 }
 
-void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
@@ -241,6 +241,8 @@ void RobotPlanInterpolator::DoCalcUnrestrictedUpdate(
       plan.pp_double_deriv = plan.pp_deriv.derivative();
     }
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 }  // namespace planner

--- a/attic/manipulation/planner/robot_plan_interpolator.h
+++ b/attic/manipulation/planner/robot_plan_interpolator.h
@@ -78,9 +78,10 @@ class RobotPlanInterpolator : public systems::LeafSystem<double> {
   std::unique_ptr<systems::AbstractValues> AllocateAbstractState()
       const override;
 
-  void DoCalcUnrestrictedUpdate(const systems::Context<double>& context,
-            const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
-            systems::State<double>* state) const override;
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
+      const systems::Context<double>& context,
+      const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
+      systems::State<double>* state) const override;
 
  private:
   struct PlanData;

--- a/attic/multibody/rigid_body_plant/drake_visualizer.cc
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.cc
@@ -119,14 +119,14 @@ void DrakeVisualizer::PlaybackTrajectory(
                 message_bytes.size(), sim_time);
 }
 
-void DrakeVisualizer::DoPublish(
+EventHandlerStatus DrakeVisualizer::DoPublish(
     const Context<double>& context,
     const std::vector<const PublishEvent<double>*>& event) const {
   // Initialization should only happen as a singleton event.
   if (event.size() == 1 && event.front()->get_trigger_type() ==
       Event<double>::TriggerType::kInitialization) {
     PublishLoadRobot();
-    return;
+    return EventHandlerStatus::Succeeded();
   }
 
   // Obtains the input vector, which contains the generalized q,v state of the
@@ -147,6 +147,7 @@ void DrakeVisualizer::DoPublish(
   // Publishes onto the specified LCM channel.
   lcm_->Publish("DRAKE_VIEWER_DRAW", message_bytes.data(),
                 message_bytes.size(), context.get_time());
+  return EventHandlerStatus::Succeeded();
 }
 
 void DrakeVisualizer::PublishLoadRobot() const {

--- a/attic/multibody/rigid_body_plant/drake_visualizer.h
+++ b/attic/multibody/rigid_body_plant/drake_visualizer.h
@@ -122,9 +122,9 @@ class DrakeVisualizer : public LeafSystem<double> {
 
   // If @p events has only 1 kInitialization trigger typed event, calls
   // PublishLoadRobot. Otherwise it publishes a draw message.
-  void DoPublish(const systems::Context<double>& context,
-                 const std::vector<const PublishEvent<double>*>& events)
-                 const override;
+  EventHandlerStatus DoPublish(
+      const systems::Context<double>& context,
+      const std::vector<const PublishEvent<double>*>& events) const override;
 
   // A pointer to the LCM subsystem. It is through this object that LCM messages
   // are published.

--- a/attic/multibody/rigid_body_plant/frame_visualizer.cc
+++ b/attic/multibody/rigid_body_plant/frame_visualizer.cc
@@ -25,7 +25,7 @@ FrameVisualizer::FrameVisualizer(
   }
 }
 
-void FrameVisualizer::DoPublish(
+systems::EventHandlerStatus FrameVisualizer::DoPublish(
     const systems::Context<double>& context,
     const std::vector<const PublishEvent<double>*>&) const {
   KinematicsCache<double> cache = tree_.CreateKinematicsCache();
@@ -52,6 +52,7 @@ void FrameVisualizer::DoPublish(
   }
 
   drake::lcm::Publish(lcm_, lcm_channel_, msg, context.get_time());
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 }  // namespace systems

--- a/attic/multibody/rigid_body_plant/frame_visualizer.h
+++ b/attic/multibody/rigid_body_plant/frame_visualizer.h
@@ -53,7 +53,7 @@ class FrameVisualizer : public LeafSystem<double> {
   }
 
  private:
-  void DoPublish(
+  systems::EventHandlerStatus DoPublish(
       const systems::Context<double>& context,
       const std::vector<const PublishEvent<double>*>&) const override;
 

--- a/attic/multibody/rigid_body_plant/rigid_body_plant.cc
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.cc
@@ -975,7 +975,7 @@ void RigidBodyPlant<T>::DoCalcTimeDerivatives(
 
 template <typename T>
 template <typename U>
-std::enable_if_t<std::is_same<U, double>::value, void>
+std::enable_if_t<std::is_same<U, double>::value, EventHandlerStatus>
 RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
     const drake::systems::Context<U>& context,
     const std::vector<const drake::systems::DiscreteUpdateEvent<U>*>&,
@@ -983,7 +983,7 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
   using std::abs;
 
   // If plant state is continuous, no discrete state to update.
-  if (!is_state_discrete()) return;
+  if (!is_state_discrete()) return EventHandlerStatus::DidNothing();
 
   // Get the time step.
   const T t = context.get_discrete_state(1).get_value()[0];
@@ -1230,11 +1230,13 @@ RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
       new_velocity;
   updates->get_mutable_vector(0).SetFromVector(xn);
   updates->get_mutable_vector(1)[0] = t + dt;
+
+  return EventHandlerStatus::Succeeded();
 }
 
 template <typename T>
 template <typename U>
-std::enable_if_t<!std::is_same<U, double>::value, void>
+std::enable_if_t<!std::is_same<U, double>::value, EventHandlerStatus>
 RigidBodyPlant<T>::DoCalcDiscreteVariableUpdatesImpl(
     const drake::systems::Context<U>&,
     const std::vector<const drake::systems::DiscreteUpdateEvent<U>*>&,

--- a/attic/multibody/rigid_body_plant/rigid_body_plant.h
+++ b/attic/multibody/rigid_body_plant/rigid_body_plant.h
@@ -419,12 +419,12 @@ class RigidBodyPlant : public LeafSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override;
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const drake::systems::Context<T>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
       drake::systems::DiscreteValues<T>* updates) const override {
     // Pass to SFINAE compatible implementation.
-    DoCalcDiscreteVariableUpdatesImpl(context, events, updates);
+    return DoCalcDiscreteVariableUpdatesImpl(context, events, updates);
   }
 
   optional<bool> DoHasDirectFeedthrough(int, int) const override;
@@ -466,14 +466,14 @@ class RigidBodyPlant : public LeafSystem<T> {
   void initialize(void);
 
   template <typename U = T>
-  std::enable_if_t<std::is_same<U, double>::value, void>
+  std::enable_if_t<std::is_same<U, double>::value, EventHandlerStatus>
   DoCalcDiscreteVariableUpdatesImpl(
       const drake::systems::Context<U>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<U>*>& events,
       drake::systems::DiscreteValues<U>* updates) const;
 
   template <typename U = T>
-  std::enable_if_t<!std::is_same<U, double>::value, void>
+  std::enable_if_t<!std::is_same<U, double>::value, EventHandlerStatus>
   DoCalcDiscreteVariableUpdatesImpl(
       const drake::systems::Context<U>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<U>*>& events,

--- a/attic/systems/controllers/plan_eval/plan_eval_base_system.h
+++ b/attic/systems/controllers/plan_eval/plan_eval_base_system.h
@@ -42,11 +42,11 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
   /**
    * Calls DoExtendedCalcUnrestrictedUpdate().
    */
-  void DoCalcUnrestrictedUpdate(
+  EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
       systems::State<double>* state) const final {
-    DoExtendedCalcUnrestrictedUpdate(context, state);
+    return DoExtendedCalcUnrestrictedUpdate(context, state);
   }
 
   /**
@@ -96,7 +96,7 @@ class PlanEvalBaseSystem : public systems::LeafSystem<double> {
   /**
    * Derived classes need to implement this for custom behaviors.
    */
-  virtual void DoExtendedCalcUnrestrictedUpdate(
+  virtual EventHandlerStatus DoExtendedCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       systems::State<double>* state) const = 0;
 

--- a/attic/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
+++ b/attic/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.cc
@@ -64,7 +64,7 @@ void QpInverseDynamicsSystem::CopyOutDebugInfo(
       abs_state_index_debug_info_);
 }
 
-void QpInverseDynamicsSystem::DoCalcUnrestrictedUpdate(
+EventHandlerStatus QpInverseDynamicsSystem::DoCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
@@ -85,8 +85,8 @@ void QpInverseDynamicsSystem::DoCalcUnrestrictedUpdate(
     err << rs->get_cache().getQ().transpose() << "\n";
     err << rs->get_cache().getV().transpose() << "\n";
     err << *qp_input << std::endl;
-    throw std::runtime_error("QpInverseDynamicsSystem: QP cannot solve\n" +
-                             err.str());
+    return EventHandlerStatus::Failed(this,
+        "QpInverseDynamicsSystem: QP cannot solve\n" + err.str());
   }
 
   // Generates debugging info.
@@ -105,6 +105,8 @@ void QpInverseDynamicsSystem::DoCalcUnrestrictedUpdate(
     debug.solved_vd[i] = qp_output.vd()[i];
     debug.solved_torque[i] = qp_output.dof_torques()[i];
   }
+
+  return EventHandlerStatus::Succeeded();
 }
 
 }  // namespace qp_inverse_dynamics

--- a/attic/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.h
+++ b/attic/systems/controllers/qp_inverse_dynamics/qp_inverse_dynamics_system.h
@@ -29,9 +29,11 @@ class QpInverseDynamicsSystem : public systems::LeafSystem<double> {
    */
   QpInverseDynamicsSystem(const RigidBodyTree<double>* robot, double dt);
 
-  void DoCalcUnrestrictedUpdate(const systems::Context<double>& context,
-     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>& events,
-     systems::State<double>* state) const override;
+  EventHandlerStatus DoCalcUnrestrictedUpdate(
+      const systems::Context<double>& context,
+      const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&
+          events,
+      systems::State<double>* state) const override;
 
   /**
    * Returns the input port for HumanoidStatus.

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.cc
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.cc
@@ -23,8 +23,9 @@ AccelerometerTestLogger::AccelerometerTestLogger(int plant_state_size) {
       this->DeclareInputPort(kVectorValued, 3).get_index();
 }
 
-void AccelerometerTestLogger::DoPublish(const Context<double>& context,
-        const std::vector<const systems::PublishEvent<double>*>&) const {
+EventHandlerStatus AccelerometerTestLogger::DoPublish(
+    const Context<double>& context,
+    const std::vector<const systems::PublishEvent<double>*>&) const {
   if (log_to_console_) {
     std::stringstream buffer;
     buffer <<
@@ -36,6 +37,7 @@ void AccelerometerTestLogger::DoPublish(const Context<double>& context,
         "  - acceleration = " << get_acceleration(context).transpose();
     drake::log()->info(buffer.str());
   }
+  return EventHandlerStatus::Succeeded();
 }
 
 const InputPort<double>&

--- a/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
+++ b/attic/systems/sensors/test/accelerometer_test/accelerometer_test_logger.h
@@ -36,8 +36,9 @@ class AccelerometerTestLogger : public LeafSystem<double> {
 
  private:
   // Logging is done in this method.
-  void DoPublish(const Context<double>& context,
-       const std::vector<const systems::PublishEvent<double>*>&) const override;
+  EventHandlerStatus DoPublish(
+      const Context<double>& context,
+      const std::vector<const systems::PublishEvent<double>*>&) const override;
 
   bool log_to_console_{false};
   int plant_state_derivative_port_index_{};

--- a/automotive/idm_controller.cc
+++ b/automotive/idm_controller.cc
@@ -164,7 +164,7 @@ void IdmController<T>::ImplCalcAcceleration(
 }
 
 template <typename T>
-void IdmController<T>::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus IdmController<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
@@ -184,6 +184,8 @@ void IdmController<T>::DoCalcUnrestrictedUpdate(
       state->template get_mutable_abstract_state<RoadPosition>(0);
 
   CalcOngoingRoadPosition(*ego_pose, *ego_velocity, road_, &rp);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 }  // namespace automotive

--- a/automotive/idm_controller.h
+++ b/automotive/idm_controller.h
@@ -97,7 +97,7 @@ class IdmController : public systems::LeafSystem<T> {
       const maliput::api::RoadPosition& ego_rp,
       systems::BasicVector<T>* command) const;
 
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<T>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
       systems::State<T>* state) const override;

--- a/automotive/maliput_railcar.cc
+++ b/automotive/maliput_railcar.cc
@@ -374,7 +374,7 @@ void MaliputRailcar<T>::DoCalcNextUpdateTime(const systems::Context<T>& context,
 }
 
 template <typename T>
-void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* next_state) const {
@@ -395,11 +395,11 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
   DRAKE_ASSERT(next_railcar_state != nullptr);
 
   // Handles the case where no lane change or speed adjustment is necessary. No
-  // lane change is necessary when the vehicle is more than epilon away from the
-  // next lane boundary.
+  // lane change is necessary when the vehicle is more than epsilon away from
+  // the next lane boundary.
   if ((current_with_s && current_s < current_length - kLaneEndEpsilon) ||
       (!current_with_s && current_s > kLaneEndEpsilon)) {
-    return;
+    return systems::EventHandlerStatus::Succeeded();
   }
 
   // Sets the speed to be zero if the car is at or is after the end of the road.
@@ -464,6 +464,8 @@ void MaliputRailcar<T>::DoCalcUnrestrictedUpdate(
       }
     }
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 // This section must match the API documentation in maliput_railcar.h.

--- a/automotive/maliput_railcar.h
+++ b/automotive/maliput_railcar.h
@@ -133,7 +133,7 @@ class MaliputRailcar final : public systems::LeafSystem<T> {
   void DoCalcNextUpdateTime(const systems::Context<T>& context,
                             systems::CompositeEventCollection<T>*,
                             T* time) const override;
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<T>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
       systems::State<T>* state) const override;

--- a/automotive/mobil_planner.cc
+++ b/automotive/mobil_planner.cc
@@ -302,7 +302,7 @@ const T MobilPlanner<T>::EvaluateIdm(
 }
 
 template <typename T>
-void MobilPlanner<T>::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus MobilPlanner<T>::DoCalcUnrestrictedUpdate(
     const systems::Context<T>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
     systems::State<T>* state) const {
@@ -322,6 +322,8 @@ void MobilPlanner<T>::DoCalcUnrestrictedUpdate(
       state->template get_mutable_abstract_state<RoadPosition>(0);
 
   CalcOngoingRoadPosition(*ego_pose, *ego_velocity, road_, &rp);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 // These instantiations must match the API documentation in mobil_planner.h.

--- a/automotive/mobil_planner.h
+++ b/automotive/mobil_planner.h
@@ -127,7 +127,7 @@ class MobilPlanner : public systems::LeafSystem<T> {
   /// @}
 
  protected:
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<T>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
       systems::State<T>* state) const override;

--- a/bindings/pydrake/manipulation/simple_ui.py
+++ b/bindings/pydrake/manipulation/simple_ui.py
@@ -8,7 +8,9 @@ import numpy as np
 
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
 from pydrake.multibody.multibody_tree import JointIndex
-from pydrake.systems.framework import BasicVector, LeafSystem, VectorSystem
+from pydrake.systems.framework import (
+    BasicVector, EventHandlerStatus, LeafSystem, VectorSystem
+    )
 
 
 class JointSliders(VectorSystem):
@@ -130,6 +132,7 @@ class JointSliders(VectorSystem):
     def _DoPublish(self, context, event):
         self.window.update_idletasks()
         self.window.update()
+        return EventHandlerStatus.Succeeded()
 
     def _DoCalcVectorOutput(self, context, unused, unused2, output):
         output[:] = self._default_position
@@ -210,6 +213,7 @@ class SchunkWsgButtons(LeafSystem):
     def _DoPublish(self, context, event):
         self.window.update_idletasks()
         self.window.update()
+        return EventHandlerStatus.Succeeded()
 
     def CalcPositionOutput(self, context, output):
         if self._open_state:

--- a/bindings/pydrake/systems/analysis_py.cc
+++ b/bindings/pydrake/systems/analysis_py.cc
@@ -21,6 +21,13 @@ PYBIND11_MODULE(analysis, m) {
 
   py::module::import("pydrake.systems.framework");
 
+  py::class_<StepToResult> step_to_result(m, "StepToResult");
+  step_to_result.def("boundary_time", &StepToResult::boundary_time)
+      .def("final_time", &StepToResult::final_time)
+      .def("reason", &StepToResult::reason)
+      .def("system", &StepToResult::system)
+      .def("message", &StepToResult::message);
+
   auto bind_scalar_types = [m](auto dummy) {
     constexpr auto& doc = pydrake_doc.drake.systems;
     using T = decltype(dummy);
@@ -81,8 +88,9 @@ PYBIND11_MODULE(analysis, m) {
             // Keep alive, ownership: `Context` keeps `self` alive.
             py::keep_alive<3, 1>(), doc.Simulator.ctor.doc_3)
         .def("Initialize", &Simulator<T>::Initialize,
-            doc.Simulator.Initialize.doc)
-        .def("StepTo", &Simulator<T>::StepTo, doc.Simulator.StepTo.doc)
+             doc.Simulator.Initialize.doc)
+        .def("StepTo", &Simulator<T>::StepTo, py::arg("boundary_time"),
+             doc.Simulator.StepTo.doc)
         .def("get_context", &Simulator<T>::get_context, py_reference_internal,
             doc.Simulator.get_context.doc)
         .def("get_integrator", &Simulator<T>::get_integrator,

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -51,6 +51,14 @@ void DefineFrameworkPySemantics(py::module m) {
   py::class_<FixedInputPortValue>(
       m, "FixedInputPortValue", doc.FixedInputPortValue.doc);
 
+  py::class_<EventHandlerStatus> event_handler_status(m, "EventHandlerStatus");
+  event_handler_status.def_static("DidNothing", &EventHandlerStatus::DidNothing)
+      .def_static("Succeeded", &EventHandlerStatus::Succeeded)
+      .def_static("ReachedTermination", &EventHandlerStatus::ReachedTermination,
+                  py::arg("system"), py::arg("message"))
+      .def_static("Failed", &EventHandlerStatus::Failed, py::arg("system"),
+                  py::arg("message"));
+
   using AbstractValuePtrList = vector<unique_ptr<AbstractValue>>;
   // N.B. `AbstractValues` provides the ability to reference non-owned values,
   // without copying them. For consistency with other model-value Python

--- a/bindings/pydrake/systems/framework_py_systems.cc
+++ b/bindings/pydrake/systems/framework_py_systems.cc
@@ -34,6 +34,7 @@ using systems::Context;
 using systems::ContinuousState;
 using systems::DiscreteUpdateEvent;
 using systems::DiscreteValues;
+using systems::EventHandlerStatus;
 using systems::LeafSystem;
 using systems::PublishEvent;
 using systems::System;
@@ -103,7 +104,7 @@ struct Impl {
     using Base::Base;
 
     // Trampoline virtual methods.
-    void DoPublish(const Context<T>& context,
+    EventHandlerStatus DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Yuck! We have to dig in and use internals :(
       // We must ensure that pybind only sees pointers, since this method may
@@ -112,9 +113,9 @@ struct Impl {
       // TODO(eric.cousineau): Figure out how to supply different behavior,
       // possibly using function wrapping.
       PYBIND11_OVERLOAD_INT(
-          void, LeafSystem<T>, "_DoPublish", &context, events);
+          EventHandlerStatus, LeafSystem<T>, "_DoPublish", &context, events);
       // If the macro did not return, use default functionality.
-      Base::DoPublish(context, events);
+      return Base::DoPublish(context, events);
     }
 
     optional<bool> DoHasDirectFeedthrough(
@@ -134,14 +135,15 @@ struct Impl {
       Base::DoCalcTimeDerivatives(context, derivatives);
     }
 
-    void DoCalcDiscreteVariableUpdates(const Context<T>& context,
+    EventHandlerStatus DoCalcDiscreteVariableUpdates(const Context<T>& context,
         const std::vector<const DiscreteUpdateEvent<T>*>& events,
         DiscreteValues<T>* discrete_state) const override {
       // See `DoPublish` for explanation.
-      PYBIND11_OVERLOAD_INT(void, LeafSystem<T>,
+      PYBIND11_OVERLOAD_INT(EventHandlerStatus, LeafSystem<T>,
           "_DoCalcDiscreteVariableUpdates", &context, events, discrete_state);
       // If the macro did not return, use default functionality.
-      Base::DoCalcDiscreteVariableUpdates(context, events, discrete_state);
+      return Base::DoCalcDiscreteVariableUpdates(context, events,
+                                                 discrete_state);
     }
   };
 
@@ -168,15 +170,15 @@ struct Impl {
     using Base::Base;
 
     // Trampoline virtual methods.
-    void DoPublish(const Context<T>& context,
+    EventHandlerStatus DoPublish(const Context<T>& context,
         const vector<const PublishEvent<T>*>& events) const override {
       // Copied from above, since we cannot use `PyLeafSystemBase` due to final
       // overrides of some methods.
       // TODO(eric.cousineau): Make this more granular?
       PYBIND11_OVERLOAD_INT(
-          void, VectorSystem<T>, "_DoPublish", &context, events);
+          EventHandlerStatus, VectorSystem<T>, "_DoPublish", &context, events);
       // If the macro did not return, use default functionality.
-      Base::DoPublish(context, events);
+      return Base::DoPublish(context, events);
     }
 
     optional<bool> DoHasDirectFeedthrough(
@@ -218,17 +220,18 @@ struct Impl {
       Base::DoCalcVectorOutput(context, input, state, derivatives);
     }
 
-    void DoCalcVectorDiscreteVariableUpdates(const Context<T>& context,
+    EventHandlerStatus DoCalcVectorDiscreteVariableUpdates(
+        const Context<T>& context,
         const Eigen::VectorBlock<const VectorX<T>>& input,
         const Eigen::VectorBlock<const VectorX<T>>& state,
         Eigen::VectorBlock<VectorX<T>>* next_state) const override {
       // WARNING: Mutating `next_state` will not work when T is AutoDiffXd,
       // Expression, etc. See above.
-      PYBIND11_OVERLOAD_INT(void, VectorSystem<T>,
+      PYBIND11_OVERLOAD_INT(EventHandlerStatus, VectorSystem<T>,
           "_DoCalcVectorDiscreteVariableUpdates", &context, input, state,
           ToEigenRef(next_state));
       // If the macro did not return, use default functionality.
-      Base::DoCalcVectorDiscreteVariableUpdates(
+      return Base::DoCalcVectorDiscreteVariableUpdates(
           context, input, state, next_state);
     }
   };
@@ -323,7 +326,7 @@ struct Impl {
             py::arg("max_depth") = std::numeric_limits<int>::max())
         // Events.
         .def("Publish",
-            overload_cast_explicit<void, const Context<T>&>(
+            overload_cast_explicit<EventHandlerStatus, const Context<T>&>(
                 &System<T>::Publish),
             doc.System.Publish.doc_1args)
         // Scalar types.

--- a/bindings/pydrake/systems/meshcat_visualizer.py
+++ b/bindings/pydrake/systems/meshcat_visualizer.py
@@ -16,7 +16,7 @@ from pydrake.geometry import DispatchLoadMessage, SceneGraph
 from pydrake.lcm import DrakeMockLcm
 from pydrake.math import RigidTransform, RotationMatrix
 from pydrake.systems.framework import (
-    AbstractValue, LeafSystem, PublishEvent, TriggerType
+    AbstractValue, EventHandlerStatus, LeafSystem, PublishEvent, TriggerType
 )
 from pydrake.systems.rendering import PoseBundle
 
@@ -119,6 +119,7 @@ class MeshcatVisualizer(LeafSystem):
 
         def on_initialize(context, event):
             self.load()
+            return EventHandlerStatus.Succeeded()
 
         self._DeclareInitializationEvent(
             event=PublishEvent(
@@ -218,3 +219,5 @@ class MeshcatVisualizer(LeafSystem):
             # TODO(russt): Use a more textual naming convention here?
             self.vis[self.prefix][source_name][str(model_id)][frame_name]\
                 .set_transform(pose_bundle.get_pose(frame_i).matrix())
+
+        return EventHandlerStatus.Succeeded()

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -17,6 +17,7 @@ from pydrake.systems.framework import (
     BasicVector, BasicVector_,
     Context,
     DiagramBuilder,
+    EventHandlerStatus,
     kUseDefaultName,
     LeafSystem, LeafSystem_,
     PortDataType,
@@ -93,6 +94,7 @@ class CustomVectorSystem(VectorSystem):
     def _DoCalcVectorDiscreteVariableUpdates(self, context, u, x, x_n):
         x_n[:] = x + 2*u
         self.has_called.append("discrete")
+        return EventHandlerStatus.Succeeded()
 
     def _DoHasDirectFeedthrough(self, input_port, output_port):
         self.has_called.append("feedthrough")
@@ -186,8 +188,6 @@ class TestCustom(unittest.TestCase):
                 self._DeclareVectorOutputPort(BasicVector(1), noop)
 
             def _DoPublish(self, context, events):
-                # Call base method to ensure we do not get recursion.
-                LeafSystem._DoPublish(self, context, events)
                 # N.B. We do not test for a singular call to `DoPublish`
                 # (checking `assertFalse(self.called_publish)` first) because
                 # the above `_DeclareInitializationEvent` will call both its
@@ -195,6 +195,8 @@ class TestCustom(unittest.TestCase):
                 # `Simulator::Initialize` from `call_leaf_system_overrides`,
                 # even when we explicitly say not to publish at initialize.
                 self.called_publish = True
+                # Call base method to ensure we do not get recursion.
+                return LeafSystem._DoPublish(self, context, events)
 
             def _DoHasDirectFeedthrough(self, input_port, output_port):
                 # Test inputs.
@@ -216,27 +218,30 @@ class TestCustom(unittest.TestCase):
 
             def _DoCalcDiscreteVariableUpdates(
                     self, context, events, discrete_state):
-                # Call base method to ensure we do not get recursion.
-                LeafSystem._DoCalcDiscreteVariableUpdates(
-                    self, context, events, discrete_state)
                 self.called_discrete = True
+                # Call base method to ensure we do not get recursion.
+                return LeafSystem._DoCalcDiscreteVariableUpdates(
+                    self, context, events, discrete_state)
 
             def _on_initialize(self, context, event):
                 test.assertIsInstance(context, Context)
                 test.assertIsInstance(event, PublishEvent)
                 test.assertFalse(self.called_initialize)
                 self.called_initialize = True
+                return EventHandlerStatus.Succeeded()
 
             def _on_per_step(self, context, event):
                 test.assertIsInstance(context, Context)
                 test.assertIsInstance(event, PublishEvent)
                 self.called_per_step = True
+                return EventHandlerStatus.Succeeded()
 
             def _on_periodic(self, context, event):
                 test.assertIsInstance(context, Context)
                 test.assertIsInstance(event, PublishEvent)
                 test.assertFalse(self.called_periodic)
                 self.called_periodic = True
+                return EventHandlerStatus.Succeeded()
 
         system = TrivialSystem()
         self.assertFalse(system.called_publish)

--- a/examples/allegro_hand/allegro_lcm.cc
+++ b/examples/allegro_hand/allegro_lcm.cc
@@ -13,6 +13,7 @@ using systems::BasicVector;
 using systems::Context;
 using systems::DiscreteValues;
 using systems::DiscreteUpdateEvent;
+using systems::EventHandlerStatus;
 
 AllegroCommandReceiver::AllegroCommandReceiver(int num_joints)
     : num_joints_(num_joints) {
@@ -43,7 +44,7 @@ void AllegroCommandReceiver::set_initial_position(
   state_value.head(num_joints_) = x;
 }
 
-void AllegroCommandReceiver::DoCalcDiscreteVariableUpdates(
+EventHandlerStatus AllegroCommandReceiver::DoCalcDiscreteVariableUpdates(
     const Context<double>& context,
     const std::vector<const DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
@@ -75,6 +76,8 @@ void AllegroCommandReceiver::DoCalcDiscreteVariableUpdates(
     for (int i = 0; i < num_joints_; i++)
       state_value[2 * num_joints_ + i] = command.joint_torque[i];
   }
+
+  return EventHandlerStatus::Succeeded();
 }
 
 void AllegroCommandReceiver::CopyStateToOutput(

--- a/examples/allegro_hand/allegro_lcm.h
+++ b/examples/allegro_hand/allegro_lcm.h
@@ -55,7 +55,7 @@ class AllegroCommandReceiver : public systems::LeafSystem<double> {
                          int length,
                          systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<double>& context,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
       systems::DiscreteValues<double>* discrete_state) const override;

--- a/examples/bouncing_ball/bouncing_ball.h
+++ b/examples/bouncing_ball/bouncing_ball.h
@@ -107,7 +107,8 @@ class BouncingBall final : public systems::LeafSystem<T> {
   // Updates the velocity discontinuously to reverse direction. This method
   // is called by the Simulator when the signed distance witness function
   // triggers.
-  void DoCalcUnrestrictedUpdate(const systems::Context<T>& context,
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
+      const systems::Context<T>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<T>*>&,
       systems::State<T>* next_state) const override {
     systems::VectorBase<T>& next_cstate =
@@ -132,6 +133,8 @@ class BouncingBall final : public systems::LeafSystem<T> {
     //                 body collisions. J. Appl. Mech., 58:1049-1055, 1991.
     next_cstate.SetAtIndex(
         1, cstate.GetAtIndex(1) * restitution_coef_ * -1.);
+
+    return systems::EventHandlerStatus::Succeeded();
   }
 
   // The signed distance witness function is always active and, hence, always

--- a/examples/compass_gait/compass_gait.cc
+++ b/examples/compass_gait/compass_gait.cc
@@ -108,7 +108,7 @@ T CompassGait<T>::FootCollision(const systems::Context<T>& context) const {
 }
 
 template <typename T>
-void CompassGait<T>::CollisionDynamics(
+systems::EventHandlerStatus CompassGait<T>::CollisionDynamics(
     const systems::Context<T>& context,
     const systems::UnrestrictedUpdateEvent<T>&,
     systems::State<T>* state) const {
@@ -177,6 +177,8 @@ void CompassGait<T>::CollisionDynamics(
 
   // Switch stance foot from left to right (or back).
   set_left_leg_is_stance(!left_leg_is_stance(context), state);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 template <typename T>

--- a/examples/compass_gait/compass_gait.h
+++ b/examples/compass_gait/compass_gait.h
@@ -144,9 +144,10 @@ class CompassGait final : public systems::LeafSystem<T> {
   T FootCollision(const systems::Context<T>& context) const;
 
   // Handles the impact dynamics, including resetting the stance and swing legs.
-  void CollisionDynamics(const systems::Context<T> &context,
-                         const systems::UnrestrictedUpdateEvent<T> &,
-                         systems::State<T> *state) const;
+  systems::EventHandlerStatus CollisionDynamics(
+      const systems::Context<T>& context,
+      const systems::UnrestrictedUpdateEvent<T>&,
+      systems::State<T>* state) const;
 
   void MinimalStateOut(const systems::Context<T>& context,
                        CompassGaitContinuousState<T>* output) const;

--- a/examples/humanoid_controller/humanoid_plan_eval_system.cc
+++ b/examples/humanoid_controller/humanoid_plan_eval_system.cc
@@ -31,7 +31,8 @@ HumanoidPlanEvalSystem::HumanoidPlanEvalSystem(
   abs_state_index_plan_ = DeclareAbstractState(std::move(plan_as_value));
 }
 
-void HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
+systems::EventHandlerStatus
+HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     systems::State<double>* state) const {
   // Gets the plan from abstract state.
@@ -59,6 +60,8 @@ void HumanoidPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
   QpInput& qp_input = get_mutable_qp_input(state);
   plan.UpdateQpInput(*robot_status, get_paramset(), get_alias_groups(),
                      &qp_input);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void HumanoidPlanEvalSystem::Initialize(

--- a/examples/humanoid_controller/humanoid_plan_eval_system.h
+++ b/examples/humanoid_controller/humanoid_plan_eval_system.h
@@ -64,7 +64,7 @@ class HumanoidPlanEvalSystem
  private:
   int get_num_extended_abstract_states() const override { return 1; }
 
-  void DoExtendedCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoExtendedCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       systems::State<double>* state) const override;
 

--- a/examples/kinova_jaco_arm/jaco_lcm.cc
+++ b/examples/kinova_jaco_arm/jaco_lcm.cc
@@ -52,7 +52,7 @@ void JacoCommandReceiver::set_initial_position(
       VectorX<double>::Zero(num_joints_ + num_fingers_);
 }
 
-void JacoCommandReceiver::DoCalcDiscreteVariableUpdates(
+systems::EventHandlerStatus JacoCommandReceiver::DoCalcDiscreteVariableUpdates(
     const Context<double>& context,
     const std::vector<const DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
@@ -80,6 +80,8 @@ void JacoCommandReceiver::DoCalcDiscreteVariableUpdates(
     velocities(i + num_joints_) =
         command.finger_velocity[i] * kFingerSdkToUrdf;
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void JacoCommandReceiver::OutputCommand(const Context<double>& context,
@@ -137,7 +139,7 @@ JacoStatusReceiver::JacoStatusReceiver(int num_joints, int num_fingers)
   this->DeclarePeriodicDiscreteUpdate(kJacoLcmStatusPeriod);
 }
 
-void JacoStatusReceiver::DoCalcDiscreteVariableUpdates(
+systems::EventHandlerStatus JacoStatusReceiver::DoCalcDiscreteVariableUpdates(
     const Context<double>& context,
     const std::vector<const DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
@@ -169,6 +171,8 @@ void JacoStatusReceiver::DoCalcDiscreteVariableUpdates(
     velocities(i + num_joints_) =
         status.finger_velocity[i] * kFingerSdkToUrdf;
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void JacoStatusReceiver::OutputStatus(const Context<double>& context,

--- a/examples/kinova_jaco_arm/jaco_lcm.h
+++ b/examples/kinova_jaco_arm/jaco_lcm.h
@@ -65,7 +65,7 @@ class JacoCommandReceiver : public systems::LeafSystem<double> {
   void OutputCommand(const systems::Context<double>& context,
                      systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<double>& context,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
       systems::DiscreteValues<double>* discrete_state) const override;
@@ -133,7 +133,7 @@ class JacoStatusReceiver : public systems::LeafSystem<double> {
   void OutputStatus(const systems::Context<double>& context,
                     systems::BasicVector<double>* output) const;
 
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<double>& context,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
       systems::DiscreteValues<double>* discrete_state) const override;

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.cc
@@ -128,7 +128,8 @@ void PickAndPlaceStateMachineSystem::CalcWsgCommand(
   *wsg_command = internal_state.last_wsg_command;
 }
 
-void PickAndPlaceStateMachineSystem::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus
+PickAndPlaceStateMachineSystem::DoCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
@@ -172,6 +173,8 @@ void PickAndPlaceStateMachineSystem::DoCalcUnrestrictedUpdate(
       });
   internal_state.state_machine.Update(internal_state.world_state, iiwa_callback,
                                       wsg_callback);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 pick_and_place::PickAndPlaceState PickAndPlaceStateMachineSystem::state(

--- a/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.h
+++ b/examples/kuka_iiwa_arm/dev/pick_and_place/state_machine_system.h
@@ -47,7 +47,7 @@ class PickAndPlaceStateMachineSystem : public systems::LeafSystem<double> {
   void SetDefaultState(const systems::Context<double>& context,
                        systems::State<double>* state) const override;
 
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
       systems::State<double>* state) const override;

--- a/examples/kuka_iiwa_arm/iiwa_lcm.cc
+++ b/examples/kuka_iiwa_arm/iiwa_lcm.cc
@@ -53,7 +53,7 @@ void IiwaCommandReceiver::set_initial_position(
   state_value.head(num_joints_) = x;
 }
 
-void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
+systems::EventHandlerStatus IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
     const Context<double>& context,
     const std::vector<const DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
@@ -86,6 +86,8 @@ void IiwaCommandReceiver::DoCalcDiscreteVariableUpdates(
     for (int i = 0; i < num_joints_; i++)
       state_value[2 * num_joints_ + i] = command.joint_torque[i];
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void IiwaCommandReceiver::CopyStateToOutput(const Context<double>& context,

--- a/examples/kuka_iiwa_arm/iiwa_lcm.h
+++ b/examples/kuka_iiwa_arm/iiwa_lcm.h
@@ -56,7 +56,7 @@ class IiwaCommandReceiver : public systems::LeafSystem<double> {
                          systems::BasicVector<double>* output) const;
 
   // TODO(russt): This system should NOT have any state.
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<double>& context,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
       systems::DiscreteValues<double>* discrete_state) const override;

--- a/examples/manipulation_station/end_effector_teleop.py
+++ b/examples/manipulation_station/end_effector_teleop.py
@@ -16,8 +16,8 @@ from pydrake.multibody.multibody_tree.parsing import AddModelFromSdfFile
 from pydrake.math import RigidTransform, RollPitchYaw
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import (AbstractValue, BasicVector,
-                                       DiagramBuilder, LeafSystem,
-                                       PortDataType)
+                                       DiagramBuilder, EventHandlerStatus,
+                                       LeafSystem, PortDataType)
 from pydrake.systems.meshcat_visualizer import MeshcatVisualizer
 from pydrake.systems.primitives import FirstOrderLowPassFilter
 from pydrake.util.eigen_geometry import Isometry3, AngleAxis
@@ -99,6 +99,7 @@ class EndEffectorTeleop(LeafSystem):
     def _DoPublish(self, context, event):
         self.window.update_idletasks()
         self.window.update()
+        return EventHandlerStatus.Succeeded()
 
     def _DoCalcOutput(self, context, output):
         output.SetAtIndex(0, self.roll.get())
@@ -196,6 +197,7 @@ class DifferentialIK(LeafSystem):
         else:
             discrete_state.get_mutable_vector().\
                 SetFromVector(q_last + self.time_step*result.joint_velocities)
+        return EventHandlerStatus.Succeeded()
 
     def CopyPositionOut(self, context, output):
         output.SetFromVector(context.get_discrete_state_vector().get_value())

--- a/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.cc
+++ b/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.cc
@@ -73,7 +73,8 @@ void ManipulatorMoveJointPlanEvalSystem::OutputDebugInfo(
       abs_state_index_debug_);
 }
 
-void ManipulatorMoveJointPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
+systems::EventHandlerStatus
+ManipulatorMoveJointPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     systems::State<double>* state) const {
   // Gets the plan from abstract state.
@@ -126,6 +127,8 @@ void ManipulatorMoveJointPlanEvalSystem::DoExtendedCalcUnrestrictedUpdate(
     debug.nominal_v[i] = plan.desired_velocity()[i];
     debug.nominal_vd[i] = plan.desired_acceleration()[i];
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 }  // namespace qp_inverse_dynamics

--- a/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.h
+++ b/examples/qp_inverse_dynamics/manipulator_move_joint_plan_eval_system.h
@@ -85,7 +85,7 @@ class ManipulatorMoveJointPlanEvalSystem
  private:
   int get_num_extended_abstract_states() const override { return 2; }
 
-  void DoExtendedCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoExtendedCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       systems::State<double>* state) const override;
 

--- a/examples/rimless_wheel/rimless_wheel.cc
+++ b/examples/rimless_wheel/rimless_wheel.cc
@@ -69,7 +69,7 @@ T RimlessWheel<T>::StepForwardGuard(const systems::Context<T>& context) const {
 }
 
 template <typename T>
-void RimlessWheel<T>::StepForwardReset(
+systems::EventHandlerStatus RimlessWheel<T>::StepForwardReset(
     const systems::Context<T>& context,
     const systems::UnrestrictedUpdateEvent<T>&,
     systems::State<T>* state) const {
@@ -109,7 +109,10 @@ void RimlessWheel<T>::StepForwardReset(
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);
+    return systems::EventHandlerStatus::ReachedTermination(this,
+        "StepForwardReset() reached double-support.");
   }
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 template <typename T>
@@ -123,7 +126,7 @@ T RimlessWheel<T>::StepBackwardGuard(const systems::Context<T>& context) const {
 }
 
 template <typename T>
-void RimlessWheel<T>::StepBackwardReset(
+systems::EventHandlerStatus RimlessWheel<T>::StepBackwardReset(
     const systems::Context<T>& context,
     const systems::UnrestrictedUpdateEvent<T>&,
     systems::State<T>* state) const {
@@ -162,7 +165,10 @@ void RimlessWheel<T>::StepBackwardReset(
     bool& double_support = get_mutable_double_support(state);
     double_support = true;
     next_state.set_thetadot(0.0);
+    return systems::EventHandlerStatus::ReachedTermination(this,
+        "StepBackwardReset() reached double-support.");
   }
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 template <typename T>

--- a/examples/rimless_wheel/rimless_wheel.h
+++ b/examples/rimless_wheel/rimless_wheel.h
@@ -134,9 +134,10 @@ class RimlessWheel final : public systems::LeafSystem<T> {
 
   // Handles the impact dynamics, including resetting theta to the angle of the
   // new stance leg, and updating the toe position by the step length.
-  void StepForwardReset(const systems::Context<T>& context,
-                        const systems::UnrestrictedUpdateEvent<T>&,
-                        systems::State<T>* state) const;
+  systems::EventHandlerStatus StepForwardReset(
+      const systems::Context<T>& context,
+      const systems::UnrestrictedUpdateEvent<T>&,
+      systems::State<T>* state) const;
 
   // Check when the foot hits the ramp (rolling uphill).  This occurs when
   //   θ = slope - the interleg angle (α).
@@ -144,9 +145,10 @@ class RimlessWheel final : public systems::LeafSystem<T> {
 
   // Handles the impact dynamics, including resetting theta to the angle of the
   // new stance leg, and updating the toe position by the step length.
-  void StepBackwardReset(const systems::Context<T>& context,
-                         const systems::UnrestrictedUpdateEvent<T>&,
-                         systems::State<T>* state) const;
+  systems::EventHandlerStatus StepBackwardReset(
+      const systems::Context<T>& context,
+      const systems::UnrestrictedUpdateEvent<T>&,
+      systems::State<T>* state) const;
 
   void MinimalStateOut(const systems::Context<T>& context,
                        RimlessWheelContinuousState<T>* output) const;

--- a/examples/rimless_wheel/simulate.cc
+++ b/examples/rimless_wheel/simulate.cc
@@ -89,7 +89,9 @@ int DoMain() {
 
   simulator.set_target_realtime_rate(FLAGS_target_realtime_rate);
   simulator.get_mutable_context().set_accuracy(FLAGS_accuracy);
-  simulator.StepTo(10);
+  auto result = simulator.StepTo(10);
+  // Report termination reason.
+  std::cout << result.FormatMessage() << std::endl;
 
   // Check that the state is still inside the expected region (I did not miss
   // any collisions).

--- a/examples/rod2d/rod2d-inl.h
+++ b/examples/rod2d/rod2d-inl.h
@@ -507,7 +507,7 @@ void Rod2D<T>::CopyPoseOut(
 /// Integrates the Rod 2D example forward in time using a
 /// half-explicit discretization scheme.
 template <class T>
-void Rod2D<T>::DoCalcDiscreteVariableUpdates(
+systems::EventHandlerStatus Rod2D<T>::DoCalcDiscreteVariableUpdates(
     const systems::Context<T>& context,
     const std::vector<const systems::DiscreteUpdateEvent<T>*>&,
     systems::DiscreteValues<T>* discrete_state) const {
@@ -625,6 +625,8 @@ void Rod2D<T>::DoCalcDiscreteVariableUpdates(
   systems::BasicVector<T>& new_state = discrete_state->get_mutable_vector(0);
   new_state.get_mutable_value().segment(0, 3) = qplus;
   new_state.get_mutable_value().segment(3, 3) = vplus;
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 // Computes the impulses such that the vertical velocity at the contact point

--- a/examples/rod2d/rod2d.h
+++ b/examples/rod2d/rod2d.h
@@ -513,7 +513,7 @@ class Rod2D : public systems::LeafSystem<T> {
   void DoCalcTimeDerivatives(const systems::Context<T>& context,
                              systems::ContinuousState<T>* derivatives)
                                const override;
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<T>& context,
       const std::vector<const systems::DiscreteUpdateEvent<T>*>& events,
       systems::DiscreteValues<T>* discrete_state) const override;

--- a/examples/simple_discrete_time_system.cc
+++ b/examples/simple_discrete_time_system.cc
@@ -22,13 +22,15 @@ class SimpleDiscreteTimeSystem : public drake::systems::VectorSystem<double> {
 
  private:
   // x[n+1] = x[n]^3
-  virtual void DoCalcVectorDiscreteVariableUpdates(
+  virtual drake::systems::EventHandlerStatus
+  DoCalcVectorDiscreteVariableUpdates(
       const drake::systems::Context<double>& context,
       const Eigen::VectorBlock<const Eigen::VectorXd>& input,
       const Eigen::VectorBlock<const Eigen::VectorXd>& state,
       Eigen::VectorBlock<Eigen::VectorXd>* next_state) const {
     drake::unused(context, input);
     (*next_state)[0] = std::pow(state[0], 3.0);
+    return drake::systems::EventHandlerStatus::Succeeded();
   }
 
   // y = x

--- a/examples/simple_mixed_continuous_and_discrete_time_system.cc
+++ b/examples/simple_mixed_continuous_and_discrete_time_system.cc
@@ -28,13 +28,15 @@ class SimpleMixedContinuousTimeDiscreteTimeSystem
 
  private:
   // x[n+1] = x[n]^3
-  void DoCalcDiscreteVariableUpdates(
+  drake::systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const drake::systems::Context<double>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<double>*>&,
       drake::systems::DiscreteValues<double>* updates) const override {
     const double x = context.get_discrete_state(0).GetAtIndex(0);
     const double xn = std::pow(x, 3.0);
     (*updates)[0] = xn;
+
+    return drake::systems::EventHandlerStatus::Succeeded();
   }
 
   // xdot = -x + x^3

--- a/manipulation/perception/optitrack_pose_extractor.cc
+++ b/manipulation/perception/optitrack_pose_extractor.cc
@@ -81,7 +81,7 @@ OptitrackPoseExtractor::OptitrackPoseExtractor(
   this->DeclarePeriodicUnrestrictedUpdate(optitrack_lcm_status_period, 0);
 }
 
-void OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
@@ -99,6 +99,8 @@ void OptitrackPoseExtractor::DoCalcUnrestrictedUpdate(
         "optitrack: id {} not found", object_id_));
   }
   internal_state = X_WO_ * ExtractOptitrackPose(*body);
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void OptitrackPoseExtractor::OutputMeasuredPose(

--- a/manipulation/perception/optitrack_pose_extractor.h
+++ b/manipulation/perception/optitrack_pose_extractor.h
@@ -76,7 +76,7 @@ class OptitrackPoseExtractor : public systems::LeafSystem<double> {
   }
 
  private:
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>& event,
       systems::State<double>* state) const override;

--- a/manipulation/perception/pose_smoother.cc
+++ b/manipulation/perception/pose_smoother.cc
@@ -116,7 +116,7 @@ PoseSmoother::PoseSmoother(double desired_max_linear_velocity,
   this->DeclarePeriodicUnrestrictedUpdate(period_sec, 0);
 }
 
-void PoseSmoother::DoCalcUnrestrictedUpdate(
+systems::EventHandlerStatus PoseSmoother::DoCalcUnrestrictedUpdate(
     const systems::Context<double>& context,
     const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
     systems::State<double>* state) const {
@@ -180,6 +180,8 @@ void PoseSmoother::DoCalcUnrestrictedUpdate(
   } else {
     drake::log()->debug("Data point rejected");
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 void PoseSmoother::OutputSmoothedPose(const systems::Context<double>& context,

--- a/manipulation/perception/pose_smoother.h
+++ b/manipulation/perception/pose_smoother.h
@@ -61,7 +61,7 @@ class PoseSmoother : public systems::LeafSystem<double> {
   }
 
  private:
-  void DoCalcUnrestrictedUpdate(
+  systems::EventHandlerStatus DoCalcUnrestrictedUpdate(
       const systems::Context<double>& context,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>& event,
       systems::State<double>* state) const override;

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.cc
@@ -59,7 +59,8 @@ void SchunkWsgTrajectoryGenerator::OutputForce(
   output->get_mutable_value() = Vector1d(traj_state->max_force());
 }
 
-void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
+systems::EventHandlerStatus
+SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
     const Context<double>& context,
     const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
     DiscreteValues<double>* discrete_state) const {
@@ -99,6 +100,8 @@ void SchunkWsgTrajectoryGenerator::DoCalcDiscreteVariableUpdates(
     new_traj_state->set_trajectory_start_time(
         last_traj_state->trajectory_start_time());
   }
+
+  return systems::EventHandlerStatus::Succeeded();
 }
 
 std::unique_ptr<DiscreteValues<double>>

--- a/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
+++ b/manipulation/schunk_wsg/schunk_wsg_trajectory_generator.h
@@ -64,7 +64,7 @@ class SchunkWsgTrajectoryGenerator : public systems::LeafSystem<double> {
                    systems::BasicVector<double>* output) const;
 
   /// Latches the input port into the discrete state.
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus  DoCalcDiscreteVariableUpdates(
       const systems::Context<double>& context,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>& events,
       systems::DiscreteValues<double>* discrete_state) const override;

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -21,6 +21,7 @@
 #include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
+#include "drake/systems/framework/event.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 
@@ -1717,10 +1718,10 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   // shown to be exactly conserved and to be within O(dt) of the real energy of
   // the mechanical system.)
   // TODO(amcastro-tri): Update this docs when contact is added.
-  void DoCalcDiscreteVariableUpdates(
-      const drake::systems::Context<T>& context0,
-      const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
-      drake::systems::DiscreteValues<T>* updates) const override;
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
+      const systems::Context<T>& context0,
+      const std::vector<const systems::DiscreteUpdateEvent<T>*>& events,
+      systems::DiscreteValues<T>* updates) const override;
 
   // Helper method used within DoCalcDiscreteVariableUpdates() to update
   // generalized velocities from previous step value v0 to next step value v.

--- a/systems/analysis/test_utilities/logistic_system.h
+++ b/systems/analysis/test_utilities/logistic_system.h
@@ -31,7 +31,7 @@ class LogisticSystem : public LeafSystem<T> {
   }
 
   void set_publish_callback(
-      std::function<void(const Context<double>&)> callback) {
+      std::function<EventHandlerStatus(const Context<double>&)> callback) {
     publish_callback_ = callback;
   }
 
@@ -56,15 +56,18 @@ class LogisticSystem : public LeafSystem<T> {
     w->push_back(witness_.get());
   }
 
-  void DoPublish(
+  EventHandlerStatus DoPublish(
       const drake::systems::Context<double>& context,
       const std::vector<const systems::PublishEvent<double>*>&) const override {
-    if (publish_callback_ != nullptr) publish_callback_(context);
+    if (publish_callback_ == nullptr)
+      return EventHandlerStatus::DidNothing();
+    return publish_callback_(context);
   }
 
  private:
   std::unique_ptr<WitnessFunction<T>> witness_;
-  std::function<void(const Context<double>&)> publish_callback_{nullptr};
+  std::function<EventHandlerStatus(const Context<double>&)> publish_callback_{
+      nullptr};
 
   T GetStateValue(const Context<T>& context) const {
     return context.get_continuous_state()[0];

--- a/systems/analysis/test_utilities/my_spring_mass_system.h
+++ b/systems/analysis/test_utilities/my_spring_mass_system.h
@@ -30,19 +30,21 @@ class MySpringMassSystem : public SpringMassSystem<T> {
 
  private:
   // Publish t q u to standard output.
-  void DoPublish(const Context<T>&,
+  EventHandlerStatus DoPublish(const Context<T>&,
                  const std::vector<const systems::PublishEvent<T>*>&)
       const override {
     ++publish_count_;
+    return EventHandlerStatus::Succeeded();
   }
 
   // The discrete equation update here is for the special case of zero
   // discrete variables- in other words, this is just a counter.
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>&,
       const std::vector<const systems::DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>*) const override {
     ++update_count_;
+    return EventHandlerStatus::Succeeded();
   }
 
   mutable int publish_count_{0};

--- a/systems/analysis/test_utilities/stateless_system.h
+++ b/systems/analysis/test_utilities/stateless_system.h
@@ -36,7 +36,7 @@ class StatelessSystem final : public LeafSystem<T> {
                            other.witness_->direction_type()) {}
 
   void set_publish_callback(
-      std::function<void(const Context<T>&)> callback) {
+      std::function<EventHandlerStatus(const Context<T>&)> callback) {
     publish_callback_ = callback;
   }
 
@@ -50,10 +50,12 @@ class StatelessSystem final : public LeafSystem<T> {
     w->push_back(witness_.get());
   }
 
-  void DoPublish(
+  EventHandlerStatus DoPublish(
       const Context<T>& context,
       const std::vector<const PublishEvent<T>*>&) const override {
-    if (publish_callback_ != nullptr) publish_callback_(context);
+    if (publish_callback_ == nullptr)
+      return EventHandlerStatus::DidNothing();
+    return publish_callback_(context);
   }
 
  private:
@@ -67,7 +69,8 @@ class StatelessSystem final : public LeafSystem<T> {
 
   const double offset_;
   std::unique_ptr<WitnessFunction<T>> witness_;
-  std::function<void(const Context<T>&)> publish_callback_{nullptr};
+  std::function<EventHandlerStatus(const Context<T>&)> publish_callback_{
+      nullptr};
 };
 
 }  // namespace analysis_test

--- a/systems/controllers/test/linear_model_predictive_controller_test.cc
+++ b/systems/controllers/test/linear_model_predictive_controller_test.cc
@@ -107,7 +107,7 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
 
   // x1(k+1) = u(k)
   // x2(k+1) = -x1³(k)
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* next_state) const final {
@@ -116,6 +116,7 @@ class CubicPolynomialSystem final : public LeafSystem<T> {
     const T& u = this->EvalVectorInput(context, 0)->get_value()[0];
     next_state->get_mutable_vector(0).SetAtIndex(0, u);
     next_state->get_mutable_vector(0).SetAtIndex(1, pow(x1, 3.));
+    return EventHandlerStatus::Succeeded();
   }
 
   void OutputState(const systems::Context<T>& context,

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -93,7 +93,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
     derivatives->SetFromVector(xdot);
   }
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const systems::Context<symbolic::Expression>& context,
       const std::vector<
           const systems::DiscreteUpdateEvent<symbolic::Expression>*>&,
@@ -110,6 +110,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
     const Vector2<symbolic::Expression> next_xd =
         A * xd + B1 * u0 + B2 * u1 + f0;
     discrete_state->get_mutable_vector(0).SetFromVector(next_xd);
+    return EventHandlerStatus::Succeeded();
   }
 };
 

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -126,9 +126,10 @@ class TestSystem : public System<double> {
   }
 
   // The default publish function.
-  void MyPublish(const Context<double>& context,
+  EventHandlerStatus MyPublish(const Context<double>& context,
                  const std::vector<const PublishEvent<double>*>& events) const {
     ++publish_count_;
+    return EventHandlerStatus::Succeeded();
   }
 
  protected:
@@ -141,17 +142,18 @@ class TestSystem : public System<double> {
       const Context<double>& context,
       ContinuousState<double>* derivatives) const override {}
 
-  void DispatchPublishHandler(
+  EventHandlerStatus DispatchPublishHandler(
       const Context<double>& context,
       const EventCollection<PublishEvent<double>>& events) const final {
     const LeafEventCollection<PublishEvent<double>>& leaf_events =
        dynamic_cast<const LeafEventCollection<PublishEvent<double>>&>(events);
     if (leaf_events.HasEvents()) {
-      this->MyPublish(context, leaf_events.get_events());
+      return this->MyPublish(context, leaf_events.get_events());
     }
+    return EventHandlerStatus::DidNothing();
   }
 
-  void DispatchDiscreteVariableUpdateHandler(
+  EventHandlerStatus DispatchDiscreteVariableUpdateHandler(
       const Context<double>& context,
       const EventCollection<DiscreteUpdateEvent<double>>& events,
       DiscreteValues<double>* discrete_state) const final {
@@ -159,12 +161,13 @@ class TestSystem : public System<double> {
         dynamic_cast<const LeafEventCollection<DiscreteUpdateEvent<double>>&>(
             events);
     if (leaf_events.HasEvents()) {
-      this->MyCalcDiscreteVariableUpdates(context, leaf_events.get_events(),
-          discrete_state);
+      return this->MyCalcDiscreteVariableUpdates(
+          context, leaf_events.get_events(), discrete_state);
     }
+    return EventHandlerStatus::DidNothing();
   }
 
-  void DispatchUnrestrictedUpdateHandler(
+  EventHandlerStatus DispatchUnrestrictedUpdateHandler(
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {
@@ -188,11 +191,12 @@ class TestSystem : public System<double> {
   }
 
   // The default update function.
-  void MyCalcDiscreteVariableUpdates(
+  EventHandlerStatus MyCalcDiscreteVariableUpdates(
       const Context<double>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>& events,
       DiscreteValues<double>* discrete_state) const {
     ++update_count_;
+    return EventHandlerStatus::Succeeded();
   }
 
   std::unique_ptr<EventCollection<PublishEvent<double>>>
@@ -575,20 +579,20 @@ class ValueIOTestSystem : public System<T> {
     vec_out.get_mutable_value() = 2 * vec_in->get_value();
   }
 
-  void DispatchPublishHandler(
+  EventHandlerStatus DispatchPublishHandler(
       const Context<T>& context,
       const EventCollection<PublishEvent<T>>& event_info) const final {
     DRAKE_ABORT_MSG("test should not get here");
   }
 
-  void DispatchDiscreteVariableUpdateHandler(
+  EventHandlerStatus DispatchDiscreteVariableUpdateHandler(
       const Context<T>& context,
       const EventCollection<DiscreteUpdateEvent<T>>& event_info,
       DiscreteValues<T>* discrete_state) const final {
     DRAKE_ABORT_MSG("test should not get here");
   }
 
-  void DispatchUnrestrictedUpdateHandler(
+  EventHandlerStatus DispatchUnrestrictedUpdateHandler(
       const Context<T>& context,
       const EventCollection<UnrestrictedUpdateEvent<T>>& event_info,
       State<T>* state) const final {
@@ -922,18 +926,18 @@ class ComputationTestSystem final : public System<double> {
       const InputPort<double>&) const final {
     return {};
   }
-  void DispatchPublishHandler(
+  EventHandlerStatus DispatchPublishHandler(
       const Context<double>& context,
       const EventCollection<PublishEvent<double>>& events) const final {
     DRAKE_ABORT_MSG("test should not get here");
   }
-  void DispatchDiscreteVariableUpdateHandler(
+  EventHandlerStatus DispatchDiscreteVariableUpdateHandler(
       const Context<double>& context,
       const EventCollection<DiscreteUpdateEvent<double>>& events,
       DiscreteValues<double>* discrete_state) const final {
     DRAKE_ABORT_MSG("test should not get here");
   }
-  void DispatchUnrestrictedUpdateHandler(
+  EventHandlerStatus DispatchUnrestrictedUpdateHandler(
       const Context<double>&,
       const EventCollection<UnrestrictedUpdateEvent<double>>&,
       State<double>*) const final {

--- a/systems/framework/test/vector_system_test.cc
+++ b/systems/framework/test/vector_system_test.cc
@@ -72,7 +72,7 @@ class TestVectorSystem : public VectorSystem<double> {
   // VectorSystem override.
   // N.B. This method signature might be used by many downstream projects.
   // Change it only with good reason and with a deprecation period first.
-  void DoCalcVectorDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcVectorDiscreteVariableUpdates(
       const Context<double>& context,
       const Eigen::VectorBlock<const VectorXd>& input,
       const Eigen::VectorBlock<const VectorXd>& state,
@@ -84,6 +84,7 @@ class TestVectorSystem : public VectorSystem<double> {
     } else {
       *next_state = input + state;
     }
+    return EventHandlerStatus::Succeeded();
   }
 
   // LeafSystem override.
@@ -452,12 +453,13 @@ class NoInputNoOutputDiscreteTimeSystem : public VectorSystem<double> {
 
  private:
   // x[n+1] = x[n]^3
-  virtual void DoCalcVectorDiscreteVariableUpdates(
+  virtual EventHandlerStatus DoCalcVectorDiscreteVariableUpdates(
       const drake::systems::Context<double>& context,
       const Eigen::VectorBlock<const Eigen::VectorXd>& input,
       const Eigen::VectorBlock<const Eigen::VectorXd>& state,
       Eigen::VectorBlock<Eigen::VectorXd>* next_state) const {
     (*next_state)[0] = std::pow(state[0], 3.0);
+    return EventHandlerStatus::Succeeded();
   }
 };
 

--- a/systems/framework/vector_system.h
+++ b/systems/framework/vector_system.h
@@ -146,13 +146,13 @@ class VectorSystem : public LeafSystem<T> {
 
   /// Converts the parameters to Eigen::VectorBlock form, then delegates to
   /// DoCalcVectorDiscreteVariableUpdates().
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
     // Short-circuit when there's no work to do.
     if (discrete_state->num_groups() == 0) {
-      return;
+      return EventHandlerStatus::DidNothing();
     }
 
     const Eigen::VectorBlock<const VectorX<T>> input_block =
@@ -172,8 +172,8 @@ class VectorSystem : public LeafSystem<T> {
         discrete_update_vector.get_mutable_value();
 
     // Delegate to subclass.
-    DoCalcVectorDiscreteVariableUpdates(context, input_block, state_block,
-                                        &discrete_update_block);
+    return DoCalcVectorDiscreteVariableUpdates(
+        context, input_block, state_block, &discrete_update_block);
   }
 
   /// Converts the parameters to Eigen::VectorBlock form, then delegates to
@@ -295,13 +295,14 @@ class VectorSystem : public LeafSystem<T> {
   ///
   /// By default, this function does nothing if the @p next_state is
   /// empty, and throws an exception otherwise.
-  virtual void DoCalcVectorDiscreteVariableUpdates(
+  virtual EventHandlerStatus DoCalcVectorDiscreteVariableUpdates(
       const Context<T>& context,
       const Eigen::VectorBlock<const VectorX<T>>& input,
       const Eigen::VectorBlock<const VectorX<T>>& state,
       Eigen::VectorBlock<VectorX<T>>* next_state) const {
     unused(context, input, state);
     DRAKE_THROW_UNLESS(next_state->size() == 0);
+    return EventHandlerStatus::DidNothing();
   }
 
  private:

--- a/systems/lcm/lcm_log_playback_system.cc
+++ b/systems/lcm/lcm_log_playback_system.cc
@@ -39,6 +39,7 @@ void LcmLogPlaybackSystem::DoCalcNextUpdateTime(
     while (log->GetNextMessageTime() == callback_context.get_time()) {
       log->DispatchMessageAndAdvanceLog(callback_context.get_time());
     }
+    return EventHandlerStatus::Succeeded();
   };
 
   // Schedule a publish event at the next message time.

--- a/systems/lcm/lcm_publisher_system.cc
+++ b/systems/lcm/lcm_publisher_system.cc
@@ -94,6 +94,7 @@ void LcmPublisherSystem::AddInitializationMessage(
       [this](const systems::Context<double>& context,
              const systems::PublishEvent<double>&) {
         this->initialization_publisher_(context, this->lcm_);
+        return EventHandlerStatus::Succeeded();
       }));
 }
 
@@ -109,7 +110,7 @@ void LcmPublisherSystem::set_publish_period(double period) {
   LeafSystem<double>::DeclarePeriodicPublish(period);
 }
 
-void LcmPublisherSystem::DoPublish(
+EventHandlerStatus LcmPublisherSystem::DoPublish(
     const Context<double>& context,
     const std::vector<const systems::PublishEvent<double>*>& events) const {
 
@@ -122,7 +123,7 @@ void LcmPublisherSystem::DoPublish(
     DRAKE_DEMAND(events.size() == 1);
     SPDLOG_TRACE(drake::log(), "Invoking initialization publisher");
     event->handle(context);
-    return;
+    return EventHandlerStatus::Succeeded();
   }
 
   // If the event isn't initialization, we assume it is a request to publish
@@ -152,6 +153,7 @@ void LcmPublisherSystem::DoPublish(
   // Publishes onto the specified LCM channel.
   lcm_->Publish(channel_, message_bytes.data(), message_bytes.size(),
                 context.get_time());
+  return EventHandlerStatus::Succeeded();
 }
 
 const LcmAndVectorBaseTranslator& LcmPublisherSystem::get_translator() const {

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -229,7 +229,7 @@ class LcmPublisherSystem : public LeafSystem<double> {
 
   // Takes the VectorBase from the input port of the context and publishes
   // it onto an LCM channel.
-  void DoPublish(
+  EventHandlerStatus DoPublish(
       const Context<double>& context,
       const std::vector<const systems::PublishEvent<double>*>&) const override;
 

--- a/systems/lcm/lcm_subscriber_system.h
+++ b/systems/lcm/lcm_subscriber_system.h
@@ -171,20 +171,22 @@ class LcmSubscriberSystem : public LeafSystem<double> {
                             systems::CompositeEventCollection<double>* events,
                             double* time) const override;
 
-  void DoCalcUnrestrictedUpdate(
+  EventHandlerStatus DoCalcUnrestrictedUpdate(
       const Context<double>&,
       const std::vector<const systems::UnrestrictedUpdateEvent<double>*>&,
       State<double>* state) const override {
     ProcessMessageAndStoreToAbstractState(&state->get_mutable_abstract_state());
+    return EventHandlerStatus::Succeeded();
   }
 
   std::unique_ptr<AbstractValues> AllocateAbstractState() const override;
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<double>&,
       const std::vector<const systems::DiscreteUpdateEvent<double>*>&,
       DiscreteValues<double>* discrete_state) const override {
     ProcessMessageAndStoreToDiscreteState(discrete_state);
+    return EventHandlerStatus::Succeeded();
   }
 
   std::unique_ptr<DiscreteValues<double>> AllocateDiscreteState()

--- a/systems/lcm/test/lcm_log_playback_test.cc
+++ b/systems/lcm/test/lcm_log_playback_test.cc
@@ -48,7 +48,7 @@ class DummySys : public LeafSystem<double> {
   }
 
  private:
-  void DoPublish(
+  EventHandlerStatus DoPublish(
       const Context<double>& context,
       const std::vector<const systems::PublishEvent<double>*>&)
   const override {
@@ -77,6 +77,8 @@ class DummySys : public LeafSystem<double> {
       // "tick" behind.
       received_time_.push_back(context.get_time() - 1.0 / publish_freq_);
     }
+
+    return EventHandlerStatus::Succeeded();
   }
 
   const double publish_freq_{100.0};  // In Hz.

--- a/systems/primitives/affine_system.cc
+++ b/systems/primitives/affine_system.cc
@@ -121,11 +121,12 @@ void TimeVaryingAffineSystem<T>::DoCalcTimeDerivatives(
 }
 
 template <typename T>
-void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
+EventHandlerStatus TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context,
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* updates) const {
-  if (num_states_ == 0 || time_period_ == 0.0) return;
+  if (num_states_ == 0 || time_period_ == 0.0)
+    return EventHandlerStatus::DidNothing();
 
   const T t = context.get_time();
 
@@ -151,6 +152,7 @@ void TimeVaryingAffineSystem<T>::DoCalcDiscreteVariableUpdates(
     xn += Bt * u;
   }
   updates->get_mutable_vector().SetFromVector(xn);
+  return EventHandlerStatus::Succeeded();
 }
 
 // Our public constructor declares that our most specific subclass is
@@ -280,11 +282,12 @@ void AffineSystem<T>::DoCalcTimeDerivatives(
 }
 
 template <typename T>
-void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
+EventHandlerStatus AffineSystem<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context,
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* updates) const {
-  if (this->num_states() == 0 || this->time_period() == 0.0) return;
+  if (this->num_states() == 0 || this->time_period() == 0.0)
+    return EventHandlerStatus::DidNothing();
 
   const auto& x = context.get_discrete_state(0).get_value();
 
@@ -298,6 +301,7 @@ void AffineSystem<T>::DoCalcDiscreteVariableUpdates(
     xnext += B_ * u;
   }
   updates->get_mutable_vector().SetFromVector(xnext);
+  return EventHandlerStatus::Succeeded();
 }
 
 

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -97,7 +97,7 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
   /// Computes @f[ x(t+h) = A(t) x(t) + B(t) u(t) + f_0(t), @f] with by calling
   /// `A(t)`, `B(t)`, and `f0(t)` with runtime size checks.  Derived classes
   /// may override this for performance reasons.
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const drake::systems::Context<T>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
       drake::systems::DiscreteValues<T>* updates) const override;
@@ -232,7 +232,7 @@ class AffineSystem : public TimeVaryingAffineSystem<T> {
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const final;
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const drake::systems::Context<T>& context,
       const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>& events,
       drake::systems::DiscreteValues<T>* updates) const final;

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -43,7 +43,8 @@ void DiscreteDerivative<T>::set_input_history(
 }
 
 template <typename T>
-void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
+drake::systems::EventHandlerStatus
+DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
     const drake::systems::Context<T>& context,
     const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
     drake::systems::DiscreteValues<T>* discrete_state) const {
@@ -54,6 +55,7 @@ void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
   // x₁[n+1] = x₀[n].
   discrete_state->get_mutable_vector().get_mutable_value().tail(n_) =
       context.get_discrete_state(0).get_value().head(n_);
+  return drake::systems::EventHandlerStatus::Succeeded();
 }
 
 template <typename T>

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -96,7 +96,7 @@ class DiscreteDerivative final : public LeafSystem<T> {
   }
 
  private:
-  void DoCalcDiscreteVariableUpdates(
+  systems::EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final;

--- a/systems/primitives/random_source.h
+++ b/systems/primitives/random_source.h
@@ -84,7 +84,7 @@ class RandomSource : public LeafSystem<double> {
 
  private:
   // Computes a random number and stores it in the discrete state.
-  void DoCalcUnrestrictedUpdate(
+  EventHandlerStatus DoCalcUnrestrictedUpdate(
       const Context<double>&,
       const std::vector<const UnrestrictedUpdateEvent<double>*>&,
       State<double>* state) const override {
@@ -94,6 +94,7 @@ class RandomSource : public LeafSystem<double> {
     for (int i = 0; i < updates.size(); i++) {
       updates[i] = random_state.GetNextValue();
     }
+    return EventHandlerStatus::Succeeded();
   }
 
   std::unique_ptr<AbstractValues> AllocateAbstractState() const override {

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -17,11 +17,12 @@ void SignalLogger<T>::set_publish_period(double period) {
 }
 
 template <typename T>
-void SignalLogger<T>::DoPublish(const Context<T>& context,
+EventHandlerStatus SignalLogger<T>::DoPublish(const Context<T>& context,
                                 const std::vector<const PublishEvent<T>*>&)
                                 const {
   log_.AddData(context.get_time(),
                this->EvalVectorInput(context, 0)->get_value());
+  return EventHandlerStatus::Succeeded();
 }
 
 template <typename T>

--- a/systems/primitives/signal_logger.h
+++ b/systems/primitives/signal_logger.h
@@ -66,7 +66,7 @@ class SignalLogger : public LeafSystem<T> {
 
  private:
   // Logging is done in this method.
-  void DoPublish(const Context<T>& context,
+  EventHandlerStatus DoPublish(const Context<T>& context,
                  const std::vector<const systems::PublishEvent<T>*>& events)
       const override;
 

--- a/systems/primitives/test/linear_system_test.cc
+++ b/systems/primitives/test/linear_system_test.cc
@@ -316,11 +316,12 @@ class TestNonPeriodicSystem : public LeafSystem<double> {
     this->DeclarePerStepEvent(PublishEvent<double>());
   }
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<double>& context,
       const std::vector<const DiscreteUpdateEvent<double>*>&,
       DiscreteValues<double>* discrete_state) const override {
     (*discrete_state)[0] = context.get_discrete_state(0).GetAtIndex(0) + 1;
+    return EventHandlerStatus::Succeeded();
   }
 };
 
@@ -613,7 +614,7 @@ class MimoSystem final : public LeafSystem<T> {
     derivatives->SetFromVector(A_ * x + B0_ * u0 + B1_ * u1);
   }
 
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
@@ -623,6 +624,7 @@ class MimoSystem final : public LeafSystem<T> {
 
     discrete_state->get_mutable_vector(0).SetFromVector(A_ * x + B0_ * u0 +
                                                         B1_ * u1);
+    return EventHandlerStatus::Succeeded();
   }
 
   void CalcOutput0(const Context<T>& context, BasicVector<T>* output) const {

--- a/systems/primitives/zero_order_hold-inl.h
+++ b/systems/primitives/zero_order_hold-inl.h
@@ -70,7 +70,7 @@ void ZeroOrderHold<T>::DoCalcVectorOutput(
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
+EventHandlerStatus ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
     const Context<T>& context,
     const std::vector<const DiscreteUpdateEvent<T>*>&,
     DiscreteValues<T>* discrete_state) const {
@@ -78,6 +78,7 @@ void ZeroOrderHold<T>::DoCalcDiscreteVariableUpdates(
   const BasicVector<T>& input_value = *this->EvalVectorInput(context, 0);
   BasicVector<T>& state_value = discrete_state->get_mutable_vector(0);
   state_value.SetFrom(input_value);
+  return EventHandlerStatus::Succeeded();
 }
 
 template <typename T>
@@ -92,7 +93,7 @@ void ZeroOrderHold<T>::DoCalcAbstractOutput(const Context<T>& context,
 }
 
 template <typename T>
-void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
+EventHandlerStatus ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
     const Context<T>& context,
     const std::vector<const UnrestrictedUpdateEvent<T>*>&,
     State<T>* state) const {
@@ -103,6 +104,7 @@ void ZeroOrderHold<T>::DoCalcUnrestrictedUpdate(
   AbstractValue& state_value =
       state->get_mutable_abstract_state().get_mutable_value(0);
   state_value.SetFrom(input_value);
+  return EventHandlerStatus::Succeeded();
 }
 
 template <typename T>

--- a/systems/primitives/zero_order_hold.h
+++ b/systems/primitives/zero_order_hold.h
@@ -73,7 +73,7 @@ class ZeroOrderHold : public LeafSystem<T> {
       BasicVector<T>* output) const;
 
   // Latches the input port into the discrete vector-valued state.
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>& events,
       DiscreteValues<T>* discrete_state) const override;
@@ -84,7 +84,7 @@ class ZeroOrderHold : public LeafSystem<T> {
       AbstractValue* output) const;
 
   // Same as `DoCalcDiscreteVariablesUpdate`, but for abstract values.
-  void DoCalcUnrestrictedUpdate(
+  EventHandlerStatus DoCalcUnrestrictedUpdate(
       const Context<T>& context,
       const std::vector<const UnrestrictedUpdateEvent<T>*>& events,
       State<T>* state) const override;

--- a/systems/sensors/image_writer.cc
+++ b/systems/sensors/image_writer.cc
@@ -151,6 +151,7 @@ const InputPort<double>& ImageWriter::DeclareImageInputPort(
       [this, port_index = port.get_index()](const Context<double>& context,
                                             const PublishEvent<double>&) {
         WriteImage<kPixelType>(context, port_index);
+        return EventHandlerStatus::Succeeded();
       });
   DeclarePeriodicEvent<PublishEvent<double>>(publish_period, start_time, event);
   port_info_.emplace_back(std::move(file_name_format), kPixelType);

--- a/systems/trajectory_optimization/test/direct_transcription_test.cc
+++ b/systems/trajectory_optimization/test/direct_transcription_test.cc
@@ -44,13 +44,14 @@ class CubicPolynomialSystem final : public systems::LeafSystem<T> {
 
  private:
   // x[n+1] = x³[n]
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
     using std::pow;
     discrete_state->get_mutable_vector(0).SetAtIndex(
         0, pow(context.get_discrete_state(0).GetAtIndex(0), 3.0));
+    return EventHandlerStatus::Succeeded();
   }
 
   const double timestep_{0.0};
@@ -76,13 +77,14 @@ class LinearSystemWParams final : public systems::LeafSystem<T> {
 
  private:
   // x[n+1] = p0 * x[n]
-  void DoCalcDiscreteVariableUpdates(
+  EventHandlerStatus DoCalcDiscreteVariableUpdates(
       const Context<T>& context,
       const std::vector<const DiscreteUpdateEvent<T>*>&,
       DiscreteValues<T>* discrete_state) const final {
     discrete_state->get_mutable_vector(0).SetAtIndex(
         0, context.get_numeric_parameter(0).GetAtIndex(0) *
                context.get_discrete_state(0).GetAtIndex(0));
+    return EventHandlerStatus::Succeeded();
   }
 };
 


### PR DESCRIPTION
Trying out a possible solution to #4447. This adds a status return to all event handlers, allowing them to communicate with the Simulator, and adds a status return to the Simulator::StepTo() method so that an interested user can find out why it returned.

This would be a non-backwards-compatible API change so users who have written Publish, DiscreteUpdate, and UnrestrictedUpdate handlers have to change their return type from `void` to `EventHandlerStatus`. No change is required for users of StepTo() unless they are interested in checking status. See examples/rimless_wheel/simulate for an example of a simulation that reports why it stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9292)
<!-- Reviewable:end -->
