### PR TITLE
Adds AddVisualization() sugar to cut down on boilerplate

### DIFF
--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -5,8 +5,7 @@ Provides an example translation of `cart_pole_passive_simluation.cc`.
 import argparse
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.geometry import (
-    ConnectVisualization, DispatchLoadMessage, SceneGraph)
+from pydrake.geometry import (ConnectVisualization, SceneGraph)
 from pydrake.lcm import DrakeLcm
 from pydrake.multibody.multibody_tree import UniformGravityFieldElement
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
@@ -43,17 +42,14 @@ def main():
     assert cart_pole.geometry_source_is_registered()
 
     builder.Connect(
+        scene_graph.get_query_output_port(),
+        cart_pole.get_geometry_query_input_port())
+    builder.Connect(
         cart_pole.get_geometry_poses_output_port(),
         scene_graph.get_source_pose_port(cart_pole.get_source_id()))
 
-    builder.Connect(
-        scene_graph.get_query_output_port(),
-        cart_pole.get_geometry_query_input_port())
-
-    lcm = DrakeLcm()
-    ConnectVisualization(scene_graph=scene_graph, builder=builder, lcm=lcm)
+    ConnectVisualization(builder=builder, scene_graph=scene_graph)
     diagram = builder.Build()
-    DispatchLoadMessage(scene_graph=scene_graph, lcm=lcm)
 
     diagram_context = diagram.CreateDefaultContext()
     cart_pole_context = diagram.GetMutableSubsystemContext(

--- a/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
+++ b/bindings/pydrake/examples/multibody/cart_pole_passive_simulation.py
@@ -5,7 +5,7 @@ Provides an example translation of `cart_pole_passive_simluation.cc`.
 import argparse
 
 from pydrake.common import FindResourceOrThrow
-from pydrake.geometry import (ConnectVisualization, SceneGraph)
+from pydrake.geometry import (ConnectDrakeVisualizer, SceneGraph)
 from pydrake.lcm import DrakeLcm
 from pydrake.multibody.multibody_tree import UniformGravityFieldElement
 from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
@@ -48,7 +48,7 @@ def main():
         cart_pole.get_geometry_poses_output_port(),
         scene_graph.get_source_pose_port(cart_pole.get_source_id()))
 
-    ConnectVisualization(builder=builder, scene_graph=scene_graph)
+    ConnectDrakeVisualizer(builder=builder, scene_graph=scene_graph)
     diagram = builder.Build()
 
     diagram_context = diagram.CreateDefaultContext()

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -44,7 +44,7 @@ PYBIND11_MODULE(geometry, m) {
   BindIdentifier<FrameId>(m, "FrameId");
   BindIdentifier<GeometryId>(m, "GeometryId");
 
-  m.def("ConnectVisualization", &ConnectVisualization,
+  m.def("ConnectDrakeVisualizer", &ConnectDrakeVisualizer,
         py::arg("builder"), py::arg("scene_graph"), py::arg("lcm") = nullptr);
   m.def("DispatchLoadMessage", &DispatchLoadMessage,
         py::arg("scene_graph"), py::arg("lcm"));

--- a/bindings/pydrake/geometry_py.cc
+++ b/bindings/pydrake/geometry_py.cc
@@ -45,7 +45,7 @@ PYBIND11_MODULE(geometry, m) {
   BindIdentifier<GeometryId>(m, "GeometryId");
 
   m.def("ConnectVisualization", &ConnectVisualization,
-        py::arg("scene_graph"), py::arg("builder"), py::arg("lcm"));
+        py::arg("builder"), py::arg("scene_graph"), py::arg("lcm") = nullptr);
   m.def("DispatchLoadMessage", &DispatchLoadMessage,
         py::arg("scene_graph"), py::arg("lcm"));
 }

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -87,15 +87,6 @@ void DoMain() {
   DRAKE_DEMAND(plant.num_actuators() == 16);
   DRAKE_DEMAND(plant.num_actuated_dofs() == 16);
 
-  // Visualization
-  lcm::DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
-  DRAKE_DEMAND(!!plant.get_source_id());
-  builder.Connect(plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
-                  plant.get_geometry_query_input_port());
-
   // constant force input
   VectorX<double> constant_load_value = VectorX<double>::Ones(
       plant.model().num_actuators()) * FLAGS_constant_load;
@@ -106,8 +97,15 @@ void DoMain() {
   builder.Connect(constant_source->get_output_port(),
                   plant.get_actuation_input_port());
 
+  DRAKE_DEMAND(!!plant.get_source_id());
+  builder.Connect(
+      plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(plant.get_source_id().value()));
+  builder.Connect(scene_graph.get_query_output_port(),
+                  plant.get_geometry_query_input_port());
+
+  geometry::ConnectVisualization(&builder, scene_graph);
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -104,7 +104,7 @@ void DoMain() {
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   std::unique_ptr<systems::Diagram<double>> diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -127,32 +127,21 @@ int main() {
 
   const auto& tree = plant.get_rigid_body_tree();
 
-  // TODO(SeanCurtis-TRI): This should be wrapped up into a sugar diagram so
-  // this can be done more concisely. Perhaps bundle a SceneGraph in with
-  // all the others and called (something like) SceneGraphWithLcmVisuals.
   auto scene_graph = builder.AddSystem<geometry::SceneGraph<double>>();
   scene_graph->set_name("scene_graph");
 
-  auto rbt_gs_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
+  auto rbt_sg_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
       &tree, scene_graph);
 
-
   builder.Connect(plant.state_output_port(),
-                  rbt_gs_bridge->rigid_body_plant_state_input_port());
+                  rbt_sg_bridge->rigid_body_plant_state_input_port());
 
   builder.Connect(
-      rbt_gs_bridge->geometry_pose_output_port(),
-      scene_graph->get_source_pose_port(rbt_gs_bridge->source_id()));
+      rbt_sg_bridge->geometry_pose_output_port(),
+      scene_graph->get_source_pose_port(rbt_sg_bridge->source_id()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context (Simulator
-  // creates one).
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   // Create simulator.
   Simulator<double> simulator(*diagram);

--- a/examples/contact_model/bowling_ball.cc
+++ b/examples/contact_model/bowling_ball.cc
@@ -140,7 +140,7 @@ int main() {
       rbt_sg_bridge->geometry_pose_output_port(),
       scene_graph->get_source_pose_port(rbt_sg_bridge->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   // Create simulator.

--- a/examples/contact_model/sliding_bricks.cc
+++ b/examples/contact_model/sliding_bricks.cc
@@ -114,13 +114,10 @@ int main() {
   auto scene_graph = builder.AddSystem<geometry::SceneGraph<double>>();
   scene_graph->set_name("scene_graph");
 
-  auto rbt_gs_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
+  auto rbt_sg_bridge = builder.AddSystem<systems::RigidBodyPlantBridge<double>>(
       &tree, scene_graph);
   builder.Connect(plant.state_output_port(),
-                  rbt_gs_bridge->rigid_body_plant_state_input_port());
-  builder.Connect(
-      rbt_gs_bridge->geometry_pose_output_port(),
-      scene_graph->get_source_pose_port(rbt_gs_bridge->source_id()));
+                  rbt_sg_bridge->rigid_body_plant_state_input_port());
 
   // Pusher
   VectorXd push_value(1);      // Single actuator.
@@ -135,15 +132,12 @@ int main() {
   builder.Connect(push_source.get_output_port(), plant.get_input_port(0));
   builder.Connect(push_source.get_output_port(), plant.get_input_port(1));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
-  auto diagram = builder.Build();
+  builder.Connect(
+      rbt_sg_bridge->geometry_pose_output_port(),
+      scene_graph->get_source_pose_port(rbt_sg_bridge->source_id()));
 
-  // Load message must be sent before creating a Context (Simulator
-  // creates one).
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
+  geometry::ConnectVisualization(&builder, *scene_graph);
+  auto diagram = builder.Build();
 
   // Create simulator.
   Simulator<double> simulator(*diagram);

--- a/examples/contact_model/sliding_bricks.cc
+++ b/examples/contact_model/sliding_bricks.cc
@@ -136,7 +136,7 @@ int main() {
       rbt_sg_bridge->geometry_pose_output_port(),
       scene_graph->get_source_pose_port(rbt_sg_bridge->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   // Create simulator.

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -66,10 +66,6 @@ int DoMain() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!kuka_plant.get_source_id());
 
-  builder.Connect(
-      kuka_plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(kuka_plant.get_source_id().value()));
-
   auto tree = std::make_unique<RigidBodyTree<double>>();
   parsers::sdf::AddModelInstancesFromSdfFile(
       FindResourceOrThrow(kSdfPath), multibody::joints::kFixed,
@@ -99,15 +95,12 @@ int DoMain() {
   builder.Connect(traj_src->get_output_port(),
                   controller->get_input_port_desired_state());
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
-  auto diagram = builder.Build();
+  builder.Connect(
+      kuka_plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(kuka_plant.get_source_id().value()));
 
-  // Load message must be sent before creating a Context (Simulator
-  // creates one).
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
+  auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);
   simulator.Initialize();

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -99,7 +99,7 @@ int DoMain() {
       kuka_plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(kuka_plant.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -86,14 +86,8 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/acrobot/passive_simulation.cc
+++ b/examples/multibody/acrobot/passive_simulation.cc
@@ -86,7 +86,7 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -148,14 +148,8 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/acrobot/run_lqr.cc
+++ b/examples/multibody/acrobot/run_lqr.cc
@@ -148,7 +148,7 @@ int do_main() {
       acrobot.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(acrobot.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -96,7 +96,7 @@ int do_main() {
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -89,20 +89,15 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
-  auto diagram = builder.Build();
+  builder.Connect(
+      plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
+  auto diagram = builder.Build();
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -71,14 +71,8 @@ int do_main() {
       cart_pole.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(cart_pole.get_source_id().value()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
+++ b/examples/multibody/cart_pole/cart_pole_passive_simulation.cc
@@ -71,7 +71,7 @@ int do_main() {
       cart_pole.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(cart_pole.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -98,7 +98,7 @@ int do_main() {
                   plant.get_geometry_query_input_port());
 
   DrakeLcm lcm;
-  geometry::ConnectVisualization(&builder, scene_graph, &lcm);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph, &lcm);
 
   // This is the source of poses for the visualizer.
   builder.Connect(

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -94,13 +94,16 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
   DrakeLcm lcm;
+  geometry::ConnectVisualization(&builder, scene_graph, &lcm);
+
+  // This is the source of poses for the visualizer.
+  builder.Connect(
+      plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   // Publish contact results for visualization.
   const auto& contact_results_to_lcm =
@@ -114,13 +117,7 @@ int do_main() {
   builder.Connect(contact_results_to_lcm.get_output_port(0),
                   contact_results_publisher.get_input_port());
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -73,20 +73,15 @@ int do_main() {
   // Sanity check on the availability of the optional source id before using it.
   DRAKE_DEMAND(!!plant.get_source_id());
 
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
   builder.Connect(scene_graph.get_query_output_port(),
                   plant.get_geometry_query_input_port());
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
-  auto diagram = builder.Build();
+  builder.Connect(
+      plant.get_geometry_poses_output_port(),
+      scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
+  auto diagram = builder.Build();
 
   // Create a context for this system:
   std::unique_ptr<systems::Context<double>> diagram_context =

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -80,7 +80,7 @@ int do_main() {
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -87,7 +87,7 @@ int do_main() {
       pendulum.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(pendulum.get_source_id().value()));
 
-  geometry::ConnectVisualization(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
 
   auto diagram_context = diagram->CreateDefaultContext();

--- a/examples/multibody/pendulum/passive_simulation.cc
+++ b/examples/multibody/pendulum/passive_simulation.cc
@@ -87,14 +87,8 @@ int do_main() {
       pendulum.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(pendulum.get_source_id().value()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context.
-  geometry::DispatchLoadMessage(scene_graph, &lcm);
 
   auto diagram_context = diagram->CreateDefaultContext();
   systems::Context<double>& pendulum_context =

--- a/examples/pendulum/energy_shaping_simulation.cc
+++ b/examples/pendulum/energy_shaping_simulation.cc
@@ -79,7 +79,7 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/energy_shaping_simulation.cc
+++ b/examples/pendulum/energy_shaping_simulation.cc
@@ -79,11 +79,9 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  lcm::DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
-
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
+
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& pendulum_context =
       diagram->GetMutableSubsystemContext(*pendulum,

--- a/examples/pendulum/lqr_simulation.cc
+++ b/examples/pendulum/lqr_simulation.cc
@@ -63,7 +63,7 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/lqr_simulation.cc
+++ b/examples/pendulum/lqr_simulation.cc
@@ -63,11 +63,9 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  lcm::DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
-
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
+
   systems::Simulator<double> simulator(*diagram);
   systems::Context<double>& sim_pendulum_context =
       diagram->GetMutableSubsystemContext(*pendulum,

--- a/examples/pendulum/passive_simulation.cc
+++ b/examples/pendulum/passive_simulation.cc
@@ -38,10 +38,7 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  lcm::DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
-
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/passive_simulation.cc
+++ b/examples/pendulum/passive_simulation.cc
@@ -38,7 +38,7 @@ int DoMain() {
   builder.Connect(pendulum->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(pendulum->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -113,11 +113,7 @@ int DoMain() {
   builder.Connect(pid_controlled_pendulum->get_output_port(geometry_port_index),
                   scene_graph->get_source_pose_port(source_id));
 
-  lcm::DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
-
-
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/pendulum/trajectory_optimization_simulation.cc
+++ b/examples/pendulum/trajectory_optimization_simulation.cc
@@ -113,7 +113,7 @@ int DoMain() {
   builder.Connect(pid_controlled_pendulum->get_output_port(geometry_port_index),
                   scene_graph->get_source_pose_port(source_id));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -64,15 +64,8 @@ int do_main() {
   builder.Connect(scene_graph->get_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context (Simulator
-  // creates one).
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   systems::Simulator<double> simulator(*diagram);
   auto init_ball = [&](BouncingBallPlant<double>* system, double z,

--- a/examples/scene_graph/bouncing_ball_run_dynamics.cc
+++ b/examples/scene_graph/bouncing_ball_run_dynamics.cc
@@ -64,7 +64,7 @@ int do_main() {
   builder.Connect(scene_graph->get_query_output_port(),
                   bouncing_ball2->get_geometry_query_input_port());
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -26,15 +26,8 @@ int do_main() {
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
-  // Last thing before building the diagram; configure the system for
-  // visualization.
-  DrakeLcm lcm;
-  geometry::ConnectVisualization(*scene_graph, &builder, &lcm);
+  geometry::ConnectVisualization(&builder, *scene_graph);
   auto diagram = builder.Build();
-
-  // Load message must be sent before creating a Context (Simulator
-  // creates one).
-  geometry::DispatchLoadMessage(*scene_graph, &lcm);
 
   systems::Simulator<double> simulator(*diagram);
 

--- a/examples/scene_graph/solar_system_run_dynamics.cc
+++ b/examples/scene_graph/solar_system_run_dynamics.cc
@@ -26,7 +26,7 @@ int do_main() {
   builder.Connect(solar_system->get_geometry_pose_output_port(),
                   scene_graph->get_source_pose_port(solar_system->source_id()));
 
-  geometry::ConnectVisualization(&builder, *scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, *scene_graph);
   auto diagram = builder.Build();
 
   systems::Simulator<double> simulator(*diagram);

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -267,7 +267,7 @@ int do_main() {
                   plant.get_geometry_query_input_port());
 
   DrakeLcm lcm;
-  geometry::ConnectVisualization(&builder, scene_graph, &lcm);
+  geometry::ConnectDrakeVisualizer(&builder, scene_graph, &lcm);
   builder.Connect(
       plant.get_geometry_poses_output_port(),
       scene_graph.get_source_pose_port(plant.get_source_id().value()));

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -199,12 +199,58 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
   return message;
 }
 
+// This System should be included in a diagram for the purpose of ensuring
+// that the one-time load geometry message gets sent to the visualizer upon
+// Simulator initialization. It will also serve to own the DrakeLcm object if
+// one isn't provided on construction.
+// TODO(sherm1) Move this functionality to LcmPublisher and remove this System
+//              (see issue #9397).
+class LcmInitSystem : public systems::LeafSystem<double> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmInitSystem)
+
+  LcmInitSystem(const SceneGraph<double>* scene_graph,
+                lcm::DrakeLcmInterface* lcm = nullptr)
+      : scene_graph_(*scene_graph), lcm_(lcm) {
+    DRAKE_DEMAND(scene_graph != nullptr);
+
+    // Create a DrakeLcm object if we don't already have one.
+    if (lcm_ == nullptr) {
+      owned_lcm_ = std::make_unique<lcm::DrakeLcm>();
+      lcm_ = owned_lcm_.get();
+    }
+
+    // Create an initialization event that sends the load message.
+    // TODO(sherm1) This is pulling geometry from the SceneGraph but should
+    // be changed to use the Context for the most current version of the
+    // geometry, once geometry is changeable at runtime. Also, subsequent
+    // geometry changes are likely to require a "geometry changed" message
+    // to be sent.
+    DeclareInitializationEvent(systems::PublishEvent<double>(
+        systems::Event<double>::TriggerType::kInitialization,
+        [this](const systems::Context<double>&,
+               const systems::PublishEvent<double>&) {
+          DispatchLoadMessage(this->scene_graph_, this->lcm_);
+        }));
+  }
+
+  // Obtain a reference to the DrakeLcm object, which may have been supplied
+  // on construction or may be internally owned.
+  lcm::DrakeLcmInterface& lcm() { return *lcm_; }
+
+ private:
+  const SceneGraph<double>& scene_graph_;
+  lcm::DrakeLcmInterface* lcm_{nullptr};
+  std::unique_ptr<lcm::DrakeLcm> owned_lcm_;
+};
+
 }  // namespace internal
 
-
+// TODO(sherm1) Per Sean Curtis, the load message should take its geometry
+// from a Context rather than directly out of the SceneGraph. If geometry
+// has been added to the Context it won't be loaded here.
 void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                          lcm::DrakeLcmInterface* lcm) {
-  scene_graph.ThrowIfContextAllocated("DispatchLoadMessage");
   lcmt_viewer_load_robot message =
       internal::GeometryVisualizationImpl::BuildLoadMessage(
           *scene_graph.initial_state_);
@@ -212,25 +258,32 @@ void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
   Publish(lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
 }
 
-void ConnectVisualization(const SceneGraph<double>& scene_graph,
-                          systems::DiagramBuilder<double>* builder,
-                          lcm::DrakeLcmInterface* lcm) {
-  using lcm::DrakeLcm;
+void ConnectVisualization(systems::DiagramBuilder<double>* builder,
+                          const SceneGraph<double>& scene_graph,
+                          lcm::DrakeLcmInterface* lcm_optional) {
   using systems::lcm::LcmPublisherSystem;
   using systems::lcm::Serializer;
   using systems::rendering::PoseBundleToDrawMessage;
 
+  DRAKE_DEMAND(builder != nullptr);
+
+  // This disembodied system serves to send out the visualizer's needed
+  // initialization message. Allocates a DrakeLcm if the supplied one is null.
+  internal::LcmInitSystem* lcm_system =
+      builder->AddSystem<internal::LcmInitSystem>(&scene_graph, lcm_optional);
+
   PoseBundleToDrawMessage* converter =
       builder->template AddSystem<PoseBundleToDrawMessage>();
+
   LcmPublisherSystem* publisher =
       builder->template AddSystem<LcmPublisherSystem>(
           "DRAKE_VIEWER_DRAW",
           std::make_unique<Serializer<drake::lcmt_viewer_draw>>(),
-          lcm);
+          &lcm_system->lcm());
   publisher->set_publish_period(1 / 60.0);
 
   builder->Connect(scene_graph.get_pose_bundle_output_port(),
-                  converter->get_input_port(0));
+                   converter->get_input_port(0));
   builder->Connect(*converter, *publisher);
 }
 

--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -258,9 +258,9 @@ void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
   Publish(lcm, "DRAKE_VIEWER_LOAD_ROBOT", message);
 }
 
-void ConnectVisualization(systems::DiagramBuilder<double>* builder,
-                          const SceneGraph<double>& scene_graph,
-                          lcm::DrakeLcmInterface* lcm_optional) {
+void ConnectDrakeVisualizer(systems::DiagramBuilder<double>* builder,
+                            const SceneGraph<double>& scene_graph,
+                            lcm::DrakeLcmInterface* lcm_optional) {
   using systems::lcm::LcmPublisherSystem;
   using systems::lcm::Serializer;
   using systems::rendering::PoseBundleToDrawMessage;

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -67,18 +67,18 @@ class GeometryVisualizationImpl {
       DiagramBuilder.
 
  @see geometry::DispatchLoadMessage() */
-void ConnectVisualization(systems::DiagramBuilder<double>* builder,
-                          const SceneGraph<double>& scene_graph,
-                          lcm::DrakeLcmInterface* lcm = nullptr);
+void ConnectDrakeVisualizer(systems::DiagramBuilder<double>* builder,
+                            const SceneGraph<double>& scene_graph,
+                            lcm::DrakeLcmInterface* lcm = nullptr);
 
 /** Explicitly dispatches an LCM load message based on the registered geometry.
  Normally this is done automatically at Simulator initialization. But if you
  have to do it yourself (likely because you are not using a Simulator), it
  should be invoked _after_ registration is complete. Typically this is used
- after ConnectVisualization() has been used to add visualization to the
+ after ConnectDrakeVisualizer() has been used to add visualization to the
  Diagram that contains the given `scene_graph`.
 
- @see geometry::ConnectVisualization() */
+ @see geometry::ConnectDrakeVisualizer() */
 void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                          lcm::DrakeLcmInterface* lcm);
 

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -29,35 +29,55 @@ class GeometryVisualizationImpl {
 }  // namespace internal
 #endif  // DRAKE_DOXYGEN_CXX
 
-/** Extends the diagram with the required components to interface with
- drake_visualizer. This must be called _during_ Diagram building and uses the
- given `builder` to add relevant subsystems and connections. You must also
- call geometry::DispatchLoadMessage() after connecting visualization but prior
- to allocating a Context for your Diagram.
+/** Extends a Diagram with the required components to interface with
+ drake_visualizer. This must be called _during_ Diagram building and
+ uses the given `builder` to add relevant subsystems and connections.
 
  This is a convenience method to simplify some common boilerplate for adding
  visualization capability to a Diagram. What it does is:
+ - adds an initialization event that sends the required load message to set up
+   the visualizer with the relevant geometry,
  - adds systems PoseBundleToDrawMessage and LcmPublisherSystem to
    the Diagram and connects the draw message output to the publisher input,
  - connects the `scene_graph` pose bundle output to the PoseBundleToDrawMessage
    system, and
  - sets the publishing rate to 1/60 of a second (simulated time).
 
- @param scene_graph  The system whose geometry will be visualized.
- @param builder      The diagram builder to which the system belongs; additional
-                     systems will be added to enable visualization updates.
- @param lcm          The lcm interface through which lcm messages will be
-                     dispatched.
+ You can then connect source output ports for visualization like this:
+ @code
+   builder->Connect(pose_output_port,
+                    scene_graph.get_source_pose_port(source_id));
+ @endcode
+
+ @note The initialization event occurs when Simulator::Initialize() is called
+ (explicitly or implicitly at the start of a simulation). If you aren't going
+ to be using a Simulator, use DispatchLoadMessage() to send the message
+ yourself.
+
+ @param builder      The diagram builder being used to construct the Diagram.
+ @param scene_graph  The System in `builder` containing the geometry to be
+                     visualized.
+ @param lcm          An optional lcm interface through which lcm messages will
+                     be dispatched. Will be allocated internally if none is
+                     supplied.
+
+ @pre This method has not been previously called while building the
+      builder's current Diagram.
+ @pre The given `scene_graph` must be contained within the supplied
+      DiagramBuilder.
 
  @see geometry::DispatchLoadMessage() */
-void ConnectVisualization(const SceneGraph<double>& scene_graph,
-                          systems::DiagramBuilder<double>* builder,
-                          lcm::DrakeLcmInterface* lcm);
+void ConnectVisualization(systems::DiagramBuilder<double>* builder,
+                          const SceneGraph<double>& scene_graph,
+                          lcm::DrakeLcmInterface* lcm = nullptr);
 
-/** Dispatches an LCM load message based on the registered geometry. It should
- be invoked _after_ registration is complete, but before context allocation.
- This assumes you used geometry::ConnectVisualization() build building the
+/** Explicitly dispatches an LCM load message based on the registered geometry.
+ Normally this is done automatically at Simulator initialization. But if you
+ have to do it yourself (likely because you are not using a Simulator), it
+ should be invoked _after_ registration is complete. Typically this is used
+ after ConnectVisualization() has been used to add visualization to the
  Diagram that contains the given `scene_graph`.
+
  @see geometry::ConnectVisualization() */
 void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                          lcm::DrakeLcmInterface* lcm);

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -145,9 +145,9 @@ bool SceneGraph<T>::SourceIsRegistered(SourceId id) const {
 
 template <typename T>
 const systems::InputPort<T>& SceneGraph<T>::get_source_pose_port(
-    SourceId id) {
+    SourceId id) const {
   ThrowUnlessRegistered(id, "Can't acquire pose port for unknown source id: ");
-  return this->get_input_port(input_source_ids_[id].pose_port);
+  return this->get_input_port(input_source_ids_.at(id).pose_port);
 }
 
 template <typename T>

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -244,7 +244,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
    with that `id`. This port is used to communicate _pose_ data for registered
    frames.
    @throws  std::logic_error if the source_id is _not_ recognized. */
-  const systems::InputPort<T>& get_source_pose_port(SourceId id);
+  const systems::InputPort<T>& get_source_pose_port(SourceId id) const;
 
   /** Returns the output port which produces the PoseBundle for LCM
    communication to drake visualizer. */


### PR DESCRIPTION
PR #9295 added some sugar to make it easier to build a SceneGraph-containing Diagram that provides visualization. However, the result was still too awkward for pedagogical examples. For example, code had  to declare a DrakeLcm object, and remember to send a load message to send the geometry (once) to the visualizer.

@RussTedrake asked if it could be made simpler. This is an attempt to do that. The PR adds a new method AddVisualization() that adds the necessary goodies, hides the DrakeLcm object, and uses an initialization event to handle the one-time load message. All the examples that were using the previous sugar have been updated to the latest, resulting in a lot of lines deleted.

One minor side effect: `SceneGraph::get_source_pose_port()` was non-const which messed up my API. I fixed that here.

Ideas for making this prettier welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9337)
<!-- Reviewable:end -->
