### PR TITLE
make pydrake.systems.drawing.plot_graphviz work on mac

### DIFF
--- a/bindings/pydrake/systems/BUILD.bazel
+++ b/bindings/pydrake/systems/BUILD.bazel
@@ -270,6 +270,8 @@ drake_py_unittest(
 drake_py_binary(
     name = "drawing_graphviz_example",
     srcs = ["drawing_graphviz_example.py"],
+    add_test_rule = 1,
+    test_rule_args = ["--test"],
     deps = [
         ":drawing_py",
         ":framework_py",

--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -4,9 +4,7 @@ Provides general visualization utilities. This is NOT related to `rendering`.
 installed.
 """
 
-from StringIO import StringIO
-
-import matplotlib.image as mpimg
+from tempfile import NamedTemporaryFile
 import matplotlib.pyplot as plt
 import pydot
 
@@ -28,11 +26,11 @@ def plot_graphviz(dot_text):
         # Handle this case for now.
         assert len(g) == 1
         g = g[0]
-    s = StringIO()
-    g.write_png(s)
-    s.seek(0)
+    f = NamedTemporaryFile(suffix='.png')
+    g.write_png(f.name)
     plt.axis('off')
-    return plt.imshow(plt.imread(s), aspect="equal")
+
+    return plt.imshow(plt.imread(f.name), aspect="equal")
 
 
 def plot_system_graphviz(system):

--- a/bindings/pydrake/systems/drawing.py
+++ b/bindings/pydrake/systems/drawing.py
@@ -5,6 +5,7 @@ installed.
 """
 
 from tempfile import NamedTemporaryFile
+from pydrake.common import temp_directory
 import matplotlib.pyplot as plt
 import pydot
 
@@ -26,7 +27,7 @@ def plot_graphviz(dot_text):
         # Handle this case for now.
         assert len(g) == 1
         g = g[0]
-    f = NamedTemporaryFile(suffix='.png')
+    f = NamedTemporaryFile(suffix='.png', dir=temp_directory())
     g.write_png(f.name)
     plt.axis('off')
 

--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -4,10 +4,20 @@ from pydrake.systems.drawing import plot_system_graphviz
 from pydrake.systems.framework import DiagramBuilder
 from pydrake.systems.primitives import Adder
 
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--test",
+                    action='store_true',
+                    help="Causes the script will run without blocking for "
+                         "user input.",
+                    default=False)
+args = parser.parse_args()
+
 builder = DiagramBuilder()
 size = 1
 adders = [
-    builder.AddSystem(Adder(1, size)),
+    builder.AddSystem(Adder(2, size)),
     builder.AddSystem(Adder(1, size)),
 ]
 for i, adder in enumerate(adders):
@@ -20,4 +30,6 @@ diagram = builder.Build()
 diagram.set_name("graphviz_example")
 
 plot_system_graphviz(diagram)
-plt.show()
+
+if not args.test:
+    plt.show()


### PR DESCRIPTION
pydot on mac could not accept a file object as an argument to write_png(); and it seems that no newer version of pydot is easily available.  replacing StringIO with NamedTemporaryFile is seems like a general solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9417)
<!-- Reviewable:end -->
