### PR TITLE
common: Add any/all/none Eigen redux operations

### DIFF
--- a/common/test/drake_bool_test.cc
+++ b/common/test/drake_bool_test.cc
@@ -132,30 +132,60 @@ TEST_F(BoolTestDouble, LogicalOperators) {
   EXPECT_TRUE(!b_false_);
 }
 
-TEST_F(BoolTestDouble, AllOf) {
-  EXPECT_TRUE(all_of(m_, [](const double v) { return v >= 0.0; }).value());
-  EXPECT_FALSE(all_of(m_, [](const double v) { return v >= 2.0; }).value());
+TEST_F(BoolTestDouble, All) {
+  auto bools = Eigen::Matrix<bool, 3, 3>::Constant(true).eval();
+  EXPECT_TRUE(all(bools));
+  bools(0, 0) = false;
+  EXPECT_FALSE(all(bools));
 
   // Vacuously true.
-  EXPECT_TRUE(all_of(zero_m_, [](const double v) { return v >= 0.0; }).value());
+  EXPECT_TRUE(all(Eigen::Matrix<bool, 0, 0>::Constant(false)));
+}
+
+TEST_F(BoolTestDouble, AllOf) {
+  EXPECT_TRUE(all_of(m_, [](const double v) { return v >= 0.0; }));
+  EXPECT_FALSE(all_of(m_, [](const double v) { return v >= 2.0; }));
+
+  // Vacuously true.
+  EXPECT_TRUE(all_of(zero_m_, [](const double v) { return v >= 0.0; }));
+}
+
+TEST_F(BoolTestDouble, Any) {
+  auto bools = Eigen::Matrix<bool, 3, 3>::Constant(false).eval();
+  EXPECT_FALSE(any(bools));
+  bools(0, 0) = true;
+  EXPECT_TRUE(any(bools));
+
+  // Vacuously false.
+  EXPECT_FALSE(any(Eigen::Matrix<bool, 0, 0>::Constant(true)));
 }
 
 TEST_F(BoolTestDouble, AnyOf) {
-  EXPECT_TRUE(any_of(m_, [](const double v) { return v >= 4.0; }).value());
-  EXPECT_FALSE(any_of(m_, [](const double v) { return v >= 5.0; }).value());
+  EXPECT_TRUE(any_of(m_, [](const double v) { return v >= 4.0; }));
+  EXPECT_FALSE(any_of(m_, [](const double v) { return v >= 5.0; }));
 
   // Vacuously false.
   EXPECT_FALSE(
-      any_of(zero_m_, [](const double v) { return v >= 0.0; }).value());
+      any_of(zero_m_, [](const double v) { return v >= 0.0; }));
+}
+
+TEST_F(BoolTestDouble, None) {
+  auto bools = Eigen::Matrix<bool, 3, 3>::Constant(false).eval();
+  EXPECT_TRUE(none(bools));
+  bools(0, 0) = true;
+  EXPECT_FALSE(none(bools));
+
+  // Vacuously true.
+  EXPECT_TRUE(none(Eigen::Matrix<bool, 0, 0>::Constant(true)));
 }
 
 TEST_F(BoolTestDouble, NoneOf) {
-  EXPECT_TRUE(none_of(m_, [](const double v) { return v >= 5.0; }).value());
-  EXPECT_FALSE(none_of(m_, [](const double v) { return v >= 4.0; }).value());
+  EXPECT_TRUE(none_of(m_, [](const double v) { return v >= 5.0; }));
+  EXPECT_FALSE(none_of(m_, [](const double v) { return v >= 4.0; }));
 
   // Vacuously true.
   EXPECT_TRUE(
-      none_of(zero_m_, [](const double v) { return v >= 0.0; }).value());
+      none_of(zero_m_, [](const double v) { return v >= 0.0; }));
 }
 
 // -------------------
@@ -244,14 +274,13 @@ TEST_F(BoolTestAutoDiffXd, AllOf) {
                      [](const AutoDiffXd& v) {
                        return v.derivatives()[0] == 1.0 ||
                               v.derivatives()[1] == 1.0;
-                     })
-                  .value());
+                     }));
   EXPECT_FALSE(
-      all_of(m_, [](const AutoDiffXd& v) { return v >= 1.0; }).value());
+      all_of(m_, [](const AutoDiffXd& v) { return v >= 1.0; }));
 
   // Vacuously true.
   EXPECT_TRUE(
-      all_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }).value());
+      all_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }));
 }
 
 TEST_F(BoolTestAutoDiffXd, AnyOf) {
@@ -259,18 +288,16 @@ TEST_F(BoolTestAutoDiffXd, AnyOf) {
                      [](const AutoDiffXd& v) {
                        return v.derivatives()[0] == 1.0 &&
                               v.derivatives()[1] == 0.0;
-                     })
-                  .value());
+                     }));
   EXPECT_FALSE(any_of(m_,
                       [](const AutoDiffXd& v) {
                         return v.derivatives()[0] == 1.0 &&
                                v.derivatives()[1] == 1.0;
-                      })
-                   .value());
+                      }));
 
   // Vacuously false.
   EXPECT_FALSE(
-      any_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }).value());
+      any_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }));
 }
 
 TEST_F(BoolTestAutoDiffXd, NoneOf) {
@@ -278,18 +305,16 @@ TEST_F(BoolTestAutoDiffXd, NoneOf) {
                       [](const AutoDiffXd& v) {
                         return v.derivatives()[0] == 1.0 &&
                                v.derivatives()[1] == 1.0;
-                      })
-                  .value());
+                      }));
   EXPECT_FALSE(none_of(m_,
                        [](const AutoDiffXd& v) {
                          return v.derivatives()[0] == 1.0 &&
                                 v.derivatives()[1] == 0.0;
-                       })
-                   .value());
+                       }));
 
   // Vacuously true.
   EXPECT_TRUE(
-      none_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }).value());
+      none_of(zero_m_, [](const AutoDiffXd& v) { return v >= 1.0; }));
 }
 
 // -----------------------------
@@ -442,36 +467,63 @@ TEST_F(BoolTestSymbolic, LogicalOperators) {
   EXPECT_PRED2(FormulaEqual, (!b1).value(), !f1);
 }
 
+TEST_F(BoolTestSymbolic, All) {
+  const MatrixX<Formula> formulae = m_.unaryExpr(&symbolic::isnan);
+  EXPECT_PRED2(FormulaEqual, all(formulae),
+               isnan(x_) && isnan(y_) && isnan(z_) && isnan(w_));
+
+  // Vacuously true.
+  EXPECT_TRUE(all(MatrixX<Formula>::Constant(0, 0, Formula::False())));
+}
+
 TEST_F(BoolTestSymbolic, AllOf) {
   EXPECT_PRED2(
       FormulaEqual,
-      all_of(m_, [](const Expression& v) { return !isnan(v); }).value(),
+      all_of(m_, [](const Expression& v) { return !isnan(v); }),
       !isnan(x_) && !isnan(y_) && !isnan(z_) && !isnan(w_));
 
   // Vacuously true.
   EXPECT_TRUE(
-      all_of(zero_m_, [](const Expression& v) { return v >= 0.0; }).value());
+      all_of(zero_m_, [](const Expression& v) { return v >= 0.0; }));
+}
+
+TEST_F(BoolTestSymbolic, Any) {
+  const MatrixX<Formula> formulae = m_.unaryExpr(&symbolic::isnan);
+  EXPECT_PRED2(FormulaEqual, any(formulae),
+               isnan(x_) || isnan(y_) || isnan(z_) || isnan(w_));
+
+  // Vacuously false.
+  EXPECT_FALSE(any(MatrixX<Formula>::Constant(0, 0, Formula::True())));
 }
 
 TEST_F(BoolTestSymbolic, AnyOf) {
   EXPECT_PRED2(FormulaEqual,
-               any_of(m_, [](const Expression& v) { return isnan(v); }).value(),
+               any_of(m_, [](const Expression& v) { return isnan(v); }),
                isnan(x_) || isnan(y_) || isnan(z_) || isnan(w_));
 
   // Vacuously false.
   EXPECT_FALSE(
-      any_of(zero_m_, [](const Expression& v) { return v >= 0.0; }).value());
+      any_of(zero_m_, [](const Expression& v) { return v >= 0.0; }));
+}
+
+TEST_F(BoolTestSymbolic, None) {
+  const MatrixX<Formula> formulae = m_.unaryExpr(&symbolic::isnan);
+  EXPECT_PRED2(FormulaEqual, none(formulae),
+               !isnan(x_) && !isnan(y_) && !isnan(z_) && !isnan(w_));
+
+  // Vacuously true.
+  EXPECT_TRUE(none(MatrixX<Formula>::Constant(0, 0, Formula::False())));
 }
 
 TEST_F(BoolTestSymbolic, NoneOf) {
   EXPECT_PRED2(
       FormulaEqual,
-      none_of(m_, [](const Expression& v) { return isnan(v); }).value(),
+      none_of(m_, [](const Expression& v) { return isnan(v); }),
       !isnan(x_) && !isnan(y_) && !isnan(z_) && !isnan(w_));
 
   // Vacuously true.
   EXPECT_TRUE(
-      none_of(zero_m_, [](const Expression& v) { return v >= 0.0; }).value());
+      none_of(zero_m_, [](const Expression& v) { return v >= 0.0; }));
 }
 
 }  // namespace drake

--- a/multibody/multibody_tree/spatial_inertia.h
+++ b/multibody/multibody_tree/spatial_inertia.h
@@ -203,13 +203,8 @@ class SpatialInertia {
   /// and `false` otherwise.
   scalar_predicate_t<T> IsNaN() const {
     using std::isnan;
-    // TODO(jwnimmer-tri) It would be cleaner if `any_of` directly returned a
-    // scalar_predicate_t<T> , instead of returning Bool<T> which is a trivial
-    // wrapper.  (Bool<T>::value_type is the same as scalar_predicate_t<T>.)
-    // For now, we'll just unpack the wrapper manually.  In the future, the
-    // trailing `.value()` unwrap here should disappear.
     return isnan(mass_) || G_SP_E_.IsNaN() ||
-        any_of(p_PScm_E_, [](auto x){ return isnan(x); }).value();
+        any_of(p_PScm_E_, [](auto x){ return isnan(x); });
   }
 
   /// Performs a number of checks to verify that this is a physically valid


### PR DESCRIPTION
These are useful for doing redux operations over Eigen arrays of symbolic formulae.  Unlike their `DenseBase` equivalents, these operations do not explicitly short-circuit, so will return the full symbolic conjunctions (or disjunctions).  The compiler is free to add back short-circuiting to the `bool` cases.

Concurrent with the new functions, this changes the return types from `Bool<T>` to `scalar_predicate_t<T>` (aka `Bool<T>::value_type`); the `Bool<T>` class is scheduled for deprecation.

Relates #6631.  Full WIP branch at #9374.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9401)
<!-- Reviewable:end -->
