### PR TITLE
Removes `monolane` dependencies from `maliput::utility`

### DIFF
--- a/automotive/maliput/utility/BUILD.bazel
+++ b/automotive/maliput/utility/BUILD.bazel
@@ -46,7 +46,6 @@ drake_cc_binary(
     srcs = ["yaml_to_obj.cc"],
     deps = [
         ":utility",
-        "//automotive/maliput/monolane",
         "//automotive/maliput/multilane",
         "//common:text_logging_gflags",
         "@yaml_cpp",
@@ -93,7 +92,7 @@ drake_cc_googletest(
     ],
     deps = [
         ":utility",
-        "//automotive/maliput/monolane",
+        "//automotive/maliput/multilane",
         "//common",
         "@spruce",
     ],
@@ -103,7 +102,7 @@ drake_cc_googletest(
     name = "generate_urdf_test",
     deps = [
         ":utility",
-        "//automotive/maliput/monolane",
+        "//automotive/maliput/multilane",
         "@spruce",
     ],
 )
@@ -122,7 +121,6 @@ drake_py_unittest(
     args = ["$(location :yaml_to_obj)"],
     data = [
         ":yaml_to_obj",
-        "//automotive/maliput/monolane:yamls",
         "//automotive/maliput/multilane:yamls",
     ],
 )

--- a/automotive/maliput/utility/test/generate_obj_test.cc
+++ b/automotive/maliput/utility/test/generate_obj_test.cc
@@ -6,15 +6,16 @@
 #include <gtest/gtest.h>
 #include <spruce.hh>
 
-#include "drake/automotive/maliput/monolane/builder.h"
-#include "drake/automotive/maliput/monolane/loader.h"
+#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/connection.h"
+#include "drake/automotive/maliput/multilane/loader.h"
 #include "drake/common/find_resource.h"
 
 namespace drake {
 namespace maliput {
 namespace utility {
 
-namespace mono = maliput::monolane;
+namespace multi = maliput::multilane;
 
 class GenerateObjTest : public ::testing::Test {
  protected:
@@ -70,20 +71,33 @@ class GenerateObjBasicDutTest : public GenerateObjTest {
  protected:
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  const api::RBounds kLaneBounds{-0.5, 0.5};
-  const api::RBounds kDriveableBounds{-1., 1.};
+  const double kLaneWidth = 1.;
+  const double kShoulder = 0.5;
   const api::HBounds kElevationBounds{0., 5.};
+  const double kScaleLength = 1.;
+  const multi::ComputationPolicy kComputationPolicy =
+      multi::ComputationPolicy::kPreferAccuracy;
+  const multi::LaneLayout kLaneLayout{kShoulder, kShoulder, 1 /* num_lanes */,
+                                      0 /* ref_lane */, 0. /* ref_r0 */};
+
+  std::unique_ptr<multi::BuilderBase> MakeMultilaneBuilder() {
+    return multi::BuilderFactory().Make(kLaneWidth, kElevationBounds,
+                                        kLinearTolerance, kAngularTolerance,
+                                        kScaleLength, kComputationPolicy);
+  }
 
   void SetUp() override {
     GenerateObjTest::SetUp();
 
-    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-                    kLinearTolerance, kAngularTolerance);
+    auto b = MakeMultilaneBuilder();
 
-    const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
-    const mono::Endpoint start{{0., 0., 0.}, kZeroZ};
-    b.Connect("0", start, 1., kZeroZ);
-    dut_ = b.Build(api::RoadGeometryId{"dut"});
+    const multi::EndpointZ kZeroZ{0., 0., 0., 0.};
+    const multi::Endpoint start{{0., 0., 0.}, kZeroZ};
+    b->Connect("0", kLaneLayout,
+               multi::StartReference().at(start, multi::Direction::kForward),
+               multi::LineOffset(1.),
+               multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    dut_ = b->Build(api::RoadGeometryId{"dut"});
   }
 
   std::unique_ptr<const api::RoadGeometry> dut_;
@@ -129,13 +143,14 @@ TEST_F(GenerateObjBasicDutTest, ChangeOrigin) {
 
   // Reconstruct the basic DUT, but starting at the offset instead of (0,0,0).
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-                    kLinearTolerance, kAngularTolerance);
-
-    const mono::EndpointZ kZeroZ{kOffsetZ, 0., 0., 0.};
-    const mono::Endpoint start{{kOffsetX, kOffsetY, 0.}, kZeroZ};
-    b.Connect("0", start, 1., kZeroZ);
-    dut_ = b.Build(api::RoadGeometryId{"dut"});
+    auto b = MakeMultilaneBuilder();
+    const multi::EndpointZ kZeroZ{kOffsetZ, 0., 0., 0.};
+    const multi::Endpoint start{{kOffsetX, kOffsetY, 0.}, kZeroZ};
+    b->Connect("0", kLaneLayout,
+               multi::StartReference().at(start, multi::Direction::kForward),
+               multi::LineOffset(1.),
+               multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    dut_ = b->Build(api::RoadGeometryId{"dut"});
   }
 
   ObjFeatures obj_features;
@@ -220,15 +235,19 @@ TEST_F(GenerateObjBasicDutTest, StackedBranchPointsObjContent) {
 
   // Construct a RoadGeometry with two lanes that don't quite connect.
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-                    kLinearTolerance, kAngularTolerance);
-
-    const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
-    const mono::Endpoint start0{{0., 0., 0.}, kZeroZ};
-    const mono::Endpoint start1{{10. * kLinearTolerance, 0., M_PI}, kZeroZ};
-    b.Connect("0", start0, 1., kZeroZ);
-    b.Connect("1", start1, 1., kZeroZ);
-    dut_ = b.Build(api::RoadGeometryId{"dut"});
+    auto b = MakeMultilaneBuilder();
+    const multi::EndpointZ kZeroZ{0., 0., 0., 0.};
+    const multi::Endpoint start0{{0., 0., 0.}, kZeroZ};
+    const multi::Endpoint start1{{10. * kLinearTolerance, 0., M_PI}, kZeroZ};
+    b->Connect("0", kLaneLayout,
+               multi::StartReference().at(start0, multi::Direction::kForward),
+               multi::LineOffset(1.),
+               multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    b->Connect("1", kLaneLayout,
+               multi::StartReference().at(start1, multi::Direction::kForward),
+               multi::LineOffset(1.),
+               multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    dut_ = b->Build(api::RoadGeometryId{"dut"});
   }
 
   GenerateObjFile(dut_.get(), directory_.getStr(), basename, ObjFeatures());
@@ -255,13 +274,16 @@ TEST_F(GenerateObjTest, DontTickleDrawLaneArrowAssert) {
   std::string dut_yaml = R"R(# -*- yaml -*-
 ---
 # distances are meters; angles are degrees.
-maliput_monolane_builder:
-  id: city_1
-  lane_bounds: [-2, 2]
-  driveable_bounds: [-4, 4]
+maliput_multilane_builder:
+  id: "city_1"
+  lane_width: 4
+  left_shoulder: 2
+  right_shoulder: 2
   elevation_bounds: [0, 5]
-  position_precision: 0.01
-  orientation_precision: 0.5
+  scale_length: 1.0
+  linear_tolerance: 0.01
+  angular_tolerance: 0.5
+  computation_policy: "prefer-accuracy"
   points:
     street_9_1_3:
       xypoint: [92.92893218813452, 307.0710678118655, -45.0]
@@ -270,12 +292,16 @@ maliput_monolane_builder:
       xypoint: [95.05025253169417, 304.9497474683058, -45.0]
       zpoint: [0.0, 0, 0, 0]
   connections:
-    street_9_1_3-street_9_1_4: {start: points.street_9_1_3, length: 3.000000000000014,
-      explicit_end: points.street_9_1_4}
+    street_9_1_3-street_9_1_4:
+      lanes: [1, 0, 0]
+      start: ["ref", "points.street_9_1_3.forward"]
+      length: 3.000000000000014
+      explicit_end: ["ref", "points.street_9_1_4.forward"]
   groups: {}
 )R";
 
-  const std::unique_ptr<const api::RoadGeometry> dut = mono::Load(dut_yaml);
+  const std::unique_ptr<const api::RoadGeometry> dut =
+      multi::Load(multi::BuilderFactory(), dut_yaml);
 
   const std::string basename{"DontTickleDrawLaneArrowAssert"};
   GenerateObjFile(dut.get(), directory_.getStr(), basename, ObjFeatures());
@@ -299,14 +325,20 @@ TEST_F(GenerateObjBasicDutTest, HighlightedSegments) {
 
   // Construct a RoadGeometry with two segments.
   {
-    mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-                    kLinearTolerance, kAngularTolerance);
-
-    const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
-    const mono::Endpoint start0{{0., 0., 0.}, kZeroZ};
-    auto c0 = b.Connect("0", start0, 2., kZeroZ);
-    b.Connect("1", c0->end(), 2., kZeroZ);
-    dut_ = b.Build(api::RoadGeometryId{"dut"});
+    auto b = MakeMultilaneBuilder();
+    const multi::EndpointZ kZeroZ{0., 0., 0., 0.};
+    const multi::Endpoint start0{{0., 0., 0.}, kZeroZ};
+    auto c0 = b->Connect(
+        "0", kLaneLayout,
+        multi::StartReference().at(start0, multi::Direction::kForward),
+        multi::LineOffset(2.),
+        multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    b->Connect("1", kLaneLayout,
+               multi::StartReference().at(*c0, api::LaneEnd::Which::kFinish,
+                                          multi::Direction::kForward),
+               multi::LineOffset(2.),
+               multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
+    dut_ = b->Build(api::RoadGeometryId{"dut"});
   }
 
   ObjFeatures features;

--- a/automotive/maliput/utility/test/generate_urdf_test.cc
+++ b/automotive/maliput/utility/test/generate_urdf_test.cc
@@ -6,14 +6,14 @@
 #include <gtest/gtest.h>
 #include <spruce.hh>
 
-#include "drake/automotive/maliput/monolane/builder.h"
-#include "drake/automotive/maliput/monolane/loader.h"
+#include "drake/automotive/maliput/multilane/builder.h"
+#include "drake/automotive/maliput/multilane/loader.h"
 
 namespace drake {
 namespace maliput {
 namespace utility {
 
-namespace mono = maliput::monolane;
+namespace multi = maliput::multilane;
 
 class GenerateUrdfTest : public ::testing::Test {
  protected:
@@ -38,17 +38,27 @@ class GenerateUrdfTest : public ::testing::Test {
 TEST_F(GenerateUrdfTest, AtLeastRunIt) {
   const double kLinearTolerance = 0.01;
   const double kAngularTolerance = 0.01 * M_PI;
-  const api::RBounds kLaneBounds{-1., 1.};
-  const api::RBounds kDriveableBounds{-2., 2.};
+  const double kLaneWidth = 2.;
+  const double kShoulder = 1.;
   const api::HBounds kElevationBounds{0., 5.};
-  mono::Builder b(kLaneBounds, kDriveableBounds, kElevationBounds,
-                  kLinearTolerance, kAngularTolerance);
+  const double kScaleLength = 1.;
+  const multi::ComputationPolicy kComputationPolicy =
+      multi::ComputationPolicy::kPreferAccuracy;
+  const multi::LaneLayout kLaneLayout{kShoulder, kShoulder, 1 /* num_lanes */,
+                                      0 /* ref_lane */, 0. /* ref_r0 */};
+  auto b = multi::BuilderFactory().Make(kLaneWidth, kElevationBounds,
+                                        kLinearTolerance, kAngularTolerance,
+                                        kScaleLength, kComputationPolicy);
 
-  const mono::EndpointZ kZeroZ{0., 0., 0., 0.};
-  const mono::Endpoint start{{0., 0., 0.}, kZeroZ};
-  b.Connect("0", start, 10., kZeroZ);
+  const multi::EndpointZ kZeroZ{0., 0., 0., 0.};
+  const multi::Endpoint start{{0., 0., 0.}, kZeroZ};
+
+  b->Connect("0", kLaneLayout,
+             multi::StartReference().at(start, multi::Direction::kForward),
+             multi::LineOffset(10.),
+             multi::EndReference().z_at(kZeroZ, multi::Direction::kForward));
   const std::unique_ptr<const api::RoadGeometry> dut =
-      b.Build(api::RoadGeometryId{"dut"});
+      b->Build(api::RoadGeometryId{"dut"});
 
   GenerateUrdfFile(dut.get(), directory_.getStr(), kJunkBasename,
                    ObjFeatures());

--- a/automotive/maliput/utility/test/yaml_to_obj_test.py
+++ b/automotive/maliput/utility/test/yaml_to_obj_test.py
@@ -22,7 +22,7 @@ class TestYamlObjing(unittest.TestCase):
 
     def test_yaml_files(self):
         this_dir = os.path.dirname(_THIS_DIR)
-        yaml_dir = os.path.join(this_dir, '../monolane')
+        yaml_dir = os.path.join(this_dir, '../multilane')
 
         yaml_files = glob.glob(os.path.join(yaml_dir, '*.yaml'))
         # NB:  Blacklist is empty now, but still here in case it is needed

--- a/automotive/maliput/utility/yaml_to_obj.cc
+++ b/automotive/maliput/utility/yaml_to_obj.cc
@@ -1,13 +1,12 @@
 /// @file yaml_to_obj.cc
 ///
-/// Take a yaml file as input, build the resulting monolane or multilane road
-/// geometry, and render the road surface to a WaveFront OBJ output file.
+/// Take a yaml file as input, build the resulting multilane road geometry, and
+/// render the road surface to a WaveFront OBJ output file.
 #include <string>
 
 #include <gflags/gflags.h>
 #include "yaml-cpp/yaml.h"
 
-#include "drake/automotive/maliput/monolane/loader.h"
 #include "drake/automotive/maliput/multilane/builder.h"
 #include "drake/automotive/maliput/multilane/loader.h"
 #include "drake/automotive/maliput/utility/generate_obj.h"
@@ -15,10 +14,9 @@
 #include "drake/common/text_logging_gflags.h"
 
 DEFINE_string(yaml_file, "",
-              "yaml input file defining a monolane or multilane road geometry");
+              "yaml input file defining a multilane road geometry");
 DEFINE_string(obj_dir, ".", "Directory to contain rendered road surface");
-DEFINE_string(obj_file, "",
-              "Basename for output Wavefront OBJ and MTL files");
+DEFINE_string(obj_file, "", "Basename for output Wavefront OBJ and MTL files");
 DEFINE_double(max_grid_unit,
               drake::maliput::utility::ObjFeatures().max_grid_unit,
               "Maximum size of a grid unit in the rendered mesh covering the "
@@ -38,23 +36,19 @@ namespace {
 
 // Available maliput implementations to load.
 enum class MaliputImplementation {
-  kMonolane,   //< monolane implementation.
   kMultilane,  //< multilane implementation.
-  kUnknown     //< Used when none of the implementation could be identified.
+  kUnknown     //< Used when none of the implementations could be identified.
 };
 
 // Parses a file whose path is `filename` as a YAML and looks for a node called
-// "maliput_multilane_builder" or "maliput_monolane_builder".
-// When the first key is found, MaliputImplementation::kMultilane is returned.
-// When the second key is found, MaliputImplementation::kMonolane is returned.
-// Otherwise, MaliputImplementation::kUnknown is returned.
+// "maliput_multilane_builder". If it is found,
+// MaliputImplementation::kMultilane is returned. Otherwise,
+// MaliputImplementation::kUnknown is returned.
 MaliputImplementation GetMaliputImplementation(const std::string& filename) {
   const YAML::Node yaml_file = YAML::LoadFile(filename);
   DRAKE_DEMAND(yaml_file.IsMap());
   if (yaml_file["maliput_multilane_builder"]) {
     return MaliputImplementation::kMultilane;
-  } else if (yaml_file["maliput_monolane_builder"]) {
-    return MaliputImplementation::kMonolane;
   }
   return MaliputImplementation::kUnknown;
 }
@@ -81,11 +75,6 @@ int main(int argc, char* argv[]) {
       rg = drake::maliput::multilane::LoadFile(
           drake::maliput::multilane::BuilderFactory(), FLAGS_yaml_file);
       drake::log()->info("Loaded a multilane road geometry.");
-      break;
-    }
-    case MaliputImplementation::kMonolane: {
-      rg = drake::maliput::monolane::LoadFile(FLAGS_yaml_file);
-      drake::log()->info("Loaded a monolane road geometry.");
       break;
     }
     default: {


### PR DESCRIPTION
Towards #9196 completion, this PR removes `monolane` dependency and introduces `multilane` when necessary within `maliput::utility`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9486)
<!-- Reviewable:end -->
