### PR TITLE
math, multibody: Stop using is_numeric<T> 

### DIFF
--- a/multibody/multibody_tree/articulated_body_inertia.h
+++ b/multibody/multibody_tree/articulated_body_inertia.h
@@ -160,7 +160,7 @@ class ArticulatedBodyInertia {
   /// The checks performed are:
   ///   - The matrix is positive semi-definite.
   template <typename T1 = T>
-  typename std::enable_if<is_numeric<T1>::value, bool>::type
+  typename std::enable_if_t<scalar_predicate<T1>::is_bool, bool>
   IsPhysicallyValid() const {
     // Note that this tolerance may need to be loosened.
     const double kTolerance = -1e-14;
@@ -174,7 +174,7 @@ class ArticulatedBodyInertia {
 
   /// IsPhysicallyValid() for non-numeric scalar types is not supported.
   template <typename T1 = T>
-  typename std::enable_if<!is_numeric<T1>::value, bool>::type
+  typename std::enable_if_t<!scalar_predicate<T1>::is_bool, bool>
   IsPhysicallyValid() const {
     throw std::logic_error(
         "IsPhysicallyValid() is only supported for numeric types. It is not "

--- a/multibody/multibody_tree/rotational_inertia.h
+++ b/multibody/multibody_tree/rotational_inertia.h
@@ -87,8 +87,8 @@ namespace multibody {
 /// rotational inertia operations in debug releases only.  This provides speed
 /// in a release build while facilitating debugging in debug builds.
 /// In addition, these validity tests are only performed for scalar types for
-/// which drake::is_numeric<T> is `true`. For instance, validity checks are not
-/// performed when T is symbolic::Expression.
+/// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
+/// checks are not performed when T is symbolic::Expression.
 ///
 /// @tparam T The underlying scalar type. Must be a valid Eigen scalar.
 /// Various methods in this class require numerical (not symbolic) data types.
@@ -899,7 +899,7 @@ class RotationalInertia {
   // eigenvalues and checking if they are positive and satisfy the triangle
   // inequality.
   template <typename T1 = T>
-  typename std::enable_if<is_numeric<T1>::value>::type
+  typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid() {
     if (!CouldBePhysicallyValid().value()) {
       throw std::logic_error("Error: Rotational inertia did not pass test: "
@@ -910,13 +910,13 @@ class RotationalInertia {
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
   template <typename T1 = T>
-  typename std::enable_if<!is_numeric<T1>::value>::type
+  typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
   ThrowIfNotPhysicallyValid() {}
 
   // Throws an exception if a rotational inertia is multiplied by a negative
   // number - which implies that the resulting rotational inertia is invalid.
   template <typename T1 = T>
-  static typename std::enable_if<is_numeric<T1>::value>::type
+  static typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfMultiplyByNegativeScalar(const T& nonnegative_scalar) {
     if (nonnegative_scalar < 0) {
       throw std::logic_error("Error: Rotational inertia is multiplied by a "
@@ -927,13 +927,13 @@ class RotationalInertia {
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
   template <typename T1 = T>
-  static typename std::enable_if<!is_numeric<T1>::value>::type
+  static typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
   ThrowIfMultiplyByNegativeScalar(const T&) {}
 
   // Throws an exception if a rotational inertia is divided by a non-positive
   // number - which implies that the resulting rotational inertia is invalid.
   template <typename T1 = T>
-  static typename std::enable_if<is_numeric<T1>::value>::type
+  static typename std::enable_if_t<scalar_predicate<T1>::is_bool>
   ThrowIfDivideByZeroOrNegativeScalar(const T& positive_scalar) {
     if (positive_scalar == 0)
       throw std::logic_error("Error: Rotational inertia is divided by 0.");
@@ -946,7 +946,7 @@ class RotationalInertia {
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
   template <typename T1 = T>
-  static typename std::enable_if<!is_numeric<T1>::value>::type
+  static typename std::enable_if_t<!scalar_predicate<T1>::is_bool>
   ThrowIfDivideByZeroOrNegativeScalar(const T&) {}
 
   // The 3x3 inertia matrix is symmetric and its diagonal elements (moments of

--- a/multibody/multibody_tree/spatial_inertia.h
+++ b/multibody/multibody_tree/spatial_inertia.h
@@ -78,8 +78,8 @@ namespace multibody {
 /// rotational inertia operations in debug releases only.  This provides speed
 /// in a release build while facilitating debugging in debug builds.
 /// In addition, these validity tests are only performed for scalar types for
-/// which drake::is_numeric<T> is `true`. For instance, validity checks are not
-/// performed when T is symbolic::Expression.
+/// which drake::scalar_predicate<T>::is_bool is `true`. For instance, validity
+/// checks are not performed when T is symbolic::Expression.
 ///
 /// - [Jain 2010]  Jain, A., 2010. Robot and multibody dynamics: analysis and
 ///                algorithms. Springer Science & Business Media.
@@ -440,7 +440,8 @@ class SpatialInertia {
   // attempt a smart way throw based on a given symbolic::Formula but instead we
   // make these methods a no-op for non-numeric types.
   template <typename T1 = T>
-  typename std::enable_if<is_numeric<T1>::value>::type CheckInvariants() const {
+  typename std::enable_if_t<scalar_predicate<T1>::is_bool> CheckInvariants()
+      const {
     if (!IsPhysicallyValid().value()) {
       throw std::runtime_error(
           "The resulting spatial inertia is not physically valid. "
@@ -451,7 +452,8 @@ class SpatialInertia {
   // SFINAE for non-numeric types. See documentation in the implementation for
   // numeric types.
   template <typename T1 = T>
-  typename std::enable_if<!is_numeric<T1>::value>::type CheckInvariants() {}
+  typename std::enable_if_t<!scalar_predicate<T1>::is_bool> CheckInvariants()
+      const {}
 
   // Mass of the body or composite body.
   T mass_{nan()};


### PR DESCRIPTION
The `is_numeric` guard is soon to be deprecated in favor of `scalar_predicate`.

Relates #6631. Full feature branch is #9374.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9394)
<!-- Reviewable:end -->
