### PR TITLE
multibody sdf: Enable parsing of `<frame>` elements at `<model>` level

### DIFF
--- a/multibody/multibody_tree/fixed_offset_frame.cc
+++ b/multibody/multibody_tree/fixed_offset_frame.cc
@@ -15,8 +15,10 @@ namespace multibody {
 template <typename T>
 FixedOffsetFrame<T>::FixedOffsetFrame(
     const std::string& name, const Frame<T>& P,
-    const Isometry3<double>& X_PF) :
-    Frame<T>(name, P.body()), parent_frame_(P), X_PF_(X_PF) {}
+    const Isometry3<double>& X_PF,
+    optional<ModelInstanceIndex> model_instance) :
+    Frame<T>(name, P.body(), model_instance.value_or(P.model_instance())),
+    parent_frame_(P), X_PF_(X_PF) {}
 
 template <typename T>
 FixedOffsetFrame<T>::FixedOffsetFrame(

--- a/multibody/multibody_tree/fixed_offset_frame.h
+++ b/multibody/multibody_tree/fixed_offset_frame.h
@@ -46,9 +46,13 @@ class FixedOffsetFrame final : public Frame<T> {
   /// @param[in] X_PF
   ///   The _default_ transform giving the pose of F in P, therefore only the
   ///   value (as an Isometry3<double>) is provided.
+  /// @param[in] model_instance
+  ///   The model instance to which this frame belongs to. If unspecified, will
+  ///   use P.body().model_instance().
   FixedOffsetFrame(
       const std::string& name, const Frame<T>& P,
-      const Isometry3<double>& X_PF);
+      const Isometry3<double>& X_PF,
+      optional<ModelInstanceIndex> model_instance = {});
 
   /// Creates an unnamed material Frame F. See overload with name for more
   /// information.

--- a/multibody/multibody_tree/frame.h
+++ b/multibody/multibody_tree/frame.h
@@ -119,8 +119,10 @@ class Frame : public FrameBase<T> {
   /// Only derived classes can use this constructor. It creates a %Frame
   /// object attached to `body` and puts the frame in the body's model
   /// instance.
-  explicit Frame(const std::string& name, const Body<T>& body)
-      : FrameBase<T>(body.model_instance()),
+  explicit Frame(
+      const std::string& name, const Body<T>& body,
+      optional<ModelInstanceIndex> model_instance = {})
+      : FrameBase<T>(model_instance.value_or(body.model_instance())),
         name_(name), body_(body) {}
 
   /// Overload to permit constructing an unnamed frame.

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1190,7 +1190,7 @@ class MultibodyTree {
     const auto range = frame_name_to_index_.equal_range(name);
     for (auto it = range.first; it != range.second; ++it) {
       const Frame<T>& frame = get_frame(it->second);
-      if (frame.body().model_instance() == model_instance) {
+      if (frame.model_instance() == model_instance) {
         return frame;
       }
     }

--- a/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
+++ b/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.cc
@@ -8,6 +8,7 @@
 #include <sdf/sdf.hh>
 
 #include "drake/geometry/geometry_instance.h"
+#include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/multibody/multibody_tree/joints/weld_joint.h"
@@ -421,6 +422,38 @@ void AddLinksFromSpecification(
   }
 }
 
+void AddFramesFromSpecification(
+    ModelInstanceIndex model_instance,
+    sdf::ElementPtr parent_element,
+    const Frame<double>& parent_frame,
+    multibody_plant::MultibodyPlant<double>* plant) {
+  // Per its API documentation, `GetElement(...)` will create a new element if
+  // one does not already exist rather than return `nullptr`; use
+  // `HasElement(...)` instead.
+  if (parent_element->HasElement("frame")) {
+    sdf::ElementPtr frame_element = parent_element->GetElement("frame");
+    while (frame_element) {
+      std::string name = frame_element->Get<std::string>("name");
+      sdf::ElementPtr pose_element = frame_element->GetElement("pose");
+      const Frame<double>* pose_frame = &parent_frame;
+      // SDF makes frame have a value of '' by default, even if unspecified.
+      DRAKE_DEMAND(pose_element->HasAttribute("frame"));
+      const std::string pose_frame_name =
+          pose_element->Get<std::string>("frame");
+      if (!pose_frame_name.empty()) {
+        // TODO(eric.cousineau): Prevent instance name from leaking in? Throw
+        // an error if a user ever specifies it?
+        pose_frame = &plant->GetFrameByName(pose_frame_name, model_instance);
+      }
+      const Isometry3d X_PF =
+          ToIsometry3(pose_element->Get<ignition::math::Pose3d>());
+      plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          name, *pose_frame, X_PF));
+      frame_element = frame_element->GetNextElement("frame");
+    }
+  }
+}
+
 // Helper method to add a model to a MultibodyPlant given an sdf::Model
 // specification object.
 ModelInstanceIndex AddModelFromSpecification(
@@ -434,16 +467,37 @@ ModelInstanceIndex AddModelFromSpecification(
   const ModelInstanceIndex model_instance =
     plant->AddModelInstance(model_name);
 
+  // TODO(eric.cousineau): Ensure this generalizes to cases when the parent
+  // frame is not the world. At present, we assume the parent frame is the
+  // world.
+  const Isometry3d X_WM = ToIsometry3(model.Pose());
+  // Add a model frame given the instance name so that way any frames added to
+  // the model are associated with this instance.
+  const Frame<double>& model_frame =
+      plant->AddFrame(std::make_unique<FixedOffsetFrame<double>>(
+          model_name, plant->world_frame(), X_WM, model_instance));
+
+  // TODO(eric.cousineau): Register frames from SDF once we have a pose graph.
   AddLinksFromSpecification(
       model_instance, model, plant, scene_graph, package_map, root_dir);
 
   // Add all the joints
+  // TODO(eric.cousineau): Register frames from SDF once we have a pose graph.
   for (uint64_t joint_index = 0; joint_index < model.JointCount();
        ++joint_index) {
     // Get a pointer to the SDF joint, and the joint axis information.
     const sdf::Joint& joint = *model.JointByIndex(joint_index);
     AddJointFromSpecification(model, joint, model_instance, plant);
   }
+
+  // Add frames at root-level of <model>.
+  // TODO(eric.cousineau): Address additional items:
+  // - adding frames nested in other elements (joints, visuals, etc.)
+  // - implicit frames for other elements (joints, visuals, etc.)
+  // - explicitly referring to model frame?
+  // See: https://bitbucket.org/osrf/sdformat/issues/200
+  AddFramesFromSpecification(
+      model_instance, model.Element(), model_frame, plant);
 
   return model_instance;
 }

--- a/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
+++ b/multibody/multibody_tree/parsing/test/links_with_visuals_and_collisions.sdf
@@ -7,7 +7,15 @@
          MultibodyPlant.
          This file is meant to be kept in sync with the corresponding unit
          test file multibody_plant_sdf_parser_test.cc -->
+    <!-- We will define the model frame as `M`. The parent, which tends to be
+         the world, will be denoted as `P`.
+         Because there is no <pose> tag at the root level, `X_PM` will be
+         identity. -->
+
     <link name='link1'>
+      <!-- We will denote this link frame as `L1`.
+           Since there is no pose and no joints referring to this link,
+           X_ML1 will be identity. -->
       <visual name='link1_visual1'>
         <geometry>
           <sphere>
@@ -105,6 +113,35 @@
         </geometry>
       </collision>
     </link>
+
+    <!-- Test frames -->
+    <!-- We will define this frame as `F1`. -->
+    <frame name='model_scope_link1_frame'>
+      <!-- This pose represents `X_L1F1`. -->
+      <pose frame='link1'>0.1 0.2 0.3 0.4 0.5 0.6</pose>
+    </frame>
+    <!-- We will define this frame as `F2`. -->
+    <frame name='model_scope_link1_frame_child'>
+      <!-- This pose represents `X_F1F2`. -->
+      <pose frame='model_scope_link1_frame'>0.1 0 0 0 0 0</pose>
+    </frame>
+    <!-- We will define this frame as `F3`.
+         NOTE: An unnamed frame implies this element's parent frame. At model
+         scope, this implies the model frame. -->
+    <frame name='model_scope_model_frame_implicit'>
+      <!-- This pose represents `X_MF3`. -->
+      <pose>0.7 0.8 0.9 0 0 0</pose>
+    </frame>
+
+    <!-- IMPORTANT NOTE: The model frame is NOT affixed to any particular
+         link's frame (e.g. a "base" frame). Thus, if you weld a joint between
+         one of the links (which could be considered the "base" link) and
+         another link, the model frame (and any frames attached to it) will not
+         be affixed to the other link. If you want frames to track the base
+         frame, you *MUST* explicitly affix it to the relevant base link /
+         frame.
+         TODO(eric.cousineau): Find a more discoverable location for this
+         note. -->
 
     <!-- For now at least, We care only that Drake's custom tag doesn't break
          parsing the rest of the elements in this file. -->

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -10,18 +10,24 @@
 #include "drake/common/test_utilities/expect_throws_message.h"
 #include "drake/geometry/geometry_instance.h"
 #include "drake/geometry/scene_graph.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/math/roll_pitch_yaw.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/systems/framework/context.h"
 
 namespace drake {
 
+using Eigen::Isometry3d;
 using Eigen::Vector3d;
 using geometry::GeometryId;
 using geometry::GeometryInstance;
 using geometry::SceneGraph;
+using math::RigidTransform;
+using math::RollPitchYaw;
 using multibody::Body;
 using multibody::parsing::AddModelFromSdfFile;
 using multibody::parsing::AddModelsFromSdfFile;
+using multibody::parsing::detail::ToIsometry3;
 using multibody::multibody_plant::MultibodyPlant;
 using systems::Context;
 
@@ -29,6 +35,13 @@ namespace multibody {
 namespace parsing {
 namespace test {
 namespace {
+
+// TODO(eric.cousineau): Figure out a core location for a sugar method like
+// this.
+Isometry3d XyzRpy(const Vector3d& xyz, const Vector3d& rpy) {
+  return RigidTransform<double>(
+      RollPitchYaw<double>(rpy).ToRotationMatrix(), xyz).GetAsIsometry3();
+}
 
 // Verifies model instances are correctly created in the plant.
 GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
@@ -141,6 +154,30 @@ GTEST_TEST(MultibodyPlantSdfParserTest, ModelInstanceTest) {
   DRAKE_EXPECT_THROWS_MESSAGE(
       plant.GetFrameByName("Link1"), std::logic_error,
       "Frame Link1 appears in multiple model instances.");
+
+  // Check model scope frames.
+  auto context = plant.CreateDefaultContext();
+  const double eps = std::numeric_limits<double>::epsilon();
+  auto check_frame = [&plant, instance1, &context, eps](
+      std::string parent_name, std::string name,
+      const Isometry3d& X_PF_expected) {
+    const Frame<double>& frame = plant.GetFrameByName(name, instance1);
+    const Frame<double>& parent_frame =
+        plant.GetFrameByName(parent_name, instance1);
+    const Isometry3d X_PF = plant.tree().CalcRelativeTransform(
+        *context, parent_frame, frame);
+    EXPECT_TRUE(CompareMatrices(X_PF_expected.matrix(), X_PF.matrix(), eps))
+        << name;
+  };
+
+  const Isometry3d X_L1F1 = XyzRpy(
+      Vector3d(0.1, 0.2, 0.3), Vector3d(0.4, 0.5, 0.6));
+  check_frame("link1", "model_scope_link1_frame", X_L1F1);
+  const Isometry3d X_F1F2 = XyzRpy(Vector3d(0.1, 0.0, 0.0), Vector3d::Zero());
+  check_frame(
+      "model_scope_link1_frame", "model_scope_link1_frame_child", X_F1F2);
+  const Isometry3d X_MF3 = XyzRpy(Vector3d(0.7, 0.8, 0.9), Vector3d::Zero());
+  check_frame("instance1", "model_scope_model_frame_implicit", X_MF3);
 }
 
 // Verify that our SDF parser throws an exception when a user specifies a joint
@@ -172,11 +209,11 @@ GTEST_TEST(SdfParser, IncludeTags) {
         sdf_file_path + "/include_models.sdf"), &plant);
   plant.Finalize();
 
-  // We should have loaded three more models.
+  // We should have loaded 3 more models.
   EXPECT_EQ(plant.num_model_instances(), 5);
-  // The models should have added 8 four more bodies.
+  // The models should have added 8 more bodies.
   EXPECT_EQ(plant.num_bodies(), 9);
-  // The models should have added five more joints.
+  // The models should have added 5 more joints.
   EXPECT_EQ(plant.num_joints(), 5);
 
   // There should be a model instance with the name "robot1".

--- a/multibody/multibody_tree/test/frames_test.cc
+++ b/multibody/multibody_tree/test/frames_test.cc
@@ -74,6 +74,14 @@ class FrameTests : public ::testing::Test {
     frameR_ = &model->AddFrame<FixedOffsetFrame>(
         "R", *frameP_, Isometry3d::Identity());
 
+    // Frame S is arbitrary, but named and with a specific model instance.
+    extra_instance_ = model->AddModelInstance("extra_instance");
+    frameS_ = &model->AddFrame<FixedOffsetFrame>(
+        "S", model->world_frame(), Isometry3d::Identity(), extra_instance_);
+    // Ensure that the model instance propagates implicitly.
+    frameSChild_ = &model->AddFrame<FixedOffsetFrame>(
+        "SChild", *frameS_, Isometry3d::Identity());
+
     // We are done adding modeling elements. Transfer tree to system and get
     // a Context.
     system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
@@ -99,11 +107,15 @@ class FrameTests : public ::testing::Test {
   std::unique_ptr<Context<double>> context_;
   // Bodies:
   const RigidBody<double>* bodyB_;
+  // Model instances.
+  ModelInstanceIndex extra_instance_;
   // Frames:
   const Frame<double>* frameB_{};
   const Frame<double>* frameP_{};
   const Frame<double>* frameQ_{};
   const Frame<double>* frameR_{};
+  const Frame<double>* frameS_{};
+  const Frame<double>* frameSChild_{};
   // Poses:
   Isometry3d X_BP_;
   Isometry3d X_PQ_;
@@ -189,6 +201,12 @@ TEST_F(FrameTests, ChainedFixedOffsetFrames) {
 
 TEST_F(FrameTests, NamedFrame) {
   EXPECT_EQ(frameR_->name(), "R");
+}
+
+TEST_F(FrameTests, ModelInstanceOverride) {
+  EXPECT_EQ(frameR_->model_instance(), default_model_instance());
+  EXPECT_EQ(frameS_->model_instance(), extra_instance_);
+  EXPECT_EQ(frameSChild_->model_instance(), extra_instance_);
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -137,6 +137,8 @@ void VerifyModelBasics(const MultibodyTree<T>& model) {
   for (const std::string frame_name : kFrameNames) {
     const Frame<T>& frame = model.GetFrameByName(frame_name);
     EXPECT_EQ(frame.name(), frame_name);
+    EXPECT_EQ(
+        &frame, &model.GetFrameByName(frame_name, default_model_instance()));
   }
   DRAKE_EXPECT_THROWS_MESSAGE(
       model.GetFrameByName(kInvalidName), std::logic_error,


### PR DESCRIPTION
Resolves #9350 (at least at the model-level)

Requires:
- [x] #9351 - Frame naming

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9352)
<!-- Reviewable:end -->
