### PR TITLE
Renames RoadCurve's p_scale to l_max.

### DIFF
--- a/automotive/maliput/monolane/arc_lane.cc
+++ b/automotive/maliput/monolane/arc_lane.cc
@@ -222,10 +222,10 @@ api::LanePosition ArcLane::DoToLanePosition(
                                   driveable_bounds(s).max());
 
   // Calculate the (uniform) road elevation.
-  const double p_scale = r_ * d_theta_;
+  const double l_max = r_ * d_theta_;
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h_unsaturated = geo_position.z() - elevation().a() * p_scale;
+  const double h_unsaturated = geo_position.z() - elevation().a() * l_max;
   const double h = math::saturate(h_unsaturated,
                                   elevation_bounds(s, r).min(),
                                   elevation_bounds(s, r).max());

--- a/automotive/maliput/monolane/lane.cc
+++ b/automotive/maliput/monolane/lane.cc
@@ -35,19 +35,19 @@ optional<api::LaneEnd> Lane::DoGetDefaultBranch(
 
 
 double Lane::do_length() const {
-  return elevation().s_p(1.0) * p_scale_;
+  return elevation().s_p(1.0) * l_max_;
 }
 
 
 Rot3 Lane::Rabg_of_p(const double p) const {
-  return Rot3(superelevation().f_p(p) * p_scale_,
+  return Rot3(superelevation().f_p(p) * l_max_,
               -std::atan(elevation().f_dot_p(p)),
               heading_of_p(p));
 }
 
 
 double Lane::p_from_s(const double s) const {
-  return elevation().p_s(s / p_scale_);
+  return elevation().p_s(s / l_max_);
 }
 
 
@@ -69,7 +69,7 @@ V3 Lane::W_prime_of_prh(const double p, const double r, const double h,
   const double sg = std::sin(gamma);
 
   // Evaluate dα/dp, dβ/dp, dγ/dp...
-  const double d_alpha = superelevation().f_dot_p(p) * p_scale_;
+  const double d_alpha = superelevation().f_dot_p(p) * l_max_;
   const double d_beta = -cb * cb * elevation().f_ddot_p(p);
   const double d_gamma = heading_dot_of_p(p);
 
@@ -83,13 +83,13 @@ V3 Lane::W_prime_of_prh(const double p, const double r, const double h,
   //
   //   ∂G(p)/∂p = G'(p)
   //
-  //   ∂Z(p)/∂p = p_scale * (z / p_scale) = p_scale * g'(p)
+  //   ∂Z(p)/∂p = l_max * (z / l_max) = l_max * g'(p)
   //
   //   ∂R_αβγ/∂p = (∂R_αβγ/∂α ∂R_αβγ/∂β ∂R_αβγ/∂γ)*(dα/dp, dβ/dp, dγ/dp)
   return
       V3(G_prime.x(),
          G_prime.y(),
-         p_scale_ * g_prime) +
+         l_max_ * g_prime) +
 
       V3((((sa*sg)+(ca*sb*cg))*r + ((ca*sg)-(sa*sb*cg))*h),
          (((-sa*cg)+(ca*sb*sg))*r - ((ca*cg)+(sa*sb*sg))*h),
@@ -125,7 +125,7 @@ api::GeoPosition Lane::DoToGeoPosition(
   // Recover parameter p from arc-length position s.
   const double p = p_from_s(lane_pos.s());
   // Calculate z (elevation) of (s,0,0);
-  const double z = elevation().f_p(p) * p_scale_;
+  const double z = elevation().f_p(p) * l_max_;
   // Calculate x,y of (s,0,0).
   const V2 xy = xy_of_p(p);
   // Calculate orientation of (s,r,h) basis at (s,0,0).
@@ -191,9 +191,9 @@ api::LanePosition Lane::DoEvalMotionDerivatives(
 
   // The definition of path-length of a path along σ yields dσ = |∂W/∂p| dp.
   // Similarly, path-length s along the road at r = 0 is related to the
-  // elevation by ds = p_scale * sqrt(1 + g'^2) dp.  Chaining yields ds/dσ:
+  // elevation by ds = l_max * sqrt(1 + g'^2) dp.  Chaining yields ds/dσ:
   const double ds_dsigma =
-      p_scale_ * std::sqrt(1 + (g_prime * g_prime)) / W_prime.norm();
+      l_max_ * std::sqrt(1 + (g_prime * g_prime)) / W_prime.norm();
 
   return api::LanePosition(ds_dsigma * velocity.sigma_v,
                            velocity.rho_v,

--- a/automotive/maliput/monolane/lane.h
+++ b/automotive/maliput/monolane/lane.h
@@ -143,7 +143,7 @@ class Lane : public api::Lane {
   ///        entire reference path
   /// @param elevation_bounds elevation bounds of the lane, uniform along the
   ///        entire driveable surface
-  /// @param p_scale isotropic scale factor for elevation and superelevation
+  /// @param l_max isotropic scale factor for elevation and superelevation
   /// @param elevation elevation function (see below)
   /// @param superelevation superelevation function (see below)
   ///
@@ -163,22 +163,22 @@ class Lane : public api::Lane {
   /// These two functions (@p elevation and @p superelevation) must be
   /// isotropically scaled to operate over the domain p in [0, 1], where
   /// p is linear in the path-length of the planar reference curve,
-  /// p = 0 corresponds to the start and p = 1 to the end.  @p p_scale is
+  /// p = 0 corresponds to the start and p = 1 to the end.  @p l_max is
   /// the scale factor.  In other words...
   ///
   /// Given:
   ///  * a reference curve R(p) parameterized by p in domain [0, 1], which
-  ///    has a path-length q(p) in range [0, q_max], linearly related to p,
-  ///    where q_max is the total path-length of R (in real-world units);
-  ///  * the true elevation function E_true(q), parameterized by the
-  ///    path-length q of R;
-  ///  * the true superelevation function S_true(q), parameterized by the
-  ///    path-length q of R;
+  ///    has a path-length ℓ(p) in range [0, l_max], linearly related to p,
+  ///    where l_max is the total path-length of R (in real-world units);
+  ///  * the true elevation function E_true(ℓ), parameterized by the
+  ///    path-length ℓ of R;
+  ///  * the true superelevation function S_true(ℓ), parameterized by the
+  ///    path-length ℓ of R;
   ///
   /// then:
-  ///  * @p p_scale is q_max (and p = q / p_scale);
-  ///  * @p elevation is  E_scaled = (1 / p_scale) * E_true(p_scale * p);
-  ///  * @p superelevation is  S_scaled = (1 / p_scale) * S_true(p_scale * p).
+  ///  * p = ℓ / l_max;
+  ///  * @p elevation is E_scaled = (1 / l_max) * E_true(l_max * p);
+  ///  * @p superelevation is  S_scaled = (1 / l_max) * S_true(l_max * p).
   ///
   /// N.B. The override Lane::ToLanePosition() is currently restricted to lanes
   /// in which superelevation and elevation change are both zero.
@@ -186,14 +186,14 @@ class Lane : public api::Lane {
        const api::RBounds& lane_bounds,
        const api::RBounds& driveable_bounds,
        const api::HBounds& elevation_bounds,
-       double p_scale,
+       double l_max,
        const CubicPolynomial& elevation,
        const CubicPolynomial& superelevation)
       : id_(id), segment_(segment),
         lane_bounds_(lane_bounds),
         driveable_bounds_(driveable_bounds),
         elevation_bounds_(elevation_bounds),
-        p_scale_(p_scale),
+        l_max_(l_max),
         elevation_(elevation),
         superelevation_(superelevation) {
     DRAKE_DEMAND(lane_bounds_.min() >= driveable_bounds_.min());
@@ -354,7 +354,7 @@ class Lane : public api::Lane {
   const api::RBounds lane_bounds_;
   const api::RBounds driveable_bounds_;
   const api::HBounds elevation_bounds_;
-  const double p_scale_{};
+  const double l_max_{};
   const CubicPolynomial elevation_;
   const CubicPolynomial superelevation_;
 };

--- a/automotive/maliput/monolane/test/monolane_lanes_test.cc
+++ b/automotive/maliput/monolane/test/monolane_lanes_test.cc
@@ -571,15 +571,15 @@ GTEST_TEST(MonolaneLanesTest, HillIntegration) {
   const double theta0 = 0.25 * M_PI;
   const double d_theta = 0.5 * M_PI;
   const double theta1 = theta0 + d_theta;
-  const double p_scale = 100. * d_theta;
+  const double l_max = 100. * d_theta;
   const double z0 = 0.;
   const double z1 = 20.;
   // A cubic polynomial such that:
-  //   f(0) = (z0 / p_scale), f(1) = (z1 / p_scale), and f'(0) = f'(1) = 0.
-  const CubicPolynomial kHillPolynomial(z0 / p_scale,
+  //   f(0) = (z0 / l_max), f(1) = (z1 / l_max), and f'(0) = f'(1) = 0.
+  const CubicPolynomial kHillPolynomial(z0 / l_max,
                                         0.,
-                                        (3. * (z1 - z0) / p_scale),
-                                        (-2. * (z1 - z0) / p_scale));
+                                        (3. * (z1 - z0) / l_max),
+                                        (-2. * (z1 - z0) / l_max));
   Lane* l1 = s1->NewArcLane(
       api::LaneId{"l2"},
       {-100., -100.}, 100., theta0, d_theta,

--- a/automotive/maliput/multilane/arc_road_curve.cc
+++ b/automotive/maliput/multilane/arc_road_curve.cc
@@ -13,17 +13,17 @@ namespace multilane {
 double ArcRoadCurve::FastCalcPFromS(double s, double r) const {
   const double effective_radius = offset_radius(r);
   const double elevation_domain = effective_radius / radius_;
-  return s / (p_scale() * std::sqrt(elevation_domain * elevation_domain +
-                                    elevation().fake_gprime(1.) *
-                                    elevation().fake_gprime(1.)));
+  return s / (l_max() * std::sqrt(elevation_domain * elevation_domain +
+                                  elevation().fake_gprime(1.) *
+                                  elevation().fake_gprime(1.)));
 }
 
 double ArcRoadCurve::FastCalcSFromP(double p, double r) const {
   const double effective_radius = offset_radius(r);
   const double elevation_domain = effective_radius / radius_;
-  return p * p_scale() * std::sqrt(elevation_domain * elevation_domain +
-                                   elevation().fake_gprime(p) *
-                                   elevation().fake_gprime(p));
+  return p * l_max() * std::sqrt(elevation_domain * elevation_domain +
+                                 elevation().fake_gprime(p) *
+                                 elevation().fake_gprime(p));
 }
 
 namespace {
@@ -117,7 +117,7 @@ Vector3<double> ArcRoadCurve::ToCurveFrame(
   // Calculate the (uniform) road elevation.
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h_unsaturated = geo_coordinate.z() - elevation().a() * p_scale();
+  const double h_unsaturated = geo_coordinate.z() - elevation().a() * l_max();
   const double h = math::saturate(h_unsaturated, height_bounds.min(),
                                   height_bounds.max());
   return Vector3<double>(p, r, h);

--- a/automotive/maliput/multilane/arc_road_curve.h
+++ b/automotive/maliput/multilane/arc_road_curve.h
@@ -103,7 +103,7 @@ class ArcRoadCurve : public RoadCurve {
     return d_theta_;
   }
 
-  double p_scale() const override { return radius_ * std::abs(d_theta_); }
+  double l_max() const override { return radius_ * std::abs(d_theta_); }
 
   Vector3<double> ToCurveFrame(
       const Vector3<double>& geo_coordinate,

--- a/automotive/maliput/multilane/connection.cc
+++ b/automotive/maliput/multilane/connection.cc
@@ -151,19 +151,19 @@ Endpoint Connection::LaneStart(int lane_index) const {
   //                   being ignored.
   const double cos_superelevation =
       std::cos(road_curve_->superelevation().f_p(0.));
-  const double planar_length = type_ == kLine ?
+  const double t_max = type_ == kLine ?
       line_length_ :
       std::abs(d_theta_ * (radius_ - std::copysign(1., d_theta_) * r *
                            cos_superelevation));
-  // Given that ∂p/∂t = 1 / planar_length.
-  const double z_dot = w_prime.z() / planar_length;
+  // Given that ∂p/∂t = 1 / t_max.
+  const double z_dot = w_prime.z() / t_max;
   // theta_dot is derivative with respect to t, but the reference curve t
   // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
   // coordinate and t_i the arc-length xy projection for lane_index lane.
   const double theta_dot = type_ == kLine ? *start_.z().theta_dot()
                                           : (*start_.z().theta_dot()) *
                                                 std::abs(d_theta_ * radius_) /
-                                                planar_length;
+                                                t_max;
   return Endpoint({position[0], position[1], rotation.yaw()},
                   {position[2], z_dot, start_.z().theta(), theta_dot});
 }
@@ -191,19 +191,19 @@ Endpoint Connection::LaneEnd(int lane_index) const {
   //                   being ignored.
   const double cos_superelevation =
       std::cos(road_curve_->superelevation().f_p(1.));
-  const double planar_length = type_ == kLine ?
+  const double t_max = type_ == kLine ?
       line_length_ :
       std::abs(d_theta_ * (radius_ - std::copysign(1., d_theta_) * r *
                            cos_superelevation));
-  // Given that ∂p/∂t = 1 / planar_length.
-  const double z_dot = w_prime.z() / planar_length;
+  // Given that ∂p/∂t = 1 / t_max.
+  const double z_dot = w_prime.z() / t_max;
   // theta_dot is derivative with respect to t, but the reference curve t
   // coordinate. So, a ∂t_0/∂t_i is needed, being t_0 the reference curve
   // coordinate and t_i the arc-length xy projection for lane_index lane.
   const double theta_dot = type_ == kLine ? *end_.z().theta_dot()
                                           : (*end_.z().theta_dot()) *
                                                 std::abs(d_theta_ * radius_) /
-                                                planar_length;
+                                                t_max;
   return Endpoint({position[0], position[1], rotation.yaw()},
                   {position[2], z_dot, end_.z().theta(), theta_dot});
 }

--- a/automotive/maliput/multilane/line_road_curve.cc
+++ b/automotive/maliput/multilane/line_road_curve.cc
@@ -11,12 +11,12 @@ const double LineRoadCurve::kMinimumNorm = 1e-12;
 
 double LineRoadCurve::FastCalcPFromS(double s, double r) const {
   unused(r);
-  return elevation().p_s(s / p_scale());
+  return elevation().p_s(s / l_max());
 }
 
 double LineRoadCurve::FastCalcSFromP(double p, double r) const {
   unused(r);
-  return p_scale() * elevation().s_p(p);
+  return l_max() * elevation().s_p(p);
 }
 
 Vector3<double> LineRoadCurve::ToCurveFrame(
@@ -33,13 +33,13 @@ Vector3<double> LineRoadCurve::ToCurveFrame(
   const Vector2<double> lane_origin_to_q = q - p0_;
 
   // Compute the distance from `q` to the start of the lane.
-  const double p_unsaturated = lane_origin_to_q.dot(s_unit_vector) / p_scale();
+  const double p_unsaturated = lane_origin_to_q.dot(s_unit_vector) / l_max();
   const double p = math::saturate(p_unsaturated, 0., 1.);
   const double r_unsaturated = lane_origin_to_q.dot(r_unit_vector);
   const double r = math::saturate(r_unsaturated, r_min, r_max);
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
-  const double h_unsaturated = geo_coordinate.z() - elevation().a() * p_scale();
+  const double h_unsaturated = geo_coordinate.z() - elevation().a() * l_max();
   const double h = math::saturate(h_unsaturated, height_bounds.min(),
                                   height_bounds.max());
   return Vector3<double>(p, r, h);

--- a/automotive/maliput/multilane/line_road_curve.h
+++ b/automotive/maliput/multilane/line_road_curve.h
@@ -72,7 +72,7 @@ class LineRoadCurve : public RoadCurve {
     return 0.;
   }
 
-  double p_scale() const override { return dp_.norm(); }
+  double l_max() const override { return dp_.norm(); }
 
   Vector3<double> ToCurveFrame(
       const Vector3<double>& geo_coordinate,

--- a/automotive/maliput/multilane/road_curve.cc
+++ b/automotive/maliput/multilane/road_curve.cc
@@ -238,7 +238,7 @@ double RoadCurve::CalcGPrimeAsUsedForCalcSFromP(double p) const {
 
 Vector3<double> RoadCurve::W_of_prh(double p, double r, double h) const {
   // Calculates z (elevation) of (p,0,0).
-  const double z = elevation().f_p(p) * p_scale();
+  const double z = elevation().f_p(p) * l_max();
   // Calculates x,y of (p,0,0).
   const Vector2<double> xy = xy_of_p(p);
   // Calculates orientation of (p,r,h) basis at (p,0,0).
@@ -266,7 +266,7 @@ Vector3<double> RoadCurve::W_prime_of_prh(double p, double r, double h,
   const double sg = std::sin(gamma);
 
   // Evaluate dα/dp, dβ/dp, dγ/dp...
-  const double d_alpha = superelevation().f_dot_p(p) * p_scale();
+  const double d_alpha = superelevation().f_dot_p(p) * l_max();
   const double d_beta = -cb * cb * elevation().f_ddot_p(p);
   const double d_gamma = heading_dot_of_p(p);
 
@@ -280,13 +280,13 @@ Vector3<double> RoadCurve::W_prime_of_prh(double p, double r, double h,
   //
   //   ∂G(p)/∂p = G'(p)
   //
-  //   ∂Z(p)/∂p = p_scale * (z / p_scale) = p_scale * g'(p)
+  //   ∂Z(p)/∂p = l_max * (z / l_max) = l_max * g'(p)
   //
   //   ∂R_αβγ/∂p = (∂R_αβγ/∂α ∂R_αβγ/∂β ∂R_αβγ/∂γ)*(dα/dp, dβ/dp, dγ/dp)
   return
       Vector3<double>(G_prime.x(),
                       G_prime.y(),
-                      p_scale() * g_prime) +
+                      l_max() * g_prime) +
 
       Vector3<double>((((sa*sg)+(ca*sb*cg))*r + ((ca*sg)-(sa*sb*cg))*h),
                       (((-sa*cg)+(ca*sb*sg))*r - ((ca*cg)+(sa*sb*sg))*h),
@@ -305,7 +305,7 @@ Vector3<double> RoadCurve::W_prime_of_prh(double p, double r, double h,
 }
 
 Rot3 RoadCurve::Rabg_of_p(double p) const {
-  return Rot3(superelevation().f_p(p) * p_scale(),
+  return Rot3(superelevation().f_p(p) * l_max(),
               -std::atan(elevation().f_dot_p(p)),
               heading_of_p(p));
 }

--- a/automotive/maliput/multilane/road_curve.h
+++ b/automotive/maliput/multilane/road_curve.h
@@ -77,8 +77,8 @@ enum class ComputationPolicy {
 /// W is derived from the three functions which define the lane:
 ///
 ///   G: p --> (x,y)     = the reference curve, a.k.a. xy_of_p()
-///   Z: p --> z / q_max = the elevation function, a.k.a. elevation_
-///   Θ: p --> θ / q_max = the superelevation function, a.k.a. superelevation_
+///   Z: p --> z / l_max = the elevation function, a.k.a. elevation_
+///   Θ: p --> θ / l_max = the superelevation function, a.k.a. superelevation_
 ///
 /// as:
 ///
@@ -171,13 +171,11 @@ class RoadCurve {
   /// d_heading/dp evaluated at @p p.
   virtual double heading_dot_of_p(double p) const = 0;
 
-  /// Computes the path length integral of the reference curve for the interval
-  /// [0;1] of p.
-  /// @return The path length integral of the reference curve.
-  // TODO(maddog-tri)  This method should be renamed to match the Maliput's
-  //                   documentation as well as other variable names along the
-  //                   implementation.
-  virtual double p_scale() const = 0;
+  /// Computes the path length integral of the reference curve for
+  /// the whole [0; 1] interval of p, formally l_max = ∫₀¹ |G'(p)| dp
+  /// where G' = dG/dp.
+  /// @return The total path length of the reference curve.
+  virtual double l_max() const = 0;
 
   /// Converts a @p geo_coordinate in the world frame to the composed curve
   /// frame, i.e., the superposition of the reference curve, elevation and
@@ -290,22 +288,22 @@ class RoadCurve {
   /// These two functions (@p elevation and @p superelevation) must be
   /// isotropically scaled to operate over the domain p in [0, 1], where
   /// p is linear in the path-length of the planar reference curve,
-  /// p = 0 corresponds to the start and p = 1 to the end. p_scale() is
-  /// the scale factor.  In other words...
+  /// p = 0 corresponds to the start and p = 1 to the end. l_max()
+  /// is the length of the reference curve. In other words...
   ///
   /// Given:
   ///  * a reference curve R(p) parameterized by p in domain [0, 1], which
-  ///    has a path-length q(p) in range [0, q_max], linearly related to p,
-  ///    where q_max is the total path-length of R (in real-world units);
-  ///  * the true elevation function E_true(q), parameterized by the
-  ///    path-length q of R;
-  ///  * the true superelevation function S_true(q), parameterized by the
-  ///    path-length q of R;
+  ///    has a path-length ℓ(p) in range [0, l_max], linearly related to p,
+  ///    where l_max is the total path-length of R (in real-world units);
+  ///  * the true elevation function E_true(ℓ), parameterized by the
+  ///    path-length ℓ of R;
+  ///  * the true superelevation function S_true(ℓ), parameterized by the
+  ///    path-length ℓ of R;
   ///
   /// then:
-  ///  * p_scale is q_max (and p = q / p_scale);
-  ///  * @p elevation is  E_scaled = (1 / p_scale) * E_true(p_scale * p);
-  ///  * @p superelevation is  S_scaled = (1 / p_scale) * S_true(p_scale * p).
+  ///  * p = ℓ / l_max;
+  ///  * @p elevation is E_scaled = (1 / l_max) * E_true(l_max * p);
+  ///  * @p superelevation is  S_scaled = (1 / l_max) * S_true(l_max * p).
   RoadCurve(double linear_tolerance, double scale_length,
             const CubicPolynomial& elevation,
             const CubicPolynomial& superelevation,

--- a/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_arc_road_curve_test.cc
@@ -72,7 +72,10 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
                          kLinearTolerance, kScaleLength, kComputationPolicy);
   // Checks curve length computations along the centerline.
   const double kExpectedLength = kDTheta * kRadius;
-  EXPECT_NEAR(dut.p_scale(), kExpectedLength, kVeryExact);
+  // The total path length of the reference curve l_max and the total path
+  // length of the curve along the centerline s_max for r = h = 0 should match
+  // provided that the curve shows no elevation.
+  EXPECT_NEAR(dut.l_max(), kExpectedLength, kVeryExact);
   std::function<double(double)> s_from_p_at_r0 =
       dut.OptimizeCalcSFromP(kR0Offset);
   const double centerline_length = s_from_p_at_r0(1.);
@@ -259,8 +262,9 @@ TEST_F(MultilaneArcRoadCurveTest, ToCurveFrameTest) {
       kVeryExact));
 }
 
-// Checks that p_scale(), p_from_s() and s_from_p() with constant superelevation
-// polynomial and up to linear elevation polynomial behave properly.
+// Checks that l_max(), p_from_s() and s_from_p() with constant
+// superelevation polynomial and up to linear elevation polynomial behave
+// properly.
 TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const std::vector<double> r_vector{-0.5 * kRadius, 0.0, 0.5 * kRadius};
   const std::vector<double> p_vector{0., 0.1, 0.2, 0.5, 0.7, 1.0};
@@ -269,7 +273,7 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const ArcRoadCurve flat_dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp,
                               kLinearTolerance, kScaleLength,
                               kComputationPolicy);
-  EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kRadius * kDTheta);
+  EXPECT_DOUBLE_EQ(flat_dut.l_max(), kRadius * kDTheta);
   // Checks that functions throw when lateral offset is exceeded.
   EXPECT_THROW(flat_dut.OptimizeCalcPFromS(kRadius), std::runtime_error);
   EXPECT_THROW(flat_dut.OptimizeCalcPFromS(2.0 * kRadius), std::runtime_error);
@@ -298,7 +302,7 @@ TEST_F(MultilaneArcRoadCurveTest, OffsetTest) {
   const ArcRoadCurve elevated_dut(kCenter, kRadius, kTheta0, kDTheta,
                                   linear_elevation, zp, kLinearTolerance,
                                   kScaleLength, kComputationPolicy);
-  EXPECT_DOUBLE_EQ(elevated_dut.p_scale(), kRadius * kDTheta);
+  EXPECT_DOUBLE_EQ(elevated_dut.l_max(), kRadius * kDTheta);
   // Evaluates inverse function and path length integral for different values of
   // p and r lateral offsets.
   for (double r : r_vector) {

--- a/automotive/maliput/multilane/test/multilane_lanes_test.cc
+++ b/automotive/maliput/multilane/test/multilane_lanes_test.cc
@@ -769,14 +769,16 @@ TEST_P(MultilaneLanesParamTest, HillIntegration) {
   const double theta1 = theta0 + d_theta;
   const double radius = 100.;
   const double offset_radius = radius - r0;
-  const double p_scale = radius * d_theta;
+  const double l_max = radius * d_theta;
   const double z0 = 0.;
   const double z1 = 20.;
   // A cubic polynomial such that:
-  //   f(0) = (z0 / p_scale), f(1) = (z1 / p_scale), and f'(0) = f'(1) = 0.
-  const CubicPolynomial kHillPolynomial(z0 / p_scale, 0.,
-                                        (3. * (z1 - z0) / p_scale),
-                                        (-2. * (z1 - z0) / p_scale));
+  //   f(0) = (z0 / l_max),
+  ///  f(1) = (z1 / l_max),
+  //   and f'(0) = f'(1) = 0.
+  const CubicPolynomial kHillPolynomial(z0 / l_max, 0.,
+                                        (3. * (z1 - z0) / l_max),
+                                        (-2. * (z1 - z0) / l_max));
   std::unique_ptr<RoadCurve> road_curve =
       std::make_unique<ArcRoadCurve>(Vector2<double>(-100., -100.), radius,
                                      theta0, d_theta, kHillPolynomial, zp,

--- a/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
+++ b/automotive/maliput/multilane/test/multilane_line_road_curve_test.cc
@@ -43,7 +43,10 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
   // Checks curve length computations.
   const double kExpectedLength = std::sqrt(kDirection.x() * kDirection.x() +
                                            kDirection.y() * kDirection.y());
-  EXPECT_NEAR(dut.p_scale(), kExpectedLength, kVeryExact);
+  // The total path length of the reference curve l_max and the total path
+  // length of the curve along the centerline s_max for r = h = 0 should match
+  // provided that the curve shows no elevation.
+  EXPECT_NEAR(dut.l_max(), kExpectedLength, kVeryExact);
   std::function<double(double)> s_from_p_at_r0 =
       dut.OptimizeCalcSFromP(kR0Offset);
   const double centerline_length = s_from_p_at_r0(1.);
@@ -147,8 +150,9 @@ TEST_F(MultilaneLineRoadCurveTest, ToCurveFrameTest) {
       Vector3<double>(0.05, -0.707106781186547, 7.0), kVeryExact));
 }
 
-// Checks that p_scale(), p_from_s() and s_from_p() with constant superelevation
-// polynomial and up to linear elevation polynomial behave properly.
+// Checks that l_max(), p_from_s() and s_from_p() with constant
+// superelevation polynomial and up to linear elevation polynomial behave
+// properly.
 TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   const std::vector<double> r_vector{-10., 0., 10.};
   const std::vector<double> p_vector{0., 0.1, 0.2, 0.5, 0.7, 1.0};
@@ -156,7 +160,7 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   // Checks for flat LineRoadCurve.
   const LineRoadCurve flat_dut(kOrigin, kDirection, zp, zp, kLinearTolerance,
                                kScaleLength, kComputationPolicy);
-  EXPECT_DOUBLE_EQ(flat_dut.p_scale(), kDirection.norm());
+  EXPECT_DOUBLE_EQ(flat_dut.l_max(), kDirection.norm());
   // Evaluates inverse function for different path length and offset values.
   for (double r : r_vector) {
     std::function<double(double)> p_from_s_at_r =
@@ -180,7 +184,7 @@ TEST_F(MultilaneLineRoadCurveTest, OffsetTest) {
   const LineRoadCurve elevated_dut(kOrigin, kDirection, linear_elevation, zp,
                                    kLinearTolerance, kScaleLength,
                                    kComputationPolicy);
-  EXPECT_DOUBLE_EQ(elevated_dut.p_scale(), kDirection.norm());
+  EXPECT_DOUBLE_EQ(elevated_dut.l_max(), kDirection.norm());
   // Evaluates inverse function and path length integral for different values of
   // p and r lateral offsets.
   for (double r : r_vector) {


### PR DESCRIPTION
Connected to #8898. This pull request replaces `p_scale` notation everywhere to match the [design document notation](https://github.com/maddog-tri/drake/blob/DOC_multilane_design/drake/automotive/maliput/doc/maliput-design.pdf).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9332)
<!-- Reviewable:end -->
