### PR TITLE
Add and use scalar_predicate<T>

### DIFF
--- a/common/drake_bool.h
+++ b/common/drake_bool.h
@@ -11,6 +11,26 @@
 
 namespace drake {
 
+/// A traits struct that describes the return type of predicates over a scalar
+/// type (named `T`).  For example, a predicate that evaluates `double`s will
+/// return a `bool`, but a predicate that evaluates symbolic::Expression will
+/// return a symbolic::Formula.  By default, the return type is inferred from
+/// the type's comparison operator, but scalar types are permitted to
+/// specialize this template for their needs.
+template <typename T>
+struct scalar_predicate {
+  /// The return type of predicates over T.
+  using type = decltype(T() < T());
+
+  /// Whether `type` is `bool`.
+  static constexpr bool is_bool = std::is_same<type, bool>::value;
+};
+
+/// The return type of predicates over some scalar type T; this is a
+/// convenience alias for scalar_predicate<T>::type.
+template <typename T>
+using scalar_predicate_t = typename scalar_predicate<T>::type;
+
 /// Class representing a Boolean value independent of the underlying
 /// scalar type T:
 ///  - For `double` or autodiff, this class embeds a `bool` value.

--- a/common/test/drake_bool_test.cc
+++ b/common/test/drake_bool_test.cc
@@ -86,6 +86,12 @@ TEST_F(BoolTestDouble, MoveAssign) {
 TEST_F(BoolTestDouble, TypeCheck) {
   static_assert(std::is_same<Bool<double>::value_type, bool>::value,
                 "Bool<double>::value_type should be bool");
+  static_assert(std::is_same<scalar_predicate_t<double>, bool>::value,
+                "scalar_predicate_t<double> should be bool");
+  static_assert(std::is_same<scalar_predicate<double>::type, bool>::value,
+                "scalar_predicate<double>::type should be bool");
+  static_assert(scalar_predicate<double>::is_bool,
+                "scalar_predicate<double>::is_bool should be true");
 }
 
 TEST_F(BoolTestDouble, Value) {
@@ -177,6 +183,12 @@ class BoolTestAutoDiffXd : public ::testing::Test {
 TEST_F(BoolTestAutoDiffXd, TypeCheck) {
   static_assert(std::is_same<Bool<AutoDiffXd>::value_type, bool>::value,
                 "Bool<AutoDiffXd>::value_type should be bool");
+  static_assert(std::is_same<scalar_predicate_t<AutoDiffXd>, bool>::value,
+                "scalar_predicate_t<AutoDiffXd> should be bool");
+  static_assert(std::is_same<scalar_predicate<AutoDiffXd>::type, bool>::value,
+                "scalar_predicate<AutoDiffXd>::type should be bool");
+  static_assert(scalar_predicate<AutoDiffXd>::is_bool,
+                "scalar_predicate<AutoDiffXd>::is_bool should be true");
 }
 
 TEST_F(BoolTestAutoDiffXd, TrueFalse) {
@@ -308,6 +320,15 @@ TEST_F(BoolTestSymbolic, TypeCheck) {
   static_assert(
       std::is_same<Bool<Expression>::value_type, Formula>::value,
       "Bool<symbolic::Expression>::value_type should be symbolic::Formula");
+  static_assert(
+      std::is_same<scalar_predicate_t<Expression>, Formula>::value,
+      "scalar_predicate_t<Expression> should be Formula");
+  static_assert(
+      std::is_same<scalar_predicate<Expression>::type, Formula>::value,
+      "scalar_predicate<Expression>::type should be Formula");
+  static_assert(
+      !scalar_predicate<Expression>::is_bool,
+      "scalar_predicate<Expression>::is_bool should be false");
 }
 
 TEST_F(BoolTestSymbolic, TrueFalse) {

--- a/tools/vector_gen/lcm_vector_gen.py
+++ b/tools/vector_gen/lcm_vector_gen.py
@@ -252,9 +252,9 @@ GET_COORDINATE_NAMES = """
 
 IS_VALID_BEGIN = """
   /// Returns whether the current values of this vector are well-formed.
-  drake::Bool<T> IsValid() const {
+  drake::scalar_predicate_t<T> IsValid() const {
     using std::isnan;
-    auto result = (T(0) == T(0));
+    drake::scalar_predicate_t<T> result{true};
 """
 IS_VALID = """
     result = result && !isnan(%(field)s());

--- a/tools/vector_gen/test/goal/sample.h
+++ b/tools/vector_gen/test/goal/sample.h
@@ -98,9 +98,9 @@ class Sample final : public drake::systems::BasicVector<T> {
   }
 
   /// Returns whether the current values of this vector are well-formed.
-  drake::Bool<T> IsValid() const {
+  drake::scalar_predicate_t<T> IsValid() const {
     using std::isnan;
-    auto result = (T(0) == T(0));
+    drake::scalar_predicate_t<T> result{true};
     result = result && !isnan(x());
     result = result && (x() >= T(0.0));
     result = result && !isnan(two_word());

--- a/tools/vector_gen/test/sample_test.cc
+++ b/tools/vector_gen/test/sample_test.cc
@@ -60,17 +60,17 @@ GTEST_TEST(SampleTest, SimpleCoverage) {
 GTEST_TEST(SampleTest, IsValid) {
   // N.B. Sample<T>.unset is an invalid value by default.
   Sample<double> dummy1;
-  EXPECT_FALSE(ExtractBoolOrThrow(dummy1.IsValid()));
+  EXPECT_FALSE(dummy1.IsValid());
   dummy1.set_unset(0.0);
-  EXPECT_TRUE(ExtractBoolOrThrow(dummy1.IsValid()));
+  EXPECT_TRUE(dummy1.IsValid());
   dummy1.set_x(std::numeric_limits<double>::quiet_NaN());
-  EXPECT_FALSE(ExtractBoolOrThrow(dummy1.IsValid()));
+  EXPECT_FALSE(dummy1.IsValid());
 
   Sample<double> dummy2;
   dummy2.set_unset(0.0);
-  EXPECT_TRUE(ExtractBoolOrThrow(dummy2.IsValid()));
+  EXPECT_TRUE(dummy2.IsValid());
   dummy2.set_two_word(std::numeric_limits<double>::quiet_NaN());
-  EXPECT_FALSE(ExtractBoolOrThrow(dummy2.IsValid()));
+  EXPECT_FALSE(dummy2.IsValid());
 }
 
 // Cover Simple<AutoDiffXd>::IsValid.
@@ -78,9 +78,9 @@ GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
   // A NaN in the AutoDiffScalar::value() makes us invalid.
   Sample<AutoDiffXd> dut;
   dut.set_unset(0.0);  // N.B. Sample<T>.unset is an invalid value by default.
-  EXPECT_TRUE(ExtractBoolOrThrow(dut.IsValid()));
+  EXPECT_TRUE(dut.IsValid());
   dut.set_x(std::numeric_limits<double>::quiet_NaN());
-  EXPECT_FALSE(ExtractBoolOrThrow(dut.IsValid()));
+  EXPECT_FALSE(dut.IsValid());
 
   // A NaN in the AutoDiffScalar::derivatives() is still valid.
   AutoDiffXd zero_with_nan_derivatives{0};
@@ -89,7 +89,7 @@ GTEST_TEST(SampleTest, AutoDiffXdIsValid) {
   ASSERT_EQ(zero_with_nan_derivatives.derivatives().size(), 1);
   EXPECT_TRUE(std::isnan(zero_with_nan_derivatives.derivatives()(0)));
   dut.set_x(zero_with_nan_derivatives);
-  EXPECT_TRUE(ExtractBoolOrThrow(dut.IsValid()));
+  EXPECT_TRUE(dut.IsValid());
 }
 
 GTEST_TEST(SampleTest, SetToNamedVariablesTest) {
@@ -112,7 +112,7 @@ GTEST_TEST(SampleTest, SymbolicIsValid) {
       (dut.x() >= 0.0) &&
       (dut.absone() >= -1.0) &&
       (dut.absone() <= 1.0);
-  EXPECT_TRUE(dut.IsValid().value().EqualTo(expected_is_valid));
+  EXPECT_TRUE(dut.IsValid().EqualTo(expected_is_valid));
 }
 
 }  // namespace


### PR DESCRIPTION
Inspired by investigation in #6631, I believe that the value-wrapper `Bool<T>` is doing more harm than good.  Instead, we should have `scalar_predicate_t<T>` which is an alias for either `bool` or `Formula`, and that predicate methods should return that type-alias directly, without any value wrapping.

The PR sketch #9374 has the entire proposal, but I have carved off a representative chunk in this PR, to help de-clutter the discussion.

I have also added an `is_bool` sugar here, as a replacement for #9339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9375)
<!-- Reviewable:end -->
