### PR TITLE
support symbolic in FrameKinematicsVector

### DIFF
--- a/geometry/BUILD.bazel
+++ b/geometry/BUILD.bazel
@@ -66,6 +66,7 @@ drake_cc_library(
         ":geometry_ids",
         "//common:autodiff",
         "//common:essential",
+        "//common:symbolic",
     ],
 )
 

--- a/geometry/frame_kinematics_vector.cc
+++ b/geometry/frame_kinematics_vector.cc
@@ -6,6 +6,7 @@
 #include <fmt/ostream.h>
 
 #include "drake/common/autodiff.h"
+#include "drake/common/symbolic.h"
 
 namespace drake {
 namespace geometry {
@@ -64,6 +65,7 @@ const KinematicsValue& FrameKinematicsVector<KinematicsValue>::value(
 // Explicitly instantiates on the most common scalar types.
 template class FrameKinematicsVector<Isometry3<double>>;
 template class FrameKinematicsVector<Isometry3<AutoDiffXd>>;
+template class FrameKinematicsVector<Isometry3<symbolic::Expression>>;
 
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/frame_kinematics_vector.h
+++ b/geometry/frame_kinematics_vector.h
@@ -164,6 +164,7 @@ struct KinematicsValueInitializer<Isometry3<S>> {
  -----------------|------------------------------------------|--------------
   FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | double
   FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | AutoDiffXd
+  FramePoseVector | FrameKinematicsVector<Isometry3<Scalar>> | Expression
   */
 template <class KinematicsValue>
 class FrameKinematicsVector {

--- a/geometry/test/frame_kinematics_vector_test.cc
+++ b/geometry/test/frame_kinematics_vector_test.cc
@@ -6,6 +6,7 @@
 
 #include "drake/common/autodiff.h"
 #include "drake/common/eigen_types.h"
+#include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/common/test_utilities/expect_throws_message.h"
 
@@ -107,6 +108,39 @@ GTEST_TEST(FrameKinematicsVector, AutoDiffInstantiation) {
 
   EXPECT_EQ(poses.source_id(), source_id);
   EXPECT_EQ(poses.size(), kCount);
+}
+
+GTEST_TEST(FrameKinematicsVector, SymbolicInstantiation) {
+  using symbolic::Expression;
+  using symbolic::Variable;
+
+  SourceId source_id = SourceId::get_new_id();
+  std::vector<FrameId> ids{FrameId::get_new_id(), FrameId::get_new_id()};
+  const int kCount = static_cast<int>(ids.size());
+  FramePoseVector<Expression> poses(source_id, ids);
+
+  EXPECT_EQ(poses.source_id(), source_id);
+  EXPECT_EQ(poses.size(), kCount);
+
+  // Set and retrieve a simple symbolic::Expression.
+  poses.clear();
+
+  poses.set_value(ids[0], Isometry3<Expression>::Identity());
+
+  const Variable var_x_{"x"};
+  const Variable var_y_{"y"};
+  const Variable var_z_{"z"};
+  const Expression x_{var_x_};
+  const Expression y_{var_y_};
+  const Expression z_{var_z_};
+
+  const Isometry3<Expression> pose = Isometry3<Expression>
+      (Translation3<Expression>(x_, y_, z_));
+  poses.set_value(ids[1], pose);
+
+  EXPECT_TRUE(x_.EqualTo(poses.value(ids[1]).translation()[0]));
+  EXPECT_TRUE(y_.EqualTo(poses.value(ids[1]).translation()[1]));
+  EXPECT_TRUE(z_.EqualTo(poses.value(ids[1]).translation()[2]));
 }
 
 }  // namespace test


### PR DESCRIPTION
(this is a minimal step to avoid enable_if type logic in systems that support symbolic and just want to publish to a SceneGraph when they are double or autodiff)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9324)
<!-- Reviewable:end -->
