### PR TITLE
Meta-workaround for regex dotall on Mac LLVM 10.0.0

### DIFF
--- a/bindings/pydrake/util/test/cpp_template_pybind_test.cc
+++ b/bindings/pydrake/util/test/cpp_template_pybind_test.cc
@@ -61,11 +61,12 @@ GTEST_TEST(CppTemplateTest, TemplateClass) {
   m.def("simple_func", [](const SimpleTemplate<int>&) {});
 
   // Check error message if a function is called with the incorrect arguments.
-  // N.B. We use `[\s\S]` because C++ regex does not have an equivalent of
-  // Python re's DOTALL flag.
+  // N.B. We use `[^\0]` because C++ regex does not have an equivalent of
+  // Python re's DOTALL flag. `[\s\S]` *should* work, but Apple LLVM 10.0.0
+  // does not work with it.
   DRAKE_EXPECT_THROWS_MESSAGE(
       py::eval("simple_func('incorrect value')"), std::runtime_error,
-      R"([\s\S]*incompatible function arguments[\s\S]*\(arg0: __main__\.SimpleTemplate\[int\]\)[\s\S]*)");  // NOLINT
+      R"([^\0]*incompatible function arguments[^\0]*\(arg0: __main__\.SimpleTemplate\[int\]\)[^\0]*)");  // NOLINT
 }
 
 template <typename ... Ts>


### PR DESCRIPTION
Resolves #9479.

It seems really wrong that `[\s\S]` does not work per #9479; this is an attempt to work around this using `[^\0]` per the recommendations here:
https://stackoverflow.com/q/2052497/7829525
https://stackoverflow.com/a/44906981/7829525

@jamiesnape Would you be able to test this with Apple LLVM 10?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9515)
<!-- Reviewable:end -->
