### PR TITLE
Removes monolane from comment in pure_pursuit_test

### DIFF
--- a/automotive/test/pure_pursuit_test.cc
+++ b/automotive/test/pure_pursuit_test.cc
@@ -258,7 +258,7 @@ TEST_F(PurePursuitTest, ComputeGoalPoint) {
   EXPECT_EQ(0., goal_position.z());
 }
 // TODO(jadecastro): Test with curved lanes once
-// monolane::Lane::ToRoadPosition() is implemented.
+// multilane::Lane::ToRoadPosition() is implemented.
 
 }  // namespace
 }  // namespace automotive


### PR DESCRIPTION
Connected to #9517, replaces `monolane` by `multilane` in TODO comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake/9552)
<!-- Reviewable:end -->
