### PR TITLE
Discrete derivative

### DIFF
--- a/systems/primitives/BUILD.bazel
+++ b/systems/primitives/BUILD.bazel
@@ -19,6 +19,7 @@ drake_cc_package_library(
         ":constant_value_source",
         ":constant_vector_source",
         ":demultiplexer",
+        ":discrete_derivative",
         ":first_order_low_pass_filter",
         ":gain",
         ":integrator",
@@ -98,6 +99,16 @@ drake_cc_library(
     srcs = ["demultiplexer.cc"],
     hdrs = ["demultiplexer.h"],
     deps = [
+        "//systems/framework",
+    ],
+)
+
+drake_cc_library(
+    name = "discrete_derivative",
+    srcs = ["discrete_derivative.cc"],
+    hdrs = ["discrete_derivative.h"],
+    deps = [
+        ":linear_system",
         "//systems/framework",
     ],
 )
@@ -369,6 +380,20 @@ drake_cc_googletest(
     deps = [
         ":demultiplexer",
         "//common/test_utilities:eigen_matrix_compare",
+        "//systems/framework",
+        "//systems/framework/test_utilities",
+    ],
+)
+
+drake_cc_googletest(
+    name = "discrete_derivative_test",
+    deps = [
+        ":discrete_derivative",
+        ":signal_logger",
+        ":trajectory_source",
+        "//common/test_utilities:eigen_matrix_compare",
+        "//common/trajectories:piecewise_polynomial",
+        "//systems/analysis:simulator",
         "//systems/framework",
         "//systems/framework/test_utilities",
     ],

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -1,6 +1,68 @@
 #include "drake/systems/primitives/discrete_derivative.h"
 
+#include <memory>
+#include <vector>
+
 #include "drake/common/default_scalars.h"
+
+namespace drake {
+namespace systems {
+
+using Eigen::MatrixXd;
+
+template <typename T>
+DiscreteDerivative<T>::DiscreteDerivative(int num_inputs, double time_step)
+    : LeafSystem<T>(SystemTypeTag<systems::DiscreteDerivative>{}),
+      n_(num_inputs),
+      time_step_(time_step) {
+  DRAKE_DEMAND(n_ > 0);
+  DRAKE_DEMAND(time_step_ > 0.0);
+
+  this->DeclareVectorInputPort("u", systems::BasicVector<T>(n_));
+  this->DeclareVectorOutputPort("dudt", systems::BasicVector<T>(n_),
+                                &DiscreteDerivative<T>::CalcOutput);
+
+  // TODO(sherm): Prefer two state vectors of size n_ upon resolution of #9705.
+  this->DeclareDiscreteState(2 * n_);
+  this->DeclarePeriodicDiscreteUpdate(time_step_);
+}
+
+template <typename T>
+void DiscreteDerivative<T>::set_state(
+    const Eigen::Ref<const drake::VectorX<T>>& u,
+    drake::systems::Context<T>* context) const {
+  DRAKE_DEMAND(u.size() == n_);
+
+  context->get_mutable_discrete_state_vector().get_mutable_value() << u, u;
+}
+
+template <typename T>
+void DiscreteDerivative<T>::DoCalcDiscreteVariableUpdates(
+    const drake::systems::Context<T>& context,
+    const std::vector<const drake::systems::DiscreteUpdateEvent<T>*>&,
+    drake::systems::DiscreteValues<T>* discrete_state) const {
+  // x₀[n+1] = u[n].
+  discrete_state->get_mutable_vector().get_mutable_value().head(n_) =
+      this->EvalEigenVectorInput(context, 0);
+
+  // x₁[n+1] = x₀[n].
+  discrete_state->get_mutable_vector().get_mutable_value().tail(n_) =
+      context.get_discrete_state(0).get_value().head(n_);
+}
+
+template <typename T>
+void DiscreteDerivative<T>::CalcOutput(
+    const drake::systems::Context<T>& context,
+    drake::systems::BasicVector<T>* output_vector) const {
+  const auto x0 = context.get_discrete_state(0).get_value().head(n_);
+  const auto x1 = context.get_discrete_state(0).get_value().tail(n_);
+
+  // y(t) = (x₀[n]-x₁[n])/h.
+  output_vector->SetFromVector((x0 - x1) / time_step_);
+}
+
+}  // namespace systems
+}  // namespace drake
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
     class ::drake::systems::DiscreteDerivative)

--- a/systems/primitives/discrete_derivative.cc
+++ b/systems/primitives/discrete_derivative.cc
@@ -1,0 +1,6 @@
+#include "drake/systems/primitives/discrete_derivative.h"
+
+#include "drake/common/default_scalars.h"
+
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(
+    class ::drake::systems::DiscreteDerivative)

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -1,23 +1,37 @@
 #pragma once
 
-#include "drake/systems/primitives/linear_system.h"
+#include <memory>
+#include <vector>
 
-using Eigen::MatrixXd;
+#include "drake/systems/framework/leaf_system.h"
 
 namespace drake {
 namespace systems {
 
-/// System that outputs the discrete-time derivative of the input:
-///   @f$ y[n] = (u[n] - u[n-1])/h @f$
+/// System that outputs the discrete-time derivative of its input:
+///   y(t) = (u[n] - u[n-1])/h,
+/// where n = floor(t/h), where h is the time period.
 ///
 /// This is implemented as the linear system
-///   @f[ x[n+1] = u[n], @f]
-///   @f[ y[n] = (u[n]-x[n])/h, @f]
-/// where @f$ h @f$ is the time period.
+/// <pre>
+///   x₀[n+1] = u[n],
+///   x₁[n+1] = x₀[n],
+///   y(t) = (x₀[n]-x₁[n])/h.
+///   x₀[0] and x₁[0] are initialized in the Context (default is zeros).
+/// </pre>
 ///
-/// @system{ DiscreteDerivative, @input_port{u(t)}, @output_port{du(t)/dt} }
+/// Note: The reason for this specific implementation is a little subtle.
+/// Since drake systems do not control the evaluation time of their output
+/// ports, a downstream system may ask for the output at any continuous time.
+/// The estimate y(t) = (u(t) - u[n])/(t-n*h), which is a more
+/// continuous-time derivative, would require fewer state variables, and
+/// introduce less delay.  But the inconsistent time interval (which could be
+/// arbitrarily close to zero) makes it numerically unreliable.  Prefer the
+/// discrete-time derivative implemented here.
 ///
-/// @tparam T The type of mathematical object being added.
+/// @system{ DiscreteDerivative, @input_port{u}, @output_port{dudt} }
+///
+/// @tparam T The underlying scalar type. Must be a valid Eigen scalar.
 ///
 /// Instantiated templates for the following kinds of T's are provided:
 /// - double
@@ -26,25 +40,48 @@ namespace systems {
 ///
 /// @ingroup primitive_systems
 template <class T>
-class DiscreteDerivative final : public LinearSystem<T> {
+class DiscreteDerivative final : public LeafSystem<T> {
  public:
   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteDerivative)
 
-  DiscreteDerivative(int num_inputs, double time_period)
-      : LinearSystem<T>(
-            SystemTypeTag<systems::DiscreteDerivative>{},
-            MatrixXd::Zero(num_inputs, num_inputs),
-            MatrixXd::Identity(num_inputs, num_inputs),
-            -MatrixXd::Identity(num_inputs, num_inputs) / time_period,
-            MatrixXd::Identity(num_inputs, num_inputs) / time_period,
-            time_period) {
-    DRAKE_DEMAND(time_period > 0.0);
-  }
+  /// Constructor taking @p num_inputs, the size of the vector to be
+  /// differentiated, and @p time_step, the sampling interval.
+  DiscreteDerivative(int num_inputs, double time_step);
 
   /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
   template <typename U>
   explicit DiscreteDerivative(const DiscreteDerivative<U>& other)
-      : DiscreteDerivative<T>(other.A().cols(), 1. / other.D()(0, 0)) {}
+      : DiscreteDerivative<T>(other.get_input_port().size(),
+                              other.time_step()) {}
+
+  /// Convenience method to set the entire input history to a constant
+  /// vector value (x₀ = x₁ = u,resulting in a derivative = 0).  This is
+  /// useful during initialization to avoid large derivative outputs if
+  /// u[0] ≠ 0.  @p u must be the same size as the input/output ports.
+  void set_state(const Eigen::Ref<const VectorX<T>>& u,
+                   systems::Context<T>* context) const;
+
+  const systems::InputPort<T>& get_input_port() const {
+    return System<T>::get_input_port(0);
+  }
+
+  const systems::OutputPort<T>& get_output_port() const {
+    return System<T>::get_output_port(0);
+  }
+
+  double time_step() const { return time_step_; }
+
+ private:
+  void DoCalcDiscreteVariableUpdates(
+      const Context<T>& context,
+      const std::vector<const DiscreteUpdateEvent<T>*>&,
+      DiscreteValues<T>* discrete_state) const final;
+
+  void CalcOutput(const Context<T>& context,
+                  BasicVector<T>* output_vector) const;
+
+  const int n_;  // The size of the input (and output) ports.
+  const double time_step_;
 };
 
 }  // namespace systems

--- a/systems/primitives/discrete_derivative.h
+++ b/systems/primitives/discrete_derivative.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "drake/systems/primitives/linear_system.h"
+
+using Eigen::MatrixXd;
+
+namespace drake {
+namespace systems {
+
+/// System that outputs the discrete-time derivative of the input:
+///   @f$ y[n] = (u[n] - u[n-1])/h @f$
+///
+/// This is implemented as the linear system
+///   @f[ x[n+1] = u[n], @f]
+///   @f[ y[n] = (u[n]-x[n])/h, @f]
+/// where @f$ h @f$ is the time period.
+///
+/// @system{ DiscreteDerivative, @input_port{u(t)}, @output_port{du(t)/dt} }
+///
+/// @tparam T The type of mathematical object being added.
+///
+/// Instantiated templates for the following kinds of T's are provided:
+/// - double
+/// - AutoDiffXd
+/// - symbolic::Expression
+///
+/// @ingroup primitive_systems
+template <class T>
+class DiscreteDerivative final : public LinearSystem<T> {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(DiscreteDerivative)
+
+  DiscreteDerivative(int num_inputs, double time_period)
+      : LinearSystem<T>(
+            SystemTypeTag<systems::DiscreteDerivative>{},
+            MatrixXd::Zero(num_inputs, num_inputs),
+            MatrixXd::Identity(num_inputs, num_inputs),
+            -MatrixXd::Identity(num_inputs, num_inputs) / time_period,
+            MatrixXd::Identity(num_inputs, num_inputs) / time_period,
+            time_period) {
+    DRAKE_DEMAND(time_period > 0.0);
+  }
+
+  /// Scalar-converting copy constructor.  See @ref system_scalar_conversion.
+  template <typename U>
+  explicit DiscreteDerivative(const DiscreteDerivative<U>& other)
+      : DiscreteDerivative<T>(other.A().cols(), 1. / other.D()(0, 0)) {}
+};
+
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/discrete_derivative_test.cc
+++ b/systems/primitives/test/discrete_derivative_test.cc
@@ -1,0 +1,59 @@
+#include "drake/systems/primitives/discrete_derivative.h"
+
+#include <gtest/gtest.h>
+
+#include "drake/common/test_utilities/eigen_matrix_compare.h"
+#include "drake/common/trajectories/piecewise_polynomial.h"
+#include "drake/systems/analysis/simulator.h"
+#include "drake/systems/framework/diagram_builder.h"
+#include "drake/systems/primitives/signal_logger.h"
+#include "drake/systems/primitives/trajectory_source.h"
+
+namespace drake {
+namespace systems {
+namespace {
+
+using Eigen::Matrix2d;
+using Eigen::Vector2d;
+
+GTEST_TEST(DiscreteDerivativeTest, FirstOrderHold) {
+  DiagramBuilder<double> builder;
+
+  const double kDuration = 1.0;
+  // Create an input system u(t) = [ 2*t, 3*t ].
+  Matrix2d knots;
+  // clang-format off
+  knots << 0., 2.,
+           0., 3.;
+  // clang-format on
+  const auto pp = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
+      Vector2d(0., kDuration), knots);
+  auto ppsource = builder.AddSystem<TrajectorySource<double>>(pp);
+
+  const int kNumInputs = 2;
+  const double time_period = 0.1;
+  auto deriv =
+      builder.AddSystem<DiscreteDerivative<double>>(kNumInputs, time_period);
+
+  builder.Connect(ppsource->get_output_port(), deriv->get_input_port());
+  auto log = LogOutput(deriv->get_output_port(), &builder);
+
+  auto diagram = builder.Build();
+  Simulator<double> simulator(*diagram);
+  simulator.StepTo(kDuration);
+
+  for (int i = 0; i < log->sample_times().size(); i++) {
+    if (log->sample_times()(i) == 0.0) {
+      // The initial outputs should be zero (due to the zero initial
+      // conditions).
+      EXPECT_TRUE(CompareMatrices(log->data().col(0), Vector2d(0., 0.)));
+    } else {
+      // Once time has advanced, outputs should have the intended derivatives.
+      EXPECT_TRUE(CompareMatrices(log->data().col(i), Vector2d(2., 3.), 1e-14));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace systems
+}  // namespace drake

--- a/systems/primitives/test/discrete_derivative_test.cc
+++ b/systems/primitives/test/discrete_derivative_test.cc
@@ -23,35 +23,60 @@ GTEST_TEST(DiscreteDerivativeTest, FirstOrderHold) {
   // Create an input system u(t) = [ 2*t, 3*t ].
   Matrix2d knots;
   // clang-format off
-  knots << 0., 2.,
-           0., 3.;
+  knots << 4, 4+2,
+           5, 5+3;
   // clang-format on
   const auto pp = trajectories::PiecewisePolynomial<double>::FirstOrderHold(
       Vector2d(0., kDuration), knots);
   auto ppsource = builder.AddSystem<TrajectorySource<double>>(pp);
 
   const int kNumInputs = 2;
-  const double time_period = 0.1;
+  const double time_step = 0.1;
   auto deriv =
-      builder.AddSystem<DiscreteDerivative<double>>(kNumInputs, time_period);
+      builder.AddSystem<DiscreteDerivative<double>>(kNumInputs, time_step);
 
   builder.Connect(ppsource->get_output_port(), deriv->get_input_port());
   auto log = LogOutput(deriv->get_output_port(), &builder);
+  // Evaluate the outputs at a distinct sampling interval.
+  log->set_publish_period(time_step / 3.267);
 
   auto diagram = builder.Build();
   Simulator<double> simulator(*diagram);
+  simulator.set_publish_every_time_step(false);
   simulator.StepTo(kDuration);
 
   for (int i = 0; i < log->sample_times().size(); i++) {
     if (log->sample_times()(i) == 0.0) {
       // The initial outputs should be zero (due to the zero initial
       // conditions).
-      EXPECT_TRUE(CompareMatrices(log->data().col(0), Vector2d(0., 0.)));
+      EXPECT_TRUE(CompareMatrices(log->data().col(i), Vector2d(0., 0.)));
+    } else if (log->sample_times()(i) <= 2 * time_step) {
+      // TODO(edrumwri): Zap this "else if" block on resolution of #9702.
+      // It is only here to cover up the bug.
+    } else if (log->sample_times()(i) <= time_step) {
+      // The outputs should jump for one timestep because u(0) is non-zero.
+      EXPECT_TRUE(CompareMatrices(
+          log->data().col(i), Vector2d(4. / time_step, 5. / time_step), 1e-12));
     } else {
-      // Once time has advanced, outputs should have the intended derivatives.
-      EXPECT_TRUE(CompareMatrices(log->data().col(i), Vector2d(2., 3.), 1e-14));
+      // Once time has advanced, outputs should have the steady-state
+      // derivatives.
+      EXPECT_TRUE(CompareMatrices(log->data().col(i), Vector2d(2, 3), 1e-12));
     }
   }
+}
+
+GTEST_TEST(DiscreteDerivativeTest, SetState) {
+  const int kNumInputs = 2;
+  const double time_step = 0.1;
+  DiscreteDerivative<double> deriv(kNumInputs, time_step);
+
+  // Setting the initial state to an arbitrary value results in the
+  // derivative output being set to zero.
+  auto context = deriv.CreateDefaultContext();
+  deriv.set_state(Eigen::Vector2d(3.4, 4.4), context.get());
+  EXPECT_TRUE(CompareMatrices(
+      deriv.get_output_port().Eval<BasicVector<double>>(*context).get_value(),
+      Vector2d::Zero()));
 }
 
 }  // namespace


### PR DESCRIPTION
Adds a discrete-time derivative system to primitives.

Implementing this system revealed a bug in the Simulator.

Previously, we did HandleDiscreteUpdates before HandlePublish. But the publish has to come first.
Consider x[n+1] = u[n], y[n] = (u[n] - x[n])/h... the simple discrete time derivative.
In the prior implementation, we get zeros out, because it’s actually using x[n+1] in the calculation of y[n].
This commit resolves the issue by publishing first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9533)
<!-- Reviewable:end -->
