### PR TITLE
Disable install linter by default

### DIFF
--- a/tools/lint/lint.bzl
+++ b/tools/lint/lint.bzl
@@ -15,7 +15,7 @@ def add_lint_tests(
         bazel_lint_ignore = None,
         bazel_lint_extra_srcs = None,
         bazel_lint_exclude = None,
-        enable_install_lint = True,
+        enable_install_lint = False,
         enable_library_lint = True):
     """For every rule in the BUILD file so far, and for all Bazel files in this
     directory, adds test rules that run Drake's standard lint suite over the


### PR DESCRIPTION
Rather than revert entire PR, disable install linter by default (for now).

See #9418

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9421)
<!-- Reviewable:end -->
