### PR TITLE
Controlled kuka with lumped gripper model

### DIFF
--- a/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
+++ b/examples/kuka_iiwa_arm/controlled_kuka/BUILD.bazel
@@ -49,6 +49,7 @@ drake_cc_binary(
     data = [
         "//examples/kuka_iiwa_arm:models",
         "//manipulation/models/iiwa_description:models",
+        "//manipulation/models/wsg_50_description:models",
     ],
     deps = [
         ":controlled_kuka_trajectory",

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -154,7 +154,7 @@ std::unique_ptr<MultibodyPlant<double>> MakePlantWithCompositeGripper(
 
   // Weld gripper to end effector.
   const auto& end_effector = plant->GetFrameByName("iiwa_link_7");
-  plant->WeldFrames(end_effector, gripper.body_frame());
+  plant->WeldFrames(end_effector, gripper.body_frame(), X_EG);
 
   // Add gravity to the model.
   plant->AddForceElement<UniformGravityFieldElement>(

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -19,6 +19,7 @@
 #include "drake/lcm/drake_lcm.h"
 #include "drake/math/roll_pitch_yaw.h"
 #include "drake/math/rotation_matrix.h"
+#include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 #include "drake/multibody/multibody_tree/multibody_plant/multibody_plant.h"
 #include "drake/multibody/multibody_tree/parsing/multibody_plant_sdf_parser.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
@@ -27,7 +28,6 @@
 #include "drake/systems/controllers/inverse_dynamics_controller.h"
 #include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/primitives/trajectory_source.h"
-#include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 
 DEFINE_double(simulation_sec, 0.1, "Number of seconds to simulate.");
 
@@ -35,7 +35,7 @@ using drake::geometry::SceneGraph;
 using drake::lcm::DrakeLcm;
 using drake::math::RollPitchYaw;
 using drake::multibody::Body;
-using drake::multibody::ModelInstanceIndex ;
+using drake::multibody::ModelInstanceIndex;
 using drake::multibody::multibody_plant::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 using drake::multibody::parsing::AddModelFromSdfFile;
@@ -69,7 +69,8 @@ SpatialInertia<double> MakeCompositeGripperInertia() {
   const auto& left_slider = plant.GetJointByName("left_finger_sliding_joint");
   const auto& right_slider = plant.GetJointByName("right_finger_sliding_joint");
 
-  const SpatialInertia<double>& M_GGo_G = gripper_body.default_spatial_inertia();
+  const SpatialInertia<double>& M_GGo_G =
+      gripper_body.default_spatial_inertia();
   const SpatialInertia<double>& M_LLo_L =
       left_finger.default_spatial_inertia();
   const SpatialInertia<double>& M_RRo_R =
@@ -129,7 +130,8 @@ std::unique_ptr<MultibodyPlant<double>> MakePlantWithCompositeGripper(
     SceneGraph<double>* scene_graph) {
   auto plant = std::make_unique<MultibodyPlant<double>>();
   ModelInstanceIndex arm_model =
-      AddModelFromSdfFile(FindResourceOrThrow(kSdfPath), plant.get(), scene_graph);
+      AddModelFromSdfFile(
+          FindResourceOrThrow(kSdfPath), plant.get(), scene_graph);
   plant->WeldFrames(plant->world_frame(),
                     plant->GetFrameByName("iiwa_link_0"));
 

--- a/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
+++ b/examples/kuka_iiwa_arm/controlled_kuka/controlled_kuka_multibody_demo.cc
@@ -136,11 +136,19 @@ std::unique_ptr<MultibodyPlant<double>> MakePlantWithCompositeGripper(
   // Pose of the gripper G in the end effector frame E.
   Isometry3<double> X_EG = Isometry3<double>::Identity();
   X_EG.translation() = Vector3<double>(0, 0, 0.081);
-  X_EG.linear() = RollPitchYaw<double>(M_PI_2, 0, M_PI_2).ToRotationMatrix().matrix();
+  X_EG.linear() =
+      RollPitchYaw<double>(M_PI_2, 0, M_PI_2).ToRotationMatrix().matrix();
 
   // Add a "lumped" model of the gripper.
   const auto& gripper = plant->AddRigidBody(
       "gripper", arm_model, MakeCompositeGripperInertia());
+
+  // From the SDF it'd seem that axes are such that (Rick please confirm):
+  // - x points towards the right finger.
+  // - y points forward, away from the body, in the direction of the fingers.
+  // - z points "up" defined by the cross product of x and y.
+  std::cout << "Gripper's composite spatial inertia: " << std::endl;
+  std::cout << MakeCompositeGripperInertia() << std::endl;
 
   // Weld gripper to end effector.
   const auto& end_effector = plant->GetFrameByName("iiwa_link_7");


### PR DESCRIPTION
Updates the controlled kuka demo to include a lumped gripper model.


A little xmas present for you @rcory, you'll have to babysit this while I'm gone.
All the math follows our monogram notation, ask @sherm1 or @mitiguy if you need help with it. If I made any mistake, it should be easy to fix from the notation and docs I provide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9458)
<!-- Reviewable:end -->
