### PR TITLE
Refactors common computations for contact Jacobians

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -624,11 +624,23 @@ MultibodyPlant<T>::DoMakeLeafContext() const {
 }
 
 template<typename T>
-MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
-    const Context<T>& context,
-    const std::vector<PenetrationAsPointPair<T>>& point_pairs_set) const {
+void MultibodyPlant<T>::CalcNormalAndTangentContactJacobians(
+    const systems::Context<T>& context,
+    const std::vector<geometry::PenetrationAsPointPair<T>>& point_pairs_set,
+    MatrixX<T>* Jn_ptr, MatrixX<T>* Jt_ptr,
+    std::vector<Matrix3<T>>* R_WC_set) const {
+  DRAKE_DEMAND(Jn_ptr != nullptr);
+  DRAKE_DEMAND(Jt_ptr != nullptr);
+
   const int num_contacts = point_pairs_set.size();
-  MatrixX<T> N(num_contacts, num_velocities());
+
+  // Jn is defined such that vn = Jn * v, with vn of size nc.
+  auto& Jn = *Jn_ptr;
+  Jn.resize(num_contacts, num_velocities());
+
+  // Jt is defined such that vt = Jt * v, with vt of size 2nc.
+  auto& Jt = *Jt_ptr;
+  Jt.resize(2 * num_contacts, num_velocities());
 
   for (int icontact = 0; icontact < num_contacts; ++icontact) {
     const auto& point_pair = point_pairs_set[icontact];
@@ -645,6 +657,11 @@ MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
     const Vector3<T>& nhat_BA_W = point_pair.nhat_BA_W;
     const Vector3<T>& p_WCa = point_pair.p_WCa;
     const Vector3<T>& p_WCb = point_pair.p_WCb;
+
+    // TODO(amcastro-tri): Consider using the midpoint between Ac and Bc for
+    // stability reasons. Besides that, there is no other reason to use the
+    // midpoint (or any other point between Ac and Bc for that matter) since,
+    // in the limit to rigid contact, Ac = Bc.
 
     // Geometric Jacobian for the velocity of the contact point C as moving with
     // body A, s.t.: v_WAc = Jv_WAc * v
@@ -659,6 +676,8 @@ MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
     tree().CalcPointsGeometricJacobianExpressedInWorld(
         context, bodyB.body_frame(), p_WCb, &Jv_WBc);
 
+    // Computation of the normal separation velocities Jacobian Jn:
+    //
     // The velocity of Bc relative to Ac is
     //   v_AcBc_W = v_WBc - v_WAc.
     // From where the separation velocity is computed as
@@ -666,43 +685,10 @@ MatrixX<T> MultibodyPlant<T>::CalcNormalSeparationVelocitiesJacobian(
     // where the negative sign stems from the sign convention for vn and xdot.
     // This can be written in terms of the Jacobians as
     //   vn = -nhat_BA_Wᵀ⋅(Jv_WBc - Jv_WAc)⋅v
+    Jn.row(icontact) = nhat_BA_W.transpose() * (Jv_WAc - Jv_WBc);
 
-    N.row(icontact) = nhat_BA_W.transpose() * (Jv_WAc - Jv_WBc);
-  }
-
-  return N;
-}
-
-template<typename T>
-MatrixX<T> MultibodyPlant<T>::CalcTangentVelocitiesJacobian(
-    const Context<T>& context,
-    const std::vector<PenetrationAsPointPair<T>>& point_pairs_set,
-    std::vector<Matrix3<T>>* R_WC_set) const {
-  const int num_contacts = point_pairs_set.size();
-  // D is defined such that vt = D * v, with vt of size 2nc.
-  MatrixX<T> D(2 * num_contacts, num_velocities());
-
-  DRAKE_ASSERT(R_WC_set);
-  R_WC_set->clear();
-  if (R_WC_set != nullptr) R_WC_set->reserve(point_pairs_set.size());
-  for (int icontact = 0; icontact < num_contacts; ++icontact) {
-    const auto& point_pair = point_pairs_set[icontact];
-
-    const GeometryId geometryA_id = point_pair.id_A;
-    const GeometryId geometryB_id = point_pair.id_B;
-
-    BodyIndex bodyA_index = geometry_id_to_body_index_.at(geometryA_id);
-    const Body<T>& bodyA = tree().get_body(bodyA_index);
-    BodyIndex bodyB_index = geometry_id_to_body_index_.at(geometryB_id);
-    const Body<T>& bodyB = tree().get_body(bodyB_index);
-
-    // Penetration depth, > 0 if bodies interpenetrate.
-    const T& x = point_pair.depth;
-    DRAKE_ASSERT(x >= 0);
-    const Vector3<T>& nhat_BA_W = point_pair.nhat_BA_W;
-    const Vector3<T>& p_WCa = point_pair.p_WCa;
-    const Vector3<T>& p_WCb = point_pair.p_WCb;
-
+    // Computation of the tangential velocities Jacobian Jt:
+    //
     // Compute the orientation of a contact frame C at the contact point such
     // that the z-axis Cz equals to nhat_BA_W. The tangent vectors are
     // arbitrary, with the only requirement being that they form a valid right
@@ -715,30 +701,15 @@ MatrixX<T> MultibodyPlant<T>::CalcTangentVelocitiesJacobian(
     const Vector3<T> that1_W = R_WC.col(0);  // that1 = Cx.
     const Vector3<T> that2_W = R_WC.col(1);  // that2 = Cy.
 
-    // TODO(amcastro-tri): Consider using the midpoint between Ac and Bc for
-    // stability reasons. Besides that, there is no other reason to use the
-    // midpoint (or any other point between Ac and Bc for that matter) since,
-    // in the limit to rigid contact, Ac = Bc.
-
-    MatrixX<T> Jv_WAc(3, this->num_velocities());  // s.t.: v_WAc = Jv_WAc * v.
-    tree().CalcPointsGeometricJacobianExpressedInWorld(
-        context, bodyA.body_frame(), p_WCa, &Jv_WAc);
-
-    MatrixX<T> Jv_WBc(3, this->num_velocities());  // s.t.: v_WBc = Jv_WBc * v.
-    tree().CalcPointsGeometricJacobianExpressedInWorld(
-        context, bodyB.body_frame(), p_WCb, &Jv_WBc);
-
     // The velocity of Bc relative to Ac is
     //   v_AcBc_W = v_WBc - v_WAc.
     // The first two components of this velocity in C corresponds to the
     // tangential velocities in a plane normal to nhat_BA.
     //   vx_AcBc_C = that1⋅v_AcBc = that1ᵀ⋅(Jv_WBc - Jv_WAc)⋅v
     //   vy_AcBc_C = that2⋅v_AcBc = that2ᵀ⋅(Jv_WBc - Jv_WAc)⋅v
-
-    D.row(2 * icontact)     = that1_W.transpose() * (Jv_WBc - Jv_WAc);
-    D.row(2 * icontact + 1) = that2_W.transpose() * (Jv_WBc - Jv_WAc);
+    Jt.row(2 * icontact)     = that1_W.transpose() * (Jv_WBc - Jv_WAc);
+    Jt.row(2 * icontact + 1) = that2_W.transpose() * (Jv_WBc - Jv_WAc);
   }
-  return D;
 }
 
 template<typename T>
@@ -1305,8 +1276,8 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
     // TODO(amcastro-tri): when it becomes a bottleneck, update the contact
     // solver to use operators instead so that we don't have to form these
     // Jacobian matrices explicitly (an O(num_contacts * nv) operation).
-    Jn = CalcNormalSeparationVelocitiesJacobian(context0, point_pairs0);
-    Jt = CalcTangentVelocitiesJacobian(context0, point_pairs0, &R_WC_set);
+    CalcNormalAndTangentContactJacobians(
+        context0, point_pairs0, &Jn, &Jt, &R_WC_set);
   }
 
   // Get friction coefficient into a single vector. Dynamic friction is ignored

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1570,8 +1570,11 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const systems::Context<T>& context, MultibodyForces<T>* forces) const;
 
   // Given a set of point pairs in `point_pairs_set`, this method computes the
-  // Jacobian N(q) such that:
-  //   vn = N(q) v
+  // normal velocities Jacobian Jn(q) and the tangential velocities Jacobian
+  // Jt(q).
+  //
+  // The normal velocities Jacobian Jn(q) is defined such that:
+  //   vn = Jn(q) v
   // where the i-th component of vn corresponds to the "separation velocity"
   // for the i-th point pair in the set. The i-th separation velocity is defined
   // positive for when the depth in the i-th point pair (
@@ -1579,16 +1582,11 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // the (positive) depth in PenetrationAsPointPair is defined so that it
   // corresponds to interpenetrating body geometries, a positive separation
   // velocity corresponds to bodies moving apart.
-  MatrixX<T> CalcNormalSeparationVelocitiesJacobian(
-      const systems::Context<T>& context,
-      const std::vector<geometry::PenetrationAsPointPair<T>>&
-      point_pairs_set) const;
-
-  // Given a set of nc point pairs in `point_pairs_set`, this method computes
-  // the tangential velocities Jacobian D(q) such that:
-  //   vt = D(q) v
-  // where v ∈ ℝⁿᵛ is the vector of generalized velocities, D(q) is a matrix of
-  // size 2⋅nc×nv and vt is a vector of size 2⋅nc.
+  //
+  // The tangential velocities Jacobian Jt(q) is defined such that:
+  //   vt = Jt(q) v
+  // where v ∈ ℝⁿᵛ is the vector of generalized velocities, Jt(q) is a matrix
+  // of size 2⋅nc×nv and vt is a vector of size 2⋅nc.
   // This method defines a contact frame C with orientation R_WC in the world
   // frame W such that Cz_W = nhat_BA_W, the normal direction in the point
   // pair (PenetrationAsPointPair::nhat_BA_W).
@@ -1604,9 +1602,10 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   // If the optional output argument R_WC_set is provided with a valid non
   // nullptr vector, on output the i-th entry of R_WC_set will contain the
   // orientation R_WC of the i-th point pair in the set.
-  MatrixX<T> CalcTangentVelocitiesJacobian(
+  void CalcNormalAndTangentContactJacobians(
       const systems::Context<T>& context,
       const std::vector<geometry::PenetrationAsPointPair<T>>& point_pairs_set,
+      MatrixX<T>* Jn, MatrixX<T>* Jt,
       std::vector<Matrix3<T>>* R_WC_set = nullptr) const;
 
   // The entire multibody model.


### PR DESCRIPTION
This PR deals makes sure we don't compute stuff twice between the normal and tangent Jacobians in MBP. This corresponds to the first action item in #9428.

It is just a refactor to improve simulation performance and therefore the code here is already unit tested in master.

Performance improvements are in the order of 20%, I'll update profiling results in #8942 once this PR gets merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9433)
<!-- Reviewable:end -->
