### PR TITLE
Revert "Add symbolic isinf and isfinite"

### DIFF
--- a/common/symbolic_formula.cc
+++ b/common/symbolic_formula.cc
@@ -1,7 +1,6 @@
 // NOLINTNEXTLINE(build/include): Its header file is included in symbolic.h.
 #include <cstddef>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <set>
 #include <sstream>
@@ -16,7 +15,6 @@ namespace drake {
 namespace symbolic {
 
 using std::make_shared;
-using std::numeric_limits;
 using std::ostream;
 using std::ostringstream;
 using std::set;
@@ -283,16 +281,6 @@ Formula operator>=(const Expression& e1, const Expression& e2) {
 
 Formula isnan(const Expression& e) {
   return Formula{make_shared<FormulaIsnan>(e)};
-}
-
-Formula isinf(const Expression& e) {
-  const double inf{numeric_limits<double>::infinity()};
-  return (-inf == e) || (e == inf);
-}
-
-Formula isfinite(const Expression& e) {
-  const double inf{numeric_limits<double>::infinity()};
-  return (-inf < e) && (e < inf);
 }
 
 Formula positive_semidefinite(const Eigen::Ref<const MatrixX<Expression>>& m) {

--- a/common/symbolic_formula.h
+++ b/common/symbolic_formula.h
@@ -302,18 +302,6 @@ Formula operator>=(const Expression& e1, const Expression& e2);
  */
 Formula isnan(const Expression& e);
 
-/** Returns a Formula determining if the given expression @p e is a
- * positive or negative infinity.
- * @throws std::runtime_error if NaN is detected during evaluation.
- */
-Formula isinf(const Expression& e);
-
-/** Returns a Formula determining if the given expression @p e has a finite
- * value.
- * @throws std::runtime_error if NaN is detected during evaluation.
- */
-Formula isfinite(const Expression& e);
-
 /** Returns a symbolic formula constraining @p m to be a positive-semidefinite
  * matrix. By definition, a symmetric matrix @p m is positive-semidefinte if xᵀ
  * m x ≥ 0 for all vector x ∈ ℝⁿ.

--- a/common/test/symbolic_formula_test.cc
+++ b/common/test/symbolic_formula_test.cc
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <cmath>
 #include <exception>
-#include <limits>
 #include <map>
 #include <set>
 #include <stdexcept>
@@ -20,7 +19,6 @@
 
 namespace drake {
 
-using std::numeric_limits;
 using test::IsMemcpyMovable;
 
 namespace symbolic {
@@ -1185,46 +1183,6 @@ TEST_F(SymbolicFormulaTest, GetMatrixInPSD_NonSymmetric_Dynamic) {
       get_matrix_in_positive_semidefinite(
           positive_semidefinite(m.triangularView<Eigen::Upper>())),
       sym_from_upper));
-}
-
-TEST_F(SymbolicFormulaTest, Isinf) {
-  // Checks the std::isinf and symbolic isinf agree on non-NaN values.
-  const double inf{numeric_limits<double>::infinity()};
-  EXPECT_EQ(std::isinf(inf), isinf(Expression(inf)).Evaluate());
-  EXPECT_EQ(std::isinf(3e18), isinf(Expression(3e18)).Evaluate());
-  EXPECT_EQ(std::isinf(3.0), isinf(Expression(3.0)).Evaluate());
-  EXPECT_EQ(std::isinf(0.0), isinf(Expression(0.0)).Evaluate());
-  EXPECT_EQ(std::isinf(-3.0), isinf(Expression(-3.0)).Evaluate());
-  EXPECT_EQ(std::isinf(-3e18), isinf(Expression(-3e18)).Evaluate());
-  EXPECT_EQ(std::isinf(-inf), isinf(Expression(-inf)).Evaluate());
-
-  // Note that constructing isinf with an expression including NaN does *not*
-  // throw.
-  EXPECT_NO_THROW(isinf(Expression::NaN()));
-
-  // For NaN, symbolic::isinf will throw an exception when evaluated while
-  // std::isfinite returns false.
-  EXPECT_THROW(isinf(Expression::NaN()).Evaluate(), std::runtime_error);
-}
-
-TEST_F(SymbolicFormulaTest, Isfinite) {
-  // Checks the std::isfinite and symbolic isfinte agree on non-NaN values.
-  const double inf{numeric_limits<double>::infinity()};
-  EXPECT_EQ(std::isfinite(inf), isfinite(Expression(inf)).Evaluate());
-  EXPECT_EQ(std::isfinite(3e18), isfinite(Expression(3e18)).Evaluate());
-  EXPECT_EQ(std::isfinite(3.0), isfinite(Expression(3.0)).Evaluate());
-  EXPECT_EQ(std::isfinite(0.0), isfinite(Expression(0.0)).Evaluate());
-  EXPECT_EQ(std::isfinite(-3.0), isfinite(Expression(-3.0)).Evaluate());
-  EXPECT_EQ(std::isfinite(-3e18), isfinite(Expression(-3e18)).Evaluate());
-  EXPECT_EQ(std::isfinite(-inf), isfinite(Expression(-inf)).Evaluate());
-
-  // Note that constructing isfinite with an expression including NaN does *not*
-  // throw.
-  EXPECT_NO_THROW(isfinite(Expression::NaN()));
-
-  // For NaN, symbolic::isfinite will throw an exception when evaluated while
-  // std::isfinite returns false.
-  EXPECT_THROW(isfinite(Expression::NaN()).Evaluate(), std::runtime_error);
 }
 
 // Confirm that formulas compile (and pass) Drake's assert-like checks.


### PR DESCRIPTION
Dear @soonho-tri ,

The on-call build cop, believes that your PR #9463  may have
broken one or more of Drake's continuous integration builds [1,2]. It is
possible to break a build even if your PR passed continuous integration
pre-merge because additional platforms and tests are built post-merge.

The specific build failures under investigation are:
https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/job/mac-highsierra-clang-bazel-nightly-memcheck-tsan/327/
https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/job/linux-xenial-gcc-bazel-continuous-memcheck-asan/1681/

Therefore, the build cop has created this revert PR and started a complete
post-merge build to determine whether your PR was in fact the cause of the
problem. If that build passes, this revert PR will be merged 60 minutes from
now. You can then fix the problem at your leisure, and send a new PR to
reinstate your change.

If you believe your original PR did not actually break the build, please
explain on this thread.

If you believe you can fix the break promptly in lieu of a revert, please
explain on this thread, and send a PR to the build cop for review ASAP.

If you believe your original PR definitely did break the build and should be
reverted, please review and LGTM this PR. This allows the build cop to merge
without waiting for CI results.

For advice on how to handle a build cop revert, see [3].

Thanks!
Your Friendly Oncall Buildcop

[1] CI Continuous Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Continuous%20Production/
[2] CI Nightly Production Dashboard: https://drake-jenkins.csail.mit.edu/view/Nightly%20Production/
[3] https://drake.mit.edu/buildcop.html#workflow-for-handling-a-build-cop-revert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9473)
<!-- Reviewable:end -->
