### PR TITLE
symbolic: Add Formula(bool) constructor

### DIFF
--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -118,12 +118,13 @@ class Formula {
   /** Default constructor.  Sets the value to Formula::False, to be consistent
    * with value-initialized `bool`s.
    */
-  Formula() { *this = False(); }
+  Formula() : Formula(False()) {}
 
-  /** Constructs the same value as the default constructor.  This overload is
-   * used by Eigen when EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
+  /** Constructs from a `bool`.  This overload is also used by Eigen when
+   * EIGEN_INITIALIZE_MATRICES_BY_ZERO is enabled.
    */
-  explicit Formula(std::nullptr_t) : Formula() {}
+  explicit Formula(bool value)
+      : Formula(value ? True() : False()) {}
 
   explicit Formula(std::shared_ptr<FormulaCell> ptr);
 

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -1226,6 +1226,24 @@ GTEST_TEST(FormulaTest, DefaultConstructors) {
   EXPECT_TRUE(is_false(f_zero));
 }
 
+// Tests the `bool`-literal constructor.
+GTEST_TEST(FormulaTest, CxxBoolLiteralConstructor) {
+  const Formula f_true(true);
+  const Formula f_false(false);
+  EXPECT_TRUE(is_true(f_true));
+  EXPECT_TRUE(is_false(f_false));
+}
+
+// Tests the `bool`-variable constructor.
+GTEST_TEST(FormulaTest, CxxBoolVariableConstructor) {
+  const bool true_variable = true;
+  const bool false_variable = false;
+  const Formula f_true(true_variable);
+  const Formula f_false(false_variable);
+  EXPECT_TRUE(is_true(f_true));
+  EXPECT_TRUE(is_false(f_false));
+}
+
 // This test checks whether symbolic::Formula is compatible with
 // std::unordered_set.
 GTEST_TEST(FormulaTest, CompatibleWithUnorderedSet) {


### PR DESCRIPTION
Groundwork for #6631.

In order to write generic algorithms over formulas (e.g., `all(...)` which folds over `&&`), it is useful to be able to supply the base case value as a literal (e.g., `Bool<T> result = true;`).  (See #9335 commits for some example uses.)

Without this PR, it would not compile when `T = Expression`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9361)
<!-- Reviewable:end -->
