### PR TITLE
Transfer the responsibility of computing joint damping from MBP to MBT.

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -1021,16 +1021,6 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
 }
 
 template<typename T>
-void MultibodyPlant<T>::AddJointDampingForces(
-    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
-  DRAKE_DEMAND(forces != nullptr);
-  for (JointIndex joint_index(0); joint_index < num_joints(); ++joint_index) {
-    const Joint<T>& joint = model().get_joint(joint_index);
-    joint.AddInDamping(context, forces);
-  }
-}
-
-template<typename T>
 void MultibodyPlant<T>::AddJointActuationForces(
     const systems::Context<T>& context, MultibodyForces<T>* forces) const {
   DRAKE_DEMAND(forces != nullptr);
@@ -1151,8 +1141,6 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context, &forces);
-
-  AddJointDampingForces(context, &forces);
 
   model_->CalcMassMatrixViaInverseDynamics(context, &M);
 
@@ -1277,10 +1265,6 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context0, &forces0);
-
-  // TODO(amcastro-tri): Update ImplicitStribeckSolver to treat this term
-  // implicitly.
-  AddJointDampingForces(context0, &forces0);
 
   AddJointLimitsPenaltyForces(context0, &forces0);
 

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1485,17 +1485,6 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   void AddJointLimitsPenaltyForces(
       const systems::Context<T>& context, MultibodyForces<T>* forces) const;
 
-  // Helper method to apply forces due to damping at the joints.
-  // Currently, MultibodyPlant treats damping forces separately from other
-  // ForceElement forces so that it can use an implicit scheme in the time
-  // stepping scheme.
-  // TODO(amcastro-tri): Consider updating ForceElement to also compute a
-  // Jacobian for general force models. That would allow MultibodyPlant to use
-  // that general infrastructure rather than having to deal with damping in a
-  // special way.
-  void AddJointDampingForces(
-      const systems::Context<T>& context, MultibodyForces<T>* forces) const;
-
   // Given a set of point pairs in `point_pairs_set`, this method computes the
   // Jacobian N(q) such that:
   //   vn = N(q) v

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -95,7 +95,7 @@ VectorX<T> MultibodyTree<T>::get_velocities_from_array(
 }
 
 template <typename T>
-void MultibodyTree<T>:: AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer() {
+void MultibodyTree<T>::AddQuaternionFreeMobilizerToAllBodiesWithNoMobilizer() {
   DRAKE_DEMAND(!topology_is_valid());
   // Skip the world.
   for (BodyIndex body_index(1); body_index < num_bodies(); ++body_index) {
@@ -602,6 +602,19 @@ void MultibodyTree<T>::CalcForceElementsContribution(
   // Add contributions from force elements.
   for (const auto& force_element : owned_force_elements_) {
     force_element->CalcAndAddForceContribution(mbt_context, pc, vc, forces);
+  }
+
+  // TODO(amcastro-tri): Remove this call once damping is implemented in terms
+  // of force elements.
+  AddJointDampingForces(context, forces);
+}
+
+template<typename T>
+void MultibodyTree<T>::AddJointDampingForces(
+    const systems::Context<T>& context, MultibodyForces<T>* forces) const {
+  DRAKE_DEMAND(forces != nullptr);
+  for (const auto& joint : owned_joints_) {
+    joint->AddInDamping(context, forces);
   }
 }
 

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -2336,6 +2336,17 @@ class MultibodyTree {
       const VelocityKinematicsCache<T>& vc,
       EigenPtr<VectorX<T>> Cv) const;
 
+  // Helper method to apply forces due to damping at the joints.
+  // MultibodyTree treats damping forces separately from other ForceElement
+  // forces for a quick simple solution. This allows clients of MBT (namely MBP)
+  // to implement their own customized (implicit) time stepping schemes.
+  // TODO(amcastro-tri): Consider updating ForceElement to also compute a
+  // Jacobian for general force models. That would allow us to implement
+  // implicit schemes for any forces using a more general infrastructure rather
+  // than having to deal with damping in a special way.
+  void AddJointDampingForces(
+      const systems::Context<T>& context, MultibodyForces<T>* forces) const;
+
   // Implementation of CalcPotentialEnergy().
   // It is assumed that the position kinematics cache pc is in sync with
   // context.


### PR DESCRIPTION
This PR addresses one of the problems identified in #9131 for the inverse dynamics controller. 
That is, inverse dynamics of course must take into account damping forces. Since these were computed explicitly by the MBP they did not get taken into account by inverse dynamics. 
This PR therefore moves this computation to MBT together with the computation of force elements's contributions.
There still is the TODO left to upgrade to using force elements for damping (which requires some infrastructure) but clearly an improvement since it fixes the problems in #9131.

All unit tests for damping are already in master. Most of them in `multibody/multibody_tree/multibody_plant:multibody_plant_test`, including plant linearization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9313)
<!-- Reviewable:end -->
