### PR TITLE
Fixes SDF parser so that default joint limits are plus/minus infinity.

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -467,10 +467,9 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
     const double penalty_time_scale = kAlpha * time_step();
 
     if (revolute_joint) {
-      // We only compute parameters if they are far from being infinity.
-      // SDF defaults to 1.0e16 instead of infinity.
-      if (-1.0e16 < revolute_joint->lower_limit() ||
-          revolute_joint->upper_limit() < 1.0e16) {
+      // We only compute parameters if joints do have upper/lower bounds.
+      if (!std::isinf(revolute_joint->lower_limit()) ||
+          !std::isinf(revolute_joint->upper_limit())) {
         joint_limits_parameters_.joints_with_limits.push_back(
             revolute_joint->index());
 
@@ -490,10 +489,9 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
     }
 
     if (prismatic_joint) {
-      // We only compute parameters if they are far from being infinity.
-      // SDF defaults to 1.0e16 instead of infinity.
-      if (-1.0e16 < prismatic_joint->lower_limit() ||
-          prismatic_joint->upper_limit() < 1.0e16) {
+      // We only compute parameters if joints do have upper/lower bounds.
+      if (!std::isinf(prismatic_joint->lower_limit()) ||
+          !std::isinf(prismatic_joint->upper_limit())) {
         joint_limits_parameters_.joints_with_limits.push_back(
             prismatic_joint->index());
 

--- a/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
+++ b/multibody/multibody_tree/parsing/test/multibody_plant_sdf_parser_test.cc
@@ -96,6 +96,15 @@ class AcrobotModelTests : public ::testing::Test {
   std::unique_ptr<systems::Context<double>> benchmark_context_;
 };
 
+// Verifies that the default joint limits when no limits are specified in the
+// SDF file are ±infinity.
+TEST_F(AcrobotModelTests, DefaultJointLimits) {
+  EXPECT_TRUE(std::isinf(shoulder_->lower_limit()));
+  EXPECT_TRUE(std::isinf(shoulder_->upper_limit()));
+  EXPECT_TRUE(std::isinf(elbow_->lower_limit()));
+  EXPECT_TRUE(std::isinf(elbow_->upper_limit()));
+}
+
 // This test verifies a number of invariants such as model sizes and that body
 // and joint models were properly added.
 TEST_F(AcrobotModelTests, ModelBasics) {


### PR DESCRIPTION
`sdformat` defaults to ±1.0e16 when joint limits are not specified while in Drake we use the convention ±∞. We fix the SDF parser so that ±1.0e16 limits are converted to ±∞.

cc'int @RussTedrake who identified the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9513)
<!-- Reviewable:end -->
