### PR TITLE
Remove :documentation_pybind from drake_pybind_library

### DIFF
--- a/tools/skylark/pybind.bzl
+++ b/tools/skylark/pybind.bzl
@@ -137,7 +137,6 @@ def drake_pybind_library(
         cc_srcs = cc_srcs,
         cc_deps = cc_deps + [
             "//:drake_shared_library",
-            "//bindings/pydrake:documentation_pybind",
             "//bindings/pydrake:pydrake_pybind",
         ],
         cc_binary_rule = drake_cc_binary,


### PR DESCRIPTION
Relates #9548.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9549)
<!-- Reviewable:end -->
