### PR TITLE
Number of positions/velocities for MBT contexts with discrete state

### DIFF
--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -320,6 +320,13 @@ class AcrobotPlantTests : public ::testing::Test {
     discrete_context_->FixInputPort(
         discrete_plant_->get_actuation_input_port().get_index(),
         Vector1<double>(0.0));
+
+    const auto& mbt_context =
+        dynamic_cast<MultibodyTreeContext<double>&>(*discrete_context_);
+    ASSERT_EQ(mbt_context.num_positions(), 2);
+    ASSERT_EQ(mbt_context.num_velocities(), 2);
+    ASSERT_EQ(mbt_context.get_positions().size(), 2);
+    ASSERT_EQ(mbt_context.get_velocities().size(), 2);
   }
 
   // Computes the vector of generalized forces due to gravity.

--- a/multibody/multibody_tree/multibody_tree_context.h
+++ b/multibody/multibody_tree/multibody_tree_context.h
@@ -98,12 +98,12 @@ class MultibodyTreeContext: public systems::LeafContext<T> {
 
   /// Returns the size of the generalized positions vector.
   int num_positions() const {
-    return this->get_continuous_state().get_generalized_position().size();
+    return topology_.num_positions();
   }
 
   /// Returns the size of the generalized velocities vector.
   int num_velocities() const {
-    return this->get_continuous_state().get_generalized_velocity().size();
+    return topology_.num_velocities();
   }
 
   /// Returns `true` if the state is discrete and `false` if the state is


### PR DESCRIPTION
Fixes a bug identified by @WenzhenYuan-TRI when using differential kinematics on a model with discrete state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9524)
<!-- Reviewable:end -->
