### PR TITLE
Clean up InternalFrame interface and docs

### DIFF
--- a/geometry/geometry_visualization.cc
+++ b/geometry/geometry_visualization.cc
@@ -170,19 +170,19 @@ lcmt_viewer_load_robot GeometryVisualizationImpl::BuildLoadMessage(
   // Load dynamic geometry into their own frames.
   for (const auto& pair : state.frames_) {
     const internal::InternalFrame& frame = pair.second;
-    SourceId s_id = state.get_source_id(frame.get_id());
+    SourceId s_id = state.get_source_id(frame.id());
     const std::string& src_name = state.get_source_name(s_id);
     // TODO(SeanCurtis-TRI): The name in the load message *must* match the name
     // in the update message. Make sure this code and the SceneGraph output
     // use a common code-base to translate (source_id, frame) -> name.
-    message.link[link_index].name = src_name + "::" + frame.get_name();
-    message.link[link_index].robot_num = frame.get_frame_group();
+    message.link[link_index].name = src_name + "::" + frame.name();
+    message.link[link_index].robot_num = frame.frame_group();
     const int geom_count = static_cast<int>(
-        frame.get_child_geometries().size());
+        frame.child_geometries().size());
     message.link[link_index].num_geom = geom_count;
     message.link[link_index].geom.resize(geom_count);
     int geom_index = 0;
-    for (GeometryId geom_id : frame.get_child_geometries()) {
+    for (GeometryId geom_id : frame.child_geometries()) {
       const InternalGeometry& geometry = state.geometries_.at(geom_id);
       GeometryIndex index = geometry.get_engine_index();
       const Isometry3<double> X_FG = state.X_FG_.at(index);

--- a/geometry/internal_frame.cc
+++ b/geometry/internal_frame.cc
@@ -17,8 +17,8 @@ InternalFrame::InternalFrame(SourceId source_id, FrameId frame_id,
       name_(name),
       frame_group_(frame_group),
       pose_index_(pose_index),
-      parent_id_(parent_id),
-      clique_(clique) {}
+      clique_(clique),
+      parent_id_(parent_id) {}
 
 bool InternalFrame::operator==(const InternalFrame& other) const {
   return id_ == other.id_;

--- a/geometry/internal_frame.h
+++ b/geometry/internal_frame.h
@@ -11,19 +11,28 @@ namespace drake {
 namespace geometry {
 namespace internal {
 
-/** This class represents the internal representation of a GeometryFrame. It
- includes the user-specified data (name and frame group), excludes the pose
- data, and then includes topology data.
+/** This is the internal representation of a GeometryFrame. It includes the
+ user-specified data (name and frame group), excludes the pose data, and then
+ includes topology data.
 
  It is not intended to be used outside of the geometry library. To instantiate
  frames in SceneGraph, use the drake::geometry::GeometryFrame class in
- conjunction with the SceneGraph::RegisterFrame() methods. */
+ conjunction with the SceneGraph::RegisterFrame() methods.
+
+ This class works with InternalGeometry. The relationships between frames and
+ geometries are *stored* in these classes but these classes have no logic to
+ enforce a coherent picture. For example, an InternalFrame F can claim to have
+ another frame G as its child, such that G's frame id appears F's list of child
+ frame ids. However, this class does not guarantee that the instance of
+ %InternalFrame for G correctly reports F's id as its parent frame. It relies
+ on GeometryState to enforce those invariants. The same can be said of child
+ InternalGeometry instances.  */
 class InternalFrame {
  public:
   DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(InternalFrame)
 
   /** Default constructor. The parent identifier and pose index will be
-   invalid. */
+   invalid.  */
   InternalFrame();
 
   /** Full constructor.
@@ -35,82 +44,108 @@ class InternalFrame {
                         known pose.
    @param parent_id     The id of the parent frame.
    @param clique        The clique that will be used to prevent self-collision
-                        among geomtries rigidly affixed to this frame.
-   */
+                        among geometries rigidly affixed to this frame.  */
   InternalFrame(SourceId source_id, FrameId frame_id, const std::string &name,
                 int frame_group, PoseIndex pose_index, FrameId parent_id,
                 int clique);
 
   /** Compares two %InternalFrame instances for "equality". Two internal frames
-   are considered equal if they have the same frame identifier. */
+   are considered equal if they have the same frame identifier.  */
   bool operator==(const InternalFrame &other) const;
 
   /** Compares two %InternalFrame instances for inequality. See operator==()
-   for the definition of equality. */
+   for the definition of equality.  */
   bool operator!=(const InternalFrame &other) const;
 
-  SourceId get_source_id() const { return source_id_; }
-  FrameId get_id() const { return id_; }
-  const std::string& get_name() const { return name_; }
-  int get_frame_group() const { return frame_group_; }
-  PoseIndex get_pose_index() const { return pose_index_; }
-  void set_pose_index(PoseIndex index) { pose_index_ = index; }
+  /** @name      Frame properties    */
+  //@{
 
-  /** Returns true if this frame is the child of the identified frame. */
+  /** Returns the source id that registered the frame.  */
+  SourceId source_id() const { return source_id_; }
+
+  /** Returns the globally unique identifier for this frame.  */
+  FrameId id() const { return id_; }
+
+  /** Returns the name of this frame.  */
+  const std::string& name() const { return name_; }
+
+  /** Returns the frame group of this frame. It is an externally defined integer
+   value that can be used to create relationships between frames; it has no
+   internal significance or dependencies.  */
+  int frame_group() const { return frame_group_; }
+
+  /** Returns the pose index of this frame in the full scene graph.  */
+  PoseIndex pose_index() const { return pose_index_; }
+
+  /** Returns the clique associated with this frame.  */
+  int clique() const { return clique_; }
+
+  //@}
+
+  /** @name     Scene Graph topology    */
+  //@{
+
+  /** Returns true if this frame has the given id as its parent.  */
   bool has_parent(FrameId parent) const { return parent_id_ == parent; }
 
-  FrameId get_parent_frame_id() const { return parent_id_; }
-  const std::unordered_set<FrameId>& get_child_frames() const {
+  /** Returns true if this frame is the one and only world frame.  */
+  bool is_world() const { return id_ == world_frame_id(); }
+
+  /** Returns the id of this frame's parent frame. If this is the world frame,
+   it returns its own id (as there is no usable "undefined" identifier value).
+   */
+  FrameId parent_frame_id() const { return parent_id_; }
+
+  /** Returns a list of ids of the frames that have *this* frame as a parent
+   frame.  */
+  const std::unordered_set<FrameId>& child_frames() const {
     return child_frames_;
   }
-  std::unordered_set<FrameId>* get_mutable_child_frames() {
-    return &child_frames_;
-  }
-  const std::unordered_set<GeometryId>& get_child_geometries() const {
+
+  /** Returns a list of ids of the geometries that are *directly* attached to
+   this frame. It does *not* include geometries that are attached to child
+   frames of this frame.  */
+  const std::unordered_set<GeometryId>& child_geometries() const {
     return child_geometries_;
   }
-  std::unordered_set<GeometryId>* get_mutable_child_geometries() {
-    return &child_geometries_;
+
+  /** The number of total geometries attached to this frame. It should be true
+   that `this->num_child_geometries() == this->child_geometries().size()`.
+   To determine the number of geometries attached to this frame *by geometry
+   role*, use the GeometryState::GetNumFrameGeometriesByRole() method.  */
+  int num_child_geometries() const {
+    return static_cast<int>(child_geometries_.size());
   }
 
-  /** Returns true if the given `frame_id` is a known child of this frame. */
+  /** Returns true if this frame considers the given `frame_id` to be a child.
+   */
   bool has_child(FrameId frame_id) const {
-    return child_frames_.find(frame_id) != child_frames_.end();
+    return child_frames_.count(frame_id) > 0;
   }
 
-  /** Adds the given `frame_id` to the children of this frame. */
+  /** Adds the given `frame_id` to the set of frames that this frame considers
+   to be children.  */
   void add_child(FrameId frame_id) {
     child_frames_.insert(frame_id);
   }
 
-  /** Removes the given `frame_id` from this frame's set of children. If the
-   given `frame_id` is _not_ a child, this frame remains unchanged. */
-  void remove_child(FrameId frame_id) {
-    child_frames_.erase(frame_id);
-  }
-
-  /** Reports if the given `geometry_id` is rigidly affixed to this frame. */
+  /** Returns true if this frame considers the given `geometry_id` to be rigidly
+   affixed to it.  */
   bool has_child(GeometryId geometry_id) const {
-    return child_geometries_.find(geometry_id) != child_geometries_.end();
+    return child_geometries_.count(geometry_id) > 0;
   }
 
-  /** Adds the given `geometry_id` to the set of rigidly affixed child
-   geometries of this frame. */
+  /** Adds the given `geometry_id` to the set of geometries that this frame
+   considers to be children.  */
   void add_child(GeometryId geometry_id) {
     child_geometries_.insert(geometry_id);
   }
 
-  /** Removes the given `geometry_id` from the set of rigidly affixed child
-   geometries of this frame. If `geometry_id` is _not_ actually a child
-   geometry, then the frame remains unchanged. */
-  void remove_child(GeometryId geometry_id) {
-    child_geometries_.erase(geometry_id);
-  }
-
-  /** Returns the clique associated with this frame. */
-  int clique() const { return clique_; }
-
-  static FrameId get_world_frame_id() { return kWorldFrame; }
+  /** The identifier used for identifying the single world frame in all
+   instances of SceneGraph. The world frame will eventually have an arbitrary
+   number of child frames and geometries; but there will always only be one
+   world frame.  */
+  static FrameId world_frame_id() { return kWorldFrame; }
 
  private:
   // The identifier of the source, to which this frame belongs.
@@ -128,10 +163,12 @@ class InternalFrame {
   // The frame group to which this frame belongs.
   int frame_group_{0};
 
-  // TODO(SeanCurtis-TRI): Use default constructor when the type safe index
-  // default value PR lands.
   // The index in the pose vector where this frame's pose lives.
-  PoseIndex pose_index_{0};
+  PoseIndex pose_index_;
+
+  // The clique used to prevent self-collision among the geometries affixed to
+  // this frame.
+  int clique_{};
 
   // The identifier of this frame's parent frame.
   FrameId parent_id_;
@@ -144,10 +181,6 @@ class InternalFrame {
   // that were hung on geometries that were already rigidly affixed.
   // It does *not* include geometries hung on child frames.
   std::unordered_set<GeometryId> child_geometries_;
-
-  // The clique used to prevent self-collision among the geometries affixed to
-  // this frame.
-  int clique_{};
 
   // The frame identifier of the world frame.
   static const FrameId kWorldFrame;

--- a/geometry/scene_graph.h
+++ b/geometry/scene_graph.h
@@ -378,7 +378,7 @@ class SceneGraph final : public systems::LeafSystem<T> {
 
   /** Reports the identifier for the world frame. */
   static FrameId world_frame_id() {
-    return internal::InternalFrame::get_world_frame_id();
+    return internal::InternalFrame::world_frame_id();
   }
 
   /** Returns an inspector on the system's *model* scene graph data.

--- a/geometry/test/geometry_state_test.cc
+++ b/geometry/test/geometry_state_test.cc
@@ -31,7 +31,7 @@ class GeometryStateTester {
   void set_state(GeometryState<T>* state) { state_ = state; }
 
   FrameId get_world_frame() const {
-    return internal::InternalFrame::get_world_frame_id();
+    return internal::InternalFrame::world_frame_id();
   }
 
   const std::unordered_map<SourceId, std::string>& get_source_name_map() const {
@@ -502,14 +502,14 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
     auto test_frame = [internal_frames, this, s_id](int i, FrameId parent_id,
                                                     int num_child_frames) {
       const auto& frame = internal_frames.at(frames_[i]);
-      EXPECT_EQ(frame.get_source_id(), s_id);
-      EXPECT_EQ(frame.get_id(), frames_[i]);
-      EXPECT_EQ(frame.get_name(), "f" + to_string(i));
-      EXPECT_EQ(frame.get_frame_group(), 0);  // Defaults to zero.
-      EXPECT_EQ(frame.get_pose_index(), i);   // ith frame added.
-      EXPECT_EQ(frame.get_parent_frame_id(), parent_id);
-      EXPECT_EQ(frame.get_child_frames().size(), num_child_frames);
-      const auto& child_geometries = frame.get_child_geometries();
+      EXPECT_EQ(frame.source_id(), s_id);
+      EXPECT_EQ(frame.id(), frames_[i]);
+      EXPECT_EQ(frame.name(), "f" + to_string(i));
+      EXPECT_EQ(frame.frame_group(), 0);  // Defaults to zero.
+      EXPECT_EQ(frame.pose_index(), i);   // ith frame added.
+      EXPECT_EQ(frame.parent_frame_id(), parent_id);
+      EXPECT_EQ(frame.child_frames().size(), num_child_frames);
+      const auto& child_geometries = frame.child_geometries();
       EXPECT_EQ(child_geometries.size(), 2);
       EXPECT_NE(child_geometries.find(geometries_[i * 2]),
                                       child_geometries.end());
@@ -517,7 +517,7 @@ TEST_F(GeometryStateTest, ValidateSingleSourceTree) {
                                       child_geometries.end());
       const auto& frame_in_parent = gs_tester_.get_frame_parent_poses();
       EXPECT_TRUE(
-          CompareMatrices(frame_in_parent[frame.get_pose_index()].matrix(),
+          CompareMatrices(frame_in_parent[frame.pose_index()].matrix(),
                           X_PF_[i].matrix()));
     };
     test_frame(0, gs_tester_.get_world_frame(), 0);
@@ -1262,7 +1262,7 @@ TEST_F(GeometryStateTest, GetGeometryIdFromName) {
       std::logic_error, "Referenced frame \\d+ has not been registered.");
 
   // Bad *anchored* geometry name.
-  const FrameId world_id = internal::InternalFrame::get_world_frame_id();
+  const FrameId world_id = gs_tester_.get_world_frame();
   DRAKE_EXPECT_THROWS_MESSAGE(
       geometry_state_.GetGeometryFromName(world_id, "bad"), std::logic_error,
       "The frame 'world' .\\d+. has no geometry with the canonical name .+");


### PR DESCRIPTION
This is the first step of moving rendering into `SceneGraph`. This is minor cosmetic tweaks of the `InternalFrame` (fixed now so that it doesn't bleed into the future work).

1. Kill the `get_` prefix from the methods.
2. Clean up layout and documentation of class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9541)
<!-- Reviewable:end -->
