### PR TITLE
framework: support T = Expression in CalcNextUpdate

### DIFF
--- a/systems/framework/BUILD.bazel
+++ b/systems/framework/BUILD.bazel
@@ -459,7 +459,6 @@ drake_cc_library(
         ":value_checker",
         "//common:default_scalars",
         "//common:essential",
-        "//common:number_traits",
         "//common:pointer_cast",
         "//common:unused",
     ],
@@ -527,7 +526,6 @@ drake_cc_library(
         ":system",
         "//common:default_scalars",
         "//common:essential",
-        "//common:number_traits",
     ],
 )
 
@@ -549,6 +547,7 @@ drake_cc_library(
     deps = [
         "//common:default_scalars",
         "//common:essential",
+        "//common:number_traits",
         "//common:symbolic",
         "//common:type_safe_index",
         "//common:unused",

--- a/systems/framework/diagram.h
+++ b/systems/framework/diagram.h
@@ -789,7 +789,7 @@ class Diagram : public System<T>, internal::SystemParentServiceInterface {
     DRAKE_DEMAND(diagram_context != nullptr);
     DRAKE_DEMAND(info != nullptr);
 
-    *time = std::numeric_limits<T>::infinity();
+    *time = std::numeric_limits<double>::infinity();
 
     // Iterate over the subsystems, and harvest the most imminent updates.
     std::vector<T> times(num_subsystems());

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -16,7 +16,6 @@
 #include "drake/common/drake_copyable.h"
 #include "drake/common/drake_deprecated.h"
 #include "drake/common/eigen_types.h"
-#include "drake/common/number_traits.h"
 #include "drake/common/pointer_cast.h"
 #include "drake/common/unused.h"
 #include "drake/systems/framework/abstract_values.h"
@@ -57,13 +56,11 @@ static T GetNextSampleTime(
     return offset;
   }
 
-  // NOLINTNEXTLINE(build/namespaces): Needed for ADL of floor and ceil.
-  using namespace std;
-
   // Compute the index in the sequence of samples for the next time to sample,
   // which should be greater than the present time.
+  using std::ceil;
   const T offset_time = current_time_sec - offset;
-  const int64_t next_k = static_cast<int64_t>(ceil(offset_time / period));
+  const T next_k = ceil(offset_time / period);
   T next_t = offset + next_k * period;
   if (next_t <= current_time_sec) {
     next_t = offset + (next_k + 1) * period;
@@ -1511,29 +1508,10 @@ class LeafSystem : public System<T> {
     events->SetFrom(initialization_events_);
   }
 
-  // Aborts for scalar types that are not numeric, since there is no reasonable
-  // definition of "next update time" outside of the real line.
-  //
-  // @tparam T1 SFINAE boilerplate for the scalar type. Do not set.
-  template <typename T1 = T>
-  typename std::enable_if_t<!is_numeric<T1>::value>
-  DoCalcNextUpdateTimeImpl(const Context<T1>&,
-                           CompositeEventCollection<T1>*,
-                           T1*) const {
-    DRAKE_ABORT_MSG(
-        "The default implementation of LeafSystem<T>::DoCalcNextUpdateTime "
-        "only works with types that are drake::is_numeric.");
-  }
-
-  // Computes the next update time across all the scheduled periodic events,
-  // for scalar types that are numeric.
-  //
-  // @tparam T1 SFINAE boilerplate for the scalar type. Do not set.
-  template <typename T1 = T>
-  typename std::enable_if_t<is_numeric<T1>::value> DoCalcNextUpdateTimeImpl(
-      const Context<T1>& context, CompositeEventCollection<T1>* events,
-      T1* time) const {
-    T1 min_time = std::numeric_limits<double>::infinity();
+  void DoCalcNextUpdateTimeImpl(
+      const Context<T>& context, CompositeEventCollection<T>* events,
+      T* time) const {
+    T min_time = std::numeric_limits<double>::infinity();
     // No periodic events events.
     if (periodic_events_.empty()) {
       // No discrete update.
@@ -1543,12 +1521,12 @@ class LeafSystem : public System<T> {
 
     // Find the minimum next sample time across all registered events, and
     // the set of registered events that will occur at that time.
-    std::vector<const Event<T1>*> next_events;
+    std::vector<const Event<T>*> next_events;
     for (const auto& event_pair : periodic_events_) {
       const PeriodicEventData& event_data =
           event_pair.first;
       const Event<T>* const event = event_pair.second.get();
-      const T1 t = leaf_system_detail::GetNextSampleTime(
+      const T t = leaf_system_detail::GetNextSampleTime(
           event_data, context.get_time());
       if (t < min_time) {
         min_time = t;
@@ -1561,7 +1539,7 @@ class LeafSystem : public System<T> {
     // Write out the events that fire at min_time.
     *time = min_time;
 
-    for (const Event<T1>* event : next_events) {
+    for (const Event<T>* event : next_events) {
       event->add_to_composite(events);
     }
   }

--- a/systems/framework/leaf_system.h
+++ b/systems/framework/leaf_system.h
@@ -361,7 +361,7 @@ class LeafSystem : public System<T> {
                             CompositeEventCollection<T>* events,
                             T* time) const override {
     T min_time = std::numeric_limits<double>::infinity();
-    // No periodic events events.
+    // No periodic events.
     if (periodic_events_.empty()) {
       // No discrete update.
       *time = min_time;
@@ -387,7 +387,6 @@ class LeafSystem : public System<T> {
 
     // Write out the events that fire at min_time.
     *time = min_time;
-
     for (const Event<T>* event : next_events) {
       event->add_to_composite(events);
     }

--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1722,7 +1722,7 @@ class System : public SystemBase {
                                     CompositeEventCollection<T>* events,
                                     T* time) const {
     unused(context, events);
-    *time = std::numeric_limits<T>::infinity();
+    *time = std::numeric_limits<double>::infinity();
   }
 
   /// Implement this method to return all periodic triggered events.


### PR DESCRIPTION
As discussed in #6631.

This change compiles now (whereas it did not a couple years ago when this code was written), because `symbolic::Formula` has an `operator bool` now.

Thinking a bit more, its plausible that we don't need any additional tests for this deletion.  Here's a PR that proposes as much.

Note to reviewers: I've left the (now-pointless) `Impl` method intact to minimize the diff.  After the first round of review completes, I can relocate its body to live within its (sole) call site and remove the `Impl`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9331)
<!-- Reviewable:end -->
