### PR TITLE
Add 'no_ubsan' tag to 'inverse_kinematics_test'

### DIFF
--- a/multibody/inverse_kinematics/BUILD.bazel
+++ b/multibody/inverse_kinematics/BUILD.bazel
@@ -122,6 +122,10 @@ drake_cc_googletest(
 
 drake_cc_googletest(
     name = "inverse_kinematics_test",
+    # TODO(betsymcphail) Ubsan fails for this test. See #9475.
+    tags = [
+        "no_ubsan",
+    ],
     deps = [
         ":inverse_kinematics_core",
         ":inverse_kinematics_test_utilities",


### PR DESCRIPTION
Issue #9475 was created to fix the ubsan build for this test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9476)
<!-- Reviewable:end -->
