### PR TITLE
symbolic: Formula default constructs to False

### DIFF
--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -115,11 +115,13 @@ class Formula {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(Formula)
 
-  /** Default constructor. */
-  Formula() { *this = True(); }
+  /** Default constructor.  Sets the value to Formula::False, to be consistent
+   * with value-initialized `bool`s.
+   */
+  Formula() { *this = False(); }
 
-  /** Constructs a default value.  This overload is used by Eigen when
-   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+  /** Constructs the same value as the default constructor.  This overload is
+   * used by Eigen when EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
    */
   explicit Formula(std::nullptr_t) : Formula() {}
 

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -1222,8 +1222,8 @@ TEST_F(SymbolicFormulaTest, DrakeAssert) {
 GTEST_TEST(FormulaTest, DefaultConstructors) {
   const Formula f_default;
   const Formula f_zero(0);
-  EXPECT_TRUE(is_true(f_default));
-  EXPECT_TRUE(is_true(f_zero));
+  EXPECT_TRUE(is_false(f_default));
+  EXPECT_TRUE(is_false(f_zero));
 }
 
 // This test checks whether symbolic::Formula is compatible with


### PR DESCRIPTION
Groundwork for #6631.

Certain constructor improvements proposed in #9335's solution to #6631 were difficult to implement without this change.  I also think that this new (documented) default values makes sense on its own, given the correspondence between `Formula` and `bool`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9340)
<!-- Reviewable:end -->
