### PR TITLE
Implements method to obtain the state vector for a multibody model.

### DIFF
--- a/multibody/multibody_tree/multibody_plant/BUILD.bazel
+++ b/multibody/multibody_tree/multibody_plant/BUILD.bazel
@@ -114,6 +114,7 @@ drake_cc_googletest(
     name = "multibody_plant_test",
     data = [
         "test/split_pendulum.sdf",
+        "//manipulation/models/iiwa_description:models",
         "//multibody/benchmarks/acrobot:models",
         "//multibody/multibody_tree/parsing:test_models",
         "//multibody/shapes:test_models",

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -1601,6 +1601,95 @@ TEST_F(MultibodyPlantContactJacobianTests, TangentJacobian) {
       D, vt_derivs, kTolerance, MatrixCompareType::relative));
 }
 
+// Unit test fixture for a model of Kuka Iiwa arm parametrized on the periodic
+// update period of the plant. This allows us to test some of the plant's
+// functionality for both continuous and discrete models.
+class KukaArmTest : public ::testing::TestWithParam<double> {
+ protected:
+  void SetUp() override {
+    const char kSdfPath[] =
+        "drake/manipulation/models/iiwa_description/sdf/"
+            "iiwa14_no_collision.sdf";
+    plant_ = std::make_unique<MultibodyPlant<double>>(this->GetParam());
+    AddModelFromSdfFile(FindResourceOrThrow(kSdfPath), plant_.get());
+    plant_->Finalize();
+
+    EXPECT_EQ(plant_->num_positions(), 7);
+    EXPECT_EQ(plant_->num_velocities(), 7);
+
+    // We expect the first joint to be the one WeldJoint fixing the model to the
+    // world. We verify this assumption.
+    const Joint<double>& weld = plant_->model().get_joint(JointIndex(0));
+    ASSERT_EQ(weld.name(), "weld_base_to_world");
+
+    context_ = plant_->CreateDefaultContext();
+  }
+
+  // Helper to set the multibody state x to x[i] = i for each i-th entry in the
+  // state vector.
+  // We use RevoluteJoint's methods to set the state in order to independently
+  // unit test the proper workings of
+  // MultibodyTree::get_multibody_state_vector() and its mutable counterpart.
+  void SetState(const VectorX<double>& xc) {
+    const int nq = plant_->num_positions();
+    for (JointIndex joint_index(1); /* Skip "weld_base_to_world". */
+         joint_index < plant_->num_joints(); ++joint_index) {
+      // We know all joints in our model, besides the first joint welding the
+      // model to the world, are revolute joints.
+      const auto& joint = plant_->GetJointByName<RevoluteJoint>(
+          "iiwa_joint_" + std::to_string(joint_index));
+
+      // For this simple model we do know the order in which variables are
+      // stored in the state vector.
+      const double angle = xc[joint_index-1];
+      const double angle_rate = xc[nq + joint_index - 1];
+
+      // We simply set each entry in the state with the value of its index.
+      joint.set_angle(context_.get(), angle);
+      joint.set_angular_rate(context_.get(), angle_rate);
+    }
+  }
+
+  std::unique_ptr<MultibodyPlant<double>> plant_;
+  std::unique_ptr<Context<double>> context_;
+};
+
+// This test verifies we can easily access the multibody state vector x = [q, v]
+// for either a discrete or continuous multibody model.
+TEST_P(KukaArmTest, StateAccess) {
+  // Set the state to x[i] = i for each i-th entry.
+  const VectorX<double> xc_expected = VectorX<double>::LinSpaced(
+      plant_->num_multibody_states() /* size */,
+      1 /* first index */, plant_->num_multibody_states() /* last index */);
+  SetState(xc_expected);
+
+  // Verify that we can retrieve the state vector and that it has the values we
+  // set above.
+  // Note: xc is an Eigen block, that is, a reference to the values stored in
+  // the context. Changes to state through the context can change the values
+  // referenced by xc.
+  Eigen::VectorBlock<const VectorX<double>> xc =
+      plant_->model().get_multibody_state_vector(*context_);
+  EXPECT_EQ(xc, xc_expected);
+
+  // Get a mutable state and modified it.
+  // Note: xc above is referencing values stored in the context. Therefore
+  // setting the entire state to zero changes the values referenced by xc.
+  plant_->model().get_mutable_multibody_state_vector(context_.get()).setZero();
+  EXPECT_EQ(xc, VectorX<double>::Zero(plant_->num_multibody_states()));
+}
+
+// Verifies we instantiated an appropriate MultibodyPlant model based on the
+// fixture's parameter.
+TEST_P(KukaArmTest, CheckContinuousOrDiscreteModel) {
+  // The plant must be a discrete system if the periodic update period is zero.
+  EXPECT_EQ(!plant_->is_discrete(), this->GetParam() == 0);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    Blank, KukaArmTest,
+    testing::Values(0.0 /* continuous state */, 1e-3 /* discrete state */));
+
 }  // namespace
 }  // namespace multibody_plant
 }  // namespace multibody

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -312,6 +312,28 @@ void MultibodyTree<T>::SetDefaultState(
 }
 
 template <typename T>
+Eigen::VectorBlock<const VectorX<T>>
+MultibodyTree<T>::get_multibody_state_vector(
+    const systems::Context<T>& context) const {
+  const auto& mbt_context =
+      dynamic_cast<const MultibodyTreeContext<T>&>(context);
+  return mbt_context.get_state_vector();
+}
+
+template <typename T>
+Eigen::VectorBlock<VectorX<T>>
+MultibodyTree<T>::get_mutable_multibody_state_vector(
+    systems::Context<T>* context) const {
+  DRAKE_DEMAND(context != nullptr);
+  auto* mbt_context = dynamic_cast<MultibodyTreeContext<T>*>(context);
+  if (mbt_context == nullptr) {
+    throw std::runtime_error(
+        "The context provided is not compatible with a multibody model.");
+  }
+  return mbt_context->get_mutable_state_vector();
+}
+
+template <typename T>
 void MultibodyTree<T>::SetFreeBodyPoseOrThrow(
     const Body<T>& body, const Isometry3<T>& X_WB,
     systems::Context<T>* context) const {

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -1400,6 +1400,20 @@ class MultibodyTree {
   void SetDefaultState(const systems::Context<T>& context,
                        systems::State<T>* state) const;
 
+  /// Returns a const Eigen vector containing the multibody state `x = [q; v]`
+  /// of the model with q the vector of generalized positions and v the vector
+  /// of generalized velocities.
+  Eigen::VectorBlock<const VectorX<T>> get_multibody_state_vector(
+      const systems::Context<T>& context) const;
+
+  /// Returns a mutable Eigen vector containing the multibody state `x = [q; v]`
+  /// of the model with q the vector of generalized positions and v the vector
+  /// of generalized velocities.
+  /// @throws std::exception if the `context` is nullptr or if it does not
+  /// correspond to the context for a multibody model.
+  Eigen::VectorBlock<VectorX<T>> get_mutable_multibody_state_vector(
+      systems::Context<T>* context) const;
+
   /// Sets `context` to store the pose `X_WB` of a given `body` B in the world
   /// frame W.
   /// @note In general setting the pose and/or velocity of a body in the model


### PR DESCRIPTION
This allow us to get a simple Eigen vector whether the state is continuous or discrete.

cc'ing @EricCousineau-TRI. You'd like to bind this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9388)
<!-- Reviewable:end -->
