### PR TITLE
Don't use doxygen @bug because it adds an ugly list to user documentation

### DIFF
--- a/systems/framework/context.h
+++ b/systems/framework/context.h
@@ -399,7 +399,7 @@ class Context : public ContextBase {
   /// state. Sends out of date notifications for all computations that depend
   /// on this discrete state group.
   /// @pre @p index must identify an existing group.
-  /// @bug Currently notifies dependents of _all_ groups.
+  /// @note Currently notifies dependents of _all_ groups.
   // TODO(sherm1) Invalidate only dependents of this one discrete group.
   BasicVector<T>& get_mutable_discrete_state(int index) {
     DiscreteValues<T>& xd = get_mutable_discrete_state();
@@ -421,7 +421,7 @@ class Context : public ContextBase {
   /// abstract state variable.
   /// @pre @p index must identify an existing element.
   /// @pre the abstract state's type must match the template argument.
-  /// @bug Currently notifies dependents of _any_ abstract state variable.
+  /// @note Currently notifies dependents of _any_ abstract state variable.
   // TODO(sherm1) Invalidate only dependents of this one abstract variable.
   template <typename U>
   U& get_mutable_abstract_state(int index) {
@@ -444,7 +444,7 @@ class Context : public ContextBase {
   /// (numeric) parameters. Sends out of date notifications for all computations
   /// dependent on this parameter.
   /// @pre @p index must identify an existing numeric parameter.
-  /// @bug Currently notifies dependents of _all_ numeric parameters.
+  /// @note Currently notifies dependents of _all_ numeric parameters.
   // TODO(sherm1) Invalidate only dependents of this one parameter.
   BasicVector<T>& get_mutable_numeric_parameter(int index) {
     const int64_t change_event = this->start_new_change_event();
@@ -457,7 +457,7 @@ class Context : public ContextBase {
   /// parameters. Sends out of date notifications for all computations dependent
   /// on this parameter.
   /// @pre @p index must identify an existing abstract parameter.
-  /// @bug Currently notifies dependents of _all_ abstract parameters.
+  /// @note Currently notifies dependents of _all_ abstract parameters.
   // TODO(sherm1) Invalidate only dependents of this one parameter.
   AbstractValue& get_mutable_abstract_parameter(int index) {
     const int64_t change_event = this->start_new_change_event();
@@ -471,7 +471,7 @@ class Context : public ContextBase {
   /// Sends out of date notifications for all dependent computations in this
   /// context.
   /// @throws std::logic_error if this is not the root context.
-  /// @bug Currently does not copy fixed input port values from `source`.
+  /// @note Currently does not copy fixed input port values from `source`.
   /// See System::FixInputPortsFrom() if you want to copy those.
   // TODO(sherm1) Should treat fixed input port values same as parameters.
   // TODO(sherm1) Change the name of this method to be more inclusive since it

--- a/systems/framework/system_base.h
+++ b/systems/framework/system_base.h
@@ -653,7 +653,7 @@ class SystemBase : public internal::SystemMessageInterface {
   recomputation of an iterative approximation of contact forces.
   @see kinematics_ticket()
 
-  @bug Currently there is no way to declare specific variables and parameters
+  @note Currently there is no way to declare specific variables and parameters
   to be configuration-affecting so we include all state variables and
   parameters except for generalized velocities v. */
   // TODO(sherm1) Remove the above bug notice once #9171 is resolved.
@@ -669,7 +669,7 @@ class SystemBase : public internal::SystemMessageInterface {
   source values. This _does not_ include time or input ports.
   @see configuration_ticket()
 
-  @bug Currently there is no way to declare specific variables and parameters
+  @note Currently there is no way to declare specific variables and parameters
   to be configuration- or velocity-affecting so we include all state variables
   and parameters. */
   // TODO(sherm1) Remove the above bug notice once #9171 is resolved.


### PR DESCRIPTION
I didn't realize that doxygen `@bug` behaves like `@todo` in that it builds a list and sticks it at the top of the Drake main page to confront users.

Switched to using `@note` instead for the cases where I had used `@bug` to inform API users of current limitations.

Fixes #9493

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9502)
<!-- Reviewable:end -->
