### PR TITLE
[WIP] rigid_body_tree: Fail fast on duplicates in `computePositionNameToIndexMap`

### DIFF
--- a/multibody/rigid_body_tree.cc
+++ b/multibody/rigid_body_tree.cc
@@ -875,7 +875,13 @@ map<string, int> RigidBodyTree<T>::computePositionNameToIndexMap() const {
   map<string, int> name_to_index_map;
 
   for (int i = 0; i < num_positions_; ++i) {
-    name_to_index_map[get_position_name(i)] = i;
+    string name = get_position_name(i);
+    if (name_to_index_map.find(name) != name_to_index_map.end()) {
+      throw std::runtime_error(fmt::format(
+          "Duplicate position name: {}, which means you have multiple "
+          "model instances. Please use custom iteration."));
+    }
+    name_to_index_map[name] = i;
   }
   return name_to_index_map;
 }


### PR DESCRIPTION
Relates #9242.

Addresses #4697 more directly.
On my laptop, so will wait on CI to see if this cause regression in the immediate code base.

I'm tentative on this fix, but more tentative about the behavior of this method.

\cc @kuindersma @mpetersen94

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9294)
<!-- Reviewable:end -->
