### PR TITLE
Add caching to MultibodyTree

### DIFF
--- a/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
+++ b/multibody/benchmarks/kuka_iiwa_robot/drake_kuka_iiwa_robot.h
@@ -66,43 +66,44 @@ class DrakeKukaIIwaRobot {
   /// to this constructor, it means the gravity vector is directed opposite the
   /// world upward z-unit vector (which is correct -- gravity is downward).
   explicit DrakeKukaIIwaRobot(double gravity) {
-    model_ = MakeKukaIiwaModel<T>(
-        true /* finalized model */, gravity /* acceleration of gravity */);
+    system_ =
+        std::make_unique<MultibodyTreeSystem<T>>(MakeKukaIiwaModel<T>(
+            true /* finalized model */, gravity /* acceleration of gravity */));
 
-    linkN_ = &(model_->world_body());
+    linkN_ = &tree().world_body();
 
     // Get this robot's seven links.
-    linkA_ = &model_->GetBodyByName("iiwa_link_1");
-    linkB_ = &model_->GetBodyByName("iiwa_link_2");
-    linkC_ = &model_->GetBodyByName("iiwa_link_3");
-    linkD_ = &model_->GetBodyByName("iiwa_link_4");
-    linkE_ = &model_->GetBodyByName("iiwa_link_5");
-    linkF_ = &model_->GetBodyByName("iiwa_link_6");
-    linkG_ = &model_->GetBodyByName("iiwa_link_7");
+    linkA_ = &tree().GetBodyByName("iiwa_link_1");
+    linkB_ = &tree().GetBodyByName("iiwa_link_2");
+    linkC_ = &tree().GetBodyByName("iiwa_link_3");
+    linkD_ = &tree().GetBodyByName("iiwa_link_4");
+    linkE_ = &tree().GetBodyByName("iiwa_link_5");
+    linkF_ = &tree().GetBodyByName("iiwa_link_6");
+    linkG_ = &tree().GetBodyByName("iiwa_link_7");
 
     // Get this robot's seven joints.
     NA_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_1");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_1");
     AB_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_2");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_2");
     BC_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_3");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_3");
     CD_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_4");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_4");
     DE_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_5");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_5");
     EF_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_6");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_6");
     FG_joint_ =
-        &model_->template GetJointByName<RevoluteJoint>("iiwa_joint_7");
+        &tree().template GetJointByName<RevoluteJoint>("iiwa_joint_7");
 
     // After Finalize() method has been called, Context can be created.
-    context_ = model_->CreateDefaultContext();
+    context_ = system_->CreateDefaultContext();
   }
 
   /// This method gets the number of rigid bodies in this robot.
   /// @returns the number of rigid bodies in this robot.
-  int get_number_of_rigid_bodies() const  { return model_->num_bodies(); }
+  int get_number_of_rigid_bodies() const  { return tree().num_bodies(); }
 
   /// This method calculates kinematic properties of the end-effector (herein
   /// denoted as rigid body G) of a 7-DOF KUKA LBR iiwa robot (14 kg payload).
@@ -124,20 +125,20 @@ class DrakeKukaIIwaRobot {
 
     // For each body, set the pose and spatial velocity in the position,
     // velocity, and acceleration caches with specified values for testing.
-    PositionKinematicsCache<T> pc(model_->get_topology());
-    VelocityKinematicsCache<T> vc(model_->get_topology());
+    PositionKinematicsCache<T> pc(tree().get_topology());
+    VelocityKinematicsCache<T> vc(tree().get_topology());
 
     // Retrieve end-effector pose from position kinematics cache.
-    model_->CalcPositionKinematicsCache(*context_, &pc);
+    tree().CalcPositionKinematicsCache(*context_, &pc);
     const Isometry3<T>& X_NG = pc.get_X_WB(linkG_->node_index());
 
     // Retrieve end-effector spatial velocity from velocity kinematics cache.
-    model_->CalcVelocityKinematicsCache(*context_, pc, &vc);
+    tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
     const SpatialVelocity<T>& V_NG_N = vc.get_V_WB(linkG_->node_index());
 
     // Retrieve end-effector spatial acceleration from acceleration cache.
-    std::vector<SpatialAcceleration<T>> A_WB(model_->num_bodies());
-    model_->CalcSpatialAccelerationsFromVdot(*context_, pc, vc, qDDt, &A_WB);
+    std::vector<SpatialAcceleration<T>> A_WB(tree().num_bodies());
+    tree().CalcSpatialAccelerationsFromVdot(*context_, pc, vc, qDDt, &A_WB);
     const SpatialAcceleration<T>& A_NG_N = A_WB[linkG_->node_index()];
 
     // Create a class to return the results.
@@ -167,22 +168,22 @@ class DrakeKukaIIwaRobot {
     SetJointAnglesAnd1stDerivatives(q.data(), qDt.data());
 
     // Get the position, velocity, and acceleration cache from the context.
-    PositionKinematicsCache<T> pc(model_->get_topology());
-    VelocityKinematicsCache<T> vc(model_->get_topology());
-    AccelerationKinematicsCache<T> ac(model_->get_topology());
-    model_->CalcPositionKinematicsCache(*context_, &pc);
-    model_->CalcVelocityKinematicsCache(*context_, pc, &vc);
-    model_->CalcAccelerationKinematicsCache(*context_, pc, vc, qDDt, &ac);
+    PositionKinematicsCache<T> pc(tree().get_topology());
+    VelocityKinematicsCache<T> vc(tree().get_topology());
+    AccelerationKinematicsCache<T> ac(tree().get_topology());
+    tree().CalcPositionKinematicsCache(*context_, &pc);
+    tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
+    tree().CalcAccelerationKinematicsCache(*context_, pc, vc, qDDt, &ac);
 
     // Applied forces:
-    MultibodyForces<T> forces(*model_);
+    MultibodyForces<T> forces(tree());
 
     // Adds the previously included effect of gravity into forces.
-    model_->CalcForceElementsContribution(*context_, pc, vc, &forces);
+    tree().CalcForceElementsContribution(*context_, pc, vc, &forces);
 
     // Output vector of generalized forces for calculated motor torques
     // required to drive the Kuka robot at its specified rate.
-    const int number_of_generalized_speeds = model_->num_velocities();
+    const int number_of_generalized_speeds = tree().num_velocities();
     VectorX<T> generalized_force_output(number_of_generalized_speeds);
 
     // Output vector of spatial forces for joint reaction force/torques for
@@ -201,7 +202,7 @@ class DrakeKukaIIwaRobot {
         forces.mutable_generalized_forces();
 
     // Calculate inverse dynamics on this robot.
-    model_->CalcInverseDynamics(*context_, pc, vc, qDDt,
+    tree().CalcInverseDynamics(*context_, pc, vc, qDDt,
                 Fapplied_Bo_W_array, generalized_force_applied,
                 &A_WB_array, &F_BMo_W_array, &generalized_force_output);
 
@@ -216,6 +217,8 @@ class DrakeKukaIIwaRobot {
     reaction_forces.F_Go_W = F_BMo_W_array[linkG_->node_index()];
     return reaction_forces;
   }
+
+  const MultibodyTree<T>& tree() const { return system_->tree(); }
 
  private:
   // This method sets the Kuka joint angles and their 1st and 2nd derivatives.
@@ -244,7 +247,7 @@ class DrakeKukaIIwaRobot {
 
   // This model's MultibodyTree always has a built-in "world" body.
   // Newtonian reference frame (linkN) is the world body.
-  std::unique_ptr<MultibodyTree<T>> model_;
+  std::unique_ptr<MultibodyTreeSystem<T>> system_;
   const Body<T>* linkN_{nullptr};
 
   // Rigid bodies (robot links).

--- a/multibody/inverse_kinematics/inverse_kinematics.cc
+++ b/multibody/inverse_kinematics/inverse_kinematics.cc
@@ -13,8 +13,8 @@ InverseKinematics::InverseKinematics(
     const multibody_plant::MultibodyPlant<double>& plant)
     : prog_{new solvers::MathematicalProgram()},
       plant_(plant),
-      tree_(plant_.tree().ToAutoDiffXd()),
-      context_(tree_->CreateDefaultContext()),
+      system_(plant_.tree().ToAutoDiffXd()),
+      context_(system_.CreateDefaultContext()),
       q_(prog_->NewContinuousVariables(plant_.num_positions(), "q")) {
   // Initialize the lower and upper bounds to -inf/inf. A free floating body
   // does not increment `num_joints()` (A single free floating body has
@@ -22,9 +22,9 @@ InverseKinematics::InverseKinematics(
   // body. The initialization below guarantees proper bounds on the
   // generalized positions for the free floating body.
   Eigen::VectorXd q_lower = Eigen::VectorXd::Constant(
-      tree_->num_positions(), -std::numeric_limits<double>::infinity());
+      system_.tree().num_positions(), -std::numeric_limits<double>::infinity());
   Eigen::VectorXd q_upper = Eigen::VectorXd::Constant(
-      tree_->num_positions(), std::numeric_limits<double>::infinity());
+      system_.tree().num_positions(), std::numeric_limits<double>::infinity());
   for (JointIndex i{0}; i < plant_.tree().num_joints(); ++i) {
     const auto& joint = plant_.tree().get_joint(i);
     q_lower.segment(joint.position_start(), joint.num_positions()) =
@@ -43,8 +43,8 @@ solvers::Binding<solvers::Constraint> InverseKinematics::AddPositionConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_lower,
     const Eigen::Ref<const Eigen::Vector3d>& p_AQ_upper) {
   auto constraint = std::make_shared<internal::PositionConstraint>(
-      *tree_, frameB.index(), p_BQ, frameA.index(), p_AQ_lower, p_AQ_upper,
-      get_mutable_context());
+      system_.tree(), frameB.index(), p_BQ, frameA.index(), p_AQ_lower,
+      p_AQ_upper, get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
 
@@ -54,7 +54,7 @@ InverseKinematics::AddOrientationConstraint(
     const Frame<double>& frameBbar, const math::RotationMatrix<double>& R_BbarB,
     double angle_bound) {
   auto constraint = std::make_shared<internal::OrientationConstraint>(
-      *tree_, frameAbar.index(), R_AbarA, frameBbar.index(), R_BbarB,
+      system_.tree(), frameAbar.index(), R_AbarA, frameBbar.index(), R_BbarB,
       angle_bound, get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
@@ -65,8 +65,8 @@ InverseKinematics::AddGazeTargetConstraint(
     const Eigen::Ref<const Eigen::Vector3d>& n_A, const Frame<double>& frameB,
     const Eigen::Ref<const Eigen::Vector3d>& p_BT, double cone_half_angle) {
   auto constraint = std::make_shared<internal::GazeTargetConstraint>(
-      *tree_, frameA.index(), p_AS, n_A, frameB.index(), p_BT, cone_half_angle,
-      get_mutable_context());
+      system_.tree(), frameA.index(), p_AS, n_A, frameB.index(), p_BT,
+      cone_half_angle, get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }
 
@@ -76,7 +76,7 @@ InverseKinematics::AddAngleBetweenVectorsConstraint(
     const Frame<double>& frameB, const Eigen::Ref<const Eigen::Vector3d>& nb_B,
     double angle_lower, double angle_upper) {
   auto constraint = std::make_shared<internal::AngleBetweenVectorsConstraint>(
-      *tree_, frameA.index(), na_A, frameB.index(), nb_B, angle_lower,
+      system_.tree(), frameA.index(), na_A, frameB.index(), nb_B, angle_lower,
       angle_upper, get_mutable_context());
   return prog_->AddConstraint(constraint, q_);
 }

--- a/multibody/inverse_kinematics/inverse_kinematics.h
+++ b/multibody/inverse_kinematics/inverse_kinematics.h
@@ -166,8 +166,8 @@ class InverseKinematics {
 
   std::unique_ptr<solvers::MathematicalProgram> prog_;
   const multibody_plant::MultibodyPlant<double>& plant_;
-  std::unique_ptr<MultibodyTree<AutoDiffXd>> tree_;
-  std::unique_ptr<systems::LeafContext<AutoDiffXd>> const context_;
+  const MultibodyTreeSystem<AutoDiffXd> system_;
+  std::unique_ptr<systems::Context<AutoDiffXd>> const context_;
   solvers::VectorXDecisionVariable q_;
 };
 }  // namespace multibody

--- a/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/angle_between_vectors_constraint_test.cc
@@ -13,18 +13,18 @@ TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
   const FrameIndex frameA_index = GetFrameIndex("iiwa_link_3");
   const FrameIndex frameB_index = GetFrameIndex("iiwa_link_7");
   AngleBetweenVectorsConstraint constraint(
-      *iiwa_autodiff_, frameA_index, n_A, frameB_index, n_B, angle_lower,
+      iiwa_autodiff_.tree(), frameA_index, n_A, frameB_index, n_B, angle_lower,
       angle_upper,
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
 
   EXPECT_EQ(constraint.num_constraints(), 1);
-  EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_->num_positions());
+  EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
   EXPECT_TRUE(CompareMatrices(constraint.lower_bound(),
                               Vector1d(std::cos(angle_upper))));
   EXPECT_TRUE(CompareMatrices(constraint.lower_bound(),
                               Vector1d(std::cos(angle_upper))));
 
-  Eigen::VectorXd q(iiwa_autodiff_->num_positions());
+  Eigen::VectorXd q(iiwa_autodiff_.tree().num_positions());
   q << 0.2, -0.5, 0.1, 0.25, -0.4, 0.35, 0.24;
   const AutoDiffVecXd q_autodiff = math::initializeAutoDiff(q);
   AutoDiffVecXd y_autodiff;
@@ -32,10 +32,10 @@ TEST_F(IiwaKinematicConstraintTest, AngleBetweenVectorsConstraint) {
 
   Vector1<AutoDiffXd> y_autodiff_expected;
   y_autodiff_expected(0) = n_A.normalized().dot(
-      iiwa_autodiff_
-          ->CalcRelativeTransform(*context_autodiff_,
-                                  iiwa_autodiff_->get_frame(frameA_index),
-                                  iiwa_autodiff_->get_frame(frameB_index))
+      iiwa_autodiff_.tree()
+          .CalcRelativeTransform(*context_autodiff_,
+                                 iiwa_autodiff_.tree().get_frame(frameA_index),
+                                 iiwa_autodiff_.tree().get_frame(frameB_index))
           .linear() *
       n_B.normalized());
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, 1E-12);
@@ -60,7 +60,7 @@ TEST_F(TwoFreeBodiesConstraintTest, AngleBetweenVectorsConstraint) {
       QuaternionToVectorWxyz(body2_quaternion), body2_position;
   {
     AngleBetweenVectorsConstraint good_constraint(
-        *two_bodies_autodiff_, body1_index_, n_A, body2_index_, n_B,
+        two_bodies_autodiff_.tree(), body1_index_, n_A, body2_index_, n_B,
         angle - 0.01, angle + 0.01,
         dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
             context_autodiff_.get()));
@@ -69,7 +69,7 @@ TEST_F(TwoFreeBodiesConstraintTest, AngleBetweenVectorsConstraint) {
 
   {
     AngleBetweenVectorsConstraint bad_constraint(
-        *two_bodies_autodiff_, body1_index_, n_A, body2_index_, n_B,
+        two_bodies_autodiff_.tree(), body1_index_, n_A, body2_index_, n_B,
         angle - 0.02, angle - 0.01,
         dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
             context_autodiff_.get()));
@@ -83,35 +83,35 @@ TEST_F(IiwaKinematicConstraintTest,
   const FrameIndex frameB_index = GetFrameIndex("iiwa_link_7");
   // n_A being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *iiwa_autodiff_, frameA_index, Eigen::Vector3d::Zero(),
+                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Zero(),
                    frameB_index, Eigen::Vector3d::Ones(), 0.1, 0.2,
                    dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
                        context_autodiff_.get())),
                std::invalid_argument);
   // n_B being zero vector.
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *iiwa_autodiff_, frameA_index, Eigen::Vector3d::Ones(),
+                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
                    frameB_index, Eigen::Vector3d::Zero(), 0.1, 0.2,
                    dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
                        context_autodiff_.get())),
                std::invalid_argument);
   // angle_lower < 0
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *iiwa_autodiff_, frameA_index, Eigen::Vector3d::Ones(),
+                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
                    frameB_index, Eigen::Vector3d::Ones(), -0.1, 0.2,
                    dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
                        context_autodiff_.get())),
                std::invalid_argument);
   // angle_upper < angle_lower
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *iiwa_autodiff_, frameA_index, Eigen::Vector3d::Ones(),
+                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
                    frameB_index, Eigen::Vector3d::Zero(), 0.1, 0.09,
                    dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
                        context_autodiff_.get())),
                std::invalid_argument);
   // angle_upper > pi
   EXPECT_THROW(AngleBetweenVectorsConstraint(
-                   *iiwa_autodiff_, frameA_index, Eigen::Vector3d::Ones(),
+                   iiwa_autodiff_.tree(), frameA_index, Eigen::Vector3d::Ones(),
                    frameB_index, Eigen::Vector3d::Zero(), 0.1, 1.1 * M_PI,
                    dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
                        context_autodiff_.get())),

--- a/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
+++ b/multibody/inverse_kinematics/test/inverse_kinematics_test_utilities.h
@@ -64,23 +64,23 @@ class IiwaKinematicConstraintTest : public ::testing::Test {
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(IiwaKinematicConstraintTest)
 
   IiwaKinematicConstraintTest()
-      : iiwa_autodiff_{benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<
-            AutoDiffXd>(true /* finalized model. */)},
-        iiwa_double_{benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<double>(
-            true /* finalized model. */)},
-        context_autodiff_(iiwa_autodiff_->CreateDefaultContext()),
-        context_double_(iiwa_double_->CreateDefaultContext()) {}
+      : iiwa_autodiff_(benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<
+            AutoDiffXd>(true /* finalized model. */)),
+        iiwa_double_(benchmarks::kuka_iiwa_robot::MakeKukaIiwaModel<double>(
+            true /* finalized model. */)),
+        context_autodiff_(iiwa_autodiff_.CreateDefaultContext()),
+        context_double_(iiwa_double_.CreateDefaultContext()) {}
 
   FrameIndex GetFrameIndex(const std::string& name) {
     // TODO(hongkai.dai): call GetFrameByName() directly.
-    return iiwa_autodiff_->GetFrameByName(name).index();
+    return iiwa_autodiff_.tree().GetFrameByName(name).index();
   }
 
  protected:
-  std::unique_ptr<MultibodyTree<AutoDiffXd>> iiwa_autodiff_;
-  std::unique_ptr<MultibodyTree<double>> iiwa_double_;
-  std::unique_ptr<systems::LeafContext<AutoDiffXd>> context_autodiff_;
-  std::unique_ptr<systems::LeafContext<double>> context_double_;
+  MultibodyTreeSystem<AutoDiffXd> iiwa_autodiff_;
+  MultibodyTreeSystem<double> iiwa_double_;
+  std::unique_ptr<systems::Context<AutoDiffXd>> context_autodiff_;
+  std::unique_ptr<systems::Context<double>> context_double_;
 };
 
 // Test kinematic constraints on two free floating bodies.
@@ -91,22 +91,26 @@ class TwoFreeBodiesConstraintTest : public ::testing::Test {
   TwoFreeBodiesConstraintTest()
       : two_bodies_autodiff_(ConstructTwoFreeBodies<AutoDiffXd>()),
         two_bodies_double_(ConstructTwoFreeBodies<double>()),
-        body1_index_(
-            two_bodies_autodiff_->GetBodyByName("body1").body_frame().index()),
-        body2_index_(
-            two_bodies_autodiff_->GetBodyByName("body2").body_frame().index()),
-        context_autodiff_(two_bodies_autodiff_->CreateDefaultContext()),
-        context_double_(two_bodies_double_->CreateDefaultContext()) {}
+        body1_index_(two_bodies_autodiff_.tree()
+                         .GetBodyByName("body1")
+                         .body_frame()
+                         .index()),
+        body2_index_(two_bodies_autodiff_.tree()
+                         .GetBodyByName("body2")
+                         .body_frame()
+                         .index()),
+        context_autodiff_(two_bodies_autodiff_.CreateDefaultContext()),
+        context_double_(two_bodies_double_.CreateDefaultContext()) {}
 
   ~TwoFreeBodiesConstraintTest() override {}
 
  protected:
-  std::unique_ptr<MultibodyTree<AutoDiffXd>> two_bodies_autodiff_;
-  std::unique_ptr<MultibodyTree<double>> two_bodies_double_;
+  MultibodyTreeSystem<AutoDiffXd> two_bodies_autodiff_;
+  MultibodyTreeSystem<double> two_bodies_double_;
   FrameIndex body1_index_;
   FrameIndex body2_index_;
-  std::unique_ptr<systems::LeafContext<AutoDiffXd>> context_autodiff_;
-  std::unique_ptr<systems::LeafContext<double>> context_double_;
+  std::unique_ptr<systems::Context<AutoDiffXd>> context_autodiff_;
+  std::unique_ptr<systems::Context<double>> context_double_;
 };
 }  // namespace internal
 }  // namespace multibody

--- a/multibody/inverse_kinematics/test/orientation_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/orientation_constraint_test.cc
@@ -14,17 +14,17 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
   const math::RotationMatrix<double> R_BbarB(Eigen::AngleAxisd(
       -0.4 * M_PI, Eigen::Vector3d(0.1, 1.2, -0.7).normalized()));
   OrientationConstraint constraint(
-      *iiwa_autodiff_, frameAbar_index, R_AbarA, frameBbar_index, R_BbarB,
+      iiwa_autodiff_.tree(), frameAbar_index, R_AbarA, frameBbar_index, R_BbarB,
       angle_bound,
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
 
   EXPECT_EQ(constraint.num_constraints(), 1);
-  EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_->num_positions());
+  EXPECT_EQ(constraint.num_vars(), iiwa_autodiff_.tree().num_positions());
   EXPECT_TRUE(CompareMatrices(constraint.lower_bound(),
                               Vector1d(2 * std::cos(angle_bound) + 1)));
   EXPECT_TRUE(CompareMatrices(constraint.upper_bound(), Vector1d(3)));
 
-  Eigen::VectorXd q(iiwa_autodiff_->num_positions());
+  Eigen::VectorXd q(iiwa_autodiff_.tree().num_positions());
   // Arbitrary joint angles.
   q << 0.1, 0.2, 0.3, 0.4, 0.5, -0.3, -0.2;
   const AutoDiffVecXd q_autodiff = math::initializeAutoDiff(q);
@@ -33,10 +33,11 @@ TEST_F(IiwaKinematicConstraintTest, OrientationConstraint) {
 
   AutoDiffVecXd y_autodiff_expected(1);
   const Matrix3<AutoDiffXd> R_AbarBbar =
-      iiwa_autodiff_
-          ->CalcRelativeTransform(*context_autodiff_,
-                                  iiwa_autodiff_->get_frame(frameAbar_index),
-                                  iiwa_autodiff_->get_frame(frameBbar_index))
+      iiwa_autodiff_.tree()
+          .CalcRelativeTransform(
+              *context_autodiff_,
+              iiwa_autodiff_.tree().get_frame(frameAbar_index),
+              iiwa_autodiff_.tree().get_frame(frameBbar_index))
           .linear();
   const Matrix3<AutoDiffXd> R_AB =
       R_AbarA.matrix().cast<AutoDiffXd>().transpose() * R_AbarBbar *
@@ -68,13 +69,13 @@ TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {
   const double theta = Eigen::AngleAxisd(R_AB).angle();
 
   OrientationConstraint good_constraint(
-      *two_bodies_autodiff_, body1_index_, R_AbarA, body2_index_, R_BbarB,
+      two_bodies_autodiff_.tree(), body1_index_, R_AbarA, body2_index_, R_BbarB,
       theta * 1.01,
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
   EXPECT_TRUE(good_constraint.CheckSatisfied(q));
 
   OrientationConstraint bad_constraint(
-      *two_bodies_autodiff_, body1_index_, R_AbarA, body2_index_, R_BbarB,
+      two_bodies_autodiff_.tree(), body1_index_, R_AbarA, body2_index_, R_BbarB,
       theta * 0.99,
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
   EXPECT_FALSE(bad_constraint.CheckSatisfied(q));
@@ -83,7 +84,7 @@ TEST_F(TwoFreeBodiesConstraintTest, OrientationConstraint) {
 TEST_F(IiwaKinematicConstraintTest, OrientationConstraintConstructionError) {
   // Throws a logic error for negative angle bound.
   EXPECT_THROW(
-      OrientationConstraint(*iiwa_autodiff_, GetFrameIndex("iiwa_link_7"),
+      OrientationConstraint(iiwa_autodiff_.tree(), GetFrameIndex("iiwa_link_7"),
                             math::RotationMatrix<double>::Identity(),
                             GetFrameIndex("iiwa_link_3"),
                             math::RotationMatrix<double>::Identity(), -0.01,

--- a/multibody/inverse_kinematics/test/position_constraint_test.cc
+++ b/multibody/inverse_kinematics/test/position_constraint_test.cc
@@ -11,10 +11,11 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   const FrameIndex frameB_index = GetFrameIndex("iiwa_link_7");
   const FrameIndex frameA_index = GetFrameIndex("iiwa_link_3");
   PositionConstraint constraint1(
-      *iiwa_autodiff_, frameB_index, p_BQ, frameA_index, p_AQ_lower, p_AQ_upper,
+      iiwa_autodiff_.tree(), frameB_index, p_BQ, frameA_index, p_AQ_lower,
+      p_AQ_upper,
       dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(context_autodiff_.get()));
 
-  EXPECT_EQ(constraint1.num_vars(), iiwa_autodiff_->num_positions());
+  EXPECT_EQ(constraint1.num_vars(), iiwa_autodiff_.tree().num_positions());
   EXPECT_EQ(constraint1.num_constraints(), 3);
   EXPECT_EQ(constraint1.lower_bound(), p_AQ_lower);
   EXPECT_EQ(constraint1.upper_bound(), p_AQ_upper);
@@ -30,9 +31,9 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   auto mbt_context_double =
       dynamic_cast<MultibodyTreeContext<double>*>(context_double_.get());
   mbt_context_double->get_mutable_positions() = q;
-  iiwa_double_->CalcPointsPositions(
-      *context_double_, iiwa_double_->get_frame(frameB_index), p_BQ,
-      iiwa_double_->get_frame(frameA_index), &y_expected);
+  iiwa_double_.tree().CalcPointsPositions(
+      *context_double_, iiwa_double_.tree().get_frame(frameB_index), p_BQ,
+      iiwa_double_.tree().get_frame(frameA_index), &y_expected);
   const double tol = 1E-12;
   EXPECT_TRUE(CompareMatrices(y, y_expected, tol));
 
@@ -41,9 +42,9 @@ TEST_F(IiwaKinematicConstraintTest, PositionConstraint) {
   constraint1.Eval(q_autodiff, &y_autodiff);
   AutoDiffVecd<Eigen::Dynamic, 3> p_BQ_autodiff;
   Vector3<AutoDiffXd> y_autodiff_expected;
-  iiwa_autodiff_->CalcPointsPositions(
-      *context_autodiff_, iiwa_autodiff_->get_frame(frameB_index),
-      p_BQ.cast<AutoDiffXd>(), iiwa_autodiff_->get_frame(frameA_index),
+  iiwa_autodiff_.tree().CalcPointsPositions(
+      *context_autodiff_, iiwa_autodiff_.tree().get_frame(frameB_index),
+      p_BQ.cast<AutoDiffXd>(), iiwa_autodiff_.tree().get_frame(frameA_index),
       &y_autodiff_expected);
   CompareAutoDiffVectors(y_autodiff, y_autodiff_expected, tol);
 }
@@ -64,13 +65,13 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
       ->get_mutable_positions() = q;
   const Eigen::Vector3d p_BQ(0.2, 0.3, 0.4);
   Eigen::Vector3d p_AQ;
-  two_bodies_double_->CalcPointsPositions(
-      *context_double_, two_bodies_double_->get_frame(body1_index_), p_BQ,
-      two_bodies_double_->get_frame(body2_index_), &p_AQ);
+  two_bodies_double_.tree().CalcPointsPositions(
+      *context_double_, two_bodies_double_.tree().get_frame(body1_index_), p_BQ,
+      two_bodies_double_.tree().get_frame(body2_index_), &p_AQ);
 
   {
     PositionConstraint good_constraint(
-        *two_bodies_autodiff_, body1_index_, p_BQ, body2_index_,
+        two_bodies_autodiff_.tree(), body1_index_, p_BQ, body2_index_,
         p_AQ - Eigen::Vector3d::Constant(0.001),
         p_AQ + Eigen::Vector3d::Constant(0.001),
         dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(
@@ -79,7 +80,7 @@ TEST_F(TwoFreeBodiesConstraintTest, PositionConstraint) {
   }
   {
     PositionConstraint bad_constraint(
-        *two_bodies_autodiff_, body1_index_, p_BQ, body2_index_,
+        two_bodies_autodiff_.tree(), body1_index_, p_BQ, body2_index_,
         p_AQ - Eigen::Vector3d::Constant(0.002),
         p_AQ - Eigen::Vector3d::Constant(0.001),
         dynamic_cast<MultibodyTreeContext<AutoDiffXd>*>(

--- a/multibody/multibody_tree/BUILD.bazel
+++ b/multibody/multibody_tree/BUILD.bazel
@@ -101,6 +101,7 @@ drake_cc_library(
         "model_instance.cc",
         "multibody_forces.cc",
         "multibody_tree.cc",
+        "multibody_tree_system.cc",
         "prismatic_mobilizer.cc",
         "quaternion_floating_mobilizer.cc",
         "revolute_mobilizer.cc",
@@ -129,6 +130,7 @@ drake_cc_library(
         "model_instance.h",
         "multibody_forces.h",
         "multibody_tree.h",
+        "multibody_tree_system.h",
         "prismatic_mobilizer.h",
         "quaternion_floating_mobilizer.h",
         "revolute_mobilizer.h",
@@ -148,6 +150,7 @@ drake_cc_library(
         "//common:autodiff",
         "//common:nice_type_name",
         "//math:geometric_transform",
+        "//systems/framework:leaf_system",
     ],
 )
 

--- a/multibody/multibody_tree/force_element.h
+++ b/multibody/multibody_tree/force_element.h
@@ -12,6 +12,8 @@
 #include "drake/multibody/multibody_tree/multibody_tree_element.h"
 #include "drake/multibody/multibody_tree/multibody_tree_indexes.h"
 #include "drake/multibody/multibody_tree/multibody_tree_topology.h"
+#include "drake/multibody/multibody_tree/position_kinematics_cache.h"
+#include "drake/multibody/multibody_tree/velocity_kinematics_cache.h"
 
 namespace drake {
 namespace multibody {

--- a/multibody/multibody_tree/joints/test/prismatic_joint_test.cc
+++ b/multibody/multibody_tree/joints/test/prismatic_joint_test.cc
@@ -25,36 +25,41 @@ class PrismaticJointTest : public ::testing::Test {
     // these tests and therefore we do not initialize it.
     const SpatialInertia<double> M_B;  // Default construction is ok for this.
 
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
+
     // Add a body so we can add joint to it.
-    body1_ = &model_.AddBody<RigidBody>(M_B);
+    body1_ = &model->AddBody<RigidBody>(M_B);
 
     // Add a prismatic joint between the world and body1:
     const double lower_limit = -1.0;
     const double upper_limit = 1.5;
     const double damping = 3.0;
-    joint1_ = &model_.AddJoint<PrismaticJoint>(
+    joint1_ = &model->AddJoint<PrismaticJoint>(
         "Joint1",
-        model_.world_body(), {}, *body1_, {}, Vector3d::UnitZ(),
+        model->world_body(), {}, *body1_, {}, Vector3d::UnitZ(),
         lower_limit, upper_limit, damping);
 
-    // We are done adding modeling elements. Finalize the model:
-    model_.Finalize();
-
-    // Create a context to store the state for this model:
-    context_ = model_.CreateDefaultContext();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    context_ = system_->CreateDefaultContext();
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
   const RigidBody<double>* body1_{nullptr};
   const PrismaticJoint<double>* joint1_{nullptr};
-  std::unique_ptr<Context<double>> context_;
 };
 
 // Verify the expected number of dofs.
 TEST_F(PrismaticJointTest, NumDOFs) {
-  EXPECT_EQ(model_.num_positions(), 1);
-  EXPECT_EQ(model_.num_velocities(), 1);
+  EXPECT_EQ(tree().num_positions(), 1);
+  EXPECT_EQ(tree().num_velocities(), 1);
   EXPECT_EQ(joint1_->num_positions(), 1);
   EXPECT_EQ(joint1_->num_velocities(), 1);
   EXPECT_EQ(joint1_->position_start(), 0);
@@ -89,13 +94,13 @@ TEST_F(PrismaticJointTest, ContextDependentAccess) {
 TEST_F(PrismaticJointTest, AddInForces) {
   const double some_value = 1.5;
   // Default initialized to zero forces:
-  MultibodyForces<double> forces1(model_);
+  MultibodyForces<double> forces1(tree());
 
   // Add value twice:
   joint1_->AddInForce(*context_, some_value, &forces1);
   joint1_->AddInForce(*context_, some_value, &forces1);
 
-  MultibodyForces<double> forces2(model_);
+  MultibodyForces<double> forces2(tree());
   // Add value only once:
   joint1_->AddInForce(*context_, some_value, &forces2);
   // Add forces2 into itself (same as adding torque twice):
@@ -109,7 +114,7 @@ TEST_F(PrismaticJointTest, AddInForces) {
 }
 
 TEST_F(PrismaticJointTest, Clone) {
-  auto model_clone = model_.CloneToScalar<AutoDiffXd>();
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
   const auto& joint1_clone = model_clone->get_variant(*joint1_);
 
   EXPECT_EQ(joint1_clone.name(), joint1_->name());

--- a/multibody/multibody_tree/joints/test/revolute_joint_test.cc
+++ b/multibody/multibody_tree/joints/test/revolute_joint_test.cc
@@ -27,36 +27,41 @@ class RevoluteJointTest : public ::testing::Test {
     // these tests and therefore we do not initialize it.
     const SpatialInertia<double> M_B;  // Default construction is ok for this.
 
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
+
     // Add some bodies so we can add joints between them:
-    body1_ = &model_.AddBody<RigidBody>(M_B);
+    body1_ = &model->AddBody<RigidBody>(M_B);
 
     // Add a revolute joint between the world and body1:
     const double lower_limit = -1.0;
     const double upper_limit = 1.5;
     const double damping = 3.0;
-    joint1_ = &model_.AddJoint<RevoluteJoint>(
+    joint1_ = &model->AddJoint<RevoluteJoint>(
         "Joint1",
-        model_.world_body(), {}, *body1_, {},
+        model->world_body(), {}, *body1_, {},
         Vector3d::UnitZ(), lower_limit, upper_limit, damping);
 
-    // We are done adding modeling elements. Finalize the model:
-    model_.Finalize();
-
-    // Create a context to store the state for this model:
-    context_ = model_.CreateDefaultContext();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    context_ = system_->CreateDefaultContext();
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
+
   const RigidBody<double>* body1_{nullptr};
   const RevoluteJoint<double>* joint1_{nullptr};
-  std::unique_ptr<Context<double>> context_;
 };
 
 // Verify the expected number of dofs.
 TEST_F(RevoluteJointTest, NumDOFs) {
-  EXPECT_EQ(model_.num_positions(), 1);
-  EXPECT_EQ(model_.num_velocities(), 1);
+  EXPECT_EQ(tree().num_positions(), 1);
+  EXPECT_EQ(tree().num_velocities(), 1);
   EXPECT_EQ(joint1_->num_positions(), 1);
   EXPECT_EQ(joint1_->num_velocities(), 1);
   EXPECT_EQ(joint1_->position_start(), 0);
@@ -91,14 +96,14 @@ TEST_F(RevoluteJointTest, ContextDependentAccess) {
 TEST_F(RevoluteJointTest, AddInTorques) {
   const double some_value = M_PI_2;
   // Default initialized to zero forces:
-  MultibodyForces<double> forces1(model_);
+  MultibodyForces<double> forces1(tree());
 
   // Add value twice:
   joint1_->AddInTorque(*context_, some_value, &forces1);
   joint1_->AddInTorque(*context_, some_value, &forces1);
 
 
-  MultibodyForces<double> forces2(model_);
+  MultibodyForces<double> forces2(tree());
   // Add value only once:
   joint1_->AddInTorque(*context_, some_value, &forces2);
   // Add forces2 into itself (same as adding torque twice):
@@ -112,7 +117,7 @@ TEST_F(RevoluteJointTest, AddInTorques) {
 }
 
 TEST_F(RevoluteJointTest, Clone) {
-  auto model_clone = model_.CloneToScalar<AutoDiffXd>();
+  auto model_clone = tree().CloneToScalar<AutoDiffXd>();
   const auto& joint1_clone = model_clone->get_variant(*joint1_);
 
   EXPECT_EQ(joint1_clone.name(), joint1_->name());

--- a/multibody/multibody_tree/joints/test/weld_joint_test.cc
+++ b/multibody/multibody_tree/joints/test/weld_joint_test.cc
@@ -25,22 +25,29 @@ class WeldJointTest : public ::testing::Test {
     // these tests and therefore we do not initialize it.
     const SpatialInertia<double> M_B;
 
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
+
     // Add a body so we can add joint to it.
-    body_ = &model_.AddBody<RigidBody>(M_B);
+    body_ = &model->AddBody<RigidBody>(M_B);
 
     // Add a prismatic joint between the world and the body.
-    joint_ = &model_.AddJoint<WeldJoint>(
+    joint_ = &model->AddJoint<WeldJoint>(
         "Welder",
-        model_.world_body(), {},  // X_PF
+        model->world_body(), {},  // X_PF
         *body_, {},               // X_BM
         X_FM_);                   // X_FM
 
-    // We are done adding modeling elements. Finalize the model:
-    model_.Finalize();
+    // We are done adding modeling elements. Transfer tree to system for
+    // computation.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
+
   const RigidBody<double>* body_{nullptr};
   const WeldJoint<double>* joint_{nullptr};
   const Isometry3d X_FM_{Translation3d(0, 0.5, 0)};
@@ -48,8 +55,8 @@ class WeldJointTest : public ::testing::Test {
 
 // Verify the expected number of dofs.
 TEST_F(WeldJointTest, NumDOFs) {
-  EXPECT_EQ(model_.num_positions(), 0);
-  EXPECT_EQ(model_.num_velocities(), 0);
+  EXPECT_EQ(tree().num_positions(), 0);
+  EXPECT_EQ(tree().num_velocities(), 0);
   EXPECT_EQ(joint_->num_positions(), 0);
   EXPECT_EQ(joint_->num_velocities(), 0);
   // We just verify we can call these methods. However their return value is

--- a/multibody/multibody_tree/mobilizer_impl.h
+++ b/multibody/multibody_tree/mobilizer_impl.h
@@ -170,8 +170,8 @@ class MobilizerImpl : public Mobilizer<T> {
     MultibodyTreeContext<T>* mbt_context =
         dynamic_cast<MultibodyTreeContext<T>*>(context);
     if (mbt_context == nullptr) {
-      throw std::logic_error("The provided systems::Context is not a"
-                               "drake::multibody::MultibodyTreeContext.");
+      throw std::logic_error("The provided systems::Context is not a "
+                             "drake::multibody::MultibodyTreeContext.");
     }
     return *mbt_context;
   }

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -220,13 +220,13 @@ struct JointLimitsPenaltyParametersEstimator {
 };
 }  // namespace internal
 
-template<typename T>
-MultibodyPlant<T>::MultibodyPlant(double time_step) :
-    systems::LeafSystem<T>(systems::SystemTypeTag<
-        drake::multibody::multibody_plant::MultibodyPlant>()),
-    time_step_(time_step) {
+template <typename T>
+MultibodyPlant<T>::MultibodyPlant(double time_step)
+    : MultibodyTreeSystem<T>(
+          systems::SystemTypeTag<multibody::multibody_plant::MultibodyPlant>{},
+          nullptr, time_step > 0),
+      time_step_(time_step) {
   DRAKE_THROW_UNLESS(time_step >= 0);
-  tree_ = std::make_unique<MultibodyTree<T>>();
   visual_geometries_.emplace_back();  // Entries for the "world" body.
   collision_geometries_.emplace_back();
 }
@@ -235,7 +235,7 @@ template<typename T>
 const WeldJoint<T>& MultibodyPlant<T>::WeldFrames(
     const Frame<T>& A, const Frame<T>& B, const Isometry3<double>& X_AB) {
   const std::string joint_name = A.name() + "_welds_to_" + B.name();
-  return tree_->AddJoint(
+  return this->mutable_tree().AddJoint(
       std::make_unique<WeldJoint<T>>(joint_name, A, B, X_AB));
 }
 
@@ -440,7 +440,8 @@ geometry::GeometryId MultibodyPlant<T>::RegisterAnchoredGeometry(
 
 template<typename T>
 void MultibodyPlant<T>::Finalize(geometry::SceneGraph<T>* scene_graph) {
-  tree_->Finalize();
+  // After finalizing the base class, tree is read-only.
+  MultibodyTreeSystem<T>::Finalize();
   FilterAdjacentBodies(scene_graph);
   ExcludeCollisionsWithVisualGeometry(scene_graph);
   FinalizePlantOnly();
@@ -535,7 +536,7 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
 
 template<typename T>
 void MultibodyPlant<T>::FinalizePlantOnly() {
-  DeclareStateAndPorts();
+  DeclareStateCacheAndPorts();
   // Only declare ports to communicate with a SceneGraph if the plant is
   // provided with a valid source id.
   if (source_id_) DeclareSceneGraphPorts();
@@ -579,8 +580,8 @@ void MultibodyPlant<T>::FilterAdjacentBodies(SceneGraph<T>* scene_graph) {
     }
     // Disallow collisions between adjacent bodies. Adjacency is implied by the
     // existence of a joint between bodies.
-    for (JointIndex j{0}; j < tree_->num_joints(); ++j) {
-      const Joint<T>& joint = tree_->get_joint(j);
+    for (JointIndex j{0}; j < tree().num_joints(); ++j) {
+      const Joint<T>& joint = tree().get_joint(j);
       const Body<T>& child = joint.child_body();
       const Body<T>& parent = joint.parent_body();
       // TODO(SeanCurtis-TRI): Determine the correct action for a body
@@ -621,14 +622,6 @@ void MultibodyPlant<T>::ExcludeCollisionsWithVisualGeometry(
     scene_graph->ExcludeCollisionsWithin(visual);
     scene_graph->ExcludeCollisionsBetween(visual, collision);
   }
-}
-
-template<typename T>
-std::unique_ptr<systems::LeafContext<T>>
-MultibodyPlant<T>::DoMakeLeafContext() const {
-  DRAKE_THROW_UNLESS(is_finalized());
-  return std::make_unique<MultibodyTreeContext<T>>(
-      tree_->get_topology(), is_discrete());
 }
 
 template<typename T>
@@ -1078,7 +1071,7 @@ VectorX<T> MultibodyPlant<T>::AssembleActuationInput(
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_dofs =
-        tree_->num_actuated_dofs(model_instance_index);
+        tree().num_actuated_dofs(model_instance_index);
     if (instance_num_dofs == 0) {
       continue;
     }
@@ -1108,9 +1101,9 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
   // Mass matrix.
   MatrixX<T> M(nv, nv);
   // Forces.
-  MultibodyForces<T> forces(*tree_);
+  MultibodyForces<T> forces(tree());
   // Bodies' accelerations, ordered by BodyNodeIndex.
-  std::vector<SpatialAcceleration<T>> A_WB_array(tree_->num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(tree().num_bodies());
   // Generalized accelerations.
   VectorX<T> vdot = VectorX<T>::Zero(nv);
 
@@ -1119,12 +1112,12 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
 
   // Compute forces applied through force elements. This effectively resets
   // the forces to zero and adds in contributions due to force elements.
-  tree_->CalcForceElementsContribution(context, pc, vc, &forces);
+  tree().CalcForceElementsContribution(context, pc, vc, &forces);
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context, &forces);
 
-  tree_->CalcMassMatrixViaInverseDynamics(context, &M);
+  tree().CalcMassMatrixViaInverseDynamics(context, &M);
 
   // WARNING: to reduce memory foot-print, we use the input applied arrays also
   // as output arrays. This means that both the array of applied body forces and
@@ -1145,7 +1138,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
         context, pc, vc, point_pairs, &F_BBo_W_array);
   }
 
-  tree_->CalcInverseDynamics(
+  tree().CalcInverseDynamics(
       context, pc, vc, vdot,
       F_BBo_W_array, tau_array,
       &A_WB_array,
@@ -1157,7 +1150,7 @@ void MultibodyPlant<T>::DoCalcTimeDerivatives(
   auto v = x.bottomRows(nv);
   VectorX<T> xdot(this->num_multibody_states());
   VectorX<T> qdot(this->num_positions());
-  tree_->MapVelocityToQDot(context, v, &qdot);
+  tree().MapVelocityToQDot(context, v, &qdot);
   xdot << qdot, vdot;
   derivatives->SetFromVector(xdot);
 }
@@ -1233,17 +1226,17 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // Mass matrix and its factorization.
   MatrixX<T> M0(nv, nv);
-  tree_->CalcMassMatrixViaInverseDynamics(context0, &M0);
+  tree().CalcMassMatrixViaInverseDynamics(context0, &M0);
   auto M0_ldlt = M0.ldlt();
 
   // Forces at the previous time step.
-  MultibodyForces<T> forces0(*tree_);
+  MultibodyForces<T> forces0(tree());
 
   const PositionKinematicsCache<T>& pc0 = EvalPositionKinematics(context0);
   const VelocityKinematicsCache<T>& vc0 = EvalVelocityKinematics(context0);
 
   // Compute forces applied through force elements.
-  tree_->CalcForceElementsContribution(context0, pc0, vc0, &forces0);
+  tree().CalcForceElementsContribution(context0, pc0, vc0, &forces0);
 
   // If there is any input actuation, add it to the multibody forces.
   AddJointActuationForces(context0, &forces0);
@@ -1256,7 +1249,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
 
   // Workspace for inverse dynamics:
   // Bodies' accelerations, ordered by BodyNodeIndex.
-  std::vector<SpatialAcceleration<T>> A_WB_array(tree_->num_bodies());
+  std::vector<SpatialAcceleration<T>> A_WB_array(tree().num_bodies());
   // Generalized accelerations.
   VectorX<T> vdot = VectorX<T>::Zero(nv);
   // Body forces (alias to forces0).
@@ -1265,7 +1258,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   // With vdot = 0, this computes:
   //   -tau = C(q, v)v - tau_app - ∑ J_WBᵀ(q) Fapp_Bo_W.
   VectorX<T>& minus_tau = forces0.mutable_generalized_forces();
-  tree_->CalcInverseDynamics(
+  tree().CalcInverseDynamics(
       context0, pc0, vc0, vdot,
       F_BBo_W_array, minus_tau,
       &A_WB_array,
@@ -1352,7 +1345,7 @@ void MultibodyPlant<T>::DoCalcDiscreteVariableUpdates(
   VectorX<T> v_next = implicit_stribeck_solver_->get_generalized_velocities();
 
   VectorX<T> qdot_next(this->num_positions());
-  tree_->MapVelocityToQDot(context0, v_next, &qdot_next);
+  tree().MapVelocityToQDot(context0, v_next, &qdot_next);
   VectorX<T> q_next = q0 + dt * qdot_next;
 
   VectorX<T> x_next(this->num_multibody_states());
@@ -1371,15 +1364,15 @@ void MultibodyPlant<T>::DoMapQDotToVelocity(
     const Eigen::Ref<const VectorX<T>>& qdot,
     systems::VectorBase<T>* generalized_velocity) const {
   if (is_discrete()) return;
-  const int nq = tree_->num_positions();
-  const int nv = tree_->num_velocities();
+  const int nq = tree().num_positions();
+  const int nv = tree().num_velocities();
 
   DRAKE_ASSERT(qdot.size() == nq);
   DRAKE_DEMAND(generalized_velocity != nullptr);
   DRAKE_DEMAND(generalized_velocity->size() == nv);
 
   VectorX<T> v(nv);
-  tree_->MapQDotToVelocity(context, qdot, &v);
+  tree().MapQDotToVelocity(context, qdot, &v);
   generalized_velocity->SetFromVector(v);
 }
 
@@ -1389,32 +1382,28 @@ void MultibodyPlant<T>::DoMapVelocityToQDot(
     const Eigen::Ref<const VectorX<T>>& generalized_velocity,
     systems::VectorBase<T>* positions_derivative) const {
   if (is_discrete()) return;
-  const int nq = tree_->num_positions();
-  const int nv = tree_->num_velocities();
+  const int nq = tree().num_positions();
+  const int nv = tree().num_velocities();
 
   DRAKE_ASSERT(generalized_velocity.size() == nv);
   DRAKE_DEMAND(positions_derivative != nullptr);
   DRAKE_DEMAND(positions_derivative->size() == nq);
 
   VectorX<T> qdot(nq);
-  tree_->MapVelocityToQDot(context, generalized_velocity, &qdot);
+  tree().MapVelocityToQDot(context, generalized_velocity, &qdot);
   positions_derivative->SetFromVector(qdot);
 }
 
 template<typename T>
-void MultibodyPlant<T>::DeclareStateAndPorts() {
+void MultibodyPlant<T>::DeclareStateCacheAndPorts() {
   // The model must be finalized.
   DRAKE_DEMAND(this->is_finalized());
 
   if (is_discrete()) {
     this->DeclarePeriodicDiscreteUpdate(time_step_);
-    this->DeclareDiscreteState(num_multibody_states());
-  } else {
-    this->DeclareContinuousState(
-        BasicVector<T>(tree_->num_states()),
-        tree_->num_positions(),
-        tree_->num_velocities(), 0 /* num_z */);
   }
+
+  // TODO(sherm1) Add ContactResults cache entry.
 
   // Declare per model instance actuation ports.
   int num_actuated_instances = 0;
@@ -1423,7 +1412,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_dofs =
-        tree_->num_actuated_dofs(model_instance_index);
+        tree().num_actuated_dofs(model_instance_index);
     if (instance_num_dofs == 0) {
       continue;
     }
@@ -1431,7 +1420,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     last_actuated_instance = model_instance_index;
     instance_actuation_ports_[model_instance_index] =
         this->DeclareVectorInputPort(
-                tree_->GetModelInstanceName(model_instance_index) +
+                tree().GetModelInstanceName(model_instance_index) +
                     "_actuation",
                 systems::BasicVector<T>(instance_num_dofs))
             .get_index();
@@ -1453,7 +1442,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_states =
-        tree_->num_states(model_instance_index);
+        tree().num_states(model_instance_index);
     if (instance_num_states == 0) {
       continue;
     }
@@ -1464,7 +1453,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     };
     instance_continuous_state_output_ports_[model_instance_index] =
         this->DeclareVectorOutputPort(
-                tree_->GetModelInstanceName(model_instance_index) +
+                tree().GetModelInstanceName(model_instance_index) +
                     "_continuous_state",
                 BasicVector<T>(instance_num_states), calc)
             .get_index();
@@ -1476,7 +1465,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
   for (ModelInstanceIndex model_instance_index(0);
        model_instance_index < num_model_instances(); ++model_instance_index) {
     const int instance_num_velocities =
-        tree_->num_velocities(model_instance_index);
+        tree().num_velocities(model_instance_index);
     if (instance_num_velocities == 0) {
       continue;
     }
@@ -1487,7 +1476,7 @@ void MultibodyPlant<T>::DeclareStateAndPorts() {
     };
     instance_generalized_contact_forces_output_ports_[model_instance_index] =
         this->DeclareVectorOutputPort(
-                tree_->GetModelInstanceName(model_instance_index) +
+                tree().GetModelInstanceName(model_instance_index) +
                     "_generalized_contact_forces",
                 BasicVector<T>(instance_num_velocities), calc)
             .get_index();
@@ -1527,12 +1516,12 @@ void MultibodyPlant<T>::CopyContinuousStateOut(
   VectorX<T> continuous_state_vector =
       GetStateVector(context).CopyToVector();
 
-  VectorX<T> instance_state_vector(tree_->num_states(model_instance));
+  VectorX<T> instance_state_vector(tree().num_states(model_instance));
   instance_state_vector.head(num_positions(model_instance)) =
-      tree_->get_positions_from_array(
+      tree().get_positions_from_array(
           model_instance, continuous_state_vector.head(num_positions()));
   instance_state_vector.tail(num_velocities(model_instance)) =
-      tree_->get_velocities_from_array(
+      tree().get_velocities_from_array(
           model_instance, continuous_state_vector.tail(num_velocities()));
 
   state_vector->set_value(instance_state_vector);
@@ -1556,7 +1545,7 @@ void MultibodyPlant<T>::CopyGeneralizedContactForcesOut(
   // Generalized velocities and generalized forces are ordered in the same way.
   // Thus we can call get_velocities_from_array().
   const VectorX<T> instance_tau_contact =
-      tree_->get_velocities_from_array(model_instance, tau_contact);
+      tree().get_velocities_from_array(model_instance, tau_contact);
 
   tau_vector->set_value(instance_tau_contact);
 }
@@ -1596,7 +1585,7 @@ MultibodyPlant<T>::get_continuous_state_output_port(
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_THROW_UNLESS(model_instance.is_valid());
   DRAKE_THROW_UNLESS(model_instance < num_model_instances());
-  DRAKE_THROW_UNLESS(tree_->num_states(model_instance) > 0);
+  DRAKE_THROW_UNLESS(tree().num_states(model_instance) > 0);
   return this->get_output_port(
       instance_continuous_state_output_ports_.at(model_instance));
 }
@@ -1609,7 +1598,7 @@ MultibodyPlant<T>::get_generalized_contact_forces_output_port(
   DRAKE_THROW_UNLESS(is_discrete());
   DRAKE_THROW_UNLESS(model_instance.is_valid());
   DRAKE_THROW_UNLESS(model_instance < num_model_instances());
-  DRAKE_THROW_UNLESS(tree_->num_states(model_instance) > 0);
+  DRAKE_THROW_UNLESS(tree().num_states(model_instance) > 0);
   return this->get_output_port(
       instance_generalized_contact_forces_output_ports_.at(model_instance));
 }
@@ -1653,7 +1642,7 @@ void MultibodyPlant<T>::CalcFramePoseOutput(
   poses->clear();
   for (const auto it : body_index_to_frame_id_) {
     const BodyIndex body_index = it.first;
-    const Body<T>& body = tree_->get_body(body_index);
+    const Body<T>& body = tree().get_body(body_index);
 
     // NOTE: The GeometryFrames for each body were registered in the world
     // frame, so we report poses in the world frame.
@@ -1676,18 +1665,6 @@ MultibodyPlant<T>::get_geometry_query_input_port() const {
   DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(geometry_source_is_registered());
   return systems::System<T>::get_input_port(geometry_query_port_);
-}
-
-template<typename T>
-const PositionKinematicsCache<T>& MultibodyPlant<T>::EvalPositionKinematics(
-    const systems::Context<T>& context) const {
-  return tree_->EvalPositionKinematics(context);
-}
-
-template<typename T>
-const VelocityKinematicsCache<T>& MultibodyPlant<T>::EvalVelocityKinematics(
-    const systems::Context<T>& context) const {
-  return tree_->EvalVelocityKinematics(context);
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -18,6 +18,7 @@
 #include "drake/multibody/multibody_tree/multibody_plant/contact_results.h"
 #include "drake/multibody/multibody_tree/multibody_plant/coulomb_friction.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
 #include "drake/systems/framework/leaf_system.h"
@@ -184,8 +185,8 @@ namespace multibody_plant {
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 /// @ingroup systems
-template<typename T>
-class MultibodyPlant : public systems::LeafSystem<T> {
+template <typename T>
+class MultibodyPlant : public MultibodyTreeSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyPlant)
 
@@ -199,12 +200,13 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   explicit MultibodyPlant(double time_step = 0);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
-  template<typename U>
-  MultibodyPlant(const MultibodyPlant<U>& other) :
-      systems::LeafSystem<T>(systems::SystemTypeTag<
-          drake::multibody::multibody_plant::MultibodyPlant>()) {
+  template <typename U>
+  MultibodyPlant(const MultibodyPlant<U>& other)
+      : MultibodyTreeSystem<T>(
+            systems::SystemTypeTag<
+                multibody::multibody_plant::MultibodyPlant>{},
+            other.tree().template CloneToScalar<T>(), other.is_discrete()) {
     DRAKE_THROW_UNLESS(other.is_finalized());
-    tree_ = other.tree_->template CloneToScalar<T>();
     time_step_ = other.time_step_;
     // Copy of all members related with geometry registration.
     source_id_ = other.source_id_;
@@ -221,50 +223,49 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     FinalizePlantOnly();
   }
 
-
   /// Returns the number of bodies in the model, including the "world" body,
   /// which is always part of the model.
   /// @see AddRigidBody().
   int num_bodies() const {
-    return tree_->num_bodies();
+    return tree().num_bodies();
   }
 
   /// Returns the number of joints in the model.
   /// @see AddJoint().
   int num_joints() const {
-    return tree_->num_joints();
+    return tree().num_joints();
   }
 
   /// Returns the number of joint actuators in the model.
   /// @see AddJointActuator().
   int num_actuators() const {
-    return tree_->num_actuators();
+    return tree().num_actuators();
   }
 
   /// Returns the number of model instances in the model.
   /// @see AddModelInstance().
   int num_model_instances() const {
-    return tree_->num_model_instances();
+    return tree().num_model_instances();
   }
 
   /// Returns the size of the generalized position vector `q` for `this`
   /// %MultibodyPlant.
-  int num_positions() const { return tree_->num_positions(); }
+  int num_positions() const { return tree().num_positions(); }
 
   /// Returns the size of the generalized position vector `q` for a specific
   /// model instance.
   int num_positions(ModelInstanceIndex model_instance) const {
-    return tree_->num_positions(model_instance);
+    return tree().num_positions(model_instance);
   }
 
   /// Returns the size of the generalized velocity vector `v` for `this`
   /// %MultibodyPlant.
-  int num_velocities() const { return tree_->num_velocities(); }
+  int num_velocities() const { return tree().num_velocities(); }
 
   /// Returns the size of the generalized velocity vector `v` for a specific
   /// model instance.
   int num_velocities(ModelInstanceIndex model_instance) const {
-    return tree_->num_velocities(model_instance);
+    return tree().num_velocities(model_instance);
   }
 
   /// Returns the size of the multibody system state vector `x = [q; v]` for
@@ -274,18 +275,18 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// Notice however that the state of a %MultibodyPlant, stored in its Context,
   /// can actually contain other variables such as integrated power and discrete
   /// states.
-  int num_multibody_states() const { return tree_->num_states(); }
+  int num_multibody_states() const { return tree().num_states(); }
 
   /// Returns the total number of actuated degrees of freedom.
   /// That is, the vector of actuation values u has this size.
   /// See AddJointActuator().
-  int num_actuated_dofs() const { return tree_->num_actuated_dofs(); }
+  int num_actuated_dofs() const { return tree().num_actuated_dofs(); }
 
   /// Returns the total number of actuated degrees of freedom for a specific
   /// model instance.  That is, the vector of actuation values u has this size.
   /// See AddJointActuator().
   int num_actuated_dofs(ModelInstanceIndex model_instance) const {
-    return tree_->num_actuated_dofs(model_instance);
+    return tree().num_actuated_dofs(model_instance);
   }
 
   /// @name Adding new multibody elements
@@ -328,7 +329,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const std::string& name, ModelInstanceIndex model_instance,
       const SpatialInertia<double>& M_BBo_B) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    const RigidBody<T>& body = tree_->AddRigidBody(
+    const RigidBody<T>& body = this->mutable_tree().AddRigidBody(
         name, model_instance, M_BBo_B);
     // Each entry of visual_geometries_, ordered by body index, contains a
     // std::vector of geometry ids for that body. The emplace_back() below
@@ -388,7 +389,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///          remain valid for the lifetime of `this` %MultibodyPlant.
   template <template<typename> class FrameType>
   const FrameType<T>& AddFrame(std::unique_ptr<FrameType<T>> frame) {
-    return tree_->AddFrame(std::move(frame));
+    return this->mutable_tree().AddFrame(std::move(frame));
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
@@ -398,7 +399,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   const JointType<T>& AddJoint(std::unique_ptr<JointType<T>> joint) {
     static_assert(std::is_convertible<JointType<T>*, Joint<T>*>::value,
                   "JointType must be a sub-class of Joint<T>.");
-    return tree_->AddJoint(std::move(joint));
+    return this->mutable_tree().AddJoint(std::move(joint));
   }
 
   /// This method adds a Joint of type `JointType` between two bodies.
@@ -478,7 +479,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const Body<T>& child, const optional<Isometry3<double>>& X_BM,
       Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    return tree_->template AddJoint<JointType>(
+    return this->mutable_tree().template AddJoint<JointType>(
         name, parent, X_PF, child, X_BM, std::forward<Args>(args)...);
   }
 
@@ -508,24 +509,24 @@ class MultibodyPlant : public systems::LeafSystem<T> {
 #endif
   AddForceElement(Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
-    return tree_->template AddForceElement<ForceElementType>(
+    return this->mutable_tree().template AddForceElement<ForceElementType>(
         std::forward<Args>(args)...);
   }
 
   // SFINAE overload for ForceElementType = UniformGravityFieldElement.
   // This allow us to keep track of the gravity field parameters.
-  template<template<typename Scalar> class ForceElementType, typename... Args>
-  typename std::enable_if<std::is_same<
-      ForceElementType<T>,
-      UniformGravityFieldElement<T>>::value, const ForceElementType<T>&>::type
+  template <template <typename Scalar> class ForceElementType, typename... Args>
+  typename std::enable_if<
+      std::is_same<ForceElementType<T>, UniformGravityFieldElement<T>>::value,
+      const ForceElementType<T>&>::type
   AddForceElement(Args&&... args) {
     DRAKE_MBP_THROW_IF_FINALIZED();
     DRAKE_DEMAND(!gravity_field_.has_value());
     // We save the force element so that we can grant users access to it for
     // gravity field specific queries.
-    gravity_field_ =
-        &tree_->template AddForceElement<UniformGravityFieldElement>(
-            std::forward<Args>(args)...);
+    gravity_field_ = &this->mutable_tree()
+                          .template AddForceElement<UniformGravityFieldElement>(
+                              std::forward<Args>(args)...);
     return *gravity_field_.value();
   }
 
@@ -547,7 +548,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   const JointActuator<T>& AddJointActuator(
       const std::string& name, const Joint<T>& joint) {
     DRAKE_THROW_UNLESS(joint.num_velocities() == 1);
-    return tree_->AddJointActuator(name, joint);
+    return this->mutable_tree().AddJointActuator(name, joint);
   }
 
   /// Creates a new model instance.  Returns the index for the model
@@ -558,7 +559,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///   model. An exception is thrown if an instance with the same name
   ///   already exists in the model. See HasModelInstanceNamed().
   ModelInstanceIndex AddModelInstance(const std::string& name) {
-    return tree_->AddModelInstance(name);
+    return this->mutable_tree().AddModelInstance(name);
   }
 
   /// Welds frames A and B with relative pose `X_AB`. That is, the pose of
@@ -586,7 +587,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the body name occurs in multiple model
   /// instances.
   bool HasBodyNamed(const std::string& name) const {
-    return tree_->HasBodyNamed(name);
+    return tree().HasBodyNamed(name);
   }
 
   /// @returns `true` if a body named `name` was added to the %MultibodyPlant
@@ -596,7 +597,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasBodyNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->HasBodyNamed(name, model_instance);
+    return tree().HasBodyNamed(name, model_instance);
   }
 
   /// @returns `true` if a joint named `name` was added to the %MultibodyPlant.
@@ -605,7 +606,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the joint name occurs in multiple model
   /// instances.
   bool HasJointNamed(const std::string& name) const {
-    return tree_->HasJointNamed(name);
+    return tree().HasJointNamed(name);
   }
 
   /// @returns `true` if a joint named `name` was added to the %MultibodyPlant
@@ -615,7 +616,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasJointNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->HasJointNamed(name, model_instance);
+    return tree().HasJointNamed(name, model_instance);
   }
 
   /// @returns `true` if an actuator named `name` was added to the
@@ -625,7 +626,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws std::logic_error if the actuator name occurs in multiple model
   /// instances.
   bool HasJointActuatorNamed(const std::string& name) const {
-    return tree_->HasJointActuatorNamed(name);
+    return tree().HasJointActuatorNamed(name);
   }
 
   /// @returns `true` if an actuator named `name` was added to the
@@ -635,14 +636,14 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @throws if @p model_instance is not valid for this model.
   bool HasJointActuatorNamed(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->HasJointActuatorNamed(name, model_instance);
+    return tree().HasJointActuatorNamed(name, model_instance);
   }
 
   /// @returns `true` if a model instance named `name` was added to the
   /// %MultibodyPlant.
   /// @see AddModelInstance().
   bool HasModelInstanceNamed(const std::string& name) const {
-    return tree_->HasModelInstanceNamed(name);
+    return tree().HasModelInstanceNamed(name);
   }
   /// @}
 
@@ -669,7 +670,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasBodyNamed() to query if there exists a body in `this`
   /// %MultibodyPlant with a given specified name.
   const Body<T>& GetBodyByName(const std::string& name) const {
-    return tree_->GetBodyByName(name);
+    return tree().GetBodyByName(name);
   }
 
   /// Returns a constant reference to the body that is uniquely identified
@@ -679,7 +680,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   const Body<T>& GetBodyByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->GetBodyByName(name, model_instance);
+    return tree().GetBodyByName(name, model_instance);
   }
 
   /// Returns a constant reference to a frame that is identified by the
@@ -690,7 +691,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasFrameNamed() to query if there exists a frame in `this` model with
   /// a given specified name.
   const Frame<T>& GetFrameByName(const std::string& name) const {
-    return tree_->GetFrameByName(name);
+    return tree().GetFrameByName(name);
   }
 
   /// Returns a constant reference to the frame that is uniquely identified
@@ -702,7 +703,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// a given specified name.
   const Frame<T>& GetFrameByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->GetFrameByName(name, model_instance);
+    return tree().GetFrameByName(name, model_instance);
   }
 
   /// Returns a constant reference to a joint that is identified
@@ -713,7 +714,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasJointNamed() to query if there exists a joint in `this`
   /// %MultibodyPlant with a given specified name.
   const Joint<T>& GetJointByName(const std::string& name) const {
-    return tree_->GetJointByName(name);
+    return tree().GetJointByName(name);
   }
 
   /// Returns a constant reference to the joint that is uniquely identified
@@ -724,7 +725,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   const Joint<T>& GetJointByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->GetJointByName(name, model_instance);
+    return tree().GetJointByName(name, model_instance);
   }
 
   /// A templated version of GetJointByName() to return a constant reference of
@@ -740,7 +741,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// %MultibodyPlant with a given specified name.
   template <template<typename> class JointType>
   const JointType<T>& GetJointByName(const std::string& name) const {
-    return tree_->template GetJointByName<JointType>(name);
+    return tree().template GetJointByName<JointType>(name);
   }
 
   /// A templated version of GetJointByName() to return a constant reference of
@@ -756,7 +757,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   template <template<typename> class JointType>
   const JointType<T>& GetJointByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->template GetJointByName<JointType>(name, model_instance);
+    return tree().template GetJointByName<JointType>(name, model_instance);
   }
 
   /// Returns a constant reference to an actuator that is identified
@@ -768,7 +769,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// `this` %MultibodyPlant with a given specified name.
   const JointActuator<T>& GetJointActuatorByName(
       const std::string& name) const {
-    return tree_->GetJointActuatorByName(name);
+    return tree().GetJointActuatorByName(name);
   }
 
   /// Returns a constant reference to the actuator that is uniquely identified
@@ -779,7 +780,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// `this` %MultibodyPlant with a given specified name.
   const JointActuator<T>& GetJointActuatorByName(
       const std::string& name, ModelInstanceIndex model_instance) const {
-    return tree_->GetJointActuatorByName(name, model_instance);
+    return tree().GetJointActuatorByName(name, model_instance);
   }
 
   /// Returns the index to the model instance that is uniquely identified
@@ -788,7 +789,7 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   /// @see HasModelInstanceNamed() to query if there exists an instance in
   /// `this` %MultibodyPlant with a given specified name.
   ModelInstanceIndex GetModelInstanceByName(const std::string& name) const {
-    return tree_->GetModelInstanceByName(name);
+    return tree().GetModelInstanceByName(name);
   }
   /// @}
 
@@ -1111,12 +1112,12 @@ class MultibodyPlant : public systems::LeafSystem<T> {
 
   /// Returns a constant reference to the *world* body.
   const RigidBody<T>& world_body() const {
-    return tree_->world_body();
+    return tree().world_body();
   }
 
   /// Returns a constant reference to the *world* frame.
   const BodyFrame<T>& world_frame() const {
-    return tree_->world_frame();
+    return tree().world_frame();
   }
 
   /// Returns a constant reference to the underlying MultibodyTree model for
@@ -1125,21 +1126,13 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   DRAKE_DEPRECATED("Please use tree().")
   const MultibodyTree<T>& model() const {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-    return *tree_;
-  }
-
-  /// Returns a constant reference to the underlying MultibodyTree model for
-  /// `this` plant.
-  /// @throws if called pre-finalize. See Finalize().
-  const MultibodyTree<T>& tree() const {
-    DRAKE_MBP_THROW_IF_NOT_FINALIZED();
-    return *tree_;
+    return tree();
   }
 
   /// Returns `true` if this %MultibodyPlant was finalized with a call to
   /// Finalize().
   /// @see Finalize().
-  bool is_finalized() const { return tree_->topology_is_valid(); }
+  bool is_finalized() const { return tree().topology_is_valid(); }
 
   /// This method must be called after all elements in the model (joints,
   /// bodies, force elements, constraints, etc.) are added and before any
@@ -1170,11 +1163,6 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   ///          3. a different scene_graph instance is provided than the one
   ///             for which this plant is a geometry source.
   void Finalize(geometry::SceneGraph<T>* scene_graph = nullptr);
-
-  /// Returns `true` if this plant is modeled as a discrete system.
-  /// This property of the plant is specified at construction and therefore this
-  /// query can be performed either pre- or post- finalize, see Finalize().
-  bool is_discrete() const { return time_step_ > 0.0; }
 
   /// The time step (or period) used to model `this` plant as a discrete system
   /// with periodic updates. Returns 0 (zero) if the plant is modeled as a
@@ -1334,8 +1322,13 @@ class MultibodyPlant : public systems::LeafSystem<T> {
                        systems::State<T>* state) const override {
     DRAKE_MBP_THROW_IF_NOT_FINALIZED();
     DRAKE_DEMAND(state != nullptr);
-    tree_->SetDefaultState(context, state);
+    tree().SetDefaultState(context, state);
   }
+
+  using MultibodyTreeSystem<T>::is_discrete;
+  using MultibodyTreeSystem<T>::tree;
+  using MultibodyTreeSystem<T>::EvalPositionKinematics;
+  using MultibodyTreeSystem<T>::EvalVelocityKinematics;
 
  private:
   // Allow different specializations to access each other's private data for
@@ -1399,17 +1392,13 @@ class MultibodyPlant : public systems::LeafSystem<T> {
     return false;
   }
 
-  // Helper method to declare state and ports after Finalize().
-  void DeclareStateAndPorts();
+  // Helper method to declare state, cache entries, and ports after Finalize().
+  void DeclareStateCacheAndPorts();
 
   // Helper method to assemble actuation input vector from the appropriate
   // ports.
   VectorX<T> AssembleActuationInput(
       const systems::Context<T>& context) const;
-
-  // This override gives System::AllocateContext() the chance to create a more
-  // specialized context type, in this case, a MultibodyTreeContext.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
 
   // Implements the system dynamics according to this class's documentation.
   void DoCalcTimeDerivatives(
@@ -1458,14 +1447,6 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const systems::Context<T>& context,
       const Eigen::Ref<const VectorX<T>>& generalized_velocity,
       systems::VectorBase<T>* qdot) const override;
-
-  // Helper method to Eval() position kinematics cached in the context.
-  const PositionKinematicsCache<T>& EvalPositionKinematics(
-      const systems::Context<T>& context) const;
-
-  // Helper method to Eval() velocity kinematics cached in the context.
-  const VelocityKinematicsCache<T>& EvalVelocityKinematics(
-      const systems::Context<T>& context) const;
 
   // Helper method to register geometry for a given body, either visual or
   // collision. The registration includes:
@@ -1629,9 +1610,6 @@ class MultibodyPlant : public systems::LeafSystem<T> {
       const std::vector<geometry::PenetrationAsPointPair<T>>& point_pairs_set,
       MatrixX<T>* Jn, MatrixX<T>* Jt,
       std::vector<Matrix3<T>>* R_WC_set = nullptr) const;
-
-  // The entire multibody model.
-  std::unique_ptr<drake::multibody::MultibodyTree<T>> tree_;
 
   // The gravity field force element.
   optional<const UniformGravityFieldElement<T>*> gravity_field_;
@@ -1817,11 +1795,10 @@ class MultibodyPlant : public systems::LeafSystem<T> {
   std::unique_ptr<implicit_stribeck::ImplicitStribeckSolver<T>>
       implicit_stribeck_solver_;
 
-  // TODO(amcastro-tri): Remove this when caching lands and properly cache the
-  // contact results.
-  // Until caching lands, we use this variable as a "caching" entry.
-  // We make it mutable so we can change its values even from within const
-  // methods.
+  // TODO(sherm1) Add CacheIndex members here for cache entries that belong to
+  //              MBPlant, not MBTree.
+
+  // TODO(sherm1) Replace this mock cache entry with the real thing.
   mutable ContactResults<T> contact_results_;
 };
 

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -252,7 +252,7 @@ GTEST_TEST(MultibodyPlant, SimpleModelCreation) {
           "AnotherJoint", link1.body_frame(), link2.body_frame(),
           Vector3d::UnitZ())),
       std::logic_error,
-      "This MultibodyTree is finalized already. .*");
+      ".*MultibodyTree.*finalized already.*");
   // TODO(amcastro-tri): add test to verify that requesting a joint of the wrong
   // type throws an exception. We need another joint type to do so.
 }

--- a/multibody/multibody_tree/multibody_tree.cc
+++ b/multibody/multibody_tree/multibody_tree.cc
@@ -300,20 +300,6 @@ void MultibodyTree<T>::CreateModelInstances() {
 }
 
 template <typename T>
-std::unique_ptr<systems::LeafContext<T>>
-MultibodyTree<T>::CreateDefaultContext() const {
-  if (!topology_is_valid()) {
-    throw std::logic_error(
-        "Attempting to create a Context for a MultibodyTree with an invalid "
-        "topology. MultibodyTree::Finalize() must be called before attempting "
-        "to create a context.");
-  }
-  auto context = std::make_unique<MultibodyTreeContext<T>>(topology_);
-  SetDefaultContext(context.get());
-  return std::move(context);
-}
-
-template <typename T>
 void MultibodyTree<T>::SetDefaultContext(systems::Context<T> *context) const {
   for (const auto& mobilizer : owned_mobilizers_) {
     mobilizer->set_zero_configuration(context);
@@ -1106,33 +1092,6 @@ T MultibodyTree<T>::DoCalcConservativePower(
         force_element->CalcConservativePower(mbt_context, pc, vc);
   }
   return conservative_power;
-}
-
-template<typename T>
-const PositionKinematicsCache<T>& MultibodyTree<T>::EvalPositionKinematics(
-    const systems::Context<T>& context) const {
-  // TODO(amcastro-tri): Replace by cache_evaluator_->EvalPositionKinematics()
-  // when MultibodyCachingEvaluatorInterface lands.
-  const auto& mbt_context =
-      dynamic_cast<const MultibodyTreeContext<T>&>(context);
-  PositionKinematicsCache<T>& pc =
-      mbt_context.get_mutable_position_kinematics_cache();
-  CalcPositionKinematicsCache(context, &pc);
-  return pc;
-}
-
-template<typename T>
-const VelocityKinematicsCache<T>& MultibodyTree<T>::EvalVelocityKinematics(
-    const systems::Context<T>& context) const {
-  // TODO(amcastro-tri): Replace by cache_evaluator_->EvalVelocityKinematics()
-  // when MultibodyCachingEvaluatorInterface lands.
-  const PositionKinematicsCache<T>& pc = EvalPositionKinematics(context);
-  const auto& mbt_context =
-      dynamic_cast<const MultibodyTreeContext<T>&>(context);
-  VelocityKinematicsCache<T>& vc =
-      mbt_context.get_mutable_velocity_kinematics_cache();
-  CalcVelocityKinematicsCache(context, pc, &vc);
-  return vc;
 }
 
 template <typename T>

--- a/multibody/multibody_tree/multibody_tree.h
+++ b/multibody/multibody_tree/multibody_tree.h
@@ -25,6 +25,7 @@
 #include "drake/multibody/multibody_tree/model_instance.h"
 #include "drake/multibody/multibody_tree/multibody_forces.h"
 #include "drake/multibody/multibody_tree/multibody_tree_context.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/multibody_tree_topology.h"
 #include "drake/multibody/multibody_tree/position_kinematics_cache.h"
 #include "drake/multibody/multibody_tree/quaternion_floating_mobilizer.h"
@@ -1462,17 +1463,6 @@ class MultibodyTree {
   // automatically when CreateDefaultContext() is called.
   void Finalize();
 
-  /// Allocates a new context for this %MultibodyTree uniquely identifying the
-  /// state of the multibody system.
-  ///
-  /// @pre The method Finalize() must be called before attempting to create a
-  /// context in order for the %MultibodyTree topology to be valid at the moment
-  /// of allocation.
-  ///
-  /// @throws std::logic_error If users attempt to call this method on a
-  ///         %MultibodyTree with an invalid topology.
-  std::unique_ptr<systems::LeafContext<T>> CreateDefaultContext() const;
-
   /// Sets default values in the context. For mobilizers, this method sets them
   /// to their _zero_ configuration according to
   /// Mobilizer::set_zero_configuration().
@@ -2484,18 +2474,32 @@ class MultibodyTree {
   }
 
   /// Evaluates position kinematics cached in context.
-  /// @param context A MultibodyTreeContext on which to update position
-  /// kinematics.
+  /// @param context A Context whose position kinematics cache will be
+  ///                updated and returned.
   /// @return Reference to the PositionKinematicsCache of context.
   const PositionKinematicsCache<T>& EvalPositionKinematics(
-      const systems::Context<T>& context) const;
+      const systems::Context<T>& context) const {
+    DRAKE_ASSERT(tree_system_ != nullptr);
+    return tree_system_->EvalPositionKinematics(context);
+  }
 
-  /// Evaluates velocity kinematics cached in context.
-  /// @param context A MultibodyTreeContext on which to update velocity
-  /// kinematics.
+  /// Evaluates velocity kinematics cached in context. This will also
+  /// force position kinematics to be updated if it hasn't already.
+  /// @param context A Context whose velocity kinematics cache will be
+  ///                updated and returned.
   /// @return Reference to the VelocityKinematicsCache of context.
   const VelocityKinematicsCache<T>& EvalVelocityKinematics(
-      const systems::Context<T>& context) const;
+      const systems::Context<T>& context) const {
+    DRAKE_ASSERT(tree_system_ != nullptr);
+    return tree_system_->EvalVelocityKinematics(context);
+  }
+
+  /// (Internal use only) Informs the MultibodyTree how to access its resources
+  /// within a Context.
+  void set_tree_system(MultibodyTreeSystem<T>* tree_system) {
+    DRAKE_DEMAND(tree_system != nullptr && tree_system_ == nullptr);
+    tree_system_ = tree_system;
+  }
 
  private:
   // Make MultibodyTree templated on every other scalar type a friend of
@@ -2866,6 +2870,8 @@ class MultibodyTree {
   std::vector<std::vector<BodyNodeIndex>> body_node_levels_;
 
   MultibodyTreeTopology topology_;
+
+  const MultibodyTreeSystem<T>* tree_system_{};
 };
 
 /// @cond

--- a/multibody/multibody_tree/multibody_tree_system.cc
+++ b/multibody/multibody_tree/multibody_tree_system.cc
@@ -1,0 +1,152 @@
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
+
+#include <memory>
+#include <utility>
+
+#include "drake/common/autodiff.h"
+#include "drake/common/default_scalars.h"
+#include "drake/common/drake_assert.h"
+#include "drake/multibody/multibody_tree/multibody_tree.h"
+
+namespace drake {
+using systems::BasicVector;
+using systems::Context;
+using systems::LeafSystem;
+using systems::State;
+
+namespace multibody {
+
+template <typename T>
+template <typename U>
+MultibodyTreeSystem<T>::MultibodyTreeSystem(const MultibodyTreeSystem<U>& other)
+    : MultibodyTreeSystem(
+          systems::SystemTypeTag<multibody::MultibodyTreeSystem>{},
+          false,  // Null tree isn't allowed (or possible).
+          other.tree().template CloneToScalar<T>(), other.is_discrete()) {}
+
+// This is the one true constructor.
+template <typename T>
+MultibodyTreeSystem<T>::MultibodyTreeSystem(
+    systems::SystemScalarConverter converter, bool null_tree_is_ok,
+    std::unique_ptr<MultibodyTree<T>> tree, bool is_discrete)
+    : LeafSystem<T>(std::move(converter)), is_discrete_(is_discrete) {
+  if (tree == nullptr) {
+    if (!null_tree_is_ok) {
+      throw std::logic_error(
+          "MultibodyTreeSystem(): the supplied MultibodyTree was null.");
+    }
+    tree_ = std::make_unique<MultibodyTree<T>>();
+    tree_->set_tree_system(this);
+    // Don't finalize.
+    return;
+  }
+
+  // We were given an already-built tree.
+  tree_ = std::move(tree);
+  tree_->set_tree_system(this);
+  Finalize();
+}
+
+template <typename T>
+void MultibodyTreeSystem<T>::SetDefaultState(const Context<T>& context,
+                                             State<T>* state) const {
+  LeafSystem<T>::SetDefaultState(context, state);
+  tree_->SetDefaultState(context, state);
+}
+
+template <typename T>
+MultibodyTreeSystem<T>::~MultibodyTreeSystem() = default;
+
+template <typename T>
+MultibodyTree<T>& MultibodyTreeSystem<T>::mutable_tree() const {
+  DRAKE_DEMAND(tree_ != nullptr);
+  if (tree_->topology_is_valid())
+    throw std::logic_error(
+        "MultibodyTreeSystem::mutable_tree(): "
+        "the contained MultibodyTree is finalized already.");\
+  return *tree_;
+}
+
+template <typename T>
+void MultibodyTreeSystem<T>::Finalize() {
+  if (already_finalized_) {
+    throw std::logic_error(
+        "MultibodyTreeSystem::Finalize(): repeated calls not allowed.");
+  }
+  if (!tree_->topology_is_valid()) {
+    tree_->Finalize();
+  }
+
+  // Declare state.
+  if (is_discrete_) {
+    this->DeclareDiscreteState(tree_->num_states());
+  } else {
+    this->DeclareContinuousState(BasicVector<T>(tree_->num_states()),
+                                 tree_->num_positions(),
+                                 tree_->num_velocities(),
+                                 0 /* num_z */);
+  }
+
+  // Allocate position cache.
+  auto& position_kinematics_cache_entry = this->DeclareCacheEntry(
+      std::string("position kinematics"),
+      [tree = tree_.get()]() {
+        return systems::AbstractValue::Make(
+            PositionKinematicsCache<T>(tree->get_topology()));
+      },
+      [tree = tree_.get()](const systems::ContextBase& context_base,
+                           systems::AbstractValue* cache_value) {
+        auto& context = dynamic_cast<const Context<T>&>(context_base);
+        auto& position_cache =
+            cache_value->GetMutableValue<PositionKinematicsCache<T>>();
+        tree->CalcPositionKinematicsCache(context, &position_cache);
+      },
+      {this->configuration_ticket()});
+  position_kinematics_cache_index_ =
+      position_kinematics_cache_entry.cache_index();
+
+  // Allocate velocity cache.
+  auto& velocity_kinematics_cache_entry = this->DeclareCacheEntry(
+      std::string("velocity kinematics"),
+      [tree = tree_.get()]() {
+        return systems::AbstractValue::Make(
+            VelocityKinematicsCache<T>(tree->get_topology()));
+      },
+      [tree = tree_.get()](const systems::ContextBase& context_base,
+                           systems::AbstractValue* cache_value) {
+        auto& context = dynamic_cast<const Context<T>&>(context_base);
+        auto& velocity_cache =
+            cache_value->GetMutableValue<VelocityKinematicsCache<T>>();
+        tree->CalcVelocityKinematicsCache(
+            context, tree->EvalPositionKinematics(context), &velocity_cache);
+      },
+      {this->kinematics_ticket()});
+  velocity_kinematics_cache_index_ =
+      velocity_kinematics_cache_entry.cache_index();
+
+  // TODO(sherm1) Allocate articulated body inertia cache.
+
+  already_finalized_ = true;
+}
+
+template <typename T>
+std::unique_ptr<systems::LeafContext<T>>
+MultibodyTreeSystem<T>::DoMakeLeafContext() const {
+  return std::make_unique<MultibodyTreeContext<T>>(tree_->get_topology(),
+                                                   is_discrete_);
+}
+
+// Instantiate supported conversion methods.
+// TODO(sherm1) Move definitions of these methods to an -inl.h file so that
+// they don't require explicit instantiation here.
+template MultibodyTreeSystem<AutoDiffXd>::MultibodyTreeSystem(
+    const MultibodyTreeSystem<double>& other);
+
+template MultibodyTreeSystem<double>::MultibodyTreeSystem(
+    const MultibodyTreeSystem<AutoDiffXd>& other);
+
+}  // namespace multibody
+}  // namespace drake
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::MultibodyTreeSystem)

--- a/multibody/multibody_tree/multibody_tree_system.h
+++ b/multibody/multibody_tree/multibody_tree_system.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "drake/multibody/multibody_tree/position_kinematics_cache.h"
+#include "drake/multibody/multibody_tree/velocity_kinematics_cache.h"
+#include "drake/systems/framework/cache_entry.h"
+#include "drake/systems/framework/context.h"
+#include "drake/systems/framework/leaf_system.h"
+
+namespace drake {
+namespace multibody {
+template <typename T> class MultibodyTree;
+
+/** This is a bare Drake System providing just enough functionality to allow
+standalone exercise of a MultibodyTree. MultibodyTree requires a few System
+services to allocate and access the resources it needs in a Context.
+
+%MultibodyTreeSystem serves as the base class for the MultibodyPlant System,
+which provides much more functionality, including full integration with the
+Drake System Framework. %MultibodyTreeSystem alone is useful for unit testing
+of MultibodyTree, and on those rare occasions where nothing but tree
+functionality is needed.
+
+To use %MultibodyTreeSystem alone, first create and populate a MultibodyTree,
+then transfer ownership of it in the constructor for %MultibodyTreeSystem, which
+will finalize the tree if that hasn't already been done, interrogate it for the
+Context resources it needs, and allocate them. No further changes are possible
+to the MultibodyTree once it is owned by %MultibodyTreeSystem. For example,
+@code{.cpp}
+  // Create an empty model.
+  auto mb_tree = std::make_unique<MultibodyTree<double>>
+  mb_tree->AddBody<RigidBody>(...);
+  mb_tree->AddMobilizer<RevoluteMobilizer>(...);
+  // ...
+  // Done adding modeling elements. Transfer tree to system, get Context.
+  auto system = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+  auto context = system->CreateDefaultContext();
+@endcode
+
+Derived classes may use an alternate protected interface that provides for
+incremental construction of the MultibodyTree owned by a MultibodyTreeSystem.
+See documentation for the protected methods below, and look at MultibodyPlant
+for an example. */
+template <typename T>
+class MultibodyTreeSystem : public systems::LeafSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(MultibodyTreeSystem)
+
+  /** Takes ownership of the given `tree`, finalizes it if it hasn't already
+  been finalized, and then allocates the resources it needs. You cannot modify
+  the tree after that. The `tree` cannot be null.
+
+  @param[in] tree        An already-complete MultibodyTree.
+  @param[in] is_discrete Whether to allocate discrete state variables for the
+      MultibodyTree kinematics. Otherwise allocates continuous state variables.
+
+  @throws std::logic_error if `tree` is null. */
+  explicit MultibodyTreeSystem(std::unique_ptr<MultibodyTree<T>> tree,
+                               bool is_discrete = false)
+      : MultibodyTreeSystem(
+            systems::SystemTypeTag<multibody::MultibodyTreeSystem>{},
+            false,  // Null tree is not allowed here.
+            std::move(tree), is_discrete) {}
+
+  /** Scalar-converting copy constructor. See @ref system_scalar_conversion. */
+  template <typename U>
+  explicit MultibodyTreeSystem(const MultibodyTreeSystem<U>& other);
+
+  ~MultibodyTreeSystem() override;
+
+  bool is_discrete() const { return is_discrete_; }
+
+  /** Returns a const reference to the MultibodyTree owned by this class. */
+  const MultibodyTree<T>& tree() const {
+    DRAKE_ASSERT(tree_ != nullptr);
+    return *tree_;
+  }
+
+  /** Returns a reference to the up to date PositionKinematicsCache in the
+  given Context, recalculating it first if necessary. */
+  const PositionKinematicsCache<T>& EvalPositionKinematics(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(position_kinematics_cache_index_)
+        .template Eval<PositionKinematicsCache<T>>(context);
+  }
+
+  /** Returns a reference to the up to date VelocityKinematicsCache in the
+  given Context, recalculating it first if necessary. Also if necessary, the
+  PositionKinematicsCache will be recalculated as well. */
+  const VelocityKinematicsCache<T>& EvalVelocityKinematics(
+      const systems::Context<T>& context) const {
+    return this->get_cache_entry(velocity_kinematics_cache_index_)
+        .template Eval<VelocityKinematicsCache<T>>(context);
+  }
+
+  // TODO(sherm1) Add ArticulatedBodyInertiaCache.
+
+ protected:
+  /** @name        Alternate API for derived classes
+  Derived classes may use these methods to create a MultibodyTreeSystem
+  that owns an empty MultibodyTree, then incrementally build it, and finalize
+  it when done. See MultibodyPlant for a working example. */
+  //@{
+
+  /** Default constructor allocates a MultibodyTree, with the intent that it
+  will be filled in later, using mutable_tree() for access. You must call
+  Finalize() when done before performing any computations. */
+  explicit MultibodyTreeSystem(bool is_discrete = false)
+      : MultibodyTreeSystem(
+            systems::SystemTypeTag<multibody::MultibodyTreeSystem>{},
+            true,  // Null tree is OK.
+            nullptr, is_discrete) {}
+
+  /**  Constructor that specifies scalar-type conversion support.
+  If `tree` is given, we'll finalize it. Otherwise, we'll allocate an
+  empty one and leave it not finalized.
+  @param[in] converter Scalar-type conversion support helper.
+  @param[in] tree Already-complete MultibodyTree if supplied. If nullptr, an
+      empty MultibodyTree is allocated internally.
+  @param[in] is_discrete Whether to use discrete state variables for tree
+      kinematics. Otherwise uses continuous state variables q and v. */
+  MultibodyTreeSystem(systems::SystemScalarConverter converter,
+                      std::unique_ptr<MultibodyTree<T>> tree,
+                      bool is_discrete = false)
+      : MultibodyTreeSystem(converter, true,  // Null tree is OK here.
+                            std::move(tree), is_discrete) {}
+
+  /** Returns a mutable reference to the MultibodyTree owned by this class.
+  The tree must _not_ have been finalized.
+  @throws std::logic_error if the tree has already been finalized. */
+  MultibodyTree<T>& mutable_tree() const;
+
+  /** Finalize the tree if that hasn't already been done, complete System
+  construction, and declare any needed Context resources for the tree. You must
+  call this before performing any computation. */
+  void Finalize();
+  //@}
+
+  // TODO(sherm1) Shouldn't require overriding the default method; need
+  // a DoLeafSetDefaultState().
+  void SetDefaultState(const systems::Context<T>& context,
+                       systems::State<T>* state) const override;
+
+ private:
+  // Allow different specializations to access each other's private data for
+  // scalar conversion.
+  template <typename U>
+  friend class MultibodyTreeSystem;
+
+  // This is the one real constructor. From the public API, a null tree is
+  // illegal and gets an error message. From the protected API, a null tree
+  // means we allocate an empty one and leave it un-finalized. In either case,
+  // we consider a non-null tree to be complete and finalize it if it hasn't
+  // already been finalized.
+  MultibodyTreeSystem(systems::SystemScalarConverter converter,
+                      bool null_tree_is_ok,
+                      std::unique_ptr<MultibodyTree<T>> tree,
+                      bool is_discrete);
+
+  // TODO(sherm1) Get rid of this and use just a plain Context<T>.
+  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const final;
+
+  // Use continuous state variables by default.
+  bool is_discrete_{false};
+
+  std::unique_ptr<drake::multibody::MultibodyTree<T>> tree_;
+  systems::CacheIndex position_kinematics_cache_index_;
+  systems::CacheIndex velocity_kinematics_cache_index_;
+
+  // Used to enforce "finalize once" restriction for protected-API users.
+  bool already_finalized_{false};
+};
+
+}  // namespace multibody
+}  // namespace drake
+
+// Disable support for symbolic evaluation.
+// TODO(amcastro-tri): Allow symbolic evaluation once MultibodyTree supports it.
+namespace drake {
+namespace systems {
+namespace scalar_conversion {
+template <>
+struct Traits<drake::multibody::MultibodyTreeSystem> :
+    public NonSymbolicTraits {};
+}  // namespace scalar_conversion
+}  // namespace systems
+}  // namespace drake

--- a/multibody/multibody_tree/test/articulated_body_algorithm_test.cc
+++ b/multibody/multibody_tree/test/articulated_body_algorithm_test.cc
@@ -6,6 +6,7 @@
 #include "drake/multibody/multibody_tree/frame.h"
 #include "drake/multibody/multibody_tree/mobilizer_impl.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/space_xyz_mobilizer.h"
 #include "drake/multibody/multibody_tree/spatial_inertia.h"
 #include "drake/multibody/multibody_tree/unit_inertia.h"
@@ -191,33 +192,32 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, FeatherstoneExample) {
   const double mass_cylinder = 0.8;
   const SpatialInertia<double> M_Ccm(mass_cylinder, Vector3d::Zero(), G_Ccm);
 
-  // Create model.
-  MultibodyTree<double> model;
+  // Create an empty model.
+  auto tree = std::make_unique<MultibodyTree<double>>();
 
   // Add box body and SpaceXYZ mobilizer.
-  const RigidBody<double>& box_link = model.AddBody<RigidBody>(M_Bcm);
-  const Frame<double>& world_frame = model.world_frame();
+  const RigidBody<double>& box_link = tree->AddBody<RigidBody>(M_Bcm);
+  const Frame<double>& world_frame = tree->world_frame();
   const Frame<double>& box_frame = box_link.body_frame();
-  model.AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
+  tree->AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
 
   // Add cylinder body and Featherstone mobilizer.
-  const RigidBody<double>& cylinder_link = model.AddBody<RigidBody>(M_Ccm);
+  const RigidBody<double>& cylinder_link =
+      tree->AddBody<RigidBody>(M_Ccm);
   const Frame<double>& cylinder_frame = cylinder_link.body_frame();
-  model.AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);
+  tree->AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);
 
-  // Finalize model.
-  model.Finalize();
-
-  // Create context.
-  std::unique_ptr<Context<double>> context = model.CreateDefaultContext();
+  // Transfer tree to system and get a Context.
+  MultibodyTreeSystem<double> system(std::move(tree));
+  auto context = system.CreateDefaultContext();
 
   // Update cache.
-  PositionKinematicsCache<double> pc(model.get_topology());
-  model.CalcPositionKinematicsCache(*context, &pc);
+  PositionKinematicsCache<double> pc(system.tree().get_topology());
+  system.tree().CalcPositionKinematicsCache(*context, &pc);
 
   // Compute articulated body cache.
-  ArticulatedBodyInertiaCache<double> abc(model.get_topology());
-  model.CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
+  ArticulatedBodyInertiaCache<double> abc(system.tree().get_topology());
+  system.tree().CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
 
   // Get expected projected articulated body inertia of cylinder.
   Matrix6<double> M_cylinder_mat = M_Ccm.CopyToFullMatrix6();
@@ -268,27 +268,25 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   const double mass_cylinder = 0.6;
   const SpatialInertia<double> M_Ccm(mass_cylinder, Vector3d::Zero(), G_Ccm);
 
-  // Create model.
-  MultibodyTree<double> model;
+  // Create an empty model.
+  auto tree = std::make_unique<MultibodyTree<double>>();
 
   // Add box body and SpaceXYZ mobilizer.
-  const RigidBody<double>& box_link = model.AddBody<RigidBody>(M_Bcm);
-  const Frame<double>& world_frame = model.world_frame();
+  const RigidBody<double>& box_link = tree->AddBody<RigidBody>(M_Bcm);
+  const Frame<double>& world_frame = tree->world_frame();
   const Frame<double>& box_frame = box_link.body_frame();
   const SpaceXYZMobilizer<double>& WB_mobilizer =
-      model.AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
+      tree->AddMobilizer<SpaceXYZMobilizer>(world_frame, box_frame);
 
   // Add cylinder body and Featherstone mobilizer.
-  const RigidBody<double>& cylinder_link = model.AddBody<RigidBody>(M_Ccm);
+  const RigidBody<double>& cylinder_link = tree->AddBody<RigidBody>(M_Ccm);
   const Frame<double>& cylinder_frame = cylinder_link.body_frame();
   const FeatherstoneMobilizer<double>& BC_mobilizer =
-    model.AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);
+      tree->AddMobilizer<FeatherstoneMobilizer>(box_frame, cylinder_frame);
 
-  // Finalize model.
-  model.Finalize();
-
-  // Create context.
-  std::unique_ptr<Context<double>> context = model.CreateDefaultContext();
+  // Transfer tree to system and get a Context.
+  MultibodyTreeSystem<double> system(std::move(tree));
+  auto context = system.CreateDefaultContext();
 
   // State of mobilizer connecting the world and box.
   Vector3d q_WB;
@@ -301,12 +299,12 @@ GTEST_TEST(ArticulatedBodyInertiaAlgorithm, ModifiedFeatherstoneExample) {
   BC_mobilizer.set_angles(context.get(), q_BC);
 
   // Update cache.
-  PositionKinematicsCache<double> pc(model.get_topology());
-  model.CalcPositionKinematicsCache(*context, &pc);
+  PositionKinematicsCache<double> pc(system.tree().get_topology());
+  system.tree().CalcPositionKinematicsCache(*context, &pc);
 
   // Compute articulated body cache.
-  ArticulatedBodyInertiaCache<double> abc(model.get_topology());
-  model.CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
+  ArticulatedBodyInertiaCache<double> abc(system.tree().get_topology());
+  system.tree().CalcArticulatedBodyInertiaCache(*context, pc,  &abc);
 
   // Rotate the spatial inertia about the y-axis to match the rotation of
   // q_WB.

--- a/multibody/multibody_tree/test/frames_test.cc
+++ b/multibody/multibody_tree/test/frames_test.cc
@@ -11,6 +11,7 @@
 
 #include "drake/common/eigen_types.h"
 #include "drake/multibody/multibody_tree/fixed_offset_frame.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/revolute_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/systems/framework/context.h"
@@ -40,16 +41,17 @@ class FrameTests : public ::testing::Test {
     // properties do not play any role.)
     SpatialInertia<double> M_Bo_B;
 
-    model_ = std::make_unique<MultibodyTree<double>>();
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
 
-    bodyB_ = &model_->AddBody<RigidBody>(M_Bo_B);
+    bodyB_ = &model->AddBody<RigidBody>(M_Bo_B);
     frameB_ = &bodyB_->body_frame();
 
     // Mobilizer connecting bodyB to the world.
     // The mobilizer is only needed because it is a requirement of MultibodyTree
     // that all bodies in the model must have an inboard mobilizer.
-    model_->AddMobilizer<RevoluteMobilizer>(
-        model_->world_frame(), bodyB_->body_frame(),
+    model->AddMobilizer<RevoluteMobilizer>(
+        model->world_frame(), bodyB_->body_frame(),
         Vector3d::UnitZ() /*revolute axis*/);
 
     // Some arbitrary pose of frame P in the body frame B.
@@ -58,7 +60,7 @@ class FrameTests : public ::testing::Test {
             Translation3d(0.0, -1.0, 0.0);
     // Frame P is rigidly attached to B with pose X_BP.
     frameP_ =
-        &model_->AddFrame<FixedOffsetFrame>(bodyB_->body_frame(), X_BP_);
+        &model->AddFrame<FixedOffsetFrame>(bodyB_->body_frame(), X_BP_);
 
     // Some arbitrary pose of frame Q in frame P.
     X_PQ_ = AngleAxisd(-M_PI / 3.0, Vector3d::UnitZ()) *
@@ -66,14 +68,16 @@ class FrameTests : public ::testing::Test {
             Translation3d(0.5, 1.0, -2.0);
     // Frame Q is rigidly attached to P with pose X_PQ.
     frameQ_ =
-        &model_->AddFrame<FixedOffsetFrame>(*frameP_, X_PQ_);
+        &model->AddFrame<FixedOffsetFrame>(*frameP_, X_PQ_);
 
     // Frame R is arbitrary, but named.
-    frameR_ = &model_->AddFrame<FixedOffsetFrame>(
+    frameR_ = &model->AddFrame<FixedOffsetFrame>(
         "R", *frameP_, Isometry3d::Identity());
 
-    model_->Finalize();
-    context_ = model_->CreateDefaultContext();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    auto context = system_->CreateDefaultContext();
 
     // An arbitrary pose of an arbitrary frame G in an arbitrary frame F.
     X_FG_ = AngleAxisd(M_PI / 6.0, Vector3d::UnitY()) *
@@ -88,8 +92,10 @@ class FrameTests : public ::testing::Test {
     X_QG_ = X_FG_;
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  std::unique_ptr<MultibodyTree<double>> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
   // Bodies:
   const RigidBody<double>* bodyB_;

--- a/multibody/multibody_tree/test/free_rotating_body_plant.h
+++ b/multibody/multibody_tree/test/free_rotating_body_plant.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/space_xyz_mobilizer.h"
 #include "drake/systems/framework/basic_vector.h"
@@ -27,7 +28,7 @@ namespace test {
 /// They are already available to link against in the containing library.
 /// No other values for T are currently supported.
 template<typename T>
-class FreeRotatingBodyPlant final : public systems::LeafSystem<T> {
+class FreeRotatingBodyPlant final : public MultibodyTreeSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(FreeRotatingBodyPlant)
 
@@ -72,11 +73,9 @@ class FreeRotatingBodyPlant final : public systems::LeafSystem<T> {
   /// SetDefaultState(). Currently a non-zero value.
   Vector3<double> get_default_initial_angular_velocity() const;
 
- private:
-  // Override of context construction so that we can delegate it to
-  // MultibodyTree.
-  std::unique_ptr<systems::LeafContext<T>> DoMakeLeafContext() const override;
+  using MultibodyTreeSystem<T>::tree;
 
+ private:
   void DoCalcTimeDerivatives(
       const systems::Context<T> &context,
       systems::ContinuousState<T> *derivatives) const override;
@@ -96,7 +95,7 @@ class FreeRotatingBodyPlant final : public systems::LeafSystem<T> {
 
   double I_{0};
   double J_{0};
-  MultibodyTree<T> model_;
+
   const RigidBody<T>* body_{nullptr};
   const SpaceXYZMobilizer<T>* mobilizer_{nullptr};
 };

--- a/multibody/multibody_tree/test/linear_spring_damper_test.cc
+++ b/multibody/multibody_tree/test/linear_spring_damper_test.cc
@@ -8,6 +8,7 @@
 #include "drake/multibody/multibody_tree/joints/prismatic_joint.h"
 #include "drake/multibody/multibody_tree/joints/weld_joint.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/position_kinematics_cache.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/spatial_inertia.h"
@@ -27,70 +28,70 @@ constexpr double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 class SpringDamperTester : public ::testing::Test {
  public:
   void SetUp() override {
-    bodyA_ = &model_.AddRigidBody(
-        "BodyA", SpatialInertia<double>());
-    bodyB_ = &model_.AddRigidBody(
-        "BodyB", SpatialInertia<double>());
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
 
-    model_.AddJoint<WeldJoint>(
-        "WeldBodyAToWorld", model_.world_body(), {}, *bodyA_, {},
+    bodyA_ = &model->AddRigidBody("BodyA", SpatialInertia<double>());
+    bodyB_ = &model->AddRigidBody("BodyB", SpatialInertia<double>());
+
+    model->AddJoint<WeldJoint>(
+        "WeldBodyAToWorld", model->world_body(), {}, *bodyA_, {},
         Isometry3<double>::Identity());
 
     // Allow body B to slide along the x axis.
-    slider_ = &model_.AddJoint<PrismaticJoint>(
-        "Slider", model_.world_body(), {}, *bodyB_, {},
+    slider_ = &model->AddJoint<PrismaticJoint>(
+        "Slider", model->world_body(), {}, *bodyB_, {},
         Vector3<double>::UnitX());
 
-    spring_damper_ = &model_.AddForceElement<LinearSpringDamper>(
+    spring_damper_ = &model->AddForceElement<LinearSpringDamper>(
         *bodyA_, p_AP_, *bodyB_, p_BQ_, free_length_, stiffness_, damping_);
 
     // Verify the the constructor for the spring-damper throws if either the
     // rest length, stiffness or damping are negative numbers.
     DRAKE_EXPECT_THROWS_MESSAGE(
-        model_.AddForceElement<LinearSpringDamper>(
+        model->AddForceElement<LinearSpringDamper>(
             *bodyA_, p_AP_, *bodyB_, p_BQ_,
             -1.0 /* negative rest length */, stiffness_, damping_),
         std::exception,
         ".*condition 'free_length > 0' failed.*");
 
     DRAKE_EXPECT_THROWS_MESSAGE(
-        model_.AddForceElement<LinearSpringDamper>(
+        model->AddForceElement<LinearSpringDamper>(
             *bodyA_, p_AP_, *bodyB_, p_BQ_,
             free_length_, -1.0  /* negative stiffness */, damping_),
         std::exception,
         ".*condition 'stiffness >= 0' failed.*");
 
     DRAKE_EXPECT_THROWS_MESSAGE(
-        model_.AddForceElement<LinearSpringDamper>(
+        model->AddForceElement<LinearSpringDamper>(
             *bodyA_, p_AP_, *bodyB_, p_BQ_,
             free_length_, stiffness_, -1.0 /* negative damping */),
         std::exception,
         ".*condition 'damping >= 0' failed.*");
 
-    model_.Finalize();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    context_ = system_->CreateDefaultContext();
 
-    context_ = model_.CreateDefaultContext();
     mbt_context_ = dynamic_cast<MultibodyTreeContext<double>*>(context_.get());
     ASSERT_TRUE(mbt_context_ != nullptr);
-    pc_ = std::make_unique<PositionKinematicsCache<double>>(
-        model_.get_topology());
-    vc_ = std::make_unique<VelocityKinematicsCache<double>>(
-        model_.get_topology());
-    forces_ = std::make_unique<MultibodyForces<double>>(model_);
+
+    context_->EnableCaching();
+
+    forces_ = std::make_unique<MultibodyForces<double>>(tree());
   }
 
   void SetSliderState(double position, double position_rate) {
     slider_->set_translation(context_.get(), position);
     slider_->set_translation_rate(context_.get(), position_rate);
-    // Update the kinematics cache.
-    model_.CalcPositionKinematicsCache(*context_, pc_.get());
-    model_.CalcVelocityKinematicsCache(*context_, *pc_, vc_.get());
   }
 
   void CalcSpringDamperForces() const {
     forces_->SetZero();
     spring_damper_->CalcAndAddForceContribution(
-        *mbt_context_, *pc_, *vc_, forces_.get());
+        *mbt_context_, tree().EvalPositionKinematics(*context_),
+        tree().EvalVelocityKinematics(*context_), forces_.get());
   }
 
   const SpatialForce<double>& GetSpatialForceOnBodyA() const {
@@ -101,12 +102,13 @@ class SpringDamperTester : public ::testing::Test {
     return forces_->body_forces().at(bodyB_->node_index());
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
   MultibodyTreeContext<double>* mbt_context_{nullptr};
-  std::unique_ptr<PositionKinematicsCache<double>> pc_;
-  std::unique_ptr<VelocityKinematicsCache<double>> vc_;
+
   const RigidBody<double>* bodyA_{nullptr};
   const RigidBody<double>* bodyB_{nullptr};
   const PrismaticJoint<double>* slider_{nullptr};
@@ -143,8 +145,8 @@ TEST_F(SpringDamperTester, RestLength) {
   EXPECT_EQ(F_B_W.get_coeffs(), SpatialForce<double>::Zero().get_coeffs());
 
   // Verify the potential energy is zero.
-  const double potential_energy =
-      spring_damper_->CalcPotentialEnergy(*mbt_context_, *pc_);
+  const double potential_energy = spring_damper_->CalcPotentialEnergy(
+      *mbt_context_, tree().EvalPositionKinematics(*context_));
   EXPECT_NEAR(potential_energy, 0.0, kTolerance);
 }
 
@@ -180,14 +182,15 @@ TEST_F(SpringDamperTester, LengthLargerThanRestLength) {
   // Verify the value of the potential energy.
   const double potential_energy_expected =
       0.5 * stiffness_ * (length - free_length_) * (length - free_length_);
-  const double potential_energy =
-      spring_damper_->CalcPotentialEnergy(*mbt_context_, *pc_);
+  const double potential_energy = spring_damper_->CalcPotentialEnergy(
+      *mbt_context_, tree().EvalPositionKinematics(*context_));
   EXPECT_NEAR(potential_energy, potential_energy_expected, kTolerance);
 
   // Since the spring configuration is static, that is velocities are zero, we
   // expect zero conservative and non-conservative power.
-  const double conservative_power =
-      spring_damper_->CalcConservativePower(*mbt_context_, *pc_, *vc_);
+  const double conservative_power = spring_damper_->CalcConservativePower(
+      *mbt_context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
   EXPECT_NEAR(conservative_power, 0.0, kTolerance);
 }
 
@@ -257,20 +260,23 @@ TEST_F(SpringDamperTester, Power) {
   const double length_dot = 1.0;
   SetSliderState(length, length_dot);
 
-  const double conservative_power =
-      spring_damper_->CalcConservativePower(*mbt_context_, *pc_, *vc_);
+  const double conservative_power = spring_damper_->CalcConservativePower(
+      *mbt_context_, tree().EvalPositionKinematics(*context_),
+      tree().EvalVelocityKinematics(*context_));
   const double conservative_power_expected =
       -stiffness_ * (length - free_length_) * length_dot;
   EXPECT_NEAR(conservative_power, conservative_power_expected, kTolerance);
 
   const double non_conservative_power =
-      spring_damper_->CalcNonConservativePower(*mbt_context_, *pc_, *vc_);
+      spring_damper_->CalcNonConservativePower(
+          *mbt_context_, tree().EvalPositionKinematics(*context_),
+          tree().EvalVelocityKinematics(*context_));
   const double non_conservative_power_expected =
       -damping_ * length_dot * length_dot;
   // It should always be non-positive.
   EXPECT_LT(non_conservative_power, 0.0);
-  EXPECT_NEAR(non_conservative_power,
-              non_conservative_power_expected, kTolerance);
+  EXPECT_NEAR(non_conservative_power, non_conservative_power_expected,
+              kTolerance);
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/multibody_tree_test.cc
+++ b/multibody/multibody_tree/test/multibody_tree_test.cc
@@ -12,9 +12,11 @@
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/MG/MG_kuka_iiwa_robot.h"
 #include "drake/multibody/benchmarks/kuka_iiwa_robot/make_kuka_iiwa_model.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/weld_mobilizer.h"
 #include "drake/systems/framework/context.h"
 #include "drake/systems/framework/continuous_state.h"
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace multibody {
@@ -29,6 +31,7 @@ using Eigen::MatrixXd;
 using Eigen::Translation3d;
 using Eigen::Vector3d;
 using multibody_tree::test_utilities::SpatialKinematicsPVA;
+using systems::BasicVector;
 using systems::Context;
 using systems::ContinuousState;
 
@@ -233,35 +236,75 @@ GTEST_TEST(MultibodyTree, VerifyModelBasics) {
   VerifyModelBasics(*model);
 }
 
+// MBPlant provides most of the testing for MBTreeSystem. Here we just want
+// to make sure that a badly-behaved derived class is notified.
+class BadDerivedMBSystem : public MultibodyTreeSystem<double> {
+ public:
+  explicit BadDerivedMBSystem(bool double_finalize)
+      : MultibodyTreeSystem<double>() {
+    mutable_tree().AddBody<RigidBody>(SpatialInertia<double>());
+    Finalize();
+    if (double_finalize) {
+      Finalize();
+    }
+  }
+
+  // Make this accessible so we can intentionally call it after finalizing
+  // and check the error message.
+  using MultibodyTreeSystem<double>::mutable_tree;
+};
+
+GTEST_TEST(MultibodyTreeSystem, CatchBadBehavior) {
+  // Create the internal tree and finalize the MBSystem correctly.
+  BadDerivedMBSystem finalized(false);
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      finalized.mutable_tree(), std::logic_error,
+      ".*mutable_tree().*MultibodyTree.*finalized.*already.*");
+
+  // Make the MBSystem behave badly.
+  DRAKE_EXPECT_THROWS_MESSAGE(BadDerivedMBSystem(true), std::logic_error,
+                              ".*Finalize().*repeated.*not allowed.*");
+
+  auto model = std::make_unique<MultibodyTree<double>>();
+  EXPECT_NO_THROW(MultibodyTreeSystem<double>(std::move(model)));
+  EXPECT_EQ(model, nullptr);  // Should have been moved from.
+
+  DRAKE_EXPECT_THROWS_MESSAGE(
+      MultibodyTreeSystem<double>(std::move(model)), std::logic_error,
+      ".*MultibodyTreeSystem().*MultibodyTree was null.*");
+}
+
 // Fixture to perform a number of computational tests on a KUKA Iiwa model.
 class KukaIiwaModelTests : public ::testing::Test {
  public:
   /// Creates MultibodyTree for a KUKA Iiwa robot arm.
   void SetUp() override {
-    model_ = MakeKukaIiwaModel<double>(true /* Finalize model */, gravity_);
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(
+        MakeKukaIiwaModel<double>(true /* Finalize model */, gravity_));
 
     // Keep pointers to the modeling elements.
-    end_effector_link_ = &model_->GetBodyByName("iiwa_link_7");
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_1"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_2"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_3"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_4"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_5"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_6"));
-    joints_.push_back(&model_->GetJointByName<RevoluteJoint>("iiwa_joint_7"));
+    end_effector_link_ = &tree().GetBodyByName("iiwa_link_7");
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_1"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_2"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_3"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_4"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_5"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_6"));
+    joints_.push_back(&tree().GetJointByName<RevoluteJoint>("iiwa_joint_7"));
 
-    context_ = model_->CreateDefaultContext();
+    context_ = system_->CreateDefaultContext();
 
     // Scalar-convert the model and create a default context for it.
-    model_autodiff_ = model_->ToAutoDiffXd();
-    context_autodiff_ = model_autodiff_->CreateDefaultContext();
+    system_autodiff_ = std::make_unique<MultibodyTreeSystem<AutoDiffXd>>(
+        tree().ToAutoDiffXd());
+    context_autodiff_ = system_autodiff_->CreateDefaultContext();
   }
 
   // Gets an arm state to an arbitrary configuration in which joint angles and
   // rates are non-zero.
   void GetArbitraryNonZeroConfiguration(
       VectorX<double>* q, VectorX<double>* v) {
-    const int kNumPositions = model_->num_positions();
+    const int kNumPositions = tree().num_positions();
     q->resize(kNumPositions);
     v->resize(kNumPositions);  // q and v have the same dimension for kuka.
 
@@ -340,11 +383,17 @@ class KukaIiwaModelTests : public ::testing::Test {
         context_on_T, linkG_on_T.body_frame(), p_EPi, p_WPi, Jv_WPi);
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
+  const MultibodyTree<AutoDiffXd>& tree_autodiff() const {
+    return system_autodiff_->tree();
+  }
+
  protected:
   // Acceleration of gravity:
   const double gravity_{9.81};
   // The model plant:
-  std::unique_ptr<MultibodyTree<double>> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
   // Workspace including context and derivatives vector:
   std::unique_ptr<Context<double>> context_;
   // Non-owning pointer to the end effector link:
@@ -353,7 +402,7 @@ class KukaIiwaModelTests : public ::testing::Test {
   std::vector<const RevoluteJoint<double>*> joints_;
 
   // AutoDiffXd model to compute automatic derivatives:
-  std::unique_ptr<MultibodyTree<AutoDiffXd>> model_autodiff_;
+  std::unique_ptr<MultibodyTreeSystem<AutoDiffXd>> system_autodiff_;
   std::unique_ptr<Context<AutoDiffXd>> context_autodiff_;
 
   // And independent benchmarking set of solutions.
@@ -363,7 +412,7 @@ class KukaIiwaModelTests : public ::testing::Test {
 // Verifies the integrity of a scalar converted MultibodyTree from <double> to
 // <AutoDiffXd>.
 TEST_F(KukaIiwaModelTests, VerifyScalarConversionToAutoDiffXd) {
-  VerifyModelBasics(*model_autodiff_);
+  VerifyModelBasics(tree_autodiff());
 }
 
 // This test is used to verify the correctness of the method
@@ -380,13 +429,13 @@ TEST_F(KukaIiwaModelTests, VerifyScalarConversionToAutoDiffXd) {
 // - MultibodyTree::CalcAllBodySpatialVelocitiesInWorld()
 TEST_F(KukaIiwaModelTests, GeometricJacobian) {
   // The number of generalized positions in the Kuka iiwa robot arm model.
-  const int kNumPositions = model_->num_positions();
-  const int kNumStates = model_->num_states();
+  const int kNumPositions = tree().num_positions();
+  const int kNumStates = tree().num_states();
 
   ASSERT_EQ(kNumPositions, 7);
 
-  ASSERT_EQ(model_autodiff_->num_positions(), kNumPositions);
-  ASSERT_EQ(model_autodiff_->num_states(), kNumStates);
+  ASSERT_EQ(tree_autodiff().num_positions(), kNumPositions);
+  ASSERT_EQ(tree_autodiff().num_states(), kNumStates);
 
   ASSERT_EQ(context_->get_continuous_state().size(), kNumStates);
   ASSERT_EQ(context_autodiff_->get_continuous_state().size(), kNumStates);
@@ -408,7 +457,7 @@ TEST_F(KukaIiwaModelTests, GeometricJacobian) {
   }
 
   // Compute the value of the end effector's velocity using <double>.
-  Vector3<double> v_WE = CalcEndEffectorVelocity(*model_, *context_);
+  Vector3<double> v_WE = CalcEndEffectorVelocity(tree(), *context_);
 
   context_autodiff_->SetTimeStateAndParametersFrom(*context_);
 
@@ -420,7 +469,7 @@ TEST_F(KukaIiwaModelTests, GeometricJacobian) {
       get_mutable_generalized_velocity().SetFromVector(v_autodiff);
 
   const Vector3<AutoDiffXd> v_WE_autodiff =
-      CalcEndEffectorVelocity(*model_autodiff_, *context_autodiff_);
+      CalcEndEffectorVelocity(tree_autodiff(), *context_autodiff_);
 
   const Vector3<double> v_WE_value = math::autoDiffToValueMatrix(v_WE_autodiff);
   const MatrixX<double> v_WE_derivs =
@@ -436,10 +485,10 @@ TEST_F(KukaIiwaModelTests, GeometricJacobian) {
   EXPECT_EQ(v_WE_derivs.cols(), kNumPositions);
 
   Vector3<double> p_WE;
-  Matrix3X<double> Jv_WE(3, model_->num_velocities());
+  Matrix3X<double> Jv_WE(3, tree().num_velocities());
   // The end effector (G) Jacobian is computed by asking the Jacobian for a
   // point P with position p_GP = 0 in the G frame.
-  model_->CalcPointsGeometricJacobianExpressedInWorld(
+  tree().CalcPointsGeometricJacobianExpressedInWorld(
       *context_, end_effector_link_->body_frame(),
       Vector3<double>::Zero(), &p_WE, &Jv_WE);
 
@@ -456,7 +505,7 @@ TEST_F(KukaIiwaModelTests, GeometricJacobian) {
   // Verify that MultibodyTree::CalcPointsPositions() computes the same value
   // of p_WE. Even both code paths resolve to CalcPointsPositions(), here we
   // call this method explicitly to provide unit testing for this API.
-  Vector3<double> p2_WE = CalcEndEffectorPosition(*model_, *context_);
+  Vector3<double> p2_WE = CalcEndEffectorPosition(tree(), *context_);
   EXPECT_TRUE(CompareMatrices(p2_WE, p_WE,
                               kTolerance, MatrixCompareType::relative));
 
@@ -472,7 +521,7 @@ TEST_F(KukaIiwaModelTests, GeometricJacobian) {
       get_mutable_generalized_velocity().SetFromVector(v_autodiff);
 
   Vector3<AutoDiffXd> p_WE_autodiff = CalcEndEffectorPosition(
-      *model_autodiff_, *context_autodiff_);
+      tree_autodiff(), *context_autodiff_);
   Vector3<double> p_WE_derivs(
       p_WE_autodiff[0].derivatives()[0],
       p_WE_autodiff[1].derivatives()[0],
@@ -517,7 +566,7 @@ TEST_F(KukaIiwaModelTests, AnalyticJacobian) {
   // Since for the Kuka iiwa arm v = q̇, the analytic Jacobian Jq_WPi equals the
   // geometric Jacobian Jv_Wpi.
   CalcPointsOnEndEffectorGeometricJacobian(
-      *model_, *context_, p_EPi, &p_WPi, &Jq_WPi);
+      tree(), *context_, p_EPi, &p_WPi, &Jq_WPi);
 
   // Alternatively, compute the analytic Jacobian by taking the gradient of
   // the positions p_WPi(q) with respect to the generalized positions. We do
@@ -535,7 +584,7 @@ TEST_F(KukaIiwaModelTests, AnalyticJacobian) {
   MatrixX<AutoDiffXd> Jq_WPi_autodiff(3 * kNumPoints, kNumPositions);
 
   CalcPointsOnEndEffectorGeometricJacobian(
-      *model_autodiff_, *context_autodiff_,
+      tree_autodiff(), *context_autodiff_,
       p_EPi_autodiff, &p_WPi_autodiff, &Jq_WPi_autodiff);
 
   // Extract values and derivatives:
@@ -579,11 +628,11 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
 
   // Spatial velocity of the end effector in the world frame.
   const SpatialVelocity<double>& V_WE =
-      model_->EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
+      tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector in the world frame.
   const Isometry3<double>& X_WE =
-      model_->EvalBodyPoseInWorld(*context_, *end_effector_link_);
+      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_);
 
   // Independent benchmark solution.
   const SpatialKinematicsPVA<double> MG_kinematics =
@@ -601,13 +650,13 @@ TEST_F(KukaIiwaModelTests, EvalPoseAndSpatialVelocity) {
 
 TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   // The number of generalized positions in the Kuka iiwa robot arm model.
-  const int kNumPositions = model_->num_positions();
-  const int kNumStates = model_->num_states();
+  const int kNumPositions = tree().num_positions();
+  const int kNumStates = tree().num_states();
 
   ASSERT_EQ(kNumPositions, 7);
 
-  ASSERT_EQ(model_autodiff_->num_positions(), kNumPositions);
-  ASSERT_EQ(model_autodiff_->num_states(), kNumStates);
+  ASSERT_EQ(tree_autodiff().num_positions(), kNumPositions);
+  ASSERT_EQ(tree_autodiff().num_states(), kNumStates);
 
   ASSERT_EQ(context_->get_continuous_state().size(), kNumStates);
   ASSERT_EQ(context_autodiff_->get_continuous_state().size(), kNumStates);
@@ -630,11 +679,11 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
 
   // Spatial velocity of the end effector.
   const SpatialVelocity<double>& V_WE =
-      model_->EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
+      tree().EvalBodySpatialVelocityInWorld(*context_, *end_effector_link_);
 
   // Pose of the end effector.
   const Isometry3d& X_WE =
-      model_->EvalBodyPoseInWorld(*context_, *end_effector_link_);
+      tree().EvalBodyPoseInWorld(*context_, *end_effector_link_);
 
   // Position of a frame F measured and expressed in frame E.
   const Vector3d p_EoFo_E = Vector3d(0.2, -0.1, 0.5);
@@ -647,10 +696,10 @@ TEST_F(KukaIiwaModelTests, CalcFrameGeometricJacobianExpressedInWorld) {
   // "shifting" from E by an offset p_EoFo.
   const SpatialVelocity<double> V_WEf = V_WE.Shift(p_EoFo_W);
 
-  MatrixX<double> Jv_WF(6, model_->num_velocities());
+  MatrixX<double> Jv_WF(6, tree().num_velocities());
   // Compute the Jacobian Jv_WF for that relate the generalized velocities with
   // the spatial velocity of frame F.
-  model_->CalcFrameGeometricJacobianExpressedInWorld(
+  tree().CalcFrameGeometricJacobianExpressedInWorld(
       *context_,
       end_effector_link_->body_frame(), p_EoFo_E, &Jv_WF);
 
@@ -671,7 +720,7 @@ TEST_F(KukaIiwaModelTests, PointsGeometricJacobianForTheWorldFrame) {
   // a zero Jacobian for the world body.
   const Matrix3X<double> p_WP_set = Matrix3X<double>::Identity(3, 10);
 
-  const int nv = model_->num_velocities();
+  const int nv = tree().num_velocities();
   const int npoints = p_WP_set.cols();
 
   // We set the output arrays to garbage so that upon returning from
@@ -683,8 +732,8 @@ TEST_F(KukaIiwaModelTests, PointsGeometricJacobianForTheWorldFrame) {
   // The state stored in the context should not affect the result of this test.
   // Therefore we do not set it.
 
-  model_->CalcPointsGeometricJacobianExpressedInWorld(
-      *context_, model_->world_body().body_frame(), p_WP_set,
+  tree().CalcPointsGeometricJacobianExpressedInWorld(
+      *context_, tree().world_body().body_frame(), p_WP_set,
       &p_WP_out, &Jv_WP);
 
   // Since in this case we are querying for the world frame:
@@ -703,7 +752,7 @@ TEST_F(KukaIiwaModelTests, FrameGeometricJacobianForTheWorldFrame) {
   // zero Jacobian for the world body.
   const Vector3<double> p_WP(1.0, 1.0, 1.0);
 
-  const int nv = model_->num_velocities();
+  const int nv = tree().num_velocities();
 
   // We set the output Jacobian to garbage so that upon returning from
   // CalcFrameGeometricJacobianExpressedInWorld() we can verify it was
@@ -713,8 +762,8 @@ TEST_F(KukaIiwaModelTests, FrameGeometricJacobianForTheWorldFrame) {
   // The state stored in the context should not affect the result of this test.
   // Therefore we do not set it.
 
-  model_->CalcFrameGeometricJacobianExpressedInWorld(
-      *context_, model_->world_body().body_frame(), p_WP, &Jv_WP);
+  tree().CalcFrameGeometricJacobianExpressedInWorld(
+      *context_, tree().world_body().body_frame(), p_WP, &Jv_WP);
 
   // Since in this case we are querying for the world frame, the Jacobian should
   // be exactly zero.
@@ -746,23 +795,26 @@ class WeldMobilizerTest : public ::testing::Test {
     // these tests since they are all kinematic.
     const SpatialInertia<double> M_B;
 
-    body1_ = &model_.AddBody<RigidBody>(M_B);
-    body2_ = &model_.AddBody<RigidBody>(M_B);
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
 
-    model_.AddMobilizer<WeldMobilizer>(
-        model_.world_body().body_frame(), body1_->body_frame(), X_WB1_);
+    body1_ = &model->AddBody<RigidBody>(M_B);
+    body2_ = &model->AddBody<RigidBody>(M_B);
+
+    model->AddMobilizer<WeldMobilizer>(
+        model->world_body().body_frame(), body1_->body_frame(), X_WB1_);
 
     // Add a weld joint between bodies 1 and 2 by welding together inboard
     // frame F (on body 1) with outboard frame M (on body 2).
-    const auto& frame_F = model_.AddFrame<FixedOffsetFrame>(*body1_, X_B1F_);
-    const auto& frame_M = model_.AddFrame<FixedOffsetFrame>(*body2_, X_B2M_);
-    model_.AddMobilizer<WeldMobilizer>(frame_F, frame_M, X_FM_);
+    const auto& frame_F = model->AddFrame<FixedOffsetFrame>(*body1_, X_B1F_);
+    const auto& frame_M = model->AddFrame<FixedOffsetFrame>(*body2_, X_B2M_);
+    model->AddMobilizer<WeldMobilizer>(frame_F, frame_M, X_FM_);
 
-    // We are done adding modeling elements. Finalize the model:
-    model_.Finalize();
-
-    // Create a context to store the state for this model:
-    context_ = model_.CreateDefaultContext();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    // Create a context to store the state for this tree:
+    context_ = system_->CreateDefaultContext();
 
     // Expected pose of body 2 in the world.
     X_WB2_.translation() =
@@ -772,11 +824,14 @@ class WeldMobilizerTest : public ::testing::Test {
     X_WB2_.makeAffine();
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
+  std::unique_ptr<Context<double>> context_;
   const RigidBody<double>* body1_{nullptr};
   const RigidBody<double>* body2_{nullptr};
-  std::unique_ptr<Context<double>> context_;
+
   Isometry3d X_WB1_{
       AngleAxisd(-M_PI_4, Vector3d::UnitZ()) * Translation3d(0.5, 0.0, 0.0)};
   Isometry3d X_FM_{AngleAxisd(-M_PI_2, Vector3d::UnitZ())};
@@ -786,8 +841,8 @@ class WeldMobilizerTest : public ::testing::Test {
 };
 
 TEST_F(WeldMobilizerTest, StateHasZeroSize) {
-  EXPECT_EQ(model_.num_positions(), 0);
-  EXPECT_EQ(model_.num_velocities(), 0);
+  EXPECT_EQ(tree().num_positions(), 0);
+  EXPECT_EQ(tree().num_velocities(), 0);
   EXPECT_EQ(context_->get_continuous_state().size(), 0);
 }
 
@@ -796,7 +851,7 @@ TEST_F(WeldMobilizerTest, PositionKinematics) {
   const double kTolerance = 10 * std::numeric_limits<double>::epsilon();
 
   std::vector<Isometry3d> body_poses;
-  model_.CalcAllBodyPosesInWorld(*context_, &body_poses);
+  tree().CalcAllBodyPosesInWorld(*context_, &body_poses);
 
   EXPECT_TRUE(CompareMatrices(
       body_poses[body1_->index()].matrix(), X_WB1_.matrix(),

--- a/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
+++ b/multibody/multibody_tree/test/tree_from_mobilizers_test.cc
@@ -16,6 +16,7 @@
 #include "drake/multibody/multibody_tree/fixed_offset_frame.h"
 #include "drake/multibody/multibody_tree/joints/revolute_joint.h"
 #include "drake/multibody/multibody_tree/multibody_forces.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/revolute_mobilizer.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/multibody/multibody_tree/uniform_gravity_field_element.h"
@@ -118,19 +119,19 @@ using systems::Context;
 //      |        |
 //      |        |
 //      +--------+
+//
 class PendulumTests : public ::testing::Test {
  public:
-  // Creates an "empty" MultibodyTree that only contains the "world" body and
-  // world body frame.
+  // SetUp() creates an "empty" MultibodyTree that only contains the
+  // world body and world body frame.
   void SetUp() override {
     model_ = std::make_unique<MultibodyTree<double>>();
-
-    // Retrieves the world body.
     world_body_ = &model_->world_body();
   }
 
   // Sets up the MultibodyTree model for a double pendulum. See this unit test's
-  // class description for details.
+  // class description for details. Note that this method does not finalize the
+  // tree.
   void CreatePendulumModel() {
     // Spatial inertia of the upper link about its frame U and expressed in U.
     Vector3d link1_com_U = Vector3d::Zero();  // U is at the link's COM.
@@ -225,10 +226,11 @@ class PendulumTests : public ::testing::Test {
   // Replace this by a method Body<T>::get_pose_in_world(const Context<T>&)
   // when we can place cache entries in the context.
   template <typename T>
-  const Isometry3<T>& get_body_pose_in_world(
+  static const Isometry3<T>& get_body_pose_in_world(
+      const MultibodyTree<T>& tree,
       const PositionKinematicsCache<T>& pc,
-      const Body<T>& body) const {
-    const MultibodyTreeTopology& topology = model_->get_topology();
+      const Body<T>& body) {
+    const MultibodyTreeTopology& topology = tree.get_topology();
     // Cache entries are accessed by BodyNodeIndex for fast traversals.
     return pc.get_X_WB(topology.get_body(body.index()).body_node);
   }
@@ -239,10 +241,11 @@ class PendulumTests : public ::testing::Test {
   // Replace this by a method
   // Body<T>::get_spatial_velocity_in_world(const Context<T>&)
   // when we can place cache entries in the context.
-  const SpatialVelocity<double>& get_body_spatial_velocity_in_world(
+  static const SpatialVelocity<double>& get_body_spatial_velocity_in_world(
+      const MultibodyTree<double>& tree,
       const VelocityKinematicsCache<double>& vc,
-      const Body<double>& body) const {
-    const MultibodyTreeTopology& topology = model_->get_topology();
+      const Body<double>& body) {
+    const MultibodyTreeTopology& topology = tree.get_topology();
     // Cache entries are accessed by BodyNodeIndex for fast traversals.
     return vc.get_V_WB(topology.get_body(body.index()).body_node);
   }
@@ -253,10 +256,11 @@ class PendulumTests : public ::testing::Test {
   // Replace this by a method
   // Body<T>::get_spatial_acceleration_in_world(const Context<T>&)
   // when we can place cache entries in the context.
-  const SpatialAcceleration<double>& get_body_spatial_acceleration_in_world(
-      const AccelerationKinematicsCache<double>& ac,
-      const Body<double>& body) const {
-    const MultibodyTreeTopology& topology = model_->get_topology();
+  static const SpatialAcceleration<double>&
+  get_body_spatial_acceleration_in_world(
+      const MultibodyTree<double>& tree,
+      const AccelerationKinematicsCache<double>& ac, const Body<double>& body) {
+    const MultibodyTreeTopology& topology = tree.get_topology();
     // Cache entries are accessed by BodyNodeIndex for fast traversals.
     return ac.get_A_WB(topology.get_body(body.index()).body_node);
   }
@@ -269,21 +273,24 @@ class PendulumTests : public ::testing::Test {
     pc->get_mutable_X_WB(BodyNodeIndex(1)) = X_WL_;
   }
 
+  // Add elements to this model_ and then transfer the whole thing to
+  // a MultibodyTreeSystem for execution.
   std::unique_ptr<MultibodyTree<double>> model_;
-  const Body<double>* world_body_;
+  const Body<double>* world_body_{nullptr};
+
   // Bodies:
-  const RigidBody<double>* upper_link_;
-  const RigidBody<double>* lower_link_;
+  const RigidBody<double>* upper_link_{nullptr};
+  const RigidBody<double>* lower_link_{nullptr};
   // Frames:
-  const BodyFrame<double>* shoulder_inboard_frame_;
-  const FixedOffsetFrame<double>* shoulder_outboard_frame_;
-  const Frame<double>* elbow_inboard_frame_;
-  const Frame<double>* elbow_outboard_frame_;
+  const BodyFrame<double>* shoulder_inboard_frame_{nullptr};
+  const FixedOffsetFrame<double>* shoulder_outboard_frame_{nullptr};
+  const Frame<double>* elbow_inboard_frame_{nullptr};
+  const Frame<double>* elbow_outboard_frame_{nullptr};
   // Mobilizers:
-  const RevoluteMobilizer<double>* shoulder_mobilizer_;
-  const RevoluteMobilizer<double>* elbow_mobilizer_;
+  const RevoluteMobilizer<double>* shoulder_mobilizer_{nullptr};
+  const RevoluteMobilizer<double>* elbow_mobilizer_{nullptr};
   // Joints:
-  const RevoluteJoint<double>* elbow_joint_;
+  const RevoluteJoint<double>* elbow_joint_{nullptr};
   // Pendulum parameters:
   const double link1_length_ = 1.0;
   const double link1_mass_ = 1.0;
@@ -462,17 +469,14 @@ TEST_F(PendulumTests, CreateContext) {
   // - lower_link_
   EXPECT_EQ(model_->num_bodies(), 3);
 
-  // Verify we cannot create a Context until we have a valid topology.
-  EXPECT_FALSE(model_->topology_is_valid());  // Not valid before Finalize().
-  EXPECT_THROW(model_->CreateDefaultContext(), std::logic_error);
-
   // Finalize() stage.
   EXPECT_NO_THROW(model_->Finalize());
   EXPECT_TRUE(model_->topology_is_valid());  // Valid after Finalize().
 
   // Create Context.
+  MultibodyTreeSystem<double> system(std::move(model_));
   std::unique_ptr<Context<double>> context;
-  EXPECT_NO_THROW(context = model_->CreateDefaultContext());
+  EXPECT_NO_THROW(context = system.CreateDefaultContext());
 
   // Tests MultibodyTreeContext accessors.
   auto mbt_context =
@@ -493,12 +497,14 @@ TEST_F(PendulumTests, CreateContext) {
   // arbitrary value that we can use for unit testing. In practice the poses in
   // the position kinematics will be the result of a position kinematics update
   // and will live in the context as a cache entry.
-  PositionKinematicsCache<double> pc(model_->get_topology());
+  PositionKinematicsCache<double> pc(system.tree().get_topology());
   SetPendulumPoses(&pc);
 
   // Retrieve body poses from position kinematics cache.
-  const Isometry3d &X_WW = get_body_pose_in_world(pc, *world_body_);
-  const Isometry3d &X_WLu = get_body_pose_in_world(pc, *upper_link_);
+  const Isometry3d& X_WW =
+      get_body_pose_in_world(system.tree(), pc, *world_body_);
+  const Isometry3d& X_WLu =
+      get_body_pose_in_world(system.tree(), pc, *upper_link_);
 
   // Asserts that the retrieved poses match with the ones specified by the unit
   // test method SetPendulumPoses().
@@ -514,11 +520,12 @@ class PendulumKinematicTests : public PendulumTests {
   void SetUp() override {
     PendulumTests::SetUp();
     CreatePendulumModel();
-    model_->Finalize();
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model_));
+    context_ = system_->CreateDefaultContext();
+
     // Only for testing, in this case we do know our Joint model IS a
     // RevoluteMobilizer.
     elbow_mobilizer_ = JointTester::get_mobilizer(*elbow_joint_);
-    context_ = model_->CreateDefaultContext();
     mbt_context_ =
         dynamic_cast<MultibodyTreeContext<double>*>(context_.get());
   }
@@ -543,7 +550,7 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_mobilizer_->set_angle(context_.get(), elbow_angle);
 
     Matrix2d H;
-    model_->CalcMassMatrixViaInverseDynamics(*context_, &H);
+    tree().CalcMassMatrixViaInverseDynamics(*context_, &H);
 
     Matrix2d H_expected = acrobot_benchmark_.CalcMassMatrix(elbow_angle);
     EXPECT_TRUE(H.isApprox(H_expected, 5 * kEpsilon));
@@ -568,7 +575,7 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_rate = 0.0;
     shoulder_mobilizer_->set_angular_rate(context_.get(), shoulder_rate);
     elbow_mobilizer_->set_angular_rate(context_.get(), elbow_rate);
-    model_->CalcBiasTerm(*context_, &C);
+    tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
             shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
     EXPECT_TRUE(CompareMatrices(
@@ -579,7 +586,7 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_rate = 0.0;
     shoulder_mobilizer_->set_angular_rate(context_.get(), shoulder_rate);
     elbow_mobilizer_->set_angular_rate(context_.get(), elbow_rate);
-    model_->CalcBiasTerm(*context_, &C);
+    tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
     EXPECT_TRUE(CompareMatrices(
@@ -590,7 +597,7 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_rate = 1.0;
     shoulder_mobilizer_->set_angular_rate(context_.get(), shoulder_rate);
     elbow_mobilizer_->set_angular_rate(context_.get(), elbow_rate);
-    model_->CalcBiasTerm(*context_, &C);
+    tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
     EXPECT_TRUE(CompareMatrices(
@@ -601,7 +608,7 @@ class PendulumKinematicTests : public PendulumTests {
     elbow_rate = 1.0;
     shoulder_mobilizer_->set_angular_rate(context_.get(), shoulder_rate);
     elbow_mobilizer_->set_angular_rate(context_.get(), elbow_rate);
-    model_->CalcBiasTerm(*context_, &C);
+    tree().CalcBiasTerm(*context_, &C);
     C_expected = acrobot_benchmark_.CalcCoriolisVector(
         shoulder_angle, elbow_angle, shoulder_rate, elbow_rate);
     EXPECT_TRUE(CompareMatrices(
@@ -617,7 +624,7 @@ class PendulumKinematicTests : public PendulumTests {
   /// drake::multibody::benchmarks::Acrobot.
   Vector2d VerifyGravityTerm(
       const Eigen::Ref<const VectorXd>& q) const {
-    DRAKE_DEMAND(q.size() == model_->num_positions());
+    DRAKE_DEMAND(q.size() == tree().num_positions());
 
     // This is the minimum factor of the machine precision within which these
     // tests pass. This factor incorporates an additional factor of two (2) to
@@ -628,8 +635,8 @@ class PendulumKinematicTests : public PendulumTests {
     const double shoulder_angle =  q(0);
     const double elbow_angle =  q(1);
 
-    PositionKinematicsCache<double> pc(model_->get_topology());
-    VelocityKinematicsCache<double> vc(model_->get_topology());
+    PositionKinematicsCache<double> pc(tree().get_topology());
+    VelocityKinematicsCache<double> vc(tree().get_topology());
     // Even though tau_g(q) only depends on positions, other velocity dependent
     // forces (for instance damping) could depend on velocities. Therefore we
     // set the velocity kinematics cache entries to zero so that only tau_g(q)
@@ -641,25 +648,25 @@ class PendulumKinematicTests : public PendulumTests {
     // Compute position kinematics.
     shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
     elbow_joint_->set_angle(context_.get(), elbow_angle);
-    model_->CalcPositionKinematicsCache(*context_, &pc);
+    tree().CalcPositionKinematicsCache(*context_, &pc);
 
     // ======================================================================
     // The force of gravity gets included in this call since we have
     // UniformGravityFieldElement in the model.
     // Applied forcing:
-    MultibodyForces<double> forcing(*model_);
-    model_->CalcForceElementsContribution(*context_, pc, vc, &forcing);
+    MultibodyForces<double> forcing(tree());
+    tree().CalcForceElementsContribution(*context_, pc, vc, &forcing);
 
     // ======================================================================
     // To get generalized forces, compute inverse dynamics applying the forces
     // computed by CalcForceElementsContribution().
 
     // Output vector of generalized forces.
-    VectorXd tau(model_->num_velocities());
+    VectorXd tau(tree().num_velocities());
 
     // Output vector of spatial forces for each body B at their inboard
     // frame Mo, expressed in the world W.
-    vector<SpatialForce<double>> F_BMo_W_array(model_->num_bodies());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
 
     // ======================================================================
     // Compute expected values using the acrobot benchmark.
@@ -672,8 +679,8 @@ class PendulumKinematicTests : public PendulumTests {
     // However, the data given at input is lost on output. A user might choose
     // then to have separate input/output arrays.
 
-    const VectorXd vdot = VectorXd::Zero(model_->num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(model_->num_bodies());
+    const VectorXd vdot = VectorXd::Zero(tree().num_velocities());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
 
     // Aliases to external forcing arrays:
     std::vector<SpatialForce<double>>& Fapplied_Bo_W_array =
@@ -684,7 +691,7 @@ class PendulumKinematicTests : public PendulumTests {
     // Initialize output to garbage, it should not affect the results.
     tau.setConstant(std::numeric_limits<double>::quiet_NaN());
     tau_applied.setZero();
-    model_->CalcInverseDynamics(
+    tree().CalcInverseDynamics(
         *context_, pc, vc, vdot, Fapplied_Bo_W_array, tau_applied,
         &A_WB_array, &F_BMo_W_array, &tau);
     // The result from inverse dynamics must be tau = -tau_g(q).
@@ -693,7 +700,7 @@ class PendulumKinematicTests : public PendulumTests {
     // Now try using the same arrays for input/output (input data
     // Fapplied_Bo_W_array will get overwritten through the output argument).
     tau_applied.setZero();  // This will now get overwritten.
-    model_->CalcInverseDynamics(
+    tree().CalcInverseDynamics(
         *context_, pc, vc, vdot, Fapplied_Bo_W_array, tau_applied,
         &A_WB_array, &Fapplied_Bo_W_array, &tau_applied);
     // The result from inverse dynamics must be tau = -tau_g(q).
@@ -702,7 +709,7 @@ class PendulumKinematicTests : public PendulumTests {
     // Compute the system's potential energy:
     const double V_expected =
         acrobot_benchmark_.CalcPotentialEnergy(shoulder_angle, elbow_angle);
-    const double V = model_->CalcPotentialEnergy(*context_);
+    const double V = tree().CalcPotentialEnergy(*context_);
     EXPECT_NEAR(V, V_expected, kTolerance);
 
     return tau;
@@ -726,7 +733,10 @@ class PendulumKinematicTests : public PendulumTests {
     return SpatialVelocity<double>(w_AB, v_AB);
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
   MultibodyTreeContext<double>* mbt_context_;
   // Reference benchmark for verification.
@@ -752,9 +762,9 @@ class PendulumKinematicTests : public PendulumTests {
       const Eigen::Ref<const VectorXd>& q,
       const Eigen::Ref<const VectorXd>& v,
       const Eigen::Ref<const VectorXd>& vdot) const {
-    DRAKE_DEMAND(q.size() == model_->num_positions());
-    DRAKE_DEMAND(v.size() == model_->num_velocities());
-    DRAKE_DEMAND(vdot.size() == model_->num_velocities());
+    DRAKE_DEMAND(q.size() == tree().num_positions());
+    DRAKE_DEMAND(v.size() == tree().num_velocities());
+    DRAKE_DEMAND(vdot.size() == tree().num_velocities());
 
     // This is the minimum factor of the machine precision within which these
     // tests pass. This factor incorporates an additional factor of two (2) to
@@ -768,39 +778,39 @@ class PendulumKinematicTests : public PendulumTests {
     const double shoulder_angle_rate = v(0);
     const double elbow_angle_rate = v(1);
 
-    PositionKinematicsCache<double> pc(model_->get_topology());
-    VelocityKinematicsCache<double> vc(model_->get_topology());
+    PositionKinematicsCache<double> pc(tree().get_topology());
+    VelocityKinematicsCache<double> vc(tree().get_topology());
 
     // ======================================================================
     // Compute position kinematics.
     shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
     elbow_joint_->set_angle(context_.get(), elbow_angle);
-    model_->CalcPositionKinematicsCache(*context_, &pc);
+    tree().CalcPositionKinematicsCache(*context_, &pc);
 
     // ======================================================================
     // Compute velocity kinematics.
     shoulder_mobilizer_->set_angular_rate(context_.get(), shoulder_angle_rate);
     elbow_joint_->set_angular_rate(context_.get(), elbow_angle_rate);
-    model_->CalcVelocityKinematicsCache(*context_, pc, &vc);
+    tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
 
     // ======================================================================
     // Compute inverse dynamics.
-    VectorXd tau(model_->num_velocities());
-    vector<SpatialAcceleration<double>> A_WB_array(model_->num_bodies());
-    vector<SpatialForce<double>> F_BMo_W_array(model_->num_bodies());
-    model_->CalcInverseDynamics(*context_, pc, vc, vdot, {}, VectorXd(),
+    VectorXd tau(tree().num_velocities());
+    vector<SpatialAcceleration<double>> A_WB_array(tree().num_bodies());
+    vector<SpatialForce<double>> F_BMo_W_array(tree().num_bodies());
+    tree().CalcInverseDynamics(*context_, pc, vc, vdot, {}, VectorXd(),
                                 &A_WB_array, &F_BMo_W_array, &tau);
 
     // ======================================================================
     // Compute acceleration kinematics.
-    AccelerationKinematicsCache<double> ac(model_->get_topology());
-    model_->CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
+    AccelerationKinematicsCache<double> ac(tree().get_topology());
+    tree().CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
 
     // From acceleration kinematics.
     const SpatialAcceleration<double>& A_WUcm_ac =
-        get_body_spatial_acceleration_in_world(ac, *upper_link_);
+        get_body_spatial_acceleration_in_world(tree(), ac, *upper_link_);
     const SpatialAcceleration<double>& A_WL_ac =
-        get_body_spatial_acceleration_in_world(ac, *lower_link_);
+        get_body_spatial_acceleration_in_world(tree(), ac, *lower_link_);
     // From inverse dynamics.
     const SpatialAcceleration<double>& A_WUcm_id =
         A_WB_array[upper_link_->node_index()];
@@ -842,7 +852,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
   shoulder_mobilizer_->set_zero_configuration(context_.get());
   EXPECT_EQ(shoulder_mobilizer_->get_angle(*context_), 0.0);
 
-  PositionKinematicsCache<double> pc(model_->get_topology());
+  PositionKinematicsCache<double> pc(tree().get_topology());
 
   const int num_angles = 50;
   const double kDeltaAngle = 2 * M_PI / (num_angles - 1.0);
@@ -860,7 +870,7 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
       EXPECT_EQ(mbt_context_->get_positions()(0), shoulder_angle);
       EXPECT_EQ(mbt_context_->get_positions()(1), elbow_angle);
 
-      model_->CalcPositionKinematicsCache(*context_, &pc);
+      tree().CalcPositionKinematicsCache(*context_, &pc);
 
       // Indexes to the BodyNode objects associated with each mobilizer.
       const BodyNodeIndex shoulder_node =
@@ -885,9 +895,9 @@ TEST_F(PendulumKinematicTests, CalcPositionKinematics) {
                 &pc.get_mutable_X_FM(elbow_node));
 
       // Retrieve body poses from position kinematics cache.
-      const Isometry3d& X_WW = get_body_pose_in_world(pc, *world_body_);
-      const Isometry3d& X_WU = get_body_pose_in_world(pc, *upper_link_);
-      const Isometry3d& X_WL = get_body_pose_in_world(pc, *lower_link_);
+      const Isometry3d& X_WW = get_body_pose_in_world(tree(), pc, *world_body_);
+      const Isometry3d& X_WU = get_body_pose_in_world(tree(), pc, *upper_link_);
+      const Isometry3d& X_WL = get_body_pose_in_world(tree(), pc, *lower_link_);
 
       const Isometry3d X_WU_expected =
           acrobot_benchmark_.CalcLink1PoseInWorldFrame(shoulder_angle);
@@ -912,9 +922,9 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
   const int kEpsilonFactor = 30;
   const double kTolerance = kEpsilonFactor * kEpsilon;
 
-  PositionKinematicsCache<double> pc(model_->get_topology());
-  VelocityKinematicsCache<double> vc(model_->get_topology());
-  AccelerationKinematicsCache<double> ac(model_->get_topology());
+  PositionKinematicsCache<double> pc(tree().get_topology());
+  VelocityKinematicsCache<double> vc(tree().get_topology());
+  AccelerationKinematicsCache<double> ac(tree().get_topology());
 
   const int num_angles = 50;
   const double kDeltaAngle = 2 * M_PI / (num_angles - 1.0);
@@ -927,12 +937,12 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       // Compute position kinematics.
       shoulder_mobilizer_->set_angle(context_.get(), shoulder_angle);
       elbow_joint_->set_angle(context_.get(), elbow_angle);
-      model_->CalcPositionKinematicsCache(*context_, &pc);
+      tree().CalcPositionKinematicsCache(*context_, &pc);
 
       // Obtain the lower link center of mass to later shift its computed
       // spatial velocity and acceleration to the center of mass frame for
       // comparison with the benchmark.
-      const Isometry3d& X_WL = get_body_pose_in_world(pc, *lower_link_);
+      const Isometry3d& X_WL = get_body_pose_in_world(tree(), pc, *lower_link_);
       const Matrix3d R_WL = X_WL.linear();
       const Vector3d p_LoLcm_L = lower_link_->default_com();
       const Vector3d p_LoLcm_W = R_WL * p_LoLcm_L;
@@ -951,13 +961,13 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       const double elbow_angle_rate = -0.5;
       elbow_joint_->set_angular_rate(context_.get(), elbow_angle_rate);
       EXPECT_EQ(elbow_joint_->get_angular_rate(*context_), elbow_angle_rate);
-      model_->CalcVelocityKinematicsCache(*context_, pc, &vc);
+      tree().CalcVelocityKinematicsCache(*context_, pc, &vc);
 
       // Retrieve body spatial velocities from velocity kinematics cache.
       const SpatialVelocity<double>& V_WUcm =
-          get_body_spatial_velocity_in_world(vc, *upper_link_);
+          get_body_spatial_velocity_in_world(tree(), vc, *upper_link_);
       const SpatialVelocity<double>& V_WL =
-          get_body_spatial_velocity_in_world(vc, *lower_link_);
+          get_body_spatial_velocity_in_world(tree(), vc, *lower_link_);
       // Obtain the lower link's center of mass frame spatial velocity by
       // shifting V_WL:
       const SpatialVelocity<double> V_WLcm = V_WL.Shift(p_LoLcm_W);
@@ -980,13 +990,13 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       VectorX<double> vdot(2);  // Vector of generalized accelerations.
       vdot = VectorX<double>::Zero(2);
 
-      model_->CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
+      tree().CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
 
       // Retrieve body spatial accelerations from acceleration kinematics cache.
       SpatialAcceleration<double> A_WUcm =
-          get_body_spatial_acceleration_in_world(ac, *upper_link_);
+          get_body_spatial_acceleration_in_world(tree(), ac, *upper_link_);
       SpatialAcceleration<double> A_WL =
-          get_body_spatial_acceleration_in_world(ac, *lower_link_);
+          get_body_spatial_acceleration_in_world(tree(), ac, *lower_link_);
       // Obtain the lower link's center of mass frame spatial acceleration by
       // shifting A_WL:
       const Vector3d& w_WL = V_WL.rotational();
@@ -1018,11 +1028,11 @@ TEST_F(PendulumKinematicTests, CalcVelocityAndAccelerationKinematics) {
       EXPECT_EQ(
           elbow_mobilizer_->get_accelerations_from_array(vdot)(0), 2.0);
 
-      model_->CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
+      tree().CalcAccelerationKinematicsCache(*context_, pc, vc, vdot, &ac);
 
       // Retrieve body spatial accelerations from acceleration kinematics cache.
-      A_WUcm = get_body_spatial_acceleration_in_world(ac, *upper_link_);
-      A_WL = get_body_spatial_acceleration_in_world(ac, *lower_link_);
+      A_WUcm = get_body_spatial_acceleration_in_world(tree(), ac, *upper_link_);
+      A_WL = get_body_spatial_acceleration_in_world(tree(), ac, *lower_link_);
       A_WLcm = A_WL.Shift(p_LoLcm_W, w_WL);
 
       A_WUcm_expected = SpatialAcceleration<double>(
@@ -1118,7 +1128,8 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
   const double kTolerance = kEpsilonFactor * kEpsilon;
 
   std::unique_ptr<MultibodyTree<AutoDiffXd>> model_autodiff =
-      model_->ToAutoDiffXd();
+      tree().ToAutoDiffXd();
+  const MultibodyTree<AutoDiffXd>& tree_autodiff = *model_autodiff.get();
 
   const RevoluteMobilizer<AutoDiffXd>& shoulder_mobilizer_autodiff =
       model_autodiff->get_variant(*shoulder_mobilizer_);
@@ -1131,10 +1142,12 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
   const RigidBody<AutoDiffXd>& lower_link_autodiff =
       model_autodiff->get_variant(*lower_link_);
 
+  MultibodyTreeSystem<AutoDiffXd> tree_system_autodiff(
+      std::move(model_autodiff));
   std::unique_ptr<Context<AutoDiffXd>> context_autodiff =
-      model_autodiff->CreateDefaultContext();
+      tree_system_autodiff.CreateDefaultContext();
 
-  PositionKinematicsCache<AutoDiffXd> pc(model_autodiff->get_topology());
+  PositionKinematicsCache<AutoDiffXd> pc(tree_autodiff.get_topology());
 
   const int num_angles = 50;
   const double kDeltaAngle = 2 * M_PI / (num_angles - 1.0);
@@ -1168,13 +1181,13 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
           shoulder_mobilizer_autodiff.set_angle(context_autodiff.get(),
                                                 shoulder_angle);
           elbow_joint_autodiff.set_angle(context_autodiff.get(), elbow_angle);
-          model_autodiff->CalcPositionKinematicsCache(*context_autodiff, &pc);
+          tree_autodiff.CalcPositionKinematicsCache(*context_autodiff, &pc);
 
           // Retrieve body poses from position kinematics cache.
           const Isometry3<AutoDiffXd>& X_WU =
-              get_body_pose_in_world(pc, upper_link_autodiff);
+              get_body_pose_in_world(tree_autodiff, pc, upper_link_autodiff);
           const Isometry3<AutoDiffXd>& X_WL =
-              get_body_pose_in_world(pc, lower_link_autodiff);
+              get_body_pose_in_world(tree_autodiff, pc, lower_link_autodiff);
 
           const Isometry3d X_WU_expected =
               acrobot_benchmark_.CalcLink1PoseInWorldFrame(
@@ -1231,7 +1244,7 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
 
           // Compute potential energy, and its time derivative.
           const AutoDiffXd V =
-              model_autodiff->CalcPotentialEnergy(*context_autodiff);
+              tree_autodiff.CalcPotentialEnergy(*context_autodiff);
           const double V_value = V.value();
           const double V_expected =
               acrobot_benchmark_.CalcPotentialEnergy(
@@ -1249,7 +1262,7 @@ TEST_F(PendulumKinematicTests, CalcVelocityKinematicsWithAutoDiffXd) {
               context_.get(), elbow_angle.value());
           elbow_mobilizer_->set_angular_rate(
               context_.get(), elbow_angle.derivatives()[0]);
-          const double Pc = model_->CalcConservativePower(*context_);
+          const double Pc = tree().CalcConservativePower(*context_);
 
           // Notice we define Pc = -d(Pc)/dt.
           const double Pc_from_autodiff = -V.derivatives()[0];
@@ -1277,10 +1290,10 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WQi_set(3, 3);
-  model_->CalcPointsPositions(
+  tree().CalcPointsPositions(
       *context_,
       lower_link_->body_frame(), p_LQi_set,
-      model_->world_frame(), &p_WQi_set);
+      tree().world_frame(), &p_WQi_set);
 
   Matrix3X<double> p_WQi_set_expected(3, 3);
   p_WQi_set_expected.col(0) << 2.0 + M_SQRT1_2, -M_SQRT1_2, 0.0;
@@ -1299,10 +1312,10 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WPi_set(3, 3);
-  model_->CalcPointsPositions(
+  tree().CalcPointsPositions(
       *context_,
       upper_link_->body_frame(), p_UPi_set,
-      model_->world_frame(), &p_WPi_set);
+      tree().world_frame(), &p_WPi_set);
 
   Matrix3X<double> p_WPi_set_expected(3, 3);
   p_WPi_set_expected.col(0) = 0.5 * Vector3d(-M_SQRT1_2, M_SQRT1_2, 0.0);
@@ -1312,7 +1325,7 @@ TEST_F(PendulumKinematicTests, PointsPositionsAndRelativeTransform) {
   EXPECT_TRUE(CompareMatrices(
       p_WPi_set, p_WPi_set_expected, kTolerance, MatrixCompareType::relative));
 
-  const Isometry3d X_UL = model_->CalcRelativeTransform(
+  const Isometry3d X_UL = tree().CalcRelativeTransform(
       *context_, upper_link_->body_frame(), lower_link_->body_frame());
   const Vector3d p_UL = X_UL.translation();
   const Matrix3d R_UL = X_UL.linear();
@@ -1338,10 +1351,10 @@ TEST_F(PendulumKinematicTests, PointsHaveTheWrongSize) {
 
   // World positions of the set of points Qi:
   Matrix3X<double> p_WQi_set(3, 3);
-  EXPECT_THROW(model_->CalcPointsPositions(
+  EXPECT_THROW(tree().CalcPointsPositions(
       *context_,
       lower_link_->body_frame(), p_LQi_set,
-      model_->world_frame(), &p_WQi_set), std::runtime_error);
+      tree().world_frame(), &p_WQi_set), std::runtime_error);
 }
 
 }  // namespace

--- a/multibody/multibody_tree/test/weld_mobilizer_test.cc
+++ b/multibody/multibody_tree/test/weld_mobilizer_test.cc
@@ -5,6 +5,7 @@
 #include "drake/common/eigen_types.h"
 #include "drake/common/test_utilities/eigen_matrix_compare.h"
 #include "drake/multibody/multibody_tree/multibody_tree.h"
+#include "drake/multibody/multibody_tree/multibody_tree_system.h"
 #include "drake/multibody/multibody_tree/rigid_body.h"
 #include "drake/systems/framework/context.h"
 
@@ -35,39 +36,44 @@ class WeldMobilizerTest : public ::testing::Test {
     // these tests since they are all kinematic.
     const SpatialInertia<double> M_B;
 
+    // Create an empty model.
+    auto model = std::make_unique<MultibodyTree<double>>();
+
     // Add a body so we can add a mobilizer to it.
-    body_ = &model_.AddBody<RigidBody>(M_B);
+    auto& body = model->AddBody<RigidBody>(M_B);
 
     X_WB_ = Translation3d(1.0, 2.0, 3.0);
 
     // Add a weld mobilizer between the world and the body:
-    weld_body_to_world_ = &model_.AddMobilizer<WeldMobilizer>(
-        model_.world_body().body_frame(), body_->body_frame(), X_WB_);
+    weld_body_to_world_ = &model->AddMobilizer<WeldMobilizer>(
+        model->world_body().body_frame(), body.body_frame(), X_WB_);
 
-    // We are done adding modeling elements. Finalize the model:
-    model_.Finalize();
+    // We are done adding modeling elements. Transfer tree to system and get
+    // a Context.
+    system_ = std::make_unique<MultibodyTreeSystem<double>>(std::move(model));
+    context_ = system_->CreateDefaultContext();
 
-    // Create a context to store the state for this model:
-    context_ = model_.CreateDefaultContext();
     // Performance critical queries take a MultibodyTreeContext to avoid dynamic
     // casting.
     mbt_context_ = dynamic_cast<MultibodyTreeContext<double>*>(context_.get());
     ASSERT_NE(mbt_context_, nullptr);
   }
 
+  const MultibodyTree<double>& tree() const { return system_->tree(); }
+
  protected:
-  MultibodyTree<double> model_;
-  const RigidBody<double>* body_{nullptr};
-  const WeldMobilizer<double>* weld_body_to_world_{nullptr};
+  std::unique_ptr<MultibodyTreeSystem<double>> system_;
   std::unique_ptr<Context<double>> context_;
   MultibodyTreeContext<double>* mbt_context_{nullptr};
+
+  const WeldMobilizer<double>* weld_body_to_world_{nullptr};
   // Pose of body B in the world frame W.
   Isometry3d X_WB_;
 };
 
 TEST_F(WeldMobilizerTest, ZeroSizedState) {
-  EXPECT_EQ(model_.num_positions(), 0);
-  EXPECT_EQ(model_.num_velocities(), 0);
+  EXPECT_EQ(tree().num_positions(), 0);
+  EXPECT_EQ(tree().num_velocities(), 0);
 }
 
 TEST_F(WeldMobilizerTest, CalcAcrossMobilizerTransform) {


### PR DESCRIPTION
Adds minimalist MultibodyTreeSystem to manage System resource declaration for MultibodyTree, so that MBTree (which is not a System) can make full use of System and Context resources, including state variables, parameters, and cache entries.

MultibodyPlant now derives from MultibodyTreeSystem and can now concern itself only with its own resources without having to worry about what MultibodyTree needs.

This PR handles the position and velocity kinematics caches for MBTree, removing the mocked-up ones from MultibodyContext. This does not yet do anything with MBPlant cache entries.

MultibodyContext still lives, but has almost no functionality and should be removed completely in a subsequent PR.

Most of the code here is trivial-but-tedious modifications to MBTree-using code to inject the MBTreeSystem where it is needed.
```
Category            added  modified  removed  
----------------------------------------------
code                326    549       146      
comments            117    32        52       
blank               86     0         22       
----------------------------------------------
TOTAL               529    581       220      
```

Fixes #9525 as a side effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9489)
<!-- Reviewable:end -->
