### PR TITLE
math, multibody: Stop using Bool<T>

### DIFF
--- a/math/rigid_transform.h
+++ b/math/rigid_transform.h
@@ -208,8 +208,9 @@ class RigidTransform {
 
   /// Returns `true` if `this` is exactly the identity %RigidTransform.
   /// @see IsIdentityToEpsilon().
-  Bool<T> IsExactlyIdentity() const {
-    const Bool<T> is_position_zero = translation() == Vector3<T>::Zero();
+  scalar_predicate_t<T> IsExactlyIdentity() const {
+    const scalar_predicate_t<T> is_position_zero =
+        (translation() == Vector3<T>::Zero());
     return is_position_zero && rotation().IsExactlyIdentity();
   }
 
@@ -222,7 +223,8 @@ class RigidTransform {
   /// (e.g., the magnitude of a characteristic position vector) by an epsilon
   /// (e.g., RotationMatrix::get_internal_tolerance_for_orthonormality()).
   /// @see IsExactlyIdentity().
-  Bool<T> IsIdentityToEpsilon(double translation_tolerance) const {
+  scalar_predicate_t<T> IsIdentityToEpsilon(
+      double translation_tolerance) const {
     const T max_component = translation().template lpNorm<Eigen::Infinity>();
     return max_component <= translation_tolerance &&
         rotation().IsIdentityToInternalTolerance();
@@ -278,8 +280,8 @@ class RigidTransform {
   /// @note Consider scaling tolerance with the largest of magA and magB, where
   /// magA and magB denoted the magnitudes of `this` position vector and `other`
   /// position vectors, respectively.
-  Bool<T> IsNearlyEqualTo(const RigidTransform<T>& other,
-                          double tolerance) const {
+  scalar_predicate_t<T> IsNearlyEqualTo(const RigidTransform<T>& other,
+                                        double tolerance) const {
     return GetMaximumAbsoluteDifference(other) <= tolerance;
   }
 
@@ -287,7 +289,7 @@ class RigidTransform {
   /// @param[in] other %RigidTransform to compare to `this`.
   /// @returns `true` if each element of `this` is exactly equal to the
   /// corresponding element of `other`.
-  Bool<T> IsExactlyEqualTo(const RigidTransform<T>& other) const {
+  scalar_predicate_t<T> IsExactlyEqualTo(const RigidTransform<T>& other) const {
     return rotation().IsExactlyEqualTo(other.rotation()) &&
            translation() == other.translation();
   }

--- a/math/roll_pitch_yaw.cc
+++ b/math/roll_pitch_yaw.cc
@@ -43,7 +43,7 @@ void RollPitchYaw<T>::SetFromQuaternionAndRotationMatrix(
   constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
   const RotationMatrix<T> R_quaternion(quaternion);
   constexpr double tolerance = 20 * kEpsilon;
-  if (!R_quaternion.IsNearlyEqualTo(R, tolerance).value()) {
+  if (!R_quaternion.IsNearlyEqualTo(R, tolerance)) {
     std::string message = fmt::format("RollPitchYaw::{}():"
         " An element of the RotationMatrix R passed to this method differs by"
         " more than {:G} from the corresponding element of the RotationMatrix"
@@ -64,7 +64,7 @@ void RollPitchYaw<T>::SetFromQuaternionAndRotationMatrix(
   // Use: (12*eps) + (4 mults + 1 add) * 1/2 eps = 17.5 eps.
   const RollPitchYaw<T> roll_pitch_yaw(rpy);
   const RotationMatrix<T> R_rpy = RotationMatrix<T>(roll_pitch_yaw);
-  DRAKE_ASSERT(R_rpy.IsNearlyEqualTo(R, 20 * kEpsilon).value());
+  DRAKE_ASSERT(R_rpy.IsNearlyEqualTo(R, 20 * kEpsilon));
 #endif
 }
 
@@ -200,7 +200,7 @@ bool RollPitchYaw<T>::IsNearlySameOrientation(const RollPitchYaw<T>& other,
   // angles' values should be able to be accurately reproduced.
   const RotationMatrix<T> R1(*this);
   const RotationMatrix<T> R2(other);
-  return R1.IsNearlyEqualTo(R2, tolerance).value();
+  return R1.IsNearlyEqualTo(R2, tolerance);
 }
 
 template <typename T>

--- a/math/roll_pitch_yaw.h
+++ b/math/roll_pitch_yaw.h
@@ -200,6 +200,10 @@ class RollPitchYaw {
     return ToRotationMatrix().matrix();
   }
 
+  // TODO(jwnimmer-tri) Nearly all of the bool-valued predicates ("IsFoo...")
+  // in this class should return scalar_predicate_t<T>, to be consistent with
+  // the RotationMatrix methods.
+
   /// Compares each element of `this` to the corresponding element of `other`
   /// to check if they are the same to within a specified `tolerance`.
   /// @param[in] other %RollPitchYaw to compare to `this`.

--- a/math/rotation_matrix.h
+++ b/math/rotation_matrix.h
@@ -321,7 +321,8 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between R * Rᵀ
   /// and the identity matrix I, i.e., checks if `‖R ⋅ Rᵀ - I‖∞ <= tolerance`.
   /// @returns `true` if R is an orthonormal matrix.
-  static Bool<T> IsOrthonormal(const Matrix3<T>& R, double tolerance) {
+  static scalar_predicate_t<T> IsOrthonormal(const Matrix3<T>& R,
+                                             double tolerance) {
     return GetMeasureOfOrthonormality(R) <= tolerance;
   }
 
@@ -331,7 +332,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference of `R * Rᵀ`
   /// and the identity matrix I (i.e., checks if `‖R ⋅ Rᵀ - I‖∞ <= tolerance`).
   /// @returns `true` if R is a valid rotation matrix.
-  static Bool<T> IsValid(const Matrix3<T>& R, double tolerance) {
+  static scalar_predicate_t<T> IsValid(const Matrix3<T>& R, double tolerance) {
     return IsOrthonormal(R, tolerance) && R.determinant() > 0;
   }
 
@@ -339,23 +340,23 @@ class RotationMatrix {
   /// within the threshold of get_internal_tolerance_for_orthonormality().
   /// @param[in] R an allegedly valid rotation matrix.
   /// @returns `true` if R is a valid rotation matrix.
-  static Bool<T> IsValid(const Matrix3<T>& R) {
+  static scalar_predicate_t<T> IsValid(const Matrix3<T>& R) {
     return IsValid(R, get_internal_tolerance_for_orthonormality());
   }
 
   /// Tests if `this` rotation matrix R is a proper orthonormal rotation matrix
   /// to within the threshold of get_internal_tolerance_for_orthonormality().
   /// @returns `true` if `this` is a valid rotation matrix.
-  Bool<T> IsValid() const { return IsValid(matrix()); }
+  scalar_predicate_t<T> IsValid() const { return IsValid(matrix()); }
 
   /// Returns `true` if `this` is exactly equal to the identity matrix.
-  Bool<T> IsExactlyIdentity() const {
+  scalar_predicate_t<T> IsExactlyIdentity() const {
     return matrix() == Matrix3<T>::Identity();
   }
 
   /// Returns true if `this` is equal to the identity matrix to within the
   /// threshold of get_internal_tolerance_for_orthonormality().
-  Bool<T> IsIdentityToInternalTolerance() const {
+  scalar_predicate_t<T> IsIdentityToInternalTolerance() const {
     return IsNearlyEqualTo(matrix(), Matrix3<T>::Identity(),
                            get_internal_tolerance_for_orthonormality());
   }
@@ -366,7 +367,7 @@ class RotationMatrix {
   /// @param[in] tolerance maximum allowable absolute difference between the
   /// matrix elements in `this` and `other`.
   /// @returns `true` if `‖this - other‖∞ <= tolerance`.
-  Bool<T> IsNearlyEqualTo(
+  scalar_predicate_t<T> IsNearlyEqualTo(
       const RotationMatrix<T>& other, double tolerance) const {
     return IsNearlyEqualTo(matrix(), other.matrix(), tolerance);
   }
@@ -376,7 +377,7 @@ class RotationMatrix {
   /// @param[in] other %RotationMatrix to compare to `this`.
   /// @returns true if each element of `this` is exactly equal to the
   /// corresponding element in `other`.
-  Bool<T> IsExactlyEqualTo(const RotationMatrix<T>& other) const {
+  scalar_predicate_t<T> IsExactlyEqualTo(const RotationMatrix<T>& other) const {
     return matrix() == other.matrix();
   }
 
@@ -575,8 +576,9 @@ class RotationMatrix {
   // @param[in] tolerance maximum allowable absolute difference between the
   // matrix elements in R and `other`.
   // @returns `true` if `‖R - `other`‖∞ <= tolerance`.
-  static Bool<T> IsNearlyEqualTo(const Matrix3<T>& R, const Matrix3<T>& other,
-                                 double tolerance) {
+  static scalar_predicate_t<T> IsNearlyEqualTo(const Matrix3<T>& R,
+                                               const Matrix3<T>& other,
+                                               double tolerance) {
     const T R_max_difference = GetMaximumAbsoluteDifference(R, other);
     return R_max_difference <= tolerance;
   }
@@ -840,7 +842,7 @@ RotationMatrix<T>::ThrowIfNotValid(const Matrix3<S>& R) {
   }
   // If the matrix is not-orthogonal, try to give a detailed message.
   // This is particularly important if matrix is very-near orthogonal.
-  if (!IsOrthonormal(R, get_internal_tolerance_for_orthonormality()).value()) {
+  if (!IsOrthonormal(R, get_internal_tolerance_for_orthonormality())) {
     const T measure_of_orthonormality = GetMeasureOfOrthonormality(R);
     const double measure = ExtractDoubleOrThrow(measure_of_orthonormality);
     std::string message = fmt::format(

--- a/math/test/rigid_transform_test.cc
+++ b/math/test/rigid_transform_test.cc
@@ -84,7 +84,7 @@ RigidTransform<double> GetRigidTransformB() {
 // Tests default constructor - should be identity RigidTransform.
 GTEST_TEST(RigidTransform, DefaultRigidTransformIsIdentity) {
   const RigidTransform<double> X;
-  EXPECT_TRUE(X.IsExactlyIdentity().value());
+  EXPECT_TRUE(X.IsExactlyIdentity());
 }
 
 // Tests constructing a RigidTransform from a RotationMatrix and Vector3.
@@ -101,7 +101,7 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorAndSet) {
 
   // Test the set method.
   X.set(RotationMatrix<double>::Identity(), Vector3d(0, 0, 0));
-  EXPECT_TRUE(X.IsExactlyIdentity().value());
+  EXPECT_TRUE(X.IsExactlyIdentity());
   X.set(R1, p);
   zero_rotation = m - X.rotation().matrix();
   zero_position = p - X.translation();
@@ -126,7 +126,7 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorAndSet) {
 GTEST_TEST(RigidTransform, RigidTransformConstructorFromRotationMatrix) {
   const RotationMatrixd R = GetRotationMatrixB();
   const RigidTransformd X(R);
-  EXPECT_TRUE(ExtractBoolOrThrow(X.rotation().IsExactlyEqualTo(R)));
+  EXPECT_TRUE(X.rotation().IsExactlyEqualTo(R));
   EXPECT_TRUE(X.translation() == Vector3d(0, 0, 0));
 }
 
@@ -134,7 +134,7 @@ GTEST_TEST(RigidTransform, RigidTransformConstructorFromRotationMatrix) {
 GTEST_TEST(RigidTransform, RigidTransformConstructorFromPositionVector) {
   const Vector3<double> p(4, 5, 6);
   const RigidTransform<double> X(p);
-  EXPECT_TRUE(ExtractBoolOrThrow(X.rotation().IsExactlyIdentity()));
+  EXPECT_TRUE(X.rotation().IsExactlyIdentity());
   EXPECT_TRUE(X.translation() == p);
 }
 
@@ -233,7 +233,7 @@ GTEST_TEST(RigidTransform, Isometry3) {
 // Tests method Identity (identity rotation matrix and zero vector).
 GTEST_TEST(RigidTransform, Identity) {
   const RigidTransform<double>& X = RigidTransform<double>::Identity();
-  EXPECT_TRUE(X.IsExactlyIdentity().value());
+  EXPECT_TRUE(X.IsExactlyIdentity());
 }
 
 // Tests method SetIdentity.
@@ -242,34 +242,34 @@ GTEST_TEST(RigidTransform, SetIdentity) {
   const Vector3d p(2, 3, 4);
   RigidTransform<double> X(R, p);
   X.SetIdentity();
-  EXPECT_TRUE(X.IsExactlyIdentity().value());
+  EXPECT_TRUE(X.IsExactlyIdentity());
 }
 
 // Tests whether or not a RigidTransform is an identity RigidTransform.
 GTEST_TEST(RigidTransform, IsIdentity) {
   // Test whether it is an identity matrix multiple ways.
   RigidTransform<double> X1;
-  EXPECT_TRUE(X1.IsExactlyIdentity().value());
-  EXPECT_TRUE(X1.IsIdentityToEpsilon(0.0).value());
-  EXPECT_TRUE(X1.rotation().IsExactlyIdentity().value());
+  EXPECT_TRUE(X1.IsExactlyIdentity());
+  EXPECT_TRUE(X1.IsIdentityToEpsilon(0.0));
+  EXPECT_TRUE(X1.rotation().IsExactlyIdentity());
   EXPECT_TRUE((X1.translation().array() == 0).all());
 
   // Test non-identity matrix.
   const RotationMatrix<double> R = GetRotationMatrixA();
   const Vector3d p(2, 3, 4);
   RigidTransform<double> X2(R, p);
-  EXPECT_FALSE(X2.IsExactlyIdentity().value());
+  EXPECT_FALSE(X2.IsExactlyIdentity());
 
   // Change rotation matrix to identity, but leave non-zero position vector.
   X2.set_rotation(RotationMatrix<double>::Identity());
-  EXPECT_FALSE(X2.IsExactlyIdentity().value());
-  EXPECT_FALSE(X2.IsIdentityToEpsilon(3.99).value());
-  EXPECT_TRUE(X2.IsIdentityToEpsilon(4.01).value());
+  EXPECT_FALSE(X2.IsExactlyIdentity());
+  EXPECT_FALSE(X2.IsIdentityToEpsilon(3.99));
+  EXPECT_TRUE(X2.IsIdentityToEpsilon(4.01));
 
   // Change position vector to zero vector.
   const Vector3d zero_vector(0, 0, 0);
   X2.set_translation(zero_vector);
-  EXPECT_TRUE(X2.IsExactlyIdentity().value());
+  EXPECT_TRUE(X2.IsExactlyIdentity());
 }
 
 // Tests calculating the inverse of a RigidTransform.
@@ -284,7 +284,7 @@ GTEST_TEST(RigidTransform, Inverse) {
   // Note: The square-root of a RigidTransform's condition number is roughly the
   // magnitude of the position vector.  The accuracy of the calculation for the
   // inverse of a RigidTransform drops off with sqrt(condition number).
-  EXPECT_TRUE(I.IsNearlyEqualTo(X_identity, 8 * kEpsilon).value());
+  EXPECT_TRUE(I.IsNearlyEqualTo(X_identity, 8 * kEpsilon));
 }
 
 // Tests RigidTransform multiplied by another RigidTransform
@@ -298,7 +298,7 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByRigidTransform) {
   const RotationMatrix<double> R_BA = GetRotationMatrixA();
   const RotationMatrix<double> R_CB = GetRotationMatrixB();
   const RotationMatrix<double> R_CA_expected = R_CB * R_BA;
-  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 0).value());
+  EXPECT_TRUE(R_CA.IsNearlyEqualTo(R_CA_expected, 0));
 
   // Expected position vector (from MotionGenesis).
   const double x_expected = 5.761769695362743;
@@ -314,7 +314,7 @@ GTEST_TEST(RigidTransform, OperatorMultiplyByRigidTransform) {
   // As documented in IsNearlyEqualTo(), 32 * epsilon was chosen because it is
   // slightly larger than the characteristic length |p_CoAo_C| = 14.2
   const RigidTransform<double> X_CA_expected(R_CA_expected, p_CoAo_C_expected);
-  EXPECT_TRUE(X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon).value());
+  EXPECT_TRUE(X_CA.IsNearlyEqualTo(X_CA_expected, 32 * kEpsilon));
 }
 
 // Tests RigidTransform multiplied by a position vector.
@@ -350,7 +350,7 @@ GTEST_TEST(RigidTransform, CastFromDoubleToAutoDiffXd) {
     for (int j = 0; j < 4; j++) {
       const double mij_double = m_double(i, j);
       const AutoDiffXd& mij_autodiff = m_autodiff(i, j);
-      EXPECT_EQ(mij_autodiff.value(), mij_double);
+      EXPECT_EQ(mij_autodiff, mij_double);
       EXPECT_EQ(mij_autodiff.derivatives().size(), 0);
     }
   }
@@ -359,29 +359,27 @@ GTEST_TEST(RigidTransform, CastFromDoubleToAutoDiffXd) {
 // Verify RigidTransform is compatible with symbolic::Expression. This includes,
 // construction and methods involving Bool specialized for symbolic::Expression,
 // namely: IsExactlyIdentity(), IsIdentityToEpsilon(), IsNearlyEqualTo().
-// TODO(Mitiguy) Once PR 9127 is merged, should not need ExtractBoolOrThrow
-// in any of these tests, so remove them.
 GTEST_TEST(RigidTransform, SymbolicRigidTransformSimpleTests) {
   // Test RigidTransform can be constructed with symbolic::Expression.
   RigidTransform<symbolic::Expression> X;
 
   // Test IsExactlyIdentity() nominally works with symbolic::Expression.
-  Bool<symbolic::Expression> test_Bool = X.IsExactlyIdentity();
-  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
+  symbolic::Formula test_Bool = X.IsExactlyIdentity();
+  EXPECT_TRUE(test_Bool);
 
   // Test IsIdentityToEpsilon() nominally works with symbolic::Expression.
   test_Bool = X.IsIdentityToEpsilon(kEpsilon);
-  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_TRUE(test_Bool);
 
   // Test IsExactlyEqualTo() nominally works for symbolic::Expression.
   const RigidTransform<symbolic::Expression>& X_built_in_identity =
       RigidTransform<symbolic::Expression>::Identity();
   test_Bool = X.IsExactlyEqualTo(X_built_in_identity);
-  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_TRUE(test_Bool);
 
   // Test IsNearlyEqualTo() nominally works for symbolic::Expression.
   test_Bool = X.IsNearlyEqualTo(X_built_in_identity, kEpsilon);
-  EXPECT_TRUE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_TRUE(test_Bool);
 
   // Now perform the same tests on a non-identity transform.
   const Vector3<symbolic::Expression> p_symbolic(1, 2, 3);
@@ -389,19 +387,19 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformSimpleTests) {
 
   // Test IsExactlyIdentity() works with symbolic::Expression.
   test_Bool = X.IsExactlyIdentity();
-  EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_FALSE(test_Bool);
 
   // Test IsIdentityToEpsilon() works with symbolic::Expression.
   test_Bool = X.IsIdentityToEpsilon(kEpsilon);
-  EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_FALSE(test_Bool);
 
   // Test IsExactlyEqualTo() works for symbolic::Expression.
   test_Bool = X.IsExactlyEqualTo(X_built_in_identity);
-  EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_FALSE(test_Bool);
 
   // Test IsNearlyEqualTo() works for symbolic::Expression.
   test_Bool = X.IsNearlyEqualTo(X_built_in_identity, kEpsilon);
-  EXPECT_FALSE(ExtractBoolOrThrow(test_Bool));
+  EXPECT_FALSE(test_Bool);
 }
 
 // Test that symbolic conversions may throw exceptions.
@@ -417,19 +415,19 @@ GTEST_TEST(RigidTransform, SymbolicRigidTransformThrowsExceptions) {
 
   // The next four tests should throw exceptions since the tests are
   // inconclusive because the value of x is unknown.
-  Bool<symbolic::Expression> test_Bool = X_symbolic.IsExactlyIdentity();
-  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
+  symbolic::Formula test_Bool = X_symbolic.IsExactlyIdentity();
+  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
 
   test_Bool = X_symbolic.IsIdentityToEpsilon(kEpsilon);
-  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
 
   const RigidTransform<symbolic::Expression>& X_identity =
       RigidTransform<symbolic::Expression>::Identity();
   test_Bool = X_symbolic.IsExactlyEqualTo(X_identity);
-  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
 
   test_Bool = X_symbolic.IsNearlyEqualTo(X_identity, kEpsilon);
-  EXPECT_THROW(ExtractBoolOrThrow(test_Bool), std::runtime_error);
+  EXPECT_THROW(test_Bool.Evaluate(), std::runtime_error);
 }
 
 }  // namespace

--- a/math/test/roll_pitch_yaw_test.cc
+++ b/math/test/roll_pitch_yaw_test.cc
@@ -78,7 +78,7 @@ GTEST_TEST(RollPitchYaw, ToRotationMatrix) {
                           * Eigen::AngleAxisd(r, Vector3d::UnitX())).matrix();
   const RotationMatrix<double> R_eigen(m_eigen);
   const RotationMatrix<double> R_rpy = rpy.ToRotationMatrix();
-  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, kEpsilon).value());
+  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, kEpsilon));
 
   // Also test associated convenience "sugar" method that returns 3x3 matrix.
   const Matrix3d m_rpy = rpy.ToMatrix3ViaRotationMatrix();
@@ -107,7 +107,7 @@ GTEST_TEST(RollPitchYaw, testToQuaternion) {
   const Eigen::Quaterniond quat = rpy.ToQuaternion();
   const RotationMatrix<double> R1(rpy);
   const RotationMatrix<double> R2(quat);
-  EXPECT_TRUE(R1.IsNearlyEqualTo(R2, kEpsilon).value());
+  EXPECT_TRUE(R1.IsNearlyEqualTo(R2, kEpsilon));
 
   // Test SetFromQuaternion.
   RollPitchYaw<double> rpy2(0, 0, 0);

--- a/math/test/rotation_conversion_test.cc
+++ b/math/test/rotation_conversion_test.cc
@@ -48,9 +48,9 @@ GTEST_TEST(EigenEulerAngleTest, MakeXYZRotation) {
   const Quaterniond qy(Eigen::AngleAxisd(theta, Vector3d::UnitY()));
   const Quaterniond qz(Eigen::AngleAxisd(theta, Vector3d::UnitZ()));
   const double tolerance = 32 * kEpsilon;
-  EXPECT_TRUE(Rx.IsNearlyEqualTo(RotationMatrixd(qx), tolerance).value());
-  EXPECT_TRUE(Ry.IsNearlyEqualTo(RotationMatrixd(qy), tolerance).value());
-  EXPECT_TRUE(Rz.IsNearlyEqualTo(RotationMatrixd(qz), tolerance).value());
+  EXPECT_TRUE(Rx.IsNearlyEqualTo(RotationMatrixd(qx), tolerance));
+  EXPECT_TRUE(Ry.IsNearlyEqualTo(RotationMatrixd(qy), tolerance));
+  EXPECT_TRUE(Rz.IsNearlyEqualTo(RotationMatrixd(qz), tolerance));
 }
 
 GTEST_TEST(EigenEulerAngleTest, BodyXYZ) {
@@ -377,7 +377,7 @@ TEST_F(RotationConversionTest, RotmatQuat) {
     // This 5-bit estimate seems to be a reasonably tight bound which
     // nevertheless passes a representative sampling of compilers and platforms.
     const RotationMatrix<double> rotmat(quat_drake);
-    EXPECT_TRUE(Ri.IsNearlyEqualTo(rotmat, 32 * kEpsilon).value());
+    EXPECT_TRUE(Ri.IsNearlyEqualTo(rotmat, 32 * kEpsilon));
   }
 }
 
@@ -386,7 +386,7 @@ TEST_F(RotationConversionTest, rotmat2rpyTest) {
     const RollPitchYaw<double> rpy(Ri);
     const RotationMatrix<double> rotmat_expected(rpy);
     // RollPitchYaw(RotationMatrix) is inverse of RotationMatrix(RollPitchYaw).
-    EXPECT_TRUE(Ri.IsNearlyEqualTo(rotmat_expected, 256 * kEpsilon).value());
+    EXPECT_TRUE(Ri.IsNearlyEqualTo(rotmat_expected, 256 * kEpsilon));
     EXPECT_TRUE(rpy.IsRollPitchYawInCanonicalRange());
   }
 }
@@ -405,7 +405,7 @@ TEST_F(RotationConversionTest, rpy2rotmatTest) {
     // then compare the result with RotationMatrix(RollPitchYaw).
     const RotationMatrix<double> R_from_rpy(rpyi);
     EXPECT_TRUE(
-        R_from_rpy.IsNearlyEqualTo(R_from_quaternion, 512 * kEpsilon).value());
+        R_from_rpy.IsNearlyEqualTo(R_from_quaternion, 512 * kEpsilon));
 
     // RollPitchYaw(RotationMatrix) is inverse of RotationMatrix(RollPitchYaw).
     const RollPitchYaw<double> rpy_expected(R_from_rpy);

--- a/math/test/rotation_matrix_test.cc
+++ b/math/test/rotation_matrix_test.cc
@@ -158,17 +158,17 @@ GTEST_TEST(RotationMatrix, MakeXRotationMakeYRotationMakeZRotation) {
   RA = RotationMatrixd::MakeXRotation(M_PI + theta);
   RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(1, -1, -1)) *
        RotationMatrixd::MakeXRotation(theta);
-  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance).value());
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
 
   RA = RotationMatrixd::MakeYRotation(M_PI + theta);
   RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(-1, 1, -1)) *
        RotationMatrixd::MakeYRotation(theta);
-  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance).value());
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
 
   RA = RotationMatrixd::MakeZRotation(M_PI + theta);
   RB = RotationMatrixd(Eigen::DiagonalMatrix<double, 3>(-1, -1, 1)) *
        RotationMatrixd::MakeZRotation(theta);
-  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance).value());
+  EXPECT_TRUE(RA.IsNearlyEqualTo(RB, tolerance));
 }
 
 // Test making a rotation matrix from a RollPitchYaw rotation sequence (which is
@@ -182,13 +182,13 @@ GTEST_TEST(RotationMatrix, ConstructorWithRollPitchYaw) {
                     * Eigen::AngleAxisd(r, Vector3d::UnitX())).matrix();
   const RotationMatrix<double> R_eigen(m);
   const RotationMatrix<double> R_rpy(rpy);
-  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, kEpsilon).value());
+  EXPECT_TRUE(R_rpy.IsNearlyEqualTo(R_eigen, kEpsilon));
 
   RotationMatrixd R1 = RotationMatrix<double>::MakeZRotation(y);
   RotationMatrixd R2 = RotationMatrix<double>::MakeYRotation(p);
   RotationMatrixd R3 = RotationMatrix<double>::MakeXRotation(r);
   RotationMatrixd R_expected = R1 * R2 * R3;
-  EXPECT_TRUE(R_rpy.IsExactlyEqualTo(R_expected).value());
+  EXPECT_TRUE(R_rpy.IsExactlyEqualTo(R_expected));
 }
 
 // Test calculating the inverse of a RotationMatrix.
@@ -202,7 +202,7 @@ GTEST_TEST(RotationMatrix, Inverse) {
   RotationMatrix<double> R(m);
   RotationMatrix<double> RRinv = R * R.inverse();
   const RotationMatrix<double>& I = RotationMatrix<double>::Identity();
-  EXPECT_TRUE(RRinv.IsNearlyEqualTo(I, 8 * kEpsilon).value());
+  EXPECT_TRUE(RRinv.IsNearlyEqualTo(I, 8 * kEpsilon));
 }
 
 // Test rotation matrix multiplication and IsNearlyEqualTo.
@@ -219,18 +219,18 @@ GTEST_TEST(RotationMatrix, OperatorMultiplyAndIsNearlyEqualTo) {
 
   // Test operator *().
   EXPECT_TRUE(
-      R_CA.IsNearlyEqualTo(R_CA_manual_multiply, 10 * kEpsilon).value());
+      R_CA.IsNearlyEqualTo(R_CA_manual_multiply, 10 * kEpsilon));
 
   // Also test IsNearlyEqualTo.
-  EXPECT_FALSE(R_CA.IsNearlyEqualTo(R_CB, 10000 * kEpsilon).value());
+  EXPECT_FALSE(R_CA.IsNearlyEqualTo(R_CB, 10000 * kEpsilon));
 
   // Also test operator*=().
   RotationMatrix<double> R_CA_times_equal_test = R_CB;
   R_CA_times_equal_test *= R_BA;
   EXPECT_TRUE(
-      R_CA_times_equal_test.IsNearlyEqualTo(R_CA, 10 * kEpsilon).value());
+      R_CA_times_equal_test.IsNearlyEqualTo(R_CA, 10 * kEpsilon));
   EXPECT_FALSE(
-      R_CA_times_equal_test.IsNearlyEqualTo(R_CB, 10000 * kEpsilon).value());
+      R_CA_times_equal_test.IsNearlyEqualTo(R_CB, 10000 * kEpsilon));
 
   // Also test operator*() with vectors.
   const Vector3d vA(1, 2, 3);     // Vector v expressed in frame A.
@@ -248,31 +248,31 @@ GTEST_TEST(RotationMatrix, IsValid) {
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   EXPECT_GT(m.determinant(), 0);
-  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
-  EXPECT_TRUE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
+  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
+  EXPECT_TRUE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
 
   // Test a matrix that should fail orthonormality check.
   m << 1, 10 * kEpsilon, 10 * kEpsilon,
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   EXPECT_GT(m.determinant(), 0);
-  EXPECT_FALSE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
+  EXPECT_FALSE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
 
   // Test a matrix that should fail determinant test.
   m << -1, 0, 0,
         0, cos_theta, sin_theta,
         0, -sin_theta, cos_theta;
   EXPECT_LT(m.determinant(), 0);
-  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon).value());
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon).value());
+  EXPECT_TRUE(RotationMatrix<double>::IsOrthonormal(m, 5 * kEpsilon));
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 5 * kEpsilon));
 }
 
 // Tests whether or not a RotationMatrix is an identity matrix.
 GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
   // Test that the default constructor creates an exact identity matrix.
   RotationMatrix<double> R;
-  EXPECT_TRUE(R.IsExactlyIdentity().value());
+  EXPECT_TRUE(R.IsExactlyIdentity());
 
   // Test that setting R to an identity matrix does not throw an exception.
   Matrix3d m;
@@ -280,12 +280,12 @@ GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
        0, 1, 0,
        0, 0, 1;
   R.set(m);
-  EXPECT_TRUE(R.IsExactlyIdentity().value());
+  EXPECT_TRUE(R.IsExactlyIdentity());
 
   // Test impact of absolute mininimum deviation from identity matrix.
   m(0, 2) = std::numeric_limits<double>::denorm_min();  // ≈ 4.94066e-324
   EXPECT_NO_THROW(R.set(m));
-  EXPECT_FALSE(R.IsExactlyIdentity().value());
+  EXPECT_FALSE(R.IsExactlyIdentity());
 
   // Test that setting a RotationMatrix to a 3x3 matrix that is close to a valid
   // RotationMatrix does not throw an exception, whereas setting to a 3x3 matrix
@@ -305,7 +305,7 @@ GTEST_TEST(RotationMatrix, IsExactlyIdentity) {
        0, cos_theta, sin_theta,
        0, -sin_theta, cos_theta;
   R.set(m);
-  EXPECT_FALSE(R.IsExactlyIdentity().value());
+  EXPECT_FALSE(R.IsExactlyIdentity());
 }
 
 
@@ -317,7 +317,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   RotationMatrix<double> R =
       RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
   EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                10 * kEpsilon).value());
+                                10 * kEpsilon));
   EXPECT_TRUE(std::abs(quality_factor - 1.0) < 40 * kEpsilon);
 
   // Test another valid rotation matrix.  Ensure near-perfect quality_factor.
@@ -325,23 +325,23 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   m = RotationMatrix<double>(rpy).matrix();
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
   EXPECT_TRUE(
-      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
+      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon));
   EXPECT_TRUE(std::abs(quality_factor - 1.0) < 40*kEpsilon);
 
   // Test scaling each element of a rotation matrix by 2 (linear scaling).
   const Matrix3d m2 = 2 * m;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m2, &quality_factor);
   EXPECT_TRUE(
-      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon).value());
+      R.IsNearlyEqualTo(RotationMatrix<double>(m), 10*kEpsilon));
   EXPECT_TRUE(std::abs(quality_factor - 2.0) < 40*kEpsilon);
 
   // Test a 3x3 matrix that is far from orthonormal.
   m << 1,   0.1, 0.1,
       -0.2, 1.0, 0.1,
        0.5, 0.6, 0.8;
-  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 64000 * kEpsilon).value());
+  EXPECT_FALSE(RotationMatrix<double>::IsValid(m, 64000 * kEpsilon));
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid().value());
+  EXPECT_TRUE(R.IsValid());
   // Singular values from MotionGenesis [1.405049, 1.061152, 0.4688222]
   EXPECT_TRUE(std::abs(quality_factor - 0.4688222) < 1E-5);
 
@@ -350,7 +350,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
        4, 5,  6,
        7, 8, -10;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid().value());
+  EXPECT_TRUE(R.IsValid());
   // Singular values from MotionGenesis [14.61524, 9.498744, 0.4105846]
   EXPECT_TRUE(std::abs(quality_factor - 14.61524) < 1E-5);
 
@@ -359,7 +359,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
           4, 5, 6,
           7, 8, -1E6;
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid().value());
+  EXPECT_TRUE(R.IsValid());
   // Singular values from MotionGenesis [1000000, 6.597777, 1.21254]
   EXPECT_TRUE(std::abs(quality_factor - 1000000) < 1E-1);
 
@@ -370,11 +370,11 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   EXPECT_TRUE(0 < m.determinant() &&
               m.determinant() < 64 * kEpsilon * kEpsilon * kEpsilon);
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
-  EXPECT_TRUE(R.IsValid().value());
+  EXPECT_TRUE(R.IsValid());
   // Singular values from MotionGenesis [kEpsilon, kEpsilon, kEpsilon]
   EXPECT_TRUE(quality_factor > 0 &&  quality_factor < 64 * kEpsilon);
   EXPECT_TRUE(R.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                64 * kEpsilon).value());
+                                64 * kEpsilon));
 
   // Test a 3x3 near-zero matrix whose determinant is negative (det = -1E-47).
   m << kEpsilon, 0, 0,
@@ -443,7 +443,7 @@ GTEST_TEST(RotationMatrix, ProjectToRotationMatrix) {
   R = RotationMatrix<double>::ProjectToRotationMatrix(m, &quality_factor);
   const RotationMatrix<double> I = R * R.inverse();
   EXPECT_TRUE(I.IsNearlyEqualTo(RotationMatrix<double>(Matrix3d::Identity()),
-                                10 * kEpsilon).value());
+                                10 * kEpsilon));
 }
 
 
@@ -463,7 +463,7 @@ GTEST_TEST(RotationMatrix, CastFromDoubleToAutoDiffXd) {
     for (int j = 0; j < 3; j++) {
       const double mij_double = m_double(i, j);
       const AutoDiffXd& mij_autodiff = m_autodiff(i, j);
-      EXPECT_EQ(mij_autodiff.value(), mij_double);
+      EXPECT_EQ(mij_autodiff, mij_double);
       EXPECT_EQ(mij_autodiff.derivatives().size(), 0);
     }
   }
@@ -694,7 +694,7 @@ TEST_F(RotationMatrixConversionTests, QuaternionToRotationMatrix) {
     const Matrix3d m_expected = qi.toRotationMatrix();
     const RotationMatrix<double> R_expected(m_expected);
     const RotationMatrix<double> R(qi);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 40 * kEpsilon).value());
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 40 * kEpsilon));
   }
 
 #ifdef DRAKE_ASSERT_IS_ARMED
@@ -716,7 +716,7 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     // Compare R with the RotationMatrix constructor that uses Eigen::AngleAxis.
     const Eigen::AngleAxisd angle_axis(qi);
     const RotationMatrix<double> R_expected(angle_axis);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 200 * kEpsilon).value());
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_expected, 200 * kEpsilon));
 
     // Check that inverting this operation (calculating the AngleAxis from
     // rotation matrix R_expected) corresponds to the same orientation.
@@ -726,7 +726,7 @@ TEST_F(RotationMatrixConversionTests, AngleAxisToRotationMatrix) {
     Eigen::AngleAxis<double> inverse_angle_axis;
     inverse_angle_axis.fromRotationMatrix(R_expected.matrix());
     const RotationMatrix<double> R_test(inverse_angle_axis);
-    EXPECT_TRUE(R.IsNearlyEqualTo(R_test, 200 * kEpsilon).value());
+    EXPECT_TRUE(R.IsNearlyEqualTo(R_test, 200 * kEpsilon));
     // Ensure the angle returned via Eigen's AngleAxis is between 0 and PI.
     const double angle = inverse_angle_axis.angle();
     EXPECT_TRUE(0 <= angle && angle <= M_PI);

--- a/multibody/multibody_tree/multibody_plant/coulomb_friction.cc
+++ b/multibody/multibody_tree/multibody_plant/coulomb_friction.cc
@@ -38,7 +38,8 @@ void CoulombFriction<T>::ThrowForBadFriction(const T& static_friction,
 }
 
 template <typename T>
-Bool<T> CoulombFriction<T>::operator==(const CoulombFriction& other) const {
+scalar_predicate_t<T> CoulombFriction<T>::operator==(
+    const CoulombFriction& other) const {
   return static_friction() == other.static_friction() &&
       dynamic_friction() == other.dynamic_friction();
 }

--- a/multibody/multibody_tree/multibody_plant/coulomb_friction.h
+++ b/multibody/multibody_tree/multibody_plant/coulomb_friction.h
@@ -84,7 +84,7 @@ class CoulombFriction {
   const T& dynamic_friction() const { return dynamic_friction_; }
 
   /// Performs a bitwise-identical comparison, not done to any tolerance.
-  Bool<T> operator==(const CoulombFriction& other) const;
+  scalar_predicate_t<T> operator==(const CoulombFriction& other) const;
 
  private:
   // Confirms two properties on the friction coefficient pair:

--- a/multibody/multibody_tree/multibody_plant/test/coulomb_friction_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/coulomb_friction_test.cc
@@ -50,17 +50,17 @@ GTEST_TEST(CoulombFriction, ConstructionFromFrictionCoefficients) {
 
 GTEST_TEST(CoulombFriction, EqualityOperator) {
   // They are equal.
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(0.8, 0.5)));
+  EXPECT_TRUE(
+      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(0.8, 0.5));
   // Static friction coefficient differs.
-  EXPECT_FALSE(ExtractBoolOrThrow(
-      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(1.2, 0.5)));
+  EXPECT_FALSE(
+      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(1.2, 0.5));
   // Dynamic friction coefficient differs.
-  EXPECT_FALSE(ExtractBoolOrThrow(
-      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(0.8, 0.3)));
+  EXPECT_FALSE(
+      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(0.8, 0.3));
   // Both friction coefficients differ.
-  EXPECT_FALSE(ExtractBoolOrThrow(
-      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(1.2, 0.6)));
+  EXPECT_FALSE(
+      CoulombFriction<double>(0.8, 0.5) == CoulombFriction<double>(1.2, 0.6));
 }
 
 // Verify CoulombFriction::CalcContactFrictionFromSurfaceProperties().
@@ -89,22 +89,22 @@ GTEST_TEST(CoulombFriction, CalcContactFrictionFromSurfaceProperties) {
   // Verify the operation is commutative.
   CoulombFriction<double> friction2_with_friction1 =
       CalcContactFrictionFromSurfaceProperties(friction2, friction1);
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      friction1_with_friction2 == friction2_with_friction1));
+  EXPECT_TRUE(
+      friction1_with_friction2 == friction2_with_friction1);
 
   // Verify result when one of the surfaces is frictionless.
   CoulombFriction<double> friction1_with_frictionless =
       CalcContactFrictionFromSurfaceProperties(friction1,
                                                CoulombFriction<double>());
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      friction1_with_frictionless == CoulombFriction<double>()));
+  EXPECT_TRUE(
+      friction1_with_frictionless == CoulombFriction<double>());
 
   // Verify commutativity when one of the surfaces is frictionless.
   CoulombFriction<double> frictionless_with_friction1 =
       CalcContactFrictionFromSurfaceProperties(CoulombFriction<double>(),
                                                friction1);
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      friction1_with_frictionless == frictionless_with_friction1));
+  EXPECT_TRUE(
+      friction1_with_frictionless == frictionless_with_friction1);
 }
 
 // Verify that the result of combining two identical surfaces returns the
@@ -130,15 +130,15 @@ GTEST_TEST(CoulombFriction, BothSurfacesAreFrictionless) {
   // Verify the surfaces are indeed frictionless.
   EXPECT_EQ(frictionless_surface1.dynamic_friction(), 0);
   EXPECT_EQ(frictionless_surface1.static_friction(), 0);
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      frictionless_surface1 == frictionless_surface2));
+  EXPECT_TRUE(
+      frictionless_surface1 == frictionless_surface2);
 
   CoulombFriction<double> frictionless_with_frictionless =
       CalcContactFrictionFromSurfaceProperties(frictionless_surface1,
                                                frictionless_surface2);
   // The result should be that of a frictionless surface pair.
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      frictionless_with_frictionless == CoulombFriction<double>()));
+  EXPECT_TRUE(
+      frictionless_with_frictionless == CoulombFriction<double>());
 }
 
 }  // namespace

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -998,12 +998,12 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   }
 
   // Verify we can retrieve friction coefficients.
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      plant.default_coulomb_friction(ground_id) == ground_friction));
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      plant.default_coulomb_friction(sphere1_id) == sphere1_friction));
-  EXPECT_TRUE(ExtractBoolOrThrow(
-      plant.default_coulomb_friction(sphere2_id) == sphere2_friction));
+  EXPECT_TRUE(
+      plant.default_coulomb_friction(ground_id) == ground_friction);
+  EXPECT_TRUE(
+      plant.default_coulomb_friction(sphere1_id) == sphere1_friction);
+  EXPECT_TRUE(
+      plant.default_coulomb_friction(sphere2_id) == sphere2_friction);
 }
 
 // Verifies the process of visual geometry registration with a SceneGraph.

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -271,12 +271,12 @@ TEST_F(MultibodyPlantSdfParser, LinksWithCollisions) {
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link1"));
   ASSERT_EQ(link1_collision_geometry_ids.size(), 2);
 
-  EXPECT_TRUE(ExtractBoolOrThrow(
+  EXPECT_TRUE(
       plant_.default_coulomb_friction(link1_collision_geometry_ids[0]) ==
-          CoulombFriction<double>(0.8, 0.3)));
-  EXPECT_TRUE(ExtractBoolOrThrow(
+          CoulombFriction<double>(0.8, 0.3));
+  EXPECT_TRUE(
       plant_.default_coulomb_friction(link1_collision_geometry_ids[1]) ==
-          CoulombFriction<double>(1.5, 0.6)));
+          CoulombFriction<double>(1.5, 0.6));
 
   const std::vector<GeometryId>& link2_collision_geometry_ids =
       plant_.GetCollisionGeometriesForBody(plant_.GetBodyByName("link2"));
@@ -287,9 +287,9 @@ TEST_F(MultibodyPlantSdfParser, LinksWithCollisions) {
   ASSERT_EQ(link3_collision_geometry_ids.size(), 1);
   // Verifies the default value of the friction coefficients when the user does
   // not specify them in the SDF file.
-  EXPECT_TRUE(ExtractBoolOrThrow(
+  EXPECT_TRUE(
       plant_.default_coulomb_friction(link3_collision_geometry_ids[0]) ==
-          default_friction()));
+          default_friction());
 }
 // Verifies model instances are correctly created in the plant.
 TEST_F(MultibodyPlantSdfParser, ModelInstanceTest) {

--- a/multibody/multibody_tree/rotational_inertia.h
+++ b/multibody/multibody_tree/rotational_inertia.h
@@ -218,7 +218,7 @@ class RotationalInertia {
   ///    in `this` and `other` can be converted to a double (discarding
   ///    supplemental scalar data such as derivatives of an AutoDiffScalar).
   ///    It fails at runtime if type T cannot be converted to `double`.
-  Bool<T> IsNearlyEqualTo(
+  scalar_predicate_t<T> IsNearlyEqualTo(
       const RotationalInertia& other, double precision) const {
     using std::min;
     const T I_maxA = CalcMaximumPossibleMomentOfInertia();
@@ -378,7 +378,7 @@ class RotationalInertia {
 
   /// Returns `true` if any moment/product in `this` rotational inertia is NaN.
   /// Otherwise returns `false`.
-  Bool<T> IsNaN() const {
+  scalar_predicate_t<T> IsNaN() const {
     using std::isnan;
     // Only check the lower-triangular part of this symmetric matrix for NaN.
     // The three upper off-diagonal products of inertia should be/remain NaN.
@@ -481,7 +481,7 @@ class RotationalInertia {
   /// @throws std::runtime_error if principal moments of inertia cannot be
   ///         calculated (eigenvalue solver) or if scalar type T cannot be
   ///         converted to a double.
-  Bool<T> CouldBePhysicallyValid() const {
+  scalar_predicate_t<T> CouldBePhysicallyValid() const {
     // To check the validity of rotational inertia use an epsilon value that is
     // a number related to machine precision multiplied by the largest possible
     // element that can appear in a valid `this` rotational inertia.  Note: The
@@ -836,7 +836,7 @@ class RotationalInertia {
   //          product absolute value in `other`.  Otherwise returns `false`.
   // @note Trace() / 2 is a rotational inertia's maximum possible element,
   // e.g., consider: epsilon = 1E-9 * Trace()  (where 1E-9 is a heuristic).
-  Bool<T> IsApproxMomentsAndProducts(
+  scalar_predicate_t<T> IsApproxMomentsAndProducts(
       const RotationalInertia& other, const T& epsilon) const {
     const Vector3<T> moment_difference = get_moments() - other.get_moments();
     const Vector3<T> product_difference = get_products() - other.get_products();
@@ -863,7 +863,8 @@ class RotationalInertia {
   //       rotational inertia (e.g., Ixx + Iyy + Izz), one can prove:
   //       0 <= Imin <= tr/3,   tr/3 <= Imed <= tr/2,   tr/3 <= Imax <= tr/2.
   //       If Imin == 0, then Imed == Imax == tr / 2.
-  static Bool<T> AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
+  static scalar_predicate_t<T>
+  AreMomentsOfInertiaNearPositiveAndSatisfyTriangleInequality(
       const T& Ixx, const T& Iyy, const T& Izz, const T& epsilon) {
     const auto are_moments_near_positive = AreMomentsOfInertiaNearPositive(
         Ixx, Iyy, Izz, epsilon);
@@ -881,7 +882,7 @@ class RotationalInertia {
   // @param epsilon Real positive number that is significantly smaller than the
   //        largest possible element in a valid rotational inertia.
   //        Heuristically, `epsilon` is a small multiplier of Trace() / 2.
-  static Bool<T> AreMomentsOfInertiaNearPositive(
+  static scalar_predicate_t<T> AreMomentsOfInertiaNearPositive(
       const T& Ixx, const T& Iyy, const T& Izz, const T& epsilon) {
     return Ixx + epsilon >= 0  &&  Iyy + epsilon >= 0  &&  Izz + epsilon >= 0;
   }
@@ -901,7 +902,7 @@ class RotationalInertia {
   template <typename T1 = T>
   typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid() {
-    if (!CouldBePhysicallyValid().value()) {
+    if (!CouldBePhysicallyValid()) {
       throw std::logic_error("Error: Rotational inertia did not pass test: "
                              "CouldBePhysicallyValid().");
     }

--- a/multibody/multibody_tree/test/articulated_body_inertia_test.cc
+++ b/multibody/multibody_tree/test/articulated_body_inertia_test.cc
@@ -62,7 +62,7 @@ GTEST_TEST(ArticulatedBodyInertia, CastToAutoDiff) {
       m_double(0), m_double(1), m_double(2), /* moments of inertia */
       p_double(0), p_double(1), p_double(2));/* products of inertia */
   const SpatialInertia<double> M_double(mass_double, com_double, G_double);
-  ASSERT_TRUE(M_double.IsPhysicallyValid().value());
+  ASSERT_TRUE(M_double.IsPhysicallyValid());
 
   // Construct articulated body inertia from spatial inertia.
   const ArticulatedBodyInertia<double> P_double(M_double);

--- a/multibody/multibody_tree/test/rigid_body_test.cc
+++ b/multibody/multibody_tree/test/rigid_body_test.cc
@@ -40,7 +40,7 @@ GTEST_TEST(RigidBody, RigidBodyConstructor) {
   // Test that RigidBody class properly calculates rotational inertia.
   const RotationalInertia<double> I_BBo_B_expected = mass * U_BBo_B;
   const RotationalInertia<double> I_BBo_B = B.default_rotational_inertia();
-  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(I_BBo_B_expected, 4.0*kEpsilon).value());
+  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(I_BBo_B_expected, 4.0*kEpsilon));
 }
 
 // Test rigid body constructor passing a string name.

--- a/multibody/multibody_tree/test/rotational_inertia_test.cc
+++ b/multibody/multibody_tree/test/rotational_inertia_test.cc
@@ -169,8 +169,8 @@ GTEST_TEST(RotationalInertia, IsNearlyEqualTo) {
 
   // Ensure rotational inertias I1 and I2 are nearly equal.
   // Ensure rotational inertias I1 and I3 are not equal.
-  EXPECT_TRUE(I1.IsNearlyEqualTo(I2, 4*kEpsilon).value());
-  EXPECT_FALSE(I1.IsNearlyEqualTo(I3, 7*kEpsilon).value());
+  EXPECT_TRUE(I1.IsNearlyEqualTo(I2, 4*kEpsilon));
+  EXPECT_FALSE(I1.IsNearlyEqualTo(I3, 7*kEpsilon));
 }
 
 // TestA: Rotational inertia expressed in frame R then re-expressed in frame E.
@@ -203,7 +203,7 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameA) {
   EXPECT_NEAR(I_RRo_F(2, 2), I_RRo_R(1, 1), kEpsilon);  // F z-axis = R -y-axis.
 
   // Ensure re-expressing in frame F still produces a physically valid inertia.
-  EXPECT_TRUE(I_RRo_F.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(I_RRo_F.CouldBePhysicallyValid());
 }
 
 // TestB: Rotational inertia expressed in frame R then re-expressed in frame E.
@@ -240,7 +240,7 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
                                           I_BBo_Axy, I_BBo_Axz, I_BBo_Ayz);
 
   // Ensure rotational inertia I_BBo_A is physically valid.
-  EXPECT_TRUE(I_BBo_A.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(I_BBo_A.CouldBePhysicallyValid());
 
   // Re-express I_BBo_A from expressed-in frame A to expressed-in frame B.
   const RotationalInertia<double> I_BBo_B = I_BBo_A.ReExpress(R_BA);
@@ -259,7 +259,7 @@ GTEST_TEST(RotationalInertia, ReExpressInAnotherFrameB) {
   // Compare Drake results versus MotionGenesis results using a comparison
   // that tests moments/products of inertia to within kEpsilon multiplied
   // by trace / 2, where trace is the smallest trace of the two matrices.
-  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(expected_I_BBo_B, kEpsilon).value());
+  EXPECT_TRUE(I_BBo_B.IsNearlyEqualTo(expected_I_BBo_B, kEpsilon));
 }
 
 // Test the method ShiftFromCenterOfMass for a body B's rotational inertia
@@ -282,7 +282,7 @@ GTEST_TEST(RotationalInertia, ShiftFromCenterOfMass) {
   const double Ixz = I_BBcm_Bxz - mass * xQ*zQ;
   const double Iyz = I_BBcm_Byz - mass * yQ*zQ;
   const RotationalInertia<double> expected_I_BQ_B(Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon).value());
+  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon));
 }
 
 // Test the method ShiftToCenterOfMass for a body B's rotational inertia
@@ -306,7 +306,7 @@ GTEST_TEST(RotationalInertia, ShiftToCenterOfMass) {
   const double Iyz = I_BP_Byz + mass * yBcm*zBcm;
   const RotationalInertia<double> expected_I_BBcm_B(
       Ixx, Iyy, Izz, Ixy, Ixz, Iyz);
-  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 2*kEpsilon).value());
+  EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(expected_I_BBcm_B, 2*kEpsilon));
 }
 
 // Test the method ShiftToThenAwayFromCenterOfMass for a body B's
@@ -333,17 +333,17 @@ GTEST_TEST(RotationalInertia, ShiftToThenAwayFromCenterOfMass) {
   // Calculate with single method that does it slightly more efficiently.
   const RotationalInertia<double> I_BQ_B =
       I_BP_B.ShiftToThenAwayFromCenterOfMass(mass, p_PBcm, p_QBcm);
-  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon).value());
+  EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(expected_I_BQ_B, 2*kEpsilon));
 
   // Test that negating position vectors have no affect on results.
   EXPECT_TRUE(I_BBcm_B.IsNearlyEqualTo(
-              I_BP_B.ShiftToCenterOfMass(mass, -p_PBcm), 2*kEpsilon).value());
+              I_BP_B.ShiftToCenterOfMass(mass, -p_PBcm), 2*kEpsilon));
   EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(
               I_BBcm_B.ShiftFromCenterOfMass(mass, -p_QBcm),
-              2*kEpsilon).value());
+              2*kEpsilon));
   EXPECT_TRUE(I_BQ_B.IsNearlyEqualTo(
               I_BP_B.ShiftToThenAwayFromCenterOfMass(mass, -p_PBcm, -p_QBcm),
-              2*kEpsilon).value());
+              2*kEpsilon));
 }
 
 // Test the method CouldBePhysicallyValid after a body B's rotational inertia
@@ -368,10 +368,10 @@ GTEST_TEST(RotationalInertia, CouldBePhysicallyValidB) {
   const double I_transverse = 20;
   const double I_axial = -1.0E-15;  // Although negative, this is effectively 0.
   const RotationalInertia<double> rod(I_transverse, I_transverse, I_axial);
-  EXPECT_TRUE(rod.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(rod.CouldBePhysicallyValid());
 
   const RotationalInertia<double> sphere(1.0E-5, 1.0E-5, 1.0E-5);
-  EXPECT_TRUE(sphere.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(sphere.CouldBePhysicallyValid());
 
   // Subtracting the sphere from the rod creates an invalid rotational inertia.
   EXPECT_THROW_IF_ARMED(rod - sphere, std::logic_error);
@@ -558,7 +558,7 @@ GTEST_TEST(RotationalInertia, CastToAutoDiff) {
 
   // Cast from double to AutoDiffScalar.
   const RotationalInertia<AutoDiff1d> I_cast = I_double.cast<AutoDiff1d>();
-  EXPECT_TRUE(I_autodiff.IsNearlyEqualTo(I_cast, kEpsilon).value());
+  EXPECT_TRUE(I_autodiff.IsNearlyEqualTo(I_cast, kEpsilon));
 
   const Matrix3<AutoDiff1d> I_autodiff_matrix = I_cast.CopyToFullMatrix3();
   auto I_value = drake::math::autoDiffToValueMatrix(I_autodiff_matrix);
@@ -662,7 +662,7 @@ GTEST_TEST(RotationalInertia, AutoDiff) {
   const Matrix3<AutoDiff1d> R_BW =
       (AngleAxis<AutoDiff1d>(-angle, Vector3d::UnitZ())).toRotationMatrix();
   const RotationalInertia<AutoDiff1d> expectedI_B = I_W.ReExpress(R_BW);
-  EXPECT_TRUE(expectedI_B.IsNearlyEqualTo(I_B, kEpsilon).value());
+  EXPECT_TRUE(expectedI_B.IsNearlyEqualTo(I_B, kEpsilon));
 }
 
 GTEST_TEST(RotationalInertia, CompatibleWithSymbolicExpression) {
@@ -688,7 +688,7 @@ GTEST_TEST(RotationalInertia, CompatibleWithSymbolicExpression) {
 
   // The expression cannot be evaluated to bool given it contains free
   // variables.
-  EXPECT_THROW(I_BQ_E.CouldBePhysicallyValid().value(), std::exception);
+  EXPECT_THROW(I_BQ_E.CouldBePhysicallyValid(), std::exception);
 }
 
 // Verifies we can still call IsPhysicallyValid() when T = symbolic::Expression
@@ -696,7 +696,7 @@ GTEST_TEST(RotationalInertia, CompatibleWithSymbolicExpression) {
 GTEST_TEST(RotationalInertia, SymbolicConstant) {
   using T = symbolic::Expression;
   RotationalInertia<T> I = RotationalInertia<T>::TriaxiallySymmetric(1.0);
-  ASSERT_TRUE(I.CouldBePhysicallyValid().value());
+  ASSERT_TRUE(I.CouldBePhysicallyValid());
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/spatial_inertia_test.cc
+++ b/multibody/multibody_tree/test/spatial_inertia_test.cc
@@ -30,7 +30,7 @@ constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 // quick detection of uninitialized values.
 GTEST_TEST(SpatialInertia, DefaultConstructor) {
   SpatialInertia<double> I;
-  ASSERT_TRUE(I.IsNaN().value());
+  ASSERT_TRUE(I.IsNaN());
 }
 
 // Test the construction from the mass, center of mass, and unit inertia of a
@@ -46,7 +46,7 @@ GTEST_TEST(SpatialInertia, ConstructionFromMasComAndUnitInertia) {
   UnitInertia<double> G(m(0), m(1), m(2), /* moments of inertia */
                         p(0), p(1), p(2));/* products of inertia */
   SpatialInertia<double> M(mass, com, G);
-  ASSERT_TRUE(M.IsPhysicallyValid().value());
+  ASSERT_TRUE(M.IsPhysicallyValid());
 
   ASSERT_EQ(M.get_mass(), mass);
   ASSERT_EQ(M.get_com(), com);
@@ -64,9 +64,9 @@ GTEST_TEST(SpatialInertia, ConstructionFromMasComAndUnitInertia) {
 
   EXPECT_TRUE(Mmatrix.isApprox(expected_matrix, kEpsilon));
 
-  EXPECT_FALSE(M.IsNaN().value());
+  EXPECT_FALSE(M.IsNaN());
   M.SetNaN();
-  EXPECT_TRUE(M.IsNaN().value());
+  EXPECT_TRUE(M.IsNaN());
 }
 
 // Tests that we can correctly cast a SpatialInertia<double> to a
@@ -83,7 +83,7 @@ GTEST_TEST(SpatialInertia, CastToAutoDiff) {
       m_double(0), m_double(1), m_double(2), /* moments of inertia */
       p_double(0), p_double(1), p_double(2));/* products of inertia */
   const SpatialInertia<double> M_double(mass_double, com_double, G_double);
-  ASSERT_TRUE(M_double.IsPhysicallyValid().value());
+  ASSERT_TRUE(M_double.IsPhysicallyValid());
 
   // Cast from double to AutoDiffXd.
   SpatialInertia<AutoDiffXd> M_autodiff = M_double.cast<AutoDiffXd>();
@@ -154,7 +154,7 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
       UnitInertia<double>::SolidCube(L));
   MRightBox_Wo_W.ShiftInPlace(-Vector3d::UnitX());
   // Check if after transformation this still is a physically valid inertia.
-  EXPECT_TRUE(MRightBox_Wo_W.IsPhysicallyValid().value());
+  EXPECT_TRUE(MRightBox_Wo_W.IsPhysicallyValid());
 
   // Spatial inertia computed about the origin for a cube with sides of
   // length L centered at x = -1.0. Expressed in world frame W.
@@ -167,7 +167,7 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
       UnitInertia<double>::SolidCube(L));
   MLeftBox_Wo_W.ShiftInPlace(Vector3d::UnitX());
   // Check if after transformation this still is a physically valid inertia.
-  EXPECT_TRUE(MLeftBox_Wo_W.IsPhysicallyValid().value());
+  EXPECT_TRUE(MLeftBox_Wo_W.IsPhysicallyValid());
 
   // The result of adding the spatial inertia of two bodies is the spatial
   // inertia of the combined system of the two bodies as if they were welded
@@ -180,7 +180,7 @@ GTEST_TEST(SpatialInertia, PlusEqualOperator) {
   // in the two individual components.
   SpatialInertia<double> MBox_Wo_W(MLeftBox_Wo_W);
   MBox_Wo_W += MRightBox_Wo_W;
-  EXPECT_TRUE(MBox_Wo_W.IsPhysicallyValid().value());
+  EXPECT_TRUE(MBox_Wo_W.IsPhysicallyValid());
 
   // Check that the compound inertia corresponds to that of a larger box of
   // length 4.0.
@@ -217,7 +217,7 @@ GTEST_TEST(SpatialInertia, ReExpress) {
   SpatialInertia<double> M_CP_W = M_CP_E.ReExpress(R_WE);
 
   // Checks for physically correct spatial inertia.
-  EXPECT_TRUE(M_CP_W.IsPhysicallyValid().value());
+  EXPECT_TRUE(M_CP_W.IsPhysicallyValid());
 
   // The mass is invariant when re-expressing in another frame.
   EXPECT_EQ(M_CP_E.get_mass(), M_CP_W.get_mass());
@@ -265,7 +265,7 @@ GTEST_TEST(SpatialInertia, Shift) {
   SpatialInertia<double> M_BBtop_W = M_BBcm_W.Shift(p_BcmBtop_W);
 
   // Checks for physically correct spatial inertia.
-  EXPECT_TRUE(M_BBtop_W.IsPhysicallyValid().value());
+  EXPECT_TRUE(M_BBtop_W.IsPhysicallyValid());
 
   // Shift() does not change the mass.
   EXPECT_EQ(M_BBtop_W.get_mass(), M_BBcm_W.get_mass());
@@ -330,7 +330,7 @@ GTEST_TEST(SpatialInertia, MakeFromCentralInertia) {
       SpatialInertia<double>::MakeFromCentralInertia(mass, p_BoBcm_B, I_BBcm_B);
 
   // Check for physically correct spatial inertia.
-  EXPECT_TRUE(M_BBo_B.IsPhysicallyValid().value());
+  EXPECT_TRUE(M_BBo_B.IsPhysicallyValid());
 
   // Check spatial inertia for proper value for mass and center of mass.
   EXPECT_EQ(M_BBo_B.get_mass(), mass);
@@ -408,7 +408,7 @@ GTEST_TEST(SpatialInertia, SymbolicNan) {
       Variable{"Ixy"}, Variable{"Ixz"}, Variable{"Iyz"}};
   const SpatialInertia<T> I{mass, p_PScm_E, G_SP_E};
   ASSERT_EQ(
-      I.IsNaN().value().to_string(),
+      I.IsNaN().to_string(),
       "(isnan(m) or isnan(p(0)) or isnan(p(1)) or isnan(p(2)) or isnan(Ixx) or"
       " isnan(Iyy) or isnan(Izz) or isnan(Ixy) or isnan(Ixz) or isnan(Iyz))");
 }
@@ -428,7 +428,7 @@ GTEST_TEST(SpatialInertia, SymbolicConstant) {
   SpatialInertia<T> M(mass, com, G);
 
   // The expression can still be evaluated since all terms are constants.
-  ASSERT_TRUE(M.IsPhysicallyValid().value());
+  ASSERT_TRUE(M.IsPhysicallyValid());
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/unit_inertia_test.cc
+++ b/multibody/multibody_tree/test/unit_inertia_test.cc
@@ -32,7 +32,7 @@ constexpr double kEpsilon = std::numeric_limits<double>::epsilon();
 // quick detection of un-initialized values.
 GTEST_TEST(UnitInertia, DefaultConstructor) {
   UnitInertia<double> I;
-  ASSERT_TRUE(I.IsNaN().value());
+  ASSERT_TRUE(I.IsNaN());
 }
 
 // Test constructor for a diagonal unit inertia with all elements equal.
@@ -119,7 +119,7 @@ GTEST_TEST(UnitInertia, ReExpressInAnotherFrame) {
 
   // While at it, check if after transformation this still is a physically
   // valid inertia.
-  EXPECT_TRUE(G_Ro_F.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(G_Ro_F.CouldBePhysicallyValid());
 }
 
 // Tests the static method to obtain the unit inertia of a point mass.
@@ -353,7 +353,7 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
   G.ShiftFromCenterOfMassInPlace({0.0, 0.0, L / 2.0});
   EXPECT_TRUE(G.CopyToFullMatrix3().isApprox(
       G_expected.CopyToFullMatrix3(), kEpsilon));  // Equal after shifting.
-  EXPECT_TRUE(G.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(G.CouldBePhysicallyValid());
 
   // Now test that we can perform the inverse operation and obtain the original
   // unit inertia.
@@ -372,7 +372,7 @@ GTEST_TEST(UnitInertia, ShiftFromCenterOfMassInPlace) {
       SolidCylinder(r, L).ShiftFromCenterOfMass({0.0, 0.0, L / 2.0});
   EXPECT_TRUE(G3.CopyToFullMatrix3().isApprox(
       G_expected.CopyToFullMatrix3(), kEpsilon));
-  EXPECT_TRUE(G3.CouldBePhysicallyValid().value());
+  EXPECT_TRUE(G3.CouldBePhysicallyValid());
 }
 
 // Tests that we can correctly cast a UnitInertia<double> to a UnitInertia
@@ -394,7 +394,7 @@ GTEST_TEST(UnitInertia, CastToAutoDiff) {
 
   // Cast from double to AutoDiffScalar.
   const UnitInertia<ADScalar> I_cast = I_double.cast<ADScalar>();
-  EXPECT_TRUE(I_autodiff.IsNearlyEqualTo(I_cast, kEpsilon).value());
+  EXPECT_TRUE(I_autodiff.IsNearlyEqualTo(I_cast, kEpsilon));
 
   const Matrix3<ADScalar> I_autodiff_matrix = I_cast.CopyToFullMatrix3();
   auto I_value = drake::math::autoDiffToValueMatrix(I_autodiff_matrix);


### PR DESCRIPTION
Relates #6631.  Full feature branch is #9374.

The main change here is to the return types of some methods.  The fallout is removed `.value()` and `ExtractBoolOrThrow` calls, mostly in tests.  (They aren't needed anyway on master, due to conversion operators.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9389)
<!-- Reviewable:end -->
