### PR TITLE
create doxygen commands to make little block diagrams in the documentation.  

### DIFF
--- a/doc/Doxyfile_CXX.in
+++ b/doc/Doxyfile_CXX.in
@@ -38,7 +38,10 @@ INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 2
 ALIASES                = "default=@n @a Default: " \
-                         "concept{1}=@ingroup \1\n@par Implemented concepts:\n@ref \1"
+                         "concept{1}=@ingroup \1\n@par Implemented concepts:\n@ref \1" \
+                         "system{3}=<table align=center cellpadding=0 cellspacing=0><tr align=center><td><table cellspacing=0 cellpadding=0>\2</table></td><td align=center style=\"border:solid;padding-left:20px;padding-right:20px\" bgcolor=#F0F0F0>\1</td><td><table cellspacing=0 cellpadding=0>\3</table></td></tr></table>" \
+                         "input_port{1}=<tr><td align=right style=\"padding:5px 0px 5px 0px\">\1 &rarr;</td></tr>"\
+                         "output_port{1}=<tr><td align=left style=\"padding:5px 0px 5px 0px\">&rarr; \1</td></tr>"
 TCL_SUBST              =
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO

--- a/doc/doxygen_instructions.rst
+++ b/doc/doxygen_instructions.rst
@@ -16,6 +16,30 @@ Coming soon. See issue
 `#2051 <https://github.com/RobotLocomotion/drake/issues/2051>`_ and PR
 `#2359 <https://github.com/RobotLocomotion/drake/pull/2359>`_.
 
+Classes that implement the `drake::systems::System <https://drake.mit
+.edu/doxygen_cxx/classdrake_1_1systems_1_1_system.html>`_ interface should add a
+simple diagram documenting their input and output ports using the macro:
+
+.. code-block:: none
+
+  @system{ system name/label,
+           @input_port{input port 1 name} @input_port{input port 2 name},
+           @output_port{output port 1 name} @output_port{output port 2 name}}
+
+The first argument is the contents of the html table cell inside the box. The
+recommendation is to use (at least) the system name, but you may also get
+creative and have images, etc, too.  Note that the comma delimiter separates the
+input and output port listings (there is no comma between ports).  Where
+possible, the names here should match the names given to the ports in the code,
+so that error messages, debugging, and automatically-generated System diagrams
+match the documentation.
+
+Some systems have variable numbers of ports, or ports that are created
+conditionally.  Prefer to add all possible ports to the diagram; see the `Adder
+<https://drake.mit.edu/doxygen_cxx/classdrake_1_1systems_1_1_adder.html>`_ system
+for an example of a system with a variable number of ports.  The ``@system``
+doxygen tag can be used multiple times to add multiple renders of the system to
+the documentation, if the system is most clearly described by a few examples.
 
 Documentation Tips and Tricks
 =============================

--- a/examples/pendulum/pendulum_plant.h
+++ b/examples/pendulum/pendulum_plant.h
@@ -15,7 +15,12 @@ namespace examples {
 namespace pendulum {
 
 /// A model of a simple pendulum
-/// @f[ ml^2 \ddot\theta + b\dot\theta + mgl\sin\theta = u @f]
+/// @f[ ml^2 \ddot\theta + b\dot\theta + mgl\sin\theta = \tau @f]
+///
+/// @system{PendulumPlant,
+///    @input_port{tau},
+///    @output_port{state} @output_port{geometry pose}
+/// }
 ///
 /// @tparam T The vector element type, which must be a valid Eigen scalar.
 ///

--- a/systems/primitives/adder.h
+++ b/systems/primitives/adder.h
@@ -10,6 +10,12 @@ namespace systems {
 
 /// An adder for arbitrarily many inputs of equal size.
 /// @ingroup primitive_systems
+///
+/// @system{Adder,
+///    @input_port{Input1} @input_port{...} @input_port{InputN},
+///    @output_port{Sum}
+/// }
+///
 /// @tparam T The type of mathematical object being added.
 ///
 /// Instantiated templates for the following kinds of T's are provided:

--- a/systems/primitives/affine_system.h
+++ b/systems/primitives/affine_system.h
@@ -15,6 +15,13 @@ namespace systems {
  * Base class for a discrete- or continuous-time, time-varying affine
  * system, with potentially time-varying coefficients.
  *
+ * @ingroup primitive_systems
+ *
+ * @system{TimeVaryingAffineSystem,
+ *    @input_port{u(t)},
+ *    @output_port{y(t)}
+ * }
+ *
  * If `time_period > 0.0`, then the affine system will have the state update:
  *   @f[ x(t+h) = A(t) x(t) + B(t) u(t) + f_0(t), @f]
  * where `h` is the time_period.  If `time_period == 0.0`, then the system will
@@ -27,6 +34,8 @@ namespace systems {
  * where `y` denotes the output vector.
  *
  * @tparam T The scalar element type, which must be a valid Eigen scalar.
+ *
+ * @see AffineSystem
  */
 template <typename T>
 class TimeVaryingAffineSystem : public LeafSystem<T> {
@@ -101,6 +110,11 @@ class TimeVaryingAffineSystem : public LeafSystem<T> {
 };
 
 /// A discrete OR continuous affine system (with constant coefficients).
+///
+/// @system{AffineSystem,
+///   @input_port{u(t)},
+///   @output_port{y(t)}
+/// }
 ///
 /// Let `u` denote the input vector, `x` denote the state vector, and
 /// `y` denote the output vector.


### PR DESCRIPTION
Resolves #6695
And adds the first two examples.

Adding the following lines to doxygen comment:
```
/// @system{Adder,
///    @input_port{Input1} @input_port{...} @input_port{InputN},
///    @output_port{Sum}
/// }
```
results in the output
![screen shot 2018-09-22 at 10 52 29 am](https://user-images.githubusercontent.com/6442292/45918529-404c3080-be56-11e8-93e0-707be1fa6410.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9490)
<!-- Reviewable:end -->
