### PR TITLE
Fix a bug in manipulator_joint_space_controller (exporting the wrong output)

### DIFF
--- a/examples/qp_inverse_dynamics/manipulator_joint_space_controller.cc
+++ b/examples/qp_inverse_dynamics/manipulator_joint_space_controller.cc
@@ -88,7 +88,7 @@ ManipulatorJointSpaceController::ManipulatorJointSpaceController(
 
   // Exposes inverse dynamics' debug output.
   output_port_index_inverse_dynamics_debug_ =
-      builder.ExportOutput(plan_eval_->get_output_port_debug_info());
+      builder.ExportOutput(id_controller->get_output_port_debug_info());
 
   // Exposes inverse dynamics' QpOutput output.
   output_port_index_qp_output_ =


### PR DESCRIPTION
This PR extracts a one-line opportunistic bug fix by @RussTedrake from PR #9459. The reviewer there reasonably objected to it being tossed in with unrelated code. The fix looks obviously correct to me, but I have no familiarity with this code. @siyuanfeng-tri, I believe this is yours? If the fix is correct, the next question is why no unit test caught the problem. If possible, can you (or @RussTedrake ?) devise a test that would have failed with the wrong output port? I do think this fix should be made asap, but this is as far as I'm going with it myself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9529)
<!-- Reviewable:end -->
