### PR TITLE
Nuke internal LcmInitSystem by enhancing LcmPublisher

### DIFF
--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -199,56 +199,12 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
   return message;
 }
 
-// This System should be included in a diagram for the purpose of ensuring
-// that the one-time load geometry message gets sent to the visualizer upon
-// Simulator initialization. It will also serve to own the DrakeLcm object if
-// one isn't provided on construction.
-// TODO(sherm1) Move this functionality to LcmPublisher and remove this System
-//              (see issue #9397).
-class LcmInitSystem : public systems::LeafSystem<double> {
- public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(LcmInitSystem)
-
-  LcmInitSystem(const SceneGraph<double>* scene_graph,
-                lcm::DrakeLcmInterface* lcm = nullptr)
-      : scene_graph_(*scene_graph), lcm_(lcm) {
-    DRAKE_DEMAND(scene_graph != nullptr);
-
-    // Create a DrakeLcm object if we don't already have one.
-    if (lcm_ == nullptr) {
-      owned_lcm_ = std::make_unique<lcm::DrakeLcm>();
-      lcm_ = owned_lcm_.get();
-    }
-
-    // Create an initialization event that sends the load message.
-    // TODO(sherm1) This is pulling geometry from the SceneGraph but should
-    // be changed to use the Context for the most current version of the
-    // geometry, once geometry is changeable at runtime. Also, subsequent
-    // geometry changes are likely to require a "geometry changed" message
-    // to be sent.
-    DeclareInitializationEvent(systems::PublishEvent<double>(
-        systems::Event<double>::TriggerType::kInitialization,
-        [this](const systems::Context<double>&,
-               const systems::PublishEvent<double>&) {
-          DispatchLoadMessage(this->scene_graph_, this->lcm_);
-        }));
-  }
-
-  // Obtain a reference to the DrakeLcm object, which may have been supplied
-  // on construction or may be internally owned.
-  lcm::DrakeLcmInterface& lcm() { return *lcm_; }
-
- private:
-  const SceneGraph<double>& scene_graph_;
-  lcm::DrakeLcmInterface* lcm_{nullptr};
-  std::unique_ptr<lcm::DrakeLcm> owned_lcm_;
-};
-
 }  // namespace internal
 
 // TODO(sherm1) Per Sean Curtis, the load message should take its geometry
 // from a Context rather than directly out of the SceneGraph. If geometry
-// has been added to the Context it won't be loaded here.
+// has been added to the Context it won't be loaded here. A runtime
+// geometry change will likely require a geometry-changed event.
 void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
                          lcm::DrakeLcmInterface* lcm) {
   lcmt_viewer_load_robot message =
@@ -267,11 +223,6 @@ void ConnectDrakeVisualizer(systems::DiagramBuilder<double>* builder,
 
   DRAKE_DEMAND(builder != nullptr);
 
-  // This disembodied system serves to send out the visualizer's needed
-  // initialization message. Allocates a DrakeLcm if the supplied one is null.
-  internal::LcmInitSystem* lcm_system =
-      builder->AddSystem<internal::LcmInitSystem>(&scene_graph, lcm_optional);
-
   PoseBundleToDrawMessage* converter =
       builder->template AddSystem<PoseBundleToDrawMessage>();
 
@@ -279,9 +230,21 @@ void ConnectDrakeVisualizer(systems::DiagramBuilder<double>* builder,
       builder->template AddSystem<LcmPublisherSystem>(
           "DRAKE_VIEWER_DRAW",
           std::make_unique<Serializer<drake::lcmt_viewer_draw>>(),
-          &lcm_system->lcm());
+          lcm_optional);
   publisher->set_publish_period(1 / 60.0);
 
+  // The functor we create in publisher here holds a reference to scene_graph,
+  // which must therefore live as long as publisher does. We can count on that
+  // because scene_graph is required to be contained in builder (see method
+  // documentation), along with the converter and publisher we just added.
+  // Builder will transfer ownership of all of these objects to the Diagram it
+  // eventually builds.
+  publisher->AddInitializationMessage([&scene_graph](
+      const systems::Context<double>&, lcm::DrakeLcmInterface* lcm) {
+    DispatchLoadMessage(scene_graph, lcm);
+  });
+
+  // Note that this will fail if scene_graph is not actually in builder.
   builder->Connect(scene_graph.get_pose_bundle_output_port(),
                    converter->get_input_port(0));
   builder->Connect(*converter, *publisher);

--- a/geometry/geometry_visualization.h
+++ b/geometry/geometry_visualization.h
@@ -71,16 +71,17 @@ void ConnectDrakeVisualizer(systems::DiagramBuilder<double>* builder,
                             const SceneGraph<double>& scene_graph,
                             lcm::DrakeLcmInterface* lcm = nullptr);
 
-/** Explicitly dispatches an LCM load message based on the registered geometry.
- Normally this is done automatically at Simulator initialization. But if you
- have to do it yourself (likely because you are not using a Simulator), it
- should be invoked _after_ registration is complete. Typically this is used
+/** (Advanced) Explicitly dispatches an LCM load message based on the registered
+ geometry. Normally this is done automatically at Simulator initialization. But
+ if you have to do it yourself (likely because you are not using a Simulator),
+ it should be invoked _after_ registration is complete. Typically this is used
  after ConnectDrakeVisualizer() has been used to add visualization to the
- Diagram that contains the given `scene_graph`.
+ Diagram that contains the given `scene_graph`. The message goes to
+ LCM channel "DRAKE_VIEWER_LOAD_ROBOT".
 
  @see geometry::ConnectDrakeVisualizer() */
-void DispatchLoadMessage(const SceneGraph<double>& scene_graph,
-                         lcm::DrakeLcmInterface* lcm);
+void DispatchLoadMessage(
+    const SceneGraph<double>& scene_graph, lcm::DrakeLcmInterface* lcm);
 
 }  // namespace geometry
 }  // namespace drake

--- a/systems/lcm/BUILD.bazel
+++ b/systems/lcm/BUILD.bazel
@@ -63,7 +63,7 @@ drake_cc_library(
     ],
     deps = [
         ":translator",
-        "//lcm:interface",
+        "//lcm:real",
         "//systems/framework",
     ],
 )
@@ -134,6 +134,7 @@ drake_cc_googletest(
     deps = [
         ":lcm_pubsub_system",
         ":lcmt_drake_signal_translator",
+        "//common/test_utilities:is_dynamic_castable",
         "//lcm:lcmt_drake_signal_utils",
         "//lcm:mock",
         "//systems/analysis",

--- a/systems/lcm/lcm_publisher_system.h
+++ b/systems/lcm/lcm_publisher_system.h
@@ -14,11 +14,24 @@
 #include "drake/systems/lcm/serializer.h"
 
 namespace drake {
+
+// Forward-declare so we can keep a pointer to a DrakeLcm if needed.
+namespace lcm {
+class DrakeLcm;
+}  // namespace lcm
+
 namespace systems {
 namespace lcm {
 
 /**
  * Publishes an LCM message containing information from its input port.
+ * Optionally sends a one-time initialization message.
+ *
+ * @note You should generally provide an LCM interface yourself, since there
+ * should normally be just one of these typically-heavyweight objects per
+ * program. However, if you're sure there isn't any other need for an LCM
+ * interface in your program, you can let %LcmPublisherSystem allocate and
+ * maintain a drake::lcm::DrakeLcm object internally.
  *
  * @ingroup message_passing
  */
@@ -34,12 +47,15 @@ class LcmPublisherSystem : public LeafSystem<double> {
    *
    * @param[in] channel The LCM channel on which to publish.
    *
-   * @param lcm A non-null pointer to the LCM subsystem. The pointer must remain
-   * valid for the lifetime of this object.
+   * @param lcm A pointer to the LCM subsystem to use, which must
+   * remain valid for the lifetime of this object. If null, a
+   * drake::lcm::DrakeLcm object is allocated and maintained internally, but
+   * see the note in the class comments.
    */
   template <typename LcmMessage>
   static std::unique_ptr<LcmPublisherSystem> Make(
-      const std::string& channel, drake::lcm::DrakeLcmInterface* lcm) {
+      const std::string& channel,
+      drake::lcm::DrakeLcmInterface* lcm) {
     return std::make_unique<LcmPublisherSystem>(
         channel, std::make_unique<Serializer<LcmMessage>>(), lcm);
   }
@@ -54,8 +70,10 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * @param[in] serializer The serializer that converts between byte vectors
    * and LCM message objects.
    *
-   * @param lcm A non-null pointer to the LCM subsystem to publish on.
-   * The pointer must remain valid for the lifetime of this object.
+   * @param lcm A pointer to the LCM subsystem to use, which must
+   * remain valid for the lifetime of this object. If null, a
+   * drake::lcm::DrakeLcm object is allocated and maintained internally, but
+   * see the note in the class comments.
    */
   LcmPublisherSystem(const std::string& channel,
                      std::unique_ptr<SerializerInterface> serializer,
@@ -72,8 +90,10 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * objects and drake::systems::VectorBase objects. This reference must remain
    * valid for the lifetime of this object.
    *
-   * @param lcm A non-null pointer to the LCM subsystem to publish on.
-   * The pointer must remain valid for the lifetime of this object.
+   * @param lcm A pointer to the LCM subsystem to use, which must
+   * remain valid for the lifetime of this object. If null, a
+   * drake::lcm::DrakeLcm object is allocated and maintained internally, but
+   * see the note in the class comments.
    */
   LcmPublisherSystem(const std::string& channel,
                      const LcmAndVectorBaseTranslator& translator,
@@ -90,8 +110,10 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * translator for a particular LCM channel. This reference must remain
    * valid for the lifetime of this object.
    *
-   * @param lcm A non-null pointer to the LCM subsystem to publish on. The
-   * pointer must remain valid for the lifetime of this object.
+   * @param lcm A pointer to the LCM subsystem to use, which must
+   * remain valid for the lifetime of this object. If null, a
+   * drake::lcm::DrakeLcm object is allocated and maintained internally, but
+   * see the note in the class comments.
    */
   LcmPublisherSystem(const std::string& channel,
                      const LcmTranslatorDictionary& translator_dictionary,
@@ -99,9 +121,34 @@ class LcmPublisherSystem : public LeafSystem<double> {
 
   ~LcmPublisherSystem() override;
 
+  /**
+   * This is the type of an initialization message publisher that can be
+   * provided via AddInitializationMessage().
+   */
+  using InitializationPublisher = std::function<void(
+      const Context<double>& context, drake::lcm::DrakeLcmInterface* lcm)>;
+
+  /**
+   * Specifies a message-publishing function to be invoked once from an
+   * initialization event. If this method is not called, no initialization event
+   * will be created.
+   *
+   * You can only call this method once.
+   * @throws std::logic_error if called a second time.
+   *
+   * @pre The publisher function may not be null.
+   */
+  void AddInitializationMessage(
+      InitializationPublisher initialization_publisher);
+
+  /**
+   * Returns the channel name supplied during construction.
+   */
   const std::string& get_channel_name() const;
 
-  /// Returns the default name for a system that publishes @p channel.
+  /**
+   * Returns the default name for a system that publishes @p channel.
+   */
   static std::string make_name(const std::string& channel);
 
   /**
@@ -110,14 +157,6 @@ class LcmPublisherSystem : public LeafSystem<double> {
    * parameter `period`.
    */
   void set_publish_period(double period);
-
-  /**
-   * Takes the VectorBase from the input port of the context and publishes
-   * it onto an LCM channel.
-   */
-  void DoPublish(
-      const Context<double>& context,
-      const std::vector<const systems::PublishEvent<double>*>&) const override;
 
   /**
    * Returns the translator used by this publisher. This can be used to convert
@@ -129,7 +168,19 @@ class LcmPublisherSystem : public LeafSystem<double> {
    */
   const LcmAndVectorBaseTranslator& get_translator() const;
 
-  /// Returns the sole input port.
+  /**
+   * Returns a mutable reference to the LCM object in use by this publisher.
+   * This may have been supplied in the constructor or may be an
+   * internally-maintained object of type drake::lcm::DrakeLcm.
+   */
+  drake::lcm::DrakeLcmInterface& lcm() {
+    DRAKE_DEMAND(lcm_ != nullptr);
+    return *lcm_;
+  }
+
+  /**
+   * Returns the sole input port.
+   */
   const InputPort<double>& get_input_port() const {
     DRAKE_THROW_UNLESS(this->get_num_input_ports() == 1);
     return LeafSystem<double>::get_input_port(0);
@@ -145,14 +196,24 @@ class LcmPublisherSystem : public LeafSystem<double> {
   void get_output_port(int) = delete;
 
  private:
-  // All constructors delegate to here.
+  // All constructors delegate to here. If the lcm pointer is null, we'll
+  // allocate and maintain a DrakeLcm object internally.
   LcmPublisherSystem(const std::string& channel,
                      const LcmAndVectorBaseTranslator* translator,
                      std::unique_ptr<SerializerInterface> serializer,
                      drake::lcm::DrakeLcmInterface* lcm);
 
+  // Takes the VectorBase from the input port of the context and publishes
+  // it onto an LCM channel.
+  void DoPublish(
+      const Context<double>& context,
+      const std::vector<const systems::PublishEvent<double>*>&) const override;
+
   // The channel on which to publish LCM messages.
   const std::string channel_;
+
+  // Optionally, the method to call during initialization (empty if none).
+  InitializationPublisher initialization_publisher_;
 
   // Converts VectorBase objects into LCM message bytes.
   // Will be non-null iff our input port is vector-valued.
@@ -162,9 +223,14 @@ class LcmPublisherSystem : public LeafSystem<double> {
   // Will be non-null iff our input port is abstract-valued.
   std::unique_ptr<SerializerInterface> serializer_;
 
+  // If we're not given a DrakeLcm object, we allocate one and keep it here.
+  // The unique_ptr is const, not the held object.
+  std::unique_ptr<drake::lcm::DrakeLcm> const owned_lcm_;
+
   // A const pointer to an LCM subsystem. Note that while the pointer is const,
-  // the LCM subsystem is not const.
-  drake::lcm::DrakeLcmInterface* const lcm_{};
+  // the LCM subsystem is not const. This may refer to an externally-supplied
+  // object or the owned_lcm_ object above.
+  drake::lcm::DrakeLcmInterface* const lcm_;
 };
 
 }  // namespace lcm

--- a/systems/lcm/test/lcm_publisher_system_test.cc
+++ b/systems/lcm/test/lcm_publisher_system_test.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include "drake/common/test_utilities/is_dynamic_castable.h"
+#include "drake/lcm/drake_lcm.h"
 #include "drake/lcm/drake_mock_lcm.h"
 #include "drake/lcm/lcmt_drake_signal_utils.h"
 #include "drake/lcmt_drake_signal.hpp"
@@ -25,7 +27,9 @@ const int kDim = 10;
 const int kPortNumber = 0;
 
 using drake::lcm::CompareLcmtDrakeSignalMessages;
+using drake::lcm::DrakeLcmInterface;
 using drake::lcm::DrakeMockLcm;
+using drake::lcm::DrakeLcm;
 
 void TestPublisher(const std::string& channel_name, lcm::DrakeMockLcm* lcm,
                    LcmPublisherSystem* dut) {
@@ -82,6 +86,64 @@ void TestPublisher(const std::string& channel_name, lcm::DrakeMockLcm* lcm,
   EXPECT_EQ(
       lcm->get_last_publication_time(dut->get_channel_name()).value_or(-1.0),
       time);
+}
+
+// Test that failure to specify an LCM interface results in an internal one
+// of being allocated. Can't check for operation in this case
+// since we won't have a mock LCM to look at.
+GTEST_TEST(LcmPublisherSystemTest, DefaultLcmTest) {
+  const std::string channel_name = "junk";
+
+  // Use a translator just so we can invoke a constructor.
+  LcmtDrakeSignalTranslator translator(kDim);
+
+  // Provide an explicit LCM interface and check that it gets used.
+  DrakeMockLcm mock_lcm;
+  LcmPublisherSystem dut1(channel_name, translator, &mock_lcm);
+  EXPECT_EQ(&dut1.lcm(), &mock_lcm);
+
+  // Now leave out the LCM interface and check that a DrakeLcm gets allocated.
+  LcmPublisherSystem dut2(channel_name, translator, nullptr);
+  EXPECT_TRUE(is_dynamic_castable<DrakeLcm>(&dut2.lcm()));
+}
+
+// Test that an initialization publisher gets invoked properly by an
+// initialization event, and that the initialization event doesn't cause
+// publishing.
+GTEST_TEST(LcmPublisherSystemTest, TestInitializationEvent) {
+  const std::string channel_name = "junk";
+
+  // Use a translator just so we can invoke a constructor.
+  LcmtDrakeSignalTranslator translator(kDim);
+
+  DrakeMockLcm mock_lcm;
+  LcmPublisherSystem dut1(channel_name, translator, &mock_lcm);
+
+  bool init_was_called{false};
+  dut1.AddInitializationMessage([&dut1, &init_was_called](
+      const Context<double>&, DrakeLcmInterface* lcm) {
+    EXPECT_EQ(lcm, &dut1.lcm());
+    init_was_called = true;
+  });
+
+  auto context = dut1.AllocateContext();
+
+  // Put something on the input port so that an attempt to publish would
+  // succeed if (erroneously) attempted after initialization.
+  auto vec = make_unique<BasicVector<double>>(kDim);
+  for (int i = 0; i < kDim; ++i) (*vec)[i] = i;
+  context->FixInputPort(kPortNumber, std::move(vec));
+
+  // Get the initialization event and publish it (this is mocking
+  // Simulator::Initialize() behavior.
+  auto init_events = dut1.AllocateCompositeEventCollection();
+  dut1.GetInitializationEvents(*context, &*init_events);
+  dut1.Publish(*context, init_events->get_publish_events());
+
+  EXPECT_TRUE(init_was_called);
+
+  // Nothing should have been published to this channel.
+  EXPECT_FALSE(mock_lcm.get_last_publication_time(channel_name));
 }
 
 // Tests LcmPublisherSystem using a translator.


### PR DESCRIPTION
This is a follow-on to #9337 to simplify the Diagram that gets built when visualization is used with a SceneGraph-using Diagram.

The internal LcmInitSystem added in #9337 is removed with its functionality absorbed by LcmPublisher:
- it can now maintain its own DrakeLcm object if none is provided on construction, and
- it can hold an initialization message publisher which gets invoked by the Simulator at initialization.

Resolves #9397.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9403)
<!-- Reviewable:end -->
