### PR TITLE
Allow mkdoc.py to be run from drake as a bazel external

### DIFF
--- a/tools/workspace/pybind11/run_mkdoc_with_python3.py
+++ b/tools/workspace/pybind11/run_mkdoc_with_python3.py
@@ -20,7 +20,12 @@ if sys.platform.startswith('linux'):
 
 os.environ['LANG'] = 'en_US.UTF-8'
 
-mkdoc_path = resolve_path('third_party/com_github_pybind_pybind11/mkdoc.py')
+mkdoc_relpath = 'third_party/com_github_pybind_pybind11/mkdoc.py'
+
+if os.path.exists(os.path.join(runfiles_dir, 'external/drake')):
+    mkdoc_relpath = os.path.join('external/drake', mkdoc_relpath)
+
+mkdoc_path = resolve_path(mkdoc_relpath)
 python3_path = resolve_path('external/python3/python3')
 argv = [python3_path, mkdoc_path] + sys.argv[1:]
 os.execv(argv[0], argv)


### PR DESCRIPTION
Fixes #9548.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9550)
<!-- Reviewable:end -->
