### PR TITLE
Implements MBT::CalcGravityGeneralizedForces()

### DIFF
--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -708,6 +708,16 @@ void MultibodyTree<T>::CalcBiasTerm(
 }
 
 template <typename T>
+VectorX<T> MultibodyTree<T>::CalcGravityGeneralizedForces(
+    const systems::Context<T>& context) const {
+  DRAKE_MBT_THROW_IF_NOT_FINALIZED();
+  if (gravity_field_.has_value()) {
+    return gravity_field_.value()->CalcGravityGeneralizedForces(context);
+  }
+  return VectorX<T>::Zero(num_velocities());
+}
+
+template <typename T>
 void MultibodyTree<T>::DoCalcBiasTerm(
     const systems::Context<T>& context,
     const PositionKinematicsCache<T>& pc,


### PR DESCRIPTION
This PR addresses another of the problems identified in #9131 for the inverse dynamics controller. That is, we need to somehow expose the computation of gravity generalized forces when we want the controller for "gravity compensation" mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9319)
<!-- Reviewable:end -->
