### PR TITLE
[multilane] Fixes ToRoadPosition to correctly use `r` coordinate

### DIFF
--- a/automotive/maliput/multilane/road_geometry.h
+++ b/automotive/maliput/multilane/road_geometry.h
@@ -57,6 +57,8 @@ class RoadGeometry : public api::RoadGeometry {
   // words, for the lane whose LanePosition makes the r coordinate be the
   // smallest. If `hint` is non-null, then the search is restricted to the
   // `hint->lane` and lanes adjacent to `hint->lane`.
+  // TODO(agalbachicar) Take into account `h` coordinate to return by minimum
+  //                    `h` and then minimum `r`.
   api::RoadPosition DoToRoadPosition(
       const api::GeoPosition& geo_position,
       const api::RoadPosition* hint,


### PR DESCRIPTION
This PR fixes how `mulitlane::RoadGeometry::ToRoadPosition()` implements the selection of `LanePosition` within `RoadPosition` based on `r` coordinate criteria.

`master` revision fails when a `GeoPosition`s translates to more than one `LanePosition` whose `r` value is within `lane`'s `lane_bounds()`. Now the code follows what's described in `maliput::api::RoadGeometry::ToRoadPosition()`. A new test has been added as well as TODO (for a FU PR) to include `h`-coordinate criteria.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9464)
<!-- Reviewable:end -->
