### PR TITLE
InverseDynamicsController does not own the plant.

### DIFF
--- a/bindings/pydrake/systems/controllers_py.cc
+++ b/bindings/pydrake/systems/controllers_py.cc
@@ -74,7 +74,7 @@ PYBIND11_MODULE(controllers, m) {
            // Keep alive, ownership: RigidBodyTree keeps this alive.
            // See "Keep Alive Behavior" in pydrake_pybind.h for details.
            py::keep_alive<2 /* Nurse */, 1 /* Patient */>())
-      .def(py::init<std::unique_ptr<MultibodyPlant<double>>,
+      .def(py::init<const MultibodyPlant<double>&,
                     const VectorX<double>&,
                     const VectorX<double>&,
                     const VectorX<double>&,
@@ -84,8 +84,8 @@ PYBIND11_MODULE(controllers, m) {
            py::arg("ki"),
            py::arg("kd"),
            py::arg("has_reference_acceleration"),
-          // Keep alive, ownership: MultibodyPlant keeps this alive.
-           py::keep_alive<2, 1>())
+           // Keep alive, reference: `self` keeps `MultibodyPlant` alive.
+           py::keep_alive<1, 2>())
       .def("set_integral_value",
            &InverseDynamicsController<double>::set_integral_value);
 

--- a/bindings/pydrake/systems/test/controllers_test.py
+++ b/bindings/pydrake/systems/test/controllers_test.py
@@ -271,14 +271,14 @@ class TestControllers(unittest.TestCase):
 
         # Set the plant's context.
         plant_context = plant.CreateDefaultContext()
-        x_plant = plant.model().get_mutable_multibody_state_vector(
+        x_plant = plant.tree().get_mutable_multibody_state_vector(
             plant_context)
         x_plant[:] = x
 
         # Compute the expected value of the generalized forces using
         # inverse dynamics.
-        tau_id = plant.model().CalcInverseDynamics(
-            plant_context, vd_d, MultibodyForces(plant.model()))
+        tau_id = plant.tree().CalcInverseDynamics(
+            plant_context, vd_d, MultibodyForces(plant.tree()))
 
         # Verify the result.
         controller.CalcOutput(context, output)

--- a/systems/controllers/inverse_dynamics_controller.cc
+++ b/systems/controllers/inverse_dynamics_controller.cc
@@ -119,15 +119,17 @@ InverseDynamicsController<T>::InverseDynamicsController(
 
 template <typename T>
 InverseDynamicsController<T>::InverseDynamicsController(
-    std::unique_ptr<MultibodyPlant<T>> robot,
+    const MultibodyPlant<T>& plant,
     const VectorX<double>& kp, const VectorX<double>& ki,
     const VectorX<double>& kd, bool has_reference_acceleration)
-    : multibody_plant_for_control_(std::move(robot)),
+    : multibody_plant_for_control_(&plant),
       has_reference_acceleration_(has_reference_acceleration) {
+  DRAKE_DEMAND(plant.is_finalized());
+
   DiagramBuilder<T> builder;
   auto inverse_dynamics =
     builder.template AddSystem<InverseDynamics<T>>(
-      multibody_plant_for_control_.get(),
+      multibody_plant_for_control_,
       false /* pure gravity compensation */);
 
   const int num_positions = multibody_plant_for_control_->num_positions();

--- a/systems/controllers/test/inverse_dynamics_controller_test.cc
+++ b/systems/controllers/test/inverse_dynamics_controller_test.cc
@@ -114,8 +114,7 @@ GTEST_TEST(InverseDynamicsControllerTestMBP, TestTorque) {
   kd = kp / 2.;
 
   auto dut = std::make_unique<InverseDynamicsController<double>>(
-      std::move(robot), kp, ki, kd,
-          true /* expose reference acceleration port */);
+      *robot, kp, ki, kd, true /* expose reference acceleration port */);
   auto inverse_dynamics_context = dut->CreateDefaultContext();
   auto output = dut->AllocateOutput();
   const MultibodyPlant<double>& robot_plant =


### PR DESCRIPTION
Per observation in #9435,  there is no reason for the `InverseDynamicsController` to own the plant but holding a reference is more appropriate. Also, this will avoid having to make a model for simulation and a model for control as reflected in #9435.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9441)
<!-- Reviewable:end -->
