### PR TITLE
Rename "namespace geometry_world" to "namespace scene_graph"

### DIFF
--- a/examples/scene_graph/bouncing_ball_plant.cc
+++ b/examples/scene_graph/bouncing_ball_plant.cc
@@ -11,7 +11,7 @@
 
 namespace drake {
 namespace examples {
-namespace geometry_world {
+namespace scene_graph {
 namespace bouncing_ball {
 
 using geometry::FramePoseVector;
@@ -138,6 +138,6 @@ void BouncingBallPlant<T>::DoCalcTimeDerivatives(
 template class BouncingBallPlant<double>;
 
 }  // namespace bouncing_ball
-}  // namespace geometry_world
+}  // namespace scene_graph
 }  // namespace examples
 }  // namespace drake

--- a/examples/scene_graph/bouncing_ball_plant.h
+++ b/examples/scene_graph/bouncing_ball_plant.h
@@ -12,7 +12,7 @@
 
 namespace drake {
 namespace examples {
-namespace geometry_world {
+namespace scene_graph {
 namespace bouncing_ball {
 
 /** A model of a bouncing ball with Hunt-Crossley compliant contact model.
@@ -141,6 +141,6 @@ class BouncingBallPlant : public systems::LeafSystem<T> {
 };
 
 }  // namespace bouncing_ball
-}  // namespace geometry_world
+}  // namespace scene_graph
 }  // namespace examples
 }  // namespace drake

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -13,7 +13,7 @@
 
 namespace drake {
 namespace examples {
-namespace geometry_world {
+namespace scene_graph {
 namespace bouncing_ball {
 namespace {
 
@@ -96,10 +96,10 @@ int do_main() {
 
 }  // namespace
 }  // namespace bouncing_ball
-}  // namespace geometry_world
+}  // namespace scene_graph
 }  // namespace examples
 }  // namespace drake
 
 int main() {
-  return drake::examples::geometry_world::bouncing_ball::do_main();
+  return drake::examples::scene_graph::bouncing_ball::do_main();
 }

--- a/examples/scene_graph/bouncing_ball_vector.named_vector
+++ b/examples/scene_graph/bouncing_ball_vector.named_vector
@@ -1,4 +1,4 @@
-namespace: "drake::examples::geometry_world::bouncing_ball"
+namespace: "drake::examples::scene_graph::bouncing_ball"
 
 element {
     name: "z"


### PR DESCRIPTION
Rename `namespace geometry_world` to `namespace scene_graph` in examples/scene_graph/*.{cc,h}
Fixes #9305

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9307)
<!-- Reviewable:end -->
