### PR TITLE
symbolic: Specialize std::numeric_limits

### DIFF
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <cstddef>
 #include <ios>
-#include <limits>
 #include <map>
 #include <memory>
 #include <stdexcept>

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -8,6 +8,7 @@
 #include <algorithm>  // for cpplint only
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <ostream>
@@ -830,6 +831,11 @@ struct equal_to<drake::symbolic::Expression> {
     return lhs.EqualTo(rhs);
   }
 };
+
+/* Provides std::numeric_limits<drake::symbolic::Expression>. */
+template <>
+struct numeric_limits<drake::symbolic::Expression>
+    : public numeric_limits<double> {};
 
 }  // namespace std
 

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -903,6 +903,25 @@ TEST_F(SymbolicExpressionTest, HashUnary) {
   EXPECT_EQ(hash_set.size(), exprs.size());
 }
 
+// Confirm that numeric_limits is appropriately specialized for Expression.
+// We'll just spot-test a few values, since our implementation is trivially
+// forwarding to numeric_limits<double>.
+TEST_F(SymbolicExpressionTest, NumericLimits) {
+  using std::numeric_limits;
+  using Limits = numeric_limits<Expression>;
+
+  const Expression num_eps = Limits::epsilon();
+  ASSERT_TRUE(is_constant(num_eps));
+  EXPECT_EQ(get_constant_value(num_eps), numeric_limits<double>::epsilon());
+
+  const Expression num_min = Limits::min();
+  ASSERT_TRUE(is_constant(num_min));
+  EXPECT_EQ(get_constant_value(num_min), numeric_limits<double>::min());
+
+  const Expression num_infinity = Limits::infinity();
+  EXPECT_EQ(num_infinity.to_string(), "inf");
+}
+
 TEST_F(SymbolicExpressionTest, UnaryPlus) {
   EXPECT_PRED2(ExprEqual, c3_, +c3_);
   EXPECT_PRED2(ExprEqual, Expression(var_x_), +var_x_);


### PR DESCRIPTION
In testing #9349, I found that Eigen's SVD relies on `std::numeric_limits<T>::min()` to be correct, in order to identify values too small to divide by.  Prior to this PR, the value of `min()` for `Expression` was zero!

(In https://github.com/RobotLocomotion/drake/pull/9331#pullrequestreview-151228948, @sherm1 presciently predicted that this could be a hazard in general, so it will be good to have this fixed.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9362)
<!-- Reviewable:end -->
