### PR TITLE
Name output ports

### DIFF
--- a/bindings/pydrake/systems/drawing_graphviz_example.py
+++ b/bindings/pydrake/systems/drawing_graphviz_example.py
@@ -36,6 +36,7 @@ builder.Connect(
 builder.Connect(
     cart_pole.get_geometry_poses_output_port(),
     scene_graph.get_source_pose_port(cart_pole.get_source_id()))
+builder.ExportInput(cart_pole.get_actuation_input_port())
 
 ConnectDrakeVisualizer(builder=builder, scene_graph=scene_graph)
 

--- a/bindings/pydrake/systems/framework_py_semantics.cc
+++ b/bindings/pydrake/systems/framework_py_semantics.cc
@@ -29,6 +29,7 @@ void DefineFrameworkPySemantics(py::module m) {
   using namespace drake::systems;
 
   m.attr("kAutoSize") = kAutoSize;
+  m.attr("kUseDefaultName") = kUseDefaultName;
 
   py::enum_<PortDataType>(m, "PortDataType")
     .value("kVectorValued", kVectorValued)
@@ -167,9 +168,9 @@ void DefineFrameworkPySemantics(py::module m) {
                const OutputPort<T>&, const InputPort<T>&>(
                &DiagramBuilder<T>::Connect))
       .def("ExportInput", &DiagramBuilder<T>::ExportInput, py::arg("input"),
-           py::arg("name") = "", py_reference_internal)
-      .def("ExportOutput", &DiagramBuilder<T>::ExportOutput,
-           py_reference_internal)
+           py::arg("name") = kUseDefaultName, py_reference_internal)
+      .def("ExportOutput", &DiagramBuilder<T>::ExportOutput, py::arg("output"),
+           py::arg("name") = kUseDefaultName, py_reference_internal)
       .def("Build", &DiagramBuilder<T>::Build,
            // Keep alive, transitive: `return` keeps `self` alive.
            py::keep_alive<1, 0>())

--- a/bindings/pydrake/systems/test/custom_test.py
+++ b/bindings/pydrake/systems/test/custom_test.py
@@ -15,6 +15,7 @@ from pydrake.systems.framework import (
     AbstractValue,
     BasicVector, BasicVector_,
     DiagramBuilder,
+    kUseDefaultName,
     LeafSystem, LeafSystem_,
     PortDataType,
     VectorSystem,
@@ -39,8 +40,9 @@ class CustomAdder(LeafSystem):
     def __init__(self, num_inputs, size):
         LeafSystem.__init__(self)
         for i in xrange(num_inputs):
-            self._DeclareInputPort(PortDataType.kVectorValued, size)
-        self._DeclareVectorOutputPort(BasicVector(size), self._calc_sum)
+            self._DeclareInputPort(kUseDefaultName, PortDataType.kVectorValued,
+                                   size)
+        self._DeclareVectorOutputPort("sum", BasicVector(size), self._calc_sum)
 
     def _calc_sum(self, context, sum_data):
         # @note This will NOT work if the scalar type is AutoDiff or symbolic,
@@ -343,9 +345,9 @@ class TestCustom(unittest.TestCase):
                     LeafSystem_[T].__init__(self)
                     test_input_type = AbstractValue.Make(
                         default_value)
-                    self.input_port = self._DeclareInputPort(
-                        PortDataType.kAbstractValued, 0)
+                    self.input_port = self._DeclareAbstractInputPort("in")
                     self.output_port = self._DeclareAbstractOutputPort(
+                        "out",
                         lambda: AbstractValue.Make(default_value),
                         self._DoCalcAbstractOutput)
 

--- a/bindings/pydrake/systems/test/general_test.py
+++ b/bindings/pydrake/systems/test/general_test.py
@@ -31,6 +31,7 @@ from pydrake.systems.framework import (
     DiscreteValues_,
     Event_,
     InputPort_,
+    kUseDefaultName,
     LeafContext_,
     LeafSystem_,
     OutputPort_,
@@ -238,10 +239,11 @@ class TestGeneral(unittest.TestCase):
         builder.Connect(adder1.get_output_port(0),
                         integrator.get_input_port(0))
 
+        # Exercise naming variants.
         builder.ExportInput(adder0.get_input_port(0))
-        builder.ExportInput(adder0.get_input_port(1))
-        builder.ExportInput(adder1.get_input_port(1))
-        builder.ExportOutput(integrator.get_output_port(0))
+        builder.ExportInput(adder0.get_input_port(1), kUseDefaultName)
+        builder.ExportInput(adder1.get_input_port(1), "third_input")
+        builder.ExportOutput(integrator.get_output_port(0), "result")
 
         diagram = builder.Build()
         # TODO(eric.cousineau): Figure out unicode handling if needed.

--- a/examples/pendulum/pendulum_plant.cc
+++ b/examples/pendulum/pendulum_plant.cc
@@ -42,11 +42,7 @@ PendulumPlant<T>::PendulumPlant(const PendulumPlant<U>& p) : PendulumPlant() {
   frame_id_ = p.frame_id();
 
   if (source_id_.is_valid()) {
-    geometry_pose_port_ =
-        this->DeclareAbstractOutputPort(
-                geometry::FramePoseVector<T>(source_id_, {frame_id_}),
-                &PendulumPlant<T>::CopyPoseOut)
-            .get_index();
+    geometry_pose_port_ = AllocateGeometryPoseOutputPort();
   }
 }
 
@@ -156,11 +152,16 @@ void PendulumPlant<T>::RegisterGeometry(
           VisualMaterial(Vector4d(0, 0, 1, 1))));
 
   // Now allocate the output port.
-  geometry_pose_port_ =
-      this->DeclareAbstractOutputPort(
-              geometry::FramePoseVector<T>(source_id_, {frame_id_}),
-              &PendulumPlant<T>::CopyPoseOut)
-          .get_index();
+  geometry_pose_port_ = AllocateGeometryPoseOutputPort();
+}
+
+template <typename T>
+systems::OutputPortIndex PendulumPlant<T>::AllocateGeometryPoseOutputPort() {
+  DRAKE_DEMAND(source_id_.is_valid() && frame_id_.is_valid());
+  return this->DeclareAbstractOutputPort("geometry_pose",
+      geometry::FramePoseVector<T>(source_id_, {frame_id_}),
+                                  &PendulumPlant<T>::CopyPoseOut)
+      .get_index();
 }
 
 }  // namespace pendulum

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -103,6 +103,8 @@ class PendulumPlant final : public systems::LeafSystem<T> {
   }
 
  private:
+  systems::OutputPortIndex AllocateGeometryPoseOutputPort();
+
   // This is the calculator method for the state output port.
   void CopyStateOut(const systems::Context<T>& context,
                     PendulumState<T>* output) const;

--- a/geometry/scene_graph.cc
+++ b/geometry/scene_graph.cc
@@ -81,13 +81,12 @@ SceneGraph<T>::SceneGraph()
   model_inspector_.set(initial_state_);
   geometry_state_index_ = this->DeclareAbstractState(std::move(state_value));
 
-  bundle_port_index_ =
-      this->DeclareAbstractOutputPort(&SceneGraph::MakePoseBundle,
-                                      &SceneGraph::CalcPoseBundle)
-          .get_index();
+  bundle_port_index_ = this->DeclareAbstractOutputPort("lcm_visualization",
+                               &SceneGraph::MakePoseBundle,
+                               &SceneGraph::CalcPoseBundle).get_index();
 
   query_port_index_ =
-      this->DeclareAbstractOutputPort(&SceneGraph::MakeQueryObject,
+      this->DeclareAbstractOutputPort("query", &SceneGraph::MakeQueryObject,
                                       &SceneGraph::CalcQueryObject)
           .get_index();
 }

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -1429,9 +1429,10 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     last_actuated_instance = model_instance_index;
     instance_actuation_ports_[model_instance_index] =
         this->DeclareVectorInputPort(
-            systems::BasicVector<T>(instance_num_dofs),
                 tree_->GetModelInstanceName(model_instance_index) +
-                "_actuation").get_index();
+                    "_actuation",
+                systems::BasicVector<T>(instance_num_dofs))
+            .get_index();
   }
 
   if (num_actuated_instances == 1) {
@@ -1440,9 +1441,10 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
 
   // Declare one output port for the entire state vector.
   continuous_state_output_port_ =
-      this->DeclareVectorOutputPort(
-          BasicVector<T>(num_multibody_states()),
-          &MultibodyPlant::CopyContinuousStateOut).get_index();
+      this->DeclareVectorOutputPort("continuous_state",
+                                    BasicVector<T>(num_multibody_states()),
+                                    &MultibodyPlant::CopyContinuousStateOut)
+          .get_index();
 
   // Declare per model instance state output ports.
   instance_continuous_state_output_ports_.resize(num_model_instances());
@@ -1460,7 +1462,10 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     };
     instance_continuous_state_output_ports_[model_instance_index] =
         this->DeclareVectorOutputPort(
-            BasicVector<T>(instance_num_states), calc).get_index();
+                tree_->GetModelInstanceName(model_instance_index) +
+                    "_continuous_state",
+                BasicVector<T>(instance_num_states), calc)
+            .get_index();
   }
 
   // Declare per model instance output port of generalized contact forces.
@@ -1480,13 +1485,17 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     };
     instance_generalized_contact_forces_output_ports_[model_instance_index] =
         this->DeclareVectorOutputPort(
-            BasicVector<T>(instance_num_velocities), calc).get_index();
+                tree_->GetModelInstanceName(model_instance_index) +
+                    "_generalized_contact_forces",
+                BasicVector<T>(instance_num_velocities), calc)
+            .get_index();
   }
 
   // Contact results output port.
   contact_results_port_ = this->DeclareAbstractOutputPort(
-      ContactResults<T>(),
-      &MultibodyPlant<T>::CalcContactResultsOutput).get_index();
+                                  "contact_results", ContactResults<T>(),
+                                  &MultibodyPlant<T>::CalcContactResultsOutput)
+                              .get_index();
 }
 
 template <typename T>
@@ -1622,9 +1631,10 @@ void MultibodyPlant<T>::DeclareSceneGraphPorts() {
     ids.push_back(it.second);
   }
   geometry_pose_port_ =
-      this->DeclareAbstractOutputPort(
-          FramePoseVector<T>(*source_id_, ids),
-          &MultibodyPlant::CalcFramePoseOutput).get_index();
+      this->DeclareAbstractOutputPort("geometry_pose",
+                                      FramePoseVector<T>(*source_id_, ids),
+                                      &MultibodyPlant::CalcFramePoseOutput)
+          .get_index();
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -162,6 +162,19 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
   EXPECT_EQ(plant->get_continuous_state_output_port(
       pendulum_model_instance).size(), 2);
 
+  // Check that model-instance ports get named properly.
+  EXPECT_TRUE(plant->HasModelInstanceNamed("DefaultModelInstance"));
+  EXPECT_TRUE(plant->HasModelInstanceNamed("SplitPendulum"));
+  EXPECT_EQ(
+      plant->get_actuation_input_port(default_model_instance()).get_name(),
+      "DefaultModelInstance_actuation");
+  EXPECT_EQ(plant->get_continuous_state_output_port(default_model_instance())
+                .get_name(),
+            "DefaultModelInstance_continuous_state");
+  EXPECT_EQ(plant->get_continuous_state_output_port(pendulum_model_instance)
+                .get_name(),
+            "SplitPendulum_continuous_state");
+
   // Query if elements exist in the model.
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link1_name()));
   EXPECT_TRUE(plant->HasBodyNamed(parameters.link2_name()));

--- a/systems/framework/diagram_output_port.h
+++ b/systems/framework/diagram_output_port.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "drake/common/drake_assert.h"
@@ -37,6 +38,8 @@ class DiagramOutputPort final : public OutputPort<T> {
 
   @param diagram The Diagram that will own this port.
   @param system_base The same Diagram cast to its base class.
+  @param name A name for the port.  Output ports names must be unique
+      within the `diagram` System.
   @param index The output port index to be assigned to the new port.
   @param ticket The DependencyTicket to be assigned to the new port.
   @param source_output_port An output port of one of this diagram's child
@@ -59,11 +62,12 @@ class DiagramOutputPort final : public OutputPort<T> {
   // the caller to do that cast for us so take a System<T> here.
   DiagramOutputPort(const System<T>* diagram,
                     SystemBase* system_base,
+                    std::string name,
                     OutputPortIndex index,
                     DependencyTicket ticket,
                     const OutputPort<T>* source_output_port,
                     SubsystemIndex source_subsystem_index)
-      : OutputPort<T>(diagram, system_base, index, ticket,
+      : OutputPort<T>(diagram, system_base, std::move(name), index, ticket,
                       source_output_port->get_data_type(),
                       source_output_port->size()),
         source_output_port_(source_output_port),

--- a/systems/framework/framework_common.h
+++ b/systems/framework/framework_common.h
@@ -72,6 +72,14 @@ rather depends on what it is connected to (not yet implemented). */
 // TODO(sherm1) Implement this.
 constexpr int kAutoSize = -1;
 
+/** Name to use when you want a default one generated. This is set to an ugly
+string that no one will want to use as an actual name. You should normally
+give meaningful names to all Drake System entities you create rather than
+using this. */
+// TODO(sherm1) Consider using std::variant<string,systems::UseDefaultName>
+// as an alternative to this hack.
+constexpr const char* kUseDefaultName = "__use_default_name__";
+
 #ifndef DRAKE_DOXYGEN_CXX
 class AbstractValue;
 class ContextBase;

--- a/systems/framework/input_port.h
+++ b/systems/framework/input_port.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 #include "drake/common/constants.h"
 #include "drake/common/drake_deprecated.h"
@@ -26,15 +27,16 @@ class InputPort final : public InputPortBase {
   /// (Internal use only)
   /// Constructs a type-specific input port. See InputPortBase::InputPortBase()
   /// for the meaning of these parameters. The additional `system` parameter
-  /// here must be the same object as the `system_base` parameter.
+  /// here must be the same object as the `system_base` parameter. The
+  /// `name` must not be empty.
   // The System and SystemBase are provided separately since we don't have
   // access to System's declaration here so can't cast but the caller can.
-  InputPort(InputPortIndex index, DependencyTicket ticket,
-            PortDataType data_type, int size, const std::string& name,
-            const optional<RandomDistribution>& random_type,
-            const System<T>* system, SystemBase* system_base)
-      : InputPortBase(index, ticket, data_type, size, name, random_type,
-                      system_base),
+  InputPort(const System<T>* system, SystemBase* system_base, std::string name,
+            InputPortIndex index, DependencyTicket ticket,
+            PortDataType data_type, int size,
+            const optional<RandomDistribution>& random_type)
+      : InputPortBase(system_base, std::move(name), index, ticket, data_type,
+                      size, random_type),
         system_(*system) {
     DRAKE_DEMAND(system != nullptr);
     DRAKE_DEMAND(static_cast<const void*>(system) == system_base);

--- a/systems/framework/input_port_base.cc
+++ b/systems/framework/input_port_base.cc
@@ -1,24 +1,25 @@
 #include "drake/systems/framework/input_port_base.h"
 
+#include <utility>
+
 #include "drake/common/drake_assert.h"
 
 namespace drake {
 namespace systems {
 
-InputPortBase::InputPortBase(InputPortIndex index, DependencyTicket ticket,
+InputPortBase::InputPortBase(SystemBase* owning_system, std::string name,
+                             InputPortIndex index, DependencyTicket ticket,
                              PortDataType data_type, int size,
-                             const std::string& name,
-                             const optional<RandomDistribution>& random_type,
-                             SystemBase* system_base)
-    : system_(*system_base),
+                             const optional<RandomDistribution>& random_type)
+    : owning_system_(*owning_system),
       index_(index),
       ticket_(ticket),
       data_type_(data_type),
       size_(size),
-      name_(name),
+      name_(std::move(name)),
       random_type_(random_type) {
-  DRAKE_DEMAND(system_base != nullptr);
-  DRAKE_DEMAND(!name.empty());
+  DRAKE_DEMAND(owning_system != nullptr);
+  DRAKE_DEMAND(!name_.empty());
   if (size_ == kAutoSize) {
     DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
   }

--- a/systems/framework/input_port_base.h
+++ b/systems/framework/input_port_base.h
@@ -39,7 +39,7 @@ class InputPortBase {
   /** Returns a reference to the SystemBase that owns this input port. Note that
   for a diagram input port this will be the diagram, not the leaf system whose
   input port was exported. */
-  const SystemBase& get_system_base() const { return system_; }
+  const SystemBase& get_system_base() const { return owning_system_; }
 
   /** Returns the port data type. */
   PortDataType get_data_type() const { return data_type_; }
@@ -61,6 +61,11 @@ class InputPortBase {
   /** Provides derived classes the ability to set the base
   class members at construction.
 
+  @param owning_system
+    The System that owns this input port.
+  @param name
+    A name for the port. Input port names should be non-empty and unique
+    within a single System.
   @param index
     The index to be assigned to this InputPort.
   @param ticket
@@ -70,23 +75,17 @@ class InputPortBase {
   @param size
     If the port described is vector-valued, the number of elements, or kAutoSize
     if determined by connections. Ignored for abstract-valued ports.
-  @param name
-    A name for the port.  Input port names should be non-empty and unique
-    within a single System.
   @param random_type
     Input ports may optionally be labeled as random, if the port is intended to
-    model a random-source "noise" or "disturbance" input.
-  @param system_base
-    The System that will own this new input port. */
-  InputPortBase(InputPortIndex index, DependencyTicket ticket,
+    model a random-source "noise" or "disturbance" input. */
+  InputPortBase(SystemBase* owning_system, std::string name,
+                InputPortIndex index, DependencyTicket ticket,
                 PortDataType data_type, int size,
-                const std::string& name,
-                const optional<RandomDistribution>& random_type,
-                SystemBase* system_base);
+                const optional<RandomDistribution>& random_type);
 
  private:
   // Associated System and System resources.
-  const SystemBase& system_;
+  const SystemBase& owning_system_;
   const InputPortIndex index_;
   const DependencyTicket ticket_;
 

--- a/systems/framework/leaf_output_port.h
+++ b/systems/framework/leaf_output_port.h
@@ -2,6 +2,8 @@
 
 #include <functional>
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "drake/common/drake_assert.h"
 #include "drake/common/drake_copyable.h"
@@ -58,10 +60,11 @@ class LeafOutputPort final : public OutputPort<T> {
   /** Constructs a cached output port. The `system` parameter must be the same
   object as the `system_base` parameter. */
   LeafOutputPort(const System<T>* system, SystemBase* system_base,
-                 OutputPortIndex index, DependencyTicket ticket,
-                 PortDataType data_type, int size,
+                 std::string name, OutputPortIndex index,
+                 DependencyTicket ticket, PortDataType data_type, int size,
                  const CacheEntry* cache_entry)
-      : OutputPort<T>(system, system_base, index, ticket, data_type, size),
+      : OutputPort<T>(system, system_base, std::move(name), index, ticket,
+                      data_type, size),
         cache_entry_(cache_entry) {
     DRAKE_DEMAND(cache_entry != nullptr);
   }

--- a/systems/framework/output_port.h
+++ b/systems/framework/output_port.h
@@ -142,15 +142,16 @@ class OutputPort : public OutputPortBase {
   /** Provides derived classes the ability to set the base class members at
   construction. See OutputPortBase::OutputPortBase() for the meaning of these
   parameters.
+  @pre The `name` must not be empty.
   @pre The `system` parameter must be the same object as the `system_base`
   parameter. */
   // The System and SystemBase are provided separately since we don't have
   // access to System's declaration here so can't cast but the caller can.
-  OutputPort(const System<T>* system,
-             SystemBase* system_base,
-             OutputPortIndex index,
-             DependencyTicket ticket, PortDataType data_type, int size)
-      : OutputPortBase(system_base, index, ticket, data_type, size),
+  OutputPort(const System<T>* system, SystemBase* system_base, std::string name,
+             OutputPortIndex index, DependencyTicket ticket,
+             PortDataType data_type, int size)
+      : OutputPortBase(system_base, std::move(name), index, ticket, data_type,
+                       size),
         system_{*system} {
     DRAKE_DEMAND(static_cast<const void*>(system) == system_base);
   }

--- a/systems/framework/output_port_base.cc
+++ b/systems/framework/output_port_base.cc
@@ -1,5 +1,7 @@
 #include "drake/systems/framework/output_port_base.h"
 
+#include <utility>
+
 #include "drake/common/drake_assert.h"
 #include "drake/systems/framework/framework_common.h"
 
@@ -8,16 +10,14 @@ namespace systems {
 
 OutputPortBase::~OutputPortBase() = default;
 
-OutputPortBase::OutputPortBase(
-    SystemBase* owning_system,
-    OutputPortIndex index, DependencyTicket ticket, PortDataType data_type,
-    int size)
+OutputPortBase::OutputPortBase(SystemBase* owning_system, std::string name,
+                               OutputPortIndex index, DependencyTicket ticket,
+                               PortDataType data_type, int size)
     : owning_system_(*owning_system),
-      index_(index),
-      ticket_(ticket),
-      data_type_(data_type),
-      size_(size) {
+      name_(std::move(name)), index_(index), ticket_(ticket),
+            data_type_(data_type), size_(size) {
   DRAKE_DEMAND(owning_system != nullptr);
+  DRAKE_DEMAND(!name_.empty());
   if (size_ == kAutoSize)
     DRAKE_ABORT_MSG("Auto-size ports are not yet implemented.");
 }

--- a/systems/framework/output_port_base.h
+++ b/systems/framework/output_port_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "drake/systems/framework/framework_common.h"
 
 namespace drake {
@@ -46,6 +48,9 @@ class OutputPortBase {
     return owning_system_;
   }
 
+  /** Gets port name. */
+  const std::string& get_name() const { return name_; }
+
 #ifndef DRAKE_DOXYGEN_CXX
   // Internal use only. Returns the prerequisite for this output port -- either
   // a cache entry in this System, or an output port of a child System.
@@ -60,6 +65,9 @@ class OutputPortBase {
 
   @param owning_system
     The System that owns this output port.
+  @param name
+    A name for the port. Must not be empty. Output port names should be unique
+    within a single System.
   @param index
     The index to be assigned to this OutputPort.
   @param ticket
@@ -69,7 +77,7 @@ class OutputPortBase {
   @param size
     If the port described is vector-valued, the number of elements expected,
     otherwise ignored. */
-  OutputPortBase(SystemBase* owning_system,
+  OutputPortBase(SystemBase* owning_system, std::string name,
                  OutputPortIndex index, DependencyTicket ticket,
                  PortDataType data_type, int size);
 
@@ -85,6 +93,7 @@ class OutputPortBase {
  private:
   // Associated System and System resources.
   SystemBase& owning_system_;
+  const std::string name_;
   const OutputPortIndex index_;
   const DependencyTicket ticket_;
 

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -751,27 +751,73 @@ class SystemBase : public internal::SystemMessageInterface {
   /** (Internal use only) Adds an already-constructed input port to this System.
   Insists that the port already contains a reference to this System, and that
   the port's index is already set to the next available input port index for
-  this System. */
+  this System, that the port name is unique (just within this System), and that
+  the port name is non-empty. */
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
   void AddInputPort(std::unique_ptr<InputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
     DRAKE_DEMAND(&port->get_system_base() == this);
-    DRAKE_DEMAND(port->get_index() == this->get_num_input_ports());
+    DRAKE_DEMAND(port->get_index() == get_num_input_ports());
+    DRAKE_DEMAND(!port->get_name().empty());
+
+    // Check that name is unique.
+    for (InputPortIndex i{0}; i < get_num_input_ports(); i++) {
+      if (port->get_name() == get_input_port_base(i).get_name()) {
+        throw std::logic_error("System " + GetSystemName() +
+            " already has an input port named " +
+            port->get_name());
+      }
+    }
+
     input_ports_.push_back(std::move(port));
   }
 
   /** (Internal use only) Adds an already-constructed output port to this
   System. Insists that the port already contains a reference to this System, and
   that the port's index is already set to the next available output port index
-  for this System. */
+  for this System, and that the name of the port is unique.
+  @throws std::logic_error if the name of the output port is not unique. */
   // TODO(sherm1) Add check on suitability of `size` parameter for the port's
   // data type.
   void AddOutputPort(std::unique_ptr<OutputPortBase> port) {
     DRAKE_DEMAND(port != nullptr);
     DRAKE_DEMAND(&port->get_system_base() == this);
-    DRAKE_DEMAND(port->get_index() == this->get_num_output_ports());
+    DRAKE_DEMAND(port->get_index() == get_num_output_ports());
+    DRAKE_DEMAND(!port->get_name().empty());
+
+    // Check that name is unique.
+    for (OutputPortIndex i{0}; i < get_num_output_ports(); i++) {
+      if (port->get_name() == get_output_port_base(i).get_name()) {
+        throw std::logic_error("System " + GetSystemName() +
+                               " already has an output port named " +
+                               port->get_name());
+      }
+    }
+
     output_ports_.push_back(std::move(port));
+  }
+
+  /** (Internal use only) Returns a name for the next input port, using the
+  given name if it isn't kUseDefaultName, otherwise making up a name like "u3"
+  from the next available input port index.
+  @pre `given_name` must not be empty. */
+  std::string NextInputPortName(std::string given_name) const {
+    DRAKE_DEMAND(!given_name.empty());
+    return given_name == kUseDefaultName
+           ? std::string("u") + std::to_string(get_num_input_ports())
+           : std::move(given_name);
+  }
+
+  /** (Internal use only) Returns a name for the next output port, using the
+  given name if it isn't kUseDefaultName, otherwise making up a name like "y3"
+  from the next available output port index.
+  @pre `given_name` must not be empty. */
+  std::string NextOutputPortName(std::string given_name) const {
+    DRAKE_DEMAND(!given_name.empty());
+    return given_name == kUseDefaultName
+           ? std::string("y") + std::to_string(get_num_output_ports())
+           : std::move(given_name);
   }
 
   /** (Internal use only) Assigns a ticket to a new discrete variable group

--- a/systems/framework/test/diagram_builder_test.cc
+++ b/systems/framework/test/diagram_builder_test.cc
@@ -197,10 +197,18 @@ GTEST_TEST(DiagramBuilderTest, SystemsThatAreNotAddedThrow) {
 template <typename T>
 class Sink : public LeafSystem<T> {
  public:
-  Sink() { this->DeclareInputPort(kVectorValued, 1, "in"); }
+  Sink() { this->DeclareInputPort("in", kVectorValued, 1); }
 };
 
-GTEST_TEST(DiagramBuilderTest, DefaultPortNamesAreUniqueTest) {
+// Helper class that has no input port, and one output port.
+template <typename T>
+class Source : public LeafSystem<T> {
+ public:
+  Source() { this->DeclareVectorOutputPort("out", &Source<T>::CalcOutput); }
+  void CalcOutput(const Context<T>& context, BasicVector<T>* output) const {}
+};
+
+GTEST_TEST(DiagramBuilderTest, DefaultInputPortNamesAreUniqueTest) {
   DiagramBuilder<double> builder;
 
   auto sink1 = builder.AddSystem<Sink<double>>();
@@ -208,6 +216,19 @@ GTEST_TEST(DiagramBuilderTest, DefaultPortNamesAreUniqueTest) {
 
   builder.ExportInput(sink1->get_input_port(0));
   builder.ExportInput(sink2->get_input_port(0));
+
+  // If the port names were not unique, then the build step would throw.
+  EXPECT_NO_THROW(builder.Build());
+}
+
+GTEST_TEST(DiagramBuilderTest, DefaultOutputPortNamesAreUniqueTest) {
+  DiagramBuilder<double> builder;
+
+  auto source1 = builder.AddSystem<Source<double>>();
+  auto source2 = builder.AddSystem<Source<double>>();
+
+  builder.ExportOutput(source1->get_output_port(0));
+  builder.ExportOutput(source2->get_output_port(0));
 
   // If the port names were not unique, then the build step would throw.
   EXPECT_NO_THROW(builder.Build());
@@ -222,13 +243,22 @@ GTEST_TEST(DiagramBuilderTest, DefaultPortNamesAreUniqueTest2) {
   auto sink2 = builder.AddSystem<Sink<double>>();
   sink2->set_name("sink2");
 
+  auto source1 = builder.AddSystem<Source<double>>();
+  source1->set_name("source1");
+  auto source2 = builder.AddSystem<Source<double>>();
+  source2->set_name("source2");
+
   const auto sink1_in = builder.ExportInput(sink1->get_input_port(0));
   const auto sink2_in = builder.ExportInput(sink2->get_input_port(0));
+  const auto source1_out = builder.ExportOutput(source1->get_output_port(0));
+  const auto source2_out = builder.ExportOutput(source2->get_output_port(0));
 
   auto diagram = builder.Build();
 
-  EXPECT_EQ(diagram->get_input_port(sink1_in).get_name(), "sink1:in");
-  EXPECT_EQ(diagram->get_input_port(sink2_in).get_name(), "sink2:in");
+  EXPECT_EQ(diagram->get_input_port(sink1_in).get_name(), "sink1_in");
+  EXPECT_EQ(diagram->get_input_port(sink2_in).get_name(), "sink2_in");
+  EXPECT_EQ(diagram->get_output_port(source1_out).get_name(), "source1_out");
+  EXPECT_EQ(diagram->get_output_port(source2_out).get_name(), "source2_out");
 }
 
 GTEST_TEST(DiagramBuilderTest, SetPortNamesTest) {
@@ -236,17 +266,25 @@ GTEST_TEST(DiagramBuilderTest, SetPortNamesTest) {
 
   auto sink1 = builder.AddSystem<Sink<double>>();
   auto sink2 = builder.AddSystem<Sink<double>>();
+  auto source1 = builder.AddSystem<Source<double>>();
+  auto source2 = builder.AddSystem<Source<double>>();
 
   const auto sink1_in = builder.ExportInput(sink1->get_input_port(0), "sink1");
   const auto sink2_in = builder.ExportInput(sink2->get_input_port(0), "sink2");
+  const auto source1_out =
+      builder.ExportOutput(source1->get_output_port(0), "source1");
+  const auto source2_out =
+      builder.ExportOutput(source2->get_output_port(0), "source2");
 
   auto diagram = builder.Build();
 
   EXPECT_EQ(diagram->get_input_port(sink1_in).get_name(), "sink1");
   EXPECT_EQ(diagram->get_input_port(sink2_in).get_name(), "sink2");
+  EXPECT_EQ(diagram->get_output_port(source1_out).get_name(), "source1");
+  EXPECT_EQ(diagram->get_output_port(source2_out).get_name(), "source2");
 }
 
-GTEST_TEST(DiagramBuilderTest, DuplicatePortNamesThrow) {
+GTEST_TEST(DiagramBuilderTest, DuplicateInputPortNamesThrow) {
   DiagramBuilder<double> builder;
 
   auto sink1 = builder.AddSystem<Sink<double>>();
@@ -258,6 +296,20 @@ GTEST_TEST(DiagramBuilderTest, DuplicatePortNamesThrow) {
   DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(), std::logic_error,
                               ".*already has an input port named.*");
 }
+
+GTEST_TEST(DiagramBuilderTest, DuplicateOutputPortNamesThrow) {
+  DiagramBuilder<double> builder;
+
+  auto sink1 = builder.AddSystem<Source<double>>();
+  auto sink2 = builder.AddSystem<Source<double>>();
+
+  builder.ExportOutput(sink1->get_output_port(0), "source");
+  builder.ExportOutput(sink2->get_output_port(0), "source");
+
+  DRAKE_EXPECT_THROWS_MESSAGE(builder.Build(), std::logic_error,
+                              ".*already has an output port named.*");
+}
+
 
 // Tests the sole-port based overload of Connect().
 class DiagramBuilderSolePortsTest : public ::testing::Test {

--- a/systems/framework/test/diagram_test.cc
+++ b/systems/framework/test/diagram_test.cc
@@ -698,8 +698,11 @@ TEST_F(DiagramTest, Graphviz) {
   EXPECT_NE(std::string::npos, dot.find(
       "_" + id + "_y2[color=green, label=\"y2\"")) << dot;
   // Check that subsystem records appear.
-  EXPECT_NE(std::string::npos, dot.find(
-      "[shape=record, label=\"adder1|{{<u0>u0|<u1>u1} | {<y0>y0}}\"]")) << dot;
+  EXPECT_NE(
+      std::string::npos,
+      dot.find(
+          "[shape=record, label=\"adder1|{{<u0>u0|<u1>u1} | {<y0>sum}}\"]"))
+      << dot;
   // Check that internal edges appear.
   const std::string adder1_id = std::to_string(
       reinterpret_cast<int64_t>(diagram_->adder1()));
@@ -908,6 +911,12 @@ TEST_F(DiagramTest, ToAutoDiffXd) {
   for (InputPortIndex i{0}; i < diagram_->get_num_input_ports(); i++) {
     EXPECT_EQ(diagram_->get_input_port(i).get_name(),
               ad_diagram->get_input_port(i).get_name());
+  }
+
+  // Make sure that the output port names survive type conversion.
+  for (OutputPortIndex i{0}; i < diagram_->get_num_output_ports(); i++) {
+    EXPECT_EQ(diagram_->get_output_port(i).get_name(),
+              ad_diagram->get_output_port(i).get_name());
   }
 
   // When the Diagram contains a System that does not support AutoDiffXd,
@@ -1440,10 +1449,10 @@ GTEST_TEST(PortDependentFeedthroughTest, DetectFeedthrough) {
 class RandomInputSystem : public LeafSystem<double> {
  public:
   RandomInputSystem() {
-    this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareInputPort(kVectorValued, 1, "uniform",
+    this->DeclareInputPort("deterministic", kVectorValued, 1);
+    this->DeclareInputPort("uniform", kVectorValued, 1,
                            RandomDistribution::kUniform);
-    this->DeclareInputPort(kVectorValued, 1, "gaussian",
+    this->DeclareInputPort("gaussian", kVectorValued, 1,
                            RandomDistribution::kGaussian);
   }
 };

--- a/systems/framework/test/leaf_system_test.cc
+++ b/systems/framework/test/leaf_system_test.cc
@@ -43,6 +43,8 @@ class TestSystem : public LeafSystem<T> {
   using LeafSystem<T>::DeclareContinuousState;
   using LeafSystem<T>::DeclareVectorInputPort;
   using LeafSystem<T>::DeclareAbstractInputPort;
+  using LeafSystem<T>::DeclareVectorOutputPort;
+  using LeafSystem<T>::DeclareAbstractOutputPort;
 
   void AddPeriodicUpdate() {
     const double period = 10.0;
@@ -83,6 +85,8 @@ class TestSystem : public LeafSystem<T> {
 
   void DoCalcTimeDerivatives(const Context<T>& context,
                              ContinuousState<T>* derivatives) const override {}
+
+  void CalcOutput(const Context<T>& context, BasicVector<T>* output) const {}
 
   const BasicVector<T>& GetVanillaNumericParameters(
       const Context<T>& context) const {
@@ -216,18 +220,19 @@ class LeafSystemTest : public ::testing::Test {
   const LeafCompositeEventCollection<double>* leaf_info_;
 };
 
+TEST_F(LeafSystemTest, DefaultPortNameTest) {
+  EXPECT_EQ(system_.DeclareVectorInputPort(BasicVector<double>(2)).get_name(),
+            "u0");
+  EXPECT_EQ(system_.DeclareAbstractInputPort(Value<int>(1)).get_name(), "u1");
 
-TEST_F(LeafSystemTest, PortNameTest) {
-  const auto& unnamed_input =
-      system_.DeclareVectorInputPort(BasicVector<double>(2));
-  const auto& named_input =
-      system_.DeclareVectorInputPort(BasicVector<double>(3), "my_input");
-  const auto& named_abstract_input =
-      system_.DeclareAbstractInputPort(Value<int>(1), "abstract");
-
-  EXPECT_EQ(unnamed_input.get_name(), "u0");
-  EXPECT_EQ(named_input.get_name(), "my_input");
-  EXPECT_EQ(named_abstract_input.get_name(), "abstract");
+  EXPECT_EQ(system_.DeclareVectorOutputPort(&TestSystem<double>::CalcOutput)
+                .get_name(), "y0");
+  EXPECT_EQ(
+      system_
+          .DeclareAbstractOutputPort(kUseDefaultName, BasicVector<double>(2),
+                                     &TestSystem<double>::CalcOutput)
+          .get_name(),
+      "y1");
 }
 
 // Tests that witness functions can be declared. Tests that witness functions
@@ -690,29 +695,29 @@ class DeclaredModelPortsSystem : public LeafSystem<double> {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DeclaredModelPortsSystem);
 
   DeclaredModelPortsSystem() {
-    this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareVectorInputPort(MyVector2d());
-    this->DeclareAbstractInputPort(Value<int>(22));
-    this->DeclareVectorInputPort(MyVector2d(), "uniform",
+    this->DeclareInputPort("input", kVectorValued, 1);
+    this->DeclareVectorInputPort("vector_input", MyVector2d());
+    this->DeclareAbstractInputPort("abstract_input", Value<int>(22));
+    this->DeclareVectorInputPort("uniform", MyVector2d(),
                                  RandomDistribution::kUniform);
-    this->DeclareVectorInputPort(MyVector2d(), "gaussian",
+    this->DeclareVectorInputPort("gaussian", MyVector2d(),
                                  RandomDistribution::kGaussian);
 
     // Output port 0 uses a BasicVector base class model.
-    this->DeclareVectorOutputPort(BasicVector<double>(3),
+    this->DeclareVectorOutputPort("basic_vector", BasicVector<double>(3),
                                   &DeclaredModelPortsSystem::CalcBasicVector3);
     // Output port 1 uses a class derived from BasicVector.
-    this->DeclareVectorOutputPort(MyVector4d(),
+    this->DeclareVectorOutputPort("my_vector", MyVector4d(),
                                   &DeclaredModelPortsSystem::CalcMyVector4d);
 
     // Output port 2 uses a concrete string model.
-    this->DeclareAbstractOutputPort(std::string("45"),
+    this->DeclareAbstractOutputPort("string", std::string("45"),
                                     &DeclaredModelPortsSystem::CalcString);
 
     // Output port 3 uses the "Advanced" methods that take a model
     // and a general calc function rather than a calc method.
     this->DeclareVectorOutputPort(
-        BasicVector<double>(2),
+        "advanced", BasicVector<double>(2),
         [](const Context<double>&, BasicVector<double>* out) {
           ASSERT_NE(out, nullptr);
           EXPECT_EQ(out->size(), 2);
@@ -840,6 +845,21 @@ GTEST_TEST(ModelLeafSystemTest, ModelPortsTopology) {
   EXPECT_FALSE(in2.get_random_type());
   EXPECT_EQ(in3.get_random_type(), RandomDistribution::kUniform);
   EXPECT_EQ(in4.get_random_type(), RandomDistribution::kGaussian);
+}
+
+// Check that names can be assigned to the ports through all of the various
+// APIs.
+GTEST_TEST(ModelLeafSystemTest, ModelPortNames) {
+  DeclaredModelPortsSystem dut;
+
+  EXPECT_EQ(dut.get_input_port(0).get_name(), "input");
+  EXPECT_EQ(dut.get_input_port(1).get_name(), "vector_input");
+  EXPECT_EQ(dut.get_input_port(2).get_name(), "abstract_input");
+
+  EXPECT_EQ(dut.get_output_port(0).get_name(), "basic_vector");
+  EXPECT_EQ(dut.get_output_port(1).get_name(), "my_vector");
+  EXPECT_EQ(dut.get_output_port(2).get_name(), "string");
+  EXPECT_EQ(dut.get_output_port(3).get_name(), "advanced");
 }
 
 // Tests that the model values specified in Declare{...} are actually used by
@@ -1373,10 +1393,13 @@ class DefaultFeedthroughSystem : public LeafSystem<double> {
 
   ~DefaultFeedthroughSystem() override {}
 
-  void AddAbstractInputPort() { this->DeclareAbstractInputPort(); }
+  void AddAbstractInputPort() {
+    this->DeclareAbstractInputPort(kUseDefaultName);
+  }
 
   void AddAbstractOutputPort() {
     this->DeclareAbstractOutputPort(
+        kUseDefaultName,
         []() { return AbstractValue::Make<int>(0); },  // Dummies.
         [](const ContextBase&, AbstractValue*) {});
   }

--- a/systems/framework/test/output_port_test.cc
+++ b/systems/framework/test/output_port_test.cc
@@ -47,8 +47,8 @@ class MyOutputPort : public OutputPort<double> {
  public:
   MyOutputPort(const System<double>* diagram, SystemBase* system_base,
                OutputPortIndex index, DependencyTicket ticket)
-      : OutputPort<double>(diagram, system_base, index, ticket, kVectorValued,
-                           2) {}
+      : OutputPort<double>(diagram, system_base, "my_output", index, ticket,
+                           kVectorValued, 2) {}
 
   std::unique_ptr<AbstractValue> DoAllocate() const override {
     return AbstractValue::Make<BasicVector<double>>(
@@ -195,6 +195,7 @@ class LeafOutputPortTest : public ::testing::Test {
   LeafOutputPort<double> absport_general_{
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
       &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      "absport",
       OutputPortIndex(dummy_.get_num_output_ports()),
       dummy_.assign_next_dependency_ticket(), kAbstractValued, 0 /* size */,
       &dummy_.DeclareCacheEntry(
@@ -202,6 +203,7 @@ class LeafOutputPortTest : public ::testing::Test {
   LeafOutputPort<double> vecport_general_{
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
       &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      "vecport",
       OutputPortIndex(dummy_.get_num_output_ports()),
       dummy_.assign_next_dependency_ticket(), kVectorValued, 3 /* size */,
       &dummy_.DeclareCacheEntry(
@@ -265,7 +267,8 @@ TEST_F(LeafOutputPortTest, ThrowIfNullAlloc) {
   // TODO(sherm1) Use implicit_cast when available (from abseil).
   LeafOutputPort<double> null_port{
       &dummy_,  // implicit_cast<const System<T>*>(&dummy_)
-      &dummy_,  // implicit_cast<SystemBase*>(&dummy_)
+      &dummy_,  // implicit_cast<SystemBase*>(&dummy_),
+      "null_port",
       OutputPortIndex(dummy_.get_num_output_ports()),
       dummy_.assign_next_dependency_ticket(),
       kAbstractValued, 0 /* size */,

--- a/systems/framework/test/system_symbolic_inspector_test.cc
+++ b/systems/framework/test/system_symbolic_inspector_test.cc
@@ -24,7 +24,7 @@ class SparseSystem : public LeafSystem<symbolic::Expression> {
                                   &SparseSystem::CalcY0);
     this->DeclareVectorOutputPort(BasicVector<symbolic::Expression>(kSize),
                                   &SparseSystem::CalcY1);
-    this->DeclareAbstractOutputPort(42, &SparseSystem::CalcNothing);
+    this->DeclareAbstractOutputPort("port_42", 42, &SparseSystem::CalcNothing);
 
     this->DeclareContinuousState(kSize);
     this->DeclareDiscreteState(kSize);

--- a/systems/framework/test/system_test.cc
+++ b/systems/framework/test/system_test.cc
@@ -84,6 +84,7 @@ class TestSystem : public System<double> {
     auto port = std::make_unique<LeafOutputPort<double>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        "y" + std::to_string(get_num_output_ports()),
         OutputPortIndex(this->get_num_output_ports()),
         assign_next_dependency_ticket(),
         kAbstractValued, 0, &cache_entry);
@@ -349,7 +350,7 @@ TEST_F(SystemTest, PortReferencesAreStable) {
 TEST_F(SystemTest, PortNameTest) {
   const auto& unnamed_input = system_.DeclareInputPort(kVectorValued, 2);
   const auto& named_input =
-      system_.DeclareInputPort(kVectorValued, 3, "my_input");
+      system_.DeclareInputPort("my_input", kVectorValued, 3);
   const auto& named_abstract_input =
       system_.DeclareAbstractInputPort("abstract");
 
@@ -359,7 +360,7 @@ TEST_F(SystemTest, PortNameTest) {
 
   // Duplicate port names should throw.
   DRAKE_EXPECT_THROWS_MESSAGE(
-      system_.DeclareInputPort(kAbstractValued, 0, "my_input"),
+      system_.DeclareInputPort("my_input", kAbstractValued, 0),
       std::logic_error, ".*already has an input port named.*");
 }
 
@@ -449,6 +450,7 @@ class ValueIOTestSystem : public System<T> {
     this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        "absport",
         OutputPortIndex(this->get_num_output_ports()),
         this->assign_next_dependency_ticket(),
         kAbstractValued, 0 /* size */,
@@ -459,13 +461,14 @@ class ValueIOTestSystem : public System<T> {
               this->CalcStringOutput(context, output);
             })));
     this->DeclareInputPort(kVectorValued, 1);
-    this->DeclareInputPort(kVectorValued, 1, "uniform",
+    this->DeclareInputPort("uniform", kVectorValued, 1,
                            RandomDistribution::kUniform);
-    this->DeclareInputPort(kVectorValued, 1, "gaussian",
+    this->DeclareInputPort("gaussian", kVectorValued, 1,
                            RandomDistribution::kGaussian);
     this->AddOutputPort(std::make_unique<LeafOutputPort<T>>(
         this,  // implicit_cast<const System<T>*>(this)
         this,  // implicit_cast<const SystemBase*>(this)
+        "vecport",
         OutputPortIndex(this->get_num_output_ports()),
         this->assign_next_dependency_ticket(),
         kVectorValued, 1 /* size */,

--- a/systems/primitives/adder.cc
+++ b/systems/primitives/adder.cc
@@ -10,10 +10,11 @@ template <typename T>
 Adder<T>::Adder(int num_inputs, int size)
     : LeafSystem<T>(SystemTypeTag<systems::Adder>{}) {
   for (int i = 0; i < num_inputs; i++) {
-    this->DeclareInputPort(kVectorValued, size);
+    this->DeclareInputPort(kUseDefaultName, kVectorValued, size);
   }
 
-  this->DeclareVectorOutputPort(BasicVector<T>(size), &Adder<T>::CalcSum);
+  this->DeclareVectorOutputPort("sum", BasicVector<T>(size),
+                                &Adder<T>::CalcSum);
 }
 
 template <typename T>

--- a/systems/primitives/signal_logger.cc
+++ b/systems/primitives/signal_logger.cc
@@ -8,7 +8,7 @@ namespace systems {
 template <typename T>
 SignalLogger<T>::SignalLogger(int input_size, int batch_allocation_size)
     : log_(input_size, batch_allocation_size) {
-  this->DeclareInputPort(kVectorValued, input_size, "data");
+  this->DeclareInputPort("data", kVectorValued, input_size);
 }
 
 template <typename T>

--- a/systems/primitives/test/random_source_test.cc
+++ b/systems/primitives/test/random_source_test.cc
@@ -148,17 +148,17 @@ GTEST_TEST(RandomSourceTest, AddToDiagramBuilderTest) {
   DiagramBuilder<double> builder;
 
   auto* sys1 = builder.AddSystem<TestSystem>();
-  sys1->DeclareInputPort(kVectorValued, 3, "uniform",
+  sys1->DeclareInputPort("uniform", kVectorValued, 3,
                          RandomDistribution::kUniform);
-  sys1->DeclareInputPort(kVectorValued, 2, "exponential",
+  sys1->DeclareInputPort("exponential", kVectorValued, 2,
                          RandomDistribution::kExponential);
 
   auto* sys2 = builder.AddSystem<TestSystem>();
-  sys2->DeclareInputPort(kVectorValued, 5, "gaussian",
+  sys2->DeclareInputPort("gaussian", kVectorValued, 5,
                          RandomDistribution::kGaussian);
-  sys2->DeclareInputPort(kVectorValued, 2, "exponential",
+  sys2->DeclareInputPort("exponential", kVectorValued, 2,
                          RandomDistribution::kExponential);
-  sys2->DeclareInputPort(kVectorValued, 1, "scalar_gaussian",
+  sys2->DeclareInputPort("scalar_gaussian", kVectorValued, 1,
                          RandomDistribution::kGaussian);
 
   // Export input 1.

--- a/systems/sensors/beam_model.cc
+++ b/systems/sensors/beam_model.cc
@@ -14,21 +14,21 @@ BeamModel<T>::BeamModel(int num_depth_readings, double max_range)
   DRAKE_DEMAND(num_depth_readings > 0);
   DRAKE_DEMAND(max_range >= 0.0);
   // Declare depth input port.
-  this->DeclareInputPort(kVectorValued, num_depth_readings, "depth");
+  this->DeclareInputPort("depth", kVectorValued, num_depth_readings);
   // Declare "event" random input port.
-  this->DeclareInputPort(kVectorValued, num_depth_readings, "event",
+  this->DeclareInputPort("event", kVectorValued, num_depth_readings,
                          RandomDistribution::kUniform);
   // Declare "hit" random input port.
-  this->DeclareInputPort(kVectorValued, num_depth_readings, "hit",
+  this->DeclareInputPort("hit", kVectorValued, num_depth_readings,
                          RandomDistribution::kGaussian);
   // Declare "short" random input port.
-  this->DeclareInputPort(kVectorValued, num_depth_readings, "short",
+  this->DeclareInputPort("short", kVectorValued, num_depth_readings,
                          RandomDistribution::kExponential);
   // Declare "uniform" random input port.
-  this->DeclareInputPort(kVectorValued, num_depth_readings, "uniform",
+  this->DeclareInputPort("uniform", kVectorValued, num_depth_readings,
                          RandomDistribution::kUniform);
   // Declare measurement output port.
-  this->DeclareVectorOutputPort(BasicVector<T>(num_depth_readings),
+  this->DeclareVectorOutputPort("depth", BasicVector<T>(num_depth_readings),
                                 &BeamModel<T>::CalcOutput);
 
   this->DeclareNumericParameter(BeamModelParams<T>());


### PR DESCRIPTION
This is an extension and replacement for #9437. This puts names as the first argument in every input and output port declaration. Currently the names are optional but the intent is to make them required and deprecate the (many) alternate signatures that don't take a name. Adds `kUseDefaultName` as a name placeholder that causes names like `u3` and `y2` to be generated instead.

One of the new signatures caused an ambiguity when a port's output type was string; I fixed that by removing the old signature just in that case. That didn't seem to cause any trouble.

Minor changes:
- grouped the to-be-deprecated signatures in their own Doxygen groups, 
- cleaned up a few things and removed some duplicate code, 
- renamed the Adder primitive's output port to "sum",
- inherited a few random things from #9437.

/cc @RussTedrake

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9459)
<!-- Reviewable:end -->
