### PR TITLE
Revert "py multibody: Bind `AddFrame`"

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -75,15 +75,6 @@ void init_module(py::module m) {
     // No need to re-bind element mixins from `Frame`.
   }
 
-  {
-    using Class = FixedOffsetFrame<T>;
-    py::class_<Class, Frame<T>>(m, "FixedOffsetFrame")
-        .def(py::init<const string&, const Frame<T>&,
-                      const Isometry3<double>&>(),
-             py::arg("name"), py::arg("P"), py::arg("X_PF"))
-        .def("GetFixedPoseInBodyFrame", &Class::GetFixedPoseInBodyFrame);
-  }
-
   // Bodies.
   {
     using Class = Body<T>;
@@ -302,10 +293,6 @@ void init_multibody_plant(py::module m) {
              overload_cast_explicit<int>(&Class::num_actuated_dofs));
     // Construction.
     cls
-        .def("AddFrame",
-             [](Class* self, std::unique_ptr<Frame<T>> frame) -> auto& {
-              return self->AddFrame(std::move(frame));
-             }, py::arg("frame"), py_reference_internal)
         .def("AddJoint",
              [](Class* self, std::unique_ptr<Joint<T>> joint) -> auto& {
                return self->AddJoint(std::move(joint));
@@ -321,9 +308,6 @@ void init_multibody_plant(py::module m) {
         .def("HasBodyNamed",
              overload_cast_explicit<bool, const string&>(&Class::HasBodyNamed),
              py::arg("name"))
-        .def("HasFrameNamed",
-             overload_cast_explicit<bool, const string&>(&Class::HasFrameNamed),
-             py::arg("name"))
         .def("HasJointNamed",
              overload_cast_explicit<bool, const string&>(
                 &Class::HasJointNamed),
@@ -337,10 +321,6 @@ void init_multibody_plant(py::module m) {
                                     ModelInstanceIndex>(
                 &Class::GetBodyByName),
              py::arg("name"), py::arg("model_instance"), py_reference_internal)
-        .def("GetFrameByName",
-             overload_cast_explicit<const Frame<T>&, const string&>(
-                &Class::GetFrameByName),
-             py::arg("name"), py_reference_internal)
         .def("GetJointByName",
              [](const Class* self, const string& name) -> auto& {
                return self->GetJointByName(name);

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -4,7 +4,6 @@ from pydrake.multibody.multibody_tree import (
     Body,
     BodyFrame,
     BodyIndex,
-    FixedOffsetFrame,
     ForceElement,
     ForceElementIndex,
     Frame,
@@ -265,15 +264,3 @@ class TestMultibodyTree(unittest.TestCase):
 
         for joint in joints:
             self._test_joint_api(joint)
-
-    def test_multibody_add_frame(self):
-        plant = MultibodyPlant()
-        frame = plant.AddFrame(
-            FixedOffsetFrame(
-                name="test_frame", P=plant.world_frame(),
-                X_PF=Isometry3.Identity()))
-        self.assertIs(
-            plant.GetFrameByName(name="test_frame"), frame)
-        self.assertIsInstance(frame.GetFixedPoseInBodyFrame(), Isometry3)
-        self.assertTrue(plant.HasFrameNamed("test_frame"))
-        plant.Finalize()

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -585,25 +585,6 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     return tree_->HasBodyNamed(name, model_instance);
   }
 
-  /// @returns `true` if a frame named `name` was added to the %MultibodyPlant.
-  /// @see AddFrame().
-  ///
-  /// @throws std::logic_error if the frame name occurs in multiple model
-  /// instances.
-  bool HasFrameNamed(const std::string& name) const {
-    return model_->HasFrameNamed(name);
-  }
-
-  /// @returns `true` if a frame named `name` was added to the %MultibodyPlant
-  /// in @p model_instance.
-  /// @see AddFrame().
-  ///
-  /// @throws if @p model_instance is not valid for this model.
-  bool HasFrameNamed(
-      const std::string& name, ModelInstanceIndex model_instance) const {
-    return model_->HasFrameNamed(name, model_instance);
-  }
-
   /// @returns `true` if a joint named `name` was added to the %MultibodyPlant.
   /// @see AddJoint().
   ///

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -171,10 +171,6 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link2_name()));
   EXPECT_FALSE(plant->HasBodyNamed(kInvalidName));
 
-  EXPECT_TRUE(plant->HasFrameNamed(parameters.link1_name()));
-  EXPECT_TRUE(plant->HasFrameNamed(parameters.link2_name()));
-  EXPECT_FALSE(plant->HasFrameNamed(kInvalidName));
-
   EXPECT_TRUE(plant->HasJointNamed(parameters.shoulder_joint_name()));
   EXPECT_TRUE(plant->HasJointNamed(parameters.elbow_joint_name()));
   EXPECT_FALSE(plant->HasJointNamed(kInvalidName));


### PR DESCRIPTION
Reverts RobotLocomotion/drake#9411.

Dear @EricCousineau-TRI,

The on-call build cop believes that your PR #9411 may have
broken one or more of Drake's continuous integration builds [1,2]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms and tests are built post-merge.

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [3].

Thanks!

Your Friendly On-Call Build Cop

[1] CI Continuous Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/
[2] CI Nightly Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/
[3] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9432)
<!-- Reviewable:end -->
