### PR TITLE
MultibodyPlant was not setting the model instance 

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -383,7 +383,10 @@ geometry::GeometryId MultibodyPlant<T>::RegisterGeometry(
         GeometryFrame(
             body.name(),
             /* Initial pose: Not really used by GS. Will get removed. */
-            Isometry3<double>::Identity()));
+            Isometry3<double>::Identity(),
+            /* TODO(@SeanCurtis-TRI): Add test coverage for this
+             * model-instance support as requested in #9390. */
+            body.model_instance()));
   }
 
   // Register geometry in the body frame.


### PR DESCRIPTION
…in the GeometryFrame when talking to SceneGraph.  

Without this one line, it was impossible to view (in drake_visualizer, or in meshcat) multiple instances of the same object, because SceneGraph had the same frame_group_id (and link name, etc) for both of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9390)
<!-- Reviewable:end -->
