### PR TITLE
py multibody: Add test for joint welding 

### DIFF
--- a/bindings/pydrake/multibody/BUILD.bazel
+++ b/bindings/pydrake/multibody/BUILD.bazel
@@ -234,6 +234,7 @@ drake_py_unittest(
 drake_py_unittest(
     name = "multibody_tree_test",
     data = [
+        "//examples/double_pendulum:models",
         "//multibody/benchmarks/acrobot:models",
     ],
     deps = [

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -8,6 +8,7 @@
 #include "drake/bindings/pydrake/util/type_safe_index_pybind.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
+#include "drake/multibody/multibody_tree/joints/weld_joint.h"
 #include "drake/multibody/multibody_tree/math/spatial_force.h"
 #include "drake/multibody/multibody_tree/math/spatial_vector.h"
 #include "drake/multibody/multibody_tree/math/spatial_velocity.h"
@@ -58,6 +59,7 @@ void init_module(py::module m) {
   BindTypeSafeIndex<ModelInstanceIndex>(m, "ModelInstanceIndex");
   m.def("world_index", &world_index);
 
+  // Frames.
   {
     using Class = Frame<T>;
     py::class_<Class> cls(m, "Frame");
@@ -72,6 +74,7 @@ void init_module(py::module m) {
     // No need to re-bind element mixins from `Frame`.
   }
 
+  // Bodies.
   {
     using Class = Body<T>;
     py::class_<Class> cls(m, "Body");
@@ -86,6 +89,7 @@ void init_module(py::module m) {
     py::class_<Class, Body<T>> cls(m, "RigidBody");
   }
 
+  // Joints.
   {
     using Class = Joint<T>;
     py::class_<Class> cls(m, "Joint");
@@ -116,11 +120,27 @@ void init_module(py::module m) {
     using Class = RevoluteJoint<T>;
     py::class_<Class, Joint<T>> cls(m, "RevoluteJoint");
     cls
+        .def(py::init<const string&, const Frame<T>&,
+             const Frame<T>&, const Vector3<T>&, double>(),
+             py::arg("name"), py::arg("frame_on_parent"),
+             py::arg("frame_on_child"), py::arg("axis"),
+             py::arg("damping") = 0)
         .def("get_angle", &Class::get_angle, py::arg("context"))
         .def("set_angle", &Class::set_angle, py::arg("context"),
              py::arg("angle"));
   }
 
+  {
+    using Class = WeldJoint<T>;
+    py::class_<Class, Joint<T>> cls(m, "WeldJoint");
+    cls
+        .def(py::init<const string&, const Frame<T>&,
+             const Frame<T>&, const Isometry3<double>&>(),
+             py::arg("name"), py::arg("parent_frame_P"),
+             py::arg("child_frame_C"), py::arg("X_PC"));
+  }
+
+  // Actuators.
   {
     using Class = JointActuator<T>;
     py::class_<Class> cls(m, "JointActuator");
@@ -130,6 +150,7 @@ void init_module(py::module m) {
         .def("joint", &Class::joint, py_reference_internal);
   }
 
+  // Force Elements.
   {
     using Class = ForceElement<T>;
     py::class_<Class> cls(m, "ForceElement");
@@ -139,9 +160,10 @@ void init_module(py::module m) {
   {
     using Class = UniformGravityFieldElement<T>;
     py::class_<Class, ForceElement<T>>(m, "UniformGravityFieldElement")
-        .def(py::init<Vector3<double>>());
+        .def(py::init<Vector3<double>>(), py::arg("g_W"));
   }
 
+  // Tree.
   {
     // N.B. Pending a concrete direction on #9366, a minimal subset of the
     // `MultibodyTree` API will be exposed.
@@ -240,8 +262,12 @@ void init_multibody_plant(py::module m) {
         .def("num_multibody_states", &Class::num_multibody_states)
         .def("num_actuated_dofs",
              overload_cast_explicit<int>(&Class::num_actuated_dofs));
-    // TODO(eric.cousineau): Add construction methods, `AddRigidBody`, etc.
+    // Construction.
     cls
+        .def("AddJoint",
+             [](Class* self, std::unique_ptr<Joint<T>> joint) -> auto& {
+               return self->AddJoint(std::move(joint));
+             }, py::arg("joint"), py_reference_internal)
         .def("AddForceElement",
              [](Class* self,
                 std::unique_ptr<ForceElement<T>> force_element) -> auto& {
@@ -261,6 +287,11 @@ void init_multibody_plant(py::module m) {
              overload_cast_explicit<const Body<T>&, const string&>(
                 &Class::GetBodyByName),
              py::arg("name"), py_reference_internal)
+        .def("GetBodyByName",
+             overload_cast_explicit<const Body<T>&, const string&,
+                                    ModelInstanceIndex>(
+                &Class::GetBodyByName),
+             py::arg("name"), py::arg("model_instance"), py_reference_internal)
         .def("GetJointByName",
              [](const Class* self, const string& name) -> auto& {
                return self->GetJointByName(name);

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -14,7 +14,9 @@ from pydrake.multibody.multibody_tree import (
     JointIndex,
     ModelInstanceIndex,
     MultibodyTree,
+    RevoluteJoint,
     UniformGravityFieldElement,
+    WeldJoint,
     world_index,
 )
 from pydrake.multibody.multibody_tree.math import (
@@ -109,6 +111,9 @@ class TestMultibodyTree(unittest.TestCase):
         self._test_joint_actuator_api(
             plant.GetJointActuatorByName(name="ElbowJoint"))
         self._test_body_api(plant.GetBodyByName(name="Link1"))
+        self.assertIs(
+            plant.GetBodyByName(name="Link1"),
+            plant.GetBodyByName(name="Link1", model_instance=model_instance))
         self.assertIsInstance(
             plant.get_actuation_input_port(), InputPort)
         self.assertIsInstance(
@@ -182,3 +187,46 @@ class TestMultibodyTree(unittest.TestCase):
             context=context, frame_B=link1_frame,
             p_BoFo_B=[0, 0, 0])
         self.assertTupleEqual(Jv_WL.shape, (6, plant.num_velocities()))
+
+    def test_multibody_add_joint(self):
+        """
+        Tests joint constructors and `AddJoint`.
+        """
+        instance_file = FindResourceOrThrow(
+            "drake/examples/double_pendulum/models/double_pendulum.sdf")
+        # Add different joints between multiple model instances.
+        # TODO(eric.cousineau): Remove the multiple instances and use
+        # programmatically constructed bodies once this API is exposed in
+        # Python.
+        num_joints = 2
+        plant = MultibodyPlant()
+        instances = []
+        for i in xrange(num_joints + 1):
+            instance = AddModelFromSdfFile(
+                instance_file, "instance_{}".format(i), plant)
+            instances.append(instance)
+        proximal_frame = "base"
+        distal_frame = "lower_link"
+        joints = [
+            RevoluteJoint(
+                name="revolve_things",
+                frame_on_parent=plant.GetBodyByName(
+                    distal_frame, instances[1]).body_frame(),
+                frame_on_child=plant.GetBodyByName(
+                    proximal_frame, instances[2]).body_frame(),
+                axis=[0, 0, 1],
+                damping=0.),
+            WeldJoint(
+                name="weld_things",
+                parent_frame_P=plant.GetBodyByName(
+                    distal_frame, instances[0]).body_frame(),
+                child_frame_C=plant.GetBodyByName(
+                    proximal_frame, instances[1]).body_frame(),
+                X_PC=Isometry3.Identity()),
+        ]
+        for joint in joints:
+            joint_out = plant.AddJoint(joint)
+            self.assertIs(joint, joint_out)
+            self._test_joint_api(joint)
+        # Ensure construction is valid.
+        plant.Finalize()

--- a/multibody/benchmarks/free_body/free_body.h
+++ b/multibody/benchmarks/free_body/free_body.h
@@ -13,7 +13,7 @@ namespace free_body {
 
 /// The purpose of the %FreeBody class is to provide the data (initial values
 /// and gravity) and methods for calculating the exact analytical solution for
-/// the translational and rotational motion of a toque-free rigid body B with
+/// the translational and rotational motion of a torque-free rigid body B with
 /// axially symmetric inertia, in a Newtonian frame (World) N. Examples of
 /// bodies with axially symmetric inertia include cylinders, rods or bars with a
 /// circular or square cross section and spinning tops.

--- a/multibody/multibody_tree/joints/revolute_joint.cc
+++ b/multibody/multibody_tree/joints/revolute_joint.cc
@@ -40,6 +40,19 @@ std::unique_ptr<Joint<AutoDiffXd>> RevoluteJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+RevoluteJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  blue_print->mobilizers_.push_back(
+      std::make_unique<RevoluteMobilizer<T>>(
+          this->frame_on_parent(), this->frame_on_child(), axis_));
+  return std::move(blue_print);
+}
+
 // Explicitly instantiates on the most common scalar types.
 template class RevoluteJoint<double>;
 template class RevoluteJoint<AutoDiffXd>;

--- a/multibody/multibody_tree/joints/revolute_joint.h
+++ b/multibody/multibody_tree/joints/revolute_joint.h
@@ -258,13 +258,7 @@ class RevoluteJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<typename Joint<T>::BluePrint>
-  MakeImplementationBlueprint() const override {
-    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-    blue_print->mobilizers_.push_back(
-        std::make_unique<RevoluteMobilizer<T>>(
-            this->frame_on_parent(), this->frame_on_child(), axis_));
-    return std::move(blue_print);
-  }
+  MakeImplementationBlueprint() const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/multibody_tree/joints/weld_joint.cc
+++ b/multibody/multibody_tree/joints/weld_joint.cc
@@ -38,6 +38,19 @@ std::unique_ptr<Joint<AutoDiffXd>> WeldJoint<T>::DoCloneToScalar(
   return TemplatedDoCloneToScalar(tree_clone);
 }
 
+// N.B. Due to esoteric linking errors on Mac (see #9345) involving
+// `MobilizerImpl`, we must place this implementation in the source file, not
+// in the header file.
+template <typename T>
+std::unique_ptr<typename Joint<T>::BluePrint>
+WeldJoint<T>::MakeImplementationBlueprint() const {
+  auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
+  blue_print->mobilizers_.push_back(
+      std::make_unique<WeldMobilizer<T>>(
+          this->frame_on_parent(), this->frame_on_child(), X_PC_));
+  return std::move(blue_print);
+}
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/multibody_tree/joints/weld_joint.h
+++ b/multibody/multibody_tree/joints/weld_joint.h
@@ -64,13 +64,7 @@ class WeldJoint final : public Joint<T> {
 
   // Joint<T> overrides:
   std::unique_ptr<typename Joint<T>::BluePrint>
-  MakeImplementationBlueprint() const override {
-    auto blue_print = std::make_unique<typename Joint<T>::BluePrint>();
-    blue_print->mobilizers_.push_back(
-        std::make_unique<WeldMobilizer<T>>(
-            this->frame_on_parent(), this->frame_on_child(), X_PC_));
-    return std::move(blue_print);
-  }
+  MakeImplementationBlueprint() const override;
 
   std::unique_ptr<Joint<double>> DoCloneToScalar(
       const MultibodyTree<double>& tree_clone) const override;

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -375,6 +375,16 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
+  /// For more information, see the below overload of `AddJoint<>`, and the
+  /// related `MultibodyTree::AddJoint<>` method.
+  template <template<typename Scalar> class JointType>
+  const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint) {
+    static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
+                  "JointType must be a sub-class of Joint<T>.");
+    return model_->AddJoint(std::move(joint));
+  }
+
+  /// This method adds a Joint of type `JointType` between two bodies.
   /// The two bodies connected by this Joint object are referred to as the
   /// _parent_ and _child_ bodies. Although the terms _parent_ and _child_ are
   /// sometimes used synonymously to describe the relationship between inboard

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -229,16 +229,21 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
       plant->AddRigidBody("AnotherBody", default_model_instance(),
                           SpatialInertia<double>()),
       std::logic_error,
-      /* Verify this method is throwing for the right reasons. */
       "Post-finalize calls to '.*' are not allowed; "
       "calls to this method must happen before Finalize\\(\\).");
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant->AddJoint<RevoluteJoint>(
           "AnotherJoint", link1, {}, link2, {}, Vector3d::UnitZ()),
       std::logic_error,
-      /* Verify this method is throwing for the right reasons. */
       "Post-finalize calls to '.*' are not allowed; "
       "calls to this method must happen before Finalize\\(\\).");
+  // Test API for simplified `AddJoint` method.
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      plant->AddJoint(std::make_unique<RevoluteJoint<double>>(
+          "AnotherJoint", link1.body_frame(), link2.body_frame(),
+          Vector3d::UnitZ())),
+      std::logic_error,
+      "This MultibodyTree is finalized already. .*");
   // TODO(amcastro-tri): add test to verify that requesting a joint of the wrong
   // type throws an exception. We need another joint type to do so.
 }

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -532,6 +532,46 @@ class MultibodyTree {
         std::make_unique<ForceElementType<T>>(std::forward<Args>(args)...));
   }
 
+  /// This method adds a Joint of type `JointType` between the frames specified
+  /// by the joint.
+  ///
+  /// @param[in] joint
+  ///   Joint to be added.
+  /// @tparam JointType
+  ///   The type of the new joint to add, which must be a subclass of Joint<T>.
+  /// @returns A const lvalue reference to the added joint.
+  ///
+  /// @see The Joint class's documentation for further details on how a Joint
+  /// is defined, or the semi-emplace `AddJoint<>` overload below.
+  template <template<typename Scalar> class JointType>
+  const JointType<T>& AddJoint(
+      std::unique_ptr<JointType<T>> joint) {
+    static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
+                  "JointType must be a sub-class of Joint<T>.");
+
+    if (HasJointNamed(joint->name(), joint->model_instance())) {
+      throw std::logic_error(
+          "Model instance '" +
+          instance_index_to_name_.at(joint->model_instance()) +
+          "' already contains a joint named '" + joint->name() + "'. " +
+          "Joint names must be unique within a given model.");
+    }
+
+    if (topology_is_valid()) {
+      throw std::logic_error("This MultibodyTree is finalized already. "
+                             "Therefore adding more joints is not allowed. "
+                             "See documentation for Finalize() for details.");
+    }
+    if (joint == nullptr) {
+      throw std::logic_error("Input joint is a nullptr.");
+    }
+    const JointIndex joint_index(owned_joints_.size());
+    joint->set_parent_tree(this, joint_index);
+    JointType<T>* raw_joint_ptr = joint.get();
+    owned_joints_.push_back(std::move(joint));
+    return *raw_joint_ptr;
+  }
+
   /// This method helps to create a Joint of type `JointType` between two
   /// bodies.
   /// The two bodies connected by this Joint object are referred to as the
@@ -569,7 +609,7 @@ class MultibodyTree {
   ///   your intention is to make a frame F with pose `X_PF`, provide
   ///   `Isometry3<double>::Identity()` as your input.
   /// @tparam JointType
-  ///   The type of the new joint to add, which must be a subclass of Joint.
+  ///   The type of the new joint to add, which must be a subclass of Joint<T>.
   /// @returns A constant reference to the new joint just added, of type
   ///   `JointType<T>` specialized on the scalar type T of `this`
   ///   %MultibodyTree. It will remain valid for the lifetime of `this`
@@ -2223,35 +2263,6 @@ class MultibodyTree {
 
   // Friend class to facilitate testing.
   friend class MultibodyTreeTester;
-
-  template <template<typename Scalar> class JointType>
-  const JointType<T>& AddJoint(
-      std::unique_ptr<JointType<T>> joint) {
-    static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
-                  "JointType must be a sub-class of Joint<T>.");
-
-    if (HasJointNamed(joint->name(), joint->model_instance())) {
-      throw std::logic_error(
-          "Model instance '" +
-          instance_index_to_name_.at(joint->model_instance()) +
-          "' already contains a joint named '" + joint->name() + "'. " +
-          "Joint names must be unique within a given model.");
-    }
-
-    if (topology_is_valid()) {
-      throw std::logic_error("This MultibodyTree is finalized already. "
-                             "Therefore adding more joints is not allowed. "
-                             "See documentation for Finalize() for details.");
-    }
-    if (joint == nullptr) {
-      throw std::logic_error("Input joint is a nullptr.");
-    }
-    const JointIndex joint_index(owned_joints_.size());
-    joint->set_parent_tree(this, joint_index);
-    JointType<T>* raw_joint_ptr = joint.get();
-    owned_joints_.push_back(std::move(joint));
-    return *raw_joint_ptr;
-  }
 
   // Finalizes the MultibodyTreeTopology of this tree.
   void FinalizeTopology();

--- a/multibody/multibody_tree/test/model_instance_test.cc
+++ b/multibody/multibody_tree/test/model_instance_test.cc
@@ -28,10 +28,12 @@ GTEST_TEST(ModelInstance, ModelInstanceTest) {
       "weld1", tree.world_body(), Eigen::Isometry3d::Identity(),
       body1, Eigen::Isometry3d::Identity(),
       Eigen::Isometry3d::Identity());
+  // Test minimal `AddJoint` overload.
   const Joint<double>& body1_body2 =
-      tree.AddJoint<PrismaticJoint>(
-          "prism1", body1, Eigen::Isometry3d::Identity(),
-          body2, Eigen::Isometry3d::Identity(), Eigen::Vector3d(0, 0, 1));
+      tree.AddJoint(
+          std::make_unique<PrismaticJoint<double>>(
+              "prism1", body1.body_frame(), body2.body_frame(),
+              Eigen::Vector3d(0, 0, 1)));
   tree.AddJointActuator("act1", body1_body2);
 
   const Joint<double>& body2_body3 =


### PR DESCRIPTION
I would prefer not to bind + test APIs that are coupled through the use of template argument forwarding. Rather, since component constructors seem useful as a standalone, I would prefer to expose the most modular aspects of the API.

Trying to keep documentation terse and minimize duplication; it'd be much appreciated if any suggestions to doc changes have full-text replacements of what they should be.

\cc @pangtao22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9345)
<!-- Reviewable:end -->
