### PR TITLE
Revert "Instead of scraping logs for error messages use CMake launchers"

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -6,6 +6,23 @@ list(APPEND CTEST_CUSTOM_COVERAGE_EXCLUDE
   ".*/third_party/.*"
 )
 
+string(ASCII 27 ESC)
+
+# DEBUG may be colored yellow (CSI 33m) and WARNING may be colored magenta
+# (CSI 35m).
+list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
+  "^DEBUG: "
+  "^WARNING: "
+  ":[0-9]+: Failure$"
+  "^${ESC}\\[(33mDEBUG|35mWARNING): ${ESC}\\[0m"
+)
+
+# ERROR may be colored red (CSI 31m) and bolded (CSI 1m).
+list(APPEND CTEST_CUSTOM_ERROR_MATCH
+  "^ERROR: "
+  "^${ESC}\\[31m${ESC}\\[1mERROR: ${ESC}\\[0m"
+)
+
 # Ignore various Mac CROSSTOOL-related warnings.
 list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
   "ranlib: file: .* has no symbols"
@@ -15,13 +32,10 @@ list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
 )
 
 # WARNING may be colored magenta (CSI 35m).
-string(ASCII 27 ESC)
 list(APPEND CTEST_CUSTOM_WARNING_MATCH
   "^WARNING: "
   "^${ESC}\\[35mWARNING: ${ESC}\\[0m"
 )
-
-set(CTEST_USE_LAUNCHERS ON)
 
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 100)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 100)


### PR DESCRIPTION
Reverts RobotLocomotion/drake#9268

Replace launchers with the solution implemented in [Drake-CI #98](https://github.com/RobotLocomotion/drake-ci/pull/98).

Also, CMake builds may still need to use `CTEST_CUSTOM_ERROR_EXCEPTION` and `CTEST_CUSTOM_ERROR_MATCH`, so they should not have been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9320)
<!-- Reviewable:end -->
