### PR TITLE
Refactors model() --> tree(). Deprecates model().

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -357,10 +357,18 @@ void init_multibody_plant(py::module m) {
     cls
         .def("world_body", &Class::world_body, py_reference_internal)
         .def("world_frame", &Class::world_frame, py_reference_internal)
-        .def("model", &Class::model, py_reference_internal)
+        .def("tree", &Class::tree, py_reference_internal)
         .def("is_finalized", &Class::is_finalized)
         .def("Finalize", py::overload_cast<SceneGraph<T>*>(&Class::Finalize),
              py::arg("scene_graph") = nullptr);
+    // Add deprecated methods.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    cls.def("model", &Class::model, py_reference_internal);
+#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
+    cls.attr("message_model") = "Please use tree().";
+    DeprecateAttribute(
+        cls, "model", cls.attr("message_model"));
   }
 }
 

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -171,7 +171,7 @@ class TestMultibodyTree(unittest.TestCase):
         AddModelFromSdfFile(file_name, plant)
         plant.Finalize()
         context = plant.CreateDefaultContext()
-        tree = plant.model()
+        tree = plant.tree()
         world_frame = plant.world_frame()
         # TODO(eric.cousineau): Replace this with `GetFrameByName`.
         link1_frame = plant.GetBodyByName("Link1").body_frame()

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -89,7 +89,7 @@ void DoMain() {
 
   // constant force input
   VectorX<double> constant_load_value = VectorX<double>::Ones(
-      plant.model().num_actuators()) * FLAGS_constant_load;
+      plant.tree().num_actuators()) * FLAGS_constant_load;
   auto constant_source =
      builder.AddSystem<systems::ConstantVectorSource<double>>(
       constant_load_value);

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -73,7 +73,7 @@ int do_main() {
 
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeBouncingBallPlant(
       radius, mass, coulomb_friction, -g * Vector3d::UnitZ(), &scene_graph));
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& tree = plant.tree();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(0.001);
 
@@ -109,13 +109,13 @@ int do_main() {
   // Set at height z0 with random orientation.
   std::mt19937 generator(41);
   std::uniform_real_distribution<double> uniform(-1.0, 1.0);
-  model.SetDefaultContext(&plant_context);
+  tree.SetDefaultContext(&plant_context);
   Matrix3d R_WB = math::UniformlyRandomRotationMatrix(&generator).matrix();
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.linear() = R_WB;
   X_WB.translation() = Vector3d(0.0, 0.0, z0);
-  model.SetFreeBodyPoseOrThrow(
-      model.GetBodyByName("Ball"), X_WB, &plant_context);
+  tree.SetFreeBodyPoseOrThrow(
+      tree.GetBodyByName("Ball"), X_WB, &plant_context);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
 

--- a/examples/multibody/cart_pole/test/cart_pole_test.cc
+++ b/examples/multibody/cart_pole/test/cart_pole_test.cc
@@ -120,7 +120,7 @@ TEST_F(CartPoleTest, MassMatrix) {
 
   Matrix2<double> M;
   pole_pin_->set_angle(context_.get(), theta);
-  cart_pole_.model().CalcMassMatrixViaInverseDynamics(*context_, &M);
+  cart_pole_.tree().CalcMassMatrixViaInverseDynamics(*context_, &M);
   Matrix2<double> M_expected = CartPoleHandWritenMassMatrix(theta);
 
   // Matrix verified to this tolerance.

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -83,7 +83,7 @@ int do_main() {
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeCylinderPlant(
       radius, length, mass, coulomb_friction, -g * Vector3d::UnitZ(),
       FLAGS_time_step, &scene_graph));
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& tree = plant.tree();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(FLAGS_penetration_allowance);
   plant.set_stiction_tolerance(FLAGS_stiction_tolerance);
@@ -126,13 +126,13 @@ int do_main() {
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
   // Set at height z0.
-  model.SetDefaultContext(&plant_context);
+  tree.SetDefaultContext(&plant_context);
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.translation() = Vector3d(0.0, 0.0, FLAGS_z0);
-  const auto& cylinder = model.GetBodyByName("Cylinder");
-  model.SetFreeBodyPoseOrThrow(
+  const auto& cylinder = tree.GetBodyByName("Cylinder");
+  tree.SetFreeBodyPoseOrThrow(
       cylinder, X_WB, &plant_context);
-  model.SetFreeBodySpatialVelocityOrThrow(
+  tree.SetFreeBodySpatialVelocityOrThrow(
       cylinder,
       SpatialVelocity<double>(
           Vector3<double>(FLAGS_wx0, 0.0, 0.0),

--- a/examples/multibody/cylinder_with_multicontact/test/make_cylinder_plant_test.cc
+++ b/examples/multibody/cylinder_with_multicontact/test/make_cylinder_plant_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(MakeCylinderPlant, VerifyPlant) {
 
   ASSERT_TRUE(plant->HasBodyNamed("Cylinder"));
   const RigidBody<double>& cylinder =
-      plant->model().GetRigidBodyByName("Cylinder");
+      plant->tree().GetRigidBodyByName("Cylinder");
   EXPECT_EQ(cylinder.get_default_mass(), mass);
 
   // Verify the value of the inertial properties for the cylinder.

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -62,7 +62,7 @@ int do_main() {
   DRAKE_DEMAND(FLAGS_time_step >= 0);
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeInclinedPlanePlant(
       radius, mass, slope, surface_friction, g, FLAGS_time_step, &scene_graph));
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& tree = plant.tree();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(1.0e-5);
   plant.set_stiction_tolerance(FLAGS_stiction_tolerance);
@@ -92,7 +92,7 @@ int do_main() {
 
   // This will set a default initial condition with the sphere located at
   // p_WBcm = (0; 0; 0) and zero spatial velocity.
-  model.SetDefaultContext(&plant_context);
+  tree.SetDefaultContext(&plant_context);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
 

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -338,7 +338,7 @@ int do_main() {
 
   // Initialize the mug pose to be right in the middle between the fingers.
   std::vector<Isometry3d> X_WB_all;
-  plant.model().CalcAllBodyPosesInWorld(plant_context, &X_WB_all);
+  plant.tree().CalcAllBodyPosesInWorld(plant_context, &X_WB_all);
   const Vector3d& p_WBr = X_WB_all[right_finger.index()].translation();
   const Vector3d& p_WBl = X_WB_all[left_finger.index()].translation();
   const double mug_y_W = (p_WBr(1) + p_WBl(1)) / 2.0;
@@ -349,7 +349,7 @@ int do_main() {
                (FLAGS_rz * M_PI / 180) + M_PI);
   X_WM.linear() = RotationMatrix<double>(RollPitchYaw<double>(rpy)).matrix();
   X_WM.translation() = Vector3d(0.0, mug_y_W, 0.0);
-  plant.model().SetFreeBodyPoseOrThrow(mug, X_WM, &plant_context);
+  plant.tree().SetFreeBodyPoseOrThrow(mug, X_WM, &plant_context);
 
   // Set the initial height of the gripper and its initial velocity so that with
   // the applied harmonic forces it continues to move in a harmonic oscillation

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -11,7 +11,7 @@ InverseKinematics::InverseKinematics(
     const multibody_plant::MultibodyPlant<double>& plant)
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
-      tree_(plant_.model().ToAutoDiffXd()),
+      tree_(plant_.tree().ToAutoDiffXd()),
       context_(tree_->CreateDefaultContext()),
       q_(prog_->NewContinuousVariables(plant_.num_positions(), "q")) {
   // TODO(hongkai.dai) Add joint limit constraint here.

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
@@ -19,7 +19,7 @@ ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
     : systems::LeafSystem<T>() {
   DRAKE_DEMAND(plant.is_finalized());
   const int body_count = plant.num_bodies();
-  const MultibodyTree<T>& model = plant.model();
+  const MultibodyTree<T>& model = plant.tree();
 
   body_names_.reserve(body_count);
   using std::to_string;

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -226,7 +226,7 @@ MultibodyPlant<T>::MultibodyPlant(double time_step) :
         drake::multibody::multibody_plant::MultibodyPlant>()),
     time_step_(time_step) {
   DRAKE_THROW_UNLESS(time_step >= 0);
-  model_ = std::make_unique<MultibodyTree<T>>();
+  tree_ = std::make_unique<MultibodyTree<T>>();
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
 }
@@ -430,7 +430,7 @@ geometry::GeometryId MultibodyPlant<T>::RegisterAnchoredGeometry(
 
 template<typename T>
 void MultibodyPlant<T>::Finalize(geometry::SceneGraph<T>* scene_graph) {
-  model_->Finalize();
+  tree_->Finalize();
   FilterAdjacentBodies(scene_graph);
   ExcludeCollisionsWithVisualGeometry(scene_graph);
   FinalizePlantOnly();
@@ -438,7 +438,7 @@ void MultibodyPlant<T>::Finalize(geometry::SceneGraph<T>* scene_graph) {
 
 template<typename T>
 void MultibodyPlant<T>::SetUpJointLimitsParameters() {
-  for (JointIndex joint_index(0); joint_index < model().num_joints();
+  for (JointIndex joint_index(0); joint_index < tree().num_joints();
        ++joint_index) {
     // Currently MultibodyPlant applies these "compliant" joint limit forces
     // using an explicit Euler strategy. Stability analysis of the explicit
@@ -450,7 +450,7 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
     // the time stepping scheme is updated to be implicit in the joint limits.
     const double kAlpha = 20 * M_PI;
 
-    const Joint<T>& joint = model().get_joint(joint_index);
+    const Joint<T>& joint = tree().get_joint(joint_index);
     auto revolute_joint = dynamic_cast<const RevoluteJoint<T>*>(&joint);
     auto prismatic_joint = dynamic_cast<const PrismaticJoint<T>*>(&joint);
     // Currently MBP only supports limits for prismatic and revolute joints.
@@ -518,7 +518,7 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
           throw std::logic_error(
               "Currently MultibodyPlant does not handle joint limits for "
               "continuous models. However a limit was specified for joint `"
-              "`" + model().get_joint(index).name() + "`.");
+              "`" + tree().get_joint(index).name() + "`.");
         }
       }
     }
@@ -571,8 +571,8 @@ void MultibodyPlant<T>::FilterAdjacentBodies(SceneGraph<T>* scene_graph) {
     }
     // Disallow collisions between adjacent bodies. Adjacency is implied by the
     // existence of a joint between bodies.
-    for (JointIndex j{0}; j < model_->num_joints(); ++j) {
-      const Joint<T>& joint = model_->get_joint(j);
+    for (JointIndex j{0}; j < tree_->num_joints(); ++j) {
+      const Joint<T>& joint = tree_->get_joint(j);
       const Body<T>& child = joint.child_body();
       const Body<T>& parent = joint.parent_body();
       // TODO(SeanCurtis-TRI): Determine the correct action for a body
@@ -620,7 +620,7 @@ std::unique_ptr<systems::LeafContext<T>>
 MultibodyPlant<T>::DoMakeLeafContext() const {
   DRAKE_THROW_UNLESS(is_finalized());
   return std::make_unique<MultibodyTreeContext<T>>(
-      model_->get_topology(), is_discrete());
+      tree_->get_topology(), is_discrete());
 }
 
 template<typename T>
@@ -637,9 +637,9 @@ MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
     const GeometryId geometryB_id = point_pair.id_B;
 
     BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
-    const Body<T>& bodyA = model().get_body(bodyA_index);
+    const Body<T>& bodyA = tree().get_body(bodyA_index);
     BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
-    const Body<T>& bodyB = model().get_body(bodyB_index);
+    const Body<T>& bodyB = tree().get_body(bodyB_index);
 
     // Penetration depth, > 0 if bodies interpenetrate.
     const Vector3<T>& nhat_BA_W = point_pair.nhat_BA_W;
@@ -650,13 +650,13 @@ MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
     // body A, s.t.: v_WAc = Jv_WAc * v
     // where v is the vector of generalized velocities.
     MatrixX<T> Jv_WAc(3, this->num_velocities());
-    model().CalcPointsGeometricJacobianExpressedInWorld(
+    tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, bodyA.body_frame(), p_WCa, &Jv_WAc);
 
     // Geometric Jacobian for the velocity of the contact point C as moving with
     // body B, s.t.: v_WBc = Jv_WBc * v.
     MatrixX<T> Jv_WBc(3, this->num_velocities());
-    model().CalcPointsGeometricJacobianExpressedInWorld(
+    tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, bodyB.body_frame(), p_WCb, &Jv_WBc);
 
     // The velocity of Bc relative to Ac is
@@ -692,9 +692,9 @@ MatrixX<T> MultibodyPlant<T>::CalcTangentVelocitiesJacobian(
     const GeometryId geometryB_id = point_pair.id_B;
 
     BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
-    const Body<T>& bodyA = model().get_body(bodyA_index);
+    const Body<T>& bodyA = tree().get_body(bodyA_index);
     BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
-    const Body<T>& bodyB = model().get_body(bodyB_index);
+    const Body<T>& bodyB = tree().get_body(bodyB_index);
 
     // Penetration depth, > 0 if bodies interpenetrate.
     const T& x = point_pair.depth;
@@ -721,11 +721,11 @@ MatrixX<T> MultibodyPlant<T>::CalcTangentVelocitiesJacobian(
     // in the limit to rigid contact, Ac = Bc.
 
     MatrixX<T> Jv_WAc(3, this->num_velocities());  // s.t.: v_WAc = Jv_WAc * v.
-    model().CalcPointsGeometricJacobianExpressedInWorld(
+    tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, bodyA.body_frame(), p_WCa, &Jv_WAc);
 
     MatrixX<T> Jv_WBc(3, this->num_velocities());  // s.t.: v_WBc = Jv_WBc * v.
-    model().CalcPointsGeometricJacobianExpressedInWorld(
+    tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, bodyB.body_frame(), p_WCb, &Jv_WBc);
 
     // The velocity of Bc relative to Ac is
@@ -760,7 +760,7 @@ void MultibodyPlant<T>::set_penetration_allowance(
   // system.
   double mass = 0.0;
   for (BodyIndex body_index(0); body_index < num_bodies(); ++body_index) {
-    const Body<T>& body = model().get_body(body_index);
+    const Body<T>& body = tree().get_body(body_index);
     mass = std::max(mass, body.get_default_mass());
   }
 
@@ -935,9 +935,9 @@ void MultibodyPlant<T>::CalcAndAddContactForcesByPenaltyMethod(
     BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
 
     BodyNodeIndex bodyA_node_index =
-        model().get_body(bodyA_index).node_index();
+        tree().get_body(bodyA_index).node_index();
     BodyNodeIndex bodyB_node_index =
-        model().get_body(bodyB_index).node_index();
+        tree().get_body(bodyB_index).node_index();
 
     // Penetration depth, > 0 during pair.
     const T& x = pair.depth;
@@ -1032,7 +1032,7 @@ void MultibodyPlant<T>::AddJointActuationForces(
     for (JointActuatorIndex actuator_index(0);
          actuator_index < num_actuators(); ++actuator_index) {
       const JointActuator<T>& actuator =
-          model().get_joint_actuator(actuator_index);
+          tree().get_joint_actuator(actuator_index);
       // We only support actuators on single dof joints for now.
       DRAKE_DEMAND(actuator.joint().num_velocities() == 1);
       for (int joint_dof = 0;
@@ -1078,7 +1078,7 @@ void MultibodyPlant<T>::AddJointLimitsPenaltyForces(
     const double upper_limit = joint_limits_parameters_.upper_limit[index];
     const double stiffness = joint_limits_parameters_.stiffness[index];
     const double damping = joint_limits_parameters_.damping[index];
-    const Joint<T>& joint = model().get_joint(joint_index);
+    const Joint<T>& joint = tree().get_joint(joint_index);
 
     const T& q = joint.GetOnePosition(context);
     const T& v = joint.GetOneVelocity(context);
@@ -1099,7 +1099,7 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_dofs =
-        model_->num_actuated_dofs(model_instance_index);
+        tree_->num_actuated_dofs(model_instance_index);
     if (instance_num_dofs == 0) {
       continue;
     }
@@ -1129,9 +1129,9 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
   // Mass matrix.
   MatrixX<T> M(nv, nv);
   // Forces.
-  MultibodyForces<T> forces(*model_);
+  MultibodyForces<T> forces(*tree_);
   // Bodies' accelerations, ordered by BodyNodeIndex.
-  std::vector<SpatialAcceleration<T>> A_WB_array(model_->num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(tree_->num_bodies());
   // Generalized accelerations.
   VectorX<T> vdot = VectorX<T>::Zero(nv);
 
@@ -1140,12 +1140,12 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
 
   // Compute forces applied through force elements. This effectively resets
   // the forces to zero and adds in contributions due to force elements.
-  model_->CalcForceElementsContribution(context, pc, vc, &forces);
+  tree_->CalcForceElementsContribution(context, pc, vc, &forces);
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context, &forces);
 
-  model_->CalcMassMatrixViaInverseDynamics(context, &M);
+  tree_->CalcMassMatrixViaInverseDynamics(context, &M);
 
   // WARNING: to reduce memory foot-print, we use the input applied arrays also
   // as output arrays. This means that both the array of applied body forces and
@@ -1166,7 +1166,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
         context, pc, vc, point_pairs, &F_BBo_W_array);
   }
 
-  model_->CalcInverseDynamics(
+  tree_->CalcInverseDynamics(
       context, pc, vc, vdot,
       F_BBo_W_array, tau_array,
       &A_WB_array,
@@ -1178,7 +1178,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
   auto v = x.bottomRows(nv);
   VectorX<T> xdot(this->num_multibody_states());
   VectorX<T> qdot(this->num_positions());
-  model_->MapVelocityToQDot(context, v, &qdot);
+  tree_->MapVelocityToQDot(context, v, &qdot);
   xdot << qdot, vdot;
   derivatives->SetFromVector(xdot);
 }
@@ -1254,17 +1254,17 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // Mass matrix and its factorization.
   MatrixX<T> M0(nv, nv);
-  model_->CalcMassMatrixViaInverseDynamics(context0, &M0);
+  tree_->CalcMassMatrixViaInverseDynamics(context0, &M0);
   auto M0_ldlt = M0.ldlt();
 
   // Forces at the previous time step.
-  MultibodyForces<T> forces0(*model_);
+  MultibodyForces<T> forces0(*tree_);
 
   const PositionKinematicsCache<T>& pc0 = EvalPositionKinematics(context0);
   const VelocityKinematicsCache<T>& vc0 = EvalVelocityKinematics(context0);
 
   // Compute forces applied through force elements.
-  model_->CalcForceElementsContribution(context0, pc0, vc0, &forces0);
+  tree_->CalcForceElementsContribution(context0, pc0, vc0, &forces0);
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context0, &forces0);
@@ -1277,7 +1277,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // Workspace for inverse dynamics:
   // Bodies' accelerations, ordered by BodyNodeIndex.
-  std::vector<SpatialAcceleration<T>> A_WB_array(model_->num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(tree_->num_bodies());
   // Generalized accelerations.
   VectorX<T> vdot = VectorX<T>::Zero(nv);
   // Body forces (alias to forces0).
@@ -1286,7 +1286,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   // With vdot = 0, this computes:
   //   -tau = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
   VectorX<T>& minus_tau = forces0.mutable_generalized_forces();
-  model_->CalcInverseDynamics(
+  tree_->CalcInverseDynamics(
       context0, pc0, vc0, vdot,
       F_BBo_W_array, minus_tau,
       &A_WB_array,
@@ -1373,7 +1373,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> v_next = implicit_stribeck_solver_->get_generalized_velocities();
 
   VectorX<T> qdot_next(this->num_positions());
-  model_->MapVelocityToQDot(context0, v_next, &qdot_next);
+  tree_->MapVelocityToQDot(context0, v_next, &qdot_next);
   VectorX<T> q_next = q0 + dt * qdot_next;
 
   VectorX<T> x_next(this->num_multibody_states());
@@ -1392,15 +1392,15 @@ void MultibodyPlant<T>::DoMapQDotToVelocity(
     const Eigen::Ref<const VectorX<T>>& qdot,
     systems::VectorBase<T>* generalized_velocity) const {
   if (is_discrete()) return;
-  const int nq = model_->num_positions();
-  const int nv = model_->num_velocities();
+  const int nq = tree_->num_positions();
+  const int nv = tree_->num_velocities();
 
   DRAKE_ASSERT(qdot.size() == nq);
   DRAKE_DEMAND(generalized_velocity != nullptr);
   DRAKE_DEMAND(generalized_velocity->size() == nv);
 
   VectorX<T> v(nv);
-  model_->MapQDotToVelocity(context, qdot, &v);
+  tree_->MapQDotToVelocity(context, qdot, &v);
   generalized_velocity->SetFromVector(v);
 }
 
@@ -1410,15 +1410,15 @@ void MultibodyPlant<T>::DoMapVelocityToQDot(
     const Eigen::Ref<const VectorX<T>>& generalized_velocity,
     systems::VectorBase<T>* positions_derivative) const {
   if (is_discrete()) return;
-  const int nq = model_->num_positions();
-  const int nv = model_->num_velocities();
+  const int nq = tree_->num_positions();
+  const int nv = tree_->num_velocities();
 
   DRAKE_ASSERT(generalized_velocity.size() == nv);
   DRAKE_DEMAND(positions_derivative != nullptr);
   DRAKE_DEMAND(positions_derivative->size() == nq);
 
   VectorX<T> qdot(nq);
-  model_->MapVelocityToQDot(context, generalized_velocity, &qdot);
+  tree_->MapVelocityToQDot(context, generalized_velocity, &qdot);
   positions_derivative->SetFromVector(qdot);
 }
 
@@ -1432,9 +1432,9 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     this->DeclareDiscreteState(num_multibody_states());
   } else {
     this->DeclareContinuousState(
-        BasicVector<T>(model_->num_states()),
-        model_->num_positions(),
-        model_->num_velocities(), 0 /* num_z */);
+        BasicVector<T>(tree_->num_states()),
+        tree_->num_positions(),
+        tree_->num_velocities(), 0 /* num_z */);
   }
 
   // Declare per model instance actuation ports.
@@ -1444,7 +1444,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_dofs =
-        model_->num_actuated_dofs(model_instance_index);
+        tree_->num_actuated_dofs(model_instance_index);
     if (instance_num_dofs == 0) {
       continue;
     }
@@ -1470,7 +1470,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_states =
-        model_->num_states(model_instance_index);
+        tree_->num_states(model_instance_index);
     if (instance_num_states == 0) {
       continue;
     }
@@ -1490,7 +1490,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_velocities =
-        model_->num_velocities(model_instance_index);
+        tree_->num_velocities(model_instance_index);
     if (instance_num_velocities == 0) {
       continue;
     }
@@ -1537,12 +1537,12 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
   VectorX<T> continuous_state_vector =
       GetStateVector(context).CopyToVector();
 
-  VectorX<T> instance_state_vector(model_->num_states(model_instance));
+  VectorX<T> instance_state_vector(tree_->num_states(model_instance));
   instance_state_vector.head(num_positions(model_instance)) =
-      model_->get_positions_from_array(
+      tree_->get_positions_from_array(
           model_instance, continuous_state_vector.head(num_positions()));
   instance_state_vector.tail(num_velocities(model_instance)) =
-      model_->get_velocities_from_array(
+      tree_->get_velocities_from_array(
           model_instance, continuous_state_vector.tail(num_velocities()));
 
   state_vector->set_value(instance_state_vector);
@@ -1566,7 +1566,7 @@ void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
   // Generalized velocities and generalized forces are ordered in the same way.
   // Thus we can call get_velocities_from_array().
   const VectorX<T> instance_tau_contact =
-      model_->get_velocities_from_array(model_instance, tau_contact);
+      tree_->get_velocities_from_array(model_instance, tau_contact);
 
   tau_vector->set_value(instance_tau_contact);
 }
@@ -1606,7 +1606,7 @@ MultibodyPlant<T>::get_continuous_state_output_port(
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(model_instance.is_valid());
   DRAKE_THROW_UNLESS(model_instance < num_model_instances());
-  DRAKE_THROW_UNLESS(model_->num_states(model_instance) > 0);
+  DRAKE_THROW_UNLESS(tree_->num_states(model_instance) > 0);
   return this->get_output_port(
       instance_continuous_state_output_ports_.at(model_instance));
 }
@@ -1619,7 +1619,7 @@ MultibodyPlant<T>::get_generalized_contact_forces_output_port(
   DRAKE_THROW_UNLESS(is_discrete());
   DRAKE_THROW_UNLESS(model_instance.is_valid());
   DRAKE_THROW_UNLESS(model_instance < num_model_instances());
-  DRAKE_THROW_UNLESS(model_->num_states(model_instance) > 0);
+  DRAKE_THROW_UNLESS(tree_->num_states(model_instance) > 0);
   return this->get_output_port(
       instance_generalized_contact_forces_output_ports_.at(model_instance));
 }
@@ -1661,7 +1661,7 @@ void MultibodyPlant<T>::CalcFramePoseOutput(
   poses->clear();
   for (const auto it : body_index_to_frame_id_) {
     const BodyIndex body_index = it.first;
-    const Body<T>& body = model_->get_body(body_index);
+    const Body<T>& body = tree_->get_body(body_index);
 
     // NOTE: The GeometryFrames for each body were registered in the world
     // frame, so we report poses in the world frame.
@@ -1689,13 +1689,13 @@ MultibodyPlant<T>::get_geometry_query_input_port() const {
 template<typename T>
 const PositionKinematicsCache<T>& MultibodyPlant<T>::EvalPositionKinematics(
     const systems::Context<T>& context) const {
-  return model_->EvalPositionKinematics(context);
+  return tree_->EvalPositionKinematics(context);
 }
 
 template<typename T>
 const VelocityKinematicsCache<T>& MultibodyPlant<T>::EvalVelocityKinematics(
     const systems::Context<T>& context) const {
-  return model_->EvalVelocityKinematics(context);
+  return tree_->EvalVelocityKinematics(context);
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "drake/common/drake_deprecated.h"
 #include "drake/common/drake_optional.h"
 #include "drake/common/nice_type_name.h"
 #include "drake/geometry/geometry_set.h"
@@ -199,7 +200,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       systems::LeafSystem<T>(systems::SystemTypeTag<
           drake::multibody::multibody_plant::MultibodyPlant>()) {
     DRAKE_THROW_UNLESS(other.is_finalized());
-    model_ = other.model_->template CloneToScalar<T>();
+    tree_ = other.tree_->template CloneToScalar<T>();
     time_step_ = other.time_step_;
     // Copy of all members related with geometry registration.
     source_id_ = other.source_id_;
@@ -220,45 +221,45 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// which is always part of the model.
   /// @see AddRigidBody().
   int num_bodies() const {
-    return model_->num_bodies();
+    return tree_->num_bodies();
   }
 
   /// Returns the number of joints in the model.
   /// @see AddJoint().
   int num_joints() const {
-    return model_->num_joints();
+    return tree_->num_joints();
   }
 
   /// Returns the number of joint actuators in the model.
   /// @see AddJointActuator().
   int num_actuators() const {
-    return model_->num_actuators();
+    return tree_->num_actuators();
   }
 
   /// Returns the number of model instances in the model.
   /// @see AddModelInstance().
   int num_model_instances() const {
-    return model_->num_model_instances();
+    return tree_->num_model_instances();
   }
 
   /// Returns the size of the generalized position vector `q` for `this`
   /// %MultibodyPlant.
-  int num_positions() const { return model_->num_positions(); }
+  int num_positions() const { return tree_->num_positions(); }
 
   /// Returns the size of the generalized position vector `q` for a specific
   /// model instance.
   int num_positions(ModelInstanceIndex model_instance) const {
-    return model_->num_positions(model_instance);
+    return tree_->num_positions(model_instance);
   }
 
   /// Returns the size of the generalized velocity vector `v` for `this`
   /// %MultibodyPlant.
-  int num_velocities() const { return model_->num_velocities(); }
+  int num_velocities() const { return tree_->num_velocities(); }
 
   /// Returns the size of the generalized velocity vector `v` for a specific
   /// model instance.
   int num_velocities(ModelInstanceIndex model_instance) const {
-    return model_->num_velocities(model_instance);
+    return tree_->num_velocities(model_instance);
   }
 
   /// Returns the size of the multibody system state vector `x = [q; v]` for
@@ -268,18 +269,18 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// Notice however that the state of a %MultibodyPlant, stored in its Context,
   /// can actually contain other variables such as integrated power and discrete
   /// states.
-  int num_multibody_states() const { return model_->num_states(); }
+  int num_multibody_states() const { return tree_->num_states(); }
 
   /// Returns the total number of actuated degrees of freedom.
   /// That is, the vector of actuation values u has this size.
   /// See AddJointActuator().
-  int num_actuated_dofs() const { return model_->num_actuated_dofs(); }
+  int num_actuated_dofs() const { return tree_->num_actuated_dofs(); }
 
   /// Returns the total number of actuated degrees of freedom for a specific
   /// model instance.  That is, the vector of actuation values u has this size.
   /// See AddJointActuator().
   int num_actuated_dofs(ModelInstanceIndex model_instance) const {
-    return model_->num_actuated_dofs(model_instance);
+    return tree_->num_actuated_dofs(model_instance);
   }
 
   /// @name Adding new multibody elements
@@ -322,7 +323,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    const RigidBody<T>& body = model_->AddRigidBody(
+    const RigidBody<T>& body = tree_->AddRigidBody(
         name, model_instance, M_BBo_B);
     // Each entry of visual_geometries_, ordered by body index, contains a
     // std::vector of geometry ids for that body. The emplace_back() below
@@ -382,7 +383,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///          remain valid for the lifetime of `this` %MultibodyPlant.
   template <template<typename> class FrameType>
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame) {
-    return model_->AddFrame(std::move(frame));
+    return tree_->AddFrame(std::move(frame));
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
@@ -392,7 +393,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint) {
     static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
                   "JointType must be a sub-class of Joint<T>.");
-    return model_->AddJoint(std::move(joint));
+    return tree_->AddJoint(std::move(joint));
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
@@ -472,7 +473,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const Body<T>& child, const optional<Isometry3<double>>& X_BM,
       Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    return model_->template AddJoint<JointType>(
+    return tree_->template AddJoint<JointType>(
         name, parent, X_PF, child, X_BM, std::forward<Args>(args)...);
   }
 
@@ -502,7 +503,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
 #endif
   AddForceElement(Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    return model_->template AddForceElement<ForceElementType>(
+    return tree_->template AddForceElement<ForceElementType>(
         std::forward<Args>(args)...);
   }
 
@@ -518,7 +519,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     // We save the force element so that we can grant users access to it for
     // gravity field specific queries.
     gravity_field_ =
-        &model_->template AddForceElement<UniformGravityFieldElement>(
+        &tree_->template AddForceElement<UniformGravityFieldElement>(
             std::forward<Args>(args)...);
     return *gravity_field_.value();
   }
@@ -541,7 +542,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   const JointActuator<T>& AddJointActuator(
       const std::string& name, const Joint<T>& joint) {
     DRAKE_THROW_UNLESS(joint.num_velocities() == 1);
-    return model_->AddJointActuator(name, joint);
+    return tree_->AddJointActuator(name, joint);
   }
 
   /// Creates a new model instance.  Returns the index for the model
@@ -552,7 +553,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///   model. An exception is thrown if an instance with the same name
   ///   already exists in the model. See HasModelInstanceNamed().
   ModelInstanceIndex AddModelInstance(const std::string& name) {
-    return model_->AddModelInstance(name);
+    return tree_->AddModelInstance(name);
   }
   /// @}
 
@@ -571,7 +572,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the body name occurs in multiple model
   /// instances.
   bool HasBodyNamed(const std::string& name) const {
-    return model_->HasBodyNamed(name);
+    return tree_->HasBodyNamed(name);
   }
 
   /// @returns `true` if a body named `name` was added to the %MultibodyPlant
@@ -581,7 +582,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasBodyNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->HasBodyNamed(name, model_instance);
+    return tree_->HasBodyNamed(name, model_instance);
   }
 
   /// @returns `true` if a joint named `name` was added to the %MultibodyPlant.
@@ -590,7 +591,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the joint name occurs in multiple model
   /// instances.
   bool HasJointNamed(const std::string& name) const {
-    return model_->HasJointNamed(name);
+    return tree_->HasJointNamed(name);
   }
 
   /// @returns `true` if a joint named `name` was added to the %MultibodyPlant
@@ -600,7 +601,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasJointNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->HasJointNamed(name, model_instance);
+    return tree_->HasJointNamed(name, model_instance);
   }
 
   /// @returns `true` if an actuator named `name` was added to the
@@ -610,7 +611,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the actuator name occurs in multiple model
   /// instances.
   bool HasJointActuatorNamed(const std::string& name) const {
-    return model_->HasJointActuatorNamed(name);
+    return tree_->HasJointActuatorNamed(name);
   }
 
   /// @returns `true` if an actuator named `name` was added to the
@@ -620,14 +621,14 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasJointActuatorNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->HasJointActuatorNamed(name, model_instance);
+    return tree_->HasJointActuatorNamed(name, model_instance);
   }
 
   /// @returns `true` if a model instance named `name` was added to the
   /// %MultibodyPlant.
   /// @see AddModelInstance().
   bool HasModelInstanceNamed(const std::string& name) const {
-    return model_->HasModelInstanceNamed(name);
+    return tree_->HasModelInstanceNamed(name);
   }
   /// @}
 
@@ -654,7 +655,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasBodyNamed() to query if there exists a body in `this`
   /// %MultibodyPlant with a given specified name.
   const Body<T>& GetBodyByName(const std::string& name) const {
-    return model_->GetBodyByName(name);
+    return tree_->GetBodyByName(name);
   }
 
   /// Returns a constant reference to the body that is uniquely identified
@@ -664,7 +665,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   const Body<T>& GetBodyByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->GetBodyByName(name, model_instance);
+    return tree_->GetBodyByName(name, model_instance);
   }
 
   /// Returns a constant reference to a frame that is identified by the
@@ -675,7 +676,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasFrameNamed() to query if there exists a frame in `this` model with
   /// a given specified name.
   const Frame<T>& GetFrameByName(const std::string& name) const {
-    return model_->GetFrameByName(name);
+    return tree_->GetFrameByName(name);
   }
 
   /// Returns a constant reference to the frame that is uniquely identified
@@ -687,7 +688,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// a given specified name.
   const Frame<T>& GetFrameByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->GetFrameByName(name, model_instance);
+    return tree_->GetFrameByName(name, model_instance);
   }
 
   /// Returns a constant reference to a joint that is identified
@@ -698,7 +699,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasJointNamed() to query if there exists a joint in `this`
   /// %MultibodyPlant with a given specified name.
   const Joint<T>& GetJointByName(const std::string& name) const {
-    return model_->GetJointByName(name);
+    return tree_->GetJointByName(name);
   }
 
   /// Returns a constant reference to the joint that is uniquely identified
@@ -709,7 +710,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   const Joint<T>& GetJointByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->GetJointByName(name, model_instance);
+    return tree_->GetJointByName(name, model_instance);
   }
 
   /// A templated version of GetJointByName() to return a constant reference of
@@ -725,7 +726,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   template <template<typename> class JointType>
   const JointType<T>& GetJointByName(const std::string& name) const {
-    return model_->template GetJointByName<JointType>(name);
+    return tree_->template GetJointByName<JointType>(name);
   }
 
   /// A templated version of GetJointByName() to return a constant reference of
@@ -741,7 +742,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   template <template<typename> class JointType>
   const JointType<T>& GetJointByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->template GetJointByName<JointType>(name, model_instance);
+    return tree_->template GetJointByName<JointType>(name, model_instance);
   }
 
   /// Returns a constant reference to an actuator that is identified
@@ -753,7 +754,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// `this` %MultibodyPlant with a given specified name.
   const JointActuator<T>& GetJointActuatorByName(
       const std::string& name) const {
-    return model_->GetJointActuatorByName(name);
+    return tree_->GetJointActuatorByName(name);
   }
 
   /// Returns a constant reference to the actuator that is uniquely identified
@@ -764,7 +765,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// `this` %MultibodyPlant with a given specified name.
   const JointActuator<T>& GetJointActuatorByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->GetJointActuatorByName(name, model_instance);
+    return tree_->GetJointActuatorByName(name, model_instance);
   }
 
   /// Returns the index to the model instance that is uniquely identified
@@ -773,7 +774,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasModelInstanceNamed() to query if there exists an instance in
   /// `this` %MultibodyPlant with a given specified name.
   ModelInstanceIndex GetModelInstanceByName(const std::string& name) const {
-    return model_->GetModelInstanceByName(name);
+    return tree_->GetModelInstanceByName(name);
   }
   /// @}
 
@@ -1005,7 +1006,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     const auto it = body_index_to_frame_id_.find(body_index);
     if (it == body_index_to_frame_id_.end()) {
       throw std::logic_error(
-          "Body '" + model().get_body(body_index).name() +
+          "Body '" + tree().get_body(body_index).name() +
           "' does not have geometry registered with it.");
     }
     return it->second;
@@ -1088,26 +1089,35 @@ class MultibodyPlant : public systems::LeafSystem<T> {
 
   /// Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
-    return model_->world_body();
+    return tree_->world_body();
   }
 
   /// Returns a constant reference to the *world* frame.
   const BodyFrame<T>& world_frame() const {
-    return model_->world_frame();
+    return tree_->world_frame();
   }
 
   /// Returns a constant reference to the underlying MultibodyTree model for
   /// `this` plant.
   /// @throws if called pre-finalize. See Finalize().
+  DRAKE_DEPRECATED("Please use tree().")
   const MultibodyTree<T>& model() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-    return *model_;
+    return *tree_;
+  }
+
+  /// Returns a constant reference to the underlying MultibodyTree model for
+  /// `this` plant.
+  /// @throws if called pre-finalize. See Finalize().
+  const MultibodyTree<T>& tree() const {
+    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
+    return *tree_;
   }
 
   /// Returns `true` if this %MultibodyPlant was finalized with a call to
   /// Finalize().
   /// @see Finalize().
-  bool is_finalized() const { return model_->topology_is_valid(); }
+  bool is_finalized() const { return tree_->topology_is_valid(); }
 
   /// This method must be called after all elements in the model (joints,
   /// bodies, force elements, constraints, etc.) are added and before any
@@ -1302,7 +1312,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
                        systems::State<T>* state) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     DRAKE_DEMAND(state != nullptr);
-    model_->SetDefaultState(context, state);
+    tree_->SetDefaultState(context, state);
   }
 
  private:
@@ -1600,7 +1610,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       std::vector<Matrix3<T>>* R_WC_set = nullptr) const;
 
   // The entire multibody model.
-  std::unique_ptr<drake::multibody::MultibodyTree<T>> model_;
+  std::unique_ptr<drake::multibody::MultibodyTree<T>> tree_;
 
   // The gravity field force element.
   optional<const UniformGravityFieldElement<T>*> gravity_field_;

--- a/multibody/multibody_tree/multibody_plant/test/box_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/box_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(Box, UnderStiction) {
 
   plant.Finalize(&scene_graph);  // Done creating the model.
 
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& tree = plant.tree();
   // Set contact parameters.
   plant.set_penetration_allowance(penetration_allowance);
   plant.set_stiction_tolerance(stiction_tolerance);
@@ -134,8 +134,8 @@ GTEST_TEST(Box, UnderStiction) {
       contact_results.contact_info(0);
 
   // Verify the bodies referenced by the contact info.
-  const RigidBody<double>& ground = model.GetRigidBodyByName("ground");
-  const RigidBody<double>& box = model.GetRigidBodyByName("box");
+  const RigidBody<double>& ground = tree.GetRigidBodyByName("ground");
+  const RigidBody<double>& box = tree.GetRigidBodyByName("box");
   EXPECT_TRUE(
       (contact_info.bodyA_index() == box.index() &&
        contact_info.bodyB_index() == ground.index()) ||

--- a/multibody/multibody_tree/multibody_plant/test/inclined_plane_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/inclined_plane_test.cc
@@ -93,11 +93,11 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeInclinedPlanePlant(
       radius, mass, slope, surface_friction, g, time_step_, &scene_graph));
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& tree = plant.tree();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(penetration_allowance_);
   plant.set_stiction_tolerance(stiction_tolerance_);
-  const RigidBody<double>& ball = model.GetRigidBodyByName("Ball");
+  const RigidBody<double>& ball = tree.GetRigidBodyByName("Ball");
 
   // Sanity check for the model's size.
   DRAKE_DEMAND(plant.num_velocities() == 6);
@@ -124,7 +124,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 
   // This will set a default initial condition with the sphere located at
   // p_WBcm = (0; 0; 0) and zero spatial velocity.
-  model.SetDefaultContext(&plant_context);
+  tree.SetDefaultContext(&plant_context);
 
   Simulator<double> simulator(*diagram, std::move(diagram_context));
   IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
@@ -135,10 +135,10 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 
   // Compute the kinetic energy of B (in frame W) from V_WB.
   const SpatialVelocity<double>& V_WB =
-      model.EvalBodySpatialVelocityInWorld(plant_context, ball);
+      tree.EvalBodySpatialVelocityInWorld(plant_context, ball);
   const SpatialInertia<double> M_BBo_B = ball.default_spatial_inertia();
   const Isometry3<double>& X_WB =
-      model.EvalBodyPoseInWorld(plant_context, ball);
+      tree.EvalBodyPoseInWorld(plant_context, ball);
   const SpatialInertia<double> M_BBo_W = M_BBo_B.ReExpress(X_WB.linear());
   const double ke_WB = 0.5 * V_WB.dot(M_BBo_W * V_WB);
   const double speed = V_WB.translational().norm();
@@ -157,7 +157,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   const double angular_velocity_expected = speed_expected / radius;
 
   // Verify the plant's potential energy matches the analytical calculation.
-  const double Ve = model.CalcPotentialEnergy(plant_context);
+  const double Ve = tree.CalcPotentialEnergy(plant_context);
   EXPECT_NEAR(-Ve, ke_WB_expected, std::numeric_limits<double>::epsilon());
 
   // Verify the relative errors. For the continuous model of the plant errors

--- a/multibody/multibody_tree/multibody_plant/test/joint_limits_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/joint_limits_test.cc
@@ -222,7 +222,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
 
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_NEAR(joint.lower_limit(), lower_limits(joint_number-1),
                 std::numeric_limits<double>::epsilon());
     EXPECT_NEAR(joint.upper_limit(), upper_limits(joint_number-1),
@@ -239,7 +239,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
 
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_LT(std::abs(
         (joint.get_angle(context)-joint.upper_limit())/joint.upper_limit()),
               kRelativePositionTolerance);
@@ -253,7 +253,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
   simulator.StepTo(simulation_time);
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_LT(std::abs(
         (joint.get_angle(context)-joint.lower_limit())/joint.lower_limit()),
               kRelativePositionTolerance);

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -138,8 +138,8 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(plant->num_actuated_dofs(), 2);
 
   // World accessors.
-  EXPECT_EQ(&plant->world_body(), &plant->model().world_body());
-  EXPECT_EQ(&plant->world_frame(), &plant->model().world_frame());
+  EXPECT_EQ(&plant->world_body(), &plant->tree().world_body());
+  EXPECT_EQ(&plant->world_frame(), &plant->tree().world_frame());
 
   // State size.
   EXPECT_EQ(plant->num_positions(), 3);
@@ -338,7 +338,7 @@ class AcrobotPlantTests : public ::testing::Test {
 
     // Calculate the generalized forces due to gravity.
     const VectorX<double> tau_g =
-        plant_->model().CalcGravityGeneralizedForces(*context_);
+        plant_->tree().CalcGravityGeneralizedForces(*context_);
 
     // Calculate a benchmark value.
     const Vector2d tau_g_expected =
@@ -378,7 +378,7 @@ class AcrobotPlantTests : public ::testing::Test {
         -parameters_.b1() * theta1dot, -parameters_.b2() * theta2dot);
 
     // Verify the computation of the contribution due to joint damping.
-    MultibodyForces<double> forces(plant_->model());
+    MultibodyForces<double> forces(plant_->tree());
     shoulder_->AddInDamping(*context_, &forces);
     elbow_->AddInDamping(*context_, &forces);
     EXPECT_TRUE(CompareMatrices(forces.generalized_forces(), tau_damping,
@@ -577,9 +577,9 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   // Compute the poses for each geometry in the model.
   plant_->get_geometry_poses_output_port().Calc(*context, poses_value.get());
 
-  const MultibodyTree<double>& model = plant_->model();
+  const MultibodyTree<double>& tree = plant_->tree();
   std::vector<Isometry3<double >> X_WB_all;
-  model.CalcAllBodyPosesInWorld(*context, &X_WB_all);
+  tree.CalcAllBodyPosesInWorld(*context, &X_WB_all);
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
   for (BodyIndex body_index(1);
        body_index < plant_->num_bodies(); ++body_index) {
@@ -965,11 +965,11 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   unique_ptr<Context<double>> context = plant.CreateDefaultContext();
 
   // Place sphere 1 on top of the ground, with offset x = -x_offset.
-  plant.model().SetFreeBodyPoseOrThrow(
+  plant.tree().SetFreeBodyPoseOrThrow(
       sphere1, Isometry3d(Translation3d(-x_offset, radius, 0.0)),
       context.get());
   // Place sphere 2 on top of the ground, with offset x = x_offset.
-  plant.model().SetFreeBodyPoseOrThrow(
+  plant.tree().SetFreeBodyPoseOrThrow(
       sphere2, Isometry3d(Translation3d(x_offset, radius, 0.0)),
       context.get());
 
@@ -984,7 +984,7 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   // Compute the poses for each geometry in the model.
   plant.get_geometry_poses_output_port().Calc(*context, poses_value.get());
 
-  const MultibodyTree<double>& model = plant.model();
+  const MultibodyTree<double>& model = plant.tree();
   std::vector<Isometry3<double >> X_WB_all;
   model.CalcAllBodyPosesInWorld(*context, &X_WB_all);
   const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
@@ -1171,12 +1171,12 @@ GTEST_TEST(MultibodyPlantTest, MapVelocityToQdotAndBack) {
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.linear() = AngleAxisd(M_PI / 3.0, axis_W).toRotationMatrix();
   X_WB.translation() = p_WB;
-  plant.model().SetFreeBodyPoseOrThrow(body, X_WB, context.get());
+  plant.tree().SetFreeBodyPoseOrThrow(body, X_WB, context.get());
 
   // Set an arbitrary, non-zero, spatial velocity of B in W.
   const SpatialVelocity<double> V_WB(Vector3d(1.0, 2.0, 3.0),
                                      Vector3d(-1.0, 4.0, -0.5));
-  plant.model().SetFreeBodySpatialVelocityOrThrow(body, V_WB, context.get());
+  plant.tree().SetFreeBodySpatialVelocityOrThrow(body, V_WB, context.get());
 
   // Use of MultibodyPlant's mapping to convert generalized velocities to time
   // derivatives of generalized coordinates.
@@ -1245,7 +1245,7 @@ TEST_F(SplitPendulum, MassMatrix) {
 
   MatrixX<double> M(1, 1);
   pin_->set_angle(context_.get(), theta);
-  plant_.model().CalcMassMatrixViaInverseDynamics(*context_, &M);
+  plant_.tree().CalcMassMatrixViaInverseDynamics(*context_, &M);
 
   // We can only expect values within the precision specified in the sdf file.
   EXPECT_NEAR(M(0, 0), Io, 1.0e-6);
@@ -1383,9 +1383,9 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
         RigidTransform<double>(RotationMatrix<double>::Identity(),
                Vector3<double>(0, small_box_size_ / 2.0 - penetration_, 0));
 
-    plant_.model().SetFreeBodyPoseOrThrow(
+    plant_.tree().SetFreeBodyPoseOrThrow(
         large_box, X_WLb.GetAsIsometry3(), context);
-    plant_.model().SetFreeBodyPoseOrThrow(
+    plant_.tree().SetFreeBodyPoseOrThrow(
         small_box, X_WSb.GetAsIsometry3(), context);
   }
 
@@ -1398,7 +1398,7 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
     const Body<double>& small_box = plant_.GetBodyByName("SmallBox");
 
     std::vector<Isometry3<double>> X_WB_set;
-    plant_.model().CalcAllBodyPosesInWorld(context, &X_WB_set);
+    plant_.tree().CalcAllBodyPosesInWorld(context, &X_WB_set);
 
     // Pose of the boxes in the world frame.
     const Isometry3<double>& X_WLb = X_WB_set[large_box.index()];
@@ -1465,11 +1465,11 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
       const Context<T>& context_on_T,
       const std::vector<PenetrationAsPointPair<double>>& pairs_set) const {
     std::vector<SpatialVelocity<T>> V_WB_set;
-    plant_on_T.model().CalcAllBodySpatialVelocitiesInWorld(
+    plant_on_T.tree().CalcAllBodySpatialVelocitiesInWorld(
         context_on_T, &V_WB_set);
 
     std::vector<Isometry3<T>> X_WB_set;
-    plant_on_T.model().CalcAllBodyPosesInWorld(
+    plant_on_T.tree().CalcAllBodyPosesInWorld(
         context_on_T, &X_WB_set);
 
     VectorX<T> vn(pairs_set.size());
@@ -1513,11 +1513,11 @@ class MultibodyPlantContactJacobianTests : public ::testing::Test {
       const std::vector<PenetrationAsPointPair<double>>& pairs_set,
       const std::vector<Matrix3<double>>& R_WC_set) const {
     std::vector<SpatialVelocity<T>> V_WB_set;
-    plant_on_T.model().CalcAllBodySpatialVelocitiesInWorld(
+    plant_on_T.tree().CalcAllBodySpatialVelocitiesInWorld(
         context_on_T, &V_WB_set);
 
     std::vector<Isometry3<T>> X_WB_set;
-    plant_on_T.model().CalcAllBodyPosesInWorld(
+    plant_on_T.tree().CalcAllBodyPosesInWorld(
         context_on_T, &X_WB_set);
 
     VectorX<T> vt(2 * pairs_set.size());
@@ -1656,7 +1656,7 @@ GTEST_TEST(KukaModel, JointIndexes) {
 
   // We expect the first joint to be the one WeldJoint fixing the model to the
   // world. We verify this assumption.
-  const Joint<double>& weld = plant.model().get_joint(JointIndex(0));
+  const Joint<double>& weld = plant.tree().get_joint(JointIndex(0));
   ASSERT_EQ(weld.name(), "weld_base_to_world");
 
   EXPECT_EQ(weld.num_positions(), 0);
@@ -1666,7 +1666,7 @@ GTEST_TEST(KukaModel, JointIndexes) {
   // positions followed by the vector v of generalized velocities.
   for (JointIndex joint_index(1); /* Skip "weld_base_to_world". */
        joint_index < plant.num_joints(); ++joint_index) {
-    const Joint<double>& joint = plant.model().get_joint(joint_index);
+    const Joint<double>& joint = plant.tree().get_joint(joint_index);
     // Start index in the vector q of generalized positions.
     const int expected_q_start = joint_index - 1;
     // Start index in the vector v of generalized velocities.
@@ -1724,7 +1724,7 @@ class KukaArmTest : public ::testing::TestWithParam<double> {
 
     // We expect the first joint to be the one WeldJoint fixing the model to the
     // world. We verify this assumption.
-    const Joint<double>& weld = plant_->model().get_joint(JointIndex(0));
+    const Joint<double>& weld = plant_->tree().get_joint(JointIndex(0));
     ASSERT_EQ(weld.name(), "weld_base_to_world");
 
     context_ = plant_->CreateDefaultContext();
@@ -1774,13 +1774,13 @@ TEST_P(KukaArmTest, StateAccess) {
   // the context. Changes to state through the context can change the values
   // referenced by xc.
   Eigen::VectorBlock<const VectorX<double>> xc =
-      plant_->model().get_multibody_state_vector(*context_);
+      plant_->tree().get_multibody_state_vector(*context_);
   EXPECT_EQ(xc, xc_expected);
 
   // Get a mutable state and modified it.
   // Note: xc above is referencing values stored in the context. Therefore
   // setting the entire state to zero changes the values referenced by xc.
-  plant_->model().get_mutable_multibody_state_vector(context_.get()).setZero();
+  plant_->tree().get_mutable_multibody_state_vector(context_.get()).setZero();
   EXPECT_EQ(xc, VectorX<double>::Zero(plant_->num_multibody_states()));
 }
 

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -70,14 +70,14 @@ class AcrobotModelTests : public ::testing::Test {
     benchmark_shoulder_->set_angle(benchmark_context_.get(), theta1);
     benchmark_elbow_->set_angle(benchmark_context_.get(), theta2);
     MatrixX<double> M_benchmark(nv, nv);
-    benchmark_plant_->model().CalcMassMatrixViaInverseDynamics(
+    benchmark_plant_->tree().CalcMassMatrixViaInverseDynamics(
         *benchmark_context_.get(), &M_benchmark);
 
     // Set the state for the parsed model and compute the mass matrix.
     shoulder_->set_angle(context_.get(), theta1);
     elbow_->set_angle(context_.get(), theta2);
     MatrixX<double> M(nv, nv);
-    plant_->model().CalcMassMatrixViaInverseDynamics(*context_.get(), &M);
+    plant_->tree().CalcMassMatrixViaInverseDynamics(*context_.get(), &M);
 
     EXPECT_TRUE(CompareMatrices(
         M, M_benchmark, kTolerance, MatrixCompareType::relative));

--- a/multibody/multibody_tree/test/floating_body_plant.cc
+++ b/multibody/multibody_tree/test/floating_body_plant.cc
@@ -62,7 +62,7 @@ void AxiallySymmetricFreeBodyPlant<T>::SetDefaultState(
   const SpatialVelocity<T> V_WB(
       get_default_initial_angular_velocity().template cast<T>(),
       get_default_initial_translational_velocity().template cast<T>());
-  this->model().SetFreeBodySpatialVelocityOrThrow(body(), V_WB, context, state);
+  this->tree().SetFreeBodySpatialVelocityOrThrow(body(), V_WB, context, state);
 }
 
 template<typename T>
@@ -80,8 +80,8 @@ Vector3<T> AxiallySymmetricFreeBodyPlant<T>::get_translational_velocity(
 template<typename T>
 Isometry3<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
-  PositionKinematicsCache<T> pc(this->model().get_topology());
-  this->model().CalcPositionKinematicsCache(context, &pc);
+  PositionKinematicsCache<T> pc(this->tree().get_topology());
+  this->tree().CalcPositionKinematicsCache(context, &pc);
   return pc.get_X_WB(body_->node_index());
 }
 
@@ -89,10 +89,10 @@ template<typename T>
 SpatialVelocity<T>
 AxiallySymmetricFreeBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
     const systems::Context<T>& context) const {
-  PositionKinematicsCache<T> pc(this->model().get_topology());
-  this->model().CalcPositionKinematicsCache(context, &pc);
-  VelocityKinematicsCache<T> vc(this->model().get_topology());
-  this->model().CalcVelocityKinematicsCache(context, pc, &vc);
+  PositionKinematicsCache<T> pc(this->tree().get_topology());
+  this->tree().CalcPositionKinematicsCache(context, &pc);
+  VelocityKinematicsCache<T> vc(this->tree().get_topology());
+  this->tree().CalcVelocityKinematicsCache(context, pc, &vc);
   return vc.get_V_WB(body_->node_index());
 }
 

--- a/multibody/multibody_tree/test/floating_body_test.cc
+++ b/multibody/multibody_tree/test/floating_body_test.cc
@@ -80,7 +80,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
 
   const QuaternionFloatingMobilizer<double>& mobilizer =
       MultibodyTreeTester::get_floating_mobilizer(
-          free_body_plant.model(), free_body_plant.body());
+          free_body_plant.tree(), free_body_plant.body());
 
   // Unit test QuaternionFloatingMobilizer context dependent setters/getters.
   mobilizer.set_angular_velocity(&context, 2.0 * w0_WB_expected);
@@ -199,7 +199,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
 
   // Verify MultibodyTree::MapVelocityToQDot() to compute the quaternion time
   // derivative.
-  const MultibodyTree<double>& model = free_body_plant.model();
+  const MultibodyTree<double>& model = free_body_plant.tree();
   VectorX<double> qdot_from_v(model.num_positions());
   // The generalized velocity computed last at time = kEndTime.
   const VectorX<double> v =
@@ -265,7 +265,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, MapVelocityToQDotAndBack) {
   // Instantiate the model for the free body in space.
   AxiallySymmetricFreeBodyPlant<double> free_body_plant(
       kMass, kInertia, kInertia, acceleration_of_gravity);
-  const MultibodyTree<double>& model = free_body_plant.model();
+  const MultibodyTree<double>& model = free_body_plant.tree();
 
   std::unique_ptr<Context<double>> context =
       free_body_plant.CreateDefaultContext();

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -39,8 +39,8 @@ InverseDynamics<T>::InverseDynamics(const MultibodyPlant<T>* plant,
                                     bool pure_gravity_compensation)
     : multibody_plant_(plant),
       pure_gravity_compensation_(pure_gravity_compensation),
-      q_dim_(plant->model().num_positions()),
-      v_dim_(plant->model().num_velocities()) {
+      q_dim_(plant->tree().num_positions()),
+      v_dim_(plant->tree().num_velocities()) {
   DRAKE_DEMAND(plant->is_finalized());
 
   input_port_index_state_ =
@@ -96,7 +96,7 @@ void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
     output->get_mutable_value() = force;
   } else {
     DRAKE_DEMAND(multibody_plant_);
-    const auto& tree = multibody_plant_->model();
+    const auto& tree = multibody_plant_->tree();
 
     if (pure_gravity_compensation_) {
       output->get_mutable_value() = tree.CalcGravityGeneralizedForces(

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -120,7 +120,7 @@ GTEST_TEST(InverseDynamicsControllerTestMBP, TestTorque) {
   auto output = dut->AllocateOutput();
   const MultibodyPlant<double>& robot_plant =
       *dut->get_multibody_plant_for_control();
-  const MultibodyTree<double>& robot_model = robot_plant.model();
+  const MultibodyTree<double>& robot_tree = robot_plant.tree();
 
   // Sets current state and reference state and acceleration values.
   VectorX<double> q(dim), v(dim), q_r(dim), v_r(dim), vd_r(dim);
@@ -133,15 +133,15 @@ GTEST_TEST(InverseDynamicsControllerTestMBP, TestTorque) {
 
   // Connects inputs.
   auto state_input = std::make_unique<BasicVector<double>>(
-      robot_model.num_positions() + robot_model.num_velocities());
+      robot_tree.num_positions() + robot_tree.num_velocities());
   state_input->get_mutable_value() << q, v;
 
   auto reference_state_input = std::make_unique<BasicVector<double>>(
-      robot_model.num_positions() + robot_model.num_velocities());
+      robot_tree.num_positions() + robot_tree.num_velocities());
   reference_state_input->get_mutable_value() << q_r, v_r;
 
   auto reference_acceleration_input =
-      std::make_unique<BasicVector<double>>(robot_model.num_velocities());
+      std::make_unique<BasicVector<double>>(robot_tree.num_velocities());
   reference_acceleration_input->get_mutable_value() << vd_r;
 
   inverse_dynamics_context->FixInputPort(

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -132,14 +132,14 @@ class InverseDynamicsTest : public ::testing::Test {
     if (rigid_body_tree_)
       return rigid_body_tree_->get_num_positions();
     DRAKE_DEMAND(multibody_plant_.get() != nullptr);
-    return multibody_plant_->model().num_positions();
+    return multibody_plant_->tree().num_positions();
   }
 
   int num_velocities() const {
     if (rigid_body_tree_)
       return rigid_body_tree_->get_num_velocities();
     DRAKE_DEMAND(multibody_plant_.get() != nullptr);
-    return multibody_plant_->model().num_velocities();
+    return multibody_plant_->tree().num_velocities();
   }
 
   std::unique_ptr<RigidBodyTree<double>> rigid_body_tree_;

--- a/systems/controllers/test_utilities/compute_torque.h
+++ b/systems/controllers/test_utilities/compute_torque.h
@@ -44,7 +44,7 @@ VectorX<double> ComputeTorque(
       get_mutable_generalized_velocity().SetFromVector(v);
 
   // Compute the caches.
-  auto& tree = plant.model();
+  auto& tree = plant.tree();
   multibody::PositionKinematicsCache<double> pcache(tree.get_topology());
   multibody::VelocityKinematicsCache<double> vcache(tree.get_topology());
   tree.CalcPositionKinematicsCache(*context, &pcache);


### PR DESCRIPTION
The so discussed refactor. Python bindings are also deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9420)
<!-- Reviewable:end -->
