### PR TITLE
Modifies maliput_railcar_test to use multilane instead of monolane.

### DIFF
--- a/automotive/BUILD.bazel
+++ b/automotive/BUILD.bazel
@@ -680,7 +680,7 @@ drake_cc_googletest(
         "//automotive:maliput_railcar",
         "//automotive/maliput/api",
         "//automotive/maliput/dragway",
-        "//automotive/maliput/monolane",
+        "//automotive/maliput/multilane",
         "//common/test_utilities:eigen_matrix_compare",
         "//math:geometric_transform",
     ],


### PR DESCRIPTION
Towards #9196 and #8033 completion, this PR removes `monolane` dependency from `maliput_railcar_test` and uses `multilane` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9342)
<!-- Reviewable:end -->
