### PR TITLE
Revert "Refactors model() --> tree(). Deprecates model()."

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -357,18 +357,10 @@ void init_multibody_plant(py::module m) {
     cls
         .def("world_body", &Class::world_body, py_reference_internal)
         .def("world_frame", &Class::world_frame, py_reference_internal)
-        .def("tree", &Class::tree, py_reference_internal)
+        .def("model", &Class::model, py_reference_internal)
         .def("is_finalized", &Class::is_finalized)
         .def("Finalize", py::overload_cast<SceneGraph<T>*>(&Class::Finalize),
              py::arg("scene_graph") = nullptr);
-    // Add deprecated methods.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    cls.def("model", &Class::model, py_reference_internal);
-#pragma GCC diagnostic pop  // pop -Wdeprecated-declarations
-    cls.attr("message_model") = "Please use tree().";
-    DeprecateAttribute(
-        cls, "model", cls.attr("message_model"));
   }
 }
 

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -171,7 +171,7 @@ class TestMultibodyTree(unittest.TestCase):
         AddModelFromSdfFile(file_name, plant)
         plant.Finalize()
         context = plant.CreateDefaultContext()
-        tree = plant.tree()
+        tree = plant.model()
         world_frame = plant.world_frame()
         # TODO(eric.cousineau): Replace this with `GetFrameByName`.
         link1_frame = plant.GetBodyByName("Link1").body_frame()

--- a/examples/allegro_hand/run_allegro_constant_load_demo.cc
+++ b/examples/allegro_hand/run_allegro_constant_load_demo.cc
@@ -89,7 +89,7 @@ void DoMain() {
 
   // constant force input
   VectorX<double> constant_load_value = VectorX<double>::Ones(
-      plant.tree().num_actuators()) * FLAGS_constant_load;
+      plant.model().num_actuators()) * FLAGS_constant_load;
   auto constant_source =
      builder.AddSystem<systems::ConstantVectorSource<double>>(
       constant_load_value);

--- a/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
+++ b/examples/multibody/bouncing_ball/bouncing_ball_run_dynamics.cc
@@ -73,7 +73,7 @@ int do_main() {
 
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeBouncingBallPlant(
       radius, mass, coulomb_friction, -g * Vector3d::UnitZ(), &scene_graph));
-  const MultibodyTree<double>& tree = plant.tree();
+  const MultibodyTree<double>& model = plant.model();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(0.001);
 
@@ -109,13 +109,13 @@ int do_main() {
   // Set at height z0 with random orientation.
   std::mt19937 generator(41);
   std::uniform_real_distribution<double> uniform(-1.0, 1.0);
-  tree.SetDefaultContext(&plant_context);
+  model.SetDefaultContext(&plant_context);
   Matrix3d R_WB = math::UniformlyRandomRotationMatrix(&generator).matrix();
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.linear() = R_WB;
   X_WB.translation() = Vector3d(0.0, 0.0, z0);
-  tree.SetFreeBodyPoseOrThrow(
-      tree.GetBodyByName("Ball"), X_WB, &plant_context);
+  model.SetFreeBodyPoseOrThrow(
+      model.GetBodyByName("Ball"), X_WB, &plant_context);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
 

--- a/examples/multibody/cart_pole/test/cart_pole_test.cc
+++ b/examples/multibody/cart_pole/test/cart_pole_test.cc
@@ -120,7 +120,7 @@ TEST_F(CartPoleTest, MassMatrix) {
 
   Matrix2<double> M;
   pole_pin_->set_angle(context_.get(), theta);
-  cart_pole_.tree().CalcMassMatrixViaInverseDynamics(*context_, &M);
+  cart_pole_.model().CalcMassMatrixViaInverseDynamics(*context_, &M);
   Matrix2<double> M_expected = CartPoleHandWritenMassMatrix(theta);
 
   // Matrix verified to this tolerance.

--- a/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
+++ b/examples/multibody/cylinder_with_multicontact/cylinder_run_dynamics.cc
@@ -83,7 +83,7 @@ int do_main() {
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeCylinderPlant(
       radius, length, mass, coulomb_friction, -g * Vector3d::UnitZ(),
       FLAGS_time_step, &scene_graph));
-  const MultibodyTree<double>& tree = plant.tree();
+  const MultibodyTree<double>& model = plant.model();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(FLAGS_penetration_allowance);
   plant.set_stiction_tolerance(FLAGS_stiction_tolerance);
@@ -126,13 +126,13 @@ int do_main() {
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
   // Set at height z0.
-  tree.SetDefaultContext(&plant_context);
+  model.SetDefaultContext(&plant_context);
   Isometry3d X_WB = Isometry3d::Identity();
   X_WB.translation() = Vector3d(0.0, 0.0, FLAGS_z0);
-  const auto& cylinder = tree.GetBodyByName("Cylinder");
-  tree.SetFreeBodyPoseOrThrow(
+  const auto& cylinder = model.GetBodyByName("Cylinder");
+  model.SetFreeBodyPoseOrThrow(
       cylinder, X_WB, &plant_context);
-  tree.SetFreeBodySpatialVelocityOrThrow(
+  model.SetFreeBodySpatialVelocityOrThrow(
       cylinder,
       SpatialVelocity<double>(
           Vector3<double>(FLAGS_wx0, 0.0, 0.0),

--- a/examples/multibody/cylinder_with_multicontact/test/make_cylinder_plant_test.cc
+++ b/examples/multibody/cylinder_with_multicontact/test/make_cylinder_plant_test.cc
@@ -47,7 +47,7 @@ GTEST_TEST(MakeCylinderPlant, VerifyPlant) {
 
   ASSERT_TRUE(plant->HasBodyNamed("Cylinder"));
   const RigidBody<double>& cylinder =
-      plant->tree().GetRigidBodyByName("Cylinder");
+      plant->model().GetRigidBodyByName("Cylinder");
   EXPECT_EQ(cylinder.get_default_mass(), mass);
 
   // Verify the value of the inertial properties for the cylinder.

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -62,7 +62,7 @@ int do_main() {
   DRAKE_DEMAND(FLAGS_time_step >= 0);
   MultibodyPlant<double>& plant = *builder.AddSystem(MakeInclinedPlanePlant(
       radius, mass, slope, surface_friction, g, FLAGS_time_step, &scene_graph));
-  const MultibodyTree<double>& tree = plant.tree();
+  const MultibodyTree<double>& model = plant.model();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(1.0e-5);
   plant.set_stiction_tolerance(FLAGS_stiction_tolerance);
@@ -92,7 +92,7 @@ int do_main() {
 
   // This will set a default initial condition with the sphere located at
   // p_WBcm = (0; 0; 0) and zero spatial velocity.
-  tree.SetDefaultContext(&plant_context);
+  model.SetDefaultContext(&plant_context);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
 

--- a/examples/simple_gripper/simple_gripper.cc
+++ b/examples/simple_gripper/simple_gripper.cc
@@ -338,7 +338,7 @@ int do_main() {
 
   // Initialize the mug pose to be right in the middle between the fingers.
   std::vector<Isometry3d> X_WB_all;
-  plant.tree().CalcAllBodyPosesInWorld(plant_context, &X_WB_all);
+  plant.model().CalcAllBodyPosesInWorld(plant_context, &X_WB_all);
   const Vector3d& p_WBr = X_WB_all[right_finger.index()].translation();
   const Vector3d& p_WBl = X_WB_all[left_finger.index()].translation();
   const double mug_y_W = (p_WBr(1) + p_WBl(1)) / 2.0;
@@ -349,7 +349,7 @@ int do_main() {
                (FLAGS_rz * M_PI / 180) + M_PI);
   X_WM.linear() = RotationMatrix<double>(RollPitchYaw<double>(rpy)).matrix();
   X_WM.translation() = Vector3d(0.0, mug_y_W, 0.0);
-  plant.tree().SetFreeBodyPoseOrThrow(mug, X_WM, &plant_context);
+  plant.model().SetFreeBodyPoseOrThrow(mug, X_WM, &plant_context);
 
   // Set the initial height of the gripper and its initial velocity so that with
   // the applied harmonic forces it continues to move in a harmonic oscillation

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -13,7 +13,7 @@ InverseKinematics::InverseKinematics(
     const multibody_plant::MultibodyPlant<double>& plant)
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
-      tree_(plant_.tree().ToAutoDiffXd()),
+      tree_(plant_.model().ToAutoDiffXd()),
       context_(tree_->CreateDefaultContext()),
       q_(prog_->NewContinuousVariables(plant_.num_positions(), "q")) {
   // Initialize the lower and upper bounds to -inf/inf. A free floating body

--- a/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
+++ b/multibody/multibody_tree/multibody_plant/contact_results_to_lcm.cc
@@ -19,7 +19,7 @@ ContactResultsToLcmSystem<T>::ContactResultsToLcmSystem(
     : systems::LeafSystem<T>() {
   DRAKE_DEMAND(plant.is_finalized());
   const int body_count = plant.num_bodies();
-  const MultibodyTree<T>& model = plant.tree();
+  const MultibodyTree<T>& model = plant.model();
 
   body_names_.reserve(body_count);
   using std::to_string;

--- a/multibody/multibody_tree/multibody_plant/test/box_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/box_test.cc
@@ -76,7 +76,7 @@ GTEST_TEST(Box, UnderStiction) {
 
   plant.Finalize(&scene_graph);  // Done creating the model.
 
-  const MultibodyTree<double>& tree = plant.tree();
+  const MultibodyTree<double>& model = plant.model();
   // Set contact parameters.
   plant.set_penetration_allowance(penetration_allowance);
   plant.set_stiction_tolerance(stiction_tolerance);
@@ -134,8 +134,8 @@ GTEST_TEST(Box, UnderStiction) {
       contact_results.contact_info(0);
 
   // Verify the bodies referenced by the contact info.
-  const RigidBody<double>& ground = tree.GetRigidBodyByName("ground");
-  const RigidBody<double>& box = tree.GetRigidBodyByName("box");
+  const RigidBody<double>& ground = model.GetRigidBodyByName("ground");
+  const RigidBody<double>& box = model.GetRigidBodyByName("box");
   EXPECT_TRUE(
       (contact_info.bodyA_index() == box.index() &&
        contact_info.bodyB_index() == ground.index()) ||

--- a/multibody/multibody_tree/multibody_plant/test/joint_limits_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/joint_limits_test.cc
@@ -222,7 +222,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
 
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_NEAR(joint.lower_limit(), lower_limits(joint_number-1),
                 std::numeric_limits<double>::epsilon());
     EXPECT_NEAR(joint.upper_limit(), upper_limits(joint_number-1),
@@ -239,7 +239,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
 
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_LT(std::abs(
         (joint.get_angle(context)-joint.upper_limit())/joint.upper_limit()),
               kRelativePositionTolerance);
@@ -253,7 +253,7 @@ GTEST_TEST(JointLimitsTest, KukaArm) {
   simulator.StepTo(simulation_time);
   for (int joint_number = 1; joint_number <= 7; ++joint_number) {
     const std::string joint_name = "iiwa_joint_" + std::to_string(joint_number);
-    const auto& joint = plant.tree().GetJointByName<RevoluteJoint>(joint_name);
+    const auto& joint = plant.model().GetJointByName<RevoluteJoint>(joint_name);
     EXPECT_LT(std::abs(
         (joint.get_angle(context)-joint.lower_limit())/joint.lower_limit()),
               kRelativePositionTolerance);

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -70,14 +70,14 @@ class AcrobotModelTests : public ::testing::Test {
     benchmark_shoulder_->set_angle(benchmark_context_.get(), theta1);
     benchmark_elbow_->set_angle(benchmark_context_.get(), theta2);
     MatrixX<double> M_benchmark(nv, nv);
-    benchmark_plant_->tree().CalcMassMatrixViaInverseDynamics(
+    benchmark_plant_->model().CalcMassMatrixViaInverseDynamics(
         *benchmark_context_.get(), &M_benchmark);
 
     // Set the state for the parsed model and compute the mass matrix.
     shoulder_->set_angle(context_.get(), theta1);
     elbow_->set_angle(context_.get(), theta2);
     MatrixX<double> M(nv, nv);
-    plant_->tree().CalcMassMatrixViaInverseDynamics(*context_.get(), &M);
+    plant_->model().CalcMassMatrixViaInverseDynamics(*context_.get(), &M);
 
     EXPECT_TRUE(CompareMatrices(
         M, M_benchmark, kTolerance, MatrixCompareType::relative));

--- a/multibody/multibody_tree/test/floating_body_plant.cc
+++ b/multibody/multibody_tree/test/floating_body_plant.cc
@@ -62,7 +62,7 @@ void AxiallySymmetricFreeBodyPlant<T>::SetDefaultState(
   const SpatialVelocity<T> V_WB(
       get_default_initial_angular_velocity().template cast<T>(),
       get_default_initial_translational_velocity().template cast<T>());
-  this->tree().SetFreeBodySpatialVelocityOrThrow(body(), V_WB, context, state);
+  this->model().SetFreeBodySpatialVelocityOrThrow(body(), V_WB, context, state);
 }
 
 template<typename T>
@@ -80,8 +80,8 @@ Vector3<T> AxiallySymmetricFreeBodyPlant<T>::get_translational_velocity(
 template<typename T>
 Isometry3<T> AxiallySymmetricFreeBodyPlant<T>::CalcPoseInWorldFrame(
     const systems::Context<T>& context) const {
-  PositionKinematicsCache<T> pc(this->tree().get_topology());
-  this->tree().CalcPositionKinematicsCache(context, &pc);
+  PositionKinematicsCache<T> pc(this->model().get_topology());
+  this->model().CalcPositionKinematicsCache(context, &pc);
   return pc.get_X_WB(body_->node_index());
 }
 
@@ -89,10 +89,10 @@ template<typename T>
 SpatialVelocity<T>
 AxiallySymmetricFreeBodyPlant<T>::CalcSpatialVelocityInWorldFrame(
     const systems::Context<T>& context) const {
-  PositionKinematicsCache<T> pc(this->tree().get_topology());
-  this->tree().CalcPositionKinematicsCache(context, &pc);
-  VelocityKinematicsCache<T> vc(this->tree().get_topology());
-  this->tree().CalcVelocityKinematicsCache(context, pc, &vc);
+  PositionKinematicsCache<T> pc(this->model().get_topology());
+  this->model().CalcPositionKinematicsCache(context, &pc);
+  VelocityKinematicsCache<T> vc(this->model().get_topology());
+  this->model().CalcVelocityKinematicsCache(context, pc, &vc);
   return vc.get_V_WB(body_->node_index());
 }
 

--- a/multibody/multibody_tree/test/floating_body_test.cc
+++ b/multibody/multibody_tree/test/floating_body_test.cc
@@ -80,7 +80,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
 
   const QuaternionFloatingMobilizer<double>& mobilizer =
       MultibodyTreeTester::get_floating_mobilizer(
-          free_body_plant.tree(), free_body_plant.body());
+          free_body_plant.model(), free_body_plant.body());
 
   // Unit test QuaternionFloatingMobilizer context dependent setters/getters.
   mobilizer.set_angular_velocity(&context, 2.0 * w0_WB_expected);
@@ -199,7 +199,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, Simulation) {
 
   // Verify MultibodyTree::MapVelocityToQDot() to compute the quaternion time
   // derivative.
-  const MultibodyTree<double>& model = free_body_plant.tree();
+  const MultibodyTree<double>& model = free_body_plant.model();
   VectorX<double> qdot_from_v(model.num_positions());
   // The generalized velocity computed last at time = kEndTime.
   const VectorX<double> v =
@@ -265,7 +265,7 @@ GTEST_TEST(QuaternionFloatingMobilizer, MapVelocityToQDotAndBack) {
   // Instantiate the model for the free body in space.
   AxiallySymmetricFreeBodyPlant<double> free_body_plant(
       kMass, kInertia, kInertia, acceleration_of_gravity);
-  const MultibodyTree<double>& model = free_body_plant.tree();
+  const MultibodyTree<double>& model = free_body_plant.model();
 
   std::unique_ptr<Context<double>> context =
       free_body_plant.CreateDefaultContext();

--- a/systems/controllers/inverse_dynamics.cc
+++ b/systems/controllers/inverse_dynamics.cc
@@ -39,8 +39,8 @@ InverseDynamics<T>::InverseDynamics(const MultibodyPlant<T>* plant,
                                     bool pure_gravity_compensation)
     : multibody_plant_(plant),
       pure_gravity_compensation_(pure_gravity_compensation),
-      q_dim_(plant->tree().num_positions()),
-      v_dim_(plant->tree().num_velocities()) {
+      q_dim_(plant->model().num_positions()),
+      v_dim_(plant->model().num_velocities()) {
   DRAKE_DEMAND(plant->is_finalized());
 
   input_port_index_state_ =
@@ -96,7 +96,7 @@ void InverseDynamics<T>::CalcOutputForce(const Context<T>& context,
     output->get_mutable_value() = force;
   } else {
     DRAKE_DEMAND(multibody_plant_);
-    const auto& tree = multibody_plant_->tree();
+    const auto& tree = multibody_plant_->model();
 
     if (pure_gravity_compensation_) {
       output->get_mutable_value() = tree.CalcGravityGeneralizedForces(

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -120,7 +120,7 @@ GTEST_TEST(InverseDynamicsControllerTestMBP, TestTorque) {
   auto output = dut->AllocateOutput();
   const MultibodyPlant<double>& robot_plant =
       *dut->get_multibody_plant_for_control();
-  const MultibodyTree<double>& robot_tree = robot_plant.tree();
+  const MultibodyTree<double>& robot_model = robot_plant.model();
 
   // Sets current state and reference state and acceleration values.
   VectorX<double> q(dim), v(dim), q_r(dim), v_r(dim), vd_r(dim);
@@ -133,15 +133,15 @@ GTEST_TEST(InverseDynamicsControllerTestMBP, TestTorque) {
 
   // Connects inputs.
   auto state_input = std::make_unique<BasicVector<double>>(
-      robot_tree.num_positions() + robot_tree.num_velocities());
+      robot_model.num_positions() + robot_model.num_velocities());
   state_input->get_mutable_value() << q, v;
 
   auto reference_state_input = std::make_unique<BasicVector<double>>(
-      robot_tree.num_positions() + robot_tree.num_velocities());
+      robot_model.num_positions() + robot_model.num_velocities());
   reference_state_input->get_mutable_value() << q_r, v_r;
 
   auto reference_acceleration_input =
-      std::make_unique<BasicVector<double>>(robot_tree.num_velocities());
+      std::make_unique<BasicVector<double>>(robot_model.num_velocities());
   reference_acceleration_input->get_mutable_value() << vd_r;
 
   inverse_dynamics_context->FixInputPort(

--- a/systems/controllers/test/inverse_dynamics_test.cc
+++ b/systems/controllers/test/inverse_dynamics_test.cc
@@ -132,14 +132,14 @@ class InverseDynamicsTest : public ::testing::Test {
     if (rigid_body_tree_)
       return rigid_body_tree_->get_num_positions();
     DRAKE_DEMAND(multibody_plant_.get() != nullptr);
-    return multibody_plant_->tree().num_positions();
+    return multibody_plant_->model().num_positions();
   }
 
   int num_velocities() const {
     if (rigid_body_tree_)
       return rigid_body_tree_->get_num_velocities();
     DRAKE_DEMAND(multibody_plant_.get() != nullptr);
-    return multibody_plant_->tree().num_velocities();
+    return multibody_plant_->model().num_velocities();
   }
 
   std::unique_ptr<RigidBodyTree<double>> rigid_body_tree_;

--- a/systems/controllers/test_utilities/compute_torque.h
+++ b/systems/controllers/test_utilities/compute_torque.h
@@ -44,7 +44,7 @@ VectorX<double> ComputeTorque(
       get_mutable_generalized_velocity().SetFromVector(v);
 
   // Compute the caches.
-  auto& tree = plant.tree();
+  auto& tree = plant.model();
   multibody::PositionKinematicsCache<double> pcache(tree.get_topology());
   multibody::VelocityKinematicsCache<double> vcache(tree.get_topology());
   tree.CalcPositionKinematicsCache(*context, &pcache);


### PR DESCRIPTION
Reverts RobotLocomotion/drake#9420.

Dear @amcastro-tri,

The on-call build cop believes that your PR #9420 may have
broken one or more of Drake's continuous integration builds [1,2]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms and tests are built post-merge.

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [3].

Thanks!
Your Friendly On-Call Build Cop

[1] CI Continuous Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/
[2] CI Nightly Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/
[3] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9425)
<!-- Reviewable:end -->
