### PR TITLE
pydrake: Fix Doxygen formatting

### DIFF
--- a/bindings/pydrake/pydrake_pybind.h
+++ b/bindings/pydrake/pydrake_pybind.h
@@ -35,11 +35,11 @@ then in Python you would do:
 
 Some (but not all) exceptions:
 
-*   Some of `drake/common` is incorporated into `pydrake.util`. (This will be
+- Some of `drake/common` is incorporated into `pydrake.util`. (This will be
 remedied in the future.)
-*   `drake/multibody/rigid_body_tree.h` is actually contained in the module
+- `drake/multibody/rigid_body_tree.h` is actually contained in the module
 `pydrake.multibody.rigid_body_tree`.
-*   `drake/solvers/mathematical_program.h` is actually contained in the module
+- `drake/solvers/mathematical_program.h` is actually contained in the module
 `pydrake.solvers.mathematicalprogram`.
 
 ## `pybind11` Tips


### PR DESCRIPTION
I introduced bad formatting in #9281. 
Before:
![image](https://user-images.githubusercontent.com/26719449/44817504-a0cbb300-abb3-11e8-87a9-c7d11d3f9648.png)

After:
![image](https://user-images.githubusercontent.com/26719449/44817526-ad500b80-abb3-11e8-8e45-9d85846c29fb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9330)
<!-- Reviewable:end -->
