### PR TITLE
Reduce boilerplate needed to connect SceneGraph to visualizer.

### DIFF
--- a/examples/contact_model/BUILD.bazel
+++ b/examples/contact_model/BUILD.bazel
@@ -27,9 +27,7 @@ drake_cc_binary(
         "//multibody/rigid_body_plant",
         "//multibody/rigid_body_plant:rigid_body_plant_bridge",
         "//systems/analysis",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )
@@ -79,8 +77,6 @@ drake_cc_binary(
         "//multibody/rigid_body_plant",
         "//multibody/rigid_body_plant:rigid_body_plant_bridge",
         "//systems/analysis",
-        "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -31,9 +31,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/find_resource.h"
 #include "drake/geometry/geometry_visualization.h"
-#include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/parsers/urdf_parser.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant.h"
 #include "drake/multibody/rigid_body_plant/rigid_body_plant_bridge.h"
@@ -41,20 +39,14 @@
 #include "drake/systems/analysis/runge_kutta2_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace systems {
 
-using drake::lcm::DrakeLcm;
-using drake::multibody::joints::kQuaternion;
+using lcm::DrakeLcm;
+using multibody::joints::kQuaternion;
 using Eigen::VectorXd;
 using std::make_unique;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
-using systems::rendering::PoseBundleToDrawMessage;
 
 // Simulation parameters.
 DEFINE_double(v, 12, "The ball's initial linear speed down the lane (m/s)");
@@ -144,15 +136,6 @@ int main() {
   auto rbt_gs_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
       &tree, scene_graph);
 
-  DrakeLcm lcm;
-
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-  std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
 
   builder.Connect(plant.state_output_port(),
                   rbt_gs_bridge->rigid_body_plant_state_input_port());
@@ -161,22 +144,22 @@ int main() {
       rbt_gs_bridge->geometry_pose_output_port(),
       scene_graph->get_source_pose_port(rbt_gs_bridge->source_id()));
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
-
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
   auto diagram = builder.Build();
 
+  // Load message must be sent before creating a Context (Simulator
+  // creates one).
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
+
   // Create simulator.
-  auto simulator = std::make_unique<Simulator<double>>(*diagram);
-  Context<double>& context = simulator->get_mutable_context();
-  simulator->reset_integrator<RungeKutta2Integrator<double>>(*diagram,
-                                                             FLAGS_timestep,
-                                                             &context);
+  Simulator<double> simulator(*diagram);
+  Context<double>& context = simulator.get_mutable_context();
+  simulator.reset_integrator<RungeKutta2Integrator<double>>(*diagram,
+                                                            FLAGS_timestep,
+                                                            &context);
   // Set initial state.
   Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, &context);
@@ -230,7 +213,7 @@ int main() {
 
   plant.set_state_vector(&plant_context, initial_state);
 
-  simulator->StepTo(FLAGS_sim_duration);
+  simulator.StepTo(FLAGS_sim_duration);
 
   return 0;
 }

--- a/examples/geometry_world/BUILD.bazel
+++ b/examples/geometry_world/BUILD.bazel
@@ -38,10 +38,8 @@ drake_cc_binary(
         "//geometry:scene_graph",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
-        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 
@@ -68,10 +66,8 @@ drake_cc_binary(
         "//geometry:scene_graph",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
         "//systems/primitives:signal_logger",
-        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/examples/geometry_world/bouncing_ball_run_dynamics.cc
+++ b/examples/geometry_world/bouncing_ball_run_dynamics.cc
@@ -10,9 +10,6 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -26,9 +23,6 @@ using geometry::HalfSpace;
 using geometry::SourceId;
 using lcm::DrakeLcm;
 using systems::InputPort;
-using systems::rendering::PoseBundleToDrawMessage;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
 using std::make_unique;
 
 int do_main() {
@@ -59,14 +53,6 @@ int do_main() {
       global_source,
       make_unique<GeometryInstance>(HalfSpace::MakePose(Hz_W, p_WH),
                                     make_unique<HalfSpace>(), "ground"));
-  DrakeLcm lcm;
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
 
   builder.Connect(bouncing_ball1->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(ball_source_id1));
@@ -78,14 +64,15 @@ int do_main() {
   builder.Connect(scene_graph->get_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
   auto diagram = builder.Build();
+
+  // Load message must be sent before creating a Context (Simulator
+  // creates one).
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   systems::Simulator<double> simulator(*diagram);
   auto init_ball = [&](BouncingBallPlant<double>* system, double z,

--- a/examples/geometry_world/solar_system_run_dynamics.cc
+++ b/examples/geometry_world/solar_system_run_dynamics.cc
@@ -2,12 +2,8 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -17,9 +13,6 @@ namespace {
 using geometry::SceneGraph;
 using geometry::SourceId;
 using lcm::DrakeLcm;
-using systems::rendering::PoseBundleToDrawMessage;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -30,27 +23,18 @@ int do_main() {
   auto solar_system = builder.AddSystem<SolarSystem>(scene_graph);
   solar_system->set_name("SolarSystem");
 
-  DrakeLcm lcm;
-  PoseBundleToDrawMessage* converter =
-      builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem* publisher =
-      builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher->set_publish_period(1 / 60.0);
-
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
-  builder.Connect(scene_graph->get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
-  builder.Connect(*converter, *publisher);
-
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(*scene_graph);
-
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
   auto diagram = builder.Build();
+
+  // Load message must be sent before creating a Context (Simulator
+  // creates one).
+  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   systems::Simulator<double> simulator(*diagram);
 

--- a/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
@@ -61,9 +61,7 @@ drake_cc_binary(
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/analysis:simulator",
         "//systems/controllers:inverse_dynamics_controller",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:trajectory_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/acrobot/BUILD.bazel
+++ b/examples/multibody/acrobot/BUILD.bazel
@@ -26,9 +26,7 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )
@@ -51,9 +49,7 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/controllers:linear_quadratic_regulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:affine_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -7,7 +7,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/benchmarks/acrobot/make_acrobot_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -15,10 +14,7 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
 #include "drake/systems/primitives/constant_vector_source.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 
@@ -30,9 +26,6 @@ using multibody::benchmarks::acrobot::MakeAcrobotPlant;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RevoluteJoint;
 using systems::ImplicitEulerIntegrator;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
-using systems::rendering::PoseBundleToDrawMessage;
 using systems::RungeKutta3Integrator;
 using systems::SemiExplicitEulerIntegrator;
 
@@ -86,17 +79,6 @@ int do_main() {
   builder.Connect(torque_source->get_output_port(),
                   acrobot.get_actuation_input_port());
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!acrobot.get_source_id());
 
@@ -104,16 +86,14 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
-
-  // And build the Diagram:
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/bouncing_ball/BUILD.bazel
+++ b/examples/multibody/bouncing_ball/BUILD.bazel
@@ -44,8 +44,6 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -8,7 +8,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/math/random_rotation.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -17,9 +16,6 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -46,17 +42,16 @@ using Eigen::Vector3d;
 using geometry::SceneGraph;
 using geometry::SourceId;
 using lcm::DrakeLcm;
+using systems::ImplicitEulerIntegrator;
+using systems::RungeKutta2Integrator;
+using systems::RungeKutta3Integrator;
+using systems::SemiExplicitEulerIntegrator;
+
+// "multibody" namespace is ambiguous here without "drake::".
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 using drake::multibody::QuaternionFloatingMobilizer;
-using drake::systems::ImplicitEulerIntegrator;
-using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::Serializer;
-using drake::systems::rendering::PoseBundleToDrawMessage;
-using drake::systems::RungeKutta2Integrator;
-using drake::systems::RungeKutta3Integrator;
-using drake::systems::SemiExplicitEulerIntegrator;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -91,17 +86,6 @@ int do_main() {
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
@@ -111,16 +95,14 @@ int do_main() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
-
-  // And build the Diagram:
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/cart_pole/BUILD.bazel
+++ b/examples/multibody/cart_pole/BUILD.bazel
@@ -36,8 +36,6 @@ drake_cc_binary(
         "//multibody/multibody_tree/parsing:multibody_plant_sdf_parser",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -8,7 +8,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
@@ -16,9 +15,6 @@
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -26,17 +22,16 @@ namespace multibody {
 namespace cart_pole {
 namespace {
 
-using drake::geometry::SceneGraph;
-using drake::lcm::DrakeLcm;
+using geometry::SceneGraph;
+using lcm::DrakeLcm;
+
+// "multibody" namespace is ambiguous here without "drake::".
 using drake::multibody::Body;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::parsing::AddModelFromSdfFile;
 using drake::multibody::PrismaticJoint;
 using drake::multibody::RevoluteJoint;
 using drake::multibody::UniformGravityFieldElement;
-using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::Serializer;
-using drake::systems::rendering::PoseBundleToDrawMessage;
 
 DEFINE_double(target_realtime_rate, 1.0,
               "Desired rate relative to real time.  See documentation for "
@@ -70,17 +65,6 @@ int do_main() {
   // Now the model is complete.
   cart_pole.Finalize(&scene_graph);
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!cart_pole.get_source_id());
 
@@ -88,16 +72,14 @@ int do_main() {
       cart_pole.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(cart_pole.get_source_id().value()));
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
-
-  // And build the Diagram:
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/cylinder_with_multicontact/BUILD.bazel
+++ b/examples/multibody/cylinder_with_multicontact/BUILD.bazel
@@ -64,7 +64,6 @@ drake_cc_binary(
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
         "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -8,13 +8,10 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -59,14 +56,14 @@ using Eigen::Matrix3d;
 using Eigen::Vector3d;
 using geometry::SceneGraph;
 using lcm::DrakeLcm;
+using systems::lcm::LcmPublisherSystem;
+
+// "multibody" namespace is ambiguous here without "drake::".
 using drake::multibody::multibody_plant::CoulombFriction;
 using drake::multibody::multibody_plant::ContactResultsToLcmSystem;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 using drake::multibody::SpatialVelocity;
-using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::Serializer;
-using drake::systems::rendering::PoseBundleToDrawMessage;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
@@ -94,17 +91,6 @@ int do_main() {
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
@@ -114,9 +100,7 @@ int do_main() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
+  DrakeLcm lcm;
 
   // Publish contact results for visualization.
   const auto& contact_results_to_lcm =
@@ -130,12 +114,13 @@ int do_main() {
   builder.Connect(contact_results_to_lcm.get_output_port(0),
                   contact_results_publisher.get_input_port());
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // And build the Diagram:
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/inclined_plane/BUILD.bazel
+++ b/examples/multibody/inclined_plane/BUILD.bazel
@@ -23,8 +23,6 @@ drake_cc_binary(
         "//multibody/benchmarks/inclined_plane",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/pendulum/BUILD.bazel
+++ b/examples/multibody/pendulum/BUILD.bazel
@@ -22,9 +22,7 @@ drake_cc_binary(
         "//systems/analysis:semi_explicit_euler_integrator",
         "//systems/analysis:simulator",
         "//systems/framework:diagram",
-        "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:constant_vector_source",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -6,7 +6,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/multibody/benchmarks/pendulum/make_pendulum_plant.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/systems/analysis/implicit_euler_integrator.h"
@@ -14,10 +13,7 @@
 #include "drake/systems/analysis/semi_explicit_euler_integrator.h"
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
-#include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
 #include "drake/systems/primitives/constant_vector_source.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 
@@ -29,9 +25,6 @@ using multibody::benchmarks::pendulum::PendulumParameters;
 using multibody::multibody_plant::MultibodyPlant;
 using multibody::RevoluteJoint;
 using systems::ImplicitEulerIntegrator;
-using systems::lcm::LcmPublisherSystem;
-using systems::lcm::Serializer;
-using systems::rendering::PoseBundleToDrawMessage;
 using systems::RungeKutta3Integrator;
 using systems::SemiExplicitEulerIntegrator;
 
@@ -87,17 +80,6 @@ int do_main() {
   builder.Connect(torque_source->get_output_port(),
                   pendulum.get_actuation_input_port());
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-  publisher.set_publish_period(1 / 60.0);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!pendulum.get_source_id());
 
@@ -105,15 +87,14 @@ int do_main() {
       pendulum.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(pendulum.get_source_id().value()));
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  DrakeLcm lcm;
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
-
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   auto diagram_context = diagram->CreateDefaultContext();
   systems::Context<double>& pendulum_context =

--- a/examples/simple_gripper/BUILD.bazel
+++ b/examples/simple_gripper/BUILD.bazel
@@ -40,7 +40,6 @@ drake_cc_binary(
         "//systems/framework:diagram",
         "//systems/lcm:lcm_pubsub_system",
         "//systems/primitives:sine",
-        "//systems/rendering:pose_bundle_to_draw_message",
         "@gflags",
     ],
 )

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -10,7 +10,6 @@
 #include "drake/geometry/geometry_visualization.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/lcm/drake_lcm.h"
-#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
@@ -26,9 +25,7 @@
 #include "drake/systems/analysis/simulator.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/lcm/lcm_publisher_system.h"
-#include "drake/systems/lcm/serializer.h"
 #include "drake/systems/primitives/sine.h"
-#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace examples {
@@ -52,8 +49,6 @@ using drake::multibody::PrismaticJoint;
 using drake::multibody::UniformGravityFieldElement;
 using drake::systems::ImplicitEulerIntegrator;
 using drake::systems::lcm::LcmPublisherSystem;
-using drake::systems::lcm::Serializer;
-using drake::systems::rendering::PoseBundleToDrawMessage;
 using drake::systems::RungeKutta2Integrator;
 using drake::systems::RungeKutta3Integrator;
 using drake::systems::SemiExplicitEulerIntegrator;
@@ -265,16 +260,6 @@ int do_main() {
   DRAKE_DEMAND(plant.num_actuators() == 2);
   DRAKE_DEMAND(plant.num_actuated_dofs() == 2);
 
-  // Boilerplate used to connect the plant to a SceneGraph for
-  // visualization.
-  DrakeLcm lcm;
-  const PoseBundleToDrawMessage& converter =
-      *builder.template AddSystem<PoseBundleToDrawMessage>();
-  LcmPublisherSystem& publisher =
-      *builder.template AddSystem<LcmPublisherSystem>(
-          "DRAKE_VIEWER_DRAW",
-          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(), &lcm);
-
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
@@ -284,10 +269,7 @@ int do_main() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  builder.Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter.get_input_port(0));
-  builder.Connect(converter, publisher);
-
+  DrakeLcm lcm;
   // Publish contact results for visualization.
   const auto& contact_results_to_lcm =
       *builder.AddSystem<ContactResultsToLcmSystem>(plant);
@@ -333,12 +315,13 @@ int do_main() {
   builder.Connect(harmonic_force.get_output_port(0),
                   plant.get_actuation_input_port());
 
-  // Last thing before building the diagram; dispatch the message to load
-  // geometry.
-  geometry::DispatchLoadMessage(scene_graph);
+  // Last thing before building the diagram; configure the system for
+  // visualization.
+  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  auto diagram = builder.Build();
 
-  // And build the Diagram:
-  std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
+  // Load message must be sent before creating a Context.
+  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -188,6 +188,9 @@ drake_cc_library(
         "//lcm",
         "//lcmtypes:viewer",
         "//math:geometric_transform",
+        "//systems/framework:diagram_builder",
+        "//systems/lcm",
+        "//systems/rendering:pose_bundle_to_draw_message",
     ],
 )
 

--- a/geometry/geometry_state.h
+++ b/geometry/geometry_state.h
@@ -19,7 +19,6 @@
 #include "drake/geometry/proximity_engine.h"
 
 namespace drake {
-
 namespace geometry {
 
 #ifndef DRAKE_DOXYGEN_CXX

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -1,16 +1,22 @@
 #include "drake/geometry/geometry_visualization.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "drake/common/drake_copyable.h"
+#include "drake/common/never_destroyed.h"
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/internal_geometry.h"
 #include "drake/geometry/scene_graph.h"
 #include "drake/geometry/shape_specification.h"
 #include "drake/lcm/drake_lcm.h"
+#include "drake/lcmt_viewer_draw.hpp"
 #include "drake/lcmt_viewer_geometry_data.hpp"
 #include "drake/math/rotation_matrix.h"
+#include "drake/systems/lcm/lcm_publisher_system.h"
+#include "drake/systems/lcm/serializer.h"
+#include "drake/systems/rendering/pose_bundle_to_draw_message.h"
 
 namespace drake {
 namespace geometry {
@@ -195,19 +201,37 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
 
 }  // namespace internal
 
-void DispatchLoadMessage(const GeometryState<double>& state) {
-  using lcm::DrakeLcm;
 
+void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
+                         lcm::DrakeLcmInterface* lcm) {
+  scene_graph.ThrowIfContextAllocated("DispatchLoadMessage");
   lcmt_viewer_load_robot message =
-      internal::GeometryVisualizationImpl::BuildLoadMessage(state);
+      internal::GeometryVisualizationImpl::BuildLoadMessage(
+          *scene_graph.initial_state_);
   // Send a load message.
-  DrakeLcm lcm;
-  Publish(&lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
+  Publish(lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
 }
 
-void DispatchLoadMessage(const SceneGraph<double>& scene_graph) {
-  scene_graph.ThrowIfContextAllocated("DisplatchLoadMessage");
-  DispatchLoadMessage(*scene_graph.initial_state_);
+void ConnectVisualization(const SceneGraph<double>& scene_graph,
+                          systems::DiagramBuilder<double>* builder,
+                          lcm::DrakeLcmInterface* lcm) {
+  using lcm::DrakeLcm;
+  using systems::lcm::LcmPublisherSystem;
+  using systems::lcm::Serializer;
+  using systems::rendering::PoseBundleToDrawMessage;
+
+  PoseBundleToDrawMessage* converter =
+      builder->template AddSystem<PoseBundleToDrawMessage>();
+  LcmPublisherSystem* publisher =
+      builder->template AddSystem<LcmPublisherSystem>(
+          "DRAKE_VIEWER_DRAW",
+          std::make_unique<Serializer<drake::lcmt_viewer_draw>>(),
+          lcm);
+  publisher->set_publish_period(1 / 60.0);
+
+  builder->Connect(scene_graph.get_pose_bundle_output_port(),
+                  converter->get_input_port(0));
+  builder->Connect(*converter, *publisher);
 }
 
 }  // namespace geometry

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -1,12 +1,14 @@
 /** @file
  Provides a set of functions to facilitate visualization operations based on
- geometry world state. */
+ SceneGraph system state. */
 
 #pragma once
 
 #include "drake/geometry/geometry_state.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/lcm/drake_lcm_interface.h"
 #include "drake/lcmt_viewer_load_robot.hpp"
+#include "drake/systems/framework/diagram_builder.h"
 
 namespace drake {
 namespace geometry {
@@ -27,12 +29,38 @@ class GeometryVisualizationImpl {
 }  // namespace internal
 #endif  // DRAKE_DOXYGEN_CXX
 
+/** Extends the diagram with the required components to interface with
+ drake_visualizer. This must be called _during_ Diagram building and uses the
+ given `builder` to add relevant subsystems and connections. You must also
+ call geometry::DispatchLoadMessage() after connecting visualization but prior
+ to allocating a Context for your Diagram.
+
+ This is a convenience method to simplify some common boilerplate for adding
+ visualization capability to a Diagram. What it does is:
+ - adds systems PoseBundleToDrawMessage and LcmPublisherSystem to
+   the Diagram and connects the draw message output to the publisher input,
+ - connects the `scene_graph` pose bundle output to the PoseBundleToDrawMessage
+   system, and
+ - sets the publishing rate to 1/60 of a second (simulated time).
+
+ @param scene_graph  The system whose geometry will be visualized.
+ @param builder      The diagram builder to which the system belongs; additional
+                     systems will be added to enable visualization updates.
+ @param lcm          The lcm interface through which lcm messages will be
+                     dispatched.
+
+ @see geometry::DispatchLoadMessage() */
+void ConnectVisualization(const SceneGraph<double>& scene_graph,
+                          systems::DiagramBuilder<double>* builder,
+                          lcm::DrakeLcmInterface* lcm);
+
 /** Dispatches an LCM load message based on the registered geometry. It should
  be invoked _after_ registration is complete, but before context allocation.
- @param scene_graph    The system whose geometry will be sent in an LCM message.
- @throws std::logic_error if the system has already had its context allocated.
- */
-void DispatchLoadMessage(const SceneGraph<double>& scene_graph);
+ This assumes you used geometry::ConnectVisualization() build building the
+ Diagram that contains the given `scene_graph`.
+ @see geometry::ConnectVisualization() */
+void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
+                         lcm::DrakeLcmInterface* lcm);
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -15,6 +15,12 @@
 #include "drake/systems/rendering/pose_bundle.h"
 
 namespace drake {
+
+// Forward declarations to give LCM message publication appropriate access.
+namespace lcm {
+class DrakeLcmInterface;
+}  // namespace lcm
+
 namespace geometry {
 
 class GeometryInstance;
@@ -449,7 +455,8 @@ class SceneGraph final : public systems::LeafSystem<T> {
   void MakeSourcePorts(SourceId source_id);
 
   // Allow the load dispatch to peek into SceneGraph.
-  friend void DispatchLoadMessage(const SceneGraph<double>&);
+  friend void DispatchLoadMessage(const SceneGraph<double>&,
+                                  lcm::DrakeLcmInterface*);
 
   // Constructs a QueryObject for OutputPort allocation.
   QueryObject<T> MakeQueryObject() const;


### PR DESCRIPTION
This is a resurrection of @SeanCurtis-TRI's PR #8526, with a few updates.

This PR provides some sugar that helps build a SceneGraph-using Diagram that can be visualized with the Drake visualizer. Lots of ugly boilerplate gets removed using these.

There was an extensive discussion in #8526 about possibly-better ways to do this, but per @RussTedrake's request we'll go with this approach as being a clear improvement, if not necessarily perfect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9295)
<!-- Reviewable:end -->
