### PR TITLE
sadly, john c is not touching drake much these days. 

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -169,7 +169,6 @@ make the review faster.
 - @EricCousineau-TRI (Toyota Research Institute)
 - @ggould-tri (Toyota Research Institute)
 - @jwnimmer-tri (Toyota Research Institute)
-- @psiorx (MIT)
 - @sammy-tri (Toyota Research Institute)
 - @SeanCurtis-TRI (Toyota Research Institute)
 - @sherm1 (Toyota Research Institute)


### PR DESCRIPTION
removing him from the documented list of platform reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9499)
<!-- Reviewable:end -->
