### PR TITLE
Symbolic uninterpreted_function takes a vector of expressions instead of a set of variables

### DIFF
--- a/common/symbolic_expression.cc
+++ b/common/symbolic_expression.cc
@@ -748,8 +748,9 @@ Expression if_then_else(const Formula& f_cond, const Expression& e_then,
   return Expression{make_shared<ExpressionIfThenElse>(f_cond, e_then, e_else)};
 }
 
-Expression uninterpreted_function(const string& name, const Variables& vars) {
-  return Expression{make_shared<ExpressionUninterpretedFunction>(name, vars)};
+Expression uninterpreted_function(string name, vector<Expression> arguments) {
+  return Expression{make_shared<ExpressionUninterpretedFunction>(
+      std::move(name), std::move(arguments))};
 }
 
 bool is_constant(const Expression& e) { return is_constant(*e.ptr_); }
@@ -823,6 +824,11 @@ const map<Expression, Expression>& get_base_to_exponent_map_in_multiplication(
 
 const string& get_uninterpreted_function_name(const Expression& e) {
   return to_uninterpreted_function(e)->get_name();
+}
+
+const vector<Expression>& get_uninterpreted_function_arguments(
+    const Expression& e) {
+  return to_uninterpreted_function(e)->get_arguments();
 }
 
 const Formula& get_conditional_formula(const Expression& e) {

--- a/common/symbolic_expression.h
+++ b/common/symbolic_expression.h
@@ -399,8 +399,8 @@ class Expression {
   friend Expression if_then_else(const Formula& f_cond,
                                  const Expression& e_then,
                                  const Expression& e_else);
-  friend Expression uninterpreted_function(const std::string& name,
-                                           const Variables& vars);
+  friend Expression uninterpreted_function(std::string name,
+                                           std::vector<Expression> arguments);
 
   friend std::ostream& operator<<(std::ostream& os, const Expression& e);
   friend void swap(Expression& a, Expression& b) { std::swap(a.ptr_, b.ptr_); }
@@ -514,14 +514,15 @@ Expression floor(const Expression& e);
 Expression if_then_else(const Formula& f_cond, const Expression& e_then,
                         const Expression& e_else);
 
-/** Constructs an uninterpreted-function expression with @p name and @p vars.
- * An uninterpreted function is an opaque function that has no other property
- * than its name and a set of its arguments. This is useful to applications
- * where it is good enough to provide abstract information of a function without
- * exposing full details. Declaring sparsity of a system is a typical example.
+/** Constructs an uninterpreted-function expression with @p name and @p
+ * arguments. An uninterpreted function is an opaque function that has no other
+ * property than its name and a list of its arguments. This is useful to
+ * applications where it is good enough to provide abstract information of a
+ * function without exposing full details. Declaring sparsity of a system is a
+ * typical example.
  */
-Expression uninterpreted_function(const std::string& name,
-                                  const Variables& vars);
+Expression uninterpreted_function(std::string name,
+                                  std::vector<Expression> arguments);
 void swap(Expression& a, Expression& b);
 
 std::ostream& operator<<(std::ostream& os, const Expression& e);
@@ -637,9 +638,15 @@ const std::map<Expression, Expression>&
 get_base_to_exponent_map_in_multiplication(const Expression& e);
 
 /** Returns the name of an uninterpreted-function expression @p e.
- *  \pre{@p e is an uninterpreted-function expression.}
+ *  \pre @p e is an uninterpreted-function expression.
  */
 const std::string& get_uninterpreted_function_name(const Expression& e);
+
+/** Returns the arguments of an uninterpreted-function expression @p e.
+ *  \pre @p e is an uninterpreted-function expression.
+ */
+const std::vector<Expression>& get_uninterpreted_function_arguments(
+    const Expression& e);
 
 /** Returns the conditional formula in the if-then-else expression @p e.
  * @pre @p e is an if-then-else expression.

--- a/common/symbolic_expression_cell.cc
+++ b/common/symbolic_expression_cell.cc
@@ -194,8 +194,7 @@ Expression ExpandPow(const Expression& base, const Expression& exponent) {
 }  // anonymous namespace
 
 ExpressionCell::ExpressionCell(const ExpressionKind k, const bool is_poly)
-    : kind_{k},
-      is_polynomial_{is_poly} {}
+    : kind_{k}, is_polynomial_{is_poly} {}
 
 UnaryExpressionCell::UnaryExpressionCell(const ExpressionKind k,
                                          const Expression& e,
@@ -235,9 +234,7 @@ BinaryExpressionCell::BinaryExpressionCell(const ExpressionKind k,
                                            const Expression& e1,
                                            const Expression& e2,
                                            const bool is_poly)
-    : ExpressionCell{k, is_poly},
-      e1_{e1},
-      e2_{e2} {}
+    : ExpressionCell{k, is_poly}, e1_{e1}, e2_{e2} {}
 
 void BinaryExpressionCell::HashAppendDetail(DelegatingHasher* hasher) const {
   DRAKE_ASSERT(hasher);
@@ -280,8 +277,7 @@ double BinaryExpressionCell::Evaluate(const Environment& env) const {
 }
 
 ExpressionVar::ExpressionVar(const Variable& v)
-    : ExpressionCell{ExpressionKind::Var, true},
-      var_{v} {
+    : ExpressionCell{ExpressionKind::Var, true}, var_{v} {
   // Dummy symbolic variable (ID = 0) should not be used in constructing
   // symbolic expressions.
   DRAKE_DEMAND(!var_.is_dummy());
@@ -393,8 +389,7 @@ Expression ExpressionConstant::Differentiate(const Variable&) const {
 
 ostream& ExpressionConstant::Display(ostream& os) const { return os << v_; }
 
-ExpressionNaN::ExpressionNaN()
-    : ExpressionCell{ExpressionKind::NaN, false} {}
+ExpressionNaN::ExpressionNaN() : ExpressionCell{ExpressionKind::NaN, false} {}
 
 void ExpressionNaN::HashAppendDetail(DelegatingHasher*) const {}
 
@@ -1794,8 +1789,7 @@ double ExpressionFloor::DoEvaluate(const double v) const {
 ExpressionIfThenElse::ExpressionIfThenElse(const Formula& f_cond,
                                            const Expression& e_then,
                                            const Expression& e_else)
-    : ExpressionCell{ExpressionKind::IfThenElse,
-                     false},
+    : ExpressionCell{ExpressionKind::IfThenElse, false},
       f_cond_{f_cond},
       e_then_{e_then},
       e_else_{e_else} {}

--- a/common/symbolic_expression_cell.h
+++ b/common/symbolic_expression_cell.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <Eigen/Core>
 
@@ -789,10 +790,11 @@ class ExpressionIfThenElse : public ExpressionCell {
 /** Symbolic expression representing an uninterpreted function. */
 class ExpressionUninterpretedFunction : public ExpressionCell {
  public:
-  /** Constructs an uninterpreted-function expression from @p name and @p vars.
+  /** Constructs an uninterpreted-function expression from @p name and @p
+   * arguments.
    */
-  ExpressionUninterpretedFunction(const std::string& name,
-                                  const Variables& vars);
+  ExpressionUninterpretedFunction(std::string name,
+                                  std::vector<Expression> arguments);
   void HashAppendDetail(DelegatingHasher*) const override;
   Variables GetVariables() const override;
   bool EqualTo(const ExpressionCell& e) const override;
@@ -807,9 +809,12 @@ class ExpressionUninterpretedFunction : public ExpressionCell {
   /** Returns the name of this expression. */
   const std::string& get_name() const { return name_; }
 
+  /** Returns the arguments of this expression. */
+  const std::vector<Expression>& get_arguments() const { return arguments_; }
+
  private:
   const std::string name_;
-  const Variables variables_;
+  const std::vector<Expression> arguments_;
 };
 
 /** Checks if @p c is a constant expression. */

--- a/common/test/symbolic_expansion_test.cc
+++ b/common/test/symbolic_expansion_test.cc
@@ -11,14 +11,15 @@
 
 using std::function;
 using std::pair;
-using std::vector;
 using std::runtime_error;
+using std::vector;
 
 namespace drake {
 namespace symbolic {
 namespace {
 
 using test::ExprEqual;
+using test::ExprNotEqual;
 
 class SymbolicExpansionTest : public ::testing::Test {
  protected:
@@ -230,12 +231,16 @@ TEST_F(SymbolicExpansionTest, IfThenElse) {
                runtime_error);
 }
 
-// Expand() should not change uninterpreted functions.
 TEST_F(SymbolicExpansionTest, UninterpretedFunction) {
   const Expression uf1{uninterpreted_function("uf1", {})};
-  const Expression uf2{uninterpreted_function("uf2", {var_x_, var_y_})};
   EXPECT_PRED2(ExprEqual, uf1, uf1.Expand());
-  EXPECT_PRED2(ExprEqual, uf2, uf2.Expand());
+  const Expression e1{3 * (x_ + y_)};
+  const Expression e2{pow(x_ + y_, 2)};
+  const Expression uf2{uninterpreted_function("uf2", {e1, e2})};
+  EXPECT_PRED2(ExprNotEqual, uf2, uf2.Expand());
+  const Expression uf2_expand_expected{
+      uninterpreted_function("uf2", {e1.Expand(), e2.Expand()})};
+  EXPECT_PRED2(ExprEqual, uf2.Expand(), uf2_expand_expected);
 }
 
 TEST_F(SymbolicExpansionTest, DivideByConstant) {

--- a/common/test/symbolic_expression_test.cc
+++ b/common/test/symbolic_expression_test.cc
@@ -806,11 +806,13 @@ TEST_F(SymbolicExpressionTest, LessIfThenElse) {
 }
 
 TEST_F(SymbolicExpressionTest, LessUninterpretedFunction) {
-  const Expression uf1_1{uninterpreted_function("uf1", {var_x_, var_y_})};
-  const Expression uf1_2{uninterpreted_function("uf1", {var_x_, var_z_})};
-  const Expression uf2_1{uninterpreted_function("uf2", {var_x_, var_z_})};
-  const Expression uf2_2{uninterpreted_function("uf2", {var_z_})};
-  CheckOrdering({uf1_1, uf1_2, uf2_1, uf2_2});
+  const Expression uf1{uninterpreted_function("name1", {x_, y_ + z_})};
+  const Expression uf2{uninterpreted_function("name1", {x_, y_ * z_})};
+  const Expression uf3{uninterpreted_function("name1", {x_, y_ * z_, 3.0})};
+  const Expression uf4{uninterpreted_function("name2", {})};
+  const Expression uf5{uninterpreted_function("name2", {0.0, -1.0})};
+  const Expression uf6{uninterpreted_function("name2", {1.0, 0.0})};
+  CheckOrdering({uf1, uf2, uf3, uf4, uf5, uf6});
 }
 
 TEST_F(SymbolicExpressionTest, Variable) {
@@ -1795,10 +1797,12 @@ TEST_F(SymbolicExpressionTest, Cond2) {
   EXPECT_EQ(e.Evaluate({{var_x_, 1}}), 0.0);
 }
 
-TEST_F(SymbolicExpressionTest, UninterpretedFunction_GetVariables_GetName) {
+TEST_F(SymbolicExpressionTest,
+       UninterpretedFunction_GetVariables_GetName_GetArguments) {
   const Expression uf1{uninterpreted_function("uf1", {})};
   EXPECT_TRUE(uf1.GetVariables().empty());
   EXPECT_EQ(get_uninterpreted_function_name(uf1), "uf1");
+  EXPECT_TRUE(get_uninterpreted_function_arguments(uf1).empty());
 
   const Expression uf2{uninterpreted_function("uf2", {var_x_, var_y_})};
   EXPECT_EQ(get_uninterpreted_function_name(uf2), "uf2");
@@ -1806,6 +1810,14 @@ TEST_F(SymbolicExpressionTest, UninterpretedFunction_GetVariables_GetName) {
   EXPECT_EQ(vars_in_uf2.size(), 2);
   EXPECT_TRUE(vars_in_uf2.include(var_x_));
   EXPECT_TRUE(vars_in_uf2.include(var_y_));
+
+  const vector<Expression> arguments{sin(x_), cos(y_)};
+  const Expression uf3{uninterpreted_function("uf3", arguments)};
+  const vector<Expression>& the_arguments{
+      get_uninterpreted_function_arguments(uf3)};
+  EXPECT_EQ(arguments.size(), the_arguments.size());
+  EXPECT_PRED2(ExprEqual, arguments[0], the_arguments[0]);
+  EXPECT_PRED2(ExprEqual, arguments[1], the_arguments[1]);
 }
 
 TEST_F(SymbolicExpressionTest, UninterpretedFunction_Evaluate) {
@@ -1813,6 +1825,21 @@ TEST_F(SymbolicExpressionTest, UninterpretedFunction_Evaluate) {
   const Expression uf2{uninterpreted_function("uf2", {var_x_, var_y_})};
   EXPECT_THROW(uf1.Evaluate(), std::runtime_error);
   EXPECT_THROW(uf2.Evaluate(), std::runtime_error);
+}
+
+TEST_F(SymbolicExpressionTest, UninterpretedFunction_Equal) {
+  const Expression uf1{uninterpreted_function("name1", {x_, y_ + z_})};
+  const Expression uf2{uninterpreted_function("name1", {x_, y_ + z_})};
+  EXPECT_TRUE(uf1.EqualTo(uf2));
+
+  const Expression uf3{uninterpreted_function("name2", {x_, y_ + z_})};
+  EXPECT_FALSE(uf1.EqualTo(uf3));
+  const Expression uf4{uninterpreted_function("name1", {y_, y_ + z_})};
+  EXPECT_FALSE(uf1.EqualTo(uf4));
+  const Expression uf5{uninterpreted_function("name1", {x_, z_})};
+  EXPECT_FALSE(uf1.EqualTo(uf5));
+  const Expression uf6{uninterpreted_function("name1", {x_, y_ + z_, 3.0})};
+  EXPECT_FALSE(uf1.EqualTo(uf6));
 }
 
 TEST_F(SymbolicExpressionTest, GetVariables) {
@@ -1860,7 +1887,7 @@ TEST_F(SymbolicExpressionTest, ToString) {
             "(3.1415926535897931 * x * pow(y, 2.7182818284590451))");
   EXPECT_EQ(e4.to_string(),
             "(2.7182818284590451 + x + 3.1415926535897931 * y)");
-  EXPECT_EQ(e_uf_.to_string(), "uf({x, y})");
+  EXPECT_EQ(e_uf_.to_string(), "uf(x, y)");
 }
 
 TEST_F(SymbolicExpressionTest, EvaluatePartial) {

--- a/common/test/symbolic_substitution_test.cc
+++ b/common/test/symbolic_substitution_test.cc
@@ -9,11 +9,11 @@
 #include "drake/common/symbolic.h"
 #include "drake/common/test_utilities/symbolic_test_util.h"
 
+using std::exception;
 using std::function;
 using std::is_same;
 using std::pair;
 using std::result_of;
-using std::exception;
 using std::vector;
 
 namespace drake {
@@ -404,20 +404,20 @@ TEST_F(SymbolicSubstitutionTest, UninterpretedFunction) {
   EXPECT_PRED2(ExprEqual, uf1.Substitute(s2), uf1);
   EXPECT_PRED2(ExprEqual, uf1.Substitute(s3), uf1);
 
-  //   s1[x].GetVariables() ∪ s1[y].GetVariables()
-  // = (1.0).GetVariables() ∪ (x + y).GetVariables()
-  // = ∅ ∪ {x, y} = {x, y}.
-  EXPECT_PRED2(ExprEqual, uf2.Substitute(s1), uf2);
+  //   (uf2(x, y)).Substitute(x ↦ 1.0, y ↦ x + y)
+  // = uf2(1.0, x + y)
+  EXPECT_PRED2(ExprEqual, uf2.Substitute(s1),
+               uninterpreted_function("uf2", {1.0, x_ + y_}));
 
-  //   s2[x].GetVariables() ∪ s2[y].GetVariables()
-  // = {y} ∪ {z} = {y, z}.
+  //   (uf2(x, y)).Substitute(x ↦ y, y ↦ z)
+  // = uf2(y, z)
   EXPECT_PRED2(ExprEqual, uf2.Substitute(s2),
-               uninterpreted_function("uf2", {var_y_, var_z_}));
+               uninterpreted_function("uf2", {y_, z_}));
 
-  //   s3[x].GetVariables() ∪ s3[y].GetVariables()
-  // = ∅ ∪ ∅ = ∅.
+  //   (uf2(x, y)).Substitute(x ↦ 3.0, y ↦ 4.0)
+  // = uf2(3.0, 4.0)
   EXPECT_PRED2(ExprEqual, uf2.Substitute(s3),
-               uninterpreted_function("uf2", {}));
+               uninterpreted_function("uf2", {3.0, 4.0}));
 }
 
 class ForallFormulaSubstitutionTest : public SymbolicSubstitutionTest {

--- a/solvers/test/dreal_solver_test.cc
+++ b/solvers/test/dreal_solver_test.cc
@@ -1,5 +1,7 @@
 #include "drake/solvers/dreal_solver.h"
 
+#include <vector>
+
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
@@ -19,6 +21,7 @@ using symbolic::Variables;
 using std::logic_error;
 using std::make_shared;
 using std::shared_ptr;
+using std::vector;
 
 class DrealSolverTest : public ::testing::Test {
  protected:
@@ -458,7 +461,7 @@ TEST_F(DrealSolverTest, IfThenElse2) {
 TEST_F(DrealSolverTest, UnsupportedFormulaUninterpretedFunction) {
   EXPECT_THROW(
       DrealSolver::CheckSatisfiability(
-          uninterpreted_function("uf", Variables{x_, y_}) == 0, delta_),
+          symbolic::uninterpreted_function("uf", {x_, y_}) == 0, delta_),
       std::runtime_error);
 }
 


### PR DESCRIPTION
Close #9353 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9384)
<!-- Reviewable:end -->
